### PR TITLE
[CIR] Add support for function linkage and visibility

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -1737,16 +1737,40 @@ def GetMemberOp : CIR_Op<"get_member"> {
 
 def FuncOp : CIR_Op<"func", [
   AutomaticAllocationScope, CallableOpInterface, FunctionOpInterface,
+  DeclareOpInterfaceMethods<CIRGlobalValueInterface>,
   IsolatedFromAbove
 ]> {
   let summary = "Declare or define a function";
   let description = [{
     The `cir.func` operation defines a function, similar to the `mlir::FuncOp`
     built-in.
+
+    The function linkage information is specified by `linkage`, as defined by
+    `GlobalLinkageKind` attribute.
+
+    Example:
+
+    ```mlir
+    // External function definitions.
+    cir.func @abort()
+
+    // A function with internal linkage.
+    cir.func internal @count(%x: i64) -> (i64)
+      return %x : i64
+
+    // Linkage information
+    cir.func linkonce_odr @some_method(...)
+    ```
   }];
 
   let arguments = (ins SymbolNameAttr:$sym_name,
+                       CIR_VisibilityAttr:$global_visibility,
                        TypeAttrOf<CIR_FuncType>:$function_type,
+                       UnitAttr:$dso_local,
+                       DefaultValuedAttr<CIR_GlobalLinkageKind,
+                                         "cir::GlobalLinkageKind::ExternalLinkage">:$linkage,
+                       OptionalAttr<StrAttr>:$sym_visibility,
+                       UnitAttr:$comdat,
                        OptionalAttr<DictArrayAttr>:$arg_attrs,
                        OptionalAttr<DictArrayAttr>:$res_attrs);
 
@@ -1754,8 +1778,10 @@ def FuncOp : CIR_Op<"func", [
 
   let skipDefaultBuilders = 1;
 
-  let builders = [OpBuilder<(ins "llvm::StringRef":$sym_name,
-                                 "FuncType":$type)>];
+  let builders = [OpBuilder<(ins
+    "llvm::StringRef":$sym_name, "FuncType":$type,
+    CArg<"cir::GlobalLinkageKind", "cir::GlobalLinkageKind::ExternalLinkage">:$linkage)
+  >];
 
   let extraClassDeclaration = [{
     /// Returns the region on the current operation that is callable. This may

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -72,16 +72,18 @@ struct MissingFeatures {
 
   // FuncOp handling
   static bool opFuncOpenCLKernelMetadata() { return false; }
+  static bool opFuncAstDeclAttr() { return false; }
   static bool opFuncCallingConv() { return false; }
   static bool opFuncExtraAttrs() { return false; }
-  static bool opFuncDsoLocal() { return false; }
-  static bool opFuncLinkage() { return false; }
-  static bool opFuncVisibility() { return false; }
   static bool opFuncNoProto() { return false; }
   static bool opFuncCPUAndFeaturesAttributes() { return false; }
   static bool opFuncSection() { return false; }
-  static bool opFuncSetComdat() { return false; }
+  static bool opFuncMultipleReturnVals() { return false; }
   static bool opFuncAttributesForDefinition() { return false; }
+  static bool opFuncMaybeHandleStaticInExternC() { return false; }
+  static bool opFuncGlobalAliases() { return false; }
+  static bool setLLVMFunctionFEnvAttributes() { return false; }
+  static bool setFunctionAttributes() { return false; }
 
   // CallOp handling
   static bool opCallPseudoDtor() { return false; }

--- a/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenCXX.cpp
@@ -25,7 +25,7 @@ cir::FuncOp CIRGenModule::codegenCXXStructor(GlobalDecl gd) {
   cir::FuncType funcType = getTypes().getFunctionType(fnInfo);
   cir::FuncOp fn = getAddrOfCXXStructor(gd, &fnInfo, /*FnType=*/nullptr,
                                         /*DontDefer=*/true, ForDefinition);
-  assert(!cir::MissingFeatures::opFuncLinkage());
+  setFunctionLinkage(gd, fn);
   CIRGenFunction cgf{*this, builder};
   curCGF = &cgf;
   {

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1583,7 +1583,7 @@ void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
   // the LLVM GV (corresponding to our FuncOp) computed, so it doesn't have to
   // recompute it here. This is a minimal fix for now.
   if (!isLocalLinkage(getFunctionLinkage(globalDecl))) {
-    const auto *decl = globalDecl.getDecl();
+    const Decl *decl = globalDecl.getDecl();
     func.setGlobalVisibilityAttr(getGlobalVisibilityAttrFromDecl(decl));
   }
 }

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -406,6 +406,16 @@ void CIRGenModule::emitGlobalFunctionDefinition(clang::GlobalDecl gd,
                                /*DontDefer=*/true, ForDefinition);
   }
 
+  // Already emitted.
+  if (!funcOp.isDeclaration())
+    return;
+
+  setFunctionLinkage(gd, funcOp);
+  setGVProperties(funcOp, funcDecl);
+  assert(!cir::MissingFeatures::opFuncMaybeHandleStaticInExternC());
+  maybeSetTrivialComdat(*funcDecl, funcOp);
+  assert(!cir::MissingFeatures::setLLVMFunctionFEnvAttributes());
+
   CIRGenFunction cgf(*this, builder);
   curCGF = &cgf;
   {
@@ -413,7 +423,17 @@ void CIRGenModule::emitGlobalFunctionDefinition(clang::GlobalDecl gd,
     cgf.generateCode(gd, funcOp, funcType);
   }
   curCGF = nullptr;
+
+  setNonAliasAttributes(gd, funcOp);
   assert(!cir::MissingFeatures::opFuncAttributesForDefinition());
+
+  if (const ConstructorAttr *ca = funcDecl->getAttr<ConstructorAttr>())
+    errorNYI(funcDecl->getSourceRange(), "constructor attribute");
+  if (const DestructorAttr *da = funcDecl->getAttr<DestructorAttr>())
+    errorNYI(funcDecl->getSourceRange(), "destructor attribute");
+
+  if (funcDecl->getAttr<AnnotateAttr>())
+    errorNYI(funcDecl->getSourceRange(), "deferredAnnotations");
 }
 
 mlir::Operation *CIRGenModule::getGlobalValue(StringRef name) {
@@ -855,10 +875,12 @@ static bool shouldBeInCOMDAT(CIRGenModule &cgm, const Decl &d) {
 void CIRGenModule::maybeSetTrivialComdat(const Decl &d, mlir::Operation *op) {
   if (!shouldBeInCOMDAT(*this, d))
     return;
-  if (auto globalOp = dyn_cast_or_null<cir::GlobalOp>(op))
+  if (auto globalOp = dyn_cast_or_null<cir::GlobalOp>(op)) {
     globalOp.setComdat(true);
-
-  assert(!cir::MissingFeatures::opFuncSetComdat());
+  } else {
+    auto funcOp = cast<cir::FuncOp>(op);
+    funcOp.setComdat(true);
+  }
 }
 
 void CIRGenModule::updateCompletedType(const TagDecl *td) {
@@ -1026,6 +1048,17 @@ CIRGenModule::getCIRLinkageVarDefinition(const VarDecl *vd, bool isConstant) {
   assert(!isConstant && "constant variables NYI");
   GVALinkage linkage = astContext.GetGVALinkageForVariable(vd);
   return getCIRLinkageForDeclarator(vd, linkage, isConstant);
+}
+
+cir::GlobalLinkageKind CIRGenModule::getFunctionLinkage(GlobalDecl gd) {
+  const auto *fd = cast<FunctionDecl>(gd.getDecl());
+
+  GVALinkage linkage = astContext.GetGVALinkageForFunction(fd);
+
+  if (const auto *dtor = dyn_cast<CXXDestructorDecl>(fd))
+    errorNYI(fd->getSourceRange(), "getFunctionLinkage: CXXDestructorDecl");
+
+  return getCIRLinkageForDeclarator(fd, linkage, /*IsConstantVariable=*/false);
 }
 
 static cir::GlobalOp
@@ -1534,6 +1567,27 @@ void CIRGenModule::setGVPropertiesAux(mlir::Operation *op,
   assert(!cir::MissingFeatures::opGlobalPartition());
 }
 
+void CIRGenModule::setFunctionAttributes(GlobalDecl globalDecl,
+                                         cir::FuncOp func,
+                                         bool isIncompleteFunction,
+                                         bool isThunk) {
+  // NOTE(cir): Original CodeGen checks if this is an intrinsic. In CIR we
+  // represent them in dedicated ops. The correct attributes are ensured during
+  // translation to LLVM. Thus, we don't need to check for them here.
+
+  assert(!cir::MissingFeatures::setFunctionAttributes());
+  assert(!cir::MissingFeatures::setTargetAttributes());
+
+  // TODO(cir): This needs a lot of work to better match CodeGen. That
+  // ultimately ends up in setGlobalVisibility, which already has the linkage of
+  // the LLVM GV (corresponding to our FuncOp) computed, so it doesn't have to
+  // recompute it here. This is a minimal fix for now.
+  if (!isLocalLinkage(getFunctionLinkage(globalDecl))) {
+    const auto *decl = globalDecl.getDecl();
+    func.setGlobalVisibilityAttr(getGlobalVisibilityAttrFromDecl(decl));
+  }
+}
+
 cir::FuncOp CIRGenModule::getOrCreateCIRFunction(
     StringRef mangledName, mlir::Type funcType, GlobalDecl gd, bool forVTable,
     bool dontDefer, bool isThunk, ForDefinition_t isForDefinition,
@@ -1576,8 +1630,9 @@ cir::FuncOp CIRGenModule::getOrCreateCIRFunction(
     // If there are two attempts to define the same mangled name, issue an
     // error.
     auto fn = cast<cir::FuncOp>(entry);
-    assert((!isForDefinition || !fn || !fn.isDeclaration()) &&
-           "Duplicate function definition");
+    if (isForDefinition && fn && !fn.isDeclaration()) {
+      errorNYI(d->getSourceRange(), "Duplicate function definition");
+    }
     if (fn && fn.getFunctionType() == funcType) {
       return fn;
     }
@@ -1597,6 +1652,9 @@ cir::FuncOp CIRGenModule::getOrCreateCIRFunction(
   cir::FuncOp funcOp = createCIRFunction(
       invalidLoc ? theModule->getLoc() : getLoc(funcDecl->getSourceRange()),
       mangledName, mlir::cast<cir::FuncType>(funcType), funcDecl);
+
+  if (d)
+    setFunctionAttributes(gd, funcOp, /*isIncompleteFunction=*/false, isThunk);
 
   // 'dontDefer' actually means don't move this to the deferredDeclsToEmit list.
   if (dontDefer) {
@@ -1667,6 +1725,20 @@ CIRGenModule::createCIRFunction(mlir::Location loc, StringRef name,
       builder.setInsertionPoint(cgf->curFn);
 
     func = builder.create<cir::FuncOp>(loc, name, funcType);
+
+    assert(!cir::MissingFeatures::opFuncAstDeclAttr());
+    assert(!cir::MissingFeatures::opFuncNoProto());
+
+    assert(func.isDeclaration() && "expected empty body");
+
+    // A declaration gets private visibility by default, but external linkage
+    // as the default linkage.
+    func.setLinkageAttr(cir::GlobalLinkageKindAttr::get(
+        &getMLIRContext(), cir::GlobalLinkageKind::ExternalLinkage));
+    mlir::SymbolTable::setSymbolVisibility(
+        func, mlir::SymbolTable::Visibility::Private);
+
+    assert(!cir::MissingFeatures::opFuncExtraAttrs());
 
     if (!cgf)
       theModule.push_back(func);

--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -268,6 +268,10 @@ public:
   void setGVProperties(mlir::Operation *op, const NamedDecl *d) const;
   void setGVPropertiesAux(mlir::Operation *op, const NamedDecl *d) const;
 
+  /// Set function attributes for a function declaration.
+  void setFunctionAttributes(GlobalDecl gd, cir::FuncOp f,
+                             bool isIncompleteFunction, bool isThunk);
+
   void emitGlobalDefinition(clang::GlobalDecl gd,
                             mlir::Operation *op = nullptr);
   void emitGlobalFunctionDefinition(clang::GlobalDecl gd, mlir::Operation *op);
@@ -340,10 +344,16 @@ public:
       clang::VisibilityAttr::VisibilityType visibility);
   cir::VisibilityAttr getGlobalVisibilityAttrFromDecl(const Decl *decl);
   static mlir::SymbolTable::Visibility getMLIRVisibility(cir::GlobalOp op);
-
+  cir::GlobalLinkageKind getFunctionLinkage(GlobalDecl gd);
   cir::GlobalLinkageKind getCIRLinkageForDeclarator(const DeclaratorDecl *dd,
                                                     GVALinkage linkage,
                                                     bool isConstantVariable);
+  void setFunctionLinkage(GlobalDecl gd, cir::FuncOp f) {
+    cir::GlobalLinkageKind l = getFunctionLinkage(gd);
+    f.setLinkageAttr(cir::GlobalLinkageKindAttr::get(&getMLIRContext(), l));
+    mlir::SymbolTable::setSymbolVisibility(f,
+                                           getMLIRVisibilityFromCIRLinkage(l));
+  }
 
   cir::GlobalLinkageKind getCIRLinkageVarDefinition(const VarDecl *vd,
                                                     bool isConstant);

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -115,8 +115,25 @@ template <typename Ty> struct EnumTraits {};
     static unsigned getMaxEnumVal() { return cir::getMaxEnumValFor##Ty(); }    \
   }
 
+REGISTER_ENUM_TYPE(GlobalLinkageKind);
+REGISTER_ENUM_TYPE(VisibilityKind);
 REGISTER_ENUM_TYPE(SideEffect);
 } // namespace
+
+/// Parse an enum from the keyword, or default to the provided default value.
+/// The return type is the enum type by default, unless overriden with the
+/// second template argument.
+template <typename EnumTy, typename RetTy = EnumTy>
+static RetTy parseOptionalCIRKeyword(AsmParser &parser, EnumTy defaultValue) {
+  llvm::SmallVector<llvm::StringRef, 10> names;
+  for (unsigned i = 0, e = EnumTraits<EnumTy>::getMaxEnumVal(); i <= e; ++i)
+    names.push_back(EnumTraits<EnumTy>::stringify(static_cast<EnumTy>(i)));
+
+  int index = parseOptionalKeywordAlternative(parser, names);
+  if (index == -1)
+    return static_cast<RetTy>(defaultValue);
+  return static_cast<RetTy>(index);
+}
 
 /// Parse an enum from the keyword, return failure if the keyword is not found.
 template <typename EnumTy, typename RetTy = EnumTy>
@@ -168,6 +185,26 @@ static bool omitRegionTerm(mlir::Region &r) {
     return y && y.getArgs().empty();
   };
   return singleNonEmptyBlock && yieldsNothing();
+}
+
+void printVisibilityAttr(OpAsmPrinter &printer,
+                         cir::VisibilityAttr &visibility) {
+  switch (visibility.getValue()) {
+  case cir::VisibilityKind::Hidden:
+    printer << "hidden";
+    break;
+  case cir::VisibilityKind::Protected:
+    printer << "protected";
+    break;
+  default:
+    break;
+  }
+}
+
+void parseVisibilityAttr(OpAsmParser &parser, cir::VisibilityAttr &visibility) {
+  cir::VisibilityKind visibilityKind =
+      parseOptionalCIRKeyword(parser, cir::VisibilityKind::Default);
+  visibility = cir::VisibilityAttr::get(parser.getContext(), visibilityKind);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1287,18 +1324,53 @@ cir::GetGlobalOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 // FuncOp
 //===----------------------------------------------------------------------===//
 
+/// Returns the name used for the linkage attribute. This *must* correspond to
+/// the name of the attribute in ODS.
+static llvm::StringRef getLinkageAttrNameString() { return "linkage"; }
+
 void cir::FuncOp::build(OpBuilder &builder, OperationState &result,
-                        StringRef name, FuncType type) {
+                        StringRef name, FuncType type,
+                        GlobalLinkageKind linkage) {
   result.addRegion();
   result.addAttribute(SymbolTable::getSymbolAttrName(),
                       builder.getStringAttr(name));
   result.addAttribute(getFunctionTypeAttrName(result.name),
                       TypeAttr::get(type));
+  result.addAttribute(
+      getLinkageAttrNameString(),
+      GlobalLinkageKindAttr::get(builder.getContext(), linkage));
+  result.addAttribute(getGlobalVisibilityAttrName(result.name),
+                      cir::VisibilityAttr::get(builder.getContext()));
 }
 
 ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   llvm::SMLoc loc = parser.getCurrentLocation();
   mlir::Builder &builder = parser.getBuilder();
+
+  mlir::StringAttr visNameAttr = getSymVisibilityAttrName(state.name);
+  mlir::StringAttr visibilityNameAttr = getGlobalVisibilityAttrName(state.name);
+  mlir::StringAttr dsoLocalNameAttr = getDsoLocalAttrName(state.name);
+
+  // Default to external linkage if no keyword is provided.
+  state.addAttribute(getLinkageAttrNameString(),
+                     GlobalLinkageKindAttr::get(
+                         parser.getContext(),
+                         parseOptionalCIRKeyword<GlobalLinkageKind>(
+                             parser, GlobalLinkageKind::ExternalLinkage)));
+
+  ::llvm::StringRef visAttrStr;
+  if (parser.parseOptionalKeyword(&visAttrStr, {"private", "public", "nested"})
+          .succeeded()) {
+    state.addAttribute(visNameAttr,
+                       parser.getBuilder().getStringAttr(visAttrStr));
+  }
+
+  cir::VisibilityAttr cirVisibilityAttr;
+  parseVisibilityAttr(parser, cirVisibilityAttr);
+  state.addAttribute(visibilityNameAttr, cirVisibilityAttr);
+
+  if (parser.parseOptionalKeyword(dsoLocalNameAttr).succeeded())
+    state.addAttribute(dsoLocalNameAttr, parser.getBuilder().getUnitAttr());
 
   StringAttr nameAttr;
   if (parser.parseSymbolName(nameAttr, SymbolTable::getSymbolAttrName(),
@@ -1347,9 +1419,8 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
 }
 
 bool cir::FuncOp::isDeclaration() {
-  // TODO(CIR): This function will actually do something once external
-  // function declarations and aliases are upstreamed.
-  return false;
+  assert(!cir::MissingFeatures::opFuncGlobalAliases());
+  return isExternal();
 }
 
 mlir::Region *cir::FuncOp::getCallableRegion() {
@@ -1359,6 +1430,25 @@ mlir::Region *cir::FuncOp::getCallableRegion() {
 }
 
 void cir::FuncOp::print(OpAsmPrinter &p) {
+  if (getComdat())
+    p << " comdat";
+
+  if (getLinkage() != GlobalLinkageKind::ExternalLinkage)
+    p << ' ' << stringifyGlobalLinkageKind(getLinkage());
+
+  mlir::SymbolTable::Visibility vis = getVisibility();
+  if (vis != mlir::SymbolTable::Visibility::Public)
+    p << ' ' << vis;
+
+  cir::VisibilityAttr cirVisibilityAttr = getGlobalVisibilityAttr();
+  if (!cirVisibilityAttr.isDefault()) {
+    p << ' ';
+    printVisibilityAttr(p, cirVisibilityAttr);
+  }
+
+  if (getDsoLocal())
+    p << " dso_local";
+
   p << ' ';
   p.printSymbolName(getSymName());
   cir::FuncType fnType = getFunctionType();

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -196,7 +196,7 @@ void printVisibilityAttr(OpAsmPrinter &printer,
   case cir::VisibilityKind::Protected:
     printer << "protected";
     break;
-  default:
+  case cir::VisibilityKind::Default:
     break;
   }
 }
@@ -1418,9 +1418,14 @@ ParseResult cir::FuncOp::parse(OpAsmParser &parser, OperationState &state) {
   return success();
 }
 
+// This function corresponds to `llvm::GlobalValue::isDeclaration` and should
+// have a similar implementation. We don't currently support aliases, ifuncs,
+// or materializable functions, but those should be handled here as they are
+// implemented.
 bool cir::FuncOp::isDeclaration() {
   assert(!cir::MissingFeatures::opFuncGlobalAliases());
-  return isExternal();
+  assert(!cir::MissingFeatures::supportIFuncAttr());
+  return getFunctionBody().empty();
 }
 
 mlir::Region *cir::FuncOp::getCallableRegion() {

--- a/clang/test/CIR/CodeGen/align-load.c
+++ b/clang/test/CIR/CodeGen/align-load.c
@@ -21,7 +21,7 @@ void accessStruct(struct S u) {
   u.d;
 }
 
-// CIR: cir.func @accessStruct
+// CIR: cir.func{{.*}} @accessStruct
 // CIR:   cir.load align(8)
 // CIR:   cir.load align(2)
 // CIR:   cir.load align(4)
@@ -58,7 +58,7 @@ void accessUnion(union U u) {
   u.d;
 }
 
-// CIR: cir.func @accessUnion
+// CIR: cir.func{{.*}} @accessUnion
 // CIR:   cir.load align(8)
 // CIR:   cir.load align(8)
 // CIR:   cir.load align(8)
@@ -86,7 +86,7 @@ int loadAligned(myint *p) {
   return *p;
 }
 
-// CIR: cir.func @loadAligned
+// CIR: cir.func{{.*}} @loadAligned
 // CIR:   cir.load align(1)
 
 // LLVM: @loadAligned

--- a/clang/test/CIR/CodeGen/align-store.c
+++ b/clang/test/CIR/CodeGen/align-store.c
@@ -12,7 +12,7 @@ void test1(myint *p) {
   *p = 0;
 }
 
-// CIR: cir.func @test1
+// CIR: cir.func{{.*}} @test1
 // CIR:   cir.store align(1)
 
 // LLVM: @test1

--- a/clang/test/CIR/CodeGen/array.cpp
+++ b/clang/test/CIR/CodeGen/array.cpp
@@ -101,7 +101,7 @@ void func() {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[ELE_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR" cir.store %[[TMP]], %[[INIT_2]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z4funcv()
+// LLVM: define{{.*}} void @_Z4funcv()
 // LLVM-NEXT: %[[ARR:.*]] = alloca [10 x i32], i64 1, align 16
 // LLVM-NEXT: %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT: %[[INIT_2:.*]] = alloca i32, i64 1, align 4
@@ -143,7 +143,7 @@ void func2() {
 // CIR: %[[ELE_1_PTR:.*]] = cir.ptr_stride(%[[LOAD_1]] : !cir.ptr<!s32i>, %[[OFFSET_1]] : !s64i), !cir.ptr<!s32i>
 // CIR: cir.store{{.*}} %[[ELE_1_PTR]], %[[ELE_ALLOCA]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 
-// LLVM: define void @_Z5func2v()
+// LLVM: define{{.*}} void @_Z5func2v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // LLVM:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[ARR_PTR:.*]] = getelementptr i32, ptr %[[ARR]], i32 0
@@ -183,7 +183,7 @@ void func3() {
 // CIR: %[[ELE_TMP:.*]] = cir.load{{.*}} %[[ELE_PTR]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store{{.*}} %[[ELE_TMP]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z5func3v()
+// LLVM: define{{.*}} void @_Z5func3v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // LLVM:  %[[IDX:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
@@ -235,7 +235,7 @@ void func4() {
 // CIR: %[[TMP:.*]] = cir.load{{.*}} %[[ELE_0]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store{{.*}} %[[TMP]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z5func4v()
+// LLVM: define{{.*}} void @_Z5func4v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR]], i32 0
@@ -279,7 +279,7 @@ void func5() {
 // CIR: %10 = cir.ptr_stride(%7 : !cir.ptr<!cir.array<!s32i x 1>>, %[[OFFSET_1]] : !s64i), !cir.ptr<!cir.array<!s32i x 1>>
 // CIR: cir.store{{.*}} %10, %[[ARR_PTR]] : !cir.ptr<!cir.array<!s32i x 1>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 1>>>
 
-// LLVM: define void @_Z5func5v()
+// LLVM: define{{.*}} void @_Z5func5v()
 // LLVM:  %[[ARR:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // LLVM:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR]], i32 0
@@ -312,7 +312,7 @@ void func6() {
 // CIR: %[[V1:.*]] = cir.const #cir.int<5> : !s32i
 // CIR: cir.store{{.*}} %[[V1]], %[[ELE_PTR]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z5func6v()
+// LLVM: define{{.*}} void @_Z5func6v()
 // LLVM:  %[[VAR:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // LLVM:  store i32 4, ptr %[[VAR]], align 4
@@ -345,7 +345,7 @@ void func7() {
 // CIR: %[[ELE_PTR:.*]] = cir.ptr_stride(%[[TMP]] : !cir.ptr<!cir.ptr<!s32i>>, %[[OFFSET]] : !s64i), !cir.ptr<!cir.ptr<!s32i>>
 // CIR: cir.store{{.*}} %[[ELE_PTR]], %[[ARR_TMP]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!cir.ptr<!cir.ptr<!s32i>>>
 
-// LLVM: define void @_Z5func7v()
+// LLVM: define{{.*}} void @_Z5func7v()
 // LLVM:  %[[ARR:.*]] = alloca [1 x ptr], i64 1, align 8
 // LLVM:  %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[ELE_PTR:.*]] = getelementptr ptr, ptr %[[ARR]], i32 0
@@ -363,7 +363,7 @@ void func8(int arr[10]) {
   int e2 = arr[1];
 }
 
-// CIR: cir.func @_Z5func8Pi(%[[ARG:.*]]: !cir.ptr<!s32i>
+// CIR: cir.func{{.*}} @_Z5func8Pi(%[[ARG:.*]]: !cir.ptr<!s32i>
 // CIR:  %[[ARR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arr", init]
 // CIR:  %[[INIT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CIR:  %[[INIT_2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e2", init]
@@ -379,7 +379,7 @@ void func8(int arr[10]) {
 // CIR:  %[[TMP_4:.*]] = cir.load{{.*}} %[[ELE_1]] : !cir.ptr<!s32i>, !s32i
 // CIR:  cir.store{{.*}} %[[TMP_4]], %[[INIT_2]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z5func8Pi(ptr %[[ARG:.*]])
+// LLVM: define{{.*}} void @_Z5func8Pi(ptr %[[ARG:.*]])
 // LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  %[[INIT_2:.*]] = alloca i32, i64 1, align 4
@@ -410,7 +410,7 @@ void func9(int arr[10][5]) {
   int e = arr[1][2];
 }
 
-// CIR: cir.func @_Z5func9PA5_i(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>
+// CIR: cir.func{{.*}} @_Z5func9PA5_i(%[[ARG:.*]]: !cir.ptr<!cir.array<!s32i x 5>>
 // CIR:  %[[ARR:.*]] = cir.alloca !cir.ptr<!cir.array<!s32i x 5>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 5>>>, ["arr", init]
 // CIR:  %[[INIT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CIR:  cir.store{{.*}} %[[ARG]], %[[ARR]] : !cir.ptr<!cir.array<!s32i x 5>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 5>>>
@@ -423,7 +423,7 @@ void func9(int arr[10][5]) {
 // CIR:  %[[TMP_2:.*]] = cir.load{{.*}} %[[ARR_1_2]] : !cir.ptr<!s32i>, !s32i
 // CIR:  cir.store{{.*}} %[[TMP_2]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z5func9PA5_i(ptr %[[ARG:.*]])
+// LLVM: define{{.*}} void @_Z5func9PA5_i(ptr %[[ARG:.*]])
 // LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8
@@ -447,7 +447,7 @@ void func10(int *a) {
   int e = a[5];
 }
 
-// CIR: cir.func @_Z6func10Pi(%[[ARG:.*]]: !cir.ptr<!s32i>
+// CIR: cir.func{{.*}} @_Z6func10Pi(%[[ARG:.*]]: !cir.ptr<!s32i>
 // CIR: %[[ARR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["a", init]
 // CIR: %[[INIT:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CIR: cir.store{{.*}} %[[ARG]], %[[ARR]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
@@ -457,7 +457,7 @@ void func10(int *a) {
 // CIR: %[[TMP_2:.*]] = cir.load{{.*}} %[[ELE]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.store{{.*}} %[[TMP_2]], %[[INIT]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z6func10Pi(ptr %[[ARG:.*]]) {
+// LLVM: define{{.*}} void @_Z6func10Pi(ptr %[[ARG:.*]]) {
 // LLVM:  %[[ARR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // LLVM:  store ptr %[[ARG]], ptr %[[ARR]], align 8

--- a/clang/test/CIR/CodeGen/basic.c
+++ b/clang/test/CIR/CodeGen/basic.c
@@ -34,7 +34,7 @@ int f1(int i) {
   return i;
 }
 
-// CIR:      cir.func @f1(%arg0: !s32i loc({{.*}})) -> !s32i
+// CIR:      cir.func{{.*}} @f1(%arg0: !s32i loc({{.*}})) -> !s32i
 // CIR-NEXT:   %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CIR-NEXT:   cir.store{{.*}} %arg0, %[[I_PTR]] : !s32i, !cir.ptr<!s32i>
@@ -44,7 +44,7 @@ int f1(int i) {
 // CIR-NEXT:   %[[R:.*]] = cir.load{{.*}} %[[RV]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
-//      LLVM: define i32 @f1(i32 %[[IP:.*]])
+//      LLVM: define{{.*}} i32 @f1(i32 %[[IP:.*]])
 // LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   store i32 %[[IP]], ptr %[[I_PTR]], align 4
@@ -64,14 +64,14 @@ int f1(int i) {
 
 int f2(void) { return 3; }
 
-//      CIR: cir.func @f2() -> !s32i
+//      CIR: cir.func{{.*}} @f2() -> !s32i
 // CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CIR-NEXT:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
 // CIR-NEXT:   cir.store{{.*}} %[[THREE]], %[[RV]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   %[[R:.*]] = cir.load{{.*}} %0 : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
-//      LLVM: define i32 @f2()
+//      LLVM: define{{.*}} i32 @f2()
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   store i32 3, ptr %[[RV]], align 4
 // LLVM-NEXT:   %[[R:.*]] = load i32, ptr %[[RV]], align 4
@@ -86,7 +86,7 @@ int f3(void) {
   return i;
 }
 
-//      CIR: cir.func @f3() -> !s32i
+//      CIR: cir.func{{.*}} @f3() -> !s32i
 // CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CIR-NEXT:   %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CIR-NEXT:   %[[THREE:.*]] = cir.const #cir.int<3> : !s32i
@@ -96,7 +96,7 @@ int f3(void) {
 // CIR-NEXT:   %[[R:.*]] = cir.load{{.*}} %[[RV]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
-//      LLVM: define i32 @f3()
+//      LLVM: define{{.*}} i32 @f3()
 // LLVM-NEXT:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   %[[I_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   store i32 3, ptr %[[I_PTR]], align 4
@@ -117,10 +117,10 @@ void f4(void) {
   ;
 }
 
-//      CIR: cir.func @f4()
+//      CIR: cir.func{{.*}} @f4()
 // CIR-NEXT:   cir.return
 
-//      LLVM: define void @f4()
+//      LLVM: define{{.*}} void @f4()
 // LLVM-NEXT:   ret void
 
 //      OGCG: define{{.*}} void @f4()
@@ -133,7 +133,7 @@ void f5(void) {
     ;
 }
 
-//      CIR: cir.func @f5()
+//      CIR: cir.func{{.*}} @f5()
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:      cir.for : cond {
 // CIR-NEXT:        %0 = cir.const #true
@@ -147,7 +147,7 @@ void f5(void) {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @f5()
+// LLVM: define{{.*}} void @f5()
 // LLVM:   br label %[[SCOPE:.*]]
 // LLVM: [[SCOPE]]:
 // LLVM:   br label %[[LOOP:.*]]
@@ -171,7 +171,7 @@ int f6(void) {
   return gv;
 }
 
-//      CIR: cir.func @f6() -> !s32i
+//      CIR: cir.func{{.*}} @f6() -> !s32i
 // CIR-NEXT:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CIR-NEXT:   %[[GV_PTR:.*]] = cir.get_global @gv : !cir.ptr<!s32i>
 // CIR-NEXT:   %[[GV:.*]] = cir.load{{.*}} %[[GV_PTR]] : !cir.ptr<!s32i>, !s32i
@@ -179,7 +179,7 @@ int f6(void) {
 // CIR-NEXT:   %[[R:.*]] = cir.load{{.*}} %[[RV]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.return %[[R]] : !s32i
 
-// LLVM:      define i32 @f6()
+// LLVM:      define{{.*}} i32 @f6()
 // LLVM-NEXT:   %[[RV_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   %[[GV:.*]] = load i32, ptr @gv, align 4
 // LLVM-NEXT:   store i32 %[[GV]], ptr %[[RV_PTR]], align 4
@@ -195,7 +195,7 @@ int f7(int a, int b, int c) {
   return a + (b + c);
 }
 
-// CIR: cir.func @f7
+// CIR: cir.func{{.*}} @f7
 // CIR:  %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR:  %[[B_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
 // CIR:  %[[C_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["c", init]
@@ -205,7 +205,7 @@ int f7(int a, int b, int c) {
 // CIR:  %[[B_PLUS_C:.*]] = cir.binop(add, %[[B]], %[[C]]) nsw : !s32i
 // CIR:  %[[RETVAL:.*]] = cir.binop(add, %[[A]], %[[B_PLUS_C]]) nsw : !s32i
 
-// LLVM: define i32 @f7
+// LLVM: define{{.*}} i32 @f7
 // LLVM:   %[[A_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[B_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[C_PTR:.*]] = alloca i32, i64 1, align 4
@@ -231,7 +231,7 @@ int f8(int *p) {
   return (*p);
 }
 
-// CIR: cir.func @f8
+// CIR: cir.func{{.*}} @f8
 // CIR:    %[[P_PTR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init]
 // CIR:    %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
 // CIR:    %[[P:.*]] = cir.load deref{{.*}} %[[P_PTR]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
@@ -239,7 +239,7 @@ int f8(int *p) {
 // CIR:    %[[P2:.*]] = cir.load deref{{.*}} %[[P_PTR]] : !cir.ptr<!cir.ptr<!s32i>>, !cir.ptr<!s32i>
 // CIR:    %[[STAR_P:.*]] = cir.load{{.*}} %[[P2]] : !cir.ptr<!s32i>, !s32i
 
-// LLVM: define i32 @f8
+// LLVM: define{{.*}} i32 @f8
 // LLVM:   %[[P_PTR:.*]] = alloca ptr, i64 1, align 8
 // LLVM:   %[[P:.*]] = load ptr, ptr %[[P_PTR]], align 8
 // LLVM:   store i32 2, ptr %[[P]], align 4
@@ -257,10 +257,10 @@ int f8(int *p) {
 
 void f9() {}
 
-//      CIR: cir.func @f9()
+//      CIR: cir.func{{.*}} @f9()
 // CIR-NEXT:   cir.return
 
-//      LLVM: define void @f9()
+//      LLVM: define{{.*}} void @f9()
 // LLVM-NEXT:   ret void
 
 //      OGCG: define{{.*}} void @f9()
@@ -269,12 +269,12 @@ void f9() {}
 
 void f10(int arg0, ...) {}
 
-//      CIR: cir.func @f10(%[[ARG0:.*]]: !s32i loc({{.*}}), ...)
+//      CIR: cir.func{{.*}} @f10(%[[ARG0:.*]]: !s32i loc({{.*}}), ...)
 // CIR-NEXT:   %[[ARG0_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["arg0", init] {alignment = 4 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG0]], %[[ARG0_PTR]] : !s32i, !cir.ptr<!s32i>
 // CIR-NEXT:   cir.return
 
-//      LLVM: define void @f10(i32 %[[ARG0:.*]], ...)
+//      LLVM: define{{.*}} void @f10(i32 %[[ARG0:.*]], ...)
 // LLVM-NEXT:   %[[ARG0_PTR:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   store i32 %[[ARG0]], ptr %[[ARG0_PTR]], align 4
 // LLVM-NEXT:   ret void
@@ -292,7 +292,7 @@ size_type max_size(void) {
   return (size_type)~0 / sizeof(_Tp);
 }
 
-// CIR: cir.func @max_size()
+// CIR: cir.func{{.*}} @max_size()
 // CIR:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
 // CIR:   %1 = cir.const #cir.int<0> : !s32i
 // CIR:   %2 = cir.unary(not, %1) : !s32i, !s32i
@@ -300,7 +300,7 @@ size_type max_size(void) {
 // CIR:   %4 = cir.const #cir.int<8> : !u64i
 // CIR:   %5 = cir.binop(div, %3, %4) : !u64i
 
-// LLVM: define i64 @max_size()
+// LLVM: define{{.*}} i64 @max_size()
 // LLVM:   store i64 2305843009213693951, ptr
 
 // OGCG: define{{.*}} i64 @max_size()
@@ -315,10 +315,10 @@ void test_char_literal() {
   c = 'X';
 }
 
-// CIR: cir.func @test_char_literal
+// CIR: cir.func{{.*}} @test_char_literal
 // CIR:   cir.const #cir.int<88>
 
-// LLVM: define void @test_char_literal()
+// LLVM: define{{.*}} void @test_char_literal()
 // LLVM:   store i8 88, ptr %{{.*}}, align 1
 
 // OGCG: define{{.*}} void @test_char_literal()

--- a/clang/test/CIR/CodeGen/basic.cpp
+++ b/clang/test/CIR/CodeGen/basic.cpp
@@ -31,7 +31,7 @@ int f1() {
   return i;
 }
 
-// CHECK: cir.func @_Z2f1v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z2f1v() -> !s32i
 // CHECK:    %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i"] {alignment = 4 : i64}
 // CHECK:    %[[I:.*]] = cir.load{{.*}} %[[I_PTR]] : !cir.ptr<!s32i>, !s32i
@@ -44,7 +44,7 @@ int f2() {
   return i;
 }
 
-// CHECK: cir.func @_Z2f2v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z2f2v() -> !s32i
 // CHECK:    %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init, const] {alignment = 4 : i64}
 // CHECK:    %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
@@ -58,7 +58,7 @@ int f3(int i) {
   return i;
 }
 
-// CHECK: cir.func @_Z2f3i(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
+// CHECK: cir.func{{.*}} @_Z2f3i(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
 // CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.store{{.*}} %[[ARG]], %[[ARG_ALLOCA]] : !s32i, !cir.ptr<!s32i>
@@ -71,7 +71,7 @@ int f4(const int i) {
   return i;
 }
 
-// CHECK: cir.func @_Z2f4i(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
+// CHECK: cir.func{{.*}} @_Z2f4i(%[[ARG:.*]]: !s32i loc({{.*}})) -> !s32i
 // CHECK:   %[[ARG_ALLOCA:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init, const] {alignment = 4 : i64}
 // CHECK:   %[[RV:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.store{{.*}} %[[ARG]], %[[ARG_ALLOCA]] : !s32i, !cir.ptr<!s32i>
@@ -91,7 +91,7 @@ int *f5() {
   return p;
 }
 
-// CHECK:      cir.func @_Z2f5v() -> !cir.ptr<!s32i>
+// CHECK:      cir.func{{.*}} @_Z2f5v() -> !cir.ptr<!s32i>
 // CHECK-NEXT:   %[[RET_ADDR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["__retval"] {alignment = 8 : i64}
 // CHECK-NEXT:   %[[P_ADDR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
 // CHECK-NEXT:   %[[NULLPTR:.*]] = cir.const #cir.ptr<null> : !cir.ptr<!s32i>
@@ -120,7 +120,7 @@ size_type max_size() {
   return size_type(~0) / sizeof(_Tp);
 }
 
-// CHECK: cir.func @_Z8max_sizev() -> !u64i
+// CHECK: cir.func{{.*}} @_Z8max_sizev() -> !u64i
 // CHECK:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.int<0> : !s32i
 // CHECK:   %2 = cir.unary(not, %1) : !s32i, !s32i
@@ -137,7 +137,7 @@ void ref_arg(int &x) {
   x = 3;
 }
 
-// CHECK: cir.func @_Z7ref_argRi(%[[ARG:.*]]: !cir.ptr<!s32i> {{.*}})
+// CHECK: cir.func{{.*}} @_Z7ref_argRi(%[[ARG:.*]]: !cir.ptr<!s32i> {{.*}})
 // CHECK:   %[[X_REF_ADDR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["x", init, const] {alignment = 8 : i64}
 // CHECK:   %[[Y_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init] {alignment = 4 : i64}
 // CHECK:   cir.store{{.*}} %[[ARG]], %[[X_REF_ADDR]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
@@ -154,7 +154,7 @@ short &return_ref() {
   return gs;
 }
 
-// CHECK: cir.func @_Z10return_refv() -> !cir.ptr<!s16i>
+// CHECK: cir.func{{.*}} @_Z10return_refv() -> !cir.ptr<!s16i>
 // CHECK:   %[[RETVAL_ADDR:.*]] = cir.alloca !cir.ptr<!s16i>, !cir.ptr<!cir.ptr<!s16i>>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %[[GS_ADDR:.*]] = cir.get_global @gs : !cir.ptr<!s16i>
 // CHECK:   cir.store{{.*}} %[[GS_ADDR]], %[[RETVAL_ADDR]] : !cir.ptr<!s16i>, !cir.ptr<!cir.ptr<!s16i>>
@@ -165,7 +165,7 @@ void ref_local(short x) {
   short &y = x;
 }
 
-// CHECK: cir.func @_Z9ref_locals(%[[ARG:.*]]: !s16i {{.*}})
+// CHECK: cir.func{{.*}} @_Z9ref_locals(%[[ARG:.*]]: !s16i {{.*}})
 // CHECK:   %[[X_ADDR:.*]] = cir.alloca !s16i, !cir.ptr<!s16i>, ["x", init] {alignment = 2 : i64}
 // CHECK:   %[[Y_REF_ADDR:.*]] = cir.alloca !cir.ptr<!s16i>, !cir.ptr<!cir.ptr<!s16i>>, ["y", init, const] {alignment = 8 : i64}
 // CHECK:   cir.store{{.*}} %[[ARG]], %[[X_ADDR]] : !s16i, !cir.ptr<!s16i>

--- a/clang/test/CIR/CodeGen/binassign.c
+++ b/clang/test/CIR/CodeGen/binassign.c
@@ -17,7 +17,7 @@ void binary_assign(void) {
     i = 42;
 }
 
-// CIR-LABEL: cir.func @binary_assign() {
+// CIR-LABEL: cir.func{{.*}} @binary_assign() {
 // CIR:         %[[B:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b"]
 // CIR:         %[[C:.*]] = cir.alloca !s8i, !cir.ptr<!s8i>, ["c"]
 // CIR:         %[[F:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f"]

--- a/clang/test/CIR/CodeGen/binop.cpp
+++ b/clang/test/CIR/CodeGen/binop.cpp
@@ -16,7 +16,7 @@ void b0(int a, int b) {
   x = x | b;
 }
 
-// CIR-LABEL: cir.func @_Z2b0ii(
+// CIR-LABEL: cir.func{{.*}} @_Z2b0ii(
 // CIR: %{{.+}} = cir.binop(mul, %{{.+}}, %{{.+}}) nsw : !s32i
 // CIR: %{{.+}} = cir.binop(div, %{{.+}}, %{{.+}}) : !s32i
 // CIR: %{{.+}} = cir.binop(rem, %{{.+}}, %{{.+}}) : !s32i
@@ -27,7 +27,7 @@ void b0(int a, int b) {
 // CIR: %{{.+}} = cir.binop(or, %{{.+}}, %{{.+}}) : !s32i
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z2b0ii(
+// LLVM-LABEL: define{{.*}} void @_Z2b0ii(
 // LLVM-SAME: i32 %[[A:.*]], i32 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i32
@@ -77,7 +77,7 @@ void b0(int a, int b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z2b0ii(i32 {{.*}} %a, i32 {{.*}} %b) {{.*}} { 
+// OGCG-LABEL: define{{.*}} void @_Z2b0ii(i32 {{.*}} %a, i32 {{.*}} %b) {{.*}} { 
 // OGCG:         %[[A_ADDR:.*]] = alloca i32
 // OGCG:         %[[B_ADDR:.*]] = alloca i32
 // OGCG:         %[[X:.*]] = alloca i32
@@ -133,14 +133,14 @@ void testFloatingPointBinOps(float a, float b) {
   a - b;
 }
 
-// CIR-LABEL: cir.func @_Z23testFloatingPointBinOpsff(
+// CIR-LABEL: cir.func{{.*}} @_Z23testFloatingPointBinOpsff(
 // CIR: cir.binop(mul, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.binop(div, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.binop(add, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.binop(sub, %{{.+}}, %{{.+}}) : !cir.float
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z23testFloatingPointBinOpsff(
+// LLVM-LABEL: define{{.*}} void @_Z23testFloatingPointBinOpsff(
 // LLVM-SAME: float %[[A:.*]], float %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca float, i64 1
 // LLVM:         %[[B_ADDR:.*]] = alloca float, i64 1
@@ -165,7 +165,7 @@ void testFloatingPointBinOps(float a, float b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z23testFloatingPointBinOpsff(float {{.*}} %a, float {{.*}} %b)
+// OGCG-LABEL: define{{.*}} void @_Z23testFloatingPointBinOpsff(float {{.*}} %a, float {{.*}} %b)
 // OGCG:         %a.addr = alloca float
 // OGCG:         %b.addr = alloca float
 // OGCG:         store float %a, ptr %a.addr
@@ -194,7 +194,7 @@ void signed_shift(int a, int b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @_Z12signed_shiftii(
+// CIR-LABEL: cir.func{{.*}} @_Z12signed_shiftii(
 // CIR-SAME: %[[ARG0:.*]]: !s32i{{.*}}, %[[ARG1:.*]]: !s32i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
@@ -215,7 +215,7 @@ void signed_shift(int a, int b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z12signed_shiftii
+// LLVM-LABEL: define{{.*}} void @_Z12signed_shiftii
 // LLVM-SAME: (i32 %[[A:.*]], i32 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i32
@@ -235,7 +235,7 @@ void signed_shift(int a, int b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z12signed_shiftii
+// OGCG-LABEL: define{{.*}} void @_Z12signed_shiftii
 // OGCG-SAME: (i32 {{.*}} %[[A:.*]], i32 {{.*}} %[[B:.*]])
 // OGCG:         %[[A_ADDR:.*]] = alloca i32
 // OGCG:         %[[B_ADDR:.*]] = alloca i32
@@ -260,7 +260,7 @@ void unsigned_shift(unsigned a, unsigned b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @_Z14unsigned_shiftjj(
+// CIR-LABEL: cir.func{{.*}} @_Z14unsigned_shiftjj(
 // CIR-SAME: %[[ARG0:.*]]: !u32i{{.*}}, %[[ARG1:.*]]: !u32i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init]
@@ -281,7 +281,7 @@ void unsigned_shift(unsigned a, unsigned b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z14unsigned_shiftjj
+// LLVM-LABEL: define{{.*}} void @_Z14unsigned_shiftjj
 // LLVM-SAME: (i32 %[[A:.*]], i32 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i32
@@ -301,7 +301,7 @@ void unsigned_shift(unsigned a, unsigned b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z14unsigned_shiftjj
+// OGCG-LABEL: define{{.*}} void @_Z14unsigned_shiftjj
 // OGCG-SAME: (i32 {{.*}} %[[A:.*]], i32 {{.*}} %[[B:.*]])
 // OGCG:         %[[A_ADDR:.*]] = alloca i32
 // OGCG:         %[[B_ADDR:.*]] = alloca i32
@@ -326,7 +326,7 @@ void zext_shift_example(int a, unsigned char b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @_Z18zext_shift_exampleih(
+// CIR-LABEL: cir.func{{.*}} @_Z18zext_shift_exampleih(
 // CIR-SAME: %[[ARG0:.*]]: !s32i{{.*}}, %[[ARG1:.*]]: !u8i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !u8i, !cir.ptr<!u8i>, ["b", init]
@@ -349,7 +349,7 @@ void zext_shift_example(int a, unsigned char b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z18zext_shift_exampleih
+// LLVM-LABEL: define{{.*}} void @_Z18zext_shift_exampleih
 // LLVM-SAME: (i32 %[[A:.*]], i8 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i8
@@ -371,7 +371,7 @@ void zext_shift_example(int a, unsigned char b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z18zext_shift_exampleih
+// OGCG-LABEL: define{{.*}} void @_Z18zext_shift_exampleih
 // OGCG-SAME: (i32 {{.*}} %[[A:.*]], i8 {{.*}} %[[B:.*]])
 // OGCG:         %[[A_ADDR:.*]] = alloca i32
 // OGCG:         %[[B_ADDR:.*]] = alloca i8
@@ -398,7 +398,7 @@ void sext_shift_example(int a, signed char b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @_Z18sext_shift_exampleia(
+// CIR-LABEL: cir.func{{.*}} @_Z18sext_shift_exampleia(
 // CIR-SAME: %[[ARG0:.*]]: !s32i{{.*}}, %[[ARG1:.*]]: !s8i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s8i, !cir.ptr<!s8i>, ["b", init]
@@ -421,7 +421,7 @@ void sext_shift_example(int a, signed char b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z18sext_shift_exampleia
+// LLVM-LABEL: define{{.*}} void @_Z18sext_shift_exampleia
 // LLVM-SAME: (i32 %[[A:.*]], i8 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i32
 // LLVM:         %[[B_ADDR:.*]] = alloca i8
@@ -443,7 +443,7 @@ void sext_shift_example(int a, signed char b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z18sext_shift_exampleia
+// OGCG-LABEL: define{{.*}} void @_Z18sext_shift_exampleia
 // OGCG-SAME: (i32 {{.*}} %[[A:.*]], i8 {{.*}} %[[B:.*]])
 // OGCG:         %[[A_ADDR:.*]] = alloca i32
 // OGCG:         %[[B_ADDR:.*]] = alloca i8
@@ -470,7 +470,7 @@ void long_shift_example(long long a, short b) {
   x = a << b;
 }
 
-// CIR-LABEL: cir.func @_Z18long_shift_examplexs(
+// CIR-LABEL: cir.func{{.*}} @_Z18long_shift_examplexs(
 // CIR-SAME: %[[ARG0:.*]]: !s64i{{.*}}, %[[ARG1:.*]]: !s16i{{.*}})
 // CIR: %[[A_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s16i, !cir.ptr<!s16i>, ["b", init]
@@ -493,7 +493,7 @@ void long_shift_example(long long a, short b) {
 
 // CIR: cir.return
 
-// LLVM-LABEL: define void @_Z18long_shift_examplexs
+// LLVM-LABEL: define{{.*}} void @_Z18long_shift_examplexs
 // LLVM-SAME: (i64 %[[A:.*]], i16 %[[B:.*]])
 // LLVM:         %[[A_ADDR:.*]] = alloca i64
 // LLVM:         %[[B_ADDR:.*]] = alloca i16
@@ -517,7 +517,7 @@ void long_shift_example(long long a, short b) {
 
 // LLVM:         ret void
 
-// OGCG-LABEL: define dso_local void @_Z18long_shift_examplexs
+// OGCG-LABEL: define{{.*}} void @_Z18long_shift_examplexs
 // OGCG-SAME: (i64 {{.*}} %[[A:.*]], i16 {{.*}} %[[B:.*]])
 // OGCG:         %[[A_ADDR:.*]] = alloca i64
 // OGCG:         %[[B_ADDR:.*]] = alloca i16
@@ -546,7 +546,7 @@ void b1(bool a, bool b) {
   x = x || b;
 }
 
-// CIR-LABEL: cir.func @_Z2b1bb(
+// CIR-LABEL: cir.func{{.*}} @_Z2b1bb(
 // CIR-SAME: %[[ARG0:.*]]: !cir.bool {{.*}}, %[[ARG1:.*]]: !cir.bool {{.*}})
 // CIR: [[A:%[0-9]+]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["a", init]
 // CIR: [[B:%[0-9]+]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b", init]
@@ -574,7 +574,7 @@ void b1(bool a, bool b) {
 // CIR: cir.return
 
 
-// LLVM-LABEL: define void @_Z2b1bb(
+// LLVM-LABEL: define{{.*}} void @_Z2b1bb(
 // LLVM-SAME: i1 %[[ARG0:.+]], i1 %[[ARG1:.+]])
 // LLVM: %[[A_ADDR:.*]] = alloca i8
 // LLVM: %[[B_ADDR:.*]] = alloca i8
@@ -611,7 +611,7 @@ void b1(bool a, bool b) {
 // LLVM: store i8 %[[ZEXT_OR]], ptr %[[X]]
 // LLVM: ret void
 
-// OGCG-LABEL: define dso_local void @_Z2b1bb
+// OGCG-LABEL: define{{.*}} void @_Z2b1bb
 // OGCG-SAME: (i1 {{.*}} %[[ARG0:.+]], i1 {{.*}} %[[ARG1:.+]])
 // OGCG: [[ENTRY:.*]]:
 // OGCG: %[[A_ADDR:.*]] = alloca i8
@@ -650,7 +650,7 @@ void b3(int a, int b, int c, int d) {
   x = (a == b) || (c == d);
 }
 
-// CIR-LABEL: cir.func @_Z2b3iiii(
+// CIR-LABEL: cir.func{{.*}} @_Z2b3iiii(
 // CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}, %[[ARG1:.*]]: !s32i {{.*}}, %[[ARG2:.*]]: !s32i {{.*}}, %[[ARG3:.*]]: !s32i {{.*}})
 // CIR: [[A:%[0-9]+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: [[B:%[0-9]+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
@@ -690,7 +690,7 @@ void b3(int a, int b, int c, int d) {
 // CIR: cir.return
 
 
-// LLVM-LABEL: define void @_Z2b3iiii(
+// LLVM-LABEL: define{{.*}} void @_Z2b3iiii(
 // LLVM-SAME: i32 %[[ARG0:.+]], i32 %[[ARG1:.+]], i32 %[[ARG2:.+]], i32 %[[ARG3:.+]])
 // LLVM: %[[A_ADDR:.*]] = alloca i32, i64 1
 // LLVM: %[[B_ADDR:.*]] = alloca i32, i64 1
@@ -733,7 +733,7 @@ void b3(int a, int b, int c, int d) {
 // LLVM: store i8 %[[ZEXT_OR]], ptr %[[X]]
 // LLVM: ret void
 
-// OGCG-LABEL: define dso_local void @_Z2b3iiii(
+// OGCG-LABEL: define{{.*}} void @_Z2b3iiii(
 // OGCG-SAME: i32 {{.*}} %[[ARG0:.+]], i32 {{.*}} %[[ARG1:.+]], i32 {{.*}} %[[ARG2:.+]], i32 {{.*}} %[[ARG3:.+]])
 // OGCG: [[ENTRY:.*]]:
 // OGCG: %[[A_ADDR:.*]] = alloca i32

--- a/clang/test/CIR/CodeGen/builtin_call.cpp
+++ b/clang/test/CIR/CodeGen/builtin_call.cpp
@@ -27,7 +27,7 @@ int is_constant_evaluated() {
   return __builtin_is_constant_evaluated();
 }
 
-// CIR: cir.func @_Z21is_constant_evaluatedv() -> !s32i
+// CIR: cir.func{{.*}} @_Z21is_constant_evaluatedv() -> !s32i
 // CIR: %[[ZERO:.+]] = cir.const #cir.int<0>
 
 // LLVM: define {{.*}}i32 @_Z21is_constant_evaluatedv()
@@ -45,7 +45,7 @@ long double constant_fp_builtin_ld() {
   return __builtin_fabsl(-0.1L);
 }
 
-// CIR: cir.func @_Z22constant_fp_builtin_ldv() -> !cir.long_double<!cir.f80>
+// CIR: cir.func{{.*}} @_Z22constant_fp_builtin_ldv() -> !cir.long_double<!cir.f80>
 // CIR: %[[PONE:.+]] = cir.const #cir.fp<1.000000e-01> : !cir.long_double<!cir.f80>
 
 // LLVM: define {{.*}}x86_fp80 @_Z22constant_fp_builtin_ldv()
@@ -63,7 +63,7 @@ float constant_fp_builtin_single() {
   return __builtin_fabsf(-0.1f);
 }
 
-// CIR: cir.func @_Z26constant_fp_builtin_singlev() -> !cir.float
+// CIR: cir.func{{.*}} @_Z26constant_fp_builtin_singlev() -> !cir.float
 // CIR: %[[PONE:.+]] = cir.const #cir.fp<1.000000e-01> : !cir.float
 
 // LLVM: define {{.*}}float @_Z26constant_fp_builtin_singlev()
@@ -82,16 +82,16 @@ void library_builtins() {
   __builtin_abort();
 }
 
-// CIR: cir.func @_Z16library_builtinsv() {
+// CIR: cir.func{{.*}} @_Z16library_builtinsv() {
 // CIR: %[[NULL:.+]] = cir.const #cir.ptr<null> : !cir.ptr<!s8i>
 // CIR: cir.call @printf(%[[NULL]]) : (!cir.ptr<!s8i>) -> !s32i
 // CIR: cir.call @abort() : () -> ()
 
-// LLVM: define void @_Z16library_builtinsv()
+// LLVM: define{{.*}} void @_Z16library_builtinsv()
 // LLVM: call i32 (ptr, ...) @printf(ptr null)
 // LLVM: call void @abort()
 
-// OGCG: define dso_local void @_Z16library_builtinsv()
+// OGCG: define{{.*}} void @_Z16library_builtinsv()
 // OGCG: call i32 (ptr, ...) @printf(ptr noundef null)
 // OGCG: call void @abort()
 
@@ -99,11 +99,11 @@ void assume(bool arg) {
   __builtin_assume(arg);
 }
 
-// CIR: cir.func @_Z6assumeb
+// CIR: cir.func{{.*}} @_Z6assumeb
 // CIR:   cir.assume %{{.+}} : !cir.bool
 // CIR: }
 
-// LLVM: define void @_Z6assumeb
+// LLVM: define {{.*}}void @_Z6assumeb
 // LLVM:   call void @llvm.assume(i1 %{{.+}})
 // LLVM: }
 
@@ -115,7 +115,7 @@ void expect(int x, int y) {
   __builtin_expect(x, y);
 }
 
-// CIR-LABEL: cir.func @_Z6expectii
+// CIR-LABEL: cir.func{{.*}} @_Z6expectii
 // CIR:         %[[X:.+]] = cir.load align(4) %{{.+}} : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:    %[[X_LONG:.+]] = cir.cast(integral, %[[X]] : !s32i), !s64i
 // CIR-NEXT:    %[[Y:.+]] = cir.load align(4) %{{.+}} : !cir.ptr<!s32i>, !s32i
@@ -123,7 +123,7 @@ void expect(int x, int y) {
 // CIR-NEXT:    %{{.+}} = cir.expect(%[[X_LONG]], %[[Y_LONG]]) : !s64i
 // CIR:       }
 
-// LLVM-LABEL: define void @_Z6expectii
+// LLVM-LABEL: define{{.*}} void @_Z6expectii
 // LLVM:         %[[X:.+]] = load i32, ptr %{{.+}}, align 4
 // LLVM-NEXT:    %[[X_LONG:.+]] = sext i32 %[[X]] to i64
 // LLVM-NEXT:    %[[Y:.+]] = load i32, ptr %{{.+}}, align 4
@@ -135,7 +135,7 @@ void expect_prob(int x, int y) {
   __builtin_expect_with_probability(x, y, 0.25);
 }
 
-// CIR-LABEL: cir.func @_Z11expect_probii
+// CIR-LABEL: cir.func{{.*}} @_Z11expect_probii
 // CIR:         %[[X:.+]] = cir.load align(4) %{{.+}} : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:    %[[X_LONG:.+]] = cir.cast(integral, %[[X]] : !s32i), !s64i
 // CIR-NEXT:    %[[Y:.+]] = cir.load align(4) %{{.+}} : !cir.ptr<!s32i>, !s32i
@@ -143,7 +143,7 @@ void expect_prob(int x, int y) {
 // CIR-NEXT:    %{{.+}} = cir.expect(%[[X_LONG]], %[[Y_LONG]], 2.500000e-01) : !s64i
 // CIR:       }
 
-// LLVM:       define void @_Z11expect_probii
+// LLVM:       define{{.*}} void @_Z11expect_probii
 // LLVM:         %[[X:.+]] = load i32, ptr %{{.+}}, align 4
 // LLVM-NEXT:    %[[X_LONG:.+]] = sext i32 %[[X]] to i64
 // LLVM-NEXT:    %[[Y:.+]] = load i32, ptr %{{.+}}, align 4

--- a/clang/test/CIR/CodeGen/builtin_printf.cpp
+++ b/clang/test/CIR/CodeGen/builtin_printf.cpp
@@ -18,9 +18,9 @@ void func(char const * const str, int i) {
   __builtin_printf("%s %d\n", str, i);
 }
 
-// CIR: cir.func @printf(!cir.ptr<!s8i>, ...) -> !s32i
+// CIR: cir.func{{.*}} @printf(!cir.ptr<!s8i>, ...) -> !s32i
 
-// CIR: cir.func @_Z4funcPKci(%[[arg0:.+]]: !cir.ptr<!s8i>{{.*}}, %[[arg1:.+]]: !s32i{{.*}}) {
+// CIR: cir.func{{.*}} @_Z4funcPKci(%[[arg0:.+]]: !cir.ptr<!s8i>{{.*}}, %[[arg1:.+]]: !s32i{{.*}}) {
 // CIR:   %[[str_ptr:.+]] = cir.alloca !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>, ["str", init, const]
 // CIR:   %[[i_ptr:.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init]
 // CIR:   cir.store %[[arg0]], %[[str_ptr]] : !cir.ptr<!s8i>, !cir.ptr<!cir.ptr<!s8i>>
@@ -38,7 +38,7 @@ void func(char const * const str, int i) {
 // CIR:   %[[printf_result3:.+]] = cir.call @printf(%[[full_fmt_ptr]], %[[str_val2]], %[[i_val]]) : (!cir.ptr<!s8i>, !cir.ptr<!s8i>, !s32i) -> !s32i
 // CIR:   cir.return
 
-// LLVM: define void @_Z4funcPKci(ptr %[[arg0:.+]], i32 %[[arg1:.+]])
+// LLVM: define{{.*}} void @_Z4funcPKci(ptr %[[arg0:.+]], i32 %[[arg1:.+]])
 // LLVM:   %[[str_ptr:.+]] = alloca ptr
 // LLVM:   %[[i_ptr:.+]] = alloca i32
 // LLVM:   store ptr %[[arg0]], ptr %[[str_ptr]]{{.*}}
@@ -51,7 +51,7 @@ void func(char const * const str, int i) {
 // LLVM:   %[[printf_result3:.+]] = call i32 (ptr, ...) @printf(ptr @.str.1, ptr %[[str_val2]], i32 %[[i_val]])
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4funcPKci(ptr noundef %[[arg0:.+]], i32 noundef %[[arg1:.+]])
+// OGCG: define{{.*}} void @_Z4funcPKci(ptr noundef %[[arg0:.+]], i32 noundef %[[arg1:.+]])
 // OGCG:   %[[str_ptr:.+]] = alloca ptr
 // OGCG:   %[[i_ptr:.+]] = alloca i32
 // OGCG:   store ptr %[[arg0]], ptr %[[str_ptr]]{{.*}}

--- a/clang/test/CIR/CodeGen/call.c
+++ b/clang/test/CIR/CodeGen/call.c
@@ -16,15 +16,15 @@ void f2() {
   f1(s);
 }
 
-// CIR-LABEL: cir.func @f2()
+// CIR-LABEL: cir.func{{.*}} @f2()
 // CIR:         %[[S:.+]] = cir.load align(4) %{{.+}} : !cir.ptr<!rec_S>, !rec_S
 // CIR-NEXT:    cir.call @f1(%[[S]]) : (!rec_S) -> ()
 
-// LLVM-LABEL: define void @f2()
+// LLVM-LABEL: define{{.*}} void @f2()
 // LLVM:         %[[S:.+]] = load %struct.S, ptr %{{.+}}, align 4
 // LLVM-NEXT:    call void @f1(%struct.S %[[S]])
 
-// OGCG-LABEL: define dso_local void @f2()
+// OGCG-LABEL: define{{.*}} void @f2()
 // OGCG:         %[[S:.+]] = load i64, ptr %{{.+}}, align 4
 // OGCG-NEXT:    call void @f1(i64 %[[S]])
 
@@ -33,15 +33,15 @@ void f4() {
   struct S s = f3();
 }
 
-// CIR-LABEL: cir.func @f4() {
+// CIR-LABEL: cir.func{{.*}} @f4() {
 // CIR:         %[[S:.+]] = cir.call @f3() : () -> !rec_S
 // CIR-NEXT:    cir.store align(4) %[[S]], %{{.+}} : !rec_S, !cir.ptr<!rec_S>
 
-// LLVM-LABEL: define void @f4() {
+// LLVM-LABEL: define{{.*}} void @f4() {
 // LLVM:         %[[S:.+]] = call %struct.S (...) @f3()
 // LLVM-NEXT:    store %struct.S %[[S]], ptr %{{.+}}, align 4
 
-// OGCG-LABEL: define dso_local void @f4() #0 {
+// OGCG-LABEL: define{{.*}} void @f4() #0 {
 // OGCG:         %[[S:.+]] = call i64 (...) @f3()
 // OGCG-NEXT:    store i64 %[[S]], ptr %{{.+}}, align 4
 
@@ -57,15 +57,15 @@ void f7() {
   f5(b);
 }
 
-// CIR-LABEL: cir.func @f7()
+// CIR-LABEL: cir.func{{.*}} @f7()
 // CIR:         %[[B:.+]] = cir.load align(4) %{{.+}} : !cir.ptr<!rec_Big>, !rec_Big
 // CIR-NEXT:    cir.call @f5(%[[B]]) : (!rec_Big) -> ()
 
-// LLVM-LABEL: define void @f7() {
+// LLVM-LABEL: define{{.*}} void @f7() {
 // LLVM:         %[[B:.+]] = load %struct.Big, ptr %{{.+}}, align 4
 // LLVM-NEXT:    call void @f5(%struct.Big %[[B]])
 
-// OGCG-LABEL: define dso_local void @f7() #0 {
+// OGCG-LABEL: define{{.*}} void @f7() #0 {
 // OGCG:         %[[B:.+]] = alloca %struct.Big, align 8
 // OGCG-NEXT:    call void @f5(ptr noundef byval(%struct.Big) align 8 %[[B]])
 
@@ -73,15 +73,15 @@ void f8() {
   struct Big b = f6();
 }
 
-// CIR-LABEL: cir.func @f8()
+// CIR-LABEL: cir.func{{.*}} @f8()
 // CIR:         %[[B:.+]] = cir.call @f6() : () -> !rec_Big
 // CIR:         cir.store align(4) %[[B]], %{{.+}} : !rec_Big, !cir.ptr<!rec_Big>
 
-// LLVM-LABEL: define void @f8() {
+// LLVM-LABEL: define{{.*}} void @f8() {
 // LLVM:        %[[B:.+]] = call %struct.Big (...) @f6()
 // LLVM-NEXT:   store %struct.Big %[[B]], ptr %{{.+}}, align 4
 
-// OGCG-LABEL: define dso_local void @f8() #0 {
+// OGCG-LABEL: define{{.*}} void @f8() #0 {
 // OGCG:         %[[B:.+]] = alloca %struct.Big, align 4
 // OGCG-NEXT:    call void (ptr, ...) @f6(ptr dead_on_unwind writable sret(%struct.Big) align 4 %[[B]])
 
@@ -89,21 +89,21 @@ void f9() {
   f1(f3());
 }
 
-// CIR-LABEL: cir.func @f9()
+// CIR-LABEL: cir.func{{.*}} @f9()
 // CIR:         %[[SLOT:.+]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["agg.tmp0"] {alignment = 4 : i64}
 // CIR-NEXT:    %[[RET:.+]] = cir.call @f3() : () -> !rec_S
 // CIR-NEXT:    cir.store align(4) %[[RET]], %[[SLOT]] : !rec_S, !cir.ptr<!rec_S>
 // CIR-NEXT:    %[[ARG:.+]] = cir.load align(4) %[[SLOT]] : !cir.ptr<!rec_S>, !rec_S
 // CIR-NEXT:    cir.call @f1(%[[ARG]]) : (!rec_S) -> ()
 
-// LLVM-LABEL: define void @f9() {
+// LLVM-LABEL: define{{.*}} void @f9() {
 // LLVM:         %[[SLOT:.+]] = alloca %struct.S, i64 1, align 4
 // LLVM-NEXT:    %[[RET:.+]] = call %struct.S (...) @f3()
 // LLVM-NEXT:    store %struct.S %[[RET]], ptr %[[SLOT]], align 4
 // LLVM-NEXT:    %[[ARG:.+]] = load %struct.S, ptr %[[SLOT]], align 4
 // LLVM-NEXT:    call void @f1(%struct.S %[[ARG]])
 
-// OGCG-LABEL: define dso_local void @f9() #0 {
+// OGCG-LABEL: define{{.*}} void @f9() #0 {
 // OGCG:         %[[SLOT:.+]] = alloca %struct.S, align 4
 // OGCG-NEXT:    %[[RET:.+]] = call i64 (...) @f3()
 // OGCG-NEXT:    store i64 %[[RET]], ptr %[[SLOT]], align 4
@@ -116,17 +116,17 @@ int f12(void) {
   return f10(1) + f11(2);
 }
 
-// CIR-LABEL: cir.func @f12() -> !s32i
+// CIR-LABEL: cir.func{{.*}} @f12() -> !s32i
 // CIR:         %[[A:.+]] = cir.const #cir.int<1> : !s32i
 // CIR-NEXT:    %{{.+}} = cir.call @f10(%[[A]]) side_effect(pure) : (!s32i) -> !s32i
 // CIR-NEXT:    %[[B:.+]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:    %{{.+}} = cir.call @f11(%[[B]]) side_effect(const) : (!s32i) -> !s32i
 
-// LLVM-LABEL: define i32 @f12()
+// LLVM-LABEL: define{{.*}} i32 @f12()
 // LLVM:         %{{.+}} = call i32 @f10(i32 1) #[[ATTR0:.+]]
 // LLVM-NEXT:    %{{.+}} = call i32 @f11(i32 2) #[[ATTR1:.+]]
 
-// OGCG-LABEL: define dso_local i32 @f12()
+// OGCG-LABEL: define{{.*}} i32 @f12()
 // OGCG:         %{{.+}} = call i32 @f10(i32 noundef 1) #[[ATTR0:.+]]
 // OGCG-NEXT:    %{{.+}} = call i32 @f11(i32 noundef 2) #[[ATTR1:.+]]
 

--- a/clang/test/CIR/CodeGen/call.cpp
+++ b/clang/test/CIR/CodeGen/call.cpp
@@ -8,11 +8,11 @@ void f2() {
   f1();
 }
 
-// CIR-LABEL: cir.func @_Z2f1v
-// CIR-LABEL: cir.func @_Z2f2v
+// CIR-LABEL: cir.func{{.*}} @_Z2f1v
+// CIR-LABEL: cir.func{{.*}} @_Z2f2v
 // CIR:         cir.call @_Z2f1v() : () -> ()
 
-// LLVM-LABEL: define void @_Z2f2v() {
+// LLVM-LABEL: define{{.*}} void @_Z2f2v() {
 // LLVM:         call void @_Z2f1v()
 
 int f3() { return 2; }
@@ -21,11 +21,11 @@ int f4() {
   return x;
 }
 
-// CIR-LABEL: cir.func @_Z2f3v() -> !s32i
-// CIR-LABEL: cir.func @_Z2f4v() -> !s32i
+// CIR-LABEL: cir.func{{.*}} @_Z2f3v() -> !s32i
+// CIR-LABEL: cir.func{{.*}} @_Z2f4v() -> !s32i
 // CIR:         cir.call @_Z2f3v() : () -> !s32i
 
-// LLVM-LABEL: define i32 @_Z2f4v() {
+// LLVM-LABEL: define{{.*}} i32 @_Z2f4v() {
 // LLVM:         %{{.+}} = call i32 @_Z2f3v()
 
 int f5(int a, int *b, bool c);
@@ -34,26 +34,26 @@ int f6() {
   return f5(2, &b, false);
 }
 
-// CIR-LABEL: cir.func @_Z2f6v() -> !s32i
+// CIR-LABEL: cir.func{{.*}} @_Z2f6v() -> !s32i
 // CIR:         %[[#b:]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
 // CIR:         %[[#a:]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:    %[[#c:]] = cir.const #false
 // CIR-NEXT:    %{{.+}} = cir.call @_Z2f5iPib(%[[#a]], %[[#b:]], %[[#c]]) : (!s32i, !cir.ptr<!s32i>, !cir.bool) -> !s32i
 
-// LLVM-LABEL: define i32 @_Z2f6v() {
+// LLVM-LABEL: define{{.*}} i32 @_Z2f6v() {
 // LLVM:         %{{.+}} = call i32 @_Z2f5iPib(i32 2, ptr %{{.+}}, i1 false)
 
 int f7(int (*ptr)(int, int)) {
   return ptr(1, 2);
 }
 
-// CIR-LABEL: cir.func @_Z2f7PFiiiE
+// CIR-LABEL: cir.func{{.*}} @_Z2f7PFiiiE
 // CIR:         %[[#ptr:]] = cir.load{{.*}} %{{.+}} : !cir.ptr<!cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>>, !cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>
 // CIR-NEXT:    %[[#a:]] = cir.const #cir.int<1> : !s32i
 // CIR-NEXT:    %[[#b:]] = cir.const #cir.int<2> : !s32i
 // CIR-NEXT:    %{{.+}} = cir.call %[[#ptr]](%[[#a]], %[[#b]]) : (!cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>, !s32i, !s32i) -> !s32i
 
-// LLVM-LABEL: define i32 @_Z2f7PFiiiE
+// LLVM-LABEL: define{{.*}} i32 @_Z2f7PFiiiE
 // LLVM:         %[[#ptr:]] = load ptr, ptr %{{.+}}
 // LLVM-NEXT:    %{{.+}} = call i32 %[[#ptr]](i32 1, i32 2)
 
@@ -63,11 +63,11 @@ void f9() {
   f8(1, 2, 3, 4);
 }
 
-// CIR-LABEL: cir.func @_Z2f9v()
+// CIR-LABEL: cir.func{{.*}} @_Z2f9v()
 // CIR:         cir.call @_Z2f8iz(%{{.+}}) : (!s32i) -> ()
 // CIR:         cir.call @_Z2f8iz(%{{.+}}, %{{.+}}, %{{.+}}, %{{.+}}) : (!s32i, !s32i, !s32i, !s32i) -> ()
 
-// LLVM-LABEL: define void @_Z2f9v()
+// LLVM-LABEL: define{{.*}} void @_Z2f9v()
 // LLVM:         call void (i32, ...) @_Z2f8iz(i32 1)
 // LLVM:         call void (i32, ...) @_Z2f8iz(i32 1, i32 2, i32 3, i32 4)
 
@@ -81,11 +81,11 @@ void f11() {
   S s = f10();
 }
 
-// CIR-LABEL: cir.func @_Z3f11v()
+// CIR-LABEL: cir.func{{.*}} @_Z3f11v()
 // CIR:         %[[#s:]] = cir.call @_Z3f10v() : () -> !rec_S
 // CIR-NEXT:    cir.store align(4) %[[#s]], %{{.+}} : !rec_S, !cir.ptr<!rec_S>
 
-// LLVM-LABEL: define void @_Z3f11v()
+// LLVM-LABEL: define{{.*}} void @_Z3f11v()
 // LLVM:         %[[#s:]] = call %struct.S @_Z3f10v()
 // LLVM-NEXT:    store %struct.S %[[#s]], ptr %{{.+}}, align 4
 
@@ -93,12 +93,12 @@ void f12() {
   f10();
 }
 
-// CIR-LABEL: cir.func @_Z3f12v()
+// CIR-LABEL: cir.func{{.*}} @_Z3f12v()
 // CIR:         %[[#slot:]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["agg.tmp0"]
 // CIR-NEXT:    %[[#ret:]] = cir.call @_Z3f10v() : () -> !rec_S
 // CIR-NEXT:    cir.store align(4) %[[#ret]], %[[#slot]] : !rec_S, !cir.ptr<!rec_S>
 
-// LLVM-LABEL: define void @_Z3f12v() {
+// LLVM-LABEL: define{{.*}} void @_Z3f12v() {
 // LLVM:         %[[#slot:]] = alloca %struct.S, i64 1, align 4
 // LLVM-NEXT:    %[[#ret:]] = call %struct.S @_Z3f10v()
 // LLVM-NEXT:    store %struct.S %[[#ret]], ptr %[[#slot]], align 4

--- a/clang/test/CIR/CodeGen/cast.cpp
+++ b/clang/test/CIR/CodeGen/cast.cpp
@@ -7,7 +7,7 @@ unsigned char cxxstaticcast_0(unsigned int x) {
   return static_cast<unsigned char>(x);
 }
 
-// CIR: cir.func @_Z15cxxstaticcast_0j
+// CIR: cir.func{{.*}} @_Z15cxxstaticcast_0j
 // CIR:    %[[XPTR:[0-9]+]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["x", init] {alignment = 4 : i64}
 // CIR:    %[[RV:[0-9]+]] = cir.alloca !u8i, !cir.ptr<!u8i>, ["__retval"] {alignment = 1 : i64}
 // CIR:    cir.store %arg0, %[[XPTR]] : !u32i, !cir.ptr<!u32i>
@@ -18,7 +18,7 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 // CIR:    cir.return %[[R]] : !u8i
 // CIR:  }
 
-// LLVM: define i8 @_Z15cxxstaticcast_0j(i32 %{{[0-9]+}})
+// LLVM: define{{.*}} i8 @_Z15cxxstaticcast_0j(i32 %{{[0-9]+}})
 // LLVM: %[[LOAD:[0-9]+]] = load i32, ptr %{{[0-9]+}}, align 4
 // LLVM: %[[TRUNC:[0-9]+]] = trunc i32 %[[LOAD]] to i8
 // LLVM: store i8 %[[TRUNC]], ptr %[[RV:[0-9]+]], align 1
@@ -26,8 +26,8 @@ unsigned char cxxstaticcast_0(unsigned int x) {
 // LLVM: ret i8 %[[R]]
 
 int cStyleCasts_0(unsigned x1, int x2, float x3, short x4, double x5) {
-// CIR: cir.func @_Z13cStyleCasts_0jifsd
-// LLVM: define i32 @_Z13cStyleCasts_0jifsd
+// CIR: cir.func{{.*}} @_Z13cStyleCasts_0jifsd
+// LLVM: define{{.*}} i32 @_Z13cStyleCasts_0jifsd
 
   char a = (char)x1; // truncate
   // CIR: %{{[0-9]+}} = cir.cast(integral, %{{[0-9]+}} : !u32i), !s8i
@@ -89,13 +89,13 @@ bool cptr(void *d) {
   return x;
 }
 
-// CIR: cir.func @_Z4cptrPv(%arg0: !cir.ptr<!void>
+// CIR: cir.func{{.*}} @_Z4cptrPv(%arg0: !cir.ptr<!void>
 // CIR:   %[[DPTR:[0-9]+]] = cir.alloca !cir.ptr<!void>, !cir.ptr<!cir.ptr<!void>>, ["d", init] {alignment = 8 : i64}
 
 // CIR:   %[[DVAL:[0-9]+]] = cir.load{{.*}} %[[DPTR]] : !cir.ptr<!cir.ptr<!void>>, !cir.ptr<!void>
 // CIR:   %{{[0-9]+}} = cir.cast(ptr_to_bool, %[[DVAL]] : !cir.ptr<!void>), !cir.bool
 
-// LLVM-LABEL: define i1 @_Z4cptrPv(ptr %0)
+// LLVM-LABEL: define{{.*}} i1 @_Z4cptrPv(ptr %0)
 // LLVM:         %[[ARG_STORAGE:.*]] = alloca ptr, i64 1
 // LLVM:         %[[RETVAL:.*]] = alloca i8, i64 1
 // LLVM:         %[[X_STORAGE:.*]] = alloca i8, i64 1
@@ -114,7 +114,7 @@ void should_not_cast() {
   (void) ib; // void cast
 }
 
-// CIR:     cir.func @_Z15should_not_castv
+// CIR:     cir.func{{.*}} @_Z15should_not_castv
 // CIR-NOT:   cir.cast
 // CIR:     cir.return
 

--- a/clang/test/CIR/CodeGen/class.cpp
+++ b/clang/test/CIR/CodeGen/class.cpp
@@ -51,7 +51,7 @@ public:
 
 int use(Derived *d) { return d->b; }
 
-// CIR: cir.func @_Z3useP7Derived(%[[ARG0:.*]]: !cir.ptr<!rec_Derived>
+// CIR: cir.func{{.*}} @_Z3useP7Derived(%[[ARG0:.*]]: !cir.ptr<!rec_Derived>
 // CIR:  %[[D_ADDR:.*]] = cir.alloca !cir.ptr<!rec_Derived>, !cir.ptr<!cir.ptr<!rec_Derived>>, ["d", init]
 // CIR:  cir.store %[[ARG0]], %[[D_ADDR]]
 // CIR:  %[[D_PTR:.*]] = cir.load align(8) %0
@@ -69,7 +69,7 @@ int use_base() {
   return d.a;
 }
 
-// CIR: cir.func @_Z8use_basev
+// CIR: cir.func{{.*}} @_Z8use_basev
 // CIR:   %[[D_ADDR:.*]] = cir.alloca !rec_Derived, !cir.ptr<!rec_Derived>, ["d"]
 // CIR:   %[[BASE_ADDR:.*]] cir.base_class_addr %[[D_ADDR]] : !cir.ptr<!rec_Derived> nonnull [0] -> !cir.ptr<!rec_Base>
 // CIR:   %[[D_A_ADDR:.*]] = cir.get_member %2[0] {name = "a"} : !cir.ptr<!rec_Base> -> !cir.ptr<!s32i>
@@ -87,7 +87,7 @@ int use_base_via_pointer(Derived *d) {
   return d->a;
 }
 
-// CIR: cir.func @_Z20use_base_via_pointerP7Derived(%[[ARG0:.*]]: !cir.ptr<!rec_Derived>
+// CIR: cir.func{{.*}} @_Z20use_base_via_pointerP7Derived(%[[ARG0:.*]]: !cir.ptr<!rec_Derived>
 // CIR:   %[[D_ADDR:.*]] = cir.alloca !cir.ptr<!rec_Derived>, !cir.ptr<!cir.ptr<!rec_Derived>>, ["d", init]
 // CIR:   cir.store %[[ARG0]], %[[D_ADDR]]
 // CIR:   %[[D:.*]] = cir.load align(8) %[[D_ADDR]]

--- a/clang/test/CIR/CodeGen/cmp.cpp
+++ b/clang/test/CIR/CodeGen/cmp.cpp
@@ -14,7 +14,7 @@ void c0(int a, int b) {
   x = a == b;
 }
 
-// CIR-LABEL: cir.func @_Z2c0ii(
+// CIR-LABEL: cir.func{{.*}} @_Z2c0ii(
 
 // CIR: %[[A_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
@@ -45,7 +45,7 @@ void c0(int a, int b) {
 // CIR: %[[B6:.*]] = cir.load{{.*}} %[[B_PTR]]
 // CIR: %{{.*}} = cir.cmp(eq, %[[A6]], %[[B6]]) : !s32i, !cir.bool
 
-// LLVM-LABEL: define void @_Z2c0ii(i32 %0, i32 %1) {
+// LLVM-LABEL: define{{.*}} void @_Z2c0ii(i32 %0, i32 %1) {
 // LLVM: %[[PTR1:.*]] = alloca i32, i64 1
 // LLVM: %[[PTR2:.*]] = alloca i32, i64 1
 // LLVM: %[[BOOL_PTR:.*]] = alloca i8, i64 1
@@ -88,7 +88,7 @@ void c0(int a, int b) {
 // LLVM: %[[ZEXT6:.*]] = zext i1 %[[CMP6]] to i8
 // LLVM: store i8 %[[ZEXT6]], ptr %[[BOOL_PTR]]
 
-// OGCG-LABEL: define dso_local void @_Z2c0ii(i32 {{.*}} %a, i32 {{.*}} %b) {{.*}} {
+// OGCG-LABEL: define{{.*}} void @_Z2c0ii(i32 {{.*}} %a, i32 {{.*}} %b) {{.*}} {
 // OGCG: %[[PTR1:.*]] = alloca i32
 // OGCG: %[[PTR2:.*]] = alloca i32
 // OGCG: %[[BOOL_PTR:.*]] = alloca i8
@@ -140,7 +140,7 @@ void c0_unsigned(unsigned int a, unsigned int b) {
   x = a == b;
 }
 
-// CIR-LABEL: cir.func @_Z11c0_unsignedjj(
+// CIR-LABEL: cir.func{{.*}} @_Z11c0_unsignedjj(
 
 // CIR: %[[U_A_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CIR: %[[U_B_PTR:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init]
@@ -170,7 +170,7 @@ void c0_unsigned(unsigned int a, unsigned int b) {
 // CIR: %[[UB6:.*]] = cir.load{{.*}} %[[U_B_PTR]]
 // CIR: %{{.*}} = cir.cmp(eq, %[[UA6]], %[[UB6]]) : !u32i, !cir.bool
 
-// LLVM-LABEL: define void @_Z11c0_unsignedjj(i32 %0, i32 %1) {
+// LLVM-LABEL: define{{.*}} void @_Z11c0_unsignedjj(i32 %0, i32 %1) {
 // LLVM: %[[U_PTR1:.*]] = alloca i32, i64 1
 // LLVM: %[[U_PTR2:.*]] = alloca i32, i64 1
 // LLVM: %[[U_BOOL_PTR:.*]] = alloca i8, i64 1
@@ -213,7 +213,7 @@ void c0_unsigned(unsigned int a, unsigned int b) {
 // LLVM: %[[UZEXT6:.*]] = zext i1 %[[UCMP6]] to i8
 // LLVM: store i8 %[[UZEXT6]], ptr %[[U_BOOL_PTR]]
 
-// OGCG-LABEL: define dso_local void @_Z11c0_unsignedjj(i32 {{.*}} %a, i32 {{.*}} %b) {{.*}} {
+// OGCG-LABEL: define{{.*}} void @_Z11c0_unsignedjj(i32 {{.*}} %a, i32 {{.*}} %b) {{.*}} {
 // OGCG: %[[U_PTR1:.*]] = alloca i32
 // OGCG: %[[U_PTR2:.*]] = alloca i32
 // OGCG: %[[U_BOOL_PTR:.*]] = alloca i8
@@ -265,7 +265,7 @@ void c0_float(float a, float b) {
   x = a == b;
 }
 
-// CIR-LABEL: cir.func @_Z8c0_floatff(%arg0: !cir.float{{.*}}, %arg1: !cir.float{{.*}}) {
+// CIR-LABEL: cir.func{{.*}} @_Z8c0_floatff(%arg0: !cir.float{{.*}}, %arg1: !cir.float{{.*}}) {
 // CIR: %[[A_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["b", init]
 // CIR: %[[X_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init]
@@ -303,7 +303,7 @@ void c0_float(float a, float b) {
 // CIR: %[[CMP6:.*]] = cir.cmp(eq, %[[A6]], %[[B6]]) : !cir.float, !cir.bool
 // CIR: cir.store{{.*}} %[[CMP6]], %[[X_PTR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM-LABEL: define void @_Z8c0_floatff(float %0, float %1) {
+// LLVM-LABEL: define{{.*}} void @_Z8c0_floatff(float %0, float %1) {
 // LLVM: %[[A_PTR:.*]] = alloca float
 // LLVM: %[[B_PTR:.*]] = alloca float
 // LLVM: store float %0, ptr %[[A_PTR]]
@@ -320,7 +320,7 @@ void c0_float(float a, float b) {
 // LLVM: fcmp une float %{{.*}}, %{{.*}}
 // LLVM: fcmp oeq float %{{.*}}, %{{.*}}
 
-// OGCG-LABEL: define dso_local void @_Z8c0_floatff(float {{.*}} %a, float  {{.*}} %b)  {{.*}} {
+// OGCG-LABEL: define{{.*}} void @_Z8c0_floatff(float {{.*}} %a, float  {{.*}} %b)  {{.*}} {
 // OGCG: %[[A_PTR:.*]] = alloca float
 // OGCG: %[[B_PTR:.*]] = alloca float
 // OGCG: store float %a, ptr %[[A_PTR]]
@@ -346,7 +346,7 @@ void pointer_cmp(int *a, int *b) {
   x = a != b;
 }
 
-// CIR-LABEL: cir.func @_Z11pointer_cmpPiS_(%arg0: !cir.ptr<!s32i>{{.*}}, %arg1: !cir.ptr<!s32i>{{.*}}) {
+// CIR-LABEL: cir.func{{.*}} @_Z11pointer_cmpPiS_(%arg0: !cir.ptr<!s32i>{{.*}}, %arg1: !cir.ptr<!s32i>{{.*}}) {
 // CIR: %[[A_PTR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["b", init]
 
@@ -360,7 +360,7 @@ void pointer_cmp(int *a, int *b) {
 // CIR: cir.cmp(eq, {{.*}}, {{.*}}) : !cir.ptr<!s32i>, !cir.bool
 // CIR: cir.cmp(ne, {{.*}}, {{.*}}) : !cir.ptr<!s32i>, !cir.bool
 
-// LLVM-LABEL: define void @_Z11pointer_cmpPiS_(ptr %0, ptr %1) {
+// LLVM-LABEL: define{{.*}} void @_Z11pointer_cmpPiS_(ptr %0, ptr %1) {
 // LLVM: %[[A_PTR:.*]] = alloca ptr
 // LLVM: %[[B_PTR:.*]] = alloca ptr
 // LLVM: store ptr %0, ptr %[[A_PTR]]
@@ -376,7 +376,7 @@ void pointer_cmp(int *a, int *b) {
 // LLVM: icmp eq ptr %{{.*}}, %{{.*}}
 // LLVM: icmp ne ptr %{{.*}}, %{{.*}}
 
-// OGCG-LABEL: define dso_local void @_Z11pointer_cmpPiS_(ptr {{.*}} %a, ptr {{.*}} %b) {{.*}} {
+// OGCG-LABEL: define{{.*}} void @_Z11pointer_cmpPiS_(ptr {{.*}} %a, ptr {{.*}} %b) {{.*}} {
 // OGCG: %[[A_PTR:.*]] = alloca ptr
 // OGCG: %[[B_PTR:.*]] = alloca ptr
 // OGCG: store ptr %a, ptr %[[A_PTR]]
@@ -401,7 +401,7 @@ void bool_cmp(bool a, bool b) {
   x = a != b;
 }
 
-// CIR-LABEL: cir.func @_Z8bool_cmpbb(%arg0: !cir.bool{{.*}}, %arg1: !cir.bool{{.*}}) {
+// CIR-LABEL: cir.func{{.*}} @_Z8bool_cmpbb(%arg0: !cir.bool{{.*}}, %arg1: !cir.bool{{.*}}) {
 // CIR: %[[A_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["a", init]
 // CIR: %[[B_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b", init]
 // CIR: %[[X_PTR:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init]
@@ -419,7 +419,7 @@ void bool_cmp(bool a, bool b) {
 // CIR: cir.cmp(eq
 // CIR: cir.cmp(ne
 
-// LLVM-LABEL: define void @_Z8bool_cmpbb(i1 %0, i1 %1) {
+// LLVM-LABEL: define{{.*}} void @_Z8bool_cmpbb(i1 %0, i1 %1) {
 // LLVM: %[[A_PTR:.*]] = alloca i8
 // LLVM: %[[B_PTR:.*]] = alloca i8
 // LLVM: %[[X_PTR:.*]] = alloca i8
@@ -444,7 +444,7 @@ void bool_cmp(bool a, bool b) {
 // LLVM: icmp eq
 // LLVM: icmp ne
 
-// OGCG-LABEL: define dso_local void @_Z8bool_cmpbb(i1 {{.*}} %a, i1 {{.*}} %b) {{.*}} {
+// OGCG-LABEL: define{{.*}} void @_Z8bool_cmpbb(i1 {{.*}} %a, i1 {{.*}} %b) {{.*}} {
 // OGCG: %[[A_PTR:.*]] = alloca i8
 // OGCG: %[[B_PTR:.*]] = alloca i8
 // OGCG: %[[X_PTR:.*]] = alloca i8

--- a/clang/test/CIR/CodeGen/comma.c
+++ b/clang/test/CIR/CodeGen/comma.c
@@ -16,7 +16,7 @@ void comma(void) {
     i = 100, 200;
 }
 
-// CIR-LABEL: cir.func @comma() {
+// CIR-LABEL: cir.func{{.*}} @comma() {
 // CIR:         %[[B:.*]] = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b"]
 // CIR:         %[[C:.*]] = cir.alloca !s8i, !cir.ptr<!s8i>, ["c"]
 // CIR:         %[[F:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f"]

--- a/clang/test/CIR/CodeGen/compound_assign.cpp
+++ b/clang/test/CIR/CodeGen/compound_assign.cpp
@@ -20,7 +20,7 @@ int compound_assign(int b) {
   return x;
 }
 
-// CIR: cir.func @_Z15compound_assigni
+// CIR: cir.func{{.*}} @_Z15compound_assigni
 // CIR:   %[[MUL:.*]] = cir.binop(mul, %{{.*}}, %{{.*}}) nsw : !s32i
 // CIR:   cir.store{{.*}} %[[MUL]], %{{.*}} : !s32i, !cir.ptr<!s32i>
 // CIR:   %[[DIV:.*]] = cir.binop(div, %{{.*}}, %{{.*}}) : !s32i

--- a/clang/test/CIR/CodeGen/ctor.cpp
+++ b/clang/test/CIR/CodeGen/ctor.cpp
@@ -16,20 +16,20 @@ void baz() {
 //       constructors here. The handling of constructor aliases is currently
 //       NYI, but when it is added this test should be updated to add a RUN
 //       line that passes '-mconstructor-aliases' to clang_cc1.
-// CHECK:   cir.func @_ZN5StrukC2Ev(%arg0: !cir.ptr<!rec_Struk>
+// CHECK:   cir.func{{.*}} @_ZN5StrukC2Ev(%arg0: !cir.ptr<!rec_Struk>
 // CHECK-NEXT:     %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_Struk>, !cir.ptr<!cir.ptr<!rec_Struk>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:     cir.store %arg0, %[[THIS_ADDR]] : !cir.ptr<!rec_Struk>, !cir.ptr<!cir.ptr<!rec_Struk>>
 // CHECK-NEXT:     %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_Struk>>, !cir.ptr<!rec_Struk>
 // CHECK-NEXT:     cir.return
 
-// CHECK:   cir.func @_ZN5StrukC1Ev(%arg0: !cir.ptr<!rec_Struk>
+// CHECK:   cir.func{{.*}} @_ZN5StrukC1Ev(%arg0: !cir.ptr<!rec_Struk>
 // CHECK-NEXT:     %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_Struk>, !cir.ptr<!cir.ptr<!rec_Struk>>, ["this", init] {alignment = 8 : i64}
 // CHECK-NEXT:     cir.store %arg0, %[[THIS_ADDR]] : !cir.ptr<!rec_Struk>, !cir.ptr<!cir.ptr<!rec_Struk>>
 // CHECK-NEXT:     %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_Struk>>, !cir.ptr<!rec_Struk>
 // CHECK-NEXT:     cir.call @_ZN5StrukC2Ev(%[[THIS]]) : (!cir.ptr<!rec_Struk>) -> ()
 // CHECK-NEXT:     cir.return
 
-// CHECK:   cir.func @_Z3bazv()
+// CHECK:   cir.func{{.*}} @_Z3bazv()
 // CHECK-NEXT:     %[[S_ADDR:.*]] = cir.alloca !rec_Struk, !cir.ptr<!rec_Struk>, ["s", init] {alignment = 4 : i64}
 // CHECK-NEXT:     cir.call @_ZN5StrukC1Ev(%[[S_ADDR]]) : (!cir.ptr<!rec_Struk>) -> ()
 // CHECK-NEXT:     cir.return
@@ -45,9 +45,9 @@ void bar() {
 
 // When a variadic constructor is present, we call the C2 constructor directly.
 
-// CHECK-NOT: cir.func @_ZN13VariadicStrukC2Eiz
+// CHECK-NOT: cir.func{{.*}} @_ZN13VariadicStrukC2Eiz
 
-// CHECK:      cir.func @_ZN13VariadicStrukC1Eiz(%arg0: !cir.ptr<!rec_VariadicStruk>
+// CHECK:      cir.func{{.*}} @_ZN13VariadicStrukC1Eiz(%arg0: !cir.ptr<!rec_VariadicStruk>
 // CHECK-SAME:                                   %arg1: !s32i
 // CHECK-SAME:                                   ...) {
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
@@ -60,7 +60,7 @@ void bar() {
 // CHECK-NEXT:   cir.store{{.*}} %[[N]], %[[A_ADDR]]
 // CHECK-NEXT:   cir.return
 
-// CHECK:  cir.func @_Z3barv
+// CHECK:  cir.func{{.*}} @_Z3barv
 // CHECK-NEXT:    %[[S_ADDR:.*]] = cir.alloca !rec_VariadicStruk, !cir.ptr<!rec_VariadicStruk>, ["s", init]
 // CHECK-NEXT:    %[[ONE:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:    %[[TWO:.*]] = cir.const #cir.int<2> : !s32i
@@ -78,7 +78,7 @@ void bam() {
   DelegatingStruk s;
 }
 
-// CHECK:       cir.func @_ZN15DelegatingStrukC2Ei(%arg0: !cir.ptr<!rec_DelegatingStruk>
+// CHECK:       cir.func{{.*}} @_ZN15DelegatingStrukC2Ei(%arg0: !cir.ptr<!rec_DelegatingStruk>
 // CHECK-SAME:                                     %arg1: !s32i
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   %[[N_ADDR:.*]] = cir.alloca {{.*}} ["n", init]
@@ -90,7 +90,7 @@ void bam() {
 // CHECK-NEXT:   cir.store{{.*}} %[[N]], %[[A_ADDR]]
 // CHECK-NEXT:   cir.return
 
-// CHECK:       cir.func @_ZN15DelegatingStrukC1Ei(%arg0: !cir.ptr<!rec_DelegatingStruk>
+// CHECK:       cir.func{{.*}} @_ZN15DelegatingStrukC1Ei(%arg0: !cir.ptr<!rec_DelegatingStruk>
 // CHECK-SAME:                                     %arg1: !s32i
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   %[[N_ADDR:.*]] = cir.alloca {{.*}} ["n", init]
@@ -101,7 +101,7 @@ void bam() {
 // CHECK-NEXT:   cir.call @_ZN15DelegatingStrukC2Ei(%[[THIS]], %[[N]])
 // CHECK-NEXT:   cir.return
 
-// CHECK: cir.func @_ZN15DelegatingStrukC1Ev(%arg0: !cir.ptr<!rec_DelegatingStruk>
+// CHECK: cir.func{{.*}} @_ZN15DelegatingStrukC1Ev(%arg0: !cir.ptr<!rec_DelegatingStruk>
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   cir.store %arg0, %[[THIS_ADDR]]
 // CHECK-NEXT:   %[[THIS:.*]] = cir.load{{.*}} %[[THIS_ADDR]]
@@ -109,7 +109,7 @@ void bam() {
 // CHECK-NEXT:   cir.call @_ZN15DelegatingStrukC1Ei(%[[THIS]], %[[ZERO]])
 // CHECK-NEXT:   cir.return
 
-// CHECK: cir.func @_Z3bamv
+// CHECK: cir.func{{.*}} @_Z3bamv
 // CHECK-NEXT:    %[[S_ADDR:.*]] = cir.alloca {{.*}} ["s", init]
 // CHECK-NEXT:    cir.call @_ZN15DelegatingStrukC1Ev(%[[S_ADDR]])
 // CHECK-NEXT:    cir.return
@@ -123,7 +123,7 @@ void init_member() {
   MemberInitStruk s;
 }
 
-// CHECK:      cir.func @_ZN15MemberInitStrukC2Ev(%arg0: !cir.ptr<!rec_MemberInitStruk>
+// CHECK:      cir.func{{.*}} @_ZN15MemberInitStrukC2Ev(%arg0: !cir.ptr<!rec_MemberInitStruk>
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   cir.store %arg0, %[[THIS_ADDR]]
 // CHECK-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]]
@@ -132,14 +132,14 @@ void init_member() {
 // CHECK-NEXT:   cir.store align(4) %[[ZERO]], %[[A_ADDR]]
 // CHECK-NEXT:   cir.return
 
-// CHECK:      cir.func @_ZN15MemberInitStrukC1Ev(%arg0: !cir.ptr<!rec_MemberInitStruk>
+// CHECK:      cir.func{{.*}} @_ZN15MemberInitStrukC1Ev(%arg0: !cir.ptr<!rec_MemberInitStruk>
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   cir.store %arg0, %[[THIS_ADDR]]
 // CHECK-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]]
 // CHECK-NEXT:   cir.call @_ZN15MemberInitStrukC2Ev(%[[THIS]])
 // CHECK-NEXT:   cir.return
 
-// CHECK: cir.func @_Z11init_memberv
+// CHECK: cir.func{{.*}} @_Z11init_memberv
 // CHECK-NEXT:    %[[S_ADDR:.*]] = cir.alloca {{.*}} ["s", init]
 // CHECK-NEXT:    cir.call @_ZN15MemberInitStrukC1Ev(%[[S_ADDR]])
 // CHECK-NEXT:    cir.return
@@ -153,7 +153,7 @@ void init_param_member() {
   ParamMemberInitStruk s(0);
 }
 
-// CHECK:      cir.func @_ZN20ParamMemberInitStrukC2Ei(%arg0: !cir.ptr<!rec_ParamMemberInitStruk>
+// CHECK:      cir.func{{.*}} @_ZN20ParamMemberInitStrukC2Ei(%arg0: !cir.ptr<!rec_ParamMemberInitStruk>
 // CHECK-SAME:                                         %arg1: !s32i
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   %[[N_ADDR:.*]] = cir.alloca {{.*}} ["n", init]
@@ -165,7 +165,7 @@ void init_param_member() {
 // CHECK-NEXT:   cir.store{{.*}} %[[N]], %[[A_ADDR]]
 // CHECK-NEXT:   cir.return
 
-// CHECK:      cir.func @_ZN20ParamMemberInitStrukC1Ei(%arg0: !cir.ptr<!rec_ParamMemberInitStruk>
+// CHECK:      cir.func{{.*}} @_ZN20ParamMemberInitStrukC1Ei(%arg0: !cir.ptr<!rec_ParamMemberInitStruk>
 // CHECK-SAME:                                         %arg1: !s32i
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   %[[N_ADDR:.*]] = cir.alloca {{.*}} ["n", init]
@@ -176,7 +176,7 @@ void init_param_member() {
 // CHECK-NEXT:   cir.call @_ZN20ParamMemberInitStrukC2Ei(%[[THIS]], %[[N]])
 // CHECK-NEXT:   cir.return
 
-// CHECK: cir.func @_Z17init_param_memberv
+// CHECK: cir.func{{.*}} @_Z17init_param_memberv
 // CHECK-NEXT:    %[[S_ADDR:.*]] = cir.alloca {{.*}} ["s", init]
 // CHECK-NEXT:    %[[ZERO:.*]] = cir.const #cir.int<0>
 // CHECK-NEXT:    cir.call @_ZN20ParamMemberInitStrukC1Ei(%[[S_ADDR]], %[[ZERO]])
@@ -197,7 +197,7 @@ void init_union() {
   UnionInitStruk s;
 }
 
-// CHECK:      cir.func @_ZN14UnionInitStrukC2Ev(%arg0: !cir.ptr<!rec_UnionInitStruk>
+// CHECK:      cir.func{{.*}} @_ZN14UnionInitStrukC2Ev(%arg0: !cir.ptr<!rec_UnionInitStruk>
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   cir.store %arg0, %[[THIS_ADDR]]
 // CHECK-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]]
@@ -208,14 +208,14 @@ void init_union() {
 // CHECK-NEXT:   cir.store{{.*}} %[[ZERO]], %[[C_ADDR]]
 // CHECK-NEXT:   cir.return
 
-// CHECK:      cir.func @_ZN14UnionInitStrukC1Ev(%arg0: !cir.ptr<!rec_UnionInitStruk>
+// CHECK:      cir.func{{.*}} @_ZN14UnionInitStrukC1Ev(%arg0: !cir.ptr<!rec_UnionInitStruk>
 // CHECK-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca {{.*}} ["this", init]
 // CHECK-NEXT:   cir.store %arg0, %[[THIS_ADDR]]
 // CHECK-NEXT:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]]
 // CHECK-NEXT:   cir.call @_ZN14UnionInitStrukC2Ev
 // CHECK-NEXT:   cir.return
 
-// CHECK: cir.func @_Z10init_unionv
+// CHECK: cir.func{{.*}} @_Z10init_unionv
 // CHECK-NEXT:    %[[S_ADDR:.*]] = cir.alloca {{.*}} ["s", init]
 // CHECK-NEXT:    cir.call @_ZN14UnionInitStrukC1Ev(%[[S_ADDR]])
 // CHECK-NEXT:    cir.return

--- a/clang/test/CIR/CodeGen/dso-local.c
+++ b/clang/test/CIR/CodeGen/dso-local.c
@@ -3,7 +3,9 @@
 
 // These are here so we find this test when grepping for missing features.
 // cir::MissingFeatures::opGlobalThreadLocal()
-// cir::MissingFeatures::opFuncDsoLocal()
+
+// Note: Unlike CIR doesn't set dso_local on function declarations. This is
+//       a difference from classic codege in the STATIC checks.
 
 /// Static relocation model defaults to -fdirect-access-external-data and sets
 /// dso_local on most global objects.
@@ -13,6 +15,9 @@
 // STATIC-NEXT: @import_var = external dso_local global i32
 // STATIC-NEXT: @weak_bar = extern_weak dso_local global i32
 // STATIC-NEXT: @bar = external dso_local global i32
+// STATIC-DAG: declare void @foo()
+// STATIC-DAG: define dso_local ptr @zed()
+// STATIC-DAG: declare void @import_func()
 
 /// If -fno-direct-access-external-data is set, drop dso_local from global variable
 /// declarations.
@@ -21,30 +26,45 @@
 // STATIC-INDIRECT-NEXT: @import_var = external global i32
 // STATIC-INDIRECT-NEXT: @weak_bar = extern_weak global i32
 // STATIC-INDIRECT-NEXT: @bar = external global i32
+// STATIC-INDIRECT-DAG:  declare void @import_func()
+// STATIC-INDIRECT-DAG:  define dso_local ptr @zed()
+// STATIC-INDIRECT-DAG:  declare void @foo()
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -pic-level 1 -pic-is-pie %s -o - | FileCheck --check-prefix=PIE %s
 // PIE:      @baz = dso_local global i32 42
 // PIE-NEXT: @import_var = external global i32
 // PIE-NEXT: @weak_bar = extern_weak global i32
 // PIE-NEXT: @bar = external global i32
+// PIE-DAG: declare void @foo()
+// PIE-DAG: define dso_local ptr @zed()
+// PIE-DAG: declare void @import_func()
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -pic-level 1 -pic-is-pie -fdirect-access-external-data %s -o - | FileCheck --check-prefix=PIE-DIRECT %s
 // PIE-DIRECT:      @baz = dso_local global i32 42
 // PIE-DIRECT-NEXT: @import_var = external dso_local global i32
 // PIE-DIRECT-NEXT: @weak_bar = extern_weak global i32
 // PIE-DIRECT-NEXT: @bar = external dso_local global i32
+// PIE-DIRECT-DAG: declare void @foo()
+// PIE-DIRECT-DAG: define dso_local ptr @zed()
+// PIE-DIRECT-DAG: declare void @import_func()
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -mrelocation-model static -fno-plt %s -o - | FileCheck --check-prefix=NOPLT %s
 // NOPLT:      @baz = dso_local global i32 42
 // NOPLT-NEXT: @import_var = external dso_local global i32
 // NOPLT-NEXT: @weak_bar = extern_weak dso_local global i32
 // NOPLT-NEXT: @bar = external dso_local global i32
+// NOPLT-DAG: declare void @foo()
+// NOPLT-DAG: define dso_local ptr @zed()
+// NOPLT-DAG: declare void @import_func()
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -fno-plt -pic-level 1 -pic-is-pie -fdirect-access-external-data %s -o - | FileCheck --check-prefix=PIE-DIRECT-NOPLT %s
 // PIE-DIRECT-NOPLT:      @baz = dso_local global i32 42
 // PIE-DIRECT-NOPLT-NEXT: @import_var = external dso_local global i32
 // PIE-DIRECT-NOPLT-NEXT: @weak_bar = extern_weak global i32
 // PIE-DIRECT-NOPLT-NEXT: @bar = external dso_local global i32
+// PIE-DIRECT-NOPLT-DAG: declare void @foo()
+// PIE-DIRECT-NOPLT-DAG: define dso_local ptr @zed()
+// PIE-DIRECT-NOPLT-DAG: declare void @import_func()
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -pic-level 1 -pic-is-pie -fno-plt %s -o - | FileCheck --check-prefix=PIE-NO-PLT %s
 // RUN: %clang_cc1 -triple powerpc64le -fclangir -emit-llvm -mrelocation-model static %s -o - | FileCheck --check-prefix=PIE-NO-PLT %s
@@ -52,24 +72,34 @@
 // PIE-NO-PLT-NEXT: @import_var = external global i32
 // PIE-NO-PLT-NEXT: @weak_bar = extern_weak global i32
 // PIE-NO-PLT-NEXT: @bar = external global i32
+// PIE-NO-PLT-DAG:  declare void @import_func()
+// PIE-NO-PLT-DAG:  define dso_local ptr @zed()
+// PIE-NO-PLT-DAG:  declare void @foo()
 
 /// -fdirect-access-external-data is currently ignored for -fPIC.
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -pic-level 2 %s -o - | FileCheck --check-prefix=SHARED %s
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm -pic-level 2 -fdirect-access-external-data %s -o - | FileCheck --check-prefix=SHARED %s
 // SHARED-DAG: @bar = external global i32
 // SHARED-DAG: @weak_bar = extern_weak global i32
+// SHARED-DAG: declare void @foo()
 // SHARED-DAG: @baz ={{.*}} global i32 42
+// SHARED-DAG: define{{.*}} ptr @zed()
 
 int baz = 42;
 __attribute__((dllimport)) extern int import_var;
 __attribute__((weak)) extern int weak_bar;
 extern int bar;
+__attribute__((dllimport)) void import_func(void);
 
 int *use_import(void) {
+  import_func();
   return &import_var;
 }
 
+void foo(void);
+
 int *zed(void) {
+  foo();
   if (baz)
     return &weak_bar;
   return &bar;

--- a/clang/test/CIR/CodeGen/forrange.cpp
+++ b/clang/test/CIR/CodeGen/forrange.cpp
@@ -13,10 +13,10 @@ void for_range() {
     ;
 }
 
-// CIR: cir.func @_Z5beginR9Container(!cir.ptr<!rec_Container>) -> !cir.ptr<!rec_Element>
-// CIR: cir.func @_Z3endR9Container(!cir.ptr<!rec_Container>) -> !cir.ptr<!rec_Element
+// CIR: cir.func{{.*}} @_Z5beginR9Container(!cir.ptr<!rec_Container>) -> !cir.ptr<!rec_Element>
+// CIR: cir.func{{.*}} @_Z3endR9Container(!cir.ptr<!rec_Container>) -> !cir.ptr<!rec_Element
 
-// CIR: cir.func @_Z9for_rangev()
+// CIR: cir.func{{.*}} @_Z9for_rangev()
 // CIR:    %[[C_ADDR:.*]] = cir.alloca !rec_Container{{.*}} ["c"]
 // CIR:    cir.scope {
 // CIR:      %[[RANGE_ADDR:.*]] = cir.alloca !cir.ptr<!rec_Container>{{.*}} ["__range1", init, const]
@@ -59,7 +59,7 @@ void for_range2() {
     ;
 }
 
-// CIR: cir.func @_Z10for_range2v()
+// CIR: cir.func{{.*}} @_Z10for_range2v()
 // CIR:    %[[C_ADDR:.*]] = cir.alloca !rec_C2{{.*}} ["c"]
 // CIR:    cir.scope {
 // CIR:      %[[RANGE_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C2>{{.*}} ["__range1", init, const]
@@ -111,7 +111,7 @@ void for_range3() {
     ;
 }
 
-// CIR: cir.func @_Z10for_range3v()
+// CIR: cir.func{{.*}} @_Z10for_range3v()
 // CIR:    %[[C_ADDR:.*]] = cir.alloca !rec_C3{{.*}} ["c"]
 // CIR:    cir.scope {
 // CIR:      %[[RANGE_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C3>{{.*}} ["__range1", init, const]

--- a/clang/test/CIR/CodeGen/if.cpp
+++ b/clang/test/CIR/CodeGen/if.cpp
@@ -14,7 +14,7 @@ int if0(bool a) {
 
 }
 
-// CIR: cir.func @_Z3if0b(%arg0: !cir.bool loc({{.*}})) -> !s32i
+// CIR: cir.func{{.*}} @_Z3if0b(%arg0: !cir.bool loc({{.*}})) -> !s32i
 // CIR: cir.scope {
 // CIR:   %4 = cir.load{{.*}} %0 : !cir.ptr<!cir.bool>, !cir.bool
 // CIR-NEXT: cir.if %4 {
@@ -26,7 +26,7 @@ int if0(bool a) {
 // CIR-NEXT:  }
 
 
-// LLVM: define i32 @_Z3if0b(i1 %0)
+// LLVM: define{{.*}} i32 @_Z3if0b(i1 %0)
 // LLVM:   br label %[[ENTRY:.*]]
 // LLVM: [[ENTRY]]:
 // LLVM:   %6 = load i8, ptr %2, align 1
@@ -43,7 +43,7 @@ int if0(bool a) {
 // LLVM:   %12 = load i32, ptr %3, align 4
 // LLVM:   ret i32 %12
 
-// OGCG: define dso_local noundef i32 @_Z3if0b(i1 noundef zeroext %a)
+// OGCG: define{{.*}} i32 @_Z3if0b(i1 noundef zeroext %a)
 // OGCG: entry:
 // OGCG:   %[[RETVAL:.*]] = alloca i32, align 4
 // OGCG:   %[[A_ADDR:.*]] = alloca i8, align 1
@@ -71,7 +71,7 @@ void if1(int a) {
   }
 }
 
-// CIR: cir.func @_Z3if1i(%arg0: !s32i loc({{.*}}))
+// CIR: cir.func{{.*}} @_Z3if1i(%arg0: !s32i loc({{.*}}))
 // CIR: cir.scope {
 // CIR:   %3 = cir.load{{.*}} %0 : !cir.ptr<!s32i>, !s32i
 // CIR:   %4 = cir.cast(int_to_bool, %3 : !s32i), !cir.bool
@@ -84,7 +84,7 @@ void if1(int a) {
 // CIR-NEXT:   }
 // CIR: }
 
-// LLVM: define void @_Z3if1i(i32 %0)
+// LLVM: define{{.*}} void @_Z3if1i(i32 %0)
 // LLVM: %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM: store i32 %0, ptr %[[A]], align 4
@@ -105,7 +105,7 @@ void if1(int a) {
 // LLVM: [[EXIT]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3if1i(i32 noundef %[[A:.*]])
+// OGCG: define{{.*}} void @_Z3if1i(i32 noundef %[[A:.*]])
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[X:.*]] = alloca i32, align 4
@@ -138,7 +138,7 @@ void if2(int a, bool b, bool c) {
   }
 }
 
-// CIR: cir.func @_Z3if2ibb(%arg0: !s32i loc({{.*}}), %arg1: !cir.bool loc({{.*}}), %arg2: !cir.bool loc({{.*}}))
+// CIR: cir.func{{.*}} @_Z3if2ibb(%arg0: !s32i loc({{.*}}), %arg1: !cir.bool loc({{.*}}), %arg2: !cir.bool loc({{.*}}))
 // CIR: cir.scope {
 // CIR:   %5 = cir.load{{.*}} %0 : !cir.ptr<!s32i>, !s32i
 // CIR:   %6 = cir.cast(int_to_bool, %5 : !s32i), !cir.bool
@@ -165,7 +165,7 @@ void if2(int a, bool b, bool c) {
 // CIR:   }
 // CIR: }
 
-// LLVM: define void @_Z3if2ibb(i32 %[[A:.*]], i1 %[[B:.*]], i1 %[[C:.*]])
+// LLVM: define{{.*}} void @_Z3if2ibb(i32 %[[A:.*]], i1 %[[B:.*]], i1 %[[C:.*]])
 // LLVM:   %[[VARA:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[VARB:.*]] = alloca i8, i64 1, align 1
 // LLVM:   %[[VARC:.*]] = alloca i8, i64 1, align 1
@@ -214,7 +214,7 @@ void if2(int a, bool b, bool c) {
 // LLVM: [[LABEL28]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3if2ibb(i32 noundef %[[A:.*]], i1 noundef zeroext %[[B:.*]], i1 noundef zeroext %[[C:.*]])
+// OGCG: define{{.*}} void @_Z3if2ibb(i32 noundef %[[A:.*]], i1 noundef zeroext %[[B:.*]], i1 noundef zeroext %[[C:.*]])
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[B_ADDR:.*]] = alloca i8, align 1
@@ -260,7 +260,7 @@ int if_init() {
   }
 }
 
-// CIR: cir.func @_Z7if_initv() -> !s32i
+// CIR: cir.func{{.*}} @_Z7if_initv() -> !s32i
 // CIR: %[[RETVAL:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>
 // CIR: cir.scope {
 // CIR:   %[[X:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>,
@@ -285,7 +285,7 @@ int if_init() {
 // CIR:   }
 // CIR: }
 
-// LLVM: define i32 @_Z7if_initv()
+// LLVM: define{{.*}} i32 @_Z7if_initv()
 // LLVM: %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM: %[[RETVAL:.*]] = alloca i32, i64 1, align 4
 // LLVM: store i32 42, ptr %[[X]], align 4
@@ -305,7 +305,7 @@ int if_init() {
 // LLVM:   %[[RETVAL_LOAD2:.*]] = load i32, ptr %[[RETVAL]], align 4
 // LLVM:   ret i32 %[[RETVAL_LOAD2]]
 
-// OGCG: define dso_local noundef i32 @_Z7if_initv()
+// OGCG: define{{.*}} i32 @_Z7if_initv()
 // OGCG: entry:
 // OGCG:   %[[RETVAL:.*]] = alloca i32, align 4
 // OGCG:   %[[X:.*]] = alloca i32, align 4

--- a/clang/test/CIR/CodeGen/inline-cxx-func.cpp
+++ b/clang/test/CIR/CodeGen/inline-cxx-func.cpp
@@ -17,7 +17,7 @@ struct S {
 // LLVM: %struct.S = type { i32 }
 // OGCG: %struct.S = type { i32 }
 
-// CIR: cir.func @_ZN1S10InlineFuncEv(%arg0: !cir.ptr<!rec_S> {{.*}}) -> !s32i
+// CIR: cir.func{{.*}} @_ZN1S10InlineFuncEv(%arg0: !cir.ptr<!rec_S> {{.*}}) -> !s32i
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["this", init]
 // CIR:   %[[RET_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"]
 // CIR:   cir.store %arg0, %[[THIS_ADDR]] : !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>
@@ -46,7 +46,7 @@ void use() {
   s.InlineFunc();
 }
 
-// CIR: cir.func @_Z3usev()
+// CIR: cir.func{{.*}} @_Z3usev()
 // CIR:   %[[S_ADDR:.*]] = cir.alloca !rec_S, !cir.ptr<!rec_S>, ["s"]
 // CIR:   %[[RET_VAL:.*]] = cir.call @_ZN1S10InlineFuncEv(%[[S_ADDR]]) : (!cir.ptr<!rec_S>) -> !s32i
 // CIR:   cir.return

--- a/clang/test/CIR/CodeGen/int-to-bool.cpp
+++ b/clang/test/CIR/CodeGen/int-to-bool.cpp
@@ -9,14 +9,14 @@ bool f1(unsigned char c) {
   return c;
 }
 
-// CIR: cir.func @_Z2f1h
+// CIR: cir.func{{.*}} @_Z2f1h
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !u8i), !cir.bool
 
 // Note: The full zext/store/load/trunc sequence is checked here to show what
 // CIR is being lowered to. There's no need to check it for every function since
 // the lowering is the same for all of them.
 
-// LLVM: define i1 @_Z2f1h
+// LLVM: define{{.*}} i1 @_Z2f1h
 // LLVM:   %[[CMP:.*]] = icmp ne i8 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 // LLVM:   store i8 %[[ZEXT]], ptr %{{.*}}
@@ -32,10 +32,10 @@ bool f2(short s) {
   return s;
 }
 
-// CIR: cir.func @_Z2f2s
+// CIR: cir.func{{.*}} @_Z2f2s
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !s16i), !cir.bool
 
-// LLVM: define i1 @_Z2f2s
+// LLVM: define{{.*}} i1 @_Z2f2s
 // LLVM:   %[[CMP:.*]] = icmp ne i16 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 
@@ -47,10 +47,10 @@ bool f3(unsigned u) {
   return u;
 }
 
-// CIR: cir.func @_Z2f3j
+// CIR: cir.func{{.*}} @_Z2f3j
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !u32i), !cir.bool
 
-// LLVM: define i1 @_Z2f3j
+// LLVM: define{{.*}} i1 @_Z2f3j
 // LLVM:   %[[CMP:.*]] = icmp ne i32 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 
@@ -62,10 +62,10 @@ bool f4(long l) {
   return l;
 }
 
-// CIR: cir.func @_Z2f4l
+// CIR: cir.func{{.*}} @_Z2f4l
 // CIR:   cir.cast(int_to_bool, %{{.*}} : !s64i), !cir.bool
 
-// LLVM: define i1 @_Z2f4l
+// LLVM: define{{.*}} i1 @_Z2f4l
 // LLVM:   %[[CMP:.*]] = icmp ne i64 %4, 0
 // LLVM:   %[[ZEXT:.*]] = zext i1 %[[CMP]] to i8
 

--- a/clang/test/CIR/CodeGen/linkage-spec.cpp
+++ b/clang/test/CIR/CodeGen/linkage-spec.cpp
@@ -1,42 +1,42 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o - 2>&1 | FileCheck %s
 
 extern "C" void TopLevelC(){}
-// CHECK: cir.func @TopLevelC() {
+// CHECK: cir.func{{.*}} @TopLevelC() {
 extern "C++" void TopLevelCpp(){}
-// CHECK: cir.func @_Z11TopLevelCppv() {
+// CHECK: cir.func{{.*}} @_Z11TopLevelCppv() {
 
 extern "C++" {
   void ExternCppEmpty(){}
-  // CHECK: cir.func @_Z14ExternCppEmptyv() {
+  // CHECK: cir.func{{.*}} @_Z14ExternCppEmptyv() {
   extern "C" void ExternCpp_C(){}
-  // CHECK: cir.func @ExternCpp_C() {
+  // CHECK: cir.func{{.*}} @ExternCpp_C() {
   extern "C++" void ExternCpp_Cpp(){}
-  // CHECK: cir.func @_Z13ExternCpp_Cppv() {
+  // CHECK: cir.func{{.*}} @_Z13ExternCpp_Cppv() {
 
   extern "C" {
   void ExternCpp_CEmpty(){}
-  // CHECK: cir.func @ExternCpp_CEmpty() {
+  // CHECK: cir.func{{.*}} @ExternCpp_CEmpty() {
   extern "C" void ExternCpp_C_C(){}
-  // CHECK: cir.func @ExternCpp_C_C() {
+  // CHECK: cir.func{{.*}} @ExternCpp_C_C() {
   extern "C++" void ExternCpp_C_Cpp(){}
-  // CHECK: cir.func @_Z15ExternCpp_C_Cppv() {
+  // CHECK: cir.func{{.*}} @_Z15ExternCpp_C_Cppv() {
   }
 }
 
 extern "C" {
   void ExternCEmpty(){}
-  // CHECK: cir.func @ExternCEmpty() {
+  // CHECK: cir.func{{.*}} @ExternCEmpty() {
   extern "C" void ExternC_C(){}
-  // CHECK: cir.func @ExternC_C() {
+  // CHECK: cir.func{{.*}} @ExternC_C() {
   extern "C++" void ExternC_Cpp(){}
-  // CHECK: cir.func @_Z11ExternC_Cppv() {
+  // CHECK: cir.func{{.*}} @_Z11ExternC_Cppv() {
   extern "C++" {
   void ExternC_CppEmpty(){}
-  // CHECK: cir.func @_Z16ExternC_CppEmptyv() {
+  // CHECK: cir.func{{.*}} @_Z16ExternC_CppEmptyv() {
   extern "C" void ExternC_Cpp_C(){}
-  // CHECK: cir.func @ExternC_Cpp_C() {
+  // CHECK: cir.func{{.*}} @ExternC_Cpp_C() {
   extern "C++" void ExternC_Cpp_Cpp(){}
-  // CHECK: cir.func @_Z15ExternC_Cpp_Cppv() {
+  // CHECK: cir.func{{.*}} @_Z15ExternC_Cpp_Cppv() {
   }
 }
 

--- a/clang/test/CIR/CodeGen/local-vars.cpp
+++ b/clang/test/CIR/CodeGen/local-vars.cpp
@@ -22,7 +22,7 @@ void test() {
 }
 
 // CHECK: module
-// CHECK: cir.func @_Z4testv()
+// CHECK: cir.func{{.*}} @_Z4testv()
 // CHECK:    %[[I_PTR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CHECK:    %[[L_PTR:.*]] = cir.alloca !s64i, !cir.ptr<!s64i>, ["l", init] {alignment = 8 : i64}
 // CHECK:    %[[F_PTR:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/loop.cpp
+++ b/clang/test/CIR/CodeGen/loop.cpp
@@ -10,7 +10,7 @@ void l0() {
   }
 }
 
-// CIR: cir.func @_Z2l0v
+// CIR: cir.func{{.*}} @_Z2l0v
 // CIR:   cir.scope {
 // CIR:     cir.for : cond {
 // CIR:       %[[TRUE:.*]] = cir.const #true
@@ -24,7 +24,7 @@ void l0() {
 // CIR:   cir.return
 // CIR: }
 
-// LLVM: define void @_Z2l0v()
+// LLVM: define{{.*}} void @_Z2l0v()
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -50,7 +50,7 @@ void l1() {
   }
 }
 
-// CIR:      cir.func @_Z2l1v
+// CIR:      cir.func{{.*}} @_Z2l1v
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CIR-NEXT:     %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
@@ -67,7 +67,7 @@ void l1() {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @_Z2l1v()
+// LLVM: define{{.*}} void @_Z2l1v()
 // LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -98,7 +98,7 @@ void l2() {
   }
 }
 
-// CIR:      cir.func @_Z2l2v
+// CIR:      cir.func{{.*}} @_Z2l2v
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     cir.for : cond {
 // CIR-NEXT:       %[[TRUE:.*]] = cir.const #true
@@ -117,7 +117,7 @@ void l2() {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @_Z2l2v()
+// LLVM: define{{.*}} void @_Z2l2v()
 // LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -148,7 +148,7 @@ void l3() {
     int i = 0;
 }
 
-// CIR:      cir.func @_Z2l3v
+// CIR:      cir.func{{.*}} @_Z2l3v
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
 // CIR-NEXT:     cir.for : cond {
@@ -165,7 +165,7 @@ void l3() {
 // CIR-NEXT:   cir.return
 // CIR-NEXT: }
 
-// LLVM: define void @_Z2l3v()
+// LLVM: define{{.*}} void @_Z2l3v()
 // LLVM:   %[[I:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -196,7 +196,7 @@ void l4() {
     ;
 }
 
-// CIR: cir.func @_Z2l4v
+// CIR: cir.func{{.*}} @_Z2l4v
 // CIR:   %[[A_ADDR:.*]] = cir.alloca {{.*}} ["a"]
 // CIR:   cir.scope {
 // CIR:     %[[RANGE_ADDR:.*]] = cir.alloca {{.*}} ["__range1", init, const]
@@ -231,7 +231,7 @@ void l4() {
 // CIR:     }
 // CIR:   }
 
-// LLVM: define void @_Z2l4v() {
+// LLVM: define{{.*}} void @_Z2l4v() {
 // LLVM:   %[[RANGE_ADDR:.*]] = alloca ptr
 // LLVM:   %[[BEGIN_ADDR:.*]] = alloca ptr
 // LLVM:   %[[END_ADDR:.*]] = alloca ptr
@@ -305,7 +305,7 @@ void l5() {
   for (int arr[]{1,2,3,4}; auto x : arr) {} 
 }
 
-// CIR: cir.func @_Z2l5v
+// CIR: cir.func{{.*}} @_Z2l5v
 // CIR:   cir.scope {
 // CIR:     %[[ARR_ADDR:.*]] = cir.alloca {{.*}} ["arr", init]
 // CIR:     %[[RANGE_ADDR:.*]] = cir.alloca {{.*}} ["__range1", init, const]
@@ -355,7 +355,7 @@ void l5() {
 // CIR:     }
 // CIR:   }
 
-// LLVM: define void @_Z2l5v() {
+// LLVM: define{{.*}} void @_Z2l5v() {
 // LLVM:   %[[ARR_ADDR:.*]] = alloca [4 x i32]
 // LLVM:   %[[RANGE_ADDR:.*]] = alloca ptr
 // LLVM:   %[[BEGIN_ADDR:.*]] = alloca ptr
@@ -439,7 +439,7 @@ void test_do_while_false() {
   } while (0);
 }
 
-// CIR: cir.func @_Z19test_do_while_falsev()
+// CIR: cir.func{{.*}} @_Z19test_do_while_falsev()
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     cir.do {
 // CIR-NEXT:       cir.yield
@@ -448,7 +448,7 @@ void test_do_while_false() {
 // CIR-NEXT:       %[[FALSE:.*]] = cir.cast(int_to_bool, %[[ZERO]] : !s32i), !cir.bool
 // CIR-NEXT:       cir.condition(%[[FALSE]])
 
-// LLVM: define void @_Z19test_do_while_falsev()
+// LLVM: define{{.*}} void @_Z19test_do_while_falsev()
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL3:.*]]
@@ -475,7 +475,7 @@ void test_empty_while_true() {
   }
 }
 
-// CIR: cir.func @_Z21test_empty_while_truev()
+// CIR: cir.func{{.*}} @_Z21test_empty_while_truev()
 // CIR-NEXT:   cir.scope {
 // CIR-NEXT:     cir.while {
 // CIR-NEXT:       %[[TRUE:.*]] = cir.const #true
@@ -486,7 +486,7 @@ void test_empty_while_true() {
 // CIR-NEXT:       }
 // CIR-NEXT:       cir.yield
 
-// LLVM: define void @_Z21test_empty_while_truev()
+// LLVM: define{{.*}} void @_Z21test_empty_while_truev()
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
 // LLVM:   br label %[[LABEL2:.*]]
@@ -517,7 +517,7 @@ void unreachable_after_continue() {
   }
 }
 
-// CIR: cir.func @_Z26unreachable_after_continuev()
+// CIR: cir.func{{.*}} @_Z26unreachable_after_continuev()
 // CIR:   cir.scope {
 // CIR:     cir.for : cond {
 // CIR:       %[[TRUE:.*]] = cir.const #true
@@ -539,7 +539,7 @@ void unreachable_after_continue() {
 // CIR:   cir.return
 // CIR: }
 
-// LLVM: define void @_Z26unreachable_after_continuev()
+// LLVM: define{{.*}} void @_Z26unreachable_after_continuev()
 // LLVM:   %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:
@@ -577,7 +577,7 @@ void unreachable_after_break() {
   }
 }
 
-// CIR: cir.func @_Z23unreachable_after_breakv()
+// CIR: cir.func{{.*}} @_Z23unreachable_after_breakv()
 // CIR:   cir.scope {
 // CIR:     cir.for : cond {
 // CIR:       %[[TRUE:.*]] = cir.const #true
@@ -599,7 +599,7 @@ void unreachable_after_break() {
 // CIR:   cir.return
 // CIR: }
 
-// LLVM: define void @_Z23unreachable_after_breakv()
+// LLVM: define{{.*}} void @_Z23unreachable_after_breakv()
 // LLVM:   %[[X:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[LABEL1:.*]]
 // LLVM: [[LABEL1]]:

--- a/clang/test/CIR/CodeGen/member-functions.cpp
+++ b/clang/test/CIR/CodeGen/member-functions.cpp
@@ -10,7 +10,7 @@ struct C {
 
 void C::f() {}
 
-// CIR: cir.func @_ZN1C1fEv(%[[THIS_ARG:.*]]: !cir.ptr<!rec_C>
+// CIR: cir.func{{.*}} @_ZN1C1fEv(%[[THIS_ARG:.*]]: !cir.ptr<!rec_C>
 // CIR:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>, ["this", init]
 // CIR:   cir.store %[[THIS_ARG]], %[[THIS_ADDR]] : !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>
 // CIR:   %[[THIS:.*]] = cir.load %[[THIS_ADDR]] : !cir.ptr<!cir.ptr<!rec_C>>, !cir.ptr<!rec_C>
@@ -19,7 +19,7 @@ void C::f() {}
 
 void C::f2(int a, int b) {}
 
-// CIR:      cir.func @_ZN1C2f2Eii(%[[THIS_ARG:.*]]: !cir.ptr<!rec_C> {{.*}}, %[[A_ARG:.*]]: !s32i {{.*}}, %[[B_ARG:.*]]: !s32i {{.*}}) {
+// CIR:      cir.func{{.*}} @_ZN1C2f2Eii(%[[THIS_ARG:.*]]: !cir.ptr<!rec_C> {{.*}}, %[[A_ARG:.*]]: !s32i {{.*}}, %[[B_ARG:.*]]: !s32i {{.*}}) {
 // CIR-NEXT:   %[[THIS_ADDR:.*]] = cir.alloca !cir.ptr<!rec_C>, !cir.ptr<!cir.ptr<!rec_C>>, ["this", init]
 // CIR-NEXT:   %[[A_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CIR-NEXT:   %[[B_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
@@ -36,7 +36,7 @@ void test1() {
   c.f2(1, 2);
 }
 
-// CIR: cir.func @_Z5test1v() {
+// CIR: cir.func{{.*}} @_Z5test1v() {
 // CIR-NEXT:   %[[C_ADDR:.*]] = cir.alloca !rec_C, !cir.ptr<!rec_C>, ["c"]
 // CIR-NEXT:   cir.call @_ZN1C1fEv(%[[C_ADDR]]) : (!cir.ptr<!rec_C>) -> ()
 // CIR-NEXT:   %[[ONE:.*]] = cir.const #cir.int<1> : !s32i

--- a/clang/test/CIR/CodeGen/namespace.cpp
+++ b/clang/test/CIR/CodeGen/namespace.cpp
@@ -23,9 +23,9 @@ namespace test {
 // CHECK-DAG: cir.global "private" internal dso_local @_ZN12_GLOBAL__N_12g1E = #cir.int<1> : !s32i
 // CHECK-DAG: cir.global external @_ZN4test2g2E = #cir.int<2> : !s32i
 // CHECK-DAG: cir.global external @_ZN4test5test22g3E = #cir.int<3> : !s32i
-// CHECK-DAG: cir.func @_ZN12_GLOBAL__N_12f1Ev()
-// CHECK-DAG: cir.func @_ZN4test2f2Ev()
-// CHECK-DAG: cir.func @_ZN4test5test22f3Ev()
+// CHECK-DAG: cir.func{{.*}} @_ZN12_GLOBAL__N_12f1Ev()
+// CHECK-DAG: cir.func{{.*}} @_ZN4test2f2Ev()
+// CHECK-DAG: cir.func{{.*}} @_ZN4test5test22f3Ev()
 
 using namespace test;
 
@@ -38,7 +38,7 @@ int f4(void) {
 }
 
 // The namespace gets added during name mangling, so this is wrong but expected.
-// CHECK: cir.func @_Z2f4v()
+// CHECK: cir.func{{.*}} @_Z2f4v()
 // CHECK:   cir.call @_ZN12_GLOBAL__N_12f1Ev()
 // CHECK:   cir.call @_ZN4test2f2Ev()
 // CHECK:   cir.call @_ZN4test5test22f3Ev()
@@ -59,7 +59,7 @@ int f5() {
   return g3;
 }
 
-// CHECK: cir.func @_Z2f5v()
+// CHECK: cir.func{{.*}} @_Z2f5v()
 // CHECK:   cir.call @_ZN4test5test22f3Ev()
 // CHECK:   %[[G3_ADDR:.*]] = cir.get_global @_ZN4test5test22g3E : !cir.ptr<!s32i>
 // CHECK:   %[[G3_VAL:.*]] = cir.load{{.*}} %[[G3_ADDR]] : !cir.ptr<!s32i>, !s32i
@@ -76,7 +76,7 @@ int f6() {
   return s.a;
 }
 
-// CHECK: cir.func @_Z2f6v()
+// CHECK: cir.func{{.*}} @_Z2f6v()
 // CHECK:   cir.get_global @_ZN5test31sE : !cir.ptr<!rec_test33A3AS>
 // CHECK:   cir.get_member %{{.*}}[0] {name = "a"}
 
@@ -92,4 +92,4 @@ void f7() {
   shadow::shadowedFunc();
 }
 
-// CHECK: cir.func @_Z2f7v()
+// CHECK: cir.func{{.*}} @_Z2f7v()

--- a/clang/test/CIR/CodeGen/nullptr-init.cpp
+++ b/clang/test/CIR/CodeGen/nullptr-init.cpp
@@ -11,7 +11,7 @@ void t1() {
   int *p3 = (int*)0;
 }
 
-// CIR:      cir.func @_Z2t1v()
+// CIR:      cir.func{{.*}} @_Z2t1v()
 // CIR-NEXT:     %[[P1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p1", init] {alignment = 8 : i64}
 // CIR-NEXT:     %[[P2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p2", init] {alignment = 8 : i64}
 // CIR-NEXT:     %[[P3:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p3", init] {alignment = 8 : i64}

--- a/clang/test/CIR/CodeGen/string-literals.c
+++ b/clang/test/CIR/CodeGen/string-literals.c
@@ -33,10 +33,10 @@ char *f1() {
   return "1";
 }
 
-// CIR: cir.func @f1()
+// CIR: cir.func{{.*}} @f1()
 // CIR:   %[[STR:.*]] = cir.get_global @[[STR1_GLOBAL]] : !cir.ptr<!cir.array<!s8i x 2>>
 
-// LLVM: define ptr @f1()
+// LLVM: define{{.*}} ptr @f1()
 // LLVM:   store ptr @[[STR1_GLOBAL]], ptr {{.*}}
 
 // OGCG: define {{.*}}ptr @f1()
@@ -46,24 +46,24 @@ char *f2() {
   return "";
 }
 
-// CIR: cir.func @f2()
+// CIR: cir.func{{.*}} @f2()
 // CIR:   %[[STR2:.*]] = cir.get_global @[[STR2_GLOBAL]] : !cir.ptr<!cir.array<!s8i x 1>>
 
-// LLVM: define ptr @f2()
+// LLVM: define{{.*}} ptr @f2()
 // LLVM:   store ptr @[[STR2_GLOBAL]], ptr {{.*}}
 
-// OGCG: define {{.*}}ptr @f2()
+// OGCG: define{{.*}} ptr @f2()
 // OGCG:   ret ptr @[[STR2_GLOBAL]]
 
 char *f3() {
   return "\00";
 }
 
-// CIR: cir.func @f3()
+// CIR: cir.func{{.*}} @f3()
 // CIR:   %[[STR3:.*]] = cir.get_global @[[STR3_GLOBAL]] : !cir.ptr<!cir.array<!s8i x 2>>
 
-// LLVM: define ptr @f3()
+// LLVM: define{{.*}} ptr @f3()
 // LLVM:   store ptr @[[STR3_GLOBAL]], ptr {{.*}}
 
-// OGCG: define {{.*}}ptr @f3()
+// OGCG: define{{.*}} ptr @f3()
 // OGCG:   ret ptr @[[STR3_GLOBAL]]

--- a/clang/test/CIR/CodeGen/struct.c
+++ b/clang/test/CIR/CodeGen/struct.c
@@ -166,11 +166,11 @@ void f(void) {
   struct IncompleteS *p;
 }
 
-// CIR:      cir.func @f()
+// CIR:      cir.func{{.*}} @f()
 // CIR-NEXT:   cir.alloca !cir.ptr<!rec_IncompleteS>, !cir.ptr<!cir.ptr<!rec_IncompleteS>>, ["p"] {alignment = 8 : i64}
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @f()
+// LLVM:      define{{.*}} void @f()
 // LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:   ret void
 
@@ -183,11 +183,11 @@ void f2(void) {
   struct CompleteS s;
 }
 
-// CIR:      cir.func @f2()
+// CIR:      cir.func{{.*}} @f2()
 // CIR-NEXT:   cir.alloca !rec_CompleteS, !cir.ptr<!rec_CompleteS>, ["s"] {alignment = 4 : i64}
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @f2()
+// LLVM:      define{{.*}} void @f2()
 // LLVM-NEXT:   %[[S:.*]] = alloca %struct.CompleteS, i64 1, align 4
 // LLVM-NEXT:   ret void
 
@@ -201,7 +201,7 @@ char f3(int a) {
   return cs.b;
 }
 
-// CIR:      cir.func @f3(%[[ARG_A:.*]]: !s32i
+// CIR:      cir.func{{.*}} @f3(%[[ARG_A:.*]]: !s32i
 // CIR-NEXT:   %[[A_ADDR:.*]] = cir.alloca {{.*}} ["a", init] {alignment = 4 : i64}
 // CIR-NEXT:   %[[RETVAL_ADDR:.*]] = cir.alloca {{.*}} ["__retval"] {alignment = 1 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG_A]], %[[A_ADDR]]
@@ -216,7 +216,7 @@ char f3(int a) {
 // CIR-NEXT:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RETVAL_ADDR]]
 // CIR-NEXT:   cir.return %[[RETVAL]]
 
-// LLVM:      define i8 @f3(i32 %[[ARG_A:.*]])
+// LLVM:      define{{.*}} i8 @f3(i32 %[[ARG_A:.*]])
 // LLVM-NEXT:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   %[[RETVAL_ADDR:.*]] = alloca i8, i64 1, align 1
 // LLVM-NEXT:   store i32 %[[ARG_A]], ptr %[[A_ADDR]], align 4
@@ -241,7 +241,7 @@ char f4(int a, struct CompleteS *p) {
   return p->b;
 }
 
-// CIR:      cir.func @f4(%[[ARG_A:.*]]: !s32i {{.*}}, %[[ARG_P:.*]]: !cir.ptr<!rec_CompleteS>
+// CIR:      cir.func{{.*}} @f4(%[[ARG_A:.*]]: !s32i {{.*}}, %[[ARG_P:.*]]: !cir.ptr<!rec_CompleteS>
 // CIR-NEXT:   %[[A_ADDR:.*]] = cir.alloca {{.*}} ["a", init] {alignment = 4 : i64}
 // CIR-NEXT:   %[[P_ADDR:.*]] = cir.alloca {{.*}} ["p", init] {alignment = 8 : i64}
 // CIR-NEXT:   %[[RETVAL_ADDR:.*]] = cir.alloca {{.*}} ["__retval"] {alignment = 1 : i64}
@@ -258,7 +258,7 @@ char f4(int a, struct CompleteS *p) {
 // CIR-NEXT:   %[[RETVAL:.*]] = cir.load{{.*}} %[[RETVAL_ADDR]]
 // CIR-NEXT:   cir.return %[[RETVAL]]
 
-// LLVM:      define i8 @f4(i32 %[[ARG_A:.*]], ptr %[[ARG_P:.*]])
+// LLVM:      define{{.*}} i8 @f4(i32 %[[ARG_A:.*]], ptr %[[ARG_P:.*]])
 // LLVM-NEXT:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   %[[P_ADDR:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:   %[[RETVAL_ADDR:.*]] = alloca i8, i64 1, align 1
@@ -294,7 +294,7 @@ void f5(struct NodeS* a) {
   a->next = 0;
 }
 
-// CIR: cir.func @f5
+// CIR: cir.func{{.*}} @f5
 // CIR:   %[[NEXT:.*]] = cir.get_member {{%.}}[0] {name = "next"} : !cir.ptr<!rec_NodeS> -> !cir.ptr<!cir.ptr<!rec_NodeS>>
 // CIR:   cir.store {{.*}}, %[[NEXT]]
 
@@ -312,7 +312,7 @@ void f6(struct CycleStart *start) {
   struct CycleStart *start2 = end->start;
 }
 
-// CIR: cir.func @f6
+// CIR: cir.func{{.*}} @f6
 // CIR:   %[[MIDDLE:.*]] = cir.get_member {{.*}}[0] {name = "middle"} : !cir.ptr<!rec_CycleStart> -> !cir.ptr<!cir.ptr<!rec_CycleMiddle>>
 // CIR:   %[[END:.*]] = cir.get_member %{{.*}}[0] {name = "end"} : !cir.ptr<!rec_CycleMiddle> -> !cir.ptr<!cir.ptr<!rec_CycleEnd>>
 // CIR:   %[[START2:.*]] = cir.get_member %{{.*}}[0] {name = "start"} : !cir.ptr<!rec_CycleEnd> -> !cir.ptr<!cir.ptr<!rec_CycleStart>>

--- a/clang/test/CIR/CodeGen/struct.cpp
+++ b/clang/test/CIR/CodeGen/struct.cpp
@@ -27,11 +27,11 @@ void f(void) {
   IncompleteS *p;
 }
 
-// CIR:      cir.func @_Z1fv()
+// CIR:      cir.func{{.*}} @_Z1fv()
 // CIR-NEXT:   cir.alloca !cir.ptr<!rec_IncompleteS>, !cir.ptr<!cir.ptr<!rec_IncompleteS>>, ["p"]
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @_Z1fv()
+// LLVM:      define{{.*}} void @_Z1fv()
 // LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:   ret void
 
@@ -44,14 +44,14 @@ char f2(CompleteS &s) {
   return s.b;
 }
 
-// CIR: cir.func @_Z2f2R9CompleteS(%[[ARG_S:.*]]: !cir.ptr<!rec_CompleteS>{{.*}})
+// CIR: cir.func{{.*}} @_Z2f2R9CompleteS(%[[ARG_S:.*]]: !cir.ptr<!rec_CompleteS>{{.*}})
 // CIR:   %[[S_ADDR:.*]] = cir.alloca !cir.ptr<!rec_CompleteS>, !cir.ptr<!cir.ptr<!rec_CompleteS>>, ["s", init, const]
 // CIR:   cir.store %[[ARG_S]], %[[S_ADDR]]
 // CIR:   %[[S_REF:.*]] = cir.load{{.*}} %[[S_ADDR]]
 // CIR:   %[[S_ADDR2:.*]] = cir.get_member %[[S_REF]][1] {name = "b"}
 // CIR:   %[[S_B:.*]] = cir.load{{.*}} %[[S_ADDR2]]
 
-// LLVM: define i8 @_Z2f2R9CompleteS(ptr %[[ARG_S:.*]])
+// LLVM: define{{.*}} i8 @_Z2f2R9CompleteS(ptr %[[ARG_S:.*]])
 // LLVM:   %[[S_ADDR:.*]] = alloca ptr
 // LLVM:   store ptr %[[ARG_S]], ptr %[[S_ADDR]]
 // LLVM:   %[[S_REF:.*]] = load ptr, ptr %[[S_ADDR]], align 8
@@ -79,7 +79,7 @@ void f3() {
   o.i.n;
 }
 
-// CIR: cir.func @_Z2f3v()
+// CIR: cir.func{{.*}} @_Z2f3v()
 // CIR:   %[[O:.*]] = cir.alloca !rec_Outer, !cir.ptr<!rec_Outer>, ["o"]
 // CIR:   %[[O_I:.*]] = cir.get_member %[[O]][0] {name = "i"}
 // CIR:   %[[O_I_N:.*]] = cir.get_member %[[O_I]][0] {name = "n"}

--- a/clang/test/CIR/CodeGen/switch.cpp
+++ b/clang/test/CIR/CodeGen/switch.cpp
@@ -19,7 +19,7 @@ void sw1(int a) {
   }
 }
 
-// CIR: cir.func @_Z3sw1i
+// CIR: cir.func{{.*}} @_Z3sw1i
 // CIR: cir.switch (%[[COND:.*]] : !s32i) {
 // CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR: cir.break
@@ -30,7 +30,7 @@ void sw1(int a) {
 // CIR: cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
 // CIR: cir.break
 
-// LLVM: define void @_Z3sw1i
+// LLVM: define{{.*}} void @_Z3sw1i
 // LLVM:   store i32 1, ptr %[[B_ADDR:.*]], align 4
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   br label %[[BB7:.*]]
@@ -60,7 +60,7 @@ void sw1(int a) {
 // LLVM: [[DEFAULT]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw1i
+// OGCG: define{{.*}} void @_Z3sw1i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[B:.*]] = alloca i32, align 4
@@ -97,7 +97,7 @@ void sw2(int a) {
   }
 }
 
-// CIR: cir.func @_Z3sw2i
+// CIR: cir.func{{.*}} @_Z3sw2i
 // CIR: cir.scope {
 // CIR-NEXT:   %[[YOLO:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["yolo", init]
 // CIR-NEXT:   %[[FOMO:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["fomo", init]
@@ -106,7 +106,7 @@ void sw2(int a) {
 // CIR-NEXT:     %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
 // CIR-NEXT:     cir.store{{.*}} %[[ZERO]], %[[FOMO]] : !s32i, !cir.ptr<!s32i>
 
-// LLVM: define void @_Z3sw2i
+// LLVM: define{{.*}} void @_Z3sw2i
 // LLVM:   store i32 2, ptr %[[YOLO_ADDR:.*]], align 4
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   br label %[[SWITCH:.*]]
@@ -126,7 +126,7 @@ void sw2(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw2i
+// OGCG: define{{.*}} void @_Z3sw2i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[YOLO:.*]] = alloca i32, align 4
@@ -151,7 +151,7 @@ void sw3(int a) {
   }
 }
 
-// CIR: cir.func @_Z3sw3i
+// CIR: cir.func{{.*}} @_Z3sw3i
 // CIR: cir.scope {
 // CIR-NEXT:   %[[COND:.*]] = cir.load{{.*}} %[[A:.*]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.switch (%[[COND]] : !s32i) {
@@ -161,7 +161,7 @@ void sw3(int a) {
 // CIR-NEXT:   cir.yield
 // CIR-NEXT:   }
 
-// LLVM-LABEL: define void @_Z3sw3i
+// LLVM-LABEL: define{{.*}} void @_Z3sw3i
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   br label %[[SWITCH:.*]]
 // LLVM: [[SWITCH]]:
@@ -174,7 +174,7 @@ void sw3(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw3i
+// OGCG: define{{.*}} void @_Z3sw3i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -195,7 +195,7 @@ int sw4(int a) {
   return 0;
 }
 
-// CIR: cir.func @_Z3sw4i
+// CIR: cir.func{{.*}} @_Z3sw4i
 // CIR:       cir.switch (%[[COND:.*]] : !s32i) {
 // CIR-NEXT:       cir.case(equal, [#cir.int<42> : !s32i]) {
 // CIR-NEXT:         cir.scope {
@@ -215,7 +215,7 @@ int sw4(int a) {
 // CIR-NEXT:       cir.yield
 // CIR-NEXT:  }
 
-// LLVM: define i32 @_Z3sw4i
+// LLVM: define{{.*}} i32 @_Z3sw4i
 // LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[RET_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[ENTRY:.*]]
@@ -241,7 +241,7 @@ int sw4(int a) {
 // LLVM:   %[[RET0:.*]] = load i32, ptr %[[RET_ADDR]], align 4
 // LLVM:   ret i32 %[[RET0]]
 
-// OGCG: define dso_local noundef i32 @_Z3sw4i
+// OGCG: define{{.*}} i32 @_Z3sw4i
 // OGCG: entry:
 // OGCG:   %[[RETVAL:.*]] = alloca i32, align 4
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
@@ -263,7 +263,7 @@ void sw5(int a) {
   }
 }
 
-// CIR: cir.func @_Z3sw5i
+// CIR: cir.func{{.*}} @_Z3sw5i
 // CIR: cir.switch (%[[A:.*]] : !s32i) {
 // CIR-NEXT:   cir.case(equal, [#cir.int<1> : !s32i]) {
 // CIR-NEXT:     cir.yield
@@ -271,7 +271,7 @@ void sw5(int a) {
 // CIR-NEXT:   cir.yield
 // CIR-NEXT:   }
 
-// LLVM-LABEL: define void @_Z3sw5i
+// LLVM-LABEL: define{{.*}} void @_Z3sw5i
 // LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   br label %[[ENTRY:.*]]
 // LLVM: [[ENTRY]]:
@@ -288,7 +288,7 @@ void sw5(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw5i
+// OGCG: define{{.*}} void @_Z3sw5i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -313,7 +313,7 @@ void sw6(int a) {
   }
 }
 
-// CIR: cir.func @_Z3sw6i
+// CIR: cir.func{{.*}} @_Z3sw6i
 // CIR: cir.switch (%[[A:.*]] : !s32i) {
 // CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
 // CIR-NEXT:     cir.yield
@@ -334,7 +334,7 @@ void sw6(int a) {
 // CIR-NEXT:     cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z3sw6i
+// LLVM: define{{.*}} void @_Z3sw6i
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   br label %[[SWITCH:.*]]
 // LLVM: [[SWITCH]]:
@@ -371,7 +371,7 @@ void sw6(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw6i
+// OGCG: define{{.*}} void @_Z3sw6i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   store i32 %a, ptr %[[A_ADDR]], align 4
@@ -404,7 +404,7 @@ void sw7(int a) {
   }
 }
 
-// CIR: cir.func @_Z3sw7i
+// CIR: cir.func{{.*}} @_Z3sw7i
 // CIR: %[[X:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["x"]
 // CIR: cir.switch (%[[A:.*]] : !s32i)
 // CIR-NEXT: cir.case(equal, [#cir.int<0> : !s32i]) {
@@ -428,7 +428,7 @@ void sw7(int a) {
 // CIR-NEXT: cir.yield
 // CIR: }
 
-// LLVM: define void @_Z3sw7i
+// LLVM: define{{.*}} void @_Z3sw7i
 // LLVM:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   br label %[[SWITCH:.*]]
 // LLVM: [[SWITCH]]:
@@ -467,7 +467,7 @@ void sw7(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw7i
+// OGCG: define{{.*}} void @_Z3sw7i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -498,7 +498,7 @@ void sw8(int a) {
   }
 }
 
-// CIR:    cir.func @_Z3sw8i
+// CIR:    cir.func{{.*}} @_Z3sw8i
 // CIR:    cir.switch (%[[A:.*]] : !s32i)
 // CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CIR-NEXT:   cir.break
@@ -510,7 +510,7 @@ void sw8(int a) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z3sw8i
+// LLVM: define{{.*}} void @_Z3sw8i
 // LLVM:   switch i32 %[[COND:.*]], label %[[DEFAULT:.*]] [
 // LLVM-DAG:  i32 3, label %[[CASE3:.*]]
 // LLVM-DAG:  i32 4, label %[[CASE4:.*]]
@@ -528,7 +528,7 @@ void sw8(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw8i
+// OGCG: define{{.*}} void @_Z3sw8i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -556,7 +556,7 @@ void sw9(int a) {
   }
 }
 
-// CIR:    cir.func @_Z3sw9i
+// CIR:    cir.func{{.*}} @_Z3sw9i
 // CIR:    cir.switch (%[[A:.*]] : !s32i)
 // CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CIR-NEXT:   cir.break
@@ -568,7 +568,7 @@ void sw9(int a) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z3sw9i
+// LLVM: define{{.*}} void @_Z3sw9i
 // LLVM:   switch i32 %[[COND:.*]], label %[[DEFAULT:.*]] [
 // LLVM-DAG:     i32 3, label %[[CASE3:.*]]
 // LLVM-DAG:     i32 4, label %[[CASE4:.*]]
@@ -586,7 +586,7 @@ void sw9(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z3sw9i
+// OGCG: define{{.*}} void @_Z3sw9i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -615,7 +615,7 @@ void sw10(int a) {
   }
 }
 
-// CIR:    cir.func @_Z4sw10i
+// CIR:    cir.func{{.*}} @_Z4sw10i
 // CIR:    cir.switch (%[[A:.*]] : !s32i)
 // CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CIR-NEXT:   cir.break
@@ -630,7 +630,7 @@ void sw10(int a) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z4sw10i
+// LLVM: define{{.*}} void @_Z4sw10i
 // LLVM:   switch i32 %[[COND:.*]], label %[[DEFAULT:.*]] [
 // LLVM-DAG:     i32 3, label %[[CASE_3:.*]]
 // LLVM-DAG:     i32 4, label %[[CASE_4:.*]]
@@ -653,7 +653,7 @@ void sw10(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4sw10i
+// OGCG: define{{.*}} void @_Z4sw10i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -687,7 +687,7 @@ void sw11(int a) {
   }
 }
 
-// CIR:    cir.func @_Z4sw11i
+// CIR:    cir.func{{.*}} @_Z4sw11i
 // CIR:    cir.switch (%[[A:.*]] : !s32i)
 // CIR-NEXT: cir.case(equal, [#cir.int<3> : !s32i]) {
 // CIR-NEXT:   cir.break
@@ -708,7 +708,7 @@ void sw11(int a) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z4sw11i
+// LLVM: define{{.*}} void @_Z4sw11i
 // LLVM:   switch i32 %[[COND:.*]], label %[[DEFAULT:.*]] [
 // LLVM-DAG:     i32 3, label %[[CASE_3:.*]]
 // LLVM-DAG:     i32 4, label %[[CASE_4:.*]]
@@ -741,7 +741,7 @@ void sw11(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4sw11i
+// OGCG: define{{.*}} void @_Z4sw11i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -772,7 +772,7 @@ void sw12(int a) {
   }
 }
 
-//      CIR: cir.func @_Z4sw12i
+//      CIR: cir.func{{.*}} @_Z4sw12i
 //      CIR:   cir.scope {
 //      CIR:     cir.switch
 // CIR-NEXT:     cir.case(equal, [#cir.int<3> : !s32i]) {
@@ -781,7 +781,7 @@ void sw12(int a) {
 // CIR-NEXT:       cir.break
 // CIR-NEXT:     }
 
-// LLVM: define void @_Z4sw12i
+// LLVM: define{{.*}} void @_Z4sw12i
 // LLVM:   switch i32 %[[COND:.*]], label %[[EXIT:.*]] [
 // LLVM-DAG:     i32 3, label %[[CASE_3:.*]]
 // LLVM:   ]
@@ -794,7 +794,7 @@ void sw12(int a) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4sw12i
+// OGCG: define{{.*}} void @_Z4sw12i
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[A_VAL:.*]] = load i32, ptr %[[A_ADDR]], align 4
@@ -816,7 +816,7 @@ void sw13(int a, int b) {
   }
 }
 
-//      CIR:  cir.func @_Z4sw13ii
+//      CIR:  cir.func{{.*}} @_Z4sw13ii
 //      CIR:    cir.scope {
 //      CIR:      cir.switch
 // CIR-NEXT:      cir.case(equal, [#cir.int<1> : !s32i]) {
@@ -832,7 +832,7 @@ void sw13(int a, int b) {
 //      CIR:    }
 //      CIR:    cir.return
 
-// LLVM: define void @_Z4sw13ii
+// LLVM: define{{.*}} void @_Z4sw13ii
 // LLVM:   switch i32 %[[COND:.*]], label %[[OUTER_EXIT:.*]] [
 // LLVM-DAG:     i32 1, label %[[CASE_A_1:.*]]
 // LLVM:   ]
@@ -858,7 +858,7 @@ void sw13(int a, int b) {
 // LLVM: [[EXIT]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4sw13ii
+// OGCG: define{{.*}} void @_Z4sw13ii
 // OGCG: entry:
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[B_ADDR:.*]] = alloca i32, align 4
@@ -890,7 +890,7 @@ void sw14(int x) {
   }
 }
 
-// CIR:      cir.func @_Z4sw14i
+// CIR:      cir.func{{.*}} @_Z4sw14i
 // CIR:      cir.switch
 // CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
 // CIR-NEXT:   cir.yield
@@ -908,7 +908,7 @@ void sw14(int x) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z4sw14i
+// LLVM: define{{.*}} void @_Z4sw14i
 // LLVM:   switch i32 %[[COND:.*]], label %[[DEFAULT:.*]] [
 // LLVM-DAG:     i32 1, label %[[CASE1:.*]]
 // LLVM-DAG:     i32 2, label %[[CASE2:.*]]
@@ -939,7 +939,7 @@ void sw14(int x) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4sw14i
+// OGCG: define{{.*}} void @_Z4sw14i
 // OGCG: entry:
 // OGCG:   %[[X_ADDR:.*]] = alloca i32, align 4
 // OGCG:   store i32 %x, ptr %[[X_ADDR]], align 4
@@ -977,7 +977,7 @@ void sw15(int x) {
   }
 }
 
-// CIR:      cir.func @_Z4sw15i
+// CIR:      cir.func{{.*}} @_Z4sw15i
 // CIR:      %[[Y:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["y"]
 // CIR:      cir.switch
 // CIR-NEXT: cir.case(equal, [#cir.int<1> : !s32i]) {
@@ -995,7 +995,7 @@ void sw15(int x) {
 // CIR-NEXT:   cir.break
 // CIR-NEXT: }
 
-// LLVM: define void @_Z4sw15i
+// LLVM: define{{.*}} void @_Z4sw15i
 // LLVM:   switch i32 %[[COND:.*]], label %[[DEFAULT:.*]] [
 // LLVM-DAG:     i32 1, label %[[CASE1:.*]]
 // LLVM-DAG:     i32 2, label %[[CASE2:.*]]
@@ -1019,7 +1019,7 @@ void sw15(int x) {
 // LLVM: [[RET]]:
 // LLVM:   ret void
 
-// OGCG: define dso_local void @_Z4sw15i
+// OGCG: define{{.*}} void @_Z4sw15i
 // OGCG: entry:
 // OGCG:   %[[X_ADDR:.*]] = alloca i32, align 4
 // OGCG:   %[[Y:.*]] = alloca i32, align 4
@@ -1081,7 +1081,7 @@ int nested_switch(int a) {
 // CIR:           cir.case(equal, [#cir.int<7> : !s32i]) {
 // CIR:           cir.return
 
-// LLVM: define i32 @_Z13nested_switchi
+// LLVM: define{{.*}} i32 @_Z13nested_switchi
 // LLVM:   %[[B_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A_ADDR:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[RES_ADDR:.*]] = alloca i32, i64 1, align 4
@@ -1136,7 +1136,7 @@ int nested_switch(int a) {
 // LLVM:   %[[RET0:.*]] = load i32, ptr %[[RES_ADDR]], align 4
 // LLVM:   ret i32 %[[RET0]]
 
-// OGCG: define dso_local noundef i32 @_Z13nested_switchi
+// OGCG: define{{.*}} i32 @_Z13nested_switchi
 // OGCG: entry:
 // OGCG:   %[[RETVAL:.*]] = alloca i32, align 4
 // OGCG:   %[[A_ADDR:.*]] = alloca i32, align 4

--- a/clang/test/CIR/CodeGen/switch_flat_op.cpp
+++ b/clang/test/CIR/CodeGen/switch_flat_op.cpp
@@ -18,7 +18,7 @@ void swf(int a) {
 
 }
 
-// BEFORE:  cir.func @_Z3swfi
+// BEFORE:  cir.func{{.*}} @_Z3swfi
 // BEFORE:   %[[VAR_B:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64}
 // BEFORE:   %[[CONST_3:.*]] = cir.const #cir.int<3> : !s32i
 // BEFORE:   cir.switch (%[[COND:.*]] : !s32i) {
@@ -44,7 +44,7 @@ void swf(int a) {
 // BEFORE: }
 // BEFORE: cir.return
 
-// AFTER: cir.func @_Z3swfi
+// AFTER: cir.func{{.*}} @_Z3swfi
 // AFTER:  %[[VAR_A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
 // AFTER:  cir.store{{.*}} %arg0, %[[VAR_A]] : !s32i, !cir.ptr<!s32i>
 // AFTER:  %[[VAR_B:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64}

--- a/clang/test/CIR/CodeGen/ternary.cpp
+++ b/clang/test/CIR/CodeGen/ternary.cpp
@@ -9,7 +9,7 @@ int x(int y) {
   return y > 0 ? 3 : 5;
 }
 
-// CIR-LABEL: cir.func @_Z1xi(
+// CIR-LABEL: cir.func{{.*}} @_Z1xi(
 // CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}) -> !s32i {
 // CIR: [[Y:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init] {alignment = 4 : i64}
 // CIR: [[RETVAL:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
@@ -24,7 +24,7 @@ int x(int y) {
 // CIR: [[RETVAL_VAL:%.+]] = cir.load [[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return [[RETVAL_VAL]] : !s32i
 
-// LLVM-LABEL: define i32 @_Z1xi(
+// LLVM-LABEL: define{{.*}} i32 @_Z1xi(
 // LLVM-SAME: i32 %[[ARG0:.+]])
 // LLVM: %[[Y:.*]] = alloca i32
 // LLVM: %[[RETVAL:.*]] = alloca i32
@@ -36,7 +36,7 @@ int x(int y) {
 // LLVM: %[[RESULT:.*]] = load i32, ptr %[[RETVAL]]
 // LLVM: ret i32 %[[RESULT]]
 
-// OGCG-LABEL: define dso_local noundef i32 @_Z1xi(
+// OGCG-LABEL: define{{.*}} i32 @_Z1xi(
 // OGCG-SAME: i32 {{.*}} %[[ARG0:.+]])
 // OGCG: %[[Y:.*]] = alloca i32
 // OGCG: store i32 %[[ARG0]], ptr %[[Y]]
@@ -51,7 +51,7 @@ int foo(int a, int b) {
   return 0;
 }
 
-// CIR-LABEL: cir.func @_Z3fooii(
+// CIR-LABEL: cir.func{{.*}} @_Z3fooii(
 // CIR-SAME: %[[ARG0:.*]]: !s32i {{.*}}, %[[ARG1:.*]]: !s32i {{.*}}) -> !s32i {
 // CIR: [[A:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
 // CIR: [[B:%.+]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64}
@@ -83,7 +83,7 @@ int foo(int a, int b) {
 // CIR: [[RETVAL_VAL2:%.+]] = cir.load [[RETVAL]] : !cir.ptr<!s32i>, !s32i
 // CIR: cir.return [[RETVAL_VAL2]] : !s32i
 
-// LLVM-LABEL: define i32 @_Z3fooii(
+// LLVM-LABEL: define{{.*}} i32 @_Z3fooii(
 // LLVM-SAME: i32 %[[ARG0:.*]], i32 %[[ARG1:.*]])
 // LLVM: %[[A:.*]] = alloca i32
 // LLVM: %[[B:.*]] = alloca i32
@@ -116,7 +116,7 @@ int foo(int a, int b) {
 // LLVM: %[[RET2:.*]] = load i32, ptr %[[RETVAL]]
 // LLVM: ret i32 %[[RET2]]
 
-// OGCG-LABEL: define dso_local noundef i32 @_Z3fooii(
+// OGCG-LABEL: define{{.*}} i32 @_Z3fooii(
 // OGCG-SAME: i32 {{.*}} %[[ARG0:.*]], i32 {{.*}} %[[ARG1:.*]])
 // OGCG: %[[RETVAL:.*]] = alloca i32
 // OGCG: %[[A:.*]] = alloca i32

--- a/clang/test/CIR/CodeGen/typedef.c
+++ b/clang/test/CIR/CodeGen/typedef.c
@@ -10,12 +10,12 @@ void local_typedef(void) {
   Struct s;
 }
 
-// CIR:      cir.func @local_typedef()
+// CIR:      cir.func{{.*}} @local_typedef()
 // CIR:        cir.alloca !rec_Struct, !cir.ptr<!rec_Struct>, ["s"] {alignment = 4 : i64}
 // CIR:        cir.return
 
 // LLVM: %struct.Struct = type { i32 }
-// LLVM: define void @local_typedef()
+// LLVM: define{{.*}} void @local_typedef()
 // LLVM:   alloca %struct.Struct, i64 1, align 4
 // LLVM:   ret void
 

--- a/clang/test/CIR/CodeGen/unary.cpp
+++ b/clang/test/CIR/CodeGen/unary.cpp
@@ -10,12 +10,12 @@ unsigned up0() {
   return +a;
 }
 
-// CHECK: cir.func @_Z3up0v() -> !u32i
+// CHECK: cir.func{{.*}} @_Z3up0v() -> !u32i
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(plus, %[[INPUT]])
 
-// LLVM: define i32 @_Z3up0v()
+// LLVM: define{{.*}} i32 @_Z3up0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -31,12 +31,12 @@ unsigned um0() {
   return -a;
 }
 
-// CHECK: cir.func @_Z3um0v() -> !u32i
+// CHECK: cir.func{{.*}} @_Z3um0v() -> !u32i
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(minus, %[[INPUT]])
 
-// LLVM: define i32 @_Z3um0v()
+// LLVM: define{{.*}} i32 @_Z3um0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -54,12 +54,12 @@ unsigned un0() {
   return ~a; // a ^ -1 , not
 }
 
-// CHECK: cir.func @_Z3un0v() -> !u32i
+// CHECK: cir.func{{.*}} @_Z3un0v() -> !u32i
 // CHECK:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(not, %[[INPUT]])
 
-// LLVM: define i32 @_Z3un0v()
+// LLVM: define{{.*}} i32 @_Z3un0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -78,7 +78,7 @@ int inc0() {
   return a;
 }
 
-// CHECK: cir.func @_Z4inc0v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z4inc0v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !s32i
@@ -87,7 +87,7 @@ int inc0() {
 // CHECK:   cir.store{{.*}} %[[INCREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define i32 @_Z4inc0v()
+// LLVM: define{{.*}} i32 @_Z4inc0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -106,7 +106,7 @@ int dec0() {
   return a;
 }
 
-// CHECK: cir.func @_Z4dec0v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z4dec0v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !s32i
@@ -115,7 +115,7 @@ int dec0() {
 // CHECK:   cir.store{{.*}} %[[DECREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define i32 @_Z4dec0v()
+// LLVM: define{{.*}} i32 @_Z4dec0v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -134,7 +134,7 @@ int inc1() {
   return a;
 }
 
-// CHECK: cir.func @_Z4inc1v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z4inc1v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !s32i
@@ -143,7 +143,7 @@ int inc1() {
 // CHECK:   cir.store{{.*}} %[[INCREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define i32 @_Z4inc1v()
+// LLVM: define{{.*}} i32 @_Z4inc1v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -162,7 +162,7 @@ int dec1() {
   return a;
 }
 
-// CHECK: cir.func @_Z4dec1v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z4dec1v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !s32i
@@ -171,7 +171,7 @@ int dec1() {
 // CHECK:   cir.store{{.*}} %[[DECREMENTED]], %[[A]]
 // CHECK:   %[[A_TO_OUTPUT:.*]] = cir.load{{.*}} %[[A]]
 
-// LLVM: define i32 @_Z4dec1v()
+// LLVM: define{{.*}} i32 @_Z4dec1v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   store i32 1, ptr %[[A]], align 4
@@ -191,7 +191,7 @@ int inc2() {
   return b;
 }
 
-// CHECK: cir.func @_Z4inc2v() -> !s32i
+// CHECK: cir.func{{.*}} @_Z4inc2v() -> !s32i
 // CHECK:   %[[A:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
 // CHECK:   %[[B:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.int<1> : !s32i
@@ -202,7 +202,7 @@ int inc2() {
 // CHECK:   cir.store{{.*}} %[[ATOB]], %[[B]]
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load{{.*}} %[[B]]
 
-// LLVM: define i32 @_Z4inc2v()
+// LLVM: define{{.*}} i32 @_Z4inc2v()
 // LLVM:   %[[RV:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca i32, i64 1, align 4
 // LLVM:   %[[B:.*]] = alloca i32, i64 1, align 4
@@ -228,12 +228,12 @@ float fpPlus() {
   return +a;
 }
 
-// CHECK: cir.func @_Z6fpPlusv() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z6fpPlusv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(plus, %[[INPUT]])
 
-// LLVM: define float @_Z6fpPlusv()
+// LLVM: define{{.*}} float @_Z6fpPlusv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -249,12 +249,12 @@ float fpMinus() {
   return -a;
 }
 
-// CHECK: cir.func @_Z7fpMinusv() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z7fpMinusv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[OUTPUT:.*]] = cir.unary(minus, %[[INPUT]])
 
-// LLVM: define float @_Z7fpMinusv()
+// LLVM: define{{.*}} float @_Z7fpMinusv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -272,14 +272,14 @@ float fpPreInc() {
   return ++a;
 }
 
-// CHECK: cir.func @_Z8fpPreIncv() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z8fpPreIncv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[INPUT]])
 
-// LLVM: define float @_Z8fpPreIncv()
+// LLVM: define{{.*}} float @_Z8fpPreIncv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -297,14 +297,14 @@ float fpPreDec() {
   return --a;
 }
 
-// CHECK: cir.func @_Z8fpPreDecv() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z8fpPreDecv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[DECREMENTED:.*]] = cir.unary(dec, %[[INPUT]])
 
-// LLVM: define float @_Z8fpPreDecv()
+// LLVM: define{{.*}} float @_Z8fpPreDecv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -322,14 +322,14 @@ float fpPostInc() {
   return a++;
 }
 
-// CHECK: cir.func @_Z9fpPostIncv() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z9fpPostIncv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[INCREMENTED:.*]] = cir.unary(inc, %[[INPUT]])
 
-// LLVM: define float @_Z9fpPostIncv()
+// LLVM: define{{.*}} float @_Z9fpPostIncv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -347,14 +347,14 @@ float fpPostDec() {
   return a--;
 }
 
-// CHECK: cir.func @_Z9fpPostDecv() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z9fpPostDecv() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
 // CHECK:   cir.store{{.*}} %[[ATMP]], %[[A]] : !cir.float
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[A]]
 // CHECK:   %[[DECREMENTED:.*]] = cir.unary(dec, %[[INPUT]])
 
-// LLVM: define float @_Z9fpPostDecv()
+// LLVM: define{{.*}} float @_Z9fpPostDecv()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   store float 1.000000e+00, ptr %[[A]], align 4
@@ -374,7 +374,7 @@ float fpPostInc2() {
   return b;
 }
 
-// CHECK: cir.func @_Z10fpPostInc2v() -> !cir.float
+// CHECK: cir.func{{.*}} @_Z10fpPostInc2v() -> !cir.float
 // CHECK:   %[[A:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init]
 // CHECK:   %[[B:.*]] = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["b", init]
 // CHECK:   %[[ATMP:.*]] = cir.const #cir.fp<1.000000e+00> : !cir.float
@@ -385,7 +385,7 @@ float fpPostInc2() {
 // CHECK:   cir.store{{.*}} %[[ATOB]], %[[B]]
 // CHECK:   %[[B_TO_OUTPUT:.*]] = cir.load{{.*}} %[[B]]
 
-// LLVM: define float @_Z10fpPostInc2v()
+// LLVM: define{{.*}} float @_Z10fpPostInc2v()
 // LLVM:   %[[RV:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[A:.*]] = alloca float, i64 1, align 4
 // LLVM:   %[[B:.*]] = alloca float, i64 1, align 4
@@ -407,7 +407,7 @@ float fpPostInc2() {
 // OGCG:   %[[B_TO_OUTPUT:.*]] = load float, ptr %[[B]], align 4
 
 void chars(char c) {
-// CHECK: cir.func @_Z5charsc
+// CHECK: cir.func{{.*}} @_Z5charsc
 
   int c1 = +c;
   // CHECK: %[[PROMO:.*]] = cir.cast(integral, %{{.+}} : !s8i), !s32i
@@ -429,13 +429,13 @@ _Float16 fp16UPlus(_Float16 f) {
   return +f;
 }
 
-// CHECK: cir.func @_Z9fp16UPlusDF16_({{.*}}) -> !cir.f16
+// CHECK: cir.func{{.*}} @_Z9fp16UPlusDF16_({{.*}}) -> !cir.f16
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[F:.*]]
 // CHECK:   %[[PROMOTED:.*]] = cir.cast(floating, %[[INPUT]] : !cir.f16), !cir.float
 // CHECK:   %[[RESULT:.*]] = cir.unary(plus, %[[PROMOTED]])
 // CHECK:   %[[UNPROMOTED:.*]] = cir.cast(floating, %[[RESULT]] : !cir.float), !cir.f16
 
-// LLVM: define half @_Z9fp16UPlusDF16_({{.*}})
+// LLVM: define{{.*}} half @_Z9fp16UPlusDF16_({{.*}})
 // LLVM:   %[[F_LOAD:.*]] = load half, ptr %{{.*}}, align 2
 // LLVM:   %[[PROMOTED:.*]] = fpext half %[[F_LOAD]] to float
 // LLVM:   %[[UNPROMOTED:.*]] = fptrunc float %[[PROMOTED]] to half
@@ -449,13 +449,13 @@ _Float16 fp16UMinus(_Float16 f) {
   return -f;
 }
 
-// CHECK: cir.func @_Z10fp16UMinusDF16_({{.*}}) -> !cir.f16
+// CHECK: cir.func{{.*}} @_Z10fp16UMinusDF16_({{.*}}) -> !cir.f16
 // CHECK:   %[[INPUT:.*]] = cir.load{{.*}} %[[F:.*]]
 // CHECK:   %[[PROMOTED:.*]] = cir.cast(floating, %[[INPUT]] : !cir.f16), !cir.float
 // CHECK:   %[[RESULT:.*]] = cir.unary(minus, %[[PROMOTED]])
 // CHECK:   %[[UNPROMOTED:.*]] = cir.cast(floating, %[[RESULT]] : !cir.float), !cir.f16
 
-// LLVM: define half @_Z10fp16UMinusDF16_({{.*}})
+// LLVM: define{{.*}} half @_Z10fp16UMinusDF16_({{.*}})
 // LLVM:   %[[F_LOAD:.*]] = load half, ptr %{{.*}}, align 2
 // LLVM:   %[[PROMOTED:.*]] = fpext half %[[F_LOAD]] to float
 // LLVM:   %[[RESULT:.*]] = fneg float %[[PROMOTED]]
@@ -480,7 +480,7 @@ void test_logical_not() {
   b = !d;
 }
 
-// CHECK: cir.func @_Z16test_logical_notv()
+// CHECK: cir.func{{.*}} @_Z16test_logical_notv()
 // CHECK:   %[[A:.*]] = cir.load{{.*}} %[[A_ADDR:.*]] : !cir.ptr<!s32i>, !s32i
 // CHECK:   %[[A_BOOL:.*]] = cir.cast(int_to_bool, %[[A]] : !s32i), !cir.bool
 // CHECK:   %[[A_NOT:.*]] = cir.unary(not, %[[A_BOOL]]) : !cir.bool, !cir.bool
@@ -503,7 +503,7 @@ void test_logical_not() {
 // CHECK:   %[[D_NOT:.*]] = cir.unary(not, %[[D_BOOL]]) : !cir.bool, !cir.bool
 // CHECK:   cir.store{{.*}} %[[D_NOT]], %[[B_ADDR]] : !cir.bool, !cir.ptr<!cir.bool>
 
-// LLVM: define void @_Z16test_logical_notv()
+// LLVM: define{{.*}} void @_Z16test_logical_notv()
 // LLVM:   %[[A:.*]] = load i32, ptr %[[A_ADDR:.*]], align 4
 // LLVM:   %[[A_BOOL:.*]] = icmp ne i32 %[[A]], 0
 // LLVM:   %[[A_NOT:.*]] = xor i1 %[[A_BOOL]], true

--- a/clang/test/CIR/CodeGen/union.c
+++ b/clang/test/CIR/CodeGen/union.c
@@ -54,11 +54,11 @@ void f1(void) {
   union IncompleteU *p;
 }
 
-// CIR:      cir.func @f1()
+// CIR:      cir.func{{.*}} @f1()
 // CIR-NEXT:   cir.alloca !cir.ptr<!rec_IncompleteU>, !cir.ptr<!cir.ptr<!rec_IncompleteU>>, ["p"]
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @f1()
+// LLVM:      define{{.*}} void @f1()
 // LLVM-NEXT:   %[[P:.*]] = alloca ptr, i64 1, align 8
 // LLVM-NEXT:   ret void
 
@@ -73,7 +73,7 @@ int f2(void) {
   return u.n;
 }
 
-// CIR:      cir.func @f2() -> !s32i
+// CIR:      cir.func{{.*}} @f2() -> !s32i
 // CIR-NEXT:   %[[RETVAL_ADDR:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U1, !cir.ptr<!rec_U1>, ["u"] {alignment = 4 : i64}
 // CIR-NEXT:   %[[I:.*]] = cir.const #cir.int<42> : !s32i
@@ -85,7 +85,7 @@ int f2(void) {
 // CIR-NEXT:   %[[RET:.*]] = cir.load{{.*}} %[[RETVAL_ADDR]] : !cir.ptr<!s32i>, !s32i
 // CIR-NEXT:   cir.return %[[RET]] : !s32i
 
-// LLVM:      define i32 @f2()
+// LLVM:      define{{.*}} i32 @f2()
 // LLVM-NEXT:   %[[RETVAL:.*]] = alloca i32, i64 1, align 4
 // LLVM-NEXT:   %[[U:.*]] = alloca %union.U1, i64 1, align 4
 // LLVM-NEXT:   store i32 42, ptr %[[U]], align 4
@@ -94,7 +94,7 @@ int f2(void) {
 // LLVM-NEXT:   %[[RET:.*]] = load i32, ptr %[[RETVAL]], align 4
 // LLVM-NEXT:   ret i32 %[[RET]]
 
-//      OGCG: define dso_local i32 @f2()
+//      OGCG: define{{.*}} i32 @f2()
 // OGCG-NEXT: entry:
 // OGCG-NEXT: %[[U:.*]] = alloca %union.U1, align 4
 // OGCG-NEXT: store i32 42, ptr %[[U]], align 4
@@ -112,7 +112,7 @@ void shouldGenerateUnionAccess(union U2 u) {
   u.d;
 }
 
-// CIR:      cir.func @shouldGenerateUnionAccess(%[[ARG:.*]]: !rec_U2
+// CIR:      cir.func{{.*}} @shouldGenerateUnionAccess(%[[ARG:.*]]: !rec_U2
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U2, !cir.ptr<!rec_U2>, ["u", init] {alignment = 8 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG]], %[[U]] : !rec_U2, !cir.ptr<!rec_U2>
 // CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
@@ -138,7 +138,7 @@ void shouldGenerateUnionAccess(union U2 u) {
 // CIR-NEXT:   %[[D_VAL:.*]] = cir.load{{.*}} %[[D_PTR2]] : !cir.ptr<!cir.double>, !cir.double
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @shouldGenerateUnionAccess(%union.U2 %[[ARG:.*]])
+// LLVM:      define{{.*}} void @shouldGenerateUnionAccess(%union.U2 %[[ARG:.*]])
 // LLVM-NEXT:   %[[U:.*]] = alloca %union.U2, i64 1, align 8
 // LLVM-NEXT:   store %union.U2 %[[ARG]], ptr %[[U]], align 8
 // LLVM-NEXT:   store i8 0, ptr %[[U]], align 8
@@ -151,7 +151,7 @@ void shouldGenerateUnionAccess(union U2 u) {
 // LLVM-NEXT:   %[[D_VAL:.*]] = load double, ptr %[[U]], align 8
 // LLVM-NEXT:   ret void
 
-// OGCG:      define dso_local void @shouldGenerateUnionAccess(i64 %[[ARG:.*]])
+// OGCG:      define{{.*}} void @shouldGenerateUnionAccess(i64 %[[ARG:.*]])
 // OGCG-NEXT: entry:
 // OGCG-NEXT:   %[[U:.*]] = alloca %union.U2, align 8
 // OGCG-NEXT:   %[[COERCE_DIVE:.*]] = getelementptr inbounds nuw %union.U2, ptr %[[U]], i32 0, i32 0
@@ -170,7 +170,7 @@ void f3(union U3 u) {
   u.c[2] = 0;
 }
 
-// CIR:      cir.func @f3(%[[ARG:.*]]: !rec_U3
+// CIR:      cir.func{{.*}} @f3(%[[ARG:.*]]: !rec_U3
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U3, !cir.ptr<!rec_U3>, ["u", init] {alignment = 1 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG]], %[[U]] : !rec_U3, !cir.ptr<!rec_U3>
 // CIR-NEXT:   %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
@@ -182,7 +182,7 @@ void f3(union U3 u) {
 // CIR-NEXT:   cir.store{{.*}} %[[ZERO_CHAR]], %[[ELEM_PTR]] : !s8i, !cir.ptr<!s8i>
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @f3(%union.U3 %[[ARG:.*]])
+// LLVM:      define{{.*}} void @f3(%union.U3 %[[ARG:.*]])
 // LLVM-NEXT:   %[[U:.*]] = alloca %union.U3, i64 1, align 1
 // LLVM-NEXT:   store %union.U3 %[[ARG]], ptr %[[U]], align 1
 // LLVM-NEXT:   %[[C_PTR:.*]] = getelementptr i8, ptr %[[U]], i32 0
@@ -190,7 +190,7 @@ void f3(union U3 u) {
 // LLVM-NEXT:   store i8 0, ptr %[[ELEM_PTR]], align 1
 // LLVM-NEXT:   ret void
 
-// OGCG:      define dso_local void @f3(i40 %[[ARG:.*]])
+// OGCG:      define{{.*}} void @f3(i40 %[[ARG:.*]])
 // OGCG-NEXT: entry:
 // OGCG-NEXT:   %[[U:.*]] = alloca %union.U3, align 1
 // OGCG-NEXT:   store i40 %[[ARG]], ptr %[[U]], align 1
@@ -202,7 +202,7 @@ void f5(union U4 u) {
   u.c[4] = 65;
 }
 
-// CIR:      cir.func @f5(%[[ARG:.*]]: !rec_U4
+// CIR:      cir.func{{.*}} @f5(%[[ARG:.*]]: !rec_U4
 // CIR-NEXT:   %[[U:.*]] = cir.alloca !rec_U4, !cir.ptr<!rec_U4>, ["u", init] {alignment = 4 : i64}
 // CIR-NEXT:   cir.store{{.*}} %[[ARG]], %[[U]] : !rec_U4, !cir.ptr<!rec_U4>
 // CIR-NEXT:   %[[CHAR_VAL:.*]] = cir.const #cir.int<65> : !s32i
@@ -214,7 +214,7 @@ void f5(union U4 u) {
 // CIR-NEXT:   cir.store{{.*}} %[[CHAR_CAST]], %[[ELEM_PTR]] : !s8i, !cir.ptr<!s8i>
 // CIR-NEXT:   cir.return
 
-// LLVM:      define void @f5(%union.U4 %[[ARG:.*]])
+// LLVM:      define{{.*}} void @f5(%union.U4 %[[ARG:.*]])
 // LLVM-NEXT:   %[[U:.*]] = alloca %union.U4, i64 1, align 4
 // LLVM-NEXT:   store %union.U4 %[[ARG]], ptr %[[U]], align 4
 // LLVM-NEXT:   %[[C_PTR:.*]] = getelementptr i8, ptr %[[U]], i32 0
@@ -222,7 +222,7 @@ void f5(union U4 u) {
 // LLVM-NEXT:   store i8 65, ptr %[[ELEM_PTR]], align 4
 // LLVM-NEXT:   ret void
 
-// OGCG:      define dso_local void @f5(i64 %[[ARG:.*]])
+// OGCG:      define{{.*}} void @f5(i64 %[[ARG:.*]])
 // OGCG-NEXT: entry:
 // OGCG-NEXT:   %[[U:.*]] = alloca %union.U4, align 4
 // OGCG-NEXT:   store i64 %[[ARG]], ptr %[[U]], align 4

--- a/clang/test/CIR/CodeGenOpenACC/combined-copy.c
+++ b/clang/test/CIR/CodeGenOpenACC/combined-copy.c
@@ -2,7 +2,7 @@
 
 int global;
 void acc_compute(int parmVar) {
-  // CHECK: cir.func @acc_compute(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_compute(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
   int localVar1;
   short localVar2;
@@ -773,7 +773,7 @@ typedef struct StructTy {
 } Struct ;
 
 void acc_compute_members() {
-  // CHECK: cir.func @acc_compute_members()
+  // CHECK: cir.func{{.*}} @acc_compute_members()
   Struct localStruct;
   // CHECK-NEXT: %[[LOCALSTRUCT:.*]] = cir.alloca !rec_StructTy, !cir.ptr<!rec_StructTy>, ["localStruct"]
 
@@ -1082,7 +1082,7 @@ typedef struct OuterTy {
 } Outer;
 
 void copy_member_of_array_element_member() {
-  // CHECK: cir.func @copy_member_of_array_element_member() {
+  // CHECK: cir.func{{.*}} @copy_member_of_array_element_member() {
   Outer outer;
   // CHECK-NEXT: %[[OUTER:.*]] = cir.alloca !rec_OuterTy, !cir.ptr<!rec_OuterTy>, ["outer"]
 

--- a/clang/test/CIR/CodeGenOpenACC/combined.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/combined.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 extern "C" void acc_combined(int N, int cond) {
-  // CHECK: cir.func @acc_combined(%[[ARG_N:.*]]: !s32i loc{{.*}}, %[[ARG_COND:.*]]: !s32i loc{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_combined(%[[ARG_N:.*]]: !s32i loc{{.*}}, %[[ARG_COND:.*]]: !s32i loc{{.*}}) {
   // CHECK-NEXT: %[[ALLOCA_N:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["N", init]
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG_N]], %[[ALLOCA_N]] : !s32i, !cir.ptr<!s32i>
@@ -1012,7 +1012,7 @@ extern "C" void acc_combined(int N, int cond) {
   // CHECK-NEXT: } loc
 }
 extern "C" void acc_combined_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func @acc_combined_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_combined_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/compute-copy.c
+++ b/clang/test/CIR/CodeGenOpenACC/compute-copy.c
@@ -2,7 +2,7 @@
 
 int global;
 void acc_compute(int parmVar) {
-  // CHECK: cir.func @acc_compute(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_compute(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[PARM:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["parmVar", init]
   int localVar1;
   short localVar2;
@@ -646,7 +646,7 @@ typedef struct StructTy {
 } Struct ;
 
 void acc_compute_members() {
-  // CHECK: cir.func @acc_compute_members()
+  // CHECK: cir.func{{.*}} @acc_compute_members()
   Struct localStruct;
   // CHECK-NEXT: %[[LOCALSTRUCT:.*]] = cir.alloca !rec_StructTy, !cir.ptr<!rec_StructTy>, ["localStruct"]
 

--- a/clang/test/CIR/CodeGenOpenACC/data.c
+++ b/clang/test/CIR/CodeGenOpenACC/data.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_data(int cond) {
-  // CHECK: cir.func @acc_data(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_data(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 

--- a/clang/test/CIR/CodeGenOpenACC/host_data.c
+++ b/clang/test/CIR/CodeGenOpenACC/host_data.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_host_data(int cond, int var1, int var2) {
-  // CHECK: cir.func @acc_host_data(%[[ARG_COND:.*]]: !s32i {{.*}}, %[[ARG_V1:.*]]: !s32i {{.*}}, %[[ARG_V2:.*]]: !s32i {{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_host_data(%[[ARG_COND:.*]]: !s32i {{.*}}, %[[ARG_V1:.*]]: !s32i {{.*}}, %[[ARG_V2:.*]]: !s32i {{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: %[[V1:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["var1", init]
   // CHECK-NEXT: %[[V2:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["var2", init]

--- a/clang/test/CIR/CodeGenOpenACC/init.c
+++ b/clang/test/CIR/CodeGenOpenACC/init.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_init(int cond) {
-  // CHECK: cir.func @acc_init(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_init(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc init

--- a/clang/test/CIR/CodeGenOpenACC/kernels.c
+++ b/clang/test/CIR/CodeGenOpenACC/kernels.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_kernels(int cond) {
-  // CHECK: cir.func @acc_kernels(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_kernels(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc kernels
@@ -418,7 +418,7 @@ void acc_kernels(int cond) {
 }
 
 void acc_kernels_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func @acc_kernels_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_kernels_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/loop.cpp
+++ b/clang/test/CIR/CodeGenOpenACC/loop.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 extern "C" void acc_loop(int *A, int *B, int *C, int N) {
-  // CHECK: cir.func @acc_loop(%[[ARG_A:.*]]: !cir.ptr<!s32i> loc{{.*}}, %[[ARG_B:.*]]: !cir.ptr<!s32i> loc{{.*}}, %[[ARG_C:.*]]: !cir.ptr<!s32i> loc{{.*}}, %[[ARG_N:.*]]: !s32i loc{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_loop(%[[ARG_A:.*]]: !cir.ptr<!s32i> loc{{.*}}, %[[ARG_B:.*]]: !cir.ptr<!s32i> loc{{.*}}, %[[ARG_C:.*]]: !cir.ptr<!s32i> loc{{.*}}, %[[ARG_N:.*]]: !s32i loc{{.*}}) {
   // CHECK-NEXT: %[[ALLOCA_A:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["A", init]
   // CHECK-NEXT: %[[ALLOCA_B:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["B", init]
   // CHECK-NEXT: %[[ALLOCA_C:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["C", init]

--- a/clang/test/CIR/CodeGenOpenACC/parallel.c
+++ b/clang/test/CIR/CodeGenOpenACC/parallel.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_parallel(int cond) {
-  // CHECK: cir.func @acc_parallel(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_parallel(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc parallel
@@ -445,7 +445,7 @@ void acc_parallel(int cond) {
 }
 
 void acc_parallel_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func @acc_parallel_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_parallel_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/serial.c
+++ b/clang/test/CIR/CodeGenOpenACC/serial.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -Wno-openacc-self-if-potential-conflict -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_serial(int cond) {
-  // CHECK: cir.func @acc_serial(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_serial(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc serial
@@ -268,7 +268,7 @@ void acc_serial(int cond) {
 }
 
 void acc_serial_data_clauses(int *arg1, int *arg2) {
-  // CHECK: cir.func @acc_serial_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_serial_data_clauses(%[[ARG1_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}, %[[ARG2_PARAM:.*]]: !cir.ptr<!s32i>{{.*}}) {
   // CHECK-NEXT: %[[ARG1:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg1", init]
   // CHECK-NEXT: %[[ARG2:.*]] = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["arg2", init]
   // CHECK-NEXT: cir.store %[[ARG1_PARAM]], %[[ARG1]] : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>

--- a/clang/test/CIR/CodeGenOpenACC/set.c
+++ b/clang/test/CIR/CodeGenOpenACC/set.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_set(int cond) {
-  // CHECK: cir.func @acc_set(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_set(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 

--- a/clang/test/CIR/CodeGenOpenACC/shutdown.c
+++ b/clang/test/CIR/CodeGenOpenACC/shutdown.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_shutdown(int cond) {
-  // CHECK: cir.func @acc_shutdown(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_shutdown(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 #pragma acc shutdown

--- a/clang/test/CIR/CodeGenOpenACC/wait.c
+++ b/clang/test/CIR/CodeGenOpenACC/wait.c
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fopenacc -emit-cir -fclangir %s -o - | FileCheck %s
 
 void acc_wait(int cond) {
-  // CHECK: cir.func @acc_wait(%[[ARG:.*]]: !s32i{{.*}}) {
+  // CHECK: cir.func{{.*}} @acc_wait(%[[ARG:.*]]: !s32i{{.*}}) {
   // CHECK-NEXT: %[[COND:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["cond", init]
   // CHECK-NEXT: cir.store %[[ARG]], %[[COND]] : !s32i, !cir.ptr<!s32i>
 

--- a/clang/test/CIR/IR/array.cir
+++ b/clang/test/CIR/IR/array.cir
@@ -33,7 +33,7 @@ cir.func @func() {
   cir.return
 }
 
-// CHECK: cir.func @func() {
+// CHECK: cir.func{{.*}} @func() {
 // CHECK:   %0 = cir.alloca !cir.array<!s32i x 10>, !cir.ptr<!cir.array<!s32i x 10>>, ["l"] {alignment = 4 : i64}
 // CHECK:   cir.return
 // CHECK: }
@@ -44,7 +44,7 @@ cir.func @func2(%arg0: !cir.ptr<!s32i>) {
   cir.return
 }
 
-// CHECK: cir.func @func2(%arg0: !cir.ptr<!s32i>) {
+// CHECK: cir.func{{.*}} @func2(%arg0: !cir.ptr<!s32i>) {
 // CHECK:   %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["p", init] {alignment = 8 : i64}
 // CHECK:   cir.store %arg0, %0 : !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>
 // CHECK:   cir.return
@@ -56,7 +56,7 @@ cir.func @func3(%arg0: !cir.ptr<!cir.array<!s32i x 10>>) {
   cir.return
 }
 
-// CHECK: cir.func @func3(%arg0: !cir.ptr<!cir.array<!s32i x 10>>) {
+// CHECK: cir.func{{.*}} @func3(%arg0: !cir.ptr<!cir.array<!s32i x 10>>) {
 // CHECK:   %0 = cir.alloca !cir.ptr<!cir.array<!s32i x 10>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 10>>>, ["pp", init] {alignment = 8 : i64}
 // CHECK:   cir.store %arg0, %0 : !cir.ptr<!cir.array<!s32i x 10>>, !cir.ptr<!cir.ptr<!cir.array<!s32i x 10>>>
 // CHECK:   cir.return

--- a/clang/test/CIR/IR/binassign.cir
+++ b/clang/test/CIR/IR/binassign.cir
@@ -26,7 +26,7 @@ module {
 // CHECK: !s8i = !cir.int<s, 8>
 // CHECK: #true = #cir.bool<true> : !cir.bool
 // CHECK: module {
-// CHECK:   cir.func @binary_assign() {
+// CHECK:   cir.func{{.*}} @binary_assign() {
 // CHECK:     %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b"] {alignment = 1 : i64}
 // CHECK:     %1 = cir.alloca !s8i, !cir.ptr<!s8i>, ["c"] {alignment = 1 : i64}
 // CHECK:     %2 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["f"] {alignment = 4 : i64}

--- a/clang/test/CIR/IR/call.cir
+++ b/clang/test/CIR/IR/call.cir
@@ -4,7 +4,7 @@
 
 module {
 
-cir.func @f1()
+cir.func private @f1()
 
 cir.func @f2() {
   cir.call @f1() : () -> ()
@@ -13,26 +13,26 @@ cir.func @f2() {
   cir.return
 }
 
-// CHECK:      cir.func @f2() {
+// CHECK:      cir.func{{.*}} @f2() {
 // CHECK-NEXT:   cir.call @f1() : () -> ()
 // CHECK-NEXT:   cir.call @f1() side_effect(pure) : () -> ()
 // CHECK-NEXT:   cir.call @f1() side_effect(const) : () -> ()
 // CHECK-NEXT:   cir.return
 // CHECK-NEXT: }
 
-cir.func @f3() -> !s32i
+cir.func private @f3() -> !s32i
 
 cir.func @f4() -> !s32i {
   %0 = cir.call @f3() : () -> !s32i
   cir.return %0 : !s32i
 }
 
-// CHECK:      cir.func @f4() -> !s32i {
+// CHECK:      cir.func{{.*}} @f4() -> !s32i {
 // CHECK-NEXT:   %[[#x:]] = cir.call @f3() : () -> !s32i
 // CHECK-NEXT:   cir.return %[[#x]] : !s32i
 // CHECK-NEXT: }
 
-cir.func @f5(!s32i, !s32i) -> !s32i
+cir.func private @f5(!s32i, !s32i) -> !s32i
 cir.func @f6() -> !s32i {
   %0 = cir.const #cir.int<1> : !s32i
   %1 = cir.const #cir.int<2> : !s32i
@@ -40,7 +40,7 @@ cir.func @f6() -> !s32i {
   cir.return %2 : !s32i
 }
 
-// CHECK:      cir.func @f6() -> !s32i {
+// CHECK:      cir.func{{.*}} @f6() -> !s32i {
 // CHECK-NEXT:   %[[#a:]] = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:   %[[#b:]] = cir.const #cir.int<2> : !s32i
 // CHECK-NEXT:   %[[#c:]] = cir.call @f5(%[[#a]], %[[#b]]) : (!s32i, !s32i) -> !s32i
@@ -54,7 +54,7 @@ cir.func @f7(%arg0: !cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>) -> !s32i {
   cir.return %2 : !s32i
 }
 
-// CHECK:      cir.func @f7(%[[ptr:.+]]: !cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>) -> !s32i {
+// CHECK:      cir.func{{.*}} @f7(%[[ptr:.+]]: !cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>) -> !s32i {
 // CHECK-NEXT:   %[[#a:]] = cir.const #cir.int<1> : !s32i
 // CHECK-NEXT:   %[[#b:]] = cir.const #cir.int<2> : !s32i
 // CHECK-NEXT:   %[[#ret:]] = cir.call %[[ptr]](%[[#a]], %[[#b]]) : (!cir.ptr<!cir.func<(!s32i, !s32i) -> !s32i>>, !s32i, !s32i) -> !s32i

--- a/clang/test/CIR/IR/cast.cir
+++ b/clang/test/CIR/IR/cast.cir
@@ -15,9 +15,9 @@ module  {
   }
 }
 
-// CHECK: cir.func @yolo(%arg0: !s32i)
+// CHECK: cir.func{{.*}} @yolo(%arg0: !s32i)
 // CHECK: %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
 // CHECK: %1 = cir.const #cir.int<0> : !s32i
 
-// CHECK: cir.func @bitcast
+// CHECK: cir.func{{.*}} @bitcast
 // CHECK: %0 = cir.cast(bitcast, %arg0 : !cir.ptr<!s32i>), !cir.ptr<f32>

--- a/clang/test/CIR/IR/cmp.cir
+++ b/clang/test/CIR/IR/cmp.cir
@@ -36,7 +36,7 @@ module {
     cir.return
   }
 
-  // CHECK: cir.func @c0(%arg0: !s32i, %arg1: !s32i) {
+  // CHECK: cir.func{{.*}} @c0(%arg0: !s32i, %arg1: !s32i) {
   // CHECK-NEXT:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["b", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %2 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init] {alignment = 1 : i64}
@@ -102,7 +102,7 @@ module {
     cir.return
   }
 
-  // CHECK: cir.func @c0_unsigned(%arg0: !u32i, %arg1: !u32i) {
+  // CHECK: cir.func{{.*}} @c0_unsigned(%arg0: !u32i, %arg1: !u32i) {
   // CHECK-NEXT:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %1 = cir.alloca !u32i, !cir.ptr<!u32i>, ["b", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %2 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init] {alignment = 1 : i64}
@@ -168,7 +168,7 @@ module {
     cir.return
   }
 
-  // CHECK: cir.func @c0_float(%arg0: !cir.float, %arg1: !cir.float) {
+  // CHECK: cir.func{{.*}} @c0_float(%arg0: !cir.float, %arg1: !cir.float) {
   // CHECK-NEXT:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["a", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %1 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["b", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %2 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init] {alignment = 1 : i64}
@@ -234,7 +234,7 @@ module {
     cir.return
   }
 
-  // CHECK: cir.func @pointer_cmp(%arg0: !cir.ptr<!s32i>, %arg1: !cir.ptr<!s32i>) {
+  // CHECK: cir.func{{.*}} @pointer_cmp(%arg0: !cir.ptr<!s32i>, %arg1: !cir.ptr<!s32i>) {
   // CHECK-NEXT:   %0 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["a", init] {alignment = 8 : i64}
   // CHECK-NEXT:   %1 = cir.alloca !cir.ptr<!s32i>, !cir.ptr<!cir.ptr<!s32i>>, ["b", init] {alignment = 8 : i64}
   // CHECK-NEXT:   %2 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init] {alignment = 1 : i64}
@@ -312,7 +312,7 @@ module {
     cir.return
   }
 
-  // CHECK: cir.func @bool_cmp(%arg0: !cir.bool, %arg1: !cir.bool) {
+  // CHECK: cir.func{{.*}} @bool_cmp(%arg0: !cir.bool, %arg1: !cir.bool) {
   // CHECK-NEXT:   %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["a", init] {alignment = 1 : i64}
   // CHECK-NEXT:   %1 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["b", init] {alignment = 1 : i64}
   // CHECK-NEXT:   %2 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["x", init] {alignment = 1 : i64}

--- a/clang/test/CIR/IR/func.cir
+++ b/clang/test/CIR/IR/func.cir
@@ -10,7 +10,7 @@ module {
 cir.func @empty() {
   cir.return
 }
-// CHECK: cir.func @empty() {
+// CHECK: cir.func{{.*}} @empty() {
 // CHECK:   cir.return
 // CHECK: }
 
@@ -18,7 +18,7 @@ cir.func @empty() {
 cir.func @voidret() {
   cir.return
 }
-// CHECK: cir.func @voidret() {
+// CHECK: cir.func{{.*}} @voidret() {
 // CHECK:   cir.return
 // CHECK: }
 
@@ -27,7 +27,7 @@ cir.func @intfunc() -> !s32i {
   %0 = cir.const #cir.int<42> : !s32i
   cir.return %0 : !s32i
 }
-// CHECK: cir.func @intfunc() -> !s32i {
+// CHECK: cir.func{{.*}} @intfunc() -> !s32i {
 // CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !s32i
 // CHECK:   cir.return %[[VAL]] : !s32i
 // CHECK: }
@@ -48,7 +48,7 @@ cir.func @scopes() -> !s32i {
   }
   cir.trap
 }
-// CHECK: cir.func @scopes() -> !s32i {
+// CHECK: cir.func{{.*}} @scopes() -> !s32i {
 // CHECK:   cir.scope {
 // CHECK:     cir.scope {
 // CHECK:       %[[VAL:.*]] = cir.const #cir.int<99> : !s32i
@@ -63,7 +63,7 @@ cir.func @longfunc() -> !s64i {
   %0 = cir.const #cir.int<42> : !s64i
   cir.return %0 : !s64i
 }
-// CHECK: cir.func @longfunc() -> !s64i
+// CHECK: cir.func{{.*}} @longfunc() -> !s64i
 // CHECK:   %0 = cir.const #cir.int<42> : !s64i
 // CHECK:   cir.return %0 : !s64i
 // CHECK: }
@@ -73,7 +73,7 @@ cir.func @unsignedfunc() -> !u32i {
   %0 = cir.const #cir.int<42> : !u32i
   cir.return %0 : !u32i
 }
-// CHECK: cir.func @unsignedfunc() -> !u32i
+// CHECK: cir.func{{.*}} @unsignedfunc() -> !u32i
 // CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !u32i
 // CHECK:   cir.return %[[VAL]] : !u32i
 // CHECK: }
@@ -83,7 +83,7 @@ cir.func @ullfunc() -> !u64i {
   %0 = cir.const #cir.int<42> : !u64i
   cir.return %0 : !u64i
 }
-// CHECK: cir.func @ullfunc() -> !u64i
+// CHECK: cir.func{{.*}} @ullfunc() -> !u64i
 // CHECK:   %[[VAL:.*]] = cir.const #cir.int<42> : !u64i
 // CHECK:   cir.return %[[VAL:.*]] : !u64i
 // CHECK: }

--- a/clang/test/CIR/IR/invalid-call.cir
+++ b/clang/test/CIR/IR/invalid-call.cir
@@ -12,7 +12,7 @@ cir.func @f1() {
 
 !u32i = !cir.int<u, 32>
 
-cir.func @f2()
+cir.func private @f2()
 cir.func @f3() {
   // expected-error @below {{callee returns void but call has results}}
   %0 = cir.call @f2() : () -> !u32i
@@ -23,7 +23,7 @@ cir.func @f3() {
 
 !u32i = !cir.int<u, 32>
 
-cir.func @f4() -> !u32i
+cir.func private @f4() -> !u32i
 cir.func @f5() {
   // expected-error @below {{incorrect number of results for callee}}
   cir.call @f4() : () -> ()
@@ -35,7 +35,7 @@ cir.func @f5() {
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-cir.func @f6() -> !u32i
+cir.func private @f6() -> !u32i
 cir.func @f7() {
   // expected-error @below {{result type mismatch}}
   %0 = cir.call @f6() : () -> !s32i
@@ -47,7 +47,7 @@ cir.func @f7() {
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-cir.func @f8(!s32i, !s32i)
+cir.func private @f8(!s32i, !s32i)
 cir.func @f9() {
   %0 = cir.const #cir.int<1> : !s32i
   // expected-error @below {{incorrect number of operands for callee}}
@@ -60,7 +60,7 @@ cir.func @f9() {
 !s32i = !cir.int<s, 32>
 !u32i = !cir.int<u, 32>
 
-cir.func @f10(!s32i, !s32i)
+cir.func private @f10(!s32i, !s32i)
 cir.func @f11() {
   %0 = cir.const #cir.int<1> : !s32i
   %1 = cir.const #cir.int<2> : !u32i
@@ -73,7 +73,7 @@ cir.func @f11() {
 
 !s32i = !cir.int<s, 32>
 
-cir.func @f12(!s32i, !s32i, ...)
+cir.func private @f12(!s32i, !s32i, ...)
 cir.func @f13() {
   %0 = cir.const #cir.int<1> : !s32i
   // expected-error @below {{too few operands for callee}}

--- a/clang/test/CIR/IR/ternary.cir
+++ b/clang/test/CIR/IR/ternary.cir
@@ -16,7 +16,7 @@ module  {
 
 // CHECK: module  {
 
-// CHECK: cir.func @blue(%arg0: !cir.bool) -> !u32i {
+// CHECK: cir.func{{.*}} @blue(%arg0: !cir.bool) -> !u32i {
 // CHECK:   %0 = cir.ternary(%arg0, true {
 // CHECK:     %1 = cir.const #cir.int<0> : !u32i
 // CHECK:     cir.yield %1 : !u32i

--- a/clang/test/CIR/IR/unary.cir
+++ b/clang/test/CIR/IR/unary.cir
@@ -16,7 +16,7 @@ module {
     %6 = cir.unary(dec, %1) : !u32i, !u32i
     cir.return
   }
-// CHECK: cir.func @test_unary_unsigned() {
+// CHECK: cir.func{{.*}} @test_unary_unsigned() {
 // CHECK:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.load %0 : !cir.ptr<!u32i>, !u32i
 // CHECK:   %2 = cir.unary(plus, %1) : !u32i, !u32i
@@ -37,7 +37,7 @@ module {
     %6 = cir.unary(dec, %1) nsw : !s32i, !s32i
     cir.return
   }
-// CHECK: cir.func @test_unary_signed() {
+// CHECK: cir.func{{.*}} @test_unary_signed() {
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.load %0 : !cir.ptr<!s32i>, !s32i
 // CHECK:   %2 = cir.unary(plus, %1) : !s32i, !s32i

--- a/clang/test/CIR/IR/vector.cir
+++ b/clang/test/CIR/IR/vector.cir
@@ -26,7 +26,7 @@ cir.func @vec_int_test() {
   cir.return
 }
 
-// CHECK: cir.func @vec_int_test() {
+// CHECK: cir.func{{.*}} @vec_int_test() {
 // CHECK:  %0 = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a"]
 // CHECK:  %1 = cir.alloca !cir.vector<3 x !s32i>, !cir.ptr<!cir.vector<3 x !s32i>>, ["b"]
 // CHECK:  %2 = cir.alloca !cir.vector<2 x !s32i>, !cir.ptr<!cir.vector<2 x !s32i>>, ["c"]
@@ -38,7 +38,7 @@ cir.func @vec_double_test() {
   cir.return
 }
 
-// CHECK: cir.func @vec_double_test() {
+// CHECK: cir.func{{.*}} @vec_double_test() {
 // CHECK:  %0 = cir.alloca !cir.vector<2 x !cir.double>, !cir.ptr<!cir.vector<2 x !cir.double>>, ["a"]
 // CHECK:  cir.return
 // CHECK: }
@@ -54,7 +54,7 @@ cir.func @local_vector_create_test() {
     cir.return
 }
 
-// CHECK: cir.func @local_vector_create_test() {
+// CHECK: cir.func{{.*}} @local_vector_create_test() {
 // CHECK:   %0 = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a", init]
 // CHECK:   %1 = cir.const #cir.int<1> : !s32i
 // CHECK:   %2 = cir.const #cir.int<2> : !s32i
@@ -81,7 +81,7 @@ cir.func @vector_extract_element_test() {
     cir.return
 }
 
-// CHECK: cir.func @vector_extract_element_test() {
+// CHECK: cir.func{{.*}} @vector_extract_element_test() {
 // CHECK:    %0 = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["d", init]
 // CHECK:    %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["e", init]
 // CHECK:    %2 = cir.const #cir.int<1> : !s32i
@@ -116,7 +116,7 @@ cir.func @vector_insert_element_test() {
     cir.return
 }
 
-// CHECK: cir.func @vector_insert_element_test() {
+// CHECK: cir.func{{.*}} @vector_insert_element_test() {
 // CHECK:    %0 = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a", init]
 // CHECK:    %1 = cir.const #cir.int<1> : !s32i
 // CHECK:    %2 = cir.const #cir.int<2> : !s32i
@@ -150,7 +150,7 @@ cir.func @vector_compare_test() {
     cir.return
 }
 
-// CHECK: cir.func @vector_compare_test() {
+// CHECK: cir.func{{.*}} @vector_compare_test() {
 // CHECK:    %[[VEC_A:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a"]
 // CHECK:    %[[VEC_B:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["b"]
 // CHECK:    %[[INIT:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["o", init]
@@ -176,7 +176,7 @@ cir.func @vector_shuffle_dynamic_test() {
     cir.return
 }
 
-// CHECK: cir.func @vector_shuffle_dynamic_test() {
+// CHECK: cir.func{{.*}} @vector_shuffle_dynamic_test() {
 // CHECK:    %[[VEC_A:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a"]
 // CHECK:    %[[VEC_B:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["b"]
 // CHECK:    %[[RES:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["r", init]
@@ -204,7 +204,7 @@ cir.func @vector_splat_test() {
     cir.return
 }
 
-// CHECK: cir.func @vector_splat_test() {
+// CHECK: cir.func{{.*}} @vector_splat_test() {
 // CHECK-NEXT: %[[VEC:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["a", init]
 // CHECK-NEXT: %[[SHL_RES:.*]] = cir.alloca !cir.vector<4 x !s32i>, !cir.ptr<!cir.vector<4 x !s32i>>, ["shl", init]
 // CHECK-NEXT: %[[CONST_1:.*]] = cir.const #cir.int<1> : !s32i

--- a/clang/test/CIR/Lowering/array.cpp
+++ b/clang/test/CIR/Lowering/array.cpp
@@ -41,7 +41,7 @@ void func() {
   int e = arr[0];
   int e2 = arr[1];
 }
-// CHECK: define void @_Z4funcv()
+// CHECK: define{{.*}} void @_Z4funcv()
 // CHECK-NEXT: %[[ARR_ALLOCA:.*]] = alloca [10 x i32], i64 1, align 16
 // CHECK-NEXT: %[[INIT:.*]] = alloca i32, i64 1, align 4
 // CHECK-NEXT: %[[INIT_2:.*]] = alloca i32, i64 1, align 4
@@ -57,7 +57,7 @@ void func() {
 void func2() {
   int arr[2] = {5};
 }
-// CHECK: define void @_Z5func2v()
+// CHECK: define{{.*}} void @_Z5func2v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x i32], i64 1, align 4
 // CHECK:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr i32, ptr %[[ARR_ALLOCA]], i32 0
@@ -72,7 +72,7 @@ void func2() {
 void func3() {
   int arr3[2] = {5, 6};
 }
-// CHECK: define void @_Z5func3v()
+// CHECK: define{{.*}} void @_Z5func3v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x i32], i64 1, align 4
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr i32, ptr %[[ARR_ALLOCA]], i32 0
 // CHECK:  store i32 5, ptr %[[ARR_PTR]], align 4
@@ -83,7 +83,7 @@ void func4() {
   int arr[2][1] = {{5}, {6}};
   int e = arr[1][0];
 }
-// CHECK: define void @_Z5func4v()
+// CHECK: define{{.*}} void @_Z5func4v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // CHECK:  %[[INIT:.*]] = alloca i32, i64 1, align 4
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR_ALLOCA]], i32 0
@@ -102,7 +102,7 @@ void func4() {
 void func5() {
   int arr[2][1] = {{5}};
 }
-// CHECK: define void @_Z5func5v()
+// CHECK: define{{.*}} void @_Z5func5v()
 // CHECK:  %[[ARR_ALLOCA:.*]] = alloca [2 x [1 x i32]], i64 1, align 4
 // CHECK:  %[[TMP:.*]] = alloca ptr, i64 1, align 8
 // CHECK:  %[[ARR_PTR:.*]] = getelementptr [1 x i32], ptr %[[ARR_ALLOCA]], i32 0
@@ -119,7 +119,7 @@ void func6() {
   int x = 4;
   int arr[2] = { x, 5 };
 }
-// CHECK: define void @_Z5func6v()
+// CHECK: define{{.*}} void @_Z5func6v()
 // CHECK:  %[[VAR:.*]] = alloca i32, i64 1, align 4
 // CHECK:  %[[ARR:.*]] = alloca [2 x i32], i64 1, align 4
 // CHECK:  store i32 4, ptr %[[VAR]], align 4
@@ -132,7 +132,7 @@ void func6() {
 void func7() {
   int* arr[1] = {};
 }
-// CHECK: define void @_Z5func7v()
+// CHECK: define{{.*}} void @_Z5func7v()
 // CHECK:  %[[ARR:.*]] = alloca [1 x ptr], i64 1, align 8
 // CHECK:  %[[ALLOCA:.*]] = alloca ptr, i64 1, align 8
 // CHECK:  %[[ELE_PTR:.*]] = getelementptr ptr, ptr %[[ARR]], i32 0
@@ -143,9 +143,9 @@ void func7() {
 // CHECK:  store ptr %[[ELE]], ptr %[[ALLOCA]], align 8
 
 void func8(int p[10]) {}
-// CHECK: define void @_Z5func8Pi(ptr {{%.*}})
+// CHECK: define{{.*}} void @_Z5func8Pi(ptr {{%.*}})
 // CHECK-NEXT: alloca ptr, i64 1, align 8
 
 void func9(int pp[10][5]) {}
-// CHECK: define void @_Z5func9PA5_i(ptr {{%.*}})
+// CHECK: define{{.*}} void @_Z5func9PA5_i(ptr {{%.*}})
 // CHECK-NEXT: alloca ptr, i64 1, align 8

--- a/clang/test/CIR/Transforms/canonicalize.cir
+++ b/clang/test/CIR/Transforms/canonicalize.cir
@@ -15,7 +15,7 @@ module {
   ^bb2:  // pred: ^bb1
     cir.return
   }
-  // CHECK:      cir.func @redundant_br() {
+  // CHECK:      cir.func{{.*}} @redundant_br() {
   // CHECK-NEXT:   %[[A:.*]] = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
   // CHECK-NEXT:   %[[FOUR:.*]] = cir.const #cir.int<4> : !u32i
   // CHECK-NEXT:   cir.store %[[FOUR]], %[[A]] : !u32i, !cir.ptr<!u32i>
@@ -27,7 +27,7 @@ module {
     }
     cir.return
   }
-  // CHECK:      cir.func @empty_scope() {
+  // CHECK:      cir.func{{.*}} @empty_scope() {
   // CHECK-NEXT:   cir.return
   // CHECK-NEXT: }
 
@@ -36,7 +36,7 @@ module {
     %1 = cir.unary(not, %0) : !cir.bool, !cir.bool
     cir.return %1 : !cir.bool
   }
-  // CHECK:      cir.func @unary_not(%arg0: !cir.bool) -> !cir.bool
+  // CHECK:      cir.func{{.*}} @unary_not(%arg0: !cir.bool) -> !cir.bool
   // CHECK-NEXT:   cir.return %arg0 : !cir.bool
 
   cir.func @cast1(%arg0: !cir.bool) -> !cir.bool {
@@ -44,7 +44,7 @@ module {
     %1 = cir.cast(int_to_bool, %0 : !s32i), !cir.bool
     cir.return %1 : !cir.bool
   }
-  // CHECK:      cir.func @cast1(%[[ARG0:.*]]: !cir.bool) -> !cir.bool
+  // CHECK:      cir.func{{.*}} @cast1(%[[ARG0:.*]]: !cir.bool) -> !cir.bool
   // CHECK-NEXT:   cir.return %[[ARG0]] : !cir.bool
 
   cir.func @cast2(%arg0: !s32i) -> !cir.bool {
@@ -54,7 +54,7 @@ module {
     %3 = cir.cast(int_to_bool, %2 : !s64i), !cir.bool
     cir.return %3 : !cir.bool
   }
-  // CHECK:      cir.func @cast2(%[[ARG0:.*]]: !s32i) -> !cir.bool
+  // CHECK:      cir.func{{.*}} @cast2(%[[ARG0:.*]]: !s32i) -> !cir.bool
   // CHECK-NEXT:   %[[CAST:.*]] = cir.cast(int_to_bool, %[[ARG0]] : !s32i), !cir.bool
   // CHECK-NEXT:   cir.return %[[CAST]] : !cir.bool
 
@@ -64,7 +64,7 @@ module {
     %2 = cir.cast(integral, %1 : !s32i), !s64i
     cir.return %2 : !s64i
   }
-  // CHECK:      cir.func @no_fold_cast(%[[ARG0:.*]]: !s32i) -> !s64i
+  // CHECK:      cir.func{{.*}} @no_fold_cast(%[[ARG0:.*]]: !s32i) -> !s64i
   // CHECK-NEXT:   %[[CAST:.*]] = cir.cast(int_to_bool, %[[ARG0]] : !s32i), !cir.bool
   // CHECK-NEXT:   %[[CAST2:.*]] = cir.cast(bool_to_int, %[[CAST]] : !cir.bool), !s32i
   // CHECK-NEXT:   %[[CAST3:.*]] = cir.cast(integral, %[[CAST2]] : !s32i), !s64i

--- a/clang/test/CIR/Transforms/complex-create-fold.cir
+++ b/clang/test/CIR/Transforms/complex-create-fold.cir
@@ -16,7 +16,7 @@ module {
     cir.return %6 : !cir.complex<!s32i>
   }
 
-// CHECK: cir.func @fold_complex_create_test() -> !cir.complex<!s32i> {
+// CHECK: cir.func{{.*}} @fold_complex_create_test() -> !cir.complex<!s32i> {
 // CHECK:   %[[RET:.*]] = cir.alloca !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>, ["__retval"]
 // CHECK:   %[[INIT:.*]] = cir.alloca !cir.complex<!s32i>, !cir.ptr<!cir.complex<!s32i>>, ["c", init]
 // CHECK:   %[[COMPLEX:.*]] = cir.const #cir.const_complex<#cir.int<1> : !s32i, #cir.int<2> : !s32i> : !cir.complex<!s32i>

--- a/clang/test/CIR/Transforms/hoist-allocas.cir
+++ b/clang/test/CIR/Transforms/hoist-allocas.cir
@@ -20,7 +20,7 @@ module {
     }
     cir.return
   }
-  // CHECK:      cir.func @l1
+  // CHECK:      cir.func{{.*}} @l1
   // CHECK-NEXT:   %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
   // CHECK-NEXT:   cir.scope {
   // CHECK-NEXT:     %[[ZERO:.*]] = cir.const #cir.int<0> : !s32i
@@ -55,7 +55,7 @@ module {
     }
     cir.return
   }
-  // CHECK:      cir.func @l2
+  // CHECK:      cir.func{{.*}} @l2
   // CHECK-NEXT:   %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
   // CHECK-NEXT:   cir.scope {
   // CHECK-NEXT:     cir.for : cond {
@@ -92,7 +92,7 @@ module {
     }
     cir.return
   }
-  // CHECK:      cir.func @l3
+  // CHECK:      cir.func{{.*}} @l3
   // CHECK-NEXT:   %[[I:.*]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["i", init] {alignment = 4 : i64}
   // CHECK-NEXT:   cir.scope {
   // CHECK-NEXT:     cir.for : cond {

--- a/clang/test/CIR/Transforms/if.cir
+++ b/clang/test/CIR/Transforms/if.cir
@@ -14,7 +14,7 @@ module {
     }
     cir.return %arg0 : !s32i
   }
-//      CHECK: cir.func @foo(%arg0: !s32i) -> !s32i {
+//      CHECK: cir.func{{.*}} @foo(%arg0: !s32i) -> !s32i {
 // CHECK-NEXT:   %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
 // CHECK-NEXT:   cir.brcond %0 ^bb1, ^bb2
 // CHECK-NEXT: ^bb1:  // pred: ^bb0
@@ -35,7 +35,7 @@ module {
     }
     cir.return %arg0 : !s32i
   }
-//      CHECK: cir.func @onlyIf(%arg0: !s32i) -> !s32i {
+//      CHECK: cir.func{{.*}} @onlyIf(%arg0: !s32i) -> !s32i {
 // CHECK-NEXT:   %0 = cir.cast(int_to_bool, %arg0 : !s32i), !cir.bool
 // CHECK-NEXT:   cir.brcond %0 ^bb1, ^bb2
 // CHECK-NEXT: ^bb1:  // pred: ^bb0

--- a/clang/test/CIR/Transforms/loop.cir
+++ b/clang/test/CIR/Transforms/loop.cir
@@ -16,7 +16,7 @@ module {
   }
 }
 
-// CHECK:  cir.func @testFor(%arg0: !cir.bool) {
+// CHECK:  cir.func{{.*}} @testFor(%arg0: !cir.bool) {
 // CHECK:    cir.br ^bb[[#COND:]]
 // CHECK:  ^bb[[#COND]]:
 // CHECK:    cir.brcond %arg0 ^bb[[#BODY:]], ^bb[[#EXIT:]]
@@ -38,7 +38,7 @@ module {
     cir.return
   }
 
-// CHECK:  cir.func @testWhile(%arg0: !cir.bool) {
+// CHECK:  cir.func{{.*}} @testWhile(%arg0: !cir.bool) {
 // CHECK:    cir.br ^bb[[#COND:]]
 // CHECK:  ^bb[[#COND]]:
 // CHECK:    cir.brcond %arg0 ^bb[[#BODY:]], ^bb[[#EXIT:]]
@@ -59,7 +59,7 @@ module {
     cir.return
   }
 
-// CHECK:  cir.func @testDoWhile(%arg0: !cir.bool) {
+// CHECK:  cir.func{{.*}} @testDoWhile(%arg0: !cir.bool) {
 // CHECK:    cir.br ^bb[[#BODY:]]
 // CHECK:  ^bb[[#COND]]:
 // CHECK:    cir.brcond %arg0 ^bb[[#BODY:]], ^bb[[#EXIT:]]

--- a/clang/test/CIR/Transforms/scope.cir
+++ b/clang/test/CIR/Transforms/scope.cir
@@ -11,7 +11,7 @@ module {
     }
     cir.return
   }
-// CHECK:  cir.func @foo() {
+// CHECK:  cir.func{{.*}} @foo() {
 // CHECK:    cir.br ^bb1
 // CHECK:  ^bb1:  // pred: ^bb0
 // CHECK:    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["a", init] {alignment = 4 : i64}
@@ -28,7 +28,7 @@ module {
     }
     cir.return
   }
-// CHECK:  cir.func @empty_scope() {
+// CHECK:  cir.func{{.*}} @empty_scope() {
 // CHECK:    cir.return
 // CHECK:  }
 
@@ -44,7 +44,7 @@ module {
     cir.return %1 : !u32i
   }
 
-// CHECK:  cir.func @scope_with_return() -> !u32i {
+// CHECK:  cir.func{{.*}} @scope_with_return() -> !u32i {
 // CHECK:    %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:    cir.br ^bb1
 // CHECK:  ^bb1:  // pred: ^bb0

--- a/clang/test/CIR/Transforms/select.cir
+++ b/clang/test/CIR/Transforms/select.cir
@@ -10,7 +10,7 @@ module {
     cir.return %1 : !s32i
   }
 
-  //      CHECK: cir.func @fold_true(%[[ARG0:.+]]: !s32i, %[[ARG1:.+]]: !s32i) -> !s32i {
+  //      CHECK: cir.func{{.*}} @fold_true(%[[ARG0:.+]]: !s32i, %[[ARG1:.+]]: !s32i) -> !s32i {
   // CHECK-NEXT:   cir.return %[[ARG0]] : !s32i
   // CHECK-NEXT: }
 
@@ -20,7 +20,7 @@ module {
     cir.return %1 : !s32i
   }
 
-  //      CHECK: cir.func @fold_false(%[[ARG0:.+]]: !s32i, %[[ARG1:.+]]: !s32i) -> !s32i {
+  //      CHECK: cir.func{{.*}} @fold_false(%[[ARG0:.+]]: !s32i, %[[ARG1:.+]]: !s32i) -> !s32i {
   // CHECK-NEXT:   cir.return %[[ARG1]] : !s32i
   // CHECK-NEXT: }
 
@@ -30,7 +30,7 @@ module {
     cir.return %1 : !s32i
   }
 
-  //      CHECK: cir.func @fold_to_const(%{{.+}}: !cir.bool) -> !s32i {
+  //      CHECK: cir.func{{.*}} @fold_to_const(%{{.+}}: !cir.bool) -> !s32i {
   // CHECK-NEXT:   %[[#A:]] = cir.const #cir.int<42> : !s32i
   // CHECK-NEXT:   cir.return %[[#A]] : !s32i
   // CHECK-NEXT: }
@@ -42,7 +42,7 @@ module {
     cir.return %2 : !cir.bool
   }
 
-  //      CHECK: cir.func @simplify_1(%[[ARG0:.+]]: !cir.bool) -> !cir.bool {
+  //      CHECK: cir.func{{.*}} @simplify_1(%[[ARG0:.+]]: !cir.bool) -> !cir.bool {
   // CHECK-NEXT:   cir.return %[[ARG0]] : !cir.bool
   // CHECK-NEXT: }
 
@@ -53,7 +53,7 @@ module {
     cir.return %2 : !cir.bool
   }
 
-  //      CHECK: cir.func @simplify_2(%[[ARG0:.+]]: !cir.bool) -> !cir.bool {
+  //      CHECK: cir.func{{.*}} @simplify_2(%[[ARG0:.+]]: !cir.bool) -> !cir.bool {
   // CHECK-NEXT:   %[[#A:]] = cir.unary(not, %[[ARG0]]) : !cir.bool, !cir.bool
   // CHECK-NEXT:   cir.return %[[#A]] : !cir.bool
   // CHECK-NEXT: }

--- a/clang/test/CIR/Transforms/switch.cir
+++ b/clang/test/CIR/Transforms/switch.cir
@@ -17,7 +17,7 @@ module {
     }
     cir.return
   }
-// CHECK:  cir.func @shouldFlatSwitchWithDefault(%arg0: !s8i) {
+// CHECK:  cir.func{{.*}} @shouldFlatSwitchWithDefault(%arg0: !s8i) {
 // CHECK:    cir.switch.flat %arg0 : !s8i, ^bb[[#DEFAULT:]] [
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
@@ -38,7 +38,7 @@ module {
     }
     cir.return
   }
-// CHECK:  cir.func @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
+// CHECK:  cir.func{{.*}} @shouldFlatSwitchWithoutDefault(%arg0: !s32i) {
 // CHECK:    cir.switch.flat %arg0 : !s32i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
@@ -58,7 +58,7 @@ module {
     }
     cir.return
   }
-// CHECK:  cir.func @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
+// CHECK:  cir.func{{.*}} @shouldFlatSwitchWithImplicitFallthrough(%arg0: !s64i) {
 // CHECK:    cir.switch.flat %arg0 : !s64i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1N2:]],
 // CHECK:      2: ^bb[[#CASE1N2]]
@@ -83,7 +83,7 @@ module {
       }
     cir.return
   }
-// CHECK:  cir.func @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
+// CHECK:  cir.func{{.*}} @shouldFlatSwitchWithExplicitFallthrough(%arg0: !s64i) {
 // CHECK:    cir.switch.flat %arg0 : !s64i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1:]],
 // CHECK:      2: ^bb[[#CASE2:]]
@@ -105,7 +105,7 @@ module {
       }
     cir.return
   }
-// CHECK:  cir.func @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
+// CHECK:  cir.func{{.*}} @shouldFlatSwitchWithFallthroughToExit(%arg0: !s64i) {
 // CHECK:    cir.switch.flat %arg0 : !s64i, ^bb[[#EXIT:]] [
 // CHECK:      1: ^bb[[#CASE1:]]
 // CHECK:    ]
@@ -122,7 +122,7 @@ module {
     // CHECK-NOT: llvm.switch
     cir.return
   }
-// CHECK:      cir.func @shouldDropEmptySwitch(%arg0: !s64i)
+// CHECK:      cir.func{{.*}} @shouldDropEmptySwitch(%arg0: !s64i)
 // CHECK-NOT:    cir.switch.flat
 
 
@@ -143,7 +143,7 @@ module {
     cir.return
   }
 
-// CHECK:  cir.func @shouldFlatMultiBlockCase(%arg0: !s32i) {
+// CHECK:  cir.func{{.*}} @shouldFlatMultiBlockCase(%arg0: !s32i) {
 // CHECK:     %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init] {alignment = 4 : i64}
 // CHECK:     cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
 // CHECK:     cir.br ^bb1
@@ -189,7 +189,7 @@ module {
     %4 = cir.load %2 : !cir.ptr<!s32i>, !s32i
     cir.return %4 : !s32i
   }
-// CHECK:  cir.func @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+// CHECK:  cir.func{{.*}} @shouldFlatNestedBreak(%arg0: !s32i, %arg1: !s32i) -> !s32i {
 // CHECK:    cir.switch.flat %[[COND:.*]] : !s32i, ^bb[[#DEFAULT_BB:]] [
 // CHECK:      0: ^bb[[#BB1:]]
 // CHECK:    ]
@@ -243,7 +243,7 @@ module {
     %5 = cir.load %1 : !cir.ptr<!s32i>, !s32i
     cir.return %5 : !s32i
   }
-//      CHECK:  cir.func @flatCaseRange(%arg0: !s32i) -> !s32i {
+//      CHECK:  cir.func{{.*}} @flatCaseRange(%arg0: !s32i) -> !s32i {
 //      CHECK:    cir.switch.flat %[[X:[0-9]+]] : !s32i, ^[[JUDGE_RANGE:bb[0-9]+]] [
 // CHECK-NEXT:      -100: ^[[CASE_EQUAL:bb[0-9]+]]
 // CHECK-NEXT:    ]
@@ -293,7 +293,7 @@ module {
     cir.return
   }
 
-// CHECK:  cir.func @_Z8bigRangei(%arg0: !s32i) {
+// CHECK:  cir.func{{.*}} @_Z8bigRangei(%arg0: !s32i) {
 // CHECK:    cir.switch.flat %[[COND:.*]] : !s32i, ^bb[[#RANGE_BR:]] [
 // CHECK:    ]
 // CHECK:  ^bb[[#NO_PRED_BB:]]:  // no predecessors

--- a/clang/test/CIR/Transforms/ternary-fold.cir
+++ b/clang/test/CIR/Transforms/ternary-fold.cir
@@ -14,7 +14,7 @@ module {
     cir.return %1 : !s32i
   }
 
-  //      CHECK: cir.func @fold_ternary(%{{.+}}: !s32i, %[[ARG:.+]]: !s32i) -> !s32i {
+  //      CHECK: cir.func{{.*}} @fold_ternary(%{{.+}}: !s32i, %[[ARG:.+]]: !s32i) -> !s32i {
   // CHECK-NEXT:   cir.return %[[ARG]] : !s32i
   // CHECK-NEXT: }
 
@@ -28,7 +28,7 @@ module {
     cir.return %0 : !s32i
   }
 
-  //      CHECK: cir.func @simplify_ternary(%[[ARG0:.+]]: !cir.bool, %[[ARG1:.+]]: !s32i) -> !s32i {
+  //      CHECK: cir.func{{.*}} @simplify_ternary(%[[ARG0:.+]]: !cir.bool, %[[ARG1:.+]]: !s32i) -> !s32i {
   // CHECK-NEXT:   %[[#A:]] = cir.const #cir.int<42> : !s32i
   // CHECK-NEXT:   %[[#B:]] = cir.select if %[[ARG0]] then %[[#A]] else %[[ARG1]] : (!cir.bool, !s32i, !s32i) -> !s32i
   // CHECK-NEXT:   cir.return %[[#B]] : !s32i
@@ -44,7 +44,7 @@ module {
     cir.return %0 : !s32i
   }
 
-  //      CHECK: cir.func @simplify_ternary_false_const(%[[ARG0:.+]]: !cir.bool, %[[ARG1:.+]]: !s32i) -> !s32i {
+  //      CHECK: cir.func{{.*}} @simplify_ternary_false_const(%[[ARG0:.+]]: !cir.bool, %[[ARG1:.+]]: !s32i) -> !s32i {
   // CHECK-NEXT:   %[[#A:]] = cir.const #cir.int<24> : !s32i
   // CHECK-NEXT:   %[[#B:]] = cir.select if %[[ARG0]] then %[[ARG1]] else %[[#A]] : (!cir.bool, !s32i, !s32i) -> !s32i
   // CHECK-NEXT:   cir.return %[[#B]] : !s32i
@@ -62,7 +62,7 @@ module {
     cir.return %1 : !s32i
   }
 
-  //      CHECK: cir.func @non_simplifiable_ternary(%[[ARG0:.+]]: !cir.bool) -> !s32i {
+  //      CHECK: cir.func{{.*}} @non_simplifiable_ternary(%[[ARG0:.+]]: !cir.bool) -> !s32i {
   // CHECK-NEXT:   %[[#A:]] = cir.alloca !s32i, !cir.ptr<!s32i>, ["a", init]
   // CHECK-NEXT:   %[[#B:]] = cir.ternary(%[[ARG0]], true {
   // CHECK-NEXT:     %[[#C:]] = cir.const #cir.int<42> : !s32i

--- a/clang/test/CIR/Transforms/ternary.cir
+++ b/clang/test/CIR/Transforms/ternary.cir
@@ -22,7 +22,7 @@ module {
     cir.return %6 : !s32i
   }
 
-// CHECK: cir.func @foo(%arg0: !s32i) -> !s32i {
+// CHECK: cir.func{{.*}} @foo(%arg0: !s32i) -> !s32i {
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["y", init] {alignment = 4 : i64}
 // CHECK:   %1 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.store %arg0, %0 : !s32i, !cir.ptr<!s32i>
@@ -53,7 +53,7 @@ module {
     cir.return
   }
 
-// CHECK: cir.func @foo2(%arg0: !cir.bool) {
+// CHECK: cir.func{{.*}} @foo2(%arg0: !cir.bool) {
 // CHECK:   cir.brcond %arg0 ^bb1, ^bb2
 // CHECK: ^bb1:  // pred: ^bb0
 // CHECK:   cir.br ^bb3

--- a/clang/test/CIR/Transforms/vector-cmp-fold.cir
+++ b/clang/test/CIR/Transforms/vector-cmp-fold.cir
@@ -10,7 +10,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i,
   // CHECK-SAME: #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -28,7 +28,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<1> : !s32i,
   // CHECK-SAME: #cir.int<1> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -46,7 +46,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<1> : !s32i,
   // CHECK-SAME: #cir.int<1> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -64,7 +64,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<1> : !s32i,
   // CHECK-SAME: #cir.int<1> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -82,7 +82,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i,
   // CHECK-SAME: #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -100,7 +100,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i,
   // CHECK-SAME: #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -120,7 +120,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i,
   // CHECK-SAME: #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -140,7 +140,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<1> : !s32i,
   // CHECK-SAME: #cir.int<1> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -160,7 +160,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<1> : !s32i,
   // CHECK-SAME: #cir.int<1> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -180,7 +180,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<1> : !s32i,
   // CHECK-SAME: #cir.int<1> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -200,7 +200,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i,
   // CHECK-SAME: #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -220,7 +220,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_cmp_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<0> : !s32i, #cir.int<0> : !s32i,
   // CHECK-SAME: #cir.int<0> : !s32i, #cir.int<0> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>

--- a/clang/test/CIR/Transforms/vector-create-fold.cir
+++ b/clang/test/CIR/Transforms/vector-create-fold.cir
@@ -12,7 +12,7 @@ module  {
     cir.return %vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK:  cir.func @fold_create_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK:  cir.func{{.*}} @fold_create_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[VEC:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<2> : !s32i,
   // CHECK-SAME: #cir.int<3> : !s32i, #cir.int<4> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[VEC]] : !cir.vector<4 x !s32i>

--- a/clang/test/CIR/Transforms/vector-shuffle-dynamic-fold.cir
+++ b/clang/test/CIR/Transforms/vector-shuffle-dynamic-fold.cir
@@ -11,7 +11,7 @@ module {
   }
 
   // Masking indices [8, 7, 6, 5] AND 3 = [0, 3, 2, 1]
-  // CHECK: cir.func @fold_shuffle_dynamic_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK: cir.func{{.*}} @fold_shuffle_dynamic_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[NEW_VEC:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<4> : !s32i, #cir.int<3> : !s32i, #cir.int<2> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[NEW_VEC:.*]] : !cir.vector<4 x !s32i>
 
@@ -23,7 +23,7 @@ module {
   }
 
   // Masking indices [3, 2, 1, 0] AND 3 = [3, 2, 1, 0]
-  // CHECK: cir.func @fold_shuffle_dynamic_vector_op_test_2() -> !cir.vector<4 x !s32i> {
+  // CHECK: cir.func{{.*}} @fold_shuffle_dynamic_vector_op_test_2() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[NEW_VEC:.*]] = cir.const #cir.const_vector<[#cir.int<4> : !s32i, #cir.int<3> : !s32i, #cir.int<2> : !s32i, #cir.int<1> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[NEW_VEC:.*]] : !cir.vector<4 x !s32i>
 }

--- a/clang/test/CIR/Transforms/vector-shuffle-fold.cir
+++ b/clang/test/CIR/Transforms/vector-shuffle-fold.cir
@@ -12,7 +12,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK: cir.func @fold_shuffle_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK: cir.func{{.*}} @fold_shuffle_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i,
   // CHECK-SAME: #cir.int<4> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
@@ -32,7 +32,7 @@ module  {
     cir.return %new_vec : !cir.vector<6 x !s32i>
   }
 
-  // CHECK: cir.func @fold_shuffle_vector_op_test() -> !cir.vector<6 x !s32i> {
+  // CHECK: cir.func{{.*}} @fold_shuffle_vector_op_test() -> !cir.vector<6 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i,
   // CHECK-SAME: #cir.int<4> : !s32i, #cir.int<5> : !s32i, #cir.int<6> : !s32i]> : !cir.vector<6 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<6 x !s32i>
@@ -52,7 +52,7 @@ module  {
     cir.return %new_vec : !cir.vector<4 x !s32i>
   }
 
-  // CHECK: cir.func @fold_shuffle_vector_op_test() -> !cir.vector<4 x !s32i> {
+  // CHECK: cir.func{{.*}} @fold_shuffle_vector_op_test() -> !cir.vector<4 x !s32i> {
   // CHECK: cir.const #cir.const_vector<[#cir.undef : !s32i, #cir.int<2> : !s32i, #cir.int<3> : !s32i,
   // CHECK-SAME: #cir.int<4> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>

--- a/clang/test/CIR/Transforms/vector-ternary-fold.cir
+++ b/clang/test/CIR/Transforms/vector-ternary-fold.cir
@@ -12,7 +12,7 @@ module {
   }
 
   // [1, 0, 1, 0] ? [1, 2, 3, 4] : [5, 6, 7, 8] Will be fold to [1, 6, 3, 8]
-  // CHECK: cir.func @vector_ternary_fold_test() -> !cir.vector<4 x !s32i> {
+  // CHECK: cir.func{{.*}} @vector_ternary_fold_test() -> !cir.vector<4 x !s32i> {
   // CHECK-NEXT: %[[RES:.*]] = cir.const #cir.const_vector<[#cir.int<1> : !s32i, #cir.int<6> : !s32i, #cir.int<3> : !s32i, #cir.int<8> : !s32i]> : !cir.vector<4 x !s32i>
   // CHECK-NEXT: cir.return %[[RES]] : !cir.vector<4 x !s32i>
 }

--- a/clang/test/CIR/func-linkage.cpp
+++ b/clang/test/CIR/func-linkage.cpp
@@ -1,0 +1,51 @@
+// Linkage types of global variables
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck %s -check-prefix=CIR --input-file %t.cir
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck %s -check-prefix=LLVM --input-file %t-cir.ll
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-llvm %s -o %t.ll
+// RUN: FileCheck %s -check-prefix=OGCG --input-file %t.ll
+
+void a() {}
+
+// CIR: cir.func dso_local @_Z1av()
+// LLVM: define dso_local void @_Z1av()
+// OGCG: define dso_local void @_Z1av()
+
+extern void b();
+// CIR: cir.func private @_Z1bv()
+// LLVM: declare void @_Z1bv()
+// OGCG: declare void @_Z1bv()
+
+static void c() {}
+// CIR: cir.func internal private dso_local @_ZL1cv()
+// LLVM: define internal void @_ZL1cv()
+// OGCG: define internal void @_ZL1cv()
+
+inline void d() {}
+// CIR: cir.func comdat linkonce_odr @_Z1dv()
+// LLVM: define linkonce_odr void @_Z1dv()
+// OGCG: define linkonce_odr void @_Z1dv(){{.*}} comdat
+
+namespace {
+  void e() {}
+}
+
+// CIR: cir.func internal private dso_local @_ZN12_GLOBAL__N_11eEv()
+// LLVM: define internal void @_ZN12_GLOBAL__N_11eEv()
+// OGCG: define internal void @_ZN12_GLOBAL__N_11eEv()
+
+void f();
+// CIR: cir.func private @_Z1fv()
+// LLVM: declare void @_Z1fv()
+// OGCG: declare void @_Z1fv()
+
+// Force the functions to be emitted
+void reference_funcs() {
+    a();
+    b();
+    c();
+    d();
+    e();
+    f();
+}

--- a/clang/test/CIR/func-simple.cpp
+++ b/clang/test/CIR/func-simple.cpp
@@ -2,17 +2,17 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o -  | FileCheck %s
 
 void empty() { }
-// CHECK: cir.func @_Z5emptyv() {
+// CHECK: cir.func{{.*}} @_Z5emptyv() {
 // CHECK:   cir.return
 // CHECK: }
 
 void voidret() { return; }
-// CHECK: cir.func @_Z7voidretv() {
+// CHECK: cir.func{{.*}} @_Z7voidretv() {
 // CHECK:   cir.return
 // CHECK: }
 
 int intfunc() { return 42; }
-// CHECK: cir.func @_Z7intfuncv() -> !s32i {
+// CHECK: cir.func{{.*}} @_Z7intfuncv() -> !s32i {
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !s32i
 // CHECK:   cir.store %1, %0 : !s32i, !cir.ptr<!s32i>
@@ -27,7 +27,7 @@ int scopes() {
     }
   }
 }
-// CHECK: cir.func @_Z6scopesv() -> !s32i {
+// CHECK: cir.func{{.*}} @_Z6scopesv() -> !s32i {
 // CHECK:   %0 = cir.alloca !s32i, !cir.ptr<!s32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   cir.scope {
 // CHECK:     cir.scope {
@@ -41,7 +41,7 @@ int scopes() {
 // CHECK: }
 
 long longfunc() { return 42l; }
-// CHECK: cir.func @_Z8longfuncv() -> !s64i
+// CHECK: cir.func{{.*}} @_Z8longfuncv() -> !s64i
 // CHECK:   %0 = cir.alloca !s64i, !cir.ptr<!s64i>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !s64i
 // CHECK:   cir.store %1, %0 : !s64i, !cir.ptr<!s64i>
@@ -50,7 +50,7 @@ long longfunc() { return 42l; }
 // CHECK: }
 
 unsigned unsignedfunc() { return 42u; }
-// CHECK: cir.func @_Z12unsignedfuncv() -> !u32i
+// CHECK: cir.func{{.*}} @_Z12unsignedfuncv() -> !u32i
 // CHECK:   %0 = cir.alloca !u32i, !cir.ptr<!u32i>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !u32i
 // CHECK:   cir.store %1, %0 : !u32i, !cir.ptr<!u32i>
@@ -59,7 +59,7 @@ unsigned unsignedfunc() { return 42u; }
 // CHECK: }
 
 unsigned long long ullfunc() { return 42ull; }
-// CHECK: cir.func @_Z7ullfuncv() -> !u64i
+// CHECK: cir.func{{.*}} @_Z7ullfuncv() -> !u64i
 // CHECK:   %0 = cir.alloca !u64i, !cir.ptr<!u64i>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.int<42> : !u64i
 // CHECK:   cir.store %1, %0 : !u64i, !cir.ptr<!u64i>
@@ -68,7 +68,7 @@ unsigned long long ullfunc() { return 42ull; }
 // CHECK: }
 
 bool boolfunc() { return true; }
-// CHECK: cir.func @_Z8boolfuncv() -> !cir.bool {
+// CHECK: cir.func{{.*}} @_Z8boolfuncv() -> !cir.bool {
 // CHECK:   %0 = cir.alloca !cir.bool, !cir.ptr<!cir.bool>, ["__retval"] {alignment = 1 : i64}
 // CHECK:   %1 = cir.const #true
 // CHECK:   cir.store %1, %0 : !cir.bool, !cir.ptr<!cir.bool>
@@ -77,7 +77,7 @@ bool boolfunc() { return true; }
 // CHECK: }
 
 float floatfunc() { return 42.42f; }
-// CHECK: cir.func @_Z9floatfuncv() -> !cir.float {
+// CHECK: cir.func{{.*}} @_Z9floatfuncv() -> !cir.float {
 // CHECK:   %0 = cir.alloca !cir.float, !cir.ptr<!cir.float>, ["__retval"] {alignment = 4 : i64}
 // CHECK:   %1 = cir.const #cir.fp<4.242
 // CHECK:   cir.store %1, %0 : !cir.float, !cir.ptr<!cir.float>
@@ -86,7 +86,7 @@ float floatfunc() { return 42.42f; }
 // CHECK: }
 
 double doublefunc() { return 42.42; }
-// CHECK: cir.func @_Z10doublefuncv() -> !cir.double {
+// CHECK: cir.func{{.*}} @_Z10doublefuncv() -> !cir.double {
 // CHECK:   %0 = cir.alloca !cir.double, !cir.ptr<!cir.double>, ["__retval"] {alignment = 8 : i64}
 // CHECK:   %1 = cir.const #cir.fp<4.242
 // CHECK:   cir.store %1, %0 : !cir.double, !cir.ptr<!cir.double>

--- a/clang/test/CIR/mlprint.c
+++ b/clang/test/CIR/mlprint.c
@@ -7,7 +7,7 @@ int foo(void) {
 }
 
 // CIR:  IR Dump After CIRCanonicalize (cir-canonicalize)
-// CIR:  cir.func @foo() -> !s32i
+// CIR:  cir.func{{.*}} @foo() -> !s32i
 // LLVM: IR Dump After cir::direct::ConvertCIRToLLVMPass (cir-flat-to-llvm)
 // LLVM: llvm.func @foo() -> i32
 // LLVM: IR Dump After


### PR DESCRIPTION
This change adds support for function linkage and visibility and related attributes. Most of the test changes are generalizations to allow 'dso_local' to be accepted where we aren't specifically testing for it. Some tests based on CIR inputs have been updated to add 'private' to function declarations where required by newly supported interfaces.

The dso-local.c test has been updated to add specific tests for dso_local being set correctly, and a new test, func-linkage.cpp tests other linkage settings.

This change sets `comdat` correctly in CIR, but it is not yet applied to functions when lowering to LLVM IR. That will be handled in a later change.