### PR TITLE
[lldb] include `LLVMTargetParser` in `LINK_COMPONENTS`

### DIFF
--- a/lldb/unittests/Host/CMakeLists.txt
+++ b/lldb/unittests/Host/CMakeLists.txt
@@ -37,7 +37,9 @@ add_lldb_unittest(HostTests
     lldbUtilityHelpers
     lldbHostHelpers
     LLVMTestingSupport
-    LLVMTargetParser
+
+  LINK_COMPONENTS
+    TargetParser
   )
 
 add_subdirectory(common)


### PR DESCRIPTION
## Purpose
Fix duplicate symbol definition errors when building LLDB `HostTests` against a LLVM Windows DLL.

## Background 
When building LLDB `HostTests` against LLVM built as a Windows DLL, compilation fails due to multiple duplicate symbol definition errors. This is because symbols are both exported by the LLVM Windows DLL and the `LLVMTargetParser` library.

## Overview
The issue is resolved by adding `LLVMTargetParser` (e.g. `TargetParser`) to `LINK_COMPONENTS`, which adds it to `LLVM_LINK_COMPONENTS`, rather than `LINK_LIBS`, which links directly against the library. This change makes it behave correctly when linking against a static or dynamic LLVM.