### PR TITLE
Handle vendor string in match for clang version string

### DIFF
--- a/clang/test/CodeGen/pragma-comment.c
+++ b/clang/test/CodeGen/pragma-comment.c
@@ -34,4 +34,4 @@
 // ELF-NOT: foo
 // This following match prevents the clang version metadata from matching the forbidden 'foo' and 'bar' tokens.
 // This can happen if the clang version string contains a Git repo URL that includes one of those substrings.
-// ELF-LABEL: !"clang version
+// ELF-LABEL: {{\!\".*clang version}}


### PR DESCRIPTION
#145455 failed to account for the optional "vendor string" that precedes the `clang version` in the Clang version string metadata. I just updated it to use a regex to allow arbitrary content before the `clang version`. Tested this both with and without a vendor string, and it seems to work as expected.
