### PR TITLE
[lllvm] add Passes to LLVM_LINK_COMPONENTS for LLVMMCATests

### DIFF
--- a/llvm/unittests/tools/llvm-mca/CMakeLists.txt
+++ b/llvm/unittests/tools/llvm-mca/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   MC
   MCA
+  Passes
   Support
   TargetParser
   )


### PR DESCRIPTION
## Purpose
Add `Passes` to `LLVM_LINK_COMPONENTS` for `LLVMMCATests` so that it links properly when LLVM is built as a Windows DLL. 

## Background
`LLVPasses` appears to be a missing dependency from `LLVMMCATests`, but when LLVM is built statically it picks-up the required `LLVMPasses` symbols from a transitive dependency (presumably). When LLVM is built as a Windows DLL, `LLVMMCATests` fails to link 4 symbols from `LLVMPasses` without this change:
```
LLVMX86CodeGen.lib(X86CodeGenPassBuilder.cpp.obj) : error LNK2019: unresolved external symbol "public: __cdecl llvm::ModuleInlinerWrapperPass::ModuleInlinerWrapperPass(struct llvm::InlineParams,bool,struct llvm::InlineContext,enum llvm::InliningAdvisorMode,unsigned int)" (??0ModuleInlinerWrapperPass@llvm@@QEAA@UInlineParams@1@_NUInlineContext@1@W4InliningAdvisorMode@1@I@Z) referenced in function "public: void __cdecl llvm::ModuleInlinerWrapperPass::`default constructor closure'(void)" (??_FModuleInlinerWrapperPass@llvm@@QEAAXXZ)
LLVMX86CodeGen.lib(X86CodeGenPassBuilder.cpp.obj) : error LNK2019: unresolved external symbol "public: __cdecl llvm::PipelineTuningOptions::PipelineTuningOptions(void)" (??0PipelineTuningOptions@llvm@@QEAA@XZ) referenced in function "public: void __cdecl llvm::PassBuilder::`default constructor closure'(void)" (??_FPassBuilder@llvm@@QEAAXXZ)
LLVMX86CodeGen.lib(X86CodeGenPassBuilder.cpp.obj) : error LNK2019: unresolved external symbol "public: __cdecl llvm::PassBuilder::PassBuilder(class llvm::TargetMachine *,class llvm::PipelineTuningOptions,class std::optional<struct llvm::PGOOptions>,class llvm::PassInstrumentationCallbacks *)" (??0PassBuilder@llvm@@QEAA@PEAVTargetMachine@1@VPipelineTuningOptions@1@V?$optional@UPGOOptions@llvm@@@std@@PEAVPassInstrumentationCallbacks@1@@Z) referenced in function "public: void __cdecl llvm::PassBuilder::`default constructor closure'(void)" (??_FPassBuilder@llvm@@QEAAXXZ)
LLVMX86CodeGen.lib(X86InsertPrefetch.cpp.obj) : error LNK2019: unresolved external symbol "public: __cdecl llvm::SampleProfileLoaderPass::SampleProfileLoaderPass(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >,enum llvm::ThinOrFullLTOPhase,class llvm::IntrusiveRefCntPtr<class llvm::vfs::FileSystem>,bool,bool)" (??0SampleProfileLoaderPass@llvm@@QEAA@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0W4ThinOrFullLTOPhase@1@V?$IntrusiveRefCntPtr@VFileSystem@vfs@llvm@@@1@_N3@Z) referenced in function "public: void __cdecl llvm::SampleProfileLoaderPass::`default constructor closure'(void)" (??_FSampleProfileLoaderPass@llvm@@QEAAXXZ)
unittests\tools\llvm-mca\LLVMMCATests.exe : fatal error LNK1120: 4 unresolved externals
```

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang