### PR TITLE
RuntimeLibcalls: Cleanup darwin exp10 case

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -149,6 +149,8 @@ private:
     return true;
   }
 
+  static bool darwinHasExp10(const Triple &TT);
+
   /// Return true if the target has sincosf/sincos/sincosl functions
   static bool hasSinCos(const Triple &TT) {
     return TT.isGNUEnvironment() || TT.isOSFuchsia() ||


### PR DESCRIPTION
Add a predicate function following the example of __sincos_stret