### PR TITLE
[AMDGPU] Drop const from return types (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.cpp
@@ -171,8 +171,7 @@ void RegBankLegalizeHelper::lowerVccExtToSel(MachineInstr &MI) {
   MI.eraseFromParent();
 }
 
-const std::pair<Register, Register>
-RegBankLegalizeHelper::unpackZExt(Register Reg) {
+std::pair<Register, Register> RegBankLegalizeHelper::unpackZExt(Register Reg) {
   auto PackedS32 = B.buildBitcast(SgprRB_S32, Reg);
   auto Mask = B.buildConstant(SgprRB_S32, 0x0000ffff);
   auto Lo = B.buildAnd(SgprRB_S32, PackedS32, Mask);
@@ -180,16 +179,14 @@ RegBankLegalizeHelper::unpackZExt(Register Reg) {
   return {Lo.getReg(0), Hi.getReg(0)};
 }
 
-const std::pair<Register, Register>
-RegBankLegalizeHelper::unpackSExt(Register Reg) {
+std::pair<Register, Register> RegBankLegalizeHelper::unpackSExt(Register Reg) {
   auto PackedS32 = B.buildBitcast(SgprRB_S32, Reg);
   auto Lo = B.buildSExtInReg(SgprRB_S32, PackedS32, 16);
   auto Hi = B.buildAShr(SgprRB_S32, PackedS32, B.buildConstant(SgprRB_S32, 16));
   return {Lo.getReg(0), Hi.getReg(0)};
 }
 
-const std::pair<Register, Register>
-RegBankLegalizeHelper::unpackAExt(Register Reg) {
+std::pair<Register, Register> RegBankLegalizeHelper::unpackAExt(Register Reg) {
   auto PackedS32 = B.buildBitcast(SgprRB_S32, Reg);
   auto Lo = PackedS32;
   auto Hi = B.buildLShr(SgprRB_S32, PackedS32, B.buildConstant(SgprRB_S32, 16));

--- a/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalizeHelper.h
@@ -111,9 +111,9 @@ private:
              SmallSet<Register, 4> &SgprWaterfallOperandRegs);
 
   void lowerVccExtToSel(MachineInstr &MI);
-  const std::pair<Register, Register> unpackZExt(Register Reg);
-  const std::pair<Register, Register> unpackSExt(Register Reg);
-  const std::pair<Register, Register> unpackAExt(Register Reg);
+  std::pair<Register, Register> unpackZExt(Register Reg);
+  std::pair<Register, Register> unpackSExt(Register Reg);
+  std::pair<Register, Register> unpackAExt(Register Reg);
   void lowerUnpackBitShift(MachineInstr &MI);
   void lowerV_BFE(MachineInstr &MI);
   void lowerS_BFE(MachineInstr &MI);


### PR DESCRIPTION
We don't need const on these return types.
