### PR TITLE
[Option] Use llvm::interlaved (NFC)

### DIFF
--- a/llvm/lib/Option/Arg.cpp
+++ b/llvm/lib/Option/Arg.cpp
@@ -6,13 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Option/Arg.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Config/llvm-config.h"
-#include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/InterleavedRange.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -72,13 +73,7 @@ std::string Arg::getAsString(const ArgList &Args) const {
 
   ArgStringList ASL;
   render(Args, ASL);
-  for (ArgStringList::iterator
-         it = ASL.begin(), ie = ASL.end(); it != ie; ++it) {
-    if (it != ASL.begin())
-      OS << ' ';
-    OS << *it;
-  }
-
+  OS << llvm::interleaved(ASL, " ");
   return std::string(OS.str());
 }
 
@@ -100,11 +95,7 @@ void Arg::render(const ArgList &Args, ArgStringList &Output) const {
   case Option::RenderCommaJoinedStyle: {
     SmallString<256> Res;
     raw_svector_ostream OS(Res);
-    OS << getSpelling();
-    for (unsigned i = 0, e = getNumValues(); i != e; ++i) {
-      if (i) OS << ',';
-      OS << getValue(i);
-    }
+    OS << getSpelling() << llvm::interleaved(getValues(), ",");
     Output.push_back(Args.MakeArgString(OS.str()));
     break;
   }


### PR DESCRIPTION
Note that llvm::interleaved constructs a string with the elements from
a given range with a given separator.
