### PR TITLE
[RISCV] Add missing required features for Zvfbfmin intrinsics

### DIFF
--- a/clang/include/clang/Basic/riscv_vector.td
+++ b/clang/include/clang/Basic/riscv_vector.td
@@ -2013,7 +2013,7 @@ let Log2LMUL = [-3, -2, -1, 0, 1, 2] in {
 }
 
 // Zvfbfmin - Vector convert BF16 to FP32
-let Log2LMUL = [-2, -1, 0, 1, 2] in
+let RequiredFeatures = ["zvfbfmin"], Log2LMUL = [-2, -1, 0, 1, 2] in
 def vfwcvtbf16_f_f_v : RVVConvBuiltin<"Fw", "Fwv", "y", "vfwcvtbf16_f">;
 
 let ManualCodegen = [{
@@ -2121,7 +2121,8 @@ let ManualCodegen = [{
     }
 
     // Zvfbfmin - Vector convert FP32 to BF16
-    let Log2LMUL = [-2, -1, 0, 1, 2],
+    let RequiredFeatures = ["zvfbfmin"],
+        Log2LMUL = [-2, -1, 0, 1, 2],
         OverloadedName = "vfncvtbf16_f" in
     defm : RVVConvBuiltinSet<"vfncvtbf16_f_f_w", "y", [["v", "vFwu"]]>;
   }

--- a/clang/test/Sema/rvv-required-features-invalid.c
+++ b/clang/test/Sema/rvv-required-features-invalid.c
@@ -48,3 +48,10 @@ void test_zvfbfwma_vfwmaccbf16(vfloat32m4_t vd, __bf16 vs1, vbfloat16m2_t vs2, s
   // expected-error@-1 {{RISC-V type '__rvv_bfloat16m2_t' requires the 'zvfbfmin' extension}}
   // expected-error@-2 {{builtin requires at least one of the following extensions: zvfbfwma}}
 }
+
+void test_zvfbfmin_vfwcvtbf16(vbfloat16m2_t vs2, size_t vl) {
+  // expected-error@-1 {{RISC-V type 'vbfloat16m2_t' (aka '__rvv_bfloat16m2_t') requires the 'zvfbfmin' extension}}
+  __riscv_vfwcvtbf16_f_f_v_f32m4(vs2, vl);; // expected-error {{RISC-V type 'vbfloat16m2_t' (aka '__rvv_bfloat16m2_t') requires the 'zvfbfmin' extension}}
+  // expected-error@-1 {{RISC-V type '__rvv_bfloat16m2_t' requires the 'zvfbfmin' extension}}
+  // expected-error@-2 {{builtin requires at least one of the following extensions: zvfbfmin}}
+}


### PR DESCRIPTION
Although `checkRVVTypeSupport` can prevent the use of bf16 vector types without Zvfbfmin, the required features for Zvfbfmin intrinsics may still be needed if bf16 vector types can someday be enabled by other extensions.