### PR TITLE
[MLIR] Replace getVoidPtrType with getPtrType in ConvertToLLVMPattern

### DIFF
--- a/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
+++ b/mlir/include/mlir/Conversion/LLVMCommon/Pattern.h
@@ -113,7 +113,11 @@ protected:
   Type getVoidType() const;
 
   /// Get the MLIR type wrapping the LLVM i8* type.
+  [[deprecated("Use getPtrType() instead!")]]
   Type getVoidPtrType() const;
+
+  /// Get the MLIR type wrapping the LLVM ptr type.
+  Type getPtrType(unsigned addressSpace = 0) const;
 
   /// Create a constant Op producing a value of `resultType` from an index-typed
   /// integer attribute.

--- a/mlir/lib/Conversion/LLVMCommon/Pattern.cpp
+++ b/mlir/lib/Conversion/LLVMCommon/Pattern.cpp
@@ -46,9 +46,12 @@ Type ConvertToLLVMPattern::getVoidType() const {
   return LLVM::LLVMVoidType::get(&getTypeConverter()->getContext());
 }
 
-Type ConvertToLLVMPattern::getVoidPtrType() const {
-  return LLVM::LLVMPointerType::get(&getTypeConverter()->getContext());
+Type ConvertToLLVMPattern::getPtrType(unsigned addressSpace) const {
+  return LLVM::LLVMPointerType::get(&getTypeConverter()->getContext(),
+                                    addressSpace);
 }
+
+Type ConvertToLLVMPattern::getVoidPtrType() const { return getPtrType(); }
 
 Value ConvertToLLVMPattern::createIndexAttrConstant(OpBuilder &builder,
                                                     Location loc,
@@ -273,7 +276,7 @@ LogicalResult ConvertToLLVMPattern::copyUnrankedDescriptors(
             ? builder
                   .create<LLVM::CallOp>(loc, mallocFunc.value(), allocationSize)
                   .getResult()
-            : builder.create<LLVM::AllocaOp>(loc, getVoidPtrType(),
+            : builder.create<LLVM::AllocaOp>(loc, getPtrType(),
                                              IntegerType::get(getContext(), 8),
                                              allocationSize,
                                              /*alignment=*/0);

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -408,8 +408,7 @@ struct AllocaScopeOpLowering
 
     // Save stack and then branch into the body of the region.
     rewriter.setInsertionPointToEnd(currentBlock);
-    auto stackSaveOp =
-        rewriter.create<LLVM::StackSaveOp>(loc, getVoidPtrType());
+    auto stackSaveOp = rewriter.create<LLVM::StackSaveOp>(loc, getPtrType());
     rewriter.create<LLVM::BrOp>(loc, ValueRange(), beforeBody);
 
     // Replace the alloca_scope return with a branch that jumps out of the body.
@@ -1122,8 +1121,7 @@ public:
     };
 
     // Save stack position before promoting descriptors
-    auto stackSaveOp =
-        rewriter.create<LLVM::StackSaveOp>(loc, getVoidPtrType());
+    auto stackSaveOp = rewriter.create<LLVM::StackSaveOp>(loc, getPtrType());
 
     auto srcMemRefType = dyn_cast<MemRefType>(srcType);
     Value unrankedSource =
@@ -1249,7 +1247,7 @@ struct MemorySpaceCastOpLowering
                                              result, resultAddrSpace, sizes);
       Value resultUnderlyingSize = sizes.front();
       Value resultUnderlyingDesc = rewriter.create<LLVM::AllocaOp>(
-          loc, getVoidPtrType(), rewriter.getI8Type(), resultUnderlyingSize);
+          loc, getPtrType(), rewriter.getI8Type(), resultUnderlyingSize);
       result.setMemRefDescPtr(rewriter, loc, resultUnderlyingDesc);
 
       // Copy pointers, performing address space casts.
@@ -1530,8 +1528,7 @@ private:
     UnrankedMemRefDescriptor::computeSizes(rewriter, loc, *getTypeConverter(),
                                            targetDesc, addressSpace, sizes);
     Value underlyingDescPtr = rewriter.create<LLVM::AllocaOp>(
-        loc, getVoidPtrType(), IntegerType::get(getContext(), 8),
-        sizes.front());
+        loc, getPtrType(), IntegerType::get(getContext(), 8), sizes.front());
     targetDesc.setMemRefDescPtr(rewriter, loc, underlyingDescPtr);
 
     // Extract pointers and offset from the source memref.

--- a/mlir/test/lib/Conversion/FuncToLLVM/TestConvertCallOp.cpp
+++ b/mlir/test/lib/Conversion/FuncToLLVM/TestConvertCallOp.cpp
@@ -28,7 +28,7 @@ public:
   LogicalResult
   matchAndRewrite(test::TestTypeProducerOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, getVoidPtrType());
+    rewriter.replaceOpWithNewOp<LLVM::ZeroOp>(op, getPtrType());
     return success();
   }
 };


### PR DESCRIPTION
`ConversionPattern::getVoidPtrType` looks a little confusion since the opaque pointer migration is already done. Also we cannot specify address space in this method.

Maybe we can mark them as deprecated and add new method `getPtrType()`, as this PR did : )