### PR TITLE
[MLIR][IRDL][CMake] CMake fixes for cross-compilation

### DIFF
--- a/mlir/cmake/modules/IRDLToCpp.cmake
+++ b/mlir/cmake/modules/IRDLToCpp.cmake
@@ -5,7 +5,7 @@ function(add_irdl_to_cpp_target target irdl_file)
 
     # The command output depends on the executable to ensure IRDL sources are properly rebuilt
     # if the tool changes.
-    DEPENDS ${MLIR_IRDL_TO_CPP_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/${irdl_file}
+    DEPENDS ${MLIR_IRDL_TO_CPP_TARGET} ${MLIR_IRDL_TO_CPP_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/${irdl_file}
     COMMENT "Building ${irdl_file}..."
   )
   add_custom_target(${target} DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${irdl_file}.cpp.inc)


### PR DESCRIPTION
The PR fixes a misconfigured dependency that causes CMake error "No rule to make target 'NATIVE/bin/mlir-irdl-to-cpp'" for cross-compilation.