### PR TITLE
[Support] Remove workarounds for building with mingw.org toolchains

### DIFF
--- a/llvm/lib/Support/Windows/Signals.inc
+++ b/llvm/lib/Support/Windows/Signals.inc
@@ -47,64 +47,6 @@
 // back on at the end of the file.
 #pragma GCC diagnostic ignored "-Wformat"
 #pragma GCC diagnostic ignored "-Wformat-extra-args"
-
-#if !defined(__MINGW64_VERSION_MAJOR)
-// MinGW.org does not have updated support for the 64-bit versions of the
-// DebugHlp APIs. So we will have to load them manually. The structures and
-// method signatures were pulled from DbgHelp.h in the Windows Platform SDK,
-// and adjusted for brevity.
-typedef struct _IMAGEHLP_LINE64 {
-  DWORD SizeOfStruct;
-  PVOID Key;
-  DWORD LineNumber;
-  PCHAR FileName;
-  DWORD64 Address;
-} IMAGEHLP_LINE64, *PIMAGEHLP_LINE64;
-
-typedef struct _IMAGEHLP_SYMBOL64 {
-  DWORD SizeOfStruct;
-  DWORD64 Address;
-  DWORD Size;
-  DWORD Flags;
-  DWORD MaxNameLength;
-  CHAR Name[1];
-} IMAGEHLP_SYMBOL64, *PIMAGEHLP_SYMBOL64;
-
-typedef struct _tagADDRESS64 {
-  DWORD64 Offset;
-  WORD Segment;
-  ADDRESS_MODE Mode;
-} ADDRESS64, *LPADDRESS64;
-
-typedef struct _KDHELP64 {
-  DWORD64 Thread;
-  DWORD ThCallbackStack;
-  DWORD ThCallbackBStore;
-  DWORD NextCallback;
-  DWORD FramePointer;
-  DWORD64 KiCallUserMode;
-  DWORD64 KeUserCallbackDispatcher;
-  DWORD64 SystemRangeStart;
-  DWORD64 KiUserExceptionDispatcher;
-  DWORD64 StackBase;
-  DWORD64 StackLimit;
-  DWORD64 Reserved[5];
-} KDHELP64, *PKDHELP64;
-
-typedef struct _tagSTACKFRAME64 {
-  ADDRESS64 AddrPC;
-  ADDRESS64 AddrReturn;
-  ADDRESS64 AddrFrame;
-  ADDRESS64 AddrStack;
-  ADDRESS64 AddrBStore;
-  PVOID FuncTableEntry;
-  DWORD64 Params[4];
-  BOOL Far;
-  BOOL Virtual;
-  DWORD64 Reserved[3];
-  KDHELP64 KdHelp;
-} STACKFRAME64, *LPSTACKFRAME64;
-#endif // !defined(__MINGW64_VERSION_MAJOR)
 #endif // __MINGW32__
 
 typedef BOOL(__stdcall *PREAD_PROCESS_MEMORY_ROUTINE64)(
@@ -535,12 +477,6 @@ void sys::PrintStackTraceOnErrorSignal(StringRef Argv0,
   LeaveCriticalSection(&CriticalSection);
 }
 } // namespace llvm
-
-#if defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR)
-// Provide a prototype for RtlCaptureContext, mingw32 from mingw.org is
-// missing it but mingw-w64 has it.
-extern "C" VOID WINAPI RtlCaptureContext(PCONTEXT ContextRecord);
-#endif
 
 static void LocalPrintStackTrace(raw_ostream &OS, PCONTEXT C) {
   STACKFRAME64 StackFrame{};


### PR DESCRIPTION
Assume that mingw builds are made with mingw-w64 headers.

The old mingw.org distribution isn't even accessible at the moment, and their project hosting site (osdn.net) seems to have been down for a couple of years, and their old project hosting (at sourceforge.net) hasn't been updated since 2018.