### PR TITLE
Delete copy constructor/assignment; NFC

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -234,6 +234,9 @@ class ApplyAtomGroup {
   uint64_t OriginalAtom = 0;
   CGDebugInfo *DI = nullptr;
 
+  ApplyAtomGroup(const ApplyAtomGroup &) = delete;
+  void operator=(const ApplyAtomGroup &) = delete;
+
 public:
   ApplyAtomGroup(CGDebugInfo *DI);
   ~ApplyAtomGroup();


### PR DESCRIPTION
This is an RAII object and static analysis was flagging it for not following the rule of three (or five).