### PR TITLE
[MLIR][AArch64] Check indexing maps before checking for dimensions compatibility

### DIFF
--- a/mlir/lib/Dialect/ArmSVE/Transforms/LowerContractionToSVEI8MMPattern.cpp
+++ b/mlir/lib/Dialect/ArmSVE/Transforms/LowerContractionToSVEI8MMPattern.cpp
@@ -141,6 +141,7 @@ public:
     //   rhs: (d0, d1, d2) -> (d1, d2)
     //   acc: (d0, d1, d2) -> (d0, d1)
     // This corresponds to matrix multiplication with transposed RHS.
+    // It also follows the operands' ranks are 2.
     if (op.getIndexingMapsArray()[0] !=
             AffineMap::getMultiDimMapWithTargets(3, ArrayRef{0u, 2u},
                                                  op.getContext()) ||
@@ -154,10 +155,6 @@ public:
 
     mlir::VectorType lhsType = op.getLhsType();
     mlir::VectorType rhsType = op.getRhsType();
-
-    // Check the rank of the types so we can safely examine their dimensions.
-    if (lhsType.getRank() != 2 || rhsType.getRank() != 2)
-      return rewriter.notifyMatchFailure(op, "non-matching operand shape");
 
     auto M = lhsType.getDimSize(0);
     auto N = rhsType.getDimSize(0);


### PR DESCRIPTION
In `LowerContractionToSVEI8MMPattern` check we have the expected indexing maps before deciding which operand dimension must match with which.

For example, with indexing map like:

    lhs: (m, n, k) -> (m, k)
    rhs: (m, n, k) -> (n, k)
    acc: (m, n, k) -> (m, n)

we would like the second `lhs` dimension (columns) to match with the second `rhs` (rows, transposed) whereas with indexing maps like

    lhs: (m, n, k) -> (m, k)
    rhs: (m, n, k) -> (k, n)
    acc: (m, n, k) -> (m, n)

we would like the second `lhs` dimension (columns) to match with the first `rhs` (rows, canonical matrix multiplication).

Since only the first kind of indexing maps is supported, the patch does not change anything of significance, just the notification message when the pattern would fail to apply anyway.