### PR TITLE
[flang][OpenMP] Remove recognition of versions 3.0 and older

### DIFF
--- a/flang/include/flang/Support/OpenMP-features.h
+++ b/flang/include/flang/Support/OpenMP-features.h
@@ -15,16 +15,8 @@ namespace Fortran::common {
 template <typename FortranPredefinitions>
 void setOpenMPMacro(int version, FortranPredefinitions &predefinitions) {
   switch (version) {
-  case 20:
-    predefinitions.emplace_back("_OPENMP", "200011");
-    break;
-  case 25:
-    predefinitions.emplace_back("_OPENMP", "200505");
-    break;
-  case 30:
-    predefinitions.emplace_back("_OPENMP", "200805");
-    break;
   case 31:
+  default:
     predefinitions.emplace_back("_OPENMP", "201107");
     break;
   case 40:
@@ -44,10 +36,6 @@ void setOpenMPMacro(int version, FortranPredefinitions &predefinitions) {
     break;
   case 60:
     predefinitions.emplace_back("_OPENMP", "202411");
-    break;
-  case 11:
-  default:
-    predefinitions.emplace_back("_OPENMP", "199911");
     break;
   }
 }

--- a/flang/test/Driver/bbc-openmp-version-macro.f90
+++ b/flang/test/Driver/bbc-openmp-version-macro.f90
@@ -1,29 +1,22 @@
 ! Test predefined _OPENMP macro which denotes OpenMP version
 
 ! RUN: bbc -fopenmp -o -  %s | FileCheck %s --check-prefix=DEFAULT-OPENMP-VERSION
-! RUN: bbc -fopenmp -fopenmp-version=11 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-11
-! RUN: bbc -fopenmp -fopenmp-version=11 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-11
-! RUN: bbc -fopenmp -fopenmp-version=20 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-20
-! RUN: bbc -fopenmp -fopenmp-version=25 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-25
-! RUN: bbc -fopenmp -fopenmp-version=30 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-30
 ! RUN: bbc -fopenmp -fopenmp-version=31 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-31
 ! RUN: bbc -fopenmp -fopenmp-version=40 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-40
 ! RUN: bbc -fopenmp -fopenmp-version=45 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-45
 ! RUN: bbc -fopenmp -fopenmp-version=50 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-50
 ! RUN: bbc -fopenmp -fopenmp-version=51 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-51
 ! RUN: bbc -fopenmp -fopenmp-version=52 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-52
+! RUN: bbc -fopenmp -fopenmp-version=60 -o - %s | FileCheck %s --check-prefix=OPENMP-VERSION-60
 
 ! DEFAULT-OPENMP-VERSION: {{.*}} = arith.constant 201107 : i32
-! OPENMP-VERSION-11: {{.*}} = arith.constant 199911 : i32
-! OPENMP-VERSION-20: {{.*}} = arith.constant 200011 : i32
-! OPENMP-VERSION-25: {{.*}} = arith.constant 200505 : i32
-! OPENMP-VERSION-30: {{.*}} = arith.constant 200805 : i32
 ! OPENMP-VERSION-31: {{.*}} = arith.constant 201107 : i32
 ! OPENMP-VERSION-40: {{.*}} = arith.constant 201307 : i32
 ! OPENMP-VERSION-45: {{.*}} = arith.constant 201511 : i32
 ! OPENMP-VERSION-50: {{.*}} = arith.constant 201811 : i32
 ! OPENMP-VERSION-51: {{.*}} = arith.constant 202011 : i32
 ! OPENMP-VERSION-52: {{.*}} = arith.constant 202111 : i32
+! OPENMP-VERSION-60: {{.*}} = arith.constant 202411 : i32
 
 #if _OPENMP
   integer :: var1 = _OPENMP

--- a/flang/test/Driver/flang-openmp-version-macro.f90
+++ b/flang/test/Driver/flang-openmp-version-macro.f90
@@ -1,10 +1,6 @@
 ! Test predefined _OPENMP macro which denotes OpenMP version
 
 ! RUN: %flang_fc1 -fopenmp -cpp -E %s | FileCheck %s --check-prefix=DEFAULT-OPENMP-VERSION
-! RUN: %flang_fc1 -fopenmp -fopenmp-version=11 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-11
-! RUN: %flang_fc1 -fopenmp -fopenmp-version=20 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-20
-! RUN: %flang_fc1 -fopenmp -fopenmp-version=25 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-25
-! RUN: %flang_fc1 -fopenmp -fopenmp-version=30 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-30
 ! RUN: %flang_fc1 -fopenmp -fopenmp-version=31 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-31
 ! RUN: %flang_fc1 -fopenmp -fopenmp-version=40 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-40
 ! RUN: %flang_fc1 -fopenmp -fopenmp-version=45 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-45
@@ -14,10 +10,6 @@
 ! RUN: %flang_fc1 -fopenmp -fopenmp-version=60 -cpp -E %s | FileCheck %s --check-prefix=OPENMP-VERSION-60
 
 ! DEFAULT-OPENMP-VERSION: integer :: var1 = 201107
-! OPENMP-VERSION-11: integer :: var1 = 199911
-! OPENMP-VERSION-20: integer :: var1 = 200011
-! OPENMP-VERSION-25: integer :: var1 = 200505
-! OPENMP-VERSION-30: integer :: var1 = 200805
 ! OPENMP-VERSION-31: integer :: var1 = 201107
 ! OPENMP-VERSION-40: integer :: var1 = 201307
 ! OPENMP-VERSION-45: integer :: var1 = 201511


### PR DESCRIPTION
The oldest supported version is now 3.1. In terms of semantic analysis the compiler treats all versions <= 4.5 identically, and there is no plan to add version-specific checks for older versions.

See discourse thread:
https://discourse.llvm.org/t/rfc-remove-openmp-versions-prior-to-3-1/86901