### PR TITLE
Revert "[clang][dataflow] Expose simple access to child StorageLocation presence."

### DIFF
--- a/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
+++ b/clang/include/clang/Analysis/FlowSensitive/StorageLocation.h
@@ -168,8 +168,6 @@ public:
     return {Children.begin(), Children.end()};
   }
 
-  bool hasChild(const ValueDecl &D) const { return Children.contains(&D); }
-
 private:
   FieldToLoc Children;
   SyntheticFieldMap SyntheticFields;


### PR DESCRIPTION
Reverts llvm/llvm-project#145520

Exposed function is no longer needed and side-stepped the intended contract that the present children are the same set returned by `getModeledFields()` and presence shouldn't need to be queried for arbitrary fields.