### PR TITLE
[bazel] Update deps from #144657

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -10168,6 +10168,7 @@ td_library(
     ]),
     includes = ["include"],
     deps = [
+        ":LinalgOpsTdFiles",
         ":SCFTdFiles",
         ":TransformDialectTdFiles",
     ],


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/144657 added #include "mlir/Dialect/Linalg/IR/LinalgEnums.td" to mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td, so we update the deps