### PR TITLE
[mlir][linalg] Fix module dependency issue due to unused import

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/WinogradConv2D.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/WinogradConv2D.cpp
@@ -15,7 +15,6 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"


### PR DESCRIPTION
This include introduces a dependency for LinalgTransforms on LinalgTransformOps, which is unspecified in the module dependencies, and would produce a cyclic dependency if it were specified.

The include is unused in WinogradConv2D.cpp, so this change removes it.