### PR TITLE
Fix Solaris buildbot

### DIFF
--- a/clang/test/CodeGen/X86/ms-secure-hotpatch-bad-file.c
+++ b/clang/test/CodeGen/X86/ms-secure-hotpatch-bad-file.c
@@ -3,7 +3,7 @@
 // This verifies that we correctly handle a -fms-secure-hotpatch-functions-file argument that points
 // to a missing file.
 //
-// RUN: not %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-file=%S/this-file-is-intentionally-missing-do-not-create-it.txt /Fo%t.obj %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-file=%S/this-file-is-intentionally-missing-do-not-create-it.txt /Fo%t.obj -- %s 2>&1 | FileCheck %s
 // CHECK: failed to open hotpatch functions file
 
 void this_might_have_side_effects();

--- a/clang/test/CodeGen/X86/ms-secure-hotpatch-cpp.cpp
+++ b/clang/test/CodeGen/X86/ms-secure-hotpatch-cpp.cpp
@@ -3,7 +3,7 @@
 // This verifies that hotpatch function attributes are correctly propagated when compiling directly to OBJ,
 // and that name mangling works as expected.
 //
-// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-list=?this_gets_hotpatched@@YAHXZ /Fo%t.obj %s
+// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-list=?this_gets_hotpatched@@YAHXZ /Fo%t.obj -- %s
 // RUN: llvm-readobj --codeview %t.obj | FileCheck %s
 
 void this_might_have_side_effects();

--- a/clang/test/CodeGen/X86/ms-secure-hotpatch-eh.cpp
+++ b/clang/test/CodeGen/X86/ms-secure-hotpatch-eh.cpp
@@ -2,7 +2,7 @@
 
 // Global constant data such as exception handler tables should not be redirected by Windows Secure Hot-Patching
 //
-// RUN: %clang_cl -c --target=x86_64-windows-msvc /EHsc -O2 -fms-secure-hotpatch-functions-list=this_gets_hotpatched /Fo%t.obj /clang:-S /clang:-o- %s 2>& 1 | FileCheck %s
+// RUN: %clang_cl -c --target=x86_64-windows-msvc /EHsc -O2 -fms-secure-hotpatch-functions-list=this_gets_hotpatched /Fo%t.obj /clang:-S /clang:-o- -- %s 2>& 1 | FileCheck %s
 
 class Foo {
 public:

--- a/clang/test/CodeGen/X86/ms-secure-hotpatch-globals.c
+++ b/clang/test/CodeGen/X86/ms-secure-hotpatch-globals.c
@@ -4,7 +4,7 @@
 //
 // RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 \
 // RUN:   -fms-secure-hotpatch-functions-list=hp1,hp2,hp3,hp4,hp5_phi_ptr_mixed,hp_phi_ptr_both,hp_const_ptr_sub \
-// RUN:   /clang:-S /clang:-o- %s | FileCheck %s
+// RUN:   /clang:-S /clang:-o- -- %s | FileCheck %s
 
 #ifdef __clang__
 #define NO_TAIL __attribute__((disable_tail_calls))

--- a/clang/test/CodeGen/X86/ms-secure-hotpatch-lto.c
+++ b/clang/test/CodeGen/X86/ms-secure-hotpatch-lto.c
@@ -2,7 +2,7 @@
 
 // This verifies that hotpatch function attributes are correctly propagated through LLVM IR when compiling with LTO.
 //
-// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-list=this_gets_hotpatched -flto /Fo%t.bc %s
+// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-list=this_gets_hotpatched -flto /Fo%t.bc -- %s
 // RUN: llvm-dis %t.bc -o - | FileCheck %s
 //
 // CHECK-LABEL: define dso_local noundef i32 @this_gets_hotpatched()

--- a/clang/test/CodeGen/X86/ms-secure-hotpatch.c
+++ b/clang/test/CodeGen/X86/ms-secure-hotpatch.c
@@ -3,7 +3,7 @@
 // This verifies that hotpatch function attributes are correctly propagated when compiling directly to OBJ.
 //
 // RUN: echo this_gets_hotpatched > %t.patch-functions.txt
-// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-file=%t.patch-functions.txt /Fo%t.obj %s
+// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /Z7 -fms-secure-hotpatch-functions-file=%t.patch-functions.txt /Fo%t.obj -- %s
 // RUN: llvm-readobj --codeview %t.obj | FileCheck %s
 
 void this_might_have_side_effects();


### PR DESCRIPTION
#145565 broke the Solaris buildbot, due to a subtlety in how command-lines are parsed, which is different between Windows and non-Windows platforms.  The fix is to use `--` to force passing the rest of args without interpretation. This is similar to existing tests for `%clang_cl`, such as `clang/test/CodeGen/debug-info-codeview-buildinfo.c`.

Currently, CI jobs for PRs do not detect this problem. Fixing that is tracked in issue #145713.