### PR TITLE
[LegacyPM] Remove unused getAdjustedAnalysisPointer() method (NFC)

### DIFF
--- a/llvm/docs/AliasAnalysis.rst
+++ b/llvm/docs/AliasAnalysis.rst
@@ -256,20 +256,6 @@ analysis run method (``run`` for a ``Pass``, ``runOnFunction`` for a
     return false;
   }
 
-Required methods to override
-----------------------------
-
-You must override the ``getAdjustedAnalysisPointer`` method on all subclasses
-of ``AliasAnalysis``. An example implementation of this method would look like:
-
-.. code-block:: c++
-
-  void *getAdjustedAnalysisPointer(const void* ID) override {
-    if (ID == &AliasAnalysis::ID)
-      return (AliasAnalysis*)this;
-    return this;
-  }
-
 Interfaces which may be specified
 ---------------------------------
 

--- a/llvm/include/llvm/Pass.h
+++ b/llvm/include/llvm/Pass.h
@@ -175,11 +175,6 @@ public:
   /// longer used.
   virtual void releaseMemory();
 
-  /// getAdjustedAnalysisPointer - This method is used when a pass implements
-  /// an analysis interface through multiple inheritance.  If needed, it should
-  /// override this to adjust the this pointer as needed for the specified pass
-  /// info.
-  virtual void *getAdjustedAnalysisPointer(AnalysisID ID);
   virtual ImmutablePass *getAsImmutablePass();
   virtual PMDataManager *getAsPMDataManager();
 

--- a/llvm/include/llvm/PassAnalysisSupport.h
+++ b/llvm/include/llvm/PassAnalysisSupport.h
@@ -214,15 +214,7 @@ AnalysisType *Pass::getAnalysisIfAvailable() const {
   assert(Resolver && "Pass not resident in a PassManager object!");
 
   const void *PI = &AnalysisType::ID;
-
-  Pass *ResultPass = Resolver->getAnalysisIfAvailable(PI);
-  if (!ResultPass) return nullptr;
-
-  // Because the AnalysisType may not be a subclass of pass (for
-  // AnalysisGroups), we use getAdjustedAnalysisPointer here to potentially
-  // adjust the return pointer (because the class may multiply inherit, once
-  // from pass, once from AnalysisType).
-  return (AnalysisType*)ResultPass->getAdjustedAnalysisPointer(PI);
+  return (AnalysisType *)Resolver->getAnalysisIfAvailable(PI);
 }
 
 /// getAnalysis<AnalysisType>() - This function is used by subclasses to get
@@ -245,12 +237,7 @@ AnalysisType &Pass::getAnalysisID(AnalysisID PI) const {
   assert(ResultPass &&
          "getAnalysis*() called on an analysis that was not "
          "'required' by pass!");
-
-  // Because the AnalysisType may not be a subclass of pass (for
-  // AnalysisGroups), we use getAdjustedAnalysisPointer here to potentially
-  // adjust the return pointer (because the class may multiply inherit, once
-  // from pass, once from AnalysisType).
-  return *(AnalysisType*)ResultPass->getAdjustedAnalysisPointer(PI);
+  return *(AnalysisType *)ResultPass;
 }
 
 /// getAnalysis<AnalysisType>() - This function is used by subclasses to get
@@ -282,12 +269,7 @@ AnalysisType &Pass::getAnalysisID(AnalysisID PI, Function &F, bool *Changed) {
   else
     assert(!LocalChanged &&
            "A pass trigged a code update but the update status is lost");
-
-  // Because the AnalysisType may not be a subclass of pass (for
-  // AnalysisGroups), we use getAdjustedAnalysisPointer here to potentially
-  // adjust the return pointer (because the class may multiply inherit, once
-  // from pass, once from AnalysisType).
-  return *(AnalysisType*)ResultPass->getAdjustedAnalysisPointer(PI);
+  return *(AnalysisType *) ResultPass;
 }
 
 } // end namespace llvm

--- a/llvm/include/llvm/PassAnalysisSupport.h
+++ b/llvm/include/llvm/PassAnalysisSupport.h
@@ -269,7 +269,7 @@ AnalysisType &Pass::getAnalysisID(AnalysisID PI, Function &F, bool *Changed) {
   else
     assert(!LocalChanged &&
            "A pass trigged a code update but the update status is lost");
-  return *(AnalysisType *) ResultPass;
+  return *(AnalysisType *)ResultPass;
 }
 
 } // end namespace llvm

--- a/llvm/lib/IR/Pass.cpp
+++ b/llvm/lib/IR/Pass.cpp
@@ -107,10 +107,6 @@ void Pass::verifyAnalysis() const {
   // By default, don't do anything.
 }
 
-void *Pass::getAdjustedAnalysisPointer(AnalysisID AID) {
-  return this;
-}
-
 ImmutablePass *Pass::getAsImmutablePass() {
   return nullptr;
 }


### PR DESCRIPTION
This never actually gets overridden and always returns this, so drop it.

Noticed this looking into why the pass vtables are so huge.