### PR TITLE
Guard against self-assignment; NFC

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -6409,14 +6409,7 @@ public:
   SpirvOperand(const SpirvOperand &Other) { *this = Other; }
   ~SpirvOperand() {}
 
-  SpirvOperand &operator=(const SpirvOperand &Other) {
-    if (this != &Other) {
-      this->Kind = Other.Kind;
-      this->ResultType = Other.ResultType;
-      this->Value = Other.Value;
-    }
-    return *this;
-  }
+  SpirvOperand &operator=(const SpirvOperand &Other) = default;
 
   bool operator==(const SpirvOperand &Other) const {
     return Kind == Other.Kind && ResultType == Other.ResultType &&

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -6410,9 +6410,11 @@ public:
   ~SpirvOperand() {}
 
   SpirvOperand &operator=(const SpirvOperand &Other) {
-    this->Kind = Other.Kind;
-    this->ResultType = Other.ResultType;
-    this->Value = Other.Value;
+    if (this != &Other) {
+      this->Kind = Other.Kind;
+      this->ResultType = Other.ResultType;
+      this->Value = Other.Value;
+    }
     return *this;
   }
 


### PR DESCRIPTION
This was caught by a static analysis tool and seemed like a reasonable code quality improvement.