### PR TITLE
[DirectX] Strip `dx.rootsignatures` metadata during `dxil-prepare`

### DIFF
--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -33,7 +33,7 @@
 ; CHECK-NEXT:   DXIL Translate Metadata
 ; CHECK-NEXT:   DXIL Post Optimization Validation
 ; CHECK-NEXT:   DXIL Op Lowering
-; CHECK-NEXT: DXIL Root Signature Analysis
+; CHECK-NEXT:   DXIL Root Signature Analysis
 ; CHECK-NEXT:   DXIL Prepare Module
 
 ; CHECK-ASM-NEXT: DXIL Metadata Pretty Printer

--- a/llvm/test/CodeGen/DirectX/llc-pipeline.ll
+++ b/llvm/test/CodeGen/DirectX/llc-pipeline.ll
@@ -33,13 +33,13 @@
 ; CHECK-NEXT:   DXIL Translate Metadata
 ; CHECK-NEXT:   DXIL Post Optimization Validation
 ; CHECK-NEXT:   DXIL Op Lowering
+; CHECK-NEXT: DXIL Root Signature Analysis
 ; CHECK-NEXT:   DXIL Prepare Module
 
 ; CHECK-ASM-NEXT: DXIL Metadata Pretty Printer
 ; CHECK-ASM-NEXT: Print Module IR
 
 ; CHECK-OBJ-NEXT: DXIL Embedder
-; CHECK-OBJ-NEXT: DXIL Root Signature Analysis
 ; CHECK-OBJ-NEXT: DXContainer Global Emitter
 ; CHECK-OBJ-NEXT: FunctionPass Manager
 ; CHECK-OBJ-NEXT:   Lazy Machine Block Frequency Analysis

--- a/llvm/test/CodeGen/DirectX/strip-rootsignatures.ll
+++ b/llvm/test/CodeGen/DirectX/strip-rootsignatures.ll
@@ -9,7 +9,8 @@ entry:
   ret void
 }
 
-; CHECK-NOT: !dx.rootsignature
+; CHECK-NOT: !dx.rootsignatures
+; CHECK-NOT: {{^!}}
 
 !dx.rootsignatures = !{!2} ; list of function/root signature pairs
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature

--- a/llvm/test/CodeGen/DirectX/strip-rootsignatures.ll
+++ b/llvm/test/CodeGen/DirectX/strip-rootsignatures.ll
@@ -1,0 +1,17 @@
+; RUN: opt -S -dxil-prepare < %s | FileCheck %s
+
+; Ensures that dxil-prepare will remove the dx.rootsignatures metadata
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+define void @main() {
+entry:
+  ret void
+}
+
+; CHECK-NOT: !dx.rootsignature
+
+!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!2 = !{ ptr @main, !3, i32 2 } ; function, root signature
+!3 = !{ !4 } ; list of root signature elements
+!4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout


### PR DESCRIPTION
The `dx.rootsignatures` metadata is not recognized in DXIL, so failure to remove this will cause validation errors.

This metadata is parsed (within `RootSignatureAnalysisWrapper`) into its binary format. As such, once it has been used to construct the binary form, it can be safely discarded without loss of information.

This pr ensures that the dxil prepare pass will depend and preserve on the root signature analysis so that it runs before the metadata is removed.

- Update `DXILPrepare.cpp` to preserve and depend on `RootSignatureAnalysisWrapper`
- Update test to demonstrate order is correct
- Provide test-case to demonstrate the metadata is removed

Resolves https://github.com/llvm/llvm-project/issues/145437.

----------

Co-authored-by: Justin Bogner <mail@justinbogner.com>