### PR TITLE
[Support] Don't re-raise signals sent from kernel

### DIFF
--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -413,7 +413,7 @@ static void SignalHandler(int Sig, siginfo_t *Info, void *) {
     raise(Sig);
 #endif
 
-#if defined(__linux__) || defined(__ANDROID__)
+#if defined(__linux__)
   // Re-raising a signal via `raise` loses the original siginfo. Recent
   // versions of linux (>= 3.9) support processes sending a signal to itself
   // with arbitrary signal information using a syscall. If this syscall is

--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -78,6 +78,10 @@
 #include <__le_cwi.h>
 #endif
 
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif
+
 using namespace llvm;
 
 static void SignalHandler(int Sig, siginfo_t *Info, void *);

--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -413,9 +413,9 @@ static void SignalHandler(int Sig, siginfo_t *Info, void *) {
     raise(Sig);
 #endif
 
-  // Signal sent from another process, do not assume that continuing the
-  // execution would re-raise it.
-  if (Info->si_pid != getpid())
+  // Signal sent from another userspace process, do not assume that continuing
+  // the execution would re-raise it.
+  if (Info->si_pid != getpid() && Info->si_pid != 0)
     raise(Sig);
 }
 

--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -413,22 +413,21 @@ static void SignalHandler(int Sig, siginfo_t *Info, void *) {
     raise(Sig);
 #endif
 
+#if defined(__linux__) || defined(__ANDROID__)
+  // Re-raising a signal via `raise` loses the original siginfo. Recent
+  // versions of linux (>= 3.9) support processes sending a signal to itself
+  // with arbitrary signal information using a syscall. If this syscall is
+  // unsupported, errno will be set to EPERM and `raise` will be used instead.
+  int retval =
+      syscall(SYS_rt_tgsigqueueinfo, getpid(), syscall(SYS_gettid), Sig, Info);
+  if (retval != 0 && errno == EPERM)
+    raise(Sig);
+#else
   // Signal sent from another userspace process, do not assume that continuing
   // the execution would re-raise it.
-  if (Info->si_pid != getpid() && Info->si_pid != 0) {
-#if defined(__linux__) || defined(__ANDROID__)
-    // Re-raising a signal via `raise` loses the original siginfo. Recent
-    // versions of linux (>= 3.9) support processes sending a signal to itself
-    // with arbitrary signal information using a syscall. If this syscall is
-    // unsupported, errno will be set to EPERM and `raise` will be used instead.
-    int retval = syscall(SYS_rt_tgsigqueueinfo, getpid(), syscall(SYS_gettid),
-                         Sig, Info);
-    if (retval != 0 && errno == EPERM)
-      raise(Sig);
-#else
+  if (Info->si_pid != getpid() && Info->si_pid != 0)
     raise(Sig);
 #endif
-  }
 }
 
 static void InfoSignalHandler(int Sig) {

--- a/llvm/lib/Support/Unix/Signals.inc
+++ b/llvm/lib/Support/Unix/Signals.inc
@@ -415,8 +415,20 @@ static void SignalHandler(int Sig, siginfo_t *Info, void *) {
 
   // Signal sent from another userspace process, do not assume that continuing
   // the execution would re-raise it.
-  if (Info->si_pid != getpid() && Info->si_pid != 0)
+  if (Info->si_pid != getpid() && Info->si_pid != 0) {
+#if defined(__linux__) || defined(__ANDROID__)
+    // Re-raising a signal via `raise` loses the original siginfo. Recent
+    // versions of linux (>= 3.9) support processes sending a signal to itself
+    // with arbitrary signal information using a syscall. If this syscall is
+    // unsupported, errno will be set to EPERM and `raise` will be used instead.
+    int retval = syscall(SYS_rt_tgsigqueueinfo, getpid(), syscall(SYS_gettid),
+                         Sig, Info);
+    if (retval != 0 && errno == EPERM)
+      raise(Sig);
+#else
     raise(Sig);
+#endif
+  }
 }
 
 static void InfoSignalHandler(int Sig) {


### PR DESCRIPTION
When an llvm tool crashes (e.g. from a segmentation fault), SignalHandler will re-raise the signal. The effect is that crash reports now contain SignalHandler in the stack trace. The crash reports are still useful, but the presence of SignalHandler can confuse tooling and automation that deduplicate or analyze crash reports.

rdar://150464802