### PR TITLE
Add triple target to buildtype.ll in X86

### DIFF
--- a/llvm/test/DebugInfo/assignment-tracking/X86/large-type.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/large-type.ll
@@ -1,6 +1,8 @@
 ; RUN: llc %s -stop-after=finalize-isel -o - \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
 
+target triple = "x86_64-unknown-linux-gnu"
+
 ;; Based on optimized IR from C source:
 ;; int main () {
 ;;   char a1[__INT_MAX__];


### PR DESCRIPTION
Fixes issue #145416.

Tagging @RKSimon for approval