### PR TITLE
[llvm-objcopy] Explain that strip-preserve-atime.test fails with Crowdstrike

### DIFF
--- a/llvm/test/tools/llvm-objcopy/ELF/strip-preserve-atime.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/strip-preserve-atime.test
@@ -1,6 +1,8 @@
 # Note: ls -lu prints the accessed timestamp
 # NetBSD: noatime mounts currently inhibit 'touch -a' updates
 # Windows: the last access time is disabled by default in the OS
+# This test is also known to fail on Mac (and possibly elsewhere) when Crowdstrike is installed;
+# please make use of the LIT_XFAIL environment variable on such machines.
 # UNSUPPORTED: system-netbsd, system-windows
 
 # Preserve dates when stripping to an output file.


### PR DESCRIPTION
Related to #82372.
Not a fix per se, but an acknowledgment and a workaround.