### PR TITLE
[Sanitizers] prefer fsanitize flag over lower-allow mllvm flag

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/LowerAllowCheckPass.cpp
+++ b/llvm/lib/Transforms/Instrumentation/LowerAllowCheckPass.cpp
@@ -31,7 +31,8 @@ using namespace llvm;
 
 static cl::opt<int>
     HotPercentileCutoff("lower-allow-check-percentile-cutoff-hot",
-                        cl::desc("Hot percentile cutoff."));
+                        cl::desc("Hot percentile cutoff."),
+                      cl::init(0));
 
 static cl::opt<float>
     RandomRate("lower-allow-check-random-rate",
@@ -84,15 +85,12 @@ static bool removeUbsanTraps(Function &F, const BlockFrequencyInfo &BFI,
   };
 
   auto GetCutoff = [&](const IntrinsicInst *II) -> unsigned {
-    if (HotPercentileCutoff.getNumOccurrences())
-      return HotPercentileCutoff;
-    else if (II->getIntrinsicID() == Intrinsic::allow_ubsan_check) {
+    if (II->getIntrinsicID() == Intrinsic::allow_ubsan_check) {
       auto *Kind = cast<ConstantInt>(II->getArgOperand(0));
       if (Kind->getZExtValue() < cutoffs.size())
         return cutoffs[Kind->getZExtValue()];
     }
-
-    return 0;
+    return HotPercentileCutoff;
   };
 
   auto ShouldRemoveHot = [&](const BasicBlock &BB, unsigned int cutoff) {

--- a/llvm/lib/Transforms/Instrumentation/LowerAllowCheckPass.cpp
+++ b/llvm/lib/Transforms/Instrumentation/LowerAllowCheckPass.cpp
@@ -31,8 +31,7 @@ using namespace llvm;
 
 static cl::opt<int>
     HotPercentileCutoff("lower-allow-check-percentile-cutoff-hot",
-                        cl::desc("Hot percentile cutoff."),
-                      cl::init(0));
+                        cl::desc("Hot percentile cutoff."), cl::init(0));
 
 static cl::opt<float>
     RandomRate("lower-allow-check-random-rate",


### PR DESCRIPTION
The fsanitize flag in question is -fsanitize-skip-hot-cutoff.

We are planning to deprecate -mllvm -ubsan-guard-checks. Then,
*emission* of the allow_ubsan_check is only controlled by the fsanitize
flag, at which point it would be very confusing if the cutoff from the
lower-allow mllvm flag applied.

Also, as is, the lower-allow mllvm flag also controls
allow_runtime_check. So now we don't have a way to control the hotness
of this without also overriding the fsanitize flag
