### PR TITLE
[sanitizers] do not accept out of bounds -fsanitize-skip-hot-cutoff

### DIFF
--- a/clang/lib/Basic/Sanitizers.cpp
+++ b/clang/lib/Basic/Sanitizers.cpp
@@ -95,9 +95,8 @@ bool clang::parseSanitizerWeightedValue(StringRef Value, bool AllowGroups,
     return false;
   auto [N, W] = Value.split('=');
   double A;
-  if (W.getAsDouble(A))
+  if (W.getAsDouble(A) || A < 0.0 || A > 1.0)
     return false;
-  A = std::clamp(A, 0.0, 1.0);
   // AllowGroups is already taken into account for ParsedKind,
   // hence we unconditionally expandSanitizerGroups.
   Cutoffs.set(expandSanitizerGroups(ParsedKind), A);

--- a/clang/test/Driver/fsanitize.c
+++ b/clang/test/Driver/fsanitize.c
@@ -1299,3 +1299,11 @@
 // No-op: -fno-sanitize-top= without parameters is unusual but valid
 // RUN: %clang -Werror --target=x86_64-linux-gnu -fsanitize-skip-hot-cutoff= %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-SKIP-HOT-CUTOFF12
 // CHECK-SKIP-HOT-CUTOFF12-NOT: "-fsanitize-skip-hot-cutoff"
+
+// Invalid: out of range cutoff
+// RUN: not %clang --target=x86_64-linux-gnu -fsanitize-skip-hot-cutoff=undefined=1.1 %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-SKIP-HOT-CUTOFF13
+// CHECK-SKIP-HOT-CUTOFF13: unsupported argument 'undefined=1.1' to option '-fsanitize-skip-hot-cutoff='
+
+// Invalid: out of range cutoff
+// RUN: not %clang --target=x86_64-linux-gnu -fsanitize-skip-hot-cutoff=undefined=-0.1 %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-SKIP-HOT-CUTOFF14
+// CHECK-SKIP-HOT-CUTOFF14: unsupported argument 'undefined=-0.1' to option '-fsanitize-skip-hot-cutoff='


### PR DESCRIPTION
If the user gives an out of bounds value, it is best to fail and let the
user decide what to do.
