### PR TITLE
opt: Add -enable-builtin flag

### DIFF
--- a/llvm/test/Transforms/InferFunctionAttrs/enable-builtin.ll
+++ b/llvm/test/Transforms/InferFunctionAttrs/enable-builtin.ll
@@ -1,0 +1,13 @@
+; RUN: opt -S -mtriple=amdgcn-- -passes=inferattrs %s | FileCheck -check-prefix=NOBUILTIN %s
+; RUN: opt -S -enable-builtin=malloc -mtriple=amdgcn-- -passes=inferattrs %s | FileCheck -check-prefix=WITHBUILTIN %s
+
+; Test that the -enable-builtin flag works and forces recognition of
+; malloc despite the target's default TargetLibraryInfo.
+
+; NOBUILTIN: declare ptr @malloc(i64)
+
+; WITHBUILTIN: declare noalias noundef ptr @malloc(i64 noundef) #0
+; WITHBUILTIN: attributes #0 = { mustprogress nofree nounwind willreturn allockind("alloc,uninitialized") allocsize(0) memory(inaccessiblemem: readwrite) "alloc-family"="malloc" }
+
+declare ptr @malloc(i64)
+

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -203,6 +203,10 @@ static cl::list<std::string> DisableBuiltins(
     "disable-builtin",
     cl::desc("Disable specific target library builtin function"));
 
+static cl::list<std::string> EnableBuiltins(
+    "enable-builtin",
+    cl::desc("Enable specific target library builtin functions"));
+
 static cl::opt<bool> EnableDebugify(
     "enable-debugify",
     cl::desc(
@@ -670,7 +674,7 @@ extern "C" int optMain(
   else {
     // Disable individual builtin functions in TargetLibraryInfo.
     LibFunc F;
-    for (auto &FuncName : DisableBuiltins)
+    for (auto &FuncName : DisableBuiltins) {
       if (TLII.getLibFunc(FuncName, F))
         TLII.setUnavailable(F);
       else {
@@ -678,6 +682,17 @@ extern "C" int optMain(
                << FuncName << '\n';
         return 1;
       }
+    }
+
+    for (auto &FuncName : EnableBuiltins) {
+      if (TLII.getLibFunc(FuncName, F))
+        TLII.setAvailable(F);
+      else {
+        errs() << argv[0] << ": cannot enable nonexistent builtin function "
+               << FuncName << '\n';
+        return 1;
+      }
+    }
   }
 
   if (UseNPM) {


### PR DESCRIPTION
Currently TargetLibraryInfo assumes ~everything is available, and
specific triples (or the -disable-builtin) flag, opt-out. This is a
backwards system, where features should only be positively be enabled
when known. Add this flag to help migrate tests with no triple.