### PR TITLE
[GlobalISel] Remove dead code. (NFC)

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/LegalizerHelper.cpp
@@ -10099,10 +10099,6 @@ LegalizerHelper::lowerMemCpyFamily(MachineInstr &MI, unsigned MaxLen) {
   }
 
   bool IsVolatile = MemOp->isVolatile();
-  if (Opc == TargetOpcode::G_MEMCPY_INLINE)
-    return lowerMemcpyInline(MI, Dst, Src, KnownLen, DstAlign, SrcAlign,
-                             IsVolatile);
-
   // Don't try to optimize volatile.
   if (IsVolatile)
     return UnableToLegalize;


### PR DESCRIPTION
LegalizerHelper::lowerMemCpyFamily only execpts G_MEMCPY, G_MEMMOVE, and
G_MMSET.
