### PR TITLE
[lldb] Correctly restore the cursor column after resizing the statusline

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -133,6 +133,8 @@ public:
 
   void SetAsyncExecution(bool async);
 
+  CursorPosition GetIOHandlerCursorPosition();
+
   lldb::FileSP GetInputFileSP() { return m_input_file_sp; }
   File &GetInputFile() { return *m_input_file_sp; }
 

--- a/lldb/include/lldb/Core/IOHandler.h
+++ b/lldb/include/lldb/Core/IOHandler.h
@@ -10,6 +10,7 @@
 #define LLDB_CORE_IOHANDLER_H
 
 #include "lldb/Host/Config.h"
+#include "lldb/Host/Terminal.h"
 #include "lldb/Utility/CompletionRequest.h"
 #include "lldb/Utility/Flags.h"
 #include "lldb/Utility/Predicate.h"
@@ -112,6 +113,10 @@ public:
   virtual const char *GetCommandPrefix() { return nullptr; }
 
   virtual const char *GetHelpPrologue() { return nullptr; }
+
+  virtual CursorPosition GetCursorPosition() const {
+    return {std::nullopt, std::nullopt};
+  }
 
   int GetInputFD();
 
@@ -403,6 +408,8 @@ public:
   uint32_t GetCurrentLineIndex() const;
 
   void PrintAsync(const char *s, size_t len, bool is_stdout) override;
+
+  virtual CursorPosition GetCursorPosition() const override;
 
 private:
 #if LLDB_ENABLE_LIBEDIT

--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -35,6 +35,7 @@
 #include <vector>
 
 #include "lldb/Host/StreamFile.h"
+#include "lldb/Host/Terminal.h"
 #include "lldb/lldb-private.h"
 
 #if !defined(_WIN32) && !defined(__ANDROID__)
@@ -266,6 +267,8 @@ public:
   size_t GetTerminalWidth() { return m_terminal_width; }
 
   size_t GetTerminalHeight() { return m_terminal_height; }
+
+  CursorPosition GetCursorPosition();
 
 private:
   /// Sets the lowest line number for multi-line editing sessions.  A value of

--- a/lldb/include/lldb/Host/Terminal.h
+++ b/lldb/include/lldb/Host/Terminal.h
@@ -169,6 +169,11 @@ protected:
   lldb::pid_t m_process_group = -1;       ///< Cached process group information.
 };
 
+struct CursorPosition {
+  std::optional<unsigned> cols;
+  std::optional<unsigned> rows;
+};
+
 } // namespace lldb_private
 
 #endif // LLDB_HOST_TERMINAL_H

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1240,6 +1240,14 @@ void Debugger::DispatchInputEndOfFile() {
     reader_sp->GotEOF();
 }
 
+CursorPosition Debugger::GetIOHandlerCursorPosition() {
+  std::lock_guard<std::recursive_mutex> guard(m_io_handler_stack.GetMutex());
+  IOHandlerSP reader_sp(m_io_handler_stack.Top());
+  if (reader_sp)
+    return reader_sp->GetCursorPosition();
+  return {std::nullopt, std::nullopt};
+}
+
 void Debugger::ClearIOHandlers() {
   // The bottom input reader should be the main debugger input reader.  We do
   // not want to close that one here.

--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -634,6 +634,14 @@ void IOHandlerEditline::GotEOF() {
 #endif
 }
 
+CursorPosition IOHandlerEditline::GetCursorPosition() const {
+#if LLDB_ENABLE_LIBEDIT
+  if (m_editline_up)
+    return m_editline_up->GetCursorPosition();
+#endif
+  return {std::nullopt, std::nullopt};
+}
+
 void IOHandlerEditline::PrintAsync(const char *s, size_t len, bool is_stdout) {
 #if LLDB_ENABLE_LIBEDIT
   if (m_editline_up) {

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -398,6 +398,20 @@ int Editline::GetLineIndexForLocation(CursorLocation location, int cursor_row) {
   return line;
 }
 
+CursorPosition Editline::GetCursorPosition() {
+  if (!m_editline)
+    return {};
+
+  const LineInfoW *info = el_wline(m_editline);
+  if (!info)
+    return {};
+
+  const size_t editline_cursor_col =
+      (int)((info->cursor - info->buffer) + GetPromptWidth()) + 1;
+
+  return {editline_cursor_col, std::nullopt};
+}
+
 void Editline::MoveCursor(CursorLocation from, CursorLocation to) {
   const LineInfoW *info = el_wline(m_editline);
   int editline_cursor_position =


### PR DESCRIPTION
This PR ensures we correctly restore the cursor column after resizing the statusline. To ensure we have space for the statusline, we have to emit a newline to move up everything on screen. The newline causes the cursor to move to the start of the next line, which needs to be undone.

Normally, we would use escape codes to save & restore the cursor position, but that doesn't work here, as the cursor position may have (purposely) changed. Instead, we move the cursor up one line using an escape code, but we weren't restoring the column.

Interestingly, Editline was able to recover from this issue through the LineInfo struct which contains the buffer and the cursor location, which allows us to compute the column. This PR addresses the bug by relying on the active IOHandler to report its cursor position and if available, use that to restore the cursor column position.

Fixes #134064