### PR TITLE
[HLSL][RootSignature] Use "stringified" version for diagnostic output of punctuator tokens

### DIFF
--- a/clang/include/clang/Lex/LexHLSLRootSignature.h
+++ b/clang/include/clang/Lex/LexHLSLRootSignature.h
@@ -50,6 +50,10 @@ operator<<(const DiagnosticBuilder &DB, const RootSignatureToken::Kind Kind) {
   case RootSignatureToken::Kind::X:                                            \
     DB << SPELLING;                                                            \
     break;
+#define PUNCTUATOR(X, SPELLING)                                                \
+  case RootSignatureToken::Kind::pu_##X:                                       \
+    DB << #SPELLING;                                                           \
+    break;
 #include "clang/Lex/HLSLRootSignatureTokenKinds.def"
   }
   return DB;

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -18,3 +18,7 @@ void bad_root_signature_3() {}
 
 [RootSignature("DescriptorTable(), invalid")] // expected-error {{expected end of stream to denote end of parameters, or, another valid parameter of RootSignature}}
 void bad_root_signature_4() {}
+
+// expected-error@+1 {{expected ')' to denote end of parameters, or, another valid parameter of RootConstants}}
+[RootSignature("RootConstants(b0, num32BitConstants = 1, invalid)")]
+void bad_root_signature_5() {}


### PR DESCRIPTION
This pr will corrects the output with a stringified version of a puncuator (eg `')'`) instead of its ascii value.

- Update `LexHLSLRootSignature` to fix the `DiagnosticBuilder` `operator<<` overload to correclty format the puncuator
- Add testcase demonstrating the stringified version is output

Resolves https://github.com/llvm/llvm-project/issues/145814.