### PR TITLE
[clang] Use llvm::is_contained instead of llvm::all_of (NFC)

### DIFF
--- a/clang/lib/AST/ExprCXX.cpp
+++ b/clang/lib/AST/ExprCXX.cpp
@@ -1208,7 +1208,7 @@ CXXConstructExpr::CXXConstructExpr(
 
   Stmt **TrailingArgs = getTrailingArgs();
   llvm::copy(Args, TrailingArgs);
-  assert(llvm::all_of(Args, [](const Stmt *Arg) { return Arg != nullptr; }));
+  assert(!llvm::is_contained(Args, nullptr));
 
   // CXXTemporaryObjectExpr does this itself after setting its TypeSourceInfo.
   if (SC == CXXConstructExprClass)

--- a/clang/lib/AST/StmtOpenACC.cpp
+++ b/clang/lib/AST/StmtOpenACC.cpp
@@ -209,7 +209,7 @@ OpenACCWaitConstruct *OpenACCWaitConstruct::Create(
     ArrayRef<Expr *> QueueIdExprs, SourceLocation RParenLoc, SourceLocation End,
     ArrayRef<const OpenACCClause *> Clauses) {
 
-  assert(llvm::all_of(QueueIdExprs, [](Expr *E) { return E != nullptr; }));
+  assert(!llvm::is_contained(QueueIdExprs, nullptr));
 
   void *Mem = C.Allocate(
       OpenACCWaitConstruct::totalSizeToAlloc<Expr *, OpenACCClause *>(

--- a/clang/lib/Analysis/FlowSensitive/CNFFormula.cpp
+++ b/clang/lib/Analysis/FlowSensitive/CNFFormula.cpp
@@ -49,8 +49,7 @@ struct CNFFormulaBuilder {
     // Contains literals of the simplified clause.
     llvm::SmallVector<Literal> Simplified;
     for (auto L : Literals) {
-      assert(L != NullLit &&
-             llvm::all_of(Simplified, [L](Literal S) { return S != L; }));
+      assert(L != NullLit && !llvm::is_contained(Simplified, L));
       auto X = var(L);
       if (trueVars.contains(X)) { // X must be true
         if (isPosLit(L))
@@ -103,7 +102,7 @@ CNFFormula::CNFFormula(Variable LargestVar)
 }
 
 void CNFFormula::addClause(ArrayRef<Literal> lits) {
-  assert(llvm::all_of(lits, [](Literal L) { return L != NullLit; }));
+  assert(!llvm::is_contained(lits, NullLit));
 
   if (lits.empty())
     KnownContradictory = true;

--- a/clang/lib/Basic/Attributes.cpp
+++ b/clang/lib/Basic/Attributes.cpp
@@ -260,8 +260,7 @@ static constexpr const char *AttrScopeSpellingList[] = {
 std::optional<StringRef>
 AttributeCommonInfo::tryGetCorrectedScopeName(StringRef ScopeName) const {
   if (ScopeName.size() > 0 &&
-      llvm::none_of(AttrScopeSpellingList,
-                    [&](const char *S) { return S == ScopeName; })) {
+      !llvm::is_contained(AttrScopeSpellingList, ScopeName)) {
     SimpleTypoCorrection STC(ScopeName);
     for (const auto &Scope : AttrScopeSpellingList)
       STC.add(Scope);
@@ -275,8 +274,7 @@ AttributeCommonInfo::tryGetCorrectedScopeName(StringRef ScopeName) const {
 std::optional<StringRef> AttributeCommonInfo::tryGetCorrectedAttrName(
     StringRef ScopeName, StringRef AttrName, const TargetInfo &Target,
     const LangOptions &LangOpts) const {
-  if (llvm::none_of(AttrSpellingList,
-                    [&](const char *A) { return A == AttrName; })) {
+  if (!llvm::is_contained(AttrSpellingList, AttrName)) {
     SimpleTypoCorrection STC(AttrName);
     for (const auto &Attr : AttrSpellingList)
       STC.add(Attr);

--- a/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/LoongArch.cpp
@@ -214,16 +214,16 @@ void loongarch::getLoongArchTargetFeatures(const Driver &D,
     if (MSIMD == "lsx") {
       // Option -msimd=lsx depends on 64-bit FPU.
       // -m*-float and -mfpu=none/0/32 conflict with -msimd=lsx.
-      if (llvm::find(Features, "-d") != Features.end())
+      if (llvm::is_contained(Features, "-d"))
         D.Diag(diag::err_drv_loongarch_wrong_fpu_width) << /*LSX*/ 0;
       else
         Features.push_back("+lsx");
     } else if (MSIMD == "lasx") {
       // Option -msimd=lasx depends on 64-bit FPU and LSX.
       // -m*-float, -mfpu=none/0/32 and -mno-lsx conflict with -msimd=lasx.
-      if (llvm::find(Features, "-d") != Features.end())
+      if (llvm::is_contained(Features, "-d"))
         D.Diag(diag::err_drv_loongarch_wrong_fpu_width) << /*LASX*/ 1;
-      else if (llvm::find(Features, "-lsx") != Features.end())
+      else if (llvm::is_contained(Features, "-lsx"))
         D.Diag(diag::err_drv_loongarch_invalid_simd_option_combination);
 
       // The command options do not contain -mno-lasx.
@@ -232,9 +232,9 @@ void loongarch::getLoongArchTargetFeatures(const Driver &D,
         Features.push_back("+lasx");
       }
     } else if (MSIMD == "none") {
-      if (llvm::find(Features, "+lsx") != Features.end())
+      if (llvm::is_contained(Features, "+lsx"))
         Features.push_back("-lsx");
-      if (llvm::find(Features, "+lasx") != Features.end())
+      if (llvm::is_contained(Features, "+lasx"))
         Features.push_back("-lasx");
     } else {
       D.Diag(diag::err_drv_loongarch_invalid_msimd_EQ) << MSIMD;

--- a/clang/unittests/Tooling/DependencyScanning/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanning/DependencyScannerTest.cpp
@@ -299,8 +299,7 @@ TEST(DependencyScanner, ScanDepsWithModuleLookup) {
       ScanTool.getDependencyFile(CommandLine, CWD).moveInto(DepFile),
       llvm::Failed());
 
-  EXPECT_TRUE(llvm::find(InterceptFS->StatPaths, OtherPath) ==
-              InterceptFS->StatPaths.end());
+  EXPECT_TRUE(!llvm::is_contained(InterceptFS->StatPaths, OtherPath));
   EXPECT_EQ(InterceptFS->ReadFiles, std::vector<std::string>{"test.m"});
 }
 

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -1657,8 +1657,7 @@ void clang::EmitClangDiagsEnums(const RecordKeeper &Records, raw_ostream &OS,
 
       llvm::SmallVector<std::string> EnumeratorNames;
       for (auto &Enumerator : Enumeration.second) {
-        if (llvm::find(EnumeratorNames, Enumerator.second) !=
-            EnumeratorNames.end())
+        if (llvm::is_contained(EnumeratorNames, Enumerator.second))
           PrintError(&R,
                      "Duplicate enumerator name '" + Enumerator.second + "'");
         EnumeratorNames.push_back(Enumerator.second);


### PR DESCRIPTION
llvm::is_contained is shorter than llvm::all_of plus a lambda.
