### PR TITLE
[llvm-debuginfo-analyzer] Fix incorrect REQUIRES in WebAssembly test case

### DIFF
--- a/llvm/test/tools/llvm-debuginfo-analyzer/WebAssembly/wasm-32bit-tombstone.s
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/WebAssembly/wasm-32bit-tombstone.s
@@ -1,4 +1,4 @@
-# REQUIRES: x86-registered-target
+# REQUIRES: webassembly-registered-target
 
 # Test that DWARF tombstones are correctly detected/respected in wasm
 # 32 bit object files.


### PR DESCRIPTION
Fixes an incorrect 'REQUIRES' in test case.
The correct value should be:

REQUIRES: webassembly-registered-target