### PR TITLE
[PS5][Driver] Allow selection of CRT with `-L`

### DIFF
--- a/clang/lib/Driver/ToolChains/PS4CPU.cpp
+++ b/clang/lib/Driver/ToolChains/PS4CPU.cpp
@@ -379,8 +379,10 @@ void tools::PS5cpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       !Relocatable &&
       !Args.hasArg(options::OPT_nostartfiles, options::OPT_nostdlib);
 
-  auto AddCRTObject = [&](const char *Name) {
-    CmdArgs.push_back(Args.MakeArgString(TC.GetFilePath(Name)));
+  auto AddCRTObject = [&](StringRef Name) {
+    // CRT objects can be found on user supplied library paths. This is
+    // an entrenched expectation on PlayStation.
+    CmdArgs.push_back(Args.MakeArgString("-l:" + Name));
   };
 
   if (AddStartFiles) {

--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -146,9 +146,9 @@
 // RUN: %clang --target=x86_64-sie-ps5 %s -nostdlib++ -static -### 2>&1 | FileCheck --check-prefixes=CHECK-LD,CHECK-STATIC-CRT,CHECK-NO-LIBCPP,CHECK-STATIC-LIBC,CHECK-STATIC-CORE-LIBS %s
 
 // CHECK-LD: {{ld(\.exe)?}}"
-// CHECK-MAIN-CRT-SAME: "crt1.o" "crti.o" "crtbegin.o"
-// CHECK-SHARED-CRT-SAME: "crti.o" "crtbeginS.o"
-// CHECK-STATIC-CRT-SAME: "crt1.o" "crti.o" "crtbeginT.o"
+// CHECK-MAIN-CRT-SAME: "-l:crt1.o" "-l:crti.o" "-l:crtbegin.o"
+// CHECK-SHARED-CRT-SAME: "-l:crti.o" "-l:crtbeginS.o"
+// CHECK-STATIC-CRT-SAME: "-l:crt1.o" "-l:crti.o" "-l:crtbeginT.o"
 
 // CHECK-NO-LIBC-NOT: "-lc{{(_stub_weak)?}}"
 // CHECK-NO-LIBCPP-NOT: "-l{{c_stub_weak|stdc\+\+}}"
@@ -161,11 +161,11 @@
 
 // CHECK-PTHREAD-SAME: "-lpthread"
 
-// CHECK-MAIN-CRT-SAME: "crtend.o" "crtn.o"
-// CHECK-SHARED-CRT-SAME: "crtendS.o" "crtn.o"
-// CHECK-STATIC-CRT-SAME: "crtend.o" "crtn.o"
+// CHECK-MAIN-CRT-SAME: "-l:crtend.o" "-l:crtn.o"
+// CHECK-SHARED-CRT-SAME: "-l:crtendS.o" "-l:crtn.o"
+// CHECK-STATIC-CRT-SAME: "-l:crtend.o" "-l:crtn.o"
 
-// CHECK-NO-CRT-NOT: "crt{{[^"]*}}.o"
+// CHECK-NO-CRT-NOT: crt{{[^"]*}}.o"
 // CHECK-NO-LIBS-NOT: "-l{{[^"]*}}"
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.
@@ -186,9 +186,9 @@
 
 // Test implicit library search paths are supplied to the linker, after any
 // search paths specified by the user. <sdk-root>/target/lib is implicitly
-// added if it exists. CRT objects are found there. "." is always implicitly
-// added to library search paths. This is long-standing behavior, unique to
-// PlayStation toolchains.
+// added if it exists. CRT objects are found there if not on user search paths.
+// "." is always implicitly added to library search paths. These are
+// long-standing and entrenched behaviors, unique to PlayStation toolchains.
 
 // RUN: rm -rf %t.dir && mkdir %t.dir
 // RUN: env SCE_PROSPERO_SDK_DIR=%t.dir %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-NO-TARGETLIB %s
@@ -200,7 +200,6 @@
 // CHECK-NO-TARGETLIB-SAME: "-L."
 
 // RUN: mkdir -p %t.dir/myroot/target/lib
-// RUN: touch %t.dir/myroot/target/lib/crti.o
 // RUN: env SCE_PROSPERO_SDK_DIR=%t.dir/myroot %clang --target=x64_64-sie-ps5 %s -### -Luser 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
 // RUN: %clang --target=x64_64-sie-ps5 %s -### -Luser --sysroot=%t.dir/myroot 2>&1 | FileCheck --check-prefixes=CHECK-TARGETLIB %s
 
@@ -208,4 +207,3 @@
 // CHECK-TARGETLIB-SAME: "-Luser"
 // CHECK-TARGETLIB-SAME: "-L{{.*}}myroot{{/|\\\\}}target{{/|\\\\}}lib"
 // CHECK-TARGETLIB-SAME: "-L."
-// CHECK-TARGETLIB-SAME: "{{.*}}myroot{{/|\\\\}}target{{/|\\\\}}lib{{/|\\\\}}crti.o"


### PR DESCRIPTION
There's long standing behaviour in PlayStation to allow user-supplied library search paths (`-L`) to influence lookup of CRT objects. This seems to be a historical quirk that has persisted to the present day.

This usage of `-L` for CRT selection is deeply entrenched among users of the PS5 toolchain. While this change is conceptually bothersome, it does reflect what's shipped.

SIE tracker: TOOLCHAIN-17706