### PR TITLE
[clang-tidy] unnecessary-value-param: Allow moving of value arguments.

### DIFF
--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
@@ -43,13 +43,12 @@ bool hasLoopStmtAncestor(const DeclRefExpr &DeclRef, const Decl &Decl,
 
 bool isArgOfStdMove(const DeclRefExpr &DeclRef, const Decl &Decl,
                     ASTContext &Context) {
-  auto Matches = match(
-      traverse(TK_AsIs, decl(forEachDescendant(callExpr(
+  return !match(
+      traverse(TK_AsIs, decl(hasDescendant(callExpr(
                             callee(functionDecl(hasName("std::move"))),
                             hasArgument(0, ignoringParenImpCasts(declRefExpr(
                                                equalsNode(&DeclRef)))))))),
-      Decl, Context);
-  return Matches.empty();
+      Decl, Context).empty();
 }
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryValueParamCheck.cpp
@@ -43,12 +43,13 @@ bool hasLoopStmtAncestor(const DeclRefExpr &DeclRef, const Decl &Decl,
 
 bool isArgOfStdMove(const DeclRefExpr &DeclRef, const Decl &Decl,
                     ASTContext &Context) {
-  return !match(
-      traverse(TK_AsIs, decl(hasDescendant(callExpr(
-                            callee(functionDecl(hasName("std::move"))),
-                            hasArgument(0, ignoringParenImpCasts(declRefExpr(
-                                               equalsNode(&DeclRef)))))))),
-      Decl, Context).empty();
+  return !match(traverse(TK_AsIs,
+                         decl(hasDescendant(callExpr(
+                             callee(functionDecl(hasName("std::move"))),
+                             hasArgument(0, ignoringParenImpCasts(declRefExpr(
+                                                equalsNode(&DeclRef)))))))),
+                Decl, Context)
+              .empty();
 }
 
 } // namespace

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -294,6 +294,7 @@ Changes in existing checks
   to avoid matching usage of functions within the current compilation unit.
   Added an option `IgnoreCoroutines` with the default value `true` to
   suppress this check for coroutines where passing by reference may be unsafe.
+  Fix false positive on by-value parameters that are only moved.
 
 - Improved :doc:`readability-convert-member-functions-to-static
   <clang-tidy/checks/readability/convert-member-functions-to-static>` check by

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
@@ -344,6 +344,10 @@ void ReferenceFunctionByCallingIt() {
   PositiveMessageAndFixAsFunctionIsCalled(ExpensiveToCopyType());
 }
 
+void NegativeMoved(ExpensiveToCopyType A) {
+  A Copy = std::move(A);
+}
+
 // Virtual method overrides of dependent types cannot be recognized unless they
 // are marked as override or final. Test that check is not triggered on methods
 // marked with override or final.

--- a/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/performance/unnecessary-value-param.cpp
@@ -345,7 +345,7 @@ void ReferenceFunctionByCallingIt() {
 }
 
 void NegativeMoved(ExpensiveToCopyType A) {
-  A Copy = std::move(A);
+  ExpensiveToCopyType Copy = std::move(A);
 }
 
 // Virtual method overrides of dependent types cannot be recognized unless they


### PR DESCRIPTION
Some functions take an argument by value because it allows efficiently moving them to a function that takes by value. Do not pessimize that case.