### PR TITLE
[OMPIRBuilder] Fix use of uninitialized variable.

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -9846,7 +9846,7 @@ void OffloadEntriesInfoManager::getTargetRegionEntryFnName(
 TargetRegionEntryInfo
 OpenMPIRBuilder::getTargetEntryUniqueInfo(FileIdentifierInfoCallbackTy CallBack,
                                           StringRef ParentName) {
-  sys::fs::UniqueID ID;
+  sys::fs::UniqueID ID(0xdeadf17e, 0);
   auto FileIDInfo = CallBack();
   uint64_t FileID = 0;
   std::error_code EC = sys::fs::getUniqueID(std::get<0>(FileIDInfo), ID);


### PR DESCRIPTION
The code in `OpenMPIRBuilder::getTargetEntryUniqueInfo` calls `ID.getDevice()` even when `getUniqueID` has failed and ID is un-initialized. This caused a sanitizer fail for me in https://github.com/llvm/llvm-project/pull/145026. Fix it by giving a default value to `ID`. The value chosen is the same as used in `OpenMPToLLVMIRTranslation.cpp`.