### PR TITLE
[libc] Fix the risc-v half precison float feature check

### DIFF
--- a/libc/src/__support/macros/properties/cpu_features.h
+++ b/libc/src/__support/macros/properties/cpu_features.h
@@ -61,7 +61,7 @@
 
 #if defined(__riscv_flen)
 // https://github.com/riscv-non-isa/riscv-c-api-doc/blob/main/src/c-api.adoc
-#if (__riscv_arch_test && __riscv_zfhmin)
+#if defined(__riscv_zfhmin)
 #define LIBC_TARGET_CPU_HAS_RISCV_FPU_HALF
 #define LIBC_TARGET_CPU_HAS_FPU_HALF
 #endif // LIBC_TARGET_CPU_HAS_RISCV_FPU_HALF


### PR DESCRIPTION
This is a follow-up to #145169, which would break compiles when __riscv_zfhmin is not defined.