### PR TITLE
[GitHub] Add PR filters for VectorCombine patches

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -632,6 +632,10 @@ llvm:instcombine:
   - llvm/test/Transforms/InstCombine/**
   - llvm/test/Transforms/InstSimplify/**
 
+llvm:vectorcombine:
+  - llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+  - llvm/test/Transforms/VectorCombine/**
+
 clangd:
   - clang-tools-extra/clangd/**
 


### PR DESCRIPTION
Distinguish VectorCombine from the vectorizers without just treating it as part of the InstCombine group

Fixes #145286