### PR TITLE
[libc] Refactored internal wcrtomb

### DIFF
--- a/libc/src/__support/wchar/wcrtomb.h
+++ b/libc/src/__support/wchar/wcrtomb.h
@@ -18,7 +18,12 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 
-ErrorOr<size_t> wcrtomb(char *__restrict s, wchar_t wc, mbstate *__restrict ps);
+struct wcrtomb_result {
+    char mbs[4];
+    size_t count = 0;    
+};
+
+ErrorOr<wcrtomb_result> wcrtomb(wchar_t wc, mbstate* ps);
 
 } // namespace internal
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wcrtomb.cpp
+++ b/libc/src/wchar/wcrtomb.cpp
@@ -30,16 +30,16 @@ LLVM_LIBC_FUNCTION(size_t, wcrtomb,
   }
 
   auto result = internal::wcrtomb(
-      s, wc,
-      ps == nullptr ? &internal_mbstate
-                    : reinterpret_cast<internal::mbstate *>(ps));
+      wc, ps == nullptr ? &internal_mbstate
+                        : reinterpret_cast<internal::mbstate *>(ps));
 
   if (!result.has_value()) {
     libc_errno = result.error();
     return -1;
   }
 
-  return result.value();
+  __builtin_memcpy(s, result.value().mbs, result.value().count);
+  return result.value().count;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wchar/wctomb.cpp
+++ b/libc/src/wchar/wctomb.cpp
@@ -22,14 +22,15 @@ LLVM_LIBC_FUNCTION(int, wctomb, (char *s, wchar_t wc)) {
   if (s == nullptr)
     return 0;
 
-  auto result = internal::wcrtomb(s, wc, &internal_mbstate);
+  auto result = internal::wcrtomb(wc, &internal_mbstate);
 
   if (!result.has_value()) { // invalid wide character
     libc_errno = EILSEQ;
     return -1;
   }
 
-  return static_cast<int>(result.value());
+  __builtin_memcpy(s, result.value().mbs, result.value().count);
+  return static_cast<int>(result.value().count);
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Removed output parameters for internal::wcrtomb and instead returned a struct containing the result of the conversion. 
