### PR TITLE
[Clang][Driver][SamplePGO] Introduce -fno_sample_profile_use_profi flag for SamplePGO

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1698,6 +1698,8 @@ def fsample_profile_use_profi : Flag<["-"], "fsample-profile-use-profi">,
                basic block counts to branch probabilities to fix them by extended
                and re-engineered classic MCMF (min-cost max-flow) approach.}]>;
 def fno_profile_sample_accurate : Flag<["-"], "fno-profile-sample-accurate">, Group<f_Group>;
+def fno_sample_profile_use_profi : Flag<["-"], "fno-sample-profile-use-profi">,
+                                   Group<f_Group>;
 def fno_auto_profile : Flag<["-"], "fno-auto-profile">, Group<f_Group>,
     Alias<fno_profile_sample_use>;
 def fauto_profile_EQ : Joined<["-"], "fauto-profile=">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6284,7 +6284,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   if (getLastProfileSampleUseArg(Args) &&
       Args.hasFlag(options::OPT_fsample_profile_use_profi,
-                   options::OPT_fno_sample_profile_use_profi, true)) {
+                   options::OPT_fno_sample_profile_use_profi, false)) {
     CmdArgs.push_back("-mllvm");
     CmdArgs.push_back("-sample-profile-use-profi");
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6283,7 +6283,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Args.AddLastArg(CmdArgs, options::OPT_fclang_abi_compat_EQ);
 
   if (getLastProfileSampleUseArg(Args) &&
-      Args.hasArg(options::OPT_fsample_profile_use_profi)) {
+      Args.hasFlag(options::OPT_fsample_profile_use_profi,
+                   options::OPT_fno_sample_profile_use_profi, true)) {
     CmdArgs.push_back("-mllvm");
     CmdArgs.push_back("-sample-profile-use-profi");
   }

--- a/clang/test/Driver/pgo-sample-use-profi.c
+++ b/clang/test/Driver/pgo-sample-use-profi.c
@@ -1,15 +1,15 @@
 /// Ensure that profi flag is enabled by default in frontend for SamplePGO
 
 // Target specific checks:
-// RUN: %clang --target=x86_64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
-// RUN: %clang --target=AArch64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+// RUN: %clang --target=x86_64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
+// RUN: %clang --target=AArch64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
 
 // Target agnostic checks:
-// RUN: %clang -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+// RUN: %clang -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
 // RUN: %clang -c -fsample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
 // RUN: %clang -c -fno-sample-profile-use-profi -fsample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
 
-// Cases where profi flag is disabled:
+// Cases where profi flag is explicitly disabled:
 // RUN: %clang -c -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
 // RUN: %clang -c -fno-sample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
 // RUN: %clang -c -fsample-profile-use-profi -fno-sample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI

--- a/clang/test/Driver/pgo-sample-use-profi.c
+++ b/clang/test/Driver/pgo-sample-use-profi.c
@@ -1,4 +1,5 @@
-/// Ensure that profi flag is enabled by default in frontend for SamplePGO
+/// Test if profi flag is enabled/disabled correctly based on user-specified configuration.
+/// Ensure that profi flag is disabled by default
 
 // Target specific checks:
 // RUN: %clang --target=x86_64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI

--- a/clang/test/Driver/pgo-sample-use-profi.c
+++ b/clang/test/Driver/pgo-sample-use-profi.c
@@ -1,4 +1,19 @@
-/// Test if profi flat is enabled in frontend as user-facing feature.
-// RUN: %clang --target=x86_64 -c -fsample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+/// Ensure that profi flag is enabled by default in frontend for SamplePGO
+
+// Target specific checks:
+// RUN: %clang --target=x86_64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+// RUN: %clang --target=AArch64 -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+
+// Target agnostic checks:
+// RUN: %clang -c -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+// RUN: %clang -c -fsample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+// RUN: %clang -c -fno-sample-profile-use-profi -fsample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s
+
+// Cases where profi flag is disabled:
+// RUN: %clang -c -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
+// RUN: %clang -c -fno-sample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
+// RUN: %clang -c -fsample-profile-use-profi -fno-sample-profile-use-profi -fprofile-sample-use=/dev/null -### %s 2>&1 | FileCheck %s --check-prefixes=CHECK-NO-PROFI
+
 
 // CHECK: "-mllvm" "-sample-profile-use-profi"
+// CHECK-NO-PROFI-NOT: "-sample-profile-use-profi"


### PR DESCRIPTION
Introduce -fno_sample_profile_use_profi flag for SamplePGO mode
This is part1 of the set of patches that is needed to [enable -fsample-profile-use-profi flag by default for SamplePGO](https://github.com/llvm/llvm-project/pull/146795).
Discourse conversation: https://discourse.llvm.org/t/turn-on-fsample-profile-use-profi-by-default/86508/2