### PR TITLE
[clang] ms-abi: member pointer inheritance model lock-down fix

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -3613,18 +3613,18 @@ Sema::MemberPointerConversionResult Sema::CheckMemberPointerConversion(
     QualType FromType, const MemberPointerType *ToPtrType, CastKind &Kind,
     CXXCastPath &BasePath, SourceLocation CheckLoc, SourceRange OpRange,
     bool IgnoreBaseAccess, MemberPointerConversionDirection Direction) {
-  const MemberPointerType *FromPtrType = FromType->getAs<MemberPointerType>();
-  if (!FromPtrType) {
-    // This must be a null pointer to member pointer conversion
-    Kind = CK_NullToMemberPointer;
-    return MemberPointerConversionResult::Success;
-  }
-
   // Lock down the inheritance model right now in MS ABI, whether or not the
   // pointee types are the same.
   if (Context.getTargetInfo().getCXXABI().isMicrosoft()) {
     (void)isCompleteType(CheckLoc, FromType);
     (void)isCompleteType(CheckLoc, QualType(ToPtrType, 0));
+  }
+
+  const MemberPointerType *FromPtrType = FromType->getAs<MemberPointerType>();
+  if (!FromPtrType) {
+    // This must be a null pointer to member pointer conversion
+    Kind = CK_NullToMemberPointer;
+    return MemberPointerConversionResult::Success;
   }
 
   // T == T, modulo cv

--- a/clang/test/CodeGenCXX/microsoft-abi-member-pointers.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-member-pointers.cpp
@@ -985,3 +985,10 @@ namespace ContainerOf {
     return reinterpret_cast<Node*>(reinterpret_cast<char*>(list) - offset);
   }
 }
+
+namespace GH144081 {
+  struct A;
+  template<int A::*> void f() {}
+  template void f<nullptr>();
+  // CHECK-LABEL: define{{.*}} void @"??$f@$0A@@GH144081@@YAXXZ"
+} // namespace GH144081


### PR DESCRIPTION
Lock down the inheritance model for member pointers even when converting from nullptr.

This fixes a regression introduced in https://github.com/llvm/llvm-project/pull/131966

There are no release notes, since the regression was never released.

Fixes https://github.com/llvm/llvm-project/issues/144081