### PR TITLE
[lldb][scripts] Fix bugs in framework fix script

### DIFF
--- a/lldb/scripts/framework-header-fix.py
+++ b/lldb/scripts/framework-header-fix.py
@@ -20,7 +20,7 @@ import sys
 
 # Main header regexes
 INCLUDE_FILENAME_REGEX = re.compile(
-    r'#include "lldb/API/(?P<include_filename>.*){0,1}"'
+    r'#include "lldb/(API/)?(?P<include_filename>.*){0,1}"'
 )
 
 # RPC header regexes
@@ -70,7 +70,7 @@ def modify_main_includes(input_file_path, output_file_path):
                     r"#include <LLDB/" + match.group("include_filename") + ">",
                     file_buffer,
                 )
-                output_file.write(file_buffer)
+            output_file.write(file_buffer)
 
 
 def remove_guards(output_file_path, unifdef_path, unifdef_guards):

--- a/lldb/test/Shell/Scripts/Inputs/Main/SBAddress.h
+++ b/lldb/test/Shell/Scripts/Inputs/Main/SBAddress.h
@@ -6,6 +6,7 @@
 // e.g. #include "lldb/API/SBDefines.h" -> #include <LLDB/SBDefines.h>
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBModule.h"
+#include "lldb/lldb-types.h"
 
 // Any include guards specified at the command line must be removed.
 #ifndef SWIG

--- a/lldb/test/Shell/Scripts/TestFrameworkFixScript.test
+++ b/lldb/test/Shell/Scripts/TestFrameworkFixScript.test
@@ -9,3 +9,4 @@ RUN: cat %t/Outputs/SBAddress.h | FileCheck %s
 # e.g. #include "lldb/API/SBDefines.h" -> #include <LLDB/SBDefines.h>
 CHECK: #include <LLDB/SBDefines.h>
 CHECK: #include <LLDB/SBModule.h>
+CHECK: #include <LLDB/lldb-types.h>


### PR DESCRIPTION
The script used to fix up LLDB's header for use in the macOS framework contained 2 bugs that this commit addreses:

1. The output contents were appended to the output file multiple times instead of only being written once.
2. The script was not considering LLDB includes that were *not* from the SB API.

This commit addresses and fixes both of these bugs and updates the corresponding test to match.