### PR TITLE
[Flang][OpenMP] Skip implicit mapping of named constants

### DIFF
--- a/flang/lib/Lower/OpenMP/OpenMP.cpp
+++ b/flang/lib/Lower/OpenMP/OpenMP.cpp
@@ -2395,6 +2395,10 @@ genTargetOp(lower::AbstractConverter &converter, lower::SymMap &symTable,
     if (dsp.getAllSymbolsToPrivatize().contains(&sym))
       return;
 
+    // Skip parameters/constants as they do not need to be mapped.
+    if (semantics::IsNamedConstant(sym))
+      return;
+
     // These symbols are mapped individually in processHasDeviceAddr.
     if (llvm::is_contained(hasDeviceAddrSyms, &sym))
       return;


### PR DESCRIPTION
Added early return when mapping named constants.

This prevents linking error in the following example:

```
program test
   use, intrinsic :: iso_c_binding, only: c_double
   implicit none

   real(c_double) :: x
   integer        :: i
   x = 0.0_c_double
   !$omp target teams distribute parallel do reduction(+:x)
   do i = 0, 9
      x = x + 1.0_c_double
   end do
   !$omp end target teams distribute parallel do
end program test
```