### PR TITLE
[DirectX] Allow vector Allocas to be transformed into arrays

### DIFF
--- a/llvm/test/CodeGen/DirectX/scalarize-alloca.ll
+++ b/llvm/test/CodeGen/DirectX/scalarize-alloca.ll
@@ -2,11 +2,29 @@
 ; RUN: opt -S -passes='dxil-data-scalarization,dxil-flatten-arrays' -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s --check-prefixes=FCHECK,CHECK
 
 ; CHECK-LABEL: alloca_2d__vec_test
-define void @alloca_2d__vec_test() local_unnamed_addr #2 {
+define void @alloca_2d__vec_test() {
   ; SCHECK:  alloca [2 x [4 x i32]], align 16
   ; FCHECK:  alloca [8 x i32], align 16
   ; CHECK: ret void
   %1 = alloca [2 x <4 x i32>], align 16
+  ret void
+}
+
+; CHECK-LABEL: alloca_4d__vec_test
+define void @alloca_4d__vec_test() {
+  ; SCHECK:  alloca [2 x [2 x [2 x [2 x i32]]]], align 16
+  ; FCHECK:  alloca [16 x i32], align 16
+  ; CHECK: ret void
+  %1 = alloca [2 x [2 x [2 x <2 x i32>]]], align 16
+  ret void
+}
+
+; CHECK-LABEL: alloca_vec_test
+define void @alloca_vec_test() {
+  ; SCHECK:  alloca [4 x i32], align 16
+  ; FCHECK:  alloca [4 x i32], align 16
+  ; CHECK: ret void
+  %1 = alloca <4 x i32>, align 16
   ret void
 }
 

--- a/llvm/test/CodeGen/DirectX/scalarize-alloca.ll
+++ b/llvm/test/CodeGen/DirectX/scalarize-alloca.ll
@@ -21,8 +21,7 @@ define void @alloca_4d__vec_test() {
 
 ; CHECK-LABEL: alloca_vec_test
 define void @alloca_vec_test() {
-  ; SCHECK:  alloca [4 x i32], align 16
-  ; FCHECK:  alloca [4 x i32], align 16
+  ; CHECK:  alloca [4 x i32], align 16
   ; CHECK: ret void
   %1 = alloca <4 x i32>, align 16
   ret void

--- a/llvm/test/tools/dxil-dis/shuffle.ll
+++ b/llvm/test/tools/dxil-dis/shuffle.ll
@@ -1,4 +1,4 @@
-; RUN: llc --filetype=obj %s -o - 2>&1 | dxil-dis -o - | FileCheck %s
+; RUN: llc -start-after=dxil-flatten-arrays --filetype=obj %s -o - 2>&1 | dxil-dis -o - | FileCheck %s
 target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-unknown-shadermodel6.7-library"
 


### PR DESCRIPTION
fixes #145782

This change modifies `isArrayOfVectors` into `isVectorOrArrayOfVectors`. The previous implementation did not support vector to array transformations. Further it was too simplistic and didn't assume allocas would create multidimensional arrays.