### PR TITLE
[lldb] Add class property for the version string

### DIFF
--- a/lldb/bindings/interface/SBDebuggerExtensions.i
+++ b/lldb/bindings/interface/SBDebuggerExtensions.i
@@ -45,4 +45,17 @@ STRING_EXTENSION_OUTSIDE(SBDebugger)
     lldb::FileSP GetErrorFileHandle() {
         return self->GetErrorFile().GetFile();
     }
+
+#ifdef SWIGPYTHON
+    %pythoncode %{
+        class staticproperty:
+            def __init__(self, func):
+                self.func = func
+            def __get__(self, instance, owner):
+                return self.func()
+        @staticproperty
+        def version():
+            return SBDebugger.GetVersionString()
+    %}
+#endif
 }

--- a/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
+++ b/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
@@ -286,3 +286,11 @@ class DebuggerAPITestCase(TestBase):
             ('remove bar ret', False), # remove_bar should fail, because it's already invoked and removed
             ('foo called', original_dbg_id), # foo should be called
         ])
+
+    def test_version(self):
+        instance_str = self.dbg.GetVersionString()
+        class_str = lldb.SBDebugger.GetVersionString()
+        property_str = lldb.SBDebugger.version
+
+        self.assertEqual(instance_str, class_str)
+        self.assertEqual(class_str, property_str)


### PR DESCRIPTION
Add a class property for the version string. This allows you to use access the version string through `lldb.SBDebugger.version` instead of having to call `lldb.SBDebugger.GetVersionString()`.