### PR TITLE
[lldb] Fix another race condition in Target::GetExecutableModule

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1510,15 +1510,18 @@ bool Target::IgnoreWatchpointByID(lldb::watch_id_t watch_id,
 }
 
 ModuleSP Target::GetExecutableModule() {
-  // search for the first executable in the module list
-  for (ModuleSP module_sp : m_images.Modules()) {
+  std::lock_guard<std::recursive_mutex> lock(m_images.GetMutex());
+
+  // Search for the first executable in the module list.
+  for (ModuleSP module_sp : m_images.ModulesNoLocking()) {
     lldb_private::ObjectFile *obj = module_sp->GetObjectFile();
     if (obj == nullptr)
       continue;
     if (obj->GetType() == ObjectFile::Type::eTypeExecutable)
       return module_sp;
   }
-  // as fall back return the first module loaded
+
+  // If there is none, fall back return the first module loaded.
   return m_images.GetModuleAtIndex(0);
 }
 


### PR DESCRIPTION
c72c0b298c13 fixed a race condition in Target::GetExecutableModule. The patch originally added the lock_guard but I suggested using the locking ModuleList::Modules() helper instead. That didn't consider that the fallback would still access the ModuleList without holding the lock. This patch fixes the remaining issue.