### PR TITLE
[lldb][scripts] Use named args in versioning script

### DIFF
--- a/lldb/scripts/version-header-fix.py
+++ b/lldb/scripts/version-header-fix.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
-Usage: <path/to/input-header.h> <path/to/output-header.h> LLDB_MAJOR_VERSION LLDB_MINOR_VERSION LLDB_PATCH_VERSION
+Usage: -i <path/to/input-header.h> -o <path/to/output-header.h> -m LLDB_MAJOR_VERSION -n LLDB_MINOR_VERSION -p LLDB_PATCH_VERSION
 
-This script uncomments and populates the versioning information in lldb-defines.h
+This script uncomments and populates the versioning information in lldb-defines.h. Note that the LLDB version numbering looks like MAJOR.MINOR.PATCH
 """
 
 import argparse
@@ -15,18 +15,19 @@ LLDB_VERSION_STRING_REGEX = re.compile(r"//\s*#define LLDB_VERSION_STRING\s*$", 
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("input_path")
-    parser.add_argument("output_path")
-    parser.add_argument("lldb_version_major")
-    parser.add_argument("lldb_version_minor")
-    parser.add_argument("lldb_version_patch")
+    parser = argparse.ArgumentParser(
+        description="This script uncomments and populates the versioning information in lldb-defines.h. Note that the LLDB version numbering looks like MAJOR.MINOR.PATCH"
+    )
+    parser.add_argument("-i", "--input_path", help="The filepath for the input header.")
+    parser.add_argument(
+        "-o", "--output_path", help="The filepath for the output header."
+    )
+    parser.add_argument("-m", "--major", help="The LLDB version major.")
+    parser.add_argument("-n", "--minor", help="The LLDB version minor.")
+    parser.add_argument("-p", "--patch", help="The LLDB version patch number.")
     args = parser.parse_args()
     input_path = str(args.input_path)
     output_path = str(args.output_path)
-    lldb_version_major = args.lldb_version_major
-    lldb_version_minor = args.lldb_version_minor
-    lldb_version_patch = args.lldb_version_patch
 
     with open(input_path, "r") as input_file:
         lines = input_file.readlines()
@@ -38,19 +39,19 @@ def main():
         # e.g. //#define LLDB_VERSION -> #define LLDB_VERSION <LLDB_MAJOR_VERSION>
         file_buffer = re.sub(
             LLDB_VERSION_REGEX,
-            r"#define LLDB_VERSION " + lldb_version_major,
+            r"#define LLDB_VERSION " + args.major,
             file_buffer,
         )
 
         file_buffer = re.sub(
             LLDB_REVISION_REGEX,
-            r"#define LLDB_REVISION " + lldb_version_patch,
+            r"#define LLDB_REVISION " + args.patch,
             file_buffer,
         )
         file_buffer = re.sub(
             LLDB_VERSION_STRING_REGEX,
             r'#define LLDB_VERSION_STRING "{0}.{1}.{2}"'.format(
-                lldb_version_major, lldb_version_minor, lldb_version_patch
+                args.major, args.minor, args.patch
             ),
             file_buffer,
         )

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -326,7 +326,7 @@ foreach(header
 endforeach()
 
 add_custom_command(TARGET liblldb POST_BUILD
-  COMMAND "${Python3_EXECUTABLE}" ${LLDB_SOURCE_DIR}/scripts/version-header-fix.py ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h ${lldb_header_staging_dir}/lldb-defines.h ${LLDB_VERSION_MAJOR} ${LLDB_VERSION_MINOR} ${LLDB_VERSION_PATCH}
+  COMMAND "${Python3_EXECUTABLE}" ${LLDB_SOURCE_DIR}/scripts/version-header-fix.py -i ${LLDB_SOURCE_DIR}/include/lldb/lldb-defines.h -o ${lldb_header_staging_dir}/lldb-defines.h -m ${LLDB_VERSION_MAJOR} -n ${LLDB_VERSION_MINOR} -p ${LLDB_VERSION_PATCH}
 )
 add_custom_target(liblldb-header-staging DEPENDS ${lldb_staged_headers})
 add_dependencies(liblldb liblldb-header-staging)

--- a/lldb/test/Shell/Scripts/TestVersionFixScript.test
+++ b/lldb/test/Shell/Scripts/TestVersionFixScript.test
@@ -1,6 +1,6 @@
 # Create a temp dir for output and run the version fix script on the truncated version of lldb-defines.h in the inputs dir.
 RUN: mkdir -p %t/Outputs
-RUN: %python %p/../../../scripts/version-header-fix.py %p/Inputs/lldb-defines.h %t/Outputs/lldb-defines.h 21 0 12
+RUN: %python %p/../../../scripts/version-header-fix.py --input_path %p/Inputs/lldb-defines.h --output_path %t/Outputs/lldb-defines.h --major 21 --minor 0 --patch 12
 
 # Check the output
 RUN: cat %t/Outputs/lldb-defines.h | FileCheck %s


### PR DESCRIPTION
Using named args means that you don't need to keep track of 5 positional args.