### PR TITLE
[llvm] Use a new constructor of ArrayRef (NFC)

### DIFF
--- a/llvm/include/llvm/Object/ELF.h
+++ b/llvm/include/llvm/Object/ELF.h
@@ -931,7 +931,7 @@ Expected<typename ELFT::ShdrRange> ELFFile<ELFT>::sections() const {
   const uintX_t SectionTableOffset = getHeader().e_shoff;
   if (SectionTableOffset == 0) {
     if (!FakeSections.empty())
-      return ArrayRef(FakeSections.data(), FakeSections.size());
+      return ArrayRef(FakeSections);
     return ArrayRef<Elf_Shdr>();
   }
 

--- a/llvm/lib/ExecutionEngine/JITLink/XCOFFLinkGraphBuilder.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/XCOFFLinkGraphBuilder.cpp
@@ -296,7 +296,7 @@ Error XCOFFLinkGraphBuilder::processCsectsAndSymbols() {
       if (!CsectSymbolAddr)
         return CsectSymbolAddr.takeError();
 
-      ArrayRef<char> SectionBuffer{Data->data(), Data->size()};
+      ArrayRef<char> SectionBuffer{*Data};
       auto Offset = *CsectSymbolAddr - SectionRef.getAddress();
 
       LLVM_DEBUG(dbgs() << "      symbol entry: offset = " << Offset

--- a/llvm/lib/ExecutionEngine/Orc/SectCreate.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/SectCreate.cpp
@@ -23,8 +23,7 @@ void SectCreateMaterializationUnit::materialize(
       SubtargetFeatures(), getGenericEdgeKindName);
 
   auto &Sect = G->createSection(SectName, MP);
-  auto Content = G->allocateContent(
-      ArrayRef<char>(Data->getBuffer().data(), Data->getBuffer().size()));
+  auto Content = G->allocateContent(ArrayRef<char>(Data->getBuffer()));
   auto &B = G->createContentBlock(Sect, Content, ExecutorAddr(), Alignment, 0);
 
   for (auto &[Name, Info] : ExtraSymbols) {

--- a/llvm/lib/Object/OffloadBundle.cpp
+++ b/llvm/lib/Object/OffloadBundle.cpp
@@ -339,8 +339,7 @@ CompressedOffloadBundle::decompress(llvm::MemoryBufferRef &Input,
     HashRecalcTimer.startTimer();
     llvm::MD5 Hash;
     llvm::MD5::MD5Result Result;
-    Hash.update(llvm::ArrayRef<uint8_t>(DecompressedData.data(),
-                                        DecompressedData.size()));
+    Hash.update(llvm::ArrayRef<uint8_t>(DecompressedData));
     Hash.final(Result);
     uint64_t RecalculatedHash = Result.low();
     HashRecalcTimer.stopTimer();

--- a/llvm/lib/XRay/FDRTraceWriter.cpp
+++ b/llvm/lib/XRay/FDRTraceWriter.cpp
@@ -96,7 +96,7 @@ Error FDRTraceWriter::visit(CustomEventRecord &R) {
   if (auto E = writeMetadata<5u>(OS, R.size(), R.tsc(), R.cpu()))
     return E;
   auto D = R.data();
-  ArrayRef<char> Bytes(D.data(), D.size());
+  ArrayRef<char> Bytes(D);
   OS.write(Bytes);
   return Error::success();
 }
@@ -105,7 +105,7 @@ Error FDRTraceWriter::visit(CustomEventRecordV5 &R) {
   if (auto E = writeMetadata<5u>(OS, R.size(), R.delta()))
     return E;
   auto D = R.data();
-  ArrayRef<char> Bytes(D.data(), D.size());
+  ArrayRef<char> Bytes(D);
   OS.write(Bytes);
   return Error::success();
 }
@@ -114,7 +114,7 @@ Error FDRTraceWriter::visit(TypedEventRecord &R) {
   if (auto E = writeMetadata<8u>(OS, R.size(), R.delta(), R.eventType()))
     return E;
   auto D = R.data();
-  ArrayRef<char> Bytes(D.data(), D.size());
+  ArrayRef<char> Bytes(D);
   OS.write(Bytes);
   return Error::success();
 }

--- a/llvm/tools/llvm-mc/Disassembler.cpp
+++ b/llvm/tools/llvm-mc/Disassembler.cpp
@@ -35,7 +35,7 @@ typedef std::pair<std::vector<unsigned char>, std::vector<const char *>>
 static bool PrintInsts(const MCDisassembler &DisAsm, const ByteArrayTy &Bytes,
                        SourceMgr &SM, MCStreamer &Streamer, bool InAtomicBlock,
                        const MCSubtargetInfo &STI) {
-  ArrayRef<uint8_t> Data(Bytes.first.data(), Bytes.first.size());
+  ArrayRef<uint8_t> Data(Bytes.first);
 
   // Disassemble it to strings.
   uint64_t Size;

--- a/llvm/tools/llvm-ml/Disassembler.cpp
+++ b/llvm/tools/llvm-ml/Disassembler.cpp
@@ -33,7 +33,7 @@ typedef std::pair<std::vector<unsigned char>, std::vector<const char *>>
 static bool PrintInsts(const MCDisassembler &DisAsm, const ByteArrayTy &Bytes,
                        SourceMgr &SM, raw_ostream &Out, MCStreamer &Streamer,
                        bool InAtomicBlock, const MCSubtargetInfo &STI) {
-  ArrayRef<uint8_t> Data(Bytes.first.data(), Bytes.first.size());
+  ArrayRef<uint8_t> Data(Bytes.first);
 
   // Disassemble it to strings.
   uint64_t Size;

--- a/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
+++ b/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
@@ -921,7 +921,7 @@ static int linkAndVerify() {
     RuntimeDyldChecker::MemoryRegionInfo SecInfo;
     SecInfo.setTargetAddress(Dyld.getSectionLoadAddress(*SectionID));
     StringRef SecContent = Dyld.getSectionContent(*SectionID);
-    SecInfo.setContent(ArrayRef<char>(SecContent.data(), SecContent.size()));
+    SecInfo.setContent(ArrayRef<char>(SecContent));
     return SecInfo;
   };
 
@@ -945,8 +945,7 @@ static int linkAndVerify() {
                                  SI.Offset);
     StringRef SecContent =
         Dyld.getSectionContent(SI.SectionID).substr(SI.Offset);
-    StubMemInfo.setContent(
-        ArrayRef<char>(SecContent.data(), SecContent.size()));
+    StubMemInfo.setContent(ArrayRef<char>(SecContent));
     return StubMemInfo;
   };
 

--- a/llvm/unittests/ExecutionEngine/Orc/ExecutionSessionWrapperFunctionCallsTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ExecutionSessionWrapperFunctionCallsTest.cpp
@@ -110,7 +110,7 @@ TEST(ExecutionSessionWrapperFunctionCalls, RegisterAsyncHandlerAndRun) {
         EXPECT_TRUE(SPSArgList<int32_t>::deserialize(IB, Result));
         RP.set_value(Result);
       },
-      AddAsyncTagAddr, ArrayRef<char>(ArgBuffer.data(), ArgBuffer.size()));
+      AddAsyncTagAddr, ArrayRef<char>(ArgBuffer));
 
   EXPECT_EQ(RF.get(), (int32_t)3);
 

--- a/llvm/unittests/Support/Base64Test.cpp
+++ b/llvm/unittests/Support/Base64Test.cpp
@@ -31,7 +31,7 @@ void TestBase64Decode(StringRef Input, StringRef Expected,
   if (ExpectedErrorMessage.empty()) {
     ASSERT_THAT_ERROR(decodeBase64(Input, DecodedBytes), Succeeded());
     EXPECT_EQ(llvm::ArrayRef<char>(DecodedBytes),
-              llvm::ArrayRef<char>(Expected.data(), Expected.size()));
+              llvm::ArrayRef<char>(Expected));
   } else {
     ASSERT_THAT_ERROR(decodeBase64(Input, DecodedBytes),
                       FailedWithMessage(ExpectedErrorMessage));


### PR DESCRIPTION
ArrayRef now has a new constructor that takes a parameter whose type
has data() and size().  This patch migrates:

  ArrayRef<T>(X.data(), X.size()

to:

  ArrayRef<T>(X)
