### PR TITLE
[ADT] Remove a constructor (NFC)

### DIFF
--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -64,6 +64,11 @@ struct ASTFileSignature : std::array<uint8_t, 20> {
 
   explicit operator bool() const { return *this != BaseT({{0}}); }
 
+  // Support implicit cast to ArrayRef.  Note that ASTFileSignature::size
+  // prevents implicit cast to ArrayRef because one of the implicit constructors
+  // of ArrayRef requires access to BaseT::size.
+  operator ArrayRef<uint8_t>() const { return ArrayRef<uint8_t>(data(), size); }
+
   /// Returns the value truncated to the size of an uint64_t.
   uint64_t truncatedValue() const {
     uint64_t Value = 0;

--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -98,11 +98,6 @@ namespace llvm {
     /*implicit*/ constexpr ArrayRef(const C &V)
         : Data(V.data()), Length(V.size()) {}
 
-    /// Construct an ArrayRef from a std::array
-    template <size_t N>
-    /*implicit*/ constexpr ArrayRef(const std::array<T, N> &Arr)
-        : Data(Arr.data()), Length(N) {}
-
     /// Construct an ArrayRef from a C array.
     template <size_t N>
     /*implicit*/ constexpr ArrayRef(const T (&Arr LLVM_LIFETIME_BOUND)[N])


### PR DESCRIPTION
ArrayRef now has a new constructor that takes a parameter whose type
has data() and size() methods.  Since the new constructor subsumes
another constructor that takes std::array, this patch removes that
constructor.  Note that std::array also comes with data() and size()
methods.

The only problem is that ASTFileSignature in the clang frontend does
not work with the new ArrayRef constructor because it overrides size,
blocking access to std::array<uint8_t, 20>::size().  This patch adds
an implicit cast operator to ArrayRef.  Note that ASTFileSignature is
defined as:

  struct ASTFileSignature : std::array<uint8_t, 20> {
    using BaseT = std::array<uint8_t, 20>;
    static constexpr size_t size = std::tuple_size<BaseT>::value;
    :
