### PR TITLE
[BOLT] Skip creation of new segments

### DIFF
--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -4190,6 +4190,11 @@ void RewriteInstance::patchELFPHDRTable() {
     NewWritableSegmentSize = NextAvailableAddress - NewWritableSegmentAddress;
   }
 
+  if (!NewTextSegmentSize && !NewWritableSegmentSize) {
+    BC->outs() << "BOLT-INFO: not adding new segments\n";
+    return;
+  }
+
   const uint64_t SavedPos = OS.tell();
   OS.seek(PHDRTableOffset);
 

--- a/bolt/test/program-header.test
+++ b/bolt/test/program-header.test
@@ -1,0 +1,14 @@
+# Check that llvm-bolt does not add new segments when writing code in-place.
+
+REQUIRES: system-linux
+
+RUN: %clang %cflags %p/Inputs/hello.c -o %t -no-pie -Wl,-q
+RUN: llvm-bolt %t -o %t.bolt --use-old-text --align-functions=1 \
+RUN:   --no-huge-pages --align-text=1 --use-gnu-stack \
+RUN:   | FileCheck %s --check-prefix=CHECK-BOLT
+RUN: llvm-readelf -WS %t.bolt | FileCheck %s
+
+CHECK-BOLT: rewriting .eh_frame_hdr in-place
+CHECK-BOLT: not adding new segments
+
+CHECK-NOT: .bolt.org.eh_frame_hdr


### PR DESCRIPTION
When all section contents are updated in-place, we can skip creation of new segment(s), save disk space, and free up low memory addresses.

Currently, this feature only works with --use-gnu-stack.