### PR TITLE
[PassBuilder] Treat pipeline aliases as normal passes

### DIFF
--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -240,6 +240,43 @@ MODULE_PASS_WITH_PARAMS(
     },
     parseStructuralHashPrinterPassOptions, "detailed;call-target-ignored")
 
+MODULE_PASS_WITH_PARAMS(
+    "default", "", [&](OptimizationLevel L) {
+      setupOptionsForPipelineAlias(PTO, L);
+      return buildPerModuleDefaultPipeline(L);
+    },
+    parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
+MODULE_PASS_WITH_PARAMS(
+    "thinlto-pre-link", "", [&](OptimizationLevel L) {
+      setupOptionsForPipelineAlias(PTO, L);
+      return buildThinLTOPreLinkDefaultPipeline(L);
+    },
+    parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
+MODULE_PASS_WITH_PARAMS(
+    "thinlto", "", [&](OptimizationLevel L) {
+      setupOptionsForPipelineAlias(PTO, L);
+      return buildThinLTODefaultPipeline(L, nullptr);
+    },
+    parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
+MODULE_PASS_WITH_PARAMS(
+    "lto-pre-link", "", [&](OptimizationLevel L) {
+      setupOptionsForPipelineAlias(PTO, L);
+      if (PTO.UnifiedLTO)
+        // When UnifiedLTO is enabled, use the ThinLTO pre-link pipeline. This
+        // avoids compile-time performance regressions and keeps the pre-link
+        // LTO pipeline "unified" for both LTO modes.
+        return buildThinLTOPreLinkDefaultPipeline(L);
+      else
+        return buildLTOPreLinkDefaultPipeline(L);
+    },
+    parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
+MODULE_PASS_WITH_PARAMS(
+    "lto", "", [&](OptimizationLevel L) {
+      setupOptionsForPipelineAlias(PTO, L);
+      return buildLTODefaultPipeline(L, nullptr);
+    },
+    parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
+
 #undef MODULE_PASS_WITH_PARAMS
 
 #ifndef CGSCC_ANALYSIS

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -261,13 +261,13 @@ MODULE_PASS_WITH_PARAMS(
 MODULE_PASS_WITH_PARAMS(
     "lto-pre-link", "", [&](OptimizationLevel L) {
       setupOptionsForPipelineAlias(PTO, L);
-      if (PTO.UnifiedLTO)
+      if (PTO.UnifiedLTO) {
         // When UnifiedLTO is enabled, use the ThinLTO pre-link pipeline. This
         // avoids compile-time performance regressions and keeps the pre-link
         // LTO pipeline "unified" for both LTO modes.
         return buildThinLTOPreLinkDefaultPipeline(L);
-      else
-        return buildLTOPreLinkDefaultPipeline(L);
+      }
+      return buildLTOPreLinkDefaultPipeline(L);
     },
     parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
 MODULE_PASS_WITH_PARAMS(

--- a/llvm/test/Other/pipeline-alias-errors.ll
+++ b/llvm/test/Other/pipeline-alias-errors.ll
@@ -1,0 +1,5 @@
+; RUN: not opt -passes="default" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
+; RUN: not opt -passes="default<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
+
+; MISSING-OPT-LEVEL: invalid optimization level ''
+; INVALID-OPT-LEVEL: invalid optimization level 'foo'

--- a/llvm/test/Other/pipeline-alias-errors.ll
+++ b/llvm/test/Other/pipeline-alias-errors.ll
@@ -1,5 +1,13 @@
 ; RUN: not opt -passes="default" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
 ; RUN: not opt -passes="default<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
+; RUN: not opt -passes="thinlto-pre-link" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
+; RUN: not opt -passes="thinlto-pre-link<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
+; RUN: not opt -passes="thinlto" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
+; RUN: not opt -passes="thinlto<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
+; RUN: not opt -passes="lto-pre-link" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
+; RUN: not opt -passes="lto-pre-link<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
+; RUN: not opt -passes="lto" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
+; RUN: not opt -passes="lto<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
 
 ; MISSING-OPT-LEVEL: invalid optimization level ''
 ; INVALID-OPT-LEVEL: invalid optimization level 'foo'


### PR DESCRIPTION
Pipelines like `-passes="default<O3>"` are currently parsed in a special way. Switch them to work like normal, parameterized module passes.