### PR TITLE
[analyzer] Fix tests broken by empty %z3_include_dir

### DIFF
--- a/clang/test/Analysis/z3-crosscheck-max-attempts.cpp
+++ b/clang/test/Analysis/z3-crosscheck-max-attempts.cpp
@@ -4,7 +4,7 @@
 // CHECK: crosscheck-with-z3-max-attempts-per-query = 3
 
 // RUN: rm -rf %t && mkdir %t
-// RUN: %host_cxx -shared -fPIC -I %z3_include_dir        \
+// RUN: %host_cxx -shared -fPIC %I_z3_include_dir         \
 // RUN:   %S/z3/Inputs/MockZ3_solver_check.cpp            \
 // RUN:   -o %t/MockZ3_solver_check.so
 

--- a/clang/test/Analysis/z3/D83660.c
+++ b/clang/test/Analysis/z3/D83660.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir %t
-// RUN: %host_cxx -shared -fPIC -I %z3_include_dir \
+// RUN: %host_cxx -shared -fPIC %I_z3_include_dir \
 // RUN:   %S/Inputs/MockZ3_solver_check.cpp \
 // RUN:   -o %t/MockZ3_solver_check.so
 //

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -180,9 +180,7 @@ if config.clang_staticanalyzer:
             I_z3_include_dir = '-I "%s"' % config.clang_staticanalyzer_z3_include_dir
     else:
         config.available_features.add("no-z3")
-    config.substitutions.append(
-        ("%I_z3_include_dir", I_z3_include_dir)
-    )
+    config.substitutions.append(("%I_z3_include_dir", I_z3_include_dir))
 
     check_analyzer_fixit_path = os.path.join(
         config.test_source_root, "Analysis", "check-analyzer-fixit.py"

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -173,13 +173,16 @@ if config.clang_staticanalyzer:
     config.available_features.add("staticanalyzer")
     tools.append("clang-check")
 
+    I_z3_include_dir = ""
     if config.clang_staticanalyzer_z3:
         config.available_features.add("z3")
-        config.substitutions.append(
-            ("%z3_include_dir", config.clang_staticanalyzer_z3_include_dir)
-        )
+        if config.clang_staticanalyzer_z3_include_dir:
+            I_z3_include_dir = '-I "%s"' % config.clang_staticanalyzer_z3_include_dir
     else:
         config.available_features.add("no-z3")
+    config.substitutions.append(
+        ("%I_z3_include_dir", I_z3_include_dir)
+    )
 
     check_analyzer_fixit_path = os.path.join(
         config.test_source_root, "Analysis", "check-analyzer-fixit.py"


### PR DESCRIPTION
This commit should fix the build failure caused by my recent commit 40cc4379cda6e0d6efe72c55d1968f9cf427a16a