### PR TITLE
[PassBuilder][FatLTO] Expose FatLTO pipeline via pipeline string

### DIFF
--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -1511,6 +1511,41 @@ Expected<bool> parseVirtRegRewriterPassOptions(StringRef Params) {
   return ClearVirtRegs;
 }
 
+struct FatLTOOptions {
+  OptimizationLevel OptLevel;
+  bool ThinLTO = false;
+  bool EmitSummary = false;
+};
+
+Expected<FatLTOOptions> parseFatLTOOptions(StringRef Params) {
+  FatLTOOptions Result;
+  bool HaveOptLevel = false;
+  while (!Params.empty()) {
+    StringRef ParamName;
+    std::tie(ParamName, Params) = Params.split(';');
+
+    if (ParamName == "thinlto") {
+      Result.ThinLTO = true;
+    } else if (ParamName == "emit-summary") {
+      Result.EmitSummary = true;
+    } else if (std::optional<OptimizationLevel> OptLevel =
+                   parseOptLevel(ParamName)) {
+      Result.OptLevel = *OptLevel;
+      HaveOptLevel = true;
+    } else {
+      return make_error<StringError>(
+          formatv("invalid fatlto-pre-link pass parameter '{}'", ParamName)
+              .str(),
+          inconvertibleErrorCode());
+    }
+  }
+  if (!HaveOptLevel)
+    return make_error<StringError>(
+        "missing optimization level for fatlto-pre-link pipeline",
+        inconvertibleErrorCode());
+  return Result;
+}
+
 } // namespace
 
 /// Tests whether registered callbacks will accept a given pass name.

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -276,6 +276,13 @@ MODULE_PASS_WITH_PARAMS(
       return buildLTODefaultPipeline(L, nullptr);
     },
     parseOptLevelParam, "O0;O1;O2;O3;Os;Oz")
+MODULE_PASS_WITH_PARAMS(
+    "fatlto-pre-link", "", [&](FatLTOOptions Opts) {
+      setupOptionsForPipelineAlias(PTO, Opts.OptLevel);
+      return buildFatLTODefaultPipeline(Opts.OptLevel, Opts.ThinLTO,
+                                        Opts.EmitSummary);
+    },
+    parseFatLTOOptions, "O0;O1;O2;O3;Os;Oz;thinlto;emit-summary")
 
 #undef MODULE_PASS_WITH_PARAMS
 

--- a/llvm/test/Other/fatlto.ll
+++ b/llvm/test/Other/fatlto.ll
@@ -1,0 +1,7 @@
+; RUN: opt -debug-pass-manager -passes='fatlto-pre-link<O2>' -disable-output %s 2>&1 | FileCheck %s
+; RUN: opt -debug-pass-manager -passes='fatlto-pre-link<O2;thinlto>' -disable-output %s 2>&1 | FileCheck %s --check-prefixes=CHECK,THINLTO
+
+; CHECK: Running pass: EmbedBitcodePass on [module]
+; THINLTO: Running analysis: ModuleSummaryIndexAnalysis on [module]
+; CHECK-NEXT: Running pass: FatLtoCleanup on [module]
+; CHECK-NEXT: Running pass: LowerTypeTestsPass on [module]

--- a/llvm/test/Other/pipeline-alias-errors.ll
+++ b/llvm/test/Other/pipeline-alias-errors.ll
@@ -8,6 +8,11 @@
 ; RUN: not opt -passes="lto-pre-link<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
 ; RUN: not opt -passes="lto" < %s 2>&1 | FileCheck %s --check-prefix=MISSING-OPT-LEVEL
 ; RUN: not opt -passes="lto<foo>" < %s 2>&1 | FileCheck %s --check-prefix=INVALID-OPT-LEVEL
+; RUN: not opt -passes="fatlto-pre-link" < %s 2>&1 | FileCheck %s --check-prefix=FATLTO-MISSING-OPT-LEVEL
+; RUN: not opt -passes="fatlto-pre-link<foo>" < %s 2>&1 | FileCheck %s --check-prefix=FATLTO-INVALID-PARAMS
 
 ; MISSING-OPT-LEVEL: invalid optimization level ''
 ; INVALID-OPT-LEVEL: invalid optimization level 'foo'
+
+; FATLTO-MISSING-OPT-LEVEL: missing optimization level for fatlto-pre-link pipeline
+; FATLTO-INVALID-PARAMS: invalid fatlto-pre-link pass parameter 'foo'


### PR DESCRIPTION
Expose the FatLTO pipeline via `-passes="fatlto-pre-link<Ox>"`, similar to all the other optimization pipelines. This is to allow reproducing it outside clang. (Possibly also useful for C API users.)