### PR TITLE
[compiler-rt][ARM] Only use bxaut when the target has pacbti

### DIFF
--- a/compiler-rt/lib/builtins/arm/aeabi_cdcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_cdcmp.S
@@ -128,7 +128,7 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_cdcmple)
         msr APSR_nzcvq, ip
 #if defined(__ARM_FEATURE_PAC_DEFAULT)
         pop {r0-r3, r12, lr}
-        bxaut r12, lr, sp
+        PAC_RETURN
 #else
         pop {r0-r3}
         POP_PC()

--- a/compiler-rt/lib/builtins/arm/aeabi_cfcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_cfcmp.S
@@ -128,7 +128,7 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_cfcmple)
         msr APSR_nzcvq, ip
 #if defined(__ARM_FEATURE_PAC_DEFAULT)
         pop {r0-r3, r12, lr}
-        bxaut r12, lr, sp
+        PAC_RETURN
 #else
         pop {r0-r3}
         POP_PC()

--- a/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_dcmp.S
@@ -29,7 +29,7 @@
 #  define PROLOGUE PACBTI_LANDING        SEPARATOR \
                    push      { r12, lr }
 #  define EPILOGUE pop       { r12, lr } SEPARATOR \
-                   bxaut     r12, lr, sp
+                   PAC_RETURN
 #elif defined(__ARM_FEATURE_BTI_DEFAULT)
 #  define PROLOGUE PACBTI_LANDING        SEPARATOR \
                    push      { r4, lr }

--- a/compiler-rt/lib/builtins/arm/aeabi_fcmp.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_fcmp.S
@@ -29,7 +29,7 @@
 #  define PROLOGUE PACBTI_LANDING        SEPARATOR \
                    push      { r12, lr }
 #  define EPILOGUE pop       { r12, lr } SEPARATOR \
-                   bxaut     r12, lr, sp
+                   PAC_RETURN
 #elif defined(__ARM_FEATURE_BTI_DEFAULT)
 #  define PROLOGUE PACBTI_LANDING        SEPARATOR \
                    push      { r4, lr }

--- a/compiler-rt/lib/builtins/arm/aeabi_idivmod.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_idivmod.S
@@ -49,7 +49,7 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_idivmod)
         add     sp, sp, #4
 #if defined(__ARM_FEATURE_PAC_DEFAULT)
         pop     { r12, lr }
-        bxaut   r12, lr, sp
+        PAC_RETURN
 #else
         pop     { pc }
 #endif

--- a/compiler-rt/lib/builtins/arm/aeabi_ldivmod.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_ldivmod.S
@@ -45,7 +45,7 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_ldivmod)
         add     sp, sp, #16
 #if defined(__ARM_FEATURE_PAC_DEFAULT)
         pop     {r6, r12, lr}
-        bxaut   r12, lr, sp
+        PAC_RETURN
 #else
         pop     {r6, pc}
 #endif

--- a/compiler-rt/lib/builtins/arm/aeabi_uidivmod.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_uidivmod.S
@@ -56,7 +56,7 @@ LOCAL_LABEL(case_denom_larger):
         add     sp, sp, #4
 #if defined(__ARM_FEATURE_PAC_DEFAULT)
         pop     { r12, lr }
-        bxaut   r12, lr, sp
+        PAC_RETURN
 #else
         pop     { pc }
 #endif

--- a/compiler-rt/lib/builtins/arm/aeabi_uldivmod.S
+++ b/compiler-rt/lib/builtins/arm/aeabi_uldivmod.S
@@ -45,7 +45,7 @@ DEFINE_COMPILERRT_FUNCTION(__aeabi_uldivmod)
         add	sp, sp, #16
 #if defined(__ARM_FEATURE_PAC_DEFAULT)
         pop     {r6, r12, lr}
-        bxaut   r12, lr, sp
+        PAC_RETURN
 #else
         pop     {r6, pc}
 #endif

--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -205,6 +205,12 @@
 #define PACBTI_LANDING
 #endif
 
+#if defined(__ARM_FEATURE_PAUTH)
+#define PAC_RETURN bxaut r12, lr, sp
+#else
+#define PAC_RETURN aut r12, lr, sp SEPARATOR bx lr
+#endif
+
 #else // !defined(__arm)
 #define DECLARE_FUNC_ENCODING
 #define DEFINE_CODE_STATE


### PR DESCRIPTION
Most pacbti instructions are a nop when the target does not have pacbti, and thus safe to execute, but bxaut is an undefined instruction. When we don't have pacbti (e.g. if we're compiling compiler-rt with -mbranch-protection=standard in order to be forward-compatible with pacbti while still working on targets without it) then we need to use separate aut and bx instructions.