### PR TITLE
[lldb][NFC] Inline ResolveSDKPathFromDebugInfo in one of its call site

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1163,7 +1163,7 @@ void PlatformDarwin::AddClangModuleCompilationOptionsForSDKType(
   FileSpec sysroot_spec;
 
   if (target) {
-    auto sysroot_spec_or_err = ResolveSDKPathFromDebugInfo(target);
+    auto sysroot_spec_or_err = ::ResolveSDKPathFromDebugInfo(target);
     if (!sysroot_spec_or_err) {
       LLDB_LOG_ERROR(GetLog(LLDBLog::Types | LLDBLog::Host),
                      sysroot_spec_or_err.takeError(),

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1156,15 +1156,11 @@ lldb_private::PlatformDarwin::ResolveSDKPathFromDebugInfo(
 
   ModuleSP exe_module_sp = target->GetExecutableModule();
   if (!exe_module_sp)
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        llvm::formatv("Failed to get module from target"));
+    return llvm::createStringError("Failed to get module from target");
 
   SymbolFile *sym_file = exe_module_sp->GetSymbolFile();
   if (!sym_file)
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        llvm::formatv("Failed to get symbol file from module"));
+    return llvm::createStringError("Failed to get symbol file from module");
 
   XcodeSDK merged_sdk;
   for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
@@ -1185,9 +1181,8 @@ lldb_private::PlatformDarwin::ResolveSDKPathFromDebugInfo(
     return FileSpec(*path_or_err);
 
   return llvm::createStringError(
-      llvm::inconvertibleErrorCode(),
       llvm::formatv("Failed to resolve SDK path: {0}",
-                    llvm::toString(path_or_err.takeError())));
+                    llvm::toString(path_or_err.takeError()));
 }
 
 ConstString PlatformDarwin::GetFullNameForDylib(ConstString basename) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1130,13 +1130,33 @@ void PlatformDarwin::AddClangModuleCompilationOptionsForSDKType(
 
   if (target) {
     if (ModuleSP exe_module_sp = target->GetExecutableModule()) {
-      auto path_or_err = ResolveSDKPathFromDebugInfo(*exe_module_sp);
-      if (path_or_err) {
-        sysroot_spec = FileSpec(*path_or_err);
+      SymbolFile *sym_file = exe_module_sp->GetSymbolFile();
+      if (!sym_file)
+        return;
+
+      XcodeSDK merged_sdk;
+      for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
+        if (auto cu_sp = sym_file->GetCompileUnitAtIndex(i)) {
+          auto cu_sdk = sym_file->ParseXcodeSDK(*cu_sp);
+          merged_sdk.Merge(cu_sdk);
+        }
+      }
+
+      // TODO: The result of this loop is almost equivalent to deriving the SDK
+      // from the target triple, which would be a lot cheaper.
+
+      if (FileSystem::Instance().Exists(merged_sdk.GetSysroot())) {
+        sysroot_spec = merged_sdk.GetSysroot();
       } else {
-        LLDB_LOG_ERROR(GetLog(LLDBLog::Types | LLDBLog::Host),
-                       path_or_err.takeError(),
-                       "Failed to resolve SDK path: {0}");
+        auto path_or_err =
+            HostInfo::GetSDKRoot(HostInfo::SDKOptions{merged_sdk});
+        if (path_or_err) {
+          sysroot_spec = FileSpec(*path_or_err);
+        } else {
+          LLDB_LOG_ERROR(GetLog(LLDBLog::Types | LLDBLog::Host),
+                         path_or_err.takeError(),
+                         "Failed to resolve SDK path: {0}");
+        }
       }
     }
   }

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1030,6 +1030,40 @@ PlatformDarwin::ExtractAppSpecificInfo(Process &process) {
   return dict_sp;
 }
 
+static llvm::Expected<lldb_private::FileSpec>
+ResolveSDKPathFromDebugInfo(lldb_private::Target *target) {
+
+  ModuleSP exe_module_sp = target->GetExecutableModule();
+  if (!exe_module_sp)
+    return llvm::createStringError("Failed to get module from target");
+
+  SymbolFile *sym_file = exe_module_sp->GetSymbolFile();
+  if (!sym_file)
+    return llvm::createStringError("Failed to get symbol file from module");
+
+  XcodeSDK merged_sdk;
+  for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
+    if (auto cu_sp = sym_file->GetCompileUnitAtIndex(i)) {
+      auto cu_sdk = sym_file->ParseXcodeSDK(*cu_sp);
+      merged_sdk.Merge(cu_sdk);
+    }
+  }
+
+  // TODO: The result of this loop is almost equivalent to deriving the SDK
+  // from the target triple, which would be a lot cheaper.
+  FileSpec sdk_path = merged_sdk.GetSysroot();
+  if (FileSystem::Instance().Exists(sdk_path)) {
+    return sdk_path;
+  }
+  auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{merged_sdk});
+  if (!path_or_err)
+    return llvm::createStringError(
+        llvm::formatv("Failed to resolve SDK path: {0}",
+                      llvm::toString(path_or_err.takeError())));
+
+  return FileSpec(*path_or_err);
+}
+
 void PlatformDarwin::AddClangModuleCompilationOptionsForSDKType(
     Target *target, std::vector<std::string> &options, XcodeSDK::Type sdk_type) {
   const std::vector<std::string> apple_arguments = {
@@ -1148,41 +1182,6 @@ void PlatformDarwin::AddClangModuleCompilationOptionsForSDKType(
     options.push_back("-isysroot");
     options.push_back(sysroot_spec.GetPath());
   }
-}
-
-llvm::Expected<lldb_private::FileSpec>
-lldb_private::PlatformDarwin::ResolveSDKPathFromDebugInfo(
-    lldb_private::Target *target) {
-
-  ModuleSP exe_module_sp = target->GetExecutableModule();
-  if (!exe_module_sp)
-    return llvm::createStringError("Failed to get module from target");
-
-  SymbolFile *sym_file = exe_module_sp->GetSymbolFile();
-  if (!sym_file)
-    return llvm::createStringError("Failed to get symbol file from module");
-
-  XcodeSDK merged_sdk;
-  for (unsigned i = 0; i < sym_file->GetNumCompileUnits(); ++i) {
-    if (auto cu_sp = sym_file->GetCompileUnitAtIndex(i)) {
-      auto cu_sdk = sym_file->ParseXcodeSDK(*cu_sp);
-      merged_sdk.Merge(cu_sdk);
-    }
-  }
-
-  // TODO: The result of this loop is almost equivalent to deriving the SDK
-  // from the target triple, which would be a lot cheaper.
-  FileSpec sdk_path = merged_sdk.GetSysroot();
-  if (FileSystem::Instance().Exists(sdk_path)) {
-    return sdk_path;
-  }
-  auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{merged_sdk});
-  if (path_or_err)
-    return FileSpec(*path_or_err);
-
-  return llvm::createStringError(
-      llvm::formatv("Failed to resolve SDK path: {0}",
-                    llvm::toString(path_or_err.takeError()));
 }
 
 ConstString PlatformDarwin::GetFullNameForDylib(ConstString basename) {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -187,6 +187,9 @@ protected:
                                              std::vector<std::string> &options,
                                              XcodeSDK::Type sdk_type);
 
+  static bool ResolveSDKPathFromDebugInfo(lldb_private::Target *target,
+                                          lldb_private::FileSpec &sysroot_spec);
+
   Status FindBundleBinaryInExecSearchPaths(
       const ModuleSpec &module_spec, Process *process,
       lldb::ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -187,8 +187,8 @@ protected:
                                              std::vector<std::string> &options,
                                              XcodeSDK::Type sdk_type);
 
-  static bool ResolveSDKPathFromDebugInfo(lldb_private::Target *target,
-                                          lldb_private::FileSpec &sysroot_spec);
+  static llvm::Expected<FileSpec>
+  ResolveSDKPathFromDebugInfo(lldb_private::Target *target);
 
   Status FindBundleBinaryInExecSearchPaths(
       const ModuleSpec &module_spec, Process *process,

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -187,9 +187,6 @@ protected:
                                              std::vector<std::string> &options,
                                              XcodeSDK::Type sdk_type);
 
-  static llvm::Expected<FileSpec>
-  ResolveSDKPathFromDebugInfo(lldb_private::Target *target);
-
   Status FindBundleBinaryInExecSearchPaths(
       const ModuleSpec &module_spec, Process *process,
       lldb::ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,


### PR DESCRIPTION
This patch is part of an effort to remove the `ResolveSDKPathFromDebugInfo` method, and more specifically the variant which takes a Module as argument.

See the following PR for a follow up on what to do:
- https://github.com/llvm/llvm-project/pull/144913.