### PR TITLE
[Clang][NFC] - Move attr-cpuspecific-cpus test over to Sema

### DIFF
--- a/clang/test/Sema/attr-cpuspecific-cpus.c
+++ b/clang/test/Sema/attr-cpuspecific-cpus.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -verify -triple x86_64-linux-gnu -o - %s
-// RUN: %clang_cc1 -verify -triple x86_64-windows-pc -fms-compatibility -o - %s
+// RUN: %clang_cc1 -verify -triple x86_64-linux-gnu -fsyntax-only %s
+// RUN: %clang_cc1 -verify -triple x86_64-windows-pc -fms-compatibility -fsyntax-only  %s
 
 // expected-no-diagnostics
 

--- a/clang/test/Sema/attr-cpuspecific-cpus.c
+++ b/clang/test/Sema/attr-cpuspecific-cpus.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -verify -triple x86_64-linux-gnu -emit-llvm -o - %s
-// RUN: %clang_cc1 -verify -triple x86_64-windows-pc -fms-compatibility -emit-llvm -o - %s
+// RUN: %clang_cc1 -verify -triple x86_64-linux-gnu -o - %s
+// RUN: %clang_cc1 -verify -triple x86_64-windows-pc -fms-compatibility -o - %s
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
The attr-cpuspecific-cpus test does not have any LLVM IR checks relevant to Codegen, Moving the test over to clang/test/Sema.  