### PR TITLE
[libc] Fix issue with using clock() in hermetic testing

### DIFF
--- a/libc/test/UnitTest/CMakeLists.txt
+++ b/libc/test/UnitTest/CMakeLists.txt
@@ -20,7 +20,7 @@ function(add_unittest_framework_library name)
       ${TEST_LIB_HDRS}
     )
     target_include_directories(${lib} PRIVATE ${LIBC_SOURCE_DIR})
-    if(TARGET libc.src.time.clock)
+    if(TARGET libc.src.time.${LIBC_TARGET_OS}.clock)
       target_compile_definitions(${lib} PRIVATE TARGET_SUPPORTS_CLOCK)
     endif()
   endforeach()

--- a/libc/test/UnitTest/LibcTest.cpp
+++ b/libc/test/UnitTest/LibcTest.cpp
@@ -26,6 +26,9 @@
 #include "src/time/clock.h"
 extern "C" clock_t clock() noexcept { return LIBC_NAMESPACE::clock(); }
 #define LIBC_TEST_USE_CLOCK
+#else
+#include <time.h>
+extern "C" [[gnu::weak]] clock_t clock() noexcept { return 0; }
 #endif
 
 namespace LIBC_NAMESPACE_DECL {


### PR DESCRIPTION
Part of https://github.com/llvm/llvm-project/issues/145349. Some targets (like baremetal) don't implement `clock()`. However, they may later be overridden (e.g. by semihosting libraries), therefore, we make it `[[gnu::weak]]`. This resolves one of the errors when building hermetic tests downstream.

I plan to use the embedding API to implement `clock()` later, however, that is out of scope of this PR. Also, this allows for other architectures to start testing without a `clock()` implementation.