### PR TITLE
MSP430: Move libcall CC setting to RuntimeLibcallsInfo

### DIFF
--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -364,6 +364,11 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT,
         RTLIB::HEXAGON_MEMCPY_LIKELY_ALIGNED_MIN32BYTES_MULT8BYTES,
         RTLIB::__hexagon_memcpy_likely_aligned_min32bytes_mult8bytes);
   }
+
+  if (TT.getArch() == Triple::ArchType::msp430) {
+    setLibcallImplCallingConv(RTLIB::__mspabi_mpyll,
+                              CallingConv::MSP430_BUILTIN);
+  }
 }
 
 bool RuntimeLibcallsInfo::darwinHasExp10(const Triple &TT) {

--- a/llvm/lib/Target/MSP430/MSP430ISelLowering.cpp
+++ b/llvm/lib/Target/MSP430/MSP430ISelLowering.cpp
@@ -208,8 +208,6 @@ MSP430TargetLowering::MSP430TargetLowering(const TargetMachine &TM,
     for (const auto &LC : LibraryCalls) {
       setLibcallImpl(LC.Op, LC.Impl);
     }
-    setLibcallImplCallingConv(RTLIB::__mspabi_mpyll,
-                              CallingConv::MSP430_BUILTIN);
   }
 
   setMinFunctionAlignment(Align(2));


### PR DESCRIPTION
As a temporary step configure the calling convention here. This
can't be moved into tablegen until RuntimeLibcallsInfo is split
into a separate lowering component.