### PR TITLE
[NFC][MC][Dwarf] Add Range/Location List Entry fragment to reduce memory usage

### DIFF
--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -716,6 +716,11 @@ public:
   // Dwarf Emission Helper Routines
   //===------------------------------------------------------------------===//
 
+  MCDwarfLocListOffsetPairFragment *
+  emitDwarfLocListOffsetPairEntry(int8_t OffsetPair, const MCSymbol *Base,
+                                  const MCSymbol *Begin, const MCSymbol *End,
+                                  StringRef EnumEle);
+
   /// Emit a .byte 42 directive that corresponds to an encoding.  If verbose
   /// assembly output is enabled, we output comments describing the encoding.
   /// Desc is a string saying what the encoding is specifying (e.g. "LSDA").

--- a/llvm/include/llvm/MC/MCAssembler.h
+++ b/llvm/include/llvm/MC/MCAssembler.h
@@ -124,6 +124,7 @@ private:
   bool relaxBoundaryAlign(MCBoundaryAlignFragment &BF);
   bool relaxDwarfLineAddr(MCDwarfLineAddrFragment &DF);
   bool relaxDwarfCallFrameFragment(MCDwarfCallFrameFragment &DF);
+  bool relaxDwarfLoclistEntry(MCDwarfLocListOffsetPairFragment &DF);
   bool relaxCVInlineLineTable(MCCVInlineLineTableFragment &DF);
   bool relaxCVDefRange(MCCVDefRangeFragment &DF);
   bool relaxFill(MCFillFragment &F);

--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -45,6 +45,7 @@ public:
     FT_Org,
     FT_Dwarf,
     FT_DwarfFrame,
+    FT_DwarfLoclistEntry,
     FT_LEB,
     FT_BoundaryAlign,
     FT_SymbolId,
@@ -135,6 +136,7 @@ public:
     case MCFragment::FT_Data:
     case MCFragment::FT_Dwarf:
     case MCFragment::FT_DwarfFrame:
+    case MCFragment::FT_DwarfLoclistEntry:
     case MCFragment::FT_PseudoProbe:
       return true;
     }
@@ -197,7 +199,8 @@ public:
     MCFragment::FragmentType Kind = F->getKind();
     return Kind == MCFragment::FT_Relaxable || Kind == MCFragment::FT_Data ||
            Kind == MCFragment::FT_CVDefRange || Kind == MCFragment::FT_Dwarf ||
-           Kind == MCFragment::FT_DwarfFrame;
+           Kind == MCFragment::FT_DwarfFrame ||
+           Kind == MCFragment::FT_DwarfLoclistEntry;
   }
 };
 
@@ -437,6 +440,29 @@ public:
 
   static bool classof(const MCFragment *F) {
     return F->getKind() == MCFragment::FT_DwarfFrame;
+  }
+};
+
+class MCContext;
+
+/// Represents a DWARF offset-pair kind location list or range list entry.
+/// Currently not suitable to use if either of the offsets require
+/// linker-relaxable relocations, which should be emitted as uleb fragments
+/// instead.
+/// LocationDescriptionExpr, which represents a DWARF location description,
+/// is only used for location list entries.
+class MCDwarfLocListOffsetPairFragment
+    : public MCEncodedFragmentWithFixups<16, 0> {
+public:
+  SmallVector<char, 8> LocationDescriptionExpr;
+  const MCExpr *StartOffset;
+  const MCExpr *EndOffset;
+
+  MCDwarfLocListOffsetPairFragment(MCContext &Context, const MCSymbol *Base,
+                                   const MCSymbol *Begin, const MCSymbol *End);
+
+  static bool classof(const MCFragment *F) {
+    return F->getKind() == MCFragment::FT_DwarfLoclistEntry;
   }
 };
 

--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -200,6 +200,11 @@ public:
   void emitAbsoluteSymbolDiffAsULEB128(const MCSymbol *Hi,
                                        const MCSymbol *Lo) override;
 
+  MCDwarfLocListOffsetPairFragment *
+  emitDwarfLocListOffsetPairEntry(int8_t OffsetPair, const MCSymbol *Base,
+                                  const MCSymbol *Begin, const MCSymbol *End,
+                                  StringRef EnumEle) override;
+
   bool mayHaveInstructions(MCSection &Sec) const override;
 
   /// Emits pending conditional assignments that depend on \p Symbol

--- a/llvm/include/llvm/MC/MCStreamer.h
+++ b/llvm/include/llvm/MC/MCStreamer.h
@@ -978,6 +978,11 @@ public:
   virtual void emitAbsoluteSymbolDiffAsULEB128(const MCSymbol *Hi,
                                                const MCSymbol *Lo);
 
+  virtual MCDwarfLocListOffsetPairFragment *
+  emitDwarfLocListOffsetPairEntry(int8_t OffsetPair, const MCSymbol *Base,
+                                  const MCSymbol *Begin, const MCSymbol *End,
+                                  StringRef EnumEle);
+
   virtual MCSymbol *getDwarfLineTableSymbol(unsigned CUID);
   virtual void emitCFISections(bool EH, bool Debug);
   void emitCFIStartProc(bool IsSimple, SMLoc Loc = SMLoc());

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -3383,6 +3383,13 @@ void AsmPrinter::emitLabelDifferenceAsULEB128(const MCSymbol *Hi,
   OutStreamer->emitAbsoluteSymbolDiffAsULEB128(Hi, Lo);
 }
 
+MCDwarfLocListOffsetPairFragment *AsmPrinter::emitDwarfLocListOffsetPairEntry(
+    int8_t OffsetPair, const MCSymbol *Base, const MCSymbol *Begin,
+    const MCSymbol *End, StringRef EnumEle) {
+  return OutStreamer->emitDwarfLocListOffsetPairEntry(OffsetPair, Base, Begin,
+                                                      End, EnumEle);
+}
+
 /// EmitLabelPlusOffset - Emit something like ".long Label+Offset"
 /// where the size in bytes of the directive is specified by Size and Label
 /// specifies the label.  This implicitly uses .set if it is available.

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -128,8 +128,8 @@ MCObjectStreamer::emitDwarfLocListOffsetPairEntry(int8_t OffsetPair,
                                                   const MCSymbol *Begin,
                                                   const MCSymbol *End,
                                                   StringRef EnumEle) {
-  // Heuristic: if we can emit one of the offsets as a constant now that
-  // that consumes less memory than creating a MCDwarfLocListOffsetPairFragment.
+  // Heuristic: if we can emit one of the offsets as a constant now, that
+  // consumes less memory than creating a MCDwarfLocListOffsetPairFragment.
   bool BeginOrEndInBaseFragment = Base->getFragment() == Begin->getFragment() ||
                                   Base->getFragment() == End->getFragment();
   // If the offset ulebs require linker-relaxable relocations then fall back to

--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -1249,6 +1249,20 @@ void MCStreamer::emitAbsoluteSymbolDiffAsULEB128(const MCSymbol *Hi,
   emitULEB128Value(Diff);
 }
 
+MCDwarfLocListOffsetPairFragment *MCStreamer::emitDwarfLocListOffsetPairEntry(
+    int8_t OffsetPair, const MCSymbol *Base, const MCSymbol *Begin,
+    const MCSymbol *End, StringRef EnumEle) {
+  // Base impl: emit offsets independently, possibly resulting in multiple
+  // fragments.
+  AddComment(EnumEle);
+  emitInt8(OffsetPair);
+  AddComment("  starting offset");
+  emitAbsoluteSymbolDiffAsULEB128(Begin, Base);
+  AddComment("  ending offset");
+  emitAbsoluteSymbolDiffAsULEB128(End, Base);
+  return nullptr;
+}
+
 void MCStreamer::emitSubsectionsViaSymbols() {
   llvm_unreachable(
       "emitSubsectionsViaSymbols only supported on Mach-O targets");


### PR DESCRIPTION
DWARF offset_pair kind RLE and LLEs encode two symbol offsets, and LLEs additionally encode a Location Description. At worst this results in two MCLEBFragments for the offsets (208 bytes each) and an MCDataFragment for the expression (208 bytes again).

Add a dedicated offset pair kind list entry fragment, MCDwarfLocListOffsetPairFragment (144 bytes). To avoid additional complexity and code duplication, if either of the offsets might span linker relaxable instructions we revert to default (pre-patch) behaviour. We also use that code path for Asm printing as it's easier to shuffle comments around that way.

---

This is the 2nd patch of two in which we try to reduce `-g` overhead to "make room" for Key Instructions (first [here](https://llvm-compile-time-tracker.com/compare.php?from=e2c43ba981620cf71ce3ccf004db7c0db4caf8a7&to=7b0fafaec5314dea177c552eaaac3a86b5b3e942&stat=instructions:u), has more of an impact).

[Compile-time-tracker max-rss link](https://llvm-compile-time-tracker.com/compare.php?from=75cf826849713c00829cdf657e330e24c1a2fd03&to=d740bd376912fb7e770534d6a05d7453a3a10db7&stat=max-rss). Slight reduction to average max-rss with multiple percentage point wins for sqlite3 and tramp3d-v4. Minor reduction of instructions:u too.

According to massif, a `-O2 -g` build of sqlite3 from CTMark allocates 6.5% less memory with this patch.

I tried various different configurations for this patch:
* Separating the new fragment into two, one each for LocationListEntry and RangeListEntry - adds a further ~2% allocation reduction for sqlite3 but doubles the code added in the patch. Possibly not worth it.
* Handling StartxLength as well OffsetPair entries. But it seems they account for a very small % of all entries in optimized builds (e.g. 1% for tramp3d-v4), so I don't think it's worth it.

---

I'm not massively familiar with this area - I'm especially dubious of my bail-out-of-linker-relaxations code in `MCObjectStreamer::emitDwarfLocListOffsetPairEntry`. Does it look alright, or is there something better to do there?


I've not written a test yet - cooking that up now - I just thought it might be useful to get expert eyes on this in the mean time in case it's an undesirable direction.

---

Credit to jmorse for the find and patch, I just tidied it up and shuffled some bits around.