### PR TITLE
[ADT] Remove MutableArrayRef(std::array) (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -327,11 +327,6 @@ namespace llvm {
                   void>>
     /*implicit*/ constexpr MutableArrayRef(const C &V) : ArrayRef<T>(V) {}
 
-    /// Construct a MutableArrayRef from a std::array
-    template <size_t N>
-    /*implicit*/ constexpr MutableArrayRef(std::array<T, N> &Arr)
-        : ArrayRef<T>(Arr) {}
-
     /// Construct a MutableArrayRef from a C array.
     template <size_t N>
     /*implicit*/ constexpr MutableArrayRef(T (&Arr)[N]) : ArrayRef<T>(Arr) {}


### PR DESCRIPTION
This constructor has been subsumed by another constructor of
MutableArrayRef that takes a parameter whose type has data() and
size() methods.
