### PR TITLE
[clang-fuzzer] Fix latent race condition in build

### DIFF
--- a/clang/tools/clang-fuzzer/handle-llvm/CMakeLists.txt
+++ b/clang/tools/clang-fuzzer/handle-llvm/CMakeLists.txt
@@ -24,4 +24,5 @@ add_clang_library(clangHandleLLVM
 
   DEPENDS
   intrinsics_gen
+  vt_gen
   )


### PR DESCRIPTION
Add explicit dependency for gen_vt to the CMakeLists.txt for clang/tools/clang-fuzzer/handle-llvm/handle_llvm.cpp to prevent race condition on generation of llvm/CodeGen/GenVT.inc This explicit dependency was added in other CMakeLists.txt when the tablegen was added for GenVT.inc file in https://reviews.llvm.org/D148770, but not for handle-llvm

A similar fix was made in https://github.com/llvm/llvm-project/pull/109306

rdar://151325382