### PR TITLE
Add CodeView S_LABEL32 symbols for jump table targets (for Windows debugging)

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.h
@@ -146,6 +146,7 @@ private:
     const MCSymbol *Branch;
     const MCSymbol *Table;
     size_t TableSize;
+    std::vector<const MCSymbol *> Cases;
   };
 
   // For each function, store a vector of labels to its instructions, as well as

--- a/llvm/test/DebugInfo/COFF/jump-table.ll
+++ b/llvm/test/DebugInfo/COFF/jump-table.ll
@@ -118,6 +118,15 @@
 ; CV:         GlobalProcIdSym {
 ; CV:           DisplayName: func
 ; CV-NOT:     GlobalProcIdSym
+; CV:           LabelSym {
+; CV-NEXT:        Kind: S_LABEL32 (0x1105)
+; CV-NEXT:        CodeOffset: 0xC0
+; CV-NEXT:        Segment: 0x0
+; CV-NEXT:        Flags: 0x0
+; CV-NEXT:        Flags [ (0x0)
+; CV-NEXT:        ]
+; CV-NEXT:        DisplayName:
+; CV-NEXT:      }
 ; CV:           JumpTableSym {
 ; CV-NEXT:        Kind: S_ARMSWITCHTABLE (0x1159)
 ; CV-NEXT:        BaseOffset: 0x0


### PR DESCRIPTION
This PR provides more information to debuggers and analysis tools on Windows. It adds `S_LABEL32` symbols for each target BB of each jump table.  This allows debuggers to insert symbolic labels when disassembling code.  `S_LABEL32` symbol records indicate that a location is definitely code, and can optionally associate a string label with the code location.  BBs generated for jump tables may or may not have string labels, so it is acceptable for the "name" field within `S_LABEL32` symbols to be an empty string.

More importantly, this PR allows Windows analysis tools, such as those that generate hot-patches for the Windows kernel, to use these labels to distinguish code basic blocks from data blocks. Microsoft's analysis tools (similar to Bolt) rely on being able to identify all code blocks, so that the tools can traverse all instructions and verify that important requirements for hot-patching are met.

This PR has no effect on code generation. It only affects the CodeView symbols that are emitted into OBJ files, which the linker then repackages into PDB files.