### PR TITLE
[BOLT][test] Fix NFC mismatches in perf2bolt tests

### DIFF
--- a/bolt/utils/llvm-bolt-wrapper.py
+++ b/bolt/utils/llvm-bolt-wrapper.py
@@ -79,7 +79,7 @@ def read_cfg():
 
 
 # perf2bolt mode
-PERF2BOLT_MODE = ["-aggregate-only", "-ignore-build-id"]
+PERF2BOLT_MODE = ["-aggregate-only", "-ignore-build-id", "-show-density"]
 
 # boltdiff mode
 BOLTDIFF_MODE = ["-diff-only", "-o", "/dev/null"]


### PR DESCRIPTION
zero-density.s causes spurious NFC mismatches, e.g.
https://lab.llvm.org/buildbot/#/builders/92/builds/21380

This is caused by NFC script wrapping llvm-bolt binary only, so that
perf2bolt invocations are replaced by `llvm-bolt --agregate-only` to
achieve perf2bolt behavior. Add `show-density` to the list of flags
wrapping perf2bolt calls to avoid similar issues in the future.

Test Plan:
```
$ bolt/utils/nfc-check-setup.py --switch-back
$ bin/llvm-lit -a tools/bolt/test/X86/zero-density.s
```
