### PR TITLE
Fix missing/outdated pass options in PassRegistry.def

### DIFF
--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -175,7 +175,7 @@ MODULE_PASS("wholeprogramdevirt", WholeProgramDevirtPass())
 MODULE_PASS_WITH_PARAMS(
     "asan", "AddressSanitizerPass",
     [](AddressSanitizerOptions Opts) { return AddressSanitizerPass(Opts); },
-    parseASanPassOptions, "kernel")
+    parseASanPassOptions, "kernel;use-after-scope")
 MODULE_PASS_WITH_PARAMS(
     "cg-profile", "CGProfilePass",
     [](bool InLTOPostLink) { return CGProfilePass(InLTOPostLink);},
@@ -187,7 +187,7 @@ MODULE_PASS_WITH_PARAMS(
     "group-by-use;ignore-single-use;max-offset=N;merge-const;"
     "merge-const-aggressive;merge-external;no-group-by-use;"
     "no-ignore-single-use;no-merge-const;no-merge-const-aggressive;"
-    "no-merge-external;size-only")
+    "no-merge-external")
 MODULE_PASS_WITH_PARAMS(
     "embed-bitcode", "EmbedBitcodePass",
     [](EmbedBitcodeOptions Opts) { return EmbedBitcodePass(Opts); },
@@ -195,7 +195,7 @@ MODULE_PASS_WITH_PARAMS(
 MODULE_PASS_WITH_PARAMS(
     "globaldce", "GlobalDCEPass",
     [](bool InLTOPostLink) { return GlobalDCEPass(InLTOPostLink); },
-    parseGlobalDCEPassOptions, "in-lto-post-link")
+    parseGlobalDCEPassOptions, "vfe-linkage-unit-visibility")
 MODULE_PASS_WITH_PARAMS(
     "hwasan", "HWAddressSanitizerPass",
     [](HWAddressSanitizerOptions Opts) { return HWAddressSanitizerPass(Opts); },
@@ -581,8 +581,7 @@ FUNCTION_PASS_WITH_PARAMS(
     "instcombine", "InstCombinePass",
     [](InstCombineOptions Opts) { return InstCombinePass(Opts); },
     parseInstCombineOptions,
-    "no-use-loop-info;use-loop-info;no-verify-fixpoint;verify-fixpoint;"
-    "max-iterations=N")
+    "no-verify-fixpoint;verify-fixpoint;max-iterations=N")
 FUNCTION_PASS_WITH_PARAMS(
     "lint", "LintPass",
     [](bool AbortOnError) { return LintPass(AbortOnError); },
@@ -604,7 +603,7 @@ FUNCTION_PASS_WITH_PARAMS(
 FUNCTION_PASS_WITH_PARAMS(
     "lower-allow-check", "LowerAllowCheckPass",
     [](LowerAllowCheckPass::Options Opts) { return LowerAllowCheckPass(Opts); },
-    parseLowerAllowCheckPassOptions, "")
+    parseLowerAllowCheckPassOptions, "cutoffs[indices]=N")
 FUNCTION_PASS_WITH_PARAMS(
     "lower-matrix-intrinsics", "LowerMatrixIntrinsicsPass",
     [](bool Minimal) { return LowerMatrixIntrinsicsPass(Minimal); },
@@ -662,10 +661,14 @@ FUNCTION_PASS_WITH_PARAMS(
     "simplifycfg", "SimplifyCFGPass",
     [](SimplifyCFGOptions Opts) { return SimplifyCFGPass(Opts); },
     parseSimplifyCFGOptions,
-    "no-forward-switch-cond;forward-switch-cond;no-switch-range-to-icmp;"
-    "switch-range-to-icmp;no-switch-to-lookup;switch-to-lookup;no-keep-loops;"
-    "keep-loops;no-hoist-common-insts;hoist-common-insts;no-sink-common-insts;"
-    "sink-common-insts;bonus-inst-threshold=N")
+    "no-speculate-blocks;speculate-blocks;no-simplify-cond-branch;"
+    "simplify-cond-branch;no-forward-switch-cond;forward-switch-cond;"
+    "no-switch-range-to-icmp;switch-range-to-icmp;no-switch-to-lookup;"
+    "switch-to-lookup;no-keep-loops;keep-loops;no-hoist-common-insts;"
+    "hoist-common-insts;no-hoist-loads-stores-with-cond-faulting;"
+    "hoist-loads-stores-with-cond-faulting;no-sink-common-insts;"
+    "sink-common-insts;no-speculate-unpredictables;speculate-unpredictables;"
+    "bonus-inst-threshold=N")
 FUNCTION_PASS_WITH_PARAMS(
     "speculative-execution", "SpeculativeExecutionPass",
     [](bool OnlyIfDivergentTarget) {
@@ -693,7 +696,8 @@ FUNCTION_PASS_WITH_PARAMS(
     [](BoundsCheckingPass::Options Options) {
       return BoundsCheckingPass(Options);
     },
-    parseBoundsCheckingOptions, "trap")
+    parseBoundsCheckingOptions,
+    "trap;rt;rt-abort;min-rt;min-rt-abort;merge;guard=N")
 #undef FUNCTION_PASS_WITH_PARAMS
 
 #ifndef LOOPNEST_PASS
@@ -753,10 +757,10 @@ LOOP_PASS("print<loopnest>", LoopNestPrinterPass(errs()))
 #endif
 LOOP_PASS_WITH_PARAMS(
     "licm", "LICMPass", [](LICMOptions Params) { return LICMPass(Params); },
-    parseLICMOptions, "allowspeculation")
+    parseLICMOptions, "allowspeculation;no-allowspeculation")
 LOOP_PASS_WITH_PARAMS(
     "lnicm", "LNICMPass", [](LICMOptions Params) { return LNICMPass(Params); },
-    parseLICMOptions, "allowspeculation")
+    parseLICMOptions, "allowspeculation;no-allowspeculation")
 LOOP_PASS_WITH_PARAMS(
     "loop-rotate", "LoopRotatePass",
     [](std::pair<bool, bool> Params) {


### PR DESCRIPTION
There are a handful of passes in PassRegistry.def with outdated or missing pass options. These strings describing pass options are used for the printPassNames() function only, which is likely why they have gotten out-of-date without being caught. This MR simply changes the few passes where the option string is out-of-date, fixing the output of -print-passes. This does not affect functionality of the pipeline parser, and is hard to verify in a unit test, so no tests were added.