### PR TITLE
Make sure all matrix options are run in libc premerge testing

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -26,12 +26,14 @@ jobs:
             include_scudo: ON
           # TODO: remove ccache logic when https://github.com/hendrikmuhs/ccache-action/issues/279 is resolved.
           - os: ubuntu-24.04-arm
+            build_type: Debug
             ccache-variant: ccache
             c_compiler: clang-21
             cpp_compiler: clang++-21
             target: aarch64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
+            build_type: Debug
             ccache-variant: ccache
             c_compiler: clang-21
             cpp_compiler: clang++-21

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -15,8 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Build linux configuration with Debug, Release, and MinSizeRel.
+        # Build all other configurations in only Debug.
         build_type: [Debug, Release, MinSizeRel]
-        os: [ubuntu-24.04, ubuntu-24.04-arm]
+        os: [ubuntu-24.04]
         include:
           - os: ubuntu-24.04
             ccache-variant: sccache

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -15,12 +15,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build linux configuration with Debug, Release, and MinSizeRel.
-        # Build all other configurations in only Debug.
-        build_type: [Debug, Release, MinSizeRel]
-        os: [ubuntu-24.04]
+        # Build basic linux configuration with Debug and MinSizeRel and all
+        # other configurations in Debug only.
         include:
           - os: ubuntu-24.04
+            build_type: Debug
+            ccache-variant: sccache
+            c_compiler: clang-21
+            cpp_compiler: clang++-21
+            target: x86_64-unknown-linux-llvm
+            include_scudo: ON
+          - os: ubuntu-24.04
+            build_type: MinSizeRel
             ccache-variant: sccache
             c_compiler: clang-21
             cpp_compiler: clang++-21

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -15,11 +15,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build basic linux configuration with Debug and MinSizeRel and all
+        # Build basic linux configuration with Debug/Release/MinSizeRel and all
         # other configurations in Debug only.
         include:
           - os: ubuntu-24.04
             build_type: Debug
+            ccache-variant: sccache
+            c_compiler: clang-21
+            cpp_compiler: clang++-21
+            target: x86_64-unknown-linux-llvm
+            include_scudo: ON
+          - os: ubuntu-24.04
+            build_type: Release
             ccache-variant: sccache
             c_compiler: clang-21
             cpp_compiler: clang++-21

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release, MinSizeRel]
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
         include:
           - os: ubuntu-24.04
             ccache-variant: sccache

--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -108,7 +108,7 @@ jobs:
         -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache-variant }} \
         -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache-variant }} \
         -DCMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.build-install-dir }} \
-        -DLLVM_RUNTIMES_TARGET=${{ matrix.target }} \
+        -DLLVM_RUNTIME_TARGETS=${{ matrix.target }} \
         -DLLVM_ENABLE_RUNTIMES="$RUNTIMES" \
         -DLLVM_LIBC_FULL_BUILD=ON \
         -G Ninja \

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -17,6 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release, MinSizeRel]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, windows-2025, macos-14]
         include:
           # TODO: add linux gcc when it is fixed
           - os: ubuntu-24.04

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -16,7 +16,6 @@ jobs:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations.
       fail-fast: false
       matrix:
-        build_type: [Debug, Release, MinSizeRel]
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, windows-2025, macos-14]
         include:
           # TODO: add linux gcc when it is fixed
@@ -97,7 +96,7 @@ jobs:
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.compiler.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache-variant }}
         -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache-variant }}
         -DCMAKE_POLICY_DEFAULT_CMP0141=NEW

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -110,7 +110,6 @@ jobs:
         cmake 
         --build ${{ steps.strings.outputs.build-output-dir }} 
         --parallel 
-        --config MinSizeRel 
         --target libc
 
     - name: Test


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/126315 changes the premerge testing to build in Debug, Release, and MinSizeRel configs, as opposed to only MinSizeRel, but for some reason the matrix is not returning all options now. Fix so that it actually builds the intended configs.

Per discussion in [146161](https://github.com/llvm/llvm-project/issues/146161), only test all three configs on Linux x86_64. Other OS's and configurations will build in Debug mode only. 

Also fix a cmake variable and remove outdated comments.

Bug: https://github.com/llvm/llvm-project/issues/146161