### PR TITLE
[workflows] Update commit access request PR links

### DIFF
--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -301,7 +301,8 @@ class CommitRequestGreeter:
         merged_prs_url = total_prs_url + "+is%3Amerged"
         comment = f"""
             ### Activity Summary:
-            * [{total_prs} Pull Requests]({total_prs_url}) ({merged_prs} [merged]({merged_prs_url}))
+            * [{total_prs} Pull Requests]({total_prs_url})
+            * [{merged_prs} Merged Pull Requests]({merged_prs_url})
             * Top 3 Committers: {get_user_values_str(get_top_values(merged_by))}
             * Top 3 Reviewers: {get_user_values_str(get_top_values(reviewed_by))}
         """

--- a/llvm/utils/git/github-automation.py
+++ b/llvm/utils/git/github-automation.py
@@ -297,9 +297,11 @@ class CommitRequestGreeter:
                 print(e)
                 continue
 
+        total_prs_url = f"https://github.com/llvm/llvm-project/pulls?q=author%3A{self.issue.user.login}+is%3Apr"
+        merged_prs_url = total_prs_url + "+is%3Amerged"
         comment = f"""
             ### Activity Summary:
-            * [{total_prs} Pull Requests](https://github.com/llvm/llvm-project/pulls/{self.issue.user.login}) ({merged_prs} merged)
+            * [{total_prs} Pull Requests]({total_prs_url}) ({merged_prs} [merged]({merged_prs_url}))
             * Top 3 Committers: {get_user_values_str(get_top_values(merged_by))}
             * Top 3 Reviewers: {get_user_values_str(get_top_values(reviewed_by))}
         """


### PR DESCRIPTION
This PR updates the links used to show the PR contribution stats of the user requesting commit access to the LLVM project. Previously we would only show the PRs that were currently opened by the user because the `/pulls/<username>` endpoint automatically applies the `is:open` filter.

The contribution guidelines suggest that the user should have at least 3 merged PRs to be considered for commit access so this seems like a relevant data point to add.

We now show all PRs that a user has created (not just the open ones) and a separate link for the PRs that are merged.