### PR TITLE
[flang][cuda] Do not generate section checks in device context

### DIFF
--- a/flang/lib/Lower/ConvertCall.cpp
+++ b/flang/lib/Lower/ConvertCall.cpp
@@ -20,6 +20,7 @@
 #include "flang/Lower/StatementContext.h"
 #include "flang/Lower/SymbolMap.h"
 #include "flang/Optimizer/Builder/BoxValue.h"
+#include "flang/Optimizer/Builder/CUFCommon.h"
 #include "flang/Optimizer/Builder/Character.h"
 #include "flang/Optimizer/Builder/FIRBuilder.h"
 #include "flang/Optimizer/Builder/HLFIRTools.h"
@@ -545,7 +546,8 @@ Fortran::lower::genCallOpAndResult(
       caller.getProcedureAttrs(builder.getContext());
 
   if (converter.getLoweringOptions().getCUDARuntimeCheck()) {
-    if (caller.getCallDescription().chevrons().empty()) {
+    if (caller.getCallDescription().chevrons().empty() &&
+        !cuf::isCUDADeviceContext(builder.getRegion())) {
       for (auto [oper, arg] :
            llvm::zip(operands, caller.getPassedArguments())) {
         if (auto boxTy = mlir::dyn_cast<fir::BaseBoxType>(oper.getType())) {

--- a/flang/test/Lower/CUDA/cuda-runtime-check.cuf
+++ b/flang/test/Lower/CUDA/cuda-runtime-check.cuf
@@ -1,22 +1,36 @@
 ! RUN: bbc -emit-hlfir -fcuda %s -o - | FileCheck %s
 
-! Check insertion of runtime checks
+! Check insertion of runtime checks in host side only
 
-interface
+module section_test
+
+contains
+
   subroutine foo(a)
     real, device, dimension(:,:) :: a
   end subroutine
-end interface
 
-  real, device, allocatable, dimension(:,:) :: a
-  allocate(a(10,10))
-  call foo(a(1:10,1:10:2))
-end
+  subroutine test_host()
+    real, device, allocatable, dimension(:,:) :: a
+    allocate(a(10,10))
+    call foo(a(1:10,1:10:2))
+  end subroutine
 
-subroutine foo(a)
-  real, device, dimension(:,:) :: a
-end subroutine
+  attributes(device) subroutine zoo(a)
+    real, device, dimension(:,:) :: a
+  end subroutine
 
-! CHECK-LABEL: func.func @_QQmain()
+  attributes(global) subroutine test_device()
+    real, device, allocatable, dimension(:,:) :: a
+    allocate(a(10,10))
+    call zoo(a(1:10,1:10:2))
+  end subroutine
+end module
+
+! CHECK-LABEL: func.func @_QMsection_testPtest_host()
 ! CHECK: fir.call @_FortranACUFDescriptorCheckSection
-! CHECK: fir.call @_QPfoo
+! CHECK: fir.call @_QMsection_testPfoo
+
+! CHECK-LABEL: func.func @_QMsection_testPtest_device()
+! CHECK-NOT: fir.call @_FortranACUFDescriptorCheckSection
+! CHECK: fir.call @_QMsection_testPzoo


### PR DESCRIPTION
This check is only useful on the host side. Also the function is bot built for the device. 