### PR TITLE
[RISCV] Remove untested code from SelectAddrRegRegScale.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -2824,10 +2824,6 @@ bool RISCVDAGToDAGISel::SelectAddrRegRegScale(SDValue Addr,
       Base = Addr.getOperand(0);
       return true;
     }
-  } else if (UnwrapShl(Addr, Index, Scale)) {
-    EVT VT = Addr.getValueType();
-    Base = CurDAG->getRegister(RISCV::X0, VT);
-    return true;
   }
 
   return false;


### PR DESCRIPTION
This code handled load/store address that are a SHL instruction. That seems very unlikely to occur unless you're accessing an array that starts at address 0. I'm not even sure if you can represent that in llvm IR.