### PR TITLE
[SHT_LLVM_BB_ADDR_MAP] Remove support for versions 1 and 0 (SHT_LLVM_BB_ADDR_MAP_V0).

### DIFF
--- a/llvm/docs/Extensions.rst
+++ b/llvm/docs/Extensions.rst
@@ -430,27 +430,6 @@ Example:
    .uleb128  .LBB_END0_1-.LBB0_1          # BB_1 size
    .byte     y                            # BB_1 metadata
 
-Version 0: basic block address offsets are computed relative to the function
-address. This uses the unversioned ``SHT_LLVM_BB_ADDR_MAP_V0`` section type and
-is semantically equivalent to using ``SHT_LLVM_BB_ADDR_MAP`` with a zero
-version field.
-
-Example:
-
-.. code-block:: gas
-
-  .section  ".llvm_bb_addr_map","",@llvm_bb_addr_map_v0
-  .quad     .Lfunc_begin0                 # address of the function
-  .byte     2                             # number of basic blocks
-  # BB record for BB_0
-   .uleb128  .Lfunc_beign0-.Lfunc_begin0  # BB_0 offset relative to the function entry (always zero)
-   .uleb128  .LBB_END0_0-.Lfunc_begin0    # BB_0 size
-   .byte     x                            # BB_0 metadata
-  # BB record for BB_1
-   .uleb128  .LBB0_1-.Lfunc_begin0        # BB_1 offset relative to the function entry
-   .uleb128  .LBB_END0_1-.LBB0_1          # BB_1 size
-   .byte     y                            # BB_1 metadata
-
 PGO Analysis Map
 """"""""""""""""
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -273,6 +273,7 @@ Changes to the LLVM tools
 * In llvm-objcopy/llvm-strip's ELF port, `--discard-locals` and `--discard-all` now allow and preserve symbols referenced by relocations.
   ([#47468](https://github.com/llvm/llvm-project/issues/47468))
 * llvm-addr2line now supports a `+` prefix when specifying an address.
+* Support for `SHT_LLVM_BB_ADDR_MAP` versions 1 and lower is dropped.
 
 Changes to LLDB
 ---------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -273,7 +273,7 @@ Changes to the LLVM tools
 * In llvm-objcopy/llvm-strip's ELF port, `--discard-locals` and `--discard-all` now allow and preserve symbols referenced by relocations.
   ([#47468](https://github.com/llvm/llvm-project/issues/47468))
 * llvm-addr2line now supports a `+` prefix when specifying an address.
-* Support for `SHT_LLVM_BB_ADDR_MAP` versions 1 and lower is dropped.
+* Support for `SHT_LLVM_BB_ADDR_MAP` versions 0 and 1 has been dropped.
 
 Changes to LLDB
 ---------------------------------

--- a/llvm/include/llvm/BinaryFormat/ELF.h
+++ b/llvm/include/llvm/BinaryFormat/ELF.h
@@ -1153,9 +1153,7 @@ enum : unsigned {
   SHT_LLVM_SYMPART = 0x6fff4c05,   // Symbol partition specification.
   SHT_LLVM_PART_EHDR = 0x6fff4c06, // ELF header for loadable partition.
   SHT_LLVM_PART_PHDR = 0x6fff4c07, // Phdrs for loadable partition.
-  SHT_LLVM_BB_ADDR_MAP_V0 =
-      0x6fff4c08, // LLVM Basic Block Address Map (old version kept for
-                  // backward-compatibility).
+  // SHT_LLVM_BB_ADDR_MAP_V0 = 0x6fff4c08,  // Do not use.
   SHT_LLVM_CALL_GRAPH_PROFILE = 0x6fff4c09, // LLVM Call Graph Profile.
   SHT_LLVM_BB_ADDR_MAP = 0x6fff4c0a,        // LLVM Basic Block Address Map.
   SHT_LLVM_OFFLOADING = 0x6fff4c0b,         // LLVM device offloading data.

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -1483,16 +1483,13 @@ void AsmPrinter::emitBBAddrMapSection(const MachineFunction &MF) {
     }
 
     if (!Features.OmitBBEntries) {
-      // TODO: Remove this check when version 1 is deprecated.
-      if (BBAddrMapVersion > 1) {
-        OutStreamer->AddComment("BB id");
-        // Emit the BB ID for this basic block.
-        // We only emit BaseID since CloneID is unset for
-        // -basic-block-adress-map.
-        // TODO: Emit the full BBID when labels and sections can be mixed
-        // together.
-        OutStreamer->emitULEB128IntValue(MBB.getBBID()->BaseID);
-      }
+      OutStreamer->AddComment("BB id");
+      // Emit the BB ID for this basic block.
+      // We only emit BaseID since CloneID is unset for
+      // -basic-block-adress-map.
+      // TODO: Emit the full BBID when labels and sections can be mixed
+      // together.
+      OutStreamer->emitULEB128IntValue(MBB.getBBID()->BaseID);
       // Emit the basic block offset relative to the end of the previous block.
       // This is zero unless the block is padded due to alignment.
       emitLabelDifferenceAsULEB128(MBBSymbol, PrevMBBEndSymbol);

--- a/llvm/lib/MC/MCSectionELF.cpp
+++ b/llvm/lib/MC/MCSectionELF.cpp
@@ -170,8 +170,6 @@ void MCSectionELF::printSwitchToSection(const MCAsmInfo &MAI, const Triple &T,
     OS << "llvm_sympart";
   else if (Type == ELF::SHT_LLVM_BB_ADDR_MAP)
     OS << "llvm_bb_addr_map";
-  else if (Type == ELF::SHT_LLVM_BB_ADDR_MAP_V0)
-    OS << "llvm_bb_addr_map_v0";
   else if (Type == ELF::SHT_LLVM_OFFLOADING)
     OS << "llvm_offloading";
   else if (Type == ELF::SHT_LLVM_LTO)

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -317,7 +317,6 @@ StringRef llvm::object::getELFSectionTypeName(uint32_t Machine, unsigned Type) {
     STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_SYMPART);
     STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_PART_EHDR);
     STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_PART_PHDR);
-    STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_BB_ADDR_MAP_V0);
     STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_BB_ADDR_MAP);
     STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_OFFLOADING);
     STRINGIFY_ENUM_CASE(ELF, SHT_LLVM_LTO);
@@ -833,33 +832,27 @@ decodeBBAddrMapImpl(const ELFFile<ELFT> &EF,
   BBAddrMap::Features FeatEnable{};
   while (!ULEBSizeErr && !MetadataDecodeErr && Cur &&
          Cur.tell() < Content.size()) {
-    if (Sec.sh_type == ELF::SHT_LLVM_BB_ADDR_MAP) {
-      Version = Data.getU8(Cur);
-      if (!Cur)
-        break;
-      if (Version > 3)
-        return createError("unsupported SHT_LLVM_BB_ADDR_MAP version: " +
-                           Twine(static_cast<int>(Version)));
-      Feature = Data.getU8(Cur); // Feature byte
-      if (!Cur)
-        break;
-      auto FeatEnableOrErr = BBAddrMap::Features::decode(Feature);
-      if (!FeatEnableOrErr)
-        return FeatEnableOrErr.takeError();
-      FeatEnable = *FeatEnableOrErr;
-      if (FeatEnable.hasPGOAnalysis() && Version < 2)
-        return createError(
-            "version should be >= 2 for SHT_LLVM_BB_ADDR_MAP when "
-            "PGO features are enabled: version = " +
-            Twine(static_cast<int>(Version)) +
-            " feature = " + Twine(static_cast<int>(Feature)));
-      if (FeatEnable.CallsiteOffsets && Version < 3)
-        return createError(
-            "version should be >= 3 for SHT_LLVM_BB_ADDR_MAP when "
-            "callsite offsets feature is enabled: version = " +
-            Twine(static_cast<int>(Version)) +
-            " feature = " + Twine(static_cast<int>(Feature)));
-    }
+    Version = Data.getU8(Cur);
+    if (!Cur)
+      break;
+    if (Version < 2)
+      return createError("deprecated SHT_LLVM_BB_ADDR_MAP version: " +
+                         Twine(static_cast<int>(Version)));
+    if (Version > 3)
+      return createError("unsupported SHT_LLVM_BB_ADDR_MAP version: " +
+                         Twine(static_cast<int>(Version)));
+    Feature = Data.getU8(Cur); // Feature byte
+    if (!Cur)
+      break;
+    auto FeatEnableOrErr = BBAddrMap::Features::decode(Feature);
+    if (!FeatEnableOrErr)
+      return FeatEnableOrErr.takeError();
+    FeatEnable = *FeatEnableOrErr;
+    if (FeatEnable.CallsiteOffsets && Version < 3)
+      return createError("version should be >= 3 for SHT_LLVM_BB_ADDR_MAP when "
+                         "callsite offsets feature is enabled: version = " +
+                         Twine(static_cast<int>(Version)) +
+                         " feature = " + Twine(static_cast<int>(Feature)));
     uint32_t NumBlocksInBBRange = 0;
     uint32_t NumBBRanges = 1;
     typename ELFFile<ELFT>::uintX_t RangeBaseAddress = 0;

--- a/llvm/lib/Object/ELF.cpp
+++ b/llvm/lib/Object/ELF.cpp
@@ -835,10 +835,7 @@ decodeBBAddrMapImpl(const ELFFile<ELFT> &EF,
     Version = Data.getU8(Cur);
     if (!Cur)
       break;
-    if (Version < 2)
-      return createError("deprecated SHT_LLVM_BB_ADDR_MAP version: " +
-                         Twine(static_cast<int>(Version)));
-    if (Version > 3)
+    if (Version < 2 || Version > 3)
       return createError("unsupported SHT_LLVM_BB_ADDR_MAP version: " +
                          Twine(static_cast<int>(Version)));
     Feature = Data.getU8(Cur); // Feature byte

--- a/llvm/lib/Object/ELFObjectFile.cpp
+++ b/llvm/lib/Object/ELFObjectFile.cpp
@@ -904,8 +904,7 @@ Expected<std::vector<BBAddrMap>> static readBBAddrMapImpl(
 
   const auto &Sections = cantFail(EF.sections());
   auto IsMatch = [&](const Elf_Shdr &Sec) -> Expected<bool> {
-    if (Sec.sh_type != ELF::SHT_LLVM_BB_ADDR_MAP &&
-        Sec.sh_type != ELF::SHT_LLVM_BB_ADDR_MAP_V0)
+    if (Sec.sh_type != ELF::SHT_LLVM_BB_ADDR_MAP)
       return false;
     if (!TextSectionIndex)
       return true;

--- a/llvm/lib/ObjectYAML/ELFYAML.cpp
+++ b/llvm/lib/ObjectYAML/ELFYAML.cpp
@@ -720,7 +720,6 @@ void ScalarEnumerationTraits<ELFYAML::ELF_SHT>::enumeration(
   ECase(SHT_LLVM_SYMPART);
   ECase(SHT_LLVM_PART_EHDR);
   ECase(SHT_LLVM_PART_PHDR);
-  ECase(SHT_LLVM_BB_ADDR_MAP_V0);
   ECase(SHT_LLVM_BB_ADDR_MAP);
   ECase(SHT_LLVM_OFFLOADING);
   ECase(SHT_LLVM_LTO);

--- a/llvm/test/tools/llvm-objdump/X86/elf-bbaddrmap-disassemble-symbolize-operands.yaml
+++ b/llvm/test/tools/llvm-objdump/X86/elf-bbaddrmap-disassemble-symbolize-operands.yaml
@@ -33,10 +33,10 @@
 # ATT-NEXT: <BB0>:
 # ATT-NEXT:   pushq  %rax
 # ATT-NEXT:   movl   %edx, %eax
-# ATT-NEXT:   je     <BB2>
-# ATT-NEXT: <BB1>:
-# ATT-NEXT:   xorl   %esi, %esi
+# ATT-NEXT:   je     <BB4>
 # ATT-NEXT: <BB2>:
+# ATT-NEXT:   xorl   %esi, %esi
+# ATT-NEXT: <BB4>:
 # ATT-NEXT:   callq  <bar>
 # ATT-NEXT:   retq
 # ATT:      <foo.cold>:
@@ -60,10 +60,10 @@
 # INTEL-NEXT: <BB0>:
 # INTEL-NEXT:   push  rax
 # INTEL-NEXT:   mov   eax, edx
-# INTEL-NEXT:   je    <BB2>
-# INTEL-NEXT: <BB1>:
-# INTEL-NEXT:   xor   esi, esi
+# INTEL-NEXT:   je    <BB4>
 # INTEL-NEXT: <BB2>:
+# INTEL-NEXT:   xor   esi, esi
+# INTEL-NEXT: <BB4>:
 # INTEL-NEXT:   call  <bar>
 # INTEL-NEXT:   ret
 # INTEL:      <foo.cold>:
@@ -139,17 +139,20 @@ Sections:
     Type:   SHT_LLVM_BB_ADDR_MAP
     Link:   .text.bar
     Entries:
-      - Version: 1
+      - Version: 2
         BBRanges:
          - BaseAddress: 0x5000
            BBEntries:
-            - AddressOffset: 0x0
+            - ID:            0
+              AddressOffset: 0x0
               Size:          0x1
               Metadata:      0x1
-            - AddressOffset: 0x4
+            - ID:            2
+              AddressOffset: 0x4
               Size:          0x2
               Metadata:      0x0
-            - AddressOffset: 0x0
+            - ID:            4
+              AddressOffset: 0x0
               Size:          0x6
               Metadata:      0x0
 
@@ -230,17 +233,20 @@ Sections:
                AddressOffset: 0x0
                Size:          0x1
                Metadata:      0x2
-      - Version: 1
+      - Version: 2
         BBRanges:
          - BaseAddress: 0x5000
            BBEntries:
-            - AddressOffset: 0x0
+            - ID:            0
+              AddressOffset: 0x0
               Size:          0x1
               Metadata:      0x1
-            - AddressOffset: 0x4
+            - ID:            2
+              AddressOffset: 0x4
               Size:          0x2
               Metadata:      0x0
-            - AddressOffset: 0x0
+            - ID:            4
+              AddressOffset: 0x0
               Size:          0x6
               Metadata:      0x0
 

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -915,7 +915,7 @@ Sections:
   {
     SCOPED_TRACE("unsupported version");
     DoCheck(UnsupportedLowVersionYamlString,
-            "deprecated SHT_LLVM_BB_ADDR_MAP version: 1");
+            "unsupported SHT_LLVM_BB_ADDR_MAP version: 1");
   }
 
   // Check that we fail when function entry count is enabled but not provided.

--- a/llvm/unittests/Object/ELFObjectFileTest.cpp
+++ b/llvm/unittests/Object/ELFObjectFileTest.cpp
@@ -737,7 +737,7 @@ Sections:
     Type: SHT_LLVM_BB_ADDR_MAP
     Link: 2
     Entries:
-      - Version: 1
+      - Version: 2
         BBRanges:
           - BaseAddress: 0x33333
             BBEntries:
@@ -904,7 +904,7 @@ Sections:
   SmallString<128> UnsupportedLowVersionYamlString(CommonYamlString);
   UnsupportedLowVersionYamlString += R"(
       - Version: 1
-        Feature: 0x4
+        Feature: 0x0
         BBRanges:
           - BBEntries:
               - AddressOffset: 0x0
@@ -915,8 +915,7 @@ Sections:
   {
     SCOPED_TRACE("unsupported version");
     DoCheck(UnsupportedLowVersionYamlString,
-            "version should be >= 2 for SHT_LLVM_BB_ADDR_MAP when PGO features "
-            "are enabled: version = 1 feature = 4");
+            "deprecated SHT_LLVM_BB_ADDR_MAP version: 1");
   }
 
   // Check that we fail when function entry count is enabled but not provided.


### PR DESCRIPTION
Version 2 was added more than two years ago (https://github.com/llvm/llvm-project/commit/6015a045d768feab3bae9ad9c0c81e118df8b04a). So it should be safe to deprecate older versions.