### PR TITLE
Fix uncaught-exception.test.

### DIFF
--- a/compiler-rt/test/fuzzer/uncaught-exception.test
+++ b/compiler-rt/test/fuzzer/uncaught-exception.test
@@ -8,4 +8,4 @@ RUN: %cpp_compiler %S/UncaughtException.cpp -o %t-UncaughtException
 # For example, msvc fails with 'uncaught C++ exception'. So the error we check depends on the compiler target.
 RUN: not %run %t-UncaughtException 2>&1 | FileCheck %s
 
-CHECK: ERROR: libFuzzer: {{deadly signal|uncaught C++ exception}}
+CHECK: ERROR: libFuzzer: {{deadly signal|uncaught C\+\+ exception}}


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/125924
To match a literal plus sign, it must be escaped with a backslash (`\`).
