### PR TITLE
[llvm] Use std::tie to implement comparison functors (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/SampleProf.h
+++ b/llvm/include/llvm/ProfileData/SampleProf.h
@@ -289,8 +289,8 @@ struct LineLocation {
   LLVM_ABI void serialize(raw_ostream &OS);
 
   bool operator<(const LineLocation &O) const {
-    return LineOffset < O.LineOffset ||
-           (LineOffset == O.LineOffset && Discriminator < O.Discriminator);
+    return std::tie(LineOffset, Discriminator) <
+           std::tie(O.LineOffset, O.Discriminator);
   }
 
   bool operator==(const LineLocation &O) const {

--- a/llvm/lib/Target/Hexagon/HexagonBlockRanges.h
+++ b/llvm/lib/Target/Hexagon/HexagonBlockRanges.h
@@ -37,7 +37,7 @@ struct HexagonBlockRanges {
     unsigned Sub;
 
     bool operator<(RegisterRef R) const {
-      return Reg < R.Reg || (Reg == R.Reg && Sub < R.Sub);
+      return std::tie(Reg, Sub) < std::tie(R.Reg, R.Sub);
     }
   };
   using RegisterSet = std::set<RegisterRef>;

--- a/llvm/lib/Target/X86/X86PreTileConfig.cpp
+++ b/llvm/lib/Target/X86/X86PreTileConfig.cpp
@@ -80,12 +80,12 @@ struct MIRef {
   bool operator<(const MIRef &RHS) const {
     // Comparison between different BBs happens when inserting a MIRef into set.
     // So we compare MBB first to make the insertion happy.
-    return MBB < RHS.MBB || (MBB == RHS.MBB && Pos < RHS.Pos);
+    return std::tie(MBB, Pos) < std::tie(RHS.MBB, RHS.Pos);
   }
   bool operator>(const MIRef &RHS) const {
     // Comparison between different BBs happens when inserting a MIRef into set.
     // So we compare MBB first to make the insertion happy.
-    return MBB > RHS.MBB || (MBB == RHS.MBB && Pos > RHS.Pos);
+    return std::tie(MBB, Pos) > std::tie(RHS.MBB, RHS.Pos);
   }
 };
 


### PR DESCRIPTION
std::tie clearly expresses the intent while slightly shortening the
code.
