### PR TITLE
[analyzer] Avoid unnecessary super region invalidation in `CStringChecker`

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CStringChecker.cpp
@@ -2252,12 +2252,10 @@ void CStringChecker::evalStrcpyCommon(CheckerContext &C, const CallEvent &Call,
         // Protect against misdeclared strncpy().
         LenVal = svalBuilder.evalCast(LenVal, sizeTy, LenExpr->getType());
 
-        std::optional<NonLoc> LenValNL = LenVal.getAs<NonLoc>();
-
         // Because analyzer doesn't handle expressions like `size -
         // dstLen - 1` very well, we roughly use `size` for
         // ConcatFnKind::strlcat here, same with other concat kinds.
-        if (LenValNL)
+        if (std::optional<NonLoc> LenValNL = LenVal.getAs<NonLoc>())
           CouldAccessOutOfBound = CouldAccessOutOfBoundForSVal(*LenValNL);
       }
     }

--- a/clang/test/Analysis/cstring-should-not-invalidate.cpp
+++ b/clang/test/Analysis/cstring-should-not-invalidate.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.cstring,alpha.unix.cstring -verify %s
 
 // expected-no-diagnostics
 
@@ -63,7 +63,7 @@ struct strncatTestClass {
 
   void KnownLen(char *src) {
     m_ptr = new int;
-    strncat(m_buff, src, sizeof(m_buff)); // known len but unknown src size
+    strncat(m_buff, src, sizeof(m_buff) - 1); // known len but unknown src size
     delete m_ptr;                         // no warning
   }
 

--- a/clang/test/Analysis/cstring-should-not-invalidate.cpp
+++ b/clang/test/Analysis/cstring-should-not-invalidate.cpp
@@ -1,13 +1,18 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.cstring,alpha.unix.cstring -verify %s
-
-// expected-no-diagnostics
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,unix.cstring,alpha.unix.cstring,debug.ExprInspection -verify %s
 
 typedef decltype(sizeof(int)) size_t;
+void clang_analyzer_eval(bool);
 
 char *strncpy(char *dest, const char *src, size_t x);
 
+constexpr int initB = 100;
+struct Base {
+  int b;
+  Base(): b(initB) {}
+};
+
 // issue 143807
-struct strncpyTestClass {
+struct strncpyTestClass: public Base {
   int *m_ptr;
   char m_buff[1000];
 
@@ -28,11 +33,12 @@ void strncpyTest(char *src, size_t n) {
   strncpyTestClass rep;
   rep.KnownLen(src);
   rep.KnownSrcLen(n);
+  clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }
 
 size_t strlcpy(char *dest, const char *src, size_t size);
 
-struct strlcpyTestClass {
+struct strlcpyTestClass: public Base {
   int *m_ptr;
   char m_buff[1000];
 
@@ -53,11 +59,12 @@ void strlcpyTest(char *src, size_t n) {
   strlcpyTestClass rep;
   rep.KnownLen(src);
   rep.KnownSrcLen(n);
+  clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }
 
 char *strncat(char *s1, const char *s2, size_t n);
 
-struct strncatTestClass {
+struct strncatTestClass: public Base {
   int *m_ptr;
   char m_buff[1000];
 
@@ -78,11 +85,12 @@ void strncatTest(char *src, size_t n) {
   strncatTestClass rep;
   rep.KnownLen(src);
   rep.KnownSrcLen(n);
+  clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }
 
 size_t strlcat(char *dst, const char *src, size_t size);
 
-struct strlcatTestClass {
+struct strlcatTestClass: public Base {
   int *m_ptr;
   char m_buff[1000];
 
@@ -103,4 +111,5 @@ void strlcatTest(char *src, size_t n) {
   strlcatTestClass rep;
   rep.KnownLen(src);
   rep.KnownSrcLen(n);
+  clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }

--- a/clang/test/Analysis/cstring-should-not-invalidate.cpp
+++ b/clang/test/Analysis/cstring-should-not-invalidate.cpp
@@ -88,6 +88,24 @@ void strncatTest(char *src, size_t n) {
   clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }
 
+struct strncatReportOutOfBoundTestClass: public Base {
+  int *m_ptr;
+  char m_buff[1000];
+
+  void KnownLen(char *src) {
+    m_ptr = new int;
+    // expected-warning@+1{{String concatenation function overflows the destination buffer}}
+    strncat(m_buff, src, sizeof(m_buff)); // known len but unknown src size
+    delete m_ptr;                         // no warning
+  }
+};
+
+void strncatReportOutOfBoundTest(char *src, size_t n) {
+  strncatReportOutOfBoundTestClass rep;
+  rep.KnownLen(src);
+  clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
+}
+
 size_t strlcat(char *dst, const char *src, size_t size);
 
 struct strlcatTestClass: public Base {

--- a/clang/test/Analysis/cstring-should-not-invalidate.cpp
+++ b/clang/test/Analysis/cstring-should-not-invalidate.cpp
@@ -88,7 +88,7 @@ void strncatTest(char *src, size_t n) {
   clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }
 
-struct strncatReportOutOfBoundTestClass: public Base {
+struct strncatReportOutOfBoundTestClass {
   int *m_ptr;
   char m_buff[1000];
 
@@ -103,7 +103,6 @@ struct strncatReportOutOfBoundTestClass: public Base {
 void strncatReportOutOfBoundTest(char *src, size_t n) {
   strncatReportOutOfBoundTestClass rep;
   rep.KnownLen(src);
-  clang_analyzer_eval(rep.b == initB); // expected-warning{{TRUE}}
 }
 
 size_t strlcat(char *dst, const char *src, size_t size);

--- a/clang/test/Analysis/cstring-should-not-invalidate.cpp
+++ b/clang/test/Analysis/cstring-should-not-invalidate.cpp
@@ -1,0 +1,107 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection
+// -analyzer-config c++-inlining=constructors -verify %s
+
+// expected-no-diagnostics
+
+typedef unsigned int size_t;
+
+char *strncpy(char *dest, const char *src, size_t x);
+
+// issue 143807
+struct strncpyTestClass {
+  int *m_ptr;
+  char m_buff[1000];
+
+  void KnownLen(char *src) {
+    m_ptr = new int;
+    strncpy(m_buff, src, sizeof(m_buff)); // known len but unknown src size
+    delete m_ptr;                         // no warning
+  }
+
+  void KnownSrcLen(size_t n) {
+    m_ptr = new int;
+    strncpy(m_buff, "xyz", n); // known src size but unknown len
+    delete m_ptr;              // no warning
+  }
+};
+
+void strncpyTest(char *src, size_t n) {
+  strncpyTestClass rep;
+  rep.KnownLen(src);
+  rep.KnownSrcLen(n);
+}
+
+size_t strlcpy(char *dest, const char *src, size_t size);
+
+struct strlcpyTestClass {
+  int *m_ptr;
+  char m_buff[1000];
+
+  void KnownLen(char *src) {
+    m_ptr = new int;
+    strlcpy(m_buff, src, sizeof(m_buff)); // known len but unknown src size
+    delete m_ptr;                         // no warning
+  }
+
+  void KnownSrcLen(size_t n) {
+    m_ptr = new int;
+    strlcpy(m_buff, "xyz", n); // known src size but unknown len
+    delete m_ptr;              // no warning
+  }
+};
+
+void strlcpyTest(char *src, size_t n) {
+  strlcpyTestClass rep;
+  rep.KnownLen(src);
+  rep.KnownSrcLen(n);
+}
+
+char *strncat(char *s1, const char *s2, size_t n);
+
+struct strncatTestClass {
+  int *m_ptr;
+  char m_buff[1000];
+
+  void KnownLen(char *src) {
+    m_ptr = new int;
+    strncat(m_buff, src, sizeof(m_buff)); // known len but unknown src size
+    delete m_ptr;                         // no warning
+  }
+
+  void KnownSrcLen(size_t n) {
+    m_ptr = new int;
+    strncat(m_buff, "xyz", n); // known src size but unknown len
+    delete m_ptr;              // no warning
+  }
+};
+
+void strncatTest(char *src, size_t n) {
+  strncatTestClass rep;
+  rep.KnownLen(src);
+  rep.KnownSrcLen(n);
+}
+
+size_t strlcat(char *dst, const char *src, size_t size);
+
+struct strlcatTestClass {
+  int *m_ptr;
+  char m_buff[1000];
+
+  void KnownLen(char *src) {
+    m_ptr = new int;
+    strlcat(m_buff, src, sizeof(m_buff)); // known len but unknown src size
+    delete m_ptr;                         // no warning
+  }
+
+  void KnownSrcLen(size_t n) {
+    m_ptr = new int;
+    strlcat(m_buff, "xyz", n); // known src size but unknown len
+    delete m_ptr;              // no warning
+  }
+};
+
+void strlcatTest(char *src, size_t n) {
+  strlcatTestClass rep;
+  rep.KnownLen(src);
+  rep.KnownSrcLen(n);
+}

--- a/clang/test/Analysis/cstring-should-not-invalidate.cpp
+++ b/clang/test/Analysis/cstring-should-not-invalidate.cpp
@@ -1,9 +1,8 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection
-// -analyzer-config c++-inlining=constructors -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
 
 // expected-no-diagnostics
 
-typedef unsigned int size_t;
+typedef decltype(sizeof(int)) size_t;
 
 char *strncpy(char *dest, const char *src, size_t x);
 


### PR DESCRIPTION
Bounded string functions takes smallest of two values as it's copy size (`amountCopied` variable in `evalStrcpyCommon`), and it's used to decided whether this operation will cause out-of-bound access and invalidate it's super region if it does.

for `strlcat`: `amountCopied = min (size - dstLen - 1 , srcLen)`
for others: `amountCopied = min (srcLen, size)`

Currently when one of two values is unknown or  `SValBuilder` can't decide which one is smaller, `amountCopied` will remain `UnknownVal`, which will invalidate copy destination's super region unconditionally. 

This patch add check to see if one of these two values is definitely in-bound, if so `amountCopied` has to be in-bound too, because it‘s less than or equal to them, we can avoid the invalidation of super region and some related false positives in this situation.

Note: This patch uses `size` as an approximation of `size - dstLen - 1` in `strlcat` case because currently analyzer doesn't handle complex expressions like this very well.

Closes #143807.