### PR TITLE
[ExecutionEngine] Remove unnecessary casts (NFC)

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ELF_aarch64.cpp
@@ -523,7 +523,7 @@ private:
     case ELFTLSDescCall:
       return "ELFTLSDescCall";
     default:
-      return getGenericEdgeKindName(static_cast<Edge::Kind>(R));
+      return getGenericEdgeKindName(R);
     }
   }
 

--- a/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/MachO_arm64.cpp
@@ -545,7 +545,7 @@ private:
     case MachONegDelta64:
       return "MachONegDelta64";
     default:
-      return getGenericEdgeKindName(static_cast<Edge::Kind>(R));
+      return getGenericEdgeKindName(R);
     }
   }
 

--- a/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch64.cpp
@@ -85,7 +85,7 @@ const char *getEdgeKindName(Edge::Kind R) {
   case RequestTLSDescEntryAndTransformToPageOffset12:
     return "RequestTLSDescEntryAndTransformToPageOffset12";
   default:
-    return getGenericEdgeKindName(static_cast<Edge::Kind>(R));
+    return getGenericEdgeKindName(R);
   }
 }
 

--- a/llvm/lib/ExecutionEngine/JITLink/ppc64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/ppc64.cpp
@@ -137,7 +137,7 @@ const char *getEdgeKindName(Edge::Kind K) {
   case RequestTLSDescInGOTAndTransformToDelta34:
     return "RequestTLSDescInGOTAndTransformToDelta34";
   default:
-    return getGenericEdgeKindName(static_cast<Edge::Kind>(K));
+    return getGenericEdgeKindName(K);
   }
 }
 

--- a/llvm/lib/ExecutionEngine/JITLink/x86_64.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/x86_64.cpp
@@ -75,7 +75,7 @@ const char *getEdgeKindName(Edge::Kind K) {
   case RequestTLVPAndTransformToPCRel32TLVPLoadREXRelaxable:
     return "RequestTLVPAndTransformToPCRel32TLVPLoadREXRelaxable";
   default:
-    return getGenericEdgeKindName(static_cast<Edge::Kind>(K));
+    return getGenericEdgeKindName(K);
   }
 }
 


### PR DESCRIPTION
R and K are already of Edge::Kind in all these cases.
