### PR TITLE
[llvm] Compare std::optional<T> to values directly (NFC)

### DIFF
--- a/llvm/lib/TargetParser/AArch64TargetParser.cpp
+++ b/llvm/lib/TargetParser/AArch64TargetParser.cpp
@@ -50,7 +50,7 @@ std::optional<AArch64::ArchInfo> AArch64::ArchInfo::findBySubArch(StringRef SubA
 
 std::optional<AArch64::FMVInfo> lookupFMVByID(AArch64::ArchExtKind ExtID) {
   for (const AArch64::FMVInfo &Info : AArch64::getFMVInfo())
-    if (Info.ID && *Info.ID == ExtID)
+    if (Info.ID == ExtID)
       return Info;
   return {};
 }

--- a/llvm/unittests/Support/RISCVAttributeParserTest.cpp
+++ b/llvm/unittests/Support/RISCVAttributeParserTest.cpp
@@ -45,7 +45,7 @@ static bool testAttribute(unsigned Tag, unsigned Value, unsigned ExpectedTag,
   cantFail(Parser.parse(Bytes, llvm::endianness::little));
 
   std::optional<unsigned> Attr = Parser.getAttributeValue("", ExpectedTag);
-  return Attr && *Attr == ExpectedValue;
+  return Attr == ExpectedValue;
 }
 
 static bool testTagString(unsigned Tag, const char *name) {


### PR DESCRIPTION
This patch transforms:

  X && *X == Y

to:

  X == Y

where X is of std::optional<T>, and Y is of T or similar.
