### PR TITLE
[Arm] Fix UAF in ARMConstantIslandPass

### DIFF
--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -476,8 +476,8 @@ bool ARMConstantIslands::runOnMachineFunction(MachineFunction &mf) {
 
     LLVM_DEBUG(dbgs() << "Beginning BR iteration #" << NoBRIters << '\n');
     bool BRChange = false;
-    for (ImmBranch &Br : ImmBranches)
-      BRChange |= fixupImmediateBr(Br);
+    for (unsigned i = 0, e = ImmBranches.size(); i != e; ++i)
+      BRChange |= fixupImmediateBr(ImmBranches[i]);
     if (BRChange && ++NoBRIters > 30)
       report_fatal_error("Branch Fix Up pass failed to converge!");
     LLVM_DEBUG(dumpBBs());

--- a/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
+++ b/llvm/lib/Target/ARM/ARMConstantIslandPass.cpp
@@ -476,8 +476,8 @@ bool ARMConstantIslands::runOnMachineFunction(MachineFunction &mf) {
 
     LLVM_DEBUG(dbgs() << "Beginning BR iteration #" << NoBRIters << '\n');
     bool BRChange = false;
-    for (unsigned i = 0, e = ImmBranches.size(); i != e; ++i)
-      BRChange |= fixupImmediateBr(ImmBranches[i]);
+    for (ImmBranch &Br : llvm::make_early_inc_range(ImmBranches))
+      BRChange |= fixupImmediateBr(Br);
     if (BRChange && ++NoBRIters > 30)
       report_fatal_error("Branch Fix Up pass failed to converge!");
     LLVM_DEBUG(dumpBBs());


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/146198 changes
```
    for (unsigned i = 0, e = ImmBranches.size(); i != e; ++i)
      BRChange |= fixupImmediateBr(ImmBranches[i]);
```
to
```
    for (ImmBranch &Br : ImmBranches)
      BRChange |= fixupImmediateBr(Br);
```
Unfortunately, they are not NFC and cause the buildbot error. e.g.,
https://lab.llvm.org/buildbot/#/builders/24/builds/9943
https://lab.llvm.org/buildbot/#/builders/169/builds/12570
Use make_early_inc_range to fix the issue
