### PR TITLE
[Github] Install `make` on Windows container

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -39,7 +39,8 @@ RUN regsvr32 /S "C:\BuildTools\DIA SDK\bin\amd64\msdia140.dll" & \
 
 # install tools as described in https://llvm.org/docs/GettingStartedVS.html
 # and a few more that were not documented...
-RUN choco install -y ninja git sccache
+# make is needed by LLDB tests
+RUN choco install -y ninja git sccache make
 # Pin an older version of Python; the current Python 3.10 fails when
 # doing "pip install" for the other dependencies, as it fails to find libxml
 # while compiling some package.


### PR DESCRIPTION
LLDB tests require GNU `make` to be present for the API tests.

This PR installs the [`make` package from Chocolatey](https://community.chocolatey.org/packages/make), which packages the GNU `make` from <https://sourceforge.net/projects/ezwinports/>.

**Alternatives considered**:
- NMake/jom: These don't support all the command line parameters and don't support the required conditionals.
- `mingw32-make`: if available, this would work. However, installing it would require a MinGW installation. Git Bash doesn't come with a package manager.

**Remaining work**:

- For testing on Windows, LLDB needs LLD, which needs to be enabled.
- After that, most tests run. I ran this through GitHub Actions, which almost took 4h to complete. The following tests failed (this might be due to my weird setup):
  ```
  Failed Tests (12):
  lldb-api :: commands/command/script_alias/TestCommandScriptAlias.py
  lldb-api :: functionalities/load_unload/TestLoadUnload.py
  lldb-api :: lang/cpp/class-template-non-type-parameter-pack/TestClassTemplateNonTypeParameterPack.py
  lldb-api :: lang/cpp/class-template-type-parameter-pack/TestClassTemplateTypeParameterPack.py
  lldb-api :: python_api/hello_world/TestHelloWorld.py
  lldb-api :: tools/lldb-server/TestGdbRemoteExitCode.py
  lldb-api :: tools/lldb-server/TestGdbRemoteExpeditedRegisters.py
  lldb-api :: tools/lldb-server/TestGdbRemoteThreadsInStopReply.py
  lldb-api :: tools/lldb-server/TestGdbRemote_qThreadStopInfo.py
  lldb-api :: tools/lldb-server/TestNonStop.py
  lldb-shell :: Process/Windows/process_load.cpp
  lldb-shell :: Target/dependent-modules-nodupe-windows.test
  ```

Towards #132800.