### PR TITLE
[AVR] Fix compile warning AVR InstPrinter

### DIFF
--- a/llvm/lib/Target/AVR/MCTargetDesc/AVRInstPrinter.cpp
+++ b/llvm/lib/Target/AVR/MCTargetDesc/AVRInstPrinter.cpp
@@ -100,7 +100,7 @@ const char *AVRInstPrinter::getPrettyRegisterName(MCRegister Reg,
 
 void AVRInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
                                   raw_ostream &O) {
-  const MCOperandInfo &MOI = this->MII.get(MI->getOpcode()).operands()[OpNo];
+  const MCOperandInfo MOI = this->MII.get(MI->getOpcode()).operands()[OpNo];
   if (MOI.RegClass == AVR::ZREGRegClassID) {
     // Special case for the Z register, which sometimes doesn't have an operand
     // in the MCInst.


### PR DESCRIPTION
Fix the only compile time warning for AVR (default flags):

```
/home/tom/src/rust/llvm-project/llvm/lib/Target/AVR/MCTargetDesc/AVRInstPrinter.cpp: In member function ‘void
 llvm::AVRInstPrinter::printOperand(const llvm::MCInst*, unsigned int, llvm::raw_ostream&)’:
/home/tom/src/rust/llvm-project/llvm/lib/Target/AVR/MCTargetDesc/AVRInstPrinter.cpp:104:24: warning: possibly
 dangling reference to a temporary [-Wdangling-reference]
  104 |   const MCOperandInfo &MOI = this->MII.get(MI->getOpcode()).operands()[OpNo];
      |                        ^~~
/home/tom/src/rust/llvm-project/llvm/lib/Target/AVR/MCTargetDesc/AVRInstPrinter.cpp:104:76: note: the tempora
ry was destroyed at the end of the full expression ‘(&(&((llvm::AVRInstPrinter*)this)->llvm::AVRInstPrinter::
<anonymous>.llvm::MCInstPrinter::MII)->llvm::MCInstrInfo::get(MI->llvm::MCInst::getOpcode()))->llvm::MCInstrD
esc::operands().llvm::ArrayRef<llvm::MCOperandInfo>::operator[](((size_t)OpNo))’
  104 |   const MCOperandInfo &MOI = this->MII.get(MI->getOpcode()).operands()[OpNo];
      |                                                                            ^
```
