### PR TITLE
[libc++] fix atomic::wait memory order

### DIFF
--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -151,8 +151,9 @@ __libcpp_contention_monitor_for_wait(__cxx_atomic_contention_t volatile* /*__con
 static void __libcpp_contention_wait(__cxx_atomic_contention_t volatile* __contention_state,
                                      __cxx_atomic_contention_t const volatile* __platform_state,
                                      __cxx_contention_t __old_value) {
-  __cxx_atomic_fetch_add(__contention_state, __cxx_contention_t(1), memory_order_seq_cst);
+  __cxx_atomic_fetch_add(__contention_state, __cxx_contention_t(1), memory_order_relaxed);
   // We sleep as long as the monitored value hasn't changed.
+  __cxx_atomic_thread_fence(memory_order_seq_cst);
   __libcpp_platform_wait_on_address(__platform_state, __old_value);
   __cxx_atomic_fetch_sub(__contention_state, __cxx_contention_t(1), memory_order_release);
 }
@@ -163,7 +164,7 @@ static void __libcpp_contention_wait(__cxx_atomic_contention_t volatile* __conte
 static void __libcpp_atomic_notify(void const volatile* __location) {
   auto const __entry = __libcpp_contention_state(__location);
   // The value sequence laundering happens on the next line below.
-  __cxx_atomic_fetch_add(&__entry->__platform_state, __cxx_contention_t(1), memory_order_release);
+  __cxx_atomic_fetch_add(&__entry->__platform_state, __cxx_contention_t(1), memory_order_seq_cst);
   __libcpp_contention_notify(
       &__entry->__contention_state,
       &__entry->__platform_state,

--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -152,8 +152,10 @@ static void __libcpp_contention_wait(__cxx_atomic_contention_t volatile* __conte
                                      __cxx_atomic_contention_t const volatile* __platform_state,
                                      __cxx_contention_t __old_value) {
   __cxx_atomic_fetch_add(__contention_state, __cxx_contention_t(1), memory_order_relaxed);
-  // We sleep as long as the monitored value hasn't changed.
+  // https://github.com/llvm/llvm-project/issues/109290
+  // There are no platform guarantees of a memory barrier in the platform wait implementation
   __cxx_atomic_thread_fence(memory_order_seq_cst);
+  // We sleep as long as the monitored value hasn't changed.
   __libcpp_platform_wait_on_address(__platform_state, __old_value);
   __cxx_atomic_fetch_sub(__contention_state, __cxx_contention_t(1), memory_order_release);
 }


### PR DESCRIPTION
Fixes #109290 

See the GH issue for the details. In conclusion, we have two issues in the `atomic<T>::wait` when `T` does not match our `contention_t`:
- We don't have a total single order which can leads to missed notification based on the Herd7 simulation on relaxed architectural like PowerPC
- We assumed the platform wait (`futex_wait`/`__ulock_wait`) has seq_cst barrier internally but there is no such guarantee 