### PR TITLE
Fix missing module exports & broken localization test.

### DIFF
--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -934,7 +934,10 @@ module std [system] {
     module chars_format               { header "__charconv/chars_format.h" }
     module from_chars_floating_point  { header "__charconv/from_chars_floating_point.h" }
     module from_chars_integral        { header "__charconv/from_chars_integral.h" }
-    module from_chars_result          { header "__charconv/from_chars_result.h" }
+    module from_chars_result          {
+        header "__charconv/from_chars_result.h"
+        export std.system_error.errc // The result type contains errc
+    }
     module tables                     { header "__charconv/tables.h" }
     module to_chars                   { header "__charconv/to_chars.h" }
     module to_chars_base_10           { header "__charconv/to_chars_base_10.h" }


### PR DESCRIPTION
The mangled_name.pass.cpp test was checked in a few days ago, and this patch attempts to fix the build breakages it introduced.

The cryptic error from the breakage is:

When reproducing on my machine, I got additional diagnostics about missing exports for `errc`. The fix, I believe, is to re-export the errc header from the charconv module (or submodule).