### PR TITLE
[clang][SPIRV] Remove volatile variants of GenericCastToPtr* built-ins

### DIFF
--- a/clang/lib/Headers/__clang_spirv_builtins.h
+++ b/clang/lib/Headers/__clang_spirv_builtins.h
@@ -56,32 +56,12 @@ __spirv_GenericCastToPtrExplicit_ToGlobal(__generic const void *,
                                           int) __SPIRV_NOEXCEPT;
 extern __SPIRV_overloadable
 __SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
-__global volatile void *
-__spirv_GenericCastToPtrExplicit_ToGlobal(__generic volatile void *,
-                                          int) __SPIRV_NOEXCEPT;
-extern __SPIRV_overloadable
-__SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
-__global const volatile void *
-__spirv_GenericCastToPtrExplicit_ToGlobal(__generic const volatile void *,
-                                          int) __SPIRV_NOEXCEPT;
-extern __SPIRV_overloadable
-__SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
 __local void *__spirv_GenericCastToPtrExplicit_ToLocal(__generic void *,
                                                        int) __SPIRV_NOEXCEPT;
 extern __SPIRV_overloadable
 __SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
 __local const void *
 __spirv_GenericCastToPtrExplicit_ToLocal(__generic const void *,
-                                         int) __SPIRV_NOEXCEPT;
-extern __SPIRV_overloadable
-__SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
-__local volatile void *
-__spirv_GenericCastToPtrExplicit_ToLocal(__generic volatile void *,
-                                         int) __SPIRV_NOEXCEPT;
-extern __SPIRV_overloadable
-__SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
-__local const volatile void *
-__spirv_GenericCastToPtrExplicit_ToLocal(__generic const volatile void *,
                                          int) __SPIRV_NOEXCEPT;
 extern __SPIRV_overloadable
 __SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
@@ -92,16 +72,6 @@ extern __SPIRV_overloadable
 __SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
 __private const void *
 __spirv_GenericCastToPtrExplicit_ToPrivate(__generic const void *,
-                                           int) __SPIRV_NOEXCEPT;
-extern __SPIRV_overloadable
-__SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
-__private volatile void *
-__spirv_GenericCastToPtrExplicit_ToPrivate(__generic volatile void *,
-                                           int) __SPIRV_NOEXCEPT;
-extern __SPIRV_overloadable
-__SPIRV_BUILTIN_ALIAS(__builtin_spirv_generic_cast_to_ptr_explicit)
-__private const volatile void *
-__spirv_GenericCastToPtrExplicit_ToPrivate(__generic const volatile void *,
                                            int) __SPIRV_NOEXCEPT;
 
 // OpGenericCastToPtr
@@ -115,16 +85,6 @@ __spirv_GenericCastToPtr_ToGlobal(__generic const void *p,
                                   int) __SPIRV_NOEXCEPT {
   return (__global const void *)p;
 }
-static __SPIRV_overloadable __SPIRV_inline __global volatile void *
-__spirv_GenericCastToPtr_ToGlobal(__generic volatile void *p,
-                                  int) __SPIRV_NOEXCEPT {
-  return (__global volatile void *)p;
-}
-static __SPIRV_overloadable __SPIRV_inline __global const volatile void *
-__spirv_GenericCastToPtr_ToGlobal(__generic const volatile void *p,
-                                  int) __SPIRV_NOEXCEPT {
-  return (__global const volatile void *)p;
-}
 static __SPIRV_overloadable __SPIRV_inline __local void *
 __spirv_GenericCastToPtr_ToLocal(__generic void *p, int) __SPIRV_NOEXCEPT {
   return (__local void *)p;
@@ -134,16 +94,6 @@ __spirv_GenericCastToPtr_ToLocal(__generic const void *p,
                                  int) __SPIRV_NOEXCEPT {
   return (__local const void *)p;
 }
-static __SPIRV_overloadable __SPIRV_inline __local volatile void *
-__spirv_GenericCastToPtr_ToLocal(__generic volatile void *p,
-                                 int) __SPIRV_NOEXCEPT {
-  return (__local volatile void *)p;
-}
-static __SPIRV_overloadable __SPIRV_inline __local const volatile void *
-__spirv_GenericCastToPtr_ToLocal(__generic const volatile void *p,
-                                 int) __SPIRV_NOEXCEPT {
-  return (__local const volatile void *)p;
-}
 static __SPIRV_overloadable __SPIRV_inline __private void *
 __spirv_GenericCastToPtr_ToPrivate(__generic void *p, int) __SPIRV_NOEXCEPT {
   return (__private void *)p;
@@ -152,16 +102,6 @@ static __SPIRV_overloadable __SPIRV_inline __private const void *
 __spirv_GenericCastToPtr_ToPrivate(__generic const void *p,
                                    int) __SPIRV_NOEXCEPT {
   return (__private const void *)p;
-}
-static __SPIRV_overloadable __SPIRV_inline __private volatile void *
-__spirv_GenericCastToPtr_ToPrivate(__generic volatile void *p,
-                                   int) __SPIRV_NOEXCEPT {
-  return (__private volatile void *)p;
-}
-static __SPIRV_overloadable __SPIRV_inline __private const volatile void *
-__spirv_GenericCastToPtr_ToPrivate(__generic const volatile void *p,
-                                   int) __SPIRV_NOEXCEPT {
-  return (__private const volatile void *)p;
 }
 
 #undef __SPIRV_overloadable


### PR DESCRIPTION
They are generally implemented with pointer comparison, e.g checking
pointer value is within a range of a specific address space. Volatile
is not needed because memory pointed to by the pointer isn't accessed.
With this PR, backend target doesn't need to implement volatile variant.