### PR TITLE
DynamicAPInt: Support APInt constructor.

### DIFF
--- a/llvm/include/llvm/ADT/DynamicAPInt.h
+++ b/llvm/include/llvm/ADT/DynamicAPInt.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_ADT_DYNAMICAPINT_H
 #define LLVM_ADT_DYNAMICAPINT_H
 
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SlowDynamicAPInt.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
@@ -115,6 +116,14 @@ public:
   LLVM_ATTRIBUTE_ALWAYS_INLINE explicit DynamicAPInt(int64_t Val)
       : ValSmall(Val) {
     ValLarge.Val.BitWidth = 0;
+  }
+  LLVM_ATTRIBUTE_ALWAYS_INLINE explicit DynamicAPInt(const APInt &Val) {
+    if (Val.getBitWidth() <= 64) {
+      ValSmall = Val.getSExtValue();
+      ValLarge.Val.BitWidth = 0;
+    } else {
+      new (&ValLarge) detail::SlowDynamicAPInt(Val);
+    }
   }
   LLVM_ATTRIBUTE_ALWAYS_INLINE DynamicAPInt() : DynamicAPInt(0) {}
   LLVM_ATTRIBUTE_ALWAYS_INLINE ~DynamicAPInt() {

--- a/llvm/unittests/ADT/DynamicAPIntTest.cpp
+++ b/llvm/unittests/ADT/DynamicAPIntTest.cpp
@@ -31,6 +31,16 @@ public:
 };
 TYPED_TEST_SUITE(IntTest, TypeList, TypeNames);
 
+TYPED_TEST(IntTest, ValueInit) {
+  APInt Large(65, 0, true);
+  Large.setBit(64);
+  TypeParam DynLarge(1ll << 63);
+  EXPECT_EQ(TypeParam(Large), DynLarge + DynLarge);
+  APInt Small(64, -1, true);
+  TypeParam DynSmall(Small.getSExtValue());
+  EXPECT_EQ(TypeParam(Small), DynSmall);
+}
+
 TYPED_TEST(IntTest, ops) {
   TypeParam Two(2), Five(5), Seven(7), Ten(10);
   EXPECT_EQ(Five + Five, Ten);


### PR DESCRIPTION
This PR introduces a constructor for `DynamicAPInt` that takes an `APInt` object as input to simplifies the creation of a large numbers.
