### PR TITLE
[libunwind] Fix return type of `DwarfFDECache::findFDE()` in definition

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -173,7 +173,8 @@ bool DwarfFDECache<A>::_registeredForDyldUnloads = false;
 #endif
 
 template <typename A>
-typename A::pint_t DwarfFDECache<A>::findFDE(pint_t mh, pint_t pc) {
+typename DwarfFDECache<A>::pint_t DwarfFDECache<A>::findFDE(pint_t mh,
+                                                            pint_t pc) {
   pint_t result = 0;
   _LIBUNWIND_LOG_IF_FALSE(_lock.lock_shared());
   for (entry *p = _buffer; p < _bufferUsed; ++p) {


### PR DESCRIPTION
Needed to resolve this compilation error on some systems:

        lib/libunwind/src/UnwindCursor.hpp:153:38: error: return type of out-of-line definition of 'libunwind::DwarfFDECache::findFDE' differs from that in the declaration
    typename A::pint_t DwarfFDECache<A>::findFDE(pint_t mh, pint_t pc) {
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        lib/libunwind/src/libunwind.cpp:31:10: note: in file included from lib/libunwind/src/libunwind.cpp:31:
    #include "UnwindCursor.hpp"
             ^
        lib/libunwind/src/UnwindCursor.hpp:100:17: note: previous declaration is here
      static pint_t findFDE(pint_t mh, pint_t pc);
             ~~~~~~~^