### PR TITLE
[Offload] Refactor device/platform info queries

### DIFF
--- a/offload/liboffload/src/Helpers.hpp
+++ b/offload/liboffload/src/Helpers.hpp
@@ -75,20 +75,20 @@ public:
   InfoWriter(InfoWriter &) = delete;
   ~InfoWriter() = default;
 
-  template <typename T> llvm::Error Write(llvm::Expected<T> &&Val) {
+  template <typename T> llvm::Error write(llvm::Expected<T> &&Val) {
     if (Val)
       return getInfo(Size, Target, SizeRet, *Val);
     return Val.takeError();
   }
 
   template <typename T>
-  llvm::Error WriteArray(llvm::Expected<T> &&Val, size_t Elems) {
+  llvm::Error writeArray(llvm::Expected<T> &&Val, size_t Elems) {
     if (Val)
       return getInfoArray(Elems, Size, Target, SizeRet, *Val);
     return Val.takeError();
   }
 
-  llvm::Error WriteString(llvm::Expected<llvm::StringRef> &&Val) {
+  llvm::Error writeString(llvm::Expected<llvm::StringRef> &&Val) {
     if (Val)
       return getInfoString(Size, Target, SizeRet, *Val);
     return Val.takeError();

--- a/offload/liboffload/src/Helpers.hpp
+++ b/offload/liboffload/src/Helpers.hpp
@@ -75,17 +75,19 @@ public:
   InfoWriter(InfoWriter &) = delete;
   ~InfoWriter() = default;
 
-  template <class T> llvm::Error Write(llvm::Expected<T> &&Val) {
+  template <typename T> llvm::Error Write(llvm::Expected<T> &&Val) {
     if (Val)
       return getInfo(Size, Target, SizeRet, *Val);
     return Val.takeError();
   }
-  template <class T>
+
+  template <typename T>
   llvm::Error WriteArray(llvm::Expected<T> &&Val, size_t Elems) {
     if (Val)
       return getInfoArray(Elems, Size, Target, SizeRet, *Val);
     return Val.takeError();
   }
+
   llvm::Error WriteString(llvm::Expected<llvm::StringRef> &&Val) {
     if (Val)
       return getInfoString(Size, Target, SizeRet, *Val);

--- a/offload/liboffload/src/Helpers.hpp
+++ b/offload/liboffload/src/Helpers.hpp
@@ -76,22 +76,19 @@ public:
   ~InfoWriter() = default;
 
   template <class T> llvm::Error Write(llvm::Expected<T> &&Val) {
-    if (Val) {
+    if (Val)
       return getInfo(Size, Target, SizeRet, *Val);
-    }
     return Val.takeError();
   }
   template <class T>
   llvm::Error WriteArray(llvm::Expected<T> &&Val, size_t Elems) {
-    if (Val) {
+    if (Val)
       return getInfoArray(Elems, Size, Target, SizeRet, *Val);
-    }
     return Val.takeError();
   }
   llvm::Error WriteString(llvm::Expected<llvm::StringRef> &&Val) {
-    if (Val) {
+    if (Val)
       return getInfoString(Size, Target, SizeRet, *Val);
-    }
     return Val.takeError();
   }
 

--- a/offload/liboffload/src/Helpers.hpp
+++ b/offload/liboffload/src/Helpers.hpp
@@ -61,39 +61,42 @@ llvm::Error getInfoArray(size_t array_length, size_t ParamValueSize,
                      array_length * sizeof(T), memcpy);
 }
 
-template <>
-inline llvm::Error
-getInfo<const char *>(size_t ParamValueSize, void *ParamValue,
-                      size_t *ParamValueSizeRet, const char *Value) {
-  return getInfoArray(strlen(Value) + 1, ParamValueSize, ParamValue,
-                      ParamValueSizeRet, Value);
+llvm::Error getInfoString(size_t ParamValueSize, void *ParamValue,
+                          size_t *ParamValueSizeRet, llvm::StringRef Value) {
+  return getInfoArray(Value.size() + 1, ParamValueSize, ParamValue,
+                      ParamValueSizeRet, Value.data());
 }
 
-class ReturnHelper {
+class InfoWriter {
 public:
-  ReturnHelper(size_t ParamValueSize, void *ParamValue,
-               size_t *ParamValueSizeRet)
-      : ParamValueSize(ParamValueSize), ParamValue(ParamValue),
-        ParamValueSizeRet(ParamValueSizeRet) {}
+  InfoWriter(size_t Size, void *Target, size_t *SizeRet)
+      : Size(Size), Target(Target), SizeRet(SizeRet) {};
+  InfoWriter() = delete;
+  InfoWriter(InfoWriter &) = delete;
+  ~InfoWriter() = default;
 
-  // A version where in/out info size is represented by a single pointer
-  // to a value which is updated on return
-  ReturnHelper(size_t *ParamValueSize, void *ParamValue)
-      : ParamValueSize(*ParamValueSize), ParamValue(ParamValue),
-        ParamValueSizeRet(ParamValueSize) {}
-
-  // Scalar return Value
-  template <class T> llvm::Error operator()(const T &t) {
-    return getInfo(ParamValueSize, ParamValue, ParamValueSizeRet, t);
+  template <class T> llvm::Error Write(llvm::Expected<T> &&Val) {
+    if (Val) {
+      return getInfo(Size, Target, SizeRet, *Val);
+    }
+    return Val.takeError();
+  }
+  template <class T>
+  llvm::Error WriteArray(llvm::Expected<T> &&Val, size_t Elems) {
+    if (Val) {
+      return getInfoArray(Elems, Size, Target, SizeRet, *Val);
+    }
+    return Val.takeError();
+  }
+  llvm::Error WriteString(llvm::Expected<llvm::StringRef> &&Val) {
+    if (Val) {
+      return getInfoString(Size, Target, SizeRet, *Val);
+    }
+    return Val.takeError();
   }
 
-  // Array return Value
-  template <class T> llvm::Error operator()(const T *t, size_t s) {
-    return getInfoArray(s, ParamValueSize, ParamValue, ParamValueSizeRet, t);
-  }
-
-protected:
-  size_t ParamValueSize;
-  void *ParamValue;
-  size_t *ParamValueSizeRet;
+private:
+  size_t Size;
+  void *Target;
+  size_t *SizeRet;
 };

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -13,6 +13,7 @@
 
 #include "OffloadImpl.hpp"
 #include "Helpers.hpp"
+#include "OffloadPrint.hpp"
 #include "PluginManager.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <OffloadAPI.h>
@@ -234,23 +235,22 @@ Error olShutDown_impl() {
 Error olGetPlatformInfoImplDetail(ol_platform_handle_t Platform,
                                   ol_platform_info_t PropName, size_t PropSize,
                                   void *PropValue, size_t *PropSizeRet) {
-  ReturnHelper ReturnValue(PropSize, PropValue, PropSizeRet);
+  InfoWriter Info(PropSize, PropValue, PropSizeRet);
   bool IsHost = Platform->BackendType == OL_PLATFORM_BACKEND_HOST;
 
   switch (PropName) {
   case OL_PLATFORM_INFO_NAME:
-    return ReturnValue(IsHost ? "Host" : Platform->Plugin->getName());
+    return Info.WriteString(IsHost ? "Host" : Platform->Plugin->getName());
   case OL_PLATFORM_INFO_VENDOR_NAME:
     // TODO: Implement this
-    return ReturnValue("Unknown platform vendor");
+    return Info.WriteString("Unknown platform vendor");
   case OL_PLATFORM_INFO_VERSION: {
-    return ReturnValue(formatv("v{0}.{1}.{2}", OL_VERSION_MAJOR,
-                               OL_VERSION_MINOR, OL_VERSION_PATCH)
-                           .str()
-                           .c_str());
+    return Info.WriteString(formatv("v{0}.{1}.{2}", OL_VERSION_MAJOR,
+                                    OL_VERSION_MINOR, OL_VERSION_PATCH)
+                                .str());
   }
   case OL_PLATFORM_INFO_BACKEND: {
-    return ReturnValue(Platform->BackendType);
+    return Info.Write<ol_platform_backend_t>(Platform->BackendType);
   }
   default:
     return createOffloadError(ErrorCode::INVALID_ENUMERATION,
@@ -277,36 +277,68 @@ Error olGetPlatformInfoSize_impl(ol_platform_handle_t Platform,
 Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
                                 ol_device_info_t PropName, size_t PropSize,
                                 void *PropValue, size_t *PropSizeRet) {
+  assert(Device != OffloadContext::get().HostDevice());
+  InfoWriter Info(PropSize, PropValue, PropSizeRet);
 
-  ReturnHelper ReturnValue(PropSize, PropValue, PropSizeRet);
+  auto MakeError = [&](ErrorCode Code, StringRef Err) {
+    std::string ErrBuffer;
+    llvm::raw_string_ostream(ErrBuffer) << PropName << ": " << Err;
+    return Plugin::error(ErrorCode::UNIMPLEMENTED, ErrBuffer.c_str());
+  };
 
   // Find the info if it exists under any of the given names
-  auto GetInfoString = [&](std::vector<std::string> Names) {
-    if (Device == OffloadContext::get().HostDevice())
-      return "Host";
-
+  auto GetInfoString =
+      [&](std::vector<std::string> Names) -> llvm::Expected<const char *> {
     for (auto Name : Names) {
-      if (auto Entry = Device->Info.get(Name))
+      if (auto Entry = Device->Info.get(Name)) {
+        if (!std::holds_alternative<std::string>((*Entry)->Value))
+          return MakeError(ErrorCode::BACKEND_FAILURE,
+                           "plugin returned incorrect type");
         return std::get<std::string>((*Entry)->Value).c_str();
+      }
     }
 
-    return "";
+    return MakeError(ErrorCode::UNIMPLEMENTED,
+                     "plugin did not provide a response for this information");
   };
 
   switch (PropName) {
   case OL_DEVICE_INFO_PLATFORM:
-    return ReturnValue(Device->Platform);
+    return Info.Write<void *>(Device->Platform);
   case OL_DEVICE_INFO_TYPE:
-    return Device == OffloadContext::get().HostDevice()
-               ? ReturnValue(OL_DEVICE_TYPE_HOST)
-               : ReturnValue(OL_DEVICE_TYPE_GPU);
+    return Info.Write<ol_device_type_t>(OL_DEVICE_TYPE_GPU);
   case OL_DEVICE_INFO_NAME:
-    return ReturnValue(GetInfoString({"Device Name"}));
+    return Info.WriteString(GetInfoString({"Device Name"}));
   case OL_DEVICE_INFO_VENDOR:
-    return ReturnValue(GetInfoString({"Vendor Name"}));
+    return Info.WriteString(GetInfoString({"Vendor Name"}));
   case OL_DEVICE_INFO_DRIVER_VERSION:
-    return ReturnValue(
+    return Info.WriteString(
         GetInfoString({"CUDA Driver Version", "HSA Runtime Version"}));
+  default:
+    return createOffloadError(ErrorCode::INVALID_ENUMERATION,
+                              "getDeviceInfo enum '%i' is invalid", PropName);
+  }
+
+  return Error::success();
+}
+
+Error olGetDeviceInfoImplDetailHost(ol_device_handle_t Device,
+                                    ol_device_info_t PropName, size_t PropSize,
+                                    void *PropValue, size_t *PropSizeRet) {
+  assert(Device == OffloadContext::get().HostDevice());
+  InfoWriter Info(PropSize, PropValue, PropSizeRet);
+
+  switch (PropName) {
+  case OL_DEVICE_INFO_PLATFORM:
+    return Info.Write<void *>(Device->Platform);
+  case OL_DEVICE_INFO_TYPE:
+    return Info.Write<ol_device_type_t>(OL_DEVICE_TYPE_HOST);
+  case OL_DEVICE_INFO_NAME:
+    return Info.WriteString("Virtual Host Device");
+  case OL_DEVICE_INFO_VENDOR:
+    return Info.WriteString("Liboffload");
+  case OL_DEVICE_INFO_DRIVER_VERSION:
+    return Info.WriteString(LLVM_VERSION_STRING);
   default:
     return createOffloadError(ErrorCode::INVALID_ENUMERATION,
                               "getDeviceInfo enum '%i' is invalid", PropName);
@@ -317,12 +349,18 @@ Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
 
 Error olGetDeviceInfo_impl(ol_device_handle_t Device, ol_device_info_t PropName,
                            size_t PropSize, void *PropValue) {
+  if (Device == OffloadContext::get().HostDevice())
+    return olGetDeviceInfoImplDetailHost(Device, PropName, PropSize, PropValue,
+                                         nullptr);
   return olGetDeviceInfoImplDetail(Device, PropName, PropSize, PropValue,
                                    nullptr);
 }
 
 Error olGetDeviceInfoSize_impl(ol_device_handle_t Device,
                                ol_device_info_t PropName, size_t *PropSizeRet) {
+  if (Device == OffloadContext::get().HostDevice())
+    return olGetDeviceInfoImplDetailHost(Device, PropName, 0, nullptr,
+                                         PropSizeRet);
   return olGetDeviceInfoImplDetail(Device, PropName, 0, nullptr, PropSizeRet);
 }
 

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -240,17 +240,17 @@ Error olGetPlatformInfoImplDetail(ol_platform_handle_t Platform,
 
   switch (PropName) {
   case OL_PLATFORM_INFO_NAME:
-    return Info.WriteString(IsHost ? "Host" : Platform->Plugin->getName());
+    return Info.writeString(IsHost ? "Host" : Platform->Plugin->getName());
   case OL_PLATFORM_INFO_VENDOR_NAME:
     // TODO: Implement this
-    return Info.WriteString("Unknown platform vendor");
+    return Info.writeString("Unknown platform vendor");
   case OL_PLATFORM_INFO_VERSION: {
-    return Info.WriteString(formatv("v{0}.{1}.{2}", OL_VERSION_MAJOR,
+    return Info.writeString(formatv("v{0}.{1}.{2}", OL_VERSION_MAJOR,
                                     OL_VERSION_MINOR, OL_VERSION_PATCH)
                                 .str());
   }
   case OL_PLATFORM_INFO_BACKEND: {
-    return Info.Write<ol_platform_backend_t>(Platform->BackendType);
+    return Info.write<ol_platform_backend_t>(Platform->BackendType);
   }
   default:
     return createOffloadError(ErrorCode::INVALID_ENUMERATION,
@@ -280,40 +280,40 @@ Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
   assert(Device != OffloadContext::get().HostDevice());
   InfoWriter Info(PropSize, PropValue, PropSizeRet);
 
-  auto MakeError = [&](ErrorCode Code, StringRef Err) {
+  auto makeError = [&](ErrorCode Code, StringRef Err) {
     std::string ErrBuffer;
     llvm::raw_string_ostream(ErrBuffer) << PropName << ": " << Err;
     return Plugin::error(ErrorCode::UNIMPLEMENTED, ErrBuffer.c_str());
   };
 
   // Find the info if it exists under any of the given names
-  auto GetInfoString =
+  auto getInfoString =
       [&](std::vector<std::string> Names) -> llvm::Expected<const char *> {
     for (auto Name : Names) {
       if (auto Entry = Device->Info.get(Name)) {
         if (!std::holds_alternative<std::string>((*Entry)->Value))
-          return MakeError(ErrorCode::BACKEND_FAILURE,
+          return makeError(ErrorCode::BACKEND_FAILURE,
                            "plugin returned incorrect type");
         return std::get<std::string>((*Entry)->Value).c_str();
       }
     }
 
-    return MakeError(ErrorCode::UNIMPLEMENTED,
+    return makeError(ErrorCode::UNIMPLEMENTED,
                      "plugin did not provide a response for this information");
   };
 
   switch (PropName) {
   case OL_DEVICE_INFO_PLATFORM:
-    return Info.Write<void *>(Device->Platform);
+    return Info.write<void *>(Device->Platform);
   case OL_DEVICE_INFO_TYPE:
-    return Info.Write<ol_device_type_t>(OL_DEVICE_TYPE_GPU);
+    return Info.write<ol_device_type_t>(OL_DEVICE_TYPE_GPU);
   case OL_DEVICE_INFO_NAME:
-    return Info.WriteString(GetInfoString({"Device Name"}));
+    return Info.writeString(getInfoString({"Device Name"}));
   case OL_DEVICE_INFO_VENDOR:
-    return Info.WriteString(GetInfoString({"Vendor Name"}));
+    return Info.writeString(getInfoString({"Vendor Name"}));
   case OL_DEVICE_INFO_DRIVER_VERSION:
-    return Info.WriteString(
-        GetInfoString({"CUDA Driver Version", "HSA Runtime Version"}));
+    return Info.writeString(
+        getInfoString({"CUDA Driver Version", "HSA Runtime Version"}));
   default:
     return createOffloadError(ErrorCode::INVALID_ENUMERATION,
                               "getDeviceInfo enum '%i' is invalid", PropName);
@@ -330,15 +330,15 @@ Error olGetDeviceInfoImplDetailHost(ol_device_handle_t Device,
 
   switch (PropName) {
   case OL_DEVICE_INFO_PLATFORM:
-    return Info.Write<void *>(Device->Platform);
+    return Info.write<void *>(Device->Platform);
   case OL_DEVICE_INFO_TYPE:
-    return Info.Write<ol_device_type_t>(OL_DEVICE_TYPE_HOST);
+    return Info.write<ol_device_type_t>(OL_DEVICE_TYPE_HOST);
   case OL_DEVICE_INFO_NAME:
-    return Info.WriteString("Virtual Host Device");
+    return Info.writeString("Virtual Host Device");
   case OL_DEVICE_INFO_VENDOR:
-    return Info.WriteString("Liboffload");
+    return Info.writeString("Liboffload");
   case OL_DEVICE_INFO_DRIVER_VERSION:
-    return Info.WriteString(LLVM_VERSION_STRING);
+    return Info.writeString(LLVM_VERSION_STRING);
   default:
     return createOffloadError(ErrorCode::INVALID_ENUMERATION,
                               "getDeviceInfo enum '%i' is invalid", PropName);

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -289,7 +289,7 @@ Error olGetDeviceInfoImplDetail(ol_device_handle_t Device,
   // Find the info if it exists under any of the given names
   auto getInfoString =
       [&](std::vector<std::string> Names) -> llvm::Expected<const char *> {
-    for (auto Name : Names) {
+    for (auto &Name : Names) {
       if (auto Entry = Device->Info.get(Name)) {
         if (!std::holds_alternative<std::string>((*Entry)->Value))
           return makeError(ErrorCode::BACKEND_FAILURE,


### PR DESCRIPTION
This makes several small changes to how the platform and device info
queries are handled:
* ReturnHelper has been replaced with InfoWriter which is more explicit
  in how it is invoked.
* InfoWriter consumes `llvm::Expected` rather than values directly, and
  will early exit if it returns an error.
* As a result of the above, `GetInfoString` now correctly returns errors
  rather than empty strings.
* The host device now has its own dedicated "getInfo" function rather
  than being checked in multiple places.
