### PR TITLE
[libc] Simplify the version guard for mpfr.

### DIFF
--- a/libc/utils/MPFRWrapper/MPCommon.cpp
+++ b/libc/utils/MPFRWrapper/MPCommon.cpp
@@ -73,8 +73,7 @@ MPFRNumber MPFRNumber::acosh() const {
 MPFRNumber MPFRNumber::acospi() const {
   MPFRNumber result(*this);
 
-#if MPFR_VERSION_MAJOR > 4 ||                                                  \
-    (MPFR_VERSION_MAJOR == 4 && MPFR_VERSION_MINOR >= 2)
+#if MPFR_VERSION >= MPFR_VERSION_NUM(4, 2, 0)
   mpfr_acospi(result.value, value, mpfr_rounding);
   return result;
 #else
@@ -150,8 +149,7 @@ MPFRNumber MPFRNumber::cosh() const {
 MPFRNumber MPFRNumber::cospi() const {
   MPFRNumber result(*this);
 
-#if MPFR_VERSION_MAJOR > 4 ||                                                  \
-    (MPFR_VERSION_MAJOR == 4 && MPFR_VERSION_MINOR >= 2)
+#if MPFR_VERSION >= MPFR_VERSION_NUM(4, 2, 0)
   mpfr_cospi(result.value, value, mpfr_rounding);
   return result;
 #else
@@ -195,8 +193,7 @@ MPFRNumber MPFRNumber::exp2() const {
 
 MPFRNumber MPFRNumber::exp2m1() const {
   // TODO: Only use mpfr_exp2m1 once CI and buildbots get MPFR >= 4.2.0.
-#if MPFR_VERSION_MAJOR > 4 ||                                                  \
-    (MPFR_VERSION_MAJOR == 4 && MPFR_VERSION_MINOR >= 2)
+#if MPFR_VERSION >= MPFR_VERSION_NUM(4, 2, 0)
   MPFRNumber result(*this);
   mpfr_exp2m1(result.value, value, mpfr_rounding);
   return result;
@@ -231,8 +228,7 @@ MPFRNumber MPFRNumber::exp10() const {
 
 MPFRNumber MPFRNumber::exp10m1() const {
   // TODO: Only use mpfr_exp10m1 once CI and buildbots get MPFR >= 4.2.0.
-#if MPFR_VERSION_MAJOR > 4 ||                                                  \
-    (MPFR_VERSION_MAJOR == 4 && MPFR_VERSION_MINOR >= 2)
+#if MPFR_VERSION >= MPFR_VERSION_NUM(4, 2, 0)
   MPFRNumber result(*this);
   mpfr_exp10m1(result.value, value, mpfr_rounding);
   return result;
@@ -402,9 +398,7 @@ MPFRNumber MPFRNumber::sin() const {
 MPFRNumber MPFRNumber::sinpi() const {
   MPFRNumber result(*this);
 
-#if MPFR_VERSION_MAJOR > 4 ||                                                  \
-    (MPFR_VERSION_MAJOR == 4 && MPFR_VERSION_MINOR >= 2)
-
+#if MPFR_VERSION >= MPFR_VERSION_NUM(4, 2, 0)
   mpfr_sinpi(result.value, value, mpfr_rounding);
   return result;
 #else
@@ -463,9 +457,7 @@ MPFRNumber MPFRNumber::tanh() const {
 MPFRNumber MPFRNumber::tanpi() const {
   MPFRNumber result(*this);
 
-#if MPFR_VERSION_MAJOR > 4 ||                                                  \
-    (MPFR_VERSION_MAJOR == 4 && MPFR_VERSION_MINOR >= 2)
-
+#if MPFR_VERSION >= MPFR_VERSION_NUM(4, 2, 0)
   mpfr_tanpi(result.value, value, mpfr_rounding);
   return result;
 #else


### PR DESCRIPTION
Instead of manually calculating the major and minor version numbers, we can directly use `MPFR_VERSION_NUM` to simplify this.