### PR TITLE
[lldb] Delete unused DWARFDataExtractor methods

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.cpp
@@ -7,19 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "DWARFDataExtractor.h"
-#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace lldb_private {
-
-uint64_t
-DWARFDataExtractor::GetDWARFInitialLength(lldb::offset_t *offset_ptr) const {
-  return GetU32(offset_ptr);
-}
-
-dw_offset_t
-DWARFDataExtractor::GetDWARFOffset(lldb::offset_t *offset_ptr) const {
-  return GetMaxU64(offset_ptr, GetDWARFSizeOfOffset());
-}
 
 llvm::DWARFDataExtractor DWARFDataExtractor::GetAsLLVMDWARF() const {
   return llvm::DWARFDataExtractor(llvm::ArrayRef(GetDataStart(), GetByteSize()),

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDataExtractor.h
@@ -9,7 +9,6 @@
 #ifndef LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDATAEXTRACTOR_H
 #define LLDB_SOURCE_PLUGINS_SYMBOLFILE_DWARF_DWARFDATAEXTRACTOR_H
 
-#include "lldb/Core/dwarf.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
 
@@ -22,13 +21,6 @@ public:
   DWARFDataExtractor(const DWARFDataExtractor &data, lldb::offset_t offset,
                      lldb::offset_t length)
       : DataExtractor(data, offset, length) {}
-
-  uint64_t GetDWARFInitialLength(lldb::offset_t *offset_ptr) const;
-
-  dw_offset_t GetDWARFOffset(lldb::offset_t *offset_ptr) const;
-
-  size_t GetDWARFSizeofInitialLength() const { return 4; }
-  size_t GetDWARFSizeOfOffset() const { return 4; }
 
   llvm::DWARFDataExtractor GetAsLLVMDWARF() const;
   llvm::DataExtractor GetAsLLVM() const;


### PR DESCRIPTION
They are left over from our previous attempt at DWARF64. The new attempt is not using them, and they also don't have equivalents in the llvm DWARFDataExtractor class.