### PR TITLE
Restrict tests in Transforms/InstCombine/SystemZ to SystemZ (NFC)

### DIFF
--- a/llvm/test/Transforms/InstCombine/SystemZ/lit.local.cfg
+++ b/llvm/test/Transforms/InstCombine/SystemZ/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "SystemZ" in config.root.targets:
+    config.unsupported = True


### PR DESCRIPTION
This commit adds a `lit.local.cfg` file to `llvm/test/Transforms/InstCombine/SystemZ` that makes sure the tests contained in that folder are only run when `SystemZ` is among the supported targets.