### PR TITLE
[HLSL] Remove dead code in Type.cpp [NFC]

### DIFF
--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -4870,15 +4870,6 @@ LinkageInfo LinkageComputer::computeTypeLinkageInfo(const Type *T) {
                                       ->getCanonicalTypeInternal());
   case Type::HLSLInlineSpirv:
     return LinkageInfo::external();
-    {
-      const auto *ST = cast<HLSLInlineSpirvType>(T);
-      LinkageInfo LV = LinkageInfo::external();
-      for (auto &Operand : ST->getOperands()) {
-        if (Operand.isConstant() || Operand.isType())
-          LV.merge(computeTypeLinkageInfo(Operand.getResultType()));
-      }
-      return LV;
-    }
   }
 
   llvm_unreachable("unhandled type class");


### PR DESCRIPTION
In a case statement for Type::HLSLInlineSpirv, the first statment
returns, and the remaining statement are never executed. This removes
the dead code.

https://github.com/llvm/llvm-project/pull/134034/files/7d8e36944370bc50bd74ce6254f93649bc1f35a8#r2166484730
