### PR TITLE
[Offload] Add skeleton for offload conformance tests

### DIFF
--- a/offload/unittests/CMakeLists.txt
+++ b/offload/unittests/CMakeLists.txt
@@ -81,9 +81,34 @@ function(add_offload_unittest test_dirname)
   target_include_directories(${target_name} PRIVATE ${PLUGINS_TEST_INCLUDE})
 endfunction()
 
+function(add_conformance_test test_name)
+  set(target_name "${test_name}.conformance")
+
+  list(TRANSFORM ARGN PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/" OUTPUT_VARIABLE files)
+
+  if(NOT TARGET libc)
+    message(WARNING "Cannot run conformance tests without the LLVM C library")
+    return()
+  endif()
+
+  add_executable(${target_name} ${files})
+  add_dependencies(${target_name} ${PLUGINS_TEST_COMMON} ${test_name}.bin)
+  target_compile_definitions(${target_name} PRIVATE DEVICE_CODE_PATH="${CONFORMANCE_TEST_DEVICE_CODE_PATH}")
+  target_link_libraries(${target_name} PRIVATE ${PLUGINS_TEST_COMMON} libc)
+  target_include_directories(${target_name} PRIVATE ${PLUGINS_TEST_INCLUDE})
+  set_target_properties(${target_name} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+  add_custom_target(offload.conformance.${test_name}
+    COMMAND $<TARGET_FILE:${target_name}>
+    DEPENDS ${target_name}
+    COMMENT "Running conformance test ${test_name}")
+  add_dependencies(offload.conformance offload.conformance.${test_name})
+endfunction()
+
 set(OFFLOAD_TESTS_FORCE_NVPTX_ARCH "" CACHE STRING
   "Force building of NVPTX device code for Offload unit tests with the given arch, e.g. sm_61")
 set(OFFLOAD_TESTS_FORCE_AMDGPU_ARCH "" CACHE STRING
   "Force building of AMDGPU device code for Offload unit tests with the given arch, e.g. gfx1030")
 
 add_subdirectory(OffloadAPI)
+add_subdirectory(Conformance)

--- a/offload/unittests/Conformance/CMakeLists.txt
+++ b/offload/unittests/Conformance/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_custom_target(offload.conformance)
+
+set(PLUGINS_TEST_COMMON LLVMOffload LLVMSupport)
+set(PLUGINS_TEST_INCLUDE ${LIBOMPTARGET_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/common)
+
+add_subdirectory(device_code)
+
+add_conformance_test(sin sin.cpp)

--- a/offload/unittests/Conformance/device_code/CMakeLists.txt
+++ b/offload/unittests/Conformance/device_code/CMakeLists.txt
@@ -1,0 +1,4 @@
+# FIXME: Currently missing dependencies to build GPU portion automatically.
+add_offload_test_device_code(sin.c sin)
+
+set(OFFLOAD_TEST_DEVICE_CODE_PATH ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)

--- a/offload/unittests/Conformance/device_code/sin.c
+++ b/offload/unittests/Conformance/device_code/sin.c
@@ -1,0 +1,4 @@
+#include <gpuintrin.h>
+#include <math.h>
+
+__gpu_kernel void kernel(double *out) { *out = sin(*out); }

--- a/offload/unittests/Conformance/sin.cpp
+++ b/offload/unittests/Conformance/sin.cpp
@@ -1,0 +1,8 @@
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+#include <OffloadAPI.h>
+#include <math.h>
+
+llvm::StringRef DeviceBinsDirectory = DEVICE_CODE_PATH;
+
+int main() { llvm::errs() << sin(0.0) << "\n"; }


### PR DESCRIPTION
Summary:
This adds a basic outline for adding 'conformance' tests. These are
tests that are intended to check device code against a standard. In this
case, we will expect this to be filled with math conformance tests to
make sure their results are within the ULP requirements we demand.

Right now this just *assumes* the GPU libc is there, meaning you'll
likely need to do a manual `ninja` before doing `ninja -C
runtimes/runtimes-bins offload.conformance`.
