### PR TITLE
[AMDGPU] Fix wrong reverse operations for `v_cmpx_le_u32`

### DIFF
--- a/llvm/lib/Target/AMDGPU/VOPCInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPCInstructions.td
@@ -846,7 +846,7 @@ defm V_CMP_T_U32 : VOPC_I32 <"v_cmp_t_u32">;
 defm V_CMPX_F_U32 : VOPCX_I32 <"v_cmpx_f_u32">;
 defm V_CMPX_LT_U32 : VOPCX_I32 <"v_cmpx_lt_u32", "v_cmpx_gt_u32">;
 defm V_CMPX_EQ_U32 : VOPCX_I32 <"v_cmpx_eq_u32">;
-defm V_CMPX_LE_U32 : VOPCX_I32 <"v_cmpx_le_u32", "v_cmpx_le_u32">;
+defm V_CMPX_LE_U32 : VOPCX_I32 <"v_cmpx_le_u32", "v_cmpx_ge_u32">;
 defm V_CMPX_GT_U32 : VOPCX_I32 <"v_cmpx_gt_u32">;
 defm V_CMPX_NE_U32 : VOPCX_I32 <"v_cmpx_ne_u32">;
 defm V_CMPX_GE_U32 : VOPCX_I32 <"v_cmpx_ge_u32">;

--- a/llvm/test/CodeGen/AMDGPU/cmp_shrink.mir
+++ b/llvm/test/CodeGen/AMDGPU/cmp_shrink.mir
@@ -17,7 +17,7 @@ body:             |
   bb.0:
     ; GCN-LABEL: name: shrink_icmp
     ; GCN: %op0:sgpr_32 = COPY $sgpr0
-    ; GCN-NEXT: %cond:sreg_64 = V_CMPX_LE_U32_e64 5, %op0, implicit-def $exec, implicit $exec
+    ; GCN-NEXT: %cond:sreg_64 = V_CMPX_GE_U32_e64 5, %op0, implicit-def $exec, implicit $exec
     ; GCN-NEXT: S_NOP 0
     %op0:sgpr_32 = COPY $sgpr0
     %cond:sreg_64 = V_CMPX_LE_U32_e64 %op0, 5, implicit-def $exec, implicit $exec


### PR DESCRIPTION
Fixes: SWDEV-538616