### PR TITLE
[DirectX] Convert private global variables to internal linkage during Finalize Linkage pass

### DIFF
--- a/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
+++ b/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
@@ -18,6 +18,16 @@
 using namespace llvm;
 
 static bool finalizeLinkage(Module &M) {
+  bool MadeChange = false;
+
+  // Convert private global variables to internal linkage.
+  for (GlobalVariable &GV : M.globals()) {
+    if (GV.hasPrivateLinkage()) {
+      GV.setLinkage(GlobalValue::InternalLinkage);
+      MadeChange = true;
+    }
+  }
+
   SmallVector<Function *> Funcs;
 
   // Collect non-entry and non-exported functions to set to internal linkage.
@@ -32,13 +42,17 @@ static bool finalizeLinkage(Module &M) {
   }
 
   for (Function *F : Funcs) {
-    if (F->getLinkage() == GlobalValue::ExternalLinkage)
+    if (F->getLinkage() == GlobalValue::ExternalLinkage) {
       F->setLinkage(GlobalValue::InternalLinkage);
-    if (F->isDefTriviallyDead())
+      MadeChange = true;
+    }
+    if (F->isDefTriviallyDead()) {
       M.getFunctionList().erase(F);
+      MadeChange = true;
+    }
   }
 
-  return false;
+  return MadeChange;
 }
 
 PreservedAnalyses DXILFinalizeLinkage::run(Module &M,

--- a/llvm/test/CodeGen/DirectX/finalize_linkage.ll
+++ b/llvm/test/CodeGen/DirectX/finalize_linkage.ll
@@ -4,7 +4,28 @@
 target triple = "dxilv1.5-pc-shadermodel6.5-compute"
 
 ; DXILFinalizeLinkage changes linkage of all functions that are hidden to
-; internal.
+; internal, and converts private global variables to internal linkage.
+
+; CHECK: @switch.table = internal unnamed_addr constant [4 x i32]
+@switch.table = private unnamed_addr constant [4 x i32] [i32 1, i32 257, i32 65793, i32 16843009], align 4
+
+; CHECK: @private_array = internal constant [3 x float]
+@private_array = private constant [3 x float] [float 1.0, float 2.0, float 3.0], align 4
+
+; CHECK: @private_var = internal global i32
+@private_var = private global i32 1, align 4
+
+; Internal global should remain internal
+; CHECK: @internal_var = internal global i32
+@internal_var = internal global i32 1, align 4
+
+; External global should remain external
+; CHECK: @external_var = external global i32
+@external_var = external global i32, align 4
+
+; Hidden global should remain hidden
+; CHECK: @hidden_var = hidden global i32
+@hidden_var = hidden global i32 1, align 4
 
 ; CHECK-NOT: define internal void @"?f1@@YAXXZ"()
 define void @"?f1@@YAXXZ"() #0 {


### PR DESCRIPTION
Fixes #140420. The switch.table.* validation errors were caused by DXIL not supporting private global variables. Converting them to internal linkage fixes the bug.

May need more discussion on the preserved analyses/a follow-up PR that fixes what this pass says it preserves.