### PR TITLE
[clang] Don't use raw source location in DeclarationName, NFC

### DIFF
--- a/clang/include/clang/AST/DeclarationName.h
+++ b/clang/include/clang/AST/DeclarationName.h
@@ -698,13 +698,13 @@ class DeclarationNameLoc {
 
   // The location (if any) of the operator keyword is stored elsewhere.
   struct CXXOpName {
-    SourceLocation::UIntTy BeginOpNameLoc;
-    SourceLocation::UIntTy EndOpNameLoc;
+    SourceLocation BeginOpNameLoc;
+    SourceLocation EndOpNameLoc;
   };
 
   // The location (if any) of the operator keyword is stored elsewhere.
   struct CXXLitOpName {
-    SourceLocation::UIntTy OpNameLoc;
+    SourceLocation OpNameLoc;
   };
 
   // struct {} CXXUsingDirective;
@@ -720,12 +720,12 @@ class DeclarationNameLoc {
   void setNamedTypeLoc(TypeSourceInfo *TInfo) { NamedType.TInfo = TInfo; }
 
   void setCXXOperatorNameRange(SourceRange Range) {
-    CXXOperatorName.BeginOpNameLoc = Range.getBegin().getRawEncoding();
-    CXXOperatorName.EndOpNameLoc = Range.getEnd().getRawEncoding();
+    CXXOperatorName.BeginOpNameLoc = Range.getBegin();
+    CXXOperatorName.EndOpNameLoc = Range.getEnd();
   }
 
   void setCXXLiteralOperatorNameLoc(SourceLocation Loc) {
-    CXXLiteralOperatorName.OpNameLoc = Loc.getRawEncoding();
+    CXXLiteralOperatorName.OpNameLoc = Loc;
   }
 
 public:
@@ -739,12 +739,12 @@ public:
 
   /// Return the beginning location of the getCXXOperatorNameRange() range.
   SourceLocation getCXXOperatorNameBeginLoc() const {
-    return SourceLocation::getFromRawEncoding(CXXOperatorName.BeginOpNameLoc);
+    return CXXOperatorName.BeginOpNameLoc;
   }
 
   /// Return the end location of the getCXXOperatorNameRange() range.
   SourceLocation getCXXOperatorNameEndLoc() const {
-    return SourceLocation::getFromRawEncoding(CXXOperatorName.EndOpNameLoc);
+    return CXXOperatorName.EndOpNameLoc;
   }
 
   /// Return the range of the operator name (without the operator keyword).
@@ -759,7 +759,7 @@ public:
   /// keyword). Assumes that the object stores location information of a literal
   /// operator.
   SourceLocation getCXXLiteralOperatorNameLoc() const {
-    return SourceLocation::getFromRawEncoding(CXXLiteralOperatorName.OpNameLoc);
+    return CXXLiteralOperatorName.OpNameLoc;
   }
 
   /// Construct location information for a constructor, destructor or conversion


### PR DESCRIPTION
Converting back and forth for the source location raw encoding is unnecessary. 