### PR TITLE
[libc][obvious] Fixed typos in some wchar headers

### DIFF
--- a/libc/src/wchar/wcpncpy.h
+++ b/libc/src/wchar/wcpncpy.h
@@ -20,4 +20,4 @@ wchar_t *wcpncpy(wchar_t *__restrict ws1, const wchar_t *__restrict ws2,
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_WCPNsCPY_H
+#endif // LLVM_LIBC_SRC_WCHAR_WCPNCPY_H

--- a/libc/src/wchar/wcsspn.h
+++ b/libc/src/wchar/wcsspn.h
@@ -19,4 +19,4 @@ size_t wcsspn(const wchar_t *s1, const wchar_t *s2);
 
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_WCHAR_WCSCHR_H
+#endif // LLVM_LIBC_SRC_WCHAR_WCSSPN_H


### PR DESCRIPTION
Some of the wchar headers had typos in them.