### PR TITLE
[AArch64] Fix ldp rename through a bundle

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
@@ -1081,8 +1081,8 @@ AArch64LoadStoreOpt::mergePairedInsns(MachineBasicBlock::iterator I,
           LLVM_DEBUG(dbgs() << "Renamed " << MI);
           return true;
         };
-    forAllMIsUntilDef(MergeForward ? *I : *std::prev(Paired), RegToRename, TRI,
-                      UINT32_MAX, UpdateMIs);
+    forAllMIsUntilDef(MergeForward ? *I : *Paired->getPrevNode(), RegToRename,
+                      TRI, UINT32_MAX, UpdateMIs);
 
 #if !defined(NDEBUG)
     // For forward merging store:

--- a/llvm/test/CodeGen/AArch64/stp-opt-with-renaming.mir
+++ b/llvm/test/CodeGen/AArch64/stp-opt-with-renaming.mir
@@ -735,6 +735,35 @@ body:             |
     RET undef $lr
 ...
 ---
+name:            bundled_load_rename
+alignment:       4
+tracksRegLiveness: true
+frameInfo:
+  maxAlignment:     1
+  maxCallFrameSize: 0
+machineFunctionInfo:
+  hasRedZone:      false
+body:             |
+  bb.0.entry:
+    liveins: $z3, $z19, $p0, $z16
+    ; CHECK-LABEL: name: bundled_load_rename
+    ; CHECK: liveins: $z3, $z19, $p0, $z16
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $q16, $q20 = LDPQi $sp, 0 :: (load (s128)), (load (s128), align 32)
+    ; CHECK-NEXT: BUNDLE implicit-def $z3, implicit-def $q3, implicit-def $d3, implicit-def $s3, implicit-def $h3, implicit-def $b3, implicit $z19, implicit $p0, implicit $z20 {
+    ; CHECK-NEXT:   $z3 = MOVPRFX_ZZ $z19
+    ; CHECK-NEXT:   $z3 = FMUL_ZPmZ_S renamable $p0, killed $z3, $z20
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: RET undef $lr
+    renamable $q16 = LDRQui $sp, 1 :: (load 16)
+    BUNDLE implicit-def $z3, implicit-def $q3, implicit-def $d3, implicit-def $s3, implicit-def $h3, implicit-def $b3, implicit $z19, implicit $p0, implicit $z16 {
+      $z3 = MOVPRFX_ZZ $z19
+      $z3 = FMUL_ZPmZ_S renamable $p0, killed $z3, renamable $z16
+    }
+    renamable $q16 = LDRQui $sp, 0 :: (load 16, align 32)
+    RET undef $lr
+...
+---
 #
 # CHECK-LABEL: name: bundled_use
 # CHECK: renamable $q0 = LDRQui $sp, 1


### PR DESCRIPTION
std::prev(Paired) will get the previous instruction, that might skip over the instructions in a bundle to the BUNDLE itself. Change it to Paired->getPrevNode() to make sure we update the registers in each instruction in the bundle.