### PR TITLE
[libc] Baremetal version of clock

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -262,6 +262,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # time.h entrypoints
     libc.src.time.asctime
     libc.src.time.asctime_r
+    libc.src.time.clock
     libc.src.time.ctime
     libc.src.time.ctime_r
     libc.src.time.difftime

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -262,6 +262,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # time.h entrypoints
     libc.src.time.asctime
     libc.src.time.asctime_r
+    libc.src.time.clock
     libc.src.time.ctime
     libc.src.time.ctime_r
     libc.src.time.difftime

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -262,6 +262,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     # time.h entrypoints
     libc.src.time.asctime
     libc.src.time.asctime_r
+    libc.src.time.clock
     libc.src.time.ctime
     libc.src.time.ctime_r
     libc.src.time.difftime

--- a/libc/src/time/baremetal/CMakeLists.txt
+++ b/libc/src/time/baremetal/CMakeLists.txt
@@ -1,4 +1,15 @@
 add_entrypoint_object(
+  clock
+  SRCS
+    clock.cpp
+  HDRS
+    ../clock.h
+  DEPENDS
+    libc.hdr.time_macros
+    libc.hdr.types.struct_timespec
+)
+
+add_entrypoint_object(
   timespec_get
   SRCS
     timespec_get.cpp

--- a/libc/src/time/baremetal/clock.cpp
+++ b/libc/src/time/baremetal/clock.cpp
@@ -1,0 +1,45 @@
+//===-- Baremetal implementation of the clock function --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/time/clock.h"
+#include "hdr/time_macros.h"
+#include "hdr/types/struct_timespec.h"
+#include "src/__support/CPP/limits.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/time/units.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+extern "C" bool __llvm_libc_timespec_get_active(struct timespec *ts);
+
+LLVM_LIBC_FUNCTION(clock_t, clock, ()) {
+  using namespace time_units;
+  struct timespec ts;
+  if (!__llvm_libc_timespec_get_active(&ts))
+    return clock_t(-1);
+
+  // The above call gets the CPU time in seconds plus nanoseconds.
+  // The standard requires that we return clock_t(-1) if we cannot represent
+  // clocks as a clock_t value.
+  constexpr clock_t CLOCK_SECS_MAX =
+      cpp::numeric_limits<clock_t>::max() / CLOCKS_PER_SEC;
+  if (ts.tv_sec > CLOCK_SECS_MAX)
+    return clock_t(-1);
+  if (ts.tv_nsec / 1_s_ns > CLOCK_SECS_MAX - ts.tv_sec)
+    return clock_t(-1);
+
+  // For the integer computation converting tv_nsec to clocks to work
+  // correctly, we want CLOCKS_PER_SEC to be less than 1000000000.
+  static_assert(1_s_ns > CLOCKS_PER_SEC,
+                "Expected CLOCKS_PER_SEC to be less than 1'000'000'000.");
+  return clock_t(ts.tv_sec * CLOCKS_PER_SEC +
+                 ts.tv_nsec / (1_s_ns / CLOCKS_PER_SEC));
+}
+
+} // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This is analogous to the baremetal version of timespec_get using the __llvm_libc_timespec_get_active embedding interface.