### PR TITLE
[lldb][framework] Correctly place framework files in framework with script

### DIFF
--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -112,7 +112,8 @@ file(GLOB lldb_framework_header_staging_list ${lldb_framework_header_staging}/*)
 foreach(header ${lldb_framework_header_staging_list})
 
   set(input_header ${header})
-  set(output_header $<TARGET_FILE_DIR:liblldb>/Headers/${input_header})
+  get_filename_component(header_basename ${input_header} NAME)
+  set(output_header $<TARGET_FILE_DIR:liblldb>/Headers/${header_basename})
 
   add_custom_command(TARGET liblldb POST_BUILD
     COMMAND ${LLDB_SOURCE_DIR}/scripts/framework-header-fix.py -f lldb_main -i ${input_header} -o ${output_header} -p ${unifdef_EXECUTABLE} USWIG

--- a/lldb/scripts/framework-header-fix.py
+++ b/lldb/scripts/framework-header-fix.py
@@ -113,6 +113,10 @@ def main():
     # arguments in and of themself, so they need to passed in without dashes.
     unifdef_guards = ["-" + guard for guard in args.unifdef_guards]
 
+    # Create the framework's header dir if it doesn't already exist
+    if not os.path.exists(os.path.dirname(output_file_path)):
+        os.makedirs(os.path.dirname(output_file_path))
+
     if framework_version == "lldb_main":
         modify_main_includes(input_file_path, output_file_path)
     if framework_version == "lldb_rpc":


### PR DESCRIPTION
There's 2 bugs that this commit fixes:
1. Calculate the correct file path for the output file by appending the basename of the input header instead of appending the entire input header's path to the framework path.
2. In the script, create the framework's header directory if it does not exist.