### PR TITLE
[flang][acc] Fix dialect dependencies

### DIFF
--- a/flang/test/lib/OpenACC/CMakeLists.txt
+++ b/flang/test/lib/OpenACC/CMakeLists.txt
@@ -2,22 +2,26 @@ add_flang_library(FIRTestOpenACCInterfaces
   TestOpenACCInterfaces.cpp
 
   DEPENDS
+  HLFIRDialect
   FIRDialect
   FIROpenACCSupport
   FIRSupport
 
   LINK_LIBS
+  HLFIRDialect
   FIRDialect
   FIROpenACCSupport
   FIRSupport
 
   MLIR_DEPS
+  MLIRDLTIDialect
   MLIRIR
   MLIROpenACCDialect
   MLIRPass
   MLIRSupport
 
   MLIR_LIBS
+  MLIRDLTIDialect
   MLIRIR
   MLIROpenACCDialect
   MLIRPass


### PR DESCRIPTION
The TestOpenACCInterfaces test loads dialects including HLFIR and DLTI (for data layout). The appropriate dependencies were missing leading to link failures:
TestOpenACCInterfaces.cpp:(.text._ZNK12_GLOBAL__N_124TestFIROpenACCInterfaces20getDependentDialectsERN4mlir15DialectRegistryE+0x66): undefined reference to
`mlir::detail::TypeIDResolver<hlfir::hlfirDialect, void>::id' TestOpenACCInterfaces.cpp:(.text._ZNK12_GLOBAL__N_124TestFIROpenACCInterfaces20getDependentDialectsERN4mlir15DialectRegistryE+0x141): undefined reference to `mlir::detail::TypeIDResolver<mlir::DLTIDialect, void>::id'