### PR TITLE
[ValueTracking] Allow getUnderlyingPointer to look through inttoptr/ptrtoint round trip casts

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1602,6 +1602,8 @@ AliasResult BasicAAResult::aliasCheck(const Value *V1, LocationSize V1Size,
   // Figure out what objects these things are pointing to if we can.
   const Value *O1 = getUnderlyingObject(V1, MaxLookupSearchDepth);
   const Value *O2 = getUnderlyingObject(V2, MaxLookupSearchDepth);
+  removeRoundTripCasts(O1);
+  removeRoundTripCasts(O2);
 
   // Null values in the default address space don't point to any object, so they
   // don't alias any other pointer.

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -6661,6 +6661,10 @@ const Value *llvm::getUnderlyingObject(const Value *V, unsigned MaxLookup) {
       if (!NewV->getType()->isPointerTy())
         return V;
       V = NewV;
+    } else if (Operator::getOpcode(V) == Instruction::IntToPtr &&
+               Operator::getOpcode(cast<Operator>(V)->getOperand(0)) ==
+                   Instruction::PtrToInt) {
+      V = cast<Operator>(cast<Operator>(V)->getOperand(0))->getOperand(0);
     } else if (auto *GA = dyn_cast<GlobalAlias>(V)) {
       if (GA->isInterposable())
         return V;

--- a/llvm/unittests/Analysis/ValueTrackingTest.cpp
+++ b/llvm/unittests/Analysis/ValueTrackingTest.cpp
@@ -3350,6 +3350,18 @@ TEST_F(ValueTrackingTest, ComputeConstantRange) {
   }
 }
 
+TEST_F(ValueTrackingTest, GetUnderlyingObject) {
+  parseAssembly(R"(
+    @globalmem = external global i8
+    define void @test() {
+      %A = getelementptr i8, ptr @globalmem, i64 0
+      %A2 = getelementptr i8, ptr inttoptr (i32 ptrtoint (ptr @globalmem to i32) to ptr), i64 0
+      ret void
+    }
+  )");
+  EXPECT_EQ(getUnderlyingObject(A), getUnderlyingObject(A2));
+}
+
 struct FindAllocaForValueTestParams {
   const char *IR;
   bool AnyOffsetResult;


### PR DESCRIPTION
It has been established in past discussions that optimizing away a round trip ptrtoint -> inttoptr cast in something like InstCombine is not correct (https://www.ralfj.de/blog/2020/12/14/provenance.html, https://github.com/llvm/llvm-project/issues/33896). However, is it possibly correct to strip this round trip when recursing through `getUnderlyingObject`? This would improve alias analysis.