### PR TITLE
[lldb] Optimize statusline redrawing on terminal size change

### DIFF
--- a/lldb/include/lldb/Core/Statusline.h
+++ b/lldb/include/lldb/Core/Statusline.h
@@ -36,9 +36,6 @@ private:
   /// Draw the statusline with the given text.
   void Draw(std::string msg);
 
-  /// Update terminal dimensions.
-  void UpdateTerminalProperties();
-
   enum ScrollWindowMode {
     EnableStatusline,
     DisableStatusline,


### PR DESCRIPTION
Avoid some of the work to disable/enable the statusline when the terminal dimensions change.