### PR TITLE
[mlir][linalg] Use hasPureTensorSemantics in TransposeMatmul methods.

### DIFF
--- a/mlir/lib/Dialect/Linalg/Transforms/TransposeMatmul.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/TransposeMatmul.cpp
@@ -38,7 +38,7 @@ FailureOr<Operation *> mlir::linalg::transposeMatmul(RewriterBase &rewriter,
         matmulOp, "only matmul ops with non-extended semantics are supported");
   }
 
-  if (!bufferization::hasTensorSemantics(matmulOp))
+  if (!matmulOp.hasPureTensorSemantics())
     return rewriter.notifyMatchFailure(
         matmulOp, "only matmul ops with tensors are supported");
 
@@ -93,7 +93,7 @@ mlir::linalg::transposeBatchMatmul(RewriterBase &rewriter,
         batchMatmulOp, "ops with user-defined maps are not supported");
   }
 
-  if (!bufferization::hasTensorSemantics(batchMatmulOp))
+  if (!batchMatmulOp.hasPureTensorSemantics())
     return rewriter.notifyMatchFailure(
         batchMatmulOp, "only matmul ops with tensors are supported");
 


### PR DESCRIPTION
The issue is triggered by https://github.com/llvm/llvm-project/commit/ee070d08163ac09842d9bf0c1315f311df39faf1 that checks `TensorLikeType` when downstream projects use the pattern without registering bufferization::BufferizationDialect. The registration is needed because the interface implementation for builtin types locate at `BufferizationDialect::initialize()`. However, we do not need to fix it by the registration. The proper fix is using the linalg method, i.e., hasPureTensorSemantics.

No additional tests are added because the functionality is well tested in [transpose-matmul.mlir](https://github.com/llvm/llvm-project/blob/main/mlir/test/Dialect/Linalg/transpose-matmul.mlir). To reproduce the issue, it requires a different setup, e.g., writing a new C++ pass, which seems not worth it.