### PR TITLE
[NFC][IR2Vec] Remove unreachable code and simplify invalid mode test

### DIFF
--- a/llvm/lib/Analysis/IR2Vec.cpp
+++ b/llvm/lib/Analysis/IR2Vec.cpp
@@ -129,7 +129,6 @@ std::unique_ptr<Embedder> Embedder::create(IR2VecKind Mode, const Function &F,
   case IR2VecKind::Symbolic:
     return std::make_unique<SymbolicEmbedder>(F, Vocabulary);
   }
-  llvm_unreachable("Unknown IR2Vec kind");
   return nullptr;
 }
 

--- a/llvm/unittests/Analysis/IR2VecTest.cpp
+++ b/llvm/unittests/Analysis/IR2VecTest.cpp
@@ -228,16 +228,9 @@ TEST(IR2VecTest, CreateInvalidMode) {
   FunctionType *FTy = FunctionType::get(Type::getVoidTy(Ctx), false);
   Function *F = Function::Create(FTy, Function::ExternalLinkage, "f", M);
 
-// static_cast an invalid int to IR2VecKind
-#ifndef NDEBUG
-#if GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(Embedder::create(static_cast<IR2VecKind>(-1), *F, V),
-               "Unknown IR2Vec kind");
-#endif // GTEST_HAS_DEATH_TEST
-#else
+  // static_cast an invalid int to IR2VecKind
   auto Result = Embedder::create(static_cast<IR2VecKind>(-1), *F, V);
   EXPECT_FALSE(static_cast<bool>(Result));
-#endif // NDEBUG
 }
 
 TEST(IR2VecTest, LookupVocab) {


### PR DESCRIPTION
The code following `llvm_unreachable`  is optimized out in Release builds. In this case, `Embedder::create` do not seem to return `nullptr` causing `CreateInvalidMode` test to break. Hence removing `llvm_unreachable`. 