### PR TITLE
CodeView: Move MCCVDefRangeFragment storage to MCContext/MCFragment. NFC

### DIFF
--- a/llvm/include/llvm/MC/MCCodeView.h
+++ b/llvm/include/llvm/MC/MCCodeView.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
+#include <deque>
 #include <map>
 #include <vector>
 
@@ -268,6 +269,10 @@ private:
   /// Indicate whether we have already laid out the checksum table addresses or
   /// not.
   bool ChecksumOffsetsAssigned = false;
+
+  /// Append-only storage of MCCVDefRangeFragment::Ranges.
+  std::deque<SmallVector<std::pair<const MCSymbol *, const MCSymbol *>, 0>>
+      DefRangeStorage;
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCSection.h
+++ b/llvm/include/llvm/MC/MCSection.h
@@ -675,8 +675,8 @@ public:
 
 /// Fragment representing the .cv_def_range directive.
 class MCCVDefRangeFragment : public MCEncodedFragmentWithFixups<32, 4> {
-  SmallVector<std::pair<const MCSymbol *, const MCSymbol *>, 2> Ranges;
-  SmallString<32> FixedSizePortion;
+  ArrayRef<std::pair<const MCSymbol *, const MCSymbol *>> Ranges;
+  StringRef FixedSizePortion;
 
   /// CodeViewContext has the real knowledge about this format, so let it access
   /// our members.
@@ -693,7 +693,7 @@ public:
     return Ranges;
   }
 
-  StringRef getFixedSizePortion() const { return FixedSizePortion.str(); }
+  StringRef getFixedSizePortion() const { return FixedSizePortion; }
 
   static bool classof(const MCFragment *F) {
     return F->getKind() == MCFragment::FT_CVDefRange;

--- a/llvm/lib/MC/MCCodeView.cpp
+++ b/llvm/lib/MC/MCCodeView.cpp
@@ -442,10 +442,13 @@ MCFragment *CodeViewContext::emitDefRange(
     MCObjectStreamer &OS,
     ArrayRef<std::pair<const MCSymbol *, const MCSymbol *>> Ranges,
     StringRef FixedSizePortion) {
+  // Store `Ranges` and `FixedSizePortion` in the context, returning references,
+  // as MCCVDefRangeFragment does not own these objects.
+  FixedSizePortion = MCCtx->allocateString(FixedSizePortion);
+  auto &Saved = DefRangeStorage.emplace_back(Ranges.begin(), Ranges.end());
   // Create and insert a fragment into the current section that will be encoded
   // later.
-  auto *F =
-      MCCtx->allocFragment<MCCVDefRangeFragment>(Ranges, FixedSizePortion);
+  auto *F = MCCtx->allocFragment<MCCVDefRangeFragment>(Saved, FixedSizePortion);
   OS.insert(F);
   return F;
 }


### PR DESCRIPTION
so that ~MCCVInlineLineTableFragment will become trivial when we
make ~MCEncodedFragment trivial (#146307).
