### PR TITLE
[mlir] Remove unnecessary casts (NFC)

### DIFF
--- a/mlir/unittests/Dialect/SPIRV/DeserializationTest.cpp
+++ b/mlir/unittests/Dialect/SPIRV/DeserializationTest.cpp
@@ -188,11 +188,11 @@ TEST_F(DeserializationTest, OpMemberNameSuccess) {
   std::swap(typeDecl, binary);
 
   SmallVector<uint32_t, 5> operands1 = {structType, 0};
-  (void)spirv::encodeStringLiteralInto(operands1, "i1");
+  spirv::encodeStringLiteralInto(operands1, "i1");
   addInstruction(spirv::Opcode::OpMemberName, operands1);
 
   SmallVector<uint32_t, 5> operands2 = {structType, 1};
-  (void)spirv::encodeStringLiteralInto(operands2, "i2");
+  spirv::encodeStringLiteralInto(operands2, "i2");
   addInstruction(spirv::Opcode::OpMemberName, operands2);
 
   binary.append(typeDecl.begin(), typeDecl.end());
@@ -227,7 +227,7 @@ TEST_F(DeserializationTest, OpMemberNameExcessOperands) {
   std::swap(typeDecl, binary);
 
   SmallVector<uint32_t, 5> operands = {structType, 0};
-  (void)spirv::encodeStringLiteralInto(operands, "int32");
+  spirv::encodeStringLiteralInto(operands, "int32");
   operands.push_back(42);
   addInstruction(spirv::Opcode::OpMemberName, operands);
 


### PR DESCRIPTION
Note that encodeStringLiteralInto returns void.
