### PR TITLE
[clang][bytecode] Allocate operator new data as array

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -176,19 +176,8 @@ APValue Pointer::toAPValue(const ASTContext &ASTCtx) const {
   if (const auto *VD = Desc->asValueDecl())
     Base = VD;
   else if (const auto *E = Desc->asExpr()) {
-    // Create a DynamicAlloc base of the right type.
-    if (const auto *NewExpr = dyn_cast<CXXNewExpr>(E)) {
-      QualType AllocatedType;
-      if (NewExpr->isArray()) {
-        assert(Desc->isArray());
-        APInt ArraySize(64, static_cast<uint64_t>(Desc->getNumElems()),
-                        /*IsSigned=*/false);
-        AllocatedType =
-            ASTCtx.getConstantArrayType(NewExpr->getAllocatedType(), ArraySize,
-                                        nullptr, ArraySizeModifier::Normal, 0);
-      } else {
-        AllocatedType = NewExpr->getAllocatedType();
-      }
+    if (block()->isDynamic()) {
+      QualType AllocatedType = getDeclPtr().getFieldDesc()->getDataType(ASTCtx);
       // FIXME: Suboptimal counting of dynamic allocations. Move this to Context
       // or InterpState?
       static int ReportedDynamicAllocs = 0;


### PR DESCRIPTION
Even if we only allocate one element, we still need to allocate it as a single-element array. This matches what the current interpreter does.