### PR TITLE
[CMake]fix CUDAToolkit_LIBRARY_ROOT DEFINED check

### DIFF
--- a/mlir/lib/Target/LLVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVM/CMakeLists.txt
@@ -59,7 +59,7 @@ if ("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
     # See: https://gitlab.kitware.com/cmake/cmake/-/issues/24858
     # TODO: Bump the MLIR CMake version to 3.26.4 and switch to
     # ${CUDAToolkit_LIBRARY_ROOT}
-    if(NOT DEFINED ${CUDAToolkit_LIBRARY_ROOT})
+    if(NOT DEFINED CUDAToolkit_LIBRARY_ROOT)
       get_filename_component(MLIR_CUDAToolkit_ROOT ${CUDAToolkit_BIN_DIR}
                              DIRECTORY ABSOLUTE)
     else()


### PR DESCRIPTION
This PR fixes #146344  by remove the brace of `CUDAToolkit_LIBRARY_ROOT`.

In mlir/lib/Target/LLVM/CMakeLists.txt, the variable `CUDAToolkit_LIBRARY_ROOT` is used in the following way in Line 66:

`set(MLIR_CUDAToolkit_ROOT ${CUDAToolkit_LIBRARY_ROOT})`

and like this in Line 135:

```
find_file(MLIR_NVVM_LIBDEVICE_PATH libdevice.10.bc
                PATHS ${CUDAToolkit_LIBRARY_ROOT}
                PATH_SUFFIXES "nvvm/libdevice" NO_DEFAULT_PATH REQUIRED)
```

However, when checking whether the variable is defined, it is done in the following way in Line 62:

`if(NOT DEFINED ${CUDAToolkit_LIBRARY_ROOT})`

This `if` command doesn't take effect when `CUDAToolkit_LIBRARY_ROOT` simply represent a path. I think the correct way to write it should be:

`if(NOT DEFINED CUDAToolkit_LIBRARY_ROOT)`

Looking forward to your feedback!