### PR TITLE
[libclc] Add __clc_nan implementation with signed nancode argument

### DIFF
--- a/libclc/clc/include/clc/math/clc_nan.inc
+++ b/libclc/clc/include/clc/math/clc_nan.inc
@@ -7,3 +7,4 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_nan(__CLC_U_GENTYPE code);
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_nan(__CLC_S_GENTYPE code);

--- a/libclc/clc/lib/generic/math/clc_nan.inc
+++ b/libclc/clc/lib/generic/math/clc_nan.inc
@@ -20,4 +20,8 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_nan(__CLC_U_GENTYPE code) {
   return __CLC_AS_GENTYPE(res);
 }
 
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_nan(__CLC_S_GENTYPE code) {
+  return __clc_nan(__CLC_AS_U_GENTYPE(code));
+}
+
 #undef NAN_MASK


### PR DESCRIPTION
In OpenCL Extended Instruction Set Specification, nancode can be signed integer or vector of signed integers values.
This PR has no change to amdgcn--amdhsa.bc and nvptx64--nvidiacl.bc because the newly added clc functions are not used in OpenCL library.