### PR TITLE
[clang][test] Remove duplication from gcc toolchain test (NFC)

### DIFF
--- a/clang/test/Driver/gcc-toolchain.cpp
+++ b/clang/test/Driver/gcc-toolchain.cpp
@@ -6,11 +6,6 @@
 // RUN:   --gcc-toolchain=%S/Inputs/ubuntu_14.04_multiarch_tree/usr -stdlib=libstdc++ --rtlib=libgcc --unwindlib=libgcc -no-pie 2>&1 | \
 // RUN:   FileCheck %s
 //
-// Additionally check that the legacy spelling of the flag works.
-// RUN: %clangxx %s -### --target=x86_64-linux-gnu --sysroot= \
-// RUN:   --gcc-toolchain=%S/Inputs/ubuntu_14.04_multiarch_tree/usr -stdlib=libstdc++ --rtlib=libgcc --unwindlib=libgcc -no-pie 2>&1 | \
-// RUN:   FileCheck %s
-//
 // Test for header search toolchain detection.
 // CHECK: "-internal-isystem"
 // CHECK: "[[TOOLCHAIN:[^"]+]]/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8"


### PR DESCRIPTION
Changes from Commit 40aab0412fe7a14781e133627c2bb0a22761eac8 "[test] Migrate -gcc-toolchain with space separator to --gcc-toolchain=" made two previously different RUN lines equal.

Remove one RUN line.