### PR TITLE
[AArch64][PAC] Rework discriminator analysis in AUT and AUTPAC

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelDAGToDAG.cpp
@@ -1624,39 +1624,6 @@ void AArch64DAGToDAGISel::SelectTable(SDNode *N, unsigned NumVecs, unsigned Opc,
   ReplaceNode(N, CurDAG->getMachineNode(Opc, dl, VT, Ops));
 }
 
-static std::tuple<SDValue, SDValue>
-extractPtrauthBlendDiscriminators(SDValue Disc, SelectionDAG *DAG) {
-  SDLoc DL(Disc);
-  SDValue AddrDisc;
-  SDValue ConstDisc;
-
-  // If this is a blend, remember the constant and address discriminators.
-  // Otherwise, it's either a constant discriminator, or a non-blended
-  // address discriminator.
-  if (Disc->getOpcode() == ISD::INTRINSIC_WO_CHAIN &&
-      Disc->getConstantOperandVal(0) == Intrinsic::ptrauth_blend) {
-    AddrDisc = Disc->getOperand(1);
-    ConstDisc = Disc->getOperand(2);
-  } else {
-    ConstDisc = Disc;
-  }
-
-  // If the constant discriminator (either the blend RHS, or the entire
-  // discriminator value) isn't a 16-bit constant, bail out, and let the
-  // discriminator be computed separately.
-  auto *ConstDiscN = dyn_cast<ConstantSDNode>(ConstDisc);
-  if (!ConstDiscN || !isUInt<16>(ConstDiscN->getZExtValue()))
-    return std::make_tuple(DAG->getTargetConstant(0, DL, MVT::i64), Disc);
-
-  // If there's no address discriminator, use XZR directly.
-  if (!AddrDisc)
-    AddrDisc = DAG->getRegister(AArch64::XZR, MVT::i64);
-
-  return std::make_tuple(
-      DAG->getTargetConstant(ConstDiscN->getZExtValue(), DL, MVT::i64),
-      AddrDisc);
-}
-
 void AArch64DAGToDAGISel::SelectPtrauthAuth(SDNode *N) {
   SDLoc DL(N);
   // IntrinsicID is operand #0
@@ -1667,12 +1634,10 @@ void AArch64DAGToDAGISel::SelectPtrauthAuth(SDNode *N) {
   unsigned AUTKeyC = cast<ConstantSDNode>(AUTKey)->getZExtValue();
   AUTKey = CurDAG->getTargetConstant(AUTKeyC, DL, MVT::i64);
 
-  SDValue AUTAddrDisc, AUTConstDisc;
-  std::tie(AUTConstDisc, AUTAddrDisc) =
-      extractPtrauthBlendDiscriminators(AUTDisc, CurDAG);
+  SDValue Zero = CurDAG->getTargetConstant(0, DL, MVT::i64);
 
   if (!Subtarget->isX16X17Safer()) {
-    std::vector<SDValue> Ops = {Val, AUTKey, AUTConstDisc, AUTAddrDisc};
+    std::vector<SDValue> Ops = {Val, AUTKey, Zero, AUTDisc};
     // Copy deactivation symbol if present.
     if (N->getNumOperands() > 4)
       Ops.push_back(N->getOperand(4));
@@ -1683,7 +1648,7 @@ void AArch64DAGToDAGISel::SelectPtrauthAuth(SDNode *N) {
   } else {
     SDValue X16Copy = CurDAG->getCopyToReg(CurDAG->getEntryNode(), DL,
                                            AArch64::X16, Val, SDValue());
-    SDValue Ops[] = {AUTKey, AUTConstDisc, AUTAddrDisc, X16Copy.getValue(1)};
+    SDValue Ops[] = {AUTKey, Zero, AUTDisc, X16Copy.getValue(1)};
 
     SDNode *AUT = CurDAG->getMachineNode(AArch64::AUTx16x17, DL, MVT::i64, Ops);
     ReplaceNode(N, AUT);
@@ -1708,13 +1673,7 @@ void AArch64DAGToDAGISel::SelectPtrauthResign(SDNode *N) {
   AUTKey = CurDAG->getTargetConstant(AUTKeyC, DL, MVT::i64);
   PACKey = CurDAG->getTargetConstant(PACKeyC, DL, MVT::i64);
 
-  SDValue AUTAddrDisc, AUTConstDisc;
-  std::tie(AUTConstDisc, AUTAddrDisc) =
-      extractPtrauthBlendDiscriminators(AUTDisc, CurDAG);
-
-  SDValue PACAddrDisc, PACConstDisc;
-  std::tie(PACConstDisc, PACAddrDisc) =
-      extractPtrauthBlendDiscriminators(PACDisc, CurDAG);
+  SDValue Zero = CurDAG->getTargetConstant(0, DL, MVT::i64);
 
   SDValue X16Copy = CurDAG->getCopyToReg(CurDAG->getEntryNode(), DL,
                                          AArch64::X16, Val, SDValue());
@@ -1722,16 +1681,16 @@ void AArch64DAGToDAGISel::SelectPtrauthResign(SDNode *N) {
   if (HasLoad) {
     SDValue Addend = N->getOperand(OffsetBase + 6);
     SDValue IncomingChain = N->getOperand(0);
-    SDValue Ops[] = {AUTKey, AUTConstDisc,  AUTAddrDisc,
-                     PACKey, PACConstDisc,  PACAddrDisc,
+    SDValue Ops[] = {AUTKey, Zero,          AUTDisc,
+                     PACKey, Zero,          PACDisc,
                      Addend, IncomingChain, X16Copy.getValue(1)};
 
     SDNode *AUTRELLOADPAC = CurDAG->getMachineNode(AArch64::AUTRELLOADPAC, DL,
                                                    MVT::i64, MVT::Other, Ops);
     ReplaceNode(N, AUTRELLOADPAC);
   } else {
-    SDValue Ops[] = {AUTKey,       AUTConstDisc, AUTAddrDisc,        PACKey,
-                     PACConstDisc, PACAddrDisc,  X16Copy.getValue(1)};
+    SDValue Ops[] = {
+        AUTKey, Zero, AUTDisc, PACKey, Zero, PACDisc, X16Copy.getValue(1)};
 
     SDNode *AUTPAC = CurDAG->getMachineNode(AArch64::AUTPAC, DL, MVT::i64, Ops);
     ReplaceNode(N, AUTPAC);

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -3593,8 +3593,23 @@ MachineBasicBlock *AArch64TargetLowering::EmitInstrWithCustomInserter(
   case AArch64::MOVT_TIZ_PSEUDO:
     return EmitZTInstr(MI, BB, AArch64::MOVT_TIZ, /*Op0IsDef=*/true);
 
+  case AArch64::AUTx16x17:
+    fixupPtrauthDiscriminator(MI, BB, MI.getOperand(1), MI.getOperand(2),
+                              &AArch64::GPR64noipRegClass);
+    return BB;
+  case AArch64::AUTxMxN:
+    fixupPtrauthDiscriminator(MI, BB, MI.getOperand(4), MI.getOperand(5),
+                              &AArch64::GPR64noipRegClass);
+    return BB;
   case AArch64::PAC:
     fixupPtrauthDiscriminator(MI, BB, MI.getOperand(3), MI.getOperand(4),
+                              &AArch64::GPR64noipRegClass);
+    return BB;
+  case AArch64::AUTPAC:
+  case AArch64::AUTRELLOADPAC:
+    fixupPtrauthDiscriminator(MI, BB, MI.getOperand(1), MI.getOperand(2),
+                              &AArch64::GPR64noipRegClass);
+    fixupPtrauthDiscriminator(MI, BB, MI.getOperand(4), MI.getOperand(5),
                               &AArch64::GPR64noipRegClass);
     return BB;
   }

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -3470,6 +3470,12 @@ void AArch64TargetLowering::fixupPtrauthDiscriminator(
         IntDisc = DiscMI->getOperand(1).getImm();
       }
       break;
+    case AArch64::COPY:
+      if (DiscMI->getOperand(1).getReg() == AArch64::XZR) {
+        AddrDisc = AArch64::NoRegister;
+        IntDisc = 0;
+      }
+      break;
     }
   }
 

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -2234,6 +2234,7 @@ let Predicates = [HasPAuth] in {
     let Size = 32;
     let Defs = [X16,X17,NZCV];
     let Uses = [X16];
+    let usesCustomInserter = 1;
   }
 
   // AArch64AsmPrinter can clobber the $AddrDisc register as long as it is
@@ -2258,6 +2259,7 @@ let Predicates = [HasPAuth] in {
     let Size = 32;
     let Defs = [NZCV];
     let Uses = [];
+    let usesCustomInserter = 1;
   }
 
   // PAC pseudo instruction. In AsmPrinter, it is expanded into an actual PAC*
@@ -2296,6 +2298,7 @@ let Predicates = [HasPAuth] in {
     let Size = 48;
     let Defs = [X16,X17,NZCV];
     let Uses = [X16];
+    let usesCustomInserter = 1;
   }
 
   // Similiar to AUTPAC, except a 32bit value is loaded at Addend offset from
@@ -2316,6 +2319,7 @@ let Predicates = [HasPAuth] in {
     let Size = 84;
     let Defs = [X16, X17, NZCV];
     let Uses = [X16];
+    let usesCustomInserter = 1;
   }
 
   // Materialize a signed global address, with adrp+add and PAC.

--- a/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64InstructionSelector.cpp
@@ -6601,25 +6601,15 @@ bool AArch64InstructionSelector::selectIntrinsicWithSideEffects(
     Register PACDisc = I.getOperand(6).getReg();
     int64_t Addend = I.getOperand(7).getImm();
 
-    Register AUTAddrDisc = AUTDisc;
-    uint16_t AUTConstDiscC = 0;
-    std::tie(AUTConstDiscC, AUTAddrDisc) =
-        extractPtrauthBlendDiscriminators(AUTDisc, MRI);
-
-    Register PACAddrDisc = PACDisc;
-    uint16_t PACConstDiscC = 0;
-    std::tie(PACConstDiscC, PACAddrDisc) =
-        extractPtrauthBlendDiscriminators(PACDisc, MRI);
-
     MIB.buildCopy({AArch64::X16}, {ValReg});
 
     MIB.buildInstr(AArch64::AUTRELLOADPAC)
         .addImm(AUTKey)
-        .addImm(AUTConstDiscC)
-        .addUse(AUTAddrDisc)
+        .addImm(0)
+        .addUse(AUTDisc)
         .addImm(PACKey)
-        .addImm(PACConstDiscC)
-        .addUse(PACAddrDisc)
+        .addImm(0)
+        .addUse(PACDisc)
         .addImm(Addend)
         .constrainAllUses(TII, TRI, RBI);
     MIB.buildCopy({DstReg}, Register(AArch64::X16));
@@ -6649,25 +6639,15 @@ bool AArch64InstructionSelector::selectIntrinsic(MachineInstr &I,
     uint64_t PACKey = I.getOperand(5).getImm();
     Register PACDisc = I.getOperand(6).getReg();
 
-    Register AUTAddrDisc = AUTDisc;
-    uint16_t AUTConstDiscC = 0;
-    std::tie(AUTConstDiscC, AUTAddrDisc) =
-        extractPtrauthBlendDiscriminators(AUTDisc, MRI);
-
-    Register PACAddrDisc = PACDisc;
-    uint16_t PACConstDiscC = 0;
-    std::tie(PACConstDiscC, PACAddrDisc) =
-        extractPtrauthBlendDiscriminators(PACDisc, MRI);
-
     MIB.buildCopy({AArch64::X16}, {ValReg});
     MIB.buildInstr(TargetOpcode::IMPLICIT_DEF, {AArch64::X17}, {});
     MIB.buildInstr(AArch64::AUTPAC)
         .addImm(AUTKey)
-        .addImm(AUTConstDiscC)
-        .addUse(AUTAddrDisc)
+        .addImm(0)
+        .addUse(AUTDisc)
         .addImm(PACKey)
-        .addImm(PACConstDiscC)
-        .addUse(PACAddrDisc)
+        .addImm(0)
+        .addUse(PACDisc)
         .constrainAllUses(TII, TRI, RBI);
     MIB.buildCopy({DstReg}, Register(AArch64::X16));
 
@@ -6681,18 +6661,13 @@ bool AArch64InstructionSelector::selectIntrinsic(MachineInstr &I,
     uint64_t AUTKey = I.getOperand(3).getImm();
     Register AUTDisc = I.getOperand(4).getReg();
 
-    Register AUTAddrDisc = AUTDisc;
-    uint16_t AUTConstDiscC = 0;
-    std::tie(AUTConstDiscC, AUTAddrDisc) =
-        extractPtrauthBlendDiscriminators(AUTDisc, MRI);
-
     if (STI.isX16X17Safer()) {
       MIB.buildCopy({AArch64::X16}, {ValReg});
       MIB.buildInstr(TargetOpcode::IMPLICIT_DEF, {AArch64::X17}, {});
       MIB.buildInstr(AArch64::AUTx16x17)
           .addImm(AUTKey)
-          .addImm(AUTConstDiscC)
-          .addUse(AUTAddrDisc)
+          .addImm(0)
+          .addUse(AUTDisc)
           .constrainAllUses(TII, TRI, RBI);
       MIB.buildCopy({DstReg}, Register(AArch64::X16));
     } else {
@@ -6703,8 +6678,8 @@ bool AArch64InstructionSelector::selectIntrinsic(MachineInstr &I,
           .addDef(ScratchReg)
           .addUse(ValReg)
           .addImm(AUTKey)
-          .addImm(AUTConstDiscC)
-          .addUse(AUTAddrDisc)
+          .addImm(0)
+          .addUse(AUTDisc)
           .constrainAllUses(TII, TRI, RBI);
     }
 

--- a/llvm/test/CodeGen/AArch64/deactivation-symbols.ll
+++ b/llvm/test/CodeGen/AArch64/deactivation-symbols.ll
@@ -1,5 +1,5 @@
-; RUN: llc < %s -O0 -mtriple=aarch64-none-linux-gnu -mattr=+pauth | FileCheck --check-prefixes=CHECK,O0 %s
-; RUN: llc < %s -O2 -mtriple=aarch64-none-linux-gnu -mattr=+pauth | FileCheck --check-prefixes=CHECK,O2 %s
+; RUN: llc < %s -O0 -mtriple=aarch64-none-linux-gnu -mattr=+pauth | FileCheck --check-prefixes=CHECK %s
+; RUN: llc < %s -O2 -mtriple=aarch64-none-linux-gnu -mattr=+pauth | FileCheck --check-prefixes=CHECK %s
 
 @ds = external global i8
 
@@ -16,11 +16,9 @@ define void @call(ptr %p) {
 
 ; CHECK: pauth_sign_zero:
 define i64 @pauth_sign_zero(i64 %p) {
-  ; O0: mov x8, xzr
   ; CHECK: [[LABEL:.L.*]]:
   ; CHECK-NEXT: .reloc [[LABEL]], R_AARCH64_PATCHINST, ds
-  ; O0-NEXT: pacia x0, x8
-  ; O2-NEXT: paciza x0
+  ; CHECK-NEXT: paciza x0
   %signed = call i64 @llvm.ptrauth.sign(i64 %p, i32 0, i64 0) [ "deactivation-symbol"(ptr @ds) ]
   ret i64 %signed
 }
@@ -46,11 +44,9 @@ define i64 @pauth_sign(i64 %p, i64 %d) {
 
 ; CHECK: pauth_auth_zero:
 define i64 @pauth_auth_zero(i64 %p) {
-  ; O0: mov x9, xzr
   ; CHECK: [[LABEL:.L.*]]:
   ; CHECK-NEXT: .reloc [[LABEL]], R_AARCH64_PATCHINST, ds
-  ; O0-NEXT: autia x0, x9
-  ; O2-NEXT: autiza x0
+  ; CHECK-NEXT: autiza x0
   %authed = call i64 @llvm.ptrauth.auth(i64 %p, i32 0, i64 0) [ "deactivation-symbol"(ptr @ds) ]
   ret i64 %authed
 }

--- a/llvm/test/CodeGen/AArch64/deactivation-symbols.ll
+++ b/llvm/test/CodeGen/AArch64/deactivation-symbols.ll
@@ -46,9 +46,11 @@ define i64 @pauth_sign(i64 %p, i64 %d) {
 
 ; CHECK: pauth_auth_zero:
 define i64 @pauth_auth_zero(i64 %p) {
+  ; O0: mov x9, xzr
   ; CHECK: [[LABEL:.L.*]]:
   ; CHECK-NEXT: .reloc [[LABEL]], R_AARCH64_PATCHINST, ds
-  ; CHECK-NEXT: autiza x0
+  ; O0-NEXT: autia x0, x9
+  ; O2-NEXT: autiza x0
   %authed = call i64 @llvm.ptrauth.auth(i64 %p, i32 0, i64 0) [ "deactivation-symbol"(ptr @ds) ]
   ret i64 %authed
 }

--- a/llvm/test/CodeGen/AArch64/ptrauth-isel.ll
+++ b/llvm/test/CodeGen/AArch64/ptrauth-isel.ll
@@ -14,8 +14,8 @@
 @discvar = dso_local global i64 0
 
 ; Make sure the components of blend(addr, imm) and integer constants are
-; recognized and passed to PAC pseudo via separate operands to prevent
-; substitution of the immediate modifier.
+; recognized and passed to AUT / PAC / AUTPAC pseudo via separate operands
+; prevent substitution of the immediate modifier.
 ;
 ; MIR output of the instruction selector is inspected, as it is hard to reliably
 ; distinguish MOVKXi immediately followed by a pseudo from a standalone pseudo
@@ -165,6 +165,70 @@ entry:
   ret i64 %signed
 }
 
+define i64 @blend_and_auth_same_bb(i64 %addr) {
+  ; DAGISEL-DARWIN-LABEL: name: blend_and_auth_same_bb
+  ; DAGISEL-DARWIN: bb.0.entry:
+  ; DAGISEL-DARWIN-NEXT:   liveins: $x0
+  ; DAGISEL-DARWIN-NEXT: {{  $}}
+  ; DAGISEL-DARWIN-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x0
+  ; DAGISEL-DARWIN-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; DAGISEL-DARWIN-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui killed [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; DAGISEL-DARWIN-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 42, 48
+  ; DAGISEL-DARWIN-NEXT:   $x16 = COPY [[COPY]]
+  ; DAGISEL-DARWIN-NEXT:   [[COPY1:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-DARWIN-NEXT:   AUTx16x17 2, 42, killed [[COPY1]], implicit-def $x16, implicit-def dead $x17, implicit-def dead $nzcv, implicit $x16
+  ; DAGISEL-DARWIN-NEXT:   [[COPY2:%[0-9]+]]:gpr64all = COPY $x16
+  ; DAGISEL-DARWIN-NEXT:   $x0 = COPY [[COPY2]]
+  ; DAGISEL-DARWIN-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; GISEL-DARWIN-LABEL: name: blend_and_auth_same_bb
+  ; GISEL-DARWIN: bb.1.entry:
+  ; GISEL-DARWIN-NEXT:   liveins: $x0
+  ; GISEL-DARWIN-NEXT: {{  $}}
+  ; GISEL-DARWIN-NEXT:   [[COPY:%[0-9]+]]:gpr64all = COPY $x0
+  ; GISEL-DARWIN-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; GISEL-DARWIN-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; GISEL-DARWIN-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 42, 48
+  ; GISEL-DARWIN-NEXT:   $x16 = COPY [[COPY]]
+  ; GISEL-DARWIN-NEXT:   $x17 = IMPLICIT_DEF
+  ; GISEL-DARWIN-NEXT:   [[COPY1:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-DARWIN-NEXT:   AUTx16x17 2, 42, [[COPY1]], implicit-def $x16, implicit-def $x17, implicit-def dead $nzcv, implicit $x16
+  ; GISEL-DARWIN-NEXT:   [[COPY2:%[0-9]+]]:gpr64 = COPY $x16
+  ; GISEL-DARWIN-NEXT:   $x0 = COPY [[COPY2]]
+  ; GISEL-DARWIN-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; DAGISEL-GNU-LABEL: name: blend_and_auth_same_bb
+  ; DAGISEL-GNU: bb.0.entry:
+  ; DAGISEL-GNU-NEXT:   liveins: $x0
+  ; DAGISEL-GNU-NEXT: {{  $}}
+  ; DAGISEL-GNU-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x0
+  ; DAGISEL-GNU-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; DAGISEL-GNU-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui killed [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; DAGISEL-GNU-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 42, 48
+  ; DAGISEL-GNU-NEXT:   [[COPY1:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-GNU-NEXT:   [[AUTxMxN:%[0-9]+]]:gpr64, early-clobber [[AUTxMxN1:%[0-9]+]]:gpr64common = AUTxMxN [[COPY]], 2, 42, killed [[COPY1]], implicit-def dead $nzcv
+  ; DAGISEL-GNU-NEXT:   $x0 = COPY [[AUTxMxN]]
+  ; DAGISEL-GNU-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; GISEL-GNU-LABEL: name: blend_and_auth_same_bb
+  ; GISEL-GNU: bb.1.entry:
+  ; GISEL-GNU-NEXT:   liveins: $x0
+  ; GISEL-GNU-NEXT: {{  $}}
+  ; GISEL-GNU-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x0
+  ; GISEL-GNU-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; GISEL-GNU-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; GISEL-GNU-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 42, 48
+  ; GISEL-GNU-NEXT:   [[COPY1:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-GNU-NEXT:   [[AUTxMxN:%[0-9]+]]:gpr64, early-clobber [[AUTxMxN1:%[0-9]+]]:gpr64common = AUTxMxN [[COPY]], 2, 42, [[COPY1]], implicit-def dead $nzcv
+  ; GISEL-GNU-NEXT:   $x0 = COPY [[AUTxMxN]]
+  ; GISEL-GNU-NEXT:   RET_ReallyLR implicit $x0
+entry:
+  %addrdisc = load i64, ptr @discvar
+  %disc = call i64 @llvm.ptrauth.blend(i64 %addrdisc, i64 42)
+  %authed = call i64 @llvm.ptrauth.auth(i64 %addr, i32 2, i64 %disc)
+  ret i64 %authed
+}
+
 define i64 @blend_and_sign_same_bb(i64 %addr) {
   ; DAGISEL-LABEL: name: blend_and_sign_same_bb
   ; DAGISEL: bb.0.entry:
@@ -198,9 +262,174 @@ entry:
   ret i64 %signed
 }
 
+define i64 @blend_and_resign_same_bb(i64 %addr) {
+  ; DAGISEL-LABEL: name: blend_and_resign_same_bb
+  ; DAGISEL: bb.0.entry:
+  ; DAGISEL-NEXT:   liveins: $x0
+  ; DAGISEL-NEXT: {{  $}}
+  ; DAGISEL-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x0
+  ; DAGISEL-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; DAGISEL-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui killed [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; DAGISEL-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 42, 48
+  ; DAGISEL-NEXT:   [[MOVKXi1:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 123, 48
+  ; DAGISEL-NEXT:   $x16 = COPY [[COPY]]
+  ; DAGISEL-NEXT:   [[COPY1:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-NEXT:   [[COPY2:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-NEXT:   AUTPAC 2, 42, killed [[COPY1]], 3, 123, killed [[COPY2]], implicit-def $x16, implicit-def dead $x17, implicit-def dead $nzcv, implicit $x16
+  ; DAGISEL-NEXT:   [[COPY3:%[0-9]+]]:gpr64all = COPY $x16
+  ; DAGISEL-NEXT:   $x0 = COPY [[COPY3]]
+  ; DAGISEL-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; GISEL-LABEL: name: blend_and_resign_same_bb
+  ; GISEL: bb.1.entry:
+  ; GISEL-NEXT:   liveins: $x0
+  ; GISEL-NEXT: {{  $}}
+  ; GISEL-NEXT:   [[COPY:%[0-9]+]]:gpr64all = COPY $x0
+  ; GISEL-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; GISEL-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; GISEL-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 42, 48
+  ; GISEL-NEXT:   [[MOVKXi1:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 123, 48
+  ; GISEL-NEXT:   $x16 = COPY [[COPY]]
+  ; GISEL-NEXT:   $x17 = IMPLICIT_DEF
+  ; GISEL-NEXT:   [[COPY1:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-NEXT:   [[COPY2:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-NEXT:   AUTPAC 2, 42, [[COPY1]], 3, 123, [[COPY2]], implicit-def $x16, implicit-def $x17, implicit-def dead $nzcv, implicit $x16
+  ; GISEL-NEXT:   [[COPY3:%[0-9]+]]:gpr64 = COPY $x16
+  ; GISEL-NEXT:   $x0 = COPY [[COPY3]]
+  ; GISEL-NEXT:   RET_ReallyLR implicit $x0
+entry:
+  %addrdisc = load i64, ptr @discvar
+  %auth.disc = call i64 @llvm.ptrauth.blend(i64 %addrdisc, i64 42)
+  %sign.disc = call i64 @llvm.ptrauth.blend(i64 %addrdisc, i64 123)
+  %resigned = call i64 @llvm.ptrauth.resign(i64 %addr, i32 2, i64 %auth.disc, i32 3, i64 %sign.disc)
+  ret i64 %resigned
+}
+
 ; In the below test cases both %addrdisc and %disc are computed (i.e. they are
 ; neither global addresses, nor function arguments) in a different basic block,
 ; making them harder to express via ISD::PtrAuthGlobalAddress.
+
+define i64 @blend_and_auth_different_bbs(i64 %addr, i64 %cond) {
+  ; DAGISEL-DARWIN-LABEL: name: blend_and_auth_different_bbs
+  ; DAGISEL-DARWIN: bb.0.entry:
+  ; DAGISEL-DARWIN-NEXT:   successors: %bb.1(0x50000000), %bb.2(0x30000000)
+  ; DAGISEL-DARWIN-NEXT:   liveins: $x0, $x1
+  ; DAGISEL-DARWIN-NEXT: {{  $}}
+  ; DAGISEL-DARWIN-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x1
+  ; DAGISEL-DARWIN-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x0
+  ; DAGISEL-DARWIN-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; DAGISEL-DARWIN-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui killed [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; DAGISEL-DARWIN-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 42, 48
+  ; DAGISEL-DARWIN-NEXT:   [[COPY2:%[0-9]+]]:gpr64noip = COPY [[MOVKXi]]
+  ; DAGISEL-DARWIN-NEXT:   CBZX [[COPY]], %bb.2
+  ; DAGISEL-DARWIN-NEXT:   B %bb.1
+  ; DAGISEL-DARWIN-NEXT: {{  $}}
+  ; DAGISEL-DARWIN-NEXT: bb.1.next:
+  ; DAGISEL-DARWIN-NEXT:   successors: %bb.2(0x80000000)
+  ; DAGISEL-DARWIN-NEXT: {{  $}}
+  ; DAGISEL-DARWIN-NEXT:   [[COPY3:%[0-9]+]]:gpr64common = COPY [[COPY2]]
+  ; DAGISEL-DARWIN-NEXT:   INLINEASM &nop, 1 /* sideeffect attdialect */, 3866633 /* reguse:GPR64common */, [[COPY3]]
+  ; DAGISEL-DARWIN-NEXT: {{  $}}
+  ; DAGISEL-DARWIN-NEXT: bb.2.exit:
+  ; DAGISEL-DARWIN-NEXT:   $x16 = COPY [[COPY1]]
+  ; DAGISEL-DARWIN-NEXT:   [[COPY4:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-DARWIN-NEXT:   AUTx16x17 2, 42, [[COPY4]], implicit-def $x16, implicit-def dead $x17, implicit-def dead $nzcv, implicit $x16
+  ; DAGISEL-DARWIN-NEXT:   [[COPY5:%[0-9]+]]:gpr64all = COPY $x16
+  ; DAGISEL-DARWIN-NEXT:   $x0 = COPY [[COPY5]]
+  ; DAGISEL-DARWIN-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; GISEL-DARWIN-LABEL: name: blend_and_auth_different_bbs
+  ; GISEL-DARWIN: bb.1.entry:
+  ; GISEL-DARWIN-NEXT:   successors: %bb.2(0x50000000), %bb.3(0x30000000)
+  ; GISEL-DARWIN-NEXT:   liveins: $x0, $x1
+  ; GISEL-DARWIN-NEXT: {{  $}}
+  ; GISEL-DARWIN-NEXT:   [[COPY:%[0-9]+]]:gpr64all = COPY $x0
+  ; GISEL-DARWIN-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x1
+  ; GISEL-DARWIN-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; GISEL-DARWIN-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; GISEL-DARWIN-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 42, 48
+  ; GISEL-DARWIN-NEXT:   CBZX [[COPY1]], %bb.3
+  ; GISEL-DARWIN-NEXT:   B %bb.2
+  ; GISEL-DARWIN-NEXT: {{  $}}
+  ; GISEL-DARWIN-NEXT: bb.2.next:
+  ; GISEL-DARWIN-NEXT:   successors: %bb.3(0x80000000)
+  ; GISEL-DARWIN-NEXT: {{  $}}
+  ; GISEL-DARWIN-NEXT:   [[COPY2:%[0-9]+]]:gpr64common = COPY [[MOVKXi]]
+  ; GISEL-DARWIN-NEXT:   INLINEASM &nop, 1 /* sideeffect attdialect */, 3866633 /* reguse:GPR64common */, [[COPY2]]
+  ; GISEL-DARWIN-NEXT: {{  $}}
+  ; GISEL-DARWIN-NEXT: bb.3.exit:
+  ; GISEL-DARWIN-NEXT:   $x16 = COPY [[COPY]]
+  ; GISEL-DARWIN-NEXT:   $x17 = IMPLICIT_DEF
+  ; GISEL-DARWIN-NEXT:   [[COPY3:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-DARWIN-NEXT:   AUTx16x17 2, 42, [[COPY3]], implicit-def $x16, implicit-def $x17, implicit-def dead $nzcv, implicit $x16
+  ; GISEL-DARWIN-NEXT:   [[COPY4:%[0-9]+]]:gpr64 = COPY $x16
+  ; GISEL-DARWIN-NEXT:   $x0 = COPY [[COPY4]]
+  ; GISEL-DARWIN-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; DAGISEL-GNU-LABEL: name: blend_and_auth_different_bbs
+  ; DAGISEL-GNU: bb.0.entry:
+  ; DAGISEL-GNU-NEXT:   successors: %bb.1(0x50000000), %bb.2(0x30000000)
+  ; DAGISEL-GNU-NEXT:   liveins: $x0, $x1
+  ; DAGISEL-GNU-NEXT: {{  $}}
+  ; DAGISEL-GNU-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x1
+  ; DAGISEL-GNU-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x0
+  ; DAGISEL-GNU-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; DAGISEL-GNU-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui killed [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; DAGISEL-GNU-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 42, 48
+  ; DAGISEL-GNU-NEXT:   [[COPY2:%[0-9]+]]:gpr64 = COPY [[MOVKXi]]
+  ; DAGISEL-GNU-NEXT:   CBZX [[COPY]], %bb.2
+  ; DAGISEL-GNU-NEXT:   B %bb.1
+  ; DAGISEL-GNU-NEXT: {{  $}}
+  ; DAGISEL-GNU-NEXT: bb.1.next:
+  ; DAGISEL-GNU-NEXT:   successors: %bb.2(0x80000000)
+  ; DAGISEL-GNU-NEXT: {{  $}}
+  ; DAGISEL-GNU-NEXT:   [[COPY3:%[0-9]+]]:gpr64common = COPY [[COPY2]]
+  ; DAGISEL-GNU-NEXT:   INLINEASM &nop, 1 /* sideeffect attdialect */, 3866633 /* reguse:GPR64common */, [[COPY3]]
+  ; DAGISEL-GNU-NEXT: {{  $}}
+  ; DAGISEL-GNU-NEXT: bb.2.exit:
+  ; DAGISEL-GNU-NEXT:   [[COPY4:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-GNU-NEXT:   [[AUTxMxN:%[0-9]+]]:gpr64, early-clobber [[AUTxMxN1:%[0-9]+]]:gpr64common = AUTxMxN [[COPY1]], 2, 42, [[COPY4]], implicit-def dead $nzcv
+  ; DAGISEL-GNU-NEXT:   $x0 = COPY [[AUTxMxN]]
+  ; DAGISEL-GNU-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; GISEL-GNU-LABEL: name: blend_and_auth_different_bbs
+  ; GISEL-GNU: bb.1.entry:
+  ; GISEL-GNU-NEXT:   successors: %bb.2(0x50000000), %bb.3(0x30000000)
+  ; GISEL-GNU-NEXT:   liveins: $x0, $x1
+  ; GISEL-GNU-NEXT: {{  $}}
+  ; GISEL-GNU-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x0
+  ; GISEL-GNU-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x1
+  ; GISEL-GNU-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; GISEL-GNU-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; GISEL-GNU-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 42, 48
+  ; GISEL-GNU-NEXT:   CBZX [[COPY1]], %bb.3
+  ; GISEL-GNU-NEXT:   B %bb.2
+  ; GISEL-GNU-NEXT: {{  $}}
+  ; GISEL-GNU-NEXT: bb.2.next:
+  ; GISEL-GNU-NEXT:   successors: %bb.3(0x80000000)
+  ; GISEL-GNU-NEXT: {{  $}}
+  ; GISEL-GNU-NEXT:   [[COPY2:%[0-9]+]]:gpr64common = COPY [[MOVKXi]]
+  ; GISEL-GNU-NEXT:   INLINEASM &nop, 1 /* sideeffect attdialect */, 3866633 /* reguse:GPR64common */, [[COPY2]]
+  ; GISEL-GNU-NEXT: {{  $}}
+  ; GISEL-GNU-NEXT: bb.3.exit:
+  ; GISEL-GNU-NEXT:   [[COPY3:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-GNU-NEXT:   [[AUTxMxN:%[0-9]+]]:gpr64, early-clobber [[AUTxMxN1:%[0-9]+]]:gpr64common = AUTxMxN [[COPY]], 2, 42, [[COPY3]], implicit-def dead $nzcv
+  ; GISEL-GNU-NEXT:   $x0 = COPY [[AUTxMxN]]
+  ; GISEL-GNU-NEXT:   RET_ReallyLR implicit $x0
+entry:
+  %addrdisc = load i64, ptr @discvar
+  %disc = call i64 @llvm.ptrauth.blend(i64 %addrdisc, i64 42)
+  %cond.b = icmp ne i64 %cond, 0
+  br i1 %cond.b, label %next, label %exit
+
+next:
+  call void asm sideeffect "nop", "r"(i64 %disc)
+  br label %exit
+
+exit:
+  %authed = call i64 @llvm.ptrauth.auth(i64 %addr, i32 2, i64 %disc)
+  ret i64 %authed
+}
 
 define i64 @blend_and_sign_different_bbs(i64 %addr, i64 %cond) {
   ; DAGISEL-LABEL: name: blend_and_sign_different_bbs
@@ -303,7 +532,8 @@ define i64 @autxmxn_earlyclobbered_scratch(i64 %addr, i64 %disc) {
   ; DAGISEL-GNU-NEXT: {{  $}}
   ; DAGISEL-GNU-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x1
   ; DAGISEL-GNU-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x0
-  ; DAGISEL-GNU-NEXT:   %2:gpr64, early-clobber %3:gpr64common = AUTxMxN [[COPY1]], 2, 0, [[COPY]], implicit-def dead $nzcv
+  ; DAGISEL-GNU-NEXT:   [[COPY2:%[0-9]+]]:gpr64noip = COPY [[COPY]]
+  ; DAGISEL-GNU-NEXT:   %2:gpr64, early-clobber %3:gpr64common = AUTxMxN [[COPY1]], 2, 0, [[COPY2]], implicit-def dead $nzcv
   ; DAGISEL-GNU-NEXT:   $x0 = COPY %2
   ; DAGISEL-GNU-NEXT:   RET_ReallyLR implicit $x0
   ;
@@ -313,10 +543,90 @@ define i64 @autxmxn_earlyclobbered_scratch(i64 %addr, i64 %disc) {
   ; GISEL-GNU-NEXT: {{  $}}
   ; GISEL-GNU-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x0
   ; GISEL-GNU-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x1
-  ; GISEL-GNU-NEXT:   %2:gpr64, early-clobber %3:gpr64common = AUTxMxN [[COPY]], 2, 0, [[COPY1]], implicit-def dead $nzcv
+  ; GISEL-GNU-NEXT:   [[COPY2:%[0-9]+]]:gpr64noip = COPY [[COPY1]]
+  ; GISEL-GNU-NEXT:   %2:gpr64, early-clobber %3:gpr64common = AUTxMxN [[COPY]], 2, 0, [[COPY2]], implicit-def dead $nzcv
   ; GISEL-GNU-NEXT:   $x0 = COPY %2
   ; GISEL-GNU-NEXT:   RET_ReallyLR implicit $x0
 entry:
   %auted = call i64 @llvm.ptrauth.auth(i64 %addr, i32 2, i64 %disc)
   ret i64 %auted
+}
+
+define i64 @blend_and_resign_different_bbs(i64 %addr, i64 %cond) {
+  ; DAGISEL-LABEL: name: blend_and_resign_different_bbs
+  ; DAGISEL: bb.0.entry:
+  ; DAGISEL-NEXT:   successors: %bb.1(0x50000000), %bb.2(0x30000000)
+  ; DAGISEL-NEXT:   liveins: $x0, $x1
+  ; DAGISEL-NEXT: {{  $}}
+  ; DAGISEL-NEXT:   [[COPY:%[0-9]+]]:gpr64 = COPY $x1
+  ; DAGISEL-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x0
+  ; DAGISEL-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; DAGISEL-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui killed [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; DAGISEL-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 42, 48
+  ; DAGISEL-NEXT:   [[COPY2:%[0-9]+]]:gpr64noip = COPY [[MOVKXi]]
+  ; DAGISEL-NEXT:   [[MOVKXi1:%[0-9]+]]:gpr64 = MOVKXi [[LDRXui]], 123, 48
+  ; DAGISEL-NEXT:   [[COPY3:%[0-9]+]]:gpr64noip = COPY [[MOVKXi1]]
+  ; DAGISEL-NEXT:   CBZX [[COPY]], %bb.2
+  ; DAGISEL-NEXT:   B %bb.1
+  ; DAGISEL-NEXT: {{  $}}
+  ; DAGISEL-NEXT: bb.1.next:
+  ; DAGISEL-NEXT:   successors: %bb.2(0x80000000)
+  ; DAGISEL-NEXT: {{  $}}
+  ; DAGISEL-NEXT:   [[COPY4:%[0-9]+]]:gpr64common = COPY [[COPY2]]
+  ; DAGISEL-NEXT:   [[COPY5:%[0-9]+]]:gpr64common = COPY [[COPY3]]
+  ; DAGISEL-NEXT:   INLINEASM &nop, 1 /* sideeffect attdialect */, 3866633 /* reguse:GPR64common */, [[COPY4]], 3866633 /* reguse:GPR64common */, [[COPY5]]
+  ; DAGISEL-NEXT: {{  $}}
+  ; DAGISEL-NEXT: bb.2.exit:
+  ; DAGISEL-NEXT:   $x16 = COPY [[COPY1]]
+  ; DAGISEL-NEXT:   [[COPY6:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-NEXT:   [[COPY7:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; DAGISEL-NEXT:   AUTPAC 2, 42, [[COPY6]], 3, 123, [[COPY7]], implicit-def $x16, implicit-def dead $x17, implicit-def dead $nzcv, implicit $x16
+  ; DAGISEL-NEXT:   [[COPY8:%[0-9]+]]:gpr64all = COPY $x16
+  ; DAGISEL-NEXT:   $x0 = COPY [[COPY8]]
+  ; DAGISEL-NEXT:   RET_ReallyLR implicit $x0
+  ;
+  ; GISEL-LABEL: name: blend_and_resign_different_bbs
+  ; GISEL: bb.1.entry:
+  ; GISEL-NEXT:   successors: %bb.2(0x50000000), %bb.3(0x30000000)
+  ; GISEL-NEXT:   liveins: $x0, $x1
+  ; GISEL-NEXT: {{  $}}
+  ; GISEL-NEXT:   [[COPY:%[0-9]+]]:gpr64all = COPY $x0
+  ; GISEL-NEXT:   [[COPY1:%[0-9]+]]:gpr64 = COPY $x1
+  ; GISEL-NEXT:   [[ADRP:%[0-9]+]]:gpr64common = ADRP target-flags(aarch64-page) @discvar
+  ; GISEL-NEXT:   [[LDRXui:%[0-9]+]]:gpr64 = LDRXui [[ADRP]], target-flags(aarch64-pageoff, aarch64-nc) @discvar :: (dereferenceable load (s64) from @discvar)
+  ; GISEL-NEXT:   [[MOVKXi:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 42, 48
+  ; GISEL-NEXT:   [[MOVKXi1:%[0-9]+]]:gpr64noip = MOVKXi [[LDRXui]], 123, 48
+  ; GISEL-NEXT:   CBZX [[COPY1]], %bb.3
+  ; GISEL-NEXT:   B %bb.2
+  ; GISEL-NEXT: {{  $}}
+  ; GISEL-NEXT: bb.2.next:
+  ; GISEL-NEXT:   successors: %bb.3(0x80000000)
+  ; GISEL-NEXT: {{  $}}
+  ; GISEL-NEXT:   [[COPY2:%[0-9]+]]:gpr64common = COPY [[MOVKXi]]
+  ; GISEL-NEXT:   [[COPY3:%[0-9]+]]:gpr64common = COPY [[MOVKXi1]]
+  ; GISEL-NEXT:   INLINEASM &nop, 1 /* sideeffect attdialect */, 3866633 /* reguse:GPR64common */, [[COPY2]], 3866633 /* reguse:GPR64common */, [[COPY3]]
+  ; GISEL-NEXT: {{  $}}
+  ; GISEL-NEXT: bb.3.exit:
+  ; GISEL-NEXT:   $x16 = COPY [[COPY]]
+  ; GISEL-NEXT:   $x17 = IMPLICIT_DEF
+  ; GISEL-NEXT:   [[COPY4:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-NEXT:   [[COPY5:%[0-9]+]]:gpr64noip = COPY [[LDRXui]]
+  ; GISEL-NEXT:   AUTPAC 2, 42, [[COPY4]], 3, 123, [[COPY5]], implicit-def $x16, implicit-def $x17, implicit-def dead $nzcv, implicit $x16
+  ; GISEL-NEXT:   [[COPY6:%[0-9]+]]:gpr64 = COPY $x16
+  ; GISEL-NEXT:   $x0 = COPY [[COPY6]]
+  ; GISEL-NEXT:   RET_ReallyLR implicit $x0
+entry:
+  %addrdisc = load i64, ptr @discvar
+  %auth.disc = call i64 @llvm.ptrauth.blend(i64 %addrdisc, i64 42)
+  %sign.disc = call i64 @llvm.ptrauth.blend(i64 %addrdisc, i64 123)
+  %cond.b = icmp ne i64 %cond, 0
+  br i1 %cond.b, label %next, label %exit
+
+next:
+  call void asm sideeffect "nop", "r,r"(i64 %auth.disc, i64 %sign.disc)
+  br label %exit
+
+exit:
+  %resigned = call i64 @llvm.ptrauth.resign(i64 %addr, i32 2, i64 %auth.disc, i32 3, i64 %sign.disc)
+  ret i64 %resigned
 }


### PR DESCRIPTION
Make use of post-processing the discriminator components by custom
inserter hook to eliminate duplication for DAGISel and GlobalISel and
improve cross-BB analysis for DAGISel.

Note: #130809 is stacked on top of this PR, but it cannot be managed by Graphite automatically, since it was initially opened from my fork of llvm-project repository.