### PR TITLE
[DAG] visitFREEZE - remove isGuaranteedNotToBeUndefOrPoison assertion

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -16714,28 +16714,25 @@ SDValue DAGCombiner::visitFREEZE(SDNode *N) {
       Op = DAG.getFreeze(Op);
   }
 
-  SDValue R;
-  if (auto *SVN = dyn_cast<ShuffleVectorSDNode>(N0)) {
-    // Special case handling for ShuffleVectorSDNode nodes.
-    R = DAG.getVectorShuffle(N0.getValueType(), SDLoc(N0), Ops[0], Ops[1],
-                             SVN->getMask());
-  } else {
-    // NOTE: this strips poison generating flags.
-    // Folding freeze(op(x, ...)) -> op(freeze(x), ...) does not require nnan,
-    // ninf, nsz, or fast.
-    // However, contract, reassoc, afn, and arcp should be preserved,
-    // as these fast-math flags do not introduce poison values.
-    SDNodeFlags SrcFlags = N0->getFlags();
-    SDNodeFlags SafeFlags;
-    SafeFlags.setAllowContract(SrcFlags.hasAllowContract());
-    SafeFlags.setAllowReassociation(SrcFlags.hasAllowReassociation());
-    SafeFlags.setApproximateFuncs(SrcFlags.hasApproximateFuncs());
-    SafeFlags.setAllowReciprocal(SrcFlags.hasAllowReciprocal());
-    R = DAG.getNode(N0.getOpcode(), SDLoc(N0), N0->getVTList(), Ops, SafeFlags);
-  }
-  assert(DAG.isGuaranteedNotToBeUndefOrPoison(R, /*PoisonOnly*/ false) &&
-         "Can't create node that may be undef/poison!");
-  return R;
+  SDLoc DL(N0);
+
+  // Special case handling for ShuffleVectorSDNode nodes.
+  if (auto *SVN = dyn_cast<ShuffleVectorSDNode>(N0))
+    return DAG.getVectorShuffle(N0.getValueType(), DL, Ops[0], Ops[1],
+                                SVN->getMask());
+
+  // NOTE: this strips poison generating flags.
+  // Folding freeze(op(x, ...)) -> op(freeze(x), ...) does not require nnan,
+  // ninf, nsz, or fast.
+  // However, contract, reassoc, afn, and arcp should be preserved,
+  // as these fast-math flags do not introduce poison values.
+  SDNodeFlags SrcFlags = N0->getFlags();
+  SDNodeFlags SafeFlags;
+  SafeFlags.setAllowContract(SrcFlags.hasAllowContract());
+  SafeFlags.setAllowReassociation(SrcFlags.hasAllowReassociation());
+  SafeFlags.setApproximateFuncs(SrcFlags.hasApproximateFuncs());
+  SafeFlags.setAllowReciprocal(SrcFlags.hasAllowReciprocal());
+  return DAG.getNode(N0.getOpcode(), DL, N0->getVTList(), Ops, SafeFlags);
 }
 
 /// We know that BV is a build_vector node with Constant, ConstantFP or Undef


### PR DESCRIPTION
Although nice to have to prove the freeze can be moved, this can fail immediately after freeze(op(...)) -> op(freeze(),freeze(),...) creation if any of the new freeze nodes now prevents value tracking from seeing through to the source values (e.g. shift amounts/element indices are in bounds etc.).

This will allow us to remove the isGuaranteedNotToBeUndefOrPoison checks inside canCreateUndefOrPoison that were discussed on #146361