### PR TITLE
[Clang][Wasm] Set __float128 alignment to 64 for emscripten

### DIFF
--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -1002,6 +1002,7 @@ public:
     // Emscripten's ABI is unstable and we may change this back to 128 to match
     // the WebAssembly default in the future.
     this->LongDoubleAlign = 64;
+    this->Float128Align = 64;
   }
 };
 

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -388,8 +388,7 @@ static void checkDataLayoutConsistency(const TargetInfo &Target,
           llvm::Type::getFloatingPointTy(Context, *Target.LongDoubleFormat),
           Target.LongDoubleAlign);
   }
-  // FIXME: Wasm has a mismatch in f128 alignment between Clang and LLVM.
-  if (Target.hasFloat128Type() && !Triple.isWasm())
+  if (Target.hasFloat128Type())
     Check("__float128", llvm::Type::getFP128Ty(Context), Target.Float128Align);
   if (Target.hasIbm128Type())
     Check("__ibm128", llvm::Type::getPPC_FP128Ty(Context), Target.Ibm128Align);


### PR DESCRIPTION
https://reviews.llvm.org/D104808 set the alignment of long double to 64 bits. This is also the alignment specified in the LLVM data layout. However, the alignment of __float128 was left at 128 bits.

I assume that this was just an oversight, rather than an intentional divergence. The C ABI document currently does not make any statement about `__float128`: https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md