### PR TITLE
[Bitcode][NFC] Add abbrev for FUNC_CODE_DEBUG_LOC

### DIFF
--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -4060,7 +4060,7 @@ void ModuleBitcodeWriter::writeBlockInfo() {
   {
     auto Abbv = std::make_shared<BitCodeAbbrev>();
     Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_DEBUG_LOC));
-    // NOTE: No IsDistinct field for FUNCTION_DEBUG_LOCs.
+    // NOTE: No IsDistinct field for FUNC_CODE_DEBUG_LOC.
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6));
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 8));
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6));


### PR DESCRIPTION
DILocations that are not attached to instructions are encoded using METADATA_LOCATION records which have an abbrev. DILocations attached to instructions are interleaved with instruction records as FUNC_CODE_DEBUG_LOC records, which do not have an abbrev (and FUNC_CODE_DEBUG_LOC_AGAIN which have no operands).

Add a new FUNCTION_BLOCK abbrev FUNCTION_DEBUG_LOC_ABBREV for FUNC_CODE_DEBUG_LOC records.

This reduces the bc file size by up to 7% in CTMark, with many between 2-4% smaller.

[per-file size comparison in compile-time-tracker](https://llvm-compile-time-tracker.com/compare.php?from=75cf826849713c00829cdf657e330e24c1a2fd03&to=1e268ebd0a581016660d9d7e942495c1be041f7d&stat=size-file&details=on) (go to stage1-ReleaseLTO-g).

This optimisation is motivated by #144102, which adds the new Key Instructions fields to bitcode records. The combined patches still overall look to be a slight improvement over the base.