### PR TITLE
[lldb] Add linux test for the three-arg version of getProcFile

### DIFF
--- a/lldb/unittests/Host/posix/SupportTest.cpp
+++ b/lldb/unittests/Host/posix/SupportTest.cpp
@@ -7,9 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "lldb/Host/posix/Support.h"
-#include "lldb/Host/aix/Support.h"
 #include "llvm/Support/Threading.h"
 #include "gtest/gtest.h"
+
+#if defined(_AIX)
+#include "lldb/Host/aix/Support.h"
+#elif defined(__linux__)
+#include "lldb/Host/linux/Support.h"
+#endif
 
 using namespace lldb_private;
 
@@ -21,9 +26,15 @@ TEST(Support, getProcFile_Pid) {
 }
 #endif // #ifndef __APPLE__
 
-#if defined(_AIX) && defined(LLVM_ENABLE_THREADING)
+#if (defined(_AIX) || defined(__linux__)) && defined(LLVM_ENABLE_THREADING)
 TEST(Support, getProcFile_Tid) {
-  auto BufferOrError = getProcFile(getpid(), llvm::get_threadid(), "lwpstatus");
+  auto BufferOrError = getProcFile(getpid(), llvm::get_threadid(),
+#ifdef _AIX
+                                   "lwpstatus"
+#else
+                                   "status"
+#endif
+  );
   ASSERT_TRUE(BufferOrError);
   ASSERT_TRUE(*BufferOrError);
 }

--- a/lldb/unittests/Host/posix/SupportTest.cpp
+++ b/lldb/unittests/Host/posix/SupportTest.cpp
@@ -26,7 +26,7 @@ TEST(Support, getProcFile_Pid) {
 }
 #endif // #ifndef __APPLE__
 
-#if (defined(_AIX) || defined(__linux__)) && defined(LLVM_ENABLE_THREADING)
+#if defined(_AIX) || defined(__linux__)
 TEST(Support, getProcFile_Tid) {
   auto BufferOrError = getProcFile(getpid(), llvm::get_threadid(),
 #ifdef _AIX
@@ -38,4 +38,4 @@ TEST(Support, getProcFile_Tid) {
   ASSERT_TRUE(BufferOrError);
   ASSERT_TRUE(*BufferOrError);
 }
-#endif // #ifdef _AIX && LLVM_ENABLE_THREADING
+#endif // #if defined(_AIX) || defined(__linux__)


### PR DESCRIPTION
Also conditionalize the header includes. Not strictly necessary, but it's weird to include an aix header on non-aix builds, it makes clang-tidy complain, and breaks build systems which require you to declare all headers belonging to a library (aka bazel).