### PR TITLE
[NFC][Offload] Fix possible edge cases in offload-tblgen

### DIFF
--- a/offload/tools/offload-tblgen/APIGen.cpp
+++ b/offload/tools/offload-tblgen/APIGen.cpp
@@ -34,7 +34,8 @@ static std::string MakeComment(StringRef in) {
     }
     out += std::string("/// ") +
            in.substr(LineStart, LineBreak - LineStart).str() + "\n";
-    LineStart = LineBreak + 1;
+    if (LineBreak != std::string::npos)
+      LineStart = LineBreak + 1;
   }
 
   return out;

--- a/offload/tools/offload-tblgen/RecordTypes.hpp
+++ b/offload/tools/offload-tblgen/RecordTypes.hpp
@@ -157,9 +157,15 @@ public:
   bool isHandleType() const { return getType().ends_with("_handle_t"); }
   bool isFptrType() const { return getType().ends_with("_cb_t"); }
   StringRef getDesc() const { return rec->getValueAsString("desc"); }
-  bool isIn() const { return dyn_cast<BitInit>(flags->getBit(0))->getValue(); }
-  bool isOut() const { return dyn_cast<BitInit>(flags->getBit(1))->getValue(); }
-  bool isOpt() const { return dyn_cast<BitInit>(flags->getBit(2))->getValue(); }
+  bool getFlagBit(unsigned int Bit) const {
+    if (auto *BitValue = dyn_cast<BitInit>(flags->getBit(Bit)))
+      return BitValue->getValue();
+    assert(false && "Parameter flags has no default or set value");
+    return false;
+  }
+  bool isIn() const { return getFlagBit(0); }
+  bool isOut() const { return getFlagBit(1); }
+  bool isOpt() const { return getFlagBit(2); }
 
   const Record *getRec() const { return rec; }
   std::optional<std::pair<StringRef, StringRef>> getRange() const {


### PR DESCRIPTION
Fix a couple of unhandled edge cases in offload-tblgen that were found by static analysis
* `LineStart` may wrap around to 0 when processing multi-line strings. The value is not actually being used in that case, but still better to explicitly handle it
* Possible unchecked nullptr when processing parameter flags