### PR TITLE
[BOLT] Improve exception handling in NFC-Mode

### DIFF
--- a/bolt/utils/nfc-check-setup.py
+++ b/bolt/utils/nfc-check-setup.py
@@ -104,7 +104,7 @@ def main():
         sys.exit(e)
 
     # build the current commit
-    print ("NFC-Setup: Building current revision..")
+    print("NFC-Setup: Building current revision..")
     subprocess.run(
         shlex.split("cmake --build . --target llvm-bolt"), cwd=args.build_dir
     )
@@ -144,7 +144,7 @@ def main():
     new_ref = get_git_ref_or_rev(source_dir)
 
     # build the previous commit
-    print ("NFC-Setup: Building previous revision..")
+    print("NFC-Setup: Building previous revision..")
     subprocess.run(
         shlex.split("cmake --build . --target llvm-bolt"), cwd=args.build_dir
     )

--- a/bolt/utils/nfc-check-setup.py
+++ b/bolt/utils/nfc-check-setup.py
@@ -92,7 +92,7 @@ def main():
     source_dir = None
     # find the repo directory
     try:
-        CMCacheFilename=f"{args.build_dir}/CMakeCache.txt"
+        CMCacheFilename = f"{args.build_dir}/CMakeCache.txt"
         with open(CMCacheFilename) as f:
             for line in f:
                 m = re.match(r"LLVM_SOURCE_DIR:STATIC=(.*)", line)
@@ -104,6 +104,7 @@ def main():
         sys.exit(e)
 
     # build the current commit
+    print ("NFC-Setup: Building current revision..")
     subprocess.run(
         shlex.split("cmake --build . --target llvm-bolt"), cwd=args.build_dir
     )
@@ -143,6 +144,7 @@ def main():
     new_ref = get_git_ref_or_rev(source_dir)
 
     # build the previous commit
+    print ("NFC-Setup: Building previous revision..")
     subprocess.run(
         shlex.split("cmake --build . --target llvm-bolt"), cwd=args.build_dir
     )


### PR DESCRIPTION
This patch introduce the following improvements:
- Catch an exception when the CMakeCache.txt is not present
- Bail out gracefully when llvm-bolt did not build successfully the
  current or previous revision.
- Always do a `--switch-back` even if building the old revision failed