### PR TITLE
[mlir][async] Erase op later to preserve insertion point

### DIFF
--- a/mlir/lib/Dialect/Async/Transforms/AsyncToAsyncRuntime.cpp
+++ b/mlir/lib/Dialect/Async/Transforms/AsyncToAsyncRuntime.cpp
@@ -723,8 +723,8 @@ public:
       // Switch the coroutine completion token to available state.
       rewriter.create<RuntimeSetAvailableOp>(loc, *coro.asyncToken);
 
-    rewriter.eraseOp(op);
     rewriter.create<cf::BranchOp>(loc, coro.cleanup);
+    rewriter.eraseOp(op);
 
     return success();
   }


### PR DESCRIPTION
Delay the erasure of an op, so that the insertion point of the rewriter remains valid.

This commit is in preparation of the One-Shot Dialect Conversion refactoring. (The current implementation works with the current dialect conversion driver because op erasure is delayed.)