### PR TITLE
[Clang][DLCov][NFCish] Fix debugloc coverage tracking macro in Clang

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/Bitcode/BitcodeWriterPass.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/Frontend/Driver/CodeGenOptions.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/DebugInfo.h"
@@ -961,7 +962,7 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
           CodeGenOpts.DIBugsReportFilePath);
     Debugify.registerCallbacks(PIC, MAM);
 
-#if LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING
+#if LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
     // If we're using debug location coverage tracking, mark all the
     // instructions coming out of the frontend without a DebugLoc as being
     // compiler-generated, to prevent both those instructions and new


### PR DESCRIPTION
In a previous commit, the llvm-config-defined macro LLVM_ENABLE_DEBUGLOC_COVERAGE_TRACKING was renamed to LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE. One instance of this in Clang remains unchanged; this patch renames it, and adds an explicit llvm-config inclusion to ensure the define doesn't silently get removed.

NFC outside of coverage tracking builds, which we do not currently test.