### PR TITLE
[LLD][Docs] Document -z gcs= option in the man page

### DIFF
--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -801,7 +801,7 @@ is the default, linker will not report the missing property otherwise will be re
 .It Cm gcs-report Ns = Ns Ar [none|warning|error]
 Specify how to report missing GNU_PROPERTY_AARCH64_FEATURE_1_GCS property. GNU_PROPERTY_AARCH64_FEATURE_1_GCS indicates object file support for the Guarded Control Stack security feature.
 .Cm none
-is the default, linker will not report the missing property otherwise will be reported as a warning or an error.
+is the (default) linker will not report the missing property otherwise, missing property will be reported as a warning or an error.
 .Pp
 .It Cm dynamic-undefined-weak
 Make undefined weak symbols dynamic when the dynamic symbol table is present, if they are referenced from
@@ -959,13 +959,13 @@ disallows overlap.
 x86 only, use shadow stack.
 .Pp
 .It Cm gcs Ns = Ns Ar [implicit|never|always]
-Specify how the GCS bit is set. A set GCS bit indicates that the object file supports the Guarded Control Stack security feature.
+Specifies how the GNU_PROPERTY_AARCH64_FEATURE_1_GCS bit is set in the output ELF file. When set, it indicates support for the Guarded Control Stack (GCS) security feature.
 .Cm implicit
-is the default, where the GCS bit is inferred from the input objects.
+is the (default) GCS feature bit is inferred from the input object marking.
 .Cm never
-disables the GCS bit regardless of input markings.
+clears the GCS feature bit regardless of input object markings.
 .Cm always
-enables the GCS bit regardless of input markings.
+set the GCS feature bit regardless of input object markings.
 .Pp
 .It Cm stack-size Ns = Ns Ar size
 Set the main thread's stack size to

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -953,6 +953,16 @@ disallows overlap.
 .It Cm shstk
 x86 only, use shadow stack.
 .Pp
+.It Cm gcs Ns = Ns Ar [implicit|never|always]
+Specify how the GCS bit is set. Set GCS bit indicates object file that supports Guarded Control Stack.
+Specify how the GCS bit is set. A set GCS bit indicates that the object file supports the Guarded Control Stack security feature.
+.Cm implicit
+is the default, where the GCS bit is inferred from the input objects.
+.Cm never
+disables the GCS bit regardless of input markings.
+.Cm always
+enables the GCS bit regardless of input markings.
+.Pp
 .It Cm stack-size Ns = Ns Ar size
 Set the main thread's stack size to
 .Ar size .

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -801,7 +801,7 @@ is the default, linker will not report the missing property otherwise will be re
 .It Cm gcs-report Ns = Ns Ar [none|warning|error]
 Specify how to report missing GNU_PROPERTY_AARCH64_FEATURE_1_GCS property. GNU_PROPERTY_AARCH64_FEATURE_1_GCS indicates object file support for the Guarded Control Stack security feature.
 .Cm none
-is the (default) linker will not report the missing property otherwise, missing property will be reported as a warning or an error.
+is the default, linker will not report the missing property otherwise will be reported as a warning or an error.
 .Pp
 .It Cm dynamic-undefined-weak
 Make undefined weak symbols dynamic when the dynamic symbol table is present, if they are referenced from
@@ -961,7 +961,7 @@ x86 only, use shadow stack.
 .It Cm gcs Ns = Ns Ar [implicit|never|always]
 Specifies how the GNU_PROPERTY_AARCH64_FEATURE_1_GCS bit is set in the output ELF file. When set, it indicates support for the Guarded Control Stack (GCS) security feature.
 .Cm implicit
-is the (default) GCS feature bit is inferred from the input object marking.
+(default) GCS feature bit is inferred from the input object marking.
 .Cm never
 clears the GCS feature bit regardless of input object markings.
 .Cm always

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -799,7 +799,9 @@ Specify how to report the missing GNU_PROPERTY_X86_FEATURE_1_IBT or GNU_PROPERTY
 is the default, linker will not report the missing property otherwise will be reported as a warning or an error.
 .Pp
 .It Cm gcs-report Ns = Ns Ar [none|warning|error]
-Specify how to report missing GNU_PROPERTY_AARCH64_FEATURE_1_GCS property. GNU_PROPERTY_AARCH64_FEATURE_1_GCS indicates object file support for the Guarded Control Stack security feature.
+Specify how to report missing
+.Cm GNU_PROPERTY_AARCH64_FEATURE_1_GCS
+property. GNU_PROPERTY_AARCH64_FEATURE_1_GCS indicates object file support for the Guarded Control Stack security feature.
 .Cm none
 is the default, linker will not report the missing property otherwise will be reported as a warning or an error.
 .Pp
@@ -959,13 +961,15 @@ disallows overlap.
 x86 only, use shadow stack.
 .Pp
 .It Cm gcs Ns = Ns Ar [implicit|never|always]
-Specifies how the GNU_PROPERTY_AARCH64_FEATURE_1_GCS bit is set in the output ELF file. When set, it indicates support for the Guarded Control Stack (GCS) security feature.
+Specifies how the
+.Cm GNU_PROPERTY_AARCH64_FEATURE_1_GCS
+bit is set in the output ELF file. When set, it indicates support for the Guarded Control Stack (GCS) security feature.
 .Cm implicit
-(default) GCS feature bit is inferred from the input object marking.
+(default) The GCS feature bit is set if all input relocatable files have a .note.gnu.property section containing the GNU_PROPERTY_AARCH64_FEATURE_1_GCS bit.
 .Cm never
-clears the GCS feature bit regardless of input object markings.
+clears the GCS feature bit regardless of input relocatable files' markings.
 .Cm always
-set the GCS feature bit regardless of input object markings.
+sets the GCS feature bit regardless of input object markings.
 .Pp
 .It Cm stack-size Ns = Ns Ar size
 Set the main thread's stack size to

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -798,6 +798,11 @@ Specify how to report the missing GNU_PROPERTY_X86_FEATURE_1_IBT or GNU_PROPERTY
 .Cm none
 is the default, linker will not report the missing property otherwise will be reported as a warning or an error.
 .Pp
+.It Cm gcs-report Ns = Ns Ar [none|warning|error]
+Specify how to report missing GNU_PROPERTY_AARCH64_FEATURE_1_GCS property. GNU_PROPERTY_AARCH64_FEATURE_1_GCS indicates object file support for the Guarded Control Stack security feature.
+.Cm none
+is the default, linker will not report the missing property otherwise will be reported as a warning or an error.
+.Pp
 .It Cm dynamic-undefined-weak
 Make undefined weak symbols dynamic when the dynamic symbol table is present, if they are referenced from
 relocatable object files and not forced local by symbol visibility or versioning. Do not make them dynamic when
@@ -954,7 +959,6 @@ disallows overlap.
 x86 only, use shadow stack.
 .Pp
 .It Cm gcs Ns = Ns Ar [implicit|never|always]
-Specify how the GCS bit is set. Set GCS bit indicates object file that supports Guarded Control Stack.
 Specify how the GCS bit is set. A set GCS bit indicates that the object file supports the Guarded Control Stack security feature.
 .Cm implicit
 is the default, where the GCS bit is inferred from the input objects.


### PR DESCRIPTION
Add documentation for the -z gcs= option to the LLD man page. This flag controls how the GCS bit is set in the output:

- implicit (default): inferred from input objects
- never: GCS bit is never set
- always: GCS bit is always set

Clarifies behavior for users and aligns the man page with existing functionality.
