### PR TITLE
[AsmParser] Remove unnecessary casts (NFC)

### DIFF
--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1234,14 +1234,12 @@ bool LLParser::parseAliasOrIFunc(const std::string &Name, unsigned NameID,
   std::unique_ptr<GlobalIFunc> GI;
   GlobalValue *GV;
   if (IsAlias) {
-    GA.reset(GlobalAlias::create(Ty, AddrSpace,
-                                 (GlobalValue::LinkageTypes)Linkage, Name,
-                                 Aliasee, /*Parent*/ nullptr));
+    GA.reset(GlobalAlias::create(Ty, AddrSpace, Linkage, Name, Aliasee,
+                                 /*Parent*/ nullptr));
     GV = GA.get();
   } else {
-    GI.reset(GlobalIFunc::create(Ty, AddrSpace,
-                                 (GlobalValue::LinkageTypes)Linkage, Name,
-                                 Aliasee, /*Parent*/ nullptr));
+    GI.reset(GlobalIFunc::create(Ty, AddrSpace, Linkage, Name, Aliasee,
+                                 /*Parent*/ nullptr));
     GV = GI.get();
   }
   GV->setThreadLocalMode(TLM);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1235,11 +1235,11 @@ bool LLParser::parseAliasOrIFunc(const std::string &Name, unsigned NameID,
   GlobalValue *GV;
   if (IsAlias) {
     GA.reset(GlobalAlias::create(Ty, AddrSpace, Linkage, Name, Aliasee,
-                                 /*Parent*/ nullptr));
+                                 /*Parent*/nullptr));
     GV = GA.get();
   } else {
     GI.reset(GlobalIFunc::create(Ty, AddrSpace, Linkage, Name, Aliasee,
-                                 /*Parent*/ nullptr));
+                                 /*Parent*/nullptr));
     GV = GI.get();
   }
   GV->setThreadLocalMode(TLM);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -1235,11 +1235,11 @@ bool LLParser::parseAliasOrIFunc(const std::string &Name, unsigned NameID,
   GlobalValue *GV;
   if (IsAlias) {
     GA.reset(GlobalAlias::create(Ty, AddrSpace, Linkage, Name, Aliasee,
-                                 /*Parent*/nullptr));
+                                 /*Parent=*/nullptr));
     GV = GA.get();
   } else {
     GI.reset(GlobalIFunc::create(Ty, AddrSpace, Linkage, Name, Aliasee,
-                                 /*Parent*/nullptr));
+                                 /*Parent=*/nullptr));
     GV = GI.get();
   }
   GV->setThreadLocalMode(TLM);


### PR DESCRIPTION
Linkage is already of GlobalValue::LinkageTypes.
