### PR TITLE
[mlir][SPIRVToLLVM] Set valid insertion point after op erasure

### DIFF
--- a/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/ConvertLaunchFuncToLLVMCalls.cpp
@@ -269,8 +269,9 @@ class GPULaunchLowering : public ConvertOpToLLVMPattern<gpu::LaunchFuncOp> {
       copyInfo.push_back(info);
     }
     // Create a call to the kernel and copy the data back.
-    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, kernelFunc,
-                                              ArrayRef<Value>());
+    Operation *callOp = rewriter.replaceOpWithNewOp<LLVM::CallOp>(
+        op, kernelFunc, ArrayRef<Value>());
+    rewriter.setInsertionPointAfter(callOp);
     for (CopyInfo info : copyInfo)
       copy(loc, info.src, info.dst, info.size, rewriter);
     return success();


### PR DESCRIPTION
Erasing/replacing an op, which is also the current insertion point, invalidates the insertion point. Explicitly set the insertion point, so that `copy` does not crash after the One-Shot Dialect Conversion refactoring. (`ConversionPatternRewriter` will start behaving more like a "normal" rewriter.)
