### PR TITLE
scudo: Support free_sized and free_aligned_sized from C23

### DIFF
--- a/compiler-rt/lib/scudo/standalone/chunk.h
+++ b/compiler-rt/lib/scudo/standalone/chunk.h
@@ -53,10 +53,11 @@ namespace Chunk {
 // but https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414 prevents it from
 // happening, as it will error, complaining the number of bits is not enough.
 enum Origin : u8 {
-  Malloc = 0,
-  New = 1,
-  NewArray = 2,
-  Memalign = 3,
+  Malloc = 0,   // malloc, calloc, realloc, free, free_sized
+  New = 1,      // operator new, operator delete
+  NewArray = 2, // operator new [], operator delete []
+  Memalign = 3, // aligned_alloc, posix_memalign, memalign, pvalloc, valloc,
+                // free_aligned_sized
 };
 
 enum State : u8 { Available = 0, Allocated = 1, Quarantined = 2 };

--- a/compiler-rt/lib/scudo/standalone/flags.inc
+++ b/compiler-rt/lib/scudo/standalone/flags.inc
@@ -49,3 +49,18 @@ SCUDO_FLAG(int, release_to_os_interval_ms, 5000,
 SCUDO_FLAG(int, allocation_ring_buffer_size, 32768,
            "Entries to keep in the allocation ring buffer for scudo. "
            "Values less or equal to zero disable the buffer.")
+
+SCUDO_FLAG(bool, delete_alignment_mismatch, true,
+           "Terminate on an alignment mismatch between a aligned-delete and "
+           "the actual "
+           "alignment of a chunk (as provided to new/new[]).")
+
+SCUDO_FLAG(bool, free_size_mismatch, true,
+           "Terminate on a size mismatch between a free_sized and the actual "
+           "size of a chunk (as provided to malloc/calloc/realloc).")
+
+SCUDO_FLAG(bool, free_alignment_mismatch, true,
+           "Terminate on an alignment mismatch between a free_aligned_sized "
+           "and the actual "
+           "alignment of a chunk (as provided to "
+           "aligned_alloc/posix_memalign/memalign).")

--- a/compiler-rt/lib/scudo/standalone/internal_defs.h
+++ b/compiler-rt/lib/scudo/standalone/internal_defs.h
@@ -47,6 +47,15 @@
 #define UNUSED __attribute__((unused))
 #define USED __attribute__((used))
 #define NOEXCEPT noexcept
+#ifdef __has_attribute
+#if __has_attribute(fallthrough)
+#define FALLTHROUGH __attribute__((fallthrough))
+#else
+#define FALLTHROUGH
+#endif
+#else
+#define FALLTHROUGH
+#endif
 
 // This check is only available on Clang. This is essentially an alias of
 // C++20's 'constinit' specifier which will take care of this when (if?) we can

--- a/compiler-rt/lib/scudo/standalone/options.h
+++ b/compiler-rt/lib/scudo/standalone/options.h
@@ -25,6 +25,9 @@ enum class OptionBit {
   UseOddEvenTags,
   UseMemoryTagging,
   AddLargeAllocationSlack,
+  DeleteAlignmentMismatch,
+  FreeSizeMismatch,
+  FreeAlignmentMismatch,
 };
 
 struct Options {

--- a/compiler-rt/lib/scudo/standalone/report.h
+++ b/compiler-rt/lib/scudo/standalone/report.h
@@ -44,9 +44,13 @@ enum class AllocatorAction : u8 {
 void NORETURN reportInvalidChunkState(AllocatorAction Action, const void *Ptr);
 void NORETURN reportMisalignedPointer(AllocatorAction Action, const void *Ptr);
 void NORETURN reportDeallocTypeMismatch(AllocatorAction Action, const void *Ptr,
-                                        u8 TypeA, u8 TypeB);
+                                        u8 TypeA, u8 TypeB, bool HasDeleteSize);
 void NORETURN reportDeleteSizeMismatch(const void *Ptr, uptr Size,
                                        uptr ExpectedSize);
+void NORETURN reportDeleteAlignmentMismatch(const void *Ptr, uptr Alignment);
+void NORETURN reportFreeSizeMismatch(const void *Ptr, uptr Size,
+                                     uptr ExpectedSize);
+void NORETURN reportFreeAlignmentMismatch(const void *Ptr, uptr Alignment);
 
 // C wrappers errors.
 void NORETURN reportAlignmentNotPowerOfTwo(uptr Alignment);

--- a/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/report_test.cpp
@@ -41,7 +41,7 @@ TEST(ScudoReportDeathTest, Generic) {
       scudo::reportMisalignedPointer(scudo::AllocatorAction::Deallocating, P),
       "Scudo ERROR.*deallocating.*42424242");
   EXPECT_DEATH(scudo::reportDeallocTypeMismatch(
-                   scudo::AllocatorAction::Reallocating, P, 0, 1),
+                   scudo::AllocatorAction::Reallocating, P, 0, 1, false),
                "Scudo ERROR.*reallocating.*42424242");
   EXPECT_DEATH(scudo::reportDeleteSizeMismatch(P, 123, 456),
                "Scudo ERROR.*42424242.*123.*456");

--- a/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test.h
+++ b/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test.h
@@ -8,6 +8,8 @@
 
 #include "platform.h"
 
+#include <stdlib.h>
+
 #if SCUDO_FUCHSIA
 #include <zxtest/zxtest.h>
 using Test = ::zxtest::Test;
@@ -56,6 +58,17 @@ using Test = ::testing::Test;
 // The zxtest library provides a default main function that does the same thing
 // for Fuchsia builds.
 #define SCUDO_NO_TEST_MAIN
+#endif
+
+// Match Android's default configuration, which disables Scudo's mismatch
+// allocation check, as it is being triggered by some third party code.
+#if SCUDO_ANDROID
+#define DEALLOC_TYPE_MISMATCH "false"
+#define SKIP_DEALLOC_TYPE_MISMATCH 1
+#else
+#define DEALLOC_TYPE_MISMATCH "true"
+#define SKIP_DEALLOC_TYPE_MISMATCH                                             \
+  (getenv("SKIP_DEALLOC_TYPE_MISMATCH") != nullptr)
 #endif
 
 extern bool UseQuarantine;

--- a/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test_main.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/scudo_unit_test_main.cpp
@@ -9,14 +9,6 @@
 #include "memtag.h"
 #include "tests/scudo_unit_test.h"
 
-// Match Android's default configuration, which disables Scudo's mismatch
-// allocation check, as it is being triggered by some third party code.
-#if SCUDO_ANDROID
-#define DEALLOC_TYPE_MISMATCH "false"
-#else
-#define DEALLOC_TYPE_MISMATCH "true"
-#endif
-
 static void EnableMemoryTaggingIfSupported() {
   if (!scudo::archSupportsMemoryTagging())
     return;

--- a/compiler-rt/lib/scudo/standalone/tests/wrappers_cpp_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/wrappers_cpp_test.cpp
@@ -17,13 +17,6 @@
 #include <thread>
 #include <vector>
 
-// Android does not support checking for new/delete mismatches.
-#if SCUDO_ANDROID
-#define SKIP_MISMATCH_TESTS 1
-#else
-#define SKIP_MISMATCH_TESTS 0
-#endif
-
 void operator delete(void *, size_t) noexcept;
 void operator delete[](void *, size_t) noexcept;
 
@@ -143,10 +136,9 @@ public:
 // by Scudo. See the comment in the C counterpart of this file.
 
 TEST_F(ScudoWrappersCppDeathTest, New) {
-  if (getenv("SKIP_TYPE_MISMATCH") || SKIP_MISMATCH_TESTS) {
-    printf("Skipped type mismatch tests.\n");
-    return;
-  }
+  if (SKIP_DEALLOC_TYPE_MISMATCH)
+    TEST_SKIP("Dealloc type mismatch disabled.");
+
   testCxxNew<bool>();
   testCxxNew<uint8_t>();
   testCxxNew<uint16_t>();

--- a/compiler-rt/lib/scudo/standalone/wrappers_c.inc
+++ b/compiler-rt/lib/scudo/standalone/wrappers_c.inc
@@ -68,6 +68,18 @@ INTERFACE WEAK void SCUDO_PREFIX(free)(void *ptr) {
   SCUDO_ALLOCATOR.deallocate(ptr, scudo::Chunk::Origin::Malloc);
 }
 
+INTERFACE WEAK void SCUDO_PREFIX(free_sized)(void *ptr, size_t size) {
+  reportDeallocation(ptr);
+  SCUDO_ALLOCATOR.deallocate(ptr, scudo::Chunk::Origin::Malloc, size, true);
+}
+
+INTERFACE WEAK void
+SCUDO_PREFIX(free_aligned_sized)(void *ptr, size_t alignment, size_t size) {
+  reportDeallocation(ptr);
+  SCUDO_ALLOCATOR.deallocate(ptr, scudo::Chunk::Origin::Memalign, size, true,
+                             alignment, true);
+}
+
 INTERFACE WEAK struct SCUDO_MALLINFO SCUDO_PREFIX(mallinfo)(void) {
   struct SCUDO_MALLINFO Info = {};
   scudo::StatCounters Stats;
@@ -308,7 +320,7 @@ INTERFACE WEAK void *SCUDO_PREFIX(aligned_alloc)(size_t alignment,
   }
 
   void *Ptr =
-      SCUDO_ALLOCATOR.allocate(size, scudo::Chunk::Origin::Malloc, alignment);
+      SCUDO_ALLOCATOR.allocate(size, scudo::Chunk::Origin::Memalign, alignment);
   reportAllocation(Ptr, size);
 
   return scudo::setErrnoOnNull(Ptr);

--- a/compiler-rt/lib/scudo/standalone/wrappers_cpp.cpp
+++ b/compiler-rt/lib/scudo/standalone/wrappers_cpp.cpp
@@ -104,47 +104,47 @@ INTERFACE WEAK void operator delete[](void *ptr,
 }
 INTERFACE WEAK void operator delete(void *ptr, size_t size) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, size);
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, size, true);
 }
 INTERFACE WEAK void operator delete[](void *ptr, size_t size) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, size);
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, size, true);
 }
 INTERFACE WEAK void operator delete(void *ptr,
                                     std::align_val_t align) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, 0,
-                       static_cast<scudo::uptr>(align));
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, 0, false,
+                       static_cast<scudo::uptr>(align), true);
 }
 INTERFACE WEAK void operator delete[](void *ptr,
                                       std::align_val_t align) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, 0,
-                       static_cast<scudo::uptr>(align));
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, 0, false,
+                       static_cast<scudo::uptr>(align), true);
 }
 INTERFACE WEAK void operator delete(void *ptr, std::align_val_t align,
                                     std::nothrow_t const &) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, 0,
-                       static_cast<scudo::uptr>(align));
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, 0, false,
+                       static_cast<scudo::uptr>(align), true);
 }
 INTERFACE WEAK void operator delete[](void *ptr, std::align_val_t align,
                                       std::nothrow_t const &) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, 0,
-                       static_cast<scudo::uptr>(align));
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, 0, false,
+                       static_cast<scudo::uptr>(align), true);
 }
 INTERFACE WEAK void operator delete(void *ptr, size_t size,
                                     std::align_val_t align) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, size,
-                       static_cast<scudo::uptr>(align));
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::New, size, true,
+                       static_cast<scudo::uptr>(align), true);
 }
 INTERFACE WEAK void operator delete[](void *ptr, size_t size,
                                       std::align_val_t align) NOEXCEPT {
   reportDeallocation(ptr);
-  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, size,
-                       static_cast<scudo::uptr>(align));
+  Allocator.deallocate(ptr, scudo::Chunk::Origin::NewArray, size, true,
+                       static_cast<scudo::uptr>(align), true);
 }
 
 #endif // !SCUDO_ANDROID || !_BIONIC

--- a/compiler-rt/test/scudo/standalone/unit/gwp_asan/lit.site.cfg.py.in
+++ b/compiler-rt/test/scudo/standalone/unit/gwp_asan/lit.site.cfg.py.in
@@ -21,4 +21,4 @@ config.test_source_root = config.test_exec_root
 config.environment['SCUDO_OPTIONS'] = 'GWP_ASAN_SampleRate=1:GWP_ASAN_MaxSimultaneousAllocations=100000'
 
 # GWP-ASan doesn't support malloc-type mismatch.
-config.environment['SKIP_TYPE_MISMATCH'] = '1'
+config.environment['SKIP_DEALLOC_TYPE_MISMATCH'] = '1'

--- a/llvm/docs/ScudoHardenedAllocator.rst
+++ b/llvm/docs/ScudoHardenedAllocator.rst
@@ -267,6 +267,16 @@ The following "string" options are available:
 |                                 |                | the scudo_malloc_set_track_allocation_stacks    |
 |                                 |                | function.                                       |
 +---------------------------------+----------------+-------------------------------------------------+
+| delete_alignment_mismatch       | true           | Whether or not we report errors on mismatch     |
+|                                 |                | between alignment of new and delete.            |
++---------------------------------+----------------+-------------------------------------------------+
+| free_size_mismatch              | true           | Whether or not we report errors on mismatch     |
+|                                 |                | between sizes of malloc and free_sized.         |
++---------------------------------+----------------+-------------------------------------------------+
+| free_alignment_mismatch         | true           | Whether or not we report errors on mismatch     |
+|                                 |                | between alignment of aligned_alloc and          |
+|                                 |                | free_aligned_sized.                             |
++---------------------------------+----------------+-------------------------------------------------+
 
 Additional flags can be specified, for example if Scudo if compiled with
 `GWP-ASan <https://llvm.org/docs/GwpAsan.html>`_ support.


### PR DESCRIPTION
Updates scudo to support `free_sized` and `free_aligned_sized` from C23.

- Adds `delete_alignment_mismatch` and enables it by default. During deallocation we check that the provided pointer is aligned at least to the provided alignment. We do not store the requested alignment, so this is the best we can do.
- Adds `free_size_mismatch` and enables it by default. If the provided size to `free_sized` is different from the requested size, we report an error.
- Adds `free_alignment_mismatch` and enables it by default. Same as `delete_alignment_mismatch`, except for `free_aligned_sized`.
- The deallocation function now knows whether size/alignment was explicitly provided, enabling it to differentiate whether `0` was provided by the user.

For https://github.com/llvm/llvm-project/issues/144435