### PR TITLE
[lldb] Take a sledgehammer approach to resizing the statusline

### DIFF
--- a/lldb/include/lldb/Core/Statusline.h
+++ b/lldb/include/lldb/Core/Statusline.h
@@ -36,12 +36,10 @@ private:
   /// Draw the statusline with the given text.
   void Draw(std::string msg);
 
-  /// Update terminal dimensions.
-  void UpdateTerminalProperties();
-
   enum ScrollWindowMode {
     EnableStatusline,
     DisableStatusline,
+    ResizeStatusline,
   };
 
   /// Set the scroll window for the given mode.

--- a/lldb/source/Core/Statusline.cpp
+++ b/lldb/source/Core/Statusline.cpp
@@ -24,6 +24,7 @@
 #define ANSI_SAVE_CURSOR ESCAPE "7"
 #define ANSI_RESTORE_CURSOR ESCAPE "8"
 #define ANSI_CLEAR_BELOW ESCAPE "[J"
+#define ANSI_CLEAR_SCREEN ESCAPE "[2J"
 #define ANSI_SET_SCROLL_ROWS ESCAPE "[1;%ur"
 #define ANSI_TO_START_OF_ROW ESCAPE "[%u;1f"
 #define ANSI_REVERSE_VIDEO ESCAPE "[7m"
@@ -41,10 +42,12 @@ Statusline::Statusline(Debugger &debugger)
 Statusline::~Statusline() { Disable(); }
 
 void Statusline::TerminalSizeChanged() {
-  UpdateTerminalProperties();
+  m_terminal_width = m_debugger.GetTerminalWidth();
+  m_terminal_height = m_debugger.GetTerminalHeight();
 
-  // This definitely isn't signal safe, but the best we can do, until we
-  // have proper signal-catching thread.
+  UpdateScrollWindow(ResizeStatusline);
+
+  // Draw the old statusline.
   Redraw(/*update=*/false);
 }
 
@@ -85,13 +88,6 @@ void Statusline::Draw(std::string str) {
   locked_stream << ANSI_RESTORE_CURSOR;
 }
 
-void Statusline::UpdateTerminalProperties() {
-  UpdateScrollWindow(DisableStatusline);
-  m_terminal_width = m_debugger.GetTerminalWidth();
-  m_terminal_height = m_debugger.GetTerminalHeight();
-  UpdateScrollWindow(EnableStatusline);
-}
-
 void Statusline::UpdateScrollWindow(ScrollWindowMode mode) {
   assert(m_terminal_width != 0 && m_terminal_height != 0);
 
@@ -99,24 +95,32 @@ void Statusline::UpdateScrollWindow(ScrollWindowMode mode) {
   if (!stream_sp)
     return;
 
-  const unsigned scroll_height =
-      (mode == DisableStatusline) ? m_terminal_height : m_terminal_height - 1;
-
+  const unsigned reduced_scroll_window = m_terminal_height - 1;
   LockedStreamFile locked_stream = stream_sp->Lock();
 
-  if (mode == EnableStatusline) {
+  switch (mode) {
+  case EnableStatusline:
     // Move everything on the screen up.
     locked_stream << '\n';
     locked_stream.Printf(ANSI_UP_ROWS, 1);
-  }
-
-  locked_stream << ANSI_SAVE_CURSOR;
-  locked_stream.Printf(ANSI_SET_SCROLL_ROWS, scroll_height);
-  locked_stream << ANSI_RESTORE_CURSOR;
-
-  if (mode == DisableStatusline) {
+    // Reduce the scroll window.
+    locked_stream << ANSI_SAVE_CURSOR;
+    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_window);
+    locked_stream << ANSI_RESTORE_CURSOR;
+    break;
+  case DisableStatusline:
+    // Reset the scroll window.
+    locked_stream << ANSI_SAVE_CURSOR;
+    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, 0);
+    locked_stream << ANSI_RESTORE_CURSOR;
     // Clear the screen below to hide the old statusline.
     locked_stream << ANSI_CLEAR_BELOW;
+    break;
+  case ResizeStatusline:
+    // Clear the screen and update the scroll window.
+    locked_stream << ANSI_CLEAR_SCREEN;
+    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_window);
+    break;
   }
 
   m_debugger.RefreshIOHandler();

--- a/lldb/source/Core/Statusline.cpp
+++ b/lldb/source/Core/Statusline.cpp
@@ -118,6 +118,7 @@ void Statusline::UpdateScrollWindow(ScrollWindowMode mode) {
     break;
   case ResizeStatusline:
     // Clear the screen and update the scroll window.
+    // FIXME: Find a better solution (#146919).
     locked_stream << ANSI_CLEAR_SCREEN;
     locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_window);
     break;

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -68,7 +68,7 @@ class TestStatusline(PExpectTest):
 
         # Hide the statusline and check or the control character.
         self.expect(
-            "set set show-statusline false", ["\x1b[1;{}r".format(self.TERMINAL_HEIGHT)]
+            "set set show-statusline false", ["\x1b[1;0r"]
         )
 
     def test_no_color(self):
@@ -114,6 +114,6 @@ class TestStatusline(PExpectTest):
         self.resize()
         self.expect("set set show-statusline true", ["no target"])
         self.resize(20, 60)
-        # Check for the escape code to resize the scroll window, followed by
-        # the prompt.
-        self.child.expect(re.escape("\x1b[1;19r\x1b8(lldb)"))
+        # Check for the escape code to resize the scroll window.
+        self.child.expect(re.escape("\x1b[1;19r"))
+        self.child.expect("(lldb)")

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -67,9 +67,7 @@ class TestStatusline(PExpectTest):
         self.expect('set set separator "| "')
 
         # Hide the statusline and check or the control character.
-        self.expect(
-            "set set show-statusline false", ["\x1b[1;0r"]
-        )
+        self.expect("set set show-statusline false", ["\x1b[1;0r"])
 
     def test_no_color(self):
         """Basic test for the statusline with colors disabled."""


### PR DESCRIPTION
Terminal resizing continues to be a source of statusline bugs, so much so that some users have started disabling it altogether. Different operating systems and terminal emulators exhibit subtly different behaviors, making it nearly impossible to handle resizing reliably across the board.

This patch sidesteps those issues by clearing the entire screen when the terminal is resized. This avoids having to account for the previous, potentially wrapped statusline, the underlying cause of many of the aforementioned bugs.

The obvious downside is that this clears the on-screen history, but I believe that’s a reasonable trade-off. Note that this only happens when resizing the terminal; when launching LLDB, the statusline is drawn without clearing the screen.

rdar://154778410