### PR TITLE
Fix missing group signature symbol when signature is a section name

### DIFF
--- a/llvm/lib/MC/ELFObjectWriter.cpp
+++ b/llvm/lib/MC/ELFObjectWriter.cpp
@@ -489,7 +489,7 @@ bool ELFWriter::isInSymtab(const MCSymbolELF &Symbol) {
   if (Symbol.isTemporary())
     return false;
 
-  return Symbol.getType() != ELF::STT_SECTION;
+  return Symbol.getType() != ELF::STT_SECTION || Symbol.isSignature();
 }
 
 void ELFWriter::computeSymbolTable(const RevGroupMapTy &RevGroupMap) {

--- a/llvm/test/MC/ELF/ARM/group-section-info.s
+++ b/llvm/test/MC/ELF/ARM/group-section-info.s
@@ -1,0 +1,17 @@
+# RUN: llvm-mc %s -triple armv7-elf -filetype obj -o %t1.1.o
+# RUN: llvm-readelf -Ss %t1.1.o | FileCheck %s
+# This test checks the value of sh_info group section when the group signature
+# is the same as a section name.
+
+# CHECK: Section Headers
+# CHECK: foo
+# CHECK: .group {{.*}} 04 6 1
+# CHECK: A {{.*}} AXG
+
+# CHECK: Symbol table
+# CHECK: 1: {{.*}} foo
+
+  .section foo,"ax",%progbits
+  .globl main
+main:
+  .section A,"axG",%progbits,foo

--- a/llvm/test/MC/ELF/RISCV/group-section-info.s
+++ b/llvm/test/MC/ELF/RISCV/group-section-info.s
@@ -1,0 +1,18 @@
+# RUN: llvm-mc %s -triple riscv64 -filetype obj -o %t1.1.o
+# RUN: llvm-readelf -Ss %t1.1.o | FileCheck %s
+# This test checks the value of sh_info group section when the group signature
+# is the same as a section name.
+
+# CHECK: Section Headers
+# CHECK: foo
+# CHECK: .group {{.*}} 04 6 1
+# CHECK: A {{.*}} AXG
+
+# CHECK: Symbol table
+# CHECK: 1: {{.*}} foo
+
+  .section foo,"ax",@progbits
+  .globl main
+main:
+  .section A,"axG",@progbits,foo
+

--- a/llvm/test/MC/ELF/RISCV/lit.local.cfg
+++ b/llvm/test/MC/ELF/RISCV/lit.local.cfg
@@ -1,2 +1,3 @@
 if "RISCV" not in config.root.targets:
     config.unsupported = True
+config.unsupported = False


### PR DESCRIPTION
This commit fixes the missing group signature symbol and consequently .group(sh_info) being incorrectly set to 0 when the group signature symbol is the same as a section name. The root cause of the issue was that the section symbols were not getting inserted to the symbol table unless they were required for a relocation.

It seems that the regression is caused by the commit 1108cf64196a056aa350baba98e3fab6d7529a59. We are seeing build failures in our builders due to this change.

Closes #146581
