### PR TITLE
[llvm-c] APIs for acquiring and releasing ThreadSafeContext locks

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -256,6 +256,9 @@ Changes to the C API
 * Added ``LLVMGetICmpSameSign`` and ``LLVMSetICmpSameSign`` for the `samesign`
   flag on `icmp` instructions.
 
+* Added `LLVMOrcThreadSafeContextGetLock` and `LLVMOrcThreadSafeContextReleaseLock`
+  for acquiring and releasing locks associated with `ThreadSafeContext` instances.
+
 Changes to the CodeGen infrastructure
 -------------------------------------
 

--- a/llvm/include/llvm-c/Orc.h
+++ b/llvm/include/llvm-c/Orc.h
@@ -386,6 +386,12 @@ typedef int (*LLVMOrcSymbolPredicate)(void *Ctx,
 typedef struct LLVMOrcOpaqueThreadSafeContext *LLVMOrcThreadSafeContextRef;
 
 /**
+ * A reference to an orc::ThreadSafeContext::Lock instance.
+ */
+typedef struct LLVMOrcOpaqueThreadSafeContextLock
+    *LLVMOrcThreadSafeContextLockRef;
+
+/**
  * A reference to an orc::ThreadSafeModule instance.
  */
 typedef struct LLVMOrcOpaqueThreadSafeModule *LLVMOrcThreadSafeModuleRef;
@@ -1081,6 +1087,18 @@ LLVMOrcThreadSafeContextGetContext(LLVMOrcThreadSafeContextRef TSCtx);
  * Dispose of a ThreadSafeContext.
  */
 void LLVMOrcDisposeThreadSafeContext(LLVMOrcThreadSafeContextRef TSCtx);
+
+/**
+ * Acquire the lock associated with a ThreadSafeContext.
+ */
+LLVMOrcThreadSafeContextLockRef
+LLVMOrcThreadSafeContextGetLock(LLVMOrcThreadSafeContextRef TSCtx);
+
+/**
+ * Release the lock associated with a ThreadSafeContext.
+ */
+void LLVMOrcThreadSafeContextReleaseLock(
+    LLVMOrcThreadSafeContextLockRef TSCtxLock);
 
 /**
  * Create a ThreadSafeModule wrapper around the given LLVM module. This takes

--- a/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcV2CBindings.cpp
@@ -61,6 +61,8 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DefinitionGenerator,
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(InProgressLookupState, LLVMOrcLookupStateRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ThreadSafeContext,
                                    LLVMOrcThreadSafeContextRef)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ThreadSafeContext::Lock,
+                                   LLVMOrcThreadSafeContextLockRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(ThreadSafeModule, LLVMOrcThreadSafeModuleRef)
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(JITTargetMachineBuilder,
                                    LLVMOrcJITTargetMachineBuilderRef)
@@ -736,6 +738,16 @@ LLVMOrcThreadSafeContextGetContext(LLVMOrcThreadSafeContextRef TSCtx) {
 
 void LLVMOrcDisposeThreadSafeContext(LLVMOrcThreadSafeContextRef TSCtx) {
   delete unwrap(TSCtx);
+}
+
+LLVMOrcThreadSafeContextLockRef
+LLVMOrcThreadSafeContextGetLock(LLVMOrcThreadSafeContextRef TSCtx) {
+  return wrap(new ThreadSafeContext::Lock(std::move(unwrap(TSCtx)->getLock())));
+}
+
+void LLVMOrcThreadSafeContextReleaseLock(
+    LLVMOrcThreadSafeContextLockRef TSCtxLock) {
+  delete unwrap(TSCtxLock);
 }
 
 LLVMErrorRef


### PR DESCRIPTION
This PR exposes to the C bindings the `ThreadSafeContext.getLock()` method and adds another for releasing the lock.