### PR TITLE
[lldb][mcp] Fix unix domain socket protocol server addresses

### DIFF
--- a/lldb/source/Commands/CommandObjectProtocolServer.cpp
+++ b/lldb/source/Commands/CommandObjectProtocolServer.cpp
@@ -75,9 +75,12 @@ protected:
 
     ProtocolServer::Connection connection;
     connection.protocol = protocol_and_mode->first;
-    connection.name =
-        formatv("[{0}]:{1}", uri->hostname.empty() ? "0.0.0.0" : uri->hostname,
-                uri->port.value_or(0));
+    if (connection.protocol == Socket::SocketProtocol::ProtocolUnixDomain)
+      connection.name = uri->path;
+    else
+      connection.name = formatv(
+          "[{0}]:{1}", uri->hostname.empty() ? "0.0.0.0" : uri->hostname,
+          uri->port.value_or(0));
 
     if (llvm::Error error = server->Start(connection)) {
       result.AppendErrorWithFormatv("{0}", llvm::fmt_consume(std::move(error)));

--- a/lldb/source/Commands/CommandObjectProtocolServer.cpp
+++ b/lldb/source/Commands/CommandObjectProtocolServer.cpp
@@ -93,6 +93,7 @@ protected:
       result.AppendMessageWithFormatv(
           "{0} server started with connection listeners: {1}", protocol,
           address);
+      result.SetStatus(eReturnStatusSuccessFinishNoResult);
     }
   }
 };

--- a/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
+++ b/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
@@ -1,8 +1,13 @@
 import os
 import tempfile
+import unittest
 
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
+
+# To be safe and portable, Unix domain socket paths should be kept at or below
+# 108 characters on Linux, and around 104 characters on macOS:
+MAX_SOCKET_PATH_LENGTH = 104
 
 
 class MCPUnixSocketCommandTestCase(TestBase):
@@ -15,6 +20,11 @@ class MCPUnixSocketCommandTestCase(TestBase):
 
         temp_directory = tempfile.TemporaryDirectory()
         socket_file = os.path.join(temp_directory.name, "mcp.sock")
+
+        if len(socket_file) >= MAX_SOCKET_PATH_LENGTH:
+            self.skipTest(
+                f"Socket path {socket_file} exceeds the {MAX_SOCKET_PATH_LENGTH} character limit"
+            )
 
         self.expect(
             f"protocol-server start MCP accept://{socket_file}",

--- a/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
+++ b/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
@@ -1,0 +1,23 @@
+import os
+import tempfile
+
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class MCPUnixSocketCommandTestCase(TestBase):
+    @skipIfWindows
+    @no_debug_info_test
+    def test_unix_socket(self):
+        """
+        Test if we can start an MCP protocol-server accepting unix sockets
+        """
+
+        temp_directory = tempfile.TemporaryDirectory()
+        socket_file = os.path.join(temp_directory.name, "mcp.sock")
+
+        self.expect(
+            f"protocol-server start MCP accept://{socket_file}",
+            startstr="MCP server started with connection listeners:",
+            substrs=[f"unix-connect://{socket_file}"],
+        )


### PR DESCRIPTION
When starting an MCP protocol server that uses unix sockets as the transport, a local `'[0.0.0.0]:0'` file is used instead of the supplied socket path, e.g:
```
(lldb) protocol-server start MCP accept:///tmp/some/path.sock
MCP server started with connection listeners: unix-connect://[0.0.0.0]:0
(lldb) shell ls '[*'
[0.0.0.0]:0
```

This change makes it so that the URI path is used if the socket protocol is `ProtocolUnixDomain`:
```
(lldb) protocol-server start MCP accept:///tmp/some/path.sock
MCP server started with connection listeners: unix-connect:///tmp/some/path.sock
```
