### PR TITLE
[CIR] Add mlir-translate to CMake

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -114,6 +114,7 @@ if(CLANG_ENABLE_CIR)
   list(APPEND CLANG_TEST_DEPS
     cir-opt
     cir-translate
+    mlir-translate
     )
 endif()
 


### PR DESCRIPTION
This PR adds the `mlir-translate` dependency to CIR.

The following test was failing when running `ninja check-clang-cir`:

```
CIR/Lowering/stack-save-restore.cir  
line 2: mlir-translate: command not found
```

The failure occurred because `mlir-translate` was not being built as part of the CIR test dependencies. This PR ensures that the target is properly built so the test can run successfully.