### PR TITLE
[lldb] Fix the hardware breakpoint decorator

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/base.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/base.py
@@ -14,5 +14,15 @@ class HardwareBreakpointTestBase(TestBase):
         self.runCmd("breakpoint set -b main --hardware")
         self.runCmd("run")
         if "stopped" in self.res.GetOutput():
+            return True
+        return False
+
+    def hw_breakpoints_supported(self):
+        if self.supports_hw_breakpoints():
             return "Hardware breakpoints are supported"
+        return None
+
+    def hw_breakpoints_unsupported(self):
+        if not self.supports_hw_breakpoints():
+            return "Hardware breakpoints are unsupported"
         return None

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/hardware_breakpoint_on_multiple_threads/TestHWBreakMultiThread.py
@@ -12,16 +12,13 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 
 
 class HardwareBreakpointMultiThreadTestCase(HardwareBreakpointTestBase):
-    def does_not_support_hw_breakpoints(self):
-        return not super().supports_hw_breakpoints()
-
-    @skipTestIfFn(does_not_support_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
     def test_hw_break_set_delete_multi_thread_macos(self):
         self.build()
         self.setTearDownCleanup()
         self.break_multi_thread("delete")
 
-    @skipTestIfFn(does_not_support_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_unsupported)
     def test_hw_break_set_disable_multi_thread_macos(self):
         self.build()
         self.setTearDownCleanup()

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/require_hw_breakpoints/TestRequireHWBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/require_hw_breakpoints/TestRequireHWBreakpoints.py
@@ -26,7 +26,7 @@ class BreakpointLocationsTestCase(HardwareBreakpointTestBase):
         breakpoint = target.BreakpointCreateByLocation("main.c", 1)
         self.assertTrue(breakpoint.IsHardware())
 
-    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_supported)
     def test_step_range(self):
         """Test stepping when hardware breakpoints are required."""
         self.build()
@@ -49,7 +49,7 @@ class BreakpointLocationsTestCase(HardwareBreakpointTestBase):
             "Could not create hardware breakpoint for thread plan", error.GetCString()
         )
 
-    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_supported)
     def test_step_out(self):
         """Test stepping out when hardware breakpoints are required."""
         self.build()
@@ -71,7 +71,7 @@ class BreakpointLocationsTestCase(HardwareBreakpointTestBase):
             "Could not create hardware breakpoint for thread plan", error.GetCString()
         )
 
-    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_supported)
     def test_step_over(self):
         """Test stepping over when hardware breakpoints are required."""
         self.build()
@@ -91,7 +91,7 @@ class BreakpointLocationsTestCase(HardwareBreakpointTestBase):
 
     # Was reported to sometimes pass on certain hardware.
     @skipIf(oslist=["linux"], archs=["arm$"])
-    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.hw_breakpoints_supported)
     def test_step_until(self):
         """Test stepping until when hardware breakpoints are required."""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/hardware_breakpoints/write_memory_with_hw_breakpoint/TestWriteMemoryWithHWBreakpoint.py
@@ -12,10 +12,9 @@ from functionalities.breakpoint.hardware_breakpoints.base import *
 
 
 class WriteMemoryWithHWBreakpoint(HardwareBreakpointTestBase):
-    def does_not_support_hw_breakpoints(self):
-        return not super().supports_hw_breakpoints()
 
-    @skipTestIfFn(does_not_support_hw_breakpoints)
+    @skipTestIfFn(HardwareBreakpointTestBase.supports_hw_breakpoints)
+    @skip
     def test_copy_memory_with_hw_break(self):
         self.build()
         exe = self.getBuildArtifact("a.out")


### PR DESCRIPTION
A decorator to skip or XFAIL a test takes effect when the function that's passed in returns a reason string. The wrappers around hw_breakpoints_supported were doing that incorrectly by inverting (calling `not`) on the result, turning it into a boolean, which means the test is always skipped.