### PR TITLE
[flang][prescanner] fix invalid check

### DIFF
--- a/flang/lib/Parser/token-sequence.cpp
+++ b/flang/lib/Parser/token-sequence.cpp
@@ -30,6 +30,7 @@ void TokenSequence::clear() {
 
 void TokenSequence::pop_back() {
   CHECK(!start_.empty());
+  // If the last token is empty then `nextStart_ == start_.back()`.
   CHECK(nextStart_ >= start_.back());
   std::size_t bytes{nextStart_ - start_.back()};
   nextStart_ = start_.back();

--- a/flang/lib/Parser/token-sequence.cpp
+++ b/flang/lib/Parser/token-sequence.cpp
@@ -30,7 +30,7 @@ void TokenSequence::clear() {
 
 void TokenSequence::pop_back() {
   CHECK(!start_.empty());
-  CHECK(nextStart_ > start_.back());
+  CHECK(nextStart_ >= start_.back());
   std::size_t bytes{nextStart_ - start_.back()};
   nextStart_ = start_.back();
   start_.pop_back();

--- a/flang/test/Parser/issue-146362.1.f90
+++ b/flang/test/Parser/issue-146362.1.f90
@@ -1,0 +1,5 @@
+! RUN: %flang_fc1 -fsyntax-only -cpp %s 2>&1
+#define UNITY(k) 1_ ## k
+PROGRAM REPRODUCER
+WRITE(*,*) UNITY(4)
+END PROGRAM REPRODUCER


### PR DESCRIPTION
`TokenSequence::pop_back()` had a check assumed that tokens are never empty. Loosen this check since isn't true.

towards #146362 