### PR TITLE
Account for inline assembly instructions in inlining cost.

### DIFF
--- a/llvm/test/Transforms/Inline/inline-call-with-asm-call.ll
+++ b/llvm/test/Transforms/Inline/inline-call-with-asm-call.ll
@@ -1,0 +1,23 @@
+;; Test to verify that when callee has inline assembly, bumping up `-inline-asm-instr-cost` would block inlining.
+
+; RUN: opt < %s -passes=inline -S | FileCheck %s --check-prefixes=INLINE
+; RUN: opt < %s -passes='cgscc(inline)' -S | FileCheck %s --check-prefixes=INLINE
+; RUN: opt < %s -passes=inline -inline-asm-instr-cost=150 -S | FileCheck %s --check-prefixes=INLINE
+; RUN: opt < %s -passes='cgscc(inline)' -inline-asm-instr-cost=150 -S | FileCheck %s --check-prefixes=INLINE
+; RUN: opt < %s -passes=inline -inline-asm-instr-cost=300 -S | FileCheck %s --check-prefixes=NOINLINE
+; RUN: opt < %s -passes='cgscc(inline)' -inline-asm-instr-cost=300 -S | FileCheck %s --check-prefixes=NOINLINE
+
+; CHECK-LABEL: caller
+; CHECK-NOT: callee
+; INLINE: call void asm
+; NOINLINE: call void @callee
+
+define void @caller(i32 %a, i1 %b) #0 {
+  call void @callee(i32 %a, i1 %b)
+  ret void
+}
+
+define void @callee(i32 %a, i1 %b) {
+  call void asm sideeffect "s_nop 1\0A\09.pushsection other\0A\09s_nop 2\0A\09s_nop 3\0A\09.popsection\0A\09s_nop 4\0A\09.align 32", ""()
+  ret void
+}

--- a/llvm/test/Transforms/Inline/inline-call-with-asm-call.ll
+++ b/llvm/test/Transforms/Inline/inline-call-with-asm-call.ll
@@ -1,23 +1,35 @@
 ;; Test to verify that when callee has inline assembly, bumping up `-inline-asm-instr-cost` would block inlining.
 
-; RUN: opt < %s -passes=inline -S | FileCheck %s --check-prefixes=INLINE
-; RUN: opt < %s -passes='cgscc(inline)' -S | FileCheck %s --check-prefixes=INLINE
-; RUN: opt < %s -passes=inline -inline-asm-instr-cost=150 -S | FileCheck %s --check-prefixes=INLINE
-; RUN: opt < %s -passes='cgscc(inline)' -inline-asm-instr-cost=150 -S | FileCheck %s --check-prefixes=INLINE
-; RUN: opt < %s -passes=inline -inline-asm-instr-cost=300 -S | FileCheck %s --check-prefixes=NOINLINE
-; RUN: opt < %s -passes='cgscc(inline)' -inline-asm-instr-cost=300 -S | FileCheck %s --check-prefixes=NOINLINE
+; RUN: opt < %s -passes=inline -S | FileCheck %s --check-prefixes=CHECK,INLINE
+; RUN: opt < %s -passes='cgscc(inline)' -S | FileCheck %s --check-prefixes=CHECK,INLINE
 
-; CHECK-LABEL: caller
-; CHECK-NOT: callee
-; INLINE: call void asm
-; NOINLINE: call void @callee
+;; Verify that a low assembly instruction cost of 150 does not block inlining.
+;; This test also verifies that the outlined section's instructions (in "other"
+;; section) do not contribute to the cost.
+; RUN: opt < %s -passes=inline -inline-asm-instr-cost=150 -S | FileCheck %s --check-prefixes=CHECK,INLINE
+; RUN: opt < %s -passes='cgscc(inline)' -inline-asm-instr-cost=150 -S | FileCheck %s --check-prefixes=CHECK,INLINE
+
+;; Verify that an assembly instruction cost of 300 blocks inlining.
+; RUN: opt < %s -passes=inline -inline-asm-instr-cost=300 -S | FileCheck %s --check-prefixes=CHECK,NOINLINE
+; RUN: opt < %s -passes='cgscc(inline)' -inline-asm-instr-cost=300 -S | FileCheck %s --check-prefixes=CHECK,NOINLINE
 
 define void @caller(i32 %a, i1 %b) #0 {
   call void @callee(i32 %a, i1 %b)
   ret void
 }
 
+; CHECK: define void @caller
+; INLINE: call void asm
+; NOINLINE: call void @callee
+
+
+;; callee function with asm call with two real assembly instructions in the
+;; destination section and two assembly instructions in the outlined "other"
+;; section.
 define void @callee(i32 %a, i1 %b) {
   call void asm sideeffect "s_nop 1\0A\09.pushsection other\0A\09s_nop 2\0A\09s_nop 3\0A\09.popsection\0A\09s_nop 4\0A\09.align 32", ""()
   ret void
 }
+; CHECK: define void @callee
+
+


### PR DESCRIPTION
Inliner currently treats every "call asm" IR instruction as a single instruction regardless of how many instructions the inline assembly may contain. This may underestimate the cost of inlining for a callee containing long inline assembly. Besides, we may need to assign a higher cost to instructions in inline assembly since they cannot be analyzed and optimized by the compiler.

This PR introduces a new option `-inline-asm-instr-cost` -- set zero by default, which can control the cost of inline assembly instructions in inliner's cost-benefit analysis.