### PR TITLE
clang: Fix parsing of seh exception model

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3682,12 +3682,13 @@ static StringRef GetInputKindName(InputKind IK) {
 static StringRef getExceptionHandlingName(unsigned EHK) {
   switch (static_cast<LangOptions::ExceptionHandlingKind>(EHK)) {
   case LangOptions::ExceptionHandlingKind::None:
-  default:
     return "none";
-  case LangOptions::ExceptionHandlingKind::SjLj:
-    return "sjlj";
   case LangOptions::ExceptionHandlingKind::DwarfCFI:
     return "dwarf";
+  case LangOptions::ExceptionHandlingKind::SjLj:
+    return "sjlj";
+  case LangOptions::ExceptionHandlingKind::WinEH:
+    return "seh";
   case LangOptions::ExceptionHandlingKind::Wasm:
     return "wasm";
   }
@@ -4028,7 +4029,7 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
               A->getValue())
               .Case("dwarf", LangOptions::ExceptionHandlingKind::DwarfCFI)
               .Case("sjlj", LangOptions::ExceptionHandlingKind::SjLj)
-              .Case("wineh", LangOptions::ExceptionHandlingKind::WinEH)
+              .Case("seh", LangOptions::ExceptionHandlingKind::WinEH)
               .Case("wasm", LangOptions::ExceptionHandlingKind::Wasm)
               .Case("none", LangOptions::ExceptionHandlingKind::None)
               .Default(std::nullopt);

--- a/clang/test/Modules/mingw-exceptions.cppm
+++ b/clang/test/Modules/mingw-exceptions.cppm
@@ -1,0 +1,4 @@
+// RUN: %clang -target x86_64-windows-gnu -x c++-module -std=gnu++23 -c -o /dev/null -Xclang -disable-llvm-passes %s
+
+// Make sure the command succeeds and doesn't break on the -exception-model flag in cc1.
+export module empty;


### PR DESCRIPTION
Fixes regression reported https://github.com/llvm/llvm-project/pull/146342#issuecomment-3026600152

The test could probably be better. I'm not sure what special is happening with the module
compile, but I can't seem to reproduce this with just a plain -cc1 run.