### PR TITLE
[clang][CodeComplete] skip explicit obj param in SignatureHelp

### DIFF
--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -3312,7 +3312,7 @@ TEST(SignatureHelpTest, SkipExplicitObjectParameter) {
                                       *Preamble, Inputs, MarkupKind::PlainText);
     // TODO: We expect 1 signature here, with this signature
     EXPECT_EQ(0U, Result.signatures.size());
-    // EXPECT_THAT(Result.signatures[0], AllOf(sig("([[A&&]], [[int]]) ->
+    // EXPECT_THAT(Result.signatures[0], AllOf(sig("([[auto&&]], [[int]]) ->
     // void")));
   }
 }
@@ -4432,8 +4432,8 @@ TEST(CompletionTest, SkipExplicitObjectParameter) {
 
   // TODO: llvm/llvm-project/146649
   // This is incorrect behavior. Correct Result should be a variant of,
-  // c2: signature = (A&& self, int arg)
-  //     snippet = (${1: A&& self}, ${2: int arg})
+  // c2: signature = (auto&& self, int arg)
+  //     snippet = (${1: auto&& self}, ${2: int arg})
   // c3: signature = (A self, int arg)
   //     snippet = (${1: A self}, ${2: int arg})
 

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -3307,12 +3307,12 @@ TEST(SignatureHelpTest, SkipExplicitObjectParameter) {
     EXPECT_THAT(Result.signatures[0], AllOf(sig("([[A]], [[int]]) -> void")));
   }
   {
+    // TODO: llvm/llvm-project/146649
     const auto Result = signatureHelp(testPath(TU.Filename), Code.point("c3"),
                                       *Preamble, Inputs, MarkupKind::PlainText);
-    // TODO: We expect 1 signature here
-    // EXPECT_EQ(1U, Result.signatures.size());
-
-    // EXPECT_THAT(Result.signatures[0], AllOf(sig("([[A]], [[int]]) ->
+    // TODO: We expect 1 signature here, with this signature
+    EXPECT_EQ(0U, Result.signatures.size());
+    // EXPECT_THAT(Result.signatures[0], AllOf(sig("([[A&&]], [[int]]) ->
     // void")));
   }
 }
@@ -4424,11 +4424,18 @@ TEST(CompletionTest, SkipExplicitObjectParameter) {
 
     int main() {
       A a {};
-      a.$c1^
-      (&A::ba$c2^;
-      (&A::fo$c3^;
+      a.$c1^;
+      (&A::fo$c2^;
+      (&A::ba$c3^;
     }
   )cpp");
+
+  // TODO: llvm/llvm-project/146649
+  // This is incorrect behavior. Correct Result should be a variant of,
+  // c2: signature = (A&& self, int arg)
+  //     snippet = (${1: A&& self}, ${2: int arg})
+  // c3: signature = (A self, int arg)
+  //     snippet = (${1: A self}, ${2: int arg})
 
   auto TU = TestTU::withCode(Code.code());
   TU.ExtraArgs = {"-std=c++23"};
@@ -4444,27 +4451,26 @@ TEST(CompletionTest, SkipExplicitObjectParameter) {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c1"),
                                Preamble.get(), Inputs, Opts);
 
-    EXPECT_THAT(
-        Result.Completions,
-        UnorderedElementsAre(
-            AllOf(named("foo"), signature("(int arg)"), snippetSuffix("")),
-            AllOf(named("bar"), signature("(int arg)"), snippetSuffix(""))));
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(AllOf(named("foo"), signature("(int arg)"),
+                                           snippetSuffix("(${1:int arg})")),
+                                     AllOf(named("bar"), signature("(int arg)"),
+                                           snippetSuffix("(${1:int arg})"))));
   }
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c2"),
-                               Preamble.get(), Inputs, Opts);
-    // TODO: snippet suffix is empty for c2
-    EXPECT_THAT(Result.Completions,
-                ElementsAre(AllOf(named("bar"), signature("(int arg)"),
-                                  snippetSuffix(""))));
-  }
-  {
-    auto Result = codeComplete(testPath(TU.Filename), Code.point("c3"),
                                Preamble.get(), Inputs, Opts);
     EXPECT_THAT(
         Result.Completions,
         ElementsAre(AllOf(named("foo"), signature("<class self:auto>(int arg)"),
                           snippetSuffix("<${1:class self:auto}>"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c3"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                ElementsAre(AllOf(named("bar"), signature("(int arg)"),
+                                  snippetSuffix(""))));
   }
 }
 } // namespace

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -4034,6 +4034,14 @@ static void AddOverloadParameterChunks(
       return;
     }
 
+    // C++23 introduces an explicit object parameter, a.k.a. "deducing this"
+    // Skip it for autocomplete and treat the next parameter as the first
+    // parameter
+    if (Function && FirstParameter &&
+        Function->getParamDecl(P)->isExplicitObjectParameter()) {
+      continue;
+    }
+
     if (FirstParameter)
       FirstParameter = false;
     else

--- a/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
+++ b/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
@@ -27,6 +27,10 @@ int func2() {
 // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):9 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC2 %s
 // CHECK-CC2: OVERLOAD: [#void#]foo(int arg)
 
+// TODO: llvm/llvm-project/146649
+// This is incorrect behavior. Correct Result should be a variant of, 
+// CC3: should be something like [#void#]foo(<#A self#>, <#int arg#>)
+// CC4: should be something like [#void#]bar(<#A self#>, <#int arg#>)
 int func3() {
   (&A::foo)
   (&A::bar)

--- a/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
+++ b/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
@@ -6,9 +6,21 @@ int main() {
   A a {};
   a.
 }
-// RUN: %clang_cc1 -cc1 -fsyntax-only -code-completion-at=%s:%(line-2):5 -std=c++23 %s | FileCheck %s
-// CHECK: COMPLETION: A : A::
-// CHECK-NEXT: COMPLETION: foo : [#void#]foo(<#int arg#>)
-// CHECK-NEXT: COMPLETION: operator= : [#A &#]operator=(<#const A &#>)
-// CHECK-NEXT: COMPLETION: operator= : [#A &#]operator=(<#A &&#>)
-// CHECK-NEXT: COMPLETION: ~A : [#void#]~A()
+// RUN: %clang_cc1 -cc1 -fsyntax-only -code-completion-at=%s:%(line-2):5 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC1 %s
+// CHECK-CC1: COMPLETION: A : A::
+// CHECK-NEXT-CC1: COMPLETION: foo : [#void#]foo(<#int arg#>)
+// CHECK-NEXT-CC1: COMPLETION: operator= : [#A &#]operator=(<#const A &#>)
+// CHECK-NEXT-CC1: COMPLETION: operator= : [#A &#]operator=(<#A &&#>)
+// CHECK-NEXT-CC1: COMPLETION: ~A : [#void#]~A()
+
+struct B {
+  template <typename T>
+  void foo(this T&& self, int arg);
+};
+
+int main2() {
+  B b {};
+  b.foo();
+}
+// RUN: %clang_cc1 -cc1 -fsyntax-only -code-completion-at=%s:%(line-2):9 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC2 %s
+// CHECK-CC2: OVERLOAD: [#void#]foo(int arg)

--- a/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
+++ b/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
@@ -28,15 +28,17 @@ int func2() {
 // CHECK-CC2: OVERLOAD: [#void#]foo(int arg)
 
 int func3() {
-  // TODO: (&A::foo)
+  (&A::foo)
   (&A::bar)
 }
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):10 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC3 %s
-// CHECK-CC3: COMPLETION: bar : [#void#]bar(<#int arg#>)
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-3):10 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC3 %s
+// CHECK-CC3: COMPLETION: foo : [#void#]foo<<#class self:auto#>>(<#int arg#>)
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-4):10 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC4 %s
+// CHECK-CC4: COMPLETION: bar : [#void#]bar(<#int arg#>)
 
 int func4() {
-  // TODO: (&A::foo)(
+  // TODO (&A::foo)(
   (&A::bar)(
 }
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC4 %s
-// CHECK-CC4: OVERLOAD: [#void#](<#A#>, int)
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC5 %s
+// CHECK-CC5: OVERLOAD: [#void#](<#A#>, int)

--- a/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
+++ b/clang/test/CodeCompletion/skip-explicit-object-parameter.cpp
@@ -1,13 +1,15 @@
 struct A {
-  void foo(this A self, int arg);
+  void foo(this auto&& self, int arg);
+  void bar(this A self, int arg);
 };
 
-int main() {
+int func1() {
   A a {};
   a.
 }
-// RUN: %clang_cc1 -cc1 -fsyntax-only -code-completion-at=%s:%(line-2):5 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC1 %s
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):5 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC1 %s
 // CHECK-CC1: COMPLETION: A : A::
+// CHECK-NEXT-CC1: COMPLETION: bar : [#void#]bar(<#int arg#>)
 // CHECK-NEXT-CC1: COMPLETION: foo : [#void#]foo(<#int arg#>)
 // CHECK-NEXT-CC1: COMPLETION: operator= : [#A &#]operator=(<#const A &#>)
 // CHECK-NEXT-CC1: COMPLETION: operator= : [#A &#]operator=(<#A &&#>)
@@ -18,9 +20,23 @@ struct B {
   void foo(this T&& self, int arg);
 };
 
-int main2() {
+int func2() {
   B b {};
   b.foo();
 }
-// RUN: %clang_cc1 -cc1 -fsyntax-only -code-completion-at=%s:%(line-2):9 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC2 %s
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):9 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC2 %s
 // CHECK-CC2: OVERLOAD: [#void#]foo(int arg)
+
+int func3() {
+  // TODO: (&A::foo)
+  (&A::bar)
+}
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):10 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC3 %s
+// CHECK-CC3: COMPLETION: bar : [#void#]bar(<#int arg#>)
+
+int func4() {
+  // TODO: (&A::foo)(
+  (&A::bar)(
+}
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC4 %s
+// CHECK-CC4: OVERLOAD: [#void#](<#A#>, int)


### PR DESCRIPTION
Fixes clangd/clangd#2284.

Seems like the code segment here is similar to the one that I updated in the previous PR #146258. It seems like the code is dissimilar enough in both the function bodies that it probably isn't possible to cleanly move it into a single place to prevent repetition. 

My current understanding is that this line checks that the given overload exists, but not that other overloads do not, right? How do I ensure that this is the _only_ overload? 

```
CHECK-CC2: OVERLOAD: [#void#]foo(int arg)
```

Please let me know if any other improvements can be made! 