### PR TITLE
[RISCV] Check whether plain type is supported for permutation intrinsics instead of its float type

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoVPseudos.td
@@ -4567,7 +4567,8 @@ multiclass VPatUnaryS_M<string intrinsic_name,
 multiclass VPatUnaryV_V_AnyMask<string intrinsic, string instruction,
                                 list<VTypeInfo> vtilist> {
   foreach vti = vtilist in {
-    let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in
+    defvar ivti = GetIntVTypeInfo<vti>.Vti;
+    let Predicates = GetVTypePredicates<ivti>.Predicates in
     def : VPatUnaryAnyMask<intrinsic, instruction, "VM",
                            vti.Vector, vti.Vector, vti.Mask,
                            vti.Log2SEW, vti.LMul, vti.RegClass, vti.RegClass>;
@@ -4886,7 +4887,7 @@ multiclass VPatBinaryV_VV_INT<string intrinsic, string instruction,
                               list<VTypeInfo> vtilist> {
   foreach vti = vtilist in {
     defvar ivti = GetIntVTypeInfo<vti>.Vti;
-    let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in
+    let Predicates = GetVTypePredicates<ivti>.Predicates in
     defm : VPatBinary<intrinsic,
                       instruction # "_VV_" # vti.LMul.MX # "_E" # vti.SEW,
                       vti.Vector, vti.Vector, ivti.Vector, vti.Mask,
@@ -4903,15 +4904,16 @@ multiclass VPatBinaryV_VV_INT_EEW<string intrinsic, string instruction,
     defvar octuple_lmul = vlmul.octuple;
     defvar octuple_emul = !srl(!mul(octuple_lmul, eew), vti.Log2SEW);
     if !and(!ge(octuple_emul, 1), !le(octuple_emul, 64)) then {
+      defvar ivti = GetIntVTypeInfo<vti>.Vti;
       defvar emul_str = octuple_to_str<octuple_emul>.ret;
-      defvar ivti = !cast<VTypeInfo>("VI" # eew # emul_str);
       defvar inst = instruction # "_VV_" # vti.LMul.MX # "_E" # vti.SEW # "_" # emul_str;
-      let Predicates = !listconcat(GetVTypeMinimalPredicates<vti>.Predicates,
-                                   GetVTypeMinimalPredicates<ivti>.Predicates) in
+      defvar eivti = !cast<VTypeInfo>("VI" # eew # emul_str);
+      let Predicates = !listconcat(GetVTypePredicates<ivti>.Predicates,
+                                   GetVTypePredicates<eivti>.Predicates) in
       defm : VPatBinary<intrinsic, inst,
-                        vti.Vector, vti.Vector, ivti.Vector, vti.Mask,
+                        vti.Vector, vti.Vector, eivti.Vector, vti.Mask,
                         vti.Log2SEW, vti.RegClass,
-                        vti.RegClass, ivti.RegClass>;
+                        vti.RegClass, eivti.RegClass>;
     }
   }
 }
@@ -4948,12 +4950,14 @@ multiclass VPatBinaryV_VX_RM<string intrinsic, string instruction,
 
 multiclass VPatBinaryV_VX_INT<string intrinsic, string instruction,
                           list<VTypeInfo> vtilist> {
-  foreach vti = vtilist in
-    let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in
+  foreach vti = vtilist in {
+    defvar ivti = GetIntVTypeInfo<vti>.Vti;
+    let Predicates = GetVTypePredicates<ivti>.Predicates in
     defm : VPatBinary<intrinsic, instruction # "_VX_" # vti.LMul.MX,
                       vti.Vector, vti.Vector, XLenVT, vti.Mask,
                       vti.Log2SEW, vti.RegClass,
                       vti.RegClass, GPR>;
+  }
 }
 
 multiclass VPatBinaryV_VI<string intrinsic, string instruction,
@@ -4980,12 +4984,14 @@ multiclass VPatBinaryV_VI_RM<string intrinsic, string instruction,
 
 multiclass VPatBinaryV_VI_INT<string intrinsic, string instruction,
                               list<VTypeInfo> vtilist, Operand imm_type> {
-  foreach vti = vtilist in
-    let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in
+  foreach vti = vtilist in {
+    defvar ivti = GetIntVTypeInfo<vti>.Vti;
+    let Predicates = GetVTypePredicates<ivti>.Predicates in
     defm : VPatBinary<intrinsic, instruction # "_VI_" # vti.LMul.MX,
                       vti.Vector, vti.Vector, XLenVT, vti.Mask,
                       vti.Log2SEW, vti.RegClass,
                       vti.RegClass, imm_type>;
+  }
 }
 
 multiclass VPatBinaryM_MM<string intrinsic, string instruction> {
@@ -5573,12 +5579,14 @@ multiclass VPatTernaryV_VV_AAXA_RM<string intrinsic, string instruction,
 
 multiclass VPatTernaryV_VX<string intrinsic, string instruction,
                            list<VTypeInfo> vtilist> {
-  foreach vti = vtilist in
-    let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in
+  foreach vti = vtilist in {
+    defvar ivti = GetIntVTypeInfo<vti>.Vti;
+    let Predicates = GetVTypePredicates<ivti>.Predicates in
     defm : VPatTernaryWithPolicy<intrinsic, instruction, "VX",
                                  vti.Vector, vti.Vector, XLenVT, vti.Mask,
                                  vti.Log2SEW, vti.LMul, vti.RegClass,
                                  vti.RegClass, GPR>;
+  }
 }
 
 multiclass VPatTernaryV_VX_AAXA<string intrinsic, string instruction,
@@ -5605,12 +5613,14 @@ multiclass VPatTernaryV_VX_AAXA_RM<string intrinsic, string instruction,
 
 multiclass VPatTernaryV_VI<string intrinsic, string instruction,
                            list<VTypeInfo> vtilist, Operand Imm_type> {
-  foreach vti = vtilist in
-    let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in
+  foreach vti = vtilist in {
+    defvar ivti = GetIntVTypeInfo<vti>.Vti;
+    let Predicates = GetVTypePredicates<ivti>.Predicates in
     defm : VPatTernaryWithPolicy<intrinsic, instruction, "VI",
                                  vti.Vector, vti.Vector, XLenVT, vti.Mask,
                                  vti.Log2SEW, vti.LMul, vti.RegClass,
                                  vti.RegClass, Imm_type>;
+  }
 }
 
 multiclass VPatTernaryW_VV<string intrinsic, string instruction,


### PR DESCRIPTION
For permutation intrinsics, the float data type is not used during processing. We only need to check whether its plain type is supported, rather than the float type. This is like what we did in https://github.com/llvm/llvm-project/blob/651c5208f8597f1f80349f6208e69bf9ea1c2862/llvm/lib/Target/RISCV/RISCVInstrInfoVVLPatterns.td#L2958