### PR TITLE
[CIR] Introduce IntTypeInterface to allow uniform integer types handling

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRTypes.td
@@ -35,7 +35,8 @@ class CIR_Type<string name, string typeMnemonic, list<Trait> traits = [],
 
 def CIR_IntType : CIR_Type<"Int", "int", [
     DeclareTypeInterfaceMethods<DataLayoutTypeInterface>,
-    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>
+    DeclareTypeInterfaceMethods<CIR_SizedTypeInterface>,
+    DeclareTypeInterfaceMethods<CIR_IntTypeInterface>,
 ]> {
   let summary = "Integer type with arbitrary precision up to a fixed limit";
   let description = [{

--- a/clang/include/clang/CIR/Interfaces/CIRTypeInterfaces.td
+++ b/clang/include/clang/CIR/Interfaces/CIRTypeInterfaces.td
@@ -15,6 +15,48 @@
 
 include "mlir/IR/OpBase.td"
 
+def CIR_IntTypeInterface : TypeInterface<"IntTypeInterface"> {
+  let description = [{
+    Contains helper functions to query properties about an integer type.
+  }];
+  let cppNamespace = "::cir";
+  let methods = [
+    InterfaceMethod<[{
+        Returns true if this is a signed integer type.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isSigned",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_type.isSigned();
+      }]
+    >,
+    InterfaceMethod<[{
+        Returns true if this is an unsigned integer type.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"isUnsigned",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_type.isUnsigned();
+      }]
+    >,
+    InterfaceMethod<[{
+        Returns the bit width of this integer type.
+      }],
+      /*retTy=*/"unsigned",
+      /*methodName=*/"getWidth",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return $_type.getWidth();
+      }]
+    >
+  ];
+}
+
 def CIR_FPTypeInterface : TypeInterface<"FPTypeInterface"> {
   let description = [{
     Contains helper functions to query properties about a floating-point type.


### PR DESCRIPTION
This will in future allow to use builtin integer types within cir operations

This mirrors incubat changes from https://github.com/llvm/clangir/pull/1724