### PR TITLE
[CIR] Untie Type and Attribute definitions

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.h
@@ -10,16 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_CLANG_CIR_DIALECT_IR_CIRATTRS_H
-#define LLVM_CLANG_CIR_DIALECT_IR_CIRATTRS_H
-
-#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
-#include "clang/CIR/Dialect/IR/CIRTypes.h"
+#ifndef CLANG_CIR_DIALECT_IR_CIRATTRS_H
+#define CLANG_CIR_DIALECT_IR_CIRATTRS_H
 
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 
-#include "llvm/ADT/SmallVector.h"
+#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+
+#include "clang/CIR/Interfaces/CIRTypeInterfaces.h"
 
 //===----------------------------------------------------------------------===//
 // CIR Dialect Attrs
@@ -27,15 +26,22 @@
 
 namespace clang {
 class FunctionDecl;
-class VarDecl;
 class RecordDecl;
+class VarDecl;
 } // namespace clang
 
 namespace cir {
 class ArrayType;
+class BoolType;
+class ComplexType;
+class IntType;
+class MethodType;
+class PointerType;
+class RecordType;
+class VectorType;
 } // namespace cir
 
 #define GET_ATTRDEF_CLASSES
 #include "clang/CIR/Dialect/IR/CIROpsAttributes.h.inc"
 
-#endif // LLVM_CLANG_CIR_DIALECT_IR_CIRATTRS_H
+#endif // CLANG_CIR_DIALECT_IR_CIRATTRS_H

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.h
@@ -29,6 +29,7 @@
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIROpsDialect.h.inc"
 #include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+#include "clang/CIR/Dialect/IR/CIRTypes.h"
 #include "clang/CIR/Interfaces/CIRLoopOpInterface.h"
 #include "clang/CIR/Interfaces/CIROpInterfaces.h"
 #include "clang/CIR/MissingFeatures.h"


### PR DESCRIPTION
This will allow to use Attributes and Types together in tablegen without inducing cyclic dependency.

This mirrors incubator changes from https://github.com/llvm/clangir/pull/1727