### PR TITLE
[VPlan] Remove redundant debug location setting in VPInterleaveRecipe::execute. nfc

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -3425,10 +3425,6 @@ void VPInterleaveRecipe::execute(VPTransformState &State) {
 
   VPValue *Addr = getAddr();
   Value *ResAddr = State.get(Addr, VPLane(0));
-  if (auto *I = dyn_cast<Instruction>(ResAddr))
-    State.setDebugLocFrom(I->getDebugLoc());
-
-  State.setDebugLocFrom(getDebugLoc());
   Value *PoisonVec = PoisonValue::get(VecTy);
 
   auto CreateGroupMask = [&BlockInMask, &State,


### PR DESCRIPTION
Remove it since we already set debug loc in VPBasicBlock::executeRecipes.