### PR TITLE
Revert "[TSan] Clarify and enforce shadow end alignment"

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_interface_java.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_java.cpp
@@ -122,6 +122,7 @@ void __tsan_java_move(jptr src, jptr dst, jptr size) {
   DCHECK_GE(dst, jctx->heap_begin);
   DCHECK_LE(dst + size, jctx->heap_begin + jctx->heap_size);
   DCHECK_NE(dst, src);
+  DCHECK_NE(size, 0);
 
   // Assuming it's not running concurrently with threads that do
   // memory accesses and mutex operations (stop-the-world phase).

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp
@@ -566,32 +566,17 @@ static bool IsValidMmapRange(uptr addr, uptr size) {
   return false;
 }
 
-void UnmapShadow(ThreadState* thr, uptr addr, uptr size) {
+void UnmapShadow(ThreadState *thr, uptr addr, uptr size) {
   if (size == 0 || !IsValidMmapRange(addr, size))
     return;
-  // unmap shadow is related to semantic of mmap/munmap, so we
-  // should clear the whole shadow range, including the tail shadow
-  // while addr + size % kShadowCell != 0.
-  uptr rounded_size_shadow = RoundUp(addr + size, kShadowCell) - addr;
-  DontNeedShadowFor(addr, rounded_size_shadow);
+  DontNeedShadowFor(addr, size);
   ScopedGlobalProcessor sgp;
   SlotLocker locker(thr, true);
-  uptr rounded_size_meta = RoundUp(addr + size, kMetaShadowCell) - addr;
-  ctx->metamap.ResetRange(thr->proc(), addr, rounded_size_meta, true);
+  ctx->metamap.ResetRange(thr->proc(), addr, size, true);
 }
 #endif
 
 void MapShadow(uptr addr, uptr size) {
-  // Although named MapShadow, this function's semantic is unrelated to
-  // UnmapShadow. This function currently only used for Go's lazy allocation
-  // of shadow, whose targets are program section (e.g., bss, data, etc.).
-  // Therefore, we can guarantee that the addr and size align to kShadowCell
-  // and kMetaShadowCell by the following assertions.
-  DCHECK_EQ(addr % kShadowCell, 0);
-  DCHECK_EQ(size % kShadowCell, 0);
-  DCHECK_EQ(addr % kMetaShadowCell, 0);
-  DCHECK_EQ(size % kMetaShadowCell, 0);
-
   // Ensure thead registry lock held, so as to synchronize
   // with DoReset, which also access the mapped_shadow_* ctxt fields.
   ThreadRegistryLock lock0(&ctx->thread_registry);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_access.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_access.cpp
@@ -688,18 +688,16 @@ void MemoryAccessRangeT(ThreadState* thr, uptr pc, uptr addr, uptr size) {
     DCHECK(IsShadowMem(shadow_mem));
   }
 
-  uptr rounded_size =
-      (RoundUpTo(addr + size, kShadowCell) - RoundDownTo(addr, kShadowCell));
-  RawShadow* shadow_mem_end =
-      shadow_mem + rounded_size / kShadowCell * kShadowCnt;
-  if (!IsShadowMem(shadow_mem_end - 1)) {
-    Printf("Bad shadow end addr: %p (%p)\n", shadow_mem_end - 1,
+  RawShadow* shadow_mem_end = reinterpret_cast<RawShadow*>(
+      reinterpret_cast<uptr>(shadow_mem) + size * kShadowMultiplier - 1);
+  if (!IsShadowMem(shadow_mem_end)) {
+    Printf("Bad shadow end addr: %p (%p)\n", shadow_mem_end,
            (void*)(addr + size - 1));
     Printf(
-        "Shadow start addr (ok): %p (%p); size: 0x%zx; rounded_size: 0x%zx; "
-        "kShadowMultiplier: %zx\n",
-        shadow_mem, (void*)addr, size, rounded_size, kShadowMultiplier);
-    DCHECK(IsShadowMem(shadow_mem_end - 1));
+        "Shadow start addr (ok): %p (%p); size: 0x%zx; kShadowMultiplier: "
+        "%zx\n",
+        shadow_mem, (void*)addr, size, kShadowMultiplier);
+    DCHECK(IsShadowMem(shadow_mem_end));
   }
 #endif
 

--- a/compiler-rt/lib/tsan/rtl/tsan_sync.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_sync.cpp
@@ -246,20 +246,6 @@ void MetaMap::MoveMemory(uptr src, uptr dst, uptr sz) {
   // there are no concurrent accesses to the regions (e.g. stop-the-world).
   CHECK_NE(src, dst);
   CHECK_NE(sz, 0);
-
-  // The current MoveMemory implementation behaves incorrectly when src, dst,
-  // and sz are not aligned to kMetaShadowCell.
-  // For example, with kMetaShadowCell == 8:
-  // - src = 4: unexpectedly clears the metadata for the range [0, 4).
-  // - src = 16, dst = 4, size = 8: A sync variable for addr = 20, which should
-  //   be moved to the metadata for address 8, is incorrectly moved to the
-  //   metadata for address 0 instead.
-  // - src = 0, sz = 4: fails to move the tail metadata.
-  // Therefore, the following assertions is needed.
-  DCHECK_EQ(src % kMetaShadowCell, 0);
-  DCHECK_EQ(dst % kMetaShadowCell, 0);
-  DCHECK_EQ(sz % kMetaShadowCell, 0);
-
   uptr diff = dst - src;
   u32 *src_meta, *dst_meta, *src_meta_end;
   uptr inc;

--- a/compiler-rt/test/tsan/java_heap_init2.cpp
+++ b/compiler-rt/test/tsan/java_heap_init2.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx_tsan -O1 %s -o %t && %run %t 2>&1 | FileCheck %s
+// XFAIL: *
 
 #include "java.h"
 #include <errno.h>

--- a/compiler-rt/test/tsan/munmap_clear_shadow.c
+++ b/compiler-rt/test/tsan/munmap_clear_shadow.c
@@ -1,4 +1,5 @@
 // RUN: %clang_tsan %s -o %t && %run %t | FileCheck %s
+// XFAIL: *
 
 #include "test.h"
 #include <assert.h>


### PR DESCRIPTION
Reverts llvm/llvm-project#144648 due to a test failure of the new added test case `munmap_clear_shadow.c` in IOS .