### PR TITLE
[llvm][ADT] Add wrappers to `std::fill`

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1759,6 +1759,12 @@ bool none_of(R &&Range, UnaryPredicate P) {
   return std::none_of(adl_begin(Range), adl_end(Range), P);
 }
 
+/// Provide wrappers to std::fill which take ranges instead of having to pass
+/// begin/end explicitly.
+template <typename R, typename T> void fill(R &&Range, T &&Value) {
+  std::fill(adl_begin(Range), adl_end(Range), std::forward<T>(Value));
+}
+
 /// Provide wrappers to std::find which take ranges instead of having to pass
 /// begin/end explicitly.
 template <typename R, typename T> auto find(R &&Range, const T &Val) {

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1595,12 +1595,11 @@ TEST(STLExtrasTest, Fill) {
   std::vector<int> V1 = {1, 2, 3};
   std::vector<int> V2;
   int Val = 4;
-  auto IsSameAsVal = [&](int V) { return V == Val; };
   fill(V1, Val);
-  EXPECT_TRUE(llvm::all_of(V1, IsSameAsVal));
-  V2.resize(5);
+  EXPECT_THAT(V1, ElementsAre(Val, Val, Val));
+  V2.resize(4);
   fill(V2, Val);
-  EXPECT_TRUE(llvm::all_of(V2, IsSameAsVal));
+  EXPECT_THAT(V2, ElementsAre(Val, Val, Val, Val));
 }
 
 struct Foo;

--- a/llvm/unittests/ADT/STLExtrasTest.cpp
+++ b/llvm/unittests/ADT/STLExtrasTest.cpp
@@ -1591,6 +1591,18 @@ TEST(STLExtrasTest, Includes) {
   }
 }
 
+TEST(STLExtrasTest, Fill) {
+  std::vector<int> V1 = {1, 2, 3};
+  std::vector<int> V2;
+  int Val = 4;
+  auto IsSameAsVal = [&](int V) { return V == Val; };
+  fill(V1, Val);
+  EXPECT_TRUE(llvm::all_of(V1, IsSameAsVal));
+  V2.resize(5);
+  fill(V2, Val);
+  EXPECT_TRUE(llvm::all_of(V2, IsSameAsVal));
+}
+
 struct Foo;
 struct Bar {};
 


### PR DESCRIPTION
This PR adds  `llvm::fill` that accepts a range instead of begin/end iterator.