### PR TITLE
[MLIR][OpenMP][NFC] Use header guards for tblgen'd definitions

### DIFF
--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPClauseOperands.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPClauseOperands.h
@@ -15,13 +15,9 @@
 #ifndef MLIR_DIALECT_OPENMP_OPENMPCLAUSEOPERANDS_H_
 #define MLIR_DIALECT_OPENMP_OPENMPCLAUSEOPERANDS_H_
 
+#include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "llvm/ADT/SmallVector.h"
-
-#include "mlir/Dialect/OpenMP/OpenMPOpsEnums.h.inc"
-
-#define GET_ATTRDEF_CLASSES
-#include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.h.inc"
 
 #include "mlir/Dialect/OpenMP/OpenMPClauseOps.h.inc"
 

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPDialect.h
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/OpenACCMPCommon/Interfaces/AtomicInterfaces.h"
 #include "mlir/Dialect/OpenACCMPCommon/Interfaces/OpenACCMPOpsInterfaces.h"
+#include "mlir/Dialect/OpenMP/OpenMPInterfaces.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
@@ -32,8 +33,6 @@
 #include "mlir/Dialect/OpenMP/OpenMPClauseOperands.h"
 
 #include "mlir/Dialect/OpenMP/OpenMPTypeInterfaces.h.inc"
-
-#include "mlir/Dialect/OpenMP/OpenMPInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "mlir/Dialect/OpenMP/OpenMPOps.h.inc"

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPInterfaces.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPInterfaces.h
@@ -13,7 +13,8 @@
 #ifndef MLIR_DIALECT_OPENMP_OPENMPINTERFACES_H_
 #define MLIR_DIALECT_OPENMP_OPENMPINTERFACES_H_
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/OpenMP/OpenMPClauseOperands.h"
+#include "mlir/Dialect/OpenMP/OpenMPOpsEnums.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOpsAttributes.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOpsAttributes.h
@@ -1,0 +1,17 @@
+//===- OpenMPOpsAttributes.h ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_OPENMP_OPENMPOPSATTRIBUTES_H_
+#define MLIR_DIALECT_OPENMP_OPENMPOPSATTRIBUTES_H_
+
+#include "mlir/Dialect/OpenMP/OpenMPOpsEnums.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "mlir/Dialect/OpenMP/OpenMPOpsAttributes.h.inc"
+
+#endif // MLIR_DIALECT_OPENMP_OPENMPOPSATTRIBUTES_H_

--- a/mlir/include/mlir/Dialect/OpenMP/OpenMPOpsEnums.h
+++ b/mlir/include/mlir/Dialect/OpenMP/OpenMPOpsEnums.h
@@ -1,0 +1,14 @@
+//===- OpenMPOpsEnums.h -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_OPENMP_OPENMPOPSENUMS_H_
+#define MLIR_DIALECT_OPENMP_OPENMPOPSENUMS_H_
+
+#include "mlir/Dialect/OpenMP/OpenMPOpsEnums.h.inc"
+
+#endif // MLIR_DIALECT_OPENMP_OPENMPOPSENUMS_H_


### PR DESCRIPTION
Currently the generated `.h.inc` files are included coarse-grained header files that just happen to work in the current source. But if at another header, call it `A.h`, a definition from e.g. "OpenMPOpsEnums.h.inc" is needed, it cannot be included there because it `A.h` is also included in `B.h` that uses `OpenMPClauseOperands.h` which already includes `OpenMPOpsEnums.h.inc`. So the content of `OpenMPOpsEnums.h.inc` appears twice in the translation unit result in a compile failure because the same enum cannot be defined twice.

This patch tries to use more fine-grained include header for generated content protected by header guards, so `OpenMPOpsEnums.h` can be included when ever needed. Some is done with `OpenMPOpsAttributes.h`. Needed for #144785. Also fixes the recursive #include of `OpenMPDialect.h` and `OpenMPInterfaces.h`.

Patch extracted out of #144785