### PR TITLE
[lldb] Use correct size when dumping DWARF64 DW_FORM_ref_addr

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
@@ -420,8 +420,7 @@ void DWARFFormValue::Dump(Stream &s) const {
       DumpAddress(s.AsRawOstream(), uvalue, sizeof(uint64_t) * 2);
     else
       DumpAddress(s.AsRawOstream(), uvalue,
-                  4 * 2); // 4 for DWARF32, 8 for DWARF64, but we don't
-                          // support DWARF64 yet
+                  m_unit->GetFormParams().getRefAddrByteSize());
     break;
   }
   case DW_FORM_ref1:

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFFormValue.cpp
@@ -416,11 +416,8 @@ void DWARFFormValue::Dump(Stream &s) const {
   case DW_FORM_ref_addr: {
     assert(m_unit); // Unit must be valid for DW_FORM_ref_addr objects or we
                     // will get this wrong
-    if (m_unit->GetVersion() <= 2)
-      DumpAddress(s.AsRawOstream(), uvalue, sizeof(uint64_t) * 2);
-    else
-      DumpAddress(s.AsRawOstream(), uvalue,
-                  m_unit->GetFormParams().getRefAddrByteSize());
+    DumpAddress(s.AsRawOstream(), uvalue,
+                m_unit->GetFormParams().getRefAddrByteSize());
     break;
   }
   case DW_FORM_ref1:


### PR DESCRIPTION
Not that we ever do that, because this is unused code, but if someone was debugging lldb I guess they'd call this.

Was missed in https://github.com/llvm/llvm-project/pull/145645

Relates to https://github.com/llvm/llvm-project/issues/135208