### PR TITLE
__config: also ignore shift-out-of-bounds error with ubsan checks

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1155,7 +1155,7 @@ typedef __char32_t char32_t;
 
 // Allow for build-time disabling of unsigned integer sanitization
 #  if __has_attribute(no_sanitize) && !defined(_LIBCPP_COMPILER_GCC)
-#    define _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK __attribute__((__no_sanitize__("unsigned-integer-overflow")))
+#    define _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK __attribute__((__no_sanitize__("unsigned-integer-overflow", "shift-out-of-bounds")))
 #  else
 #    define _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK
 #  endif


### PR DESCRIPTION
Otherwise functions such as __hash_len_16 in hash.h still trigger harmless but frustrating ubsan warnings despite being marked as _LIBCPP_DISABLE_UBSAN_UNSIGNED_INTEGER_CHECK.