### PR TITLE
[clangd] Drop const from a return type (NFC)

### DIFF
--- a/clang-tools-extra/clangd/refactor/tweaks/ExtractVariable.cpp
+++ b/clang-tools-extra/clangd/refactor/tweaks/ExtractVariable.cpp
@@ -359,9 +359,9 @@ struct ParsedBinaryOperator {
 //    +   c <- End
 //   / \
 //  a   b <- Start
-const SourceRange getBinaryOperatorRange(const SelectionTree::Node &N,
-                                         const SourceManager &SM,
-                                         const LangOptions &LangOpts) {
+SourceRange getBinaryOperatorRange(const SelectionTree::Node &N,
+                                   const SourceManager &SM,
+                                   const LangOptions &LangOpts) {
   // If N is not a suitable binary operator, bail out.
   ParsedBinaryOperator Op;
   if (!Op.parse(N.ignoreImplicit()) || !Op.associative() ||


### PR DESCRIPTION
We don't need const on the return type.
