### PR TITLE
[NFC][Bitcode] Remove FUNCTION_INST_UNOP abbrevs

### DIFF
--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -141,8 +141,6 @@ enum {
 
   // FUNCTION_BLOCK abbrev id's.
   FUNCTION_INST_LOAD_ABBREV = bitc::FIRST_APPLICATION_ABBREV,
-  FUNCTION_INST_UNOP_ABBREV,
-  FUNCTION_INST_UNOP_FLAGS_ABBREV,
   FUNCTION_INST_BINOP_ABBREV,
   FUNCTION_INST_BINOP_FLAGS_ABBREV,
   FUNCTION_INST_CAST_ABBREV,
@@ -3127,13 +3125,10 @@ void ModuleBitcodeWriter::writeInstruction(const Instruction &I,
     break;
   case Instruction::FNeg: {
     Code = bitc::FUNC_CODE_INST_UNOP;
-    if (!pushValueAndType(I.getOperand(0), InstID, Vals))
-      AbbrevToUse = FUNCTION_INST_UNOP_ABBREV;
+    pushValueAndType(I.getOperand(0), InstID, Vals);
     Vals.push_back(getEncodedUnaryOpcode(I.getOpcode()));
     uint64_t Flags = getOptimizationFlags(&I);
     if (Flags != 0) {
-      if (AbbrevToUse == FUNCTION_INST_UNOP_ABBREV)
-        AbbrevToUse = FUNCTION_INST_UNOP_FLAGS_ABBREV;
       Vals.push_back(Flags);
     }
     break;
@@ -3947,23 +3942,23 @@ void ModuleBitcodeWriter::writeBlockInfo() {
       llvm_unreachable("Unexpected abbrev ordering!");
   }
   { // INST_UNOP abbrev for FUNCTION_BLOCK.
-    auto Abbv = std::make_shared<BitCodeAbbrev>();
-    Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_UNOP));
-    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // LHS
-    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
-    if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
-        FUNCTION_INST_UNOP_ABBREV)
-      llvm_unreachable("Unexpected abbrev ordering!");
+    // auto Abbv = std::make_shared<BitCodeAbbrev>();
+    // Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_UNOP));
+    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // LHS
+    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
+    // if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
+    //     FUNCTION_INST_UNOP_ABBREV)
+    //   llvm_unreachable("Unexpected abbrev ordering!");
   }
   { // INST_UNOP_FLAGS abbrev for FUNCTION_BLOCK.
-    auto Abbv = std::make_shared<BitCodeAbbrev>();
-    Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_UNOP));
-    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // LHS
-    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
-    Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 8)); // flags
-    if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
-        FUNCTION_INST_UNOP_FLAGS_ABBREV)
-      llvm_unreachable("Unexpected abbrev ordering!");
+    // auto Abbv = std::make_shared<BitCodeAbbrev>();
+    // Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_UNOP));
+    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // LHS
+    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
+    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 8)); // flags
+    // if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
+    //     FUNCTION_INST_UNOP_FLAGS_ABBREV)
+    //   llvm_unreachable("Unexpected abbrev ordering!");
   }
   { // INST_BINOP abbrev for FUNCTION_BLOCK.
     auto Abbv = std::make_shared<BitCodeAbbrev>();

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -3941,25 +3941,6 @@ void ModuleBitcodeWriter::writeBlockInfo() {
         FUNCTION_INST_LOAD_ABBREV)
       llvm_unreachable("Unexpected abbrev ordering!");
   }
-  { // INST_UNOP abbrev for FUNCTION_BLOCK.
-    // auto Abbv = std::make_shared<BitCodeAbbrev>();
-    // Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_UNOP));
-    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // LHS
-    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
-    // if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
-    //     FUNCTION_INST_UNOP_ABBREV)
-    //   llvm_unreachable("Unexpected abbrev ordering!");
-  }
-  { // INST_UNOP_FLAGS abbrev for FUNCTION_BLOCK.
-    // auto Abbv = std::make_shared<BitCodeAbbrev>();
-    // Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_UNOP));
-    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6)); // LHS
-    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 4)); // opc
-    // Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 8)); // flags
-    // if (Stream.EmitBlockInfoAbbrev(bitc::FUNCTION_BLOCK_ID, Abbv) !=
-    //     FUNCTION_INST_UNOP_FLAGS_ABBREV)
-    //   llvm_unreachable("Unexpected abbrev ordering!");
-  }
   { // INST_BINOP abbrev for FUNCTION_BLOCK.
     auto Abbv = std::make_shared<BitCodeAbbrev>();
     Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_INST_BINOP));


### PR DESCRIPTION
Discussed in #146497.

Seems to have a positive impact on bitcode file size in CTMark LTO builds, and makes space for more abbrevs without bumping the CodeLen for function blocks.

Alternatively, we could just bump the CodeLen to 5 bits.