### PR TITLE
[compiler-rt][sanitizer_common] Improve handling of env vars for iOS simulator tests

### DIFF
--- a/compiler-rt/test/sanitizer_common/ios_commands/iossim_env.py
+++ b/compiler-rt/test/sanitizer_common/ios_commands/iossim_env.py
@@ -5,13 +5,13 @@ import os, sys, subprocess
 
 idx = 1
 for arg in sys.argv[1:]:
-  if not "=" in arg:
-    break
-  idx += 1
-  (argname, argval) = arg.split("=")
-  os.environ["SIMCTL_CHILD_" + argname] = argval
+    if not "=" in arg:
+        break
+    idx += 1
+    (argname, argval) = arg.split("=", maxsplit=1)
+    os.environ["SIMCTL_CHILD_" + argname] = argval
 
 exitcode = subprocess.call(sys.argv[idx:])
 if exitcode > 125:
-  exitcode = 126
+    exitcode = 126
 sys.exit(exitcode)

--- a/compiler-rt/test/sanitizer_common/lit.common.cfg.py
+++ b/compiler-rt/test/sanitizer_common/lit.common.cfg.py
@@ -87,7 +87,7 @@ config.substitutions.append(("%collect_stack_traces", collect_stack_traces))
 config.substitutions.append(("%tool_name", config.tool_name))
 config.substitutions.append(("%tool_options", tool_options))
 config.substitutions.append(
-    ("%env_tool_opts=", "env " + tool_options + "=" + default_tool_options_str)
+    ("%env_tool_opts=", "%env " + tool_options + "=" + default_tool_options_str)
 )
 
 config.suffixes = [".c", ".cpp"]


### PR DESCRIPTION
I have been bringing up sanitizer_common tests to run on iOS simulators, and found that a clang argument `LSAN_OPTIONS=suppressions=lsan.supp` was incorrectly split - this patch fixes up the environment handling behaviour in the python scripts.