### PR TITLE
[LLVM][AsmWriter] Print a comment for unknown intrinsics

### DIFF
--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -4129,6 +4129,9 @@ void AssemblyWriter::printFunction(const Function *F) {
       Out << "; Function Attrs: " << AttrStr << '\n';
   }
 
+  if (F->isIntrinsic() && F->getIntrinsicID() == Intrinsic::not_intrinsic)
+    Out << "; Unknown intrinsic\n";
+
   Machine.incorporateFunction(F);
 
   if (F->isDeclaration()) {

--- a/llvm/test/Feature/intrinsics.ll
+++ b/llvm/test/Feature/intrinsics.ll
@@ -3,8 +3,12 @@
 ; RUN: diff %t1.ll %t2.ll
 ; RUN: FileCheck %s < %t1.ll
 
+; CHECK: Unknown intrinsic
+; CHECK-NEXT: declare i1 @llvm.isunordered.f32(float, float)
 declare i1 @llvm.isunordered.f32(float, float)
 
+; CHECK: Unknown intrinsic
+; CHECK-NEXT: declare i1 @llvm.isunordered.f64(double, double)
 declare i1 @llvm.isunordered.f64(double, double)
 
 
@@ -60,7 +64,6 @@ define void @libm() {
 
 ; FIXME: test ALL the intrinsics in this file.
 
-; rdar://11542750
 ; CHECK: declare void @llvm.trap() #1
 declare void @llvm.trap()
 


### PR DESCRIPTION
Unknown intrinsics are functions that begin with `llvm.` but are not an intrinsic that is recognized by LLVM. Add a comment before such functions in LLVM IR assembly to indicate that they are unknown intrinsics.