### PR TITLE
[Xtensa] Fix XtensaELFObjectWriter.

### DIFF
--- a/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaELFObjectWriter.cpp
+++ b/llvm/lib/Target/Xtensa/MCTargetDesc/XtensaELFObjectWriter.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "MCTargetDesc/XtensaMCExpr.h"
+#include "MCTargetDesc/XtensaMCAsmInfo.h"
 #include "MCTargetDesc/XtensaMCTargetDesc.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/BinaryFormat/ELF.h"


### PR DESCRIPTION
The "XtensaMCExpr.h" used by XtensaELFObjectWriter was removed by previous commit. And functionality from this file is now implemented in "XtensaMCAsmInfo.h". So, fix this situation.