### PR TITLE
[Offload] Add missing license header to Common.td

### DIFF
--- a/offload/liboffload/API/Common.td
+++ b/offload/liboffload/API/Common.td
@@ -1,3 +1,15 @@
+//===-- Common.td - Common definitions for Offload ---------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains shared Offload API definitions
+//
+//===----------------------------------------------------------------------===//
+
 def : Macro {
   let name = "OL_VERSION_MAJOR";
   let desc = "Major version of the Offload API";


### PR DESCRIPTION
All other tablegen files in this directory have the license header, but `Common.td` is missing it