### PR TITLE
scudo: default enabled dealloc_type_mismatch on new platforms

### DIFF
--- a/compiler-rt/lib/scudo/standalone/flags.inc
+++ b/compiler-rt/lib/scudo/standalone/flags.inc
@@ -24,7 +24,11 @@ SCUDO_FLAG(int, quarantine_max_chunk_size, 0,
            "Size (in bytes) up to which chunks will be quarantined (if lower "
            "than or equal to).")
 
-SCUDO_FLAG(bool, dealloc_type_mismatch, false,
+// Historically dealloc_type_mismatch was disabled by default. Mismatching is
+// undefined behavior and software that triggers it should feel bad. To stop the
+// bleeding, we default enable except on Android, Fuchsia, and Trusty.
+SCUDO_FLAG(bool, dealloc_type_mismatch,
+           !SCUDO_ANDROID && !SCUDO_FUCHSIA && !SCUDO_TRUSTY,
            "Terminate on a type mismatch in allocation-deallocation functions, "
            "eg: malloc/delete, new/free, new/delete[], etc.")
 

--- a/llvm/docs/ScudoHardenedAllocator.rst
+++ b/llvm/docs/ScudoHardenedAllocator.rst
@@ -231,8 +231,10 @@ The following "string" options are available:
 |                                 |                | *both* this and quarantine_size_kb to zero will |
 |                                 |                | disable the quarantine entirely.                |
 +---------------------------------+----------------+-------------------------------------------------+
-| dealloc_type_mismatch           | false          | Whether or not we report errors on              |
+| dealloc_type_mismatch           | true           | Whether or not we report errors on              |
 |                                 |                | malloc/delete, new/free, new/delete[], etc.     |
+|                                 |                |                                                 |
+|                                 |                | Current false on Android, Fuchsia, and Trusty.  |
 +---------------------------------+----------------+-------------------------------------------------+
 | delete_size_mismatch            | true           | Whether or not we report errors on mismatch     |
 |                                 |                | between sizes of new and delete.                |


### PR DESCRIPTION
Default enable on new platforms, leaving it disabled for existing well known platforms using scudo.