### PR TITLE
[Test] Account for spaces in paths in the new dtlto/files.test

### DIFF
--- a/lld/test/ELF/dtlto/files.test
+++ b/lld/test/ELF/dtlto/files.test
@@ -24,8 +24,8 @@ RUN: llc t2.ll --filetype=obj -o t2.o
 ## the contents of the object files supplied on the command line into the
 ## output object files in job order.
 RUN: echo "t1.bc t2.bc --start-lib t3.bc --end-lib -o my.elf \
-RUN:   --thinlto-distributor=%python \
-RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/mock.py \
+RUN:   --thinlto-distributor=\"%python\" \
+RUN:   --thinlto-distributor-arg=\"%llvm_src_root/utils/dtlto/mock.py\" \
 RUN:   --thinlto-distributor-arg=t1.o \
 RUN:   --thinlto-distributor-arg=t2.o" > l.rsp
 


### PR DESCRIPTION
This uses LIT substitutions in a response file that could contain spaces in paths. This caused a failure on a build bot where the path to the system Python executable was "C:\Program Files\Python310\python.exe", as reported in #142757.

Add appropriate quoting to fix the issue.