### PR TITLE
[flang][preprocessor] fix use of bitwise-and for logical-and

### DIFF
--- a/flang/lib/Parser/preprocessor.cpp
+++ b/flang/lib/Parser/preprocessor.cpp
@@ -1276,14 +1276,19 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
       left = right >= 64 ? 0 : left >> right;
       break;
     case BITAND:
-    case AND:
       left = left & right;
+      break;
+    // (bool)(1 && 2) != (bool)(1 & 2), we can't use bitwise AND here.
+    case AND:
+      left = left && right;
       break;
     case BITXOR:
       left = left ^ right;
       break;
-    case BITOR:
+    // (bool)(1 || 2) == (bool)(1 | 2), seems like we can use `|` here.
+    // But should we?
     case OR:
+    case BITOR:
       left = left | right;
       break;
     case LT:

--- a/flang/lib/Parser/preprocessor.cpp
+++ b/flang/lib/Parser/preprocessor.cpp
@@ -1278,18 +1278,17 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
     case BITAND:
       left = left & right;
       break;
-    // (bool)(1 && 2) != (bool)(1 & 2), we can't use bitwise AND here.
-    case AND:
-      left = left && right;
-      break;
     case BITXOR:
       left = left ^ right;
       break;
-    // (bool)(1 || 2) == (bool)(1 | 2), seems like we can use `|` here.
-    // But should we?
-    case OR:
     case BITOR:
       left = left | right;
+      break;
+    case AND:
+      left = left && right;
+      break;
+    case OR:
+      left = left || right;
       break;
     case LT:
       left = -(left < right);

--- a/flang/test/Parser/issue-146362.2.f90
+++ b/flang/test/Parser/issue-146362.2.f90
@@ -7,5 +7,12 @@ PROGRAM P
   !CHECK-NOT: FALSE
   WRITE(*,*) 'FALSE'
 #endif
+#if ((1 || 2) != 3)
+  !CHECK: TRUE
+  WRITE(*,*) 'TRUE'
+#else
+  !CHECK-NOT: FALSE
+  WRITE(*,*) 'FALSE'
+#endif
 END PROGRAM
 

--- a/flang/test/Parser/issue-146362.2.f90
+++ b/flang/test/Parser/issue-146362.2.f90
@@ -1,0 +1,11 @@
+!RUN: %flang_fc1 -cpp -fdebug-unparse %s | FileCheck %s
+PROGRAM P
+#if (1 && 2)
+  !CHECK: TRUE
+  WRITE(*,*) 'TRUE'
+#else
+  !CHECK-NOT: FALSE
+  WRITE(*,*) 'FALSE'
+#endif
+END PROGRAM
+


### PR DESCRIPTION
The preprocessor used bitwise and to implement logical, this is a bug.

towards #146362