### PR TITLE
[clang] Refactor `LangOptions` to specify compatibility as X macro arg

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -38,25 +38,25 @@
 #endif
 
 // FIXME: A lot of the Benign options should be Compatible instead.
-LANGOPT(C99               , 1, 0, Affecting, "C99")
-LANGOPT(C11               , 1, 0, Affecting, "C11")
-LANGOPT(C17               , 1, 0, Affecting, "C17")
-LANGOPT(C23               , 1, 0, Affecting, "C23")
-LANGOPT(C2y               , 1, 0, Affecting, "C2y")
-LANGOPT(MSVCCompat        , 1, 0, Affecting, "Microsoft Visual C++ full compatibility mode")
-LANGOPT(Kernel            , 1, 0, Affecting, "Kernel mode")
-LANGOPT(MicrosoftExt      , 1, 0, Affecting, "Microsoft C++ extensions")
-LANGOPT(ZOSExt            , 1, 0, Affecting, "z/OS extensions")
-LANGOPT(AsmBlocks         , 1, 0, Affecting, "Microsoft inline asm blocks")
-LANGOPT(Borland           , 1, 0, Affecting, "Borland extensions")
-LANGOPT(CPlusPlus         , 1, 0, Affecting, "C++")
-LANGOPT(CPlusPlus11       , 1, 0, Affecting, "C++11")
-LANGOPT(CPlusPlus14       , 1, 0, Affecting, "C++14")
-LANGOPT(CPlusPlus17       , 1, 0, Affecting, "C++17")
-LANGOPT(CPlusPlus20       , 1, 0, Affecting, "C++20")
-LANGOPT(CPlusPlus23       , 1, 0, Affecting, "C++23")
-LANGOPT(CPlusPlus26       , 1, 0, Affecting, "C++26")
-LANGOPT(ObjC              , 1, 0, Affecting, "Objective-C")
+LANGOPT(C99               , 1, 0, NotCompatible, "C99")
+LANGOPT(C11               , 1, 0, NotCompatible, "C11")
+LANGOPT(C17               , 1, 0, NotCompatible, "C17")
+LANGOPT(C23               , 1, 0, NotCompatible, "C23")
+LANGOPT(C2y               , 1, 0, NotCompatible, "C2y")
+LANGOPT(MSVCCompat        , 1, 0, NotCompatible, "Microsoft Visual C++ full compatibility mode")
+LANGOPT(Kernel            , 1, 0, NotCompatible, "Kernel mode")
+LANGOPT(MicrosoftExt      , 1, 0, NotCompatible, "Microsoft C++ extensions")
+LANGOPT(ZOSExt            , 1, 0, NotCompatible, "z/OS extensions")
+LANGOPT(AsmBlocks         , 1, 0, NotCompatible, "Microsoft inline asm blocks")
+LANGOPT(Borland           , 1, 0, NotCompatible, "Borland extensions")
+LANGOPT(CPlusPlus         , 1, 0, NotCompatible, "C++")
+LANGOPT(CPlusPlus11       , 1, 0, NotCompatible, "C++11")
+LANGOPT(CPlusPlus14       , 1, 0, NotCompatible, "C++14")
+LANGOPT(CPlusPlus17       , 1, 0, NotCompatible, "C++17")
+LANGOPT(CPlusPlus20       , 1, 0, NotCompatible, "C++20")
+LANGOPT(CPlusPlus23       , 1, 0, NotCompatible, "C++23")
+LANGOPT(CPlusPlus26       , 1, 0, NotCompatible, "C++26")
+LANGOPT(ObjC              , 1, 0, NotCompatible, "Objective-C")
 LANGOPT(ObjCDefaultSynthProperties , 1, 0, Benign,
         "Objective-C auto-synthesized properties")
 LANGOPT(EncodeExtendedBlockSig , 1, 0, Benign,
@@ -65,89 +65,89 @@ LANGOPT(EncodeCXXClassTemplateSpec , 1, 0, Benign,
         "Fully encode c++ class template specialization")
 LANGOPT(ObjCInferRelatedResultType , 1, 1, Benign,
         "Objective-C related result type inference")
-LANGOPT(AppExt            , 1, 0, Affecting, "Objective-C App Extension")
-LANGOPT(Trigraphs         , 1, 0, Affecting, "trigraphs")
-LANGOPT(LineComment       , 1, 0, Affecting, "'//' comments")
-LANGOPT(Bool              , 1, 0, Affecting, "bool, true, and false keywords")
-LANGOPT(Half              , 1, 0, Affecting, "half keyword")
-LANGOPT(WChar             , 1, 0, Affecting, "wchar_t keyword")
-LANGOPT(Char8             , 1, 0, Affecting, "char8_t keyword")
-LANGOPT(IEEE128           , 1, 0, Affecting, "__ieee128 keyword")
-LANGOPT(DeclSpecKeyword   , 1, 0, Affecting, "__declspec keyword")
+LANGOPT(AppExt            , 1, 0, NotCompatible, "Objective-C App Extension")
+LANGOPT(Trigraphs         , 1, 0, NotCompatible, "trigraphs")
+LANGOPT(LineComment       , 1, 0, NotCompatible, "'//' comments")
+LANGOPT(Bool              , 1, 0, NotCompatible, "bool, true, and false keywords")
+LANGOPT(Half              , 1, 0, NotCompatible, "half keyword")
+LANGOPT(WChar             , 1, 0, NotCompatible, "wchar_t keyword")
+LANGOPT(Char8             , 1, 0, NotCompatible, "char8_t keyword")
+LANGOPT(IEEE128           , 1, 0, NotCompatible, "__ieee128 keyword")
+LANGOPT(DeclSpecKeyword   , 1, 0, NotCompatible, "__declspec keyword")
 LANGOPT(DollarIdents      , 1, 1, Benign, "'$' in identifiers")
 LANGOPT(AsmPreprocessor   , 1, 0, Benign, "preprocessor in asm mode")
-LANGOPT(GNUMode           , 1, 1, Affecting, "GNU extensions")
-LANGOPT(GNUKeywords       , 1, 1, Affecting, "GNU keywords")
-VALUE_LANGOPT(GNUCVersion , 32, 0, Affecting, "GNU C compatibility version")
-LANGOPT(DisableKNRFunctions, 1, 0, Affecting, "require function types to have a prototype")
-LANGOPT(Digraphs          , 1, 0, Affecting, "digraphs")
+LANGOPT(GNUMode           , 1, 1, NotCompatible, "GNU extensions")
+LANGOPT(GNUKeywords       , 1, 1, NotCompatible, "GNU keywords")
+VALUE_LANGOPT(GNUCVersion , 32, 0, NotCompatible, "GNU C compatibility version")
+LANGOPT(DisableKNRFunctions, 1, 0, NotCompatible, "require function types to have a prototype")
+LANGOPT(Digraphs          , 1, 0, NotCompatible, "digraphs")
 LANGOPT(HexFloats         , 1, 0, Benign, "C99 hexadecimal float constants")
-LANGOPT(CXXOperatorNames  , 1, 0, Affecting, "C++ operator name keywords")
-LANGOPT(AppleKext         , 1, 0, Affecting, "Apple kext support")
+LANGOPT(CXXOperatorNames  , 1, 0, NotCompatible, "C++ operator name keywords")
+LANGOPT(AppleKext         , 1, 0, NotCompatible, "Apple kext support")
 LANGOPT(PascalStrings     , 1, 0, Benign, "Pascal string support")
-LANGOPT(WritableStrings   , 1, 0, Affecting, "writable string support")
-LANGOPT(ConstStrings      , 1, 0, Affecting, "const-qualified string support")
+LANGOPT(WritableStrings   , 1, 0, NotCompatible, "writable string support")
+LANGOPT(ConstStrings      , 1, 0, NotCompatible, "const-qualified string support")
 ENUM_LANGOPT(LaxVectorConversions, LaxVectorConversionKind, 2,
-             LaxVectorConversionKind::All, Affecting, "lax vector conversions")
+             LaxVectorConversionKind::All, NotCompatible, "lax vector conversions")
 ENUM_LANGOPT(AltivecSrcCompat, AltivecSrcCompatKind, 2,
-             AltivecSrcCompatKind::Default, Affecting, "Altivec source compatibility")
-LANGOPT(ConvergentFunctions, 1, 1, Affecting, "Assume convergent functions")
-LANGOPT(AltiVec           , 1, 0, Affecting, "AltiVec-style vector initializers")
-LANGOPT(ZVector           , 1, 0, Affecting, "System z vector extensions")
-LANGOPT(Exceptions        , 1, 0, Affecting, "exception handling")
-LANGOPT(ObjCExceptions    , 1, 0, Affecting, "Objective-C exceptions")
-LANGOPT(CXXExceptions     , 1, 0, Affecting, "C++ exceptions")
-LANGOPT(EHAsynch          , 1, 0, Affecting, "C/C++ EH Asynch exceptions")
+             AltivecSrcCompatKind::Default, NotCompatible, "Altivec source compatibility")
+LANGOPT(ConvergentFunctions, 1, 1, NotCompatible, "Assume convergent functions")
+LANGOPT(AltiVec           , 1, 0, NotCompatible, "AltiVec-style vector initializers")
+LANGOPT(ZVector           , 1, 0, NotCompatible, "System z vector extensions")
+LANGOPT(Exceptions        , 1, 0, NotCompatible, "exception handling")
+LANGOPT(ObjCExceptions    , 1, 0, NotCompatible, "Objective-C exceptions")
+LANGOPT(CXXExceptions     , 1, 0, NotCompatible, "C++ exceptions")
+LANGOPT(EHAsynch          , 1, 0, NotCompatible, "C/C++ EH Asynch exceptions")
 ENUM_LANGOPT(ExceptionHandling, ExceptionHandlingKind, 3,
-             ExceptionHandlingKind::None,  Affecting, "exception handling")
-LANGOPT(IgnoreExceptions  , 1, 0, Affecting, "ignore exceptions")
-LANGOPT(ExternCNoUnwind   , 1, 0, Affecting, "Assume extern C functions don't unwind")
-LANGOPT(AssumeNothrowExceptionDtor , 1, 0, Affecting, "Assume exception object's destructor is nothrow")
-LANGOPT(TraditionalCPP    , 1, 0, Affecting, "traditional CPP emulation")
-LANGOPT(RTTI              , 1, 1, Affecting, "run-time type information")
-LANGOPT(RTTIData          , 1, 1, Affecting, "emit run-time type information data")
-LANGOPT(MSBitfields       , 1, 0, Affecting, "Microsoft-compatible structure layout")
-LANGOPT(MSVolatile        , 1, 0, Affecting, "Microsoft-compatible volatile loads and stores")
-LANGOPT(Freestanding      , 1, 0, Affecting, "freestanding implementation")
-LANGOPT(NoBuiltin         , 1, 0, Affecting, "disable builtin functions")
-LANGOPT(NoMathBuiltin     , 1, 0, Affecting, "disable math builtin functions")
-LANGOPT(GNUAsm            , 1, 1, Affecting, "GNU-style inline assembly")
-LANGOPT(Coroutines        , 1, 0, Affecting, "C++20 coroutines")
-LANGOPT(CoroAlignedAllocation, 1, 0, Affecting, "prefer Aligned Allocation according to P2014 Option 2")
-LANGOPT(DllExportInlines  , 1, 1, Affecting, "dllexported classes dllexport inline methods")
-LANGOPT(ExperimentalLibrary, 1, 0, Affecting, "enable unstable and experimental library features")
+             ExceptionHandlingKind::None,  NotCompatible, "exception handling")
+LANGOPT(IgnoreExceptions  , 1, 0, NotCompatible, "ignore exceptions")
+LANGOPT(ExternCNoUnwind   , 1, 0, NotCompatible, "Assume extern C functions don't unwind")
+LANGOPT(AssumeNothrowExceptionDtor , 1, 0, NotCompatible, "Assume exception object's destructor is nothrow")
+LANGOPT(TraditionalCPP    , 1, 0, NotCompatible, "traditional CPP emulation")
+LANGOPT(RTTI              , 1, 1, NotCompatible, "run-time type information")
+LANGOPT(RTTIData          , 1, 1, NotCompatible, "emit run-time type information data")
+LANGOPT(MSBitfields       , 1, 0, NotCompatible, "Microsoft-compatible structure layout")
+LANGOPT(MSVolatile        , 1, 0, NotCompatible, "Microsoft-compatible volatile loads and stores")
+LANGOPT(Freestanding      , 1, 0, NotCompatible, "freestanding implementation")
+LANGOPT(NoBuiltin         , 1, 0, NotCompatible, "disable builtin functions")
+LANGOPT(NoMathBuiltin     , 1, 0, NotCompatible, "disable math builtin functions")
+LANGOPT(GNUAsm            , 1, 1, NotCompatible, "GNU-style inline assembly")
+LANGOPT(Coroutines        , 1, 0, NotCompatible, "C++20 coroutines")
+LANGOPT(CoroAlignedAllocation, 1, 0, NotCompatible, "prefer Aligned Allocation according to P2014 Option 2")
+LANGOPT(DllExportInlines  , 1, 1, NotCompatible, "dllexported classes dllexport inline methods")
+LANGOPT(ExperimentalLibrary, 1, 0, NotCompatible, "enable unstable and experimental library features")
 
-LANGOPT(PointerAuthIntrinsics, 1, 0, Affecting, "pointer authentication intrinsics")
-LANGOPT(PointerAuthCalls  , 1, 0, Affecting, "function pointer authentication")
-LANGOPT(PointerAuthReturns, 1, 0, Affecting, "return pointer authentication")
-LANGOPT(PointerAuthIndirectGotos, 1, 0, Affecting, "indirect gotos pointer authentication")
-LANGOPT(PointerAuthAuthTraps, 1, 0, Affecting, "pointer authentication failure traps")
-LANGOPT(PointerAuthVTPtrAddressDiscrimination, 1, 0, Affecting, "incorporate address discrimination in authenticated vtable pointers")
-LANGOPT(PointerAuthVTPtrTypeDiscrimination, 1, 0, Affecting, "incorporate type discrimination in authenticated vtable pointers")
-LANGOPT(PointerAuthTypeInfoVTPtrDiscrimination, 1, 0, Affecting, "incorporate type and address discrimination in authenticated vtable pointers for std::type_info")
+LANGOPT(PointerAuthIntrinsics, 1, 0, NotCompatible, "pointer authentication intrinsics")
+LANGOPT(PointerAuthCalls  , 1, 0, NotCompatible, "function pointer authentication")
+LANGOPT(PointerAuthReturns, 1, 0, NotCompatible, "return pointer authentication")
+LANGOPT(PointerAuthIndirectGotos, 1, 0, NotCompatible, "indirect gotos pointer authentication")
+LANGOPT(PointerAuthAuthTraps, 1, 0, NotCompatible, "pointer authentication failure traps")
+LANGOPT(PointerAuthVTPtrAddressDiscrimination, 1, 0, NotCompatible, "incorporate address discrimination in authenticated vtable pointers")
+LANGOPT(PointerAuthVTPtrTypeDiscrimination, 1, 0, NotCompatible, "incorporate type discrimination in authenticated vtable pointers")
+LANGOPT(PointerAuthTypeInfoVTPtrDiscrimination, 1, 0, NotCompatible, "incorporate type and address discrimination in authenticated vtable pointers for std::type_info")
 LANGOPT(PointerAuthFunctionTypeDiscrimination, 1, 0, Benign,
         "Use type discrimination when signing function pointers")
-LANGOPT(PointerAuthInitFini, 1, 0, Affecting, "sign function pointers in init/fini arrays")
-LANGOPT(PointerAuthInitFiniAddressDiscrimination, 1, 0, Affecting,
+LANGOPT(PointerAuthInitFini, 1, 0, NotCompatible, "sign function pointers in init/fini arrays")
+LANGOPT(PointerAuthInitFiniAddressDiscrimination, 1, 0, NotCompatible,
         "incorporate address discrimination in authenticated function pointers in init/fini arrays")
-LANGOPT(PointerAuthELFGOT, 1, 0, Affecting, "authenticate pointers from GOT")
-LANGOPT(AArch64JumpTableHardening, 1, 0, Affecting, "use hardened lowering for jump-table dispatch")
+LANGOPT(PointerAuthELFGOT, 1, 0, NotCompatible, "authenticate pointers from GOT")
+LANGOPT(AArch64JumpTableHardening, 1, 0, NotCompatible, "use hardened lowering for jump-table dispatch")
 
-LANGOPT(DoubleSquareBracketAttributes, 1, 0, Affecting, "'[[]]' attributes extension for all language standard modes")
-LANGOPT(ExperimentalLateParseAttributes, 1, 0, Affecting, "experimental late parsing of attributes")
+LANGOPT(DoubleSquareBracketAttributes, 1, 0, NotCompatible, "'[[]]' attributes extension for all language standard modes")
+LANGOPT(ExperimentalLateParseAttributes, 1, 0, NotCompatible, "experimental late parsing of attributes")
 
 LANGOPT(RecoveryAST, 1, 1, Compatible, "Preserve expressions in AST when encountering errors")
 LANGOPT(RecoveryASTType, 1, 1, Compatible, "Preserve the type in recovery expressions")
 
 LANGOPT(ThreadsafeStatics , 1, 1, Benign, "thread-safe static initializers")
-LANGOPT(POSIXThreads      , 1, 0, Affecting, "POSIX thread support")
-LANGOPT(Blocks            , 1, 0, Affecting, "blocks extension to C")
+LANGOPT(POSIXThreads      , 1, 0, NotCompatible, "POSIX thread support")
+LANGOPT(Blocks            , 1, 0, NotCompatible, "blocks extension to C")
 LANGOPT(EmitAllDecls      , 1, 0, Benign, "emitting all declarations")
-LANGOPT(MathErrno         , 1, 1, Affecting, "errno in math functions")
-LANGOPT(Modules           , 1, 0, Affecting, "modules semantics")
+LANGOPT(MathErrno         , 1, 1, NotCompatible, "errno in math functions")
+LANGOPT(Modules           , 1, 0, NotCompatible, "modules semantics")
 LANGOPT(CPlusPlusModules  , 1, 0, Compatible, "C++ modules syntax")
-LANGOPT(SkipODRCheckInGMF , 1, 0, Affecting, "Skip ODR checks for decls in the global module fragment")
-LANGOPT(BuiltinHeadersInSystemModules, 1, 0, Affecting, "builtin headers belong to system modules, and _Builtin_ modules are ignored for cstdlib headers")
+LANGOPT(SkipODRCheckInGMF , 1, 0, NotCompatible, "Skip ODR checks for decls in the global module fragment")
+LANGOPT(BuiltinHeadersInSystemModules, 1, 0, NotCompatible, "builtin headers belong to system modules, and _Builtin_ modules are ignored for cstdlib headers")
 ENUM_LANGOPT(CompilingModule, CompilingModuleKind, 3, CMK_None, Benign,
              "compiling a module interface")
 LANGOPT(CompilingPCH, 1, 0, Benign, "building a pch")
@@ -164,20 +164,20 @@ LANGOPT(ModulesLocalVisibility, 1, 0, Compatible, "local submodule visibility")
 LANGOPT(Optimize          , 1, 0, Compatible, "__OPTIMIZE__ predefined macro")
 LANGOPT(OptimizeSize      , 1, 0, Compatible, "__OPTIMIZE_SIZE__ predefined macro")
 LANGOPT(Static            , 1, 0, Compatible, "__STATIC__ predefined macro (as opposed to __DYNAMIC__)")
-VALUE_LANGOPT(PackStruct  , 32, 0, Affecting,
+VALUE_LANGOPT(PackStruct  , 32, 0, NotCompatible,
               "default struct packing maximum alignment")
-VALUE_LANGOPT(MaxTypeAlign  , 32, 0, Affecting,
+VALUE_LANGOPT(MaxTypeAlign  , 32, 0, NotCompatible,
               "default maximum alignment for types")
-VALUE_LANGOPT(AlignDouble            , 1, 0, Affecting, "Controls if doubles should be aligned to 8 bytes (x86 only)")
-VALUE_LANGOPT(DoubleSize            , 32, 0, Affecting, "width of double")
-VALUE_LANGOPT(LongDoubleSize        , 32, 0, Affecting, "width of long double")
-LANGOPT(PPCIEEELongDouble            , 1, 0, Affecting, "use IEEE 754 quadruple-precision for long double")
-LANGOPT(EnableAIXExtendedAltivecABI  , 1, 0, Affecting, "__EXTABI__  predefined macro")
-LANGOPT(EnableAIXQuadwordAtomicsABI  , 1, 0, Affecting, "Use 16-byte atomic lock free semantics")
+VALUE_LANGOPT(AlignDouble            , 1, 0, NotCompatible, "Controls if doubles should be aligned to 8 bytes (x86 only)")
+VALUE_LANGOPT(DoubleSize            , 32, 0, NotCompatible, "width of double")
+VALUE_LANGOPT(LongDoubleSize        , 32, 0, NotCompatible, "width of long double")
+LANGOPT(PPCIEEELongDouble            , 1, 0, NotCompatible, "use IEEE 754 quadruple-precision for long double")
+LANGOPT(EnableAIXExtendedAltivecABI  , 1, 0, NotCompatible, "__EXTABI__  predefined macro")
+LANGOPT(EnableAIXQuadwordAtomicsABI  , 1, 0, NotCompatible, "Use 16-byte atomic lock free semantics")
 VALUE_LANGOPT(PICLevel               , 2, 0, Compatible, "__PIC__ level")
 VALUE_LANGOPT(PIE                    , 1, 0, Compatible, "is pie")
-LANGOPT(ROPI                         , 1, 0, Affecting, "Read-only position independence")
-LANGOPT(RWPI                         , 1, 0, Affecting, "Read-write position independence")
+LANGOPT(ROPI                         , 1, 0, NotCompatible, "Read-only position independence")
+LANGOPT(RWPI                         , 1, 0, NotCompatible, "Read-write position independence")
 LANGOPT(GNUInline                    , 1, 0, Compatible, "GNU inline semantics")
 LANGOPT(NoInlineDefine               , 1, 0, Compatible, "__NO_INLINE__ predefined macro")
 LANGOPT(Deprecated                   , 1, 0, Compatible, "__DEPRECATED predefined macro")
@@ -192,83 +192,83 @@ LANGOPT(NoSignedZero      , 1, 0, Benign, "Permit Floating Point optimization wi
 LANGOPT(AllowRecip        , 1, 0, Benign, "Permit Floating Point reciprocal")
 LANGOPT(ApproxFunc        , 1, 0, Benign, "Permit Floating Point approximation")
 
-ENUM_LANGOPT(ComplexRange, ComplexRangeKind, 3, CX_None, Affecting, "Enable use of range reduction for complex arithmetics.")
+ENUM_LANGOPT(ComplexRange, ComplexRangeKind, 3, CX_None, NotCompatible, "Enable use of range reduction for complex arithmetics.")
 
 LANGOPT(ObjCGCBitmapPrint , 1, 0, Benign, "printing of GC's bitmap layout for __weak/__strong ivars")
 
 LANGOPT(AccessControl     , 1, 1, Benign, "C++ access control")
-LANGOPT(CharIsSigned      , 1, 1, Affecting, "signed char")
-LANGOPT(WCharSize         , 4, 0, Affecting, "width of wchar_t")
-LANGOPT(WCharIsSigned        , 1, 0, Affecting, "signed or unsigned wchar_t")
-ENUM_LANGOPT(MSPointerToMemberRepresentationMethod, PragmaMSPointersToMembersKind, 2, PPTMK_BestCase, Affecting, "member-pointer representation method")
-ENUM_LANGOPT(DefaultCallingConv, DefaultCallingConvention, 3, DCC_None, Affecting, "default calling convention")
+LANGOPT(CharIsSigned      , 1, 1, NotCompatible, "signed char")
+LANGOPT(WCharSize         , 4, 0, NotCompatible, "width of wchar_t")
+LANGOPT(WCharIsSigned        , 1, 0, NotCompatible, "signed or unsigned wchar_t")
+ENUM_LANGOPT(MSPointerToMemberRepresentationMethod, PragmaMSPointersToMembersKind, 2, PPTMK_BestCase, NotCompatible, "member-pointer representation method")
+ENUM_LANGOPT(DefaultCallingConv, DefaultCallingConvention, 3, DCC_None, NotCompatible, "default calling convention")
 
-LANGOPT(ShortEnums        , 1, 0, Affecting, "short enum types")
+LANGOPT(ShortEnums        , 1, 0, NotCompatible, "short enum types")
 
-LANGOPT(OpenCL            , 1, 0, Affecting, "OpenCL")
-LANGOPT(OpenCLVersion     , 32, 0, Affecting, "OpenCL C version")
-LANGOPT(OpenCLCPlusPlus   , 1, 0, Affecting, "C++ for OpenCL")
-LANGOPT(OpenCLCPlusPlusVersion     , 32, 0, Affecting, "C++ for OpenCL version")
-LANGOPT(OpenCLGenericAddressSpace, 1, 0, Affecting, "OpenCL generic keyword")
-LANGOPT(OpenCLPipes              , 1, 0, Affecting, "OpenCL pipes language constructs and built-ins")
-LANGOPT(NativeHalfType    , 1, 0, Affecting, "Native half type support")
-LANGOPT(NativeHalfArgsAndReturns, 1, 0, Affecting, "Native half args and returns")
-LANGOPT(CUDA              , 1, 0, Affecting, "CUDA")
-LANGOPT(HIP               , 1, 0, Affecting, "HIP")
-LANGOPT(OpenMP            , 32, 0, Affecting, "OpenMP support and version of OpenMP (31, 40 or 45)")
-LANGOPT(OpenMPExtensions  , 1, 1, Affecting, "Enable all Clang extensions for OpenMP directives and clauses")
-LANGOPT(OpenMPSimd        , 1, 0, Affecting, "Use SIMD only OpenMP support.")
-LANGOPT(OpenMPUseTLS      , 1, 0, Affecting, "Use TLS for threadprivates or runtime calls")
-LANGOPT(OpenMPIsTargetDevice    , 1, 0, Affecting, "Generate code only for OpenMP target device")
-LANGOPT(OpenMPCUDAMode    , 1, 0, Affecting, "Generate code for OpenMP pragmas in SIMT/SPMD mode")
-LANGOPT(OpenMPIRBuilder   , 1, 0, Affecting, "Use the experimental OpenMP-IR-Builder codegen path.")
-LANGOPT(OpenMPCUDANumSMs  , 32, 0, Affecting, "Number of SMs for CUDA devices.")
-LANGOPT(OpenMPCUDABlocksPerSM  , 32, 0, Affecting, "Number of blocks per SM for CUDA devices.")
-LANGOPT(OpenMPCUDAReductionBufNum , 32, 1024, Affecting, "Number of the reduction records in the intermediate reduction buffer used for the teams reductions.")
-LANGOPT(OpenMPTargetDebug , 32, 0, Affecting, "Enable debugging in the OpenMP offloading device RTL")
-LANGOPT(OpenMPOptimisticCollapse  , 1, 0, Affecting, "Use at most 32 bits to represent the collapsed loop nest counter.")
-LANGOPT(OpenMPThreadSubscription  , 1, 0, Affecting, "Assume work-shared loops do not have more iterations than participating threads.")
-LANGOPT(OpenMPTeamSubscription  , 1, 0, Affecting, "Assume distributed loops do not have more iterations than participating teams.")
-LANGOPT(OpenMPNoThreadState  , 1, 0, Affecting, "Assume that no thread in a parallel region will modify an ICV.")
-LANGOPT(OpenMPNoNestedParallelism  , 1, 0, Affecting, "Assume that no thread in a parallel region will encounter a parallel region")
-LANGOPT(OpenMPOffloadMandatory  , 1, 0, Affecting, "Assert that offloading is mandatory and do not create a host fallback.")
-LANGOPT(OpenMPForceUSM     , 1, 0, Affecting, "Enable OpenMP unified shared memory mode via compiler.")
-LANGOPT(NoGPULib  , 1, 0, Affecting, "Indicate a build without the standard GPU libraries.")
+LANGOPT(OpenCL            , 1, 0, NotCompatible, "OpenCL")
+LANGOPT(OpenCLVersion     , 32, 0, NotCompatible, "OpenCL C version")
+LANGOPT(OpenCLCPlusPlus   , 1, 0, NotCompatible, "C++ for OpenCL")
+LANGOPT(OpenCLCPlusPlusVersion     , 32, 0, NotCompatible, "C++ for OpenCL version")
+LANGOPT(OpenCLGenericAddressSpace, 1, 0, NotCompatible, "OpenCL generic keyword")
+LANGOPT(OpenCLPipes              , 1, 0, NotCompatible, "OpenCL pipes language constructs and built-ins")
+LANGOPT(NativeHalfType    , 1, 0, NotCompatible, "Native half type support")
+LANGOPT(NativeHalfArgsAndReturns, 1, 0, NotCompatible, "Native half args and returns")
+LANGOPT(CUDA              , 1, 0, NotCompatible, "CUDA")
+LANGOPT(HIP               , 1, 0, NotCompatible, "HIP")
+LANGOPT(OpenMP            , 32, 0, NotCompatible, "OpenMP support and version of OpenMP (31, 40 or 45)")
+LANGOPT(OpenMPExtensions  , 1, 1, NotCompatible, "Enable all Clang extensions for OpenMP directives and clauses")
+LANGOPT(OpenMPSimd        , 1, 0, NotCompatible, "Use SIMD only OpenMP support.")
+LANGOPT(OpenMPUseTLS      , 1, 0, NotCompatible, "Use TLS for threadprivates or runtime calls")
+LANGOPT(OpenMPIsTargetDevice    , 1, 0, NotCompatible, "Generate code only for OpenMP target device")
+LANGOPT(OpenMPCUDAMode    , 1, 0, NotCompatible, "Generate code for OpenMP pragmas in SIMT/SPMD mode")
+LANGOPT(OpenMPIRBuilder   , 1, 0, NotCompatible, "Use the experimental OpenMP-IR-Builder codegen path.")
+LANGOPT(OpenMPCUDANumSMs  , 32, 0, NotCompatible, "Number of SMs for CUDA devices.")
+LANGOPT(OpenMPCUDABlocksPerSM  , 32, 0, NotCompatible, "Number of blocks per SM for CUDA devices.")
+LANGOPT(OpenMPCUDAReductionBufNum , 32, 1024, NotCompatible, "Number of the reduction records in the intermediate reduction buffer used for the teams reductions.")
+LANGOPT(OpenMPTargetDebug , 32, 0, NotCompatible, "Enable debugging in the OpenMP offloading device RTL")
+LANGOPT(OpenMPOptimisticCollapse  , 1, 0, NotCompatible, "Use at most 32 bits to represent the collapsed loop nest counter.")
+LANGOPT(OpenMPThreadSubscription  , 1, 0, NotCompatible, "Assume work-shared loops do not have more iterations than participating threads.")
+LANGOPT(OpenMPTeamSubscription  , 1, 0, NotCompatible, "Assume distributed loops do not have more iterations than participating teams.")
+LANGOPT(OpenMPNoThreadState  , 1, 0, NotCompatible, "Assume that no thread in a parallel region will modify an ICV.")
+LANGOPT(OpenMPNoNestedParallelism  , 1, 0, NotCompatible, "Assume that no thread in a parallel region will encounter a parallel region")
+LANGOPT(OpenMPOffloadMandatory  , 1, 0, NotCompatible, "Assert that offloading is mandatory and do not create a host fallback.")
+LANGOPT(OpenMPForceUSM     , 1, 0, NotCompatible, "Enable OpenMP unified shared memory mode via compiler.")
+LANGOPT(NoGPULib  , 1, 0, NotCompatible, "Indicate a build without the standard GPU libraries.")
 
-LANGOPT(HLSL, 1, 0, Affecting, "HLSL")
-ENUM_LANGOPT(HLSLVersion, HLSLLangStd, 16, HLSL_Unset, Affecting, "HLSL Version")
-LANGOPT(HLSLStrictAvailability, 1, 0, Affecting,
+LANGOPT(HLSL, 1, 0, NotCompatible, "HLSL")
+ENUM_LANGOPT(HLSLVersion, HLSLLangStd, 16, HLSL_Unset, NotCompatible, "HLSL Version")
+LANGOPT(HLSLStrictAvailability, 1, 0, NotCompatible,
         "Strict availability diagnostic mode for HLSL built-in functions.")
 
-LANGOPT(CUDAIsDevice      , 1, 0, Affecting, "compiling for CUDA device")
-LANGOPT(CUDAAllowVariadicFunctions, 1, 0, Affecting, "allowing variadic functions in CUDA device code")
-LANGOPT(CUDAHostDeviceConstexpr, 1, 1, Affecting, "treating unattributed constexpr functions as __host__ __device__")
-LANGOPT(GPUDeviceApproxTranscendentals, 1, 0, Affecting, "using approximate transcendental functions")
-LANGOPT(GPURelocatableDeviceCode, 1, 0, Affecting, "generate relocatable device code")
-LANGOPT(OffloadImplicitHostDeviceTemplates, 1, 0, Affecting, "assume template functions to be implicitly host device by default for CUDA/HIP")
-LANGOPT(GPUAllowDeviceInit, 1, 0, Affecting, "allowing device side global init functions for HIP")
-LANGOPT(GPUMaxThreadsPerBlock, 32, 1024, Affecting, "default max threads per block for kernel launch bounds for HIP")
-LANGOPT(GPUDeferDiag, 1, 0, Affecting, "defer host/device related diagnostic messages for CUDA/HIP")
-LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, Affecting, "always exclude wrong side overloads in overloading resolution for CUDA/HIP")
-LANGOPT(OffloadingNewDriver, 1, 0, Affecting, "use the new driver for generating offloading code.")
-LANGOPT(OffloadViaLLVM, 1, 0, Affecting, "target LLVM/Offload as portable offloading runtime.")
+LANGOPT(CUDAIsDevice      , 1, 0, NotCompatible, "compiling for CUDA device")
+LANGOPT(CUDAAllowVariadicFunctions, 1, 0, NotCompatible, "allowing variadic functions in CUDA device code")
+LANGOPT(CUDAHostDeviceConstexpr, 1, 1, NotCompatible, "treating unattributed constexpr functions as __host__ __device__")
+LANGOPT(GPUDeviceApproxTranscendentals, 1, 0, NotCompatible, "using approximate transcendental functions")
+LANGOPT(GPURelocatableDeviceCode, 1, 0, NotCompatible, "generate relocatable device code")
+LANGOPT(OffloadImplicitHostDeviceTemplates, 1, 0, NotCompatible, "assume template functions to be implicitly host device by default for CUDA/HIP")
+LANGOPT(GPUAllowDeviceInit, 1, 0, NotCompatible, "allowing device side global init functions for HIP")
+LANGOPT(GPUMaxThreadsPerBlock, 32, 1024, NotCompatible, "default max threads per block for kernel launch bounds for HIP")
+LANGOPT(GPUDeferDiag, 1, 0, NotCompatible, "defer host/device related diagnostic messages for CUDA/HIP")
+LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, NotCompatible, "always exclude wrong side overloads in overloading resolution for CUDA/HIP")
+LANGOPT(OffloadingNewDriver, 1, 0, NotCompatible, "use the new driver for generating offloading code.")
+LANGOPT(OffloadViaLLVM, 1, 0, NotCompatible, "target LLVM/Offload as portable offloading runtime.")
 
-LANGOPT(SYCLIsDevice      , 1, 0, Affecting, "Generate code for SYCL device")
-LANGOPT(SYCLIsHost        , 1, 0, Affecting, "SYCL host compilation")
-ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, Affecting, "Version of the SYCL standard used")
+LANGOPT(SYCLIsDevice      , 1, 0, NotCompatible, "Generate code for SYCL device")
+LANGOPT(SYCLIsHost        , 1, 0, NotCompatible, "SYCL host compilation")
+ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, NotCompatible, "Version of the SYCL standard used")
 
-LANGOPT(HIPUseNewLaunchAPI, 1, 0, Affecting, "Use new kernel launching API for HIP")
-LANGOPT(OffloadUniformBlock, 1, 0, Affecting, "Assume that kernels are launched with uniform block sizes (default true for CUDA/HIP and false otherwise)")
-LANGOPT(HIPStdPar, 1, 0, Affecting, "Enable Standard Parallel Algorithm Acceleration for HIP (experimental)")
-LANGOPT(HIPStdParInterposeAlloc, 1, 0, Affecting, "Replace allocations / deallocations with HIP RT calls when Standard Parallel Algorithm Acceleration for HIP is enabled (Experimental)")
+LANGOPT(HIPUseNewLaunchAPI, 1, 0, NotCompatible, "Use new kernel launching API for HIP")
+LANGOPT(OffloadUniformBlock, 1, 0, NotCompatible, "Assume that kernels are launched with uniform block sizes (default true for CUDA/HIP and false otherwise)")
+LANGOPT(HIPStdPar, 1, 0, NotCompatible, "Enable Standard Parallel Algorithm Acceleration for HIP (experimental)")
+LANGOPT(HIPStdParInterposeAlloc, 1, 0, NotCompatible, "Replace allocations / deallocations with HIP RT calls when Standard Parallel Algorithm Acceleration for HIP is enabled (Experimental)")
 
-LANGOPT(OpenACC           , 1, 0, Affecting, "OpenACC Enabled")
+LANGOPT(OpenACC           , 1, 0, NotCompatible, "OpenACC Enabled")
 
-LANGOPT(MSVCEnableStdcMacro , 1, 0, Affecting, "Define __STDC__ with '-fms-compatibility'")
-LANGOPT(SizedDeallocation , 1, 0, Affecting, "sized deallocation")
-LANGOPT(AlignedAllocation , 1, 0, Affecting, "aligned allocation")
-LANGOPT(AlignedAllocationUnavailable, 1, 0, Affecting, "aligned allocation functions are unavailable")
-LANGOPT(NewAlignOverride  , 32, 0, Affecting, "maximum alignment guaranteed by '::operator new(size_t)'")
+LANGOPT(MSVCEnableStdcMacro , 1, 0, NotCompatible, "Define __STDC__ with '-fms-compatibility'")
+LANGOPT(SizedDeallocation , 1, 0, NotCompatible, "sized deallocation")
+LANGOPT(AlignedAllocation , 1, 0, NotCompatible, "aligned allocation")
+LANGOPT(AlignedAllocationUnavailable, 1, 0, NotCompatible, "aligned allocation functions are unavailable")
+LANGOPT(NewAlignOverride  , 32, 0, NotCompatible, "maximum alignment guaranteed by '::operator new(size_t)'")
 LANGOPT(ModulesCodegen , 1, 0, Benign, "Modules code generation")
 LANGOPT(ModulesDebugInfo , 1, 0, Benign, "Modules debug info")
 LANGOPT(ElideConstructors , 1, 1, Benign, "C++ copy constructor elision")
@@ -277,24 +277,24 @@ LANGOPT(DumpRecordLayoutsSimple , 1, 0, Benign, "dumping the layout of IRgen'd r
 LANGOPT(DumpRecordLayoutsCanonical , 1, 0, Benign, "dumping the AST layout of records using canonical field types")
 LANGOPT(DumpRecordLayoutsComplete , 1, 0, Benign, "dumping the AST layout of all complete records")
 LANGOPT(DumpVTableLayouts , 1, 0, Benign, "dumping the layouts of emitted vtables")
-LANGOPT(NoConstantCFStrings , 1, 0, Affecting, "no constant CoreFoundation strings")
+LANGOPT(NoConstantCFStrings , 1, 0, NotCompatible, "no constant CoreFoundation strings")
 LANGOPT(InlineVisibilityHidden , 1, 0, Benign, "hidden visibility for inline C++ methods")
 ENUM_LANGOPT(DefaultVisibilityExportMapping, DefaultVisiblityExportMapping, 2, DefaultVisiblityExportMapping::None, Benign, "controls mapping of default visibility to dllexport")
 LANGOPT(IgnoreXCOFFVisibility, 1, 0, Benign, "All the visibility attributes that are specified in the source code are ignored in aix XCOFF.")
 LANGOPT(VisibilityInlinesHiddenStaticLocalVar, 1, 0, Benign,
         "hidden visibility for static local variables in inline C++ "
         "methods when -fvisibility-inlines hidden is enabled")
-ENUM_LANGOPT(GlobalAllocationFunctionVisibility, VisibilityForcedKinds, 3, VisibilityForcedKinds::ForceDefault, Affecting,
+ENUM_LANGOPT(GlobalAllocationFunctionVisibility, VisibilityForcedKinds, 3, VisibilityForcedKinds::ForceDefault, NotCompatible,
              "How to apply visibility to global operator new and delete declarations")
-LANGOPT(NewInfallible , 1, 0, Affecting, "Treats throwing global C++ operator new as always returning valid memory (annotates with __attribute__((returns_nonnull)) and throw()). This is detectable in source.")
+LANGOPT(NewInfallible , 1, 0, NotCompatible, "Treats throwing global C++ operator new as always returning valid memory (annotates with __attribute__((returns_nonnull)) and throw()). This is detectable in source.")
 LANGOPT(ParseUnknownAnytype, 1, 0, Benign, "__unknown_anytype")
 LANGOPT(DebuggerSupport , 1, 0, Benign, "debugger support")
 LANGOPT(DebuggerCastResultToId, 1, 0, Benign, "for 'po' in the debugger, cast the result to id if it is of unknown type")
 LANGOPT(DebuggerObjCLiteral , 1, 0, Benign, "debugger Objective-C literals and subscripting support")
 
 LANGOPT(SpellChecking , 1, 1, Benign, "spell-checking")
-LANGOPT(SinglePrecisionConstants , 1, 0, Affecting, "treating double-precision floating point constants as single precision constants")
-LANGOPT(FastRelaxedMath , 1, 0, Affecting, "OpenCL fast relaxed math")
+LANGOPT(SinglePrecisionConstants , 1, 0, NotCompatible, "treating double-precision floating point constants as single precision constants")
+LANGOPT(FastRelaxedMath , 1, 0, NotCompatible, "OpenCL fast relaxed math")
 LANGOPT(CLNoSignedZero , 1, 0, Benign, "Permit Floating Point optimization without regard to signed zeros")
 LANGOPT(CLUnsafeMath , 1, 0, Compatible, "Unsafe Floating Point Math")
 /// FP_CONTRACT mode (on/off/fast).
@@ -303,40 +303,40 @@ LANGOPT(ExpStrictFP, 1, false, Compatible, "Enable experimental strict floating 
 LANGOPT(RoundingMath, 1, false, Benign, "Do not assume default floating-point rounding behavior")
 ENUM_LANGOPT(FPExceptionMode, FPExceptionModeKind, 2, FPE_Default, Benign, "FP Exception Behavior Mode type")
 ENUM_LANGOPT(FPEvalMethod, FPEvalMethodKind, 2, FEM_UnsetOnCommandLine, Benign, "FP type used for floating point arithmetic")
-ENUM_LANGOPT(Float16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, Affecting, "Intermediate truncation behavior for Float16 arithmetic")
-ENUM_LANGOPT(BFloat16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, Affecting, "Intermediate truncation behavior for BFloat16 arithmetic")
-LANGOPT(NoBitFieldTypeAlign , 1, 0, Affecting, "bit-field type alignment")
-LANGOPT(HexagonQdsp6Compat , 1, 0, Affecting, "hexagon-qdsp6 backward compatibility")
-LANGOPT(ObjCAutoRefCount , 1, 0, Affecting, "Objective-C automated reference counting")
-LANGOPT(ObjCWeakRuntime     , 1, 0, Affecting, "__weak support in the ARC runtime")
-LANGOPT(ObjCWeak            , 1, 0, Affecting, "Objective-C __weak in ARC and MRC files")
-LANGOPT(ObjCSubscriptingLegacyRuntime         , 1, 0, Affecting, "Subscripting support in legacy ObjectiveC runtime")
+ENUM_LANGOPT(Float16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, NotCompatible, "Intermediate truncation behavior for Float16 arithmetic")
+ENUM_LANGOPT(BFloat16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, NotCompatible, "Intermediate truncation behavior for BFloat16 arithmetic")
+LANGOPT(NoBitFieldTypeAlign , 1, 0, NotCompatible, "bit-field type alignment")
+LANGOPT(HexagonQdsp6Compat , 1, 0, NotCompatible, "hexagon-qdsp6 backward compatibility")
+LANGOPT(ObjCAutoRefCount , 1, 0, NotCompatible, "Objective-C automated reference counting")
+LANGOPT(ObjCWeakRuntime     , 1, 0, NotCompatible, "__weak support in the ARC runtime")
+LANGOPT(ObjCWeak            , 1, 0, NotCompatible, "Objective-C __weak in ARC and MRC files")
+LANGOPT(ObjCSubscriptingLegacyRuntime         , 1, 0, NotCompatible, "Subscripting support in legacy ObjectiveC runtime")
 LANGOPT(CompatibilityQualifiedIdBlockParamTypeChecking, 1, 0, Benign,
         "compatibility mode for type checking block parameters "
         "involving qualified id types")
-LANGOPT(ObjCDisableDirectMethodsForTesting, 1, 0, Affecting,
+LANGOPT(ObjCDisableDirectMethodsForTesting, 1, 0, NotCompatible,
         "Disable recognition of objc_direct methods")
-LANGOPT(CFProtectionBranch , 1, 0, Affecting, "Control-Flow Branch Protection enabled")
-ENUM_LANGOPT(CFBranchLabelScheme, CFBranchLabelSchemeKind, 2, CFBranchLabelSchemeKind::Default, Affecting,
+LANGOPT(CFProtectionBranch , 1, 0, NotCompatible, "Control-Flow Branch Protection enabled")
+ENUM_LANGOPT(CFBranchLabelScheme, CFBranchLabelSchemeKind, 2, CFBranchLabelSchemeKind::Default, NotCompatible,
              "Control-Flow Branch Protection Label Scheme")
-LANGOPT(CFProtectionReturn, 1, 0, Affecting, "Control-Flow Return Protection enabled")
-LANGOPT(FakeAddressSpaceMap , 1, 0, Affecting, "OpenCL fake address space map")
-ENUM_LANGOPT(AddressSpaceMapMangling , AddrSpaceMapMangling, 2, ASMM_Target, Affecting, "OpenCL address space map mangling mode")
-LANGOPT(IncludeDefaultHeader, 1, 0, Affecting, "Include default header file for OpenCL")
-LANGOPT(DeclareOpenCLBuiltins, 1, 0, Affecting, "Declare OpenCL builtin functions")
+LANGOPT(CFProtectionReturn, 1, 0, NotCompatible, "Control-Flow Return Protection enabled")
+LANGOPT(FakeAddressSpaceMap , 1, 0, NotCompatible, "OpenCL fake address space map")
+ENUM_LANGOPT(AddressSpaceMapMangling , AddrSpaceMapMangling, 2, ASMM_Target, NotCompatible, "OpenCL address space map mangling mode")
+LANGOPT(IncludeDefaultHeader, 1, 0, NotCompatible, "Include default header file for OpenCL")
+LANGOPT(DeclareOpenCLBuiltins, 1, 0, NotCompatible, "Declare OpenCL builtin functions")
 LANGOPT(DelayedTemplateParsing , 1, 0, Benign, "delayed template parsing")
-LANGOPT(BlocksRuntimeOptional , 1, 0, Affecting, "optional blocks runtime")
+LANGOPT(BlocksRuntimeOptional , 1, 0, NotCompatible, "optional blocks runtime")
 LANGOPT(
-    CompleteMemberPointers, 1, 0, Affecting,
+    CompleteMemberPointers, 1, 0, NotCompatible,
     "Require member pointer base types to be complete at the point where the "
     "type's inheritance model would be determined under the Microsoft ABI")
 
-ENUM_LANGOPT(GC, GCMode, 2, NonGC, Affecting, "Objective-C Garbage Collection mode")
+ENUM_LANGOPT(GC, GCMode, 2, NonGC, NotCompatible, "Objective-C Garbage Collection mode")
 ENUM_LANGOPT(ValueVisibilityMode, Visibility, 3, DefaultVisibility, Benign,
              "default visibility for functions and variables [-fvisibility]")
 ENUM_LANGOPT(TypeVisibilityMode, Visibility, 3, DefaultVisibility, Benign,
              "default visibility for types [-ftype-visibility]")
-LANGOPT(SetVisibilityForExternDecls, 1, 0, Affecting,
+LANGOPT(SetVisibilityForExternDecls, 1, 0, NotCompatible,
         "apply global symbol visibility to external declarations without an explicit visibility")
 LANGOPT(VisibilityFromDLLStorageClass, 1, 0, Benign,
         "override the visibility of globals based on their final DLL storage class [-fvisibility-from-dllstorageclass]")
@@ -351,7 +351,7 @@ ENUM_LANGOPT(ExternDeclNoDLLStorageClassVisibility, VisibilityFromDLLStorageClas
 LANGOPT(SemanticInterposition        , 1, 0, Benign, "semantic interposition")
 LANGOPT(HalfNoSemanticInterposition, 1, 0, Benign,
         "Like -fno-semantic-interposition but don't use local aliases")
-ENUM_LANGOPT(StackProtector, StackProtectorMode, 2, SSPOff, Affecting,
+ENUM_LANGOPT(StackProtector, StackProtectorMode, 2, SSPOff, NotCompatible,
              "stack protector mode")
 ENUM_LANGOPT(TrivialAutoVarInit, TrivialAutoVarInitKind, 2, TrivialAutoVarInitKind::Uninitialized, Benign,
              "trivial automatic variable initialization")
@@ -359,10 +359,10 @@ VALUE_LANGOPT(TrivialAutoVarInitStopAfter, 32, 0, Benign,
               "stop trivial automatic variable initialization after the specified number of instances. Must be greater than 0.")
 VALUE_LANGOPT(TrivialAutoVarInitMaxSize, 32, 0, Benign,
               "stop trivial automatic variable initialization if var size exceeds the specified size (in bytes). Must be greater than 0.")
-ENUM_LANGOPT(SignedOverflowBehavior, SignedOverflowBehaviorTy, 2, SOB_Undefined, Affecting,
+ENUM_LANGOPT(SignedOverflowBehavior, SignedOverflowBehaviorTy, 2, SOB_Undefined, NotCompatible,
              "signed integer overflow handling")
-LANGOPT(PointerOverflowDefined, 1, 0, Affecting, "make pointer overflow defined")
-ENUM_LANGOPT(ThreadModel  , ThreadModelKind, 2, ThreadModelKind::POSIX, Affecting, "Thread Model")
+LANGOPT(PointerOverflowDefined, 1, 0, NotCompatible, "make pointer overflow defined")
+ENUM_LANGOPT(ThreadModel  , ThreadModelKind, 2, ThreadModelKind::POSIX, NotCompatible, "Thread Model")
 
 LANGOPT(ArrowDepth, 32, 256, Benign,
         "maximum number of operator->s to follow")
@@ -378,94 +378,94 @@ LANGOPT(BracketDepth, 32, 256, Benign,
         "maximum bracket nesting depth")
 LANGOPT(NumLargeByValueCopy, 32, 0, Benign,
         "if non-zero, warn about parameter or return Warn if parameter/return value is larger in bytes than this setting. 0 is no check.")
-VALUE_LANGOPT(MSCompatibilityVersion, 32, 0, Affecting, "Microsoft Visual C/C++ Version")
-ENUM_LANGOPT(VtorDispMode, MSVtorDispMode, 2, MSVtorDispMode::ForVBaseOverride, Affecting,
+VALUE_LANGOPT(MSCompatibilityVersion, 32, 0, NotCompatible, "Microsoft Visual C/C++ Version")
+ENUM_LANGOPT(VtorDispMode, MSVtorDispMode, 2, MSVtorDispMode::ForVBaseOverride, NotCompatible,
              "How many vtordisps to insert")
 
-LANGOPT(ApplePragmaPack, 1, 0, Affecting, "Apple gcc-compatible #pragma pack handling")
+LANGOPT(ApplePragmaPack, 1, 0, NotCompatible, "Apple gcc-compatible #pragma pack handling")
 
-LANGOPT(XLPragmaPack, 1, 0, Affecting, "IBM XL #pragma pack handling")
+LANGOPT(XLPragmaPack, 1, 0, NotCompatible, "IBM XL #pragma pack handling")
 
 LANGOPT(RetainCommentsFromSystemHeaders, 1, 0, Compatible, "retain documentation comments from system headers in the AST")
 
-LANGOPT(APINotes, 1, 0, Affecting, "use external API notes")
-LANGOPT(APINotesModules, 1, 0, Affecting, "use module-based external API notes")
+LANGOPT(APINotes, 1, 0, NotCompatible, "use external API notes")
+LANGOPT(APINotesModules, 1, 0, NotCompatible, "use module-based external API notes")
 
-LANGOPT(SanitizeAddressFieldPadding, 2, 0, Affecting, "controls how aggressive is ASan "
+LANGOPT(SanitizeAddressFieldPadding, 2, 0, NotCompatible, "controls how aggressive is ASan "
                                                       "field padding (0: none, 1:least "
                                                       "aggressive, 2: more aggressive)")
 
-LANGOPT(Cmse, 1, 0, Affecting, "ARM Security extensions support")
+LANGOPT(Cmse, 1, 0, NotCompatible, "ARM Security extensions support")
 
-LANGOPT(XRayInstrument, 1, 0, Affecting, "controls whether to do XRay instrumentation")
-LANGOPT(XRayAlwaysEmitCustomEvents, 1, 0, Affecting,
+LANGOPT(XRayInstrument, 1, 0, NotCompatible, "controls whether to do XRay instrumentation")
+LANGOPT(XRayAlwaysEmitCustomEvents, 1, 0, NotCompatible,
         "controls whether to always emit intrinsic calls to "
         "__xray_customevent(...) builtin.")
-LANGOPT(XRayAlwaysEmitTypedEvents, 1, 0, Affecting,
+LANGOPT(XRayAlwaysEmitTypedEvents, 1, 0, NotCompatible,
         "controls whether to always emit intrinsic calls to "
         "__xray_typedevent(...) builtin.")
 
-LANGOPT(ForceEmitVTables, 1, 0, Affecting, "whether to emit all vtables")
+LANGOPT(ForceEmitVTables, 1, 0, NotCompatible, "whether to emit all vtables")
 
 LANGOPT(AllowEditorPlaceholders, 1, 0, Benign,
         "allow editor placeholders in source")
 
-ENUM_LANGOPT(ClangABICompat, ClangABI, 4, ClangABI::Latest, Affecting,
+ENUM_LANGOPT(ClangABICompat, ClangABI, 4, ClangABI::Latest, NotCompatible,
              "version of Clang that we should attempt to be ABI-compatible "
              "with")
 
 VALUE_LANGOPT(FunctionAlignment, 5, 0, Compatible, "Default alignment for functions")
 VALUE_LANGOPT(LoopAlignment, 32, 0, Compatible, "Default alignment for loops")
 
-LANGOPT(FixedPoint, 1, 0, Affecting, "fixed point types")
-LANGOPT(PaddingOnUnsignedFixedPoint, 1, 0, Affecting,
+LANGOPT(FixedPoint, 1, 0, NotCompatible, "fixed point types")
+LANGOPT(PaddingOnUnsignedFixedPoint, 1, 0, NotCompatible,
         "unsigned fixed point types having one extra padding bit")
 
 ENUM_LANGOPT(RegisterStaticDestructors, RegisterStaticDestructorsKind, 2,
-             RegisterStaticDestructorsKind::All, Affecting,
+             RegisterStaticDestructorsKind::All, NotCompatible,
              "Register C++ static destructors")
 
-LANGOPT(RegCall4, 1, 0, Affecting, "Set __regcall4 as a default calling convention to respect __regcall ABI v.4")
+LANGOPT(RegCall4, 1, 0, NotCompatible, "Set __regcall4 as a default calling convention to respect __regcall ABI v.4")
 
-LANGOPT(MatrixTypes, 1, 0, Affecting, "Enable or disable the builtin matrix type")
+LANGOPT(MatrixTypes, 1, 0, NotCompatible, "Enable or disable the builtin matrix type")
 
-LANGOPT(CXXAssumptions, 1, 1, Affecting, "Enable or disable codegen and compile-time checks for C++23's [[assume]] attribute")
+LANGOPT(CXXAssumptions, 1, 1, NotCompatible, "Enable or disable codegen and compile-time checks for C++23's [[assume]] attribute")
 
-LANGOPT(RawStringLiterals, 1, 1, Affecting, "Enable or disable raw string literals")
+LANGOPT(RawStringLiterals, 1, 1, NotCompatible, "Enable or disable raw string literals")
 
 ENUM_LANGOPT(StrictFlexArraysLevel, StrictFlexArraysLevelKind, 2,
-             StrictFlexArraysLevelKind::Default, Affecting,
+             StrictFlexArraysLevelKind::Default, NotCompatible,
              "Rely on strict definition of flexible arrays")
 
 VALUE_LANGOPT(MaxTokens, 32, 0, Compatible, "Max number of tokens per TU or 0")
 
-ENUM_LANGOPT(SignReturnAddressScope, SignReturnAddressScopeKind, 2, SignReturnAddressScopeKind::None, Affecting,
+ENUM_LANGOPT(SignReturnAddressScope, SignReturnAddressScopeKind, 2, SignReturnAddressScopeKind::None, NotCompatible,
              "Scope of return address signing")
-ENUM_LANGOPT(SignReturnAddressKey, SignReturnAddressKeyKind, 1, SignReturnAddressKeyKind::AKey, Affecting,
+ENUM_LANGOPT(SignReturnAddressKey, SignReturnAddressKeyKind, 1, SignReturnAddressKeyKind::AKey, NotCompatible,
              "Key used for return address signing")
-LANGOPT(BranchTargetEnforcement, 1, 0, Affecting, "Branch-target enforcement enabled")
-LANGOPT(BranchProtectionPAuthLR, 1, 0, Affecting, "Use PC as a diversifier using PAuthLR NOP instructions.")
-LANGOPT(GuardedControlStack, 1, 0, Affecting, "Guarded control stack enabled")
+LANGOPT(BranchTargetEnforcement, 1, 0, NotCompatible, "Branch-target enforcement enabled")
+LANGOPT(BranchProtectionPAuthLR, 1, 0, NotCompatible, "Use PC as a diversifier using PAuthLR NOP instructions.")
+LANGOPT(GuardedControlStack, 1, 0, NotCompatible, "Guarded control stack enabled")
 
-LANGOPT(SpeculativeLoadHardening, 1, 0, Affecting, "Speculative load hardening enabled")
+LANGOPT(SpeculativeLoadHardening, 1, 0, NotCompatible, "Speculative load hardening enabled")
 
-LANGOPT(RelativeCXXABIVTables, 1, 0, Affecting,
+LANGOPT(RelativeCXXABIVTables, 1, 0, NotCompatible,
         "Use an ABI-incompatible v-table layout that uses relative references")
 
-LANGOPT(OmitVTableRTTI, 1, 0, Affecting,
+LANGOPT(OmitVTableRTTI, 1, 0, NotCompatible,
         "Use an ABI-incompatible v-table layout that omits the RTTI component")
 
-LANGOPT(VScaleMin, 32, 0, Affecting, "Minimum vscale value")
-LANGOPT(VScaleMax, 32, 0, Affecting, "Maximum vscale value")
+LANGOPT(VScaleMin, 32, 0, NotCompatible, "Minimum vscale value")
+LANGOPT(VScaleMax, 32, 0, NotCompatible, "Maximum vscale value")
 
-LANGOPT(VScaleStreamingMin, 32, 0, Affecting, "Minimum streaming vscale value")
-LANGOPT(VScaleStreamingMax, 32, 0, Affecting, "Maximum streaming vscale value")
+LANGOPT(VScaleStreamingMin, 32, 0, NotCompatible, "Minimum streaming vscale value")
+LANGOPT(VScaleStreamingMax, 32, 0, NotCompatible, "Maximum streaming vscale value")
 
-ENUM_LANGOPT(ExtendIntArgs, ExtendArgsKind, 1, ExtendArgsKind::ExtendTo32, Affecting,
+ENUM_LANGOPT(ExtendIntArgs, ExtendArgsKind, 1, ExtendArgsKind::ExtendTo32, NotCompatible,
              "Controls how scalar integer arguments are extended in calls "
              "to unprototyped and varargs functions")
 
-VALUE_LANGOPT(FuchsiaAPILevel, 32, 0, Affecting, "Fuchsia API level")
+VALUE_LANGOPT(FuchsiaAPILevel, 32, 0, NotCompatible, "Fuchsia API level")
 
 // This option will be removed in the future once the backend
 // supports all operations (like division or float-to-integer conversion)
@@ -488,9 +488,9 @@ LANGOPT(CheckConstexprFunctionBodies, 1, 1, Benign,
         "Emit diagnostics for a constexpr function body that can never "
         "be used in a constant expression.")
 
-LANGOPT(BoundsSafety, 1, 0, Affecting, "Bounds safety extension for C")
+LANGOPT(BoundsSafety, 1, 0, NotCompatible, "Bounds safety extension for C")
 
-LANGOPT(PreserveVec3Type, 1, 0, Affecting, "Preserve 3-component vector type")
+LANGOPT(PreserveVec3Type, 1, 0, NotCompatible, "Preserve 3-component vector type")
 
 #undef LANGOPT
 #undef ENUM_LANGOPT

--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -9,30 +9,15 @@
 // This file defines the language options. Users of this file must
 // define the LANGOPT macro to make use of this information. The arguments to
 // the macro are:
-//   LANGOPT(Name, Bits, DefaultValue, Description)
+//   LANGOPT(Name, Bits, DefaultValue, Compatibility, Description)
 // Note that the DefaultValue must be a constant value (literal or enumeration);
 // it cannot depend on the value of another language option.
 //
 // Optionally, the user may also define:
 //
-// BENIGN_LANGOPT: for options that don't affect the construction of the AST in
-//     any way (that is, the value can be different between an implicit module
-//     and the user of that module).
-//
-// COMPATIBLE_LANGOPT: for options that affect the construction of the AST in
-//     a way that doesn't prevent interoperability (that is, the value can be
-//     different between an explicit module and the user of that module).
-//
 // ENUM_LANGOPT: for options that have enumeration, rather than unsigned, type.
 //
 // VALUE_LANGOPT: for options that describe a value rather than a flag.
-//
-// BENIGN_ENUM_LANGOPT, COMPATIBLE_ENUM_LANGOPT,
-// BENIGN_VALUE_LANGOPT, COMPATIBLE_VALUE_LANGOPT: combinations of the above.
-//
-// FIXME: Clients should be able to more easily select whether they want
-// different levels of compatibility versus how to handle different kinds
-// of option.
 //
 // The Description field should be a noun phrase, for instance "frobbing all
 // widgets" or "C's implicit blintz feature".
@@ -42,507 +27,471 @@
 #  error Define the LANGOPT macro to handle language options
 #endif
 
-#ifndef COMPATIBLE_LANGOPT
-#  define COMPATIBLE_LANGOPT(Name, Bits, Default, Description) \
-     LANGOPT(Name, Bits, Default, Description)
-#endif
-
-#ifndef BENIGN_LANGOPT
-#  define BENIGN_LANGOPT(Name, Bits, Default, Description) \
-     COMPATIBLE_LANGOPT(Name, Bits, Default, Description)
-#endif
-
 #ifndef ENUM_LANGOPT
-#  define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-     LANGOPT(Name, Bits, Default, Description)
-#endif
-
-#ifndef COMPATIBLE_ENUM_LANGOPT
-#  define COMPATIBLE_ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-     ENUM_LANGOPT(Name, Type, Bits, Default, Description)
-#endif
-
-#ifndef BENIGN_ENUM_LANGOPT
-#  define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-     COMPATIBLE_ENUM_LANGOPT(Name, Type, Bits, Default, Description)
+#  define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description) \
+     LANGOPT(Name, Bits, Default, Compatibility, Description)
 #endif
 
 #ifndef VALUE_LANGOPT
-#  define VALUE_LANGOPT(Name, Bits, Default, Description) \
-     LANGOPT(Name, Bits, Default, Description)
+#  define VALUE_LANGOPT(Name, Bits, Default, Compatibility, Description) \
+     LANGOPT(Name, Bits, Default, Compatibility, Description)
 #endif
 
-#ifndef COMPATIBLE_VALUE_LANGOPT
-#  define COMPATIBLE_VALUE_LANGOPT(Name, Bits, Default, Description) \
-     VALUE_LANGOPT(Name, Bits, Default, Description)
-#endif
-
-#ifndef BENIGN_VALUE_LANGOPT
-#  define BENIGN_VALUE_LANGOPT(Name, Bits, Default, Description) \
-     COMPATIBLE_VALUE_LANGOPT(Name, Bits, Default, Description)
-#endif
-
-// FIXME: A lot of the BENIGN_ options should be COMPATIBLE_ instead.
-LANGOPT(C99               , 1, 0, "C99")
-LANGOPT(C11               , 1, 0, "C11")
-LANGOPT(C17               , 1, 0, "C17")
-LANGOPT(C23               , 1, 0, "C23")
-LANGOPT(C2y               , 1, 0, "C2y")
-LANGOPT(MSVCCompat        , 1, 0, "Microsoft Visual C++ full compatibility mode")
-LANGOPT(Kernel            , 1, 0, "Kernel mode")
-LANGOPT(MicrosoftExt      , 1, 0, "Microsoft C++ extensions")
-LANGOPT(ZOSExt            , 1, 0, "z/OS extensions")
-LANGOPT(AsmBlocks         , 1, 0, "Microsoft inline asm blocks")
-LANGOPT(Borland           , 1, 0, "Borland extensions")
-LANGOPT(CPlusPlus         , 1, 0, "C++")
-LANGOPT(CPlusPlus11       , 1, 0, "C++11")
-LANGOPT(CPlusPlus14       , 1, 0, "C++14")
-LANGOPT(CPlusPlus17       , 1, 0, "C++17")
-LANGOPT(CPlusPlus20       , 1, 0, "C++20")
-LANGOPT(CPlusPlus23       , 1, 0, "C++23")
-LANGOPT(CPlusPlus26       , 1, 0, "C++26")
-LANGOPT(ObjC              , 1, 0, "Objective-C")
-BENIGN_LANGOPT(ObjCDefaultSynthProperties , 1, 0,
-               "Objective-C auto-synthesized properties")
-BENIGN_LANGOPT(EncodeExtendedBlockSig , 1, 0,
-               "Encoding extended block type signature")
-BENIGN_LANGOPT(EncodeCXXClassTemplateSpec , 1, 0,
-               "Fully encode c++ class template specialization")
-BENIGN_LANGOPT(ObjCInferRelatedResultType , 1, 1,
-               "Objective-C related result type inference")
-LANGOPT(AppExt , 1, 0, "Objective-C App Extension")
-LANGOPT(Trigraphs         , 1, 0,"trigraphs")
-LANGOPT(LineComment       , 1, 0, "'//' comments")
-LANGOPT(Bool              , 1, 0, "bool, true, and false keywords")
-LANGOPT(Half              , 1, 0, "half keyword")
-LANGOPT(WChar             , 1, 0, "wchar_t keyword")
-LANGOPT(Char8             , 1, 0, "char8_t keyword")
-LANGOPT(IEEE128           , 1, 0, "__ieee128 keyword")
-LANGOPT(DeclSpecKeyword   , 1, 0, "__declspec keyword")
-BENIGN_LANGOPT(DollarIdents   , 1, 1, "'$' in identifiers")
-BENIGN_LANGOPT(AsmPreprocessor, 1, 0, "preprocessor in asm mode")
-LANGOPT(GNUMode           , 1, 1, "GNU extensions")
-LANGOPT(GNUKeywords       , 1, 1, "GNU keywords")
-VALUE_LANGOPT(GNUCVersion , 32, 0, "GNU C compatibility version")
-LANGOPT(DisableKNRFunctions, 1, 0, "require function types to have a prototype")
-LANGOPT(Digraphs          , 1, 0, "digraphs")
-BENIGN_LANGOPT(HexFloats  , 1, 0, "C99 hexadecimal float constants")
-LANGOPT(CXXOperatorNames  , 1, 0, "C++ operator name keywords")
-LANGOPT(AppleKext         , 1, 0, "Apple kext support")
-BENIGN_LANGOPT(PascalStrings, 1, 0, "Pascal string support")
-LANGOPT(WritableStrings   , 1, 0, "writable string support")
-LANGOPT(ConstStrings      , 1, 0, "const-qualified string support")
+// FIXME: A lot of the Benign options should be Compatible instead.
+LANGOPT(C99               , 1, 0, Affecting, "C99")
+LANGOPT(C11               , 1, 0, Affecting, "C11")
+LANGOPT(C17               , 1, 0, Affecting, "C17")
+LANGOPT(C23               , 1, 0, Affecting, "C23")
+LANGOPT(C2y               , 1, 0, Affecting, "C2y")
+LANGOPT(MSVCCompat        , 1, 0, Affecting, "Microsoft Visual C++ full compatibility mode")
+LANGOPT(Kernel            , 1, 0, Affecting, "Kernel mode")
+LANGOPT(MicrosoftExt      , 1, 0, Affecting, "Microsoft C++ extensions")
+LANGOPT(ZOSExt            , 1, 0, Affecting, "z/OS extensions")
+LANGOPT(AsmBlocks         , 1, 0, Affecting, "Microsoft inline asm blocks")
+LANGOPT(Borland           , 1, 0, Affecting, "Borland extensions")
+LANGOPT(CPlusPlus         , 1, 0, Affecting, "C++")
+LANGOPT(CPlusPlus11       , 1, 0, Affecting, "C++11")
+LANGOPT(CPlusPlus14       , 1, 0, Affecting, "C++14")
+LANGOPT(CPlusPlus17       , 1, 0, Affecting, "C++17")
+LANGOPT(CPlusPlus20       , 1, 0, Affecting, "C++20")
+LANGOPT(CPlusPlus23       , 1, 0, Affecting, "C++23")
+LANGOPT(CPlusPlus26       , 1, 0, Affecting, "C++26")
+LANGOPT(ObjC              , 1, 0, Affecting, "Objective-C")
+LANGOPT(ObjCDefaultSynthProperties , 1, 0, Benign,
+        "Objective-C auto-synthesized properties")
+LANGOPT(EncodeExtendedBlockSig , 1, 0, Benign,
+        "Encoding extended block type signature")
+LANGOPT(EncodeCXXClassTemplateSpec , 1, 0, Benign,
+        "Fully encode c++ class template specialization")
+LANGOPT(ObjCInferRelatedResultType , 1, 1, Benign,
+        "Objective-C related result type inference")
+LANGOPT(AppExt            , 1, 0, Affecting, "Objective-C App Extension")
+LANGOPT(Trigraphs         , 1, 0, Affecting, "trigraphs")
+LANGOPT(LineComment       , 1, 0, Affecting, "'//' comments")
+LANGOPT(Bool              , 1, 0, Affecting, "bool, true, and false keywords")
+LANGOPT(Half              , 1, 0, Affecting, "half keyword")
+LANGOPT(WChar             , 1, 0, Affecting, "wchar_t keyword")
+LANGOPT(Char8             , 1, 0, Affecting, "char8_t keyword")
+LANGOPT(IEEE128           , 1, 0, Affecting, "__ieee128 keyword")
+LANGOPT(DeclSpecKeyword   , 1, 0, Affecting, "__declspec keyword")
+LANGOPT(DollarIdents      , 1, 1, Benign, "'$' in identifiers")
+LANGOPT(AsmPreprocessor   , 1, 0, Benign, "preprocessor in asm mode")
+LANGOPT(GNUMode           , 1, 1, Affecting, "GNU extensions")
+LANGOPT(GNUKeywords       , 1, 1, Affecting, "GNU keywords")
+VALUE_LANGOPT(GNUCVersion , 32, 0, Affecting, "GNU C compatibility version")
+LANGOPT(DisableKNRFunctions, 1, 0, Affecting, "require function types to have a prototype")
+LANGOPT(Digraphs          , 1, 0, Affecting, "digraphs")
+LANGOPT(HexFloats         , 1, 0, Benign, "C99 hexadecimal float constants")
+LANGOPT(CXXOperatorNames  , 1, 0, Affecting, "C++ operator name keywords")
+LANGOPT(AppleKext         , 1, 0, Affecting, "Apple kext support")
+LANGOPT(PascalStrings     , 1, 0, Benign, "Pascal string support")
+LANGOPT(WritableStrings   , 1, 0, Affecting, "writable string support")
+LANGOPT(ConstStrings      , 1, 0, Affecting, "const-qualified string support")
 ENUM_LANGOPT(LaxVectorConversions, LaxVectorConversionKind, 2,
-             LaxVectorConversionKind::All, "lax vector conversions")
+             LaxVectorConversionKind::All, Affecting, "lax vector conversions")
 ENUM_LANGOPT(AltivecSrcCompat, AltivecSrcCompatKind, 2,
-             AltivecSrcCompatKind::Default, "Altivec source compatibility")
-LANGOPT(ConvergentFunctions, 1, 1, "Assume convergent functions")
-LANGOPT(AltiVec           , 1, 0, "AltiVec-style vector initializers")
-LANGOPT(ZVector           , 1, 0, "System z vector extensions")
-LANGOPT(Exceptions        , 1, 0, "exception handling")
-LANGOPT(ObjCExceptions    , 1, 0, "Objective-C exceptions")
-LANGOPT(CXXExceptions     , 1, 0, "C++ exceptions")
-LANGOPT(EHAsynch          , 1, 0, "C/C++ EH Asynch exceptions")
+             AltivecSrcCompatKind::Default, Affecting, "Altivec source compatibility")
+LANGOPT(ConvergentFunctions, 1, 1, Affecting, "Assume convergent functions")
+LANGOPT(AltiVec           , 1, 0, Affecting, "AltiVec-style vector initializers")
+LANGOPT(ZVector           , 1, 0, Affecting, "System z vector extensions")
+LANGOPT(Exceptions        , 1, 0, Affecting, "exception handling")
+LANGOPT(ObjCExceptions    , 1, 0, Affecting, "Objective-C exceptions")
+LANGOPT(CXXExceptions     , 1, 0, Affecting, "C++ exceptions")
+LANGOPT(EHAsynch          , 1, 0, Affecting, "C/C++ EH Asynch exceptions")
 ENUM_LANGOPT(ExceptionHandling, ExceptionHandlingKind, 3,
-             ExceptionHandlingKind::None, "exception handling")
-LANGOPT(IgnoreExceptions  , 1, 0, "ignore exceptions")
-LANGOPT(ExternCNoUnwind   , 1, 0, "Assume extern C functions don't unwind")
-LANGOPT(AssumeNothrowExceptionDtor , 1, 0, "Assume exception object's destructor is nothrow")
-LANGOPT(TraditionalCPP    , 1, 0, "traditional CPP emulation")
-LANGOPT(RTTI              , 1, 1, "run-time type information")
-LANGOPT(RTTIData          , 1, 1, "emit run-time type information data")
-LANGOPT(MSBitfields       , 1, 0, "Microsoft-compatible structure layout")
-LANGOPT(MSVolatile        , 1, 0, "Microsoft-compatible volatile loads and stores")
-LANGOPT(Freestanding, 1, 0, "freestanding implementation")
-LANGOPT(NoBuiltin         , 1, 0, "disable builtin functions")
-LANGOPT(NoMathBuiltin     , 1, 0, "disable math builtin functions")
-LANGOPT(GNUAsm            , 1, 1, "GNU-style inline assembly")
-LANGOPT(Coroutines        , 1, 0, "C++20 coroutines")
-LANGOPT(CoroAlignedAllocation, 1, 0, "prefer Aligned Allocation according to P2014 Option 2")
-LANGOPT(DllExportInlines  , 1, 1, "dllexported classes dllexport inline methods")
-LANGOPT(ExperimentalLibrary, 1, 0, "enable unstable and experimental library features")
+             ExceptionHandlingKind::None,  Affecting, "exception handling")
+LANGOPT(IgnoreExceptions  , 1, 0, Affecting, "ignore exceptions")
+LANGOPT(ExternCNoUnwind   , 1, 0, Affecting, "Assume extern C functions don't unwind")
+LANGOPT(AssumeNothrowExceptionDtor , 1, 0, Affecting, "Assume exception object's destructor is nothrow")
+LANGOPT(TraditionalCPP    , 1, 0, Affecting, "traditional CPP emulation")
+LANGOPT(RTTI              , 1, 1, Affecting, "run-time type information")
+LANGOPT(RTTIData          , 1, 1, Affecting, "emit run-time type information data")
+LANGOPT(MSBitfields       , 1, 0, Affecting, "Microsoft-compatible structure layout")
+LANGOPT(MSVolatile        , 1, 0, Affecting, "Microsoft-compatible volatile loads and stores")
+LANGOPT(Freestanding      , 1, 0, Affecting, "freestanding implementation")
+LANGOPT(NoBuiltin         , 1, 0, Affecting, "disable builtin functions")
+LANGOPT(NoMathBuiltin     , 1, 0, Affecting, "disable math builtin functions")
+LANGOPT(GNUAsm            , 1, 1, Affecting, "GNU-style inline assembly")
+LANGOPT(Coroutines        , 1, 0, Affecting, "C++20 coroutines")
+LANGOPT(CoroAlignedAllocation, 1, 0, Affecting, "prefer Aligned Allocation according to P2014 Option 2")
+LANGOPT(DllExportInlines  , 1, 1, Affecting, "dllexported classes dllexport inline methods")
+LANGOPT(ExperimentalLibrary, 1, 0, Affecting, "enable unstable and experimental library features")
 
-LANGOPT(PointerAuthIntrinsics, 1, 0, "pointer authentication intrinsics")
-LANGOPT(PointerAuthCalls  , 1, 0, "function pointer authentication")
-LANGOPT(PointerAuthReturns, 1, 0, "return pointer authentication")
-LANGOPT(PointerAuthIndirectGotos, 1, 0, "indirect gotos pointer authentication")
-LANGOPT(PointerAuthAuthTraps, 1, 0, "pointer authentication failure traps")
-LANGOPT(PointerAuthVTPtrAddressDiscrimination, 1, 0, "incorporate address discrimination in authenticated vtable pointers")
-LANGOPT(PointerAuthVTPtrTypeDiscrimination, 1, 0, "incorporate type discrimination in authenticated vtable pointers")
-LANGOPT(PointerAuthTypeInfoVTPtrDiscrimination, 1, 0, "incorporate type and address discrimination in authenticated vtable pointers for std::type_info")
-BENIGN_LANGOPT(PointerAuthFunctionTypeDiscrimination, 1, 0,
-               "Use type discrimination when signing function pointers")
-LANGOPT(PointerAuthInitFini, 1, 0, "sign function pointers in init/fini arrays")
-LANGOPT(PointerAuthInitFiniAddressDiscrimination, 1, 0,
+LANGOPT(PointerAuthIntrinsics, 1, 0, Affecting, "pointer authentication intrinsics")
+LANGOPT(PointerAuthCalls  , 1, 0, Affecting, "function pointer authentication")
+LANGOPT(PointerAuthReturns, 1, 0, Affecting, "return pointer authentication")
+LANGOPT(PointerAuthIndirectGotos, 1, 0, Affecting, "indirect gotos pointer authentication")
+LANGOPT(PointerAuthAuthTraps, 1, 0, Affecting, "pointer authentication failure traps")
+LANGOPT(PointerAuthVTPtrAddressDiscrimination, 1, 0, Affecting, "incorporate address discrimination in authenticated vtable pointers")
+LANGOPT(PointerAuthVTPtrTypeDiscrimination, 1, 0, Affecting, "incorporate type discrimination in authenticated vtable pointers")
+LANGOPT(PointerAuthTypeInfoVTPtrDiscrimination, 1, 0, Affecting, "incorporate type and address discrimination in authenticated vtable pointers for std::type_info")
+LANGOPT(PointerAuthFunctionTypeDiscrimination, 1, 0, Benign,
+        "Use type discrimination when signing function pointers")
+LANGOPT(PointerAuthInitFini, 1, 0, Affecting, "sign function pointers in init/fini arrays")
+LANGOPT(PointerAuthInitFiniAddressDiscrimination, 1, 0, Affecting,
         "incorporate address discrimination in authenticated function pointers in init/fini arrays")
-LANGOPT(PointerAuthELFGOT, 1, 0, "authenticate pointers from GOT")
-LANGOPT(AArch64JumpTableHardening, 1, 0, "use hardened lowering for jump-table dispatch")
+LANGOPT(PointerAuthELFGOT, 1, 0, Affecting, "authenticate pointers from GOT")
+LANGOPT(AArch64JumpTableHardening, 1, 0, Affecting, "use hardened lowering for jump-table dispatch")
 
-LANGOPT(DoubleSquareBracketAttributes, 1, 0, "'[[]]' attributes extension for all language standard modes")
-LANGOPT(ExperimentalLateParseAttributes, 1, 0, "experimental late parsing of attributes")
+LANGOPT(DoubleSquareBracketAttributes, 1, 0, Affecting, "'[[]]' attributes extension for all language standard modes")
+LANGOPT(ExperimentalLateParseAttributes, 1, 0, Affecting, "experimental late parsing of attributes")
 
-COMPATIBLE_LANGOPT(RecoveryAST, 1, 1, "Preserve expressions in AST when encountering errors")
-COMPATIBLE_LANGOPT(RecoveryASTType, 1, 1, "Preserve the type in recovery expressions")
+LANGOPT(RecoveryAST, 1, 1, Compatible, "Preserve expressions in AST when encountering errors")
+LANGOPT(RecoveryASTType, 1, 1, Compatible, "Preserve the type in recovery expressions")
 
-BENIGN_LANGOPT(ThreadsafeStatics , 1, 1, "thread-safe static initializers")
-LANGOPT(POSIXThreads      , 1, 0, "POSIX thread support")
-LANGOPT(Blocks            , 1, 0, "blocks extension to C")
-BENIGN_LANGOPT(EmitAllDecls      , 1, 0, "emitting all declarations")
-LANGOPT(MathErrno         , 1, 1, "errno in math functions")
-LANGOPT(Modules           , 1, 0, "modules semantics")
-COMPATIBLE_LANGOPT(CPlusPlusModules, 1, 0, "C++ modules syntax")
-LANGOPT(SkipODRCheckInGMF, 1, 0, "Skip ODR checks for decls in the global module fragment")
-LANGOPT(BuiltinHeadersInSystemModules, 1, 0, "builtin headers belong to system modules, and _Builtin_ modules are ignored for cstdlib headers")
-BENIGN_ENUM_LANGOPT(CompilingModule, CompilingModuleKind, 3, CMK_None,
-                    "compiling a module interface")
-BENIGN_LANGOPT(CompilingPCH, 1, 0, "building a pch")
-BENIGN_LANGOPT(BuildingPCHWithObjectFile, 1, 0, "building a pch which has a corresponding object file")
-BENIGN_LANGOPT(CacheGeneratedPCH, 1, 0, "cache generated PCH files in memory")
-BENIGN_LANGOPT(PCHInstantiateTemplates, 1, 0, "instantiate templates while building a PCH")
-COMPATIBLE_LANGOPT(ModulesDeclUse    , 1, 0, "require declaration of module uses")
-BENIGN_LANGOPT(ModulesSearchAll  , 1, 1, "searching even non-imported modules to find unresolved references")
-COMPATIBLE_LANGOPT(ModulesStrictDeclUse, 1, 0, "requiring declaration of module uses and all headers to be in modules")
-COMPATIBLE_LANGOPT(ModulesValidateTextualHeaderIncludes, 1, 1, "validation of textual header includes")
-BENIGN_LANGOPT(ModulesErrorRecovery, 1, 1, "automatically importing modules as needed when performing error recovery")
-BENIGN_LANGOPT(ImplicitModules, 1, 1, "building modules that are not specified via -fmodule-file")
-COMPATIBLE_LANGOPT(ModulesLocalVisibility, 1, 0, "local submodule visibility")
-COMPATIBLE_LANGOPT(Optimize          , 1, 0, "__OPTIMIZE__ predefined macro")
-COMPATIBLE_LANGOPT(OptimizeSize      , 1, 0, "__OPTIMIZE_SIZE__ predefined macro")
-COMPATIBLE_LANGOPT(Static            , 1, 0, "__STATIC__ predefined macro (as opposed to __DYNAMIC__)")
-VALUE_LANGOPT(PackStruct  , 32, 0,
+LANGOPT(ThreadsafeStatics , 1, 1, Benign, "thread-safe static initializers")
+LANGOPT(POSIXThreads      , 1, 0, Affecting, "POSIX thread support")
+LANGOPT(Blocks            , 1, 0, Affecting, "blocks extension to C")
+LANGOPT(EmitAllDecls      , 1, 0, Benign, "emitting all declarations")
+LANGOPT(MathErrno         , 1, 1, Affecting, "errno in math functions")
+LANGOPT(Modules           , 1, 0, Affecting, "modules semantics")
+LANGOPT(CPlusPlusModules  , 1, 0, Compatible, "C++ modules syntax")
+LANGOPT(SkipODRCheckInGMF , 1, 0, Affecting, "Skip ODR checks for decls in the global module fragment")
+LANGOPT(BuiltinHeadersInSystemModules, 1, 0, Affecting, "builtin headers belong to system modules, and _Builtin_ modules are ignored for cstdlib headers")
+ENUM_LANGOPT(CompilingModule, CompilingModuleKind, 3, CMK_None, Benign,
+             "compiling a module interface")
+LANGOPT(CompilingPCH, 1, 0, Benign, "building a pch")
+LANGOPT(BuildingPCHWithObjectFile, 1, 0, Benign, "building a pch which has a corresponding object file")
+LANGOPT(CacheGeneratedPCH, 1, 0, Benign, "cache generated PCH files in memory")
+LANGOPT(PCHInstantiateTemplates, 1, 0, Benign, "instantiate templates while building a PCH")
+LANGOPT(ModulesDeclUse    , 1, 0, Compatible, "require declaration of module uses")
+LANGOPT(ModulesSearchAll  , 1, 1, Benign, "searching even non-imported modules to find unresolved references")
+LANGOPT(ModulesStrictDeclUse, 1, 0, Compatible, "requiring declaration of module uses and all headers to be in modules")
+LANGOPT(ModulesValidateTextualHeaderIncludes, 1, 1, Compatible, "validation of textual header includes")
+LANGOPT(ModulesErrorRecovery, 1, 1, Benign, "automatically importing modules as needed when performing error recovery")
+LANGOPT(ImplicitModules, 1, 1, Benign, "building modules that are not specified via -fmodule-file")
+LANGOPT(ModulesLocalVisibility, 1, 0, Compatible, "local submodule visibility")
+LANGOPT(Optimize          , 1, 0, Compatible, "__OPTIMIZE__ predefined macro")
+LANGOPT(OptimizeSize      , 1, 0, Compatible, "__OPTIMIZE_SIZE__ predefined macro")
+LANGOPT(Static            , 1, 0, Compatible, "__STATIC__ predefined macro (as opposed to __DYNAMIC__)")
+VALUE_LANGOPT(PackStruct  , 32, 0, Affecting,
               "default struct packing maximum alignment")
-VALUE_LANGOPT(MaxTypeAlign  , 32, 0,
+VALUE_LANGOPT(MaxTypeAlign  , 32, 0, Affecting,
               "default maximum alignment for types")
-VALUE_LANGOPT(AlignDouble            , 1, 0, "Controls if doubles should be aligned to 8 bytes (x86 only)")
-VALUE_LANGOPT(DoubleSize            , 32, 0, "width of double")
-VALUE_LANGOPT(LongDoubleSize        , 32, 0, "width of long double")
-LANGOPT(PPCIEEELongDouble            , 1, 0, "use IEEE 754 quadruple-precision for long double")
-LANGOPT(EnableAIXExtendedAltivecABI  , 1, 0, "__EXTABI__  predefined macro")
-LANGOPT(EnableAIXQuadwordAtomicsABI  , 1, 0, "Use 16-byte atomic lock free semantics")
-COMPATIBLE_VALUE_LANGOPT(PICLevel    , 2, 0, "__PIC__ level")
-COMPATIBLE_VALUE_LANGOPT(PIE         , 1, 0, "is pie")
-LANGOPT(ROPI                         , 1, 0, "Read-only position independence")
-LANGOPT(RWPI                         , 1, 0, "Read-write position independence")
-COMPATIBLE_LANGOPT(GNUInline         , 1, 0, "GNU inline semantics")
-COMPATIBLE_LANGOPT(NoInlineDefine    , 1, 0, "__NO_INLINE__ predefined macro")
-COMPATIBLE_LANGOPT(Deprecated        , 1, 0, "__DEPRECATED predefined macro")
-COMPATIBLE_LANGOPT(FastMath          , 1, 0, "fast FP math optimizations, and __FAST_MATH__ predefined macro")
-COMPATIBLE_LANGOPT(UnsafeFPMath      , 1, 0, "Unsafe Floating Point Math")
-COMPATIBLE_LANGOPT(ProtectParens     , 1, 0, "optimizer honors parentheses "
-                   "when floating-point expressions are evaluated")
-BENIGN_LANGOPT(AllowFPReassoc    , 1, 0, "Permit Floating Point reassociation")
-BENIGN_LANGOPT(NoHonorNaNs       , 1, 0, "Permit Floating Point optimization without regard to NaN")
-BENIGN_LANGOPT(NoHonorInfs       , 1, 0, "Permit Floating Point optimization without regard to infinities")
-BENIGN_LANGOPT(NoSignedZero      , 1, 0, "Permit Floating Point optimization without regard to signed zeros")
-BENIGN_LANGOPT(AllowRecip        , 1, 0, "Permit Floating Point reciprocal")
-BENIGN_LANGOPT(ApproxFunc        , 1, 0, "Permit Floating Point approximation")
+VALUE_LANGOPT(AlignDouble            , 1, 0, Affecting, "Controls if doubles should be aligned to 8 bytes (x86 only)")
+VALUE_LANGOPT(DoubleSize            , 32, 0, Affecting, "width of double")
+VALUE_LANGOPT(LongDoubleSize        , 32, 0, Affecting, "width of long double")
+LANGOPT(PPCIEEELongDouble            , 1, 0, Affecting, "use IEEE 754 quadruple-precision for long double")
+LANGOPT(EnableAIXExtendedAltivecABI  , 1, 0, Affecting, "__EXTABI__  predefined macro")
+LANGOPT(EnableAIXQuadwordAtomicsABI  , 1, 0, Affecting, "Use 16-byte atomic lock free semantics")
+VALUE_LANGOPT(PICLevel               , 2, 0, Compatible, "__PIC__ level")
+VALUE_LANGOPT(PIE                    , 1, 0, Compatible, "is pie")
+LANGOPT(ROPI                         , 1, 0, Affecting, "Read-only position independence")
+LANGOPT(RWPI                         , 1, 0, Affecting, "Read-write position independence")
+LANGOPT(GNUInline                    , 1, 0, Compatible, "GNU inline semantics")
+LANGOPT(NoInlineDefine               , 1, 0, Compatible, "__NO_INLINE__ predefined macro")
+LANGOPT(Deprecated                   , 1, 0, Compatible, "__DEPRECATED predefined macro")
+LANGOPT(FastMath                     , 1, 0, Compatible, "fast FP math optimizations, and __FAST_MATH__ predefined macro")
+LANGOPT(UnsafeFPMath                 , 1, 0, Compatible, "Unsafe Floating Point Math")
+LANGOPT(ProtectParens                , 1, 0, Compatible, "optimizer honors parentheses "
+        "when floating-point expressions are evaluated")
+LANGOPT(AllowFPReassoc    , 1, 0, Benign, "Permit Floating Point reassociation")
+LANGOPT(NoHonorNaNs       , 1, 0, Benign, "Permit Floating Point optimization without regard to NaN")
+LANGOPT(NoHonorInfs       , 1, 0, Benign, "Permit Floating Point optimization without regard to infinities")
+LANGOPT(NoSignedZero      , 1, 0, Benign, "Permit Floating Point optimization without regard to signed zeros")
+LANGOPT(AllowRecip        , 1, 0, Benign, "Permit Floating Point reciprocal")
+LANGOPT(ApproxFunc        , 1, 0, Benign, "Permit Floating Point approximation")
 
-ENUM_LANGOPT(ComplexRange, ComplexRangeKind, 3, CX_None, "Enable use of range reduction for complex arithmetics.")
+ENUM_LANGOPT(ComplexRange, ComplexRangeKind, 3, CX_None, Affecting, "Enable use of range reduction for complex arithmetics.")
 
-BENIGN_LANGOPT(ObjCGCBitmapPrint , 1, 0, "printing of GC's bitmap layout for __weak/__strong ivars")
+LANGOPT(ObjCGCBitmapPrint , 1, 0, Benign, "printing of GC's bitmap layout for __weak/__strong ivars")
 
-BENIGN_LANGOPT(AccessControl     , 1, 1, "C++ access control")
-LANGOPT(CharIsSigned      , 1, 1, "signed char")
-LANGOPT(WCharSize         , 4, 0, "width of wchar_t")
-LANGOPT(WCharIsSigned        , 1, 0, "signed or unsigned wchar_t")
-ENUM_LANGOPT(MSPointerToMemberRepresentationMethod, PragmaMSPointersToMembersKind, 2, PPTMK_BestCase, "member-pointer representation method")
-ENUM_LANGOPT(DefaultCallingConv, DefaultCallingConvention, 3, DCC_None, "default calling convention")
+LANGOPT(AccessControl     , 1, 1, Benign, "C++ access control")
+LANGOPT(CharIsSigned      , 1, 1, Affecting, "signed char")
+LANGOPT(WCharSize         , 4, 0, Affecting, "width of wchar_t")
+LANGOPT(WCharIsSigned        , 1, 0, Affecting, "signed or unsigned wchar_t")
+ENUM_LANGOPT(MSPointerToMemberRepresentationMethod, PragmaMSPointersToMembersKind, 2, PPTMK_BestCase, Affecting, "member-pointer representation method")
+ENUM_LANGOPT(DefaultCallingConv, DefaultCallingConvention, 3, DCC_None, Affecting, "default calling convention")
 
-LANGOPT(ShortEnums        , 1, 0, "short enum types")
+LANGOPT(ShortEnums        , 1, 0, Affecting, "short enum types")
 
-LANGOPT(OpenCL            , 1, 0, "OpenCL")
-LANGOPT(OpenCLVersion     , 32, 0, "OpenCL C version")
-LANGOPT(OpenCLCPlusPlus   , 1, 0, "C++ for OpenCL")
-LANGOPT(OpenCLCPlusPlusVersion     , 32, 0, "C++ for OpenCL version")
-LANGOPT(OpenCLGenericAddressSpace, 1, 0, "OpenCL generic keyword")
-LANGOPT(OpenCLPipes              , 1, 0, "OpenCL pipes language constructs and built-ins")
-LANGOPT(NativeHalfType    , 1, 0, "Native half type support")
-LANGOPT(NativeHalfArgsAndReturns, 1, 0, "Native half args and returns")
-LANGOPT(CUDA              , 1, 0, "CUDA")
-LANGOPT(HIP               , 1, 0, "HIP")
-LANGOPT(OpenMP            , 32, 0, "OpenMP support and version of OpenMP (31, 40 or 45)")
-LANGOPT(OpenMPExtensions  , 1, 1, "Enable all Clang extensions for OpenMP directives and clauses")
-LANGOPT(OpenMPSimd        , 1, 0, "Use SIMD only OpenMP support.")
-LANGOPT(OpenMPUseTLS      , 1, 0, "Use TLS for threadprivates or runtime calls")
-LANGOPT(OpenMPIsTargetDevice    , 1, 0, "Generate code only for OpenMP target device")
-LANGOPT(OpenMPCUDAMode    , 1, 0, "Generate code for OpenMP pragmas in SIMT/SPMD mode")
-LANGOPT(OpenMPIRBuilder   , 1, 0, "Use the experimental OpenMP-IR-Builder codegen path.")
-LANGOPT(OpenMPCUDANumSMs  , 32, 0, "Number of SMs for CUDA devices.")
-LANGOPT(OpenMPCUDABlocksPerSM  , 32, 0, "Number of blocks per SM for CUDA devices.")
-LANGOPT(OpenMPCUDAReductionBufNum , 32, 1024, "Number of the reduction records in the intermediate reduction buffer used for the teams reductions.")
-LANGOPT(OpenMPTargetDebug , 32, 0, "Enable debugging in the OpenMP offloading device RTL")
-LANGOPT(OpenMPOptimisticCollapse  , 1, 0, "Use at most 32 bits to represent the collapsed loop nest counter.")
-LANGOPT(OpenMPThreadSubscription  , 1, 0, "Assume work-shared loops do not have more iterations than participating threads.")
-LANGOPT(OpenMPTeamSubscription  , 1, 0, "Assume distributed loops do not have more iterations than participating teams.")
-LANGOPT(OpenMPNoThreadState  , 1, 0, "Assume that no thread in a parallel region will modify an ICV.")
-LANGOPT(OpenMPNoNestedParallelism  , 1, 0, "Assume that no thread in a parallel region will encounter a parallel region")
-LANGOPT(OpenMPOffloadMandatory  , 1, 0, "Assert that offloading is mandatory and do not create a host fallback.")
-LANGOPT(OpenMPForceUSM     , 1, 0, "Enable OpenMP unified shared memory mode via compiler.")
-LANGOPT(NoGPULib  , 1, 0, "Indicate a build without the standard GPU libraries.")
+LANGOPT(OpenCL            , 1, 0, Affecting, "OpenCL")
+LANGOPT(OpenCLVersion     , 32, 0, Affecting, "OpenCL C version")
+LANGOPT(OpenCLCPlusPlus   , 1, 0, Affecting, "C++ for OpenCL")
+LANGOPT(OpenCLCPlusPlusVersion     , 32, 0, Affecting, "C++ for OpenCL version")
+LANGOPT(OpenCLGenericAddressSpace, 1, 0, Affecting, "OpenCL generic keyword")
+LANGOPT(OpenCLPipes              , 1, 0, Affecting, "OpenCL pipes language constructs and built-ins")
+LANGOPT(NativeHalfType    , 1, 0, Affecting, "Native half type support")
+LANGOPT(NativeHalfArgsAndReturns, 1, 0, Affecting, "Native half args and returns")
+LANGOPT(CUDA              , 1, 0, Affecting, "CUDA")
+LANGOPT(HIP               , 1, 0, Affecting, "HIP")
+LANGOPT(OpenMP            , 32, 0, Affecting, "OpenMP support and version of OpenMP (31, 40 or 45)")
+LANGOPT(OpenMPExtensions  , 1, 1, Affecting, "Enable all Clang extensions for OpenMP directives and clauses")
+LANGOPT(OpenMPSimd        , 1, 0, Affecting, "Use SIMD only OpenMP support.")
+LANGOPT(OpenMPUseTLS      , 1, 0, Affecting, "Use TLS for threadprivates or runtime calls")
+LANGOPT(OpenMPIsTargetDevice    , 1, 0, Affecting, "Generate code only for OpenMP target device")
+LANGOPT(OpenMPCUDAMode    , 1, 0, Affecting, "Generate code for OpenMP pragmas in SIMT/SPMD mode")
+LANGOPT(OpenMPIRBuilder   , 1, 0, Affecting, "Use the experimental OpenMP-IR-Builder codegen path.")
+LANGOPT(OpenMPCUDANumSMs  , 32, 0, Affecting, "Number of SMs for CUDA devices.")
+LANGOPT(OpenMPCUDABlocksPerSM  , 32, 0, Affecting, "Number of blocks per SM for CUDA devices.")
+LANGOPT(OpenMPCUDAReductionBufNum , 32, 1024, Affecting, "Number of the reduction records in the intermediate reduction buffer used for the teams reductions.")
+LANGOPT(OpenMPTargetDebug , 32, 0, Affecting, "Enable debugging in the OpenMP offloading device RTL")
+LANGOPT(OpenMPOptimisticCollapse  , 1, 0, Affecting, "Use at most 32 bits to represent the collapsed loop nest counter.")
+LANGOPT(OpenMPThreadSubscription  , 1, 0, Affecting, "Assume work-shared loops do not have more iterations than participating threads.")
+LANGOPT(OpenMPTeamSubscription  , 1, 0, Affecting, "Assume distributed loops do not have more iterations than participating teams.")
+LANGOPT(OpenMPNoThreadState  , 1, 0, Affecting, "Assume that no thread in a parallel region will modify an ICV.")
+LANGOPT(OpenMPNoNestedParallelism  , 1, 0, Affecting, "Assume that no thread in a parallel region will encounter a parallel region")
+LANGOPT(OpenMPOffloadMandatory  , 1, 0, Affecting, "Assert that offloading is mandatory and do not create a host fallback.")
+LANGOPT(OpenMPForceUSM     , 1, 0, Affecting, "Enable OpenMP unified shared memory mode via compiler.")
+LANGOPT(NoGPULib  , 1, 0, Affecting, "Indicate a build without the standard GPU libraries.")
 
-LANGOPT(HLSL, 1, 0, "HLSL")
-ENUM_LANGOPT(HLSLVersion, HLSLLangStd, 16, HLSL_Unset, "HLSL Version")
-LANGOPT(HLSLStrictAvailability, 1, 0,
+LANGOPT(HLSL, 1, 0, Affecting, "HLSL")
+ENUM_LANGOPT(HLSLVersion, HLSLLangStd, 16, HLSL_Unset, Affecting, "HLSL Version")
+LANGOPT(HLSLStrictAvailability, 1, 0, Affecting,
         "Strict availability diagnostic mode for HLSL built-in functions.")
 
-LANGOPT(CUDAIsDevice      , 1, 0, "compiling for CUDA device")
-LANGOPT(CUDAAllowVariadicFunctions, 1, 0, "allowing variadic functions in CUDA device code")
-LANGOPT(CUDAHostDeviceConstexpr, 1, 1, "treating unattributed constexpr functions as __host__ __device__")
-LANGOPT(GPUDeviceApproxTranscendentals, 1, 0, "using approximate transcendental functions")
-LANGOPT(GPURelocatableDeviceCode, 1, 0, "generate relocatable device code")
-LANGOPT(OffloadImplicitHostDeviceTemplates, 1, 0, "assume template functions to be implicitly host device by default for CUDA/HIP")
-LANGOPT(GPUAllowDeviceInit, 1, 0, "allowing device side global init functions for HIP")
-LANGOPT(GPUMaxThreadsPerBlock, 32, 1024, "default max threads per block for kernel launch bounds for HIP")
-LANGOPT(GPUDeferDiag, 1, 0, "defer host/device related diagnostic messages for CUDA/HIP")
-LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, "always exclude wrong side overloads in overloading resolution for CUDA/HIP")
-LANGOPT(OffloadingNewDriver, 1, 0, "use the new driver for generating offloading code.")
-LANGOPT(OffloadViaLLVM, 1, 0, "target LLVM/Offload as portable offloading runtime.")
+LANGOPT(CUDAIsDevice      , 1, 0, Affecting, "compiling for CUDA device")
+LANGOPT(CUDAAllowVariadicFunctions, 1, 0, Affecting, "allowing variadic functions in CUDA device code")
+LANGOPT(CUDAHostDeviceConstexpr, 1, 1, Affecting, "treating unattributed constexpr functions as __host__ __device__")
+LANGOPT(GPUDeviceApproxTranscendentals, 1, 0, Affecting, "using approximate transcendental functions")
+LANGOPT(GPURelocatableDeviceCode, 1, 0, Affecting, "generate relocatable device code")
+LANGOPT(OffloadImplicitHostDeviceTemplates, 1, 0, Affecting, "assume template functions to be implicitly host device by default for CUDA/HIP")
+LANGOPT(GPUAllowDeviceInit, 1, 0, Affecting, "allowing device side global init functions for HIP")
+LANGOPT(GPUMaxThreadsPerBlock, 32, 1024, Affecting, "default max threads per block for kernel launch bounds for HIP")
+LANGOPT(GPUDeferDiag, 1, 0, Affecting, "defer host/device related diagnostic messages for CUDA/HIP")
+LANGOPT(GPUExcludeWrongSideOverloads, 1, 0, Affecting, "always exclude wrong side overloads in overloading resolution for CUDA/HIP")
+LANGOPT(OffloadingNewDriver, 1, 0, Affecting, "use the new driver for generating offloading code.")
+LANGOPT(OffloadViaLLVM, 1, 0, Affecting, "target LLVM/Offload as portable offloading runtime.")
 
-LANGOPT(SYCLIsDevice      , 1, 0, "Generate code for SYCL device")
-LANGOPT(SYCLIsHost        , 1, 0, "SYCL host compilation")
-ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, "Version of the SYCL standard used")
+LANGOPT(SYCLIsDevice      , 1, 0, Affecting, "Generate code for SYCL device")
+LANGOPT(SYCLIsHost        , 1, 0, Affecting, "SYCL host compilation")
+ENUM_LANGOPT(SYCLVersion  , SYCLMajorVersion, 2, SYCL_None, Affecting, "Version of the SYCL standard used")
 
-LANGOPT(HIPUseNewLaunchAPI, 1, 0, "Use new kernel launching API for HIP")
-LANGOPT(OffloadUniformBlock, 1, 0, "Assume that kernels are launched with uniform block sizes (default true for CUDA/HIP and false otherwise)")
-LANGOPT(HIPStdPar, 1, 0, "Enable Standard Parallel Algorithm Acceleration for HIP (experimental)")
-LANGOPT(HIPStdParInterposeAlloc, 1, 0, "Replace allocations / deallocations with HIP RT calls when Standard Parallel Algorithm Acceleration for HIP is enabled (Experimental)")
+LANGOPT(HIPUseNewLaunchAPI, 1, 0, Affecting, "Use new kernel launching API for HIP")
+LANGOPT(OffloadUniformBlock, 1, 0, Affecting, "Assume that kernels are launched with uniform block sizes (default true for CUDA/HIP and false otherwise)")
+LANGOPT(HIPStdPar, 1, 0, Affecting, "Enable Standard Parallel Algorithm Acceleration for HIP (experimental)")
+LANGOPT(HIPStdParInterposeAlloc, 1, 0, Affecting, "Replace allocations / deallocations with HIP RT calls when Standard Parallel Algorithm Acceleration for HIP is enabled (Experimental)")
 
-LANGOPT(OpenACC           , 1, 0, "OpenACC Enabled")
+LANGOPT(OpenACC           , 1, 0, Affecting, "OpenACC Enabled")
 
-LANGOPT(MSVCEnableStdcMacro , 1, 0, "Define __STDC__ with '-fms-compatibility'")
-LANGOPT(SizedDeallocation , 1, 0, "sized deallocation")
-LANGOPT(AlignedAllocation , 1, 0, "aligned allocation")
-LANGOPT(AlignedAllocationUnavailable, 1, 0, "aligned allocation functions are unavailable")
-LANGOPT(NewAlignOverride  , 32, 0, "maximum alignment guaranteed by '::operator new(size_t)'")
-BENIGN_LANGOPT(ModulesCodegen , 1, 0, "Modules code generation")
-BENIGN_LANGOPT(ModulesDebugInfo , 1, 0, "Modules debug info")
-BENIGN_LANGOPT(ElideConstructors , 1, 1, "C++ copy constructor elision")
-BENIGN_LANGOPT(DumpRecordLayouts , 1, 0, "dumping the layout of IRgen'd records")
-BENIGN_LANGOPT(DumpRecordLayoutsSimple , 1, 0, "dumping the layout of IRgen'd records in a simple form")
-BENIGN_LANGOPT(DumpRecordLayoutsCanonical , 1, 0, "dumping the AST layout of records using canonical field types")
-BENIGN_LANGOPT(DumpRecordLayoutsComplete , 1, 0, "dumping the AST layout of all complete records")
-BENIGN_LANGOPT(DumpVTableLayouts , 1, 0, "dumping the layouts of emitted vtables")
-LANGOPT(NoConstantCFStrings , 1, 0, "no constant CoreFoundation strings")
-BENIGN_LANGOPT(InlineVisibilityHidden , 1, 0, "hidden visibility for inline C++ methods")
-BENIGN_ENUM_LANGOPT(DefaultVisibilityExportMapping, DefaultVisiblityExportMapping, 2, DefaultVisiblityExportMapping::None, "controls mapping of default visibility to dllexport")
-BENIGN_LANGOPT(IgnoreXCOFFVisibility, 1, 0, "All the visibility attributes that are specified in the source code are ignored in aix XCOFF.")
-BENIGN_LANGOPT(VisibilityInlinesHiddenStaticLocalVar, 1, 0,
-               "hidden visibility for static local variables in inline C++ "
-               "methods when -fvisibility-inlines hidden is enabled")
-ENUM_LANGOPT(GlobalAllocationFunctionVisibility, VisibilityForcedKinds, 3, VisibilityForcedKinds::ForceDefault,
+LANGOPT(MSVCEnableStdcMacro , 1, 0, Affecting, "Define __STDC__ with '-fms-compatibility'")
+LANGOPT(SizedDeallocation , 1, 0, Affecting, "sized deallocation")
+LANGOPT(AlignedAllocation , 1, 0, Affecting, "aligned allocation")
+LANGOPT(AlignedAllocationUnavailable, 1, 0, Affecting, "aligned allocation functions are unavailable")
+LANGOPT(NewAlignOverride  , 32, 0, Affecting, "maximum alignment guaranteed by '::operator new(size_t)'")
+LANGOPT(ModulesCodegen , 1, 0, Benign, "Modules code generation")
+LANGOPT(ModulesDebugInfo , 1, 0, Benign, "Modules debug info")
+LANGOPT(ElideConstructors , 1, 1, Benign, "C++ copy constructor elision")
+LANGOPT(DumpRecordLayouts , 1, 0, Benign, "dumping the layout of IRgen'd records")
+LANGOPT(DumpRecordLayoutsSimple , 1, 0, Benign, "dumping the layout of IRgen'd records in a simple form")
+LANGOPT(DumpRecordLayoutsCanonical , 1, 0, Benign, "dumping the AST layout of records using canonical field types")
+LANGOPT(DumpRecordLayoutsComplete , 1, 0, Benign, "dumping the AST layout of all complete records")
+LANGOPT(DumpVTableLayouts , 1, 0, Benign, "dumping the layouts of emitted vtables")
+LANGOPT(NoConstantCFStrings , 1, 0, Affecting, "no constant CoreFoundation strings")
+LANGOPT(InlineVisibilityHidden , 1, 0, Benign, "hidden visibility for inline C++ methods")
+ENUM_LANGOPT(DefaultVisibilityExportMapping, DefaultVisiblityExportMapping, 2, DefaultVisiblityExportMapping::None, Benign, "controls mapping of default visibility to dllexport")
+LANGOPT(IgnoreXCOFFVisibility, 1, 0, Benign, "All the visibility attributes that are specified in the source code are ignored in aix XCOFF.")
+LANGOPT(VisibilityInlinesHiddenStaticLocalVar, 1, 0, Benign,
+        "hidden visibility for static local variables in inline C++ "
+        "methods when -fvisibility-inlines hidden is enabled")
+ENUM_LANGOPT(GlobalAllocationFunctionVisibility, VisibilityForcedKinds, 3, VisibilityForcedKinds::ForceDefault, Affecting,
              "How to apply visibility to global operator new and delete declarations")
-LANGOPT(NewInfallible , 1, 0, "Treats throwing global C++ operator new as always returning valid memory (annotates with __attribute__((returns_nonnull)) and throw()). This is detectable in source.")
-BENIGN_LANGOPT(ParseUnknownAnytype, 1, 0, "__unknown_anytype")
-BENIGN_LANGOPT(DebuggerSupport , 1, 0, "debugger support")
-BENIGN_LANGOPT(DebuggerCastResultToId, 1, 0, "for 'po' in the debugger, cast the result to id if it is of unknown type")
-BENIGN_LANGOPT(DebuggerObjCLiteral , 1, 0, "debugger Objective-C literals and subscripting support")
+LANGOPT(NewInfallible , 1, 0, Affecting, "Treats throwing global C++ operator new as always returning valid memory (annotates with __attribute__((returns_nonnull)) and throw()). This is detectable in source.")
+LANGOPT(ParseUnknownAnytype, 1, 0, Benign, "__unknown_anytype")
+LANGOPT(DebuggerSupport , 1, 0, Benign, "debugger support")
+LANGOPT(DebuggerCastResultToId, 1, 0, Benign, "for 'po' in the debugger, cast the result to id if it is of unknown type")
+LANGOPT(DebuggerObjCLiteral , 1, 0, Benign, "debugger Objective-C literals and subscripting support")
 
-BENIGN_LANGOPT(SpellChecking , 1, 1, "spell-checking")
-LANGOPT(SinglePrecisionConstants , 1, 0, "treating double-precision floating point constants as single precision constants")
-LANGOPT(FastRelaxedMath , 1, 0, "OpenCL fast relaxed math")
-BENIGN_LANGOPT(CLNoSignedZero , 1, 0, "Permit Floating Point optimization without regard to signed zeros")
-COMPATIBLE_LANGOPT(CLUnsafeMath , 1, 0, "Unsafe Floating Point Math")
+LANGOPT(SpellChecking , 1, 1, Benign, "spell-checking")
+LANGOPT(SinglePrecisionConstants , 1, 0, Affecting, "treating double-precision floating point constants as single precision constants")
+LANGOPT(FastRelaxedMath , 1, 0, Affecting, "OpenCL fast relaxed math")
+LANGOPT(CLNoSignedZero , 1, 0, Benign, "Permit Floating Point optimization without regard to signed zeros")
+LANGOPT(CLUnsafeMath , 1, 0, Compatible, "Unsafe Floating Point Math")
 /// FP_CONTRACT mode (on/off/fast).
-BENIGN_ENUM_LANGOPT(DefaultFPContractMode, FPModeKind, 2, FPM_Off, "FP contraction type")
-COMPATIBLE_LANGOPT(ExpStrictFP, 1, false, "Enable experimental strict floating point")
-BENIGN_LANGOPT(RoundingMath, 1, false, "Do not assume default floating-point rounding behavior")
-BENIGN_ENUM_LANGOPT(FPExceptionMode, FPExceptionModeKind, 2, FPE_Default, "FP Exception Behavior Mode type")
-BENIGN_ENUM_LANGOPT(FPEvalMethod, FPEvalMethodKind, 2, FEM_UnsetOnCommandLine, "FP type used for floating point arithmetic")
-ENUM_LANGOPT(Float16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, "Intermediate truncation behavior for Float16 arithmetic")
-ENUM_LANGOPT(BFloat16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, "Intermediate truncation behavior for BFloat16 arithmetic")
-LANGOPT(NoBitFieldTypeAlign , 1, 0, "bit-field type alignment")
-LANGOPT(HexagonQdsp6Compat , 1, 0, "hexagon-qdsp6 backward compatibility")
-LANGOPT(ObjCAutoRefCount , 1, 0, "Objective-C automated reference counting")
-LANGOPT(ObjCWeakRuntime     , 1, 0, "__weak support in the ARC runtime")
-LANGOPT(ObjCWeak            , 1, 0, "Objective-C __weak in ARC and MRC files")
-LANGOPT(ObjCSubscriptingLegacyRuntime         , 1, 0, "Subscripting support in legacy ObjectiveC runtime")
-BENIGN_LANGOPT(CompatibilityQualifiedIdBlockParamTypeChecking, 1, 0,
-               "compatibility mode for type checking block parameters "
-               "involving qualified id types")
-LANGOPT(ObjCDisableDirectMethodsForTesting, 1, 0,
+ENUM_LANGOPT(DefaultFPContractMode, FPModeKind, 2, FPM_Off, Benign, "FP contraction type")
+LANGOPT(ExpStrictFP, 1, false, Compatible, "Enable experimental strict floating point")
+LANGOPT(RoundingMath, 1, false, Benign, "Do not assume default floating-point rounding behavior")
+ENUM_LANGOPT(FPExceptionMode, FPExceptionModeKind, 2, FPE_Default, Benign, "FP Exception Behavior Mode type")
+ENUM_LANGOPT(FPEvalMethod, FPEvalMethodKind, 2, FEM_UnsetOnCommandLine, Benign, "FP type used for floating point arithmetic")
+ENUM_LANGOPT(Float16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, Affecting, "Intermediate truncation behavior for Float16 arithmetic")
+ENUM_LANGOPT(BFloat16ExcessPrecision, ExcessPrecisionKind, 2, FPP_Standard, Affecting, "Intermediate truncation behavior for BFloat16 arithmetic")
+LANGOPT(NoBitFieldTypeAlign , 1, 0, Affecting, "bit-field type alignment")
+LANGOPT(HexagonQdsp6Compat , 1, 0, Affecting, "hexagon-qdsp6 backward compatibility")
+LANGOPT(ObjCAutoRefCount , 1, 0, Affecting, "Objective-C automated reference counting")
+LANGOPT(ObjCWeakRuntime     , 1, 0, Affecting, "__weak support in the ARC runtime")
+LANGOPT(ObjCWeak            , 1, 0, Affecting, "Objective-C __weak in ARC and MRC files")
+LANGOPT(ObjCSubscriptingLegacyRuntime         , 1, 0, Affecting, "Subscripting support in legacy ObjectiveC runtime")
+LANGOPT(CompatibilityQualifiedIdBlockParamTypeChecking, 1, 0, Benign,
+        "compatibility mode for type checking block parameters "
+        "involving qualified id types")
+LANGOPT(ObjCDisableDirectMethodsForTesting, 1, 0, Affecting,
         "Disable recognition of objc_direct methods")
-LANGOPT(CFProtectionBranch , 1, 0, "Control-Flow Branch Protection enabled")
-ENUM_LANGOPT(CFBranchLabelScheme, CFBranchLabelSchemeKind, 2, CFBranchLabelSchemeKind::Default,
+LANGOPT(CFProtectionBranch , 1, 0, Affecting, "Control-Flow Branch Protection enabled")
+ENUM_LANGOPT(CFBranchLabelScheme, CFBranchLabelSchemeKind, 2, CFBranchLabelSchemeKind::Default, Affecting,
              "Control-Flow Branch Protection Label Scheme")
-LANGOPT(CFProtectionReturn, 1, 0, "Control-Flow Return Protection enabled")
-LANGOPT(FakeAddressSpaceMap , 1, 0, "OpenCL fake address space map")
-ENUM_LANGOPT(AddressSpaceMapMangling , AddrSpaceMapMangling, 2, ASMM_Target, "OpenCL address space map mangling mode")
-LANGOPT(IncludeDefaultHeader, 1, 0, "Include default header file for OpenCL")
-LANGOPT(DeclareOpenCLBuiltins, 1, 0, "Declare OpenCL builtin functions")
-BENIGN_LANGOPT(DelayedTemplateParsing , 1, 0, "delayed template parsing")
-LANGOPT(BlocksRuntimeOptional , 1, 0, "optional blocks runtime")
+LANGOPT(CFProtectionReturn, 1, 0, Affecting, "Control-Flow Return Protection enabled")
+LANGOPT(FakeAddressSpaceMap , 1, 0, Affecting, "OpenCL fake address space map")
+ENUM_LANGOPT(AddressSpaceMapMangling , AddrSpaceMapMangling, 2, ASMM_Target, Affecting, "OpenCL address space map mangling mode")
+LANGOPT(IncludeDefaultHeader, 1, 0, Affecting, "Include default header file for OpenCL")
+LANGOPT(DeclareOpenCLBuiltins, 1, 0, Affecting, "Declare OpenCL builtin functions")
+LANGOPT(DelayedTemplateParsing , 1, 0, Benign, "delayed template parsing")
+LANGOPT(BlocksRuntimeOptional , 1, 0, Affecting, "optional blocks runtime")
 LANGOPT(
-    CompleteMemberPointers, 1, 0,
+    CompleteMemberPointers, 1, 0, Affecting,
     "Require member pointer base types to be complete at the point where the "
     "type's inheritance model would be determined under the Microsoft ABI")
 
-ENUM_LANGOPT(GC, GCMode, 2, NonGC, "Objective-C Garbage Collection mode")
-BENIGN_ENUM_LANGOPT(ValueVisibilityMode, Visibility, 3, DefaultVisibility,
+ENUM_LANGOPT(GC, GCMode, 2, NonGC, Affecting, "Objective-C Garbage Collection mode")
+ENUM_LANGOPT(ValueVisibilityMode, Visibility, 3, DefaultVisibility, Benign,
              "default visibility for functions and variables [-fvisibility]")
-BENIGN_ENUM_LANGOPT(TypeVisibilityMode, Visibility, 3, DefaultVisibility,
+ENUM_LANGOPT(TypeVisibilityMode, Visibility, 3, DefaultVisibility, Benign,
              "default visibility for types [-ftype-visibility]")
-LANGOPT(SetVisibilityForExternDecls, 1, 0,
+LANGOPT(SetVisibilityForExternDecls, 1, 0, Affecting,
         "apply global symbol visibility to external declarations without an explicit visibility")
-BENIGN_LANGOPT(VisibilityFromDLLStorageClass, 1, 0,
-               "override the visibility of globals based on their final DLL storage class [-fvisibility-from-dllstorageclass]")
-BENIGN_ENUM_LANGOPT(DLLExportVisibility, VisibilityFromDLLStorageClassKinds, 3, VisibilityFromDLLStorageClassKinds::Default,
+LANGOPT(VisibilityFromDLLStorageClass, 1, 0, Benign,
+        "override the visibility of globals based on their final DLL storage class [-fvisibility-from-dllstorageclass]")
+ENUM_LANGOPT(DLLExportVisibility, VisibilityFromDLLStorageClassKinds, 3, VisibilityFromDLLStorageClassKinds::Default, Benign,
              "how to adjust the visibility for functions and variables with dllexport annotations [-fvisibility-dllexport]")
-BENIGN_ENUM_LANGOPT(NoDLLStorageClassVisibility, VisibilityFromDLLStorageClassKinds, 3, VisibilityFromDLLStorageClassKinds::Hidden,
+ENUM_LANGOPT(NoDLLStorageClassVisibility, VisibilityFromDLLStorageClassKinds, 3, VisibilityFromDLLStorageClassKinds::Hidden, Benign,
              "how to adjust the visibility for functions and variables without an explicit DLL storage class [-fvisibility-nodllstorageclass]")
-BENIGN_ENUM_LANGOPT(ExternDeclDLLImportVisibility, VisibilityFromDLLStorageClassKinds, 3, VisibilityFromDLLStorageClassKinds::Default,
+ENUM_LANGOPT(ExternDeclDLLImportVisibility, VisibilityFromDLLStorageClassKinds, 3, VisibilityFromDLLStorageClassKinds::Default, Benign,
              "how to adjust the visibility for external declarations with dllimport annotations [-fvisibility-externs-dllimport]")
-BENIGN_ENUM_LANGOPT(ExternDeclNoDLLStorageClassVisibility, VisibilityFromDLLStorageClassKinds, 3,  VisibilityFromDLLStorageClassKinds::Hidden,
+ENUM_LANGOPT(ExternDeclNoDLLStorageClassVisibility, VisibilityFromDLLStorageClassKinds, 3,  VisibilityFromDLLStorageClassKinds::Hidden, Benign,
              "how to adjust the visibility for external declarations without an explicit DLL storage class [-fvisibility-externs-nodllstorageclass]")
-BENIGN_LANGOPT(SemanticInterposition        , 1, 0, "semantic interposition")
-BENIGN_LANGOPT(HalfNoSemanticInterposition, 1, 0,
-               "Like -fno-semantic-interposition but don't use local aliases")
-ENUM_LANGOPT(StackProtector, StackProtectorMode, 2, SSPOff,
+LANGOPT(SemanticInterposition        , 1, 0, Benign, "semantic interposition")
+LANGOPT(HalfNoSemanticInterposition, 1, 0, Benign,
+        "Like -fno-semantic-interposition but don't use local aliases")
+ENUM_LANGOPT(StackProtector, StackProtectorMode, 2, SSPOff, Affecting,
              "stack protector mode")
-BENIGN_ENUM_LANGOPT(TrivialAutoVarInit, TrivialAutoVarInitKind, 2, TrivialAutoVarInitKind::Uninitialized,
+ENUM_LANGOPT(TrivialAutoVarInit, TrivialAutoVarInitKind, 2, TrivialAutoVarInitKind::Uninitialized, Benign,
              "trivial automatic variable initialization")
-BENIGN_VALUE_LANGOPT(TrivialAutoVarInitStopAfter, 32, 0,
-             "stop trivial automatic variable initialization after the specified number of instances. Must be greater than 0.")
-BENIGN_VALUE_LANGOPT(TrivialAutoVarInitMaxSize, 32, 0,
-             "stop trivial automatic variable initialization if var size exceeds the specified size (in bytes). Must be greater than 0.")
-ENUM_LANGOPT(SignedOverflowBehavior, SignedOverflowBehaviorTy, 2, SOB_Undefined,
+VALUE_LANGOPT(TrivialAutoVarInitStopAfter, 32, 0, Benign,
+              "stop trivial automatic variable initialization after the specified number of instances. Must be greater than 0.")
+VALUE_LANGOPT(TrivialAutoVarInitMaxSize, 32, 0, Benign,
+              "stop trivial automatic variable initialization if var size exceeds the specified size (in bytes). Must be greater than 0.")
+ENUM_LANGOPT(SignedOverflowBehavior, SignedOverflowBehaviorTy, 2, SOB_Undefined, Affecting,
              "signed integer overflow handling")
-LANGOPT(PointerOverflowDefined, 1, 0, "make pointer overflow defined")
-ENUM_LANGOPT(ThreadModel  , ThreadModelKind, 2, ThreadModelKind::POSIX, "Thread Model")
+LANGOPT(PointerOverflowDefined, 1, 0, Affecting, "make pointer overflow defined")
+ENUM_LANGOPT(ThreadModel  , ThreadModelKind, 2, ThreadModelKind::POSIX, Affecting, "Thread Model")
 
-BENIGN_LANGOPT(ArrowDepth, 32, 256,
-               "maximum number of operator->s to follow")
-BENIGN_LANGOPT(InstantiationDepth, 32, 1024,
-               "maximum template instantiation depth")
-BENIGN_LANGOPT(ConstexprCallDepth, 32, 512,
-               "maximum constexpr call depth")
-BENIGN_LANGOPT(ConstexprStepLimit, 32, 1048576,
-               "maximum constexpr evaluation steps")
-BENIGN_LANGOPT(EnableNewConstInterp, 1, 0,
-               "enable the experimental new constant interpreter")
-BENIGN_LANGOPT(BracketDepth, 32, 256,
-               "maximum bracket nesting depth")
-BENIGN_LANGOPT(NumLargeByValueCopy, 32, 0,
+LANGOPT(ArrowDepth, 32, 256, Benign,
+        "maximum number of operator->s to follow")
+LANGOPT(InstantiationDepth, 32, 1024, Benign,
+        "maximum template instantiation depth")
+LANGOPT(ConstexprCallDepth, 32, 512, Benign,
+        "maximum constexpr call depth")
+LANGOPT(ConstexprStepLimit, 32, 1048576, Benign,
+        "maximum constexpr evaluation steps")
+LANGOPT(EnableNewConstInterp, 1, 0, Benign,
+        "enable the experimental new constant interpreter")
+LANGOPT(BracketDepth, 32, 256, Benign,
+        "maximum bracket nesting depth")
+LANGOPT(NumLargeByValueCopy, 32, 0, Benign,
         "if non-zero, warn about parameter or return Warn if parameter/return value is larger in bytes than this setting. 0 is no check.")
-VALUE_LANGOPT(MSCompatibilityVersion, 32, 0, "Microsoft Visual C/C++ Version")
-ENUM_LANGOPT(VtorDispMode, MSVtorDispMode, 2, MSVtorDispMode::ForVBaseOverride,
+VALUE_LANGOPT(MSCompatibilityVersion, 32, 0, Affecting, "Microsoft Visual C/C++ Version")
+ENUM_LANGOPT(VtorDispMode, MSVtorDispMode, 2, MSVtorDispMode::ForVBaseOverride, Affecting,
              "How many vtordisps to insert")
 
-LANGOPT(ApplePragmaPack, 1, 0, "Apple gcc-compatible #pragma pack handling")
+LANGOPT(ApplePragmaPack, 1, 0, Affecting, "Apple gcc-compatible #pragma pack handling")
 
-LANGOPT(XLPragmaPack, 1, 0, "IBM XL #pragma pack handling")
+LANGOPT(XLPragmaPack, 1, 0, Affecting, "IBM XL #pragma pack handling")
 
-COMPATIBLE_LANGOPT(RetainCommentsFromSystemHeaders, 1, 0, "retain documentation comments from system headers in the AST")
+LANGOPT(RetainCommentsFromSystemHeaders, 1, 0, Compatible, "retain documentation comments from system headers in the AST")
 
-LANGOPT(APINotes, 1, 0, "use external API notes")
-LANGOPT(APINotesModules, 1, 0, "use module-based external API notes")
+LANGOPT(APINotes, 1, 0, Affecting, "use external API notes")
+LANGOPT(APINotesModules, 1, 0, Affecting, "use module-based external API notes")
 
-LANGOPT(SanitizeAddressFieldPadding, 2, 0, "controls how aggressive is ASan "
-                                           "field padding (0: none, 1:least "
-                                           "aggressive, 2: more aggressive)")
+LANGOPT(SanitizeAddressFieldPadding, 2, 0, Affecting, "controls how aggressive is ASan "
+                                                      "field padding (0: none, 1:least "
+                                                      "aggressive, 2: more aggressive)")
 
-LANGOPT(Cmse, 1, 0, "ARM Security extensions support")
+LANGOPT(Cmse, 1, 0, Affecting, "ARM Security extensions support")
 
-LANGOPT(XRayInstrument, 1, 0, "controls whether to do XRay instrumentation")
-LANGOPT(XRayAlwaysEmitCustomEvents, 1, 0,
+LANGOPT(XRayInstrument, 1, 0, Affecting, "controls whether to do XRay instrumentation")
+LANGOPT(XRayAlwaysEmitCustomEvents, 1, 0, Affecting,
         "controls whether to always emit intrinsic calls to "
         "__xray_customevent(...) builtin.")
-LANGOPT(XRayAlwaysEmitTypedEvents, 1, 0,
+LANGOPT(XRayAlwaysEmitTypedEvents, 1, 0, Affecting,
         "controls whether to always emit intrinsic calls to "
         "__xray_typedevent(...) builtin.")
 
-LANGOPT(ForceEmitVTables, 1, 0, "whether to emit all vtables")
+LANGOPT(ForceEmitVTables, 1, 0, Affecting, "whether to emit all vtables")
 
-BENIGN_LANGOPT(AllowEditorPlaceholders, 1, 0,
-               "allow editor placeholders in source")
+LANGOPT(AllowEditorPlaceholders, 1, 0, Benign,
+        "allow editor placeholders in source")
 
-ENUM_LANGOPT(ClangABICompat, ClangABI, 4, ClangABI::Latest,
+ENUM_LANGOPT(ClangABICompat, ClangABI, 4, ClangABI::Latest, Affecting,
              "version of Clang that we should attempt to be ABI-compatible "
              "with")
 
-COMPATIBLE_VALUE_LANGOPT(FunctionAlignment, 5, 0, "Default alignment for functions")
-COMPATIBLE_VALUE_LANGOPT(LoopAlignment, 32, 0, "Default alignment for loops")
+VALUE_LANGOPT(FunctionAlignment, 5, 0, Compatible, "Default alignment for functions")
+VALUE_LANGOPT(LoopAlignment, 32, 0, Compatible, "Default alignment for loops")
 
-LANGOPT(FixedPoint, 1, 0, "fixed point types")
-LANGOPT(PaddingOnUnsignedFixedPoint, 1, 0,
+LANGOPT(FixedPoint, 1, 0, Affecting, "fixed point types")
+LANGOPT(PaddingOnUnsignedFixedPoint, 1, 0, Affecting,
         "unsigned fixed point types having one extra padding bit")
 
 ENUM_LANGOPT(RegisterStaticDestructors, RegisterStaticDestructorsKind, 2,
-             RegisterStaticDestructorsKind::All,
+             RegisterStaticDestructorsKind::All, Affecting,
              "Register C++ static destructors")
 
-LANGOPT(RegCall4, 1, 0, "Set __regcall4 as a default calling convention to respect __regcall ABI v.4")
+LANGOPT(RegCall4, 1, 0, Affecting, "Set __regcall4 as a default calling convention to respect __regcall ABI v.4")
 
-LANGOPT(MatrixTypes, 1, 0, "Enable or disable the builtin matrix type")
+LANGOPT(MatrixTypes, 1, 0, Affecting, "Enable or disable the builtin matrix type")
 
-LANGOPT(CXXAssumptions, 1, 1, "Enable or disable codegen and compile-time checks for C++23's [[assume]] attribute")
+LANGOPT(CXXAssumptions, 1, 1, Affecting, "Enable or disable codegen and compile-time checks for C++23's [[assume]] attribute")
 
-LANGOPT(RawStringLiterals, 1, 1, "Enable or disable raw string literals")
+LANGOPT(RawStringLiterals, 1, 1, Affecting, "Enable or disable raw string literals")
 
 ENUM_LANGOPT(StrictFlexArraysLevel, StrictFlexArraysLevelKind, 2,
-             StrictFlexArraysLevelKind::Default,
+             StrictFlexArraysLevelKind::Default, Affecting,
              "Rely on strict definition of flexible arrays")
 
-COMPATIBLE_VALUE_LANGOPT(MaxTokens, 32, 0, "Max number of tokens per TU or 0")
+VALUE_LANGOPT(MaxTokens, 32, 0, Compatible, "Max number of tokens per TU or 0")
 
-ENUM_LANGOPT(SignReturnAddressScope, SignReturnAddressScopeKind, 2, SignReturnAddressScopeKind::None,
+ENUM_LANGOPT(SignReturnAddressScope, SignReturnAddressScopeKind, 2, SignReturnAddressScopeKind::None, Affecting,
              "Scope of return address signing")
-ENUM_LANGOPT(SignReturnAddressKey, SignReturnAddressKeyKind, 1, SignReturnAddressKeyKind::AKey,
+ENUM_LANGOPT(SignReturnAddressKey, SignReturnAddressKeyKind, 1, SignReturnAddressKeyKind::AKey, Affecting,
              "Key used for return address signing")
-LANGOPT(BranchTargetEnforcement, 1, 0, "Branch-target enforcement enabled")
-LANGOPT(BranchProtectionPAuthLR, 1, 0, "Use PC as a diversifier using PAuthLR NOP instructions.")
-LANGOPT(GuardedControlStack, 1, 0, "Guarded control stack enabled")
+LANGOPT(BranchTargetEnforcement, 1, 0, Affecting, "Branch-target enforcement enabled")
+LANGOPT(BranchProtectionPAuthLR, 1, 0, Affecting, "Use PC as a diversifier using PAuthLR NOP instructions.")
+LANGOPT(GuardedControlStack, 1, 0, Affecting, "Guarded control stack enabled")
 
-LANGOPT(SpeculativeLoadHardening, 1, 0, "Speculative load hardening enabled")
+LANGOPT(SpeculativeLoadHardening, 1, 0, Affecting, "Speculative load hardening enabled")
 
-LANGOPT(RelativeCXXABIVTables, 1, 0,
+LANGOPT(RelativeCXXABIVTables, 1, 0, Affecting,
         "Use an ABI-incompatible v-table layout that uses relative references")
 
-LANGOPT(OmitVTableRTTI, 1, 0,
+LANGOPT(OmitVTableRTTI, 1, 0, Affecting,
         "Use an ABI-incompatible v-table layout that omits the RTTI component")
 
-LANGOPT(VScaleMin, 32, 0, "Minimum vscale value")
-LANGOPT(VScaleMax, 32, 0, "Maximum vscale value")
+LANGOPT(VScaleMin, 32, 0, Affecting, "Minimum vscale value")
+LANGOPT(VScaleMax, 32, 0, Affecting, "Maximum vscale value")
 
-LANGOPT(VScaleStreamingMin, 32, 0, "Minimum streaming vscale value")
-LANGOPT(VScaleStreamingMax, 32, 0, "Maximum streaming vscale value")
+LANGOPT(VScaleStreamingMin, 32, 0, Affecting, "Minimum streaming vscale value")
+LANGOPT(VScaleStreamingMax, 32, 0, Affecting, "Maximum streaming vscale value")
 
-ENUM_LANGOPT(ExtendIntArgs, ExtendArgsKind, 1, ExtendArgsKind::ExtendTo32,
+ENUM_LANGOPT(ExtendIntArgs, ExtendArgsKind, 1, ExtendArgsKind::ExtendTo32, Affecting,
              "Controls how scalar integer arguments are extended in calls "
              "to unprototyped and varargs functions")
 
-VALUE_LANGOPT(FuchsiaAPILevel, 32, 0, "Fuchsia API level")
+VALUE_LANGOPT(FuchsiaAPILevel, 32, 0, Affecting, "Fuchsia API level")
 
 // This option will be removed in the future once the backend
 // supports all operations (like division or float-to-integer conversion)
 // on large _BitInts.
-BENIGN_VALUE_LANGOPT(MaxBitIntWidth, 32, 128, "Maximum width of a _BitInt")
+VALUE_LANGOPT(MaxBitIntWidth, 32, 128, Benign, "Maximum width of a _BitInt")
 
-COMPATIBLE_LANGOPT(IncrementalExtensions, 1, 0, "True if we want to process statements "
+LANGOPT(IncrementalExtensions, 1, 0, Compatible,  "True if we want to process statements "
         "on the global scope, ignore EOF token and continue later on (thus "
         "avoid tearing the Lexer and etc. down). Controlled by "
         "-fincremental-extensions.")
 
-BENIGN_LANGOPT(CheckNew, 1, 0, "Do not assume C++ operator new may not return NULL")
+LANGOPT(CheckNew, 1, 0, Benign, "Do not assume C++ operator new may not return NULL")
 
 // FIXME: It would be better for us to find a way to encode the state of this
 // diagnostic in tablegen so that we can specify a particular diagnostic option
 // is disabled or enabled based on other language options or made it easier to
 // do this from the compiler invocation without hitting option round-tripping
 // issues.
-BENIGN_LANGOPT(CheckConstexprFunctionBodies, 1, 1,
-               "Emit diagnostics for a constexpr function body that can never "
-               "be used in a constant expression.")
+LANGOPT(CheckConstexprFunctionBodies, 1, 1, Benign,
+        "Emit diagnostics for a constexpr function body that can never "
+        "be used in a constant expression.")
 
-LANGOPT(BoundsSafety, 1, 0, "Bounds safety extension for C")
+LANGOPT(BoundsSafety, 1, 0, Affecting, "Bounds safety extension for C")
 
-LANGOPT(PreserveVec3Type, 1, 0, "Preserve 3-component vector type")
+LANGOPT(PreserveVec3Type, 1, 0, Affecting, "Preserve 3-component vector type")
 
 #undef LANGOPT
-#undef COMPATIBLE_LANGOPT
-#undef BENIGN_LANGOPT
 #undef ENUM_LANGOPT
-#undef COMPATIBLE_ENUM_LANGOPT
-#undef BENIGN_ENUM_LANGOPT
 #undef VALUE_LANGOPT
-#undef COMPATIBLE_VALUE_LANGOPT
-#undef BENIGN_VALUE_LANGOPT

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -66,6 +66,20 @@ enum class PointerAuthenticationMode : unsigned {
   SignAndAuth
 };
 
+enum EffectKind {
+  // Does affect the construction of the AST in a way that does prevent module
+  // interoperability.
+  Affecting,
+  // Does affect the construction of the AST in a way that doesn't prevent
+  // interoperability (that is, the value can be different between an explicit
+  // module and the user of that module).
+  Compatible,
+  // Does not affect the construction of the AST in any way (that is, the
+  // value can be different between an implicit module and the user of that
+  // module).
+  Benign,
+};
+
 /// Bitfields of LangOptions, split out from LangOptions in order to ensure that
 /// this large collection of bitfields is a trivial class type.
 class LangOptionsBase {
@@ -486,16 +500,17 @@ public:
   };
 
   // Define simple language options (with no accessors).
-#define LANGOPT(Name, Bits, Default, Description) unsigned Name : Bits;
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
+  unsigned Name : Bits;
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)
 #include "clang/Basic/LangOptions.def"
 
 protected:
   // Define language options of enumeration type. These are private, and will
   // have accessors (below).
-#define LANGOPT(Name, Bits, Default, Description)
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-  LLVM_PREFERRED_TYPE(Type) \
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
+  LLVM_PREFERRED_TYPE(Type)                                                    \
   unsigned Name : Bits;
 #include "clang/Basic/LangOptions.def"
 };
@@ -655,8 +670,8 @@ public:
                   LangStandard::Kind LangStd = LangStandard::lang_unspecified);
 
   // Define accessors/mutators for language options of enumeration type.
-#define LANGOPT(Name, Bits, Default, Description)
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)                   \
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
   Type get##Name() const { return static_cast<Type>(Name); }                   \
   void set##Name(Type Value) {                                                 \
     assert(static_cast<unsigned>(Value) < (1u << Bits));                       \

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -66,20 +66,6 @@ enum class PointerAuthenticationMode : unsigned {
   SignAndAuth
 };
 
-enum EffectKind {
-  // Does affect the construction of the AST in a way that does prevent module
-  // interoperability.
-  Affecting,
-  // Does affect the construction of the AST in a way that doesn't prevent
-  // interoperability (that is, the value can be different between an explicit
-  // module and the user of that module).
-  Compatible,
-  // Does not affect the construction of the AST in any way (that is, the
-  // value can be different between an implicit module and the user of that
-  // module).
-  Benign,
-};
-
 /// Bitfields of LangOptions, split out from LangOptions in order to ensure that
 /// this large collection of bitfields is a trivial class type.
 class LangOptionsBase {
@@ -90,6 +76,22 @@ public:
   using Visibility = clang::Visibility;
   using RoundingMode = llvm::RoundingMode;
   using CFBranchLabelSchemeKind = clang::CFBranchLabelSchemeKind;
+
+  /// For ASTs produced with different value, signifies their level of
+  /// compatibility.
+  enum class CompatibilityKind {
+    /// Does affect the construction of the AST in a way that does prevent
+    /// module interoperability.
+    NotCompatible,
+    /// Does affect the construction of the AST in a way that doesn't prevent
+    /// interoperability (that is, the value can be different between an
+    /// explicit module and the user of that module).
+    Compatible,
+    /// Does not affect the construction of the AST in any way (that is, the
+    /// value can be different between an implicit module and the user of that
+    /// module).
+    Benign,
+  };
 
   enum GCMode { NonGC, GCOnly, HybridGC };
   enum StackProtectorMode { SSPOff, SSPOn, SSPStrong, SSPReq };

--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -77,7 +77,7 @@ public:
   using RoundingMode = llvm::RoundingMode;
   using CFBranchLabelSchemeKind = clang::CFBranchLabelSchemeKind;
 
-  /// For ASTs produced with different value, signifies their level of
+  /// For ASTs produced with different option value, signifies their level of
   /// compatibility.
   enum class CompatibilityKind {
     /// Does affect the construction of the AST in a way that does prevent

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -16,16 +16,19 @@
 using namespace clang;
 
 LangOptions::LangOptions() : LangStd(LangStandard::lang_unspecified) {
-#define LANGOPT(Name, Bits, Default, Description) Name = Default;
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) set##Name(Default);
+#define LANGOPT(Name, Bits, Default, Compatibility, Description) Name = Default;
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
+  set##Name(Default);
 #include "clang/Basic/LangOptions.def"
 }
 
 void LangOptions::resetNonModularOptions() {
-#define LANGOPT(Name, Bits, Default, Description)
-#define BENIGN_LANGOPT(Name, Bits, Default, Description) Name = Default;
-#define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-  Name = static_cast<unsigned>(Default);
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
+  if constexpr (Compatibility == Benign)                                       \
+    Name = Default;
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
+  if constexpr (Compatibility == Benign)                                       \
+    Name = static_cast<unsigned>(Default);
 #include "clang/Basic/LangOptions.def"
 
   // Reset "benign" options with implied values (Options.td ImpliedBy relations)

--- a/clang/lib/Basic/LangOptions.cpp
+++ b/clang/lib/Basic/LangOptions.cpp
@@ -24,10 +24,10 @@ LangOptions::LangOptions() : LangStd(LangStandard::lang_unspecified) {
 
 void LangOptions::resetNonModularOptions() {
 #define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
-  if constexpr (Compatibility == Benign)                                       \
+  if constexpr (CompatibilityKind::Compatibility == CompatibilityKind::Benign) \
     Name = Default;
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
-  if constexpr (Compatibility == Benign)                                       \
+  if constexpr (CompatibilityKind::Compatibility == CompatibilityKind::Benign) \
     Name = static_cast<unsigned>(Default);
 #include "clang/Basic/LangOptions.def"
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5222,11 +5222,12 @@ std::string CompilerInvocation::getModuleHash() const {
   HBuilder.add(serialization::VERSION_MAJOR, serialization::VERSION_MINOR);
 
   // Extend the signature with the language options
-#define LANGOPT(Name, Bits, Default, Description) HBuilder.add(LangOpts->Name);
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)                   \
-  HBuilder.add(static_cast<unsigned>(LangOpts->get##Name()));
-#define BENIGN_LANGOPT(Name, Bits, Default, Description)
-#define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description)
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
+  if constexpr (Compatibility != Benign)                                       \
+    HBuilder.add(LangOpts->Name);
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
+  if constexpr (Compatibility != Benign)                                       \
+    HBuilder.add(static_cast<unsigned>(LangOpts->get##Name()));
 #include "clang/Basic/LangOptions.def"
 
   HBuilder.addRange(getLangOpts().ModuleFeatures);

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5222,11 +5222,13 @@ std::string CompilerInvocation::getModuleHash() const {
   HBuilder.add(serialization::VERSION_MAJOR, serialization::VERSION_MINOR);
 
   // Extend the signature with the language options
+  // FIXME: Replace with C++20 `using enum LangOptions::CompatibilityKind`.
+  using CK = LangOptions::CompatibilityKind;
 #define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
-  if constexpr (Compatibility != Benign)                                       \
+  if constexpr (CK::Compatibility != CK::Benign)                               \
     HBuilder.add(LangOpts->Name);
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
-  if constexpr (Compatibility != Benign)                                       \
+  if constexpr (CK::Compatibility != CK::Benign)                               \
     HBuilder.add(static_cast<unsigned>(LangOpts->get##Name()));
 #include "clang/Basic/LangOptions.def"
 

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -644,15 +644,16 @@ namespace {
                              StringRef ModuleFilename, bool Complain,
                              bool AllowCompatibleDifferences) override {
       Out.indent(2) << "Language options:\n";
-#define LANGOPT(Name, Bits, Default, Description) \
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
+    if constexpr (Compatibility != Benign)                                     \
       DUMP_BOOLEAN(LangOpts.Name, Description);
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-      Out.indent(4) << Description << ": "                   \
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
+    if constexpr (Compatibility != Benign)                                     \
+      Out.indent(4) << Description << ": "                                     \
                     << static_cast<unsigned>(LangOpts.get##Name()) << "\n";
-#define VALUE_LANGOPT(Name, Bits, Default, Description) \
+#define VALUE_LANGOPT(Name, Bits, Default, Compatibility, Description)         \
+    if constexpr (Compatibility != Benign)                                     \
       Out.indent(4) << Description << ": " << LangOpts.Name << "\n";
-#define BENIGN_LANGOPT(Name, Bits, Default, Description)
-#define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description)
 #include "clang/Basic/LangOptions.def"
 
       if (!LangOpts.ModuleFeatures.empty()) {

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -643,16 +643,19 @@ namespace {
     bool ReadLanguageOptions(const LangOptions &LangOpts,
                              StringRef ModuleFilename, bool Complain,
                              bool AllowCompatibleDifferences) override {
+      // FIXME: Replace with C++20 `using enum LangOptions::CompatibilityKind`.
+      using CK = LangOptions::CompatibilityKind;
+
       Out.indent(2) << "Language options:\n";
 #define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
-    if constexpr (Compatibility != Benign)                                     \
+    if constexpr (CK::Compatibility != CK::Benign)                             \
       DUMP_BOOLEAN(LangOpts.Name, Description);
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
-    if constexpr (Compatibility != Benign)                                     \
+    if constexpr (CK::Compatibility != CK::Benign)                             \
       Out.indent(4) << Description << ": "                                     \
                     << static_cast<unsigned>(LangOpts.get##Name()) << "\n";
 #define VALUE_LANGOPT(Name, Bits, Default, Compatibility, Description)         \
-    if constexpr (Compatibility != Benign)                                     \
+    if constexpr (CK::Compatibility != CK::Benign)                             \
       Out.indent(4) << Description << ": " << LangOpts.Name << "\n";
 #include "clang/Basic/LangOptions.def"
 

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -278,51 +278,51 @@ static bool checkLanguageOptions(const LangOptions &LangOpts,
                                  StringRef ModuleFilename,
                                  DiagnosticsEngine *Diags,
                                  bool AllowCompatibleDifferences = true) {
-#define LANGOPT(Name, Bits, Default, Description)                              \
-  if (ExistingLangOpts.Name != LangOpts.Name) {                                \
-    if (Diags) {                                                               \
-      if (Bits == 1)                                                           \
-        Diags->Report(diag::err_ast_file_langopt_mismatch)                     \
-            << Description << LangOpts.Name << ExistingLangOpts.Name           \
-            << ModuleFilename;                                                 \
-      else                                                                     \
-        Diags->Report(diag::err_ast_file_langopt_value_mismatch)               \
-            << Description << ModuleFilename;                                  \
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
+  if constexpr (Compatibility != Benign) {                                     \
+    if ((Compatibility == Affecting) ||                                        \
+        (Compatibility == Compatible && !AllowCompatibleDifferences)) {        \
+      if (ExistingLangOpts.Name != LangOpts.Name) {                            \
+        if (Diags) {                                                           \
+          if (Bits == 1)                                                       \
+            Diags->Report(diag::err_ast_file_langopt_mismatch)                 \
+                << Description << LangOpts.Name << ExistingLangOpts.Name       \
+                << ModuleFilename;                                             \
+          else                                                                 \
+            Diags->Report(diag::err_ast_file_langopt_value_mismatch)           \
+                << Description << ModuleFilename;                              \
+        }                                                                      \
+        return true;                                                           \
+      }                                                                        \
     }                                                                          \
-    return true;                                                               \
   }
 
-#define VALUE_LANGOPT(Name, Bits, Default, Description)                        \
-  if (ExistingLangOpts.Name != LangOpts.Name) {                                \
-    if (Diags)                                                                 \
-      Diags->Report(diag::err_ast_file_langopt_value_mismatch)                 \
-          << Description << ModuleFilename;                                    \
-    return true;                                                               \
+#define VALUE_LANGOPT(Name, Bits, Default, Compatibility, Description)         \
+  if constexpr (Compatibility != Benign) {                                     \
+    if ((Compatibility == Affecting) ||                                        \
+        (Compatibility == Compatible && !AllowCompatibleDifferences)) {        \
+      if (ExistingLangOpts.Name != LangOpts.Name) {                            \
+        if (Diags)                                                             \
+          Diags->Report(diag::err_ast_file_langopt_value_mismatch)             \
+              << Description << ModuleFilename;                                \
+        return true;                                                           \
+      }                                                                        \
+    }                                                                          \
   }
 
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)                   \
-  if (ExistingLangOpts.get##Name() != LangOpts.get##Name()) {                  \
-    if (Diags)                                                                 \
-      Diags->Report(diag::err_ast_file_langopt_value_mismatch)                 \
-          << Description << ModuleFilename;                                    \
-    return true;                                                               \
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
+  if constexpr (Compatibility != Benign) {                                     \
+    if ((Compatibility == Affecting) ||                                        \
+        (Compatibility == Compatible && !AllowCompatibleDifferences)) {        \
+      if (ExistingLangOpts.get##Name() != LangOpts.get##Name()) {              \
+        if (Diags)                                                             \
+          Diags->Report(diag::err_ast_file_langopt_value_mismatch)             \
+              << Description << ModuleFilename;                                \
+        return true;                                                           \
+      }                                                                        \
+    }                                                                          \
   }
 
-#define COMPATIBLE_LANGOPT(Name, Bits, Default, Description)  \
-  if (!AllowCompatibleDifferences)                            \
-    LANGOPT(Name, Bits, Default, Description)
-
-#define COMPATIBLE_ENUM_LANGOPT(Name, Bits, Default, Description)  \
-  if (!AllowCompatibleDifferences)                                 \
-    ENUM_LANGOPT(Name, Bits, Default, Description)
-
-#define COMPATIBLE_VALUE_LANGOPT(Name, Bits, Default, Description) \
-  if (!AllowCompatibleDifferences)                                 \
-    VALUE_LANGOPT(Name, Bits, Default, Description)
-
-#define BENIGN_LANGOPT(Name, Bits, Default, Description)
-#define BENIGN_ENUM_LANGOPT(Name, Type, Bits, Default, Description)
-#define BENIGN_VALUE_LANGOPT(Name, Bits, Default, Description)
 #include "clang/Basic/LangOptions.def"
 
   if (ExistingLangOpts.ModuleFeatures != LangOpts.ModuleFeatures) {
@@ -6353,9 +6353,9 @@ bool ASTReader::ParseLanguageOptions(const RecordData &Record,
                                      bool AllowCompatibleDifferences) {
   LangOptions LangOpts;
   unsigned Idx = 0;
-#define LANGOPT(Name, Bits, Default, Description) \
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
   LangOpts.Name = Record[Idx++];
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
   LangOpts.set##Name(static_cast<LangOptions::Type>(Record[Idx++]));
 #include "clang/Basic/LangOptions.def"
 #define SANITIZER(NAME, ID)                                                    \

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -278,10 +278,14 @@ static bool checkLanguageOptions(const LangOptions &LangOpts,
                                  StringRef ModuleFilename,
                                  DiagnosticsEngine *Diags,
                                  bool AllowCompatibleDifferences = true) {
+  // FIXME: Replace with C++20 `using enum LangOptions::CompatibilityKind`.
+  using CK = LangOptions::CompatibilityKind;
+
 #define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
-  if constexpr (Compatibility != Benign) {                                     \
-    if ((Compatibility == Affecting) ||                                        \
-        (Compatibility == Compatible && !AllowCompatibleDifferences)) {        \
+  if constexpr (CK::Compatibility != CK::Benign) {                             \
+    if ((CK::Compatibility == CK::NotCompatible) ||                            \
+        (CK::Compatibility == CK::Compatible &&                                \
+         !AllowCompatibleDifferences)) {                                       \
       if (ExistingLangOpts.Name != LangOpts.Name) {                            \
         if (Diags) {                                                           \
           if (Bits == 1)                                                       \
@@ -298,9 +302,10 @@ static bool checkLanguageOptions(const LangOptions &LangOpts,
   }
 
 #define VALUE_LANGOPT(Name, Bits, Default, Compatibility, Description)         \
-  if constexpr (Compatibility != Benign) {                                     \
-    if ((Compatibility == Affecting) ||                                        \
-        (Compatibility == Compatible && !AllowCompatibleDifferences)) {        \
+  if constexpr (CK::Compatibility != CK::Benign) {                             \
+    if ((CK::Compatibility == CK::NotCompatible) ||                            \
+        (CK::Compatibility == CK::Compatible &&                                \
+         !AllowCompatibleDifferences)) {                                       \
       if (ExistingLangOpts.Name != LangOpts.Name) {                            \
         if (Diags)                                                             \
           Diags->Report(diag::err_ast_file_langopt_value_mismatch)             \
@@ -311,9 +316,10 @@ static bool checkLanguageOptions(const LangOptions &LangOpts,
   }
 
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
-  if constexpr (Compatibility != Benign) {                                     \
-    if ((Compatibility == Affecting) ||                                        \
-        (Compatibility == Compatible && !AllowCompatibleDifferences)) {        \
+  if constexpr (CK::Compatibility != CK::Benign) {                             \
+    if ((CK::Compatibility == CK::NotCompatible) ||                            \
+        (CK::Compatibility == CK::Compatible &&                                \
+         !AllowCompatibleDifferences)) {                                       \
       if (ExistingLangOpts.get##Name() != LangOpts.get##Name()) {              \
         if (Diags)                                                             \
           Diags->Report(diag::err_ast_file_langopt_value_mismatch)             \

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1612,9 +1612,9 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
   // Language options.
   Record.clear();
   const LangOptions &LangOpts = PP.getLangOpts();
-#define LANGOPT(Name, Bits, Default, Description) \
+#define LANGOPT(Name, Bits, Default, Compatibility, Description)               \
   Record.push_back(LangOpts.Name);
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Compatibility, Description)    \
   Record.push_back(static_cast<unsigned>(LangOpts.get##Name()));
 #include "clang/Basic/LangOptions.def"
 #define SANITIZER(NAME, ID)                                                    \

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -852,27 +852,9 @@ getCompilationDatabase(int argc, char **argv, std::string &ErrorMessage) {
 }
 
 int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
-#define LANGOPT(Name, Bits, DefaultValue, Description)                         \
+#define LANGOPT(Name, Bits, DefaultValue, Compatibility, Description)          \
   llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Affecting" << " " << Description << "\n";
-#define COMPATIBLE_LANGOPT(Name, Bits, DefaultValue, Description)              \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Compatible" << " " << Description << "\n";
-#define COMPATIBLE_VALUE_LANGOPT(Name, Bits, DefaultValue, Description)        \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Compatible" << " " << Description << "\n";
-#define COMPATIBLE_ENUM_LANGOPT(Name, Type, Bits, DefaultValue, Description)   \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Compatible" << " " << Description << "\n";
-#define BENIGN_LANGOPT(Name, Bits, DefaultValue, Description)                  \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Benign" << " " << Description << "\n";
-#define BENIGN_VALUE_LANGOPT(Name, Bits, DefaultValue, Description)            \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Benign" << " " << Description << "\n";
-#define BENIGN_ENUM_LANGOPT(Name, Type, Bits, DefaultValue, Description)       \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << "Benign" << " " << Description << "\n";
+               << #Compatibility << " " << Description << "\n";
 #include "clang/Basic/LangOptions.def"
 
   llvm::InitializeAllTargetInfos();

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -852,11 +852,6 @@ getCompilationDatabase(int argc, char **argv, std::string &ErrorMessage) {
 }
 
 int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
-#define LANGOPT(Name, Bits, DefaultValue, Compatibility, Description)          \
-  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
-               << #Compatibility << " " << Description << "\n";
-#include "clang/Basic/LangOptions.def"
-
   llvm::InitializeAllTargetInfos();
   std::string ErrorMessage;
   std::unique_ptr<tooling::CompilationDatabase> Compilations =

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -852,6 +852,29 @@ getCompilationDatabase(int argc, char **argv, std::string &ErrorMessage) {
 }
 
 int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
+#define LANGOPT(Name, Bits, DefaultValue, Description)                         \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Affecting" << " " << Description << "\n";
+#define COMPATIBLE_LANGOPT(Name, Bits, DefaultValue, Description)              \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Compatible" << " " << Description << "\n";
+#define COMPATIBLE_VALUE_LANGOPT(Name, Bits, DefaultValue, Description)        \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Compatible" << " " << Description << "\n";
+#define COMPATIBLE_ENUM_LANGOPT(Name, Type, Bits, DefaultValue, Description)   \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Compatible" << " " << Description << "\n";
+#define BENIGN_LANGOPT(Name, Bits, DefaultValue, Description)                  \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Benign" << " " << Description << "\n";
+#define BENIGN_VALUE_LANGOPT(Name, Bits, DefaultValue, Description)            \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Benign" << " " << Description << "\n";
+#define BENIGN_ENUM_LANGOPT(Name, Type, Bits, DefaultValue, Description)       \
+  llvm::outs() << #Name << " " << Bits << " " << #DefaultValue << " "          \
+               << "Benign" << " " << Description << "\n";
+#include "clang/Basic/LangOptions.def"
+
   llvm::InitializeAllTargetInfos();
   std::string ErrorMessage;
   std::unique_ptr<tooling::CompilationDatabase> Compilations =


### PR DESCRIPTION
This removes the `{BENIGN,COMPATIBLE}{,_ENUM,_VALUE}_LANGOPT` X macros controlling `LangOptions`. These are permutations of the base `LANGOPT`, `ENUM_LANGOPT` and `VALUE_LANGOPT` X macros that also carry the information of their effect on AST (and therefore module compatibility). Their functionality is now implemented by passing `Benign`, `Compatible` or `NotCompatible` argument to the base X macros and using C++17 `if constexpr` in the clients to achieve the same codegen.

This PR solves this FIXME:
```
// FIXME: Clients should be able to more easily select whether they want
// different levels of compatibility versus how to handle different kinds
// of option.
```

The base X macros are preserved, since they are used in `LangOptions.h` to generate different kinds of field and function declarations for flags, values and enums, which can't be achieved with `if constexpr`.

The new syntax also forces developers to think about compatibility when adding new language option, hopefully reducing the number of new options that are affecting by default even though they are benign or compatible.

Note that the `BENIGN_` macros used to forward to their `COMPATIBLE_` counterparts. I don't think this ever kicked in, since there are no clients of the `.def` file that define `COMPATIBLE_` without also defining `BENIGN_`. However, this might be something downstream forks need to take care of by doing `if constexpr (CK::Compatibility == CK::Benign || CK::Compatibility == CK::Compatible)` in place of `#define COMPATIBLE_`.