### PR TITLE
[lldb-dap] Improving 'variables' hover requests.

### DIFF
--- a/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
+++ b/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
@@ -2,7 +2,6 @@
 Test lldb-dap disconnect request
 """
 
-
 import dap_server
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -71,7 +70,9 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         lldbutil.wait_for_file_on_target(self, sync_file_path)
 
         self.attach(pid=self.process.pid, disconnectAutomatically=False)
-        response = self.dap_server.request_evaluate("wait_for_attach = false;")
+        response = self.dap_server.request_evaluate(
+            "`expr -- wait_for_attach = false;", context="repl"
+        )
         self.assertTrue(response["success"])
 
         # verify we haven't produced the side effect file yet

--- a/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
+++ b/lldb/test/API/tools/lldb-dap/locations/TestDAP_locations.py
@@ -76,6 +76,6 @@ class TestDAP_locations(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(val_loc_func_ref["body"]["line"], 3)
 
         # `evaluate` responses for function pointers also have locations associated
-        eval_res = self.dap_server.request_evaluate("greet")
-        self.assertTrue(eval_res["success"])
+        eval_res = self.dap_server.request_evaluate("greet", context="repl")
+        self.assertTrue(eval_res["success"], f"evaluate failed: {eval_res}")
         self.assertIn("valueLocationReference", eval_res["body"].keys())

--- a/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
+++ b/lldb/test/API/tools/lldb-dap/memory/TestDAP_memory.py
@@ -92,7 +92,7 @@ class TestDAP_memory(lldbdap_testcase.DAPTestCaseBase):
         )
         self.continue_to_next_stop()
 
-        ptr_deref = self.dap_server.request_evaluate("*rawptr")["body"]
+        ptr_deref = self.dap_server.request_evaluate("*rawptr", context="repl")["body"]
         memref = ptr_deref["memoryReference"]
 
         # We can read the complete string

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -738,7 +738,7 @@ class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
         self.do_test_indexedVariables(enableSyntheticChildDebugging=True)
 
     @skipIfWindows
-    @skipIfAsan # FIXME this fails with a non-asan issue on green dragon.
+    @skipIfAsan  # FIXME this fails with a non-asan issue on green dragon.
     def test_registers(self):
         """
         Test that registers whose byte size is the size of a pointer on

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -205,10 +205,7 @@ void EvaluateRequestHandler::operator()(
     if (value.GetError().Success() && context == "repl")
       value = value.Persist();
 
-    // Only the repl should evaluate expressions, which can mutate application
-    // state. Other contexts are used for observing debuggee state only, not
-    // mutating state.
-    if (value.GetError().Fail() && context == "repl")
+    if (value.GetError().Fail() && context != "hover")
       value = frame.EvaluateExpression(expression.data());
 
     if (value.GetError().Fail()) {

--- a/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/EvaluateRequestHandler.cpp
@@ -181,7 +181,17 @@ void EvaluateRequestHandler::operator()(
         expression = dap.last_nonempty_var_expression;
       else
         dap.last_nonempty_var_expression = expression;
+    } else {
+      // If this isn't a REPL context, trim leading pointer/reference characters
+      // to ensure we return the actual value of the expression.
+      // This can come up if you hover over a pointer or reference declaration
+      // like 'MyType *foo;' or `void fn(std::string &arg)`, which results in
+      // the hover request sending '*foo' or `&arg`. When we're not in the REPL,
+      // we should trim these characters to get to the actual variable, which
+      // should have the proper type encoded by the compiler.
+      expression = llvm::StringRef(expression).ltrim("*&").str();
     }
+
     // Always try to get the answer from the local variables if possible. If
     // this fails, then if the context is not "hover", actually evaluate an
     // expression using the expression parser.


### PR DESCRIPTION
This partially fixes https://github.com/llvm/llvm-project/issues/146559.

When hovering over variables while debugging with lldb-dap we are receiving hover requests that include symbols.

For example, if you have:

```
MyClass *foo;
```

and hover over 'foo', the request will contain the expression `expression="*foo"` and we're evaluating the dereference, so you end up with different hover results vs the variables view.

A more complete solution would be to implement an
[EvaluatableExpressionProvider](https://code.visualstudio.com/api/references/vscode-api#EvaluatableExpressionProvider) in the VS Code extension.

For example, if you have a declaration without any whitespace like

```c
char*foo = "bar";
```

And try to hover over 'foo', the request will be `expression="char*foo"`, which won't evaluate correctly in lldb.