### PR TITLE
[LLDB] Fix Memory64 BaseRVA, move all non-stack memory to Mem64.

### DIFF
--- a/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
+++ b/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
@@ -63,6 +63,18 @@ Note that currently ELF Core files are not supported."
     Get an SBThreadCollection of all threads marked to be saved. This collection is not sorted according to insertion order."
 ) lldb::SBSaveCoreOptions::GetThreadsToSave;
 
+
+%feature("docstring", "
+    Get an SBMemoryRegionInfoList of all the Regions that LLDB will attempt to write into the Core. Note, reading from these
+    regions can fail, and it's guaraunteed every region will be present. If called without a valid process or style set an empty
+    collection will be returned."
+) lldb::SBSaveCoreOptions::GetMemoryRegionsToSave;
+
+%feature("docstring", "
+    Add a plugin specific flag to the objects option."
+) lldb::SBSaveCoreOptions::AddFlag;
+
+
 %feature("docstring", "
     Get the current total number of bytes the core is expected to have, excluding the overhead of the core file format.
     Requires both a Process and a Style to be specified. An error will be returned if the provided options would result in no data being saved."

--- a/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
+++ b/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
@@ -46,7 +46,7 @@ Note that currently ELF Core files are not supported."
 ) lldb::SBSaveCoreOptions::SetProcess;
 
 %feature("docstring", "
-    Get the process to save. If undefined, an invalid SBProcess will be returned."
+    Get the process to save. If a process is not defined, whether by calling clear or by not setting a process, an invalid process will be returned."
 ) lldb::SBSaveCoreOptions::GetProcess;
 
 %feature("docstring", "
@@ -69,7 +69,7 @@ Note that currently ELF Core files are not supported."
 
 %feature("docstring", "
     Get an SBMemoryRegionInfoList of all the Regions that LLDB will attempt to write into the Core. Note, reading from these
-    regions can fail, and it's guaraunteed every region will be present. If called without a valid process or style set an empty
+    regions can fail, and it's not guaraunteed every region will be present in the resulting core. If called without a valid process or style set an empty
     collection will be returned."
 ) lldb::SBSaveCoreOptions::GetMemoryRegionsToSave;
 

--- a/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
+++ b/lldb/bindings/interface/SBSaveCoreOptionsDocstrings.i
@@ -46,6 +46,10 @@ Note that currently ELF Core files are not supported."
 ) lldb::SBSaveCoreOptions::SetProcess;
 
 %feature("docstring", "
+    Get the process to save. If undefined, an invalid SBProcess will be returned."
+) lldb::SBSaveCoreOptions::GetProcess;
+
+%feature("docstring", "
     Add an SBThread to be saved, an error will be returned if an SBThread from a different process is specified. 
     The process is set either by the first SBThread added to the options container, or explicitly by the SetProcess call."
 ) lldb::SBSaveCoreOptions::AddThread;
@@ -63,17 +67,11 @@ Note that currently ELF Core files are not supported."
     Get an SBThreadCollection of all threads marked to be saved. This collection is not sorted according to insertion order."
 ) lldb::SBSaveCoreOptions::GetThreadsToSave;
 
-
 %feature("docstring", "
     Get an SBMemoryRegionInfoList of all the Regions that LLDB will attempt to write into the Core. Note, reading from these
     regions can fail, and it's guaraunteed every region will be present. If called without a valid process or style set an empty
     collection will be returned."
 ) lldb::SBSaveCoreOptions::GetMemoryRegionsToSave;
-
-%feature("docstring", "
-    Add a plugin specific flag to the objects option."
-) lldb::SBSaveCoreOptions::AddFlag;
-
 
 %feature("docstring", "
     Get the current total number of bytes the core is expected to have, excluding the overhead of the core file format.

--- a/lldb/include/lldb/API/SBMemoryRegionInfoList.h
+++ b/lldb/include/lldb/API/SBMemoryRegionInfoList.h
@@ -45,6 +45,7 @@ protected:
 
 private:
   friend class SBProcess;
+  friend class SBSaveCoreOptions;
 
   lldb_private::MemoryRegionInfos &ref();
 

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -140,14 +140,6 @@ public:
   ///   The expected size of the data contained in the core in bytes.
   uint64_t GetCurrentSizeInBytes(SBError &error);
 
-  /// Add a flag to be consumed by the specified plugin, null or empty flags
-  /// will be ignored.
-  ///
-  /// \note
-  ///   This API is currently only used for testing, with forcing Minidumps to
-  ///   to 64b memory list the reason this api was added
-  void AddFlag(const char *flag);
-
   /// Reset all options.
   void Clear();
 

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -140,7 +140,7 @@ public:
   ///   The expected size of the data contained in the core in bytes.
   uint64_t GetCurrentSizeInBytes(SBError &error);
 
-  /// Add a flag specific to a plugin provider, null or empty flags
+  /// Add a flag to be consumed by the specified plugin, null or empty flags
   /// will be ignored.
   ///
   /// \note

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -12,10 +12,10 @@
 #include "lldb/API/SBDefines.h"
 #include "lldb/API/SBError.h"
 #include "lldb/API/SBFileSpec.h"
+#include "lldb/API/SBMemoryRegionInfoList.h"
 #include "lldb/API/SBProcess.h"
 #include "lldb/API/SBThread.h"
 #include "lldb/API/SBThreadCollection.h"
-#include "lldb/API/SBMemoryRegionInfoList.h"
 
 namespace lldb {
 
@@ -123,7 +123,7 @@ public:
   /// Get an unsorted copy of all memory regions to save
   ///
   /// \returns
-  ///   An unsorted copy of all memory regions to save. If no process or style 
+  ///   An unsorted copy of all memory regions to save. If no process or style
   ///   is specified an empty collection will be returned.
   SBMemoryRegionInfoList GetMemoryRegionsToSave();
 
@@ -146,7 +146,7 @@ public:
   /// \note
   ///   This API is currently only used for testing, with forcing Minidumps to
   ///   to 64b memory list the reason this api was added
-  void AddFlag(const char* flag);
+  void AddFlag(const char *flag);
 
   /// Reset all options.
   void Clear();

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -79,6 +79,12 @@ public:
   ///   api, or implicitly from any function that requires a process.
   SBError SetProcess(lldb::SBProcess process);
 
+  /// Get the process to save, if the process is not set an invalid SBProcess will be returned.
+  ///
+  /// \return
+  ///   The set process, or an invalid SBProcess if no process is set.
+  SBProcess GetProcess();
+
   /// Add a thread to save in the core file.
   ///
   /// \param thread

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -15,6 +15,7 @@
 #include "lldb/API/SBProcess.h"
 #include "lldb/API/SBThread.h"
 #include "lldb/API/SBThreadCollection.h"
+#include "lldb/API/SBMemoryRegionInfoList.h"
 
 namespace lldb {
 
@@ -118,6 +119,13 @@ public:
   ///   An unsorted copy of all threads to save. If no process is specified
   ///   an empty collection will be returned.
   SBThreadCollection GetThreadsToSave() const;
+
+  /// Get an unsorted copy of all memory regions to save
+  ///
+  /// \returns
+  ///   An unsorted copy of all memory regions to save. If no process or style 
+  ///   is specified an empty collection will be returned.
+  SBMemoryRegionInfoList GetMemoryRegionsToSave();
 
   /// Get the current total number of bytes the core is expected to have
   /// excluding the overhead of the core file format. Requires a Process and

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -140,6 +140,14 @@ public:
   ///   The expected size of the data contained in the core in bytes.
   uint64_t GetCurrentSizeInBytes(SBError &error);
 
+  /// Add a flag specific to a plugin provider, null or empty flags
+  /// will be ignored.
+  ///
+  /// \note
+  ///   This API is currently only used for testing, with forcing Minidumps to
+  ///   to 64b memory list the reason this api was added
+  void AddFlag(const char* flag);
+
   /// Reset all options.
   void Clear();
 

--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -79,7 +79,8 @@ public:
   ///   api, or implicitly from any function that requires a process.
   SBError SetProcess(lldb::SBProcess process);
 
-  /// Get the process to save, if the process is not set an invalid SBProcess will be returned.
+  /// Get the process to save, if the process is not set an invalid SBProcess
+  /// will be returned.
   ///
   /// \return
   ///   The set process, or an invalid SBProcess if no process is set.

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -261,8 +261,7 @@ public:
   static ObjectFileCreateMemoryInstance
   GetObjectFileCreateMemoryCallbackForPluginName(llvm::StringRef name);
 
-  static Status SaveCore(const lldb::ProcessSP &process_sp,
-                         lldb_private::SaveCoreOptions &core_options);
+  static Status SaveCore(lldb_private::SaveCoreOptions &core_options);
 
   static std::vector<llvm::StringRef> GetSaveCorePluginNames();
 

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -44,7 +44,7 @@ public:
   bool ShouldThreadBeSaved(lldb::tid_t tid) const;
   bool HasSpecifiedThreads() const;
 
-  Status EnsureValidConfiguration(lldb::ProcessSP process_sp) const;
+  Status EnsureValidConfiguration() const;
   const MemoryRanges &GetCoreFileMemoryRanges() const;
 
   void AddMemoryRegionToSave(const lldb_private::MemoryRegionInfo &region);

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -37,6 +37,7 @@ public:
   const std::optional<lldb_private::FileSpec> GetOutputFile() const;
 
   Status SetProcess(lldb::ProcessSP process_sp);
+  lldb::ProcessSP GetProcess() { return m_process_sp; }
 
   Status AddThread(lldb::ThreadSP thread_sp);
   bool RemoveThread(lldb::ThreadSP thread_sp);

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -52,11 +52,7 @@ public:
   lldb_private::ThreadCollection::collection GetThreadsToSave() const;
 
   llvm::Expected<uint64_t> GetCurrentSizeInBytes();
-
-  void AddFlag(const char *flag);
-
-  bool ContainsFlag(const char *flag) const;
-
+  
   void Clear();
 
 private:
@@ -65,7 +61,6 @@ private:
   std::optional<std::string> m_plugin_name;
   std::optional<lldb_private::FileSpec> m_file;
   std::optional<lldb::SaveCoreStyle> m_style;
-  std::optional<std::unordered_set<std::string>> m_flags;
   lldb::ProcessSP m_process_sp;
   std::unordered_set<lldb::tid_t> m_threads_to_save;
   MemoryRanges m_regions_to_save;

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -24,7 +24,7 @@ namespace lldb_private {
 
 class SaveCoreOptions {
 public:
-  SaveCoreOptions(){};
+  SaveCoreOptions() = default;
   ~SaveCoreOptions() = default;
 
   lldb_private::Status SetPluginName(const char *name);
@@ -53,6 +53,10 @@ public:
 
   llvm::Expected<uint64_t> GetCurrentSizeInBytes();
 
+  void AddFlag(const char *flag);
+
+  bool ContainsFlag(const char *flag) const;
+
   void Clear();
 
 private:
@@ -61,6 +65,7 @@ private:
   std::optional<std::string> m_plugin_name;
   std::optional<lldb_private::FileSpec> m_file;
   std::optional<lldb::SaveCoreStyle> m_style;
+  std::optional<std::unordered_set<std::string>> m_flags;
   lldb::ProcessSP m_process_sp;
   std::unordered_set<lldb::tid_t> m_threads_to_save;
   MemoryRanges m_regions_to_save;

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -53,7 +53,7 @@ public:
   lldb_private::ThreadCollection::collection GetThreadsToSave() const;
 
   llvm::Expected<uint64_t> GetCurrentSizeInBytes();
-  
+
   void Clear();
 
 private:

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -9,8 +9,8 @@
 #ifndef LLDB_SOURCE_PLUGINS_OBJECTFILE_SaveCoreOPTIONS_H
 #define LLDB_SOURCE_PLUGINS_OBJECTFILE_SaveCoreOPTIONS_H
 
-#include "lldb/Target/ThreadCollection.h"
 #include "lldb/Target/CoreFileMemoryRanges.h"
+#include "lldb/Target/ThreadCollection.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/RangeMap.h"
 

--- a/lldb/include/lldb/Symbol/SaveCoreOptions.h
+++ b/lldb/include/lldb/Symbol/SaveCoreOptions.h
@@ -10,6 +10,7 @@
 #define LLDB_SOURCE_PLUGINS_OBJECTFILE_SaveCoreOPTIONS_H
 
 #include "lldb/Target/ThreadCollection.h"
+#include "lldb/Target/CoreFileMemoryRanges.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/RangeMap.h"
 
@@ -47,6 +48,7 @@ public:
 
   void AddMemoryRegionToSave(const lldb_private::MemoryRegionInfo &region);
 
+  llvm::Expected<lldb_private::CoreFileMemoryRanges> GetMemoryRegionsToSave();
   lldb_private::ThreadCollection::collection GetThreadsToSave() const;
 
   llvm::Expected<uint64_t> GetCurrentSizeInBytes();

--- a/lldb/source/API/SBProcess.cpp
+++ b/lldb/source/API/SBProcess.cpp
@@ -1263,6 +1263,15 @@ lldb::SBError SBProcess::SaveCore(SBSaveCoreOptions &options) {
     return error;
   }
 
+  if (!options.GetProcess())
+    options.SetProcess(process_sp);
+
+  if (options.GetProcess().GetSP() != process_sp) {
+    error = Status::FromErrorString(
+        "Save Core Options configured for a different process.");
+    return error;
+  }
+
   std::lock_guard<std::recursive_mutex> guard(
       process_sp->GetTarget().GetAPIMutex());
 
@@ -1271,7 +1280,7 @@ lldb::SBError SBProcess::SaveCore(SBSaveCoreOptions &options) {
     return error;
   }
 
-  error.ref() = PluginManager::SaveCore(process_sp, options.ref());
+  error.ref() = PluginManager::SaveCore(options.ref());
 
   return error;
 }

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -128,6 +128,25 @@ uint64_t SBSaveCoreOptions::GetCurrentSizeInBytes(SBError &error) {
   return *expected_bytes;
 }
 
+lldb::SBMemoryRegionInfoList SBSaveCoreOptions::GetMemoryRegionsToSave() {
+  LLDB_INSTRUMENT_VA(this);
+  llvm::Expected<lldb_private::CoreFileMemoryRanges> memory_ranges = m_opaque_up->GetMemoryRegionsToSave();
+  if (!memory_ranges) {
+    llvm::consumeError(memory_ranges.takeError());
+    return SBMemoryRegionInfoList();
+  }
+
+  
+  SBMemoryRegionInfoList m_memory_region_infos;
+  for (const auto &range : *memory_ranges) {
+    SBMemoryRegionInfo region_info(nullptr, 
+      range.GetRangeBase(), range.GetRangeEnd(), range.data.lldb_permissions, /*mapped=*/true);
+    m_memory_region_infos.Append(region_info);
+  }
+
+  return m_memory_region_infos;
+}
+
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {
   return *m_opaque_up;
 }

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -130,17 +130,18 @@ uint64_t SBSaveCoreOptions::GetCurrentSizeInBytes(SBError &error) {
 
 lldb::SBMemoryRegionInfoList SBSaveCoreOptions::GetMemoryRegionsToSave() {
   LLDB_INSTRUMENT_VA(this);
-  llvm::Expected<lldb_private::CoreFileMemoryRanges> memory_ranges = m_opaque_up->GetMemoryRegionsToSave();
+  llvm::Expected<lldb_private::CoreFileMemoryRanges> memory_ranges =
+      m_opaque_up->GetMemoryRegionsToSave();
   if (!memory_ranges) {
     llvm::consumeError(memory_ranges.takeError());
     return SBMemoryRegionInfoList();
   }
 
-  
   SBMemoryRegionInfoList m_memory_region_infos;
   for (const auto &range : *memory_ranges) {
-    SBMemoryRegionInfo region_info(nullptr, 
-      range.GetRangeBase(), range.GetRangeEnd(), range.data.lldb_permissions, /*mapped=*/true);
+    SBMemoryRegionInfo region_info(
+        nullptr, range.GetRangeBase(), range.GetRangeEnd(),
+        range.data.lldb_permissions, /*mapped=*/true);
     m_memory_region_infos.Append(region_info);
   }
 

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -142,15 +142,15 @@ lldb::SBMemoryRegionInfoList SBSaveCoreOptions::GetMemoryRegionsToSave() {
     return SBMemoryRegionInfoList();
   }
 
-  SBMemoryRegionInfoList m_memory_region_infos;
+  SBMemoryRegionInfoList memory_region_infos;
   for (const auto &range : *memory_ranges) {
     SBMemoryRegionInfo region_info(
         nullptr, range.GetRangeBase(), range.GetRangeEnd(),
         range.data.lldb_permissions, /*mapped=*/true);
-    m_memory_region_infos.Append(region_info);
+    memory_region_infos.Append(region_info);
   }
 
-  return m_memory_region_infos;
+  return memory_region_infos;
 }
 
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -147,6 +147,12 @@ lldb::SBMemoryRegionInfoList SBSaveCoreOptions::GetMemoryRegionsToSave() {
   return m_memory_region_infos;
 }
 
+void SBSaveCoreOptions::AddFlag(const char *flag) {
+  LLDB_INSTRUMENT_VA(this, flag);
+
+  m_opaque_up->AddFlag(flag);
+}
+
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {
   return *m_opaque_up;
 }

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -148,12 +148,6 @@ lldb::SBMemoryRegionInfoList SBSaveCoreOptions::GetMemoryRegionsToSave() {
   return m_memory_region_infos;
 }
 
-void SBSaveCoreOptions::AddFlag(const char *flag) {
-  LLDB_INSTRUMENT_VA(this, flag);
-
-  m_opaque_up->AddFlag(flag);
-}
-
 lldb_private::SaveCoreOptions &SBSaveCoreOptions::ref() const {
   return *m_opaque_up;
 }

--- a/lldb/source/API/SBSaveCoreOptions.cpp
+++ b/lldb/source/API/SBSaveCoreOptions.cpp
@@ -81,6 +81,11 @@ SBError SBSaveCoreOptions::SetProcess(lldb::SBProcess process) {
   return m_opaque_up->SetProcess(process.GetSP());
 }
 
+SBProcess SBSaveCoreOptions::GetProcess() {
+  LLDB_INSTRUMENT_VA(this);
+  return SBProcess(m_opaque_up->GetProcess());
+}
+
 SBError SBSaveCoreOptions::AddThread(lldb::SBThread thread) {
   LLDB_INSTRUMENT_VA(this, thread);
   return m_opaque_up->AddThread(thread.GetSP());

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -1354,7 +1354,8 @@ protected:
         FileSystem::Instance().Resolve(output_file);
         auto &core_dump_options = m_options.m_core_dump_options;
         core_dump_options.SetOutputFile(output_file);
-        Status error = PluginManager::SaveCore(process_sp, core_dump_options);
+        core_dump_options.SetProcess(process_sp);
+        Status error = PluginManager::SaveCore(core_dump_options);
         if (error.Success()) {
           if (core_dump_options.GetStyle() ==
                   SaveCoreStyle::eSaveCoreDirtyOnly ||

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -965,13 +965,11 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
     return error;
   }
 
-  // Set the process sp if not already set.
-  ProcessSP options_sp = options.GetProcess();
-  if (!options_sp)
+  if (!options.GetProcess())
     options.SetProcess(process_sp);
 
   // Make sure the process sp is the same as the one we are using.
-  if (options_sp && options_sp != process_sp) {
+  if (options.GetProcess() != process_sp) {
     error = Status::FromErrorString(
         "Save Core Options configured for a different process.");
     return error;

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -972,7 +972,8 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
 
   // Make sure the process sp is the same as the one we are using.
   if (options_sp != process_sp) {
-    error = Status::FromErrorString("Save Core Options configured for a different process.");
+    error = Status::FromErrorString(
+        "Save Core Options configured for a different process.");
     return error;
   }
 

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -952,37 +952,26 @@ PluginManager::GetObjectFileCreateMemoryCallbackForPluginName(
   return nullptr;
 }
 
-Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
-                               lldb_private::SaveCoreOptions &options) {
+Status PluginManager::SaveCore(lldb_private::SaveCoreOptions &options) {
   Status error;
   if (!options.GetOutputFile()) {
     error = Status::FromErrorString("No output file specified");
     return error;
   }
 
-  if (!process_sp) {
+  if (!options.GetProcess()) {
     error = Status::FromErrorString("Invalid process");
     return error;
   }
 
-  if (!options.GetProcess())
-    options.SetProcess(process_sp);
-
-  // Make sure the process sp is the same as the one we are using.
-  if (options.GetProcess() != process_sp) {
-    error = Status::FromErrorString(
-        "Save Core Options configured for a different process.");
-    return error;
-  }
-
-  error = options.EnsureValidConfiguration(process_sp);
+  error = options.EnsureValidConfiguration();
   if (error.Fail())
     return error;
 
   if (!options.GetPluginName().has_value()) {
     // Try saving core directly from the process plugin first.
     llvm::Expected<bool> ret =
-        process_sp->SaveCore(options.GetOutputFile()->GetPath());
+        options.GetProcess()->SaveCore(options.GetOutputFile()->GetPath());
     if (!ret)
       return Status::FromError(ret.takeError());
     if (ret.get())
@@ -994,7 +983,10 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
   auto instances = GetObjectFileInstances().GetSnapshot();
   for (auto &instance : instances) {
     if (plugin_name.empty() || instance.name == plugin_name) {
-      if (instance.save_core && instance.save_core(process_sp, options, error))
+      // TODO: Refactor the instance.save_core() to not require a process and
+      // get it from options instead.
+      if (instance.save_core &&
+          instance.save_core(options.GetProcess(), options, error))
         return error;
     }
   }

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -965,6 +965,17 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
     return error;
   }
 
+  // Set the process sp if not already set.
+  ProcessSP options_sp = options.GetProcess();
+  if (!options_sp)
+    options.SetProcess(process_sp);
+
+  // Make sure the process sp is the same as the one we are using.
+  if (options_sp != process_sp) {
+    error = Status::FromErrorString("Save Core Options configured for a different process.");
+    return error;
+  }
+
   error = options.EnsureValidConfiguration(process_sp);
   if (error.Fail())
     return error;

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -971,7 +971,7 @@ Status PluginManager::SaveCore(const lldb::ProcessSP &process_sp,
     options.SetProcess(process_sp);
 
   // Make sure the process sp is the same as the one we are using.
-  if (options_sp != process_sp) {
+  if (options_sp && options_sp != process_sp) {
     error = Status::FromErrorString(
         "Save Core Options configured for a different process.");
     return error;

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -834,7 +834,7 @@ Status MinidumpFileBuilder::AddMemoryList() {
   // Note this is here for testing. In the past there has been many occasions that the 64b
   // code has regressed because it's wasteful and expensive to write a 4.2gb+ on every CI run
   // to get around this and to exercise this codepath we define a flag in the options object.
-  bool force_64b_for_non_threads = m_save_core_options.ContainsFlag(&FORCE_64B_FLAG);
+  bool force_64b_for_non_threads = m_save_core_options.ContainsFlag(FORCE_64B_FLAG);
 
   // We first save the thread stacks to ensure they fit in the first UINT32_MAX
   // bytes of the core file. Thread structures in minidump files can only use
@@ -895,7 +895,7 @@ Status MinidumpFileBuilder::AddMemoryList() {
     const addr_t range_size = core_range.range.size();
     // We don't need to check for stacks here because we already removed them
     // from all_core_memory_ranges.
-    if (total_size + range_size < UINT32_MAX) {
+    if (!force_64b_for_non_threads && total_size + range_size < UINT32_MAX) {
       ranges_32.push_back(core_range);
       total_size += range_size;
     } else {

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -836,12 +836,11 @@ Status MinidumpFileBuilder::AddMemoryList() {
   // 32 bit memory descriptiors, so we emit them first to ensure the memory is
   // in accessible with a 32 bit offset.
   std::vector<CoreFileMemoryRange> ranges_32;
-  CoreFileMemoryRanges all_core_memory_ranges;
-  error = m_process_sp->CalculateCoreFileSaveRanges(m_save_core_options,
-                                                    all_core_memory_ranges);
+  llvm::Expected<CoreFileMemoryRanges> all_core_memory_ranges_maybe = m_save_core_options.GetMemoryRegionsToSave();
+  if (!all_core_memory_ranges_maybe)
+    return Status::FromError(all_core_memory_ranges_maybe.takeError());
 
-  if (error.Fail())
-    return error;
+  const CoreFileMemoryRanges &all_core_memory_ranges = *all_core_memory_ranges_maybe;
 
   lldb_private::Progress progress("Saving Minidump File", "",
                                   all_core_memory_ranges.GetSize());

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -831,10 +831,12 @@ Status MinidumpFileBuilder::AddLinuxFileStreams() {
 Status MinidumpFileBuilder::AddMemoryList() {
   Status error;
 
-  // Note this is here for testing. In the past there has been many occasions that the 64b
-  // code has regressed because it's wasteful and expensive to write a 4.2gb+ on every CI run
-  // to get around this and to exercise this codepath we define a flag in the options object.
-  bool force_64b_for_non_threads = m_save_core_options.ContainsFlag(FORCE_64B_FLAG);
+  // Note this is here for testing. In the past there has been many occasions
+  // that the 64b code has regressed because it's wasteful and expensive to
+  // write a 4.2gb+ on every CI run to get around this and to exercise this
+  // codepath we define a flag in the options object.
+  bool force_64b_for_non_threads =
+      m_save_core_options.ContainsFlag(FORCE_64B_FLAG);
 
   // We first save the thread stacks to ensure they fit in the first UINT32_MAX
   // bytes of the core file. Thread structures in minidump files can only use
@@ -1004,7 +1006,10 @@ Status MinidumpFileBuilder::ReadWriteMemoryInChunks(
     }
 
     if (current_addr != addr + total_bytes_read) {
-      LLDB_LOGF(log, "Current addr is at expected address, 0x%" PRIx64 ", expected at 0x%" PRIx64, current_addr, addr + total_bytes_read);
+      LLDB_LOGF(log,
+                "Current addr is at expected address, 0x%" PRIx64
+                ", expected at 0x%" PRIx64,
+                current_addr, addr + total_bytes_read);
     }
 
     // Write to the minidump file with the chunk potentially flushing to
@@ -1019,8 +1024,7 @@ Status MinidumpFileBuilder::ReadWriteMemoryInChunks(
     total_bytes_read += bytes_read;
     // If we have a partial read, report it, but only if the partial read
     // didn't finish reading the entire region.
-    if (bytes_read != data_buffer.GetByteSize() &&
-        total_bytes_read != size) {
+    if (bytes_read != data_buffer.GetByteSize() && total_bytes_read != size) {
       LLDB_LOGF(log,
                 "Memory region at: 0x%" PRIx64 " partial read 0x%" PRIx64
                 " bytes out of 0x%" PRIx64 " bytes.",

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -831,6 +831,11 @@ Status MinidumpFileBuilder::AddLinuxFileStreams() {
 Status MinidumpFileBuilder::AddMemoryList() {
   Status error;
 
+  // Note this is here for testing. In the past there has been many occasions that the 64b
+  // code has regressed because it's wasteful and expensive to write a 4.2gb+ on every CI run
+  // to get around this and to exercise this codepath we define a flag in the options object.
+  bool force_64b_for_non_threads = m_save_core_options.ContainsFlag(&FORCE_64B_FLAG);
+
   // We first save the thread stacks to ensure they fit in the first UINT32_MAX
   // bytes of the core file. Thread structures in minidump files can only use
   // 32 bit memory descriptiors, so we emit them first to ensure the memory is

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -836,11 +836,13 @@ Status MinidumpFileBuilder::AddMemoryList() {
   // 32 bit memory descriptiors, so we emit them first to ensure the memory is
   // in accessible with a 32 bit offset.
   std::vector<CoreFileMemoryRange> ranges_32;
-  llvm::Expected<CoreFileMemoryRanges> all_core_memory_ranges_maybe = m_save_core_options.GetMemoryRegionsToSave();
+  llvm::Expected<CoreFileMemoryRanges> all_core_memory_ranges_maybe =
+      m_save_core_options.GetMemoryRegionsToSave();
   if (!all_core_memory_ranges_maybe)
     return Status::FromError(all_core_memory_ranges_maybe.takeError());
 
-  const CoreFileMemoryRanges &all_core_memory_ranges = *all_core_memory_ranges_maybe;
+  const CoreFileMemoryRanges &all_core_memory_ranges =
+      *all_core_memory_ranges_maybe;
 
   lldb_private::Progress progress("Saving Minidump File", "",
                                   all_core_memory_ranges.GetSize());
@@ -878,8 +880,8 @@ Status MinidumpFileBuilder::AddMemoryList() {
     return error;
   }
 
-  // Save only the thread stacks to the 32b memory list. Everything else will get put in 
-  // Memory64, this simplifies tracking 
+  // Save only the thread stacks to the 32b memory list. Everything else will
+  // get put in Memory64, this simplifies tracking
   error = AddMemoryList_32(ranges_32, progress);
   if (error.Fail())
     return error;

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -1109,7 +1109,7 @@ MinidumpFileBuilder::AddMemoryList_64(std::vector<CoreFileMemoryRange> &ranges,
     return error;
 
   error = AddDirectory(StreamType::Memory64List,
-                       (sizeof(llvm::support::ulittle64_t) * 2) +
+                       (sizeof(llvm::minidump::Memory64ListHeader)) +
                            ranges.size() *
                                sizeof(llvm::minidump::MemoryDescriptor_64));
   if (error.Fail())

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -1138,7 +1138,7 @@ MinidumpFileBuilder::AddMemoryList_64(std::vector<CoreFileMemoryRange> &ranges,
   offset_t starting_offset =
       GetCurrentDataEndOffset() + sizeof(llvm::minidump::Memory64ListHeader);
   // The base_rva needs to start after the directories, which is right after
-  // this 8 byte variable.
+  // the descriptors + the size of the header.
   offset_t base_rva =
       starting_offset +
       (ranges.size() * sizeof(llvm::minidump::MemoryDescriptor_64));

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -984,9 +984,17 @@ Status MinidumpFileBuilder::ReadWriteMemoryInChunks(
 
     if (current_addr != addr + total_bytes_read) {
       LLDB_LOGF(log,
-                "Current addr is at expected address, 0x%" PRIx64
+                "Current addr is at unexpected address, 0x%" PRIx64
                 ", expected at 0x%" PRIx64,
                 current_addr, addr + total_bytes_read);
+
+      // Something went wrong and the address is not where it should be
+      // we'll error out of this Minidump generation.
+      addDataError = Status::FromErrorStringWithFormat(
+          "Unexpected address encounterd when reading memory in chunks "
+          "0x" PRIx64 " expected 0x" PRIx64,
+          current_addr, addr + total_bytes_read);
+      return lldb_private::IterationAction::Stop;
     }
 
     // Write to the minidump file with the chunk potentially flushing to

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.cpp
@@ -992,7 +992,7 @@ Status MinidumpFileBuilder::ReadWriteMemoryInChunks(
       // we'll error out of this Minidump generation.
       addDataError = Status::FromErrorStringWithFormat(
           "Unexpected address encounterd when reading memory in chunks "
-          "0x" PRIx64 " expected 0x" PRIx64,
+          "0x%" PRIx64 " expected 0x%" PRIx64,
           current_addr, addr + total_bytes_read);
       return lldb_private::IterationAction::Stop;
     }

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -176,7 +176,7 @@ private:
   static constexpr size_t HEADER_SIZE = sizeof(llvm::minidump::Header);
   static constexpr size_t DIRECTORY_SIZE = sizeof(llvm::minidump::Directory);
 
-  static const char[10] FORCE_64B_FLAG = "force_64b";
+  static constexpr const char FORCE_64B_FLAG[] = "force_64b";
 
   // More that one place can mention the register thread context locations,
   // so when we emit the thread contents, remember where it is so we don't have

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -176,8 +176,6 @@ private:
   static constexpr size_t HEADER_SIZE = sizeof(llvm::minidump::Header);
   static constexpr size_t DIRECTORY_SIZE = sizeof(llvm::minidump::Directory);
 
-  static constexpr const char FORCE_64B_FLAG[] = "force_64b";
-
   // More that one place can mention the register thread context locations,
   // so when we emit the thread contents, remember where it is so we don't have
   // to duplicate it in the exception data.

--- a/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/MinidumpFileBuilder.h
@@ -176,6 +176,8 @@ private:
   static constexpr size_t HEADER_SIZE = sizeof(llvm::minidump::Header);
   static constexpr size_t DIRECTORY_SIZE = sizeof(llvm::minidump::Directory);
 
+  static const char[10] FORCE_64B_FLAG = "force_64b";
+
   // More that one place can mention the register thread context locations,
   // so when we emit the thread contents, remember where it is so we don't have
   // to duplicate it in the exception data.

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -214,17 +214,3 @@ void SaveCoreOptions::Clear() {
   m_process_sp.reset();
   m_regions_to_save.Clear();
 }
-
-void SaveCoreOptions::AddFlag(const char *flag) {
-  if (!flag || !flag[0])
-    return;
-
-  if (!m_flags)
-    m_flags = std::unordered_set<std::string>();
-
-  m_flags->emplace(std::string(flag));
-}
-
-bool SaveCoreOptions::ContainsFlag(const char *flag) const {
-  return m_flags && m_flags->find(flag) != m_flags->end();
-}

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -194,7 +194,7 @@ llvm::Expected<uint64_t> SaveCoreOptions::GetCurrentSizeInBytes() {
   const lldb_private::CoreFileMemoryRanges &core_file_ranges =
       *core_file_ranges_maybe;
   uint64_t total_in_bytes = 0;
-  for (auto &core_range : core_file_ranges)
+  for (const auto &core_range : core_file_ranges)
     total_in_bytes += core_range.data.range.size();
 
   return total_in_bytes;

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -124,16 +124,14 @@ void SaveCoreOptions::AddMemoryRegionToSave(
 const MemoryRanges &SaveCoreOptions::GetCoreFileMemoryRanges() const {
   return m_regions_to_save;
 }
-Status
-SaveCoreOptions::EnsureValidConfiguration(lldb::ProcessSP process_sp) const {
+Status SaveCoreOptions::EnsureValidConfiguration() const {
   Status error;
   std::string error_str;
   if (!m_threads_to_save.empty() && GetStyle() == lldb::eSaveCoreFull)
     error_str += "Cannot save a full core with a subset of threads\n";
 
-  if (m_process_sp && m_process_sp != process_sp)
-    error_str += "Cannot save core for process using supplied core options. "
-                 "Options were constructed targeting a different process. \n";
+  if (!m_process_sp)
+    error_str += "Need to assign a valid process\n";
 
   if (!error_str.empty())
     error = Status(error_str);
@@ -161,7 +159,7 @@ SaveCoreOptions::GetMemoryRegionsToSave() {
   if (!m_process_sp)
     return Status::FromErrorString("Requires a process to be set.").takeError();
 
-  error = EnsureValidConfiguration(m_process_sp);
+  error = EnsureValidConfiguration();
   if (error.Fail())
     return error.takeError();
 
@@ -178,7 +176,7 @@ llvm::Expected<uint64_t> SaveCoreOptions::GetCurrentSizeInBytes() {
   if (!m_process_sp)
     return Status::FromErrorString("Requires a process to be set.").takeError();
 
-  error = EnsureValidConfiguration(m_process_sp);
+  error = EnsureValidConfiguration();
   if (error.Fail())
     return error.takeError();
 

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -211,3 +211,17 @@ void SaveCoreOptions::Clear() {
   m_process_sp.reset();
   m_regions_to_save.Clear();
 }
+
+void SaveCoreOptions::AddFlag(const char *flag) {
+  if (!flag || !flag[0])
+    return;
+
+  if (!m_flags)
+    m_flags = std::unordered_set<std::string>();
+
+  m_flags->emplace(std::string(flag));
+}
+
+bool SaveCoreOptions::ContainsFlag(const char *flag) const {
+  return m_flags && m_flags->find(flag) != m_flags->end();
+}

--- a/lldb/source/Symbol/SaveCoreOptions.cpp
+++ b/lldb/source/Symbol/SaveCoreOptions.cpp
@@ -155,7 +155,8 @@ SaveCoreOptions::GetThreadsToSave() const {
   return thread_collection;
 }
 
-llvm::Expected<lldb_private::CoreFileMemoryRanges> SaveCoreOptions::GetMemoryRegionsToSave() {
+llvm::Expected<lldb_private::CoreFileMemoryRanges>
+SaveCoreOptions::GetMemoryRegionsToSave() {
   Status error;
   if (!m_process_sp)
     return Status::FromErrorString("Requires a process to be set.").takeError();
@@ -186,10 +187,12 @@ llvm::Expected<uint64_t> SaveCoreOptions::GetCurrentSizeInBytes() {
   if (error.Fail())
     return error.takeError();
 
-  llvm::Expected<lldb_private::CoreFileMemoryRanges> core_file_ranges_maybe = GetMemoryRegionsToSave();
+  llvm::Expected<lldb_private::CoreFileMemoryRanges> core_file_ranges_maybe =
+      GetMemoryRegionsToSave();
   if (!core_file_ranges_maybe)
     return core_file_ranges_maybe.takeError();
-  const lldb_private::CoreFileMemoryRanges &core_file_ranges = *core_file_ranges_maybe;
+  const lldb_private::CoreFileMemoryRanges &core_file_ranges =
+      *core_file_ranges_maybe;
   uint64_t total_in_bytes = 0;
   for (auto &core_range : core_file_ranges)
     total_in_bytes += core_range.data.range.size();

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -1,0 +1,84 @@
+"""
+Test saving a minidumps with the force 64b flag, and evaluate that every
+saved memory region is byte-wise 1:1 with the live process.
+"""
+
+import os
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+# Constant from MinidumpFileBuilder.h, this forces 64b for non threads
+FORCE_64B = "force_64b"
+
+class ProcessSaveCoreMinidump64bTestCase(TestBase):
+
+    def verify_minidump(
+        self,
+        core_proc,
+        live_proc,
+        options,
+    ):
+        """Verify that the minidump is the same byte for byte as the live process."""
+        # Get the memory regions we saved off in this core, we can't compare to the core
+        # because we pull from /proc/pid/maps, so even ranges that don't get mapped in will show up
+        # as ranges in the minidump.
+        #
+        # Instead, we have an API that returns to us the number of regions we planned to save from the live process
+        # and we compare those
+        memory_regions_to_compare = options.GetMemoryRegionsToSave()
+
+        for region in memory_regions_to_compare:
+            start_addr = region.GetRegionBase()
+            end_addr = region.GetRegionEnd()
+            actual_process_read_error = lldb.SBError()
+            actual = live_proc.ReadMemory(start_addr, end_addr - start_addr, actual_process_read_error)
+            expected_process_read_error = lldb.SBError()
+            expected = core_proc.ReadMemory(start_addr, end_addr - start_addr, expected_process_read_error)
+
+            # Both processes could fail to read a given memory region, so if they both pass
+            # compare, then we'll fail them if the core differs from the live process.
+            if (actual_process_read_error.Success() and expected_process_read_error.Success()):
+                self.assertEqual(actual, expected, "Bytes differ between live process and core")
+
+            # Now we check if the error is the same, error isn't abnormal but they should fail for the same reason
+            self.assertTrue(
+                (actual_process_read_error.Success() and expected_process_read_error.Success()) or
+                (actual_process_read_error.Fail() and expected_process_read_error.Fail())
+            )
+
+    @skipUnlessArch("x86_64")
+    @skipUnlessPlatform(["linux"])
+    def test_minidump_save_style_full(self):
+        """Test that a full minidump is the same byte for byte."""
+
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        minidump_path = self.getBuildArtifact("minidump_full_force64b.dmp")
+
+        try:
+            target = self.dbg.CreateTarget(exe)
+            live_process = target.LaunchSimple(
+                None, None, self.get_process_working_directory()
+            )
+            self.assertState(live_process.GetState(), lldb.eStateStopped)
+            options = lldb.SBSaveCoreOptions()
+
+            options.SetOutputFile(lldb.SBFileSpec(minidump_path))
+            options.SetStyle(lldb.eSaveCoreFull)
+            options.SetPluginName("minidump")
+            options.SetProcess(live_process)
+            options.AddFlag(FORCE_64B)
+
+            error = live_process.SaveCore(options)
+            self.assertTrue(error.Success(), error.GetCString())
+
+            target = self.dbg.CreateTarget(None)
+            core_proc = target.LoadCore(minidump_path)
+
+            self.verify_minidump(core_proc, live_process, options)
+        finally:
+            self.assertTrue(self.dbg.DeleteTarget(target))
+            if os.path.isfile(minidump_path):
+                os.unlink(minidump_path)

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -60,15 +60,10 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
                     )
 
                 # Now we check if the error is the same, error isn't abnormal but they should fail for the same reason
+                # Success will be false if they both fail
                 self.assertTrue(
-                    (
-                        actual_process_read_error.Success()
-                        and expected_process_read_error.Success()
-                    )
-                    or (
-                        actual_process_read_error.Fail()
-                        and expected_process_read_error.Fail()
-                    ),
+                    actual_process_read_error.Success()
+                    == expected_process_read_error.Success(),
                     f"Address range {hex(start_addr)} - {hex(end_addr)} failed to read from live process and core for different reasons",
                 )
         finally:

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -9,9 +9,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-# Constant from MinidumpFileBuilder.h, this forces 64b for non threads
-FORCE_64B = "force_64b"
-
 
 class ProcessSaveCoreMinidump64bTestCase(TestBase):
     def verify_minidump(
@@ -51,6 +48,7 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
                     actual, expected, "Bytes differ between live process and core"
                 )
 
+
             # Now we check if the error is the same, error isn't abnormal but they should fail for the same reason
             self.assertTrue(
                 (
@@ -60,7 +58,8 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
                 or (
                     actual_process_read_error.Fail()
                     and expected_process_read_error.Fail()
-                )
+                ),
+                f"Address range {hex(start_addr)} - {hex(end_addr)} failed to read from live process and core for different reasons",
             )
 
     @skipUnlessArch("x86_64")
@@ -84,7 +83,6 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
             options.SetStyle(lldb.eSaveCoreFull)
             options.SetPluginName("minidump")
             options.SetProcess(live_process)
-            options.AddFlag(FORCE_64B)
 
             error = live_process.SaveCore(options)
             self.assertTrue(error.Success(), error.GetCString())
@@ -119,7 +117,6 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
             options.SetStyle(lldb.eSaveCoreDirtyOnly)
             options.SetPluginName("minidump")
             options.SetProcess(live_process)
-            options.AddFlag(FORCE_64B)
 
             error = live_process.SaveCore(options)
             self.assertTrue(error.Success(), error.GetCString())

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 # Constant from MinidumpFileBuilder.h, this forces 64b for non threads
 FORCE_64B = "force_64b"
 
+
 class ProcessSaveCoreMinidump64bTestCase(TestBase):
 
     def verify_minidump(
@@ -33,19 +34,34 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
             start_addr = region.GetRegionBase()
             end_addr = region.GetRegionEnd()
             actual_process_read_error = lldb.SBError()
-            actual = live_proc.ReadMemory(start_addr, end_addr - start_addr, actual_process_read_error)
+            actual = live_proc.ReadMemory(
+                start_addr, end_addr - start_addr, actual_process_read_error
+            )
             expected_process_read_error = lldb.SBError()
-            expected = core_proc.ReadMemory(start_addr, end_addr - start_addr, expected_process_read_error)
+            expected = core_proc.ReadMemory(
+                start_addr, end_addr - start_addr, expected_process_read_error
+            )
 
             # Both processes could fail to read a given memory region, so if they both pass
             # compare, then we'll fail them if the core differs from the live process.
-            if (actual_process_read_error.Success() and expected_process_read_error.Success()):
-                self.assertEqual(actual, expected, "Bytes differ between live process and core")
+            if (
+                actual_process_read_error.Success()
+                and expected_process_read_error.Success()
+            ):
+                self.assertEqual(
+                    actual, expected, "Bytes differ between live process and core"
+                )
 
             # Now we check if the error is the same, error isn't abnormal but they should fail for the same reason
             self.assertTrue(
-                (actual_process_read_error.Success() and expected_process_read_error.Success()) or
-                (actual_process_read_error.Fail() and expected_process_read_error.Fail())
+                (
+                    actual_process_read_error.Success()
+                    and expected_process_read_error.Success()
+                )
+                or (
+                    actual_process_read_error.Fail()
+                    and expected_process_read_error.Fail()
+                )
             )
 
     @skipUnlessArch("x86_64")

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -14,7 +14,6 @@ FORCE_64B = "force_64b"
 
 
 class ProcessSaveCoreMinidump64bTestCase(TestBase):
-
     def verify_minidump(
         self,
         core_proc,

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -1,6 +1,6 @@
 """
-Test saving a minidumps with the force 64b flag, and evaluate that every
-saved memory region is byte-wise 1:1 with the live process.
+Test that saved memory regions is byte-wise 1:1 with the live process. Specifically 
+that the memory regions that will be populated in the Memory64List are the same byte for byte.
 """
 
 import os

--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump64b.py
@@ -48,7 +48,6 @@ class ProcessSaveCoreMinidump64bTestCase(TestBase):
                     actual, expected, "Bytes differ between live process and core"
                 )
 
-
             # Now we check if the error is the same, error isn't abnormal but they should fail for the same reason
             self.assertTrue(
                 (

--- a/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
+++ b/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
@@ -189,7 +189,6 @@ class SBSaveCoreOptionsAPICase(TestBase):
         self.assertEqual(0, memory_list.GetSize())
         options.Clear()
 
-
         # Validate we get back the single region we populate
         options.SetStyle(lldb.eSaveCoreCustomOnly)
         process = self.get_basic_process()

--- a/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
+++ b/lldb/test/API/python_api/sbsavecoreoptions/TestSBSaveCoreOptions.py
@@ -164,3 +164,47 @@ class SBSaveCoreOptionsAPICase(TestBase):
         options.SetStyle(lldb.eSaveCoreCustomOnly)
         total = options.GetCurrentSizeInBytes(error)
         self.assertTrue(error.Fail(), error.GetCString())
+
+    def test_get_memory_regions_to_save(self):
+        """
+        Tests the matrix of responses for GetMemoryRegionsToSave
+        """
+
+        options = lldb.SBSaveCoreOptions()
+
+        # Not specifying plugin or process should return an empty list.
+        memory_list = options.GetMemoryRegionsToSave()
+        self.assertEqual(0, memory_list.GetSize())
+
+        # No style returns an empty list
+        process = self.get_basic_process()
+        options.SetProcess(process)
+        memory_list = options.GetMemoryRegionsToSave()
+        self.assertEqual(0, memory_list.GetSize())
+        options.Clear()
+
+        # No Process returns an empty list
+        options.SetStyle(lldb.eSaveCoreCustomOnly)
+        memory_list = options.GetMemoryRegionsToSave()
+        self.assertEqual(0, memory_list.GetSize())
+        options.Clear()
+
+
+        # Validate we get back the single region we populate
+        options.SetStyle(lldb.eSaveCoreCustomOnly)
+        process = self.get_basic_process()
+        options.SetProcess(process)
+        memory_range = lldb.SBMemoryRegionInfo()
+
+        # Add the memory range of 0x1000-0x1100
+        process.GetMemoryRegionInfo(0x1000, memory_range)
+        options.AddMemoryRegionToSave(memory_range)
+        memory_list = options.GetMemoryRegionsToSave()
+        self.assertEqual(1, memory_list.GetSize())
+        read_region = lldb.SBMemoryRegionInfo()
+        memory_list.GetMemoryRegionAtIndex(0, read_region)
+
+        # Permissions from Process getLLDBRegion aren't matching up with
+        # the live process permissions, so we're just checking the range for now.
+        self.assertEqual(memory_range.GetRegionBase(), read_region.GetRegionBase())
+        self.assertEqual(memory_range.GetRegionEnd(), read_region.GetRegionEnd())


### PR DESCRIPTION
### Context

Over a year ago, I landed support for 64b Memory ranges in Minidump (#95312). In this patch we added the Memory64 list stream, which is effectively a Linked List on disk. The layout is a sixteen byte header and then however many Memory descriptors. 

### The Bug
This is a classic off-by one error, where I added 8 bytes instead of 16 for the header. This caused the first region to start 8 bytes before the correct RVA, thus shifting all memory reads by 8 bytes. We are correctly writing all the regions to disk correctly, with no physical corruption but the RVA is defined wrong, meaning we were incorrectly reading memory

![image](https://github.com/user-attachments/assets/049ef55d-856c-4f3c-9376-aeaa3fe8c0e1)


### Why wasn't this caught?

One problem we've had is forcing Minidump to actually use the 64b mode, it would be a massive waste of resources to have a test that actually wrote >4.2gb of IO to validate the 64b regions, and so almost all validation has been manual. As a weakness of manual testing, this issue is psuedo non-deterministic, as what regions end up in 64b or 32b is handled greedily and iterated in the order it's laid out in /proc/pid/maps. We often validated 64b was written correctly by hexdumping the Minidump itself, which was not corrupted (other than the BaseRVA)

![image](https://github.com/user-attachments/assets/b599e3be-2d59-47e2-8a2d-75f182bb0b1d)

### Why is this showing up now?

During internal usage, we had a bug report that the Minidump wasn't displaying values. I was unable to repro the issue, but during my investigation I saw the variables were in the 64b regions which resulted in me identifying the bug.

### How do we prevent future regressions?

To prevent regressions, and honestly to save my sanity for figuring out where 8 bytes magically came from, I've added a new API to SBSaveCoreOptions.

```SBSaveCoreOptions::GetMemoryRegionsToSave()```
The ability to get the memory regions that we intend to include in the Coredump. I added this so we can compare what we intended to include versus what was actually included. Traditionally we've always had issues comparing regions because Minidump includes `/proc/pid/maps` and it can be difficult to know what memoryregion read failure was a genuine error or just a page that wasn't meant to be included. 

We are also leveraging this API to choose the memory regions to be generated, as well as for testing what regions should be bytewise 1:1.

After much debate with @clayborg, I've moved all non-stack memory to the Memory64 List. This list doesn't incur us any meaningful overhead and Greg originally suggested doing this in the original 64b PR. This also means we're exercising the 64b path every single time we save a Minidump, preventing regressions on this feature from slipping through testing in the future.

Snippet produced by [minidump.py](https://github.com/clayborg/scripts) 
```
MINIDUMP_MEMORY_LIST:
NumberOfMemoryRanges = 0x00000002
MemoryRanges[0]      = [0x00007f61085ff9f0 - 0x00007f6108601000) @ 0x0003f655
MemoryRanges[1]      = [0x00007ffe47e50910 - 0x00007ffe47e52000) @ 0x00040c65

MINIDUMP_MEMORY64_LIST:
NumberOfMemoryRanges = 0x000000000000002e
BaseRva              = 0x0000000000042669
MemoryRanges[0]      = [0x00005584162d8000 - 0x00005584162d9000)
MemoryRanges[1]      = [0x00005584162d9000 - 0x00005584162db000)
MemoryRanges[2]      = [0x00005584162db000 - 0x00005584162dd000)
MemoryRanges[3]      = [0x00005584162dd000 - 0x00005584162ff000)
MemoryRanges[4]      = [0x00007f6100000000 - 0x00007f6100021000)
MemoryRanges[5]      = [0x00007f6108800000 - 0x00007f6108828000)
MemoryRanges[6]      = [0x00007f6108828000 - 0x00007f610899d000)
MemoryRanges[7]      = [0x00007f610899d000 - 0x00007f61089f9000)
MemoryRanges[8]      = [0x00007f61089f9000 - 0x00007f6108a08000)
MemoryRanges[9]      = [0x00007f6108bf5000 - 0x00007f6108bf7000)
```

### Misc
As a part of this fix I had to look at LLDB logs a lot, you'll notice I added `0x` to many of the PRIx64 `LLDB_LOGF`. This is so the user (or I) can directly copy paste the address in the logs instead of adding the hex prefix themselves.

Added some SBSaveCore tests for the new GetMemoryAPI, and Docstrings.

CC: @DavidSpickett, @da-viper @labath because we've been working together on save-core plugins, review it optional and I didn't tag you but figured you'd want to know