### PR TITLE
[BPF] Emit proper error message for insns with tied operands

### DIFF
--- a/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
+++ b/llvm/lib/Target/BPF/AsmParser/BPFAsmParser.cpp
@@ -348,6 +348,9 @@ bool BPFAsmParser::matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   case Match_InvalidSImm16:
     return Error(Operands[ErrorInfo]->getStartLoc(),
                  "operand is not a 16-bit signed integer");
+  case Match_InvalidTiedOperand:
+    return Error(Operands[ErrorInfo]->getStartLoc(),
+                 "operand is not the same as the dst register");
   }
 
   llvm_unreachable("Unknown match type detected!");

--- a/llvm/test/MC/BPF/bad-tied.s
+++ b/llvm/test/MC/BPF/bad-tied.s
@@ -1,0 +1,12 @@
+# RUN: not llvm-mc -mcpu=v4 -triple bpfel < %s 2>&1 \
+# RUN:   | grep 'error: operand is not the same as the dst register' \
+# RUN:   | count 9
+        r0 = bswap16 r1
+        r0 = bswap32 r1
+        r0 = bswap64 r1
+        r0 = atomic_fetch_add((u64*)(r2 + 0), r1)
+        r0 = atomic_fetch_and((u64*)(r2 + 0), r1)
+        r0 = atomic_fetch_or((u64*)(r2 + 0), r1)
+        r0 = atomic_fetch_xor((u64*)(r2 + 0), r1)
+        w0 = xchg32_32(r2 + 0, w1)
+        r0 = xchg_64(r2 + 0, r1)


### PR DESCRIPTION
Jonathan Cottrill reported a crash in [1] with the following command line:
```
  $ echo 'r0 = atomic_fetch_add((u64*)(r2 + 0), r1)' | llvm-mc --arch bpf --filetype null
```

Note that in the above command, the insn specification requires that r0 and r1 must be the same register. Otherwise, the crash will happen.

Let us add a case Match_InvalidTiedOperand to handle such invalid insns. With this patch, the error message looks like below:
```
  <stdin>:1:39: error: operand is not the same as the dst register
  r0 = atomic_fetch_add((u64*)(r2 + 0), r1)
                                        ^
```
The error message is much better than the crash. Some other insns are also covered by this patch.
```
  $ echo 'w0 = xchg32_32(r2 + 0, w1)' | llvm-mc --arch bpf --filetype null
  <stdin>:1:24: error: operand is not the same as the dst register
  w0 = xchg32_32(r2 + 0, w1)
                         ^
```
  [1] https://github.com/llvm/llvm-project/issues/145180