### PR TITLE
[libc++] constexpr is_sufficiently_aligned

### DIFF
--- a/libcxx/include/__memory/is_sufficiently_aligned.h
+++ b/libcxx/include/__memory/is_sufficiently_aligned.h
@@ -12,7 +12,6 @@
 
 #include <__config>
 #include <__cstddef/size_t.h>
-#include <__type_traits/is_constant_evaluated.h>
 #include <cstdint>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
@@ -28,10 +27,11 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool is_sufficiently_aligned(_Tp* __ptr) {
 #  ifdef _LIBCPP_COMPILER_CLANG_BASED
   return __builtin_is_aligned(__ptr, _Alignment);
 #  else
-  if constexpr (is_constant_evaluated())
+  if consteval {
     return __builtin_constant_p(__builtin_assume_aligned(__ptr, _Alignment) != nullptr);
-  else
+  } else {
     return reinterpret_cast<uintptr_t>(__ptr) % _Alignment == 0;
+  }
 #  endif
 }
 

--- a/libcxx/include/__memory/is_sufficiently_aligned.h
+++ b/libcxx/include/__memory/is_sufficiently_aligned.h
@@ -23,8 +23,8 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 #if _LIBCPP_STD_VER >= 26
 
 template <size_t _Alignment, class _Tp>
-_LIBCPP_HIDE_FROM_ABI bool is_sufficiently_aligned(_Tp* __ptr) {
-  return reinterpret_cast<uintptr_t>(__ptr) % _Alignment == 0;
+_LIBCPP_HIDE_FROM_ABI constexpr bool is_sufficiently_aligned(_Tp* __ptr) {
+  return __builtin_constant_p(__builtin_assume_aligned(__ptr, _Alignment) != nullptr);
 }
 
 #endif // _LIBCPP_STD_VER >= 26

--- a/libcxx/test/std/utilities/memory/ptr.align/is_sufficiently_aligned.pass.cpp
+++ b/libcxx/test/std/utilities/memory/ptr.align/is_sufficiently_aligned.pass.cpp
@@ -21,7 +21,7 @@
 #include "test_macros.h"
 
 template <typename T>
-void test_is_sufficiently_aligned() {
+constexpr void test_is_sufficiently_aligned() {
   constexpr std::size_t N = alignof(T);
 
   alignas(8 * N) std::remove_cv_t<T> buf[5];
@@ -54,7 +54,7 @@ void test_is_sufficiently_aligned() {
 }
 
 template <typename T>
-void check(T* p) {
+constexpr void check(T* p) {
   ASSERT_SAME_TYPE(bool, decltype(std::is_sufficiently_aligned<alignof(T)>(p)));
   test_is_sufficiently_aligned<T>();
   test_is_sufficiently_aligned<const T>();
@@ -73,7 +73,7 @@ struct alignas(1) X {
 };
 static_assert(sizeof(X) == 2 * alignof(X));
 
-bool tests() {
+constexpr bool test() {
   char c;
   int i;
   long l;
@@ -107,7 +107,8 @@ bool tests() {
 }
 
 int main(int, char**) {
-  tests();
+  test();
+  static_assert(test());
 
   return 0;
 }


### PR DESCRIPTION
This is indended as support for filing a LWG issue. The implementation was suggested by Nikolas in https://github.com/llvm/llvm-project/pull/122603/files#r2035285951