### PR TITLE
[AArch64] Enable convertSetCCLogicToBitwiseLogic for scalar integers

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -365,6 +365,10 @@ public:
     return true;
   }
 
+  bool convertSetCCLogicToBitwiseLogic(EVT VT) const override {
+    return VT.isScalarInteger();
+  }
+
   bool isMaskAndCmp0FoldingBeneficial(const Instruction &AndI) const override;
 
   bool hasAndNotCompare(SDValue V) const override {


### PR DESCRIPTION
It works just like it does on ARM.