### PR TITLE
[Win][X86]Fix issue where _fltused reference is incorrectly issued for vector floating point operations

### DIFF
--- a/llvm/lib/Target/X86/X86AsmPrinter.cpp
+++ b/llvm/lib/Target/X86/X86AsmPrinter.cpp
@@ -1002,11 +1002,11 @@ static bool usesMSVCFloatingPoint(const Triple &TT, const Module &M) {
 
   for (const Function &F : M) {
     for (const Instruction &I : instructions(F)) {
-      if (I.getType()->isFPOrFPVectorTy())
+      if (I.getType()->isFloatingPointTy())
         return true;
 
       for (const auto &Op : I.operands()) {
-        if (Op->getType()->isFPOrFPVectorTy())
+        if (Op->getType()->isFloatingPointTy())
           return true;
       }
     }

--- a/llvm/test/CodeGen/X86/fltused_vec.ll
+++ b/llvm/test/CodeGen/X86/fltused_vec.ll
@@ -1,10 +1,8 @@
 ; The purpose of this test to verify that the fltused symbol is
 ; not emitted when purely vector floating point operations are used on Windows.
 
-; RUN: llc < %s -mtriple i686-pc-win32 | FileCheck %s --check-prefix WIN32
-; RUN: llc < %s -mtriple x86_64-pc-win32 | FileCheck %s --check-prefix WIN64
-; RUN: llc < %s -O0 -mtriple i686-pc-win32 | FileCheck %s --check-prefix WIN32
-; RUN: llc < %s -O0 -mtriple x86_64-pc-win32 | FileCheck %s --check-prefix WIN64
+; RUN: llc < %s -mtriple i686-pc-win32 | FileCheck %s
+; RUN: llc < %s -mtriple x86_64-pc-win32 | FileCheck %s
 
 @foo = external dso_local global [4 x float], align 16
 
@@ -28,5 +26,4 @@ entry:
 }
 
 ; _fltused is determined at a module level
-; WIN32-NOT: .globl __fltused
-; WIN64-NOT: .globl _fltused
+; CHECK-NOT: .globl {{_?}}_fltused

--- a/llvm/test/CodeGen/X86/fltused_vec.ll
+++ b/llvm/test/CodeGen/X86/fltused_vec.ll
@@ -1,0 +1,32 @@
+; The purpose of this test to verify that the fltused symbol is
+; not emitted when purely vector floating point operations are used on Windows.
+
+; RUN: llc < %s -mtriple i686-pc-win32 | FileCheck %s --check-prefix WIN32
+; RUN: llc < %s -mtriple x86_64-pc-win32 | FileCheck %s --check-prefix WIN64
+; RUN: llc < %s -O0 -mtriple i686-pc-win32 | FileCheck %s --check-prefix WIN32
+; RUN: llc < %s -O0 -mtriple x86_64-pc-win32 | FileCheck %s --check-prefix WIN64
+
+@foo = external dso_local global [4 x float], align 16
+
+; Function Attrs: noinline nounwind optnone sspstrong uwtable
+define dso_local <4 x float> @func() #0 {
+entry:
+  %__p.addr.i = alloca ptr, align 8
+  %vector1 = alloca <4 x float>, align 16
+  store ptr @foo, ptr %__p.addr.i, align 8
+  %0 = load ptr, ptr %__p.addr.i, align 8
+  %1 = load <4 x float>, ptr %0, align 16
+  store <4 x float> %1, ptr %vector1, align 16
+  %2 = load <4 x float>, ptr %vector1, align 16
+  ret <4 x float> %2
+}
+
+define <4 x float> @mul_vectors(<4 x float> %a, <4 x float> %b) {
+entry:
+  %result = fmul <4 x float> %a, %b
+  ret <4 x float> %result
+}
+
+; _fltused is determined at a module level
+; WIN32-NOT: .globl __fltused
+; WIN64-NOT: .globl _fltused


### PR DESCRIPTION
Fixes #146428 _fltused reference generated for vector floating point operations

Currently references to _fltused are incorrectly emitted due to the presence of vector floating point operations.  This causes spurious references to _fltused in vector floating point system code where the CRT is not used.  This issue is limited to the X86 MSVC environment.  

As described in the bug:
*  _fltused should only be emitted for floating point operations as the reference is used to initialize some parts of FP CRT support.
* Vector floating point operations on their own don't require that CRT support.

Have confirmed intended behavior with MSVC team.

Fix alters usesMSVCFloatingPoint() to look for floating point instructions/operands rather than floating point or vector floating point.

adamglass@microsoft.com