### PR TITLE
Replace instances of LLVM_RUNTIMES_TARGET with LLVM_RUNTIME_TARGETS

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -97,7 +97,7 @@ jobs:
         -DCMAKE_C_COMPILER_LAUNCHER=${{ matrix.ccache-variant }} \
         -DCMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.ccache-variant }} \
         -DCMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.build-install-dir }} \
-        -DLLVM_RUNTIMES_TARGET=${{ matrix.target }} \
+        -DLLVM_RUNTIME_TARGETS=${{ matrix.target }} \
         -DLLVM_ENABLE_RUNTIMES="$RUNTIMES" \
         -DLLVM_LIBC_FULL_BUILD=ON \
         -G Ninja \

--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -223,9 +223,9 @@ endif()
 
 # The GPU targets require a few mandatory arguments to make the standard CMake
 # check flags happy.
-if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn")
+if ("${LLVM_RUNTIME_TARGETS}" MATCHES "^amdgcn")
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -nogpulib")
-elseif ("${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx")
+elseif ("${LLVM_RUNTIME_TARGETS}" MATCHES "^nvptx")
   set(CMAKE_REQUIRED_FLAGS
       "${CMAKE_REQUIRED_FLAGS} -flto -c -Wno-unused-command-line-argument")
 endif()

--- a/flang-rt/README.md
+++ b/flang-rt/README.md
@@ -113,7 +113,7 @@ will test whether the Fortran compiler can compile and link programs which will
 obviously fail without a runtime library available yet.
 
 Building Flang-RT for cross-compilation triple, the target triple can
-be selected using `LLVM_DEFAULT_TARGET_TRIPLE` AND `LLVM_RUNTIMES_TARGET`.
+be selected using `LLVM_DEFAULT_TARGET_TRIPLE` AND `LLVM_RUNTIME_TARGETS`.
 Of course, Flang-RT can be built multiple times with different build
 configurations, but have to be located manually when using with the Flang
 driver using the `-L` option.

--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -234,11 +234,11 @@ function (add_flangrt_library name)
     endif ()
 
     # Add target specific options if necessary.
-    if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn")
+    if ("${LLVM_RUNTIME_TARGETS}" MATCHES "^amdgcn")
       target_compile_options(${tgtname} PRIVATE
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden>
         )
-    elseif ("${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx")
+    elseif ("${LLVM_RUNTIME_TARGETS}" MATCHES "^nvptx")
       target_compile_options(${tgtname} PRIVATE
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden -Wno-unknown-cuda-version --cuda-feature=+ptx63>
         )

--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -175,7 +175,7 @@ else ()
   set(f128_sources "")
 endif ()
 
-if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
+if ("${LLVM_RUNTIME_TARGETS}" MATCHES "^amdgcn|^nvptx")
   set(sources ${gpu_sources})
 else ()
   set(sources ${supported_sources} ${host_sources} ${f128_sources})

--- a/libc/cmake/modules/LLVMLibCArchitectures.cmake
+++ b/libc/cmake/modules/LLVMLibCArchitectures.cmake
@@ -106,24 +106,24 @@ set(LIBC_TARGET_ARCHITECTURE ${compiler_arch})
 set(LIBC_TARGET_OS ${compiler_sys})
 set(LIBC_CROSSBUILD FALSE)
 
-# One should not set LLVM_RUNTIMES_TARGET and LIBC_TARGET_TRIPLE
-if(LLVM_RUNTIMES_TARGET AND LIBC_TARGET_TRIPLE)
+# One should not set LLVM_RUNTIME_TARGETS and LIBC_TARGET_TRIPLE
+if(LLVM_RUNTIME_TARGETS AND LIBC_TARGET_TRIPLE)
   message(FATAL_ERROR
-          "libc build: Specify only LLVM_RUNTIMES_TARGET if you are doing a "
+          "libc build: Specify only LLVM_RUNTIME_TARGETS if you are doing a "
           "runtimes/bootstrap build. If you are doing a standalone build, "
           "specify only LIBC_TARGET_TRIPLE.")
 endif()
 
 set(explicit_target_triple)
-if(LLVM_RUNTIMES_TARGET)
-  set(explicit_target_triple ${LLVM_RUNTIMES_TARGET})
+if(LLVM_RUNTIME_TARGETS)
+  set(explicit_target_triple ${LLVM_RUNTIME_TARGETS})
 elseif(LIBC_TARGET_TRIPLE)
   set(explicit_target_triple ${LIBC_TARGET_TRIPLE})
 endif()
 
 # The libc's target architecture and OS are set to match the compiler's default
 # target triple above. However, one can explicitly set LIBC_TARGET_TRIPLE or
-# LLVM_RUNTIMES_TARGET (for runtimes/bootstrap build). If one of them is set,
+# LLVM_RUNTIME_TARGETS (for runtimes/bootstrap build). If one of them is set,
 # then we will use that target triple to deduce libc's target OS and
 # architecture.
 if(explicit_target_triple)
@@ -198,7 +198,7 @@ endif()
 
 
 # If the compiler target triple is not the same as the triple specified by
-# LIBC_TARGET_TRIPLE or LLVM_RUNTIMES_TARGET, we will add a --target option
+# LIBC_TARGET_TRIPLE or LLVM_RUNTIME_TARGETS, we will add a --target option
 # if the compiler is clang. If the compiler is GCC we just error out as there
 # is no equivalent of an option like --target.
 if(explicit_target_triple AND

--- a/libc/docs/gpu/building.rst
+++ b/libc/docs/gpu/building.rst
@@ -105,7 +105,7 @@ targeting a GPU architecture.
      -DCMAKE_C_COMPILER=$TARGET_C_COMPILER     \
      -DCMAKE_CXX_COMPILER=$TARGET_CXX_COMPILER \
      -DLLVM_LIBC_FULL_BUILD=ON                 \
-     -DLLVM_RUNTIMES_TARGET=$TARGET_TRIPLE     \
+     -DLLVM_RUNTIME_TARGETS=$TARGET_TRIPLE     \
      -DCMAKE_BUILD_TYPE=Release
   $> ninja install
 

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -409,7 +409,7 @@ function(runtime_register_target name)
                                       -DCMAKE_Fortran_COMPILER_WORKS=ON
                                       -DCMAKE_ASM_COMPILER_WORKS=ON
                                       -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
-                                      -DLLVM_RUNTIMES_TARGET=${name}
+				      -DLLVM_RUNTIME_TARGETS=${name}
                                       ${COMMON_CMAKE_ARGS}
                                       ${${name}_extra_args}
                            EXTRA_TARGETS ${${name}_extra_targets}

--- a/runtimes/CMakeLists.txt
+++ b/runtimes/CMakeLists.txt
@@ -165,8 +165,8 @@ endif()
 set(LLVM_COMPILER_CHECKED ON)
 
 # This can be used to detect whether we're targeting a GPU architecture.
-if("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn" OR
-   "${LLVM_RUNTIMES_TARGET}" MATCHES "^nvptx64")
+if("${LLVM_RUNTIME_TARGETS}" MATCHES "^amdgcn" OR
+   "${LLVM_RUNTIME_TARGETS}" MATCHES "^nvptx64")
   set(LLVM_RUNTIMES_GPU_BUILD ON)
 endif()
 
@@ -336,10 +336,10 @@ if(SUB_COMPONENTS)
     endif()
   endforeach()
 
-  if(LLVM_RUNTIMES_TARGET)
+  if(LLVM_RUNTIME_TARGETS)
     configure_file(
       ${CMAKE_CURRENT_SOURCE_DIR}/Components.cmake.in
-      ${CMAKE_CURRENT_BINARY_DIR}/runtimes/${LLVM_RUNTIMES_TARGET}/Components.cmake)
+      ${CMAKE_CURRENT_BINARY_DIR}/runtimes/${LLVM_RUNTIME_TARGETS}/Components.cmake)
   else()
     configure_file(
       ${CMAKE_CURRENT_SOURCE_DIR}/Components.cmake.in


### PR DESCRIPTION
In the libc documentation and in LLVM cmake files this variable is named LLVM_RUNTIME_TARGETS.
However in libc cmake files it is named LLVM_RUNTIMES_TARGET.
I assume it should be the same everywhere, so this patch replaces all instances of one name with the other name.
