### PR TITLE
[msan] Fix "Add optional flag to improve instrumentation of disjoint OR (#145990)"

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -2525,11 +2525,10 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
 
     Value *S = IRB.CreateOr({S1S2, V1S2, S1V2});
     if (ClPreciseDisjointOr && cast<PossiblyDisjointInst>(&I)->isDisjoint()) {
-      // "V1" and "V2" were NOT'ed above, but we still want to reuse them
-      // because they were IntCast'ed to the same type as the shadows.
-      //
-      // (V1 & V2) == ~(~V1 | ~V2) (de Morgan)
-      Value *V1V2 = IRB.CreateNot(IRB.CreateOr(V1, V2));
+      // "V1" and "V2" were NOT'ed above
+      V1 = IRB.CreateIntCast(I.getOperand(0), S1->getType(), false);
+      V2 = IRB.CreateIntCast(I.getOperand(1), S2->getType(), false);
+      Value *V1V2 = IRB.CreateAnd(V1, V2);
       S = IRB.CreateOr({S, V1V2});
     }
 

--- a/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -2512,24 +2512,25 @@ struct MemorySanitizerVisitor : public InstVisitor<MemorySanitizerVisitor> {
     //    S = S | (V1 & V2)
     Value *S1 = getShadow(&I, 0);
     Value *S2 = getShadow(&I, 1);
-    // Gotcha: V1 and V2 are NOT'ed here
-    Value *V1 = IRB.CreateNot(I.getOperand(0));
-    Value *V2 = IRB.CreateNot(I.getOperand(1));
+    Value *V1 = I.getOperand(0);
+    Value *V2 = I.getOperand(1);
     if (V1->getType() != S1->getType()) {
       V1 = IRB.CreateIntCast(V1, S1->getType(), false);
       V2 = IRB.CreateIntCast(V2, S2->getType(), false);
     }
-    Value *S1S2 = IRB.CreateAnd(S1, S2);
-    Value *V1S2 = IRB.CreateAnd(V1, S2);
-    Value *S1V2 = IRB.CreateAnd(S1, V2);
 
-    Value *S = IRB.CreateOr({S1S2, V1S2, S1V2});
+    Value *NotV1 = IRB.CreateNot(V1);
+    Value *NotV2 = IRB.CreateNot(V2);
+
+    Value *S1S2 = IRB.CreateAnd(S1, S2);
+    Value *S2NotV1 = IRB.CreateAnd(NotV1, S2);
+    Value *S1NotV2 = IRB.CreateAnd(S1, NotV2);
+
+    Value *S = IRB.CreateOr({S1S2, S2NotV1, S1NotV2});
+
     if (ClPreciseDisjointOr && cast<PossiblyDisjointInst>(&I)->isDisjoint()) {
-      // "V1" and "V2" were NOT'ed above
-      V1 = IRB.CreateIntCast(I.getOperand(0), S1->getType(), false);
-      V2 = IRB.CreateIntCast(I.getOperand(1), S2->getType(), false);
       Value *V1V2 = IRB.CreateAnd(V1, V2);
-      S = IRB.CreateOr({S, V1V2});
+      S = IRB.CreateOr(S, V1V2, "_ms_disjoint");
     }
 
     setShadow(&I, S);

--- a/llvm/test/Instrumentation/MemorySanitizer/or.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/or.ll
@@ -45,8 +45,9 @@ define i8 @test_disjoint_or(i8 %a, i8 %b) sanitize_memory {
 ; CHECK-IMPRECISE:      [[C:%.*]] = or disjoint i8 [[A]], [[B]]
 ; CHECK-IMPRECISE-NEXT: store i8 [[TMP11]], ptr @__msan_retval_tls, align 8
 ;
-; CHECK-PRECISE:         [[TMP10:%.*]] = and i8 [[TMP3]], [[TMP4]]
-; CHECK-PRECISE-NEXT:    [[TMP12:%.*]] = or i8 [[TMP11]], [[TMP10]]
+; CHECK-PRECISE:         [[TMP10:%.*]] = or i8 [[TMP3]], [[TMP4]]
+; CHECK-PRECISE-NEXT:    [[TMP11:%.*]] = xor i8 [[TMP10]], -1
+; CHECK-PRECISE-NEXT:    [[TMP12:%.*]] = or i8 [[TMP9]], [[TMP11]]
 ; CHECK-PRECISE-NEXT:    [[C:%.*]] = or disjoint i8 [[A]], [[B]]
 ; CHECK-PRECISE-NEXT:    store i8 [[TMP12]], ptr @__msan_retval_tls, align 8
 ;

--- a/llvm/test/Instrumentation/MemorySanitizer/or.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/or.ll
@@ -46,9 +46,9 @@ define i8 @test_disjoint_or(i8 %a, i8 %b) sanitize_memory {
 ; CHECK-IMPRECISE-NEXT: store i8 [[TMP11]], ptr @__msan_retval_tls, align 8
 ;
 ; CHECK-PRECISE:         [[TMP10:%.*]] = and i8 [[A]], [[B]]
-; CHECK-PRECISE-NEXT:    [[TMP11:%.*]] = or i8 [[TMP9]], [[TMP10]]
+; CHECK-PRECISE-NEXT:    [[TMP12:%.*]] = or i8 [[TMP11]], [[TMP10]]
 ; CHECK-PRECISE-NEXT:    [[C:%.*]] = or disjoint i8 [[A]], [[B]]
-; CHECK-PRECISE-NEXT:    store i8 [[TMP11]], ptr @__msan_retval_tls, align 8
+; CHECK-PRECISE-NEXT:    store i8 [[TMP12]], ptr @__msan_retval_tls, align 8
 ;
 ; CHECK-NEXT:    ret i8 [[C]]
 ;

--- a/llvm/test/Instrumentation/MemorySanitizer/or.ll
+++ b/llvm/test/Instrumentation/MemorySanitizer/or.ll
@@ -45,11 +45,10 @@ define i8 @test_disjoint_or(i8 %a, i8 %b) sanitize_memory {
 ; CHECK-IMPRECISE:      [[C:%.*]] = or disjoint i8 [[A]], [[B]]
 ; CHECK-IMPRECISE-NEXT: store i8 [[TMP11]], ptr @__msan_retval_tls, align 8
 ;
-; CHECK-PRECISE:         [[TMP10:%.*]] = or i8 [[TMP3]], [[TMP4]]
-; CHECK-PRECISE-NEXT:    [[TMP11:%.*]] = xor i8 [[TMP10]], -1
-; CHECK-PRECISE-NEXT:    [[TMP12:%.*]] = or i8 [[TMP9]], [[TMP11]]
+; CHECK-PRECISE:         [[TMP10:%.*]] = and i8 [[A]], [[B]]
+; CHECK-PRECISE-NEXT:    [[TMP11:%.*]] = or i8 [[TMP9]], [[TMP10]]
 ; CHECK-PRECISE-NEXT:    [[C:%.*]] = or disjoint i8 [[A]], [[B]]
-; CHECK-PRECISE-NEXT:    store i8 [[TMP12]], ptr @__msan_retval_tls, align 8
+; CHECK-PRECISE-NEXT:    store i8 [[TMP11]], ptr @__msan_retval_tls, align 8
 ;
 ; CHECK-NEXT:    ret i8 [[C]]
 ;


### PR DESCRIPTION
The "V1" and "V2" values were already NOT'ed, hence the calculation of disjoint OR in #145990 was incorrect. This patch fixes the issue by using DeMorgan's law.