### PR TITLE
[Sema][ObjC] Treat unknown selector messages as unrecoverable errors under ARC

### DIFF
--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -832,7 +832,11 @@ bool DiagnosticIDs::isUnrecoverable(unsigned DiagID) const {
       DiagID == diag::err_unavailable_message)
     return false;
 
-  // Currently we consider all ARC errors as recoverable.
+  // Currently we consider all ARC errors except err_arc_may_not_respond as
+  // recoverable.
+  if (DiagID == diag::err_arc_may_not_respond)
+    return true;
+
   if (isARCDiagnostic(DiagID))
     return false;
 

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -832,8 +832,11 @@ bool DiagnosticIDs::isUnrecoverable(unsigned DiagID) const {
       DiagID == diag::err_unavailable_message)
     return false;
 
-  // Currently we consider all ARC errors except err_arc_may_not_respond as
-  // recoverable.
+  // All ARC errors are currently considered recoverable, with the exception of
+  // err_arc_may_not_respond. This specific error is treated as unrecoverable
+  // because sending a message with an unknown selector could lead to crashes
+  // within CodeGen if the resulting expression is used to initialize a C++
+  // auto variable, where type deduction is required.
   if (isARCDiagnostic(DiagID) && DiagID != diag::err_arc_may_not_respond)
     return false;
 

--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -834,10 +834,7 @@ bool DiagnosticIDs::isUnrecoverable(unsigned DiagID) const {
 
   // Currently we consider all ARC errors except err_arc_may_not_respond as
   // recoverable.
-  if (DiagID == diag::err_arc_may_not_respond)
-    return true;
-
-  if (isARCDiagnostic(DiagID))
+  if (isARCDiagnostic(DiagID) && DiagID != diag::err_arc_may_not_respond)
     return false;
 
   if (isCodegenABICheckDiagnostic(DiagID))

--- a/clang/test/SemaObjCXX/arc-0x.mm
+++ b/clang/test/SemaObjCXX/arc-0x.mm
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -std=c++11 -fsyntax-only -fobjc-arc -fobjc-runtime-has-weak -fobjc-weak -verify -fblocks -fobjc-exceptions %s
+// RUN: %clang_cc1 -std=c++11 -fobjc-arc -fobjc-runtime-has-weak -fobjc-weak -verify -fblocks -fobjc-exceptions -emit-llvm -o - %s
 
 // "Move" semantics, trivial version.
 void move_it(__strong id &&from) {
@@ -13,6 +13,11 @@ void move_it(__strong id &&from) {
 
 // don't warn about this
 extern "C" A* MakeA();
+
+void test_nonexistent_method(A *a) {
+  // This used to crash in codegen.
+  auto a1 = [a foo]; // expected-error {{no visible @interface for 'A' declares the selector 'foo'}}
+}
 
 // Ensure that deduction works with lifetime qualifiers.
 void deduction(id obj) {


### PR DESCRIPTION
Fixes a CodeGen crash observed when C++ auto variable types remained non-deduced due to a message being sent with an unknown selector under ARC.

By treating these instances as an unrecoverable error, we prevent the compiler from proceeding to CodeGen with fundamentally incorrect code.

rdar://144394403