### PR TITLE
[lldb][mcp] Skip MCPUnixSocketCommandTestCase if remote

### DIFF
--- a/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
+++ b/lldb/test/API/commands/protocol/TestMCPUnixSocket.py
@@ -12,6 +12,7 @@ MAX_SOCKET_PATH_LENGTH = 104
 
 class MCPUnixSocketCommandTestCase(TestBase):
     @skipIfWindows
+    @skipIfRemote
     @no_debug_info_test
     def test_unix_socket(self):
         """


### PR DESCRIPTION
It looks like #146603 broke the [lldb-remote-linux-win](https://lab.llvm.org/buildbot/#/builders/197) build bot because `MCPUnixSocketCommandTestCase` is trying to start a protocol-server via unix domain sockets on windows. 
This change makes it so the test is skipped if it is remote.