### PR TITLE
[compiler-rt] Include missing headers for libFuzzer

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
@@ -24,11 +24,11 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <functional>
 #include <mutex>
 #include <string>
 #include <thread>
-#include <fstream>
 
 // This function should be present in the libFuzzer so that the client
 // binary can test for its existence.

--- a/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerDriver.cpp
@@ -24,6 +24,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <thread>

--- a/compiler-rt/lib/fuzzer/FuzzerIOPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIOPosix.cpp
@@ -12,10 +12,10 @@
 
 #include "FuzzerExtFunctions.h"
 #include "FuzzerIO.h"
+#include <cerrno>
 #include <cstdarg>
 #include <cstdio>
 #include <dirent.h>
-#include <cerrno>
 #include <fstream>
 #include <iterator>
 #include <libgen.h>

--- a/compiler-rt/lib/fuzzer/FuzzerIOPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIOPosix.cpp
@@ -15,7 +15,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <dirent.h>
-#include <errno.h>
+#include <cerrno>
 #include <fstream>
 #include <iterator>
 #include <libgen.h>

--- a/compiler-rt/lib/fuzzer/FuzzerIOPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerIOPosix.cpp
@@ -15,6 +15,7 @@
 #include <cstdarg>
 #include <cstdio>
 #include <dirent.h>
+#include <errno.h>
 #include <fstream>
 #include <iterator>
 #include <libgen.h>

--- a/compiler-rt/lib/fuzzer/FuzzerRandom.h
+++ b/compiler-rt/lib/fuzzer/FuzzerRandom.h
@@ -11,6 +11,7 @@
 #ifndef LLVM_FUZZER_RANDOM_H
 #define LLVM_FUZZER_RANDOM_H
 
+#include <math.h>
 #include <random>
 
 namespace fuzzer {

--- a/compiler-rt/lib/fuzzer/FuzzerRandom.h
+++ b/compiler-rt/lib/fuzzer/FuzzerRandom.h
@@ -11,7 +11,7 @@
 #ifndef LLVM_FUZZER_RANDOM_H
 #define LLVM_FUZZER_RANDOM_H
 
-#include <math.h>
+#include <cmath>
 #include <random>
 
 namespace fuzzer {


### PR DESCRIPTION
This is to fix modules build errors in chromium like
* https://ci.chromium.org/ui/p/chromium/builders/try/linux-libfuzzer-asan-rel/2292144/overview
* https://ci.chromium.org/ui/p/chromium/builders/try/linux-libfuzzer-asan-rel/2292444/overview