### PR TITLE
[MLIR/Utils] Add missing dep on Arith dialect

### DIFF
--- a/mlir/lib/Dialect/Utils/CMakeLists.txt
+++ b/mlir/lib/Dialect/Utils/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_library(MLIRDialectUtils
 
   DEPENDS
   MLIRDialectUtilsIncGen
+  MLIRArithDialect
 
   LINK_LIBS PUBLIC
   MLIRIR


### PR DESCRIPTION
Fix the following compile error when building libMLIRDialectUtils.a
only:

In file included from mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h:17,
                 from mlir/lib/Dialect/Utils/ReshapeOpsUtils.cpp:9:
mlir/include/mlir/Dialect/Arith/IR/Arith.h:28:10:
fatal error: mlir/Dialect/Arith/IR/ArithOpsDialect.h.inc: No such file or directory

ArithDialect dependency is now needed since
0515449f6dcb452ea0b089fb3057d469c3cffa3f to create arith.muli op.
