### PR TITLE
[LLDB] Mark TestCallStdStringFunction as XPASS on Windows

### DIFF
--- a/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
+++ b/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py
@@ -12,7 +12,6 @@ class ExprCommandCallFunctionTestCase(TestBase):
     @expectedFailureAll(
         compiler="icc", bugnumber="llvm.org/pr14437, fails with ICC 13.1"
     )
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr21765")
     @skipIf(compiler="clang", compiler_version=["<", "9.0"])
     def test_with(self):
         """Test calling std::String member function."""


### PR DESCRIPTION
#146562 made [TestCallStdStringFunction](https://github.com/llvm/llvm-project/blob/bd6cd92984e7a30cb91e4f069a0bacc5c582a234/lldb/test/API/commands/expression/call-function/TestCallStdStringFunction.py) unexpectedly pass on Windows.

The test now passes, because `expression str` now prints the "raw" string object, which happens to include the string "Hello world". Previously, this resulted in an error:

```
(lldb) expression str
(std::string) $0 = {
  _Mypair = {
    _Myval2 = {
      _Bx = (_Buf = "Hello world", _Ptr = "", _Alias = "Hello world")
      _Mysize = 11
      _Myres = 15
    }
  }
}
(lldb) type summary add std::string --summary-string "${var._M_dataplus._M_p}"
^^^ previous summary ^^^
(lldb) expression str
(std::string) $1 = error: summary string parsing error
```

#143177 will eventually add the correct summary for MSVC STL strings.

Relates to https://github.com/llvm/llvm-project/issues/22139