### PR TITLE
[libclc] Reduce include usage in OpenCL builtins

### DIFF
--- a/libclc/opencl/include/clc/opencl/clc.h
+++ b/libclc/opencl/include/clc/opencl/clc.h
@@ -15,19 +15,7 @@
 
 #pragma OPENCL EXTENSION cl_clang_storage_class_specifiers : enable
 
-#ifdef cl_khr_fp64
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#endif
-
-#ifdef cl_khr_fp16
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-#endif
-
-/* Function Attributes */
-#include <clc/clcfunc.h>
-
-/* 6.1 Supported Data Types */
-#include <clc/clctypes.h>
+#include <clc/opencl/opencl-base.h>
 
 /* 6.2.3 Explicit Conversions */
 #include <clc/opencl/convert.h>

--- a/libclc/opencl/include/clc/opencl/integer/abs.h
+++ b/libclc/opencl/include/clc/opencl/integer/abs.h
@@ -6,5 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_ABS_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_ABS_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define __CLC_BODY <clc/opencl/integer/abs.inc>
 #include <clc/integer/gentype.inc>
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_ABS_H__

--- a/libclc/opencl/include/clc/opencl/integer/abs.h
+++ b/libclc/opencl/include/clc/opencl/integer/abs.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_ABS_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_ABS_H__
+#ifndef __CLC_OPENCL_INTEGER_ABS_H__
+#define __CLC_OPENCL_INTEGER_ABS_H__
 
 #include <clc/opencl/opencl-base.h>
 
 #define __CLC_BODY <clc/opencl/integer/abs.inc>
 #include <clc/integer/gentype.inc>
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_ABS_H__
+#endif // __CLC_OPENCL_INTEGER_ABS_H__

--- a/libclc/opencl/include/clc/opencl/integer/abs_diff.h
+++ b/libclc/opencl/include/clc/opencl/integer/abs_diff.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_ABS_DIFF_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_ABS_DIFF_H__
+#ifndef __CLC_OPENCL_INTEGER_ABS_DIFF_H__
+#define __CLC_OPENCL_INTEGER_ABS_DIFF_H__
 
 #include <clc/opencl/opencl-base.h>
 
 #define __CLC_BODY <clc/opencl/integer/abs_diff.inc>
 #include <clc/integer/gentype.inc>
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_ABS_DIFF_H__
+#endif // __CLC_OPENCL_INTEGER_ABS_DIFF_H__

--- a/libclc/opencl/include/clc/opencl/integer/abs_diff.h
+++ b/libclc/opencl/include/clc/opencl/integer/abs_diff.h
@@ -6,5 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_ABS_DIFF_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_ABS_DIFF_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define __CLC_BODY <clc/opencl/integer/abs_diff.inc>
 #include <clc/integer/gentype.inc>
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_ABS_DIFF_H__

--- a/libclc/opencl/include/clc/opencl/integer/add_sat.h
+++ b/libclc/opencl/include/clc/opencl/integer/add_sat.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_ADD_SAT_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_ADD_SAT_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION add_sat
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_ADD_SAT_H__

--- a/libclc/opencl/include/clc/opencl/integer/add_sat.h
+++ b/libclc/opencl/include/clc/opencl/integer/add_sat.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_ADD_SAT_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_ADD_SAT_H__
+#ifndef __CLC_OPENCL_INTEGER_ADD_SAT_H__
+#define __CLC_OPENCL_INTEGER_ADD_SAT_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_ADD_SAT_H__
+#endif // __CLC_OPENCL_INTEGER_ADD_SAT_H__

--- a/libclc/opencl/include/clc/opencl/integer/clz.h
+++ b/libclc/opencl/include/clc/opencl/integer/clz.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_CLZ_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_CLZ_H__
+#ifndef __CLC_OPENCL_INTEGER_CLZ_H__
+#define __CLC_OPENCL_INTEGER_CLZ_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_CLZ_H__
+#endif // __CLC_OPENCL_INTEGER_CLZ_H__

--- a/libclc/opencl/include/clc/opencl/integer/clz.h
+++ b/libclc/opencl/include/clc/opencl/integer/clz.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_CLZ_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_CLZ_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION clz
 #define __CLC_BODY <clc/shared/unary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_CLZ_H__

--- a/libclc/opencl/include/clc/opencl/integer/ctz.h
+++ b/libclc/opencl/include/clc/opencl/integer/ctz.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_CTZ_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_CTZ_H__
+
 #if __OPENCL_C_VERSION__ >= CL_VERSION_2_0
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION ctz
 #define __CLC_BODY <clc/shared/unary_decl.inc>
@@ -16,3 +21,5 @@
 #undef FUNCTION
 
 #endif // __OPENCL_C_VERSION__ >= CL_VERSION_2_0
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_CTZ_H__

--- a/libclc/opencl/include/clc/opencl/integer/ctz.h
+++ b/libclc/opencl/include/clc/opencl/integer/ctz.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_CTZ_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_CTZ_H__
+#ifndef __CLC_OPENCL_INTEGER_CTZ_H__
+#define __CLC_OPENCL_INTEGER_CTZ_H__
 
 #if __OPENCL_C_VERSION__ >= CL_VERSION_2_0
 
@@ -22,4 +22,4 @@
 
 #endif // __OPENCL_C_VERSION__ >= CL_VERSION_2_0
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_CTZ_H__
+#endif // __CLC_OPENCL_INTEGER_CTZ_H__

--- a/libclc/opencl/include/clc/opencl/integer/hadd.h
+++ b/libclc/opencl/include/clc/opencl/integer/hadd.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_HADD_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_HADD_H__
+#ifndef __CLC_OPENCL_INTEGER_HADD_H__
+#define __CLC_OPENCL_INTEGER_HADD_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_HADD_H__
+#endif // __CLC_OPENCL_INTEGER_HADD_H__

--- a/libclc/opencl/include/clc/opencl/integer/hadd.h
+++ b/libclc/opencl/include/clc/opencl/integer/hadd.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_HADD_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_HADD_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION hadd
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_HADD_H__

--- a/libclc/opencl/include/clc/opencl/integer/mad24.h
+++ b/libclc/opencl/include/clc/opencl/integer/mad24.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_MAD24_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_MAD24_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION mad24
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
 
 #include <clc/integer/gentype24.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_MAD24_H__

--- a/libclc/opencl/include/clc/opencl/integer/mad24.h
+++ b/libclc/opencl/include/clc/opencl/integer/mad24.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_MAD24_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_MAD24_H__
+#ifndef __CLC_OPENCL_INTEGER_MAD24_H__
+#define __CLC_OPENCL_INTEGER_MAD24_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_MAD24_H__
+#endif // __CLC_OPENCL_INTEGER_MAD24_H__

--- a/libclc/opencl/include/clc/opencl/integer/mad_hi.h
+++ b/libclc/opencl/include/clc/opencl/integer/mad_hi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_MAD_HI_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_MAD_HI_H__
+#ifndef __CLC_OPENCL_INTEGER_MAD_HI_H__
+#define __CLC_OPENCL_INTEGER_MAD_HI_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_MAD_HI_H__
+#endif // __CLC_OPENCL_INTEGER_MAD_HI_H__

--- a/libclc/opencl/include/clc/opencl/integer/mad_hi.h
+++ b/libclc/opencl/include/clc/opencl/integer/mad_hi.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_MAD_HI_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_MAD_HI_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION mad_hi
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_MAD_HI_H__

--- a/libclc/opencl/include/clc/opencl/integer/mad_sat.h
+++ b/libclc/opencl/include/clc/opencl/integer/mad_sat.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_MAD_SAT_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_MAD_SAT_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION mad_sat
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_MAD_SAT_H__

--- a/libclc/opencl/include/clc/opencl/integer/mad_sat.h
+++ b/libclc/opencl/include/clc/opencl/integer/mad_sat.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_MAD_SAT_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_MAD_SAT_H__
+#ifndef __CLC_OPENCL_INTEGER_MAD_SAT_H__
+#define __CLC_OPENCL_INTEGER_MAD_SAT_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_MAD_SAT_H__
+#endif // __CLC_OPENCL_INTEGER_MAD_SAT_H__

--- a/libclc/opencl/include/clc/opencl/integer/mul24.h
+++ b/libclc/opencl/include/clc/opencl/integer/mul24.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_MUL24_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_MUL24_H__
+#ifndef __CLC_OPENCL_INTEGER_MUL24_H__
+#define __CLC_OPENCL_INTEGER_MUL24_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_MUL24_H__
+#endif // __CLC_OPENCL_INTEGER_MUL24_H__

--- a/libclc/opencl/include/clc/opencl/integer/mul24.h
+++ b/libclc/opencl/include/clc/opencl/integer/mul24.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_MUL24_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_MUL24_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION mul24
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype24.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_MUL24_H__

--- a/libclc/opencl/include/clc/opencl/integer/mul_hi.h
+++ b/libclc/opencl/include/clc/opencl/integer/mul_hi.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_MUL_HI_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_MUL_HI_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION mul_hi
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_MUL_HI_H__

--- a/libclc/opencl/include/clc/opencl/integer/mul_hi.h
+++ b/libclc/opencl/include/clc/opencl/integer/mul_hi.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_MUL_HI_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_MUL_HI_H__
+#ifndef __CLC_OPENCL_INTEGER_MUL_HI_H__
+#define __CLC_OPENCL_INTEGER_MUL_HI_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_MUL_HI_H__
+#endif // __CLC_OPENCL_INTEGER_MUL_HI_H__

--- a/libclc/opencl/include/clc/opencl/integer/popcount.h
+++ b/libclc/opencl/include/clc/opencl/integer/popcount.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_POPCOUNT_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_POPCOUNT_H__
+#ifndef __CLC_OPENCL_INTEGER_POPCOUNT_H__
+#define __CLC_OPENCL_INTEGER_POPCOUNT_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_POPCOUNT_H__
+#endif // __CLC_OPENCL_INTEGER_POPCOUNT_H__

--- a/libclc/opencl/include/clc/opencl/integer/popcount.h
+++ b/libclc/opencl/include/clc/opencl/integer/popcount.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_POPCOUNT_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_POPCOUNT_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION popcount
 #define __CLC_BODY <clc/shared/unary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_POPCOUNT_H__

--- a/libclc/opencl/include/clc/opencl/integer/rhadd.h
+++ b/libclc/opencl/include/clc/opencl/integer/rhadd.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_INTEGER_RHADD_H__
+#define __CLC_OPENCL_INTEGER_RHADD_H__
+
 #define FUNCTION rhadd
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_INTEGER_RHADD_H__

--- a/libclc/opencl/include/clc/opencl/integer/rotate.h
+++ b/libclc/opencl/include/clc/opencl/integer/rotate.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_ROTATE_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_ROTATE_H__
+#ifndef __CLC_OPENCL_INTEGER_ROTATE_H__
+#define __CLC_OPENCL_INTEGER_ROTATE_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -18,4 +18,4 @@
 
 #undef FUNCTION
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_ROTATE_H__
+#endif // __CLC_OPENCL_INTEGER_ROTATE_H__

--- a/libclc/opencl/include/clc/opencl/integer/rotate.h
+++ b/libclc/opencl/include/clc/opencl/integer/rotate.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_ROTATE_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_ROTATE_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION rotate
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_ROTATE_H__

--- a/libclc/opencl/include/clc/opencl/integer/sub_sat.h
+++ b/libclc/opencl/include/clc/opencl/integer/sub_sat.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_INTEGER_SUB_SAT_H__
+#define __CLC_OPENCL_INTEGER_SUB_SAT_H__
+
 #define FUNCTION sub_sat
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/integer/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_INTEGER_SUB_SAT_H__

--- a/libclc/opencl/include/clc/opencl/integer/upsample.h
+++ b/libclc/opencl/include/clc/opencl/integer/upsample.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __CLC_OPENCL_OPENCL_INTEGER_UPSAMPLE_H__
-#define __CLC_OPENCL_OPENCL_INTEGER_UPSAMPLE_H__
+#ifndef __CLC_OPENCL_INTEGER_UPSAMPLE_H__
+#define __CLC_OPENCL_INTEGER_UPSAMPLE_H__
 
 #include <clc/opencl/opencl-base.h>
 
@@ -36,4 +36,4 @@ __CLC_UPSAMPLE_TYPES()
 #undef __CLC_UPSAMPLE_DECL
 #undef __CLC_UPSAMPLE_VEC
 
-#endif // __CLC_OPENCL_OPENCL_INTEGER_UPSAMPLE_H__
+#endif // __CLC_OPENCL_INTEGER_UPSAMPLE_H__

--- a/libclc/opencl/include/clc/opencl/integer/upsample.h
+++ b/libclc/opencl/include/clc/opencl/integer/upsample.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_OPENCL_INTEGER_UPSAMPLE_H__
+#define __CLC_OPENCL_OPENCL_INTEGER_UPSAMPLE_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define __CLC_UPSAMPLE_DECL(BGENTYPE, GENTYPE, UGENTYPE)                       \
   _CLC_OVERLOAD _CLC_DECL BGENTYPE upsample(GENTYPE hi, UGENTYPE lo);
 
@@ -30,3 +35,5 @@ __CLC_UPSAMPLE_TYPES()
 #undef __CLC_UPSAMPLE_TYPES
 #undef __CLC_UPSAMPLE_DECL
 #undef __CLC_UPSAMPLE_VEC
+
+#endif // __CLC_OPENCL_OPENCL_INTEGER_UPSAMPLE_H__

--- a/libclc/opencl/include/clc/opencl/opencl-base.h
+++ b/libclc/opencl/include/clc/opencl/opencl-base.h
@@ -6,8 +6,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/integer/clc_abs.h>
-#include <clc/opencl/integer/abs.h>
+#ifndef __CLC_OPENCL_OPENCL_BASE_H__
+#define __CLC_OPENCL_OPENCL_BASE_H__
 
-#define __CLC_BODY <abs.inc>
-#include <clc/integer/gentype.inc>
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#endif
+
+#ifdef cl_khr_fp16
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#endif
+
+/* Function Attributes */
+#include <clc/clcfunc.h>
+
+/* 6.1 Supported Data Types */
+#include <clc/clctypes.h>
+
+#endif // __CLC_OPENCL_OPENCL_BASE_H__

--- a/libclc/opencl/lib/generic/integer/abs_diff.cl
+++ b/libclc/opencl/lib/generic/integer/abs_diff.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_abs_diff.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/abs_diff.h>
 
 #define __CLC_BODY <abs_diff.inc>
 #include <clc/integer/gentype.inc>

--- a/libclc/opencl/lib/generic/integer/add_sat.cl
+++ b/libclc/opencl/lib/generic/integer/add_sat.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_add_sat.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/add_sat.h>
 
 #define FUNCTION add_sat
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/clz.cl
+++ b/libclc/opencl/lib/generic/integer/clz.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_clz.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/clz.h>
 
 #define FUNCTION clz
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/integer/ctz.cl
+++ b/libclc/opencl/lib/generic/integer/ctz.cl
@@ -9,7 +9,7 @@
 #if __OPENCL_C_VERSION__ >= CL_VERSION_2_0
 
 #include <clc/integer/clc_ctz.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/ctz.h>
 
 #define FUNCTION ctz
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/integer/hadd.cl
+++ b/libclc/opencl/lib/generic/integer/hadd.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_hadd.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/hadd.h>
 
 #define FUNCTION hadd
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/mad24.cl
+++ b/libclc/opencl/lib/generic/integer/mad24.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_mad24.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/mad24.h>
 
 #define FUNCTION mad24
 #define __CLC_BODY <clc/shared/ternary_def.inc>

--- a/libclc/opencl/lib/generic/integer/mad_hi.cl
+++ b/libclc/opencl/lib/generic/integer/mad_hi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_mad_hi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/mad_hi.h>
 
 #define FUNCTION mad_hi
 #define __CLC_BODY <clc/shared/ternary_def.inc>

--- a/libclc/opencl/lib/generic/integer/mad_sat.cl
+++ b/libclc/opencl/lib/generic/integer/mad_sat.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_mad_sat.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/mad_sat.h>
 
 #define FUNCTION mad_sat
 #define __CLC_BODY <clc/shared/ternary_def.inc>

--- a/libclc/opencl/lib/generic/integer/mul24.cl
+++ b/libclc/opencl/lib/generic/integer/mul24.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_mul24.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/mul24.h>
 
 #define FUNCTION mul24
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/mul_hi.cl
+++ b/libclc/opencl/lib/generic/integer/mul_hi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_mul_hi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/mul_hi.h>
 
 #define FUNCTION mul_hi
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/popcount.cl
+++ b/libclc/opencl/lib/generic/integer/popcount.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_popcount.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/popcount.h>
 
 #define FUNCTION popcount
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/integer/rhadd.cl
+++ b/libclc/opencl/lib/generic/integer/rhadd.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_rhadd.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/rhadd.h>
 
 #define FUNCTION rhadd
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/rotate.cl
+++ b/libclc/opencl/lib/generic/integer/rotate.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_rotate.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/rotate.h>
 
 #define FUNCTION rotate
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/sub_sat.cl
+++ b/libclc/opencl/lib/generic/integer/sub_sat.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_sub_sat.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/sub_sat.h>
 
 #define FUNCTION sub_sat
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/integer/upsample.cl
+++ b/libclc/opencl/lib/generic/integer/upsample.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/integer/clc_upsample.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/integer/upsample.h>
 
 #define __CLC_UPSAMPLE_IMPL(BGENTYPE, GENTYPE, UGENTYPE)                       \
   _CLC_OVERLOAD _CLC_DEF BGENTYPE upsample(GENTYPE hi, UGENTYPE lo) {          \


### PR DESCRIPTION
This commit starts the process of reducing the amount of code included by OpenCL builtins, hopefully reducing build times in the process.

It introduces a minimal OpenCL header - opencl-base.h - which includes only the OpenCL type definitions and the macros necessary for declaring/defining functions.

Where the OpenCL builtin implementations would currently include the whole of <clc/opencl/clc.h>, which defines *all* OpenCL builtins, now they include only the specific declaration they need.

This mirrors how the CLC builtins are defined.