### PR TITLE
[Driver][RISCV] Fix incorrect compiler-rt path override in BareMetal toolchain after RISCVToolChain removal

### DIFF
--- a/clang/lib/Driver/ToolChains/BareMetal.cpp
+++ b/clang/lib/Driver/ToolChains/BareMetal.cpp
@@ -206,6 +206,16 @@ std::string BareMetal::computeSysRoot() const {
   return computeClangRuntimesSysRoot(D, /*IncludeTriple*/ true);
 }
 
+std::string BareMetal::getCompilerRTPath() const {
+  const Driver &D = getDriver();
+  if (IsGCCInstallationValid || detectGCCToolchainAdjacent(getDriver())) {
+    SmallString<128> Path(D.ResourceDir);
+    llvm::sys::path::append(Path, "lib");
+    return std::string(Path.str());
+  }
+  return ToolChain::getCompilerRTPath();
+}
+
 static void addMultilibsFilePaths(const Driver &D, const MultilibSet &Multilibs,
                                   const Multilib &Multilib,
                                   StringRef InstallPath,

--- a/clang/lib/Driver/ToolChains/BareMetal.h
+++ b/clang/lib/Driver/ToolChains/BareMetal.h
@@ -76,6 +76,7 @@ public:
   addLibStdCxxIncludePaths(const llvm::opt::ArgList &DriverArgs,
                            llvm::opt::ArgStringList &CC1Args) const override;
   std::string computeSysRoot() const override;
+  std::string getCompilerRTPath() const override;
   SanitizerMask getSupportedSanitizers() const override;
 
   SmallVector<std::string>

--- a/clang/test/Driver/print-libgcc-file-name-clangrt.c
+++ b/clang/test/Driver/print-libgcc-file-name-clangrt.c
@@ -63,3 +63,12 @@
 // RUN:     -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-ARM-BAREMETAL-PER-TARGET %s
 // CHECK-CLANGRT-ARM-BAREMETAL-PER-TARGET: libclang_rt.builtins.a
+
+// RUN: %clang -rtlib=compiler-rt -print-libgcc-file-name \
+// RUN:     --target=riscv32-unknown-elf \
+// RUN:     --sysroot=%S/Inputs/resource_dir_with_arch_subdir \
+// RUN:     -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir \
+// RUN:     --gcc-toolchain=%S/Inputs/basic_riscv32_tree 2>&1 \
+// RUN:    | FileCheck --check-prefix=CHECK-CLANGRT-RISCV-BAREMETAL %s
+// CHECK-CLANGRT-RISCV-BAREMETAL-NOT: baremetal{{/|\\}}libclang_rt.builtins-riscv32.a
+// CHECK-CLANGRT-RISCV-BAREMETAL: libclang_rt.builtins.a


### PR DESCRIPTION
The RISCVToolChain, which was removed in commit f8cb798,
used a different compiler-rt path relative to the resource-dir
when GCCInstallation was valid. However, this behavior was
unintentionally overridden when it was merged into the
BareMetal toolchain. This patch restores the correct path
handling logic.

After this fix -
With valid GCCInstallation
`<resource-dir>/<llvm-rel-ver>/lib/<target-triple>libclang_rt.builtins.a`

Without valid GCCInstallation
`<resource-dir>/<llvm-rel-ver>/lib/baremetal/libclang_rt.builtins-<target>.a`

