### PR TITLE
[flang] Fix x86 REQUIRES in a couple of tests

### DIFF
--- a/flang/test/Lower/Intrinsics/ieee_class_queries.f90
+++ b/flang/test/Lower/Intrinsics/ieee_class_queries.f90
@@ -1,5 +1,5 @@
 ! REQUIRES: flang-supports-f128-math
-! REQUIRES: x86_64-registered-target
+! REQUIRES: x86-registered-target
 ! RUN: bbc -target x86_64-unknown-linux-gnu -emit-fir -o - %s | FileCheck %s
 
   ! CHECK-LABEL: func @_QQmain

--- a/flang/test/Semantics/windows.f90
+++ b/flang/test/Semantics/windows.f90
@@ -1,4 +1,4 @@
-! RUN: %if x86_64-registered-target %{ %python %S/test_errors.py %s %flang --target=x86_64-pc-windows-msvc -Werror %}
+! RUN: %if x86-registered-target %{ %python %S/test_errors.py %s %flang --target=x86_64-pc-windows-msvc -Werror %}
 ! RUN: %if aarch64-registered-target %{ %python %S/test_errors.py %s %flang --target=aarch64-pc-windows-msvc -Werror %}
 
 subroutine uid


### PR DESCRIPTION
Many tests in Flang are looking for x86_64-registered-target, but this never exists because the target is just called x86.

These two pass with this corrected but the others I need to look into why they fail.