### PR TITLE
[flang][test] Enable kinds01/02.f90 and update expected output

### DIFF
--- a/flang/test/Semantics/kinds01.f90
+++ b/flang/test/Semantics/kinds01.f90
@@ -1,5 +1,5 @@
-! REQUIRES: x86_64-registered-target
-! RUN: %python %S/test_symbols.py %s %flang_fc1
+! REQUIRES: x86-registered-target
+! RUN: %python %S/test_symbols.py %s %flang_fc1 -triple x86_64-unknown-linux-gnu
  !DEF: /MainProgram1/jk1 ObjectEntity INTEGER(1)
  integer(kind=1) jk1
  !DEF: /MainProgram1/js1 ObjectEntity INTEGER(1)

--- a/flang/test/Semantics/kinds02.f90
+++ b/flang/test/Semantics/kinds02.f90
@@ -1,5 +1,5 @@
-! REQUIRES: x86_64-registered-target
-! RUN: %python %S/test_errors.py %s %flang_fc1
+! REQUIRES: x86-registered-target
+! RUN: %python %S/test_errors.py %s %flang_fc1 -triple x86_64-unknown-linux-gnu
 ! C712 The value of scalar-int-constant-expr shall be nonnegative and 
 ! shall specify a representation method that exists on the processor.
 ! C714 The value of kind-param shall be nonnegative.
@@ -44,9 +44,9 @@ complex(kind=7) :: z7
 complex(kind=32) :: z32
 !ERROR: COMPLEX*1 is not a supported type
 complex*1 :: zs1
-!ERROR: COMPLEX*2 is not a supported type
+!ERROR: COMPLEX(KIND=1) is not a supported type
 complex*2 :: zs2
-!ERROR: COMPLEX*64 is not a supported type
+!ERROR: COMPLEX(KIND=32) is not a supported type
 complex*64 :: zs64
 !ERROR: LOGICAL(KIND=0) is not a supported type
 logical(kind=0) :: l0


### PR DESCRIPTION
These have not been run in a while because they required the "x86_64" target but it's not called that, it's just "x86".

After fixing that, 02 had some failures. I've just updated it to match, and reviewers will hopefully tell me if that's correct.