### PR TITLE
[lldb][test] Run generic set formatter test-case on specified STL

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
@@ -137,7 +137,7 @@ class GenericSetDataFormatterTestCase(TestBase):
 
     def do_test_ref_and_ptr(self, stdlib_type):
         """Test that the data formatters work on ref and ptr."""
-        self.build()
+        self.build(dictionary={stdlib_type: "1"})
         (self.target, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
             self,
             "Stop here to check by ref and ptr.",


### PR DESCRIPTION
Previously the parameter wasn't respected. So we would only run the test with whatever stdlib the `Makefile.rules` deduced.

Confirmed that
```
lldb-dotest -p TestDataFormatterGenericSet.py --category libstdcxx
```
passes on my machine.