### PR TITLE
[mlir][toy] Use `make_early_inc_range` when erasing ops during iteration

### DIFF
--- a/mlir/examples/toy/Ch6/mlir/LowerToLLVM.cpp
+++ b/mlir/examples/toy/Ch6/mlir/LowerToLLVM.cpp
@@ -92,7 +92,7 @@ public:
       auto step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
       auto loop =
           rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
-      for (Operation &nested : *loop.getBody())
+      for (Operation &nested : make_early_inc_range(*loop.getBody()))
         rewriter.eraseOp(&nested);
       loopIvs.push_back(loop.getInductionVar());
 

--- a/mlir/examples/toy/Ch7/mlir/LowerToLLVM.cpp
+++ b/mlir/examples/toy/Ch7/mlir/LowerToLLVM.cpp
@@ -92,7 +92,7 @@ public:
       auto step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
       auto loop =
           rewriter.create<scf::ForOp>(loc, lowerBound, upperBound, step);
-      for (Operation &nested : *loop.getBody())
+      for (Operation &nested : make_early_inc_range(*loop.getBody()))
         rewriter.eraseOp(&nested);
       loopIvs.push_back(loop.getInductionVar());
 


### PR DESCRIPTION
Use `make_early_inc_range` when erasing operations from a block to make sure that the iterator is not invalidated. The previous implementation happened to work on a "normal" dialect conversion because some IR modifications are delayed. It no longer works with a One-Shot Dialect Conversion. The new One-Shot Dialect Conversion API is more similar to the normal rewriter API.
