### PR TITLE
[mlir][transform] Fix Wtype-limits warning

### DIFF
--- a/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
+++ b/mlir/lib/Dialect/Transform/IR/TransformOps.cpp
@@ -799,8 +799,8 @@ transform::ApplyRegisteredPassOp::apply(transform::TransformRewriter &rewriter,
     if (auto paramOperand = dyn_cast<transform::ParamOperandAttr>(valueAttr)) {
       // The corresponding value attribute(s) is/are passed in via a param.
       // Obtain the param-operand via its specified index.
-      size_t dynamicOptionIdx = paramOperand.getIndex().getInt();
-      assert(dynamicOptionIdx < dynamicOptions.size() &&
+      int64_t dynamicOptionIdx = paramOperand.getIndex().getInt();
+      assert(dynamicOptionIdx < static_cast<int64_t>(dynamicOptions.size()) &&
              "the number of ParamOperandAttrs in the options DictionaryAttr"
              "should be the same as the number of options passed as params");
       ArrayRef<Attribute> attrsAssociatedToParam =
@@ -1015,8 +1015,9 @@ LogicalResult transform::ApplyRegisteredPassOp::verify() {
   std::function<LogicalResult(Attribute)> checkOptionValue =
       [&](Attribute valueAttr) -> LogicalResult {
     if (auto paramOperand = dyn_cast<transform::ParamOperandAttr>(valueAttr)) {
-      size_t dynamicOptionIdx = paramOperand.getIndex().getInt();
-      if (dynamicOptionIdx < 0 || dynamicOptionIdx >= dynamicOptions.size())
+      int64_t dynamicOptionIdx = paramOperand.getIndex().getInt();
+      if (dynamicOptionIdx < 0 ||
+          dynamicOptionIdx >= static_cast<int64_t>(dynamicOptions.size()))
         return emitOpError()
                << "dynamic option index " << dynamicOptionIdx
                << " is out of bounds for the number of dynamic options: "


### PR DESCRIPTION
```
warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
```
`size_t` is unsigned and always non-negative, whereas `getInt()` returns a signless `int64_t`. To ensure type compatibility and eliminate the warning, `dynamicOptionIdx` should be changed to `int64_t`.