### PR TITLE
[llvm][SandBoxIR] Fix Windows+clang compiler warning

### DIFF
--- a/llvm/include/llvm/SandboxIR/Value.h
+++ b/llvm/include/llvm/SandboxIR/Value.h
@@ -33,6 +33,7 @@ class IntrinsicInst;
 class Operator;
 class OverflowingBinaryOperator;
 class FPMathOperator;
+class Region;
 
 /// Iterator for the `Use` edges of a Value's users.
 /// \Returns a `Use` when dereferenced.


### PR DESCRIPTION
C:\Users\tcwg\llvm-worker\lldb-aarch64-windows\llvm-project\llvm\include\llvm/SandboxIR/Value.h(172,16): warning: unqualified friend declaration referring to type outside of the nearest enclosing namespace is a Microsoft extension; add a nested name specifier [-Wmicrosoft-unqualified-friend]

Clang suggests adding ::llvm::, but:
* Region is in ::llvm::sandboxir
* Region is not defined at this point

So forward declare it.