### PR TITLE
[mlir][TosaToLinalg] Ensure valid insertion pointer after op erasure

### DIFF
--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
@@ -815,6 +815,7 @@ public:
         ValueRange{paddedInput, fakeWindowDims}, filledEmptyTensor, strideAttr,
         dilationAttr);
 
+    rewriter.setInsertionPointAfter(op);
     rewriter.replaceOp(op, resultOp);
 
     // NaN propagation has no meaning for non floating point types.


### PR DESCRIPTION
Erasing/replacing an op, which is also the current insertion point, invalidates the insertion point. Explicitly set the insertion point, so that subsequent op insertions do not crash after the One-Shot Dialect Conversion refactoring. (`ConversionPatternRewriter` will start behaving more like a "normal" rewriter.)