### PR TITLE
[lld][WebAssembly] Abide by configured page size for memory imports

### DIFF
--- a/lld/test/wasm/page-size.s
+++ b/lld/test/wasm/page-size.s
@@ -41,3 +41,21 @@ foo:
 # CHECK-DEFAULT-DIS:      <_start>:
 # CHECK-DEFAULT-DIS:          i32.const 65536
 # CHECK-DEFAULT-DIS-NEXT:     end
+
+# RUN: wasm-ld -no-gc-sections -o %t.custom-import.wasm %t.o --page-size=1 --import-memory
+# RUN: obj2yaml %t.custom-import.wasm | FileCheck %s --check-prefix=CHECK-CUSTOM-IMPORT
+
+# CHECK-CUSTOM-IMPORT:      Imports:
+# CHECK-CUSTOM-IMPORT-NEXT:   - Module:          env
+# CHECK-CUSTOM-IMPORT-NEXT:     Field:           memory
+# CHECK-CUSTOM-IMPORT-NEXT:     Kind:            MEMORY
+# CHECK-CUSTOM-IMPORT-NEXT:     Memory:
+# CHECK-CUSTOM-IMPORT-NEXT:       Flags:           [ HAS_PAGE_SIZE ]
+# CHECK-CUSTOM-IMPORT-NEXT:       Minimum:         0x10410
+# CHECK-CUSTOM-IMPORT-NEXT:       PageSize:        0x1
+
+# RUN: llvm-objdump --disassemble-symbols=_start %t.custom-import.wasm | FileCheck %s --check-prefix=CHECK-CUSTOM-IMPORT-DIS
+
+# CHECK-CUSTOM-IMPORT-DIS:      <_start>:
+# CHECK-CUSTOM-IMPORT-DIS:          i32.const 1
+# CHECK-CUSTOM-IMPORT-DIS-NEXT:     end

--- a/lld/wasm/SyntheticSections.cpp
+++ b/lld/wasm/SyntheticSections.cpp
@@ -258,6 +258,10 @@ void ImportSection::writeBody() {
       import.Memory.Flags |= WASM_LIMITS_FLAG_IS_SHARED;
     if (is64)
       import.Memory.Flags |= WASM_LIMITS_FLAG_IS_64;
+    if (ctx.arg.pageSize != WasmDefaultPageSize) {
+      import.Memory.Flags |= WASM_LIMITS_FLAG_HAS_PAGE_SIZE;
+      import.Memory.PageSize = ctx.arg.pageSize;
+    }
     writeImport(os, import);
   }
 


### PR DESCRIPTION
This was an oversight in https://github.com/llvm/llvm-project/pull/128942 where I forgot to add the configured page size to the `WasmLimits` in the import we emit when importing a memory.

Fixes https://github.com/llvm/llvm-project/issues/146713

r? @sbc100 