### PR TITLE
[RISCV][VLOPT] Add support for vfrec7.v

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -1103,6 +1103,8 @@ static bool isSupportedInstr(const MachineInstr &MI) {
   case RISCV::VFSQRT_V:
   // Vector Floating-Point Reciprocal Square-Root Estimate Instruction
   case RISCV::VFRSQRT7_V:
+  // Vector Floating-Point Reciprocal Estimate Instruction
+  case RISCV::VFREC7_V:
   // Vector Floating-Point MIN/MAX Instructions
   case RISCV::VFMIN_VF:
   case RISCV::VFMIN_VV:

--- a/llvm/test/CodeGen/RISCV/rvv/vl-opt-instrs.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/vl-opt-instrs.ll
@@ -5338,12 +5338,11 @@ define <vscale x 4 x double> @vfrec7(<vscale x 4 x float> %a) {
 ;
 ; VLOPT-LABEL: vfrec7:
 ; VLOPT:       # %bb.0:
-; VLOPT-NEXT:    vsetivli zero, 7, e32, m2, ta, ma
+; VLOPT-NEXT:    vsetivli zero, 6, e32, m2, ta, ma
 ; VLOPT-NEXT:    vmv2r.v v12, v8
 ; VLOPT-NEXT:    fsrmi a0, 0
 ; VLOPT-NEXT:    vfrec7.v v14, v8
 ; VLOPT-NEXT:    fsrm a0
-; VLOPT-NEXT:    vsetivli zero, 6, e32, m2, ta, ma
 ; VLOPT-NEXT:    vfwmacc.vv v8, v12, v14
 ; VLOPT-NEXT:    ret
   %1 = call <vscale x 4 x float> @llvm.riscv.vfrec7.nxv4f32(<vscale x 4 x float> poison, <vscale x 4 x float> %a, iXLen 0, iXLen 7)


### PR DESCRIPTION
Add support for the vfrec7.v instruction in the RISC-V VLOptimizer. 

This patch was motivated by the list of missing instructions shared on PR #146692.
