### PR TITLE
[AArch64] Do not promote scalable constants to global variables

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PromoteConstant.cpp
@@ -345,6 +345,10 @@ static bool shouldConvertImpl(const Constant *Cst) {
   if (Cst->isZeroValue())
     return false;
 
+  // Globals cannot be or contain scalable vectors.
+  if (Cst->getType()->isScalableTy())
+    return false;
+
   if (Stress)
     return true;
 

--- a/llvm/test/CodeGen/AArch64/no-promote-scalabale-const-to-global.ll
+++ b/llvm/test/CodeGen/AArch64/no-promote-scalabale-const-to-global.ll
@@ -1,0 +1,20 @@
+; RUN: llc -mtriple=aarch64 -mattr=+sve -stop-after=aarch64-promote-const < %s | FileCheck %s
+
+; Test that the constant inside the `phi` is not promoted to a global
+; CHECK-NOT: _PromotedConst
+define void @f(i1 %c, ptr %p, ptr %q) {
+entry:
+  br i1 %c, label %if.then, label %if.else
+
+if.then:
+  %u = load [2 x <vscale x 4 x float> ], ptr %p
+  br label %exit
+
+if.else:
+  br label %exit
+
+exit:
+  %v = phi [2 x <vscale x 4 x float> ]  [ %u, %if.then], [[<vscale x 4 x float> zeroinitializer, <vscale x 4 x float> poison], %if.else]
+  store [2 x <vscale x 4 x float>] %v, ptr %q
+  ret void
+}


### PR DESCRIPTION
Following https://github.com/llvm/llvm-project/commit/878d3594ed74cd1153bc5cba2cb7a449702cdf34
IREE/MLIR started generating values like
```
    [<vscale x 4 x float> zeroinitializer, <vscale x 4 x float> poison]
```
which then LLVM promoted to global variables in `AArch64PromoteConstant` pass.
This patch prevents it by explicitly checking the type of the promotion candidate.
