### PR TITLE
[mlir] List lead maintainers for MLIR

### DIFF
--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -1,0 +1,30 @@
+# MLIR Maintainers
+
+This file is a list of the [maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for MLIR.
+
+The following people are the active maintainers for the project.
+For the sake of simplicity, responsibility areas are subdivided into broad categories, which are further
+subdivided into individual components, such as dialects.
+Please reach out to them for code reviews, questions about their area of expertise, or other assistance.
+
+## Lead Maintainers
+
+Lead Maintainers are responsible for the entirety of the MLIR project, in particular for components not
+covered by anyone else, and can also serve as escalation contacts for arbitration.
+
+- Alex Zinenko \
+  ftynse@gmail.com (email),
+  [@ftynse](https://github.com/ftynse) (GitHub),
+  ftynse (Discourse)
+- Renato Golin \
+  rengolin@gmail.com (email),
+  [@rengolin](https://github.com/rengolin) (GitHub),
+  rengolin (Discourse)
+- Jacques Pienaar \
+  jpienaar@google.com (email),
+  [@jpienaar](https://github.com/jpienaar) (GitHub),
+  jpienaar (Discourse)
+- Matthias Springer \
+  me@m-sp.org (email),
+  [@matthias-springer](https://github.com/matthias-springer) (GitHub),
+  matthias-springer (Discourse)


### PR DESCRIPTION
Historically, MLIR project has not had a public list of maintainers, unlike the rest of the LLVM project and at odds with the developer policy. The MLIR Area Team initiated a process for (self-)nomination of maintainers in order to remedy this, and is now proposing to establish this list.

Following the self-nominations, discussions in the MLIR Area Team and the LLVM Project Council, this is a proposed list of lead maintainers for the MLIR Project.

The full list of maintainers expected for MLIR components and nomination criteria are available at https://discourse.llvm.org/t/mlir-project-maintainers/87189. These will be listed in the repo progressively.