### PR TITLE
[NFC][DWARF][DebugInfo] Consolidate NextCUOffset checks

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugInfoEntry.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugInfoEntry.cpp
@@ -30,7 +30,7 @@ bool DWARFDebugInfoEntry::extractFast(const DWARFUnit &U, uint64_t *OffsetPtr,
                           "DWARF unit from offset 0x%8.8" PRIx64 " incl. "
                           "to offset 0x%8.8" PRIx64 " excl. "
                           "tries to read DIEs at offset 0x%8.8" PRIx64,
-                          U.getOffset(), U.getNextUnitOffset(), *OffsetPtr));
+                          U.getOffset(), UEndOffset, *OffsetPtr));
     return false;
   }
   assert(DebugInfoData.isValidOffset(UEndOffset - 1));

--- a/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFUnit.cpp
@@ -294,9 +294,9 @@ Error DWARFUnitHeader::extract(DWARFContext &Context,
   // Header fields all parsed, capture the size of this unit header.
   assert(*offset_ptr - Offset <= 255 && "unexpected header size");
   Size = uint8_t(*offset_ptr - Offset);
-  uint64_t NextCUOffset = Offset + getUnitLengthFieldByteSize() + getLength();
+  uint64_t NextCUOffset = getNextUnitOffset();
 
-  if (!debug_info.isValidOffset(getNextUnitOffset() - 1))
+  if (!debug_info.isValidOffset(NextCUOffset - 1))
     return createStringError(errc::invalid_argument,
                              "DWARF unit from offset 0x%8.8" PRIx64 " incl. "
                              "to offset  0x%8.8" PRIx64 " excl. "


### PR DESCRIPTION
Some error checking code involving `getNextUnitOffset()` looks a bit strange and what is tested may not be equal to what is reported if any changes are made to `getNextUnitOffset()`.

Change this so what is tested is consistent with what is reported. Also remove unnecessary calls when the value is already available in the function.