### PR TITLE
[Clang][NFC] Avoid copies by using std::move

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -6404,7 +6404,7 @@ public:
   SpirvOperand() : Kind(Invalid), ResultType(), Value() {}
 
   SpirvOperand(SpirvOperandKind Kind, QualType ResultType, llvm::APInt Value)
-      : Kind(Kind), ResultType(ResultType), Value(Value) {}
+      : Kind(Kind), ResultType(ResultType), Value(std::move(Value)) {}
 
   SpirvOperand(const SpirvOperand &Other) { *this = Other; }
   ~SpirvOperand() {}
@@ -6438,11 +6438,11 @@ public:
   }
 
   static SpirvOperand createConstant(QualType ResultType, llvm::APInt Val) {
-    return SpirvOperand(ConstantId, ResultType, Val);
+    return SpirvOperand(ConstantId, ResultType, std::move(Val));
   }
 
   static SpirvOperand createLiteral(llvm::APInt Val) {
-    return SpirvOperand(Literal, QualType(), Val);
+    return SpirvOperand(Literal, QualType(), std::move(Val));
   }
 
   static SpirvOperand createType(QualType T) {

--- a/clang/lib/CodeGen/Targets/SPIR.cpp
+++ b/clang/lib/CodeGen/Targets/SPIR.cpp
@@ -421,14 +421,12 @@ static llvm::Type *getInlineSpirvType(CodeGenModule &CGM,
     case SpirvOperandKind::ConstantId: {
       llvm::Type *IntegralType =
           CGM.getTypes().ConvertType(Operand.getResultType());
-      llvm::APInt Value = Operand.getValue();
 
-      Result = getInlineSpirvConstant(CGM, IntegralType, Value);
+      Result = getInlineSpirvConstant(CGM, IntegralType, Operand.getValue());
       break;
     }
     case SpirvOperandKind::Literal: {
-      llvm::APInt Value = Operand.getValue();
-      Result = getInlineSpirvConstant(CGM, nullptr, Value);
+      Result = getInlineSpirvConstant(CGM, nullptr, Operand.getValue());
       break;
     }
     case SpirvOperandKind::TypeId: {


### PR DESCRIPTION
Static analysis flagged this code as using copies when we could use move instead. I used a temporary in some cases instead of an explicit move.