### PR TITLE
[clang-doc] add namespace references to VarInfo

### DIFF
--- a/clang-tools-extra/clang-doc/BitcodeReader.cpp
+++ b/clang-tools-extra/clang-doc/BitcodeReader.cpp
@@ -569,6 +569,17 @@ static llvm::Error addReference(T I, Reference &&R, FieldId F) {
                                  "invalid type cannot contain Reference");
 }
 
+template <> llvm::Error addReference(VarInfo *I, Reference &&R, FieldId F) {
+  switch (F) {
+  case FieldId::F_namespace:
+    I->Namespace.emplace_back(std::move(R));
+    return llvm::Error::success();
+  default:
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "VarInfo cannot contain this Reference");
+  }
+}
+
 template <> llvm::Error addReference(TypeInfo *I, Reference &&R, FieldId F) {
   switch (F) {
   case FieldId::F_type:

--- a/clang-tools-extra/test/clang-doc/json/nested-namespace.cpp
+++ b/clang-tools-extra/test/clang-doc/json/nested-namespace.cpp
@@ -1,0 +1,36 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=json --executor=standalone %s
+// RUN: FileCheck %s < %t/nested/index.json --check-prefix=NESTED
+// RUN: FileCheck %s < %t/nested/inner/index.json --check-prefix=INNER
+
+namespace nested {
+  int Global;
+  namespace inner {
+    int InnerGlobal;
+  } // namespace inner
+} // namespace nested
+
+// NESTED:       "Variables": [
+// NESTED-NEXT:    {
+// NESTED-NEXT:      "IsStatic": false,
+// NESTED-NEXT:      "Location": {
+// NESTED-NEXT:        "Filename": "{{.*}}nested-namespace.cpp",
+// NESTED-NEXT:        "LineNumber": 7
+// NESTED-NEXT:      },
+// NESTED-NEXT:      "Name": "Global",
+// NESTED-NEXT:      "Namespace": [
+// NESTED-NEXT:        "nested"
+// NESTED-NEXT:      ],
+
+// INNER:       "Variables": [
+// INNER-NEXT:    {
+// INNER-NEXT:      "IsStatic": false,
+// INNER-NEXT:      "Location": {
+// INNER-NEXT:        "Filename": "{{.*}}nested-namespace.cpp",
+// INNER-NEXT:        "LineNumber": 9
+// INNER-NEXT:      },
+// INNER-NEXT:      "Name": "InnerGlobal",
+// INNER-NEXT:      "Namespace": [
+// INNER-NEXT:        "inner",
+// INNER-NEXT:        "nested"
+// INNER-NEXT:      ],


### PR DESCRIPTION
VarInfo was missing its addReference specialization. This causes errors
when a VarInfo is inside a namespace that isn't the global namespace.