### PR TITLE
[ValueTracking] Have sub and xor in KnownNonZero take the same exact path

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -3036,14 +3036,12 @@ static bool isKnownNonZeroFromOperator(const Operator *I,
         return isKnownNonZero(TI->getOperand(0), DemandedElts, Q, Depth);
     break;
 
+  // Iff x - y != 0, then x ^ y != 0
+  // Therefore we can do the same exact checks
+  case Instruction::Xor:
   case Instruction::Sub:
     return isNonZeroSub(DemandedElts, Q, BitWidth, I->getOperand(0),
                         I->getOperand(1), Depth);
-  case Instruction::Xor:
-    // (X ^ (X != 0)) is non zero
-    if (matchOpWithOpEqZero(I->getOperand(0), I->getOperand(1)))
-      return true;
-    break;
   case Instruction::Or:
     // (X | (X != 0)) is non zero
     if (matchOpWithOpEqZero(I->getOperand(0), I->getOperand(1)))

--- a/llvm/test/Transforms/InstCombine/ctpop-cttz.ll
+++ b/llvm/test/Transforms/InstCombine/ctpop-cttz.ll
@@ -127,3 +127,24 @@ define <2 x i32> @ctpop3v_poison(<2 x i32> %0) {
   %5 = tail call <2 x i32> @llvm.ctpop.v2i32(<2 x i32> %4)
   ret <2 x i32> %5
 }
+
+define i32 @ctpop_xor(i32 %x, i32 %y) {
+; CHECK-LABEL: @ctpop_xor(
+; CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp eq i32 [[X:%.*]], [[Y:%.*]]
+; CHECK-NEXT:    br i1 [[CMP_NOT]], label [[FALSE:%.*]], label [[TRUE:%.*]]
+; CHECK:       true:
+; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[X]], [[Y]]
+; CHECK-NEXT:    [[RET:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[XOR]])
+; CHECK-NEXT:    ret i32 [[RET]]
+; CHECK:       false:
+; CHECK-NEXT:    ret i32 0
+;
+  %cmp = icmp ne i32 %x, %y
+  br i1 %cmp, label %true, label %false
+true:
+  %xor = xor i32 %x, %y
+  %ret = call i32 @llvm.ctpop.i32(i32 %xor)
+  ret i32 %ret
+false:
+  ret i32 0
+}

--- a/llvm/test/Transforms/InstCombine/ctpop-cttz.ll
+++ b/llvm/test/Transforms/InstCombine/ctpop-cttz.ll
@@ -134,7 +134,7 @@ define i32 @ctpop_xor(i32 %x, i32 %y) {
 ; CHECK-NEXT:    br i1 [[CMP_NOT]], label [[FALSE:%.*]], label [[TRUE:%.*]]
 ; CHECK:       true:
 ; CHECK-NEXT:    [[XOR:%.*]] = xor i32 [[X]], [[Y]]
-; CHECK-NEXT:    [[RET:%.*]] = call range(i32 0, 33) i32 @llvm.ctpop.i32(i32 [[XOR]])
+; CHECK-NEXT:    [[RET:%.*]] = call range(i32 1, 33) i32 @llvm.ctpop.i32(i32 [[XOR]])
 ; CHECK-NEXT:    ret i32 [[RET]]
 ; CHECK:       false:
 ; CHECK-NEXT:    ret i32 0


### PR DESCRIPTION
If x - y == 0, then x ^ y == 0. Therefore, we can do the exact same checks.

https://alive2.llvm.org/ce/z/MtBRoj