### PR TITLE
[mlir] add optional type functor to call and function interfaces

### DIFF
--- a/mlir/include/mlir/Interfaces/CallInterfaces.h
+++ b/mlir/include/mlir/Interfaces/CallInterfaces.h
@@ -37,6 +37,8 @@ Operation *resolveCallable(CallOpInterface call,
                            SymbolTableCollection *symbolTable = nullptr);
 
 /// Parse a function or call result list.
+/// You can override the default type parsing behavior using the typeParser
+/// parameter.
 ///
 ///   function-result-list ::= function-result-list-parens
 ///                          | non-function-type
@@ -45,31 +47,39 @@ Operation *resolveCallable(CallOpInterface call,
 ///   function-result-list-no-parens ::= function-result (`,` function-result)*
 ///   function-result ::= type attribute-dict?
 ///
-ParseResult
-parseFunctionResultList(OpAsmParser &parser, SmallVectorImpl<Type> &resultTypes,
-                        SmallVectorImpl<DictionaryAttr> &resultAttrs);
+ParseResult parseFunctionResultList(
+    OpAsmParser &parser, SmallVectorImpl<Type> &resultTypes,
+    SmallVectorImpl<DictionaryAttr> &resultAttrs,
+    function_ref<ParseResult(AsmParser &, Type &)> typeParser = {});
 
 /// Parses a function signature using `parser`. This does not deal with function
 /// signatures containing SSA region arguments (to parse these signatures, use
 /// function_interface_impl::parseFunctionSignature). When
 /// `mustParseEmptyResult`, `-> ()` is expected when there is no result type.
+/// You can override the default type parsing behavior using the typeParser
+/// parameter.
+///
 ///
 ///   no-ssa-function-signature ::= `(` no-ssa-function-arg-list `)`
 ///                               -> function-result-list
 ///   no-ssa-function-arg-list  ::= no-ssa-function-arg
 ///                               (`,` no-ssa-function-arg)*
 ///   no-ssa-function-arg       ::= type attribute-dict?
-ParseResult parseFunctionSignature(OpAsmParser &parser,
-                                   SmallVectorImpl<Type> &argTypes,
-                                   SmallVectorImpl<DictionaryAttr> &argAttrs,
-                                   SmallVectorImpl<Type> &resultTypes,
-                                   SmallVectorImpl<DictionaryAttr> &resultAttrs,
-                                   bool mustParseEmptyResult = true);
+ParseResult parseFunctionSignature(
+    OpAsmParser &parser, SmallVectorImpl<Type> &argTypes,
+    SmallVectorImpl<DictionaryAttr> &argAttrs,
+    SmallVectorImpl<Type> &resultTypes,
+    SmallVectorImpl<DictionaryAttr> &resultAttrs,
+    bool mustParseEmptyResult = true,
+    function_ref<ParseResult(AsmParser &, Type &)> typeParser = {});
 
 /// Print a function signature for a call or callable operation. If a body
 /// region is provided, the SSA arguments are printed in the signature. When
 /// `printEmptyResult` is false, `-> function-result-list` is omitted when
 /// `resultTypes` is empty.
+/// You can override the default type printing behavior using the typePrinter
+/// parameter.
+///
 ///
 ///   function-signature     ::= ssa-function-signature
 ///                            | no-ssa-function-signature
@@ -77,11 +87,11 @@ ParseResult parseFunctionSignature(OpAsmParser &parser,
 ///                            -> function-result-list
 ///   ssa-function-arg-list  ::= ssa-function-arg (`,` ssa-function-arg)*
 ///   ssa-function-arg       ::= `%`name `:` type attribute-dict?
-void printFunctionSignature(OpAsmPrinter &p, TypeRange argTypes,
-                            ArrayAttr argAttrs, bool isVariadic,
-                            TypeRange resultTypes, ArrayAttr resultAttrs,
-                            Region *body = nullptr,
-                            bool printEmptyResult = true);
+void printFunctionSignature(
+    OpAsmPrinter &p, TypeRange argTypes, ArrayAttr argAttrs, bool isVariadic,
+    TypeRange resultTypes, ArrayAttr resultAttrs, Region *body = nullptr,
+    bool printEmptyResult = true,
+    function_ref<void(AsmPrinter &, Type)> typePrinter = {});
 
 /// Adds argument and result attributes, provided as `argAttrs` and
 /// `resultAttrs` arguments, to the list of operation attributes in `result`.

--- a/mlir/test/Interfaces/FunctionOpInterface/custom-type-parse-and-print.mlir
+++ b/mlir/test/Interfaces/FunctionOpInterface/custom-type-parse-and-print.mlir
@@ -1,0 +1,26 @@
+// RUN: mlir-opt %s | FileCheck %s
+
+//      CHECK: test.custom_type_format_func @single_arg_no_return(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: type:f32) {
+// CHECK-NEXT: }
+test.custom_type_format_func @single_arg_no_return(%arg0 : type:f32) {}
+
+//      CHECK: test.custom_type_format_func @multiple_arg_multiple_return(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: type:f32
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: type:f32)
+// CHECK-SAME: -> (type:f32, type:f32) {
+// CHECK-NEXT: }
+test.custom_type_format_func @multiple_arg_multiple_return(
+    %arg0 : type:f32, %arg1 : type:f32)
+    -> (type:f32, type:f32) {}
+
+//      CHECK: test.custom_type_format_func @no_block
+// CHECK-SAME: (type:f32, type:f32)
+// CHECK-SAME: -> (type:f32, type:f32)
+test.custom_type_format_func @no_block(%arg0 : type:f32, %arg1 : type:f32)
+    -> (type:f32, type:f32)
+
+//      CHECK: test.custom_type_format_func @one_return
+// CHECK-SAME: -> type:f32
+test.custom_type_format_func @one_return()
+    -> type:f32

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -692,6 +692,42 @@ def FoldToCallOp : TEST_Op<"fold_to_call_op"> {
   let hasCanonicalizer = 1;
 }
 
+def CustomTypeFormatFuncOp
+    : TEST_Op<"custom_type_format_func", [FunctionOpInterface, NoTerminator]> {
+
+  let arguments = (ins TypeAttrOf<FunctionType>:$function_type,
+      OptionalAttr<DictArrayAttr>:$arg_attrs,
+      OptionalAttr<DictArrayAttr>:$res_attrs);
+
+  let regions = (region AnyRegion:$body);
+  let extraClassDeclaration = [{
+    //===------------------------------------------------------------------===//
+    // FunctionOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Returns the region on the current operation that is callable. This may
+    /// return null in the case of an external callable object, e.g. an external
+    /// function.
+    ::mlir::Region *getCallableRegion() {
+      return nullptr;
+    }
+
+    /// Returns the argument types of this function.
+    ::mlir::ArrayRef<::mlir::Type> getArgumentTypes() {
+      return getFunctionType().getInputs();
+    }
+
+    /// Returns the result types of this function.
+    ::mlir::ArrayRef<::mlir::Type> getResultTypes() {
+      return getFunctionType().getResults();
+    }
+
+    /// Returns the number of results of this function
+    unsigned getNumResults() {return getResultTypes().size();}
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+}
 //===----------------------------------------------------------------------===//
 // Test Traits
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
adds type parsing functors to `call_interface_impl` and `function_interface_impl`