### PR TITLE
[flang] Fix Windows bot failure caused by #146667

### DIFF
--- a/flang/test/Lower/OpenMP/parallel-reduction-array.f90
+++ b/flang/test/Lower/OpenMP/parallel-reduction-array.f90
@@ -2,7 +2,8 @@
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s --check-prefix=CPU
 
 ! RUN: bbc -emit-hlfir -fopenmp -fopenmp-is-target-device -fopenmp-is-gpu -o - %s 2>&1 | FileCheck %s --check-prefix=GPU
-! RUN: %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir -fopenmp -fopenmp-is-target-device -o - %s 2>&1 | FileCheck %s --check-prefix=GPU
+! RUN: %if amdgpu-registered-target %{ %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir -fopenmp -fopenmp-is-target-device -o - %s 2>&1 | \
+! RUN: FileCheck %s --check-prefix=GPU %}
 
 program reduce
 integer, dimension(3) :: i = 0


### PR DESCRIPTION
Fixes a Windows bot failure caused by #146667. Just run the test if an AMD GPU target is registered. Hopefully, the bot now passes.

Test coverage is not reduced since `bbc` is still run on all platforms.