### PR TITLE
[llvm][release] Add links to automatically built packages on release page

### DIFF
--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -58,7 +58,7 @@ Note: Immediately after a release some of these links may not be valid yet.
 * [x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-X64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-X64.tar.xz.jsonl))
 * [Arm64](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-ARM64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-ARM64.tar.xz.jsonl))
 
-**Mac:**
+**macOS:**
 * [Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-ARM64.tar.xz) (ARM64) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-ARM64.tar.xz.jsonl))
 * [Intel](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-X64.tar.xz) (x86-64) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-X64.tar.xz.jsonl))
 

--- a/llvm/utils/release/github-upload-release.py
+++ b/llvm/utils/release/github-upload-release.py
@@ -45,9 +45,24 @@ def create_release(repo, release, tag=None, name=None, message=None):
         # Note that these lines are not length limited because if we do so, GitHub
         # assumes that should be how it is laid out on the page. We want GitHub to
         # do the reflowing for us instead.
+        #
+        # In the first section, only links to automatically built files are
+        # included because we know the links will become valid.
         message = dedent(
             """\
-LLVM {release} Release
+## LLVM {release} Release
+
+Note: Immediately after a release some of these links may not be valid yet.
+
+**Linux:**
+* [x86_64](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-X64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-X64.tar.xz.jsonl))
+* [Arm64](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-ARM64.tar.xz) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-Linux-ARM64.tar.xz.jsonl))
+
+**Mac:**
+* [Apple Silicon](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-ARM64.tar.xz) (ARM64) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-ARM64.tar.xz.jsonl))
+* [Intel](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-X64.tar.xz) (x86-64) ([signature](https://github.com/llvm/llvm-project/releases/download/llvmorg-{release}/LLVM-{release}-macOS-X64.tar.xz.jsonl))
+
+For Windows, and any other variants of platform and architecture, check the full list of release packages at the bottom of this release page.
 
 ## Package Types
 


### PR DESCRIPTION
This adds links to the release packages that are automatically built using GitHub, so that users of those platforms can find them more easily.

The approach taken:
* "LLVM x.y.z Release" becomes the title for this links section.
* No hand built files are linked to because we can't be sure when or if they will appear. It's better that users check the full file list if they need those.
* This means no Windows links, but I've specifically mentioned Windows just below the links to mitigate this.
* I have tried to use the vendor names for the architectures, that casual users would recognise.
* Their signature file is linked as well. I expect most will ignore this but better to show it to remind people it exists.
* I called it "signature" as a generic term to cover the .jsonl and .sig files, but we're not linking to any .sig files yet.

I considered generating this using a lot of templates, but considering the small number of links and how useful it is to see the layout in the Python file, I prefer writing it out.

We could link to all files that *usually*, *eventually* get built, but I'm not sure how misleading that will be for users. So I'm proposing this conservative version for now.