### PR TITLE
[flang] use set_union instead of merge in added DerivedTypeCache

### DIFF
--- a/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
+++ b/flang/lib/Optimizer/Transforms/DebugTypeGenerator.cpp
@@ -303,9 +303,9 @@ void DerivedTypeCache::postComponentVisitUpdate(
     return;
   ActiveLevels oldLevels;
   oldLevels.swap(activeRecursionLevels);
-  std::merge(componentActiveRecursionLevels.begin(),
-             componentActiveRecursionLevels.end(), oldLevels.begin(),
-             oldLevels.end(), std::back_inserter(activeRecursionLevels));
+  std::set_union(componentActiveRecursionLevels.begin(),
+                 componentActiveRecursionLevels.end(), oldLevels.begin(),
+                 oldLevels.end(), std::back_inserter(activeRecursionLevels));
 }
 
 void DerivedTypeCache::finalize(mlir::Type ty, mlir::LLVM::DITypeAttr attr,


### PR DESCRIPTION
When merging the list of recursive reference under two components, duplicates should be removed.
If the recursive reference to parents nodes (referred by depth of the parents node) are [1, 2, 5] and [4, 5], the new list should be [1,2,4,5].

With std::merge, the order was correct but 5 was duplicated use std::set_union instead that removes duplicates.

With this patch Fujitsu tests [0394_0030.f90](https://github.com/fujitsu/compiler-test-suite/blob/0d02267bb98b6bfdf46d1f6bbd92e9781c24356c/Fortran/0394/0394_0030.f90) and [0390_0230.f90](https://github.com/fujitsu/compiler-test-suite/blob/0d02267bb98b6bfdf46d1f6bbd92e9781c24356c/Fortran/0390/0390_0230.f90) finally compile with -g in about 10s. Their compilation was hanging before https://github.com/llvm/llvm-project/pull/146543, and they were now hitting an error "LLVM ERROR: SmallVector unable to grow" which is fixed by this patch.