### PR TITLE
[BranchFolding] Add an optional target hook to skip branch folding when it's unsafe

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -2335,6 +2335,12 @@ public:
     llvm_unreachable("unknown number of operands necessary");
   }
 
+  /// Return false if \p MBB whose any predecessor is not analyzable is not safe
+  /// to do \p BranchFolding.
+  virtual bool isMBBSafeToBranchFolding(const MachineBasicBlock &MBB) const {
+    return true;
+  }
+
 private:
   mutable std::unique_ptr<MIRFormatter> Formatter;
   unsigned CallFrameSetupOpcode, CallFrameDestroyOpcode;

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -1346,6 +1346,19 @@ static void salvageDebugInfoFromEmptyBlock(const TargetInstrInfo *TII,
       copyDebugInfoToPredecessor(TII, MBB, *PredBB);
 }
 
+static bool areAllPredsAnalyzable(const llvm::TargetInstrInfo *TII,
+                                  MachineBasicBlock *MBB) {
+  for (auto itr = MBB->pred_begin(); itr != MBB->pred_end(); ++itr) {
+    MachineBasicBlock *CurTBB = nullptr, *CurFBB = nullptr;
+    SmallVector<MachineOperand, 4> CurCond;
+    bool CantAnalyzable = TII->analyzeBranch(**itr, CurTBB, CurFBB, CurCond,
+                                             /*AllowModify*/ false);
+    if (CantAnalyzable)
+      return false;
+  }
+  return true;
+}
+
 bool BranchFolder::OptimizeBlock(MachineBasicBlock *MBB) {
   bool MadeChange = false;
   MachineFunction &MF = *MBB->getParent();
@@ -1389,6 +1402,9 @@ ReoptimizeBlock:
       // TODO: Is it ever worth rewriting predecessors which don't already
       // jump to a landing pad, and so can safely jump to the fallthrough?
     } else if (MBB->isSuccessor(&*FallThrough)) {
+      if (!TII->isMBBSafeToBranchFolding(*MBB) &&
+          !areAllPredsAnalyzable(TII, MBB))
+        return MadeChange;
       // Rewrite all predecessors of the old block to go to the fallthrough
       // instead.
       while (!MBB->pred_empty()) {


### PR DESCRIPTION
Assume the indirect branch implementation is as follows:

```
mov r0.lo BB0.label_lo
mov r0.hi BB0.label_hi
add r2 r1 r0
jr r2
```

Here, the base address and offset are stored in `r0`  and `r1` respectively, with `r2 = r1 + r0` as the jump target. Analyzing the target of the indirect branch `jr`  is often challenging, particularly when register `r2` is spilled.

When basic block `BB0` is empty, `BranchFolding` may optimize it, causing a dangling label. To address this, the target can override  `isMBBSafeToBranchFolding`  and return  `false`.
 
This issue was found in an out-of-tree target, hence the lack of testcase in this commit.