### PR TITLE
[VPlan] Iterate over header phis to determine FORs that need EVL fixup. NFCI

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2212,7 +2212,7 @@ static void transformRecipestoEVLRecipes(VPlan &Plan, VPValue &EVL) {
     assert(!Plan.isUnrolled() && "When unrolled splices might not use "
                                  "VPFirstOrederRecurrencePHIRecipe!");
 
-    for (VPUser *User : PhiR.getVPSingleValue()->users()) {
+    for (VPUser *User : FOR->users()) {
       auto *R = cast<VPRecipeBase>(User);
       using namespace VPlanPatternMatch;
       VPValue *V1, *V2;

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.cpp
@@ -2189,7 +2189,8 @@ static void transformRecipestoEVLRecipes(VPlan &Plan, VPValue &EVL) {
 
   // When unrolling splices may not use VPFirstOrderRecurrencePHIRecipes, so the
   // below transformation will need to be fixed.
-  assert(!Plan.isUnrolled() && "Unrolling not supported with EVL tail folding.");
+  assert(!Plan.isUnrolled() &&
+         "Unrolling not supported with EVL tail folding.");
 
   // Replace FirstOrderRecurrenceSplice with experimental_vp_splice intrinsics.
   VPValue *PrevEVL = nullptr;


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/146672#discussion_r2183176231

We can avoid iterating over every recipe to pick out splices that need fixed up given that for now, all splices must use a VPFirstOrderRecurrencePHIRecipe.

An assertion was added since this doesn't hold for unrolled loops:

    vector.body:
      EMIT-SCALAR vp<%index> = phi [ ir<0>, vector.ph ], [ vp<%index.next>, vector.body ]
      FIRST-ORDER-RECURRENCE-PHI ir<%10> = phi ir<%pre_load>, ir<%11>.1
      CLONE ir<%indvars.iv.next> = add nuw nsw vp<%index>, ir<1>
      CLONE ir<%arrayidx32> = getelementptr inbounds ir<%a>, ir<%indvars.iv.next>
      vp<%3> = vector-pointer ir<%arrayidx32>
      vp<%4> = vector-pointer ir<%arrayidx32>, ir<1>
      WIDEN ir<%11> = load vp<%3>
      WIDEN ir<%11>.1 = load vp<%4>
      EMIT vp<%5> = first-order splice ir<%10>, ir<%11>
      EMIT vp<%6> = first-order splice ir<%11>, ir<%11>.1 <-- doesn't use phi

Or sometimes we splices in loops without a FOR phi at all:

    vector.body:
      EMIT-SCALAR vp<%index> = phi [ ir<0>, vector.ph ], [ vp<%index.next>, vector.body ]
      CLONE ir<%gep.a> = getelementptr ir<%a>, vp<%index>
      vp<%3> = vector-pointer ir<%gep.a>
      vp<%4> = vector-pointer ir<%gep.a>, ir<1>
      WIDEN ir<%load.a> = load vp<%3>
      WIDEN ir<%load.a>.1 = load vp<%4>
      WIDEN-CAST ir<%ext.a> = zext ir<%load.a> to i32
      WIDEN-CAST ir<%ext.a>.1 = zext ir<%load.a>.1 to i32
      CLONE ir<%gep.b> = getelementptr ir<%b>, vp<%index>
      vp<%5> = vector-pointer ir<%gep.b>
      vp<%6> = vector-pointer ir<%gep.b>, ir<1>
      WIDEN ir<%load.b> = load vp<%5>
      WIDEN ir<%load.b>.1 = load vp<%6>
      WIDEN-CAST ir<%ext.b> = zext ir<%load.b> to i32
      WIDEN-CAST ir<%ext.b>.1 = zext ir<%load.b>.1 to i32
      WIDEN ir<%mul> = mul ir<%ext.b>, ir<%ext.a>
      WIDEN ir<%mul>.1 = mul ir<%ext.b>.1, ir<%ext.a>.1
      EMIT vp<%7> = first-order splice ir<%mul>, ir<%mul>.1

A test was added for second order recurrences just to double check that they indeed also have their own FOR phi.
