### PR TITLE
[lldb][Formatters] Fix weak reference count for std::shared_ptr/std::weak_ptr

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -177,6 +177,9 @@ bool lldb_private::formatters::LibcxxSmartPointerSummaryProvider(
     if (!success)
       return false;
 
+    // std::shared_ptr releases the underlying resource when the
+    // __shared_owners_ count hits -1. So `__shared_owners_ == 0` indicates 1
+    // owner. Hence add +1 here.
     stream.Printf(" strong=%" PRIu64, count + 1);
   }
 
@@ -187,7 +190,9 @@ bool lldb_private::formatters::LibcxxSmartPointerSummaryProvider(
     if (!success)
       return false;
 
-    stream.Printf(" weak=%" PRIu64, count + 1);
+    // Unlike __shared_owners_, __shared_weak_owners_ indicates the exact
+    // std::weak_ptr reference count.
+    stream.Printf(" weak=%" PRIu64, count);
   }
 
   return true;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/main.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <memory>
 #include <string>
 
@@ -26,5 +27,12 @@ int main() {
   std::shared_ptr<int> si(new int(47));
   std::shared_ptr<int> sie(si, nullptr);
 
-  return 0; // break here
+  std::puts("// break here");
+
+  std::weak_ptr<int> wie = sie;
+  std::weak_ptr<int> wie2 = sie;
+
+  std::puts("// break here");
+
+  return 0;
 }


### PR DESCRIPTION
For the `__shared_owners_` we need to add `+1` to the count, but for `__shared_weak_owners_` the value reflects the exact number of weak references.