### PR TITLE
[Clang][Sema] Avoid duplicate diagnostics for incomplete types in nested name specifier (C++20+)

### DIFF
--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -76,10 +76,6 @@ class CXXScopeSpec {
   NestedNameSpecifierLocBuilder Builder;
   ArrayRef<TemplateParameterList *> TemplateParamLists;
 
-  /// Flag indicating whether an incomplete-type diagnostic
-  /// has already been emitted for this scope specifier.
-  bool HadIncompleteTypeError = false;
-
 public:
   SourceRange getRange() const { return Range; }
   void setRange(SourceRange R) { Range = R; }
@@ -87,12 +83,6 @@ public:
   void setEndLoc(SourceLocation Loc) { Range.setEnd(Loc); }
   SourceLocation getBeginLoc() const { return Range.getBegin(); }
   SourceLocation getEndLoc() const { return Range.getEnd(); }
-  
-  /// Return true if an incomplete-type diagnostic has already been emitted.
-  bool hasIncompleteTypeError() const { return HadIncompleteTypeError; }
-
-  /// Mark that an incomplete-type error was emitted for this scope.
-  void setIncompleteTypeError(bool v = true) { HadIncompleteTypeError = v; }
 
   void setTemplateParamLists(ArrayRef<TemplateParameterList *> L) {
     TemplateParamLists = L;

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -76,6 +76,10 @@ class CXXScopeSpec {
   NestedNameSpecifierLocBuilder Builder;
   ArrayRef<TemplateParameterList *> TemplateParamLists;
 
+  /// Flag indicating whether an incomplete-type diagnostic
+  /// has already been emitted for this scope specifier.
+  bool HadIncompleteTypeError = false;
+
 public:
   SourceRange getRange() const { return Range; }
   void setRange(SourceRange R) { Range = R; }
@@ -83,6 +87,12 @@ public:
   void setEndLoc(SourceLocation Loc) { Range.setEnd(Loc); }
   SourceLocation getBeginLoc() const { return Range.getBegin(); }
   SourceLocation getEndLoc() const { return Range.getEnd(); }
+  
+  /// Return true if an incomplete-type diagnostic has already been emitted.
+  bool hasIncompleteTypeError() const { return HadIncompleteTypeError; }
+
+  /// Mark that an incomplete-type error was emitted for this scope.
+  void setIncompleteTypeError(bool v = true) { HadIncompleteTypeError = v; }
 
   void setTemplateParamLists(ArrayRef<TemplateParameterList *> L) {
     TemplateParamLists = L;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1555,11 +1555,11 @@ private:
   Sema(const Sema &) = delete;
   void operator=(const Sema &) = delete;
 
-  /// Used to suppress duplicate diagnostics for incomplete types
-  /// in nested name specifiers (e.g. `incomplete::type`).
-  /// Without this, Clang may emit the same error multiple times
-  /// in C++20 or later, due to multiple semantic passes over the scope.
-  llvm::DenseSet<const TagDecl *> IncompleteDiagSet;
+  /// Tracks (TagDecl, SourceLocation) pairs that have already triggered
+  /// an "incomplete type in nested name specifier" diagnostic,
+  /// to prevent emitting duplicate errors in C++20 and later,
+  /// where the same scope may be processed multiple times.
+  llvm::DenseSet<std::pair<const clang::TagDecl *, clang::SourceLocation>> DiagnosedIncompleteTypeSet;
 
   /// The handler for the FileChanged preprocessor events.
   ///

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1555,6 +1555,12 @@ private:
   Sema(const Sema &) = delete;
   void operator=(const Sema &) = delete;
 
+  /// Used to suppress duplicate diagnostics for incomplete types
+  /// in nested name specifiers (e.g. `incomplete::type`).
+  /// Without this, Clang may emit the same error multiple times
+  /// in C++20 or later, due to multiple semantic passes over the scope.
+  llvm::DenseSet<const TagDecl *> IncompleteDiagSet;
+
   /// The handler for the FileChanged preprocessor events.
   ///
   /// Used for diagnostics that implement custom semantic analysis for #include

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -206,22 +206,21 @@ bool Sema::RequireCompleteDeclContext(CXXScopeSpec &SS,
   if (tag->isBeingDefined())
     return false;
 
+  // Avoid emitting duplicate diagnostics for the same tag.
+  // This happens in C++20+ due to more aggressive semantic analysis.
+  if (IncompleteDiagSet.contains(tag))
+    return true;
+
   SourceLocation loc = SS.getLastQualifierNameLoc();
   if (loc.isInvalid()) loc = SS.getRange().getBegin();
-
-  // If an incomplete-type error has already been emitted for this scope,
-  // suppress duplicate diagnostics to avoid noisy repeated messages.
-  if (SS.hasIncompleteTypeError())
-    return true;
 
   // The type must be complete.
   if (RequireCompleteType(loc, type, diag::err_incomplete_nested_name_spec,
                           SS.getRange())) {
-    SS.SetInvalid(SS.getRange());
+    // mark as diagnosed
+    IncompleteDiagSet.insert(tag); 
 
-    // Remember that we've already diagnosed this incomplete type,
-    // so later checks won't emit redundant diagnostics.
-    SS.setIncompleteTypeError();
+    SS.SetInvalid(SS.getRange());
 
     return true;
   }

--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -209,10 +209,20 @@ bool Sema::RequireCompleteDeclContext(CXXScopeSpec &SS,
   SourceLocation loc = SS.getLastQualifierNameLoc();
   if (loc.isInvalid()) loc = SS.getRange().getBegin();
 
+  // If an incomplete-type error has already been emitted for this scope,
+  // suppress duplicate diagnostics to avoid noisy repeated messages.
+  if (SS.hasIncompleteTypeError())
+    return true;
+
   // The type must be complete.
   if (RequireCompleteType(loc, type, diag::err_incomplete_nested_name_spec,
                           SS.getRange())) {
     SS.SetInvalid(SS.getRange());
+
+    // Remember that we've already diagnosed this incomplete type,
+    // so later checks won't emit redundant diagnostics.
+    SS.setIncompleteTypeError();
+
     return true;
   }
 

--- a/clang/test/SemaCXX/nested-name-spec.cpp
+++ b/clang/test/SemaCXX/nested-name-spec.cpp
@@ -1,3 +1,10 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+struct incomplete;
+incomplete::type var; // expected-error{{incomplete type 'incomplete' named in nested name specifier}}
+// expected-note@-2{{forward declaration of 'incomplete'}}
+
+
 // RUN: %clang_cc1 -fsyntax-only -std=c++98 -verify -fblocks %s
 namespace A {
   struct C {


### PR DESCRIPTION
Linked issue #147000
Clang currently emits duplicate diagnostics when encountering an incomplete
type in a nested name specifier (e.g., `incomplete::type`) in C++20 or later.
This is due to multiple semantic analysis paths (such as scope resolution
and qualified type building) triggering the same diagnostic.

This patch suppresses duplicate errors by recording diagnosed TagDecls
in a DenseSet within Sema (`IncompleteDiagSet`). If a TagDecl has already
triggered a diagnostic for being incomplete in a nested name specifier, it
will be skipped on subsequent checks.