### PR TITLE
[mlir][vector] Add foldInsertUseChain folder function to insert op

### DIFF
--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3470,7 +3470,7 @@ func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %value : f32, %pos: ind
 //       CHECK:   %[[DEST_1:.*]] = vector.insert %[[VAL]], %[[DEST_0]] [0] : f32 into vector<4xf32>
 //       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[DEST_1]] [1] : f32 into vector<4xf32>
 //       CHECK:   return %[[RES]] : vector<4xf32>
-func.func @no_fold_insert_use_chain(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
+func.func @no_fold_insert_use_chain_mismatch_static_position(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
   %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
   %v_2 = vector.insert %value, %v_0[1] : f32 into vector<4xf32>
   return %v_2 : vector<4xf32>  

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3449,14 +3449,65 @@ func.func @fold_insert_constant_indices(%arg : vector<4x1xi32>) -> vector<4x1xi3
 
 // -----
 
-// CHECK-LABEL: @insert_insert_to_insert(
+// CHECK-LABEL: @fold_insert_use_chain_static_pos(
 //  CHECK-SAME:   %[[ARG:.*]]: vector<4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
 //       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[ARG]] [0] : f32 into vector<4xf32>
 //       CHECK:    return %[[RES]] : vector<4xf32>
-func.func @insert_insert_to_insert(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
+func.func @fold_insert_use_chain_static_pos(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
   %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
   %v_1 = vector.insert %value, %v_0[0] : f32 into vector<4xf32>
   %v_2 = vector.insert %value, %v_1[0] : f32 into vector<4xf32>
   return %v_2 : vector<4xf32>  
+}
+
+// -----
+
+// CHECK-LABEL: @fold_insert_use_chain_dynamic_pos(
+//  CHECK-SAME:   %[[ARG:.*]]: vector<4x4xf32>,
+//  CHECK-SAME:   %[[VAL:.*]]: f32,
+//  CHECK-SAME:   %[[POS:.*]]: index) -> vector<4x4xf32> {
+//       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[ARG]] {{\[}}%[[POS]], 0] : f32 into vector<4x4xf32>
+//       CHECK:   return %[[RES]] : vector<4x4xf32>
+func.func @fold_insert_use_chain_dynamic_pos(%arg : vector<4x4xf32>, %value : f32, %pos: index) -> vector<4x4xf32> {
+  %v_0 = vector.insert %value, %arg[%pos, 0] : f32 into vector<4x4xf32>
+  %v_1 = vector.insert %value, %v_0[%pos, 0] : f32 into vector<4x4xf32>
+  %v_2 = vector.insert %value, %v_1[%pos, 0] : f32 into vector<4x4xf32>
+  return %v_2 : vector<4x4xf32>  
+}
+
+// -----
+
+// CHECK-LABEL: @fold_insert_use_chain_add_float(
+//  CHECK-SAME:   %[[VEC_0:.*]]: vector<4xf32>,
+//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
+//       CHECK:   %[[VEC_1:.*]] = vector.insert %[[VAL]], %[[VEC_0]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[VEC_2:.*]] = arith.addf %[[VEC_1]], %[[VEC_1]] : vector<4xf32>
+//       CHECK:   %[[VEC_3:.*]] = vector.insert %[[VAL]], %[[VEC_0]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[VEC_4:.*]] = arith.addf %[[VEC_2]], %[[VEC_3]] : vector<4xf32>
+//       CHECK:   return %[[VEC_4]] : vector<4xf32>
+func.func @fold_insert_use_chain_add_float(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
+  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
+  %v_1 = arith.addf %v_0, %v_0 : vector<4xf32>
+  %v_2 = vector.insert %value, %v_0[0] : f32 into vector<4xf32>
+  %v_3 = arith.addf %v_1, %v_2 : vector<4xf32>
+  return %v_3 : vector<4xf32>  
+}
+
+// -----
+
+// CHECK-LABEL: @fold_insert_use_chain_add_float_pos_mismatch(
+//  CHECK-SAME:   %[[VEC_0:.*]]: vector<4xf32>,
+//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
+//       CHECK:   %[[VEC_1:.*]] = vector.insert %[[VAL]], %[[VEC_0]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[VEC_2:.*]] = arith.addf %[[VEC_1]], %[[VEC_1]] : vector<4xf32>
+//       CHECK:   %[[VEC_3:.*]] = vector.insert %[[VAL]], %[[VEC_1]] [1] : f32 into vector<4xf32>
+//       CHECK:   %[[VEC_4:.*]] = arith.addf %[[VEC_2]], %[[VEC_3]] : vector<4xf32>
+//       CHECK:   return %[[VEC_4]] : vector<4xf32>
+func.func @fold_insert_use_chain_add_float_pos_mismatch(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
+  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
+  %v_1 = arith.addf %v_0, %v_0 : vector<4xf32>
+  %v_2 = vector.insert %value, %v_0[1] : f32 into vector<4xf32>
+  %v_3 = arith.addf %v_1, %v_2 : vector<4xf32>
+  return %v_3 : vector<4xf32>  
 }

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3450,28 +3450,28 @@ func.func @fold_insert_constant_indices(%arg : vector<4x1xi32>) -> vector<4x1xi3
 // -----
 
 // CHECK-LABEL: @fold_insert_use_chain(
-//  CHECK-SAME:   %[[DEST:.*]]: vector<4x4xf32>,
+//  CHECK-SAME:   %[[ARG:.*]]: vector<4x4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32,
 //  CHECK-SAME:   %[[POS:.*]]: index) -> vector<4x4xf32> {
 //  CHECK-NEXT:   %[[RES:.*]] = vector.insert %[[VAL]], %[[DEST]] {{\[}}%[[POS]], 0] : f32 into vector<4x4xf32>
 //  CHECK-NEXT:   return %[[RES]] : vector<4x4xf32>
-func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %value : f32, %pos: index) -> vector<4x4xf32> {
-  %v_0 = vector.insert %value, %arg[%pos, 0] : f32 into vector<4x4xf32>
-  %v_1 = vector.insert %value, %v_0[%pos, 0] : f32 into vector<4x4xf32>
-  %v_2 = vector.insert %value, %v_1[%pos, 0] : f32 into vector<4x4xf32>
+func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %val : f32, %pos: index) -> vector<4x4xf32> {
+  %v_0 = vector.insert %val, %arg[%pos, 0] : f32 into vector<4x4xf32>
+  %v_1 = vector.insert %val, %v_0[%pos, 0] : f32 into vector<4x4xf32>
+  %v_2 = vector.insert %val, %v_1[%pos, 0] : f32 into vector<4x4xf32>
   return %v_2 : vector<4x4xf32>  
 }
 
 // -----
 
 // CHECK-LABEL: @no_fold_insert_use_chain_mismatch_static_position(
-//  CHECK-SAME:   %[[DEST_0:.*]]: vector<4xf32>,
+//  CHECK-SAME:   %[[ARG:.*]]: vector<4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
-//       CHECK:   %[[DEST_1:.*]] = vector.insert %[[VAL]], %[[DEST_0]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[DEST_1]] [1] : f32 into vector<4xf32>
+//       CHECK:   %[[V_0:.*]] = vector.insert %[[VAL]], %[[DEST_0]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[V_1:.*]] = vector.insert %[[VAL]], %[[DEST_1]] [1] : f32 into vector<4xf32>
 //       CHECK:   return %[[RES]] : vector<4xf32>
-func.func @no_fold_insert_use_chain_mismatch_static_position(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
-  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
-  %v_2 = vector.insert %value, %v_0[1] : f32 into vector<4xf32>
-  return %v_2 : vector<4xf32>  
+func.func @no_fold_insert_use_chain_mismatch_static_position(%arg : vector<4xf32>, %value : f32) -> vector<4xf32> {
+  %v_0 = vector.insert %val, %arg[0] : f32 into vector<4xf32>
+  %v_1 = vector.insert %val, %v_0[1] : f32 into vector<4xf32>
+  return %v_1 : vector<4xf32>  
 }

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3464,7 +3464,7 @@ func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %value : f32, %pos: ind
 
 // -----
 
-// CHECK-LABEL: @no_fold_insert_use_chain(
+// CHECK-LABEL: @no_fold_insert_use_chain_mismatch_static_position(
 //  CHECK-SAME:   %[[DEST_0:.*]]: vector<4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
 //       CHECK:   %[[DEST_1:.*]] = vector.insert %[[VAL]], %[[DEST_0]] [0] : f32 into vector<4xf32>
@@ -3474,22 +3474,4 @@ func.func @no_fold_insert_use_chain_mismatch_static_position(%v : vector<4xf32>,
   %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
   %v_2 = vector.insert %value, %v_0[1] : f32 into vector<4xf32>
   return %v_2 : vector<4xf32>  
-}
-
-// -----
-
-// CHECK-LABEL: @fold_insert_use_chain_add_float(
-//  CHECK-SAME:   %[[DEST:.*]]: vector<4xf32>,
-//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
-//       CHECK:   %{{.*}} = vector.insert %[[VAL]], %[[DEST]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[LHS:.*]] = arith.addf %{{.*}}, %{{.*}} : vector<4xf32>
-//       CHECK:   %[[RHS:.*]] = vector.insert %[[VAL]], %[[DEST]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[RES:.*]] = arith.addf %[[LHS]], %[[RHS]] : vector<4xf32>
-//       CHECK:   return %[[RES]] : vector<4xf32>
-func.func @fold_insert_use_chain_add_float(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
-  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
-  %v_1 = arith.addf %v_0, %v_0 : vector<4xf32>
-  %v_2 = vector.insert %value, %v_0[0] : f32 into vector<4xf32>
-  %v_3 = arith.addf %v_1, %v_2 : vector<4xf32>
-  return %v_3 : vector<4xf32>
 }

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3453,7 +3453,7 @@ func.func @fold_insert_constant_indices(%arg : vector<4x1xi32>) -> vector<4x1xi3
 //  CHECK-SAME:   %[[ARG:.*]]: vector<4x4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32,
 //  CHECK-SAME:   %[[POS:.*]]: index) -> vector<4x4xf32> {
-//  CHECK-NEXT:   %[[RES:.*]] = vector.insert %[[VAL]], %[[DEST]] {{\[}}%[[POS]], 0] : f32 into vector<4x4xf32>
+//  CHECK-NEXT:   %[[RES:.*]] = vector.insert %[[VAL]], %[[ARG]] {{\[}}%[[POS]], 0] : f32 into vector<4x4xf32>
 //  CHECK-NEXT:   return %[[RES]] : vector<4x4xf32>
 func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %val : f32, %pos: index) -> vector<4x4xf32> {
   %v_0 = vector.insert %val, %arg[%pos, 0] : f32 into vector<4x4xf32>
@@ -3467,10 +3467,10 @@ func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %val : f32, %pos: index
 // CHECK-LABEL: @no_fold_insert_use_chain_mismatch_static_position(
 //  CHECK-SAME:   %[[ARG:.*]]: vector<4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
-//       CHECK:   %[[V_0:.*]] = vector.insert %[[VAL]], %[[DEST_0]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[V_1:.*]] = vector.insert %[[VAL]], %[[DEST_1]] [1] : f32 into vector<4xf32>
-//       CHECK:   return %[[RES]] : vector<4xf32>
-func.func @no_fold_insert_use_chain_mismatch_static_position(%arg : vector<4xf32>, %value : f32) -> vector<4xf32> {
+//       CHECK:   %[[V_0:.*]] = vector.insert %[[VAL]], %[[ARG]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[V_1:.*]] = vector.insert %[[VAL]], %[[V_0]] [1] : f32 into vector<4xf32>
+//       CHECK:   return %[[V_1]] : vector<4xf32>
+func.func @no_fold_insert_use_chain_mismatch_static_position(%arg : vector<4xf32>, %val : f32) -> vector<4xf32> {
   %v_0 = vector.insert %val, %arg[0] : f32 into vector<4xf32>
   %v_1 = vector.insert %val, %v_0[1] : f32 into vector<4xf32>
   return %v_1 : vector<4xf32>  

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3446,3 +3446,17 @@ func.func @fold_insert_constant_indices(%arg : vector<4x1xi32>) -> vector<4x1xi3
   %res = vector.insert %1, %arg[%0, %0] : i32 into vector<4x1xi32>
   return %res : vector<4x1xi32>
 }
+
+// -----
+
+// CHECK-LABEL: @insert_insert_to_insert(
+//  CHECK-SAME:   %[[ARG:.*]]: vector<4xf32>,
+//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
+//       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[ARG]] [0] : f32 into vector<4xf32>
+//       CHECK:    return %[[RES]] : vector<4xf32>
+func.func @insert_insert_to_insert(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
+  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
+  %v_1 = vector.insert %value, %v_0[0] : f32 into vector<4xf32>
+  %v_2 = vector.insert %value, %v_1[0] : f32 into vector<4xf32>
+  return %v_2 : vector<4xf32>  
+}

--- a/mlir/test/Dialect/Vector/canonicalize.mlir
+++ b/mlir/test/Dialect/Vector/canonicalize.mlir
@@ -3449,27 +3449,13 @@ func.func @fold_insert_constant_indices(%arg : vector<4x1xi32>) -> vector<4x1xi3
 
 // -----
 
-// CHECK-LABEL: @fold_insert_use_chain_static_pos(
-//  CHECK-SAME:   %[[ARG:.*]]: vector<4xf32>,
-//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
-//       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[ARG]] [0] : f32 into vector<4xf32>
-//       CHECK:    return %[[RES]] : vector<4xf32>
-func.func @fold_insert_use_chain_static_pos(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
-  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
-  %v_1 = vector.insert %value, %v_0[0] : f32 into vector<4xf32>
-  %v_2 = vector.insert %value, %v_1[0] : f32 into vector<4xf32>
-  return %v_2 : vector<4xf32>  
-}
-
-// -----
-
-// CHECK-LABEL: @fold_insert_use_chain_dynamic_pos(
-//  CHECK-SAME:   %[[ARG:.*]]: vector<4x4xf32>,
+// CHECK-LABEL: @fold_insert_use_chain(
+//  CHECK-SAME:   %[[DEST:.*]]: vector<4x4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32,
 //  CHECK-SAME:   %[[POS:.*]]: index) -> vector<4x4xf32> {
-//       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[ARG]] {{\[}}%[[POS]], 0] : f32 into vector<4x4xf32>
-//       CHECK:   return %[[RES]] : vector<4x4xf32>
-func.func @fold_insert_use_chain_dynamic_pos(%arg : vector<4x4xf32>, %value : f32, %pos: index) -> vector<4x4xf32> {
+//  CHECK-NEXT:   %[[RES:.*]] = vector.insert %[[VAL]], %[[DEST]] {{\[}}%[[POS]], 0] : f32 into vector<4x4xf32>
+//  CHECK-NEXT:   return %[[RES]] : vector<4x4xf32>
+func.func @fold_insert_use_chain(%arg : vector<4x4xf32>, %value : f32, %pos: index) -> vector<4x4xf32> {
   %v_0 = vector.insert %value, %arg[%pos, 0] : f32 into vector<4x4xf32>
   %v_1 = vector.insert %value, %v_0[%pos, 0] : f32 into vector<4x4xf32>
   %v_2 = vector.insert %value, %v_1[%pos, 0] : f32 into vector<4x4xf32>
@@ -3478,36 +3464,32 @@ func.func @fold_insert_use_chain_dynamic_pos(%arg : vector<4x4xf32>, %value : f3
 
 // -----
 
-// CHECK-LABEL: @fold_insert_use_chain_add_float(
-//  CHECK-SAME:   %[[VEC_0:.*]]: vector<4xf32>,
+// CHECK-LABEL: @no_fold_insert_use_chain(
+//  CHECK-SAME:   %[[DEST_0:.*]]: vector<4xf32>,
 //  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
-//       CHECK:   %[[VEC_1:.*]] = vector.insert %[[VAL]], %[[VEC_0]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[VEC_2:.*]] = arith.addf %[[VEC_1]], %[[VEC_1]] : vector<4xf32>
-//       CHECK:   %[[VEC_3:.*]] = vector.insert %[[VAL]], %[[VEC_0]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[VEC_4:.*]] = arith.addf %[[VEC_2]], %[[VEC_3]] : vector<4xf32>
-//       CHECK:   return %[[VEC_4]] : vector<4xf32>
+//       CHECK:   %[[DEST_1:.*]] = vector.insert %[[VAL]], %[[DEST_0]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[RES:.*]] = vector.insert %[[VAL]], %[[DEST_1]] [1] : f32 into vector<4xf32>
+//       CHECK:   return %[[RES]] : vector<4xf32>
+func.func @no_fold_insert_use_chain(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
+  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
+  %v_2 = vector.insert %value, %v_0[1] : f32 into vector<4xf32>
+  return %v_2 : vector<4xf32>  
+}
+
+// -----
+
+// CHECK-LABEL: @fold_insert_use_chain_add_float(
+//  CHECK-SAME:   %[[DEST:.*]]: vector<4xf32>,
+//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
+//       CHECK:   %{{.*}} = vector.insert %[[VAL]], %[[DEST]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[LHS:.*]] = arith.addf %{{.*}}, %{{.*}} : vector<4xf32>
+//       CHECK:   %[[RHS:.*]] = vector.insert %[[VAL]], %[[DEST]] [0] : f32 into vector<4xf32>
+//       CHECK:   %[[RES:.*]] = arith.addf %[[LHS]], %[[RHS]] : vector<4xf32>
+//       CHECK:   return %[[RES]] : vector<4xf32>
 func.func @fold_insert_use_chain_add_float(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
   %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
   %v_1 = arith.addf %v_0, %v_0 : vector<4xf32>
   %v_2 = vector.insert %value, %v_0[0] : f32 into vector<4xf32>
   %v_3 = arith.addf %v_1, %v_2 : vector<4xf32>
-  return %v_3 : vector<4xf32>  
-}
-
-// -----
-
-// CHECK-LABEL: @fold_insert_use_chain_add_float_pos_mismatch(
-//  CHECK-SAME:   %[[VEC_0:.*]]: vector<4xf32>,
-//  CHECK-SAME:   %[[VAL:.*]]: f32) -> vector<4xf32> {
-//       CHECK:   %[[VEC_1:.*]] = vector.insert %[[VAL]], %[[VEC_0]] [0] : f32 into vector<4xf32>
-//       CHECK:   %[[VEC_2:.*]] = arith.addf %[[VEC_1]], %[[VEC_1]] : vector<4xf32>
-//       CHECK:   %[[VEC_3:.*]] = vector.insert %[[VAL]], %[[VEC_1]] [1] : f32 into vector<4xf32>
-//       CHECK:   %[[VEC_4:.*]] = arith.addf %[[VEC_2]], %[[VEC_3]] : vector<4xf32>
-//       CHECK:   return %[[VEC_4]] : vector<4xf32>
-func.func @fold_insert_use_chain_add_float_pos_mismatch(%v : vector<4xf32>, %value : f32) -> vector<4xf32> {
-  %v_0 = vector.insert %value, %v[0] : f32 into vector<4xf32>
-  %v_1 = arith.addf %v_0, %v_0 : vector<4xf32>
-  %v_2 = vector.insert %value, %v_0[1] : f32 into vector<4xf32>
-  %v_3 = arith.addf %v_1, %v_2 : vector<4xf32>
-  return %v_3 : vector<4xf32>  
+  return %v_3 : vector<4xf32>
 }


### PR DESCRIPTION
When the result of an insert op is used by an insert op, and the subsequent insert op is inserted at the same location as the previous insert op, replaces the dest of the subsequent insert op with the dest of the previous insert op.This is because the previous insert op does not affect subsequent insert ops.