### PR TITLE
[clang-tidy][NFC] fix compilation by disambiguating equality operator

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
@@ -144,7 +144,9 @@ TaggedUnionMemberCountCheck::getNumberOfEnumValues(const EnumDecl *ED) {
 
   if (EnableCountingEnumHeuristic && LastEnumConstant &&
       isCountingEnumLikeName(LastEnumConstant->getName()) &&
-      (LastEnumConstant->getInitVal() == (EnumValues.size() - 1))) {
+      llvm::APSInt::compareValues(LastEnumConstant->getInitVal(),
+                                  llvm::APSInt::get(EnumValues.size() - 1)) ==
+          0) {
     return {EnumValues.size() - 1, LastEnumConstant};
   }
 

--- a/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
@@ -144,9 +144,8 @@ TaggedUnionMemberCountCheck::getNumberOfEnumValues(const EnumDecl *ED) {
 
   if (EnableCountingEnumHeuristic && LastEnumConstant &&
       isCountingEnumLikeName(LastEnumConstant->getName()) &&
-      llvm::APSInt::compareValues(LastEnumConstant->getInitVal(),
-                                  llvm::APSInt::get(EnumValues.size() - 1)) ==
-          0) {
+      llvm::APSInt::isSameValue(LastEnumConstant->getInitVal(),
+                                llvm::APSInt::get(EnumValues.size() - 1))) {
     return {EnumValues.size() - 1, LastEnumConstant};
   }
 


### PR DESCRIPTION
This fixes an issue compiling LLVM 20.1.7 on Ubuntu 22.04 with the Ubuntu provided Clang 14 and C++20. That's probably happening due to incomplete C++20 support in either Clang 14 or the GNU libstdc++ 12.

The actual error is:
```
[1/8] Building CXX object tools/clang/tools/extra/clang-tidy/bugprone/CMakeFiles/obj.clangTidyBugproneModule.dir/TaggedUnionMemberCountCheck.cpp.o
FAILED: tools/clang/tools/extra/clang-tidy/bugprone/CMakeFiles/obj.clangTidyBugproneModule.dir/TaggedUnionMemberCountCheck.cpp.o
/usr/lib/llvm-14/bin/clang++ -DGTEST_HAS_RTTI=0 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/work/_build/tools/clang/tools/extra/clang-tidy/bugprone -I/work/llvm-project/clang-tools-extra/clang-tidy/bugprone -I/work/_build/tools/clang/tools/extra/clang-tidy -I/work/llvm-project/clang/include -I/work/_build/tools/clang/include -I/work/_build/include -I/work/llvm-project/llvm/include -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -fno-common -Woverloaded-virtual -Wno-nested-anon-types -O3 -DNDEBUG -std=c++20  -fno-exceptions -funwind-tables -fno-rtti -MD -MT tools/clang/tools/extra/clang-tidy/bugprone/CMakeFiles/obj.clangTidyBugproneModule.dir/TaggedUnionMemberCountCheck.cpp.o -MF tools/clang/tools/extra/clang-tidy/bugprone/CMakeFiles/obj.clangTidyBugproneModule.dir/TaggedUnionMemberCountCheck.cpp.o.d -o tools/clang/tools/extra/clang-tidy/bugprone/CMakeFiles/obj.clangTidyBugproneModule.dir/TaggedUnionMemberCountCheck.cpp.o -c /work/llvm-project/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp
/work/llvm-project/clang-tools-extra/clang-tidy/bugprone/TaggedUnionMemberCountCheck.cpp:148:39: error: use of overloaded operator '==' is ambiguous (with operand types 'llvm::APSInt' and 'unsigned long')
      (LastEnumConstant->getInitVal() == (EnumValues.size() - 1))) {
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~
/work/llvm-project/llvm/include/llvm/ADT/APInt.h:2080:13: note: candidate function (with reversed parameter order)
inline bool operator==(uint64_t V1, const APInt &V2) { return V2 == V1; }
            ^
/work/llvm-project/llvm/include/llvm/ADT/APSInt.h:188:8: note: candidate function
  bool operator==(int64_t RHS) const {
       ^
/work/llvm-project/llvm/include/llvm/ADT/APSInt.h:357:13: note: candidate function (with reversed parameter order)
inline bool operator==(int64_t V1, const APSInt &V2) { return V2 == V1; }
            ^
1 error generated.
```

I know that clang-14 in combination with the GNU libstdc++ 12 might not be 100% C++20 compliant. But this is the only error we see when compiling LLVM 20.1.7 and it looks very fixable. Would it be possible to cherry-pick the fix to the `release/20.x` branch?

Thanks,
Gregor