### PR TITLE
[mlir][xevm] Add missing static value utils dependency

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
+++ b/mlir/lib/Dialect/LLVMIR/CMakeLists.txt
@@ -128,6 +128,7 @@ add_mlir_dialect_library(MLIRXeVMDialect
   Core
 
   LINK_LIBS PUBLIC
+  MLIRDialectUtils
   MLIRIR
   MLIRLLVMDialect
   MLIRSideEffectInterfaces


### PR DESCRIPTION
Fixes missing symbol linker error from #144811