### PR TITLE
[Flang][OpenMP] Push context when parsing DECLARE VARIANT

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -499,7 +499,7 @@ public:
     PushContext(x.source, llvm::omp::Directive::OMPD_declare_variant);
     return true;
   }
-  void Post (const parser::OmpDeclareVariantDirective &) { PopContext(); };
+  void Post(const parser::OmpDeclareVariantDirective &) { PopContext(); };
 
   void Post(const parser::OmpObjectList &x) {
     // The objects from OMP clauses should have already been resolved,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -495,6 +495,12 @@ public:
   bool Pre(const parser::OpenMPAllocatorsConstruct &);
   void Post(const parser::OpenMPAllocatorsConstruct &);
 
+  bool Pre(const parser::OmpDeclareVariantDirective &x) {
+    PushContext(x.source, llvm::omp::Directive::OMPD_declare_variant);
+    return true;
+  }
+  void Post (const parser::OmpDeclareVariantDirective &) { PopContext(); };
+
   void Post(const parser::OmpObjectList &x) {
     // The objects from OMP clauses should have already been resolved,
     // except common blocks (the ResolveNamesVisitor does not visit


### PR DESCRIPTION
Basic parsing and semantics support for Declare Variant was added in #130578. However, this did not include variant of `Pre` and `Post` within `OmpAttributeVisitor`. This meant that when a function in the class tried to get the context using `GetContext`, Flang would crash as the context was empty. To ensure this is possible, such as when resolving names as part of the `uniform` clause in the `simd` directive, the context is now pushed within `OmpAttributeVisitor` when parsing a `DECLARE VARIANT` directive.

Fixes #145222