### PR TITLE
[Flang][Doc] NFC: Minor fix for headings

### DIFF
--- a/flang/docs/OpenMP-declare-target.md
+++ b/flang/docs/OpenMP-declare-target.md
@@ -7,7 +7,15 @@
 
 -->
 
-# Introduction to Declare Target
+# OpenMP Declare Target
+
+```{contents}
+---
+local:
+---
+```
+
+## Introduction to Declare Target
 
 In OpenMP `declare target` is a directive that can be applied to a function or
 variable (primarily global) to notate to the compiler that it should be 
@@ -55,7 +63,7 @@ in this case, leave off the `declare target` from the function and it
 would be implicitly marked `declare target any` (for both host and device), 
 as it's been utilised within a target region.
 
-# Declare Target as represented in the OpenMP Dialect
+## Declare Target as represented in the OpenMP Dialect
 
 In the OpenMP Dialect `declare target` is not represented by a specific 
 `operation`. Instead, it's an OpenMP dialect specific `attribute` that can be 
@@ -89,7 +97,7 @@ llvm::dyn_cast<mlir::omp::DeclareTargetInterface>(Op.getOperation());
 declareTargetGlobal.isDeclareTarget();
 ```
 
-# Declare Target Fortran OpenMP Lowering
+## Declare Target Fortran OpenMP Lowering
 
 The initial lowering of `declare target` to MLIR for both use-cases is done
 inside of the usual OpenMP lowering in flang/lib/Lower/OpenMP.cpp. However, 
@@ -145,7 +153,7 @@ to the way `threadprivate` handles these cases, we raise and initialize the
 variable as an internal `GlobalOp` and apply the attribute. This occurs in the
 flang/lib/Lower/OpenMP.cpp function `genDeclareTargetIntGlobal`.
 
-# Declare Target Transformation Passes for Flang
+## Declare Target Transformation Passes for Flang
 
 There are currently two passes within Flang that are related to the processing 
 of `declare target`:
@@ -173,7 +181,7 @@ While this infrastructure could be generally applicable to more than just Flang,
 it is only utilised in the Flang frontend, so it resides there rather than in 
 the OpenMP dialect codebase. 
 
-# Declare Target OpenMP Dialect To LLVM-IR Lowering
+## Declare Target OpenMP Dialect To LLVM-IR Lowering
 
 The OpenMP dialect lowering of `declare target` is done through the 
 `amendOperation` flow, as it's not an `operation` but rather an 
@@ -228,7 +236,7 @@ place. It may be possible to store this information in the OMPIRBuilder and
 then perform this cleanup process on finalization, but this is open for 
 discussion and implementation still.
 
-# Current Support
+## Current Support
 
 For the moment, `declare target` should work for:
 * Marking functions/subroutines and function/subroutine interfaces for 

--- a/flang/docs/OpenMP-descriptor-management.md
+++ b/flang/docs/OpenMP-descriptor-management.md
@@ -6,8 +6,15 @@
 
 -->
 
-# OpenMP dialect: Fortran descriptor type mapping for offload
+# Fortran descriptor type mapping for OpenMP offload
+```{contents}
+---
+local:
+---
+```
 
+
+## Details
 The initial method for mapping Fortran types tied to descriptors for OpenMP offloading is to treat these types 
 as a special case of OpenMP record type (C/C++ structure/class, Fortran derived type etc.) mapping as far as the 
 runtime is concerned. Where the box (descriptor information) is the holding container and the underlying 
@@ -103,7 +110,7 @@ it is a little rigid in how the descriptor mappings are handled as there is no s
 to specialise the mappings for possible edge cases without polluting the dialect or lowering with further
 knowledge of Fortran and the FIR dialect.
 
-# OpenMP dialect differences from OpenACC dialect
+## Differences from OpenACC
 
 The descriptor mapping for OpenMP currently works differently to the planned direction for OpenACC, however, 
 it is possible and would likely be ideal to align the method with OpenACC in the future. 


### PR DESCRIPTION
Use a top level section to ensure that there is only one entry in the flang.llvm.org/docs page.

Also generate a table of contents.