### PR TITLE
[HLSL][RootSignature] Correct `RootSignatureParser` to use correct `SourceLocation` in diagnostics

### DIFF
--- a/clang/include/clang/Lex/LexHLSLRootSignature.h
+++ b/clang/include/clang/Lex/LexHLSLRootSignature.h
@@ -31,16 +31,17 @@ struct RootSignatureToken {
 
   Kind TokKind = Kind::invalid;
 
-  // Retain the SouceLocation of the token for diagnostics
-  clang::SourceLocation TokLoc;
+  // Retain the location offset of the token in the Signature
+  // string
+  uint32_t LocOffset;
 
   // Retain spelling of an numeric constant to be parsed later
   StringRef NumSpelling;
 
   // Constructors
-  RootSignatureToken(clang::SourceLocation TokLoc) : TokLoc(TokLoc) {}
-  RootSignatureToken(Kind TokKind, clang::SourceLocation TokLoc)
-      : TokKind(TokKind), TokLoc(TokLoc) {}
+  RootSignatureToken(uint32_t LocOffset) : LocOffset(LocOffset) {}
+  RootSignatureToken(Kind TokKind, uint32_t LocOffset)
+      : TokKind(TokKind), LocOffset(LocOffset) {}
 };
 
 inline const DiagnosticBuilder &
@@ -61,8 +62,7 @@ operator<<(const DiagnosticBuilder &DB, const RootSignatureToken::Kind Kind) {
 
 class RootSignatureLexer {
 public:
-  RootSignatureLexer(StringRef Signature, clang::SourceLocation SourceLoc)
-      : Buffer(Signature), SourceLoc(SourceLoc) {}
+  RootSignatureLexer(StringRef Signature) : Buffer(Signature) {}
 
   /// Consumes and returns the next token.
   RootSignatureToken consumeToken();
@@ -76,14 +76,12 @@ public:
   }
 
 private:
-  // Internal buffer to iterate over
+  // Internal buffer state
   StringRef Buffer;
+  uint32_t LocOffset = 0;
 
   // Current peek state
   std::optional<RootSignatureToken> NextToken = std::nullopt;
-
-  // Passed down parameters from Sema
-  clang::SourceLocation SourceLoc;
 
   /// Consumes the buffer and returns the lexed token.
   RootSignatureToken lexToken();
@@ -92,7 +90,7 @@ private:
   /// Updates the SourceLocation appropriately.
   void advanceBuffer(unsigned NumCharacters = 1) {
     Buffer = Buffer.drop_front(NumCharacters);
-    SourceLoc = SourceLoc.getLocWithOffset(NumCharacters);
+    LocOffset += NumCharacters;
   }
 };
 

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CLANG_PARSE_PARSEHLSLROOTSIGNATURE_H
 #define LLVM_CLANG_PARSE_PARSEHLSLROOTSIGNATURE_H
 
+#include "clang/AST/Expr.h"
 #include "clang/Basic/DiagnosticParse.h"
 #include "clang/Lex/LexHLSLRootSignature.h"
 #include "clang/Lex/Preprocessor.h"
@@ -29,7 +30,8 @@ class RootSignatureParser {
 public:
   RootSignatureParser(llvm::dxbc::RootSignatureVersion Version,
                       SmallVector<llvm::hlsl::rootsig::RootElement> &Elements,
-                      RootSignatureLexer &Lexer, clang::Preprocessor &PP);
+                      RootSignatureLexer &Lexer, StringLiteral *Signature,
+                      Preprocessor &PP);
 
   /// Consumes tokens from the Lexer and constructs the in-memory
   /// representations of the RootElements. Tokens are consumed until an
@@ -192,6 +194,7 @@ private:
   SmallVector<llvm::hlsl::rootsig::RootElement> &Elements;
   RootSignatureLexer &Lexer;
 
+  clang::StringLiteral *Signature;
   clang::Preprocessor &PP;
 
   RootSignatureToken CurToken;

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -197,9 +197,9 @@ private:
 private:
   llvm::dxbc::RootSignatureVersion Version;
   SmallVector<llvm::hlsl::rootsig::RootElement> &Elements;
-  clang::StringLiteral *Signature;
+  StringLiteral *Signature;
   RootSignatureLexer Lexer;
-  clang::Preprocessor &PP;
+  Preprocessor &PP;
 
   RootSignatureToken CurToken;
 };

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -194,6 +194,11 @@ private:
   /// StringLiterals
   SourceLocation getTokenLocation(RootSignatureToken Tok);
 
+  /// Construct a diagnostics at the location of the current token
+  DiagnosticBuilder reportDiag(unsigned DiagID) {
+    return getDiags().Report(getTokenLocation(CurToken), DiagID);
+  }
+
 private:
   llvm::dxbc::RootSignatureVersion Version;
   SmallVector<llvm::hlsl::rootsig::RootElement> &Elements;

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -189,6 +189,12 @@ private:
   bool tryConsumeExpectedToken(RootSignatureToken::Kind Expected);
   bool tryConsumeExpectedToken(ArrayRef<RootSignatureToken::Kind> Expected);
 
+  /// Convert the token's offset in the signature string to its SourceLocation
+  ///
+  /// This allows to currently retrieve the location for multi-token
+  /// StringLiterals
+  SourceLocation getTokenLocation(RootSignatureToken Tok);
+
 private:
   llvm::dxbc::RootSignatureVersion Version;
   SmallVector<llvm::hlsl::rootsig::RootElement> &Elements;

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -30,8 +30,7 @@ class RootSignatureParser {
 public:
   RootSignatureParser(llvm::dxbc::RootSignatureVersion Version,
                       SmallVector<llvm::hlsl::rootsig::RootElement> &Elements,
-                      RootSignatureLexer &Lexer, StringLiteral *Signature,
-                      Preprocessor &PP);
+                      StringLiteral *Signature, Preprocessor &PP);
 
   /// Consumes tokens from the Lexer and constructs the in-memory
   /// representations of the RootElements. Tokens are consumed until an
@@ -198,9 +197,8 @@ private:
 private:
   llvm::dxbc::RootSignatureVersion Version;
   SmallVector<llvm::hlsl::rootsig::RootElement> &Elements;
-  RootSignatureLexer &Lexer;
-
   clang::StringLiteral *Signature;
+  RootSignatureLexer Lexer;
   clang::Preprocessor &PP;
 
   RootSignatureToken CurToken;

--- a/clang/lib/Lex/LexHLSLRootSignature.cpp
+++ b/clang/lib/Lex/LexHLSLRootSignature.cpp
@@ -27,10 +27,10 @@ RootSignatureToken RootSignatureLexer::lexToken() {
   advanceBuffer(Buffer.take_while(isspace).size());
 
   if (isEndOfBuffer())
-    return RootSignatureToken(TokenKind::end_of_stream, SourceLoc);
+    return RootSignatureToken(TokenKind::end_of_stream, LocOffset);
 
   // Record where this token is in the text for usage in parser diagnostics
-  RootSignatureToken Result(SourceLoc);
+  RootSignatureToken Result(LocOffset);
 
   char C = Buffer.front();
 
@@ -62,7 +62,7 @@ RootSignatureToken RootSignatureLexer::lexToken() {
 
   // All following tokens require at least one additional character
   if (Buffer.size() <= 1) {
-    Result = RootSignatureToken(TokenKind::invalid, SourceLoc);
+    Result = RootSignatureToken(TokenKind::invalid, LocOffset);
     return Result;
   }
 

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4950,10 +4950,8 @@ void Parser::ParseHLSLRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   // If we haven't found an already defined DeclIdent then parse the root
   // signature string and construct the in-memory elements
   if (!Found) {
-    // Offset location 1 to account for '"'
-    SourceLocation SignatureLoc = Signature->getExprLoc().getLocWithOffset(1);
     // Invoke the root signature parser to construct the in-memory constructs
-    hlsl::RootSignatureLexer Lexer(Signature->getString(), SignatureLoc);
+    hlsl::RootSignatureLexer Lexer(Signature->getString());
     SmallVector<llvm::hlsl::rootsig::RootElement> RootElements;
     hlsl::RootSignatureParser Parser(getLangOpts().HLSLRootSigVer, RootElements,
                                      Lexer, Signature, PP);

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4951,10 +4951,9 @@ void Parser::ParseHLSLRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   // signature string and construct the in-memory elements
   if (!Found) {
     // Invoke the root signature parser to construct the in-memory constructs
-    hlsl::RootSignatureLexer Lexer(Signature->getString());
     SmallVector<llvm::hlsl::rootsig::RootElement> RootElements;
     hlsl::RootSignatureParser Parser(getLangOpts().HLSLRootSigVer, RootElements,
-                                     Lexer, Signature, PP);
+                                     Signature, PP);
     if (Parser.parse()) {
       T.consumeClose();
       return;

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -4944,20 +4944,19 @@ void Parser::ParseHLSLRootSignatureAttributeArgs(ParsedAttributes &Attrs) {
   }
 
   // Construct our identifier
-  StringRef Signature = StrLiteral.value()->getString();
+  StringLiteral *Signature = StrLiteral.value();
   auto [DeclIdent, Found] =
-      Actions.HLSL().ActOnStartRootSignatureDecl(Signature);
+      Actions.HLSL().ActOnStartRootSignatureDecl(Signature->getString());
   // If we haven't found an already defined DeclIdent then parse the root
   // signature string and construct the in-memory elements
   if (!Found) {
     // Offset location 1 to account for '"'
-    SourceLocation SignatureLoc =
-        StrLiteral.value()->getExprLoc().getLocWithOffset(1);
+    SourceLocation SignatureLoc = Signature->getExprLoc().getLocWithOffset(1);
     // Invoke the root signature parser to construct the in-memory constructs
-    hlsl::RootSignatureLexer Lexer(Signature, SignatureLoc);
+    hlsl::RootSignatureLexer Lexer(Signature->getString(), SignatureLoc);
     SmallVector<llvm::hlsl::rootsig::RootElement> RootElements;
     hlsl::RootSignatureParser Parser(getLangOpts().HLSLRootSigVer, RootElements,
-                                     Lexer, PP);
+                                     Lexer, Signature, PP);
     if (Parser.parse()) {
       T.consumeClose();
       return;

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -19,10 +19,10 @@ using TokenKind = RootSignatureToken::Kind;
 
 RootSignatureParser::RootSignatureParser(
     llvm::dxbc::RootSignatureVersion Version,
-    SmallVector<RootElement> &Elements, RootSignatureLexer &Lexer,
-    StringLiteral *Signature, Preprocessor &PP)
-    : Version(Version), Elements(Elements), Signature(Signature), Lexer(Lexer),
-      PP(PP), CurToken(0) {}
+    SmallVector<RootElement> &Elements, StringLiteral *Signature,
+    Preprocessor &PP)
+    : Version(Version), Elements(Elements), Signature(Signature),
+      Lexer(Signature->getString()), PP(PP), CurToken(0) {}
 
 bool RootSignatureParser::parse() {
   // Iterate as many RootElements as possible

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -20,9 +20,9 @@ using TokenKind = RootSignatureToken::Kind;
 RootSignatureParser::RootSignatureParser(
     llvm::dxbc::RootSignatureVersion Version,
     SmallVector<RootElement> &Elements, RootSignatureLexer &Lexer,
-    Preprocessor &PP)
-    : Version(Version), Elements(Elements), Lexer(Lexer), PP(PP),
-      CurToken(SourceLocation()) {}
+    StringLiteral *Signature, Preprocessor &PP)
+    : Version(Version), Elements(Elements), Signature(Signature), Lexer(Lexer),
+      PP(PP), CurToken(SourceLocation()) {}
 
 bool RootSignatureParser::parse() {
   // Iterate as many RootElements as possible

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -91,8 +91,7 @@ std::optional<llvm::dxbc::RootFlags> RootSignatureParser::parseRootFlags() {
   // Handle the edge-case of '0' to specify no flags set
   if (tryConsumeExpectedToken(TokenKind::int_literal)) {
     if (!verifyZeroFlag()) {
-      getDiags().Report(getTokenLocation(CurToken),
-                        diag::err_hlsl_rootsig_non_zero_flag);
+      reportDiag(diag::err_hlsl_rootsig_non_zero_flag);
       return std::nullopt;
     }
   } else {
@@ -142,8 +141,7 @@ std::optional<RootConstants> RootSignatureParser::parseRootConstants() {
 
   // Check mandatory parameters where provided
   if (!Params->Num32BitConstants.has_value()) {
-    getDiags().Report(getTokenLocation(CurToken),
-                      diag::err_hlsl_rootsig_missing_param)
+    reportDiag(diag::err_hlsl_rootsig_missing_param)
         << TokenKind::kw_num32BitConstants;
     return std::nullopt;
   }
@@ -151,9 +149,7 @@ std::optional<RootConstants> RootSignatureParser::parseRootConstants() {
   Constants.Num32BitConstants = Params->Num32BitConstants.value();
 
   if (!Params->Reg.has_value()) {
-    getDiags().Report(getTokenLocation(CurToken),
-                      diag::err_hlsl_rootsig_missing_param)
-        << TokenKind::bReg;
+    reportDiag(diag::err_hlsl_rootsig_missing_param) << TokenKind::bReg;
     return std::nullopt;
   }
 
@@ -212,9 +208,7 @@ std::optional<RootDescriptor> RootSignatureParser::parseRootDescriptor() {
 
   // Check mandatory parameters were provided
   if (!Params->Reg.has_value()) {
-    getDiags().Report(getTokenLocation(CurToken),
-                      diag::err_hlsl_rootsig_missing_param)
-        << ExpectedReg;
+    reportDiag(diag::err_hlsl_rootsig_missing_param) << ExpectedReg;
     return std::nullopt;
   }
 
@@ -262,9 +256,7 @@ std::optional<DescriptorTable> RootSignatureParser::parseDescriptorTable() {
 
     if (tryConsumeExpectedToken(TokenKind::kw_visibility)) {
       if (Visibility.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -333,9 +325,7 @@ RootSignatureParser::parseDescriptorTableClause() {
 
   // Check mandatory parameters were provided
   if (!Params->Reg.has_value()) {
-    getDiags().Report(getTokenLocation(CurToken),
-                      diag::err_hlsl_rootsig_missing_param)
-        << ExpectedReg;
+    reportDiag(diag::err_hlsl_rootsig_missing_param) << ExpectedReg;
     return std::nullopt;
   }
 
@@ -378,9 +368,7 @@ std::optional<StaticSampler> RootSignatureParser::parseStaticSampler() {
 
   // Check mandatory parameters were provided
   if (!Params->Reg.has_value()) {
-    getDiags().Report(getTokenLocation(CurToken),
-                      diag::err_hlsl_rootsig_missing_param)
-        << TokenKind::sReg;
+    reportDiag(diag::err_hlsl_rootsig_missing_param) << TokenKind::sReg;
     return std::nullopt;
   }
 
@@ -444,9 +432,7 @@ RootSignatureParser::parseRootConstantParams() {
     // `num32BitConstants` `=` POS_INT
     if (tryConsumeExpectedToken(TokenKind::kw_num32BitConstants)) {
       if (Params.Num32BitConstants.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -462,9 +448,7 @@ RootSignatureParser::parseRootConstantParams() {
     // `b` POS_INT
     if (tryConsumeExpectedToken(TokenKind::bReg)) {
       if (Params.Reg.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
       auto Reg = parseRegister();
@@ -476,9 +460,7 @@ RootSignatureParser::parseRootConstantParams() {
     // `space` `=` POS_INT
     if (tryConsumeExpectedToken(TokenKind::kw_space)) {
       if (Params.Space.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -494,9 +476,7 @@ RootSignatureParser::parseRootConstantParams() {
     // `visibility` `=` SHADER_VISIBILITY
     if (tryConsumeExpectedToken(TokenKind::kw_visibility)) {
       if (Params.Visibility.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -523,9 +503,7 @@ RootSignatureParser::parseRootDescriptorParams(TokenKind RegType) {
     // ( `b` | `t` | `u`) POS_INT
     if (tryConsumeExpectedToken(RegType)) {
       if (Params.Reg.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
       auto Reg = parseRegister();
@@ -537,9 +515,7 @@ RootSignatureParser::parseRootDescriptorParams(TokenKind RegType) {
     // `space` `=` POS_INT
     if (tryConsumeExpectedToken(TokenKind::kw_space)) {
       if (Params.Space.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -555,9 +531,7 @@ RootSignatureParser::parseRootDescriptorParams(TokenKind RegType) {
     // `visibility` `=` SHADER_VISIBILITY
     if (tryConsumeExpectedToken(TokenKind::kw_visibility)) {
       if (Params.Visibility.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -573,9 +547,7 @@ RootSignatureParser::parseRootDescriptorParams(TokenKind RegType) {
     // `flags` `=` ROOT_DESCRIPTOR_FLAGS
     if (tryConsumeExpectedToken(TokenKind::kw_flags)) {
       if (Params.Flags.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -602,9 +574,7 @@ RootSignatureParser::parseDescriptorTableClauseParams(TokenKind RegType) {
     // ( `b` | `t` | `u` | `s`) POS_INT
     if (tryConsumeExpectedToken(RegType)) {
       if (Params.Reg.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
       auto Reg = parseRegister();
@@ -616,9 +586,7 @@ RootSignatureParser::parseDescriptorTableClauseParams(TokenKind RegType) {
     // `numDescriptors` `=` POS_INT | unbounded
     if (tryConsumeExpectedToken(TokenKind::kw_numDescriptors)) {
       if (Params.NumDescriptors.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -640,9 +608,7 @@ RootSignatureParser::parseDescriptorTableClauseParams(TokenKind RegType) {
     // `space` `=` POS_INT
     if (tryConsumeExpectedToken(TokenKind::kw_space)) {
       if (Params.Space.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -658,9 +624,7 @@ RootSignatureParser::parseDescriptorTableClauseParams(TokenKind RegType) {
     // `offset` `=` POS_INT | DESCRIPTOR_RANGE_OFFSET_APPEND
     if (tryConsumeExpectedToken(TokenKind::kw_offset)) {
       if (Params.Offset.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -682,9 +646,7 @@ RootSignatureParser::parseDescriptorTableClauseParams(TokenKind RegType) {
     // `flags` `=` DESCRIPTOR_RANGE_FLAGS
     if (tryConsumeExpectedToken(TokenKind::kw_flags)) {
       if (Params.Flags.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -712,9 +674,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `s` POS_INT
     if (tryConsumeExpectedToken(TokenKind::sReg)) {
       if (Params.Reg.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
       auto Reg = parseRegister();
@@ -726,9 +686,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `filter` `=` FILTER
     if (tryConsumeExpectedToken(TokenKind::kw_filter)) {
       if (Params.Filter.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -744,9 +702,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `addressU` `=` TEXTURE_ADDRESS
     if (tryConsumeExpectedToken(TokenKind::kw_addressU)) {
       if (Params.AddressU.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -762,9 +718,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `addressV` `=` TEXTURE_ADDRESS
     if (tryConsumeExpectedToken(TokenKind::kw_addressV)) {
       if (Params.AddressV.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -780,9 +734,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `addressW` `=` TEXTURE_ADDRESS
     if (tryConsumeExpectedToken(TokenKind::kw_addressW)) {
       if (Params.AddressW.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -798,9 +750,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `mipLODBias` `=` NUMBER
     if (tryConsumeExpectedToken(TokenKind::kw_mipLODBias)) {
       if (Params.MipLODBias.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -816,9 +766,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `maxAnisotropy` `=` POS_INT
     if (tryConsumeExpectedToken(TokenKind::kw_maxAnisotropy)) {
       if (Params.MaxAnisotropy.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -834,9 +782,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `comparisonFunc` `=` COMPARISON_FUNC
     if (tryConsumeExpectedToken(TokenKind::kw_comparisonFunc)) {
       if (Params.CompFunc.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -852,9 +798,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `borderColor` `=` STATIC_BORDER_COLOR
     if (tryConsumeExpectedToken(TokenKind::kw_borderColor)) {
       if (Params.BorderColor.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -870,9 +814,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `minLOD` `=` NUMBER
     if (tryConsumeExpectedToken(TokenKind::kw_minLOD)) {
       if (Params.MinLOD.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -888,9 +830,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `maxLOD` `=` NUMBER
     if (tryConsumeExpectedToken(TokenKind::kw_maxLOD)) {
       if (Params.MaxLOD.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -906,9 +846,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `space` `=` POS_INT
     if (tryConsumeExpectedToken(TokenKind::kw_space)) {
       if (Params.Space.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -924,9 +862,7 @@ RootSignatureParser::parseStaticSamplerParams() {
     // `visibility` `=` SHADER_VISIBILITY
     if (tryConsumeExpectedToken(TokenKind::kw_visibility)) {
       if (Params.Visibility.has_value()) {
-        getDiags().Report(getTokenLocation(CurToken),
-                          diag::err_hlsl_rootsig_repeat_param)
-            << CurToken.TokKind;
+        reportDiag(diag::err_hlsl_rootsig_repeat_param) << CurToken.TokKind;
         return std::nullopt;
       }
 
@@ -1157,8 +1093,7 @@ RootSignatureParser::parseRootDescriptorFlags() {
   // Handle the edge-case of '0' to specify no flags set
   if (tryConsumeExpectedToken(TokenKind::int_literal)) {
     if (!verifyZeroFlag()) {
-      getDiags().Report(getTokenLocation(CurToken),
-                        diag::err_hlsl_rootsig_non_zero_flag);
+      reportDiag(diag::err_hlsl_rootsig_non_zero_flag);
       return std::nullopt;
     }
     return llvm::dxbc::RootDescriptorFlags::None;
@@ -1197,8 +1132,7 @@ RootSignatureParser::parseDescriptorRangeFlags() {
   // Handle the edge-case of '0' to specify no flags set
   if (tryConsumeExpectedToken(TokenKind::int_literal)) {
     if (!verifyZeroFlag()) {
-      getDiags().Report(getTokenLocation(CurToken),
-                        diag::err_hlsl_rootsig_non_zero_flag);
+      reportDiag(diag::err_hlsl_rootsig_non_zero_flag);
       return std::nullopt;
     }
     return llvm::dxbc::DescriptorRangeFlags::None;
@@ -1243,8 +1177,7 @@ std::optional<uint32_t> RootSignatureParser::handleUIntLiteral() {
   llvm::APSInt Val(32, /*IsUnsigned=*/true);
   if (Literal.GetIntegerValue(Val)) {
     // Report that the value has overflowed
-    PP.getDiagnostics().Report(getTokenLocation(CurToken),
-                               diag::err_hlsl_number_literal_overflow)
+    reportDiag(diag::err_hlsl_number_literal_overflow)
         << /*integer type*/ 0 << /*is signed*/ 0;
     return std::nullopt;
   }
@@ -1277,8 +1210,7 @@ std::optional<int32_t> RootSignatureParser::handleIntLiteral(bool Negated) {
 
   if (Overflowed) {
     // Report that the value has overflowed
-    PP.getDiagnostics().Report(getTokenLocation(CurToken),
-                               diag::err_hlsl_number_literal_overflow)
+    reportDiag(diag::err_hlsl_number_literal_overflow)
         << /*integer type*/ 0 << /*is signed*/ 1;
     return std::nullopt;
   }
@@ -1321,16 +1253,13 @@ std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {
 
   if (Status & llvm::APFloat::opStatus::opUnderflow) {
     // Report that the value has underflowed
-    PP.getDiagnostics().Report(getTokenLocation(CurToken),
-                               diag::err_hlsl_number_literal_underflow);
+    reportDiag(diag::err_hlsl_number_literal_underflow);
     return std::nullopt;
   }
 
   if (Status & llvm::APFloat::opStatus::opOverflow) {
     // Report that the value has overflowed
-    PP.getDiagnostics().Report(getTokenLocation(CurToken),
-                               diag::err_hlsl_number_literal_overflow)
-        << /*float type*/ 1;
+    reportDiag(diag::err_hlsl_number_literal_overflow) << /*float type*/ 1;
     return std::nullopt;
   }
 
@@ -1341,9 +1270,7 @@ std::optional<float> RootSignatureParser::handleFloatLiteral(bool Negated) {
   double FloatMax = double(std::numeric_limits<float>::max());
   if (FloatMax < DoubleVal || DoubleVal < -FloatMax) {
     // Report that the value has overflowed
-    PP.getDiagnostics().Report(getTokenLocation(CurToken),
-                               diag::err_hlsl_number_literal_overflow)
-        << /*float type*/ 1;
+    reportDiag(diag::err_hlsl_number_literal_overflow) << /*float type*/ 1;
     return std::nullopt;
   }
 
@@ -1372,7 +1299,7 @@ bool RootSignatureParser::consumeExpectedToken(TokenKind Expected,
     return false;
 
   // Report unexpected token kind error
-  DiagnosticBuilder DB = getDiags().Report(getTokenLocation(CurToken), DiagID);
+  DiagnosticBuilder DB = reportDiag(DiagID);
   switch (DiagID) {
   case diag::err_expected:
     DB << Expected;

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -28,7 +28,7 @@ void bad_root_signature_5() {}
  "CBV(b0)," \
  "RootConstants(num32BitConstants = 3, b0, invalid)"
 
-// CHECK: note: expanded from macro 'MultiLineRootSignature'
+// CHECK: [[@LINE-2]]:42: note: expanded from macro 'MultiLineRootSignature'
 // CHECK-NEXT: [[@LINE-3]] | "RootConstants(num32BitConstants = 3, b0, invalid)"
 // CHECK-NEXT:             |                                         ^
 // expected-error@+1 {{expected ')' to denote end of parameters, or, another valid parameter of RootConstants}}

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - %s -verify
+// RUN: not %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - %s 2>&1 | FileCheck %s
 
 // Attr test
 
@@ -22,3 +23,14 @@ void bad_root_signature_4() {}
 // expected-error@+1 {{expected ')' to denote end of parameters, or, another valid parameter of RootConstants}}
 [RootSignature("RootConstants(b0, num32BitConstants = 1, invalid)")]
 void bad_root_signature_5() {}
+
+#define MultiLineRootSignature \
+ "CBV(b0)," \
+ "RootConstants(num32BitConstants = 3, b0, invalid)"
+
+// CHECK: note: expanded from macro 'MultiLineRootSignature'
+// CHECK-NEXT: [[@LINE-3]] | "RootConstants(num32BitConstants = 3, b0, invalid)"
+// CHECK-NEXT:             |                                         ^
+// expected-error@+1 {{expected ')' to denote end of parameters, or, another valid parameter of RootConstants}}
+[RootSignature(MultiLineRootSignature)]
+void bad_root_signature_6() {}

--- a/clang/test/SemaHLSL/RootSignature-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-err.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - %s -verify
-// RUN: not %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -o - %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -fsyntax-only %s -verify
+// RUN: not %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -fsyntax-only %s 2>&1 | FileCheck %s
 
 // Attr test
 

--- a/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Lex/LexHLSLRootSignatureTest.cpp
@@ -49,9 +49,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexNumbersTest) {
     42.e+10f
   )cc";
 
-  auto TokLoc = SourceLocation();
-
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
 
   SmallVector<hlsl::RootSignatureToken> Tokens;
   SmallVector<TokenKind> Expected = {
@@ -229,8 +227,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexAllTokensTest) {
     STATIC_BORDER_COLOR_OPAQUE_BLACK_UINT
     STATIC_BORDER_COLOR_OPAQUE_WHITE_UINT
   )cc";
-  auto TokLoc = SourceLocation();
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
 
   SmallVector<hlsl::RootSignatureToken> Tokens;
   SmallVector<TokenKind> Expected = {
@@ -251,8 +248,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidCaseInsensitiveKeywordsTest) {
     SPACE visibility FLAGS
     numDescriptors OFFSET
   )cc";
-  auto TokLoc = SourceLocation();
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
 
   SmallVector<hlsl::RootSignatureToken> Tokens;
   SmallVector<TokenKind> Expected = {
@@ -276,8 +272,7 @@ TEST_F(LexHLSLRootSignatureTest, ValidLexPeekTest) {
   const llvm::StringLiteral Source = R"cc(
     )1
   )cc";
-  auto TokLoc = SourceLocation();
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
 
   // Test basic peek
   hlsl::RootSignatureToken Res = Lexer.peekNextToken();

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -134,9 +134,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseEmptyTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -172,9 +171,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -279,9 +277,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -368,9 +365,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -447,9 +443,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidSamplerFlagsTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -482,9 +477,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootConsantsTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -543,9 +537,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootFlagsTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -600,9 +593,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootDescriptorsTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -678,9 +670,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidTrailingCommaTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -852,9 +843,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedTokenTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -876,9 +866,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseInvalidTokenTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -900,9 +889,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedEndOfStreamTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -929,9 +917,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingDTParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -955,9 +942,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRDParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -981,9 +967,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRCParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1009,9 +994,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryDTParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1035,9 +1019,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryRCParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1063,9 +1046,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalDTParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1093,9 +1075,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalRCParameterTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1120,9 +1101,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1146,9 +1126,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseOverflowedNegativeNumberTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1171,9 +1150,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedFloatTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1196,9 +1174,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexNegOverflowedFloatTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1221,9 +1198,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedDoubleTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1246,9 +1222,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexUnderflowFloatTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);
@@ -1274,9 +1249,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidNonZeroFlagsTest) {
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
+  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
                                    Signature, *PP);

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Expr.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticOptions.h"
 #include "clang/Basic/FileManager.h"
@@ -93,6 +95,22 @@ protected:
     return PP;
   }
 
+  std::unique_ptr<ASTContext> createMinimalASTContext() {
+    IdentifierTable Idents(LangOpts);
+    SelectorTable Selectors;
+    Builtin::Context Builtins;
+
+    return std::make_unique<ASTContext>(LangOpts, SourceMgr, Idents, Selectors,
+                                        Builtins, TU_Complete);
+  }
+
+  StringLiteral *wrapSource(std::unique_ptr<ASTContext> &Ctx,
+                            StringRef Source) {
+    SourceLocation Locs[1] = {SourceLocation()};
+    return StringLiteral::Create(*Ctx, Source, StringLiteralKind::Unevaluated,
+                                 false, Ctx->VoidTy, Locs);
+  }
+
   FileSystemOptions FileMgrOpts;
   FileManager FileMgr;
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID;
@@ -110,6 +128,9 @@ protected:
 
 TEST_F(ParseHLSLRootSignatureTest, ValidParseEmptyTest) {
   const llvm::StringLiteral Source = R"cc()cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -145,6 +166,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
     ),
     DescriptorTable()
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -250,6 +274,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -336,6 +363,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
     StaticSampler(s0, mipLODBias = 2147483648),
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -412,6 +442,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidSamplerFlagsTest) {
     DescriptorTable(Sampler(s0, flags = DESCRIPTORS_VOLATILE))
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -443,6 +476,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootConsantsTest) {
       visibility = SHADER_VISIBILITY_HULL
     )
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -502,6 +538,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootFlagsTest) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -555,6 +594,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootDescriptorsTest) {
     UAV(visibility = SHADER_VISIBILITY_HULL, u34893247),
     CBV(b0, flags = 0),
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -630,6 +672,9 @@ TEST_F(ParseHLSLRootSignatureTest, ValidTrailingCommaTest) {
       SRV(t42),
     )
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -802,6 +847,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedTokenTest) {
     space
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -823,6 +871,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseInvalidTokenTest) {
     notAnIdentifier
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -843,6 +894,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedEndOfStreamTest) {
   const llvm::StringLiteral Source = R"cc(
     DescriptorTable
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -870,6 +924,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingDTParameterTest) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -893,6 +950,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRDParameterTest) {
     SRV()
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -915,6 +975,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRCParameterTest) {
   const llvm::StringLiteral Source = R"cc(
     RootConstants(b0)
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -941,6 +1004,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryDTParameterTest) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -963,6 +1029,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryRCParameterTest) {
   const llvm::StringLiteral Source = R"cc(
     RootConstants(num32BitConstants = 32, num32BitConstants = 24)
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -988,6 +1057,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalDTParameterTest) {
       CBV(space = 2, space = 0)
     )
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -1016,6 +1088,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalRCParameterTest) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -1040,6 +1115,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -1063,6 +1141,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseOverflowedNegativeNumberTest) {
     StaticSampler(s0, mipLODBias = -4294967295)
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -1084,6 +1165,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedFloatTest) {
   const llvm::StringLiteral Source = R"cc(
     StaticSampler(s0, mipLODBias = 3.402823467e+38F)
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -1107,6 +1191,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexNegOverflowedFloatTest) {
     StaticSampler(s0, mipLODBias = -3.402823467e+38F)
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -1129,6 +1216,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedDoubleTest) {
     StaticSampler(s0, mipLODBias = 1.e+500)
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
   auto TokLoc = SourceLocation();
@@ -1150,6 +1240,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexUnderflowFloatTest) {
   const llvm::StringLiteral Source = R"cc(
     StaticSampler(s0, mipLODBias = 10e-309)
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
@@ -1175,6 +1268,9 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidNonZeroFlagsTest) {
       CBV(b0, flags = 3)
     )
   )cc";
+
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
 
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -139,7 +139,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseEmptyTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -177,7 +177,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -284,7 +284,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -373,7 +373,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -452,7 +452,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidSamplerFlagsTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -487,7 +487,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootConsantsTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -548,7 +548,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootFlagsTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -605,7 +605,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootDescriptorsTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -683,7 +683,7 @@ TEST_F(ParseHLSLRootSignatureTest, ValidTrailingCommaTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -857,7 +857,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedTokenTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_unexpected_end_of_params);
@@ -881,7 +881,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseInvalidTokenTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced - invalid token
   Consumer->setExpected(diag::err_hlsl_unexpected_end_of_params);
@@ -905,7 +905,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedEndOfStreamTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced - end of stream
   Consumer->setExpected(diag::err_expected_after);
@@ -934,7 +934,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingDTParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_missing_param);
@@ -960,7 +960,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRDParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_missing_param);
@@ -986,7 +986,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRCParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_missing_param);
@@ -1014,7 +1014,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryDTParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_repeat_param);
@@ -1040,7 +1040,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryRCParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_repeat_param);
@@ -1068,7 +1068,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalDTParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_repeat_param);
@@ -1098,7 +1098,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalRCParameterTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_repeat_param);
@@ -1125,7 +1125,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
@@ -1151,7 +1151,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseOverflowedNegativeNumberTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
@@ -1176,7 +1176,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedFloatTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
@@ -1201,7 +1201,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexNegOverflowedFloatTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
@@ -1226,7 +1226,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedDoubleTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_number_literal_overflow);
@@ -1251,7 +1251,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexUnderflowFloatTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_number_literal_underflow);
@@ -1279,7 +1279,7 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidNonZeroFlagsTest) {
   hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
   hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+                                   Signature, *PP);
 
   // Test correct diagnostic produced
   Consumer->setExpected(diag::err_hlsl_rootsig_non_zero_flag);

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -690,14 +690,15 @@ TEST_F(ParseHLSLRootSignatureTest, ValidVersion10Test) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_0, Elements, Lexer,
-                                   *PP);
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_0, Elements,
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();
@@ -762,14 +763,15 @@ TEST_F(ParseHLSLRootSignatureTest, ValidVersion11Test) {
     )
   )cc";
 
+  auto Ctx = createMinimalASTContext();
+  StringLiteral *Signature = wrapSource(Ctx, Source);
+
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
-  auto TokLoc = SourceLocation();
 
-  hlsl::RootSignatureLexer Lexer(Source, TokLoc);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
-                                   *PP);
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
+                                   Signature, *PP);
 
   // Test no diagnostics produced
   Consumer->setNoDiag();

--- a/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
+++ b/clang/unittests/Parse/ParseHLSLRootSignatureTest.cpp
@@ -135,9 +135,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseEmptyTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -172,9 +171,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseDTClausesTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -278,9 +276,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseStaticSamplerTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -366,9 +363,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseFloatsTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -444,9 +440,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidSamplerFlagsTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -478,9 +473,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootConsantsTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -538,9 +532,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootFlagsTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -594,9 +587,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidParseRootDescriptorsTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -671,9 +663,8 @@ TEST_F(ParseHLSLRootSignatureTest, ValidTrailingCommaTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test no diagnostics produced
@@ -844,9 +835,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedTokenTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -867,9 +857,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseInvalidTokenTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced - invalid token
@@ -890,9 +879,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseUnexpectedEndOfStreamTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced - end of stream
@@ -918,9 +906,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingDTParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -943,9 +930,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRDParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -968,9 +954,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidMissingRCParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -995,9 +980,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryDTParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1020,9 +1004,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedMandatoryRCParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1047,9 +1030,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalDTParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1076,9 +1058,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidRepeatedOptionalRCParameterTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1102,9 +1083,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedNumberTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1127,9 +1107,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidParseOverflowedNegativeNumberTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1151,9 +1130,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedFloatTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1175,9 +1153,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexNegOverflowedFloatTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1199,9 +1176,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexOverflowedDoubleTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1223,9 +1199,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidLexUnderflowFloatTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced
@@ -1250,9 +1225,8 @@ TEST_F(ParseHLSLRootSignatureTest, InvalidNonZeroFlagsTest) {
   TrivialModuleLoader ModLoader;
   auto PP = createPP(Source, ModLoader);
 
-  hlsl::RootSignatureLexer Lexer(Source);
   SmallVector<RootElement> Elements;
-  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements, Lexer,
+  hlsl::RootSignatureParser Parser(RootSignatureVersion::V1_1, Elements,
                                    Signature, *PP);
 
   // Test correct diagnostic produced


### PR DESCRIPTION
The `SourceLocation` of a `RootSignatureToken` is incorrectly set to be the "offset" into the concatenated string that denotes the rootsignature. This causes an issue when the `StringLiteral` is a multi-line expansion macro, since the offset will not account for the characters between `StringLiteral` tokens.

This pr resolves this by retaining the `SourceLocation` information that is kept in `StringLiteral` and then converting the offset in the concatenated string into the proper `SourceLocation` using the `StringLiteral::getLocationOfByte` interface. To do so, we will need to adjust the `RootSignatureToken` to only hold its offset into the root signature string. Then when the parser will use the token, it will need to compute its actual `SourceLocation`.

See linked issue for more context.

For example:

```
#define DemoRootSignature \
 "CBV(b0)," \
 "RootConstants(num32BitConstants = 3, b0, invalid)"
  expected caret location ---------------^
  actual caret location ------------^
```

The caret points 5 characters early because the current offset did not account for the characters:
```
'"' ' ' '\' ' ' '"'
 1   2   3   4   5
```

- Updates `RootSignatureParser` to retain `SourceLocation` information by retaining the `StringLiteral` and passing the underlying `StringRef` to the `Lexer`
- Updates `RootSignatureLexer` so that the constructed tokens only reflect an offset into the `StringRef`
- Updates `RootSignatureParser` to directly construct its used `Lexer` so that the `StringLiteral` is directly tied with the string used in the `RootSignatureLexer`
- Updates `RootSignatureParser` to use `StringLiteral::getLocationOfByte` to get the actual token location for diagnostics
- Updates `ParseHLSLRootSignatureTest` to construct a phony `AST`/`StringLiteral` for the test cases
- Adds a test to `RootSignature-err.hlsl` showing that the `SourceLocation` is correctly set for diagnostics in a multi-line macro expansion

Resolves: https://github.com/llvm/llvm-project/issues/146967