### PR TITLE
[test] Fix `coro-split-dbg-labels.ll` for non-x86

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
@@ -12,8 +12,8 @@
 
 source_filename = "coro.c"
 
-declare void @bar(...) local_unnamed_addr #2
-declare void @baz(...) local_unnamed_addr #2
+declare void @bar(...) local_unnamed_addr #0
+declare void @baz(...) local_unnamed_addr #0
 
 ; Roughly equivalent to:
 ;
@@ -27,16 +27,16 @@ declare void @baz(...) local_unnamed_addr #2
 ; }
 
 ; Function Attrs: nounwind uwtable
-define ptr @f() #3 !dbg !16 {
+define ptr @f() #2 !dbg !16 {
 entry:
   %0 = tail call token @llvm.coro.id(i32 0, ptr null, ptr @f, ptr null), !dbg !26
   %1 = tail call i64 @llvm.coro.size.i64(), !dbg !26
   %frame = tail call ptr @malloc(i64 %1), !dbg !26
-  %2 = tail call ptr @llvm.coro.begin(token %0, ptr %frame) #4, !dbg !26
+  %2 = tail call ptr @llvm.coro.begin(token %0, ptr %frame) #3, !dbg !26
   br label %loop1, !dbg !27
 
 loop1:                                         ; preds = %for.cond, %entry
-  tail call void (...) @bar() #7, !dbg !33
+  tail call void (...) @bar() #0, !dbg !33
   %3 = tail call token @llvm.coro.save(ptr null), !dbg !34
   %4 = tail call i8 @llvm.coro.suspend(token %3, i1 false), !dbg !34
   switch i8 %4, label %coro_Suspend [
@@ -45,7 +45,7 @@ loop1:                                         ; preds = %for.cond, %entry
   ], !dbg !34
 
 loop2:                                         ; preds = %for.cond, %entry
-  tail call void (...) @baz() #7, !dbg !35
+  tail call void (...) @baz() #0, !dbg !35
   %5 = tail call token @llvm.coro.save(ptr null), !dbg !36
   %6 = tail call i8 @llvm.coro.suspend(token %5, i1 false), !dbg !36
   switch i8 %6, label %coro_Suspend [
@@ -59,7 +59,7 @@ coro_Cleanup:                                     ; preds = %for.cond
   br label %coro_Suspend, !dbg !37
 
 coro_Suspend:                                     ; preds = %for.cond, %if.then, %coro_Cleanup
-  tail call i1 @llvm.coro.end(ptr null, i1 false, token none) #4, !dbg !40
+  tail call i1 @llvm.coro.end(ptr null, i1 false, token none) #3, !dbg !40
   ret ptr %2, !dbg !41
 }
 
@@ -94,27 +94,23 @@ coro_Suspend:                                     ; preds = %for.cond, %if.then,
 
 
 ; Function Attrs: argmemonly nounwind readonly
-declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #5
+declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr) #4
 
 ; Function Attrs: nounwind
-declare noalias ptr @malloc(i64) local_unnamed_addr #6
+declare noalias ptr @malloc(i64) local_unnamed_addr #0
 declare i64 @llvm.coro.size.i64() #1
-declare ptr @llvm.coro.begin(token, ptr writeonly) #7
-declare token @llvm.coro.save(ptr) #7
-declare i8 @llvm.coro.suspend(token, i1) #7
-declare ptr @llvm.coro.free(token, ptr nocapture readonly) #5
-declare void @free(ptr nocapture) local_unnamed_addr #6
-declare i1 @llvm.coro.end(ptr, i1, token) #7
+declare ptr @llvm.coro.begin(token, ptr writeonly) #0
+declare token @llvm.coro.save(ptr) #0
+declare i8 @llvm.coro.suspend(token, i1) #0
+declare ptr @llvm.coro.free(token, ptr nocapture readonly) #4
+declare void @free(ptr nocapture) local_unnamed_addr #0
+declare i1 @llvm.coro.end(ptr, i1, token) #0
 
-attributes #0 = { nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone }
-attributes #2 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind uwtable presplitcoroutine "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #4 = { noduplicate }
-attributes #5 = { argmemonly nounwind readonly }
-attributes #6 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "frame-pointer"="none" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+fxsr,+mmx,+sse,+sse2,+x87" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #7 = { nounwind }
-attributes #8 = { alwaysinline nounwind }
+attributes #2 = { nounwind uwtable presplitcoroutine }
+attributes #3 = { noduplicate }
+attributes #4 = { argmemonly nounwind readonly }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}


### PR DESCRIPTION
This test case was recently introduced in 24b3c1f680446f87a. It was meant to be target-independent, but the function attributes still contained x86-specific attributes. This commit removes those attributes.