### PR TITLE
[mlir][docs][python] Fix up testing docs

### DIFF
--- a/mlir/docs/Bindings/Python.md
+++ b/mlir/docs/Bindings/Python.md
@@ -51,8 +51,9 @@ python -m pip install --upgrade pip
 # packages will be installed there.
 python -m pip install -r mlir/python/requirements.txt
 
-# Now run `cmake`, `ninja`, et al. For example, to run python bindings test only
-# using ninja:
+# Now run your build command with `cmake`, `ninja`, et al.
+
+# Run mlir tests. For example, to run python bindings tests only using ninja:
 ninja check-mlir-python
 ```
 

--- a/mlir/docs/Bindings/Python.md
+++ b/mlir/docs/Bindings/Python.md
@@ -51,7 +51,9 @@ python -m pip install --upgrade pip
 # packages will be installed there.
 python -m pip install -r mlir/python/requirements.txt
 
-# Now run `cmake`, `ninja`, et al.
+# Now run `cmake`, `ninja`, et al. For example, to run python bindings test only
+# using ninja:
+ninja check-mlir-python
 ```
 
 For interactive use, it is sufficient to add the
@@ -859,7 +861,7 @@ mutually exclusive with a more complete mapping of the backing constructs.
 
 ## Testing
 
-Tests should be added in the `test/Bindings/Python` directory and should
+Tests should be added in the `mlir/test/python` directory and should
 typically be `.py` files that have a lit run line.
 
 We use `lit` and `FileCheck` based tests:


### PR DESCRIPTION
Use the correct path to binding tests.
Also add a suggested ninja command to run tests.