### PR TITLE
[libclang] Add missing dllexport annotation

### DIFF
--- a/clang/include/clang-c/FatalErrorHandler.h
+++ b/clang/include/clang-c/FatalErrorHandler.h
@@ -11,6 +11,7 @@
 #define LLVM_CLANG_C_FATAL_ERROR_HANDLER_H
 
 #include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
 
 LLVM_CLANG_C_EXTERN_C_BEGIN
 
@@ -18,14 +19,14 @@ LLVM_CLANG_C_EXTERN_C_BEGIN
  * Installs error handler that prints error message to stderr and calls abort().
  * Replaces currently installed error handler (if any).
  */
-void clang_install_aborting_llvm_fatal_error_handler(void);
+CINDEX_LINKAGE void clang_install_aborting_llvm_fatal_error_handler(void);
 
 /**
  * Removes currently installed error handler (if any).
  * If no error handler is intalled, the default strategy is to print error
  * message to stderr and call exit(1).
  */
-void clang_uninstall_llvm_fatal_error_handler(void);
+CINDEX_LINKAGE void clang_uninstall_llvm_fatal_error_handler(void);
 
 LLVM_CLANG_C_EXTERN_C_END
 


### PR DESCRIPTION
All other declarations of clang-c already have CINDEX_LINKAGE.

This missing annotation causes a linker error when building `tools/clang/unittests/libclang/CrashTests/libclangCrashTests.exe` for the Cygwin target.
On the regular Win32 target, this issue went unnoticed because the entire libclang gtest-based testsuite is currently disabled for that platform.