### PR TITLE
[clang][diagnostics] Refactor "warn_doc_container_decl_mismatch" to use enum_select

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommentKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommentKinds.td
@@ -90,8 +90,10 @@ def warn_doc_api_container_decl_mismatch : Warning<
   InGroup<Documentation>, DefaultIgnore;
 
 def warn_doc_container_decl_mismatch : Warning<
-  "'%select{\\|@}0%select{classdesign|coclass|dependency|helper"
-  "|helperclass|helps|instancesize|ownership|performance|security|superclass}1' "
+  "'%select{\\|@}0%enum_select<DocCommandKind>{%ClassDesign{classdesign}|"
+  "%CoClass{coclass}|%Dependency{dependency}|%Helper{helper}|%HelperClass{helperclass}|"
+  "%Helps{helps}|%InstanceSize{instancesize}|%Ownership{ownership}|"
+  "%Performance{performance}|%Security{security}|%Superclass{superclass}}1' "
   "command should not be used in a comment attached to a non-container declaration">,
   InGroup<Documentation>, DefaultIgnore;
 

--- a/clang/lib/AST/CommentSema.cpp
+++ b/clang/lib/AST/CommentSema.cpp
@@ -171,50 +171,49 @@ void Sema::checkContainerDecl(const BlockCommandComment *Comment) {
   const CommandInfo *Info = Traits.getCommandInfo(Comment->getCommandID());
   if (!Info->IsRecordLikeDetailCommand || isRecordLikeDecl())
     return;
-  unsigned DiagSelect;
+  std::optional<unsigned> DiagSelect;
   switch (Comment->getCommandID()) {
     case CommandTraits::KCI_classdesign:
-      DiagSelect = 1;
+      DiagSelect = diag::DocCommandKind::ClassDesign;
       break;
     case CommandTraits::KCI_coclass:
-      DiagSelect = 2;
+      DiagSelect = diag::DocCommandKind::CoClass;
       break;
     case CommandTraits::KCI_dependency:
-      DiagSelect = 3;
+      DiagSelect = diag::DocCommandKind::Dependency;
       break;
     case CommandTraits::KCI_helper:
-      DiagSelect = 4;
+      DiagSelect = diag::DocCommandKind::Helper;
       break;
     case CommandTraits::KCI_helperclass:
-      DiagSelect = 5;
+      DiagSelect = diag::DocCommandKind::HelperClass;
       break;
     case CommandTraits::KCI_helps:
-      DiagSelect = 6;
+      DiagSelect = diag::DocCommandKind::Helps;
       break;
     case CommandTraits::KCI_instancesize:
-      DiagSelect = 7;
+      DiagSelect = diag::DocCommandKind::InstanceSize;
       break;
     case CommandTraits::KCI_ownership:
-      DiagSelect = 8;
+      DiagSelect = diag::DocCommandKind::Ownership;
       break;
     case CommandTraits::KCI_performance:
-      DiagSelect = 9;
+      DiagSelect = diag::DocCommandKind::Performance;
       break;
     case CommandTraits::KCI_security:
-      DiagSelect = 10;
+      DiagSelect = diag::DocCommandKind::Security;
       break;
     case CommandTraits::KCI_superclass:
-      DiagSelect = 11;
+      DiagSelect = diag::DocCommandKind::Superclass;
       break;
     default:
-      DiagSelect = 0;
+      DiagSelect = std::nullopt;
       break;
   }
   if (DiagSelect)
     Diag(Comment->getLocation(), diag::warn_doc_container_decl_mismatch)
-    << Comment->getCommandMarker()
-    << (DiagSelect-1)
-    << Comment->getSourceRange();
+        << Comment->getCommandMarker() << (*DiagSelect)
+        << Comment->getSourceRange();
 }
 
 /// Turn a string into the corresponding PassDirection or -1 if it's not


### PR DESCRIPTION
Related: https://github.com/llvm/llvm-project/issues/123121

This patch refactors the `warn_doc_container_decl_mismatch` diagnostic to use `enum_select` instead of `select`. This gets rid of magic numbers and improves readability in the caller site.

@cor3ntin @erichkeane 