### PR TITLE
[libclang][Cygwin] Use __declspec(dllexport) for libclang on Cygwin

### DIFF
--- a/clang/include/clang-c/Platform.h
+++ b/clang/include/clang-c/Platform.h
@@ -22,7 +22,7 @@ LLVM_CLANG_C_EXTERN_C_BEGIN
 #ifndef CINDEX_NO_EXPORTS
   #define CINDEX_EXPORTS
 #endif
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
   #ifdef CINDEX_EXPORTS
     #ifdef _CINDEX_LIB_
       #define CINDEX_LINKAGE __declspec(dllexport)


### PR DESCRIPTION
This is needed for Cygwin build without `-DLLVM_LINK_LLVM_DYLIB=ON`, otherwise causes a linker error 'export ordinal too large'.