### PR TITLE
[clang-tidy] Add filtering of check options by enabled checks in '--dump-config'

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -505,14 +505,13 @@ getCheckNames(const ClangTidyOptions &Options,
 
 void filterCheckOptions(ClangTidyOptions &Options,
                         const std::vector<std::string> &EnabledChecks) {
-  StringSet<> EnabledChecksSet(llvm::from_range, EnabledChecks);
   ClangTidyOptions::OptionMap FilteredOptions;
   for (const auto &[OptionName, Value] : Options.CheckOptions) {
     const size_t CheckNameEndPos = OptionName.find('.');
     if (CheckNameEndPos == StringRef::npos)
       continue;
     const StringRef CheckName = OptionName.substr(0, CheckNameEndPos);
-    if (EnabledChecksSet.contains(CheckName))
+    if (llvm::binary_search(EnabledChecks, CheckName))
       FilteredOptions[OptionName] = Value;
   }
   Options.CheckOptions = std::move(FilteredOptions);

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -503,6 +503,21 @@ getCheckNames(const ClangTidyOptions &Options,
   return Factory.getCheckNames();
 }
 
+void filterCheckOptions(ClangTidyOptions &Options,
+                        const std::vector<std::string> &EnabledChecks) {
+  StringSet<> EnabledChecksSet(llvm::from_range, EnabledChecks);
+  ClangTidyOptions::OptionMap FilteredOptions;
+  for (const auto &[OptionName, Value] : Options.CheckOptions) {
+    const size_t CheckNameEndPos = OptionName.find('.');
+    if (CheckNameEndPos == StringRef::npos)
+      continue;
+    const StringRef CheckName = OptionName.substr(0, CheckNameEndPos);
+    if (EnabledChecksSet.contains(CheckName))
+      FilteredOptions[OptionName] = Value;
+  }
+  Options.CheckOptions = std::move(FilteredOptions);
+}
+
 ClangTidyOptions::OptionMap
 getCheckOptions(const ClangTidyOptions &Options,
                 bool AllowEnablingAnalyzerAlphaCheckers) {

--- a/clang-tools-extra/clang-tidy/ClangTidy.h
+++ b/clang-tools-extra/clang-tidy/ClangTidy.h
@@ -77,7 +77,7 @@ getCheckOptions(const ClangTidyOptions &Options,
                 bool AllowEnablingAnalyzerAlphaCheckers);
 
 /// Filters CheckOptions in \p Options to only include options specified in
-/// the \p EnabledChecks.
+/// the \p EnabledChecks which is a sorted vector.
 void filterCheckOptions(ClangTidyOptions &Options,
                         const std::vector<std::string> &EnabledChecks);
 

--- a/clang-tools-extra/clang-tidy/ClangTidy.h
+++ b/clang-tools-extra/clang-tidy/ClangTidy.h
@@ -76,6 +76,11 @@ ClangTidyOptions::OptionMap
 getCheckOptions(const ClangTidyOptions &Options,
                 bool AllowEnablingAnalyzerAlphaCheckers);
 
+/// Filters CheckOptions in \p Options to only include options specified in
+/// the \p EnabledChecks.
+void filterCheckOptions(ClangTidyOptions &Options,
+                        const std::vector<std::string> &EnabledChecks);
+
 /// Run a set of clang-tidy checks on a set of files.
 ///
 /// \param EnableCheckProfile If provided, it enables check profile collection

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -659,9 +659,10 @@ int clangTidyMain(int argc, const char **argv) {
   if (DumpConfig) {
     EffectiveOptions.CheckOptions =
         getCheckOptions(EffectiveOptions, AllowEnablingAnalyzerAlphaCheckers);
-    llvm::outs() << configurationAsText(ClangTidyOptions::getDefaults().merge(
-                        EffectiveOptions, 0))
-                 << "\n";
+    ClangTidyOptions OptionsToDump =
+        ClangTidyOptions::getDefaults().merge(EffectiveOptions, 0);
+    filterCheckOptions(OptionsToDump, EnabledChecks);
+    llvm::outs() << configurationAsText(OptionsToDump) << "\n";
     return 0;
   }
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -108,6 +108,9 @@ Improvements to clang-tidy
 - Improved :program:`clang-tidy-diff.py` script. Add the `-warnings-as-errors`
   argument to treat warnings as errors.
 
+- Improved :program:`clang-tidy` to show `CheckOptions` only for checks enabled
+  in `Checks` when running ``--dump-config``.
+
 - Fixed bug in :program:`clang-tidy` by which `HeaderFilterRegex` did not take
   effect when passed via the `.clang-tidy` file.
 

--- a/clang-tools-extra/test/clang-tidy/infrastructure/dump-config-filtering.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/dump-config-filtering.cpp
@@ -1,0 +1,12 @@
+// RUN: clang-tidy -checks='-*,misc-unused-parameters' -dump-config %s -- 2>/dev/null | FileCheck %s --check-prefix=CHECK
+// RUN: clang-tidy -checks='-*' -dump-config %s -- 2>/dev/null | FileCheck %s --check-prefix=CHECK-DISABLED
+
+// CHECK: CheckOptions:
+// CHECK-NEXT:   misc-unused-parameters.IgnoreVirtual: 'false'
+// CHECK-NEXT:   misc-unused-parameters.StrictMode: 'false'
+// CHECK-NEXT: SystemHeaders:   false
+
+// CHECK-DISABLED: CheckOptions:    {}
+// CHECK-DISABLED-NEXT: SystemHeaders:   false
+
+int main() { return 0; }


### PR DESCRIPTION
Added function to filter out `CheckOptions` that come from `ClangTidyOptions::getDefaults()`, but does not have a corresponding check enabled in the `Checks` configuration.

Fixes https://github.com/llvm/llvm-project/issues/146693.