### PR TITLE
[libc++][NFC] atomic::wait use public API on macOS

### DIFF
--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -41,6 +41,10 @@
 // OpenBSD has no indirect syscalls
 #  define _LIBCPP_FUTEX(...) futex(__VA_ARGS__)
 
+#elif defined(__APPLE__) && defined(_LIBCPP_USE_ULOCK)
+
+#  include <os/os_sync_wait_on_address.h>
+
 #else // <- Add other operating systems here
 
 // Baseline needs no new headers
@@ -65,24 +69,15 @@ static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const vo
 
 #elif defined(__APPLE__) && defined(_LIBCPP_USE_ULOCK)
 
-extern "C" int __ulock_wait(
-    uint32_t operation, void* addr, uint64_t value, uint32_t timeout); /* timeout is specified in microseconds */
-extern "C" int __ulock_wake(uint32_t operation, void* addr, uint64_t wake_value);
-
-// https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/ulock.h#L82
-#  define UL_COMPARE_AND_WAIT64 5
-#  define ULF_WAKE_ALL 0x00000100
-
 static void
 __libcpp_platform_wait_on_address(__cxx_atomic_contention_t const volatile* __ptr, __cxx_contention_t __val) {
   static_assert(sizeof(__cxx_atomic_contention_t) == 8, "Waiting on 8 bytes value");
-  __ulock_wait(UL_COMPARE_AND_WAIT64, const_cast<__cxx_atomic_contention_t*>(__ptr), __val, 0);
+  os_sync_wait_on_address(const_cast<__cxx_atomic_contention_t*>(__ptr), __val, 8, OS_SYNC_WAIT_ON_ADDRESS_NONE);
 }
 
 static void __libcpp_platform_wake_by_address(__cxx_atomic_contention_t const volatile* __ptr, bool __notify_one) {
   static_assert(sizeof(__cxx_atomic_contention_t) == 8, "Waking up on 8 bytes value");
-  __ulock_wake(
-      UL_COMPARE_AND_WAIT64 | (__notify_one ? 0 : ULF_WAKE_ALL), const_cast<__cxx_atomic_contention_t*>(__ptr), 0);
+  os_sync_wake_by_address_all(const_cast<__cxx_atomic_contention_t*>(__ptr), 8, OS_SYNC_WAKE_BY_ADDRESS_NONE);
 }
 
 #elif defined(__FreeBSD__) && __SIZEOF_LONG__ == 8


### PR DESCRIPTION
At the moment, we use the os internal functions `__ulock_wait`. This patch updates the code on macOS to use the public API `os_sync_wait_on_address`.

Fixes #146142