### PR TITLE
[clang-format] Stop crashing when the input contains `??/\n`

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -4052,6 +4052,7 @@ LangOptions getFormattingLangOpts(const FormatStyle &Style) {
   // the sequence "<::" will be unconditionally treated as "[:".
   // Cf. Lexer::LexTokenInternal.
   LangOpts.Digraphs = SinceCpp11;
+  LangOpts.Trigraphs = Style.isCpp();
 
   LangOpts.LineComment = 1;
   LangOpts.Bool = 1;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -6681,6 +6681,31 @@ TEST_F(FormatTest, EscapedNewlines) {
                "  int x(int a);",
                AlignLeft);
 
+  // Escaped with a trigraph.
+  verifyFormat("#define A \\\n"
+               "  int i;  \\\n"
+               "  int j;",
+               "#define A \?\?/\n"
+               "int i;\?\?/\n"
+               "  int j;",
+               Narrow);
+  verifyFormat("#define A \\\r\n"
+               "  int i;  \\\r\n"
+               "  int j;",
+               "#define A \?\?/\r\n"
+               "int i;\?\?/\r\n"
+               "  int j;",
+               Narrow);
+  verifyFormat("#define A int i;", "#define A \?\?/\n"
+                                   "int i;");
+  verifyFormat("#define A int i;", "#define A \?\?/\r\n"
+                                   "int i;");
+  // In a language that does not support the trigraph, the program should not
+  // crash.
+  verifyNoCrash("#define A \?\?/\n"
+                "int i;",
+                getGoogleStyle(FormatStyle::LK_CSharp));
+
   // CRLF line endings
   verifyFormat("#define A \\\r\n  int i;  \\\r\n  int j;",
                "#define A \\\r\nint i;\\\r\n  int j;", Narrow);


### PR DESCRIPTION
In the debug build, this kind of input caused the assertion in the function `countLeadingWhitespace` to fail.  The release build without assertions outputted `?` `?` `/` separated by spaces.

```C
#define A ??/
  int i;
```

This is because the code in `countLeadingWhitespace` assumed that the underlying lexer recognized the entire `??/` sequence as a single token. In fact, the lexer recognized it as 3 separate tokens.  The flag to make the lexer recognize trigraphs was never enabled.

This patch enables the flag in the underlying lexer.  This way, the program now either turns the trigraph into a single `\` or removes it altogether if the line is short enough.  There are operators like the `??=` in C#.  So the flag is not enabled for all input languages. Instead the check for the token size is moved from the assert line into the if line.

The problem was introduced by my own patch 370bee480139 from about 3 years ago.  I added code to count the number of characters in the escape sequence probably just because the block of code used to have a comment saying someone should add the feature.  Maybe I forgot to enable assertions when I ran the code.  I found the problem because reviewing pull request 145243 made me look at the code again.