### PR TITLE
[clang][bytecode] Narrow allocated single-array Pointer

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -1564,7 +1564,7 @@ static bool interp__builtin_operator_new(InterpState &S, CodePtr OpPC,
   Block *B = Allocator.allocate(Desc, S.getContext().getEvalID(),
                                 DynamicAllocator::Form::Operator);
   assert(B);
-  S.Stk.push<Pointer>(Pointer(B).atIndex(0));
+  S.Stk.push<Pointer>(Pointer(B).atIndex(0).narrow());
   return true;
 }
 


### PR DESCRIPTION
Since the result should not be an array element.