### PR TITLE
[PowerPC] Test SPE incompatibility with VSX

### DIFF
--- a/clang/test/CodeGen/PowerPC/builtins-ppc-fpconstrained.c
+++ b/clang/test/CodeGen/PowerPC/builtins-ppc-fpconstrained.c
@@ -11,7 +11,7 @@
 // RUN: -S -ffp-exception-behavior=strict \
 // RUN: -o - %s | FileCheck --check-prefix=CHECK-ASM \
 // RUN: --check-prefix=FIXME-CHECK  %s
-// RUN: %clang_cc1 -triple powerpcspe -ffp-exception-behavior=strict \
+// RUN: %clang_cc1 -triple powerpc -ffp-exception-behavior=strict \
 // RUN: -target-feature +vsx -fexperimental-strict-floating-point -emit-llvm \
 // RUN: %s -o - | FileCheck --check-prefix=CHECK-CONSTRAINED %s
 

--- a/llvm/test/CodeGen/PowerPC/spe-vsx-incompatibility.ll
+++ b/llvm/test/CodeGen/PowerPC/spe-vsx-incompatibility.ll
@@ -1,0 +1,8 @@
+; Adding -enable-matrix, which is disabled by default, forces the initialization
+; of the PPCSubtarget which verifies the incompatible CPU features.
+; RUN: not llc -mtriple=powerpcspe -mattr=+vsx -enable-matrix < %s 2>&1  | FileCheck %s
+
+; CHECK: SPE and traditional floating point cannot both be enabled
+define void @test() {
+    ret void
+}


### PR DESCRIPTION
PPCSubtarget is not always initialized, depending on which passes are running, and in our downstream fork, -enable-matrix is the default configuration (regardless of whether matrix intrinsics are present in the IR), which triggers a fatal error in builtins-ppc-fpconstrained.c.