### PR TITLE
Add support in LLVM BitstreamWriter to automatically choose abbrevs.

### DIFF
--- a/clang/include/clang/Serialization/ASTRecordWriter.h
+++ b/clang/include/clang/Serialization/ASTRecordWriter.h
@@ -94,7 +94,7 @@ public:
   uint64_t Emit(unsigned Code) {
     uint64_t Offset = Writer->Stream.GetCurrentBitNo();
     PrepareToEmit(Offset);
-    Writer->Stream.EmitRecord(Code, *Record);
+    Writer->Stream.EmitRecordAutoAbbrev(Code, *Record);
     FlushStmts();
     return Offset;
   }

--- a/clang/include/clang/Serialization/ASTRecordWriter.h
+++ b/clang/include/clang/Serialization/ASTRecordWriter.h
@@ -91,20 +91,19 @@ public:
 
   /// Emit the record to the stream, followed by its substatements, and
   /// return its offset.
-  // FIXME: Allow record producers to suggest Abbrevs.
-  uint64_t Emit(unsigned Code, unsigned Abbrev = 0) {
+  uint64_t Emit(unsigned Code) {
     uint64_t Offset = Writer->Stream.GetCurrentBitNo();
     PrepareToEmit(Offset);
-    Writer->Stream.EmitRecord(Code, *Record, Abbrev);
+    Writer->Stream.EmitRecord(Code, *Record);
     FlushStmts();
     return Offset;
   }
 
   /// Emit the record to the stream, preceded by its substatements.
-  uint64_t EmitStmt(unsigned Code, unsigned Abbrev = 0) {
+  uint64_t EmitStmt(unsigned Code) {
     FlushSubStmts();
     PrepareToEmit(Writer->Stream.GetCurrentBitNo());
-    Writer->Stream.EmitRecord(Code, *Record, Abbrev);
+    Writer->Stream.EmitRecordAutoAbbrev(Code, *Record);
     return Writer->Stream.GetCurrentBitNo();
   }
 

--- a/clang/include/clang/Serialization/ASTWriter.h
+++ b/clang/include/clang/Serialization/ASTWriter.h
@@ -638,44 +638,6 @@ private:
   void WriteModuleFileExtension(Sema &SemaRef,
                                 ModuleFileExtensionWriter &Writer);
 
-  unsigned DeclParmVarAbbrev = 0;
-  unsigned DeclContextLexicalAbbrev = 0;
-  unsigned DeclContextVisibleLookupAbbrev = 0;
-  unsigned DeclModuleLocalVisibleLookupAbbrev = 0;
-  unsigned DeclTULocalLookupAbbrev = 0;
-  unsigned UpdateVisibleAbbrev = 0;
-  unsigned ModuleLocalUpdateVisibleAbbrev = 0;
-  unsigned TULocalUpdateVisibleAbbrev = 0;
-  unsigned DeclRecordAbbrev = 0;
-  unsigned DeclTypedefAbbrev = 0;
-  unsigned DeclVarAbbrev = 0;
-  unsigned DeclFieldAbbrev = 0;
-  unsigned DeclEnumAbbrev = 0;
-  unsigned DeclObjCIvarAbbrev = 0;
-  unsigned DeclCXXMethodAbbrev = 0;
-  unsigned DeclSpecializationsAbbrev = 0;
-  unsigned DeclPartialSpecializationsAbbrev = 0;
-
-  unsigned DeclDependentNonTemplateCXXMethodAbbrev = 0;
-  unsigned DeclTemplateCXXMethodAbbrev = 0;
-  unsigned DeclMemberSpecializedCXXMethodAbbrev = 0;
-  unsigned DeclTemplateSpecializedCXXMethodAbbrev = 0;
-  unsigned DeclDependentSpecializationCXXMethodAbbrev = 0;
-  unsigned DeclTemplateTypeParmAbbrev = 0;
-  unsigned DeclUsingShadowAbbrev = 0;
-
-  unsigned DeclRefExprAbbrev = 0;
-  unsigned CharacterLiteralAbbrev = 0;
-  unsigned IntegerLiteralAbbrev = 0;
-  unsigned ExprImplicitCastAbbrev = 0;
-  unsigned BinaryOperatorAbbrev = 0;
-  unsigned CompoundAssignOperatorAbbrev = 0;
-  unsigned CallExprAbbrev = 0;
-  unsigned CXXOperatorCallExprAbbrev = 0;
-  unsigned CXXMemberCallExprAbbrev = 0;
-
-  unsigned CompoundStmtAbbrev = 0;
-
   void WriteDeclAbbrevs();
   void WriteDecl(ASTContext &Context, Decl *D);
 
@@ -843,53 +805,6 @@ public:
   unsigned getSwitchCaseID(SwitchCase *S);
 
   void ClearSwitchCaseIDs();
-
-  unsigned getTypeExtQualAbbrev() const {
-    return TypeExtQualAbbrev;
-  }
-
-  unsigned getDeclParmVarAbbrev() const { return DeclParmVarAbbrev; }
-  unsigned getDeclRecordAbbrev() const { return DeclRecordAbbrev; }
-  unsigned getDeclTypedefAbbrev() const { return DeclTypedefAbbrev; }
-  unsigned getDeclVarAbbrev() const { return DeclVarAbbrev; }
-  unsigned getDeclFieldAbbrev() const { return DeclFieldAbbrev; }
-  unsigned getDeclEnumAbbrev() const { return DeclEnumAbbrev; }
-  unsigned getDeclObjCIvarAbbrev() const { return DeclObjCIvarAbbrev; }
-  unsigned getDeclCXXMethodAbbrev(FunctionDecl::TemplatedKind Kind) const {
-    switch (Kind) {
-    case FunctionDecl::TK_NonTemplate:
-      return DeclCXXMethodAbbrev;
-    case FunctionDecl::TK_FunctionTemplate:
-      return DeclTemplateCXXMethodAbbrev;
-    case FunctionDecl::TK_MemberSpecialization:
-      return DeclMemberSpecializedCXXMethodAbbrev;
-    case FunctionDecl::TK_FunctionTemplateSpecialization:
-      return DeclTemplateSpecializedCXXMethodAbbrev;
-    case FunctionDecl::TK_DependentNonTemplate:
-      return DeclDependentNonTemplateCXXMethodAbbrev;
-    case FunctionDecl::TK_DependentFunctionTemplateSpecialization:
-      return DeclDependentSpecializationCXXMethodAbbrev;
-    }
-    llvm_unreachable("Unknwon Template Kind!");
-  }
-  unsigned getDeclTemplateTypeParmAbbrev() const {
-    return DeclTemplateTypeParmAbbrev;
-  }
-  unsigned getDeclUsingShadowAbbrev() const { return DeclUsingShadowAbbrev; }
-
-  unsigned getDeclRefExprAbbrev() const { return DeclRefExprAbbrev; }
-  unsigned getCharacterLiteralAbbrev() const { return CharacterLiteralAbbrev; }
-  unsigned getIntegerLiteralAbbrev() const { return IntegerLiteralAbbrev; }
-  unsigned getExprImplicitCastAbbrev() const { return ExprImplicitCastAbbrev; }
-  unsigned getBinaryOperatorAbbrev() const { return BinaryOperatorAbbrev; }
-  unsigned getCompoundAssignOperatorAbbrev() const {
-    return CompoundAssignOperatorAbbrev;
-  }
-  unsigned getCallExprAbbrev() const { return CallExprAbbrev; }
-  unsigned getCXXOperatorCallExprAbbrev() { return CXXOperatorCallExprAbbrev; }
-  unsigned getCXXMemberCallExprAbbrev() { return CXXMemberCallExprAbbrev; }
-
-  unsigned getCompoundStmtAbbrev() const { return CompoundStmtAbbrev; }
 
   bool hasChain() const { return Chain; }
   ASTReader *getChain() const { return Chain; }


### PR DESCRIPTION
This adds a new API `BitstreamWriter::EmitRecordAutoAbbrev`, which chooses a valid abbreviation that can encode the provided record, if one exists, otherwise emits an unabbreviated record.

It then uses this new functionality in Clang's ASTWriter, eliminating all error-prone manual specification of abbrevs.

This PR was created as an alternative to the proposal to stop using abbrevs in Clang record emission, in https://discourse.llvm.org/t/rfc-c-modules-stop-using-abbrev-and-drop-the-maintainance.

(Note, only after starting this did I discover that records encoded with a "Blob" abbrev are not interchangeable to the current BitstreamReader code with an unabbreviated record (or an abbrev with e.g. an Array). Given that, I'm wondering if I should remove blob support from EmitRecordAutoAbbrev, and switch the blob-encoding callers back to EmitRecordWithBlob.)