### PR TITLE
[ASTMatchers][NFC] Replace `makeMatcher` function with CTAD

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/Matchers.h
+++ b/clang-tools-extra/clang-tidy/utils/Matchers.h
@@ -145,7 +145,7 @@ private:
 // qualified name will be used for matching, otherwise its name will be used.
 inline ::clang::ast_matchers::internal::Matcher<NamedDecl>
 matchesAnyListedName(llvm::ArrayRef<StringRef> NameList) {
-  return ::clang::ast_matchers::internal::makeMatcher(
+  return ::clang::ast_matchers::internal::Matcher(
       new MatchesAnyListedNameMatcher(NameList));
 }
 
@@ -188,7 +188,7 @@ private:
 inline ::clang::ast_matchers::internal::Matcher<QualType>
 matchesAnyListedTypeName(llvm::ArrayRef<StringRef> NameList,
                          bool CanonicalTypes) {
-  return ::clang::ast_matchers::internal::makeMatcher(
+  return ::clang::ast_matchers::internal::Matcher(
       new MatchesAnyListedTypeNameMatcher(NameList, CanonicalTypes));
 }
 inline ::clang::ast_matchers::internal::Matcher<QualType>

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -672,7 +672,18 @@ private:
   DynTypedMatcher Implementation;
 };  // class Matcher
 
+// Deduction guide for Matcher.
 template <typename T> Matcher(MatcherInterface<T> *) -> Matcher<T>;
+
+// TODO: Remove in LLVM 23.
+template <typename T>
+[[deprecated(
+    "makeMatcher() is deprecated and will be removed in LLVM 23. "
+    "Uses of it can be replaced with direct calls to Matcher's "
+    "constructor; with C++17's CTAD, template arguments will be deduced.")]]
+inline Matcher<T> makeMatcher(MatcherInterface<T> *Implementation) {
+  return Matcher<T>(Implementation);
+}
 
 /// Interface that allows matchers to traverse the AST.
 /// FIXME: Find a better name.

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -672,12 +672,7 @@ private:
   DynTypedMatcher Implementation;
 };  // class Matcher
 
-/// A convenient helper for creating a Matcher<T> without specifying
-/// the template type argument.
-template <typename T>
-inline Matcher<T> makeMatcher(MatcherInterface<T> *Implementation) {
-  return Matcher<T>(Implementation);
-}
+template <typename T> Matcher(MatcherInterface<T> *) -> Matcher<T>;
 
 /// Interface that allows matchers to traverse the AST.
 /// FIXME: Find a better name.

--- a/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersInternal.h
@@ -678,9 +678,7 @@ template <typename T> Matcher(MatcherInterface<T> *) -> Matcher<T>;
 // TODO: Remove in LLVM 23.
 template <typename T>
 [[deprecated(
-    "makeMatcher() is deprecated and will be removed in LLVM 23. "
-    "Uses of it can be replaced with direct calls to Matcher's "
-    "constructor; with C++17's CTAD, template arguments will be deduced.")]]
+    "Use CTAD constructor instead, 'makeMatcher' will be removed in LLVM 23.")]]
 inline Matcher<T> makeMatcher(MatcherInterface<T> *Implementation) {
   return Matcher<T>(Implementation);
 }

--- a/clang/include/clang/ASTMatchers/ASTMatchersMacros.h
+++ b/clang/include/clang/ASTMatchers/ASTMatchersMacros.h
@@ -106,7 +106,7 @@
   };                                                                           \
   }                                                                            \
   inline ::clang::ast_matchers::internal::Matcher<Type> DefineMatcher() {      \
-    return ::clang::ast_matchers::internal::makeMatcher(                       \
+    return ::clang::ast_matchers::internal::Matcher(                           \
         new internal::matcher_##DefineMatcher##Matcher());                     \
   }                                                                            \
   inline bool internal::matcher_##DefineMatcher##Matcher::matches(             \
@@ -150,7 +150,7 @@
   }                                                                            \
   inline ::clang::ast_matchers::internal::Matcher<Type> DefineMatcher(         \
       ParamType const &Param) {                                                \
-    return ::clang::ast_matchers::internal::makeMatcher(                       \
+    return ::clang::ast_matchers::internal::Matcher(                           \
         new internal::matcher_##DefineMatcher##OverloadId##Matcher(Param));    \
   }                                                                            \
   typedef ::clang::ast_matchers::internal::Matcher<Type> (                     \
@@ -200,7 +200,7 @@
   }                                                                            \
   inline ::clang::ast_matchers::internal::Matcher<Type> DefineMatcher(         \
       ParamType1 const &Param1, ParamType2 const &Param2) {                    \
-    return ::clang::ast_matchers::internal::makeMatcher(                       \
+    return ::clang::ast_matchers::internal::Matcher(                           \
         new internal::matcher_##DefineMatcher##OverloadId##Matcher(Param1,     \
                                                                    Param2));   \
   }                                                                            \
@@ -476,7 +476,7 @@
   }                                                                            \
   inline ::clang::ast_matchers::internal::Matcher<Type> DefineMatcher(         \
       llvm::StringRef Param, llvm::Regex::RegexFlags RegexFlags) {             \
-    return ::clang::ast_matchers::internal::makeMatcher(                       \
+    return ::clang::ast_matchers::internal::Matcher(                           \
         new internal::matcher_##DefineMatcher##OverloadId##Matcher(            \
             ::clang::ast_matchers::internal::createAndVerifyRegex(             \
                 Param, RegexFlags, #DefineMatcher)));                          \

--- a/clang/lib/Tooling/Transformer/RewriteRule.cpp
+++ b/clang/lib/Tooling/Transformer/RewriteRule.cpp
@@ -258,9 +258,9 @@ template <typename T>
 ast_matchers::internal::Matcher<T>
 forEachDescendantDynamically(ast_matchers::BoundNodes Nodes,
                              DynTypedMatcher M) {
-  return ast_matchers::internal::makeMatcher(new BindingsMatcher<T>(
+  return ast_matchers::internal::Matcher(new BindingsMatcher<T>(
       std::move(Nodes),
-      ast_matchers::internal::makeMatcher(
+      ast_matchers::internal::Matcher(
           new DynamicForEachDescendantMatcher<T>(std::move(M)))));
 }
 


### PR DESCRIPTION
C++17's CTAD obsoletes `makeMatcher` (and many `make*` functions like it).

The deduction guide is written out explicitly to avoid `-Wctad-maybe-unsupported` warnings.