### PR TITLE
[DebugInfo] [DWARF] Fix C to CMake comment

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/LowLevel/CMakeLists.txt
+++ b/llvm/lib/DebugInfo/DWARF/LowLevel/CMakeLists.txt
@@ -5,8 +5,8 @@ add_llvm_component_library(LLVMDebugInfoDWARFLowLevel
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/DebugInfo/DWARF/LowLevel
 
-  // This code should have almost no dependencies. Anything that needs
-  // more should use the higher-level DebugInfo/DWARF/ library.
+  # This code should have almost no dependencies. Anything that needs
+  # more should use the higher-level DebugInfo/DWARF/ library.
   LINK_COMPONENTS
   BinaryFormat
   Support


### PR DESCRIPTION
This comment affects the actual dependency resolver, causing builds to randomly fail.