### PR TITLE
[cir-translate] Fix crash issue where the data layout string is missing

### DIFF
--- a/clang/test/CIR/Lowering/select.cir
+++ b/clang/test/CIR/Lowering/select.cir
@@ -1,5 +1,5 @@
-// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o %t.ll %s
-// RUN: FileCheck --input-file=%t.ll -check-prefix=LLVM %s
+// RUN: cir-translate -cir-to-llvmir --disable-cc-lowering -o - %s | FileCheck -check-prefix=LLVM %s
+// RUN: cir-translate -target aarch64 -cir-to-llvmir --disable-cc-lowering -o - %s | FileCheck -check-prefix=LLVM %s
 
 !s32i = !cir.int<s, 32>
 


### PR DESCRIPTION
- Targets like 'aarch64' or 'arm' only populate the data layout string after the constructor. Need to call 'CreateTargetInfo' to setup them properly.