### PR TITLE
[AVR] No cli for SPWRITE on XMEGA

### DIFF
--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2556,7 +2556,8 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
 
     buildMI(MBB, MBBI, AVR::BCLRs).addImm(0x07).setMIFlags(Flags);
 
-    buildMI(MBB, MBBI, AVR::OUTARr)
+    if (STI.getIORegSPH() != -1)
+      buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSPH())
         .addReg(SrcHiReg, getKillRegState(SrcIsKill))
         .setMIFlags(Flags);

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2538,12 +2538,12 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   if (STI.getELFArch() >= 102) { // An XMEGA device
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-        .addImm(0x3d)
+        .addImm(STI.getIORegSPL())
         .addReg(SrcLoReg, getKillRegState(SrcIsKill))
         .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-        .addImm(0x3e)
+        .addImm(STI.getIORegSPH())
         .addReg(SrcHiReg, getKillRegState(SrcIsKill))
         .setMIFlags(Flags);
 
@@ -2557,7 +2557,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
     buildMI(MBB, MBBI, AVR::BCLRs).addImm(0x07).setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-        .addImm(0x3e)
+        .addImm(STI.getIORegSPH())
         .addReg(SrcHiReg, getKillRegState(SrcIsKill))
         .setMIFlags(Flags);
 
@@ -2567,7 +2567,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
         .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-        .addImm(0x3d)
+        .addImm(STI.getIORegSPL())
         .addReg(SrcLoReg, getKillRegState(SrcIsKill))
         .setMIFlags(Flags);
   }

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2558,9 +2558,9 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
 
     if (STI.getIORegSPH() != -1)
       buildMI(MBB, MBBI, AVR::OUTARr)
-        .addImm(STI.getIORegSPH())
-        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
-        .setMIFlags(Flags);
+          .addImm(STI.getIORegSPH())
+          .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+          .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSREG())

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2554,7 +2554,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
       .setMIFlags(Flags);
 
   if (STI.getELFArch() < 102 &&
-      STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
+      STI.getIORegSPH() >= 0) // Not an XMEGA device and not just SPL
     buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSREG())
         .addReg(STI.getTmpRegister(), RegState::Kill)

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2536,36 +2536,40 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   // a write to SPL will automatically disable interrupts
   // for up to four instructions or until the next I/O memory write.
   if (STI.getELFArch() >= 102) { // An XMEGA device
+
     buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3d)
-      .addReg(SrcLoReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+        .addImm(0x3d)
+        .addReg(SrcLoReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
+
     buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3e)
-      .addReg(SrcHiReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+        .addImm(0x3e)
+        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
+
   } else { // Disable interrupts for older devices (3 extra instructions)
+
     buildMI(MBB, MBBI, AVR::INRdA)
-      .addReg(STI.getTmpRegister(), RegState::Define)
-      .addImm(STI.getIORegSREG())
-      .setMIFlags(Flags);
+        .addReg(STI.getTmpRegister(), RegState::Define)
+        .addImm(STI.getIORegSREG())
+        .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::BCLRs).addImm(0x07).setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3e)
-      .addReg(SrcHiReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+        .addImm(0x3e)
+        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(STI.getIORegSREG())
-      .addReg(STI.getTmpRegister(), RegState::Kill)
-      .setMIFlags(Flags);
+        .addImm(STI.getIORegSREG())
+        .addReg(STI.getTmpRegister(), RegState::Kill)
+        .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3d)
-      .addReg(SrcLoReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+        .addImm(0x3d)
+        .addReg(SrcLoReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
   }
 
   MI.eraseFromParent();

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2538,7 +2538,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   //
   // For old devices disable interrupts (3 extra instructions)
 
-  if (STI.getELFArch() < 102) { // Not an XMEGA device
+  if (STI.getELFArch() < 102 && STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
     buildMI(MBB, MBBI, AVR::INRdA)
         .addReg(STI.getTmpRegister(), RegState::Define)
         .addImm(STI.getIORegSREG())
@@ -2558,7 +2558,8 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
         .addReg(STI.getTmpRegister(), RegState::Kill)
         .setMIFlags(Flags);
 
-  buildMI(MBB, MBBI, AVR::OUTARr)
+  if (STI.getIORegSPH() >= 0)
+    buildMI(MBB, MBBI, AVR::OUTARr)
       .addImm(STI.getIORegSPH())
       .addReg(SrcHiReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2531,27 +2531,42 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   unsigned Flags = MI.getFlags();
   TRI->splitReg(SrcReg, SrcLoReg, SrcHiReg);
 
-  buildMI(MBB, MBBI, AVR::INRdA)
+  // From the XMEGA series manual:
+  // To prevent corruption when updating the stack pointer from software,
+  // a write to SPL will automatically disable interrupts
+  // for up to four instructions or until the next I/O memory write.
+  if (STI.getELFArch() >= 102) { // An XMEGA device
+    buildMI(MBB, MBBI, AVR::OUTARr)
+      .addImm(0x3d)
+      .addReg(SrcLoReg, getKillRegState(SrcIsKill))
+      .setMIFlags(Flags);
+    buildMI(MBB, MBBI, AVR::OUTARr)
+      .addImm(0x3e)
+      .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+      .setMIFlags(Flags);
+  } else { // Disable interrupts for older devices (3 extra instructions)
+    buildMI(MBB, MBBI, AVR::INRdA)
       .addReg(STI.getTmpRegister(), RegState::Define)
       .addImm(STI.getIORegSREG())
       .setMIFlags(Flags);
 
-  buildMI(MBB, MBBI, AVR::BCLRs).addImm(0x07).setMIFlags(Flags);
+    buildMI(MBB, MBBI, AVR::BCLRs).addImm(0x07).setMIFlags(Flags);
 
-  buildMI(MBB, MBBI, AVR::OUTARr)
+    buildMI(MBB, MBBI, AVR::OUTARr)
       .addImm(0x3e)
       .addReg(SrcHiReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 
-  buildMI(MBB, MBBI, AVR::OUTARr)
+    buildMI(MBB, MBBI, AVR::OUTARr)
       .addImm(STI.getIORegSREG())
       .addReg(STI.getTmpRegister(), RegState::Kill)
       .setMIFlags(Flags);
 
-  buildMI(MBB, MBBI, AVR::OUTARr)
+    buildMI(MBB, MBBI, AVR::OUTARr)
       .addImm(0x3d)
       .addReg(SrcLoReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
+  }
 
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2538,7 +2538,8 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   //
   // For old devices disable interrupts (3 extra instructions)
 
-  if (STI.getELFArch() < 102 && STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
+  if (STI.getELFArch() < 102 &&
+      STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
     buildMI(MBB, MBBI, AVR::INRdA)
         .addReg(STI.getTmpRegister(), RegState::Define)
         .addImm(STI.getIORegSREG())
@@ -2560,9 +2561,9 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
 
   if (STI.getIORegSPH() >= 0)
     buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(STI.getIORegSPH())
-      .addReg(SrcHiReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+        .addImm(STI.getIORegSPH())
+        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
 
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2554,7 +2554,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
       .setMIFlags(Flags);
 
   if (STI.getELFArch() < 102 &&
-      STI.getIORegSPH() >= 0) // Not an XMEGA device and not just SPL
+      STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
     buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSREG())
         .addReg(STI.getTmpRegister(), RegState::Kill)

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2548,7 +2548,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   }
 
   buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3d)
+      .addImm(STI.getIORegSPL())
       .addReg(SrcLoReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 
@@ -2559,7 +2559,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
         .setMIFlags(Flags);
 
   buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3e)
+      .addImm(STI.getIORegSPH())
       .addReg(SrcHiReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2538,8 +2538,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   //
   // For old devices disable interrupts (3 extra instructions)
 
-  if (STI.getELFArch() < 102 &&
-      STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
+  if (STI.getELFArch() < 102 && STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
     buildMI(MBB, MBBI, AVR::INRdA)
         .addReg(STI.getTmpRegister(), RegState::Define)
         .addImm(STI.getIORegSREG())
@@ -2561,9 +2560,9 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
 
   if (STI.getIORegSPH() >= 0)
     buildMI(MBB, MBBI, AVR::OUTARr)
-        .addImm(STI.getIORegSPH())
-        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
-        .setMIFlags(Flags);
+      .addImm(STI.getIORegSPH())
+      .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+      .setMIFlags(Flags);
 
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2548,7 +2548,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   }
 
   buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(STI.getIORegSPL())
+      .addImm(0x3d)
       .addReg(SrcLoReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 
@@ -2559,7 +2559,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
         .setMIFlags(Flags);
 
   buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(STI.getIORegSPH())
+      .addImm(0x3e)
       .addReg(SrcHiReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2553,8 +2553,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
       .addReg(SrcLoReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 
-  if (STI.getELFArch() < 102 &&
-      STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
+  if (STI.getELFArch() < 102) // Not an XMEGA device
     buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSREG())
         .addReg(STI.getTmpRegister(), RegState::Kill)

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2535,33 +2535,42 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   // To prevent corruption when updating the stack pointer from software,
   // a write to SPL will automatically disable interrupts
   // for up to four instructions or until the next I/O memory write.
-  //
-  // For old devices disable interrupts (3 extra instructions)
+  if (STI.getELFArch() >= 102) { // An XMEGA device
 
-  if (STI.getELFArch() < 102) { // Not an XMEGA device
+    buildMI(MBB, MBBI, AVR::OUTARr)
+        .addImm(0x3d)
+        .addReg(SrcLoReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
+
+    buildMI(MBB, MBBI, AVR::OUTARr)
+        .addImm(0x3e)
+        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
+
+  } else { // Disable interrupts for older devices (3 extra instructions)
+
     buildMI(MBB, MBBI, AVR::INRdA)
         .addReg(STI.getTmpRegister(), RegState::Define)
         .addImm(STI.getIORegSREG())
         .setMIFlags(Flags);
 
     buildMI(MBB, MBBI, AVR::BCLRs).addImm(0x07).setMIFlags(Flags);
-  }
 
-  buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3d)
-      .addReg(SrcLoReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+    buildMI(MBB, MBBI, AVR::OUTARr)
+        .addImm(0x3e)
+        .addReg(SrcHiReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
 
-  if (STI.getELFArch() < 102) // Not an XMEGA device
     buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSREG())
         .addReg(STI.getTmpRegister(), RegState::Kill)
         .setMIFlags(Flags);
 
-  buildMI(MBB, MBBI, AVR::OUTARr)
-      .addImm(0x3e)
-      .addReg(SrcHiReg, getKillRegState(SrcIsKill))
-      .setMIFlags(Flags);
+    buildMI(MBB, MBBI, AVR::OUTARr)
+        .addImm(0x3d)
+        .addReg(SrcLoReg, getKillRegState(SrcIsKill))
+        .setMIFlags(Flags);
+  }
 
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2553,7 +2553,8 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
       .addReg(SrcLoReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);
 
-  if (STI.getELFArch() < 102) // Not an XMEGA device
+  if (STI.getELFArch() < 102 &&
+      STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
     buildMI(MBB, MBBI, AVR::OUTARr)
         .addImm(STI.getIORegSREG())
         .addReg(STI.getTmpRegister(), RegState::Kill)

--- a/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -2538,7 +2538,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
   //
   // For old devices disable interrupts (3 extra instructions)
 
-  if (STI.getELFArch() < 102 && STI.getIORegSPH() >= 0) { // Not an XMEGA device and not just SPL
+  if (STI.getELFArch() < 102) { // Not an XMEGA device
     buildMI(MBB, MBBI, AVR::INRdA)
         .addReg(STI.getTmpRegister(), RegState::Define)
         .addImm(STI.getIORegSREG())
@@ -2558,8 +2558,7 @@ bool AVRExpandPseudo::expand<AVR::SPWRITE>(Block &MBB, BlockIt MBBI) {
         .addReg(STI.getTmpRegister(), RegState::Kill)
         .setMIFlags(Flags);
 
-  if (STI.getIORegSPH() >= 0)
-    buildMI(MBB, MBBI, AVR::OUTARr)
+  buildMI(MBB, MBBI, AVR::OUTARr)
       .addImm(STI.getIORegSPH())
       .addReg(SrcHiReg, getKillRegState(SrcIsKill))
       .setMIFlags(Flags);

--- a/llvm/test/CodeGen/AVR/pseudo/SPWRITE.mir
+++ b/llvm/test/CodeGen/AVR/pseudo/SPWRITE.mir
@@ -39,7 +39,6 @@ body: |
     ; NOSPH:       OUTARr 63, killed $r0
     ; NOSPH:       OUTARr 61, $r14
 
-
     ; XMEGA-LABEL: test
     ; XMEGA-LABEL: OUTARr 61, $r14
     ; XMEGA-LABEL: OUTARr 62, $r15

--- a/llvm/test/CodeGen/AVR/pseudo/SPWRITE.mir
+++ b/llvm/test/CodeGen/AVR/pseudo/SPWRITE.mir
@@ -1,0 +1,48 @@
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=attiny11 %s -o - \
+# RUN:     | FileCheck --check-prefix=NOSPH %s
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=atmega328 %s -o - \
+# RUN:     | FileCheck %s
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=attiny817 %s -o - \
+# RUN:     | FileCheck --check-prefix=XMEGA %s
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=atxmega64a1 %s -o - \
+# RUN:     | FileCheck --check-prefix=XMEGA %s
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=atxmega256a3u %s -o - \
+# RUN:     | FileCheck --check-prefix=XMEGA %s
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=attiny1614 %s -o - \
+# RUN:     | FileCheck --check-prefix=XMEGA %s
+# RUN: llc -O0 -run-pass=avr-expand-pseudo -mtriple=avr -mcpu=avr128db28 %s -o - \
+# RUN:     | FileCheck --check-prefix=XMEGA %s
+
+--- |
+  target triple = "avr--"
+  define void @test() {
+  entry:
+    ret void
+  }
+...
+
+---
+name:            test
+body: |
+  bb.0.entry:
+
+    ; CHECK-LABEL: test
+    ; CHECK:       $r0 = INRdA 63
+    ; CHECK:       BCLRs 7, implicit-def $sreg
+    ; CHECK:       OUTARr 62, $r15
+    ; CHECK:       OUTARr 63, killed $r0
+    ; CHECK:       OUTARr 61, $r14
+
+    ; NOSPH-LABEL: test
+    ; NOSPH:       $r0 = INRdA 63
+    ; NOSPH:       BCLRs 7, implicit-def $sreg
+    ; NOSPH:       OUTARr 63, killed $r0
+    ; NOSPH:       OUTARr 61, $r14
+
+
+    ; XMEGA-LABEL: test
+    ; XMEGA-LABEL: OUTARr 61, $r14
+    ; XMEGA-LABEL: OUTARr 62, $r15
+
+    $sp = SPWRITE implicit-def $sp, implicit $sp, $r15r14
+...


### PR DESCRIPTION
From the XMEGA series manual:
_To prevent corruption when updating the stack pointer from software,
a write to SPL will automatically disable interrupts
for up to four instructions or until the next I/O memory write._

This will save 6! instructions in every function with an FP on ALL Xmega devices and it
is compatible with gcc code generation for all those devices. It is also not very modern, because the first devices are from 2013. So this is really significant and it is a small change.

@benshi001 Note that I could not find any existing (SPWRITE) unit tests to which this variant could be added.
