### PR TITLE
[Bitcode][NFC] Add abbrev for FUNC_CODE_DEBUG_LOC (CI-test)

### DIFF
--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -4060,7 +4060,7 @@ void ModuleBitcodeWriter::writeBlockInfo() {
   {
     auto Abbv = std::make_shared<BitCodeAbbrev>();
     Abbv->Add(BitCodeAbbrevOp(bitc::FUNC_CODE_DEBUG_LOC));
-    // NOTE: No IsDistinct field for FUNCTION_DEBUG_LOCs.
+    // NOTE: No IsDistinct field for FUNC_CODE_DEBUG_LOC.
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6));
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 8));
     Abbv->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 6));

--- a/llvm/test/Bitcode/debug-loc-again.ll
+++ b/llvm/test/Bitcode/debug-loc-again.ll
@@ -1,9 +1,9 @@
 ; RUN: llvm-as < %s | llvm-bcanalyzer -dump | FileCheck %s -check-prefix=BC
 ; PR23436: Actually emit DEBUG_LOC_AGAIN records.
 
-; BC: <DEBUG_LOC op
+; BC: <DEBUG_LOC abbrevid
 ; BC: <DEBUG_LOC_AGAIN/>
-; BC: <DEBUG_LOC op
+; BC: <DEBUG_LOC abbrevid
 ; BC: <DEBUG_LOC_AGAIN/>
 
 ; RUN: llvm-as < %s | llvm-dis | FileCheck %s


### PR DESCRIPTION
This is a duplicate of #146497 , adding an abbrev for key-instruction bitcode information, so that I can fix up an obvious test failure, run CI and land it all at once. Doing so on Orlandos behalf. Will land on the basis of the LGTM (given by uh, me) in that other PR.