### PR TITLE
RuntimeLibcalls: Account for Triple default exception handling

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -60,6 +60,14 @@ struct RuntimeLibcallsInfo {
       FloatABI::ABIType FloatABI = FloatABI::Default,
       EABI EABIVersion = EABI::Default, StringRef ABIName = "") {
     initSoftFloatCmpLibcallPredicates();
+
+    // FIXME: The ExceptionModel parameter is to handle the field in
+    // TargetOptions. This interface fails to distinguish the forced disable
+    // case for targets which support exceptions by default. This should
+    // probably be a module flag and removed from TargetOptions.
+    if (ExceptionModel == ExceptionHandling::None)
+      ExceptionModel = TT.getDefaultExceptionHandling();
+
     initLibcalls(TT, ExceptionModel, FloatABI, EABIVersion, ABIName);
   }
 


### PR DESCRIPTION
Previously we were taking the raw TargetOptions exception mode.
This only works correctly for the TargetLowering usage, when
the -exception-model flag is explicitly used.

The interface isn't great, and interprets none to both mean use
target default and unsupported, such that it's not possible to
opt-out of exceptions on targets that report a non-none default.

We also still get the wrong mode in the linker usecase of
RuntimeLibcalls since it doesn't have the TargetMachine. But at
least wrongly being the default is an improvement over being unset.

I'm not really sure how to write a test for this.