### PR TITLE
DAG: Fix asserting in error case for powi softening

### DIFF
--- a/llvm/test/CodeGen/ARM/powi-soften-libcall-error.ll
+++ b/llvm/test/CodeGen/ARM/powi-soften-libcall-error.ll
@@ -1,0 +1,8 @@
+; RUN: not llc -mtriple=arm-linux-gnu -float-abi=soft -filetype=null %s 2>&1 | FileCheck %s
+
+; FIXME: This should not fail but isn't implemented
+; CHECK: error: powi exponent does not match sizeof(int)
+define float @soften_powi_error(float %x, i64 %n) {
+  %powi = call float @llvm.powi.f32.i64(float %x, i64 %n)
+  ret float %powi
+}

--- a/llvm/test/CodeGen/MSP430/powi-soften-libcall-error.ll
+++ b/llvm/test/CodeGen/MSP430/powi-soften-libcall-error.ll
@@ -1,0 +1,16 @@
+; RUN: not llc -mtriple=msp430 -filetype=null %s 2>&1 | FileCheck %s
+
+; FIXME: This should not fail but isn't implemented
+; CHECK: error: powi exponent does not match sizeof(int)
+define float @soften_powi_error(float %x, i32 %n) {
+  %powi = call float @llvm.powi.f32.i32(float %x, i32 %n)
+  ret float %powi
+}
+
+; CHECK: error: powi exponent does not match sizeof(int)
+define float @soften_powi_error_strictfp(float %x, i32 %n) strictfp {
+ %powi = call float @llvm.experimental.constrained.powi.f32.i32(float %x, i32 %n, metadata !"round.tonearest", metadata !"fpexcept.strict")
+  ret float %powi
+}
+
+


### PR DESCRIPTION
We need to return the expected legalized type, not the original
in this case. Also swap to returning poison, and avoid contraction
in error message.