### PR TITLE
[DebugInfo][LoopStrengthReduce] Salvage the debug value of the dead cmp instruction

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -2559,8 +2559,10 @@ ICmpInst *LSRInstance::OptimizeMax(ICmpInst *Cond, IVStrideUse* &CondUse) {
   Instruction *Cmp = cast<Instruction>(Sel->getOperand(0));
   Cond->eraseFromParent();
   Sel->eraseFromParent();
-  if (Cmp->use_empty())
+  if (Cmp->use_empty()) {
+    salvageDebugInfo(*Cmp);
     Cmp->eraseFromParent();
+  }
   return NewCond;
 }
 

--- a/llvm/test/Transforms/LoopStrengthReduce/optimizemax_debugloc.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/optimizemax_debugloc.ll
@@ -6,8 +6,10 @@
 ;; This test case also checks that the debug value of the dead icmp
 ;; instruction is salvaged.
 
-; CHECK:   #dbg_value(i32 %n, ![[META1:[0-9]+]], !DIExpression(DW_OP_lit0, DW_OP_eq, DW_OP_stack_value), ![[META2:[0-9]+]])
-; CHECK: icmp uge i32 %indvar.next, %n, !dbg ![[DBGLOC:[0-9]+]]
+; CHECK-LABEL: bb.nph:
+; CHECK:           #dbg_value(i32 %n, ![[META1:[0-9]+]], !DIExpression(DW_OP_lit0, DW_OP_eq, DW_OP_stack_value), ![[META2:[0-9]+]])
+; CHECK-LABEL: bb:
+; CHECK:         icmp uge i32 %indvar.next, %n, !dbg ![[DBGLOC:[0-9]+]]
 
 ; CHECK: ![[META1]] = !DILocalVariable(name: "1",
 ; CHECK: ![[META2]] = !DILocation(line: 1, column: 1,

--- a/llvm/test/Transforms/LoopStrengthReduce/optimizemax_debugloc.ll
+++ b/llvm/test/Transforms/LoopStrengthReduce/optimizemax_debugloc.ll
@@ -1,7 +1,16 @@
 ; RUN: opt < %s -loop-reduce -S 2>&1 | FileCheck %s
+
 ;; This test case checks that whether the new icmp instruction preserves
 ;; the debug location of the original instruction for %exitcond
+
+;; This test case also checks that the debug value of the dead icmp
+;; instruction is salvaged.
+
+; CHECK:   #dbg_value(i32 %n, ![[META1:[0-9]+]], !DIExpression(DW_OP_lit0, DW_OP_eq, DW_OP_stack_value), ![[META2:[0-9]+]])
 ; CHECK: icmp uge i32 %indvar.next, %n, !dbg ![[DBGLOC:[0-9]+]]
+
+; CHECK: ![[META1]] = !DILocalVariable(name: "1",
+; CHECK: ![[META2]] = !DILocation(line: 1, column: 1,
 ; CHECK: ![[DBGLOC]] = !DILocation(line: 6, column: 1, scope
 
 ; ModuleID = 'simplified-dbg.bc'


### PR DESCRIPTION
Fix #147238 