### PR TITLE
[RISCV] Add compress patterns for Xqcilia instructions with tied-operands

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1560,12 +1560,18 @@ def : CompressPat<(QC_E_LI GPRNoX0:$rd, simm20_li:$imm),
 } // Predicates = [HasVendorXqcili, IsRV32]
 
 let isCompressOnly = true, Predicates = [HasVendorXqcilia, IsRV32] in {
+def : CompressPat<(QC_E_ADDAI GPRNoX0:$rd, simm6nonzero:$imm),
+                  (C_ADDI GPRNoX0:$rd, simm6nonzero:$imm)>;
 def : CompressPat<(QC_E_ADDI GPRNoX0:$rs1, GPRNoX0:$rs1, simm6nonzero:$imm),
                   (C_ADDI GPRNoX0:$rs1, simm6nonzero:$imm)>;
+def : CompressPat<(QC_E_ANDAI GPRC:$rd, simm6:$imm),
+                  (C_ANDI GPRC:$rd, simm6:$imm)>;
 def : CompressPat<(QC_E_ANDI GPRC:$rs1, GPRC:$rs1, simm6:$imm),
                   (C_ANDI GPRC:$rs1, simm6:$imm)>;
 def : CompressPat<(QC_E_ADDI GPRNoX0:$rs1, GPRNoX0:$rs2, 0),
                   (C_MV GPRNoX0:$rs1, GPRNoX0:$rs2)>;
+def : CompressPat<(QC_E_ADDAI X2, simm10_lsb0000nonzero:$imm),
+                  (C_ADDI16SP X2, simm10_lsb0000nonzero:$imm)>;
 def : CompressPat<(QC_E_ADDI X2, X2, simm10_lsb0000nonzero:$imm),
                   (C_ADDI16SP X2, simm10_lsb0000nonzero:$imm)>;
 } // let isCompressOnly = true, Predicates = [HasVendorXqcilia, IsRV32]

--- a/llvm/test/MC/RISCV/xqcilia-valid.s
+++ b/llvm/test/MC/RISCV/xqcilia-valid.s
@@ -10,9 +10,13 @@
 # RUN:     | llvm-objdump --mattr=+experimental-xqcilia --no-print-imm-hex -d - \
 # RUN:     | FileCheck -check-prefix=CHECK-INST %s
 
+.option exact
+
 # CHECK-INST: qc.e.addai      s1, -1
 # CHECK-ENC: encoding: [0x9f,0x24,0xff,0xff,0xff,0xff]
 qc.e.addai x9, 4294967295
+
+.option noexact
 
 # CHECK-INST: qc.e.addai      s1, -2147483648
 # CHECK-ENC: encoding: [0x9f,0x24,0x00,0x00,0x00,0x80]
@@ -27,10 +31,13 @@ qc.e.addi x10, x9, -33554432
 # CHECK-ENC: encoding: [0x1f,0xb5,0xf4,0xbf,0xff,0x7f]
 qc.e.addi x10, x9, 33554431
 
+.option exact
 
 # CHECK-INST: qc.e.andai      s1, -1
 # CHECK-ENC: encoding: [0x9f,0xa4,0xff,0xff,0xff,0xff]
 qc.e.andai x9, 4294967295
+
+.option noexact
 
 # CHECK-INST: qc.e.andai      s1, -2147483648
 # CHECK-ENC: encoding: [0x9f,0xa4,0x00,0x00,0x00,0x80]
@@ -102,3 +109,18 @@ qc.e.addi x5, x6, 0
 # CHECK-NOALIAS: c.addi16sp sp, 48
 # CHECK-ENC: encoding: [0x45,0x61]
 qc.e.addi x2, x2, 48
+
+# CHECK-ALIAS: addi s1, s1, -1
+# CHECK-NOALIAS: c.addi s1, -1
+# CHECK-ENC: encoding: [0xfd,0x14]
+qc.e.addai x9, 4294967295
+
+# CHECK-ALIAS: addi sp, sp, 48
+# CHECK-NOALIAS: c.addi16sp sp, 48
+# CHECK-ENC: encoding: [0x45,0x61]
+qc.e.addai x2, 48
+
+# CHECK-ALIAS: andi s1, s1, -1
+# CHECK-NOALIAS: c.andi s1, -1
+# CHECK-ENC: encoding: [0xfd,0x98]
+qc.e.andai x9, 4294967295

--- a/llvm/test/MC/RISCV/xqcilia-valid.s
+++ b/llvm/test/MC/RISCV/xqcilia-valid.s
@@ -16,7 +16,6 @@
 # CHECK-ENC: encoding: [0x9f,0x24,0xff,0xff,0xff,0xff]
 qc.e.addai x9, 4294967295
 
-.option noexact
 
 # CHECK-INST: qc.e.addai      s1, -2147483648
 # CHECK-ENC: encoding: [0x9f,0x24,0x00,0x00,0x00,0x80]
@@ -31,13 +30,11 @@ qc.e.addi x10, x9, -33554432
 # CHECK-ENC: encoding: [0x1f,0xb5,0xf4,0xbf,0xff,0x7f]
 qc.e.addi x10, x9, 33554431
 
-.option exact
 
 # CHECK-INST: qc.e.andai      s1, -1
 # CHECK-ENC: encoding: [0x9f,0xa4,0xff,0xff,0xff,0xff]
 qc.e.andai x9, 4294967295
 
-.option noexact
 
 # CHECK-INST: qc.e.andai      s1, -2147483648
 # CHECK-ENC: encoding: [0x9f,0xa4,0x00,0x00,0x00,0x80]
@@ -89,6 +86,8 @@ qc.e.xori x10, x9, -33554432
 qc.e.xori x10, x9, 33554431
 
 # Check that compress patterns work as expected
+
+.option noexact
 
 # CHECK-ALIAS: addi t0, t0, 20
 # CHECK-NOALIAS: c.addi t0, 20


### PR DESCRIPTION

Now that the compress instruction emitter supports source instructions with tied-operands, add some patterns for such instructions in the Xqcilia extension.