### PR TITLE
[libclc] Fix typo in OpenCL header math/sincos.h

### DIFF
--- a/libclc/opencl/include/clc/opencl/math/sincos.h
+++ b/libclc/opencl/include/clc/opencl/math/sincos.h
@@ -7,6 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
-#define FUNCTION __clc_sincos
+#define FUNCTION sincos
 #include <clc/math/gentype.inc>
 #undef FUNCTION


### PR DESCRIPTION
llvm-diff shows no change to nvptx64--nvidiacl.bc and amdgcn--amdhsa.bc