### PR TITLE
[DTLTO][Clang] Add support for Integrated Distributed ThinLTO

### DIFF
--- a/clang/docs/ThinLTO.rst
+++ b/clang/docs/ThinLTO.rst
@@ -268,7 +268,7 @@ If ``-fthinlto-distributor=`` is specified, Clang supplies the path to a
 compiler to be executed remotely to perform the ThinLTO backend
 compilations. Currently, this is Clang itself.
 
-Note that currently, DTLTO is only supported in some LLD flavors. Support will
+Note that currently, DTLTO is only supported in some LLD flavors. Support can
 be added to other LLD flavours in the future.
 See `DTLTO <https://lld.llvm.org/dtlto.html>`_ for more information.
 

--- a/clang/docs/ThinLTO.rst
+++ b/clang/docs/ThinLTO.rst
@@ -240,6 +240,38 @@ The ``BOOTSTRAP_LLVM_ENABLE_LTO=Thin`` will enable ThinLTO for stage 2 and
 stage 3 in case the compiler used for stage 1 does not support the ThinLTO
 option.
 
+Integrated Distributed ThinLTO (DTLTO)
+--------------------------------------
+
+Integrated Distributed ThinLTO (DTLTO) enables the distribution of backend
+ThinLTO compilations via external distribution systems, such as Incredibuild,
+during the traditional link step.
+
+The implementation is documented here: https://llvm.org/docs/DTLTO.html.
+
+DTLTO requires the LLD linker (``-fuse-ld=lld``).
+
+``-fthinlto-distributor=<path>``
+   - Specifies the ``<path>`` to the distributor process executable for DTLTO.
+   - If specified, ThinLTO backend compilations will be distributed by LLD.
+
+``-Xthinlto-distributor=<arg>``
+   - Passes ``<arg>`` to the distributor process (see ``-fthinlto-distributor=``).
+   - Can be specified multiple times to pass multiple options.
+   - Multiple options can also be specified by separating them with commas.
+
+Examples:
+   - ``clang -flto=thin -fthinlto-distributor=incredibuild.exe -Xthinlto-distributor=--verbose,--j10 -fuse-ld=lld``
+   - ``clang -flto=thin -fthinlto-distributor=$(which python) -Xthinlto-distributor=incredibuild.py -fuse-ld=lld``
+
+If ``-fthinlto-distributor=`` is specified, Clang supplies the path to a
+compiler to be executed remotely to perform the ThinLTO backend
+compilations. Currently, this is Clang itself.
+
+Note that currently, DTLTO is only supported in some LLD flavors. Support will
+be added to other LLD flavours in the future.
+See `DTLTO <https://lld.llvm.org/dtlto.html>`_ for more information.
+
 More Information
 ================
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -990,6 +990,13 @@ def Xlinker : Separate<["-"], "Xlinker">, Flags<[LinkerInput, RenderAsInput]>,
   Visibility<[ClangOption, CLOption, FlangOption]>,
   HelpText<"Pass <arg> to the linker">, MetaVarName<"<arg>">,
   Group<Link_Group>;
+def Xthinlto_distributor_EQ : CommaJoined<["-"], "Xthinlto-distributor=">,
+  Flags<[LinkOption]>,
+  Visibility<[ClangOption, CLOption]>,
+  HelpText<"Pass <arg> to the ThinLTO distributor process. Can be specified "
+           "multiple times or with comma-separated values.">,
+  MetaVarName<"<arg>">,
+  Group<Link_Group>;
 def Xoffload_linker : JoinedAndSeparate<["-"], "Xoffload-linker">,
   Visibility<[ClangOption, FlangOption]>,
   HelpText<"Pass <arg> to the offload linkers or the ones identified by -<triple>">,
@@ -4233,7 +4240,12 @@ def ffinite_loops: Flag<["-"],  "ffinite-loops">, Group<f_Group>,
 def fno_finite_loops: Flag<["-"], "fno-finite-loops">, Group<f_Group>,
   HelpText<"Do not assume that any loop is finite.">,
   Visibility<[ClangOption, CC1Option]>;
-
+def fthinlto_distributor_EQ : Joined<["-"], "fthinlto-distributor=">,
+  Group<f_Group>,
+  HelpText<"Path to the ThinLTO distributor process. If specified, "
+           "ThinLTO backend compilations will be distributed by LLD">,
+  MetaVarName<"<path>">,
+  Visibility<[ClangOption, CLOption]>;
 def ftrigraphs : Flag<["-"], "ftrigraphs">, Group<f_Group>,
   HelpText<"Process trigraph sequences">, Visibility<[ClangOption, CC1Option]>;
 def fno_trigraphs : Flag<["-"], "fno-trigraphs">, Group<f_Group>,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -1309,6 +1309,17 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
   if (Args.hasArg(options::OPT_ftime_report))
     CmdArgs.push_back(
         Args.MakeArgString(Twine(PluginOptPrefix) + "-time-passes"));
+
+  if (Arg *A = Args.getLastArg(options::OPT_fthinlto_distributor_EQ)) {
+    CmdArgs.push_back(
+        Args.MakeArgString("--thinlto-distributor=" + Twine(A->getValue())));
+    CmdArgs.push_back(
+        Args.MakeArgString("--thinlto-remote-compiler=" +
+                           Twine(ToolChain.getDriver().getClangProgramPath())));
+
+    for (auto A : Args.getAllArgValues(options::OPT_Xthinlto_distributor_EQ))
+      CmdArgs.push_back(Args.MakeArgString("--thinlto-distributor-arg=" + A));
+  }
 }
 
 void tools::addOpenMPRuntimeLibraryPath(const ToolChain &TC,

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -455,21 +455,6 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     addLTOOptions(ToolChain, Args, CmdArgs, Output, Inputs,
                   D.getLTOMode() == LTOK_Thin);
 
-  // Forward the DTLTO options to the linker. We add these unconditionally,
-  // rather than in addLTOOptions() as it is the linker that decides whether to
-  // do LTO or not dependent upon whether there are any bitcode input files in
-  // the link.
-  if (Arg *A = Args.getLastArg(options::OPT_fthinlto_distributor_EQ)) {
-    CmdArgs.push_back(
-        Args.MakeArgString("--thinlto-distributor=" + Twine(A->getValue())));
-    CmdArgs.push_back(
-        Args.MakeArgString("--thinlto-remote-compiler=" +
-                           Twine(ToolChain.getDriver().getClangProgramPath())));
-
-    for (auto A : Args.getAllArgValues(options::OPT_Xthinlto_distributor_EQ))
-      CmdArgs.push_back(Args.MakeArgString("--thinlto-distributor-arg=" + A));
-  }
-
   if (Args.hasArg(options::OPT_Z_Xlinker__no_demangle))
     CmdArgs.push_back("--no-demangle");
 

--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -455,6 +455,21 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     addLTOOptions(ToolChain, Args, CmdArgs, Output, Inputs,
                   D.getLTOMode() == LTOK_Thin);
 
+  // Forward the DTLTO options to the linker. We add these unconditionally,
+  // rather than in addLTOOptions() as it is the linker that decides whether to
+  // do LTO or not dependent upon whether there are any bitcode input files in
+  // the link.
+  if (Arg *A = Args.getLastArg(options::OPT_fthinlto_distributor_EQ)) {
+    CmdArgs.push_back(
+        Args.MakeArgString("--thinlto-distributor=" + Twine(A->getValue())));
+    CmdArgs.push_back(
+        Args.MakeArgString("--thinlto-remote-compiler=" +
+                           Twine(ToolChain.getDriver().getClangProgramPath())));
+
+    for (auto A : Args.getAllArgValues(options::OPT_Xthinlto_distributor_EQ))
+      CmdArgs.push_back(Args.MakeArgString("--thinlto-distributor-arg=" + A));
+  }
+
   if (Args.hasArg(options::OPT_Z_Xlinker__no_demangle))
     CmdArgs.push_back("--no-demangle");
 

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -2,14 +2,10 @@
 
 /// Check DTLTO options are forwarded to the linker.
 
-/// Create a response file to check that explicitly specified -Xthinlto-distributor
-/// options are forwarded correctly.
-// RUN: echo "-flto=thin \"%/s\" -### -fuse-ld=lld --target=x86_64-linux-gnu \
-// RUN:   -Xthinlto-distributor=a1 \
-// RUN:   -Xthinlto-distributor=a2,a3" > %t_l1.rsp
-
 /// Check that options are forwarded as expected with --thinlto-distributor=.
-// RUN: %clang @%t_l1.rsp -fthinlto-distributor=d.exe -Werror 2>&1 | \
+// RUN: %clang -flto=thin %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
+// RUN:   -Xthinlto-distributor=a1 -Xthinlto-distributor=a2,a3 \
+// RUN:   -fthinlto-distributor=d.exe -Werror 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=FORWARD
 
 // FORWARD: ld.lld
@@ -21,20 +17,18 @@
 
 /// Check that options are not added without --thinlto-distributor= and
 /// that a warning is issued for unused -Xthinlto-distributor options.
-// RUN: %clang @%t_l1.rsp 2>&1 | \
+// RUN: %clang -flto=thin %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
+// RUN:   -Xthinlto-distributor=a1 -Xthinlto-distributor=a2,a3 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=NODIST
 
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
 // NODIST: ld.lld
 
-/// Create a response file to check the default behavior.
-// RUN: echo " \"%/s\" -### -fuse-ld=lld --target=x86_64-linux-gnu \
-// RUN:   -fthinlto-distributor=d.exe" > %t_l2.rsp
-
 /// Check the expected arguments are forwarded by default with only
 /// --thinlto-distributor=.
-// RUN: %clang -flto=thin @%t_l2.rsp -Werror 2>&1 | \
+// RUN: %clang -flto=thin %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
+// RUN:   -fthinlto-distributor=d.exe -Werror 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=DEFAULT
 
 // DEFAULT: ld.lld
@@ -43,7 +37,8 @@
 
 /// Check that nothing is forwarded when the compiler is not in LTO mode, and that
 /// appropriate unused option warnings are issued.
-// RUN: %clang @%t_l2.rsp 2>&1 | \
+// RUN: %clang %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
+// RUN:   -fthinlto-distributor=d.exe 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=NOFLTO
 
 // NOFLTO: warning: argument unused during compilation: '-fthinlto-distributor=d.exe'

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -40,7 +40,7 @@
 /// Check the expected arguments are forwarded by default with only
 /// --thinlto-distributor=.
 // RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=d.exe \
-// RUN:   -fuse-ld=lld -Werror -### %s 2>&1 | \
+// RUN:   -fuse-ld=lld -### %s 2>&1 | \
 // RUN:   FileCheck @%t_f.rsp --check-prefix=DEFAULT
 
 // DEFAULT: ld.lld

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -9,7 +9,9 @@
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
 // RUN: %clang -### @%t.rsp -fthinlto-distributor=d.exe %s 2>&1 | \
-// RUN:   FileCheck %s --implicit-check-not=warning --check-prefix=FORWARD
+// RUN:   FileCheck %s --implicit-check-not=distributor \
+// RUN:   --implicit-check-not=remote-compiler \
+// RUN:   --implicit-check-not=warning: --check-prefix=FORWARD
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
@@ -23,20 +25,22 @@
 /// that there is an unused option warning issued for -Xthinlto-distributor=
 /// options. We specify -flto here as these options should be unaffected by it.
 // RUN: %clang -### @%t.rsp -flto=thin %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefixes=NODIST,NOMORE --implicit-check-not=warning
+// RUN:   FileCheck %s --check-prefix=NODIST --implicit-check-not=distributor \
+// RUN:     --implicit-check-not=remote-compiler \
+// RUN:     --implicit-check-not=warning:
 
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
 // NODIST: ld.lld
-// NOMORE-NOT: distributor
-// NOMORE-NOT: remote-compiler
 
 
 /// Check the expected arguments are forwarded by default with only
 /// --thinlto-distributor=.
 // RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=d.exe \
 // RUN:   -fuse-ld=lld -Werror -### %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefixes=DEFAULT,NOMORE
+// RUN:   FileCheck %s --check-prefix=DEFAULT --implicit-check-not=distributor \
+// RUN:     --implicit-check-not=remote-compiler \
+// RUN:     --implicit-check-not=warning:
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -9,13 +9,14 @@
 // RUN:   --implicit-check-not=remote-compiler \
 // RUN:   --implicit-check-not=warning:" > %t_f.rsp
 
-// RUN: echo "--target=x86_64-linux-gnu \
+/// Create a response file to check that explicitly specified -Xthinlto-distributor
+/// options are forwarded correctly.
+// RUN: echo "-flto=thin \"%/s\" -### -fuse-ld=lld --target=x86_64-linux-gnu \
 // RUN:   -Xthinlto-distributor=a1 \
-// RUN:   -Xthinlto-distributor=a2,a3 \
-// RUN:   -fuse-ld=lld" > %t.rsp
+// RUN:   -Xthinlto-distributor=a2,a3" > %t_l1.rsp
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
-// RUN: %clang -### @%t.rsp -fthinlto-distributor=d.exe %s 2>&1 | \
+// RUN: %clang @%t_l1.rsp -fthinlto-distributor=d.exe 2>&1 | \
 // RUN:   FileCheck @%t_f.rsp --check-prefix=FORWARD
 
 // FORWARD: ld.lld
@@ -29,7 +30,7 @@
 /// Check that options are not added without --thinlto-distributor= and
 /// that there is an unused option warning issued for -Xthinlto-distributor=
 /// options. We specify -flto here as these options should be unaffected by it.
-// RUN: %clang -### @%t.rsp -flto=thin %s 2>&1 | \
+// RUN: %clang @%t_l1.rsp 2>&1 | \
 // RUN:   FileCheck @%t_f.rsp --check-prefix=NODIST
 
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -9,25 +9,25 @@
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
 // RUN: %clang -### @%t.rsp -fthinlto-distributor=d.exe %s 2>&1 | \
-// RUN:   FileCheck %s --implicit-check-not=warning
+// RUN:   FileCheck %s --implicit-check-not=warning --check-prefix=FORWARD
 
-// CHECK: ld.lld
-// CHECK-SAME: "--thinlto-distributor=d.exe"
-// CHECK-SAME: "--thinlto-remote-compiler={{.*}}clang
-// CHECK-SAME: "--thinlto-distributor-arg=a1"
-// CHECK-SAME: "--thinlto-distributor-arg=a2"
-// CHECK-SAME: "--thinlto-distributor-arg=a3"
+// FORWARD: ld.lld
+// FORWARD-SAME: "--thinlto-distributor=d.exe"
+// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang
+// FORWARD-SAME: "--thinlto-distributor-arg=a1"
+// FORWARD-SAME: "--thinlto-distributor-arg=a2"
+// FORWARD-SAME: "--thinlto-distributor-arg=a3"
 
 
 /// Check that options are not added without --thinlto-distributor= and
 /// that there is an unused option warning issued for -Xthinlto-distributor=
 /// options. We specify -flto here as these options should be unaffected by it.
 // RUN: %clang -### @%t.rsp -flto=thin %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefixes=NONE,NOMORE --implicit-check-not=warning
+// RUN:   FileCheck %s --check-prefixes=NODIST,NOMORE --implicit-check-not=warning
 
-// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
-// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
-// NONE:     ld.lld
+// NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
+// NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
+// NODIST: ld.lld
 // NOMORE-NOT: distributor
 // NOMORE-NOT: remote-compiler
 

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -19,7 +19,8 @@
 /// that a warning is issued for unused -Xthinlto-distributor options.
 // RUN: %clang -flto=thin %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
 // RUN:   -Xthinlto-distributor=a1 -Xthinlto-distributor=a2,a3 2>&1 | \
-// RUN:   FileCheck %s --check-prefix=NODIST
+// RUN:   FileCheck %s --check-prefix=NODIST --implicit-check-not=distributor \
+// RUN:     --implicit-check-not=remote-compiler
 
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
@@ -29,7 +30,8 @@
 /// --thinlto-distributor=.
 // RUN: %clang -flto=thin %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
 // RUN:   -fthinlto-distributor=d.exe -Werror 2>&1 | \
-// RUN:   FileCheck %s --check-prefix=DEFAULT
+// RUN:   FileCheck %s --check-prefix=DEFAULT --implicit-check-not=distributor \
+// RUN:     --implicit-check-not=remote-compiler
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
@@ -39,7 +41,8 @@
 /// appropriate unused option warnings are issued.
 // RUN: %clang %s -### -fuse-ld=lld --target=x86_64-linux-gnu \
 // RUN:   -fthinlto-distributor=d.exe 2>&1 | \
-// RUN:   FileCheck %s --check-prefix=NOFLTO
+// RUN:   FileCheck %s --check-prefix=NOFLTO --implicit-check-not=distributor \
+// RUN:     --implicit-check-not=remote-compiler
 
 // NOFLTO: warning: argument unused during compilation: '-fthinlto-distributor=d.exe'
 // NOFLTO: ld.lld

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -3,20 +3,20 @@
 /// Check DTLTO options are forwarded to the linker.
 
 // RUN: echo "--target=x86_64-linux-gnu \
-// RUN:   -Xthinlto-distributor=distarg1 \
-// RUN:   -Xthinlto-distributor=distarg2,distarg3 \
+// RUN:   -Xthinlto-distributor=a1 \
+// RUN:   -Xthinlto-distributor=a2,a3 \
 // RUN:   -fuse-ld=lld" > %t.rsp
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
-// RUN: %clang -### @%t.rsp -fthinlto-distributor=dist.exe %s 2>&1 | \
+// RUN: %clang -### @%t.rsp -fthinlto-distributor=d.exe %s 2>&1 | \
 // RUN:   FileCheck %s --implicit-check-not=warning
 
 // CHECK: ld.lld
-// CHECK-SAME: "--thinlto-distributor=dist.exe"
+// CHECK-SAME: "--thinlto-distributor=d.exe"
 // CHECK-SAME: "--thinlto-remote-compiler={{.*}}clang
-// CHECK-SAME: "--thinlto-distributor-arg=distarg1"
-// CHECK-SAME: "--thinlto-distributor-arg=distarg2"
-// CHECK-SAME: "--thinlto-distributor-arg=distarg3"
+// CHECK-SAME: "--thinlto-distributor-arg=a1"
+// CHECK-SAME: "--thinlto-distributor-arg=a2"
+// CHECK-SAME: "--thinlto-distributor-arg=a3"
 
 
 /// Check that options are not added without --thinlto-distributor= and
@@ -25,8 +25,8 @@
 // RUN: %clang -### @%t.rsp -flto=thin %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=NONE,NOMORE --implicit-check-not=warning
 
-// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=distarg1'
-// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=distarg2,distarg3'
+// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
+// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
 // NONE:     ld.lld
 // NOMORE-NOT: distributor
 // NOMORE-NOT: remote-compiler
@@ -34,10 +34,10 @@
 
 /// Check the expected arguments are forwarded by default with only
 /// --thinlto-distributor=.
-// RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=dist.exe \
+// RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=d.exe \
 // RUN:   -fuse-ld=lld -Werror -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEFAULT,NOMORE
 
 // DEFAULT: ld.lld
-// DEFAULT-SAME: "--thinlto-distributor=dist.exe"
+// DEFAULT-SAME: "--thinlto-distributor=d.exe"
 // DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -36,11 +36,13 @@
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
 // NODIST: ld.lld
 
+/// Create a response file to check the default behavior.
+// RUN: echo " \"%/s\" -### -fuse-ld=lld --target=x86_64-linux-gnu \
+// RUN:   -fthinlto-distributor=d.exe" > %t_l2.rsp
 
 /// Check the expected arguments are forwarded by default with only
 /// --thinlto-distributor=.
-// RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=d.exe \
-// RUN:   -fuse-ld=lld -### %s 2>&1 | \
+// RUN: %clang -flto=thin @%t_l2.rsp 2>&1 | \
 // RUN:   FileCheck @%t_f.rsp --check-prefix=DEFAULT
 
 // DEFAULT: ld.lld

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -5,7 +5,7 @@
 /// Create a response file for all FileCheck invocations to share. These implicit
 /// checks ensure that all lines which mention DTLTO options are checked,
 /// and that no unexpected warnings appear.
-// RUN: echo " \"%s\" --implicit-check-not=distributor \
+// RUN: echo " \"%/s\" --implicit-check-not=distributor \
 // RUN:   --implicit-check-not=remote-compiler \
 // RUN:   --implicit-check-not=warning:" > %t_f.rsp
 

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -2,6 +2,13 @@
 
 /// Check DTLTO options are forwarded to the linker.
 
+/// Create a response file for all FileCheck invocations to share. These implicit
+/// checks ensure that all lines which mention DTLTO options are checked,
+/// and that no unexpected warnings appear.
+// RUN: echo " \"%s\" --implicit-check-not=distributor \
+// RUN:   --implicit-check-not=remote-compiler \
+// RUN:   --implicit-check-not=warning:" > %t_f.rsp
+
 // RUN: echo "--target=x86_64-linux-gnu \
 // RUN:   -Xthinlto-distributor=a1 \
 // RUN:   -Xthinlto-distributor=a2,a3 \
@@ -9,9 +16,7 @@
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
 // RUN: %clang -### @%t.rsp -fthinlto-distributor=d.exe %s 2>&1 | \
-// RUN:   FileCheck %s --implicit-check-not=distributor \
-// RUN:   --implicit-check-not=remote-compiler \
-// RUN:   --implicit-check-not=warning: --check-prefix=FORWARD
+// RUN:   FileCheck @%t_f.rsp --check-prefix=FORWARD
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
@@ -25,9 +30,7 @@
 /// that there is an unused option warning issued for -Xthinlto-distributor=
 /// options. We specify -flto here as these options should be unaffected by it.
 // RUN: %clang -### @%t.rsp -flto=thin %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefix=NODIST --implicit-check-not=distributor \
-// RUN:     --implicit-check-not=remote-compiler \
-// RUN:     --implicit-check-not=warning:
+// RUN:   FileCheck @%t_f.rsp --check-prefix=NODIST
 
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
@@ -38,9 +41,7 @@
 /// --thinlto-distributor=.
 // RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=d.exe \
 // RUN:   -fuse-ld=lld -Werror -### %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefix=DEFAULT --implicit-check-not=distributor \
-// RUN:     --implicit-check-not=remote-compiler \
-// RUN:     --implicit-check-not=warning:
+// RUN:   FileCheck @%t_f.rsp --check-prefix=DEFAULT
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -21,7 +21,7 @@
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang{{(.exe)?}}"
+// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"
@@ -46,7 +46,7 @@
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
-// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang{{(.exe)?}}"
+// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
 
 /// Check that nothing is forwarded when the compiler is not in LTO mode, and that
 /// appropriate unused option warnings are issued.

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -2,13 +2,6 @@
 
 /// Check DTLTO options are forwarded to the linker.
 
-/// Create a response file for all FileCheck invocations to share. These implicit
-/// checks ensure that all lines which mention DTLTO options are checked,
-/// and that no unexpected warnings appear.
-// RUN: echo " \"%/s\" --implicit-check-not=distributor \
-// RUN:   --implicit-check-not=remote-compiler \
-// RUN:   --implicit-check-not=warning:" > %t_f.rsp
-
 /// Create a response file to check that explicitly specified -Xthinlto-distributor
 /// options are forwarded correctly.
 // RUN: echo "-flto=thin \"%/s\" -### -fuse-ld=lld --target=x86_64-linux-gnu \
@@ -16,8 +9,8 @@
 // RUN:   -Xthinlto-distributor=a2,a3" > %t_l1.rsp
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
-// RUN: %clang @%t_l1.rsp -fthinlto-distributor=d.exe 2>&1 | \
-// RUN:   FileCheck @%t_f.rsp --check-prefix=FORWARD
+// RUN: %clang @%t_l1.rsp -fthinlto-distributor=d.exe -Werror 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=FORWARD
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
@@ -29,7 +22,7 @@
 /// Check that options are not added without --thinlto-distributor= and
 /// that a warning is issued for unused -Xthinlto-distributor options.
 // RUN: %clang @%t_l1.rsp 2>&1 | \
-// RUN:   FileCheck @%t_f.rsp --check-prefix=NODIST
+// RUN:   FileCheck %s --check-prefix=NODIST
 
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a1'
 // NODIST: warning: argument unused during compilation: '-Xthinlto-distributor=a2,a3'
@@ -41,8 +34,8 @@
 
 /// Check the expected arguments are forwarded by default with only
 /// --thinlto-distributor=.
-// RUN: %clang -flto=thin @%t_l2.rsp 2>&1 | \
-// RUN:   FileCheck @%t_f.rsp --check-prefix=DEFAULT
+// RUN: %clang -flto=thin @%t_l2.rsp -Werror 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=DEFAULT
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
@@ -51,7 +44,7 @@
 /// Check that nothing is forwarded when the compiler is not in LTO mode, and that
 /// appropriate unused option warnings are issued.
 // RUN: %clang @%t_l2.rsp 2>&1 | \
-// RUN:   FileCheck @%t_f.rsp --check-prefix=NOFLTO
+// RUN:   FileCheck %s --check-prefix=NOFLTO
 
 // NOFLTO: warning: argument unused during compilation: '-fthinlto-distributor=d.exe'
 // NOFLTO: ld.lld

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -21,11 +21,10 @@
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang
+// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang{{(.exe)?}}"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"
-
 
 /// Check that options are not added without --thinlto-distributor= and
 /// that there is an unused option warning issued for -Xthinlto-distributor=
@@ -46,4 +45,4 @@
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
-// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang
+// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang{{(.exe)?}}"

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -27,8 +27,7 @@
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"
 
 /// Check that options are not added without --thinlto-distributor= and
-/// that there is an unused option warning issued for -Xthinlto-distributor=
-/// options. We specify -flto here as these options should be unaffected by it.
+/// that a warning is issued for unused -Xthinlto-distributor options.
 // RUN: %clang @%t_l1.rsp 2>&1 | \
 // RUN:   FileCheck @%t_f.rsp --check-prefix=NODIST
 
@@ -48,3 +47,11 @@
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
 // DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang{{(.exe)?}}"
+
+/// Check that nothing is forwarded when the compiler is not in LTO mode, and that
+/// appropriate unused option warnings are issued.
+// RUN: %clang @%t_l2.rsp 2>&1 | \
+// RUN:   FileCheck @%t_f.rsp --check-prefix=NOFLTO
+
+// NOFLTO: warning: argument unused during compilation: '-fthinlto-distributor=d.exe'
+// NOFLTO: ld.lld

--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -1,0 +1,43 @@
+// REQUIRES: lld
+
+/// Check DTLTO options are forwarded to the linker.
+
+// RUN: echo "--target=x86_64-linux-gnu \
+// RUN:   -Xthinlto-distributor=distarg1 \
+// RUN:   -Xthinlto-distributor=distarg2,distarg3 \
+// RUN:   -fuse-ld=lld" > %t.rsp
+
+/// Check that options are forwarded as expected with --thinlto-distributor=.
+// RUN: %clang -### @%t.rsp -fthinlto-distributor=dist.exe %s 2>&1 | \
+// RUN:   FileCheck %s --implicit-check-not=warning
+
+// CHECK: ld.lld
+// CHECK-SAME: "--thinlto-distributor=dist.exe"
+// CHECK-SAME: "--thinlto-remote-compiler={{.*}}clang
+// CHECK-SAME: "--thinlto-distributor-arg=distarg1"
+// CHECK-SAME: "--thinlto-distributor-arg=distarg2"
+// CHECK-SAME: "--thinlto-distributor-arg=distarg3"
+
+
+/// Check that options are not added without --thinlto-distributor= and
+/// that there is an unused option warning issued for -Xthinlto-distributor=
+/// options. We specify -flto here as these options should be unaffected by it.
+// RUN: %clang -### @%t.rsp -flto=thin %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=NONE,NOMORE --implicit-check-not=warning
+
+// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=distarg1'
+// NONE: warning: argument unused during compilation: '-Xthinlto-distributor=distarg2,distarg3'
+// NONE:     ld.lld
+// NOMORE-NOT: distributor
+// NOMORE-NOT: remote-compiler
+
+
+/// Check the expected arguments are forwarded by default with only
+/// --thinlto-distributor=.
+// RUN: %clang --target=x86_64-linux-gnu -fthinlto-distributor=dist.exe \
+// RUN:   -fuse-ld=lld -Werror -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEFAULT,NOMORE
+
+// DEFAULT: ld.lld
+// DEFAULT-SAME: "--thinlto-distributor=dist.exe"
+// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang

--- a/cross-project-tests/dtlto/ld-dtlto.c
+++ b/cross-project-tests/dtlto/ld-dtlto.c
@@ -5,13 +5,11 @@
 
 // RUN: rm -rf %t && mkdir %t && cd %t
 
-// RUN: %clang --target=x86_64-linux-gnu -c -flto=thin %s -o dtlto.o
-
-// RUN: ld.lld dtlto.o \
-// RUN:   --thinlto-distributor=%python \
-// RUN:   --thinlto-distributor-arg=%llvm_src_root/utils/dtlto/local.py \
-// RUN:   --thinlto-remote-compiler=%clang \
-// RUN:   --thinlto-remote-compiler-arg=--save-temps
+// RUN: %clang --target=x86_64-linux-gnu %s -flto=thin -fuse-ld=lld \
+// RUN:   -fthinlto-distributor=%python \
+// RUN:   -Xthinlto-distributor=%llvm_src_root/utils/dtlto/local.py \
+// RUN:   -Wl,--thinlto-remote-compiler-arg=--save-temps \
+// RUN:   -nostdlib -Werror
 
 /// Check that the required output files have been created.
 // RUN: ls | sort | FileCheck %s
@@ -22,18 +20,15 @@
 /// Linked ELF.
 // CHECK: {{^}}a.out{{$}}
 
-/// Produced by the bitcode compilation.
-// CHECK-NEXT: {{^}}dtlto.o{{$}}
-
 /// --save-temps output for the backend compilation.
-// CHECK-NEXT: {{^}}dtlto.s{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.0.preopt.bc{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.1.promote.bc{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.2.internalize.bc{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.3.import.bc{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.4.opt.bc{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.5.precodegen.bc{{$}}
-// CHECK-NEXT: {{^}}dtlto.s.resolution.txt{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP:[a-zA-Z0-9_]+]].s{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.0.preopt.bc{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.1.promote.bc{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.2.internalize.bc{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.3.import.bc{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.4.opt.bc{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.5.precodegen.bc{{$}}
+// CHECK-NEXT: {{^}}ld-dtlto-[[TMP]].s.resolution.txt{{$}}
 
 /// No files are expected after.
 // CHECK-NOT: {{.}}


### PR DESCRIPTION
This patch introduces support for Integrated Distributed ThinLTO (DTLTO) in Clang.

DTLTO enables the distribution of ThinLTO backend compilations via external distribution systems, such as Incredibuild, during the traditional link step: https://llvm.org/docs/DTLTO.html.

Testing:
- `lit` test coverage has been added to Clang's Driver tests.
- The DTLTO cross-project tests will use this Clang support.

For the design discussion of the DTLTO feature, see: https://github.com/llvm/llvm-project/pull/126654

Note that I have removed the forwarding of -mllvm options to the backend compilations which was discussed in the design review from this patch. LTO configuration for DTLTO will be addressed in a follow-up patch. In the meantime -mllvm options can be forwarded manually if required.