### PR TITLE
[mlir][SPIRV] Add `spirv.vce` when create `spirv.module` in GPUToSPIRV

### DIFF
--- a/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
+++ b/mlir/lib/Conversion/GPUToSPIRV/GPUToSPIRV.cpp
@@ -368,8 +368,8 @@ LogicalResult GPUModuleConversion::matchAndRewrite(
   // Add a keyword to the module name to avoid symbolic conflict.
   std::string spvModuleName = (kSPIRVModule + moduleOp.getName()).str();
   auto spvModule = rewriter.create<spirv::ModuleOp>(
-      moduleOp.getLoc(), addressingModel, *memoryModel, std::nullopt,
-      StringRef(spvModuleName));
+      moduleOp.getLoc(), addressingModel, *memoryModel,
+      targetEnv.getAttr().getTripleAttr(), StringRef(spvModuleName));
 
   // Move the region from the module op into the SPIR-V module.
   Region &spvModuleRegion = spvModule.getRegion();


### PR DESCRIPTION
In GPUToSPIRV conversion, we can pass the `spirv.vce` triple obtained from `spirv.target_env` when creating a `spirv.module` in `GPUModuleConversion::matchAndRewrite` because `spirv.target_env` must derived by executing `lookupTargetEnvOrDefault`