### PR TITLE
[Clang] Do not mark ambiguous specialization invalid.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -903,6 +903,7 @@ Bug Fixes to C++ Support
 - Fix a bug where private access specifier of overloaded function not respected. (#GH107629)
 - Correctly handle allocations in the condition of a ``if constexpr``.(#GH120197) (#GH134820)
 - Fixed a crash when handling invalid member using-declaration in C++20+ mode. (#GH63254)
+- Fix a crash when trying to instantiate an ambiguous specialization. (#GH51866)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4111,7 +4111,6 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
         if (Ambiguous) {
           // Partial ordering did not produce a clear winner. Complain.
           Inst.Clear();
-          ClassTemplateSpec->setInvalidDecl();
           S.Diag(PointOfInstantiation,
                  diag::err_partial_spec_ordering_ambiguous)
               << ClassTemplateSpec;

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4111,9 +4111,6 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
         if (Ambiguous) {
           // Partial ordering did not produce a clear winner. Complain.
           Inst.Clear();
-
-          ClassTemplateSpec->setInvalidDecl();
-
           S.Diag(PointOfInstantiation,
                  diag::err_partial_spec_ordering_ambiguous)
               << ClassTemplateSpec;

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4111,6 +4111,10 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
         if (Ambiguous) {
           // Partial ordering did not produce a clear winner. Complain.
           Inst.Clear();
+
+          if (!S.isSFINAEContext())
+            ClassTemplateSpec->setInvalidDecl();
+
           S.Diag(PointOfInstantiation,
                  diag::err_partial_spec_ordering_ambiguous)
               << ClassTemplateSpec;

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -4112,8 +4112,7 @@ static ActionResult<CXXRecordDecl *> getPatternForClassTemplateSpecialization(
           // Partial ordering did not produce a clear winner. Complain.
           Inst.Clear();
 
-          if (!S.isSFINAEContext())
-            ClassTemplateSpec->setInvalidDecl();
+          ClassTemplateSpec->setInvalidDecl();
 
           S.Diag(PointOfInstantiation,
                  diag::err_partial_spec_ordering_ambiguous)

--- a/clang/test/SemaTemplate/partial-order.cpp
+++ b/clang/test/SemaTemplate/partial-order.cpp
@@ -47,3 +47,29 @@ namespace GH132562 {
     // expected-note@-2 {{value of type 'const J' is not implicitly convertible to 'int'}}
   } // namespace t3
 } // namespace GH132562
+
+namespace GH51866 {
+
+template <class> struct Trait;
+template <class T>
+    requires T::one
+struct Trait<T> {}; // #gh51866-one
+template <class T>
+    requires T::two
+struct Trait<T> {}; // #gh51866-two
+
+struct Y {
+    static constexpr bool one = true;
+    static constexpr bool two = true;
+};
+
+template <class T>
+concept C = sizeof(Trait<T>) != 0;
+
+static_assert(!C<Y>);
+
+Trait<Y> t;
+// expected-error@-1{{ambiguous partial specializations of 'Trait<GH51866::Y>'}}
+// expected-note@#gh51866-one{{partial specialization matches}}
+// expected-note@#gh51866-two{{partial specialization matches}}
+}


### PR DESCRIPTION
When a specialization was ambiguous, we would mark it as invalid, even if the specialization occured in an immediate context.

This would subsequently lead to scenarios where invalid specialization produced no diagnostics, causing crashes during codegen.

Fixes #51866