### PR TITLE
[libclc] Tighten OpenCL builtin include strategy

### DIFF
--- a/libclc/opencl/include/clc/opencl/common/degrees.h
+++ b/libclc/opencl/include/clc/opencl/common/degrees.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_COMMON_DEGREES_H__
+#define __CLC_OPENCL_COMMON_DEGREES_H__
+
 #define FUNCTION degrees
 #define __CLC_BODY <clc/math/unary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_COMMON_DEGREES_H__

--- a/libclc/opencl/include/clc/opencl/common/mix.h
+++ b/libclc/opencl/include/clc/opencl/common/mix.h
@@ -6,5 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_COMMON_MIX_H__
+#define __CLC_OPENCL_COMMON_MIX_H__
+
 #define __CLC_BODY <clc/opencl/common/mix.inc>
 #include <clc/math/gentype.inc>
+
+#endif // __CLC_OPENCL_COMMON_MIX_H__

--- a/libclc/opencl/include/clc/opencl/common/radians.h
+++ b/libclc/opencl/include/clc/opencl/common/radians.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_COMMON_RADIANS_H__
+#define __CLC_OPENCL_COMMON_RADIANS_H__
+
 #define FUNCTION radians
 #define __CLC_BODY <clc/math/unary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_COMMON_RADIANS_H__

--- a/libclc/opencl/include/clc/opencl/common/sign.h
+++ b/libclc/opencl/include/clc/opencl/common/sign.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_COMMON_SIGN_H__
+#define __CLC_OPENCL_COMMON_SIGN_H__
+
 #define FUNCTION sign
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_COMMON_SIGN_H__

--- a/libclc/opencl/include/clc/opencl/common/smoothstep.h
+++ b/libclc/opencl/include/clc/opencl/common/smoothstep.h
@@ -6,5 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_COMMON_SMOOTHSTEP_H__
+#define __CLC_OPENCL_COMMON_SMOOTHSTEP_H__
+
 #define __CLC_BODY <clc/opencl/common/smoothstep.inc>
 #include <clc/math/gentype.inc>
+
+#endif // __CLC_OPENCL_COMMON_SMOOTHSTEP_H__

--- a/libclc/opencl/include/clc/opencl/common/step.h
+++ b/libclc/opencl/include/clc/opencl/common/step.h
@@ -6,5 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_COMMON_STEP_H__
+#define __CLC_OPENCL_COMMON_STEP_H__
+
 #define __CLC_BODY <clc/opencl/common/step.inc>
 #include <clc/math/gentype.inc>
+
+#endif // __CLC_OPENCL_COMMON_STEP_H__

--- a/libclc/opencl/include/clc/opencl/geometric/cross.h
+++ b/libclc/opencl/include/clc/opencl/geometric/cross.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_CROSS_H__
+#define __CLC_OPENCL_GEOMETRIC_CROSS_H__
+
 _CLC_OVERLOAD _CLC_DECL float3 cross(float3 p0, float3 p1);
 _CLC_OVERLOAD _CLC_DECL float4 cross(float4 p0, float4 p1);
 
@@ -13,3 +16,5 @@ _CLC_OVERLOAD _CLC_DECL float4 cross(float4 p0, float4 p1);
 _CLC_OVERLOAD _CLC_DECL double3 cross(double3 p0, double3 p1);
 _CLC_OVERLOAD _CLC_DECL double4 cross(double4 p0, double4 p1);
 #endif
+
+#endif // __CLC_OPENCL_GEOMETRIC_CROSS_H__

--- a/libclc/opencl/include/clc/opencl/geometric/distance.h
+++ b/libclc/opencl/include/clc/opencl/geometric/distance.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_DISTANCE_H__
+#define __CLC_OPENCL_GEOMETRIC_DISTANCE_H__
+
 #define FUNCTION distance
 #define __CLC_BODY <clc/geometric/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_GEOMETRIC_DISTANCE_H__

--- a/libclc/opencl/include/clc/opencl/geometric/dot.h
+++ b/libclc/opencl/include/clc/opencl/geometric/dot.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_DOT_H__
+#define __CLC_OPENCL_GEOMETRIC_DOT_H__
+
 #define FUNCTION dot
 #define __CLC_BODY <clc/geometric/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_GEOMETRIC_DOT_H__

--- a/libclc/opencl/include/clc/opencl/geometric/fast_distance.h
+++ b/libclc/opencl/include/clc/opencl/geometric/fast_distance.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_FAST_DISTANCE_H__
+#define __CLC_OPENCL_GEOMETRIC_FAST_DISTANCE_H__
+
 #define __FLOAT_ONLY
 #define FUNCTION fast_distance
 #define __CLC_BODY <clc/geometric/binary_decl.inc>
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_GEOMETRIC_FAST_DISTANCE_H__

--- a/libclc/opencl/include/clc/opencl/geometric/fast_length.h
+++ b/libclc/opencl/include/clc/opencl/geometric/fast_length.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_FAST_LENGTH_H__
+#define __CLC_OPENCL_GEOMETRIC_FAST_LENGTH_H__
+
 #define __FLOAT_ONLY
 #define FUNCTION fast_length
 #define __CLC_BODY <clc/geometric/unary_decl.inc>
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_GEOMETRIC_FAST_LENGTH_H__

--- a/libclc/opencl/include/clc/opencl/geometric/fast_normalize.h
+++ b/libclc/opencl/include/clc/opencl/geometric/fast_normalize.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_FAST_NORMALIZE_H__
+#define __CLC_OPENCL_GEOMETRIC_FAST_NORMALIZE_H__
+
 #define __FLOAT_ONLY
 #define FUNCTION fast_normalize
 #define __CLC_GEOMETRIC_RET_GENTYPE
@@ -15,3 +18,5 @@
 
 #undef FUNCTION
 #undef __CLC_GEOMETRIC_RET_GENTYPE
+
+#endif // __CLC_OPENCL_GEOMETRIC_FAST_NORMALIZE_H__

--- a/libclc/opencl/include/clc/opencl/geometric/length.h
+++ b/libclc/opencl/include/clc/opencl/geometric/length.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_LENGTH_H__
+#define __CLC_OPENCL_GEOMETRIC_LENGTH_H__
+
 #define FUNCTION length
 #define __CLC_BODY <clc/geometric/unary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_GEOMETRIC_LENGTH_H__

--- a/libclc/opencl/include/clc/opencl/geometric/normalize.h
+++ b/libclc/opencl/include/clc/opencl/geometric/normalize.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_GEOMETRIC_NORMALIZE_H__
+#define __CLC_OPENCL_GEOMETRIC_NORMALIZE_H__
+
 #define FUNCTION normalize
 #define __CLC_GEOMETRIC_RET_GENTYPE
 #define __CLC_BODY <clc/geometric/unary_decl.inc>
@@ -14,3 +17,5 @@
 
 #undef __CLC_GEOMETRIC_RET_GENTYPE
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_GEOMETRIC_NORMALIZE_H__

--- a/libclc/opencl/include/clc/opencl/math/acos.h
+++ b/libclc/opencl/include/clc/opencl/math/acos.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ACOS_H__
+#define __CLC_OPENCL_MATH_ACOS_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION acos
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ACOS_H__

--- a/libclc/opencl/include/clc/opencl/math/acosh.h
+++ b/libclc/opencl/include/clc/opencl/math/acosh.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ACOSH_H__
+#define __CLC_OPENCL_MATH_ACOSH_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION acosh
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ACOSH_H__

--- a/libclc/opencl/include/clc/opencl/math/acospi.h
+++ b/libclc/opencl/include/clc/opencl/math/acospi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ACOSPI_H__
+#define __CLC_OPENCL_MATH_ACOSPI_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION acospi
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ACOSPI_H__

--- a/libclc/opencl/include/clc/opencl/math/asin.h
+++ b/libclc/opencl/include/clc/opencl/math/asin.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ASIN_H__
+#define __CLC_OPENCL_MATH_ASIN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION asin
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ASIN_H__

--- a/libclc/opencl/include/clc/opencl/math/asinh.h
+++ b/libclc/opencl/include/clc/opencl/math/asinh.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ASINH_H__
+#define __CLC_OPENCL_MATH_ASINH_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION asinh
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ASINH_H__

--- a/libclc/opencl/include/clc/opencl/math/asinpi.h
+++ b/libclc/opencl/include/clc/opencl/math/asinpi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ASINPI_H__
+#define __CLC_OPENCL_MATH_ASINPI_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION asinpi
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ASINPI_H__

--- a/libclc/opencl/include/clc/opencl/math/atan.h
+++ b/libclc/opencl/include/clc/opencl/math/atan.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ATAN_H__
+#define __CLC_OPENCL_MATH_ATAN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION atan
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ATAN_H__

--- a/libclc/opencl/include/clc/opencl/math/atan2.h
+++ b/libclc/opencl/include/clc/opencl/math/atan2.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ATAN2_H__
+#define __CLC_OPENCL_MATH_ATAN2_H__
+
 #define FUNCTION atan2
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ATAN2_H__

--- a/libclc/opencl/include/clc/opencl/math/atan2pi.h
+++ b/libclc/opencl/include/clc/opencl/math/atan2pi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ATAN2PI_H__
+#define __CLC_OPENCL_MATH_ATAN2PI_H__
+
 #define FUNCTION atan2pi
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ATAN2PI_H__

--- a/libclc/opencl/include/clc/opencl/math/atanh.h
+++ b/libclc/opencl/include/clc/opencl/math/atanh.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ATANH_H__
+#define __CLC_OPENCL_MATH_ATANH_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION atanh
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ATANH_H__

--- a/libclc/opencl/include/clc/opencl/math/atanpi.h
+++ b/libclc/opencl/include/clc/opencl/math/atanpi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ATANPI_H__
+#define __CLC_OPENCL_MATH_ATANPI_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION atanpi
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ATANPI_H__

--- a/libclc/opencl/include/clc/opencl/math/cbrt.h
+++ b/libclc/opencl/include/clc/opencl/math/cbrt.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_CBRT_H__
+#define __CLC_OPENCL_MATH_CBRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION cbrt
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_CBRT_H__

--- a/libclc/opencl/include/clc/opencl/math/ceil.h
+++ b/libclc/opencl/include/clc/opencl/math/ceil.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_CEIL_H__
+#define __CLC_OPENCL_MATH_CEIL_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION ceil
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_CEIL_H__

--- a/libclc/opencl/include/clc/opencl/math/copysign.h
+++ b/libclc/opencl/include/clc/opencl/math/copysign.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_COPYSIGN_H__
+#define __CLC_OPENCL_MATH_COPYSIGN_H__
+
 #define FUNCTION copysign
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_COPYSIGN_H__

--- a/libclc/opencl/include/clc/opencl/math/cos.h
+++ b/libclc/opencl/include/clc/opencl/math/cos.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_COS_H__
+#define __CLC_OPENCL_MATH_COS_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION cos
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_COS_H__

--- a/libclc/opencl/include/clc/opencl/math/cosh.h
+++ b/libclc/opencl/include/clc/opencl/math/cosh.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_COSH_H__
+#define __CLC_OPENCL_MATH_COSH_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION cosh
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_COSH_H__

--- a/libclc/opencl/include/clc/opencl/math/cospi.h
+++ b/libclc/opencl/include/clc/opencl/math/cospi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_COSPI_H__
+#define __CLC_OPENCL_MATH_COSPI_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION cospi
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_COSPI_H__

--- a/libclc/opencl/include/clc/opencl/math/erf.h
+++ b/libclc/opencl/include/clc/opencl/math/erf.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ERF_H__
+#define __CLC_OPENCL_MATH_ERF_H__
+
 #undef erfc
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ERF_H__

--- a/libclc/opencl/include/clc/opencl/math/erfc.h
+++ b/libclc/opencl/include/clc/opencl/math/erfc.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ERFC_H__
+#define __CLC_OPENCL_MATH_ERFC_H__
+
 #undef erfc
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ERFC_H__

--- a/libclc/opencl/include/clc/opencl/math/exp.h
+++ b/libclc/opencl/include/clc/opencl/math/exp.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_EXP_H__
+#define __CLC_OPENCL_MATH_EXP_H__
+
 #undef exp
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_EXP_H__

--- a/libclc/opencl/include/clc/opencl/math/exp10.h
+++ b/libclc/opencl/include/clc/opencl/math/exp10.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_EXP10_H__
+#define __CLC_OPENCL_MATH_EXP10_H__
+
 #undef exp10
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_EXP10_H__

--- a/libclc/opencl/include/clc/opencl/math/exp2.h
+++ b/libclc/opencl/include/clc/opencl/math/exp2.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_EXP2_H__
+#define __CLC_OPENCL_MATH_EXP2_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION exp2
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_EXP2_H__

--- a/libclc/opencl/include/clc/opencl/math/expm1.h
+++ b/libclc/opencl/include/clc/opencl/math/expm1.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_EXPM1_H__
+#define __CLC_OPENCL_MATH_EXPM1_H__
+
 #undef exp
 
 #define __CLC_BODY <clc/math/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_EXPM1_H__

--- a/libclc/opencl/include/clc/opencl/math/fabs.h
+++ b/libclc/opencl/include/clc/opencl/math/fabs.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FABS_H__
+#define __CLC_OPENCL_MATH_FABS_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION fabs
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FABS_H__

--- a/libclc/opencl/include/clc/opencl/math/fdim.h
+++ b/libclc/opencl/include/clc/opencl/math/fdim.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FDIM_H__
+#define __CLC_OPENCL_MATH_FDIM_H__
+
 #define FUNCTION fdim
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FDIM_H__

--- a/libclc/opencl/include/clc/opencl/math/floor.h
+++ b/libclc/opencl/include/clc/opencl/math/floor.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FLOOR_H__
+#define __CLC_OPENCL_MATH_FLOOR_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION floor
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FLOOR_H__

--- a/libclc/opencl/include/clc/opencl/math/fma.h
+++ b/libclc/opencl/include/clc/opencl/math/fma.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FMA_H__
+#define __CLC_OPENCL_MATH_FMA_H__
+
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
 #define FUNCTION fma
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FMA_H__

--- a/libclc/opencl/include/clc/opencl/math/fmax.h
+++ b/libclc/opencl/include/clc/opencl/math/fmax.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FMAX_H__
+#define __CLC_OPENCL_MATH_FMAX_H__
+
 #define __CLC_BODY <clc/math/binary_decl_with_scalar_second_arg.inc>
 #define FUNCTION fmax
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FMAX_H__

--- a/libclc/opencl/include/clc/opencl/math/fmin.h
+++ b/libclc/opencl/include/clc/opencl/math/fmin.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FMIN_H__
+#define __CLC_OPENCL_MATH_FMIN_H__
+
 #define __CLC_BODY <clc/math/binary_decl_with_scalar_second_arg.inc>
 #define FUNCTION fmin
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FMIN_H__

--- a/libclc/opencl/include/clc/opencl/math/fmod.h
+++ b/libclc/opencl/include/clc/opencl/math/fmod.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FMOD_H__
+#define __CLC_OPENCL_MATH_FMOD_H__
+
 #define FUNCTION fmod
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FMOD_H__

--- a/libclc/opencl/include/clc/opencl/math/fract.h
+++ b/libclc/opencl/include/clc/opencl/math/fract.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FRACT_H__
+#define __CLC_OPENCL_MATH_FRACT_H__
+
 #define FUNCTION fract
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FRACT_H__

--- a/libclc/opencl/include/clc/opencl/math/frexp.h
+++ b/libclc/opencl/include/clc/opencl/math/frexp.h
@@ -6,8 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_FREXP_H__
+#define __CLC_OPENCL_MATH_FREXP_H__
+
 #define FUNCTION frexp
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_FREXP_H__

--- a/libclc/opencl/include/clc/opencl/math/half_cos.h
+++ b/libclc/opencl/include/clc/opencl/math/half_cos.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_COS_H__
+#define __CLC_OPENCL_MATH_HALF_COS_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_cos
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_COS_H__

--- a/libclc/opencl/include/clc/opencl/math/half_divide.h
+++ b/libclc/opencl/include/clc/opencl/math/half_divide.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_DIVIDE_H__
+#define __CLC_OPENCL_MATH_HALF_DIVIDE_H__
+
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define FUNCTION half_divide
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_DIVIDE_H__

--- a/libclc/opencl/include/clc/opencl/math/half_exp.h
+++ b/libclc/opencl/include/clc/opencl/math/half_exp.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_EXP_H__
+#define __CLC_OPENCL_MATH_HALF_EXP_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_exp
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_EXP_H__

--- a/libclc/opencl/include/clc/opencl/math/half_exp10.h
+++ b/libclc/opencl/include/clc/opencl/math/half_exp10.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_EXP10_H__
+#define __CLC_OPENCL_MATH_HALF_EXP10_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_exp10
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_EXP10_H__

--- a/libclc/opencl/include/clc/opencl/math/half_exp2.h
+++ b/libclc/opencl/include/clc/opencl/math/half_exp2.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_EXP2_H__
+#define __CLC_OPENCL_MATH_HALF_EXP2_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_exp2
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_EXP2_H__

--- a/libclc/opencl/include/clc/opencl/math/half_log.h
+++ b/libclc/opencl/include/clc/opencl/math/half_log.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_LOG_H__
+#define __CLC_OPENCL_MATH_HALF_LOG_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_log
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_LOG_H__

--- a/libclc/opencl/include/clc/opencl/math/half_log10.h
+++ b/libclc/opencl/include/clc/opencl/math/half_log10.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_LOG10_H__
+#define __CLC_OPENCL_MATH_HALF_LOG10_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_log10
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_LOG10_H__

--- a/libclc/opencl/include/clc/opencl/math/half_log2.h
+++ b/libclc/opencl/include/clc/opencl/math/half_log2.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_LOG2_H__
+#define __CLC_OPENCL_MATH_HALF_LOG2_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_log2
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_LOG2_H__

--- a/libclc/opencl/include/clc/opencl/math/half_powr.h
+++ b/libclc/opencl/include/clc/opencl/math/half_powr.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_POWR_H__
+#define __CLC_OPENCL_MATH_HALF_POWR_H__
+
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define FUNCTION half_powr
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_POWR_H__

--- a/libclc/opencl/include/clc/opencl/math/half_recip.h
+++ b/libclc/opencl/include/clc/opencl/math/half_recip.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_RECIP_H__
+#define __CLC_OPENCL_MATH_HALF_RECIP_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_recip
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_RECIP_H__

--- a/libclc/opencl/include/clc/opencl/math/half_rsqrt.h
+++ b/libclc/opencl/include/clc/opencl/math/half_rsqrt.h
@@ -6,8 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_RSQRT_H__
+#define __CLC_OPENCL_MATH_HALF_RSQRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_rsqrt
 #define __FLOAT_ONLY
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_RSQRT_H__

--- a/libclc/opencl/include/clc/opencl/math/half_sin.h
+++ b/libclc/opencl/include/clc/opencl/math/half_sin.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_SIN_H__
+#define __CLC_OPENCL_MATH_HALF_SIN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_sin
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_SIN_H__

--- a/libclc/opencl/include/clc/opencl/math/half_sqrt.h
+++ b/libclc/opencl/include/clc/opencl/math/half_sqrt.h
@@ -6,8 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_SQRT_H__
+#define __CLC_OPENCL_MATH_HALF_SQRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_sqrt
 #define __FLOAT_ONLY
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_SQRT_H__

--- a/libclc/opencl/include/clc/opencl/math/half_tan.h
+++ b/libclc/opencl/include/clc/opencl/math/half_tan.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HALF_TAN_H__
+#define __CLC_OPENCL_MATH_HALF_TAN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION half_tan
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HALF_TAN_H__

--- a/libclc/opencl/include/clc/opencl/math/hypot.h
+++ b/libclc/opencl/include/clc/opencl/math/hypot.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_HYPOT_H__
+#define __CLC_OPENCL_MATH_HYPOT_H__
+
 #define FUNCTION hypot
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_HYPOT_H__

--- a/libclc/opencl/include/clc/opencl/math/ilogb.h
+++ b/libclc/opencl/include/clc/opencl/math/ilogb.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ILOGB_H__
+#define __CLC_OPENCL_MATH_ILOGB_H__
+
 #define FUNCTION ilogb
 #define __CLC_BODY <clc/math/unary_decl_with_int_return.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ILOGB_H__

--- a/libclc/opencl/include/clc/opencl/math/ldexp.h
+++ b/libclc/opencl/include/clc/opencl/math/ldexp.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LDEXP_H__
+#define __CLC_OPENCL_MATH_LDEXP_H__
+
 #define FUNCTION ldexp
 #define __CLC_BODY <clc/shared/binary_decl_with_int_second_arg.inc>
 #include <clc/math/gentype.inc>
@@ -13,3 +16,5 @@
 
 #define __CLC_BODY <clc/opencl/math/ldexp.inc>
 #include <clc/math/gentype.inc>
+
+#endif // __CLC_OPENCL_MATH_LDEXP_H__

--- a/libclc/opencl/include/clc/opencl/math/lgamma.h
+++ b/libclc/opencl/include/clc/opencl/math/lgamma.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LGAMMA_H__
+#define __CLC_OPENCL_MATH_LGAMMA_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION lgamma
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LGAMMA_H__

--- a/libclc/opencl/include/clc/opencl/math/lgamma_r.h
+++ b/libclc/opencl/include/clc/opencl/math/lgamma_r.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LGAMMA_R_H__
+#define __CLC_OPENCL_MATH_LGAMMA_R_H__
+
 #define FUNCTION lgamma_r
 #define __CLC_BODY <clc/math/unary_decl_with_int_ptr.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LGAMMA_R_H__

--- a/libclc/opencl/include/clc/opencl/math/log.h
+++ b/libclc/opencl/include/clc/opencl/math/log.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LOG_H__
+#define __CLC_OPENCL_MATH_LOG_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION log
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LOG_H__

--- a/libclc/opencl/include/clc/opencl/math/log10.h
+++ b/libclc/opencl/include/clc/opencl/math/log10.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LOG10_H__
+#define __CLC_OPENCL_MATH_LOG10_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION log10
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LOG10_H__

--- a/libclc/opencl/include/clc/opencl/math/log1p.h
+++ b/libclc/opencl/include/clc/opencl/math/log1p.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LOG1P_H__
+#define __CLC_OPENCL_MATH_LOG1P_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION log1p
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LOG1P_H__

--- a/libclc/opencl/include/clc/opencl/math/log2.h
+++ b/libclc/opencl/include/clc/opencl/math/log2.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LOG2_H__
+#define __CLC_OPENCL_MATH_LOG2_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION log2
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LOG2_H__

--- a/libclc/opencl/include/clc/opencl/math/logb.h
+++ b/libclc/opencl/include/clc/opencl/math/logb.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_LOGB_H__
+#define __CLC_OPENCL_MATH_LOGB_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION logb
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_LOGB_H__

--- a/libclc/opencl/include/clc/opencl/math/mad.h
+++ b/libclc/opencl/include/clc/opencl/math/mad.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_MAD_H__
+#define __CLC_OPENCL_MATH_MAD_H__
+
 #define __CLC_BODY <clc/shared/ternary_decl.inc>
 #define FUNCTION mad
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_MAD_H__

--- a/libclc/opencl/include/clc/opencl/math/maxmag.h
+++ b/libclc/opencl/include/clc/opencl/math/maxmag.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_MAXMAG_H__
+#define __CLC_OPENCL_MATH_MAXMAG_H__
+
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define FUNCTION maxmag
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_MAXMAG_H__

--- a/libclc/opencl/include/clc/opencl/math/minmag.h
+++ b/libclc/opencl/include/clc/opencl/math/minmag.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_MINMAG_H__
+#define __CLC_OPENCL_MATH_MINMAG_H__
+
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define FUNCTION minmag
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_MINMAG_H__

--- a/libclc/opencl/include/clc/opencl/math/modf.h
+++ b/libclc/opencl/include/clc/opencl/math/modf.h
@@ -6,8 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_MODF_H__
+#define __CLC_OPENCL_MATH_MODF_H__
+
 #define FUNCTION modf
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_MODF_H__

--- a/libclc/opencl/include/clc/opencl/math/nan.h
+++ b/libclc/opencl/include/clc/opencl/math/nan.h
@@ -6,5 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NAN_H__
+#define __CLC_OPENCL_MATH_NAN_H__
+
 #define __CLC_BODY <clc/opencl/math/nan.inc>
 #include <clc/math/gentype.inc>
+
+#endif // __CLC_OPENCL_MATH_NAN_H__

--- a/libclc/opencl/include/clc/opencl/math/native_cos.h
+++ b/libclc/opencl/include/clc/opencl/math/native_cos.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_COS_H__
+#define __CLC_OPENCL_MATH_NATIVE_COS_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_cos
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_COS_H__

--- a/libclc/opencl/include/clc/opencl/math/native_divide.h
+++ b/libclc/opencl/include/clc/opencl/math/native_divide.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_DIVIDE_H__
+#define __CLC_OPENCL_MATH_NATIVE_DIVIDE_H__
+
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define FUNCTION native_divide
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_DIVIDE_H__

--- a/libclc/opencl/include/clc/opencl/math/native_exp.h
+++ b/libclc/opencl/include/clc/opencl/math/native_exp.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_EXP_H__
+#define __CLC_OPENCL_MATH_NATIVE_EXP_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_exp
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_EXP_H__

--- a/libclc/opencl/include/clc/opencl/math/native_exp10.h
+++ b/libclc/opencl/include/clc/opencl/math/native_exp10.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_EXP10_H__
+#define __CLC_OPENCL_MATH_NATIVE_EXP10_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_exp10
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_EXP10_H__

--- a/libclc/opencl/include/clc/opencl/math/native_exp2.h
+++ b/libclc/opencl/include/clc/opencl/math/native_exp2.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_EXP2_H__
+#define __CLC_OPENCL_MATH_NATIVE_EXP2_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_exp2
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_EXP2_H__

--- a/libclc/opencl/include/clc/opencl/math/native_log.h
+++ b/libclc/opencl/include/clc/opencl/math/native_log.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_LOG_H__
+#define __CLC_OPENCL_MATH_NATIVE_LOG_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_log
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_LOG_H__

--- a/libclc/opencl/include/clc/opencl/math/native_log10.h
+++ b/libclc/opencl/include/clc/opencl/math/native_log10.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_LOG10_H__
+#define __CLC_OPENCL_MATH_NATIVE_LOG10_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_log10
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_LOG10_H__

--- a/libclc/opencl/include/clc/opencl/math/native_log2.h
+++ b/libclc/opencl/include/clc/opencl/math/native_log2.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_LOG2_H__
+#define __CLC_OPENCL_MATH_NATIVE_LOG2_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_log2
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_LOG2_H__

--- a/libclc/opencl/include/clc/opencl/math/native_powr.h
+++ b/libclc/opencl/include/clc/opencl/math/native_powr.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_POWR_H__
+#define __CLC_OPENCL_MATH_NATIVE_POWR_H__
+
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #define FUNCTION native_powr
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_POWR_H__

--- a/libclc/opencl/include/clc/opencl/math/native_recip.h
+++ b/libclc/opencl/include/clc/opencl/math/native_recip.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_RECIP_H__
+#define __CLC_OPENCL_MATH_NATIVE_RECIP_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_recip
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_RECIP_H__

--- a/libclc/opencl/include/clc/opencl/math/native_rsqrt.h
+++ b/libclc/opencl/include/clc/opencl/math/native_rsqrt.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_RSQRT_H__
+#define __CLC_OPENCL_MATH_NATIVE_RSQRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_rsqrt
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_RSQRT_H__

--- a/libclc/opencl/include/clc/opencl/math/native_sin.h
+++ b/libclc/opencl/include/clc/opencl/math/native_sin.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_SIN_H__
+#define __CLC_OPENCL_MATH_NATIVE_SIN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_sin
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_SIN_H__

--- a/libclc/opencl/include/clc/opencl/math/native_sqrt.h
+++ b/libclc/opencl/include/clc/opencl/math/native_sqrt.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_SQRT_H__
+#define __CLC_OPENCL_MATH_NATIVE_SQRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_sqrt
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_SQRT_H__

--- a/libclc/opencl/include/clc/opencl/math/native_tan.h
+++ b/libclc/opencl/include/clc/opencl/math/native_tan.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NATIVE_TAN_H__
+#define __CLC_OPENCL_MATH_NATIVE_TAN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION native_tan
 #define __FLOAT_ONLY
@@ -13,3 +16,5 @@
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NATIVE_TAN_H__

--- a/libclc/opencl/include/clc/opencl/math/nextafter.h
+++ b/libclc/opencl/include/clc/opencl/math/nextafter.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_NEXTAFTER_H__
+#define __CLC_OPENCL_MATH_NEXTAFTER_H__
+
 #define FUNCTION nextafter
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_NEXTAFTER_H__

--- a/libclc/opencl/include/clc/opencl/math/pow.h
+++ b/libclc/opencl/include/clc/opencl/math/pow.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_POW_H__
+#define __CLC_OPENCL_MATH_POW_H__
+
 #define FUNCTION pow
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_POW_H__

--- a/libclc/opencl/include/clc/opencl/math/pown.h
+++ b/libclc/opencl/include/clc/opencl/math/pown.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_POWN_H__
+#define __CLC_OPENCL_MATH_POWN_H__
+
 #define FUNCTION pown
 #define __CLC_BODY <clc/shared/binary_decl_with_int_second_arg.inc>
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_POWN_H__

--- a/libclc/opencl/include/clc/opencl/math/powr.h
+++ b/libclc/opencl/include/clc/opencl/math/powr.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_POWR_H__
+#define __CLC_OPENCL_MATH_POWR_H__
+
 #define FUNCTION powr
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_POWR_H__

--- a/libclc/opencl/include/clc/opencl/math/remainder.h
+++ b/libclc/opencl/include/clc/opencl/math/remainder.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_REMAINDER_H__
+#define __CLC_OPENCL_MATH_REMAINDER_H__
+
 #define FUNCTION remainder
 #define __CLC_BODY <clc/shared/binary_decl.inc>
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_REMAINDER_H__

--- a/libclc/opencl/include/clc/opencl/math/remquo.h
+++ b/libclc/opencl/include/clc/opencl/math/remquo.h
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_REMQUO_H__
+#define __CLC_OPENCL_MATH_REMQUO_H__
+
 #define FUNCTION remquo
 
 #define __CLC_BODY <clc/math/remquo_decl.inc>
@@ -19,3 +22,5 @@
 #endif
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_REMQUO_H__

--- a/libclc/opencl/include/clc/opencl/math/rint.h
+++ b/libclc/opencl/include/clc/opencl/math/rint.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_RINT_H__
+#define __CLC_OPENCL_MATH_RINT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION rint
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_RINT_H__

--- a/libclc/opencl/include/clc/opencl/math/rootn.h
+++ b/libclc/opencl/include/clc/opencl/math/rootn.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ROOTN_H__
+#define __CLC_OPENCL_MATH_ROOTN_H__
+
 #define __CLC_BODY <clc/shared/binary_decl_with_int_second_arg.inc>
 #define FUNCTION rootn
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ROOTN_H__

--- a/libclc/opencl/include/clc/opencl/math/round.h
+++ b/libclc/opencl/include/clc/opencl/math/round.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_ROUND_H__
+#define __CLC_OPENCL_MATH_ROUND_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION round
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_ROUND_H__

--- a/libclc/opencl/include/clc/opencl/math/rsqrt.h
+++ b/libclc/opencl/include/clc/opencl/math/rsqrt.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_RSQRT_H__
+#define __CLC_OPENCL_MATH_RSQRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION rsqrt
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_RSQRT_H__

--- a/libclc/opencl/include/clc/opencl/math/sin.h
+++ b/libclc/opencl/include/clc/opencl/math/sin.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_SIN_H__
+#define __CLC_OPENCL_MATH_SIN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION sin
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_SIN_H__

--- a/libclc/opencl/include/clc/opencl/math/sincos.h
+++ b/libclc/opencl/include/clc/opencl/math/sincos.h
@@ -6,7 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_SINCOS_H__
+#define __CLC_OPENCL_MATH_SINCOS_H__
+
 #define __CLC_BODY <clc/math/unary_decl_with_ptr.inc>
 #define FUNCTION __clc_sincos
 #include <clc/math/gentype.inc>
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_SINCOS_H__

--- a/libclc/opencl/include/clc/opencl/math/sinh.h
+++ b/libclc/opencl/include/clc/opencl/math/sinh.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_SINH_H__
+#define __CLC_OPENCL_MATH_SINH_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION sinh
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_SINH_H__

--- a/libclc/opencl/include/clc/opencl/math/sinpi.h
+++ b/libclc/opencl/include/clc/opencl/math/sinpi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_SINPI_H__
+#define __CLC_OPENCL_MATH_SINPI_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION sinpi
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_SINPI_H__

--- a/libclc/opencl/include/clc/opencl/math/sqrt.h
+++ b/libclc/opencl/include/clc/opencl/math/sqrt.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_SQRT_H__
+#define __CLC_OPENCL_MATH_SQRT_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION sqrt
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_SQRT_H__

--- a/libclc/opencl/include/clc/opencl/math/tan.h
+++ b/libclc/opencl/include/clc/opencl/math/tan.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_TAN_H__
+#define __CLC_OPENCL_MATH_TAN_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION tan
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_TAN_H__

--- a/libclc/opencl/include/clc/opencl/math/tanh.h
+++ b/libclc/opencl/include/clc/opencl/math/tanh.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_TANH_H__
+#define __CLC_OPENCL_MATH_TANH_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION tanh
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_TANH_H__

--- a/libclc/opencl/include/clc/opencl/math/tanpi.h
+++ b/libclc/opencl/include/clc/opencl/math/tanpi.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_TANPI_H__
+#define __CLC_OPENCL_MATH_TANPI_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION tanpi
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_TANPI_H__

--- a/libclc/opencl/include/clc/opencl/math/tgamma.h
+++ b/libclc/opencl/include/clc/opencl/math/tgamma.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_TGAMMA_H__
+#define __CLC_OPENCL_MATH_TGAMMA_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION tgamma
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_TGAMMA_H__

--- a/libclc/opencl/include/clc/opencl/math/trunc.h
+++ b/libclc/opencl/include/clc/opencl/math/trunc.h
@@ -6,9 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_MATH_TRUNC_H__
+#define __CLC_OPENCL_MATH_TRUNC_H__
+
 #define __CLC_BODY <clc/math/unary_decl.inc>
 #define FUNCTION trunc
 
 #include <clc/math/gentype.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_MATH_TRUNC_H__

--- a/libclc/opencl/include/clc/opencl/relational/all.h
+++ b/libclc/opencl/include/clc/opencl/relational/all.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ALL_H__
+#define __CLC_OPENCL_RELATIONAL_ALL_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define _CLC_ALL_DECL(TYPE) _CLC_OVERLOAD _CLC_DECL int all(TYPE v);
 
 #define _CLC_VECTOR_ALL_DECL(TYPE)                                             \
@@ -23,3 +28,5 @@ _CLC_VECTOR_ALL_DECL(long)
 
 #undef _CLC_ALL_DECL
 #undef _CLC_VECTOR_ALL_DECL
+
+#endif // __CLC_OPENCL_RELATIONAL_ALL_H__

--- a/libclc/opencl/include/clc/opencl/relational/any.h
+++ b/libclc/opencl/include/clc/opencl/relational/any.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ANY_H__
+#define __CLC_OPENCL_RELATIONAL_ANY_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define _CLC_ANY_DECL(TYPE) _CLC_OVERLOAD _CLC_DECL int any(TYPE v);
 
 #define _CLC_VECTOR_ANY_DECL(TYPE)                                             \
@@ -23,3 +28,5 @@ _CLC_VECTOR_ANY_DECL(long)
 
 #undef _CLC_ANY_DECL
 #undef _CLC_VECTOR_ANY_DECL
+
+#endif // __CLC_OPENCL_RELATIONAL_ANY_H__

--- a/libclc/opencl/include/clc/opencl/relational/bitselect.h
+++ b/libclc/opencl/include/clc/opencl/relational/bitselect.h
@@ -6,7 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_BITSELECT_H__
+#define __CLC_OPENCL_RELATIONAL_BITSELECT_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define __CLC_BODY <clc/opencl/relational/bitselect.inc>
 #include <clc/math/gentype.inc>
 #define __CLC_BODY <clc/opencl/relational/bitselect.inc>
 #include <clc/integer/gentype.inc>
+
+#endif // __CLC_OPENCL_RELATIONAL_BITSELECT_H__

--- a/libclc/opencl/include/clc/opencl/relational/isequal.h
+++ b/libclc/opencl/include/clc/opencl/relational/isequal.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ISEQUAL_H__
+#define __CLC_OPENCL_RELATIONAL_ISEQUAL_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define _CLC_ISEQUAL_DECL(TYPE, RETTYPE)                                       \
   _CLC_OVERLOAD _CLC_DECL RETTYPE isequal(TYPE x, TYPE y);
 
@@ -30,3 +35,5 @@ _CLC_VECTOR_ISEQUAL_DECL(half, short)
 
 #undef _CLC_ISEQUAL_DECL
 #undef _CLC_VECTOR_ISEQUAL_DEC
+
+#endif // __CLC_OPENCL_RELATIONAL_ISEQUAL_H__

--- a/libclc/opencl/include/clc/opencl/relational/isfinite.h
+++ b/libclc/opencl/include/clc/opencl/relational/isfinite.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isfinite
+#ifndef __CLC_OPENCL_RELATIONAL_ISFINITE_H__
+#define __CLC_OPENCL_RELATIONAL_ISFINITE_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isfinite
 #define __CLC_BODY <clc/relational/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISFINITE_H__

--- a/libclc/opencl/include/clc/opencl/relational/isgreater.h
+++ b/libclc/opencl/include/clc/opencl/relational/isgreater.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isgreater
+#ifndef __CLC_OPENCL_RELATIONAL_ISGREATER_H__
+#define __CLC_OPENCL_RELATIONAL_ISGREATER_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isgreater
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISGREATER_H__

--- a/libclc/opencl/include/clc/opencl/relational/isgreaterequal.h
+++ b/libclc/opencl/include/clc/opencl/relational/isgreaterequal.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isgreaterequal
+#ifndef __CLC_OPENCL_RELATIONAL_ISGREATEREQUAL_H__
+#define __CLC_OPENCL_RELATIONAL_ISGREATEREQUAL_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isgreaterequal
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISGREATEREQUAL_H__

--- a/libclc/opencl/include/clc/opencl/relational/isinf.h
+++ b/libclc/opencl/include/clc/opencl/relational/isinf.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ISINF_H__
+#define __CLC_OPENCL_RELATIONAL_ISINF_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define _CLC_ISINF_DECL(RET_TYPE, ARG_TYPE)                                    \
   _CLC_OVERLOAD _CLC_DECL RET_TYPE isinf(ARG_TYPE);
 
@@ -31,3 +36,5 @@ _CLC_VECTOR_ISINF_DECL(short, half)
 
 #undef _CLC_ISINF_DECL
 #undef _CLC_VECTOR_ISINF_DECL
+
+#endif // __CLC_OPENCL_RELATIONAL_ISINF_H__

--- a/libclc/opencl/include/clc/opencl/relational/isless.h
+++ b/libclc/opencl/include/clc/opencl/relational/isless.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ISLESS_H__
+#define __CLC_OPENCL_RELATIONAL_ISLESS_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION isless
 #define __CLC_BODY <clc/relational/binary_decl.inc>
 
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISLESS_H__

--- a/libclc/opencl/include/clc/opencl/relational/islessequal.h
+++ b/libclc/opencl/include/clc/opencl/relational/islessequal.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ISLESSEQUAL_H__
+#define __CLC_OPENCL_RELATIONAL_ISLESSEQUAL_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION islessequal
 #define __CLC_BODY <clc/relational/binary_decl.inc>
 
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISLESSEQUAL_H__

--- a/libclc/opencl/include/clc/opencl/relational/islessgreater.h
+++ b/libclc/opencl/include/clc/opencl/relational/islessgreater.h
@@ -6,9 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ISLESSGREATER_H__
+#define __CLC_OPENCL_RELATIONAL_ISLESSGREATER_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define FUNCTION islessgreater
 #define __CLC_BODY <clc/relational/binary_decl.inc>
 
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISLESSGREATER_H__

--- a/libclc/opencl/include/clc/opencl/relational/isnan.h
+++ b/libclc/opencl/include/clc/opencl/relational/isnan.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_ISNAN_H__
+#define __CLC_OPENCL_RELATIONAL_ISNAN_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define _CLC_ISNAN_DECL(RET_TYPE, ARG_TYPE)                                    \
   _CLC_OVERLOAD _CLC_DECL RET_TYPE isnan(ARG_TYPE);
 
@@ -31,3 +36,5 @@ _CLC_VECTOR_ISNAN_DECL(short, half)
 
 #undef _CLC_ISNAN_DECL
 #undef _CLC_VECTOR_ISNAN_DECL
+
+#endif // __CLC_OPENCL_RELATIONAL_ISNAN_H__

--- a/libclc/opencl/include/clc/opencl/relational/isnormal.h
+++ b/libclc/opencl/include/clc/opencl/relational/isnormal.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isnormal
+#ifndef __CLC_OPENCL_RELATIONAL_ISNORMAL_H__
+#define __CLC_OPENCL_RELATIONAL_ISNORMAL_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isnormal
 #define __CLC_BODY <clc/relational/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISNORMAL_H__

--- a/libclc/opencl/include/clc/opencl/relational/isnotequal.h
+++ b/libclc/opencl/include/clc/opencl/relational/isnotequal.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isnotequal
+#ifndef __CLC_OPENCL_RELATIONAL_ISNOTEQUAL_H__
+#define __CLC_OPENCL_RELATIONAL_ISNOTEQUAL_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isnotequal
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISNOTEQUAL_H__

--- a/libclc/opencl/include/clc/opencl/relational/isordered.h
+++ b/libclc/opencl/include/clc/opencl/relational/isordered.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isordered
+#ifndef __CLC_OPENCL_RELATIONAL_ISORDERED_H__
+#define __CLC_OPENCL_RELATIONAL_ISORDERED_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isordered
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISORDERED_H__

--- a/libclc/opencl/include/clc/opencl/relational/isunordered.h
+++ b/libclc/opencl/include/clc/opencl/relational/isunordered.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef isunordered
+#ifndef __CLC_OPENCL_RELATIONAL_ISUNORDERED_H__
+#define __CLC_OPENCL_RELATIONAL_ISUNORDERED_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION isunordered
 #define __CLC_BODY <clc/relational/binary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_ISUNORDERED_H__

--- a/libclc/opencl/include/clc/opencl/relational/select.h
+++ b/libclc/opencl/include/clc/opencl/relational/select.h
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef __CLC_OPENCL_RELATIONAL_SELECT_H__
+#define __CLC_OPENCL_RELATIONAL_SELECT_H__
+
+#include <clc/opencl/opencl-base.h>
+
 #define __CLC_SELECT_FN select
 
 #define __CLC_BODY <clc/relational/clc_select_decl.inc>
@@ -14,3 +19,5 @@
 #include <clc/integer/gentype.inc>
 
 #undef __CLC_SELECT_FN
+
+#endif // __CLC_OPENCL_RELATIONAL_SELECT_H__

--- a/libclc/opencl/include/clc/opencl/relational/signbit.h
+++ b/libclc/opencl/include/clc/opencl/relational/signbit.h
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#undef signbit
+#ifndef __CLC_OPENCL_RELATIONAL_SIGNBIT_H__
+#define __CLC_OPENCL_RELATIONAL_SIGNBIT_H__
+
+#include <clc/opencl/opencl-base.h>
 
 #define FUNCTION signbit
 #define __CLC_BODY <clc/relational/unary_decl.inc>
@@ -14,3 +17,5 @@
 #include <clc/relational/floatn.inc>
 
 #undef FUNCTION
+
+#endif // __CLC_OPENCL_RELATIONAL_SIGNBIT_H__

--- a/libclc/opencl/lib/clspv/math/fma.cl
+++ b/libclc/opencl/lib/clspv/math/fma.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/internal/math/clc_sw_fma.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fma.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION fma

--- a/libclc/opencl/lib/generic/common/degrees.cl
+++ b/libclc/opencl/lib/generic/common/degrees.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/common/clc_degrees.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/common/degrees.h>
 
 #define FUNCTION degrees
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/common/mix.cl
+++ b/libclc/opencl/lib/generic/common/mix.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_mad.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/common/mix.h>
 
 #define __CLC_BODY <mix.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/opencl/lib/generic/common/radians.cl
+++ b/libclc/opencl/lib/generic/common/radians.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/common/clc_radians.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/common/radians.h>
 
 #define FUNCTION radians
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/common/sign.cl
+++ b/libclc/opencl/lib/generic/common/sign.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/common/clc_sign.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/common/sign.h>
 
 #define FUNCTION sign
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/common/smoothstep.cl
+++ b/libclc/opencl/lib/generic/common/smoothstep.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/common/clc_smoothstep.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/common/smoothstep.h>
 
 #define SMOOTHSTEP_SINGLE_DEF(X_TYPE)                                          \
   _CLC_OVERLOAD _CLC_DEF X_TYPE smoothstep(X_TYPE edge0, X_TYPE edge1,         \

--- a/libclc/opencl/lib/generic/common/step.cl
+++ b/libclc/opencl/lib/generic/common/step.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/common/clc_step.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/common/step.h>
 
 #define __CLC_BODY <step.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/opencl/lib/generic/geometric/cross.cl
+++ b/libclc/opencl/lib/generic/geometric/cross.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_cross.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/cross.h>
 
 _CLC_OVERLOAD _CLC_DEF float3 cross(float3 p0, float3 p1) {
   return __clc_cross(p0, p1);

--- a/libclc/opencl/lib/generic/geometric/distance.cl
+++ b/libclc/opencl/lib/generic/geometric/distance.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_distance.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/distance.h>
 
 #define FUNCTION distance
 #define __CLC_BODY <clc/geometric/binary_def.inc>

--- a/libclc/opencl/lib/generic/geometric/dot.cl
+++ b/libclc/opencl/lib/generic/geometric/dot.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_dot.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/dot.h>
 
 #define FUNCTION dot
 #define __CLC_BODY <clc/geometric/binary_def.inc>

--- a/libclc/opencl/lib/generic/geometric/fast_distance.cl
+++ b/libclc/opencl/lib/generic/geometric/fast_distance.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_fast_distance.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/fast_distance.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION fast_distance

--- a/libclc/opencl/lib/generic/geometric/fast_length.cl
+++ b/libclc/opencl/lib/generic/geometric/fast_length.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_fast_length.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/fast_length.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION fast_length

--- a/libclc/opencl/lib/generic/geometric/fast_normalize.cl
+++ b/libclc/opencl/lib/generic/geometric/fast_normalize.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_fast_normalize.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/fast_normalize.h>
 
 #define FUNCTION fast_normalize
 #define __FLOAT_ONLY

--- a/libclc/opencl/lib/generic/geometric/length.cl
+++ b/libclc/opencl/lib/generic/geometric/length.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_length.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/length.h>
 
 #define FUNCTION length
 #define __CLC_BODY <clc/geometric/unary_def.inc>

--- a/libclc/opencl/lib/generic/geometric/normalize.cl
+++ b/libclc/opencl/lib/generic/geometric/normalize.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/geometric/clc_normalize.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/geometric/normalize.h>
 
 #define FUNCTION normalize
 #define __CLC_GEOMETRIC_RET_GENTYPE

--- a/libclc/opencl/lib/generic/math/acos.cl
+++ b/libclc/opencl/lib/generic/math/acos.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_acos.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/acos.h>
 
 #define FUNCTION acos
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/acosh.cl
+++ b/libclc/opencl/lib/generic/math/acosh.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_acosh.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/acosh.h>
 
 #define FUNCTION acosh
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/acospi.cl
+++ b/libclc/opencl/lib/generic/math/acospi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_acospi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/acospi.h>
 
 #define FUNCTION acospi
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/asin.cl
+++ b/libclc/opencl/lib/generic/math/asin.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_asin.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/asin.h>
 
 #define FUNCTION asin
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/asinh.cl
+++ b/libclc/opencl/lib/generic/math/asinh.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_asinh.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/asinh.h>
 
 #define FUNCTION asinh
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/asinpi.cl
+++ b/libclc/opencl/lib/generic/math/asinpi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_asinpi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/asinpi.h>
 
 #define FUNCTION asinpi
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/atan.cl
+++ b/libclc/opencl/lib/generic/math/atan.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_atan.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/atan.h>
 
 #define FUNCTION atan
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/atan2.cl
+++ b/libclc/opencl/lib/generic/math/atan2.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/math/clc_atan2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/atan2.h>
 
 #define FUNCTION atan2
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/atan2pi.cl
+++ b/libclc/opencl/lib/generic/math/atan2pi.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/math/clc_atan2pi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/atan2pi.h>
 
 #define FUNCTION atan2pi
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/atanh.cl
+++ b/libclc/opencl/lib/generic/math/atanh.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_atanh.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/atanh.h>
 
 #define FUNCTION atanh
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/atanpi.cl
+++ b/libclc/opencl/lib/generic/math/atanpi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_atanpi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/atanpi.h>
 
 #define FUNCTION atanpi
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/cbrt.cl
+++ b/libclc/opencl/lib/generic/math/cbrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_cbrt.inc>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/cbrt.h>
 
 #define FUNCTION cbrt
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/ceil.cl
+++ b/libclc/opencl/lib/generic/math/ceil.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_ceil.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/ceil.h>
 
 #define FUNCTION ceil
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/copysign.cl
+++ b/libclc/opencl/lib/generic/math/copysign.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_copysign.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/copysign.h>
 
 #define FUNCTION copysign
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/cos.cl
+++ b/libclc/opencl/lib/generic/math/cos.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_cos.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/cos.h>
 
 #define FUNCTION cos
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/cosh.cl
+++ b/libclc/opencl/lib/generic/math/cosh.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_cosh.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/cosh.h>
 
 #define FUNCTION cosh
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/cospi.cl
+++ b/libclc/opencl/lib/generic/math/cospi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_cospi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/cospi.h>
 
 #define FUNCTION cospi
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/erf.cl
+++ b/libclc/opencl/lib/generic/math/erf.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_erf.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/erf.h>
 
 #define FUNCTION erf
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/erfc.cl
+++ b/libclc/opencl/lib/generic/math/erfc.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_erfc.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/erfc.h>
 
 #define FUNCTION erfc
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/exp.cl
+++ b/libclc/opencl/lib/generic/math/exp.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_exp.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/exp.h>
 
 #define FUNCTION exp
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/exp10.cl
+++ b/libclc/opencl/lib/generic/math/exp10.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_exp10.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/exp10.h>
 
 #define FUNCTION exp10
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/exp2.cl
+++ b/libclc/opencl/lib/generic/math/exp2.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_exp2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/exp2.h>
 
 #define FUNCTION exp2
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/expm1.cl
+++ b/libclc/opencl/lib/generic/math/expm1.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_expm1.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/expm1.h>
 
 #define FUNCTION expm1
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/fabs.cl
+++ b/libclc/opencl/lib/generic/math/fabs.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_fabs.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fabs.h>
 
 #define FUNCTION fabs
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/fdim.cl
+++ b/libclc/opencl/lib/generic/math/fdim.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_fdim.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fdim.h>
 
 #define FUNCTION fdim
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/floor.cl
+++ b/libclc/opencl/lib/generic/math/floor.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_floor.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/floor.h>
 
 #define FUNCTION floor
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/fma.cl
+++ b/libclc/opencl/lib/generic/math/fma.cl
@@ -8,7 +8,7 @@
 
 #include <clc/math/clc_fma.h>
 #include <clc/math/math.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fma.h>
 
 #define FUNCTION fma
 #define __CLC_BODY <clc/shared/ternary_def.inc>

--- a/libclc/opencl/lib/generic/math/fmax.cl
+++ b/libclc/opencl/lib/generic/math/fmax.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_fmax.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fmax.h>
 
 #define FUNCTION fmax
 #define __CLC_BODY <clc/shared/binary_def_with_scalar_second_arg.inc>

--- a/libclc/opencl/lib/generic/math/fmin.cl
+++ b/libclc/opencl/lib/generic/math/fmin.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_fmin.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fmin.h>
 
 #define FUNCTION fmin
 #define __CLC_BODY <clc/shared/binary_def_with_scalar_second_arg.inc>

--- a/libclc/opencl/lib/generic/math/fmod.cl
+++ b/libclc/opencl/lib/generic/math/fmod.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_fmod.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fmod.h>
 
 #define FUNCTION fmod
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/fract.cl
+++ b/libclc/opencl/lib/generic/math/fract.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_fract.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fract.h>
 
 #define FUNCTION fract
 #define __CLC_BODY <clc/math/unary_def_with_ptr.inc>

--- a/libclc/opencl/lib/generic/math/frexp.cl
+++ b/libclc/opencl/lib/generic/math/frexp.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_frexp.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/frexp.h>
 
 #define FUNCTION frexp
 #define __CLC_BODY <clc/math/unary_def_with_int_ptr.inc>

--- a/libclc/opencl/lib/generic/math/half_cos.cl
+++ b/libclc/opencl/lib/generic/math/half_cos.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_cos.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_cos.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_cos

--- a/libclc/opencl/lib/generic/math/half_divide.cl
+++ b/libclc/opencl/lib/generic/math/half_divide.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_divide.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_divide.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_divide

--- a/libclc/opencl/lib/generic/math/half_exp.cl
+++ b/libclc/opencl/lib/generic/math/half_exp.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_exp.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_exp.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_exp

--- a/libclc/opencl/lib/generic/math/half_exp10.cl
+++ b/libclc/opencl/lib/generic/math/half_exp10.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_exp10.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_exp10.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_exp10

--- a/libclc/opencl/lib/generic/math/half_exp2.cl
+++ b/libclc/opencl/lib/generic/math/half_exp2.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_exp2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_exp2.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_exp2

--- a/libclc/opencl/lib/generic/math/half_log.cl
+++ b/libclc/opencl/lib/generic/math/half_log.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_log.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_log.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_log

--- a/libclc/opencl/lib/generic/math/half_log10.cl
+++ b/libclc/opencl/lib/generic/math/half_log10.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_log10.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_log10.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_log10

--- a/libclc/opencl/lib/generic/math/half_log2.cl
+++ b/libclc/opencl/lib/generic/math/half_log2.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_log2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_log2.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_log2

--- a/libclc/opencl/lib/generic/math/half_powr.cl
+++ b/libclc/opencl/lib/generic/math/half_powr.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_powr.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_powr.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_powr

--- a/libclc/opencl/lib/generic/math/half_recip.cl
+++ b/libclc/opencl/lib/generic/math/half_recip.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_recip.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_recip.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_recip

--- a/libclc/opencl/lib/generic/math/half_rsqrt.cl
+++ b/libclc/opencl/lib/generic/math/half_rsqrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_rsqrt.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_rsqrt.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_rsqrt

--- a/libclc/opencl/lib/generic/math/half_sin.cl
+++ b/libclc/opencl/lib/generic/math/half_sin.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_sin.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_sin.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_sin

--- a/libclc/opencl/lib/generic/math/half_sqrt.cl
+++ b/libclc/opencl/lib/generic/math/half_sqrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_sqrt.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_sqrt.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_sqrt

--- a/libclc/opencl/lib/generic/math/half_tan.cl
+++ b/libclc/opencl/lib/generic/math/half_tan.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_half_tan.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/half_tan.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION half_tan

--- a/libclc/opencl/lib/generic/math/hypot.cl
+++ b/libclc/opencl/lib/generic/math/hypot.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_hypot.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/hypot.h>
 
 #define FUNCTION hypot
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/ilogb.cl
+++ b/libclc/opencl/lib/generic/math/ilogb.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_ilogb.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/ilogb.h>
 
 #define FUNCTION ilogb
 #define __CLC_BODY <clc/math/unary_def_with_int_return.inc>

--- a/libclc/opencl/lib/generic/math/ldexp.cl
+++ b/libclc/opencl/lib/generic/math/ldexp.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_ldexp.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/ldexp.h>
 
 #define FUNCTION ldexp
 #define __IMPL_FUNCTION(x) __clc_ldexp

--- a/libclc/opencl/lib/generic/math/lgamma.cl
+++ b/libclc/opencl/lib/generic/math/lgamma.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_lgamma.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/lgamma.h>
 
 #define FUNCTION lgamma
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/lgamma_r.cl
+++ b/libclc/opencl/lib/generic/math/lgamma_r.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_lgamma_r.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/lgamma_r.h>
 
 #define FUNCTION lgamma_r
 #define __CLC_BODY <clc/math/unary_def_with_int_ptr.inc>

--- a/libclc/opencl/lib/generic/math/log.cl
+++ b/libclc/opencl/lib/generic/math/log.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/math/clc_log.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/log.h>
 
 #define FUNCTION log
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/log10.cl
+++ b/libclc/opencl/lib/generic/math/log10.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/math/clc_log10.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/log10.h>
 
 #define FUNCTION log10
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/log1p.cl
+++ b/libclc/opencl/lib/generic/math/log1p.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_log1p.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/log1p.h>
 
 #define FUNCTION log1p
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/log2.cl
+++ b/libclc/opencl/lib/generic/math/log2.cl
@@ -8,7 +8,7 @@
 
 #include <clc/clcmacro.h>
 #include <clc/math/clc_log2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/log2.h>
 
 #define FUNCTION log2
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/logb.cl
+++ b/libclc/opencl/lib/generic/math/logb.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_logb.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/logb.h>
 
 #define FUNCTION logb
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/mad.cl
+++ b/libclc/opencl/lib/generic/math/mad.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_mad.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/mad.h>
 
 #define FUNCTION mad
 #define __CLC_BODY <clc/shared/ternary_def.inc>

--- a/libclc/opencl/lib/generic/math/maxmag.cl
+++ b/libclc/opencl/lib/generic/math/maxmag.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_maxmag.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/maxmag.h>
 
 #define FUNCTION maxmag
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/minmag.cl
+++ b/libclc/opencl/lib/generic/math/minmag.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_minmag.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/minmag.h>
 
 #define FUNCTION minmag
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/modf.cl
+++ b/libclc/opencl/lib/generic/math/modf.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_modf.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/modf.h>
 
 #define FUNCTION modf
 #define __CLC_BODY <clc/math/unary_def_with_ptr.inc>

--- a/libclc/opencl/lib/generic/math/native_cos.cl
+++ b/libclc/opencl/lib/generic/math/native_cos.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_cos.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_cos.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_cos

--- a/libclc/opencl/lib/generic/math/native_divide.cl
+++ b/libclc/opencl/lib/generic/math/native_divide.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_divide.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_divide.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_divide

--- a/libclc/opencl/lib/generic/math/native_exp.cl
+++ b/libclc/opencl/lib/generic/math/native_exp.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_exp.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_exp.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_exp

--- a/libclc/opencl/lib/generic/math/native_exp10.cl
+++ b/libclc/opencl/lib/generic/math/native_exp10.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_exp10.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_exp10.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_exp10

--- a/libclc/opencl/lib/generic/math/native_exp2.cl
+++ b/libclc/opencl/lib/generic/math/native_exp2.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_exp2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_exp2.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_exp2

--- a/libclc/opencl/lib/generic/math/native_log.cl
+++ b/libclc/opencl/lib/generic/math/native_log.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_log.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_log.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_log

--- a/libclc/opencl/lib/generic/math/native_log10.cl
+++ b/libclc/opencl/lib/generic/math/native_log10.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_log10.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_log10.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_log10

--- a/libclc/opencl/lib/generic/math/native_log2.cl
+++ b/libclc/opencl/lib/generic/math/native_log2.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_log2.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_log2.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_log2

--- a/libclc/opencl/lib/generic/math/native_powr.cl
+++ b/libclc/opencl/lib/generic/math/native_powr.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_powr.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_powr.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_powr

--- a/libclc/opencl/lib/generic/math/native_recip.cl
+++ b/libclc/opencl/lib/generic/math/native_recip.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_recip.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_recip.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_recip

--- a/libclc/opencl/lib/generic/math/native_rsqrt.cl
+++ b/libclc/opencl/lib/generic/math/native_rsqrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_rsqrt.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_rsqrt.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_rsqrt

--- a/libclc/opencl/lib/generic/math/native_sin.cl
+++ b/libclc/opencl/lib/generic/math/native_sin.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_sin.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_sin.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_sin

--- a/libclc/opencl/lib/generic/math/native_sqrt.cl
+++ b/libclc/opencl/lib/generic/math/native_sqrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_sqrt.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_sqrt.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_sqrt

--- a/libclc/opencl/lib/generic/math/native_tan.cl
+++ b/libclc/opencl/lib/generic/math/native_tan.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_native_tan.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/native_tan.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION native_tan

--- a/libclc/opencl/lib/generic/math/nextafter.cl
+++ b/libclc/opencl/lib/generic/math/nextafter.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_nextafter.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/nextafter.h>
 
 #define FUNCTION nextafter
 #define __IMPL_FUNCTION(x) __clc_nextafter

--- a/libclc/opencl/lib/generic/math/pow.cl
+++ b/libclc/opencl/lib/generic/math/pow.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_pow.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/pow.h>
 
 #define FUNCTION pow
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/pown.cl
+++ b/libclc/opencl/lib/generic/math/pown.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_pown.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/pown.h>
 
 #define FUNCTION pown
 #define __CLC_BODY <clc/shared/binary_def_with_int_second_arg.inc>

--- a/libclc/opencl/lib/generic/math/powr.cl
+++ b/libclc/opencl/lib/generic/math/powr.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_powr.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/powr.h>
 
 #define FUNCTION powr
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/remainder.cl
+++ b/libclc/opencl/lib/generic/math/remainder.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_remainder.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/remainder.h>
 
 #define FUNCTION remainder
 #define __CLC_BODY <clc/shared/binary_def.inc>

--- a/libclc/opencl/lib/generic/math/remquo.cl
+++ b/libclc/opencl/lib/generic/math/remquo.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_remquo.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/remquo.h>
 
 #define __CLC_BODY <remquo.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/opencl/lib/generic/math/rint.cl
+++ b/libclc/opencl/lib/generic/math/rint.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_rint.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/rint.h>
 
 #define FUNCTION rint
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/rootn.cl
+++ b/libclc/opencl/lib/generic/math/rootn.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_rootn.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/rootn.h>
 
 #define FUNCTION rootn
 #define __CLC_BODY <clc/shared/binary_def_with_int_second_arg.inc>

--- a/libclc/opencl/lib/generic/math/round.cl
+++ b/libclc/opencl/lib/generic/math/round.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_round.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/round.h>
 
 #define FUNCTION round
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/rsqrt.cl
+++ b/libclc/opencl/lib/generic/math/rsqrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_rsqrt.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/rsqrt.h>
 
 #define FUNCTION rsqrt
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/sin.cl
+++ b/libclc/opencl/lib/generic/math/sin.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_sin.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/sin.h>
 
 #define FUNCTION sin
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/sincos.cl
+++ b/libclc/opencl/lib/generic/math/sincos.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_sincos.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/sincos.h>
 
 #define FUNCTION sincos
 #define __CLC_BODY <clc/math/unary_def_with_ptr.inc>

--- a/libclc/opencl/lib/generic/math/sinh.cl
+++ b/libclc/opencl/lib/generic/math/sinh.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_sinh.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/sinh.h>
 
 #define FUNCTION sinh
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/sinpi.cl
+++ b/libclc/opencl/lib/generic/math/sinpi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_sinpi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/sinpi.h>
 
 #define FUNCTION sinpi
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/sqrt.cl
+++ b/libclc/opencl/lib/generic/math/sqrt.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_sqrt.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/sqrt.h>
 
 #define FUNCTION sqrt
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/tan.cl
+++ b/libclc/opencl/lib/generic/math/tan.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_tan.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/tan.h>
 
 #define FUNCTION tan
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/tanh.cl
+++ b/libclc/opencl/lib/generic/math/tanh.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_tanh.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/tanh.h>
 
 #define FUNCTION tanh
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/tanpi.cl
+++ b/libclc/opencl/lib/generic/math/tanpi.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_tanpi.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/tanpi.h>
 
 #define FUNCTION tanpi
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/tgamma.cl
+++ b/libclc/opencl/lib/generic/math/tgamma.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_tgamma.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/tgamma.h>
 
 #define FUNCTION tgamma
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/math/trunc.cl
+++ b/libclc/opencl/lib/generic/math/trunc.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/math/clc_trunc.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/trunc.h>
 
 #define FUNCTION trunc
 #define __CLC_BODY <clc/shared/unary_def.inc>

--- a/libclc/opencl/lib/generic/relational/all.cl
+++ b/libclc/opencl/lib/generic/relational/all.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/all.h>
 #include <clc/relational/clc_all.h>
 
 #define ALL_ID(TYPE) _CLC_OVERLOAD _CLC_DEF int all(TYPE v)

--- a/libclc/opencl/lib/generic/relational/any.cl
+++ b/libclc/opencl/lib/generic/relational/any.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/any.h>
 #include <clc/relational/clc_any.h>
 
 #define ANY_ID(TYPE) _CLC_OVERLOAD _CLC_DEF int any(TYPE v)

--- a/libclc/opencl/lib/generic/relational/bitselect.cl
+++ b/libclc/opencl/lib/generic/relational/bitselect.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/bitselect.h>
 #include <clc/relational/clc_bitselect.h>
 
 #define __CLC_BODY <bitselect.inc>

--- a/libclc/opencl/lib/generic/relational/isequal.cl
+++ b/libclc/opencl/lib/generic/relational/isequal.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isequal.h>
 #include <clc/relational/clc_isequal.h>
 
 #define FUNCTION isequal

--- a/libclc/opencl/lib/generic/relational/isfinite.cl
+++ b/libclc/opencl/lib/generic/relational/isfinite.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isfinite.h>
 #include <clc/relational/clc_isfinite.h>
 
 #define FUNCTION isfinite

--- a/libclc/opencl/lib/generic/relational/isgreater.cl
+++ b/libclc/opencl/lib/generic/relational/isgreater.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isgreater.h>
 #include <clc/relational/clc_isgreater.h>
 
 #define FUNCTION isgreater

--- a/libclc/opencl/lib/generic/relational/isgreaterequal.cl
+++ b/libclc/opencl/lib/generic/relational/isgreaterequal.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isgreaterequal.h>
 #include <clc/relational/clc_isgreaterequal.h>
 
 #define FUNCTION isgreaterequal

--- a/libclc/opencl/lib/generic/relational/isinf.cl
+++ b/libclc/opencl/lib/generic/relational/isinf.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isinf.h>
 #include <clc/relational/clc_isinf.h>
 
 #define FUNCTION isinf

--- a/libclc/opencl/lib/generic/relational/isless.cl
+++ b/libclc/opencl/lib/generic/relational/isless.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isless.h>
 #include <clc/relational/clc_isless.h>
 
 #define FUNCTION isless

--- a/libclc/opencl/lib/generic/relational/islessequal.cl
+++ b/libclc/opencl/lib/generic/relational/islessequal.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/islessequal.h>
 #include <clc/relational/clc_islessequal.h>
 
 #define FUNCTION islessequal

--- a/libclc/opencl/lib/generic/relational/islessgreater.cl
+++ b/libclc/opencl/lib/generic/relational/islessgreater.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/islessgreater.h>
 #include <clc/relational/clc_islessgreater.h>
 
 #define FUNCTION islessgreater

--- a/libclc/opencl/lib/generic/relational/isnan.cl
+++ b/libclc/opencl/lib/generic/relational/isnan.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isnan.h>
 #include <clc/relational/clc_isnan.h>
 
 #define FUNCTION isnan

--- a/libclc/opencl/lib/generic/relational/isnormal.cl
+++ b/libclc/opencl/lib/generic/relational/isnormal.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isnormal.h>
 #include <clc/relational/clc_isnormal.h>
 
 #define FUNCTION isnormal

--- a/libclc/opencl/lib/generic/relational/isnotequal.cl
+++ b/libclc/opencl/lib/generic/relational/isnotequal.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isnotequal.h>
 #include <clc/relational/clc_isnotequal.h>
 
 #define FUNCTION isnotequal

--- a/libclc/opencl/lib/generic/relational/isordered.cl
+++ b/libclc/opencl/lib/generic/relational/isordered.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isordered.h>
 #include <clc/relational/clc_isordered.h>
 
 #define FUNCTION isordered

--- a/libclc/opencl/lib/generic/relational/isunordered.cl
+++ b/libclc/opencl/lib/generic/relational/isunordered.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/isunordered.h>
 #include <clc/relational/clc_isunordered.h>
 
 #define FUNCTION isunordered

--- a/libclc/opencl/lib/generic/relational/select.cl
+++ b/libclc/opencl/lib/generic/relational/select.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/select.h>
 #include <clc/relational/clc_select.h>
 #include <clc/utils.h>
 

--- a/libclc/opencl/lib/generic/relational/signbit.cl
+++ b/libclc/opencl/lib/generic/relational/signbit.cl
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/opencl/clc.h>
+#include <clc/opencl/relational/signbit.h>
 #include <clc/relational/clc_signbit.h>
 
 #define FUNCTION signbit

--- a/libclc/opencl/lib/spirv/math/fma.cl
+++ b/libclc/opencl/lib/spirv/math/fma.cl
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <clc/internal/math/clc_sw_fma.h>
-#include <clc/opencl/clc.h>
+#include <clc/opencl/math/fma.h>
 
 #define __FLOAT_ONLY
 #define FUNCTION fma


### PR DESCRIPTION
This commit continues the work from #146840 and extends it to the maths, geomtrics, common, and relational directories.

All headers have include guards and, where appropriate, include the minimal code required for their specific definitions. Implementation files no longer include the large catch-all header of all OpenCL builtin declarations.