### PR TITLE
[lldb][test] Fix libstdc++ std::variant formatter tests for valueless variants

### DIFF
--- a/lldb/examples/synthetic/gnu_libstdcpp.py
+++ b/lldb/examples/synthetic/gnu_libstdcpp.py
@@ -889,12 +889,17 @@ def VariantSummaryProvider(valobj, dict):
     if not (index_obj and index_obj.IsValid() and data_obj and data_obj.IsValid()):
         return "<Can't find _M_index or _M_u>"
 
-    npos = valobj.GetTarget().FindFirstGlobalVariable("std::variant_npos")
-    if not npos:
-        return "<Can't find std::variant_npos sentinel>"
+    def get_variant_npos_value(index_byte_size):
+        if index_byte_size == 1:
+            return 0xFF
+        elif index_byte_size == 2:
+            return 0xFFFF
+        else:
+            return 0xFFFFFFFF
 
+    npos_value = get_variant_npos_value(index_obj.GetByteSize())
     index = index_obj.GetValueAsUnsigned(0)
-    if index == npos.GetValueAsUnsigned(0):
+    if index == npos_value:
         return " No Value"
 
     # Strip references and typedefs.

--- a/lldb/examples/synthetic/gnu_libstdcpp.py
+++ b/lldb/examples/synthetic/gnu_libstdcpp.py
@@ -889,17 +889,12 @@ def VariantSummaryProvider(valobj, dict):
     if not (index_obj and index_obj.IsValid() and data_obj and data_obj.IsValid()):
         return "<Can't find _M_index or _M_u>"
 
-    def get_variant_npos_value(index_byte_size):
-        if index_byte_size == 1:
-            return 0xFF
-        elif index_byte_size == 2:
-            return 0xFFFF
-        else:
-            return 0xFFFFFFFF
+    npos = valobj.GetTarget().FindFirstGlobalVariable("std::variant_npos")
+    if not npos:
+        return "<Can't find std::variant_npos sentinel>"
 
-    npos_value = get_variant_npos_value(index_obj.GetByteSize())
     index = index_obj.GetValueAsUnsigned(0)
-    if index == npos_value:
+    if index == npos.GetValueAsUnsigned(0):
         return " No Value"
 
     # Strip references and typedefs.

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -62,11 +62,11 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
             substrs=["v3 =  Active Type = char  {", "Value = 'A'", "}"],
         )
 
-        self.expect("frame variable v_no_value", substrs=["v_no_value =  No Value"])
+        self.expect("frame variable v_valueless", substrs=["v_valueless =  No Value"])
 
         self.expect(
-            "frame variable v_many_types_no_value",
-            substrs=["v_many_types_no_value =  No Value"],
+            "frame variable v_many_types_valueless",
+            substrs=["v_many_types_valueless =  No Value"],
         )
 
     @add_test_categories(["libstdcxx"])

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/TestDataFormatterLibStdcxxVariant.py
@@ -2,7 +2,6 @@
 Test lldb data formatter for LibStdC++ std::variant.
 """
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -62,9 +61,6 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
             "frame variable v3",
             substrs=["v3 =  Active Type = char  {", "Value = 'A'", "}"],
         )
-        """
-        TODO: temporarily disable No Value tests as they seem to fail on ubuntu/debian
-        bots. Pending reproduce and investigation.
 
         self.expect("frame variable v_no_value", substrs=["v_no_value =  No Value"])
 
@@ -72,7 +68,6 @@ class LibStdcxxVariantDataFormatterTestCase(TestBase):
             "frame variable v_many_types_no_value",
             substrs=["v_many_types_no_value =  No Value"],
         )
-        """
 
     @add_test_categories(["libstdcxx"])
     def test_invalid_variant_index(self):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/main.cpp
@@ -49,7 +49,6 @@ int main() {
   v1 = 12; // v contains int
   v1_typedef = v1;
   v_v1 = v1;
-  v1_typedef = v1;
   int i = std::get<int>(v1);
   printf("%d\n", i); // break here
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libstdcpp/variant/main.cpp
@@ -49,6 +49,7 @@ int main() {
   v1 = 12; // v contains int
   v1_typedef = v1;
   v_v1 = v1;
+  v1_typedef = v1;
   int i = std::get<int>(v1);
   printf("%d\n", i); // break here
 


### PR DESCRIPTION
A default-constructed variant has a valid index (being the first element of the variant). The only case where the index is variant_npos is when the variant is "valueless", which [according to cppreference](https://en.cppreference.com/w/cpp/utility/variant/valueless_by_exception.html) only happens when an exception is thrown during assignment to the variant.

I adjusted the test to test that scenario, and the formatter seems to work. 

Unblocks https://github.com/llvm/llvm-project/pull/147253