### PR TITLE
[NFC] Remove undef in swp-const-tc1.ll test

### DIFF
--- a/llvm/test/CodeGen/Hexagon/swp-const-tc1.ll
+++ b/llvm/test/CodeGen/Hexagon/swp-const-tc1.ll
@@ -13,14 +13,14 @@
 ; CHECK: memb(r{{[0-9]+}}+#0) =
 
 ; Function Attrs: nounwind optsize
-define void @f0(i1 %x) #0 {
+define void @f0(i1 %x, i32 %y, ptr %p1, ptr %p2, ptr %p3) #0 {
 b0:
   br label %b1
 
 b1:                                               ; preds = %b5, %b0
-  %v0 = load i16, ptr undef, align 2, !tbaa !0
+  %v0 = load i16, ptr %p1, align 2, !tbaa !0
   %v1 = sext i16 %v0 to i32
-  %v2 = load i16, ptr undef, align 2, !tbaa !0
+  %v2 = load i16, ptr %p2, align 2, !tbaa !0
   %v3 = sext i16 %v2 to i32
   %v4 = and i32 %v1, 7
   %v5 = and i32 %v3, 7
@@ -31,8 +31,8 @@ b2:                                               ; preds = %b4, %b1
 
 b3:                                               ; preds = %b3, %b2
   %v6 = phi i32 [ 0, %b2 ], [ %v22, %b3 ]
-  %v7 = add i32 %v6, undef
-  %v8 = icmp slt i32 undef, %v7
+  %v7 = add i32 %v6, %y
+  %v8 = icmp slt i32 %y, %v7
   %v9 = add nsw i32 %v7, 1
   %v10 = select i1 %x, i32 1, i32 %v9
   %v11 = add i32 %v10, 0
@@ -46,16 +46,16 @@ b3:                                               ; preds = %b3, %b2
   %v19 = add i32 %v18, 0
   %v20 = lshr i32 %v19, 6
   %v21 = trunc i32 %v20 to i8
-  store i8 %v21, ptr undef, align 1, !tbaa !4
+  store i8 %v21, ptr %p3, align 1, !tbaa !4
   %v22 = add i32 %v6, 1
   %v23 = icmp eq i32 %v22, 2
   br i1 %v23, label %b4, label %b3
 
 b4:                                               ; preds = %b3
-  br i1 undef, label %b5, label %b2
+  br i1 true, label %b5, label %b2
 
 b5:                                               ; preds = %b4
-  br i1 undef, label %b1, label %b6
+  br i1 false, label %b1, label %b6
 
 b6:                                               ; preds = %b5
   ret void


### PR DESCRIPTION
Change undef branch conditions to the values that loop-simplify gives them, and handle other undef values by using extra arguments. I'm making this change because of an upcoming loop strength reduction change that results in instsimplify removing more instructions due to them using undef, causing the test checks to fail.