### PR TITLE
[libc] Add atexit to baremetal entrypoints

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -218,6 +218,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.abort
     libc.src.stdlib.abs
     libc.src.stdlib.aligned_alloc
+    libc.src.stdlib.atexit
     libc.src.stdlib.atof
     libc.src.stdlib.atoi
     libc.src.stdlib.atol

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -218,6 +218,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.abort
     libc.src.stdlib.abs
     libc.src.stdlib.aligned_alloc
+    libc.src.stdlib.atexit
     libc.src.stdlib.atof
     libc.src.stdlib.atoi
     libc.src.stdlib.atol

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -218,6 +218,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdlib.abort
     libc.src.stdlib.abs
     libc.src.stdlib.aligned_alloc
+    libc.src.stdlib.atexit
     libc.src.stdlib.atof
     libc.src.stdlib.atoi
     libc.src.stdlib.atol


### PR DESCRIPTION
Part of #145349. Requires #145358. Required by #146863. Once the mutex has been implemented, we can register functions to be called for exit with `atexit`.