### PR TITLE
[Offload] Generate OffloadInfo.inc

### DIFF
--- a/offload/liboffload/API/Device.td
+++ b/offload/liboffload/API/Device.td
@@ -22,7 +22,7 @@ def : Enum {
   ];
 }
 
-def : Enum {
+def DeviceInfo : Enum {
   let name = "ol_device_info_t";
   let desc = "Supported device info.";
   let is_typed = 1;

--- a/offload/plugins-nextgen/common/CMakeLists.txt
+++ b/offload/plugins-nextgen/common/CMakeLists.txt
@@ -4,6 +4,7 @@ include(TableGen)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
 set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API/OffloadAPI.td)
 tablegen(OFFLOAD include/OffloadErrcodes.inc -gen-errcodes -I ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
+tablegen(OFFLOAD include/OffloadInfo.inc -gen-info -I ${CMAKE_CURRENT_SOURCE_DIR}/../../liboffload/API)
 add_public_tablegen_target(PluginErrcodes)
 
 # NOTE: Don't try to build `PluginInterface` using `add_llvm_library` because we

--- a/offload/tools/offload-tblgen/Generators.hpp
+++ b/offload/tools/offload-tblgen/Generators.hpp
@@ -23,3 +23,4 @@ void EmitOffloadExports(const llvm::RecordKeeper &Records,
                         llvm::raw_ostream &OS);
 void EmitOffloadErrcodes(const llvm::RecordKeeper &Records,
                          llvm::raw_ostream &OS);
+void EmitOffloadInfo(const llvm::RecordKeeper &Records, llvm::raw_ostream &OS);

--- a/offload/tools/offload-tblgen/MiscGen.cpp
+++ b/offload/tools/offload-tblgen/MiscGen.cpp
@@ -93,3 +93,24 @@ void EmitOffloadErrcodes(const RecordKeeper &Records, raw_ostream &OS) {
                   EnumVal.getDesc(), EtorVal++);
   }
 }
+
+// Emit macro calls for each info
+void EmitOffloadInfo(const RecordKeeper &Records, raw_ostream &OS) {
+  OS << GenericHeader;
+  OS << R"(
+#ifndef OFFLOAD_DEVINFO
+#error Please define the macro OFFLOAD_DEVINFO(Name, Desc, Value)
+#endif
+
+// Device info codes are shared between PluginInterface and liboffload.
+// To add new error codes, add them to offload/liboffload/API/Device.td.
+
+)";
+
+  auto ErrorCodeEnum = EnumRec{Records.getDef("DeviceInfo")};
+  uint32_t EtorVal = 0;
+  for (const auto &EnumVal : ErrorCodeEnum.getValues()) {
+    OS << formatv(TAB_1 "OFFLOAD_DEVINFO({0}, \"{1}\", {2})\n",
+                  EnumVal.getName(), EnumVal.getDesc(), EtorVal++);
+  }
+}

--- a/offload/tools/offload-tblgen/offload-tblgen.cpp
+++ b/offload/tools/offload-tblgen/offload-tblgen.cpp
@@ -32,6 +32,7 @@ enum ActionType {
   GenPrintHeader,
   GenExports,
   GenErrcodes,
+  GenInfo,
 };
 
 namespace {
@@ -55,7 +56,8 @@ cl::opt<ActionType> Action(
         clEnumValN(GenExports, "gen-exports",
                    "Generate export file for the Offload library"),
         clEnumValN(GenErrcodes, "gen-errcodes",
-                   "Generate Offload Error Code enum")));
+                   "Generate Offload Error Code enum"),
+        clEnumValN(GenInfo, "gen-info", "Generate Offload Info enum")));
 }
 
 static bool OffloadTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
@@ -86,6 +88,9 @@ static bool OffloadTableGenMain(raw_ostream &OS, const RecordKeeper &Records) {
     break;
   case GenErrcodes:
     EmitOffloadErrcodes(Records, OS);
+    break;
+  case GenInfo:
+    EmitOffloadInfo(Records, OS);
     break;
   }
 


### PR DESCRIPTION
This is a generated file which contains a macro for all Device Info
keys. This is visible to the plugin interface so that it can use the
definitions in a future patch.
