### PR TITLE
[Offload] Implement 'Vendor Name' device info for CUDA

### DIFF
--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -940,6 +940,8 @@ struct CUDADeviceTy : public GenericDeviceTy {
     if (Res == CUDA_SUCCESS)
       Info.add("Device Name", TmpChar);
 
+    Info.add("Vendor Name", "NVIDIA");
+
     Res = cuDeviceTotalMem(&TmpSt, Device);
     if (Res == CUDA_SUCCESS)
       Info.add("Global Memory Size", TmpSt, "bytes");


### PR DESCRIPTION
After #146345 the device info implementation requires a value for every query, rather than silently returning an empty string. This broke the test for `OL_DEVICE_INFO_VENDOR` on CUDA.

Add a value to the CUDA plugin. We can quite safely hard code this one.