### PR TITLE
[llvm] add ProfileData to yaml2obj and obj2yaml LLVM_LINK_COMPONENTS

### DIFF
--- a/llvm/tools/obj2yaml/CMakeLists.txt
+++ b/llvm/tools/obj2yaml/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   DebugInfoDWARF
   Object
   ObjectYAML
+  ProfileData
   Support
   )
 

--- a/llvm/tools/yaml2obj/CMakeLists.txt
+++ b/llvm/tools/yaml2obj/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   Object
   ObjectYAML
+  ProfileData
   Support
   )
 


### PR DESCRIPTION
## Purpose
Add `ProfileData` to `LLVM_LINK_COMPONENTS` for the `yaml2obj` and `obj2yaml` tools so they link properly when LLVM is built as a Windows DLL. 

## Background
`ProfileData` appears to be a missing dependency from `yaml2obj` and `obj2yaml`, but when LLVM is built statically it picks-up the required `LLVMPasses` symbols from a transitive dependency (presumably). When LLVM is built as a Windows DLL, `yaml2obj` and `obj2yaml` fail to link 3 symbols from `ProfileData` without this change:

```
LLVMCore.lib(Verifier.cpp.obj) : error LNK2019: unresolved external symbol "class std::error_category const & __cdecl llvm::instrprof_category(void)" (?instrprof_category@llvm@@YAAEBVerror_category@std@@XZ) referenced in function "public: virtual class std::error_code __cdecl llvm::InstrProfError::convertToErrorCode(void)const " (?convertToErrorCode@InstrProfError@llvm@@UEBA?AVerror_code@std@@XZ)
LLVMCore.lib(Verifier.cpp.obj) : error LNK2001: unresolved external symbol "public: virtual class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl llvm::InstrProfError::message(void)const " (?message@InstrProfError@llvm@@UEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ)
LLVMCore.lib(Verifier.cpp.obj) : error LNK2019: unresolved external symbol "public: static char llvm::InstrProfError::ID" (?ID@InstrProfError@llvm@@2DA) referenced in function "void __cdecl llvm::handleAllErrors<class `public: static struct std::pair<enum llvm::instrprof_error,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > __cdecl llvm::InstrProfError::take(class llvm::Error)'::`2'::<lambda_1> >(class llvm::Error,class `public: static struct std::pair<enum llvm::instrprof_error,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > > __cdecl llvm::InstrProfError::take(class llvm::Error)'::`2'::<lambda_1> &&)" (??$handleAllErrors@V<lambda_1>@?1??take@InstrProfError@llvm@@SA?AU?$pair@W4instrprof_error@llvm@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@VError@4@@Z@@llvm@@YAXVError@0@$$QEAV<lambda_1>@?1??take@InstrProfError@0@SA?AU?$pair@W4instrprof_error@llvm@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@std@@0@Z@@Z)
bin\yaml2obj.exe : fatal error LNK1120: 3 unresolved externals
```

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang