### PR TITLE
Fix MSVC warning in benchmark

### DIFF
--- a/third-party/benchmark/src/sysinfo.cc
+++ b/third-party/benchmark/src/sysinfo.cc
@@ -358,7 +358,6 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
     C.num_sharing = static_cast<int>(b.count());
     C.level = cache.Level;
     C.size = cache.Size;
-    C.type = "Unknown";
     switch (cache.Type) {
       case CacheUnified:
         C.type = "Unified";
@@ -371,6 +370,9 @@ std::vector<CPUInfo::CacheInfo> GetCacheSizesWindows() {
         break;
       case CacheTrace:
         C.type = "Trace";
+        break;
+      case CacheUnknown:
+        C.type = "Unknown";
         break;
     }
     res.push_back(C);


### PR DESCRIPTION
Building LLVM with MSVC is raising the following warning:

```
llvm\third-party\benchmark\src\sysinfo.cc(375): warning C4062: enumerator 'CacheUnknown' in switch of enum '_PROCESSOR_CACHE_TYPE' is not handled
```

This change resolves the warning by moving the `Unknown` type into a case block for `CacheUnknown`.

Not sure how this code flows back into the original source.