### PR TITLE
Fix the type of offset that broke 32-bit flang-rt build to use `uint64_t` consistently

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -598,7 +598,7 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
         std::size_t componentByteSize{
             this->component_->SizeInBytes(this->instance_)};
         if (IS_COMPONENTWISE && toIsContiguous_ && fromIsContiguous_) {
-          std::size_t offset{this->component_->offset()};
+          std::uint64_t offset{this->component_->offset()};
           char *to{this->instance_.template OffsetElement<char>(offset)};
           const char *from{
               this->from_->template OffsetElement<const char>(offset)};
@@ -630,7 +630,7 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
       std::size_t componentByteSize{
           this->component_->SizeInBytes(this->instance_)};
       if (IS_COMPONENTWISE && toIsContiguous_ && fromIsContiguous_) {
-        std::size_t offset{this->component_->offset()};
+        std::uint64_t offset{this->component_->offset()};
         char *to{this->instance_.template OffsetElement<char>(offset)};
         const char *from{
             this->from_->template OffsetElement<const char>(offset)};

--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -598,7 +598,7 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
         std::size_t componentByteSize{
             this->component_->SizeInBytes(this->instance_)};
         if (IS_COMPONENTWISE && toIsContiguous_ && fromIsContiguous_) {
-          std::uint64_t offset{this->component_->offset()};
+          std::size_t offset{static_cast<size_t>(this->component_->offset())};
           char *to{this->instance_.template OffsetElement<char>(offset)};
           const char *from{
               this->from_->template OffsetElement<const char>(offset)};
@@ -630,7 +630,7 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
       std::size_t componentByteSize{
           this->component_->SizeInBytes(this->instance_)};
       if (IS_COMPONENTWISE && toIsContiguous_ && fromIsContiguous_) {
-        std::uint64_t offset{this->component_->offset()};
+        std::uint64_t offset{static_cast<size_t>(this->component_->offset())};
         char *to{this->instance_.template OffsetElement<char>(offset)};
         const char *from{
             this->from_->template OffsetElement<const char>(offset)};

--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -598,7 +598,8 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
         std::size_t componentByteSize{
             this->component_->SizeInBytes(this->instance_)};
         if (IS_COMPONENTWISE && toIsContiguous_ && fromIsContiguous_) {
-          std::size_t offset{static_cast<size_t>(this->component_->offset())};
+          std::size_t offset{
+              static_cast<std::size_t>(this->component_->offset())};
           char *to{this->instance_.template OffsetElement<char>(offset)};
           const char *from{
               this->from_->template OffsetElement<const char>(offset)};
@@ -630,7 +631,8 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
       std::size_t componentByteSize{
           this->component_->SizeInBytes(this->instance_)};
       if (IS_COMPONENTWISE && toIsContiguous_ && fromIsContiguous_) {
-        std::uint64_t offset{static_cast<size_t>(this->component_->offset())};
+        std::size_t offset{
+            static_cast<std::size_t>(this->component_->offset())};
         char *to{this->instance_.template OffsetElement<char>(offset)};
         const char *from{
             this->from_->template OffsetElement<const char>(offset)};

--- a/flang-rt/lib/runtime/type-info.cpp
+++ b/flang-rt/lib/runtime/type-info.cpp
@@ -140,7 +140,7 @@ RT_API_ATTRS void Component::CreatePointerDescriptor(Descriptor &descriptor,
     const SubscriptValue *subscripts) const {
   RUNTIME_CHECK(terminator, genre_ == Genre::Data);
   EstablishDescriptor(descriptor, container, terminator);
-  std::size_t offset{offset_};
+  std::uint64_t offset{offset_};
   if (subscripts) {
     offset += container.SubscriptsToByteOffset(subscripts);
   }

--- a/flang-rt/lib/runtime/type-info.cpp
+++ b/flang-rt/lib/runtime/type-info.cpp
@@ -140,7 +140,7 @@ RT_API_ATTRS void Component::CreatePointerDescriptor(Descriptor &descriptor,
     const SubscriptValue *subscripts) const {
   RUNTIME_CHECK(terminator, genre_ == Genre::Data);
   EstablishDescriptor(descriptor, container, terminator);
-  std::uint64_t offset{offset_};
+  std::size_t offset{static_cast<size_t>(offset_)};
   if (subscripts) {
     offset += container.SubscriptsToByteOffset(subscripts);
   }

--- a/flang-rt/lib/runtime/type-info.cpp
+++ b/flang-rt/lib/runtime/type-info.cpp
@@ -140,7 +140,7 @@ RT_API_ATTRS void Component::CreatePointerDescriptor(Descriptor &descriptor,
     const SubscriptValue *subscripts) const {
   RUNTIME_CHECK(terminator, genre_ == Genre::Data);
   EstablishDescriptor(descriptor, container, terminator);
-  std::size_t offset{static_cast<size_t>(offset_)};
+  std::size_t offset{static_cast<std::size_t>(offset_)};
   if (subscripts) {
     offset += container.SubscriptsToByteOffset(subscripts);
   }


### PR DESCRIPTION
The recent change of `flang-rt` has code like `std::size_t offset{offset_};`. 
It broke the 32-bit `flang-rt` build because `Component::offset_` is of type `uint64_t` but `size_t` varies. 
Clang complains
```
error: non-constant-expression cannot be narrowed from type 'std::uint64_t' (aka 'unsigned long long') to 'std::size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
  143 |   std::size_t offset{offset_};
      |                      ^~~~~~~

```

This patch is to use the consistent `uint64_t` for offset.