### PR TITLE
Report wider source range for unsafe buffers warnings

### DIFF
--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2275,28 +2275,23 @@ public:
     unsigned MsgParam = 0;
     NamedDecl *D = nullptr;
     if (const auto *ASE = dyn_cast<ArraySubscriptExpr>(Operation)) {
-      Loc = ASE->getBase()->getExprLoc();
-      Range = ASE->getBase()->getSourceRange();
+      Loc = ASE->getExprLoc();
+      Range = ASE->getSourceRange();
       MsgParam = 2;
     } else if (const auto *BO = dyn_cast<BinaryOperator>(Operation)) {
       BinaryOperator::Opcode Op = BO->getOpcode();
       if (Op == BO_Add || Op == BO_AddAssign || Op == BO_Sub ||
           Op == BO_SubAssign) {
-        if (BO->getRHS()->getType()->isIntegerType()) {
-          Loc = BO->getLHS()->getExprLoc();
-          Range = BO->getLHS()->getSourceRange();
-        } else {
-          Loc = BO->getRHS()->getExprLoc();
-          Range = BO->getRHS()->getSourceRange();
-        }
+        Loc = BO->getExprLoc();
+        Range = BO->getSourceRange();
         MsgParam = 1;
       }
     } else if (const auto *UO = dyn_cast<UnaryOperator>(Operation)) {
       UnaryOperator::Opcode Op = UO->getOpcode();
       if (Op == UO_PreInc || Op == UO_PreDec || Op == UO_PostInc ||
           Op == UO_PostDec) {
-        Loc = UO->getSubExpr()->getExprLoc();
-        Range = UO->getSubExpr()->getSourceRange();
+        Loc = UO->getExprLoc();
+        Range = UO->getSourceRange();
         MsgParam = 1;
       }
     } else {

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-source-ranges.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-source-ranges.cpp
@@ -6,45 +6,45 @@ void foo(int i) {
   int * ptr;
 
   ptr++;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:8}
   ptr--;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:8}
   ++ptr;
-  // CHECK: {[[@LINE-1]]:5-[[@LINE-1]]:8}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:8}
   --ptr;
-  // CHECK: {[[@LINE-1]]:5-[[@LINE-1]]:8}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:8}
 
 
   ptr + 1;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:10}
   2 + ptr;
-  // CHECK: {[[@LINE-1]]:7-[[@LINE-1]]:10}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:10}
   ptr + i;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:10}
   i + ptr;
-  // CHECK: {[[@LINE-1]]:7-[[@LINE-1]]:10}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:10}
 
 
   ptr - 3;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:10}
   ptr - i;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:10}
 
 
   ptr += 4;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:11}
   ptr += i;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:11}
 
 
   ptr -= 5;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:11}
   ptr -= i;
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:11}
 
 
   ptr[5];
-  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:6}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:9}
   5[ptr];
-  // CHECK: {[[@LINE-1]]:5-[[@LINE-1]]:8}
+  // CHECK: {[[@LINE-1]]:3-[[@LINE-1]]:9}
 }


### PR DESCRIPTION
Updates UnsafeBufferUsageReporter::handleUnsafeOperation() to report the entire expression when reporting an unsafe buffers operation instead of just one operand. This is more meaningful when trying to find / replace / suppress unsafe buffer warnings in source code.  In particular, it changes e.g.
```
  return i[s];  // This header is checked and makes an error.
         ^
```
into
```
  return i[s]; 
         ^~~~
```

as reported in https://github.com/llvm/llvm-project/issues/146579