### PR TITLE
Propose new ClangIR Maintainer

### DIFF
--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -59,6 +59,8 @@ Clang MLIR generation
 | Bruno Cardoso Lopes
 | bruno.cardoso\@gmail.com (email), sonicsprawl (Discord), bcardosolopes (GitHub)
 
+| Henrich Lauko
+| henrich.lauko\@trailofbits.com  (email), henrich.lauko (Discord), xlauko (GitHub)
 
 Analysis & CFG
 ~~~~~~~~~~~~~~

--- a/clang/Maintainers.rst
+++ b/clang/Maintainers.rst
@@ -60,7 +60,7 @@ Clang MLIR generation
 | bruno.cardoso\@gmail.com (email), sonicsprawl (Discord), bcardosolopes (GitHub)
 
 | Henrich Lauko
-| henrich.lauko\@trailofbits.com  (email), henrich.lauko (Discord), xlauko (GitHub)
+| henrich.lau\@gmail.com  (email), henrich.lauko (Discord), xlauko (GitHub)
 
 Analysis & CFG
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
@xlauko is an active PR reviewer, contributing to ClangIR/MLIR discussion for years now, and has been effectively overseeing the quality of CIR dialect (the MLIR part). I'd like to nominate him to join the list of maintainers.