### PR TITLE
Add ":MathDialect" as a dep of "GPUDialect". Fixes bazel build.

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -5321,6 +5321,7 @@ cc_library(
         ":InferIntRangeInterface",
         ":InferTypeOpInterface",
         ":InliningUtils",
+        ":MathDialect",
         ":MemRefDialect",
         ":SCFDialect",
         ":SideEffectInterfaces",


### PR DESCRIPTION
Error was:
external/llvm-project/mlir/lib/Dialect/GPU/IR/GPUDialect.cpp:17:10: fatal error: 'mlir/Dialect/Math/IR/Math.h' file not found
   17 | #include "mlir/Dialect/Math/IR/Math.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
