### PR TITLE
[Modules] Don't const eval VarDecls with dependent type

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2450,7 +2450,8 @@ bool VarDecl::hasInitWithSideEffects() const {
     ES->HasSideEffects =
         E->HasSideEffects(getASTContext()) &&
         // We can get a value-dependent initializer during error recovery.
-        (E->isValueDependent() || !evaluateValue());
+        (E->isValueDependent() || getType()->isDependentType() ||
+         !evaluateValue());
     ES->CheckedForSideEffects = true;
   }
   return ES->HasSideEffects;

--- a/clang/test/Modules/var-init-side-effects-templated.cpp
+++ b/clang/test/Modules/var-init-side-effects-templated.cpp
@@ -1,0 +1,20 @@
+// Tests referencing variable with initializer containing side effect across module boundary
+
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface %s -o %t
+
+export module Foo;
+
+export template <class Float>
+struct Wrapper {
+  double value;
+};
+
+export constexpr Wrapper<double> Compute() {
+  return Wrapper<double>{1.0};
+}
+
+export template <typename Float>
+Wrapper<Float> ComputeInFloat() {
+  const Wrapper<Float> a = Compute();
+  return a;
+}


### PR DESCRIPTION
EvaluateAsInitializer does not support evaluating values with dependent types. This was previously guarded with a check for the initializer expression, but it is possible for the VarDecl to have a dependent type without the initializer having a dependent type, when the initializer is a specialized template type and the VarDecl has the unspecialized type. This adds a guard checking for dependence in the VarDecl type as well. This fixes the issue raised by Google in https://github.com/llvm/llvm-project/pull/145447