### PR TITLE
Fix post-build check for #146121

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -3572,7 +3572,8 @@ void CodeViewDebug::collectDebugInfoForJumpTables(const MachineFunction *MF,
                             BaseOffset,
                             Branch,
                             MF->getJTISymbol(JumpTableIndex, MMI->getContext()),
-                            JTE.MBBs.size()};
+                            JTE.MBBs.size(),
+                            {}};
         for (const auto &MBB : JTE.MBBs)
           CVJTI.Cases.push_back(MBB->getSymbol());
         CurFn->JumpTables.push_back(std::move(CVJTI));


### PR DESCRIPTION
#146121 caused a build warning in a post-CI job.  The fix should be trivial; provide an extra initializer element when initializing a class, for the additional field.
