### PR TITLE
[Github][CI] Bump Github Runner Version in CI Container to v2.326.0

### DIFF
--- a/.github/workflows/containers/github-action-ci-windows/Dockerfile
+++ b/.github/workflows/containers/github-action-ci-windows/Dockerfile
@@ -85,7 +85,7 @@ RUN powershell -Command \
 RUN git config --system core.longpaths true & \
     git config --global core.autocrlf false
 
-ARG RUNNER_VERSION=2.325.0
+ARG RUNNER_VERSION=2.326.0
 ENV RUNNER_VERSION=$RUNNER_VERSION
 
 RUN powershell -Command \

--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -86,7 +86,7 @@ WORKDIR /home/gha
 
 FROM ci-container as ci-container-agent
 
-ENV GITHUB_RUNNER_VERSION=2.325.0
+ENV GITHUB_RUNNER_VERSION=2.326.0
 
 RUN mkdir actions-runner && \
     cd actions-runner && \


### PR DESCRIPTION
This is the latest runner version. Looks like it contains some minor fixes/dependency bumps.