### PR TITLE
[lldb] Replace PathMappingList::GetPathsAtIndex with thread-safe alternative

### DIFF
--- a/lldb/include/lldb/Target/PathMappingList.h
+++ b/lldb/include/lldb/Target/PathMappingList.h
@@ -63,8 +63,8 @@ public:
 
   /// Invokes callback for each pair of paths in the list. The callback can
   /// return false to immediately stop iteration.
-  void
-  ForEach(std::function<bool(llvm::StringRef, llvm::StringRef)> callback) const;
+  void ForEach(std::function<bool(size_t, llvm::StringRef, llvm::StringRef)>
+                   callback) const;
 
   void Insert(llvm::StringRef path, llvm::StringRef replacement,
               uint32_t insert_idx, bool notify);

--- a/lldb/include/lldb/Target/PathMappingList.h
+++ b/lldb/include/lldb/Target/PathMappingList.h
@@ -61,8 +61,10 @@ public:
     return m_pairs.size();
   }
 
-  bool GetPathsAtIndex(uint32_t idx, ConstString &path,
-                       ConstString &new_path) const;
+  /// Invokes callback for each pair of paths in the list. The callback can
+  /// return false to immediately stop iteration.
+  void
+  ForEach(std::function<bool(llvm::StringRef, llvm::StringRef)> callback) const;
 
   void Insert(llvm::StringRef path, llvm::StringRef replacement,
               uint32_t insert_idx, bool notify);

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1139,15 +1139,17 @@ public:
 
     Target *target = m_exe_ctx.GetTargetPtr();
     const PathMappingList &list = target->GetImageSearchPathList();
-    const size_t num = list.GetSize();
-    ConstString old_path, new_path;
-    for (size_t i = 0; i < num; ++i) {
-      if (!list.GetPathsAtIndex(i, old_path, new_path))
-        break;
-      StreamString strm;
-      strm << old_path << " -> " << new_path;
-      request.TryCompleteCurrentArg(std::to_string(i), strm.GetString());
-    }
+
+    StreamString strm;
+    size_t index = 0;
+    list.ForEach([&](llvm::StringRef orig_path, llvm::StringRef remap_path) {
+      strm << orig_path << " -> " << remap_path;
+      request.TryCompleteCurrentArg(std::to_string(index), strm.GetString());
+
+      index++;
+      strm.Clear();
+      return true;
+    });
   }
 
 protected:

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1141,14 +1141,12 @@ public:
     const PathMappingList &list = target->GetImageSearchPathList();
 
     StreamString strm;
-    list.ForEach([&](size_t index, llvm::StringRef orig_path,
-                     llvm::StringRef remap_path) {
-      strm << orig_path << " -> " << remap_path;
-      request.TryCompleteCurrentArg(std::to_string(index), strm.GetString());
-
+    size_t index = 0;
+    for (const auto &[original_path, remap_path] : list.PathMappings()) {
+      strm << original_path << " -> " << remap_path;
+      request.TryCompleteCurrentArg(std::to_string(index++), strm.GetString());
       strm.Clear();
-      return true;
-    });
+    }
   }
 
 protected:

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -1141,12 +1141,11 @@ public:
     const PathMappingList &list = target->GetImageSearchPathList();
 
     StreamString strm;
-    size_t index = 0;
-    list.ForEach([&](llvm::StringRef orig_path, llvm::StringRef remap_path) {
+    list.ForEach([&](size_t index, llvm::StringRef orig_path,
+                     llvm::StringRef remap_path) {
       strm << orig_path << " -> " << remap_path;
       request.TryCompleteCurrentArg(std::to_string(index), strm.GetString());
 
-      index++;
       strm.Clear();
       return true;
     });

--- a/lldb/source/Target/PathMappingList.cpp
+++ b/lldb/source/Target/PathMappingList.cpp
@@ -346,15 +346,12 @@ PathMappingList::FindIteratorForPath(ConstString path) {
   return pos;
 }
 
-bool PathMappingList::GetPathsAtIndex(uint32_t idx, ConstString &path,
-                                      ConstString &new_path) const {
+void PathMappingList::ForEach(
+    std::function<bool(llvm::StringRef, llvm::StringRef)> callback) const {
   std::lock_guard<std::mutex> lock(m_pairs_mutex);
-  if (idx < m_pairs.size()) {
-    path = m_pairs[idx].first;
-    new_path = m_pairs[idx].second;
-    return true;
-  }
-  return false;
+  for (const auto &[original, replacement] : m_pairs)
+    if (!callback(original, replacement))
+      break;
 }
 
 uint32_t

--- a/lldb/source/Target/PathMappingList.cpp
+++ b/lldb/source/Target/PathMappingList.cpp
@@ -347,10 +347,12 @@ PathMappingList::FindIteratorForPath(ConstString path) {
 }
 
 void PathMappingList::ForEach(
-    std::function<bool(llvm::StringRef, llvm::StringRef)> callback) const {
+    std::function<bool(size_t, llvm::StringRef, llvm::StringRef)> callback)
+    const {
   std::lock_guard<std::mutex> lock(m_pairs_mutex);
+  size_t index = 0;
   for (const auto &[original, replacement] : m_pairs)
-    if (!callback(original, replacement))
+    if (!callback(index++, original, replacement))
       break;
 }
 

--- a/lldb/source/Target/PathMappingList.cpp
+++ b/lldb/source/Target/PathMappingList.cpp
@@ -346,16 +346,6 @@ PathMappingList::FindIteratorForPath(ConstString path) {
   return pos;
 }
 
-void PathMappingList::ForEach(
-    std::function<bool(size_t, llvm::StringRef, llvm::StringRef)> callback)
-    const {
-  std::lock_guard<std::mutex> lock(m_pairs_mutex);
-  size_t index = 0;
-  for (const auto &[original, replacement] : m_pairs)
-    if (!callback(index++, original, replacement))
-      break;
-}
-
 uint32_t
 PathMappingList::FindIndexForPathNoLock(llvm::StringRef orig_path) const {
   const ConstString path = ConstString(NormalizePath(orig_path));


### PR DESCRIPTION
Iteration by index is not thread-safe with PathMapingList's design. Instead, we can expose a `ForEach` method that grabs the PathMappingList's lock before the callback.

There is a potential pitfall here where the callback tries to call another PathMappingList method (causing a deadlock), but that seems a little easier to debug than the PathMappingList getting updated in the middle of a loop somewhere.