### PR TITLE
[clang-tidy][NFC] concat static-analyzer name at compilation time

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -55,8 +55,9 @@ namespace clang::tidy {
 
 namespace {
 #if CLANG_TIDY_ENABLE_STATIC_ANALYZER
+#define ANALYZER_CHECK_NAME_PREFIX "clang-analyzer-"
 static constexpr llvm::StringLiteral AnalyzerCheckNamePrefix =
-    "clang-analyzer-";
+    ANALYZER_CHECK_NAME_PREFIX;
 
 class AnalyzerDiagnosticConsumer : public ento::PathDiagnosticConsumer {
 public:
@@ -674,7 +675,7 @@ getAllChecksAndOptions(bool AllowEnablingAnalyzerAlphaCheckers) {
 #define GET_CHECKER_OPTIONS
 #define CHECKER_OPTION(TYPE, CHECKER, OPTION_NAME, DESCRIPTION, DEFAULT,       \
                        RELEASE, HIDDEN)                                        \
-  "clang-analyzer-" CHECKER ":" OPTION_NAME,
+  ANALYZER_CHECK_NAME_PREFIX CHECKER ":" OPTION_NAME,
 
 #include "clang/StaticAnalyzer/Checkers/Checkers.inc"
 #undef CHECKER_OPTION

--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -669,18 +669,19 @@ getAllChecksAndOptions(bool AllowEnablingAnalyzerAlphaCheckers) {
     Buffer.append(AnalyzerCheck);
     Result.Checks.insert(Buffer);
   }
-  for (std::string OptionName : {
+
+  static constexpr llvm::StringLiteral OptionNames[] = {
 #define GET_CHECKER_OPTIONS
 #define CHECKER_OPTION(TYPE, CHECKER, OPTION_NAME, DESCRIPTION, DEFAULT,       \
                        RELEASE, HIDDEN)                                        \
-  Twine(AnalyzerCheckNamePrefix).concat(CHECKER ":" OPTION_NAME).str(),
+  "clang-analyzer-" CHECKER ":" OPTION_NAME,
 
 #include "clang/StaticAnalyzer/Checkers/Checkers.inc"
 #undef CHECKER_OPTION
 #undef GET_CHECKER_OPTIONS
-       }) {
-    Result.Options.insert(OptionName);
-  }
+  };
+
+  Result.Options.insert_range(OptionNames);
 #endif // CLANG_TIDY_ENABLE_STATIC_ANALYZER
 
   Context.setOptionsCollector(&Result.Options);


### PR DESCRIPTION
```cpp
  for (std::string OptionName : {
#define GET_CHECKER_OPTIONS
#define CHECKER_OPTION(TYPE, CHECKER, OPTION_NAME, DESCRIPTION, DEFAULT,       \
                       RELEASE, HIDDEN)                                        \
  Twine(AnalyzerCheckNamePrefix).concat(CHECKER ":" OPTION_NAME).str(),

#include "clang/StaticAnalyzer/Checkers/Checkers.inc"
#undef CHECKER_OPTION
#undef GET_CHECKER_OPTIONS
       }) {
    Result.Options.insert(OptionName);
  }
```
This code is doing a lot of unnecessary work at runtime. For each of the (currently) 59 checker options, it runs `Twine(AnalyzerCheckNamePrefix).concat(CHECKER ":" OPTION_NAME).str(),`, which allocates a string (all of this is unrolled, leading to code bloat). Then it copies all those strings (because `std::string OptionName`, not `const std::string& OptionName`). All of this can be done at compile time!