### PR TITLE
[CI][Github] Enable CIR CI build and test

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -259,10 +259,11 @@ def _get_modified_projects(modified_files: list[str]) -> Set[str]:
         if len(path_parts) > 3 and path_parts[:3] == ("llvm", "utils", "gn"):
             continue
         # If the file is in the clang/lib/CIR directory, add the CIR project.
-        if (len(path_parts) > 3 and
-               (path_parts[:3] == ("clang", "lib", "CIR") or
-                path_parts[:3] == ("clang", "test", "CIR") or
-                path_parts[:4] == ("clang", "include", "clang", "CIR"))):
+        if len(path_parts) > 3 and (
+            path_parts[:3] == ("clang", "lib", "CIR") or
+            path_parts[:3] == ("clang", "test", "CIR") or
+            path_parts[:4] == ("clang", "include", "clang", "CIR")
+        ):
             modified_projects.add("clang")
             modified_projects.add("CIR")
             continue
@@ -288,7 +289,9 @@ def get_env_variables(modified_files: list[str], platform: str) -> Set[str]:
     )
 
     # Check if both clang and mlir are in projects_to_build to enable CIR
-    enable_cir = "ON" if "clang" in projects_to_build and "mlir" in projects_to_build else "OFF"
+    enable_cir = (
+        "ON" if "clang" in projects_to_build and "mlir" in projects_to_build else "OFF"
+    )
 
     # We use a semicolon to separate the projects/runtimes as they get passed
     # to the CMake invocation and thus we need to use the CMake list separator

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -260,9 +260,9 @@ def _get_modified_projects(modified_files: list[str]) -> Set[str]:
             continue
         # If the file is in the clang/lib/CIR directory, add the CIR project.
         if len(path_parts) > 3 and (
-            path_parts[:3] == ("clang", "lib", "CIR") or
-            path_parts[:3] == ("clang", "test", "CIR") or
-            path_parts[:4] == ("clang", "include", "clang", "CIR")
+            path_parts[:3] == ("clang", "lib", "CIR")
+            or path_parts[:3] == ("clang", "test", "CIR")
+            or path_parts[:4] == ("clang", "include", "clang", "CIR")
         ):
             modified_projects.add("clang")
             modified_projects.add("CIR")

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -51,10 +51,7 @@ DEPENDENTS_TO_TEST = {
     "lld": {"bolt", "cross-project-tests"},
     # TODO(issues/132795): LLDB should be enabled on clang changes.
     "clang": {"clang-tools-extra", "cross-project-tests"},
-    "mlir": {
-        "CIR",
-        "flang",
-    },
+    "mlir": {"flang"},
     # Test everything if ci scripts are changed.
     ".ci": {
         "llvm",

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -195,8 +195,7 @@ def _compute_projects_to_test(modified_projects: Set[str], platform: str) -> Set
 def _compute_projects_to_build(
     projects_to_test: Set[str], runtimes: Set[str]
 ) -> Set[str]:
-    projects_with_deps = _add_dependencies(projects_to_test, runtimes)
-    return projects_with_deps
+    return _add_dependencies(projects_to_test, runtimes)
 
 
 def _compute_project_check_targets(projects_to_test: Set[str]) -> Set[str]:

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -183,7 +183,8 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;mlir")
         self.assertEqual(
-            env_variables["project_check_targets"], "check-clang-cir check-flang check-mlir"
+            env_variables["project_check_targets"],
+            "check-clang-cir check-flang check-mlir"
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -184,7 +184,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;mlir")
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang-cir check-flang check-mlir",
+            "check-flang check-mlir",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -104,6 +104,10 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(
+            env_variables["enable_cir"],
+            "OFF",
+        )
 
     def test_clang_windows(self):
         env_variables = compute_projects.get_env_variables(
@@ -126,6 +130,32 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["runtimes_check_targets_needs_reconfig"],
             "check-cxx check-cxxabi check-unwind",
         )
+        self.assertEqual(env_variables["enable_cir"], "OFF")
+
+    def test_cir(self):
+        env_variables = compute_projects.get_env_variables(
+            ["clang/lib/CIR/CMakeLists.txt"], "Linux"
+        )
+        self.assertEqual(
+            env_variables["projects_to_build"],
+            "clang;clang-tools-extra;lld;llvm;mlir",
+        )
+        self.assertEqual(
+            env_variables["project_check_targets"],
+            "check-clang check-clang-cir check-clang-tools",
+        )
+        self.assertEqual(
+            env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets"],
+            "check-compiler-rt",
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets_needs_reconfig"],
+            "check-cxx check-cxxabi check-unwind",
+        )
+        self.assertEqual(env_variables["enable_cir"], "ON")
 
     def test_bolt(self):
         env_variables = compute_projects.get_env_variables(
@@ -153,11 +183,12 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;mlir")
         self.assertEqual(
-            env_variables["project_check_targets"], "check-flang check-mlir"
+            env_variables["project_check_targets"], "check-clang-cir check-flang check-mlir"
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_cir"], "ON")
 
     def test_flang(self):
         env_variables = compute_projects.get_env_variables(
@@ -168,6 +199,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
+        self.assertEqual(env_variables["enable_cir"], "OFF")
 
     def test_invalid_subproject(self):
         env_variables = compute_projects.get_env_variables(
@@ -237,7 +269,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-bolt check-clang check-clang-tools check-flang check-lld check-lldb check-llvm check-mlir check-polly",
+            "check-bolt check-clang check-clang-cir check-clang-tools check-flang check-lld check-lldb check-llvm check-mlir check-polly",
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -184,7 +184,7 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;mlir")
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang-cir check-flang check-mlir"
+            "check-clang-cir check-flang check-mlir",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -183,7 +183,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;mlir")
         self.assertEqual(
-            env_variables["project_check_targets"], "check-flang check-mlir",
+            env_variables["project_check_targets"], "check-flang check-mlir"
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -183,13 +183,12 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(env_variables["projects_to_build"], "clang;flang;llvm;mlir")
         self.assertEqual(
-            env_variables["project_check_targets"],
-            "check-flang check-mlir",
+            env_variables["project_check_targets"], "check-flang check-mlir",
         )
         self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(env_variables["runtimes_check_targets"], "")
         self.assertEqual(env_variables["runtimes_check_targets_needs_reconfig"], "")
-        self.assertEqual(env_variables["enable_cir"], "ON")
+        self.assertEqual(env_variables["enable_cir"], "OFF")
 
     def test_flang(self):
         env_variables = compute_projects.get_env_variables(

--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -53,6 +53,7 @@ targets="${2}"
 runtimes="${3}"
 runtime_targets="${4}"
 runtime_targets_needs_reconfig="${5}"
+enable_cir="${6}"
 
 lit_args="-v --xunit-xml-output ${BUILD_DIR}/test-results.xml --use-unique-output-file-name --timeout=1200 --time-tests"
 
@@ -72,6 +73,7 @@ cmake -S "${MONOREPO_ROOT}"/llvm -B "${BUILD_DIR}" \
       -G Ninja \
       -D CMAKE_PREFIX_PATH="${HOME}/.local" \
       -D CMAKE_BUILD_TYPE=Release \
+      -D CLANG_ENABLE_CIR=${enable_cir} \
       -D LLVM_ENABLE_ASSERTIONS=ON \
       -D LLVM_BUILD_EXAMPLES=ON \
       -D COMPILER_RT_BUILD_LIBFUZZER=OFF \

--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -61,7 +61,7 @@ jobs:
           export CC=/opt/llvm/bin/clang
           export CXX=/opt/llvm/bin/clang++
 
-          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}"
+          ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}" "${enable_cir}"
       - name: Upload Artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:


### PR DESCRIPTION
This change modifies CI scripts to add a pseudo-project for CIR and detect when CIR-specific files are modified. It also enables building clang with CIR enabled whenever both the clang and mlir projects are being built.

Building and testing CIR is only enabled on Linux at this time, as CIR doesn't properly support Windows or MacOS yet.