### PR TITLE
[DirectX] Lower `llvm.lifetime.*` intrinsics to stores when DXIL version is lower than 1.6

### DIFF
--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -934,8 +934,8 @@ public:
         getAnalysis<DXILResourceWrapperPass>().getResourceMap();
     DXILResourceTypeMap &DRTM =
         getAnalysis<DXILResourceTypeWrapperPass>().getResourceTypeMap();
-  const ModuleMetadataInfo MMDI =
-      getAnalysis<DXILMetadataAnalysisWrapperPass>().getModuleMetadata();
+    const ModuleMetadataInfo MMDI =
+        getAnalysis<DXILMetadataAnalysisWrapperPass>().getModuleMetadata();
 
     return OpLowerer(M, DRM, DRTM, MMDI).lowerIntrinsics();
   }

--- a/llvm/lib/Target/DirectX/DXILOpLowering.cpp
+++ b/llvm/lib/Target/DirectX/DXILOpLowering.cpp
@@ -911,7 +911,7 @@ PreservedAnalyses DXILOpLowering::run(Module &M, ModuleAnalysisManager &MAM) {
   DXILResourceTypeMap &DRTM = MAM.getResult<DXILResourceTypeAnalysis>(M);
   const ModuleMetadataInfo MMDI = MAM.getResult<DXILMetadataAnalysis>(M);
 
-  bool MadeChanges = OpLowerer(M, DRM, DRTM, MMDI).lowerIntrinsics();
+  const bool MadeChanges = OpLowerer(M, DRM, DRTM, MMDI).lowerIntrinsics();
   if (!MadeChanges)
     return PreservedAnalyses::all();
   PreservedAnalyses PA;

--- a/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.5.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.5.ll
@@ -17,5 +17,6 @@ define void @test_legal_lifetime()  {
   ret void
 }
 
+; Set the validator version to 1.5
 !dx.valver = !{!0}
 !0 = !{i32 1, i32 5}

--- a/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.5.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.5.ll
@@ -3,9 +3,9 @@
 ; CHECK-LABEL: define void @test_legal_lifetime() {
 ; CHECK-NEXT:    [[ACCUM_I_FLAT:%.*]] = alloca [1 x i32], align 4
 ; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr [[ACCUM_I_FLAT]], i32 0
-; CHECK-NEXT:    call void @llvm.lifetime.start.p0(i64 4, ptr nonnull [[ACCUM_I_FLAT]])
+; CHECK-NEXT:    store [1 x i32] zeroinitializer, ptr [[ACCUM_I_FLAT]], align 4
 ; CHECK-NEXT:    store i32 0, ptr [[GEP]], align 4
-; CHECK-NEXT:    call void @llvm.lifetime.end.p0(i64 4, ptr nonnull [[ACCUM_I_FLAT]])
+; CHECK-NEXT:    store [1 x i32] zeroinitializer, ptr [[ACCUM_I_FLAT]], align 4
 ; CHECK-NEXT:    ret void
 ;
 define void @test_legal_lifetime()  {
@@ -16,3 +16,6 @@ define void @test_legal_lifetime()  {
   call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %accum.i.flat)
   ret void
 }
+
+!dx.valver = !{!0}
+!0 = !{i32 1, i32 5}

--- a/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.6.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.6.ll
@@ -26,5 +26,6 @@ define void @test_legal_lifetime()  {
   ret void
 }
 
+; Set the validator version to 1.6
 !dx.valver = !{!0}
 !0 = !{i32 1, i32 6}

--- a/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.6.ll
+++ b/llvm/test/CodeGen/DirectX/legalize-lifetimes-valver-1.6.ll
@@ -1,0 +1,30 @@
+; RUN: opt -S -passes='dxil-op-lower' -mtriple=dxil-pc-shadermodel6.3-library %s | FileCheck %s --check-prefixes=CHECK,CHECK-SM63
+; RUN: opt -S -passes='dxil-op-lower' -mtriple=dxil-pc-shadermodel6.6-library %s | FileCheck %s --check-prefixes=CHECK,CHECK-SM66
+
+; CHECK-LABEL: define void @test_legal_lifetime() {
+; 
+; CHECK-SM63-NEXT:    [[ACCUM_I_FLAT:%.*]] = alloca [1 x i32], align 4
+; CHECK-SM63-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr [[ACCUM_I_FLAT]], i32 0
+; CHECK-SM63-NEXT:    store [1 x i32] undef, ptr [[ACCUM_I_FLAT]], align 4
+; CHECK-SM63-NEXT:    store i32 0, ptr [[GEP]], align 4
+; CHECK-SM63-NEXT:    store [1 x i32] undef, ptr [[ACCUM_I_FLAT]], align 4
+; 
+; CHECK-SM66-NEXT:    [[ACCUM_I_FLAT:%.*]] = alloca [1 x i32], align 4
+; CHECK-SM66-NEXT:    [[GEP:%.*]] = getelementptr i32, ptr [[ACCUM_I_FLAT]], i32 0
+; CHECK-SM66-NEXT:    call void @llvm.lifetime.start.p0(i64 4, ptr nonnull [[ACCUM_I_FLAT]])
+; CHECK-SM66-NEXT:    store i32 0, ptr [[GEP]], align 4
+; CHECK-SM66-NEXT:    call void @llvm.lifetime.end.p0(i64 4, ptr nonnull [[ACCUM_I_FLAT]])
+; 
+; CHECK-NEXT:    ret void
+;
+define void @test_legal_lifetime()  {
+  %accum.i.flat = alloca [1 x i32], align 4
+  %gep = getelementptr i32, ptr %accum.i.flat, i32 0
+  call void @llvm.lifetime.start.p0(i64 4, ptr nonnull %accum.i.flat)
+  store i32 0, ptr %gep, align 4
+  call void @llvm.lifetime.end.p0(i64 4, ptr nonnull %accum.i.flat)
+  ret void
+}
+
+!dx.valver = !{!0}
+!0 = !{i32 1, i32 6}


### PR DESCRIPTION
Fixes #147394

References DXC for the implementation logic:
https://github.com/microsoft/DirectXShaderCompiler/blob/d751c827ed3b61e87fdf57d0f424cb2d7af30cd0/lib/HLSL/DxilPreparePasses.cpp#L693-L699

If DXIL Version < 1.6 then replace lifetime intrinsics with stores

- For validator version >= 1.6, store an undef
- For validator version < 1.6, store zeros

else keep the lifetime intrinsics in the DXIL.

After this PR, the number of DML shaders failing validation due to #146974 is reduced from 157 to 50.