### PR TITLE
[NFC] Remove redundant namespace qualifier in SelectionDAGPatternMatchTest

### DIFF
--- a/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
+++ b/llvm/unittests/CodeGen/SelectionDAGPatternMatchTest.cpp
@@ -834,7 +834,7 @@ TEST_F(SelectionDAGPatternMatchTest, MatchZeroOneAllOnes) {
 
   // Scalar constant 0
   SDValue Zero = DAG->getConstant(0, DL, VT);
-  EXPECT_TRUE(sd_match(Zero, DAG.get(), llvm::SDPatternMatch::m_Zero()));
+  EXPECT_TRUE(sd_match(Zero, DAG.get(), m_Zero()));
   EXPECT_FALSE(sd_match(Zero, DAG.get(), m_One()));
   EXPECT_FALSE(sd_match(Zero, DAG.get(), m_AllOnes()));
 


### PR DESCRIPTION
### Summary
This PR remove the extra llvm::SDPatternMatch prefix in https://github.com/llvm/llvm-project/pull/147044


