### PR TITLE
[clang][Sema] Two-pass noreturn inference via CFG for always-throwing functions

### DIFF
--- a/clang/include/clang/Sema/AnalysisBasedWarnings.h
+++ b/clang/include/clang/Sema/AnalysisBasedWarnings.h
@@ -14,6 +14,7 @@
 #define LLVM_CLANG_SEMA_ANALYSISBASEDWARNINGS_H
 
 #include "clang/AST/Decl.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
 #include "llvm/ADT/DenseMap.h"
 #include <memory>
 
@@ -107,6 +108,8 @@ public:
   // Issue warnings that require whole-translation-unit analysis.
   void IssueWarnings(TranslationUnitDecl *D);
 
+  void InferNoReturnAttributes(Sema &S, TranslationUnitDecl *TU);
+
   // Gets the default policy which is in effect at the given source location.
   Policy getPolicyInEffectAt(SourceLocation Loc);
 
@@ -119,6 +122,17 @@ public:
 };
 
 } // namespace sema
+
+enum ControlFlowKind {
+  UnknownFallThrough,
+  NeverFallThrough,
+  MaybeFallThrough,
+  AlwaysFallThrough,
+  NeverFallThroughOrReturn
+};
+
+ControlFlowKind CheckFallThrough(AnalysisDeclContext &AC);
+
 } // namespace clang
 
 #endif

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -834,7 +834,7 @@ enum class CCEKind {
                            ///< message.
 };
 
-void inferNoReturnAttr(Sema &S, const Decl *D);
+bool inferNoReturnAttr(Sema &S, const Decl *D, bool FirstPass);
 
 /// Sema - This implements semantic analysis and AST building for C.
 /// \nosubgrouping

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -3587,7 +3587,7 @@ bool FunctionDecl::isGlobal() const {
 
 bool FunctionDecl::isNoReturn() const {
   if (hasAttr<NoReturnAttr>() || hasAttr<CXX11NoReturnAttr>() ||
-      hasAttr<C11NoReturnAttr>())
+      hasAttr<C11NoReturnAttr>() || hasAttr<InferredNoReturnAttr>())
     return true;
 
   if (auto *FnTy = getType()->getAs<FunctionType>())

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2453,7 +2453,8 @@ Sema::PopFunctionScopeInfo(const AnalysisBasedWarnings::Policy *WP,
 
   // Issue any analysis-based warnings.
   if (WP && D) {
-    inferNoReturnAttr(*this, D);
+    AnalysisWarnings.InferNoReturnAttributes(
+        *this, getASTContext().getTranslationUnitDecl());
     AnalysisWarnings.IssueWarnings(*WP, Scope.get(), D, BlockType);
   } else
     for (const auto &PUD : Scope->PossiblyUnreachableDiags)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1971,15 +1971,8 @@ static bool isKnownToAlwaysThrowCFG(const FunctionDecl *FD, Sema &S) {
   FunctionDecl *NonConstFD = const_cast<FunctionDecl *>(FD);
   AnalysisDeclContext AC(nullptr, NonConstFD);
 
-  switch (CheckFallThrough(AC)) {
-  case NeverFallThrough:
-  case NeverFallThroughOrReturn:
-    return true;
-  case AlwaysFallThrough:
-  case UnknownFallThrough:
-  case MaybeFallThrough:
-    return false;
-  }
+  auto FT = CheckFallThrough(AC);
+  return FT == NeverFallThroughOrReturn;
 }
 
 bool clang::inferNoReturnAttr(Sema &S, const Decl *D, bool FirstPass) {

--- a/clang/test/SemaCXX/wreturn-always-throws-control-flow.cpp
+++ b/clang/test/SemaCXX/wreturn-always-throws-control-flow.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -fsyntax-only -fcxx-exceptions -fexceptions -Wreturn-type -verify %s
+// expected-no-diagnostics
+
+namespace std {
+  class string {
+  public:
+    string(const char*); // constructor for runtime_error
+  };
+  class runtime_error {
+  public:
+    runtime_error(const string &); 
+  };
+}
+
+void throwA() {
+  throw std::runtime_error("ERROR A");
+}
+
+void throwB(int n) {
+    if (n)
+        throw std::runtime_error("ERROR B");
+    else
+        throw std::runtime_error("ERROR B with n=0");
+}
+
+int test(int x) {
+    if (x > 0) 
+        throwA(); 
+    else 
+        throwB(x); 
+}


### PR DESCRIPTION
This patch adds a new AnalysisBasedWarnings pass that runs right before
IssueWarnings:

1. Pass 1 seeds trivial always-throwing functions.
2. Pass 2 performs a fixed-point CFG-based analysis (CheckFallThrough) to propagate noreturn inference to any caller whose all paths end in calls to already-inferred noreturn functions.

To support templates, we also walk each FunctionTemplateDecl’s specializations so that instantiations (e.g. ensureZeroTemplate<int>) get analyzed.