### PR TITLE
[TableGen] Remove an unnecessary cast (NFC)

### DIFF
--- a/llvm/utils/TableGen/X86DisassemblerTables.cpp
+++ b/llvm/utils/TableGen/X86DisassemblerTables.cpp
@@ -603,8 +603,7 @@ static inline bool inheritsFrom(InstructionContext child,
   case IC_EVEX_W_OPSIZE_KZ_B_U:
     return false;
   default:
-    errs() << "Unknown instruction class: "
-           << stringForContext((InstructionContext)parent) << "\n";
+    errs() << "Unknown instruction class: " << stringForContext(parent) << "\n";
     llvm_unreachable("Unknown instruction class");
   }
 }


### PR DESCRIPTION
parent is already of InstructionContext.
