### PR TITLE
RuntimeLibcalls: Fix dropping first libcall entry

### DIFF
--- a/lld/test/wasm/lto/Inputs/libcall-archive.ll
+++ b/lld/test/wasm/lto/Inputs/libcall-archive.ll
@@ -5,4 +5,12 @@ define void @memcpy() #0 {
   ret void
 }
 
+define float @acosf(float %x) {
+  ret float %x
+}
+
+define i128 @__umodti3(i128 %a, i128 %b) {
+  ret i128 %a
+}
+
 attributes #0 = { "target-features"="-bulk-memory,-bulk-memory-opt" }

--- a/lld/test/wasm/lto/libcall-archive.ll
+++ b/lld/test/wasm/lto/libcall-archive.ll
@@ -8,10 +8,26 @@
 target datalayout = "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-n32:64-S128-ni:1:10:20"
 target triple = "wasm32-unknown-unknown"
 
+@llvm.used = appending global [2 x ptr] [ptr @test_acosf, ptr @test___umodti3]
+
 define void @_start(ptr %a, ptr %b) #0 {
 entry:
   call void @llvm.memcpy.p0.p0.i64(ptr %a, ptr %b, i64 1024, i1 false)
   ret void
+}
+
+; Emit acosf, which currently happens to be the first runtime libcall
+; entry.
+define float @test_acosf(float %x) {
+  %acos = call float @llvm.acos.f32(float %x)
+  ret float %acos
+}
+
+; Emit __umodti3, which currently happens to be the last runtime
+; libcall entry.
+define i128 @test___umodti3(i128 %a, i128 %b) {
+  %urem = urem i128 %a, %b
+  ret i128 %urem
 }
 
 declare void @llvm.memcpy.p0.p0.i64(ptr nocapture, ptr nocapture, i64, i1)
@@ -22,6 +38,12 @@ attributes #0 = { "target-features"="-bulk-memory,-bulk-memory-opt" }
 ; CHECK-NEXT:    Name:            name
 ; CHECK-NEXT:    FunctionNames:
 ; CHECK-NEXT:      - Index:           0
-; CHECK-NEXT:        Name:            _start
+; CHECK-NEXT:        Name:            test_acosf
 ; CHECK-NEXT:      - Index:           1
-; CHECK-NEXT:        Name:            memcpy
+; CHECK-NEXT:        Name:            acosf
+; CHECK-NEXT:      - Index:           2
+; CHECK-NEXT:        Name:            test___umodti3
+; CHECK-NEXT:      - Index:           3
+; CHECK-NEXT:        Name:            __umodti3
+; CHECK-NEXT:      - Index:           4
+; CHECK-NEXT:        Name:            _start

--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -110,8 +110,8 @@ struct RuntimeLibcallsInfo {
   }
 
   ArrayRef<RTLIB::LibcallImpl> getLibcallImpls() const {
-    // Trim Unsupported from the start
-    return ArrayRef(LibcallImpls).drop_front();
+    // Trim UNKNOWN_LIBCALL from the back
+    return ArrayRef(LibcallImpls).drop_back();
   }
 
   /// Get the comparison predicate that's to be used to test the result of the


### PR DESCRIPTION
Fixes regression reported after #144973, which happened to
be acosf.