### PR TITLE
[Clang] Fix template arguments collection for out-of-line declarations

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -857,6 +857,7 @@ Bug Fixes to C++ Support
 - Clang now correctly parses arbitrary order of ``[[]]``, ``__attribute__`` and ``alignas`` attributes for declarations (#GH133107)
 - Fixed a crash when forming an invalid function type in a dependent context. (#GH138657) (#GH115725) (#GH68852)
 - Fixed a function declaration mismatch that caused inconsistencies between concepts and variable template declarations. (#GH139476)
+- Fixed an out-of-line declaration mismatch involving nested template parameters. (#GH145521)
 - Clang no longer segfaults when there is a configuration mismatch between modules and their users (http://crbug.com/400353616).
 - Fix an incorrect deduction when calling an explicit object member function template through an overload set address.
 - Fixed bug in constant evaluation that would allow using the value of a

--- a/clang/lib/Sema/SemaConcept.cpp
+++ b/clang/lib/Sema/SemaConcept.cpp
@@ -898,7 +898,7 @@ static const Expr *SubstituteConstraintExpressionWithoutSatisfaction(
     Sema &S, const Sema::TemplateCompareNewDeclInfo &DeclInfo,
     const Expr *ConstrExpr) {
   MultiLevelTemplateArgumentList MLTAL = S.getTemplateInstantiationArgs(
-      DeclInfo.getDecl(), DeclInfo.getLexicalDeclContext(), /*Final=*/false,
+      DeclInfo.getDecl(), DeclInfo.getDeclContext(), /*Final=*/false,
       /*Innermost=*/std::nullopt,
       /*RelativeToPrimary=*/true,
       /*Pattern=*/nullptr, /*ForConstraintInstantiation=*/true,

--- a/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
+++ b/clang/test/SemaTemplate/concepts-out-of-line-def.cpp
@@ -868,3 +868,28 @@ template <typename T> requires moo::baa<T>
 void moo::caw() {}
 
 }
+
+namespace GH145521 {
+
+template <typename X>
+concept is_valid = true;
+
+template<typename T>
+class Nesting
+{
+public:
+    template<typename Q> requires is_valid<Q>
+    class Inner;
+
+    template<typename Q> requires is_valid<Q>
+    friend class Inner2;
+};
+
+template<typename T>
+template<typename Q> requires is_valid<Q>
+class Nesting<T>::Inner {};
+
+template<typename Q> requires is_valid<Q>
+class Inner2 {};
+
+}


### PR DESCRIPTION
We were using the lexical DC as the starting point of template argument collection when comparing declarations. This caused an issue that template arguments from out-of-line declarations are ignored when substituting into the constraints, which in turn led to expression mismatching.

Fixes https://github.com/llvm/llvm-project/issues/145521
