### PR TITLE
[PS5][Driver] Fix bad negative check in ps5-linker.c test case

### DIFF
--- a/clang/test/Driver/ps5-linker.c
+++ b/clang/test/Driver/ps5-linker.c
@@ -165,7 +165,7 @@
 // CHECK-SHARED-CRT-SAME: "-l:crtendS.o" "-l:crtn.o"
 // CHECK-STATIC-CRT-SAME: "-l:crtend.o" "-l:crtn.o"
 
-// CHECK-NO-CRT-NOT: crt{{[^"]*}}.o"
+// CHECK-NO-CRT-NOT: "-l:crt
 // CHECK-NO-LIBS-NOT: "-l{{[^"]*}}"
 
 // Test the driver's control over the -fcrash-diagnostics-dir behavior with linker flags.


### PR DESCRIPTION
A regex used in a negative check had an unintended match with the pseudo-random part of the temporary directory created by a lit run on the SIE buildbot, causing a spurious test failure:

https://lab.llvm.org/buildbot/#/builders/144/builds/29507

    // CHECK-NO-CRT-NOT: crt{{[^"]*}}.o"
                         ^
    <stdin>:7:224: note: found here
    [...] "/tmp/lit-tmp-vcrtn3vi/ps5-linker-ee5f76.o" "-r"
                         !~~~~~~~~~~~~~~~~~~~~~~~~~~

The updated check avoids such accidental matches.