### PR TITLE
[Triple][M68k] Add missing handling for target m68k in getDefaultExceptionHandling.

### DIFF
--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -2288,6 +2288,7 @@ ExceptionHandling Triple::getDefaultExceptionHandling() const {
   case Triple::csky:
   case Triple::hexagon:
   case Triple::lanai:
+  case Triple::m68k:
   case Triple::msp430:
   case Triple::systemz:
   case Triple::xcore:

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -2833,6 +2833,8 @@ TEST(TripleTest, DefaultExceptionHandling) {
   EXPECT_EQ(ExceptionHandling::DwarfCFI,
             Triple("msp430-unknown-unknown").getDefaultExceptionHandling());
   EXPECT_EQ(ExceptionHandling::DwarfCFI,
+            Triple("m68k-unknown-unknown").getDefaultExceptionHandling());
+  EXPECT_EQ(ExceptionHandling::DwarfCFI,
             Triple("csky-unknown-unknown").getDefaultExceptionHandling());
 
   EXPECT_EQ(ExceptionHandling::AIX,


### PR DESCRIPTION
I encountered the assertion failure `Assertion TmpAsmInfo->getExceptionHandlingType() == getTargetTriple().getDefaultExceptionHandling() && "MCAsmInfo and Triple disagree on default exception handling type"' failed`.