### PR TITLE
[lit][docs] Mention LIT_OPTS instead of LIT_ARGS

### DIFF
--- a/llvm/docs/TestingGuide.rst
+++ b/llvm/docs/TestingGuide.rst
@@ -152,12 +152,12 @@ can run the LLVM and Clang tests simultaneously using:
 
     % make check-all
 
-To run the tests with Valgrind (Memcheck by default), use the ``LIT_ARGS`` make
+To run the tests with Valgrind (Memcheck by default), use the ``LIT_OPTS`` make
 variable to pass the required options to lit. For example, you can use:
 
 .. code-block:: bash
 
-    % make check LIT_ARGS="-v --vg --vg-leak"
+    % make check LIT_OPTS="-v --vg --vg-leak"
 
 to enable testing with valgrind and with leak checking enabled.
 


### PR DESCRIPTION
Noticed that the current [docs](https://llvm.org/docs/TestingGuide.html#unit-and-regression-tests) recommend using LIT_ARGS (config option in cmake script), rather than LIT_OPTS (environment variable interpreted by lit directly). While LIT_ARGS doesn't do anything at all when set with make, at least not in a way outlined in the docs.

Additionally documented a way to skip dependency checks when invoking lit tests using make (for faster evaluation).