### PR TITLE
Add an llvm::cl::opt::operator=(T &&Val)

### DIFF
--- a/llvm/include/llvm/Support/CommandLine.h
+++ b/llvm/include/llvm/Support/CommandLine.h
@@ -1496,6 +1496,12 @@ public:
     return this->getValue();
   }
 
+  template <class T> DataType &operator=(T &&Val) {
+    this->getValue() = std::forward<T>(Val);
+    Callback(this->getValue());
+    return this->getValue();
+  }
+
   template <class... Mods>
   explicit opt(const Mods &... Ms)
       : Option(llvm::cl::Optional, NotHidden), Parser(*this) {


### PR DESCRIPTION
Add an llvm::cl::opt::operator= that takes an rvalue reference of value, to avoid an unecessary copy for types with memory allocation (string, vector, etc).