### PR TITLE
[clang-tidy] support ak_attr_info in diagnostic forwarding

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -544,6 +544,9 @@ void ClangTidyDiagnosticConsumer::forwardDiagnostic(const Diagnostic &Info) {
     case clang::DiagnosticsEngine::ak_attr:
       Builder << reinterpret_cast<Attr *>(Info.getRawArg(Index));
       break;
+    case clang::DiagnosticsEngine::ak_attr_info:
+      Builder << reinterpret_cast<AttributeCommonInfo *>(Info.getRawArg(Index));
+      break;
     case clang::DiagnosticsEngine::ak_addrspace:
       Builder << static_cast<LangAS>(Info.getRawArg(Index));
       break;


### PR DESCRIPTION
This patch addresses missing support for forwarding `ak_attr_info` diagnostic arguments in `ClangTidyDiagnosticConsumer`