### PR TITLE
[flang] Avoid undefined behaviour in Interval::Contains

### DIFF
--- a/flang/include/flang/Common/interval.h
+++ b/flang/include/flang/Common/interval.h
@@ -60,7 +60,8 @@ public:
     return start_ <= x && x < start_ + size_;
   }
   constexpr bool Contains(const Interval &that) const {
-    return Contains(that.start_) && Contains(that.start_ + (that.size_ - 1));
+    return Contains(that.start_) &&
+        ((that.size_ == 0) || Contains(that.start_ + (that.size_ - 1)));
   }
   constexpr bool IsDisjointWith(const Interval &that) const {
     return that.NextAfter() <= start_ || NextAfter() <= that.start_;


### PR DESCRIPTION
If the size of the other Interval was 0, (that.size_ - 1) would wrap below zero.

I've fixed this so that a zero size interval A is within interval B if the start of A is within B. There's a few ways you could handle zero sized intervals in theory but this one passes all tests so I assume it's the intention.

This fixes the following tests when ubsan is enabled:
  Flang :: Lower/OpenMP/PFT/sections-pft.f90
  Flang :: Lower/OpenMP/derived-type-allocatable.f90
  Flang :: Lower/OpenMP/privatization-proc-ptr.f90
  Flang :: Lower/OpenMP/sections.f90
  Flang :: Parser/OpenMP/sections.f90
  Flang :: Semantics/OpenMP/clause-validity01.f90
  Flang :: Semantics/OpenMP/if-clause.f90
  Flang :: Semantics/OpenMP/parallel-sections01.f90
  Flang :: Semantics/OpenMP/private-assoc.f90