### PR TITLE
[RISCV] Correct immediate operand type in QC_MVLTUI ISel pattern

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -1308,9 +1308,9 @@ class QCIMVCCPat<CondCode Cond, QCIMVCC Inst>
     : Pat<(select (XLenVT (setcc (XLenVT GPRNoX0:$rs1), (XLenVT GPRNoX0:$rs2), Cond)), (XLenVT GPRNoX0:$rs3), (XLenVT GPRNoX0:$rd)),
           (Inst GPRNoX0:$rd, GPRNoX0:$rs1, GPRNoX0:$rs2, GPRNoX0:$rs3)>;
 
-class QCIMVCCIPat<CondCode Cond, QCIMVCCI Inst>
-    : Pat<(select (XLenVT (setcc (XLenVT GPRNoX0:$rs1), simm5:$imm, Cond)), (XLenVT GPRNoX0:$rs3), (XLenVT GPRNoX0:$rd)),
-          (Inst GPRNoX0:$rd, GPRNoX0:$rs1, simm5:$imm, GPRNoX0:$rs3)>;
+class QCIMVCCIPat<CondCode Cond, QCIMVCCI Inst, DAGOperand InTyImm>
+    : Pat<(select (XLenVT (setcc (XLenVT GPRNoX0:$rs1), InTyImm:$imm, Cond)), (XLenVT GPRNoX0:$rs3), (XLenVT GPRNoX0:$rd)),
+          (Inst GPRNoX0:$rd, GPRNoX0:$rs1, InTyImm:$imm, GPRNoX0:$rs3)>;
 
 // Match `riscv_brcc` and lower to the appropriate XQCIBI branch instruction.
 class BcciPat<CondCode Cond, QCIBranchInst_rii Inst, DAGOperand InTyImm>
@@ -1455,10 +1455,10 @@ def : QCIMVCCPat <SETNE,  QC_MVNE>;
 def : QCIMVCCPat <SETLT,  QC_MVLT>;
 def : QCIMVCCPat <SETULT, QC_MVLTU>;
 
-def : QCIMVCCIPat <SETEQ,  QC_MVEQI>;
-def : QCIMVCCIPat <SETNE,  QC_MVNEI>;
-def : QCIMVCCIPat <SETLT,  QC_MVLTI>;
-def : QCIMVCCIPat <SETULT, QC_MVLTUI>;
+def : QCIMVCCIPat <SETEQ,  QC_MVEQI, simm5>;
+def : QCIMVCCIPat <SETNE,  QC_MVNEI, simm5>;
+def : QCIMVCCIPat <SETLT,  QC_MVLTI, simm5>;
+def : QCIMVCCIPat <SETULT, QC_MVLTUI, uimm5>;
 }
 
 //===----------------------------------------------------------------------===/i

--- a/llvm/test/CodeGen/RISCV/xqcicm.ll
+++ b/llvm/test/CodeGen/RISCV/xqcicm.ll
@@ -677,3 +677,26 @@ entry:
   %sel = select i1 %cmp, i32 %x, i32 %y
   ret i32 %sel
 }
+
+define i32 @select_cc_example_ule_neg(i32 %a, i32 %b, i32 %x, i32 %y) {
+; RV32I-LABEL: select_cc_example_ule_neg:
+; RV32I:       # %bb.0: # %entry
+; RV32I-NEXT:    li a1, -10
+; RV32I-NEXT:    bltu a0, a1, .LBB31_2
+; RV32I-NEXT:  # %bb.1: # %entry
+; RV32I-NEXT:    mv a2, a3
+; RV32I-NEXT:  .LBB31_2: # %entry
+; RV32I-NEXT:    mv a0, a2
+; RV32I-NEXT:    ret
+;
+; RV32IXQCICM-LABEL: select_cc_example_ule_neg:
+; RV32IXQCICM:       # %bb.0: # %entry
+; RV32IXQCICM-NEXT:    li a1, -10
+; RV32IXQCICM-NEXT:    qc.mvltu a3, a0, a1, a2
+; RV32IXQCICM-NEXT:    mv a0, a3
+; RV32IXQCICM-NEXT:    ret
+entry:
+  %cmp = icmp ule i32 %a, -11
+  %sel = select i1 %cmp, i32 %x, i32 %y
+  ret i32 %sel
+}


### PR DESCRIPTION
The pattern was incorrectly using simm5 for QC_MVLTUI when it should have been uimm5.