### PR TITLE
[support] Make ScopedPrinter compatible with bitmask enums

### DIFF
--- a/llvm/unittests/Support/ScopedPrinterTest.cpp
+++ b/llvm/unittests/Support/ScopedPrinterTest.cpp
@@ -8,10 +8,20 @@
 
 #include "llvm/Support/ScopedPrinter.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/Support/Format.h"
 #include "gtest/gtest.h"
 #include <cmath>
 #include <vector>
+
+namespace {
+enum class BitmaskEnum : uint8_t {
+  F1 = 0x1,
+  F2 = 0x2,
+  LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/F2),
+};
+LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
+} // namespace
 
 using namespace llvm;
 
@@ -261,6 +271,12 @@ TEST_F(ScopedPrinterTest, PrintFlag) {
         {"SecondByte2", "Second2", 0x20u}, {"SecondByte3", "Second3", 0x30u},
         {"ThirdByte1", "Third1", 0x100u},  {"ThirdByte2", "Third2", 0x200u},
         {"ThirdByte3", "Third3", 0x300u}};
+
+    const EnumEntry<BitmaskEnum> ScopedFlags[] = {
+        {"F1", "AltF1", BitmaskEnum::F1},
+        {"F2", "AltF2", BitmaskEnum::F2},
+    };
+
     W.printFlags("ZeroFlag", 0, ArrayRef(SingleBitFlags));
     W.printFlags("NoFlag", 1 << 3, ArrayRef(SingleBitFlags));
     W.printFlags("Flag1", SingleBitFlags[1].Value, ArrayRef(SingleBitFlags));
@@ -286,6 +302,7 @@ TEST_F(ScopedPrinterTest, PrintFlag) {
                  FirstByteMask, SecondByteMask);
     W.printFlags("FirstSecondThirdByteMask", 0x333u, ArrayRef(EnumFlags),
                  FirstByteMask, SecondByteMask, ThirdByteMask);
+    W.printFlags("BitmaskEnum::F1", BitmaskEnum::F1, ArrayRef(ScopedFlags));
   };
 
   const char *ExpectedOut = R"(ZeroFlag [ (0x0)
@@ -342,6 +359,9 @@ FirstSecondThirdByteMask [ (0x333)
   FirstByte3 (0x3)
   SecondByte3 (0x30)
   ThirdByte3 (0x300)
+]
+BitmaskEnum::F1 [ (0x1)
+  F1 (0x1)
 ]
 )";
 
@@ -502,6 +522,15 @@ FirstSecondThirdByteMask [ (0x333)
       {
         "Name": "ThirdByte3",
         "Value": 768
+      }
+    ]
+  },
+  "BitmaskEnum::F1": {
+    "Value": 1,
+    "Flags": [
+      {
+        "Name": "F1",
+        "Value": 1
       }
     ]
   }


### PR DESCRIPTION
.. produced by ADT/BitmaskEnum.h.

These aren't implicitly convertible to an integer, so I needed to tweak a couple of bitwise operations and add an explicit constructor for HexNumber and FlagEntry.

Motivation: I'd like to use this in the SFrame data structures (#147264)