### PR TITLE
[libc++][z/OS] XFAIL thread_create_failure.pass.cpp on z/OS

### DIFF
--- a/libcxx/test/std/thread/futures/futures.async/thread_create_failure.pass.cpp
+++ b/libcxx/test/std/thread/futures/futures.async/thread_create_failure.pass.cpp
@@ -21,6 +21,9 @@
 // XFAIL: target={{.+}}-apple-{{.*}}
 // XFAIL: freebsd
 
+// z/OS does not have mechanism to limit the number of threads
+// XFAIL: target={{.+}}-zos{{.*}}
+
 // This test makes sure that we fail gracefully in care the thread creation fails. This is only reliably possible on
 // systems that allow limiting the number of threads that can be created. See https://llvm.org/PR125428 for more details
 


### PR DESCRIPTION
Number of threads on z/OS are controlled at the system level and thus we need to XFAIL this test.