### PR TITLE
[NFC][SPIRV] Fix test after spirv-val update

### DIFF
--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/ptr-annotation.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/ptr-annotation.ll
@@ -7,13 +7,13 @@
 ; CHECK-DAG: OpName %[[#Ptr3:]] "_arg3"
 ; CHECK-DAG: OpName %[[#Ptr4:]] "_arg4"
 ; CHECK-DAG: OpName %[[#Ptr5:]] "_arg5"
-; CHECK-DAG: OpDecorate %[[#Ptr1]] NonReadable
+; CHECK-DAG: OpDecorate %[[#Ptr1]] Restrict
 ; CHECK-DAG: OpDecorate %[[#Ptr2]] Alignment 128
-; CHECK-DAG: OpDecorate %[[#Ptr2]] NonReadable
+; CHECK-DAG: OpDecorate %[[#Ptr2]] Restrict
 ; CHECK-DAG: OpDecorate %[[#Ptr3]] Alignment 128
-; CHECK-DAG: OpDecorate %[[#Ptr3]] NonReadable
+; CHECK-DAG: OpDecorate %[[#Ptr3]] Restrict
 ; CHECK-DAG: OpDecorate %[[#Ptr4]] Alignment 128
-; CHECK-DAG: OpDecorate %[[#Ptr4]] NonReadable
+; CHECK-DAG: OpDecorate %[[#Ptr4]] Restrict
 ; CHECK-DAG: OpDecorate %[[#Ptr5]] UserSemantic "Unknown format"
 ; CHECK: %[[#Foo]] = OpFunction
 ; CHECK-NEXT: %[[#Ptr1]] = OpFunctionParameter
@@ -24,10 +24,10 @@
 ; CHECK: OpFunctionEnd
 
 @.str.0 = private unnamed_addr addrspace(1) constant [16 x i8] c"../prefetch.hpp\00", section "llvm.metadata"
-@.str.1 = private unnamed_addr addrspace(1) constant [5 x i8] c"{25}\00", section "llvm.metadata"
-@.str.2 = private unnamed_addr addrspace(1) constant [13 x i8] c"{44:128}{25}\00", section "llvm.metadata"
-@.str.3 = private unnamed_addr addrspace(1) constant [15 x i8] c"{44:\22128\22}{25}\00", section "llvm.metadata"
-@.str.4 = private unnamed_addr addrspace(1) constant [13 x i8] c"{44,128}{25}\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr addrspace(1) constant [5 x i8] c"{19}\00", section "llvm.metadata"
+@.str.2 = private unnamed_addr addrspace(1) constant [13 x i8] c"{44:128}{19}\00", section "llvm.metadata"
+@.str.3 = private unnamed_addr addrspace(1) constant [15 x i8] c"{44:\22128\22}{19}\00", section "llvm.metadata"
+@.str.4 = private unnamed_addr addrspace(1) constant [13 x i8] c"{44,128}{19}\00", section "llvm.metadata"
 @.str.5 = private unnamed_addr addrspace(1) constant [15 x i8] c"Unknown format\00", section "llvm.metadata"
 
 define spir_kernel void @foo(ptr addrspace(1) %_arg1, ptr addrspace(1) %_arg2, ptr addrspace(1) %_arg3, ptr addrspace(1) %_arg4, ptr addrspace(1) %_arg5) {


### PR DESCRIPTION
ptr-annotation.ll was incorrectly applying a decoration to an unsuitable target.

The patch changes the decoration to a valid one for the test.