### PR TITLE
[lldb][test] Move std::queue from libcxx to generic directory

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/Makefile
@@ -1,4 +1,3 @@
 CXX_SOURCES := main.cpp
 
-USE_LIBCPP := 1
 include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
@@ -2,14 +2,13 @@
 Test lldb data formatter subsystem.
 """
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-class TestDataFormatterLibcxxQueue(TestBase):
+class TestDataFormatterStdQueue(TestBase):
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"
@@ -30,9 +29,9 @@ class TestDataFormatterLibcxxQueue(TestBase):
         bugnumber="llvm.org/pr36109", debug_info="gmodules", triple=".*-android"
     )
     @add_test_categories(["libc++"])
-    def test(self):
+    def test_libcxx(self):
         """Test that std::queue is displayed correctly"""
-        self.build()
+        self.build(dictionary={"USE_LIBCPP": 1})
         lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.cpp", False)
         )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/main.cpp
@@ -2,8 +2,8 @@
 #include <vector>
 
 int main() {
-  std::queue<int> q1{{1,2,3,4,5}};
-  std::queue<int, std::vector<int>> q2{{1,2,3,4,5}};
+  std::queue<int> q1{{1, 2, 3, 4, 5}};
+  std::queue<int, std::vector<int>> q2{{1, 2, 3, 4, 5}};
   int ret = q1.size() + q2.size(); // break here
   return ret;
 }


### PR DESCRIPTION
This just moves the test from `libcxx` to `generic`. There are currently no `std::queue` formatters for libstdc++ so I didn't add a test-case for it.

Split out from https://github.com/llvm/llvm-project/pull/146740