### PR TITLE
Utils: Add pass to declare runtime libcalls

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/DeclareRuntimeLibcalls.h
+++ b/llvm/include/llvm/Transforms/Utils/DeclareRuntimeLibcalls.h
@@ -1,0 +1,23 @@
+//===- DeclareRuntimeLibcalls.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_UTILS_DECLARERUNTIMELIBCALLS_H
+#define LLVM_TRANSFORMS_UTILS_DECLARERUNTIMELIBCALLS_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+class DeclareRuntimeLibcallsPass
+    : public PassInfoMixin<DeclareRuntimeLibcallsPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+};
+
+} // end namespace llvm
+
+#endif // LLVM_TRANSFORMS_UTILS_DECLARERUNTIMELIBCALLS_H

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -339,6 +339,7 @@
 #include "llvm/Transforms/Utils/CountVisits.h"
 #include "llvm/Transforms/Utils/DXILUpgrade.h"
 #include "llvm/Transforms/Utils/Debugify.h"
+#include "llvm/Transforms/Utils/DeclareRuntimeLibcalls.h"
 #include "llvm/Transforms/Utils/EntryExitInstrumenter.h"
 #include "llvm/Transforms/Utils/FixIrreducible.h"
 #include "llvm/Transforms/Utils/HelloWorld.h"

--- a/llvm/lib/Passes/PassRegistry.def
+++ b/llvm/lib/Passes/PassRegistry.def
@@ -70,6 +70,7 @@ MODULE_PASS("ctx-prof-flatten-prethinlink",
 MODULE_PASS("noinline-nonprevailing", NoinlineNonPrevailing())
 MODULE_PASS("deadargelim", DeadArgumentEliminationPass())
 MODULE_PASS("debugify", NewPMDebugifyPass())
+MODULE_PASS("declare-runtime-libcalls", DeclareRuntimeLibcallsPass())
 MODULE_PASS("dfsan", DataFlowSanitizerPass())
 MODULE_PASS("dot-callgraph", CallGraphDOTPrinterPass())
 MODULE_PASS("dxil-upgrade", DXILUpgradePass())

--- a/llvm/lib/Transforms/Utils/CMakeLists.txt
+++ b/llvm/lib/Transforms/Utils/CMakeLists.txt
@@ -20,6 +20,7 @@ add_llvm_component_library(LLVMTransformUtils
   CtorUtils.cpp
   CountVisits.cpp
   Debugify.cpp
+  DeclareRuntimeLibcalls.cpp
   DemoteRegToStack.cpp
   DXILUpgrade.cpp
   EntryExitInstrumenter.cpp

--- a/llvm/lib/Transforms/Utils/DeclareRuntimeLibcalls.cpp
+++ b/llvm/lib/Transforms/Utils/DeclareRuntimeLibcalls.cpp
@@ -1,0 +1,38 @@
+//===- DeclareRuntimeLibcalls.cpp -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Insert declarations for all runtime library calls known for the target.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Utils/DeclareRuntimeLibcalls.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/RuntimeLibcalls.h"
+
+using namespace llvm;
+
+PreservedAnalyses DeclareRuntimeLibcallsPass::run(Module &M,
+                                                  ModuleAnalysisManager &MAM) {
+  RTLIB::RuntimeLibcallsInfo RTLCI(M.getTargetTriple());
+  LLVMContext &Ctx = M.getContext();
+
+  for (RTLIB::LibcallImpl Impl : RTLCI.getLibcallImpls()) {
+    if (Impl == RTLIB::Unsupported)
+      continue;
+
+    // TODO: Declare with correct type, calling convention, and attributes.
+
+    FunctionType *FuncTy =
+        FunctionType::get(Type::getVoidTy(Ctx), {}, /*IsVarArgs=*/true);
+
+    const char *FuncName = RTLCI.getLibcallImplName(Impl);
+    M.getOrInsertFunction(FuncName, FuncTy);
+  }
+
+  return PreservedAnalyses::none();
+}

--- a/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
+++ b/llvm/test/Transforms/Util/DeclareRuntimeLibcalls/basic.ll
@@ -1,0 +1,15 @@
+; RUN: opt -S -passes=declare-runtime-libcalls -mtriple=x86_64-unknown-linux-gnu < %s | FileCheck %s
+
+; Check an already declared function
+; CHECK: declare float @logf(float)
+declare float @logf(float)
+
+; Check an already defined function
+; CHECK: define float @sinf(float %x) {
+define float @sinf(float %x) {
+  ret float %x
+}
+
+; CHECK: declare void @acosf(...)
+; CHECK: declare void @__umodti3(...)
+

--- a/llvm/utils/gn/secondary/llvm/lib/Transforms/Utils/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Transforms/Utils/BUILD.gn
@@ -29,6 +29,7 @@ static_library("Utils") {
     "CtorUtils.cpp",
     "DXILUpgrade.cpp",
     "Debugify.cpp",
+    "DeclareRuntimeLibcalls.cpp",
     "DemoteRegToStack.cpp",
     "EntryExitInstrumenter.cpp",
     "EscapeEnumerator.cpp",


### PR DESCRIPTION
This will be useful for testing the set of calls for different systems,
and eventually the product of context specific modifiers applied. In
the future we should also know the type signatures, and be able to
emit the correct one.