### PR TITLE
[SPIRV] Implement translation for llvm.modf.* intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -4040,7 +4040,7 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
       ++VarPos;
     }
     // Advance VarPos to the next instruction after OpFunction, it will either
-    // be an OpFunctionParameter, so that we can start the next loop, or the 
+    // be an OpFunctionParameter, so that we can start the next loop, or the
     // position to insert the OpVariable instruction.
     ++VarPos;
     while (VarPos != EntryBB.end() &&

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -4029,7 +4029,7 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
     GR.assignSPIRVTypeToVReg(PtrType, PtrTyReg, MIRBuilder.getMF());
     MachineBasicBlock &EntryBB = I.getMF()->front();
     MachineBasicBlock::iterator VarPos =
-        getPosForOpVariableWithinBlock(EntryBB);
+        getFirstValidInstructionInsertPoint(EntryBB);
     auto AllocaMIB =
         BuildMI(EntryBB, VarPos, I.getDebugLoc(), TII.get(SPIRV::OpVariable))
             .addDef(PtrTyReg)

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -4028,7 +4028,8 @@ bool SPIRVInstructionSelector::selectModf(Register ResVReg,
     // new register.
     GR.assignSPIRVTypeToVReg(PtrType, PtrTyReg, MIRBuilder.getMF());
     MachineBasicBlock &EntryBB = I.getMF()->front();
-    MachineBasicBlock::iterator VarPos = getPosForOpVariableWithinBlock(EntryBB);
+    MachineBasicBlock::iterator VarPos =
+        getPosForOpVariableWithinBlock(EntryBB);
     auto AllocaMIB =
         BuildMI(EntryBB, VarPos, I.getDebugLoc(), TII.get(SPIRV::OpVariable))
             .addDef(PtrTyReg)

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -996,7 +996,7 @@ unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
 }
 
 MachineBasicBlock::iterator
-getPosForOpVariableWithinBlock(MachineBasicBlock &BB) {
+getFirstValidInstructionInsertPoint(MachineBasicBlock &BB) {
   // Find the position to insert the OpVariable instruction.
   // We will insert it after the last OpFunctionParameter, if any, or
   // after OpFunction otherwise.
@@ -1014,7 +1014,8 @@ getPosForOpVariableWithinBlock(MachineBasicBlock &BB) {
   }
   // VarPos is now pointing at after the last OpFunctionParameter, if any,
   // or after OpFunction, if no parameters.
-  return VarPos;
+  return VarPos != BB.end() && VarPos->getOpcode() == SPIRV::OpLabel ? ++VarPos
+                                                                     : VarPos;
 }
 
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -995,4 +995,26 @@ unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
   return foldImm(ResType->getOperand(2), MRI);
 }
 
+MachineBasicBlock::iterator
+getPosForOpVariableWithinBlock(MachineBasicBlock &BB) {
+  // Find the position to insert the OpVariable instruction.
+  // We will insert it after the last OpFunctionParameter, if any, or
+  // after OpFunction otherwise.
+  MachineBasicBlock::iterator VarPos = BB.begin();
+  while (VarPos != BB.end() && VarPos->getOpcode() != SPIRV::OpFunction) {
+    ++VarPos;
+  }
+  // Advance VarPos to the next instruction after OpFunction, it will either
+  // be an OpFunctionParameter, so that we can start the next loop, or the
+  // position to insert the OpVariable instruction.
+  ++VarPos;
+  while (VarPos != BB.end() &&
+         VarPos->getOpcode() == SPIRV::OpFunctionParameter) {
+    ++VarPos;
+  }
+  // VarPos is now pointing at after the last OpFunctionParameter, if any,
+  // or after OpFunction, if no parameters.
+  return VarPos;
+}
+
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -507,7 +507,7 @@ int64_t foldImm(const MachineOperand &MO, const MachineRegisterInfo *MRI);
 unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
                                 const MachineInstr *ResType);
 MachineBasicBlock::iterator
-getPosForOpVariableWithinBlock(MachineBasicBlock &BB);
+getFirstValidInstructionInsertPoint(MachineBasicBlock &BB);
 
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -506,6 +506,8 @@ MachineInstr *getImm(const MachineOperand &MO, const MachineRegisterInfo *MRI);
 int64_t foldImm(const MachineOperand &MO, const MachineRegisterInfo *MRI);
 unsigned getArrayComponentCount(const MachineRegisterInfo *MRI,
                                 const MachineInstr *ResType);
+MachineBasicBlock::iterator
+getPosForOpVariableWithinBlock(MachineBasicBlock &BB);
 
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
@@ -1,4 +1,5 @@
 ; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK: %[[#extinst_id:]] = OpExtInstImport "OpenCL.std"
 
@@ -348,13 +349,49 @@ declare float @llvm.fma.f32(float, float, float)
 ; CHECK: OpStore %[[#fracPtr]] %[[#frac]]
 ; CHECK: OpStore %[[#integralPtr]] %[[#integral]]
 ; CHECK: OpFunctionEnd
-define void @foo(double %d, ptr addrspace(1) %frac, ptr addrspace(1) %integral) {
+define void @TestModf(double %d, ptr addrspace(1) %frac, ptr addrspace(1) %integral) {
 entry:
   %4 = tail call { double, double } @llvm.modf.f64(double %d)
   %5 = extractvalue { double, double } %4, 0
   %6 = extractvalue { double, double } %4, 1
   store double %5, ptr addrspace(1) %frac, align 8
   store double %6, ptr addrspace(1) %integral, align 8
+  ret void
+}
+
+define dso_local void @TestModf2(double noundef %d, ptr noundef %frac, ptr noundef %integral) {
+entry:
+  %d.addr = alloca double, align 4
+  %frac.addr = alloca ptr, align 8
+  %integral.addr = alloca ptr, align 8
+  store double %d, ptr %d.addr, align 4
+  store ptr %frac, ptr %frac.addr, align 8
+  store ptr %integral, ptr %integral.addr, align 8
+  %0 = load ptr, ptr %frac.addr, align 8
+  %tobool = icmp ne ptr %0, null
+  br i1 %tobool, label %lor.lhs.false, label %if.then
+
+lor.lhs.false:
+  %1 = load ptr, ptr %integral.addr, align 8
+  %tobool1 = icmp ne ptr %1, null
+  br i1 %tobool1, label %if.end, label %if.then
+
+if.then:
+  br label %return
+
+if.end:
+  %2 = load ptr, ptr %frac.addr, align 8
+  %3 = load double, ptr %2, align 4
+  %4 = load ptr, ptr %integral.addr, align 8
+  %5 = load double, ptr %4, align 4
+  %6 = tail call { double, double } @llvm.modf.f64(double %d)
+  %7 = extractvalue { double, double } %6, 0
+  %8 = extractvalue { double, double } %6, 1
+  store double %7, ptr %frac, align 4
+  store double %7, ptr %integral, align 4
+  br label %return
+
+return:
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
@@ -337,3 +337,25 @@ entry:
 }
 
 declare float @llvm.fma.f32(float, float, float)
+
+; CHECK: OpFunction
+; CHECK: %[[#d:]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#fracPtr:]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#integralPtr:]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#varPtr:]] = OpVariable %[[#]] Function
+; CHECK: %[[#frac:]] = OpExtInst %[[#var2]] %[[#extinst_id]] modf %[[#d]] %[[#varPtr]]
+; CHECK: %[[#integral:]] = OpLoad %[[#var2]] %[[#varPtr]]
+; CHECK: OpStore %[[#fracPtr]] %[[#frac]]
+; CHECK: OpStore %[[#integralPtr]] %[[#integral]]
+; CHECK: OpFunctionEnd
+define void @foo(double %d, ptr addrspace(1) %frac, ptr addrspace(1) %integral) {
+entry:
+  %4 = tail call { double, double } @llvm.modf.f64(double %d)
+  %5 = extractvalue { double, double } %4, 0
+  %6 = extractvalue { double, double } %4, 1
+  store double %5, ptr addrspace(1) %frac, align 8
+  store double %6, ptr addrspace(1) %integral, align 8
+  ret void
+}
+
+declare { double, double } @llvm.modf.f64(double)

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
@@ -359,6 +359,23 @@ entry:
   ret void
 }
 
+; CHECK: OpFunction
+; CHECK: %[[#d:]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#fracPtr:]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#integralPtr:]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#entryBlock:]] = OpLabel
+; CHECK: %[[#varPtr:]] = OpVariable %[[#]] Function
+; CHECK: OpBranchConditional %[[#]] %[[#lor_lhs_falseBlock:]] %[[#if_thenBlock:]]
+; CHECK: %[[#lor_lhs_falseBlock]] = OpLabel
+; CHECK: OpBranchConditional %[[#]] %[[#if_endBlock:]] %[[#if_thenBlock]]
+; CHECK: %[[#if_thenBlock]] = OpLabel
+; CHECK: OpBranch %[[#returnBlock:]]
+; CHECK: %[[#if_endBlock]] = OpLabel
+; CHECK: %[[#frac:]] = OpExtInst %[[#var2]] %[[#extinst_id]] modf %[[#d]] %[[#varPtr]]
+; CHECK: %[[#integral:]] = OpLoad %[[#var2]] %[[#varPtr]]
+; CHECK: OpStore %[[#fracPtr]] %[[#frac]]
+; CHECK: OpStore %[[#integralPtr]] %[[#integral]]
+; CHECK: OpFunctionEnd
 define dso_local void @TestModf2(double noundef %d, ptr noundef %frac, ptr noundef %integral) {
 entry:
   %0 = load ptr, ptr %frac, align 8

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fp-intrinsics.ll
@@ -361,18 +361,12 @@ entry:
 
 define dso_local void @TestModf2(double noundef %d, ptr noundef %frac, ptr noundef %integral) {
 entry:
-  %d.addr = alloca double, align 4
-  %frac.addr = alloca ptr, align 8
-  %integral.addr = alloca ptr, align 8
-  store double %d, ptr %d.addr, align 4
-  store ptr %frac, ptr %frac.addr, align 8
-  store ptr %integral, ptr %integral.addr, align 8
-  %0 = load ptr, ptr %frac.addr, align 8
+  %0 = load ptr, ptr %frac, align 8
   %tobool = icmp ne ptr %0, null
   br i1 %tobool, label %lor.lhs.false, label %if.then
 
 lor.lhs.false:
-  %1 = load ptr, ptr %integral.addr, align 8
+  %1 = load ptr, ptr %integral, align 8
   %tobool1 = icmp ne ptr %1, null
   br i1 %tobool1, label %if.end, label %if.then
 
@@ -380,15 +374,11 @@ if.then:
   br label %return
 
 if.end:
-  %2 = load ptr, ptr %frac.addr, align 8
-  %3 = load double, ptr %2, align 4
-  %4 = load ptr, ptr %integral.addr, align 8
-  %5 = load double, ptr %4, align 4
   %6 = tail call { double, double } @llvm.modf.f64(double %d)
   %7 = extractvalue { double, double } %6, 0
   %8 = extractvalue { double, double } %6, 1
   store double %7, ptr %frac, align 4
-  store double %7, ptr %integral, align 4
+  store double %8, ptr %integral, align 4
   br label %return
 
 return:


### PR DESCRIPTION
Based on https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3100, I'm adding translation for `llvm.modf.*` intrinsics.