### PR TITLE
[LLDB] Add formatters for MSVC STL std::shared_ptr

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
@@ -34,6 +34,7 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
   LibStdcppTuple.cpp
   LibStdcppUniquePointer.cpp
   MsvcStl.cpp
+  MsvcStlSmartPointer.cpp
   MSVCUndecoratedNameParser.cpp
 
   LINK_COMPONENTS

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1580,6 +1580,25 @@ static void LoadLibStdcppFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
                 "^std::optional<.+>(( )?&)?$", stl_summary_flags, true);
 }
 
+static lldb_private::SyntheticChildrenFrontEnd *
+GenericSmartPointerSyntheticFrontEndCreator(CXXSyntheticChildren *children,
+                                            lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+
+  if (IsMsvcStlSmartPointer(*valobj_sp))
+    return MsvcStlSmartPointerSyntheticFrontEndCreator(valobj_sp);
+  return LibStdcppSharedPtrSyntheticFrontEndCreator(children, valobj_sp);
+}
+
+static bool
+GenericSmartPointerSummaryProvider(ValueObject &valobj, Stream &stream,
+                                   const TypeSummaryOptions &options) {
+  if (IsMsvcStlSmartPointer(valobj))
+    return MsvcStlSmartPointerSummaryProvider(valobj, stream, options);
+  return LibStdcppSmartPointerSummaryProvider(valobj, stream, options);
+}
+
 /// Load formatters that are formatting types from more than one STL
 static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
   if (!cpp_category_sp)

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -1623,33 +1623,17 @@ static void LoadCommonStlFormatters(lldb::TypeCategoryImplSP cpp_category_sp) {
           },
           "MSVC STL/libstdc++ std::wstring summary provider"));
 
-  auto smart_ptr_creator =
-      [](CXXSyntheticChildren *children,
-         ValueObjectSP valobj_sp) -> SyntheticChildrenFrontEnd * {
-    if (!valobj_sp)
-      return nullptr;
-
-    if (auto *msvc = MsvcStlSmartPointerSyntheticFrontEndCreator(valobj_sp))
-      return msvc;
-
-    return LibStdcppSharedPtrSyntheticFrontEndCreator(children, valobj_sp);
-  };
-  AddCXXSynthetic(cpp_category_sp, smart_ptr_creator,
+  AddCXXSynthetic(cpp_category_sp, GenericSmartPointerSyntheticFrontEndCreator,
                   "std::shared_ptr synthetic children",
                   "^std::shared_ptr<.+>(( )?&)?$", stl_synth_flags, true);
-  AddCXXSynthetic(cpp_category_sp, smart_ptr_creator,
+  AddCXXSynthetic(cpp_category_sp, GenericSmartPointerSyntheticFrontEndCreator,
                   "std::weak_ptr synthetic children",
                   "^std::weak_ptr<.+>(( )?&)?$", stl_synth_flags, true);
 
-  auto smart_ptr_summary = [](ValueObject &valobj, Stream &stream,
-                              const TypeSummaryOptions &options) {
-    return MsvcStlSmartPointerSummaryProvider(valobj, stream, options) ||
-           LibStdcppSmartPointerSummaryProvider(valobj, stream, options);
-  };
-  AddCXXSummary(cpp_category_sp, smart_ptr_summary,
+  AddCXXSummary(cpp_category_sp, GenericSmartPointerSummaryProvider,
                 "MSVC STL/libstdc++ std::shared_ptr summary provider",
                 "^std::shared_ptr<.+>(( )?&)?$", stl_summary_flags, true);
-  AddCXXSummary(cpp_category_sp, smart_ptr_summary,
+  AddCXXSummary(cpp_category_sp, GenericSmartPointerSummaryProvider,
                 "MSVC STL/libstdc++ std::weak_ptr summary provider",
                 "^std::weak_ptr<.+>(( )?&)?$", stl_summary_flags, true);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
@@ -16,7 +16,8 @@ lldb::ValueObjectSP lldb_private::formatters::GetDesugaredSmartPointerValue(
 
   auto arg = container_type.GetTypeTemplateArgument(0);
   if (!arg)
-    return ptr.GetSP(); // FIXME: PDB doesn't have info about template arguments
+    // If there isn't enough debug info, use the pointer type as is
+    return ptr.GetSP();
 
   return ptr.Cast(arg.GetPointerType());
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
@@ -7,6 +7,8 @@
 //===---------------------------------------------------------------------===//
 
 #include "Generic.h"
+#include "LibStdcpp.h"
+#include "MsvcStl.h"
 
 lldb::ValueObjectSP lldb_private::formatters::GetDesugaredSmartPointerValue(
     ValueObject &ptr, ValueObject &container) {
@@ -20,4 +22,19 @@ lldb::ValueObjectSP lldb_private::formatters::GetDesugaredSmartPointerValue(
     return ptr.GetSP();
 
   return ptr.Cast(arg.GetPointerType());
+}
+
+lldb_private::SyntheticChildrenFrontEnd *
+lldb_private::formatters::GenericSmartPointerSyntheticFrontEndCreator(
+    CXXSyntheticChildren *children, lldb::ValueObjectSP valobj_sp) {
+  if (auto *msvc = MsvcStlSmartPointerSyntheticFrontEndCreator(valobj_sp))
+    return msvc;
+
+  return LibStdcppSharedPtrSyntheticFrontEndCreator(children, valobj_sp);
+}
+
+bool lldb_private::formatters::GenericSmartPointerSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  return MsvcStlSmartPointerSummaryProvider(valobj, stream, options) ||
+         LibStdcppSmartPointerSummaryProvider(valobj, stream, options);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
@@ -23,18 +23,3 @@ lldb::ValueObjectSP lldb_private::formatters::GetDesugaredSmartPointerValue(
 
   return ptr.Cast(arg.GetPointerType());
 }
-
-lldb_private::SyntheticChildrenFrontEnd *
-lldb_private::formatters::GenericSmartPointerSyntheticFrontEndCreator(
-    CXXSyntheticChildren *children, lldb::ValueObjectSP valobj_sp) {
-  if (auto *msvc = MsvcStlSmartPointerSyntheticFrontEndCreator(valobj_sp))
-    return msvc;
-
-  return LibStdcppSharedPtrSyntheticFrontEndCreator(children, valobj_sp);
-}
-
-bool lldb_private::formatters::GenericSmartPointerSummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  return MsvcStlSmartPointerSummaryProvider(valobj, stream, options) ||
-         LibStdcppSmartPointerSummaryProvider(valobj, stream, options);
-}

--- a/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/Generic.cpp
@@ -16,7 +16,7 @@ lldb::ValueObjectSP lldb_private::formatters::GetDesugaredSmartPointerValue(
 
   auto arg = container_type.GetTypeTemplateArgument(0);
   if (!arg)
-    return nullptr;
+    return ptr.GetSP(); // FIXME: PDB doesn't have info about template arguments
 
   return ptr.Cast(arg.GetPointerType());
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/Generic.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/Generic.h
@@ -24,13 +24,6 @@ bool GenericOptionalSummaryProvider(ValueObject &valobj, Stream &stream,
 lldb::ValueObjectSP GetDesugaredSmartPointerValue(ValueObject &ptr,
                                                   ValueObject &container);
 
-// std::shared_ptr<>/std::weak_ptr<>
-SyntheticChildrenFrontEnd *
-GenericSmartPointerSyntheticFrontEndCreator(CXXSyntheticChildren *children,
-                                            lldb::ValueObjectSP valobj_sp);
-bool GenericSmartPointerSummaryProvider(ValueObject &valobj, Stream &stream,
-                                        const TypeSummaryOptions &options);
-
 } // namespace formatters
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/Language/CPlusPlus/Generic.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/Generic.h
@@ -24,6 +24,13 @@ bool GenericOptionalSummaryProvider(ValueObject &valobj, Stream &stream,
 lldb::ValueObjectSP GetDesugaredSmartPointerValue(ValueObject &ptr,
                                                   ValueObject &container);
 
+// std::shared_ptr<>/std::weak_ptr<>
+SyntheticChildrenFrontEnd *
+GenericSmartPointerSyntheticFrontEndCreator(CXXSyntheticChildren *children,
+                                            lldb::ValueObjectSP valobj_sp);
+bool GenericSmartPointerSummaryProvider(ValueObject &valobj, Stream &stream,
+                                        const TypeSummaryOptions &options);
+
 } // namespace formatters
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.h
@@ -29,6 +29,14 @@ bool MsvcStlWStringSummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &options); // VC 2015+ std::wstring
 
+// MSVC STL std::shared_ptr<> and std::weak_ptr<>
+bool IsMsvcStlSmartPointer(ValueObject &valobj);
+bool MsvcStlSmartPointerSummaryProvider(ValueObject &valobj, Stream &stream,
+                                        const TypeSummaryOptions &options);
+
+lldb_private::SyntheticChildrenFrontEnd *
+MsvcStlSmartPointerSyntheticFrontEndCreator(lldb::ValueObjectSP valobj_sp);
+
 } // namespace formatters
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -158,11 +158,5 @@ lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::
 lldb_private::SyntheticChildrenFrontEnd *
 lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEndCreator(
     lldb::ValueObjectSP valobj_sp) {
-  if (!valobj_sp)
-    return nullptr;
-
-  if (!IsMsvcStlSmartPointer(*valobj_sp))
-    return nullptr;
-
   return new MsvcStlSmartPointerSyntheticFrontEnd(valobj_sp);
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -15,9 +15,7 @@
 using namespace lldb;
 
 bool lldb_private::formatters::IsMsvcStlSmartPointer(ValueObject &valobj) {
-  std::vector<uint32_t> indexes;
-  return valobj.GetCompilerType().GetIndexOfChildMemberWithName("_Ptr", true,
-                                                                indexes) > 0;
+  return valobj.GetChildMemberWithName("_Ptr") != nullptr;
 }
 
 bool lldb_private::formatters::MsvcStlSmartPointerSummaryProvider(

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -142,7 +142,7 @@ lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::Update() {
 llvm::Expected<size_t>
 lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
-  if (name == "_Ptr" || name == "pointer")
+  if (name == "pointer")
     return 0;
 
   if (name == "object" || name == "$$dereference$$")

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -1,0 +1,170 @@
+//===-- MsvcStlSmartPointer.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Generic.h"
+#include "MsvcStl.h"
+
+#include "lldb/DataFormatters/FormattersHelpers.h"
+#include "lldb/DataFormatters/TypeSynthetic.h"
+
+using namespace lldb;
+
+bool lldb_private::formatters::IsMsvcStlSmartPointer(ValueObject &valobj) {
+  std::vector<uint32_t> indexes;
+  return valobj.GetCompilerType().GetIndexOfChildMemberWithName("_Ptr", true,
+                                                                indexes) > 0;
+}
+
+bool lldb_private::formatters::MsvcStlSmartPointerSummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  ValueObjectSP valobj_sp(valobj.GetNonSyntheticValue());
+  if (!valobj_sp)
+    return false;
+
+  ValueObjectSP ptr_sp(valobj_sp->GetChildMemberWithName("_Ptr"));
+  ValueObjectSP ctrl_sp(valobj_sp->GetChildMemberWithName("_Rep"));
+  if (!ctrl_sp || !ptr_sp)
+    return false;
+
+  DumpCxxSmartPtrPointerSummary(stream, *ptr_sp, options);
+
+  bool success;
+  uint64_t ctrl_addr = ctrl_sp->GetValueAsUnsigned(0, &success);
+  // Empty control field (expired)
+  if (!success || ctrl_addr == 0)
+    return true;
+
+  uint64_t uses = 0;
+  if (auto uses_sp = ctrl_sp->GetChildMemberWithName("_Uses")) {
+    bool success;
+    uses = uses_sp->GetValueAsUnsigned(0, &success);
+    if (!success)
+      return false;
+
+    stream.Printf(" strong=%" PRIu64, uses);
+  }
+
+  // _Weaks is the number of weak references - (_Uses != 0).
+  if (auto weak_count_sp = ctrl_sp->GetChildMemberWithName("_Weaks")) {
+    bool success;
+    uint64_t count = weak_count_sp->GetValueAsUnsigned(0, &success);
+    if (!success)
+      return false;
+
+    stream.Printf(" weak=%" PRIu64, count - (uses != 0));
+  }
+
+  return true;
+}
+
+namespace lldb_private {
+namespace formatters {
+
+class MsvcStlSmartPointerSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+public:
+  MsvcStlSmartPointerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
+
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
+
+  lldb::ChildCacheState Update() override;
+
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
+
+  ~MsvcStlSmartPointerSyntheticFrontEnd() override;
+
+private:
+  ValueObject *m_ptr_obj = nullptr;
+};
+
+} // namespace formatters
+} // namespace lldb_private
+
+lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::
+    MsvcStlSmartPointerSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+    : SyntheticChildrenFrontEnd(*valobj_sp) {
+  if (valobj_sp)
+    Update();
+}
+
+llvm::Expected<uint32_t> lldb_private::formatters::
+    MsvcStlSmartPointerSyntheticFrontEnd::CalculateNumChildren() {
+  return (m_ptr_obj ? 1 : 0);
+}
+
+lldb::ValueObjectSP
+lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::GetChildAtIndex(
+    uint32_t idx) {
+  if (!m_ptr_obj)
+    return lldb::ValueObjectSP();
+
+  ValueObjectSP valobj_sp = m_backend.GetSP();
+  if (!valobj_sp)
+    return lldb::ValueObjectSP();
+
+  if (idx == 0)
+    return m_ptr_obj->GetSP();
+
+  if (idx == 1) {
+    Status status;
+    ValueObjectSP value_sp = m_ptr_obj->Dereference(status);
+    if (status.Success())
+      return value_sp;
+  }
+
+  return lldb::ValueObjectSP();
+}
+
+lldb::ChildCacheState
+lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::Update() {
+  m_ptr_obj = nullptr;
+
+  ValueObjectSP valobj_sp = m_backend.GetSP();
+  if (!valobj_sp)
+    return lldb::ChildCacheState::eRefetch;
+
+  auto ptr_obj_sp = valobj_sp->GetChildMemberWithName("_Ptr");
+  if (!ptr_obj_sp)
+    return lldb::ChildCacheState::eRefetch;
+
+  auto cast_ptr_sp = GetDesugaredSmartPointerValue(*ptr_obj_sp, *valobj_sp);
+  if (!cast_ptr_sp)
+    return lldb::ChildCacheState::eRefetch;
+
+  m_ptr_obj = cast_ptr_sp->Clone(ConstString("pointer")).get();
+  return lldb::ChildCacheState::eRefetch;
+}
+
+llvm::Expected<size_t>
+lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::
+    GetIndexOfChildWithName(ConstString name) {
+  if (name == "_Ptr" || name == "pointer")
+    return 0;
+
+  if (name == "object" || name == "$$dereference$$")
+    return 1;
+
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
+}
+
+lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEnd::
+    ~MsvcStlSmartPointerSyntheticFrontEnd() = default;
+
+lldb_private::SyntheticChildrenFrontEnd *
+lldb_private::formatters::MsvcStlSmartPointerSyntheticFrontEndCreator(
+    lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return nullptr;
+
+  if (!IsMsvcStlSmartPointer(*valobj_sp))
+    return nullptr;
+
+  return new MsvcStlSmartPointerSyntheticFrontEnd(valobj_sp);
+}

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -122,5 +122,5 @@ class TestCase(TestBase):
     @add_test_categories(["msvcstl"])
     def test_msvcstl(self):
         # No flags, because the "msvcstl" category checks that the MSVC STL is used by default.
-        self.build(dictionary={})
+        self.build()
         self.do_test()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -118,3 +118,9 @@ class TestCase(TestBase):
     def test_libstdcxx(self):
         self.build(dictionary={"USE_LIBSTDCPP": 1})
         self.do_test()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        # No flags, because the "msvcstl" category checks that the MSVC STL is used by default.
+        self.build(dictionary={})
+        self.do_test()


### PR DESCRIPTION
This PR adds formatters for `std::shared_ptr` and `std::weak_ptr`. They are similar to the ones from libc++ and libstdc++. 
[Section from MSVC STL NatVis](https://github.com/microsoft/STL/blob/313964b78a8fd5a52e7965e13781f735bcce13c5/stl/debugger/STL.natvis#L512-L578).

To support debugging with PDB debug info, I had to add an early exit in `GetDesugaredSmartPointerValue`, because with PDB, LLDB doesn't know about template types. This isn't an issue here, since the typedef type is already resolved there, so no casting is needed.

The tests don't check for PDB - maybe this should be changed? I don't know a good way to do this. PDB has the downside that it resolves typedefs. Here in particular, the test for `element_type` would need to be replaced with `User` and `std::string` with `std::basic_string<char,std::char_traits<char>,std::allocator<char> >`.

Towards #24834.