### PR TITLE
[llvm] statically link TableGenTests

### DIFF
--- a/llvm/unittests/TableGen/CMakeLists.txt
+++ b/llvm/unittests/TableGen/CMakeLists.txt
@@ -13,6 +13,8 @@ add_llvm_unittest(TableGenTests
   AutomataTest.cpp
   CodeExpanderTest.cpp
   ParserEntryPointTest.cpp
+
+  DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
 target_link_libraries(TableGenTests PRIVATE LLVMTableGenCommon LLVMTableGen)


### PR DESCRIPTION
## Purpose
Statically link `TableGenTests` so it can still build when linked against an LLVM Windows DLL.

## Background
The effort to build LLVM as a WIndows DLL is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307).

If `TableGenTests` is linked against LLVM built as a DLL on Windows, it will fail due to a large number of duplicate symbols found in both the LLVM DLL and TableGen libraries. This is because `LLVMTableGenBasic` and `LLVMTableGenCommon` are linked statically against LLVM (using `DISABLE_LLVM_LINK_LLVM_DYLIB`) so already contain a sub-set of symbols also exported from the LLVM DLL.

This patch was originally part of #145448.