### PR TITLE
[CIR] Fold ComplexRealOp from ComplexCreateOp

### DIFF
--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2066,10 +2066,9 @@ LogicalResult cir::ComplexRealOp::verify() {
 }
 
 OpFoldResult cir::ComplexRealOp::fold(FoldAdaptor adaptor) {
-  if (auto complexCreateOp = dyn_cast_or_null<cir::ComplexCreateOp>(
-          getOperand().getDefiningOp())) {
+  if (auto complexCreateOp =
+          dyn_cast_or_null<cir::ComplexCreateOp>(getOperand().getDefiningOp()))
     return complexCreateOp.getOperand(0);
-  }
 
   auto complex =
       mlir::cast_if_present<cir::ConstComplexAttr>(adaptor.getOperand());

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2066,6 +2066,11 @@ LogicalResult cir::ComplexRealOp::verify() {
 }
 
 OpFoldResult cir::ComplexRealOp::fold(FoldAdaptor adaptor) {
+  if (auto complexCreateOp = dyn_cast_or_null<cir::ComplexCreateOp>(
+          getOperand().getDefiningOp())) {
+    return complexCreateOp.getOperand(0);
+  }
+
   auto complex =
       mlir::cast_if_present<cir::ConstComplexAttr>(adaptor.getOperand());
   return complex ? complex.getReal() : nullptr;

--- a/clang/test/CIR/Transforms/complex-real-fold.cir
+++ b/clang/test/CIR/Transforms/complex-real-fold.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -cir-canonicalize  -o - -split-input-file | FileCheck %s
+// RUN: cir-opt %s -cir-canonicalize -o - -split-input-file | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Transforms/complex-real-fold.cir
+++ b/clang/test/CIR/Transforms/complex-real-fold.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -cir-canonicalize -o - -split-input-file | FileCheck %s
+// RUN: cir-opt %s -cir-canonicalize -split-input-file -o - | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 

--- a/clang/test/CIR/Transforms/complex-real-fold.cir
+++ b/clang/test/CIR/Transforms/complex-real-fold.cir
@@ -1,4 +1,4 @@
-// RUN: cir-opt %s -cir-canonicalize -o - | FileCheck %s
+// RUN: cir-opt %s -cir-canonicalize  -o - -split-input-file | FileCheck %s
 
 !s32i = !cir.int<s, 32>
 
@@ -20,4 +20,20 @@ module {
   // CHECK:   cir.return %[[TMP]] : !s32i
   // CHECK: }
 
+}
+
+// -----
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.func dso_local @fold_complex_real_from_create_test(%arg0: !s32i, %arg1: !s32i) -> !s32i {
+    %0 = cir.complex.create %arg0, %arg1 : !s32i -> !cir.complex<!s32i>
+    %1 = cir.complex.real %0 : !cir.complex<!s32i> -> !s32i
+    cir.return %1 : !s32i
+  }
+
+  // CHECK: cir.func dso_local @fold_complex_real_from_create_test(%[[ARG_0:.*]]: !s32i, %[[ARG_1:.*]]: !s32i) -> !s32i {
+  // CHECK:   cir.return %[[ARG_0]] : !s32i
+  // CHECK: }
 }


### PR DESCRIPTION
Folding ComplexRealOp if the operand is ComplexCreateOp, inspired by MLIR Complex dialect

Ref: https://github.com/llvm/llvm-project/blob/8b65c9d1ed298a9f4be675d1da9d678fd61ff2b0/mlir/lib/Dialect/Complex/IR/ComplexOps.cpp#L237-L245

https://github.com/llvm/llvm-project/issues/141365