### PR TITLE
[Flang][FlangRT][Runtime]  Add RT_OFFLOAD_API_GROUP_BEGIN to missing symbols on AMDGPU

### DIFF
--- a/flang-rt/include/flang-rt/runtime/format.h
+++ b/flang-rt/include/flang-rt/runtime/format.h
@@ -25,6 +25,8 @@ class Descriptor;
 
 namespace Fortran::runtime::io {
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 class IoStatementState;
 
 enum EditingFlags {
@@ -200,5 +202,8 @@ private:
   // must be last, may be incomplete
   Iteration stack_[maxMaxHeight];
 };
+
+RT_OFFLOAD_API_GROUP_END
+
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_FORMAT_H_

--- a/flang-rt/include/flang-rt/runtime/internal-unit.h
+++ b/flang-rt/include/flang-rt/runtime/internal-unit.h
@@ -18,6 +18,8 @@
 
 namespace Fortran::runtime::io {
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 class IoErrorHandler;
 
 // Points to (but does not own) a CHARACTER scalar or array for internal I/O.
@@ -55,5 +57,8 @@ private:
 
 extern template class InternalDescriptorUnit<Direction::Output>;
 extern template class InternalDescriptorUnit<Direction::Input>;
+
+RT_OFFLOAD_API_GROUP_END
+
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_INTERNAL_UNIT_H_

--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -28,6 +28,8 @@
 
 namespace Fortran::runtime::io {
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 class ExternalFileUnit;
 class ChildIo;
 
@@ -879,6 +881,8 @@ private:
   ConnectionState connection_;
   ExternalFileUnit *unit_{nullptr};
 };
+
+RT_OFFLOAD_API_GROUP_END
 
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_IO_STMT_H_

--- a/flang-rt/include/flang-rt/runtime/non-tbp-dio.h
+++ b/flang-rt/include/flang-rt/runtime/non-tbp-dio.h
@@ -32,6 +32,8 @@ class DerivedType;
 
 namespace Fortran::runtime::io {
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 struct NonTbpDefinedIo {
   const typeInfo::DerivedType &derivedType;
   void (*subroutine)(); // null means no non-TBP defined I/O here
@@ -51,6 +53,8 @@ struct NonTbpDefinedIoTable {
   // but the remaining specifics remain visible.
   bool ignoreNonTbpEntries{false};
 };
+
+RT_OFFLOAD_API_GROUP_END
 
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_NON_TBP_DIO_H_

--- a/flang-rt/include/flang-rt/runtime/work-queue.h
+++ b/flang-rt/include/flang-rt/runtime/work-queue.h
@@ -74,6 +74,8 @@ namespace Fortran::runtime {
 class Terminator;
 class WorkQueue;
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 // Ticket worker base classes
 
 template <typename TICKET> class ImmediateTicketRunner {
@@ -361,6 +363,7 @@ public:
       : ImmediateTicketRunner<DescriptorIoTicket>(*this),
         Elementwise{descriptor}, io_{io}, table_{table},
         anyIoTookPlace_{anyIoTookPlace} {}
+
   RT_API_ATTRS int Begin(WorkQueue &);
   RT_API_ATTRS int Continue(WorkQueue &);
   RT_API_ATTRS bool &anyIoTookPlace() { return anyIoTookPlace_; }
@@ -550,6 +553,8 @@ private:
   TicketList static_[numStatic_];
   TicketList *firstFree_{static_};
 };
+
+RT_OFFLOAD_API_GROUP_END
 
 } // namespace Fortran::runtime
 #endif // FLANG_RT_RUNTIME_WORK_QUEUE_H_

--- a/flang-rt/lib/runtime/edit-input.h
+++ b/flang-rt/lib/runtime/edit-input.h
@@ -15,6 +15,8 @@
 
 namespace Fortran::runtime::io {
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 RT_API_ATTRS bool EditIntegerInput(
     IoStatementState &, const DataEdit &, void *, int kind, bool isSigned);
 
@@ -48,6 +50,8 @@ extern template RT_API_ATTRS bool EditCharacterInput(
     IoStatementState &, const DataEdit &, char16_t *, std::size_t);
 extern template RT_API_ATTRS bool EditCharacterInput(
     IoStatementState &, const DataEdit &, char32_t *, std::size_t);
+
+RT_OFFLOAD_API_GROUP_END
 
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_EDIT_INPUT_H_

--- a/flang-rt/lib/runtime/edit-output.h
+++ b/flang-rt/lib/runtime/edit-output.h
@@ -25,6 +25,8 @@
 
 namespace Fortran::runtime::io {
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 // I, B, O, Z, and G output editing for INTEGER.
 // The DataEdit reference is const here (and elsewhere in this header) so that
 // one edit descriptor with a repeat factor may safely serve to edit
@@ -136,6 +138,8 @@ extern template class RealOutputEditing<8>;
 extern template class RealOutputEditing<10>;
 // TODO: double/double
 extern template class RealOutputEditing<16>;
+
+RT_OFFLOAD_API_GROUP_END
 
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_EDIT_OUTPUT_H_

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -46,6 +46,8 @@ extern RT_VAR_ATTRS ExternalFileUnit *defaultOutput; // unit 6
 extern RT_VAR_ATTRS ExternalFileUnit *errorOutput; // unit 0 extension
 RT_OFFLOAD_VAR_GROUP_END
 
+RT_OFFLOAD_API_GROUP_BEGIN
+
 #if defined(RT_USE_PSEUDO_FILE_UNIT)
 // A flavor of OpenFile class that pretends to be a terminal,
 // and only provides basic buffering of the output
@@ -297,6 +299,8 @@ private:
       u_;
   Fortran::common::optional<IoStatementState> io_;
 };
+
+RT_OFFLOAD_API_GROUP_END
 
 } // namespace Fortran::runtime::io
 #endif // FLANG_RT_RUNTIME_UNIT_H_

--- a/flang/include/flang/Decimal/decimal.h
+++ b/flang/include/flang/Decimal/decimal.h
@@ -65,6 +65,9 @@ enum DecimalConversionFlags {
 #define EXTRA_DECIMAL_CONVERSION_SPACE (1 + 1 + 2 * 16 - 1)
 
 #ifdef __cplusplus
+
+RT_OFFLOAD_API_GROUP_BEGIN
+
 template <int PREC>
 RT_API_ATTRS ConversionToDecimalResult ConvertToDecimal(char *, size_t,
     DecimalConversionFlags, int digits, enum FortranRounding rounding,
@@ -110,6 +113,9 @@ extern template RT_API_ATTRS ConversionToBinaryResult<64> ConvertToBinary<64>(
     const char *&, enum FortranRounding, const char *end);
 extern template RT_API_ATTRS ConversionToBinaryResult<113> ConvertToBinary<113>(
     const char *&, enum FortranRounding, const char *end);
+
+RT_OFFLOAD_API_GROUP_END
+
 } // namespace Fortran::decimal
 extern "C" {
 #define NS(x) Fortran::decimal::x


### PR DESCRIPTION
After the recent move to work queues, in certain cases when linking in the fortran runtime built for offload on AMDGPU as required in certain cases, we'll get missing symbols when linking. This PR tries to address this issue by encompassing more of the library in RT_OFFLOAD_API_GROUP_BEGIN, which has the affect of compiling these functions for AMDGPU, resolving the missing symbols.

This PR should address the following issue: https://github.com/llvm/llvm-project/issues/145888 