### PR TITLE
[NFC][TableGen] Change DecoderEmitter `insertBits` to use integer types only

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -43,17 +43,6 @@ public:
   DecoderUInt128() = default;
   DecoderUInt128(uint64_t Lo, uint64_t Hi = 0) : Lo(Lo), Hi(Hi) {}
   operator bool() const { return Lo || Hi; }
-  void insertBits(uint64_t SubBits, unsigned BitPosition, unsigned NumBits) {
-    assert(NumBits && NumBits <= 64);
-    assert(SubBits >> 1 >> (NumBits - 1) == 0);
-    assert(BitPosition < 128);
-    if (BitPosition < 64) {
-      Lo |= SubBits << BitPosition;
-      Hi |= SubBits >> 1 >> (63 - BitPosition);
-    } else {
-      Hi |= SubBits << (BitPosition - 64);
-    }
-  }
   uint64_t extractBitsAsZExtValue(unsigned NumBits,
                                   unsigned BitPosition) const {
     assert(NumBits && NumBits <= 64);
@@ -78,12 +67,7 @@ public:
   bool operator!=(const DecoderUInt128 &RHS) {
     return Lo != RHS.Lo || Hi != RHS.Hi;
   }
-  bool operator!=(const int &RHS) {
-    return *this != DecoderUInt128(RHS);
-  }
-  friend raw_ostream &operator<<(raw_ostream &OS, const DecoderUInt128 &RHS) {
-    return OS << APInt(128, {RHS.Lo, RHS.Hi});
-  }
+  bool operator!=(const int &RHS) { return *this != DecoderUInt128(RHS); }
 };
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The `insertBits` templated function generated by DecoderEmitter is called with variable `tmp` of type `TmpType` which is:

```
using TmpType = std::conditional_t<std::is_integral<InsnType>::value, InsnType, uint64_t>;
```

That is, `TmpType` is always an integral type. Change the generated `insertBits` to be valid only for integer types, and eliminate the unused `insertBits` function from `DecoderUInt128` in AMDGPUDisassembler.h

Additionally, drop some of the requirements `InsnType` must support as they no longer seem to be required.