### PR TITLE
[clang] Implemeent consteval for captured structured bindings.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -145,6 +145,8 @@ C++20 Feature Support
 - Fixed a crash with a defaulted spaceship (``<=>``) operator when the class
   contains a member declaration of vector type. Vector types cannot yet be
   compared directly, so this causes the operator to be deleted. (#GH137452)
+- Implement constant evaluation of lambdas that capture structured bindings.
+  (#GH145956)
 
 C++17 Feature Support
 ^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8951,7 +8951,7 @@ static bool EvaluateLValue(const Expr *E, LValue &Result, EvalInfo &Info,
 }
 
 bool LValueExprEvaluator::VisitDeclRefExpr(const DeclRefExpr *E) {
-  const NamedDecl *D = E->getDecl();
+  const ValueDecl *D = E->getDecl();
 
   // If we are within a lambda's call operator, check whether the 'VD' referred
   // to within 'E' actually represents a lambda-capture that maps to a
@@ -8966,8 +8966,7 @@ bool LValueExprEvaluator::VisitDeclRefExpr(const DeclRefExpr *E) {
     if (Info.checkingPotentialConstantExpression())
       return false;
 
-    if (auto *FD =
-            Info.CurrentCall->LambdaCaptureFields.lookup(cast<ValueDecl>(D))) {
+    if (auto *FD = Info.CurrentCall->LambdaCaptureFields.lookup(D)) {
       const auto *MD = cast<CXXMethodDecl>(Info.CurrentCall->Callee);
       return HandleLambdaCapture(Info, E, Result, MD, FD,
                                  FD->getType()->isReferenceType());

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -8952,6 +8952,28 @@ static bool EvaluateLValue(const Expr *E, LValue &Result, EvalInfo &Info,
 
 bool LValueExprEvaluator::VisitDeclRefExpr(const DeclRefExpr *E) {
   const NamedDecl *D = E->getDecl();
+
+  // If we are within a lambda's call operator, check whether the 'VD' referred
+  // to within 'E' actually represents a lambda-capture that maps to a
+  // data-member/field within the closure object, and if so, evaluate to the
+  // field or what the field refers to.
+  if (Info.CurrentCall && isLambdaCallOperator(Info.CurrentCall->Callee) &&
+      E->refersToEnclosingVariableOrCapture()) {
+    // We don't always have a complete capture-map when checking or inferring if
+    // the function call operator meets the requirements of a constexpr function
+    // - but we don't need to evaluate the captures to determine constexprness
+    // (dcl.constexpr C++17).
+    if (Info.checkingPotentialConstantExpression())
+      return false;
+
+    if (auto *FD =
+            Info.CurrentCall->LambdaCaptureFields.lookup(cast<ValueDecl>(D))) {
+      const auto *MD = cast<CXXMethodDecl>(Info.CurrentCall->Callee);
+      return HandleLambdaCapture(Info, E, Result, MD, FD,
+                                 FD->getType()->isReferenceType());
+    }
+  }
+
   if (isa<FunctionDecl, MSGuidDecl, TemplateParamObjectDecl,
           UnnamedGlobalConstantDecl>(D))
     return Success(cast<ValueDecl>(D));
@@ -8963,27 +8985,6 @@ bool LValueExprEvaluator::VisitDeclRefExpr(const DeclRefExpr *E) {
 }
 
 bool LValueExprEvaluator::VisitVarDecl(const Expr *E, const VarDecl *VD) {
-  // If we are within a lambda's call operator, check whether the 'VD' referred
-  // to within 'E' actually represents a lambda-capture that maps to a
-  // data-member/field within the closure object, and if so, evaluate to the
-  // field or what the field refers to.
-  if (Info.CurrentCall && isLambdaCallOperator(Info.CurrentCall->Callee) &&
-      isa<DeclRefExpr>(E) &&
-      cast<DeclRefExpr>(E)->refersToEnclosingVariableOrCapture()) {
-    // We don't always have a complete capture-map when checking or inferring if
-    // the function call operator meets the requirements of a constexpr function
-    // - but we don't need to evaluate the captures to determine constexprness
-    // (dcl.constexpr C++17).
-    if (Info.checkingPotentialConstantExpression())
-      return false;
-
-    if (auto *FD = Info.CurrentCall->LambdaCaptureFields.lookup(VD)) {
-      const auto *MD = cast<CXXMethodDecl>(Info.CurrentCall->Callee);
-      return HandleLambdaCapture(Info, E, Result, MD, FD,
-                                 FD->getType()->isReferenceType());
-    }
-  }
-
   CallStackFrame *Frame = nullptr;
   unsigned Version = 0;
   if (VD->hasLocalStorage()) {

--- a/clang/test/SemaCXX/cxx1z-constexpr-lambdas.cpp
+++ b/clang/test/SemaCXX/cxx1z-constexpr-lambdas.cpp
@@ -373,3 +373,31 @@ static_assert(
 }
 
 #endif
+
+#ifndef CPP14_AND_EARLIER
+namespace GH145956 {
+  constexpr int f() {
+    struct Pair { int first; int second; };
+    Pair p = {1, 2};
+    auto const& [key, value] = p;
+    return [&] { return key; }();
+#if __cpp_constexpr < 202002L
+    // expected-warning@-2 {{captured structured bindings are a C++20 extension}}
+    // expected-note@-4 {{'key' declared here}}
+#endif
+  }
+  static_assert(f() == 1);
+  constexpr auto retlambda() {
+    struct Pair { int first; int second; };
+    Pair p = {1, 2};
+    auto const& [key, value] = p;
+    return [=] { return key; };
+#if __cpp_constexpr < 202002L
+    // expected-warning@-2 {{captured structured bindings are a C++20 extension}}
+    // expected-note@-4 {{'key' declared here}}
+#endif
+  }
+  constexpr auto lambda = retlambda();
+  static_assert(lambda() == 1);
+}
+#endif


### PR DESCRIPTION
127bf44385424891eb04cff8e52d3f157fc2cb7c implemented most of the infrastructure for capturing structured bindings in lambdas, but missed one piece: constant evaluation of such lambdas. Refactor the code to handle this case.

Fixes #145956. Fixes #134897.