### PR TITLE
[lldb] Enable SWIG Doxygen Translation

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -14,6 +14,7 @@ add_custom_command(
   DEPENDS lldb-sbapi-dwarf-enums
   COMMAND ${SWIG_EXECUTABLE}
       ${SWIG_COMMON_FLAGS}
+      -doxygen
       -I${CMAKE_CURRENT_SOURCE_DIR}
       ${SWIG_EXTRA_FLAGS}
       -outdir ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
Enable SWIG support for translating Doxygen comments found in interface and header files into a target language's normal documentation language. This feature was introduced in SWIG 4.0 and currently only supports Python (and Java). Hand-written documentation still takes precedence.

SWIG documentation: https://www.swig.org/Doc4.0/Doxygen.html