### PR TITLE
[CIR] Add test for parsing bitfield_info attribute

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -489,28 +489,28 @@ def BitfieldInfoAttr : CIR_Attr<"BitfieldInfo", "bitfield_info"> {
       is 4 bits wide, starts at offset 0, and is signed.
   }];
   let parameters = (ins "mlir::StringAttr":$name,
-                        "mlir::Type":$storageType,
+                        "mlir::Type":$storage_type,
                         "uint64_t":$size,
                         "uint64_t":$offset,
-                        "bool":$isSigned);
+                        "bool":$is_signed);
 
   let assemblyFormat = [{`<` struct($name,
-                                    $storageType,
+                                    $storage_type,
                                     $size,
                                     $offset,
-                                    $isSigned)
+                                    $is_signed)
                          `>`
                         }];
 
   let builders = [
     AttrBuilder<(ins "llvm::StringRef":$name,
-                     "mlir::Type":$storageType,
+                     "mlir::Type":$storage_type,
                      "uint64_t":$size,
                      "uint64_t":$offset,
-                     "bool":$isSigned
+                     "bool":$is_signed
                      ), [{
-      return $_get($_ctxt, mlir::StringAttr::get($_ctxt, name), storageType,
-                   size, offset, isSigned);
+      return $_get($_ctxt, mlir::StringAttr::get($_ctxt, name), storage_type,
+                   size, offset, is_signed);
     }]>
   ];
 }

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -13,7 +13,7 @@ typedef struct {
 } A;
 
 // CIR-DAG:  !rec_A = !cir.record<struct "A" packed padded {!s8i, !s8i, !s8i, !u16i, !cir.array<!u8i x 3>}>
-// CIR-DAG:  #bfi_more_bits = #cir.bitfield_info<name = "more_bits", storageType = !u16i, size = 4, offset = 3, isSigned = false>
+// CIR-DAG:  #bfi_more_bits = #cir.bitfield_info<name = "more_bits", storage_type = !u16i, size = 4, offset = 3, is_signed = false>
 // LLVM-DAG: %struct.A = type <{ i8, i8, i8, i16, [3 x i8] }>
 // OGCG-DAG: %struct.A = type <{ i8, i8, i8, i16, [3 x i8] }>
 
@@ -35,7 +35,7 @@ typedef struct {
   int e : 15;
   unsigned f; // type other than int above, not a bitfield
 } S;
-// CIR-DAG:  #bfi_c = #cir.bitfield_info<name = "c", storageType = !u64i, size = 17, offset = 32, isSigned = true>
+// CIR-DAG:  #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u64i, size = 17, offset = 32, is_signed = true>
 // CIR-DAG:  !rec_S = !cir.record<struct "S" {!u64i, !u16i, !u32i}>
 // LLVM-DAG: %struct.S = type { i64, i16, i32 }
 // OGCG-DAG: %struct.S = type { i64, i16, i32 }

--- a/clang/test/CIR/CodeGen/bitfields.cpp
+++ b/clang/test/CIR/CodeGen/bitfields.cpp
@@ -14,7 +14,7 @@ typedef struct {
   unsigned f; // type other than int above, not a bitfield
 } S;
 // CIR-DAG:  !rec_S = !cir.record<struct "S" {!u64i, !u16i, !u32i}>
-// CIR-DAG:  #bfi_c = #cir.bitfield_info<name = "c", storageType = !u64i, size = 17, offset = 32, isSigned = true>
+// CIR-DAG:  #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u64i, size = 17, offset = 32, is_signed = true>
 // LLVM-DAG: %struct.S = type { i64, i16, i32 }
 // OGCG-DAG: %struct.S = type { i64, i16, i32 }
 

--- a/clang/test/CIR/IR/bitfield_info.cir
+++ b/clang/test/CIR/IR/bitfield_info.cir
@@ -1,0 +1,20 @@
+// RUN: cir-opt %s | FileCheck %s
+
+!s32i = !cir.int<s, 32>
+!u32i = !cir.int<u, 32>
+
+
+!rec_S = !cir.record<struct "S" {!u32i}>
+#bfi_c = #cir.bitfield_info<name = "c", storage_type = !u32i, size = 17, offset = 15, is_signed = true>
+
+// CHECK: #bfi_c = #cir.bitfield_info<name = "c", storage_type = !u32i, size = 17, offset = 15, is_signed = true>
+
+// Use bitfield to enforce printing the attribute
+cir.func dso_local @init(%arg0: !cir.ptr<!rec_S> ){
+  %0 = cir.alloca !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>, ["s", init] {alignment = 8 : i64}
+  cir.store %arg0, %0 : !cir.ptr<!rec_S>, !cir.ptr<!cir.ptr<!rec_S>>
+  %1 = cir.load align(8) %0 : !cir.ptr<!cir.ptr<!rec_S>>, !cir.ptr<!rec_S>
+  %2 = cir.get_member %1[0] {name = "c"} : !cir.ptr<!rec_S> -> !cir.ptr<!u32i>
+  %3 = cir.get_bitfield(#bfi_c, %2 : !cir.ptr<!u32i>) -> !s32i
+  cir.return
+}


### PR DESCRIPTION
This PR adds a test for parsing the bitfield_info attribute. Additionally, it updates the `storage_type` and `is_signed` fields to match the style used in the incubator ASM format guide.