### PR TITLE
Improve file patterns for some backends.

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -784,18 +784,20 @@ backend:NVPTX:
 backend:MIPS:
   - '**/*mips*'
   - '**/*Mips*'
+  - '**/*mips*/**'
+  - '**/*Mips*/**'
 
 backend:RISC-V:
-  - clang/**/*riscv*
-  - clang/**/*RISCV*
-  - llvm/**/*riscv*
-  - llvm/**/*RISCV*
+  - '**/*riscv*'
+  - '**/*RISCV*'
+  - '**/*riscv*/**'
+  - '**/*RISCV*/**'
 
 backend:Xtensa:
-  - clang/**/*xtensa*
-  - clang/**/*Xtensa*
-  - llvm/**/*xtensa*
-  - llvm/**/*Xtensa*
+  - '**/*xtensa*'
+  - '**/*Xtensa*'
+  - '**/*xtensa*/**'
+  - '**/*Xtensa*/**'
 
 lld:coff:
   - lld/**/COFF/**


### PR DESCRIPTION
I noticed that one of my PRs, #147624, did not get automatically
labelled with `backend:RISC-V` when it touched a test under
`llvm/test/CodeGen/RISCV`. This seems to be because the pattern only
looks for files named `*RISCV*` or `*riscv* and not necessarily files
in a directory named like that. To fix that, let's make RISC-V use
a more accepting pattern, similar to AMDGPU, and do the same for two
other backends.
