### PR TITLE
[SelectionDAG] isADDLike should also include XORs that have no common bits set.

### DIFF
--- a/llvm/include/llvm/CodeGen/SelectionDAG.h
+++ b/llvm/include/llvm/CodeGen/SelectionDAG.h
@@ -2260,8 +2260,9 @@ public:
   /// Return true if the specified operand is an ISD::OR or ISD::XOR node
   /// that can be treated as an ISD::ADD node.
   /// or(x,y) == add(x,y) iff haveNoCommonBitsSet(x,y)
-  /// xor(x,y) == add(x,y) iff isMinSignedConstant(y) && !NoWrap
-  /// If \p NoWrap is true, this will not match ISD::XOR.
+  /// xor(x,y) == add(x,y) if isMinSignedConstant(y) && !NoWrap, or
+  /// haveNoCommonBitsSet(x,y) If \p NoWrap is true, this will not match
+  /// isMinSignedConstant(y) && !NoWrap
   LLVM_ABI bool isADDLike(SDValue Op, bool NoWrap = false) const;
 
   /// Return true if the specified operand is an ISD::ADD with a ConstantSDNode

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5677,7 +5677,8 @@ bool SelectionDAG::isADDLike(SDValue Op, bool NoWrap) const {
     return Op->getFlags().hasDisjoint() ||
            haveNoCommonBitsSet(Op.getOperand(0), Op.getOperand(1));
   if (Opcode == ISD::XOR)
-    return !NoWrap && isMinSignedConstant(Op.getOperand(1));
+    return (!NoWrap && isMinSignedConstant(Op.getOperand(1))) ||
+           haveNoCommonBitsSet(Op.getOperand(0), Op.getOperand(1));
   return false;
 }
 


### PR DESCRIPTION
A disjoint or is also a disjoint xor, because (x | y) - (x & y) = x ^ y, and a disjoint or by definition has (x & y) as 0.