### PR TITLE
[MLGO] Use SPDX License Expression

### DIFF
--- a/llvm/utils/mlgo-utils/pyproject.toml
+++ b/llvm/utils/mlgo-utils/pyproject.toml
@@ -8,10 +8,7 @@ description = "Tooling for ML in LLVM"
 readme = "README.md"
 requires-python = ">=3.8"
 dynamic = ["version"]
-license = {text = "Apache-2.0 WITH LLVM-exception"}
-classifiers = [
-  "License :: OSI Approved :: Apache Software License"
-]
+license = "Apache-2.0 WITH LLVM-exception"
 
 [tool.setuptools.dynamic]
 version = {attr = "mlgo.__version__"}


### PR DESCRIPTION
Using license classifiers and a text based license was deprecated at some point and now gives a warning saying it is unsupported. The text that we had was just the SPDX expression, although misplaced apparently. Use the SPDX expression properly.