### PR TITLE
[SelectionDAG] Correctly Mark Required Analyses

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGISel.cpp
@@ -396,9 +396,7 @@ void SelectionDAGISelLegacy::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addRequired<StackProtector>();
   AU.addPreserved<GCModuleInfo>();
   AU.addRequired<TargetLibraryInfoWrapperPass>();
-#ifndef NDEBUG
   AU.addRequired<TargetTransformInfoWrapperPass>();
-#endif
   AU.addRequired<AssumptionCacheTracker>();
   if (UseMBPI && OptLevel != CodeGenOptLevel::None)
       AU.addRequired<BranchProbabilityInfoWrapperPass>();


### PR DESCRIPTION
llvm/llvm-project#147560 changed when the legacy SelectionDAG pass needs TargetTransformInfoWrapperPass to always require it (rather than only when assertions are enabled). `SelectionDAGISelLegacy::getAnalysisUsage` was not updated in that PR, which was causing crashes on assertions-disabled builds, which are hard to track down.

This makes the required update, which should avoid crashes being seen on some buildbots and by some users.