### PR TITLE
RuntimeLibcalls: Stop using defset for default calls

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -430,7 +430,6 @@ def OBJC_SYNC_EXIT : RuntimeLibcall;
 // Define implementation default libcalls
 //--------------------------------------------------------------------
 
-defset list<RuntimeLibcallImpl> AllDefaultRuntimeLibcallImpls = {
 let IsDefault = true in {
 
 //--------------------------------------------------------------------
@@ -936,7 +935,6 @@ def memset : RuntimeLibcallImpl<MEMSET>;
 def calloc : RuntimeLibcallImpl<CALLOC>;
 
 } // End let IsDefault = true
-} // End defset AllDefaultRuntimeLibcallImpls
 
 //--------------------------------------------------------------------
 // Define implementation other libcalls
@@ -1027,8 +1025,8 @@ defset list<RuntimeLibcallImpl> LibmF128FiniteLibcalls = {
 // unreasonable defaults like reporting f80 calls on most targets when
 // they are relevant to only one.
 
-defvar AllDefaultLibCalls =
-    !foreach(entry, AllDefaultRuntimeLibcallImpls, entry.Provides);
+defvar AllDefaultRuntimeLibcallImpls
+  = !filter(entry, !instances<RuntimeLibcallImpl>(), entry.IsDefault);
 
 // Exist in libgcc and compiler-rt for 64-bit targets, or if
 // COMPILER_RT_ENABLE_SOFTWARE_INT128.


### PR DESCRIPTION
This is redundant with the IsDefault field, so avoid a really
long enclosing pair of braces. This will make it easier to gradually
remove calls from the default set.