### PR TITLE
RuntimeLibcalls: Avoid adding ppcf128 calls to non-ppc targets

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1040,14 +1040,20 @@ defvar CompilerRTOnlyInt128Libcalls = [
   __mulodi4
 ];
 
-defvar DefaultRuntimeLibcallImpls =
-  !listremove(!listremove(AllDefaultRuntimeLibcallImpls,
-                          Int128RTLibcalls),
-                          CompilerRTOnlyInt128Libcalls);
+defvar DefaultRuntimeLibcallImpls_ppcf128 =
+    !filter(entry, AllDefaultRuntimeLibcallImpls,
+            !match(!cast<string>(entry.Provides), "PPCF128"));
 
 defvar DefaultRuntimeLibcallImpls_f128 =
-    !filter(entry, DefaultRuntimeLibcallImpls,
+    !filter(entry, AllDefaultRuntimeLibcallImpls,
             !match(!cast<string>(entry.Provides), "_F128"));
+
+defvar DefaultRuntimeLibcallImpls =
+  !listremove(
+    !listremove(
+        !listremove(AllDefaultRuntimeLibcallImpls, Int128RTLibcalls),
+                    CompilerRTOnlyInt128Libcalls),
+                    DefaultRuntimeLibcallImpls_ppcf128);
 
 defvar DefaultRuntimeLibcallImpls_atomic =
     !filter(entry, DefaultRuntimeLibcallImpls,
@@ -1900,6 +1906,7 @@ def PPCSystemLibrary
            (sub DefaultRuntimeLibcallImpls, memcpy,
                 DefaultRuntimeLibcallImpls_f128),
            __extendkftf2, __trunctfkf2,
+           DefaultRuntimeLibcallImpls_ppcf128,
            LibmF128Libcalls, AIX32Calls, AIX64Calls,
            AvailableIf<memcpy, isNotAIX>,
            LibcallImpls<(add Int128RTLibcalls), isPPC64>)>;


### PR DESCRIPTION
Filter out PPCF128 calls from the default set, and only add them
back to PPC.