### PR TITLE
RuntimeLibcalls: Avoid adding f80 calls to default set

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1040,6 +1040,10 @@ defvar CompilerRTOnlyInt128Libcalls = [
   __mulodi4
 ];
 
+defvar DefaultRuntimeLibcallImpls_f80 =
+    !filter(entry, AllDefaultRuntimeLibcallImpls,
+            !match(!cast<string>(entry.Provides), "F80"));
+
 defvar DefaultRuntimeLibcallImpls_ppcf128 =
     !filter(entry, AllDefaultRuntimeLibcallImpls,
             !match(!cast<string>(entry.Provides), "PPCF128"));
@@ -1049,10 +1053,12 @@ defvar DefaultRuntimeLibcallImpls_f128 =
             !match(!cast<string>(entry.Provides), "_F128"));
 
 defvar DefaultRuntimeLibcallImpls =
+!listremove(
   !listremove(
     !listremove(
         !listremove(AllDefaultRuntimeLibcallImpls, Int128RTLibcalls),
                     CompilerRTOnlyInt128Libcalls),
+                    DefaultRuntimeLibcallImpls_f80),
                     DefaultRuntimeLibcallImpls_ppcf128);
 
 defvar DefaultRuntimeLibcallImpls_atomic =
@@ -1985,6 +1991,21 @@ def _aulldiv : RuntimeLibcallImpl<UDIV_I64>;
 def _allrem : RuntimeLibcallImpl<SREM_I64>;
 def _aullrem : RuntimeLibcallImpl<UREM_I64>;
 def _allmul : RuntimeLibcallImpl<MUL_I64>;
+
+//===----------------------------------------------------------------------===//
+// X86 Runtime Libcalls
+//===----------------------------------------------------------------------===//
+
+def isX86_32 : RuntimeLibcallPredicate<"TT.getArch() == Triple::x86">;
+def isX86_64 : RuntimeLibcallPredicate<"TT.getArch() == Triple::x86_64">;
+
+def X86_32SystemLibrary
+    : SystemRuntimeLibrary<isX86_32,
+      (add DefaultLibcallImpls32, DefaultRuntimeLibcallImpls_f80)>;
+
+def X86_64SystemLibrary
+    : SystemRuntimeLibrary<isX86_64,
+      (add DefaultLibcallImpls64, DefaultRuntimeLibcallImpls_f80)>;
 
 //===----------------------------------------------------------------------===//
 // XCore Runtime Libcalls


### PR DESCRIPTION
Starts adding a stub X86 configuration which doesn't attempt
the system specific pieces yet. This is mostly to have a point
to add back in the f80 calls so they can be removed from every
other target.