### PR TITLE
[clang][bytecode] Diagnose constexpr-unknown dummy pointers differently

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1093,8 +1093,18 @@ bool CheckDummy(InterpState &S, CodePtr OpPC, const Pointer &Ptr,
 
   const Descriptor *Desc = Ptr.getDeclDesc();
   const ValueDecl *D = Desc->asValueDecl();
+
   if (!D)
     return false;
+
+  // Diagnose constexpr-unknown values as differently.
+  if (S.getLangOpts().CPlusPlus23 && isConstexprUnknown(Ptr)) {
+    S.FFDiag(S.Current->getExpr(OpPC),
+             diag::note_constexpr_access_unknown_variable, 1)
+        << AK << D;
+    S.Note(D->getLocation(), diag::note_declared_at);
+    return false;
+  }
 
   if (AK == AK_Read || AK == AK_Increment || AK == AK_Decrement)
     return diagnoseUnknownDecl(S, OpPC, D);

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -35,7 +35,7 @@ constexpr int how_many(Swim& swam) {
   return (p + 1 - 1)->phelps();
 }
 
-void splash(Swim& swam) {                 // nointerpreter-note {{declared here}}
+void splash(Swim& swam) {                 // expected-note {{declared here}}
   static_assert(swam.phelps() == 28);     // ok
   static_assert((&swam)->phelps() == 28); // ok
   Swim* pswam = &swam;                    // expected-note {{declared here}}
@@ -46,7 +46,7 @@ void splash(Swim& swam) {                 // nointerpreter-note {{declared here}
   static_assert(swam.lochte() == 12);     // expected-error {{static assertion expression is not an integral constant expression}} \
                                           // nointerpreter-note {{virtual function called on object 'swam' whose dynamic type is not constant}}
   static_assert(swam.coughlin == 12);     // expected-error {{static assertion expression is not an integral constant expression}} \
-                                          // nointerpreter-note {{read of variable 'swam' whose value is not known}}
+                                          // expected-note {{read of variable 'swam' whose value is not known}}
 }
 
 extern Swim dc;
@@ -256,14 +256,14 @@ namespace uninit_reference_used {
 
 namespace param_reference {
   constexpr int arbitrary = -12345;
-  constexpr void f(const int &x = arbitrary) { // nointerpreter-note 3 {{declared here}} interpreter-note {{declared here}}
+  constexpr void f(const int &x = arbitrary) { // expected-note 3{{declared here}}
     constexpr const int &v1 = x; // expected-error {{must be initialized by a constant expression}} \
     // expected-note {{reference to 'x' is not a constant expression}}
     constexpr const int &v2 = (x, arbitrary); // expected-warning {{left operand of comma operator has no effect}}
     constexpr int v3 = x; // expected-error {{must be initialized by a constant expression}} \
-                          // nointerpreter-note {{read of variable 'x' whose value is not known}}
+                          // expected-note {{read of variable 'x' whose value is not known}}
     static_assert(x==arbitrary); // expected-error {{static assertion expression is not an integral constant expression}} \
-                                 // nointerpreter-note {{read of variable 'x' whose value is not known}}
+                                 // expected-note {{read of variable 'x' whose value is not known}}
     static_assert(&x - &x == 0);
   }
 }


### PR DESCRIPTION
To adapt to recent changes in the current interpreter.