### PR TITLE
[RISCV] Add UnsupportedSchedXXX for vendor extensions package

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedAndes45.td
@@ -330,14 +330,10 @@ def : ReadAdvance<ReadCSR, 0>;
 defm : UnsupportedSchedQ;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedV;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZabha;
 defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZvk;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedGenericOOO.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedGenericOOO.td
@@ -497,9 +497,5 @@ defm : UnsupportedSchedV;
 defm : UnsupportedSchedZfaWithQ;
 defm : UnsupportedSchedZvk;
 defm : UnsupportedSchedSFB;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedMIPSP8700.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedMIPSP8700.td
@@ -273,10 +273,6 @@ defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZfhmin;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZabha;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZvk;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedRocket.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedRocket.td
@@ -262,10 +262,6 @@ defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZfhmin;
 defm : UnsupportedSchedSFB;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZvk;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP400.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP400.td
@@ -1238,9 +1238,5 @@ defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZfa;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP500.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP500.td
@@ -358,9 +358,5 @@ defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZvk;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP600.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP600.td
@@ -1494,9 +1494,5 @@ defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZfa;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSiFiveP800.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFiveP800.td
@@ -1183,9 +1183,5 @@ defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZfaWithQ;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSpacemitX60.td
@@ -345,15 +345,11 @@ def : ReadAdvance<ReadSingleBitImm, 0>;
 // Unsupported extensions
 defm : UnsupportedSchedQ;
 defm : UnsupportedSchedV;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZabha;
 defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZvk;
 defm : UnsupportedSchedSFB;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR1.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR1.td
@@ -116,10 +116,6 @@ defm : UnsupportedSchedZbs;
 defm : UnsupportedSchedZbkb;
 defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedZfa;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZvk;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR345.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR345.td
@@ -182,11 +182,6 @@ multiclass SCR_Other {
 multiclass SCR_Unsupported :
   UnsupportedSchedSFB,
   UnsupportedSchedV,
-  UnsupportedSchedXsfvcp,
-  UnsupportedSchedXSfvfnrclipxfqf,
-  UnsupportedSchedXSfvfwmaccqqq,
-  UnsupportedSchedXSfvqmaccdod,
-  UnsupportedSchedXSfvqmaccqoq,
   UnsupportedSchedZabha,
   UnsupportedSchedZba,
   UnsupportedSchedZbb,
@@ -195,7 +190,8 @@ multiclass SCR_Unsupported :
   UnsupportedSchedZbkb,
   UnsupportedSchedZbkx,
   UnsupportedSchedZfa,
-  UnsupportedSchedZvk;
+  UnsupportedSchedZvk,
+  UnsupportedSchedXsf;
 
 multiclass SCR3_Unsupported :
   SCR_Unsupported,

--- a/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSyntacoreSCR7.td
@@ -244,15 +244,11 @@ multiclass SCR7_Unsupported {
   defm : UnsupportedSchedQ;
   defm : UnsupportedSchedSFB;
   defm : UnsupportedSchedV;
-  defm : UnsupportedSchedXsfvcp;
-  defm : UnsupportedSchedXSfvfnrclipxfqf;
-  defm : UnsupportedSchedXSfvfwmaccqqq;
-  defm : UnsupportedSchedXSfvqmaccdod;
-  defm : UnsupportedSchedXSfvqmaccqoq;
   defm : UnsupportedSchedZabha;
   defm : UnsupportedSchedZfa;
   defm : UnsupportedSchedZfhmin;
   defm : UnsupportedSchedZvk;
+  defm : UnsupportedSchedXsf;
 }
 
 

--- a/llvm/lib/Target/RISCV/RISCVSchedTTAscalonD8.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedTTAscalonD8.td
@@ -320,11 +320,6 @@ def : ReadAdvance<ReadSingleBitImm, 0>;
 // Unsupported extensions
 defm : UnsupportedSchedQ;
 defm : UnsupportedSchedV;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZabha;
 defm : UnsupportedSchedZbc;
 defm : UnsupportedSchedZbkb;
@@ -332,4 +327,5 @@ defm : UnsupportedSchedZbkx;
 defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZvk;
 defm : UnsupportedSchedSFB;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedXiangShanNanHu.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedXiangShanNanHu.td
@@ -312,10 +312,6 @@ defm : UnsupportedSchedZfa;
 defm : UnsupportedSchedZfhmin;
 defm : UnsupportedSchedSFB;
 defm : UnsupportedSchedZabha;
-defm : UnsupportedSchedXsfvcp;
-defm : UnsupportedSchedXSfvfnrclipxfqf;
-defm : UnsupportedSchedXSfvfwmaccqqq;
-defm : UnsupportedSchedXSfvqmaccdod;
-defm : UnsupportedSchedXSfvqmaccqoq;
 defm : UnsupportedSchedZvk;
+defm : UnsupportedSchedXsf;
 }

--- a/llvm/lib/Target/RISCV/RISCVSchedule.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedule.td
@@ -519,3 +519,12 @@ include "RISCVScheduleZb.td"
 include "RISCVScheduleV.td"
 include "RISCVScheduleXSf.td"
 include "RISCVScheduleZvk.td"
+
+// Vendor Extensions
+multiclass UnsupportedSchedXsf {
+  defm : UnsupportedSchedXsfvcp;
+  defm : UnsupportedSchedXSfvfnrclipxfqf;
+  defm : UnsupportedSchedXSfvfwmaccqqq;
+  defm : UnsupportedSchedXSfvqmaccdod;
+  defm : UnsupportedSchedXSfvqmaccqoq;
+}


### PR DESCRIPTION
There will be more schedule definitions for vendor extentions and
we need to add these `UnsupportedSchedXXX` to exsiting models every
time we add new schedule definitions.

The fact is that each vendor will barely implement other vendors'
extensions, so we can package these definitions into one.
