### PR TITLE
Fix Doxygen comment

### DIFF
--- a/llvm/include/llvm/Support/ErrorHandling.h
+++ b/llvm/include/llvm/Support/ErrorHandling.h
@@ -155,7 +155,7 @@ LLVM_ABI void install_out_of_memory_new_handler();
 ///   support such hints, prints a reduced message instead and aborts the
 ///   program.
 /// * When "OFF", a builtin_trap is emitted instead of an
-//    optimizer hint or printing a reduced message.
+///   optimizer hint or printing a reduced message.
 ///
 /// Use this instead of assert(0). It conveys intent more clearly, suppresses
 /// diagnostics for unreachable code paths, and allows compilers to omit


### PR DESCRIPTION
One line in Doxygen comment block is a regular `//` comment and is skipped by Doxygen leading to a phrase ("optimizer hint or printing a reduced message.") missing from resulting [documentation](https://llvm.org/doxygen/llvm_2Support_2ErrorHandling_8h.html#ace243f5c25697a1107cce46626b3dc94):

![image](https://github.com/user-attachments/assets/03601ba3-e66d-4c52-b9c6-39f4dd78e558)