### PR TITLE
[libc++] Add ABI flag to make __tree nodes more compact

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -925,6 +925,7 @@ set(files
   __utility/no_destroy.h
   __utility/pair.h
   __utility/piecewise_construct.h
+  __utility/pointer_int_pair.h
   __utility/priority_tag.h
   __utility/private_constructor_tag.h
   __utility/rel_ops.h

--- a/libcxx/include/__bit/bit_log2.h
+++ b/libcxx/include/__bit/bit_log2.h
@@ -22,7 +22,7 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp __bit_log2(_Tp __t) _NOEXCEPT {
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Tp __bit_log2(_Tp __t) _NOEXCEPT {
   static_assert(__is_unsigned_integer_v<_Tp>, "__bit_log2 requires an unsigned integer type");
   _LIBCPP_ASSERT_INTERNAL(__t != 0, "logarithm of 0 is undefined");
   return numeric_limits<_Tp>::digits - 1 - std::__countl_zero(__t);

--- a/libcxx/include/__bit/countl.h
+++ b/libcxx/include/__bit/countl.h
@@ -23,7 +23,7 @@ _LIBCPP_PUSH_MACROS
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 int __countl_zero(_Tp __t) _NOEXCEPT {
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR int __countl_zero(_Tp __t) _NOEXCEPT {
   static_assert(__is_unsigned_integer_v<_Tp>, "__countl_zero requires an unsigned integer type");
   return __builtin_clzg(__t, numeric_limits<_Tp>::digits);
 }

--- a/libcxx/include/__configuration/abi.h
+++ b/libcxx/include/__configuration/abi.h
@@ -75,6 +75,7 @@
 #  define _LIBCPP_ABI_OPTIMIZED_FUNCTION
 #  define _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
 #  define _LIBCPP_ABI_STRING_OPTIMIZED_EXTERNAL_INSTANTIATION
+#  define _LIBCPP_ABI_TREE_POINTER_INT_PAIR
 #  define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_ARRAY
 #  define _LIBCPP_ABI_USE_WRAP_ITER_IN_STD_STRING_VIEW
 #  define _LIBCPP_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
@@ -97,6 +98,8 @@
 #    define _LIBCPP_DEPRECATED_ABI_DISABLE_PAIR_TRIVIAL_COPY_CTOR
 #  endif
 #endif
+
+#define _LIBCPP_ABI_TREE_POINTER_INT_PAIR
 
 // We had some bugs where we use [[no_unique_address]] together with construct_at,
 // which causes UB as the call on construct_at could write to overlapping subobjects

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -83,6 +83,11 @@ class __tree_node;
 template <class _Key, class _Value>
 struct __value_type;
 
+enum class __tree_color : bool {
+  __red = false,
+  __black = true,
+};
+
 /*
 
 _NodePtr algorithms
@@ -108,7 +113,7 @@ __root, have a non-null __parent_ field.
 // Precondition:  __x != nullptr.
 template <class _NodePtr>
 inline _LIBCPP_HIDE_FROM_ABI bool __tree_is_left_child(_NodePtr __x) _NOEXCEPT {
-  return __x == __x->__parent_->__left_;
+  return __x == __x->__get_parent()->__left_;
 }
 
 // Determines if the subtree rooted at __x is a proper red black subtree.  If
@@ -116,6 +121,8 @@ inline _LIBCPP_HIDE_FROM_ABI bool __tree_is_left_child(_NodePtr __x) _NOEXCEPT {
 //    __x is an improper subtree, returns 0.
 template <class _NodePtr>
 unsigned __tree_sub_invariant(_NodePtr __x) {
+  using enum __tree_color;
+
   if (__x == nullptr)
     return 1;
   // parent consistency checked by caller
@@ -129,10 +136,10 @@ unsigned __tree_sub_invariant(_NodePtr __x) {
   if (__x->__left_ == __x->__right_ && __x->__left_ != nullptr)
     return 0;
   // If this is red, neither child can be red
-  if (!__x->__is_black_) {
-    if (__x->__left_ && !__x->__left_->__is_black_)
+  if (__x->__color_ == __red) {
+    if (__x->__left_ && __x->__left_->__color_ == __red)
       return 0;
-    if (__x->__right_ && !__x->__right_->__is_black_)
+    if (__x->__right_ && __x->__right_->__color_ == __red)
       return 0;
   }
   unsigned __h = std::__tree_sub_invariant(__x->__left_);
@@ -140,7 +147,7 @@ unsigned __tree_sub_invariant(_NodePtr __x) {
     return 0; // invalid left subtree
   if (__h != std::__tree_sub_invariant(__x->__right_))
     return 0;                    // invalid or different height right subtree
-  return __h + __x->__is_black_; // return black height of this node
+  return __h + (__x->__color_ == __black ? 1 : 0); // return black height of this node
 }
 
 // Determines if the red black tree rooted at __root is a proper red black tree.
@@ -156,7 +163,7 @@ _LIBCPP_HIDE_FROM_ABI bool __tree_invariant(_NodePtr __root) {
   if (!std::__tree_is_left_child(__root))
     return false;
   // root must be black
-  if (!__root->__is_black_)
+  if (__root->__color_ == __tree_color::__red)
     return false;
   // do normal node checks
   return std::__tree_sub_invariant(__root) != 0;
@@ -203,7 +210,7 @@ inline _LIBCPP_HIDE_FROM_ABI _EndNodePtr __tree_next_iter(_NodePtr __x) _NOEXCEP
     return static_cast<_EndNodePtr>(std::__tree_min(__x->__right_));
   while (!std::__tree_is_left_child(__x))
     __x = __x->__parent_unsafe();
-  return static_cast<_EndNodePtr>(__x->__parent_);
+  return static_cast<_EndNodePtr>(__x->__get_parent());
 }
 
 // Returns:  pointer to the previous in-order node before __x.
@@ -247,9 +254,9 @@ _LIBCPP_HIDE_FROM_ABI void __tree_left_rotate(_NodePtr __x) _NOEXCEPT {
   __x->__right_ = __y->__left_;
   if (__x->__right_ != nullptr)
     __x->__right_->__set_parent(__x);
-  __y->__parent_ = __x->__parent_;
+  __y->__set_parent(__x->__get_parent());
   if (std::__tree_is_left_child(__x))
-    __x->__parent_->__left_ = __y;
+    __x->__get_parent()->__left_ = __y;
   else
     __x->__parent_unsafe()->__right_ = __y;
   __y->__left_ = __x;
@@ -266,9 +273,9 @@ _LIBCPP_HIDE_FROM_ABI void __tree_right_rotate(_NodePtr __x) _NOEXCEPT {
   __x->__left_ = __y->__right_;
   if (__x->__left_ != nullptr)
     __x->__left_->__set_parent(__x);
-  __y->__parent_ = __x->__parent_;
+  __y->__set_parent(__x->__get_parent());
   if (std::__tree_is_left_child(__x))
-    __x->__parent_->__left_ = __y;
+    __x->__get_parent()->__left_ = __y;
   else
     __x->__parent_unsafe()->__right_ = __y;
   __y->__right_ = __x;
@@ -286,46 +293,47 @@ template <class _NodePtr>
 _LIBCPP_HIDE_FROM_ABI void __tree_balance_after_insert(_NodePtr __root, _NodePtr __x) _NOEXCEPT {
   _LIBCPP_ASSERT_INTERNAL(__root != nullptr, "Root of the tree shouldn't be null");
   _LIBCPP_ASSERT_INTERNAL(__x != nullptr, "Can't attach null node to a leaf");
-  __x->__is_black_ = __x == __root;
-  while (__x != __root && !__x->__parent_unsafe()->__is_black_) {
-    // __x->__parent_ != __root because __x->__parent_->__is_black == false
+  using enum __tree_color;
+  __x->__set_color(__x == __root ? __black : __red);
+  while (__x != __root && __x->__parent_unsafe()->__get_color() == __red) {
+    // __x->__parent_ != __root because __x->__parent_->__get_color() == __red
     if (std::__tree_is_left_child(__x->__parent_unsafe())) {
       _NodePtr __y = __x->__parent_unsafe()->__parent_unsafe()->__right_;
-      if (__y != nullptr && !__y->__is_black_) {
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = true;
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = __x == __root;
-        __y->__is_black_ = true;
+      if (__y != nullptr && __y->__get_color() == __red) {
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__black);
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__x == __root ? __black : __red);
+        __y->__set_color(__black);
       } else {
         if (!std::__tree_is_left_child(__x)) {
           __x = __x->__parent_unsafe();
           std::__tree_left_rotate(__x);
         }
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = true;
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = false;
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__black);
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__red);
         std::__tree_right_rotate(__x);
         break;
       }
     } else {
-      _NodePtr __y = __x->__parent_unsafe()->__parent_->__left_;
-      if (__y != nullptr && !__y->__is_black_) {
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = true;
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = __x == __root;
-        __y->__is_black_ = true;
+      _NodePtr __y = __x->__parent_unsafe()->__get_parent()->__left_;
+      if (__y != nullptr && __y->__get_color() == __red) {
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__black);
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__x == __root ? __black : __red);
+        __y->__set_color(__black);
       } else {
         if (std::__tree_is_left_child(__x)) {
           __x = __x->__parent_unsafe();
           std::__tree_right_rotate(__x);
         }
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = true;
-        __x              = __x->__parent_unsafe();
-        __x->__is_black_ = false;
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__black);
+        __x = __x->__parent_unsafe();
+        __x->__set_color(__red);
         std::__tree_left_rotate(__x);
         break;
       }
@@ -343,6 +351,9 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
   _LIBCPP_ASSERT_INTERNAL(__root != nullptr, "Root node should not be null");
   _LIBCPP_ASSERT_INTERNAL(__z != nullptr, "The node to remove should not be null");
   _LIBCPP_ASSERT_INTERNAL(std::__tree_invariant(__root), "The tree invariants should hold");
+
+  using enum __tree_color;
+
   // __z will be removed from the tree.  Client still needs to destruct/deallocate it
   // __y is either __z, or if __z has two children, __tree_next(__z).
   // __y will have at most one child.
@@ -354,9 +365,9 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
   _NodePtr __w = nullptr;
   // link __x to __y's parent, and find __w
   if (__x != nullptr)
-    __x->__parent_ = __y->__parent_;
+    __x->__set_parent(__y->__get_parent());
   if (std::__tree_is_left_child(__y)) {
-    __y->__parent_->__left_ = __x;
+    __y->__get_parent()->__left_ = __x;
     if (__y != __root)
       __w = __y->__parent_unsafe()->__right_;
     else
@@ -364,16 +375,16 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
   } else {
     __y->__parent_unsafe()->__right_ = __x;
     // __y can't be root if it is a right child
-    __w = __y->__parent_->__left_;
+    __w = __y->__get_parent()->__left_;
   }
-  bool __removed_black = __y->__is_black_;
+  bool __removed_black = __y->__get_color() == __black;
   // If we didn't remove __z, do so now by splicing in __y for __z,
   //    but copy __z's color.  This does not impact __x or __w.
   if (__y != __z) {
     // __z->__left_ != nulptr but __z->__right_ might == __x == nullptr
-    __y->__parent_ = __z->__parent_;
+    __y->__set_parent(__z->__get_parent());
     if (std::__tree_is_left_child(__z))
-      __y->__parent_->__left_ = __y;
+      __y->__get_parent()->__left_ = __y;
     else
       __y->__parent_unsafe()->__right_ = __y;
     __y->__left_ = __z->__left_;
@@ -381,7 +392,7 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
     __y->__right_ = __z->__right_;
     if (__y->__right_ != nullptr)
       __y->__right_->__set_parent(__y);
-    __y->__is_black_ = __z->__is_black_;
+    __y->__set_color(__z->__get_color());
     if (__root == __z)
       __root = __y;
   }
@@ -401,7 +412,7 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
     //   different black heights under left and right pointers.
     // if (__x == __root || __x != nullptr && !__x->__is_black_)
     if (__x != nullptr)
-      __x->__is_black_ = true;
+      __x->__set_color(__black);
     else {
       //  Else __x isn't root, and is "doubly black", even though it may
       //     be null.  __w can not be null here, else the parent would
@@ -411,9 +422,9 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
       while (true) {
         if (!std::__tree_is_left_child(__w)) // if x is left child
         {
-          if (!__w->__is_black_) {
-            __w->__is_black_                    = true;
-            __w->__parent_unsafe()->__is_black_ = false;
+          if (__w->__get_color() == __red) {
+            __w->__set_color(__black);
+            __w->__parent_unsafe()->__set_color(__red);
             std::__tree_left_rotate(__w->__parent_unsafe());
             // __x is still valid
             // reset __root only if necessary
@@ -423,40 +434,40 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
             __w = __w->__left_->__right_;
           }
           // __w->__is_black_ is now true, __w may have null children
-          if ((__w->__left_ == nullptr || __w->__left_->__is_black_) &&
-              (__w->__right_ == nullptr || __w->__right_->__is_black_)) {
-            __w->__is_black_ = false;
-            __x              = __w->__parent_unsafe();
+          if ((__w->__left_ == nullptr || __w->__left_->__get_color() == __black) &&
+              (__w->__right_ == nullptr || __w->__right_->__get_color() == __black)) {
+            __w->__set_color(__red);
+            __x = __w->__parent_unsafe();
             // __x can no longer be null
-            if (__x == __root || !__x->__is_black_) {
-              __x->__is_black_ = true;
+            if (__x == __root || __x->__get_color() == __red) {
+              __x->__set_color(__black);
               break;
             }
             // reset sibling, and it still can't be null
-            __w = std::__tree_is_left_child(__x) ? __x->__parent_unsafe()->__right_ : __x->__parent_->__left_;
+            __w = std::__tree_is_left_child(__x) ? __x->__parent_unsafe()->__right_ : __x->__get_parent()->__left_;
             // continue;
           } else // __w has a red child
           {
-            if (__w->__right_ == nullptr || __w->__right_->__is_black_) {
+            if (__w->__right_ == nullptr || __w->__right_->__get_color() == __black) {
               // __w left child is non-null and red
-              __w->__left_->__is_black_ = true;
-              __w->__is_black_          = false;
+              __w->__left_->__set_color(__black);
+              __w->__set_color(__red);
               std::__tree_right_rotate(__w);
               // __w is known not to be root, so root hasn't changed
               // reset sibling, and it still can't be null
               __w = __w->__parent_unsafe();
             }
             // __w has a right red child, left child may be null
-            __w->__is_black_                    = __w->__parent_unsafe()->__is_black_;
-            __w->__parent_unsafe()->__is_black_ = true;
-            __w->__right_->__is_black_          = true;
+            __w->__set_color(__w->__parent_unsafe()->__get_color());
+            __w->__parent_unsafe()->__set_color(__black);
+            __w->__right_->__set_color(__black);
             std::__tree_left_rotate(__w->__parent_unsafe());
             break;
           }
         } else {
-          if (!__w->__is_black_) {
-            __w->__is_black_                    = true;
-            __w->__parent_unsafe()->__is_black_ = false;
+          if (__w->__get_color() == __red) {
+            __w->__set_color(__black);
+            __w->__parent_unsafe()->__set_color(__red);
             std::__tree_right_rotate(__w->__parent_unsafe());
             // __x is still valid
             // reset __root only if necessary
@@ -466,33 +477,33 @@ _LIBCPP_HIDE_FROM_ABI void __tree_remove(_NodePtr __root, _NodePtr __z) _NOEXCEP
             __w = __w->__right_->__left_;
           }
           // __w->__is_black_ is now true, __w may have null children
-          if ((__w->__left_ == nullptr || __w->__left_->__is_black_) &&
-              (__w->__right_ == nullptr || __w->__right_->__is_black_)) {
-            __w->__is_black_ = false;
-            __x              = __w->__parent_unsafe();
+          if ((__w->__left_ == nullptr || __w->__left_->__get_color() == __black) &&
+              (__w->__right_ == nullptr || __w->__right_->__get_color() == __black)) {
+            __w->__set_color(__red);
+            __x = __w->__parent_unsafe();
             // __x can no longer be null
-            if (!__x->__is_black_ || __x == __root) {
-              __x->__is_black_ = true;
+            if (__x->__get_color() == __red || __x == __root) {
+              __x->__set_color(__black);
               break;
             }
             // reset sibling, and it still can't be null
-            __w = std::__tree_is_left_child(__x) ? __x->__parent_unsafe()->__right_ : __x->__parent_->__left_;
+            __w = std::__tree_is_left_child(__x) ? __x->__parent_unsafe()->__right_ : __x->__get_parent()->__left_;
             // continue;
           } else // __w has a red child
           {
-            if (__w->__left_ == nullptr || __w->__left_->__is_black_) {
+            if (__w->__left_ == nullptr || __w->__left_->__get_color() == __black) {
               // __w right child is non-null and red
-              __w->__right_->__is_black_ = true;
-              __w->__is_black_           = false;
+              __w->__right_->__set_color(__black);
+              __w->__set_color(__red);
               std::__tree_left_rotate(__w);
               // __w is known not to be root, so root hasn't changed
               // reset sibling, and it still can't be null
               __w = __w->__parent_unsafe();
             }
             // __w has a left red child, right child may be null
-            __w->__is_black_                    = __w->__parent_unsafe()->__is_black_;
-            __w->__parent_unsafe()->__is_black_ = true;
-            __w->__left_->__is_black_           = true;
+            __w->__set_color(__w->__parent_unsafe()->__get_color());
+            __w->__parent_unsafe()->__set_color(__black);
+            __w->__left_->__set_color(__black);
             std::__tree_right_rotate(__w->__parent_unsafe());
             break;
           }
@@ -565,12 +576,19 @@ public:
   using __end_node_pointer _LIBCPP_NODEBUG = __rebind_pointer_t<_VoidPtr, __tree_end_node<pointer> >;
 
   pointer __right_;
-  __end_node_pointer __parent_;
-  bool __is_black_;
 
+private:
+  __end_node_pointer __parent_;
+  __tree_color __color_;
+
+public:
   _LIBCPP_HIDE_FROM_ABI pointer __parent_unsafe() const { return static_cast<pointer>(__parent_); }
 
   _LIBCPP_HIDE_FROM_ABI void __set_parent(pointer __p) { __parent_ = static_cast<__end_node_pointer>(__p); }
+  _LIBCPP_HIDE_FROM_ABI void __set_parent(__end_node_pointer __p) { __parent_ = __p; }
+  _LIBCPP_HIDE_FROM_ABI __end_node_pointer __get_parent() const { return __parent_; }
+  _LIBCPP_HIDE_FROM_ABI __tree_color __get_color() const { return __color_; }
+  _LIBCPP_HIDE_FROM_ABI void __set_color(__tree_color __color) { __color_ = __color; }
 
   ~__tree_node_base()                                  = delete;
   __tree_node_base(__tree_node_base const&)            = delete;
@@ -1257,8 +1275,8 @@ private:
     _LIBCPP_HIDE_FROM_ABI ~_DetachedTreeCache() {
       __t_->destroy(__cache_elem_);
       if (__cache_root_) {
-        while (__cache_root_->__parent_ != nullptr)
-          __cache_root_ = static_cast<__node_pointer>(__cache_root_->__parent_);
+        while (__cache_root_->__get_parent() != nullptr)
+          __cache_root_ = static_cast<__node_pointer>(__cache_root_->__get_parent());
         __t_->destroy(__cache_root_);
       }
     }
@@ -1397,11 +1415,11 @@ __tree<_Tp, _Compare, _Allocator>::__tree(const value_compare& __comp, const all
 template <class _Tp, class _Compare, class _Allocator>
 typename __tree<_Tp, _Compare, _Allocator>::__node_pointer
 __tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_from_tree(__tree* __t) _NOEXCEPT {
-  __node_pointer __cache                = static_cast<__node_pointer>(__t->__begin_node_);
-  __t->__begin_node_                    = __t->__end_node();
-  __t->__end_node()->__left_->__parent_ = nullptr;
-  __t->__end_node()->__left_            = nullptr;
-  __t->__size_                          = 0;
+  __node_pointer __cache = static_cast<__node_pointer>(__t->__begin_node_);
+  __t->__begin_node_     = __t->__end_node();
+  __t->__end_node()->__left_->__set_parent(__parent_pointer(nullptr));
+  __t->__end_node()->__left_ = nullptr;
+  __t->__size_               = 0;
   // __cache->__left_ == nullptr
   if (__cache->__right_ != nullptr)
     __cache = static_cast<__node_pointer>(__cache->__right_);
@@ -1417,18 +1435,18 @@ __tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_from_tree(__tree
 template <class _Tp, class _Compare, class _Allocator>
 typename __tree<_Tp, _Compare, _Allocator>::__node_pointer
 __tree<_Tp, _Compare, _Allocator>::_DetachedTreeCache::__detach_next(__node_pointer __cache) _NOEXCEPT {
-  if (__cache->__parent_ == nullptr)
+  if (__cache->__get_parent() == nullptr)
     return nullptr;
   if (std::__tree_is_left_child(static_cast<__node_base_pointer>(__cache))) {
-    __cache->__parent_->__left_ = nullptr;
-    __cache                     = static_cast<__node_pointer>(__cache->__parent_);
+    __cache->__get_parent()->__left_ = nullptr;
+    __cache                     = static_cast<__node_pointer>(__cache->__get_parent());
     if (__cache->__right_ == nullptr)
       return __cache;
     return static_cast<__node_pointer>(std::__tree_leaf(__cache->__right_));
   }
   // __cache is right child
   __cache->__parent_unsafe()->__right_ = nullptr;
-  __cache                              = static_cast<__node_pointer>(__cache->__parent_);
+  __cache                              = static_cast<__node_pointer>(__cache->__get_parent());
   if (__cache->__left_ == nullptr)
     return __cache;
   return static_cast<__node_pointer>(std::__tree_leaf(__cache->__left_));
@@ -1522,10 +1540,10 @@ __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t) _NOEXCEPT_(
   if (__size_ == 0)
     __begin_node_ = __end_node();
   else {
-    __end_node()->__left_->__parent_ = static_cast<__end_node_pointer>(__end_node());
-    __t.__begin_node_                = __t.__end_node();
-    __t.__end_node()->__left_        = nullptr;
-    __t.__size_                      = 0;
+    __end_node()->__left_->__set_parent(static_cast<__end_node_pointer>(__end_node()));
+    __t.__begin_node_         = __t.__end_node();
+    __t.__end_node()->__left_ = nullptr;
+    __t.__size_               = 0;
   }
 }
 
@@ -1536,13 +1554,13 @@ __tree<_Tp, _Compare, _Allocator>::__tree(__tree&& __t, const allocator_type& __
     if (__t.__size_ == 0)
       __begin_node_ = __end_node();
     else {
-      __begin_node_                    = __t.__begin_node_;
-      __end_node()->__left_            = __t.__end_node()->__left_;
-      __end_node()->__left_->__parent_ = static_cast<__end_node_pointer>(__end_node());
-      __size_                          = __t.__size_;
-      __t.__begin_node_                = __t.__end_node();
-      __t.__end_node()->__left_        = nullptr;
-      __t.__size_                      = 0;
+      __begin_node_         = __t.__begin_node_;
+      __end_node()->__left_ = __t.__end_node()->__left_;
+      __end_node()->__left_->__set_parent(static_cast<__end_node_pointer>(__end_node()));
+      __size_                   = __t.__size_;
+      __t.__begin_node_         = __t.__end_node();
+      __t.__end_node()->__left_ = nullptr;
+      __t.__size_               = 0;
     }
   } else {
     __begin_node_ = __end_node();
@@ -1561,10 +1579,10 @@ void __tree<_Tp, _Compare, _Allocator>::__move_assign(__tree& __t, true_type)
   if (__size_ == 0)
     __begin_node_ = __end_node();
   else {
-    __end_node()->__left_->__parent_ = static_cast<__end_node_pointer>(__end_node());
-    __t.__begin_node_                = __t.__end_node();
-    __t.__end_node()->__left_        = nullptr;
-    __t.__size_                      = 0;
+    __end_node()->__left_->__set_parent(static_cast<__end_node_pointer>(__end_node()));
+    __t.__begin_node_         = __t.__end_node();
+    __t.__end_node()->__left_ = nullptr;
+    __t.__size_               = 0;
   }
 }
 
@@ -1628,11 +1646,11 @@ void __tree<_Tp, _Compare, _Allocator>::swap(__tree& __t)
   if (__size_ == 0)
     __begin_node_ = __end_node();
   else
-    __end_node()->__left_->__parent_ = __end_node();
+    __end_node()->__left_->__set_parent(__end_node());
   if (__t.__size_ == 0)
     __t.__begin_node_ = __t.__end_node();
   else
-    __t.__end_node()->__left_->__parent_ = __t.__end_node();
+    __t.__end_node()->__left_->__set_parent(static_cast<__end_node_pointer>(__t.__end_node()));
 }
 
 template <class _Tp, class _Compare, class _Allocator>
@@ -1819,7 +1837,7 @@ void __tree<_Tp, _Compare, _Allocator>::__insert_node_at(
     __end_node_pointer __parent, __node_base_pointer& __child, __node_base_pointer __new_node) _NOEXCEPT {
   __new_node->__left_   = nullptr;
   __new_node->__right_  = nullptr;
-  __new_node->__parent_ = __parent;
+  __new_node->__set_parent(__parent);
   // __new_node->__is_black_ is initialized in __tree_balance_after_insert
   __child = __new_node;
   if (__begin_node_->__left_ != nullptr)
@@ -2247,7 +2265,7 @@ __tree<_Tp, _Compare, _Allocator>::remove(const_iterator __p) _NOEXCEPT {
     if (__np->__right_ != nullptr)
       __begin_node_ = static_cast<__end_node_pointer>(__np->__right_);
     else
-      __begin_node_ = static_cast<__end_node_pointer>(__np->__parent_);
+      __begin_node_ = static_cast<__end_node_pointer>(__np->__get_parent());
   }
   --__size_;
   std::__tree_remove(__end_node()->__left_, static_cast<__node_base_pointer>(__np));

--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -36,6 +36,7 @@
 #include <__utility/forward.h>
 #include <__utility/move.h>
 #include <__utility/pair.h>
+#include <__utility/pointer_int_pair.h>
 #include <__utility/swap.h>
 #include <__utility/try_key_extraction.h>
 #include <limits>
@@ -575,6 +576,8 @@ public:
   using pointer                            = __rebind_pointer_t<_VoidPtr, __tree_node_base>;
   using __end_node_pointer _LIBCPP_NODEBUG = __rebind_pointer_t<_VoidPtr, __tree_end_node<pointer> >;
 
+  static_assert(is_same<typename pointer_traits<_VoidPtr>::element_type, void>::value);
+
   pointer __right_;
 
 private:
@@ -594,6 +597,43 @@ public:
   __tree_node_base(__tree_node_base const&)            = delete;
   __tree_node_base& operator=(__tree_node_base const&) = delete;
 };
+
+#ifdef _LIBCPP_ABI_TREE_POINTER_INT_PAIR
+template <>
+class __tree_node_base<void*> : public __tree_end_node<__tree_node_base<void*>*> {
+public:
+  using pointer                            = __tree_node_base<void*>*;
+  using __end_node_pointer _LIBCPP_NODEBUG = __tree_end_node<__tree_node_base<void*>*>*;
+
+  pointer __right_;
+
+private:
+  using __pair_t = __pointer_int_pair<__end_node_pointer, bool, __integer_width(1)>;
+
+  __pair_t __parent_and_color_;
+
+public:
+  _LIBCPP_HIDE_FROM_ABI pointer __parent_unsafe() const {
+    return static_cast<pointer>(__parent_and_color_.__get_ptr());
+  }
+
+  _LIBCPP_HIDE_FROM_ABI void __set_parent(pointer __ptr) { __set_parent(static_cast<__end_node_pointer>(__ptr)); }
+
+  _LIBCPP_HIDE_FROM_ABI void __set_parent(__end_node_pointer __ptr) {
+    __parent_and_color_ = __pair_t(__ptr, __parent_and_color_.__get_value());
+  }
+
+  _LIBCPP_HIDE_FROM_ABI __end_node_pointer __get_parent() const { return __parent_and_color_.__get_ptr(); }
+  _LIBCPP_HIDE_FROM_ABI __tree_color __get_color() const {
+    return static_cast<__tree_color>(__parent_and_color_.__get_value());
+  }
+  _LIBCPP_HIDE_FROM_ABI void __set_color(__tree_color __color) {
+    __parent_and_color_ = __pair_t(__parent_and_color_.__get_ptr(), __color == __tree_color::__black);
+  }
+};
+#endif // _LIBCPP_ABI_TREE_POINTER_INT_PAIR
+
+static_assert(sizeof(__tree_node_base<void*>) == 24);
 
 template <class _Tp, class _VoidPtr>
 class _LIBCPP_STANDALONE_DEBUG __tree_node : public __tree_node_base<_VoidPtr> {

--- a/libcxx/include/__utility/pointer_int_pair.h
+++ b/libcxx/include/__utility/pointer_int_pair.h
@@ -1,0 +1,159 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___UTILITY_POINTER_INT_PAIR_H
+#define _LIBCPP___UTILITY_POINTER_INT_PAIR_H
+
+#include <__assert>
+#include <__config>
+#include <__cstddef/size_t.h>
+#include <__fwd/tuple.h>
+#include <__type_traits/enable_if.h>
+#include <__type_traits/is_integral.h>
+#include <__type_traits/is_unsigned.h>
+#include <__type_traits/is_void.h>
+#include <cstdint>
+#include <limits>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+// A __pointer_int_pair is a pair of a pointer and an integral type. The lower bits of the pointer that are free
+// due to the alignment requirement of the pointee are used to store the integral type.
+//
+// This imposes a constraint on the number of bits available for the integral type -- the integral type can use
+// at most log2(alignof(T)) bits. This technique allows storing the integral type without additional storage
+// beyond that of the pointer itself, at the cost of some bit twiddling.
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class, class = void>
+struct _PointerLikeTraits;
+
+template <class _Tp>
+struct _PointerLikeTraits<_Tp*, __enable_if_t<!is_void<_Tp>::value> > {
+  // This is really `__bit_log2`, but we need this to be a constant expression even in C++03, so we can't use that
+  static const size_t __low_bits_available = numeric_limits<size_t>::digits - 1 - __builtin_clzg(_LIBCPP_ALIGNOF(_Tp));
+
+  static _LIBCPP_HIDE_FROM_ABI uintptr_t __to_uintptr(_Tp* __ptr) { return reinterpret_cast<uintptr_t>(__ptr); }
+  static _LIBCPP_HIDE_FROM_ABI _Tp* __to_pointer(uintptr_t __ptr) { return reinterpret_cast<_Tp*>(__ptr); }
+};
+
+template <class _Tp>
+struct _PointerLikeTraits<_Tp*, __enable_if_t<is_void<_Tp>::value> > {
+  static const size_t __low_bits_available = 0;
+
+  static _LIBCPP_HIDE_FROM_ABI uintptr_t __to_uintptr(_Tp* __ptr) { return reinterpret_cast<uintptr_t>(__ptr); }
+  static _LIBCPP_HIDE_FROM_ABI _Tp* __to_pointer(uintptr_t __ptr) { return reinterpret_cast<_Tp*>(__ptr); }
+};
+
+enum __integer_width : size_t {};
+
+template <class _Pointer, class _IntType, __integer_width __int_bit_count>
+class __pointer_int_pair {
+  using _PointerTraits = _PointerLikeTraits<_Pointer>;
+
+  static const auto __int_width = static_cast<size_t>(__int_bit_count);
+
+  static_assert(__int_width <= _PointerTraits::__low_bits_available,
+                "Not enough bits available for requested bit count");
+  static_assert(is_integral<_IntType>::value, "_IntType has to be an integral type");
+  static_assert(is_unsigned<_IntType>::value,
+                "__pointer_int_pair doesn't work for signed types since that would require handling the sign bit");
+
+  static const size_t __extra_bits  = _PointerTraits::__low_bits_available - __int_width;
+  static const uintptr_t __int_mask = static_cast<uintptr_t>(1 << _PointerTraits::__low_bits_available) - 1;
+  static const uintptr_t __ptr_mask = ~__int_mask;
+
+  uintptr_t __value_ = 0;
+
+public:
+  __pointer_int_pair() = default;
+
+  _LIBCPP_HIDE_FROM_ABI __pointer_int_pair(_Pointer __ptr_value, _IntType __int_value)
+      : __value_(_PointerTraits::__to_uintptr(__ptr_value) | (__int_value << __extra_bits)) {
+    _LIBCPP_ASSERT_INTERNAL((__int_value & (__int_mask >> __extra_bits)) == __int_value, "integer is too large!");
+    _LIBCPP_ASSERT_INTERNAL(
+        (_PointerTraits::__to_uintptr(__ptr_value) & __ptr_mask) == _PointerTraits::__to_uintptr(__ptr_value),
+        "Pointer alignment is too low!");
+  }
+
+  _LIBCPP_HIDE_FROM_ABI _IntType __get_value() const { return (__value_ & __int_mask) >> __extra_bits; }
+  _LIBCPP_HIDE_FROM_ABI _Pointer __get_ptr() const { return _PointerTraits::__to_pointer(__value_ & __ptr_mask); }
+
+  template <class, class>
+  friend struct _PointerLikeTraits;
+};
+
+template <class _Pointer, __integer_width __int_bit_count, class _IntType>
+struct _PointerLikeTraits<__pointer_int_pair<_Pointer, _IntType, __int_bit_count> > {
+private:
+  using _PointerIntPair = __pointer_int_pair<_Pointer, _IntType, __int_bit_count>;
+
+public:
+  static inline const size_t __low_bits_available = _PointerIntPair::__extra_bits;
+
+  static _LIBCPP_HIDE_FROM_ABI uintptr_t __to_uintptr(_PointerIntPair __ptr) { return __ptr.__value_; }
+
+  static _LIBCPP_HIDE_FROM_ABI _PointerIntPair __to_pointer(uintptr_t __ptr) {
+    _PointerIntPair __tmp;
+    __tmp.__value_ = __ptr;
+    return __tmp;
+  }
+};
+
+#ifndef _LIBCPP_CXX03_LANG
+
+// Make __pointer_int_pair tuple-like
+
+template <class _Pointer, class _IntType, __integer_width __int_bit_count>
+struct tuple_size<__pointer_int_pair<_Pointer, _IntType, __int_bit_count> > : integral_constant<size_t, 2> {};
+
+template <class _Pointer, class _IntType, __integer_width __int_bit_count>
+struct tuple_element<0, __pointer_int_pair<_Pointer, _IntType, __int_bit_count> > {
+  using type = _Pointer;
+};
+
+template <class _Pointer, class _IntType, __integer_width __int_bit_count>
+struct tuple_element<1, __pointer_int_pair<_Pointer, _IntType, __int_bit_count> > {
+  using type = _IntType;
+};
+
+template <size_t __i>
+struct __pointer_int_pair_getter;
+
+template <>
+struct __pointer_int_pair_getter<0> {
+  template <class _Pointer, class _IntType, __integer_width __int_bit_count>
+  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _Pointer
+  __get(__pointer_int_pair<_Pointer, _IntType, __int_bit_count> __pair) {
+    return __pair.__get_ptr();
+  }
+};
+
+template <>
+struct __pointer_int_pair_getter<1> {
+  template <class _Pointer, class _IntType, __integer_width __int_bit_count>
+  static _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR _IntType
+  __get(__pointer_int_pair<_Pointer, _IntType, __int_bit_count> __pair) {
+    return __pair.__get_value();
+  }
+};
+
+template <size_t __i, class _Pointer, class _IntType, __integer_width __int_bit_count>
+_LIBCPP_HIDE_FROM_ABI typename tuple_element<__i, __pointer_int_pair<_Pointer, _IntType, __int_bit_count> >::type
+get(__pointer_int_pair<_Pointer, _IntType, __int_bit_count> __pair) {
+  return __pointer_int_pair_getter<__i>::__get(__pair);
+}
+
+#endif // _LIBCPP_CXX03_LANG
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___UTILITY_POINTER_INT_PAIR_H

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -2170,6 +2170,11 @@ module std [system] {
       export std.utility.piecewise_construct
     }
     module piecewise_construct        { header "__utility/piecewise_construct.h" }
+    module pointer_int_pair           {
+      header "__utility/pointer_int_pair.h"
+
+      export std_core.fwd.tuple
+    }
     module priority_tag               { header "__utility/priority_tag.h" }
     module private_constructor_tag    { header "__utility/private_constructor_tag.h" }
     module rel_ops                    { header "__utility/rel_ops.h" }

--- a/libcxx/test/libcxx/containers/associative/tree_balance_after_insert.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/tree_balance_after_insert.pass.cpp
@@ -8,7 +8,7 @@
 
 // Not a portable test
 
-// Precondition:  __root->__is_black_ == true
+// Precondition:  __root->__color_ == std::__tree_color::__black
 // template <class _NodePtr>
 // void
 // __tree_balance_after_insert(_NodePtr __root, _NodePtr __x)
@@ -22,12 +22,15 @@ struct Node {
   Node* __left_;
   Node* __right_;
   Node* __parent_;
-  bool __is_black_;
+  std::__tree_color __color_;
 
   Node* __parent_unsafe() const { return __parent_; }
   void __set_parent(Node* x) { __parent_ = x; }
+  Node* __get_parent() { return __parent_; }
+  void __set_color(std::__tree_color __color) { __color_ = __color; }
+  std::__tree_color __get_color() { return __color_; }
 
-  Node() : __left_(), __right_(), __parent_(), __is_black_() {}
+  Node() : __left_(), __right_(), __parent_(), __color_() {}
 };
 
 void test1() {
@@ -43,22 +46,22 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &a;
     b.__right_    = 0;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = 0;
     d.__right_    = 0;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -69,22 +72,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == &a);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == 0);
     assert(d.__right_ == 0);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -98,22 +101,22 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = 0;
     b.__right_    = &a;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = 0;
     d.__right_    = 0;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -124,22 +127,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == 0);
     assert(b.__right_ == &a);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == 0);
     assert(d.__right_ == 0);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -153,22 +156,22 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = 0;
     b.__right_    = 0;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = &a;
     d.__right_    = 0;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &d;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -179,22 +182,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == &a);
     assert(d.__right_ == 0);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &d);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -208,22 +211,22 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = 0;
     b.__right_    = 0;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = 0;
     d.__right_    = &a;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &d;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -234,22 +237,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == 0);
     assert(d.__right_ == &a);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &d);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -268,37 +271,37 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &a;
     b.__right_    = &g;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = &h;
     d.__right_    = &i;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &b;
     a.__left_     = &e;
     a.__right_    = &f;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     e.__parent_   = &a;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &a;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &b;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     h.__parent_   = &d;
-    h.__is_black_ = true;
+    h.__color_ = std::__tree_color::__black;
 
     i.__parent_   = &d;
-    i.__is_black_ = true;
+    i.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -309,22 +312,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == &a);
     assert(b.__right_ == &g);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == &h);
     assert(d.__right_ == &i);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == &e);
     assert(a.__right_ == &f);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -343,37 +346,37 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &g;
     b.__right_    = &a;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = &h;
     d.__right_    = &i;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &b;
     a.__left_     = &e;
     a.__right_    = &f;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     e.__parent_   = &a;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &a;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &b;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     h.__parent_   = &d;
-    h.__is_black_ = true;
+    h.__color_ = std::__tree_color::__black;
 
     i.__parent_   = &d;
-    i.__is_black_ = true;
+    i.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -384,22 +387,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == &g);
     assert(b.__right_ == &a);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == &h);
     assert(d.__right_ == &i);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == &e);
     assert(a.__right_ == &f);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -418,37 +421,37 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &g;
     b.__right_    = &h;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = &a;
     d.__right_    = &i;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &d;
     a.__left_     = &e;
     a.__right_    = &f;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     e.__parent_   = &a;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &a;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &b;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     h.__parent_   = &b;
-    h.__is_black_ = true;
+    h.__color_ = std::__tree_color::__black;
 
     i.__parent_   = &d;
-    i.__is_black_ = true;
+    i.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -459,22 +462,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == &g);
     assert(b.__right_ == &h);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == &a);
     assert(d.__right_ == &i);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &d);
     assert(a.__left_ == &e);
     assert(a.__right_ == &f);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -493,37 +496,37 @@ void test1() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &d;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &g;
     b.__right_    = &h;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &c;
     d.__left_     = &i;
     d.__right_    = &a;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &d;
     a.__left_     = &e;
     a.__right_    = &f;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     e.__parent_   = &a;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &a;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &b;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     h.__parent_   = &b;
-    h.__is_black_ = true;
+    h.__color_ = std::__tree_color::__black;
 
     i.__parent_   = &d;
-    i.__is_black_ = true;
+    i.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -534,22 +537,22 @@ void test1() {
     assert(c.__parent_ == &root);
     assert(c.__left_ == &b);
     assert(c.__right_ == &d);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &c);
     assert(b.__left_ == &g);
     assert(b.__right_ == &h);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &c);
     assert(d.__left_ == &i);
     assert(d.__right_ == &a);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(a.__parent_ == &d);
     assert(a.__left_ == &e);
     assert(a.__right_ == &f);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
   }
 }
 
@@ -565,17 +568,17 @@ void test2() {
     c.__parent_   = &root;
     c.__left_     = &a;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &c;
     a.__left_     = 0;
     a.__right_    = &b;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     b.__parent_   = &a;
     b.__left_     = 0;
     b.__right_    = 0;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &b);
 
@@ -586,17 +589,17 @@ void test2() {
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
   }
   {
     Node root;
@@ -609,17 +612,17 @@ void test2() {
     a.__parent_   = &root;
     a.__left_     = 0;
     a.__right_    = &c;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &a;
     c.__left_     = &b;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     b.__parent_   = &c;
     b.__left_     = 0;
     b.__right_    = 0;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &b);
 
@@ -630,17 +633,17 @@ void test2() {
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
   }
   {
     Node root;
@@ -657,29 +660,29 @@ void test2() {
     c.__parent_   = &root;
     c.__left_     = &a;
     c.__right_    = &g;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &c;
     a.__left_     = &d;
     a.__right_    = &b;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     b.__parent_   = &a;
     b.__left_     = &e;
     b.__right_    = &f;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &a;
-    d.__is_black_ = true;
+    d.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &b;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &b;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &c;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &b);
 
@@ -690,29 +693,29 @@ void test2() {
     assert(c.__parent_ == &b);
     assert(c.__left_ == &f);
     assert(c.__right_ == &g);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == &d);
     assert(a.__right_ == &e);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &a);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(e.__parent_ == &a);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
 
     assert(f.__parent_ == &c);
-    assert(f.__is_black_ == true);
+    assert(f.__color_ == std::__tree_color::__black);
 
     assert(g.__parent_ == &c);
-    assert(g.__is_black_ == true);
+    assert(g.__color_ == std::__tree_color::__black);
   }
   {
     Node root;
@@ -729,29 +732,29 @@ void test2() {
     a.__parent_   = &root;
     a.__left_     = &d;
     a.__right_    = &c;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &a;
     c.__left_     = &b;
     c.__right_    = &g;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     b.__parent_   = &c;
     b.__left_     = &e;
     b.__right_    = &f;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &a;
-    d.__is_black_ = true;
+    d.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &b;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &b;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &c;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &b);
 
@@ -762,29 +765,29 @@ void test2() {
     assert(c.__parent_ == &b);
     assert(c.__left_ == &f);
     assert(c.__right_ == &g);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == &d);
     assert(a.__right_ == &e);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &a);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(e.__parent_ == &a);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
 
     assert(f.__parent_ == &c);
-    assert(f.__is_black_ == true);
+    assert(f.__color_ == std::__tree_color::__black);
 
     assert(g.__parent_ == &c);
-    assert(g.__is_black_ == true);
+    assert(g.__color_ == std::__tree_color::__black);
   }
 }
 
@@ -800,17 +803,17 @@ void test3() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &a;
     b.__right_    = 0;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -821,17 +824,17 @@ void test3() {
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
   }
   {
     Node root;
@@ -844,17 +847,17 @@ void test3() {
     a.__parent_   = &root;
     a.__left_     = 0;
     a.__right_    = &b;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &a;
     b.__left_     = 0;
     b.__right_    = &c;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_balance_after_insert(root.__left_, &c);
 
@@ -865,17 +868,17 @@ void test3() {
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
   }
   {
     Node root;
@@ -892,29 +895,29 @@ void test3() {
     c.__parent_   = &root;
     c.__left_     = &b;
     c.__right_    = &g;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &c;
     b.__left_     = &a;
     b.__right_    = &f;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     a.__parent_   = &b;
     a.__left_     = &d;
     a.__right_    = &e;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &a;
-    d.__is_black_ = true;
+    d.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &a;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &b;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &c;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &a);
 
@@ -925,29 +928,29 @@ void test3() {
     assert(c.__parent_ == &b);
     assert(c.__left_ == &f);
     assert(c.__right_ == &g);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == &d);
     assert(a.__right_ == &e);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &a);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(e.__parent_ == &a);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
 
     assert(f.__parent_ == &c);
-    assert(f.__is_black_ == true);
+    assert(f.__color_ == std::__tree_color::__black);
 
     assert(g.__parent_ == &c);
-    assert(g.__is_black_ == true);
+    assert(g.__color_ == std::__tree_color::__black);
   }
   {
     Node root;
@@ -964,29 +967,29 @@ void test3() {
     a.__parent_   = &root;
     a.__left_     = &d;
     a.__right_    = &b;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     b.__parent_   = &a;
     b.__left_     = &e;
     b.__right_    = &c;
-    b.__is_black_ = false;
+    b.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = &f;
     c.__right_    = &g;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     d.__parent_   = &a;
-    d.__is_black_ = true;
+    d.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &b;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &c;
-    f.__is_black_ = true;
+    f.__color_ = std::__tree_color::__black;
 
     g.__parent_   = &c;
-    g.__is_black_ = true;
+    g.__color_ = std::__tree_color::__black;
 
     std::__tree_balance_after_insert(root.__left_, &c);
 
@@ -997,29 +1000,29 @@ void test3() {
     assert(c.__parent_ == &b);
     assert(c.__left_ == &f);
     assert(c.__right_ == &g);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == &d);
     assert(a.__right_ == &e);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(d.__parent_ == &a);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(e.__parent_ == &a);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
 
     assert(f.__parent_ == &c);
-    assert(f.__is_black_ == true);
+    assert(f.__color_ == std::__tree_color::__black);
 
     assert(g.__parent_ == &c);
-    assert(g.__is_black_ == true);
+    assert(g.__color_ == std::__tree_color::__black);
   }
 }
 
@@ -1044,12 +1047,12 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &a);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(a.__parent_ == &root);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   a.__right_  = &b;
   b.__parent_ = &a;
@@ -1061,17 +1064,17 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &a);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(a.__parent_ == &root);
   assert(a.__left_ == 0);
   assert(a.__right_ == &b);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &a);
   assert(b.__left_ == 0);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == false);
+  assert(b.__color_ == std::__tree_color::__red);
 
   b.__right_  = &c;
   c.__parent_ = &b;
@@ -1083,22 +1086,22 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == &c);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &b);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   c.__right_  = &d;
   d.__parent_ = &c;
@@ -1110,27 +1113,27 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == &c);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &b);
   assert(c.__left_ == 0);
   assert(c.__right_ == &d);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(d.__parent_ == &c);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == false);
+  assert(d.__color_ == std::__tree_color::__red);
 
   d.__right_  = &e;
   e.__parent_ = &d;
@@ -1142,32 +1145,32 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == &d);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(d.__parent_ == &b);
   assert(d.__left_ == &c);
   assert(d.__right_ == &e);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &d);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &d);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == false);
+  assert(e.__color_ == std::__tree_color::__red);
 
   e.__right_  = &f;
   f.__parent_ = &e;
@@ -1179,37 +1182,37 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == &d);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(d.__parent_ == &b);
   assert(d.__left_ == &c);
   assert(d.__right_ == &e);
-  assert(d.__is_black_ == false);
+  assert(d.__color_ == std::__tree_color::__red);
 
   assert(c.__parent_ == &d);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &d);
   assert(e.__left_ == 0);
   assert(e.__right_ == &f);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &e);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   f.__right_  = &g;
   g.__parent_ = &f;
@@ -1221,42 +1224,42 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == &d);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(d.__parent_ == &b);
   assert(d.__left_ == &c);
   assert(d.__right_ == &f);
-  assert(d.__is_black_ == false);
+  assert(d.__color_ == std::__tree_color::__red);
 
   assert(c.__parent_ == &d);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &d);
   assert(f.__left_ == &e);
   assert(f.__right_ == &g);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &f);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == false);
+  assert(e.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &f);
   assert(g.__left_ == 0);
   assert(g.__right_ == 0);
-  assert(g.__is_black_ == false);
+  assert(g.__color_ == std::__tree_color::__red);
 
   g.__right_  = &h;
   h.__parent_ = &g;
@@ -1268,47 +1271,47 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &d);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &root);
   assert(d.__left_ == &b);
   assert(d.__right_ == &f);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &d);
   assert(b.__left_ == &a);
   assert(b.__right_ == &c);
-  assert(b.__is_black_ == false);
+  assert(b.__color_ == std::__tree_color::__red);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &b);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &d);
   assert(f.__left_ == &e);
   assert(f.__right_ == &g);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &f);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &f);
   assert(g.__left_ == 0);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 }
 
 void test5() {
@@ -1332,12 +1335,12 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &h);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &root);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   h.__left_   = &g;
   g.__parent_ = &h;
@@ -1349,17 +1352,17 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &h);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &root);
   assert(h.__left_ == &g);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &h);
   assert(g.__left_ == 0);
   assert(g.__right_ == 0);
-  assert(g.__is_black_ == false);
+  assert(g.__color_ == std::__tree_color::__red);
 
   g.__left_   = &f;
   f.__parent_ = &g;
@@ -1371,22 +1374,22 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == &f);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &g);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 
   f.__left_   = &e;
   e.__parent_ = &f;
@@ -1398,27 +1401,27 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == &f);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &g);
   assert(f.__left_ == &e);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &f);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == false);
+  assert(e.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   e.__left_   = &d;
   d.__parent_ = &e;
@@ -1430,32 +1433,32 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == &e);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &g);
   assert(e.__left_ == &d);
   assert(e.__right_ == &f);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(d.__parent_ == &e);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == false);
+  assert(d.__color_ == std::__tree_color::__red);
 
   assert(f.__parent_ == &e);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   d.__left_   = &c;
   c.__parent_ = &d;
@@ -1467,37 +1470,37 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == &e);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &g);
   assert(e.__left_ == &d);
   assert(e.__right_ == &f);
-  assert(e.__is_black_ == false);
+  assert(e.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &e);
   assert(d.__left_ == &c);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &d);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   assert(f.__parent_ == &e);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   c.__left_   = &b;
   b.__parent_ = &c;
@@ -1509,42 +1512,42 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == &e);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &g);
   assert(e.__left_ == &c);
   assert(e.__right_ == &f);
-  assert(e.__is_black_ == false);
+  assert(e.__color_ == std::__tree_color::__red);
 
   assert(c.__parent_ == &e);
   assert(c.__left_ == &b);
   assert(c.__right_ == &d);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &c);
   assert(b.__left_ == 0);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == false);
+  assert(b.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &c);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == false);
+  assert(d.__color_ == std::__tree_color::__red);
 
   assert(f.__parent_ == &e);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   b.__left_   = &a;
   a.__parent_ = &b;
@@ -1556,47 +1559,47 @@ void test5() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &e);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &root);
   assert(e.__left_ == &c);
   assert(e.__right_ == &g);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &e);
   assert(c.__left_ == &b);
   assert(c.__right_ == &d);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &c);
   assert(b.__left_ == &a);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &c);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &e);
   assert(g.__left_ == &f);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == false);
+  assert(g.__color_ == std::__tree_color::__red);
 
   assert(f.__parent_ == &g);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 }
 
 int main(int, char**) {

--- a/libcxx/test/libcxx/containers/associative/tree_left_rotate.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/tree_left_rotate.pass.cpp
@@ -25,6 +25,7 @@ struct Node {
 
   Node* __parent_unsafe() const { return __parent_; }
   void __set_parent(Node* x) { __parent_ = x; }
+  Node* __get_parent() { return __parent_; }
 
   Node() : __left_(), __right_(), __parent_() {}
 };

--- a/libcxx/test/libcxx/containers/associative/tree_remove.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/tree_remove.pass.cpp
@@ -22,12 +22,15 @@ struct Node {
   Node* __left_;
   Node* __right_;
   Node* __parent_;
-  bool __is_black_;
+  std::__tree_color __color_;
 
   Node* __parent_unsafe() const { return __parent_; }
   void __set_parent(Node* x) { __parent_ = x; }
+  Node* __get_parent() { return __parent_; }
+  void __set_color(std::__tree_color __color) { __color_ = __color; }
+  std::__tree_color __get_color() { return __color_; }
 
-  Node() : __left_(), __right_(), __parent_(), __is_black_() {}
+  Node() : __left_(), __right_(), __parent_(), __color_() {}
 };
 
 void test1() {
@@ -46,27 +49,27 @@ void test1() {
     b.__parent_   = &root;
     b.__left_     = &y;
     b.__right_    = &d;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     y.__parent_   = &b;
     y.__left_     = 0;
     y.__right_    = 0;
-    y.__is_black_ = true;
+    y.__color_ = std::__tree_color::__black;
 
     d.__parent_   = &b;
     d.__left_     = &c;
     d.__right_    = &e;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &d;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &d;
     e.__left_     = 0;
     e.__right_    = 0;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &y);
     assert(std::__tree_invariant(root.__left_));
@@ -74,27 +77,27 @@ void test1() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &d);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(d.__parent_ == &root);
     assert(d.__left_ == &b);
     assert(d.__right_ == &e);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &d);
     assert(b.__left_ == 0);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(e.__parent_ == &d);
     assert(e.__left_ == 0);
     assert(e.__right_ == 0);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
   }
   {
     // Right
@@ -111,55 +114,56 @@ void test1() {
     b.__parent_   = &root;
     b.__right_    = &y;
     b.__left_     = &d;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     y.__parent_   = &b;
     y.__right_    = 0;
     y.__left_     = 0;
-    y.__is_black_ = true;
+    y.__color_ = std::__tree_color::__black;
 
     d.__parent_   = &b;
     d.__right_    = &c;
     d.__left_     = &e;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &d;
     c.__right_    = 0;
     c.__left_     = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &d;
     e.__right_    = 0;
     e.__left_     = 0;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
+    assert(std::__tree_invariant(root.__left_));
     std::__tree_remove(root.__left_, &y);
     assert(std::__tree_invariant(root.__left_));
 
     assert(root.__parent_ == 0);
     assert(root.__left_ == &d);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(d.__parent_ == &root);
     assert(d.__right_ == &b);
     assert(d.__left_ == &e);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(b.__parent_ == &d);
     assert(b.__right_ == 0);
     assert(b.__left_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &b);
     assert(c.__right_ == 0);
     assert(c.__left_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     assert(e.__parent_ == &d);
     assert(e.__right_ == 0);
     assert(e.__left_ == 0);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
   }
   {
     // Left
@@ -177,32 +181,32 @@ void test1() {
     b.__parent_   = &root;
     b.__left_     = &y;
     b.__right_    = &d;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     y.__parent_   = &b;
     y.__left_     = 0;
     y.__right_    = 0;
-    y.__is_black_ = true;
+    y.__color_ = std::__tree_color::__black;
 
     d.__parent_   = &b;
     d.__left_     = &c;
     d.__right_    = &e;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &d;
     c.__left_     = &f;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &d;
     e.__left_     = 0;
     e.__right_    = 0;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &c;
     f.__left_     = 0;
     f.__right_    = 0;
-    f.__is_black_ = false;
+    f.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &y);
     assert(std::__tree_invariant(root.__left_));
@@ -210,32 +214,32 @@ void test1() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &d);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(d.__parent_ == &root);
     assert(d.__left_ == &f);
     assert(d.__right_ == &e);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(f.__parent_ == &d);
     assert(f.__left_ == &b);
     assert(f.__right_ == &c);
-    assert(f.__is_black_ == false);
+    assert(f.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &f);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &f);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(e.__parent_ == &d);
     assert(e.__left_ == 0);
     assert(e.__right_ == 0);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
   }
   {
     // Right
@@ -253,32 +257,32 @@ void test1() {
     b.__parent_   = &root;
     b.__right_    = &y;
     b.__left_     = &d;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     y.__parent_   = &b;
     y.__right_    = 0;
     y.__left_     = 0;
-    y.__is_black_ = true;
+    y.__color_ = std::__tree_color::__black;
 
     d.__parent_   = &b;
     d.__right_    = &c;
     d.__left_     = &e;
-    d.__is_black_ = false;
+    d.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &d;
     c.__right_    = &f;
     c.__left_     = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     e.__parent_   = &d;
     e.__right_    = 0;
     e.__left_     = 0;
-    e.__is_black_ = true;
+    e.__color_ = std::__tree_color::__black;
 
     f.__parent_   = &c;
     f.__right_    = 0;
     f.__left_     = 0;
-    f.__is_black_ = false;
+    f.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &y);
     assert(std::__tree_invariant(root.__left_));
@@ -286,32 +290,32 @@ void test1() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &d);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(d.__parent_ == &root);
     assert(d.__right_ == &f);
     assert(d.__left_ == &e);
-    assert(d.__is_black_ == true);
+    assert(d.__color_ == std::__tree_color::__black);
 
     assert(f.__parent_ == &d);
     assert(f.__right_ == &b);
     assert(f.__left_ == &c);
-    assert(f.__is_black_ == false);
+    assert(f.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &f);
     assert(b.__right_ == 0);
     assert(b.__left_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &f);
     assert(c.__right_ == 0);
     assert(c.__left_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     assert(e.__parent_ == &d);
     assert(e.__right_ == 0);
     assert(e.__left_ == 0);
-    assert(e.__is_black_ == true);
+    assert(e.__color_ == std::__tree_color::__black);
   }
 }
 
@@ -327,17 +331,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &a);
 
@@ -346,17 +350,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -365,12 +369,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -379,7 +383,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -392,17 +396,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &a);
 
@@ -411,17 +415,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -430,12 +434,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -444,7 +448,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -457,17 +461,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &a);
 
@@ -476,17 +480,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -495,12 +499,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -509,7 +513,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -522,17 +526,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &a);
 
@@ -541,17 +545,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == &c);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     assert(c.__parent_ == &b);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == false);
+    assert(c.__color_ == std::__tree_color::__red);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -560,12 +564,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -574,7 +578,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -587,17 +591,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &b);
 
@@ -606,17 +610,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &c);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == &a);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -625,12 +629,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -639,7 +643,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -652,17 +656,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &b);
 
@@ -671,17 +675,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &c);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == &a);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -690,12 +694,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == 0);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -704,7 +708,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -717,17 +721,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &b);
 
@@ -736,17 +740,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &c);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == &a);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -755,12 +759,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &a);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &root);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == true);
+    assert(a.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -769,7 +773,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -782,17 +786,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &b);
 
@@ -801,17 +805,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &c);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &c);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(c.__parent_ == &root);
     assert(c.__left_ == &a);
     assert(c.__right_ == 0);
-    assert(c.__is_black_ == true);
+    assert(c.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &c);
 
@@ -820,12 +824,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &a);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &root);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == true);
+    assert(a.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -834,7 +838,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -847,17 +851,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &c);
 
@@ -866,17 +870,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -885,12 +889,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &a);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &root);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == true);
+    assert(a.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -899,7 +903,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -912,17 +916,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &c);
 
@@ -931,17 +935,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -950,12 +954,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &a);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &root);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == true);
+    assert(a.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -964,7 +968,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -977,17 +981,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = true;
+    a.__color_ = std::__tree_color::__black;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = true;
+    c.__color_ = std::__tree_color::__black;
 
     std::__tree_remove(root.__left_, &c);
 
@@ -996,17 +1000,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -1015,12 +1019,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -1029,7 +1033,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
   {
     Node root;
@@ -1042,17 +1046,17 @@ void test2() {
     b.__parent_   = &root;
     b.__left_     = &a;
     b.__right_    = &c;
-    b.__is_black_ = true;
+    b.__color_ = std::__tree_color::__black;
 
     a.__parent_   = &b;
     a.__left_     = 0;
     a.__right_    = 0;
-    a.__is_black_ = false;
+    a.__color_ = std::__tree_color::__red;
 
     c.__parent_   = &b;
     c.__left_     = 0;
     c.__right_    = 0;
-    c.__is_black_ = false;
+    c.__color_ = std::__tree_color::__red;
 
     std::__tree_remove(root.__left_, &c);
 
@@ -1061,17 +1065,17 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(a.__parent_ == &b);
     assert(a.__left_ == 0);
     assert(a.__right_ == 0);
-    assert(a.__is_black_ == false);
+    assert(a.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == &a);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &a);
 
@@ -1080,12 +1084,12 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == &b);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
 
     assert(b.__parent_ == &root);
     assert(b.__left_ == 0);
     assert(b.__right_ == 0);
-    assert(b.__is_black_ == true);
+    assert(b.__color_ == std::__tree_color::__black);
 
     std::__tree_remove(root.__left_, &b);
 
@@ -1094,7 +1098,7 @@ void test2() {
     assert(root.__parent_ == 0);
     assert(root.__left_ == 0);
     assert(root.__right_ == 0);
-    assert(root.__is_black_ == false);
+    assert(root.__color_ == std::__tree_color::__red);
   }
 }
 
@@ -1114,42 +1118,42 @@ void test3() {
   e.__parent_   = &root;
   e.__left_     = &c;
   e.__right_    = &g;
-  e.__is_black_ = true;
+  e.__color_ = std::__tree_color::__black;
 
   c.__parent_   = &e;
   c.__left_     = &b;
   c.__right_    = &d;
-  c.__is_black_ = false;
+  c.__color_ = std::__tree_color::__red;
 
   g.__parent_   = &e;
   g.__left_     = &f;
   g.__right_    = &h;
-  g.__is_black_ = false;
+  g.__color_ = std::__tree_color::__red;
 
   b.__parent_   = &c;
   b.__left_     = &a;
   b.__right_    = 0;
-  b.__is_black_ = true;
+  b.__color_ = std::__tree_color::__black;
 
   d.__parent_   = &c;
   d.__left_     = 0;
   d.__right_    = 0;
-  d.__is_black_ = true;
+  d.__color_ = std::__tree_color::__black;
 
   f.__parent_   = &g;
   f.__left_     = 0;
   f.__right_    = 0;
-  f.__is_black_ = true;
+  f.__color_ = std::__tree_color::__black;
 
   h.__parent_   = &g;
   h.__left_     = 0;
   h.__right_    = 0;
-  h.__is_black_ = true;
+  h.__color_ = std::__tree_color::__black;
 
   a.__parent_   = &b;
   a.__left_     = 0;
   a.__right_    = 0;
-  a.__is_black_ = false;
+  a.__color_ = std::__tree_color::__red;
 
   assert(std::__tree_invariant(root.__left_));
 
@@ -1160,42 +1164,42 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &e);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &root);
   assert(e.__left_ == &c);
   assert(e.__right_ == &g);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &e);
   assert(c.__left_ == &b);
   assert(c.__right_ == &d);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &e);
   assert(g.__left_ == &f);
   assert(g.__right_ == 0);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &c);
   assert(b.__left_ == &a);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &c);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &g);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &g);
 
@@ -1204,37 +1208,37 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &e);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &root);
   assert(e.__left_ == &c);
   assert(e.__right_ == &f);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &e);
   assert(c.__left_ == &b);
   assert(c.__right_ == &d);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &c);
   assert(b.__left_ == &a);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &c);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &e);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   std::__tree_remove(root.__left_, &f);
 
@@ -1243,32 +1247,32 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &c);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(c.__parent_ == &root);
   assert(c.__left_ == &b);
   assert(c.__right_ == &e);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &c);
   assert(b.__left_ == &a);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &c);
   assert(e.__left_ == &d);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &e);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == false);
+  assert(d.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &e);
 
@@ -1277,27 +1281,27 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &c);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(c.__parent_ == &root);
   assert(c.__left_ == &b);
   assert(c.__right_ == &d);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &c);
   assert(b.__left_ == &a);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &c);
   assert(d.__left_ == 0);
   assert(d.__right_ == 0);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   std::__tree_remove(root.__left_, &d);
 
@@ -1306,22 +1310,22 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == &c);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &b);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   std::__tree_remove(root.__left_, &c);
 
@@ -1330,17 +1334,17 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &b);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(b.__parent_ == &root);
   assert(b.__left_ == &a);
   assert(b.__right_ == 0);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(a.__parent_ == &b);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == false);
+  assert(a.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &b);
 
@@ -1349,12 +1353,12 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &a);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(a.__parent_ == &root);
   assert(a.__left_ == 0);
   assert(a.__right_ == 0);
-  assert(a.__is_black_ == true);
+  assert(a.__color_ == std::__tree_color::__black);
 
   std::__tree_remove(root.__left_, &a);
 
@@ -1363,7 +1367,7 @@ void test3() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == 0);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 }
 
 void test4() {
@@ -1382,42 +1386,42 @@ void test4() {
   d.__parent_   = &root;
   d.__left_     = &b;
   d.__right_    = &f;
-  d.__is_black_ = true;
+  d.__color_ = std::__tree_color::__black;
 
   b.__parent_   = &d;
   b.__left_     = &a;
   b.__right_    = &c;
-  b.__is_black_ = false;
+  b.__color_ = std::__tree_color::__red;
 
   f.__parent_   = &d;
   f.__left_     = &e;
   f.__right_    = &g;
-  f.__is_black_ = false;
+  f.__color_ = std::__tree_color::__red;
 
   a.__parent_   = &b;
   a.__left_     = 0;
   a.__right_    = 0;
-  a.__is_black_ = true;
+  a.__color_ = std::__tree_color::__black;
 
   c.__parent_   = &b;
   c.__left_     = 0;
   c.__right_    = 0;
-  c.__is_black_ = true;
+  c.__color_ = std::__tree_color::__black;
 
   e.__parent_   = &f;
   e.__left_     = 0;
   e.__right_    = 0;
-  e.__is_black_ = true;
+  e.__color_ = std::__tree_color::__black;
 
   g.__parent_   = &f;
   g.__left_     = 0;
   g.__right_    = &h;
-  g.__is_black_ = true;
+  g.__color_ = std::__tree_color::__black;
 
   h.__parent_   = &g;
   h.__left_     = 0;
   h.__right_    = 0;
-  h.__is_black_ = false;
+  h.__color_ = std::__tree_color::__red;
 
   assert(std::__tree_invariant(root.__left_));
 
@@ -1428,42 +1432,42 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &d);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &root);
   assert(d.__left_ == &b);
   assert(d.__right_ == &f);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(b.__parent_ == &d);
   assert(b.__left_ == 0);
   assert(b.__right_ == &c);
-  assert(b.__is_black_ == true);
+  assert(b.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &d);
   assert(f.__left_ == &e);
   assert(f.__right_ == &g);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   assert(c.__parent_ == &b);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == false);
+  assert(c.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &f);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &f);
   assert(g.__left_ == 0);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &b);
 
@@ -1472,37 +1476,37 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &d);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(d.__parent_ == &root);
   assert(d.__left_ == &c);
   assert(d.__right_ == &f);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(c.__parent_ == &d);
   assert(c.__left_ == 0);
   assert(c.__right_ == 0);
-  assert(c.__is_black_ == true);
+  assert(c.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &d);
   assert(f.__left_ == &e);
   assert(f.__right_ == &g);
-  assert(f.__is_black_ == false);
+  assert(f.__color_ == std::__tree_color::__red);
 
   assert(e.__parent_ == &f);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &f);
   assert(g.__left_ == 0);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &c);
 
@@ -1511,32 +1515,32 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &f);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(f.__parent_ == &root);
   assert(f.__left_ == &d);
   assert(f.__right_ == &g);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(d.__parent_ == &f);
   assert(d.__left_ == 0);
   assert(d.__right_ == &e);
-  assert(d.__is_black_ == true);
+  assert(d.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &f);
   assert(g.__left_ == 0);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &d);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == false);
+  assert(e.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &d);
 
@@ -1545,27 +1549,27 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &f);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(f.__parent_ == &root);
   assert(f.__left_ == &e);
   assert(f.__right_ == &g);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(e.__parent_ == &f);
   assert(e.__left_ == 0);
   assert(e.__right_ == 0);
-  assert(e.__is_black_ == true);
+  assert(e.__color_ == std::__tree_color::__black);
 
   assert(g.__parent_ == &f);
   assert(g.__left_ == 0);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &e);
 
@@ -1574,22 +1578,22 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == &f);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(f.__parent_ == &g);
   assert(f.__left_ == 0);
   assert(f.__right_ == 0);
-  assert(f.__is_black_ == true);
+  assert(f.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   std::__tree_remove(root.__left_, &f);
 
@@ -1598,17 +1602,17 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &g);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(g.__parent_ == &root);
   assert(g.__left_ == 0);
   assert(g.__right_ == &h);
-  assert(g.__is_black_ == true);
+  assert(g.__color_ == std::__tree_color::__black);
 
   assert(h.__parent_ == &g);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == false);
+  assert(h.__color_ == std::__tree_color::__red);
 
   std::__tree_remove(root.__left_, &g);
 
@@ -1617,12 +1621,12 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == &h);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 
   assert(h.__parent_ == &root);
   assert(h.__left_ == 0);
   assert(h.__right_ == 0);
-  assert(h.__is_black_ == true);
+  assert(h.__color_ == std::__tree_color::__black);
 
   std::__tree_remove(root.__left_, &h);
 
@@ -1631,7 +1635,7 @@ void test4() {
   assert(root.__parent_ == 0);
   assert(root.__left_ == 0);
   assert(root.__right_ == 0);
-  assert(root.__is_black_ == false);
+  assert(root.__color_ == std::__tree_color::__red);
 }
 
 int main(int, char**) {

--- a/libcxx/test/libcxx/containers/associative/tree_right_rotate.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/tree_right_rotate.pass.cpp
@@ -25,6 +25,7 @@ struct Node {
 
   Node* __parent_unsafe() const { return __parent_; }
   void __set_parent(Node* x) { __parent_ = x; }
+  Node* __get_parent() { return __parent_; }
 
   Node() : __left_(), __right_(), __parent_() {}
 };

--- a/libcxx/test/libcxx/utilities/pointer_int_pair/assert.constructor.pass.cpp
+++ b/libcxx/test/libcxx/utilities/pointer_int_pair/assert.constructor.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// REQUIRES: has-unix-headers
+// REQUIRES: libcpp-hardening-mode=debug
+// XFAIL: availability-verbose_abort-missing
+
+#include "test_macros.h"
+
+TEST_DIAGNOSTIC_PUSH
+TEST_CLANG_DIAGNOSTIC_IGNORED("-Wprivate-header")
+#include <__utility/pointer_int_pair.h>
+TEST_DIAGNOSTIC_POP
+
+#include <cassert>
+
+#include "check_assertion.h"
+
+struct [[gnu::packed]] Packed {
+  char c;
+  int i;
+};
+
+int main(int, char**) {
+  TEST_LIBCPP_ASSERT_FAILURE(
+      (std::__pointer_int_pair<int*, size_t, std::__integer_width{1}>{nullptr, 2}), "integer is too large!");
+
+  TEST_DIAGNOSTIC_PUSH
+  TEST_CLANG_DIAGNOSTIC_IGNORED("-Waddress-of-packed-member") // That's what we're trying to test
+  TEST_GCC_DIAGNOSTIC_IGNORED("-Waddress-of-packed-member")
+  alignas(int) Packed p;
+  TEST_LIBCPP_ASSERT_FAILURE(
+      (std::__pointer_int_pair<int*, size_t, std::__integer_width{1}>{&p.i, 0}), "Pointer alignment is too low!");
+  TEST_DIAGNOSTIC_POP
+
+  return 0;
+}

--- a/libcxx/test/libcxx/utilities/pointer_int_pair/constinit.verify.cpp
+++ b/libcxx/test/libcxx/utilities/pointer_int_pair/constinit.verify.cpp
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Ensure that __pointer_int_pair cannot be constant initialized with a value.
+// This would mean that the constructor is `constexpr`, which should only be
+// possible with compiler magic.
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+// clang-format off
+
+#include <__utility/pointer_int_pair.h>
+#include <cstddef>
+
+template <class Ptr, class UnderlyingType>
+using single_bit_pair = std::__pointer_int_pair<Ptr, UnderlyingType, std::__integer_width{1}>;
+
+constinit int ptr = 0;
+constinit single_bit_pair<int*, size_t> continitiable_pointer_int_pair_values{&ptr, 0}; // expected-error {{variable does not have a constant initializer}}

--- a/libcxx/test/libcxx/utilities/pointer_int_pair/pointer_int_pair.pass.cpp
+++ b/libcxx/test/libcxx/utilities/pointer_int_pair/pointer_int_pair.pass.cpp
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
+#include <__utility/pointer_int_pair.h>
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+
+#include "test_macros.h"
+
+template <class Ptr, class UnderlyingType>
+using single_bit_pair = std::__pointer_int_pair<Ptr, UnderlyingType, std::__integer_width(1)>;
+
+template <class Ptr, class UnderlyingType>
+using two_bit_pair = std::__pointer_int_pair<Ptr, UnderlyingType, std::__integer_width(2)>;
+
+#if _LIBCPP_STD_VER >= 20
+constinit single_bit_pair<int*, size_t> continitiable_pointer_int_pair;
+#endif
+
+int main(int, char**) {
+#if TEST_STD_VER >= 11
+  { // __pointer_int_pair() constructor
+    single_bit_pair<int*, size_t> pair = {};
+    assert(pair.__get_value() == 0);
+    assert(pair.__get_ptr() == nullptr);
+  }
+#endif
+
+  { // __pointer_int_pair(pointer, int) constructor
+    single_bit_pair<int*, size_t> pair(nullptr, 1);
+    assert(pair.__get_value() == 1);
+    assert(pair.__get_ptr() == nullptr);
+  }
+
+  { // pointer is correctly packed/unpacked (with different types and values)
+    int i;
+    single_bit_pair<int*, size_t> pair(&i, 0);
+    assert(pair.__get_value() == 0);
+    assert(pair.__get_ptr() == &i);
+  }
+  {
+    int i;
+    two_bit_pair<int*, size_t> pair(&i, 2);
+    assert(pair.__get_value() == 2);
+    assert(pair.__get_ptr() == &i);
+  }
+  {
+    short i;
+    single_bit_pair<short*, size_t> pair(&i, 1);
+    assert(pair.__get_value() == 1);
+    assert(pair.__get_ptr() == &i);
+  }
+
+  { // check that a __pointer_int_pair<__pointer_int_pair> works
+    int i;
+    single_bit_pair<single_bit_pair<int*, size_t>, size_t> pair(single_bit_pair<int*, size_t>(&i, 1), 0);
+    assert(pair.__get_value() == 0);
+    assert(pair.__get_ptr().__get_ptr() == &i);
+    assert(pair.__get_ptr().__get_value() == 1);
+  }
+
+#if _LIBCPP_STD_VER >= 17
+  { // check that the tuple protocol is correctly implemented
+    int i;
+    two_bit_pair<int*, size_t> pair{&i, 3};
+    auto [ptr, value] = pair;
+    assert(ptr == &i);
+    assert(value == 3);
+  }
+#endif
+
+  { // check that the (pointer, int) constructor is implicit
+    int i;
+    two_bit_pair<int*, size_t> pair(&i, 3);
+    assert(pair.__get_ptr() == &i);
+    assert(pair.__get_value() == 3);
+  }
+
+  { // check that overaligned types work as expected
+    struct TEST_ALIGNAS(32) Overaligned {
+      int i;
+    };
+
+    Overaligned i;
+    std::__pointer_int_pair<Overaligned*, size_t, std::__integer_width(4)> pair(&i, 13);
+    assert(pair.__get_ptr() == &i);
+    assert(pair.__get_value() == 13);
+  }
+
+  { // check that types other than size_t work as well
+    int i;
+    single_bit_pair<int*, bool> pair(&i, true);
+    assert(pair.__get_ptr() == &i);
+    assert(pair.__get_value());
+    static_assert(std::is_same<decltype(pair.__get_value()), bool>::value, "");
+  }
+  {
+    int i;
+    single_bit_pair<int*, unsigned char> pair(&i, 1);
+    assert(pair.__get_ptr() == &i);
+    assert(pair.__get_value() == 1);
+    static_assert(std::is_same<decltype(pair.__get_value()), unsigned char>::value, "");
+  }
+
+  return 0;
+}

--- a/libcxx/test/libcxx/utilities/pointer_int_pair/static_asserts.verify.cpp
+++ b/libcxx/test/libcxx/utilities/pointer_int_pair/static_asserts.verify.cpp
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// XFAIL: FROZEN-CXX03-HEADERS-FIXME
+
+#include <__utility/pointer_int_pair.h>
+#include <cstddef>
+
+// expected-error@*:* {{Not enough bits available for requested bit count}}
+std::__pointer_int_pair<char*, size_t, std::__integer_width(2)> ptr1; // expected-note {{here}}
+// expected-error@*:* {{_IntType has to be an integral type}}
+std::__pointer_int_pair<int*, int*, std::__integer_width(2)> ptr2; // expected-note {{here}}
+// expected-error@*:* {{__pointer_int_pair doesn't work for signed types}}
+std::__pointer_int_pair<int*, signed, std::__integer_width(2)> ptr3; // expected-note {{here}}


### PR DESCRIPTION
Currently, the `__tree_node_base` consists of three pointers and a bool. If an eight byte aligned object is allocated, this results in seven additional padding bytes. With this  ABI flag we instead put the bool into the low bit of one of the pointers, making every node eight bytes smaller. Consider for example string. There every node goes down from 56 to 48 bytes.