### PR TITLE
[LLDB] Fix build after TargetInfo::adjust signature change

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -831,7 +831,7 @@ ClangExpressionParser::ClangExpressionParser(
   // FIXME: We shouldn't need to do this, the target should be immutable once
   // created. This complexity should be lifted elsewhere.
   m_compiler->getTarget().adjust(m_compiler->getDiagnostics(),
-                                 m_compiler->getLangOpts());
+                                 m_compiler->getLangOpts(), /*AuxTarget=*/nullptr);
 
   // 5. Set up the diagnostic buffer for reporting errors
   auto diag_mgr = new ClangDiagnosticManagerAdapter(

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -757,7 +757,7 @@ ClangModulesDeclVendor::Create(Target &target) {
   if (!instance->hasTarget())
     return nullptr;
 
-  instance->getTarget().adjust(*diagnostics_engine, instance->getLangOpts());
+  instance->getTarget().adjust(*diagnostics_engine, instance->getLangOpts(), /*AuxTarget=*/nullptr);
 
   if (!action->BeginSourceFile(*instance,
                                instance->getFrontendOpts().Inputs[0]))


### PR DESCRIPTION
Fixes buildbot failure on lldb-x86_64-debian due to https://github.com/llvm/llvm-project/pull/146620

https://lab.llvm.org/buildbot/#/builders/162/builds/26414

Update LLDB calls to TargetInfo::adjust() to use the new 3-parameter signature introduced in beea2a941470368a87b1816e455b1db366c1bbb9. Pass nullptr for AuxTarget since LLDB doesn't use auxiliary targets in these contexts.
