### PR TITLE
[libclc] Change symlinks to copies on Windows

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -425,11 +425,17 @@ function(add_libclc_builtin_set)
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
   endif()
 
-  foreach( a ${ARG_ALIASES} )
+  if(CMAKE_HOST_UNIX OR LLVM_USE_SYMLINKS)
+    set(LIBCLC_LINK_OR_COPY create_symlink)
+  else()
+    set(LIBCLC_LINK_OR_COPY copy)
+  endif()
+
+  foreach( a IN LISTS ARG_ALIASES )
     set( alias_suffix "${a}-${ARG_TRIPLE}.bc" )
     add_custom_command(
       OUTPUT ${LIBCLC_OUTPUT_LIBRARY_DIR}/${alias_suffix}
-      COMMAND ${CMAKE_COMMAND} -E create_symlink ${libclc_builtins_lib} ${LIBCLC_OUTPUT_LIBRARY_DIR}/${alias_suffix}
+      COMMAND ${CMAKE_COMMAND} -E ${LIBCLC_LINK_OR_COPY} ${libclc_builtins_lib} ${LIBCLC_OUTPUT_LIBRARY_DIR}/${alias_suffix}
       DEPENDS prepare-${obj_suffix}
     )
     add_custom_target( alias-${alias_suffix} ALL


### PR DESCRIPTION
This mirrors how other LLVM libraries handle symlinks