### PR TITLE
[flang] Fix array assignment regression introduced by #147371

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/OptimizedBufferization.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/OptimizedBufferization.cpp
@@ -805,8 +805,8 @@ llvm::LogicalResult BroadcastAssignBufferization::matchAndRewrite(
                                                shape, /*slice=*/mlir::Value{});
     } else {
       // Array references must have fixed shape, when used in assignments.
-      auto refTy = mlir::cast<fir::ReferenceType>(lhs.getType());
-      auto seqTy = mlir::cast<fir::SequenceType>(refTy.getElementType());
+      auto seqTy =
+          mlir::cast<fir::SequenceType>(fir::unwrapRefType(lhs.getType()));
       llvm::ArrayRef<int64_t> fixedShape = seqTy.getShape();
       int64_t flatExtent = 1;
       for (int64_t extent : fixedShape)

--- a/flang/test/HLFIR/opt-scalar-assign.fir
+++ b/flang/test/HLFIR/opt-scalar-assign.fir
@@ -184,3 +184,34 @@ func.func private @_QFPtest7(%arg0: !fir.ref<tuple<!fir.box<!fir.array<2x2xi32>>
 // CHECK:             hlfir.assign %[[VAL_0]] to %[[VAL_2]] : i32, !fir.ref<i32>
 // CHECK:           }
 // CHECK:         }
+
+func.func @_QPtest8() {
+  %0 = fir.dummy_scope : !fir.dscope
+  %1 = fir.alloca !fir.array<120xi8> {uniq_name = "_QFtest8Ea"}
+  %c0 = arith.constant 0 : index
+  %2 = fir.coordinate_of %1, %c0 : (!fir.ref<!fir.array<120xi8>>, index) -> !fir.ref<i8>
+  %3 = fir.convert %2 : (!fir.ref<i8>) -> !fir.ptr<!fir.array<2x10xf32>>
+  %c2 = arith.constant 2 : index
+  %c10 = arith.constant 10 : index
+  %4 = fir.shape %c2, %c10 : (index, index) -> !fir.shape<2>
+  %5:2 = hlfir.declare %3(%4) {uniq_name = "_QFtest8Ea"} : (!fir.ptr<!fir.array<2x10xf32>>, !fir.shape<2>) -> (!fir.ptr<!fir.array<2x10xf32>>, !fir.ptr<!fir.array<2x10xf32>>)
+  %c0_0 = arith.constant 0 : index
+  %6 = fir.coordinate_of %1, %c0_0 : (!fir.ref<!fir.array<120xi8>>, index) -> !fir.ref<i8>
+  %7 = fir.convert %6 : (!fir.ref<i8>) -> !fir.ptr<!fir.array<30xf32>>
+  %c30 = arith.constant 30 : index
+  %8 = fir.shape %c30 : (index) -> !fir.shape<1>
+  %9:2 = hlfir.declare %7(%8) {uniq_name = "_QFtest8Eb"} : (!fir.ptr<!fir.array<30xf32>>, !fir.shape<1>) -> (!fir.ptr<!fir.array<30xf32>>, !fir.ptr<!fir.array<30xf32>>)
+  %cst = arith.constant -1.000000e+00 : f32
+  hlfir.assign %cst to %5#0 : f32, !fir.ptr<!fir.array<2x10xf32>>
+  return
+}
+
+// CHECK-LABEL:   func.func @_QPtest8() {
+// CHECK:           %[[VAL_0:.*]] = arith.constant -1.000000e+00 : f32
+// CHECK:           %[[VAL_1:.*]]:2 = hlfir.declare %{{.*}}(%{{.*}}) {uniq_name = "_QFtest8Ea"} : (!fir.ptr<!fir.array<2x10xf32>>, !fir.shape<2>) -> (!fir.ptr<!fir.array<2x10xf32>>, !fir.ptr<!fir.array<2x10xf32>>)
+// CHECK:           %[[VAL_2:.*]] = fir.convert %[[VAL_1]]#0 : (!fir.ptr<!fir.array<2x10xf32>>) -> !fir.ref<!fir.array<20xf32>>
+// CHECK:           fir.do_loop %[[VAL_3:.*]] = %{{.*}} to %{{.*}} step %{{.*}} unordered {
+// CHECK:             %[[VAL_4:.*]] = hlfir.designate %[[VAL_2]] (%[[VAL_3]]) : (!fir.ref<!fir.array<20xf32>>, index) -> !fir.ref<f32>
+// CHECK:             hlfir.assign %[[VAL_0]] to %[[VAL_4]] : f32, !fir.ref<f32>
+// CHECK:           }
+// CHECK:         }


### PR DESCRIPTION
In some cases fixed shape arrays can be fir.heap/fir.ptr, even
after hlfir::derefPointersAndAllocatables() is called.
