### PR TITLE
[clang][analyzer] Add C standard streams to the internal memory space

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1063,9 +1063,11 @@ const VarRegion *MemRegionManager::getVarRegion(const VarDecl *D,
       bool IsStdStreamVar = Ty->isPointerType() &&
                             Ty->getPointeeType() == FILETy &&
                             (N == "stdin" || N == "stdout" || N == "stderr");
-      // Pointer value of C standard streams is usually not modified by system
-      // calls. This means they should not get invalidated at system calls and
-      // can not belong to the system memory space.
+      // Pointer value of C standard streams is usually not modified by calls
+      // to functions declared in system headers. This means that they should
+      // not get invalidated by calls to functions declared in system headers,
+      // so they are placed in the global internal space, which is not
+      // invalidated by calls to functions declared in system headers.
       if (Ctx.getSourceManager().isInSystemHeader(D->getLocation()) &&
           !IsStdStreamVar) {
         sReg = getGlobalsRegion(MemRegion::GlobalSystemSpaceRegionKind);

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1023,13 +1023,12 @@ getStackOrCaptureRegionForDeclContext(const LocationContext *LC,
 }
 
 static bool isStdStreamVar(const VarDecl *D) {
-  const auto *ND = dyn_cast<NamedDecl>(D);
-  if (!ND)
+  const IdentifierInfo *II = D->getIdentifier();
+  if (!II)
     return false;
-  DeclarationName DeclN = ND->getDeclName();
-  if (!DeclN.isIdentifier())
+  if (!D->getDeclContext()->isTranslationUnit())
     return false;
-  StringRef N = DeclN.getAsIdentifierInfo()->getName();
+  StringRef N = II->getName();
   QualType FILETy = D->getASTContext().getFILEType();
   if (FILETy.isNull())
     return false;


### PR DESCRIPTION
If variables `stdin`, `stdout`, `stderr` are added to the system memory space, they are invalidated at any call to system (or C library) functions. These variables are not expected to be changed by system functions, therefore should not belong to the system memory space. This change moves these to the "internal memory space" which is not invalidated at system calls (but is at non-system calls). This eliminates some false positives coming from StreamChecker.