### PR TITLE
[CI] Remove Remaining Buildkite References in generate_test_report_lib

### DIFF
--- a/.ci/generate_test_report_github.py
+++ b/.ci/generate_test_report_github.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     report, _ = generate_test_report_lib.generate_report_from_files(
-        args.title, args.return_code, args.junit_files, None
+        args.title, args.return_code, args.junit_files
     )
 
     print(report)

--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -18,7 +18,6 @@ def generate_report(
     junit_objects,
     size_limit=1024 * 1024,
     list_failures=True,
-    buildkite_info=None,
 ):
     if not junit_objects:
         # Note that we do not post an empty report, therefore we can ignore a
@@ -73,22 +72,12 @@ def generate_report(
     if tests_failed:
         report.append(f"* {tests_failed} {plural(tests_failed)} failed")
 
-    if buildkite_info is not None:
-        log_url = (
-            "https://buildkite.com/organizations/{BUILDKITE_ORGANIZATION_SLUG}/"
-            "pipelines/{BUILDKITE_PIPELINE_SLUG}/builds/{BUILDKITE_BUILD_NUMBER}/"
-            "jobs/{BUILDKITE_JOB_ID}/download.txt".format(**buildkite_info)
-        )
-        download_text = f"[Download]({log_url})"
-    else:
-        download_text = "Download"
-
     if not list_failures:
         report.extend(
             [
                 "",
                 "Failed tests and their output was too large to report. "
-                f"{download_text} the build's log file to see the details.",
+                "Download the build's log file to see the details.",
             ]
         )
     elif failures:
@@ -118,7 +107,7 @@ def generate_report(
                 "",
                 "All tests passed but another part of the build **failed**.",
                 "",
-                f"{download_text} the build's log file to see the details.",
+                "Download the build's log file to see the details.",
             ]
         )
 
@@ -141,16 +130,14 @@ def generate_report(
             junit_objects,
             size_limit,
             list_failures=False,
-            buildkite_info=buildkite_info,
         )
 
     return report, style
 
 
-def generate_report_from_files(title, return_code, junit_files, buildkite_info):
+def generate_report_from_files(title, return_code, junit_files):
     return generate_report(
         title,
         return_code,
         [JUnitXml.fromfile(p) for p in junit_files],
-        buildkite_info=buildkite_info,
     )

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -93,12 +93,6 @@ class TestReports(unittest.TestCase):
                         )
                     )
                 ],
-                buildkite_info={
-                    "BUILDKITE_ORGANIZATION_SLUG": "organization_slug",
-                    "BUILDKITE_PIPELINE_SLUG": "pipeline_slug",
-                    "BUILDKITE_BUILD_NUMBER": "build_number",
-                    "BUILDKITE_JOB_ID": "job_id",
-                },
             ),
             (
                 dedent(
@@ -109,7 +103,7 @@ class TestReports(unittest.TestCase):
 
               All tests passed but another part of the build **failed**.
 
-              [Download](https://buildkite.com/organizations/organization_slug/pipelines/pipeline_slug/builds/build_number/jobs/job_id/download.txt) the build's log file to see the details.
+              Download the build's log file to see the details.
               
               If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
                 ),
@@ -346,12 +340,6 @@ class TestReports(unittest.TestCase):
                     )
                 ],
                 list_failures=False,
-                buildkite_info={
-                    "BUILDKITE_ORGANIZATION_SLUG": "organization_slug",
-                    "BUILDKITE_PIPELINE_SLUG": "pipeline_slug",
-                    "BUILDKITE_BUILD_NUMBER": "build_number",
-                    "BUILDKITE_JOB_ID": "job_id",
-                },
             ),
             (
                 dedent(
@@ -360,7 +348,7 @@ class TestReports(unittest.TestCase):
 
           * 1 test failed
 
-          Failed tests and their output was too large to report. [Download](https://buildkite.com/organizations/organization_slug/pipelines/pipeline_slug/builds/build_number/jobs/job_id/download.txt) the build's log file to see the details.
+          Failed tests and their output was too large to report. Download the build's log file to see the details.
           
           If these failures are unrelated to your changes (for example tests are broken or flaky at HEAD), please open an issue at https://github.com/llvm/llvm-project/issues and add the `infrastructure` label."""
                 ),


### PR DESCRIPTION
This patch removes the buildkite_info object from
generate_test_report_lib as we no longer support buildkite so it is dead
code now. Eventually we should set up equivalent functionality on the
Github side for downloading the logs from a convenient link, but for now
clean up the code.
