### PR TITLE
[libc] Fix DyadicFloat::generic_as() requiring LIBC_TYPES_HAS_FLOAT16

### DIFF
--- a/libc/src/__support/FPUtil/dyadic_float.h
+++ b/libc/src/__support/FPUtil/dyadic_float.h
@@ -170,7 +170,6 @@ template <size_t Bits> struct DyadicFloat {
     return DyadicFloat(result_sign, result_exponent, result_mantissa);
   }
 
-#ifdef LIBC_TYPES_HAS_FLOAT16
   template <typename T, bool ShouldSignalExceptions>
   LIBC_INLINE constexpr cpp::enable_if_t<
       cpp::is_floating_point_v<T> && (FPBits<T>::FRACTION_LEN < Bits), T>
@@ -277,7 +276,6 @@ template <size_t Bits> struct DyadicFloat {
 
     return FPBits(result).get_val();
   }
-#endif // LIBC_TYPES_HAS_FLOAT16
 
   template <typename T, bool ShouldSignalExceptions,
             typename = cpp::enable_if_t<cpp::is_floating_point_v<T> &&


### PR DESCRIPTION
See https://lab.llvm.org/buildbot/#/builders/215/builds/710.
