### PR TITLE
[ARM] Improve arm_neon.h header diagnostic when included on unsupported targets

### DIFF
--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -2417,7 +2417,9 @@ void NeonEmitter::run(raw_ostream &OS) {
   OS << "#ifndef __ARM_NEON_H\n";
   OS << "#define __ARM_NEON_H\n\n";
 
-  OS << "#ifndef __ARM_FP\n";
+  OS << "#if !defined(__arm__) && !defined(__aarch64__) && !defined(__arm64ec__)\n";
+  OS << "#error \"<arm_neon.h> is intended only for ARM and AArch64 targets\"\n";
+  OS << "#elif !defined(__ARM_FP)\n";
   OS << "#error \"NEON intrinsics not available with the soft-float ABI. "
         "Please use -mfloat-abi=softfp or -mfloat-abi=hard\"\n";
   OS << "#else\n\n";

--- a/clang/utils/TableGen/NeonEmitter.cpp
+++ b/clang/utils/TableGen/NeonEmitter.cpp
@@ -2417,8 +2417,10 @@ void NeonEmitter::run(raw_ostream &OS) {
   OS << "#ifndef __ARM_NEON_H\n";
   OS << "#define __ARM_NEON_H\n\n";
 
-  OS << "#if !defined(__arm__) && !defined(__aarch64__) && !defined(__arm64ec__)\n";
-  OS << "#error \"<arm_neon.h> is intended only for ARM and AArch64 targets\"\n";
+  OS << "#if !defined(__arm__) && !defined(__aarch64__) && "
+        "!defined(__arm64ec__)\n";
+  OS << "#error \"<arm_neon.h> is intended only for ARM and AArch64 "
+        "targets\"\n";
   OS << "#elif !defined(__ARM_FP)\n";
   OS << "#error \"NEON intrinsics not available with the soft-float ABI. "
         "Please use -mfloat-abi=softfp or -mfloat-abi=hard\"\n";


### PR DESCRIPTION
The footgun here was that the preprocessor diagnostic that looks for __ARM_FP would fire when included on targets like x86_64, but the suggestion it gives in that case is totally bogus. Avoid giving bad advice, by first checking whether we're being built for an appropriate target, and only then do the soft-fp check.

rdar://155449666