### PR TITLE
[libc][math] Refactor frexpf128 implementation to header-only in src/…

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -13,5 +13,6 @@
 
 #include "math/expf.h"
 #include "math/expf16.h"
+#include "math/frexpf128.h"
 
 #endif // LLVM_LIBC_SHARED_MATH_H

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -1,0 +1,30 @@
+//===-- Shared frexpf128 function -------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_FREXPF128_H
+#define LLVM_LIBC_SHARED_MATH_FREXPF128_H
+
+#include "include/llvm-libc-types/float128.h"
+#include "shared/libc_common.h"
+#include "src/__support/macros/properties/complex_types.h"
+
+#ifndef LIBC_TYPES_HAS_FLOAT128
+#error unsupported
+#endif
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using math::frexpf128;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SHARED_MATH_FREXPF128_H

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -10,12 +10,11 @@
 #define LLVM_LIBC_SHARED_MATH_FREXPF128_H
 
 #include "include/llvm-libc-types/float128.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT128
+
 #include "shared/libc_common.h"
 #include "src/__support/macros/properties/complex_types.h"
-
-#ifndef LIBC_TYPES_HAS_FLOAT128
-#error unsupported
-#endif
 
 namespace LIBC_NAMESPACE_DECL {
 namespace shared {

--- a/libc/shared/math/frexpf128.h
+++ b/libc/shared/math/frexpf128.h
@@ -14,7 +14,6 @@
 #ifdef LIBC_TYPES_HAS_FLOAT128
 
 #include "shared/libc_common.h"
-#include "src/__support/macros/properties/complex_types.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace shared {

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -55,3 +55,12 @@ add_header_library(
     libc.src.__support.macros.optimization
     libc.include.llvm-libc-macros.float16_macros
 )
+
+add_header_library(
+  frexpf128
+  HDRS
+    frexpf128.h
+  DEPENDS
+    libc.src.__support.macros.properties.types
+    libc.src.__support.FPUtil.manipulation_functions
+)

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -1,0 +1,36 @@
+//===-- Implementation header for expf --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H
+
+#include "include/llvm-libc-types/float128.h"
+
+#ifndef LIBC_TYPES_HAS_FLOAT128
+#error unsupported
+#else
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+static constexpr float128 frexpf128(float128 x, int *exp) {
+  return fputil::frexp(x, *exp);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT128
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_FREXPF128_H

--- a/libc/src/__support/math/frexpf128.h
+++ b/libc/src/__support/math/frexpf128.h
@@ -11,9 +11,7 @@
 
 #include "include/llvm-libc-types/float128.h"
 
-#ifndef LIBC_TYPES_HAS_FLOAT128
-#error unsupported
-#else
+#ifdef LIBC_TYPES_HAS_FLOAT128
 
 #include "src/__support/FPUtil/ManipulationFunctions.h"
 #include "src/__support/common.h"

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1775,8 +1775,7 @@ add_entrypoint_object(
   HDRS
     ../frexpf128.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.math.frexpf128
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/frexpf128.cpp
+++ b/libc/src/math/generic/frexpf128.cpp
@@ -7,14 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/frexpf128.h"
-#include "src/__support/FPUtil/ManipulationFunctions.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+
+#include "src/__support/math/frexpf128.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(float128, frexpf128, (float128 x, int *exp)) {
-  return fputil::frexp(x, *exp);
+  return math::frexpf128(x, exp);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2756,7 +2756,6 @@ libc_math_function(
     name = "expf",
     additional_deps = [
         ":__support_math_expf",
-        ":__support_math_frexpf128",
         ":errno",
     ],
 )
@@ -3210,7 +3209,12 @@ libc_math_function(name = "frexpf")
 
 libc_math_function(name = "frexpl")
 
-libc_math_function(name = "frexpf128")
+libc_math_function(
+    name = "frexpf128",
+    additional_deps = [
+        ":__support_math_frexpf128",
+    ]
+)
 
 libc_math_function(name = "frexpf16")
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2149,6 +2149,15 @@ libc_support_library(
     ],
 )
 
+libc_support_library(
+    name = "__support_math_frexpf128",
+    hdrs = ["src/__support/math/frexpf128.h"],
+    deps = [
+        ":__support_macros_properties_types",
+        ":__support_fputil_manipulation_functions",
+    ],
+)
+
 ############################### complex targets ################################
 
 libc_function(
@@ -2747,6 +2756,7 @@ libc_math_function(
     name = "expf",
     additional_deps = [
         ":__support_math_expf",
+        ":__support_math_frexpf128",
         ":errno",
     ],
 )


### PR DESCRIPTION
Part of #147386 

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450

@lntue