### PR TITLE
[RISCV] Remove BREV8 and ORC_B from hasAllNBitUsers in RISCVOptWInstrs.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
+++ b/llvm/lib/Target/RISCV/RISCVOptWInstrs.cpp
@@ -311,9 +311,7 @@ static bool hasAllNBitUsers(const MachineInstr &OrigMI,
       case RISCV::XORI:
 
       case RISCV::ANDN:
-      case RISCV::BREV8:
       case RISCV::CLMUL:
-      case RISCV::ORC_B:
       case RISCV::ORN:
       case RISCV::SH1ADD:
       case RISCV::SH2ADD:


### PR DESCRIPTION
These instructions operate on bytes so we need to round the demanded bits up to the nearest byte which we aren't doing. I think we forgot to update this when we changed from hasAllWUsers to hasNBitUsers.

We don't have any test case for these instruction so remove them until we can put together a test.