### PR TITLE
[libcxx] Bump Container Runner Version

### DIFF
--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       dockerfile: Dockerfile
       target: actions-builder
       args:
-        BASE_IMAGE: ghcr.io/actions/actions-runner:2.322.0
+        BASE_IMAGE: ghcr.io/actions/actions-runner:2.326.0
         <<: *compiler_versions
 
   android-buildkite-builder:


### PR DESCRIPTION
This patch bumps the runner version from v3.222.0 to v3.226.0 as v3.222.0 is too old at this point to connect to Github. This is needed for the new premerge system given we are directly using this container. This did not impact the existing libc++ CI as the runner was contained in a separate container image.