### PR TITLE
[flang][acc] Update FIR ref, heap, and pointer to be MappableType

### DIFF
--- a/flang/lib/Lower/OpenACC.cpp
+++ b/flang/lib/Lower/OpenACC.cpp
@@ -164,14 +164,13 @@ createDataEntryOp(fir::FirOpBuilder &builder, mlir::Location loc,
   op.setStructured(structured);
   op.setImplicit(implicit);
   op.setDataClause(dataClause);
-  if (auto mappableTy =
-          mlir::dyn_cast<mlir::acc::MappableType>(baseAddr.getType())) {
-    op.setVarType(baseAddr.getType());
+  if (auto pointerLikeTy =
+          mlir::dyn_cast<mlir::acc::PointerLikeType>(baseAddr.getType())) {
+    op.setVarType(pointerLikeTy.getElementType());
   } else {
-    assert(mlir::isa<mlir::acc::PointerLikeType>(baseAddr.getType()) &&
-           "expected pointer-like");
-    op.setVarType(mlir::cast<mlir::acc::PointerLikeType>(baseAddr.getType())
-                      .getElementType());
+    assert(mlir::isa<mlir::acc::MappableType>(baseAddr.getType()) &&
+           "expected mappable");
+    op.setVarType(baseAddr.getType());
   }
 
   op->setAttr(Op::getOperandSegmentSizeAttr(),

--- a/flang/lib/Optimizer/Dialect/FIRType.cpp
+++ b/flang/lib/Optimizer/Dialect/FIRType.cpp
@@ -1533,7 +1533,9 @@ std::optional<std::pair<uint64_t, unsigned short>>
 fir::getTypeSizeAndAlignment(mlir::Location loc, mlir::Type ty,
                              const mlir::DataLayout &dl,
                              const fir::KindMapping &kindMap) {
-  if (mlir::isa<mlir::IntegerType, mlir::FloatType, mlir::ComplexType>(ty)) {
+  if (ty.isIntOrIndexOrFloat() ||
+      mlir::isa<mlir::ComplexType, mlir::VectorType,
+                mlir::DataLayoutTypeInterface>(ty)) {
     llvm::TypeSize size = dl.getTypeSize(ty);
     unsigned short alignment = dl.getTypeABIAlignment(ty);
     return std::pair{size, alignment};

--- a/flang/lib/Optimizer/OpenACC/RegisterOpenACCExtensions.cpp
+++ b/flang/lib/Optimizer/OpenACC/RegisterOpenACCExtensions.cpp
@@ -19,11 +19,14 @@ namespace fir::acc {
 void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
   registry.addExtension(+[](mlir::MLIRContext *ctx,
                             fir::FIROpsDialect *dialect) {
-    fir::SequenceType::attachInterface<OpenACCMappableModel<fir::SequenceType>>(
-        *ctx);
     fir::BoxType::attachInterface<OpenACCMappableModel<fir::BaseBoxType>>(*ctx);
     fir::ClassType::attachInterface<OpenACCMappableModel<fir::BaseBoxType>>(
         *ctx);
+    fir::ReferenceType::attachInterface<
+        OpenACCMappableModel<fir::ReferenceType>>(*ctx);
+    fir::PointerType::attachInterface<OpenACCMappableModel<fir::PointerType>>(
+        *ctx);
+    fir::HeapType::attachInterface<OpenACCMappableModel<fir::HeapType>>(*ctx);
 
     fir::ReferenceType::attachInterface<
         OpenACCPointerLikeModel<fir::ReferenceType>>(*ctx);
@@ -31,6 +34,7 @@ void registerOpenACCExtensions(mlir::DialectRegistry &registry) {
         OpenACCPointerLikeModel<fir::PointerType>>(*ctx);
     fir::HeapType::attachInterface<OpenACCPointerLikeModel<fir::HeapType>>(
         *ctx);
+
     fir::LLVMPointerType::attachInterface<
         OpenACCPointerLikeModel<fir::LLVMPointerType>>(*ctx);
   });

--- a/flang/test/Fir/OpenACC/openacc-mappable.fir
+++ b/flang/test/Fir/OpenACC/openacc-mappable.fir
@@ -23,7 +23,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   // CHECK: Size: 40
 
   // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "arr", structured = false}
-  // CHECK: Mappable: !fir.array<10xf32>
+  // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
   // CHECK: Type category: array
   // CHECK: Size: 40
 
@@ -60,20 +60,17 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<f16 = dense<16> : vector<2xi64>,
   }
 
   // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr1", structured = false}
-  // CHECK: Pointer-like: !fir.ref<!fir.array<?xf32>>
-  // CHECK: Mappable: !fir.array<?xf32>
+  // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<?xf32>>
   // CHECK: Type category: array
   // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%c1{{.*}} : index) startIdx(%c1{{.*}} : index)
 
   // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<?xf32>>) -> !fir.ref<!fir.array<?xf32>> {name = "arr2", structured = false}
-  // CHECK: Pointer-like: !fir.ref<!fir.array<?xf32>>
-  // CHECK: Mappable: !fir.array<?xf32>
+  // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<?xf32>>
   // CHECK: Type category: array
   // CHECK: Bound[0]: %{{.*}} = acc.bounds lowerbound(%c0{{.*}} : index) upperbound(%{{.*}} : index) extent(%{{.*}} : index) stride(%c1{{.*}} : index) startIdx(%c2{{.*}} : index)
 
   // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<!fir.array<10xf32>>) -> !fir.ref<!fir.array<10xf32>> {name = "arr3", structured = false}
-  // CHECK: Pointer-like: !fir.ref<!fir.array<10xf32>>
-  // CHECK: Mappable: !fir.array<10xf32>
+  // CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
   // CHECK: Type category: array
   // CHECK: Size: 40
   // CHECK: Offset: 0

--- a/flang/test/Fir/OpenACC/openacc-type-categories-class.f90
+++ b/flang/test/Fir/OpenACC/openacc-type-categories-class.f90
@@ -29,13 +29,13 @@ end module
 ! CHECK: Mappable: !fir.class<!fir.type<_QMmmTpolyty{field:f32}>>
 ! CHECK: Type category: composite
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "this%field", structured = false}
-! CHECK: Pointer-like: !fir.ref<f32>
+! CHECK: Pointer-like and Mappable: !fir.ref<f32>
 ! CHECK: Type category: composite
 
 ! For unlimited polymorphic entities and assumed types - they effectively have
 ! no declared type. Thus the type categorizer cannot categorize it.
 ! CHECK: Visiting: {{.*}} = acc.copyin {{.*}} {name = "var", structured = false}
-! CHECK: Pointer-like: !fir.ref<none>
+! CHECK: Pointer-like and Mappable: !fir.ref<none>
 ! CHECK: Type category: uncategorized
 ! CHECK: Visiting: {{.*}} = acc.copyin {{.*}} {name = "this", structured = false}
 ! CHECK: Mappable: !fir.class<none>

--- a/flang/test/Fir/OpenACC/openacc-type-categories.f90
+++ b/flang/test/Fir/OpenACC/openacc-type-categories.f90
@@ -18,32 +18,32 @@ program main
 end program
 
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "scalar", structured = false}
-! CHECK: Pointer-like: !fir.ref<f32>
+! CHECK: Pointer-like and Mappable: !fir.ref<f32>
 ! CHECK: Type category: scalar
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "scalaralloc", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.box<!fir.heap<f32>>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.box<!fir.heap<f32>>>
 ! CHECK: Type category: nonscalar
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "ttvar", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.type<_QFTtt{field:f32,fieldarray:!fir.array<10xf32>}>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.type<_QFTtt{field:f32,fieldarray:!fir.array<10xf32>}>>
 ! CHECK: Type category: composite
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "arrayconstsize", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.array<10xf32>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
 ! CHECK: Type category: array
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "arrayalloc", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
 ! CHECK: Type category: array
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "complexvar", structured = false}
-! CHECK: Pointer-like: !fir.ref<complex<f32>>
+! CHECK: Pointer-like and Mappable: !fir.ref<complex<f32>>
 ! CHECK: Type category: scalar
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "charvar", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.char<1>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.char<1>>
 ! CHECK: Type category: nonscalar
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "ttvar%field", structured = false}
-! CHECK: Pointer-like: !fir.ref<f32>
+! CHECK: Pointer-like and Mappable: !fir.ref<f32>
 ! CHECK: Type category: composite
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "ttvar%fieldarray", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.array<10xf32>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
 ! CHECK: Type category: array
 ! CHECK: Visiting: {{.*}} acc.copyin {{.*}} {name = "arrayconstsize(1)", structured = false}
-! CHECK: Pointer-like: !fir.ref<!fir.array<10xf32>>
+! CHECK: Pointer-like and Mappable: !fir.ref<!fir.array<10xf32>>
 ! CHECK: Type category: array

--- a/flang/test/lib/OpenACC/TestOpenACCInterfaces.cpp
+++ b/flang/test/lib/OpenACC/TestOpenACCInterfaces.cpp
@@ -58,8 +58,18 @@ struct TestFIROpenACCInterfaces
         llvm::errs() << "Visiting: " << *op << "\n";
         llvm::errs() << "\tVar: " << var << "\n";
 
-        if (auto ptrTy = dyn_cast_if_present<acc::PointerLikeType>(typeOfVar)) {
+        if (mlir::isa<acc::PointerLikeType>(typeOfVar) &&
+            mlir::isa<acc::MappableType>(typeOfVar)) {
+          llvm::errs() << "\tPointer-like and Mappable: " << typeOfVar << "\n";
+        } else if (mlir::isa<acc::PointerLikeType>(typeOfVar)) {
           llvm::errs() << "\tPointer-like: " << typeOfVar << "\n";
+        } else {
+          assert(mlir::isa<acc::MappableType>(typeOfVar) &&
+                 "expected mappable");
+          llvm::errs() << "\tMappable: " << typeOfVar << "\n";
+        }
+
+        if (auto ptrTy = dyn_cast_if_present<acc::PointerLikeType>(typeOfVar)) {
           // If the pointee is not mappable, print details about it. Otherwise,
           // we defer to the mappable printing below to print those details.
           if (!mappableTy) {
@@ -72,8 +82,6 @@ struct TestFIROpenACCInterfaces
         }
 
         if (mappableTy) {
-          llvm::errs() << "\tMappable: " << mappableTy << "\n";
-
           acc::VariableTypeCategory typeCategory =
               mappableTy.getTypeCategory(var);
           llvm::errs() << "\t\tType category: " << typeCategory << "\n";

--- a/flang/test/lib/OpenACC/TestOpenACCInterfaces.cpp
+++ b/flang/test/lib/OpenACC/TestOpenACCInterfaces.cpp
@@ -64,8 +64,8 @@ struct TestFIROpenACCInterfaces
         } else if (mlir::isa<acc::PointerLikeType>(typeOfVar)) {
           llvm::errs() << "\tPointer-like: " << typeOfVar << "\n";
         } else {
-          assert(mlir::isa<acc::MappableType>(typeOfVar) &&
-                 "expected mappable");
+          assert(
+              mlir::isa<acc::MappableType>(typeOfVar) && "expected mappable");
           llvm::errs() << "\tMappable: " << typeOfVar << "\n";
         }
 


### PR DESCRIPTION
The MappableType OpenACC type interface is a richer interface that allows OpenACC dialect to be capable to better interact with a source dialect, FIR in this case. fir.box and fir.class types already implemented this interface. Now the same is being done with the other FIR types that represent variables.

One additional notable change is that fir.array no longer implements this interface. This is because MappableType is primarily intended for variables - and FIR variables of this type have storage associated and thus there's a pointer-like type (fir.ref/heap/pointer) that holds the array type.

The end goal of promoting these FIR types to MappableType is that we will soon implement ability to generate recipes outside of the frontend via this interface.