### PR TITLE
[flang] Don't check the '-mframe-pointer' flag

### DIFF
--- a/flang/test/Driver/frontend-forwarding.f90
+++ b/flang/test/Driver/frontend-forwarding.f90
@@ -60,7 +60,6 @@
 ! CHECK: "-Reverything"
 ! CHECK: "-Rno-everything"
 ! CHECK: "-Rpass=inline"
-! CHECK: "-mframe-pointer=none"
 ! CHECK: "-mllvm" "-print-before-all"
 ! CHECK: "-fwrapv"
 ! CHECK: "-save-temps=obj"


### PR DESCRIPTION
The `-mframe-pointer` flag is not explicitly set in the original `flang` invocation and so the value passed to `flang -fc1` can vary depending on the host machine, so don't verify it in the output.

`-mframe-pointer` forwarding is already verified by `flang/test/Driver/frame-pointer-forwarding.f90`.