### PR TITLE
[NFC][TableGen] Remove small heap allocations in SearchableTableEmitter

### DIFF
--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -320,8 +320,9 @@ void SearchableTableEmitter::emitGenericEnum(const GenericEnum &Enum,
   emitIfdef((Twine("GET_") + Enum.PreprocessorGuard + "_DECL").str(), OS);
 
   OS << "enum " << Enum.Name << " {\n";
-  for (const auto &[_, Entry] : Enum.Entries.getArrayRef())
-    OS << "  " << Entry.Name << " = " << Entry.Value << ",\n";
+  for (const auto &[Name, Value] :
+       make_second_range(Enum.Entries.getArrayRef()))
+    OS << "  " << Name << " = " << Value << ",\n";
   OS << "};\n";
 
   OS << "#endif\n\n";

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -651,7 +651,9 @@ void SearchableTableEmitter::collectEnumEntries(
   if (ValueField.empty()) {
     // Copy the map entries for sorting and clear the map.
     auto SavedEntries = Enum.Entries.takeVector();
-    llvm::stable_sort(SavedEntries, [](const auto &LHS, const auto &RHS) {
+    using MapVectorEntryTy = std::pair<const Record *, GenericEnum::Entry>;
+    llvm::stable_sort(SavedEntries, [](const MapVectorEntryTy &LHS,
+                                       const MapVectorEntryTy &RHS) {
       return LHS.second.Name < RHS.second.Name;
     });
 

--- a/llvm/utils/TableGen/SearchableTableEmitter.cpp
+++ b/llvm/utils/TableGen/SearchableTableEmitter.cpp
@@ -651,12 +651,9 @@ void SearchableTableEmitter::collectEnumEntries(
   if (ValueField.empty()) {
     // Copy the map entries for sorting and clear the map.
     auto SavedEntries = Enum.Entries.takeVector();
-    llvm::stable_sort(
-        SavedEntries,
-        [](const std::pair<const Record *, GenericEnum::Entry> &LHS,
-           const std::pair<const Record *, GenericEnum::Entry> &RHS) {
-          return LHS.second.Name < RHS.second.Name;
-        });
+    llvm::stable_sort(SavedEntries, [](const auto &LHS, const auto &RHS) {
+      return LHS.second.Name < RHS.second.Name;
+    });
 
     // Repopulate entries using the new sorted order.
     for (auto [Idx, Entry] : enumerate(SavedEntries))


### PR DESCRIPTION
Change `GenericEnum` to not heap allocate its entries. Instead stash them directly in the `Entries` vector. Change `EntryMap` to hold an index as opposed to a pointer to the entry (the original reason why they were unique_ptr).