### PR TITLE
[PseudoProbe] use print to emit function name

### DIFF
--- a/llvm/lib/MC/MCAsmStreamer.cpp
+++ b/llvm/lib/MC/MCAsmStreamer.cpp
@@ -2466,7 +2466,8 @@ void MCAsmStreamer::emitPseudoProbe(uint64_t Guid, uint64_t Index,
   for (const auto &Site : InlineStack)
     OS << " @ " << std::get<0>(Site) << ":" << std::get<1>(Site);
 
-  OS << " " << FnSym->getName();
+  OS << " ";
+  FnSym->print(OS, MAI);
 
   EmitEOL();
 }


### PR DESCRIPTION
This PR is part of #123870.

For COFF Asm, function name should be wrapped in quotes.
MCSymbol::print will automatically do that.