### PR TITLE
TargetLowering: Avoid a use of PointerType::getUnqual

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -1991,7 +1991,9 @@ bool TargetLoweringBase::isLegalAddressingMode(const DataLayout &DL,
 Value *TargetLoweringBase::getIRStackGuard(IRBuilderBase &IRB) const {
   if (getTargetMachine().getTargetTriple().isOSOpenBSD()) {
     Module &M = *IRB.GetInsertBlock()->getParent()->getParent();
-    PointerType *PtrTy = PointerType::getUnqual(M.getContext());
+    const DataLayout &DL = M.getDataLayout();
+    PointerType *PtrTy =
+        PointerType::get(M.getContext(), DL.getDefaultGlobalsAddressSpace());
     GlobalVariable *G = M.getOrInsertGlobal("__guard_local", PtrTy);
     G->setVisibility(GlobalValue::HiddenVisibility);
     return G;


### PR DESCRIPTION
Use the default globals address space