### PR TITLE
[LoongArch] Add custom lowering for BCOND and perform BR_CC combine

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchFloat32InstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchFloat32InstrInfo.td
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+def NotBoolXor : PatFrags<(ops node:$val),
+                          [(xor node:$val, -1), (xor node:$val, 1)]>;
+
 //===----------------------------------------------------------------------===//
 // LoongArch specific DAG Nodes.
 //===----------------------------------------------------------------------===//
@@ -22,6 +25,9 @@ def SDT_LoongArchFTINT : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisFP<1>]>;
 def SDT_LoongArchFRECIPE : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisFP<1>]>;
 def SDT_LoongArchFRSQRTE : SDTypeProfile<1, 1, [SDTCisFP<0>, SDTCisFP<1>]>;
 
+// ISD::BRCOND is custom-lowered to LoongArchISD::BRCOND for floating-point
+// comparisons to prevent recursive lowering.
+def loongarch_brcond : SDNode<"LoongArchISD::BRCOND", SDTBrcond, [SDNPHasChain]>;
 def loongarch_movgr2fr_w_la64
     : SDNode<"LoongArchISD::MOVGR2FR_W_LA64", SDT_LoongArchMOVGR2FR_W_LA64>;
 def loongarch_movfr2gr_s_la64
@@ -208,16 +214,18 @@ def : PatFPSetcc<SETUO,  FCMP_CUN_S,  FPR32>;
 def : PatFPSetcc<SETLT,  FCMP_CLT_S,  FPR32>;
 
 multiclass PatFPBrcond<CondCode cc, LAInst CmpInst, RegisterClass RegTy> {
-  def : Pat<(brcond (xor (GRLenVT (setcc RegTy:$fj, RegTy:$fk, cc)), -1),
-                     bb:$imm21),
+  def : Pat<(loongarch_brcond (NotBoolXor (GRLenVT (setcc RegTy:$fj, RegTy:$fk, cc))),
+                              bb:$imm21),
             (BCEQZ (CmpInst RegTy:$fj, RegTy:$fk), bb:$imm21)>;
-  def : Pat<(brcond (GRLenVT (setcc RegTy:$fj, RegTy:$fk, cc)), bb:$imm21),
+  def : Pat<(loongarch_brcond (GRLenVT (setcc RegTy:$fj, RegTy:$fk, cc)), bb:$imm21),
             (BCNEZ (CmpInst RegTy:$fj, RegTy:$fk), bb:$imm21)>;
 }
 
 defm : PatFPBrcond<SETOEQ, FCMP_CEQ_S, FPR32>;
+defm : PatFPBrcond<SETEQ , FCMP_CEQ_S, FPR32>;
 defm : PatFPBrcond<SETOLT, FCMP_CLT_S, FPR32>;
 defm : PatFPBrcond<SETOLE, FCMP_CLE_S, FPR32>;
+defm : PatFPBrcond<SETLE,  FCMP_CLE_S, FPR32>;
 defm : PatFPBrcond<SETONE, FCMP_CNE_S, FPR32>;
 defm : PatFPBrcond<SETO,   FCMP_COR_S, FPR32>;
 defm : PatFPBrcond<SETUEQ, FCMP_CUEQ_S, FPR32>;

--- a/llvm/lib/Target/LoongArch/LoongArchFloat64InstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchFloat64InstrInfo.td
@@ -184,8 +184,10 @@ def : PatFPSetcc<SETUO,  FCMP_CUN_D,  FPR64>;
 def : PatFPSetcc<SETLT,  FCMP_CLT_D,  FPR64>;
 
 defm : PatFPBrcond<SETOEQ, FCMP_CEQ_D, FPR64>;
+defm : PatFPBrcond<SETEQ,  FCMP_CEQ_D, FPR64>;
 defm : PatFPBrcond<SETOLT, FCMP_CLT_D, FPR64>;
 defm : PatFPBrcond<SETOLE, FCMP_CLE_D, FPR64>;
+defm : PatFPBrcond<SETLE,  FCMP_CLE_D, FPR64>;
 defm : PatFPBrcond<SETONE, FCMP_CNE_D, FPR64>;
 defm : PatFPBrcond<SETO,   FCMP_COR_D, FPR64>;
 defm : PatFPBrcond<SETUEQ, FCMP_CUEQ_D, FPR64>;

--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -127,6 +127,7 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
 
   setOperationAction(ISD::BR_JT, MVT::Other, Expand);
   setOperationAction(ISD::BR_CC, GRLenVT, Expand);
+  setOperationAction(ISD::BRCOND, MVT::Other, Custom);
   setOperationAction(ISD::SELECT_CC, GRLenVT, Expand);
   setOperationAction(ISD::SIGN_EXTEND_INREG, MVT::i1, Expand);
   setOperationAction({ISD::SMUL_LOHI, ISD::UMUL_LOHI}, GRLenVT, Expand);
@@ -516,6 +517,8 @@ SDValue LoongArchTargetLowering::LowerOperation(SDValue Op,
     return lowerPREFETCH(Op, DAG);
   case ISD::SELECT:
     return lowerSELECT(Op, DAG);
+  case ISD::BRCOND:
+    return lowerBRCOND(Op, DAG);
   case ISD::FP_TO_FP16:
     return lowerFP_TO_FP16(Op, DAG);
   case ISD::FP16_TO_FP:
@@ -911,6 +914,35 @@ SDValue LoongArchTargetLowering::lowerSELECT(SDValue Op,
 
   SDValue Ops[] = {LHS, RHS, TargetCC, TrueV, FalseV};
   return DAG.getNode(LoongArchISD::SELECT_CC, DL, VT, Ops);
+}
+
+SDValue LoongArchTargetLowering::lowerBRCOND(SDValue Op,
+                                             SelectionDAG &DAG) const {
+  SDValue CondV = Op.getOperand(1);
+  SDLoc DL(Op);
+  MVT GRLenVT = Subtarget.getGRLenVT();
+
+  if (CondV.getOpcode() == ISD::SETCC) {
+    if (CondV.getOperand(0).getValueType() == GRLenVT) {
+      SDValue LHS = CondV.getOperand(0);
+      SDValue RHS = CondV.getOperand(1);
+      ISD::CondCode CCVal = cast<CondCodeSDNode>(CondV.getOperand(2))->get();
+
+      translateSetCCForBranch(DL, LHS, RHS, CCVal, DAG);
+
+      SDValue TargetCC = DAG.getCondCode(CCVal);
+      return DAG.getNode(LoongArchISD::BR_CC, DL, Op.getValueType(),
+                         Op.getOperand(0), LHS, RHS, TargetCC,
+                         Op.getOperand(2));
+    } else if (CondV.getOperand(0).getValueType().isFloatingPoint()) {
+      return DAG.getNode(LoongArchISD::BRCOND, DL, Op.getValueType(),
+                         Op.getOperand(0), CondV, Op.getOperand(2));
+    }
+  }
+
+  return DAG.getNode(LoongArchISD::BR_CC, DL, Op.getValueType(),
+                     Op.getOperand(0), CondV, DAG.getConstant(0, DL, GRLenVT),
+                     DAG.getCondCode(ISD::SETNE), Op.getOperand(2));
 }
 
 SDValue
@@ -5208,6 +5240,71 @@ static SDValue performBITREV_WCombine(SDNode *N, SelectionDAG &DAG,
                      Src.getOperand(0));
 }
 
+// Perform combines for BR_CC conditions.
+static bool combine_CC(SDValue &LHS, SDValue &RHS, SDValue &CC, const SDLoc &DL,
+                       SelectionDAG &DAG, const LoongArchSubtarget &Subtarget) {
+  ISD::CondCode CCVal = cast<CondCodeSDNode>(CC)->get();
+
+  // As far as arithmetic right shift always saves the sign,
+  // shift can be omitted.
+  // Fold setlt (sra X, N), 0 -> setlt X, 0 and
+  // setge (sra X, N), 0 -> setge X, 0
+  if (isNullConstant(RHS) && (CCVal == ISD::SETGE || CCVal == ISD::SETLT) &&
+      LHS.getOpcode() == ISD::SRA) {
+    LHS = LHS.getOperand(0);
+    return true;
+  }
+
+  if (!ISD::isIntEqualitySetCC(CCVal))
+    return false;
+
+  // Fold ((setlt X, Y), 0, ne) -> (X, Y, lt)
+  // Sometimes the setcc is introduced after br_cc/select_cc has been formed.
+  if (LHS.getOpcode() == ISD::SETCC && isNullConstant(RHS) &&
+      LHS.getOperand(0).getValueType() == Subtarget.getGRLenVT()) {
+    // If we're looking for eq 0 instead of ne 0, we need to invert the
+    // condition.
+    bool Invert = CCVal == ISD::SETEQ;
+    CCVal = cast<CondCodeSDNode>(LHS.getOperand(2))->get();
+    if (Invert)
+      CCVal = ISD::getSetCCInverse(CCVal, LHS.getValueType());
+
+    RHS = LHS.getOperand(1);
+    LHS = LHS.getOperand(0);
+    translateSetCCForBranch(DL, LHS, RHS, CCVal, DAG);
+
+    CC = DAG.getCondCode(CCVal);
+    return true;
+  }
+
+  // (X, 1, setne) -> (X, 0, seteq) if we can prove X is 0/1.
+  // This can occur when legalizing some floating point comparisons.
+  APInt Mask = APInt::getBitsSetFrom(LHS.getValueSizeInBits(), 1);
+  if (isOneConstant(RHS) && DAG.MaskedValueIsZero(LHS, Mask)) {
+    CCVal = ISD::getSetCCInverse(CCVal, LHS.getValueType());
+    CC = DAG.getCondCode(CCVal);
+    RHS = DAG.getConstant(0, DL, LHS.getValueType());
+    return true;
+  }
+
+  return false;
+}
+
+static SDValue performBR_CCCombine(SDNode *N, SelectionDAG &DAG,
+                                   TargetLowering::DAGCombinerInfo &DCI,
+                                   const LoongArchSubtarget &Subtarget) {
+  SDValue LHS = N->getOperand(1);
+  SDValue RHS = N->getOperand(2);
+  SDValue CC = N->getOperand(3);
+  SDLoc DL(N);
+
+  if (combine_CC(LHS, RHS, CC, DL, DAG, Subtarget))
+    return DAG.getNode(LoongArchISD::BR_CC, DL, N->getValueType(0),
+                       N->getOperand(0), LHS, RHS, CC, N->getOperand(4));
+
+  return SDValue();
+}
+
 template <unsigned N>
 static SDValue legalizeIntrinsicImmArg(SDNode *Node, unsigned ImmOp,
                                        SelectionDAG &DAG,
@@ -5900,6 +5997,8 @@ SDValue LoongArchTargetLowering::PerformDAGCombine(SDNode *N,
     return performBITCASTCombine(N, DAG, DCI, Subtarget);
   case LoongArchISD::BITREV_W:
     return performBITREV_WCombine(N, DAG, DCI, Subtarget);
+  case LoongArchISD::BR_CC:
+    return performBR_CCCombine(N, DAG, DCI, Subtarget);
   case ISD::INTRINSIC_WO_CHAIN:
     return performINTRINSIC_WO_CHAINCombine(N, DAG, DCI, Subtarget);
   case LoongArchISD::MOVGR2FR_W_LA64:
@@ -6629,6 +6728,8 @@ const char *LoongArchTargetLowering::getTargetNodeName(unsigned Opcode) const {
     NODE_NAME_CASE(TAIL_MEDIUM)
     NODE_NAME_CASE(TAIL_LARGE)
     NODE_NAME_CASE(SELECT_CC)
+    NODE_NAME_CASE(BR_CC)
+    NODE_NAME_CASE(BRCOND)
     NODE_NAME_CASE(SLL_W)
     NODE_NAME_CASE(SRA_W)
     NODE_NAME_CASE(SRL_W)

--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
@@ -37,6 +37,10 @@ enum NodeType : unsigned {
   // Select
   SELECT_CC,
 
+  // Branch
+  BR_CC,
+  BRCOND,
+
   // 32-bit shifts, directly matching the semantics of the named LoongArch
   // instructions.
   SLL_W,
@@ -385,6 +389,7 @@ private:
   SDValue lowerSCALAR_TO_VECTOR(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerPREFETCH(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerSELECT(SDValue Op, SelectionDAG &DAG) const;
+  SDValue lowerBRCOND(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFP_TO_FP16(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFP16_TO_FP(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerFP_TO_BF16(SDValue Op, SelectionDAG &DAG) const;

--- a/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
+++ b/llvm/lib/Target/LoongArch/LoongArchInstrInfo.td
@@ -31,6 +31,10 @@ def SDT_LoongArchSelectCC : SDTypeProfile<1, 5, [SDTCisSameAs<1, 2>,
                                                  SDTCisSameAs<0, 4>,
                                                  SDTCisSameAs<4, 5>]>;
 
+def SDT_LoongArchBrCC : SDTypeProfile<0, 4, [SDTCisSameAs<0, 1>,
+                                             SDTCisVT<2, OtherVT>,
+                                             SDTCisVT<3, OtherVT>]>;
+
 def SDT_LoongArchBStrIns: SDTypeProfile<1, 4, [
   SDTCisInt<0>, SDTCisSameAs<0, 1>, SDTCisSameAs<0, 2>, SDTCisInt<3>,
   SDTCisSameAs<3, 4>
@@ -94,6 +98,8 @@ def loongarch_tail_large : SDNode<"LoongArchISD::TAIL_LARGE", SDT_LoongArchCall,
                                   [SDNPHasChain, SDNPOptInGlue, SDNPOutGlue,
                                    SDNPVariadic]>;
 def loongarch_selectcc : SDNode<"LoongArchISD::SELECT_CC", SDT_LoongArchSelectCC>;
+def loongarch_brcc : SDNode<"LoongArchISD::BR_CC", SDT_LoongArchBrCC,
+                            [SDNPHasChain]>;
 def loongarch_sll_w : SDNode<"LoongArchISD::SLL_W", SDT_LoongArchIntBinOpW>;
 def loongarch_sra_w : SDNode<"LoongArchISD::SRA_W", SDT_LoongArchIntBinOpW>;
 def loongarch_srl_w : SDNode<"LoongArchISD::SRL_W", SDT_LoongArchIntBinOpW>;
@@ -1537,47 +1543,29 @@ def : Pat<(select GPR:$cond, GPR:$t, GPR:$f),
 
 /// Branches and jumps
 
-class BccPat<PatFrag CondOp, LAInst Inst>
-    : Pat<(brcond (GRLenVT (CondOp GPR:$rj, GPR:$rd)), bb:$imm16),
-          (Inst GPR:$rj, GPR:$rd, bb:$imm16)>;
-
-def : BccPat<seteq, BEQ>;
-def : BccPat<setne, BNE>;
-def : BccPat<setlt, BLT>;
-def : BccPat<setge, BGE>;
-def : BccPat<setult, BLTU>;
-def : BccPat<setuge, BGEU>;
-
-class BccSwapPat<PatFrag CondOp, LAInst InstBcc>
-    : Pat<(brcond (GRLenVT (CondOp GPR:$rd, GPR:$rj)), bb:$imm16),
-          (InstBcc GPR:$rj, GPR:$rd, bb:$imm16)>;
-
-// Condition codes that don't have matching LoongArch branch instructions, but
-// are trivially supported by swapping the two input operands.
-def : BccSwapPat<setgt, BLT>;
-def : BccSwapPat<setle, BGE>;
-def : BccSwapPat<setugt, BLTU>;
-def : BccSwapPat<setule, BGEU>;
-
 let Predicates = [Has32S] in {
-// An extra pattern is needed for a brcond without a setcc (i.e. where the
-// condition was calculated elsewhere).
-def : Pat<(brcond GPR:$rj, bb:$imm21), (BNEZ GPR:$rj, bb:$imm21)>;
+class BccZeroPat<CondCode Cond, LAInst Inst>
+    : Pat<(loongarch_brcc (GRLenVT GPR:$rj), 0, Cond, bb:$imm21),
+           (Inst GPR:$rj, bb:$imm21)>;
 
-def : Pat<(brcond (GRLenVT (seteq GPR:$rj, 0)), bb:$imm21),
-          (BEQZ GPR:$rj, bb:$imm21)>;
-def : Pat<(brcond (GRLenVT (setne GPR:$rj, 0)), bb:$imm21),
-          (BNEZ GPR:$rj, bb:$imm21)>;
+def : BccZeroPat<SETEQ, BEQZ>;
+def : BccZeroPat<SETNE, BNEZ>;
 } // Predicates = [Has32S]
 
-// An extra pattern is needed for a brcond without a setcc (i.e. where the
-// condition was calculated elsewhere).
-def : Pat<(brcond GPR:$rj, bb:$imm16), (BNE GPR:$rj, R0, bb:$imm16)>;
+multiclass BccPat<CondCode Cond, LAInst Inst> {
+  def : Pat<(loongarch_brcc (GRLenVT GPR:$rj), GPR:$rd, Cond, bb:$imm16),
+            (Inst GPR:$rj, GPR:$rd, bb:$imm16)>;
+  // Explicitly select 0 to R0. The register coalescer doesn't always do it.
+  def : Pat<(loongarch_brcc (GRLenVT GPR:$rj), 0, Cond, bb:$imm16),
+            (Inst GPR:$rj, (GRLenVT R0), bb:$imm16)>;
+}
 
-def : Pat<(brcond (GRLenVT (seteq GPR:$rj, 0)), bb:$imm16),
-          (BEQ GPR:$rj, R0, bb:$imm16)>;
-def : Pat<(brcond (GRLenVT (setne GPR:$rj, 0)), bb:$imm16),
-          (BNE GPR:$rj, R0, bb:$imm16)>;
+defm : BccPat<SETEQ, BEQ>;
+defm : BccPat<SETNE, BNE>;
+defm : BccPat<SETLT, BLT>;
+defm : BccPat<SETGE, BGE>;
+defm : BccPat<SETULT, BLTU>;
+defm : BccPat<SETUGE, BGEU>;
 
 let isBarrier = 1, isBranch = 1, isTerminator = 1 in
 def PseudoBR : Pseudo<(outs), (ins simm26_b:$imm26), [(br bb:$imm26)]>,

--- a/llvm/test/CodeGen/LoongArch/bittest.ll
+++ b/llvm/test/CodeGen/LoongArch/bittest.ll
@@ -975,8 +975,8 @@ define void @bit_10_nz_branch_i32(i32 signext %0) {
 define void @bit_11_z_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_11_z_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    andi $a0, $a0, 2048
-; LA32-NEXT:    bne $a0, $zero, .LBB39_2
+; LA32-NEXT:    slli.w $a0, $a0, 20
+; LA32-NEXT:    bltz $a0, .LBB39_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB39_2:
@@ -984,8 +984,8 @@ define void @bit_11_z_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_11_z_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    andi $a0, $a0, 2048
-; LA64-NEXT:    bnez $a0, .LBB39_2
+; LA64-NEXT:    slli.d $a0, $a0, 52
+; LA64-NEXT:    bltz $a0, .LBB39_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1006,8 +1006,8 @@ define void @bit_11_z_branch_i32(i32 signext %0) {
 define void @bit_11_nz_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_11_nz_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    andi $a0, $a0, 2048
-; LA32-NEXT:    beq $a0, $zero, .LBB40_2
+; LA32-NEXT:    slli.w $a0, $a0, 20
+; LA32-NEXT:    bgez $a0, .LBB40_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB40_2:
@@ -1015,8 +1015,8 @@ define void @bit_11_nz_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_11_nz_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    andi $a0, $a0, 2048
-; LA64-NEXT:    beqz $a0, .LBB40_2
+; LA64-NEXT:    slli.d $a0, $a0, 52
+; LA64-NEXT:    bgez $a0, .LBB40_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1037,9 +1037,8 @@ define void @bit_11_nz_branch_i32(i32 signext %0) {
 define void @bit_24_z_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_24_z_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4096
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    bne $a0, $zero, .LBB41_2
+; LA32-NEXT:    slli.w $a0, $a0, 7
+; LA32-NEXT:    bltz $a0, .LBB41_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB41_2:
@@ -1047,9 +1046,8 @@ define void @bit_24_z_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_24_z_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu12i.w $a1, 4096
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    bnez $a0, .LBB41_2
+; LA64-NEXT:    slli.d $a0, $a0, 39
+; LA64-NEXT:    bltz $a0, .LBB41_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1070,9 +1068,8 @@ define void @bit_24_z_branch_i32(i32 signext %0) {
 define void @bit_24_nz_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_24_nz_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4096
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    beq $a0, $zero, .LBB42_2
+; LA32-NEXT:    slli.w $a0, $a0, 7
+; LA32-NEXT:    bgez $a0, .LBB42_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB42_2:
@@ -1080,9 +1077,8 @@ define void @bit_24_nz_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_24_nz_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu12i.w $a1, 4096
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    beqz $a0, .LBB42_2
+; LA64-NEXT:    slli.d $a0, $a0, 39
+; LA64-NEXT:    bgez $a0, .LBB42_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1103,9 +1099,7 @@ define void @bit_24_nz_branch_i32(i32 signext %0) {
 define void @bit_31_z_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_31_z_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, -524288
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    bne $a0, $zero, .LBB43_2
+; LA32-NEXT:    bltz $a0, .LBB43_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB43_2:
@@ -1135,9 +1129,7 @@ define void @bit_31_z_branch_i32(i32 signext %0) {
 define void @bit_31_nz_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_31_nz_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, -524288
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    beq $a0, $zero, .LBB44_2
+; LA32-NEXT:    bgez $a0, .LBB44_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB44_2:
@@ -1229,8 +1221,8 @@ define void @bit_10_nz_branch_i64(i64 %0) {
 define void @bit_11_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_11_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    andi $a0, $a0, 2048
-; LA32-NEXT:    bne $a0, $zero, .LBB47_2
+; LA32-NEXT:    slli.w $a0, $a0, 20
+; LA32-NEXT:    bltz $a0, .LBB47_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB47_2:
@@ -1238,8 +1230,8 @@ define void @bit_11_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_11_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    andi $a0, $a0, 2048
-; LA64-NEXT:    bnez $a0, .LBB47_2
+; LA64-NEXT:    slli.d $a0, $a0, 52
+; LA64-NEXT:    bltz $a0, .LBB47_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1260,8 +1252,8 @@ define void @bit_11_z_branch_i64(i64 %0) {
 define void @bit_11_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_11_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    andi $a0, $a0, 2048
-; LA32-NEXT:    beq $a0, $zero, .LBB48_2
+; LA32-NEXT:    slli.w $a0, $a0, 20
+; LA32-NEXT:    bgez $a0, .LBB48_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB48_2:
@@ -1269,8 +1261,8 @@ define void @bit_11_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_11_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    andi $a0, $a0, 2048
-; LA64-NEXT:    beqz $a0, .LBB48_2
+; LA64-NEXT:    slli.d $a0, $a0, 52
+; LA64-NEXT:    bgez $a0, .LBB48_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1291,9 +1283,8 @@ define void @bit_11_nz_branch_i64(i64 %0) {
 define void @bit_24_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_24_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4096
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    bne $a0, $zero, .LBB49_2
+; LA32-NEXT:    slli.w $a0, $a0, 7
+; LA32-NEXT:    bltz $a0, .LBB49_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB49_2:
@@ -1301,9 +1292,8 @@ define void @bit_24_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_24_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu12i.w $a1, 4096
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    bnez $a0, .LBB49_2
+; LA64-NEXT:    slli.d $a0, $a0, 39
+; LA64-NEXT:    bltz $a0, .LBB49_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1324,9 +1314,8 @@ define void @bit_24_z_branch_i64(i64 %0) {
 define void @bit_24_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_24_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4096
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    beq $a0, $zero, .LBB50_2
+; LA32-NEXT:    slli.w $a0, $a0, 7
+; LA32-NEXT:    bgez $a0, .LBB50_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB50_2:
@@ -1334,9 +1323,8 @@ define void @bit_24_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_24_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu12i.w $a1, 4096
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    beqz $a0, .LBB50_2
+; LA64-NEXT:    slli.d $a0, $a0, 39
+; LA64-NEXT:    bgez $a0, .LBB50_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1357,9 +1345,7 @@ define void @bit_24_nz_branch_i64(i64 %0) {
 define void @bit_31_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_31_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, -524288
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    bne $a0, $zero, .LBB51_2
+; LA32-NEXT:    bltz $a0, .LBB51_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB51_2:
@@ -1367,10 +1353,8 @@ define void @bit_31_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_31_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu12i.w $a1, -524288
-; LA64-NEXT:    lu32i.d $a1, 0
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    bnez $a0, .LBB51_2
+; LA64-NEXT:    slli.d $a0, $a0, 32
+; LA64-NEXT:    bltz $a0, .LBB51_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1391,9 +1375,7 @@ define void @bit_31_z_branch_i64(i64 %0) {
 define void @bit_31_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_31_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, -524288
-; LA32-NEXT:    and $a0, $a0, $a1
-; LA32-NEXT:    beq $a0, $zero, .LBB52_2
+; LA32-NEXT:    bgez $a0, .LBB52_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB52_2:
@@ -1401,10 +1383,8 @@ define void @bit_31_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_31_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu12i.w $a1, -524288
-; LA64-NEXT:    lu32i.d $a1, 0
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    beqz $a0, .LBB52_2
+; LA64-NEXT:    slli.d $a0, $a0, 32
+; LA64-NEXT:    bgez $a0, .LBB52_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1434,10 +1414,8 @@ define void @bit_32_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_32_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    ori $a1, $zero, 0
-; LA64-NEXT:    lu32i.d $a1, 1
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    bnez $a0, .LBB53_2
+; LA64-NEXT:    slli.d $a0, $a0, 31
+; LA64-NEXT:    bltz $a0, .LBB53_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1467,10 +1445,8 @@ define void @bit_32_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_32_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    ori $a1, $zero, 0
-; LA64-NEXT:    lu32i.d $a1, 1
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    beqz $a0, .LBB54_2
+; LA64-NEXT:    slli.d $a0, $a0, 31
+; LA64-NEXT:    bgez $a0, .LBB54_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1491,9 +1467,8 @@ define void @bit_32_nz_branch_i64(i64 %0) {
 define void @bit_62_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_62_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a0, 262144
-; LA32-NEXT:    and $a0, $a1, $a0
-; LA32-NEXT:    bne $a0, $zero, .LBB55_2
+; LA32-NEXT:    slli.w $a0, $a1, 1
+; LA32-NEXT:    bltz $a0, .LBB55_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB55_2:
@@ -1501,9 +1476,8 @@ define void @bit_62_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_62_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu52i.d $a1, $zero, 1024
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    bnez $a0, .LBB55_2
+; LA64-NEXT:    slli.d $a0, $a0, 1
+; LA64-NEXT:    bltz $a0, .LBB55_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1524,9 +1498,8 @@ define void @bit_62_z_branch_i64(i64 %0) {
 define void @bit_62_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_62_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a0, 262144
-; LA32-NEXT:    and $a0, $a1, $a0
-; LA32-NEXT:    beq $a0, $zero, .LBB56_2
+; LA32-NEXT:    slli.w $a0, $a1, 1
+; LA32-NEXT:    bgez $a0, .LBB56_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB56_2:
@@ -1534,9 +1507,8 @@ define void @bit_62_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_62_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    lu52i.d $a1, $zero, 1024
-; LA64-NEXT:    and $a0, $a0, $a1
-; LA64-NEXT:    beqz $a0, .LBB56_2
+; LA64-NEXT:    slli.d $a0, $a0, 1
+; LA64-NEXT:    bgez $a0, .LBB56_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1557,9 +1529,7 @@ define void @bit_62_nz_branch_i64(i64 %0) {
 define void @bit_63_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_63_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a0, -524288
-; LA32-NEXT:    and $a0, $a1, $a0
-; LA32-NEXT:    bne $a0, $zero, .LBB57_2
+; LA32-NEXT:    bltz $a1, .LBB57_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB57_2:
@@ -1567,8 +1537,7 @@ define void @bit_63_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_63_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrins.d $a0, $zero, 62, 0
-; LA64-NEXT:    bnez $a0, .LBB57_2
+; LA64-NEXT:    bltz $a0, .LBB57_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -1589,9 +1558,7 @@ define void @bit_63_z_branch_i64(i64 %0) {
 define void @bit_63_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_63_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a0, -524288
-; LA32-NEXT:    and $a0, $a1, $a0
-; LA32-NEXT:    beq $a0, $zero, .LBB58_2
+; LA32-NEXT:    bgez $a1, .LBB58_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
 ; LA32-NEXT:  .LBB58_2:
@@ -1599,8 +1566,7 @@ define void @bit_63_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_63_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrins.d $a0, $zero, 62, 0
-; LA64-NEXT:    beqz $a0, .LBB58_2
+; LA64-NEXT:    bgez $a0, .LBB58_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
 ; LA64-NEXT:    jr $t8
@@ -2534,9 +2500,7 @@ define void @bit_11_1_nz_branch_i32(i32 signext %0) {
 define void @bit_16_1_z_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_16_1_z_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 15
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 16
 ; LA32-NEXT:    beq $a0, $zero, .LBB93_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    ret
@@ -2545,7 +2509,7 @@ define void @bit_16_1_z_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_16_1_z_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 15, 0
+; LA64-NEXT:    slli.d $a0, $a0, 48
 ; LA64-NEXT:    beqz $a0, .LBB93_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -2567,9 +2531,7 @@ define void @bit_16_1_z_branch_i32(i32 signext %0) {
 define void @bit_16_1_nz_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_16_1_nz_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 15
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 16
 ; LA32-NEXT:    beq $a0, $zero, .LBB94_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
@@ -2578,7 +2540,7 @@ define void @bit_16_1_nz_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_16_1_nz_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 15, 0
+; LA64-NEXT:    slli.d $a0, $a0, 48
 ; LA64-NEXT:    beqz $a0, .LBB94_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -2600,9 +2562,7 @@ define void @bit_16_1_nz_branch_i32(i32 signext %0) {
 define void @bit_24_1_z_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_24_1_z_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4095
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 8
 ; LA32-NEXT:    beq $a0, $zero, .LBB95_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    ret
@@ -2611,7 +2571,7 @@ define void @bit_24_1_z_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_24_1_z_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 23, 0
+; LA64-NEXT:    slli.d $a0, $a0, 40
 ; LA64-NEXT:    beqz $a0, .LBB95_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -2633,9 +2593,7 @@ define void @bit_24_1_z_branch_i32(i32 signext %0) {
 define void @bit_24_1_nz_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_24_1_nz_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4095
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 8
 ; LA32-NEXT:    beq $a0, $zero, .LBB96_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
@@ -2644,7 +2602,7 @@ define void @bit_24_1_nz_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_24_1_nz_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 23, 0
+; LA64-NEXT:    slli.d $a0, $a0, 40
 ; LA64-NEXT:    beqz $a0, .LBB96_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -2666,9 +2624,7 @@ define void @bit_24_1_nz_branch_i32(i32 signext %0) {
 define void @bit_31_1_z_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_31_1_z_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 524287
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 1
 ; LA32-NEXT:    beq $a0, $zero, .LBB97_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    ret
@@ -2677,7 +2633,7 @@ define void @bit_31_1_z_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_31_1_z_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 30, 0
+; LA64-NEXT:    slli.d $a0, $a0, 33
 ; LA64-NEXT:    beqz $a0, .LBB97_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -2699,9 +2655,7 @@ define void @bit_31_1_z_branch_i32(i32 signext %0) {
 define void @bit_31_1_nz_branch_i32(i32 signext %0) {
 ; LA32-LABEL: bit_31_1_nz_branch_i32:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 524287
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 1
 ; LA32-NEXT:    beq $a0, $zero, .LBB98_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
@@ -2710,7 +2664,7 @@ define void @bit_31_1_nz_branch_i32(i32 signext %0) {
 ;
 ; LA64-LABEL: bit_31_1_nz_branch_i32:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 30, 0
+; LA64-NEXT:    slli.d $a0, $a0, 33
 ; LA64-NEXT:    beqz $a0, .LBB98_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -2914,9 +2868,7 @@ define void @bit_11_1_nz_branch_i64(i64 %0) {
 define void @bit_16_1_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_16_1_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 15
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 16
 ; LA32-NEXT:    beq $a0, $zero, .LBB105_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    ret
@@ -2925,7 +2877,7 @@ define void @bit_16_1_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_16_1_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 15, 0
+; LA64-NEXT:    slli.d $a0, $a0, 48
 ; LA64-NEXT:    beqz $a0, .LBB105_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -2947,9 +2899,7 @@ define void @bit_16_1_z_branch_i64(i64 %0) {
 define void @bit_16_1_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_16_1_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 15
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 16
 ; LA32-NEXT:    beq $a0, $zero, .LBB106_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
@@ -2958,7 +2908,7 @@ define void @bit_16_1_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_16_1_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 15, 0
+; LA64-NEXT:    slli.d $a0, $a0, 48
 ; LA64-NEXT:    beqz $a0, .LBB106_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -2980,9 +2930,7 @@ define void @bit_16_1_nz_branch_i64(i64 %0) {
 define void @bit_24_1_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_24_1_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4095
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 8
 ; LA32-NEXT:    beq $a0, $zero, .LBB107_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    ret
@@ -2991,7 +2939,7 @@ define void @bit_24_1_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_24_1_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 23, 0
+; LA64-NEXT:    slli.d $a0, $a0, 40
 ; LA64-NEXT:    beqz $a0, .LBB107_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -3013,9 +2961,7 @@ define void @bit_24_1_z_branch_i64(i64 %0) {
 define void @bit_24_1_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_24_1_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 4095
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 8
 ; LA32-NEXT:    beq $a0, $zero, .LBB108_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
@@ -3024,7 +2970,7 @@ define void @bit_24_1_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_24_1_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 23, 0
+; LA64-NEXT:    slli.d $a0, $a0, 40
 ; LA64-NEXT:    beqz $a0, .LBB108_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -3046,9 +2992,7 @@ define void @bit_24_1_nz_branch_i64(i64 %0) {
 define void @bit_31_1_z_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_31_1_z_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 524287
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 1
 ; LA32-NEXT:    beq $a0, $zero, .LBB109_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    ret
@@ -3057,7 +3001,7 @@ define void @bit_31_1_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_31_1_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 30, 0
+; LA64-NEXT:    slli.d $a0, $a0, 33
 ; LA64-NEXT:    beqz $a0, .LBB109_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -3079,9 +3023,7 @@ define void @bit_31_1_z_branch_i64(i64 %0) {
 define void @bit_31_1_nz_branch_i64(i64 %0) {
 ; LA32-LABEL: bit_31_1_nz_branch_i64:
 ; LA32:       # %bb.0:
-; LA32-NEXT:    lu12i.w $a1, 524287
-; LA32-NEXT:    ori $a1, $a1, 4095
-; LA32-NEXT:    and $a0, $a0, $a1
+; LA32-NEXT:    slli.w $a0, $a0, 1
 ; LA32-NEXT:    beq $a0, $zero, .LBB110_2
 ; LA32-NEXT:  # %bb.1:
 ; LA32-NEXT:    b bar
@@ -3090,7 +3032,7 @@ define void @bit_31_1_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_31_1_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 30, 0
+; LA64-NEXT:    slli.d $a0, $a0, 33
 ; LA64-NEXT:    beqz $a0, .LBB110_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -3120,7 +3062,7 @@ define void @bit_32_1_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_32_1_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 31, 0
+; LA64-NEXT:    slli.d $a0, $a0, 32
 ; LA64-NEXT:    beqz $a0, .LBB111_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -3150,7 +3092,7 @@ define void @bit_32_1_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_32_1_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 31, 0
+; LA64-NEXT:    slli.d $a0, $a0, 32
 ; LA64-NEXT:    beqz $a0, .LBB112_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -3184,7 +3126,7 @@ define void @bit_62_1_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_62_1_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 61, 0
+; LA64-NEXT:    slli.d $a0, $a0, 2
 ; LA64-NEXT:    beqz $a0, .LBB113_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -3218,7 +3160,7 @@ define void @bit_62_1_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_62_1_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 61, 0
+; LA64-NEXT:    slli.d $a0, $a0, 2
 ; LA64-NEXT:    beqz $a0, .LBB114_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)
@@ -3252,7 +3194,7 @@ define void @bit_63_1_z_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_63_1_z_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 62, 0
+; LA64-NEXT:    slli.d $a0, $a0, 1
 ; LA64-NEXT:    beqz $a0, .LBB115_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    ret
@@ -3286,7 +3228,7 @@ define void @bit_63_1_nz_branch_i64(i64 %0) {
 ;
 ; LA64-LABEL: bit_63_1_nz_branch_i64:
 ; LA64:       # %bb.0:
-; LA64-NEXT:    bstrpick.d $a0, $a0, 62, 0
+; LA64-NEXT:    slli.d $a0, $a0, 1
 ; LA64-NEXT:    beqz $a0, .LBB116_2
 ; LA64-NEXT:  # %bb.1:
 ; LA64-NEXT:    pcaddu18i $t8, %call36(bar)

--- a/llvm/test/CodeGen/LoongArch/ir-instruction/fcmp-dbl.ll
+++ b/llvm/test/CodeGen/LoongArch/ir-instruction/fcmp-dbl.ll
@@ -263,8 +263,7 @@ define i1 @fcmp_fast_olt(double %a, double %b, i1 %c) nounwind {
 ; LA32-NEXT:    movgr2fr.w $fa1, $zero
 ; LA32-NEXT:    movgr2frh.w $fa1, $zero
 ; LA32-NEXT:    fcmp.cle.d $fcc0, $fa1, $fa0
-; LA32-NEXT:    movcf2gr $a1, $fcc0
-; LA32-NEXT:    bnez $a1, .LBB16_2
+; LA32-NEXT:    bcnez $fcc0, .LBB16_2
 ; LA32-NEXT:  # %bb.1: # %if.then
 ; LA32-NEXT:    ret
 ; LA32-NEXT:  .LBB16_2: # %if.else
@@ -276,8 +275,7 @@ define i1 @fcmp_fast_olt(double %a, double %b, i1 %c) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    movgr2fr.d $fa1, $zero
 ; LA64-NEXT:    fcmp.cle.d $fcc0, $fa1, $fa0
-; LA64-NEXT:    movcf2gr $a1, $fcc0
-; LA64-NEXT:    bnez $a1, .LBB16_2
+; LA64-NEXT:    bcnez $fcc0, .LBB16_2
 ; LA64-NEXT:  # %bb.1: # %if.then
 ; LA64-NEXT:    ret
 ; LA64-NEXT:  .LBB16_2: # %if.else
@@ -300,9 +298,7 @@ define i1 @fcmp_fast_oeq(double %a, double %b, i1 %c) nounwind {
 ; LA32-NEXT:    movgr2fr.w $fa1, $zero
 ; LA32-NEXT:    movgr2frh.w $fa1, $zero
 ; LA32-NEXT:    fcmp.ceq.d $fcc0, $fa0, $fa1
-; LA32-NEXT:    movcf2gr $a1, $fcc0
-; LA32-NEXT:    xori $a1, $a1, 1
-; LA32-NEXT:    bnez $a1, .LBB17_2
+; LA32-NEXT:    bceqz $fcc0, .LBB17_2
 ; LA32-NEXT:  # %bb.1: # %if.then
 ; LA32-NEXT:    ret
 ; LA32-NEXT:  .LBB17_2: # %if.else
@@ -313,9 +309,7 @@ define i1 @fcmp_fast_oeq(double %a, double %b, i1 %c) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    movgr2fr.d $fa1, $zero
 ; LA64-NEXT:    fcmp.ceq.d $fcc0, $fa0, $fa1
-; LA64-NEXT:    movcf2gr $a1, $fcc0
-; LA64-NEXT:    xori $a1, $a1, 1
-; LA64-NEXT:    bnez $a1, .LBB17_2
+; LA64-NEXT:    bceqz $fcc0, .LBB17_2
 ; LA64-NEXT:  # %bb.1: # %if.then
 ; LA64-NEXT:    ret
 ; LA64-NEXT:  .LBB17_2: # %if.else

--- a/llvm/test/CodeGen/LoongArch/ir-instruction/fcmp-flt.ll
+++ b/llvm/test/CodeGen/LoongArch/ir-instruction/fcmp-flt.ll
@@ -262,8 +262,7 @@ define i1 @fcmp_fast_olt(float %a, float %b, i1 %c) nounwind {
 ; LA32:       # %bb.0:
 ; LA32-NEXT:    movgr2fr.w $fa1, $zero
 ; LA32-NEXT:    fcmp.cle.s $fcc0, $fa1, $fa0
-; LA32-NEXT:    movcf2gr $a1, $fcc0
-; LA32-NEXT:    bnez $a1, .LBB16_2
+; LA32-NEXT:    bcnez $fcc0, .LBB16_2
 ; LA32-NEXT:  # %bb.1: # %if.then
 ; LA32-NEXT:    ret
 ; LA32-NEXT:  .LBB16_2: # %if.else
@@ -275,8 +274,7 @@ define i1 @fcmp_fast_olt(float %a, float %b, i1 %c) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    movgr2fr.w $fa1, $zero
 ; LA64-NEXT:    fcmp.cle.s $fcc0, $fa1, $fa0
-; LA64-NEXT:    movcf2gr $a1, $fcc0
-; LA64-NEXT:    bnez $a1, .LBB16_2
+; LA64-NEXT:    bcnez $fcc0, .LBB16_2
 ; LA64-NEXT:  # %bb.1: # %if.then
 ; LA64-NEXT:    ret
 ; LA64-NEXT:  .LBB16_2: # %if.else
@@ -298,9 +296,7 @@ define i1 @fcmp_fast_oeq(float %a, float %b, i1 %c) nounwind {
 ; LA32:       # %bb.0:
 ; LA32-NEXT:    movgr2fr.w $fa1, $zero
 ; LA32-NEXT:    fcmp.ceq.s $fcc0, $fa0, $fa1
-; LA32-NEXT:    movcf2gr $a1, $fcc0
-; LA32-NEXT:    xori $a1, $a1, 1
-; LA32-NEXT:    bnez $a1, .LBB17_2
+; LA32-NEXT:    bceqz $fcc0, .LBB17_2
 ; LA32-NEXT:  # %bb.1: # %if.then
 ; LA32-NEXT:    ret
 ; LA32-NEXT:  .LBB17_2: # %if.else
@@ -311,9 +307,7 @@ define i1 @fcmp_fast_oeq(float %a, float %b, i1 %c) nounwind {
 ; LA64:       # %bb.0:
 ; LA64-NEXT:    movgr2fr.w $fa1, $zero
 ; LA64-NEXT:    fcmp.ceq.s $fcc0, $fa0, $fa1
-; LA64-NEXT:    movcf2gr $a1, $fcc0
-; LA64-NEXT:    xori $a1, $a1, 1
-; LA64-NEXT:    bnez $a1, .LBB17_2
+; LA64-NEXT:    bceqz $fcc0, .LBB17_2
 ; LA64-NEXT:  # %bb.1: # %if.then
 ; LA64-NEXT:    ret
 ; LA64-NEXT:  .LBB17_2: # %if.else

--- a/llvm/test/CodeGen/LoongArch/merge-base-offset-tlsle.ll
+++ b/llvm/test/CodeGen/LoongArch/merge-base-offset-tlsle.ll
@@ -630,8 +630,7 @@ define dso_local void @tlsle_control_flow_with_mem_access() nounwind {
 ; LA32-NEXT:    lu12i.w $a0, %le_hi20_r(g_a32+4)
 ; LA32-NEXT:    add.w $a0, $a0, $tp, %le_add_r(g_a32+4)
 ; LA32-NEXT:    ld.w $a1, $a0, %le_lo12_r(g_a32+4)
-; LA32-NEXT:    ori $a2, $zero, 1
-; LA32-NEXT:    blt $a1, $a2, .LBB25_2
+; LA32-NEXT:    blez $a1, .LBB25_2
 ; LA32-NEXT:  # %bb.1: # %if.then
 ; LA32-NEXT:    ori $a1, $zero, 10
 ; LA32-NEXT:    st.w $a1, $a0, %le_lo12_r(g_a32+4)
@@ -643,8 +642,7 @@ define dso_local void @tlsle_control_flow_with_mem_access() nounwind {
 ; LA64-NEXT:    lu12i.w $a0, %le_hi20_r(g_a32+4)
 ; LA64-NEXT:    add.d $a0, $a0, $tp, %le_add_r(g_a32+4)
 ; LA64-NEXT:    ld.w $a1, $a0, %le_lo12_r(g_a32+4)
-; LA64-NEXT:    ori $a2, $zero, 1
-; LA64-NEXT:    blt $a1, $a2, .LBB25_2
+; LA64-NEXT:    blez $a1, .LBB25_2
 ; LA64-NEXT:  # %bb.1: # %if.then
 ; LA64-NEXT:    ori $a1, $zero, 10
 ; LA64-NEXT:    st.w $a1, $a0, %le_lo12_r(g_a32+4)

--- a/llvm/test/CodeGen/LoongArch/merge-base-offset.ll
+++ b/llvm/test/CodeGen/LoongArch/merge-base-offset.ll
@@ -811,8 +811,7 @@ define dso_local void @control_flow_with_mem_access() nounwind {
 ; LA32:       # %bb.0: # %entry
 ; LA32-NEXT:    pcalau12i $a0, %pc_hi20(g_a32+4)
 ; LA32-NEXT:    ld.w $a1, $a0, %pc_lo12(g_a32+4)
-; LA32-NEXT:    ori $a2, $zero, 1
-; LA32-NEXT:    blt $a1, $a2, .LBB25_2
+; LA32-NEXT:    blez $a1, .LBB25_2
 ; LA32-NEXT:  # %bb.1: # %if.then
 ; LA32-NEXT:    ori $a1, $zero, 10
 ; LA32-NEXT:    st.w $a1, $a0, %pc_lo12(g_a32+4)
@@ -823,8 +822,7 @@ define dso_local void @control_flow_with_mem_access() nounwind {
 ; LA64:       # %bb.0: # %entry
 ; LA64-NEXT:    pcalau12i $a0, %pc_hi20(g_a32+4)
 ; LA64-NEXT:    ld.w $a1, $a0, %pc_lo12(g_a32+4)
-; LA64-NEXT:    ori $a2, $zero, 1
-; LA64-NEXT:    blt $a1, $a2, .LBB25_2
+; LA64-NEXT:    blez $a1, .LBB25_2
 ; LA64-NEXT:  # %bb.1: # %if.then
 ; LA64-NEXT:    ori $a1, $zero, 10
 ; LA64-NEXT:    st.w $a1, $a0, %pc_lo12(g_a32+4)
@@ -838,8 +836,7 @@ define dso_local void @control_flow_with_mem_access() nounwind {
 ; LA64-LARGE-NEXT:    lu32i.d $a1, %pc64_lo20(g_a32+4)
 ; LA64-LARGE-NEXT:    lu52i.d $a1, $a1, %pc64_hi12(g_a32+4)
 ; LA64-LARGE-NEXT:    ldx.w $a0, $a1, $a0
-; LA64-LARGE-NEXT:    ori $a1, $zero, 1
-; LA64-LARGE-NEXT:    blt $a0, $a1, .LBB25_2
+; LA64-LARGE-NEXT:    blez $a0, .LBB25_2
 ; LA64-LARGE-NEXT:  # %bb.1: # %if.then
 ; LA64-LARGE-NEXT:    pcalau12i $a0, %pc_hi20(g_a32+4)
 ; LA64-LARGE-NEXT:    addi.d $a1, $zero, %pc_lo12(g_a32+4)

--- a/llvm/test/CodeGen/LoongArch/preferred-alignments.ll
+++ b/llvm/test/CodeGen/LoongArch/preferred-alignments.ll
@@ -5,10 +5,9 @@
 define signext i32 @sum(ptr noalias nocapture noundef readonly %0, i32 noundef signext %1) {
 ; LA464-LABEL: sum:
 ; LA464:       # %bb.0:
-; LA464-NEXT:    ori $a2, $zero, 1
-; LA464-NEXT:    blt $a1, $a2, .LBB0_4
-; LA464-NEXT:  # %bb.1:
 ; LA464-NEXT:    move $a2, $zero
+; LA464-NEXT:    blez $a1, .LBB0_3
+; LA464-NEXT:  # %bb.1:
 ; LA464-NEXT:    bstrpick.d $a1, $a1, 31, 0
 ; LA464-NEXT:    .p2align 4, , 16
 ; LA464-NEXT:  .LBB0_2: # =>This Inner Loop Header: Depth=1
@@ -17,11 +16,7 @@ define signext i32 @sum(ptr noalias nocapture noundef readonly %0, i32 noundef s
 ; LA464-NEXT:    addi.d $a1, $a1, -1
 ; LA464-NEXT:    addi.d $a0, $a0, 4
 ; LA464-NEXT:    bnez $a1, .LBB0_2
-; LA464-NEXT:  # %bb.3:
-; LA464-NEXT:    move $a0, $a2
-; LA464-NEXT:    ret
-; LA464-NEXT:  .LBB0_4:
-; LA464-NEXT:    move $a2, $zero
+; LA464-NEXT:  .LBB0_3:
 ; LA464-NEXT:    move $a0, $a2
 ; LA464-NEXT:    ret
   %3 = icmp sgt i32 %1, 0


### PR DESCRIPTION
This patch attempts to optimize conditional branches by combinding logical operations within the conditions. This enables the selection of more efficient branch instructions. For example, for integers, `blez x` can be used instead of `blt x, (ori, t, 1)`; for floating-point comparisons, dedicated floating-point branch instructions can be used to avoid moving the result to an integer register.