### PR TITLE
[TableGen] Remove the name from the union in OpData in PseudoLoweringEmitter and CompressInstEmitter

### DIFF
--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -85,16 +85,15 @@ using namespace llvm;
 namespace {
 class CompressInstEmitter {
   struct OpData {
-    enum MapKind { Operand, Imm, Reg };
-    MapKind Kind;
+    enum MapKind { Operand, Imm, Reg } Kind;
     union {
       // Operand number mapped to.
-      unsigned Operand;
+      unsigned OpNo;
       // Integer immediate value.
-      int64_t Imm;
+      int64_t ImmVal;
       // Physical register.
-      const Record *Reg;
-    } Data;
+      const Record *RegRec;
+    };
     // Tied operand index within the instruction.
     int TiedOpIdx = -1;
   };
@@ -255,7 +254,7 @@ void CompressInstEmitter::addDagOperandMapping(const Record *Rec,
                                 "' is not in register class '" +
                                 OpndRec->getName() + "'");
           OperandMap[OpNo].Kind = OpData::Reg;
-          OperandMap[OpNo].Data.Reg = DI->getDef();
+          OperandMap[OpNo].RegRec = DI->getDef();
           continue;
         }
         // Validate that Dag operand type matches the type defined in the
@@ -282,7 +281,7 @@ void CompressInstEmitter::addDagOperandMapping(const Record *Rec,
                                              "operand expected a register!");
         // No pattern validation check possible for values of fixed immediate.
         OperandMap[OpNo].Kind = OpData::Imm;
-        OperandMap[OpNo].Data.Imm = II->getValue();
+        OperandMap[OpNo].ImmVal = II->getValue();
         LLVM_DEBUG(
             dbgs() << "  Found immediate '" << II->getValue() << "' at "
                    << (IsSourceInst ? "input " : "output ")
@@ -403,9 +402,8 @@ void CompressInstEmitter::createInstOperandMapping(
       if (DestOperandMap[OpNo].Kind == OpData::Operand)
         // No need to fill the SourceOperandMap here since it was mapped to
         // destination operand 'TiedInstOpIdx' in a previous iteration.
-        LLVM_DEBUG(dbgs() << "    " << DestOperandMap[OpNo].Data.Operand
-                          << " ====> " << OpNo
-                          << "  Dest operand tied with operand '"
+        LLVM_DEBUG(dbgs() << "    " << DestOperandMap[OpNo].OpNo << " ====> "
+                          << OpNo << "  Dest operand tied with operand '"
                           << TiedInstOpIdx << "'\n");
       ++OpNo;
       continue;
@@ -430,8 +428,8 @@ void CompressInstEmitter::createInstOperandMapping(
              "Incorrect operand mapping detected!\n");
 
       unsigned SourceOpNo = SourceOp->getValue().MIOpNo;
-      DestOperandMap[OpNo].Data.Operand = SourceOpNo;
-      SourceOperandMap[SourceOpNo].Data.Operand = OpNo;
+      DestOperandMap[OpNo].OpNo = SourceOpNo;
+      SourceOperandMap[SourceOpNo].OpNo = OpNo;
       LLVM_DEBUG(dbgs() << "    " << SourceOpNo << " ====> " << OpNo << "\n");
     }
   }
@@ -774,11 +772,10 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
           CondStream.indent(8)
               << "(MI.getOperand(" << OpNo << ").isImm()) &&\n"
               << "      (MI.getOperand(" << OpNo
-              << ").getImm() == " << SourceOperandMap[OpNo].Data.Imm
-              << ") &&\n";
+              << ").getImm() == " << SourceOperandMap[OpNo].ImmVal << ") &&\n";
           break;
         case OpData::Reg: {
-          const Record *Reg = SourceOperandMap[OpNo].Data.Reg;
+          const Record *Reg = SourceOperandMap[OpNo].RegRec;
           CondStream.indent(8) << "(MI.getOperand(" << OpNo << ").isReg()) &&\n"
                                << indent(8) << "(MI.getOperand(" << OpNo
                                << ").getReg() == " << TargetName
@@ -806,7 +803,7 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
 
         switch (DestOperandMap[OpNo].Kind) {
         case OpData::Operand: {
-          unsigned OpIdx = DestOperandMap[OpNo].Data.Operand;
+          unsigned OpIdx = DestOperandMap[OpNo].OpNo;
           // Check that the operand in the Source instruction fits
           // the type for the Dest instruction.
           if (DestRec->isSubClassOf("RegisterClass") ||
@@ -862,7 +859,7 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
                                            DestRec, "MCOperandPredicate");
             CondStream.indent(8)
                 << ValidatorName << "("
-                << "MCOperand::createImm(" << DestOperandMap[OpNo].Data.Imm
+                << "MCOperand::createImm(" << DestOperandMap[OpNo].Imm
                 << "), STI, " << Entry << ") &&\n";
           } else {
             unsigned Entry =
@@ -871,17 +868,17 @@ void CompressInstEmitter::emitCompressInstEmitter(raw_ostream &OS,
             CondStream.indent(8)
                 << TargetName
                 << "ValidateMachineOperand(MachineOperand::CreateImm("
-                << DestOperandMap[OpNo].Data.Imm << "), &STI, " << Entry
+                << DestOperandMap[OpNo].ImmVal << "), &STI, " << Entry
                 << ") &&\n";
           }
           if (CompressOrUncompress)
             CodeStream.indent(6) << "OutInst.addOperand(MCOperand::createImm("
-                                 << DestOperandMap[OpNo].Data.Imm << "));\n";
+                                 << DestOperandMap[OpNo].ImmVal << "));\n";
         } break;
         case OpData::Reg: {
           if (CompressOrUncompress) {
             // Fixed register has been validated at pattern validation time.
-            const Record *Reg = DestOperandMap[OpNo].Data.Reg;
+            const Record *Reg = DestOperandMap[OpNo].RegRec;
             CodeStream.indent(6)
                 << "OutInst.addOperand(MCOperand::createReg(" << TargetName
                 << "::" << Reg->getName() << "));\n";

--- a/llvm/utils/TableGen/PseudoLoweringEmitter.cpp
+++ b/llvm/utils/TableGen/PseudoLoweringEmitter.cpp
@@ -24,13 +24,12 @@ using namespace llvm;
 namespace {
 class PseudoLoweringEmitter {
   struct OpData {
-    enum MapKind { Operand, Imm, Reg };
-    MapKind Kind;
+    enum MapKind { Operand, Imm, Reg } Kind;
     union {
-      unsigned Operand; // Operand number mapped to.
-      uint64_t Imm;     // Integer immedate value.
-      const Record *Reg; // Physical register.
-    } Data;
+      unsigned OpNo;        // Operand number mapped to.
+      uint64_t ImmVal;      // Integer immedate value.
+      const Record *RegRec; // Physical register.
+    };
   };
   struct PseudoExpansion {
     CodeGenInstruction Source; // The source pseudo instruction definition.
@@ -80,7 +79,7 @@ void PseudoLoweringEmitter::addOperandMapping(
         DI->getDef()->getName() == "zero_reg") {
       auto &Entry = OperandMap[MIOpNo];
       Entry.Kind = OpData::Reg;
-      Entry.Data.Reg = DI->getDef();
+      Entry.RegRec = DI->getDef();
       return;
     }
 
@@ -111,7 +110,7 @@ void PseudoLoweringEmitter::addOperandMapping(
     for (unsigned I = 0, E = NumOps; I != E; ++I) {
       auto &Entry = OperandMap[MIOpNo + I];
       Entry.Kind = OpData::Operand;
-      Entry.Data.Operand = SrcOpnd.MIOperandNo + I;
+      Entry.OpNo = SrcOpnd.MIOperandNo + I;
     }
 
     LLVM_DEBUG(dbgs() << "    " << SourceOp->getValue() << " ==> " << DagIdx
@@ -120,12 +119,12 @@ void PseudoLoweringEmitter::addOperandMapping(
     assert(NumOps == 1);
     auto &Entry = OperandMap[MIOpNo];
     Entry.Kind = OpData::Imm;
-    Entry.Data.Imm = II->getValue();
+    Entry.ImmVal = II->getValue();
   } else if (const auto *BI = dyn_cast<BitsInit>(DagArg)) {
     assert(NumOps == 1);
     auto &Entry = OperandMap[MIOpNo];
     Entry.Kind = OpData::Imm;
-    Entry.Data.Imm = *BI->convertInitializerToInt();
+    Entry.ImmVal = *BI->convertInitializerToInt();
   } else {
     llvm_unreachable("Unhandled pseudo-expansion argument type!");
   }
@@ -247,15 +246,15 @@ void PseudoLoweringEmitter::emitLoweringEmitter(raw_ostream &o) {
           switch (Expansion.OperandMap[MIOpNo + i].Kind) {
           case OpData::Operand:
             o << "    lowerOperand(MI->getOperand("
-              << Expansion.OperandMap[MIOpNo + i].Data.Operand << "), MCOp);\n"
+              << Expansion.OperandMap[MIOpNo + i].OpNo << "), MCOp);\n"
               << "    Inst.addOperand(MCOp);\n";
             break;
           case OpData::Imm:
             o << "    Inst.addOperand(MCOperand::createImm("
-              << Expansion.OperandMap[MIOpNo + i].Data.Imm << "));\n";
+              << Expansion.OperandMap[MIOpNo + i].ImmVal << "));\n";
             break;
           case OpData::Reg: {
-            const Record *Reg = Expansion.OperandMap[MIOpNo + i].Data.Reg;
+            const Record *Reg = Expansion.OperandMap[MIOpNo + i].RegRec;
             o << "    Inst.addOperand(MCOperand::createReg(";
             // "zero_reg" is special.
             if (Reg->getName() == "zero_reg")


### PR DESCRIPTION
We can use an anonymous union here, the name doesn't provide any additional information.