### PR TITLE
[libc][math] Refactor ldexpf16 implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -17,5 +17,6 @@
 #include "math/frexpf128.h"
 #include "math/frexpf16.h"
 #include "math/ldexpf128.h"
+#include "math/ldexpf16.h"
 
 #endif // LLVM_LIBC_SHARED_MATH_H

--- a/libc/shared/math/ldexpf16.h
+++ b/libc/shared/math/ldexpf16.h
@@ -1,0 +1,31 @@
+//===-- Shared ldexpf16 function --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_MATH_LDEXPF16_H
+#define LLVM_LIBC_SHARED_MATH_LDEXPF16_H
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "shared/libc_common.h"
+#include "src/__support/math/ldexpf16.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace shared {
+
+using math::ldexpf16;
+
+} // namespace shared
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SHARED_MATH_LDEXPF16_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -92,3 +92,13 @@ add_header_library(
     libc.src.__support.FPUtil.manipulation_functions
     libc.include.llvm-libc-types.float128
 )
+
+add_header_library(
+  ldexpf16
+  HDRS
+    ldexpf16.h
+  DEPENDS
+    libc.src.__support.macros.properties.types
+    libc.src.__support.FPUtil.manipulation_functions
+    libc.include.llvm-libc-macros.float16_macros
+)

--- a/libc/src/__support/math/ldexpf16.h
+++ b/libc/src/__support/math/ldexpf16.h
@@ -1,0 +1,34 @@
+//===-- Implementation header for ldexpf16 ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LDEXPF16_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_LDEXPF16_H
+
+#include "include/llvm-libc-macros/float16-macros.h"
+
+#ifdef LIBC_TYPES_HAS_FLOAT16
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+static constexpr float16 ldexpf16(float16 x, int exp) {
+  return fputil::ldexp(x, exp);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LIBC_TYPES_HAS_FLOAT16
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_LDEXPF16_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1933,8 +1933,7 @@ add_entrypoint_object(
   HDRS
     ../ldexpf16.h
   DEPENDS
-    libc.src.__support.macros.properties.types
-    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.math.ldexpf16
 )
 
 add_entrypoint_object(

--- a/libc/src/math/generic/ldexpf16.cpp
+++ b/libc/src/math/generic/ldexpf16.cpp
@@ -7,14 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/ldexpf16.h"
-#include "src/__support/FPUtil/ManipulationFunctions.h"
-#include "src/__support/common.h"
-#include "src/__support/macros/config.h"
+
+#include "src/__support/math/ldexpf16.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(float16, ldexpf16, (float16 x, int exp)) {
-  return fputil::ldexp(x, exp);
+  return math::ldexpf16(x, exp);
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2187,6 +2187,16 @@ libc_support_library(
     ],
 )
 
+libc_support_library(
+    name = "__support_math_ldexpf16",
+    hdrs = ["src/__support/math/ldexpf16.h"],
+    deps = [
+        ":__support_macros_properties_types",
+        ":__support_fputil_manipulation_functions",
+        ":llvm_libc_macros_float16_macros"
+    ],
+)
+
 ############################### complex targets ################################
 
 libc_function(
@@ -3347,7 +3357,12 @@ libc_math_function(
     ],
 )
 
-libc_math_function(name = "ldexpf16")
+libc_math_function(
+    name = "ldexpf16",
+    additional_deps = [
+        ":__support_math_ldexpf16",
+    ],
+)
 
 libc_math_function(name = "llogb")
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450

Please merge #147895 first

@lntue 