### PR TITLE
Format root clang-tidy config (NFC)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: [
+Checks: >
   -*,
   clang-diagnostic-*,
   llvm-*,
@@ -10,7 +10,7 @@ Checks: [
   -misc-unused-parameters,
   -misc-use-anonymous-namespace,
   readability-identifier-naming
-]
+
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,16 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-const-correctness,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,-misc-use-anonymous-namespace,readability-identifier-naming,-misc-include-cleaner'
+Checks: [
+  -*,
+  clang-diagnostic-*,
+  llvm-*,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  readability-identifier-naming
+]
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase


### PR DESCRIPTION
Formatted config to column format, which is more readable.
Placed checks in alphabetical order.