### PR TITLE
[libc][math] Refactor ldexpf implementation to header-only in src/__support/math folder

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -16,6 +16,7 @@
 #include "math/frexpf.h"
 #include "math/frexpf128.h"
 #include "math/frexpf16.h"
+#include "math/ldexpf.h"
 #include "math/ldexpf128.h"
 #include "math/ldexpf16.h"
 

--- a/libc/shared/math/ldexpf.h
+++ b/libc/shared/math/ldexpf.h
@@ -1,4 +1,4 @@
-//===-- Implementation of ldexpf function ---------------------------------===//
+//===-- Shared ldexpf function ----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,13 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/ldexpf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_LDEXPF_H
+#define LLVM_LIBC_SHARED_MATH_LDEXPF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/ldexpf.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, ldexpf, (float x, int exp)) {
-  return math::ldexpf(x, exp);
-}
+using math::ldexpf;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_LDEXPF_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -102,3 +102,11 @@ add_header_library(
     libc.src.__support.FPUtil.manipulation_functions
     libc.include.llvm-libc-macros.float16_macros
 )
+
+add_header_library(
+  ldexpf
+  HDRS
+    ldexpf.h
+  DEPENDS
+    libc.src.__support.FPUtil.manipulation_functions
+)

--- a/libc/src/__support/math/ldexpf.h
+++ b/libc/src/__support/math/ldexpf.h
@@ -1,0 +1,28 @@
+//===-- Implementation header for ldexpf ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_LDEXPF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_LDEXPF_H
+
+#include "src/__support/FPUtil/ManipulationFunctions.h"
+#include "src/__support/common.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+static constexpr float ldexpf(float x, int exp) {
+  return fputil::ldexp(x, exp);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_LDEXPF_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1913,7 +1913,7 @@ add_entrypoint_object(
   HDRS
     ../ldexpf.h
   DEPENDS
-    libc.src.__support.FPUtil.manipulation_functions
+    libc.src.__support.math.ldexpf
 )
 
 add_entrypoint_object(

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2197,6 +2197,14 @@ libc_support_library(
     ],
 )
 
+libc_support_library(
+    name = "__support_math_ldexpf",
+    hdrs = ["src/__support/math/ldexpf.h"],
+    deps = [
+        ":__support_fputil_manipulation_functions",
+    ],
+)
+
 ############################### complex targets ################################
 
 libc_function(
@@ -3346,7 +3354,12 @@ libc_math_function(name = "ilogbf16")
 
 libc_math_function(name = "ldexp")
 
-libc_math_function(name = "ldexpf")
+libc_math_function(
+    name = "ldexpf",
+    additional_deps = [
+        ":__support_math_ldexpf",
+    ]
+)
 
 libc_math_function(name = "ldexpl")
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450

Please merge #147901 first

@lntue 