### PR TITLE
[libc++] Remove temporary XFAIL for Android CI again

### DIFF
--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// The Clang version that Android currently uses in the CI is too old.
-// XFAIL: LIBCXX-ANDROID-FIXME
-
 // type_traits
 
 // has_unique_object_representations


### PR DESCRIPTION
The test has been XFAILed temporarily because the Clang version in the Android CI is too old. Once the Android CI is updated the XFAIL should be removed again.