### PR TITLE
[clang][bytecode] Allocate Record fields and bases via Program

### DIFF
--- a/clang/lib/AST/ByteCode/Program.cpp
+++ b/clang/lib/AST/ByteCode/Program.cpp
@@ -315,9 +315,17 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
   };
 
   // Reserve space for base classes.
-  Record::BaseList Bases;
-  Record::VirtualBaseList VirtBases;
+  Record::Base *Bases = nullptr;
+  Record::Base *VBases = nullptr;
+  unsigned NumRecordBases = 0;
+  unsigned NumRecordVBases = 0;
   if (const auto *CD = dyn_cast<CXXRecordDecl>(RD)) {
+    unsigned NumBases = CD->getNumBases();
+    unsigned NumVBases = CD->getNumVBases();
+
+    Bases = new (*this) Record::Base[NumBases];
+    VBases = new (*this) Record::Base[NumVBases];
+
     for (const CXXBaseSpecifier &Spec : CD->bases()) {
       if (Spec.isVirtual())
         continue;
@@ -334,9 +342,11 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
         return nullptr;
 
       BaseSize += align(sizeof(InlineDescriptor));
-      Bases.push_back({BD, BaseSize, Desc, BR});
+      new (&Bases[NumRecordBases]) Record::Base{BD, BaseSize, Desc, BR};
       BaseSize += align(BR->getSize());
+      ++NumRecordBases;
     }
+    assert(NumRecordBases <= NumBases);
 
     for (const CXXBaseSpecifier &Spec : CD->vbases()) {
       const auto *RT = Spec.getType()->getAs<RecordType>();
@@ -351,13 +361,17 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
         return nullptr;
 
       VirtSize += align(sizeof(InlineDescriptor));
-      VirtBases.push_back({BD, VirtSize, Desc, BR});
+      new (&VBases[NumRecordVBases]) Record::Base{BD, VirtSize, Desc, BR};
       VirtSize += align(BR->getSize());
+      ++NumRecordVBases;
     }
+    assert(NumRecordVBases <= NumVBases);
   }
 
   // Reserve space for fields.
-  Record::FieldList Fields;
+  unsigned NumFields = std::distance(RD->field_begin(), RD->field_end());
+  unsigned NumRecordFields = 0;
+  Record::Field *Fields = new (*this) Record::Field[NumFields];
   for (const FieldDecl *FD : RD->fields()) {
     FD = FD->getFirstDecl();
     // Note that we DO create fields and descriptors
@@ -382,12 +396,15 @@ Record *Program::getOrCreateRecord(const RecordDecl *RD) {
     }
     if (!Desc)
       return nullptr;
-    Fields.push_back({FD, BaseSize, Desc});
+
+    new (&Fields[NumRecordFields]) Record::Field{FD, BaseSize, Desc};
     BaseSize += align(Desc->getAllocSize());
+    ++NumRecordFields;
   }
 
-  Record *R = new (Allocator) Record(RD, std::move(Bases), std::move(Fields),
-                                     std::move(VirtBases), VirtSize, BaseSize);
+  Record *R =
+      new (Allocator) Record(RD, Bases, NumRecordBases, Fields, NumRecordFields,
+                             VBases, NumRecordVBases, VirtSize, BaseSize);
   Records[RD] = R;
   return R;
 }

--- a/clang/lib/AST/ByteCode/Record.cpp
+++ b/clang/lib/AST/ByteCode/Record.cpp
@@ -12,20 +12,23 @@
 using namespace clang;
 using namespace clang::interp;
 
-Record::Record(const RecordDecl *Decl, BaseList &&SrcBases,
-               FieldList &&SrcFields, VirtualBaseList &&SrcVirtualBases,
-               unsigned VirtualSize, unsigned BaseSize)
-    : Decl(Decl), Bases(std::move(SrcBases)), Fields(std::move(SrcFields)),
+Record::Record(const RecordDecl *Decl, const Base *SrcBases, unsigned NumBases,
+               const Field *Fields, unsigned NumFields, Base *VBases,
+               unsigned NumVBases, unsigned VirtualSize, unsigned BaseSize)
+    : Decl(Decl), Bases(SrcBases), NumBases(NumBases), Fields(Fields),
+      NumFields(NumFields), VBases(VBases), NumVBases(NumVBases),
       BaseSize(BaseSize), VirtualSize(VirtualSize), IsUnion(Decl->isUnion()),
       IsAnonymousUnion(IsUnion && Decl->isAnonymousStructOrUnion()) {
-  for (Base &V : SrcVirtualBases)
-    VirtualBases.push_back({V.Decl, V.Offset + BaseSize, V.Desc, V.R});
 
-  for (Base &B : Bases)
+  for (unsigned I = 0; I != NumVBases; ++I) {
+    VBases[I].Offset += BaseSize;
+  }
+
+  for (const Base &B : bases())
     BaseMap[B.Decl] = &B;
-  for (Field &F : Fields)
+  for (const Field &F : fields())
     FieldMap[F.Decl] = &F;
-  for (Base &V : VirtualBases)
+  for (const Base &V : virtual_bases())
     VirtualBaseMap[V.Decl] = &V;
 }
 


### PR DESCRIPTION
Records have Program-lifetime, but we used to allocate their fields, bases and virtual bases using llvm::SmallVector. However, after creating a Record, it doesn't change and we know all the number of elements beforehand.

So, allocate the lists via the BumpPtrAllocator we already have in Program. This results in slight compile-time improvements:

https://llvm-compile-time-tracker.com/compare.php?from=3a3d55705b0f69f3ef5bed0b0211e7c884001842&to=e0fede973116c4d43e9883586c737c3d0bb99c3e&stat=instructions:u

Unfortunately, we still have the three DenseMaps in Record, so they still heap-allocate memory on their own.