### PR TITLE
SafeStack: Emit call to __stack_chk_fail through RuntimeLibcalls

### DIFF
--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -475,8 +475,16 @@ void SafeStack::checkStackGuard(IRBuilder<> &IRB, Function &F, Instruction &RI,
       SplitBlockAndInsertIfThen(Cmp, &RI, /* Unreachable */ true, Weights, DTU);
   IRBuilder<> IRBFail(CheckTerm);
   // FIXME: respect -fsanitize-trap / -ftrap-function here?
+  const char *StackChkFailName =
+      TL.getLibcallName(RTLIB::STACKPROTECTOR_CHECK_FAIL);
+  if (!StackChkFailName) {
+    F.getContext().emitError(
+        "no libcall available for stackprotector check fail");
+    return;
+  }
+
   FunctionCallee StackChkFail =
-      F.getParent()->getOrInsertFunction("__stack_chk_fail", IRB.getVoidTy());
+      F.getParent()->getOrInsertFunction(StackChkFailName, IRB.getVoidTy());
   IRBFail.CreateCall(StackChkFail, {});
 }
 

--- a/llvm/test/Transforms/SafeStack/NVPTX/lit.local.cfg
+++ b/llvm/test/Transforms/SafeStack/NVPTX/lit.local.cfg
@@ -1,0 +1,2 @@
+if not "NVPTX" in config.root.targets:
+    config.unsupported = True

--- a/llvm/test/Transforms/SafeStack/NVPTX/safestack-libcall-error.ll
+++ b/llvm/test/Transforms/SafeStack/NVPTX/safestack-libcall-error.ll
@@ -1,0 +1,12 @@
+; RUN: not opt -disable-output -mtriple=nvptx64-- -mcpu=sm_90 -passes=safe-stack %s 2>&1 | FileCheck %s
+
+; CHECK: error: no libcall available for stackprotector check fail
+define void @foo(i32 %t) #0 {
+  %vla = alloca i32, i32 %t, align 4
+  call void @baz(ptr %vla)
+  ret void
+}
+
+declare void @baz(ptr)
+
+attributes #0 = { nounwind safestack sspstrong }


### PR DESCRIPTION
Avoid hardcoding the function name, and query if it's really
supported or not.