### PR TITLE
SafeStack: Emit __safestack_pointer_address call through RuntimeLibcalls

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -362,6 +362,9 @@ defset list<RuntimeLibcall> LibCalls__OutOfLineAtomic = {
 def STACKPROTECTOR_CHECK_FAIL : RuntimeLibcall;
 def STACK_SMASH_HANDLER : RuntimeLibcall;
 
+// Safe stack
+def SAFESTACK_POINTER_ADDRESS : RuntimeLibcall;
+
 // Deoptimization
 def DEOPTIMIZE : RuntimeLibcall;
 
@@ -701,6 +704,9 @@ foreach lc = LibCalls__atomic in {
 
 // Stack Protector Fail
 def __stack_chk_fail : RuntimeLibcallImpl<STACKPROTECTOR_CHECK_FAIL>;
+
+// Safe stack.
+def __safestack_pointer_address : RuntimeLibcallImpl<SAFESTACK_POINTER_ADDRESS>;
 
 // Deoptimization
 def __llvm_deoptimize : RuntimeLibcallImpl<DEOPTIMIZE>;

--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -799,8 +799,16 @@ bool SafeStack::run() {
     IRB.SetCurrentDebugLocation(
         DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP));
   if (SafeStackUsePointerAddress) {
+    const char *SafestackPointerAddressName =
+        TL.getLibcallName(RTLIB::SAFESTACK_POINTER_ADDRESS);
+    if (!SafestackPointerAddressName) {
+      F.getContext().emitError(
+          "no libcall available for safestack pointer address");
+      return false;
+    }
+
     FunctionCallee Fn = F.getParent()->getOrInsertFunction(
-        "__safestack_pointer_address", IRB.getPtrTy(0));
+        SafestackPointerAddressName, IRB.getPtrTy(0));
     UnsafeStackPtr = IRB.CreateCall(Fn);
   } else {
     UnsafeStackPtr = TL.getSafeStackPointerLocation(IRB);

--- a/llvm/test/Transforms/SafeStack/NVPTX/safestack-pointer-address-libcall-error.ll
+++ b/llvm/test/Transforms/SafeStack/NVPTX/safestack-pointer-address-libcall-error.ll
@@ -1,0 +1,12 @@
+; RUN: not opt -disable-output -mtriple=nvptx64-- -safestack-use-pointer-address -mcpu=sm_90 -passes=safe-stack %s 2>&1 | FileCheck %s
+
+; CHECK: error: no libcall available for safestack pointer address
+define void @foo(i32 %t) #0 {
+  %vla = alloca i32, i32 %t, align 4
+  call void @baz(ptr %vla)
+  ret void
+}
+
+declare void @baz(ptr)
+
+attributes #0 = { nounwind safestack sspstrong }


### PR DESCRIPTION
Stop using hardcoded function named and check availability. This only fixes
the forced usage via command line in the pass itself; the implementations
inside of TargetLoweringBase hide additional call emission.