### PR TITLE
SafeStack: Check if __safestack_pointer_address is available

### DIFF
--- a/llvm/test/Transforms/SafeStack/NVPTX/safestack-pointer-address-libcall-error.ll
+++ b/llvm/test/Transforms/SafeStack/NVPTX/safestack-pointer-address-libcall-error.ll
@@ -1,6 +1,6 @@
-; RUN: not opt -disable-output -mtriple=nvptx64-- -safestack-use-pointer-address -mcpu=sm_90 -passes=safe-stack %s 2>&1 | FileCheck %s
+; RUN: not opt -disable-output -mtriple=nvptx64-- -safestack-use-pointer-address -mcpu=sm_90 -passes=safe-stack %s 2>&1 | FileCheck -check-prefix=ERR %s
 
-; CHECK: error: no libcall available for safestack pointer address
+; ERR: error: no libcall available for safestack pointer address
 define void @foo(i32 %t) #0 {
   %vla = alloca i32, i32 %t, align 4
   call void @baz(ptr %vla)


### PR DESCRIPTION
Start using RuntimeLibcalls in the base implementation of
getSafeStackPointerLocation instead of hardcoding the function
names.