### PR TITLE
[MLIR][Target/Cpp] Fix variable naming conflict for function declarations

### DIFF
--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1258,6 +1258,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
                                     DeclareFuncOp declareFuncOp) {
   raw_indented_ostream &os = emitter.ostream();
 
+  CppEmitter::FunctionScope scope(emitter);
   auto functionOp = SymbolTable::lookupNearestSymbolFrom<emitc::FuncOp>(
       declareFuncOp, declareFuncOp.getSymNameAttr());
 

--- a/mlir/test/Target/Cpp/declare_func.mlir
+++ b/mlir/test/Target/Cpp/declare_func.mlir
@@ -24,3 +24,20 @@ emitc.declare_func @array_arg
 emitc.func @array_arg(%arg0: !emitc.array<3xi32>) {
     emitc.return
 }
+
+// CHECK: int32_t foo1(int32_t [[V1:[^ ]*]]);
+emitc.declare_func @foo1
+// CHECK: int32_t foo2(int32_t [[V1]]);
+emitc.declare_func @foo2
+// CHECK: int32_t foo1(int32_t [[V1]]) {
+emitc.func @foo1(%arg0: i32) -> i32 {
+    // CHECK-NOT: int32_t [[V1]] = 0;
+    %0 = "emitc.constant"() <{value = 0 : i32}> : () -> i32
+    // CHECK: return [[V1]];
+    emitc.return %arg0 : i32
+}
+// CHECK: int32_t foo2(int32_t [[V1]]) {
+emitc.func @foo2(%arg0: i32) -> i32 {
+    // CHECK: return [[V1]];
+    emitc.return %arg0 : i32
+}


### PR DESCRIPTION
This is a fix for https://github.com/llvm/llvm-project/pull/136102. It missed scoping for `DeclareFuncOps`.
In scenarios with multiple function declarations, the `valueMapper` wasn't updated and later uses of values in other functions still used the assigned names in prior functions.

This is visible in the reproducer here https://github.com/iree-org/iree/issues/21303: Although the counter for variable enumeration was reset, as it is visible for the local vars, the function arguments were mapped to old names. Due to this mapping, the counter was never increased, and the local variables conflicted with the arguments.

This fix adds proper scoping for declarations and a test-case to cover the scenario with multiple `DeclareFuncOps`.