### PR TITLE
[libc] Fix WEOF and fix 1'000'000 error messages on test failure

### DIFF
--- a/libc/include/llvm-libc-macros/wchar-macros.h
+++ b/libc/include/llvm-libc-macros/wchar-macros.h
@@ -10,7 +10,7 @@
 #define LLVM_LIBC_MACROS_WCHAR_MACROS_H
 
 #ifndef WEOF
-#define WEOF 0xffffffffu
+#define WEOF ((wint_t)(0xffffffffu))
 #endif
 
 #endif // LLVM_LIBC_MACROS_WCHAR_MACROS_H

--- a/libc/include/llvm-libc-macros/wchar-macros.h
+++ b/libc/include/llvm-libc-macros/wchar-macros.h
@@ -9,6 +9,8 @@
 #ifndef LLVM_LIBC_MACROS_WCHAR_MACROS_H
 #define LLVM_LIBC_MACROS_WCHAR_MACROS_H
 
+#include "../llvm-libc-types/wint_t.h"
+
 #ifndef WEOF
 #define WEOF ((wint_t)(0xffffffffu))
 #endif

--- a/libc/test/src/math/smoke/RoundToIntegerTest.h
+++ b/libc/test/src/math/smoke/RoundToIntegerTest.h
@@ -113,7 +113,8 @@ public:
   }
 
   void testSubnormalRange(RoundToIntegerFunc func) {
-    constexpr int COUNT = 1'000'001;
+    // Arbitrary, trades off completeness with testing time (esp. on failure)
+    constexpr int COUNT = 1'000;
     constexpr StorageType STEP = LIBC_NAMESPACE::cpp::max(
         static_cast<StorageType>((MAX_SUBNORMAL - MIN_SUBNORMAL) / COUNT),
         StorageType(1));


### PR DESCRIPTION
1. WEOF is defined as a `wint_t` by the C standard. On certain architectures, the test won't compile on `-Wall`. This fixes it.
2. If `testSubnormalRange` fails, it will spit out way too many error messages, which overwhelms my test environment. I reduce this to 1k for now.

This is required for #145349