### PR TITLE
[LangRef] Document the difference between `<abi>` and `<pref>`

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3240,15 +3240,23 @@ as follows:
     as :ref:`Non-Integral Pointer Type <nointptrtype>` s.  The ``0``
     address space cannot be specified as non-integral.
 
-``<abi>`` provides a minimum allowed alignment for a type, and
+``<abi>`` is a lower bound on what is required for a type to be
+considered aligned. This is used in various places, such as:
+
+- The alignment for loads and stores if none is explicitly given.
+- The alignment used to compute struct layout.
+- The alignment used to compute allocation sizes and thus
+  ``getelementptr`` offsets.
+- The alignment below which accesses are considered underaligned.
+
 ``<pref>`` allows providing a more optimal alignment that should be used
 when possible. ``<pref>`` is an optional value that must be greater than
 or equal to ``<abi>``. If omitted, the preceding ``:`` should also be
 omitted and ``<pref>`` will be equal to ``<abi>``.
 
-Unless explicitly stated otherwise, on every specification that specifies
-an alignment, the value of the alignment must be in the range [1,2^16)
-and must be a power of two times the width of a byte.
+Unless explicitly stated otherwise, every alignment specification is
+provided in bits and must be in the range [1,2^16). The value must be a
+power of times the width of a byte (i.e. ``align = 8 * 2^N``).
 
 When constructing the data layout for a given target, LLVM starts with a
 default set of specifications which are then (possibly) overridden by
@@ -3264,8 +3272,8 @@ specifications are given in this list:
 -  ``i8:8:8`` - i8 is 8-bit (byte) aligned as mandated
 -  ``i16:16:16`` - i16 is 16-bit aligned
 -  ``i32:32:32`` - i32 is 32-bit aligned
--  ``i64:32:64`` - i64 has a required alignment of 32-bits but should be
-   aligned to 64-bits if possible.
+-  ``i64:32:64`` - i64 is aligned at 32-bits but should be aligned to
+   64-bits if possible.
 -  ``f16:16:16`` - half is 16-bit aligned
 -  ``f32:32:32`` - float is 32-bit aligned
 -  ``f64:64:64`` - double is 64-bit aligned

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3240,12 +3240,15 @@ as follows:
     as :ref:`Non-Integral Pointer Type <nointptrtype>` s.  The ``0``
     address space cannot be specified as non-integral.
 
+``<abi>`` provides a minimum allowed alignment for a type, and
+``<pref>`` allows providing a more optimal alignment that should be used
+when possible. ``<pref>`` is an optional value that must be greater than
+or equal to ``<abi>``. If omitted, the preceding ``:`` should also be
+omitted and ``<pref>`` will be equal to ``<abi>``.
+
 Unless explicitly stated otherwise, on every specification that specifies
 an alignment, the value of the alignment must be in the range [1,2^16)
 and must be a power of two times the width of a byte.
-On every specification that takes a ``<abi>:<pref>``, specifying the
-``<pref>`` alignment is optional. If omitted, the preceding ``:``
-should be omitted too and ``<pref>`` will be equal to ``<abi>``.
 
 When constructing the data layout for a given target, LLVM starts with a
 default set of specifications which are then (possibly) overridden by
@@ -3261,8 +3264,8 @@ specifications are given in this list:
 -  ``i8:8:8`` - i8 is 8-bit (byte) aligned as mandated
 -  ``i16:16:16`` - i16 is 16-bit aligned
 -  ``i32:32:32`` - i32 is 32-bit aligned
--  ``i64:32:64`` - i64 has ABI alignment of 32-bits but preferred
-   alignment of 64-bits
+-  ``i64:32:64`` - i64 has a required alignment of 32-bits but should be
+   aligned to 64-bits if possible.
 -  ``f16:16:16`` - half is 16-bit aligned
 -  ``f32:32:32`` - float is 32-bit aligned
 -  ``f64:64:64`` - double is 64-bit aligned

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3272,8 +3272,8 @@ specifications are given in this list:
 -  ``i8:8:8`` - i8 is 8-bit (byte) aligned as mandated
 -  ``i16:16:16`` - i16 is 16-bit aligned
 -  ``i32:32:32`` - i32 is 32-bit aligned
--  ``i64:32:64`` - i64 is aligned at 32-bits but should be aligned to
-   64-bits if possible.
+-  ``i64:32:64`` - i64 has ABI alignment of 32-bits but preferred
+   alignment of 64-bits
 -  ``f16:16:16`` - half is 16-bit aligned
 -  ``f32:32:32`` - float is 32-bit aligned
 -  ``f64:64:64`` - double is 64-bit aligned

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3240,23 +3240,24 @@ as follows:
     as :ref:`Non-Integral Pointer Type <nointptrtype>` s.  The ``0``
     address space cannot be specified as non-integral.
 
-``<abi>`` is a lower bound on what is required for a type to be
-considered aligned. This is used in various places, such as:
+``<abi>`` is a lower bound on what is required for a type to be considered
+aligned. This is used in various places, such as:
 
 - The alignment for loads and stores if none is explicitly given.
 - The alignment used to compute struct layout.
-- The alignment used to compute allocation sizes and thus
-  ``getelementptr`` offsets.
+- The alignment used to compute allocation sizes and thus ``getelementptr``
+  offsets.
 - The alignment below which accesses are considered underaligned.
 
-``<pref>`` allows providing a more optimal alignment that should be used
-when possible. ``<pref>`` is an optional value that must be greater than
-or equal to ``<abi>``. If omitted, the preceding ``:`` should also be
-omitted and ``<pref>`` will be equal to ``<abi>``.
+``<pref>`` allows providing a more optimal alignment that should be used when
+possible, primarily for ``alloca`` and the alignment of global variables. It is
+an optional value that must be greater than or equal to ``<abi>``. If omitted,
+the preceding ``:`` should also be omitted and ``<pref>`` will be equal to
+``<abi>``.
 
-Unless explicitly stated otherwise, every alignment specification is
-provided in bits and must be in the range [1,2^16). The value must be a
-power of times the width of a byte (i.e. ``align = 8 * 2^N``).
+Unless explicitly stated otherwise, every alignment specification is provided in
+bits and must be in the range [1,2^16). The value must be a power of two times
+the width of a byte (i.e. ``align = 8 * 2^N``).
 
 When constructing the data layout for a given target, LLVM starts with a
 default set of specifications which are then (possibly) overridden by


### PR DESCRIPTION
Document how LLVM expects to use `<abi>` and `<pref>`, as well as the `pref >= abi` requirement.