### PR TITLE
[Clang] Mark a concept as being invalid if the constraint is invalid

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -8968,8 +8968,10 @@ Sema::ActOnFinishConceptDefinition(Scope *S, ConceptDecl *C,
                                    Expr *ConstraintExpr,
                                    const ParsedAttributesView &Attrs) {
   assert(!C->hasDefinition() && "Concept already defined");
-  if (DiagnoseUnexpandedParameterPack(ConstraintExpr))
+  if (DiagnoseUnexpandedParameterPack(ConstraintExpr)) {
+    C->setInvalidDecl();
     return nullptr;
+  }
   C->setDefinition(ConstraintExpr);
   ProcessDeclAttributeList(S, C, Attrs);
 

--- a/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
+++ b/clang/test/SemaCXX/concept-crash-on-diagnostic.cpp
@@ -60,3 +60,17 @@ concept atomicish = requires() {
 };
 atomicish<int> f(); // expected-error {{expected 'auto' or 'decltype(auto)' after concept name}}
 } // namespace GH138820
+
+namespace GH138823 {
+  template <typename T> void foo();
+  template <class... Ts>
+  concept ConceptA = requires { foo<Ts>(); };
+  // expected-error@-1 {{expression contains unexpanded parameter pack 'Ts'}}
+
+  template <class>
+  concept ConceptB = ConceptA<int>;
+
+  template <ConceptB Foo> void bar(Foo);
+
+  void test() { bar(1); }
+}


### PR DESCRIPTION
Make sure to mark a concept decl as being invalid if the constraint is invalid.


Fixes #138823