### PR TITLE
[clang][bytecode][NFC] Move Pointer::StorageKind above the union

### DIFF
--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -30,8 +30,8 @@ Pointer::Pointer(Block *Pointee, uint64_t BaseAndOffset)
     : Pointer(Pointee, BaseAndOffset, BaseAndOffset) {}
 
 Pointer::Pointer(const Pointer &P)
-    : Offset(P.Offset), PointeeStorage(P.PointeeStorage),
-      StorageKind(P.StorageKind) {
+    : Offset(P.Offset), StorageKind(P.StorageKind),
+      PointeeStorage(P.PointeeStorage) {
 
   if (isBlockPointer() && PointeeStorage.BS.Pointee)
     PointeeStorage.BS.Pointee->addPointer(this);
@@ -48,8 +48,8 @@ Pointer::Pointer(Block *Pointee, unsigned Base, uint64_t Offset)
 }
 
 Pointer::Pointer(Pointer &&P)
-    : Offset(P.Offset), PointeeStorage(P.PointeeStorage),
-      StorageKind(P.StorageKind) {
+    : Offset(P.Offset), StorageKind(P.StorageKind),
+      PointeeStorage(P.PointeeStorage) {
 
   if (StorageKind == Storage::Block && PointeeStorage.BS.Pointee)
     PointeeStorage.BS.Pointee->replacePointer(&P, this);

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -809,13 +809,13 @@ private:
   /// Next link in the pointer chain.
   Pointer *Next = nullptr;
 
+  Storage StorageKind = Storage::Int;
   union {
     BlockPointer BS;
     IntPointer Int;
     FunctionPointer Fn;
     TypeidPointer Typeid;
   } PointeeStorage;
-  Storage StorageKind = Storage::Int;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const Pointer &P) {


### PR DESCRIPTION
This is easier to read in debuggers and more common.