### PR TITLE
[llvm-exegesis] Fix musl build

### DIFF
--- a/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp
@@ -10,8 +10,7 @@
 #include "AArch64RegisterInfo.h"
 
 #if defined(__aarch64__) && defined(__linux__)
-#include <linux/prctl.h> // For PR_PAC_* constants
-#include <sys/prctl.h>
+#include <sys/prctl.h> // For PR_PAC_* constants
 #ifndef PR_PAC_APIAKEY
 #define PR_PAC_APIAKEY (1UL << 0)
 #endif


### PR DESCRIPTION
We should not include both linux/prctl.h and sys/prctl.h. This works with glibc because the latter includes the former, but breaks with musl because the latter redeclares the contents of the former, resulting in:

    /usr/local/aarch64-linux-musl/include/sys/prctl.h:88:8: error: redefinition of 'struct prctl_mm_map'
       88 | struct prctl_mm_map {
          |        ^~~~~~~~~~~~
    In file included from /checkout/src/llvm-project/llvm/tools/llvm-exegesis/lib/AArch64/Target.cpp:13:
    /usr/local/aarch64-linux-musl/include/linux/prctl.h:134:8: note: previous definition of 'struct prctl_mm_map'
      134 | struct prctl_mm_map {
          |        ^~~~~~~~~~~~

Fixes https://github.com/llvm/llvm-project/issues/139443.