### PR TITLE
[LLDB] Check comp_unit before accessing it in DIL

### DIFF
--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -50,8 +50,9 @@ lldb::ValueObjectSP LookupGlobalIdentifier(
   // Get a global variables list without the locals from the current frame
   SymbolContext symbol_context =
       stack_frame->GetSymbolContext(lldb::eSymbolContextCompUnit);
-  lldb::VariableListSP variable_list =
-      symbol_context.comp_unit->GetVariableList(true);
+  lldb::VariableListSP variable_list;
+  if (symbol_context.comp_unit)
+    variable_list = symbol_context.comp_unit->GetVariableList(true);
 
   name_ref.consume_front("::");
   lldb::ValueObjectSP value_sp;

--- a/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/Makefile
+++ b/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+CFLAGS_EXTRAS := -g0
+
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/TestFrameVarDILNoDebugInfo.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/TestFrameVarDILNoDebugInfo.py
@@ -1,0 +1,29 @@
+"""
+Test DIL without debug info.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestFrameVarDILNoDebugInfo(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_no_debug_info(self):
+        self.build()
+        lldbutil.run_to_name_breakpoint(self, "main")
+
+        self.runCmd("settings set target.experimental.use-DIL true")
+
+        self.expect(
+            "frame var 'argc'",
+            error=True,
+            substrs=["use of undeclared identifier"],
+        )
+        self.expect(
+            "frame var 'foo'",
+            error=True,
+            substrs=["use of undeclared identifier"],
+        )

--- a/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/basics/NoDebugInfo/main.cpp
@@ -1,0 +1,3 @@
+int foo = 1;
+
+int main(int argc, char **argv) { return foo; }


### PR DESCRIPTION
Check `symbol_context.comp_unit` before accessing it to avoid `nullptr` dereferencing.