### PR TITLE
[Offload] Add `olGetSymbolInfo[Size]`

### DIFF
--- a/offload/liboffload/API/Symbol.td
+++ b/offload/liboffload/API/Symbol.td
@@ -33,3 +33,57 @@ def : Function {
     ];
     let returns = [];
 }
+
+def : Enum {
+  let name = "ol_symbol_info_t";
+  let desc = "Supported symbol info.";
+  let is_typed = 1;
+  let etors = [
+    TaggedEtor<"KIND", "ol_symbol_kind_t", "The kind of this symbol.">
+  ];
+}
+
+def : Function {
+  let name = "olGetSymbolInfo";
+  let desc = "Queries the given property of the symbol.";
+  let details = [
+    "`olGetSymbolInfoSize` can be used to query the storage size "
+    "required for the given query."
+  ];
+  let params = [
+    Param<"ol_symbol_handle_t", "Symbol", "handle of the symbol", PARAM_IN>,
+    Param<"ol_symbol_info_t", "PropName", "type of the info to retrieve", PARAM_IN>,
+    Param<"size_t", "PropSize", "the number of bytes pointed to by PropValue.", PARAM_IN>,
+    TypeTaggedParam<"void*", "PropValue", "array of bytes holding the info. "
+      "If PropSize is not equal to or greater to the real number of bytes needed to return the info "
+      "then the OL_ERRC_INVALID_SIZE error is returned and PropValue is not used.", PARAM_OUT,
+      TypeInfo<"PropName" , "PropSize">>
+  ];
+  let returns = [
+    Return<"OL_ERRC_INVALID_SIZE", [
+      "`PropSize == 0`",
+      "If `PropSize` is less than the real number of bytes needed to return the info."
+    ]>,
+    Return<"OL_ERRC_SYMBOL_KIND", [
+      "If the requested info isn't applicable to the type of symbol."
+    ]>,
+    Return<"OL_ERRC_INVALID_SYMBOL">
+  ];
+}
+
+def : Function {
+  let name = "olGetSymbolInfoSize";
+  let desc = "Returns the storage size of the given symbol query.";
+  let details = [];
+  let params = [
+    Param<"ol_symbol_handle_t", "Symbol", "handle of the symbol", PARAM_IN>,
+    Param<"ol_symbol_info_t", "PropName", "type of the info to query", PARAM_IN>,
+    Param<"size_t*", "PropSizeRet", "pointer to the number of bytes required to store the query", PARAM_OUT>
+  ];
+  let returns = [
+    Return<"OL_ERRC_INVALID_SYMBOL">,
+    Return<"OL_ERRC_SYMBOL_KIND", [
+      "If the requested info isn't applicable to the type of symbol."
+    ]>,
+  ];
+}

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -748,5 +748,33 @@ Error olGetSymbol_impl(ol_program_handle_t Program, const char *Name,
   }
 }
 
+Error olGetSymbolInfoImplDetail(ol_symbol_handle_t Symbol,
+                                ol_symbol_info_t PropName, size_t PropSize,
+                                void *PropValue, size_t *PropSizeRet) {
+  InfoWriter Info(PropSize, PropValue, PropSizeRet);
+
+  switch (PropName) {
+  case OL_SYMBOL_INFO_KIND:
+    return Info.write<ol_symbol_kind_t>(Symbol->Kind);
+  default:
+    return createOffloadError(ErrorCode::INVALID_ENUMERATION,
+                              "olGetSymbolInfo enum '%i' is invalid", PropName);
+  }
+
+  return Error::success();
+}
+
+Error olGetSymbolInfo_impl(ol_symbol_handle_t Symbol, ol_symbol_info_t PropName,
+                           size_t PropSize, void *PropValue) {
+
+  return olGetSymbolInfoImplDetail(Symbol, PropName, PropSize, PropValue,
+                                   nullptr);
+}
+
+Error olGetSymbolInfoSize_impl(ol_symbol_handle_t Symbol,
+                               ol_symbol_info_t PropName, size_t *PropSizeRet) {
+  return olGetSymbolInfoImplDetail(Symbol, PropName, 0, nullptr, PropSizeRet);
+}
+
 } // namespace offload
 } // namespace llvm

--- a/offload/unittests/OffloadAPI/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/CMakeLists.txt
@@ -42,4 +42,6 @@ add_offload_unittest("queue"
     queue/olGetQueueInfoSize.cpp)
 
 add_offload_unittest("symbol"
-    symbol/olGetSymbol.cpp)
+    symbol/olGetSymbol.cpp
+    symbol/olGetSymbolInfo.cpp
+    symbol/olGetSymbolInfoSize.cpp)

--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -91,9 +91,12 @@ struct OffloadPlatformTest : OffloadDeviceTest {
 // Fixture for a generic program test. If you want a different program, use
 // offloadQueueTest and create your own program handle with the binary you want.
 struct OffloadProgramTest : OffloadDeviceTest {
-  void SetUp() override {
+  void SetUp() override { SetUpWith("foo"); }
+
+  void SetUpWith(const char *ProgramName) {
     RETURN_ON_FATAL_FAILURE(OffloadDeviceTest::SetUp());
-    ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
+    ASSERT_TRUE(
+        TestEnvironment::loadDeviceBinary(ProgramName, Device, DeviceBin));
     ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
     ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
@@ -121,6 +124,20 @@ struct OffloadKernelTest : OffloadProgramTest {
   }
 
   ol_symbol_handle_t Kernel = nullptr;
+};
+
+struct OffloadGlobalTest : OffloadProgramTest {
+  void SetUp() override {
+    RETURN_ON_FATAL_FAILURE(OffloadProgramTest::SetUpWith("global"));
+    ASSERT_SUCCESS(olGetSymbol(Program, "global",
+                               OL_SYMBOL_KIND_GLOBAL_VARIABLE, &Global));
+  }
+
+  void TearDown() override {
+    RETURN_ON_FATAL_FAILURE(OffloadProgramTest::TearDown());
+  }
+
+  ol_symbol_handle_t Global = nullptr;
 };
 
 struct OffloadQueueTest : OffloadDeviceTest {

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
@@ -1,0 +1,65 @@
+//===------- Offload API tests - olGetSymbolInfo --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <OffloadAPI.h>
+
+#include "../common/Fixtures.hpp"
+
+using olGetSymbolInfoKernelTest = OffloadKernelTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolInfoKernelTest);
+
+using olGetSymbolInfoGlobalTest = OffloadGlobalTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolInfoGlobalTest);
+
+TEST_P(olGetSymbolInfoKernelTest, SuccessKind) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_SUCCESS(olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
+                                 sizeof(RetrievedKind), &RetrievedKind));
+  ASSERT_EQ(RetrievedKind, OL_SYMBOL_KIND_KERNEL);
+}
+
+TEST_P(olGetSymbolInfoGlobalTest, SuccessKind) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_KIND,
+                                 sizeof(RetrievedKind), &RetrievedKind));
+  ASSERT_EQ(RetrievedKind, OL_SYMBOL_KIND_GLOBAL_VARIABLE);
+}
+
+TEST_P(olGetSymbolInfoKernelTest, InvalidNullHandle) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+               olGetSymbolInfo(nullptr, OL_SYMBOL_INFO_KIND,
+                               sizeof(RetrievedKind), &RetrievedKind));
+}
+
+TEST_P(olGetSymbolInfoKernelTest, InvalidSymbolInfoEnumeration) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+               olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_FORCE_UINT32,
+                               sizeof(RetrievedKind), &RetrievedKind));
+}
+
+TEST_P(olGetSymbolInfoKernelTest, InvalidSizeZero) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+               olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND, 0, &RetrievedKind));
+}
+
+TEST_P(olGetSymbolInfoKernelTest, InvalidSizeSmall) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+               olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
+                               sizeof(RetrievedKind) - 1, &RetrievedKind));
+}
+
+TEST_P(olGetSymbolInfoKernelTest, InvalidNullPointerPropValue) {
+  ol_symbol_kind_t RetrievedKind;
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
+                               sizeof(RetrievedKind), nullptr));
+}

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbolInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbolInfoSize.cpp
@@ -1,0 +1,46 @@
+//===------- Offload API tests - olGetSymbolInfoSize ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <OffloadAPI.h>
+
+#include "../common/Fixtures.hpp"
+
+using olGetSymbolInfoSizeKernelTest = OffloadKernelTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolInfoSizeKernelTest);
+
+using olGetSymbolInfoSizeGlobalTest = OffloadGlobalTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolInfoSizeGlobalTest);
+
+TEST_P(olGetSymbolInfoSizeKernelTest, SuccessKind) {
+  size_t Size = 0;
+  ASSERT_SUCCESS(olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_KIND, &Size));
+  ASSERT_EQ(Size, sizeof(ol_symbol_kind_t));
+}
+
+TEST_P(olGetSymbolInfoSizeGlobalTest, SuccessKind) {
+  size_t Size = 0;
+  ASSERT_SUCCESS(olGetSymbolInfoSize(Global, OL_SYMBOL_INFO_KIND, &Size));
+  ASSERT_EQ(Size, sizeof(ol_symbol_kind_t));
+}
+
+TEST_P(olGetSymbolInfoSizeKernelTest, InvalidNullHandle) {
+  size_t Size = 0;
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+               olGetSymbolInfoSize(nullptr, OL_SYMBOL_INFO_KIND, &Size));
+}
+
+TEST_P(olGetSymbolInfoSizeKernelTest, InvalidSymbolInfoEnumeration) {
+  size_t Size = 0;
+  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+               olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_FORCE_UINT32, &Size));
+}
+
+TEST_P(olGetSymbolInfoSizeKernelTest, InvalidNullPointer) {
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_KIND, nullptr));
+}


### PR DESCRIPTION
This mirrors the similar functions for other handles. The only
implemented info at the moment is the symbol's kind.
