### PR TITLE
Turn off uninitialized warnings for GCC up to 14.

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -510,7 +510,7 @@ set(USE_NO_UNINITIALIZED 0)
 # false positives.
 if (CMAKE_COMPILER_IS_GNUCXX)
   # Disable all -Wuninitialized warning for old GCC versions.
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.0)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0)
     set(USE_NO_UNINITIALIZED 1)
   else()
     set(USE_NO_MAYBE_UNINITIALIZED 1)


### PR DESCRIPTION
Although the false positives that caused it to be disabled originally may have been fixed in GCC 12, GCC also suffers from a problem where -Wuninitialized may cause the build to hang on some platforms (GCC #120729). This has been fixed in GCC 15, so turn on -Wuninitialized for GCC 15+ instead of GCC 12+.