### PR TITLE
[support] Add packed_endian_specific_integral::value()

### DIFF
--- a/llvm/include/llvm/Support/Endian.h
+++ b/llvm/include/llvm/Support/Endian.h
@@ -223,10 +223,11 @@ struct packed_endian_specific_integral {
 
   explicit packed_endian_specific_integral(value_type val) { *this = val; }
 
-  operator value_type() const {
+  value_type value() const {
     return endian::read<value_type, endian, alignment>(
       (const void*)Value.buffer);
   }
+  operator value_type() const { return value(); }
 
   void operator=(value_type newValue) {
     endian::write<value_type, endian, alignment>(

--- a/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/aarch32.cpp
@@ -239,15 +239,14 @@ Error makeUnexpectedOpcodeError(const LinkGraph &G, const ThumbRelocation &R,
                                 Edge::Kind Kind) {
   return make_error<JITLinkError>(
       formatv("Invalid opcode [ {0:x4}, {1:x4} ] for relocation: {2}",
-              static_cast<uint16_t>(R.Hi), static_cast<uint16_t>(R.Lo),
-              G.getEdgeKindName(Kind)));
+              R.Hi.value(), R.Lo.value(), G.getEdgeKindName(Kind)));
 }
 
 Error makeUnexpectedOpcodeError(const LinkGraph &G, const ArmRelocation &R,
                                 Edge::Kind Kind) {
   return make_error<JITLinkError>(
-      formatv("Invalid opcode {0:x8} for relocation: {1}",
-              static_cast<uint32_t>(R.Wd), G.getEdgeKindName(Kind)));
+      formatv("Invalid opcode {0:x8} for relocation: {1}", R.Wd.value(),
+              G.getEdgeKindName(Kind)));
 }
 
 template <EdgeKind_aarch32 K> constexpr bool isArm() {

--- a/llvm/unittests/Support/EndianTest.cpp
+++ b/llvm/unittests/Support/EndianTest.cpp
@@ -237,6 +237,7 @@ TEST(Endian, PackedEndianSpecificIntegral) {
     reinterpret_cast<little32_t *>(little + 1);
 
   EXPECT_EQ(*big_val, *little_val);
+  EXPECT_EQ(big_val->value(), little_val->value());
 }
 
 TEST(Endian, PacketEndianSpecificIntegralAsEnum) {


### PR DESCRIPTION
They are already implicitly convertible to the underlying type, but that doesn't work in some contexts, and it can be useful to get the underlying value without needing the remember/guess the right type.

I converted a couple of call sites to demonstrate usefulness, but there's likely more of them. I know at least of at least a few in LLDB, but I don't want to make this a cross-project patch.