### PR TITLE
[Clang][Doc] Add Changelog line for (#144886)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1038,6 +1038,8 @@ RISC-V Support
 CUDA/HIP Language Changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Provide a __device__ version of std::__glibcxx_assert_fail() in a header wrapper.
+
 CUDA Support
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
The patch [CUDA][HIP] Add a __device__ version of std::__glibcxx_assert_fail() (#144886) missed a changelog line.