### PR TITLE
[WIP][DO NOT MERGE][Clang][Driver] Emit warning when -fsanitize-trap=<...> is passed without associated -fsanitize=<...>

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -876,4 +876,9 @@ def warn_drv_openacc_without_cir
     : Warning<"OpenACC directives will result in no runtime behavior; use "
               "-fclangir to enable runtime effect">,
       InGroup<SourceUsesOpenACC>;
+
+def warn_drv_sanitize_trap_mismatch : Warning<
+  "-fsanitize-trap=%0 has no effect because the \"%0\" sanitizer is disabled; "
+  "consider passing \"-fsanitize=%0\" to enable the sanitizer">,
+  InGroup<SanitizeTrapMismatch>;
 }

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1758,3 +1758,6 @@ def ExplicitSpecializationStorageClass : DiagGroup<"explicit-specialization-stor
 
 // A warning for options that enable a feature that is not yet complete
 def ExperimentalOption : DiagGroup<"experimental-option">;
+
+// Warnings for sanitizer arguments
+def SanitizeTrapMismatch : DiagGroup<"sanitize-trap-mismatch">;

--- a/clang/test/Driver/fsanitize-trap-mismatch.c
+++ b/clang/test/Driver/fsanitize-trap-mismatch.c
@@ -1,0 +1,9 @@
+// RUN: %clang -S -emit-llvm -g -O0 %s -fsanitize-trap=undefined -o - 2>&1 | FileCheck %s --check-prefix=WARN
+// RUN: %clang -S -emit-llvm -g -O0 %s -fsanitize=undefined  -fsanitize-trap=undefined -o - 2>&1 | FileCheck %s --check-prefix=NOWARN
+// RUN: %clang -S -emit-llvm -g -O0 %s -fsanitize-trap=undefined -Wno-sanitize-trap-mismatch -o - 2>&1 | FileCheck %s --check-prefix=SUPPRESS
+//
+// WARN: warning: -fsanitize-trap=undefined has no effect because the "undefined" sanitizer is disabled; consider passing "fsanitize=undefined" to enable the sanitizer
+// NOWARN-NOT: warning: -fsanitize-trap=undefined has no effect because the "undefined" sanitizer is disabled; consider passing "fsanitize=undefined" to enable the sanitizer
+// SUPPRESS-NOT: warning: -fsanitize-trap=undefined has no effect because the "undefined" sanitizer is disabled; consider passing "fsanitize=undefined" to enable the sanitizer
+
+int main(void) { return 0; }


### PR DESCRIPTION
**This PR is a work-in-progress (WIP) and should not be merged.**

This is a sketch PR that will accompany an RFC about changing Clang's behavior handling -`fsanitize-trap=` without the corresponding sanitizer being enabled.

After parsing the sanitizer arguments and detecting a mismatched set of bits (`-fsanitize-trap=<...>` passed without corresponding `-fsanitize=<...>`), it is passed off to the helper, diagnoseTrapOnly. There, we utilize an X Macro pattern to first clear any sanitizer groups in the first pass, then clear any remaining individual sanitizer handlers in the second pass. This is intended to prevent flooding the user with warnings; for example if `-fsanitize-trap=undefined` is passed without `-fsanitize=undefined`, we don’t want every individual sanitizer inside the undefined group to emit a warning. 

Part of a GSoC 2025 Project
