### PR TITLE
[Offload] Add tagged type to enumerator docs

### DIFF
--- a/offload/tools/offload-tblgen/DocGen.cpp
+++ b/offload/tools/offload-tblgen/DocGen.cpp
@@ -86,7 +86,11 @@ void processEnum(const EnumRec &E, raw_ostream &OS) {
   for (const EnumValueRec Etor : E.getValues()) {
     OS << formatv("  .. c:enumerator:: {0}_{1}\n\n", E.getEnumValNamePrefix(),
                   Etor.getName());
-    OS << "    " << Etor.getDesc() << "\n\n";
+    OS << "    ";
+    if (E.isTyped()) {
+      OS << ":c:expr:`" << Etor.getTaggedType() << "` — ";
+    }
+    OS << Etor.getDesc() << "\n\n";
   }
 }
 


### PR DESCRIPTION
When `EnumRec::isTyped()` is true, include the `EnumValueRec::getTaggedType()` to the documentation.
