### PR TITLE
[ci] premerge: upload artifacts even on failure

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -63,6 +63,7 @@ jobs:
 
           ./.ci/monolithic-linux.sh "${projects_to_build}" "${project_check_targets}" "${runtimes_to_build}" "${runtimes_check_targets}" "${runtimes_check_targets_needs_reconfig}"
       - name: Upload Artifacts
+        if: '!cancelled()'
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: Premerge Artifacts (Linux)
@@ -113,6 +114,7 @@ jobs:
           call C:\\BuildTools\\Common7\\Tools\\VsDevCmd.bat -arch=amd64 -host_arch=amd64
           bash .ci/monolithic-windows.sh "${{ steps.vars.outputs.windows-projects }}" "${{ steps.vars.outputs.windows-check-targets }}"
       - name: Upload Artifacts
+        if: '!cancelled()'
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: Premerge Artifacts (Windows)


### PR DESCRIPTION
This makes sure we upload the artifacts even if the previous step failed.

This is helpful because we wish to upload crash reproducers, which the scritps are already prepared to do.

Example: https://github.com/llvm/llvm-project/actions/runs/16180778101/job/45676677544?pr=147835