### PR TITLE
[BOLT] Force frame pointers off for runtimes

### DIFF
--- a/bolt/runtime/CMakeLists.txt
+++ b/bolt/runtime/CMakeLists.txt
@@ -35,7 +35,12 @@ set(BOLT_RT_FLAGS
   -fno-exceptions
   -fno-rtti
   -fno-stack-protector
-  -fPIC)
+  -fPIC
+  # Runtime currently assumes omitted frame pointers for functions marked __attribute((naked)).
+  # Protect against distros adding -fno-omit-frame-pointer and compiling with GCC.
+  # Refs: llvm/llvm-project#148595 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
+  -fomit-frame-pointer
+)
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
   set(BOLT_RT_FLAGS ${BOLT_RT_FLAGS} 
     -mno-sse 


### PR DESCRIPTION
Distributions are making the choice to turn frame pointers on by default. Nixpkgs recently turned them on, and the method they use to do so implies that everything is built with them on by default.

https://github.com/NixOS/nixpkgs/pull/399014

Assuming that a well behaved distribution doing this puts `-fno-omit-frame-pointer` at the beginning of the compiler invocation, we can still re-enable omission by supplying `-fomit-frame-pointer` during compilation.

This fixes some segfaults from stack corruption in binaries rewritten by bolt with `llvm-bolt -instrument`.

See also: #147569
Fixes: #148595