### PR TITLE
[CIR] Add handlers for 'using enum' and namespace alias

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1258,6 +1258,8 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
   case Decl::Enum:
   case Decl::Using:          // using X; [C++]
   case Decl::UsingDirective: // using namespace X; [C++]
+  case Decl::UsingEnum:      // using enum X; [C++]
+  case Decl::NamespaceAlias:
   case Decl::Typedef:
   case Decl::TypeAlias: // using foo = bar; [C++11]
   case Decl::Record:

--- a/clang/test/CIR/CodeGen/enum.cpp
+++ b/clang/test/CIR/CodeGen/enum.cpp
@@ -14,3 +14,14 @@ int f() {
 
 // CHECK: cir.func{{.*}} @_Z1fv
 // CHECK:    cir.const #cir.int<1> : !u32i
+
+namespace test {
+  using enum Numbers;
+};
+
+int f2() {
+  return test::Two;
+}
+
+// CHECK: cir.func{{.*}} @_Z2f2v
+// CHECK:    cir.const #cir.int<2> : !u32i

--- a/clang/test/CIR/CodeGen/namespace.cpp
+++ b/clang/test/CIR/CodeGen/namespace.cpp
@@ -93,3 +93,11 @@ void f7() {
 }
 
 // CHECK: cir.func{{.*}} @_Z2f7v()
+
+namespace test_alias = test;
+
+int f8() {
+  return test_alias::g2;
+}
+
+// CHECK: cir.func{{.*}} @_Z2f8v()


### PR DESCRIPTION
These decl types don't require any code generation, though when debug info is implemented, we will need to add handling for that. Until then, we just need to have a handler  so they don't generate an NYI error.