### PR TITLE
[clang-query] Allow for trailing comma in matchers

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -88,6 +88,11 @@ Improvements to clang-doc
 Improvements to clang-query
 ---------------------------
 
+- Matcher queries interpreted by clang-query are now support trailing comma (,)
+  in matcher arguments. Note that C++ still doesn't allow this in function
+  arguments. So when porting a query to C++, remove all instances of trailing
+  comma (otherwise C++ compiler will just complain about "expected expression").
+
 Improvements to include-cleaner
 -------------------------------
 - Deprecated the ``-insert`` and ``-remove`` command line options, and added

--- a/clang-tools-extra/test/clang-query/trailing-comma.c
+++ b/clang-tools-extra/test/clang-query/trailing-comma.c
@@ -1,0 +1,21 @@
+void foo(void) {}
+// CHECK-OK: trailing-comma.c:1:1: note: "root" binds here
+// CHECK-ERR-COMMA: Invalid token <,> found when looking for a value.
+
+// RUN: clang-query -c "match \
+// RUN:   functionDecl( \
+// RUN:     hasName( \
+// RUN:       \"foo\", \
+// RUN:     ), \
+// RUN:   ) \
+// RUN: " %s | FileCheck --check-prefix=CHECK-OK %s
+
+// Same with \n tokens
+// RUN: echo "match functionDecl( hasName( \"foo\" , ) , )" | sed "s/ /\n/g" >%t
+// RUN: clang-query -f %t %s | FileCheck --check-prefix=CHECK-OK %s
+
+// RUN: not clang-query -c "match functionDecl(hasName(\"foo\"),,)" %s \
+// RUN:   | FileCheck --check-prefix=CHECK-ERR-COMMA %s
+
+// RUN: not clang-query -c "match functionDecl(,)" %s \
+// RUN:   | FileCheck --check-prefix=CHECK-ERR-COMMA %s

--- a/clang/lib/ASTMatchers/Dynamic/Parser.cpp
+++ b/clang/lib/ASTMatchers/Dynamic/Parser.cpp
@@ -490,6 +490,11 @@ bool Parser::parseMatcherBuilder(MatcherCtor Ctor, const TokenInfo &NameToken,
               << CommaToken.Text;
           return false;
         }
+        // Allow for a trailing , token and possibly a new line.
+        Tokenizer->SkipNewlines();
+        if (Tokenizer->nextTokenKind() == TokenInfo::TK_CloseParen) {
+          continue;
+        }
       }
 
       Diagnostics::Context Ctx(Diagnostics::Context::MatcherArg, Error,
@@ -657,6 +662,11 @@ bool Parser::parseMatcherExpressionImpl(const TokenInfo &NameToken,
           Error->addError(CommaToken.Range, Error->ET_ParserNoComma)
               << CommaToken.Text;
           return false;
+        }
+        // Allow for a trailing , token and possibly a new line.
+        Tokenizer->SkipNewlines();
+        if (Tokenizer->nextTokenKind() == TokenInfo::TK_CloseParen) {
+          continue;
         }
       }
 


### PR DESCRIPTION
Allow AST matches in clang-query to have a trailing comma at the end of matcher arguments. Makes it nicer to work with queries that span multiple lines.

So, for example, the following is possible:

```clang-query
match namedDecl(
  isExpansionInMainFile(),
  anyOf(
    varDecl().bind("var"),
    functionDecl().bind("func"),
    # enumDecl().bind("enum"),
  ),
)
```

CC: @AaronBallman