### PR TITLE
Add back fallthrough annotations removed by 7f3afab

### DIFF
--- a/third-party/siphash/include/siphash/SipHash.h
+++ b/third-party/siphash/include/siphash/SipHash.h
@@ -104,25 +104,24 @@ void siphash(const unsigned char *in, uint64_t inlen,
   switch (left) {
   case 7:
     b |= ((uint64_t)ni[6]) << 48;
-    /* FALLTHRU */
+    [[fallthrough]];
   case 6:
     b |= ((uint64_t)ni[5]) << 40;
-    /* FALLTHRU */
+    [[fallthrough]];
   case 5:
     b |= ((uint64_t)ni[4]) << 32;
-    /* FALLTHRU */
+    [[fallthrough]];
   case 4:
     b |= ((uint64_t)ni[3]) << 24;
-    /* FALLTHRU */
+    [[fallthrough]];
   case 3:
     b |= ((uint64_t)ni[2]) << 16;
-    /* FALLTHRU */
+    [[fallthrough]];
   case 2:
     b |= ((uint64_t)ni[1]) << 8;
-    /* FALLTHRU */
+    [[fallthrough]];
   case 1:
     b |= ((uint64_t)ni[0]);
-    /* FALLTHRU */
     break;
   case 0:
     break;


### PR DESCRIPTION
The original commit removed them to avoid the dependency on llvm Support because of LLVM_FALLTHROUGH, but this triggers `-Wimplicit-fallthrough` warnings.

LLVM requires a C++17 compiler now, so we should be able to use the standard [[fallthrough]] attribute.