### PR TITLE
[RISCV] RFC: Add PE/COFF file output support

### DIFF
--- a/llvm/docs/CodeGenerator.rst
+++ b/llvm/docs/CodeGenerator.rst
@@ -723,7 +723,7 @@ The table below captures a snapshot of object file support in LLVM:
      ================== ========================================================
      Format              Supported Targets
      ================== ========================================================
-     ``COFF``            AArch64, ARM, X86
+     ``COFF``            AArch64, ARM, RISCV, X86
      ``DXContainer``     DirectX
      ``ELF``             AArch64, AMDGPU, ARM, AVR, BPF, CSKY, Hexagon, Lanai, LoongArch, M86k, MSP430, MIPS, PowerPC, RISCV, SPARC, SystemZ, VE, X86
      ``GOFF``            SystemZ

--- a/llvm/include/llvm/BinaryFormat/COFF.h
+++ b/llvm/include/llvm/BinaryFormat/COFF.h
@@ -132,7 +132,8 @@ template <typename T> bool isAnyArm64(T Machine) {
 }
 
 template <typename T> bool is64Bit(T Machine) {
-  return Machine == IMAGE_FILE_MACHINE_AMD64 || isAnyArm64(Machine);
+  return Machine == IMAGE_FILE_MACHINE_AMD64 || isAnyArm64(Machine) ||
+         IMAGE_FILE_MACHINE_RISCV64;
 }
 
 enum Characteristics : unsigned {
@@ -726,7 +727,10 @@ enum BaseRelocationType : unsigned {
   IMAGE_REL_BASED_HIGHADJ = 4,
   IMAGE_REL_BASED_MIPS_JMPADDR = 5,
   IMAGE_REL_BASED_ARM_MOV32A = 5,
+  IMAGE_REL_BASED_RISCV_HI20 = 5,
   IMAGE_REL_BASED_ARM_MOV32T = 7,
+  IMAGE_REL_BASED_RISCV_LOW12I = 7,
+  IMAGE_REL_BASED_RISCV_LOW12S = 8,
   IMAGE_REL_BASED_MIPS_JMPADDR16 = 9,
   IMAGE_REL_BASED_DIR64 = 10
 };

--- a/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/CodeViewDebug.cpp
@@ -32,6 +32,7 @@
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/DebugInfo/CodeView/CVTypeVisitor.h"
+#include "llvm/DebugInfo/CodeView/CodeView.h"
 #include "llvm/DebugInfo/CodeView/CodeViewRecordIO.h"
 #include "llvm/DebugInfo/CodeView/ContinuationRecordBuilder.h"
 #include "llvm/DebugInfo/CodeView/DebugInlineeLinesSubsection.h"
@@ -125,6 +126,9 @@ static CPUType mapArchToCVCPUType(Triple::ArchType Type) {
     return CPUType::ARM64;
   case Triple::ArchType::mipsel:
     return CPUType::MIPS;
+  case llvm::Triple::ArchType::riscv32:
+  case llvm::Triple::ArchType::riscv64:
+    return CPUType::Unknown;
   case Triple::ArchType::UnknownArch:
     return CPUType::Unknown;
   default:

--- a/llvm/lib/Object/COFFObjectFile.cpp
+++ b/llvm/lib/Object/COFFObjectFile.cpp
@@ -1115,11 +1115,14 @@ dynamic_reloc_iterator COFFObjectFile::dynamic_reloc_end() const {
 }
 
 uint8_t COFFObjectFile::getBytesInAddress() const {
-  return getArch() == Triple::x86_64 || getArch() == Triple::aarch64 ? 8 : 4;
+  return getArch() == Triple::x86_64 || getArch() == Triple::aarch64 ||
+                 getArch() == Triple::riscv64
+             ? 8
+             : 4;
 }
 
 StringRef COFFObjectFile::getFileFormatName() const {
-  switch(getMachine()) {
+  switch (getMachine()) {
   case COFF::IMAGE_FILE_MACHINE_I386:
     return "COFF-i386";
   case COFF::IMAGE_FILE_MACHINE_AMD64:
@@ -1134,6 +1137,10 @@ StringRef COFFObjectFile::getFileFormatName() const {
     return "COFF-ARM64X";
   case COFF::IMAGE_FILE_MACHINE_R4000:
     return "COFF-MIPS";
+  case COFF::IMAGE_FILE_MACHINE_RISCV32:
+    return "COFF-RISCV32";
+  case COFF::IMAGE_FILE_MACHINE_RISCV64:
+    return "COFF-RISCV64";
   default:
     return "COFF-<unknown arch>";
   }

--- a/llvm/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/CMakeLists.txt
@@ -11,6 +11,8 @@ add_llvm_component_library(LLVMRISCVDesc
   RISCVMatInt.cpp
   RISCVTargetStreamer.cpp
   RISCVELFStreamer.cpp
+  RISCVWinCOFFObjectWriter.cpp
+  RISCVWinCOFFStreamer.cpp
 
   LINK_COMPONENTS
   MC

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -57,3 +57,15 @@ void RISCVMCAsmInfo::printSpecifierExpr(raw_ostream &OS,
   if (HasSpecifier)
     OS << ')';
 }
+
+
+void RISCVCOFFMCAsmInfo::anchor() {}
+
+RISCVCOFFMCAsmInfo::RISCVCOFFMCAsmInfo() {
+  HasSingleParameterDotFile = true;
+  WinEHEncodingType = WinEH::EncodingType::Itanium;
+
+  ExceptionsType = ExceptionHandling::WinEH;
+
+  AllowAtInName = true;
+}

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCASMINFO_H
 #define LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCASMINFO_H
 
+#include "llvm/MC/MCAsmInfoCOFF.h"
 #include "llvm/MC/MCAsmInfoELF.h"
 #include "llvm/MC/MCFixup.h"
 
@@ -29,6 +30,13 @@ public:
                                     MCStreamer &Streamer) const override;
   void printSpecifierExpr(raw_ostream &OS,
                           const MCSpecifierExpr &Expr) const override;
+};
+
+class RISCVCOFFMCAsmInfo : public MCAsmInfoGNUCOFF {
+  void anchor() override;
+
+public:
+  explicit RISCVCOFFMCAsmInfo();
 };
 
 namespace RISCV {

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -44,6 +44,13 @@
 
 using namespace llvm;
 
+namespace {
+class RISCVWinCOFFTargetStreamer : public RISCVTargetStreamer {
+public:
+  RISCVWinCOFFTargetStreamer(MCStreamer &S) : RISCVTargetStreamer(S) {}
+};
+} // end namespace
+
 static MCInstrInfo *createRISCVMCInstrInfo() {
   MCInstrInfo *X = new MCInstrInfo();
   InitRISCVMCInstrInfo(X);
@@ -59,7 +66,13 @@ static MCRegisterInfo *createRISCVMCRegisterInfo(const Triple &TT) {
 static MCAsmInfo *createRISCVMCAsmInfo(const MCRegisterInfo &MRI,
                                        const Triple &TT,
                                        const MCTargetOptions &Options) {
-  MCAsmInfo *MAI = new RISCVMCAsmInfo(TT);
+  MCAsmInfo *MAI;
+
+  if(TT.isOSWindows()){
+	  MAI = new RISCVCOFFMCAsmInfo();
+  } else {
+	  MAI = new RISCVMCAsmInfo(TT);
+  }
 
   unsigned SP = MRI.getDwarfRegNum(RISCV::X2, true);
   MCCFIInstruction Inst = MCCFIInstruction::cfiDefCfa(nullptr, SP, 0);
@@ -110,6 +123,8 @@ static MCInstPrinter *createRISCVMCInstPrinter(const Triple &T,
 static MCTargetStreamer *
 createRISCVObjectTargetStreamer(MCStreamer &S, const MCSubtargetInfo &STI) {
   const Triple &TT = STI.getTargetTriple();
+  if(TT.isOSBinFormatCOFF())
+	return new RISCVWinCOFFTargetStreamer(S);
   if (TT.isOSBinFormatELF())
     return new RISCVTargetELFStreamer(S, STI);
   return nullptr;
@@ -344,6 +359,7 @@ LLVMInitializeRISCVTargetMC() {
     TargetRegistry::RegisterMCInstPrinter(*T, createRISCVMCInstPrinter);
     TargetRegistry::RegisterMCSubtargetInfo(*T, createRISCVMCSubtargetInfo);
     TargetRegistry::RegisterELFStreamer(*T, createRISCVELFStreamer);
+	TargetRegistry::RegisterCOFFStreamer(*T, createRISCVWinCOFFStreamer);
     TargetRegistry::RegisterObjectTargetStreamer(
         *T, createRISCVObjectTargetStreamer);
     TargetRegistry::RegisterMCInstrAnalysis(*T, createRISCVInstrAnalysis);

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h
@@ -13,6 +13,8 @@
 #ifndef LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 #define LLVM_LIB_TARGET_RISCV_MCTARGETDESC_RISCVMCTARGETDESC_H
 
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/DataTypes.h"
 #include <memory>
@@ -23,7 +25,9 @@ class MCCodeEmitter;
 class MCContext;
 class MCInstrInfo;
 class MCObjectTargetWriter;
+class MCObjectWriter;
 class MCRegisterInfo;
+class MCStreamer;
 class MCSubtargetInfo;
 class Target;
 
@@ -34,8 +38,16 @@ MCAsmBackend *createRISCVAsmBackend(const Target &T, const MCSubtargetInfo &STI,
                                     const MCRegisterInfo &MRI,
                                     const MCTargetOptions &Options);
 
+MCStreamer *createRISCVWinCOFFStreamer(MCContext &C,
+                                       std::unique_ptr<MCAsmBackend> &&AB,
+                                       std::unique_ptr<MCObjectWriter> &&OW,
+                                       std::unique_ptr<MCCodeEmitter> &&CE);
+
 std::unique_ptr<MCObjectTargetWriter> createRISCVELFObjectWriter(uint8_t OSABI,
                                                                  bool Is64Bit);
+
+std::unique_ptr<MCObjectTargetWriter> createRISCVWinCOFFObjectWriter(bool Is64Bit);
+	
 } // namespace llvm
 
 // Defines symbolic names for RISC-V registers.

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVWinCOFFObjectWriter.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVWinCOFFObjectWriter.cpp
@@ -1,0 +1,51 @@
+//===- RISCVWinCOFFObjectWriter.cpp-----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#include "MCTargetDesc/RISCVFixupKinds.h"
+#include "MCTargetDesc/RISCVMCTargetDesc.h"
+#include "llvm/BinaryFormat/COFF.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCWinCOFFObjectWriter.h"
+
+using namespace llvm;
+
+namespace {
+
+class RISCVWinCOFFObjectWriter : public MCWinCOFFObjectTargetWriter {
+public:
+  RISCVWinCOFFObjectWriter(bool Is64Bit);
+
+  unsigned getRelocType(MCContext &Ctx, const MCValue &Target,
+                        const MCFixup &Fixup, bool IsCrossSection,
+                        const MCAsmBackend &MAB) const override;
+};
+
+} // namespace
+
+RISCVWinCOFFObjectWriter::RISCVWinCOFFObjectWriter(bool Is64Bit)
+    : MCWinCOFFObjectTargetWriter(Is64Bit ? COFF::IMAGE_FILE_MACHINE_RISCV64
+                                          : COFF::IMAGE_FILE_MACHINE_RISCV32) {}
+
+unsigned RISCVWinCOFFObjectWriter::getRelocType(MCContext &Ctx,
+                                                const MCValue &Target,
+                                                const MCFixup &Fixup,
+                                                bool IsCrossSection,
+                                                const MCAsmBackend &MAB) const {
+  unsigned FixupKind = Fixup.getKind();
+
+  switch (FixupKind) {
+  default:
+    Ctx.reportError(Fixup.getLoc(), "unsupported relocation type");
+    return COFF::IMAGE_REL_BASED_RISCV_HI20; // FIXME
+  }
+}
+
+std::unique_ptr<MCObjectTargetWriter>
+llvm::createRISCVWinCOFFObjectWriter(bool Is64Bit) {
+  return std::make_unique<RISCVWinCOFFObjectWriter>(Is64Bit);
+}

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVWinCOFFStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVWinCOFFStreamer.cpp
@@ -1,0 +1,33 @@
+//===- RISCVWinCOFFStreamer.cpp----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+#include "RISCVMCTargetDesc.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAssembler.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCWinCOFFStreamer.h"
+
+using namespace llvm;
+
+namespace {
+class RISCVWinCOFFStreamer : public MCWinCOFFStreamer {
+public:
+  RISCVWinCOFFStreamer(MCContext &C, std::unique_ptr<MCAsmBackend> AB,
+                       std::unique_ptr<MCCodeEmitter> CE,
+                       std::unique_ptr<MCObjectWriter> OW)
+      : MCWinCOFFStreamer(C, std::move(AB), std::move(CE), std::move(OW)) {}
+};
+} // namespace
+
+MCStreamer *llvm::createRISCVWinCOFFStreamer(
+    MCContext &C, std::unique_ptr<MCAsmBackend> &&AB,
+    std::unique_ptr<MCObjectWriter> &&OW, std::unique_ptr<MCCodeEmitter> &&CE) {
+  return new RISCVWinCOFFStreamer(C, std::move(AB), std::move(CE),
+                                  std::move(OW));
+}

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -927,6 +927,8 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
   case Triple::aarch64:
   case Triple::aarch64_32:
   case Triple::arm:
+  case Triple::riscv32:
+  case Triple::riscv64:
   case Triple::thumb:
   case Triple::x86:
   case Triple::x86_64:
@@ -966,8 +968,6 @@ static Triple::ObjectFormatType getDefaultFormat(const Triple &T) {
   case Triple::r600:
   case Triple::renderscript32:
   case Triple::renderscript64:
-  case Triple::riscv32:
-  case Triple::riscv64:
   case Triple::shave:
   case Triple::sparc:
   case Triple::sparcel:


### PR DESCRIPTION
Adding support for PE file output for RISC-V target, mainly targeted for producing UEFI Applications.