### PR TITLE
[libc++] Define __shared_mutex_base's destructor in the dylib

### DIFF
--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -355,6 +355,12 @@
 #define _LIBCPP_AVAILABILITY_HAS_BAD_FUNCTION_CALL_GOOD_WHAT_MESSAGE _LIBCPP_INTRODUCED_IN_LLVM_21
 // No attribute, since we've had bad_function_call::what() in the headers before
 
+// This controls whether we assume that __shared_mutex_base::~__shared_mutex_base() is defined in the dylib.
+// Defining that function in the dylib provides additional flexibility for changing the representation of the
+// class, which may eventually be used to provide a better implementation.
+#define _LIBCPP_AVAILABILITY_HAS_SHARED_MUTEX_BASE_DESTRUCTOR _LIBCPP_INTRODUCED_IN_LLVM_21
+// No attribute, since we define the destructor in the headers otherwise
+
 // Define availability attributes that depend on both
 // _LIBCPP_HAS_EXCEPTIONS and _LIBCPP_HAS_RTTI.
 #if !_LIBCPP_HAS_EXCEPTIONS || !_LIBCPP_HAS_RTTI

--- a/libcxx/include/shared_mutex
+++ b/libcxx/include/shared_mutex
@@ -163,7 +163,11 @@ struct _LIBCPP_EXPORTED_FROM_ABI __shared_mutex_base {
   static const unsigned __n_readers_     = ~__write_entered_;
 
   __shared_mutex_base();
+#      if defined(_LIBCPP_BUILDING_LIBRARY) || _LIBCPP_AVAILABILITY_HAS_SHARED_MUTEX_BASE_DESTRUCTOR
+  ~__shared_mutex_base();
+#      else
   _LIBCPP_HIDE_FROM_ABI ~__shared_mutex_base() = default;
+#      endif
 
   __shared_mutex_base(const __shared_mutex_base&)            = delete;
   __shared_mutex_base& operator=(const __shared_mutex_base&) = delete;

--- a/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/arm64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1551,6 +1551,8 @@
 {'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/lib/abi/i686-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/i686-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1187,6 +1187,8 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -545,6 +545,8 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_base8try_lockEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
+{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
+{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count14__release_weakEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count4lockEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_weak_countD0Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}

--- a/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/powerpc64-ibm-aix.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -545,6 +545,8 @@
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_base8try_lockEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
+{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD1Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
+{'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD2Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count14__release_weakEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count4lockEv', 'storage_mapping_class': 'DS', 'type': 'FUNC'}
 {'import_export': 'EXP', 'is_defined': True, 'name': '_ZNSt3__119__shared_weak_countD0Ev', 'storage_mapping_class': 'DS', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-apple-darwin.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1550,6 +1550,8 @@
 {'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '__ZNSt3__119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '__ZNSt3__119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-linux-android21.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1187,6 +1187,8 @@
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt6__ndk119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt6__ndk119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-freebsd.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1201,6 +1201,8 @@
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.exceptions.nonew.abilist
@@ -1199,6 +1199,8 @@
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
+++ b/libcxx/lib/abi/x86_64-unknown-linux-gnu.libcxxabi.v1.stable.noexceptions.nonew.abilist
@@ -1170,6 +1170,8 @@
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_base8try_lockEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC1Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseC2Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD1Ev', 'type': 'FUNC'}
+{'is_defined': True, 'name': '_ZNSt3__119__shared_mutex_baseD2Ev', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count10__add_weakEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count12__add_sharedEv', 'type': 'FUNC'}
 {'is_defined': True, 'name': '_ZNSt3__119__shared_weak_count14__release_weakEv', 'type': 'FUNC'}

--- a/libcxx/src/shared_mutex.cpp
+++ b/libcxx/src/shared_mutex.cpp
@@ -16,6 +16,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // Shared Mutex Base
 __shared_mutex_base::__shared_mutex_base() : __state_(0) {}
+__shared_mutex_base::~__shared_mutex_base() {}
 
 // Exclusive ownership
 


### PR DESCRIPTION
This makes the whole implementation of __shared_mutex_base live in the dylib, which means that we could in principle change its implementation without introducing an ABI break, once we are comfortable with assuming that no code out there remains with the inline destructor implementation.