### PR TITLE
[flang][cuda][NFC] Remove TODO implemented in semantic

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -4842,8 +4842,6 @@ private:
                   .detailsIf<Fortran::semantics::ObjectEntityDetails>()) {
         if (details->cudaDataAttr() &&
             *details->cudaDataAttr() != Fortran::common::CUDADataAttr::Pinned) {
-          // TODO: This should probably being checked in semantic and give a
-          // proper error.
           assert(
               nbDeviceResidentObject <= 1 &&
               "Only one reference to the device resident object is supported");


### PR DESCRIPTION
This is implemented here: https://github.com/llvm/llvm-project/blob/838701a5403efbaf6e25254377a6f033acee6681/flang/lib/Semantics/check-cuda.cpp#L764

Keep the assert in place as security, 