### PR TITLE
[lldb-dap] persistent assembly breakpoints

### DIFF
--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -23,6 +23,7 @@
 #include "lldb/API/SBValue.h"
 #include "lldb/API/SBWatchpoint.h"
 #include "lldb/API/SBWatchpointOptions.h"
+#include "lldb/lldb-types.h"
 
 namespace lldb_private {
 namespace python {
@@ -738,7 +739,7 @@ public:
   lldb::SBBreakpoint BreakpointCreateBySBAddress(SBAddress &address);
 
   lldb::SBBreakpoint BreakpointCreateByFileAddress(const SBFileSpec &file_spec,
-                                                   addr_t file_addr);
+                                                   addr_t file_addr, addr_t offset = 0, addr_t instructions_offset = 0);
 
   /// Create a breakpoint using a scripted resolver.
   ///

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -738,8 +738,10 @@ public:
 
   lldb::SBBreakpoint BreakpointCreateBySBAddress(SBAddress &address);
 
-  lldb::SBBreakpoint BreakpointCreateByFileAddress(const SBFileSpec &file_spec,
-                                                   addr_t file_addr, addr_t offset = 0, addr_t instructions_offset = 0);
+  lldb::SBBreakpoint
+  BreakpointCreateByFileAddress(const SBFileSpec &file_spec, addr_t file_addr,
+                                addr_t offset = 0,
+                                addr_t instructions_offset = 0);
 
   /// Create a breakpoint using a scripted resolver.
   ///

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -23,7 +23,6 @@
 #include "lldb/API/SBValue.h"
 #include "lldb/API/SBWatchpoint.h"
 #include "lldb/API/SBWatchpointOptions.h"
-#include "lldb/lldb-types.h"
 
 namespace lldb_private {
 namespace python {
@@ -659,6 +658,14 @@ public:
       lldb::LanguageType symbol_language,
       const SBFileSpecList &module_list, const SBFileSpecList &comp_unit_list);
 
+  lldb::SBBreakpoint BreakpointCreateByName(
+      const char *symbol_name,
+      uint32_t
+          name_type_mask, // Logical OR one or more FunctionNameType enum bits
+      lldb::LanguageType symbol_language, lldb::addr_t offset,
+      bool offset_is_insn_count, const SBFileSpecList &module_list,
+      const SBFileSpecList &comp_unit_list);
+
 #ifdef SWIG
   lldb::SBBreakpoint BreakpointCreateByNames(
       const char **symbol_name, uint32_t num_names,
@@ -737,11 +744,6 @@ public:
   lldb::SBBreakpoint BreakpointCreateByAddress(addr_t address);
 
   lldb::SBBreakpoint BreakpointCreateBySBAddress(SBAddress &address);
-
-  lldb::SBBreakpoint
-  BreakpointCreateByFileAddress(const SBFileSpec &file_spec, addr_t file_addr,
-                                addr_t offset = 0,
-                                addr_t instructions_offset = 0);
 
   /// Create a breakpoint using a scripted resolver.
   ///

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -737,6 +737,9 @@ public:
 
   lldb::SBBreakpoint BreakpointCreateBySBAddress(SBAddress &address);
 
+  lldb::SBBreakpoint BreakpointCreateByFileAddress(const SBFileSpec &file_spec,
+                                                   addr_t file_addr);
+
   /// Create a breakpoint using a scripted resolver.
   ///
   /// \param[in] class_name

--- a/lldb/include/lldb/Breakpoint/BreakpointResolver.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolver.h
@@ -16,6 +16,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/lldb-private.h"
+#include "lldb/lldb-types.h"
 #include <optional>
 
 namespace lldb_private {
@@ -47,7 +48,8 @@ public:
   ///   The concrete breakpoint resolver type for this breakpoint.
   BreakpointResolver(const lldb::BreakpointSP &bkpt,
                      unsigned char resolverType,
-                     lldb::addr_t offset = 0);
+                     lldb::addr_t offset = 0,
+                     lldb::addr_t instructions_offset = 0);
 
   /// The Destructor is virtual, all significant breakpoint resolvers derive
   /// from this class.
@@ -182,6 +184,7 @@ protected:
     SearchDepth,
     SkipPrologue,
     SymbolNameArray,
+    InstructionsOffset,
     LastOptionName
   };
   static const char
@@ -220,6 +223,7 @@ private:
   lldb::BreakpointWP m_breakpoint; // This is the breakpoint we add locations to.
   lldb::addr_t m_offset;    // A random offset the user asked us to add to any
                             // breakpoints we set.
+  lldb::addr_t m_instructions_offset; // Number of instructions to add to the resolved breakpoint address.
 
   // Subclass identifier (for llvm isa/dyn_cast)
   const unsigned char SubclassID;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolver.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolver.h
@@ -46,8 +46,7 @@ public:
   ///   The breakpoint that owns this resolver.
   /// \param[in] resolverType
   ///   The concrete breakpoint resolver type for this breakpoint.
-  BreakpointResolver(const lldb::BreakpointSP &bkpt,
-                     unsigned char resolverType,
+  BreakpointResolver(const lldb::BreakpointSP &bkpt, unsigned char resolverType,
                      lldb::addr_t offset = 0,
                      lldb::addr_t instructions_offset = 0);
 
@@ -223,7 +222,8 @@ private:
   lldb::BreakpointWP m_breakpoint; // This is the breakpoint we add locations to.
   lldb::addr_t m_offset;    // A random offset the user asked us to add to any
                             // breakpoints we set.
-  lldb::addr_t m_instructions_offset; // Number of instructions to add to the resolved breakpoint address.
+  lldb::addr_t m_instructions_offset; // Number of instructions to add to the
+                                      // resolved breakpoint address.
 
   // Subclass identifier (for llvm isa/dyn_cast)
   const unsigned char SubclassID;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolver.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolver.h
@@ -48,7 +48,7 @@ public:
   ///   The concrete breakpoint resolver type for this breakpoint.
   BreakpointResolver(const lldb::BreakpointSP &bkpt, unsigned char resolverType,
                      lldb::addr_t offset = 0,
-                     lldb::addr_t instructions_offset = 0);
+                     bool offset_is_insn_count = false);
 
   /// The Destructor is virtual, all significant breakpoint resolvers derive
   /// from this class.
@@ -77,6 +77,7 @@ public:
   void SetOffset(lldb::addr_t offset);
 
   lldb::addr_t GetOffset() const { return m_offset; }
+  lldb::addr_t GetOffsetIsInsnCount() const { return m_offset_is_insn_count; }
 
   /// In response to this method the resolver scans all the modules in the
   /// breakpoint's target, and adds any new locations it finds.
@@ -183,7 +184,6 @@ protected:
     SearchDepth,
     SkipPrologue,
     SymbolNameArray,
-    InstructionsOffset,
     LastOptionName
   };
   static const char
@@ -222,8 +222,8 @@ private:
   lldb::BreakpointWP m_breakpoint; // This is the breakpoint we add locations to.
   lldb::addr_t m_offset;    // A random offset the user asked us to add to any
                             // breakpoints we set.
-  lldb::addr_t m_instructions_offset; // Number of instructions to add to the
-                                      // resolved breakpoint address.
+  bool m_offset_is_insn_count; // Use the offset as an instruction count
+                               // instead of an address offset.
 
   // Subclass identifier (for llvm isa/dyn_cast)
   const unsigned char SubclassID;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolver.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolver.h
@@ -16,7 +16,6 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/lldb-private.h"
-#include "lldb/lldb-types.h"
 #include <optional>
 
 namespace lldb_private {

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
@@ -28,6 +28,12 @@ public:
                             const Address &addr,
                             const FileSpec &module_spec);
 
+  BreakpointResolverAddress(const lldb::BreakpointSP &bkpt,
+                            const Address &addr,
+                            const FileSpec &module_spec,
+                            lldb::addr_t offset,
+                            lldb::addr_t instructions_offset);
+
   ~BreakpointResolverAddress() override = default;
 
   static lldb::BreakpointResolverSP

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
@@ -28,10 +28,6 @@ public:
                             const Address &addr,
                             const FileSpec &module_spec);
 
-  BreakpointResolverAddress(const lldb::BreakpointSP &bkpt, const Address &addr,
-                            const FileSpec &module_spec, lldb::addr_t offset,
-                            lldb::addr_t instructions_offset);
-
   ~BreakpointResolverAddress() override = default;
 
   static lldb::BreakpointResolverSP

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverAddress.h
@@ -28,10 +28,8 @@ public:
                             const Address &addr,
                             const FileSpec &module_spec);
 
-  BreakpointResolverAddress(const lldb::BreakpointSP &bkpt,
-                            const Address &addr,
-                            const FileSpec &module_spec,
-                            lldb::addr_t offset,
+  BreakpointResolverAddress(const lldb::BreakpointSP &bkpt, const Address &addr,
+                            const FileSpec &module_spec, lldb::addr_t offset,
                             lldb::addr_t instructions_offset);
 
   ~BreakpointResolverAddress() override = default;

--- a/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
+++ b/lldb/include/lldb/Breakpoint/BreakpointResolverName.h
@@ -27,7 +27,7 @@ public:
                          lldb::FunctionNameType name_type_mask,
                          lldb::LanguageType language,
                          Breakpoint::MatchType type, lldb::addr_t offset,
-                         bool skip_prologue);
+                         bool offset_is_insn_count, bool skip_prologue);
 
   // This one takes an array of names.  It is always MatchType = Exact.
   BreakpointResolverName(const lldb::BreakpointSP &bkpt, const char *names[],

--- a/lldb/include/lldb/Core/Disassembler.h
+++ b/lldb/include/lldb/Core/Disassembler.h
@@ -291,6 +291,8 @@ public:
 
   size_t GetSize() const;
 
+  size_t GetTotalByteSize() const;
+
   uint32_t GetMaxOpcocdeByteSize() const;
 
   lldb::InstructionSP GetInstructionAtIndex(size_t idx) const;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -725,10 +725,10 @@ public:
                                       bool request_hardware);
 
   // Use this to create a breakpoint from a file address and a module file spec
-  lldb::BreakpointSP CreateAddressInModuleBreakpoint(
-      lldb::addr_t file_addr, bool internal, const FileSpec &file_spec,
-      bool request_hardware, lldb::addr_t offset = 0,
-      lldb::addr_t instructions_offset = 0);
+  lldb::BreakpointSP CreateAddressInModuleBreakpoint(lldb::addr_t file_addr,
+                                                     bool internal,
+                                                     const FileSpec &file_spec,
+                                                     bool request_hardware);
 
   // Use this to create Address breakpoints:
   lldb::BreakpointSP CreateBreakpoint(const Address &addr, bool internal,
@@ -753,8 +753,8 @@ public:
       const FileSpecList *containingModules,
       const FileSpecList *containingSourceFiles, const char *func_name,
       lldb::FunctionNameType func_name_type_mask, lldb::LanguageType language,
-      lldb::addr_t offset, LazyBool skip_prologue, bool internal,
-      bool request_hardware);
+      lldb::addr_t offset, bool offset_is_insn_count, LazyBool skip_prologue,
+      bool internal, bool request_hardware);
 
   lldb::BreakpointSP
   CreateExceptionBreakpoint(enum lldb::LanguageType language, bool catch_bp,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1335,9 +1335,9 @@ public:
                                const lldb_private::RegisterFlags &flags,
                                uint32_t byte_size);
 
-  lldb::DisassemblerSP ReadInstructions(const Address &start_addr,
-                                        uint32_t count,
-                                        const char *flavor_string = nullptr);
+  llvm::Expected<lldb::DisassemblerSP>
+  ReadInstructions(const Address &start_addr, uint32_t count,
+                   const char *flavor_string = nullptr);
 
   // Target Stop Hooks
   class StopHook : public UserID {

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -725,12 +725,10 @@ public:
                                       bool request_hardware);
 
   // Use this to create a breakpoint from a file address and a module file spec
-  lldb::BreakpointSP CreateAddressInModuleBreakpoint(lldb::addr_t file_addr,
-                                                     bool internal,
-                                                     const FileSpec &file_spec,
-                                                     bool request_hardware,
-                                                     lldb::addr_t offset = 0,
-                                                     lldb::addr_t instructions_offset = 0);
+  lldb::BreakpointSP CreateAddressInModuleBreakpoint(
+      lldb::addr_t file_addr, bool internal, const FileSpec &file_spec,
+      bool request_hardware, lldb::addr_t offset = 0,
+      lldb::addr_t instructions_offset = 0);
 
   // Use this to create Address breakpoints:
   lldb::BreakpointSP CreateBreakpoint(const Address &addr, bool internal,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -723,7 +723,7 @@ public:
   lldb::BreakpointSP CreateBreakpoint(lldb::addr_t load_addr, bool internal,
                                       bool request_hardware);
 
-  // Use this to create a breakpoint from a load address and a module file spec
+  // Use this to create a breakpoint from a file address and a module file spec
   lldb::BreakpointSP CreateAddressInModuleBreakpoint(lldb::addr_t file_addr,
                                                      bool internal,
                                                      const FileSpec &file_spec,

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -18,6 +18,7 @@
 #include "lldb/Breakpoint/BreakpointList.h"
 #include "lldb/Breakpoint/BreakpointName.h"
 #include "lldb/Breakpoint/WatchpointList.h"
+#include "lldb/Core/Address.h"
 #include "lldb/Core/Architecture.h"
 #include "lldb/Core/Disassembler.h"
 #include "lldb/Core/ModuleList.h"
@@ -727,7 +728,9 @@ public:
   lldb::BreakpointSP CreateAddressInModuleBreakpoint(lldb::addr_t file_addr,
                                                      bool internal,
                                                      const FileSpec &file_spec,
-                                                     bool request_hardware);
+                                                     bool request_hardware,
+                                                     lldb::addr_t offset = 0,
+                                                     lldb::addr_t instructions_offset = 0);
 
   // Use this to create Address breakpoints:
   lldb::BreakpointSP CreateBreakpoint(const Address &addr, bool internal,
@@ -1333,6 +1336,10 @@ public:
   CompilerType GetRegisterType(const std::string &name,
                                const lldb_private::RegisterFlags &flags,
                                uint32_t byte_size);
+
+  lldb::DisassemblerSP ReadInstructions(const Address &start_addr,
+                                        uint32_t count,
+                                        const char *flavor_string = nullptr);
 
   // Target Stop Hooks
   class StopHook : public UserID {

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -107,17 +107,20 @@ def dump_dap_log(log_file):
 
 class Source(object):
     def __init__(
-        self, path: Optional[str] = None, source_reference: Optional[int] = None
+        self, path: Optional[str] = None, source_reference: Optional[int] = None, raw_dict: Optional[dict[str, Any]] = None
     ):
         self._name = None
         self._path = None
         self._source_reference = None
+        self._raw_dict = None
 
         if path is not None:
             self._name = os.path.basename(path)
             self._path = path
         elif source_reference is not None:
             self._source_reference = source_reference
+        elif raw_dict is not None:
+            self._raw_dict = raw_dict
         else:
             raise ValueError("Either path or source_reference must be provided")
 
@@ -125,6 +128,9 @@ class Source(object):
         return f"Source(name={self.name}, path={self.path}), source_reference={self.source_reference})"
 
     def as_dict(self):
+        if self._raw_dict is not None:
+            return self._raw_dict
+
         source_dict = {}
         if self._name is not None:
             source_dict["name"] = self._name
@@ -133,6 +139,19 @@ class Source(object):
         if self._source_reference is not None:
             source_dict["sourceReference"] = self._source_reference
         return source_dict
+
+
+class Breakpoint(object):
+    def __init__(self, obj):
+        self._breakpoint = obj
+
+    def is_verified(self):
+        """Check if the breakpoint is verified."""
+        return self._breakpoint.get("verified", False)
+    
+    def source(self):
+        """Get the source of the breakpoint."""
+        return self._breakpoint.get("source", {})
 
 
 class NotSupportedError(KeyError):
@@ -170,7 +189,7 @@ class DebugCommunication(object):
         self.initialized = False
         self.frame_scopes = {}
         self.init_commands = init_commands
-        self.resolved_breakpoints = {}
+        self.resolved_breakpoints: dict[str, Breakpoint] = {}
 
     @classmethod
     def encode_content(cls, s: str) -> bytes:
@@ -326,9 +345,7 @@ class DebugCommunication(object):
     def _update_verified_breakpoints(self, breakpoints: list[Event]):
         for breakpoint in breakpoints:
             if "id" in breakpoint:
-                self.resolved_breakpoints[str(breakpoint["id"])] = breakpoint.get(
-                    "verified", False
-                )
+                self.resolved_breakpoints[str(breakpoint["id"])] = Breakpoint(breakpoint)
 
     def send_packet(self, command_dict: Request, set_sequence=True):
         """Take the "command_dict" python dictionary and encode it as a JSON
@@ -484,7 +501,7 @@ class DebugCommunication(object):
             if breakpoint_event is None:
                 break
 
-        return [id for id in breakpoint_ids if id not in self.resolved_breakpoints]
+        return [id for id in breakpoint_ids if (id not in self.resolved_breakpoints or not self.resolved_breakpoints[id].is_verified())]
 
     def wait_for_exited(self, timeout: Optional[float] = None):
         event_dict = self.wait_for_event("exited", timeout=timeout)

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -107,7 +107,10 @@ def dump_dap_log(log_file):
 
 class Source(object):
     def __init__(
-        self, path: Optional[str] = None, source_reference: Optional[int] = None, raw_dict: Optional[dict[str, Any]] = None
+        self,
+        path: Optional[str] = None,
+        source_reference: Optional[int] = None,
+        raw_dict: Optional[dict[str, Any]] = None,
     ):
         self._name = None
         self._path = None
@@ -148,7 +151,7 @@ class Breakpoint(object):
     def is_verified(self):
         """Check if the breakpoint is verified."""
         return self._breakpoint.get("verified", False)
-    
+
     def source(self):
         """Get the source of the breakpoint."""
         return self._breakpoint.get("source", {})
@@ -345,7 +348,9 @@ class DebugCommunication(object):
     def _update_verified_breakpoints(self, breakpoints: list[Event]):
         for breakpoint in breakpoints:
             if "id" in breakpoint:
-                self.resolved_breakpoints[str(breakpoint["id"])] = Breakpoint(breakpoint)
+                self.resolved_breakpoints[str(breakpoint["id"])] = Breakpoint(
+                    breakpoint
+                )
 
     def send_packet(self, command_dict: Request, set_sequence=True):
         """Take the "command_dict" python dictionary and encode it as a JSON
@@ -501,7 +506,14 @@ class DebugCommunication(object):
             if breakpoint_event is None:
                 break
 
-        return [id for id in breakpoint_ids if (id not in self.resolved_breakpoints or not self.resolved_breakpoints[id].is_verified())]
+        return [
+            id
+            for id in breakpoint_ids
+            if (
+                id not in self.resolved_breakpoints
+                or not self.resolved_breakpoints[id].is_verified()
+            )
+        ]
 
     def wait_for_exited(self, timeout: Optional[float] = None):
         event_dict = self.wait_for_event("exited", timeout=timeout)

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -59,24 +59,22 @@ class DAPTestCaseBase(TestBase):
         Each object in data is 1:1 mapping with the entry in lines.
         It contains optional location/hitCondition/logMessage parameters.
         """
-        response = self.dap_server.request_setBreakpoints(
-            Source(source_path), lines, data
+        return self.set_source_breakpoints_from_source(
+            Source(path=source_path), lines, data, wait_for_resolve
         )
-        if response is None or not response["success"]:
-            return []
-        breakpoints = response["body"]["breakpoints"]
-        breakpoint_ids = []
-        for breakpoint in breakpoints:
-            breakpoint_ids.append("%i" % (breakpoint["id"]))
-        if wait_for_resolve:
-            self.wait_for_breakpoints_to_resolve(breakpoint_ids)
-        return breakpoint_ids
 
     def set_source_breakpoints_assembly(
         self, source_reference, lines, data=None, wait_for_resolve=True
     ):
+        return self.set_source_breakpoints_from_source(
+            Source(source_reference=source_reference), lines, data, wait_for_resolve
+        )
+    
+    def set_source_breakpoints_from_source(
+        self, source: Source, lines, data=None, wait_for_resolve=True
+    ):
         response = self.dap_server.request_setBreakpoints(
-            Source(source_reference=source_reference),
+            source,
             lines,
             data,
         )

--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -69,7 +69,7 @@ class DAPTestCaseBase(TestBase):
         return self.set_source_breakpoints_from_source(
             Source(source_reference=source_reference), lines, data, wait_for_resolve
         )
-    
+
     def set_source_breakpoints_from_source(
         self, source: Source, lines, data=None, wait_for_resolve=True
     ):

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -1970,8 +1970,10 @@ lldb::SBInstructionList SBTarget::ReadInstructions(lldb::SBAddress base_addr,
 
   if (TargetSP target_sp = GetSP()) {
     if (Address *addr_ptr = base_addr.get()) {
-      sb_instructions.SetDisassembler(
-          target_sp->ReadInstructions(*addr_ptr, count, flavor_string));
+      if (llvm::Expected<DisassemblerSP> disassembler =
+              target_sp->ReadInstructions(*addr_ptr, count, flavor_string)) {
+        sb_instructions.SetDisassembler(*disassembler);
+      }
     }
   }
 

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -66,6 +66,7 @@
 
 #include "Commands/CommandObjectBreakpoint.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
+#include "lldb/lldb-types.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Regex.h"
 
@@ -944,6 +945,19 @@ SBBreakpoint SBTarget::BreakpointCreateBySBAddress(SBAddress &sb_address) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool hardware = false;
     sb_bp = target_sp->CreateBreakpoint(sb_address.ref(), false, hardware);
+  }
+
+  return sb_bp;
+}
+
+SBBreakpoint SBTarget::BreakpointCreateByFileAddress(const SBFileSpec &file_spec, addr_t file_addr) {
+  LLDB_INSTRUMENT_VA(this, file_spec, file_addr);
+
+  SBBreakpoint sb_bp;
+  if (TargetSP target_sp = GetSP()) {
+    std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
+    const bool hardware = false;
+    sb_bp = target_sp->CreateAddressInModuleBreakpoint(file_addr, false, *file_spec.get(), hardware);
   }
 
   return sb_bp;

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -66,7 +66,6 @@
 
 #include "Commands/CommandObjectBreakpoint.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
-#include "lldb/lldb-types.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Regex.h"
 

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -950,14 +950,19 @@ SBBreakpoint SBTarget::BreakpointCreateBySBAddress(SBAddress &sb_address) {
   return sb_bp;
 }
 
-SBBreakpoint SBTarget::BreakpointCreateByFileAddress(const SBFileSpec &file_spec, addr_t file_addr, addr_t offset, addr_t instructions_offset) {
+SBBreakpoint
+SBTarget::BreakpointCreateByFileAddress(const SBFileSpec &file_spec,
+                                        addr_t file_addr, addr_t offset,
+                                        addr_t instructions_offset) {
   LLDB_INSTRUMENT_VA(this, file_spec, file_addr);
 
   SBBreakpoint sb_bp;
   if (TargetSP target_sp = GetSP()) {
     std::lock_guard<std::recursive_mutex> guard(target_sp->GetAPIMutex());
     const bool hardware = false;
-    sb_bp = target_sp->CreateAddressInModuleBreakpoint(file_addr, false, *file_spec.get(), hardware, offset, instructions_offset);
+    sb_bp = target_sp->CreateAddressInModuleBreakpoint(
+        file_addr, false, *file_spec.get(), hardware, offset,
+        instructions_offset);
   }
 
   return sb_bp;
@@ -1969,8 +1974,8 @@ lldb::SBInstructionList SBTarget::ReadInstructions(lldb::SBAddress base_addr,
 
   if (TargetSP target_sp = GetSP()) {
     if (Address *addr_ptr = base_addr.get()) {
-      sb_instructions.SetDisassembler(target_sp->ReadInstructions(
-          *addr_ptr, count, flavor_string));
+      sb_instructions.SetDisassembler(
+          target_sp->ReadInstructions(*addr_ptr, count, flavor_string));
     }
   }
 

--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -29,7 +29,6 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StreamString.h"
-#include "lldb/lldb-forward.h"
 #include <optional>
 
 using namespace lldb_private;

--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -43,9 +43,11 @@ const char *BreakpointResolver::g_ty_to_name[] = {"FileAndLine", "Address",
 
 const char *BreakpointResolver::g_option_names[static_cast<uint32_t>(
     BreakpointResolver::OptionNames::LastOptionName)] = {
-    "AddressOffset", "Exact",     "FileName",     "Inlines",     "Language",
-    "LineNumber",    "Column",    "ModuleName",   "NameMask",    "Offset",
-    "PythonClass",   "Regex",     "ScriptArgs",   "SectionName", "SearchDepth",
+    "AddressOffset", "Exact",       "FileName",
+    "Inlines",       "Language",    "LineNumber",
+    "Column",        "ModuleName",  "NameMask",
+    "Offset",        "PythonClass", "Regex",
+    "ScriptArgs",    "SectionName", "SearchDepth",
     "SkipPrologue",  "SymbolNames", "InstructionsOffset"};
 
 const char *BreakpointResolver::ResolverTyToName(enum ResolverTy type) {
@@ -68,7 +70,8 @@ BreakpointResolver::BreakpointResolver(const BreakpointSP &bkpt,
                                        const unsigned char resolverTy,
                                        lldb::addr_t offset,
                                        lldb::addr_t instructions_offset)
-    : m_breakpoint(bkpt), m_offset(offset), m_instructions_offset(instructions_offset), SubclassID(resolverTy) {}
+    : m_breakpoint(bkpt), m_offset(offset),
+      m_instructions_offset(instructions_offset), SubclassID(resolverTy) {}
 
 BreakpointResolver::~BreakpointResolver() = default;
 
@@ -368,7 +371,8 @@ BreakpointLocationSP BreakpointResolver::AddLocation(Address loc_addr,
                                                      bool *new_location) {
   if (m_instructions_offset != 0) {
     Target &target = GetBreakpoint()->GetTarget();
-    const DisassemblerSP instructions = target.ReadInstructions(loc_addr, m_instructions_offset);
+    const DisassemblerSP instructions =
+        target.ReadInstructions(loc_addr, m_instructions_offset);
     loc_addr.Slide(instructions->GetInstructionList().GetTotalByteSize());
   }
 

--- a/lldb/source/Breakpoint/BreakpointResolver.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolver.cpp
@@ -381,10 +381,9 @@ BreakpointLocationSP BreakpointResolver::AddLocation(Address loc_addr,
     const DisassemblerSP instructions = *expected_instructions;
     if (!instructions ||
         instructions->GetInstructionList().GetSize() != m_offset) {
-      LLDB_LOGF(GetLog(LLDBLog::Breakpoints),
-                "error: Unable to read %lu instructions at address 0x%" PRIx64
-                "\n",
-                m_offset, loc_addr.GetLoadAddress(&target));
+      LLDB_LOG(GetLog(LLDBLog::Breakpoints),
+               "error: Unable to read {0} instructions at address 0x{1:x}",
+               m_offset, loc_addr.GetLoadAddress(&target));
       return BreakpointLocationSP();
     }
 

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -31,8 +31,10 @@ BreakpointResolverAddress::BreakpointResolverAddress(const BreakpointSP &bkpt,
       m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS) {}
 
 BreakpointResolverAddress::BreakpointResolverAddress(
-    const BreakpointSP &bkpt, const Address &addr, const FileSpec &module_spec, lldb::addr_t offset, lldb::addr_t instructions_offset)
-    : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver, offset, instructions_offset),
+    const BreakpointSP &bkpt, const Address &addr, const FileSpec &module_spec,
+    lldb::addr_t offset, lldb::addr_t instructions_offset)
+    : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver, offset,
+                         instructions_offset),
       m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS),
       m_module_filespec(module_spec) {}
 

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -141,6 +141,11 @@ Searcher::CallbackReturn BreakpointResolverAddress::SearchCallback(
           Address tmp_address;
           if (module_sp->ResolveFileAddress(m_addr.GetOffset(), tmp_address))
             m_addr = tmp_address;
+          else
+            return Searcher::eCallbackReturnStop;
+        } else {
+          // If we didn't find the module, then we can't resolve the address.
+          return Searcher::eCallbackReturnStop;
         }
       }
 

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -30,6 +30,12 @@ BreakpointResolverAddress::BreakpointResolverAddress(const BreakpointSP &bkpt,
     : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver),
       m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS) {}
 
+BreakpointResolverAddress::BreakpointResolverAddress(
+    const BreakpointSP &bkpt, const Address &addr, const FileSpec &module_spec, lldb::addr_t offset, lldb::addr_t instructions_offset)
+    : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver, offset, instructions_offset),
+      m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS),
+      m_module_filespec(module_spec) {}
+
 BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
     const StructuredData::Dictionary &options_dict, Status &error) {
   llvm::StringRef module_name;

--- a/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverAddress.cpp
@@ -30,14 +30,6 @@ BreakpointResolverAddress::BreakpointResolverAddress(const BreakpointSP &bkpt,
     : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver),
       m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS) {}
 
-BreakpointResolverAddress::BreakpointResolverAddress(
-    const BreakpointSP &bkpt, const Address &addr, const FileSpec &module_spec,
-    lldb::addr_t offset, lldb::addr_t instructions_offset)
-    : BreakpointResolver(bkpt, BreakpointResolver::AddressResolver, offset,
-                         instructions_offset),
-      m_addr(addr), m_resolved_addr(LLDB_INVALID_ADDRESS),
-      m_module_filespec(module_spec) {}
-
 BreakpointResolverSP BreakpointResolverAddress::CreateFromStructuredData(
     const StructuredData::Dictionary &options_dict, Status &error) {
   llvm::StringRef module_name;

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -24,11 +24,13 @@
 using namespace lldb;
 using namespace lldb_private;
 
-BreakpointResolverName::BreakpointResolverName(const BreakpointSP &bkpt,
-    const char *name_cstr, FunctionNameType name_type_mask,
-    LanguageType language, Breakpoint::MatchType type, lldb::addr_t offset,
+BreakpointResolverName::BreakpointResolverName(
+    const BreakpointSP &bkpt, const char *name_cstr,
+    FunctionNameType name_type_mask, LanguageType language,
+    Breakpoint::MatchType type, lldb::addr_t offset, bool offset_is_insn_count,
     bool skip_prologue)
-    : BreakpointResolver(bkpt, BreakpointResolver::NameResolver, offset),
+    : BreakpointResolver(bkpt, BreakpointResolver::NameResolver, offset,
+                         offset_is_insn_count),
       m_match_type(type), m_language(language), m_skip_prologue(skip_prologue) {
   if (m_match_type == Breakpoint::Regexp) {
     m_regex = RegularExpression(name_cstr);
@@ -81,7 +83,7 @@ BreakpointResolverName::BreakpointResolverName(const BreakpointSP &bkpt,
 BreakpointResolverName::BreakpointResolverName(
     const BreakpointResolverName &rhs)
     : BreakpointResolver(rhs.GetBreakpoint(), BreakpointResolver::NameResolver,
-                         rhs.GetOffset()),
+                         rhs.GetOffset(), rhs.GetOffsetIsInsnCount()),
       m_lookups(rhs.m_lookups), m_class_name(rhs.m_class_name),
       m_regex(rhs.m_regex), m_match_type(rhs.m_match_type),
       m_language(rhs.m_language), m_skip_prologue(rhs.m_skip_prologue) {}
@@ -177,7 +179,7 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
     std::shared_ptr<BreakpointResolverName> resolver_sp =
         std::make_shared<BreakpointResolverName>(
             nullptr, names[0].c_str(), name_masks[0], language,
-            Breakpoint::MatchType::Exact, offset, skip_prologue);
+            Breakpoint::MatchType::Exact, offset, false, skip_prologue);
     for (size_t i = 1; i < num_elem; i++) {
       resolver_sp->AddNameLookup(ConstString(names[i]), name_masks[i]);
     }

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -179,7 +179,7 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
     std::shared_ptr<BreakpointResolverName> resolver_sp =
         std::make_shared<BreakpointResolverName>(
             nullptr, names[0].c_str(), name_masks[0], language,
-            Breakpoint::MatchType::Exact, offset, false, skip_prologue);
+            Breakpoint::MatchType::Exact, offset, /*offset_is_insn_count = */false, skip_prologue);
     for (size_t i = 1; i < num_elem; i++) {
       resolver_sp->AddNameLookup(ConstString(names[i]), name_masks[i]);
     }

--- a/lldb/source/Breakpoint/BreakpointResolverName.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverName.cpp
@@ -179,7 +179,8 @@ BreakpointResolverSP BreakpointResolverName::CreateFromStructuredData(
     std::shared_ptr<BreakpointResolverName> resolver_sp =
         std::make_shared<BreakpointResolverName>(
             nullptr, names[0].c_str(), name_masks[0], language,
-            Breakpoint::MatchType::Exact, offset, /*offset_is_insn_count = */false, skip_prologue);
+            Breakpoint::MatchType::Exact, offset,
+            /*offset_is_insn_count = */ false, skip_prologue);
     for (size_t i = 1; i < num_elem; i++) {
       resolver_sp->AddNameLookup(ConstString(names[i]), name_masks[i]);
     }

--- a/lldb/source/Core/Disassembler.cpp
+++ b/lldb/source/Core/Disassembler.cpp
@@ -1016,6 +1016,16 @@ uint32_t InstructionList::GetMaxOpcocdeByteSize() const {
   return max_inst_size;
 }
 
+size_t InstructionList::GetTotalByteSize() const {
+  size_t total_byte_size = 0;
+  collection::const_iterator pos, end;
+  for (pos = m_instructions.begin(), end = m_instructions.end(); pos != end;
+       ++pos) {
+    total_byte_size += (*pos)->GetOpcode().GetByteSize();
+  }
+  return total_byte_size;
+}
+
 InstructionSP InstructionList::GetInstructionAtIndex(size_t idx) const {
   InstructionSP inst_sp;
   if (idx < m_instructions.size())

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1561,7 +1561,7 @@ void DynamicLoaderDarwinKernel::SetNotificationBreakpointIfNeeded() {
             .CreateBreakpoint(&module_spec_list, nullptr,
                               "OSKextLoadedKextSummariesUpdated",
                               eFunctionNameTypeFull, eLanguageTypeUnknown, 0,
-                              false, skip_prologue, internal_bp, hardware)
+                              /*offset_is_insn_count = */false, skip_prologue, internal_bp, hardware)
             .get();
 
     bp->SetCallback(DynamicLoaderDarwinKernel::BreakpointHitCallback, this,

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1561,7 +1561,8 @@ void DynamicLoaderDarwinKernel::SetNotificationBreakpointIfNeeded() {
             .CreateBreakpoint(&module_spec_list, nullptr,
                               "OSKextLoadedKextSummariesUpdated",
                               eFunctionNameTypeFull, eLanguageTypeUnknown, 0,
-                              /*offset_is_insn_count = */false, skip_prologue, internal_bp, hardware)
+                              /*offset_is_insn_count = */ false, skip_prologue,
+                              internal_bp, hardware)
             .get();
 
     bp->SetCallback(DynamicLoaderDarwinKernel::BreakpointHitCallback, this,

--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1561,7 +1561,7 @@ void DynamicLoaderDarwinKernel::SetNotificationBreakpointIfNeeded() {
             .CreateBreakpoint(&module_spec_list, nullptr,
                               "OSKextLoadedKextSummariesUpdated",
                               eFunctionNameTypeFull, eLanguageTypeUnknown, 0,
-                              skip_prologue, internal_bp, hardware)
+                              false, skip_prologue, internal_bp, hardware)
             .get();
 
     bp->SetCallback(DynamicLoaderDarwinKernel::BreakpointHitCallback, this,

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -546,7 +546,7 @@ bool DynamicLoaderMacOS::SetNotificationBreakpoint() {
             m_process->GetTarget()
                 .CreateBreakpoint(&dyld_filelist, source_files,
                                   "gdb_image_notifier", eFunctionNameTypeFull,
-                                  eLanguageTypeUnknown, 0, false, skip_prologue,
+                                  eLanguageTypeUnknown, 0, /*offset_is_insn_count = */false, skip_prologue,
                                   internal, hardware)
                 .get();
         breakpoint->SetCallback(DynamicLoaderMacOS::NotifyBreakpointHit, this,

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -530,7 +530,7 @@ bool DynamicLoaderMacOS::SetNotificationBreakpoint() {
           m_process->GetTarget()
               .CreateBreakpoint(&dyld_filelist, source_files,
                                 "lldb_image_notifier", eFunctionNameTypeFull,
-                                eLanguageTypeUnknown, 0, skip_prologue,
+                                eLanguageTypeUnknown, 0, false, skip_prologue,
                                 internal, hardware)
               .get();
       breakpoint->SetCallback(DynamicLoaderMacOS::NotifyBreakpointHit, this,
@@ -546,7 +546,7 @@ bool DynamicLoaderMacOS::SetNotificationBreakpoint() {
             m_process->GetTarget()
                 .CreateBreakpoint(&dyld_filelist, source_files,
                                   "gdb_image_notifier", eFunctionNameTypeFull,
-                                  eLanguageTypeUnknown, 0, skip_prologue,
+                                  eLanguageTypeUnknown, 0, false, skip_prologue,
                                   internal, hardware)
                 .get();
         breakpoint->SetCallback(DynamicLoaderMacOS::NotifyBreakpointHit, this,

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderMacOS.cpp
@@ -546,8 +546,9 @@ bool DynamicLoaderMacOS::SetNotificationBreakpoint() {
             m_process->GetTarget()
                 .CreateBreakpoint(&dyld_filelist, source_files,
                                   "gdb_image_notifier", eFunctionNameTypeFull,
-                                  eLanguageTypeUnknown, 0, /*offset_is_insn_count = */false, skip_prologue,
-                                  internal, hardware)
+                                  eLanguageTypeUnknown, 0,
+                                  /*offset_is_insn_count = */ false,
+                                  skip_prologue, internal, hardware)
                 .get();
         breakpoint->SetCallback(DynamicLoaderMacOS::NotifyBreakpointHit, this,
                                 true);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -102,7 +102,7 @@ AppleObjCRuntimeV1::CreateExceptionResolver(const BreakpointSP &bkpt,
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
-        false, eLazyBoolNo);
+        /*offset_is_insn_count = */false, eLazyBoolNo);
   // FIXME: don't do catch yet.
   return resolver_sp;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -102,7 +102,7 @@ AppleObjCRuntimeV1::CreateExceptionResolver(const BreakpointSP &bkpt,
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
-        /*offset_is_insn_count = */false, eLazyBoolNo);
+        /*offset_is_insn_count = */ false, eLazyBoolNo);
   // FIXME: don't do catch yet.
   return resolver_sp;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -102,7 +102,7 @@ AppleObjCRuntimeV1::CreateExceptionResolver(const BreakpointSP &bkpt,
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
-        eLazyBoolNo);
+        false, eLazyBoolNo);
   // FIXME: don't do catch yet.
   return resolver_sp;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1163,7 +1163,7 @@ AppleObjCRuntimeV2::CreateExceptionResolver(const BreakpointSP &bkpt,
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
-        false, eLazyBoolNo);
+        /*offset_is_insn_count = */false, eLazyBoolNo);
   // FIXME: We don't do catch breakpoints for ObjC yet.
   // Should there be some way for the runtime to specify what it can do in this
   // regard?

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1163,7 +1163,7 @@ AppleObjCRuntimeV2::CreateExceptionResolver(const BreakpointSP &bkpt,
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
-        eLazyBoolNo);
+        false, eLazyBoolNo);
   // FIXME: We don't do catch breakpoints for ObjC yet.
   // Should there be some way for the runtime to specify what it can do in this
   // regard?

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1163,7 +1163,7 @@ AppleObjCRuntimeV2::CreateExceptionResolver(const BreakpointSP &bkpt,
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, std::get<1>(GetExceptionThrowLocation()).AsCString(),
         eFunctionNameTypeBase, eLanguageTypeUnknown, Breakpoint::Exact, 0,
-        /*offset_is_insn_count = */false, eLazyBoolNo);
+        /*offset_is_insn_count = */ false, eLazyBoolNo);
   // FIXME: We don't do catch breakpoints for ObjC yet.
   // Should there be some way for the runtime to specify what it can do in this
   // regard?

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
@@ -169,7 +169,7 @@ GNUstepObjCRuntime::CreateExceptionResolver(const BreakpointSP &bkpt,
   if (throw_bp)
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, "objc_exception_throw", eFunctionNameTypeBase,
-        eLanguageTypeUnknown, Breakpoint::Exact, 0, eLazyBoolNo);
+        eLanguageTypeUnknown, Breakpoint::Exact, 0, false, eLazyBoolNo);
 
   return resolver_sp;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
@@ -169,7 +169,8 @@ GNUstepObjCRuntime::CreateExceptionResolver(const BreakpointSP &bkpt,
   if (throw_bp)
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, "objc_exception_throw", eFunctionNameTypeBase,
-        eLanguageTypeUnknown, Breakpoint::Exact, 0, /*offset_is_insn_count = */false, eLazyBoolNo);
+        eLanguageTypeUnknown, Breakpoint::Exact, 0,
+        /*offset_is_insn_count = */ false, eLazyBoolNo);
 
   return resolver_sp;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
@@ -169,7 +169,7 @@ GNUstepObjCRuntime::CreateExceptionResolver(const BreakpointSP &bkpt,
   if (throw_bp)
     resolver_sp = std::make_shared<BreakpointResolverName>(
         bkpt, "objc_exception_throw", eFunctionNameTypeBase,
-        eLanguageTypeUnknown, Breakpoint::Exact, 0, false, eLazyBoolNo);
+        eLanguageTypeUnknown, Breakpoint::Exact, 0, /*offset_is_insn_count = */false, eLazyBoolNo);
 
   return resolver_sp;
 }

--- a/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
+++ b/lldb/source/Plugins/StructuredData/DarwinLog/StructuredDataDarwinLog.cpp
@@ -1601,6 +1601,7 @@ void StructuredDataDarwinLog::AddInitCompletionHook(Process &process) {
 
   const char *func_name = "_libtrace_init";
   const lldb::addr_t offset = 0;
+  const bool offset_is_insn_count = false;
   const LazyBool skip_prologue = eLazyBoolCalculate;
   // This is an internal breakpoint - the user shouldn't see it.
   const bool internal = true;
@@ -1608,7 +1609,8 @@ void StructuredDataDarwinLog::AddInitCompletionHook(Process &process) {
 
   auto breakpoint_sp = target.CreateBreakpoint(
       &module_spec_list, source_spec_list, func_name, eFunctionNameTypeFull,
-      eLanguageTypeC, offset, skip_prologue, internal, hardware);
+      eLanguageTypeC, offset, offset_is_insn_count, skip_prologue, internal,
+      hardware);
   if (!breakpoint_sp) {
     // Huh?  Bail here.
     LLDB_LOGF(log,

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -566,12 +566,10 @@ BreakpointSP Target::CreateBreakpoint(const Address &addr, bool internal,
   return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, false);
 }
 
-lldb::BreakpointSP
-Target::CreateAddressInModuleBreakpoint(lldb::addr_t file_addr, bool internal,
-                                        const FileSpec &file_spec,
-                                        bool request_hardware,
-                                        lldb::addr_t offset,
-                                        lldb::addr_t instructions_offset) {
+lldb::BreakpointSP Target::CreateAddressInModuleBreakpoint(
+    lldb::addr_t file_addr, bool internal, const FileSpec &file_spec,
+    bool request_hardware, lldb::addr_t offset,
+    lldb::addr_t instructions_offset) {
   SearchFilterSP filter_sp(
       new SearchFilterForUnconstrainedSearches(shared_from_this()));
   BreakpointResolverSP resolver_sp(new BreakpointResolverAddress(
@@ -2999,8 +2997,9 @@ lldb::addr_t Target::GetBreakableLoadAddress(lldb::addr_t addr) {
   return arch_plugin ? arch_plugin->GetBreakableLoadAddress(addr, *this) : addr;
 }
 
-lldb::DisassemblerSP Target::ReadInstructions(const Address &start_addr, uint32_t count,
-                                             const char *flavor_string) {
+lldb::DisassemblerSP Target::ReadInstructions(const Address &start_addr,
+                                              uint32_t count,
+                                              const char *flavor_string) {
   if (!m_process_sp)
     return lldb::DisassemblerSP();
 
@@ -3008,24 +3007,24 @@ lldb::DisassemblerSP Target::ReadInstructions(const Address &start_addr, uint32_
   bool force_live_memory = true;
   lldb_private::Status error;
   lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;
-  const size_t bytes_read = ReadMemory(start_addr, data.GetBytes(), data.GetByteSize(),
-                            error, force_live_memory, &load_addr);
+  const size_t bytes_read =
+      ReadMemory(start_addr, data.GetBytes(), data.GetByteSize(), error,
+                 force_live_memory, &load_addr);
 
   const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;
   if (!flavor_string || flavor_string[0] == '\0') {
     // FIXME - we don't have the mechanism in place to do per-architecture
     // settings.  But since we know that for now we only support flavors on
     // x86 & x86_64,
-    const llvm::Triple::ArchType arch =
-      GetArchitecture().GetTriple().getArch();
+    const llvm::Triple::ArchType arch = GetArchitecture().GetTriple().getArch();
     if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64)
       flavor_string = GetDisassemblyFlavor();
   }
 
   return Disassembler::DisassembleBytes(
-    GetArchitecture(), nullptr, flavor_string,
-    GetDisassemblyCPU(), GetDisassemblyFeatures(),
-    start_addr, data.GetBytes(), bytes_read, count, data_from_file);
+      GetArchitecture(), nullptr, flavor_string, GetDisassemblyCPU(),
+      GetDisassemblyFeatures(), start_addr, data.GetBytes(), bytes_read, count,
+      data_from_file);
 }
 
 SourceManager &Target::GetSourceManager() {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -66,6 +66,7 @@
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
+#include "lldb/lldb-forward.h"
 
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"
@@ -568,11 +569,13 @@ BreakpointSP Target::CreateBreakpoint(const Address &addr, bool internal,
 lldb::BreakpointSP
 Target::CreateAddressInModuleBreakpoint(lldb::addr_t file_addr, bool internal,
                                         const FileSpec &file_spec,
-                                        bool request_hardware) {
+                                        bool request_hardware,
+                                        lldb::addr_t offset,
+                                        lldb::addr_t instructions_offset) {
   SearchFilterSP filter_sp(
       new SearchFilterForUnconstrainedSearches(shared_from_this()));
   BreakpointResolverSP resolver_sp(new BreakpointResolverAddress(
-      nullptr, file_addr, file_spec));
+      nullptr, file_addr, file_spec, offset, instructions_offset));
   return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
                           false);
 }
@@ -2994,6 +2997,35 @@ lldb::addr_t Target::GetOpcodeLoadAddress(lldb::addr_t load_addr,
 lldb::addr_t Target::GetBreakableLoadAddress(lldb::addr_t addr) {
   auto arch_plugin = GetArchitecturePlugin();
   return arch_plugin ? arch_plugin->GetBreakableLoadAddress(addr, *this) : addr;
+}
+
+lldb::DisassemblerSP Target::ReadInstructions(const Address &start_addr, uint32_t count,
+                                             const char *flavor_string) {
+  if (!m_process_sp)
+    return lldb::DisassemblerSP();
+
+  DataBufferHeap data(GetArchitecture().GetMaximumOpcodeByteSize() * count, 0);
+  bool force_live_memory = true;
+  lldb_private::Status error;
+  lldb::addr_t load_addr = LLDB_INVALID_ADDRESS;
+  const size_t bytes_read = ReadMemory(start_addr, data.GetBytes(), data.GetByteSize(),
+                            error, force_live_memory, &load_addr);
+
+  const bool data_from_file = load_addr == LLDB_INVALID_ADDRESS;
+  if (!flavor_string || flavor_string[0] == '\0') {
+    // FIXME - we don't have the mechanism in place to do per-architecture
+    // settings.  But since we know that for now we only support flavors on
+    // x86 & x86_64,
+    const llvm::Triple::ArchType arch =
+      GetArchitecture().GetTriple().getArch();
+    if (arch == llvm::Triple::x86 || arch == llvm::Triple::x86_64)
+      flavor_string = GetDisassemblyFlavor();
+  }
+
+  return Disassembler::DisassembleBytes(
+    GetArchitecture(), nullptr, flavor_string,
+    GetDisassemblyCPU(), GetDisassemblyFeatures(),
+    start_addr, data.GetBytes(), bytes_read, count, data_from_file);
 }
 
 SourceManager &Target::GetSourceManager() {

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3000,9 +3000,6 @@ lldb::addr_t Target::GetBreakableLoadAddress(lldb::addr_t addr) {
 lldb::DisassemblerSP Target::ReadInstructions(const Address &start_addr,
                                               uint32_t count,
                                               const char *flavor_string) {
-  if (!m_process_sp)
-    return lldb::DisassemblerSP();
-
   DataBufferHeap data(GetArchitecture().GetMaximumOpcodeByteSize() * count, 0);
   bool force_live_memory = true;
   lldb_private::Status error;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -566,14 +566,14 @@ BreakpointSP Target::CreateBreakpoint(const Address &addr, bool internal,
   return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, false);
 }
 
-lldb::BreakpointSP Target::CreateAddressInModuleBreakpoint(
-    lldb::addr_t file_addr, bool internal, const FileSpec &file_spec,
-    bool request_hardware, lldb::addr_t offset,
-    lldb::addr_t instructions_offset) {
+lldb::BreakpointSP
+Target::CreateAddressInModuleBreakpoint(lldb::addr_t file_addr, bool internal,
+                                        const FileSpec &file_spec,
+                                        bool request_hardware) {
   SearchFilterSP filter_sp(
       new SearchFilterForUnconstrainedSearches(shared_from_this()));
-  BreakpointResolverSP resolver_sp(new BreakpointResolverAddress(
-      nullptr, file_addr, file_spec, offset, instructions_offset));
+  BreakpointResolverSP resolver_sp(
+      new BreakpointResolverAddress(nullptr, file_addr, file_spec));
   return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
                           false);
 }
@@ -582,7 +582,8 @@ BreakpointSP Target::CreateBreakpoint(
     const FileSpecList *containingModules,
     const FileSpecList *containingSourceFiles, const char *func_name,
     FunctionNameType func_name_type_mask, LanguageType language,
-    lldb::addr_t offset, LazyBool skip_prologue, bool internal, bool hardware) {
+    lldb::addr_t offset, bool offset_is_insn_count, LazyBool skip_prologue,
+    bool internal, bool hardware) {
   BreakpointSP bp_sp;
   if (func_name) {
     SearchFilterSP filter_sp(GetSearchFilterForModuleAndCUList(
@@ -595,7 +596,7 @@ BreakpointSP Target::CreateBreakpoint(
 
     BreakpointResolverSP resolver_sp(new BreakpointResolverName(
         nullptr, func_name, func_name_type_mask, language, Breakpoint::Exact,
-        offset, skip_prologue));
+        offset, offset_is_insn_count, skip_prologue));
     bp_sp = CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, true);
   }
   return bp_sp;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -558,10 +558,8 @@ BreakpointSP Target::CreateBreakpoint(lldb::addr_t addr, bool internal,
 
 BreakpointSP Target::CreateBreakpoint(const Address &addr, bool internal,
                                       bool hardware) {
-  SearchFilterSP filter_sp(
-      new SearchFilterForUnconstrainedSearches(shared_from_this()));
-  BreakpointResolverSP resolver_sp(
-      new BreakpointResolverAddress(nullptr, addr));
+  SearchFilterSP filter_sp = std::make_shared<SearchFilterForUnconstrainedSearches>(shared_from_this());
+  BreakpointResolverSP resolver_sp = std::make_shared<BreakpointResolverAddress>(nullptr, addr);
   return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, false);
 }
 
@@ -569,10 +567,8 @@ lldb::BreakpointSP
 Target::CreateAddressInModuleBreakpoint(lldb::addr_t file_addr, bool internal,
                                         const FileSpec &file_spec,
                                         bool request_hardware) {
-  SearchFilterSP filter_sp(
-      new SearchFilterForUnconstrainedSearches(shared_from_this()));
-  BreakpointResolverSP resolver_sp(
-      new BreakpointResolverAddress(nullptr, file_addr, file_spec));
+  SearchFilterSP filter_sp = std::make_shared<SearchFilterForUnconstrainedSearches>(shared_from_this());
+  BreakpointResolverSP resolver_sp = std::make_shared<BreakpointResolverAddress>(nullptr, file_addr, file_spec);
   return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
                           false);
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -558,8 +558,11 @@ BreakpointSP Target::CreateBreakpoint(lldb::addr_t addr, bool internal,
 
 BreakpointSP Target::CreateBreakpoint(const Address &addr, bool internal,
                                       bool hardware) {
-  SearchFilterSP filter_sp = std::make_shared<SearchFilterForUnconstrainedSearches>(shared_from_this());
-  BreakpointResolverSP resolver_sp = std::make_shared<BreakpointResolverAddress>(nullptr, addr);
+  SearchFilterSP filter_sp =
+      std::make_shared<SearchFilterForUnconstrainedSearches>(
+          shared_from_this());
+  BreakpointResolverSP resolver_sp =
+      std::make_shared<BreakpointResolverAddress>(nullptr, addr);
   return CreateBreakpoint(filter_sp, resolver_sp, internal, hardware, false);
 }
 
@@ -567,8 +570,12 @@ lldb::BreakpointSP
 Target::CreateAddressInModuleBreakpoint(lldb::addr_t file_addr, bool internal,
                                         const FileSpec &file_spec,
                                         bool request_hardware) {
-  SearchFilterSP filter_sp = std::make_shared<SearchFilterForUnconstrainedSearches>(shared_from_this());
-  BreakpointResolverSP resolver_sp = std::make_shared<BreakpointResolverAddress>(nullptr, file_addr, file_spec);
+  SearchFilterSP filter_sp =
+      std::make_shared<SearchFilterForUnconstrainedSearches>(
+          shared_from_this());
+  BreakpointResolverSP resolver_sp =
+      std::make_shared<BreakpointResolverAddress>(nullptr, file_addr,
+                                                  file_spec);
   return CreateBreakpoint(filter_sp, resolver_sp, internal, request_hardware,
                           false);
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -66,7 +66,6 @@
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/Timer.h"
-#include "lldb/lldb-forward.h"
 
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SetVector.h"

--- a/lldb/test/API/tools/lldb-dap/breakpoint-assembly/TestDAP_breakpointAssembly.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-assembly/TestDAP_breakpointAssembly.py
@@ -107,12 +107,16 @@ class TestDAP_setBreakpointsAssembly(lldbdap_testcase.DAPTestCaseBase):
             persistent_breakpoint_ids = self.set_source_breakpoints_assembly(
                 source_reference, [persistent_breakpoint_line]
             )
-            
+
             self.assertEqual(
-                len(persistent_breakpoint_ids), 1, "Expected one assembly breakpoint to be set"
+                len(persistent_breakpoint_ids),
+                1,
+                "Expected one assembly breakpoint to be set",
             )
 
-            persistent_breakpoint_source = self.dap_server.resolved_breakpoints[persistent_breakpoint_ids[0]].source()
+            persistent_breakpoint_source = self.dap_server.resolved_breakpoints[
+                persistent_breakpoint_ids[0]
+            ].source()
             self.assertIn(
                 "adapterData",
                 persistent_breakpoint_source,
@@ -135,9 +139,10 @@ class TestDAP_setBreakpointsAssembly(lldbdap_testcase.DAPTestCaseBase):
             self.dap_server.request_initialize()
             self.dap_server.request_launch(program)
             new_session_breakpoints_ids = self.set_source_breakpoints_from_source(
-                Source(raw_dict=persistent_breakpoint_source), [persistent_breakpoint_line]
+                Source(raw_dict=persistent_breakpoint_source),
+                [persistent_breakpoint_line],
             )
-            
+
             self.assertEqual(
                 len(new_session_breakpoints_ids),
                 1,
@@ -146,9 +151,11 @@ class TestDAP_setBreakpointsAssembly(lldbdap_testcase.DAPTestCaseBase):
 
             self.continue_to_breakpoints(new_session_breakpoints_ids)
             current_line = self.get_stackFrames()[0]["line"]
-            self.assertEqual(current_line, persistent_breakpoint_line,
-                            "Expected to hit the persistent assembly breakpoint at the same line")
+            self.assertEqual(
+                current_line,
+                persistent_breakpoint_line,
+                "Expected to hit the persistent assembly breakpoint at the same line",
+            )
         finally:
             self.dap_server.request_disconnect(terminateDebuggee=True)
             self.dap_server.terminate()
-

--- a/lldb/test/API/tools/lldb-dap/breakpoint-assembly/TestDAP_breakpointAssembly.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint-assembly/TestDAP_breakpointAssembly.py
@@ -83,3 +83,72 @@ class TestDAP_setBreakpointsAssembly(lldbdap_testcase.DAPTestCaseBase):
             break_point["message"],
             "Invalid sourceReference.",
         )
+
+    @skipIfWindows
+    def test_persistent_assembly_breakpoint(self):
+        """Tests that assembly breakpoints are working persistently across sessions"""
+        self.build()
+        program = self.getBuildArtifact("a.out")
+        self.create_debug_adapter()
+
+        # Run the first session and set a persistent assembly breakpoint
+        try:
+            self.dap_server.request_initialize()
+            self.dap_server.request_launch(program)
+
+            assmebly_func_breakpoints = self.set_function_breakpoints(["assembly_func"])
+            self.continue_to_breakpoints(assmebly_func_breakpoints)
+
+            assembly_func_frame = self.get_stackFrames()[0]
+            source_reference = assembly_func_frame["source"]["sourceReference"]
+
+            # Set an assembly breakpoint in the middle of the assembly function
+            persistent_breakpoint_line = 4
+            persistent_breakpoint_ids = self.set_source_breakpoints_assembly(
+                source_reference, [persistent_breakpoint_line]
+            )
+            
+            self.assertEqual(
+                len(persistent_breakpoint_ids), 1, "Expected one assembly breakpoint to be set"
+            )
+
+            persistent_breakpoint_source = self.dap_server.resolved_breakpoints[persistent_breakpoint_ids[0]].source()
+            self.assertIn(
+                "adapterData",
+                persistent_breakpoint_source,
+                "Expected assembly breakpoint to have persistent information",
+            )
+            self.assertIn(
+                "persistenceData",
+                persistent_breakpoint_source["adapterData"],
+                "Expected assembly breakpoint to have persistent information",
+            )
+
+            self.continue_to_breakpoints(persistent_breakpoint_ids)
+        finally:
+            self.dap_server.request_disconnect(terminateDebuggee=True)
+            self.dap_server.terminate()
+
+        # Restart the session and verify the breakpoint is still there
+        self.create_debug_adapter()
+        try:
+            self.dap_server.request_initialize()
+            self.dap_server.request_launch(program)
+            new_session_breakpoints_ids = self.set_source_breakpoints_from_source(
+                Source(raw_dict=persistent_breakpoint_source), [persistent_breakpoint_line]
+            )
+            
+            self.assertEqual(
+                len(new_session_breakpoints_ids),
+                1,
+                "Expected one breakpoint to be set in the new session",
+            )
+
+            self.continue_to_breakpoints(new_session_breakpoints_ids)
+            current_line = self.get_stackFrames()[0]["line"]
+            self.assertEqual(current_line, persistent_breakpoint_line,
+                            "Expected to hit the persistent assembly breakpoint at the same line")
+        finally:
+            self.dap_server.request_disconnect(terminateDebuggee=True)
+            self.dap_server.terminate()
+

--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -8,6 +8,7 @@
 
 #include "Breakpoint.h"
 #include "DAP.h"
+#include "LLDBUtils.h"
 #include "Protocol/DAPTypes.h"
 #include "ProtocolUtils.h"
 #include "lldb/API/SBAddress.h"
@@ -35,7 +36,7 @@ GetPersistenceDataForAddress(lldb::SBAddress &addr) {
   if (!file_spec.IsValid())
     return std::nullopt;
 
-  persistence_data.module = file_spec.GetFilename();
+  persistence_data.module = GetSBFileSpecPath(file_spec);
   persistence_data.file_addr = addr.GetFileAddress();
   return persistence_data;
 }

--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -106,8 +106,10 @@ protocol::Breakpoint Breakpoint::ToProtocolBreakpoint() {
         // in future sessions.
         std::optional<protocol::PersistenceData> persistence_data =
             GetPersistenceDataForAddress(start_address);
-        if (persistence_data)
-          source->adapterData->persistence_data = std::move(persistence_data);
+        if (persistence_data) {
+          source->adapterData =
+              protocol::SourceLLDBData{std::move(persistence_data)};
+        }
       }
     }
 

--- a/lldb/tools/lldb-dap/Breakpoint.cpp
+++ b/lldb/tools/lldb-dap/Breakpoint.cpp
@@ -37,7 +37,7 @@ GetPersistenceDataForAddress(lldb::SBAddress &addr) {
     return std::nullopt;
 
   persistence_data.module = GetSBFileSpecPath(file_spec);
-  persistence_data.file_addr = addr.GetFileAddress();
+  persistence_data.fileAddress = addr.GetFileAddress();
   return persistence_data;
 }
 

--- a/lldb/tools/lldb-dap/CMakeLists.txt
+++ b/lldb/tools/lldb-dap/CMakeLists.txt
@@ -66,7 +66,8 @@ add_lldb_library(lldbDAP
   Handler/ThreadsRequestHandler.cpp
   Handler/VariablesRequestHandler.cpp
   Handler/WriteMemoryRequestHandler.cpp
-  
+
+  Protocol/DAPTypes.cpp
   Protocol/ProtocolBase.cpp
   Protocol/ProtocolEvents.cpp
   Protocol/ProtocolTypes.cpp

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -31,7 +31,6 @@
 #include "lldb/API/SBStream.h"
 #include "lldb/Utility/IOObject.h"
 #include "lldb/Utility/Status.h"
-#include "lldb/Utility/TraceIntelPTGDBRemotePackets.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-types.h"

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1497,8 +1497,9 @@ std::vector<protocol::Breakpoint> DAP::SetSourceBreakpoints(
 
       protocol::Breakpoint response_breakpoint =
           iv->second.ToProtocolBreakpoint();
-      response_breakpoint.source = source;
 
+      if (!response_breakpoint.source)
+        response_breakpoint.source = source;
       if (!response_breakpoint.line &&
           src_bp.GetLine() != LLDB_INVALID_LINE_NUMBER)
         response_breakpoint.line = src_bp.GetLine();

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1408,12 +1408,11 @@ void DAP::EventThread() {
             // CreateBreakpoint doesn't apply source mapping and certain
             // implementation ignore the source part of this event anyway.
             protocol::Breakpoint protocol_bp = bp.ToProtocolBreakpoint();
-            llvm::json::Value protocol_bp_value = toJSON(protocol_bp);
 
             // "source" is not needed here, unless we add adapter data to be
             // saved by the client.
             if (protocol_bp.source && !protocol_bp.source->adapterData)
-              protocol_bp_value.getAsObject()->erase("source");
+              protocol_bp.source = std::nullopt;
 
             llvm::json::Object body;
             body.try_emplace("breakpoint", protocol_bp);

--- a/lldb/tools/lldb-dap/Handler/SetBreakpointsRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/SetBreakpointsRequestHandler.cpp
@@ -9,7 +9,6 @@
 #include "DAP.h"
 #include "Protocol/ProtocolRequests.h"
 #include "RequestHandler.h"
-#include <vector>
 
 namespace lldb_dap {
 

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
@@ -1,5 +1,4 @@
 #include "Protocol/DAPTypes.h"
-// #include "llvm/Support/JSON.h"
 
 using namespace llvm;
 

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
@@ -5,19 +5,17 @@ using namespace llvm;
 
 namespace lldb_dap::protocol {
 
-bool fromJSON(const llvm::json::Value &Params, AssemblyBreakpointData &ABD,
+bool fromJSON(const llvm::json::Value &Params, PersistenceData &PD,
               llvm::json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && O.mapOptional("module", ABD.module) &&
-         O.mapOptional("symbol_mangled_name", ABD.symbol_mangled_name) &&
-         O.mapOptional("offset", ABD.offset);
+  return O && O.mapOptional("module", PD.module) &&
+         O.mapOptional("symbol_mangled_name", PD.symbol_mangled_name);
 }
 
-llvm::json::Value toJSON(const AssemblyBreakpointData &ABD) {
+llvm::json::Value toJSON(const PersistenceData &PD) {
   json::Object result{
-      {"module", ABD.module},
-      {"symbol_mangled_name", ABD.symbol_mangled_name},
-      {"offset", ABD.offset},
+      {"module", PD.module},
+      {"symbol_mangled_name", PD.symbol_mangled_name},
   };
 
   return result;
@@ -26,13 +24,13 @@ llvm::json::Value toJSON(const AssemblyBreakpointData &ABD) {
 bool fromJSON(const llvm::json::Value &Params, SourceLLDBData &SLD,
               llvm::json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && O.mapOptional("assembly_breakpoint", SLD.assembly_breakpoint);
+  return O && O.mapOptional("persistence_data", SLD.persistence_data);
 }
 
 llvm::json::Value toJSON(const SourceLLDBData &SLD) {
   json::Object result;
-  if (SLD.assembly_breakpoint)
-    result.insert({"assembly_breakpoint", SLD.assembly_breakpoint});
+  if (SLD.persistence_data)
+    result.insert({"persistence_data", SLD.persistence_data});
   return result;
 }
 

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
@@ -1,0 +1,39 @@
+#include "Protocol/DAPTypes.h"
+// #include "llvm/Support/JSON.h"
+
+using namespace llvm;
+
+namespace lldb_dap::protocol {
+
+bool fromJSON(const llvm::json::Value &Params, AssemblyBreakpointData &ABD,
+              llvm::json::Path P) {
+  json::ObjectMapper O(Params, P);
+  return O && O.mapOptional("module", ABD.module) &&
+         O.mapOptional("symbol_mangled_name", ABD.symbol_mangled_name) &&
+         O.mapOptional("offset", ABD.offset);
+}
+
+llvm::json::Value toJSON(const AssemblyBreakpointData &ABD) {
+  json::Object result{
+      {"module", ABD.module},
+      {"symbol_mangled_name", ABD.symbol_mangled_name},
+      {"offset", ABD.offset},
+  };
+
+  return result;
+}
+
+bool fromJSON(const llvm::json::Value &Params, SourceLLDBData &SLD,
+              llvm::json::Path P) {
+  json::ObjectMapper O(Params, P);
+  return O && O.mapOptional("assembly_breakpoint", SLD.assembly_breakpoint);
+}
+
+llvm::json::Value toJSON(const SourceLLDBData &SLD) {
+  json::Object result;
+  if (SLD.assembly_breakpoint)
+    result.insert({"assembly_breakpoint", SLD.assembly_breakpoint});
+  return result;
+}
+
+} // namespace lldb_dap::protocol

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
@@ -8,14 +8,14 @@ namespace lldb_dap::protocol {
 bool fromJSON(const llvm::json::Value &Params, PersistenceData &PD,
               llvm::json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && O.mapOptional("module", PD.module) &&
-         O.mapOptional("fileAddress", PD.fileAddress);
+  return O && O.mapOptional("module_path", PD.module_path) &&
+         O.mapOptional("symbol_name", PD.symbol_name);
 }
 
 llvm::json::Value toJSON(const PersistenceData &PD) {
   json::Object result{
-      {"module", PD.module},
-      {"fileAddress", PD.fileAddress},
+      {"module_path", PD.module_path},
+      {"symbol_name", PD.symbol_name},
   };
 
   return result;

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
@@ -9,13 +9,13 @@ bool fromJSON(const llvm::json::Value &Params, PersistenceData &PD,
               llvm::json::Path P) {
   json::ObjectMapper O(Params, P);
   return O && O.mapOptional("module", PD.module) &&
-         O.mapOptional("file_addr", PD.file_addr);
+         O.mapOptional("fileAddress", PD.fileAddress);
 }
 
 llvm::json::Value toJSON(const PersistenceData &PD) {
   json::Object result{
       {"module", PD.module},
-      {"file_addr", PD.file_addr},
+      {"fileAddress", PD.fileAddress},
   };
 
   return result;
@@ -24,13 +24,13 @@ llvm::json::Value toJSON(const PersistenceData &PD) {
 bool fromJSON(const llvm::json::Value &Params, SourceLLDBData &SLD,
               llvm::json::Path P) {
   json::ObjectMapper O(Params, P);
-  return O && O.mapOptional("persistence_data", SLD.persistence_data);
+  return O && O.mapOptional("persistenceData", SLD.persistenceData);
 }
 
 llvm::json::Value toJSON(const SourceLLDBData &SLD) {
   json::Object result;
-  if (SLD.persistence_data)
-    result.insert({"persistence_data", SLD.persistence_data});
+  if (SLD.persistenceData)
+    result.insert({"persistenceData", SLD.persistenceData});
   return result;
 }
 

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.cpp
@@ -9,13 +9,13 @@ bool fromJSON(const llvm::json::Value &Params, PersistenceData &PD,
               llvm::json::Path P) {
   json::ObjectMapper O(Params, P);
   return O && O.mapOptional("module", PD.module) &&
-         O.mapOptional("symbol_mangled_name", PD.symbol_mangled_name);
+         O.mapOptional("file_addr", PD.file_addr);
 }
 
 llvm::json::Value toJSON(const PersistenceData &PD) {
   json::Object result{
       {"module", PD.module},
-      {"symbol_mangled_name", PD.symbol_mangled_name},
+      {"file_addr", PD.file_addr},
   };
 
   return result;

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -23,28 +23,27 @@
 
 namespace lldb_dap::protocol {
 
-/// Data used to help lldb-dap resolve assembly breakpoints across different
-/// sessions.
-struct AssemblyBreakpointData {
+/// Data used to help lldb-dap resolve breakpoints persistently across different sessions.
+/// This information is especially useful for assembly breakpoints, because `sourceReference`
+/// can change across sessions. For regular source breakpoints the path and line are the same
+/// For each session.
+struct PersistenceData {
   /// The source module path.
   std::string module;
 
   /// The symbol unique name.
   std::string symbol_mangled_name;
-
-  /// The breakpoint offset from the symbol resolved address.
-  lldb::addr_t offset;
 };
-bool fromJSON(const llvm::json::Value &, AssemblyBreakpointData &,
+bool fromJSON(const llvm::json::Value &, PersistenceData &,
               llvm::json::Path);
-llvm::json::Value toJSON(const AssemblyBreakpointData &);
+llvm::json::Value toJSON(const PersistenceData &);
 
 /// Custom source data used by lldb-dap.
 /// This data should help lldb-dap identify sources correctly across different
 /// sessions.
 struct SourceLLDBData {
-  /// Assembly breakpoint data.
-  std::optional<AssemblyBreakpointData> assembly_breakpoint;
+  /// Data that helps lldb resolve this source persistently across different sessions.
+  std::optional<PersistenceData> persistence_data;
 };
 bool fromJSON(const llvm::json::Value &, SourceLLDBData &, llvm::json::Path);
 llvm::json::Value toJSON(const SourceLLDBData &);

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -1,0 +1,54 @@
+//===-- ProtocolTypes.h ---------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains private DAP types used in the protocol.
+//
+// Each struct has a toJSON and fromJSON function, that converts between
+// the struct and a JSON representation. (See JSON.h)
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_DAP_TYPES_H
+#define LLDB_TOOLS_LLDB_DAP_PROTOCOL_DAP_TYPES_H
+
+#include "lldb/lldb-types.h"
+#include "llvm/Support/JSON.h"
+#include <optional>
+#include <string>
+
+namespace lldb_dap::protocol {
+
+/// Data used to help lldb-dap resolve assembly breakpoints across different
+/// sessions.
+struct AssemblyBreakpointData {
+  /// The source module path.
+  std::string module;
+
+  /// The symbol unique name.
+  std::string symbol_mangled_name;
+
+  /// The breakpoint offset from the symbol resolved address.
+  lldb::addr_t offset;
+};
+bool fromJSON(const llvm::json::Value &, AssemblyBreakpointData &,
+              llvm::json::Path);
+llvm::json::Value toJSON(const AssemblyBreakpointData &);
+
+/// Custom source data used by lldb-dap.
+/// This data should help lldb-dap identify sources correctly across different
+/// sessions.
+struct SourceLLDBData {
+  /// Assembly breakpoint data.
+  std::optional<AssemblyBreakpointData> assembly_breakpoint;
+};
+bool fromJSON(const llvm::json::Value &, SourceLLDBData &, llvm::json::Path);
+llvm::json::Value toJSON(const SourceLLDBData &);
+
+} // namespace lldb_dap::protocol
+
+#endif

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -32,7 +32,7 @@ struct PersistenceData {
   std::string module;
 
   /// The file address of the function.
-  lldb::addr_t file_addr;
+  lldb::addr_t fileAddress;
 };
 bool fromJSON(const llvm::json::Value &, PersistenceData &, llvm::json::Path);
 llvm::json::Value toJSON(const PersistenceData &);
@@ -43,7 +43,7 @@ llvm::json::Value toJSON(const PersistenceData &);
 struct SourceLLDBData {
   /// Data that helps lldb resolve this source persistently across different
   /// sessions.
-  std::optional<PersistenceData> persistence_data;
+  std::optional<PersistenceData> persistenceData;
 };
 bool fromJSON(const llvm::json::Value &, SourceLLDBData &, llvm::json::Path);
 llvm::json::Value toJSON(const SourceLLDBData &);

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -23,10 +23,10 @@
 
 namespace lldb_dap::protocol {
 
-/// Data used to help lldb-dap resolve breakpoints persistently across different sessions.
-/// This information is especially useful for assembly breakpoints, because `sourceReference`
-/// can change across sessions. For regular source breakpoints the path and line are the same
-/// For each session.
+/// Data used to help lldb-dap resolve breakpoints persistently across different
+/// sessions. This information is especially useful for assembly breakpoints,
+/// because `sourceReference` can change across sessions. For regular source
+/// breakpoints the path and line are the same For each session.
 struct PersistenceData {
   /// The source module path.
   std::string module;
@@ -34,15 +34,15 @@ struct PersistenceData {
   /// The file address of the function.
   lldb::addr_t file_addr;
 };
-bool fromJSON(const llvm::json::Value &, PersistenceData &,
-              llvm::json::Path);
+bool fromJSON(const llvm::json::Value &, PersistenceData &, llvm::json::Path);
 llvm::json::Value toJSON(const PersistenceData &);
 
 /// Custom source data used by lldb-dap.
 /// This data should help lldb-dap identify sources correctly across different
 /// sessions.
 struct SourceLLDBData {
-  /// Data that helps lldb resolve this source persistently across different sessions.
+  /// Data that helps lldb resolve this source persistently across different
+  /// sessions.
   std::optional<PersistenceData> persistence_data;
 };
 bool fromJSON(const llvm::json::Value &, SourceLLDBData &, llvm::json::Path);

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -31,7 +31,7 @@ struct PersistenceData {
   /// The source module path.
   std::string module;
 
-  /// The file address inside the module.
+  /// The file address of the function.
   lldb::addr_t file_addr;
 };
 bool fromJSON(const llvm::json::Value &, PersistenceData &,

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -31,8 +31,8 @@ struct PersistenceData {
   /// The source module path.
   std::string module;
 
-  /// The symbol unique name.
-  std::string symbol_mangled_name;
+  /// The file address inside the module.
+  lldb::addr_t file_addr;
 };
 bool fromJSON(const llvm::json::Value &, PersistenceData &,
               llvm::json::Path);

--- a/lldb/tools/lldb-dap/Protocol/DAPTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/DAPTypes.h
@@ -29,10 +29,10 @@ namespace lldb_dap::protocol {
 /// breakpoints the path and line are the same For each session.
 struct PersistenceData {
   /// The source module path.
-  std::string module;
+  std::string module_path;
 
-  /// The file address of the function.
-  lldb::addr_t fileAddress;
+  /// The symbol name of the Source.
+  std::string symbol_name;
 };
 bool fromJSON(const llvm::json::Value &, PersistenceData &, llvm::json::Path);
 llvm::json::Value toJSON(const PersistenceData &);

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.cpp
@@ -46,7 +46,8 @@ bool fromJSON(const json::Value &Params, Source &S, json::Path P) {
   json::ObjectMapper O(Params, P);
   return O && O.map("name", S.name) && O.map("path", S.path) &&
          O.map("presentationHint", S.presentationHint) &&
-         O.map("sourceReference", S.sourceReference);
+         O.map("sourceReference", S.sourceReference) &&
+         O.map("adapterData", S.adapterData);
 }
 
 llvm::json::Value toJSON(Source::PresentationHint hint) {
@@ -71,6 +72,8 @@ llvm::json::Value toJSON(const Source &S) {
     result.insert({"sourceReference", *S.sourceReference});
   if (S.presentationHint)
     result.insert({"presentationHint", *S.presentationHint});
+  if (S.adapterData)
+    result.insert({"adapterData", *S.adapterData});
 
   return result;
 }

--- a/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
+++ b/lldb/tools/lldb-dap/Protocol/ProtocolTypes.h
@@ -20,6 +20,7 @@
 #ifndef LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_TYPES_H
 #define LLDB_TOOLS_LLDB_DAP_PROTOCOL_PROTOCOL_TYPES_H
 
+#include "Protocol/DAPTypes.h"
 #include "lldb/lldb-defines.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/JSON.h"
@@ -336,7 +337,12 @@ struct Source {
   /// skipped on stepping.
   std::optional<PresentationHint> presentationHint;
 
-  // unsupported keys: origin, sources, adapterData, checksums
+  /// Additional data that a debug adapter might want to loop through the
+  /// client. The client should leave the data intact and persist it across
+  /// sessions. The client should not interpret the data.
+  std::optional<SourceLLDBData> adapterData;
+
+  // unsupported keys: origin, sources, checksums
 };
 bool fromJSON(const llvm::json::Value &, Source::PresentationHint &,
               llvm::json::Path);

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -12,6 +12,7 @@
 #include "JSONUtils.h"
 #include "ProtocolUtils.h"
 #include "lldb/API/SBBreakpoint.h"
+#include "lldb/API/SBFileSpec.h"
 #include "lldb/API/SBFileSpecList.h"
 #include "lldb/API/SBFrame.h"
 #include "lldb/API/SBInstruction.h"
@@ -115,6 +116,8 @@ llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(int64_
 }
 
 llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(const protocol::PersistenceData &persistence_data) {
+  lldb::SBFileSpec file_spec(persistence_data.module.c_str());
+  m_bp = m_dap.target.BreakpointCreateByFileAddress(file_spec, persistence_data.file_addr);
   return llvm::Error::success();
 }
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -121,9 +121,14 @@ llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(
 
 llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(
     const protocol::PersistenceData &persistence_data) {
-  lldb::SBFileSpec file_spec(persistence_data.module.c_str());
-  m_bp = m_dap.target.BreakpointCreateByFileAddress(
-      file_spec, persistence_data.fileAddress, 0, m_line - 1);
+  lldb::SBFileSpec file_spec(persistence_data.module_path.c_str());
+  lldb::SBFileSpecList comp_unit_list;
+  lldb::SBFileSpecList file_spec_list;
+  file_spec_list.Append(file_spec);
+  m_bp = m_dap.target.BreakpointCreateByName(
+      persistence_data.symbol_name.c_str(), lldb::eFunctionNameTypeFull,
+      lldb::eLanguageTypeUnknown, m_line - 1, true, file_spec_list,
+      comp_unit_list);
   return llvm::Error::success();
 }
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -10,6 +10,7 @@
 #include "BreakpointBase.h"
 #include "DAP.h"
 #include "JSONUtils.h"
+#include "ProtocolUtils.h"
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/API/SBFileSpecList.h"
 #include "lldb/API/SBFrame.h"
@@ -44,7 +45,7 @@ llvm::Error SourceBreakpoint::SetBreakpoint(const protocol::Source &source) {
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "Invalid line number.");
 
-  if (source.sourceReference) {
+  if (IsAssemblySource(source)) {
     // Breakpoint set by assembly source.
     std::optional<lldb::addr_t> raw_addr =
         m_dap.GetSourceReferenceAddress(*source.sourceReference);

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -46,7 +46,7 @@ llvm::Error SourceBreakpoint::SetBreakpoint(const protocol::Source &source) {
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "Invalid line number.");
 
-  if (IsAssemblySource(source)) {
+  if (source.sourceReference) {
     // Breakpoint set by assembly source.
     if (source.adapterData && source.adapterData->persistence_data) {
       // Prefer use the adapter persitence data, because this could be a

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -49,12 +49,15 @@ llvm::Error SourceBreakpoint::SetBreakpoint(const protocol::Source &source) {
   if (IsAssemblySource(source)) {
     // Breakpoint set by assembly source.
     if (source.adapterData && source.adapterData->persistence_data) {
-      // Prefer use the adapter persitence data, because this could be a breakpoint 
-      // from a previous session where the `sourceReference` is not valid anymore.
-      if (llvm::Error error = CreateAssemblyBreakpointWithPersistenceData(*source.adapterData->persistence_data))
+      // Prefer use the adapter persitence data, because this could be a
+      // breakpoint from a previous session where the `sourceReference` is not
+      // valid anymore.
+      if (llvm::Error error = CreateAssemblyBreakpointWithPersistenceData(
+              *source.adapterData->persistence_data))
         return error;
     } else {
-      if (llvm::Error error = CreateAssemblyBreakpointWithSourceReference(*source.sourceReference))
+      if (llvm::Error error = CreateAssemblyBreakpointWithSourceReference(
+              *source.sourceReference))
         return error;
     }
   } else {
@@ -77,36 +80,37 @@ void SourceBreakpoint::UpdateBreakpoint(const SourceBreakpoint &request_bp) {
 
 void SourceBreakpoint::CreatePathBreakpoint(const protocol::Source &source) {
   const auto source_path = source.path.value_or("");
-    lldb::SBFileSpecList module_list;
-    m_bp = m_dap.target.BreakpointCreateByLocation(source_path.c_str(), m_line,
-                                                   m_column, 0, module_list);
+  lldb::SBFileSpecList module_list;
+  m_bp = m_dap.target.BreakpointCreateByLocation(source_path.c_str(), m_line,
+                                                 m_column, 0, module_list);
 }
 
-llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(int64_t source_reference) {
+llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(
+    int64_t source_reference) {
   std::optional<lldb::addr_t> raw_addr =
       m_dap.GetSourceReferenceAddress(source_reference);
   if (!raw_addr)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                    "Invalid sourceReference.");
+                                   "Invalid sourceReference.");
 
   lldb::SBAddress source_address(*raw_addr, m_dap.target);
   if (!source_address.IsValid())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                    "Invalid sourceReference.");
+                                   "Invalid sourceReference.");
 
   lldb::SBSymbol symbol = source_address.GetSymbol();
   if (!symbol.IsValid()) {
     // FIXME: Support assembly breakpoints without a valid symbol.
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                    "Breakpoints in assembly without a valid "
-                                    "symbol are not supported yet.");
+                                   "Breakpoints in assembly without a valid "
+                                   "symbol are not supported yet.");
   }
 
   lldb::SBInstructionList inst_list =
       m_dap.target.ReadInstructions(symbol.GetStartAddress(), m_line);
   if (inst_list.GetSize() < m_line)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                    "Invalid instruction list size.");
+                                   "Invalid instruction list size.");
 
   lldb::SBAddress address =
       inst_list.GetInstructionAtIndex(m_line - 1).GetAddress();
@@ -115,7 +119,8 @@ llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(int64_
   return llvm::Error::success();
 }
 
-llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(const protocol::PersistenceData &persistence_data) {
+llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(
+    const protocol::PersistenceData &persistence_data) {
   lldb::SBFileSpec file_spec(persistence_data.module.c_str());
   m_bp = m_dap.target.BreakpointCreateByFileAddress(
       file_spec, persistence_data.file_addr, 0, m_line - 1);

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -48,12 +48,12 @@ llvm::Error SourceBreakpoint::SetBreakpoint(const protocol::Source &source) {
 
   if (source.sourceReference) {
     // Breakpoint set by assembly source.
-    if (source.adapterData && source.adapterData->persistence_data) {
+    if (source.adapterData && source.adapterData->persistenceData) {
       // Prefer use the adapter persitence data, because this could be a
       // breakpoint from a previous session where the `sourceReference` is not
       // valid anymore.
       if (llvm::Error error = CreateAssemblyBreakpointWithPersistenceData(
-              *source.adapterData->persistence_data))
+              *source.adapterData->persistenceData))
         return error;
     } else {
       if (llvm::Error error = CreateAssemblyBreakpointWithSourceReference(
@@ -123,7 +123,7 @@ llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(
     const protocol::PersistenceData &persistence_data) {
   lldb::SBFileSpec file_spec(persistence_data.module.c_str());
   m_bp = m_dap.target.BreakpointCreateByFileAddress(
-      file_spec, persistence_data.file_addr, 0, m_line - 1);
+      file_spec, persistence_data.fileAddress, 0, m_line - 1);
   return llvm::Error::success();
 }
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.cpp
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.cpp
@@ -117,7 +117,8 @@ llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithSourceReference(int64_
 
 llvm::Error SourceBreakpoint::CreateAssemblyBreakpointWithPersistenceData(const protocol::PersistenceData &persistence_data) {
   lldb::SBFileSpec file_spec(persistence_data.module.c_str());
-  m_bp = m_dap.target.BreakpointCreateByFileAddress(file_spec, persistence_data.file_addr);
+  m_bp = m_dap.target.BreakpointCreateByFileAddress(
+      file_spec, persistence_data.file_addr, 0, m_line - 1);
   return llvm::Error::success();
 }
 

--- a/lldb/tools/lldb-dap/SourceBreakpoint.h
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.h
@@ -11,6 +11,7 @@
 
 #include "Breakpoint.h"
 #include "DAPForward.h"
+#include "Protocol/DAPTypes.h"
 #include "Protocol/ProtocolTypes.h"
 #include "lldb/API/SBError.h"
 #include "llvm/ADT/StringRef.h"
@@ -50,8 +51,9 @@ public:
   uint32_t GetColumn() const { return m_column; }
 
 protected:
-  llvm::Error SetAssemblyBreakpoint(const protocol::Source &source);
-  llvm::Error SetPathBreakpoint(const protocol::Source &source);
+  void CreatePathBreakpoint(const protocol::Source &source);
+  llvm::Error CreateAssemblyBreakpointWithSourceReference(int64_t source_reference);
+  llvm::Error CreateAssemblyBreakpointWithPersistenceData(const protocol::PersistenceData &persistence_data);
 
   // logMessage part can be either a raw text or an expression.
   struct LogMessagePart {

--- a/lldb/tools/lldb-dap/SourceBreakpoint.h
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.h
@@ -50,6 +50,9 @@ public:
   uint32_t GetColumn() const { return m_column; }
 
 protected:
+  llvm::Error SetAssemblyBreakpoint(const protocol::Source &source);
+  llvm::Error SetPathBreakpoint(const protocol::Source &source);
+
   // logMessage part can be either a raw text or an expression.
   struct LogMessagePart {
     LogMessagePart(llvm::StringRef text, bool is_expr)

--- a/lldb/tools/lldb-dap/SourceBreakpoint.h
+++ b/lldb/tools/lldb-dap/SourceBreakpoint.h
@@ -52,8 +52,10 @@ public:
 
 protected:
   void CreatePathBreakpoint(const protocol::Source &source);
-  llvm::Error CreateAssemblyBreakpointWithSourceReference(int64_t source_reference);
-  llvm::Error CreateAssemblyBreakpointWithPersistenceData(const protocol::PersistenceData &persistence_data);
+  llvm::Error
+  CreateAssemblyBreakpointWithSourceReference(int64_t source_reference);
+  llvm::Error CreateAssemblyBreakpointWithPersistenceData(
+      const protocol::PersistenceData &persistence_data);
 
   // logMessage part can be either a raw text or an expression.
   struct LogMessagePart {


### PR DESCRIPTION
Resolves #141955

- Adds data to breakpoints `Source` object, in order for assembly breakpoints, which rely on a temporary `sourceReference` value, to be able to resolve in future sessions like normal path+line breakpoints
- Adds optional `instructions_offset` parameter to `BreakpointResolver`