### PR TITLE
[scudo] Fix c wrappers double free test.

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/wrappers_c_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/wrappers_c_test.cpp
@@ -175,7 +175,19 @@ TEST_F(ScudoWrappersCDeathTest, Malloc) {
 
   free(P);
   verifyDeallocHookPtr(P);
-  EXPECT_DEATH(free(P), "");
+
+  // Verify a double free causes an abort.
+  // Don't simply free(P) since EXPECT_DEATH will do a number of
+  // allocations before creating a new process. There is a possibility
+  // that the previously freed P is reused, therefore, in the new
+  // process doing free(P) is not a double free.
+  EXPECT_DEATH(
+      {
+        void *Ptr = malloc(Size);
+        free(Ptr);
+        free(Ptr);
+      },
+      "");
 
   P = malloc(0U);
   EXPECT_NE(P, nullptr);


### PR DESCRIPTION
The previous test simply tried to double free the pointer in the EXPECT_DEATH macro. Unfortunately, the gtest infrastructure can allocate a pointer that happens to be the previously freed pointer. Thus the free doesn't fail since the spawned process does not attempt to free all of the pointers allocated in the original test.

NOTE: Scudo should be checked to make sure that the TSD is not always returning pointers in the same order they are freed. Although this appears to be a problem with a program that only does a small number of allocations.