### PR TITLE
[mlir][vector] Fix issue in WarpOpDeadResult in vector distribution.

### DIFF
--- a/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorDistribute.cpp
@@ -856,9 +856,10 @@ struct WarpOpDeadResult : public WarpDistributionPattern {
     // Some values may be yielded multiple times and correspond to multiple
     // results. Deduplicating occurs by taking each result with its matching
     // yielded value, and:
-    //   1. recording the unique first position at which the value is yielded.
-    //   2. recording for the result, the first position at which the dedup'ed
-    //      value is yielded.
+    //   1. recording the unique first position at which the value is yielded in
+    //      new yielded operands.
+    //   2. recording for a used result, the first position at which the
+    //      dedup'ed value is yielded.
     //   3. skipping from the new result types / new yielded values any result
     //      that has no use or whose yielded value has already been seen.
     for (OpResult result : warpOp.getResults()) {

--- a/mlir/test/Dialect/Vector/vector-warp-distribute.mlir
+++ b/mlir/test/Dialect/Vector/vector-warp-distribute.mlir
@@ -1054,6 +1054,24 @@ func.func @dedup(%laneid: index, %v0: vector<4xf32>, %v1: vector<4xf32>)
 }
 
 // -----
+// CHECK-PROP:   func @dedup_used_and_unused_result
+func.func @dedup_used_and_unused_result(%laneid: index) -> (vector<1xf32>) {
+  // CHECK-PROP: %[[R:.*]]:2 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<2xf32>, vector<1xf32>)
+  %r:3 = gpu.warp_execute_on_lane_0(%laneid)[32] ->
+    (vector<1xf32>, vector<2xf32>, vector<1xf32>) {
+    // CHECK-PROP: %[[Y0:.*]] = "some_def"() : () -> vector<32xf32>
+    %2 = "some_def"() : () -> (vector<32xf32>)
+    // CHECK-PROP: %[[Y1:.*]] = "some_def"() : () -> vector<64xf32>
+    %3 = "some_def"() : () -> (vector<64xf32>)
+    // CHECK-PROP: gpu.yield %[[Y1]], %[[Y0]] : vector<64xf32>, vector<32xf32>
+    gpu.yield %2, %3, %2 : vector<32xf32>, vector<64xf32>, vector<32xf32>
+  }
+  // CHECK-PROP: "some_use"(%[[R]]#0, %[[R]]#1) : (vector<2xf32>, vector<1xf32>) -> vector<1xf32>
+  %r0 = "some_use"(%r#1, %r#2) : (vector<2xf32>, vector<1xf32>) -> (vector<1xf32>)
+  return %r0 : vector<1xf32>
+}
+
+// -----
 
 // CHECK-SCF-IF:   func @warp_execute_has_broadcast_semantics
 func.func @warp_execute_has_broadcast_semantics(%laneid: index, %s0: f32, %v0: vector<f32>, %v1: vector<1xf32>, %v2: vector<1x1xf32>)


### PR DESCRIPTION
Current version generates incorrect code when a result is yielded multiple times but only one if the matching result has uses.

Example:
```
func.func @warp_dead_result(%laneid: index) -> (vector<1xf32>) {
  %r:3 = gpu.warp_execute_on_lane_0(%laneid)[32] ->
    (vector<1xf32>, vector<2xf32>, vector<1xf32>) {
    %2 = "some_def"() : () -> (vector<32xf32>)
    %3 = "some_def"() : () -> (vector<64xf32>)
    gpu.yield %2, %3, %2 : vector<32xf32>, vector<64xf32>, vector<32xf32>
  }
  %r0 = "some_use"(%r#1, %r#2) : (vector<2xf32>, vector<1xf32>) -> (vector<1xf32>)
  return %r0 : vector<1xf32>
```
Current (incorrect):
```
  func.func @warp_dead_result(%arg0: index) -> vector<1xf32> {
    %0 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<2xf32>) {
      %2 = "some_def"() : () -> vector<32xf32>
      %3 = "some_def"() : () -> vector<64xf32>
      gpu.yield %3 : vector<64xf32>
    }
    %1 = "some_use"(%0, %0) : (vector<2xf32>, vector<2xf32>) -> vector<1xf32>
    return %1 : vector<1xf32>
  }
```
Correct code:
```
func.func @dedup_used_and_unused_result(%arg0: index) -> vector<1xf32> {
    %0:2 = gpu.warp_execute_on_lane_0(%arg0)[32] -> (vector<2xf32>, vector<1xf32>) {
      %2 = "some_def"() : () -> vector<32xf32>
      %3 = "some_def"() : () -> vector<64xf32>
      gpu.yield %3, %2 : vector<64xf32>, vector<32xf32>
    }
    %1 = "some_use"(%0#0, %0#1) : (vector<2xf32>, vector<1xf32>) -> vector<1xf32>
    return %1 : vector<1xf32>
}
``` 