### PR TITLE
[clang] Fix a crash when dynamic_cast-ing to a `final` class

### DIFF
--- a/clang/lib/CodeGen/CGCXXABI.h
+++ b/clang/lib/CodeGen/CGCXXABI.h
@@ -296,12 +296,11 @@ public:
 
   /// Emit a dynamic_cast from SrcRecordTy to DestRecordTy. The cast fails if
   /// the dynamic type of Value is not exactly DestRecordTy.
-  virtual llvm::Value *emitExactDynamicCast(CodeGenFunction &CGF, Address Value,
-                                            QualType SrcRecordTy,
-                                            QualType DestTy,
-                                            QualType DestRecordTy,
-                                            llvm::BasicBlock *CastSuccess,
-                                            llvm::BasicBlock *CastFail) = 0;
+  virtual std::optional<llvm::Value *>
+  emitExactDynamicCast(CodeGenFunction &CGF, Address Value,
+                       QualType SrcRecordTy, QualType DestTy,
+                       QualType DestRecordTy, llvm::BasicBlock *CastSuccess,
+                       llvm::BasicBlock *CastFail) = 0;
 
   virtual bool EmitBadCastCall(CodeGenFunction &CGF) = 0;
 

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -231,11 +231,11 @@ public:
                                    QualType DestRecordTy,
                                    llvm::BasicBlock *CastEnd) override;
 
-  llvm::Value *emitExactDynamicCast(CodeGenFunction &CGF, Address ThisAddr,
-                                    QualType SrcRecordTy, QualType DestTy,
-                                    QualType DestRecordTy,
-                                    llvm::BasicBlock *CastSuccess,
-                                    llvm::BasicBlock *CastFail) override;
+  std::optional<llvm::Value *>
+  emitExactDynamicCast(CodeGenFunction &CGF, Address ThisAddr,
+                       QualType SrcRecordTy, QualType DestTy,
+                       QualType DestRecordTy, llvm::BasicBlock *CastSuccess,
+                       llvm::BasicBlock *CastFail) override;
 
   llvm::Value *emitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
                                      QualType SrcRecordTy) override;
@@ -1681,7 +1681,7 @@ llvm::Value *ItaniumCXXABI::emitDynamicCastCall(
   return Value;
 }
 
-llvm::Value *ItaniumCXXABI::emitExactDynamicCast(
+std::optional<llvm::Value *> ItaniumCXXABI::emitExactDynamicCast(
     CodeGenFunction &CGF, Address ThisAddr, QualType SrcRecordTy,
     QualType DestTy, QualType DestRecordTy, llvm::BasicBlock *CastSuccess,
     llvm::BasicBlock *CastFail) {
@@ -1736,8 +1736,7 @@ llvm::Value *ItaniumCXXABI::emitExactDynamicCast(
 
   if (!Offset) {
     // If there are no public inheritance paths, the cast always fails.
-    CGF.EmitBranch(CastFail);
-    return llvm::PoisonValue::get(CGF.VoidPtrTy);
+    return std::nullopt;
   }
 
   // Compare the vptr against the expected vptr for the destination type at

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -158,11 +158,11 @@ public:
     // TODO: Add support for exact dynamic_casts.
     return false;
   }
-  llvm::Value *emitExactDynamicCast(CodeGenFunction &CGF, Address Value,
-                                    QualType SrcRecordTy, QualType DestTy,
-                                    QualType DestRecordTy,
-                                    llvm::BasicBlock *CastSuccess,
-                                    llvm::BasicBlock *CastFail) override {
+  std::optional<llvm::Value *>
+  emitExactDynamicCast(CodeGenFunction &CGF, Address Value,
+                       QualType SrcRecordTy, QualType DestTy,
+                       QualType DestRecordTy, llvm::BasicBlock *CastSuccess,
+                       llvm::BasicBlock *CastFail) override {
     llvm_unreachable("unsupported");
   }
 

--- a/clang/test/CodeGenCXX/dynamic-cast-exact-disabled.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast-exact-disabled.cpp
@@ -13,3 +13,19 @@ B *exact(A *a) {
   // EXACT-NOT: call {{.*}} @__dynamic_cast
   return dynamic_cast<B*>(a);
 }
+
+struct C {
+  virtual ~C();
+};
+
+struct D final : private C {
+
+};
+
+// CHECK-LABEL: @_Z5exactP1C
+D *exact(C *a) {
+  // INEXACT: call {{.*}} @__dynamic_cast
+  // EXACT: entry:
+  // EXACT-NEXT: ret ptr null
+  return dynamic_cast<D*>(a);
+}

--- a/clang/test/CodeGenCXX/dynamic-cast-exact.cpp
+++ b/clang/test/CodeGenCXX/dynamic-cast-exact.cpp
@@ -9,6 +9,7 @@ struct E : A { int e; };
 struct F : virtual A { int f; };
 struct G : virtual A { int g; };
 struct H final : C, D, E, F, G { int h; };
+struct H1 final: C, private D { int h1; };
 
 // CHECK-LABEL: @_Z7inexactP1A
 C *inexact(A *a) {
@@ -75,6 +76,23 @@ H *exact_multi(A *a) {
   // CHECK: [[LABEL_END]]:
   // CHECK: phi ptr [ %[[RESULT]], %[[LABEL_NOTNULL]] ], [ null, %[[LABEL_FAILED]] ]
   return dynamic_cast<H*>(a);
+}
+
+// CHECK-LABEL: @_Z19exact_invalid_multiP1D
+H1 *exact_invalid_multi(D* d) {
+  // CHECK: dynamic_cast.end:
+  // CHECK-NEXT: ret ptr null
+  return dynamic_cast<H1*>(d);
+}
+
+// CHECK-LABEL: @_Z19exact_invalid_multiR1D
+H1 &exact_invalid_multi(D& d) {
+  // CHECK: dynamic_cast.notnull:
+  // CHECK-NEXT: br label %dynamic_cast.null
+  // CHECK: dynamic_cast.null:
+  // CHECK-NEXT: call void @__cxa_bad_cast()
+  // CHECK-NEXT: unreachable
+  return dynamic_cast<H1&>(d);
 }
 
 namespace GH64088 {


### PR DESCRIPTION
The verification pass correctly identifies that the phi node produced for an exact dynamic_cast that always fails. Rather than trying to construct pretend that we have pass and fail paths through an invalid exact dynamic_cast we handle the failure path explicitly.

Fixes #137518