### PR TITLE
[mlir] [presburger] Add IntegerRelation::rangeProduct

### DIFF
--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -707,6 +707,21 @@ public:
   /// this for uniformity with `applyDomain`.
   void applyRange(const IntegerRelation &rel);
 
+  /// Let the relation `this` be R1, and the relation `rel` be R2. Requires
+  /// R1 and R2 to have the same domain.
+  ///
+  /// This operation computes the relation whose domain is the same as R1 and
+  /// whose range is the product of the ranges of R1 and R2, and whose
+  /// constraints are the conjunction of the constraints of R1 and R2 applied
+  /// to the relevant subspaces of the range.
+  ///
+  /// Example:
+  ///
+  /// R1: (i, j) -> k : f(i, j, k) = 0
+  /// R2: (i, j) -> l : g(i, j, l) = 0
+  /// R1.rangeProduct(R2): (i, j) -> (k, l) : f(i, j, k) = 0 and g(i, j, l) = 0
+  IntegerRelation rangeProduct(const IntegerRelation &rel);
+
   /// Given a relation `other: (A -> B)`, this operation merges the symbol and
   /// local variables and then takes the composition of `other` on `this: (B ->
   /// C)`. The resulting relation represents tuples of the form: `A -> C`.

--- a/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
+++ b/mlir/include/mlir/Analysis/Presburger/IntegerRelation.h
@@ -710,10 +710,8 @@ public:
   /// Let the relation `this` be R1, and the relation `rel` be R2. Requires
   /// R1 and R2 to have the same domain.
   ///
-  /// This operation computes the relation whose domain is the same as R1 and
-  /// whose range is the product of the ranges of R1 and R2, and whose
-  /// constraints are the conjunction of the constraints of R1 and R2 applied
-  /// to the relevant subspaces of the range.
+  /// Let R3 be the rangeProduct of R1 and R2. Then x R3 (y, z) iff
+  /// (x R1 y and x R2 z).
   ///
   /// Example:
   ///

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2481,6 +2481,41 @@ void IntegerRelation::applyDomain(const IntegerRelation &rel) {
 
 void IntegerRelation::applyRange(const IntegerRelation &rel) { compose(rel); }
 
+IntegerRelation IntegerRelation::rangeProduct(const IntegerRelation &rel) {
+  /// R1: (i, j) -> k : f(i, j, k) = 0
+  /// R2: (i, j) -> l : g(i, j, l) = 0
+  /// R1.rangeProduct(R2): (i, j) -> (k, l) : f(i, j, k) = 0 and g(i, j, l) = 0
+  assert(getNumDomainVars() == rel.getNumDomainVars() &&
+         "Range product is only defined for relations with equal domains");
+
+  // explicit copy of the context relation
+  IntegerRelation result = *this;
+  unsigned srcOffset = getVarKindOffset(VarKind::Range);
+  unsigned newNumRangeVars = rel.getNumRangeVars();
+
+  result.appendVar(VarKind::Range, newNumRangeVars);
+
+  for (unsigned i = 0; i < rel.getNumEqualities(); ++i) {
+    // Add a new equality that uses the new range variables.
+    // The old equality is a list of coefficients of the variables
+    // from `rel`, and so the range variables need to be shifted
+    // right by the number of range variables added to `result`.
+    SmallVector<DynamicAPInt> copy =
+        SmallVector<DynamicAPInt>(rel.getEquality(i));
+    copy.insert(copy.begin() + srcOffset, newNumRangeVars, DynamicAPInt(0));
+    result.addEquality(copy);
+  }
+
+  for (unsigned i = 0; i < rel.getNumInequalities(); ++i) {
+    SmallVector<DynamicAPInt> copy =
+        SmallVector<DynamicAPInt>(rel.getInequality(i));
+    copy.insert(copy.begin() + srcOffset, newNumRangeVars, DynamicAPInt(0));
+    result.addInequality(copy);
+  }
+
+  return result;
+}
+
 void IntegerRelation::printSpace(raw_ostream &os) const {
   space.print(os);
   os << getNumConstraints() << " constraints\n";

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2490,12 +2490,6 @@ IntegerRelation IntegerRelation::rangeProduct(const IntegerRelation &rel) {
 
   // explicit copy of `this`
   IntegerRelation result = *this;
-
-  // An explicit copy of `rel` is needed to merge and align symbols, since that
-  // function mutates both relations.
-  IntegerRelation relCopy = rel;
-  result.mergeAndAlignSymbols(relCopy);
-
   unsigned relRangeVarStart = rel.getVarKindOffset(VarKind::Range);
   unsigned numThisRangeVars = getNumRangeVars();
   unsigned numNewSymbolVars = result.getNumSymbolVars() - getNumSymbolVars();

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2488,12 +2488,12 @@ IntegerRelation IntegerRelation::rangeProduct(const IntegerRelation &rel) {
   assert(getNumDomainVars() == rel.getNumDomainVars() &&
          "Range product is only defined for relations with equal domains");
 
-  // explicit copy of the context relation
+  // explicit copy of `this`
   IntegerRelation result = *this;
   unsigned srcOffset = getVarKindOffset(VarKind::Range);
-  unsigned newNumRangeVars = rel.getNumRangeVars();
+  unsigned numRelRangeVars = rel.getNumRangeVars();
 
-  result.appendVar(VarKind::Range, newNumRangeVars);
+  result.appendVar(VarKind::Range, numRelRangeVars);
 
   for (unsigned i = 0; i < rel.getNumEqualities(); ++i) {
     // Add a new equality that uses the new range variables.
@@ -2502,14 +2502,14 @@ IntegerRelation IntegerRelation::rangeProduct(const IntegerRelation &rel) {
     // right by the number of range variables added to `result`.
     SmallVector<DynamicAPInt> copy =
         SmallVector<DynamicAPInt>(rel.getEquality(i));
-    copy.insert(copy.begin() + srcOffset, newNumRangeVars, DynamicAPInt(0));
+    copy.insert(copy.begin() + srcOffset, numRelRangeVars, DynamicAPInt(0));
     result.addEquality(copy);
   }
 
   for (unsigned i = 0; i < rel.getNumInequalities(); ++i) {
     SmallVector<DynamicAPInt> copy =
         SmallVector<DynamicAPInt>(rel.getInequality(i));
-    copy.insert(copy.begin() + srcOffset, newNumRangeVars, DynamicAPInt(0));
+    copy.insert(copy.begin() + srcOffset, numRelRangeVars, DynamicAPInt(0));
     result.addInequality(copy);
   }
 

--- a/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
+++ b/mlir/lib/Analysis/Presburger/IntegerRelation.cpp
@@ -2490,26 +2490,29 @@ IntegerRelation IntegerRelation::rangeProduct(const IntegerRelation &rel) {
 
   // explicit copy of `this`
   IntegerRelation result = *this;
-  unsigned srcOffset = getVarKindOffset(VarKind::Range);
+  unsigned relRangeVarStart = rel.getVarKindOffset(VarKind::Range);
   unsigned numRelRangeVars = rel.getNumRangeVars();
+  unsigned numThisRangeVars = getNumRangeVars();
 
   result.appendVar(VarKind::Range, numRelRangeVars);
 
+  // Copy each equality from `rel` and update the copy to account for range
+  // variables from `this`. The `rel` equality is a list of coefficients of the
+  // variables from `rel`, and so the range variables need to be shifted right
+  // by the number of `this` range variables.
   for (unsigned i = 0; i < rel.getNumEqualities(); ++i) {
-    // Add a new equality that uses the new range variables.
-    // The old equality is a list of coefficients of the variables
-    // from `rel`, and so the range variables need to be shifted
-    // right by the number of range variables added to `result`.
     SmallVector<DynamicAPInt> copy =
         SmallVector<DynamicAPInt>(rel.getEquality(i));
-    copy.insert(copy.begin() + srcOffset, numRelRangeVars, DynamicAPInt(0));
+    copy.insert(copy.begin() + relRangeVarStart, numThisRangeVars,
+                DynamicAPInt(0));
     result.addEquality(copy);
   }
 
   for (unsigned i = 0; i < rel.getNumInequalities(); ++i) {
     SmallVector<DynamicAPInt> copy =
         SmallVector<DynamicAPInt>(rel.getInequality(i));
-    copy.insert(copy.begin() + srcOffset, numRelRangeVars, DynamicAPInt(0));
+    copy.insert(copy.begin() + relRangeVarStart, numThisRangeVars,
+                DynamicAPInt(0));
     result.addInequality(copy);
   }
 

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -653,3 +653,52 @@ TEST(IntegerRelationTest, rangeProductMultdimRangeSwapped) {
 
   EXPECT_TRUE(expected.isEqual(rangeProd));
 }
+
+TEST(IntegerRelationTest, rangeProductEmptyDomain) {
+  IntegerRelation r1 =
+      parseRelationFromSet("(i, j) : (4*i + 9*j == 0, i >= 0, j >= 0)", 0);
+  IntegerRelation r2 =
+      parseRelationFromSet("(k, l) : (2*k + 3*l == 0, k >= 0, l >= 0)", 0);
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected =
+      parseRelationFromSet("(i, j, k, l) : (2*k + 3*l == 0, 4*i + 9*j == "
+                           "0, i >= 0, j >= 0, k >= 0, l >= 0)",
+                           0);
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}
+
+TEST(IntegerRelationTest, rangeProductEmptyRange) {
+  IntegerRelation r1 =
+      parseRelationFromSet("(i, j) : (4*i + 9*j == 0, i >= 0, j >= 0)", 2);
+  IntegerRelation r2 =
+      parseRelationFromSet("(i, j) : (2*i + 3*j == 0, i >= 0, j >= 0)", 2);
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected =
+      parseRelationFromSet("(i, j) : (2*i + 3*j == 0, 4*i + 9*j == "
+                           "0, i >= 0, j >= 0)",
+                           2);
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}
+
+TEST(IntegerRelationTest, rangeProductEmptyDomainAndRange) {
+  IntegerRelation r1 = parseRelationFromSet("() : ()", 0);
+  IntegerRelation r2 = parseRelationFromSet("() : ()", 0);
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected = parseRelationFromSet("() : ()", 0);
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}
+
+TEST(IntegerRelationTest, rangeProductSymbols) {
+  IntegerRelation r1 = parseRelationFromSet(
+      "(i, j)[s] : (2*i + 3*j + s == 0, i >= 0, j >= 0)", 1);
+  IntegerRelation r2 = parseRelationFromSet(
+      "(i, l)[t] : (3*i + 4*l + t == 0, i >= 0, l >= 0)", 1);
+
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected = parseRelationFromSet(
+      "(i, j, k, l)[s, t] : (2*i + 3*j + s == 0, 3*i + 4*l + t == "
+      "0, i >= 0, j >= 0, l >= 0)",
+      1);
+
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -692,11 +692,11 @@ TEST(IntegerRelationTest, rangeProductSymbols) {
   IntegerRelation r1 = parseRelationFromSet(
       "(i, j)[s] : (2*i + 3*j + s == 0, i >= 0, j >= 0)", 1);
   IntegerRelation r2 = parseRelationFromSet(
-      "(i, l)[t] : (3*i + 4*l + t == 0, i >= 0, l >= 0)", 1);
+      "(i, l)[s] : (3*i + 4*l + s == 0, i >= 0, l >= 0)", 1);
 
   IntegerRelation rangeProd = r1.rangeProduct(r2);
   IntegerRelation expected = parseRelationFromSet(
-      "(i, j, k, l)[s, t] : (2*i + 3*j + s == 0, 3*i + 4*l + t == "
+      "(i, j, l)[s] : (2*i + 3*j + s == 0, 3*i + 4*l + s == "
       "0, i >= 0, j >= 0, l >= 0)",
       1);
 

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -625,8 +625,8 @@ TEST(IntegerRelationTest, rangeProduct) {
 }
 
 TEST(IntegerRelationTest, rangeProductMultdimRange) {
-  IntegerRelation r1 = parseRelationFromSet(
-      "(i, k) : (2*i + 3*k == 0, i >= 0, k >= 0)", 1);
+  IntegerRelation r1 =
+      parseRelationFromSet("(i, k) : (2*i + 3*k == 0, i >= 0, k >= 0)", 1);
   IntegerRelation r2 = parseRelationFromSet(
       "(i, l, m) : (4*i + 6*m + 9*l == 0, i >= 0, l >= 0, m >= 0)", 1);
 
@@ -642,8 +642,8 @@ TEST(IntegerRelationTest, rangeProductMultdimRange) {
 TEST(IntegerRelationTest, rangeProductMultdimRangeSwapped) {
   IntegerRelation r1 = parseRelationFromSet(
       "(i, l, m) : (4*i + 6*m + 9*l == 0, i >= 0, l >= 0, m >= 0)", 1);
-  IntegerRelation r2 = parseRelationFromSet(
-      "(i, k) : (2*i + 3*k == 0, i >= 0, k >= 0)", 1);
+  IntegerRelation r2 =
+      parseRelationFromSet("(i, k) : (2*i + 3*k == 0, i >= 0, k >= 0)", 1);
 
   IntegerRelation rangeProd = r1.rangeProduct(r2);
   IntegerRelation expected =

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -616,9 +616,10 @@ TEST(IntegerRelationTest, rangeProduct) {
       "(i, j, l) : (4*i + 6*j + 9*l == 0, i >= 0, j >= 0, l >= 0)", 2);
 
   IntegerRelation rangeProd = r1.rangeProduct(r2);
-  IntegerRelation expected = parseRelationFromSet(
-      "(i, j, k, l) : (2*i + 3*k == 0, 4*i + 6*j + 9*l == 0, i >= 0, j >= 0, k >= 0, l >= 0)", 2);
+  IntegerRelation expected =
+      parseRelationFromSet("(i, j, k, l) : (2*i + 3*k == 0, 4*i + 6*j + 9*l == "
+                           "0, i >= 0, j >= 0, k >= 0, l >= 0)",
+                           2);
 
   EXPECT_TRUE(expected.isEqual(rangeProd));
 }
-

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -623,3 +623,33 @@ TEST(IntegerRelationTest, rangeProduct) {
 
   EXPECT_TRUE(expected.isEqual(rangeProd));
 }
+
+TEST(IntegerRelationTest, rangeProductMultdimRange) {
+  IntegerRelation r1 = parseRelationFromSet(
+      "(i, k) : (2*i + 3*k == 0, i >= 0, k >= 0)", 1);
+  IntegerRelation r2 = parseRelationFromSet(
+      "(i, l, m) : (4*i + 6*m + 9*l == 0, i >= 0, l >= 0, m >= 0)", 1);
+
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected =
+      parseRelationFromSet("(i, k, l, m) : (2*i + 3*k == 0, 4*i + 6*m + 9*l == "
+                           "0, i >= 0, k >= 0, l >= 0, m >= 0)",
+                           1);
+
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}
+
+TEST(IntegerRelationTest, rangeProductMultdimRangeSwapped) {
+  IntegerRelation r1 = parseRelationFromSet(
+      "(i, l, m) : (4*i + 6*m + 9*l == 0, i >= 0, l >= 0, m >= 0)", 1);
+  IntegerRelation r2 = parseRelationFromSet(
+      "(i, k) : (2*i + 3*k == 0, i >= 0, k >= 0)", 1);
+
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected =
+      parseRelationFromSet("(i, l, m, k) : (2*i + 3*k == 0, 4*i + 6*m + 9*l == "
+                           "0, i >= 0, k >= 0, l >= 0, m >= 0)",
+                           1);
+
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}

--- a/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
+++ b/mlir/unittests/Analysis/Presburger/IntegerRelationTest.cpp
@@ -608,3 +608,17 @@ TEST(IntegerRelationTest, convertVarKindToLocal) {
   EXPECT_EQ(space.getId(VarKind::Symbol, 0), Identifier(&identifiers[3]));
   EXPECT_EQ(space.getId(VarKind::Symbol, 1), Identifier(&identifiers[4]));
 }
+
+TEST(IntegerRelationTest, rangeProduct) {
+  IntegerRelation r1 = parseRelationFromSet(
+      "(i, j, k) : (2*i + 3*k == 0, i >= 0, j >= 0, k >= 0)", 2);
+  IntegerRelation r2 = parseRelationFromSet(
+      "(i, j, l) : (4*i + 6*j + 9*l == 0, i >= 0, j >= 0, l >= 0)", 2);
+
+  IntegerRelation rangeProd = r1.rangeProduct(r2);
+  IntegerRelation expected = parseRelationFromSet(
+      "(i, j, k, l) : (2*i + 3*k == 0, 4*i + 6*j + 9*l == 0, i >= 0, j >= 0, k >= 0, l >= 0)", 2);
+
+  EXPECT_TRUE(expected.isEqual(rangeProd));
+}
+


### PR DESCRIPTION
This is intended to match `isl::map`'s `flat_range_product`.

I'd like to add some more tests, so hoping for a brief early review to make sure I'm going in the right direction.