### PR TITLE
[coro] Fix crash due to DILabel in `LineTableOnly` mode

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1484,12 +1484,9 @@ private:
     // If there is no DISubprogram for F, it implies the function is compiled
     // without debug info. So we also don't generate debug info for the
     // suspension points.
-    bool AddDebugLabels =
-        (DIS && DIS->getUnit() &&
-         (DIS->getUnit()->getEmissionKind() ==
-              DICompileUnit::DebugEmissionKind::FullDebug ||
-          DIS->getUnit()->getEmissionKind() ==
-              DICompileUnit::DebugEmissionKind::LineTablesOnly));
+    bool AddDebugLabels = DIS && DIS->getUnit() &&
+                          (DIS->getUnit()->getEmissionKind() ==
+                           DICompileUnit::DebugEmissionKind::FullDebug);
 
     // resume.entry:
     //  %index.addr = getelementptr inbounds %f.Frame, %f.Frame* %FramePtr, i32

--- a/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
@@ -1,14 +1,19 @@
 ; Tests that we add DILabels for the suspend points.
 ;
-; We check both the generated LLVM:
+; Check the generated LLVM:
 ; RUN: opt < %s -passes='cgscc(coro-split)' -S | FileCheck %s
 ;
-; And the debug info:
+; Check the generated DWARF debug info:
 ; REQUIRES: object-emission
 ; RUN: opt < %s -passes='cgscc(coro-split),coro-cleanup' \
 ; RUN:   | %llc_dwarf -O0 -filetype=obj -o - \
 ; RUN:   | llvm-dwarfdump - \
 ; RUN:   | FileCheck %s -check-prefix=DWARF
+;
+; Check that we don't emit any DILabel if in `LineTablesOnly` mode
+; RUN: sed -e 's/emissionKind: FullDebug/emissionKind: LineTablesOnly/' %s \
+; RUN:   | opt -passes='cgscc(coro-split)' -S \
+; RUN:   | FileCheck %s -check-prefix=LINE-TABLE
 
 source_filename = "coro.c"
 
@@ -82,6 +87,12 @@ coro_Suspend:                                     ; preds = %for.cond, %if.then,
 ; CHECK: ![[RESUME_1]] = !DILabel(scope: !{{[0-9]+}}, name: "__coro_resume_1", file: !{{[0-9]*}}, line: 14, column: 6, isArtificial: true, coroSuspendIdx: 1)
 ; CHECK: ![[DESTROY_0]] = !DILabel(scope: !{{[0-9]+}}, name: "__coro_resume_0", file: !{{[0-9]*}}, line: 12, column: 6, isArtificial: true, coroSuspendIdx: 0)
 ; CHECK: ![[DESTROY_1]] = !DILabel(scope: !{{[0-9]+}}, name: "__coro_resume_1", file: !{{[0-9]*}}, line: 14, column: 6, isArtificial: true, coroSuspendIdx: 1)
+
+; Check the we do not emit any DILabels in LineTableOnly mode.
+; The DWARF emitter cannot handle this and would run into an assertion
+; LINE-TABLE: !DICompileUnit{{.*}}LineTablesOnly
+; LINE-TABLE-NOT: DILabel
+
 
 ; DWARF:        {{.*}}DW_TAG_label
 ; DWARF-NEXT:    DW_AT_name ("__coro_resume_0")

--- a/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-dbg-labels.ll
@@ -88,8 +88,8 @@ coro_Suspend:                                     ; preds = %for.cond, %if.then,
 ; CHECK: ![[DESTROY_0]] = !DILabel(scope: !{{[0-9]+}}, name: "__coro_resume_0", file: !{{[0-9]*}}, line: 12, column: 6, isArtificial: true, coroSuspendIdx: 0)
 ; CHECK: ![[DESTROY_1]] = !DILabel(scope: !{{[0-9]+}}, name: "__coro_resume_1", file: !{{[0-9]*}}, line: 14, column: 6, isArtificial: true, coroSuspendIdx: 1)
 
-; Check the we do not emit any DILabels in LineTableOnly mode.
-; The DWARF emitter cannot handle this and would run into an assertion
+; Check the we do not emit any DILabels in LineTablesOnly mode.
+; The DWARF emitter cannot handle this and would run into an assertion.
 ; LINE-TABLE: !DICompileUnit{{.*}}LineTablesOnly
 ; LINE-TABLE-NOT: DILabel
 


### PR DESCRIPTION
Since the recent commit de3c8410d8, the `CoroSplit` pass adds `DILabel`s to help find the location of a suspension point from its suspension point id. Those labels are added in both `DebugEmissionKind::FullDebug` and `DebugEmissionKind::LineTableOnly` mode. The idea was that this information is necessary to reconstruct async stack traces and should hence also be available for LineTableOnly.

Unfortunately, it turns out that the DWARF backend does not expect to find any DILabel debug metadata if the emission kind is set to LineTableOnly. The Dwarf backend simply runs into an assertion in that case.

This commit fixes the issue by only adding `DILabel` for FullDebug.