### PR TITLE
properly align long double on i386 darwin

### DIFF
--- a/llvm/lib/Target/X86/X86CallingConv.td
+++ b/llvm/lib/Target/X86/X86CallingConv.td
@@ -832,6 +832,7 @@ def CC_X86_32_Common : CallingConv<[
   CCIfType<[f64], CCAssignToStack<8, 4>>,
 
   // Long doubles get slots whose size and alignment depends on the subtarget.
+  CCIfSubtarget<"isTargetDarwin()", CCIfType<[f80], CCAssignToStack<0, 4>>>,
   CCIfType<[f80], CCAssignToStack<0, 0>>,
 
   // Boolean vectors of AVX-512 are passed in SIMD registers.

--- a/llvm/test/CodeGen/X86/2007-09-27-LDIntrinsics.ll
+++ b/llvm/test/CodeGen/X86/2007-09-27-LDIntrinsics.ll
@@ -8,9 +8,8 @@ entry:
 	ret x86_fp80 %tmp2
         
 ; CHECK-LABEL: foo:
-; CHECK: fldt 16(%esp)
+; CHECK: fldt 4(%esp)
 ; CHECK-NEXT: fsqrt
-; CHECK-NEXT: addl $12, %esp
 ; CHECK-NEXT: ret
 }
 
@@ -21,11 +20,10 @@ entry:
 	%tmp2 = call x86_fp80 @llvm.powi.f80.i32( x86_fp80 %x, i32 3 )
 	ret x86_fp80 %tmp2
 ; CHECK-LABEL: bar:
-; CHECK: fldt 16(%esp)
+; CHECK: fldt 4(%esp)
 ; CHECK-NEXT: fld	%st(0)
 ; CHECK-NEXT: fmul	%st(1)
 ; CHECK-NEXT: fmulp
-; CHECK-NEXT: addl $12, %esp
 ; CHECK-NEXT: ret
 }
 

--- a/llvm/test/CodeGen/X86/inline-asm-fpstack.ll
+++ b/llvm/test/CodeGen/X86/inline-asm-fpstack.ll
@@ -29,12 +29,10 @@ define double @test2() nounwind {
 define void @test3(x86_fp80 %X) nounwind {
 ; CHECK-LABEL: test3:
 ; CHECK:       ## %bb.0:
-; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    ## InlineAsm Start
 ; CHECK-NEXT:    frob
 ; CHECK-NEXT:    ## InlineAsm End
-; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
   call void asm sideeffect "frob ", "{st(0)},~{st},~{dirflag},~{fpsr},~{flags}"( x86_fp80 %X)
   ret void
@@ -248,14 +246,12 @@ entry:
 define void @fist1(x86_fp80 %x, ptr %p) nounwind ssp {
 ; CHECK-LABEL: fist1:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; CHECK-NEXT:    ## InlineAsm Start
 ; CHECK-NEXT:    fistl (%eax)
 ; CHECK-NEXT:    ## InlineAsm End
 ; CHECK-NEXT:    fstp %st(0)
-; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
 entry:
   tail call void asm sideeffect "fistl $1", "{st},*m,~{memory},~{dirflag},~{fpsr},~{flags}"(x86_fp80 %x, ptr elementtype(i32) %p) nounwind
@@ -273,13 +269,11 @@ entry:
 define x86_fp80 @fist2(x86_fp80 %x, ptr %p) nounwind ssp {
 ; CHECK-LABEL: fist2:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; CHECK-NEXT:    ## InlineAsm Start
 ; CHECK-NEXT:    fistl (%eax)
 ; CHECK-NEXT:    ## InlineAsm End
-; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
 entry:
   %0 = tail call x86_fp80 asm "fistl $2", "=&{st},0,*m,~{memory},~{dirflag},~{fpsr},~{flags}"(x86_fp80 %x, ptr elementtype(i32) %p) nounwind
@@ -294,7 +288,6 @@ entry:
 define void @fucomp1(x86_fp80 %x, x86_fp80 %y) nounwind ssp {
 ; CHECK-LABEL: fucomp1:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    fxch %st(1)
@@ -302,7 +295,6 @@ define void @fucomp1(x86_fp80 %x, x86_fp80 %y) nounwind ssp {
 ; CHECK-NEXT:    fucomp %st(1)
 ; CHECK-NEXT:    ## InlineAsm End
 ; CHECK-NEXT:    fstp %st(0)
-; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
 entry:
   tail call void asm sideeffect "fucomp $1", "{st},f,~{st},~{dirflag},~{fpsr},~{flags}"(x86_fp80 %x, x86_fp80 %y) nounwind
@@ -322,7 +314,6 @@ entry:
 define void @fucomp2(x86_fp80 %x, x86_fp80 %y) nounwind ssp {
 ; CHECK-LABEL: fucomp2:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    fxch %st(1)
@@ -330,7 +321,6 @@ define void @fucomp2(x86_fp80 %x, x86_fp80 %y) nounwind ssp {
 ; CHECK-NEXT:    fucomp %st(1)
 ; CHECK-NEXT:    ## InlineAsm End
 ; CHECK-NEXT:    fstp %st(0)
-; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
 entry:
   tail call void asm sideeffect "fucomp $1", "{st},{st(1)},~{st},~{dirflag},~{fpsr},~{flags}"(x86_fp80 %x, x86_fp80 %y) nounwind
@@ -340,14 +330,12 @@ entry:
 define void @fucomp3(x86_fp80 %x, x86_fp80 %y) nounwind ssp {
 ; CHECK-LABEL: fucomp3:
 ; CHECK:       ## %bb.0: ## %entry
-; CHECK-NEXT:    subl $12, %esp
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    fldt {{[0-9]+}}(%esp)
 ; CHECK-NEXT:    fxch %st(1)
 ; CHECK-NEXT:    ## InlineAsm Start
 ; CHECK-NEXT:    fucompp %st(1)
 ; CHECK-NEXT:    ## InlineAsm End
-; CHECK-NEXT:    addl $12, %esp
 ; CHECK-NEXT:    retl
 entry:
   tail call void asm sideeffect "fucompp $1", "{st},{st(1)},~{st},~{st(1)},~{dirflag},~{fpsr},~{flags}"(x86_fp80 %x, x86_fp80 %y) nounwind

--- a/llvm/test/CodeGen/X86/isel-fcmp-x87.ll
+++ b/llvm/test/CodeGen/X86/isel-fcmp-x87.ll
@@ -33,7 +33,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_oeq:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -43,12 +42,10 @@
 ; X86-NEXT:    setnp %cl
 ; X86-NEXT:    sete %al
 ; X86-NEXT:    andb %cl, %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_oeq:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
@@ -57,7 +54,6 @@
 ; GISEL-X86-NEXT:    sete %cl
 ; GISEL-X86-NEXT:    setnp %al
 ; GISEL-X86-NEXT:    andb %cl, %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp oeq x86_fp80 %x, %y
     ret i1 %1
@@ -85,7 +81,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_ogt:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -93,19 +88,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    seta %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ogt:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    seta %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ogt x86_fp80 %x, %y
     ret i1 %1
@@ -133,7 +125,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_oge:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -141,19 +132,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    setae %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_oge:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setae %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp oge x86_fp80 %x, %y
     ret i1 %1
@@ -190,7 +178,6 @@
 ;
 ; SDAG-X86-LABEL: fcmp_x86_fp80_olt:
 ; SDAG-X86:       ## %bb.0:
-; SDAG-X86-NEXT:    subl $12, %esp
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fucompp
@@ -198,12 +185,10 @@
 ; SDAG-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; SDAG-X86-NEXT:    sahf
 ; SDAG-X86-NEXT:    seta %al
-; SDAG-X86-NEXT:    addl $12, %esp
 ; SDAG-X86-NEXT:    retl
 ;
 ; FAST-X86-LABEL: fcmp_x86_fp80_olt:
 ; FAST-X86:       ## %bb.0:
-; FAST-X86-NEXT:    subl $12, %esp
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fxch %st(1)
@@ -212,18 +197,15 @@
 ; FAST-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; FAST-X86-NEXT:    sahf
 ; FAST-X86-NEXT:    seta %al
-; FAST-X86-NEXT:    addl $12, %esp
 ; FAST-X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_olt:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    seta %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp olt x86_fp80 %x, %y
     ret i1 %1
@@ -260,7 +242,6 @@
 ;
 ; SDAG-X86-LABEL: fcmp_x86_fp80_ole:
 ; SDAG-X86:       ## %bb.0:
-; SDAG-X86-NEXT:    subl $12, %esp
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fucompp
@@ -268,12 +249,10 @@
 ; SDAG-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; SDAG-X86-NEXT:    sahf
 ; SDAG-X86-NEXT:    setae %al
-; SDAG-X86-NEXT:    addl $12, %esp
 ; SDAG-X86-NEXT:    retl
 ;
 ; FAST-X86-LABEL: fcmp_x86_fp80_ole:
 ; FAST-X86:       ## %bb.0:
-; FAST-X86-NEXT:    subl $12, %esp
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fxch %st(1)
@@ -282,18 +261,15 @@
 ; FAST-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; FAST-X86-NEXT:    sahf
 ; FAST-X86-NEXT:    setae %al
-; FAST-X86-NEXT:    addl $12, %esp
 ; FAST-X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ole:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setae %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ole x86_fp80 %x, %y
     ret i1 %1
@@ -321,7 +297,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_one:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -329,19 +304,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    setne %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_one:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setne %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp one x86_fp80 %x, %y
     ret i1 %1
@@ -369,7 +341,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_ord:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -377,19 +348,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    setnp %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ord:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setnp %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ord x86_fp80 %x, %y
     ret i1 %1
@@ -417,7 +385,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_uno:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -425,19 +392,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    setp %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_uno:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setp %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp uno x86_fp80 %x, %y
     ret i1 %1
@@ -465,7 +429,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_ueq:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -473,19 +436,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    sete %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ueq:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    sete %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ueq x86_fp80 %x, %y
     ret i1 %1
@@ -522,7 +482,6 @@
 ;
 ; SDAG-X86-LABEL: fcmp_x86_fp80_ugt:
 ; SDAG-X86:       ## %bb.0:
-; SDAG-X86-NEXT:    subl $12, %esp
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fucompp
@@ -530,12 +489,10 @@
 ; SDAG-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; SDAG-X86-NEXT:    sahf
 ; SDAG-X86-NEXT:    setb %al
-; SDAG-X86-NEXT:    addl $12, %esp
 ; SDAG-X86-NEXT:    retl
 ;
 ; FAST-X86-LABEL: fcmp_x86_fp80_ugt:
 ; FAST-X86:       ## %bb.0:
-; FAST-X86-NEXT:    subl $12, %esp
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fxch %st(1)
@@ -544,18 +501,15 @@
 ; FAST-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; FAST-X86-NEXT:    sahf
 ; FAST-X86-NEXT:    setb %al
-; FAST-X86-NEXT:    addl $12, %esp
 ; FAST-X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ugt:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setb %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ugt x86_fp80 %x, %y
     ret i1 %1
@@ -592,7 +546,6 @@
 ;
 ; SDAG-X86-LABEL: fcmp_x86_fp80_uge:
 ; SDAG-X86:       ## %bb.0:
-; SDAG-X86-NEXT:    subl $12, %esp
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; SDAG-X86-NEXT:    fucompp
@@ -600,12 +553,10 @@
 ; SDAG-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; SDAG-X86-NEXT:    sahf
 ; SDAG-X86-NEXT:    setbe %al
-; SDAG-X86-NEXT:    addl $12, %esp
 ; SDAG-X86-NEXT:    retl
 ;
 ; FAST-X86-LABEL: fcmp_x86_fp80_uge:
 ; FAST-X86:       ## %bb.0:
-; FAST-X86-NEXT:    subl $12, %esp
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; FAST-X86-NEXT:    fxch %st(1)
@@ -614,18 +565,15 @@
 ; FAST-X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; FAST-X86-NEXT:    sahf
 ; FAST-X86-NEXT:    setbe %al
-; FAST-X86-NEXT:    addl $12, %esp
 ; FAST-X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_uge:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setbe %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp uge x86_fp80 %x, %y
     ret i1 %1
@@ -653,7 +601,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_ult:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -661,19 +608,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    setb %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ult:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setb %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ult x86_fp80 %x, %y
     ret i1 %1
@@ -701,7 +645,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_ule:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -709,19 +652,16 @@
 ; X86-NEXT:    ## kill: def $ah killed $ah killed $ax
 ; X86-NEXT:    sahf
 ; X86-NEXT:    setbe %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_ule:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
 ; GISEL-X86-NEXT:    fucompi %st(1), %st
 ; GISEL-X86-NEXT:    fstp %st(0)
 ; GISEL-X86-NEXT:    setbe %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp ule x86_fp80 %x, %y
     ret i1 %1
@@ -753,7 +693,6 @@
 ;
 ; X86-LABEL: fcmp_x86_fp80_une:
 ; X86:       ## %bb.0:
-; X86-NEXT:    subl $12, %esp
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; X86-NEXT:    fucompp
@@ -763,12 +702,10 @@
 ; X86-NEXT:    setp %cl
 ; X86-NEXT:    setne %al
 ; X86-NEXT:    orb %cl, %al
-; X86-NEXT:    addl $12, %esp
 ; X86-NEXT:    retl
 ;
 ; GISEL-X86-LABEL: fcmp_x86_fp80_une:
 ; GISEL-X86:       ## %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
 ; GISEL-X86-NEXT:    fxch %st(1)
@@ -777,7 +714,6 @@
 ; GISEL-X86-NEXT:    setne %cl
 ; GISEL-X86-NEXT:    setp %al
 ; GISEL-X86-NEXT:    orb %cl, %al
-; GISEL-X86-NEXT:    addl $12, %esp
 ; GISEL-X86-NEXT:    retl
     %1 = fcmp une x86_fp80 %x, %y
     ret i1 %1

--- a/llvm/test/CodeGen/X86/long-double-abi-align.ll
+++ b/llvm/test/CodeGen/X86/long-double-abi-align.ll
@@ -73,7 +73,7 @@ define void @foo(i32 %0, x86_fp80 %1, i32 %2) nounwind {
 ; DARWIN-LABEL: foo:
 ; DARWIN:       ## %bb.0:
 ; DARWIN-NEXT:    subl $44, %esp
-; DARWIN-NEXT:    fldt 64(%esp)
+; DARWIN-NEXT:    fldt 52(%esp)
 ; DARWIN-NEXT:    fstpt 16(%esp)
 ; DARWIN-NEXT:    leal 48(%esp), %eax
 ; DARWIN-NEXT:    movl %eax, (%esp)
@@ -81,7 +81,7 @@ define void @foo(i32 %0, x86_fp80 %1, i32 %2) nounwind {
 ; DARWIN-NEXT:    leal 16(%esp), %eax
 ; DARWIN-NEXT:    movl %eax, (%esp)
 ; DARWIN-NEXT:    calll _escape
-; DARWIN-NEXT:    leal 80(%esp), %eax
+; DARWIN-NEXT:    leal 68(%esp), %eax
 ; DARWIN-NEXT:    movl %eax, (%esp)
 ; DARWIN-NEXT:    calll _escape
 ; DARWIN-NEXT:    addl $44, %esp


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/148034

e49fcfc7cdf82e41f15a857083c0fb275c1b6021 broke long double stack alignment on i386 Darwin, this PR fixes the issue.