### PR TITLE
[Github] Bump CI Container to 20.1.8

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/ubuntu:24.04 as base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base as stage1-toolchain
-ENV LLVM_VERSION=20.1.4
+ENV LLVM_VERSION=20.1.8
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
This patch bumps the LLVM toolchain version within the CI container to 20.1.8.