### PR TITLE
[AMDGPU][NPM] Add isRequired to passes missing it

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/StructurizeCFG.h
+++ b/llvm/include/llvm/Transforms/Scalar/StructurizeCFG.h
@@ -23,6 +23,7 @@ public:
                      function_ref<StringRef(StringRef)> MapClassName2PassName);
 
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/include/llvm/Transforms/Utils/LoopSimplify.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopSimplify.h
@@ -54,6 +54,7 @@ class ScalarEvolution;
 class LoopSimplifyPass : public PassInfoMixin<LoopSimplifyPass> {
 public:
   LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 /// Simplify each loop in a loop nest recursively.

--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
@@ -90,6 +90,7 @@ public:
   SILowerI1CopiesPass() = default;
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 void initializeAMDGPUDAGToDAGISelLegacyPass(PassRegistry &);
@@ -368,6 +369,7 @@ class SIModeRegisterPass : public PassInfoMixin<SIModeRegisterPass> {
 public:
   SIModeRegisterPass() {}
   PreservedAnalyses run(MachineFunction &F, MachineFunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 class SIMemoryLegalizerPass : public PassInfoMixin<SIMemoryLegalizerPass> {
@@ -480,6 +482,7 @@ private:
 public:
   SIAnnotateControlFlowPass(const AMDGPUTargetMachine &TM) : TM(TM) {}
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 void initializeSIAnnotateControlFlowLegacyPass(PassRegistry &);

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.h
@@ -314,6 +314,7 @@ public:
 
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 class AMDGPUDAGToDAGISelLegacy : public SelectionDAGISelLegacy {

--- a/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUUnifyDivergentExitNodes.h
@@ -29,6 +29,7 @@ class AMDGPUUnifyDivergentExitNodesPass
     : public PassInfoMixin<AMDGPUUnifyDivergentExitNodesPass> {
 public:
   PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  static bool isRequired() { return true; }
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AMDGPU/GCNNSAReassign.h
+++ b/llvm/lib/Target/AMDGPU/GCNNSAReassign.h
@@ -16,6 +16,7 @@ class GCNNSAReassignPass : public PassInfoMixin<GCNNSAReassignPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/GCNPreRALongBranchReg.h
+++ b/llvm/lib/Target/AMDGPU/GCNPreRALongBranchReg.h
@@ -17,6 +17,7 @@ class GCNPreRALongBranchRegPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.h
+++ b/llvm/lib/Target/AMDGPU/GCNRewritePartialRegUses.h
@@ -17,6 +17,7 @@ class GCNRewritePartialRegUsesPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.h
+++ b/llvm/lib/Target/AMDGPU/SIFixSGPRCopies.h
@@ -18,6 +18,7 @@ public:
   SIFixSGPRCopiesPass() = default;
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/SIFixVGPRCopies.h
+++ b/llvm/lib/Target/AMDGPU/SIFixVGPRCopies.h
@@ -16,6 +16,7 @@ class SIFixVGPRCopiesPass : public PassInfoMixin<SIFixVGPRCopiesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SILowerControlFlow.h
+++ b/llvm/lib/Target/AMDGPU/SILowerControlFlow.h
@@ -16,6 +16,7 @@ class SILowerControlFlowPass : public PassInfoMixin<SILowerControlFlowPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.h
@@ -21,6 +21,7 @@ public:
     // SILowerSGPRSpills introduces new Virtual VGPRs for spilling SGPRs.
     return MachineFunctionProperties().setIsSSA().setNoVRegs();
   }
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SILowerWWMCopies.h
+++ b/llvm/lib/Target/AMDGPU/SILowerWWMCopies.h
@@ -16,6 +16,7 @@ class SILowerWWMCopiesPass : public PassInfoMixin<SILowerWWMCopiesPass> {
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SIPreAllocateWWMRegs.h
+++ b/llvm/lib/Target/AMDGPU/SIPreAllocateWWMRegs.h
@@ -18,6 +18,7 @@ class SIPreAllocateWWMRegsPass
 public:
   PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
+  static bool isRequired() { return true; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AMDGPU/SIWholeQuadMode.h
+++ b/llvm/lib/Target/AMDGPU/SIWholeQuadMode.h
@@ -20,6 +20,7 @@ public:
   MachineFunctionProperties getClearedProperties() const {
     return MachineFunctionProperties().setIsSSA();
   }
+  static bool isRequired() { return true; }
 };
 } // namespace llvm
 

--- a/llvm/test/Feature/optnone-opt.ll
+++ b/llvm/test/Feature/optnone-opt.ll
@@ -54,7 +54,6 @@ attributes #0 = { optnone noinline }
 ; Loop IR passes that opt doesn't turn on by default.
 ; LoopPassManager should not be skipped over an optnone function
 ; NPM-LOOP-NOT: Skipping pass: PassManager
-; NPM-LOOP-DAG: Skipping pass: LoopSimplifyPass on foo
 ; NPM-LOOP-DAG: Skipping pass: LCSSAPass
 ; NPM-LOOP-DAG: Skipping pass: IndVarSimplifyPass
 ; NPM-LOOP-DAG: Skipping pass: SimpleLoopUnswitchPass


### PR DESCRIPTION
same as https://github.com/llvm/llvm-project/pull/134033. adds StructurizeCFG and LoopSimplify to the list.

The skipFunction check is done automatically in OptNone instrumentation, we have to add this method to passes that should not be skipped

Co-authored-by : Oke, Akshat <[Akshat.Oke@amd.com](mailto:Akshat.Oke@amd.com)>