### PR TITLE
AMDGPU: Remove "gws" feature from generic targets

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNProcessors.td
+++ b/llvm/lib/Target/AMDGPU/GCNProcessors.td
@@ -9,11 +9,11 @@
 // The code produced for "generic" is only useful for tests and cannot
 // reasonably be expected to execute on any particular target.
 def : ProcessorModel<"generic", NoSchedModel,
-  [FeatureGDS, FeatureGWS]
+  [FeatureGDS]
 >;
 
 def : ProcessorModel<"generic-hsa", NoSchedModel,
-  [FeatureGDS, FeatureGWS, FeatureFlatAddressSpace]
+  [FeatureGDS, FeatureFlatAddressSpace]
 >;
 
 //===------------------------------------------------------------===//


### PR DESCRIPTION
  Here "generic targets" means when no target is specified. This is because gfx12+ does not support this feature, and thus it is no longer universally available.

Fixes: SWDEV-541399