### PR TITLE
[Uniformity] Legacy PM: Set UniformityInfoWrapperPass isCFGOnly to false

### DIFF
--- a/llvm/lib/Analysis/UniformityAnalysis.cpp
+++ b/llvm/lib/Analysis/UniformityAnalysis.cpp
@@ -150,8 +150,11 @@ INITIALIZE_PASS_BEGIN(UniformityInfoWrapperPass, "uniformity",
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(CycleInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)
+// Though Uniformity Analysis depends on the CFG,
+// it also needs to be invalidated if values are changed, so isCFGOnly: false.
+// See NOTE on updatability at the start of GenericUniformityImpl.h
 INITIALIZE_PASS_END(UniformityInfoWrapperPass, "uniformity",
-                    "Uniformity Analysis", true, true)
+                    "Uniformity Analysis", false, true)
 
 void UniformityInfoWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();

--- a/llvm/lib/Analysis/UniformityAnalysis.cpp
+++ b/llvm/lib/Analysis/UniformityAnalysis.cpp
@@ -146,7 +146,7 @@ char UniformityInfoWrapperPass::ID = 0;
 UniformityInfoWrapperPass::UniformityInfoWrapperPass() : FunctionPass(ID) {}
 
 INITIALIZE_PASS_BEGIN(UniformityInfoWrapperPass, "uniformity",
-                      "Uniformity Analysis", true, true)
+                      "Uniformity Analysis", false, true)
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(CycleInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)

--- a/llvm/lib/Analysis/UniformityAnalysis.cpp
+++ b/llvm/lib/Analysis/UniformityAnalysis.cpp
@@ -150,9 +150,6 @@ INITIALIZE_PASS_BEGIN(UniformityInfoWrapperPass, "uniformity",
 INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(CycleInfoWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(TargetTransformInfoWrapperPass)
-// Though Uniformity Analysis depends on the CFG,
-// it also needs to be invalidated if values are changed, so isCFGOnly: false.
-// See NOTE on updatability at the start of GenericUniformityImpl.h
 INITIALIZE_PASS_END(UniformityInfoWrapperPass, "uniformity",
                     "Uniformity Analysis", false, true)
 


### PR DESCRIPTION
Currently, Uniformity Analysis is preserved in the Legacy PM when a pass sets `setPreservesCFG()`. This is incorrect: any values' uniformity not only depends on the CFG, but also on the uniformity of other values, so a CFG-preserving change in many cases doesn't preserve uniformity analysis. 

This corrected behavior also matches the behavior of the new PM.

---

On its own, this change does not affect the pass pipeline because of the happenstance of pass ordering. I also created a PR to change AMDGPULateCodeGenPrepare (#148167), this will have an actual impact on pass executions. That PR also includes changes to the `amdgpu/llc-pipeline.ll` test in order to check that this change works, but if this is preferred, I would also be happy to try to extend this PR to add an isolated test case; though my personal opinion is that the test in #148167 should suffice, as it should also accurately pinpoint failures related to this change.

---

I ran `git-clang-format` on my changes. I tested them using the `check-llvm` target; no unexpected failures occurred.

