### PR TITLE
Reland "[flang] Avoid undefined behaviour when parsing format expressions (#147539)"

### DIFF
--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -34,7 +34,7 @@ namespace Fortran::common {
 
 /// Add two signed integers, computing the two's complement truncated result,
 /// returning true if overflow occurred.
-bool AddOverflow(int64_t X, int64_t Y, int64_t &Result) {
+static inline bool AddOverflow(int64_t X, int64_t Y, int64_t &Result) {
 #if __has_builtin(__builtin_add_overflow)
   return __builtin_add_overflow(X, Y, &Result);
 #else
@@ -58,7 +58,7 @@ bool AddOverflow(int64_t X, int64_t Y, int64_t &Result) {
 
 /// Multiply two signed integers, computing the two's complement truncated
 /// result, returning true if an overflow occurred.
-int64_t MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
+static inline bool MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
 #if __has_builtin(__builtin_mul_overflow)
   return __builtin_mul_overflow(X, Y, &Result);
 #else

--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -81,11 +81,12 @@ static inline bool MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
   // Check how the max allowed absolute value (2^n for negative, 2^(n-1) for
   // positive) divided by an argument compares to the other.
   if (IsNegative)
-    return UX >
-        (static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + uint64_t(1)) /
+    return UX > (static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) +
+                    uint64_t(1)) /
         UY;
   else
-    return UX > (static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) / UY;
+    return UX >
+        (static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) / UY;
 #endif
 }
 

--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -82,10 +82,10 @@ int64_t MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
   // positive) divided by an argument compares to the other.
   if (IsNegative)
     return UX >
-        (static_cast<uint64_t>(std::numeric_limits<T>::max()) + uint64_t(1)) /
+        (static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + uint64_t(1)) /
         UY;
   else
-    return UX > (static_cast<uint64_t>(std::numeric_limits<T>::max())) / UY;
+    return UX > (static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) / UY;
 #endif
 }
 

--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -63,8 +63,10 @@ int64_t MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
   return __builtin_mul_overflow(X, Y, &Result);
 #else
   // Perform the unsigned multiplication on absolute values.
-  const uint64_t UX = X < 0 ? (0 - static_cast<uint64_t>(X)) : static_cast<uint64_t>(X);
-  const uint64_t UY = Y < 0 ? (0 - static_cast<uint64_t>(Y)) : static_cast<uint64_t>(Y);
+  const uint64_t UX =
+      X < 0 ? (0 - static_cast<uint64_t>(X)) : static_cast<uint64_t>(X);
+  const uint64_t UY =
+      Y < 0 ? (0 - static_cast<uint64_t>(Y)) : static_cast<uint64_t>(Y);
   const uint64_t UResult = UX * UY;
 
   // Convert to signed.
@@ -79,7 +81,9 @@ int64_t MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
   // Check how the max allowed absolute value (2^n for negative, 2^(n-1) for
   // positive) divided by an argument compares to the other.
   if (IsNegative)
-    return UX > (static_cast<uint64_t>(std::numeric_limits<T>::max()) + uint64_t(1)) / UY;
+    return UX >
+        (static_cast<uint64_t>(std::numeric_limits<T>::max()) + uint64_t(1)) /
+        UY;
   else
     return UX > (static_cast<uint64_t>(std::numeric_limits<T>::max())) / UY;
 #endif

--- a/flang/include/flang/Common/format.h
+++ b/flang/include/flang/Common/format.h
@@ -47,11 +47,13 @@ static inline bool AddOverflow(int64_t X, int64_t Y, int64_t &Result) {
   Result = static_cast<int64_t>(UResult);
 
   // Adding two positive numbers should result in a positive number.
-  if (X > 0 && Y > 0)
+  if (X > 0 && Y > 0) {
     return Result <= 0;
+  }
   // Adding two negatives should result in a negative number.
-  if (X < 0 && Y < 0)
+  if (X < 0 && Y < 0) {
     return Result >= 0;
+  }
   return false;
 #endif
 }
@@ -74,19 +76,21 @@ static inline bool MulOverflow(int64_t X, int64_t Y, int64_t &Result) {
   Result = IsNegative ? (0 - UResult) : UResult;
 
   // If any of the args was 0, result is 0 and no overflow occurs.
-  if (UX == 0 || UY == 0)
+  if (UX == 0 || UY == 0) {
     return false;
+  }
 
   // UX and UY are in [1, 2^n], where n is the number of digits.
   // Check how the max allowed absolute value (2^n for negative, 2^(n-1) for
   // positive) divided by an argument compares to the other.
-  if (IsNegative)
+  if (IsNegative) {
     return UX > (static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) +
                     uint64_t(1)) /
         UY;
-  else
+  } else {
     return UX >
         (static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) / UY;
+  }
 #endif
 }
 


### PR DESCRIPTION
This reverts commit e8e5d07767c444913f837dd35846a92fcf520eab.

This previously failed because the flang-rt build could not find the 
llvm header file. It passed on some machines but only because they
had globally installed copies of older llvm.

To fix this, I've copied the required routines from llvm into flang.

With the following justification:
* Flang can, and does, use llvm headers.
* Some Flang headers are also used in Flang-rt.
* Flang-rt cannot use llvm headers.
* Therefore any Flang header using in Flang-rt cannot use llvm headers either.

To support that conclusion, https://flang.llvm.org/docs/IORuntimeInternals.html
states:
"The Fortran I/O runtime support library is written in C++17, and uses some C++17 standard library facilities, but it is intended to not have any link-time dependences on the C++ runtime support library or any LLVM libraries." 

This talks about libraries but I assume it applies to llvm in general.

Nothing in flang/include/flang/Common, or flang/include/flang/Common
includes any llvm header, and I see some very similar headers there
that duplicate llvm functionality. Like float128.h.

I can only assume this means these files must remain free of dependencies
on LLVM.

I have copied the two routines literally and put them in the flang::common
namespace, for lack of a better place for them. So they don't clash with something.

I have specialised the function to the 1 type flang needs, as it might
save a bit of compile time.