### PR TITLE
[LLDB] Use non synthetic value for MSVC smart ptr check

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -15,8 +15,10 @@
 using namespace lldb;
 
 bool lldb_private::formatters::IsMsvcStlSmartPointer(ValueObject &valobj) {
-  ValueObjectSP valobj_sp = valobj.GetNonSyntheticValue();
-  return valobj_sp->GetChildMemberWithName("_Ptr") != nullptr;
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Ptr") != nullptr;
+
+  return false;
 }
 
 bool lldb_private::formatters::MsvcStlSmartPointerSummaryProvider(

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlSmartPointer.cpp
@@ -15,7 +15,8 @@
 using namespace lldb;
 
 bool lldb_private::formatters::IsMsvcStlSmartPointer(ValueObject &valobj) {
-  return valobj.GetChildMemberWithName("_Ptr") != nullptr;
+  ValueObjectSP valobj_sp = valobj.GetNonSyntheticValue();
+  return valobj_sp->GetChildMemberWithName("_Ptr") != nullptr;
 }
 
 bool lldb_private::formatters::MsvcStlSmartPointerSummaryProvider(


### PR DESCRIPTION
I forgot to use the non-synthetic value to check for the `_Ptr` member.

Fixes the test failure from #147575.