### PR TITLE
[FIX] Fix sanitizer-aarch64-linux build after commit 8472eb1361bbabd6…

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64LoadStoreOptimizer.cpp
@@ -2569,7 +2569,6 @@ MachineBasicBlock::iterator AArch64LoadStoreOpt::findMatchingUpdateInsnForward(
     // such that BaseReg is alive along it but not at its exits
     MachineBasicBlock *SuccToVisit = nullptr;
     unsigned LiveSuccCount = 0;
-    MCRegister RegNoBAse = BaseReg;
     for (MachineBasicBlock *Succ : CurMBB->successors()) {
       for (MCRegAliasIterator AI(BaseReg, TRI, true); AI.isValid(); ++AI) {
         if (Succ->isLiveIn(*AI)) {


### PR DESCRIPTION
The previous commit 8472eb1361bbabd6428a65da446618503e439743 broke the sanitizer-aarch64-linux builder.

This patch fixes it: unused variable is removed

