### PR TITLE
[mlir][tosa] Remove profile compliance of cond_if and while_loop

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/IR/TosaComplianceData.h.inc
+++ b/mlir/include/mlir/Dialect/Tosa/IR/TosaComplianceData.h.inc
@@ -433,8 +433,6 @@ extensionComplianceMap = {
       {{Extension::fp8e4m3}, {{fp8e4m3T, fp8e4m3T}}},
       {{Extension::fp8e5m2}, {{fp8e5m2T, fp8e5m2T}}},
       {{Extension::bf16}, {{bf16T, bf16T}}}}},
-    {"tosa.cond_if", {{{Extension::controlflow}, {{boolT}}}}},
-    {"tosa.while_loop", {{{Extension::controlflow}, {{boolT}}}}},
     {"tosa.variable", {{{Extension::variable}, {{i8T}, {fp16T}, {fp32T}}}}},
     {"tosa.variable_write",
      {{{Extension::variable}, {{i8T}, {fp16T}, {fp32T}}}}},

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaProfileCompliance.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaProfileCompliance.cpp
@@ -225,20 +225,6 @@ LogicalResult ProfileInfoDepot::populateProfileInfo(tosa::VariableWriteOp op) {
   return success();
 }
 
-template <>
-LogicalResult ProfileInfoDepot::populateProfileInfo(tosa::IfOp op) {
-  addValue(op.getCondition());
-  return success();
-}
-
-template <>
-LogicalResult ProfileInfoDepot::populateProfileInfo(tosa::WhileOp op) {
-  Block *block = &op.getCondGraph().front();
-  Operation *terminator = block->getTerminator();
-  addValue(terminator->getOperands().front());
-  return success();
-}
-
 LogicalResult ProfileInfoDepot::populatationDispatch(Operation *op) {
 // This helper function only populates the info for the customised operands.
 #define POPULATE_PROFILE_INFO_CUSTOM(tosaOp)                                   \
@@ -280,8 +266,6 @@ LogicalResult ProfileInfoDepot::populatationDispatch(Operation *op) {
   POPULATE_PROFILE_INFO_CUSTOM(MatMul)
   POPULATE_PROFILE_INFO_CUSTOM(Variable)
   POPULATE_PROFILE_INFO_CUSTOM(VariableWrite)
-  POPULATE_PROFILE_INFO_CUSTOM(If)
-  POPULATE_PROFILE_INFO_CUSTOM(While)
 
   // For the most of tosa operators, all operands are profile/extension related
   // and hence are all considered in this profile-based compilance check.
@@ -340,6 +324,8 @@ LogicalResult ProfileInfoDepot::populatationDispatch(Operation *op) {
   // constraint for those operations.
   POPULATE_PROFILE_INFO_SKIP(ConstShape)
   POPULATE_PROFILE_INFO_SKIP(Yield)
+  POPULATE_PROFILE_INFO_SKIP(If)
+  POPULATE_PROFILE_INFO_SKIP(While)
 
   return failure();
 }


### PR DESCRIPTION
The requirement for a boolean condition is already checked for both operators elsewhere. `cond_if` requires a boolean condition at construction. `while_loop` cond_graph is checked in the verifier for a scalar boolean output type.