### PR TITLE
[AArch64] Set the cache line size to 64 for the V2 and V3.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -270,6 +270,7 @@ void AArch64Subtarget::initializeProperties(bool HasMinSize) {
     break;
   case NeoverseV2:
   case NeoverseV3:
+    CacheLineSize = 64;
     EpilogueVectorizationMinVF = 8;
     MaxInterleaveFactor = 4;
     ScatterOverhead = 13;


### PR DESCRIPTION
This sets the cache line size to 64 for the Neoverse V2 and V3.  I've tested this with loop-interchange: it doesn't result in extra compile-times, but it does enable a lot more interchange.

I've also set this for V3, have not tested this, but looks like the sensible thing to do, but am happy to remove this.