### PR TITLE
[LTO] Add unified LTO tests for the PS targets.

### DIFF
--- a/clang/test/CodeGen/asan-unified-lto.ll
+++ b/clang/test/CodeGen/asan-unified-lto.ll
@@ -5,6 +5,7 @@
 
 ; RUN: %clang_cc1 -emit-llvm-bc -O1 -flto -fsanitize=address -o - -x ir < %s | llvm-dis -o - | FileCheck %s
 ; RUN: %clang_cc1 -emit-llvm-bc -O1 -flto -funified-lto -fsanitize=address -o - -x ir < %s | llvm-dis -o - | FileCheck %s
+; RUN: %clang_cc1 -emit-llvm-bc -O1 -flto -fno-unified-lto -fsanitize=address -o - -x ir < %s | llvm-dis -o - | FileCheck %s
 ; CHECK: @anon.3ee0898e5200a57350fed5485ae5d237
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"

--- a/clang/test/CodeGen/unified-lto-pipeline.c
+++ b/clang/test/CodeGen/unified-lto-pipeline.c
@@ -11,8 +11,10 @@
 /// Check that pass pipelines for thin, thin-unified, full-unified all match.
 // RUN: diff %t.0.txt %t.1.txt
 // RUN: diff %t.0.txt %t.2.txt
-/// Pass pipeline for full is different.
-// RUN: not diff %t.0.txt %t.3.txt
+/// Pass pipeline for full is different. Unified uses the full Linux pipeline except ThinLTOBitcodeWriterPass vs BitcodeWriterPass.
+// RUN: not diff -u %t.0.txt %t.3.txt | FileCheck %s --check-prefix=DIFF --implicit-check-not="{{^[-+!<>] }}"
+// DIFF:      -Running pass: ThinLTOBitcodeWriterPass
+// DIFF-NEXT: +Running pass: BitcodeWriterPass
 
 int foo() {
   return 2 + 2;


### PR DESCRIPTION
For the PS targets, unified LTO pipeline is used as default behaviour when enabling LTO. Other targets use Distinct LTO pipeline behaviour as default behaviours. Unified LTO tests are added in this PR:

1. clang/test/CodeGen/asan-unified-lto.ll: add a RUN line to check the explicit Distinct LTO pipeline behavior for PS targets.
2. clang/test/CodeGen/unified-lto-pipeline-ps.c: a new test for PS targets.