### PR TITLE
[lldb][Format] Fall back to old function.name-with-args if language frame format is emtpy

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1280,7 +1280,9 @@ static bool FormatFunctionNameForLanguage(Stream &s,
     return false;
 
   FormatEntity::Entry format = language_plugin->GetFunctionNameFormat();
-  if (!format)
+
+  // Bail on invalid or empty format.
+  if (!format || format == FormatEntity::Entry(Entry::Type::Root))
     return false;
 
   StreamString name_stream;

--- a/lldb/test/Shell/Settings/TestCxxFrameFormatEmpty.test
+++ b/lldb/test/Shell/Settings/TestCxxFrameFormatEmpty.test
@@ -1,0 +1,32 @@
+# XFAIL: target-windows
+
+# Test that setting plugin.cplusplus.display.function-name-format
+# to an empty string disables the "format by language" part of
+# ${function.name-with-args}.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
+# RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s
+
+#--- main.cpp
+namespace ns::ns2 {
+void custom(int x) {}
+void bar() { custom(5); }
+}
+
+int main(int argc, char const *argv[]) {
+    ns::ns2::bar();
+    return 0;
+}
+
+#--- commands.input
+settings set plugin.cplusplus.display.function-name-format ""
+settings set -f frame-format "custom-frame '${function.name-with-args}'\n"
+break set -l 2 -f main.cpp
+
+run
+bt
+
+# CHECK: custom-frame 'ns::ns2::custom(x=5)'
+# CHECK: custom-frame 'ns::ns2::bar()'


### PR DESCRIPTION
There is currently no way to prevent `${function.name-with-args}` from using the `plugin.cplusplus.display.function-name-format` setting. Even if the setting is set to an empty string. As a way to disable formatting by language plugin, this patch makes it so `plugin.cplusplus.display.function-name-format` falls back to the old way of printing `${function.name-with-args}`. Even if we didn't want to add a fallback, making the setting an empty string shouldn't really "succeed".