### PR TITLE
[mlir][scf] Add `ReturnLike` to `scf::InParallelOp`

### DIFF
--- a/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
+++ b/mlir/include/mlir/Dialect/SCF/IR/SCFOps.td
@@ -633,6 +633,7 @@ def ForallOp : SCF_Op<"forall", [
 def InParallelOp : SCF_Op<"forall.in_parallel", [
        Pure,
        Terminator,
+       ReturnLike,
        DeclareOpInterfaceMethods<ParallelCombiningOpInterface>,
        HasParent<"ForallOp">,
       ] # GraphRegionNoTerminator.traits> {


### PR DESCRIPTION
This patch adds the `ReturnLike` trait to `scf::InParallelOp`. This is the first step to clean the branching semantics of `scf::ForallOp` and `scf::InParallelOp`.