### PR TITLE
[flang][acc][NFC] Add deviation to the spec that declaring the same variable is permitted

### DIFF
--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -29,7 +29,7 @@ local:
   `deviceptr` and `present` clauses.
 * The OpenACC specification disallows a variable appearing multiple times in
   clauses of `!$acc declare` directives for a function, subroutine, program,
-  or module, but we allow it with a warning.
+  or module, but it is allowed with a warning when same clause is used.
 
 ## Remarks about incompatibilities with other implementations
 * Array element references in the data clauses are equivalent to array sections

--- a/flang/docs/OpenACC.md
+++ b/flang/docs/OpenACC.md
@@ -27,6 +27,9 @@ local:
 * `!$acc cache` directive accepts scalar variable.
 * The `!$acc declare` directive accepts assumed size array arguments for 
   `deviceptr` and `present` clauses.
+* The OpenACC specification disallows a variable appearing multiple times in
+  clauses of `!$acc declare` directives for a function, subroutine, program,
+  or module, but we allow it with a warning.
 
 ## Remarks about incompatibilities with other implementations
 * Array element references in the data clauses are equivalent to array sections


### PR DESCRIPTION
OpenACC spec says `A var may appear at most once in all the clauses of declare directives for a function, subroutine, program, or module.` but our implementation allows it with a warning generated. Add this to the diviation list for record.

