### PR TITLE
[LLDB][NVIDIA] Add Disassembler log channel

### DIFF
--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -49,6 +49,7 @@ enum class LLDBLog : Log::MaskType {
   Watchpoints = Log::ChannelFlag<30>,
   OnDemand = Log::ChannelFlag<31>,
   Source = Log::ChannelFlag<32>,
+  Disassembler = Log::ChannelFlag<33>,
   LLVM_MARK_AS_BITMASK_ENUM(OnDemand),
 };
 

--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -50,7 +50,7 @@ enum class LLDBLog : Log::MaskType {
   OnDemand = Log::ChannelFlag<31>,
   Source = Log::ChannelFlag<32>,
   Disassembler = Log::ChannelFlag<33>,
-  LLVM_MARK_AS_BITMASK_ENUM(OnDemand),
+  LLVM_MARK_AS_BITMASK_ENUM(Disassembler),
 };
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1146,7 +1146,7 @@ public:
       }
     }
 
-    if (Log *log = GetLog(LLDBLog::Disassembler)) {
+    if (Log *log = GetLog(LLDBLog::Process | LLDBLog::Disassembler)) {
       StreamString ss;
 
       ss.Printf("[%s] expands to %zu operands:\n", operands_string,

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1146,7 +1146,7 @@ public:
       }
     }
 
-    if (Log *log = GetLog(LLDBLog::Process)) {
+    if (Log *log = GetLog(LLDBLog::Disassembler)) {
       StreamString ss;
 
       ss.Printf("[%s] expands to %zu operands:\n", operands_string,

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -64,6 +64,9 @@ static constexpr Log::Category g_categories[] = {
      {"log symbol on-demand related activities"},
      LLDBLog::OnDemand},
     {{"source"}, {"log source related activities"}, LLDBLog::Source},
+    {{"disassembler"},
+     {"log disassembler related activities"},
+     LLDBLog::Disassembler},
 };
 
 static Log::Channel g_log_channel(g_categories,


### PR DESCRIPTION
This commit introduces a new log channel for the disassembler in LLDB, allowing for better logging of disassembler related activities. The `LLDBLOG` enum has been updated to include the `Disassembler` channel, and the relevant logging in the `DisassemblerLLVMC` plugin has been modified to utilize this new channel. This is in preparation for adding additional disassembler implementations.

Key Changes:
- Added `Disassembler` to the `LLDBLog` enum.
- Updated logging in `DisassemblerLLVMC.cpp` to use the new `Disassembler` log channel.