### PR TITLE
[mlir][acc] Add MappableType API for generating private recipe init

### DIFF
--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCTypeInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCTypeInterfaces.td
@@ -180,6 +180,36 @@ def OpenACC_MappableTypeInterface : TypeInterface<"MappableType"> {
         return ::mlir::acc::VariableTypeCategory::uncategorized;
       }]
     >,
+      InterfaceMethod<
+      /*description=*/[{
+        Generates the operations that would be normally placed in a recipe's
+        init region. It inserts at the builder's current location.
+        It can be used either to directly "inline" the init region
+        or if the caller sets the insertion point to inside a recipe body,
+        it fills it in. This does not generate the `acc.yield` that normally
+        would terminate a recipe.
+
+        The `extents` are optional and can be empty - it is only when a
+        slice of the private variable needs allocated.
+        The `initVal` can be empty - it is primarily needed for reductions
+        to ensure the variable is also initialized with appropriate value.
+
+        If the return value is empty, it means that recipe body was not
+        successfully generated.
+      }],
+      /*retTy=*/"::mlir::Value",
+      /*methodName=*/"generatePrivateInit",
+      /*args=*/(ins "::mlir::OpBuilder &":$builder,
+                    "::mlir::Location":$loc,
+                    "::mlir::TypedValue<::mlir::acc::MappableType>":$var,
+                    "::llvm::StringRef":$varName,
+                    "::mlir::ValueRange":$extents,
+                    "::mlir::Value":$initVal),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return {};
+      }]
+    >,
   ];
 }
 

--- a/mlir/include/mlir/Dialect/OpenACC/OpenACCTypeInterfaces.td
+++ b/mlir/include/mlir/Dialect/OpenACC/OpenACCTypeInterfaces.td
@@ -190,7 +190,7 @@ def OpenACC_MappableTypeInterface : TypeInterface<"MappableType"> {
         would terminate a recipe.
 
         The `extents` are optional and can be empty - it is only when a
-        slice of the private variable needs allocated.
+        slice of the private variable needs allocation.
         The `initVal` can be empty - it is primarily needed for reductions
         to ensure the variable is also initialized with appropriate value.
 


### PR DESCRIPTION
This introduces the first in a series of APIs that will allow a MappableType to generate the body of the recipes. The current API does not actually generate the recipe itself - it generates the body of it. So it can either be placed in a recipe or inlined directly as needed.