### PR TITLE
[flang][cuda] Fix false positive on unsupported CUDA data transfer

### DIFF
--- a/flang/test/Lower/CUDA/cuda-data-transfer.cuf
+++ b/flang/test/Lower/CUDA/cuda-data-transfer.cuf
@@ -436,3 +436,11 @@ end subroutine
 
 ! CHECK-LABEL: func.func @_QPsub22()
 ! CHECK: cuf.data_transfer
+
+subroutine sub23(n)
+  integer :: n
+  real(8), device :: d(n,n), x(n)
+  x = sum(d,dim=2) ! Was triggering Unsupported CUDA data transfer
+end subroutine
+
+! CHECK-LABEL: func.func @_QPsub23


### PR DESCRIPTION
The switch to `GetSymbolVector` introduced a regression on detecting implicit data transfer when the rhs is a function call.
Make sure the symbol we are looking at are of interest to detect data transfer. 