### PR TITLE
DWARF CFI Checker prototype

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -1086,7 +1086,7 @@ public:
     return false;
   }
 
-  /// Use \p Input1 or Input2 as the current value for the input
+  /// Use \p Input1 or \p Input2 as the current value for the input
   /// register and put in \p Output the changes incurred by executing
   /// \p Inst. Return false if it was not possible to perform the
   /// evaluation. evaluateStackOffsetExpr is restricted to operations

--- a/bolt/lib/Utils/CommandLineOpts.cpp
+++ b/bolt/lib/Utils/CommandLineOpts.cpp
@@ -146,7 +146,7 @@ cl::opt<bool> Lite("lite", cl::desc("skip processing of cold functions"),
                    cl::cat(BoltCategory));
 
 cl::opt<std::string>
-OutputFilename("o",
+OutputFilename("ooo",
   cl::desc("<output file>"),
   cl::Optional,
   cl::cat(BoltOutputCategory));

--- a/llvm/test/tools/llvm-mc/cfi-validation/single-func-cfa-mistake.s
+++ b/llvm/test/tools/llvm-mc/cfi-validation/single-func-cfa-mistake.s
@@ -1,0 +1,33 @@
+# RUN: not llvm-mc %s --validate-cfi --filetype=null 2>&1 \
+# RUN:   | FileCheck %s 
+        .text
+        .globl  f
+        .type   f,@function
+f:
+        .cfi_startproc
+
+        .cfi_undefined %rax
+
+        pushq   %rbp
+        # CHECK: error: Expected CFA [reg: 61, offset: 16] but got [reg: 61, offset: 17]
+        .cfi_def_cfa_offset 17
+        .cfi_offset %rbp, -16
+
+        movq    %rsp, %rbp
+        .cfi_def_cfa_register %rbp
+
+        movl    %edi, -4(%rbp)
+
+        movl    -4(%rbp), %eax
+
+        addl    $10, %eax
+
+        popq    %rbp
+        .cfi_def_cfa %rsp, 8
+
+        retq
+
+.Lfunc_end0:
+        .size   f, .Lfunc_end0-f
+
+        .cfi_endproc

--- a/llvm/test/tools/llvm-mc/cfi-validation/single-func-missed-cfi-directive.s
+++ b/llvm/test/tools/llvm-mc/cfi-validation/single-func-missed-cfi-directive.s
@@ -1,0 +1,32 @@
+# RUN: not llvm-mc %s --validate-cfi --filetype=null 2>&1 \
+# RUN:   | FileCheck %s 
+        .text
+        .globl  f
+        .type   f,@function
+f:
+        .cfi_startproc
+        
+        .cfi_undefined %rax
+        
+        pushq   %rbp
+        .cfi_def_cfa_offset 16
+        
+        movq    %rsp, %rbp
+        # CHECK: error: Reg#52 caller's value is in reg#52 which is changed by this instruction, but not changed in CFI directives
+        .cfi_def_cfa_register %rbp
+        
+        movl    %edi, -4(%rbp)
+        
+        movl    -4(%rbp), %eax
+        
+        addl    $10, %eax
+        
+        popq    %rbp
+        .cfi_def_cfa %rsp, 8
+        
+        retq
+
+.Lfunc_end0:
+        .size   f, .Lfunc_end0-f
+
+        .cfi_endproc

--- a/llvm/test/tools/llvm-mc/cfi-validation/single-func.s
+++ b/llvm/test/tools/llvm-mc/cfi-validation/single-func.s
@@ -1,0 +1,31 @@
+# RUN: llvm-mc %s --validate-cfi --filetype=null
+        .text
+        .globl  f
+        .type   f,@function
+f:
+        .cfi_startproc
+        
+        .cfi_undefined %rax
+        
+        pushq   %rbp
+        .cfi_def_cfa_offset 16
+        .cfi_offset %rbp, -16
+        
+        movq    %rsp, %rbp
+        .cfi_def_cfa_register %rbp
+        
+        movl    %edi, -4(%rbp)
+        
+        movl    -4(%rbp), %eax
+        
+        addl    $10, %eax
+        
+        popq    %rbp
+        .cfi_def_cfa %rsp, 8
+        
+        retq
+
+.Lfunc_end0:
+        .size   f, .Lfunc_end0-f
+
+        .cfi_endproc

--- a/llvm/test/tools/llvm-mc/cfi-validation/spill-two-reg-reversed.s
+++ b/llvm/test/tools/llvm-mc/cfi-validation/spill-two-reg-reversed.s
@@ -1,0 +1,47 @@
+# RUN: not llvm-mc %s --validate-cfi --filetype=null 2>&1 \
+# RUN:   | FileCheck %s 
+        .text
+        .type   _start,@function
+        .globl  _start
+        .hidden _start
+_start:
+        .cfi_startproc
+
+        .cfi_same_value %rdi
+        .cfi_same_value %rsi
+
+        pushq   %rbp
+        .cfi_adjust_cfa_offset 8
+        .cfi_offset %rbp, -16
+
+        movq    %rsp, %rbp
+
+        pushq   %rdi
+        .cfi_adjust_cfa_offset 8
+        .cfi_rel_offset %rdi, 0
+
+        pushq   %rsi
+        .cfi_adjust_cfa_offset 8
+        .cfi_rel_offset %rsi, 0
+        
+        popq    %rsi
+        # CHECK: warning: The reg#55 CFI state is changed
+        .cfi_adjust_cfa_offset -8
+        .cfi_same_value %rdi
+
+        popq    %rdi
+        # CHECK: warning: The reg#60 CFI state is changed
+        # CHECK: Reg#55 caller's value is in reg#55 which is changed by this instruction, but not changed in CFI directives
+        .cfi_adjust_cfa_offset -8
+        .cfi_same_value %rsi
+
+        popq    %rbp
+        .cfi_adjust_cfa_offset -8
+        .cfi_same_value %rbp
+
+        retq
+
+        .cfi_endproc
+.Ltmp0:
+        .size   _start, .Ltmp0-_start
+        .text

--- a/llvm/test/tools/llvm-mc/cfi-validation/spill-two-reg.s
+++ b/llvm/test/tools/llvm-mc/cfi-validation/spill-two-reg.s
@@ -1,0 +1,43 @@
+# RUN: llvm-mc %s --validate-cfi --filetype=null
+        .text
+        .type   _start,@function
+        .globl  _start
+        .hidden _start
+_start:
+        .cfi_startproc
+
+        .cfi_same_value %rdi
+        .cfi_same_value %rsi
+
+        pushq   %rbp
+        .cfi_adjust_cfa_offset 8
+        .cfi_offset %rbp, -16
+
+        movq    %rsp, %rbp
+
+        pushq   %rdi
+        .cfi_adjust_cfa_offset 8
+        .cfi_rel_offset %rdi, 0
+
+        pushq   %rsi
+        .cfi_adjust_cfa_offset 8
+        .cfi_rel_offset %rsi, 0
+        
+        popq    %rsi
+        .cfi_adjust_cfa_offset -8
+        .cfi_same_value %rsi
+
+        popq    %rdi
+        .cfi_adjust_cfa_offset -8
+        .cfi_same_value %rdi
+
+        popq    %rbp
+        .cfi_adjust_cfa_offset -8
+        .cfi_same_value %rbp
+
+        retq
+
+        .cfi_endproc
+.Ltmp0:
+        .size   _start, .Ltmp0-_start
+        .text

--- a/llvm/test/tools/llvm-mc/cfi-validation/update-with-no-cfi.s
+++ b/llvm/test/tools/llvm-mc/cfi-validation/update-with-no-cfi.s
@@ -1,0 +1,31 @@
+# RUN: not llvm-mc %s --validate-cfi --filetype=null 2>&1 \
+# RUN:   | FileCheck %s 
+        .text
+        .globl  f
+        .type   f,@function
+f:
+        .cfi_startproc
+
+        .cfi_same_value %rax
+        .cfi_same_value %rbx
+        .cfi_same_value %rcx
+        .cfi_same_value %rdx
+
+        movq $10, %rax
+        # CHECK: error: Reg#51 caller's value is in reg#51 which is changed by this instruction, but not changed in CFI directives
+
+        movq $10, %rbx
+        # CHECK: error: Reg#53 caller's value is in reg#53 which is changed by this instruction, but not changed in CFI directives
+
+        movq $10, %rcx
+        # CHECK: error: Reg#54 caller's value is in reg#54 which is changed by this instruction, but not changed in CFI directives
+
+        movq $10, %rdx
+        # CHECK: error: Reg#56 caller's value is in reg#56 which is changed by this instruction, but not changed in CFI directives
+
+        retq
+
+.Lfunc_end0:
+        .size   f, .Lfunc_end0-f
+
+        .cfi_endproc

--- a/llvm/tools/llvm-mc/CFIAnalysis.h
+++ b/llvm/tools/llvm-mc/CFIAnalysis.h
@@ -2,14 +2,18 @@
 #define LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/Debug.h"
+#include <ostream>
+#include <set>
 
 namespace llvm {
 
@@ -25,20 +29,47 @@ class CFIAnalysis {
 
 public:
   CFIAnalysis(MCContext &Context, MCInstrInfo const &MCII)
-      : Context(Context), MCII(MCII) {}
+      : Context(Context), MCII(MCII) {
+    // TODO it should look at the poluge directives and setup the
+    // registers' previous value state here, but for now, it's assumed that all
+    // values are by default `samevalue`.
+  }
 
   void update(const MCDwarfFrameInfo &DwarfFrame, const MCInst &Inst,
               ArrayRef<MCCFIInstruction> CFIDirectives) {
-    dbgs() << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
-    printUntilNextLine(Inst.getLoc().getPointer());
-    dbgs() << "\n";
-    dbgs() << "codes: ";
-    Inst.print(dbgs());
-    dbgs() << "\n";
-    dbgs() << "------------------------------\n";
+
+    auto MCInstInfo = MCII.get(Inst.getOpcode());
     auto *RI = Context.getRegisterInfo();
     auto CFAReg = RI->getLLVMRegNum(DwarfFrame.CurrentCfaRegister, false);
-    dbgs() << "The CFA register is: " << CFAReg << "\n";
+
+    std::set<int> Writes, Reads; // TODO reads is not ready for now
+    // FIXME this way of extracting uses is buggy:
+    // for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++)
+    //   Reads.insert(MCInstInfo.implicit_uses()[I]);
+    // for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++)
+    //   Writes.insert(MCInstInfo.implicit_defs()[I]);
+
+    for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
+      auto &&Operand = Inst.getOperand(I);
+      if (Operand.isReg()) {
+        // TODO it is not percise, maybe this operand is for output, then it
+        // means that there is no read happening here.
+        Reads.insert(Operand.getReg());
+      }
+
+      if (Operand.isExpr()) {
+        // TODO maybe the argument is not a register, but is a expression like
+        // `34(sp)` that has a register in it. Check if this works or not and if
+        // no change it somehow that it count that register as reads or writes
+        // too.
+      }
+
+      if (Operand.isReg() &&
+          MCInstInfo.hasDefOfPhysReg(Inst, Operand.getReg(), *RI))
+        Writes.insert(Operand.getReg().id());
+    }
+
+    bool ChangedCFA = Writes.count(CFAReg->id());
     bool GoingToChangeCFA = false;
     for (auto CFIDirective : CFIDirectives) {
       auto Op = CFIDirective.getOperation();
@@ -48,38 +79,28 @@ public:
                            Op == MCCFIInstruction::OpAdjustCfaOffset ||
                            Op == MCCFIInstruction::OpLLVMDefAspaceCfa);
     }
-    dbgs() << "------------------------------\n";
-    bool ChangedCFA = false;
-    for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
-      auto &&Operand = Inst.getOperand(I);
-      if (!Operand.isReg())
-        continue;
-      if (MCII.get(Inst.getOpcode())
-              .hasDefOfPhysReg(Inst, Operand.getReg(), *RI)) {
-        dbgs() << "This instruction modifies: " << Operand.getReg().id()
-               << "\n";
-        if (Operand.getReg() == CFAReg.value())
-          ChangedCFA = true;
-      }
-    }
-    dbgs() << "------------------------------\n";
-    dbgs() << "The instruction DOES " << (ChangedCFA ? "" : "NOT ")
-           << "change the CFA.\n";
-    dbgs() << "The CFI directives DOES " << (GoingToChangeCFA ? "" : "NOT ")
-           << "change the CFA.\n";
     if (ChangedCFA && !GoingToChangeCFA) {
       Context.reportError(Inst.getLoc(),
                           "The instruction changes CFA register value, but the "
                           "CFI directives don't update the CFA.");
     }
-    // TODO needs more work
-    // if (!ChangedCFA && GoingToChangeCFA) {
-    //   Context.reportError(
-    //       Inst.getLoc(),
-    //       "The instruction doesn't change CFA register value, but the "
-    //       "CFI directives update the CFA.");
-    // }
-    dbgs() << "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n";
+
+    dbgs() << "^^^^^^^^^^^^^^^^ InsCFIs ^^^^^^^^^^^^^^^^\n";
+    printUntilNextLine(Inst.getLoc().getPointer());
+    dbgs() << "\n";
+    dbgs() << "-----------------------------------------\n";
+    dbgs() << "writes into: { ";
+    for (auto Reg : Writes) {
+      dbgs() << (int)Reg << " ";
+    }
+    dbgs() << "}\n";
+    dbgs() << "-----------------------------------------\n";
+    dbgs() << "The CFA register is: " << CFAReg << "\n";
+    dbgs() << "The instruction does " << (ChangedCFA ? "" : "NOT ")
+           << "change the CFA.\n";
+    dbgs() << "The CFI directives does " << (GoingToChangeCFA ? "" : "NOT ")
+           << "change the CFA.\n";
+    dbgs() << "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n";
     ChangedCFA = false;
   }
 };

--- a/llvm/tools/llvm-mc/CFIAnalysis.h
+++ b/llvm/tools/llvm-mc/CFIAnalysis.h
@@ -1,0 +1,88 @@
+#ifndef LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_H
+#define LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/Debug.h"
+
+namespace llvm {
+
+// TODO remove it, it's just for debug purposes.
+void printUntilNextLine(const char *Str) {
+  for (int I = 0; Str[I] != '\0' && Str[I] != '\n'; I++)
+    dbgs() << Str[I];
+}
+
+class CFIAnalysis {
+  MCContext &Context;
+  MCInstrInfo const &MCII;
+
+public:
+  CFIAnalysis(MCContext &Context, MCInstrInfo const &MCII)
+      : Context(Context), MCII(MCII) {}
+
+  void update(const MCDwarfFrameInfo &DwarfFrame, const MCInst &Inst,
+              ArrayRef<MCCFIInstruction> CFIDirectives) {
+    dbgs() << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
+    printUntilNextLine(Inst.getLoc().getPointer());
+    dbgs() << "\n";
+    dbgs() << "codes: ";
+    Inst.print(dbgs());
+    dbgs() << "\n";
+    dbgs() << "------------------------------\n";
+    auto *RI = Context.getRegisterInfo();
+    auto CFAReg = RI->getLLVMRegNum(DwarfFrame.CurrentCfaRegister, false);
+    dbgs() << "The CFA register is: " << CFAReg << "\n";
+    bool GoingToChangeCFA = false;
+    for (auto CFIDirective : CFIDirectives) {
+      auto Op = CFIDirective.getOperation();
+      GoingToChangeCFA |= (Op == MCCFIInstruction::OpDefCfa ||
+                           Op == MCCFIInstruction::OpDefCfaOffset ||
+                           Op == MCCFIInstruction::OpDefCfaRegister ||
+                           Op == MCCFIInstruction::OpAdjustCfaOffset ||
+                           Op == MCCFIInstruction::OpLLVMDefAspaceCfa);
+    }
+    dbgs() << "------------------------------\n";
+    bool ChangedCFA = false;
+    for (int I = 0; I < Inst.getNumOperands(); I++) {
+      auto &&Operand = Inst.getOperand(I);
+      if (!Operand.isReg())
+        continue;
+      if (MCII.get(Inst.getOpcode())
+              .hasDefOfPhysReg(Inst, Operand.getReg(), *RI)) {
+        dbgs() << "This instruction modifies: " << Operand.getReg().id()
+               << "\n";
+        if (Operand.getReg() == CFAReg.value())
+          ChangedCFA = true;
+      }
+    }
+    dbgs() << "------------------------------\n";
+    dbgs() << "The instruction DOES " << (ChangedCFA ? "" : "NOT ")
+           << "change the CFA.\n";
+    dbgs() << "The CFI directives DOES " << (GoingToChangeCFA ? "" : "NOT ")
+           << "change the CFA.\n";
+    if (ChangedCFA && !GoingToChangeCFA) {
+      Context.reportError(Inst.getLoc(),
+                          "The instruction changes CFA register value, but the "
+                          "CFI directives don't update the CFA.");
+    }
+    // TODO needs more work
+    // if (!ChangedCFA && GoingToChangeCFA) {
+    //   Context.reportError(
+    //       Inst.getLoc(),
+    //       "The instruction doesn't change CFA register value, but the "
+    //       "CFI directives update the CFA.");
+    // }
+    dbgs() << "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n";
+    ChangedCFA = false;
+  }
+};
+
+} // namespace llvm
+#endif

--- a/llvm/tools/llvm-mc/CFIAnalysis.h
+++ b/llvm/tools/llvm-mc/CFIAnalysis.h
@@ -50,7 +50,7 @@ public:
     }
     dbgs() << "------------------------------\n";
     bool ChangedCFA = false;
-    for (int I = 0; I < Inst.getNumOperands(); I++) {
+    for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
       auto &&Operand = Inst.getOperand(I);
       if (!Operand.isReg())
         continue;

--- a/llvm/tools/llvm-mc/CFIAnalysis.h
+++ b/llvm/tools/llvm-mc/CFIAnalysis.h
@@ -1,10 +1,12 @@
 #ifndef LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_H
 #define LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_H
 
+#include "CFIState.h"
 #include "bolt/Core/MCPlusBuilder.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCExpr.h"
@@ -17,6 +19,8 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <set>
@@ -51,51 +55,196 @@ class CFIAnalysis {
   MCContext &Context;
   MCInstrInfo const &MCII;
   std::unique_ptr<bolt::MCPlusBuilder> MCPB;
+  MCRegisterInfo const *MCRI;
+  CFIState State;
 
 public:
   CFIAnalysis(MCContext &Context, MCInstrInfo const &MCII,
               MCInstrAnalysis *MCIA)
-      : Context(Context), MCII(MCII) {
-    // TODO it should look at the poluge directives and setup the
+      : Context(Context), MCII(MCII), MCRI(Context.getRegisterInfo()) {
+    // TODO it should look at the prologue directives and setup the
     // registers' previous value state here, but for now, it's assumed that all
     // values are by default `samevalue`.
     MCPB.reset(createMCPlusBuilder(Context.getTargetTriple().getArch(), MCIA,
                                    &MCII, Context.getRegisterInfo(),
                                    Context.getSubtargetInfo()));
+
+    // TODO CFA offset should be the slot size, but for now I don't have any
+    // access to it, maybe can be read from the prologue
+    // TODO check what should be passed as EH?
+    State = CFIState(MCRI->getDwarfRegNum(MCPB->getStackPointer(), false), 8);
+    for (unsigned I = 0; I < MCRI->getNumRegs(); I++) {
+      DWARFRegType DwarfI = MCRI->getDwarfRegNum(I, false);
+      State.RegisterCFIStates[DwarfI] = RegisterCFIState::createSameValue();
+    }
+
+    // TODO these are temporay added to make things work.
+    // Setup the basic information:
+    State.RegisterCFIStates[MCRI->getDwarfRegNum(MCRI->getProgramCounter(),
+                                                 false)] =
+        RegisterCFIState::createUndefined(); // For now, we don't care about the
+                                             // PC
+    State.RegisterCFIStates[MCRI->getDwarfRegNum(MCPB->getStackPointer(),
+                                                 false)] =
+        RegisterCFIState::createOffsetFromCFAVal(0); // sp's old value is CFA
+  }
+
+  bool doesConstantChange(const MCInst &Inst, MCPhysReg Reg, int64_t &HowMuch) {
+    if (MCPB->isPush(Inst) && Reg == MCPB->getStackPointer()) {
+      // TODO should get the stack direction here, now it assumes that it goes
+      // down.
+      HowMuch = -MCPB->getPushSize(Inst);
+      return true;
+    }
+
+    if (MCPB->isPop(Inst) && Reg == MCPB->getStackPointer()) {
+      // TODO should get the stack direction here, now it assumes that it goes
+      // down.
+      HowMuch = MCPB->getPushSize(Inst);
+      return true;
+    }
+
+    return false;
+  }
+
+  // Tries to guess Reg1's value in a form of Reg2 (before Inst's execution) +
+  // Diff.
+  bool isInConstantDistanceOfEachOther(const MCInst &Inst, MCPhysReg Reg1,
+                                       MCPhysReg Reg2, int &Diff) {
+    {
+      MCPhysReg From;
+      MCPhysReg To;
+      if (MCPB->isRegToRegMove(Inst, From, To) && From == Reg2 && To == Reg1) {
+        Diff = 0;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  void checkCFADiff(const MCInst &Inst, const CFIState &PrevState,
+                    const CFIState &NextState,
+                    const std::set<DWARFRegType> &Reads,
+                    const std::set<DWARFRegType> &Writes) {
+    if (PrevState.CFARegister == NextState.CFARegister) {
+      if (PrevState.CFAOffset == NextState.CFAOffset) {
+        if (Writes.count(PrevState.CFARegister)) {
+          Context.reportWarning(
+              Inst.getLoc(),
+              formatv("This instruction changes reg#{0}, which is "
+                      "the CFA register, but the CFI directives do not.",
+                      MCRI->getLLVMRegNum(PrevState.CFARegister, false)));
+        }
+        return;
+      }
+      // The offset is changed.
+      if (!Writes.count(PrevState.CFARegister)) {
+        Context.reportWarning(
+            Inst.getLoc(),
+            formatv(
+                "You changed the CFA offset, but there is no modification to "
+                "the CFA register happening in this instruction."));
+      }
+      int64_t HowMuch;
+      if (!doesConstantChange(
+              Inst, MCRI->getLLVMRegNum(PrevState.CFARegister, false).value(),
+              HowMuch)) {
+        Context.reportWarning(
+            Inst.getLoc(),
+            formatv("The CFA register changed, but I don't know how, finger "
+                    "crossed the CFI directives are correct."));
+        return;
+      }
+      // we know it is changed by HowMuch, so the CFA offset should be changed
+      // by -HowMuch, i.e. AfterState.Offset - State.Offset = -HowMuch
+      if (NextState.CFAOffset - PrevState.CFAOffset != -HowMuch) {
+        Context.reportError(
+            Inst.getLoc(),
+            formatv("The CFA offset is changed by {0}, but "
+                    "the directives changed it by {1}. (to be exact, the new "
+                    "offset should be {2}, but it is {3})",
+                    -HowMuch, NextState.CFAOffset - PrevState.CFAOffset,
+                    PrevState.CFAOffset - HowMuch, NextState.CFAOffset));
+        return;
+      }
+
+      // Everything OK!
+      return;
+    }
+    // The CFA register is changed.
+    // TODO move it up
+    MCPhysReg OldCFAReg = MCRI->getLLVMRegNum(PrevState.CFARegister, false).value();
+    MCPhysReg NewCFAReg =
+        MCRI->getLLVMRegNum(NextState.CFARegister, false).value();
+    if (!Writes.count(NextState.CFARegister)) {
+      Context.reportWarning(
+          Inst.getLoc(),
+          formatv(
+              "The new CFA register reg#{0}'s value is not assigned by this "
+              "instruction, try to move the new CFA def to where this "
+              "value is changed, now I can't infer if this change is "
+              "correct or not.",
+              NewCFAReg));
+      return;
+    }
+    // Because CFA should is the CFA always stays the same:
+    int OffsetDiff = PrevState.CFAOffset - NextState.CFAOffset;
+    int Diff;
+    if (!isInConstantDistanceOfEachOther(Inst, NewCFAReg, OldCFAReg, Diff)) {
+      Context.reportWarning(
+          Inst.getLoc(),
+          formatv("Based on this instruction I cannot infer that the new and "
+                  "old CFA registers are in {0} distance of each other. I "
+                  "hope it's ok.",
+                  OffsetDiff));
+      return;
+    }
+    if (Diff != OffsetDiff) {
+      Context.reportError(
+          Inst.getLoc(), formatv("After changing the CFA register, the CFA "
+                                 "offset should be {0}, but it is {1}.",
+                                 PrevState.CFAOffset - Diff, NextState.CFAOffset));
+      return;
+    }
+    // Everything is OK!
   }
 
   void update(const MCDwarfFrameInfo &DwarfFrame, MCInst &Inst,
-              ArrayRef<MCCFIInstruction> CFIDirectives) {
+              std::pair<unsigned, unsigned>
+                  CFIDirectivesRange) { // FIXME this should not be a pair,
+                                        // but an ArrayRef
+    ArrayRef<MCCFIInstruction> CFIDirectives(DwarfFrame.Instructions);
+    CFIDirectives = CFIDirectives.drop_front(CFIDirectivesRange.first)
+                        .drop_back(DwarfFrame.Instructions.size() -
+                                   CFIDirectivesRange.second);
 
     const MCInstrDesc &MCInstInfo = MCII.get(Inst.getOpcode());
-    auto *RI = Context.getRegisterInfo();
-    auto CFAReg = RI->getLLVMRegNum(DwarfFrame.CurrentCfaRegister, false);
+    CFIState AfterState(State);
+    for (auto &&CFIDirective : CFIDirectives)
+      if (!AfterState.apply(CFIDirective))
+        Context.reportWarning(
+            CFIDirective.getLoc(),
+            "I don't support this CFI directive, I assume this does nothing "
+            "(which will probably break other things)");
+    auto CFAReg = MCRI->getLLVMRegNum(DwarfFrame.CurrentCfaRegister, false);
+    assert(DwarfFrame.CurrentCfaRegister == AfterState.CFARegister &&
+           "Checking if the CFA tracking is working");
 
-    std::set<int> Writes, Reads; // TODO reads is not ready for now
-    // FIXME this way of extracting uses is buggy:
-    // for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++)
-    //   Reads.insert(MCInstInfo.implicit_uses()[I]);
+    std::set<DWARFRegType> Writes, Reads;
+    for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++)
+      Reads.insert(MCRI->getDwarfRegNum(MCInstInfo.implicit_uses()[I], false));
     for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++)
-      Writes.insert(MCInstInfo.implicit_defs()[I]);
+      Writes.insert(MCRI->getDwarfRegNum(MCInstInfo.implicit_defs()[I], false));
 
     for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
       auto &&Operand = Inst.getOperand(I);
       if (Operand.isReg()) {
-        // TODO it is not percise, maybe this operand is for output, then it
-        // means that there is no read happening here.
-        Reads.insert(Operand.getReg());
+        if (I < MCInstInfo.getNumDefs())
+          Writes.insert(MCRI->getDwarfRegNum(Operand.getReg(), false));
+        else
+          Reads.insert(MCRI->getDwarfRegNum(Operand.getReg(), false));
       }
-
-      if (Operand.isExpr()) {
-        // TODO maybe the argument is not a register, but is a expression like
-        // `34(sp)` that has a register in it. Check if this works or not and if
-        // no change it somehow that it count that register as reads or writes
-        // too.
-      }
-
-      if (Operand.isReg() &&
-          MCInstInfo.hasDefOfPhysReg(Inst, Operand.getReg(), *RI))
-        Writes.insert(Operand.getReg().id());
     }
 
     bool ChangedCFA = Writes.count(CFAReg->id());
@@ -114,132 +263,137 @@ public:
                           "CFI directives don't update the CFA.");
     }
 
-    dbgs() << "^^^^^^^^^^^^^^^^ InsCFIs ^^^^^^^^^^^^^^^^\n";
-    printUntilNextLine(Inst.getLoc().getPointer());
-    dbgs() << "\n";
-    dbgs() << "Op code: " << Inst.getOpcode() << "\n";
-    dbgs() << "--------------Operands Info--------------\n";
-    auto DefCount = MCInstInfo.getNumDefs();
-    for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
-      dbgs() << "Operand #" << I << ", which will be "
-             << (I < DefCount ? "defined" : "used") << ", is a";
-      if (I == MCPB->getMemoryOperandNo(Inst)) {
-        dbgs() << " memory access, details are:\n";
-        auto X86MemoryOperand = MCPB->evaluateX86MemoryOperand(Inst);
-        dbgs() << "  Base Register{ reg#" << X86MemoryOperand->BaseRegNum
-               << " }";
-        dbgs() << " + (Index Register{ reg#" << X86MemoryOperand->IndexRegNum
-               << " }";
-        dbgs() << " * Scale{ value " << X86MemoryOperand->ScaleImm << " }";
-        dbgs() << ") + Displacement{ "
-               << (X86MemoryOperand->DispExpr
-                       ? "an expression"
-                       : "value " + itostr(X86MemoryOperand->DispImm))
-               << " }\n";
-        // TODO, it's not correct always, it cannot be assumed (or should be
-        // checked) that memory operands are flatten into 4 operands in MCInc.
-        I += 4;
-        continue;
-      }
-      auto &&Operand = Inst.getOperand(I);
-      if (Operand.isImm()) {
-        dbgs() << "n immediate with value " << Operand.getImm() << "\n";
-        continue;
-      }
-      if (Operand.isReg()) {
-        dbgs() << " reg#" << Operand.getReg() << "\n";
-        continue;
-      }
-      assert(Operand.isExpr());
-      dbgs() << "n unknown expression \n";
-    }
-    if (MCInstInfo.NumImplicitDefs) {
-      dbgs() << "implicitly defines: { ";
-      for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++) {
-        dbgs() << "reg#" << MCInstInfo.implicit_defs()[I] << " ";
-      }
-      dbgs() << "}\n";
-    }
-    if (MCInstInfo.NumImplicitUses) {
-      dbgs() << "implicitly uses: { ";
-      for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++) {
-        dbgs() << "reg#" << MCInstInfo.implicit_uses()[I] << " ";
-      }
-      dbgs() << "}\n";
-    }
-    dbgs() << "----------------Move Info----------------\n";
-    {   // move
-      { // Reg2Reg
-        MCPhysReg From, To;
-        if (MCPB->isRegToRegMove(Inst, From, To)) {
-          dbgs() << "It's a reg to reg move.\nFrom reg#" << From << " to reg#"
-                 << To << "\n";
-        } else if (MCInstInfo.isMoveReg()) {
-          dbgs() << "It's reg to reg move from MCInstInfo view but not from "
-                    "MCPlus view.\n";
-        }
-      }
-      if (MCPB->isConditionalMove(Inst)) {
-        dbgs() << "Its a conditional move.\n";
-      }
-      if (MCPB->isMoveMem2Reg(Inst)) {
-        dbgs() << "It's a move from memory to register\n";
-        assert(MCPB->getMemoryOperandNo(Inst) == 1);
-      }
-    }
+    ///////////// being diffing the CFI states
+    checkCFADiff(Inst, State, AfterState, Reads, Writes);
+    ///////////// end diffing the CFI states
 
-    dbgs() << "---------------Stack Info----------------\n";
-    { // stack
-      int32_t SrcImm = 0;
-      MCPhysReg Reg = 0;
-      uint16_t StackPtrReg = 0;
-      int64_t StackOffset = 0;
-      uint8_t Size = 0;
-      bool IsSimple = false;
-      bool IsIndexed = false;
-      bool IsLoad = false;
-      bool IsStore = false;
-      bool IsStoreFromReg = false;
-      if (MCPB->isStackAccess(Inst, IsLoad, IsStore, IsStoreFromReg, Reg,
-                              SrcImm, StackPtrReg, StackOffset, Size, IsSimple,
-                              IsIndexed)) {
-        dbgs() << "This instruction accesses the stack, the details are:\n";
-        dbgs() << "  Source immediate: " << SrcImm << "\n";
-        dbgs() << "  Source reg#" << Reg << "\n";
-        dbgs() << "  Stack pointer: reg#" << StackPtrReg << "\n";
-        dbgs() << "  Stack offset: " << StackOffset << "\n";
-        dbgs() << "  size: " << (int)Size << "\n";
-        dbgs() << "  Is simple: " << (IsSimple ? "yes" : "no") << "\n";
-        dbgs() << "  Is indexed: " << (IsIndexed ? "yes" : "no") << "\n";
-        dbgs() << "  Is load: " << (IsLoad ? "yes" : "no") << "\n";
-        dbgs() << "  Is store: " << (IsStore ? "yes" : "no") << "\n";
-        dbgs() << "  Is store from reg: " << (IsStoreFromReg ? "yes" : "no")
-               << "\n";
-      }
-      if (MCPB->isPush(Inst)) {
-        dbgs() << "This is a push instruction with size "
-               << MCPB->getPushSize(Inst) << "\n";
-      }
-      if (MCPB->isPop(Inst)) {
-        dbgs() << "This is a pop instruction with size "
-               << MCPB->getPopSize(Inst) << "\n";
-      }
-    }
+    // dbgs() << "^^^^^^^^^^^^^^^^ InsCFIs ^^^^^^^^^^^^^^^^\n";
+    // printUntilNextLine(Inst.getLoc().getPointer());
+    // dbgs() << "\n";
+    // dbgs() << "Op code: " << Inst.getOpcode() << "\n";
+    // dbgs() << "--------------Operands Info--------------\n";
+    // auto DefCount = MCInstInfo.getNumDefs();
+    // for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
+    //   dbgs() << "Operand #" << I << ", which will be "
+    //          << (I < DefCount ? "defined" : "used") << ", is a";
+    //   if (I == MCPB->getMemoryOperandNo(Inst)) {
+    //     dbgs() << " memory access, details are:\n";
+    //     auto X86MemoryOperand = MCPB->evaluateX86MemoryOperand(Inst);
+    //     dbgs() << "  Base Register{ reg#" << X86MemoryOperand->BaseRegNum
+    //            << " }";
+    //     dbgs() << " + (Index Register{ reg#" << X86MemoryOperand->IndexRegNum
+    //            << " }";
+    //     dbgs() << " * Scale{ value " << X86MemoryOperand->ScaleImm << " }";
+    //     dbgs() << ") + Displacement{ "
+    //            << (X86MemoryOperand->DispExpr
+    //                    ? "an expression"
+    //                    : "value " + itostr(X86MemoryOperand->DispImm))
+    //            << " }\n";
+    //     // TODO, it's not correct always, it cannot be assumed (or should be
+    //     // checked) that memory operands are flatten into 4 operands in
+    //     MCInc. I += 4; continue;
+    //   }
+    //   auto &&Operand = Inst.getOperand(I);
+    //   if (Operand.isImm()) {
+    //     dbgs() << "n immediate with value " << Operand.getImm() << "\n";
+    //     continue;
+    //   }
+    //   if (Operand.isReg()) {
+    //     dbgs() << " reg#" << Operand.getReg() << "\n";
+    //     continue;
+    //   }
+    //   assert(Operand.isExpr());
+    //   dbgs() << "n unknown expression \n";
+    // }
+    // if (MCInstInfo.NumImplicitDefs) {
+    //   dbgs() << "implicitly defines: { ";
+    //   for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++) {
+    //     dbgs() << "reg#" << MCInstInfo.implicit_defs()[I] << " ";
+    //   }
+    //   dbgs() << "}\n";
+    // }
+    // if (MCInstInfo.NumImplicitUses) {
+    //   dbgs() << "implicitly uses: { ";
+    //   for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++) {
+    //     dbgs() << "reg#" << MCInstInfo.implicit_uses()[I] << " ";
+    //   }
+    //   dbgs() << "}\n";
+    // }
+    // dbgs() << "----------------Move Info----------------\n";
+    // {   // move
+    //   { // Reg2Reg
+    //     MCPhysReg From, To;
+    //     if (MCPB->isRegToRegMove(Inst, From, To)) {
+    //       dbgs() << "It's a reg to reg move.\nFrom reg#" << From << " to
+    //       reg#"
+    //              << To << "\n";
+    //     } else if (MCInstInfo.isMoveReg()) {
+    //       dbgs() << "It's reg to reg move from MCInstInfo view but not from "
+    //                 "MCPlus view.\n";
+    //     }
+    //   }
+    //   if (MCPB->isConditionalMove(Inst)) {
+    //     dbgs() << "Its a conditional move.\n";
+    //   }
+    //   if (MCPB->isMoveMem2Reg(Inst)) {
+    //     dbgs() << "It's a move from memory to register\n";
+    //     assert(MCPB->getMemoryOperandNo(Inst) == 1);
+    //   }
+    // }
 
-    dbgs() << "---------------Arith Info----------------\n";
-    { // arith
-      MutableArrayRef<MCInst> MAR = {Inst};
-      if (MCPB->matchAdd(MCPB->matchAnyOperand(), MCPB->matchAnyOperand())
-              ->match(*RI, *MCPB, MutableArrayRef<MCInst>(), -1)) {
-        dbgs() << "It is an addition instruction.\n";
-      } else if (MCInstInfo.isAdd()) {
-        dbgs() << "It is an addition from MCInstInfo view but not from MCPlus "
-                  "view.\n";
-      }
-      if (MCPB->isSUB(Inst)) {
-        dbgs() << "This is a subtraction.\n";
-      }
-    }
+    // dbgs() << "---------------Stack Info----------------\n";
+    // { // stack
+    //   int32_t SrcImm = 0;
+    //   MCPhysReg Reg = 0;
+    //   uint16_t StackPtrReg = 0;
+    //   int64_t StackOffset = 0;
+    //   uint8_t Size = 0;
+    //   bool IsSimple = false;
+    //   bool IsIndexed = false;
+    //   bool IsLoad = false;
+    //   bool IsStore = false;
+    //   bool IsStoreFromReg = false;
+    //   if (MCPB->isStackAccess(Inst, IsLoad, IsStore, IsStoreFromReg, Reg,
+    //                           SrcImm, StackPtrReg, StackOffset, Size,
+    //                           IsSimple, IsIndexed)) {
+    //     dbgs() << "This instruction accesses the stack, the details are:\n";
+    //     dbgs() << "  Source immediate: " << SrcImm << "\n";
+    //     dbgs() << "  Source reg#" << Reg << "\n";
+    //     dbgs() << "  Stack pointer: reg#" << StackPtrReg << "\n";
+    //     dbgs() << "  Stack offset: " << StackOffset << "\n";
+    //     dbgs() << "  size: " << (int)Size << "\n";
+    //     dbgs() << "  Is simple: " << (IsSimple ? "yes" : "no") << "\n";
+    //     dbgs() << "  Is indexed: " << (IsIndexed ? "yes" : "no") << "\n";
+    //     dbgs() << "  Is load: " << (IsLoad ? "yes" : "no") << "\n";
+    //     dbgs() << "  Is store: " << (IsStore ? "yes" : "no") << "\n";
+    //     dbgs() << "  Is store from reg: " << (IsStoreFromReg ? "yes" : "no")
+    //            << "\n";
+    //   }
+    //   if (MCPB->isPush(Inst)) {
+    //     dbgs() << "This is a push instruction with size "
+    //            << MCPB->getPushSize(Inst) << "\n";
+    //   }
+    //   if (MCPB->isPop(Inst)) {
+    //     dbgs() << "This is a pop instruction with size "
+    //            << MCPB->getPopSize(Inst) << "\n";
+    //   }
+    // }
+
+    // dbgs() << "---------------Arith Info----------------\n";
+    // { // arith
+    //   MutableArrayRef<MCInst> MAR = {Inst};
+    //   if (MCPB->matchAdd(MCPB->matchAnyOperand(), MCPB->matchAnyOperand())
+    //           ->match(*MCRI, *MCPB, MutableArrayRef<MCInst>(), -1)) {
+    //     dbgs() << "It is an addition instruction.\n";
+    //   } else if (MCInstInfo.isAdd()) {
+    //     dbgs() << "It is an addition from MCInstInfo view but not from MCPlus
+    //     "
+    //               "view.\n";
+    //   }
+    //   if (MCPB->isSUB(Inst)) {
+    //     dbgs() << "This is a subtraction.\n";
+    //   }
+    // }
 
     // dbgs() << "-----------------------------------------\n";
     // dbgs() << "The CFA register is: " << CFAReg << "\n";
@@ -247,9 +401,12 @@ public:
     //        << "change the CFA.\n";
     // dbgs() << "The CFI directives does " << (GoingToChangeCFA ? "" : "NOT ")
     //        << "change the CFA.\n";
-    dbgs() << "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n";
-    ChangedCFA = false;
+    // dbgs() << "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n";
+
+    State = AfterState;
   }
+
+private:
 };
 
 } // namespace llvm

--- a/llvm/tools/llvm-mc/CFIAnalysis.h
+++ b/llvm/tools/llvm-mc/CFIAnalysis.h
@@ -4,17 +4,21 @@
 #include "bolt/Core/MCPlusBuilder.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Error.h"
 #include <memory>
+#include <optional>
 #include <set>
 
 namespace llvm {
@@ -60,7 +64,7 @@ public:
                                    Context.getSubtargetInfo()));
   }
 
-  void update(const MCDwarfFrameInfo &DwarfFrame, const MCInst &Inst,
+  void update(const MCDwarfFrameInfo &DwarfFrame, MCInst &Inst,
               ArrayRef<MCCFIInstruction> CFIDirectives) {
 
     const MCInstrDesc &MCInstInfo = MCII.get(Inst.getOpcode());
@@ -71,8 +75,8 @@ public:
     // FIXME this way of extracting uses is buggy:
     // for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++)
     //   Reads.insert(MCInstInfo.implicit_uses()[I]);
-    // for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++)
-    //   Writes.insert(MCInstInfo.implicit_defs()[I]);
+    for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++)
+      Writes.insert(MCInstInfo.implicit_defs()[I]);
 
     for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
       auto &&Operand = Inst.getOperand(I);
@@ -113,20 +117,136 @@ public:
     dbgs() << "^^^^^^^^^^^^^^^^ InsCFIs ^^^^^^^^^^^^^^^^\n";
     printUntilNextLine(Inst.getLoc().getPointer());
     dbgs() << "\n";
-    dbgs() << "-----------------------------------------\n";
-    dbgs() << "writes into: { ";
-    for (auto Reg : Writes) {
-      dbgs() << (int)Reg << " ";
+    dbgs() << "Op code: " << Inst.getOpcode() << "\n";
+    dbgs() << "--------------Operands Info--------------\n";
+    auto DefCount = MCInstInfo.getNumDefs();
+    for (unsigned I = 0; I < Inst.getNumOperands(); I++) {
+      dbgs() << "Operand #" << I << ", which will be "
+             << (I < DefCount ? "defined" : "used") << ", is a";
+      if (I == MCPB->getMemoryOperandNo(Inst)) {
+        dbgs() << " memory access, details are:\n";
+        auto X86MemoryOperand = MCPB->evaluateX86MemoryOperand(Inst);
+        dbgs() << "  Base Register{ reg#" << X86MemoryOperand->BaseRegNum
+               << " }";
+        dbgs() << " + (Index Register{ reg#" << X86MemoryOperand->IndexRegNum
+               << " }";
+        dbgs() << " * Scale{ value " << X86MemoryOperand->ScaleImm << " }";
+        dbgs() << ") + Displacement{ "
+               << (X86MemoryOperand->DispExpr
+                       ? "an expression"
+                       : "value " + itostr(X86MemoryOperand->DispImm))
+               << " }\n";
+        // TODO, it's not correct always, it cannot be assumed (or should be
+        // checked) that memory operands are flatten into 4 operands in MCInc.
+        I += 4;
+        continue;
+      }
+      auto &&Operand = Inst.getOperand(I);
+      if (Operand.isImm()) {
+        dbgs() << "n immediate with value " << Operand.getImm() << "\n";
+        continue;
+      }
+      if (Operand.isReg()) {
+        dbgs() << " reg#" << Operand.getReg() << "\n";
+        continue;
+      }
+      assert(Operand.isExpr());
+      dbgs() << "n unknown expression \n";
     }
-    dbgs() << "}\n";
-    dbgs() << "-----------------------------------------\n";
-    dbgs() << "isMoveMem2Reg: " << MCPB->isMoveMem2Reg(Inst) << "\n";
-    dbgs() << "-----------------------------------------\n";
-    dbgs() << "The CFA register is: " << CFAReg << "\n";
-    dbgs() << "The instruction does " << (ChangedCFA ? "" : "NOT ")
-           << "change the CFA.\n";
-    dbgs() << "The CFI directives does " << (GoingToChangeCFA ? "" : "NOT ")
-           << "change the CFA.\n";
+    if (MCInstInfo.NumImplicitDefs) {
+      dbgs() << "implicitly defines: { ";
+      for (unsigned I = 0; I < MCInstInfo.NumImplicitDefs; I++) {
+        dbgs() << "reg#" << MCInstInfo.implicit_defs()[I] << " ";
+      }
+      dbgs() << "}\n";
+    }
+    if (MCInstInfo.NumImplicitUses) {
+      dbgs() << "implicitly uses: { ";
+      for (unsigned I = 0; I < MCInstInfo.NumImplicitUses; I++) {
+        dbgs() << "reg#" << MCInstInfo.implicit_uses()[I] << " ";
+      }
+      dbgs() << "}\n";
+    }
+    dbgs() << "----------------Move Info----------------\n";
+    {   // move
+      { // Reg2Reg
+        MCPhysReg From, To;
+        if (MCPB->isRegToRegMove(Inst, From, To)) {
+          dbgs() << "It's a reg to reg move.\nFrom reg#" << From << " to reg#"
+                 << To << "\n";
+        } else if (MCInstInfo.isMoveReg()) {
+          dbgs() << "It's reg to reg move from MCInstInfo view but not from "
+                    "MCPlus view.\n";
+        }
+      }
+      if (MCPB->isConditionalMove(Inst)) {
+        dbgs() << "Its a conditional move.\n";
+      }
+      if (MCPB->isMoveMem2Reg(Inst)) {
+        dbgs() << "It's a move from memory to register\n";
+        assert(MCPB->getMemoryOperandNo(Inst) == 1);
+      }
+    }
+
+    dbgs() << "---------------Stack Info----------------\n";
+    { // stack
+      int32_t SrcImm = 0;
+      MCPhysReg Reg = 0;
+      uint16_t StackPtrReg = 0;
+      int64_t StackOffset = 0;
+      uint8_t Size = 0;
+      bool IsSimple = false;
+      bool IsIndexed = false;
+      bool IsLoad = false;
+      bool IsStore = false;
+      bool IsStoreFromReg = false;
+      if (MCPB->isStackAccess(Inst, IsLoad, IsStore, IsStoreFromReg, Reg,
+                              SrcImm, StackPtrReg, StackOffset, Size, IsSimple,
+                              IsIndexed)) {
+        dbgs() << "This instruction accesses the stack, the details are:\n";
+        dbgs() << "  Source immediate: " << SrcImm << "\n";
+        dbgs() << "  Source reg#" << Reg << "\n";
+        dbgs() << "  Stack pointer: reg#" << StackPtrReg << "\n";
+        dbgs() << "  Stack offset: " << StackOffset << "\n";
+        dbgs() << "  size: " << (int)Size << "\n";
+        dbgs() << "  Is simple: " << (IsSimple ? "yes" : "no") << "\n";
+        dbgs() << "  Is indexed: " << (IsIndexed ? "yes" : "no") << "\n";
+        dbgs() << "  Is load: " << (IsLoad ? "yes" : "no") << "\n";
+        dbgs() << "  Is store: " << (IsStore ? "yes" : "no") << "\n";
+        dbgs() << "  Is store from reg: " << (IsStoreFromReg ? "yes" : "no")
+               << "\n";
+      }
+      if (MCPB->isPush(Inst)) {
+        dbgs() << "This is a push instruction with size "
+               << MCPB->getPushSize(Inst) << "\n";
+      }
+      if (MCPB->isPop(Inst)) {
+        dbgs() << "This is a pop instruction with size "
+               << MCPB->getPopSize(Inst) << "\n";
+      }
+    }
+
+    dbgs() << "---------------Arith Info----------------\n";
+    { // arith
+      MutableArrayRef<MCInst> MAR = {Inst};
+      if (MCPB->matchAdd(MCPB->matchAnyOperand(), MCPB->matchAnyOperand())
+              ->match(*RI, *MCPB, MutableArrayRef<MCInst>(), -1)) {
+        dbgs() << "It is an addition instruction.\n";
+      } else if (MCInstInfo.isAdd()) {
+        dbgs() << "It is an addition from MCInstInfo view but not from MCPlus "
+                  "view.\n";
+      }
+      if (MCPB->isSUB(Inst)) {
+        dbgs() << "This is a subtraction.\n";
+      }
+    }
+
+    // dbgs() << "-----------------------------------------\n";
+    // dbgs() << "The CFA register is: " << CFAReg << "\n";
+    // dbgs() << "The instruction does " << (ChangedCFA ? "" : "NOT ")
+    //        << "change the CFA.\n";
+    // dbgs() << "The CFI directives does " << (GoingToChangeCFA ? "" : "NOT ")
+    //        << "change the CFA.\n";
     dbgs() << "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv\n";
     ChangedCFA = false;
   }

--- a/llvm/tools/llvm-mc/CFIAnalysisMCStreamer.h
+++ b/llvm/tools/llvm-mc/CFIAnalysisMCStreamer.h
@@ -1,0 +1,151 @@
+#ifndef LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_MC_STREAMER_H
+#define LLVM_TOOLS_LLVM_MC_CFI_ANALYSIS_MC_STREAMER_H
+
+#include "CFIAnalysis.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/Debug.h"
+#include <cstdio>
+#include <optional>
+#include <set>
+
+namespace llvm {
+
+class CFIAnalysisMCStreamer : public MCStreamer {
+  struct CFIDirectivesState {
+    int FrameIndex; // TODO remove it, no need for it
+    int DirectiveIndex;
+
+    CFIDirectivesState() : FrameIndex(-1), DirectiveIndex(0) {}
+
+    CFIDirectivesState(int FrameIndex, int InstructionIndex)
+        : FrameIndex(FrameIndex), DirectiveIndex(InstructionIndex) {}
+  } LastCFIDirectivesState;
+  std::vector<int> FrameIndices;
+
+  struct ICFI {
+    MCInst Instruction;
+    ArrayRef<MCCFIInstruction> CFIDirectives;
+
+    ICFI(MCInst Instruction, ArrayRef<MCCFIInstruction> CFIDirectives)
+        : Instruction(Instruction), CFIDirectives(CFIDirectives) {}
+  };
+
+  std::optional<MCInst> LastInstruction;
+  std::optional<MCDwarfFrameInfo> LastDwarfFrameInfo;
+  CFIAnalysis CFIA;
+
+  std::optional<ICFI> getLastICFI() {
+    if (!LastInstruction)
+      return std::nullopt;
+
+    auto DwarfFrameInfos = getDwarfFrameInfos();
+    int FrameIndex = FrameIndices.back();
+    auto CurrentCFIDirectiveState =
+        hasUnfinishedDwarfFrameInfo()
+            ? CFIDirectivesState(
+                  FrameIndex, DwarfFrameInfos[FrameIndex].Instructions.size())
+            : CFIDirectivesState();
+    assert(CurrentCFIDirectiveState.FrameIndex ==
+           LastCFIDirectivesState.FrameIndex);
+    assert(CurrentCFIDirectiveState.DirectiveIndex >=
+           LastCFIDirectivesState.DirectiveIndex);
+
+    std::vector<MCCFIInstruction> CFIDirectives;
+    if (LastCFIDirectivesState.FrameIndex >= 0) {
+      auto CFIInstructions = DwarfFrameInfos[FrameIndex].Instructions;
+      CFIDirectives = std::vector<MCCFIInstruction>(
+          CFIInstructions.begin() + LastCFIDirectivesState.DirectiveIndex,
+          CFIInstructions.begin() + CurrentCFIDirectiveState.DirectiveIndex);
+    }
+
+    LastCFIDirectivesState = CurrentCFIDirectiveState;
+    return ICFI(LastInstruction.value(), CFIDirectives);
+  }
+
+  void feedCFIA() {
+    if (!LastDwarfFrameInfo) {
+      // TODO Maybe this corner case causes bugs, when the programmer did a
+      // mistake in the startproc, endprocs and also made a mistake in not
+      // adding cfi directives for a instruction. Then this would cause to
+      // ignore the instruction.
+      auto LastICFI = getLastICFI();
+      assert(!LastICFI || LastICFI->CFIDirectives.empty());
+      return;
+    }
+
+    if (auto ICFI = getLastICFI())
+      CFIA.update(LastDwarfFrameInfo.value(), ICFI->Instruction,
+                  ICFI->CFIDirectives);
+  }
+
+public:
+  CFIAnalysisMCStreamer(MCContext &Context, const MCInstrInfo &MCII)
+      : MCStreamer(Context), LastCFIDirectivesState(),
+        LastInstruction(std::nullopt), CFIA(Context, MCII) {
+    FrameIndices.push_back(-1);
+  }
+
+  /// @name MCStreamer Interface
+  /// @{
+
+  bool hasRawTextSupport() const override { return true; }
+  void emitRawTextImpl(StringRef String) override {}
+
+  bool emitSymbolAttribute(MCSymbol *Symbol, MCSymbolAttr Attribute) override {
+    return true;
+  }
+
+  void emitCommonSymbol(MCSymbol *Symbol, uint64_t Size,
+                        Align ByteAlignment) override {}
+  void beginCOFFSymbolDef(const MCSymbol *Symbol) override {}
+  void emitCOFFSymbolStorageClass(int StorageClass) override {}
+  void emitCOFFSymbolType(int Type) override {}
+  void endCOFFSymbolDef() override {}
+  void emitXCOFFSymbolLinkageWithVisibility(MCSymbol *Symbol,
+                                            MCSymbolAttr Linkage,
+                                            MCSymbolAttr Visibility) override {}
+
+  void emitInstruction(const MCInst &Inst,
+                       const MCSubtargetInfo &STI) override {
+    feedCFIA();
+    LastInstruction = Inst;
+    if (hasUnfinishedDwarfFrameInfo())
+      LastDwarfFrameInfo = getDwarfFrameInfos()[FrameIndices.back()];
+    else
+      LastDwarfFrameInfo = std::nullopt;
+  }
+
+  void emitCFIStartProcImpl(MCDwarfFrameInfo &Frame) override {
+    feedCFIA();
+    FrameIndices.push_back(getNumFrameInfos());
+    LastInstruction = std::nullopt;
+    LastDwarfFrameInfo = std::nullopt;
+    LastCFIDirectivesState.FrameIndex = FrameIndices.back();
+    LastCFIDirectivesState.DirectiveIndex = 0;
+    MCStreamer::emitCFIStartProcImpl(Frame);
+  }
+
+  void emitCFIEndProcImpl(MCDwarfFrameInfo &CurFrame) override {
+    feedCFIA();
+    // TODO this will break if the input frame are malformed.
+    FrameIndices.pop_back();
+    LastInstruction = std::nullopt;
+    LastDwarfFrameInfo = std::nullopt;
+    LastCFIDirectivesState.FrameIndex = FrameIndices.back();
+    LastCFIDirectivesState.DirectiveIndex =
+        LastCFIDirectivesState.FrameIndex >= 0
+            ? getDwarfFrameInfos()[LastCFIDirectivesState.FrameIndex]
+                  .Instructions.size()
+            : 0;
+    MCStreamer::emitCFIEndProcImpl(CurFrame);
+  }
+};
+
+} // namespace llvm
+#endif

--- a/llvm/tools/llvm-mc/CFIState.h
+++ b/llvm/tools/llvm-mc/CFIState.h
@@ -76,7 +76,7 @@ struct CFIState {
   DWARFRegType CFARegister;
   int CFAOffset;
 
-  CFIState() : CFARegister(-1 /* Change to to max unsigned */), CFAOffset(-1) {}
+  CFIState() : CFARegister(-1), CFAOffset(-1) {}
 
   CFIState(const CFIState &Other) {
     CFARegister = Other.CFARegister;
@@ -147,7 +147,7 @@ struct CFIState {
     case MCCFIInstruction::OpNegateRAStateWithPC:
     case MCCFIInstruction::OpGnuArgsSize:
     case MCCFIInstruction::OpLabel:
-      // TODO it's not supported.
+      // These instructions are not supported.
       return false;
       break;
     }

--- a/llvm/tools/llvm-mc/CFIState.h
+++ b/llvm/tools/llvm-mc/CFIState.h
@@ -2,11 +2,8 @@
 #define LLVM_TOOLS_LLVM_MC_CFI_STATE_H
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/StringRef.h"
 #include "llvm/MC/MCDwarf.h"
-#include "llvm/MC/MCRegister.h"
 #include "llvm/Support/FormatVariadic.h"
-#include "llvm/Support/MathExtras.h"
 #include <cassert>
 #include <cstdint>
 #include <optional>

--- a/llvm/tools/llvm-mc/CFIState.h
+++ b/llvm/tools/llvm-mc/CFIState.h
@@ -1,0 +1,160 @@
+#ifndef LLVM_TOOLS_LLVM_MC_CFI_STATE_H
+#define LLVM_TOOLS_LLVM_MC_CFI_STATE_H
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCRegister.h"
+#include "llvm/Support/MathExtras.h"
+#include <cstdint>
+namespace llvm {
+
+using DWARFRegType = int64_t;
+
+struct RegisterCFIState {
+  enum Approach {
+    Undefined,
+    SameValue,
+    AnotherRegister,
+    OffsetFromCFAAddr,
+    OffsetFromCFAVal,
+    Other,
+  } RetrieveApproach;
+
+  // TODO use a correct type for this.
+  union {
+    int OffsetFromCFA;
+    DWARFRegType Register;
+  } Info;
+
+  static RegisterCFIState createUndefined() {
+    RegisterCFIState State;
+    State.RetrieveApproach = Undefined;
+
+    return State;
+  }
+
+  static RegisterCFIState createSameValue() {
+    RegisterCFIState State;
+    State.RetrieveApproach = SameValue;
+
+    return State;
+  }
+
+  static RegisterCFIState createAnotherRegister(DWARFRegType Register) {
+    RegisterCFIState State;
+    State.RetrieveApproach = AnotherRegister;
+    State.Info.Register = Register;
+
+    return State;
+  }
+
+  static RegisterCFIState createOffsetFromCFAAddr(int OffsetFromCFA) {
+    RegisterCFIState State;
+    State.RetrieveApproach = OffsetFromCFAAddr;
+    State.Info.OffsetFromCFA = OffsetFromCFA;
+
+    return State;
+  }
+
+  static RegisterCFIState createOffsetFromCFAVal(int OffsetFromCFA) {
+    RegisterCFIState State;
+    State.RetrieveApproach = OffsetFromCFAVal;
+    State.Info.OffsetFromCFA = OffsetFromCFA;
+
+    return State;
+  }
+
+  static RegisterCFIState createOther() {
+    RegisterCFIState State;
+    State.RetrieveApproach = Other;
+
+    return State;
+  }
+};
+struct CFIState {
+  DenseMap<DWARFRegType, RegisterCFIState> RegisterCFIStates;
+  DWARFRegType CFARegister;
+  int CFAOffset;
+
+  CFIState() : CFARegister(-1 /* Change to to max unsigned */), CFAOffset(-1) {}
+
+  CFIState(const CFIState &Other) {
+    CFARegister = Other.CFARegister;
+    CFAOffset = Other.CFAOffset;
+    RegisterCFIStates = Other.RegisterCFIStates;
+  }
+
+  CFIState &operator=(const CFIState &Other) {
+    if (this != &Other) {
+      CFARegister = Other.CFARegister;
+      CFAOffset = Other.CFAOffset;
+      RegisterCFIStates = Other.RegisterCFIStates;
+    }
+
+    return *this;
+  }
+
+  CFIState(DWARFRegType CFARegister, int CFIOffset)
+      : CFARegister(CFARegister), CFAOffset(CFIOffset) {}
+
+  bool apply(const MCCFIInstruction &CFIDirective) {
+    switch (CFIDirective.getOperation()) {
+    case MCCFIInstruction::OpDefCfaRegister:
+      CFARegister = CFIDirective.getRegister();
+      break;
+    case MCCFIInstruction::OpDefCfaOffset:
+      CFAOffset = CFIDirective.getOffset();
+      break;
+    case MCCFIInstruction::OpAdjustCfaOffset:
+      CFAOffset += CFIDirective.getOffset();
+      break;
+    case MCCFIInstruction::OpDefCfa:
+      CFARegister = CFIDirective.getRegister();
+      CFAOffset = CFIDirective.getOffset();
+      break;
+    case MCCFIInstruction::OpOffset:
+      RegisterCFIStates[CFIDirective.getRegister()] =
+          RegisterCFIState::createOffsetFromCFAAddr(CFIDirective.getOffset());
+      break;
+    case MCCFIInstruction::OpRegister:
+      RegisterCFIStates[CFIDirective.getRegister()] =
+          RegisterCFIState::createAnotherRegister(CFIDirective.getRegister2());
+      break;
+    case MCCFIInstruction::OpRelOffset:
+      RegisterCFIStates[CFIDirective.getRegister()] =
+          RegisterCFIState::createOffsetFromCFAAddr(CFIDirective.getOffset() -
+                                                    CFAOffset);
+      break;
+    case MCCFIInstruction::OpUndefined:
+      RegisterCFIStates[CFIDirective.getRegister()] =
+          RegisterCFIState::createUndefined();
+      break;
+    case MCCFIInstruction::OpSameValue:
+      RegisterCFIStates[CFIDirective.getRegister()] =
+          RegisterCFIState::createSameValue();
+      break;
+    case MCCFIInstruction::OpValOffset:
+      RegisterCFIStates[CFIDirective.getRegister()] =
+          RegisterCFIState::createOffsetFromCFAVal(CFIDirective.getOffset());
+      break;
+    case MCCFIInstruction::OpRestoreState:
+    case MCCFIInstruction::OpRememberState:
+    case MCCFIInstruction::OpLLVMDefAspaceCfa:
+    case MCCFIInstruction::OpRestore:
+    case MCCFIInstruction::OpEscape:
+    case MCCFIInstruction::OpWindowSave:
+    case MCCFIInstruction::OpNegateRAState:
+    case MCCFIInstruction::OpNegateRAStateWithPC:
+    case MCCFIInstruction::OpGnuArgsSize:
+    case MCCFIInstruction::OpLabel:
+      // TODO it's not supported.
+      return false;
+      break;
+    }
+
+    return true;
+  }
+};
+} // namespace llvm
+
+#endif

--- a/llvm/tools/llvm-mc/CMakeLists.txt
+++ b/llvm/tools/llvm-mc/CMakeLists.txt
@@ -13,3 +13,6 @@ add_llvm_tool(llvm-mc
   llvm-mc.cpp
   Disassembler.cpp
   )
+
+target_link_libraries(llvm-mc PRIVATE LLVMBOLTCore LLVMBOLTTargetX86)
+target_include_directories(llvm-mc PRIVATE "${LLVM_MAIN_SRC_DIR}/../bolt/include")

--- a/llvm/tools/llvm-mc/ExtendedMCInstrAnalysis.h
+++ b/llvm/tools/llvm-mc/ExtendedMCInstrAnalysis.h
@@ -44,6 +44,7 @@ public:
   /// Extra semantic information needed from MC layer:
 
   MCPhysReg getStackPointer() const { return MCPB->getStackPointer(); }
+  MCPhysReg getFlagsReg() const { return MCPB->getFlagsReg(); }
 
   bool isPush(const MCInst &Inst) const { return MCPB->isPush(Inst); }
   int getPushSize(const MCInst &Inst) const { return MCPB->getPushSize(Inst); }

--- a/llvm/tools/llvm-mc/ExtendedMCInstrAnalysis.h
+++ b/llvm/tools/llvm-mc/ExtendedMCInstrAnalysis.h
@@ -1,0 +1,85 @@
+#ifndef LLVM_TOOLS_LLVM_MC_EXTENDED_MC_INSTR_ANALYSIS_H
+#define LLVM_TOOLS_LLVM_MC_EXTENDED_MC_INSTR_ANALYSIS_H
+
+#include "bolt/Core/MCPlusBuilder.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDwarf.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/TargetRegistry.h"
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+namespace llvm {
+
+class ExtendedMCInstrAnalysis {
+private:
+  std::unique_ptr<bolt::MCPlusBuilder> MCPB;
+
+  static bolt::MCPlusBuilder *
+  createMCPlusBuilder(const Triple::ArchType Arch,
+                      const MCInstrAnalysis *Analysis, const MCInstrInfo *Info,
+                      const MCRegisterInfo *RegInfo,
+                      const MCSubtargetInfo *STI) {
+    if (Arch == Triple::x86_64)
+      return bolt::createX86MCPlusBuilder(Analysis, Info, RegInfo, STI);
+
+    llvm_unreachable("architecture unsupported by ExtendedMCInstrAnalysis");
+  }
+
+public:
+  ExtendedMCInstrAnalysis(MCContext &Context, MCInstrInfo const &MCII,
+                          MCInstrAnalysis *MCIA) {
+    MCPB.reset(createMCPlusBuilder(Context.getTargetTriple().getArch(), MCIA,
+                                   &MCII, Context.getRegisterInfo(),
+                                   Context.getSubtargetInfo()));
+  }
+
+  /// Extra semantic information needed from MC layer:
+
+  MCPhysReg getStackPointer() const { return MCPB->getStackPointer(); }
+
+  bool isPush(const MCInst &Inst) const { return MCPB->isPush(Inst); }
+  int getPushSize(const MCInst &Inst) const { return MCPB->getPushSize(Inst); }
+
+  bool isPop(const MCInst &Inst) const { return MCPB->isPop(Inst); }
+  int getPopSize(const MCInst &Inst) const { return MCPB->getPopSize(Inst); }
+
+  bool isRegToRegMove(const MCInst &Inst, MCPhysReg &From,
+                      MCPhysReg &To) const {
+    return MCPB->isRegToRegMove(Inst, From, To);
+  }
+  bool isConditionalMove(const MCInst &Inst) const {
+    return MCPB->isConditionalMove(Inst);
+  }
+  bool isMoveMem2Reg(const MCInst &Inst) const {
+    return MCPB->isMoveMem2Reg(Inst);
+  }
+  bool isSUB(const MCInst &Inst) const { return MCPB->isSUB(Inst); }
+
+  int getMemoryOperandNo(const MCInst &Inst) const {
+    return MCPB->getMemoryOperandNo(Inst);
+  }
+  std::optional<bolt::MCPlusBuilder::X86MemOperand>
+  evaluateX86MemoryOperand(const MCInst &Inst) const {
+    return MCPB->evaluateX86MemoryOperand(Inst);
+  }
+  bool isStackAccess(const MCInst &Inst, bool &IsLoad, bool &IsStore,
+                     bool &IsStoreFromReg, MCPhysReg &Reg, int32_t &SrcImm,
+                     uint16_t &StackPtrReg, int64_t &StackOffset, uint8_t &Size,
+                     bool &IsSimple, bool &IsIndexed) const {
+    return MCPB->isStackAccess(Inst, IsLoad, IsStore, IsStoreFromReg, Reg,
+                               SrcImm, StackPtrReg, StackOffset, Size, IsSimple,
+                               IsIndexed);
+  }
+};
+
+} // namespace llvm
+
+#endif


### PR DESCRIPTION
In this [RFC](https://discourse.llvm.org/t/rfc-dwarf-cfi-validation/86936), the design behind this prototype is explained.

This prototype implements the full algorithm explained in the RFC, as opposed to the [current](https://github.com/llvm/llvm-project/pull/145633) DWARFCFIChecker in LLVM, which is only capable of implementing the invalidation part of the algorithm. 

The main difference is that this implementation has access to semantic information through BOLT `MCPlusBuilder`, which is an extension of `MCInstrAnalysis` providing the following information:
- `matches`, which can be used to see if an instruction is an `add`/`sub`/`multiple`/... and what the arguments are, are they const or registers.
- Helper functions for extracting load and storing memory address targets.
- And a lot more information about control flow.

Using this information, this implementation is capable of applying the abstract execution mentioned in the RFC properly.
Consider the following example:
```asm
pushq   %rdi # spill rdi
.cfi_adjust_cfa_offset 8
.cfi_rel_offset %rdi, 0
pushq   %rsi # spill rsi
.cfi_adjust_cfa_offset 8
.cfi_rel_offset %rsi, 0

callq some_func

popq    %rsi # load rsi
.cfi_adjust_cfa_offset -8
.cfi_same_value %rdi # prototype: error: loading %rdi from wrong location
popq    %rdi # spill rdi
# (landed and prototype) error: changed register RDI, that register RDI's unwinding rule uses, but there is no CFI directives about it
.cfi_adjust_cfa_offset -8
.cfi_same_value %rsi # prototype: error: loading %rsi from wrong location
``` 

In this example, two registers (`rdi` and `rsi`) are spilled but are loaded in reverse order.  The prototype can identify when `rdi` and `rsi` are loaded from incorrect memory locations, a capability not shared by the currently landed checker, which only detects modifications to `rdi`, with its unwinding rule set to `same_value`.

To fix the issue, we need to add more semantic information to `MCInst`. There are a couple of options proposed in the [RFC](https://discourse.llvm.org/t/rfc-dwarf-cfi-validation/86936). I recommend the first option as my personal choice, which is:
*Option 1: Extend MCInstrAnalysis with functionalities currently in BOLT’s MCPlus.*
The reason to choose this option is that it’s the only truly incremental option that has already been implemented, tested, and explored by BOLT.

  
