### PR TITLE
[lldb] Update JSONTransport to use MainLoop for reading.

### DIFF
--- a/lldb/include/lldb/Host/JSONTransport.h
+++ b/lldb/include/lldb/Host/JSONTransport.h
@@ -78,7 +78,7 @@ class JSONTransport {
 public:
   using ReadHandleUP = MainLoopBase::ReadHandleUP;
   template <typename T>
-  using Callback = std::function<void(MainLoopBase &, llvm::Expected<T>)>;
+  using Callback = std::function<void(MainLoopBase &, const llvm::Expected<T>)>;
 
   JSONTransport(lldb::IOObjectSP input, lldb::IOObjectSP output);
   virtual ~JSONTransport() = default;
@@ -98,7 +98,7 @@ public:
   /// Registers the transport with the MainLoop.
   template <typename T>
   llvm::Expected<ReadHandleUP> RegisterReadObject(MainLoopBase &loop,
-                                                  Callback<T> callback) {
+                                                  const Callback<T> &callback) {
     Status error;
     ReadHandleUP handle = loop.RegisterReadObject(
         m_input,
@@ -170,6 +170,7 @@ protected:
   static constexpr llvm::StringLiteral kHeaderContentLength = "Content-Length";
   static constexpr llvm::StringLiteral kHeaderFieldSeparator = ":";
   static constexpr llvm::StringLiteral kHeaderSeparator = "\r\n";
+  static constexpr llvm::StringLiteral kEndOfHeader = "\r\n\r\n";
 };
 
 /// A transport class for JSON RPC.

--- a/lldb/include/lldb/Host/JSONTransport.h
+++ b/lldb/include/lldb/Host/JSONTransport.h
@@ -123,7 +123,8 @@ public:
             else
               callback(loop, llvm::json::parse<T>(message));
 
-          // On EOF, request termination after handling all the messages.
+          // On EOF, notify the callback after the remaining messages were
+          // handled.
           if (len == 0)
             callback(loop, llvm::make_error<TransportEOFError>());
         },

--- a/lldb/include/lldb/Host/JSONTransport.h
+++ b/lldb/include/lldb/Host/JSONTransport.h
@@ -15,6 +15,7 @@
 
 #include "lldb/Host/MainLoopBase.h"
 #include "lldb/lldb-forward.h"
+#include "llvm/ADT/FunctionExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatVariadic.h"
@@ -78,7 +79,8 @@ class JSONTransport {
 public:
   using ReadHandleUP = MainLoopBase::ReadHandleUP;
   template <typename T>
-  using Callback = std::function<void(MainLoopBase &, const llvm::Expected<T>)>;
+  using Callback =
+      llvm::unique_function<void(MainLoopBase &, const llvm::Expected<T>)>;
 
   JSONTransport(lldb::IOObjectSP input, lldb::IOObjectSP output);
   virtual ~JSONTransport() = default;
@@ -98,7 +100,7 @@ public:
   /// Registers the transport with the MainLoop.
   template <typename T>
   llvm::Expected<ReadHandleUP> RegisterReadObject(MainLoopBase &loop,
-                                                  const Callback<T> &callback) {
+                                                  Callback<T> callback) {
     Status error;
     ReadHandleUP handle = loop.RegisterReadObject(
         m_input,

--- a/lldb/source/Host/common/JSONTransport.cpp
+++ b/lldb/source/Host/common/JSONTransport.cpp
@@ -59,12 +59,15 @@ Expected<std::vector<std::string>> HTTPDelimitedJSONTransport::Parse() {
       continue;
     }
 
-    // HTTP Headers are `<field-name>: [<field-value>]`.
+    // HTTP Headers are formatted like `<field-name> ':' [<field-value>]`.
     if (!header.contains(kHeaderFieldSeparator))
       return make_error<StringError>("malformed content header",
                                      inconvertibleErrorCode());
 
     auto [name, value] = header.split(kHeaderFieldSeparator);
+
+    // Handle known headers, at the moment only "Content-Length" is supported,
+    // other headers are ignored.
     if (name.lower() == kHeaderContentLength.lower()) {
       value = value.trim();
       if (value.trim().consumeInteger(10, content_length))

--- a/lldb/source/Host/common/JSONTransport.cpp
+++ b/lldb/source/Host/common/JSONTransport.cpp
@@ -36,11 +36,9 @@ Expected<std::vector<std::string>> HTTPDelimitedJSONTransport::Parse() {
   StringRef buffer = m_buffer;
   while (buffer.contains(kEndOfHeader)) {
     auto [headers, rest] = buffer.split(kEndOfHeader);
-    SmallVector<StringRef> kv_pairs;
-    // HTTP Headers are formatted like `<field-name> ':' [<field-value>]`.
-    headers.split(kv_pairs, kHeaderSeparator);
     size_t content_length = 0;
-    for (const auto &header : kv_pairs) {
+    // HTTP Headers are formatted like `<field-name> ':' [<field-value>]`.
+    for (const auto &header : llvm::split(headers, kHeaderSeparator)) {
       auto [key, value] = header.split(kHeaderFieldSeparator);
       // 'Content-Length' is the only meaningful key at the moment. Others are
       // ignored.

--- a/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
+++ b/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
@@ -48,18 +48,18 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
         lldb-dap handles invalid message headers.
         """
         process = self.launch()
-        process.stdin.write(b"not the corret message header")
+        process.stdin.write(b"not the correct message header")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 1)
+        self.assertEqual(process.wait(timeout=5.0), 0)
 
     def test_partial_header(self):
         """
-        lldb-dap handles parital message headers.
+        lldb-dap handles partial message headers.
         """
         process = self.launch()
         process.stdin.write(b"Content-Length: ")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 1)
+        self.assertEqual(process.wait(timeout=5.0), 0)
 
     def test_incorrect_content_length(self):
         """
@@ -68,7 +68,7 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
         process = self.launch()
         process.stdin.write(b"Content-Length: abc")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 1)
+        self.assertEqual(process.wait(timeout=5.0), 0)
 
     def test_partial_content_length(self):
         """
@@ -77,4 +77,4 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
         process = self.launch()
         process.stdin.write(b"Content-Length: 10\r\n\r\n{")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 1)
+        self.assertEqual(process.wait(timeout=5.0), 0)

--- a/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
+++ b/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
@@ -8,6 +8,9 @@ from lldbsuite.test.decorators import *
 import lldbdap_testcase
 import dap_server
 
+EXIT_FAILURE = 1
+EXIT_SUCCESS = 0
+
 
 class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
     def launch(self):
@@ -41,40 +44,44 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
         """
         process = self.launch()
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 0)
+        self.assertEqual(process.wait(timeout=5.0), EXIT_SUCCESS)
 
     def test_invalid_header(self):
         """
-        lldb-dap handles invalid message headers.
+        lldb-dap returns a failure exit code when the input stream is closed
+        with a malformed request header.
         """
         process = self.launch()
         process.stdin.write(b"not the correct message header")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 0)
+        self.assertEqual(process.wait(timeout=5.0), EXIT_FAILURE)
 
     def test_partial_header(self):
         """
-        lldb-dap handles partial message headers.
+        lldb-dap returns a failure exit code when the input stream is closed
+        with an incomplete message header is in the message buffer.
         """
         process = self.launch()
         process.stdin.write(b"Content-Length: ")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 0)
+        self.assertEqual(process.wait(timeout=5.0), EXIT_FAILURE)
 
     def test_incorrect_content_length(self):
         """
-        lldb-dap handles malformed content length headers.
+        lldb-dap returns a failure exit code when reading malformed content
+        length headers.
         """
         process = self.launch()
         process.stdin.write(b"Content-Length: abc")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 0)
+        self.assertEqual(process.wait(timeout=5.0), EXIT_FAILURE)
 
     def test_partial_content_length(self):
         """
-        lldb-dap handles partial messages.
+        lldb-dap returns a failure exit code when the input stream is closed
+        with a partial message in the message buffer.
         """
         process = self.launch()
         process.stdin.write(b"Content-Length: 10\r\n\r\n{")
         process.stdin.close()
-        self.assertEqual(process.wait(timeout=5.0), 0)
+        self.assertEqual(process.wait(timeout=5.0), EXIT_FAILURE)

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -23,13 +23,14 @@
 #include "Transport.h"
 #include "lldb/API/SBBreakpoint.h"
 #include "lldb/API/SBCommandInterpreter.h"
-#include "lldb/API/SBCommandReturnObject.h"
 #include "lldb/API/SBEvent.h"
 #include "lldb/API/SBLanguageRuntime.h"
 #include "lldb/API/SBListener.h"
 #include "lldb/API/SBProcess.h"
 #include "lldb/API/SBStream.h"
-#include "lldb/Utility/IOObject.h"
+#include "lldb/Host/JSONTransport.h"
+#include "lldb/Host/MainLoop.h"
+#include "lldb/Host/MainLoopBase.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
@@ -52,7 +53,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cstdio>
-#include <fstream>
+#include <functional>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -919,6 +920,8 @@ llvm::Error DAP::Disconnect(bool terminateDebuggee) {
   SendTerminatedEvent();
 
   disconnecting = true;
+  m_loop.AddPendingCallback(
+      [](MainLoopBase &loop) { loop.RequestTermination(); });
 
   return ToError(error);
 }
@@ -949,75 +952,76 @@ static std::optional<T> getArgumentsIfRequest(const Message &pm,
   return args;
 }
 
+Status DAP::TransportHandler() {
+  llvm::set_thread_name(transport.GetClientName() + ".transport_handler");
+
+  auto cleanup = llvm::make_scope_exit([&]() {
+    // Ensure we're marked as disconnecting when the reader exits.
+    disconnecting = true;
+    m_queue_cv.notify_all();
+  });
+
+  Status status;
+  auto handle = transport.RegisterReadObject<protocol::Message>(
+      m_loop,
+      [&](MainLoopBase &loop, llvm::Expected<protocol::Message> message) {
+        if (message.errorIsA<TransportEOFError>()) {
+          llvm::consumeError(message.takeError());
+          loop.RequestTermination();
+          return;
+        }
+
+        if (llvm::Error err = message.takeError()) {
+          status = Status::FromError(std::move(err));
+          loop.RequestTermination();
+          return;
+        }
+
+        if (const protocol::Request *req =
+                std::get_if<protocol::Request>(&*message);
+            req && req->arguments == "disconnect")
+          disconnecting = true;
+
+        const std::optional<CancelArguments> cancel_args =
+            getArgumentsIfRequest<CancelArguments>(*message, "cancel");
+        if (cancel_args) {
+          {
+            std::lock_guard<std::mutex> guard(m_cancelled_requests_mutex);
+            if (cancel_args->requestId)
+              m_cancelled_requests.insert(*cancel_args->requestId);
+          }
+
+          // If a cancel is requested for the active request, make a best
+          // effort attempt to interrupt.
+          std::lock_guard<std::mutex> guard(m_active_request_mutex);
+          if (m_active_request &&
+              cancel_args->requestId == m_active_request->seq) {
+            DAP_LOG(log,
+                    "({0}) interrupting inflight request (command={1} seq={2})",
+                    transport.GetClientName(), m_active_request->command,
+                    m_active_request->seq);
+            debugger.RequestInterrupt();
+          }
+        }
+
+        {
+          std::lock_guard<std::mutex> guard(m_queue_mutex);
+          m_queue.push_back(std::move(*message));
+        }
+        m_queue_cv.notify_one();
+      });
+  if (auto err = handle.takeError())
+    return Status::FromError(std::move(err));
+  if (llvm::Error err = m_loop.Run().takeError())
+    return Status::FromError(std::move(err));
+  return status;
+}
+
 llvm::Error DAP::Loop() {
   // Can't use \a std::future<llvm::Error> because it doesn't compile on
   // Windows.
-  std::future<lldb::SBError> queue_reader =
-      std::async(std::launch::async, [&]() -> lldb::SBError {
-        llvm::set_thread_name(transport.GetClientName() + ".transport_handler");
-        auto cleanup = llvm::make_scope_exit([&]() {
-          // Ensure we're marked as disconnecting when the reader exits.
-          disconnecting = true;
-          m_queue_cv.notify_all();
-        });
-
-        while (!disconnecting) {
-          llvm::Expected<Message> next =
-              transport.Read<protocol::Message>(std::chrono::seconds(1));
-          if (next.errorIsA<TransportEOFError>()) {
-            consumeError(next.takeError());
-            break;
-          }
-
-          // If the read timed out, continue to check if we should disconnect.
-          if (next.errorIsA<TransportTimeoutError>()) {
-            consumeError(next.takeError());
-            continue;
-          }
-
-          if (llvm::Error err = next.takeError()) {
-            lldb::SBError errWrapper;
-            errWrapper.SetErrorString(llvm::toString(std::move(err)).c_str());
-            return errWrapper;
-          }
-
-          if (const protocol::Request *req =
-                  std::get_if<protocol::Request>(&*next);
-              req && req->command == "disconnect")
-            disconnecting = true;
-
-          const std::optional<CancelArguments> cancel_args =
-              getArgumentsIfRequest<CancelArguments>(*next, "cancel");
-          if (cancel_args) {
-            {
-              std::lock_guard<std::mutex> guard(m_cancelled_requests_mutex);
-              if (cancel_args->requestId)
-                m_cancelled_requests.insert(*cancel_args->requestId);
-            }
-
-            // If a cancel is requested for the active request, make a best
-            // effort attempt to interrupt.
-            std::lock_guard<std::mutex> guard(m_active_request_mutex);
-            if (m_active_request &&
-                cancel_args->requestId == m_active_request->seq) {
-              DAP_LOG(
-                  log,
-                  "({0}) interrupting inflight request (command={1} seq={2})",
-                  transport.GetClientName(), m_active_request->command,
-                  m_active_request->seq);
-              debugger.RequestInterrupt();
-            }
-          }
-
-          {
-            std::lock_guard<std::mutex> guard(m_queue_mutex);
-            m_queue.push_back(std::move(*next));
-          }
-          m_queue_cv.notify_one();
-        }
-
-        return lldb::SBError();
-      });
+  std::future<Status> queue_reader =
+      std::async(std::launch::async, &DAP::TransportHandler, this);
 
   auto cleanup = llvm::make_scope_exit([&]() {
     out.Stop();
@@ -1043,7 +1047,7 @@ llvm::Error DAP::Loop() {
                                      "unhandled packet");
   }
 
-  return ToError(queue_reader.get());
+  return queue_reader.get().takeError();
 }
 
 lldb::SBError DAP::WaitForProcessToStop(std::chrono::seconds seconds) {

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -1004,10 +1004,8 @@ Status DAP::TransportHandler() {
           }
         }
 
-        {
-          std::lock_guard<std::mutex> guard(m_queue_mutex);
-          m_queue.push_back(std::move(*message));
-        }
+        std::lock_guard<std::mutex> guard(m_queue_mutex);
+        m_queue.push_back(std::move(*message));
         m_queue_cv.notify_one();
       });
   if (auto err = handle.takeError())

--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -31,6 +31,8 @@
 #include "lldb/API/SBMutex.h"
 #include "lldb/API/SBTarget.h"
 #include "lldb/API/SBThread.h"
+#include "lldb/Host/MainLoop.h"
+#include "lldb/Utility/Status.h"
 #include "lldb/lldb-types.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
@@ -424,6 +426,8 @@ private:
       const std::optional<std::vector<protocol::SourceBreakpoint>> &breakpoints,
       SourceBreakpointMap &existing_breakpoints);
 
+  lldb_private::Status TransportHandler();
+
   /// Registration of request handler.
   /// @{
   void RegisterRequests();
@@ -450,6 +454,9 @@ private:
   std::deque<protocol::Message> m_queue;
   std::mutex m_queue_mutex;
   std::condition_variable m_queue_cv;
+
+  // Loop for managing reading from the client.
+  lldb_private::MainLoop m_loop;
 
   std::mutex m_cancelled_requests_mutex;
   llvm::SmallSet<int64_t, 4> m_cancelled_requests;

--- a/lldb/tools/lldb-dap/Transport.h
+++ b/lldb/tools/lldb-dap/Transport.h
@@ -29,7 +29,7 @@ public:
             lldb::IOObjectSP input, lldb::IOObjectSP output);
   virtual ~Transport() = default;
 
-  virtual void Log(llvm::StringRef message) override;
+  void Log(llvm::StringRef message) override;
 
   /// Returns the name of this transport client, for example `stdin/stdout` or
   /// `client_1`.

--- a/lldb/unittests/DAP/DAPTest.cpp
+++ b/lldb/unittests/DAP/DAPTest.cpp
@@ -9,10 +9,8 @@
 #include "DAP.h"
 #include "Protocol/ProtocolBase.h"
 #include "TestBase.h"
-#include "Transport.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
-#include <chrono>
 #include <memory>
 #include <optional>
 
@@ -32,8 +30,9 @@ TEST_F(DAPTest, SendProtocolMessages) {
       /*transport=*/*to_dap,
   };
   dap.Send(Event{/*event=*/"my-event", /*body=*/std::nullopt});
-  ASSERT_THAT_EXPECTED(
-      from_dap->Read<protocol::Message>(std::chrono::milliseconds(1)),
-      HasValue(testing::VariantWith<Event>(testing::FieldsAre(
-          /*event=*/"my-event", /*body=*/std::nullopt))));
+  RunOnce<protocol::Message>([&](llvm::Expected<protocol::Message> message) {
+    ASSERT_THAT_EXPECTED(
+        message, HasValue(testing::VariantWith<Event>(testing::FieldsAre(
+                     /*event=*/"my-event", /*body=*/std::nullopt))));
+  });
 }

--- a/lldb/unittests/DAP/TestBase.h
+++ b/lldb/unittests/DAP/TestBase.h
@@ -10,6 +10,7 @@
 #include "Protocol/ProtocolBase.h"
 #include "TestingSupport/Host/PipeTestUtilities.h"
 #include "Transport.h"
+#include "lldb/Host/MainLoop.h"
 #include "llvm/ADT/StringRef.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -22,8 +23,28 @@ class TransportBase : public PipePairTest {
 protected:
   std::unique_ptr<lldb_dap::Transport> to_dap;
   std::unique_ptr<lldb_dap::Transport> from_dap;
+  lldb_private::MainLoop loop;
 
   void SetUp() override;
+
+  template <typename P>
+  void
+  RunOnce(std::function<void(llvm::Expected<P>)> callback,
+          std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+    auto handle = from_dap->RegisterReadObject<P>(
+        loop, [&](lldb_private::MainLoopBase &loop, llvm::Expected<P> message) {
+          callback(std::move(message));
+          loop.RequestTermination();
+        });
+    loop.AddCallback(
+        [&](lldb_private::MainLoopBase &loop) {
+          loop.RequestTermination();
+          FAIL() << "timeout waiting for read callback";
+        },
+        timeout);
+    ASSERT_THAT_EXPECTED(handle, llvm::Succeeded());
+    ASSERT_THAT_ERROR(loop.Run().takeError(), llvm::Succeeded());
+  }
 };
 
 /// Matches an "output" event.

--- a/lldb/unittests/DAP/TestBase.h
+++ b/lldb/unittests/DAP/TestBase.h
@@ -28,9 +28,8 @@ protected:
   void SetUp() override;
 
   template <typename P>
-  void
-  RunOnce(std::function<void(llvm::Expected<P>)> callback,
-          std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+  void RunOnce(std::function<void(llvm::Expected<P>)> callback,
+               std::chrono::milliseconds timeout = std::chrono::seconds(1)) {
     auto handle = from_dap->RegisterReadObject<P>(
         loop, [&](lldb_private::MainLoopBase &loop, llvm::Expected<P> message) {
           callback(std::move(message));

--- a/lldb/unittests/Host/JSONTransportTest.cpp
+++ b/lldb/unittests/Host/JSONTransportTest.cpp
@@ -9,6 +9,14 @@
 #include "lldb/Host/JSONTransport.h"
 #include "TestingSupport/Host/PipeTestUtilities.h"
 #include "lldb/Host/File.h"
+#include "lldb/Host/MainLoop.h"
+#include "lldb/Host/MainLoopBase.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+#include <chrono>
+#include <future>
+#include <thread>
 
 using namespace llvm;
 using namespace lldb_private;
@@ -17,6 +25,7 @@ namespace {
 template <typename T> class JSONTransportTest : public PipePairTest {
 protected:
   std::unique_ptr<JSONTransport> transport;
+  MainLoop loop;
 
   void SetUp() override {
     PipePairTest::SetUp();
@@ -27,6 +36,25 @@ protected:
         std::make_shared<NativeFile>(output.GetWriteFileDescriptor(),
                                      File::eOpenOptionWriteOnly,
                                      NativeFile::Unowned));
+  }
+
+  template <typename P>
+  void
+  RunOnce(std::function<void(llvm::Expected<P>)> callback,
+          std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+    auto handle = transport->RegisterReadObject<P>(
+        loop, [&](MainLoopBase &loop, llvm::Expected<P> message) {
+          callback(std::move(message));
+          loop.RequestTermination();
+        });
+    loop.AddCallback(
+        [&](MainLoopBase &loop) {
+          loop.RequestTermination();
+          FAIL() << "timeout waiting for read callback";
+        },
+        timeout);
+    ASSERT_THAT_EXPECTED(handle, Succeeded());
+    ASSERT_THAT_ERROR(loop.Run().takeError(), Succeeded());
   }
 };
 
@@ -56,40 +84,73 @@ bool fromJSON(const llvm::json::Value &V, JSONTestType &T, llvm::json::Path P) {
 } // namespace
 
 TEST_F(HTTPDelimitedJSONTransportTest, MalformedRequests) {
-  std::string malformed_header = "COnTent-LenGth: -1{}\r\n\r\nnotjosn";
+  std::string malformed_header =
+      "COnTent-LenGth: -1\r\nContent-Type: text/json\r\n\r\nnotjosn";
   ASSERT_THAT_EXPECTED(
       input.Write(malformed_header.data(), malformed_header.size()),
       Succeeded());
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      FailedWithMessage(
-          "expected 'Content-Length: ' and got 'COnTent-LenGth: '"));
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message,
+                         FailedWithMessage("invalid content length: -1"));
+  });
 }
 
 TEST_F(HTTPDelimitedJSONTransportTest, Read) {
   std::string json = R"json({"str": "foo"})json";
   std::string message =
+      formatv("Content-Length: {0}\r\nContent-type: text/json\r\n\r\n{1}",
+              json.size(), json)
+          .str();
+  ASSERT_THAT_EXPECTED(input.Write(message.data(), message.size()),
+                       Succeeded());
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message, HasValue(testing::FieldsAre(/*str=*/"foo")));
+  });
+}
+
+TEST_F(HTTPDelimitedJSONTransportTest, ReadAcrossMultipleChunks) {
+  std::string long_str = std::string(2048, 'x');
+  std::string json = formatv(R"({"str": "{0}"})", long_str).str();
+  std::string message =
       formatv("Content-Length: {0}\r\n\r\n{1}", json.size(), json).str();
   ASSERT_THAT_EXPECTED(input.Write(message.data(), message.size()),
                        Succeeded());
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      HasValue(testing::FieldsAre(/*str=*/"foo")));
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message,
+                         HasValue(testing::FieldsAre(/*str=*/long_str)));
+  });
+}
+
+TEST_F(HTTPDelimitedJSONTransportTest, ReadPartialMessage) {
+  std::future<void> background_task = std::async(std::launch::async, [&]() {
+    std::string json = R"({"str": "foo"})";
+    std::string message =
+        formatv("Content-Length: {0}\r\n\r\n{1}", json.size(), json).str();
+    std::string part1 = message.substr(0, 28);
+    std::string part2 = message.substr(28);
+
+    ASSERT_THAT_EXPECTED(input.Write(part1.data(), part1.size()), Succeeded());
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    ASSERT_THAT_EXPECTED(input.Write(part2.data(), part2.size()), Succeeded());
+  });
+
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message, HasValue(testing::FieldsAre(/*str=*/"foo")));
+  });
 }
 
 TEST_F(HTTPDelimitedJSONTransportTest, ReadWithEOF) {
   input.CloseWriteFileDescriptor();
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      Failed<TransportEOFError>());
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message, Failed<TransportEOFError>());
+  });
 }
-
 
 TEST_F(HTTPDelimitedJSONTransportTest, InvalidTransport) {
   transport = std::make_unique<HTTPDelimitedJSONTransport>(nullptr, nullptr);
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      Failed<TransportInvalidError>());
+  auto handle = transport->RegisterReadObject<JSONTestType>(
+      loop, [&](MainLoopBase &, llvm::Expected<JSONTestType>) {});
+  ASSERT_THAT_EXPECTED(handle, FailedWithMessage("IO object is not valid."));
 }
 
 TEST_F(HTTPDelimitedJSONTransportTest, Write) {
@@ -108,9 +169,8 @@ TEST_F(JSONRPCTransportTest, MalformedRequests) {
   ASSERT_THAT_EXPECTED(
       input.Write(malformed_header.data(), malformed_header.size()),
       Succeeded());
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      llvm::Failed());
+  RunOnce<JSONTestType>(
+      [&](auto message) { ASSERT_THAT_EXPECTED(message, llvm::Failed()); });
 }
 
 TEST_F(JSONRPCTransportTest, Read) {
@@ -118,16 +178,45 @@ TEST_F(JSONRPCTransportTest, Read) {
   std::string message = formatv("{0}\n", json).str();
   ASSERT_THAT_EXPECTED(input.Write(message.data(), message.size()),
                        Succeeded());
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      HasValue(testing::FieldsAre(/*str=*/"foo")));
+  RunOnce<JSONTestType>([&](auto message) {
+    ASSERT_THAT_EXPECTED(message, HasValue(testing::FieldsAre(/*str=*/"foo")));
+  });
+}
+
+TEST_F(JSONRPCTransportTest, ReadAcrossMultipleChunks) {
+  std::string long_str = std::string(2048, 'x');
+  std::string json = formatv(R"({"str": "{0}"})", long_str).str();
+  std::string message = formatv("{0}\n", json).str();
+  ASSERT_THAT_EXPECTED(input.Write(message.data(), message.size()),
+                       Succeeded());
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message,
+                         HasValue(testing::FieldsAre(/*str=*/long_str)));
+  });
+}
+
+TEST_F(JSONRPCTransportTest, ReadPartialMessage) {
+  std::future<void> background_task = std::async(std::launch::async, [&]() {
+    std::string message = R"({"str": "foo"})"
+                          "\n";
+    std::string part1 = message.substr(0, 7);
+    std::string part2 = message.substr(7);
+
+    ASSERT_THAT_EXPECTED(input.Write(part1.data(), part1.size()), Succeeded());
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    ASSERT_THAT_EXPECTED(input.Write(part2.data(), part2.size()), Succeeded());
+  });
+
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message, HasValue(testing::FieldsAre(/*str=*/"foo")));
+  });
 }
 
 TEST_F(JSONRPCTransportTest, ReadWithEOF) {
   input.CloseWriteFileDescriptor();
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      Failed<TransportEOFError>());
+  RunOnce<JSONTestType>([&](llvm::Expected<JSONTestType> message) {
+    ASSERT_THAT_EXPECTED(message, Failed<TransportEOFError>());
+  });
 }
 
 TEST_F(JSONRPCTransportTest, Write) {
@@ -143,39 +232,7 @@ TEST_F(JSONRPCTransportTest, Write) {
 
 TEST_F(JSONRPCTransportTest, InvalidTransport) {
   transport = std::make_unique<JSONRPCTransport>(nullptr, nullptr);
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      Failed<TransportInvalidError>());
+  auto handle = transport->RegisterReadObject<JSONTestType>(
+      loop, [&](MainLoopBase &, llvm::Expected<JSONTestType>) {});
+  ASSERT_THAT_EXPECTED(handle, FailedWithMessage("IO object is not valid."));
 }
-
-#ifndef _WIN32
-TEST_F(HTTPDelimitedJSONTransportTest, ReadWithTimeout) {
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      Failed<TransportTimeoutError>());
-}
-
-TEST_F(JSONRPCTransportTest, ReadWithTimeout) {
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      Failed<TransportTimeoutError>());
-}
-
-// Windows CRT _read checks that the file descriptor is valid and calls a
-// handler if not. This handler is normally a breakpoint, which looks like a
-// crash when not handled by a debugger.
-// https://learn.microsoft.com/en-us/%20cpp/c-runtime-library/reference/read?view=msvc-170
-TEST_F(HTTPDelimitedJSONTransportTest, ReadAfterClosed) {
-  input.CloseReadFileDescriptor();
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      llvm::Failed());
-}
-
-TEST_F(JSONRPCTransportTest, ReadAfterClosed) {
-  input.CloseReadFileDescriptor();
-  ASSERT_THAT_EXPECTED(
-      transport->Read<JSONTestType>(std::chrono::milliseconds(1)),
-      llvm::Failed());
-}
-#endif

--- a/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
@@ -15,9 +15,15 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/JSONTransport.h"
+#include "lldb/Host/MainLoop.h"
+#include "lldb/Host/MainLoopBase.h"
 #include "lldb/Host/Socket.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
 
 using namespace llvm;
 using namespace lldb;
@@ -38,7 +44,7 @@ public:
 class TestJSONTransport : public lldb_private::JSONRPCTransport {
 public:
   using JSONRPCTransport::JSONRPCTransport;
-  using JSONRPCTransport::ReadImpl;
+  using JSONRPCTransport::Parse;
   using JSONRPCTransport::WriteImpl;
 };
 
@@ -47,7 +53,7 @@ class TestTool : public mcp::Tool {
 public:
   using mcp::Tool::Tool;
 
-  virtual llvm::Expected<mcp::protocol::TextResult>
+  llvm::Expected<mcp::protocol::TextResult>
   Call(const ToolArguments &args) override {
     std::string argument;
     if (const json::Object *args_obj =
@@ -100,7 +106,7 @@ class ErrorTool : public mcp::Tool {
 public:
   using mcp::Tool::Tool;
 
-  virtual llvm::Expected<mcp::protocol::TextResult>
+  llvm::Expected<mcp::protocol::TextResult>
   Call(const ToolArguments &args) override {
     return llvm::createStringError("error");
   }
@@ -111,7 +117,7 @@ class FailTool : public mcp::Tool {
 public:
   using mcp::Tool::Tool;
 
-  virtual llvm::Expected<mcp::protocol::TextResult>
+  llvm::Expected<mcp::protocol::TextResult>
   Call(const ToolArguments &args) override {
     mcp::protocol::TextResult text_result;
     text_result.content.emplace_back(mcp::protocol::TextContent{{"failed"}});
@@ -128,6 +134,7 @@ public:
   lldb::IOObjectSP m_io_sp;
   std::unique_ptr<TestJSONTransport> m_transport_up;
   std::unique_ptr<TestProtocolServerMCP> m_server_up;
+  MainLoop loop;
 
   static constexpr llvm::StringLiteral k_localhost = "localhost";
 
@@ -135,11 +142,26 @@ public:
     return m_transport_up->WriteImpl(llvm::formatv("{0}\n", message).str());
   }
 
-  llvm::Expected<std::string> Read() {
-    return m_transport_up->ReadImpl(std::chrono::milliseconds(100));
+  template <typename P>
+  void
+  RunOnce(std::function<void(llvm::Expected<P>)> callback,
+          std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+    auto handle = m_transport_up->RegisterReadObject<P>(
+        loop, [&](lldb_private::MainLoopBase &loop, llvm::Expected<P> message) {
+          callback(std::move(message));
+          loop.RequestTermination();
+        });
+    loop.AddCallback(
+        [&](lldb_private::MainLoopBase &loop) {
+          loop.RequestTermination();
+          FAIL() << "timeout waiting for read callback";
+        },
+        timeout);
+    ASSERT_THAT_EXPECTED(handle, llvm::Succeeded());
+    ASSERT_THAT_ERROR(loop.Run().takeError(), llvm::Succeeded());
   }
 
-  void SetUp() {
+  void SetUp() override {
     // Create a debugger.
     ArchSpec arch("arm64-apple-macosx-");
     Platform::SetHostPlatform(
@@ -171,7 +193,7 @@ public:
     m_transport_up = std::make_unique<TestJSONTransport>(m_io_sp, m_io_sp);
   }
 
-  void TearDown() {
+  void TearDown() override {
     // Stop the server.
     ASSERT_THAT_ERROR(m_server_up->Stop(), llvm::Succeeded());
   }
@@ -186,17 +208,16 @@ TEST_F(ProtocolServerMCPTest, Intialization) {
       R"json( {"id":0,"jsonrpc":"2.0","result":{"capabilities":{"resources":{"listChanged":false,"subscribe":false},"tools":{"listChanged":true}},"protocolVersion":"2024-11-05","serverInfo":{"name":"lldb-mcp","version":"0.1.0"}}})json";
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
+  RunOnce<std::string>([&](llvm::Expected<std::string> response_str) {
+    ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> response_json = json::parse(*response_str);
+    ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
 
-  llvm::Expected<std::string> response_str = Read();
-  ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> expected_json = json::parse(response);
+    ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> response_json = json::parse(*response_str);
-  ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
-
-  llvm::Expected<json::Value> expected_json = json::parse(response);
-  ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
-
-  EXPECT_EQ(*response_json, *expected_json);
+    EXPECT_EQ(*response_json, *expected_json);
+  });
 }
 
 TEST_F(ProtocolServerMCPTest, ToolsList) {
@@ -206,17 +227,17 @@ TEST_F(ProtocolServerMCPTest, ToolsList) {
       R"json({"id":1,"jsonrpc":"2.0","result":{"tools":[{"description":"test tool","inputSchema":{"type":"object"},"name":"test"},{"description":"Run an lldb command.","inputSchema":{"properties":{"arguments":{"type":"string"},"debugger_id":{"type":"number"}},"required":["debugger_id"],"type":"object"},"name":"lldb_command"}]}})json";
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
+  RunOnce<std::string>([&](llvm::Expected<std::string> response_str) {
+    ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
 
-  llvm::Expected<std::string> response_str = Read();
-  ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> response_json = json::parse(*response_str);
+    ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> response_json = json::parse(*response_str);
-  ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
+    llvm::Expected<json::Value> expected_json = json::parse(response);
+    ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> expected_json = json::parse(response);
-  ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
-
-  EXPECT_EQ(*response_json, *expected_json);
+    EXPECT_EQ(*response_json, *expected_json);
+  });
 }
 
 TEST_F(ProtocolServerMCPTest, ResourcesList) {
@@ -226,17 +247,17 @@ TEST_F(ProtocolServerMCPTest, ResourcesList) {
       R"json({"id":2,"jsonrpc":"2.0","result":{"resources":[{"description":"description","mimeType":"application/json","name":"name","uri":"lldb://foo/bar"}]}})json";
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
+  RunOnce<std::string>([&](llvm::Expected<std::string> response_str) {
+    ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
 
-  llvm::Expected<std::string> response_str = Read();
-  ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> response_json = json::parse(*response_str);
+    ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> response_json = json::parse(*response_str);
-  ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
+    llvm::Expected<json::Value> expected_json = json::parse(response);
+    ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> expected_json = json::parse(response);
-  ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
-
-  EXPECT_EQ(*response_json, *expected_json);
+    EXPECT_EQ(*response_json, *expected_json);
+  });
 }
 
 TEST_F(ProtocolServerMCPTest, ToolsCall) {
@@ -246,17 +267,17 @@ TEST_F(ProtocolServerMCPTest, ToolsCall) {
       R"json({"id":11,"jsonrpc":"2.0","result":{"content":[{"text":"foo","type":"text"}],"isError":false}})json";
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
+  RunOnce<std::string>([&](llvm::Expected<std::string> response_str) {
+    ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
 
-  llvm::Expected<std::string> response_str = Read();
-  ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> response_json = json::parse(*response_str);
+    ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> response_json = json::parse(*response_str);
-  ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
+    llvm::Expected<json::Value> expected_json = json::parse(response);
+    ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> expected_json = json::parse(response);
-  ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
-
-  EXPECT_EQ(*response_json, *expected_json);
+    EXPECT_EQ(*response_json, *expected_json);
+  });
 }
 
 TEST_F(ProtocolServerMCPTest, ToolsCallError) {
@@ -268,17 +289,17 @@ TEST_F(ProtocolServerMCPTest, ToolsCallError) {
       R"json({"error":{"code":-32603,"message":"error"},"id":11,"jsonrpc":"2.0"})json";
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
+  RunOnce<std::string>([&](llvm::Expected<std::string> response_str) {
+    ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
 
-  llvm::Expected<std::string> response_str = Read();
-  ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> response_json = json::parse(*response_str);
+    ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> response_json = json::parse(*response_str);
-  ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
+    llvm::Expected<json::Value> expected_json = json::parse(response);
+    ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> expected_json = json::parse(response);
-  ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
-
-  EXPECT_EQ(*response_json, *expected_json);
+    EXPECT_EQ(*response_json, *expected_json);
+  });
 }
 
 TEST_F(ProtocolServerMCPTest, ToolsCallFail) {
@@ -290,17 +311,17 @@ TEST_F(ProtocolServerMCPTest, ToolsCallFail) {
       R"json({"id":11,"jsonrpc":"2.0","result":{"content":[{"text":"failed","type":"text"}],"isError":true}})json";
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
+  RunOnce<std::string>([&](llvm::Expected<std::string> response_str) {
+    ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
 
-  llvm::Expected<std::string> response_str = Read();
-  ASSERT_THAT_EXPECTED(response_str, llvm::Succeeded());
+    llvm::Expected<json::Value> response_json = json::parse(*response_str);
+    ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> response_json = json::parse(*response_str);
-  ASSERT_THAT_EXPECTED(response_json, llvm::Succeeded());
+    llvm::Expected<json::Value> expected_json = json::parse(response);
+    ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
 
-  llvm::Expected<json::Value> expected_json = json::parse(response);
-  ASSERT_THAT_EXPECTED(expected_json, llvm::Succeeded());
-
-  EXPECT_EQ(*response_json, *expected_json);
+    EXPECT_EQ(*response_json, *expected_json);
+  });
 }
 
 TEST_F(ProtocolServerMCPTest, NotificationInitialized) {


### PR DESCRIPTION
This updates JSONTransport to use a MainLoop for reading messages.

This also allows us to read in larger chunks than we did previously. With the event driven reading operations we can read in chunks and store the contents in an internal buffer. Separately we can parse the buffer and split the contents up into messages.

Our previous version approach would read a byte at a time, which is less efficient.