### PR TITLE
[TTI] Treat `*l` (long double) and `*f128` (_Float128) libcalls the same

### DIFF
--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -210,10 +210,9 @@ public:
     // These are all likely to be optimized into something smaller.
     if (Name == "pow" || Name == "powf" || Name == "powl" ||
         Name == "powf128" || Name == "exp2" || Name == "exp2f" ||
-        Name == "exp2l" || Name == "powf128" || Name == "floor" ||
-        Name == "floorf" || Name == "ceil" || Name == "round" ||
-        Name == "ffs" || Name == "ffsl" || Name == "abs" || Name == "labs" ||
-        Name == "llabs")
+        Name == "exp2l" || Name == "floor" || Name == "floorf" ||
+        Name == "ceil" || Name == "round" || Name == "ffs" || Name == "ffsl" ||
+        Name == "abs" || Name == "labs" || Name == "llabs")
       return false;
 
     return true;

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -189,27 +189,28 @@ public:
 
     // These will all likely lower to a single selection DAG node.
     // clang-format off
-    if (Name == "copysign" || Name == "copysignf" || Name == "copysignl" ||
-        Name == "fabs"  || Name == "fabsf"  || Name == "fabsl" ||
-        Name == "fmin"  || Name == "fminf"  || Name == "fminl" ||
-        Name == "fmax"  || Name == "fmaxf"  || Name == "fmaxl" ||
-        Name == "sin"   || Name == "sinf"   || Name == "sinl"  ||
-        Name == "cos"   || Name == "cosf"   || Name == "cosl"  ||
-        Name == "tan"   || Name == "tanf"   || Name == "tanl"  ||
-        Name == "asin"  || Name == "asinf"  || Name == "asinl" ||
-        Name == "acos"  || Name == "acosf"  || Name == "acosl" ||
-        Name == "atan"  || Name == "atanf"  || Name == "atanl" ||
-        Name == "atan2" || Name == "atan2f" || Name == "atan2l"||
-        Name == "sinh"  || Name == "sinhf"  || Name == "sinhl" ||
-        Name == "cosh"  || Name == "coshf"  || Name == "coshl" ||
-        Name == "tanh"  || Name == "tanhf"  || Name == "tanhl" ||
-        Name == "sqrt"  || Name == "sqrtf"  || Name == "sqrtl" ||
-        Name == "exp10"  || Name == "exp10l"  || Name == "exp10f")
+    if (Name == "copysign" || Name == "copysignf" || Name == "copysignl" || Name == "copysignl128" ||
+        Name == "fabs"  || Name == "fabsf"  || Name == "fabsl" || Name == "fabsl128" ||
+        Name == "fmin"  || Name == "fminf"  || Name == "fminl" || Name == "fminl128" ||
+        Name == "fmax"  || Name == "fmaxf"  || Name == "fmaxl" || Name == "fmaxl128" ||
+        Name == "sin"   || Name == "sinf"   || Name == "sinl"  || Name == "sinl128"  ||
+        Name == "cos"   || Name == "cosf"   || Name == "cosl"  || Name == "cosl128"  ||
+        Name == "tan"   || Name == "tanf"   || Name == "tanl"  || Name == "tanl128"  ||
+        Name == "asin"  || Name == "asinf"  || Name == "asinl" || Name == "asinl128" ||
+        Name == "acos"  || Name == "acosf"  || Name == "acosl" || Name == "acosl128" ||
+        Name == "atan"  || Name == "atanf"  || Name == "atanl" || Name == "atanl128" ||
+        Name == "atan2" || Name == "atan2f" || Name == "atan2l"|| Name == "atan2128l"||
+        Name == "sinh"  || Name == "sinhf"  || Name == "sinhl" || Name == "sinhl128" ||
+        Name == "cosh"  || Name == "coshf"  || Name == "coshl" || Name == "coshl128" ||
+        Name == "tanh"  || Name == "tanhf"  || Name == "tanhl" || Name == "tanhl128" ||
+        Name == "sqrt"  || Name == "sqrtf"  || Name == "sqrtl" || Name == "sqrtl128" ||
+        Name == "exp10" || Name == "exp10f" || Name == "exp10l"|| Name == "exp10f128")
       return false;
     // clang-format on
     // These are all likely to be optimized into something smaller.
-    if (Name == "pow" || Name == "powf" || Name == "powl" || Name == "exp2" ||
-        Name == "exp2l" || Name == "exp2f" || Name == "floor" ||
+    if (Name == "pow" || Name == "powf" || Name == "powl" ||
+        Name == "powf128" || Name == "exp2" || Name == "exp2f" ||
+        Name == "exp2l" || Name == "powf128" || Name == "floor" ||
         Name == "floorf" || Name == "ceil" || Name == "round" ||
         Name == "ffs" || Name == "ffsl" || Name == "abs" || Name == "labs" ||
         Name == "llabs")

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -189,30 +189,31 @@ public:
 
     // These will all likely lower to a single selection DAG node.
     // clang-format off
-    if (Name == "copysign" || Name == "copysignf" || Name == "copysignl" || Name == "copysignl128" ||
-        Name == "fabs"  || Name == "fabsf"  || Name == "fabsl" || Name == "fabsl128" ||
-        Name == "fmin"  || Name == "fminf"  || Name == "fminl" || Name == "fminl128" ||
-        Name == "fmax"  || Name == "fmaxf"  || Name == "fmaxl" || Name == "fmaxl128" ||
-        Name == "sin"   || Name == "sinf"   || Name == "sinl"  || Name == "sinl128"  ||
-        Name == "cos"   || Name == "cosf"   || Name == "cosl"  || Name == "cosl128"  ||
-        Name == "tan"   || Name == "tanf"   || Name == "tanl"  || Name == "tanl128"  ||
-        Name == "asin"  || Name == "asinf"  || Name == "asinl" || Name == "asinl128" ||
-        Name == "acos"  || Name == "acosf"  || Name == "acosl" || Name == "acosl128" ||
-        Name == "atan"  || Name == "atanf"  || Name == "atanl" || Name == "atanl128" ||
-        Name == "atan2" || Name == "atan2f" || Name == "atan2l"|| Name == "atan2128l"||
-        Name == "sinh"  || Name == "sinhf"  || Name == "sinhl" || Name == "sinhl128" ||
-        Name == "cosh"  || Name == "coshf"  || Name == "coshl" || Name == "coshl128" ||
-        Name == "tanh"  || Name == "tanhf"  || Name == "tanhl" || Name == "tanhl128" ||
-        Name == "sqrt"  || Name == "sqrtf"  || Name == "sqrtl" || Name == "sqrtl128" ||
+    if (Name == "copysign" || Name == "copysignf" || Name == "copysignl" || Name == "copysignf128" ||
+        Name == "fabs"  || Name == "fabsf"  || Name == "fabsl" || Name == "fabsf128" ||
+        Name == "fmin"  || Name == "fminf"  || Name == "fminl" || Name == "fminf128" ||
+        Name == "fmax"  || Name == "fmaxf"  || Name == "fmaxl" || Name == "fmaxf128" ||
+        Name == "sin"   || Name == "sinf"   || Name == "sinl"  || Name == "sinf128"  ||
+        Name == "cos"   || Name == "cosf"   || Name == "cosl"  || Name == "cosf128"  ||
+        Name == "tan"   || Name == "tanf"   || Name == "tanl"  || Name == "tanf128"  ||
+        Name == "asin"  || Name == "asinf"  || Name == "asinl" || Name == "asinf128" ||
+        Name == "acos"  || Name == "acosf"  || Name == "acosl" || Name == "acosf128" ||
+        Name == "atan"  || Name == "atanf"  || Name == "atanl" || Name == "atanf128" ||
+        Name == "atan2" || Name == "atan2f" || Name == "atan2l"|| Name == "atan2f128"||
+        Name == "sinh"  || Name == "sinhf"  || Name == "sinhl" || Name == "sinhf128" ||
+        Name == "cosh"  || Name == "coshf"  || Name == "coshl" || Name == "coshf128" ||
+        Name == "tanh"  || Name == "tanhf"  || Name == "tanhl" || Name == "tanhf128" ||
+        Name == "sqrt"  || Name == "sqrtf"  || Name == "sqrtl" || Name == "sqrtf128" ||
         Name == "exp10" || Name == "exp10f" || Name == "exp10l"|| Name == "exp10f128")
       return false;
     // clang-format on
     // These are all likely to be optimized into something smaller.
     if (Name == "pow" || Name == "powf" || Name == "powl" ||
         Name == "powf128" || Name == "exp2" || Name == "exp2f" ||
-        Name == "exp2l" || Name == "floor" || Name == "floorf" ||
-        Name == "ceil" || Name == "round" || Name == "ffs" || Name == "ffsl" ||
-        Name == "abs" || Name == "labs" || Name == "llabs")
+        Name == "exp2l" || Name == "exp2f128" || Name == "floor" ||
+        Name == "floorf" || Name == "ceil" || Name == "round" ||
+        Name == "ffs" || Name == "ffsl" || Name == "abs" || Name == "labs" ||
+        Name == "llabs")
       return false;
 
     return true;


### PR DESCRIPTION
As noted in the preexisting FIXME above this hunk, the logic in this function is not always accurate. However, the logic for `long double` and `_Float128` should be approximately the same for these functions (almost everything requiring a libcall), so it makes sense to treat them the same.

This is meant to reduce churn in cases where `*l` and `*f128` lowerings call to the same symbol so can be used interchangeably.