### PR TITLE
[lldb] Simplify handling of empty strings for MCP (NFC)

### DIFF
--- a/lldb/source/Plugins/Protocol/MCP/Protocol.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Protocol.cpp
@@ -42,7 +42,7 @@ bool fromJSON(const llvm::json::Value &V, Request &R, llvm::json::Path P) {
 
 llvm::json::Value toJSON(const ErrorInfo &EI) {
   llvm::json::Object Result{{"code", EI.code}, {"message", EI.message}};
-  if (EI.data)
+  if (!EI.data.empty())
     Result.insert({"data", EI.data});
   return Result;
 }
@@ -132,9 +132,9 @@ bool fromJSON(const llvm::json::Value &V, Resource &R, llvm::json::Path P) {
 
 llvm::json::Value toJSON(const Resource &R) {
   llvm::json::Object Result{{"uri", R.uri}, {"name", R.name}};
-  if (R.description)
+  if (!R.description.empty())
     Result.insert({"description", R.description});
-  if (R.mimeType)
+  if (!R.mimeType.empty())
     Result.insert({"mimeType", R.mimeType});
   return Result;
 }
@@ -146,7 +146,7 @@ bool fromJSON(const llvm::json::Value &V, Capabilities &C, llvm::json::Path P) {
 
 llvm::json::Value toJSON(const ResourceContents &RC) {
   llvm::json::Object Result{{"uri", RC.uri}, {"text", RC.text}};
-  if (RC.mimeType)
+  if (!RC.mimeType.empty())
     Result.insert({"mimeType", RC.mimeType});
   return Result;
 }
@@ -188,7 +188,7 @@ bool fromJSON(const llvm::json::Value &V, TextResult &TR, llvm::json::Path P) {
 
 llvm::json::Value toJSON(const ToolDefinition &TD) {
   llvm::json::Object Result{{"name", TD.name}};
-  if (TD.description)
+  if (!TD.description.empty())
     Result.insert({"description", TD.description});
   if (TD.inputSchema)
     Result.insert({"inputSchema", TD.inputSchema});

--- a/lldb/source/Plugins/Protocol/MCP/Protocol.h
+++ b/lldb/source/Plugins/Protocol/MCP/Protocol.h
@@ -36,7 +36,7 @@ bool fromJSON(const llvm::json::Value &, Request &, llvm::json::Path);
 struct ErrorInfo {
   int64_t code = 0;
   std::string message;
-  std::optional<std::string> data;
+  std::string data;
 };
 
 llvm::json::Value toJSON(const ErrorInfo &);
@@ -112,10 +112,10 @@ struct Resource {
   std::string name;
 
   /// A description of what this resource represents.
-  std::optional<std::string> description;
+  std::string description;
 
   /// The MIME type of this resource, if known.
-  std::optional<std::string> mimeType;
+  std::string mimeType;
 };
 
 llvm::json::Value toJSON(const Resource &);
@@ -131,7 +131,7 @@ struct ResourceContents {
   std::string text;
 
   /// The MIME type of this resource, if known.
-  std::optional<std::string> mimeType;
+  std::string mimeType;
 };
 
 llvm::json::Value toJSON(const ResourceContents &);
@@ -167,7 +167,7 @@ struct ToolDefinition {
   std::string name;
 
   /// Human-readable description.
-  std::optional<std::string> description;
+  std::string description;
 
   // JSON Schema for the tool's parameters.
   std::optional<llvm::json::Value> inputSchema;

--- a/lldb/source/Plugins/Protocol/MCP/Tool.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.cpp
@@ -45,7 +45,7 @@ Tool::Tool(std::string name, std::string description)
 protocol::ToolDefinition Tool::GetDefinition() const {
   protocol::ToolDefinition definition;
   definition.name = m_name;
-  definition.description.emplace(m_description);
+  definition.description = m_description;
 
   if (std::optional<llvm::json::Value> input_schema = GetSchema())
     definition.inputSchema = *input_schema;

--- a/lldb/unittests/Protocol/ProtocolMCPTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPTest.cpp
@@ -257,8 +257,8 @@ TEST(ProtocolMCPTest, ResourceWithoutOptionals) {
 
   EXPECT_EQ(resource.uri, deserialized_resource->uri);
   EXPECT_EQ(resource.name, deserialized_resource->name);
-  EXPECT_FALSE(deserialized_resource->description.has_value());
-  EXPECT_FALSE(deserialized_resource->mimeType.has_value());
+  EXPECT_TRUE(deserialized_resource->description.empty());
+  EXPECT_TRUE(deserialized_resource->mimeType.empty());
 }
 
 TEST(ProtocolMCPTest, ResourceContents) {
@@ -287,7 +287,7 @@ TEST(ProtocolMCPTest, ResourceContentsWithoutMimeType) {
 
   EXPECT_EQ(contents.uri, deserialized_contents->uri);
   EXPECT_EQ(contents.text, deserialized_contents->text);
-  EXPECT_FALSE(deserialized_contents->mimeType.has_value());
+  EXPECT_TRUE(deserialized_contents->mimeType.empty());
 }
 
 TEST(ProtocolMCPTest, ResourceResult) {


### PR DESCRIPTION
Instead of storing a `std::optional<std::string>`, directly use a `std::string` and treat a missing value the same was as an empty string.