### PR TITLE
[MLIR][Affine] Rename/update affine fusion test pass options to avoid confusion

### DIFF
--- a/mlir/test/Dialect/Affine/loop-fusion-utilities.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-utilities.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -allow-unregistered-dialect -test-loop-fusion=test-loop-fusion-transformation -split-input-file -canonicalize | FileCheck %s
+// RUN: mlir-opt %s -allow-unregistered-dialect -test-loop-fusion=test-loop-fusion-utilities -split-input-file -canonicalize | FileCheck %s
 
 // CHECK-LABEL: func @slice_depth1_loop_nest() {
 func.func @slice_depth1_loop_nest() {


### PR DESCRIPTION
This test pass is meant to test various affine fusion utilities as opposed to being a pass to perform valid fusion. Rename an option to avoid confusion.

Fixes: https://github.com/llvm/llvm-project/issues/132172