### PR TITLE
[libc++] Save duration/timeout locally for condition_variable waits

### DIFF
--- a/libcxx/include/condition_variable
+++ b/libcxx/include/condition_variable
@@ -188,9 +188,10 @@ public:
   _LIBCPP_HIDE_FROM_ABI cv_status wait_until(_Lock& __lock, const chrono::time_point<_Clock, _Duration>& __t) {
     shared_ptr<mutex> __mut = __mut_;
     unique_lock<mutex> __lk(*__mut);
+    const chrono::time_point<_Clock, _Duration> __t_local = __t;
     __unlock_guard<_Lock> __unlock(__lock);
     lock_guard<unique_lock<mutex> > __lx(__lk, adopt_lock_t());
-    return __cv_.wait_until(__lk, __t);
+    return __cv_.wait_until(__lk, __t_local);
   } // __mut_.unlock(), __lock.lock()
 
   template <class _Lock, class _Clock, class _Duration, class _Predicate>
@@ -240,8 +241,9 @@ inline void condition_variable_any::wait(_Lock& __lock, _Predicate __pred) {
 template <class _Lock, class _Clock, class _Duration, class _Predicate>
 inline bool
 condition_variable_any::wait_until(_Lock& __lock, const chrono::time_point<_Clock, _Duration>& __t, _Predicate __pred) {
+  const chrono::time_point<_Clock, _Duration> __t_local = __t;
   while (!__pred())
-    if (wait_until(__lock, __t) == cv_status::timeout)
+    if (wait_until(__lock, __t_local) == cv_status::timeout)
       return __pred();
   return true;
 }
@@ -313,6 +315,7 @@ bool condition_variable_any::wait_until(
 
   shared_ptr<mutex> __mut = __mut_;
   stop_callback __cb(__stoken, [this] { notify_all(); });
+  const chrono::time_point<_Clock, _Duration> __abs_time_local = __abs_time;
 
   while (true) {
     if (__pred())
@@ -326,7 +329,7 @@ bool condition_variable_any::wait_until(
     unique_lock<mutex> __internal_lock2(
         std::move(__internal_lock)); // switch unlock order between __internal_lock and __user_lock
 
-    if (__cv_.wait_until(__internal_lock2, __abs_time) == cv_status::timeout)
+    if (__cv_.wait_until(__internal_lock2, __abs_time_local) == cv_status::timeout)
       break;
   } // __internal_lock2.unlock(), __user_lock.lock()
   return __pred();


### PR DESCRIPTION
wait_for() and wait_until() for condition_variable and condition_variable_any take their wait duration or timeout parameters by const-reference.  This can lead to unexpected behavior if the referent changes while the wait_for() or wait_until() blocks.

For condition_variable_any, this is an actual data race if the timeout parameter is protected by the lock, as the implementation accesses the timeout outside of the lock.

Fix this by saving a local copy of the duration or timeout while the condition variable is waiting.

Fixes #148328