### PR TITLE
[clang-tidy] Teach `cppcoreguidelines-interfaces-global-init` about `constinit`

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/InterfacesGlobalInitCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/InterfacesGlobalInitCheck.cpp
@@ -19,7 +19,7 @@ void InterfacesGlobalInitCheck::registerMatchers(MatchFinder *Finder) {
               hasDeclContext(anyOf(translationUnitDecl(), // Global scope.
                                    namespaceDecl(),       // Namespace scope.
                                    recordDecl())),        // Class scope.
-              unless(isConstexpr()));
+              unless(isConstexpr()), unless(isConstinit()));
 
   const auto ReferencesUndefinedGlobalVar = declRefExpr(hasDeclaration(
       varDecl(GlobalVarDecl, unless(isDefinition())).bind("referencee")));

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -212,6 +212,10 @@ Changes in existing checks
   <clang-tidy/checks/cppcoreguidelines/avoid-goto>` check by adding the option
   `IgnoreMacros` to ignore ``goto`` labels defined in macros.
 
+- Improved :doc:`cppcoreguidelines-interfaces-global-init
+  <clang-tidy/checks/cppcoreguidelines/interfaces-global-init>` check by
+  fixing false positives on uses of ``constinit`` variables.
+
 - Improved :doc:`cppcoreguidelines-missing-std-forward
   <clang-tidy/checks/cppcoreguidelines/missing-std-forward>` check by adding a
   flag to specify the function used for forwarding instead of ``std::forward``.

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/interfaces-global-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/interfaces-global-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy -std=c++20 %s cppcoreguidelines-interfaces-global-init %t
+// RUN: %check_clang_tidy %s cppcoreguidelines-interfaces-global-init %t
 
 constexpr int makesInt() { return 3; }
 constexpr int takesInt(int i) { return i + 1; }
@@ -14,18 +14,22 @@ static int GlobalScopeBadInit3 = takesIntPtr(&ExternGlobal);
 static int GlobalScopeBadInit4 = 3 * (ExternGlobal + 2);
 // CHECK-MESSAGES: [[@LINE-1]]:12: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'ExternGlobal'
 
+#if __cplusplus >= 202002L
 extern constinit int ExternConstinitGlobal;
 static int GlobalScopeConstinit1 = ExternConstinitGlobal;
 static int GlobalScopeConstinit2 = takesInt(ExternConstinitGlobal);
 static int GlobalScopeConstinit3 = takesIntPtr(&ExternConstinitGlobal);
 static int GlobalScopeConstinit4 = 3 * (ExternConstinitGlobal + 2);
+#endif
 
 namespace ns {
 static int NamespaceScope = makesInt();
 static int NamespaceScopeBadInit = takesInt(ExternGlobal);
 // CHECK-MESSAGES: [[@LINE-1]]:12: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'ExternGlobal'
 
+#if __cplusplus >= 202002L
 static int NamespaceScopeConstinit = takesInt(ExternConstinitGlobal);
+#endif
 
 struct A {
   static int ClassScope;
@@ -38,6 +42,7 @@ int A::ClassScopeBadInit = takesInt(ExternGlobal);
 static int FromClassBadInit = takesInt(A::ClassScope);
 // CHECK-MESSAGES: [[@LINE-1]]:12: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'ClassScope'
 
+#if __cplusplus >= 202002L
 struct B {
   static constinit int ClassScopeConstinit;
   static int ClassScopeFromConstinit;
@@ -45,6 +50,7 @@ struct B {
 
 int B::ClassScopeFromConstinit = takesInt(ExternConstinitGlobal);
 static int FromClassScopeConstinit = takesInt(B::ClassScopeConstinit);
+#endif
 
 } // namespace ns
 
@@ -59,6 +65,7 @@ const int B1::J;
 // CHECK-MESSAGES: [[@LINE-1]]:15: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'I'
 const int B1::I;
 
+#if __cplusplus >= 202002L
 class D {
   static const constinit int I = 0;
   static const int J = I;
@@ -66,6 +73,7 @@ class D {
 
 const int D::J;
 const int D::I;
+#endif
 
 void f() {
   // This is fine, it's executed after dynamic initialization occurs.

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/interfaces-global-init.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/interfaces-global-init.cpp
@@ -1,4 +1,4 @@
-// RUN: %check_clang_tidy %s cppcoreguidelines-interfaces-global-init %t
+// RUN: %check_clang_tidy -std=c++20 %s cppcoreguidelines-interfaces-global-init %t
 
 constexpr int makesInt() { return 3; }
 constexpr int takesInt(int i) { return i + 1; }
@@ -14,10 +14,18 @@ static int GlobalScopeBadInit3 = takesIntPtr(&ExternGlobal);
 static int GlobalScopeBadInit4 = 3 * (ExternGlobal + 2);
 // CHECK-MESSAGES: [[@LINE-1]]:12: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'ExternGlobal'
 
+extern constinit int ExternConstinitGlobal;
+static int GlobalScopeConstinit1 = ExternConstinitGlobal;
+static int GlobalScopeConstinit2 = takesInt(ExternConstinitGlobal);
+static int GlobalScopeConstinit3 = takesIntPtr(&ExternConstinitGlobal);
+static int GlobalScopeConstinit4 = 3 * (ExternConstinitGlobal + 2);
+
 namespace ns {
 static int NamespaceScope = makesInt();
 static int NamespaceScopeBadInit = takesInt(ExternGlobal);
 // CHECK-MESSAGES: [[@LINE-1]]:12: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'ExternGlobal'
+
+static int NamespaceScopeConstinit = takesInt(ExternConstinitGlobal);
 
 struct A {
   static int ClassScope;
@@ -29,6 +37,15 @@ int A::ClassScopeBadInit = takesInt(ExternGlobal);
 
 static int FromClassBadInit = takesInt(A::ClassScope);
 // CHECK-MESSAGES: [[@LINE-1]]:12: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'ClassScope'
+
+struct B {
+  static constinit int ClassScopeConstinit;
+  static int ClassScopeFromConstinit;
+};
+
+int B::ClassScopeFromConstinit = takesInt(ExternConstinitGlobal);
+static int FromClassScopeConstinit = takesInt(B::ClassScopeConstinit);
+
 } // namespace ns
 
 // "const int B::I;" is fine, it just ODR-defines B::I. See [9.4.3] Static
@@ -41,6 +58,14 @@ class B1 {
 const int B1::J;
 // CHECK-MESSAGES: [[@LINE-1]]:15: warning: initializing non-local variable with non-const expression depending on uninitialized non-local variable 'I'
 const int B1::I;
+
+class D {
+  static const constinit int I = 0;
+  static const int J = I;
+};
+
+const int D::J;
+const int D::I;
 
 void f() {
   // This is fine, it's executed after dynamic initialization occurs.
@@ -81,4 +106,3 @@ class B2 {
 };
 const int B2::I;
 const int B2::J;
-


### PR DESCRIPTION
This check already understands how `constexpr` makes initialization order problems impossible, and C++20's `constinit` provides the exact same guarantees.
