### PR TITLE
[clang] Fix suppressing diagnostics for uninitialized variables

### DIFF
--- a/clang/test/SemaCXX/warn-no-sometimes-uninitialized.cpp
+++ b/clang/test/SemaCXX/warn-no-sometimes-uninitialized.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -fsyntax-only -Wuninitialized -Wno-sometimes-uninitialized -verify %s
+
+void foo(const int &);
+
+int f(bool a) {
+  int v;
+  if (a) {
+    foo(v); // expected-warning {{variable 'v' is uninitialized when passed as a const reference argument here}}
+    v = 5;
+  }
+  return v;
+}


### PR DESCRIPTION
When one kind of diagnostics is disabled, this should not preclude other diagnostics from displaying, even if they have lower priority. For example, this should print a warning about passing an uninitialized variable as a const reference:
```
> cat test.cpp
void foo(const int &);
int f(bool a) {
  int v;
  if (a) {
    foo(v);
    v = 5;
  }
  return v;
}
> clang test.cpp -fsyntax-only -Wuninitialized -Wno-sometimes-uninitialized
```