### PR TITLE
[ProfileData] Remove an unnecessary cast (NFC)

### DIFF
--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -1839,7 +1839,7 @@ std::error_code SampleProfileReaderGCC::readImpl() {
 }
 
 bool SampleProfileReaderGCC::hasFormat(const MemoryBuffer &Buffer) {
-  StringRef Magic(reinterpret_cast<const char *>(Buffer.getBufferStart()));
+  StringRef Magic(Buffer.getBufferStart());
   return Magic == "adcg*704";
 }
 


### PR DESCRIPTION
getBufferStart() already returns const char *.
