### PR TITLE
[RuntimeLibcalls] Use a multiclass for all libm impls (NFC)

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1236,7 +1236,6 @@ defm __log2_finite : LibmLibcallImpls<"LOG2_FINITE", "__log2<typesuffix>_finite"
 defm __log_finite : LibmLibcallImpls<"LOG_FINITE", "__log<typesuffix>_finite">;
 defm __pow_finite : LibmLibcallImpls<"POW_FINITE", "__pow<typesuffix>_finite">;
 
-
 /* Standard complex.h routines */
 
 // Present since C99

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -515,25 +515,25 @@ def MIPS16_RET_SC : RuntimeLibcall;
 def MIPS16_RET_SF : RuntimeLibcall;
 
 // Produce libcall impls for all float types. If provided, `rtbasename` should
-// contain an `X` that will be replaced with the `f`/`l`/`fX` suffix (if not
-// provided, it is appended to the def name).
+// contain a `<typesuffix>` that will be replaced with the `f`/`l`/`fX` suffix.
+// If not provided, it is appended to the def name.
 multiclass LibmLibcallImpls<string libcall_basename = !toupper(NAME),
-                            string rtbasename = !strconcat(NAME, "X")> {
+                            string rtbasename = !strconcat(NAME, "<typesuffix>")> {
   def NAME#"f"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F32"),
-                           !subst("X", "f", rtbasename)>;
+                           !subst("<typesuffix>", "f", rtbasename)>;
   def NAME#""
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F64"),
-                           !subst("X", "", rtbasename)>;
+                           !subst("<typesuffix>", "", rtbasename)>;
   def NAME#"l_f128"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F128"),
-                           !subst("X", "l", rtbasename)>;
+                           !subst("<typesuffix>", "l", rtbasename)>;
   def NAME#"l_ppcf128"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_PPCF128"),
-                           !subst("X", "l", rtbasename)>;
+                           !subst("<typesuffix>", "l", rtbasename)>;
   def NAME#"l_f80"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F80"),
-                           !subst("X", "l", rtbasename)>;
+                           !subst("<typesuffix>", "l", rtbasename)>;
 }
 
 // AArch64 calls
@@ -1229,12 +1229,12 @@ defm trunc : LibmLibcallImpls;
 /* math.h extensions */
 
 // Extensions for -ffinite-math-only
-defm __exp2_finite : LibmLibcallImpls<"EXP2_FINITE", "__exp2X_finite">;
-defm __exp_finite : LibmLibcallImpls<"EXP_FINITE", "__expX_finite">;
-defm __log10_finite : LibmLibcallImpls<"LOG10_FINITE", "__log10X_finite">;
-defm __log2_finite : LibmLibcallImpls<"LOG2_FINITE", "__log2X_finite">;
-defm __log_finite : LibmLibcallImpls<"LOG_FINITE", "__logX_finite">;
-defm __pow_finite : LibmLibcallImpls<"POW_FINITE", "__powX_finite">;
+defm __exp2_finite : LibmLibcallImpls<"EXP2_FINITE", "__exp2<typesuffix>_finite">;
+defm __exp_finite : LibmLibcallImpls<"EXP_FINITE", "__exp<typesuffix>_finite">;
+defm __log10_finite : LibmLibcallImpls<"LOG10_FINITE", "__log10<typesuffix>_finite">;
+defm __log2_finite : LibmLibcallImpls<"LOG2_FINITE", "__log2<typesuffix>_finite">;
+defm __log_finite : LibmLibcallImpls<"LOG_FINITE", "__log<typesuffix>_finite">;
+defm __pow_finite : LibmLibcallImpls<"POW_FINITE", "__pow<typesuffix>_finite">;
 
 
 /* Standard complex.h routines */

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1236,11 +1236,6 @@ defm __log2_finite : LibmLibcallImpls<"LOG2_FINITE", "__log2X_finite">;
 defm __log_finite : LibmLibcallImpls<"LOG_FINITE", "__logX_finite">;
 defm __pow_finite : LibmLibcallImpls<"POW_FINITE", "__powX_finite">;
 
-// Not specified as of C23 but present in numerous implementations
-defm sincos : LibmLibcallImpls;
-
-// Exists in sun math library
-defm sincospi : LibmLibcallImpls;
 
 /* Standard complex.h routines */
 
@@ -1658,15 +1653,19 @@ defset list<RuntimeLibcallImpl> CompilerRTOnlyInt128Libcalls = {
 
 // TODO: Define other custom names targets use to override
 
-def __exp10f : RuntimeLibcallImpl<EXP10_F32>;
+// Not specified as of C23 but present in numerous implementations
+defm sincos : LibmLibcallImpls;
+
+// Exists in sun math library
+defm sincospi : LibmLibcallImpls;
+
+// Exists on Apple targets
 def __exp10 : RuntimeLibcallImpl<EXP10_F64>;
-
-def __sincosf_stret : RuntimeLibcallImpl<SINCOS_STRET_F32>;
+def __exp10f : RuntimeLibcallImpl<EXP10_F32>;
 def __sincos_stret : RuntimeLibcallImpl<SINCOS_STRET_F64>;
-
-// Exists on macOS
-def __sincospif : RuntimeLibcallImpl<SINCOSPI_F32>;
+def __sincosf_stret : RuntimeLibcallImpl<SINCOS_STRET_F32>;
 def __sincospi : RuntimeLibcallImpl<SINCOSPI_F64>;
+def __sincospif : RuntimeLibcallImpl<SINCOSPI_F32>;
 
 def bzero : RuntimeLibcallImpl<BZERO>;
 def __bzero : RuntimeLibcallImpl<BZERO>;

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -514,19 +514,26 @@ def MIPS16_RET_DF : RuntimeLibcall;
 def MIPS16_RET_SC : RuntimeLibcall;
 def MIPS16_RET_SF : RuntimeLibcall;
 
-multiclass LibmLongDoubleLibCall<string libcall_basename = !toupper(!substr(NAME, 0, !sub(!size(NAME), 1))),
-                                 string rtname = NAME> {
-
-
-  def NAME#"_f128"
+// Produce libcall impls for all float types. If provided, `rtbasename` should
+// contain an `X` that will be replaced with the `f`/`l`/`fX` suffix (if not
+// provided, it is appended to the def name).
+multiclass LibmLibcallImpls<string libcall_basename = !toupper(NAME),
+                            string rtbasename = !strconcat(NAME, "X")> {
+  def NAME#"f"
+      : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F32"),
+                           !subst("X", "f", rtbasename)>;
+  def NAME#""
+      : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F64"),
+                           !subst("X", "", rtbasename)>;
+  def NAME#"l_f128"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F128"),
-                           rtname>;
-  def NAME#"_ppcf128"
+                           !subst("X", "l", rtbasename)>;
+  def NAME#"l_ppcf128"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_PPCF128"),
-                           rtname>;
-  def NAME#"_f80"
+                           !subst("X", "l", rtbasename)>;
+  def NAME#"l_f80"
       : RuntimeLibcallImpl<!cast<RuntimeLibcall>(libcall_basename#"_F80"),
-                           rtname>;
+                           !subst("X", "l", rtbasename)>;
 }
 
 // AArch64 calls
@@ -1165,245 +1172,90 @@ def __clear_cache : RuntimeLibcallImpl<CLEAR_CACHE>;
 // libm
 //--------------------------------------------------------------------
 
-def fmodf : RuntimeLibcallImpl<REM_F32>;
-def fmod : RuntimeLibcallImpl<REM_F64>;
-def fmodl_f128 : RuntimeLibcallImpl<REM_F128, "fmodl">;
-def fmodl_f80 : RuntimeLibcallImpl<REM_F80, "fmodl">;
-def fmodl_ppc128 : RuntimeLibcallImpl<REM_PPCF128, "fmodl">;
+/* Standard math.h routines */
 
-def fmaf : RuntimeLibcallImpl<FMA_F32>;
-def fma : RuntimeLibcallImpl<FMA_F64>;
-defm fmal : LibmLongDoubleLibCall;
+// Unless specified, all of these have been available since C99.
+defm acos : LibmLibcallImpls;
+defm asin : LibmLibcallImpls;
+defm atan : LibmLibcallImpls;
+defm atan2 : LibmLibcallImpls;
+defm cbrt : LibmLibcallImpls;
+defm ceil : LibmLibcallImpls;
+defm copysign : LibmLibcallImpls;
+defm cos : LibmLibcallImpls;
+defm cosh : LibmLibcallImpls;
+defm exp : LibmLibcallImpls;
+defm exp10 : LibmLibcallImpls; // C23
+defm exp2 : LibmLibcallImpls;
+defm fdim : LibmLibcallImpls;
+defm floor : LibmLibcallImpls;
+defm fma : LibmLibcallImpls;
+defm fmax : LibmLibcallImpls;
+defm fmaximum : LibmLibcallImpls; // C23
+defm fmaximum_num : LibmLibcallImpls; // C23
+defm fmin : LibmLibcallImpls;
+defm fminimum : LibmLibcallImpls; // C23
+defm fminimum_num : LibmLibcallImpls; // C23
+defm fmod : LibmLibcallImpls<"REM">;
+defm frexp : LibmLibcallImpls;
+defm ldexp : LibmLibcallImpls;
+defm llrint : LibmLibcallImpls;
+defm llround : LibmLibcallImpls;
+defm log : LibmLibcallImpls;
+defm log10 : LibmLibcallImpls;
+defm log2 : LibmLibcallImpls;
+defm lrint : LibmLibcallImpls;
+defm lround : LibmLibcallImpls;
+defm modf : LibmLibcallImpls;
+defm nan : LibmLibcallImpls;
+defm nearbyint : LibmLibcallImpls;
+defm nexttoward : LibmLibcallImpls;
+defm pow : LibmLibcallImpls;
+defm remainder : LibmLibcallImpls;
+defm remquo : LibmLibcallImpls;
+defm rint : LibmLibcallImpls;
+defm round : LibmLibcallImpls;
+defm roundeven : LibmLibcallImpls; // C23
+defm scalbln : LibmLibcallImpls;
+defm scalbn : LibmLibcallImpls;
+defm sin : LibmLibcallImpls;
+defm sinh : LibmLibcallImpls;
+defm sqrt : LibmLibcallImpls;
+defm tan : LibmLibcallImpls;
+defm tanh : LibmLibcallImpls;
+defm tgamma : LibmLibcallImpls;
+defm trunc : LibmLibcallImpls;
 
-def sqrtf : RuntimeLibcallImpl<SQRT_F32>;
-def sqrt : RuntimeLibcallImpl<SQRT_F64>;
-defm sqrtl : LibmLongDoubleLibCall;
+/* math.h extensions */
 
-def cbrtf : RuntimeLibcallImpl<CBRT_F32>;
-def cbrt : RuntimeLibcallImpl<CBRT_F64>;
-defm cbrtl : LibmLongDoubleLibCall;
+// Extensions for -ffinite-math-only
+defm __exp2_finite : LibmLibcallImpls<"EXP2_FINITE", "__exp2X_finite">;
+defm __exp_finite : LibmLibcallImpls<"EXP_FINITE", "__expX_finite">;
+defm __log10_finite : LibmLibcallImpls<"LOG10_FINITE", "__log10X_finite">;
+defm __log2_finite : LibmLibcallImpls<"LOG2_FINITE", "__log2X_finite">;
+defm __log_finite : LibmLibcallImpls<"LOG_FINITE", "__logX_finite">;
+defm __pow_finite : LibmLibcallImpls<"POW_FINITE", "__powX_finite">;
 
-def logf : RuntimeLibcallImpl<LOG_F32>;
-def log : RuntimeLibcallImpl<LOG_F64>;
-defm logl : LibmLongDoubleLibCall;
+// Not specified as of C23 but present in numerous implementations
+defm sincos : LibmLibcallImpls;
 
-def __logf_finite : RuntimeLibcallImpl<LOG_FINITE_F32>;
-def __log_finite : RuntimeLibcallImpl<LOG_FINITE_F64>;
-def __logl_finite_f80 : RuntimeLibcallImpl<LOG_FINITE_F80, "__logl_finite">;
-def __logl_finite_f128 : RuntimeLibcallImpl<LOG_FINITE_F128, "__logl_finite">;
-def __logl_finite_ppcf128 : RuntimeLibcallImpl<LOG_FINITE_PPCF128, "__logl_finite">;
+// Exists in sun math library
+defm sincospi : LibmLibcallImpls;
 
-def log2f : RuntimeLibcallImpl<LOG2_F32>;
-def log2 : RuntimeLibcallImpl<LOG2_F64>;
-defm log2l : LibmLongDoubleLibCall;
+/* Standard complex.h routines */
 
-def __log2f_finite : RuntimeLibcallImpl<LOG2_FINITE_F32>;
-def __log2_finite : RuntimeLibcallImpl<LOG2_FINITE_F64>;
-def __log2l_finite_f80 : RuntimeLibcallImpl<LOG2_FINITE_F80, "__log2l_finite">;
-def __log2l_finite_f128 : RuntimeLibcallImpl<LOG2_FINITE_F128, "__log2l_finite">;
-def __log2l_finite_ppcf128 : RuntimeLibcallImpl<LOG2_FINITE_PPCF128, "__log2l_finite">;
+// Present since C99
+defm cabs : LibmLibcallImpls;
 
-def log10f : RuntimeLibcallImpl<LOG10_F32>;
-def log10 : RuntimeLibcallImpl<LOG10_F64>;
-defm log10l : LibmLongDoubleLibCall;
+/* Standard fenv.h routines */
 
-def __log10f_finite : RuntimeLibcallImpl<LOG10_FINITE_F32>;
-def __log10_finite : RuntimeLibcallImpl<LOG10_FINITE_F64>;
-def __log10l_finite_f80 : RuntimeLibcallImpl<LOG10_FINITE_F80, "__log10l_finite">;
-def __log10l_finite_f128 : RuntimeLibcallImpl<LOG10_FINITE_F128, "__log10l_finite">;
-def __log10l_finite_ppcf128 : RuntimeLibcallImpl<LOG10_FINITE_PPCF128, "__log10l_finite">;
-
-def expf : RuntimeLibcallImpl<EXP_F32>;
-def exp : RuntimeLibcallImpl<EXP_F64>;
-defm expl : LibmLongDoubleLibCall<"EXP">;
-
-def __expf_finite : RuntimeLibcallImpl<EXP_FINITE_F32>;
-def __exp_finite : RuntimeLibcallImpl<EXP_FINITE_F64>;
-def __expl_finite_f80 : RuntimeLibcallImpl<EXP_FINITE_F80, "__expl_finite">;
-def __expl_finite_f128 : RuntimeLibcallImpl<EXP_FINITE_F128, "__expl_finite">;
-def __expl_finite_ppcf128 : RuntimeLibcallImpl<EXP_FINITE_PPCF128, "__expl_finite">;
-
-def exp2f : RuntimeLibcallImpl<EXP2_F32>;
-def exp2 : RuntimeLibcallImpl<EXP2_F64>;
-defm exp2l : LibmLongDoubleLibCall<"EXP2">;
-
-def __exp2f_finite : RuntimeLibcallImpl<EXP2_FINITE_F32>;
-def __exp2_finite : RuntimeLibcallImpl<EXP2_FINITE_F64>;
-def __exp2l_finite_f80 : RuntimeLibcallImpl<EXP2_FINITE_F80, "__exp2l_finite">;
-def __exp2l_finite_f128 : RuntimeLibcallImpl<EXP2_FINITE_F128, "__exp2l_finite">;
-def __exp2l_finite_ppcf128 : RuntimeLibcallImpl<EXP2_FINITE_PPCF128, "__exp2l_finite">;
-
-def sinf : RuntimeLibcallImpl<SIN_F32>;
-def sin : RuntimeLibcallImpl<SIN_F64>;
-defm sinl : LibmLongDoubleLibCall;
-
-def cosf : RuntimeLibcallImpl<COS_F32>;
-def cos : RuntimeLibcallImpl<COS_F64>;
-defm cosl : LibmLongDoubleLibCall;
-
-def tanf : RuntimeLibcallImpl<TAN_F32>;
-def tan : RuntimeLibcallImpl<TAN_F64>;
-defm tanl : LibmLongDoubleLibCall;
-
-def sinhf : RuntimeLibcallImpl<SINH_F32>;
-def sinh : RuntimeLibcallImpl<SINH_F64>;
-defm sinhl : LibmLongDoubleLibCall;
-
-def coshf : RuntimeLibcallImpl<COSH_F32>;
-def cosh : RuntimeLibcallImpl<COSH_F64>;
-defm coshl : LibmLongDoubleLibCall;
-
-def tanhf : RuntimeLibcallImpl<TANH_F32>;
-def tanh : RuntimeLibcallImpl<TANH_F64>;
-defm tanhl : LibmLongDoubleLibCall;
-
-def asinf : RuntimeLibcallImpl<ASIN_F32>;
-def asin : RuntimeLibcallImpl<ASIN_F64>;
-defm asinl : LibmLongDoubleLibCall;
-
-def acosf : RuntimeLibcallImpl<ACOS_F32>;
-def acos : RuntimeLibcallImpl<ACOS_F64>;
-defm acosl : LibmLongDoubleLibCall;
-
-def atanf : RuntimeLibcallImpl<ATAN_F32>;
-def atan : RuntimeLibcallImpl<ATAN_F64>;
-defm atanl : LibmLongDoubleLibCall;
-
-def atan2f : RuntimeLibcallImpl<ATAN2_F32>;
-def atan2 : RuntimeLibcallImpl<ATAN2_F64>;
-defm atan2l : LibmLongDoubleLibCall;
-
-def powf : RuntimeLibcallImpl<POW_F32>;
-def pow : RuntimeLibcallImpl<POW_F64>;
-defm powl : LibmLongDoubleLibCall;
-
-def __powf_finite : RuntimeLibcallImpl<POW_FINITE_F32>;
-def __pow_finite : RuntimeLibcallImpl<POW_FINITE_F64>;
-def __powl_finite_f80 : RuntimeLibcallImpl<POW_FINITE_F80, "__powl_finite">;
-def __powl_finite_f128 : RuntimeLibcallImpl<POW_FINITE_F128, "__powl_finite">;
-def __powl_finite_ppcf128 : RuntimeLibcallImpl<POW_FINITE_PPCF128, "__powl_finite">;
-
-def ceilf : RuntimeLibcallImpl<CEIL_F32>;
-def ceil : RuntimeLibcallImpl<CEIL_F64>;
-defm ceill : LibmLongDoubleLibCall;
-
-def truncf : RuntimeLibcallImpl<TRUNC_F32>;
-def trunc : RuntimeLibcallImpl<TRUNC_F64>;
-defm truncl : LibmLongDoubleLibCall;
-
-def rintf : RuntimeLibcallImpl<RINT_F32>;
-def rint : RuntimeLibcallImpl<RINT_F64>;
-defm rintl : LibmLongDoubleLibCall;
-
-def nearbyintf : RuntimeLibcallImpl<NEARBYINT_F32>;
-def nearbyint : RuntimeLibcallImpl<NEARBYINT_F64>;
-defm nearbyintl : LibmLongDoubleLibCall;
-
-def roundf : RuntimeLibcallImpl<ROUND_F32>;
-def round : RuntimeLibcallImpl<ROUND_F64>;
-defm roundl : LibmLongDoubleLibCall;
-
-def roundevenf : RuntimeLibcallImpl<ROUNDEVEN_F32>;
-def roundeven : RuntimeLibcallImpl<ROUNDEVEN_F64>;
-defm roundevenl : LibmLongDoubleLibCall;
-
-def floorf : RuntimeLibcallImpl<FLOOR_F32>;
-def floor : RuntimeLibcallImpl<FLOOR_F64>;
-defm floorl : LibmLongDoubleLibCall;
-
-def copysignf : RuntimeLibcallImpl<COPYSIGN_F32>;
-def copysign : RuntimeLibcallImpl<COPYSIGN_F64>;
-defm copysignl : LibmLongDoubleLibCall;
-
-def fminf : RuntimeLibcallImpl<FMIN_F32>;
-def fmin : RuntimeLibcallImpl<FMIN_F64>;
-defm fminl : LibmLongDoubleLibCall;
-
-def fmaxf : RuntimeLibcallImpl<FMAX_F32>;
-def fmax : RuntimeLibcallImpl<FMAX_F64>;
-defm fmaxl : LibmLongDoubleLibCall;
-
-def fminimumf : RuntimeLibcallImpl<FMINIMUM_F32>;
-def fminimum : RuntimeLibcallImpl<FMINIMUM_F64>;
-defm fminimuml : LibmLongDoubleLibCall;
-
-def fmaximumf : RuntimeLibcallImpl<FMAXIMUM_F32>;
-def fmaximum : RuntimeLibcallImpl<FMAXIMUM_F64>;
-defm fmaximuml : LibmLongDoubleLibCall;
-
-def fminimum_numf : RuntimeLibcallImpl<FMINIMUM_NUM_F32>;
-def fminimum_num : RuntimeLibcallImpl<FMINIMUM_NUM_F64>;
-defm fminimum_numl : LibmLongDoubleLibCall;
-
-def fmaximum_numf : RuntimeLibcallImpl<FMAXIMUM_NUM_F32>;
-def fmaximum_num : RuntimeLibcallImpl<FMAXIMUM_NUM_F64>;
-defm fmaximum_numl : LibmLongDoubleLibCall;
-
-def lroundf : RuntimeLibcallImpl<LROUND_F32>;
-def lround : RuntimeLibcallImpl<LROUND_F64>;
-defm lroundl : LibmLongDoubleLibCall;
-
-def llroundf : RuntimeLibcallImpl<LLROUND_F32>;
-def llround : RuntimeLibcallImpl<LLROUND_F64>;
-defm llroundl : LibmLongDoubleLibCall;
-
-def lrintf : RuntimeLibcallImpl<LRINT_F32>;
-def lrint : RuntimeLibcallImpl<LRINT_F64>;
-defm lrintl : LibmLongDoubleLibCall;
-
-def llrintf : RuntimeLibcallImpl<LLRINT_F32>;
-def llrint : RuntimeLibcallImpl<LLRINT_F64>;
-defm llrintl : LibmLongDoubleLibCall;
-
-def ldexpf : RuntimeLibcallImpl<LDEXP_F32>;
-def ldexp : RuntimeLibcallImpl<LDEXP_F64>;
-defm ldexpl : LibmLongDoubleLibCall;
-
-def frexpf : RuntimeLibcallImpl<FREXP_F32>;
-def frexp : RuntimeLibcallImpl<FREXP_F64>;
-defm frexpl : LibmLongDoubleLibCall;
-
-def modff : RuntimeLibcallImpl<MODF_F32>;
-def modf : RuntimeLibcallImpl<MODF_F64>;
-defm modfl : LibmLongDoubleLibCall;
-
-def nanf : RuntimeLibcallImpl<NAN_F32>;
-def nan : RuntimeLibcallImpl<NAN_F64>;
-defm nanl : LibmLongDoubleLibCall;
-
-def nexttowardf : RuntimeLibcallImpl<NEXTTOWARD_F32>;
-def nexttoward : RuntimeLibcallImpl<NEXTTOWARD_F64>;
-defm nexttowardl : LibmLongDoubleLibCall;
-
-def remainderf : RuntimeLibcallImpl<REMAINDER_F32>;
-def remainder : RuntimeLibcallImpl<REMAINDER_F64>;
-defm remainderl : LibmLongDoubleLibCall;
-
-def remquof : RuntimeLibcallImpl<REMQUO_F32>;
-def remquo : RuntimeLibcallImpl<REMQUO_F64>;
-defm remquol : LibmLongDoubleLibCall;
-
-def fdimf : RuntimeLibcallImpl<FDIM_F32>;
-def fdim : RuntimeLibcallImpl<FDIM_F64>;
-defm fdiml : LibmLongDoubleLibCall;
-
-def scalbnf : RuntimeLibcallImpl<SCALBN_F32>;
-def scalbn : RuntimeLibcallImpl<SCALBN_F64>;
-defm scalbnl : LibmLongDoubleLibCall;
-
-def scalblnf : RuntimeLibcallImpl<SCALBLN_F32>;
-def scalbln : RuntimeLibcallImpl<SCALBLN_F64>;
-defm scalblnl : LibmLongDoubleLibCall;
-
-def tgammaf : RuntimeLibcallImpl<TGAMMA_F32>;
-def tgamma : RuntimeLibcallImpl<TGAMMA_F64>;
-defm tgammal : LibmLongDoubleLibCall;
-
-// Floating point environment
+// Present since C99
 def fegetenv : RuntimeLibcallImpl<FEGETENV>;
 def fesetenv : RuntimeLibcallImpl<FESETENV>;
 
-// Floating point control modes
+/* fenv.h extensions */
+
+// Floating point control modes, present in glibc
 def fegetmode : RuntimeLibcallImpl<FEGETMODE>;
 def fesetmode : RuntimeLibcallImpl<FESETMODE>;
 
@@ -1427,12 +1279,6 @@ def calloc : RuntimeLibcallImpl<CALLOC>;
 def free : RuntimeLibcallImpl<FREE>;
 
 } // End let IsDefault = true
-
-def exp10f : RuntimeLibcallImpl<EXP10_F32>;
-def exp10 : RuntimeLibcallImpl<EXP10_F64>;
-def exp10l_f80 : RuntimeLibcallImpl<EXP10_F80, "exp10l">;
-def exp10l_f128 : RuntimeLibcallImpl<EXP10_F128, "exp10l">;
-def exp10l_ppcf128 : RuntimeLibcallImpl<EXP10_PPCF128, "exp10l">;
 
 // Stack Protector Fail
 def __stack_chk_fail : RuntimeLibcallImpl<STACKPROTECTOR_CHECK_FAIL>;
@@ -1592,9 +1438,6 @@ def atol : RuntimeLibcallImpl<ATOL>;
 def atoll : RuntimeLibcallImpl<ATOLL>;
 def bcmp : RuntimeLibcallImpl<BCMP>;
 def bcopy : RuntimeLibcallImpl<BCOPY>;
-def cabs : RuntimeLibcallImpl<CABS_F64>;
-def cabsf : RuntimeLibcallImpl<CABS_F32>;
-defm cabsl : LibmLongDoubleLibCall;
 def chmod : RuntimeLibcallImpl<CHMOD>;
 def chown : RuntimeLibcallImpl<CHOWN>;
 def clearerr : RuntimeLibcallImpl<CLEARERR>;
@@ -1820,15 +1663,6 @@ def __exp10 : RuntimeLibcallImpl<EXP10_F64>;
 
 def __sincosf_stret : RuntimeLibcallImpl<SINCOS_STRET_F32>;
 def __sincos_stret : RuntimeLibcallImpl<SINCOS_STRET_F64>;
-
-def sincosf : RuntimeLibcallImpl<SINCOS_F32>;
-def sincos : RuntimeLibcallImpl<SINCOS_F64>;
-defm sincosl : LibmLongDoubleLibCall;
-
-// Exists in sun math library
-def sincospif : RuntimeLibcallImpl<SINCOSPI_F32>;
-def sincospi : RuntimeLibcallImpl<SINCOSPI_F64>;
-defm sincospil : LibmLongDoubleLibCall;
 
 // Exists on macOS
 def __sincospif : RuntimeLibcallImpl<SINCOSPI_F32>;


### PR DESCRIPTION
`LibmLongDoubleLibcalls` currently handles generating definitions for the three long double variants, but `F32` and `F64` always get a written definition. Simplify this by changing `LibmLongDoubleLibcalls` to `LibmLibcallImpls` that also expands `F32` and `F64`.

As part of this, `LibmLibcallImpls` can take a function name with an `X` placeholder, to be replaced with the float type suffix. This allows the multiclass to also be used for libcalls with the suffix in the middle rather than strictly at the end.