### PR TITLE
[libc++] Don't instantiate allocators in __hash_table on an incomplete type

### DIFF
--- a/libcxx/include/unordered_map
+++ b/libcxx/include/unordered_map
@@ -967,9 +967,8 @@ private:
   typedef __hash_value_type<key_type, mapped_type> __value_type;
   typedef __unordered_map_hasher<key_type, value_type, hasher, key_equal> __hasher;
   typedef __unordered_map_equal<key_type, value_type, key_equal, hasher> __key_equal;
-  typedef __rebind_alloc<allocator_traits<allocator_type>, __value_type> __allocator_type;
 
-  typedef __hash_table<__value_type, __hasher, __key_equal, __allocator_type> __table;
+  typedef __hash_table<__value_type, __hasher, __key_equal, allocator_type> __table;
 
   __table __table_;
 
@@ -1777,9 +1776,8 @@ private:
   typedef __hash_value_type<key_type, mapped_type> __value_type;
   typedef __unordered_map_hasher<key_type, value_type, hasher, key_equal> __hasher;
   typedef __unordered_map_equal<key_type, value_type, key_equal, hasher> __key_equal;
-  typedef __rebind_alloc<allocator_traits<allocator_type>, __value_type> __allocator_type;
 
-  typedef __hash_table<__value_type, __hasher, __key_equal, __allocator_type> __table;
+  typedef __hash_table<__value_type, __hasher, __key_equal, allocator_type> __table;
 
   __table __table_;
 

--- a/libcxx/test/std/containers/associative/multimap/incomplete_type.pass.cpp
+++ b/libcxx/test/std/containers/associative/multimap/incomplete_type.pass.cpp
@@ -13,6 +13,7 @@
 
 #include <map>
 
+#include "min_allocator.h"
 #include "test_macros.h"
 
 struct A {
@@ -27,6 +28,9 @@ inline bool operator==(A const& L, A const& R) { return &L == &R; }
 inline bool operator<(A const& L, A const& R) { return L.data < R.data; }
 int main(int, char**) {
   A a;
+
+  // Make sure that the allocator isn't rebound to and incomplete type
+  std::multimap<int, int, std::less<int>, complete_type_allocator<std::pair<const int, int> > > m;
 
   return 0;
 }

--- a/libcxx/test/std/containers/unord/unord.map/incomplete_type.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.map/incomplete_type.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <unordered_map>
 
+#include "min_allocator.h"
 #include "test_macros.h"
 
 template <class Tp>
@@ -35,6 +36,10 @@ inline bool operator==(A const& L, A const& R) { return &L == &R; }
 
 int main(int, char**) {
   A a;
+
+  // Make sure that the allocator isn't rebound to an incomplete type
+  std::unordered_map<int, int, std::hash<int>, std::equal_to<int>, complete_type_allocator<std::pair<const int, int> > >
+      m;
 
   return 0;
 }

--- a/libcxx/test/std/containers/unord/unord.multimap/incomplete.pass.cpp
+++ b/libcxx/test/std/containers/unord/unord.multimap/incomplete.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <unordered_map>
 
+#include "min_allocator.h"
 #include "test_macros.h"
 
 template <class Tp>
@@ -35,6 +36,14 @@ inline bool operator==(A const& L, A const& R) { return &L == &R; }
 
 int main(int, char**) {
   A a;
+
+  // Make sure that the allocator isn't rebound to an incomplete type
+  std::unordered_multimap<int,
+                          int,
+                          std::hash<int>,
+                          std::equal_to<int>,
+                          complete_type_allocator<std::pair<const int, int> > >
+      m;
 
   return 0;
 }


### PR DESCRIPTION
Currently, we try to instantiate the allocator on `__hash_value_type`, which we don't define anymore. Instead, just use the `map::allocator_type` to instantiate `__tree`, since that's what we actually want anyways. 