### PR TITLE
[mlir][SCF] Do not access erased op in `scf.while` lowering

### DIFF
--- a/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
+++ b/mlir/lib/Conversion/SCFToControlFlow/SCFToControlFlow.cpp
@@ -630,14 +630,16 @@ DoWhileLowering::matchAndRewrite(WhileOp whileOp,
   // Loop around the "before" region based on condition.
   rewriter.setInsertionPointToEnd(before);
   auto condOp = cast<ConditionOp>(before->getTerminator());
-  rewriter.replaceOpWithNewOp<cf::CondBranchOp>(condOp, condOp.getCondition(),
-                                                before, condOp.getArgs(),
-                                                continuation, ValueRange());
+  rewriter.create<cf::CondBranchOp>(condOp.getLoc(), condOp.getCondition(),
+                                    before, condOp.getArgs(), continuation,
+                                    ValueRange());
 
   // Replace the op with values "yielded" from the "before" region, which are
   // visible by dominance.
   rewriter.replaceOp(whileOp, condOp.getArgs());
 
+  // Erase the condition op.
+  rewriter.eraseOp(condOp);
   return success();
 }
 


### PR DESCRIPTION
Do not access the erased `scf.condition` operation in the lowering pattern. That won't work anymore in a One-Shot Dialect Conversion and triggers a use-after-free sanitizer error.

After the One-Shot Dialect Conversion refactoring, a `ConversionPatternRewriter` will behave more like a normal `PatternRewriter`.
