### PR TITLE
[CIR][NFC] Resolve various nits for builtin bit operations

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -2678,7 +2678,7 @@ class CIR_BitOpBase<string mnemonic, TypeConstraint operandTy>
   let results = (outs operandTy:$result);
 
   let assemblyFormat = [{
-    `(` $input `:` type($input) `)` `:` type($result) attr-dict
+    $input `:` type($result) attr-dict
   }];
 }
 
@@ -2687,20 +2687,20 @@ class CIR_BitZeroCountOpBase<string mnemonic, TypeConstraint operandTy>
   let arguments = (ins operandTy:$input, UnitAttr:$poison_zero);
 
   let assemblyFormat = [{
-    `(` $input `:` type($input) `)` (`poison_zero` $poison_zero^)?
+    $input (`poison_zero` $poison_zero^)?
     `:` type($result) attr-dict
   }];
 }
 
-def BitClrsbOp : CIR_BitOpBase<"bit.clrsb", CIR_SIntOfWidths<[32, 64]>> {
+def BitClrsbOp : CIR_BitOpBase<"clrsb", CIR_SIntOfWidths<[32, 64]>> {
   let summary = "Get the number of leading redundant sign bits in the input";
   let description = [{
     Compute the number of leading redundant sign bits in the input integer.
 
     The input integer must be a signed integer. The most significant bit of the
-    input integer is the sign bit. The `cir.bit.clrsb` operation returns the
-    number of consecutive bits following the sign bit that are identical to the
-    sign bit.
+    input integer is the sign bit. The `cir.clrsb` operation returns the number
+    of consecutive bits following the sign bit that are identical to the sign
+    bit.
 
     The bit width of the input integer must be either 32 or 64.
 
@@ -2711,24 +2711,23 @@ def BitClrsbOp : CIR_BitOpBase<"bit.clrsb", CIR_SIntOfWidths<[32, 64]>> {
     %0 = cir.const #cir.int<3735928559> : !s32i
     // %1 will be 1 because there is 1 bit following the most significant bit
     // that is identical to it.
-    %1 = cir.bit.clrsb(%0 : !s32i) : !s32i
+    %1 = cir.clrsb %0 : !s32i
 
     // %2 = 1, 0b0000_0000_0000_0000_0000_0000_0000_0001
     %2 = cir.const #cir.int<1> : !s32i
     // %3 will be 30 because there are 30 consecutive bits following the sign
     // bit that are identical to the sign bit.
-    %3 = cir.bit.clrsb(%2 : !s32i) : !s32i
+    %3 = cir.clrsb %2 : !s32i
     ```
   }];
 }
 
-def BitClzOp : CIR_BitZeroCountOpBase<"bit.clz",
-                                      CIR_UIntOfWidths<[16, 32, 64]>> {
+def BitClzOp : CIR_BitZeroCountOpBase<"clz", CIR_UIntOfWidths<[16, 32, 64]>> {
   let summary = "Get the number of leading 0-bits in the input";
   let description = [{
     Compute the number of leading 0-bits in the input.
 
-    The input integer must be an unsigned integer. The `cir.bit.clz` operation
+    The input integer must be an unsigned integer. The `cir.clz` operation
     returns the number of consecutive 0-bits at the most significant bit
     position in the input.
 
@@ -2741,18 +2740,17 @@ def BitClzOp : CIR_BitZeroCountOpBase<"bit.clz",
     // %0 = 0b0000_0000_0000_0000_0000_0000_0000_1000
     %0 = cir.const #cir.int<8> : !u32i
     // %1 will be 28
-    %1 = cir.bit.clz(%0 : !u32i) poison_zero : !u32i
+    %1 = cir.clz %0 poison_zero : !u32i
     ```
   }];
 }
 
-def BitCtzOp : CIR_BitZeroCountOpBase<"bit.ctz",
-                                      CIR_UIntOfWidths<[16, 32, 64]>> {
+def BitCtzOp : CIR_BitZeroCountOpBase<"ctz", CIR_UIntOfWidths<[16, 32, 64]>> {
   let summary = "Get the number of trailing 0-bits in the input";
   let description = [{
     Compute the number of trailing 0-bits in the input.
 
-    The input integer must be an unsigned integer. The `cir.bit.ctz` operation
+    The input integer must be an unsigned integer. The `cir.ctz` operation
     counts the number of consecutive 0-bits starting from the least significant
     bit.
 
@@ -2765,12 +2763,12 @@ def BitCtzOp : CIR_BitZeroCountOpBase<"bit.ctz",
     // %0 = 0b1000
     %0 = cir.const #cir.int<8> : !u32i
     // %1 will be 3
-    %1 = cir.bit.ctz(%0 : !u32i) poison_zero : !u32i
+    %1 = cir.ctz %0 poison_zero : !u32i
     ```
   }];
 }
 
-def BitParityOp : CIR_BitOpBase<"bit.parity", CIR_UIntOfWidths<[32, 64]>> {
+def BitParityOp : CIR_BitOpBase<"parity", CIR_UIntOfWidths<[32, 64]>> {
   let summary = "Get the parity of input";
   let description = [{
     Compute the parity of the input. The parity of an integer is the number of
@@ -2784,13 +2782,12 @@ def BitParityOp : CIR_BitOpBase<"bit.parity", CIR_UIntOfWidths<[32, 64]>> {
     // %0 = 0x0110_1000
     %0 = cir.const #cir.int<104> : !u32i
     // %1 will be 1 since there are three 1-bits in %0
-    %1 = cir.bit.parity(%0 : !u32i) : !u32i
+    %1 = cir.parity %0 : !u32i
     ```
   }];
 }
 
-def BitPopcountOp : CIR_BitOpBase<"bit.popcnt",
-                                  CIR_UIntOfWidths<[16, 32, 64]>> {
+def BitPopcountOp : CIR_BitOpBase<"popcount", CIR_UIntOfWidths<[16, 32, 64]>> {
   let summary = "Get the number of 1-bits in input";
   let description = [{
     Compute the number of 1-bits in the input.
@@ -2803,25 +2800,22 @@ def BitPopcountOp : CIR_BitOpBase<"bit.popcnt",
     // %0 = 0x0110_1000
     %0 = cir.const #cir.int<104> : !u32i
     // %1 will be 3 since there are 3 1-bits in %0
-    %1 = cir.bit.popcnt(%0 : !u32i) : !u32i
+    %1 = cir.popcount %0 : !u32i
     ```
   }];
 }
 
-def BitReverseOp : CIR_BitOpBase<"bit.reverse",
+def BitReverseOp : CIR_BitOpBase<"bitreverse",
                                  CIR_UIntOfWidths<[8, 16, 32, 64]>> {
   let summary = "Reverse the bit pattern of the operand integer";
   let description = [{
-    The `cir.bit.reverse` operation reverses the bits of the operand integer.
-    Its only argument must be of unsigned integer types of width 8, 16, 32, or
-    64.
-
-    This operation covers the C/C++ builtin function `__builtin_bitreverse`.
+    The `cir.bitreverse` operation reverses the bits of the operand integer. Its
+    only argument must be of unsigned integer types of width 8, 16, 32, or 64.
 
     Example:
 
     ```mlir
-    %1 = cir.bit.reverse(%0 : !u32i): !u32i
+    %1 = cir.bitreverse %0: !u32i
     ```
   }];
 }
@@ -2842,7 +2836,7 @@ def ByteSwapOp : CIR_BitOpBase<"byte_swap", CIR_UIntOfWidths<[16, 32, 64]>> {
     %0 = cir.const #cir.int<305419896> : !u32i
 
     // %1 should be 0x78563412
-    %1 = cir.byte_swap(%0 : !u32i) : !u32i
+    %1 = cir.byte_swap %0 : !u32i
     ```
   }];
 }

--- a/clang/test/CIR/CodeGen/builtin_bit.cpp
+++ b/clang/test/CIR/CodeGen/builtin_bit.cpp
@@ -10,7 +10,7 @@ int test_builtin_clrsb(int x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_clrsbi
-// CIR:         [[TMP:%.+]] = cir.bit.clrsb(%{{.+}} : !s32i) : !s32i
+// CIR:         [[TMP:%.+]] = cir.clrsb %{{.+}} : !s32i
 
 // LLVM-LABEL: _Z18test_builtin_clrsbi
 // LLVM:         %[[X:.+]] = load i32, ptr %{{.+}}, align 4
@@ -33,7 +33,7 @@ int test_builtin_clrsbl(long x) {
 }
 
 // CIR-LABEL: _Z19test_builtin_clrsbll
-// CIR:         [[TMP:%.+]] = cir.bit.clrsb(%{{.+}} : !s64i) : !s64i
+// CIR:         [[TMP:%.+]] = cir.clrsb %{{.+}} : !s64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !s64i), !s32i
 
 // LLVM-LABEL: _Z19test_builtin_clrsbll
@@ -57,7 +57,7 @@ int test_builtin_clrsbll(long long x) {
 }
 
 // CIR-LABEL: _Z20test_builtin_clrsbllx
-// CIR:         [[TMP:%.+]] = cir.bit.clrsb(%{{.+}} : !s64i) : !s64i
+// CIR:         [[TMP:%.+]] = cir.clrsb %{{.+}} : !s64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !s64i), !s32i
 
 // LLVM-LABEL: _Z20test_builtin_clrsbllx
@@ -81,7 +81,7 @@ int test_builtin_ctzs(unsigned short x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_ctzst
-// CIR:         [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u16i) poison_zero : !u16i
+// CIR:         [[TMP:%.+]] = cir.ctz %{{.+}} poison_zero : !u16i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u16i), !s32i
 
 // LLVM-LABEL: _Z17test_builtin_ctzst
@@ -95,7 +95,7 @@ int test_builtin_ctz(unsigned x) {
 }
 
 // CIR-LABEL: _Z16test_builtin_ctzj
-// CIR:         [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u32i) poison_zero : !u32i
+// CIR:         [[TMP:%.+]] = cir.ctz %{{.+}} poison_zero : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z16test_builtin_ctzj
@@ -109,7 +109,7 @@ int test_builtin_ctzl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_ctzlm
-// CIR:         [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u64i) poison_zero : !u64i
+// CIR:         [[TMP:%.+]] = cir.ctz %{{.+}} poison_zero : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z17test_builtin_ctzlm
@@ -123,7 +123,7 @@ int test_builtin_ctzll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_ctzlly
-// CIR:         [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u64i) poison_zero : !u64i
+// CIR:         [[TMP:%.+]] = cir.ctz %{{.+}} poison_zero : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z18test_builtin_ctzlly
@@ -137,7 +137,7 @@ int test_builtin_ctzg(unsigned x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_ctzgj
-// CIR:         [[TMP:%.+]] = cir.bit.ctz(%{{.+}} : !u32i) poison_zero : !u32i
+// CIR:         [[TMP:%.+]] = cir.ctz %{{.+}} poison_zero : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z17test_builtin_ctzgj
@@ -151,7 +151,7 @@ int test_builtin_clzs(unsigned short x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_clzst
-// CIR:         [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u16i) poison_zero : !u16i
+// CIR:         [[TMP:%.+]] = cir.clz %{{.+}} poison_zero : !u16i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u16i), !s32i
 
 // LLVM-LABEL: _Z17test_builtin_clzst
@@ -165,7 +165,7 @@ int test_builtin_clz(unsigned x) {
 }
 
 // CIR-LABEL: _Z16test_builtin_clzj
-// CIR:         [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u32i) poison_zero : !u32i
+// CIR:         [[TMP:%.+]] = cir.clz %{{.+}} poison_zero : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z16test_builtin_clzj
@@ -179,7 +179,7 @@ int test_builtin_clzl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_clzlm
-// CIR:         [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u64i) poison_zero : !u64i
+// CIR:         [[TMP:%.+]] = cir.clz %{{.+}} poison_zero : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z17test_builtin_clzlm
@@ -193,7 +193,7 @@ int test_builtin_clzll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z18test_builtin_clzlly
-// CIR:         [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u64i) poison_zero : !u64i
+// CIR:         [[TMP:%.+]] = cir.clz %{{.+}} poison_zero : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z18test_builtin_clzlly
@@ -207,7 +207,7 @@ int test_builtin_clzg(unsigned x) {
 }
 
 // CIR-LABEL: _Z17test_builtin_clzgj
-// CIR:         [[TMP:%.+]] = cir.bit.clz(%{{.+}} : !u32i) poison_zero : !u32i
+// CIR:         [[TMP:%.+]] = cir.clz %{{.+}} poison_zero : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z17test_builtin_clzgj
@@ -221,7 +221,7 @@ int test_builtin_parity(unsigned x) {
 }
 
 // CIR-LABEL: _Z19test_builtin_parityj
-// CIR:         [[TMP:%.+]] = cir.bit.parity(%{{.+}} : !u32i) : !u32i
+// CIR:         [[TMP:%.+]] = cir.parity %{{.+}} : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z19test_builtin_parityj
@@ -239,7 +239,7 @@ int test_builtin_parityl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z20test_builtin_paritylm
-// CIR:         [[TMP:%.+]] = cir.bit.parity(%{{.+}} : !u64i) : !u64i
+// CIR:         [[TMP:%.+]] = cir.parity %{{.+}} : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z20test_builtin_paritylm
@@ -257,7 +257,7 @@ int test_builtin_parityll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z21test_builtin_paritylly
-// CIR:         [[TMP:%.+]] = cir.bit.parity(%{{.+}} : !u64i) : !u64i
+// CIR:         [[TMP:%.+]] = cir.parity %{{.+}} : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z21test_builtin_paritylly
@@ -275,7 +275,7 @@ int test_builtin_popcount(unsigned x) {
 }
 
 // CIR-LABEL: _Z21test_builtin_popcountj
-// CIR:         [[TMP:%.+]] = cir.bit.popcnt(%{{.+}} : !u32i) : !u32i
+// CIR:         [[TMP:%.+]] = cir.popcount %{{.+}} : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z21test_builtin_popcountj
@@ -289,7 +289,7 @@ int test_builtin_popcountl(unsigned long x) {
 }
 
 // CIR-LABEL: _Z22test_builtin_popcountlm
-// CIR:         [[TMP:%.+]] = cir.bit.popcnt(%{{.+}} : !u64i) : !u64i
+// CIR:         [[TMP:%.+]] = cir.popcount %{{.+}} : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z22test_builtin_popcountlm
@@ -303,7 +303,7 @@ int test_builtin_popcountll(unsigned long long x) {
 }
 
 // CIR-LABEL: _Z23test_builtin_popcountlly
-// CIR:         [[TMP:%.+]] = cir.bit.popcnt(%{{.+}} : !u64i) : !u64i
+// CIR:         [[TMP:%.+]] = cir.popcount %{{.+}} : !u64i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u64i), !s32i
 
 // LLVM-LABEL: _Z23test_builtin_popcountlly
@@ -317,7 +317,7 @@ int test_builtin_popcountg(unsigned x) {
 }
 
 // CIR-LABEL: _Z22test_builtin_popcountgj
-// CIR:         [[TMP:%.+]] = cir.bit.popcnt(%{{.+}} : !u32i) : !u32i
+// CIR:         [[TMP:%.+]] = cir.popcount %{{.+}} : !u32i
 // CIR:         {{%.+}} = cir.cast(integral, [[TMP]] : !u32i), !s32i
 
 // LLVM-LABEL: _Z22test_builtin_popcountgj
@@ -331,7 +331,7 @@ unsigned char test_builtin_bitreverse8(unsigned char x) {
 }
 
 // CIR-LABEL: @_Z24test_builtin_bitreverse8h
-// CIR:         %{{.+}} = cir.bit.reverse(%{{.+}} : !u8i) : !u8i
+// CIR:         %{{.+}} = cir.bitreverse %{{.+}} : !u8i
 
 // LLVM-LABEL: @_Z24test_builtin_bitreverse8h
 // LLVM:         %{{.+}} = call i8 @llvm.bitreverse.i8(i8 %{{.+}})
@@ -344,7 +344,7 @@ unsigned short test_builtin_bitreverse16(unsigned short x) {
 }
 
 // CIR-LABEL: @_Z25test_builtin_bitreverse16t
-// CIR:         %{{.+}} = cir.bit.reverse(%{{.+}} : !u16i) : !u16i
+// CIR:         %{{.+}} = cir.bitreverse %{{.+}} : !u16i
 
 // LLVM-LABEL: @_Z25test_builtin_bitreverse16t
 // LLVM:         %{{.+}} = call i16 @llvm.bitreverse.i16(i16 %{{.+}})
@@ -357,7 +357,7 @@ unsigned test_builtin_bitreverse32(unsigned x) {
 }
 
 // CIR-LABEL: @_Z25test_builtin_bitreverse32j
-// CIR:         %{{.+}} = cir.bit.reverse(%{{.+}} : !u32i) : !u32i
+// CIR:         %{{.+}} = cir.bitreverse %{{.+}} : !u32i
 
 // LLVM-LABEL: @_Z25test_builtin_bitreverse32j
 // LLVM:         %{{.+}} = call i32 @llvm.bitreverse.i32(i32 %{{.+}})
@@ -370,7 +370,7 @@ unsigned long long test_builtin_bitreverse64(unsigned long long x) {
 }
 
 // CIR-LABEL: @_Z25test_builtin_bitreverse64y
-// CIR:         %{{.+}} = cir.bit.reverse(%{{.+}} : !u64i) : !u64i
+// CIR:         %{{.+}} = cir.bitreverse %{{.+}} : !u64i
 
 // LLVM-LABEL: @_Z25test_builtin_bitreverse64y
 // LLVM:         %{{.+}} = call i64 @llvm.bitreverse.i64(i64 %{{.+}})
@@ -383,7 +383,7 @@ unsigned short test_builtin_bswap16(unsigned short x) {
 }
 
 // CIR-LABEL: @_Z20test_builtin_bswap16t
-// CIR:         %{{.+}} = cir.byte_swap(%{{.+}} : !u16i) : !u16i
+// CIR:         %{{.+}} = cir.byte_swap %{{.+}} : !u16i
 
 // LLVM-LABEL: @_Z20test_builtin_bswap16t
 // LLVM:         %{{.+}} = call i16 @llvm.bswap.i16(i16 %{{.+}})
@@ -396,7 +396,7 @@ unsigned test_builtin_bswap32(unsigned x) {
 }
 
 // CIR-LABEL: @_Z20test_builtin_bswap32j
-// CIR:         %{{.+}} = cir.byte_swap(%{{.+}} : !u32i) : !u32i
+// CIR:         %{{.+}} = cir.byte_swap %{{.+}} : !u32i
 
 // LLVM-LABEL: @_Z20test_builtin_bswap32j
 // LLVM:         %{{.+}} = call i32 @llvm.bswap.i32(i32 %{{.+}})
@@ -409,7 +409,7 @@ unsigned long long test_builtin_bswap64(unsigned long long x) {
 }
 
 // CIR-LABEL: @_Z20test_builtin_bswap64y
-// CIR:         %{{.+}} = cir.byte_swap(%{{.+}} : !u64i) : !u64i
+// CIR:         %{{.+}} = cir.byte_swap %{{.+}} : !u64i
 
 // LLVM-LABEL: @_Z20test_builtin_bswap64y
 // LLVM:         %{{.+}} = call i64 @llvm.bswap.i64(i64 %{{.+}})


### PR DESCRIPTION
This patch contains fixes for various nits mentioned in #147200:

- This patch removes the `bit.` prefix in the op mnemonic. The operation names now directly correspond to the builtin function names except for `bswap` which is represented by `cir.byte_swap` for more clarity.

- Since all bit operations are `SameOperandsAndResultType`, this patch updates their assembly format and avoids spelling out the operand type twice.