### PR TITLE
[clang-tools-extra][NFC] Fix link to code review in README.txt

### DIFF
--- a/clang-tools-extra/README.txt
+++ b/clang-tools-extra/README.txt
@@ -11,9 +11,8 @@ All discussion regarding Clang, Clang-based tools, and code in this repository
 should be held using the standard Clang forum:
   https://discourse.llvm.org/c/clang
 
-Code review for this tree should take place on the standard Clang patch and
-commit lists:
-  http://lists.llvm.org/mailman/listinfo/cfe-commits
+Code review for this tree should take place on Github:
+  https://github.com/llvm/llvm-project/pulls?q=label%3Aclang-tools-extra
 
 If you find a bug in these tools, please file it in the LLVM bug tracker:
   https://github.com/llvm/llvm-project/issues/

--- a/clang-tools-extra/README.txt
+++ b/clang-tools-extra/README.txt
@@ -8,8 +8,10 @@ Clang frontend.  These tools are kept in a separate "extra" repository to
 allow lighter weight checkouts of the core Clang codebase.
 
 All discussion regarding Clang, Clang-based tools, and code in this repository
-should be held using the standard Clang forum:
+should be held using the standard Clang forums:
   https://discourse.llvm.org/c/clang
+  https://discourse.llvm.org/c/clang/clang-tidy/71
+  https://discourse.llvm.org/c/clang/clangd/34
 
 Code review for this tree should take place on Github:
   https://github.com/llvm/llvm-project/pulls?q=label%3Aclang-tools-extra


### PR DESCRIPTION
I'm not sure if we need to add label inside link or not, but `lists.llvm.org` seems outdated for sure, WDYT?