### PR TITLE
[Mips] Remove unnecessary casts (NFC)

### DIFF
--- a/llvm/lib/Target/Mips/MicroMipsSizeReduction.cpp
+++ b/llvm/lib/Target/Mips/MicroMipsSizeReduction.cpp
@@ -781,7 +781,7 @@ bool MicroMipsSizeReduce::runOnMachineFunction(MachineFunction &MF) {
       Subtarget->hasMips32r6())
     return false;
 
-  MipsII = static_cast<const MipsInstrInfo *>(Subtarget->getInstrInfo());
+  MipsII = Subtarget->getInstrInfo();
 
   bool Modified = false;
   MachineFunction::iterator I = MF.begin(), E = MF.end();

--- a/llvm/lib/Target/Mips/MipsBranchExpansion.cpp
+++ b/llvm/lib/Target/Mips/MipsBranchExpansion.cpp
@@ -941,7 +941,7 @@ bool MipsBranchExpansion::runOnMachineFunction(MachineFunction &MF) {
   IsPIC = TM.isPositionIndependent();
   ABI = static_cast<const MipsTargetMachine &>(TM).getABI();
   STI = &MF.getSubtarget<MipsSubtarget>();
-  TII = static_cast<const MipsInstrInfo *>(STI->getInstrInfo());
+  TII = STI->getInstrInfo();
 
   if (IsPIC && ABI.IsO32() &&
       MF.getInfo<MipsFunctionInfo>()->globalBaseRegSet())

--- a/llvm/lib/Target/Mips/MipsSEFrameLowering.cpp
+++ b/llvm/lib/Target/Mips/MipsSEFrameLowering.cpp
@@ -403,8 +403,7 @@ void MipsSEFrameLowering::emitPrologue(MachineFunction &MF,
 
   const MipsSEInstrInfo &TII =
       *static_cast<const MipsSEInstrInfo *>(STI.getInstrInfo());
-  const MipsRegisterInfo &RegInfo =
-      *static_cast<const MipsRegisterInfo *>(STI.getRegisterInfo());
+  const MipsRegisterInfo &RegInfo = *STI.getRegisterInfo();
 
   MachineBasicBlock::iterator MBBI = MBB.begin();
   DebugLoc dl;
@@ -658,8 +657,7 @@ void MipsSEFrameLowering::emitEpilogue(MachineFunction &MF,
 
   const MipsSEInstrInfo &TII =
       *static_cast<const MipsSEInstrInfo *>(STI.getInstrInfo());
-  const MipsRegisterInfo &RegInfo =
-      *static_cast<const MipsRegisterInfo *>(STI.getRegisterInfo());
+  const MipsRegisterInfo &RegInfo = *STI.getRegisterInfo();
 
   DebugLoc DL = MBBI != MBB.end() ? MBBI->getDebugLoc() : DebugLoc();
   MipsABIInfo ABI = STI.getABI();


### PR DESCRIPTION
getRegisterInfo() already returns const MipsRegisterInfo *.

Likewise, getInstrInfo() already returns const MipsInstrInfo *.
