### PR TITLE
[mlir][Transforms] Dialect Conversion: `allowPatternRollback` to check foldings

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2176,6 +2176,7 @@ OperationLegalizer::legalizeWithFold(Operation *op,
   (void)rewriterImpl;
 
   // Try to fold the operation.
+  StringRef opName = op->getName().getStringRef();
   SmallVector<Value, 2> replacementValues;
   SmallVector<Operation *, 2> newOps;
   rewriter.setInsertionPoint(op);
@@ -2195,6 +2196,12 @@ OperationLegalizer::legalizeWithFold(Operation *op,
       LLVM_DEBUG(logFailure(rewriterImpl.logger,
                             "failed to legalize generated constant '{0}'",
                             newOp->getName()));
+      if (!config.allowPatternRollback) {
+        // Rolling back a folder is like rolling back a pattern.
+        llvm::report_fatal_error(
+            "op '" + opName +
+            "' folder rollback of IR modifications requested");
+      }
       // Legalization failed: erase all materialized constants.
       for (Operation *op : newOps)
         rewriter.eraseOp(op);


### PR DESCRIPTION
When an operation is folded to an attribute, the attribute must be materialized as a constant operation. That operation must then be legalized. If such a legalization fails, the entire folding is rolled back. This is not supported in a One-Shot Dialect Conversion. (Support for rolling back foldings could be added at a later point of time.)

This commit improves the `allowPatternRollback` flag handling, such that a fatal error is reported when a folder is attempted to be rolled back.

