### PR TITLE
[X86] Remove unnecessary casts (NFC)

### DIFF
--- a/llvm/lib/Target/X86/X86CallFrameOptimization.cpp
+++ b/llvm/lib/Target/X86/X86CallFrameOptimization.cpp
@@ -239,8 +239,7 @@ bool X86CallFrameOptimization::runOnMachineFunction(MachineFunction &MF) {
   TFL = STI->getFrameLowering();
   MRI = &MF.getRegInfo();
 
-  const X86RegisterInfo &RegInfo =
-      *static_cast<const X86RegisterInfo *>(STI->getRegisterInfo());
+  const X86RegisterInfo &RegInfo = *STI->getRegisterInfo();
   SlotSize = RegInfo.getSlotSize();
   assert(isPowerOf2_32(SlotSize) && "Expect power of 2 stack slot size");
   Log2SlotSize = Log2_32(SlotSize);
@@ -356,8 +355,7 @@ void X86CallFrameOptimization::collectCallInfo(MachineFunction &MF,
                                                CallContext &Context) {
   // Check that this particular call sequence is amenable to the
   // transformation.
-  const X86RegisterInfo &RegInfo =
-      *static_cast<const X86RegisterInfo *>(STI->getRegisterInfo());
+  const X86RegisterInfo &RegInfo = *STI->getRegisterInfo();
 
   // We expect to enter this at the beginning of a call sequence
   assert(I->getOpcode() == TII->getCallFrameSetupOpcode());


### PR DESCRIPTION
getRegisterInfo() already returns const X86RegisterInfo *.
