### PR TITLE
[Docs] Update Opt's Option to Specify Pass Pipeline (NFC)

### DIFF
--- a/llvm/docs/CommandGuide/opt.rst
+++ b/llvm/docs/CommandGuide/opt.rst
@@ -46,12 +46,13 @@ OPTIONS
 
  Write output in LLVM intermediate language (instead of bitcode).
 
-.. option:: -{passname}
+.. option:: --passes=<string>
 
- :program:`opt` provides the ability to run any of LLVM's optimization or
- analysis passes in any order.  The :option:`-help` option lists all the passes
- available.  The order in which the options occur on the command line are the
- order in which they are executed (within pass constraints).
+ A textual (comma separated) description of the pass pipeline
+ e.g.,-passes="foo,bar", to have analysis passes available before a pass, add
+ "require<foo-analysis>". See `Using the New Pass Manager
+ <../NewPassManager.html>`_, section ``#invoking-opt`` for more details on the
+ pass pipeline syntax.
 
 .. option:: -strip-debug
 

--- a/llvm/docs/CommandGuide/opt.rst
+++ b/llvm/docs/CommandGuide/opt.rst
@@ -49,7 +49,7 @@ OPTIONS
 .. option:: -passes=<string>
 
  A textual (comma-separated) description of the pass pipeline,
- e.g.,``-passes="sroa,instcombine"``. See
+ e.g., ``-passes="sroa,instcombine"``. See
  `invoking opt <../NewPassManager.html#invoking-opt>`_ for more details on the
  pass pipeline syntax.
 

--- a/llvm/docs/CommandGuide/opt.rst
+++ b/llvm/docs/CommandGuide/opt.rst
@@ -46,12 +46,11 @@ OPTIONS
 
  Write output in LLVM intermediate language (instead of bitcode).
 
-.. option:: --passes=<string>
+.. option:: -passes=<string>
 
- A textual (comma separated) description of the pass pipeline
- e.g.,-passes="foo,bar", to have analysis passes available before a pass, add
- "require<foo-analysis>". See `Using the New Pass Manager
- <../NewPassManager.html>`_, section ``#invoking-opt`` for more details on the
+ A textual (comma-separated) description of the pass pipeline,
+ e.g.,``-passes="sroa,instcombine"``. See
+ `invoking opt <../NewPassManager.html#invoking-opt>`_ for more details on the
  pass pipeline syntax.
 
 .. option:: -strip-debug


### PR DESCRIPTION
Since the new pass manager, we use `--passes=<string>` to specify the pass pipeline instead of the `-{passname}` syntax.