### PR TITLE
[libc] Update some implementation status for `search.h`

### DIFF
--- a/libc/docs/headers/search.rst
+++ b/libc/docs/headers/search.rst
@@ -29,7 +29,7 @@ Type Name                    Available
 ============================ =========
 ACTION                       |check|
 ENTRY                        |check|
-VISIT
+VISIT                        |check|
 ============================ =========
 
 POSIX Standard Functions
@@ -43,7 +43,7 @@ hdestroy                     |check|
 hsearch                      |check|
 insque                       |check|
 lfind                        |check|
-lsearch
+lsearch                      |check|
 remque                       |check|
 tdelete
 tfind


### PR DESCRIPTION
- `VISIT` was implemented in https://github.com/llvm/llvm-project/pull/132746.
- `lsearch` was implemented in https://github.com/llvm/llvm-project/pull/131431.

At first, I thought this would be updated automatically, but it seems that the header status needs to be added manually.