### PR TITLE
[CodeGen] Add 2 subtarget hooks canLowerToZeroCycleReg[Move|Zeroing]

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetSubtargetInfo.h
@@ -200,7 +200,7 @@ public:
   ///
   /// NOTE: Subtargets must maintain consistency between the logic here and
   /// on lowering.
-  virtual bool canLowerToZeroCycleRegMove(const MachineInstr *CopyMI,
+  virtual bool canLowerToZeroCycleRegMove(const MachineInstr &CopyMI,
                                           const Register &DestReg,
                                           const Register &SrcReg) const {
     return false;
@@ -221,7 +221,7 @@ public:
   ///
   /// NOTE: Subtargets must maintain consistency between the logic here and
   /// on lowering.
-  virtual bool canLowerToZeroCycleRegZeroing(const MachineInstr *CopyMI,
+  virtual bool canLowerToZeroCycleRegZeroing(const MachineInstr &CopyMI,
                                              const Register &DestReg,
                                              const Register &SrcReg) const {
     return false;

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -674,18 +674,18 @@ bool AArch64Subtarget::enableMachinePipeliner() const {
   return getSchedModel().hasInstrSchedModel();
 }
 
-bool AArch64Subtarget::isRegInClass(const MachineInstr *MI, const Register &Reg,
+bool AArch64Subtarget::isRegInClass(const MachineInstr &MI, const Register &Reg,
                                     const TargetRegisterClass *TRC) const {
   if (Reg.isPhysical()) {
     return TRC->contains(Reg);
   }
-  const MachineRegisterInfo &MRI = MI->getMF()->getRegInfo();
+  const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
   return TRC->hasSubClassEq(MRI.getRegClass(Reg));
 }
 
 /// NOTE: must maintain consistency with `AArch64InstrInfo::copyPhysReg`.
 bool AArch64Subtarget::canLowerToZeroCycleRegMove(
-    const MachineInstr *CopyMI, const Register &DestReg,
+    const MachineInstr &CopyMI, const Register &DestReg,
     const Register &SrcReg) const {
   if (isRegInClass(CopyMI, DestReg, &AArch64::GPR32allRegClass) &&
       isRegInClass(CopyMI, SrcReg, &AArch64::GPR32allRegClass) &&
@@ -737,7 +737,7 @@ bool AArch64Subtarget::canLowerToZeroCycleRegMove(
 
 /// NOTE: must maintain consistency with `AArch64InstrInfo::copyPhysReg`.
 bool AArch64Subtarget::canLowerToZeroCycleRegZeroing(
-    const MachineInstr *CopyMI, const Register &DestReg,
+    const MachineInstr &CopyMI, const Register &DestReg,
     const Register &SrcReg) const {
   if (isRegInClass(CopyMI, DestReg, &AArch64::GPR32allRegClass) &&
       isRegInClass(CopyMI, SrcReg, &AArch64::GPR32allRegClass) &&

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -679,7 +679,6 @@ bool AArch64Subtarget::isRegInClass(const MachineInstr *MI, const Register &Reg,
   if (Reg.isPhysical()) {
     return TRC->contains(Reg);
   }
-  
   const MachineRegisterInfo &MRI = MI->getMF()->getRegInfo();
   return TRC->hasSubClassEq(MRI.getRegClass(Reg));
 }

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -678,10 +678,10 @@ bool AArch64Subtarget::isRegInClass(const MachineInstr *MI, const Register &Reg,
                                     const TargetRegisterClass *TRC) const {
   if (Reg.isPhysical()) {
     return TRC->contains(Reg);
-  } else {
-    const MachineRegisterInfo &MRI = MI->getMF()->getRegInfo();
-    return TRC->hasSubClassEq(MRI.getRegClass(Reg));
   }
+  
+  const MachineRegisterInfo &MRI = MI->getMF()->getRegInfo();
+  return TRC->hasSubClassEq(MRI.getRegClass(Reg));
 }
 
 /// NOTE: must maintain consistency with `AArch64InstrInfo::copyPhysReg`.

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.h
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.h
@@ -123,7 +123,7 @@ private:
   /// Returns true if Reg is virtual and is assigned to,
   /// or is physcial and is a member of, the TRC register class.
   /// Otherwise, returns false.
-  bool isRegInClass(const MachineInstr *MI, const Register &Reg,
+  bool isRegInClass(const MachineInstr &MI, const Register &Reg,
                     const TargetRegisterClass *TRC) const;
 
 public:
@@ -169,10 +169,10 @@ public:
   bool enableMachinePipeliner() const override;
   bool useDFAforSMS() const override { return false; }
 
-  bool canLowerToZeroCycleRegMove(const MachineInstr *CopyMI,
+  bool canLowerToZeroCycleRegMove(const MachineInstr &CopyMI,
                                   const Register &DestReg,
                                   const Register &SrcReg) const override;
-  bool canLowerToZeroCycleRegZeroing(const MachineInstr *CopyMI,
+  bool canLowerToZeroCycleRegZeroing(const MachineInstr &CopyMI,
                                      const Register &DestReg,
                                      const Register &SrcReg) const override;
 


### PR DESCRIPTION
Adds 2 subtarget hooks `canLowerToZeroCycleRegMove` and `canLowerToZeroCycleRegZeroing` to enable query if an instruction can be lowered to a zero cycle instruction. The logic depends on the microarchitecture. This patch also provide an implementation for AArch64 based on `AArch64InstrInfo::copyPhysReg` which supports both physical and virtual registers.

It prepares for a register coalescer optimization to prevent rematerialization of moves where the target supports ZCM.
