### PR TITLE
Thread Safety Analysis: Compare values of literals

### DIFF
--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyCommon.h
@@ -35,8 +35,8 @@
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 #include <functional>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -91,9 +91,10 @@ inline bool partiallyMatches(const til::SExpr *E1, const til::SExpr *E2) {
 }
 
 inline std::string toString(const til::SExpr *E) {
-  std::stringstream ss;
+  std::string s;
+  llvm::raw_string_ostream ss(s);
   til::StdPrinter::print(E, ss);
-  return ss.str();
+  return s;
 }
 
 }  // namespace sx

--- a/clang/include/clang/Analysis/Analyses/ThreadSafetyTraverse.h
+++ b/clang/include/clang/Analysis/Analyses/ThreadSafetyTraverse.h
@@ -192,7 +192,6 @@ public:
   R_SExpr reduceUndefined(Undefined &Orig) { return true; }
   R_SExpr reduceWildcard(Wildcard &Orig) { return true; }
 
-  R_SExpr reduceLiteral(Literal &Orig) { return true; }
   template<class T>
   R_SExpr reduceLiteralT(LiteralT<T> &Orig) { return true; }
   R_SExpr reduceLiteralPtr(Literal &Orig) { return true; }
@@ -336,7 +335,7 @@ public:
   CType trueResult() { return true; }
   bool notTrue(CType ct) { return !ct; }
 
-  bool compareIntegers(unsigned i, unsigned j) { return i == j; }
+  bool compareIntegers(uint64_t i, uint64_t j) { return i == j; }
   bool compareStrings (StringRef s, StringRef r) { return s == r; }
   bool comparePointers(const void* P, const void* Q) { return P == Q; }
 
@@ -364,7 +363,7 @@ public:
   CType trueResult() { return true; }
   bool notTrue(CType ct) { return !ct; }
 
-  bool compareIntegers(unsigned i, unsigned j) { return i == j; }
+  bool compareIntegers(uint64_t i, uint64_t j) { return i == j; }
   bool compareStrings (StringRef s, StringRef r) { return s == r; }
   bool comparePointers(const void *P, const void *Q) { return P == Q; }
 
@@ -532,88 +531,34 @@ protected:
     SS << "*";
   }
 
-  template<class T>
-  void printLiteralT(const LiteralT<T> *E, StreamType &SS) {
-    SS << E->value();
-  }
-
-  void printLiteralT(const LiteralT<uint8_t> *E, StreamType &SS) {
-    SS << "'" << E->value() << "'";
-  }
-
   void printLiteral(const Literal *E, StreamType &SS) {
-    if (E->clangExpr()) {
-      SS << getSourceLiteralString(E->clangExpr());
+    ValueType VT = E->valueType();
+    switch (VT.Base) {
+    case ValueType::BT_Bool:
+      if (E->as<bool>().value())
+        SS << "true";
+      else
+        SS << "false";
+      return;
+    case ValueType::BT_Char:
+      CharacterLiteral::print(E->as<char32_t>().value(),
+                              CharacterLiteralKind::UTF32, SS);
+      return;
+    case ValueType::BT_SInt:
+      SS << E->as<int64_t>().value();
+      return;
+    case ValueType::BT_UInt:
+      SS << E->as<uint64_t>().value();
+      return;
+    case ValueType::BT_String:
+      SS << '\"' << E->as<StringRef>().value() << '\"';
+      return;
+    case ValueType::BT_NullPointer:
+      assert(E->as<std::nullptr_t>().value() == nullptr);
+      SS << "nullptr";
       return;
     }
-    else {
-      ValueType VT = E->valueType();
-      switch (VT.Base) {
-      case ValueType::BT_Void:
-        SS << "void";
-        return;
-      case ValueType::BT_Bool:
-        if (E->as<bool>().value())
-          SS << "true";
-        else
-          SS << "false";
-        return;
-      case ValueType::BT_Int:
-        switch (VT.Size) {
-        case ValueType::ST_8:
-          if (VT.Signed)
-            printLiteralT(&E->as<int8_t>(), SS);
-          else
-            printLiteralT(&E->as<uint8_t>(), SS);
-          return;
-        case ValueType::ST_16:
-          if (VT.Signed)
-            printLiteralT(&E->as<int16_t>(), SS);
-          else
-            printLiteralT(&E->as<uint16_t>(), SS);
-          return;
-        case ValueType::ST_32:
-          if (VT.Signed)
-            printLiteralT(&E->as<int32_t>(), SS);
-          else
-            printLiteralT(&E->as<uint32_t>(), SS);
-          return;
-        case ValueType::ST_64:
-          if (VT.Signed)
-            printLiteralT(&E->as<int64_t>(), SS);
-          else
-            printLiteralT(&E->as<uint64_t>(), SS);
-          return;
-        default:
-          break;
-        }
-        break;
-      case ValueType::BT_Float:
-        switch (VT.Size) {
-        case ValueType::ST_32:
-          printLiteralT(&E->as<float>(), SS);
-          return;
-        case ValueType::ST_64:
-          printLiteralT(&E->as<double>(), SS);
-          return;
-        default:
-          break;
-        }
-        break;
-      case ValueType::BT_String:
-        SS << "\"";
-        printLiteralT(&E->as<StringRef>(), SS);
-        SS << "\"";
-        return;
-      case ValueType::BT_Pointer:
-        SS << "#ptr";
-        return;
-      case ValueType::BT_ValueRef:
-        SS << "#vref";
-        return;
-      }
-    }
-    SS << "#lit";
+    llvm_unreachable("Invalid BaseType");
   }
 
   void printLiteralPtr(const LiteralPtr *E, StreamType &SS) {
@@ -919,7 +864,7 @@ protected:
   }
 };
 
-class StdPrinter : public PrettyPrinter<StdPrinter, std::ostream> {};
+class StdPrinter : public PrettyPrinter<StdPrinter, llvm::raw_ostream> {};
 
 } // namespace til
 } // namespace threadSafety

--- a/clang/lib/Analysis/ThreadSafetyCommon.cpp
+++ b/clang/lib/Analysis/ThreadSafetyCommon.cpp
@@ -337,15 +337,29 @@ til::SExpr *SExprBuilder::translate(const Stmt *S, CallingContext *Ctx) {
 
   // Collect all literals
   case Stmt::CharacterLiteralClass:
+    return new (Arena)
+        til::LiteralT<char32_t>(cast<CharacterLiteral>(S)->getValue());
   case Stmt::CXXNullPtrLiteralExprClass:
   case Stmt::GNUNullExprClass:
+    return new (Arena) til::LiteralT(nullptr);
   case Stmt::CXXBoolLiteralExprClass:
-  case Stmt::FloatingLiteralClass:
-  case Stmt::ImaginaryLiteralClass:
-  case Stmt::IntegerLiteralClass:
+    return new (Arena) til::LiteralT(cast<CXXBoolLiteralExpr>(S)->getValue());
+  case Stmt::IntegerLiteralClass: {
+    const auto *IL = cast<IntegerLiteral>(S);
+    const auto *BT = cast<BuiltinType>(IL->getType());
+    const llvm::APInt &Value = IL->getValue();
+    if (BT->isSignedInteger())
+      return new (Arena) til::LiteralT(Value.getSExtValue());
+    else if (BT->isUnsignedInteger())
+      return new (Arena) til::LiteralT(Value.getZExtValue());
+    else
+      llvm_unreachable("Invalid integer type");
+  }
   case Stmt::StringLiteralClass:
+    return new (Arena) til::LiteralT(cast<StringLiteral>(S)->getString());
   case Stmt::ObjCStringLiteralClass:
-    return new (Arena) til::Literal(cast<Expr>(S));
+    return new (Arena)
+        til::LiteralT(cast<ObjCStringLiteral>(S)->getString()->getString());
 
   case Stmt::DeclStmtClass:
     return translateDeclStmt(cast<DeclStmt>(S), Ctx);

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -2532,6 +2532,10 @@ public:
   Foo& getFoo()              { return *f; }
   Foo& getFoo2(int c)        { return *f; }
   Foo& getFoo3(int c, int d) { return *f; }
+  Foo& getFoo4(bool)         { return *f; }
+  Foo& getFoo5(char)         { return *f; }
+  Foo& getFoo6(char16_t)     { return *f; }
+  Foo& getFoo7(const char*)  { return *f; }
 
   Foo& getFooey() { return *f; }
 };
@@ -2562,6 +2566,22 @@ void test() {
   bar.getFoo3(a, b).mu_.Lock();
   bar.getFoo3(a, b).a = 0;
   bar.getFoo3(a, b).mu_.Unlock();
+
+  bar.getFoo4(true).mu_.Lock();
+  bar.getFoo4(true).a = 0;
+  bar.getFoo4(true).mu_.Unlock();
+
+  bar.getFoo5('a').mu_.Lock();
+  bar.getFoo5('a').a = 0;
+  bar.getFoo5('a').mu_.Unlock();
+
+  bar.getFoo6(u'\u1234').mu_.Lock();
+  bar.getFoo6(u'\u1234').a = 0;
+  bar.getFoo6(u'\u1234').mu_.Unlock();
+
+  bar.getFoo7("foo").mu_.Lock();
+  bar.getFoo7("foo").a = 0;
+  bar.getFoo7("foo").mu_.Unlock();
 
   getBarFoo(bar, a).mu_.Lock();
   getBarFoo(bar, a).a = 0;
@@ -2604,11 +2624,41 @@ void test2() {
     // expected-note {{found near match 'bar.getFoo2(a).mu_'}}
   bar.getFoo2(a).mu_.Unlock();
 
+  bar.getFoo2(0).mu_.Lock();
+  bar.getFoo2(1).a = 0; // \
+    // expected-warning {{writing variable 'a' requires holding mutex 'bar.getFoo2(1).mu_' exclusively}} \
+    // expected-note {{found near match 'bar.getFoo2(0).mu_'}}
+  bar.getFoo2(0).mu_.Unlock();
+
   bar.getFoo3(a, b).mu_.Lock();
   bar.getFoo3(a, c).a = 0;  // \
     // expected-warning {{writing variable 'a' requires holding mutex 'bar.getFoo3(a, c).mu_' exclusively}} \
     // expected-note {{found near match 'bar.getFoo3(a, b).mu_'}}
   bar.getFoo3(a, b).mu_.Unlock();
+
+  bar.getFoo4(true).mu_.Lock();
+  bar.getFoo4(false).a = 0; // \
+    // expected-warning {{writing variable 'a' requires holding mutex 'bar.getFoo4(false).mu_' exclusively}} \
+    // expected-note {{found near match 'bar.getFoo4(true).mu_'}}
+  bar.getFoo4(true).mu_.Unlock();
+
+  bar.getFoo5('x').mu_.Lock();
+  bar.getFoo5('y').a = 0; // \
+    // expected-warning {{writing variable 'a' requires holding mutex 'bar.getFoo5(U'y').mu_' exclusively}} \
+    // expected-note {{found near match 'bar.getFoo5(U'x').mu_'}}
+  bar.getFoo5('x').mu_.Unlock();
+
+  bar.getFoo6(u'\u1234').mu_.Lock();
+  bar.getFoo6(u'\u4321').a = 0; // \
+    // expected-warning {{writing variable 'a' requires holding mutex 'bar.getFoo6(U'\u4321').mu_' exclusively}} \
+    // expected-note {{found near match 'bar.getFoo6(U'\u1234').mu_'}}
+  bar.getFoo6(u'\u1234').mu_.Unlock();
+
+  bar.getFoo7("foo").mu_.Lock();
+  bar.getFoo7("bar").a = 0; // \
+    // expected-warning {{writing variable 'a' requires holding mutex 'bar.getFoo7("bar").mu_' exclusively}} \
+    // expected-note {{found near match 'bar.getFoo7("foo").mu_'}}
+  bar.getFoo7("foo").mu_.Unlock();
 
   getBarFoo(bar, a).mu_.Lock();
   getBarFoo(bar, b).a = 0;  // \


### PR DESCRIPTION
The typical case for literals is an array of mutexes, where we want to distinguish `mutex[0]` from `mutex[1]` and so on. Currently they're treated as the same expression, in fact all literals are treated as the same expression.

The infrastructure for literals is already there, although it required some changes, and some simplifications seemed opportune:
* The `ValueType` had fields for size and signedness. But only integer have signedness, and the size is irrelevant if we don't want to emit machine code. For the abstract semantics that we're interested in, only the number matters.
* We remove the `BT_Void`: `void` literals don't exist in C++.
* We remove `BT_Float` and `BT_ValueRef`: floating-point numbers and complex numbers are probably not used in lock expressions.
* We replace `BT_Pointer` with `BT_NullPointer`. There are no pointer literals, only null pointer literals.

It seems to me that `ValueType` was intended to assign types to any node in the TIL, but it is currently only used for literals. I was trying to come up with reasons to assign types everywhere, but we're not trying to type check anything, and we don't support overloading. The comparison of expressions surely doesn't need it. But maybe this should be clarified at some point. (Including the fact that it is called Typed Intermediate Language.)

We turn `Literal` into a pure base class, as it seems to have been intended, and only create `LiteralT` instances of the correct type. Assertions on `as` ensure we're not mixing up types.

We print to `llvm::raw_ostream` instead of `std::ostream` because that's required for `CharacterLiteral::print`.

Fixes https://github.com/llvm/llvm-project/issues/58535.