### PR TITLE
[Clang] Do not emit -Wmissing-noreturn when [[noreturn]] is present

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1976,7 +1976,7 @@ void clang::inferNoReturnAttr(Sema &S, const Decl *D) {
       Diags.isIgnored(diag::warn_suggest_noreturn_function, FD->getLocation()))
     return;
 
-  if (!FD->hasAttr<NoReturnAttr>() && !FD->hasAttr<InferredNoReturnAttr>() &&
+  if (!FD->isNoReturn() && !FD->hasAttr<InferredNoReturnAttr>() &&
       isKnownToAlwaysThrow(FD)) {
     NonConstFD->addAttr(InferredNoReturnAttr::CreateImplicit(S.Context));
 

--- a/clang/test/SemaCXX/wmissing-noreturn-suggestion.cpp
+++ b/clang/test/SemaCXX/wmissing-noreturn-suggestion.cpp
@@ -21,3 +21,25 @@ int ensureZero(int i) {
   if (i == 0) return 0;
   throwError("ERROR"); // no-warning
 }
+
+
+template <typename Ex>
+[[noreturn]]
+void tpl_throws(Ex const& e) {
+    throw e;
+}
+
+[[noreturn]]
+void tpl_throws_test() {
+    tpl_throws(0);
+}
+
+[[gnu::noreturn]]
+int gnu_throws() {
+    throw 0;
+}
+
+[[noreturn]]
+int cxx11_throws() {
+    throw 0;
+}


### PR DESCRIPTION
Fix a false positve warning which was introduced by #146234.