### PR TITLE
[libc++][docs] Confirm that P2372R3 has been implemented

### DIFF
--- a/libcxx/docs/ReleaseNotes/21.rst
+++ b/libcxx/docs/ReleaseNotes/21.rst
@@ -42,6 +42,7 @@ Implemented Papers
 - P0767R1: Deprecate POD (`Github <https://github.com/llvm/llvm-project/issues/104013>`__)
 - P1361R2: Integration of chrono with text formatting (`Github <https://github.com/llvm/llvm-project/issues/100014>`__)
 - P2255R2: A type trait to detect reference binding to temporary (implemented the type traits only) (`Github <https://github.com/llvm/llvm-project/issues/105180>`__)
+- P2372R3: Fixing locale handling in chrono formatters (`Github <https://github.com/llvm/llvm-project/issues/100043>`__)
 - P2562R1: ``constexpr`` Stable Sorting (`Github <https://github.com/llvm/llvm-project/issues/105360>`__)
 - P0472R3: Put std::monostate in <utility> (`Github <https://github.com/llvm/llvm-project/issues/127874>`__)
 - P1222R4: A Standard ``flat_set`` (`Github <https://github.com/llvm/llvm-project/issues/105193>`__)

--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -200,7 +200,7 @@
 "`P2328R1 <https://wg21.link/P2328R1>`__","join_view should join all views of ranges","2021-06 (Virtual)","|Complete|","15",""
 "`P2367R0 <https://wg21.link/P2367R0>`__","Remove misuses of list-initialization from Clause 24","2021-06 (Virtual)","|Complete|","15",""
 "","","","","",""
-"`P2372R3 <https://wg21.link/P2372R3>`__","Fixing locale handling in chrono formatters","2021-10 (Virtual)","|In Progress|","",""
+"`P2372R3 <https://wg21.link/P2372R3>`__","Fixing locale handling in chrono formatters","2021-10 (Virtual)","|Complete|","21",""
 "`P2415R2 <https://wg21.link/P2415R2>`__","What is a ``view``","2021-10 (Virtual)","|Complete|","14",""
 "`P2418R2 <https://wg21.link/P2418R2>`__","Add support for ``std::generator``-like types to ``std::format``","2021-10 (Virtual)","|Complete|","15",""
 "`P2432R1 <https://wg21.link/P2432R1>`__","Fix ``istream_view``","2021-10 (Virtual)","|Complete|","16",""


### PR DESCRIPTION
In #125921, the changes requested by P2372R3 were completed and tested together with corresponding `chrono` types. But that PR didn't mention P2372R3. The `__cpp_lib_format` FTM was even bumped by an earlier PR #98275.

This PR confirms that P2372R3 was completed in LLVM 21 (together with P1361R2). Closes #100043.