### PR TITLE
[clang] Update diagnostics and documentation for type aware allocators

### DIFF
--- a/clang/docs/CXXTypeAwareAllocators.rst
+++ b/clang/docs/CXXTypeAwareAllocators.rst
@@ -27,7 +27,7 @@ The most basic use case is as follows
 .. code-block:: c++
 
   #include <new>
-  #include <type_identity>
+  #include <type_traits>
 
   struct S {
    // ...

--- a/clang/docs/CXXTypeAwareAllocators.rst
+++ b/clang/docs/CXXTypeAwareAllocators.rst
@@ -1,0 +1,155 @@
+=========================
+C++ Type Aware Allocators
+=========================
+
+.. contents::
+   :local:
+
+Introduction
+============
+
+Clang includes an implementation of P2719 "Type-aware allocation and deallocation
+functions".
+
+This is a feature that extends the semantics of `new`, `new[]`, `delete` and
+`delete[]` operators to expose the type being allocated to the operator. This
+can be used to customize allocation of types without needing to modify the
+type declaration, or via template definitions fully generic type aware
+allocators.
+
+P2719 introduces a type-identity tag as valid parameter type for all allocation
+operators. This tag is a default initialized value of type `std::type_identity<T>`
+where T is the type being allocated or deallocated.  Unlike the other placement
+arguments this tag is passed as the first parameter to the operator.
+
+The most basic use case is as follows
+
+.. code-block:: c++
+
+  #include <new>
+  #include <type_identity>
+
+  struct S {
+   // ...
+  };
+
+  void *operator new(std::type_identity<S>, size_t, std::align_val_t);
+  void operator delete(std::type_identity<S>, void *, size_t, std::align_val_t);
+
+  void f() {
+    S *s = new S; // calls ::operator new(std::type_identity<S>(), sizeof(S), alignof(S))
+    delete s; // calls ::operator delete(std::type_identity<S>(), s, sizeof(S), alignof(S))
+  }
+
+While this functionality alone is powerful and useful, the true power comes
+by using templates. In addition to adding the type-identity tag, P2719 allows
+the tag parameter to be a dependent specialization of `std::type_identity`,
+updates the overload resolution rules to support full template deduction and
+constraint semantics, and updates the definition of usual deallocation functions
+to include `operator delete` definitions that are templatized on the
+type-identity tag.
+
+This allows arbitrarily constrained definitions of the operators that resolve
+as would be expected for any other template function resolution, e.g (only
+showing `operator new` for brevity)
+
+.. code-block:: c++
+
+   template <typename T, unsigned Size> struct Array {
+     T buffer[Size];
+   };
+
+   // Starting with a concrete type
+   void *operator new(std::type_identity<Array<int, 5>>, size_t, std::align_val_t);
+
+   // Only care about five element arrays
+   template <typename T>
+   void *operator new(std::type_identity<Array<T, 5>>, size_t, std::align_val_t);
+
+   // An array of N floats
+   template <unsigned N>
+   void *operator new(std::type_identity<Array<float, N>>, size_t, std::align_val_t);
+
+   // Any array
+   template <typename T, unsigned N>
+   void *operator new(std::type_identity<Array<T, N>>, size_t, std::align_val_t);
+
+   // A handy concept
+   template <typename T> concept Polymorphic = std::is_polymorphic_v<T>;
+
+   // Only applies is T is Polymorphic
+   template <Polymorphic T, unsigned N>
+   void *operator new(std::type_identity<Array<T, N>>, size_t, std::align_val_t);
+
+   // Any even length array
+   template <typename T, unsigned N>
+   void *operator new(std::type_identity<Array<T, N>>, size_t, std::align_val_t)
+       requires(N%2 == 0);
+
+Operator selection then proceeds according to the usual rules for choosing
+the best/most constrained match.
+
+Any declaration of a type aware operator new or operator delete must include a
+matching complimentary operator defined in the same scope.
+
+Notes
+=====
+
+Unconstrained Global Operators
+------------------------------
+
+Declaring an unconstrained type aware global operator `new` or `delete` (or
+`[]` variants) creates numerous hazards, similar to, but different from, those
+created by attempting to replace the non-type aware global operators. For that
+reason unconstrained operators are strongly discouraged.
+
+Mismatching Constraints
+-----------------------
+
+When declaring global type aware operators you should ensure the constraints
+applied to new and delete match exactly, and declare them together. This
+limits the risk of having mismatching operators selected due to differing
+constraints resulting in changes to prioritization when determining the most
+viable candidate.
+
+Declarations Across Libraries
+-----------------------------
+
+Declaring a typed allocator for a type in a separate TU or library creates
+similar hazards as different libraries and TUs may see (or select) different
+definitions.
+
+Under this model something like this would be risky
+
+.. code-block:: c++
+
+  template<typename T>
+  void *operator new(std::type_identity<std::vector<T>>, size_t, std::align_val_t);
+
+However this hazard is not present simply due to the use of the a type from
+another library:
+
+.. code-block:: c++
+
+  template<typename T>
+  struct MyType {
+    T thing;
+  };
+  template<typename T>
+  void *operator new(std::type_identity<MyType<std::vector<T>>>, size_t, std::align_val_t);
+
+Here we see `std::vector` being used, but that is not the actual type being
+allocated.
+
+Implicit and Placement Parameters
+---------------------------------
+
+Type aware allocators are always passed both the implicit alignment and size
+parameters in all cases. Explicit placement parameters are supported after the
+mandatory implicit parameters.
+
+Publication
+===========
+
+`Type-aware allocation and deallocation functions <https://wg21.link/P2719>`_.
+Louis Dionne, Oliver Hunt.

--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -15,6 +15,7 @@ Clang Language Extensions
    AutomaticReferenceCounting
    PointerAuthentication
    MatrixTypes
+   CXXTypeAwareAllocators
 
 Introduction
 ============
@@ -1539,6 +1540,13 @@ C++14 variable templates
 Use ``__has_feature(cxx_variable_templates)`` or
 ``__has_extension(cxx_variable_templates)`` to determine if support for
 templated variable declarations is enabled.
+
+C++ type aware allocators
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``__has_extension(cxx_type_aware_allocators)`` to determine the existence of
+support for the future C++2d type aware allocator feature. For full details see
+:doc:`C++ Type Aware Allocators <CXXTypeAwareAllocators>` for additional details.
 
 C11
 ---

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -133,7 +133,8 @@ C++2c Feature Support
 
 - Implemented `P0963R3 Structured binding declaration as a condition <https://wg21.link/P0963R3>`_.
 
-- Implemented `P2719R4 Type-aware allocation and deallocation functions <https://wg21.link/P2719>`_.
+- Implemented `P2719R5 Type-aware allocation and deallocation functions <https://wg21.link/P2719>`_
+  as an extension in all C++ language modes.
 
 - Implemented `P3618R0 Allow attaching main to the global module <https://wg21.link/P3618>`_.
 

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -133,9 +133,6 @@ C++2c Feature Support
 
 - Implemented `P0963R3 Structured binding declaration as a condition <https://wg21.link/P0963R3>`_.
 
-- Implemented `P2719R5 Type-aware allocation and deallocation functions <https://wg21.link/P2719>`_
-  as an extension in all C++ language modes.
-
 - Implemented `P3618R0 Allow attaching main to the global module <https://wg21.link/P3618>`_.
 
 C++23 Feature Support
@@ -1192,6 +1189,9 @@ New features
   so frequent 'not yet implemented' diagnostics should be expected.  Also, the
   ACC MLIR dialect does not currently implement any lowering to LLVM-IR, so no
   code generation is possible for OpenACC.
+- Implemented `P2719R5 Type-aware allocation and deallocation functions <https://wg21.link/P2719>`_
+  as an extension in all C++ language modes.
+
 
 Crash and bug fixes
 ^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/index.rst
+++ b/clang/docs/index.rst
@@ -61,6 +61,7 @@ Using Clang as a Compiler
    APINotes
    DebuggingCoroutines
    AMDGPUSupport
+   CXXTypeAwareAllocators
    CommandGuide/index
    FAQ
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10082,7 +10082,7 @@ def err_type_aware_destroying_operator_delete : Error<
   "destroying delete is not permitted to be type aware">;
 
 def warn_ext_type_aware_allocators : ExtWarn<
-  "type aware allocators are a clang extension">, InGroup<DiagGroup<"cxx-type-aware-allocators">>;
+  "type aware allocators are a Clang extension">, InGroup<DiagGroup<"cxx-type-aware-allocators">>;
 def err_type_aware_allocator_missing_matching_operator : Error<
   "declaration of type aware %0 in %1 must have matching type aware %2"
 >;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10082,7 +10082,7 @@ def err_type_aware_destroying_operator_delete : Error<
   "destroying delete is not permitted to be type aware">;
 
 def warn_ext_type_aware_allocators : ExtWarn<
-  "type aware allocators are a Clang extension">, InGroup<DiagGroup<"cxx-type-aware-allocators">>;
+  "type aware allocators are a Clang extension">, InGroup<DiagGroup<"ext-cxx-type-aware-allocators">>;
 def err_type_aware_allocator_missing_matching_operator : Error<
   "declaration of type aware %0 in %1 must have matching type aware %2"
 >;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10081,11 +10081,8 @@ def err_destroying_operator_delete_not_usual : Error<
 def err_type_aware_destroying_operator_delete : Error<
   "destroying delete is not permitted to be type aware">;
 
-def ext_cxx26_type_aware_allocators : ExtWarn<
-  "type aware allocators are a C++2c extension">, InGroup<CXX26>;
-def warn_cxx26_type_aware_allocators : Warning<
-  "type aware allocators are incompatible with C++ standards before C++2c">,
-  DefaultIgnore, InGroup<CXXPre26Compat>;
+def warn_ext_type_aware_allocators : ExtWarn<
+  "type aware allocators are a clang extension">, InGroup<DiagGroup<"cxx-type-aware-allocators">>;
 def err_type_aware_allocator_missing_matching_operator : Error<
   "declaration of type aware %0 in %1 must have matching type aware %2"
 >;

--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -366,5 +366,8 @@ FEATURE(clang_atomic_attributes, true)
 FEATURE(cuda_noinline_keyword, LangOpts.CUDA)
 EXTENSION(cuda_implicit_host_device_templates, LangOpts.CUDA && LangOpts.OffloadImplicitHostDeviceTemplates)
 
+// C++2d type-aware allocators
+EXTENSION(cxx_type_aware_allocators, true)
+
 #undef EXTENSION
 #undef FEATURE

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -779,9 +779,6 @@ static void InitializeCPlusPlusFeatureTestMacros(const LangOptions &LangOpts,
   if (LangOpts.Char8)
     Builder.defineMacro("__cpp_char8_t", "202207L");
   Builder.defineMacro("__cpp_impl_destroying_delete", "201806L");
-
-  // TODO: Final number?
-  Builder.defineMacro("__cpp_type_aware_allocators", "202500L");
 }
 
 /// InitializeOpenCLFeatureTestMacros - Define OpenCL macros based on target

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -16541,12 +16541,8 @@ static inline bool CheckOperatorNewDeleteTypes(
   if (IsPotentiallyTypeAware) {
     // We don't emit this diagnosis for template instantiations as we will
     // have already emitted it for the original template declaration.
-    if (!FnDecl->isTemplateInstantiation()) {
-      unsigned DiagID = SemaRef.getLangOpts().CPlusPlus26
-                            ? diag::warn_cxx26_type_aware_allocators
-                            : diag::ext_cxx26_type_aware_allocators;
-      SemaRef.Diag(FnDecl->getLocation(), DiagID);
-    }
+    if (!FnDecl->isTemplateInstantiation())
+      SemaRef.Diag(FnDecl->getLocation(), diag::warn_ext_type_aware_allocators);
 
     if (OperatorKind == AllocationOperatorKind::New) {
       SizeParameterIndex = 1;

--- a/clang/test/SemaCXX/type-aware-class-scoped-mismatched-constraints.cpp
+++ b/clang/test/SemaCXX/type-aware-class-scoped-mismatched-constraints.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-class-scoped-mismatched-constraints.cpp
+++ b/clang/test/SemaCXX/type-aware-class-scoped-mismatched-constraints.cpp
@@ -1,12 +1,14 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=1
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation -Wno-non-c-typedef-for-linkage -DDEFAULT_DELETE=0
 
 namespace std {
   template <class T> struct type_identity {};
   enum class align_val_t : __SIZE_TYPE__ {};
 }
+
+static_assert(__has_extension(cxx_type_aware_allocators), "Verifying the type aware extension flag is set");
 
 using size_t = __SIZE_TYPE__;
 

--- a/clang/test/SemaCXX/type-aware-coroutines.cpp
+++ b/clang/test/SemaCXX/type-aware-coroutines.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fcoroutines -fexceptions -Wall -Wpedantic
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fcoroutines -fexceptions -Wall -Wpedantic
 
 
 #include "Inputs/std-coroutine.h"

--- a/clang/test/SemaCXX/type-aware-coroutines.cpp
+++ b/clang/test/SemaCXX/type-aware-coroutines.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -fcoroutines -fexceptions -Wall -Wpedantic
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fcoroutines -fexceptions -Wall -Wpedantic
 
 
 #include "Inputs/std-coroutine.h"

--- a/clang/test/SemaCXX/type-aware-new-constexpr.cpp
+++ b/clang/test/SemaCXX/type-aware-new-constexpr.cpp
@@ -1,11 +1,11 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions    -fsized-deallocation    -faligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions -fno-sized-deallocation    -faligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions    -fsized-deallocation -fno-aligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions -fno-sized-deallocation -fno-aligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions    -fsized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions -fno-sized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions    -fsized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions -fno-sized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter 
 
 
 namespace std {

--- a/clang/test/SemaCXX/type-aware-new-constexpr.cpp
+++ b/clang/test/SemaCXX/type-aware-new-constexpr.cpp
@@ -1,11 +1,11 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter 
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter 
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation -fexperimental-new-constant-interpreter
 
 
 namespace std {

--- a/clang/test/SemaCXX/type-aware-new-delete-arrays.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-arrays.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation  -Wall -Wpedantic
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation  -Wall -Wpedantic
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-arrays.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-arrays.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions    -fsized-deallocation    -faligned-allocation  -Wall -Wpedantic
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions -fno-sized-deallocation    -faligned-allocation  -Wall -Wpedantic
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions -fno-sized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -fexceptions    -fsized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation  -Wall -Wpedantic
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-free-declarations.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-free-declarations.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26    -fsized-deallocation -fno-aligned-allocation
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-free-declarations.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-free-declarations.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26    -fsized-deallocation -fno-aligned-allocation
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-in-class-declarations.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-in-class-declarations.cpp
@@ -13,24 +13,24 @@ using size_t = __SIZE_TYPE__;
 struct S {
   void *operator new(std::type_identity<S>, size_t, std::align_val_t); // #1
   void operator delete(std::type_identity<S>, void *, size_t, std::align_val_t); // #2
-  // clangext-warning@#1 {{type aware allocators are a clang extension}}
-  // clangext-warning@#2 {{type aware allocators are a clang extension}}
+  // clangext-warning@#1 {{type aware allocators are a Clang extension}}
+  // clangext-warning@#2 {{type aware allocators are a Clang extension}}
   void operator delete(S *, std::destroying_delete_t);
 };
 
 template <typename T> struct S2 {
   void *operator new(std::type_identity<S2<T>>, size_t, std::align_val_t); // #3
   void operator delete(std::type_identity<S2<T>>, void *, size_t, std::align_val_t); // #4
-  // clangext-warning@#3 {{type aware allocators are a clang extension}}
-  // clangext-warning@#4 {{type aware allocators are a clang extension}}
+  // clangext-warning@#3 {{type aware allocators are a Clang extension}}
+  // clangext-warning@#4 {{type aware allocators are a Clang extension}}
   void operator delete(S2 *, std::destroying_delete_t);
 };
 
 struct S3 {
   template <typename T> void *operator new(std::type_identity<T>, size_t, std::align_val_t); // #5
   template <typename T> void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); // #6
-  // clangext-warning@#5 {{type aware allocators are a clang extension}}
-  // clangext-warning@#6 {{type aware allocators are a clang extension}}
+  // clangext-warning@#5 {{type aware allocators are a Clang extension}}
+  // clangext-warning@#6 {{type aware allocators are a Clang extension}}
   void operator delete(S3 *, std::destroying_delete_t);
 };
 
@@ -38,34 +38,34 @@ struct S4 {
   template <typename T> void *operator new(std::type_identity<T>, size_t, std::align_val_t); // #7
   template <typename T> void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); // #8
   template <typename T> void operator delete(std::type_identity<T>, S4 *, std::destroying_delete_t, size_t, std::align_val_t); // #9
-  // clangext-warning@#7 {{type aware allocators are a clang extension}}
-  // clangext-warning@#8 {{type aware allocators are a clang extension}}
+  // clangext-warning@#7 {{type aware allocators are a Clang extension}}
+  // clangext-warning@#8 {{type aware allocators are a Clang extension}}
   // expected-error@#9 {{destroying delete is not permitted to be type aware}}
 };
 
 struct S5 {
   template <typename T> void operator delete(std::type_identity<T>, T *, size_t, std::align_val_t); // #10
   // expected-error@#10 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter}}
-  // clangext-warning@#10 {{type aware allocators are a clang extension}}
+  // clangext-warning@#10 {{type aware allocators are a Clang extension}}
 };
 
 struct S6 {
   template <typename T> void *operator new(std::type_identity<S6>, T, std::align_val_t); // #11
   // expected-error@#11 {{type aware 'operator new' cannot take a dependent type as its 2nd parameter}}
-  // clangext-warning@#11 {{type aware allocators are a clang extension}}
+  // clangext-warning@#11 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(std::type_identity<S6>, T, size_t, std::align_val_t); // #12
   // expected-error@#12 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter}}
-  // clangext-warning@#12 {{type aware allocators are a clang extension}}
+  // clangext-warning@#12 {{type aware allocators are a Clang extension}}
 };
 
 template <typename U>
 struct S7 {
   template <typename T> void *operator new(std::type_identity<T>, U, std::align_val_t); // #13
   // expected-error@#13 {{type aware 'operator new' cannot take a dependent type as its 2nd parameter;}}
-  // clangext-warning@#13 {{type aware allocators are a clang extension}}
+  // clangext-warning@#13 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(std::type_identity<T>, U, size_t, std::align_val_t); // #14
   // expected-error@#14 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter;}}
-  // clangext-warning@#14 {{type aware allocators are a clang extension}}
+  // clangext-warning@#14 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(std::type_identity<T>, S7 *, std::destroying_delete_t, U, std::align_val_t); // #15
   // expected-error@#15 {{destroying delete is not permitted to be type aware}}
   void operator delete(S7 *, std::destroying_delete_t, U); // #16
@@ -80,10 +80,10 @@ void f() {
 struct S8 {
   template <typename T, typename U> void *operator new(std::type_identity<T>, U, std::align_val_t); // #17
   // expected-error@#17 {{type aware 'operator new' cannot take a dependent type as its 2nd parameter;}}
-  // clangext-warning@#17 {{type aware allocators are a clang extension}}
+  // clangext-warning@#17 {{type aware allocators are a Clang extension}}
   template <typename T, typename U> void operator delete(std::type_identity<T>, U, size_t, std::align_val_t); // #18
   // expected-error@#18 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter;}}
-  // clangext-warning@#18 {{type aware allocators are a clang extension}}
+  // clangext-warning@#18 {{type aware allocators are a Clang extension}}
   template <typename T, typename U> void operator delete(std::type_identity<T>, S8 *, std::destroying_delete_t, U, std::align_val_t); // #19
   // expected-error@#19 {{destroying delete is not permitted to be type aware}}
 };
@@ -95,23 +95,23 @@ using UsingAlias = std::type_identity<float>;
 struct S9 {
   void *operator new(Alias<size_t>, std::align_val_t);
   template <typename T> void *operator new(Alias<std::type_identity<T>>, Alias<size_t>, std::align_val_t); // #20
-  // clangext-warning@#20 {{type aware allocators are a clang extension}}
+  // clangext-warning@#20 {{type aware allocators are a Clang extension}}
   void *operator new(Alias<std::type_identity<int>>, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(Alias<std::type_identity<T>>, void *, size_t, std::align_val_t); // #21
-  // clangext-warning@#21{{type aware allocators are a clang extension}}
+  // clangext-warning@#21{{type aware allocators are a Clang extension}}
   void operator delete(Alias<std::type_identity<int>>, void *, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
 };
 struct S10 {
   template <typename T> void *operator new(TypeIdentityAlias<T>, size_t, std::align_val_t); // #22
-  // clangext-warning@#22 {{type aware allocators are a clang extension}}
+  // clangext-warning@#22 {{type aware allocators are a Clang extension}}
   void *operator new(TypeIdentityAlias<int>, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(TypeIdentityAlias<T>, void *, size_t, std::align_val_t); // #23
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   void operator delete(TypeIdentityAlias<int>, void *, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
 };
 
 void test() {
@@ -123,28 +123,28 @@ void test() {
 
 struct S11 {
   template <typename T> void *operator new(TypedefAlias, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   void *operator new(TypedefAlias, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(TypedefAlias, void *, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   void operator delete(TypedefAlias, void *, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
 };
 struct S12 {
   template <typename T> void *operator new(UsingAlias, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   void *operator new(UsingAlias, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   template <typename T> void operator delete(UsingAlias, void *, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   void operator delete(UsingAlias, void *, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
 };
 
 struct S13 {
   void *operator new(std::type_identity<S13>, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
   void operator delete(std::type_identity<S13>, void*, size_t, std::align_val_t);
-  // clangext-warning@-1 {{type aware allocators are a clang extension}}
+  // clangext-warning@-1 {{type aware allocators are a Clang extension}}
 };

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-in-class-declarations.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-in-class-declarations.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx -std=c++26 -fsyntax-only -verify=expected,clangext %s
-// RUN: %clang_cc1 -triple arm64-apple-macosx -std=c++26 -Wno-cxx-type-aware-allocators -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple arm64-apple-macosx -std=c++26 -Wno-ext-cxx-type-aware-allocators -fsyntax-only -verify %s
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-in-class-declarations.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-in-class-declarations.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify=expected,precxx26 %s           -std=c++23
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s                             -std=c++26
+// RUN: %clang_cc1 -triple arm64-apple-macosx -std=c++26 -fsyntax-only -verify=expected,clangext %s
+// RUN: %clang_cc1 -triple arm64-apple-macosx -std=c++26 -Wno-cxx-type-aware-allocators -fsyntax-only -verify %s
 
 namespace std {
   template <class T> struct type_identity {};
@@ -13,24 +13,24 @@ using size_t = __SIZE_TYPE__;
 struct S {
   void *operator new(std::type_identity<S>, size_t, std::align_val_t); // #1
   void operator delete(std::type_identity<S>, void *, size_t, std::align_val_t); // #2
-  // precxx26-warning@#1 {{type aware allocators are a C++2c extension}}
-  // precxx26-warning@#2 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#1 {{type aware allocators are a clang extension}}
+  // clangext-warning@#2 {{type aware allocators are a clang extension}}
   void operator delete(S *, std::destroying_delete_t);
 };
 
 template <typename T> struct S2 {
   void *operator new(std::type_identity<S2<T>>, size_t, std::align_val_t); // #3
   void operator delete(std::type_identity<S2<T>>, void *, size_t, std::align_val_t); // #4
-  // precxx26-warning@#3 {{type aware allocators are a C++2c extension}}
-  // precxx26-warning@#4 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#3 {{type aware allocators are a clang extension}}
+  // clangext-warning@#4 {{type aware allocators are a clang extension}}
   void operator delete(S2 *, std::destroying_delete_t);
 };
 
 struct S3 {
   template <typename T> void *operator new(std::type_identity<T>, size_t, std::align_val_t); // #5
   template <typename T> void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); // #6
-  // precxx26-warning@#5 {{type aware allocators are a C++2c extension}}
-  // precxx26-warning@#6 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#5 {{type aware allocators are a clang extension}}
+  // clangext-warning@#6 {{type aware allocators are a clang extension}}
   void operator delete(S3 *, std::destroying_delete_t);
 };
 
@@ -38,34 +38,34 @@ struct S4 {
   template <typename T> void *operator new(std::type_identity<T>, size_t, std::align_val_t); // #7
   template <typename T> void operator delete(std::type_identity<T>, void *, size_t, std::align_val_t); // #8
   template <typename T> void operator delete(std::type_identity<T>, S4 *, std::destroying_delete_t, size_t, std::align_val_t); // #9
-  // precxx26-warning@#7 {{type aware allocators are a C++2c extension}}
-  // precxx26-warning@#8 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#7 {{type aware allocators are a clang extension}}
+  // clangext-warning@#8 {{type aware allocators are a clang extension}}
   // expected-error@#9 {{destroying delete is not permitted to be type aware}}
 };
 
 struct S5 {
   template <typename T> void operator delete(std::type_identity<T>, T *, size_t, std::align_val_t); // #10
   // expected-error@#10 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter}}
-  // precxx26-warning@#10 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#10 {{type aware allocators are a clang extension}}
 };
 
 struct S6 {
   template <typename T> void *operator new(std::type_identity<S6>, T, std::align_val_t); // #11
   // expected-error@#11 {{type aware 'operator new' cannot take a dependent type as its 2nd parameter}}
-  // precxx26-warning@#11 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#11 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(std::type_identity<S6>, T, size_t, std::align_val_t); // #12
   // expected-error@#12 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter}}
-  // precxx26-warning@#12 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#12 {{type aware allocators are a clang extension}}
 };
 
 template <typename U>
 struct S7 {
   template <typename T> void *operator new(std::type_identity<T>, U, std::align_val_t); // #13
   // expected-error@#13 {{type aware 'operator new' cannot take a dependent type as its 2nd parameter;}}
-  // precxx26-warning@#13 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#13 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(std::type_identity<T>, U, size_t, std::align_val_t); // #14
   // expected-error@#14 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter;}}
-  // precxx26-warning@#14 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#14 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(std::type_identity<T>, S7 *, std::destroying_delete_t, U, std::align_val_t); // #15
   // expected-error@#15 {{destroying delete is not permitted to be type aware}}
   void operator delete(S7 *, std::destroying_delete_t, U); // #16
@@ -80,10 +80,10 @@ void f() {
 struct S8 {
   template <typename T, typename U> void *operator new(std::type_identity<T>, U, std::align_val_t); // #17
   // expected-error@#17 {{type aware 'operator new' cannot take a dependent type as its 2nd parameter;}}
-  // precxx26-warning@#17 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#17 {{type aware allocators are a clang extension}}
   template <typename T, typename U> void operator delete(std::type_identity<T>, U, size_t, std::align_val_t); // #18
   // expected-error@#18 {{type aware 'operator delete' cannot take a dependent type as its 2nd parameter;}}
-  // precxx26-warning@#18 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#18 {{type aware allocators are a clang extension}}
   template <typename T, typename U> void operator delete(std::type_identity<T>, S8 *, std::destroying_delete_t, U, std::align_val_t); // #19
   // expected-error@#19 {{destroying delete is not permitted to be type aware}}
 };
@@ -95,23 +95,23 @@ using UsingAlias = std::type_identity<float>;
 struct S9 {
   void *operator new(Alias<size_t>, std::align_val_t);
   template <typename T> void *operator new(Alias<std::type_identity<T>>, Alias<size_t>, std::align_val_t); // #20
-  // precxx26-warning@#20 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#20 {{type aware allocators are a clang extension}}
   void *operator new(Alias<std::type_identity<int>>, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(Alias<std::type_identity<T>>, void *, size_t, std::align_val_t); // #21
-  // precxx26-warning@#21{{type aware allocators are a C++2c extension}}
+  // clangext-warning@#21{{type aware allocators are a clang extension}}
   void operator delete(Alias<std::type_identity<int>>, void *, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
 };
 struct S10 {
   template <typename T> void *operator new(TypeIdentityAlias<T>, size_t, std::align_val_t); // #22
-  // precxx26-warning@#22 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@#22 {{type aware allocators are a clang extension}}
   void *operator new(TypeIdentityAlias<int>, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(TypeIdentityAlias<T>, void *, size_t, std::align_val_t); // #23
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   void operator delete(TypeIdentityAlias<int>, void *, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
 };
 
 void test() {
@@ -123,28 +123,28 @@ void test() {
 
 struct S11 {
   template <typename T> void *operator new(TypedefAlias, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   void *operator new(TypedefAlias, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(TypedefAlias, void *, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   void operator delete(TypedefAlias, void *, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
 };
 struct S12 {
   template <typename T> void *operator new(UsingAlias, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   void *operator new(UsingAlias, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   template <typename T> void operator delete(UsingAlias, void *, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   void operator delete(UsingAlias, void *, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
 };
 
 struct S13 {
   void *operator new(std::type_identity<S13>, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
   void operator delete(std::type_identity<S13>, void*, size_t, std::align_val_t);
-  // precxx26-warning@-1 {{type aware allocators are a C++2c extension}}
+  // clangext-warning@-1 {{type aware allocators are a clang extension}}
 };

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-resolution.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-resolution.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s        -std=c++26 -fexceptions    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s        -std=c++26 -fexceptions -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s        -std=c++26 -fexceptions    -fsized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s        -std=c++26 -fexceptions -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-basic-resolution.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-basic-resolution.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fno-sized-deallocation -fno-aligned-allocation
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-new-delete-qualifiers.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-qualifiers.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-ext-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-ext-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-ext-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-ext-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26    -fsized-deallocation -fno-aligned-allocation
 namespace std {
   template <class T> struct type_identity {
     typedef T type;

--- a/clang/test/SemaCXX/type-aware-new-delete-qualifiers.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-qualifiers.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -DNO_TADD -std=c++26    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s -DNO_TADD -std=c++26    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26 -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -Wno-cxx-type-aware-allocators -verify %s -DNO_TADD -std=c++26    -fsized-deallocation -fno-aligned-allocation
 namespace std {
   template <class T> struct type_identity {
     typedef T type;

--- a/clang/test/SemaCXX/type-aware-new-delete-transparent-contexts.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-transparent-contexts.cpp
@@ -2,9 +2,9 @@
 // RUN: mkdir %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp         -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=0
-// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp         -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=1
-// RUN: %clang_cc1  -fsyntax-only -verify %t/module_testing.cppm -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=2
+// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp         -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=0
+// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp         -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=1
+// RUN: %clang_cc1  -fsyntax-only -verify %t/module_testing.cppm -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=2
 
 //--- module_testing.cppm
 // expected-no-diagnostics

--- a/clang/test/SemaCXX/type-aware-new-delete-transparent-contexts.cpp
+++ b/clang/test/SemaCXX/type-aware-new-delete-transparent-contexts.cpp
@@ -2,9 +2,9 @@
 // RUN: mkdir %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp -std=c++26 -fexceptions -DTRANSPARENT_DECL=0
-// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp -std=c++26 -fexceptions -DTRANSPARENT_DECL=1
-// RUN: %clang_cc1  -fsyntax-only -verify %t/module_testing.cppm -std=c++26 -fexceptions -DTRANSPARENT_DECL=2
+// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp         -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=0
+// RUN: %clang_cc1  -fsyntax-only -verify %t/testing.cpp         -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=1
+// RUN: %clang_cc1  -fsyntax-only -verify %t/module_testing.cppm -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -DTRANSPARENT_DECL=2
 
 //--- module_testing.cppm
 // expected-no-diagnostics

--- a/clang/test/SemaCXX/type-aware-new-invalid-type-identity.cpp
+++ b/clang/test/SemaCXX/type-aware-new-invalid-type-identity.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=0
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=1
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=2
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=3
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=4
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s          -std=c++26 
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=0
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=1
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=2
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=3
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=4
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 
 
 namespace std {
 #if !defined(INVALID_TYPE_IDENTITY_VERSION)

--- a/clang/test/SemaCXX/type-aware-new-invalid-type-identity.cpp
+++ b/clang/test/SemaCXX/type-aware-new-invalid-type-identity.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=0
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=1
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=2
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=3
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=4
-// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-cxx-type-aware-allocators -std=c++26 
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=0
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=1
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=2
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=3
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26 -DINVALID_TYPE_IDENTITY_VERSION=4
+// RUN: %clang_cc1 -triple arm64-apple-macosx -fsyntax-only -verify %s -Wno-ext-cxx-type-aware-allocators -std=c++26
 
 namespace std {
 #if !defined(INVALID_TYPE_IDENTITY_VERSION)

--- a/clang/test/SemaCXX/type-aware-placement-operators.cpp
+++ b/clang/test/SemaCXX/type-aware-placement-operators.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s        -std=c++26 -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s        -std=c++26 -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s        -std=c++26 -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s        -std=c++26 -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation
 
 namespace std {
   template <class T> struct type_identity {};

--- a/clang/test/SemaCXX/type-aware-placement-operators.cpp
+++ b/clang/test/SemaCXX/type-aware-placement-operators.cpp
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation    -faligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions -fno-sized-deallocation -fno-aligned-allocation
+// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++26 -Wno-ext-cxx-type-aware-allocators -fexceptions -fcxx-exceptions    -fsized-deallocation -fno-aligned-allocation
 
 namespace std {
   template <class T> struct type_identity {};


### PR DESCRIPTION
Alas reflection pushed p2719 out of C++26, so this PR changes the diagnostics to reflect that for now type aware allocation is functionally a clang extension.