### PR TITLE
RuntimeLibcalls: Remove unused variable for atomic libcalls

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1061,10 +1061,6 @@ defvar DefaultRuntimeLibcallImpls =
                     DefaultRuntimeLibcallImpls_f80),
                     DefaultRuntimeLibcallImpls_ppcf128);
 
-defvar DefaultRuntimeLibcallImpls_atomic =
-    !filter(entry, DefaultRuntimeLibcallImpls,
-            !match(!cast<string>(entry.Provides), "ATOMIC"));
-
 /// Default set of libcall impls for 32-bit architectures.
 defvar DefaultLibcallImpls32 = DefaultRuntimeLibcallImpls;
 


### PR DESCRIPTION
This was obsoleted by ed1ee9a9bf6deb5ec147e79a156e2f8d9465616d