### PR TITLE
[lldb][test] TestProcessSaveCoreMinidump: Rename duplicate test-case

### DIFF
--- a/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
+++ b/lldb/test/API/functionalities/process_save_core_minidump/TestProcessSaveCoreMinidump.py
@@ -608,7 +608,7 @@ class ProcessSaveCoreMinidumpTestCase(TestBase):
 
     @skipUnlessPlatform(["linux"])
     @skipUnlessArch("x86_64")
-    def minidump_saves_fs_base_region(self):
+    def minidump_saves_tls(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
         try:


### PR DESCRIPTION
Ran my python script from
https://github.com/llvm/llvm-project/pull/97043 over the repo again and there was 1 duplicate test-case that has been introduced since I last did this.

This patch renames that test.