### PR TITLE
RuntimeLibcalls: Stop opting out of exp10

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -29,6 +29,9 @@ def isNotOSWindowsOrIsCygwinMinGW
 def isGNUEnvironment : RuntimeLibcallPredicate<"TT.isGNUEnvironment()">;
 def darwinHasSinCosStret : RuntimeLibcallPredicate<"darwinHasSinCosStret(TT)">;
 def darwinHasExp10 : RuntimeLibcallPredicate<"darwinHasExp10(TT)">;
+
+def hasExp10 : RuntimeLibcallPredicate<[{!TT.isOSDarwin()}]>;
+
 def hasSinCos : RuntimeLibcallPredicate<"hasSinCos(TT)">;
 
 // FIXME: Way to combine predicates
@@ -786,12 +789,6 @@ def __exp2l_finite_f80 : RuntimeLibcallImpl<EXP2_FINITE_F80, "__exp2l_finite">;
 def __exp2l_finite_f128 : RuntimeLibcallImpl<EXP2_FINITE_F128, "__exp2l_finite">;
 def __exp2l_finite_ppcf128 : RuntimeLibcallImpl<EXP2_FINITE_PPCF128, "__exp2l_finite">;
 
-def exp10f : RuntimeLibcallImpl<EXP10_F32>;
-def exp10 : RuntimeLibcallImpl<EXP10_F64>;
-def exp10l_f80 : RuntimeLibcallImpl<EXP10_F80, "exp10l">;
-def exp10l_f128 : RuntimeLibcallImpl<EXP10_F128, "exp10l">;
-def exp10l_ppcf128 : RuntimeLibcallImpl<EXP10_PPCF128, "exp10l">;
-
 def sinf : RuntimeLibcallImpl<SIN_F32>;
 def sin : RuntimeLibcallImpl<SIN_F64>;
 defm sin : LibmLongDoubleLibCall;
@@ -951,6 +948,12 @@ def memset : RuntimeLibcallImpl<MEMSET>;
 def calloc : RuntimeLibcallImpl<CALLOC>;
 
 } // End let IsDefault = true
+
+def exp10f : RuntimeLibcallImpl<EXP10_F32>;
+def exp10 : RuntimeLibcallImpl<EXP10_F64>;
+def exp10l_f80 : RuntimeLibcallImpl<EXP10_F80, "exp10l">;
+def exp10l_f128 : RuntimeLibcallImpl<EXP10_F128, "exp10l">;
+def exp10l_ppcf128 : RuntimeLibcallImpl<EXP10_PPCF128, "exp10l">;
 
 //--------------------------------------------------------------------
 // compiler-rt/libgcc but 64-bit only, not available by default
@@ -1113,6 +1116,12 @@ defvar LibmHasSinCosF80 = LibcallImpls<(add sincos_f80), hasSinCos>;
 defvar LibmHasSinCosF128 = LibcallImpls<(add sincos_f128), hasSinCos>;
 defvar LibmHasSinCosPPCF128 = LibcallImpls<(add sincos_ppcf128), hasSinCos>;
 
+defvar LibmHasExp10F32 = LibcallImpls<(add exp10f), hasExp10>;
+defvar LibmHasExp10F64 = LibcallImpls<(add exp10), hasExp10>;
+defvar LibmHasExp10F80 = LibcallImpls<(add exp10l_f80), hasExp10>;
+defvar LibmHasExp10F128 = LibcallImpls<(add exp10l_f128), hasExp10>;
+defvar LibmHasExp10PPCF128 = LibcallImpls<(add exp10l_ppcf128), hasExp10>;
+
 defvar WindowsMathRemovals = [
   ldexpf, ldexp_f80, ldexp_f128, ldexp_ppcf128,
   frexpf, frexp_f80, frexp_f128, frexp_ppcf128
@@ -1211,7 +1220,8 @@ def AArch64SystemLibrary : SystemRuntimeLibrary<
        LibcallImpls<(add Int128RTLibcalls), isAArch64_ILP64>,
        LibcallImpls<(add bzero), isOSDarwin>,
        DarwinExp10, DarwinSinCosStret,
-       LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128)
+       LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
+       LibmHasExp10F32, LibmHasExp10F64, LibmHasExp10F128)
 >;
 
 // Prepend a # to every name
@@ -1482,6 +1492,7 @@ def ARMSystemLibrary
            AEABIDivRemCalls,
            DarwinSinCosStret, DarwinExp10,
            LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
+           LibmHasExp10F32, LibmHasExp10F64,  LibmHasExp10F128,
 
            // Use divmod compiler-rt calls for iOS 5.0 and later.
            LibcallImpls<(add __divmodsi4, __udivmodsi4),
@@ -1983,6 +1994,7 @@ def PPCSystemLibrary
                 DefaultRuntimeLibcallImpls_f128),
            __extendkftf2, __trunctfkf2,
            DefaultRuntimeLibcallImpls_ppcf128,
+           exp10f, exp10, exp10l_ppcf128,
            LibmF128Libcalls, AIX32Calls, AIX64Calls,
            LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
            LibmHasSinCosPPCF128,
@@ -1998,7 +2010,9 @@ def isRISCV64 : RuntimeLibcallPredicate<"TT.isRISCV64()">;
 
 def RISCVSystemLibrary
     : SystemRuntimeLibrary<isRISCV,
-      (add DefaultRuntimeLibcallImpls, __riscv_flush_icache,
+      (add DefaultRuntimeLibcallImpls,
+           exp10f, exp10, exp10l_f128,
+           __riscv_flush_icache,
            LibcallImpls<(add Int128RTLibcalls), isRISCV64>)>;
 
 //===----------------------------------------------------------------------===//
@@ -2104,7 +2118,7 @@ def isX86 : RuntimeLibcallPredicate<"TT.isX86()">;
 def darwinHas__bzero : RuntimeLibcallPredicate<"TT.isMacOSX() && !TT.isMacOSXVersionLT(10, 6)">;
 
 // FIXME: This is has ldexpl/frexpl plus use f128 for long double.
-def hasFrexplLdexplF128
+def hasExpFrexplLdexplF128
   : RuntimeLibcallPredicate<[{(!TT.isOSWindows() || TT.isOSCygMing()) && !TT.isGNUEnvironment()}]>;
 
 // Use the f128 variants of math functions on x86
@@ -2120,12 +2134,13 @@ defvar X86CommonLibcalls =
        LibcallImpls<(add __bzero), darwinHas__bzero>,
        LibmHasFrexpF32, LibmHasLdexpF32,
        LibmHasFrexpF80, LibmHasLdexpF80,
-       LibcallImpls<(add frexp_f128, ldexp_f128), hasFrexplLdexplF128>,
+       LibcallImpls<(add frexp_f128, ldexp_f128, exp10l_f128), hasExpFrexplLdexplF128>,
        DefaultRuntimeLibcallImpls_f80,
+       LibmHasExp10F32, LibmHasExp10F64, LibmHasExp10F80,
+       LibcallImpls<(add MostPowI), isNotOSMSVCRT>,
        // FIXME: MSVCRT doesn't have powi. The f128 case is added as a
        // hack for one test relying on it.
-       __powitf2_f128,
-       LibcallImpls<(add MostPowI), isNotOSMSVCRT>
+       __powitf2_f128
 );
 
 defvar Windows32DivRemMulCalls =
@@ -2265,4 +2280,5 @@ def WasmSystemLibrary
     : SystemRuntimeLibrary<isWasm,
       (add DefaultRuntimeLibcallImpls, Int128RTLibcalls,
            CompilerRTOnlyInt64Libcalls, CompilerRTOnlyInt128Libcalls,
+           exp10f, exp10,
            emscripten_return_address)>;

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1122,6 +1122,11 @@ defvar LibmHasExp10F80 = LibcallImpls<(add exp10l_f80), hasExp10>;
 defvar LibmHasExp10F128 = LibcallImpls<(add exp10l_f128), hasExp10>;
 defvar LibmHasExp10PPCF128 = LibcallImpls<(add exp10l_ppcf128), hasExp10>;
 
+defvar DefaultLibmExp10 = [
+  LibmHasExp10F32, LibmHasExp10F64, LibmHasExp10F128
+];
+
+
 defvar WindowsMathRemovals = [
   ldexpf, ldexp_f80, ldexp_f128, ldexp_ppcf128,
   frexpf, frexp_f80, frexp_f128, frexp_ppcf128
@@ -1143,7 +1148,6 @@ defvar LibmHasLdexpF80 = LibcallImpls<(add ldexp_f80), isNotOSWindowsOrIsCygwinM
 
 defvar LibmHasFrexpF128 = LibcallImpls<(add frexp_f128), isNotOSWindowsOrIsCygwinMinGW>;
 defvar LibmHasLdexpF128 = LibcallImpls<(add ldexp_f128), isNotOSWindowsOrIsCygwinMinGW>;
-
 
 //===----------------------------------------------------------------------===//
 // Objective-C Runtime Libcalls
@@ -1221,7 +1225,7 @@ def AArch64SystemLibrary : SystemRuntimeLibrary<
        LibcallImpls<(add bzero), isOSDarwin>,
        DarwinExp10, DarwinSinCosStret,
        LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
-       LibmHasExp10F32, LibmHasExp10F64, LibmHasExp10F128)
+       DefaultLibmExp10)
 >;
 
 // Prepend a # to every name
@@ -1492,7 +1496,7 @@ def ARMSystemLibrary
            AEABIDivRemCalls,
            DarwinSinCosStret, DarwinExp10,
            LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
-           LibmHasExp10F32, LibmHasExp10F64,  LibmHasExp10F128,
+           DefaultLibmExp10,
 
            // Use divmod compiler-rt calls for iOS 5.0 and later.
            LibcallImpls<(add __divmodsi4, __udivmodsi4),

--- a/llvm/lib/IR/RuntimeLibcalls.cpp
+++ b/llvm/lib/IR/RuntimeLibcalls.cpp
@@ -104,9 +104,9 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT,
     setLibcallImpl(RTLIB::STACK_SMASH_HANDLER, RTLIB::__stack_smash_handler);
   }
 
-  // Skip default manual processing for targets that have been fully ported to
+  // Skip default manual processing for targets that have been mostly ported to
   // tablegen for now. Eventually the rest of this should be deleted.
-  if (TT.isX86() || TT.isAArch64() || TT.isWasm())
+  if (TT.isX86() || TT.isAArch64() || TT.isWasm() || TT.isPPC())
     return;
 
   if (TT.isARM() || TT.isThumb()) {
@@ -119,6 +119,10 @@ void RuntimeLibcallsInfo::initLibcalls(const Triple &TT,
     setLibcallImpl(RTLIB::SINCOS_F64, RTLIB::sincos);
     setLibcallImpl(RTLIB::SINCOS_F128, RTLIB::sincos_f128);
   }
+
+  setLibcallImpl(RTLIB::EXP10_F32, RTLIB::exp10f);
+  setLibcallImpl(RTLIB::EXP10_F64, RTLIB::exp10);
+  setLibcallImpl(RTLIB::EXP10_F128, RTLIB::exp10l_f128);
 
   // These libcalls are only available in compiler-rt, not libgcc.
   if (TT.isArch64Bit()) {

--- a/llvm/test/CodeGen/Generic/fp128-exp10-libcall.ll
+++ b/llvm/test/CodeGen/Generic/fp128-exp10-libcall.ll
@@ -13,10 +13,7 @@
 ; RUN: %if x86-registered-target     %{ llc < %s -mtriple=i686-unknown-linux-musl      | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
 ; RUN: %if x86-registered-target     %{ llc < %s -mtriple=x86_64-unknown-linux-gnu     | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
 ; RUN: %if x86-registered-target     %{ llc < %s -mtriple=x86_64-unknown-linux-musl    | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
-;
-; FIXME(#144006): Windows-MSVC should also be run but has a ldexp selection
-; failure.
-; %if x86-registered-target     %{ llc < %s -mtriple=x86_64-pc-windows-msvc       -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+; RUN %if x86-registered-target     %{ llc < %s -mtriple=x86_64-pc-windows-msvc        | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
 
 ; ERR: error: no libcall available for fexp10
 define fp128 @test_exp10(fp128 %a) {

--- a/llvm/test/CodeGen/Generic/fp128-exp10-libcall.ll
+++ b/llvm/test/CodeGen/Generic/fp128-exp10-libcall.ll
@@ -1,0 +1,31 @@
+; RUN: %if aarch64-registered-target %{ llc < %s -mtriple=aarch64-unknown-linux-gnu    | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if aarch64-registered-target %{ llc < %s -mtriple=aarch64-unknown-linux-musl   | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if aarch64-registered-target %{ llc < %s -mtriple=aarch64-unknown-none         | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if aarch64-registered-target %{ not llc -mtriple=arm64-apple-macosx -filetype=null %s 2>&1 | FileCheck --check-prefix=ERR %s %}
+; RUN: %if arm-registered-target     %{ llc < %s -mtriple=arm-none-eabi                | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if arm-registered-target     %{ llc < %s -mtriple=arm-unknown-linux-gnueabi    | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if powerpc-registered-target %{ llc < %s -mtriple=powerpc-unknown-linux-gnu    | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+; RUN: %if powerpc-registered-target %{ llc < %s -mtriple=powerpc64-unknown-linux-gnu  | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+; RUN: %if powerpc-registered-target %{ llc < %s -mtriple=powerpc64-unknown-linux-musl | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+; RUN: %if riscv-registered-target   %{ llc < %s -mtriple=riscv32-unknown-linux-gnu    | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if systemz-registered-target %{ llc < %s -mtriple=s390x-unknown-linux-gnu      | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-S390X %}
+; RUN: %if x86-registered-target     %{ llc < %s -mtriple=i686-unknown-linux-gnu       | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+; RUN: %if x86-registered-target     %{ llc < %s -mtriple=i686-unknown-linux-musl      | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+; RUN: %if x86-registered-target     %{ llc < %s -mtriple=x86_64-unknown-linux-gnu     | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+; RUN: %if x86-registered-target     %{ llc < %s -mtriple=x86_64-unknown-linux-musl    | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-USELD %}
+;
+; FIXME(#144006): Windows-MSVC should also be run but has a ldexp selection
+; failure.
+; %if x86-registered-target     %{ llc < %s -mtriple=x86_64-pc-windows-msvc       -verify-machineinstrs | FileCheck %s --check-prefixes=CHECK-ALL,CHECK-F128  %}
+
+; ERR: error: no libcall available for fexp10
+define fp128 @test_exp10(fp128 %a) {
+; CHECK-ALL-LABEL:  test_exp10:
+; CHECK-F128:       exp10f128
+; CHECK-USELD:      exp10l
+; CHECK-S390X:      exp10l
+start:
+  %0 = tail call fp128 @llvm.exp10.f128(fp128 %a)
+  ret fp128 %0
+}
+

--- a/llvm/test/CodeGen/Generic/fp128-math-libcalls.ll
+++ b/llvm/test/CodeGen/Generic/fp128-math-libcalls.ll
@@ -95,16 +95,6 @@ start:
   ret fp128 %0
 }
 
-define fp128 @test_exp10(fp128 %a) {
-; CHECK-ALL-LABEL:  test_exp10:
-; CHECK-F128:       exp10f128
-; CHECK-USELD:      exp10l
-; CHECK-S390X:      exp10l
-start:
-  %0 = tail call fp128 @llvm.exp10.f128(fp128 %a)
-  ret fp128 %0
-}
-
 define fp128 @test_exp2(fp128 %a) {
 ; CHECK-ALL-LABEL:  test_exp2:
 ; CHECK-F128:       exp2f128

--- a/llvm/test/CodeGen/X86/exp10-libcall-names.ll
+++ b/llvm/test/CodeGen/X86/exp10-libcall-names.ll
@@ -13,10 +13,7 @@
 ; RUN: llc < %s -mtriple=i686-linux-gnu -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=GISEL-X86
 ; RUN: llc < %s -mtriple=x86_64-linux-gnu -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=GISEL-X64
 
-; RUN: not llc -mtriple=x86_64-apple-macos10.8 -filetype=null %s 2>&1 | FileCheck -check-prefix=ERR %s
-; Check exp10/exp10f is emitted as __exp10/__exp10f on assorted systems.
-
-; ERR: no libcall available for fexp10
+; Check exp10/exp10f is emitted as __exp10/__exp10f on assorted darwin systems.
 
 define float @test_exp10_f32(float %x) nounwind {
 ; LINUX-LABEL: test_exp10_f32:
@@ -77,44 +74,4 @@ define double @test_exp10_f64(double %x) nounwind {
 ; GISEL-X64-NEXT:    retq
   %ret = call double @llvm.exp10.f64(double %x)
   ret double %ret
-}
-
-define x86_fp80 @test_exp10_f80(x86_fp80 %x) nounwind {
-; LINUX-LABEL: test_exp10_f80:
-; LINUX:       # %bb.0:
-; LINUX-NEXT:    subq $24, %rsp
-; LINUX-NEXT:    fldt {{[0-9]+}}(%rsp)
-; LINUX-NEXT:    fstpt (%rsp)
-; LINUX-NEXT:    callq exp10l@PLT
-; LINUX-NEXT:    addq $24, %rsp
-; LINUX-NEXT:    retq
-;
-; APPLE-LABEL: test_exp10_f80:
-; APPLE:       ## %bb.0:
-; APPLE-NEXT:    subq $24, %rsp
-; APPLE-NEXT:    fldt {{[0-9]+}}(%rsp)
-; APPLE-NEXT:    fstpt (%rsp)
-; APPLE-NEXT:    callq _exp10l
-; APPLE-NEXT:    addq $24, %rsp
-; APPLE-NEXT:    retq
-;
-; GISEL-X86-LABEL: test_exp10_f80:
-; GISEL-X86:       # %bb.0:
-; GISEL-X86-NEXT:    subl $12, %esp
-; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
-; GISEL-X86-NEXT:    fstpt (%esp)
-; GISEL-X86-NEXT:    calll exp10l
-; GISEL-X86-NEXT:    addl $12, %esp
-; GISEL-X86-NEXT:    retl
-;
-; GISEL-X64-LABEL: test_exp10_f80:
-; GISEL-X64:       # %bb.0:
-; GISEL-X64-NEXT:    subq $24, %rsp
-; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
-; GISEL-X64-NEXT:    fstpt (%rsp)
-; GISEL-X64-NEXT:    callq exp10l
-; GISEL-X64-NEXT:    addq $24, %rsp
-; GISEL-X64-NEXT:    retq
-  %ret = call x86_fp80 @llvm.exp10.f80(x86_fp80 %x)
-  ret x86_fp80 %ret
 }

--- a/llvm/test/CodeGen/X86/exp10l-libcall-names.ll
+++ b/llvm/test/CodeGen/X86/exp10l-libcall-names.ll
@@ -1,0 +1,46 @@
+; RUN: llc -mtriple=x86_64-linux-gnu < %s | FileCheck -check-prefix=LINUX %s
+; RUN: not llc -mtriple=x86_64-apple-macos10.9 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-ios9.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-tvos9.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-watchos9.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-xros9.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-ios8.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-tvos8.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-xros8.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-driverkit < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not llc -mtriple=x86_64-apple-driverkit24.0 < %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: llc < %s -mtriple=i686-linux-gnu -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=GISEL-X86
+; RUN: llc < %s -mtriple=x86_64-linux-gnu -global-isel -global-isel-abort=1 | FileCheck %s --check-prefix=GISEL-X64
+
+; ERR: no libcall available for fexp10
+
+define x86_fp80 @test_exp10_f80(x86_fp80 %x) nounwind {
+; LINUX-LABEL: test_exp10_f80:
+; LINUX:       # %bb.0:
+; LINUX-NEXT:    subq $24, %rsp
+; LINUX-NEXT:    fldt {{[0-9]+}}(%rsp)
+; LINUX-NEXT:    fstpt (%rsp)
+; LINUX-NEXT:    callq exp10l@PLT
+; LINUX-NEXT:    addq $24, %rsp
+; LINUX-NEXT:    retq
+;
+; GISEL-X86-LABEL: test_exp10_f80:
+; GISEL-X86:       # %bb.0:
+; GISEL-X86-NEXT:    subl $12, %esp
+; GISEL-X86-NEXT:    fldt {{[0-9]+}}(%esp)
+; GISEL-X86-NEXT:    fstpt (%esp)
+; GISEL-X86-NEXT:    calll exp10l
+; GISEL-X86-NEXT:    addl $12, %esp
+; GISEL-X86-NEXT:    retl
+;
+; GISEL-X64-LABEL: test_exp10_f80:
+; GISEL-X64:       # %bb.0:
+; GISEL-X64-NEXT:    subq $24, %rsp
+; GISEL-X64-NEXT:    fldt {{[0-9]+}}(%rsp)
+; GISEL-X64-NEXT:    fstpt (%rsp)
+; GISEL-X64-NEXT:    callq exp10l
+; GISEL-X64-NEXT:    addq $24, %rsp
+; GISEL-X64-NEXT:    retq
+  %ret = call x86_fp80 @llvm.exp10.f80(x86_fp80 %x)
+  ret x86_fp80 %ret
+}


### PR DESCRIPTION
This changes the behavior on old darwin triples for x86_fp80;
it now turns into an error instead of emitting exp10l. The comments
in TargetLibraryInfo suggest it never existed.