### PR TITLE
[Offload] Have `doJITPostProcessing` accept multiple binaries

### DIFF
--- a/offload/plugins-nextgen/amdgpu/src/rtl.cpp
+++ b/offload/plugins-nextgen/amdgpu/src/rtl.cpp
@@ -2067,7 +2067,7 @@ struct AMDGPUDeviceTy : public GenericDeviceTy, AMDGenericDeviceTy {
   uint64_t getStreamBusyWaitMicroseconds() const { return OMPX_StreamBusyWait; }
 
   Expected<std::unique_ptr<MemoryBuffer>> doJITPostProcessing(
-      std::vector<std::unique_ptr<MemoryBuffer>> &&MB) const override {
+      llvm::SmallVector<std::unique_ptr<MemoryBuffer>> &&MB) const override {
 
     // TODO: We should try to avoid materialization but there seems to be no
     // good linker interface w/o file i/o.

--- a/offload/plugins-nextgen/common/include/JIT.h
+++ b/offload/plugins-nextgen/common/include/JIT.h
@@ -44,7 +44,7 @@ struct JITEngine {
   /// called.
   using PostProcessingFn =
       std::function<Expected<std::unique_ptr<MemoryBuffer>>(
-          std::unique_ptr<MemoryBuffer>)>;
+          std::vector<std::unique_ptr<MemoryBuffer>> &&)>;
 
   JITEngine(Triple::ArchType TA);
 

--- a/offload/plugins-nextgen/common/include/JIT.h
+++ b/offload/plugins-nextgen/common/include/JIT.h
@@ -44,7 +44,7 @@ struct JITEngine {
   /// called.
   using PostProcessingFn =
       std::function<Expected<std::unique_ptr<MemoryBuffer>>(
-          std::vector<std::unique_ptr<MemoryBuffer>> &&)>;
+          llvm::SmallVector<std::unique_ptr<MemoryBuffer>> &&)>;
 
   JITEngine(Triple::ArchType TA);
 

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -935,8 +935,12 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
 
   /// Post processing after jit backend. The ownership of \p MB will be taken.
   virtual Expected<std::unique_ptr<MemoryBuffer>>
-  doJITPostProcessing(std::unique_ptr<MemoryBuffer> MB) const {
-    return std::move(MB);
+  doJITPostProcessing(std::vector<std::unique_ptr<MemoryBuffer>> &&MB) const {
+    if (MB.size() > 1)
+      return make_error<error::OffloadError>(
+          error::ErrorCode::UNSUPPORTED,
+          "Plugin does not support linking multiple binaries");
+    return std::move(MB[0]);
   }
 
   /// The minimum number of threads we use for a low-trip count combined loop.

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -934,8 +934,8 @@ struct GenericDeviceTy : public DeviceAllocatorTy {
   virtual std::string getComputeUnitKind() const { return "unknown"; }
 
   /// Post processing after jit backend. The ownership of \p MB will be taken.
-  virtual Expected<std::unique_ptr<MemoryBuffer>>
-  doJITPostProcessing(std::vector<std::unique_ptr<MemoryBuffer>> &&MB) const {
+  virtual Expected<std::unique_ptr<MemoryBuffer>> doJITPostProcessing(
+      llvm::SmallVector<std::unique_ptr<MemoryBuffer>> &&MB) const {
     if (MB.size() > 1)
       return make_error<error::OffloadError>(
           error::ErrorCode::UNSUPPORTED,

--- a/offload/plugins-nextgen/common/src/JIT.cpp
+++ b/offload/plugins-nextgen/common/src/JIT.cpp
@@ -292,7 +292,9 @@ JITEngine::compile(const __tgt_device_image &Image,
   if (!ObjMBOrErr)
     return ObjMBOrErr.takeError();
 
-  auto ImageMBOrErr = PostProcessing(std::move(*ObjMBOrErr));
+  std::vector<std::unique_ptr<MemoryBuffer>> Buffers;
+  Buffers.push_back(std::move(*ObjMBOrErr));
+  auto ImageMBOrErr = PostProcessing(std::move(Buffers));
   if (!ImageMBOrErr)
     return ImageMBOrErr.takeError();
 
@@ -314,7 +316,8 @@ JITEngine::process(const __tgt_device_image &Image,
                    target::plugin::GenericDeviceTy &Device) {
   const std::string &ComputeUnitKind = Device.getComputeUnitKind();
 
-  PostProcessingFn PostProcessing = [&Device](std::unique_ptr<MemoryBuffer> MB)
+  PostProcessingFn PostProcessing =
+      [&Device](std::vector<std::unique_ptr<MemoryBuffer>> &&MB)
       -> Expected<std::unique_ptr<MemoryBuffer>> {
     return Device.doJITPostProcessing(std::move(MB));
   };

--- a/offload/plugins-nextgen/common/src/JIT.cpp
+++ b/offload/plugins-nextgen/common/src/JIT.cpp
@@ -292,7 +292,7 @@ JITEngine::compile(const __tgt_device_image &Image,
   if (!ObjMBOrErr)
     return ObjMBOrErr.takeError();
 
-  std::vector<std::unique_ptr<MemoryBuffer>> Buffers;
+  llvm::SmallVector<std::unique_ptr<MemoryBuffer>> Buffers;
   Buffers.push_back(std::move(*ObjMBOrErr));
   auto ImageMBOrErr = PostProcessing(std::move(Buffers));
   if (!ImageMBOrErr)
@@ -317,7 +317,7 @@ JITEngine::process(const __tgt_device_image &Image,
   const std::string &ComputeUnitKind = Device.getComputeUnitKind();
 
   PostProcessingFn PostProcessing =
-      [&Device](std::vector<std::unique_ptr<MemoryBuffer>> &&MB)
+      [&Device](llvm::SmallVector<std::unique_ptr<MemoryBuffer>> &&MB)
       -> Expected<std::unique_ptr<MemoryBuffer>> {
     return Device.doJITPostProcessing(std::move(MB));
   };

--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -421,7 +421,7 @@ struct CUDADeviceTy : public GenericDeviceTy {
   }
 
   Expected<std::unique_ptr<MemoryBuffer>> doJITPostProcessing(
-      std::vector<std::unique_ptr<MemoryBuffer>> &&MB) const override {
+      llvm::SmallVector<std::unique_ptr<MemoryBuffer>> &&MB) const override {
     // TODO: This should be possible, just needs to be implemented
     if (MB.size() > 1)
       return make_error<error::OffloadError>(


### PR DESCRIPTION
The device handler for JIT processing images now accepts a list of
buffers rather than just one. Devices are expected to either link them
all into a single binary, or return an error code if they don't support
linking.

Currently, only amdgpu supports multiple binaries.
