### PR TITLE
[Dexter] Add option to Dexter to name results based on directory

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/tools/TestToolBase.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/tools/TestToolBase.py
@@ -58,6 +58,13 @@ class TestToolBase(ToolBase):
             default=None,
             help="directory to save results (default: none)",
         )
+        parser.add_argument(
+            "--test-root-dir",
+            type=str,
+            metavar="<directory>",
+            default=None,
+            help="if passed, result names will include relative path from this directory",
+        )
 
     def handle_options(self, defaults):
         options = self.context.options
@@ -130,10 +137,10 @@ class TestToolBase(ToolBase):
         """Get the test name from either the test file, or the sub directory
         path it's stored in.
         """
-        # test names are distinguished by their relative path from the
-        # specified test path.
-        test_name = os.path.relpath(test_path, self.context.options.test_path)
-        if self._is_current_directory(test_name):
+        # Test names are either relative to an explicitly given test root directory, or else we just use the base name.
+        if self.context.options.test_root_dir is not None:
+            test_name = os.path.relpath(test_path, self.context.options.test_root_dir)
+        else:
             test_name = os.path.basename(test_path)
         return test_name
 


### PR DESCRIPTION
As a legacy of Dexter's role as a test runner, it selects a name for result files based on the relative path from the test root to each individual test. Since Dexter no longer takes a test directory as an argument, only the basename for each test is ever used. This patch adds an optional --test-root-dir argument, allowing for relative paths to be used for result files again.