### PR TITLE
[HashRecognize] Strip ValueEvolution

### DIFF
--- a/llvm/include/llvm/Analysis/HashRecognize.h
+++ b/llvm/include/llvm/Analysis/HashRecognize.h
@@ -20,17 +20,11 @@
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/Value.h"
-#include "llvm/Support/KnownBits.h"
 #include <variant>
 
 namespace llvm {
 
 class LPMUpdater;
-
-/// A tuple of bits that are expected to be zero, number N of them expected to
-/// be zero, with a boolean indicating whether it's the top or bottom N bits
-/// expected to be zero.
-using ErrBits = std::tuple<KnownBits, unsigned, bool>;
 
 /// A custom std::array with 256 entries, that also has a print function.
 struct CRCTable : public std::array<APInt, 256> {
@@ -85,7 +79,7 @@ public:
   HashRecognize(const Loop &L, ScalarEvolution &SE);
 
   // The main analysis entry points.
-  std::variant<PolynomialInfo, ErrBits, StringRef> recognizeCRC() const;
+  std::variant<PolynomialInfo, StringRef> recognizeCRC() const;
   std::optional<PolynomialInfo> getResult() const;
 
   // Auxilary entry point after analysis to interleave the generating polynomial

--- a/llvm/include/llvm/IR/PatternMatch.h
+++ b/llvm/include/llvm/IR/PatternMatch.h
@@ -2284,6 +2284,14 @@ m_ZExtOrSExtOrSelf(const OpTy &Op) {
 }
 
 template <typename OpTy>
+inline match_combine_or<match_combine_or<CastInst_match<OpTy, ZExtInst>,
+                                         CastInst_match<OpTy, TruncInst>>,
+                        OpTy>
+m_ZExtOrTruncOrSelf(const OpTy &Op) {
+  return m_CombineOr(m_CombineOr(m_ZExt(Op), m_Trunc(Op)), Op);
+}
+
+template <typename OpTy>
 inline CastInst_match<OpTy, UIToFPInst> m_UIToFP(const OpTy &Op) {
   return CastInst_match<OpTy, UIToFPInst>(Op);
 }

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -178,10 +178,10 @@ isSignificantBitCheckWellFormed(const RecurrenceInfo &ConditionalRecurrence,
 
   // Match predicate with or without a SimpleRecurrence (the corresponding data
   // is LHSAux).
-  auto MatchPred =
-      m_CombineOr(m_Specific(ConditionalRecurrence.Phi),
-                  m_c_Xor(m_CastOrSelf(m_Specific(ConditionalRecurrence.Phi)),
-                          m_CastOrSelf(m_Specific(SimpleRecurrence.Phi))));
+  auto MatchPred = m_CombineOr(
+      m_Specific(ConditionalRecurrence.Phi),
+      m_c_Xor(m_ZExtOrTruncOrSelf(m_Specific(ConditionalRecurrence.Phi)),
+              m_ZExtOrTruncOrSelf(m_Specific(SimpleRecurrence.Phi))));
   bool LWellFormed = ByteOrderSwapped ? match(L, MatchPred)
                                       : match(L, m_c_And(MatchPred, m_One()));
   if (!LWellFormed)
@@ -401,8 +401,8 @@ static bool isConditionalOnXorOfPHIs(const SelectInst *SI, const PHINode *P1,
       continue;
 
     // If we match an XOR of the two PHIs ignoring casts, we're done.
-    if (match(I, m_c_Xor(m_CastOrSelf(m_Specific(P1)),
-                         m_CastOrSelf(m_Specific(P2)))))
+    if (match(I, m_c_Xor(m_ZExtOrTruncOrSelf(m_Specific(P1)),
+                         m_ZExtOrTruncOrSelf(m_Specific(P2)))))
       return true;
 
     // Continue along the use-def chain.

--- a/llvm/test/Analysis/HashRecognize/cyclic-redundancy-check.ll
+++ b/llvm/test/Analysis/HashRecognize/cyclic-redundancy-check.ll
@@ -1109,7 +1109,7 @@ exit:                                              ; preds = %loop
 define i16 @not.crc.unknown.value(i16 %msg, i16 %checksum, i16 %corrupt) {
 ; CHECK-LABEL: 'not.crc.unknown.value'
 ; CHECK-NEXT:  Did not find a hash algorithm
-; CHECK-NEXT:  Reason: Found stray unvisited or unhandled instructions
+; CHECK-NEXT:  Reason: Malformed significant-bit check
 ;
 entry:
   br label %loop
@@ -1137,7 +1137,7 @@ exit:                                              ; preds = %loop
 define i16 @not.crc.unknown.call.outside.loop(i16 %msg, i16 %checksum) {
 ; CHECK-LABEL: 'not.crc.unknown.call.outside.loop'
 ; CHECK-NEXT:  Did not find a hash algorithm
-; CHECK-NEXT:  Reason: Found stray unvisited or unhandled instructions
+; CHECK-NEXT:  Reason: Malformed significant-bit check
 ;
 entry:
   %corrupt = call i16 @side.effect()
@@ -1250,7 +1250,7 @@ exit:                                              ; preds = %loop
 define i16 @not.crc.stray.unvisited.call(i16 %crc.init) {
 ; CHECK-LABEL: 'not.crc.stray.unvisited.call'
 ; CHECK-NEXT:  Did not find a hash algorithm
-; CHECK-NEXT:  Reason: Found stray unvisited or unhandled instructions
+; CHECK-NEXT:  Reason: Found stray unvisited instructions
 ;
 entry:
   br label %loop
@@ -1276,7 +1276,7 @@ declare void @print(i16)
 define i16 @not.crc.call.sb.check(i16 %crc.init) {
 ; CHECK-LABEL: 'not.crc.call.sb.check'
 ; CHECK-NEXT:  Did not find a hash algorithm
-; CHECK-NEXT:  Reason: Found stray unvisited or unhandled instructions
+; CHECK-NEXT:  Reason: Malformed significant-bit check
 ;
 entry:
   br label %loop
@@ -1320,8 +1320,8 @@ exit:                                              ; preds = %loop
   ret i16 %crc.next
 }
 
-define i16 @not.crc.knownbits.sb.check.fail(i16 %crc.init) {
-; CHECK-LABEL: 'not.crc.knownbits.sb.check.fail'
+define i16 @not.crc.sb.check.patternmatch.fail(i16 %crc.init) {
+; CHECK-LABEL: 'not.crc.sb.check.patternmatch.fail'
 ; CHECK-NEXT:  Did not find a hash algorithm
 ; CHECK-NEXT:  Reason: Malformed significant-bit check
 ;
@@ -1346,8 +1346,8 @@ exit:                                              ; preds = %loop
   ret i16 %crc.next
 }
 
-define i16 @not.crc.knownbits.sb.check.fail.call.outside.loop(i16 %crc.init) {
-; CHECK-LABEL: 'not.crc.knownbits.sb.check.fail.call.outside.loop'
+define i16 @not.crc.sb.check.patternmatch.fail.call.outside.loop(i16 %crc.init) {
+; CHECK-LABEL: 'not.crc.sb.check.patternmatch.fail.call.outside.loop'
 ; CHECK-NEXT:  Did not find a hash algorithm
 ; CHECK-NEXT:  Reason: Malformed significant-bit check
 ;


### PR DESCRIPTION
The ValueEvolution logic is deeply flawed, and checking that zero-bits are shifted can be exploited for miscompiles. In an effort to redo HashRecognize with a pattern-matching based approach, extract and fix the core logic of ValueEvolution, and strip it completely, showing that none of the tests rely on the KnownBits computation of ValueEvolution.