### PR TITLE
[NFC] Remove mention of nonexistent SPIR_FUNC restriction.

### DIFF
--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -130,11 +130,10 @@ namespace CallingConv {
 
     /// Used for SPIR non-kernel device functions. No lowering or expansion of
     /// arguments. Structures are passed as a pointer to a struct with the
-    /// byval attribute. Functions can only call SPIR_FUNC and SPIR_KERNEL
-    /// functions. Functions can only have zero or one return values. Variable
-    /// arguments are not allowed, except for printf. How arguments/return
-    /// values are lowered are not specified. Functions are only visible to the
-    /// devices.
+    /// byval attribute. Functions can only have zero or one return values.
+    /// Variable arguments are not allowed, except for printf. How
+    /// arguments/return values are lowered are not specified. Functions are
+    /// only visible to the devices.
     SPIR_FUNC = 75,
 
     /// Used for SPIR kernel functions. Inherits the restrictions of SPIR_FUNC,


### PR DESCRIPTION
The documentation for SPIR_FUNC mentions that functions can only call SPIR_FUNC and SPIR_KERNEL functions, but there is no verification of this and we rely on being able to call functions with the default calling convention at least for intrinsics.