### PR TITLE
SPIRV: Define runtime libcalls to be (almost) empty

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -1998,6 +1998,17 @@ def SPARCSystemLibrary
 >;
 
 //===----------------------------------------------------------------------===//
+// SPIRV Runtime Libcalls
+//===----------------------------------------------------------------------===//
+
+def isSPIRV : RuntimeLibcallPredicate<"TT.isSPIRV()">;
+
+// No calls FIXME: Add memcpy/memset is a hack to skip
+// PreISelIntrinsicLowering in favor of SPIRVPrepareFunctions;
+// probably should remove that and just use the default one.
+def SPIRVSystemLibrary : SystemRuntimeLibrary<isSPIRV, (add memset, memcpy)>;
+
+//===----------------------------------------------------------------------===//
 // Windows Runtime Libcalls
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This is a behavior change; previously SPIRV inherited
a default set of calls which seems like a mistake. This
defines a library set with no calls. Add memcpy and memset
as a hack; this avoids PreISelIntrinsicLowering performing
the default expansion. SPIRVPrepareFunctions also calls
the utilities to expand these but the resulting output
is slightly different. The backend specific version
can probably be removed, it for some reason has a larger
output than the default one.