### PR TITLE
[Offload] Skip event tests on AMDGPU

### DIFF
--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -73,6 +73,18 @@ struct OffloadDeviceTest
       GTEST_SKIP() << "No available devices.";
   }
 
+  ol_platform_backend_t getPlatformBackend() const {
+    ol_platform_handle_t Platform = nullptr;
+    if (olGetDeviceInfo(Device, OL_DEVICE_INFO_PLATFORM,
+                        sizeof(ol_platform_handle_t), &Platform))
+      return OL_PLATFORM_BACKEND_UNKNOWN;
+    ol_platform_backend_t Backend;
+    if (olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND,
+                          sizeof(ol_platform_backend_t), &Backend))
+      return OL_PLATFORM_BACKEND_UNKNOWN;
+    return Backend;
+  }
+
   ol_device_handle_t Device = nullptr;
 };
 
@@ -159,6 +171,8 @@ struct OffloadQueueTest : OffloadDeviceTest {
 struct OffloadEventTest : OffloadQueueTest {
   void SetUp() override {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
+    if (getPlatformBackend() == OL_PLATFORM_BACKEND_AMDGPU)
+      GTEST_SKIP() << "AMDGPU synchronize event not implemented";
 
     // Get an event from a memcpy. We can still use it in olGetEventInfo etc
     // after it has been waited on.

--- a/offload/unittests/OffloadAPI/event/olWaitEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olWaitEvent.cpp
@@ -14,6 +14,9 @@ using olWaitEventTest = OffloadQueueTest;
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olWaitEventTest);
 
 TEST_P(olWaitEventTest, Success) {
+  if (getPlatformBackend() == OL_PLATFORM_BACKEND_AMDGPU)
+    GTEST_SKIP() << "AMDGPU synchronize event not implemented";
+
   uint32_t Src = 42;
   void *DstPtr;
 


### PR DESCRIPTION
Add `OffloadDeviceTest::getPlatformBackend()` and use it to skip event tests which currently fail on AMDGPU due to:

```
OL_ERRC_UNIMPLEMENTED: synchronize event not implemented
```
