### PR TITLE
[AArch64] computeKnownBitsForTargetNode - add AArch64ISD::MOVIshift support

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -2600,6 +2600,12 @@ void AArch64TargetLowering::computeKnownBitsForTargetNode(
         APInt(Known.getBitWidth(), Op->getConstantOperandVal(0)));
     break;
   }
+  case AArch64ISD::MOVIshift: {
+    Known = KnownBits::makeConstant(
+        APInt(Known.getBitWidth(), Op->getConstantOperandVal(0)
+                                       << Op->getConstantOperandVal(1)));
+    break;
+  }
   case AArch64ISD::LOADgot:
   case AArch64ISD::ADDlow: {
     if (!Subtarget->isTargetILP32())
@@ -30287,6 +30293,7 @@ bool AArch64TargetLowering::SimplifyDemandedBitsForTargetNode(
 bool AArch64TargetLowering::isTargetCanonicalConstantNode(SDValue Op) const {
   return Op.getOpcode() == AArch64ISD::DUP ||
          Op.getOpcode() == AArch64ISD::MOVI ||
+         Op.getOpcode() == AArch64ISD::MOVIshift ||
          (Op.getOpcode() == ISD::EXTRACT_SUBVECTOR &&
           Op.getOperand(0).getOpcode() == AArch64ISD::DUP) ||
          TargetLowering::isTargetCanonicalConstantNode(Op);

--- a/llvm/test/CodeGen/AArch64/arm64-zip.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zip.ll
@@ -454,7 +454,7 @@ define <4 x i32> @shuffle_zip3(<4 x i32> %arg) {
 ; CHECK-NEXT:    zip2.4h v0, v0, v1
 ; CHECK-NEXT:    movi.4s v1, #1
 ; CHECK-NEXT:    zip1.4h v0, v0, v0
-; CHECK-NEXT:    sshll.4s v0, v0, #0
+; CHECK-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-NEXT:    and.16b v0, v0, v1
 ; CHECK-NEXT:    ret
 bb:

--- a/llvm/test/CodeGen/AArch64/combine-mul.ll
+++ b/llvm/test/CodeGen/AArch64/combine-mul.ll
@@ -28,10 +28,7 @@ define <4 x i1> @PR48683_vec(<4 x i32> %x) {
 define <4 x i1> @PR48683_vec_undef(<4 x i32> %x) {
 ; CHECK-LABEL: PR48683_vec_undef:
 ; CHECK:       // %bb.0:
-; CHECK-NEXT:    movi v1.4s, #2
-; CHECK-NEXT:    mul v0.4s, v0.4s, v0.4s
-; CHECK-NEXT:    cmtst v0.4s, v0.4s, v1.4s
-; CHECK-NEXT:    xtn v0.4h, v0.4s
+; CHECK-NEXT:    movi v0.2d, #0000000000000000
 ; CHECK-NEXT:    ret
   %a = mul <4 x i32> %x, %x
   %b = and <4 x i32> %a, <i32 2, i32 2, i32 2, i32 undef>

--- a/llvm/test/CodeGen/AArch64/fast-isel-cmp-vec.ll
+++ b/llvm/test/CodeGen/AArch64/fast-isel-cmp-vec.ll
@@ -26,7 +26,6 @@ define <2 x i32> @icmp_constfold_v2i32(<2 x i32> %a) {
 ; CHECK-LABEL: icmp_constfold_v2i32:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    movi.2s v0, #1
-; CHECK-NEXT:    and.8b v0, v0, v0
 ; CHECK-NEXT:    ret
   %1 = icmp eq <2 x i32> %a, %a
   br label %bb2
@@ -56,8 +55,6 @@ define <4 x i32> @icmp_constfold_v4i32(<4 x i32> %a) {
 ; CHECK-LABEL: icmp_constfold_v4i32:
 ; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    movi.4h v0, #1
-; CHECK-NEXT:  ; %bb.1: ; %bb2
-; CHECK-NEXT:    and.8b v0, v0, v0
 ; CHECK-NEXT:    ushll.4s v0, v0, #0
 ; CHECK-NEXT:    ret
   %1 = icmp eq <4 x i32> %a, %a

--- a/llvm/test/CodeGen/AArch64/zext-to-tbl.ll
+++ b/llvm/test/CodeGen/AArch64/zext-to-tbl.ll
@@ -1246,33 +1246,33 @@ define void @zext_v16i4_to_v16i32_in_loop(ptr %src, ptr %dst) {
 ; CHECK-NEXT:    add x8, x8, #16
 ; CHECK-NEXT:    cmp x8, #128
 ; CHECK-NEXT:    ubfx x12, x9, #48, #4
-; CHECK-NEXT:    ubfx x10, x9, #52, #4
-; CHECK-NEXT:    ubfx x14, x9, #32, #4
+; CHECK-NEXT:    lsr x10, x9, #52
+; CHECK-NEXT:    ubfx x13, x9, #32, #4
 ; CHECK-NEXT:    ubfx w15, w9, #16, #4
-; CHECK-NEXT:    ubfx x11, x9, #36, #4
-; CHECK-NEXT:    ubfx w13, w9, #20, #4
+; CHECK-NEXT:    lsr x11, x9, #36
+; CHECK-NEXT:    lsr w14, w9, #20
 ; CHECK-NEXT:    fmov s1, w12
-; CHECK-NEXT:    fmov s2, w14
-; CHECK-NEXT:    ubfx w12, w9, #4, #4
+; CHECK-NEXT:    fmov s2, w13
+; CHECK-NEXT:    lsr w12, w9, #4
 ; CHECK-NEXT:    fmov s3, w15
 ; CHECK-NEXT:    mov.h v1[1], w10
 ; CHECK-NEXT:    and w10, w9, #0xf
 ; CHECK-NEXT:    mov.h v2[1], w11
 ; CHECK-NEXT:    fmov s4, w10
-; CHECK-NEXT:    ubfx x11, x9, #56, #4
-; CHECK-NEXT:    mov.h v3[1], w13
-; CHECK-NEXT:    ubfx x10, x9, #40, #4
+; CHECK-NEXT:    lsr x11, x9, #56
+; CHECK-NEXT:    mov.h v3[1], w14
+; CHECK-NEXT:    lsr x10, x9, #40
 ; CHECK-NEXT:    mov.h v4[1], w12
-; CHECK-NEXT:    ubfx w12, w9, #24, #4
+; CHECK-NEXT:    lsr w12, w9, #24
 ; CHECK-NEXT:    mov.h v1[2], w11
-; CHECK-NEXT:    ubfx w11, w9, #8, #4
+; CHECK-NEXT:    lsr w11, w9, #8
 ; CHECK-NEXT:    mov.h v2[2], w10
 ; CHECK-NEXT:    lsr x10, x9, #60
 ; CHECK-NEXT:    mov.h v3[2], w12
-; CHECK-NEXT:    ubfx x12, x9, #44, #4
+; CHECK-NEXT:    lsr x12, x9, #44
 ; CHECK-NEXT:    mov.h v4[2], w11
 ; CHECK-NEXT:    lsr w11, w9, #28
-; CHECK-NEXT:    ubfx w9, w9, #12, #4
+; CHECK-NEXT:    lsr w9, w9, #12
 ; CHECK-NEXT:    mov.h v1[3], w10
 ; CHECK-NEXT:    mov.h v2[3], w12
 ; CHECK-NEXT:    mov.h v3[3], w11
@@ -1300,38 +1300,37 @@ define void @zext_v16i4_to_v16i32_in_loop(ptr %src, ptr %dst) {
 ; CHECK-BE-NEXT:    ldr x9, [x0, x8]
 ; CHECK-BE-NEXT:    add x8, x8, #16
 ; CHECK-BE-NEXT:    cmp x8, #128
-; CHECK-BE-NEXT:    ubfx w12, w9, #12, #4
+; CHECK-BE-NEXT:    ubfx w11, w9, #12, #4
 ; CHECK-BE-NEXT:    lsr w14, w9, #28
-; CHECK-BE-NEXT:    ubfx w10, w9, #8, #4
+; CHECK-BE-NEXT:    lsr w10, w9, #8
 ; CHECK-BE-NEXT:    ubfx x15, x9, #44, #4
-; CHECK-BE-NEXT:    ubfx w11, w9, #24, #4
-; CHECK-BE-NEXT:    ubfx x13, x9, #40, #4
-; CHECK-BE-NEXT:    fmov s1, w12
-; CHECK-BE-NEXT:    lsr x12, x9, #60
+; CHECK-BE-NEXT:    lsr w12, w9, #24
+; CHECK-BE-NEXT:    lsr x13, x9, #40
+; CHECK-BE-NEXT:    fmov s1, w11
+; CHECK-BE-NEXT:    lsr x11, x9, #60
 ; CHECK-BE-NEXT:    fmov s2, w14
 ; CHECK-BE-NEXT:    fmov s3, w15
-; CHECK-BE-NEXT:    fmov s4, w12
-; CHECK-BE-NEXT:    ubfx w12, w9, #20, #4
+; CHECK-BE-NEXT:    fmov s4, w11
+; CHECK-BE-NEXT:    lsr w11, w9, #20
 ; CHECK-BE-NEXT:    mov v1.h[1], w10
-; CHECK-BE-NEXT:    ubfx x10, x9, #56, #4
-; CHECK-BE-NEXT:    mov v2.h[1], w11
-; CHECK-BE-NEXT:    ubfx w11, w9, #4, #4
+; CHECK-BE-NEXT:    lsr x10, x9, #56
+; CHECK-BE-NEXT:    mov v2.h[1], w12
+; CHECK-BE-NEXT:    lsr w12, w9, #4
 ; CHECK-BE-NEXT:    mov v3.h[1], w13
 ; CHECK-BE-NEXT:    mov v4.h[1], w10
-; CHECK-BE-NEXT:    ubfx x10, x9, #36, #4
-; CHECK-BE-NEXT:    mov v1.h[2], w11
-; CHECK-BE-NEXT:    ubfx x11, x9, #52, #4
-; CHECK-BE-NEXT:    mov v2.h[2], w12
+; CHECK-BE-NEXT:    lsr x10, x9, #36
+; CHECK-BE-NEXT:    mov v1.h[2], w12
+; CHECK-BE-NEXT:    lsr x12, x9, #52
+; CHECK-BE-NEXT:    mov v2.h[2], w11
 ; CHECK-BE-NEXT:    mov v3.h[2], w10
-; CHECK-BE-NEXT:    and w10, w9, #0xf
-; CHECK-BE-NEXT:    ubfx w12, w9, #16, #4
-; CHECK-BE-NEXT:    mov v4.h[2], w11
-; CHECK-BE-NEXT:    ubfx x11, x9, #32, #4
-; CHECK-BE-NEXT:    ubfx x9, x9, #48, #4
-; CHECK-BE-NEXT:    mov v1.h[3], w10
-; CHECK-BE-NEXT:    mov v2.h[3], w12
-; CHECK-BE-NEXT:    add x10, x1, #32
+; CHECK-BE-NEXT:    lsr w10, w9, #16
+; CHECK-BE-NEXT:    lsr x11, x9, #32
+; CHECK-BE-NEXT:    mov v4.h[2], w12
+; CHECK-BE-NEXT:    mov v1.h[3], w9
+; CHECK-BE-NEXT:    lsr x9, x9, #48
+; CHECK-BE-NEXT:    mov v2.h[3], w10
 ; CHECK-BE-NEXT:    mov v3.h[3], w11
+; CHECK-BE-NEXT:    add x10, x1, #32
 ; CHECK-BE-NEXT:    mov v4.h[3], w9
 ; CHECK-BE-NEXT:    add x9, x1, #48
 ; CHECK-BE-NEXT:    ushll v1.4s, v1.4h, #0


### PR DESCRIPTION
Fixes #148596