### PR TITLE
[AArch64][llvm] Fix DC CIGDVAPS instruction to require FEAT_MTE2

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64SystemOperands.td
+++ b/llvm/lib/Target/AArch64/AArch64SystemOperands.td
@@ -2387,6 +2387,9 @@ def : RWSysReg<"TRBSR_EL3",       0b11, 0b110, 0b1001, 0b1011, 0b011>;
 // v9.6 FEAT_PoPS
 //
 let Requires = [{ {AArch64::FeaturePoPS} }] in {
-def : DC<"CIGDVAPS",  0b000, 0b0111, 0b1111, 0b101>;
 def : DC<"CIVAPS",    0b000, 0b0111, 0b1111, 0b001>;
+}
+
+let Requires = [{ {AArch64::FeaturePoPS, AArch64::FeatureMTE} }] in {
+def : DC<"CIGDVAPS",  0b000, 0b0111, 0b1111, 0b101>;
 }

--- a/llvm/test/MC/AArch64/armv9.6a-ras.s
+++ b/llvm/test/MC/AArch64/armv9.6a-ras.s
@@ -1,9 +1,9 @@
 // RUN: not llvm-mc -triple aarch64 -show-encoding < %s 2>&1 | FileCheck %s --check-prefix NO-POPS
-// RUN: llvm-mc -triple aarch64 -mattr=+pops -show-encoding < %s 2>&1 | FileCheck %s --check-prefix HAS-POPS
+// RUN: llvm-mc -triple aarch64 -mattr=+pops,+mte -show-encoding < %s 2>&1 | FileCheck %s --check-prefix HAS-POPS
 
 dc CIGDVAPS, x3
 dc CIVAPS, x3
-// NO-POPS: error: DC CIGDVAPS requires: pops
+// NO-POPS: error: DC CIGDVAPS requires: mte, memtag, pops
 // NO-POPS: error: DC CIVAPS requires: pops
 
 # HAS-POPS:      	dc	cigdvaps, x3                    // encoding: [0xa3,0x7f,0x08,0xd5]

--- a/llvm/test/MC/Disassembler/AArch64/armv9.6a-ras.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.6a-ras.txt
@@ -1,4 +1,4 @@
-# RUN: llvm-mc -triple aarch64 -mattr=+pops -disassemble < %s | FileCheck %s
+# RUN: llvm-mc -triple aarch64 -mattr=+pops,+mte -disassemble < %s | FileCheck %s
 
 #------------------------------------------------------------------------------
 # ARMV9.6-A RAS Extensions


### PR DESCRIPTION
The `DC CIGDVAPS` instruction, according to the Armv9.6-A RAS specifiction, should only be available if `FEAT_PoPS` and `FEAT_MTE2` are implemented. Ensure this additional guard is required, and adjust tests for this instruction.