### PR TITLE
[Github] Use sparse checkout in release asset audit

### DIFF
--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout LLVM
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          sprase-checkout: |
+          sparse-checkout: |
             .github/workflows/release-asset-audit.py
             llvm/utils/git/requirements.txt
       - name: "Run Audit Script"

--- a/.github/workflows/release-asset-audit.yml
+++ b/.github/workflows/release-asset-audit.yml
@@ -22,7 +22,12 @@ jobs:
     runs-on: ubuntu-24.04
     if: github.repository == 'llvm/llvm-project'
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 #v4.1.6
+      - name: Checkout LLVM
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sprase-checkout: |
+            .github/workflows/release-asset-audit.py
+            llvm/utils/git/requirements.txt
       - name: "Run Audit Script"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This patch makes the release asset audit script use a sparse checkout given we only need two files. This should make the action quite a bit more efficient as it is presumably currently bottlenecked by checking out the entire monorepo.