### PR TITLE
[NFC][SemaHLSL] Remove check dependent on non-deterministic root element association

### DIFF
--- a/clang/test/SemaHLSL/RootSignature-resource-ranges-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-resource-ranges-err.hlsl
@@ -109,19 +109,6 @@ void bad_root_signature_14() {}
 #define DuplicatesRootSignature \
   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
 
-// CHECK: [[@LINE-2]]:4: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-3]] |   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:             |    ^
-// CHECK: [[@LINE-5]]:13: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-6]] |   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:             |             ^
-// CHECK: [[@LINE-8]]:22: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-9]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:             |                       ^
-// CHECK: [[@LINE-11]]:47: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-12]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:             |                                                ^
-
 // expected-error@+6 {{resource ranges b[0;0] and b[0;0] overlap within space = 0 and visibility = All}}
 // expected-note@+5 {{overlapping resource range here}}
 // expected-error@+4 {{resource ranges b[0;0] and b[0;0] overlap within space = 0 and visibility = All}}

--- a/clang/test/SemaHLSL/RootSignature-resource-ranges-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-resource-ranges-err.hlsl
@@ -112,21 +112,12 @@ void bad_root_signature_14() {}
 // CHECK: [[@LINE-2]]:13: note: expanded from macro 'DuplicatesRootSignature'
 // CHECK-NEXT: [[@LINE-3]] |   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
 // CHECK-NEXT:             |             ^
-// CHECK: [[@LINE-5]]:4: note: expanded from macro 'DuplicatesRootSignature'
+// CHECK: [[@LINE-5]]:22: note: expanded from macro 'DuplicatesRootSignature'
 // CHECK-NEXT: [[@LINE-6]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:             |     ^
-// CHECK: [[@LINE-8]]:22: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-9]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
 // CHECK-NEXT:             |                       ^
-// CHECK: [[@LINE-11]]:4: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-12]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:              |     ^
-// CHECK: [[@LINE-14]]:47: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-15]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:              |                                                ^
-// CHECK: [[@LINE-17]]:4: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-18]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:              |     ^
+// CHECK: [[@LINE-8]]:47: note: expanded from macro 'DuplicatesRootSignature'
+// CHECK-NEXT: [[@LINE-9]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
+// CHECK-NEXT:             |                                                ^
 
 // expected-error@+6 {{resource ranges b[0;0] and b[0;0] overlap within space = 0 and visibility = All}}
 // expected-note@+5 {{overlapping resource range here}}

--- a/clang/test/SemaHLSL/RootSignature-resource-ranges-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-resource-ranges-err.hlsl
@@ -109,14 +109,17 @@ void bad_root_signature_14() {}
 #define DuplicatesRootSignature \
   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
 
-// CHECK: [[@LINE-2]]:13: note: expanded from macro 'DuplicatesRootSignature'
+// CHECK: [[@LINE-2]]:4: note: expanded from macro 'DuplicatesRootSignature'
 // CHECK-NEXT: [[@LINE-3]] |   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
+// CHECK-NEXT:             |    ^
+// CHECK: [[@LINE-5]]:13: note: expanded from macro 'DuplicatesRootSignature'
+// CHECK-NEXT: [[@LINE-6]] |   "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
 // CHECK-NEXT:             |             ^
-// CHECK: [[@LINE-5]]:22: note: expanded from macro 'DuplicatesRootSignature'
-// CHECK-NEXT: [[@LINE-6]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
-// CHECK-NEXT:             |                       ^
-// CHECK: [[@LINE-8]]:47: note: expanded from macro 'DuplicatesRootSignature'
+// CHECK: [[@LINE-8]]:22: note: expanded from macro 'DuplicatesRootSignature'
 // CHECK-NEXT: [[@LINE-9]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
+// CHECK-NEXT:             |                       ^
+// CHECK: [[@LINE-11]]:47: note: expanded from macro 'DuplicatesRootSignature'
+// CHECK-NEXT: [[@LINE-12]] |    "CBV(b0), CBV(b0), CBV(b0), DescriptorTable(CBV(b0, numDescriptors = 2))"
 // CHECK-NEXT:             |                                                ^
 
 // expected-error@+6 {{resource ranges b[0;0] and b[0;0] overlap within space = 0 and visibility = All}}


### PR DESCRIPTION
- when there are duplicate (equivalent) `RangeInfo`s created we will attempt to `llvm::sort` or `llvm::stable_sort` them, it does not appear deterministic in which order they will be sorted (because they are equivalent)

- when `DLLVM_ENABLE_EXSTENSIVE_CHECKS` is enabled, it appears to deal with this tie-breaker sorting the list differently than when it is not enabled, this causes one of the test cases to fail because the diagnostic is produced, not in a different order, but with a different root element associated with an identical `RangeInfo`

- functionally this makes no difference to the diagnostic being produced and the removed test-case was added just as a nicety to demonstrate how the diagnostics might look

- the test above the removed will correctly demonstrate that the `SourceLocation` will be set to the correct column, and, the `-verify` portion of this testcase will ensure that we still generate a diagnostic for each duplicate

- therefore, it is safe to remove this portion of the test-case that can have a non-deterministic association of root element

This resolves the build issues reported [here](https://github.com/llvm/llvm-project/pull/147115#issuecomment-3069543491) and [here](https://github.com/llvm/llvm-project/pull/147800#issuecomment-3069797406)