### PR TITLE
[DebugInfo] Add option for producing no source-file hash

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.h
+++ b/clang/include/clang/Basic/CodeGenOptions.h
@@ -115,6 +115,7 @@ public:
     DSH_MD5,
     DSH_SHA1,
     DSH_SHA256,
+    DSH_NONE,
   };
 
   // This field stores one of the allowed values for the option

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4681,8 +4681,8 @@ def gsimple_template_names_EQ
       Values<"simple,mangled">, Visibility<[CC1Option]>;
 def gsrc_hash_EQ : Joined<["-"], "gsrc-hash=">,
   Group<g_flags_Group>, Visibility<[CC1Option]>,
-  Values<"md5,sha1,sha256">,
-  NormalizedValues<["DSH_MD5", "DSH_SHA1", "DSH_SHA256"]>,
+  Values<"md5,sha1,sha256,none">,
+  NormalizedValues<["DSH_MD5", "DSH_SHA1", "DSH_SHA256", "DSH_NONE"]>,
   NormalizedValuesScope<"CodeGenOptions">,
   MarshallingInfoEnum<CodeGenOpts<"DebugSrcHash">, "DSH_MD5">;
 def gno_simple_template_names : Flag<["-"], "gno-simple-template-names">,

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -514,6 +514,8 @@ CGDebugInfo::computeChecksum(FileID FID, SmallString<64> &Checksum) const {
   case clang::CodeGenOptions::DSH_SHA256:
     llvm::toHex(llvm::SHA256::hash(Data), /*LowerCase=*/true, Checksum);
     return llvm::DIFile::CSK_SHA256;
+  case clang::CodeGenOptions::DSH_NONE:
+    return std::nullopt;
   }
   llvm_unreachable("Unhandled DebugSrcHashKind enum");
 }

--- a/clang/test/CodeGen/debug-info-file-checksum.c
+++ b/clang/test/CodeGen/debug-info-file-checksum.c
@@ -13,12 +13,15 @@
 // RUN:     | FileCheck --check-prefix=SHA256 %s
 // RUN: %clang -emit-llvm -S -g -gcodeview -x c %S/Inputs/debug-info-file-checksum.c -o - | FileCheck %s
 // RUN: %clang -emit-llvm -S -gdwarf-5 -x c %S/Inputs/debug-info-file-checksum.c -o - | FileCheck %s
+// RUN: %clang -emit-llvm -S -gdwarf-5 -Xclang -gsrc-hash=md5 -x c %S/Inputs/debug-info-file-checksum.c -o - | FileCheck %s
+// RUN: %clang -emit-llvm -S -gdwarf-5 -Xclang -gsrc-hash=none -x c %S/Inputs/debug-info-file-checksum.c -o - | FileCheck %s --check-prefix=NONE
 
 // Check that "checksum" is created correctly for the compiled file.
 
 // CHECK: !DIFile(filename:{{.*}}, directory:{{.*}}, checksumkind: CSK_MD5, checksum: "a3b7d27af071accdeccaa933fc603608")
 // SHA1: !DIFile(filename:{{.*}}, directory:{{.*}}, checksumkind: CSK_SHA1, checksum: "6f6eeaba705ad6db6fbb05c2cbcf3cbb3e374bcd")
 // SHA256: !DIFile(filename:{{.*}}, directory:{{.*}}, checksumkind: CSK_SHA256, checksum: "2d49b53859e57898a0f8c16ff1fa4d99306b8ec28d65cf7577109761f0d56197")
+// NONE: !DIFile(filename:{{.*}}, directory:{{.*}})
 
 // Ensure #line directives (in already pre-processed files) do not emit checksums
 // RUN: %clang -emit-llvm -S -g -gcodeview -x c %S/Inputs/debug-info-file-checksum-pre.cpp -o - | FileCheck %s --check-prefix NOCHECKSUM


### PR DESCRIPTION
Clang can chose which sort of source-file hash is attached to a DIFile metadata node. However, whenever hashing is possible, we /always/ attach a hash. This patch permits users who want DWARF5 but don't want the file hashes to opt out, by adding a "none" option to the -gsrc-hash option that skips hash computation.

The option supports abnormal build processes where source-files are functionally identical between build time and debug time, but aren't byte-for-byte identical. Long story short, in various downstream builds we sometimes adjust things like version-strings and copyright notices in files after builds have taken place, and then distribute binaries + source to developers. This has no effect on the debugging experience as line-numbers don't change, but it does lead to a visual-studio pop-up alerting developers that some source files don't match the original build files.

Obviously this isn't a perfect arrangement, and the pop-up is correct. This patch is an non-invasive way of opting out of this facility for builds where byte-for-byte identicalness can't be achieved.