### PR TITLE
[llvm] annotate new symbols for DLL export

### DIFF
--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -757,7 +757,8 @@ LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderCreateDynamicArrayType(
  * @see DIBuilder::replaceArrays()
  */
 LLVM_C_ABI void LLVMReplaceArrays(LLVMDIBuilderRef Builder, LLVMMetadataRef *T,
-                       LLVMMetadataRef *Elements, unsigned NumElements);
+                                  LLVMMetadataRef *Elements,
+                                  unsigned NumElements);
 
 /**
  * Create debugging information entry for a vector type.

--- a/llvm/include/llvm-c/DebugInfo.h
+++ b/llvm/include/llvm-c/DebugInfo.h
@@ -700,7 +700,7 @@ LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderCreateArrayType(
  * \param AlignInBits    Set alignment.
  * \param BaseTy         The base type of the set.
  */
-LLVMMetadataRef LLVMDIBuilderCreateSetType(
+LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderCreateSetType(
     LLVMDIBuilderRef Builder, LLVMMetadataRef Scope, const char *Name,
     size_t NameLen, LLVMMetadataRef File, unsigned LineNumber,
     uint64_t SizeInBits, uint32_t AlignInBits, LLVMMetadataRef BaseTy);
@@ -722,7 +722,7 @@ LLVMMetadataRef LLVMDIBuilderCreateSetType(
  * \param Stride     Stride of the subrange.
  * \param Bias       Bias of the subrange.
  */
-LLVMMetadataRef LLVMDIBuilderCreateSubrangeType(
+LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderCreateSubrangeType(
     LLVMDIBuilderRef Builder, LLVMMetadataRef Scope, const char *Name,
     size_t NameLen, unsigned LineNo, LLVMMetadataRef File, uint64_t SizeInBits,
     uint32_t AlignInBits, LLVMDIFlags Flags, LLVMMetadataRef BaseTy,
@@ -743,7 +743,7 @@ LLVMMetadataRef LLVMDIBuilderCreateSubrangeType(
  * \param Rank         Rank. (DIVariable, DIExpression or NULL)
  * \param BitStride    BitStride.
  */
-LLVMMetadataRef LLVMDIBuilderCreateDynamicArrayType(
+LLVM_C_ABI LLVMMetadataRef LLVMDIBuilderCreateDynamicArrayType(
     LLVMDIBuilderRef Builder, LLVMMetadataRef Scope, const char *Name,
     size_t NameLen, unsigned LineNo, LLVMMetadataRef File, uint64_t Size,
     uint32_t AlignInBits, LLVMMetadataRef Ty, LLVMMetadataRef *Subscripts,
@@ -756,7 +756,7 @@ LLVMMetadataRef LLVMDIBuilderCreateDynamicArrayType(
  *
  * @see DIBuilder::replaceArrays()
  */
-void LLVMReplaceArrays(LLVMDIBuilderRef Builder, LLVMMetadataRef *T,
+LLVM_C_ABI void LLVMReplaceArrays(LLVMDIBuilderRef Builder, LLVMMetadataRef *T,
                        LLVMMetadataRef *Elements, unsigned NumElements);
 
 /**

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIAnalysis.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIAnalysis.h
@@ -24,6 +24,7 @@
 #ifndef LLVM_DWARFCFICHECKER_DWARFCFIANALYSIS_H
 #define LLVM_DWARFCFICHECKER_DWARFCFIANALYSIS_H
 
+#include "llvm/Support/Compiler.h"
 #include "DWARFCFIState.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallSet.h"
@@ -74,10 +75,10 @@ namespace llvm {
 /// checked, and in all other case(s), a warning is emitted.
 class DWARFCFIAnalysis {
 public:
-  DWARFCFIAnalysis(MCContext *Context, MCInstrInfo const &MCII, bool IsEH,
+  LLVM_ABI DWARFCFIAnalysis(MCContext *Context, MCInstrInfo const &MCII, bool IsEH,
                    ArrayRef<MCCFIInstruction> Prologue);
 
-  void update(const MCInst &Inst, ArrayRef<MCCFIInstruction> Directives);
+  LLVM_ABI void update(const MCInst &Inst, ArrayRef<MCCFIInstruction> Directives);
 
 private:
   void checkRegDiff(const MCInst &Inst, DWARFRegNum Reg,

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIAnalysis.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIAnalysis.h
@@ -24,7 +24,6 @@
 #ifndef LLVM_DWARFCFICHECKER_DWARFCFIANALYSIS_H
 #define LLVM_DWARFCFICHECKER_DWARFCFIANALYSIS_H
 
-#include "llvm/Support/Compiler.h"
 #include "DWARFCFIState.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallSet.h"
@@ -39,6 +38,7 @@
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -75,10 +75,11 @@ namespace llvm {
 /// checked, and in all other case(s), a warning is emitted.
 class DWARFCFIAnalysis {
 public:
-  LLVM_ABI DWARFCFIAnalysis(MCContext *Context, MCInstrInfo const &MCII, bool IsEH,
-                   ArrayRef<MCCFIInstruction> Prologue);
+  LLVM_ABI DWARFCFIAnalysis(MCContext *Context, MCInstrInfo const &MCII,
+                            bool IsEH, ArrayRef<MCCFIInstruction> Prologue);
 
-  LLVM_ABI void update(const MCInst &Inst, ArrayRef<MCCFIInstruction> Directives);
+  LLVM_ABI void update(const MCInst &Inst,
+                       ArrayRef<MCCFIInstruction> Directives);
 
 private:
   void checkRegDiff(const MCInst &Inst, DWARFRegNum Reg,

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameAnalyzer.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameAnalyzer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMEANALYZER_H
 #define LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMEANALYZER_H
 
+#include "llvm/Support/Compiler.h"
 #include "DWARFCFIAnalysis.h"
 #include "DWARFCFIFunctionFrameReceiver.h"
 #include "llvm/ADT/ArrayRef.h"
@@ -27,7 +28,7 @@ namespace llvm {
 /// emitted through the `MCContext` instance to the constructor. If a frame
 /// finishes without being started or if all the frames are not finished before
 /// this classes is destructed, the program fails through an assertion.
-class CFIFunctionFrameAnalyzer : public CFIFunctionFrameReceiver {
+class LLVM_ABI CFIFunctionFrameAnalyzer : public CFIFunctionFrameReceiver {
 public:
   CFIFunctionFrameAnalyzer(MCContext &Context, const MCInstrInfo &MCII)
       : CFIFunctionFrameReceiver(Context), MCII(MCII) {}

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameAnalyzer.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameAnalyzer.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMEANALYZER_H
 #define LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMEANALYZER_H
 
-#include "llvm/Support/Compiler.h"
 #include "DWARFCFIAnalysis.h"
 #include "DWARFCFIFunctionFrameReceiver.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameStreamer.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameStreamer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMESTREAMER_H
 #define LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMESTREAMER_H
 
+#include "llvm/Support/Compiler.h"
 #include "DWARFCFIFunctionFrameReceiver.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCContext.h"
@@ -30,7 +31,7 @@ namespace llvm {
 /// channels them to `CFIFunctionFrameReceiver`. A function frame is the machine
 /// instructions and CFI directives that are between `.cfi_startproc` and
 /// `.cfi_endproc` directives.
-class CFIFunctionFrameStreamer : public MCStreamer {
+class LLVM_ABI CFIFunctionFrameStreamer : public MCStreamer {
 public:
   CFIFunctionFrameStreamer(MCContext &Context,
                            std::unique_ptr<CFIFunctionFrameReceiver> Receiver)

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameStreamer.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIFunctionFrameStreamer.h
@@ -14,13 +14,13 @@
 #ifndef LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMESTREAMER_H
 #define LLVM_DWARFCFICHECKER_DWARFCFIFUNCTIONFRAMESTREAMER_H
 
-#include "llvm/Support/Compiler.h"
 #include "DWARFCFIFunctionFrameReceiver.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/Compiler.h"
 #include <memory>
 #include <optional>
 

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIState.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIState.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_DWARFCFICHECKER_UNWINDINFOSTATE_H
 #define LLVM_DWARFCFICHECKER_UNWINDINFOSTATE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/LowLevel/DWARFUnwindTable.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
@@ -30,13 +31,13 @@ class DWARFCFIState {
 public:
   DWARFCFIState(MCContext *Context) : Context(Context), IsInitiated(false) {};
 
-  std::optional<dwarf::UnwindRow> getCurrentUnwindRow() const;
+  LLVM_ABI std::optional<dwarf::UnwindRow> getCurrentUnwindRow() const;
 
   /// This method updates the state by applying \p Directive to the current
   /// state. If the directive is not supported by the checker or any error
   /// happens while applying the CFI directive, a warning or error is reported
   /// to the user, and the directive is ignored, leaving the state unchanged.
-  void update(const MCCFIInstruction &Directive);
+  LLVM_ABI void update(const MCCFIInstruction &Directive);
 
 private:
   dwarf::CFIProgram convert(MCCFIInstruction Directive);

--- a/llvm/include/llvm/DWARFCFIChecker/DWARFCFIState.h
+++ b/llvm/include/llvm/DWARFCFIChecker/DWARFCFIState.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_DWARFCFICHECKER_UNWINDINFOSTATE_H
 #define LLVM_DWARFCFICHECKER_UNWINDINFOSTATE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/DebugInfo/DWARF/LowLevel/DWARFUnwindTable.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDwarf.h"
+#include "llvm/Support/Compiler.h"
 #include <optional>
 
 namespace llvm {

--- a/llvm/include/llvm/Frontend/HLSL/RootSignatureValidations.h
+++ b/llvm/include/llvm/Frontend/HLSL/RootSignatureValidations.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_FRONTEND_HLSL_ROOTSIGNATUREVALIDATIONS_H
 #define LLVM_FRONTEND_HLSL_ROOTSIGNATUREVALIDATIONS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 
@@ -23,22 +24,22 @@ namespace rootsig {
 
 // Basic verification of RootElements
 
-bool verifyRootFlag(uint32_t Flags);
-bool verifyVersion(uint32_t Version);
-bool verifyRegisterValue(uint32_t RegisterValue);
-bool verifyRegisterSpace(uint32_t RegisterSpace);
-bool verifyRootDescriptorFlag(uint32_t Version, uint32_t FlagsVal);
-bool verifyRangeType(uint32_t Type);
-bool verifyDescriptorRangeFlag(uint32_t Version, uint32_t Type,
+LLVM_ABI bool verifyRootFlag(uint32_t Flags);
+LLVM_ABI bool verifyVersion(uint32_t Version);
+LLVM_ABI bool verifyRegisterValue(uint32_t RegisterValue);
+LLVM_ABI bool verifyRegisterSpace(uint32_t RegisterSpace);
+LLVM_ABI bool verifyRootDescriptorFlag(uint32_t Version, uint32_t FlagsVal);
+LLVM_ABI bool verifyRangeType(uint32_t Type);
+LLVM_ABI bool verifyDescriptorRangeFlag(uint32_t Version, uint32_t Type,
                                uint32_t FlagsVal);
-bool verifyNumDescriptors(uint32_t NumDescriptors);
-bool verifySamplerFilter(uint32_t Value);
-bool verifyAddress(uint32_t Address);
-bool verifyMipLODBias(float MipLODBias);
-bool verifyMaxAnisotropy(uint32_t MaxAnisotropy);
-bool verifyComparisonFunc(uint32_t ComparisonFunc);
-bool verifyBorderColor(uint32_t BorderColor);
-bool verifyLOD(float LOD);
+LLVM_ABI bool verifyNumDescriptors(uint32_t NumDescriptors);
+LLVM_ABI bool verifySamplerFilter(uint32_t Value);
+LLVM_ABI bool verifyAddress(uint32_t Address);
+LLVM_ABI bool verifyMipLODBias(float MipLODBias);
+LLVM_ABI bool verifyMaxAnisotropy(uint32_t MaxAnisotropy);
+LLVM_ABI bool verifyComparisonFunc(uint32_t ComparisonFunc);
+LLVM_ABI bool verifyBorderColor(uint32_t BorderColor);
+LLVM_ABI bool verifyLOD(float LOD);
 
 struct RangeInfo {
   const static uint32_t Unbounded = ~0u;
@@ -145,7 +146,7 @@ struct OverlappingRanges {
 ///      A: Insert the current RangeInfo into the corresponding Visibility
 ///   ResourceRange
 ///      B: Check for overlap with any overlapping Visibility ResourceRange
-llvm::SmallVector<OverlappingRanges>
+LLVM_ABI llvm::SmallVector<OverlappingRanges>
 findOverlappingRanges(ArrayRef<RangeInfo> Infos);
 
 } // namespace rootsig

--- a/llvm/include/llvm/Frontend/HLSL/RootSignatureValidations.h
+++ b/llvm/include/llvm/Frontend/HLSL/RootSignatureValidations.h
@@ -14,9 +14,9 @@
 #ifndef LLVM_FRONTEND_HLSL_ROOTSIGNATUREVALIDATIONS_H
 #define LLVM_FRONTEND_HLSL_ROOTSIGNATUREVALIDATIONS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/IntervalMap.h"
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 namespace hlsl {
@@ -31,7 +31,7 @@ LLVM_ABI bool verifyRegisterSpace(uint32_t RegisterSpace);
 LLVM_ABI bool verifyRootDescriptorFlag(uint32_t Version, uint32_t FlagsVal);
 LLVM_ABI bool verifyRangeType(uint32_t Type);
 LLVM_ABI bool verifyDescriptorRangeFlag(uint32_t Version, uint32_t Type,
-                               uint32_t FlagsVal);
+                                        uint32_t FlagsVal);
 LLVM_ABI bool verifyNumDescriptors(uint32_t NumDescriptors);
 LLVM_ABI bool verifySamplerFilter(uint32_t Value);
 LLVM_ABI bool verifyAddress(uint32_t Address);

--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -147,7 +147,7 @@ private:
   LLVM_ABI static const char *const LibCallImplNames[RTLIB::NumLibcallImpls];
 
   /// Map from a concrete LibcallImpl implementation to its RTLIB::Libcall kind.
-  static const RTLIB::Libcall ImplToLibcall[RTLIB::NumLibcallImpls];
+  LLVM_ABI static const RTLIB::Libcall ImplToLibcall[RTLIB::NumLibcallImpls];
 
   static bool darwinHasSinCosStret(const Triple &TT) {
     if (!TT.isOSDarwin())

--- a/llvm/include/llvm/Target/RegisterTargetPassConfigCallback.h
+++ b/llvm/include/llvm/Target/RegisterTargetPassConfigCallback.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_TARGET_REGISTERTARGETPASSCONFIGCALLBACK_H
 #define LLVM_TARGET_REGISTERTARGETPASSCONFIGCALLBACK_H
 
-#include "llvm/Support/Compiler.h"
 #include "TargetMachine.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 
@@ -30,9 +30,9 @@ public:
   LLVM_ABI ~RegisterTargetPassConfigCallback();
 };
 
-LLVM_ABI void invokeGlobalTargetPassConfigCallbacks(TargetMachine &TM,
-                                           PassManagerBase &PM,
-                                           TargetPassConfig *PassConfig);
+LLVM_ABI void
+invokeGlobalTargetPassConfigCallbacks(TargetMachine &TM, PassManagerBase &PM,
+                                      TargetPassConfig *PassConfig);
 } // namespace llvm
 
 #endif // LLVM_TARGET_REGISTERTARGETPASSCONFIGCALLBACK_H

--- a/llvm/include/llvm/Target/RegisterTargetPassConfigCallback.h
+++ b/llvm/include/llvm/Target/RegisterTargetPassConfigCallback.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_TARGET_REGISTERTARGETPASSCONFIGCALLBACK_H
 #define LLVM_TARGET_REGISTERTARGETPASSCONFIGCALLBACK_H
 
+#include "llvm/Support/Compiler.h"
 #include "TargetMachine.h"
 
 namespace llvm {
@@ -25,11 +26,11 @@ class RegisterTargetPassConfigCallback {
 public:
   PassConfigCallback Callback;
 
-  explicit RegisterTargetPassConfigCallback(PassConfigCallback &&C);
-  ~RegisterTargetPassConfigCallback();
+  LLVM_ABI explicit RegisterTargetPassConfigCallback(PassConfigCallback &&C);
+  LLVM_ABI ~RegisterTargetPassConfigCallback();
 };
 
-void invokeGlobalTargetPassConfigCallbacks(TargetMachine &TM,
+LLVM_ABI void invokeGlobalTargetPassConfigCallbacks(TargetMachine &TM,
                                            PassManagerBase &PM,
                                            TargetPassConfig *PassConfig);
 } // namespace llvm


### PR DESCRIPTION
## Purpose
This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates symbols that were added to LLVM in the last two weeks and were missed by previous code-mods. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background
This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview
These changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang