### PR TITLE
[flang][Lower] fix warning

### DIFF
--- a/flang/lib/Lower/Support/ReductionProcessor.cpp
+++ b/flang/lib/Lower/Support/ReductionProcessor.cpp
@@ -134,6 +134,7 @@ ReductionProcessor::getReductionType(const fir::ReduceOperationEnum &redOp) {
   case fir::ReduceOperationEnum::MIN:
     return ReductionIdentifier::MIN;
   }
+  llvm_unreachable("Unhandled ReductionIdentifier case");
 }
 
 bool ReductionProcessor::supportedIntrinsicProcReduction(


### PR DESCRIPTION
GCC 9.3.0
```
.../flang/lib/Lower/Support/ReductionProcessor.cpp:137:1: error: control reaches end of non-void function [-Werror=return-type]
```