### PR TITLE
[clang][deps] Fix dependency scanner misidentifying 'import::' as module partition

### DIFF
--- a/clang/lib/Lex/DependencyDirectivesScanner.cpp
+++ b/clang/lib/Lex/DependencyDirectivesScanner.cpp
@@ -722,6 +722,13 @@ bool Scanner::lexModule(const char *&First, const char *const End) {
       skipLine(First, End);
       return false;
     }
+    // A module partition starts with exactly one ':'. If we have '::', this is
+    // a scope resolution instead and shouldn't be recognized as a directive
+    // per P1857R3.
+    if (First + 1 != End && First[1] == ':') {
+      skipLine(First, End);
+      return false;
+    }
     // `import:(type)name` is a valid ObjC method decl, so check one more token.
     (void)lexToken(First, End);
     if (!tryLexIdentifierOrSkipLine(First, End))

--- a/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
+++ b/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
@@ -1151,6 +1151,18 @@ TEST(MinimizeSourceToDependencyDirectivesTest, ObjCMethodArgs) {
   EXPECT_STREQ("<TokBeforeEOF>\n", Out.data());
 }
 
+TEST(MinimizeSourceToDependencyDirectivesTest, CxxModulesImportScopeResolution) {
+  SmallString<16> Out;
+  SmallVector<dependency_directives_scan::Token, 2> Tokens;
+  SmallVector<Directive, 1> Directives;
+
+  StringRef Source = "import::inner xi = {};'\n"
+                     "module::inner yi = {};";
+  ASSERT_FALSE(
+      minimizeSourceToDependencyDirectives(Source, Out, Tokens, Directives));
+  EXPECT_STREQ("<TokBeforeEOF>\n", Out.data());
+}
+
 TEST(MinimizeSourceToDependencyDirectivesTest, TokensBeforeEOF) {
   SmallString<128> Out;
 

--- a/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
+++ b/clang/unittests/Lex/DependencyDirectivesScannerTest.cpp
@@ -1151,7 +1151,8 @@ TEST(MinimizeSourceToDependencyDirectivesTest, ObjCMethodArgs) {
   EXPECT_STREQ("<TokBeforeEOF>\n", Out.data());
 }
 
-TEST(MinimizeSourceToDependencyDirectivesTest, CxxModulesImportScopeResolution) {
+TEST(MinimizeSourceToDependencyDirectivesTest,
+     CxxModulesImportScopeResolution) {
   SmallString<16> Out;
   SmallVector<dependency_directives_scan::Token, 2> Tokens;
   SmallVector<Directive, 1> Directives;


### PR DESCRIPTION
The dependency directive scanner was incorrectly classifying namespaces such as `import::inner xi` as directives. According to [P1857R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1857r3.html#tony-table), `import` should not be treated as a directive when followed by `::`.
This change fixes that behavior.