### PR TITLE
[ORC] Support non-moving cloneToContext

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/ThreadSafeModule.h
@@ -62,6 +62,12 @@ public:
       return F((const LLVMContext *)nullptr);
   }
 
+  /// Get a raw pointer to the contained context without locking the context.
+  LLVMContext *getContextUnlocked() { return S->Ctx.get(); }
+
+  /// Get a raw pointer to the contained context without locking the context.
+  const LLVMContext *getContextUnlocked() const { return S->Ctx.get(); }
+
 private:
   std::shared_ptr<State> S;
 };
@@ -154,6 +160,10 @@ using GVPredicate = std::function<bool(const GlobalValue &)>;
 using GVModifier = std::function<void(GlobalValue &)>;
 
 /// Clones teh given module onto the given context.
+LLVM_ABI ThreadSafeModule
+cloneToContext(const Module &M, ThreadSafeContext TSCtx,
+               GVPredicate ShouldCloneDef = GVPredicate(),
+               GVModifier UpdateClonedDefSource = GVModifier());
 LLVM_ABI ThreadSafeModule
 cloneToContext(const ThreadSafeModule &TSMW, ThreadSafeContext TSCtx,
                GVPredicate ShouldCloneDef = GVPredicate(),


### PR DESCRIPTION
There are two usability concerns, in some cases, with the new `cloneToContext` from https://github.com/llvm/llvm-project/pull/146852.

1. This API assumes the LLVM context is in a `ThreadSafeContext`, but I have no need for that. My IR gen is single-threaded. IR gen (via `IRBuilder`) uses the context and module often, so I would need to do a whole lot of `withContextDo` with closures just to do things like create a new basic block.

2. The new cloning function requires a `ThreadSafeModule`, which can only be constructed by *moving* (i.e. consuming) a module. This prevents me from caching my C++ modules, which explodes the number I need to generate. Cloning should be read-only, so the module consuming here feels like it's just an implication of TSMs being used.

We can address both of these by:

1. Adding a `getContextUnlocked` to `ThreadSafeContext`, following what exists for `ThreadSafeModule`; this allows me to store a raw pointer for easy use with IR gen

2. Add an overload for `cloneToContext` which take a `const Module &` and use that as the implementation for the TSM version

@lhames for vis.