### PR TITLE
[LLDB] Compile API tests with exceptions enabled on Windows

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -344,10 +344,6 @@ endif
 #----------------------------------------------------------------------
 ifeq "$(OS)" "Windows_NT"
 	ifeq ($(CC_TYPE), clang)
-		# Clang for Windows doesn't support C++ Exceptions
-		CXXFLAGS += -fno-exceptions
-		CXXFLAGS += -D_HAS_EXCEPTIONS=0
-
 		# MSVC 2015 or higher is required, which depends on c++14, so
 		# append these values unconditionally.
 		CXXFLAGS += -fms-compatibility-version=19.0

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/main.cpp
@@ -165,6 +165,7 @@ int main (int argc, const char * argv[])
     Simple a_simple_object(3,0.14,'E');
     
     VeryLong a_long_guy;
+    auto *unused = &a_long_guy; // ensure a_long_guy isn't optimized out
 
     std::string some_string = "012345678901234567890123456789"
                               "012345678901234567890123456789"


### PR DESCRIPTION
From #148554 - compile tests with exceptions on Windows (`-fno-exceptions` was added 11 years ago in c7826524acda6a9c8816261d5c48b94dc92935ed). The variant test uses `try {} catch {}` to create variants that are valueless by exception. On other platforms, exceptions are enabled as well.

I have no clue why compiling with exceptions will optimize out `a_long_guy` in the changed test (even with `-O0`). Taking the address of that value will ensure it's kept.