### PR TITLE
[DebugInfo][DWARF] Add DWARF/LowLevel to module.modulemap

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -125,6 +125,13 @@ module LLVM_DebugInfo_DWARF {
   module * { export * }
 }
 
+module LLVM_DebugInfo_DWARF_LowLevel {
+  requires cplusplus
+
+  umbrella "llvm/DebugInfo/DWARF/LowLevel"
+  module * { export * }
+}
+
 module LLVM_DebugInfo_PDB {
   requires cplusplus
 


### PR DESCRIPTION
This ensures the generation of Attributes.inc when using -DLLVM_ENABLE_MODULES=ON.