### PR TITLE
Fix an issue where we erroneously diagnose a `[[noreturn]]` function with `warn_suggest_noreturn_function`

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1976,8 +1976,8 @@ void clang::inferNoReturnAttr(Sema &S, const Decl *D) {
       Diags.isIgnored(diag::warn_suggest_noreturn_function, FD->getLocation()))
     return;
 
-  if (!FD->hasAttr<NoReturnAttr>() && !FD->hasAttr<InferredNoReturnAttr>() &&
-      isKnownToAlwaysThrow(FD)) {
+  if (!FD->hasAttr<NoReturnAttr>() && !FD->hasAttr<CXX11NoReturnAttr>() &&
+      !FD->hasAttr<InferredNoReturnAttr>() && isKnownToAlwaysThrow(FD)) {
     NonConstFD->addAttr(InferredNoReturnAttr::CreateImplicit(S.Context));
 
     // Emit a diagnostic suggesting the function being marked [[noreturn]].


### PR DESCRIPTION
The following snippet,

```c++
#include <cassert>
#include <stdexcept>

[[noreturn]] void foo() { throw std::runtime_error("Why...?"); }

int main() {
    try {
        foo();
    } catch (std::runtime_error const& ex) {
        (void)ex;
    }
}
```

is diagnosed with `error: function 'foo' could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]` when compiled with clang_trunk using `-Werror=missing-noreturn` flag. See more at [godbolt](https://godbolt.org/z/5zMsev4as)


AST shows
```
| `-CXX11NoReturnAttr 0x1896e81eb00 <line:2:20> Inherited noreturn
|-FunctionDecl 0x1896e81ebd8 <line:10:14, col:46> col:19 used foo 'void ()'
| |-CompoundStmt 0x1896e81ee20 <col:25, col:46>
| | `-CXXThrowExpr 0x1896e81ee08 <col:27, col:43> 'void'
| |   `-ImplicitCastExpr 0x1896e81edf0 <col:33, col:43> 'const char *' <ArrayToPointerDecay>
| |     `-ParenExpr 0x1896e81eda0 <col:33, col:43> 'const char[8]' lvalue
| |       `-StringLiteral 0x1896e81ed80 <col:34> 'const char[8]' lvalue "Why...?"
| |-CXX11NoReturnAttr 0x1896e81ec80 <col:3> noreturn
| `-InferredNoReturnAttr 0x1896e81ee38 <<invalid sloc>> Implicit
```

but the responsible code only checks for `NoReturnAttr`, adding a check for `CXX11NoReturnAttr` before emitting the diagnostic should fix this issue.