### PR TITLE
[CI][Github] Add Workflow to Run Python Tests in CI Folder

### DIFF
--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -7,9 +7,11 @@ on:
   push:
     paths:
      - '.ci/**'
+     - '.github/workflows/check-ci.yml'
   pull_request:
     paths:
      - '.ci/**'
+     - '.github/workflows/check-ci.yml'
 
 jobs:
   test-python:
@@ -29,5 +31,5 @@ jobs:
       - name: Install Python Dependencies
         run: pip3 install -r .ci/all_requirements.txt
       - name: Run Tests
-        working-direcotry: .ci
+        working-directory: .ci
         run: pytest

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Fetch LLVM sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          sparse-checkout: .ci/**
+          sparse-checkout: .ci
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -29,7 +29,9 @@ jobs:
           python-version: 3.13
           cache: 'pip'
       - name: Install Python Dependencies
-        run: pip3 install -r .ci/all_requirements.txt
+        run: |
+          pip3 install -r .ci/all_requirements.txt
+          pip3 install pytest==8.4.1
       - name: Run Tests
         working-directory: .ci
         run: pytest

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -1,0 +1,33 @@
+name: Check CI
+
+permissions:
+  contents: read
+
+on:
+  push:
+    paths:
+     - '.ci/**'
+  pull_request:
+    paths:
+     - '.ci/**'
+
+jobs:
+  test-python:
+    name: "Check Python Tests"
+    runs-on: ubuntu-24.04
+    if: github.repository == 'llvm/llvm-project'
+    steps:
+      - name: Fetch LLVM sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .ci/**
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: 3.13
+          cache: 'pip'
+      - name: Install Python Dependencies
+        run: pip3 install -r .ci/all_requirements.txt
+      - name: Run Tests
+        working-direcotry: .ci
+        run: pytest

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -1,4 +1,4 @@
-name: Check CI
+name: Check CI Scripts
 
 permissions:
   contents: read


### PR DESCRIPTION
This patch adds a new GHA workflow that runs pytest inside of the .ci directory to test all of the CI infrastructure. This is to make it more visible to new contributors that these tests exist and also to ensure that they are passing before merge. There have been several instances already where someone neglected to update these tests and we should have automation to enforce this.