### PR TITLE
[flang] Fix crash in Semantics

### DIFF
--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -348,9 +348,9 @@ const Symbol &BypassGeneric(const Symbol &symbol) {
 
 const Symbol &GetCrayPointer(const Symbol &crayPointee) {
   const Symbol *found{nullptr};
-  for (const auto &[pointee, pointer] :
-      crayPointee.GetUltimate().owner().crayPointers()) {
-    if (pointee == crayPointee.name()) {
+  const Symbol &ultimate{crayPointee.GetUltimate()};
+  for (const auto &[pointee, pointer] : ultimate.owner().crayPointers()) {
+    if (pointee == ultimate.name()) {
       found = &pointer.get();
       break;
     }

--- a/flang/test/Semantics/bug148559.f90
+++ b/flang/test/Semantics/bug148559.f90
@@ -1,0 +1,12 @@
+!RUN: %flang_fc1 -fsyntax-only %s
+!Regression test for crash in semantics on Cray pointers
+
+module m
+  pointer(ptr,pp)
+end module m
+
+program main
+  use m, only:renamea=>pp
+  use m, only:pp
+  print *, renamea
+end


### PR DESCRIPTION
Allow for renaming in USE association of Cray pointers.

Fixes https://github.com/llvm/llvm-project/issues/148559.