### PR TITLE
[flang] Mangle main program's symbol name to make it distinct from the other symbols

### DIFF
--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -836,7 +836,6 @@ public:
   using Flags = common::EnumSet<Flag, Flag_enumSize>;
 
   const Scope &owner() const { return *owner_; }
-
   const SourceName &name() const {
     if (const auto *details = detailsIf<MainProgramDetails>()) {
       // For main program symbol always return the original name
@@ -844,7 +843,6 @@ public:
     }
     return name_;
   }
-
   Attrs &attrs() { return attrs_; }
   const Attrs &attrs() const { return attrs_; }
   Attrs &implicitAttrs() { return implicitAttrs_; }

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -107,7 +107,14 @@ private:
 
 class MainProgramDetails : public WithOmpDeclarative {
 public:
+  MainProgramDetails() {}
+  MainProgramDetails(const SourceName &name, const SourceName &scopeName)
+  : name_{name}, scopeName_{scopeName} {}
+  const SourceName& scopeName() const { return scopeName_; }
+  const SourceName& name() const { return name_; }
 private:
+  SourceName name_; // Original main program symbol name
+  SourceName scopeName_; // Main program symbol name used in scope symbol table
 };
 
 class WithBindName {
@@ -828,7 +835,15 @@ public:
   using Flags = common::EnumSet<Flag, Flag_enumSize>;
 
   const Scope &owner() const { return *owner_; }
-  const SourceName &name() const { return name_; }
+
+  const SourceName &name() const {
+    if (const auto* details = detailsIf<MainProgramDetails>()) {
+      // For main program symbol always return the original name
+      return details->name();
+    }
+    return name_;
+  }
+
   Attrs &attrs() { return attrs_; }
   const Attrs &attrs() const { return attrs_; }
   Attrs &implicitAttrs() { return implicitAttrs_; }

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -109,9 +109,10 @@ class MainProgramDetails : public WithOmpDeclarative {
 public:
   MainProgramDetails() {}
   MainProgramDetails(const SourceName &name, const SourceName &scopeName)
-  : name_{name}, scopeName_{scopeName} {}
-  const SourceName& scopeName() const { return scopeName_; }
-  const SourceName& name() const { return name_; }
+      : name_{name}, scopeName_{scopeName} {}
+  const SourceName &scopeName() const { return scopeName_; }
+  const SourceName &name() const { return name_; }
+
 private:
   SourceName name_; // Original main program symbol name
   SourceName scopeName_; // Main program symbol name used in scope symbol table
@@ -837,7 +838,7 @@ public:
   const Scope &owner() const { return *owner_; }
 
   const SourceName &name() const {
-    if (const auto* details = detailsIf<MainProgramDetails>()) {
+    if (const auto *details = detailsIf<MainProgramDetails>()) {
       // For main program symbol always return the original name
       return details->name();
     }


### PR DESCRIPTION
The following code is now accepted:
```
module m
end
program m
use m
end
```
The PROGRAM name doesn't really have an effect on the compilation result,
so it shouldn't result in symbol name conflicts.