### PR TITLE
[flang][runtime] Fix bad instance of std::optional in runtime

### DIFF
--- a/flang-rt/include/flang-rt/runtime/work-queue.h
+++ b/flang-rt/include/flang-rt/runtime/work-queue.h
@@ -307,7 +307,7 @@ public:
 
 private:
   bool finalize_{false};
-  std::optional<SubscriptValue> fixedStride_;
+  common::optional<SubscriptValue> fixedStride_;
 };
 
 // Implements general intrinsic assignment


### PR DESCRIPTION
The runtime needs to use common::optional, not std::optional.