### PR TITLE
[clang] Reduce the size of ParsedAttributesView and AttributePool

### DIFF
--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -678,7 +678,7 @@ class AttributePool {
   friend class AttributeFactory;
   friend class ParsedAttributes;
   AttributeFactory &Factory;
-  llvm::SmallVector<ParsedAttr *> Attrs;
+  llvm::SmallVector<ParsedAttr *, 2> Attrs;
 
   void *allocate(size_t size) {
     return Factory.allocate(size);
@@ -808,7 +808,7 @@ public:
 
 class ParsedAttributesView {
   friend class AttributePool;
-  using VecTy = llvm::SmallVector<ParsedAttr *>;
+  using VecTy = llvm::SmallVector<ParsedAttr *, 2>;
   using SizeType = decltype(std::declval<VecTy>().size());
 
 public:


### PR DESCRIPTION
These objects are used as local stack variables during parsing, and they are not small. This patch reduces their sizes:

* `ParsedAttributesView`: 72 → 40 bytes
* `AttributePool`: 72 → 40 bytes

No negative performance impact has been [observed](https://llvm-compile-time-tracker.com/compare.php?from=a709621cd545b061782b03136286227867b452a6&to=f50500b3c178e97c0c861301e853e6d5b859040b&stat=instructions:u).

**Context:**
We have some verilator-generated code with extremely deep nesting of parenthesized expressions, e.g.:

```cpp
bool s = 
(...(bool)(i[0])
 |(bool)(i[1]))
 |(bool)(i[2]))
 | ...
 |(bool)(i[n]));
```

Before this patch, on my local machine, Clang begins emitting `-Wstack-exhausted` when `n` is 715. After the patch, that threshold increases to `950`.
