### PR TITLE
Add new "target module replace" command

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -547,6 +547,22 @@ public:
   ///     remains valid as long as the object is around.
   virtual ObjectFile *GetObjectFile();
 
+  /// Replace existing backing object file with new \param object_file.
+  ///
+  /// The old object file being replaced will be kept alive to prevent from
+  /// dangling symbol references.
+  /// UUID and underlying symbol file will be reparsed during further access.
+  /// A common use case is to replace an Placeholder object file with a real
+  /// one during dump debugging.
+  ///
+  /// \param[in] target
+  ///    The target to update object file load address.
+  ///
+  /// \param[in] object_file
+  ///     The new object file spec to replace the existing one.
+  virtual void ReplaceObjectFile(Target &target, FileSpec object_file,
+                                 uint64_t object_offset);
+
   /// Get the unified section list for the module. This is the section list
   /// created by the module's object file and any debug info and symbol files
   /// created by the symbol vendor.
@@ -1032,6 +1048,9 @@ protected:
   lldb::ObjectFileSP m_objfile_sp; ///< A shared pointer to the object file
                                    /// parser for this module as it may or may
                                    /// not be shared with the SymbolFile
+  lldb::ObjectFileSP m_old_objfile_sp; /// Strong reference to keep the old
+                                       /// object file being replaced alive.
+
   UnwindTable m_unwind_table;      ///< Table of FuncUnwinders
                                    /// objects created for this
                                    /// Module's functions
@@ -1092,6 +1111,8 @@ protected:
 
 private:
   Module(); // Only used internally by CreateJITModule ()
+
+  void LoadObjectFile();
 
   Module(const Module &) = delete;
   const Module &operator=(const Module &) = delete;


### PR DESCRIPTION
Summary:
For dump debugging (both minidump and coredump), the dump most likely only contains the process memory without real modules so placeholder object files are created for the modules.

LLDB lacks a feature to hydrate/upgrade these dummy modules into real modules. This diff bridges the gap with a new `target module replace` command.

The new command would replace the place holder object file in target module with input new/real object file and refresh the symbol table/stack. The target module is located with file name matching, users can also specify the target module via "-s" option if the module names differ.

Another change is placeholder modules will have `(*)` added at the end as hint.

The workflow would be:
* lldb -c <path_to_dump>
* `image list` to see place holder modules
* download fbpkg and unzip it
* `target module replace <downloaded_fbpkg_module>`

Test Plan:
A new unit test is added.
c4crasher end-to-end debugging is tested.
c4crasher testing workflow is documented here: https://www.internalfb.com/intern/wiki/Coredumper/Developer_Guide/Development_Process/

Reviewers: wanyi, #lldb_team

Reviewed By: wanyi

Subscribers: gclayton, #lldb_team

Differential Revision: https://phabricator.intern.facebook.com/D43756670