### PR TITLE
[SelectionDAG] [KCFI] Allow "kcfi" on invoke

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -3355,7 +3355,7 @@ void SelectionDAGBuilder::visitInvoke(const InvokeInst &I) {
           {LLVMContext::OB_deopt, LLVMContext::OB_gc_transition,
            LLVMContext::OB_gc_live, LLVMContext::OB_funclet,
            LLVMContext::OB_cfguardtarget, LLVMContext::OB_ptrauth,
-           LLVMContext::OB_clang_arc_attachedcall}))
+           LLVMContext::OB_clang_arc_attachedcall, LLVMContext::OB_kcfi}))
     reportFatalUsageError(
         "cannot lower invokes with arbitrary operand bundles!");
 

--- a/llvm/test/CodeGen/X86/kcfi.ll
+++ b/llvm/test/CodeGen/X86/kcfi.ll
@@ -138,6 +138,29 @@ define void @f8() {
   ret void
 }
 
+declare i32 @__gxx_personality_v0(...)
+
+define void @f9() personality ptr @__gxx_personality_v0 {
+; MIR-LABEL: name: f9
+; MIR: body:
+; ISEL: CALL64m killed %0, 1, $noreg, 0, $noreg, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp, cfi-type 12345678
+; KCFI: $r11 = MOV64rm killed renamable $rax, 1, $noreg, 0, $noreg
+; KCFI-NEXT:  BUNDLE{{.*}} {
+; KCFI-NEXT:    KCFI_CHECK $r11, 12345678, implicit-def $r10, implicit-def $r11, implicit-def $eflags
+; KCFI-NEXT:    CALL64r internal $r11, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp
+; KCFI-NEXT:  }
+  %1 = load ptr, ptr @g, align 8
+  invoke void %1() [ "kcfi"(i32 12345678) ]
+    to label %cont
+    unwind label %err
+cont:
+  ret void
+err:
+  %exn = landingpad { i8*, i32 }
+          catch i8* null
+  resume { i8*, i32 } %exn
+}
+
 attributes #0 = { "target-features"="+retpoline-indirect-branches,+retpoline-indirect-calls" }
 
 !llvm.module.flags = !{!0}


### PR DESCRIPTION
This is handled in CallBase, so it is valid for both call and invoke
