### PR TITLE
[CI][Github] Switch windows to server 2022

### DIFF
--- a/.github/workflows/premerge.yaml
+++ b/.github/workflows/premerge.yaml
@@ -76,7 +76,7 @@ jobs:
     if: >-
         github.repository_owner == 'llvm' &&
         (github.event_name != 'pull_request' || github.event.action != 'closed')
-    runs-on: llvm-premerge-windows-runners
+    runs-on: llvm-premerge-windows-2022-runners
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This patch switches the windows testing over to server 2022 by switching to the recently introduced runner set.