### PR TITLE
[Clang] [Driver] Canoncalise `-internal-isystem` include paths

### DIFF
--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -228,9 +228,13 @@ protected:
   static void addSystemFrameworkInclude(const llvm::opt::ArgList &DriverArgs,
                                         llvm::opt::ArgStringList &CC1Args,
                                         const Twine &Path);
+
+public:
   static void addSystemInclude(const llvm::opt::ArgList &DriverArgs,
                                llvm::opt::ArgStringList &CC1Args,
                                const Twine &Path);
+
+protected:
   static void addExternCSystemInclude(const llvm::opt::ArgList &DriverArgs,
                                       llvm::opt::ArgStringList &CC1Args,
                                       const Twine &Path);

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1370,13 +1370,12 @@ ToolChain::CXXStdlibType ToolChain::GetCXXStdlibType(const ArgList &Args) const{
   return *cxxStdlibType;
 }
 
-
 static void ResolveAndAddSystemIncludePath(const ArgList &DriverArgs,
-                                               ArgStringList &CC1Args,
-                                               const Twine &Path) {
+                                           ArgStringList &CC1Args,
+                                           const Twine &Path) {
   bool Canonicalize =
-        DriverArgs.hasFlag(options::OPT_canonical_prefixes,
-                           options::OPT_no_canonical_prefixes, true);
+      DriverArgs.hasFlag(options::OPT_canonical_prefixes,
+                         options::OPT_no_canonical_prefixes, true);
 
   if (!Canonicalize) {
     CC1Args.push_back(DriverArgs.MakeArgString(Path));

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1382,18 +1382,11 @@ static void ResolveAndAddSystemIncludePath(const ArgList &DriverArgs,
     return;
   }
 
-  // We canonicalise system include paths that were added automatically if
-  // that yields a shorter path since those can end up quite long otherwise.
-  //
-  // While we would ideally prefer to use FileManager for this, there doesn't
-  // seem to be a way to obtain one in here, so we just resolve these via the
-  // real file system; most system libraries will hopefully correspond to
-  // actual files.
-  IntrusiveRefCntPtr<vfs::FileSystem> VFS = vfs::getRealFileSystem();
+  // We canonicalise system include paths that were added automatically
+  // since those can end up quite long otherwise.
   SmallString<256> Canonical, PathStorage;
   StringRef SimplifiedPath = Path.toStringRef(PathStorage);
-  if (!VFS->getRealPath(SimplifiedPath, Canonical) &&
-      Canonical.size() < SimplifiedPath.size())
+  if (!sys::fs::real_path(SimplifiedPath, Canonical))
     SimplifiedPath = Canonical;
   CC1Args.push_back(DriverArgs.MakeArgString(SimplifiedPath));
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -946,8 +946,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       SmallString<128> P(D.ResourceDir);
       llvm::sys::path::append(P, "include");
       llvm::sys::path::append(P, "openmp_wrappers");
-      CmdArgs.push_back("-internal-isystem");
-      CmdArgs.push_back(Args.MakeArgString(P));
+      getToolChain().addSystemInclude(Args, CmdArgs, P);
     }
 
     CmdArgs.push_back("-include");
@@ -959,7 +958,8 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     // standard library headers and other headers.
     SmallString<128> P(D.ResourceDir);
     llvm::sys::path::append(P, "include", "llvm_offload_wrappers");
-    CmdArgs.append({"-internal-isystem", Args.MakeArgString(P), "-include"});
+    getToolChain().addSystemInclude(Args, CmdArgs, P);
+    CmdArgs.push_back("-include");
     if (JA.isDeviceOffloading(Action::OFK_OpenMP))
       CmdArgs.push_back("__llvm_offload_device.h");
     else
@@ -1132,16 +1132,14 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
       SmallString<128> P(llvm::sys::path::parent_path(D.Dir));
       llvm::sys::path::append(P, "include");
       llvm::sys::path::append(P, getToolChain().getTripleString());
-      CmdArgs.push_back("-internal-isystem");
-      CmdArgs.push_back(Args.MakeArgString(P));
+      getToolChain().addSystemInclude(Args, CmdArgs, P);
     } else if (C.getActiveOffloadKinds() == Action::OFK_OpenMP) {
       // TODO: CUDA / HIP include their own headers for some common functions
       // implemented here. We'll need to clean those up so they do not conflict.
       SmallString<128> P(D.ResourceDir);
       llvm::sys::path::append(P, "include");
       llvm::sys::path::append(P, "llvm_libc_wrappers");
-      CmdArgs.push_back("-internal-isystem");
-      CmdArgs.push_back(Args.MakeArgString(P));
+      getToolChain().addSystemInclude(Args, CmdArgs, P);
     }
   }
 

--- a/clang/test/Driver/aarch64-toolchain.c
+++ b/clang/test/Driver/aarch64-toolchain.c
@@ -2,6 +2,7 @@
 
 // Test interaction with -fuse-ld=lld
 // RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_aarch64_gcc_tree/aarch64-none-elf 2>&1 \
@@ -20,6 +21,7 @@
 // LLD-AARCH64-BAREMETAL: "{{.*}}/Inputs/basic_aarch64_gcc_tree/lib/gcc/aarch64-none-elf/8.2.1/crtend.o"
 
 // RUN: %clang -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_aarch64_gcc_tree/aarch64-none-elf 2>&1 \
@@ -39,6 +41,7 @@
 // C-AARCH64-BAREMETAL: "{{.*}}/Inputs/basic_aarch64_gcc_tree/lib/gcc/aarch64-none-elf/8.2.1/crtend.o"
 
 // RUN: %clang -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=  2>&1 \
@@ -56,6 +59,7 @@
 // C-AARCH64-BAREMETAL-NOSYSROOT: "{{.*}}/Inputs/basic_aarch64_gcc_tree/lib/gcc/aarch64-none-elf/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf -stdlib=libstdc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_aarch64_gcc_tree/aarch64-none-elf 2>&1 \
@@ -76,6 +80,7 @@
 // CXX-AARCH64-BAREMETAL: "{{.*}}/Inputs/basic_aarch64_gcc_tree/lib/gcc/aarch64-none-elf/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf -stdlib=libstdc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=  2>&1 \
@@ -95,6 +100,7 @@
 // CXX-AARCH64-BAREMETAL-NOSYSROOT: "{{.*}}/Inputs/basic_aarch64_gcc_tree/lib/gcc/aarch64-none-elf/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf -stdlib=libc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_aarch64_gcc_tree/aarch64-none-elf 2>&1 \
@@ -114,6 +120,7 @@
 // CXX-AARCH64-BAREMETAL-LIBCXX: "{{.*}}/Inputs/basic_aarch64_gcc_tree/lib/gcc/aarch64-none-elf/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=aarch64-none-elf -stdlib=libc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_aarch64_gcc_tree \
 // RUN:   --sysroot=  2>&1 \

--- a/clang/test/Driver/android-installed-libcxx.cpp
+++ b/clang/test/Driver/android-installed-libcxx.cpp
@@ -16,10 +16,12 @@
 // RUN: mkdir -p %t2/include/aarch64-none-linux-android23/c++/v1
 
 // RUN: %clang -target aarch64-none-linux-android -ccc-install-dir %/t2/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --sysroot=%t2/sysroot -stdlib=libc++ -fsyntax-only \
 // RUN:   %s -### 2>&1 | FileCheck --check-prefix=ANDROID-DIR -DDIR=%/t2/bin %s
 
 // RUN: %clang -target aarch64-none-linux-android21 -ccc-install-dir %/t2/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --sysroot=%t2/sysroot -stdlib=libc++ -fsyntax-only \
 // RUN:   %s -### 2>&1 | FileCheck --check-prefix=ANDROID-DIR -DDIR=%/t2/bin %s
 
@@ -27,10 +29,12 @@
 // ANDROID-DIR-SAME: "-internal-isystem" "[[DIR]][[SEP]]..[[SEP]]include[[SEP]]c++[[SEP]]v1"
 
 // RUN: %clang -target aarch64-none-linux-android23 -ccc-install-dir %/t2/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --sysroot=%t2/sysroot -stdlib=libc++ -fsyntax-only \
 // RUN:   %s -### 2>&1 | FileCheck --check-prefix=ANDROID23-DIR -DDIR=%/t2/bin %s
 
 // RUN: %clang -target aarch64-none-linux-android28 -ccc-install-dir %/t2/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --sysroot=%t2/sysroot -stdlib=libc++ -fsyntax-only \
 // RUN:   %s -### 2>&1 | FileCheck --check-prefix=ANDROID23-DIR -DDIR=%/t2/bin %s
 

--- a/clang/test/Driver/arm-toolchain.c
+++ b/clang/test/Driver/arm-toolchain.c
@@ -1,6 +1,7 @@
 // UNSUPPORTED: system-windows
 
 // RUN: %clang -### %s -fuse-ld=lld -B%S/Inputs/lld \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_arm_gcc_tree/armv6m-none-eabi 2>&1 \
@@ -19,6 +20,7 @@
 // LLD-ARM-BAREMETAL: "{{.*}}/Inputs/basic_arm_gcc_tree/lib/gcc/armv6m-none-eabi/8.2.1/crtend.o"
 
 // RUN: %clang -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_arm_gcc_tree/armv6m-none-eabi 2>&1 \
@@ -38,6 +40,7 @@
 // C-ARM-BAREMETAL: "{{.*}}/Inputs/basic_arm_gcc_tree/lib/gcc/armv6m-none-eabi/8.2.1/crtend.o"
 
 // RUN: %clang -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=  2>&1 \
@@ -55,6 +58,7 @@
 // C-ARM-BAREMETAL-NOSYSROOT: "{{.*}}/Inputs/basic_arm_gcc_tree/lib/gcc/armv6m-none-eabi/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi -stdlib=libstdc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_arm_gcc_tree/armv6m-none-eabi 2>&1 \
@@ -77,6 +81,7 @@
 
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi -stdlib=libstdc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=  2>&1 \
@@ -96,6 +101,7 @@
 // CXX-ARM-BAREMETAL-NOSYSROOT: "{{.*}}/Inputs/basic_arm_gcc_tree/lib/gcc/armv6m-none-eabi/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi -stdlib=libc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=%S/Inputs/basic_arm_gcc_tree/armv6m-none-eabi 2>&1 \
@@ -115,6 +121,7 @@
 // CXX-ARM-BAREMETAL-LIBCXX: "{{.*}}/Inputs/basic_arm_gcc_tree/lib/gcc/armv6m-none-eabi/8.2.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=armv6m-none-eabi -stdlib=libc++ --rtlib=libgcc --unwindlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_arm_gcc_tree \
 // RUN:   --sysroot=  2>&1 \

--- a/clang/test/Driver/avr-toolchain.c
+++ b/clang/test/Driver/avr-toolchain.c
@@ -1,7 +1,7 @@
 // UNSUPPORTED: system-windows
 // A basic clang -cc1 command-line.
 
-// RUN: %clang -### %s --target=avr --sysroot=%S/Inputs/basic_avr_tree -resource-dir=%S/Inputs/resource_dir 2>&1 | FileCheck --check-prefix=CHECK1 %s
+// RUN: %clang -### %s -no-canonical-prefixes --target=avr --sysroot=%S/Inputs/basic_avr_tree -resource-dir=%S/Inputs/resource_dir 2>&1 | FileCheck --check-prefix=CHECK1 %s
 // CHECK1: "-cc1" "-triple" "avr"
 // CHECK1-SAME: "-resource-dir" "[[RESOURCE:[^"]+]]"
 // CHECK1-SAME: "-isysroot" "[[SYSROOT:[^"]+/basic_avr_tree]]"
@@ -12,13 +12,13 @@
 // CHECK1-SAME: "-o" "a.out"
 // CHECK1-SAME: {{^}} "--gc-sections"
 
-// RUN: %clang -### %s --target=avr --sysroot=%S/Inputs/basic_avr_tree_2/opt/local -S 2>&1 | FileCheck --check-prefix=CHECK2 %s
+// RUN: %clang -### %s -no-canonical-prefixes --target=avr --sysroot=%S/Inputs/basic_avr_tree_2/opt/local -S 2>&1 | FileCheck --check-prefix=CHECK2 %s
 // CHECK2: "-cc1" "-triple" "avr"
 // CHECK2-SAME: "-isysroot" "[[SYSROOT:[^"]+/basic_avr_tree_2/opt/local]]"
 // CHECK2-SAME: "-internal-isystem"
 // CHECK2-SAME: {{^}} "[[SYSROOT]]/lib/gcc/avr/10.3.0/../../../../avr/include"
 
-// RUN: %clang -### %s --target=avr --sysroot=%S/Inputs/basic_avr_tree_2 -S 2>&1 | FileCheck --check-prefix=CHECK3 %s
+// RUN: %clang -### %s -no-canonical-prefixes --target=avr --sysroot=%S/Inputs/basic_avr_tree_2 -S 2>&1 | FileCheck --check-prefix=CHECK3 %s
 // CHECK3: "-cc1" "-triple" "avr"
 // CHECK3-SAME: "-isysroot" "[[SYSROOT:[^"]+/basic_avr_tree_2]]"
 // CHECK3-SAME: "-internal-isystem"
@@ -32,8 +32,8 @@
 // CHECK4-NOT: "-fno-use-init-array"
 // CHECK4-NOT: "-fno-use-cxa-atexit"
 
-// RUN: %clang -### %s --target=avr --sysroot=%S/Inputs/basic_avr_tree 2>&1 -nostdinc | FileCheck --check-prefix=NOSTDINC %s
-// RUN: %clang -### %s --target=avr --sysroot=%S/Inputs/basic_avr_tree 2>&1 -nostdlibinc | FileCheck --check-prefix=NOSTDINC %s
+// RUN: %clang -### %s -no-canonical-prefixes --target=avr --sysroot=%S/Inputs/basic_avr_tree 2>&1 -nostdinc | FileCheck --check-prefix=NOSTDINC %s
+// RUN: %clang -### %s -no-canonical-prefixes --target=avr --sysroot=%S/Inputs/basic_avr_tree 2>&1 -nostdlibinc | FileCheck --check-prefix=NOSTDINC %s
 // NOSTDINC-NOT: "-internal-isystem" {{".*avr/include"}}
 
 // RUN: %clang -### --target=avr --sysroot=%S/Inputs/basic_avr_tree -mmcu=atmega328 %s 2>&1 | FileCheck --check-prefix=NOWARN %s

--- a/clang/test/Driver/baremetal.cpp
+++ b/clang/test/Driver/baremetal.cpp
@@ -5,6 +5,7 @@
 // CHECK-STATIC-LIB: {{.*}}llvm-ar{{.*}}" "rcsD"
 
 // RUN: %clang %s -### --target=armv6m-none-eabi -o %t.out 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     -T semihosted.lds \
 // RUN:     -L some/directory/user/asked/for \
 // RUN:     --sysroot=%S/Inputs/baremetal_arm \
@@ -33,6 +34,7 @@
 // CHECK-V6M-LIBINC-NOT: "-internal-isystem"
 
 // RUN: %clang %s -### --target=armv6m-none-eabi -o %t.out 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     -ccc-install-dir %S/Inputs/basic_baremetal_tree/bin \
 // RUN:   | FileCheck --check-prefix=CHECK-V6M-TREE %s
 // CHECK-V6M-TREE:      InstalledDir: [[INSTALLED_DIR:.+]]

--- a/clang/test/Driver/cygwin.cpp
+++ b/clang/test/Driver/cygwin.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang -### %s --target=i686-pc-windows-cygnus --sysroot=%S/Inputs/basic_cygwin_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK %s
 // CHECK:      "-cc1"
@@ -31,6 +32,7 @@
 // CHECK-SHARED-SAME: "-shared"
 
 // RUN: %clang -### -o %t %s 2>&1 -no-integrated-as -fuse-ld=ld \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --gcc-toolchain=%S/Inputs/basic_cross_cygwin_tree/usr \
 // RUN:     --target=i686-pc-cygwin \
 // RUN:   | FileCheck --check-prefix=CHECK-CROSS %s
@@ -38,6 +40,7 @@
 // CHECK-CROSS: "{{.*}}/Inputs/basic_cross_cygwin_tree/usr/lib/gcc/i686-pc-msys/10/../../../../i686-pc-msys/bin{{(/|\\\\)}}as" "--32"
 
 // RUN: %clang -### %s --target=x86_64-pc-windows-cygnus --sysroot=%S/Inputs/basic_cygwin_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK-64 %s
 // CHECK-64:      "-cc1"

--- a/clang/test/Driver/darwin-header-search-libcxx-2.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx-2.cpp
@@ -50,7 +50,7 @@
 // RUN:   | FileCheck -DTOOLCHAIN=%t/install \
 // RUN:               -DSYSROOT=%S/Inputs/basic_darwin_sdk_usr_cxx_v1 \
 // RUN:               --check-prefix=CHECK-TOOLCHAIN-INCLUDE-CXX-V1 %s
-// CHECK-TOOLCHAIN-INCLUDE-CXX-V1: "-internal-isystem" "[[TOOLCHAIN]]/bin/../include/c++/v1"
+// CHECK-TOOLCHAIN-INCLUDE-CXX-V1: "-internal-isystem" "[[TOOLCHAIN]]/include/c++/v1"
 // CHECK-TOOLCHAIN-INCLUDE-CXX-V1-NOT: "-internal-isystem" "[[SYSROOT]]/usr/include/c++/v1"
 
 // Headers in (2) and nowhere else -> (2) is used
@@ -61,4 +61,4 @@
 // RUN:   | FileCheck -DTOOLCHAIN=%t/install \
 // RUN:               -DSYSROOT=%S/Inputs/basic_darwin_sdk_no_libcxx \
 // RUN:               --check-prefix=CHECK-TOOLCHAIN-NO-SYSROOT %s
-// CHECK-TOOLCHAIN-NO-SYSROOT: "-internal-isystem" "[[TOOLCHAIN]]/bin/../include/c++/v1"
+// CHECK-TOOLCHAIN-NO-SYSROOT: "-internal-isystem" "[[TOOLCHAIN]]/include/c++/v1"

--- a/clang/test/Driver/darwin-header-search-libcxx.cpp
+++ b/clang/test/Driver/darwin-header-search-libcxx.cpp
@@ -16,6 +16,7 @@
 // Check with only headers alongside the installation (those should be used).
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_darwin_toolchain/usr/bin \
@@ -27,6 +28,7 @@
 // CHECK-LIBCXX-TOOLCHAIN-1-NOT: "-internal-isystem" "/usr/include/c++/v1"
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_darwin_toolchain/usr/bin \
@@ -41,6 +43,7 @@
 // Check with only headers in the sysroot (those should be used).
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_darwin_toolchain_no_libcxx/usr/bin \
@@ -58,6 +61,7 @@
 // over --sysroot.
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_darwin_toolchain/usr/bin \
@@ -68,6 +72,7 @@
 // RUN:               --check-prefix=CHECK-LIBCXX-SYSROOT_AND_TOOLCHAIN-1 %s
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_darwin_toolchain/usr/bin \
@@ -78,6 +83,7 @@
 // RUN:               --check-prefix=CHECK-LIBCXX-SYSROOT_AND_TOOLCHAIN-1 %s
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-apple-darwin \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_darwin_toolchain/usr/bin \

--- a/clang/test/Driver/gcc-install-dir.cpp
+++ b/clang/test/Driver/gcc-install-dir.cpp
@@ -2,6 +2,7 @@
 
 /// Test native GCC installation on Arch Linux i686.
 // RUN: %clang -### %s --target=i686-linux-gnu --sysroot=%S/Inputs/archlinux_i686_tree -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform \
 // RUN:   --gcc-install-dir=%S/Inputs/archlinux_i686_tree/usr/lib/gcc/i686-pc-linux-gnu/11.1.0 2>&1 | FileCheck %s --check-prefix=ARCH_I686
 // ARCH_I686:      "-internal-isystem"
@@ -14,6 +15,7 @@
 
 /// Test native GCC installation on Debian amd64. --gcc-install-dir= may end with /.
 // RUN: %clangxx %s -### --target=x86_64-unknown-linux-gnu --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir --stdlib=platform --rtlib=platform --unwindlib=platform \
 // RUN:   --gcc-install-dir=%S/Inputs/debian_multiarch_tree/usr/lib/gcc/x86_64-linux-gnu/10/ 2>&1 | FileCheck %s --check-prefix=DEBIAN_X86_64
 // DEBIAN_X86_64:      "-internal-isystem"
@@ -28,6 +30,7 @@
 
 /// Test -m32.
 // RUN: %clangxx %s -### --target=x86_64-unknown-linux-gnu -m32 --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir --stdlib=platform --rtlib=platform --unwindlib=platform \
 // RUN:   --gcc-install-dir=%S/Inputs/debian_multiarch_tree/usr/lib/gcc/x86_64-linux-gnu/10/ 2>&1 | FileCheck %s --check-prefix=DEBIAN_X86_64_M32
 // DEBIAN_X86_64_M32:      "-internal-isystem"

--- a/clang/test/Driver/gcc-toolchain-rt-libs-multi.cpp
+++ b/clang/test/Driver/gcc-toolchain-rt-libs-multi.cpp
@@ -1,7 +1,7 @@
-// RUN: %clangxx %s -### -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X64-STDCPLUS
-// RUN: %clangxx %s -### -stdlib=libc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X64-LIBCPLUS
-// RUN: %clangxx %s -m32 -### -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X32-STDCPLUS
-// RUN: %clangxx %s -m32 -### -stdlib=libc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X32-LIBCPLUS
+// RUN: %clangxx %s -### -no-canonical-prefixes -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X64-STDCPLUS
+// RUN: %clangxx %s -### -no-canonical-prefixes -stdlib=libc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X64-LIBCPLUS
+// RUN: %clangxx %s -m32 -### -no-canonical-prefixes -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X32-STDCPLUS
+// RUN: %clangxx %s -m32 -### -no-canonical-prefixes -stdlib=libc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs_multilib --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=X32-LIBCPLUS
 
 int main() {}
 

--- a/clang/test/Driver/gcc-toolchain-rt-libs.cpp
+++ b/clang/test/Driver/gcc-toolchain-rt-libs.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx %s -### -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=STDCPLUS
-// RUN: %clangxx %s -### -stdlib=libc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=LIBCPLUS
+// RUN: %clangxx %s -### -no-canonical-prefixes -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=STDCPLUS
+// RUN: %clangxx %s -### -no-canonical-prefixes -stdlib=libc++ --gcc-toolchain=%S/Inputs/gcc_version_parsing_rt_libs --target=x86_64-redhat-linux 2>&1 | FileCheck %s -check-prefix=LIBCPLUS
 
 int main() {}
 

--- a/clang/test/Driver/gcc-toolchain.cpp
+++ b/clang/test/Driver/gcc-toolchain.cpp
@@ -3,6 +3,7 @@
 /// Without --rtlib=libgcc the driver may pick clang_rt.crtbegin.o if
 /// -DCLANG_DEFAULT_RTLIB=compiler-rt.
 // RUN: %clangxx %s -### --target=x86_64-linux-gnu --sysroot= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --gcc-toolchain=%S/Inputs/ubuntu_14.04_multiarch_tree/usr -stdlib=libstdc++ --rtlib=libgcc --unwindlib=libgcc -no-pie 2>&1 | \
 // RUN:   FileCheck %s
 //

--- a/clang/test/Driver/haiku.cpp
+++ b/clang/test/Driver/haiku.cpp
@@ -1,5 +1,6 @@
 // Check the C++ header path (libstdc++)
 // RUN: %clangxx --target=x86_64-unknown-haiku --stdlib=libstdc++ -### %s 2>&1 \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --sysroot=%S/Inputs/haiku_x86_64_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LIBSTDCXX-HEADER-PATH %s
 // CHECK-LIBSTDCXX-HEADER-PATH: "-internal-isystem" "[[SYSROOT:[^"]+]]/boot/system/develop/tools/lib/gcc/x86_64-unknown-haiku/13.2.0/../../../gcc/x86_64-unknown-haiku/13.2.0/include/c++/"

--- a/clang/test/Driver/hexagon-toolchain-elf.c
+++ b/clang/test/Driver/hexagon-toolchain-elf.c
@@ -3,10 +3,12 @@
 // -----------------------------------------------------------------------------
 
 // RUN: %clang -### --target=hexagon-unknown-elf \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK000 %s
 // CHECK000: "-cc1" {{.*}} "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin %s 2>&1 | FileCheck -check-prefix=CHECK001 %s
 // CHECK001: "-cc1" {{.*}} "-internal-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include/c++"
 // CHECK001:   "-internal-externc-isystem" "{{.*}}/Inputs/hexagon_tree/Tools/bin/../target/hexagon/include"
@@ -28,6 +30,7 @@
 // CHECK111-NOT: "-internal-externc-isystem"
 
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -nostdinc++ %s 2>&1 | FileCheck -check-prefix=CHECK112 %s
 // CHECK112: "-cc1"

--- a/clang/test/Driver/hexagon-toolchain-linux.c
+++ b/clang/test/Driver/hexagon-toolchain-linux.c
@@ -79,6 +79,7 @@
 // c++ when musl is selected
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### --target=hexagon-unknown-linux-musl \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   --sysroot=%S/Inputs/basic_linux_libcxx_tree \
 // RUN:   -mcpu=hexagonv60 %s 2>&1 | FileCheck -check-prefix=CHECK006 %s
@@ -87,6 +88,7 @@
 // c++ when musl is selected
 // -----------------------------------------------------------------------------
 // RUN: %clangxx -### --target=hexagon-unknown-elf \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -stdlib=libc++ \
 // RUN:   -mcpu=hexagonv60 %s 2>&1 | FileCheck -check-prefix=CHECK007 %s
@@ -95,6 +97,7 @@
 // internal-isystem for linux with and without musl
 // -----------------------------------------------------------------------------
 // RUN: %clang -### --target=hexagon-unknown-linux-musl \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -resource-dir=%S/Inputs/resource_dir %s 2>&1 | FileCheck -check-prefix=CHECK008 %s
 // CHECK008:   InstalledDir: [[INSTALLED_DIR:.+]]
@@ -103,6 +106,7 @@
 // CHECK008-SAME: {{^}} "-internal-externc-isystem" "[[INSTALLED_DIR]]/../target/hexagon/include"
 
 // RUN: %clang -### --target=hexagon-unknown-linux \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/hexagon_tree/Tools/bin \
 // RUN:   -resource-dir=%S/Inputs/resource_dir %s 2>&1 | FileCheck -check-prefix=CHECK009 %s
 // CHECK009:   InstalledDir: [[INSTALLED_DIR:.+]]

--- a/clang/test/Driver/hurd.cpp
+++ b/clang/test/Driver/hurd.cpp
@@ -1,6 +1,7 @@
 // UNSUPPORTED: system-windows
 
 // RUN: %clang -### %s --target=i686-pc-hurd-gnu --sysroot=%S/Inputs/basic_hurd_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK %s
 // CHECK:      "-cc1"
 // CHECK-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -28,6 +29,7 @@
 // CHECK-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=i686-pc-hurd-gnu --sysroot=%S/Inputs/basic_hurd_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform -static 2>&1 | FileCheck --check-prefix=CHECK-STATIC %s
 // CHECK-STATIC:      "-cc1"
 // CHECK-STATIC-SAME: "-static-define"
@@ -80,6 +82,7 @@
 // CHECK-CROSS: "-L{{.*}}/Inputs/basic_cross_hurd_tree/usr/lib/gcc/i686-gnu/10/../../../../i686-gnu/lib"
 
 // RUN: %clang -### %s --target=x86_64-pc-hurd-gnu --sysroot=%S/Inputs/basic_hurd_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK-64 %s
 // CHECK-64:      "-cc1"
 // CHECK-64-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -107,6 +110,7 @@
 // CHECK-64-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=x86_64-pc-hurd-gnu --sysroot=%S/Inputs/basic_hurd_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform -static 2>&1 | FileCheck --check-prefix=CHECK-64-STATIC %s
 // CHECK-64-STATIC:      "-cc1"
 // CHECK-64-STATIC-SAME: "-static-define"

--- a/clang/test/Driver/linux-cross.cpp
+++ b/clang/test/Driver/linux-cross.cpp
@@ -2,6 +2,7 @@
 
 /// Test native GCC installation on Arch Linux i686.
 // RUN: %clang -### %s --target=i686-linux-gnu --sysroot=%S/Inputs/archlinux_i686_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform 2>&1 | FileCheck %s --check-prefix=ARCH_I686
 // ARCH_I686:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -24,6 +25,7 @@
 
 /// Test native x86-64 in the tree.
 // RUN: %clang -### %s --target=x86_64-linux-gnu --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform 2>&1 | FileCheck %s --check-prefix=DEBIAN_X86_64
 // DEBIAN_X86_64:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -53,6 +55,7 @@
 
 /// Test -m32.
 // RUN: %clang -### %s --target=x86_64-linux-gnu -m32 --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform 2>&1 | FileCheck %s --check-prefix=DEBIAN_X86_64_M32
 // DEBIAN_X86_64_M32:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -77,6 +80,7 @@
 
 /// Test native GCC installation on Debian i386.
 // RUN: %clang -### %s --target=i686-linux-gnu --sysroot=%S/Inputs/debian_i386_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform 2>&1 | FileCheck %s --check-prefix=DEBIAN_I686
 // DEBIAN_I686:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -102,6 +106,7 @@
 
 /// Test -m64 on Debian i386.
 // RUN: %clang -### %s --target=i686-linux-gnu --sysroot=%S/Inputs/debian_i386_tree -m64 \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform 2>&1 | FileCheck %s --check-prefix=DEBIAN_I686_M64
 // DEBIAN_I686_M64:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -128,6 +133,7 @@
 
 /// Test a cross compiler.
 // RUN: %clang -### %s --target=aarch64-linux-gnu --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform --unwindlib=platform 2>&1 | FileCheck %s --check-prefix=DEBIAN_AARCH64
 // DEBIAN_AARCH64:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -154,6 +160,7 @@
 /// Test native x86-64 with -DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=on.
 /// FIXME -internal-isystem .*bin/../include/x86_64-linux-gnu/c++/v1 and -L[[PREFIX]]/bin/../lib/x86_64-linux-gnu are missing.
 // RUN: %clang -### %s --target=x86_64-linux-gnu --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/debian_per_target_tree/usr/lib/llvm-14/bin -resource-dir=%S/Inputs/debian_per_target_tree/usr/lib/llvm-14/lib/clang/14.0.0 \
 // RUN:   --stdlib=libc++ --rtlib=compiler-rt 2>&1 | FileCheck %s --check-prefix=DEBIAN_X86_64_PER_TARGET
 // DEBIAN_X86_64_PER_TARGET:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -181,6 +188,7 @@
 /// Test -m32.
 /// FIXME -internal-isystem .*bin/../include/i386-linux-gnu/c++/v1 and -L[[PREFIX]]/bin/../lib/i386-linux-gnu are missing.
 // RUN: %clang -### %s --target=x86_64-linux-gnu -m32 --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/debian_per_target_tree/usr/lib/llvm-14/bin -resource-dir=%S/Inputs/debian_per_target_tree/usr/lib/llvm-14/lib/clang/14.0.0 \
 // RUN:   --stdlib=libc++ --rtlib=compiler-rt 2>&1 | FileCheck %s --check-prefix=DEBIAN_X86_64_M32_PER_TARGET
 // DEBIAN_X86_64_M32_PER_TARGET:      "-resource-dir" "[[RESOURCE:[^"]+]]"
@@ -213,6 +221,7 @@
 
 /// -r suppresses -dynamic-linker, default -l, and crt*.o like -nostdlib.
 // RUN: %clang -### %s --target=x86_64-linux-gnu --sysroot=%S/Inputs/debian_multiarch_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin -resource-dir=%S/Inputs/resource_dir \
 // RUN:   --stdlib=platform --rtlib=platform -r 2>&1 | FileCheck %s --check-prefix=RELOCATABLE
 // RELOCATABLE-NOT:  "-dynamic-linker"

--- a/clang/test/Driver/linux-header-search.cpp
+++ b/clang/test/Driver/linux-header-search.cpp
@@ -4,6 +4,7 @@
 // Test a simulated installation of libc++ on Linux, both through sysroot and
 // the installation path of Clang.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
@@ -18,6 +19,7 @@
 
 // Test include paths when the sysroot path ends with `/`.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
@@ -31,6 +33,7 @@
 // CHECK-BASIC-LIBCXX-SYSROOT-SLASH-SAME: "-internal-isystem" "[[SYSROOT]]usr/local/include"
 
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/usr/bin \
@@ -44,6 +47,7 @@
 // CHECK-BASIC-LIBCXX-INSTALL: "-internal-isystem" "[[SYSROOT]]/usr/local/include"
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
@@ -56,6 +60,7 @@
 // CHECK-BASIC-LIBCXXV2-SYSROOT: "-internal-isystem" "[[SYSROOT]][[SEP]]usr[[SEP]]include[[SEP]]c++[[SEP]]v2"
 // CHECK-BASIC-LIBCXXV2-SYSROOT: "-internal-isystem" "[[SYSROOT]]/usr/local/include"
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxxv2_tree/usr/bin \
@@ -70,6 +75,7 @@
 
 // Test Linux with libstdc++ when the sysroot path ends with `/`.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libstdc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
@@ -82,6 +88,7 @@
 
 // Test Linux with both libc++ and libstdc++ installed.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
@@ -97,6 +104,7 @@
 // Test Gentoo's weirdness both before and after they changed it in their GCC
 // 4.6.4 release.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_4.6.2_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-6-2 %s
@@ -111,6 +119,7 @@
 // CHECK-GENTOO-4-6-2: "-internal-externc-isystem" "[[SYSROOT]]/include"
 // CHECK-GENTOO-4-6-2: "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_4.6.4_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-6-4 %s
@@ -125,6 +134,7 @@
 // CHECK-GENTOO-4-6-4: "-internal-externc-isystem" "[[SYSROOT]]/include"
 // CHECK-GENTOO-4-6-4: "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_4.9.3_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-9-3 %s
@@ -149,6 +159,7 @@
 //
 // Test that gcc-config support does not break multilib.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnux32 -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_multi_version_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-9-3-X32 %s
@@ -164,6 +175,7 @@
 // CHECK-GENTOO-4-9-3-X32: "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=i386-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_multi_version_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-9-3-32 %s
@@ -183,6 +195,7 @@
 // Then should pick the multilibs from version 4.9.x specified in
 // /etc/env.d/gcc/x86_64-pc-linux-gnu-4.9.3.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_4.9.x_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-9-X %s
@@ -199,6 +212,7 @@
 // CHECK-GENTOO-4-9-X: "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnux32 -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_4.9.x_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-9-X-X32 %s
@@ -214,6 +228,7 @@
 // CHECK-GENTOO-4-9-X-X32: "-internal-externc-isystem" "[[SYSROOT]]/usr/include"
 //
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=i386-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/gentoo_linux_gcc_4.9.x_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-GENTOO-4-9-X-32 %s
@@ -230,12 +245,14 @@
 //
 // Check header search on Debian loong64
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=loongarch64-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/debian_loong64_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LOONG64-GNU %s
 //
 // Check that "-gnuf64" is seen as "-gnu" for loong64.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=loongarch64-unknown-linux-gnuf64 -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/debian_loong64_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LOONG64-GNU %s
@@ -254,6 +271,7 @@
 //
 // Check header search on Debian 6 / MIPS64
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-unknown-linux-gnuabi64 -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/debian_6_mips64_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64-GNUABI %s
@@ -271,6 +289,7 @@
 //
 // Check header search on Debian 6 / MIPS64
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-unknown-linux-gnuabi64 -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/debian_6_mips64_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-MIPS64EL-GNUABI %s
@@ -289,6 +308,7 @@
 
 // Check header search on OpenEmbedded ARM.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=arm-oe-linux-gnueabi -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/openembedded_arm_linux_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-OE-ARM %s
@@ -300,6 +320,7 @@
 
 // Check header search on OpenEmbedded AArch64.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=aarch64-oe-linux -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/openembedded_aarch64_linux_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-OE-AARCH64 %s
@@ -311,6 +332,7 @@
 
 // Check header search with Cray's gcc package.
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu -stdlib=libstdc++ \
 // RUN:     --sysroot=%S/Inputs/cray_suse_gcc_tree \
 // RUN:     --gcc-toolchain="%S/Inputs/cray_suse_gcc_tree/opt/gcc/8.2.0/snos" \

--- a/clang/test/Driver/linux-ld.c
+++ b/clang/test/Driver/linux-ld.c
@@ -450,6 +450,7 @@
 // Test a simulated installation of libc++ on Linux, both through sysroot and
 // the installation path of Clang.
 // RUN: %clangxx -x c++ -### %s -no-pie 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_tree/usr/bin \
@@ -462,6 +463,7 @@
 // CHECK-BASIC-LIBCXX-SYSROOT: "-internal-isystem" "[[SYSROOT]]/usr/local/include"
 // CHECK-BASIC-LIBCXX-SYSROOT: "--sysroot=[[SYSROOT]]"
 // RUN: %clang -x c++ -### %s -no-pie 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/usr/bin \
@@ -477,6 +479,7 @@
 // Test that we can use -stdlib=libc++ in a build system even when it
 // occasionally links C code instead of C++ code.
 // RUN: %clang -x c -### %s -Werror -no-pie 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -ccc-install-dir %S/Inputs/basic_linux_libcxx_tree/usr/bin \

--- a/clang/test/Driver/linux-per-target-runtime-dir.c
+++ b/clang/test/Driver/linux-per-target-runtime-dir.c
@@ -1,4 +1,5 @@
 // RUN: %clangxx -x c++ %s -### -o %t.o 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=x86_64-unknown-linux-gnu \
 // RUN:     -stdlib=libc++ \
 // RUN:     -resource-dir=%S/Inputs/resource_dir_with_per_target_subdir \

--- a/clang/test/Driver/managarm.cpp
+++ b/clang/test/Driver/managarm.cpp
@@ -1,6 +1,7 @@
 // UNSUPPORTED: system-windows
 
 // RUN: %clang -### %s --target=x86_64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK-X86-64 %s
 // CHECK-X86-64:      "-cc1"
 // CHECK-X86-64-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -26,6 +27,7 @@
 // CHECK-X86-64-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=x86_64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=libc++ --rtlib=compiler-rt --unwindlib=libunwind 2>&1 | FileCheck --check-prefix=CHECK-X86-64-LIBS %s
 // CHECK-X86-64-LIBS:      "-cc1"
 // CHECK-X86-64-LIBS-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -49,6 +51,7 @@
 // CHECK-X86-64-LIBS-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=x86_64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform -static 2>&1 | FileCheck --check-prefix=CHECK-X86-64-STATIC %s
 // CHECK-X86-64-STATIC:      "-cc1"
 // CHECK-X86-64-STATIC-SAME: "-static-define"
@@ -89,6 +92,7 @@
 // CHECK-X86-64-SHARED-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=aarch64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK-AARCH64 %s
 // CHECK-AARCH64:      "-cc1"
 // CHECK-AARCH64-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -115,6 +119,7 @@
 // CHECK-AARCH64-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=aarch64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=libc++ --rtlib=compiler-rt --unwindlib=libunwind 2>&1 | FileCheck --check-prefix=CHECK-AARCH64-LIBS %s
 // CHECK-AARCH64-LIBS:      "-cc1"
 // CHECK-AARCH64-LIBS-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -139,6 +144,7 @@
 // CHECK-AARCH64-LIBS-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=aarch64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform -static 2>&1 | FileCheck --check-prefix=CHECK-AARCH64-STATIC %s
 // CHECK-AARCH64-STATIC:      "-cc1"
 // CHECK-AARCH64-STATIC-SAME: "-static-define"
@@ -181,6 +187,7 @@
 // CHECK-AARCH64-SHARED-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=riscv64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform 2>&1 | FileCheck --check-prefix=CHECK-RISCV64 %s
 // CHECK-RISCV64:      "-cc1"
 // CHECK-RISCV64-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -205,6 +212,7 @@
 // CHECK-RISCV64-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=riscv64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=libc++ --rtlib=compiler-rt --unwindlib=libunwind 2>&1 | FileCheck --check-prefix=CHECK-RISCV64-LIBS %s
 // CHECK-RISCV64-LIBS:      "-cc1"
 // CHECK-RISCV64-LIBS-SAME: "-isysroot" "[[SYSROOT:[^"]+]]"
@@ -227,6 +235,7 @@
 // CHECK-RISCV64-LIBS-SAME: {{^}} "-L[[SYSROOT]]/usr/lib"
 
 // RUN: %clang -### %s --target=riscv64-unknown-managarm-mlibc --sysroot=%S/Inputs/basic_managarm_tree \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --stdlib=platform -static 2>&1 | FileCheck --check-prefix=CHECK-RISCV64-STATIC %s
 // CHECK-RISCV64-STATIC:      "-cc1"
 // CHECK-RISCV64-STATIC-SAME: "-static-define"

--- a/clang/test/Driver/mingw-sysroot.cpp
+++ b/clang/test/Driver/mingw-sysroot.cpp
@@ -33,7 +33,7 @@
 // directory to the path - this would end up including /usr/include for
 // cross toolchains installed in /usr.
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s --implicit-check-not="\"{{.*}}/testroot-gcc{{/|\\\\}}include\""
+// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s --implicit-check-not="\"{{.*}}/testroot-gcc{{/|\\\\}}include\""
 // CHECK_TESTROOT_GCC: "-internal-isystem" "[[BASE:[^"]+]]/testroot-gcc{{/|\\\\}}lib{{/|\\\\}}gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}10.2-posix{{/|\\\\}}include{{/|\\\\}}c++"
 // CHECK_TESTROOT_GCC-SAME: {{^}} "-internal-isystem" "[[BASE]]/testroot-gcc{{/|\\\\}}lib{{/|\\\\}}gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}10.2-posix{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}x86_64-w64-mingw32"
 // CHECK_TESTROOT_GCC-SAME: {{^}} "-internal-isystem" "[[BASE]]/testroot-gcc{{/|\\\\}}lib{{/|\\\\}}gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}10.2-posix{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}backward"
@@ -45,7 +45,7 @@
 
 // If we pass --sysroot explicitly, then we do include <sysroot>/include
 // even when cross compiling.
-// RUN: %clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="%T/testroot-gcc" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC_EXPLICIT %s
+// RUN: %clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="%T/testroot-gcc" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC_EXPLICIT %s
 
 // CHECK_TESTROOT_GCC_EXPLICIT: "-internal-isystem" "{{[^"]+}}/testroot-gcc{{/|\\\\}}include"
 
@@ -55,7 +55,7 @@
 
 // RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-clang/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC2 %s
 // RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-clang/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s -no-canonical-prefixes 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG %s
-// CHECK_TESTROOT_GCC2: "{{[^"]+}}/testroot-gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}include"
+// CHECK_TESTROOT_GCC2: "{{[^"]+}}/mingw_ubuntu_posix_tree{{/|\\\\}}usr{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}include"
 // CHECK_TESTROOT_CLANG: "{{[^"]+}}/testroot-clang{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}include"
 
 
@@ -63,7 +63,7 @@
 // happens to be in the same directory as gcc, make sure we still can pick up
 // the libgcc directory:
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-gcc/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s
+// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-gcc/bin/x86_64-w64-mingw32-clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s
 
 
 // If we're executing clang from a directory with what looks like a mingw sysroot,

--- a/clang/test/Driver/mips-cs.cpp
+++ b/clang/test/Driver/mips-cs.cpp
@@ -2,6 +2,7 @@
 //
 // = Big-endian, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-32 %s
@@ -30,6 +31,7 @@
 //
 // = Big-endian, hard float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-UC-HF-32 %s
@@ -59,6 +61,7 @@
 //
 // = Big-endian, hard float, mips16
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -mips16 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-16 %s
@@ -88,6 +91,7 @@
 //
 // = Big-endian, hard float, mmicromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -mmicromips -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-MICRO %s
@@ -117,6 +121,7 @@
 //
 // = Big-endian, hard float, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-NAN %s
@@ -146,6 +151,7 @@
 //
 // = Big-endian, hard float, uclibc, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -muclibc -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-UC-HF-NAN %s
@@ -175,6 +181,7 @@
 //
 // = Big-endian, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-32 %s
@@ -204,6 +211,7 @@
 //
 // = Big-endian, soft float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -muclibc -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-UC-SF-32 %s
@@ -233,6 +241,7 @@
 //
 // = Big-endian, soft float, mips16
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -msoft-float -mips16 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-16 %s
@@ -262,6 +271,7 @@
 //
 // = Big-endian, soft float, micromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-linux-gnu -msoft-float -mmicromips -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-MICRO %s
@@ -291,6 +301,7 @@
 //
 // = Big-endian, hard float, 64-bit
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-linux-gnu -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64 %s
@@ -320,6 +331,7 @@
 //
 // = Big-endian, soft float, 64-bit
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-linux-gnu -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-64 %s
@@ -349,6 +361,7 @@
 //
 // = Little-endian, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-32 %s
@@ -378,6 +391,7 @@
 //
 // = Little-endian, hard float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mhard-float -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-UC-HF-32 %s
@@ -407,6 +421,7 @@
 //
 // = Little-endian, hard float, mips16
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mips16 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-16 %s
@@ -436,6 +451,7 @@
 //
 // = Little-endian, hard float, micromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mmicromips -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-MICRO %s
@@ -465,6 +481,7 @@
 //
 // = Little-endian, hard float, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-NAN %s
@@ -494,6 +511,7 @@
 //
 // = Little-endian, hard float, uclibc, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -muclibc -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-UC-HF-NAN %s
@@ -523,6 +541,7 @@
 //
 // = Little-endian, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mfloat-abi=soft -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-32 %s
@@ -552,6 +571,7 @@
 //
 // = Little-endian, soft float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mfloat-abi=soft -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-UC-SF-32 %s
@@ -581,6 +601,7 @@
 //
 // = Little-endian, soft float, mips16
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mips16 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-16 %s
@@ -610,6 +631,7 @@
 //
 // = Little-endian, soft float, micromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-linux-gnu -mmicromips -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-MICRO %s
@@ -639,6 +661,7 @@
 //
 // = Little-endian, hard float, 64-bit
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-linux-gnu -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-64 %s
@@ -668,6 +691,7 @@
 //
 // = Little-endian, soft float, 64-bit
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-linux-gnu -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_cs_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-64 %s

--- a/clang/test/Driver/mips-fsf.cpp
+++ b/clang/test/Driver/mips-fsf.cpp
@@ -2,6 +2,7 @@
 //
 // = Big-endian, mips32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-32 %s
@@ -29,6 +30,7 @@
 //
 // = Big-endian, mips32, hard float, fp64
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-32 %s
@@ -56,6 +58,7 @@
 //
 // = Big-endian, mips32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-32 %s
@@ -83,6 +86,7 @@
 //
 // = Big-endian, mips16 / mips32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mips16 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-16 %s
@@ -110,6 +114,7 @@
 //
 // = Big-endian, mips16 / mips32, hard float, fp64
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mips16 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-16 %s
@@ -137,6 +142,7 @@
 //
 // = Big-endian, mips16 / mips32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mips16 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-16 %s
@@ -164,6 +170,7 @@
 //
 // = Big-endian, mips32 / mips16, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mips16 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-16 %s
@@ -191,6 +198,7 @@
 //
 // = Big-endian, mips32 / mips16, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mips16 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-16 %s
@@ -218,6 +226,7 @@
 //
 // = Big-endian, mips32, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-32 %s
@@ -245,6 +254,7 @@
 //
 // = Big-endian, mips32, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-32 %s
@@ -272,6 +282,7 @@
 //
 // = Big-endian, mips32r2, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-32R2 %s
@@ -299,6 +310,7 @@
 //
 // = Big-endian, mips32r2, hard float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mhard-float -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-UC-HF-32R2 %s
@@ -326,6 +338,7 @@
 //
 // = Big-endian, mips32r2, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-32R2 %s
@@ -353,6 +366,7 @@
 //
 // = Big-endian, mips32r2, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-32R2 %s
@@ -380,6 +394,7 @@
 //
 // = Big-endian, mips32r2, soft float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -msoft-float -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-UC-SF-32R2 %s
@@ -407,6 +422,7 @@
 //
 // = Big-endian, mips32r2 / mips16, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mips16 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-16R2 %s
@@ -434,6 +450,7 @@
 //
 // = Big-endian, mips32r2 / mips16, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mips16 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-16R2 %s
@@ -461,6 +478,7 @@
 //
 // = Big-endian, mips32r2 / mips16, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mips16 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-16R2 %s
@@ -488,6 +506,7 @@
 //
 // = Big-endian, mips32r2 / mips16, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mips16 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-16R2 %s
@@ -515,6 +534,7 @@
 //
 // = Big-endian, mips32r2 / mips16, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mips16 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-16R2 %s
@@ -542,6 +562,7 @@
 //
 // = Big-endian, mips32r2, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-32R2 %s
@@ -569,6 +590,7 @@
 //
 // = Big-endian, mips32r2, nan2008, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mnan=2008 -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-UC-NAN-32R2 %s
@@ -596,6 +618,7 @@
 //
 // = Big-endian, mips32r2, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r2 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-32R2 %s
@@ -623,6 +646,7 @@
 //
 // = Big-endian, default (mips32r2), fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-32R2-DEF %s
@@ -650,6 +674,7 @@
 //
 // = Big-endian, micromips, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mmicromips -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-MM %s
@@ -677,6 +702,7 @@
 //
 // = Big-endian, micromips, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mmicromips -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-MM %s
@@ -704,6 +730,7 @@
 //
 // = Big-endian, micromips, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mmicromips -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-MM %s
@@ -731,6 +758,7 @@
 //
 // = Big-endian, micromips, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mmicromips -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-MM %s
@@ -758,6 +786,7 @@
 //
 // = Big-endian, micromips, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mmicromips -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-MM %s
@@ -785,6 +814,7 @@
 //
 // = Big-endian, mips64, ABI n32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=n32 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64-N32 %s
@@ -812,6 +842,7 @@
 //
 // = Big-endian, mips64, ABI n32, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=n32 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-64-N32 %s
@@ -839,6 +870,7 @@
 //
 // = Big-endian, mips64, ABI n32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=n32 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-64-N32 %s
@@ -866,6 +898,7 @@
 //
 // = Big-endian, mips64, ABI n32, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=n32 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-64-N32 %s
@@ -893,6 +926,7 @@
 //
 // = Big-endian, mips64, ABI n32, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=n32 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-64-N32 %s
@@ -920,6 +954,7 @@
 //
 // = Big-endian, mips64, ABI 64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64-64 %s
@@ -947,6 +982,7 @@
 //
 // = Big-endian, mips64, ABI 64, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=64 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-64-64 %s
@@ -974,6 +1010,7 @@
 //
 // = Big-endian, mips64, ABI 64, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=64 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-64-64 %s
@@ -1001,6 +1038,7 @@
 //
 // = Big-endian, mips64, ABI 64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-64-64 %s
@@ -1028,6 +1066,7 @@
 //
 // = Big-endian, mips64, ABI 64, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64 -mabi=64 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-64-64 %s
@@ -1055,6 +1094,7 @@
 //
 // = Big-endian, mips64r2, ABI n32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=n32 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64R2-N32 %s
@@ -1082,6 +1122,7 @@
 //
 // = Big-endian, mips64r2, ABI n32, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=n32 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-64R2-N32 %s
@@ -1109,6 +1150,7 @@
 //
 // = Big-endian, mips64r2, ABI n32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=n32 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-64R2-N32 %s
@@ -1136,6 +1178,7 @@
 //
 // = Big-endian, mips64r2, ABI n32, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=n32 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-64R2-N32 %s
@@ -1163,6 +1206,7 @@
 //
 // = Big-endian, mips64r2, ABI n32, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=n32 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-64R2-N32 %s
@@ -1190,6 +1234,7 @@
 //
 // = Big-endian, mips64r2, ABI 64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64R2-64 %s
@@ -1217,6 +1262,7 @@
 //
 // = Big-endian, mips64r2, ABI 64, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=64 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF64-64R2-64 %s
@@ -1244,6 +1290,7 @@
 //
 // = Big-endian, mips64r2, ABI 64, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=64 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-SF-64R2-64 %s
@@ -1271,6 +1318,7 @@
 //
 // = Big-endian, mips64r2, ABI 64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN-64R2-64 %s
@@ -1298,6 +1346,7 @@
 //
 // = Big-endian, mips64r2, ABI 64, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r2 -mabi=64 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-64R2-64 %s
@@ -1325,6 +1374,7 @@
 //
 // = Big-endian, default (mips64r2), ABI 64, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mabi=64 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-NAN64-64R2-64-DEF %s
@@ -1352,6 +1402,7 @@
 //
 // = Little-endian, mips32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-32 %s
@@ -1379,6 +1430,7 @@
 //
 // = Little-endian, mips32, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-32 %s
@@ -1406,6 +1458,7 @@
 //
 // = Little-endian, mips32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-32 %s
@@ -1433,6 +1486,7 @@
 //
 // = Little-endian, mips32 / mips16, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mips16 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-16 %s
@@ -1460,6 +1514,7 @@
 //
 // = Little-endian, mips32 / mips16, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mips16 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-16 %s
@@ -1487,6 +1542,7 @@
 //
 // = Little-endian, mips32 / mips16, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mips16 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-16 %s
@@ -1514,6 +1570,7 @@
 //
 // = Little-endian, mips32 / mips16, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mips16 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-16 %s
@@ -1541,6 +1598,7 @@
 //
 // = Little-endian, mips32 / mips16, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mips16 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-16 %s
@@ -1568,6 +1626,7 @@
 //
 // = Little-endian, mips32, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-32 %s
@@ -1595,6 +1654,7 @@
 //
 // = Little-endian, mips32, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-32 %s
@@ -1622,6 +1682,7 @@
 //
 // = Little-endian, mips32r2, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-32R2 %s
@@ -1649,6 +1710,7 @@
 //
 // = Little-endian, mips32r2, hard float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mhard-float -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-UC-HF-32R2 %s
@@ -1676,6 +1738,7 @@
 //
 // = Little-endian, mips32r2, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-32R2 %s
@@ -1703,6 +1766,7 @@
 //
 // = Little-endian, mips32r2, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-32R2 %s
@@ -1730,6 +1794,7 @@
 //
 // = Little-endian, mips32r2, soft float, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -msoft-float -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-UC-SF-32R2 %s
@@ -1757,6 +1822,7 @@
 //
 // = Little-endian, mips32r2 / mips16, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mips16 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-16R2 %s
@@ -1784,6 +1850,7 @@
 //
 // = Little-endian, mips32r2 / mips16, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mips16 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-16R2 %s
@@ -1811,6 +1878,7 @@
 //
 // = Little-endian, mips32r2 / mips16, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mips16 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-16R2 %s
@@ -1838,6 +1906,7 @@
 //
 // = Little-endian, mips32r2 / mips16, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mips16 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-16R2 %s
@@ -1865,6 +1934,7 @@
 //
 // = Little-endian, mips32r2 / mips16, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mips16 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-16R2 %s
@@ -1892,6 +1962,7 @@
 //
 // = Little-endian, mips32r2, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-32R2 %s
@@ -1919,6 +1990,7 @@
 //
 // = Little-endian, mips32r2, nan2008, uclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mnan=2008 -muclibc -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-UC-NAN-32R2 %s
@@ -1946,6 +2018,7 @@
 //
 // = Little-endian, mips32r2, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mips32r2 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-32R2 %s
@@ -1973,6 +2046,7 @@
 //
 // = Little-endian, default (mips32r2), fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-32R2-DEF %s
@@ -2000,6 +2074,7 @@
 //
 // = Little-endian, micromips, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mmicromips -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-MM %s
@@ -2027,6 +2102,7 @@
 //
 // = Little-endian, micromips, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mmicromips -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-MM %s
@@ -2054,6 +2130,7 @@
 //
 // = Little-endian, micromips, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mmicromips -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-MM %s
@@ -2081,6 +2158,7 @@
 //
 // = Little-endian, micromips, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mmicromips -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-MM %s
@@ -2108,6 +2186,7 @@
 //
 // = Little-endian, micromips, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mipsel-mti-linux-gnu -mmicromips -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-MM %s
@@ -2135,6 +2214,7 @@
 //
 // = Little-endian, mips64, ABI n32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=n32 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-64-N32 %s
@@ -2162,6 +2242,7 @@
 //
 // = Little-endian, mips64, ABI n32, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=n32 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-64-N32 %s
@@ -2189,6 +2270,7 @@
 //
 // = Little-endian, mips64, ABI n32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=n32 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-64-N32 %s
@@ -2216,6 +2298,7 @@
 //
 // = Little-endian, mips64, ABI n32, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=n32 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-64-N32 %s
@@ -2243,6 +2326,7 @@
 //
 // = Little-endian, mips64, ABI n32, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=n32 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-64-N32 %s
@@ -2270,6 +2354,7 @@
 //
 // = Little-endian, mips64, ABI 64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-64-64 %s
@@ -2297,6 +2382,7 @@
 //
 // = Little-endian, mips64, ABI 64, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=64 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-64-64 %s
@@ -2324,6 +2410,7 @@
 //
 // = Little-endian, mips64, ABI 64, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=64 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-64-64 %s
@@ -2351,6 +2438,7 @@
 //
 // = Little-endian, mips64, ABI 64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-64-64 %s
@@ -2378,6 +2466,7 @@
 //
 // = Little-endian, mips64, ABI 64, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64 -mabi=64 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-64-64 %s
@@ -2405,6 +2494,7 @@
 //
 // = Little-endian, mips64r2, ABI n32, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=n32 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-64R2-N32 %s
@@ -2432,6 +2522,7 @@
 //
 // = Little-endian, mips64r2, ABI n32, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=n32 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-64R2-N32 %s
@@ -2459,6 +2550,7 @@
 //
 // = Little-endian, mips64r2, ABI n32, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=n32 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-64R2-N32 %s
@@ -2486,6 +2578,7 @@
 //
 // = Little-endian, mips64r2, ABI n32, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=n32 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-64R2-N32 %s
@@ -2513,6 +2606,7 @@
 //
 // = Little-endian, mips64r2, ABI n32, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=n32 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-64R2-N32 %s
@@ -2540,6 +2634,7 @@
 //
 // = Little-endian, mips64r2, ABI 64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF-64R2-64 %s
@@ -2567,6 +2662,7 @@
 //
 // = Little-endian, mips64r2, ABI 64, fp64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=64 -mfp64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-HF64-64R2-64 %s
@@ -2594,6 +2690,7 @@
 //
 // = Little-endian, mips64r2, ABI 64, soft float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=64 -msoft-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-SF-64R2-64 %s
@@ -2621,6 +2718,7 @@
 //
 // = Little-endian, mips64r2, ABI 64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN-64R2-64 %s
@@ -2648,6 +2746,7 @@
 //
 // = Little-endian, mips64r2, ABI 64, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mips64r2 -mabi=64 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-64R2-64 %s
@@ -2675,6 +2774,7 @@
 //
 // = Little-endian, default (mips64r2), ABI 64, fp64, nan2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64el-mti-linux-gnu -mabi=64 -mfp64 -mnan=2008 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-EL-NAN64-64R2-64-DEF %s
@@ -2704,6 +2804,7 @@
 //
 // = Big-endian, mips32r3, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r3 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-32R3 %s
@@ -2731,6 +2832,7 @@
 //
 // = Big-endian, mips32r5, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-mti-linux-gnu -mips32r5 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-32R5 %s
@@ -2758,6 +2860,7 @@
 //
 // = Big-endian, mips64r3, ABI 64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r3 -mabi=64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64R3-64 %s
@@ -2785,6 +2888,7 @@
 //
 // = Big-endian, mips64r5, ABI 64, hard float
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-mti-linux-gnu -mips64r5 -mabi=64 -mhard-float -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_fsf_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-HF-64R5-64 %s

--- a/clang/test/Driver/mips-img-v2.cpp
+++ b/clang/test/Driver/mips-img-v2.cpp
@@ -2,6 +2,7 @@
 
 // -EB -mips32r6 -mhard-float -mabi=32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -30,6 +31,7 @@
 
 // -EB -mips64r6 -mhard-float -mabi=n32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -58,6 +60,7 @@
 
 // -EB -mips64r6 -mhard-float -mabi=64
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips64-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -86,6 +89,7 @@
 
 // -EL -mips32r6 -mhard-float -mabi=32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -114,6 +118,7 @@
 
 // -EL -mips64r6 -mhard-float -mabi=n32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -142,6 +147,7 @@
 
 // -EL -mips64r6 -mhard-float -mabi=64
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips64-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -170,6 +176,7 @@
 
 // -EB -mips32r6 -msoft-float
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -198,6 +205,7 @@
 
 // -EL -mips32r6 -msoft-float
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -226,6 +234,7 @@
 
 // -EB -mips32r6 -mhard-float -mmicromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -254,6 +263,7 @@
 
 // -EB -mips32r6 -msoft-float -mmicromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -282,6 +292,7 @@
 
 // -EL -mips32r6 -mhard-float -mmicromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \
@@ -310,6 +321,7 @@
 
 // -EL -mips32r6 -msoft-float -mmicromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-img-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_img_v2_tree \
 // RUN:        -stdlib=libstdc++ \

--- a/clang/test/Driver/mips-img.cpp
+++ b/clang/test/Driver/mips-img.cpp
@@ -2,6 +2,7 @@
 //
 // = Big-endian, mips32r6
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-img-linux-gnu -mips32r6 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_img_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-32R6 %s
@@ -29,6 +30,7 @@
 //
 // = Little-endian, mips32r6
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips-img-linux-gnu -mips32r6 -EL -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_img_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LE-32R6 %s
@@ -56,6 +58,7 @@
 //
 // = Big-endian, mips64r6, N32
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-img-linux-gnu -mips64r6 -mabi=n32 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_img_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-64R6-N32 %s
@@ -83,6 +86,7 @@
 //
 // = Little-endian, mips64r6, N32
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-img-linux-gnu -mips64r6 -EL -mabi=n32 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_img_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LE-64R6-N32 %s
@@ -110,6 +114,7 @@
 //
 // = Big-endian, mips64r6, N64
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-img-linux-gnu -mips64r6 -mabi=64 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_img_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-BE-64R6-N64 %s
@@ -137,6 +142,7 @@
 //
 // = Little-endian, mips64r6, N64
 // RUN: %clang -### %s 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=mips64-img-linux-gnu -mips64r6 -EL -mabi=64 -no-pie \
 // RUN:     -stdlib=libstdc++ --gcc-toolchain=%S/Inputs/mips_img_tree \
 // RUN:   | FileCheck --check-prefix=CHECK-LE-64R6-N64 %s

--- a/clang/test/Driver/mips-mti.cpp
+++ b/clang/test/Driver/mips-mti.cpp
@@ -2,6 +2,7 @@
 
 // -EB -mhard-float -mabi=32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -31,6 +32,7 @@
 
 // -EB -mhard-float -mabi=n32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -60,6 +62,7 @@
 
 // -EB -mhard-float -mabi=64
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips64-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -89,6 +92,7 @@
 
 // -EL -mhard-float -mabi=32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -118,6 +122,7 @@
 
 // -EL -mhard-float -mabi=n32
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -147,6 +152,7 @@
 
 // -EL -mhard-float -mabi=64
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips64-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -176,6 +182,7 @@
 
 // -EB -msoft-float
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -205,6 +212,7 @@
 
 // -EL -msoft-float
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -234,6 +242,7 @@
 
 // -EB -mhard-float -muclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -263,6 +272,7 @@
 
 // -EL -mhard-float -muclibc
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -292,6 +302,7 @@
 
 // -EB -mhard-float -mnan=2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -321,6 +332,7 @@
 
 // -EL -mhard-float -mnan=2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -350,6 +362,7 @@
 
 // -EB -mhard-float -muclibc -mnan=2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -379,6 +392,7 @@
 
 // -EL -mhard-float -muclibc -mnan=2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -408,6 +422,7 @@
 
 // -EL -msoft-float -mmicromips
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \
@@ -437,6 +452,7 @@
 
 // -EL -mhard-float -mmicromips -mnan=2008
 // RUN: %clang -### %s 2>&1 \
+// RUN:        -no-canonical-prefixes \
 // RUN:        --target=mips-mti-linux-gnu \
 // RUN:        --gcc-toolchain=%S/Inputs/mips_mti_tree \
 // RUN:        --sysroot="" \

--- a/clang/test/Driver/riscv32-toolchain.c
+++ b/clang/test/Driver/riscv32-toolchain.c
@@ -46,6 +46,7 @@
 // C-RV32-BAREMETAL-NOSYSROOT-ILP32: "{{.*}}/Inputs/basic_riscv32_tree/lib/gcc/riscv32-unknown-elf/8.0.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=riscv32-unknown-elf -stdlib=libstdc++ --rtlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv32_tree \
 // RUN:   --sysroot=%S/Inputs/basic_riscv32_tree/riscv32-unknown-elf 2>&1 \
@@ -62,6 +63,7 @@
 // CXX-RV32-BAREMETAL-ILP32: "{{.*}}/Inputs/basic_riscv32_tree/lib/gcc/riscv32-unknown-elf/8.0.1/crtend.o"
 
 // RUN: %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=riscv32-unknown-elf -stdlib=libstdc++ --rtlib=platform \
 // RUN:   --sysroot= \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv32_tree 2>&1 \
@@ -200,6 +202,7 @@
 // C-RV32-RTLIB-COMPILERRT-ILP32: "{{.*}}clang_rt.crtend.o"
 
 // RUN: %clang -### %s --target=riscv32 \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv32_tree --sysroot= \
 // RUN:   -resource-dir=%s/Inputs/resource_dir 2>&1 \
 // RUN:   | FileCheck -check-prefix=RESOURCE-INC %s
@@ -207,6 +210,7 @@
 // RESOURCE-INC: "-internal-isystem" "{{.*}}/basic_riscv32_tree{{.*}}riscv32-unknown-linux-gnu/include"
 
 // RUN: %clang -### %s --target=riscv32 \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv32_tree --sysroot= \
 // RUN:   -resource-dir=%s/Inputs/resource_dir -nobuiltininc 2>&1 \
 // RUN:   | FileCheck -check-prefix=NO-RESOURCE-INC %s

--- a/clang/test/Driver/riscv64-toolchain.c
+++ b/clang/test/Driver/riscv64-toolchain.c
@@ -46,6 +46,7 @@
 // C-RV64-BAREMETAL-NOSYSROOT-LP64: "{{.*}}/Inputs/basic_riscv64_tree/lib/gcc/riscv64-unknown-elf/8.0.1/crtend.o"
 
 // RUN: env "PATH=" %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=riscv64-unknown-elf -stdlib=libstdc++ --rtlib=platform \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv64_tree \
 // RUN:   --sysroot=%S/Inputs/basic_riscv64_tree/riscv64-unknown-elf 2>&1 \
@@ -62,6 +63,7 @@
 // CXX-RV64-BAREMETAL-LP64: "{{.*}}/Inputs/basic_riscv64_tree/lib/gcc/riscv64-unknown-elf/8.0.1/crtend.o"
 
 // RUN: env "PATH=" %clangxx -### %s -fuse-ld= \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --target=riscv64-unknown-elf -stdlib=libstdc++ --rtlib=platform \
 // RUN:   --sysroot= \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv64_tree 2>&1 \
@@ -156,6 +158,7 @@
 // C-RV64-RTLIB-COMPILERRT-LP64: "{{.*}}clang_rt.crtend.o"
 
 // RUN: %clang -### %s --target=riscv64 \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv64_tree --sysroot= \
 // RUN:   -resource-dir=%s/Inputs/resource_dir 2>&1 \
 // RUN:   | FileCheck -check-prefix=RESOURCE-INC %s
@@ -163,6 +166,7 @@
 // RESOURCE-INC: "-internal-isystem" "{{.*}}/basic_riscv64_tree/{{.*}}riscv64-unknown-linux-gnu/include"
 
 // RUN: %clang -### %s --target=riscv64 \
+// RUN:   -no-canonical-prefixes \
 // RUN:   --gcc-toolchain=%S/Inputs/basic_riscv64_tree --sysroot= \
 // RUN:   -resource-dir=%s/Inputs/resource_dir -nobuiltininc 2>&1 \
 // RUN:   | FileCheck -check-prefix=NO-RESOURCE-INC %s

--- a/clang/test/Driver/solaris-header-search.cpp
+++ b/clang/test/Driver/solaris-header-search.cpp
@@ -2,6 +2,7 @@
 //
 // Sparc, 32bit
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=sparc-sun-solaris2.11 --stdlib=platform \
 // RUN:     --sysroot=%S/Inputs/solaris_sparc_tree \
 // RUN:   | FileCheck --check-prefix=CHECK_SOLARIS_SPARC %s
@@ -12,6 +13,7 @@
 
 // Sparc, 64bit
 // RUN: %clang -m64 -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=sparc-sun-solaris2.11 --stdlib=platform \
 // RUN:     --sysroot=%S/Inputs/solaris_sparc_tree \
 // RUN:   | FileCheck --check-prefix=CHECK_SOLARIS_SPARC64 %s
@@ -22,6 +24,7 @@
 
 // Intel, 32bit
 // RUN: %clang -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=i386-pc-solaris2.11 --stdlib=platform \
 // RUN:     --sysroot=%S/Inputs/solaris_x86_tree \
 // RUN:   | FileCheck --check-prefix=CHECK_SOLARIS_X86 %s
@@ -32,6 +35,7 @@
 
 // Intel, 64bit
 // RUN: %clang -m64 -### %s -fsyntax-only 2>&1 \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=i386-pc-solaris2.11 --stdlib=platform \
 // RUN:     --sysroot=%S/Inputs/solaris_x86_tree \
 // RUN:   | FileCheck --check-prefix=CHECK_SOLARIS_X64 %s

--- a/clang/test/Driver/stdlibxx-isystem.cpp
+++ b/clang/test/Driver/stdlibxx-isystem.cpp
@@ -6,9 +6,11 @@
 // RUN: mkdir -p %t/bin
 // RUN: mkdir -p %t/include/c++/v1
 // RUN: %clang -target aarch64-linux-gnu -ccc-install-dir %/t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib=libc++ -fsyntax-only %s -### 2>&1 | \
 // RUN:   FileCheck -check-prefix=LIBCXX %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %/t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib=libc++ -fsyntax-only %s -### 2>&1 | \
 // RUN:   FileCheck -check-prefix=LIBCXX %s
 // LIBCXX: InstalledDir: [[INSTALLDIR:.+$]]
@@ -16,9 +18,11 @@
 
 // Passing -stdlib++-isystem should suppress the default search.
 // RUN: %clang -target aarch64-linux-gnu -ccc-install-dir %/t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -stdlib=libc++ \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=NODEFAULT %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %/t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -stdlib=libc++ \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=NODEFAULT %s
 // NODEFAULT: InstalledDir: [[INSTALLDIR:.+$]]
@@ -26,9 +30,11 @@
 
 // And we should add it as an -internal-isystem.
 // RUN: %clang -target aarch64-linux-gnu -ccc-install-dir %t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -stdlib=libc++ \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=INCPATH %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -stdlib=libc++ \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=INCPATH %s
 // INCPATH: "-internal-isystem" "/tmp/foo" "-internal-isystem" "/tmp/bar"
@@ -44,9 +50,11 @@
 
 // It should respect -nostdinc++.
 // RUN: %clang -target aarch64-linux-gnu -ccc-install-dir %t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -nostdinc++ \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=NOSTDINCXX %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -nostdinc++ \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=NOSTDINCXX %s
 // NOSTDINCXX-NOT: "-internal-isystem" "/tmp/foo" "-internal-isystem" "/tmp/bar"
@@ -54,9 +62,11 @@
 // It should take effect even if -nostdinc or -nostdlibinc are specified; only
 // -nostdinc++ should suppress it.
 // RUN: %clang -target aarch64-linux-gnu -ccc-install-dir %t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -nostdinc \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=NOSTDINC %s
 // RUN: %clang -target x86_64-apple-darwin -ccc-install-dir %t/bin \
+// RUN:   -no-canonical-prefixes \
 // RUN:   -stdlib++-isystem /tmp/foo -stdlib++-isystem /tmp/bar -nostdlibinc \
 // RUN:   -fsyntax-only %s -### 2>&1 | FileCheck -check-prefix=NOSTDINC %s
 // NOSTDINC: "-internal-isystem" "/tmp/foo" "-internal-isystem" "/tmp/bar"

--- a/clang/test/Driver/ve-toolchain.cpp
+++ b/clang/test/Driver/ve-toolchain.cpp
@@ -12,6 +12,7 @@
 /// Checking include-path
 
 // RUN: %clangxx -### --target=ve-unknown-linux-gnu \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --sysroot %S/Inputs/basic_ve_tree %s -fuse-ld=ld \
 // RUN:     -ccc-install-dir %S/Inputs/basic_ve_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/basic_ve_tree/resource_dir \
@@ -28,6 +29,7 @@
 // DEFINC-SAME: "-rpath" "[[SYSROOT]]/bin/../lib/ve-unknown-linux-gnu"
 
 // RUN: %clangxx -### --target=ve-unknown-linux-gnu \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --sysroot %S/Inputs/basic_ve_tree %s \
 // RUN:     -ccc-install-dir %S/Inputs/basic_ve_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/basic_ve_tree/resource_dir \
@@ -41,6 +43,7 @@
 // NOSTDLIBINC-NOT: "-internal-isystem" "[[SYSROOT]]/opt/nec/ve/include"
 
 // RUN: %clangxx -### --target=ve-unknown-linux-gnu \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --sysroot %S/Inputs/basic_ve_tree %s \
 // RUN:     -ccc-install-dir %S/Inputs/basic_ve_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/basic_ve_tree/resource_dir \
@@ -55,6 +58,7 @@
 // NOBUILTININC-SAME: "-internal-isystem" "[[SYSROOT]]/opt/nec/ve/include"
 
 // RUN: %clangxx -### --target=ve-unknown-linux-gnu \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --sysroot %S/Inputs/basic_ve_tree %s \
 // RUN:     -ccc-install-dir %S/Inputs/basic_ve_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/basic_ve_tree/resource_dir \
@@ -69,6 +73,7 @@
 // NOSTDINC-NOT: "-internal-isystem" "[[SYSROOT]]/opt/nec/ve/include"
 
 // RUN: %clangxx -### --target=ve-unknown-linux-gnu \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --sysroot %S/Inputs/basic_ve_tree %s \
 // RUN:     -ccc-install-dir %S/Inputs/basic_ve_tree/bin \
 // RUN:     -resource-dir=%S/Inputs/basic_ve_tree/resource_dir \
@@ -86,6 +91,7 @@
 /// Checking environment variable NCC_CPLUS_INCLUDE_PATH
 
 // RUN: env NCC_CPLUS_INCLUDE_PATH=/test/test %clangxx -### \
+// RUN:     -no-canonical-prefixes \
 // RUN:     --target=ve-unknown-linux-gnu %s \
 // RUN:     --sysroot %S/Inputs/basic_ve_tree \
 // RUN:     -resource-dir=%S/Inputs/basic_ve_tree/resource_dir \


### PR DESCRIPTION
This is another attempt at implementing #143520, but with a different strategy this time: Instead of simplifying paths that contain `..` when we print them, we now canonicalise any include directories added via `addSystemInclude()` and friends (i.e. all the `-internal-` options such as `-internal-isystem`) in the driver. If the canonical path ends up being shorter, we forward it to the frontend instead of forwarding the original path.

The motivation for this (as well as the original patch) is that it can significantly shorten file paths to standard library headers, e.g. on my system, `<ranges>` is currently printed as
```console
/usr/lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/ranges
```
but with this change, we instead print
```console
/usr/include/c++/15/ranges
```

Additionally, since there was a request to allow disabling this functionality, passing `-no-canonical-prefixes` now also disables this canonicalisation. This also greatly simplified fixing all of the tests: most of the changes are just adding `-no-canonical-prefixes` to a few hundred RUN lines.