### PR TITLE
[DWARFCFIChecker] Use llvm::unique (NFC)

### DIFF
--- a/llvm/lib/DWARFCFIChecker/Registers.h
+++ b/llvm/lib/DWARFCFIChecker/Registers.h
@@ -38,8 +38,7 @@ inline SmallVector<MCPhysReg> getSuperRegs(const MCRegisterInfo *MCRI) {
     }
 
   sort(SuperRegs.begin(), SuperRegs.end());
-  SuperRegs.resize(std::distance(
-      SuperRegs.begin(), std::unique(SuperRegs.begin(), SuperRegs.end())));
+  SuperRegs.erase(llvm::unique(SuperRegs), SuperRegs.end());
   return SuperRegs;
 }
 


### PR DESCRIPTION
While I am at it, this patch replaces resize with erase, which is a
lot shorter and idiomatic.
