### PR TITLE
llvm-shlib: Fix mingw dll exports

### DIFF
--- a/llvm/tools/llvm-shlib/CMakeLists.txt
+++ b/llvm/tools/llvm-shlib/CMakeLists.txt
@@ -41,6 +41,15 @@ if(LLVM_BUILD_LLVM_DYLIB)
     llvm_install_library_symlink(LLVM-${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX} $<TARGET_FILE_NAME:LLVM> SHARED FULL_DEST COMPONENT LLVM)
   endif()
 
+  if (MINGW OR CYGWIN)
+    # The LLVM DLL is supposed to export all symbols (except for ones
+    # that are explicitly hidden). Normally, this is what happens anyway, but
+    # if there are symbols that are marked explicitly as dllexport, we'd only
+    # export them and nothing else. Therefore, add --export-all-symbols to
+    # make sure we export all symbols despite potential dllexports.
+    target_link_options(LLVM PRIVATE LINKER:--export-all-symbols)
+  endif()
+
   list(REMOVE_DUPLICATES LIB_NAMES)
   if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     set(LIB_NAMES -Wl,-all_load ${LIB_NAMES})


### PR DESCRIPTION
In c87d198cd964f37343083848f8fdd58bb0b00156, the `__jit_debug_*` symbols gained explicit dllexport annotations. Unfortunately, mingw's linkers have a quirk where the presence of any dllexport symbols at all will switch off the `-export-all-symbols` flag, so without a full conversion to dllexport annotations (#109483), the mingw LLVM dll build is broken in LLVM 20+. Fix this by adding the flag explicitly as was done for clang-shlib earlier in https://reviews.llvm.org/D151620.

cc @fsfod