### PR TITLE
[clang] Reduce the small vector size for DeclTypeInfo.

### DIFF
--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1918,7 +1918,7 @@ private:
   /// parsed.  This is pushed from the identifier out, which means that element
   /// #0 will be the most closely bound to the identifier, and
   /// DeclTypeInfo.back() will be the least closely bound.
-  SmallVector<DeclaratorChunk, 8> DeclTypeInfo;
+  SmallVector<DeclaratorChunk, 4> DeclTypeInfo;
 
   /// InvalidType - Set by Sema::GetTypeForDeclarator().
   LLVM_PREFERRED_TYPE(bool)


### PR DESCRIPTION
The `Declarator` class is large (4584 bytes) and used as a stack-local variable during parsing.

This patch reduces the default size of its `DeclTypeInfo` member, reducing the overall size down to 3880 bytes. This allows clang handle more deeply nested expressions without exhausting the stack.

Combined with #148726, the nesting threshold for such expressions increases to `~1100`.

No performance impact being [observed](https://llvm-compile-time-tracker.com/compare.php?from=d4f5ed6a23464cbe831820cb695aa1d39b11e4aa&to=66ba54b8a295cc2759387ef2a4a162de2ad4946e&stat=instructions:u).