### PR TITLE
[DAG] canCreateUndefOrPoison - add handling for ISD::ABS nodes

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5550,6 +5550,7 @@ bool SelectionDAG::canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
   case ISD::UMAX:
   case ISD::AND:
   case ISD::XOR:
+  case ISD::ABS:
   case ISD::ROTL:
   case ISD::ROTR:
   case ISD::FSHL:

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5572,7 +5572,7 @@ bool SelectionDAG::canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
     return false;
 
   case ISD::ABS:
-    // ISD::ABD defines abs(INT_MIN) -> INT_MIN and never generates poison.
+    // ISD::ABS defines abs(INT_MIN) -> INT_MIN and never generates poison.
     // Different to Intrinsic::abs.
     return false;
 

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -5550,7 +5550,6 @@ bool SelectionDAG::canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
   case ISD::UMAX:
   case ISD::AND:
   case ISD::XOR:
-  case ISD::ABS:
   case ISD::ROTL:
   case ISD::ROTR:
   case ISD::FSHL:
@@ -5570,6 +5569,11 @@ bool SelectionDAG::canCreateUndefOrPoison(SDValue Op, const APInt &DemandedElts,
   case ISD::BUILD_VECTOR:
   case ISD::BUILD_PAIR:
   case ISD::SPLAT_VECTOR:
+    return false;
+
+  case ISD::ABS:
+    // ISD::ABD defines abs(INT_MIN) -> INT_MIN and never generates poison.
+    // Different to Intrinsic::abs.
     return false;
 
   case ISD::ADDC:

--- a/llvm/test/CodeGen/X86/freeze-unary.ll
+++ b/llvm/test/CodeGen/X86/freeze-unary.ll
@@ -73,10 +73,7 @@ define <2 x i64> @freeze_zext_vec(<2 x i16> %a0) nounwind {
 define i32 @freeze_abs(i32 %a0) nounwind {
 ; X86-LABEL: freeze_abs:
 ; X86:       # %bb.0:
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    movl %eax, %ecx
-; X86-NEXT:    negl %ecx
-; X86-NEXT:    cmovsl %eax, %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    negl %eax
 ; X86-NEXT:    cmovsl %ecx, %eax
@@ -84,12 +81,9 @@ define i32 @freeze_abs(i32 %a0) nounwind {
 ;
 ; X64-LABEL: freeze_abs:
 ; X64:       # %bb.0:
-; X64-NEXT:    movl %edi, %ecx
-; X64-NEXT:    negl %ecx
-; X64-NEXT:    cmovsl %edi, %ecx
-; X64-NEXT:    movl %ecx, %eax
+; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    negl %eax
-; X64-NEXT:    cmovsl %ecx, %eax
+; X64-NEXT:    cmovsl %edi, %eax
 ; X64-NEXT:    retq
   %x = call i32 @llvm.abs.i32(i32 %a0, i1 0)
   %f = freeze i32 %x
@@ -104,15 +98,10 @@ define <4 x i32> @freeze_abs_vec(<4 x i32> %a0) nounwind {
 ; X86-NEXT:    psrad $31, %xmm1
 ; X86-NEXT:    pxor %xmm1, %xmm0
 ; X86-NEXT:    psubd %xmm1, %xmm0
-; X86-NEXT:    movdqa %xmm0, %xmm1
-; X86-NEXT:    psrad $31, %xmm1
-; X86-NEXT:    pxor %xmm1, %xmm0
-; X86-NEXT:    psubd %xmm1, %xmm0
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: freeze_abs_vec:
 ; X64:       # %bb.0:
-; X64-NEXT:    pabsd %xmm0, %xmm0
 ; X64-NEXT:    pabsd %xmm0, %xmm0
 ; X64-NEXT:    retq
   %x = call <4 x i32> @llvm.abs.v4i32(<4 x i32> %a0, i1 0)
@@ -124,10 +113,7 @@ define <4 x i32> @freeze_abs_vec(<4 x i32> %a0) nounwind {
 define i32 @freeze_abs_undef(i32 %a0) nounwind {
 ; X86-LABEL: freeze_abs_undef:
 ; X86:       # %bb.0:
-; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    movl %eax, %ecx
-; X86-NEXT:    negl %ecx
-; X86-NEXT:    cmovsl %eax, %ecx
+; X86-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-NEXT:    movl %ecx, %eax
 ; X86-NEXT:    negl %eax
 ; X86-NEXT:    cmovsl %ecx, %eax
@@ -135,12 +121,9 @@ define i32 @freeze_abs_undef(i32 %a0) nounwind {
 ;
 ; X64-LABEL: freeze_abs_undef:
 ; X64:       # %bb.0:
-; X64-NEXT:    movl %edi, %ecx
-; X64-NEXT:    negl %ecx
-; X64-NEXT:    cmovsl %edi, %ecx
-; X64-NEXT:    movl %ecx, %eax
+; X64-NEXT:    movl %edi, %eax
 ; X64-NEXT:    negl %eax
-; X64-NEXT:    cmovsl %ecx, %eax
+; X64-NEXT:    cmovsl %edi, %eax
 ; X64-NEXT:    retq
   %x = call i32 @llvm.abs.i32(i32 %a0, i1 -1)
   %f = freeze i32 %x
@@ -155,15 +138,10 @@ define <4 x i32> @freeze_abs_undef_vec(<4 x i32> %a0) nounwind {
 ; X86-NEXT:    psrad $31, %xmm1
 ; X86-NEXT:    pxor %xmm1, %xmm0
 ; X86-NEXT:    psubd %xmm1, %xmm0
-; X86-NEXT:    movdqa %xmm0, %xmm1
-; X86-NEXT:    psrad $31, %xmm1
-; X86-NEXT:    pxor %xmm1, %xmm0
-; X86-NEXT:    psubd %xmm1, %xmm0
 ; X86-NEXT:    retl
 ;
 ; X64-LABEL: freeze_abs_undef_vec:
 ; X64:       # %bb.0:
-; X64-NEXT:    pabsd %xmm0, %xmm0
 ; X64-NEXT:    pabsd %xmm0, %xmm0
 ; X64-NEXT:    retq
   %x = call <4 x i32> @llvm.abs.v4i32(<4 x i32> %a0, i1 -1)


### PR DESCRIPTION
Unlike the abs intrinsic, the ISD::ABS node defines ABS(INT_MIN) -> INT_MIN, so no undef/poison is created by the node itself