### PR TITLE
[Clang] Fix a crash when parsing an invalid `decltype`

### DIFF
--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1132,14 +1132,14 @@ void Parser::AnnotateExistingDecltypeSpecifier(const DeclSpec &DS,
                                                SourceLocation EndLoc) {
   // make sure we have a token we can turn into an annotation token
   if (PP.isBacktrackEnabled()) {
-    PP.RevertCachedTokens(1);
-    if (DS.getTypeSpecType() == TST_error) {
+    if (DS.getTypeSpecType() == TST_error)
       // We encountered an error in parsing 'decltype(...)' so lets annotate all
       // the tokens in the backtracking cache - that we likely had to skip over
       // to get to a token that allows us to resume parsing, such as a
       // semi-colon.
       EndLoc = PP.getLastCachedTokenLocation();
-    }
+    else
+      PP.RevertCachedTokens(1);
   } else
     PP.EnterToken(Tok, /*IsReinject*/ true);
 

--- a/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/clang/lib/Parse/ParseDeclCXX.cpp
@@ -1132,14 +1132,7 @@ void Parser::AnnotateExistingDecltypeSpecifier(const DeclSpec &DS,
                                                SourceLocation EndLoc) {
   // make sure we have a token we can turn into an annotation token
   if (PP.isBacktrackEnabled()) {
-    if (DS.getTypeSpecType() == TST_error)
-      // We encountered an error in parsing 'decltype(...)' so lets annotate all
-      // the tokens in the backtracking cache - that we likely had to skip over
-      // to get to a token that allows us to resume parsing, such as a
-      // semi-colon.
-      EndLoc = PP.getLastCachedTokenLocation();
-    else
-      PP.RevertCachedTokens(1);
+    PP.RevertCachedTokens(1);
   } else
     PP.EnterToken(Tok, /*IsReinject*/ true);
 

--- a/clang/test/Parser/gh114815.cpp
+++ b/clang/test/Parser/gh114815.cpp
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -verify %s -std=c++11 -fsyntax-only
+
+#define ID(X) X
+extern int ID(decltype);
+// expected-error@-1 {{expected '(' after 'decltype'}} \
+// expected-error@-1 {{expected unqualified-id}}


### PR DESCRIPTION
We would try to exact an annotated token before checking if it was valid, leading to a crash when `decltype` was the only token that was parsed (which can happen in the absense of opening paren)

Fixes #114815