### PR TITLE
TargetLowering: Replace android triple check with libcall check

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -483,6 +483,9 @@ def STACK_SMASH_HANDLER : RuntimeLibcall;
 // Safe stack
 def SAFESTACK_POINTER_ADDRESS : RuntimeLibcall;
 
+// Really a global variable, not a function
+def SAFESTACK_UNSAFE_STACK_PTR : RuntimeLibcall;
+
 def STACK_PROBE : RuntimeLibcall;
 def SECURITY_CHECK_COOKIE : RuntimeLibcall;
 
@@ -1141,6 +1144,7 @@ foreach lc = LibCalls__atomic in {
 
 // Safe stack.
 def __safestack_pointer_address : RuntimeLibcallImpl<SAFESTACK_POINTER_ADDRESS>;
+def __safestack_unsafe_stack_ptr : RuntimeLibcallImpl<SAFESTACK_UNSAFE_STACK_PTR>;
 
 // Deoptimization
 def __llvm_deoptimize : RuntimeLibcallImpl<DEOPTIMIZE>;
@@ -2057,6 +2061,11 @@ defvar DefaultStackProtector = (add has__stack_chk_fail, has__stack_chk_guard,
 defvar LibcSafestackPointerAddress =
     LibcallImpls<(add __safestack_pointer_address), isAndroid>;
 
+// compiler-rt sources suggest this is only available if
+// (TT.isOSLinux() || TT.isOSFreeBSD() || TT.isOSNetBSD() ||
+// TT.isOSSolaris()), but tests exist for other os targets.
+defvar DefaultSafeStackGlobals = (add __safestack_unsafe_stack_ptr);
+
 //===----------------------------------------------------------------------===//
 // Objective-C Runtime Libcalls
 //===----------------------------------------------------------------------===//
@@ -2654,7 +2663,8 @@ def ARMSystemLibrary
            LibcallImpls<(add __divmodsi4, __udivmodsi4),
                         RuntimeLibcallPredicate<[{TT.isOSBinFormatMachO() &&
                                                   (!TT.isiOS() || !TT.isOSVersionLT(5, 0))}]>>,
-           DefaultStackProtector)> {
+           DefaultStackProtector,
+           DefaultSafeStackGlobals)> {
   let DefaultLibcallCallingConv = LibcallCallingConv<[{
      TT.isOSDarwin() ? CallingConv::C :
         (FloatABI == FloatABI::Hard ? CallingConv::ARM_AAPCS_VFP
@@ -3201,7 +3211,8 @@ def RISCVSystemLibrary
            exp10f, exp10, exp10l_f128,
            __riscv_flush_icache,
            LibcallImpls<(add Int128RTLibcalls), isRISCV64>,
-           DefaultStackProtector)>;
+           DefaultStackProtector,
+           DefaultSafeStackGlobals)>;
 
 //===----------------------------------------------------------------------===//
 // SPARC Runtime Libcalls
@@ -3356,6 +3367,7 @@ defvar X86CommonLibcalls =
        // hack for one test relying on it.
        __powitf2_f128,
        DefaultStackProtector,
+       DefaultSafeStackGlobals,
        LibcallImpls<(add MemChkLibcalls), isNotPS>,
        LibcallImpls<(add ___chkstk_ms), isCygwinMinGW64>,
        LibcallImpls<(add __chkstk), isWin64NotCygMing>,
@@ -3541,7 +3553,7 @@ def LegacyDefaultSystemLibrary
          exp10f, exp10, exp10l_f128,
          __powisf2, __powidf2, __powitf2_f128,
          LibcallImpls<(add Int128RTLibcalls), isArch64Bit>,
-         DefaultStackProtector
+         DefaultStackProtector, DefaultSafeStackGlobals
 )>;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/include/llvm/IR/RuntimeLibcalls.td
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.td
@@ -27,6 +27,7 @@ def isPS : RuntimeLibcallPredicate<"TT.isPS()">;
 def isMacOSX : RuntimeLibcallPredicate<[{TT.isMacOSX()}]>;
 def isNotOSWindowsOrIsCygwinMinGW
   : RuntimeLibcallPredicate<"!TT.isOSWindows() || TT.isOSCygMing()">;
+
 def isWindowsMSVCEnvironment : RuntimeLibcallPredicate<
   [{TT.isWindowsMSVCEnvironment()}]>;
 
@@ -47,6 +48,8 @@ def hasStackChkFail : RuntimeLibcallPredicate<
 
 def isWindowsMSVCOrItaniumEnvironment : RuntimeLibcallPredicate<
   [{TT.isWindowsMSVCEnvironment() || TT.isWindowsItaniumEnvironment()}]>;
+
+def isAndroid : RuntimeLibcallPredicate<"TT.isAndroid()">;
 
 def isGNUEnvironment : RuntimeLibcallPredicate<"TT.isGNUEnvironment()">;
 def darwinHasSinCosStret : RuntimeLibcallPredicate<"darwinHasSinCosStret(TT)">;
@@ -2051,6 +2054,9 @@ defvar has___guard_local = LibcallImpls<(add __guard_local), isOSOpenBSD>;
 defvar DefaultStackProtector = (add has__stack_chk_fail, has__stack_chk_guard,
     has__stack_smash_handler, has___guard_local);
 
+defvar LibcSafestackPointerAddress =
+    LibcallImpls<(add __safestack_pointer_address), isAndroid>;
+
 //===----------------------------------------------------------------------===//
 // Objective-C Runtime Libcalls
 //===----------------------------------------------------------------------===//
@@ -2161,7 +2167,8 @@ def AArch64SystemLibrary : SystemRuntimeLibrary<
        LibcallImpls<(add __chkstk), isOSWindows>,
        SMEABI_LibCalls_PreserveMost_From_X0,
        SMEABI_LibCalls_PreserveMost_From_X1,
-       SMEABI_LibCalls_PreserveMost_From_X2)
+       SMEABI_LibCalls_PreserveMost_From_X2,
+       LibcSafestackPointerAddress)
 >;
 
 // Prepend a # to every name
@@ -2629,6 +2636,7 @@ def ARMSystemLibrary
            DarwinSinCosStret, DarwinExp10, DarwinMemsetPattern,
            LibmHasSinCosF32, LibmHasSinCosF64, LibmHasSinCosF128,
            DefaultLibmExp10,
+           LibcSafestackPointerAddress,
 
            AEABICalls,
            AEABI45MemCalls,
@@ -3352,7 +3360,8 @@ defvar X86CommonLibcalls =
        LibcallImpls<(add ___chkstk_ms), isCygwinMinGW64>,
        LibcallImpls<(add __chkstk), isWin64NotCygMing>,
        LibcallImpls<(add _alloca), isCygwinMinGW32>,
-       LibcallImpls<(add _chkstk), isWin32NotCygMing>
+       LibcallImpls<(add _chkstk), isWin32NotCygMing>,
+       LibcSafestackPointerAddress
 );
 
 defvar Windows32DivRemMulCalls =

--- a/llvm/lib/CodeGen/SafeStack.cpp
+++ b/llvm/lib/CodeGen/SafeStack.cpp
@@ -786,23 +786,22 @@ bool SafeStack::run() {
     IRB.SetCurrentDebugLocation(
         DILocation::get(SP->getContext(), SP->getScopeLine(), 0, SP));
   if (SafeStackUsePointerAddress) {
-    RTLIB::LibcallImpl SafestackPointerAddressImpl =
-        Libcalls.getLibcallImpl(RTLIB::SAFESTACK_POINTER_ADDRESS);
-    if (SafestackPointerAddressImpl == RTLIB::Unsupported) {
-      F.getContext().emitError(
-          "no libcall available for safestack pointer address");
-      return false;
-    }
-
+    // FIXME: A more correct implementation of SafeStackUsePointerAddress would
+    // change the libcall availability in RuntimeLibcallsInfo
     StringRef SafestackPointerAddressName =
         RTLIB::RuntimeLibcallsInfo::getLibcallImplName(
-            SafestackPointerAddressImpl);
+            RTLIB::impl___safestack_pointer_address);
 
     FunctionCallee Fn = F.getParent()->getOrInsertFunction(
         SafestackPointerAddressName, IRB.getPtrTy(0));
     UnsafeStackPtr = IRB.CreateCall(Fn);
   } else {
     UnsafeStackPtr = TL.getSafeStackPointerLocation(IRB, Libcalls);
+    if (!UnsafeStackPtr) {
+      F.getContext().emitError(
+          "no location available for safestack pointer address");
+      UnsafeStackPtr = PoisonValue::get(StackPtrTy);
+    }
   }
 
   // Load the current stack pointer (we'll also use it as a base pointer).

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -2257,7 +2257,14 @@ TargetLoweringBase::getDefaultSafeStackPointerLocation(IRBuilderBase &IRB,
   // compiler-rt provides a variable with a magic name.  Targets that do not
   // link with compiler-rt may also provide such a variable.
   Module *M = IRB.GetInsertBlock()->getParent()->getParent();
-  const char *UnsafeStackPtrVar = "__safestack_unsafe_stack_ptr";
+
+  RTLIB::LibcallImpl UnsafeStackPtrImpl =
+      Libcalls.getLibcallImpl(RTLIB::SAFESTACK_UNSAFE_STACK_PTR);
+  if (UnsafeStackPtrImpl == RTLIB::Unsupported)
+    return nullptr;
+
+  StringRef UnsafeStackPtrVar =
+      RTLIB::RuntimeLibcallsInfo::getLibcallImplName(UnsafeStackPtrImpl);
   auto UnsafeStackPtr =
       dyn_cast_or_null<GlobalVariable>(M->getNamedValue(UnsafeStackPtrVar));
 
@@ -2289,19 +2296,13 @@ TargetLoweringBase::getDefaultSafeStackPointerLocation(IRBuilderBase &IRB,
 
 Value *TargetLoweringBase::getSafeStackPointerLocation(
     IRBuilderBase &IRB, const LibcallLoweringInfo &Libcalls) const {
-  Module *M = IRB.GetInsertBlock()->getParent()->getParent();
-  auto *PtrTy = PointerType::getUnqual(M->getContext());
-
   RTLIB::LibcallImpl SafestackPointerAddressImpl =
       Libcalls.getLibcallImpl(RTLIB::SAFESTACK_POINTER_ADDRESS);
-  if (SafestackPointerAddressImpl == RTLIB::Unsupported) {
-
+  if (SafestackPointerAddressImpl == RTLIB::Unsupported)
     return getDefaultSafeStackPointerLocation(IRB, true);
 
-    M->getContext().emitError(
-        "no libcall available for safestack pointer address");
-    return PoisonValue::get(PtrTy);
-  }
+  Module *M = IRB.GetInsertBlock()->getParent()->getParent();
+  auto *PtrTy = PointerType::getUnqual(M->getContext());
 
   // Android provides a libc function to retrieve the address of the current
   // thread's unsafe stack pointer.

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -2289,17 +2289,15 @@ TargetLoweringBase::getDefaultSafeStackPointerLocation(IRBuilderBase &IRB,
 
 Value *TargetLoweringBase::getSafeStackPointerLocation(
     IRBuilderBase &IRB, const LibcallLoweringInfo &Libcalls) const {
-  // FIXME: Can this triple check be replaced with SAFESTACK_POINTER_ADDRESS
-  // being available?
-  if (!TM.getTargetTriple().isAndroid())
-    return getDefaultSafeStackPointerLocation(IRB, true);
-
   Module *M = IRB.GetInsertBlock()->getParent()->getParent();
   auto *PtrTy = PointerType::getUnqual(M->getContext());
 
   RTLIB::LibcallImpl SafestackPointerAddressImpl =
       Libcalls.getLibcallImpl(RTLIB::SAFESTACK_POINTER_ADDRESS);
   if (SafestackPointerAddressImpl == RTLIB::Unsupported) {
+
+    return getDefaultSafeStackPointerLocation(IRB, true);
+
     M->getContext().emitError(
         "no libcall available for safestack pointer address");
     return PoisonValue::get(PtrTy);

--- a/llvm/test/Transforms/SafeStack/NVPTX/safestack-libcall-error.ll
+++ b/llvm/test/Transforms/SafeStack/NVPTX/safestack-libcall-error.ll
@@ -1,6 +1,9 @@
-; RUN: not opt -disable-output -mtriple=nvptx64-- -mcpu=sm_90 -passes='require<libcall-lowering-info>,safe-stack' %s 2>&1 | FileCheck %s
+; RUN: not opt -disable-output -mtriple=nvptx64-- -mcpu=sm_90 -passes='require<libcall-lowering-info>,safe-stack' %s 2>&1 | FileCheck --implicit-check-not=error %s
 
-; CHECK: error: no libcall available for stackprotector check fail
+; CHECK: error: no location available for safestack pointer address
+
+; FIXME: If opt had more reasonable error handling behavior, this should emit 2 errors
+; xCHECK: error: no libcall available for stackprotector check fail
 define void @foo(i32 %t) #0 {
   %vla = alloca i32, i32 %t, align 4
   call void @baz(ptr %vla)

--- a/llvm/test/Transforms/SafeStack/NVPTX/safestack-pointer-address-libcall-error.ll
+++ b/llvm/test/Transforms/SafeStack/NVPTX/safestack-pointer-address-libcall-error.ll
@@ -1,6 +1,6 @@
-; RUN: not opt -disable-output -mtriple=nvptx64-- -safestack-use-pointer-address -mcpu=sm_90 -passes='require<libcall-lowering-info>,safe-stack' %s 2>&1 | FileCheck -check-prefix=ERR %s
+; RUN: not opt -disable-output -mtriple=nvptx64-- -safestack-use-pointer-address -mcpu=sm_90 -passes='require<libcall-lowering-info>,safe-stack' %s 2>&1 | FileCheck --implicit-check-not=error -check-prefix=ERR %s
 
-; ERR: error: no libcall available for safestack pointer address
+; ERR: error: no libcall available for stackprotector check fail
 define void @foo(i32 %t) #0 {
   %vla = alloca i32, i32 %t, align 4
   call void @baz(ptr %vla)


### PR DESCRIPTION
Instead of directly checking if the target is android, check if
__safestack_pointer_address is available and configure android
to have the call. Maintain the -safestack-use-pointer-address cl::opt
in an unclean way by ignoring libcall availability.

Also add a RuntimeLibcallsInfo entry for __safestack_unsafe_stack_ptr, similar
to other special globals. Also add this unconditionally to most targets, even though
this seems contrary to reality. A few tests rely on unsupported OSes, so leave that 
alone for now.