### PR TITLE
[RISCV] Fix issues in ORI to QC.INSBI transformation

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXqci.td
@@ -845,10 +845,11 @@ let Predicates = [HasVendorXqcibi, IsRV32] in {
 let Predicates = [HasVendorXqcibm, IsRV32] in {
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
   def QC_INSBRI : QCIRVInstRI<0b1, simm11, "qc.insbri">;
-  def QC_INSBI : RVInstIBase<0b001, OPC_CUSTOM_0, (outs GPRNoX0:$rd),
-                             (ins simm5:$imm5, uimm5_plus1:$width,
+  def QC_INSBI : RVInstIBase<0b001, OPC_CUSTOM_0, (outs GPRNoX0:$rd_wb),
+                             (ins GPRNoX0:$rd, simm5:$imm5, uimm5_plus1:$width,
                              uimm5:$shamt), "qc.insbi",
                              "$rd, $imm5, $width, $shamt"> {
+    let Constraints = "$rd = $rd_wb";
     bits<5> imm5;
     bits<5> shamt;
     bits<5> width;

--- a/llvm/test/CodeGen/RISCV/xqcibm-cto-clo-brev.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibm-cto-clo-brev.ll
@@ -105,6 +105,7 @@ define i16 @test_cttz_i16(i16 %a) nounwind {
 ;
 ; RV32ZBBXQCIBM-LABEL: test_cttz_i16:
 ; RV32ZBBXQCIBM:       # %bb.0:
+; RV32ZBBXQCIBM-NEXT:    not a0, a0
 ; RV32ZBBXQCIBM-NEXT:    qc.insbi a0, -1, 1, 16
 ; RV32ZBBXQCIBM-NEXT:    ctz a0, a0
 ; RV32ZBBXQCIBM-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
@@ -57,11 +57,13 @@ define i32 @test_insbi_mask_mv(i32 %a, i32 %b) nounwind {
 ;
 ; RV32IXQCIBM-LABEL: test_insbi_mask_mv:
 ; RV32IXQCIBM:       # %bb.0:
+; RV32IXQCIBM-NEXT:    mv a0, a1
 ; RV32IXQCIBM-NEXT:    qc.insbi a0, -1, 16, 0
 ; RV32IXQCIBM-NEXT:    ret
 ;
 ; RV32IXQCIBMZBS-LABEL: test_insbi_mask_mv:
 ; RV32IXQCIBMZBS:       # %bb.0:
+; RV32IXQCIBMZBS-NEXT:    mv a0, a1
 ; RV32IXQCIBMZBS-NEXT:    qc.insbi a0, -1, 16, 0
 ; RV32IXQCIBMZBS-NEXT:    ret
   %or = or i32 %b, 65535
@@ -99,14 +101,16 @@ define i32 @test_insbi_shifted_mask_multiple_uses(i32 %a) nounwind {
 ;
 ; RV32IXQCIBM-LABEL: test_insbi_shifted_mask_multiple_uses:
 ; RV32IXQCIBM:       # %bb.0:
-; RV32IXQCIBM-NEXT:    qc.insbi a1, -1, 4, 12
+; RV32IXQCIBM-NEXT:    lui a1, 15
+; RV32IXQCIBM-NEXT:    or a1, a1, a0
 ; RV32IXQCIBM-NEXT:    addi a0, a0, 10
 ; RV32IXQCIBM-NEXT:    xor a0, a0, a1
 ; RV32IXQCIBM-NEXT:    ret
 ;
 ; RV32IXQCIBMZBS-LABEL: test_insbi_shifted_mask_multiple_uses:
 ; RV32IXQCIBMZBS:       # %bb.0:
-; RV32IXQCIBMZBS-NEXT:    qc.insbi a1, -1, 4, 12
+; RV32IXQCIBMZBS-NEXT:    lui a1, 15
+; RV32IXQCIBMZBS-NEXT:    or a1, a1, a0
 ; RV32IXQCIBMZBS-NEXT:    addi a0, a0, 10
 ; RV32IXQCIBMZBS-NEXT:    xor a0, a0, a1
 ; RV32IXQCIBMZBS-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibm-insert.ll
@@ -47,6 +47,27 @@ define i32 @test_insbi_mask(i32 %a) nounwind {
   ret i32 %or
 }
 
+define i32 @test_insbi_mask_mv(i32 %a, i32 %b) nounwind {
+; RV32I-LABEL: test_insbi_mask_mv:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    lui a0, 16
+; RV32I-NEXT:    addi a0, a0, -1
+; RV32I-NEXT:    or a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32IXQCIBM-LABEL: test_insbi_mask_mv:
+; RV32IXQCIBM:       # %bb.0:
+; RV32IXQCIBM-NEXT:    qc.insbi a0, -1, 16, 0
+; RV32IXQCIBM-NEXT:    ret
+;
+; RV32IXQCIBMZBS-LABEL: test_insbi_mask_mv:
+; RV32IXQCIBMZBS:       # %bb.0:
+; RV32IXQCIBMZBS-NEXT:    qc.insbi a0, -1, 16, 0
+; RV32IXQCIBMZBS-NEXT:    ret
+  %or = or i32 %b, 65535
+  ret i32 %or
+}
+
 define i32 @test_insbi_shifted_mask(i32 %a) nounwind {
 ; RV32I-LABEL: test_insbi_shifted_mask:
 ; RV32I:       # %bb.0:
@@ -65,6 +86,34 @@ define i32 @test_insbi_shifted_mask(i32 %a) nounwind {
 ; RV32IXQCIBMZBS-NEXT:    ret
   %or = or i32 %a, 61440
   ret i32 %or
+}
+
+define i32 @test_insbi_shifted_mask_multiple_uses(i32 %a) nounwind {
+; RV32I-LABEL: test_insbi_shifted_mask_multiple_uses:
+; RV32I:       # %bb.0:
+; RV32I-NEXT:    lui a1, 15
+; RV32I-NEXT:    or a1, a0, a1
+; RV32I-NEXT:    addi a0, a0, 10
+; RV32I-NEXT:    xor a0, a1, a0
+; RV32I-NEXT:    ret
+;
+; RV32IXQCIBM-LABEL: test_insbi_shifted_mask_multiple_uses:
+; RV32IXQCIBM:       # %bb.0:
+; RV32IXQCIBM-NEXT:    qc.insbi a1, -1, 4, 12
+; RV32IXQCIBM-NEXT:    addi a0, a0, 10
+; RV32IXQCIBM-NEXT:    xor a0, a0, a1
+; RV32IXQCIBM-NEXT:    ret
+;
+; RV32IXQCIBMZBS-LABEL: test_insbi_shifted_mask_multiple_uses:
+; RV32IXQCIBMZBS:       # %bb.0:
+; RV32IXQCIBMZBS-NEXT:    qc.insbi a1, -1, 4, 12
+; RV32IXQCIBMZBS-NEXT:    addi a0, a0, 10
+; RV32IXQCIBMZBS-NEXT:    xor a0, a0, a1
+; RV32IXQCIBMZBS-NEXT:    ret
+  %or = or i32 %a, 61440
+  %add = add i32 %a, 10
+  %xor = xor i32 %or, %add
+  ret i32 %xor
 }
 
 define i32 @test_single_bit_set(i32 %a) nounwind {


### PR DESCRIPTION
The transformation done in #147349  was incorrect since we were not passing the input node of the `OR` instruction to the `QC.INSBI` instruction leading to the generated instruction doing the wrong thing. In order to do this we first needed to add the output register to `QC.INSBI` as being both an input and output. 

The code produced after the above fix will need a copy (mv) to preserve the register input to the OR instruction if it has more than one use making the transformation net neutral ( `6-byte QC.E.ORI/ORAI` vs `2-byte C.MV + 4-byte QC.INSB`I). Avoid doing the transformation if there is more than one use of the input register to the OR instruction.