### PR TITLE
[mlir][spirv] Add 8-bit float type emulation

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -197,8 +197,9 @@ def ConvertArithToSPIRVPass : Pass<"convert-arith-to-spirv"> {
            "Emulate narrower scalar types with 32-bit ones if not supported by "
            "the target">,
     Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
-    "bool", /*default=*/"true",
-    "Emulate unsupported float types by emulating them with integer types of same bit width">
+           "bool", /*default=*/"true",
+           "Emulate unsupported float types by representing them with integer "
+           "types of same bit width">
   ];
 }
 
@@ -421,8 +422,9 @@ def ConvertControlFlowToSPIRVPass : Pass<"convert-cf-to-spirv"> {
            "Emulate narrower scalar types with 32-bit ones if not supported by"
            " the target">,
     Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
-    "bool", /*default=*/"true",
-    "Emulate unsupported float types by emulating them with integer types of same bit width">
+           "bool", /*default=*/"true",
+           "Emulate unsupported float types by representing them with integer "
+           "types of same bit width">
   ];
 }
 
@@ -508,8 +510,9 @@ def ConvertFuncToSPIRVPass : Pass<"convert-func-to-spirv"> {
            "Emulate narrower scalar types with 32-bit ones if not supported by"
            " the target">,
     Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
-    "bool", /*default=*/"true",
-    "Emulate unsupported float types by emulating them with integer types of same bit width">
+           "bool", /*default=*/"true",
+           "Emulate unsupported float types by representing them with integer "
+           "types of same bit width">
   ];
 }
 
@@ -1178,8 +1181,9 @@ def ConvertTensorToSPIRVPass : Pass<"convert-tensor-to-spirv"> {
            "Emulate narrower scalar types with 32-bit ones if not supported by"
            " the target">,
     Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
-    "bool", /*default=*/"true",
-    "Emulate unsupported float types by emulating them with integer types of same bit width">
+           "bool", /*default=*/"true",
+           "Emulate unsupported float types by representing them with integer "
+           "types of same bit width">
   ];
 }
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -196,6 +196,9 @@ def ConvertArithToSPIRVPass : Pass<"convert-arith-to-spirv"> {
            "bool", /*default=*/"true",
            "Emulate narrower scalar types with 32-bit ones if not supported by "
            "the target">,
+    Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
+    "bool", /*default=*/"true",
+    "Emulate unsupported float types by emulating them with integer types of same bit width">
   ];
 }
 
@@ -416,7 +419,10 @@ def ConvertControlFlowToSPIRVPass : Pass<"convert-cf-to-spirv"> {
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
            "bool", /*default=*/"true",
            "Emulate narrower scalar types with 32-bit ones if not supported by"
-           " the target">
+           " the target">,
+    Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
+    "bool", /*default=*/"true",
+    "Emulate unsupported float types by emulating them with integer types of same bit width">
   ];
 }
 
@@ -500,7 +506,10 @@ def ConvertFuncToSPIRVPass : Pass<"convert-func-to-spirv"> {
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
            "bool", /*default=*/"true",
            "Emulate narrower scalar types with 32-bit ones if not supported by"
-           " the target">
+           " the target">,
+    Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
+    "bool", /*default=*/"true",
+    "Emulate unsupported float types by emulating them with integer types of same bit width">
   ];
 }
 
@@ -1167,7 +1176,10 @@ def ConvertTensorToSPIRVPass : Pass<"convert-tensor-to-spirv"> {
     Option<"emulateLT32BitScalarTypes", "emulate-lt-32-bit-scalar-types",
            "bool", /*default=*/"true",
            "Emulate narrower scalar types with 32-bit ones if not supported by"
-           " the target">
+           " the target">,
+    Option<"emulateUnsupportedFloatTypes", "emulate-unsupported-float-types",
+    "bool", /*default=*/"true",
+    "Emulate unsupported float types by emulating them with integer types of same bit width">
   ];
 }
 

--- a/mlir/include/mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h
+++ b/mlir/include/mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h
@@ -39,6 +39,10 @@ struct SPIRVConversionOptions {
   /// The number of bits to store a boolean value.
   unsigned boolNumBits{8};
 
+  /// Whether to emulate unsupported floats with integer types of same bit
+  /// width.
+  bool emulateUnsupportedFloatTypes{true};
+
   /// How sub-byte values are storaged in memory.
   SPIRVSubByteTypeStorage subByteTypeStorage{SPIRVSubByteTypeStorage::Packed};
 

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -99,6 +99,14 @@ static FloatAttr convertFloatAttr(FloatAttr srcAttr, FloatType dstType,
   return builder.getF32FloatAttr(dstVal.convertToFloat());
 }
 
+// Get IntegerAttr from FloatAttr.
+IntegerAttr getIntegerAttrFromFloatAttr(FloatAttr floatAttr, Type dstType,
+                                        ConversionPatternRewriter &rewriter) {
+  APFloat floatVal = floatAttr.getValue();
+  APInt intVal = floatVal.bitcastToAPInt();
+  return rewriter.getIntegerAttr(dstType, intVal);
+}
+
 /// Returns true if the given `type` is a boolean scalar or vector type.
 static bool isBoolScalarOrVector(Type type) {
   assert(type && "Not a valid type");
@@ -296,8 +304,16 @@ struct ConstantCompositeOpPattern final
       SmallVector<Attribute, 8> elements;
       if (isa<FloatType>(srcElemType)) {
         for (FloatAttr srcAttr : dstElementsAttr.getValues<FloatAttr>()) {
-          FloatAttr dstAttr =
-              convertFloatAttr(srcAttr, cast<FloatType>(dstElemType), rewriter);
+          Attribute dstAttr = nullptr;
+          // Handle 8-bit float conversion to 8-bit integer.
+          if (srcElemType.getIntOrFloatBitWidth() == 8 &&
+              isa<IntegerType>(dstElemType)) {
+            dstAttr =
+                getIntegerAttrFromFloatAttr(srcAttr, dstElemType, rewriter);
+          } else {
+            dstAttr = convertFloatAttr(srcAttr, cast<FloatType>(dstElemType),
+                                       rewriter);
+          }
           if (!dstAttr)
             return failure();
           elements.push_back(dstAttr);
@@ -361,11 +377,17 @@ struct ConstantScalarOpPattern final
     // Floating-point types.
     if (isa<FloatType>(srcType)) {
       auto srcAttr = cast<FloatAttr>(cstAttr);
-      auto dstAttr = srcAttr;
+      Attribute dstAttr = srcAttr;
 
       // Floating-point types not supported in the target environment are all
       // converted to float type.
-      if (srcType != dstType) {
+      if (srcType.getIntOrFloatBitWidth() == 8 && isa<IntegerType>(dstType) &&
+          dstType.getIntOrFloatBitWidth() == 8) {
+        // If the source is an 8-bit float, convert it to a 8-bit integer.
+        dstAttr = getIntegerAttrFromFloatAttr(srcAttr, dstType, rewriter);
+        if (!dstAttr)
+          return failure();
+      } else if (srcType != dstType) {
         dstAttr = convertFloatAttr(srcAttr, cast<FloatType>(dstType), rewriter);
         if (!dstAttr)
           return failure();

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -99,9 +99,12 @@ static FloatAttr convertFloatAttr(FloatAttr srcAttr, FloatType dstType,
   return builder.getF32FloatAttr(dstVal.convertToFloat());
 }
 
-// Get IntegerAttr from FloatAttr.
-IntegerAttr getIntegerAttrFromFloatAttr(FloatAttr floatAttr, Type dstType,
-                                        ConversionPatternRewriter &rewriter) {
+// Get in IntegerAttr from FloatAttr while preserving the bits.
+// Useful for converting float constants to integer constants while preserving
+// the bits.
+static IntegerAttr
+getIntegerAttrFromFloatAttr(FloatAttr floatAttr, Type dstType,
+                            ConversionPatternRewriter &rewriter) {
   APFloat floatVal = floatAttr.getValue();
   APInt intVal = floatVal.bitcastToAPInt();
   return rewriter.getIntegerAttr(dstType, intVal);

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
@@ -43,8 +43,7 @@ void ConvertControlFlowToSPIRVPass::runOnOperation() {
 
   SPIRVConversionOptions options;
   options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
-  options.emulateUnsupportedFloatTypes =
-      this->emulateUnsupportedFloatTypes;
+  options.emulateUnsupportedFloatTypes = this->emulateUnsupportedFloatTypes;
   SPIRVTypeConverter typeConverter(targetAttr, options);
 
   // TODO: We should also take care of block argument type conversion.

--- a/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/ControlFlowToSPIRV/ControlFlowToSPIRVPass.cpp
@@ -43,6 +43,8 @@ void ConvertControlFlowToSPIRVPass::runOnOperation() {
 
   SPIRVConversionOptions options;
   options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
+  options.emulateUnsupportedFloatTypes =
+      this->emulateUnsupportedFloatTypes;
   SPIRVTypeConverter typeConverter(targetAttr, options);
 
   // TODO: We should also take care of block argument type conversion.

--- a/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
@@ -42,8 +42,7 @@ void ConvertFuncToSPIRVPass::runOnOperation() {
 
   SPIRVConversionOptions options;
   options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
-  options.emulateUnsupportedFloatTypes =
-      this->emulateUnsupportedFloatTypes;
+  options.emulateUnsupportedFloatTypes = this->emulateUnsupportedFloatTypes;
   SPIRVTypeConverter typeConverter(targetAttr, options);
 
   RewritePatternSet patterns(context);

--- a/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/FuncToSPIRV/FuncToSPIRVPass.cpp
@@ -42,6 +42,8 @@ void ConvertFuncToSPIRVPass::runOnOperation() {
 
   SPIRVConversionOptions options;
   options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
+  options.emulateUnsupportedFloatTypes =
+      this->emulateUnsupportedFloatTypes;
   SPIRVTypeConverter typeConverter(targetAttr, options);
 
   RewritePatternSet patterns(context);

--- a/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
@@ -41,8 +41,7 @@ class ConvertTensorToSPIRVPass
 
     SPIRVConversionOptions options;
     options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
-    options.emulateUnsupportedFloatTypes =
-      this->emulateUnsupportedFloatTypes;
+    options.emulateUnsupportedFloatTypes = this->emulateUnsupportedFloatTypes;
     SPIRVTypeConverter typeConverter(targetAttr, options);
 
     RewritePatternSet patterns(context);

--- a/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
+++ b/mlir/lib/Conversion/TensorToSPIRV/TensorToSPIRVPass.cpp
@@ -41,6 +41,8 @@ class ConvertTensorToSPIRVPass
 
     SPIRVConversionOptions options;
     options.emulateLT32BitScalarTypes = this->emulateLT32BitScalarTypes;
+    options.emulateUnsupportedFloatTypes =
+      this->emulateUnsupportedFloatTypes;
     SPIRVTypeConverter typeConverter(targetAttr, options);
 
     RewritePatternSet patterns(context);

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -169,7 +169,6 @@ static spirv::ScalarType getIndexType(MLIRContext *ctx,
 // SPIR-V dialect. Keeping it local till the use case arises.
 static std::optional<int64_t>
 getTypeNumBytes(const SPIRVConversionOptions &options, Type type) {
-
   if (isa<spirv::ScalarType>(type)) {
     auto bitWidth = type.getIntOrFloatBitWidth();
     // According to the SPIR-V spec:
@@ -188,8 +187,7 @@ getTypeNumBytes(const SPIRVConversionOptions &options, Type type) {
     auto bitWidth = type.getIntOrFloatBitWidth();
     if (bitWidth == 8)
       return bitWidth / 8;
-    else
-      return std::nullopt;
+    return std::nullopt;
   }
 
   if (auto complexType = dyn_cast<ComplexType>(type)) {
@@ -339,7 +337,7 @@ static Type convert8BitFloatType(const SPIRVConversionOptions &options,
           Float8E4M3FNUZType, Float8E4M3B11FNUZType, Float8E3M4Type,
           Float8E8M0FNUType>(type))
     return IntegerType::get(type.getContext(), type.getWidth());
-  LLVM_DEBUG(llvm::dbgs() << "unsupported 8-bit float type\n");
+  LLVM_DEBUG(llvm::dbgs() << "unsupported 8-bit float type: " << type << "\n");
   return nullptr;
 }
 
@@ -351,7 +349,7 @@ convertShaped8BitFloatType(ShapedType type,
                            const SPIRVConversionOptions &options) {
   if (!options.emulateUnsupportedFloatTypes)
     return type;
-  auto srcElementType = type.getElementType();
+  Type srcElementType = type.getElementType();
   Type convertedElementType = nullptr;
   // F8 types are converted to integer types with the same bit width.
   if (isa<Float8E5M2Type, Float8E4M3Type, Float8E4M3FNType, Float8E5M2FNUZType,

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -366,52 +366,6 @@ convertShaped8BitFloatType(ShapedType type,
   return type.clone(convertedElementType);
 }
 
-/// Converts a sub-byte float ``type` to i32 regardless of target environment.
-/// Returns a nullptr for unsupported float types, including non sub-byte
-/// types.
-///
-/// We are treating 8 bit floats as sub-byte types here due to it's similar
-/// nature of being used as a packed format.
-
-/// Note that we don't recognize
-/// sub-byte types in `spirv::ScalarType` and use the above given that these
-/// sub-byte types are not supported at all in SPIR-V; there are no
-/// compute/storage capability for them like other supported integer types.
-
-// static Type convertPackedFLoatType(const SPIRVConversionOptions &options,
-//                                    FloatType type) {
-
-//   // F4, F6, F8 types are converted to integer types with the same bit width.
-
-//   if (isa<Float8E5M2Type, Float8E4M3Type, Float8E4M3FNType,
-//   Float8E5M2FNUZType,
-//           Float8E4M3FNUZType, Float8E4M3B11FNUZType, Float8E3M4Type,
-//           Float4E2M1FNType, Float6E2M3FNType, Float6E3M2FNType,
-//           Float8E8M0FNUType>(type))
-//     auto emulatedType = IntegerType::get(type.getContext(), type.getWidth());
-
-//   if (type.getWidth() > 8) {
-//     LLVM_DEBUG(llvm::dbgs() << "not a packed type\n");
-//     return nullptr;
-//   }
-//   if (options.subByteTypeStorage != SPIRVSubByteTypeStorage::Packed) {
-//     LLVM_DEBUG(llvm::dbgs() << "unsupported sub-byte storage kind\n");
-//     return nullptr;
-//   }
-
-//   // if (!llvm::isPowerOf2_32(type.getWidth())) {
-//   //   LLVM_DEBUG(llvm::dbgs()
-//   //              << "unsupported non-power-of-two bitwidth in sub-byte" <<
-//   type
-//   //              << "\n");
-//   //   return nullptr;
-//   // }
-
-//   LLVM_DEBUG(llvm::dbgs() << type << " converted to 32-bit for SPIR-V\n");
-//   return IntegerType::get(type.getContext(), /*width=*/32,
-//                           type.getSignedness());
-// }
-
 /// Returns a type with the same shape but with any index element type converted
 /// to the matching integer type. This is a noop when the element type is not
 /// the index type.

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -345,12 +345,12 @@ static Type convert8BitFloatType(const SPIRVConversionOptions &options,
 
 /// Returns a type with the same shape but with any 8-bit float element type
 /// converted to the same bit width integer type. This is a noop when the
-/// element type is not the 8-bit float type.
+/// element type is not the 8-bit float type or emulation flag is set to false.
 static ShapedType
 convertShaped8BitFloatType(ShapedType type,
                            const SPIRVConversionOptions &options) {
   if (!options.emulateUnsupportedFloatTypes)
-    return nullptr;
+    return type;
   auto srcElementType = type.getElementType();
   Type convertedElementType = nullptr;
   // F8 types are converted to integer types with the same bit width.

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -650,12 +650,6 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
     // Hnadle 8 bit float types.
     type = cast<MemRefType>(convertShaped8BitFloatType(type, options));
     arrayElemType = type.getElementType();
-    // if (options.emulateUnsupportedFloatTypes && floatType &&
-    //     floatType.getWidth() == 8) {
-    //   // If this is an 8 bit float type, try to convert it to a supported
-    //   // integer type.
-    //   arrayElemType = convert8BitFloatType(options, floatType);
-    // }
   } else {
     LLVM_DEBUG(
         llvm::dbgs()

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -563,10 +563,16 @@ func.func @constant() {
 func.func @constant_8bit_float() {
   // CHECK: spirv.Constant 56 : i8
   %cst = arith.constant 1.0 : f8E4M3
+  // CHECK: spirv.Constant 56 : i8
+  %cst_i8 = arith.bitcast %cst : f8E4M3 to i8
   // CHECK: spirv.Constant dense<56> : vector<4xi8>
   %cst_vector = arith.constant dense<1.0> : vector<4xf8E4M3>
+  // CHECK: spirv.Constant dense<56> : vector<4xi8>
+  %cst_vector_i8 = arith.bitcast %cst_vector : vector<4xf8E4M3> to vector<4xi8>
   // CHECK: spirv.Constant dense<60> : tensor<4xi8> : !spirv.array<4 x i8>
   %cst_tensor = arith.constant dense<1.0> : tensor<4xf8E5M2>
+  // CHECK: spirv.Constant dense<60> : tensor<4xi8> : !spirv.array<4 x i8>
+  %cst_tensor_i8 = arith.bitcast %cst_tensor : tensor<4xf8E5M2> to tensor<4xi8>
   return
 }
 

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -559,6 +559,17 @@ func.func @constant() {
   return
 }
 
+// CHECK-LABEL: @constant_8bit_float
+func.func @constant_8bit_float() {
+  // CHECK: spirv.Constant 56 : i8
+  %cst = arith.constant 1.0 : f8E4M3
+  // CHECK: spirv.Constant dense<56> : vector<4xi8>
+  %cst_vector = arith.constant dense<1.0> : vector<4xf8E4M3>
+  // CHECK: spirv.Constant dense<60> : tensor<4xi8> : !spirv.array<4 x i8>
+  %cst_tensor = arith.constant dense<1.0> : tensor<4xf8E5M2>
+  return
+}
+
 // CHECK-LABEL: @constant_16bit
 func.func @constant_16bit() {
   // CHECK: spirv.Constant 4 : i16


### PR DESCRIPTION
8-bit floats are not supported in SPIR-V. They are emulated as 8-bit integer during conversion.
