### PR TITLE
[Clang][Test] Add PS5 and WI cases to clang/test/Sema/dllexport.c

### DIFF
--- a/clang/test/Sema/dllexport.c
+++ b/clang/test/Sema/dllexport.c
@@ -2,6 +2,10 @@
 // RUN: %clang_cc1 -triple x86_64-win32   -fsyntax-only -fms-extensions -verify -std=c11 %s
 // RUN: %clang_cc1 -triple i686-mingw32   -fsyntax-only -fms-extensions -verify -std=c11 %s
 // RUN: %clang_cc1 -triple x86_64-mingw32 -fsyntax-only -fms-extensions -verify -std=c99 %s
+// RUN: %clang_cc1 -triple i686-windows-itanium   -fsyntax-only -fms-extensions -verify -std=c99 %s
+// RUN: %clang_cc1 -triple x86_64-windows-itanium -fsyntax-only -fms-extensions -verify -std=c11 %s
+// RUN: %clang_cc1 -triple x86_64-sie-ps5         -fsyntax-only -fms-extensions -verify -std=c99 %s
+// RUN: %clang_cc1 -triple x86_64-sie-ps5         -fsyntax-only -fms-extensions -verify -std=c11 %s
 
 // Invalid usage.
 __declspec(dllexport) typedef int typedef1;


### PR DESCRIPTION
Windows Itanium and PS5 are both Itanium C++ ABI variants which have the goal of semantic compatibility with Microsoft C++ code that uses dllimport/export.

This patch adds Windows Itanium and PS5 triple testing to clang/test/Sema/dllexport.c. We have this testing in our downstream toolchain - for some reason it was not added upstream when the work for supporting dllimport/export was done.