### PR TITLE
[lldb] Improve setting of program for filtering disassembly

### DIFF
--- a/lldb/test/Shell/Commands/command-disassemble-riscv32-bytes.s
+++ b/lldb/test/Shell/Commands/command-disassemble-riscv32-bytes.s
@@ -1,6 +1,5 @@
 # REQUIRES: riscv
-# Unsupported until we fix launching the filter program on Windows.
-# UNSUPPORTED: system-windows
+# REQUIRES: python
 
 # This test verifies that disassemble -b prints out the correct bytes and
 # format for standard and unknown riscv instructions of various sizes,
@@ -11,7 +10,7 @@
 
 # RUN: llvm-mc -filetype=obj -mattr=+c --triple=riscv32-unknown-unknown %s -o %t
 # RUN: %lldb -b %t "-o" "disassemble -b -n main" | FileCheck %s
-# RUN: %lldb -b %t -o "command script import %S/../../../examples/python/filter_disasm.py" -o "fdis set %S/Inputs/dis_filt.py" -o "fdis -n main" | FileCheck --check-prefix=FILTER %s
+# RUN: %lldb -b %t -o "command script import %S/../../../examples/python/filter_disasm.py" -o "fdis set %python %S/Inputs/dis_filt.py" -o "fdis -n main" | FileCheck --check-prefix=FILTER %s
 
 main:
     addi   sp, sp, -0x20               # 16 bit standard instruction


### PR DESCRIPTION
This changes the example command added in https://github.com/llvm/llvm-project/pull/145793 so that the fdis program does not have to be a single program name.

Doing so also means we can run the test on Windows where the program needs to be "python.exe script_name".

I've changed "fdis set" to treat the rest of the command as the program. Then store that as a list to be passed to subprocess. If we just use a string, Python will think that "python.exe foo" is the name of an actual program instead of a program and an argument to it.

This will still break if the paths have spaces in, but I'm trying to do just enough to fix the test here without rewriting all the option handling.