### PR TITLE
[flang][Parser] Add whitespace token after the sentinel in fixed form

### DIFF
--- a/flang/lib/Parser/prescan.cpp
+++ b/flang/lib/Parser/prescan.cpp
@@ -179,7 +179,9 @@ void Prescanner::Statement() {
         EmitChar(tokens, *sp);
       }
       if (inFixedForm_) {
-        while (column_ < 6) {
+        // We need to add the whitespace after the sentinel because otherwise
+        // the line cannot be re-categorised as a compiler directive.
+        while (column_ <= 6) {
           if (*at_ == '\t') {
             tabInCurrentLine_ = true;
             ++at_;

--- a/flang/test/Preprocessing/omp-sentinel-fixed-form.F
+++ b/flang/test/Preprocessing/omp-sentinel-fixed-form.F
@@ -1,0 +1,21 @@
+! RUN: %flang_fc1 -fdebug-unparse -fopenmp -fopenmp-version=50 %s | FileCheck %s
+
+#define OMP_TARGET        .true.
+#define OMP_SIMD    .false.
+      program test
+      implicit none
+      integer     i,j,n
+      n = 100
+! CHECK: !$OMP METADIRECTIVE  WHEN(USER={CONDITION(.true._4)}: TARGET TEAMS DISTRIBUTE PARALLEL&
+! CHECK: !$OMP& DO) DEFAULT(TARGET TEAMS LOOP)
+!$omp  metadirective
+!$omp& when(user={condition(OMP_TARGET.or.OMP_SIMD)}:
+!$omp&      target teams distribute parallel do )
+!$omp& default(target teams loop)
+      do i=0,n
+        do j=0,n
+          write(*,*) "Test"
+        enddo
+      enddo
+      return
+      end program


### PR DESCRIPTION
Fixes #148386

The first time the line was classified (using
`Prescanner::ClassifyLine(const char *)`) the line was correctly classified as a compiler directive. But then later on the token form is invoked (`Prescanner::ClassifyLine(TokenSequence, Provenance)`). This one incorrectly classified the line as a comment because there was no whitespace token right after the sentinel. This fixes the issue by ensuring this whitespace is added.