### PR TITLE
[CodeGen][ObjC] Include all referenced protocols in protocol list

### DIFF
--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -1942,8 +1942,9 @@ class CGObjCGNUstep2 : public CGObjCGNUstep {
     // struct objc_class *sibling_class
     classFields.addNullPointer(PtrTy);
     // struct objc_protocol_list *protocols;
-    auto RuntimeProtocols = GetRuntimeProtocolList(classDecl->protocol_begin(),
-                                                   classDecl->protocol_end());
+    auto RuntimeProtocols =
+        GetRuntimeProtocolList(classDecl->all_referenced_protocol_begin(),
+                               classDecl->all_referenced_protocol_end());
     SmallVector<llvm::Constant *, 16> Protocols;
     for (const auto *I : RuntimeProtocols)
       Protocols.push_back(GenerateProtocolRef(I));

--- a/clang/test/CodeGenObjC/gnustep2-class-exts.m
+++ b/clang/test/CodeGenObjC/gnustep2-class-exts.m
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu -fobjc-runtime=gnustep-2.2 -emit-llvm -o - %s | FileCheck %s
+
+@protocol BaseProtocol
+@end
+
+@protocol ExtendedProtocol
+@end
+
+@interface TestClass <BaseProtocol>
+
+-(void) Meth;
+@end
+
+@interface TestClass () <BaseProtocol, ExtendedProtocol>
+@end
+
+@implementation TestClass
+@end
+
+// Check that we emit metadata for both protocols
+// CHECK: @._OBJC_PROTOCOL_ExtendedProtocol = global
+// CHECK: @._OBJC_PROTOCOL_BaseProtocol = global
+
+// Check that we deduplicate the protocol list
+// CHECK: @.objc_protocol_list{{\.[0-9]*}} = internal global { ptr, i64, [2 x ptr] }


### PR DESCRIPTION
When constructing the protocol list in the class metadata generation (`GenerateClass`), only the protocols from the base class are added but not protocols declared in class extensions.

This is fixed by using `all_referenced_protocol_{begin, end}` instead of `protocol_{begin, end}`, matching the behaviour on Apple platforms.

A unit test is included to check if all protocol metadata was emitted and that no duplication occurs in the protocol list.

Fixes https://github.com/gnustep/libobjc2/issues/339

CC: @davidchisnall  