### PR TITLE
[C++] Fix a failed assertion with nullability checking

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -800,6 +800,8 @@ Bug Fixes in This Version
   declaration statements. Clang now emits a warning for these patterns. (#GH141659)
 - Fixed false positives for redeclaration errors of using enum in
   nested scopes. (#GH147495)
+- Fixed a failed assertion with an operator call expression which comes from a
+  macro expansion when performing analysis for nullability attributes. (#GH138371)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/SemaTemplate/gh138371.cpp
+++ b/clang/test/SemaTemplate/gh138371.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+// This would previously trigger a failed assertion when instantiating the
+// template which uses an overloaded call operator because the end location
+// for the expression came from a macro expansion.
+
+#define ASSIGN_OR_RETURN(...)  (__VA_ARGS__)
+
+struct Loc {
+  int operator()(const char* _Nonnull f = __builtin_FILE()) const;
+};
+
+template <typename Ty>
+void f() {
+  ASSIGN_OR_RETURN(Loc()());
+}
+
+void test() {
+  f<int>();
+}
+


### PR DESCRIPTION
This fixes a failed assertion with an operator call expression which comes from a macro expansion when performing analysis for nullability attributes.

Fixes #138371