### PR TITLE
Minor formatting fix in 'generate_feature_test_macro_components'

### DIFF
--- a/libcxx/test/std/language.support/support.limits/support.limits.general/algorithm.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/algorithm.version.compile.pass.cpp
@@ -459,4 +459,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/any.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/any.version.compile.pass.cpp
@@ -69,4 +69,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/array.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/array.version.compile.pass.cpp
@@ -171,4 +171,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/atomic.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/atomic.version.compile.pass.cpp
@@ -420,4 +420,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/barrier.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/bit.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/bit.version.compile.pass.cpp
@@ -195,4 +195,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/bitset.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/bitset.version.compile.pass.cpp
@@ -90,4 +90,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/charconv.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/charconv.version.compile.pass.cpp
@@ -123,4 +123,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/chrono.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/chrono.version.compile.pass.cpp
@@ -108,4 +108,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/cmath.version.compile.pass.cpp
@@ -204,4 +204,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/compare.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/compare.version.compile.pass.cpp
@@ -66,4 +66,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/complex.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/complex.version.compile.pass.cpp
@@ -105,4 +105,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/concepts.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/concepts.version.compile.pass.cpp
@@ -66,4 +66,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/coroutine.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/coroutine.version.compile.pass.cpp
@@ -66,4 +66,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/cstddef.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/cstddef.version.compile.pass.cpp
@@ -69,4 +69,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/cstdlib.version.compile.pass.cpp
@@ -75,4 +75,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/cstring.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/cstring.version.compile.pass.cpp
@@ -66,4 +66,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/deque.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/deque.version.compile.pass.cpp
@@ -201,4 +201,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/exception.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/exception.version.compile.pass.cpp
@@ -69,4 +69,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/execution.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/execution.version.compile.pass.cpp
@@ -126,4 +126,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/expected.version.compile.pass.cpp
@@ -129,4 +129,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/filesystem.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/filesystem.version.compile.pass.cpp
@@ -179,4 +179,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/flat_map.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/flat_map.version.compile.pass.cpp
@@ -63,4 +63,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/flat_set.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/flat_set.version.compile.pass.cpp
@@ -63,4 +63,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/format.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/format.version.compile.pass.cpp
@@ -147,4 +147,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/forward_list.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/forward_list.version.compile.pass.cpp
@@ -297,4 +297,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/fstream.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/fstream.version.compile.pass.cpp
@@ -68,4 +68,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/functional.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/functional.version.compile.pass.cpp
@@ -579,4 +579,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/iomanip.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/iomanip.version.compile.pass.cpp
@@ -104,4 +104,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/ios.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/ios.version.compile.pass.cpp
@@ -65,4 +65,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/istream.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/istream.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/iterator.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/iterator.version.compile.pass.cpp
@@ -315,4 +315,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/latch.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/latch.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/limits.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/limits.version.compile.pass.cpp
@@ -84,4 +84,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/list.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/list.version.compile.pass.cpp
@@ -297,4 +297,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/locale.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/locale.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/map.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/map.version.compile.pass.cpp
@@ -396,4 +396,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/mdspan.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/mdspan.version.compile.pass.cpp
@@ -156,4 +156,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/memory.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/memory.version.compile.pass.cpp
@@ -678,4 +678,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/memory_resource.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/memory_resource.version.compile.pass.cpp
@@ -144,4 +144,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/mutex.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/mutex.version.compile.pass.cpp
@@ -95,4 +95,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/new.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/new.version.compile.pass.cpp
@@ -213,4 +213,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/numbers.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/numbers.version.compile.pass.cpp
@@ -66,4 +66,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/numeric.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/numeric.version.compile.pass.cpp
@@ -252,4 +252,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/optional.version.compile.pass.cpp
@@ -168,4 +168,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/ostream.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/ostream.version.compile.pass.cpp
@@ -128,4 +128,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/print.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/print.version.compile.pass.cpp
@@ -77,4 +77,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/queue.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/queue.version.compile.pass.cpp
@@ -120,4 +120,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/random.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/random.version.compile.pass.cpp
@@ -99,4 +99,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/ranges.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/ranges.version.compile.pass.cpp
@@ -450,4 +450,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/ratio.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/ratio.version.compile.pass.cpp
@@ -60,4 +60,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/regex.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/regex.version.compile.pass.cpp
@@ -71,4 +71,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/scoped_allocator.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/scoped_allocator.version.compile.pass.cpp
@@ -69,4 +69,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/semaphore.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/semaphore.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/set.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/set.version.compile.pass.cpp
@@ -318,4 +318,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/shared_mutex.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/shared_mutex.version.compile.pass.cpp
@@ -164,4 +164,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/source_location.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/source_location.version.compile.pass.cpp
@@ -66,4 +66,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/span.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/span.version.compile.pass.cpp
@@ -120,4 +120,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/sstream.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/sstream.version.compile.pass.cpp
@@ -62,4 +62,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/stack.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/stack.version.compile.pass.cpp
@@ -93,4 +93,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/stdatomic.h.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/stdatomic.h.version.compile.pass.cpp
@@ -65,4 +65,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/stop_token.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/stop_token.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/string.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/string.version.compile.pass.cpp
@@ -486,4 +486,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/string_view.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/string_view.version.compile.pass.cpp
@@ -249,4 +249,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/syncstream.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/syncstream.version.compile.pass.cpp
@@ -86,4 +86,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/thread.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/thread.version.compile.pass.cpp
@@ -128,4 +128,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/tuple.version.compile.pass.cpp
@@ -333,4 +333,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/type_traits.version.compile.pass.cpp
@@ -996,4 +996,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/typeinfo.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/typeinfo.version.compile.pass.cpp
@@ -63,4 +63,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/unordered_map.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/unordered_map.version.compile.pass.cpp
@@ -390,4 +390,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/unordered_set.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/unordered_set.version.compile.pass.cpp
@@ -312,4 +312,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/utility.version.compile.pass.cpp
@@ -492,4 +492,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/variant.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/variant.version.compile.pass.cpp
@@ -135,4 +135,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/vector.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/vector.version.compile.pass.cpp
@@ -270,4 +270,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
+++ b/libcxx/test/std/language.support/support.limits/support.limits.general/version.version.compile.pass.cpp
@@ -8154,4 +8154,3 @@
 #endif // TEST_STD_VER > 23
 
 // clang-format on
-

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -1882,7 +1882,6 @@ def produce_tests():
 {cxx_tests}
 
 // clang-format on
-
 """.format(
             script_name=script_name,
             header=h,


### PR DESCRIPTION
Fixes a small annoyance where generated files have a format which does not agree with the one checked during `code-formatter` in CI.

For example `libcxx-generate-files` updates (among possibly others) the `*.version.compile.pass.cpp` files.  Previously these files contained an extra newline which would fail the code format check.  If you update that file manually to remove just that extra trailing newline, then `check-generated-output` will fail due to the file's contents differing from what's expected.

Contains a number of changes: one actual change to the py script, and lots of resulting whitespace changes.

My process for this was:
* Update `generate_feature_test_macro_components`: just remove an extra newline which causes the code-format step to fail
* Run `$NINJA libcxx-generate-files` to rebuild all these `.version.pass.cpp`'s
* Watch this PR's CI run to ensure things pass (i.e. this didn't break things worse)