### PR TITLE
[Support] Error if SocketPath is too long

### DIFF
--- a/llvm/lib/Support/raw_socket_stream.cpp
+++ b/llvm/lib/Support/raw_socket_stream.cpp
@@ -119,6 +119,14 @@ ListeningSocket::ListeningSocket(ListeningSocket &&LS)
 Expected<ListeningSocket> ListeningSocket::createUnix(StringRef SocketPath,
                                                       int MaxBacklog) {
 
+  // If SocketPath is too long, the path will be truncated, and there may be
+  // collisions with other truncated addresses that the fs::exists check below
+  // will be unable to detect.
+  if (SocketPath.size() >= sizeof(sockaddr_un::sun_path))
+    return llvm::make_error<StringError>(
+        std::make_error_code(std::errc::filename_too_long),
+        "SocketPath too long");
+
   // Handle instances where the target socket address already exists and
   // differentiate between a preexisting file with and without a bound socket
   //


### PR DESCRIPTION
If the path is longer than sockaddr_un's buffer, it will be truncated, at which point it may become indistinguishable from similar truncated paths. This will cause `bind` to fail with an "Address already in use" error. There is some existing code that checks `fs::exists` to catch these errors, but since `fs::exists` compares the full un-truncated paths, a too-long path will prevent those checks from working.

rdar://154397133