### PR TITLE
[DTLTO][TEST] Fix Clang driver test failing on some build bots

### DIFF
--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -10,7 +10,7 @@
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
+// FORWARD-SAME: "--thinlto-remote-compiler={{[^"]+}}"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"


### PR DESCRIPTION
Not all builds name the compiler executable `clang`. For example, the Fuchsia build bots use `llvm` as their single toolchain executable name, as they combine everything together in a busybox-style binary.

Update the Clang driver test to simply check that a non-empty path is provided for the `--thinlto-remote-compiler` argument, rather than hardcoding the executable name. The cross-project test will verify that the path is valid later.

Should fix #147265.