### PR TITLE
[RISCV] Change the InstFormat for Zicbop prefetch instructions to InstFormatOther.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrFormats.td
@@ -193,7 +193,9 @@ class RVInstCommon<dag outs, dag ins, string opcodestr, string argstr,
   let AsmString = opcodestr # !if(!empty(argstr), "", "\t" # argstr);
   let Pattern = pattern;
 
-  let TSFlags{4-0} = format.Value;
+  InstFormat Format = format;
+
+  let TSFlags{4-0} = Format.Value;
 
   // Defaults
   RISCVVConstraint RVVConstraint = NoConstraint;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicbo.td
@@ -41,6 +41,7 @@ class Prefetch_ri<bits<5> optype, string opcodestr>
               opcodestr, "${imm12}(${rs1})"> {
   let Inst{11-7} = 0b00000;
   let rs2 = optype;
+  let Format = InstFormatOther; // this does not follow the normal S format.
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The lower 5-bits of the immediate are not part of the address unlike other InstFormatS instructions.

We use InstFormatS in RISCVRegisterInfo::needsFrameBaseReg and RISCVRegisterInfo::getFrameIndexInstrOffset which is not aware of this special encoding. Force the format to InstFormatOther so those functions will ignore it.

InstFormatS is also used by relocation emission, but I don't believe we ever emit these instructions with a relocation because of the encoding.