### PR TITLE
[NFC][SemaHLSL] Fix typo causing float to double conversion

### DIFF
--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -1150,7 +1150,7 @@ bool SemaHLSL::handleRootSignatureElements(
       if (!llvm::hlsl::rootsig::verifyMaxAnisotropy(Sampler->MaxAnisotropy))
         ReportError(Loc, 0, 16);
       if (!llvm::hlsl::rootsig::verifyMipLODBias(Sampler->MipLODBias))
-        ReportFloatError(Loc, -16.f, 15.99);
+        ReportFloatError(Loc, -16.f, 15.99f);
     } else if (const auto *Clause =
                    std::get_if<llvm::hlsl::rootsig::DescriptorTableClause>(
                        &Elem)) {


### PR DESCRIPTION
- it was noted, [here](https://github.com/llvm/llvm-project/pull/145795#discussion_r2208118547), that by accidently not specifying this explicitly as a float it will cause a build warning on MSVC

- this commit resolves this by explicitly specifying it as a float