### PR TITLE
[lldb] Fix plugin test to not rely on enabled targets

### DIFF
--- a/lldb/test/API/commands/plugin/TestPlugin.py
+++ b/lldb/test/API/commands/plugin/TestPlugin.py
@@ -82,10 +82,10 @@ class TestFrameVar(TestBase):
         )
 
         # A completion for a full namespace should contain the plugins in that namespace.
-        self.completions_contain("plugin list abi", ["abi.sysv-x86_64"])
-        self.completions_contain("plugin list abi.", ["abi.sysv-x86_64"])
-        self.completions_contain("plugin list abi.s", ["abi.sysv-x86_64"])
-        self.completions_contain("plugin list abi.sysv-x", ["abi.sysv-x86_64"])
+        self.completions_contain("plugin list object-file", ["object-file.JSON"])
+        self.completions_contain("plugin list object-file.", ["object-file.JSON"])
+        self.completions_contain("plugin list object-file.J", ["object-file.JSON"])
+        self.completions_contain("plugin list object-file.JS", ["object-file.JSON"])
 
         # Check for a completion that is a both a complete namespace and a prefix of
         # another namespace. It should return the completions for the plugins in the completed


### PR DESCRIPTION
The plugins completion test was checking completions for the abi plugins. But the available abi plugins will depend on which [targets](https://github.com/llvm/llvm-project/blob/42d2ae1034b287eb60563c370dbf52c59b66db20/lldb/source/Plugins/ABI/CMakeLists.txt#L7) are enabled in the cmake build configuration.

This PR updates the test to check for the json object file instead which should be enabled on all builds.