### PR TITLE
[libclang] Fix version for symbol clang_visitCXXMethods

### DIFF
--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -435,12 +435,12 @@ LLVM_20 {
     clang_getTypePrettyPrinted;
     clang_isBeforeInTranslationUnit;
     clang_visitCXXBaseClasses;
-    clang_visitCXXMethods;
 };
 
 LLVM_21 {
   global:
     clang_getFullyQualifiedName;
+    clang_visitCXXMethods;
     clang_Cursor_getGCCAssemblyTemplate;
     clang_Cursor_isGCCAssemblyHasGoto;
     clang_Cursor_getGCCAssemblyNumOutputs;


### PR DESCRIPTION
Happened to spot this while looking at libclang.map for other reasons. clang_visitCXXMethods was added in LLVM 21, not LLVM 20.