### PR TITLE
[Clang] Fix FE crash during CGCoroutine GRO Alloca Emission

### DIFF
--- a/clang/lib/CodeGen/CGCoroutine.cpp
+++ b/clang/lib/CodeGen/CGCoroutine.cpp
@@ -707,11 +707,15 @@ struct GetReturnObjectManager {
     Builder.CreateStore(Builder.getFalse(), GroActiveFlag);
 
     GroEmission = CGF.EmitAutoVarAlloca(*GroVarDecl);
-    auto *GroAlloca = dyn_cast_or_null<llvm::AllocaInst>(
-        GroEmission.getOriginalAllocatedAddress().getPointer());
-    assert(GroAlloca && "expected alloca to be emitted");
-    GroAlloca->setMetadata(llvm::LLVMContext::MD_coro_outside_frame,
-                           llvm::MDNode::get(CGF.CGM.getLLVMContext(), {}));
+
+    if (!GroVarDecl->isNRVOVariable()) {
+      // NRVO variables don't have allocas and won't have the same issue.
+      auto *GroAlloca = dyn_cast_or_null<llvm::AllocaInst>(
+          GroEmission.getOriginalAllocatedAddress().getPointer());
+      assert(GroAlloca && "expected alloca to be emitted");
+      GroAlloca->setMetadata(llvm::LLVMContext::MD_coro_outside_frame,
+                             llvm::MDNode::get(CGF.CGM.getLLVMContext(), {}));
+    }
 
     // Remember the top of EHStack before emitting the cleanup.
     auto old_top = CGF.EHStack.stable_begin();


### PR DESCRIPTION
Fixes: https://github.com/llvm/llvm-project/issues/148953

Currently when coroutine return object type is const qualified, we don't do direct emission. The regular emission logic assumed that the auto var emission will always result in an `AllocaInst`. However, based on my findings, NRVO var emissions don't result in `AllocaInst`s. Therefore, this [assertion](https://github.com/llvm/llvm-project/blob/1a940bfff9176fb38a71b0045d7ae25df9a4ca7d/clang/lib/CodeGen/CGCoroutine.cpp#L712) will fail. 

Since the NRVOed returned object don't live on the coroutine frame, we won't have the problem of it outliving the coroutine frame, therefore, we can safely omit this metadata. 