### PR TITLE
[lld-macho] Enable Linker Optimization Hints pass for arm64_32

### DIFF
--- a/lld/MachO/LinkerOptimizationHints.cpp
+++ b/lld/MachO/LinkerOptimizationHints.cpp
@@ -351,9 +351,6 @@ static void applyAdrpLdrGotLdr(uint8_t *buf, const ConcatInputSection *isec,
       return;
     if (ldr3.baseRegister != ldr2.destRegister)
       return;
-    // Loads from the GOT must be pointer sized.
-    if (ldr2.p2Size != 3 || ldr2.isFloat)
-      return;
     applyAdrpLdr(buf, isec, offset1, offset2);
   }
 }

--- a/lld/MachO/Writer.cpp
+++ b/lld/MachO/Writer.cpp
@@ -1210,7 +1210,8 @@ void Writer::writeSections() {
 }
 
 void Writer::applyOptimizationHints() {
-  if (config->arch() != AK_arm64 || config->ignoreOptimizationHints)
+  if (!is_contained({AK_arm64, AK_arm64e, AK_arm64_32}, config->arch()) ||
+      config->ignoreOptimizationHints)
     return;
 
   uint8_t *buf = buffer->getBufferStart();

--- a/lld/test/MachO/loh-arm64-32.s
+++ b/lld/test/MachO/loh-arm64-32.s
@@ -1,0 +1,64 @@
+# REQUIRES: aarch64
+
+# RUN: llvm-mc -filetype=obj -triple=arm64_32-apple-watchos %s -o %t.o
+# RUN: %lld-watchos -U _external %t.o -o %t
+# RUN: llvm-objdump -d --macho %t | FileCheck %s
+
+.text
+.align 2
+.globl _foo
+_foo:
+    ret
+.globl _bar
+_bar:
+    ret
+
+.globl _main
+_main:
+# CHECK-LABEL: _main:
+
+L1: adrp x0, _foo@PAGE
+L2: add  x0, x0, _foo@PAGEOFF
+# CHECK-NEXT: adr x0
+# CHECK-NEXT: nop
+
+L3: adrp x0, _ptr@PAGE
+L4: add  x1, x0, _ptr@PAGEOFF
+L5: ldr  x2, [x1]
+# CHECK-NEXT: nop
+# CHECK-NEXT: nop
+# CHECK-NEXT: ldr x2
+
+L6: adrp x0, _foo@PAGE
+L7: adrp x0, _bar@PAGE
+# CHECK-NEXT: adrp x0
+# CHECK-NEXT: nop
+
+L8: adrp x0, _ptr@PAGE
+L9: ldr  x0, [x0, _ptr@PAGEOFF]
+# CHECK-NEXT: nop
+# CHECK-NEXT: ldr x0
+
+L10: adrp x0, _ptr@PAGE
+L11: ldr  w0, [x0, _ptr@PAGEOFF]
+# CHECK-NEXT: nop
+# CHECK-NEXT: ldr w0, _ptr
+
+L12: adrp x0, _external@PAGE
+L13: ldr  w1, [x0, _external@PAGEOFF]
+L14: ldr  x2, [x1]
+# CHECK-NEXT: nop
+# CHECK-NEXT: ldr w1, 0x{{.*}}
+# CHECK-NEXT: ldr x2, [x1]
+
+.data
+.align 4
+_ptr:
+    .quad 0
+
+.loh AdrpAdd L1, L2
+.loh AdrpAddLdr L3, L4, L5
+.loh AdrpAdrp L6, L7
+.loh AdrpLdr L8, L9
+.loh AdrpLdrGot L10, L11
+.loh AdrpLdrGotLdr L12, L13, L14


### PR DESCRIPTION
The backend emits `.loh` directives for arm64_32 as well. Our pass already handles 32-bit pointer loads correctly (there was an extraneous sanity check for 8-byte pointer sizes, I removed that here), so we can enable them for both arm64 subtargets, as well as our upcoming arm64e support.

This commit moves the functionality out of the arm64 `TargetInfo` into a standalone file.
