### PR TITLE
[LifetimeSafety] Implement LiveOrigins analysis

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LifetimeSafety.h
+++ b/clang/include/clang/Analysis/Analyses/LifetimeSafety.h
@@ -34,6 +34,7 @@ class Fact;
 class FactManager;
 class LoanPropagationAnalysis;
 class ExpiredLoansAnalysis;
+class LiveOriginAnalysis;
 struct LifetimeFactory;
 
 /// A generic, type-safe wrapper for an ID, distinguished by its `Tag` type.
@@ -97,6 +98,9 @@ public:
   /// their Path.
   std::vector<LoanID> getLoanIDForVar(const VarDecl *VD) const;
 
+  /// Returns the set of live origins at a specific program point.
+  OriginSet getLiveOriginsAtPoint(ProgramPoint PP) const;
+
   /// Retrieves program points that were specially marked in the source code
   /// for testing.
   ///
@@ -114,6 +118,7 @@ private:
   std::unique_ptr<FactManager> FactMgr;
   std::unique_ptr<LoanPropagationAnalysis> LoanPropagation;
   std::unique_ptr<ExpiredLoansAnalysis> ExpiredLoans;
+  std::unique_ptr<LiveOriginAnalysis> LiveOrigins;
 };
 } // namespace internal
 } // namespace clang::lifetimes

--- a/clang/lib/Analysis/LifetimeSafety.cpp
+++ b/clang/lib/Analysis/LifetimeSafety.cpp
@@ -721,12 +721,14 @@ join(llvm::ImmutableMap<K, V> A, llvm::ImmutableMap<K, V> B,
 // ========================================================================= //
 
 using OriginLoanMap = llvm::ImmutableMap<OriginID, LoanSet>;
+using OriginSet = llvm::ImmutableSet<OriginID>;
 
 /// An object to hold the factories for immutable collections, ensuring
 /// that all created states share the same underlying memory management.
 struct LifetimeFactory {
   OriginLoanMap::Factory OriginMapFactory;
   LoanSet::Factory LoanSetFactory;
+  OriginSet::Factory OriginSetFactory;
 
   /// Creates a singleton set containing only the given loan ID.
   LoanSet createLoanSet(LoanID LID) {
@@ -824,6 +826,78 @@ private:
     if (auto *Loans = L.Origins.lookup(OID))
       return *Loans;
     return Factory.LoanSetFactory.getEmptySet();
+  }
+};
+
+// ========================================================================= //
+//                         Live Origins Analysis
+// ========================================================================= //
+
+/// The dataflow lattice for origin liveness analysis.
+/// It tracks the set of origins that are live at a given program point.
+struct LivenessLattice {
+  OriginSet LiveOrigins;
+
+  LivenessLattice() : LiveOrigins(nullptr) {};
+  explicit LivenessLattice(OriginSet S) : LiveOrigins(S) {}
+
+  bool operator==(const LivenessLattice &Other) const {
+    return LiveOrigins == Other.LiveOrigins;
+  }
+  bool operator!=(const LivenessLattice &Other) const {
+    return !(*this == Other);
+  }
+
+  void dump(llvm::raw_ostream &OS) const {
+    OS << "LivenessLattice State:\n";
+    if (LiveOrigins.isEmpty())
+      OS << "  <empty>\n";
+    for (const OriginID &OID : LiveOrigins)
+      OS << "  Origin " << OID << " is live\n";
+  }
+};
+
+/// The analysis that tracks which origins are live. This is a backward
+/// analysis.
+class LiveOriginAnalysis
+    : public DataflowAnalysis<LiveOriginAnalysis, LivenessLattice,
+                              Direction::Backward> {
+
+  OriginSet::Factory &SetFactory;
+
+public:
+  LiveOriginAnalysis(const CFG &C, AnalysisDeclContext &AC, FactManager &F,
+                     OriginSet::Factory &SF)
+      : DataflowAnalysis(C, AC, F), SetFactory(SF) {}
+
+  using DataflowAnalysis<LiveOriginAnalysis, Lattice,
+                         Direction::Backward>::transfer;
+
+  StringRef getAnalysisName() const { return "LiveOrigins"; }
+
+  Lattice getInitialState() { return Lattice(SetFactory.getEmptySet()); }
+
+  /// Merges two lattices by taking the union of the live origin sets.
+  Lattice join(Lattice L1, Lattice L2) const {
+    return Lattice(utils::join(L1.LiveOrigins, L2.LiveOrigins, SetFactory));
+  }
+
+  /// An assignment `p = q` kills the liveness of `p` and generates liveness
+  /// for `q`.
+  Lattice transfer(Lattice In, const AssignOriginFact &F) {
+    OriginSet S = SetFactory.remove(In.LiveOrigins, F.getDestOriginID());
+    S = SetFactory.add(S, F.getSrcOriginID());
+    return Lattice(S);
+  }
+
+  /// Issuing a new loan to an origin kills its liveness.
+  Lattice transfer(Lattice In, const IssueFact &F) {
+    return Lattice(SetFactory.remove(In.LiveOrigins, F.getOriginID()));
+  }
+
+  /// A return statement generates liveness for the returned origin.
+  Lattice transfer(Lattice In, const ReturnOfOriginFact &F) {
+    return Lattice(SetFactory.add(In.LiveOrigins, F.getReturnedOriginID()));
   }
 };
 
@@ -957,6 +1031,10 @@ void LifetimeSafetyAnalysis::run() {
   ExpiredLoans =
       std::make_unique<ExpiredLoansAnalysis>(Cfg, AC, *FactMgr, *Factory);
   ExpiredLoans->run();
+
+  LiveOrigins = std::make_unique<LiveOriginAnalysis>(Cfg, AC, *FactMgr,
+                                                     Factory->OriginSetFactory);
+  LiveOrigins->run();
 }
 
 LoanSet LifetimeSafetyAnalysis::getLoansAtPoint(OriginID OID,
@@ -987,6 +1065,11 @@ LifetimeSafetyAnalysis::getLoanIDForVar(const VarDecl *VD) const {
     if (L.Path.D == VD)
       Result.push_back(L.ID);
   return Result;
+}
+
+OriginSet LifetimeSafetyAnalysis::getLiveOriginsAtPoint(ProgramPoint PP) const {
+  assert(LiveOrigins && "LiveOriginAnalysis has not been run.");
+  return LiveOrigins->getState(PP).LiveOrigins;
 }
 
 llvm::StringMap<ProgramPoint> LifetimeSafetyAnalysis::getTestPoints() const {


### PR DESCRIPTION
Add a live origins analysis to the lifetime safety checker.

This PR introduces a new backward dataflow analysis called `LiveOriginAnalysis` that tracks which origins are live at each program point. The analysis:

- Uses a `LivenessLattice` structure to represent the set of live origins
- Implements transfer functions for assignment, loan issuance, and return statements
- Joins lattices by taking the union of live origin sets
