### PR TITLE
[lldb][rpc] Use Clang attributes to keep track of pointer plus len

### DIFF
--- a/lldb/include/lldb/API/SBData.h
+++ b/lldb/include/lldb/API/SBData.h
@@ -69,6 +69,7 @@ public:
 
   const char *GetString(lldb::SBError &error, lldb::offset_t offset);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t ReadRawData(lldb::SBError &error, lldb::offset_t offset, void *buf,
                      size_t size);
 
@@ -80,9 +81,11 @@ public:
   // DataExtractor, but having two SetData() signatures triggers a SWIG bug
   // where the typemap isn't applied before resolving the overload, and thus
   // the right function never gets called
+  LLDB_RPC_POINTER_PLUS_LEN
   void SetData(lldb::SBError &error, const void *buf, size_t size,
                lldb::ByteOrder endian, uint8_t addr_size);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   void SetDataWithOwnership(lldb::SBError &error, const void *buf, size_t size,
                             lldb::ByteOrder endian, uint8_t addr_size);
 
@@ -96,26 +99,31 @@ public:
   // in the following CreateData*() and SetData*() prototypes, the two
   // parameters array and array_len should not be renamed or rearranged,
   // because doing so will break the SWIG typemap
+  LLDB_RPC_POINTER_PLUS_LEN
   static lldb::SBData CreateDataFromUInt64Array(lldb::ByteOrder endian,
                                                 uint32_t addr_byte_size,
                                                 uint64_t *array,
                                                 size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   static lldb::SBData CreateDataFromUInt32Array(lldb::ByteOrder endian,
                                                 uint32_t addr_byte_size,
                                                 uint32_t *array,
                                                 size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   static lldb::SBData CreateDataFromSInt64Array(lldb::ByteOrder endian,
                                                 uint32_t addr_byte_size,
                                                 int64_t *array,
                                                 size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   static lldb::SBData CreateDataFromSInt32Array(lldb::ByteOrder endian,
                                                 uint32_t addr_byte_size,
                                                 int32_t *array,
                                                 size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   static lldb::SBData CreateDataFromDoubleArray(lldb::ByteOrder endian,
                                                 uint32_t addr_byte_size,
                                                 double *array,
@@ -123,14 +131,19 @@ public:
 
   bool SetDataFromCString(const char *data);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   bool SetDataFromUInt64Array(uint64_t *array, size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   bool SetDataFromUInt32Array(uint32_t *array, size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   bool SetDataFromSInt64Array(int64_t *array, size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   bool SetDataFromSInt32Array(int32_t *array, size_t array_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   bool SetDataFromDoubleArray(double *array, size_t array_len);
 
 protected:

--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -421,6 +421,7 @@ public:
   bool GetUseSourceCache() const;
 
   /// Get the default architecture.
+  LLDB_RPC_POINTER_PLUS_LEN
   static bool GetDefaultArchitecture(char *arch_name, size_t arch_name_len);
 
   /// Set the default architecture.
@@ -476,6 +477,7 @@ public:
 #endif
 
   /// Dispatch input to the debugger.
+  LLDB_RPC_POINTER_PLUS_LEN
   void DispatchInput(const void *data, size_t data_len);
 
   /// Interrupt the current input dispatch.

--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -39,6 +39,13 @@
 #define LLDB_DEPRECATED_FIXME(MSG, FIX)
 #endif
 
+#if defined(LLDB_RPC_GEN)
+#define LLDB_RPC_POINTER_PLUS_LEN                                              \
+  __attribute__((annotate("lldb-rpc-gen pointer plus len")))
+#else
+#define LLDB_RPC_POINTER_PLUS_LEN
+#endif
+
 // Forward Declarations
 namespace lldb {
 

--- a/lldb/include/lldb/API/SBFile.h
+++ b/lldb/include/lldb/API/SBFile.h
@@ -34,7 +34,9 @@ public:
 
   SBFile &operator=(const SBFile &rhs);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   SBError Read(uint8_t *buf, size_t num_bytes, size_t *OUTPUT);
+  LLDB_RPC_POINTER_PLUS_LEN
   SBError Write(const uint8_t *buf, size_t num_bytes, size_t *OUTPUT);
   SBError Flush();
   bool IsValid() const;

--- a/lldb/include/lldb/API/SBFileSpec.h
+++ b/lldb/include/lldb/API/SBFileSpec.h
@@ -51,8 +51,10 @@ public:
 
   void SetDirectory(const char *directory);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   uint32_t GetPath(char *dst_path, size_t dst_len) const;
 
+  LLDB_RPC_POINTER_PLUS_LEN
   static int ResolvePath(const char *src_path, char *dst_path, size_t dst_len);
 
   bool GetDescription(lldb::SBStream &description) const;

--- a/lldb/include/lldb/API/SBModule.h
+++ b/lldb/include/lldb/API/SBModule.h
@@ -274,6 +274,7 @@ public:
   ///     This function always returns the number of version numbers
   ///     that this object file has regardless of the number of
   ///     version numbers that were copied into \a versions.
+  LLDB_RPC_POINTER_PLUS_LEN
   uint32_t GetVersion(uint32_t *versions, uint32_t num_versions);
 
   /// Get accessor for the symbol file specification.

--- a/lldb/include/lldb/API/SBModuleSpec.h
+++ b/lldb/include/lldb/API/SBModuleSpec.h
@@ -71,6 +71,7 @@ public:
 
   void SetTriple(const char *triple);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   const uint8_t *GetUUIDBytes();
 
   size_t GetUUIDLength();

--- a/lldb/include/lldb/API/SBProcess.h
+++ b/lldb/include/lldb/API/SBProcess.h
@@ -63,10 +63,13 @@ public:
 
   size_t PutSTDIN(const char *src, size_t src_len);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t GetSTDOUT(char *dst, size_t dst_len) const;
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t GetSTDERR(char *dst, size_t dst_len) const;
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t GetAsyncProfileData(char *dst, size_t dst_len) const;
 
 #ifndef SWIG
@@ -197,11 +200,14 @@ public:
   ///
   void ForceScriptedState(StateType new_state);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t ReadMemory(addr_t addr, void *buf, size_t size, lldb::SBError &error);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t WriteMemory(addr_t addr, const void *buf, size_t size,
                      lldb::SBError &error);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t ReadCStringFromMemory(addr_t addr, void *char_buf, size_t size,
                                lldb::SBError &error);
 

--- a/lldb/include/lldb/API/SBStructuredData.h
+++ b/lldb/include/lldb/API/SBStructuredData.h
@@ -104,6 +104,7 @@ public:
   /// \return
   ///     Returns the byte size needed to completely write the string value at
   ///     \a dst in all cases.
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t GetStringValue(char *dst, size_t dst_len) const;
 
   /// Return the generic pointer if this data structure is a generic type.

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -607,6 +607,7 @@ public:
   ///
   /// \return
   ///     The amount of data read in host bytes.
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t ReadMemory(const SBAddress addr, void *buf, size_t size,
                     lldb::SBError &error);
 
@@ -688,12 +689,13 @@ public:
       const SBFileSpecList &module_list,
       const SBFileSpecList &comp_unit_list);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   lldb::SBBreakpoint BreakpointCreateByNames(
       const char *symbol_name[], uint32_t num_names,
       uint32_t
           name_type_mask, // Logical OR one or more FunctionNameType enum bits
-      lldb::LanguageType symbol_language,
-      const SBFileSpecList &module_list, const SBFileSpecList &comp_unit_list);
+      lldb::LanguageType symbol_language, const SBFileSpecList &module_list,
+      const SBFileSpecList &comp_unit_list);
 
   lldb::SBBreakpoint BreakpointCreateByNames(
       const char *symbol_name[], uint32_t num_names,
@@ -900,20 +902,24 @@ public:
                                            lldb::SBAddress end_addr,
                                            const char *flavor_string);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   lldb::SBInstructionList GetInstructions(lldb::SBAddress base_addr,
                                           const void *buf, size_t size);
 
   // The "WithFlavor" is necessary to keep SWIG from getting confused about
   // overloaded arguments when using the buf + size -> Python Object magic.
 
+  LLDB_RPC_POINTER_PLUS_LEN
   lldb::SBInstructionList GetInstructionsWithFlavor(lldb::SBAddress base_addr,
                                                     const char *flavor_string,
                                                     const void *buf,
                                                     size_t size);
 
 #ifndef SWIG
+  LLDB_RPC_POINTER_PLUS_LEN
   lldb::SBInstructionList GetInstructions(lldb::addr_t base_addr,
                                           const void *buf, size_t size);
+  LLDB_RPC_POINTER_PLUS_LEN
   lldb::SBInstructionList GetInstructionsWithFlavor(lldb::addr_t base_addr,
                                                     const char *flavor_string,
                                                     const void *buf,

--- a/lldb/include/lldb/API/SBThread.h
+++ b/lldb/include/lldb/API/SBThread.h
@@ -81,6 +81,7 @@ public:
   SBThreadCollection
   GetStopReasonExtendedBacktraces(InstrumentationRuntimeType type);
 
+  LLDB_RPC_POINTER_PLUS_LEN
   size_t GetStopDescription(char *dst_or_null, size_t dst_len);
 
   SBValue GetStopReturnValue();

--- a/lldb/tools/lldb-rpc-gen/RPCCommon.h
+++ b/lldb/tools/lldb-rpc-gen/RPCCommon.h
@@ -32,6 +32,7 @@ bool TypeIsDisallowedClass(QualType T);
 bool TypeIsCallbackFunctionPointer(QualType T);
 
 bool MethodIsDisallowed(ASTContext &Context, CXXMethodDecl *MDecl);
+bool MethodContainsPointerPlusLen(CXXMethodDecl *MDecl);
 
 std::string ReplaceLLDBNamespaceWithRPCNamespace(std::string Name);
 std::string StripLLDBNamespace(std::string Name);

--- a/lldb/tools/lldb-rpc/LLDBRPCGeneration.cmake
+++ b/lldb/tools/lldb-rpc/LLDBRPCGeneration.cmake
@@ -78,3 +78,7 @@ add_custom_target(lldb-rpc-generate-sources
   lldb-sbapi-dwarf-enums)
 
 add_dependencies(lldb-rpc-generate-sources clang-resource-headers)
+
+# Add a compile definition to liblldb in order to create a macro for
+# a Clang attribute for lldb-rpc-gen.
+target_compile_definitions(liblldb PUBLIC LLDB_RPC_GEN)


### PR DESCRIPTION
In LLDB RPC, we need to keep track of methods that have a pointer parameter followed by a lengtgh parameter as these parameters need some exceptions when they're being emitted by lldb-rpc-gen. Previously, we used an exception list to keep track of every method that fell under this category using their mangled names. This method worked, but manually maintaining an exception list this way is unwieldly and can lead to hard-to-track errors for clients that use RPC and forget to add a method that they use to said list.

This commit changes this by using the Clang annotation attribute to annotate every method that uses a pointer plus length directly in the SB API, and checks that a given method has this attribute when determining if a method has a pointer plus length.