### PR TITLE
[OpenMP] Simplify GNU strerror_r check for Android

### DIFF
--- a/openmp/runtime/src/kmp_i18n.cpp
+++ b/openmp/runtime/src/kmp_i18n.cpp
@@ -708,9 +708,7 @@ static char *sys_error(int err) {
      int    strerror_r( int, char *, size_t );  // XSI version
   */
 
-#if (defined(__GLIBC__) && defined(_GNU_SOURCE)) ||                            \
-    (defined(__BIONIC__) && defined(_GNU_SOURCE) &&                            \
-     __ANDROID_API__ >= __ANDROID_API_M__)
+#if (defined(__GLIBC__) || defined(__BIONIC__)) && defined(_GNU_SOURCE)
   // GNU version of strerror_r.
 
   char buffer[2048];


### PR DESCRIPTION
Android 6 is the baseline so simplify the Android check.