### PR TITLE
[MLIR] Fold TOSA truthy boolean to i32 with 1 instead of -1

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1303,7 +1303,8 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
 
       if (trunc) {
         intVal = intVal.trunc(bitwidth);
-      } else if (unsignIn) {
+      } else if (unsignIn || inETy.getIntOrFloatBitWidth() == 1) {
+        // Casting from i1 to iX will treat it as unsigned.
         intVal = intVal.zext(bitwidth);
       } else {
         intVal = intVal.sext(bitwidth);

--- a/mlir/test/Dialect/Tosa/constant-op-fold.mlir
+++ b/mlir/test/Dialect/Tosa/constant-op-fold.mlir
@@ -598,7 +598,7 @@ func.func @cast_int_to_int_sign() -> tensor<i32> {
 // CHECK: func.func @cast_i1_true_to_i32
 func.func @cast_i1_true_to_i32() -> tensor<i32> {
   %splat = "tosa.const"() {values = dense<true> : tensor<i1>} : () -> tensor<i1>
-  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-1> : tensor<i32>}
+  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<1> : tensor<i32>}
   %cast = tosa.cast %splat : (tensor<i1>) -> tensor<i32>
   // CHECK: return %[[SPLAT]]
   return %cast : tensor<i32>

--- a/mlir/test/Dialect/Tosa/constant-op-fold.mlir
+++ b/mlir/test/Dialect/Tosa/constant-op-fold.mlir
@@ -594,6 +594,16 @@ func.func @cast_int_to_int_sign() -> tensor<i32> {
   return %cast : tensor<i32>
 }
 
+
+// CHECK: func.func @cast_i1_true_to_i32
+func.func @cast_i1_true_to_i32() -> tensor<i32> {
+  %splat = "tosa.const"() {values = dense<true> : tensor<i1>} : () -> tensor<i1>
+  // CHECK: %[[SPLAT:.+]] = "tosa.const"() <{values = dense<-1> : tensor<i32>}
+  %cast = tosa.cast %splat : (tensor<i1>) -> tensor<i32>
+  // CHECK: return %[[SPLAT]]
+  return %cast : tensor<i32>
+}
+
 // -----
 
 // CHECK-LABEL: @reverse_splat


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/148846.

I don't think there's a spec on https://mlir.llvm.org/docs/Dialects/TOSA/#tosacast-mlirtosacastop that details how casting from i1 to i32 should happen but from the issue and from the godbolt https://godbolt.org/z/qTEraE3nh, it seems reasonable to implement this.

Would love some feedback on this as its my first time contributing to MLIR specifically 