### PR TITLE
[sanitizer_common][nfc] Rename `tid_t` to avoid conflicting declarations

### DIFF
--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -282,7 +282,7 @@ void AsanThread::Init(const InitOptions *options) {
 // asan_fuchsia.c definies CreateMainThread and SetThreadStackAndTls.
 #if !SANITIZER_FUCHSIA
 
-void AsanThread::ThreadStart(thid_t os_id) {
+void AsanThread::ThreadStart(ThreadID os_id) {
   Init();
   asanThreadRegistry().StartThread(tid(), os_id, ThreadType::Regular, nullptr);
 
@@ -469,7 +469,7 @@ void EnsureMainThreadIDIsCorrect() {
     context->os_id = GetTid();
 }
 
-__asan::AsanThread *GetAsanThreadByOsIDLocked(thid_t os_id) {
+__asan::AsanThread *GetAsanThreadByOsIDLocked(ThreadID os_id) {
   __asan::AsanThreadContext *context = static_cast<__asan::AsanThreadContext *>(
       __asan::asanThreadRegistry().FindThreadContextByOsIDLocked(os_id));
   if (!context)
@@ -497,7 +497,7 @@ static ThreadRegistry *GetAsanThreadRegistryLocked() {
 
 void EnsureMainThreadIDIsCorrect() { __asan::EnsureMainThreadIDIsCorrect(); }
 
-bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(ThreadID os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls) {
   __asan::AsanThread *t = __asan::GetAsanThreadByOsIDLocked(os_id);
@@ -516,7 +516,7 @@ bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
 
 void GetAllThreadAllocatorCachesLocked(InternalMmapVector<uptr> *caches) {}
 
-void GetThreadExtraStackRangesLocked(thid_t os_id,
+void GetThreadExtraStackRangesLocked(ThreadID os_id,
                                      InternalMmapVector<Range> *ranges) {
   __asan::AsanThread *t = __asan::GetAsanThreadByOsIDLocked(os_id);
   if (!t)
@@ -546,11 +546,11 @@ void GetAdditionalThreadContextPtrsLocked(InternalMmapVector<uptr> *ptrs) {
   __asan::asanThreadArgRetval().GetAllPtrsLocked(ptrs);
 }
 
-void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads) {
+void GetRunningThreadsLocked(InternalMmapVector<ThreadID> *threads) {
   GetAsanThreadRegistryLocked()->RunCallbackForEachThreadLocked(
       [](ThreadContextBase *tctx, void *threads) {
         if (tctx->status == ThreadStatusRunning)
-          reinterpret_cast<InternalMmapVector<thid_t> *>(threads)->push_back(
+          reinterpret_cast<InternalMmapVector<ThreadID> *>(threads)->push_back(
               tctx->os_id);
       },
       threads);

--- a/compiler-rt/lib/asan/asan_thread.cpp
+++ b/compiler-rt/lib/asan/asan_thread.cpp
@@ -282,7 +282,7 @@ void AsanThread::Init(const InitOptions *options) {
 // asan_fuchsia.c definies CreateMainThread and SetThreadStackAndTls.
 #if !SANITIZER_FUCHSIA
 
-void AsanThread::ThreadStart(tid_t os_id) {
+void AsanThread::ThreadStart(thid_t os_id) {
   Init();
   asanThreadRegistry().StartThread(tid(), os_id, ThreadType::Regular, nullptr);
 
@@ -469,7 +469,7 @@ void EnsureMainThreadIDIsCorrect() {
     context->os_id = GetTid();
 }
 
-__asan::AsanThread *GetAsanThreadByOsIDLocked(tid_t os_id) {
+__asan::AsanThread *GetAsanThreadByOsIDLocked(thid_t os_id) {
   __asan::AsanThreadContext *context = static_cast<__asan::AsanThreadContext *>(
       __asan::asanThreadRegistry().FindThreadContextByOsIDLocked(os_id));
   if (!context)
@@ -497,7 +497,7 @@ static ThreadRegistry *GetAsanThreadRegistryLocked() {
 
 void EnsureMainThreadIDIsCorrect() { __asan::EnsureMainThreadIDIsCorrect(); }
 
-bool GetThreadRangesLocked(tid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls) {
   __asan::AsanThread *t = __asan::GetAsanThreadByOsIDLocked(os_id);
@@ -516,7 +516,7 @@ bool GetThreadRangesLocked(tid_t os_id, uptr *stack_begin, uptr *stack_end,
 
 void GetAllThreadAllocatorCachesLocked(InternalMmapVector<uptr> *caches) {}
 
-void GetThreadExtraStackRangesLocked(tid_t os_id,
+void GetThreadExtraStackRangesLocked(thid_t os_id,
                                      InternalMmapVector<Range> *ranges) {
   __asan::AsanThread *t = __asan::GetAsanThreadByOsIDLocked(os_id);
   if (!t)
@@ -546,11 +546,11 @@ void GetAdditionalThreadContextPtrsLocked(InternalMmapVector<uptr> *ptrs) {
   __asan::asanThreadArgRetval().GetAllPtrsLocked(ptrs);
 }
 
-void GetRunningThreadsLocked(InternalMmapVector<tid_t> *threads) {
+void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads) {
   GetAsanThreadRegistryLocked()->RunCallbackForEachThreadLocked(
       [](ThreadContextBase *tctx, void *threads) {
         if (tctx->status == ThreadStatusRunning)
-          reinterpret_cast<InternalMmapVector<tid_t> *>(threads)->push_back(
+          reinterpret_cast<InternalMmapVector<thid_t> *>(threads)->push_back(
               tctx->os_id);
       },
       threads);

--- a/compiler-rt/lib/asan/asan_thread.h
+++ b/compiler-rt/lib/asan/asan_thread.h
@@ -75,7 +75,7 @@ class AsanThread {
   struct InitOptions;
   void Init(const InitOptions *options = nullptr);
 
-  void ThreadStart(thid_t os_id);
+  void ThreadStart(ThreadID os_id);
   thread_return_t RunThread();
 
   uptr stack_top();

--- a/compiler-rt/lib/asan/asan_thread.h
+++ b/compiler-rt/lib/asan/asan_thread.h
@@ -75,7 +75,7 @@ class AsanThread {
   struct InitOptions;
   void Init(const InitOptions *options = nullptr);
 
-  void ThreadStart(tid_t os_id);
+  void ThreadStart(thid_t os_id);
   thread_return_t RunThread();
 
   uptr stack_top();

--- a/compiler-rt/lib/hwasan/hwasan_thread.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_thread.cpp
@@ -174,7 +174,7 @@ static __hwasan::HwasanThreadList *GetHwasanThreadListLocked() {
   return &tl;
 }
 
-static __hwasan::Thread *GetThreadByOsIDLocked(thid_t os_id) {
+static __hwasan::Thread *GetThreadByOsIDLocked(ThreadID os_id) {
   return GetHwasanThreadListLocked()->FindThreadLocked(
       [os_id](__hwasan::Thread *t) { return t->os_id() == os_id; });
 }
@@ -191,7 +191,7 @@ void UnlockThreads() {
 
 void EnsureMainThreadIDIsCorrect() { __hwasan::EnsureMainThreadIDIsCorrect(); }
 
-bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(ThreadID os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls) {
   auto *t = GetThreadByOsIDLocked(os_id);
@@ -210,7 +210,7 @@ bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
 
 void GetAllThreadAllocatorCachesLocked(InternalMmapVector<uptr> *caches) {}
 
-void GetThreadExtraStackRangesLocked(thid_t os_id,
+void GetThreadExtraStackRangesLocked(ThreadID os_id,
                                      InternalMmapVector<Range> *ranges) {}
 void GetThreadExtraStackRangesLocked(InternalMmapVector<Range> *ranges) {}
 
@@ -218,7 +218,7 @@ void GetAdditionalThreadContextPtrsLocked(InternalMmapVector<uptr> *ptrs) {
   __hwasan::hwasanThreadArgRetval().GetAllPtrsLocked(ptrs);
 }
 
-void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads) {
+void GetRunningThreadsLocked(InternalMmapVector<ThreadID> *threads) {
   // TODO: implement.
 }
 void PrintThreads() {

--- a/compiler-rt/lib/hwasan/hwasan_thread.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_thread.cpp
@@ -174,7 +174,7 @@ static __hwasan::HwasanThreadList *GetHwasanThreadListLocked() {
   return &tl;
 }
 
-static __hwasan::Thread *GetThreadByOsIDLocked(tid_t os_id) {
+static __hwasan::Thread *GetThreadByOsIDLocked(thid_t os_id) {
   return GetHwasanThreadListLocked()->FindThreadLocked(
       [os_id](__hwasan::Thread *t) { return t->os_id() == os_id; });
 }
@@ -191,7 +191,7 @@ void UnlockThreads() {
 
 void EnsureMainThreadIDIsCorrect() { __hwasan::EnsureMainThreadIDIsCorrect(); }
 
-bool GetThreadRangesLocked(tid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls) {
   auto *t = GetThreadByOsIDLocked(os_id);
@@ -210,7 +210,7 @@ bool GetThreadRangesLocked(tid_t os_id, uptr *stack_begin, uptr *stack_end,
 
 void GetAllThreadAllocatorCachesLocked(InternalMmapVector<uptr> *caches) {}
 
-void GetThreadExtraStackRangesLocked(tid_t os_id,
+void GetThreadExtraStackRangesLocked(thid_t os_id,
                                      InternalMmapVector<Range> *ranges) {}
 void GetThreadExtraStackRangesLocked(InternalMmapVector<Range> *ranges) {}
 
@@ -218,7 +218,7 @@ void GetAdditionalThreadContextPtrsLocked(InternalMmapVector<uptr> *ptrs) {
   __hwasan::hwasanThreadArgRetval().GetAllPtrsLocked(ptrs);
 }
 
-void GetRunningThreadsLocked(InternalMmapVector<tid_t> *threads) {
+void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads) {
   // TODO: implement.
 }
 void PrintThreads() {

--- a/compiler-rt/lib/hwasan/hwasan_thread.h
+++ b/compiler-rt/lib/hwasan/hwasan_thread.h
@@ -69,8 +69,8 @@ class Thread {
     Print("Thread: ");
   }
 
-  tid_t os_id() const { return os_id_; }
-  void set_os_id(tid_t os_id) { os_id_ = os_id; }
+  thid_t os_id() const { return os_id_; }
+  void set_os_id(thid_t os_id) { os_id_ = os_id; }
 
   uptr &vfork_spill() { return vfork_spill_; }
 
@@ -96,7 +96,7 @@ class Thread {
 
   u32 unique_id_;  // counting from zero.
 
-  tid_t os_id_;
+  thid_t os_id_;
 
   u32 tagging_disabled_;  // if non-zero, malloc uses zero tag in this thread.
 

--- a/compiler-rt/lib/hwasan/hwasan_thread.h
+++ b/compiler-rt/lib/hwasan/hwasan_thread.h
@@ -69,8 +69,8 @@ class Thread {
     Print("Thread: ");
   }
 
-  thid_t os_id() const { return os_id_; }
-  void set_os_id(thid_t os_id) { os_id_ = os_id; }
+  ThreadID os_id() const { return os_id_; }
+  void set_os_id(ThreadID os_id) { os_id_ = os_id; }
 
   uptr &vfork_spill() { return vfork_spill_; }
 
@@ -96,7 +96,7 @@ class Thread {
 
   u32 unique_id_;  // counting from zero.
 
-  thid_t os_id_;
+  ThreadID os_id_;
 
   u32 tagging_disabled_;  // if non-zero, malloc uses zero tag in this thread.
 

--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -412,7 +412,7 @@ void ScanExtraStackRanges(const InternalMmapVector<Range> &ranges,
 #  if SANITIZER_FUCHSIA
 
 // Fuchsia handles all threads together with its own callback.
-static void ProcessThreads(SuspendedThreadsList const &, Frontier *, thid_t,
+static void ProcessThreads(SuspendedThreadsList const &, Frontier *, ThreadID,
                            uptr) {}
 
 #  else
@@ -445,7 +445,7 @@ static void ProcessThreadRegistry(Frontier *frontier) {
 
 // Scans thread data (stacks and TLS) for heap pointers.
 template <class Accessor>
-static void ProcessThread(thid_t os_id, uptr sp,
+static void ProcessThread(ThreadID os_id, uptr sp,
                           const InternalMmapVector<uptr> &registers,
                           InternalMmapVector<Range> &extra_ranges,
                           Frontier *frontier, Accessor &accessor) {
@@ -556,16 +556,16 @@ static void ProcessThread(thid_t os_id, uptr sp,
 }
 
 static void ProcessThreads(SuspendedThreadsList const &suspended_threads,
-                           Frontier *frontier, thid_t caller_tid,
+                           Frontier *frontier, ThreadID caller_tid,
                            uptr caller_sp) {
-  InternalMmapVector<thid_t> done_threads;
+  InternalMmapVector<ThreadID> done_threads;
   InternalMmapVector<uptr> registers;
   InternalMmapVector<Range> extra_ranges;
   for (uptr i = 0; i < suspended_threads.ThreadCount(); i++) {
     registers.clear();
     extra_ranges.clear();
 
-    const thid_t os_id = suspended_threads.GetThreadID(i);
+    const ThreadID os_id = suspended_threads.GetThreadID(i);
     uptr sp = 0;
     PtraceRegistersStatus have_registers =
         suspended_threads.GetRegistersAndSP(i, &registers, &sp);
@@ -589,10 +589,10 @@ static void ProcessThreads(SuspendedThreadsList const &suspended_threads,
 
   if (flags()->use_detached) {
     CopyMemoryAccessor accessor;
-    InternalMmapVector<thid_t> known_threads;
+    InternalMmapVector<ThreadID> known_threads;
     GetRunningThreadsLocked(&known_threads);
     Sort(done_threads.data(), done_threads.size());
-    for (thid_t os_id : known_threads) {
+    for (ThreadID os_id : known_threads) {
       registers.clear();
       extra_ranges.clear();
 
@@ -712,7 +712,7 @@ static void CollectIgnoredCb(uptr chunk, void *arg) {
 
 // Sets the appropriate tag on each chunk.
 static void ClassifyAllChunks(SuspendedThreadsList const &suspended_threads,
-                              Frontier *frontier, thid_t caller_tid,
+                              Frontier *frontier, ThreadID caller_tid,
                               uptr caller_sp) {
   const InternalMmapVector<u32> &suppressed_stacks =
       GetSuppressionContext()->GetSortedSuppressedStacks();
@@ -790,13 +790,13 @@ static bool ReportUnsuspendedThreads(const SuspendedThreadsList &) {
 
 static bool ReportUnsuspendedThreads(
     const SuspendedThreadsList &suspended_threads) {
-  InternalMmapVector<thid_t> threads(suspended_threads.ThreadCount());
+  InternalMmapVector<ThreadID> threads(suspended_threads.ThreadCount());
   for (uptr i = 0; i < suspended_threads.ThreadCount(); ++i)
     threads[i] = suspended_threads.GetThreadID(i);
 
   Sort(threads.data(), threads.size());
 
-  InternalMmapVector<thid_t> known_threads;
+  InternalMmapVector<ThreadID> known_threads;
   GetRunningThreadsLocked(&known_threads);
 
   bool succeded = true;

--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -412,7 +412,7 @@ void ScanExtraStackRanges(const InternalMmapVector<Range> &ranges,
 #  if SANITIZER_FUCHSIA
 
 // Fuchsia handles all threads together with its own callback.
-static void ProcessThreads(SuspendedThreadsList const &, Frontier *, tid_t,
+static void ProcessThreads(SuspendedThreadsList const &, Frontier *, thid_t,
                            uptr) {}
 
 #  else
@@ -445,7 +445,7 @@ static void ProcessThreadRegistry(Frontier *frontier) {
 
 // Scans thread data (stacks and TLS) for heap pointers.
 template <class Accessor>
-static void ProcessThread(tid_t os_id, uptr sp,
+static void ProcessThread(thid_t os_id, uptr sp,
                           const InternalMmapVector<uptr> &registers,
                           InternalMmapVector<Range> &extra_ranges,
                           Frontier *frontier, Accessor &accessor) {
@@ -556,16 +556,16 @@ static void ProcessThread(tid_t os_id, uptr sp,
 }
 
 static void ProcessThreads(SuspendedThreadsList const &suspended_threads,
-                           Frontier *frontier, tid_t caller_tid,
+                           Frontier *frontier, thid_t caller_tid,
                            uptr caller_sp) {
-  InternalMmapVector<tid_t> done_threads;
+  InternalMmapVector<thid_t> done_threads;
   InternalMmapVector<uptr> registers;
   InternalMmapVector<Range> extra_ranges;
   for (uptr i = 0; i < suspended_threads.ThreadCount(); i++) {
     registers.clear();
     extra_ranges.clear();
 
-    const tid_t os_id = suspended_threads.GetThreadID(i);
+    const thid_t os_id = suspended_threads.GetThreadID(i);
     uptr sp = 0;
     PtraceRegistersStatus have_registers =
         suspended_threads.GetRegistersAndSP(i, &registers, &sp);
@@ -589,10 +589,10 @@ static void ProcessThreads(SuspendedThreadsList const &suspended_threads,
 
   if (flags()->use_detached) {
     CopyMemoryAccessor accessor;
-    InternalMmapVector<tid_t> known_threads;
+    InternalMmapVector<thid_t> known_threads;
     GetRunningThreadsLocked(&known_threads);
     Sort(done_threads.data(), done_threads.size());
-    for (tid_t os_id : known_threads) {
+    for (thid_t os_id : known_threads) {
       registers.clear();
       extra_ranges.clear();
 
@@ -712,7 +712,7 @@ static void CollectIgnoredCb(uptr chunk, void *arg) {
 
 // Sets the appropriate tag on each chunk.
 static void ClassifyAllChunks(SuspendedThreadsList const &suspended_threads,
-                              Frontier *frontier, tid_t caller_tid,
+                              Frontier *frontier, thid_t caller_tid,
                               uptr caller_sp) {
   const InternalMmapVector<u32> &suppressed_stacks =
       GetSuppressionContext()->GetSortedSuppressedStacks();
@@ -790,13 +790,13 @@ static bool ReportUnsuspendedThreads(const SuspendedThreadsList &) {
 
 static bool ReportUnsuspendedThreads(
     const SuspendedThreadsList &suspended_threads) {
-  InternalMmapVector<tid_t> threads(suspended_threads.ThreadCount());
+  InternalMmapVector<thid_t> threads(suspended_threads.ThreadCount());
   for (uptr i = 0; i < suspended_threads.ThreadCount(); ++i)
     threads[i] = suspended_threads.GetThreadID(i);
 
   Sort(threads.data(), threads.size());
 
-  InternalMmapVector<tid_t> known_threads;
+  InternalMmapVector<thid_t> known_threads;
   GetRunningThreadsLocked(&known_threads);
 
   bool succeded = true;

--- a/compiler-rt/lib/lsan/lsan_common.h
+++ b/compiler-rt/lib/lsan/lsan_common.h
@@ -102,15 +102,15 @@ void UnlockThreads() SANITIZER_NO_THREAD_SAFETY_ANALYSIS;
 // where leak checking is initiated from a non-main thread).
 void EnsureMainThreadIDIsCorrect();
 
-bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(ThreadID os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls);
 void GetAllThreadAllocatorCachesLocked(InternalMmapVector<uptr> *caches);
 void GetThreadExtraStackRangesLocked(InternalMmapVector<Range> *ranges);
-void GetThreadExtraStackRangesLocked(thid_t os_id,
+void GetThreadExtraStackRangesLocked(ThreadID os_id,
                                      InternalMmapVector<Range> *ranges);
 void GetAdditionalThreadContextPtrsLocked(InternalMmapVector<uptr> *ptrs);
-void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads);
+void GetRunningThreadsLocked(InternalMmapVector<ThreadID> *threads);
 void PrintThreads();
 
 //// --------------------------------------------------------------------------
@@ -247,7 +247,7 @@ void ProcessPlatformSpecificAllocations(Frontier *frontier);
 struct CheckForLeaksParam {
   Frontier frontier;
   LeakedChunks leaks;
-  thid_t caller_tid;
+  ThreadID caller_tid;
   uptr caller_sp;
   bool success = false;
 };

--- a/compiler-rt/lib/lsan/lsan_common.h
+++ b/compiler-rt/lib/lsan/lsan_common.h
@@ -102,15 +102,15 @@ void UnlockThreads() SANITIZER_NO_THREAD_SAFETY_ANALYSIS;
 // where leak checking is initiated from a non-main thread).
 void EnsureMainThreadIDIsCorrect();
 
-bool GetThreadRangesLocked(tid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls);
 void GetAllThreadAllocatorCachesLocked(InternalMmapVector<uptr> *caches);
 void GetThreadExtraStackRangesLocked(InternalMmapVector<Range> *ranges);
-void GetThreadExtraStackRangesLocked(tid_t os_id,
+void GetThreadExtraStackRangesLocked(thid_t os_id,
                                      InternalMmapVector<Range> *ranges);
 void GetAdditionalThreadContextPtrsLocked(InternalMmapVector<uptr> *ptrs);
-void GetRunningThreadsLocked(InternalMmapVector<tid_t> *threads);
+void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads);
 void PrintThreads();
 
 //// --------------------------------------------------------------------------
@@ -247,7 +247,7 @@ void ProcessPlatformSpecificAllocations(Frontier *frontier);
 struct CheckForLeaksParam {
   Frontier frontier;
   LeakedChunks leaks;
-  tid_t caller_tid;
+  thid_t caller_tid;
   uptr caller_sp;
   bool success = false;
 };

--- a/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -385,7 +385,7 @@ INTERCEPTOR(void, _lwp_exit) {
 #endif
 
 #if SANITIZER_INTERCEPT_THR_EXIT
-INTERCEPTOR(void, thr_exit, thid_t *state) {
+INTERCEPTOR(void, thr_exit, ThreadID *state) {
   ENSURE_LSAN_INITED;
   ThreadFinish();
   REAL(thr_exit)(state);

--- a/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -385,7 +385,7 @@ INTERCEPTOR(void, _lwp_exit) {
 #endif
 
 #if SANITIZER_INTERCEPT_THR_EXIT
-INTERCEPTOR(void, thr_exit, tid_t *state) {
+INTERCEPTOR(void, thr_exit, thid_t *state) {
   ENSURE_LSAN_INITED;
   ThreadFinish();
   REAL(thr_exit)(state);

--- a/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -390,7 +390,7 @@ INTERCEPTOR(void, thr_exit, thid_t *state) {
   ThreadFinish();
   REAL(thr_exit)(state);
 }
-#define LSAN_MAYBE_INTERCEPT_THR_EXIT INTERCEPT_FUNCTION(thr_exit)
+#  define LSAN_MAYBE_INTERCEPT_THR_EXIT INTERCEPT_FUNCTION(thr_exit)
 #else
 #define LSAN_MAYBE_INTERCEPT_THR_EXIT
 #endif

--- a/compiler-rt/lib/lsan/lsan_posix.cpp
+++ b/compiler-rt/lib/lsan/lsan_posix.cpp
@@ -48,7 +48,7 @@ void ThreadContext::OnStarted(void *arg) {
   dtls_ = args->dtls;
 }
 
-void ThreadStart(u32 tid, thid_t os_id, ThreadType thread_type) {
+void ThreadStart(u32 tid, ThreadID os_id, ThreadType thread_type) {
   OnStartedArgs args;
   GetThreadStackAndTls(tid == kMainTid, &args.stack_begin, &args.stack_end,
                        &args.tls_begin, &args.tls_end);
@@ -57,7 +57,7 @@ void ThreadStart(u32 tid, thid_t os_id, ThreadType thread_type) {
   ThreadContextLsanBase::ThreadStart(tid, os_id, thread_type, &args);
 }
 
-bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(ThreadID os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls) {
   ThreadContext *context = static_cast<ThreadContext *>(

--- a/compiler-rt/lib/lsan/lsan_posix.cpp
+++ b/compiler-rt/lib/lsan/lsan_posix.cpp
@@ -48,7 +48,7 @@ void ThreadContext::OnStarted(void *arg) {
   dtls_ = args->dtls;
 }
 
-void ThreadStart(u32 tid, tid_t os_id, ThreadType thread_type) {
+void ThreadStart(u32 tid, thid_t os_id, ThreadType thread_type) {
   OnStartedArgs args;
   GetThreadStackAndTls(tid == kMainTid, &args.stack_begin, &args.stack_end,
                        &args.tls_begin, &args.tls_end);
@@ -57,7 +57,7 @@ void ThreadStart(u32 tid, tid_t os_id, ThreadType thread_type) {
   ThreadContextLsanBase::ThreadStart(tid, os_id, thread_type, &args);
 }
 
-bool GetThreadRangesLocked(tid_t os_id, uptr *stack_begin, uptr *stack_end,
+bool GetThreadRangesLocked(thid_t os_id, uptr *stack_begin, uptr *stack_end,
                            uptr *tls_begin, uptr *tls_end, uptr *cache_begin,
                            uptr *cache_end, DTLS **dtls) {
   ThreadContext *context = static_cast<ThreadContext *>(

--- a/compiler-rt/lib/lsan/lsan_posix.h
+++ b/compiler-rt/lib/lsan/lsan_posix.h
@@ -41,7 +41,7 @@ class ThreadContext final : public ThreadContextLsanBase {
   DTLS *dtls_ = nullptr;
 };
 
-void ThreadStart(u32 tid, tid_t os_id,
+void ThreadStart(u32 tid, thid_t os_id,
                  ThreadType thread_type = ThreadType::Regular);
 
 }  // namespace __lsan

--- a/compiler-rt/lib/lsan/lsan_posix.h
+++ b/compiler-rt/lib/lsan/lsan_posix.h
@@ -41,7 +41,7 @@ class ThreadContext final : public ThreadContextLsanBase {
   DTLS *dtls_ = nullptr;
 };
 
-void ThreadStart(u32 tid, thid_t os_id,
+void ThreadStart(u32 tid, ThreadID os_id,
                  ThreadType thread_type = ThreadType::Regular);
 
 }  // namespace __lsan

--- a/compiler-rt/lib/lsan/lsan_thread.cpp
+++ b/compiler-rt/lib/lsan/lsan_thread.cpp
@@ -66,7 +66,7 @@ u32 ThreadCreate(u32 parent_tid, bool detached, void *arg) {
   return thread_registry->CreateThread(0, detached, parent_tid, arg);
 }
 
-void ThreadContextLsanBase::ThreadStart(u32 tid, tid_t os_id,
+void ThreadContextLsanBase::ThreadStart(u32 tid, thid_t os_id,
                                         ThreadType thread_type, void *arg) {
   thread_registry->StartThread(tid, os_id, thread_type, arg);
 }
@@ -80,7 +80,7 @@ void EnsureMainThreadIDIsCorrect() {
 
 ///// Interface to the common LSan module. /////
 
-void GetThreadExtraStackRangesLocked(tid_t os_id,
+void GetThreadExtraStackRangesLocked(thid_t os_id,
                                      InternalMmapVector<Range> *ranges) {}
 void GetThreadExtraStackRangesLocked(InternalMmapVector<Range> *ranges) {}
 
@@ -99,11 +99,11 @@ ThreadRegistry *GetLsanThreadRegistryLocked() {
   return thread_registry;
 }
 
-void GetRunningThreadsLocked(InternalMmapVector<tid_t> *threads) {
+void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads) {
   GetLsanThreadRegistryLocked()->RunCallbackForEachThreadLocked(
       [](ThreadContextBase *tctx, void *threads) {
         if (tctx->status == ThreadStatusRunning) {
-          reinterpret_cast<InternalMmapVector<tid_t> *>(threads)->push_back(
+          reinterpret_cast<InternalMmapVector<thid_t> *>(threads)->push_back(
               tctx->os_id);
         }
       },

--- a/compiler-rt/lib/lsan/lsan_thread.cpp
+++ b/compiler-rt/lib/lsan/lsan_thread.cpp
@@ -66,7 +66,7 @@ u32 ThreadCreate(u32 parent_tid, bool detached, void *arg) {
   return thread_registry->CreateThread(0, detached, parent_tid, arg);
 }
 
-void ThreadContextLsanBase::ThreadStart(u32 tid, thid_t os_id,
+void ThreadContextLsanBase::ThreadStart(u32 tid, ThreadID os_id,
                                         ThreadType thread_type, void *arg) {
   thread_registry->StartThread(tid, os_id, thread_type, arg);
 }
@@ -80,7 +80,7 @@ void EnsureMainThreadIDIsCorrect() {
 
 ///// Interface to the common LSan module. /////
 
-void GetThreadExtraStackRangesLocked(thid_t os_id,
+void GetThreadExtraStackRangesLocked(ThreadID os_id,
                                      InternalMmapVector<Range> *ranges) {}
 void GetThreadExtraStackRangesLocked(InternalMmapVector<Range> *ranges) {}
 
@@ -99,11 +99,11 @@ ThreadRegistry *GetLsanThreadRegistryLocked() {
   return thread_registry;
 }
 
-void GetRunningThreadsLocked(InternalMmapVector<thid_t> *threads) {
+void GetRunningThreadsLocked(InternalMmapVector<ThreadID> *threads) {
   GetLsanThreadRegistryLocked()->RunCallbackForEachThreadLocked(
       [](ThreadContextBase *tctx, void *threads) {
         if (tctx->status == ThreadStatusRunning) {
-          reinterpret_cast<InternalMmapVector<thid_t> *>(threads)->push_back(
+          reinterpret_cast<InternalMmapVector<ThreadID> *>(threads)->push_back(
               tctx->os_id);
         }
       },

--- a/compiler-rt/lib/lsan/lsan_thread.h
+++ b/compiler-rt/lib/lsan/lsan_thread.h
@@ -30,7 +30,7 @@ class ThreadContextLsanBase : public ThreadContextBase {
   uptr cache_end() { return cache_end_; }
 
   // The argument is passed on to the subclass's OnStarted member function.
-  static void ThreadStart(u32 tid, tid_t os_id, ThreadType thread_type,
+  static void ThreadStart(u32 tid, thid_t os_id, ThreadType thread_type,
                           void *onstarted_arg);
 
  protected:

--- a/compiler-rt/lib/lsan/lsan_thread.h
+++ b/compiler-rt/lib/lsan/lsan_thread.h
@@ -30,7 +30,7 @@ class ThreadContextLsanBase : public ThreadContextBase {
   uptr cache_end() { return cache_end_; }
 
   // The argument is passed on to the subclass's OnStarted member function.
-  static void ThreadStart(u32 tid, thid_t os_id, ThreadType thread_type,
+  static void ThreadStart(u32 tid, ThreadID os_id, ThreadType thread_type,
                           void *onstarted_arg);
 
  protected:

--- a/compiler-rt/lib/memprof/memprof_thread.cpp
+++ b/compiler-rt/lib/memprof/memprof_thread.cpp
@@ -131,7 +131,7 @@ void MemprofThread::Init(const InitOptions *options) {
 }
 
 thread_return_t
-MemprofThread::ThreadStart(thid_t os_id,
+MemprofThread::ThreadStart(ThreadID os_id,
                            atomic_uintptr_t *signal_thread_is_registered) {
   Init();
   memprofThreadRegistry().StartThread(tid(), os_id, ThreadType::Regular,

--- a/compiler-rt/lib/memprof/memprof_thread.cpp
+++ b/compiler-rt/lib/memprof/memprof_thread.cpp
@@ -131,7 +131,7 @@ void MemprofThread::Init(const InitOptions *options) {
 }
 
 thread_return_t
-MemprofThread::ThreadStart(tid_t os_id,
+MemprofThread::ThreadStart(thid_t os_id,
                            atomic_uintptr_t *signal_thread_is_registered) {
   Init();
   memprofThreadRegistry().StartThread(tid(), os_id, ThreadType::Regular,

--- a/compiler-rt/lib/memprof/memprof_thread.h
+++ b/compiler-rt/lib/memprof/memprof_thread.h
@@ -59,7 +59,7 @@ public:
   struct InitOptions;
   void Init(const InitOptions *options = nullptr);
 
-  thread_return_t ThreadStart(thid_t os_id,
+  thread_return_t ThreadStart(ThreadID os_id,
                               atomic_uintptr_t *signal_thread_is_registered);
 
   uptr stack_top();

--- a/compiler-rt/lib/memprof/memprof_thread.h
+++ b/compiler-rt/lib/memprof/memprof_thread.h
@@ -59,7 +59,7 @@ public:
   struct InitOptions;
   void Init(const InitOptions *options = nullptr);
 
-  thread_return_t ThreadStart(tid_t os_id,
+  thread_return_t ThreadStart(thid_t os_id,
                               atomic_uintptr_t *signal_thread_is_registered);
 
   uptr stack_top();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -78,8 +78,8 @@ uptr GetMmapGranularity();
 uptr GetMaxVirtualAddress();
 uptr GetMaxUserVirtualAddress();
 // Threads
-tid_t GetTid();
-int TgKill(pid_t pid, tid_t tid, int sig);
+thid_t GetTid();
+int TgKill(pid_t pid, thid_t tid, int sig);
 uptr GetThreadSelf();
 void GetThreadStackTopAndBottom(bool at_initialization, uptr *stack_top,
                                 uptr *stack_bottom);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -78,8 +78,8 @@ uptr GetMmapGranularity();
 uptr GetMaxVirtualAddress();
 uptr GetMaxUserVirtualAddress();
 // Threads
-thid_t GetTid();
-int TgKill(pid_t pid, thid_t tid, int sig);
+ThreadID GetTid();
+int TgKill(pid_t pid, ThreadID tid, int sig);
 uptr GetThreadSelf();
 void GetThreadStackTopAndBottom(bool at_initialization, uptr *stack_top,
                                 uptr *stack_bottom);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_fuchsia.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_fuchsia.cpp
@@ -68,7 +68,7 @@ int internal_dlinfo(void *handle, int request, void *p) { UNIMPLEMENTED(); }
 
 uptr GetThreadSelf() { return reinterpret_cast<uptr>(thrd_current()); }
 
-tid_t GetTid() { return GetThreadSelf(); }
+thid_t GetTid() { return GetThreadSelf(); }
 
 void Abort() { abort(); }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_fuchsia.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_fuchsia.cpp
@@ -68,7 +68,7 @@ int internal_dlinfo(void *handle, int request, void *p) { UNIMPLEMENTED(); }
 
 uptr GetThreadSelf() { return reinterpret_cast<uptr>(thrd_current()); }
 
-thid_t GetTid() { return GetThreadSelf(); }
+ThreadID GetTid() { return GetThreadSelf(); }
 
 void Abort() { abort(); }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_haiku.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_haiku.cpp
@@ -231,12 +231,12 @@ uptr internal_execve(const char *filename, char *const argv[],
 }
 
 #  if 0
-tid_t GetTid() {
+thid_t GetTid() {
   DEFINE__REAL(int, _lwp_self);
   return _REAL(_lwp_self);
 }
 
-int TgKill(pid_t pid, tid_t tid, int sig) {
+int TgKill(pid_t pid, thid_t tid, int sig) {
   DEFINE__REAL(int, _lwp_kill, int a, int b);
   (void)pid;
   return _REAL(_lwp_kill, tid, sig);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_haiku.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_haiku.cpp
@@ -231,12 +231,12 @@ uptr internal_execve(const char *filename, char *const argv[],
 }
 
 #  if 0
-thid_t GetTid() {
+ThreadID GetTid() {
   DEFINE__REAL(int, _lwp_self);
   return _REAL(_lwp_self);
 }
 
-int TgKill(pid_t pid, thid_t tid, int sig) {
+int TgKill(pid_t pid, ThreadID tid, int sig) {
   DEFINE__REAL(int, _lwp_kill, int a, int b);
   (void)pid;
   return _REAL(_lwp_kill, tid, sig);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -209,7 +209,7 @@ typedef long ssize;
 typedef sptr ssize;
 #endif
 
-typedef u64 thid_t;
+typedef u64 ThreadID;
 
 // ----------- ATTENTION -------------
 // This header should NOT include any other headers to avoid portability issues.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_internal_defs.h
@@ -209,7 +209,7 @@ typedef long ssize;
 typedef sptr ssize;
 #endif
 
-typedef u64 tid_t;
+typedef u64 thid_t;
 
 // ----------- ATTENTION -------------
 // This header should NOT include any other headers to avoid portability issues.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -638,7 +638,7 @@ bool DirExists(const char *path) {
 }
 
 #  if !SANITIZER_NETBSD
-tid_t GetTid() {
+thid_t GetTid() {
 #    if SANITIZER_FREEBSD
   long Tid;
   thr_self(&Tid);
@@ -652,7 +652,7 @@ tid_t GetTid() {
 #    endif
 }
 
-int TgKill(pid_t pid, tid_t tid, int sig) {
+int TgKill(pid_t pid, thid_t tid, int sig) {
 #    if SANITIZER_LINUX
   return internal_syscall(SYSCALL(tgkill), pid, tid, sig);
 #    elif SANITIZER_FREEBSD
@@ -1089,7 +1089,7 @@ ThreadLister::ThreadLister(pid_t pid) : buffer_(4096) {
 }
 
 ThreadLister::Result ThreadLister::ListThreads(
-    InternalMmapVector<tid_t> *threads) {
+    InternalMmapVector<thid_t> *threads) {
   int descriptor = internal_open(task_path_.data(), O_RDONLY | O_DIRECTORY);
   if (internal_iserror(descriptor)) {
     Report("Can't open %s for reading.\n", task_path_.data());
@@ -1144,7 +1144,7 @@ ThreadLister::Result ThreadLister::ListThreads(
   }
 }
 
-const char *ThreadLister::LoadStatus(tid_t tid) {
+const char *ThreadLister::LoadStatus(thid_t tid) {
   status_path_.clear();
   status_path_.AppendF("%s/%llu/status", task_path_.data(), tid);
   auto cleanup = at_scope_exit([&] {
@@ -1157,7 +1157,7 @@ const char *ThreadLister::LoadStatus(tid_t tid) {
   return buffer_.data();
 }
 
-bool ThreadLister::IsAlive(tid_t tid) {
+bool ThreadLister::IsAlive(thid_t tid) {
   // /proc/%d/task/%d/status uses same call to detect alive threads as
   // proc_task_readdir. See task_state implementation in Linux.
   static const char kPrefix[] = "\nPPid:";

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -638,7 +638,7 @@ bool DirExists(const char *path) {
 }
 
 #  if !SANITIZER_NETBSD
-thid_t GetTid() {
+ThreadID GetTid() {
 #    if SANITIZER_FREEBSD
   long Tid;
   thr_self(&Tid);
@@ -652,7 +652,7 @@ thid_t GetTid() {
 #    endif
 }
 
-int TgKill(pid_t pid, thid_t tid, int sig) {
+int TgKill(pid_t pid, ThreadID tid, int sig) {
 #    if SANITIZER_LINUX
   return internal_syscall(SYSCALL(tgkill), pid, tid, sig);
 #    elif SANITIZER_FREEBSD
@@ -1089,7 +1089,7 @@ ThreadLister::ThreadLister(pid_t pid) : buffer_(4096) {
 }
 
 ThreadLister::Result ThreadLister::ListThreads(
-    InternalMmapVector<thid_t> *threads) {
+    InternalMmapVector<ThreadID> *threads) {
   int descriptor = internal_open(task_path_.data(), O_RDONLY | O_DIRECTORY);
   if (internal_iserror(descriptor)) {
     Report("Can't open %s for reading.\n", task_path_.data());
@@ -1144,7 +1144,7 @@ ThreadLister::Result ThreadLister::ListThreads(
   }
 }
 
-const char *ThreadLister::LoadStatus(thid_t tid) {
+const char *ThreadLister::LoadStatus(ThreadID tid) {
   status_path_.clear();
   status_path_.AppendF("%s/%llu/status", task_path_.data(), tid);
   auto cleanup = at_scope_exit([&] {
@@ -1157,7 +1157,7 @@ const char *ThreadLister::LoadStatus(thid_t tid) {
   return buffer_.data();
 }
 
-bool ThreadLister::IsAlive(thid_t tid) {
+bool ThreadLister::IsAlive(ThreadID tid) {
   // /proc/%d/task/%d/status uses same call to detect alive threads as
   // proc_task_readdir. See task_state implementation in Linux.
   static const char kPrefix[] = "\nPPid:";

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.h
@@ -108,11 +108,11 @@ class ThreadLister {
     Incomplete,
     Ok,
   };
-  Result ListThreads(InternalMmapVector<thid_t> *threads);
-  const char *LoadStatus(thid_t tid);
+  Result ListThreads(InternalMmapVector<ThreadID> *threads);
+  const char *LoadStatus(ThreadID tid);
 
  private:
-  bool IsAlive(thid_t tid);
+  bool IsAlive(ThreadID tid);
 
   InternalScopedString task_path_;
   InternalScopedString status_path_;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_linux.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_linux.h
@@ -108,11 +108,11 @@ class ThreadLister {
     Incomplete,
     Ok,
   };
-  Result ListThreads(InternalMmapVector<tid_t> *threads);
-  const char *LoadStatus(tid_t tid);
+  Result ListThreads(InternalMmapVector<thid_t> *threads);
+  const char *LoadStatus(thid_t tid);
 
  private:
-  bool IsAlive(tid_t tid);
+  bool IsAlive(thid_t tid);
 
   InternalScopedString task_path_;
   InternalScopedString status_path_;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -394,8 +394,8 @@ bool DirExists(const char *path) {
   return S_ISDIR(st.st_mode);
 }
 
-tid_t GetTid() {
-  tid_t tid;
+thid_t GetTid() {
+  thid_t tid;
   pthread_threadid_np(nullptr, &tid);
   return tid;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp
@@ -394,8 +394,8 @@ bool DirExists(const char *path) {
   return S_ISDIR(st.st_mode);
 }
 
-thid_t GetTid() {
-  thid_t tid;
+ThreadID GetTid() {
+  ThreadID tid;
   pthread_threadid_np(nullptr, &tid);
   return tid;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
@@ -229,12 +229,12 @@ uptr internal_execve(const char *filename, char *const argv[],
   return _sys_execve(filename, argv, envp);
 }
 
-tid_t GetTid() {
+thid_t GetTid() {
   DEFINE__REAL(int, _lwp_self);
   return _REAL(_lwp_self);
 }
 
-int TgKill(pid_t pid, tid_t tid, int sig) {
+int TgKill(pid_t pid, thid_t tid, int sig) {
   DEFINE__REAL(int, _lwp_kill, int a, int b);
   (void)pid;
   return _REAL(_lwp_kill, tid, sig);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_netbsd.cpp
@@ -229,12 +229,12 @@ uptr internal_execve(const char *filename, char *const argv[],
   return _sys_execve(filename, argv, envp);
 }
 
-thid_t GetTid() {
+ThreadID GetTid() {
   DEFINE__REAL(int, _lwp_self);
   return _REAL(_lwp_self);
 }
 
-int TgKill(pid_t pid, thid_t tid, int sig) {
+int TgKill(pid_t pid, ThreadID tid, int sig) {
   DEFINE__REAL(int, _lwp_kill, int a, int b);
   (void)pid;
   return _REAL(_lwp_kill, tid, sig);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld.h
@@ -38,7 +38,7 @@ class SuspendedThreadsList {
   }
 
   virtual uptr ThreadCount() const { UNIMPLEMENTED(); }
-  virtual tid_t GetThreadID(uptr index) const { UNIMPLEMENTED(); }
+  virtual thid_t GetThreadID(uptr index) const { UNIMPLEMENTED(); }
 
  protected:
   ~SuspendedThreadsList() {}

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld.h
@@ -38,7 +38,7 @@ class SuspendedThreadsList {
   }
 
   virtual uptr ThreadCount() const { UNIMPLEMENTED(); }
-  virtual thid_t GetThreadID(uptr index) const { UNIMPLEMENTED(); }
+  virtual ThreadID GetThreadID(uptr index) const { UNIMPLEMENTED(); }
 
  protected:
   ~SuspendedThreadsList() {}

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -94,17 +94,17 @@ class SuspendedThreadsListLinux final : public SuspendedThreadsList {
  public:
   SuspendedThreadsListLinux() { thread_ids_.reserve(1024); }
 
-  thid_t GetThreadID(uptr index) const override;
+  ThreadID GetThreadID(uptr index) const override;
   uptr ThreadCount() const override;
-  bool ContainsTid(thid_t thread_id) const;
-  void Append(thid_t tid);
+  bool ContainsTid(ThreadID thread_id) const;
+  void Append(ThreadID tid);
 
   PtraceRegistersStatus GetRegistersAndSP(uptr index,
                                           InternalMmapVector<uptr> *buffer,
                                           uptr *sp) const override;
 
  private:
-  InternalMmapVector<thid_t> thread_ids_;
+  InternalMmapVector<ThreadID> thread_ids_;
 };
 
 // Structure for passing arguments into the tracer thread.
@@ -137,10 +137,10 @@ class ThreadSuspender {
  private:
   SuspendedThreadsListLinux suspended_threads_list_;
   pid_t pid_;
-  bool SuspendThread(thid_t thread_id);
+  bool SuspendThread(ThreadID thread_id);
 };
 
-bool ThreadSuspender::SuspendThread(thid_t tid) {
+bool ThreadSuspender::SuspendThread(ThreadID tid) {
   int pterrno;
   if (internal_iserror(internal_ptrace(PTRACE_ATTACH, tid, nullptr, nullptr),
                        &pterrno)) {
@@ -210,7 +210,7 @@ void ThreadSuspender::KillAllThreads() {
 bool ThreadSuspender::SuspendAllThreads() {
   ThreadLister thread_lister(pid_);
   bool retry = true;
-  InternalMmapVector<thid_t> threads;
+  InternalMmapVector<ThreadID> threads;
   threads.reserve(128);
   for (int i = 0; i < 30 && retry; ++i) {
     retry = false;
@@ -226,7 +226,7 @@ bool ThreadSuspender::SuspendAllThreads() {
       case ThreadLister::Ok:
         break;
     }
-    for (thid_t tid : threads) {
+    for (ThreadID tid : threads) {
       // Are we already attached to this thread?
       // Currently this check takes linear time, however the number of threads
       // is usually small.
@@ -546,7 +546,7 @@ static constexpr uptr kExtraRegs[] = {0};
 #error "Unsupported architecture"
 #endif // SANITIZER_ANDROID && defined(__arm__)
 
-thid_t SuspendedThreadsListLinux::GetThreadID(uptr index) const {
+ThreadID SuspendedThreadsListLinux::GetThreadID(uptr index) const {
   CHECK_LT(index, thread_ids_.size());
   return thread_ids_[index];
 }
@@ -555,14 +555,14 @@ uptr SuspendedThreadsListLinux::ThreadCount() const {
   return thread_ids_.size();
 }
 
-bool SuspendedThreadsListLinux::ContainsTid(thid_t thread_id) const {
+bool SuspendedThreadsListLinux::ContainsTid(ThreadID thread_id) const {
   for (uptr i = 0; i < thread_ids_.size(); i++) {
     if (thread_ids_[i] == thread_id) return true;
   }
   return false;
 }
 
-void SuspendedThreadsListLinux::Append(thid_t tid) {
+void SuspendedThreadsListLinux::Append(ThreadID tid) {
   thread_ids_.push_back(tid);
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -94,17 +94,17 @@ class SuspendedThreadsListLinux final : public SuspendedThreadsList {
  public:
   SuspendedThreadsListLinux() { thread_ids_.reserve(1024); }
 
-  tid_t GetThreadID(uptr index) const override;
+  thid_t GetThreadID(uptr index) const override;
   uptr ThreadCount() const override;
-  bool ContainsTid(tid_t thread_id) const;
-  void Append(tid_t tid);
+  bool ContainsTid(thid_t thread_id) const;
+  void Append(thid_t tid);
 
   PtraceRegistersStatus GetRegistersAndSP(uptr index,
                                           InternalMmapVector<uptr> *buffer,
                                           uptr *sp) const override;
 
  private:
-  InternalMmapVector<tid_t> thread_ids_;
+  InternalMmapVector<thid_t> thread_ids_;
 };
 
 // Structure for passing arguments into the tracer thread.
@@ -137,10 +137,10 @@ class ThreadSuspender {
  private:
   SuspendedThreadsListLinux suspended_threads_list_;
   pid_t pid_;
-  bool SuspendThread(tid_t thread_id);
+  bool SuspendThread(thid_t thread_id);
 };
 
-bool ThreadSuspender::SuspendThread(tid_t tid) {
+bool ThreadSuspender::SuspendThread(thid_t tid) {
   int pterrno;
   if (internal_iserror(internal_ptrace(PTRACE_ATTACH, tid, nullptr, nullptr),
                        &pterrno)) {
@@ -210,7 +210,7 @@ void ThreadSuspender::KillAllThreads() {
 bool ThreadSuspender::SuspendAllThreads() {
   ThreadLister thread_lister(pid_);
   bool retry = true;
-  InternalMmapVector<tid_t> threads;
+  InternalMmapVector<thid_t> threads;
   threads.reserve(128);
   for (int i = 0; i < 30 && retry; ++i) {
     retry = false;
@@ -226,7 +226,7 @@ bool ThreadSuspender::SuspendAllThreads() {
       case ThreadLister::Ok:
         break;
     }
-    for (tid_t tid : threads) {
+    for (thid_t tid : threads) {
       // Are we already attached to this thread?
       // Currently this check takes linear time, however the number of threads
       // is usually small.
@@ -546,7 +546,7 @@ static constexpr uptr kExtraRegs[] = {0};
 #error "Unsupported architecture"
 #endif // SANITIZER_ANDROID && defined(__arm__)
 
-tid_t SuspendedThreadsListLinux::GetThreadID(uptr index) const {
+thid_t SuspendedThreadsListLinux::GetThreadID(uptr index) const {
   CHECK_LT(index, thread_ids_.size());
   return thread_ids_[index];
 }
@@ -555,14 +555,14 @@ uptr SuspendedThreadsListLinux::ThreadCount() const {
   return thread_ids_.size();
 }
 
-bool SuspendedThreadsListLinux::ContainsTid(tid_t thread_id) const {
+bool SuspendedThreadsListLinux::ContainsTid(thid_t thread_id) const {
   for (uptr i = 0; i < thread_ids_.size(); i++) {
     if (thread_ids_[i] == thread_id) return true;
   }
   return false;
 }
 
-void SuspendedThreadsListLinux::Append(tid_t tid) {
+void SuspendedThreadsListLinux::Append(thid_t tid) {
   thread_ids_.push_back(tid);
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_mac.cpp
@@ -23,7 +23,7 @@
 
 namespace __sanitizer {
 typedef struct {
-  tid_t tid;
+  thid_t tid;
   thread_t thread;
 } SuspendedThreadInfo;
 
@@ -31,7 +31,7 @@ class SuspendedThreadsListMac final : public SuspendedThreadsList {
  public:
   SuspendedThreadsListMac() = default;
 
-  tid_t GetThreadID(uptr index) const override;
+  thid_t GetThreadID(uptr index) const override;
   thread_t GetThread(uptr index) const;
   uptr ThreadCount() const override;
   bool ContainsThread(thread_t thread) const;
@@ -111,7 +111,7 @@ typedef x86_thread_state32_t regs_struct;
 #error "Unsupported architecture"
 #endif
 
-tid_t SuspendedThreadsListMac::GetThreadID(uptr index) const {
+thid_t SuspendedThreadsListMac::GetThreadID(uptr index) const {
   CHECK_LT(index, threads_.size());
   return threads_[index].tid;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_mac.cpp
@@ -23,7 +23,7 @@
 
 namespace __sanitizer {
 typedef struct {
-  thid_t tid;
+  ThreadID tid;
   thread_t thread;
 } SuspendedThreadInfo;
 
@@ -31,7 +31,7 @@ class SuspendedThreadsListMac final : public SuspendedThreadsList {
  public:
   SuspendedThreadsListMac() = default;
 
-  thid_t GetThreadID(uptr index) const override;
+  ThreadID GetThreadID(uptr index) const override;
   thread_t GetThread(uptr index) const;
   uptr ThreadCount() const override;
   bool ContainsThread(thread_t thread) const;
@@ -111,7 +111,7 @@ typedef x86_thread_state32_t regs_struct;
 #error "Unsupported architecture"
 #endif
 
-thid_t SuspendedThreadsListMac::GetThreadID(uptr index) const {
+ThreadID SuspendedThreadsListMac::GetThreadID(uptr index) const {
   CHECK_LT(index, threads_.size());
   return threads_[index].tid;
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_netbsd_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_netbsd_libcdep.cpp
@@ -52,17 +52,17 @@ class SuspendedThreadsListNetBSD final : public SuspendedThreadsList {
  public:
   SuspendedThreadsListNetBSD() { thread_ids_.reserve(1024); }
 
-  thid_t GetThreadID(uptr index) const;
+  ThreadID GetThreadID(uptr index) const;
   uptr ThreadCount() const;
-  bool ContainsTid(thid_t thread_id) const;
-  void Append(thid_t tid);
+  bool ContainsTid(ThreadID thread_id) const;
+  void Append(ThreadID tid);
 
   PtraceRegistersStatus GetRegistersAndSP(uptr index,
                                           InternalMmapVector<uptr> *buffer,
                                           uptr *sp) const;
 
  private:
-  InternalMmapVector<thid_t> thread_ids_;
+  InternalMmapVector<ThreadID> thread_ids_;
 };
 
 struct TracerThreadArgument {
@@ -313,7 +313,7 @@ void StopTheWorld(StopTheWorldCallback callback, void *argument) {
   }
 }
 
-thid_t SuspendedThreadsListNetBSD::GetThreadID(uptr index) const {
+ThreadID SuspendedThreadsListNetBSD::GetThreadID(uptr index) const {
   CHECK_LT(index, thread_ids_.size());
   return thread_ids_[index];
 }
@@ -322,7 +322,7 @@ uptr SuspendedThreadsListNetBSD::ThreadCount() const {
   return thread_ids_.size();
 }
 
-bool SuspendedThreadsListNetBSD::ContainsTid(thid_t thread_id) const {
+bool SuspendedThreadsListNetBSD::ContainsTid(ThreadID thread_id) const {
   for (uptr i = 0; i < thread_ids_.size(); i++) {
     if (thread_ids_[i] == thread_id)
       return true;
@@ -330,7 +330,7 @@ bool SuspendedThreadsListNetBSD::ContainsTid(thid_t thread_id) const {
   return false;
 }
 
-void SuspendedThreadsListNetBSD::Append(thid_t tid) {
+void SuspendedThreadsListNetBSD::Append(ThreadID tid) {
   thread_ids_.push_back(tid);
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_netbsd_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_netbsd_libcdep.cpp
@@ -52,17 +52,17 @@ class SuspendedThreadsListNetBSD final : public SuspendedThreadsList {
  public:
   SuspendedThreadsListNetBSD() { thread_ids_.reserve(1024); }
 
-  tid_t GetThreadID(uptr index) const;
+  thid_t GetThreadID(uptr index) const;
   uptr ThreadCount() const;
-  bool ContainsTid(tid_t thread_id) const;
-  void Append(tid_t tid);
+  bool ContainsTid(thid_t thread_id) const;
+  void Append(thid_t tid);
 
   PtraceRegistersStatus GetRegistersAndSP(uptr index,
                                           InternalMmapVector<uptr> *buffer,
                                           uptr *sp) const;
 
  private:
-  InternalMmapVector<tid_t> thread_ids_;
+  InternalMmapVector<thid_t> thread_ids_;
 };
 
 struct TracerThreadArgument {
@@ -313,7 +313,7 @@ void StopTheWorld(StopTheWorldCallback callback, void *argument) {
   }
 }
 
-tid_t SuspendedThreadsListNetBSD::GetThreadID(uptr index) const {
+thid_t SuspendedThreadsListNetBSD::GetThreadID(uptr index) const {
   CHECK_LT(index, thread_ids_.size());
   return thread_ids_[index];
 }
@@ -322,7 +322,7 @@ uptr SuspendedThreadsListNetBSD::ThreadCount() const {
   return thread_ids_.size();
 }
 
-bool SuspendedThreadsListNetBSD::ContainsTid(tid_t thread_id) const {
+bool SuspendedThreadsListNetBSD::ContainsTid(thid_t thread_id) const {
   for (uptr i = 0; i < thread_ids_.size(); i++) {
     if (thread_ids_[i] == thread_id)
       return true;
@@ -330,7 +330,7 @@ bool SuspendedThreadsListNetBSD::ContainsTid(tid_t thread_id) const {
   return false;
 }
 
-void SuspendedThreadsListNetBSD::Append(tid_t tid) {
+void SuspendedThreadsListNetBSD::Append(thid_t tid) {
   thread_ids_.push_back(tid);
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
@@ -38,7 +38,7 @@ struct SuspendedThreadsListWindows final : public SuspendedThreadsList {
                                           InternalMmapVector<uptr> *buffer,
                                           uptr *sp) const override;
 
-  tid_t GetThreadID(uptr index) const override;
+  thid_t GetThreadID(uptr index) const override;
   uptr ThreadCount() const override;
 };
 
@@ -68,7 +68,7 @@ PtraceRegistersStatus SuspendedThreadsListWindows::GetRegistersAndSP(
   return REGISTERS_AVAILABLE;
 }
 
-tid_t SuspendedThreadsListWindows::GetThreadID(uptr index) const {
+thid_t SuspendedThreadsListWindows::GetThreadID(uptr index) const {
   CHECK_LT(index, threadIds.size());
   return threadIds[index];
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_win.cpp
@@ -38,7 +38,7 @@ struct SuspendedThreadsListWindows final : public SuspendedThreadsList {
                                           InternalMmapVector<uptr> *buffer,
                                           uptr *sp) const override;
 
-  thid_t GetThreadID(uptr index) const override;
+  ThreadID GetThreadID(uptr index) const override;
   uptr ThreadCount() const override;
 };
 
@@ -68,7 +68,7 @@ PtraceRegistersStatus SuspendedThreadsListWindows::GetRegistersAndSP(
   return REGISTERS_AVAILABLE;
 }
 
-thid_t SuspendedThreadsListWindows::GetThreadID(uptr index) const {
+ThreadID SuspendedThreadsListWindows::GetThreadID(uptr index) const {
   CHECK_LT(index, threadIds.size());
   return threadIds[index];
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.cpp
@@ -80,7 +80,7 @@ void ThreadContextBase::SetFinished() {
   OnFinished();
 }
 
-void ThreadContextBase::SetStarted(thid_t _os_id, ThreadType _thread_type,
+void ThreadContextBase::SetStarted(ThreadID _os_id, ThreadType _thread_type,
                                    void *arg) {
   status = ThreadStatusRunning;
   os_id = _os_id;
@@ -228,7 +228,7 @@ static bool FindThreadContextByOsIdCallback(ThreadContextBase *tctx,
           tctx->status != ThreadStatusDead);
 }
 
-ThreadContextBase *ThreadRegistry::FindThreadContextByOsIDLocked(thid_t os_id) {
+ThreadContextBase *ThreadRegistry::FindThreadContextByOsIDLocked(ThreadID os_id) {
   return FindThreadContextLocked(FindThreadContextByOsIdCallback,
                                  (void *)os_id);
 }
@@ -322,7 +322,7 @@ ThreadStatus ThreadRegistry::FinishThread(u32 tid) {
   return prev_status;
 }
 
-void ThreadRegistry::StartThread(u32 tid, thid_t os_id, ThreadType thread_type,
+void ThreadRegistry::StartThread(u32 tid, ThreadID os_id, ThreadType thread_type,
                                  void *arg) {
   ThreadRegistryLock l(this);
   running_threads_++;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.cpp
@@ -228,7 +228,8 @@ static bool FindThreadContextByOsIdCallback(ThreadContextBase *tctx,
           tctx->status != ThreadStatusDead);
 }
 
-ThreadContextBase *ThreadRegistry::FindThreadContextByOsIDLocked(ThreadID os_id) {
+ThreadContextBase *ThreadRegistry::FindThreadContextByOsIDLocked(
+    ThreadID os_id) {
   return FindThreadContextLocked(FindThreadContextByOsIdCallback,
                                  (void *)os_id);
 }
@@ -322,8 +323,8 @@ ThreadStatus ThreadRegistry::FinishThread(u32 tid) {
   return prev_status;
 }
 
-void ThreadRegistry::StartThread(u32 tid, ThreadID os_id, ThreadType thread_type,
-                                 void *arg) {
+void ThreadRegistry::StartThread(u32 tid, ThreadID os_id,
+                                 ThreadType thread_type, void *arg) {
   ThreadRegistryLock l(this);
   running_threads_++;
   ThreadContextBase *tctx = threads_[tid];

--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.cpp
@@ -80,7 +80,7 @@ void ThreadContextBase::SetFinished() {
   OnFinished();
 }
 
-void ThreadContextBase::SetStarted(tid_t _os_id, ThreadType _thread_type,
+void ThreadContextBase::SetStarted(thid_t _os_id, ThreadType _thread_type,
                                    void *arg) {
   status = ThreadStatusRunning;
   os_id = _os_id;
@@ -228,7 +228,7 @@ static bool FindThreadContextByOsIdCallback(ThreadContextBase *tctx,
           tctx->status != ThreadStatusDead);
 }
 
-ThreadContextBase *ThreadRegistry::FindThreadContextByOsIDLocked(tid_t os_id) {
+ThreadContextBase *ThreadRegistry::FindThreadContextByOsIDLocked(thid_t os_id) {
   return FindThreadContextLocked(FindThreadContextByOsIdCallback,
                                  (void *)os_id);
 }
@@ -322,7 +322,7 @@ ThreadStatus ThreadRegistry::FinishThread(u32 tid) {
   return prev_status;
 }
 
-void ThreadRegistry::StartThread(u32 tid, tid_t os_id, ThreadType thread_type,
+void ThreadRegistry::StartThread(u32 tid, thid_t os_id, ThreadType thread_type,
                                  void *arg) {
   ThreadRegistryLock l(this);
   running_threads_++;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
@@ -43,7 +43,7 @@ class ThreadContextBase {
   const u32 tid;  // Thread ID. Main thread should have tid = 0.
   u64 unique_id;  // Unique thread ID.
   u32 reuse_count;  // Number of times this tid was reused.
-  tid_t os_id;     // PID (used for reporting).
+  thid_t os_id;     // PID (used for reporting).
   uptr user_id;   // Some opaque user thread id (e.g. pthread_t).
   char name[64];  // As annotated by user.
 
@@ -62,7 +62,7 @@ class ThreadContextBase {
   void SetDead();
   void SetJoined(void *arg);
   void SetFinished();
-  void SetStarted(tid_t _os_id, ThreadType _thread_type, void *arg);
+  void SetStarted(thid_t _os_id, ThreadType _thread_type, void *arg);
   void SetCreated(uptr _user_id, u64 _unique_id, bool _detached,
                   u32 _parent_tid, u32 _stack_tid, void *arg);
   void Reset();
@@ -126,7 +126,7 @@ class SANITIZER_MUTEX ThreadRegistry {
   // is found.
   ThreadContextBase *FindThreadContextLocked(FindThreadCallback cb,
                                              void *arg);
-  ThreadContextBase *FindThreadContextByOsIDLocked(tid_t os_id);
+  ThreadContextBase *FindThreadContextByOsIDLocked(thid_t os_id);
 
   void SetThreadName(u32 tid, const char *name);
   void SetThreadNameByUserId(uptr user_id, const char *name);
@@ -134,7 +134,7 @@ class SANITIZER_MUTEX ThreadRegistry {
   void JoinThread(u32 tid, void *arg);
   // Finishes thread and returns previous status.
   ThreadStatus FinishThread(u32 tid);
-  void StartThread(u32 tid, tid_t os_id, ThreadType thread_type, void *arg);
+  void StartThread(u32 tid, thid_t os_id, ThreadType thread_type, void *arg);
   u32 ConsumeThreadUserId(uptr user_id);
   void SetThreadUserId(u32 tid, uptr user_id);
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
@@ -43,7 +43,7 @@ class ThreadContextBase {
   const u32 tid;  // Thread ID. Main thread should have tid = 0.
   u64 unique_id;  // Unique thread ID.
   u32 reuse_count;  // Number of times this tid was reused.
-  ThreadID os_id;     // PID (used for reporting).
+  ThreadID os_id;   // PID (used for reporting).
   uptr user_id;   // Some opaque user thread id (e.g. pthread_t).
   char name[64];  // As annotated by user.
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
@@ -43,7 +43,7 @@ class ThreadContextBase {
   const u32 tid;  // Thread ID. Main thread should have tid = 0.
   u64 unique_id;  // Unique thread ID.
   u32 reuse_count;  // Number of times this tid was reused.
-  thid_t os_id;     // PID (used for reporting).
+  ThreadID os_id;     // PID (used for reporting).
   uptr user_id;   // Some opaque user thread id (e.g. pthread_t).
   char name[64];  // As annotated by user.
 
@@ -62,7 +62,7 @@ class ThreadContextBase {
   void SetDead();
   void SetJoined(void *arg);
   void SetFinished();
-  void SetStarted(thid_t _os_id, ThreadType _thread_type, void *arg);
+  void SetStarted(ThreadID _os_id, ThreadType _thread_type, void *arg);
   void SetCreated(uptr _user_id, u64 _unique_id, bool _detached,
                   u32 _parent_tid, u32 _stack_tid, void *arg);
   void Reset();
@@ -126,7 +126,7 @@ class SANITIZER_MUTEX ThreadRegistry {
   // is found.
   ThreadContextBase *FindThreadContextLocked(FindThreadCallback cb,
                                              void *arg);
-  ThreadContextBase *FindThreadContextByOsIDLocked(thid_t os_id);
+  ThreadContextBase *FindThreadContextByOsIDLocked(ThreadID os_id);
 
   void SetThreadName(u32 tid, const char *name);
   void SetThreadNameByUserId(uptr user_id, const char *name);
@@ -134,7 +134,7 @@ class SANITIZER_MUTEX ThreadRegistry {
   void JoinThread(u32 tid, void *arg);
   // Finishes thread and returns previous status.
   ThreadStatus FinishThread(u32 tid);
-  void StartThread(u32 tid, thid_t os_id, ThreadType thread_type, void *arg);
+  void StartThread(u32 tid, ThreadID os_id, ThreadType thread_type, void *arg);
   u32 ConsumeThreadUserId(uptr user_id);
   void SetThreadUserId(u32 tid, uptr user_id);
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -108,7 +108,7 @@ int internal_dlinfo(void *handle, int request, void *p) {
 
 // In contrast to POSIX, on Windows GetCurrentThreadId()
 // returns a system-unique identifier.
-tid_t GetTid() {
+thid_t GetTid() {
   return GetCurrentThreadId();
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -108,9 +108,7 @@ int internal_dlinfo(void *handle, int request, void *p) {
 
 // In contrast to POSIX, on Windows GetCurrentThreadId()
 // returns a system-unique identifier.
-thid_t GetTid() {
-  return GetCurrentThreadId();
-}
+thid_t GetTid() { return GetCurrentThreadId(); }
 
 uptr GetThreadSelf() {
   return GetTid();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_win.cpp
@@ -108,7 +108,7 @@ int internal_dlinfo(void *handle, int request, void *p) {
 
 // In contrast to POSIX, on Windows GetCurrentThreadId()
 // returns a system-unique identifier.
-thid_t GetTid() { return GetCurrentThreadId(); }
+ThreadID GetTid() { return GetCurrentThreadId(); }
 
 uptr GetThreadSelf() {
   return GetTid();

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
@@ -43,7 +43,7 @@ struct TidReporterArgument {
     pthread_cond_destroy(&tid_reported_cond);
   }
 
-  tid_t reported_tid;
+  thid_t reported_tid;
   // For signaling to spawned threads that they should terminate.
   pthread_cond_t terminate_thread_cond;
   pthread_mutex_t terminate_thread_mutex;
@@ -62,7 +62,7 @@ class ThreadListerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
     pthread_t pthread_id;
-    tid_t tid;
+    thid_t tid;
     for (uptr i = 0; i < kThreadCount; i++) {
       SpawnTidReporter(&pthread_id, &tid);
       pthread_ids_.push_back(pthread_id);
@@ -79,12 +79,12 @@ class ThreadListerTest : public ::testing::Test {
       pthread_join(pthread_ids_[i], NULL);
   }
 
-  void SpawnTidReporter(pthread_t *pthread_id, tid_t *tid);
+  void SpawnTidReporter(pthread_t *pthread_id, thid_t *tid);
 
   static const uptr kThreadCount = 20;
 
   std::vector<pthread_t> pthread_ids_;
-  std::vector<tid_t> tids_;
+  std::vector<thid_t> tids_;
 
   TidReporterArgument thread_arg;
 };
@@ -105,42 +105,42 @@ void *TidReporterThread(void *argument) {
   return NULL;
 }
 
-void ThreadListerTest::SpawnTidReporter(pthread_t *pthread_id, tid_t *tid) {
+void ThreadListerTest::SpawnTidReporter(pthread_t *pthread_id, thid_t *tid) {
   pthread_mutex_lock(&thread_arg.tid_reported_mutex);
   thread_arg.reported_tid = -1;
   ASSERT_EQ(0,
             pthread_create(pthread_id, NULL, TidReporterThread, &thread_arg));
-  while (thread_arg.reported_tid == (tid_t)(-1))
+  while (thread_arg.reported_tid == (thid_t)(-1))
     pthread_cond_wait(&thread_arg.tid_reported_cond,
                       &thread_arg.tid_reported_mutex);
   pthread_mutex_unlock(&thread_arg.tid_reported_mutex);
   *tid = thread_arg.reported_tid;
 }
 
-static std::vector<tid_t> ReadTidsToVector(ThreadLister *thread_lister) {
-  std::vector<tid_t> listed_tids;
-  InternalMmapVector<tid_t> threads(128);
+static std::vector<thid_t> ReadTidsToVector(ThreadLister *thread_lister) {
+  std::vector<thid_t> listed_tids;
+  InternalMmapVector<thid_t> threads(128);
   EXPECT_TRUE(thread_lister->ListThreads(&threads));
-  return std::vector<tid_t>(threads.begin(), threads.end());
+  return std::vector<thid_t>(threads.begin(), threads.end());
 }
 
-static bool Includes(std::vector<tid_t> first, std::vector<tid_t> second) {
+static bool Includes(std::vector<thid_t> first, std::vector<thid_t> second) {
   std::sort(first.begin(), first.end());
   std::sort(second.begin(), second.end());
   return std::includes(first.begin(), first.end(), second.begin(),
                        second.end());
 }
 
-static bool HasElement(const std::vector<tid_t> &vector, tid_t element) {
+static bool HasElement(const std::vector<thid_t> &vector, thid_t element) {
   return std::find(vector.begin(), vector.end(), element) != vector.end();
 }
 
 // ThreadLister's output should include the current thread's TID and the TID of
 // every thread we spawned.
 TEST_F(ThreadListerTest, ThreadListerSeesAllSpawnedThreads) {
-  tid_t self_tid = GetTid();
+  thid_t self_tid = GetTid();
   ThreadLister thread_lister(getpid());
-  std::vector<tid_t> listed_tids = ReadTidsToVector(&thread_lister);
+  std::vector<thid_t> listed_tids = ReadTidsToVector(&thread_lister);
   ASSERT_TRUE(HasElement(listed_tids, self_tid));
   ASSERT_TRUE(Includes(listed_tids, tids_));
 
@@ -154,7 +154,7 @@ TEST_F(ThreadListerTest, DoNotForgetThreads) {
   // Run the loop body twice, because ThreadLister might behave differently if
   // called on a freshly created object.
   for (uptr i = 0; i < 2; i++) {
-    std::vector<tid_t> listed_tids = ReadTidsToVector(&thread_lister);
+    std::vector<thid_t> listed_tids = ReadTidsToVector(&thread_lister);
     ASSERT_TRUE(Includes(listed_tids, tids_));
   }
 }
@@ -163,10 +163,10 @@ TEST_F(ThreadListerTest, DoNotForgetThreads) {
 // relisting should cause ThreadLister to recognize their existence.
 TEST_F(ThreadListerTest, NewThreads) {
   ThreadLister thread_lister(getpid());
-  std::vector<tid_t> threads_before_extra = ReadTidsToVector(&thread_lister);
+  std::vector<thid_t> threads_before_extra = ReadTidsToVector(&thread_lister);
 
   pthread_t extra_pthread_id;
-  tid_t extra_tid;
+  thid_t extra_tid;
   SpawnTidReporter(&extra_pthread_id, &extra_tid);
   // Register the new thread so it gets terminated in TearDown().
   pthread_ids_.push_back(extra_pthread_id);
@@ -176,7 +176,7 @@ TEST_F(ThreadListerTest, NewThreads) {
   // so better check for that.
   ASSERT_FALSE(HasElement(threads_before_extra, extra_tid));
 
-  std::vector<tid_t> threads_after_extra = ReadTidsToVector(&thread_lister);
+  std::vector<thid_t> threads_after_extra = ReadTidsToVector(&thread_lister);
   ASSERT_TRUE(HasElement(threads_after_extra, extra_tid));
 }
 

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
@@ -43,7 +43,7 @@ struct TidReporterArgument {
     pthread_cond_destroy(&tid_reported_cond);
   }
 
-  thid_t reported_tid;
+  ThreadID reported_tid;
   // For signaling to spawned threads that they should terminate.
   pthread_cond_t terminate_thread_cond;
   pthread_mutex_t terminate_thread_mutex;
@@ -62,7 +62,7 @@ class ThreadListerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
     pthread_t pthread_id;
-    thid_t tid;
+    ThreadID tid;
     for (uptr i = 0; i < kThreadCount; i++) {
       SpawnTidReporter(&pthread_id, &tid);
       pthread_ids_.push_back(pthread_id);
@@ -79,12 +79,12 @@ class ThreadListerTest : public ::testing::Test {
       pthread_join(pthread_ids_[i], NULL);
   }
 
-  void SpawnTidReporter(pthread_t *pthread_id, thid_t *tid);
+  void SpawnTidReporter(pthread_t *pthread_id, ThreadID *tid);
 
   static const uptr kThreadCount = 20;
 
   std::vector<pthread_t> pthread_ids_;
-  std::vector<thid_t> tids_;
+  std::vector<ThreadID> tids_;
 
   TidReporterArgument thread_arg;
 };
@@ -105,42 +105,42 @@ void *TidReporterThread(void *argument) {
   return NULL;
 }
 
-void ThreadListerTest::SpawnTidReporter(pthread_t *pthread_id, thid_t *tid) {
+void ThreadListerTest::SpawnTidReporter(pthread_t *pthread_id, ThreadID *tid) {
   pthread_mutex_lock(&thread_arg.tid_reported_mutex);
   thread_arg.reported_tid = -1;
   ASSERT_EQ(0,
             pthread_create(pthread_id, NULL, TidReporterThread, &thread_arg));
-  while (thread_arg.reported_tid == (thid_t)(-1))
+  while (thread_arg.reported_tid == (ThreadID)(-1))
     pthread_cond_wait(&thread_arg.tid_reported_cond,
                       &thread_arg.tid_reported_mutex);
   pthread_mutex_unlock(&thread_arg.tid_reported_mutex);
   *tid = thread_arg.reported_tid;
 }
 
-static std::vector<thid_t> ReadTidsToVector(ThreadLister *thread_lister) {
-  std::vector<thid_t> listed_tids;
-  InternalMmapVector<thid_t> threads(128);
+static std::vector<ThreadID> ReadTidsToVector(ThreadLister *thread_lister) {
+  std::vector<ThreadID> listed_tids;
+  InternalMmapVector<ThreadID> threads(128);
   EXPECT_TRUE(thread_lister->ListThreads(&threads));
-  return std::vector<thid_t>(threads.begin(), threads.end());
+  return std::vector<ThreadID>(threads.begin(), threads.end());
 }
 
-static bool Includes(std::vector<thid_t> first, std::vector<thid_t> second) {
+static bool Includes(std::vector<ThreadID> first, std::vector<ThreadID> second) {
   std::sort(first.begin(), first.end());
   std::sort(second.begin(), second.end());
   return std::includes(first.begin(), first.end(), second.begin(),
                        second.end());
 }
 
-static bool HasElement(const std::vector<thid_t> &vector, thid_t element) {
+static bool HasElement(const std::vector<ThreadID> &vector, ThreadID element) {
   return std::find(vector.begin(), vector.end(), element) != vector.end();
 }
 
 // ThreadLister's output should include the current thread's TID and the TID of
 // every thread we spawned.
 TEST_F(ThreadListerTest, ThreadListerSeesAllSpawnedThreads) {
-  thid_t self_tid = GetTid();
+  ThreadID self_tid = GetTid();
   ThreadLister thread_lister(getpid());
-  std::vector<thid_t> listed_tids = ReadTidsToVector(&thread_lister);
+  std::vector<ThreadID> listed_tids = ReadTidsToVector(&thread_lister);
   ASSERT_TRUE(HasElement(listed_tids, self_tid));
   ASSERT_TRUE(Includes(listed_tids, tids_));
 
@@ -154,7 +154,7 @@ TEST_F(ThreadListerTest, DoNotForgetThreads) {
   // Run the loop body twice, because ThreadLister might behave differently if
   // called on a freshly created object.
   for (uptr i = 0; i < 2; i++) {
-    std::vector<thid_t> listed_tids = ReadTidsToVector(&thread_lister);
+    std::vector<ThreadID> listed_tids = ReadTidsToVector(&thread_lister);
     ASSERT_TRUE(Includes(listed_tids, tids_));
   }
 }
@@ -163,10 +163,10 @@ TEST_F(ThreadListerTest, DoNotForgetThreads) {
 // relisting should cause ThreadLister to recognize their existence.
 TEST_F(ThreadListerTest, NewThreads) {
   ThreadLister thread_lister(getpid());
-  std::vector<thid_t> threads_before_extra = ReadTidsToVector(&thread_lister);
+  std::vector<ThreadID> threads_before_extra = ReadTidsToVector(&thread_lister);
 
   pthread_t extra_pthread_id;
-  thid_t extra_tid;
+  ThreadID extra_tid;
   SpawnTidReporter(&extra_pthread_id, &extra_tid);
   // Register the new thread so it gets terminated in TearDown().
   pthread_ids_.push_back(extra_pthread_id);
@@ -176,7 +176,7 @@ TEST_F(ThreadListerTest, NewThreads) {
   // so better check for that.
   ASSERT_FALSE(HasElement(threads_before_extra, extra_tid));
 
-  std::vector<thid_t> threads_after_extra = ReadTidsToVector(&thread_lister);
+  std::vector<ThreadID> threads_after_extra = ReadTidsToVector(&thread_lister);
   ASSERT_TRUE(HasElement(threads_after_extra, extra_tid));
 }
 

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_linux_test.cpp
@@ -124,7 +124,8 @@ static std::vector<ThreadID> ReadTidsToVector(ThreadLister *thread_lister) {
   return std::vector<ThreadID>(threads.begin(), threads.end());
 }
 
-static bool Includes(std::vector<ThreadID> first, std::vector<ThreadID> second) {
+static bool Includes(std::vector<ThreadID> first,
+                     std::vector<ThreadID> second) {
   std::sort(first.begin(), first.end());
   std::sort(second.begin(), second.end());
   return std::includes(first.begin(), first.end(), second.begin(),

--- a/compiler-rt/lib/tsan/rtl/tsan_debugging.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_debugging.cpp
@@ -165,7 +165,7 @@ int __tsan_get_report_mutex(void *report, uptr idx, uptr *mutex_id, void **addr,
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE
-int __tsan_get_report_thread(void *report, uptr idx, int *tid, tid_t *os_id,
+int __tsan_get_report_thread(void *report, uptr idx, int *tid, thid_t *os_id,
                              int *running, const char **name, int *parent_tid,
                              void **trace, uptr trace_size) {
   const ReportDesc *rep = (ReportDesc *)report;
@@ -242,7 +242,7 @@ const char *__tsan_locate_address(uptr addr, char *name, uptr name_size,
 
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_get_alloc_stack(uptr addr, uptr *trace, uptr size, int *thread_id,
-                           tid_t *os_id) {
+                           thid_t *os_id) {
   MBlock *b = 0;
   Allocator *a = allocator();
   if (a->PointerIsMine((void *)addr)) {

--- a/compiler-rt/lib/tsan/rtl/tsan_debugging.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_debugging.cpp
@@ -165,7 +165,7 @@ int __tsan_get_report_mutex(void *report, uptr idx, uptr *mutex_id, void **addr,
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE
-int __tsan_get_report_thread(void *report, uptr idx, int *tid, thid_t *os_id,
+int __tsan_get_report_thread(void *report, uptr idx, int *tid, ThreadID *os_id,
                              int *running, const char **name, int *parent_tid,
                              void **trace, uptr trace_size) {
   const ReportDesc *rep = (ReportDesc *)report;
@@ -242,7 +242,7 @@ const char *__tsan_locate_address(uptr addr, char *name, uptr name_size,
 
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_get_alloc_stack(uptr addr, uptr *trace, uptr size, int *thread_id,
-                           thid_t *os_id) {
+                           ThreadID *os_id) {
   MBlock *b = 0;
   Allocator *a = allocator();
   if (a->PointerIsMine((void *)addr)) {

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2893,7 +2893,7 @@ TSAN_INTERCEPTOR(void, thr_exit, thid_t *state) {
   DestroyThreadState();
   REAL(thr_exit(state));
 }
-#define TSAN_MAYBE_INTERCEPT_THR_EXIT TSAN_INTERCEPT(thr_exit)
+#  define TSAN_MAYBE_INTERCEPT_THR_EXIT TSAN_INTERCEPT(thr_exit)
 #else
 #define TSAN_MAYBE_INTERCEPT_THR_EXIT
 #endif

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2888,7 +2888,7 @@ TSAN_INTERCEPTOR(void, _lwp_exit) {
 #endif
 
 #if SANITIZER_FREEBSD
-TSAN_INTERCEPTOR(void, thr_exit, tid_t *state) {
+TSAN_INTERCEPTOR(void, thr_exit, thid_t *state) {
   SCOPED_TSAN_INTERCEPTOR(thr_exit, state);
   DestroyThreadState();
   REAL(thr_exit(state));

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2888,7 +2888,7 @@ TSAN_INTERCEPTOR(void, _lwp_exit) {
 #endif
 
 #if SANITIZER_FREEBSD
-TSAN_INTERCEPTOR(void, thr_exit, thid_t *state) {
+TSAN_INTERCEPTOR(void, thr_exit, ThreadID *state) {
   SCOPED_TSAN_INTERCEPTOR(thr_exit, state);
   DestroyThreadState();
   REAL(thr_exit(state));

--- a/compiler-rt/lib/tsan/rtl/tsan_interface.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface.h
@@ -16,7 +16,7 @@
 #define TSAN_INTERFACE_H
 
 #include <sanitizer_common/sanitizer_internal_defs.h>
-using __sanitizer::thid_t;
+using __sanitizer::ThreadID;
 using __sanitizer::uptr;
 
 // This header should NOT include any other headers.
@@ -175,7 +175,7 @@ int __tsan_get_report_mutex(void *report, uptr idx, uptr *mutex_id, void **addr,
 
 // Returns information about threads included in the report.
 SANITIZER_INTERFACE_ATTRIBUTE
-int __tsan_get_report_thread(void *report, uptr idx, int *tid, thid_t *os_id,
+int __tsan_get_report_thread(void *report, uptr idx, int *tid, ThreadID *os_id,
                              int *running, const char **name, int *parent_tid,
                              void **trace, uptr trace_size);
 
@@ -192,7 +192,7 @@ const char *__tsan_locate_address(uptr addr, char *name, uptr name_size,
 // Returns the allocation stack for a heap pointer.
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_get_alloc_stack(uptr addr, uptr *trace, uptr size, int *thread_id,
-                           thid_t *os_id);
+                           ThreadID *os_id);
 
 #endif  // SANITIZER_GO
 

--- a/compiler-rt/lib/tsan/rtl/tsan_interface.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface.h
@@ -16,7 +16,7 @@
 #define TSAN_INTERFACE_H
 
 #include <sanitizer_common/sanitizer_internal_defs.h>
-using __sanitizer::tid_t;
+using __sanitizer::thid_t;
 using __sanitizer::uptr;
 
 // This header should NOT include any other headers.
@@ -175,7 +175,7 @@ int __tsan_get_report_mutex(void *report, uptr idx, uptr *mutex_id, void **addr,
 
 // Returns information about threads included in the report.
 SANITIZER_INTERFACE_ATTRIBUTE
-int __tsan_get_report_thread(void *report, uptr idx, int *tid, tid_t *os_id,
+int __tsan_get_report_thread(void *report, uptr idx, int *tid, thid_t *os_id,
                              int *running, const char **name, int *parent_tid,
                              void **trace, uptr trace_size);
 
@@ -192,7 +192,7 @@ const char *__tsan_locate_address(uptr addr, char *name, uptr name_size,
 // Returns the allocation stack for a heap pointer.
 SANITIZER_INTERFACE_ATTRIBUTE
 int __tsan_get_alloc_stack(uptr addr, uptr *trace, uptr size, int *thread_id,
-                           tid_t *os_id);
+                           thid_t *os_id);
 
 #endif  // SANITIZER_GO
 

--- a/compiler-rt/lib/tsan/rtl/tsan_report.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.h
@@ -84,7 +84,7 @@ struct ReportLocation {
 
 struct ReportThread {
   Tid id;
-  tid_t os_id;
+  thid_t os_id;
   bool running;
   ThreadType thread_type;
   char *name;

--- a/compiler-rt/lib/tsan/rtl/tsan_report.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_report.h
@@ -84,7 +84,7 @@ struct ReportLocation {
 
 struct ReportThread {
   Tid id;
-  thid_t os_id;
+  ThreadID os_id;
   bool running;
   ThreadType thread_type;
   char *name;

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -559,7 +559,7 @@ void ThreadIgnoreSyncBegin(ThreadState *thr, uptr pc);
 void ThreadIgnoreSyncEnd(ThreadState *thr);
 
 Tid ThreadCreate(ThreadState *thr, uptr pc, uptr uid, bool detached);
-void ThreadStart(ThreadState *thr, Tid tid, tid_t os_id,
+void ThreadStart(ThreadState *thr, Tid tid, thid_t os_id,
                  ThreadType thread_type);
 void ThreadFinish(ThreadState *thr);
 Tid ThreadConsumeTid(ThreadState *thr, uptr pc, uptr uid);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -559,7 +559,7 @@ void ThreadIgnoreSyncBegin(ThreadState *thr, uptr pc);
 void ThreadIgnoreSyncEnd(ThreadState *thr);
 
 Tid ThreadCreate(ThreadState *thr, uptr pc, uptr uid, bool detached);
-void ThreadStart(ThreadState *thr, Tid tid, thid_t os_id,
+void ThreadStart(ThreadState *thr, Tid tid, ThreadID os_id,
                  ThreadType thread_type);
 void ThreadFinish(ThreadState *thr);
 Tid ThreadConsumeTid(ThreadState *thr, uptr pc, uptr uid);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
@@ -149,7 +149,7 @@ struct OnStartedArgs {
   uptr tls_size;
 };
 
-void ThreadStart(ThreadState *thr, Tid tid, tid_t os_id,
+void ThreadStart(ThreadState *thr, Tid tid, thid_t os_id,
                  ThreadType thread_type) {
   ctx->thread_registry.StartThread(tid, os_id, thread_type, thr);
   if (!thr->ignore_sync) {

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
@@ -149,7 +149,7 @@ struct OnStartedArgs {
   uptr tls_size;
 };
 
-void ThreadStart(ThreadState *thr, Tid tid, thid_t os_id,
+void ThreadStart(ThreadState *thr, Tid tid, ThreadID os_id,
                  ThreadType thread_type) {
   ctx->thread_registry.StartThread(tid, os_id, thread_type, thr);
   if (!thr->ignore_sync) {

--- a/compiler-rt/lib/xray/xray_fdr_controller.h
+++ b/compiler-rt/lib/xray/xray_fdr_controller.h
@@ -32,7 +32,7 @@ template <size_t Version = 5> class FDRController {
   uint64_t LastFunctionEntryTSC = 0;
   uint64_t LatestTSC = 0;
   uint16_t LatestCPU = 0;
-  tid_t TId = 0;
+  thid_t TId = 0;
   pid_t PId = 0;
   bool First = true;
 
@@ -84,7 +84,7 @@ template <size_t Version = 5> class FDRController {
         // buffer, associated with a particular thread, with a new CPU. For the
         // data, we have 15 bytes to squeeze as much information as we can. At
         // this point we only write down the following bytes:
-        //   - Thread ID (tid_t, cast to 4 bytes type due to Darwin being 8
+        //   - Thread ID (thid_t, cast to 4 bytes type due to Darwin being 8
         //   bytes)
         createMetadataRecord<MetadataRecord::RecordKinds::NewBuffer>(
             static_cast<int32_t>(TId)),

--- a/compiler-rt/lib/xray/xray_fdr_controller.h
+++ b/compiler-rt/lib/xray/xray_fdr_controller.h
@@ -32,7 +32,7 @@ template <size_t Version = 5> class FDRController {
   uint64_t LastFunctionEntryTSC = 0;
   uint64_t LatestTSC = 0;
   uint16_t LatestCPU = 0;
-  thid_t TId = 0;
+  ThreadID TId = 0;
   pid_t PId = 0;
   bool First = true;
 
@@ -84,7 +84,7 @@ template <size_t Version = 5> class FDRController {
         // buffer, associated with a particular thread, with a new CPU. For the
         // data, we have 15 bytes to squeeze as much information as we can. At
         // this point we only write down the following bytes:
-        //   - Thread ID (thid_t, cast to 4 bytes type due to Darwin being 8
+        //   - Thread ID (ThreadID, cast to 4 bytes type due to Darwin being 8
         //   bytes)
         createMetadataRecord<MetadataRecord::RecordKinds::NewBuffer>(
             static_cast<int32_t>(TId)),

--- a/compiler-rt/lib/xray/xray_profile_collector.cpp
+++ b/compiler-rt/lib/xray/xray_profile_collector.cpp
@@ -28,7 +28,7 @@ namespace {
 
 SpinMutex GlobalMutex;
 struct ThreadTrie {
-  tid_t TId;
+  thid_t TId;
   alignas(FunctionCallTrie) std::byte TrieStorage[sizeof(FunctionCallTrie)];
 };
 
@@ -61,7 +61,7 @@ struct ThreadData {
   FunctionCallTrie::Allocators::Buffers Buffers;
   FunctionCallTrie::Allocators Allocators;
   FunctionCallTrie FCT;
-  tid_t TId;
+  thid_t TId;
 };
 
 using ThreadDataArray = Array<ThreadData>;
@@ -105,7 +105,7 @@ static atomic_uint8_t CollectorInitialized{0};
 void post(BufferQueue *Q, FunctionCallTrie &&T,
           FunctionCallTrie::Allocators &&A,
           FunctionCallTrie::Allocators::Buffers &&B,
-          tid_t TId) XRAY_NEVER_INSTRUMENT {
+          thid_t TId) XRAY_NEVER_INSTRUMENT {
   DCHECK_NE(Q, nullptr);
 
   // Bail out early if the collector has not been initialized.

--- a/compiler-rt/lib/xray/xray_profile_collector.cpp
+++ b/compiler-rt/lib/xray/xray_profile_collector.cpp
@@ -28,7 +28,7 @@ namespace {
 
 SpinMutex GlobalMutex;
 struct ThreadTrie {
-  thid_t TId;
+  ThreadID TId;
   alignas(FunctionCallTrie) std::byte TrieStorage[sizeof(FunctionCallTrie)];
 };
 
@@ -61,7 +61,7 @@ struct ThreadData {
   FunctionCallTrie::Allocators::Buffers Buffers;
   FunctionCallTrie::Allocators Allocators;
   FunctionCallTrie FCT;
-  thid_t TId;
+  ThreadID TId;
 };
 
 using ThreadDataArray = Array<ThreadData>;
@@ -105,7 +105,7 @@ static atomic_uint8_t CollectorInitialized{0};
 void post(BufferQueue *Q, FunctionCallTrie &&T,
           FunctionCallTrie::Allocators &&A,
           FunctionCallTrie::Allocators::Buffers &&B,
-          thid_t TId) XRAY_NEVER_INSTRUMENT {
+          ThreadID TId) XRAY_NEVER_INSTRUMENT {
   DCHECK_NE(Q, nullptr);
 
   // Bail out early if the collector has not been initialized.

--- a/compiler-rt/lib/xray/xray_profile_collector.h
+++ b/compiler-rt/lib/xray/xray_profile_collector.h
@@ -38,7 +38,7 @@ namespace profileCollectorService {
 ///
 void post(BufferQueue *Q, FunctionCallTrie &&T,
           FunctionCallTrie::Allocators &&A,
-          FunctionCallTrie::Allocators::Buffers &&B, tid_t TId);
+          FunctionCallTrie::Allocators::Buffers &&B, thid_t TId);
 
 /// The serialize will process all FunctionCallTrie instances in memory, and
 /// turn those into specifically formatted blocks, each describing the

--- a/compiler-rt/lib/xray/xray_profile_collector.h
+++ b/compiler-rt/lib/xray/xray_profile_collector.h
@@ -38,7 +38,7 @@ namespace profileCollectorService {
 ///
 void post(BufferQueue *Q, FunctionCallTrie &&T,
           FunctionCallTrie::Allocators &&A,
-          FunctionCallTrie::Allocators::Buffers &&B, thid_t TId);
+          FunctionCallTrie::Allocators::Buffers &&B, ThreadID TId);
 
 /// The serialize will process all FunctionCallTrie instances in memory, and
 /// turn those into specifically formatted blocks, each describing the


### PR DESCRIPTION
`tid_t` is also defined in the AIX header `/usr/include/sys/types.h` which is included by system `pthread.h`. The use of `tid_t` by AIX is conforming according to [POSIX](https://pubs.opengroup.org/onlinepubs/9799919799/functions/V2_chap02.html):
> Implementations may add symbols to the headers shown in the following table [ ... ]