### PR TITLE
[libclc] Enable -fdiscard-value-names build flag to reduce bitcode size

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -405,6 +405,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       -I${CMAKE_CURRENT_SOURCE_DIR}/clc/include
       # Error on undefined macros
       -Werror=undef
+      -fdiscard-value-names
     )
 
     if( NOT "${cpu}" STREQUAL "" )


### PR DESCRIPTION
The flag reduces nvptx64--nvidiacl.bc size from 10.6MB to 5.2MB.