### PR TITLE
[llvm][cmake] Add clang if not already present when building lldb

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -181,8 +181,9 @@ endif()
 
 if ("lldb" IN_LIST LLVM_ENABLE_PROJECTS)
   if (NOT "clang" IN_LIST LLVM_ENABLE_PROJECTS)
-    message(FATAL_ERROR "Clang is not enabled, but is required for lldb.")
-  endif ()
+    message(STATUS "Enabling clang as a dependency of lldb")
+    list(APPEND LLVM_ENABLE_PROJECTS "clang")
+  endif()
 endif ()
 
 if ("libc" IN_LIST LLVM_ENABLE_PROJECTS)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -179,6 +179,12 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
   endif ()
 endif()
 
+if ("lldb" IN_LIST LLVM_ENABLE_PROJECTS)
+  if (NOT "clang" IN_LIST LLVM_ENABLE_PROJECTS)
+    message(FATAL_ERROR "Clang is not enabled, but is required for lldb.")
+  endif ()
+endif ()
+
 if ("libc" IN_LIST LLVM_ENABLE_PROJECTS)
   message(WARNING "Using LLVM_ENABLE_PROJECTS=libc is deprecated.  Please use "
     "-DLLVM_ENABLE_RUNTIMES=libc or see the instructions at "


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/54555

This follows flang's pattern, it adds clang if you don't have it in LLVM_ENABLE_PROJECTS.