### PR TITLE
[Clang] Fix export declaration diagnostic message

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10642,7 +10642,7 @@ def warn_dangling_reference_captured_by_unknown : Warning<
    "the full-expression">, InGroup<DanglingCapture>;
 
 def warn_experimental_lifetime_safety_dummy_warning : Warning<
-   "todo: remove this warning after we have atleast one warning based on the lifetime analysis">, 
+   "todo: remove this warning after we have atleast one warning based on the lifetime analysis">,
    InGroup<LifetimeSafety>, DefaultIgnore;
 
 // For non-floating point, expressions of the form x == x or x != x
@@ -12357,7 +12357,7 @@ def err_export_using_internal : Error<
   "using declaration referring to %1 with %select{internal|module|unknown}0 "
   "linkage cannot be exported">;
 def err_export_not_in_module_interface : Error<
-  "export declaration can only be used within a module purview">;
+  "export declaration can only be used within a module interface">;
 def err_export_inline_not_defined : Error<
   "inline function not defined%select{| before the private module fragment}0">;
 def err_export_partition_impl : Error<
@@ -12540,7 +12540,7 @@ def warn_zero_as_null_pointer_constant : Warning<
   InGroup<DiagGroup<"zero-as-null-pointer-constant">>, DefaultIgnore;
 
 def warn_not_eliding_copy_on_return : Warning<
-  "not eliding copy on return">, 
+  "not eliding copy on return">,
   InGroup<DiagGroup<"nrvo">>, DefaultIgnore;
 
 def err_nullability_cs_multilevel : Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10642,7 +10642,7 @@ def warn_dangling_reference_captured_by_unknown : Warning<
    "the full-expression">, InGroup<DanglingCapture>;
 
 def warn_experimental_lifetime_safety_dummy_warning : Warning<
-   "todo: remove this warning after we have atleast one warning based on the lifetime analysis">,
+   "todo: remove this warning after we have atleast one warning based on the lifetime analysis">, 
    InGroup<LifetimeSafety>, DefaultIgnore;
 
 // For non-floating point, expressions of the form x == x or x != x
@@ -12540,7 +12540,7 @@ def warn_zero_as_null_pointer_constant : Warning<
   InGroup<DiagGroup<"zero-as-null-pointer-constant">>, DefaultIgnore;
 
 def warn_not_eliding_copy_on_return : Warning<
-  "not eliding copy on return">,
+  "not eliding copy on return">, 
   InGroup<DiagGroup<"nrvo">>, DefaultIgnore;
 
 def err_nullability_cs_multilevel : Error<

--- a/clang/test/CXX/drs/cwg8xx.cpp
+++ b/clang/test/CXX/drs/cwg8xx.cpp
@@ -9,10 +9,10 @@
 namespace cwg820 { // cwg820: 2.7
 export template <class T> struct B {};
 // cxx98-17-warning@-1 {{exported templates are unsupported}}
-// since-cxx20-error@-2 {{export declaration can only be used within a module purview}}
+// since-cxx20-error@-2 {{export declaration can only be used within a module interface}}
 export template<typename T> void f() {}
 // cxx98-17-warning@-1 {{exported templates are unsupported}}
-// since-cxx20-error@-2 {{export declaration can only be used within a module purview}}
+// since-cxx20-error@-2 {{export declaration can only be used within a module interface}}
 } // namespace cwg820
 
 namespace cwg873 { // cwg873: 3.0

--- a/clang/test/CXX/module/dcl.dcl/dcl.module/dcl.module.interface/p1.cppm
+++ b/clang/test/CXX/module/dcl.dcl/dcl.module/dcl.module.interface/p1.cppm
@@ -9,7 +9,7 @@
 
 //--- ExportDeclNotInModulePurview.cppm
 // expected-error@* {{missing 'export module' declaration in module interface unit}}
-export int b; // expected-error {{export declaration can only be used within a module purview}}
+export int b; // expected-error {{export declaration can only be used within a module interface}}
 
 //--- A.cppm
 // expected-no-diagnostics
@@ -18,7 +18,7 @@ export int a;
 
 //--- AddExport.cppm
 module A; // #module-decl
-export int b; // expected-error {{export declaration can only be used within a module purview}}
+export int b; // expected-error {{export declaration can only be used within a module interface}}
 // expected-note@#module-decl {{add 'export' here}}
 
 //--- AddExport2.cppm

--- a/clang/test/CXX/module/module.interface/p1.cpp
+++ b/clang/test/CXX/module/module.interface/p1.cpp
@@ -7,7 +7,7 @@
 
 //--- errors.cpp
 module;
-export int a; // expected-error {{export declaration can only be used within a module purview}}
+export int a; // expected-error {{export declaration can only be used within a module interface}}
 export module M;
 export int b; // #1
 namespace N {
@@ -37,8 +37,8 @@ namespace N {
 //--- impl.cpp
 module M; // #M
 
-export int b2; // expected-error {{export declaration can only be used within a module purview}}
+export int b2; // expected-error {{export declaration can only be used within a module interface}}
 namespace N {
-  export int c2; // expected-error {{export declaration can only be used within a module purview}}
+  export int c2; // expected-error {{export declaration can only be used within a module interface}}
 }
 // expected-note@#M 2+{{add 'export'}}

--- a/clang/test/Modules/cxx20-10-2-ex1.cpp
+++ b/clang/test/Modules/cxx20-10-2-ex1.cpp
@@ -14,7 +14,7 @@ export int x;
 module;
 
 #include "std-10-2-ex1.h"
-// expected-error@std-10-2-ex1.h:* {{export declaration can only be used within a module purview}}
+// expected-error@std-10-2-ex1.h:* {{export declaration can only be used within a module interface}}
 
 export module M1;
 export namespace {} // expected-error {{anonymous namespaces cannot be exported}}

--- a/clang/test/Modules/cxx20-export-import.cpp
+++ b/clang/test/Modules/cxx20-export-import.cpp
@@ -11,4 +11,4 @@
 export module dummy;
 
 //--- test.cpp
-export import dummy; // expected-error {{export declaration can only be used within a module purview}}
+export import dummy; // expected-error {{export declaration can only be used within a module interface}}

--- a/clang/test/Modules/cxx20-import-diagnostics-a.cpp
+++ b/clang/test/Modules/cxx20-import-diagnostics-a.cpp
@@ -110,7 +110,7 @@ module;
 
 module AOK1;
 
-export import C; // expected-error {{export declaration can only be used within a module purview}}
+export import C; // expected-error {{export declaration can only be used within a module interface}}
 
 int theAnswer () { return 42; }
 

--- a/clang/test/Modules/export-in-non-modules.cpp
+++ b/clang/test/Modules/export-in-non-modules.cpp
@@ -1,4 +1,4 @@
 // RUN: %clang_cc1 -std=c++20 %s -fsyntax-only -verify
-export struct Unit { // expected-error {{export declaration can only be used within a module purview}}
+export struct Unit { // expected-error {{export declaration can only be used within a module interface}}
   bool operator<(const Unit &);
 };


### PR DESCRIPTION
Change the error message from "export declaration can only be used within a module purview" to "export declaration can only be used within a module interface" to be technically accurate.

The previous message was misleading because export declarations are actually within a module purview when used in module implementation units, but they are only allowed in module interface units.

This addresses the issue pointed out in GitHub issue #149008 where Bigcheese noted that the diagnostic wording was incorrect.

Fixes #149008