### PR TITLE
[Offload] Remove unnecessary omp CMake target dependencies

### DIFF
--- a/offload/libomptarget/CMakeLists.txt
+++ b/offload/libomptarget/CMakeLists.txt
@@ -1,11 +1,5 @@
 message(STATUS "Building offloading runtime library libomptarget.")
 
-if(LIBOMP_STANDALONE)
-  set(LIBOMP ${LIBOMP_STANDALONE})
-else()
-  set(LIBOMP omp)
-endif()
-
 add_llvm_library(omptarget
   SHARED
 
@@ -32,10 +26,6 @@ add_llvm_library(omptarget
   FrontendOpenMP
   Support
   Object
-
-  LINK_LIBS
-  PUBLIC
-  ${LIBOMP}
 
   NO_INSTALL_RPATH
   BUILDTREE_ONLY

--- a/offload/tools/deviceinfo/CMakeLists.txt
+++ b/offload/tools/deviceinfo/CMakeLists.txt
@@ -8,6 +8,5 @@ target_include_directories(llvm-offload-device-info PRIVATE
   ${LIBOMPTARGET_INCLUDE_DIR}
 )
 target_link_libraries(llvm-offload-device-info PRIVATE
-  omp
   omptarget
 )

--- a/offload/tools/kernelreplay/CMakeLists.txt
+++ b/offload/tools/kernelreplay/CMakeLists.txt
@@ -9,6 +9,5 @@ target_include_directories(llvm-omp-kernel-replay PRIVATE
 )
 target_link_libraries(llvm-omp-kernel-replay PRIVATE
   LLVMSupport
-  omp
   omptarget
 )


### PR DESCRIPTION
In my quest to build `liboffload` with ASAN enabled I've been looking into decoupling `offload` and `openmp` project entablement. When removing `openmp` from `LLVM_ENABLE_PROJECTS` it resulted in failure to link against the `omp` target. As an experiment I disabled that dependency and the build appears to work as expected.

This patch removes dependencies on the `omp` target from `libomptarget`/`llvm-offload-device-info`/`llvm-omp-kernel-replay` targets.
