### PR TITLE
[Clang] Reintroduce obsolete libclang symbols to avoid an ABI break

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6953,6 +6953,21 @@ clang_getCursorUnaryOperatorKind(CXCursor cursor);
  * @}
  */
 
+CINDEX_DEPRECATED
+typedef void *CXRemapping;
+
+CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping
+clang_getRemappingsFromFileList(const char **, unsigned);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE unsigned clang_remap_getNumFiles(CXRemapping);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE void
+clang_remap_getFilenames(CXRemapping, unsigned, CXString *, CXString *);
+
+CINDEX_DEPRECATED CINDEX_LINKAGE void clang_remap_dispose(CXRemapping);
+
 LLVM_CLANG_C_EXTERN_C_END
 
 #endif

--- a/clang/tools/libclang/CMakeLists.txt
+++ b/clang/tools/libclang/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SOURCES
   Indexing.cpp
   FatalErrorHandler.cpp
   Rewrite.cpp
+  Obsolete.cpp
 
   ADDITIONAL_HEADERS
   CIndexDiagnostic.h

--- a/clang/tools/libclang/Obsolete.cpp
+++ b/clang/tools/libclang/Obsolete.cpp
@@ -1,0 +1,46 @@
+//===- Obsolete.cpp - Obsolete libclang functions and types -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===--------------------------------------------------------------------===//
+//
+// This file contains libclang symbols whose underlying functionality has been
+// removed from Clang, but which need to be kept around so as to retain ABI
+// compatibility.
+//
+//===--------------------------------------------------------------------===//
+
+#include "clang-c/CXString.h"
+#include "clang-c/Platform.h"
+#include "llvm/Support/raw_ostream.h"
+
+// The functions below used to be part of the C API for ARCMigrate, which has
+// since been removed from Clang; they already used to print an error if Clang
+// was compiled without arcmt support, so we continue doing so.
+typedef void *CXRemapping;
+CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *) {
+  llvm::errs() << "error: ARCMigrate has been removed from Clang";
+  return nullptr;
+}
+
+CINDEX_LINKAGE
+CXRemapping clang_getRemappingsFromFileList(const char **, unsigned) {
+  llvm::errs() << "error: ARCMigrate has been removed from Clang";
+  return nullptr;
+}
+
+CINDEX_LINKAGE unsigned clang_remap_getNumFiles(CXRemapping) {
+  llvm::errs() << "error: ARCMigrate has been removed from Clang";
+  return 0;
+}
+
+CINDEX_LINKAGE void clang_remap_getFilenames(CXRemapping, unsigned, CXString *,
+                                             CXString *) {
+  llvm::errs() << "error: ARCMigrate has been removed from Clang";
+}
+
+CINDEX_LINKAGE void clang_remap_dispose(CXRemapping) {
+  llvm::errs() << "error: ARCMigrate has been removed from Clang";
+}

--- a/clang/tools/libclang/Obsolete.cpp
+++ b/clang/tools/libclang/Obsolete.cpp
@@ -16,6 +16,8 @@
 #include "clang-c/Platform.h"
 #include "llvm/Support/raw_ostream.h"
 
+extern "C" {
+
 // The functions below used to be part of the C API for ARCMigrate, which has
 // since been removed from Clang; they already used to print an error if Clang
 // was compiled without arcmt support, so we continue doing so.
@@ -44,3 +46,5 @@ CINDEX_LINKAGE void clang_remap_getFilenames(CXRemapping, unsigned, CXString *,
 CINDEX_LINKAGE void clang_remap_dispose(CXRemapping) {
   llvm::errs() << "error: ARCMigrate has been removed from Clang";
 }
+
+} // extern "C"

--- a/clang/tools/libclang/Obsolete.cpp
+++ b/clang/tools/libclang/Obsolete.cpp
@@ -13,6 +13,7 @@
 //===--------------------------------------------------------------------===//
 
 #include "clang-c/CXString.h"
+#include "clang-c/Index.h"
 #include "clang-c/Platform.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -21,29 +22,26 @@ extern "C" {
 // The functions below used to be part of the C API for ARCMigrate, which has
 // since been removed from Clang; they already used to print an error if Clang
 // was compiled without arcmt support, so we continue doing so.
-typedef void *CXRemapping;
-CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *) {
+CXRemapping clang_getRemappings(const char *) {
   llvm::errs() << "error: ARCMigrate has been removed from Clang";
   return nullptr;
 }
 
-CINDEX_LINKAGE
 CXRemapping clang_getRemappingsFromFileList(const char **, unsigned) {
   llvm::errs() << "error: ARCMigrate has been removed from Clang";
   return nullptr;
 }
 
-CINDEX_LINKAGE unsigned clang_remap_getNumFiles(CXRemapping) {
+unsigned clang_remap_getNumFiles(CXRemapping) {
   llvm::errs() << "error: ARCMigrate has been removed from Clang";
   return 0;
 }
 
-CINDEX_LINKAGE void clang_remap_getFilenames(CXRemapping, unsigned, CXString *,
-                                             CXString *) {
+void clang_remap_getFilenames(CXRemapping, unsigned, CXString *, CXString *) {
   llvm::errs() << "error: ARCMigrate has been removed from Clang";
 }
 
-CINDEX_LINKAGE void clang_remap_dispose(CXRemapping) {
+void clang_remap_dispose(CXRemapping) {
   llvm::errs() << "error: ARCMigrate has been removed from Clang";
 }
 

--- a/llvm/utils/gn/secondary/clang/tools/libclang/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/tools/libclang/BUILD.gn
@@ -87,6 +87,7 @@ shared_library("libclang") {
     "Index_Internal.h",
     "Indexing.cpp",
     "Rewrite.cpp",
+    "Obsolete.cpp",
   ]
   if (host_os == "mac") {
     ldflags = [


### PR DESCRIPTION
For more context, see https://github.com/llvm/llvm-project/pull/119269#issuecomment-3075444493, but briefly, when removing ARCMigrate, I also removed some symbols in libclang, which constitutes an ABI break that we don’t want, so this pr reintroduces the removed symbols; the declarations are marked as deprecated for future removal, and the implementations print an error and do nothing, which is what we used to do when ARCMigrate was disabled.