### PR TITLE
[Coverage] Add gap region between binary operator '&& and ||' and RHS

### DIFF
--- a/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -2269,6 +2269,11 @@ struct CounterCoverageMappingBuilder
     // Track LHS True/False Decision.
     const auto DecisionLHS = MCDCBuilder.pop();
 
+    if (auto Gap =
+            findGapAreaBetween(getEnd(E->getLHS()), getStart(E->getRHS()))) {
+      fillGapAreaWithCount(Gap->getBegin(), Gap->getEnd(), getRegionCounter(E));
+    }
+
     // Counter tracks the right hand side of a logical and operator.
     extendRegion(E->getRHS());
     propagateCounts(getRegionCounter(E), E->getRHS());
@@ -2329,6 +2334,11 @@ struct CounterCoverageMappingBuilder
 
     // Track LHS True/False Decision.
     const auto DecisionLHS = MCDCBuilder.pop();
+
+    if (auto Gap =
+            findGapAreaBetween(getEnd(E->getLHS()), getStart(E->getRHS()))) {
+      fillGapAreaWithCount(Gap->getBegin(), Gap->getEnd(), getRegionCounter(E));
+    }
 
     // Counter tracks the right hand side of a logical or operator.
     extendRegion(E->getRHS());

--- a/clang/test/CoverageMapping/logical.cpp
+++ b/clang/test/CoverageMapping/logical.cpp
@@ -1,27 +1,31 @@
 // RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -main-file-name logical.cpp %s | FileCheck %s
 // RUN: %clang_cc1 -mllvm -emptyline-comment-coverage=false -fcoverage-mcdc -fprofile-instrument=clang -fcoverage-mapping -dump-coverage-mapping -emit-llvm-only -main-file-name logical.cpp %s | FileCheck %s -check-prefix=MCDC
 
-int main() {                        // CHECK: File 0, [[@LINE]]:12 -> [[@LINE+23]]:2 = #0
+int main() {                        // CHECK: File 0, [[@LINE]]:12 -> [[@LINE+27]]:2 = #0
   bool bt = true;
   bool bf = false;                  // MCDC: Decision,File 0, [[@LINE+1]]:12 -> [[@LINE+1]]:20 = M:3, C:2
   bool a = bt && bf;                // CHECK-NEXT: File 0, [[@LINE]]:12 -> [[@LINE]]:14 = #0
                                     // CHECK-NEXT: Branch,File 0, [[@LINE-1]]:12 -> [[@LINE-1]]:14 = #1, (#0 - #1)
-                                    // CHECK-NEXT: File 0, [[@LINE-2]]:18 -> [[@LINE-2]]:20 = #1
-                                    // CHECK-NEXT: Branch,File 0, [[@LINE-3]]:18 -> [[@LINE-3]]:20 = #2, (#1 - #2)
+                                    // CHECK-NEXT: Gap,File 0, [[@LINE-2]]:14 -> [[@LINE-2]]:18 = #1
+                                    // CHECK-NEXT: File 0, [[@LINE-3]]:18 -> [[@LINE-3]]:20 = #1
+                                    // CHECK-NEXT: Branch,File 0, [[@LINE-4]]:18 -> [[@LINE-4]]:20 = #2, (#1 - #2)
                                     // MCDC: Decision,File 0, [[@LINE+1]]:7 -> [[@LINE+2]]:9 = M:6, C:2
   a = bt &&                         // CHECK-NEXT: File 0, [[@LINE]]:7 -> [[@LINE]]:9 = #0
       bf;                           // CHECK-NEXT: Branch,File 0, [[@LINE-1]]:7 -> [[@LINE-1]]:9 = #3, (#0 - #3)
-                                    // CHECK-NEXT: File 0, [[@LINE-1]]:7 -> [[@LINE-1]]:9 = #3
-                                    // CHECK-NEXT: Branch,File 0, [[@LINE-2]]:7 -> [[@LINE-2]]:9 = #4, (#3 - #4)
+                                    // CHECK-NEXT: Gap,File 0, [[@LINE-2]]:9 -> [[@LINE-1]]:7 = #3
+                                    // CHECK-NEXT: File 0, [[@LINE-2]]:7 -> [[@LINE-2]]:9 = #3
+                                    // CHECK-NEXT: Branch,File 0, [[@LINE-3]]:7 -> [[@LINE-3]]:9 = #4, (#3 - #4)
                                     // MCDC: Decision,File 0, [[@LINE+1]]:7 -> [[@LINE+1]]:15 = M:9, C:2
   a = bf || bt;                     // CHECK-NEXT: File 0, [[@LINE]]:7 -> [[@LINE]]:9 = #0
                                     // CHECK-NEXT: Branch,File 0, [[@LINE-1]]:7 -> [[@LINE-1]]:9 = (#0 - #5), #5
-                                    // CHECK-NEXT: File 0, [[@LINE-2]]:13 -> [[@LINE-2]]:15 = #5
-                                    // CHECK-NEXT: Branch,File 0, [[@LINE-3]]:13 -> [[@LINE-3]]:15 = (#5 - #6), #6
+                                    // CHECK-NEXT: Gap,File 0, [[@LINE-2]]:9 -> [[@LINE-2]]:13 = #5
+                                    // CHECK-NEXT: File 0, [[@LINE-3]]:13 -> [[@LINE-3]]:15 = #5
+                                    // CHECK-NEXT: Branch,File 0, [[@LINE-4]]:13 -> [[@LINE-4]]:15 = (#5 - #6), #6
                                     // MCDC: Decision,File 0, [[@LINE+1]]:7 -> [[@LINE+2]]:9 = M:12, C:2
   a = bf ||                         // CHECK-NEXT: File 0, [[@LINE]]:7 -> [[@LINE]]:9 = #0
       bt;                           // CHECK-NEXT: Branch,File 0, [[@LINE-1]]:7 -> [[@LINE-1]]:9 = (#0 - #7), #7
-                                    // CHECK-NEXT: File 0, [[@LINE-1]]:7 -> [[@LINE-1]]:9 = #7
-                                    // CHECK-NEXT: Branch,File 0, [[@LINE-2]]:7 -> [[@LINE-2]]:9 = (#7 - #8), #8
+                                    // CHECK-NEXT: Gap,File 0, [[@LINE-2]]:9 -> [[@LINE-1]]:7 = #7
+                                    // CHECK-NEXT: File 0, [[@LINE-2]]:7 -> [[@LINE-2]]:9 = #7
+                                    // CHECK-NEXT: Branch,File 0, [[@LINE-3]]:7 -> [[@LINE-3]]:9 = (#7 - #8), #8
   return 0;
 }

--- a/compiler-rt/test/profile/Linux/coverage_short_circuit.cpp
+++ b/compiler-rt/test/profile/Linux/coverage_short_circuit.cpp
@@ -8,7 +8,7 @@ void foo() {          // CHECK:       [[@LINE]]| 1|void foo() {
   bool cond2 = true;  // CHECK-NEXT:  [[@LINE]]| 1|  bool cond2 = true;
   if (cond1 &&        // CHECK-NEXT:  [[@LINE]]| 1|  if (cond1 &&
       cond2) {        // CHECK-NEXT:  [[@LINE]]| 0|      cond2) {
-  }                   // CHECK-NEXT:  [[@LINE]]| 0|  }
+  } // CHECK-NEXT:  [[@LINE]]| 0|  }
 } // CHECK-NEXT:  [[@LINE]]| 1|}
 
 void bar() {          // CHECK:       [[@LINE]]| 1|void bar() {
@@ -16,7 +16,7 @@ void bar() {          // CHECK:       [[@LINE]]| 1|void bar() {
   bool cond2 = false; // CHECK-NEXT:  [[@LINE]]| 1|  bool cond2 = false;
   if (cond1 &&        // CHECK-NEXT:  [[@LINE]]| 1|  if (cond1 &&
       cond2) {        // CHECK-NEXT:  [[@LINE]]| 1|      cond2) {
-  }                   // CHECK-NEXT:  [[@LINE]]| 0|  }
+  } // CHECK-NEXT:  [[@LINE]]| 0|  }
 } // CHECK-NEXT:  [[@LINE]]| 1|}
 
 void baz() {          // CHECK:       [[@LINE]]| 1|void baz() {
@@ -25,7 +25,7 @@ void baz() {          // CHECK:       [[@LINE]]| 1|void baz() {
   if (cond1           // CHECK-NEXT:  [[@LINE]]| 1|  if (cond1
       &&              // CHECK-NEXT:  [[@LINE]]| 0|      &&
       cond2) {        // CHECK-NEXT:  [[@LINE]]| 0|      cond2) {
-  }                   // CHECK-NEXT:  [[@LINE]]| 0|  }
+  } // CHECK-NEXT:  [[@LINE]]| 0|  }
 } // CHECK-NEXT:  [[@LINE]]| 1|}
 
 int main() {

--- a/compiler-rt/test/profile/Linux/coverage_short_circuit.cpp
+++ b/compiler-rt/test/profile/Linux/coverage_short_circuit.cpp
@@ -1,0 +1,36 @@
+// RUN: %clangxx_profgen -std=c++17 -fuse-ld=lld -fcoverage-mapping -o %t %s
+// RUN: env LLVM_PROFILE_FILE=%t.profraw %run %t
+// RUN: llvm-profdata merge -o %t.profdata %t.profraw
+// RUN: llvm-cov show %t -instr-profile=%t.profdata 2>&1 | FileCheck %s
+
+void foo() {          // CHECK:       [[@LINE]]| 1|void foo() {
+  bool cond1 = false; // CHECK-NEXT:  [[@LINE]]| 1|  bool cond1 = false;
+  bool cond2 = true;  // CHECK-NEXT:  [[@LINE]]| 1|  bool cond2 = true;
+  if (cond1 &&        // CHECK-NEXT:  [[@LINE]]| 1|  if (cond1 &&
+      cond2) {        // CHECK-NEXT:  [[@LINE]]| 0|      cond2) {
+  }                   // CHECK-NEXT:  [[@LINE]]| 0|  }
+} // CHECK-NEXT:  [[@LINE]]| 1|}
+
+void bar() {          // CHECK:       [[@LINE]]| 1|void bar() {
+  bool cond1 = true;  // CHECK-NEXT:  [[@LINE]]| 1|  bool cond1 = true;
+  bool cond2 = false; // CHECK-NEXT:  [[@LINE]]| 1|  bool cond2 = false;
+  if (cond1 &&        // CHECK-NEXT:  [[@LINE]]| 1|  if (cond1 &&
+      cond2) {        // CHECK-NEXT:  [[@LINE]]| 1|      cond2) {
+  }                   // CHECK-NEXT:  [[@LINE]]| 0|  }
+} // CHECK-NEXT:  [[@LINE]]| 1|}
+
+void baz() {          // CHECK:       [[@LINE]]| 1|void baz() {
+  bool cond1 = false; // CHECK-NEXT:  [[@LINE]]| 1|  bool cond1 = false;
+  bool cond2 = true;  // CHECK-NEXT:  [[@LINE]]| 1|  bool cond2 = true;
+  if (cond1           // CHECK-NEXT:  [[@LINE]]| 1|  if (cond1
+      &&              // CHECK-NEXT:  [[@LINE]]| 0|      &&
+      cond2) {        // CHECK-NEXT:  [[@LINE]]| 0|      cond2) {
+  }                   // CHECK-NEXT:  [[@LINE]]| 0|  }
+} // CHECK-NEXT:  [[@LINE]]| 1|}
+
+int main() {
+  foo();
+  bar();
+  baz();
+  return 0;
+}


### PR DESCRIPTION
## Issue Summary
We identified an inaccuracy in line coverage reporting when short-circuit evaluation occurs in multi-line conditional expressions. Specifically:
1. Un-executed conditions following line breaks may be incorrectly marked as covered
(e.g., conditionB in a non-executed && chain shows coverage)
```
    1|       |#include <iostream>
    2|       |
    3|      1|int main() {
    4|      1|    bool conditionA = false;
    5|      1|    bool conditionB = true;
    6|      1|    if (conditionA &&
    7|      1|        conditionB) {
    8|      0|        std::cout << "IF-THEN" << std::endl;
    9|      0|    }
   10|      1|    return 0;
   11|      1|}
```
2. Inconsistent coverage reporting across un-executed conditions
*(adjacent un-executed conditions may show 1 vs 0 line coverage)*
```
    1|       |#include <iostream>
    2|       |
    3|      1|int main() {
    4|      1|    bool conditionA = false;
    5|      1|    bool conditionB = true;
    6|      1|    bool conditionC = true;
    7|      1|    if (conditionA &&
    8|      1|        (conditionB ||
    9|      0|        conditionC)) {
   10|      0|        std::cout << "IF-THEN" << std::endl;
   11|      0|    }
   12|      1|    return 0;
   13|      1|}
```

## Root Cause Analysis
The current `WrappedSegment` mechanism may propagates coverage data from the last segment of the LHS line to subsequent RHS lines. Because the LHS line's coverage data depends on count of its segments and `WrappedSegment`'s count, it may causes false positive coverage for un-executed RHS conditions.

## Proposed Solution
The current implementation correctly handles single-statement if bodies through GapRegion insertion:
```
if (cond)       // Line 1
    statement;  // Line 2
```
Processing workflow:

1. A GapRegion is created spanning from the end of the condition (Line 1) to the start of the body statement (Line 2)
2. This GapRegion inherits the execution counter from Line 2
3. During coverage calculation:
  * Line 2 uses this GapRegion as its WrappedSegment
  * Prevents propagation of Line 1's coverage data to Line 2

Generalize the GapRegion insertion strategy from if-statements to logical operators, placing RHS-synchronized segments at LHS-line-end to isolate coverage contexts during short-circuit evaluation.
