### PR TITLE
[lldb] Print children-count warning for dwim-print and expr

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -150,6 +150,8 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
         return;
       }
     }
+    m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
+                                           m_cmd_name);
     result.SetStatus(eReturnStatusSuccessFinishResult);
   };
 

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -470,6 +470,9 @@ bool CommandObjectExpression::EvaluateExpression(llvm::StringRef expr,
           return false;
         }
 
+        m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
+                                               m_cmd_name);
+
         if (suppress_result)
           if (auto result_var_sp =
                   target.GetPersistentVariable(result_valobj_sp->GetName())) {

--- a/lldb/test/Shell/Settings/TestChildCountTruncation.test
+++ b/lldb/test/Shell/Settings/TestChildCountTruncation.test
@@ -1,0 +1,67 @@
+# Test that we warn the user about truncated output
+# when target.max-children-count wasn't explicitly set.
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
+# RUN: %lldb -x -b -s %t/dwim-commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s --check-prefix=DWIM
+#
+# RUN: %lldb -x -b -s %t/expr-commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s --check-prefix=EXPR
+#
+# RUN: %lldb -x -b -s %t/frame-var-commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s --check-prefix=VAR
+#
+# RUN: %lldb -x -b -s %t/with-setting-commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s --check-prefix=SETTING
+
+#--- main.cpp
+
+int main() {
+  int arr[512] = { 3 };
+  __builtin_debugtrap();
+}
+
+#--- dwim-commands.input
+
+run
+dwim-print arr
+frame variable arr
+
+DWIM:      (lldb) dwim-print arr
+DWIM:      *** Some of the displayed variables have more members
+DWIM-SAME: use the --show-all-children option to dwim-print
+DWIM:      (lldb) frame variable arr
+DWIM-NOT:  *** Some of the displayed variables have more members
+
+#--- expr-commands.input
+
+run
+expression arr
+frame variable arr
+
+EXPR:      (lldb) expression arr
+EXPR:      *** Some of the displayed variables have more members
+EXPR-SAME: use the --show-all-children option to expression
+EXPR:      (lldb) frame variable arr
+EXPR-NOT:  *** Some of the displayed variables have more members
+
+#--- frame-var-commands.input
+
+run
+frame variable arr
+
+VAR:      (lldb) frame variable arr
+VAR:      *** Some of the displayed variables have more members
+VAR-SAME: use the --show-all-children option to frame variable
+VAR:      (lldb) frame variable arr
+VAR-NOT:  *** Some of the displayed variables have more members
+
+#--- with-setting-commands.input
+
+run
+settings set target.max-children-count 1
+frame variable arr
+
+SETTING:      (lldb) frame variable arr
+SETTING-NOT:  *** Some of the displayed variables have more members


### PR DESCRIPTION
When dumping variables, LLDB will print a one-time warning about truncating children (when the children count exceeds the default `target.max-children-count`). But we only do this for `frame variable`. So if we use `dwim-print` or `expression`, the output gets truncated but we don't print a warning. But because we store the fact that we truncated some output on the `CommandInterpreter`, we fire the warning next time we use `frame variable`. E.g.,:
```
(lldb) p arr
(int[1000]) {
  [0] = -5
  [1] = 0
  [2] = 0
  <-- snipped -->
  [253] = 0
  [254] = 0
  [255] = 0
  ...
}
(lldb) v someLocal
(int) someLocal = 10
*** Some of the displayed variables have more members than the debugger
will show by default. To show all of them, you can either use the
--show-all-children option to frame variable or raise the limit by
changing the target.max-children-count setting.
```

This patch prints the warning for `dwim-print` and `expression`.

I only added a test for the `target.max-children-count` for now because it seems the `target.max-children-depth` warning is broken (I can't get it to fire).