### PR TITLE
[clang-linker-wrapper] Pass on --cuda-path to child clang processes

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -567,6 +567,8 @@ Expected<StringRef> clang(ArrayRef<StringRef> InputFiles, const ArgList &Args,
     CmdArgs.append({"-Xlinker", Args.MakeArgString(Arg)});
   for (StringRef Arg : Args.getAllArgValues(OPT_compiler_arg_EQ))
     CmdArgs.push_back(Args.MakeArgString(Arg));
+  for (StringRef Arg : Args.getAllArgValues(OPT_cuda_path_EQ))
+    CmdArgs.push_back(Args.MakeArgString("--cuda-path=" + Arg));
 
   if (Error Err = executeCommands(*ClangPath, CmdArgs))
     return std::move(Err);


### PR DESCRIPTION
When using clang-linker-wrapper with --cuda-path, it does not get passed on to the child device linking processes. This causes it to fail when cuda linking is involved and nvlink is not in $PATH. This patch lets the child linking process find nvlink through --cuda-path.