### PR TITLE
[lldb][SBType] GetBasicType to unwrap canonical type

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -5467,7 +5467,7 @@ CompilerType TypeSystemClang::GetBuiltinTypeByName(ConstString name) {
 lldb::BasicType
 TypeSystemClang::GetBasicTypeEnumeration(lldb::opaque_compiler_type_t type) {
   if (type) {
-    clang::QualType qual_type(GetQualType(type));
+    clang::QualType qual_type(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
     if (type_class == clang::Type::Builtin) {
       switch (llvm::cast<clang::BuiltinType>(qual_type)->getKind()) {

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -354,12 +354,11 @@ bool CompilerType::IsSigned() const {
 }
 
 bool CompilerType::IsNullPtrType() const {
-  return GetCanonicalType().GetBasicTypeEnumeration() ==
-         lldb::eBasicTypeNullPtr;
+  return GetBasicTypeEnumeration() == lldb::eBasicTypeNullPtr;
 }
 
 bool CompilerType::IsBoolean() const {
-  return GetCanonicalType().GetBasicTypeEnumeration() == lldb::eBasicTypeBool;
+  return GetBasicTypeEnumeration() == lldb::eBasicTypeBool;
 }
 
 bool CompilerType::IsEnumerationIntegerTypeSigned() const {
@@ -379,7 +378,7 @@ bool CompilerType::IsPromotableIntegerType() const {
   if (IsUnscopedEnumerationType())
     return true;
 
-  switch (GetCanonicalType().GetBasicTypeEnumeration()) {
+  switch (GetBasicTypeEnumeration()) {
   case lldb::eBasicTypeBool:
   case lldb::eBasicTypeChar:
   case lldb::eBasicTypeSignedChar:
@@ -455,8 +454,7 @@ bool CompilerType::IsContextuallyConvertibleToBool() const {
 }
 
 bool CompilerType::IsBasicType() const {
-  return GetCanonicalType().GetBasicTypeEnumeration() !=
-         lldb::eBasicTypeInvalid;
+  return GetBasicTypeEnumeration() != lldb::eBasicTypeInvalid;
 }
 
 std::string CompilerType::TypeDescription() {

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3228,8 +3228,8 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         llvm::APSInt ext =
             int_value_or_err->extOrTrunc(type_byte_size * CHAR_BIT);
         Scalar scalar_int(ext);
-        llvm::APFloat f = scalar_int.CreateAPFloatFromAPSInt(
-            type.GetCanonicalType().GetBasicTypeEnumeration());
+        llvm::APFloat f =
+            scalar_int.CreateAPFloatFromAPSInt(type.GetBasicTypeEnumeration());
         return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                          "result");
       } else {
@@ -3245,7 +3245,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         if (int_value_or_err) {
           Scalar scalar_int(*int_value_or_err);
           llvm::APFloat f = scalar_int.CreateAPFloatFromAPSInt(
-              type.GetCanonicalType().GetBasicTypeEnumeration());
+              type.GetBasicTypeEnumeration());
           return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                            "result");
         } else {
@@ -3261,7 +3261,7 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
         if (float_value_or_err) {
           Scalar scalar_float(*float_value_or_err);
           llvm::APFloat f = scalar_float.CreateAPFloatFromAPFloat(
-              type.GetCanonicalType().GetBasicTypeEnumeration());
+              type.GetBasicTypeEnumeration());
           return ValueObject::CreateValueObjectFromAPFloat(target, f, type,
                                                            "result");
         } else {

--- a/lldb/test/API/python_api/sbtype_basic_type/Makefile
+++ b/lldb/test/API/python_api/sbtype_basic_type/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -1,0 +1,32 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        """Test that SBType.GetBasicType unwraps typedefs."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "return", lldb.SBFileSpec("main.cpp")
+        )
+
+        a = self.frame().FindVariable("a")
+        self.assertTrue(a)
+
+        int_basic_type = a.GetType().GetBasicType()
+        self.assertEqual(int_basic_type, 13)
+
+        b = self.frame().FindVariable("b")
+        self.assertTrue(b)
+
+        c = self.frame().FindVariable("c")
+        self.assertTrue(c)
+
+        d = self.frame().FindVariable("d")
+        self.assertTrue(d)
+
+        self.assertEqual(a.GetType().GetBasicType(), int_basic_type)
+        self.assertEqual(b.GetType().GetBasicType(), int_basic_type)
+        self.assertEqual(c.GetType().GetBasicType(), int_basic_type)

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -27,6 +27,6 @@ class TestCase(TestBase):
         d = self.frame().FindVariable("d")
         self.assertTrue(d)
 
-        self.assertEqual(a.GetType().GetBasicType(), int_basic_type)
         self.assertEqual(b.GetType().GetBasicType(), int_basic_type)
         self.assertEqual(c.GetType().GetBasicType(), int_basic_type)
+        self.assertEqual(d.GetType().GetBasicType(), int_basic_type)

--- a/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
+++ b/lldb/test/API/python_api/sbtype_basic_type/TestSBTypeBasicType.py
@@ -8,9 +8,7 @@ class TestCase(TestBase):
     def test(self):
         """Test that SBType.GetBasicType unwraps typedefs."""
         self.build()
-        lldbutil.run_to_source_breakpoint(
-            self, "return", lldb.SBFileSpec("main.cpp")
-        )
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
 
         a = self.frame().FindVariable("a")
         self.assertTrue(a)

--- a/lldb/test/API/python_api/sbtype_basic_type/main.cpp
+++ b/lldb/test/API/python_api/sbtype_basic_type/main.cpp
@@ -1,0 +1,11 @@
+using T1 = int;
+using T2 = T1;
+using T3 = T2;
+
+int main() {
+  int a;
+  T1 b;
+  T2 c;
+  T3 d;
+  return 0;
+}


### PR DESCRIPTION
`SBType::GetBasicType` fails on typedefs to primitive types. The docs for `GetBasicType` state:
```
Returns the BasicType value that is most appropriate to this type
```
But, e.g., for `uint64_t` this would currently return `eBasicTypeInvalid`.

`TypeSystemClang::GetBasicTypeEnumeration` (which is what `SBType::GetBasicType` uses) doesn't see through typedefs. Inside LLDB we almost always call `GetBasicTypeEnumeration` on the canonical type. In the cases we don't I suspect those were just subtle bugs. This patch gets the canonical type inside of `GetBasicTypeEnumeration` instead.

rdar://155829208