### PR TITLE
[llvm][blake3] Prefix blake3_hash4_neon

### DIFF
--- a/llvm/lib/Support/BLAKE3/llvm_blake3_prefix.h
+++ b/llvm/lib/Support/BLAKE3/llvm_blake3_prefix.h
@@ -41,5 +41,6 @@
 #define blake3_hash_many_avx512 llvm_blake3_hash_many_avx512
 #define _blake3_hash_many_avx512 _llvm_blake3_hash_many_avx512
 #define blake3_hash_many_neon llvm_blake3_hash_many_neon
+#define blake3_hash4_neon llvm_blake3_hash4_neon
 
 #endif /* LLVM_BLAKE3_PREFIX_H */


### PR DESCRIPTION
In #147948 blake3_hash4_neon became a public symbol (no longer static).
Like other APIs introduced, it was not prefixed, resulting in conflicts if
libblake3 and LLVM are both linked statically into the same binary.