### PR TITLE
[Docs] remove beginner office hours from GettingInvolved

### DIFF
--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -354,11 +354,6 @@ The :doc:`CodeOfConduct` applies to all office hours.
     - Every first Friday of the month, 14:00 UK time, for 60 minutes.
     - `Google meet <https://meet.google.com/jps-twgq-ivz>`__
     - English, Portuguese
-  * - Rotating hosts
-    - Getting Started, beginner questions, new contributors.
-    - Every Tuesday at 2 PM ET (11 AM PT), for 30 minutes.
-    - `Google meet <https://meet.google.com/nga-uhpf-bbb>`__
-    - English
 
 For event owners, our Discord bot also supports sending automated announcements
 of upcoming office hours. Please see the :ref:`discord-bot-event-pings` section


### PR DESCRIPTION
These were turned down at the beginning of this year; thanks to the folks on
https://discourse.llvm.org/t/is-the-beginner-office-hours-still-running/87398/2 for flagging this!

---

N.B., I tried testing via `ninja doxygen-llvm`, but that didn't terminate on my machine within 30mins (either with or without this patch). I assume it's some local config bug on my end, but it happened on `main` and `main~1000`, so I'm not sure how to test.

Since the change is pretty trivial, still comfortable uploading for review.