### PR TITLE
[llvm] simplify and clean-up DemangleConfig.h

### DIFF
--- a/llvm/include/llvm/Demangle/DemangleConfig.h
+++ b/llvm/include/llvm/Demangle/DemangleConfig.h
@@ -6,84 +6,24 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file contains a variety of feature test macros copied from
-// include/llvm/Support/Compiler.h so that LLVMDemangle does not need to take
-// a dependency on LLVMSupport.
+// Contains DEMANGLE_ aliases for LLVM_ definitions. The canonical copy of
+// ItaniumDemangle.h cannot depend on LLVM headers because lives in the
+// libcxxabi project.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_DEMANGLE_DEMANGLECONFIG_H
 #define LLVM_DEMANGLE_DEMANGLECONFIG_H
 
-#ifndef __has_feature
-#define __has_feature(x) 0
-#endif
+#include "llvm/Support/Compiler.h"
 
-#ifndef __has_cpp_attribute
-#define __has_cpp_attribute(x) 0
-#endif
+#define DEMANGLE_DUMP_METHOD LLVM_DUMP_METHOD
+#define DEMANGLE_FALLTHROUGH LLVM_FALLTHROUGH
 
-#ifndef __has_attribute
-#define __has_attribute(x) 0
-#endif
-
-#ifndef __has_builtin
-#define __has_builtin(x) 0
-#endif
-
-#ifndef DEMANGLE_GNUC_PREREQ
-#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
-#define DEMANGLE_GNUC_PREREQ(maj, min, patch)                           \
-  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) + __GNUC_PATCHLEVEL__ >=          \
-   ((maj) << 20) + ((min) << 10) + (patch))
-#elif defined(__GNUC__) && defined(__GNUC_MINOR__)
-#define DEMANGLE_GNUC_PREREQ(maj, min, patch)                           \
-  ((__GNUC__ << 20) + (__GNUC_MINOR__ << 10) >= ((maj) << 20) + ((min) << 10))
-#else
-#define DEMANGLE_GNUC_PREREQ(maj, min, patch) 0
-#endif
-#endif
-
-#if __has_attribute(used) || DEMANGLE_GNUC_PREREQ(3, 1, 0)
-#define DEMANGLE_ATTRIBUTE_USED __attribute__((__used__))
-#else
-#define DEMANGLE_ATTRIBUTE_USED
-#endif
-
-#if __has_builtin(__builtin_unreachable) || DEMANGLE_GNUC_PREREQ(4, 5, 0)
-#define DEMANGLE_UNREACHABLE __builtin_unreachable()
-#elif defined(_MSC_VER)
-#define DEMANGLE_UNREACHABLE __assume(false)
+#if defined(LLVM_BUILTIN_UNREACHABLE)
+#define DEMANGLE_UNREACHABLE LLVM_BUILTIN_UNREACHABLE
 #else
 #define DEMANGLE_UNREACHABLE
-#endif
-
-#if __has_attribute(noinline) || DEMANGLE_GNUC_PREREQ(3, 4, 0)
-#define DEMANGLE_ATTRIBUTE_NOINLINE __attribute__((noinline))
-#elif defined(_MSC_VER)
-#define DEMANGLE_ATTRIBUTE_NOINLINE __declspec(noinline)
-#else
-#define DEMANGLE_ATTRIBUTE_NOINLINE
-#endif
-
-#if !defined(NDEBUG)
-#define DEMANGLE_DUMP_METHOD DEMANGLE_ATTRIBUTE_NOINLINE DEMANGLE_ATTRIBUTE_USED
-#else
-#define DEMANGLE_DUMP_METHOD DEMANGLE_ATTRIBUTE_NOINLINE
-#endif
-
-#if __cplusplus > 201402L && __has_cpp_attribute(fallthrough)
-#define DEMANGLE_FALLTHROUGH [[fallthrough]]
-#elif __has_cpp_attribute(gnu::fallthrough)
-#define DEMANGLE_FALLTHROUGH [[gnu::fallthrough]]
-#elif !__cplusplus
-// Workaround for llvm.org/PR23435, since clang 3.6 and below emit a spurious
-// error when __has_cpp_attribute is given a scoped attribute in C mode.
-#define DEMANGLE_FALLTHROUGH
-#elif __has_cpp_attribute(clang::fallthrough)
-#define DEMANGLE_FALLTHROUGH [[clang::fallthrough]]
-#else
-#define DEMANGLE_FALLTHROUGH
 #endif
 
 #ifndef DEMANGLE_ASSERT


### PR DESCRIPTION
## Purpose
Simplify `DEMANGLE_` macro definitions in `llvm/Demangle/DemangleConfig.h` for clarity/maintainability.

## Overview
* Alias `DEMANGLE_DUMP_METHOD`, `DEMANGLE_FALLTHROUGH`, and `DEMANGLE_UNREACHABLE` macros to their `LLVM_` counterparts defined in `llvm/Support/Compiler.h`
* Remove several `DEMANGLE_`-prefixed macros that were only used within `DemangleConfig.h`

## Background
* It should be safe for the `Demangle` component library to depend on `Support`, so there is no need for it to maintain copies of macros defined in `llvm/Support/Compiler.h`. 
* Since the canonical copy `llvm/Demangle/ItaniumDemangle.h` lives under `libcxxabi`, it cannot directly reference the `LLVM_`-prefixed macros so we define `DEMANGLE_`-prefixed aliases.

## Validation
* Built llvm-project on Windows with `clang-cl` and MSVC `cl`.
* Built llvm-project on Linux with `clang` and `gcc`.