### PR TITLE
Ensure proper NULL macro definition for system include files.

### DIFF
--- a/clang/lib/Headers/CMakeLists.txt
+++ b/clang/lib/Headers/CMakeLists.txt
@@ -39,6 +39,26 @@ set(core_files
   varargs.h
   )
 
+set(aix_wrapper_files
+  dbm.h
+  locale.h
+  stdio.h
+  stdlib.h
+  string.h
+  time.h
+  unistd.h
+  wchar.h
+  )
+set(aix_sys_subdir_wrapper_files
+  sys/dir.h
+  sys/param.h
+  sys/types.h
+  )
+set(aix_files
+  ${aix_wrapper_files}
+  ${aix_sys_subdir_wrapper_files}
+  )
+
 set(arm_common_files
   # Headers shared by Arm and AArch64
   arm_acle.h
@@ -312,6 +332,7 @@ set(utility_files
 
 set(files
   ${core_files}
+  ${aix_files}
   ${arm_common_files}
   ${arm_only_files}
   ${aarch64_only_files}
@@ -529,6 +550,7 @@ set_target_properties("clang-resource-headers" PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${output_dir}")
 add_dependencies("clang-resource-headers"
                  "core-resource-headers"
+		 "aix-resource-headers"
                  "arm-common-resource-headers"
                  "arm-resource-headers"
                  "aarch64-resource-headers"
@@ -557,6 +579,7 @@ add_header_target("core-resource-headers" ${core_files})
 add_header_target("arm-common-resource-headers" "${arm_common_files};${arm_common_generated_files}")
 
 # Architecture/platform specific targets
+add_header_target("aix-resource-headers" "${aix_files}")
 add_header_target("arm-resource-headers" "${arm_only_files};${arm_only_generated_files}")
 add_header_target("aarch64-resource-headers" "${aarch64_only_files};${aarch64_only_generated_files}")
 add_header_target("cuda-resource-headers" "${cuda_files};${cuda_wrapper_files};${cuda_wrapper_bits_files};${cuda_wrapper_utility_files}")
@@ -643,6 +666,18 @@ install(
   DESTINATION ${header_install_dir}
   EXCLUDE_FROM_ALL
   COMPONENT core-resource-headers)
+
+install(
+  FILES ${aix_wrapper_files}
+  DESTINATION ${header_install_dir}
+  EXCLUDE_FROM_ALL
+  COMPONENT aix-resource-headers)
+
+install(
+  FILES ${aix_sys_subdir_wrapper_files}
+  DESTINATION ${header_install_dir}/sys
+  EXCLUDE_FROM_ALL
+  COMPONENT aix-resource-headers)
 
 install(
   FILES ${arm_common_files} ${arm_common_generated_files}
@@ -837,6 +872,9 @@ if (NOT LLVM_ENABLE_IDE)
   add_llvm_install_targets(install-core-resource-headers
                            DEPENDS core-resource-headers
                            COMPONENT core-resource-headers)
+  add_llvm_install_targets(install-aix-resource-headers
+                           DEPENDS aix-resource-headers
+                           COMPONENT aix-resource-headers)
   add_llvm_install_targets(install-arm-common-resource-headers
                            DEPENDS arm-common-resource-headers
                            COMPONENT arm-common-resource-headers)

--- a/clang/lib/Headers/dbm.h
+++ b/clang/lib/Headers/dbm.h
@@ -1,0 +1,24 @@
+/*===---- dbm.h - BSD header for database management ----------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <dbm.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <dbm.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/locale.h
+++ b/clang/lib/Headers/locale.h
@@ -1,0 +1,24 @@
+/*===---- locale.h - Standard header for localization ---------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <locale.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <locale.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/stdio.h
+++ b/clang/lib/Headers/stdio.h
@@ -1,0 +1,24 @@
+/*===---- stdio.h - Standard header for input and output-------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <stdio.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <stdio.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/stdlib.h
+++ b/clang/lib/Headers/stdlib.h
@@ -1,0 +1,24 @@
+/*===---- stdlib.h - Standard header for general utilities ----------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <stdlib.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <stdlib.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/string.h
+++ b/clang/lib/Headers/string.h
@@ -1,0 +1,24 @@
+/*===---- string.h - Standard header for string handling ------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <string.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <string.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/sys/dir.h
+++ b/clang/lib/Headers/sys/dir.h
@@ -1,0 +1,24 @@
+/*===---- sys/dir.h - BSD header for directory handling -------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <sys/dir.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <sys/dir.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/sys/param.h
+++ b/clang/lib/Headers/sys/param.h
@@ -1,0 +1,24 @@
+/*===---- sys/param.h - BSD header ----------------------------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <sys/param.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <sys/param.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/sys/types.h
+++ b/clang/lib/Headers/sys/types.h
@@ -1,0 +1,24 @@
+/*===---- sys/types.h - BSD header for types ------------------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <sys/types.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <sys/types.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/time.h
+++ b/clang/lib/Headers/time.h
@@ -1,0 +1,24 @@
+/*===---- time.h - Standard header for date and time handling -------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <time.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <time.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/unistd.h
+++ b/clang/lib/Headers/unistd.h
@@ -1,0 +1,24 @@
+/*===---- unistd.h - Posix Standard header --------------------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <unistd.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <unistd.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/lib/Headers/wchar.h
+++ b/clang/lib/Headers/wchar.h
@@ -1,0 +1,24 @@
+/*===---- wchar.h - Standard header for string handling ------------------===*\
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+\*===----------------------------------------------------------------------===*/
+
+#if !defined(_AIX)
+
+#include_next <wchar.h>
+
+#else
+
+#define __need_NULL
+#include <stddef.h>
+
+#include_next <wchar.h>
+
+/* Ensure that the definition of NULL is as expected. */
+#define __need_NULL
+#include <stddef.h>
+
+#endif

--- a/clang/test/Headers/check-NULL-aix.c
+++ b/clang/test/Headers/check-NULL-aix.c
@@ -1,0 +1,22 @@
+// There are at least 2 valid C null-pointer constants as defined
+// by the C language standard.
+// Test that the macro NULL is defined consistently by those system headers
+// on AIX that have a macro definition for NULL.
+
+// REQUIRES: system-aix
+
+// RUN: %clang %s -Dheader="<dbm.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<locale.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<stdio.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<stdlib.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<string.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<sys/dir.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<sys/param.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<sys/types.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<time.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<unistd.h>" -E | tail -1 | FileCheck %s
+// RUN: %clang %s -Dheader="<wchar.h>" -E | tail -1 | FileCheck %s
+
+#include header
+void *p = NULL;
+// CHECK: ({{ *}}({{ *}}void{{ *}}*{{ *}}){{ *}}0{{ *}})


### PR DESCRIPTION
The C standard allows for at least 2 valid definitions of a null pointer constant and mandates that several standard headers files define the macro NULL to be a null pointer constant.  Ensure that definitions of NULL are consistent across the various C  header files.