### PR TITLE
[CodeGen] Ensure clearRegisterKills clears inside bundles.

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -880,9 +880,9 @@ public:
   /// queries but they are bundle aware.
 
   enum QueryType {
-    IgnoreBundle,    // Ignore bundles
-    AnyInBundle,     // Return true if any instruction in bundle has property
-    AllInBundle      // Return true if all instructions in bundle have property
+    IgnoreBundle, // Ignore bundles
+    AnyInBundle,  // Check/update property for any instruction in bundle
+    AllInBundle   // Check/update property for all instructions in bundle
   };
 
   /// Return true if the instruction (or in the case of a bundle,
@@ -1700,7 +1700,8 @@ public:
   /// Clear all kill flags affecting Reg.  If RegInfo is provided, this includes
   /// all aliasing registers.
   LLVM_ABI void clearRegisterKills(Register Reg,
-                                   const TargetRegisterInfo *RegInfo);
+                                   const TargetRegisterInfo *RegInfo,
+                                   QueryType Type = AllInBundle);
 
   /// We have determined MI defined a register without a use.
   /// Look for the operand that defines it and mark it as IsDead. If

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2189,7 +2189,7 @@ void MachineInstr::clearRegisterKills(Register Reg,
     }
   };
 
-  if (Type != AllInBundle || !isBundled() || isBundledWithPred())
+  if (Type == IgnoreBundle || !isBundled() || isBundledWithPred())
     clearKills(operands());
   else
     clearKills(mi_bundle_ops(*this));

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -2177,12 +2177,12 @@ void MachineInstr::clearRegisterKills(Register Reg,
                                       const TargetRegisterInfo *RegInfo) {
   if (!Reg.isPhysical())
     RegInfo = nullptr;
-  for (MachineOperand &MO : operands()) {
-    if (!MO.isReg() || !MO.isUse() || !MO.isKill())
+  for (MIBundleOperands O(*this); O.isValid(); ++O) {
+    if (!O->isReg() || !O->isUse() || !O->isKill())
       continue;
-    Register OpReg = MO.getReg();
+    Register OpReg = O->getReg();
     if ((RegInfo && RegInfo->regsOverlap(Reg, OpReg)) || Reg == OpReg)
-      MO.setIsKill(false);
+      O->setIsKill(false);
   }
 }
 

--- a/llvm/test/CodeGen/AArch64/sve-vls-ldst-opt.mir
+++ b/llvm/test/CodeGen/AArch64/sve-vls-ldst-opt.mir
@@ -72,3 +72,23 @@ body: |
 # CHECK: STURQi killed renamable $q1, renamable $x1, 16 :: (store (s128))
 # CHECK: STURQi killed renamable $q2, renamable $x1, 48 :: (store (s128))
 # CHECK: STR_ZXI killed renamable $z3, renamable $x1, 4 :: (store (<vscale x 1 x s128>))
+---
+name: clear-kill-in-bundle
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $x0, $z0
+
+    STR_ZXI $z0, $x0, 0 :: (store (<vscale x 1 x s128>))
+    BUNDLE implicit-def $z1, implicit-def $q1, implicit killed $z0 {
+      $z1 = ADD_ZZZ_D $z0, killed $z0
+    }
+    STR_ZXI renamable $z1, $x0, 1 :: (store (<vscale x 1 x s128>))
+
+    RET_ReallyLR
+...
+# CHECK-LABEL: name: clear-kill-in-bundle
+# CHECK: BUNDLE implicit-def $z1, implicit-def $q1, implicit $z0 {
+# CHECK:   $z1 = ADD_ZZZ_D $z0, $z0
+# CHECK: }
+# CHECK: STPQi $q0, $q1, $x0, 0 :: (store (<vscale x 1 x s128>))


### PR DESCRIPTION
When clearing register kills, ensure we do so inside a bundle too. This came up in AArch64LdStOpt when we attempt to clear kill flags that affect the first store's register. If the kill happens in a bundle, we were only clearing it in the bundle operands, but not in the constituent instructions. This was leading to a verification error, for example: https://godbolt.org/z/WjhEWGcPW.

Fixes #149092.