### PR TITLE
[DirectX] Remove unused global variables

### DIFF
--- a/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
+++ b/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
@@ -28,6 +28,18 @@ static bool finalizeLinkage(Module &M) {
     }
   }
 
+  // Remove unused global variables.
+  SmallVector<GlobalVariable *> ToErase;
+  for (GlobalVariable &GV : M.globals()) {
+    if (GV.use_empty()) {
+      ToErase.push_back(&GV);
+    }
+  }
+  for (GlobalVariable *GV : ToErase) {
+    GV->eraseFromParent();
+    MadeChange = true;
+  }
+
   SmallVector<Function *> Funcs;
 
   // Collect non-entry and non-exported functions to set to internal linkage.

--- a/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
+++ b/llvm/lib/Target/DirectX/DXILFinalizeLinkage.cpp
@@ -29,15 +29,11 @@ static bool finalizeLinkage(Module &M) {
   }
 
   // Remove unused global variables.
-  SmallVector<GlobalVariable *> ToErase;
-  for (GlobalVariable &GV : M.globals()) {
+  for (GlobalVariable &GV : make_early_inc_range(M.globals())) {
     if (GV.use_empty()) {
-      ToErase.push_back(&GV);
+      GV.eraseFromParent();
+      MadeChange = true;
     }
-  }
-  for (GlobalVariable *GV : ToErase) {
-    GV->eraseFromParent();
-    MadeChange = true;
   }
 
   SmallVector<Function *> Funcs;

--- a/llvm/test/CodeGen/DirectX/finalize_linkage.ll
+++ b/llvm/test/CodeGen/DirectX/finalize_linkage.ll
@@ -1,10 +1,17 @@
 ; RUN: opt -S -dxil-finalize-linkage -mtriple=dxil-unknown-shadermodel6.5-compute %s | FileCheck %s
-; RUN: llc %s --filetype=asm -o - | FileCheck %s --check-prefixes=CHECK-LLC
+; TODO: Add back the llc test once #149179 and #149180 are fixed
 
 target triple = "dxilv1.5-pc-shadermodel6.5-compute"
 
 ; DXILFinalizeLinkage changes linkage of all functions that are hidden to
-; internal, and converts private global variables to internal linkage.
+; internal, converts private global variables to internal linkage, and removes
+; unused global variables.
+
+; CHECK-NOT: @aTile
+@aTile = hidden addrspace(3) global [4 x [1 x i32]] zeroinitializer, align 4
+
+; CHECK-NOT: @bTile
+@bTile = hidden addrspace(3) global [1 x <1 x i32>] zeroinitializer, align 4
 
 ; CHECK: @switch.table = internal unnamed_addr constant [4 x i32]
 @switch.table = private unnamed_addr constant [4 x i32] [i32 1, i32 257, i32 65793, i32 16843009], align 4
@@ -26,6 +33,17 @@ target triple = "dxilv1.5-pc-shadermodel6.5-compute"
 ; Hidden global should remain hidden
 ; CHECK: @hidden_var = hidden global i32
 @hidden_var = hidden global i32 1, align 4
+
+define void @anchor_function() #0 {
+entry:
+  %0 = load i32, ptr @switch.table, align 4
+  %1 = load [3 x float], ptr @private_array, align 4
+  %2 = load i32, ptr @private_var, align 4
+  %3 = load i32, ptr @internal_var, align 4
+  %4 = load i32, ptr @external_var, align 4
+  %5 = load i32, ptr @hidden_var, align 4
+  ret void
+}
 
 ; CHECK-NOT: define internal void @"?f1@@YAXXZ"()
 define void @"?f1@@YAXXZ"() #0 {

--- a/llvm/test/CodeGen/DirectX/scalar-data.ll
+++ b/llvm/test/CodeGen/DirectX/scalar-data.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -mtriple=dxil-pc-shadermodel6.3-library --filetype=asm -o - | FileCheck %s
+; RUN: opt -S -passes='dxil-data-scalarization,dxil-flatten-arrays' -mtriple=dxil-unknown-shadermodel6.5-compute %s | FileCheck %s
 
 ; Make sure we don't touch arrays without vectors and that can recurse and flatten multiple-dimension arrays of vectors
 


### PR DESCRIPTION
Fixes #139023

This PR:
- Removes unused global variables in the finalize linkage pass
- Changes the `scalar-data.ll` run command to avoid removing its global variables
- Adds tests to `finalize_linkage.ll` that make sure unused global variables are removed
- Temporarily removes the llc run command from `finalize_linkage.ll`
  - This needs to be added back once [ #149179](https://github.com/llvm/llvm-project/issues/149179) and [#149180](https://github.com/llvm/llvm-project/issues/149180) are fixed