### PR TITLE
[CI] Drop CLEAR_CACHE Support in monolithic-* scripts

### DIFF
--- a/.ci/monolithic-linux.sh
+++ b/.ci/monolithic-linux.sh
@@ -23,11 +23,6 @@ rm -rf "${BUILD_DIR}"
 
 ccache --zero-stats
 
-if [[ -n "${CLEAR_CACHE:-}" ]]; then
-  echo "clearing cache"
-  ccache --clear
-fi
-
 mkdir -p artifacts/reproducers
 
 # Make sure any clang reproducers will end up as artifacts.

--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -21,11 +21,6 @@ BUILD_DIR="${BUILD_DIR:=${MONOREPO_ROOT}/build}"
 
 rm -rf "${BUILD_DIR}"
 
-if [[ -n "${CLEAR_CACHE:-}" ]]; then
-  echo "clearing sccache"
-  rm -rf "$SCCACHE_DIR"
-fi
-
 sccache --zero-stats
 function at-exit {
   retcode=$?


### PR DESCRIPTION
This patch drops support for clearing the cache with the CLEAR_CACHE
environment variable. This is an artifact of the old infrastructure as
we now do not persist the cache across builds, instead redownloading the
cache directory everytime. This makes the scripts slightly simpler as we
are no longer supporting unneeded functionality.
