### PR TITLE
[llvm] annotate ABIBreakingChecks symbols for DLL export

### DIFF
--- a/llvm/include/llvm/Config/abi-breaking.h.cmake
+++ b/llvm/include/llvm/Config/abi-breaking.h.cmake
@@ -12,11 +12,35 @@
 #ifndef LLVM_ABI_BREAKING_CHECKS_H
 #define LLVM_ABI_BREAKING_CHECKS_H
 
+// llvm-config.h is required for LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS
+#include "llvm/Config/llvm-config.h"
+
 /* Define to enable checks that alter the LLVM C++ ABI */
 #cmakedefine01 LLVM_ENABLE_ABI_BREAKING_CHECKS
 
 /* Define to enable reverse iteration of unordered llvm containers */
 #cmakedefine01 LLVM_ENABLE_REVERSE_ITERATION
+
+// Properly annotate EnableABIBreakingChecks or DisableABIBreakingChecks for
+// export from shared library.
+#if !defined(LLVM_ABI_GENERATING_ANNOTATIONS)
+// TODO(https://github.com/llvm/llvm-project/issues/145406): eliminate need for
+// two preprocessor definitions to gate LLVM_ABI macro definitions.
+#if defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS) && !defined(LLVM_BUILD_STATIC)
+#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(LLVM_EXPORTS)
+#define ABI_BREAKING_EXPORT_ABI __declspec(dllexport)
+#else
+#define ABI_BREAKING_EXPORT_ABI __declspec(dllimport)
+#endif
+#elif defined(__has_attribute) && __has_attribute(visibility)
+#define ABI_BREAKING_EXPORT_ABI __attribute__((visibility("default")))
+#endif
+#endif
+#if !defined(ABI_BREAKING_EXPORT_ABI)
+#define ABI_BREAKING_EXPORT_ABI
+#endif
+#endif
 
 /* Allow selectively disabling link-time mismatch checking so that header-only
    ADT content from LLVM can be used without linking libSupport. */
@@ -43,12 +67,12 @@
 #endif
 namespace llvm {
 #if LLVM_ENABLE_ABI_BREAKING_CHECKS
-extern int EnableABIBreakingChecks;
+ABI_BREAKING_EXPORT_ABI extern int EnableABIBreakingChecks;
 LLVM_HIDDEN_VISIBILITY
 __attribute__((weak)) int *VerifyEnableABIBreakingChecks =
     &EnableABIBreakingChecks;
 #else
-extern int DisableABIBreakingChecks;
+ABI_BREAKING_EXPORT_ABI extern int DisableABIBreakingChecks;
 LLVM_HIDDEN_VISIBILITY
 __attribute__((weak)) int *VerifyDisableABIBreakingChecks =
     &DisableABIBreakingChecks;

--- a/llvm/include/llvm/Config/abi-breaking.h.cmake
+++ b/llvm/include/llvm/Config/abi-breaking.h.cmake
@@ -21,24 +21,29 @@
 /* Define to enable reverse iteration of unordered llvm containers */
 #cmakedefine01 LLVM_ENABLE_REVERSE_ITERATION
 
+#if !defined(__has_attribute)
+#define __has_attribute(attribute) 0
+#endif
+
 // Properly annotate EnableABIBreakingChecks or DisableABIBreakingChecks for
 // export from shared library.
-#if !defined(LLVM_ABI_GENERATING_ANNOTATIONS)
 // TODO(https://github.com/llvm/llvm-project/issues/145406): eliminate need for
 // two preprocessor definitions to gate LLVM_ABI macro definitions.
-#if defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS) && !defined(LLVM_BUILD_STATIC)
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(LLVM_BUILD_STATIC) || !defined(LLVM_ENABLE_LLVM_EXPORT_ANNOTATIONS)
+#define ABI_BREAKING_EXPORT_ABI
+#else
+#if defined(_WIN32)
 #if defined(LLVM_EXPORTS)
 #define ABI_BREAKING_EXPORT_ABI __declspec(dllexport)
 #else
 #define ABI_BREAKING_EXPORT_ABI __declspec(dllimport)
 #endif
-#elif defined(__has_attribute) && __has_attribute(visibility)
-#define ABI_BREAKING_EXPORT_ABI __attribute__((visibility("default")))
-#endif
-#endif
-#if !defined(ABI_BREAKING_EXPORT_ABI)
+#else
+#if __has_attribute(visibility)
+#define ABI_BREAKING_EXPORT_ABI __attribute__((__visibility__("default")))
+#else
 #define ABI_BREAKING_EXPORT_ABI
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
## Purpose
This PR is a re-application of  #145575 with independent definition of  `ABI_BREAKING_EXPORT_ABI` that does not depend on `llvm/Support/Compiler.h`.  It is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates the ABI Breaking Checks interface in llvm/config. The annotations currently have no meaningful impact on the LLVM build; however, they are a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background
The effort to build LLVM as a Windows DLL is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Validation
Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang