### PR TITLE
[libc] add wctype.h header

### DIFF
--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -278,6 +278,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.wchar.wcslen
     libc.src.wchar.wctob
 
+    # wctype.h entrypoints
+    libc.src.wctype.iswalpha
+
     # internal entrypoints
     libc.startup.baremetal.init
     libc.startup.baremetal.fini

--- a/libc/include/CMakeLists.txt
+++ b/libc/include/CMakeLists.txt
@@ -721,6 +721,15 @@ add_header_macro(
 )
 
 add_header_macro(
+  wctype
+  ../libc/include/wctype.yaml
+  wctype.h
+  DEPENDS
+    .llvm_libc_common_h    
+    .llvm-libc-types.wint_t
+)
+
+add_header_macro(
   locale
   ../libc/include/locale.yaml
   locale.h

--- a/libc/include/wctype.h.def
+++ b/libc/include/wctype.h.def
@@ -1,0 +1,16 @@
+//===-- C standard library header network.h -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_WCTYPE_H
+#define LLVM_LIBC_WCTYPE_H
+
+#include "__llvm-libc-common.h"
+
+%%public_api()
+
+#endif // LLVM_LIBC_WCTYPE_H

--- a/libc/include/wctype.yaml
+++ b/libc/include/wctype.yaml
@@ -1,0 +1,14 @@
+header: wctype.h
+header_template: wctype.h.def
+macros: []
+types:
+  - type_name: wint_t
+enums: []
+objects: []
+functions:
+  - name: iswalpha
+    standards:
+      - stdc
+    return_type: int
+    arguments:
+      - type: wint_t

--- a/libc/src/CMakeLists.txt
+++ b/libc/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(strings)
 add_subdirectory(time)
 add_subdirectory(unistd)
 add_subdirectory(wchar)
+add_subdirectory(wctype)
 
 if(${LIBC_TARGET_OS} STREQUAL "linux")
   add_subdirectory(dirent)

--- a/libc/src/wctype/CMakeLists.txt
+++ b/libc/src/wctype/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_entrypoint_object(
+  iswalpha
+  SRCS
+    iswalpha.cpp
+  HDRS
+    iswalpha.h
+  DEPENDS
+    libc.src.__support.wctype_utils    
+)

--- a/libc/src/wctype/iswalpha.cpp
+++ b/libc/src/wctype/iswalpha.cpp
@@ -1,0 +1,21 @@
+//===-- Implementation of wctob -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/wctype/iswalpha.h"
+#include "src/__support/common.h"
+#include "src/__support/wctype_utils.h"
+
+#include "hdr/types/wint_t.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(bool, iswalpha, (wint_t c)) {
+  return internal::iswalpha(c);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/wctype/iswalpha.h
+++ b/libc/src/wctype/iswalpha.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for iswalpha ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_WCHAR_WCTOB_H
+#define LLVM_LIBC_SRC_WCHAR_WCTOB_H
+
+#include "hdr/types/wint_t.h"
+#include "src/__support/common.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+bool iswalpha(wint_t c);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_WCHAR_WCTOB_H


### PR DESCRIPTION
Add basic configurations to generate wctype.h header file. To begin with
this header file just exposes one function iswalpha.
