### PR TITLE
[LLDB] Process minidump better error messages

### DIFF
--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
@@ -480,9 +480,22 @@ void MinidumpParser::PopulateMemoryRanges() {
 
 llvm::ArrayRef<uint8_t> MinidumpParser::GetMemory(lldb::addr_t addr,
                                                   size_t size) {
+  llvm::Expected<llvm::ArrayRef<uint8_t>> expected_memory = GetExpectedMemory(addr, size);
+  if (!expected_memory) {
+    llvm::consumeError(expected_memory.takeError());
+    return {};
+  }
+
+  return *expected_memory;
+}
+
+llvm::Expected<llvm::ArrayRef<uint8_t>> MinidumpParser::GetExpectedMemory(lldb::addr_t addr,
+                                                                          size_t size) {
   std::optional<minidump::Range> range = FindMemoryRange(addr);
   if (!range)
-    return {};
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "No memory range found for address {0x%" PRIx64 "}",
+                                   addr);
 
   // There's at least some overlap between the beginning of the desired range
   // (addr) and the current range.  Figure out where the overlap begins and
@@ -491,7 +504,8 @@ llvm::ArrayRef<uint8_t> MinidumpParser::GetMemory(lldb::addr_t addr,
   const size_t offset = addr - range->start;
 
   if (addr < range->start || offset >= range->range_ref.size())
-    return {};
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "Address {0x%" PRIx64 "} is not in range [{0x%" PRIx64 " - 0x%" PRIx64 "}]", addr, range->start, range->start + range->range_ref.size());
 
   const size_t overlap = std::min(size, range->range_ref.size() - offset);
   return range->range_ref.slice(offset, overlap);

--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
@@ -494,7 +494,7 @@ llvm::Expected<llvm::ArrayRef<uint8_t>> MinidumpParser::GetExpectedMemory(lldb::
   std::optional<minidump::Range> range = FindMemoryRange(addr);
   if (!range)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "No memory range found for address {0x%" PRIx64 "}",
+                                   "No memory range found for address (0x%" PRIx64 ")",
                                    addr);
 
   // There's at least some overlap between the beginning of the desired range
@@ -505,7 +505,7 @@ llvm::Expected<llvm::ArrayRef<uint8_t>> MinidumpParser::GetExpectedMemory(lldb::
 
   if (addr < range->start || offset >= range->range_ref.size())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "Address {0x%" PRIx64 "} is not in range [{0x%" PRIx64 " - 0x%" PRIx64 "}]", addr, range->start, range->start + range->range_ref.size());
+                                   "Address (0x%" PRIx64 ") is not in range [0x%" PRIx64 " - 0x%" PRIx64 ")", addr, range->start, range->start + range->range_ref.size());
 
   const size_t overlap = std::min(size, range->range_ref.size() - offset);
   return range->range_ref.slice(offset, overlap);

--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.cpp
@@ -480,7 +480,8 @@ void MinidumpParser::PopulateMemoryRanges() {
 
 llvm::ArrayRef<uint8_t> MinidumpParser::GetMemory(lldb::addr_t addr,
                                                   size_t size) {
-  llvm::Expected<llvm::ArrayRef<uint8_t>> expected_memory = GetExpectedMemory(addr, size);
+  llvm::Expected<llvm::ArrayRef<uint8_t>> expected_memory =
+      GetExpectedMemory(addr, size);
   if (!expected_memory) {
     llvm::consumeError(expected_memory.takeError());
     return {};
@@ -489,13 +490,13 @@ llvm::ArrayRef<uint8_t> MinidumpParser::GetMemory(lldb::addr_t addr,
   return *expected_memory;
 }
 
-llvm::Expected<llvm::ArrayRef<uint8_t>> MinidumpParser::GetExpectedMemory(lldb::addr_t addr,
-                                                                          size_t size) {
+llvm::Expected<llvm::ArrayRef<uint8_t>>
+MinidumpParser::GetExpectedMemory(lldb::addr_t addr, size_t size) {
   std::optional<minidump::Range> range = FindMemoryRange(addr);
   if (!range)
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "No memory range found for address (0x%" PRIx64 ")",
-                                   addr);
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "No memory range found for address (0x%" PRIx64 ")", addr);
 
   // There's at least some overlap between the beginning of the desired range
   // (addr) and the current range.  Figure out where the overlap begins and
@@ -504,8 +505,11 @@ llvm::Expected<llvm::ArrayRef<uint8_t>> MinidumpParser::GetExpectedMemory(lldb::
   const size_t offset = addr - range->start;
 
   if (addr < range->start || offset >= range->range_ref.size())
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "Address (0x%" PRIx64 ") is not in range [0x%" PRIx64 " - 0x%" PRIx64 ")", addr, range->start, range->start + range->range_ref.size());
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        "Address (0x%" PRIx64 ") is not in range [0x%" PRIx64 " - 0x%" PRIx64
+        ")",
+        addr, range->start, range->start + range->range_ref.size());
 
   const size_t overlap = std::min(size, range->range_ref.size() - offset);
   return range->range_ref.slice(offset, overlap);

--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.h
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.h
@@ -104,9 +104,8 @@ public:
 
   std::optional<Range> FindMemoryRange(lldb::addr_t addr);
 
-  llvm::ArrayRef<uint8_t> GetMemory(lldb::addr_t addr, size_t size);
-  llvm::Expected<llvm::ArrayRef<uint8_t>> GetExpectedMemory(lldb::addr_t addr,
-                                                            size_t size);
+  llvm::Expected<llvm::ArrayRef<uint8_t>> GetMemory(lldb::addr_t addr,
+                                                    size_t size);
 
   /// Returns a list of memory regions and a flag indicating whether the list is
   /// complete (includes all regions mapped into the process memory).

--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.h
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.h
@@ -105,6 +105,7 @@ public:
   std::optional<Range> FindMemoryRange(lldb::addr_t addr);
 
   llvm::ArrayRef<uint8_t> GetMemory(lldb::addr_t addr, size_t size);
+  llvm::Expected<llvm::ArrayRef<uint8_t>> GetExpectedMemory(lldb::addr_t addr, size_t size);
 
   /// Returns a list of memory regions and a flag indicating whether the list is
   /// complete (includes all regions mapped into the process memory).

--- a/lldb/source/Plugins/Process/minidump/MinidumpParser.h
+++ b/lldb/source/Plugins/Process/minidump/MinidumpParser.h
@@ -105,7 +105,8 @@ public:
   std::optional<Range> FindMemoryRange(lldb::addr_t addr);
 
   llvm::ArrayRef<uint8_t> GetMemory(lldb::addr_t addr, size_t size);
-  llvm::Expected<llvm::ArrayRef<uint8_t>> GetExpectedMemory(lldb::addr_t addr, size_t size);
+  llvm::Expected<llvm::ArrayRef<uint8_t>> GetExpectedMemory(lldb::addr_t addr,
+                                                            size_t size);
 
   /// Returns a list of memory regions and a flag indicating whether the list is
   /// complete (includes all regions mapped into the process memory).

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -322,11 +322,13 @@ size_t ProcessMinidump::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
 size_t ProcessMinidump::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
                                      Status &error) {
 
-  llvm::ArrayRef<uint8_t> mem = m_minidump_parser->GetMemory(addr, size);
-  if (mem.empty()) {
-    error = Status::FromErrorString("could not parse memory info");
+  llvm::Expected<llvm::ArrayRef<uint8_t>> mem_maybe = m_minidump_parser->GetExpectedMemory(addr, size);
+  if (!mem_maybe) {
+    error = Status::FromError(mem_maybe.takeError());
     return 0;
   }
+
+  llvm::ArrayRef<uint8_t> mem = *mem_maybe;
 
   std::memcpy(buf, mem.data(), mem.size());
   return mem.size();

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -323,7 +323,7 @@ size_t ProcessMinidump::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
                                      Status &error) {
 
   llvm::Expected<llvm::ArrayRef<uint8_t>> mem_maybe =
-      m_minidump_parser->GetExpectedMemory(addr, size);
+      m_minidump_parser->GetMemory(addr, size);
   if (!mem_maybe) {
     error = Status::FromError(mem_maybe.takeError());
     return 0;

--- a/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
+++ b/lldb/source/Plugins/Process/minidump/ProcessMinidump.cpp
@@ -322,7 +322,8 @@ size_t ProcessMinidump::ReadMemory(lldb::addr_t addr, void *buf, size_t size,
 size_t ProcessMinidump::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
                                      Status &error) {
 
-  llvm::Expected<llvm::ArrayRef<uint8_t>> mem_maybe = m_minidump_parser->GetExpectedMemory(addr, size);
+  llvm::Expected<llvm::ArrayRef<uint8_t>> mem_maybe =
+      m_minidump_parser->GetExpectedMemory(addr, size);
   if (!mem_maybe) {
     error = Status::FromError(mem_maybe.takeError());
     return 0;

--- a/lldb/test/Shell/Minidump/missing-memory-region.yaml
+++ b/lldb/test/Shell/Minidump/missing-memory-region.yaml
@@ -1,0 +1,42 @@
+# Check that looking up a memory region not present in the Minidump fails
+# even if it's in the /proc/<pid>/maps file.
+
+# RUN: yaml2obj %s -o %t
+# RUN: %lldb -c %t -o "memory read 0x5000" 2>&1 | FileCheck %s
+
+# CHECK-LABEL: (lldb) memory read 0x5000
+# CHECK-NEXT: error: No memory range found for address (0x5000)
+
+--- !minidump
+Streams:
+  - Type:            SystemInfo
+    Processor Arch:  AMD64
+    Processor Level: 6
+    Processor Revision: 15876
+    Number of Processors: 40
+    Platform ID:     Linux
+    CSD Version:     'Linux 3.13.0-91-generic #138-Ubuntu SMP Fri Jun 24 17:00:34 UTC 2016 x86_64'
+    CPU:
+      Vendor ID:       GenuineIntel
+      Version Info:    0x00000000
+      Feature Info:    0x00000000
+  - Type:            LinuxProcStatus
+    Text:             |
+      Name:	test-yaml
+      Umask:	0002
+      State:	t (tracing stop)
+      Pid:	8567
+  - Type:            LinuxMaps
+    Text:             |
+      0x1000-0x1100     r-xp 00000000 00:00 0
+      0x2000-0x2200     rw-p 00000000 00:00 0
+      0x4000-0x6000     rw-- 00000000 00:00 0
+  - Type:            Memory64List
+    Memory Ranges:
+      - Start of Memory Range: 0x1000
+        Data Size:       0x100
+        Content :        ''
+      - Start of Memory Range: 0x2000
+        Data Size:       0x200
+        Content :        ''
+...

--- a/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
+++ b/lldb/unittests/Process/minidump/MinidumpParserTest.cpp
@@ -308,16 +308,19 @@ Streams:
 )"),
                     llvm::Succeeded());
 
-  EXPECT_EQ((llvm::ArrayRef<uint8_t>{0x54}), parser->GetMemory(0x401d46, 1));
-  EXPECT_EQ((llvm::ArrayRef<uint8_t>{0x54, 0x21}),
-            parser->GetMemory(0x401d46, 4));
-
-  EXPECT_EQ((llvm::ArrayRef<uint8_t>{0xc8, 0x4d, 0x04, 0xbc, 0xe9}),
-            parser->GetMemory(0x7ffceb34a000, 5));
-  EXPECT_EQ((llvm::ArrayRef<uint8_t>{0xc8, 0x4d, 0x04}),
-            parser->GetMemory(0x7ffceb34a000, 3));
-
-  EXPECT_EQ(llvm::ArrayRef<uint8_t>(), parser->GetMemory(0x500000, 512));
+  EXPECT_THAT_EXPECTED(parser->GetMemory(0x401d46, 1),
+                       llvm::HasValue(llvm::ArrayRef<uint8_t>{0x54}));
+  EXPECT_THAT_EXPECTED(parser->GetMemory(0x401d46, 4),
+                       llvm::HasValue(llvm::ArrayRef<uint8_t>{0x54, 0x21}));
+  EXPECT_THAT_EXPECTED(
+      parser->GetMemory(0x7ffceb34a000, 5),
+      llvm::HasValue(llvm::ArrayRef<uint8_t>{0xc8, 0x4d, 0x04, 0xbc, 0xe9}));
+  EXPECT_THAT_EXPECTED(
+      parser->GetMemory(0x7ffceb34a000, 3),
+      llvm::HasValue(llvm::ArrayRef<uint8_t>{0xc8, 0x4d, 0x04}));
+  EXPECT_THAT_EXPECTED(
+      parser->GetMemory(0x500000, 512),
+      llvm::FailedWithMessage("No memory range found for address (0x500000)"));
 }
 
 TEST_F(MinidumpParserTest, FindMemoryRangeWithFullMemoryMinidump) {


### PR DESCRIPTION
Prior, Process Minidump would return 

```
Status::FromErrorString("could not parse memory info");
```

For any unsuccessful memory read, with no differentiation between an error in LLDB and the data simply not being present. This lead to a lot of user confusion and overall pretty terrible user experience. To fix this I've refactored the APIs so we can pass an error back in an llvm expected. 

There were also no shell tests for memory read and process Minidump so I added one.