### PR TITLE
[clang] Fix potential constant expression checking with constexpr-unknown.

### DIFF
--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -357,3 +357,27 @@ namespace pointer_comparisons {
   static_assert(!f4()); // expected-error {{static assertion expression is not an integral constant expression}} \
                         // expected-note {{in call to 'f4()'}}
 }
+
+namespace enable_if_1 {
+  template <__SIZE_TYPE__ N>
+  constexpr void foo(const char (&Str)[N])
+  __attribute((enable_if(__builtin_strlen(Str), ""))) {}
+
+  void x() {
+      foo("1234");
+  }
+}
+
+namespace enable_if_2 {
+  constexpr const char (&f())[];
+  extern const char (&Str)[];
+  constexpr int foo()
+  __attribute((enable_if(__builtin_strlen(Str), "")))
+  {return __builtin_strlen(Str);}
+
+  constexpr const char (&f())[] {return "a";}
+  constexpr const char (&Str)[] = f();
+  void x() {
+      constexpr int x = foo();
+  }
+}

--- a/clang/test/SemaCXX/constant-expression-p2280r4.cpp
+++ b/clang/test/SemaCXX/constant-expression-p2280r4.cpp
@@ -358,6 +358,7 @@ namespace pointer_comparisons {
                         // expected-note {{in call to 'f4()'}}
 }
 
+namespace GH149188 {
 namespace enable_if_1 {
   template <__SIZE_TYPE__ N>
   constexpr void foo(const char (&Str)[N])
@@ -380,4 +381,5 @@ namespace enable_if_2 {
   void x() {
       constexpr int x = foo();
   }
+}
 }

--- a/clang/test/SemaCXX/constexpr-never-constant.cpp
+++ b/clang/test/SemaCXX/constexpr-never-constant.cpp
@@ -24,3 +24,8 @@ constexpr void other_func() {
 
   throw 12;
 }
+
+// Make sure these don't trigger the diagnostic.
+extern const bool& b;
+constexpr bool fun1() { return b; }
+constexpr bool fun2(const bool& b) { return b; }

--- a/clang/test/SemaCXX/constexpr-never-constant.cpp
+++ b/clang/test/SemaCXX/constexpr-never-constant.cpp
@@ -25,7 +25,9 @@ constexpr void other_func() {
   throw 12;
 }
 
-// Make sure these don't trigger the diagnostic.
-extern const bool& b;
-constexpr bool fun1() { return b; }
-constexpr bool fun2(const bool& b) { return b; }
+namespace GH149041 {
+  // Make sure these don't trigger the diagnostic.
+  extern const bool& b;
+  constexpr bool fun1() { return b; }
+  constexpr bool fun2(const bool& b) { return b; }
+}


### PR DESCRIPTION
071765749a70b22fb62f2efc07a3f242ff5b4c52 improved constexpr-unkown diagnostics, but potential constant expression checking broke in the process: we produce diagnostics in more cases.  Supress the diagnostics as appropriate.

This fix affects -Winvalid-constexpr and the enable_if attribute.  (The -Winvalid-constexpr diagnostic isn't really important right now, but it will become important if we allow constexpr-unknown with pre-C++23 standards.)

Fixes #149041.  Fixes #149188.