### PR TITLE
[clang][docs] Fix example in SanitizerSpecialCaseList.rst

### DIFF
--- a/clang/docs/SanitizerSpecialCaseList.rst
+++ b/clang/docs/SanitizerSpecialCaseList.rst
@@ -39,6 +39,7 @@ Example
   void bad_foo() {
     int *a = (int*)malloc(40);
     a[10] = 1;
+    free(a);
   }
   int main() { bad_foo(); }
   $ cat ignorelist.txt


### PR DESCRIPTION
As-ie example suppresses buffer overflow in
malloc, and leave memory leak in place. It can be
confusing.

Fixes #62421.
