### PR TITLE
[asan] Revert global check for non-AIX 

### DIFF
--- a/compiler-rt/lib/asan/asan_descriptions.cpp
+++ b/compiler-rt/lib/asan/asan_descriptions.cpp
@@ -475,8 +475,8 @@ AddressDescription::AddressDescription(uptr addr, uptr access_size,
 
 #if !SANITIZER_AIX
   if (GetGlobalAddressInformation(addr, access_size, &data.global)) {
-     data.kind = kAddressKindGlobal;
-     return;
+    data.kind = kAddressKindGlobal;
+    return;
   }
 #endif
 

--- a/compiler-rt/lib/asan/asan_descriptions.cpp
+++ b/compiler-rt/lib/asan/asan_descriptions.cpp
@@ -449,10 +449,12 @@ AddressDescription::AddressDescription(uptr addr, uptr access_size,
   // are put to the STACK region for unknown reasons. Check global first can
   // workaround this issue.
   // TODO: Look into whether there's a different solution to this problem.
+#if SANITIZER_AIX
   if (GetGlobalAddressInformation(addr, access_size, &data.global)) {
     data.kind = kAddressKindGlobal;
     return;
   }
+#endif
 
   if (GetHeapAddressInformation(addr, access_size, &data.heap)) {
     data.kind = kAddressKindHeap;
@@ -470,6 +472,13 @@ AddressDescription::AddressDescription(uptr addr, uptr access_size,
     data.kind = kAddressKindStack;
     return;
   }
+
+#if !SANITIZER_AIX
+  if (GetGlobalAddressInformation(addr, access_size, &data.global)) {
+     data.kind = kAddressKindGlobal;
+     return;
+  }
+#endif
 
   data.kind = kAddressKindWild;
   data.wild.addr = addr;

--- a/compiler-rt/lib/asan/asan_descriptions.cpp
+++ b/compiler-rt/lib/asan/asan_descriptions.cpp
@@ -473,6 +473,7 @@ AddressDescription::AddressDescription(uptr addr, uptr access_size,
     return;
   }
 
+// GetGlobalAddressInformation is called earlier on AIX due to a workaround
 #if !SANITIZER_AIX
   if (GetGlobalAddressInformation(addr, access_size, &data.global)) {
     data.kind = kAddressKindGlobal;


### PR DESCRIPTION
287b24e1899eb6ce62eb9daef5a24faae5e66c1e moved the `GetGlobalAddressInformation` call earlier, but this broke a chromium test, so make this workaround for AIX only.