### PR TITLE
[CodeGen] Change the type from int64_t to uint64_t for getObjectSize and setObjectSize

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineFrameInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineFrameInfo.h
@@ -471,14 +471,14 @@ public:
   }
 
   /// Return the size of the specified object.
-  int64_t getObjectSize(int ObjectIdx) const {
+  uint64_t getObjectSize(int ObjectIdx) const {
     assert(unsigned(ObjectIdx+NumFixedObjects) < Objects.size() &&
            "Invalid Object Idx!");
     return Objects[ObjectIdx+NumFixedObjects].Size;
   }
 
   /// Change the size of the specified stack object.
-  void setObjectSize(int ObjectIdx, int64_t Size) {
+  void setObjectSize(int ObjectIdx, uint64_t Size) {
     assert(unsigned(ObjectIdx+NumFixedObjects) < Objects.size() &&
            "Invalid Object Idx!");
     Objects[ObjectIdx+NumFixedObjects].Size = Size;

--- a/llvm/lib/CodeGen/SanitizerBinaryMetadata.cpp
+++ b/llvm/lib/CodeGen/SanitizerBinaryMetadata.cpp
@@ -84,7 +84,7 @@ bool MachineSanitizerBinaryMetadata::run(MachineFunction &MF) {
   if (!Features->getUniqueInteger()[kSanitizerBinaryMetadataUARBit])
     return false;
   // Calculate size of stack args for the function.
-  int64_t Size = 0;
+  uint64_t Size = 0;
   uint64_t Align = 0;
   const MachineFrameInfo &MFI = MF.getFrameInfo();
   for (int i = -1; i >= (int)-MFI.getNumFixedObjects(); --i) {

--- a/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/StatepointLowering.cpp
@@ -394,7 +394,7 @@ spillIncomingStatepointValue(SDValue Incoming, SDValue Chain,
     MachineFrameInfo &MFI = Builder.DAG.getMachineFunction().getFrameInfo();
     assert((MFI.getObjectSize(Index) * 8) ==
                (-8 & (7 + // Round up modulo 8.
-                      (int64_t)Incoming.getValueSizeInBits())) &&
+                      Incoming.getValueSizeInBits())) &&
            "Bad spill:  stack slot does not match!");
 
     // Note: Using the alignment of the spill slot (rather than the abi or

--- a/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
+++ b/llvm/lib/Target/SystemZ/SystemZInstrInfo.cpp
@@ -404,7 +404,7 @@ bool SystemZInstrInfo::isStackSlotCopy(const MachineInstr &MI,
     return false;
 
   // Check that Length covers the full slots.
-  int64_t Length = MI.getOperand(2).getImm();
+  uint64_t Length = MI.getOperand(2).getImm();
   unsigned FI1 = MI.getOperand(0).getIndex();
   unsigned FI2 = MI.getOperand(3).getIndex();
   if (MFI.getObjectSize(FI1) != Length ||


### PR DESCRIPTION
The type of the variable returned by `getObjectSize` and set by `setObjectSize` is uint64_t.