### PR TITLE
[libclc] Enable `clang fp reciprocal` in clc_native_divide/recip/rsqrt/tan

### DIFF
--- a/libclc/clc/lib/generic/math/clc_native_divide.inc
+++ b/libclc/clc/lib/generic/math/clc_native_divide.inc
@@ -8,5 +8,6 @@
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_divide(__CLC_GENTYPE x,
                                                          __CLC_GENTYPE y) {
+#pragma clang fp reciprocal(on)
   return x / y;
 }

--- a/libclc/clc/lib/generic/math/clc_native_divide.inc
+++ b/libclc/clc/lib/generic/math/clc_native_divide.inc
@@ -8,6 +8,6 @@
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_divide(__CLC_GENTYPE x,
                                                          __CLC_GENTYPE y) {
-#pragma clang fp reciprocal(on)
+  _Pragma("clang fp reciprocal(on)");
   return x / y;
 }

--- a/libclc/clc/lib/generic/math/clc_native_recip.inc
+++ b/libclc/clc/lib/generic/math/clc_native_recip.inc
@@ -7,5 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_recip(__CLC_GENTYPE val) {
+#pragma clang fp reciprocal(on)
   return 1.0f / val;
 }

--- a/libclc/clc/lib/generic/math/clc_native_recip.inc
+++ b/libclc/clc/lib/generic/math/clc_native_recip.inc
@@ -7,6 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_recip(__CLC_GENTYPE val) {
-#pragma clang fp reciprocal(on)
+  _Pragma("clang fp reciprocal(on)");
   return 1.0f / val;
 }

--- a/libclc/clc/lib/generic/math/clc_native_rsqrt.inc
+++ b/libclc/clc/lib/generic/math/clc_native_rsqrt.inc
@@ -7,6 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_rsqrt(__CLC_GENTYPE val) {
-#pragma clang fp reciprocal(on)
+  _Pragma("clang fp reciprocal(on)");
   return 1.0f / __clc_native_sqrt(val);
 }

--- a/libclc/clc/lib/generic/math/clc_native_rsqrt.inc
+++ b/libclc/clc/lib/generic/math/clc_native_rsqrt.inc
@@ -7,5 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_rsqrt(__CLC_GENTYPE val) {
+#pragma clang fp reciprocal(on)
   return 1.0f / __clc_native_sqrt(val);
 }

--- a/libclc/clc/lib/generic/math/clc_native_tan.inc
+++ b/libclc/clc/lib/generic/math/clc_native_tan.inc
@@ -7,6 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_tan(__CLC_GENTYPE val) {
-#pragma clang fp reciprocal(on)
+  _Pragma("clang fp reciprocal(on)");
   return __clc_native_sin(val) / __clc_native_cos(val);
 }

--- a/libclc/clc/lib/generic/math/clc_native_tan.inc
+++ b/libclc/clc/lib/generic/math/clc_native_tan.inc
@@ -7,5 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_native_tan(__CLC_GENTYPE val) {
+#pragma clang fp reciprocal(on)
   return __clc_native_sin(val) / __clc_native_cos(val);
 }


### PR DESCRIPTION
The pragma adds `arcp` flag to `fdiv` instruction in these functions. The flag can provide better performance.