### PR TITLE
Clean up LLDB `type format` docs a bit

### DIFF
--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -231,7 +231,7 @@ defined the same format for multiple types on the same command,
 argument.
 
 To delete ALL formats, use ``type format clear``. To see all the formats
-defined, use type format list.
+defined, use ``type format list``.
 
 If all you need to do, however, is display one variable in a custom format,
 while leaving the others of the same type untouched, you can simply type:

--- a/lldb/docs/use/variable.rst
+++ b/lldb/docs/use/variable.rst
@@ -224,10 +224,11 @@ format, which means you are effectively formatting the address stored in the
 pointer rather than the pointee value. For this reason, you may want to use the
 -p option when defining formats.
 
-If you need to delete a custom format simply type type format delete followed
-by the name of the type to which the format applies.Even if you defined the
-same format for multiple types on the same command, type format delete will
-only remove the format for the type name passed as argument.
+If you need to delete a custom format, simply type ``type format delete``
+followed by the name of the type to which the format applies. Even if you
+defined the same format for multiple types on the same command,
+``type format delete`` will only remove the format for the type name passed as
+argument.
 
 To delete ALL formats, use ``type format clear``. To see all the formats
 defined, use type format list.


### PR DESCRIPTION
This PR cleans up the formatting of the [LLDB doc paragraph about `type format delete`](https://lldb.llvm.org/use/variable.html#type-format) to make it more readable, as well as a following paragraph about `type format list`.