### PR TITLE
[offload] Add missing build dependency

### DIFF
--- a/offload/tools/offload-tblgen/CMakeLists.txt
+++ b/offload/tools/offload-tblgen/CMakeLists.txt
@@ -22,5 +22,11 @@ add_tablegen(offload-tblgen OFFLOAD
   RecordTypes.hpp
   )
 
+# Make sure that C++ headers are available, if libcxx is built at the same
+# time. This is important if clang is set to prefer libc++ over libstdc++
+if(TARGET cxx-headers)
+  add_dependencies(offload-tblgen cxx-headers)
+endif()
+
 set(OFFLOAD_TABLEGEN_EXE "${OFFLOAD_TABLEGEN_EXE}" CACHE INTERNAL "")
 set(OFFLOAD_TABLEGEN_TARGET "${OFFLOAD_TABLEGEN_TARGET}" CACHE INTERNAL "")


### PR DESCRIPTION
libc++ headers must be generated before compiling part of liboffload. 
The build error occurs if clang is configured to use libc++ by default. 
Fixes issue #149324