### PR TITLE
[libc] Fixed StringConverter Error Edge Case

### DIFF
--- a/libc/src/__support/wchar/string_converter.h
+++ b/libc/src/__support/wchar/string_converter.h
@@ -63,7 +63,7 @@ public:
       auto src_elements_read = pushFullCharacter();
       if (!src_elements_read.has_value())
         return Error(src_elements_read.error());
-      
+
       if (cr.sizeAsUTF32() > num_to_write) {
         cr.clear();
         return Error(-1);
@@ -84,7 +84,7 @@ public:
   ErrorOr<char8_t> popUTF8() {
     if (num_to_write == 0)
       return Error(-1);
-      
+
     if (cr.isEmpty() || src_idx == 0) {
       auto src_elements_read = pushFullCharacter();
       if (!src_elements_read.has_value())

--- a/libc/src/__support/wchar/string_converter.h
+++ b/libc/src/__support/wchar/string_converter.h
@@ -56,11 +56,14 @@ public:
   // TODO: following functions are almost identical
   // look into templating CharacterConverter pop functions
   ErrorOr<char32_t> popUTF32() {
+    if (num_to_write == 0)
+      return Error(-1);
+
     if (cr.isEmpty() || src_idx == 0) {
       auto src_elements_read = pushFullCharacter();
       if (!src_elements_read.has_value())
         return Error(src_elements_read.error());
-
+      
       if (cr.sizeAsUTF32() > num_to_write) {
         cr.clear();
         return Error(-1);
@@ -79,6 +82,9 @@ public:
   }
 
   ErrorOr<char8_t> popUTF8() {
+    if (num_to_write == 0)
+      return Error(-1);
+      
     if (cr.isEmpty() || src_idx == 0) {
       auto src_elements_read = pushFullCharacter();
       if (!src_elements_read.has_value())


### PR DESCRIPTION
Fixed StringConverter edge case related to destination limit

If we call pop() but there is no space in the dest array, we should always return the "no space in destination" error even if the following character is invalid (since we shouldn't really have to look at the next character)
