### PR TITLE
AMDGPU: Remove the dot4 test in insert-delay-alu-wmma-xdl.mir, NFC

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-xdl.mir
+++ b/llvm/test/CodeGen/AMDGPU/insert-delay-alu-wmma-xdl.mir
@@ -65,20 +65,3 @@ body: |
     $vgpr12 = V_EXP_F32_e32 $vgpr12, implicit $exec, implicit $mode
     $vgpr13 = V_ADD_U32_e32 $vgpr13, $vgpr8, implicit $exec
 ...
-
----
-name: dot_xdl_dep_2
-tracksRegLiveness: true
-body: |
-  bb.0:
-    ; CHECK-LABEL: {{^}}dot_xdl_dep_2:
-    ; CHECK: %bb.0:
-    ; CHECK-NEXT: v_dot4_i32_iu8 v0, s2, s3, v0 neg_lo:[1,1,0]
-    ; CHECK-NEXT: v_dot4_i32_iu8 v1, s2, s3, v2 neg_lo:[1,1,0]
-    ; CHECK-NEXT: s_delay_alu instid0(VALU_DEP_2)
-    ; CHECK-NEXT: v_add_nc_u32_e32 v2, v0, v0
-    liveins: $vgpr0, $sgpr2, $sgpr3, $vgpr0, $vgpr1, $vgpr2
-    $vgpr0 = V_DOT4_I32_IU8 9, $sgpr2, 9, $sgpr3, 8, $vgpr0, 0, 0, 0, implicit $exec
-    $vgpr1 = V_DOT4_I32_IU8 9, $sgpr2, 9, $sgpr3, 8, $vgpr2, 0, 0, 0, implicit $exec
-    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr0, implicit $exec
-...


### PR DESCRIPTION
 This is irrelevant, and caused a failure in downstream.

Fixes: SWDEV-544025