### PR TITLE
[mlir] Fix CI breakage from https://github.com/llvm/llvm-project/pull/146228

### DIFF
--- a/mlir/test/IR/test-pattern-logging-listener.mlir
+++ b/mlir/test/IR/test-pattern-logging-listener.mlir
@@ -2,14 +2,21 @@
 // RUN:   --allow-unregistered-dialect --debug-only=pattern-logging-listener 2>&1 | FileCheck %s
 
 // Check that when replacing an op with a new op, we get appropriate
-// pattern-logging lines. The regex is because the anonymous namespace is
-// printed differently on different platforms.
+// pattern-logging lines. The use of check same is to avoid the complexity of
+// matching the anonymous namespace prefix, which can be one of {anonymous} vs
+// {anonymous_namespace} vs `anonymous_namespace` (and maybe others?) on the
+// various platforms.
 
-// CHECK: [pattern-logging-listener] {{.anonymous.namespace.}}::ReplaceWithNewOp | notifyOperationInserted | test.new_op
-// CHECK: [pattern-logging-listener] {{.anonymous.namespace.}}::ReplaceWithNewOp | notifyOperationReplaced (with values) | test.replace_with_new_op
-// CHECK: [pattern-logging-listener] {{.anonymous.namespace.}}::ReplaceWithNewOp | notifyOperationModified | arith.addi
-// CHECK: [pattern-logging-listener] {{.anonymous.namespace.}}::ReplaceWithNewOp | notifyOperationModified | arith.addi
-// CHECK: [pattern-logging-listener] {{.anonymous.namespace.}}::ReplaceWithNewOp | notifyOperationErased | test.replace_with_new_op
+// CHECK: [pattern-logging-listener]
+// CHECK-SAME: ::ReplaceWithNewOp | notifyOperationInserted | test.new_op
+// CHECK: [pattern-logging-listener]
+// CHECK-SAME: ::ReplaceWithNewOp | notifyOperationReplaced (with values) | test.replace_with_new_op
+// CHECK: [pattern-logging-listener]
+// CHECK-SAME: ::ReplaceWithNewOp | notifyOperationModified | arith.addi
+// CHECK: [pattern-logging-listener]
+// CHECK-SAME: ::ReplaceWithNewOp | notifyOperationModified | arith.addi
+// CHECK: [pattern-logging-listener]
+// CHECK-SAME: ::ReplaceWithNewOp | notifyOperationErased | test.replace_with_new_op
 func.func @replace_with_new_op() -> i32 {
   %a = "test.replace_with_new_op"() : () -> (i32)
   %res = arith.addi %a, %a : i32


### PR DESCRIPTION
Some platforms print `{anonymous}` instead of the other two forms accepted by the test regex. This PR just removes the attempt to guess how the anonymous namespace will be printed.

@Kewen12 is there a way to trigger the particular CIs that failed in https://github.com/llvm/llvm-project/pull/146228 on this PR?