### PR TITLE
[X86] Correct an assertion message (NFC)

### DIFF
--- a/llvm/lib/Target/X86/X86CallingConv.cpp
+++ b/llvm/lib/Target/X86/X86CallingConv.cpp
@@ -389,7 +389,7 @@ static bool CC_X86_32_I128_FP128(unsigned &ValNo, MVT &ValVT, MVT &LocVT,
   if (!ArgFlags.isInConsecutiveRegsLast())
     return true;
 
-  assert(PendingMembers.size() == 4 && "Should have two parts");
+  assert(PendingMembers.size() == 4 && "Should have four parts");
 
   int64_t Offset = State.AllocateStack(16, Align(16));
   PendingMembers[0].convertToMem(Offset);


### PR DESCRIPTION
I introduced this in a78a0f8d2043 ("[X86] Align f128 and i128 to 16 bytes"). Correct the message here.