### PR TITLE
[Github] Run code formatter job in release branch

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - 'users/**'
+      - 'release/**'
 
 jobs:
   code_formatter:


### PR DESCRIPTION
This patch makes it so that the code formatting job will run in the release branch.

Per the request of tru@ (the current release manager).