### PR TITLE
[libcxx][fstream][NFC] Make __failed helper lambda a member function

### DIFF
--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -402,7 +402,7 @@ private:
     }
   }
 
-  typename traits_type::int_type __overflow_failed() {
+  _LIBCPP_HIDE_FROM_ABI typename traits_type::int_type __overflow_failed() {
     if (this->pptr() == this->epptr() + 1) {
       this->pbump(-1); // lose the character we overflowed above -- we don't really have a
                        // choice since we couldn't commit the contents of the put area

--- a/libcxx/include/fstream
+++ b/libcxx/include/fstream
@@ -401,6 +401,14 @@ private:
       }
     }
   }
+
+  typename traits_type::int_type __overflow_failed() {
+    if (this->pptr() == this->epptr() + 1) {
+      this->pbump(-1); // lose the character we overflowed above -- we don't really have a
+                       // choice since we couldn't commit the contents of the put area
+    }
+    return traits_type::eof();
+  }
 };
 
 template <class _CharT, class _Traits>
@@ -821,14 +829,6 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
 
 template <class _CharT, class _Traits>
 typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>::overflow(int_type __c) {
-  auto __failed = [this]() {
-    if (this->pptr() == this->epptr() + 1) {
-      this->pbump(-1); // lose the character we overflowed above -- we don't really have a
-                       // choice since we couldn't commit the contents of the put area
-    }
-    return traits_type::eof();
-  };
-
   if (__file_ == nullptr)
     return traits_type::eof();
   __write_mode();
@@ -850,7 +850,7 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
   if (__always_noconv_) {
     size_t __n = static_cast<size_t>(this->pptr() - this->pbase());
     if (std::fwrite(this->pbase(), sizeof(char_type), __n, __file_) != __n) {
-      return __failed();
+      return __overflow_failed();
     }
   } else {
     if (!__cv_)
@@ -864,14 +864,14 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
     do {
       codecvt_base::result __r = __cv_->out(__st_, __b, __p, __end, __extbuf_, __extbuf_ + __ebs_, __extbuf_end);
       if (__end == __b) {
-        return __failed();
+        return __overflow_failed();
       }
 
       // No conversion needed: output characters directly to the file, done.
       if (__r == codecvt_base::noconv) {
         size_t __n = static_cast<size_t>(__p - __b);
         if (std::fwrite(__b, 1, __n, __file_) != __n) {
-          return __failed();
+          return __overflow_failed();
         }
         break;
 
@@ -879,7 +879,7 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
       } else if (__r == codecvt_base::ok) {
         size_t __n = static_cast<size_t>(__extbuf_end - __extbuf_);
         if (std::fwrite(__extbuf_, 1, __n, __file_) != __n) {
-          return __failed();
+          return __overflow_failed();
         }
         break;
 
@@ -888,13 +888,13 @@ typename basic_filebuf<_CharT, _Traits>::int_type basic_filebuf<_CharT, _Traits>
       } else if (__r == codecvt_base::partial) {
         size_t __n = static_cast<size_t>(__extbuf_end - __extbuf_);
         if (std::fwrite(__extbuf_, 1, __n, __file_) != __n) {
-          return __failed();
+          return __overflow_failed();
         }
         __b = const_cast<char_type*>(__end);
         continue;
 
       } else {
-        return __failed();
+        return __overflow_failed();
       }
     } while (true);
   }


### PR DESCRIPTION
This patch makes the `__failed` lambda a member function on `fstream`. This fixes two LLDB expression evaluation test failures that got introduced with https://github.com/llvm/llvm-project/pull/147389:
```
16:22:51  ********************
16:22:51  Unresolved Tests (2):
16:22:51    lldb-api :: commands/expression/import-std-module/list-dbg-info-content/TestDbgInfoContentListFromStdModule.py
16:22:51    lldb-api :: commands/expression/import-std-module/list/TestListFromStdModule.py
```

The expression evaluator is asserting in the Clang parser:
```
Assertion failed: (capture_size() == Class->capture_size() && "Wrong number of captures"), function LambdaExpr, file ExprCXX.cpp, line 1277.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
```

Ideally we'd figure out why LLDB is falling over on this lambda. But to unblock CI for now, make this a member function.

In the long run we should figure out the LLDB bug here so libc++ doesn't need to care about whether it uses lambdas like this or not.