### PR TITLE
[MLIR][Python] Fix bug when garbage collecting a DenseResourceElementsAttribute

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -18,7 +18,6 @@
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
 #include "mlir/Bindings/Python/Nanobind.h"
-#include "pylifecycle.h"
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/mlir/test/python/ir/array_attributes.py
+++ b/mlir/test/python/ir/array_attributes.py
@@ -617,3 +617,16 @@ def testGetDenseResourceElementsAttr():
     # CHECK: BACKING MEMORY DELETED
     # CHECK: EXIT FUNCTION
     print("EXIT FUNCTION")
+
+
+print("TEST: danglingResource")
+# This error occurs only when there is an alive context with a DenseResourceElementsAttr 
+# in the end of the program, so we put it here without an encapsulating function.
+ctx = Context()
+
+with ctx, Location.unknown():
+    DenseResourceElementsAttr.get_from_buffer(
+        memoryview(np.array([1,2,3])),
+        "some_resource",
+        RankedTensorType.get((3,), IntegerType.get_signed(32))
+    )


### PR DESCRIPTION
### Bug description
When running `iree.turbine` example script we have encountered the following error:

```python
import torch
import iree.turbine.aot as aot
module = torch.nn.Linear(2, 2, bias=True)
exported = aot.export(module, torch.rand(2, 2))

> python test.py
Fatal Python error: _PyImport_Init: global import state already initialized
Python runtime state: preinitialized

Current thread 0x00007dd45de45300 (most recent call first):
  Garbage-collecting
  <no Python frame>
```

This error reproduces in multiple environments from a simple installation from the main branch. Other people have also [noticed](https://github.com/iree-org/iree-turbine/issues/804) this issue, however it was not caught in turbine's CI since this test is disabled there:

```
tests/examples/aot_mlp_test.py::AOTMLPTest::testMLPExportSimple 
[gw0] [ 95%] SKIPPED tests/examples/aot_mlp_test.py::AOTMLPTest::testMLPExportSimple 
```

While figuring out the origins of the issue we have found the export part which leads to this issue happening and it was related to MLIR's python bindings:

```python
from iree.compiler.ir import DenseResourceElementsAttr, RankedTensorType, IntegerType, Context, Location
import numpy as np

ctx = Context()

with Location.unknown(ctx):
    DenseResourceElementsAttr.get_from_buffer(
        memoryview(np.array([1,2,3])),
        "some_resource",
        RankedTensorType.get((3,), IntegerType.get_signed(32)),
        context=ctx
    )

> python bindings.py
Fatal Python error: _PyImport_Init: global import state already initialized
Python runtime state: preinitialized

Current thread 0x00007dd45de45300 (most recent call first):
  Garbage-collecting
  <no Python frame>
```

This reproduces with bindings not built by IREE.
Turned out that if we explicitly destroy the context object issue from the previous script disappears, same thing happens if we explicitly destroy the export result in the first script.
```python
...
del ctx
> python bindings.py
>
```

```python
...
del exported
gc.collect()
> python test.py
>
```

I would argue that this is a bug and needs to be fixed, since not explicitly destroying all the objects shouldn't lead to a fatal python error.

### Bug origins
Bug comes from [this](https://github.com/llvm/llvm-project/commit/28507ac62928d79f647804de4df60409b3ebb364) modification to the bindings - here people introduced explicit construction of python interpreter and GIL ca when deleting a DenseResource object.
```c++
    // The userData is a Py_buffer* that the deleter owns.
    auto deleter = [](void *userData, const void *data, size_t size,
                      size_t align) {
      if (!Py_IsInitialized())
        Py_Initialize();
      Py_buffer *ownedView = static_cast<Py_buffer *>(userData);
      nb::gil_scoped_acquire gil;
      PyBuffer_Release(ownedView);
      delete ownedView;
    };
```

However, when python terminates the interpreter it sets IsInitilized variable to false before doing garbage collection. So when the deleter is called `Py_IsInitialized` returns false while actually not all of the interpreter state has been stripped down. Import state still exist and so this leads to the error that we see in the scripts:
```c
PyStatus
_PyImport_Init(void)
{
    if (INITTAB != NULL) {
        return _PyStatus_ERR("global import state already initialized");
    }
    if (init_builtin_modules_table() != 0) {
        return PyStatus_NoMemory();
    }
    return _PyStatus_OK();
}
// this function is ran as a part of initialization process, so it throws an error since INITTAB hasn't been deleted yet
```



### Solution
We need to separate cases when interpreter says it is not initialized due to never existing or being killed in the moment. There is a function which can do that.
```c++
if (!(Py_IsInitialized() || _Py_IsFinalizing()))
        Py_Initialize();
```

However this function was deprecated in python3.13 and another one came into its place. To support all versions of Python we introduce a function which compiles to different variants based on python version. We took this function [from lldb](https://github.com/llvm/llvm-project/blob/9ce0a61bdbf13d4d0f2e13e1bb6e7a4bb9d01858/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp#L73).