### PR TITLE
[libc++][Android] Reenable 2 tests for Android

### DIFF
--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.comp/is_bounded_array.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.comp/is_bounded_array.pass.cpp
@@ -7,9 +7,6 @@
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// The Clang version that Android currently uses in the CI is too old.
-// UNSUPPORTED: LIBCXX-ANDROID-FIXME
-
 // type_traits
 
 // is_bounded_array<T>

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 
-// The Clang version that Android currently uses in the CI is too old.
-// UNSUPPORTED: LIBCXX-ANDROID-FIXME
-
 // type_traits
 
 // has_unique_object_representations


### PR DESCRIPTION
Now that the Android clang has been upgraded to clang-r563880 (llvm.org/pr148998), these two tests pass again.