### PR TITLE
[MLIR][SCF] Add dedicated Python bindings for ForallOp

### DIFF
--- a/mlir/python/mlir/dialects/scf.py
+++ b/mlir/python/mlir/dialects/scf.py
@@ -17,7 +17,7 @@ try:
 except ImportError as e:
     raise RuntimeError("Error loading imports from extension module") from e
 
-from typing import Optional, Sequence, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)
@@ -69,6 +69,120 @@ class ForOp(ForOp):
         To obtain the loop-carried operands, use `iter_args`.
         """
         return self.body.arguments[1:]
+
+
+def dispatch_index_op_fold_results(
+    ofrs: Sequence[Union[int, Value]],
+) -> Tuple[List[Value], List[int]]:
+    """`mlir::dispatchIndexOpFoldResults`"""
+    dynamic_vals = []
+    static_vals = []
+    for ofr in ofrs:
+        if isinstance(ofr, Value):
+            dynamic_vals.append(ofr)
+            static_vals.append(ShapedType.get_dynamic_size())
+        else:
+            static_vals.append(ofr)
+    return dynamic_vals, static_vals
+
+
+@_ods_cext.register_operation(_Dialect, replace=True)
+class ForallOp(ForallOp):
+    """Specialization for the SCF forall op class."""
+
+    def __init__(
+        self,
+        lower_bounds: Sequence[Union[Value, int]],
+        upper_bounds: Sequence[Union[Value, int]],
+        steps: Sequence[Union[Value, int]],
+        iter_args: Optional[Union[Operation, OpView, Sequence[Value]]] = None,
+        *,
+        mapping=None,
+        loc=None,
+        ip=None,
+    ):
+        """Creates an SCF `forall` operation.
+
+        - `lower_bounds` are the values to use as lower bounds of the loop.
+        - `upper_bounds` are the values to use as upper bounds of the loop.
+        - `steps` are the values to use as loop steps.
+        - `iter_args` is a list of additional loop-carried arguments or an operation
+          producing them as results.
+        """
+        if iter_args is None:
+            iter_args = []
+        iter_args = _get_op_results_or_values(iter_args)
+
+        dynamic_lbs, static_lbs = dispatch_index_op_fold_results(lower_bounds)
+        dynamic_ubs, static_ubs = dispatch_index_op_fold_results(upper_bounds)
+        dynamic_steps, static_steps = dispatch_index_op_fold_results(steps)
+
+        results = [arg.type for arg in iter_args]
+        super().__init__(
+            results,
+            dynamic_lbs,
+            dynamic_ubs,
+            dynamic_steps,
+            static_lbs,
+            static_ubs,
+            static_steps,
+            iter_args,
+            mapping=mapping,
+            loc=loc,
+            ip=ip,
+        )
+        rank = len(static_lbs)
+        iv_types = [IndexType.get()] * rank
+        self.regions[0].blocks.append(*iv_types, *results)
+
+    @property
+    def body(self) -> Block:
+        """Returns the body (block) of the loop."""
+        return self.regions[0].blocks[0]
+
+    @property
+    def rank(self) -> int:
+        """Returns the number of induction variables the loop has."""
+        return len(self.staticLowerBound)
+
+    @property
+    def induction_variables(self) -> BlockArgumentList:
+        """Returns the induction variables usable within the loop."""
+        return self.body.arguments[: self.rank]
+
+    @property
+    def inner_iter_args(self):
+        """Returns the loop-carried arguments usable within the loop.
+
+        To obtain the loop-carried operands, use `iter_args`.
+        """
+        return self.body.arguments[self.rank :]
+
+    @property
+    def terminator(self) -> InParallelOp:
+        """
+        Returns the loop terminator if it exists.
+        Otherwise, create a new one.
+        """
+        ops = self.body.operations
+        with InsertionPoint(self.body):
+            if not ops:
+                return InParallelOp()
+            last = ops[len(ops) - 1]
+            return last if isinstance(last, InParallelOp) else InParallelOp()
+
+
+@_ods_cext.register_operation(_Dialect, replace=True)
+class InParallelOp(InParallelOp):
+    """Specialization of the SCF forall.in_parallel op class."""
+
+    def __init__(self, loc=None, ip=None):
+        super().__init__(loc=loc, ip=ip)
+        self.region.blocks.append()
+
+    @property
+    def block(self) -> Block:
+        return self.region.blocks[0]
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)

--- a/mlir/python/mlir/dialects/scf.py
+++ b/mlir/python/mlir/dialects/scf.py
@@ -71,15 +71,16 @@ class ForOp(ForOp):
         return self.body.arguments[1:]
 
 
-def dispatch_index_op_fold_results(
-    ofrs: Sequence[Union[int, Value]],
+def _dispatch_index_op_fold_results(
+    ofrs: Sequence[Union[Operation, OpView, Value, int]],
 ) -> Tuple[List[Value], List[int]]:
     """`mlir::dispatchIndexOpFoldResults`"""
     dynamic_vals = []
     static_vals = []
     for ofr in ofrs:
-        if isinstance(ofr, Value):
-            dynamic_vals.append(ofr)
+        if isinstance(ofr, (Operation, OpView, Value)):
+            val = _get_op_result_or_value(ofr)
+            dynamic_vals.append(val)
             static_vals.append(ShapedType.get_dynamic_size())
         else:
             static_vals.append(ofr)
@@ -92,10 +93,10 @@ class ForallOp(ForallOp):
 
     def __init__(
         self,
-        lower_bounds: Sequence[Union[Value, int]],
-        upper_bounds: Sequence[Union[Value, int]],
+        lower_bounds: Sequence[Union[Operation, OpView, Value, int]],
+        upper_bounds: Sequence[Union[Operation, OpView, Value, int]],
         steps: Sequence[Union[Value, int]],
-        iter_args: Optional[Union[Operation, OpView, Sequence[Value]]] = None,
+        shared_outs: Optional[Union[Operation, OpView, Sequence[Value]]] = None,
         *,
         mapping=None,
         loc=None,
@@ -106,18 +107,21 @@ class ForallOp(ForallOp):
         - `lower_bounds` are the values to use as lower bounds of the loop.
         - `upper_bounds` are the values to use as upper bounds of the loop.
         - `steps` are the values to use as loop steps.
-        - `iter_args` is a list of additional loop-carried arguments or an operation
+        - `shared_outs` is a list of additional loop-carried arguments or an operation
           producing them as results.
         """
-        if iter_args is None:
-            iter_args = []
-        iter_args = _get_op_results_or_values(iter_args)
+        assert (
+            len(lower_bounds) == len(upper_bounds) == len(steps)
+        ), "Mismatch in length of lower bounds, upper bounds, and steps"
+        if shared_outs is None:
+            shared_outs = []
+        shared_outs = _get_op_results_or_values(shared_outs)
 
-        dynamic_lbs, static_lbs = dispatch_index_op_fold_results(lower_bounds)
-        dynamic_ubs, static_ubs = dispatch_index_op_fold_results(upper_bounds)
-        dynamic_steps, static_steps = dispatch_index_op_fold_results(steps)
+        dynamic_lbs, static_lbs = _dispatch_index_op_fold_results(lower_bounds)
+        dynamic_ubs, static_ubs = _dispatch_index_op_fold_results(upper_bounds)
+        dynamic_steps, static_steps = _dispatch_index_op_fold_results(steps)
 
-        results = [arg.type for arg in iter_args]
+        results = [arg.type for arg in shared_outs]
         super().__init__(
             results,
             dynamic_lbs,
@@ -126,7 +130,7 @@ class ForallOp(ForallOp):
             static_lbs,
             static_ubs,
             static_steps,
-            iter_args,
+            shared_outs,
             mapping=mapping,
             loc=loc,
             ip=ip,
@@ -151,18 +155,17 @@ class ForallOp(ForallOp):
         return self.body.arguments[: self.rank]
 
     @property
-    def inner_iter_args(self):
+    def inner_iter_args(self) -> BlockArgumentList:
         """Returns the loop-carried arguments usable within the loop.
 
         To obtain the loop-carried operands, use `iter_args`.
         """
         return self.body.arguments[self.rank :]
 
-    @property
     def terminator(self) -> InParallelOp:
         """
         Returns the loop terminator if it exists.
-        Otherwise, create a new one.
+        Otherwise, creates a new one.
         """
         ops = self.body.operations
         with InsertionPoint(self.body):

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -18,6 +18,26 @@ def constructAndPrintInModule(f):
     return f
 
 
+# CHECK-LABEL: TEST: testSimpleForall
+# CHECK: scf.forall (%[[IV0:.*]], %[[IV1:.*]]) in (4, 8) shared_outs(%[[BOUND_ARG:.*]] = %{{.*}}) -> (tensor<4x8xf32>)
+# CHECK:   arith.addi %[[IV0]], %[[IV1]]
+# CHECK:   scf.forall.in_parallel
+@constructAndPrintInModule
+def testSimpleForall():
+    f32 = F32Type.get()
+    tensor_type = RankedTensorType.get([4, 8], f32)
+
+    @func.FuncOp.from_py_func(tensor_type)
+    def forall_loop(tensor):
+        loop = scf.ForallOp([0, 0], [4, 8], [1, 1], [tensor])
+        with InsertionPoint(loop.body):
+            i, j = loop.induction_variables
+            arith.addi(i, j)
+            loop.terminator
+        # The verifier will check that the regions have been created properly.
+        assert loop.verify()
+
+
 # CHECK-LABEL: TEST: testSimpleLoop
 @constructAndPrintInModule
 def testSimpleLoop():

--- a/mlir/test/python/dialects/scf.py
+++ b/mlir/test/python/dialects/scf.py
@@ -33,7 +33,7 @@ def testSimpleForall():
         with InsertionPoint(loop.body):
             i, j = loop.induction_variables
             arith.addi(i, j)
-            loop.terminator
+            loop.terminator()
         # The verifier will check that the regions have been created properly.
         assert loop.verify()
 


### PR DESCRIPTION
This patch specializes the Python bindings for ForallOp and InParallelOp, similar to the existing one for ForOp.  These bindings create the regions and blocks properly and expose some additional helpers.