### PR TITLE
[WebAssembly] Unstackify operands for removed terminators

### DIFF
--- a/llvm/test/CodeGen/WebAssembly/removed-terminator.ll
+++ b/llvm/test/CodeGen/WebAssembly/removed-terminator.ll
@@ -1,0 +1,15 @@
+; RUN: llc -O0 < %s
+
+target triple = "wasm32-unknown-unknown"
+
+define void @test(i1 %x) {
+  %y = xor i1 %x, true
+  ; We now do a limited amount of register stackification in RegStackify even in
+  ; -O0, so its operand (%y) is stackified. But this terminator will be removed
+  ; in CFGSort after that. We need to make sure we unstackify %y so that it can
+  ; be dropped in ExplicitLocals.
+  br i1 %y, label %exit, label %exit
+
+exit:
+  ret void
+}

--- a/llvm/test/CodeGen/WebAssembly/removed-terminator.ll
+++ b/llvm/test/CodeGen/WebAssembly/removed-terminator.ll
@@ -4,10 +4,9 @@ target triple = "wasm32-unknown-unknown"
 
 define void @test(i1 %x) {
   %y = xor i1 %x, true
-  ; We now do a limited amount of register stackification in RegStackify even in
-  ; -O0, so its operand (%y) is stackified. But this terminator will be removed
-  ; in CFGSort after that. We need to make sure we unstackify %y so that it can
-  ; be dropped in ExplicitLocals.
+  ; This br_if's operand (%y) is stackified in RegStackify. But this terminator
+  ; will be removed in CFGSort after that. We need to make sure we unstackify %y
+  ; so that it can be dropped in ExplicitLocals.
   br i1 %y, label %exit, label %exit
 
 exit:


### PR DESCRIPTION
There are cases we end up removing a conditional branch with a stackified register condition operand. For example:
```wasm
bb.0:
  %0 = ...    ;; %0 is stackified
  br_if %bb.1, %0
bb.1:
```

In this code, br_if will be removed, so we should unstackify %0 so that it can be correctly dropped in ExplicitLocals.

There seems no good method to determine which registers to unstackify without analyzing branches thoroughly, which is supposed to be done within `updateTerminator()`. So we just unstackify all of them and restackify the still-remaining registers after `updateTerminator()`.

Fixes #149097.