### PR TITLE
[lldb-dap] Fix type req->arguments == "disconnect"

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -983,7 +983,7 @@ llvm::Error DAP::Loop() {
 
           if (const protocol::Request *req =
                   std::get_if<protocol::Request>(&*next);
-              req && req->arguments == "disconnect")
+              req && req->command == "disconnect")
             disconnecting = true;
 
           const std::optional<CancelArguments> cancel_args =


### PR DESCRIPTION
This typo was introduced in PR #140331. This branch will never get executed. We also set the `disconnecting = true` in the `DAP::Disconnect()` so I am not sure if we need it in both places.