### PR TITLE
[Clang] Add -Wimplicit-fallthrough to -Wextra for GCC compatibility

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -716,6 +716,8 @@ Improvements to Clang's diagnostics
   Added a new warning in this group for the case where the attribute is missing/implicit on
   an override of a virtual method.
 
+- ``-Wimplicit-fallthrough`` was added to ``-Wextra`` for GCC compatibility.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1231,6 +1231,7 @@ def Extra : DiagGroup<"extra", [
     CastFunctionTypeMismatch,
     InitStringTooLongMissingNonString,
     WarnUnnecessaryVirtualSpecifier,
+    ImplicitFallthrough,
   ]>;
 
 def Most : DiagGroup<"most", [


### PR DESCRIPTION
See also https://github.com/llvm/llvm-project/issues/58375