### PR TITLE
[lldb] Correct spacing of = {...} when depth limit is hit

### DIFF
--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -854,7 +854,7 @@ llvm::Error ValueObjectPrinter::PrintChildrenIfNeeded(bool value_printed,
       PrintChildren(value_printed, summary_printed, curr_ptr_depth);
   } else if (HasReachedMaximumDepth() && IsAggregate() &&
              ShouldPrintValueObject()) {
-    m_stream->PutCString("{...}\n");
+    m_stream->PutCString(" {...}\n");
     // The maximum child depth has been reached. If `m_max_depth` is the default
     // (i.e. the user has _not_ customized it), then lldb presents a warning to
     // the user. The warning tells the user that the limit has been reached, but

--- a/lldb/test/API/lang/cpp/frame-var-depth-and-elem-count/TestFrameVarDepthAndElemCount.py
+++ b/lldb/test/API/lang/cpp/frame-var-depth-and-elem-count/TestFrameVarDepthAndElemCount.py
@@ -19,10 +19,10 @@ class TestFrameVarDepthAndElemCount(TestBase):
         self.expect(
             "frame var --depth 2 --element-count 5 -- c",
             substrs=[
-                "[0] = {\n    b ={...}\n  }",
-                "[1] = {\n    b ={...}\n  }",
-                "[2] = {\n    b ={...}\n  }",
-                "[3] = {\n    b ={...}\n  }",
-                "[4] = {\n    b ={...}\n  }",
+                "[0] = {\n    b = {...}\n  }",
+                "[1] = {\n    b = {...}\n  }",
+                "[2] = {\n    b = {...}\n  }",
+                "[3] = {\n    b = {...}\n  }",
+                "[4] = {\n    b = {...}\n  }",
             ],
         )


### PR DESCRIPTION
In some places it was printing "= {...}" and some "={...}" with no space. I think the space looks nicer so do that in both cases.