### PR TITLE
[NFC][lldb] fix extra line after documentation

### DIFF
--- a/lldb/include/lldb/Utility/Stream.h
+++ b/lldb/include/lldb/Utility/Stream.h
@@ -270,7 +270,6 @@ public:
   /// \param[in] suffix
   ///     The ANSI color code to end colorization. This is
   ///     environment-dependent.
-
   void PutCStringColorHighlighted(
       llvm::StringRef text,
       std::optional<HighlightSettings> settings = std::nullopt);


### PR DESCRIPTION
Formatting patch which removes an extra line after a docstring.