### PR TITLE
[mlir] Nominate MLIR Core category maintainers

### DIFF
--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -1,0 +1,28 @@
+# MLIR Maintainers
+
+This file is a list of the
+[maintainers](https://llvm.org/docs/DeveloperPolicy.html#maintainers) for MLIR.
+
+The following people are the active maintainers for the project. For the sake of
+simplicity, responsibility areas are subdivided into broad categories, which are
+further subdivided into individual components, such as dialects. Please reach
+out to them for code reviews, questions about their area of expertise, or other
+assistance.
+
+## Core
+
+Core components of MLIR, including core IR, analyses and rewriters, fundamental
+dialects, build system and language bindings.
+
+- Alex Zinenko \
+  ftynse@gmail.com (email),
+  [@ftynse](https://github.com/ftynse) (GitHub),
+  ftynse (Discourse)
+- Jacques Pienaar \
+  jpienaar@google.com (email),
+  [@jpienaar](https://github.com/jpienaar) (GitHub),
+  jpienaar (Discourse)
+- Mehdi Amini \
+  joker.eph@gmail.com (email),
+  [@joker-eph](https://github.com/joker-eph) (GitHub),
+  mehdi_amini (Discourse)


### PR DESCRIPTION
This is a nomination for the maintainers of the core category within MLIR as proposed in https://discourse.llvm.org/t/mlir-project-maintainers/87189. As agreed in the Project Council meeting on July 17, we are proceeding with category nominations without waiting for lead maintainers to be nominated.