### PR TITLE
[DAG][ARM] computeKnownBitsForTargetNode - add handling for ARMISD VORRIMM\VBICIMM nodes

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -20065,6 +20065,31 @@ void ARMTargetLowering::computeKnownBitsForTargetNode(const SDValue Op,
     Known = KnownOp0.intersectWith(KnownOp1);
     break;
   }
+  case ARMISD::VORRIMM: {
+    KnownBits KnownLHS = DAG.computeKnownBits(Op.getOperand(0), Depth + 1);
+
+    unsigned Encoded = Op.getConstantOperandVal(1);
+    unsigned ElemSize = Op.getValueType().getScalarSizeInBits();
+    uint64_t DecodedVal = ARM_AM::decodeVMOVModImm(Encoded, ElemSize);
+    APInt Imm(Known.getBitWidth(), DecodedVal);
+
+    Known.One = KnownLHS.One | Imm;
+    Known.Zero = KnownLHS.Zero & ~Imm;
+    return;
+  }
+  case ARMISD::VBICIMM: {
+    KnownBits KnownLHS = DAG.computeKnownBits(Op.getOperand(0), Depth + 1);
+
+    unsigned Encoded = Op.getConstantOperandVal(1);
+    unsigned ElemSize = Op.getValueType().getScalarSizeInBits();
+    uint64_t DecodedVal = ARM_AM::decodeVMOVModImm(Encoded, ElemSize);
+    APInt Imm(Known.getBitWidth(), DecodedVal);
+
+    APInt NotImm = ~Imm;
+    Known.One = KnownLHS.One & NotImm;
+    Known.Zero = KnownLHS.Zero | Imm;
+    return;
+  }
   }
 }
 

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -20069,9 +20069,9 @@ void ARMTargetLowering::computeKnownBitsForTargetNode(const SDValue Op,
     KnownBits KnownLHS = DAG.computeKnownBits(Op.getOperand(0), Depth + 1);
 
     unsigned Encoded = Op.getConstantOperandVal(1);
-    unsigned ElemSize = Op.getValueType().getScalarSizeInBits();
+    unsigned ElemSize = Op.getScalarValueSizeInBits();
     uint64_t DecodedVal = ARM_AM::decodeVMOVModImm(Encoded, ElemSize);
-    APInt Imm(Known.getBitWidth(), DecodedVal);
+    APInt Imm(ElemSize, DecodedVal);
 
     Known.One = KnownLHS.One | Imm;
     Known.Zero = KnownLHS.Zero & ~Imm;
@@ -20081,9 +20081,9 @@ void ARMTargetLowering::computeKnownBitsForTargetNode(const SDValue Op,
     KnownBits KnownLHS = DAG.computeKnownBits(Op.getOperand(0), Depth + 1);
 
     unsigned Encoded = Op.getConstantOperandVal(1);
-    unsigned ElemSize = Op.getValueType().getScalarSizeInBits();
+    unsigned ElemSize = Op.getScalarValueSizeInBits();
     uint64_t DecodedVal = ARM_AM::decodeVMOVModImm(Encoded, ElemSize);
-    APInt Imm(Known.getBitWidth(), DecodedVal);
+    APInt Imm(ElemSize, DecodedVal);
 
     APInt NotImm = ~Imm;
     Known.One = KnownLHS.One & NotImm;

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -20071,16 +20071,19 @@ void ARMTargetLowering::computeKnownBitsForTargetNode(const SDValue Op,
     unsigned Encoded = Op.getConstantOperandVal(1);
     unsigned DecEltBits = 0;
     uint64_t DecodedVal = ARM_AM::decodeVMOVModImm(Encoded, DecEltBits);
+    bool IsVORR = Op.getOpcode() == ARMISD::VORRIMM;
 
     if (Op.getScalarValueSizeInBits() == DecEltBits) {
-      bool IsVORR = Op.getOpcode() == ARMISD::VORRIMM;
       APInt Imm(DecEltBits, DecodedVal);
       Known.One = IsVORR ? (KnownLHS.One | Imm) : (KnownLHS.One & ~Imm);
       Known.Zero = IsVORR ? (KnownLHS.Zero & ~Imm) : (KnownLHS.Zero | Imm);
     } else {
-      Known = KnownLHS;
+      if (IsVORR)
+        Known.One = KnownLHS.One;
+      else
+        Known.Zero = KnownLHS.Zero;
     }
-    return;
+    break;
   }
   }
 }

--- a/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
@@ -1,3 +1,10 @@
+//===----------------------------------------------------------------------===//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "ARMISelLowering.h"
 #include "MCTargetDesc/ARMAddressingModes.h"
 #include "llvm/Analysis/OptimizationRemarkEmitter.h"
@@ -89,7 +96,7 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VORRIMM) {
   SDValue EncSD = DAG->getTargetConstant(Encoded, DL, MVT::i32);
   SDValue Op = DAG->getNode(ARMISD::VORRIMM, DL, VT, LHS, EncSD);
 
-  APInt DemandedElts(/*numBits=*/2, /*val=*/3);
+  APInt DemandedElts = APInt::getAllOnes(2);
 
   KnownBits Known = DAG->computeKnownBits(Op, DemandedElts);
 
@@ -105,15 +112,14 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VBICIMM) {
   SDLoc DL;
   EVT VT = EVT::getVectorVT(Context, EVT::getIntegerVT(Context, 32), 2);
 
-  APInt AllOnes(32, 0);
-  AllOnes.setAllBits();
+  APInt AllOnes = APInt::getAllOnes(32);
   SDValue LHS = DAG->getConstant(AllOnes, DL, VT);
 
   unsigned Encoded = 0xF0;
   SDValue EncSD = DAG->getTargetConstant(Encoded, DL, MVT::i32);
   SDValue Op = DAG->getNode(ARMISD::VBICIMM, DL, VT, LHS, EncSD);
 
-  APInt DemandedElts(2, 3);
+  APInt DemandedElts = APInt::getAllOnes(2);
 
   KnownBits Known = DAG->computeKnownBits(Op, DemandedElts);
 

--- a/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
@@ -1,0 +1,128 @@
+#include "ARMISelLowering.h"
+#include "MCTargetDesc/ARMAddressingModes.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/AsmParser/Parser.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/SelectionDAG.h"
+#include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/IR/MDBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/KnownBits.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+
+namespace llvm {
+
+class ARMSelectionDAGTest : public testing::Test {
+protected:
+  static void SetUpTestCase() {
+    LLVMInitializeARMTargetInfo();
+    LLVMInitializeARMTarget();
+    LLVMInitializeARMTargetMC();
+  }
+
+  void SetUp() override {
+    StringRef Assembly = "define void @f() { ret void }";
+
+    Triple TargetTriple("armv7-unknown-none-eabi");
+
+    std::string Error;
+    const Target *T = TargetRegistry::lookupTarget("", TargetTriple, Error);
+
+    TargetOptions Options;
+    TM = std::unique_ptr<TargetMachine>(
+        T->createTargetMachine(TargetTriple,
+                               /*CPU*/ "cortex-a9",
+                               /*Features*/ "+neon", Options, std::nullopt,
+                               std::nullopt, CodeGenOptLevel::Aggressive));
+
+    SMDiagnostic SMError;
+    M = parseAssemblyString(Assembly, SMError, Context);
+    if (!M)
+      report_fatal_error(SMError.getMessage());
+    M->setDataLayout(TM->createDataLayout());
+
+    F = M->getFunction("f");
+    if (!F)
+      report_fatal_error("Function 'f' not found");
+
+    MachineModuleInfo MMI(TM.get());
+
+    MF = std::make_unique<MachineFunction>(*F, *TM, *TM->getSubtargetImpl(*F),
+                                           MMI.getContext(), /*FunctionNum*/ 0);
+
+    DAG = std::make_unique<SelectionDAG>(*TM, CodeGenOptLevel::None);
+    if (!DAG)
+      report_fatal_error("SelectionDAG allocation failed");
+
+    OptimizationRemarkEmitter ORE(F);
+    DAG->init(*MF, ORE, /*LibInfo*/ nullptr, /*AA*/ nullptr,
+              /*AC*/ nullptr, /*MDT*/ nullptr, /*MSDT*/ nullptr, MMI, nullptr);
+  }
+
+  TargetLoweringBase::LegalizeTypeAction getTypeAction(EVT VT) {
+    return DAG->getTargetLoweringInfo().getTypeAction(Context, VT);
+  }
+
+  EVT getTypeToTransformTo(EVT VT) {
+    return DAG->getTargetLoweringInfo().getTypeToTransformTo(Context, VT);
+  }
+
+  LLVMContext Context;
+  std::unique_ptr<TargetMachine> TM;
+  std::unique_ptr<Module> M;
+  Function *F = nullptr;
+  std::unique_ptr<MachineFunction> MF;
+  std::unique_ptr<SelectionDAG> DAG;
+};
+
+TEST_F(ARMSelectionDAGTest, computeKnownBits_VORRIMM) {
+  SDLoc DL;
+  EVT VT = EVT::getVectorVT(Context, EVT::getIntegerVT(Context, 32), 2);
+
+  SDValue LHS = DAG->getConstant(0, DL, VT);
+
+  unsigned Encoded = 0xF0;
+  SDValue EncSD = DAG->getTargetConstant(Encoded, DL, MVT::i32);
+  SDValue Op = DAG->getNode(ARMISD::VORRIMM, DL, VT, LHS, EncSD);
+
+  APInt DemandedElts(/*numBits=*/2, /*val=*/3);
+
+  KnownBits Known = DAG->computeKnownBits(Op, DemandedElts);
+
+  unsigned ElemBits = 32;
+  uint64_t Decoded = ARM_AM::decodeVMOVModImm(Encoded, ElemBits);
+  APInt Imm(32, Decoded);
+
+  EXPECT_EQ(Known.One, Imm);
+  EXPECT_EQ(Known.Zero, ~Imm);
+}
+
+TEST_F(ARMSelectionDAGTest, computeKnownBits_VBICIMM) {
+  SDLoc DL;
+  EVT VT = EVT::getVectorVT(Context, EVT::getIntegerVT(Context, 32), 2);
+
+  APInt AllOnes(32, 0);
+  AllOnes.setAllBits();
+  SDValue LHS = DAG->getConstant(AllOnes, DL, VT);
+
+  unsigned Encoded = 0xF0;
+  SDValue EncSD = DAG->getTargetConstant(Encoded, DL, MVT::i32);
+  SDValue Op = DAG->getNode(ARMISD::VBICIMM, DL, VT, LHS, EncSD);
+
+  APInt DemandedElts(2, 3);
+
+  KnownBits Known = DAG->computeKnownBits(Op, DemandedElts);
+
+  unsigned ElemBits = 32;
+  uint64_t Decoded = ARM_AM::decodeVMOVModImm(Encoded, ElemBits);
+  APInt Imm(32, Decoded);
+
+  EXPECT_EQ(Known.One, ~Imm);
+  EXPECT_EQ(Known.Zero, Imm);
+}
+
+} // end namespace llvm

--- a/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
@@ -93,8 +93,8 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VORRIMM) {
   EVT VT = EVT::getVectorVT(Context, EVT::getIntegerVT(Context, 32), 4);
   SDValue LHS = DAG->getRegister(0, VT);
 
-  SDValue EncSD = DAG->getTargetConstant(ARM_AM::createVMOVModImm(0x0, 0xAA),
-                                         DL, MVT::i32);
+  SDValue EncSD =
+      DAG->getTargetConstant(ARM_AM::createVMOVModImm(0x0, 0xAA), DL, MVT::i32);
   SDValue Op = DAG->getNode(ARMISD::VORRIMM, DL, VT, LHS, EncSD);
 
   // LHS(per-lane)     = ???????? ???????? ???????? ????????
@@ -116,8 +116,8 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VBICIMM) {
 
   SDValue LHS = DAG->getConstant(APInt(32, 0xFFFFFFFF), DL, VT);
 
-  SDValue EncSD = DAG->getTargetConstant(ARM_AM::createVMOVModImm(0x0, 0xAA),
-                                         DL, MVT::i32);
+  SDValue EncSD =
+      DAG->getTargetConstant(ARM_AM::createVMOVModImm(0x0, 0xAA), DL, MVT::i32);
   SDValue Op = DAG->getNode(ARMISD::VBICIMM, DL, VT, LHS, EncSD);
 
   // LHS(per-lane)     = 11111111 11111111 11111111 11111111  (0xFFFFFFFF)

--- a/llvm/unittests/Target/ARM/CMakeLists.txt
+++ b/llvm/unittests/Target/ARM/CMakeLists.txt
@@ -22,4 +22,5 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_target_unittest(ARMTests
   MachineInstrTest.cpp
   InstSizes.cpp
+  ARMSelectionDAGTest.cpp
   )


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/llvm/llvm-project/issues/147179