### PR TITLE
[AssignmentTracking][NFC] Cache interesting debug records and instructions

### DIFF
--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -1780,10 +1780,9 @@ void AssignmentTrackingLowering::processTaggedInstruction(
 
 void AssignmentTrackingLowering::processDbgAssign(DbgVariableRecord *DbgAssign,
                                                   BlockInfo *LiveSet) {
-  // Only bother tracking variables that are at some point stack homed. Other
-  // variables can be dealt with trivially later.
-  if (!VarsWithStackSlot->count(getAggregate(DbgAssign)))
-    return;
+  // Fully promoted variables are dealt with later.
+  assert(VarsWithStackSlot->count(getAggregate(DbgAssign)) &&
+         "Not a stack variable");
 
   VariableID Var = getVariableID(DebugVariable(DbgAssign));
   Assignment AV = Assignment::make(getIDFromMarker(*DbgAssign), DbgAssign);
@@ -1822,10 +1821,9 @@ void AssignmentTrackingLowering::processDbgAssign(DbgVariableRecord *DbgAssign,
 
 void AssignmentTrackingLowering::processDbgValue(DbgVariableRecord *DbgValue,
                                                  BlockInfo *LiveSet) {
-  // Only other tracking variables that are at some point stack homed.
-  // Other variables can be dealt with trivally later.
-  if (!VarsWithStackSlot->count(getAggregate(DbgValue)))
-    return;
+  // Fully promoted variables are dealt with later.
+  assert(VarsWithStackSlot->count(getAggregate(DbgValue)) &&
+         "Not a stack variable");
 
   VariableID Var = getVariableID(DebugVariable(DbgValue));
   // We have no ID to create an Assignment with so we mark this assignment as

--- a/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
+++ b/llvm/lib/CodeGen/AssignmentTrackingAnalysis.cpp
@@ -2150,7 +2150,10 @@ static AssignmentTrackingLowering::OverlapMap buildOverlapMapAndRecordDeclares(
     for (auto &I : BB) {
       for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange()))
         ProcessDbgRecord(&DVR);
-      if (auto Info = getUntaggedStoreAssignmentInfo(I, Fn.getDataLayout())) {
+      if (I.getMetadata(LLVMContext::MD_DIAssignID)) {
+        // Do nothing.
+      } else if (auto Info =
+                     getUntaggedStoreAssignmentInfo(I, Fn.getDataLayout())) {
         // Find markers linked to this alloca.
         auto HandleDbgAssignForStore = [&](DbgVariableRecord *Assign) {
           std::optional<DIExpression::FragmentInfo> FragInfo;


### PR DESCRIPTION
Rather than visit all instructions each iteration of the analysis, we can cache the interesting ones ahead of time while performing other setup related tasks.

Marginal performance improvement. Note in this compile-tim-tracker comparison I've enabled assignment tracking support with lto, which isn't the same as on main:
http://llvm-compile-time-tracker.com/compare.php?from=80d92fc648d0160e0bbd191ba67b0f05218d4b69&to=1a38acc6e758919bbce5a451b7fe39c89a134c01&stat=instructions%3Au