### PR TITLE
[AMDGPU] Switch default dwarf register encoding to wave32

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp
@@ -64,7 +64,8 @@ static MCRegisterInfo *createAMDGPUMCRegisterInfo(const Triple &TT) {
   if (TT.getArch() == Triple::r600)
     InitR600MCRegisterInfo(X, 0);
   else
-    InitAMDGPUMCRegisterInfo(X, AMDGPU::PC_REG);
+    InitAMDGPUMCRegisterInfo(X, AMDGPU::PC_REG, AMDGPUDwarfFlavour::Wave32,
+                             AMDGPUDwarfFlavour::Wave32);
   return X;
 }
 

--- a/llvm/test/DebugInfo/AMDGPU/print-reg-name.s
+++ b/llvm/test/DebugInfo/AMDGPU/print-reg-name.s
@@ -10,7 +10,7 @@ f:
 ; CHECK: .cfi_undefined 2560
 .cfi_undefined 2560
 ; FIXME: Until we implement a distinct set of DWARF register names we
-; will continue to parse physical registers and pick an arbitrary encoding.
-; CHECK: .cfi_undefined 2560
+; will continue to parse physical registers and pick the default encoding.
+; CHECK: .cfi_undefined 1536
 .cfi_undefined v0
 .cfi_endproc

--- a/llvm/unittests/MC/AMDGPU/DwarfRegMappings.cpp
+++ b/llvm/unittests/MC/AMDGPU/DwarfRegMappings.cpp
@@ -81,3 +81,18 @@ TEST(AMDGPUDwarfRegMappingTests, TestWave32DwarfRegMapping) {
     }
   }
 }
+
+TEST(AMDGPUDwarfRegMappingTests, TestDefaultDwarfRegMapping) {
+  InitializeAMDGPUTarget();
+  std::string Error;
+  const Target *TheTarget =
+      TargetRegistry::lookupTarget("amdgcn-amd-amdhsa", Error);
+  ASSERT_TRUE(Error.empty()) << Error;
+  std::unique_ptr<MCRegisterInfo> MRI{
+      TheTarget->createMCRegInfo("amdgcn-amd-amdhsa")};
+  // Verify that we use the wave32 encodings by default.
+  EXPECT_TRUE(MRI->getLLVMRegNum(1536, false));
+  EXPECT_TRUE(MRI->getLLVMRegNum(2048, false));
+  EXPECT_FALSE(MRI->getLLVMRegNum(2560, false));
+  EXPECT_FALSE(MRI->getLLVMRegNum(3072, false));
+}


### PR DESCRIPTION
This affects tools that don't set up the full subtarget, like llvm-dwarfdump or llvm-mc.