### PR TITLE
[Offload] Verify SyncCycle for events in AMDGPU

### DIFF
--- a/offload/unittests/OffloadAPI/event/olWaitEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olWaitEvent.cpp
@@ -30,3 +30,20 @@ TEST_P(olWaitEventTest, Success) {
 TEST_P(olWaitEventTest, InvalidNullEvent) {
   ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvent(nullptr));
 }
+
+TEST_P(olWaitEventTest, SuccessMultipleWait) {
+  uint32_t Src = 42;
+  void *DstPtr;
+
+  ol_event_handle_t Event = nullptr;
+  ASSERT_SUCCESS(
+      olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, sizeof(uint32_t), &DstPtr));
+  ASSERT_SUCCESS(
+      olMemcpy(Queue, DstPtr, Device, &Src, Host, sizeof(Src), &Event));
+  ASSERT_NE(Event, nullptr);
+
+  for (size_t I = 0; I < 10; I++)
+    ASSERT_SUCCESS(olWaitEvent(Event));
+
+  ASSERT_SUCCESS(olDestroyEvent(Event));
+}


### PR DESCRIPTION
This check ensures that events after a synchronise (and thus after the
queue is reset) are always considered complete. A test has been added
as well.
