### PR TITLE
[mlir][vector][NFC] Add deprecation notice to splat's .td

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -2919,6 +2919,8 @@ def Vector_SplatOp : Vector_Op<"splat", [
   ]> {
   let summary = "vector splat or broadcast operation";
   let description = [{
+    Note: This operation is deprecated. Please use vector.broadcast.
+
     Broadcast the operand to all elements of the result vector. The type of the
     operand must match the element type of the vector type.
 
@@ -2927,6 +2929,13 @@ def Vector_SplatOp : Vector_Op<"splat", [
     ```mlir
     %s = arith.constant 10.1 : f32
     %t = vector.splat %s : vector<8x16xf32>
+    ```
+
+    This operation is deprecated, the preferred representation of the above is:
+
+    ```mlir
+    %s = arith.constant 10.1 : f32
+    %t = vector.broadcast %s : f32 to vector<8x16xf32>
     ```
   }];
 


### PR DESCRIPTION
Part of deprecation of vector.splat

RFC: https://discourse.llvm.org/t/rfc-mlir-vector-deprecate-then-remove-vector-splat/87143/4
More complete deprecation: https://github.com/llvm/llvm-project/pull/147818