### PR TITLE
[lldb] Use a range-based for loop instead of llvm::for_each (NFC)

### DIFF
--- a/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
+++ b/lldb/source/Plugins/SymbolLocator/Debuginfod/SymbolLocatorDebuginfod.cpp
@@ -87,9 +87,8 @@ private:
   void ServerURLsChangedCallback() {
     m_server_urls = GetDebugInfoDURLs();
     llvm::SmallVector<llvm::StringRef> dbginfod_urls;
-    llvm::for_each(m_server_urls, [&](const auto &obj) {
+    for (const auto &obj : m_server_urls)
       dbginfod_urls.push_back(obj.ref());
-    });
     llvm::setDefaultDebuginfodUrls(dbginfod_urls);
   }
   // Storage for the StringRef's used within the Debuginfod library.


### PR DESCRIPTION
LLVM Coding Standards discourages llvm::for_each unless we already
have a callable.
