### PR TITLE
[flang][NFC] Fix build-time warning

### DIFF
--- a/flang/lib/Semantics/resolve-labels.cpp
+++ b/flang/lib/Semantics/resolve-labels.cpp
@@ -492,10 +492,9 @@ public:
     // Uppercase the name of the main program, so that its symbol name
     // would be unique from similarly named non-main-program symbols.
     auto upperCaseCharBlock = [](const parser::CharBlock &cb) {
-      char *ch{const_cast<char *>(cb.begin())};
-      char *endCh{ch + cb.size()};
-      while (ch != endCh) {
-        *ch++ = parser::ToUpperCaseLetter(*ch);
+      auto ch{const_cast<char *>(cb.begin())};
+      for (char *endCh{ch + cb.size()}; ch != endCh; ++ch) {
+        *ch = parser::ToUpperCaseLetter(*ch);
       }
     };
     const parser::CharBlock *progName{nullptr};


### PR DESCRIPTION
Don't increment the LHS variable of an assignment that also uses that variable on the RHS.