### PR TITLE
[gn build] Manually partially port #108276

### DIFF
--- a/llvm/utils/gn/build/BUILD.gn
+++ b/llvm/utils/gn/build/BUILD.gn
@@ -179,6 +179,7 @@ config("compiler_defaults") {
       "_HAS_EXCEPTIONS=0",
       "_UNICODE",
       "UNICODE",
+      "CLANG_BUILD_STATIC",
     ]
     cflags += [ "/EHs-c-" ]
     cflags_cc += [ "/std:c++17" ]


### PR DESCRIPTION
Fixes windows gn clang build.

Don't worry about exporting clang symbols on windows in gn build for now.