### PR TITLE
[NVPTX][test] regenerate some tests broken by successive changes

### DIFF
--- a/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f16x2-instructions.ll
@@ -1504,7 +1504,8 @@ define <2 x half> @test_fptrunc_2xfloat(<2 x float> %a) #0 {
 ; CHECK-NEXT:    .reg .b64 %rd<2>;
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
-; CHECK-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_fptrunc_2xfloat_param_0];
+; CHECK-NEXT:    ld.param.b64 %rd1, [test_fptrunc_2xfloat_param_0];
+; CHECK-NEXT:    mov.b64 {%r1, %r2}, %rd1;
 ; CHECK-NEXT:    cvt.rn.f16.f32 %rs1, %r2;
 ; CHECK-NEXT:    cvt.rn.f16.f32 %rs2, %r1;
 ; CHECK-NEXT:    mov.b32 %r3, {%rs2, %rs1};

--- a/llvm/test/CodeGen/NVPTX/f32x2-instructions.ll
+++ b/llvm/test/CodeGen/NVPTX/f32x2-instructions.ll
@@ -2116,7 +2116,8 @@ define void @test_trunc_to_v2bf16(<2 x float> %a, ptr %p) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b64 %rd2, [test_trunc_to_v2bf16_param_1];
-; CHECK-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_trunc_to_v2bf16_param_0];
+; CHECK-NEXT:    ld.param.b64 %rd1, [test_trunc_to_v2bf16_param_0];
+; CHECK-NEXT:    mov.b64 {%r1, %r2}, %rd1;
 ; CHECK-NEXT:    cvt.rn.bf16x2.f32 %r3, %r2, %r1;
 ; CHECK-NEXT:    st.b32 [%rd2], %r3;
 ; CHECK-NEXT:    ret;
@@ -2133,7 +2134,8 @@ define void @test_trunc_to_v2f16(<2 x float> %a, ptr %p) {
 ; CHECK-EMPTY:
 ; CHECK-NEXT:  // %bb.0:
 ; CHECK-NEXT:    ld.param.b64 %rd2, [test_trunc_to_v2f16_param_1];
-; CHECK-NEXT:    ld.param.v2.b32 {%r1, %r2}, [test_trunc_to_v2f16_param_0];
+; CHECK-NEXT:    ld.param.b64 %rd1, [test_trunc_to_v2f16_param_0];
+; CHECK-NEXT:    mov.b64 {%r1, %r2}, %rd1;
 ; CHECK-NEXT:    cvt.rn.f16x2.f32 %r3, %r2, %r1;
 ; CHECK-NEXT:    st.b32 [%rd2], %r3;
 ; CHECK-NEXT:    ret;


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/149393 and https://github.com/llvm/llvm-project/pull/149571 landed in quick succession requiring some tests to be regenerated to account for their interactions. 