### PR TITLE
[flang] Minor revision of the getting started guide.

### DIFF
--- a/flang/docs/GettingStarted.md
+++ b/flang/docs/GettingStarted.md
@@ -74,15 +74,14 @@ cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=$INSTALLDIR \
-  -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,$LD_LIBRARY_PATH" \
   -DFLANG_ENABLE_WERROR=ON \
   -DLLVM_ENABLE_ASSERTIONS=ON \
   -DLLVM_TARGETS_TO_BUILD=host \
   -DLLVM_LIT_ARGS=-v \
-  -DLLVM_ENABLE_PROJECTS="clang;mlir;flang;openmp" \
-  -DLLVM_ENABLE_RUNTIMES="compiler-rt;flang-rt" \
+  -DLLVM_ENABLE_PROJECTS="clang;mlir;flang" \
+  -DLLVM_ENABLE_RUNTIMES="compiler-rt;flang-rt;openmp" \
   ../llvm-project/llvm
 
 ninja
@@ -141,7 +140,6 @@ cd build
 cmake \
   -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_CXX_LINK_FLAGS="-Wl,-rpath,$LD_LIBRARY_PATH" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DFLANG_ENABLE_WERROR=ON \


### PR DESCRIPTION
- C++17 is now the default, no need to specify explicitly.

https://github.com/llvm/llvm-project/blob/b3c9ed151f18fbbfe027cf93dd7957f36bcbaccf/flang/CMakeLists.txt#L13

- The current recommended way to set up OpenMP is as a runtime, not as a project.

https://github.com/llvm/llvm-project/blob/b3c9ed151f18fbbfe027cf93dd7957f36bcbaccf/llvm/CMakeLists.txt#L209-L214