### PR TITLE
[mlir][test] Add missing `REQUIRES: asserts` for --debug-only flag

### DIFF
--- a/mlir/test/IR/test-pattern-logging-listener.mlir
+++ b/mlir/test/IR/test-pattern-logging-listener.mlir
@@ -1,3 +1,4 @@
+// REQUIRES: asserts
 // RUN: mlir-opt %s --test-walk-pattern-rewrite-driver \
 // RUN:   --allow-unregistered-dialect --debug-only=pattern-logging-listener 2>&1 | FileCheck %s
 


### PR DESCRIPTION
Debug flags are not provided in fully optimized builds.

Test added in #149378 / #146228