### PR TITLE
[libc] Revise document on building exhaustive math functions.

### DIFF
--- a/libc/src/math/docs/add_math_function.md
+++ b/libc/src/math/docs/add_math_function.md
@@ -183,8 +183,8 @@ implementation (which is very often glibc).
 
 - Build and Run exhaustive test (might take hours to run):
 ```
-  $ ninja libc.test.src.math.exhaustive.<func>_test
-  $ projects/libc/test/src/math/exhaustive/libc.test.src.math.exhaustive.<func>_test
+  $ ninja libc.test.src.math.exhaustive.<func>_test.__unit__
+  $ projects/libc/test/src/math/exhaustive/libc.test.src.math.exhaustive.<func>_test.__unit__
 ```
 
 - Build and Run performance test:


### PR DESCRIPTION
I suspect the reason is that we use `add_fp_unittest` in exhaustive testing, so the suffix `__unit__` is necessary.