### PR TITLE
[lldb] Fix updating persistent variables without JIT

### DIFF
--- a/lldb/test/API/functionalities/postmortem/elf-core/expr/TestExpr.py
+++ b/lldb/test/API/functionalities/postmortem/elf-core/expr/TestExpr.py
@@ -37,6 +37,10 @@ class CoreExprTestCase(TestBase):
         self.target.EvaluateExpression("int $my_int = 5")
         self.expect_expr("$my_int * 2", result_type="int", result_value="10")
 
+        # Try assigning the persistent variable a new value.
+        self.target.EvaluateExpression("$my_int = 55")
+        self.expect_expr("$my_int", result_type="int", result_value="55")
+
     def test_context_object(self):
         """Test expression evaluation in context of an object."""
 


### PR DESCRIPTION
This patch fixes updating persistent variables when memory cannot be allocated in an inferior process:
```
> lldb -c test.core
(lldb) expr int $i = 5
(lldb) expr $i = 55
(int) $0 = 55
(lldb) expr $i
(int) $i = 5
```

With this patch, the last command prints:
```
(int) $i = 55
```

The issue was introduced in #145599.