### PR TITLE
[libc] Disabled mpfr tests in full build mode, even if we set the mpfr path

### DIFF
--- a/libc/cmake/modules/LLVMLibCCheckMPFR.cmake
+++ b/libc/cmake/modules/LLVMLibCCheckMPFR.cmake
@@ -1,11 +1,11 @@
 set(LLVM_LIBC_MPFR_INSTALL_PATH "" CACHE PATH "Path to where MPFR is installed (e.g. C:/src/install or ~/src/install)")
 
-if(LLVM_LIBC_MPFR_INSTALL_PATH)
-  set(LIBC_TESTS_CAN_USE_MPFR TRUE)
-elseif(LIBC_TARGET_OS_IS_GPU OR LLVM_LIBC_FULL_BUILD)
+if(LIBC_TARGET_OS_IS_GPU OR LLVM_LIBC_FULL_BUILD)
   # In full build mode, the MPFR library should be built using our own facilities,
   # which is currently not possible.
   set(LIBC_TESTS_CAN_USE_MPFR FALSE)
+elseif(LLVM_LIBC_MPFR_INSTALL_PATH)
+  set(LIBC_TESTS_CAN_USE_MPFR TRUE)
 else()
   try_compile(
     LIBC_TESTS_CAN_USE_MPFR


### PR DESCRIPTION
If we are doing a full libc build, mpfr tests should be disabled even if we set the mpfr path. This patch simply swaps the check order.

This should fix the rv32 buildbot.