### PR TITLE
[libclc] Expose `prepare_builtins_*` variables in top-level CMakeLists

### DIFF
--- a/libclc/utils/CMakeLists.txt
+++ b/libclc/utils/CMakeLists.txt
@@ -12,8 +12,8 @@ set( LLVM_LINK_COMPONENTS
 
 if( LIBCLC_STANDALONE_BUILD )
   add_llvm_executable( prepare_builtins prepare-builtins.cpp )
-  set( prepare_builtins_exe prepare_builtins )
-  set( prepare_builtins_target prepare_builtins )
+  set( prepare_builtins_exe prepare_builtins PARENT_SCOPE )
+  set( prepare_builtins_target prepare_builtins PARENT_SCOPE )
 else()
   add_llvm_utility( prepare_builtins prepare-builtins.cpp )
   setup_host_tool( prepare_builtins PREPARE_BUILTINS prepare_builtins_exe prepare_builtins_target )


### PR DESCRIPTION
Fix `libclc/utils/CMakeLists.txt` to expose `prepare_builtins_*` variables in parent scope.  This was a regression introduced in #148815 where the code was moved into subdirectory, and the variables would no longer be accessible to calls in top-level CMakeLists, resulting in attempting to build targets with empty command:

```
[1566/1676] cd /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build && -o /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build/clspv--.bc /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build/obj.libclc.dir/clspv--/builtins.opt.clspv--.bc
FAILED: clspv--.bc /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build/clspv--.bc
cd /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build && -o /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build/clspv--.bc /var/tmp/portage/llvm-core/libclc-22.0.0.9999/work/libclc_build/obj.libclc.dir/clspv--/builtins.opt.clspv--.bc
/bin/sh: line 1: -o: command not found
```