### PR TITLE
[libc] Fix setitimer build when full_build=OFF

### DIFF
--- a/libc/src/sys/time/linux/setitimer.cpp
+++ b/libc/src/sys/time/linux/setitimer.cpp
@@ -22,9 +22,9 @@ LLVM_LIBC_FUNCTION(int, setitimer,
     // There is no SYS_setitimer_time64 call, so we can't use time_t directly,
     // and need to convert it to long first.
     long new_value32[4] = {static_cast<long>(new_value->it_interval.tv_sec),
-                           new_value->it_interval.tv_usec,
+                           static_cast<long>(new_value->it_interval.tv_usec),
                            static_cast<long>(new_value->it_value.tv_sec),
-                           new_value->it_value.tv_usec};
+                           static_cast<long>(new_value->it_value.tv_usec)};
     long old_value32[4];
 
     ret = LIBC_NAMESPACE::syscall_impl<long>(SYS_setitimer, which, new_value32,


### PR DESCRIPTION
When we pull the headers from the system, we might get a suseconds_t that's a long long, so add a cast to prevent a implicit conversion error.