### PR TITLE
Include <vector> in TemplatingUtils.h

### DIFF
--- a/mlir/lib/Target/IRDLToCpp/TemplatingUtils.h
+++ b/mlir/lib/Target/IRDLToCpp/TemplatingUtils.h
@@ -15,6 +15,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include <variant>
+#include <vector>
 
 namespace mlir::irdl::detail {
 


### PR DESCRIPTION
This is needed after 3ee0f97b950a550ef14e3adbdf45f507273f2190