### PR TITLE
fix-149477-- Emit correct closure members for lambdas in CreateLimitedType

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -4187,6 +4187,32 @@ llvm::DICompositeType *CGDebugInfo::CreateLimitedType(const RecordType *Ty) {
   RegionMap[Ty->getDecl()].reset(RealDecl);
   TypeCache[QualType(Ty, 0).getAsOpaquePtr()].reset(RealDecl);
 
+  if (const auto *CXXRD = dyn_cast<CXXRecordDecl>(RD)) {
+    SmallVector<llvm::Metadata *, 16> EltTys;
+    const ASTRecordLayout &Layout = CGM.getContext().getASTRecordLayout(CXXRD);
+
+    for (const FieldDecl *Field : CXXRD->fields()) {
+      if (!CXXRD->isLambda() && Field->isImplicit())
+        continue;
+
+      llvm::DIType *FieldType = getOrCreateType(Field->getType(), DefUnit);
+      unsigned FieldLine = getLineNumber(Field->getLocation());
+      uint64_t FieldOffset = Layout.getFieldOffset(Field->getFieldIndex());
+      llvm::DIFile *FieldFile = DefUnit;
+
+      llvm::DIDerivedType *Elem = DBuilder.createMemberType(
+          RealDecl, Field->getName(), FieldFile, FieldLine,
+          CGM.getContext().getTypeSize(Field->getType()),
+          getTypeAlignIfRequired(Field->getType(), CGM.getContext()),
+          FieldOffset,
+          getAccessFlag(Field->getAccess()), FieldType);
+
+      EltTys.push_back(Elem);
+    }
+    // Attach the fields.
+    DBuilder.replaceArrays(RealDecl, DBuilder.getOrCreateArray(EltTys));
+  }
+
   if (const auto *TSpecial = dyn_cast<ClassTemplateSpecializationDecl>(RD))
     DBuilder.replaceArrays(RealDecl, llvm::DINodeArray(),
                            CollectCXXTemplateParams(TSpecial, DefUnit));


### PR DESCRIPTION
Fix an issue where local lambdas caused a crash when importing the std module in LLDB due to missing capture fields in debug info.  
Now closures always emit all fields for lambdas by skipping the `isImplicit` check.  
This unblocks libc++ from using local lambdas freely
