### PR TITLE
[libc] Disable bfloat16 test for full build mode

### DIFF
--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -39,6 +39,10 @@ add_fp_unittest(
     libc.src.__support.FPUtil.rounding_mode
 )
 
+if(LLVM_LIBC_FULL_BUILD)
+  return()
+endif()
+
 add_fp_unittest(
   bfloat16_test
   NEED_MPFR

--- a/libc/test/src/__support/FPUtil/CMakeLists.txt
+++ b/libc/test/src/__support/FPUtil/CMakeLists.txt
@@ -39,6 +39,8 @@ add_fp_unittest(
     libc.src.__support.FPUtil.rounding_mode
 )
 
+# TODO: Temporally disable bfloat16 test until MPCommon target is updated
+# https://github.com/llvm/llvm-project/pull/149678
 if(LLVM_LIBC_FULL_BUILD)
   return()
 endif()


### PR DESCRIPTION
This patch temporarily disables bfloat16_test for full build mode, until the MPCommon target is updated so that mpfr_inc.h is not included in the MPCommon.h header.

This should fix the rv32 buildbot failures.