### PR TITLE
[Clang][Driver] Override Generic_ELF::buildLinker() to avoid calling gcc to link

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -3375,3 +3375,5 @@ void Generic_ELF::addClangTargetOptions(const ArgList &DriverArgs,
                           options::OPT_fno_use_init_array, true))
     CC1Args.push_back("-fno-use-init-array");
 }
+
+Tool *Generic_ELF::buildLinker() const { return new tools::gnutools::Linker(*this); }

--- a/clang/lib/Driver/ToolChains/Gnu.h
+++ b/clang/lib/Driver/ToolChains/Gnu.h
@@ -382,6 +382,9 @@ public:
   }
 
   virtual void addExtraOpts(llvm::opt::ArgStringList &CmdArgs) const {}
+
+protected:
+  Tool *buildLinker() const override;
 };
 
 } // end namespace toolchains

--- a/clang/test/Driver/baremetal-ld.c
+++ b/clang/test/Driver/baremetal-ld.c
@@ -4,3 +4,16 @@
 
 // RUN: %clang -### --target=armv7-unknown-none-eabi -mcpu=cortex-m4 --sysroot= -fuse-ld=ld -flto -O3 %s 2>&1 | FileCheck --check-prefix=LTO %s
 // LTO: {{".*ld.*"}} {{.*}} "-plugin-opt=mcpu=cortex-m4" "-plugin-opt=O3"
+
+// Ensure that, for freestanding -none targets, the linker does not call into gcc.
+// We do this by checking if clang is trying to pass "-fuse-ld=bfd" to the linker command.
+// RUN: %clang --target=aarch64-unknown-none-elf -ccc-print-bindings %s 2>&1 | FileCheck --check-prefix=LDAARCH64 %s
+// LDAARCH64: "baremetal::Linker"
+// RUN: %clang --target=loongarch64-unknown-none-elf -ccc-print-bindings %s 2>&1 | FileCheck --check-prefix=LDLOONGARCH64 %s
+// LDLOONGARCH64: "GNU::Linker"
+// RUN: %clang --target=riscv64-unknown-none-elf -ccc-print-bindings %s 2>&1 | FileCheck --check-prefix=LDRISCV64 %s
+// LDRISCV64: "baremetal::Linker"
+// RUN: %clang --target=x86_64-unknown-none-elf -ccc-print-bindings %s 2>&1 | FileCheck --check-prefix=LDX8664 %s
+// LDX8664: "GNU::Linker"
+// RUN: %clang --target=i386-unknown-none-elf -ccc-print-bindings %s 2>&1 | FileCheck --check-prefix=LDI386 %s
+// LDI386: "GNU::Linker"

--- a/clang/test/Driver/bindings.c
+++ b/clang/test/Driver/bindings.c
@@ -2,7 +2,7 @@
 // RUN: %clang -target i386-unknown-unknown -ccc-print-bindings -no-integrated-as %s 2>&1 | FileCheck %s --check-prefix=CHECK01
 // CHECK01: "clang", inputs: ["{{.*}}bindings.c"], output: "{{.*}}.s"
 // CHECK01: "GNU::Assembler", inputs: ["{{.*}}.s"], output: "{{.*}}.o"
-// CHECK01: "gcc::Linker", inputs: ["{{.*}}.o"], output: "a.out"
+// CHECK01: "GNU::Linker", inputs: ["{{.*}}.o"], output: "a.out"
 
 // Clang control options
 


### PR DESCRIPTION
This change primarily makes it so that when targeting freestanding/unknown
OSes, the driver will not use `gcc` to link, but rather will link using
the chosen linker (`-fuse-ld=...`) directly.

If Clang is to be a cross compiler, there is no reason to assume that the
host's gcc is in any way capable of handling the linkage of programs for
targets that do not match the host's triple, especially for freestanding
targets.
