### PR TITLE
[lld] [hexagon] guard allocateAux: only if idx nonzero

### DIFF
--- a/lld/ELF/Relocations.cpp
+++ b/lld/ELF/Relocations.cpp
@@ -2526,7 +2526,8 @@ void elf::hexagonTLSSymbolUpdate(Ctx &ctx) {
           for (Relocation &rel : isec->relocs())
             if (rel.sym->type == llvm::ELF::STT_TLS && rel.expr == R_PLT_PC) {
               if (needEntry) {
-                sym->allocateAux(ctx);
+                if (sym->auxIdx == 0)
+                  sym->allocateAux(ctx);
                 addPltEntry(ctx, *ctx.in.plt, *ctx.in.gotPlt, *ctx.in.relaPlt,
                             ctx.target->pltRel, *sym);
                 needEntry = false;

--- a/lld/test/ELF/hexagon-tls-allocateaux-multiple.s
+++ b/lld/test/ELF/hexagon-tls-allocateaux-multiple.s
@@ -1,0 +1,36 @@
+# REQUIRES: hexagon
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf one.s -o one.o
+# RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf two.s -o two.o
+# RUN: ld.lld -shared one.o two.o -o %t.so
+# RUN: llvm-readobj -r %t.so | FileCheck --check-prefix=RELOC %s
+
+#--- one.s
+.globl _start
+.type _start, @function
+
+_start:
+  r2 = add(pc,##_GLOBAL_OFFSET_TABLE_@PCREL)
+  r0 = add(r2,##tls_var@GDGOT)
+  call tls_var@GDPLT
+  jumpr r31
+
+.section .tdata,"awT",@progbits
+.globl tls_var
+.type tls_var, @object
+tls_var:
+  .word 0x1234
+
+#--- two.s
+.globl other_func
+.type other_func, @function
+
+other_func:
+  ## Direct call to __tls_get_addr - this creates another path that may
+  ## try to allocate auxiliary data for the same symbol
+  call __tls_get_addr
+  jumpr r31
+
+# RELOC:      Section ({{.*}}) .rela.plt {
+# RELOC:        R_HEX_JMP_SLOT __tls_get_addr 0x0
+# RELOC:      }

--- a/lld/test/ELF/hexagon-tls-allocateaux-multiple.s
+++ b/lld/test/ELF/hexagon-tls-allocateaux-multiple.s
@@ -1,11 +1,11 @@
 # REQUIRES: hexagon
 # RUN: rm -rf %t && split-file %s %t && cd %t
-# RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf one.s -o one.o
-# RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf two.s -o two.o
-# RUN: ld.lld -shared one.o two.o -o %t.so
-# RUN: llvm-readobj -r %t.so | FileCheck --check-prefix=RELOC %s
+# RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf a.s -o a.o
+# RUN: llvm-mc -filetype=obj -triple=hexagon-unknown-elf b.s -o b.o
+# RUN: ld.lld -shared a.o b.o -o out.so
+# RUN: llvm-readobj -r out.so | FileCheck --check-prefix=RELOC %s
 
-#--- one.s
+#--- a.s
 .globl _start
 .type _start, @function
 
@@ -21,7 +21,7 @@ _start:
 tls_var:
   .word 0x1234
 
-#--- two.s
+#--- b.s
 .globl other_func
 .type other_func, @function
 


### PR DESCRIPTION
While building libclang_rt.asan-hexagon.so, lld would assert in lld::elf::hexagonTLSSymbolUpdate().

Fixes #132766