### PR TITLE
[llvm-pdbutil] Pass filename when formatting `setfile` annotation

### DIFF
--- a/llvm/tools/llvm-pdbutil/MinimalSymbolDumper.cpp
+++ b/llvm/tools/llvm-pdbutil/MinimalSymbolDumper.cpp
@@ -773,7 +773,7 @@ Error MinimalSymbolDumper::visitKnownRecord(CVSymbol &CVR, InlineSiteSym &IS) {
         else
           return MaybeFile.takeError();
       }
-      P.format(" setfile {0} 0x{1}", utohexstr(FileOffset));
+      P.format(" setfile {0} 0x{1}", Filename, utohexstr(FileOffset));
       break;
     }
 


### PR DESCRIPTION
When dumping a PDB with an inlinesite that had a ChangeFile annotation, the `Filename` wasn't passed to the format string. This hit an assertion in debug mode and silently failed in release mode.