### PR TITLE
[libc] Fix epoll_create behavior when only epoll_create1 is available

### DIFF
--- a/libc/src/sys/epoll/linux/epoll_create.cpp
+++ b/libc/src/sys/epoll/linux/epoll_create.cpp
@@ -20,6 +20,11 @@ LLVM_LIBC_FUNCTION(int, epoll_create, ([[maybe_unused]] int size)) {
 #ifdef SYS_epoll_create
   int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_epoll_create, size);
 #elif defined(SYS_epoll_create1)
+  if (size == 0) {
+    libc_errno = EINVAL;
+    return -1;
+  }
+
   int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_epoll_create1, 0);
 #else
 #error                                                                         \

--- a/libc/test/src/sys/epoll/linux/epoll_create_test.cpp
+++ b/libc/test/src/sys/epoll/linux/epoll_create_test.cpp
@@ -10,7 +10,6 @@
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
-#include <sys/syscall.h> // For syscall numbers.
 
 using namespace LIBC_NAMESPACE::testing::ErrnoSetterMatcher;
 using LlvmLibcEpollCreateTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
@@ -23,8 +22,6 @@ TEST_F(LlvmLibcEpollCreateTest, Basic) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds());
 }
 
-#ifdef SYS_epoll_create
 TEST_F(LlvmLibcEpollCreateTest, Fails) {
   ASSERT_THAT(LIBC_NAMESPACE::epoll_create(0), Fails(EINVAL));
 }
-#endif


### PR DESCRIPTION
In PR #99785, I disabled a test for `epoll_create` that was intended to fail on systems where only `epoll_create1` is available. This is because `epoll_create1` cannot fail in the same way that `epoll_create` does.

Specifically, calling `epoll_create(0)` should result in an EINVAL error. So, when only `epoll_create1` is available, we should simply check if the argument is zero and return the error accordingly.