### PR TITLE
[clang] [Sema] Check argument range for prefetchi* intrinsics

### DIFF
--- a/clang/lib/Sema/SemaX86.cpp
+++ b/clang/lib/Sema/SemaX86.cpp
@@ -954,6 +954,11 @@ bool SemaX86::CheckBuiltinFunctionCall(const TargetInfo &TI, unsigned BuiltinID,
     l = 0;
     u = 15;
     break;
+  case X86::BI__builtin_ia32_prefetchi:
+    i = 1;
+    l = 2; // _MM_HINT_T1
+    u = 3; // _MM_HINT_T0
+    break;
   }
 
   // Note that we don't force a hard error on the range check here, allowing

--- a/clang/test/CodeGen/X86/prefetchi-error.c
+++ b/clang/test/CodeGen/X86/prefetchi-error.c
@@ -1,0 +1,7 @@
+// RUN: %clang_cc1 %s -ffreestanding -triple=x86_64-unknown-unknown -target-feature +prefetchi  -fsyntax-only -verify
+
+#include <immintrin.h>
+
+void test_invalid_prefetchi(void* p) {
+  __builtin_ia32_prefetchi(p, 1); // expected-error {{argument value 1 is outside the valid range [2, 3]}}
+}


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/144857 . I can create a test if desired, but I think the fix is trivial enough.

<img width="805" height="105" alt="image" src="https://github.com/user-attachments/assets/aaee8e5f-6e65-4f04-b8b9-e4ae1434d958" />
