### PR TITLE
[PowerPC] Add assembly directives to change endianness

### DIFF
--- a/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
+++ b/llvm/lib/Target/PowerPC/AsmParser/PPCAsmParser.cpp
@@ -122,6 +122,7 @@ class PPCAsmParser : public MCTargetAsmParser {
   bool parseDirectiveMachine(SMLoc L);
   bool parseDirectiveAbiVersion(SMLoc L);
   bool parseDirectiveLocalEntry(SMLoc L);
+  void ParseDirectiveSetEndian(bool little);
   bool parseGNUAttribute(SMLoc L);
 
   bool matchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
@@ -1649,9 +1650,22 @@ bool PPCAsmParser::ParseDirective(AsmToken DirectiveID) {
     parseDirectiveLocalEntry(DirectiveID.getLoc());
   else if (IDVal.starts_with(".gnu_attribute"))
     parseGNUAttribute(DirectiveID.getLoc());
-  else
+  else if (IDVal == ".big") {
+    ParseDirectiveSetEndian(false);
+  } else if (IDVal == ".little") {
+    ParseDirectiveSetEndian(true);
+  } else
     return true;
   return false;
+}
+
+/// ParseDirectiveSetEndian
+///  ::= .big | .little
+void PPCAsmParser::ParseDirectiveSetEndian(bool little) {
+  PPCTargetStreamer *TStreamer = static_cast<PPCTargetStreamer *>(
+      getParser().getStreamer().getTargetStreamer());
+  if (TStreamer != nullptr)
+    TStreamer->emitEndianSet(little);
 }
 
 ///  ::= .word [ expression (, expression)* ]

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCCodeEmitter.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCCodeEmitter.h
@@ -116,6 +116,8 @@ public:
   /// Check if Opcode corresponds to a call instruction that should be marked
   /// with the NOTOC relocation.
   bool isNoTOCCallInstr(const MCInst &MI) const;
+
+  void setLittleEndian(bool little_endian) { IsLittleEndian = little_endian; }
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/PowerPC/MCTargetDesc/PPCTargetStreamer.h
+++ b/llvm/lib/Target/PowerPC/MCTargetDesc/PPCTargetStreamer.h
@@ -27,6 +27,7 @@ public:
 
   virtual void emitTCEntry(const MCSymbol &S, PPCMCExpr::Specifier Kind) {}
   virtual void emitMachine(StringRef CPU){};
+  virtual void emitEndianSet(bool little) {};
   virtual void emitAbiVersion(int AbiVersion){};
   virtual void emitLocalEntry(MCSymbolELF *S, const MCExpr *LocalOffset){};
 };

--- a/llvm/test/MC/PowerPC/endian-directive.s
+++ b/llvm/test/MC/PowerPC/endian-directive.s
@@ -1,0 +1,10 @@
+# RUN: llvm-mc -filetype=obj -triple=powerpc-unknown-linux-gnu %s | llvm-readobj -x .text - | FileCheck -check-prefix=CHECK-BE %s
+# RUN: llvm-mc -filetype=obj -triple=ppc32le-unknown-linux-gnu %s | llvm-readobj -x .text - | FileCheck -check-prefix=CHECK-LE %s
+add %r0, %r1, %r2
+.big
+add %r0, %r1, %r2
+.little
+add %r0, %r1, %r2
+
+# CHECK-BE: 0x00000000 7c011214 7c011214 1412017c          |...|......|
+# CHECK-LE: 0x00000000 1412017c 7c011214 1412017c          ...||......|


### PR DESCRIPTION
Add simple assembly directives to change endianness of the code being assembled. This is useful in some edge cases to write code involving different endian modes.
Relocations in 'non-native' endian don't work.