### PR TITLE
[compiler-rt][MSVC] Conditionally remove emupac.cpp for msvc

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -591,9 +591,13 @@ set(aarch64_SOURCES
   ${GENERIC_TF_SOURCES}
   ${GENERIC_SOURCES}
   cpu_model/aarch64.c
-  aarch64/emupac.cpp
   aarch64/fp_mode.c
 )
+
+# Append sources specific to AArch64 targets that aren't supported by MSVC.
+if(NOT MSVC)
+  list(APPEND aarch64_SOURCES aarch64/emupac.cpp)
+endif()
 
 set(COMPILER_RT_AARCH64_FMV_USES_GLOBAL_CONSTRUCTOR NOT(FUCHSIA OR APPLE))
 


### PR DESCRIPTION
#148094 introduces logic for emulated PAC, which utilizes language extensions not available on MSVC.

