### PR TITLE
[libc] Add dependency <stdint.h> to src/string/string_utils.h

### DIFF
--- a/libc/src/string/string_utils.h
+++ b/libc/src/string/string_utils.h
@@ -21,6 +21,8 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 
+#include <stdint.h> // uintptr_t
+
 namespace LIBC_NAMESPACE_DECL {
 namespace internal {
 


### PR DESCRIPTION
string_utils.h uses uintptr_t, and there seems to be no tracking of this dependency. It seems upstream builds are unaffected but downstream this is causing a lot of flaky builds.