### PR TITLE
[Sparc] Remove bogus stack adjustment for LD/GD TLS

### DIFF
--- a/llvm/lib/Target/Sparc/SparcISelLowering.cpp
+++ b/llvm/lib/Target/Sparc/SparcISelLowering.cpp
@@ -2201,7 +2201,7 @@ SDValue SparcTargetLowering::LowerGlobalTLSAddress(SDValue Op,
     SDValue Chain = DAG.getEntryNode();
     SDValue InGlue;
 
-    Chain = DAG.getCALLSEQ_START(Chain, 1, 0, DL);
+    Chain = DAG.getCALLSEQ_START(Chain, 0, 0, DL);
     Chain = DAG.getCopyToReg(Chain, DL, SP::O0, Argument, InGlue);
     InGlue = Chain.getValue(1);
     SDValue Callee = DAG.getTargetExternalSymbol("__tls_get_addr", PtrVT);
@@ -2219,7 +2219,7 @@ SDValue SparcTargetLowering::LowerGlobalTLSAddress(SDValue Op,
                      InGlue};
     Chain = DAG.getNode(SPISD::TLS_CALL, DL, NodeTys, Ops);
     InGlue = Chain.getValue(1);
-    Chain = DAG.getCALLSEQ_END(Chain, 1, 0, InGlue, DL);
+    Chain = DAG.getCALLSEQ_END(Chain, 0, 0, InGlue, DL);
     InGlue = Chain.getValue(1);
     SDValue Ret = DAG.getCopyFromReg(Chain, DL, SP::O0, PtrVT, InGlue);
 

--- a/llvm/test/CodeGen/SPARC/tls-sp.ll
+++ b/llvm/test/CodeGen/SPARC/tls-sp.ll
@@ -29,7 +29,7 @@ define ptr @no_alloca() nounwind {
 ;
 ; SPARC64-LABEL: no_alloca:
 ; SPARC64:       ! %bb.0: ! %entry
-; SPARC64-NEXT:    save %sp, -144, %sp
+; SPARC64-NEXT:    save %sp, -128, %sp
 ; SPARC64-NEXT:  .Ltmp0:
 ; SPARC64-NEXT:    rd %pc, %o7
 ; SPARC64-NEXT:  .Ltmp2:
@@ -62,13 +62,11 @@ define ptr @dynamic_alloca(i64 %n) nounwind {
 ; SPARC-NEXT:  .Ltmp4:
 ; SPARC-NEXT:    or %i0, %lo(_GLOBAL_OFFSET_TABLE_+(.Ltmp4-.Ltmp3)), %i0
 ; SPARC-NEXT:    add %i0, %o7, %i0
-; SPARC-NEXT:    add %sp, -1, %sp
 ; SPARC-NEXT:    sethi %tgd_hi22(x), %i2
 ; SPARC-NEXT:    add %i2, %tgd_lo10(x), %i2
 ; SPARC-NEXT:    add %i0, %i2, %o0, %tgd_add(x)
 ; SPARC-NEXT:    call __tls_get_addr, %tgd_call(x)
 ; SPARC-NEXT:    nop
-; SPARC-NEXT:    add %sp, 1, %sp
 ; SPARC-NEXT:    add %i1, 7, %i0
 ; SPARC-NEXT:    and %i0, -8, %i0
 ; SPARC-NEXT:    sub %sp, %i0, %i0
@@ -88,13 +86,11 @@ define ptr @dynamic_alloca(i64 %n) nounwind {
 ; SPARC64-NEXT:  .Ltmp4:
 ; SPARC64-NEXT:    or %i1, %lo(_GLOBAL_OFFSET_TABLE_+(.Ltmp4-.Ltmp3)), %i1
 ; SPARC64-NEXT:    add %i1, %o7, %i1
-; SPARC64-NEXT:    add %sp, -1, %sp
 ; SPARC64-NEXT:    sethi %tgd_hi22(x), %i2
 ; SPARC64-NEXT:    add %i2, %tgd_lo10(x), %i2
 ; SPARC64-NEXT:    add %i1, %i2, %o0, %tgd_add(x)
 ; SPARC64-NEXT:    call __tls_get_addr, %tgd_call(x)
 ; SPARC64-NEXT:    nop
-; SPARC64-NEXT:    add %sp, 1, %sp
 ; SPARC64-NEXT:    add %i0, 15, %i0
 ; SPARC64-NEXT:    and %i0, -16, %i0
 ; SPARC64-NEXT:    sub %sp, %i0, %i0

--- a/llvm/test/CodeGen/SPARC/tls-sp.ll
+++ b/llvm/test/CodeGen/SPARC/tls-sp.ll
@@ -2,8 +2,6 @@
 ; RUN: llc -mtriple=sparc -relocation-model=pic < %s | FileCheck --check-prefix=SPARC %s
 ; RUN: llc -mtriple=sparc64 -relocation-model=pic < %s | FileCheck --check-prefix=SPARC64 %s
 
-;; TODO: Fix the code generation for these functions.
-
 @x = external thread_local global i8
 
 ;; Test that we don't over-allocate stack space when calling __tls_get_addr


### PR DESCRIPTION
This argument is the number of bytes to adjust the stack by for the
duration of the call. In most cases, PEI is able to eliminate the
corresponding call frame pseudos, folding them into the initial stack
frame allocation (rounded up to stack alignment), where it just ends up
allocating more space than needed. However, in the rare case where this
cannot be done, e.g. due to the use of a dynamic alloca, the 1 byte
stack adjustment persists and results in a misaligned stack for the
duration of the call. This has been the case ever since TLS support was
added in cb1dca602c43 ("[Sparc] Add support for TLS in sparc."), and I
can only assume that 1 was used erroneously thinking that it is the
number of arguments (as there is 1 register argument for the call), not
the number of bytes for on-stack arguments.

Fixes: https://github.com/llvm/llvm-project/issues/149808
