### PR TITLE
[LLDB] Update SBMemoryRegionInfo doc strings to document len and str 

### DIFF
--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -1,7 +1,10 @@
 %feature("docstring",
 "API clients can get information about memory regions in processes.
 
-For Python users, `len()` is overriden to output the size of the memory region in bytes."
+For Python users, `len()` is overriden to output the size of the memory region in bytes.
+For Python users, `str()` is overriden with the results of the GetDescription function-
+        produces a formatted string that describes a memory range in the form: 
+        [Hex start - Hex End) with associated permissions (RWX)"
 ) lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "
@@ -37,7 +40,5 @@ For Python users, `len()` is overriden to output the size of the memory region i
         formatted [Hex start - Hex End) with associated permissions (RWX).
         If the function results false, no output will be written. 
         If results true, the output will be written to the stream.
-
-        For Python users, `str()` is overriden with the results of this function.
         "
 ) lldb::SBMemoryRegionInfo::GetDescription;

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -7,22 +7,20 @@
 %feature("docstring", "
         Returns whether this memory region has a list of modified (dirty)
         pages available or not.  When calling GetNumDirtyPages(), you will
-        have 0 returned for both \"dirty page list is not known\" and
+        have 0 returned for both \"dirty page list is not known\" and 
         \"empty dirty page list\" (that is, no modified pages in this
         memory region).  You must use this method to disambiguate."
 ) lldb::SBMemoryRegionInfo::HasDirtyMemoryPageList;
 
-%feature(
-        "docstring",
-        "
-        Return the number of dirty(modified) memory pages in this memory region,
-        if available.You must use the SBMemoryRegionInfo::HasDirtyMemoryPageList()
-                method to determine if a dirty memory list is available;
-        it will depend on the target system can provide this information."
+%feature("docstring", "
+        Return the number of dirty (modified) memory pages in this
+        memory region, if available.  You must use the 
+        SBMemoryRegionInfo::HasDirtyMemoryPageList() method to
+        determine if a dirty memory list is available; it will depend
+        on the target system can provide this information."
 ) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
 
-%feature("docstring",
-        "
+%feature("docstring", "
         Return the address of a modified,
         or dirty, page of memory.If the provided index is out of range,
         or this memory region does not have dirty page information,
@@ -31,7 +29,7 @@
 
 %feature("docstring", "
         Return the size of pages in this memory region .0 will be
-                returned if this information was unavailable."
+        returned if this information was unavailable."
 ) lldb::SBMemoryRegionInfo::GetPageSize;
 
 %feature("docstring", "

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -1,5 +1,8 @@
 % feature("docstring",
-          "API clients can get information about memory regions in processes.")
+          "API clients can get information about memory regions in processes.
+
+          When printed using str(), the memory region info is formatted as:
+                '[Hex start - Hex End] RWX' ")
         lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "
@@ -34,10 +37,11 @@
 
 %feature("docstring", "
         takes a SBStream parameter 'description' where it will write the output to.
-        it formats the memory region information into a string with Memory region info
-        [Hex start - Hex End) and premission flags R/W/X
-        returns a boolean value indicating success or failure
+        The function will formats the memory region information into a string with Memory region info
+        [Hex start - Hex End) and premission flags R/W/X.
+        Returns a boolean value indicating success or failure.
 
-        alternative to using this method to find out the size of the memory region
-        is to use the len() function on the SBMemoryRegionInfo object"
+        alternatively, to get the size of the memory region is to use
+        the len() function on the SBMemoryRegionInfo object.
+        The function function will return the size of the memory region"
 ) lldb::SBMemoryRegionInfo::GetDescription;

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -1,31 +1,43 @@
-%feature("docstring",
-"API clients can get information about memory regions in processes."
-) lldb::SBMemoryRegionInfo;
+% feature("docstring",
+          "API clients can get information about memory regions in processes.")
+        lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "
         Returns whether this memory region has a list of modified (dirty)
         pages available or not.  When calling GetNumDirtyPages(), you will
-        have 0 returned for both \"dirty page list is not known\" and 
+        have 0 returned for both \"dirty page list is not known\" and
         \"empty dirty page list\" (that is, no modified pages in this
         memory region).  You must use this method to disambiguate."
 ) lldb::SBMemoryRegionInfo::HasDirtyMemoryPageList;
 
-%feature("docstring", "
-        Return the number of dirty (modified) memory pages in this
-        memory region, if available.  You must use the 
-        SBMemoryRegionInfo::HasDirtyMemoryPageList() method to
-        determine if a dirty memory list is available; it will depend
-        on the target system can provide this information."
-) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
+% feature(
+      "docstring",
+      "
+      Return the number of dirty(modified) memory pages in this memory region,
+      if available.You must use the SBMemoryRegionInfo::HasDirtyMemoryPageList()
+          method to determine if a dirty memory list is available;
+      it will depend on the target system can provide this information."
+      ) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
+
+% feature("docstring",
+          "
+          Return the address of a modified,
+          or dirty, page of memory.If the provided index is out of range,
+          or this memory region does not have dirty page information,
+          LLDB_INVALID_ADDRESS is returned."
+          ) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
+
+% feature("docstring", "
+                       Return the size of pages in this memory region .0 will be
+                           returned if this information was unavailable."
+          ) lldb::SBMemoryRegionInfo::GetPageSize();
 
 %feature("docstring", "
-        Return the address of a modified, or dirty, page of memory.
-        If the provided index is out of range, or this memory region 
-        does not have dirty page information, LLDB_INVALID_ADDRESS 
-        is returned."
-) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
+        takes a SBStream parameter 'description' where it will write the output to.
+        it formats the memory region information into a string with Memory region info
+        [Hex start - Hex End) and premission flags R/W/X
+        returns a boolean value indicating success or failure
 
-%feature("docstring", "
-        Return the size of pages in this memory region.  0 will be returned
-        if this information was unavailable."
-) lldb::SBMemoryRegionInfo::GetPageSize();
+        alternative to using this method to find out the size of the memory region
+        is to use the len() function on the SBMemoryRegionInfo object"
+) lldb::SBMemoryRegionInfo::GetDescription;

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -1,9 +1,8 @@
-% feature("docstring",
-          "API clients can get information about memory regions in processes.
+%feature("docstring",
+        "API clients can get information about memory regions in processes.
 
-          When printed using str(), the memory region info is formatted as:
-                '[Hex start - Hex End] RWX' ")
-        lldb::SBMemoryRegionInfo;
+        For Python users, `len()` is overriden to output the size of the memory region in bytes."
+        ) lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "
         Returns whether this memory region has a list of modified (dirty)
@@ -11,37 +10,36 @@
         have 0 returned for both \"dirty page list is not known\" and
         \"empty dirty page list\" (that is, no modified pages in this
         memory region).  You must use this method to disambiguate."
-) lldb::SBMemoryRegionInfo::HasDirtyMemoryPageList;
+        ) lldb::SBMemoryRegionInfo::HasDirtyMemoryPageList;
 
-% feature(
-      "docstring",
-      "
-      Return the number of dirty(modified) memory pages in this memory region,
-      if available.You must use the SBMemoryRegionInfo::HasDirtyMemoryPageList()
-          method to determine if a dirty memory list is available;
-      it will depend on the target system can provide this information."
-      ) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
+%feature(
+        "docstring",
+        "
+        Return the number of dirty(modified) memory pages in this memory region,
+        if available.You must use the SBMemoryRegionInfo::HasDirtyMemoryPageList()
+                method to determine if a dirty memory list is available;
+        it will depend on the target system can provide this information."
+        ) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
 
-% feature("docstring",
-          "
-          Return the address of a modified,
-          or dirty, page of memory.If the provided index is out of range,
-          or this memory region does not have dirty page information,
-          LLDB_INVALID_ADDRESS is returned."
-          ) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
-
-% feature("docstring", "
-                       Return the size of pages in this memory region .0 will be
-                           returned if this information was unavailable."
-          ) lldb::SBMemoryRegionInfo::GetPageSize();
+%feature("docstring",
+        "
+        Return the address of a modified,
+        or dirty, page of memory.If the provided index is out of range,
+        or this memory region does not have dirty page information,
+        LLDB_INVALID_ADDRESS is returned."
+        ) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
 
 %feature("docstring", "
-        takes a SBStream parameter 'description' where it will write the output to.
-        The function will formats the memory region information into a string with Memory region info
-        [Hex start - Hex End) and premission flags R/W/X.
-        Returns a boolean value indicating success or failure.
+        Return the size of pages in this memory region .0 will be
+                returned if this information was unavailable."
+        ) lldb::SBMemoryRegionInfo::GetPageSize;
 
-        alternatively, to get the size of the memory region is to use
-        the len() function on the SBMemoryRegionInfo object.
-        The function function will return the size of the memory region"
-) lldb::SBMemoryRegionInfo::GetDescription;
+%feature("docstring", "
+        Takes an SBStream parameter to write output to,
+        formatted [Hex start - Hex End) with associated permissions (RWX).
+        If the function results false, no output will be written. 
+        If results true, the output will be written to the stream.
+
+        For Python users, `str()` is overriden with the results of this function.
+        "
+        ) lldb::SBMemoryRegionInfo::GetDescription;

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -2,7 +2,7 @@
         "API clients can get information about memory regions in processes.
 
         For Python users, `len()` is overriden to output the size of the memory region in bytes."
-        ) lldb::SBMemoryRegionInfo;
+) lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "
         Returns whether this memory region has a list of modified (dirty)
@@ -10,7 +10,7 @@
         have 0 returned for both \"dirty page list is not known\" and
         \"empty dirty page list\" (that is, no modified pages in this
         memory region).  You must use this method to disambiguate."
-        ) lldb::SBMemoryRegionInfo::HasDirtyMemoryPageList;
+) lldb::SBMemoryRegionInfo::HasDirtyMemoryPageList;
 
 %feature(
         "docstring",
@@ -19,7 +19,7 @@
         if available.You must use the SBMemoryRegionInfo::HasDirtyMemoryPageList()
                 method to determine if a dirty memory list is available;
         it will depend on the target system can provide this information."
-        ) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
+) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
 
 %feature("docstring",
         "
@@ -27,12 +27,12 @@
         or dirty, page of memory.If the provided index is out of range,
         or this memory region does not have dirty page information,
         LLDB_INVALID_ADDRESS is returned."
-        ) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
+) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
 
 %feature("docstring", "
         Return the size of pages in this memory region .0 will be
                 returned if this information was unavailable."
-        ) lldb::SBMemoryRegionInfo::GetPageSize;
+) lldb::SBMemoryRegionInfo::GetPageSize;
 
 %feature("docstring", "
         Takes an SBStream parameter to write output to,
@@ -42,4 +42,4 @@
 
         For Python users, `str()` is overriden with the results of this function.
         "
-        ) lldb::SBMemoryRegionInfo::GetDescription;
+) lldb::SBMemoryRegionInfo::GetDescription;

--- a/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
+++ b/lldb/bindings/interface/SBMemoryRegionInfoDocstrings.i
@@ -1,7 +1,7 @@
 %feature("docstring",
-        "API clients can get information about memory regions in processes.
+"API clients can get information about memory regions in processes.
 
-        For Python users, `len()` is overriden to output the size of the memory region in bytes."
+For Python users, `len()` is overriden to output the size of the memory region in bytes."
 ) lldb::SBMemoryRegionInfo;
 
 %feature("docstring", "
@@ -21,16 +21,16 @@
 ) lldb::SBMemoryRegionInfo::GetNumDirtyPages;
 
 %feature("docstring", "
-        Return the address of a modified,
-        or dirty, page of memory.If the provided index is out of range,
-        or this memory region does not have dirty page information,
-        LLDB_INVALID_ADDRESS is returned."
+        Return the address of a modified, or dirty, page of memory.
+        If the provided index is out of range, or this memory region 
+        does not have dirty page information, LLDB_INVALID_ADDRESS 
+        is returned."
 ) lldb::SBMemoryRegionInfo::GetDirtyPageAddressAtIndex;
 
 %feature("docstring", "
-        Return the size of pages in this memory region .0 will be
-        returned if this information was unavailable."
-) lldb::SBMemoryRegionInfo::GetPageSize;
+        Return the size of pages in this memory region.  0 will be returned
+        if this information was unavailable."
+) lldb::SBMemoryRegionInfo::GetPageSize();
 
 %feature("docstring", "
         Takes an SBStream parameter to write output to,

--- a/lldb/include/lldb/API/SBMemoryRegionInfo.h
+++ b/lldb/include/lldb/API/SBMemoryRegionInfo.h
@@ -124,7 +124,8 @@ public:
   ///     Returns true if the description was successfully written,
   ///     false otherwise.
   ///
-  /// The description format is: [Hex start - Hex End) with associated permissions (RWX)
+  /// The description format is: [Hex start - Hex End) with associated
+  /// permissions (RWX)
   bool GetDescription(lldb::SBStream &description);
 
 private:

--- a/lldb/include/lldb/API/SBMemoryRegionInfo.h
+++ b/lldb/include/lldb/API/SBMemoryRegionInfo.h
@@ -125,9 +125,6 @@ public:
   ///     false otherwise.
   ///
   /// The description format is: [Hex start - Hex End) with associated permissions (RWX)
-  ///
-  /// In Python bindings, this method is used by the __str__ implementation,
-  /// allowing memory regions to be printed directly.
   bool GetDescription(lldb::SBStream &description);
 
 private:

--- a/lldb/include/lldb/API/SBMemoryRegionInfo.h
+++ b/lldb/include/lldb/API/SBMemoryRegionInfo.h
@@ -115,6 +115,19 @@ public:
 
   bool operator!=(const lldb::SBMemoryRegionInfo &rhs) const;
 
+  /// writes a description of the memory region to a SBStream.
+  ///
+  /// \param[in,out] description
+  ///     A stream object where the description will be written.
+  ///
+  /// \return
+  ///     Returns true if the description was successfully written,
+  ///     false otherwise.
+  ///
+  /// The description format is: [Hex start - Hex End) with associated permissions (RWX)
+  ///
+  /// In Python bindings, this method is used by the __str__ implementation,
+  /// allowing memory regions to be printed directly.
   bool GetDescription(lldb::SBStream &description);
 
 private:


### PR DESCRIPTION
Updated SBMemoryRegionInfo doc strings:

- Added detailed documentation for the GetDescription() method.
- Included information about the overwritten len() and str() functions for the SBMemoryRegionInfo type, explaining their behavior and usage.