### PR TITLE
[mlir-lsp] Fix window.workDoneProgress capability

### DIFF
--- a/mlir/lib/Tools/lsp-server-support/Protocol.cpp
+++ b/mlir/lib/Tools/lsp-server-support/Protocol.cpp
@@ -284,11 +284,11 @@ bool mlir::lsp::fromJSON(const llvm::json::Value &value,
       if (codeAction->getObject("codeActionLiteralSupport"))
         result.codeActionStructure = true;
     }
-    if (auto *window = textDocument->getObject("window")) {
-      if (std::optional<bool> workDoneProgressSupport =
-              window->getBoolean("workDoneProgress"))
-        result.workDoneProgress = *workDoneProgressSupport;
-    }
+  }
+  if (auto *window = o->getObject("window")) {
+    if (std::optional<bool> workDoneProgressSupport =
+            window->getBoolean("workDoneProgress"))
+      result.workDoneProgress = *workDoneProgressSupport;
   }
   return true;
 }


### PR DESCRIPTION
PR #143449 had an incorrect parser implementation for window.workDoneProgress that actually parsed textDocument.window.workDoneProgress.