### PR TITLE
[profdata] Return Expected from showSampleProfile()

### DIFF
--- a/llvm/test/tools/llvm-profdata/sample-profile-basic.test
+++ b/llvm/test/tools/llvm-profdata/sample-profile-basic.test
@@ -32,4 +32,4 @@ MERGE1: _Z3fooi:15422:1220
 
 5- Detect invalid text encoding (e.g. instrumentation profile text format).
 RUN: not llvm-profdata show --sample %p/Inputs/foo3bar3-1.proftext 2>&1 | FileCheck %s --check-prefix=BADTEXT
-BADTEXT: error: {{.+}}: Unrecognized sample profile encoding format
+BADTEXT: Unrecognized sample profile encoding format


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/149433 broke the hwasan buildbot: https://lab.llvm.org/buildbot/#/builders/55/builds/14455 and it is unclear why it triggered the failures. As far as I can tell, the memory leak existed before because `LLVMContext` leaks memory when `exit(1)` is called, which happens in this test. To fix this, `showSampleProfile()` now returns `Expected` and the caller handles the error with `ExitOnError`. Then `LLVMContext`'s stack is cleaned up when `showSampleProfile()` returns.

If the bots don't break with this change, I will follow up to return `Expected` from the remaining functions. I believe we can then remove `exitWithError*()` entirely and replace it with `ExitOnError`.