### PR TITLE
[MLIR][AMDGPU] Use Attr for resetOffset + boundsCheck in RawBufferCastOp

### DIFF
--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -237,8 +237,8 @@ def AMDGPU_FatRawBufferCastOp :
     Arguments<(ins AnyMemRef:$source,
       Optional<I32>:$validBytes,
       Optional<I<14>>:$cacheSwizzleStride,
-      DefaultValuedProp<BoolProp, "true">:$boundsCheck,
-      UnitProp:$resetOffset)>,
+      DefaultValuedAttr<BoolAttr, "true">:$boundsCheck,
+      UnitAttr:$resetOffset)>,
     Results<(outs AnyMemRef:$result)> {
   let summary = "Create a raw buffer fat pointer that matches `memref`";
   let description = [{

--- a/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
+++ b/mlir/include/mlir/Dialect/AMDGPU/IR/AMDGPU.td
@@ -240,6 +240,8 @@ def AMDGPU_FatRawBufferCastOp :
       DefaultValuedAttr<BoolAttr, "true">:$boundsCheck,
       UnitAttr:$resetOffset)>,
     Results<(outs AnyMemRef:$result)> {
+  // TODO: Set `resetOffset` and `boundsCheck` to use `Property` once
+  //       we implemented pythonic binding for `Property`.
   let summary = "Create a raw buffer fat pointer that matches `memref`";
   let description = [{
     Wraps the memory pointed to by `source` as a raw buffer fat pointer, or,

--- a/mlir/test/python/dialects/amdgpu.py
+++ b/mlir/test/python/dialects/amdgpu.py
@@ -2,7 +2,7 @@
 # This is just a smoke test that the dialect is functional.
 
 from mlir.ir import *
-from mlir.dialects import amdgpu, arith, memref
+from mlir.dialects import amdgpu, func
 
 
 def constructAndPrintInModule(f):
@@ -20,3 +20,28 @@ def constructAndPrintInModule(f):
 def testSmoke():
     # CHECK: amdgpu.lds_barrier
     amdgpu.LDSBarrierOp()
+
+
+# CHECK-LABEL: testFatRawBufferCastOpParams
+@constructAndPrintInModule
+def testFatRawBufferCastOpParams():
+    memref_type = MemRefType.get(
+        [ShapedType.get_dynamic_size(), ShapedType.get_dynamic_size()],
+        F32Type.get(),
+    )
+    f = func.FuncOp(
+        "test_raw_buffer_cast_params", ([memref_type], [])
+    )
+    with InsertionPoint(f.add_entry_block()):
+        block_args = f.arguments
+        amdgpu.FatRawBufferCastOp(block_args[0])
+        amdgpu.FatRawBufferCastOp(block_args[0], resetOffset=True)
+        amdgpu.FatRawBufferCastOp(block_args[0], boundsCheck=False)
+        amdgpu.FatRawBufferCastOp(block_args[0], boundsCheck=False, resetOffset=True)
+        func.ReturnOp([])
+
+    #CHECK:     func.func @test_raw_buffer_cast_params(%[[ARG0:.+]]: memref<?x?xf32>) {
+    #CHECK:        amdgpu.fat_raw_buffer_cast %[[ARG0]] : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    #CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] resetOffset : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    #CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] boundsCheck(false) : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    #CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] boundsCheck(false) resetOffset : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>

--- a/mlir/test/python/dialects/amdgpu.py
+++ b/mlir/test/python/dialects/amdgpu.py
@@ -29,9 +29,7 @@ def testFatRawBufferCastOpParams():
         [ShapedType.get_dynamic_size(), ShapedType.get_dynamic_size()],
         F32Type.get(),
     )
-    f = func.FuncOp(
-        "test_raw_buffer_cast_params", ([memref_type], [])
-    )
+    f = func.FuncOp("test_raw_buffer_cast_params", ([memref_type], []))
     with InsertionPoint(f.add_entry_block()):
         block_args = f.arguments
         amdgpu.FatRawBufferCastOp(block_args[0])
@@ -40,8 +38,8 @@ def testFatRawBufferCastOpParams():
         amdgpu.FatRawBufferCastOp(block_args[0], boundsCheck=False, resetOffset=True)
         func.ReturnOp([])
 
-    #CHECK:     func.func @test_raw_buffer_cast_params(%[[ARG0:.+]]: memref<?x?xf32>) {
-    #CHECK:        amdgpu.fat_raw_buffer_cast %[[ARG0]] : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
-    #CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] resetOffset : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
-    #CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] boundsCheck(false) : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
-    #CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] boundsCheck(false) resetOffset : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK:     func.func @test_raw_buffer_cast_params(%[[ARG0:.+]]: memref<?x?xf32>) {
+    # CHECK:        amdgpu.fat_raw_buffer_cast %[[ARG0]] : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] resetOffset : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] boundsCheck(false) : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>
+    # CHECK-NEXT:   amdgpu.fat_raw_buffer_cast %[[ARG0]] boundsCheck(false) resetOffset : memref<?x?xf32> to memref<?x?xf32, #amdgpu.address_space<fat_raw_buffer>>


### PR DESCRIPTION
In order to access and modify resetOffset and boundsCheck of RawBufferCastOp in pythonic binding, we will have to use Attrs instead of Property. This is because we do not have python binding support for property yet. We should move back to property once we add pythonic binding support for it.