### PR TITLE
[WIP][mlir] `DenseElementsAttr::reshape(arg)`: make arg a shape, not a type

### DIFF
--- a/mlir/examples/toy/Ch3/mlir/ToyCombine.td
+++ b/mlir/examples/toy/Ch3/mlir/ToyCombine.td
@@ -43,7 +43,7 @@ def ReshapeReshapeOptPattern : Pat<(ReshapeOp(ReshapeOp $arg)),
 
 // Reshape(Constant(x)) = x'
 def ReshapeConstant :
-  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()))">;
+  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()).getShape())">;
 def FoldConstantReshapeOptPattern : Pat<
   (ReshapeOp:$res (ConstantOp $arg)),
   (ConstantOp (ReshapeConstant $arg, $res))>;

--- a/mlir/examples/toy/Ch4/mlir/ToyCombine.td
+++ b/mlir/examples/toy/Ch4/mlir/ToyCombine.td
@@ -42,7 +42,7 @@ def ReshapeReshapeOptPattern : Pat<(ReshapeOp(ReshapeOp $arg)),
 
 // Reshape(Constant(x)) = x'
 def ReshapeConstant :
-  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()))">;
+  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()).getShape())">;
 def FoldConstantReshapeOptPattern : Pat<
   (ReshapeOp:$res (ConstantOp $arg)),
   (ConstantOp (ReshapeConstant $arg, $res))>;

--- a/mlir/examples/toy/Ch5/mlir/ToyCombine.td
+++ b/mlir/examples/toy/Ch5/mlir/ToyCombine.td
@@ -42,7 +42,7 @@ def ReshapeReshapeOptPattern : Pat<(ReshapeOp(ReshapeOp $arg)),
 
 // Reshape(Constant(x)) = x'
 def ReshapeConstant :
-  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()))">;
+  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()).getShape())">;
 def FoldConstantReshapeOptPattern : Pat<
   (ReshapeOp:$res (ConstantOp $arg)),
   (ConstantOp (ReshapeConstant $arg, $res))>;

--- a/mlir/examples/toy/Ch6/mlir/ToyCombine.td
+++ b/mlir/examples/toy/Ch6/mlir/ToyCombine.td
@@ -42,7 +42,7 @@ def ReshapeReshapeOptPattern : Pat<(ReshapeOp(ReshapeOp $arg)),
 
 // Reshape(Constant(x)) = x'
 def ReshapeConstant :
-  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()))">;
+  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()).getShape())">;
 def FoldConstantReshapeOptPattern : Pat<
   (ReshapeOp:$res (ConstantOp $arg)),
   (ConstantOp (ReshapeConstant $arg, $res))>;

--- a/mlir/examples/toy/Ch7/mlir/ToyCombine.td
+++ b/mlir/examples/toy/Ch7/mlir/ToyCombine.td
@@ -42,7 +42,7 @@ def ReshapeReshapeOptPattern : Pat<(ReshapeOp(ReshapeOp $arg)),
 
 // Reshape(Constant(x)) = x'
 def ReshapeConstant :
-  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()))">;
+  NativeCodeCall<"$0.reshape(::llvm::cast<ShapedType>($1.getType()).getShape())">;
 def FoldConstantReshapeOptPattern : Pat<
   (ReshapeOp:$res (ConstantOp $arg)),
   (ConstantOp (ReshapeConstant $arg, $res))>;

--- a/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
+++ b/mlir/include/mlir/Dialect/Utils/ReshapeOpsUtils.h
@@ -92,7 +92,8 @@ static OpFoldResult foldReshapeOp(ReshapeOpTy reshapeOp,
 
   // Reshape of a constant can be replaced with a new constant.
   if (auto elements = dyn_cast_or_null<DenseElementsAttr>(operands.front()))
-    return elements.reshape(cast<ShapedType>(reshapeOp.getResult().getType()));
+    return elements.reshape(
+        cast<ShapedType>(reshapeOp.getResult().getType()).getShape());
 
   // Fold if the producer reshape source has the same shape with at most 1
   // dynamic dimension.

--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -619,8 +619,6 @@ public:
   /// the same total number of elements.
   DenseElementsAttr reshape(ArrayRef<int64_t> newShape);
 
-  DenseElementsAttr reshape(ShapedType newType);
-
   /// Return a new DenseElementsAttr that has the same data as the current
   /// attribute, but with a different shape for a splat type. The new type must
   /// have the same element type.

--- a/mlir/include/mlir/IR/BuiltinAttributes.h
+++ b/mlir/include/mlir/IR/BuiltinAttributes.h
@@ -615,8 +615,10 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Return a new DenseElementsAttr that has the same data as the current
-  /// attribute, but has been reshaped to 'newType'. The new type must have the
-  /// same total number of elements as well as element type.
+  /// attribute, but has been reshaped to 'newShape'. The new shape must have
+  /// the same total number of elements.
+  DenseElementsAttr reshape(ArrayRef<int64_t> newShape);
+
   DenseElementsAttr reshape(ShapedType newType);
 
   /// Return a new DenseElementsAttr that has the same data as the current

--- a/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/CAPI/IR/BuiltinAttributes.cpp
@@ -679,8 +679,9 @@ MlirAttribute mlirDenseElementsAttrStringGet(MlirType shapedType,
 
 MlirAttribute mlirDenseElementsAttrReshapeGet(MlirAttribute attr,
                                               MlirType shapedType) {
-  return wrap(llvm::cast<DenseElementsAttr>(unwrap(attr))
-                  .reshape(llvm::cast<ShapedType>(unwrap(shapedType))));
+  return wrap(
+      llvm::cast<DenseElementsAttr>(unwrap(attr))
+          .reshape(llvm::cast<ShapedType>(unwrap(shapedType)).getShape()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -274,7 +274,7 @@ struct ConstantCompositeOpPattern final
       if (isa<RankedTensorType>(srcType)) {
         dstAttrType = RankedTensorType::get(srcType.getNumElements(),
                                             srcType.getElementType());
-        dstElementsAttr = dstElementsAttr.reshape(dstAttrType);
+        dstElementsAttr = dstElementsAttr.reshape(dstAttrType.getShape());
       } else {
         // TODO: add support for large vectors.
         return failure();

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1387,7 +1387,7 @@ OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
       return {};
 
     return operand.reshape(
-        llvm::cast<ShapedType>(operand.getType()).clone(shapeVec));
+        llvm::cast<ShapedType>(operand.getType()).clone(shapeVec).getShape());
   }
 
   return {};
@@ -1546,7 +1546,7 @@ OpFoldResult TransposeOp::fold(FoldAdaptor adaptor) {
           llvm::dyn_cast_if_present<DenseElementsAttr>(adaptor.getInput1())) {
     if (input.isSplat() && resultTy.hasStaticShape() &&
         input.getType().getElementType() == resultTy.getElementType())
-      return input.reshape(resultTy);
+      return input.reshape(resultTy.getShape());
   }
 
   // Transpose is not the identity transpose.

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaReduceTransposes.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaReduceTransposes.cpp
@@ -193,7 +193,7 @@ TosaReduceTransposes::transposeDenseAttribute(DenseElementsAttr input,
       RankedTensorType::get(newShape, oldType.getElementType());
 
   if (input.isSplat()) {
-    return input.reshape(newType);
+    return input.reshape(newType.getShape());
   }
 
   auto rawData = input.getRawData();

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -5999,14 +5999,12 @@ OpFoldResult ShapeCastOp::fold(FoldAdaptor adaptor) {
 
   // shape_cast(constant) -> constant
   if (auto splatAttr =
-          llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource())) {
+          llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource()))
     return splatAttr.reshape(getType().getShape());
-  }
 
   // shape_cast(poison) -> poison
-  if (llvm::dyn_cast_if_present<ub::PoisonAttr>(adaptor.getSource())) {
+  if (llvm::dyn_cast_if_present<ub::PoisonAttr>(adaptor.getSource()))
     return ub::PoisonAttr::get(getContext());
-  }
 
   return {};
 }
@@ -6347,7 +6345,6 @@ OpFoldResult vector::TransposeOp::fold(FoldAdaptor adaptor) {
   // Eliminate splat constant transpose ops.
   if (auto splat =
           llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getVector()))
-
     return DenseElementsAttr::get(getResultVectorType(),
                                   splat.getSplatValue<Attribute>());
 

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -5999,8 +5999,9 @@ OpFoldResult ShapeCastOp::fold(FoldAdaptor adaptor) {
 
   // shape_cast(constant) -> constant
   if (auto splatAttr =
-          llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource()))
+          llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource())) {
     return splatAttr.reshape(getType().getShape());
+  }
 
   // shape_cast(poison) -> poison
   if (llvm::dyn_cast_if_present<ub::PoisonAttr>(adaptor.getSource())) {
@@ -6346,7 +6347,9 @@ OpFoldResult vector::TransposeOp::fold(FoldAdaptor adaptor) {
   // Eliminate splat constant transpose ops.
   if (auto splat =
           llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getVector()))
-    return splat.reshape(getResultVectorType().getShape());
+
+    return DenseElementsAttr::get(getResultVectorType(),
+                                  splat.getSplatValue<Attribute>());
 
   // Eliminate poison transpose ops.
   if (llvm::dyn_cast_if_present<ub::PoisonAttr>(adaptor.getVector()))

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -6000,7 +6000,7 @@ OpFoldResult ShapeCastOp::fold(FoldAdaptor adaptor) {
   // shape_cast(constant) -> constant
   if (auto splatAttr =
           llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getSource()))
-    return splatAttr.reshape(getType());
+    return splatAttr.reshape(getType().getShape());
 
   // shape_cast(poison) -> poison
   if (llvm::dyn_cast_if_present<ub::PoisonAttr>(adaptor.getSource())) {
@@ -6346,7 +6346,7 @@ OpFoldResult vector::TransposeOp::fold(FoldAdaptor adaptor) {
   // Eliminate splat constant transpose ops.
   if (auto splat =
           llvm::dyn_cast_if_present<SplatElementsAttr>(adaptor.getVector()))
-    return splat.reshape(getResultVectorType());
+    return splat.reshape(getResultVectorType().getShape());
 
   // Eliminate poison transpose ops.
   if (llvm::dyn_cast_if_present<ub::PoisonAttr>(adaptor.getVector()))

--- a/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
@@ -36,7 +36,7 @@ linearizeConstAttr(Location loc, ConversionPatternRewriter &rewriter,
           loc,
           "Cannot linearize a constant scalable vector that's not a splat");
 
-    return dstElementsAttr.reshape(resType.getNumElements());
+    return dstElementsAttr.reshape(resType.getShape());
   }
 
   if (auto poisonAttr = dyn_cast<ub::PoisonAttr>(value))

--- a/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
@@ -36,7 +36,7 @@ linearizeConstAttr(Location loc, ConversionPatternRewriter &rewriter,
           loc,
           "Cannot linearize a constant scalable vector that's not a splat");
 
-    return dstElementsAttr.reshape(resType.getShape());
+    return dstElementsAttr.reshape(resType.getNumElements());
   }
 
   if (auto poisonAttr = dyn_cast<ub::PoisonAttr>(value))

--- a/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorLinearize.cpp
@@ -36,7 +36,7 @@ linearizeConstAttr(Location loc, ConversionPatternRewriter &rewriter,
           loc,
           "Cannot linearize a constant scalable vector that's not a splat");
 
-    return dstElementsAttr.reshape(resType);
+    return dstElementsAttr.reshape(resType.getShape());
   }
 
   if (auto poisonAttr = dyn_cast<ub::PoisonAttr>(value))

--- a/mlir/lib/IR/BuiltinAttributes.cpp
+++ b/mlir/lib/IR/BuiltinAttributes.cpp
@@ -1241,8 +1241,10 @@ ArrayRef<StringRef> DenseElementsAttr::getRawStringData() const {
 /// Return a new DenseElementsAttr that has the same data as the current
 /// attribute, but has been reshaped to 'newType'. The new type must have the
 /// same total number of elements as well as element type.
-DenseElementsAttr DenseElementsAttr::reshape(ShapedType newType) {
+DenseElementsAttr DenseElementsAttr::reshape(ArrayRef<int64_t> newShape) {
+
   ShapedType curType = getType();
+  auto newType = curType.cloneWith(newShape, curType.getElementType());
   if (curType == newType)
     return *this;
 


### PR DESCRIPTION
The motivation is that it would have prevented the issue detected in https://github.com/llvm/llvm-project/pull/147691. 

