### PR TITLE
[Sema] Fix -Wunreachable-code false negative when operands differ only by implicit casts

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -134,6 +134,11 @@ Bug Fixes in This Version
 -------------------------
 - Fix a crash when marco name is empty in ``#pragma push_macro("")`` or
   ``#pragma pop_macro("")``. (#GH149762).
+- `-Wunreachable-code`` now diagnoses tautological or contradictory
+  comparisons such as ``x != 0 || x != 1.0`` and ``x == 0 && x == 1.0`` on
+  targets that treat ``_Float16``/``__fp16`` as native scalar types. Previously
+  the warning was silently lost because the operands differed only by an implicit
+  cast chain. (#GH149967).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/test/Sema/warn-unreachable_crash.cpp
+++ b/clang/test/Sema/warn-unreachable_crash.cpp
@@ -1,16 +1,33 @@
-// RUN: %clang_cc1 -verify -Wunreachable-code %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -verify -Wunreachable-code %s
+// RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu -target-feature +fullfp16 -verify -Wunreachable-code %s
+// REQUIRES: aarch64-registered-target
 
-// Previously this test will crash
-static void test(__fp16& x) {
-  if (x != 0 || x != 1.0) { // expected-note{{}} no-crash
-      x = 0.9;
-    } else
-      x = 0.8; // expected-warning{{code will never be executed}}
+// =======  __fp16 version  =======
+static void test_fp16(__fp16 &x) {
+  if (x != 0 || x != 1.0) {           // expected-note {{}} no-crash
+    x = 0.9;
+  } else
+    x = 0.8;                          // expected-warning{{code will never be executed}}
 }
 
-static void test2(__fp16& x) {
-  if (x != 1 && x == 1.0) { // expected-note{{}} no-crash
-      x = 0.9; // expected-warning{{code will never be executed}}
-    } else
-      x = 0.8;
+static void test_fp16_b(__fp16 &x) {
+  if (x != 1 && x == 1.0) {           // expected-note {{}} no-crash
+    x = 0.9;                          // expected-warning{{code will never be executed}}
+  } else
+    x = 0.8;
+}
+
+// =======  _Float16 version  =======
+static void test_f16(_Float16 &x) {
+  if (x != 0 || x != 1.0) {           // expected-note {{}} no-crash
+    x = 0.9;
+  } else
+    x = 0.8;                          // expected-warning{{code will never be executed}}
+}
+
+static void test_f16_b(_Float16 &x) {
+  if (x != 1 && x == 1.0) {           // expected-note {{}} no-crash
+    x = 0.9;                          // expected-warning{{code will never be executed}}
+  } else
+    x = 0.8;
 }


### PR DESCRIPTION
## Motivation  
`-Wunreachable-code` missed—or in rare cases crashed on—tautological comparisons such as

```cpp
x != 0 || x != 1.0   // always true
x == 0 && x == 1.0   // always false
```

when the *same* variable appears on both sides but one operand goes through a floating‑rank promotion that is target‑dependent.  On back‑ends with **native half‑precision** (`_Float16` / `__fp16`) such as AArch64 `+fullfp16`, no promotion occurs, so the cast stacks between the two operands differ and the existing heuristic bails out.

## Technical description 
* **Extends `Expr::isSameComparisonOperand()`** – the helper now ignores parentheses **and value‑preserving implicit casts** (`CK_LValueToRValue`, floating‑rank `CK_FloatingCast`) before comparing the underlying operands. This prevents floating‑rank promotions and lvalue‑to‑rvalue conversions from blocking the unreachable‑code diagnostic on targets with native FP16. 
*No change needed in `CheckIncorrectLogicOperator`; it simply benefits from the improved helper.*  
* **Regression test** – `warn-unreachable_crash.cpp` updated to cover both the promoted case (x86‑64) and the native‑half case (AArch64 `+fullfp16`).  
* **Docs** – release‑note bullet added under *Bug Fixes in This Version*.

@ziqingluo-90  @yronglin  Could you please review promptly? (feel free to also merge it on my behalf) Thanks!

Fixes #149967 
