### PR TITLE
[clang-c] Don't deprecate CXRemapping as well as its users

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6953,6 +6953,7 @@ clang_getCursorUnaryOperatorKind(CXCursor cursor);
  * @}
  */
 
+/* CINDEX_DEPRECATED - disable this to appease MSVC deprecation diagnostic warnings */
 typedef void *CXRemapping;
 
 CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *);

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6953,7 +6953,7 @@ clang_getCursorUnaryOperatorKind(CXCursor cursor);
  * @}
  */
 
-/* CINDEX_DEPRECATED - disable this to appease MSVC deprecation diagnostic warnings */
+/* CINDEX_DEPRECATED - disabled to silence MSVC deprecation warnings */
 typedef void *CXRemapping;
 
 CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *);

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -6953,7 +6953,6 @@ clang_getCursorUnaryOperatorKind(CXCursor cursor);
  * @}
  */
 
-CINDEX_DEPRECATED
 typedef void *CXRemapping;
 
 CINDEX_DEPRECATED CINDEX_LINKAGE CXRemapping clang_getRemappings(const char *);


### PR DESCRIPTION
#149079 deprecated CXRemapping and all its methods, however MSVC warns when a deprecated method is using a deprecated variable (and breaks our Werror builds) - best way to avoid this is to only deprecate the methods directly.