### PR TITLE
[clang] Check empty macro name in `#pragma push_macro("")` or `#pragma pop_macro("")`

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -814,6 +814,8 @@ Bug Fixes in This Version
 - Fixed a failed assertion with an operator call expression which comes from a
   macro expansion when performing analysis for nullability attributes. (#GH138371)
 - Fixed a concept equivalent checking crash due to untransformed constraint expressions. (#GH146614)
+- Fix a crash when marco name is empty in ``#pragma push_macro("")`` or
+  ``#pragma pop_macro("")``. (GH149762).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -695,7 +695,7 @@ def warn_pragma_pop_macro_no_push : Warning<
    "pragma pop_macro could not pop '%0', no matching push_macro">,
   InGroup<IgnoredPragmas>;
 def warn_pargma_push_pop_macro_empty_string : Warning<
-   "#pragma %select{push_macro|pop_macro}0 expected a non-empty string">,
+   "'#pragma %select{push_macro|pop_macro}0' expected a non-empty string">,
   InGroup<IgnoredPragmas>;
 def warn_pragma_message : Warning<"%0">,
    InGroup<PoundPragmaMessage>, DefaultWarnNoWerror;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -694,6 +694,9 @@ def err_pragma_push_pop_macro_malformed : Error<
 def warn_pragma_pop_macro_no_push : Warning<
    "pragma pop_macro could not pop '%0', no matching push_macro">,
   InGroup<IgnoredPragmas>;
+def warn_pargma_push_pop_macro_empty_string : Warning<
+   "#pragma %select{push_macro|pop_macro}0 expected an non-empty string">,
+  InGroup<IgnoredPragmas>;
 def warn_pragma_message : Warning<"%0">,
    InGroup<PoundPragmaMessage>, DefaultWarnNoWerror;
 def err_pragma_message : Error<"%0">;

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -695,7 +695,7 @@ def warn_pragma_pop_macro_no_push : Warning<
    "pragma pop_macro could not pop '%0', no matching push_macro">,
   InGroup<IgnoredPragmas>;
 def warn_pargma_push_pop_macro_empty_string : Warning<
-   "#pragma %select{push_macro|pop_macro}0 expected an non-empty string">,
+   "#pragma %select{push_macro|pop_macro}0 expected a non-empty string">,
   InGroup<IgnoredPragmas>;
 def warn_pragma_message : Warning<"%0">,
    InGroup<PoundPragmaMessage>, DefaultWarnNoWerror;

--- a/clang/lib/Lex/Pragma.cpp
+++ b/clang/lib/Lex/Pragma.cpp
@@ -591,7 +591,8 @@ IdentifierInfo *Preprocessor::ParsePragmaPushOrPopMacro(Token &Tok) {
   }
 
   // Remember the macro string.
-  std::string StrVal = getSpelling(Tok);
+  Token StrTok = Tok;
+  std::string StrVal = getSpelling(StrTok);
 
   // Read the ')'.
   Lex(Tok);
@@ -604,9 +605,14 @@ IdentifierInfo *Preprocessor::ParsePragmaPushOrPopMacro(Token &Tok) {
   assert(StrVal[0] == '"' && StrVal[StrVal.size()-1] == '"' &&
          "Invalid string token!");
 
-  // FIXME: Should we emit a warning?
-  if (StrVal.size() <= 2)
+  if (StrVal.size() <= 2) {
+    Diag(StrTok.getLocation(), diag::warn_pargma_push_pop_macro_empty_string)
+        << SourceRange(
+               StrTok.getLocation(),
+               StrTok.getLocation().getLocWithOffset(StrTok.getLength()))
+        << PragmaTok.getIdentifierInfo()->isStr("pop_macro");
     return nullptr;
+  }
 
   // Create a Token from the string.
   Token MacroTok;

--- a/clang/lib/Lex/Pragma.cpp
+++ b/clang/lib/Lex/Pragma.cpp
@@ -604,6 +604,10 @@ IdentifierInfo *Preprocessor::ParsePragmaPushOrPopMacro(Token &Tok) {
   assert(StrVal[0] == '"' && StrVal[StrVal.size()-1] == '"' &&
          "Invalid string token!");
 
+  // FIXME: Should we emit a warning?
+  if (StrVal.size() <= 2)
+    return nullptr;
+
   // Create a Token from the string.
   Token MacroTok;
   MacroTok.startToken();

--- a/clang/test/Preprocessor/pragma-pushpop-macro-diag.c
+++ b/clang/test/Preprocessor/pragma-pushpop-macro-diag.c
@@ -1,0 +1,4 @@
+// RUN: %clang_cc1 -fms-extensions %s -fsyntax-only -verify
+
+#pragma push_macro("") // expected-warning {{#pragma push_macro expected an non-empty string}}
+#pragma pop_macro("") // expected-warning {{#pragma pop_macro expected an non-empty string}}

--- a/clang/test/Preprocessor/pragma-pushpop-macro-diag.c
+++ b/clang/test/Preprocessor/pragma-pushpop-macro-diag.c
@@ -1,4 +1,4 @@
 // RUN: %clang_cc1 -fms-extensions %s -fsyntax-only -verify
 
-#pragma push_macro("") // expected-warning {{#pragma push_macro expected an non-empty string}}
-#pragma pop_macro("") // expected-warning {{#pragma pop_macro expected an non-empty string}}
+#pragma push_macro("") // expected-warning {{#pragma push_macro expected a non-empty string}}
+#pragma pop_macro("") // expected-warning {{#pragma pop_macro expected a non-empty string}}

--- a/clang/test/Preprocessor/pragma-pushpop-macro-diag.c
+++ b/clang/test/Preprocessor/pragma-pushpop-macro-diag.c
@@ -1,4 +1,4 @@
 // RUN: %clang_cc1 -fms-extensions %s -fsyntax-only -verify
 
-#pragma push_macro("") // expected-warning {{#pragma push_macro expected a non-empty string}}
-#pragma pop_macro("") // expected-warning {{#pragma pop_macro expected a non-empty string}}
+#pragma push_macro("") // expected-warning {{'#pragma push_macro' expected a non-empty string}}
+#pragma pop_macro("") // expected-warning {{'#pragma pop_macro' expected a non-empty string}}

--- a/clang/test/Preprocessor/pragma-pushpop-macro.c
+++ b/clang/test/Preprocessor/pragma-pushpop-macro.c
@@ -56,3 +56,6 @@ int P;
 // CHECK: int pmy2 = 4
 // CHECK: int Q;
 // CHECK: int P;
+
+#pragma push_macro("")
+#pragma pop_macro("")


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/149762.
