### PR TITLE
[RISCV][llvm-exegesis] Add missing operand frm for FCVT_D_W

### DIFF
--- a/llvm/test/tools/llvm-exegesis/RISCV/set-reg-init-check.s
+++ b/llvm/test/tools/llvm-exegesis/RISCV/set-reg-init-check.s
@@ -1,7 +1,7 @@
 # RUN: llvm-exegesis -mode=latency -mtriple=riscv32-unknown-linux-gnu --mcpu=generic --dump-object-to-disk=%d --benchmark-phase=assemble-measured-code --opcode-name=FADD_D -mattr="+d" 2>&1
 # RUN: llvm-objdump -M numeric -d %d > %t.s
-# RUN: FileCheck %s --check-prefix=FCVT_D_W_ASM < %t.s
+# RUN: FileCheck %s < %t.s
 
-FCVT_D_W_ASM:       <foo>:
-FCVT_D_W_ASM:       li       x30, 0x0
-FCVT_D_W_ASM-NEXT:  fcvt.d.w f{{[0-9]|[12][0-9]|3[01]}}, x30
+CHECK:       <foo>:
+CHECK:       li       x30, 0x0
+CHECK-NEXT:  fcvt.d.w f{{[0-9]|[12][0-9]|3[01]}}, x30

--- a/llvm/test/tools/llvm-exegesis/RISCV/set-reg-init-check.s
+++ b/llvm/test/tools/llvm-exegesis/RISCV/set-reg-init-check.s
@@ -1,0 +1,7 @@
+# RUN: llvm-exegesis -mode=latency -mtriple=riscv32-unknown-linux-gnu --mcpu=generic --dump-object-to-disk=%d --benchmark-phase=assemble-measured-code --opcode-name=FADD_D -mattr="+d" 2>&1
+# RUN: llvm-objdump -M numeric -d %d > %t.s
+# RUN: FileCheck %s --check-prefix=FCVT_D_W_ASM < %t.s
+
+FCVT_D_W_ASM:       <foo>:
+FCVT_D_W_ASM:       li       x30, 0x0
+FCVT_D_W_ASM-NEXT:  fcvt.d.w f{{[0-9]|[12][0-9]|3[01]}}, x30

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -654,7 +654,7 @@ static std::vector<MCInst> loadFP64RegBits32(const MCSubtargetInfo &STI,
   Instrs.push_back(MCInstBuilder(RISCV::FCVT_D_W)
                        .addReg(Reg)
                        .addReg(ScratchIntReg)
-                       .addImm(RISCVFPRndMode::RoundingMode::RNE));
+                       .addImm(RISCVFPRndMode::RNE));
   return Instrs;
 }
 

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -654,7 +654,7 @@ static std::vector<MCInst> loadFP64RegBits32(const MCSubtargetInfo &STI,
   Instrs.push_back(MCInstBuilder(RISCV::FCVT_D_W)
                        .addReg(Reg)
                        .addReg(ScratchIntReg)
-                       .addImm(7));
+                       .addImm(RISCVFPRndMode::RoundingMode::RNE));
   return Instrs;
 }
 

--- a/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
+++ b/llvm/tools/llvm-exegesis/lib/RISCV/Target.cpp
@@ -651,8 +651,10 @@ static std::vector<MCInst> loadFP64RegBits32(const MCSubtargetInfo &STI,
   }
 
   std::vector<MCInst> Instrs = loadIntReg(STI, ScratchIntReg, Bits);
-  Instrs.push_back(
-      MCInstBuilder(RISCV::FCVT_D_W).addReg(Reg).addReg(ScratchIntReg));
+  Instrs.push_back(MCInstBuilder(RISCV::FCVT_D_W)
+                       .addReg(Reg)
+                       .addReg(ScratchIntReg)
+                       .addImm(7));
   return Instrs;
 }
 


### PR DESCRIPTION
We encountered the index of operand out of bounds crash because FCVT_D_W lacks frm operand.