### PR TITLE
[BranchFolding] Kill common hoisted debug instructions

### DIFF
--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -2143,7 +2143,7 @@ bool BranchFolder::HoistCommonCodeInSuccs(MachineBasicBlock *MBB) {
       ++FI;
     }
   }
-  assert(FIB->getParent() == FBB && "Unexpectedly moved FIB?");
+
   FBB->erase(FBB->begin(), FIB);
 
   if (UpdateLiveIns)

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -2130,7 +2130,7 @@ bool BranchFolder::HoistCommonCodeInSuccs(MachineBasicBlock *MBB) {
       FI = skipDebugInstructionsForward(FI, FE, false);
       // Pseudo probes are excluded from the range when identifying foldable
       // instructions, so we don't expect to see one now.
-      assert(!TI->isPseudoProbe() && "Unexpected psuedo probe in range");
+      assert(!TI->isPseudoProbe() && "Unexpected pseudo probe in range");
       // NOTE: The loop above checks CheckKillDead but we can't do that here as
       // it modifies some kill markers after the check.
       assert(TI->isIdenticalTo(*FI, MachineInstr::CheckDefs) &&

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -2089,22 +2089,21 @@ bool BranchFolder::HoistCommonCodeInSuccs(MachineBasicBlock *MBB) {
     // both branches. FIXME: We could probably try harder to preserve some debug
     // instructions (but at least this isn't producing wrong locations).
     MachineInstrBuilder MIRBuilder(*MBB->getParent(), Loc);
-    auto HoistAndKillDbgInstr =
-        [MBB, Loc](MachineBasicBlock::iterator DI) {
-          assert(DI->isDebugInstr() && "Expected a debug instruction");
-          if (DI->isDebugRef()) {
-            const TargetInstrInfo *TII =
-                MBB->getParent()->getSubtarget().getInstrInfo();
-            const MCInstrDesc &DBGV = TII->get(TargetOpcode::DBG_VALUE);
-            DI = BuildMI(*MBB->getParent(), DI->getDebugLoc(), DBGV, false, 0,
-                         DI->getDebugVariable(), DI->getDebugExpression());
-            MBB->insert(Loc, &*DI);
-            return;
-          }
+    auto HoistAndKillDbgInstr = [MBB, Loc](MachineBasicBlock::iterator DI) {
+      assert(DI->isDebugInstr() && "Expected a debug instruction");
+      if (DI->isDebugRef()) {
+        const TargetInstrInfo *TII =
+            MBB->getParent()->getSubtarget().getInstrInfo();
+        const MCInstrDesc &DBGV = TII->get(TargetOpcode::DBG_VALUE);
+        DI = BuildMI(*MBB->getParent(), DI->getDebugLoc(), DBGV, false, 0,
+                     DI->getDebugVariable(), DI->getDebugExpression());
+        MBB->insert(Loc, &*DI);
+        return;
+      }
 
-          DI->setDebugValueUndef();
-          DI->moveBefore(&*Loc);
-        };
+      DI->setDebugValueUndef();
+      DI->moveBefore(&*Loc);
+    };
 
     // TIB and FIB point to the end of the regions to hoist/merge in TBB and
     // FBB.

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -48,8 +48,6 @@
 #include "llvm/IR/Function.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/MC/LaneBitmask.h"
-#include "llvm/MC/MCInstrDesc.h"
-#include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/BlockFrequency.h"

--- a/llvm/lib/CodeGen/BranchFolding.cpp
+++ b/llvm/lib/CodeGen/BranchFolding.cpp
@@ -2098,6 +2098,11 @@ bool BranchFolder::HoistCommonCodeInSuccs(MachineBasicBlock *MBB) {
         MBB->insert(Loc, &*DI);
         return;
       }
+      // Deleting a DBG_PHI results in an undef at the referenced DBG_INSTR_REF.
+      if (DI->isDebugPHI()) {
+        DI->eraseFromParent();
+        return;
+      }
 
       DI->setDebugValueUndef();
       DI->moveBefore(&*Loc);

--- a/llvm/test/DebugInfo/X86/branch-folder-dbg.mir
+++ b/llvm/test/DebugInfo/X86/branch-folder-dbg.mir
@@ -1,16 +1,21 @@
 # RUN: llc %s --start-before=branch-folder --stop-after=branch-folder -o - | FileCheck %s
 
 ## Check that common instructions hoisted from `if.then` and `if.else` into
-## common pred `entry` get merged debug locations.
-
-## FIXME: The debug instructions handling here is wrong.
+## common pred `entry` get merged debug locations. The debug instructions from
+## both branches should get hoisted and killed.
+##
+## The MIR debug instructions have been modified by hand in order to check they
+## can be killed.
 
 # CHECK: bb.0
 # CHECK:      CALL64pcrel32 @f, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
-## --- Start splice from bb.2.if.else ---
-# CHECK-NEXT: DBG_VALUE 2, $noreg, ![[#]], !DIExpression(),  debug-location ![[#]]
-# CHECK-NEXT: $edi = MOV32r0 implicit-def dead $eflags,  debug-location !DILocation(line: 0, scope: ![[#]])
-## --- End splice --------------
+## --- Start splice from bb.2.if.else (and debug instructions from bb.1.if.then) ---
+# CHECK-NEXT: DBG_VALUE $noreg, $noreg, ![[#]], !DIExpression(),  debug-location ![[#]]
+# CHECK-NEXT: DBG_VALUE $noreg, $noreg, ![[#]], !DIExpression(),  debug-location ![[#]]
+# CHECK-NEXT: $edi = MOV32r0 implicit-def dead $eflags, debug-instr-number 2, debug-location !DILocation(line: 0, scope: ![[#]])
+# CHECK-NEXT: DBG_VALUE $noreg, $noreg, ![[#]], !DIExpression(DW_OP_LLVM_arg, 0),  debug-location ![[#]]
+# CHECK-NEXT: DBG_VALUE $noreg, $noreg, ![[#]], !DIExpression(DW_OP_LLVM_arg, 0),  debug-location ![[#]]
+## --- End splice ------------------------------------------------------------------
 # CHECK-NEXT: TEST64rr killed renamable $rax, renamable $rax, implicit-def $eflags
 # CHECK-NEXT: JCC_1 %bb.2, 9, implicit killed $eflags
 # CHECK: bb.1
@@ -73,6 +78,8 @@
 ...
 ---
 name:            g
+tracksRegLiveness: true
+isSSA: false
 body:             |
   bb.0 (%ir-block.0):
     successors: %bb.1(0x40000000), %bb.2(0x40000000)
@@ -86,22 +93,21 @@ body:             |
 
   bb.1.if.then:
     successors: %bb.3(0x80000000)
-
-    DBG_VALUE 0, $noreg, !11, !DIExpression(),  debug-location !13
-    $edi = MOV32r0 implicit-def dead $eflags,  debug-location !14
+    DBG_VALUE $esi, $noreg, !11, !DIExpression(),  debug-location !13
+    $edi = MOV32r0 implicit-def dead $eflags, debug-instr-number 1, debug-location !14
+    DBG_INSTR_REF !11, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0),  debug-location !13
     $esi = MOV32r0 implicit-def dead $eflags,  debug-location !14
     CALL64pcrel32 target-flags(x86-plt) @_Z3fooii, csr_64, implicit $rsp, implicit $ssp, implicit killed $edi, implicit killed $esi, implicit-def $rsp, implicit-def $ssp,  debug-location !14
-    DBG_VALUE 1, $noreg, !11, !DIExpression(),  debug-location !13
     JMP_1 %bb.3,  debug-location !15
 
   bb.2.if.else:
     successors: %bb.3(0x80000000)
 
-    DBG_VALUE 2, $noreg, !11, !DIExpression(),  debug-location !13
-    $edi = MOV32r0 implicit-def dead $eflags,  debug-location !16
+    DBG_VALUE $esp, $noreg, !11, !DIExpression(), debug-location !13
+    $edi = MOV32r0 implicit-def dead $eflags, debug-instr-number 2, debug-location !16
+    DBG_INSTR_REF !11, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(2, 0),  debug-location !13
     $esi = MOV32ri 1,  debug-location !16
     CALL64pcrel32 target-flags(x86-plt) @_Z3barii, csr_64, implicit $rsp, implicit $ssp, implicit killed $edi, implicit killed $esi, implicit-def $rsp, implicit-def $ssp,  debug-location !16
-    DBG_VALUE 3, $noreg, !11, !DIExpression(),  debug-location !13
 
   bb.3.if.end:
     $eax = MOV32ri 2

--- a/llvm/test/DebugInfo/X86/branch-folder-dbg.mir
+++ b/llvm/test/DebugInfo/X86/branch-folder-dbg.mir
@@ -6,6 +6,8 @@
 ##
 ## The MIR debug instructions have been modified by hand in order to check they
 ## can be killed.
+##
+## Check DBG_PHIs are deleted rather than hoisted.
 
 # CHECK: bb.0
 # CHECK:      CALL64pcrel32 @f, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp, implicit-def $rax
@@ -93,6 +95,8 @@ body:             |
 
   bb.1.if.then:
     successors: %bb.3(0x80000000)
+
+    DBG_PHI $esp, 3
     DBG_VALUE $esi, $noreg, !11, !DIExpression(),  debug-location !13
     $edi = MOV32r0 implicit-def dead $eflags, debug-instr-number 1, debug-location !14
     DBG_INSTR_REF !11, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0),  debug-location !13
@@ -103,6 +107,7 @@ body:             |
   bb.2.if.else:
     successors: %bb.3(0x80000000)
 
+    DBG_PHI $esp, 4
     DBG_VALUE $esp, $noreg, !11, !DIExpression(), debug-location !13
     $edi = MOV32r0 implicit-def dead $eflags, debug-instr-number 2, debug-location !16
     DBG_INSTR_REF !11, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(2, 0),  debug-location !13

--- a/llvm/test/DebugInfo/X86/branch-folder-dbg.mir
+++ b/llvm/test/DebugInfo/X86/branch-folder-dbg.mir
@@ -1,4 +1,5 @@
-# RUN: llc %s --start-before=branch-folder --stop-after=branch-folder -o - | FileCheck %s
+# RUN: llc %s --start-before=branch-folder --stop-after=branch-folder -o - \
+# RUN: | FileCheck %s --implicit-check-not=DBG_PHI
 
 ## Check that common instructions hoisted from `if.then` and `if.else` into
 ## common pred `entry` get merged debug locations. The debug instructions from
@@ -7,7 +8,7 @@
 ## The MIR debug instructions have been modified by hand in order to check they
 ## can be killed.
 ##
-## Check DBG_PHIs are deleted rather than hoisted.
+## Check DBG_PHIs are deleted rather than hoisted (implicit-check-not).
 
 # CHECK: bb.0
 # CHECK:      CALL64pcrel32 @f, csr_64, implicit $rsp, implicit $ssp, implicit-def $rsp, implicit-def $ssp, implicit-def $rax


### PR DESCRIPTION
Mirror of https://github.com/llvm/llvm-project/pull/140091 with an assertion failure fixed in the latest commit as a DBG_PHI was tripping a checking in `setDebugValueUndef` - @jmorse does the last commit look alright to you?

Reproducer shared here - https://github.com/llvm/llvm-project/pull/140091#issuecomment-3097416136