### PR TITLE
[clang] Fix clang debug info generation for unprtototyped function

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -4805,8 +4805,7 @@ void CGDebugInfo::EmitFuncDeclForCallSite(llvm::CallBase *CallOrInvoke,
                                           const FunctionDecl *CalleeDecl) {
   if (!CallOrInvoke)
     return;
-  auto *Func =
-      dyn_cast<llvm::Function>(CallOrInvoke->getCalledOperand());
+  auto *Func = dyn_cast<llvm::Function>(CallOrInvoke->getCalledOperand());
   if (!Func)
     return;
   if (Func->getSubprogram())

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -4805,7 +4805,8 @@ void CGDebugInfo::EmitFuncDeclForCallSite(llvm::CallBase *CallOrInvoke,
                                           const FunctionDecl *CalleeDecl) {
   if (!CallOrInvoke)
     return;
-  auto *Func = CallOrInvoke->getCalledFunction();
+  auto *Func =
+      dyn_cast<llvm::Function>(CallOrInvoke->getCalledOperand());
   if (!Func)
     return;
   if (Func->getSubprogram())

--- a/clang/test/CodeGen/dbg-info-all-calls-described.c
+++ b/clang/test/CodeGen/dbg-info-all-calls-described.c
@@ -1,0 +1,88 @@
+// Test that call site debug info is (un)supported in various configurations.
+
+// Supported: DWARF5, -O1, standalone DI
+// RUN: %clang_cc1 -emit-llvm -triple %itanium_abi_triple %s -o - \
+// RUN:   -O1 -disable-llvm-passes \
+// RUN:   -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: | FileCheck %s -check-prefix=HAS-ATTR \
+// RUN:     -implicit-check-not=DISubprogram -implicit-check-not=DIFlagAllCallsDescribed
+
+// Supported: DWARF4 + LLDB tuning, -O1, limited DI
+// RUN: %clang_cc1 -emit-llvm -triple %itanium_abi_triple %s -o - \
+// RUN:   -O1 -disable-llvm-passes \
+// RUN:   -debugger-tuning=lldb \
+// RUN:   -debug-info-kind=standalone -dwarf-version=4 \
+// RUN: | FileCheck %s -check-prefix=HAS-ATTR \
+// RUN:     -implicit-check-not=DISubprogram -implicit-check-not=DIFlagAllCallsDescribed
+
+// Note: DIFlagAllCallsDescribed may have been enabled prematurely when tuning
+// for GDB under -gdwarf-4 in https://reviews.llvm.org/D69743. It's possible
+// this should have been 'Unsupported' until entry values emission was enabled
+// by default.
+//
+// Supported: DWARF4 + GDB tuning
+// RUN: %clang_cc1 -emit-llvm -triple x86_64-linux-gnu \
+// RUN:   %s -o - -O1 -disable-llvm-passes -debugger-tuning=gdb \
+// RUN:   -debug-info-kind=standalone -dwarf-version=4 \
+// RUN: | FileCheck %s -check-prefix=HAS-ATTR \
+// RUN:     -implicit-check-not=DIFlagAllCallsDescribed
+
+// Supported: DWARF4 + LLDB, -O1
+// RUN: %clang_cc1 -emit-llvm -triple x86_64-linux-gnu \
+// RUN:   %s -o - -O1 -disable-llvm-passes -debugger-tuning=lldb \
+// RUN:   -debug-info-kind=standalone -dwarf-version=4 \
+// RUN: | FileCheck %s -check-prefix=HAS-ATTR \
+// RUN:     -implicit-check-not=DIFlagAllCallsDescribed
+
+// Unsupported: -O0
+// RUN: %clang_cc1 -emit-llvm -triple x86_64-linux-gnu \
+// RUN:   %s -o - -O0 -disable-llvm-passes -debugger-tuning=gdb \
+// RUN:   -debug-info-kind=standalone -dwarf-version=4 \
+// RUN: | FileCheck %s -check-prefix=NO-ATTR
+
+// Supported: DWARF4 + LLDB tuning, -O1, line-tables only DI
+// RUN: %clang_cc1 -emit-llvm -triple %itanium_abi_triple %s -o - \
+// RUN:   -O1 -disable-llvm-passes \
+// RUN:   -debugger-tuning=lldb \
+// RUN:   -debug-info-kind=line-tables-only -dwarf-version=4 \
+// RUN: | FileCheck %s -check-prefix=LINE-TABLES-ONLY
+
+// Unsupported: -O0
+// RUN: %clang_cc1 -emit-llvm -triple %itanium_abi_triple %s -o - \
+// RUN:   -O0 \
+// RUN:   -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: | FileCheck %s -check-prefix=NO-ATTR
+
+// Unsupported: DWARF4
+// RUN: %clang_cc1 -emit-llvm -triple %itanium_abi_triple %s -o - \
+// RUN:   -O1 -disable-llvm-passes \
+// RUN:   -debug-info-kind=standalone -dwarf-version=4 \
+// RUN: | FileCheck %s -check-prefix=NO-ATTR
+
+// NO-ATTR-NOT: FlagAllCallsDescribed
+
+// HAS-ATTR-DAG: DISubprogram(name: "declaration1", {{.*}}, spFlags: DISPFlagOptimized)
+// HAS-ATTR-DAG: DISubprogram(name: "declaration2", {{.*}}, flags: DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized 
+// HAS-ATTR-DAG: DISubprogram(name: "declaration3", {{.*}}, flags: DIFlagPrototyped, spFlags: DISPFlagOptimized)
+// HAS-ATTR-DAG: DISubprogram(name: "declaration4", {{.*}}, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized
+
+// HAS-ATTR-DAG: DISubprogram(name: "force_irgen", {{.*}}, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition
+
+// LINE-TABLES-ONLY: DISubprogram(name: "force_irgen", {{.*}}, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition
+
+void declaration1();
+
+void declaration2();
+
+void declaration2() {}
+
+void declaration3(void);
+
+void declaration4(void);
+
+void declaration4(void) {}
+
+void __attribute__((optnone)) force_irgen(void) {
+  declaration1();
+  declaration3();
+}


### PR DESCRIPTION
Consider this declaration:

`int foo();`

This function is described in LLVM with `clang::FunctionNoProtoType` class. ([See description](https://clang.llvm.org/doxygen/classclang_1_1FunctionNoProtoType.html))

Judging by [this comment](https://github.com/llvm/llvm-project/blob/a1bf0d1394e48894be05d274d3942ff77c35ce87/clang/lib/CodeGen/CGCall.cpp#L159C11-L159C12) all such functions are treated like functions with variadic number of parameters.

When we want to [emit debug info](https://github.com/llvm/llvm-project/blob/0a8ddd396546bec7eaa4c3b7ef2f495e52bca0b8/clang/lib/CodeGen/CGDebugInfo.cpp#L4808) we have to know function that we calling.

In method [getCalledFunction()](https://github.com/llvm/llvm-project/blob/0a8ddd396546bec7eaa4c3b7ef2f495e52bca0b8/llvm/include/llvm/IR/InstrTypes.h#L1348) we compare two types of function:

1. Function that we deduce from calling operand, and
2. Function that we store locally

If they differ we get `nullptr` and can't emit appropriate debug info.

The only thing they differ is: lhs function is variadic, but rhs function isn't

Reason of this difference is that under RISC-V there is no overridden function that tells us about treating functions with no parameters. [Default function](https://github.com/llvm/llvm-project/blob/0a8ddd396546bec7eaa4c3b7ef2f495e52bca0b8/clang/lib/CodeGen/TargetInfo.cpp#L87) always return `false`.

This patch overrides this function for RISC-V