### PR TITLE
[Offload] Rename olWaitEvent/Queue to olSyncEvent/Queue

### DIFF
--- a/offload/liboffload/API/Event.td
+++ b/offload/liboffload/API/Event.td
@@ -21,8 +21,8 @@ def : Function {
 }
 
 def : Function {
-    let name = "olWaitEvent";
-    let desc = "Wait for the event to be complete.";
+    let name = "olSyncEvent";
+    let desc = "Block the calling thread until the event is complete.";
     let details = [];
     let params = [
         Param<"ol_event_handle_t", "Event", "handle of the event", PARAM_IN>

--- a/offload/liboffload/API/Queue.td
+++ b/offload/liboffload/API/Queue.td
@@ -32,8 +32,8 @@ def : Function {
 }
 
 def : Function {
-    let name = "olWaitQueue";
-    let desc = "Wait for the enqueued work on a queue to complete.";
+    let name = "olSyncQueue";
+    let desc = "Block the calling thread until the enqueued work on a queue is complete.";
     let details = [];
     let params = [
         Param<"ol_queue_handle_t", "Queue", "handle of the queue", PARAM_IN>

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -483,7 +483,7 @@ Error olCreateQueue_impl(ol_device_handle_t Device, ol_queue_handle_t *Queue) {
 
 Error olDestroyQueue_impl(ol_queue_handle_t Queue) { return olDestroy(Queue); }
 
-Error olWaitQueue_impl(ol_queue_handle_t Queue) {
+Error olSyncQueue_impl(ol_queue_handle_t Queue) {
   // Host plugin doesn't have a queue set so it's not safe to call synchronize
   // on it, but we have nothing to synchronize in that situation anyway.
   if (Queue->AsyncInfo->Queue) {
@@ -527,7 +527,7 @@ Error olGetQueueInfoSize_impl(ol_queue_handle_t Queue, ol_queue_info_t PropName,
   return olGetQueueInfoImplDetail(Queue, PropName, 0, nullptr, PropSizeRet);
 }
 
-Error olWaitEvent_impl(ol_event_handle_t Event) {
+Error olSyncEvent_impl(ol_event_handle_t Event) {
   if (auto Res = Event->Queue->Device->Device->syncEvent(Event->EventInfo))
     return Res;
 

--- a/offload/unittests/OffloadAPI/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/CMakeLists.txt
@@ -10,7 +10,7 @@ add_offload_unittest("device"
 
 add_offload_unittest("event"
     event/olDestroyEvent.cpp
-    event/olWaitEvent.cpp
+    event/olSyncEvent.cpp
     event/olGetEventInfo.cpp
     event/olGetEventInfoSize.cpp)
 
@@ -36,7 +36,7 @@ add_offload_unittest("program"
 
 add_offload_unittest("queue"
     queue/olCreateQueue.cpp
-    queue/olWaitQueue.cpp
+    queue/olSyncQueue.cpp
     queue/olDestroyQueue.cpp
     queue/olGetQueueInfo.cpp
     queue/olGetQueueInfoSize.cpp)

--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -179,7 +179,7 @@ struct OffloadEventTest : OffloadQueueTest {
         olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, sizeof(Value), &Alloc));
     ASSERT_SUCCESS(
         olMemcpy(Queue, Alloc, Device, &Value, Host, sizeof(Value), &Event));
-    ASSERT_SUCCESS(olWaitEvent(Event));
+    ASSERT_SUCCESS(olSyncEvent(Event));
     ASSERT_SUCCESS(olMemFree(Alloc));
   }
 

--- a/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
@@ -23,7 +23,7 @@ TEST_P(olDestroyEventTest, Success) {
   ASSERT_SUCCESS(
       olMemcpy(Queue, DstPtr, Device, &Src, Host, sizeof(Src), &Event));
   ASSERT_NE(Event, nullptr);
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   ASSERT_SUCCESS(olDestroyEvent(Event));
 }
 

--- a/offload/unittests/OffloadAPI/event/olSyncEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olSyncEvent.cpp
@@ -1,4 +1,4 @@
-//===------- Offload API tests - olWaitEvent -====-------------------------===//
+//===------- Offload API tests - olSyncEvent -====-------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,10 +10,10 @@
 #include <OffloadAPI.h>
 #include <gtest/gtest.h>
 
-using olWaitEventTest = OffloadQueueTest;
-OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olWaitEventTest);
+using olSyncEventTest = OffloadQueueTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olSyncEventTest);
 
-TEST_P(olWaitEventTest, Success) {
+TEST_P(olSyncEventTest, Success) {
   uint32_t Src = 42;
   void *DstPtr;
 
@@ -23,15 +23,15 @@ TEST_P(olWaitEventTest, Success) {
   ASSERT_SUCCESS(
       olMemcpy(Queue, DstPtr, Device, &Src, Host, sizeof(Src), &Event));
   ASSERT_NE(Event, nullptr);
-  ASSERT_SUCCESS(olWaitEvent(Event));
+  ASSERT_SUCCESS(olSyncEvent(Event));
   ASSERT_SUCCESS(olDestroyEvent(Event));
 }
 
-TEST_P(olWaitEventTest, InvalidNullEvent) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvent(nullptr));
+TEST_P(olSyncEventTest, InvalidNullEvent) {
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olSyncEvent(nullptr));
 }
 
-TEST_P(olWaitEventTest, SuccessMultipleWait) {
+TEST_P(olSyncEventTest, SuccessMultipleWait) {
   uint32_t Src = 42;
   void *DstPtr;
 
@@ -43,7 +43,7 @@ TEST_P(olWaitEventTest, SuccessMultipleWait) {
   ASSERT_NE(Event, nullptr);
 
   for (size_t I = 0; I < 10; I++)
-    ASSERT_SUCCESS(olWaitEvent(Event));
+    ASSERT_SUCCESS(olSyncEvent(Event));
 
   ASSERT_SUCCESS(olDestroyEvent(Event));
 }

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -94,7 +94,7 @@ TEST_P(olLaunchKernelFooTest, Success) {
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
 
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < 64; i++) {
@@ -108,7 +108,7 @@ TEST_P(olLaunchKernelNoArgsTest, Success) {
   ASSERT_SUCCESS(
       olLaunchKernel(Queue, Device, Kernel, nullptr, 0, &LaunchArgs, nullptr));
 
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 }
 
 TEST_P(olLaunchKernelFooTest, SuccessSynchronous) {
@@ -147,7 +147,7 @@ TEST_P(olLaunchKernelLocalMemTest, Success) {
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
 
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < LaunchArgs.GroupSize.x * LaunchArgs.NumGroups.x; i++)
@@ -170,7 +170,7 @@ TEST_P(olLaunchKernelLocalMemReductionTest, Success) {
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
 
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < LaunchArgs.NumGroups.x; i++)
@@ -193,7 +193,7 @@ TEST_P(olLaunchKernelLocalMemStaticTest, Success) {
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
 
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < LaunchArgs.NumGroups.x; i++)
@@ -212,10 +212,10 @@ TEST_P(olLaunchKernelGlobalTest, Success) {
 
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernels[0], nullptr, 0,
                                 &LaunchArgs, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernels[1], &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < 64; i++) {
@@ -244,7 +244,7 @@ TEST_P(olLaunchKernelGlobalCtorTest, Success) {
 
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 0; i < 64; i++) {
@@ -260,5 +260,5 @@ TEST_P(olLaunchKernelGlobalDtorTest, Success) {
   // crashes
   ASSERT_SUCCESS(
       olLaunchKernel(Queue, Device, Kernel, nullptr, 0, &LaunchArgs, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 }

--- a/offload/unittests/OffloadAPI/memory/olMemcpy.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemcpy.cpp
@@ -46,7 +46,7 @@ TEST_P(olMemcpyTest, SuccessHtoD) {
   std::vector<uint8_t> Input(Size, 42);
   ASSERT_SUCCESS(
       olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size, nullptr));
-  olWaitQueue(Queue);
+  olSyncQueue(Queue);
   olMemFree(Alloc);
 }
 
@@ -61,7 +61,7 @@ TEST_P(olMemcpyTest, SuccessDtoH) {
       olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size, nullptr));
   ASSERT_SUCCESS(
       olMemcpy(Queue, Output.data(), Host, Alloc, Device, Size, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   for (uint8_t Val : Output) {
     ASSERT_EQ(Val, 42);
   }
@@ -83,7 +83,7 @@ TEST_P(olMemcpyTest, SuccessDtoD) {
       olMemcpy(Queue, AllocB, Device, AllocA, Device, Size, nullptr));
   ASSERT_SUCCESS(
       olMemcpy(Queue, Output.data(), Host, AllocB, Device, Size, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   for (uint8_t Val : Output) {
     ASSERT_EQ(Val, 42);
   }
@@ -146,10 +146,10 @@ TEST_P(olMemcpyGlobalTest, SuccessRoundTrip) {
 
   ASSERT_SUCCESS(olMemcpy(Queue, Addr, Device, SourceMem, Host,
                           64 * sizeof(uint32_t), nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   ASSERT_SUCCESS(olMemcpy(Queue, DestMem, Host, Addr, Device,
                           64 * sizeof(uint32_t), nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *DestData = (uint32_t *)DestMem;
   for (uint32_t I = 0; I < 64; I++)
@@ -178,10 +178,10 @@ TEST_P(olMemcpyGlobalTest, SuccessWrite) {
 
   ASSERT_SUCCESS(olMemcpy(Queue, Addr, Device, SourceMem, Host,
                           64 * sizeof(uint32_t), nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, ReadKernel, &Args, sizeof(Args),
                                 &LaunchArgs, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *DestData = (uint32_t *)DestMem;
   for (uint32_t I = 0; I < 64; I++)
@@ -199,10 +199,10 @@ TEST_P(olMemcpyGlobalTest, SuccessRead) {
 
   ASSERT_SUCCESS(olLaunchKernel(Queue, Device, WriteKernel, nullptr, 0,
                                 &LaunchArgs, nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
   ASSERT_SUCCESS(olMemcpy(Queue, DestMem, Host, Addr, Device,
                           64 * sizeof(uint32_t), nullptr));
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *DestData = (uint32_t *)DestMem;
   for (uint32_t I = 0; I < 64; I++)

--- a/offload/unittests/OffloadAPI/queue/olSyncQueue.cpp
+++ b/offload/unittests/OffloadAPI/queue/olSyncQueue.cpp
@@ -1,4 +1,4 @@
-//===------- Offload API tests - olWaitQueue ------------------------------===//
+//===------- Offload API tests - olSyncQueue ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,9 +10,9 @@
 #include <OffloadAPI.h>
 #include <gtest/gtest.h>
 
-using olWaitQueueTest = OffloadQueueTest;
-OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olWaitQueueTest);
+using olSyncQueueTest = OffloadQueueTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olSyncQueueTest);
 
-TEST_P(olWaitQueueTest, SuccessEmptyQueue) {
-  ASSERT_SUCCESS(olWaitQueue(Queue));
+TEST_P(olSyncQueueTest, SuccessEmptyQueue) {
+  ASSERT_SUCCESS(olSyncQueue(Queue));
 }


### PR DESCRIPTION
This more closely matches the nomenclature used by CUDA, AMDGPU and
the plugin interface.
