### PR TITLE
[libc] Use long in a64l instead of int32_t.

### DIFF
--- a/libc/src/stdlib/CMakeLists.txt
+++ b/libc/src/stdlib/CMakeLists.txt
@@ -192,7 +192,6 @@ add_entrypoint_object(
     a64l.h
   DEPENDS
     libc.src.__support.ctype_utils
-    libc.hdr.types.size_t
 )
 
 add_entrypoint_object(

--- a/libc/src/stdlib/a64l.cpp
+++ b/libc/src/stdlib/a64l.cpp
@@ -16,7 +16,7 @@ namespace LIBC_NAMESPACE_DECL {
 // I'm not sure this should go in ctype_utils since the specific ordering of
 // base64 is so very implementation specific, and also this set is unusual.
 // Returns -1 on any char without a specified value.
-constexpr static int b64_char_to_int(char ch) {
+constexpr static long b64_char_to_int(char ch) {
   // from the standard: "The characters used to represent digits are '.' (dot)
   // for 0, '/' for 1, '0' through '9' for [2,11], 'A' through 'Z' for [12,37],
   // and 'a' through 'z' for [38,63]."
@@ -41,10 +41,10 @@ constexpr static int b64_char_to_int(char ch) {
 LLVM_LIBC_FUNCTION(long, a64l, (const char *s)) {
   // the standard says to only use up to 6 characters.
   constexpr unsigned MAX_LENGTH = 6;
-  int result = 0;
+  long result = 0;
 
   for (unsigned i = 0; i < MAX_LENGTH && s[i] != '\0'; ++i) {
-    int cur_val = b64_char_to_int(s[i]);
+    long cur_val = b64_char_to_int(s[i]);
     // The standard says what happens on an unspecified character is undefined,
     // here we treat it as the end of the string.
     if (cur_val == -1)
@@ -56,7 +56,7 @@ LLVM_LIBC_FUNCTION(long, a64l, (const char *s)) {
   }
 
   // standard says to sign extend from 32 bits.
-  return static_cast<long>(result);
+  return result & 0xFFFF'FFFF;
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/stdlib/a64l.cpp
+++ b/libc/src/stdlib/a64l.cpp
@@ -12,14 +12,12 @@
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
 
-#include <stdint.h>
-
 namespace LIBC_NAMESPACE_DECL {
 
 // I'm not sure this should go in ctype_utils since the specific ordering of
 // base64 is so very implementation specific, and also this set is unusual.
 // Returns -1 on any char without a specified value.
-constexpr static int32_t b64_char_to_int(char ch) {
+constexpr static int b64_char_to_int(char ch) {
   // from the standard: "The characters used to represent digits are '.' (dot)
   // for 0, '/' for 1, '0' through '9' for [2,11], 'A' through 'Z' for [12,37],
   // and 'a' through 'z' for [38,63]."
@@ -44,10 +42,10 @@ constexpr static int32_t b64_char_to_int(char ch) {
 LLVM_LIBC_FUNCTION(long, a64l, (const char *s)) {
   // the standard says to only use up to 6 characters.
   constexpr size_t MAX_LENGTH = 6;
-  int32_t result = 0;
+  int result = 0;
 
   for (size_t i = 0; i < MAX_LENGTH && s[i] != '\0'; ++i) {
-    int32_t cur_val = b64_char_to_int(s[i]);
+    int cur_val = b64_char_to_int(s[i]);
     // The standard says what happens on an unspecified character is undefined,
     // here we treat it as the end of the string.
     if (cur_val == -1)

--- a/libc/src/stdlib/a64l.cpp
+++ b/libc/src/stdlib/a64l.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/stdlib/a64l.h"
-#include "hdr/types/size_t.h"
 #include "src/__support/common.h"
 #include "src/__support/ctype_utils.h"
 #include "src/__support/macros/config.h"
@@ -41,10 +40,10 @@ constexpr static int b64_char_to_int(char ch) {
 // TODO: use LIBC_ADD_NULL_CHECKS for checking if the input is a null pointer.
 LLVM_LIBC_FUNCTION(long, a64l, (const char *s)) {
   // the standard says to only use up to 6 characters.
-  constexpr size_t MAX_LENGTH = 6;
+  constexpr unsigned MAX_LENGTH = 6;
   int result = 0;
 
-  for (size_t i = 0; i < MAX_LENGTH && s[i] != '\0'; ++i) {
+  for (unsigned i = 0; i < MAX_LENGTH && s[i] != '\0'; ++i) {
     int cur_val = b64_char_to_int(s[i]);
     // The standard says what happens on an unspecified character is undefined,
     // here we treat it as the end of the string.


### PR DESCRIPTION
Build errors from: https://lab.llvm.org/buildbot/#/builders/11/builds/20066/steps/4/logs/stdio
```
[203/2518] Building CXX object libc/src/stdlib/CMakeFiles/libc.src.stdlib.a64l.dir/a64l.cpp.obj
FAILED: libc/src/stdlib/CMakeFiles/libc.src.stdlib.a64l.dir/a64l.cpp.obj 
/var/lib/buildbot/fuchsia-x86_64-linux/build/llvm-build-ubfz36i3/./bin/clang++ --target=armv7em-none-eabi -DLIBC_NAMESPACE=__llvm_libc_22_0_0_git -I/var/lib/buildbot/fuchsia-x86_64-linux/llvm-project/libc -isystem /var/lib/buildbot/fuchsia-x86_64-linux/build/llvm-build-ubfz36i3/include/armv7em-unknown-none-eabi --target=armv7em-none-eabi -Wno-atomic-alignment "-Dvfprintf(stream, format, vlist)=vprintf(format, vlist)" "-Dfprintf(stream, format, ...)=printf(format)" -D_LIBCPP_PRINT=1 -mthumb -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -ffunction-sections -fdata-sections -ffile-prefix-map=/var/lib/buildbot/fuchsia-x86_64-linux/build/llvm-build-ubfz36i3/runtimes/runtimes-armv7em-none-eabi-bins=../../../../llvm-project -ffile-prefix-map=/var/lib/buildbot/fuchsia-x86_64-linux/llvm-project/= -no-canonical-prefixes -Os -DNDEBUG --target=armv7em-none-eabi -DLIBC_QSORT_IMPL=LIBC_QSORT_HEAP_SORT -DLIBC_TYPES_TIME_T_IS_32_BIT -DLIBC_ADD_NULL_CHECKS "-DLIBC_MATH=(LIBC_MATH_SKIP_ACCURATE_PASS | LIBC_MATH_SMALL_TABLES)" -DLIBC_ERRNO_MODE=LIBC_ERRNO_MODE_EXTERNAL -fpie -ffreestanding -DLIBC_FULL_BUILD -nostdlibinc -ffixed-point -fno-builtin -fno-exceptions -fno-lax-vector-conversions -fno-unwind-tables -fno-asynchronous-unwind-tables -fno-rtti -ftrivial-auto-var-init=pattern -fno-omit-frame-pointer -Wall -Wextra -Werror -Wconversion -Wno-sign-conversion -Wdeprecated -Wno-c99-extensions -Wno-gnu-imaginary-constant -Wno-pedantic -Wimplicit-fallthrough -Wwrite-strings -Wextra-semi -Wnewline-eof -Wnonportable-system-include-path -Wstrict-prototypes -Wthread-safety -Wglobal-constructors -DLIBC_COPT_PUBLIC_PACKAGING -MD -MT libc/src/stdlib/CMakeFiles/libc.src.stdlib.a64l.dir/a64l.cpp.obj -MF libc/src/stdlib/CMakeFiles/libc.src.stdlib.a64l.dir/a64l.cpp.obj.d -o libc/src/stdlib/CMakeFiles/libc.src.stdlib.a64l.dir/a64l.cpp.obj -c /var/lib/buildbot/fuchsia-x86_64-linux/llvm-project/libc/src/stdlib/a64l.cpp
/var/lib/buildbot/fuchsia-x86_64-linux/llvm-project/libc/src/stdlib/a64l.cpp:22:18: error: unknown type name 'int32_t'
   22 | constexpr static int32_t b64_char_to_int(char ch) {
      |                  ^
/var/lib/buildbot/fuchsia-x86_64-linux/llvm-project/libc/src/stdlib/a64l.cpp:47:3: error: unknown type name 'int32_t'
   47 |   int32_t result = 0;
      |   ^
/var/lib/buildbot/fuchsia-x86_64-linux/llvm-project/libc/src/stdlib/a64l.cpp:50:5: error: unknown type name 'int32_t'
   50 |     int32_t cur_val = b64_char_to_int(s[i]);
      |     ^
3 errors generated.
```