### PR TITLE
[NFC][AMDGPU] Remove `-verify-machineinstrs` from `llvm/test/CodeGen/MIR/AMDGPU/`

### DIFF
--- a/llvm/test/CodeGen/MIR/AMDGPU/custom-pseudo-source-values.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/custom-pseudo-source-values.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=amdgcn-mesa-mesa3d -mcpu=gfx1010 -stop-after finalize-isel -o %t.mir %s
-; RUN: llc -run-pass=none -verify-machineinstrs %t.mir -o - | FileCheck %s
+; RUN: llc -run-pass=none %t.mir -o - | FileCheck %s
 
 ; Test that custom pseudo source values can be round trip serialized through MIR.
 

--- a/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index-invalid-fixed-stack.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index-invalid-fixed-stack.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 name: invalid_scavenge_fi

--- a/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index-invalid-stack.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index-invalid-stack.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 name: invalid_scavenge_fi

--- a/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index-no-stack.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index-no-stack.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 name: invalid_scavenge_fi

--- a/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 name: invalid_scavenge_fi

--- a/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index2.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/invalid-frame-index2.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 name: invalid_scavenge_fi

--- a/llvm/test/CodeGen/MIR/AMDGPU/long-branch-reg-all-sgpr-used.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/long-branch-reg-all-sgpr-used.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn -verify-machineinstrs -amdgpu-s-branch-bits=5 -stop-after=branch-relaxation  %s -o - | FileCheck %s
+; RUN: llc -mtriple=amdgcn -amdgpu-s-branch-bits=5 -stop-after=branch-relaxation  %s -o - | FileCheck %s
 
 ; Test long branch reserved register pass when all
 ; SGPRs are used

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-after-pei.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-after-pei.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-mesa-mesa3d -mcpu=tahiti -amdgpu-spill-sgpr-to-vgpr=0 -stop-after prologepilog -verify-machineinstrs %s -o - | FileCheck -check-prefix=AFTER-PEI %s
+; RUN: llc -mtriple=amdgcn-mesa-mesa3d -mcpu=tahiti -amdgpu-spill-sgpr-to-vgpr=0 -stop-after prologepilog %s -o - | FileCheck -check-prefix=AFTER-PEI %s
 
 ; Test that the ScavengeFI is serialized in the SIMachineFunctionInfo.
 

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-dynlds-align-invalid-case.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-dynlds-align-invalid-case.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o - 2>&1 | FileCheck %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o - 2>&1 | FileCheck %s
 
 ---
 # CHECK: error: YAML:8:16: must be a power of two

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-long-branch-reg-debug.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-long-branch-reg-debug.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -verify-machineinstrs -amdgpu-s-branch-bits=4 -stop-after=branch-relaxation -verify-machineinstrs %s -o - | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -amdgpu-s-branch-bits=4 -stop-after=branch-relaxation %s -o - | FileCheck %s
 
 ; Test that debug instructions do not change long branch reserved serialized through
 ; MIR.

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-long-branch-reg.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-long-branch-reg.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -verify-machineinstrs -amdgpu-s-branch-bits=4 -stop-after=branch-relaxation -verify-machineinstrs %s -o - | FileCheck %s
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -amdgpu-s-branch-bits=4 -stop-after=branch-relaxation %s -o - | FileCheck %s
 
 ; Test that long branch reserved register is serialized through
 ; MIR.

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-no-ir.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info-no-ir.mir
@@ -1,5 +1,5 @@
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o - | FileCheck -check-prefixes=FULL,ALL %s
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -simplify-mir -verify-machineinstrs %s -o - | FileCheck -check-prefixes=SIMPLE,ALL %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o - | FileCheck -check-prefixes=FULL,ALL %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -simplify-mir %s -o - | FileCheck -check-prefixes=SIMPLE,ALL %s
 
 
 ---

--- a/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info.ll
+++ b/llvm/test/CodeGen/MIR/AMDGPU/machine-function-info.ll
@@ -1,5 +1,5 @@
 ; RUN: llc -mtriple=amdgcn-mesa-mesa3d -mcpu=tahiti -stop-after=si-pre-allocate-wwm-regs -o %t.mir %s
-; RUN: llc -run-pass=none -verify-machineinstrs %t.mir -o - | FileCheck %s
+; RUN: llc -run-pass=none %t.mir -o - | FileCheck %s
 
 ; Test that SIMachineFunctionInfo can be round trip serialized through
 ; MIR.

--- a/llvm/test/CodeGen/MIR/AMDGPU/mir-canon-multi.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/mir-canon-multi.mir
@@ -1,5 +1,5 @@
-# RUN: llc -o -  -mtriple=amdgcn  -run-pass mir-canonicalizer -verify-machineinstrs %s | FileCheck %s
-# RUN: llc -o -  -mtriple=amdgcn  -run-pass mir-canonicalizer -mir-vreg-namer-use-stable-hash -verify-machineinstrs %s | FileCheck %s
+# RUN: llc -o -  -mtriple=amdgcn  -run-pass mir-canonicalizer %s | FileCheck %s
+# RUN: llc -o -  -mtriple=amdgcn  -run-pass mir-canonicalizer -mir-vreg-namer-use-stable-hash %s | FileCheck %s
 
 # This tests for the itereator invalidation fix (reviews.llvm.org/D62713)
 ...

--- a/llvm/test/CodeGen/MIR/AMDGPU/mircanon-memoperands.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/mircanon-memoperands.mir
@@ -1,5 +1,5 @@
-# RUN: llc -mtriple=amdgcn -mcpu=tahiti -run-pass mir-canonicalizer -verify-machineinstrs -o - %s | FileCheck %s
-# RUN: llc -mtriple=amdgcn -mcpu=tahiti -run-pass mir-canonicalizer -mir-vreg-namer-use-stable-hash -verify-machineinstrs -o - %s | FileCheck %s
+# RUN: llc -mtriple=amdgcn -mcpu=tahiti -run-pass mir-canonicalizer -o - %s | FileCheck %s
+# RUN: llc -mtriple=amdgcn -mcpu=tahiti -run-pass mir-canonicalizer -mir-vreg-namer-use-stable-hash -o - %s | FileCheck %s
 --- |
   target datalayout = "e-p:32:32-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
 

--- a/llvm/test/CodeGen/MIR/AMDGPU/noconvergent-invalid.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/noconvergent-invalid.mir
@@ -1,4 +1,4 @@
-# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck %s
+# RUN: not --crash llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck %s
 
 ---
 name:            noconvergent_invalid

--- a/llvm/test/CodeGen/MIR/AMDGPU/parse-order-reserved-regs.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/parse-order-reserved-regs.mir
@@ -1,6 +1,6 @@
-# RUN: llc -mtriple=amdgcn -run-pass=none -verify-machineinstrs -o - %s | FileCheck %s
-# RUN: llc -mtriple=amdgcn  -run-pass mir-canonicalizer -verify-machineinstrs -o - %s
-# RUN: llc -mtriple=amdgcn  -run-pass mir-canonicalizer -mir-vreg-namer-use-stable-hash -verify-machineinstrs -o - %s
+# RUN: llc -mtriple=amdgcn -run-pass=none -o - %s | FileCheck %s
+# RUN: llc -mtriple=amdgcn  -run-pass mir-canonicalizer -o - %s
+# RUN: llc -mtriple=amdgcn  -run-pass mir-canonicalizer -mir-vreg-namer-use-stable-hash -o - %s
 
 # Previously getReservedRegs was called before parsing
 # machineFunctionInfo, but the AMDGPU implementation depends on

--- a/llvm/test/CodeGen/MIR/AMDGPU/stack-id-assert.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/stack-id-assert.mir
@@ -3,7 +3,7 @@
 # contains not dead objects only. So using objects IDs as offset in the storage
 # caused out of bounds access.
 
-# RUN: llc -mtriple=amdgcn -start-before=si-lower-sgpr-spills -stop-after=prologepilog -verify-machineinstrs -o - %s | FileCheck %s
+# RUN: llc -mtriple=amdgcn -start-before=si-lower-sgpr-spills -stop-after=prologepilog -o - %s | FileCheck %s
 
 # CHECK-LABEL: name:            foo
 # CHECK: {{^}}fixedStack:      []

--- a/llvm/test/CodeGen/MIR/AMDGPU/subreg-def-is-not-ssa.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/subreg-def-is-not-ssa.mir
@@ -1,5 +1,5 @@
 # REQUIRES: asserts
-# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=instruction-select -verify-machineinstrs -o /dev/null %s 2>&1 | FileCheck %s
+# RUN: not --crash llc -mtriple=amdgcn -mcpu=gfx900 -run-pass=instruction-select -o /dev/null %s 2>&1 | FileCheck %s
 
 # CHECK: MachineFunctionProperties required by InstructionSelect pass are not met by function subreg_def_is_not_ssa.
 # CHECK-NEXT: Required properties: IsSSA

--- a/llvm/test/CodeGen/MIR/AMDGPU/vgpr-for-agpr-copy-invalid-reg.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/vgpr-for-agpr-copy-invalid-reg.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
 
 ---
 name: invalid_reg

--- a/llvm/test/CodeGen/MIR/AMDGPU/wwm-reserved-regs-invalid-reg.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/wwm-reserved-regs-invalid-reg.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
 
 ---
 name: invalid_reg

--- a/llvm/test/CodeGen/MIR/AMDGPU/wwm-reserved-regs-not-a-reg.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/wwm-reserved-regs-not-a-reg.mir
@@ -1,4 +1,4 @@
-# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o /dev/null 2>&1 | FileCheck -check-prefix=ERR %s
 
 ---
 name: invalid_reg

--- a/llvm/test/CodeGen/MIR/AMDGPU/wwm-reserved-regs.mir
+++ b/llvm/test/CodeGen/MIR/AMDGPU/wwm-reserved-regs.mir
@@ -1,5 +1,5 @@
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -verify-machineinstrs %s -o - | FileCheck %s
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -simplify-mir -verify-machineinstrs %s -o - | FileCheck %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none %s -o - | FileCheck %s
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -run-pass=none -simplify-mir %s -o - | FileCheck %s
 
 # CHECK-LABEL: name: empty_wwm_regs{{$}}
 # CHECK: machineFunctionInfo:


### PR DESCRIPTION
Similar to #150024, this one is for `llvm/test/CodeGen/MIR/AMDGPU/`.