### PR TITLE
[clang] Rename files that MacOS libtool warns about (NFC)

### DIFF
--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -117,17 +117,17 @@ add_clang_library(clangCodeGen
   PatternInit.cpp
   SanitizerMetadata.cpp
   SwiftCallingConv.cpp
-  TargetBuiltins/ARM.cpp
-  TargetBuiltins/AMDGPU.cpp
-  TargetBuiltins/DirectX.cpp
-  TargetBuiltins/Hexagon.cpp
-  TargetBuiltins/NVPTX.cpp
-  TargetBuiltins/PPC.cpp
-  TargetBuiltins/RISCV.cpp
-  TargetBuiltins/SPIR.cpp
-  TargetBuiltins/SystemZ.cpp
-  TargetBuiltins/WebAssembly.cpp
-  TargetBuiltins/X86.cpp
+  TargetBuiltins/BuiltinARM.cpp
+  TargetBuiltins/BuiltinAMDGPU.cpp
+  TargetBuiltins/BuiltinDirectX.cpp
+  TargetBuiltins/BuiltinHexagon.cpp
+  TargetBuiltins/BuiltinNVPTX.cpp
+  TargetBuiltins/BuiltinPPC.cpp
+  TargetBuiltins/BuiltinRISCV.cpp
+  TargetBuiltins/BuiltinSPIR.cpp
+  TargetBuiltins/BuiltinSystemZ.cpp
+  TargetBuiltins/BuiltinWebAssembly.cpp
+  TargetBuiltins/BuiltinX86.cpp
   TargetInfo.cpp
   Targets/AArch64.cpp
   Targets/AMDGPU.cpp

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinAMDGPU.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinAMDGPU.cpp
@@ -1,4 +1,4 @@
-//===------- AMDCPU.cpp - Emit LLVM Code for builtins ---------------------===//
+//===------- BuiltinAMDGPU.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinARM.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinARM.cpp
@@ -1,4 +1,4 @@
-//===---------- ARM.cpp - Emit LLVM Code for builtins ---------------------===//
+//===---------- BuiltinARM.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinDirectX.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinDirectX.cpp
@@ -1,4 +1,4 @@
-//===--------- DirectX.cpp - Emit LLVM Code for builtins ------------------===//
+//===--------- BuiltinDirectX.cpp - Emit LLVM Code for builtins -----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinHexagon.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinHexagon.cpp
@@ -1,4 +1,4 @@
-//===------ Hexagon.cpp - Emit LLVM Code for builtins ---------------------===//
+//===------ BuiltinHexagon.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinNVPTX.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinNVPTX.cpp
@@ -1,4 +1,4 @@
-//===-------- NVPTX.cpp - Emit LLVM Code for builtins ---------------------===//
+//===-------- BuiltinNVPTX.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinPPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinPPC.cpp
@@ -1,4 +1,4 @@
-//===---------- PPC.cpp - Emit LLVM Code for builtins ---------------------===//
+//===---------- BuiltinPPC.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinRISCV.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinRISCV.cpp
@@ -1,4 +1,4 @@
-//===-------- RISCV.cpp - Emit LLVM Code for builtins ---------------------===//
+//===-------- BuiltinRISCV.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinSPIR.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinSPIR.cpp
@@ -1,4 +1,4 @@
-//===--------- SPIR.cpp - Emit LLVM Code for builtins ---------------------===//
+//===--------- BuiltinSPIR.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinSystemZ.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinSystemZ.cpp
@@ -1,4 +1,4 @@
-//===------ SystemZ.cpp - Emit LLVM Code for builtins ---------------------===//
+//===------ BuiltinSystemZ.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinWebAssembly.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinWebAssembly.cpp
@@ -1,4 +1,4 @@
-//===-- WebAssembly.cpp - Emit LLVM Code for builtins ---------------------===//
+//===-- BuiltinWebAssembly.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/clang/lib/CodeGen/TargetBuiltins/BuiltinX86.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/BuiltinX86.cpp
@@ -1,4 +1,4 @@
-//===---------- X86.cpp - Emit LLVM Code for builtins ---------------------===//
+//===---------- BuiltinX86.cpp - Emit LLVM Code for builtins --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.


### PR DESCRIPTION
As mentioned in https://discourse.llvm.org/t/rfc-rename-source-files-in-clang-lib-codegen-targetbuiltins/87462/ it appears that MacOS's libtool warns about source filenames that are identically named, even if they exist in separate directories.

Sadly, there doesn't appear to be an easy way to disable this warning, so rename these files, as these warnings are annoying for MacOS users.

Fixes #133199.