### PR TITLE
[DAG] optimize llvm.ucmp for 1-bit inputs to return subtraction of operands

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -10942,6 +10942,10 @@ SDValue TargetLowering::expandCMP(SDNode *Node, SelectionDAG &DAG) const {
   SDValue IsLT = DAG.getSetCC(dl, BoolVT, LHS, RHS, LTPredicate);
   SDValue IsGT = DAG.getSetCC(dl, BoolVT, LHS, RHS, GTPredicate);
 
+  if (isa<VTSDNode>(RHS->getOperand(1)) &&
+      cast<VTSDNode>(RHS->getOperand(1))->getVT().getScalarSizeInBits() == 1) {
+    return DAG.getNode(ISD::SUB, dl, VT, LHS, RHS);
+  }
   // We can't perform arithmetic on i1 values. Extending them would
   // probably result in worse codegen, so let's just use two selects instead.
   // Some targets are also just better off using selects rather than subtraction

--- a/llvm/test/CodeGen/Generic/ucmp_i1.ll
+++ b/llvm/test/CodeGen/Generic/ucmp_i1.ll
@@ -1,0 +1,13 @@
+; RUN: llc -o - %s | FileCheck %s
+define i8 @test_ucmp_i8_i1(i1 zeroext %a, i1 zeroext %b) {
+  %cmp = call i8 @llvm.ucmp.i8.i1(i1 %a, i1 %b)
+  ret i8 %cmp
+}
+
+define i16 @test_ucmp_i16_i1(i1 zeroext %a, i1 zeroext %b) {
+  %cmp = call i16 @llvm.ucmp.i16.i1(i1 %a, i1 %b)
+  ret i16 %cmp
+}
+
+declare i8 @llvm.ucmp.i8.i1(i1, i1)
+declare i16 @llvm.ucmp.i16.i1(i1, i1)


### PR DESCRIPTION
## Description

Fixes: https://github.com/llvm/llvm-project/issues/129401

I came across contributor guide for InstCombine: https://llvm.org/docs/InstCombineContributorGuide.html, do we've a similar guide for SelectionDAG?

I still need to figure out how to run tests locally to ensure that my changes don't break anything (not necessarily relying on CI).