### PR TITLE
Fix switches for non-windows platforms, regression fix for #144745

### DIFF
--- a/clang/test/CodeGenCXX/microsoft-abi-eh-disabled.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-eh-disabled.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cl -c --target=x86_64-windows-msvc /EHs-c- -O2 /GS- \
+// RUN: %clang_cl -c --target=x86_64-windows-msvc -EHs-c- -O2 -GS- \
 // RUN:   -Xclang=-import-call-optimization \
-// RUN:   /clang:-S /clang:-o- %s 2>&1 \
+// RUN:   -clang:-S -clang:-o- -- %s 2>&1 \
 // RUN:   | FileCheck %s
 
 #ifdef __clang__

--- a/clang/test/CodeGenCXX/microsoft-abi-eh-ip2state.cpp
+++ b/clang/test/CodeGenCXX/microsoft-abi-eh-ip2state.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 /EHsc /GS- \
+// RUN: %clang_cl -c --target=x86_64-windows-msvc -O2 -EHsc -GS- \
 // RUN:   -Xclang=-import-call-optimization \
-// RUN:   /clang:-S /clang:-o- %s 2>&1 \
+// RUN:   -clang:-S -clang:-o- -- %s 2>&1 \
 // RUN:   | FileCheck %s
 
 #ifdef __clang__


### PR DESCRIPTION
Fix `-` vs `/` paths for non-Windows platforms for integration tests in #144745
