### PR TITLE
[WIP][CFI][LTO] Avoid duplicate symbols on aliased weak function

### DIFF
--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -1135,7 +1135,6 @@ void LowerTypeTestsModule::importFunction(
   } else {
     F->setName(Name + ".cfi");
     maybeReplaceComdat(F, Name);
-    F->setLinkage(GlobalValue::ExternalLinkage);
     FDecl = Function::Create(F->getFunctionType(), GlobalValue::ExternalLinkage,
                              F->getAddressSpace(), Name, &M);
     FDecl->setVisibility(Visibility);


### PR DESCRIPTION
Problem is that LowerTypeTests expects that only one
definition will be left by LTO for a symbol.

However, thanks to strong alias, weak non-prevaling
definition can be preserved.

So strong and weak function definition will be renamed to strong .cfi,
making them duplicate.

Fixes #150070.
