### PR TITLE
[libc] Expose the Sign type for shared use

### DIFF
--- a/libc/shared/sign.h
+++ b/libc/shared/sign.h
@@ -1,0 +1,23 @@
+//===-- Shared sign type ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SHARED_SIGN_H
+#define LLVM_LIBC_SHARED_SIGN_H
+
+#include "libc_common.h"
+#include "src/__support/sign.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace shared {
+
+using LIBC_NAMESPACE_DECL::Sign;
+
+} // namespace shared
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_SIGN_H


### PR DESCRIPTION
This patch exposes the internal `Sign` type for shared use by other LLVM subprojects, following the pattern established by `FPBits`.

The `FPBits` utility is exposed via `libc/shared/fp_bits.h`. However, its public interface relies on the `Sign` type for, e.g., creating signed infinities and returning the sign of a value. Currently, users of the shared `FPBits` have no way to access the `Sign` type.

Following the existing pattern for sharing `libc` utilities, this patch adds a new public header `libc/shared/sign.h`. This header simply includes the internal `src/__support/sign.h` and brings the `Sign` type into the `shared` namespace.