### PR TITLE
[AArch64] Exhaustively have all flag and non-flag instructions map to each other

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -1417,6 +1417,26 @@ static unsigned convertToNonFlagSettingOpc(const MachineInstr &MI) {
     return MIDefinesZeroReg ? AArch64::ADDSXrs : AArch64::ADDXrs;
   case AArch64::ADDSXrx:
     return AArch64::ADDXrx;
+  case AArch64::ANDSWri:
+    return AArch64::ANDWri;
+  case AArch64::ANDSWrr:
+    return AArch64::ANDWrr;
+  case AArch64::ANDSWrs:
+    return AArch64::ANDWrs;
+  case AArch64::ANDSXri:
+    return AArch64::ANDXri;
+  case AArch64::ANDSXrr:
+    return AArch64::ANDXrr;
+  case AArch64::ANDSXrs:
+    return AArch64::ANDXrs;
+  case AArch64::BICSWrr:
+    return AArch64::BICWrr;
+  case AArch64::BICSWrs:
+    return AArch64::BICWrs;
+  case AArch64::BICSXrr:
+    return AArch64::BICXrr;
+  case AArch64::BICSXrs:
+    return AArch64::BICXrs;
   case AArch64::SUBSWrr:
     return AArch64::SUBWrr;
   case AArch64::SUBSWri:
@@ -1433,6 +1453,14 @@ static unsigned convertToNonFlagSettingOpc(const MachineInstr &MI) {
     return MIDefinesZeroReg ? AArch64::SUBSXrs : AArch64::SUBXrs;
   case AArch64::SUBSXrx:
     return AArch64::SUBXrx;
+  case AArch64::SBCSXr:
+    return AArch64::SBCXr;
+  case AArch64::SBCSWr:
+    return AArch64::SBCWr;
+  case AArch64::ADCSXr:
+    return AArch64::ADCXr;
+  case AArch64::ADCSWr:
+    return AArch64::ADCWr;
   }
 }
 
@@ -2861,6 +2889,14 @@ unsigned AArch64InstrInfo::convertToFlagSettingOpc(unsigned Opc) {
     return AArch64::SUBSXrs;
   case AArch64::SUBXrx:
     return AArch64::SUBSXrx;
+  case AArch64::SBCXr:
+    return AArch64::SBCSXr;
+  case AArch64::SBCWr:
+    return AArch64::SBCSWr;
+  case AArch64::ADCXr:
+    return AArch64::ADCSXr;
+  case AArch64::ADCWr:
+    return AArch64::ADCSWr;
   // SVE instructions:
   case AArch64::AND_PPzPP:
     return AArch64::ANDS_PPzPP;

--- a/llvm/lib/Target/AArch64/GISel/AArch64PostSelectOptimize.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64PostSelectOptimize.cpp
@@ -71,6 +71,10 @@ unsigned getNonFlagSettingVariant(unsigned Opc) {
     return AArch64::SUBXrs;
   case AArch64::SUBSWrs:
     return AArch64::SUBWrs;
+  case AArch64::SUBSWrx:
+    return AArch64::SUBWrx;
+  case AArch64::SUBSXrx:
+    return AArch64::SUBXrx;
   case AArch64::SUBSXri:
     return AArch64::SUBXri;
   case AArch64::SUBSWri:
@@ -83,6 +87,10 @@ unsigned getNonFlagSettingVariant(unsigned Opc) {
     return AArch64::ADDXrs;
   case AArch64::ADDSWrs:
     return AArch64::ADDWrs;
+  case AArch64::ADDSWrx:
+    return AArch64::ADDWrx;
+  case AArch64::ADDSXrx:
+    return AArch64::ADDXrx;
   case AArch64::ADDSXri:
     return AArch64::ADDXri;
   case AArch64::ADDSWri:
@@ -95,6 +103,26 @@ unsigned getNonFlagSettingVariant(unsigned Opc) {
     return AArch64::ADCXr;
   case AArch64::ADCSWr:
     return AArch64::ADCWr;
+  case AArch64::ANDSWri:
+    return AArch64::ANDWri;
+  case AArch64::ANDSWrr:
+    return AArch64::ANDWrr;
+  case AArch64::ANDSWrs:
+    return AArch64::ANDWrs;
+  case AArch64::ANDSXri:
+    return AArch64::ANDXri;
+  case AArch64::ANDSXrr:
+    return AArch64::ANDXrr;
+  case AArch64::ANDSXrs:
+    return AArch64::ANDXrs;
+  case AArch64::BICSWrr:
+    return AArch64::BICWrr;
+  case AArch64::BICSWrs:
+    return AArch64::BICWrs;
+  case AArch64::BICSXrr:
+    return AArch64::BICXrr;
+  case AArch64::BICSXrs:
+    return AArch64::BICXrs;
   }
 }
 

--- a/llvm/test/CodeGen/AArch64/GlobalISel/postselectopt-dead-cc-defs-in-fcmp.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/postselectopt-dead-cc-defs-in-fcmp.mir
@@ -164,6 +164,54 @@ body:             |
     RET_ReallyLR implicit $x0
 ...
 ---
+name:            test_impdef_addsrx
+alignment:       4
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: test_impdef_addsrx
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64sp = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
+    ; CHECK-NEXT: [[ADDXrx:%[0-9]+]]:gpr64common = ADDXrx [[COPY]], [[COPY1]], 18
+    ; CHECK-NEXT: $x0 = COPY [[ADDXrx]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
+    %1:gpr64sp = COPY $x0
+    %2:gpr32 = COPY $w1
+    %4:gpr64 = ADDSXrx %1, %2, 18, implicit-def $nzcv
+    $x0 = COPY %4
+    RET_ReallyLR implicit $x0
+...
+---
+name:            test_impdef_subsrx
+alignment:       4
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $x0, $w1
+    ; CHECK-LABEL: name: test_impdef_subsrx
+    ; CHECK: liveins: $x0, $w1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr64sp = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32 = COPY $w1
+    ; CHECK-NEXT: [[SUBXrx:%[0-9]+]]:gpr64common = SUBXrx [[COPY]], [[COPY1]], 18
+    ; CHECK-NEXT: $x0 = COPY [[SUBXrx]]
+    ; CHECK-NEXT: RET_ReallyLR implicit $x0
+    %1:gpr64sp = COPY $x0
+    %2:gpr32 = COPY $w1
+    %4:gpr64 = SUBSXrx %1, %2, 18, implicit-def $nzcv
+    $x0 = COPY %4
+    RET_ReallyLR implicit $x0
+...
+---
 name:            test_impdef_subsw
 alignment:       4
 legalized:       true


### PR DESCRIPTION
They are both missing entries from each other.