### PR TITLE
[mlir][ArithToAMDGPU][NFC] Add PatternBenefit

### DIFF
--- a/mlir/include/mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h
+++ b/mlir/include/mlir/Conversion/ArithToAMDGPU/ArithToAMDGPU.h
@@ -10,6 +10,7 @@
 #define MLIR_CONVERSION_ARITHTOAMDGPU_ARITHTOAMDGPU_H
 
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
+#include "mlir/IR/PatternMatch.h"
 #include <memory>
 #include <string>
 
@@ -31,7 +32,8 @@ void populateArithToAMDGPUConversionPatterns(RewritePatternSet &patterns,
                                              bool convertFP8Arithmetic,
                                              bool saturateFP8Truncf,
                                              bool allowPackedF16Rtz,
-                                             amdgpu::Chipset chipset);
+                                             amdgpu::Chipset chipset,
+                                             PatternBenefit benefit = 1);
 } // namespace arith
 } // namespace mlir
 


### PR DESCRIPTION
Since there may be caseses where these patterns are run alongside the generic patterns from ArithExpandOps, add a PatternBenefit argument to allow these architecture-specific patterns to be prioritized.