### PR TITLE
[MC] Relaxable Fragments Can be Linker Relaxable

### DIFF
--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -777,6 +777,14 @@ bool MCAssembler::relaxInstruction(MCFragment &F) {
   getEmitter().encodeInstruction(Relaxed, Data, Fixups, *F.getSubtargetInfo());
   F.setVarContents(Data);
   F.setVarFixups(Fixups);
+
+  for (const auto &Fixup : Fixups) {
+    if (!Fixup.isLinkerRelaxable())
+      continue;
+    F.setLinkerRelaxable();
+    F.getParent()->setLinkerRelaxable();
+  }
+
   return true;
 }
 

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -269,7 +269,7 @@ bool MCExpr::evaluateAsAbsolute(int64_t &Res, const MCAssembler *Asm,
   return IsRelocatable && Value.isAbsolute() && Value.getSpecifier() == 0;
 }
 
-/// Helper method for \see EvaluateSymbolAdd().
+/// Helper method for \see evaluateSymbolicAdd().
 static void attemptToFoldSymbolOffsetDifference(const MCAssembler *Asm,
                                                 bool InSet, const MCSymbol *&A,
                                                 const MCSymbol *&B,
@@ -361,6 +361,9 @@ static void attemptToFoldSymbolOffsetDifference(const MCAssembler *Asm,
         if (BBeforeRelax && AAfterRelax)
           return;
       }
+      if (F->getKind() == MCFragment::FT_Relaxable && Asm->hasFinalLayout() && F->isLinkerRelaxable())
+        // FIXME: More accurate calculation of AAfterRelax/BBeforeRelax?
+        return;
       if (&*F == FA) {
         // If FA and FB belong to the same subsection, the loop will find FA and
         // we can resolve the difference.

--- a/llvm/lib/MC/MCExpr.cpp
+++ b/llvm/lib/MC/MCExpr.cpp
@@ -361,7 +361,8 @@ static void attemptToFoldSymbolOffsetDifference(const MCAssembler *Asm,
         if (BBeforeRelax && AAfterRelax)
           return;
       }
-      if (F->getKind() == MCFragment::FT_Relaxable && Asm->hasFinalLayout() && F->isLinkerRelaxable())
+      if (F->getKind() == MCFragment::FT_Relaxable && Asm->hasFinalLayout() &&
+          F->isLinkerRelaxable())
         // FIXME: More accurate calculation of AAfterRelax/BBeforeRelax?
         return;
       if (&*F == FA) {

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -68,6 +68,8 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
       OS << "\n  Fixup @" << F.getOffset() << " Value:";
       F.getValue()->print(OS, nullptr);
       OS << " Kind:" << F.getKind();
+      if (F.isLinkerRelaxable())
+        OS << " LinkerRelaxable";
     }
   };
 

--- a/llvm/lib/MC/MCSection.cpp
+++ b/llvm/lib/MC/MCSection.cpp
@@ -41,6 +41,8 @@ LLVM_DUMP_METHOD void MCSection::dump(
   raw_ostream &OS = errs();
 
   OS << "MCSection Name:" << getName();
+  if (isLinkerRelaxable())
+    OS << " LinkerRelaxable";
   for (auto &F : *this) {
     OS << '\n';
     F.dump();

--- a/llvm/test/MC/RISCV/linker-relaxation-pr150071.s
+++ b/llvm/test/MC/RISCV/linker-relaxation-pr150071.s
@@ -1,0 +1,18 @@
+# RUN: llvm-mc --triple=riscv32 -mattr=+relax,+experimental-xqcilb \
+# RUN:    %s -filetype=obj -o - -riscv-add-build-attributes \
+# RUN:    | llvm-objdump -dr - \
+# RUN:    | FileCheck %s
+
+.global foo
+
+bar:
+  jal x1, foo
+# CHECK: qc.e.jal 0x0 <bar>
+# CHECK-NEXT: R_RISCV_VENDOR QUALCOMM
+# CHECK-NEXT: R_RISCV_CUSTOM195 foo
+# CHECK-NEXT: R_RISCV_RELAX *ABS*
+  bne a0, a1, bar
+# CHECK-NEXT: bne a0, a1, 0x6 <bar+0x6>
+# CHECK-NEXT: R_RISCV_BRANCH bar
+  ret
+# CHECK-NEXT: ret


### PR DESCRIPTION
When relaxing a relaxable fragment, the new fixup may end up being linker relaxable (when the one before relaxation was not).

This change ensures that:
- a new linker-relaxable fixup propagates that info into the fragment and the section.
- linker-relaxable relaxable fragments are handled in attemptToFoldSymbolOffsetDifference.

Fixes: #150071