### PR TITLE
[LLDB] Add formatters for MSVC STL std::deque

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/CPlusPlus/CMakeLists.txt
@@ -35,6 +35,7 @@ add_lldb_library(lldbPluginCPlusPlusLanguage PLUGIN
   LibStdcppUniquePointer.cpp
   MsvcStl.cpp
   MsvcStlAtomic.cpp
+  MsvcStlDeque.cpp
   MsvcStlSmartPointer.cpp
   MsvcStlTree.cpp
   MsvcStlTuple.cpp

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStl.h
@@ -103,6 +103,12 @@ bool IsMsvcStlMapLike(ValueObject &valobj);
 lldb_private::SyntheticChildrenFrontEnd *
 MsvcStlMapLikeSyntheticFrontEndCreator(lldb::ValueObjectSP valobj_sp);
 
+// MSVC STL std::deque<>
+bool IsMsvcStlDeque(ValueObject &valobj);
+SyntheticChildrenFrontEnd *
+MsvcStlDequeSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                     lldb::ValueObjectSP valobj_sp);
+
 } // namespace formatters
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlDeque.cpp
@@ -1,0 +1,174 @@
+//===-- MsvcStlDeque.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "MsvcStl.h"
+
+#include "lldb/DataFormatters/FormattersHelpers.h"
+#include "lldb/DataFormatters/TypeSynthetic.h"
+
+using namespace lldb;
+
+namespace lldb_private {
+namespace formatters {
+
+class MsvcStlDequeSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+public:
+  MsvcStlDequeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
+
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
+
+  lldb::ChildCacheState Update() override;
+
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
+
+private:
+  ValueObject *m_map = nullptr;
+  ExecutionContextRef m_exe_ctx_ref;
+
+  size_t m_block_size = 0;
+  size_t m_offset = 0;
+  size_t m_map_size = 0;
+
+  size_t m_element_size = 0;
+  CompilerType m_element_type;
+
+  uint32_t m_size = 0;
+};
+
+} // namespace formatters
+} // namespace lldb_private
+
+lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::
+    MsvcStlDequeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+    : SyntheticChildrenFrontEnd(*valobj_sp) {
+  if (valobj_sp)
+    Update();
+}
+
+llvm::Expected<uint32_t> lldb_private::formatters::
+    MsvcStlDequeSyntheticFrontEnd::CalculateNumChildren() {
+  if (!m_map)
+    return llvm::createStringError("Failed to read size");
+  return m_size;
+}
+
+lldb::ValueObjectSP
+lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::GetChildAtIndex(
+    uint32_t idx) {
+  if (idx >= m_size || !m_map)
+    return nullptr;
+  ProcessSP process_sp(m_exe_ctx_ref.GetProcessSP());
+  if (!process_sp)
+    return nullptr;
+
+  // _EEN_DS = _Block_size
+  // _Map[(($i + _Myoff) / _EEN_DS) % _Mapsize][($i + _Myoff) % _EEN_DS]
+  size_t first_idx = ((idx + m_offset) / m_block_size) % m_map_size;
+  lldb::addr_t first_address = m_map->GetValueAsUnsigned(0) +
+                               first_idx * process_sp->GetAddressByteSize();
+
+  Status err;
+  lldb::addr_t second_base =
+      process_sp->ReadPointerFromMemory(first_address, err);
+  if (err.Fail())
+    return nullptr;
+
+  size_t second_idx = (idx + m_offset) % m_block_size;
+  size_t second_address = second_base + second_idx * m_element_size;
+
+  StreamString name;
+  name.Printf("[%" PRIu64 "]", (uint64_t)idx);
+  return CreateValueObjectFromAddress(name.GetString(), second_address,
+                                      m_backend.GetExecutionContextRef(),
+                                      m_element_type);
+}
+
+lldb::ChildCacheState
+lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::Update() {
+  m_size = 0;
+  m_map = nullptr;
+  m_element_type.Clear();
+
+  auto storage_sp = m_backend.GetChildAtNamePath({"_Mypair", "_Myval2"});
+  if (!storage_sp)
+    return lldb::eRefetch;
+
+  auto deque_type = m_backend.GetCompilerType();
+  if (!deque_type)
+    return lldb::eRefetch;
+
+  auto block_size_decl = deque_type.GetStaticFieldWithName("_Block_size");
+  if (!block_size_decl)
+    return lldb::eRefetch;
+  auto block_size = block_size_decl.GetConstantValue();
+  if (!block_size.IsValid())
+    return lldb::eRefetch;
+
+  auto element_type = deque_type.GetTypeTemplateArgument(0);
+  if (!element_type)
+    return lldb::eRefetch;
+  auto element_size = element_type.GetByteSize(nullptr);
+  if (!element_size)
+    return lldb::eRefetch;
+
+  auto offset_sp = storage_sp->GetChildMemberWithName("_Myoff");
+  auto map_size_sp = storage_sp->GetChildMemberWithName("_Mapsize");
+  auto map_sp = storage_sp->GetChildMemberWithName("_Map");
+  auto size_sp = storage_sp->GetChildMemberWithName("_Mysize");
+  if (!offset_sp || !map_size_sp || !map_sp || !size_sp)
+    return lldb::eRefetch;
+
+  bool ok = false;
+  uint64_t offset = offset_sp->GetValueAsUnsigned(0, &ok);
+  if (!ok)
+    return lldb::eRefetch;
+
+  uint64_t map_size = map_size_sp->GetValueAsUnsigned(0, &ok);
+  if (!ok)
+    return lldb::eRefetch;
+
+  uint64_t size = size_sp->GetValueAsUnsigned(0, &ok);
+  if (!ok)
+    return lldb::eRefetch;
+
+  m_map = map_sp.get();
+  m_exe_ctx_ref = m_backend.GetExecutionContextRef();
+  m_block_size = block_size.ULongLong();
+  m_offset = offset;
+  m_map_size = map_size;
+  m_element_size = *element_size;
+  m_element_type = element_type;
+  m_size = size;
+  return lldb::eRefetch;
+}
+
+llvm::Expected<size_t> lldb_private::formatters::MsvcStlDequeSyntheticFrontEnd::
+    GetIndexOfChildWithName(ConstString name) {
+  if (!m_map)
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
+  if (auto optional_idx = ExtractIndexFromString(name.GetCString()))
+    return *optional_idx;
+
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
+}
+
+bool lldb_private::formatters::IsMsvcStlDeque(ValueObject &valobj) {
+  if (auto valobj_sp = valobj.GetNonSyntheticValue())
+    return valobj_sp->GetChildMemberWithName("_Mypair") != nullptr;
+  return false;
+}
+
+lldb_private::SyntheticChildrenFrontEnd *
+lldb_private::formatters::MsvcStlDequeSyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  return new MsvcStlDequeSyntheticFrontEnd(valobj_sp);
+}

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
@@ -3,9 +3,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-USE_LIBSTDCPP = "USE_LIBSTDCPP"
-USE_LIBCPP = "USE_LIBCPP"
-
 
 class GenericDequeDataFormatterTestCase(TestBase):
     def findVariable(self, name):
@@ -56,8 +53,7 @@ class GenericDequeDataFormatterTestCase(TestBase):
             ],
         )
 
-    def do_test(self, stdlib_type):
-        self.build(dictionary={stdlib_type: "1"})
+    def do_test(self):
         (_, process, _, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp")
         )
@@ -135,15 +131,22 @@ class GenericDequeDataFormatterTestCase(TestBase):
 
     @add_test_categories(["libstdcxx"])
     def test_libstdcpp(self):
-        self.do_test(USE_LIBSTDCPP)
+        self.build(dictionary={"USE_LIBSTDCPP": 1})
+        self.do_test()
 
     @add_test_categories(["libc++"])
     def test_libcpp(self):
-        self.do_test(USE_LIBCPP)
+        self.build(dictionary={"USE_LIBCPP": 1})
+        self.do_test()
 
-    def do_test_ref_and_ptr(self, stdlib_type: str):
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl(self):
+        # No flags, because the "msvcstl" category checks that the MSVC STL is used by default.
+        self.build()
+        self.do_test()
+
+    def do_test_ref_and_ptr(self):
         """Test formatting of std::deque& and std::deque*"""
-        self.build(dictionary={stdlib_type: "1"})
         (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "stop here", lldb.SBFileSpec("main.cpp", False)
         )
@@ -157,8 +160,15 @@ class GenericDequeDataFormatterTestCase(TestBase):
 
     @add_test_categories(["libstdcxx"])
     def test_libstdcpp_ref_and_ptr(self):
-        self.do_test_ref_and_ptr(USE_LIBSTDCPP)
+        self.build(dictionary={"USE_LIBSTDCPP": 1})
+        self.do_test_ref_and_ptr()
 
     @add_test_categories(["libc++"])
     def test_libcpp_ref_and_ptr(self):
-        self.do_test_ref_and_ptr(USE_LIBCPP)
+        self.build(dictionary={"USE_LIBCPP": 1})
+        self.do_test_ref_and_ptr()
+
+    @add_test_categories(["msvcstl"])
+    def test_msvcstl_ref_and_ptr(self):
+        self.build()
+        self.do_test_ref_and_ptr()


### PR DESCRIPTION
This PR adds synthetic children for std::deque from MSVC's STL.

Similar to libstdc++ and libc++, the elements are in a `T**`, so we need to "subscript" twice. The [NatVis for deque](https://github.com/microsoft/STL/blob/313964b78a8fd5a52e7965e13781f735bcce13c5/stl/debugger/STL.natvis#L1103-L1112) uses `_EEN_DS` which contains the block size. We can't access this, but we can access the [constexpr `_Block_size`](https://github.com/microsoft/STL/blob/313964b78a8fd5a52e7965e13781f735bcce13c5/stl/inc/deque#L641).

Towards #24834.