### PR TITLE
[llvm] annotate recently added interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -227,7 +227,7 @@ public:
   LLVM_ABI static VocabVector createDummyVocabForTest(unsigned Dim = 1);
 
   LLVM_ABI bool invalidate(Module &M, const PreservedAnalyses &PA,
-                  ModuleAnalysisManager::Invalidator &Inv) const;
+                           ModuleAnalysisManager::Invalidator &Inv) const;
 };
 
 /// Embedder provides the interface to generate embeddings (vector

--- a/llvm/include/llvm/Analysis/IR2Vec.h
+++ b/llvm/include/llvm/Analysis/IR2Vec.h
@@ -164,37 +164,37 @@ class Vocabulary {
 
 public:
   Vocabulary() = default;
-  Vocabulary(VocabVector &&Vocab);
+  LLVM_ABI Vocabulary(VocabVector &&Vocab);
 
-  bool isValid() const;
-  unsigned getDimension() const;
-  size_t size() const;
+  LLVM_ABI bool isValid() const;
+  LLVM_ABI unsigned getDimension() const;
+  LLVM_ABI size_t size() const;
 
   static size_t expectedSize() {
     return MaxOpcodes + MaxTypeIDs + MaxOperandKinds;
   }
 
   /// Helper function to get vocabulary key for a given Opcode
-  static StringRef getVocabKeyForOpcode(unsigned Opcode);
+  LLVM_ABI static StringRef getVocabKeyForOpcode(unsigned Opcode);
 
   /// Helper function to get vocabulary key for a given TypeID
-  static StringRef getVocabKeyForTypeID(Type::TypeID TypeID);
+  LLVM_ABI static StringRef getVocabKeyForTypeID(Type::TypeID TypeID);
 
   /// Helper function to get vocabulary key for a given OperandKind
-  static StringRef getVocabKeyForOperandKind(OperandKind Kind);
+  LLVM_ABI static StringRef getVocabKeyForOperandKind(OperandKind Kind);
 
   /// Helper function to classify an operand into OperandKind
-  static OperandKind getOperandKind(const Value *Op);
+  LLVM_ABI static OperandKind getOperandKind(const Value *Op);
 
   /// Helpers to return the IDs of a given Opcode, TypeID, or OperandKind
-  static unsigned getNumericID(unsigned Opcode);
-  static unsigned getNumericID(Type::TypeID TypeID);
-  static unsigned getNumericID(const Value *Op);
+  LLVM_ABI static unsigned getNumericID(unsigned Opcode);
+  LLVM_ABI static unsigned getNumericID(Type::TypeID TypeID);
+  LLVM_ABI static unsigned getNumericID(const Value *Op);
 
   /// Accessors to get the embedding for a given entity.
-  const ir2vec::Embedding &operator[](unsigned Opcode) const;
-  const ir2vec::Embedding &operator[](Type::TypeID TypeId) const;
-  const ir2vec::Embedding &operator[](const Value *Arg) const;
+  LLVM_ABI const ir2vec::Embedding &operator[](unsigned Opcode) const;
+  LLVM_ABI const ir2vec::Embedding &operator[](Type::TypeID TypeId) const;
+  LLVM_ABI const ir2vec::Embedding &operator[](const Value *Arg) const;
 
   /// Const Iterator type aliases
   using const_iterator = VocabVector::const_iterator;
@@ -221,12 +221,12 @@ public:
   /// Returns the string key for a given index position in the vocabulary.
   /// This is useful for debugging or printing the vocabulary. Do not use this
   /// for embedding generation as string based lookups are inefficient.
-  static StringRef getStringKey(unsigned Pos);
+  LLVM_ABI static StringRef getStringKey(unsigned Pos);
 
   /// Create a dummy vocabulary for testing purposes.
-  static VocabVector createDummyVocabForTest(unsigned Dim = 1);
+  LLVM_ABI static VocabVector createDummyVocabForTest(unsigned Dim = 1);
 
-  bool invalidate(Module &M, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(Module &M, const PreservedAnalyses &PA,
                   ModuleAnalysisManager::Invalidator &Inv) const;
 };
 

--- a/llvm/include/llvm/BinaryFormat/SFrame.h
+++ b/llvm/include/llvm/BinaryFormat/SFrame.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_BINARYFORMAT_SFRAME_H
 #define LLVM_BINARYFORMAT_SFRAME_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/Support/DataTypes.h"
@@ -163,9 +164,9 @@ template <endianness E> using FrameRowEntryAddr1 = FrameRowEntry<uint8_t, E>;
 template <endianness E> using FrameRowEntryAddr2 = FrameRowEntry<uint16_t, E>;
 template <endianness E> using FrameRowEntryAddr4 = FrameRowEntry<uint32_t, E>;
 
-ArrayRef<EnumEntry<Version>> getVersions();
-ArrayRef<EnumEntry<Flags>> getFlags();
-ArrayRef<EnumEntry<ABI>> getABIs();
+LLVM_ABI ArrayRef<EnumEntry<Version>> getVersions();
+LLVM_ABI ArrayRef<EnumEntry<Flags>> getFlags();
+LLVM_ABI ArrayRef<EnumEntry<ABI>> getABIs();
 
 } // namespace sframe
 } // namespace llvm

--- a/llvm/include/llvm/BinaryFormat/SFrame.h
+++ b/llvm/include/llvm/BinaryFormat/SFrame.h
@@ -15,9 +15,9 @@
 #ifndef LLVM_BINARYFORMAT_SFRAME_H
 #define LLVM_BINARYFORMAT_SFRAME_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitmaskEnum.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 #include "llvm/Support/Endian.h"
 

--- a/llvm/include/llvm/CodeGen/GCMetadata.h
+++ b/llvm/include/llvm/CodeGen/GCMetadata.h
@@ -101,11 +101,11 @@ private:
   // are live per safe point (1.5% on 64-bit hosts).
 
 public:
-  GCFunctionInfo(const Function &F, GCStrategy &S);
-  ~GCFunctionInfo();
+  LLVM_ABI GCFunctionInfo(const Function &F, GCStrategy &S);
+  LLVM_ABI ~GCFunctionInfo();
 
   /// Handle invalidation explicitly.
-  bool invalidate(Function &F, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(Function &F, const PreservedAnalyses &PA,
                   FunctionAnalysisManager::Invalidator &Inv);
 
   /// getFunction - Return the function to which this metadata applies.
@@ -163,7 +163,7 @@ public:
   GCStrategyMap(GCStrategyMap &&) = default;
 
   /// Handle invalidation explicitly.
-  bool invalidate(Module &M, const PreservedAnalyses &PA,
+  LLVM_ABI bool invalidate(Module &M, const PreservedAnalyses &PA,
                   ModuleAnalysisManager::Invalidator &Inv);
 
   using iterator = MapT::iterator;
@@ -205,7 +205,7 @@ class CollectorMetadataAnalysis
 
 public:
   using Result = GCStrategyMap;
-  Result run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI Result run(Module &M, ModuleAnalysisManager &MAM);
 };
 
 /// An analysis pass which caches information about the Function.
@@ -217,7 +217,7 @@ class GCFunctionAnalysis : public AnalysisInfoMixin<GCFunctionAnalysis> {
 
 public:
   using Result = GCFunctionInfo;
-  Result run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI Result run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 /// LowerIntrinsics - This pass rewrites calls to the llvm.gcread or
@@ -228,7 +228,7 @@ public:
 /// This pass requires `CollectorMetadataAnalysis`.
 class GCLoweringPass : public PassInfoMixin<GCLoweringPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 /// An analysis pass which caches information about the entire Module.
@@ -244,7 +244,7 @@ public:
   /// Lookup the GCStrategy object associated with the given gc name.
   /// Objects are owned internally; No caller should attempt to delete the
   /// returned objects.
-  GCStrategy *getGCStrategy(const StringRef Name);
+  LLVM_ABI GCStrategy *getGCStrategy(const StringRef Name);
 
   /// List of per function info objects.  In theory, Each of these
   /// may be associated with a different GC.
@@ -265,14 +265,14 @@ private:
 public:
   using iterator = SmallVector<std::unique_ptr<GCStrategy>, 1>::const_iterator;
 
-  static char ID;
+  LLVM_ABI static char ID;
 
-  GCModuleInfo();
+  LLVM_ABI GCModuleInfo();
 
   /// clear - Resets the pass. Any pass, which uses GCModuleInfo, should
   /// call it in doFinalization().
   ///
-  void clear();
+  LLVM_ABI void clear();
 
   /// begin/end - Iterators for used strategies.
   ///
@@ -282,7 +282,7 @@ public:
   /// get - Look up function metadata.  This is currently assumed
   /// have the side effect of initializing the associated GCStrategy.  That
   /// will soon change.
-  GCFunctionInfo &getFunctionInfo(const Function &F);
+  LLVM_ABI GCFunctionInfo &getFunctionInfo(const Function &F);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/CodeGen/GCMetadata.h
+++ b/llvm/include/llvm/CodeGen/GCMetadata.h
@@ -106,7 +106,7 @@ public:
 
   /// Handle invalidation explicitly.
   LLVM_ABI bool invalidate(Function &F, const PreservedAnalyses &PA,
-                  FunctionAnalysisManager::Invalidator &Inv);
+                           FunctionAnalysisManager::Invalidator &Inv);
 
   /// getFunction - Return the function to which this metadata applies.
   const Function &getFunction() const { return F; }
@@ -164,7 +164,7 @@ public:
 
   /// Handle invalidation explicitly.
   LLVM_ABI bool invalidate(Module &M, const PreservedAnalyses &PA,
-                  ModuleAnalysisManager::Invalidator &Inv);
+                           ModuleAnalysisManager::Invalidator &Inv);
 
   using iterator = MapT::iterator;
   using const_iterator = MapT::const_iterator;

--- a/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineFunctionAnalysis.h
@@ -48,7 +48,7 @@ public:
 
 class FreeMachineFunctionPass : public PassInfoMixin<FreeMachineFunctionPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/CodeGen/MachineInstrBundle.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBundle.h
@@ -297,7 +297,7 @@ LLVM_ABI PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI,
 
 class FinalizeBundleTestPass : public PassInfoMixin<FinalizeBundleTestPass> {
 public:
-  PreservedAnalyses run(MachineFunction &MF,
+  LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM);
 };
 

--- a/llvm/include/llvm/CodeGen/MachineInstrBundle.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBundle.h
@@ -298,7 +298,7 @@ LLVM_ABI PhysRegInfo AnalyzePhysRegInBundle(const MachineInstr &MI,
 class FinalizeBundleTestPass : public PassInfoMixin<FinalizeBundleTestPass> {
 public:
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
-                        MachineFunctionAnalysisManager &MFAM);
+                                 MachineFunctionAnalysisManager &MFAM);
 };
 
 } // End llvm namespace

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCIndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCIndirectionUtils.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCINDIRECTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCINDIRECTIONUTILS_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
 #include "llvm/ExecutionEngine/Orc/LazyReexports.h"
@@ -33,7 +34,7 @@ class EPCIndirectionUtils {
 public:
   /// ABI support base class. Used to write resolver, stub, and trampoline
   /// blocks.
-  class ABISupport {
+  class LLVM_ABI ABISupport {
   protected:
     ABISupport(unsigned PointerSize, unsigned TrampolineSize, unsigned StubSize,
                unsigned StubToPointerMaxDisplacement, unsigned ResolverCodeSize)
@@ -81,7 +82,7 @@ public:
   CreateWithABI(ExecutorProcessControl &EPC);
 
   /// Create based on the ExecutorProcessControl triple.
-  static Expected<std::unique_ptr<EPCIndirectionUtils>>
+  LLVM_ABI static Expected<std::unique_ptr<EPCIndirectionUtils>>
   Create(ExecutorProcessControl &EPC);
 
   /// Create based on the ExecutorProcessControl triple.
@@ -98,12 +99,12 @@ public:
 
   /// Release memory for resources held by this instance. This *must* be called
   /// prior to destruction of the class.
-  Error cleanup();
+  LLVM_ABI Error cleanup();
 
   /// Write resolver code to the executor process and return its address.
   /// This must be called before any call to createTrampolinePool or
   /// createLazyCallThroughManager.
-  Expected<ExecutorAddr> writeResolverBlock(ExecutorAddr ReentryFnAddr,
+  LLVM_ABI Expected<ExecutorAddr> writeResolverBlock(ExecutorAddr ReentryFnAddr,
                                             ExecutorAddr ReentryCtxAddr);
 
   /// Returns the address of the Resolver block. Returns zero if the
@@ -111,14 +112,14 @@ public:
   ExecutorAddr getResolverBlockAddress() const { return ResolverBlockAddr; }
 
   /// Create an IndirectStubsManager for the executor process.
-  std::unique_ptr<IndirectStubsManager> createIndirectStubsManager();
+  LLVM_ABI std::unique_ptr<IndirectStubsManager> createIndirectStubsManager();
 
   /// Create a TrampolinePool for the executor process.
-  TrampolinePool &getTrampolinePool();
+  LLVM_ABI TrampolinePool &getTrampolinePool();
 
   /// Create a LazyCallThroughManager.
   /// This function should only be called once.
-  LazyCallThroughManager &
+  LLVM_ABI LazyCallThroughManager &
   createLazyCallThroughManager(ExecutionSession &ES,
                                ExecutorAddr ErrorHandlerAddr);
 
@@ -170,7 +171,7 @@ private:
 /// called.
 ///
 /// This function is experimental and likely subject to revision.
-Error setUpInProcessLCTMReentryViaEPCIU(EPCIndirectionUtils &EPCIU);
+LLVM_ABI Error setUpInProcessLCTMReentryViaEPCIU(EPCIndirectionUtils &EPCIU);
 
 namespace detail {
 

--- a/llvm/include/llvm/ExecutionEngine/Orc/EPCIndirectionUtils.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/EPCIndirectionUtils.h
@@ -14,10 +14,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_EPCINDIRECTIONUTILS_H
 #define LLVM_EXECUTIONENGINE_ORC_EPCINDIRECTIONUTILS_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ExecutionEngine/JITLink/JITLinkMemoryManager.h"
 #include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
 #include "llvm/ExecutionEngine/Orc/LazyReexports.h"
+#include "llvm/Support/Compiler.h"
 
 #include <mutex>
 
@@ -104,8 +104,8 @@ public:
   /// Write resolver code to the executor process and return its address.
   /// This must be called before any call to createTrampolinePool or
   /// createLazyCallThroughManager.
-  LLVM_ABI Expected<ExecutorAddr> writeResolverBlock(ExecutorAddr ReentryFnAddr,
-                                            ExecutorAddr ReentryCtxAddr);
+  LLVM_ABI Expected<ExecutorAddr>
+  writeResolverBlock(ExecutorAddr ReentryFnAddr, ExecutorAddr ReentryCtxAddr);
 
   /// Returns the address of the Resolver block. Returns zero if the
   /// writeResolverBlock method has not previously been called.

--- a/llvm/include/llvm/ExecutionEngine/Orc/SpeculateAnalyses.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SpeculateAnalyses.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SPECULATEANALYSES_H
 #define LLVM_EXECUTIONENGINE_ORC_SPECULATEANALYSES_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Analysis/BranchProbabilityInfo.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Speculation.h"
@@ -24,8 +25,8 @@ namespace orc {
 // Provides common code.
 class SpeculateQuery {
 protected:
-  void findCalles(const BasicBlock *, DenseSet<StringRef> &);
-  bool isStraightLine(const Function &F);
+  LLVM_ABI void findCalles(const BasicBlock *, DenseSet<StringRef> &);
+  LLVM_ABI bool isStraightLine(const Function &F);
 
 public:
   using ResultTy = std::optional<DenseMap<StringRef, DenseSet<StringRef>>>;
@@ -37,7 +38,7 @@ class BlockFreqQuery : public SpeculateQuery {
 
 public:
   // Find likely next executables based on IR Block Frequency
-  ResultTy operator()(Function &F);
+  LLVM_ABI ResultTy operator()(Function &F);
 };
 
 // This Query generates a sequence of basic blocks which follows the order of
@@ -73,7 +74,7 @@ private:
                            VisitedBlocksInfoTy &);
 
 public:
-  ResultTy operator()(Function &F);
+  LLVM_ABI ResultTy operator()(Function &F);
 };
 
 } // namespace orc

--- a/llvm/include/llvm/ExecutionEngine/Orc/SpeculateAnalyses.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/SpeculateAnalyses.h
@@ -13,10 +13,10 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_SPECULATEANALYSES_H
 #define LLVM_EXECUTIONENGINE_ORC_SPECULATEANALYSES_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/Analysis/BranchProbabilityInfo.h"
 #include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/Speculation.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/IR/GCStrategy.h
+++ b/llvm/include/llvm/IR/GCStrategy.h
@@ -47,6 +47,7 @@
 #ifndef LLVM_IR_GCSTRATEGY_H
 #define LLVM_IR_GCSTRATEGY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Registry.h"
 #include <optional>
 #include <string>
@@ -81,7 +82,7 @@ protected:
   bool UsesMetadata = false;     ///< If set, backend must emit metadata tables.
 
 public:
-  GCStrategy();
+  LLVM_ABI GCStrategy();
   virtual ~GCStrategy() = default;
 
   /// Return the name of the GC strategy.  This is the value of the collector
@@ -145,7 +146,7 @@ using GCRegistry = Registry<GCStrategy>;
 extern template class LLVM_TEMPLATE_ABI Registry<GCStrategy>;
 
 /// Lookup the GCStrategy object associated with the given gc name.
-std::unique_ptr<GCStrategy> getGCStrategy(const StringRef Name);
+LLVM_ABI std::unique_ptr<GCStrategy> getGCStrategy(const StringRef Name);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -134,7 +134,7 @@ struct RuntimeLibcallsInfo {
 
   /// Check if this is valid libcall for the current module, otherwise
   /// RTLIB::Unsupported.
-  RTLIB::LibcallImpl getSupportedLibcallImpl(StringRef FuncName) const;
+  LLVM_ABI RTLIB::LibcallImpl getSupportedLibcallImpl(StringRef FuncName) const;
 
 private:
   static const RTLIB::LibcallImpl

--- a/llvm/include/llvm/MC/DXContainerRootSignature.h
+++ b/llvm/include/llvm/MC/DXContainerRootSignature.h
@@ -9,8 +9,8 @@
 #ifndef LLVM_MC_DXCONTAINERROOTSIGNATURE_H
 #define LLVM_MC_DXCONTAINERROOTSIGNATURE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/DXContainer.h"
+#include "llvm/Support/Compiler.h"
 #include <cstdint>
 #include <limits>
 

--- a/llvm/include/llvm/MC/DXContainerRootSignature.h
+++ b/llvm/include/llvm/MC/DXContainerRootSignature.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_MC_DXCONTAINERROOTSIGNATURE_H
 #define LLVM_MC_DXCONTAINERROOTSIGNATURE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/BinaryFormat/DXContainer.h"
 #include <cstdint>
 #include <limits>
@@ -113,9 +114,9 @@ struct RootSignatureDesc {
   mcdxbc::RootParametersContainer ParametersContainer;
   SmallVector<dxbc::RTS0::v1::StaticSampler> StaticSamplers;
 
-  void write(raw_ostream &OS) const;
+  LLVM_ABI void write(raw_ostream &OS) const;
 
-  size_t getSize() const;
+  LLVM_ABI size_t getSize() const;
 };
 } // namespace mcdxbc
 } // namespace llvm

--- a/llvm/include/llvm/MC/MCAssembler.h
+++ b/llvm/include/llvm/MC/MCAssembler.h
@@ -209,7 +209,7 @@ public:
 
   LLVM_ABI bool registerSection(MCSection &Section);
   LLVM_ABI bool registerSymbol(const MCSymbol &Symbol);
-  void addRelocDirective(RelocDirective RD);
+  LLVM_ABI void addRelocDirective(RelocDirective RD);
 
   LLVM_ABI void reportError(SMLoc L, const Twine &Msg) const;
   // Record pending errors during layout iteration, as they may go away once the

--- a/llvm/include/llvm/MC/MCSection.h
+++ b/llvm/include/llvm/MC/MCSection.h
@@ -220,7 +220,7 @@ public:
   MutableArrayRef<char> getContents();
   ArrayRef<char> getContents() const;
 
-  void setVarContents(ArrayRef<char> Contents);
+  LLVM_ABI void setVarContents(ArrayRef<char> Contents);
   void clearVarContents() { setVarContents({}); }
   MutableArrayRef<char> getVarContents();
   ArrayRef<char> getVarContents() const;
@@ -241,7 +241,7 @@ public:
 
   // Source fixup offsets are relative to the variable part's start.
   // Stored fixup offsets are relative to the fixed part's start.
-  void setVarFixups(ArrayRef<MCFixup> Fixups);
+  LLVM_ABI void setVarFixups(ArrayRef<MCFixup> Fixups);
   void clearVarFixups() { setVarFixups({}); }
   MutableArrayRef<MCFixup> getVarFixups();
   ArrayRef<MCFixup> getVarFixups() const;

--- a/llvm/include/llvm/Object/SFrameParser.h
+++ b/llvm/include/llvm/Object/SFrameParser.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/BinaryFormat/SFrame.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include <cstdint>
 
@@ -39,8 +40,8 @@ private:
       : Data(Data), Header(Header) {}
 };
 
-extern template class SFrameParser<endianness::big>;
-extern template class SFrameParser<endianness::little>;
+extern template class LLVM_TEMPLATE_ABI SFrameParser<endianness::big>;
+extern template class LLVM_TEMPLATE_ABI SFrameParser<endianness::little>;
 
 } // end namespace object
 } // end namespace llvm

--- a/llvm/include/llvm/Support/AArch64AttributeParser.h
+++ b/llvm/include/llvm/Support/AArch64AttributeParser.h
@@ -34,7 +34,7 @@ struct AArch64BuildAttrSubsections {
   uint32_t AndFeatures = 0;
 };
 
-AArch64BuildAttrSubsections
+LLVM_ABI AArch64BuildAttrSubsections
 extractBuildAttributesSubsections(const llvm::AArch64AttributeParser &);
 } // namespace llvm
 

--- a/llvm/include/llvm/TextAPI/SymbolSet.h
+++ b/llvm/include/llvm/TextAPI/SymbolSet.h
@@ -92,7 +92,7 @@ private:
 
 public:
   SymbolSet() = default;
-  ~SymbolSet();
+  LLVM_ABI ~SymbolSet();
   LLVM_ABI Symbol *addGlobal(EncodeKind Kind, StringRef Name, SymbolFlags Flags,
                              const Target &Targ);
   size_t size() const { return Symbols.size(); }

--- a/llvm/include/llvm/Transforms/Scalar/Reassociate.h
+++ b/llvm/include/llvm/Transforms/Scalar/Reassociate.h
@@ -22,6 +22,7 @@
 #ifndef LLVM_TRANSFORMS_SCALAR_REASSOCIATE_H
 #define LLVM_TRANSFORMS_SCALAR_REASSOCIATE_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SetVector.h"
@@ -96,7 +97,7 @@ protected:
   bool MadeChange;
 
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &);
 
 private:
   void BuildRankMap(Function &F, ReversePostOrderTraversal<Function *> &RPOT);

--- a/llvm/include/llvm/Transforms/Scalar/Reassociate.h
+++ b/llvm/include/llvm/Transforms/Scalar/Reassociate.h
@@ -22,13 +22,13 @@
 #ifndef LLVM_TRANSFORMS_SCALAR_REASSOCIATE_H
 #define LLVM_TRANSFORMS_SCALAR_REASSOCIATE_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/IR/ValueHandle.h"
+#include "llvm/Support/Compiler.h"
 #include <deque>
 
 namespace llvm {

--- a/llvm/include/llvm/Transforms/Utils/Mem2Reg.h
+++ b/llvm/include/llvm/Transforms/Utils/Mem2Reg.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_TRANSFORMS_UTILS_MEM2REG_H
 #define LLVM_TRANSFORMS_UTILS_MEM2REG_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
 
 namespace llvm {
@@ -22,7 +23,7 @@ class Function;
 
 class PromotePass : public PassInfoMixin<PromotePass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/Mem2Reg.h
+++ b/llvm/include/llvm/Transforms/Utils/Mem2Reg.h
@@ -14,8 +14,8 @@
 #ifndef LLVM_TRANSFORMS_UTILS_MEM2REG_H
 #define LLVM_TRANSFORMS_UTILS_MEM2REG_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/Transforms/Utils/ProfileVerify.h
+++ b/llvm/include/llvm/Transforms/Utils/ProfileVerify.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_TRANSFORMS_UTILS_PROFILEVERIFY_H
 #define LLVM_TRANSFORMS_UTILS_PROFILEVERIFY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/IR/Analysis.h"
 #include "llvm/IR/PassManager.h"
 
@@ -21,7 +22,7 @@ namespace llvm {
 /// don't accidentally drop this metadata.
 class ProfileInjectorPass : public PassInfoMixin<ProfileInjectorPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 /// Checks that MD_prof is present on every instruction that supports it. Used
@@ -29,7 +30,7 @@ public:
 /// valid (i.e. !{!"unknown"})
 class ProfileVerifierPass : public PassInfoMixin<ProfileVerifierPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/Transforms/Utils/ProfileVerify.h
+++ b/llvm/include/llvm/Transforms/Utils/ProfileVerify.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_TRANSFORMS_UTILS_PROFILEVERIFY_H
 #define LLVM_TRANSFORMS_UTILS_PROFILEVERIFY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/IR/Analysis.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 /// Inject MD_prof metadata where it's missing. Used for testing that passes

--- a/llvm/lib/Object/SFrameParser.cpp
+++ b/llvm/lib/Object/SFrameParser.cpp
@@ -51,5 +51,5 @@ Expected<SFrameParser<E>> SFrameParser<E>::create(ArrayRef<uint8_t> Contents) {
   return SFrameParser(Contents, *Header);
 }
 
-template class llvm::object::SFrameParser<endianness::big>;
-template class llvm::object::SFrameParser<endianness::little>;
+template class LLVM_EXPORT_TEMPLATE llvm::object::SFrameParser<endianness::big>;
+template class LLVM_EXPORT_TEMPLATE llvm::object::SFrameParser<endianness::little>;

--- a/llvm/lib/Object/SFrameParser.cpp
+++ b/llvm/lib/Object/SFrameParser.cpp
@@ -52,4 +52,5 @@ Expected<SFrameParser<E>> SFrameParser<E>::create(ArrayRef<uint8_t> Contents) {
 }
 
 template class LLVM_EXPORT_TEMPLATE llvm::object::SFrameParser<endianness::big>;
-template class LLVM_EXPORT_TEMPLATE llvm::object::SFrameParser<endianness::little>;
+template class LLVM_EXPORT_TEMPLATE
+    llvm::object::SFrameParser<endianness::little>;


### PR DESCRIPTION
## Purpose

This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates symbols that were recently added to LLVM without proper annotations. The annotations currently have no meaningful impact on the LLVM build; however, they are  a prerequisite to support an LLVM Windows DLL (shared library) build.

## Background

This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS:
- Add `LLVM_EXPORT_TEMPLATE` and `LLVM_TEMPLATE_ABI` annotations to explicitly instantiated instances of `llvm::object::SFrameParser`.

## Validation

Local builds and tests to validate cross-platform compatibility. This included llvm, clang, and lldb on the following configurations:

- Windows with MSVC
- Windows with Clang
- Linux with GCC
- Linux with Clang
- Darwin with Clang