### PR TITLE
[BPF] Fix build warnings due to a static var in header file

### DIFF
--- a/llvm/lib/Target/BPF/BPF.h
+++ b/llvm/lib/Target/BPF/BPF.h
@@ -22,7 +22,7 @@ class BPFTargetMachine;
 class InstructionSelector;
 class PassRegistry;
 
-static const char *BPF_TRAP = "__bpf_trap";
+#define BPF_TRAP "__bpf_trap"
 
 ModulePass *createBPFCheckAndAdjustIR();
 


### PR DESCRIPTION
Simon Pilgrim ([1]) and Anton reported that the following warning will appear when building clang compiler:
```
In file included from .../llvm-project/llvm/lib/Target/BPF/BPFASpaceCastSimplifyPass.cpp:9: .../llvm-project/llvm/lib/Target/BPF/BPF.h:25:20: warning: ‘llvm::BPF_TRAP’ defined but not used [-Wunused-variable]
   25 | static const char *BPF_TRAP = "__bpf_trap";
      |                    ^~~~~~~~
...
In file included from .../llvm-project/llvm/lib/Target/BPF/MCTargetDesc/BPFInstPrinter.cpp:14:
.../llvm-project/llvm/lib/Target/BPF/BPF.h:25:20: warning: ‘llvm::BPF_TRAP’ defined but not used [-Wunused-variable]
   25 | static const char *BPF_TRAP = "__bpf_trap";
      |                    ^~~~~~~~
...
```
Instead of using static const variable, use macro to silence warnings.

  [1] https://github.com/llvm/llvm-project/pull/131731