### PR TITLE
[clang][analyzer] Delay checking the model-path

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1323,11 +1323,6 @@ static void parseAnalyzerConfigs(AnalyzerOptions &AnOpts,
   if (!AnOpts.CTUDir.empty() && !llvm::sys::fs::is_directory(AnOpts.CTUDir))
     Diags->Report(diag::err_analyzer_config_invalid_input) << "ctu-dir"
                                                            << "a filename";
-
-  if (!AnOpts.ModelPath.empty() &&
-      !llvm::sys::fs::is_directory(AnOpts.ModelPath))
-    Diags->Report(diag::err_analyzer_config_invalid_input) << "model-path"
-                                                           << "a filename";
 }
 
 /// Generate a remark argument. This is an inverse of `ParseOptimizationRemark`.

--- a/clang/test/Analysis/model-file-missing.cpp
+++ b/clang/test/Analysis/model-file-missing.cpp
@@ -1,0 +1,3 @@
+// RUN: not %clang_analyze_cc1 -analyzer-checker=core -analyzer-config model-path=%t/blah %s -o - 2>&1 | FileCheck %s
+// CHECK: error: invalid input for analyzer-config option 'model-path', that expects a filename value
+// CHECK-NEXT: 1 error generated


### PR DESCRIPTION
This PR is part of an effort to remove file system usage from the command line parsing code. The reason for that is that it's impossible to do file system access correctly without a configured VFS, and the VFS can only be configured after the command line is parsed. I don't want to intertwine command line parsing and VFS configuration, so I decided to perform the file system access after the command line is parsed and the VFS is configured - ideally right before the file system entity is used for the first time.

This patch delays checking that `model-path` is an existing directory.