### PR TITLE
[libc] Fix incorrect macro usage in shared/sign.h

### DIFF
--- a/libc/shared/sign.h
+++ b/libc/shared/sign.h
@@ -15,7 +15,7 @@
 namespace LIBC_NAMESPACE_DECL {
 namespace shared {
 
-using LIBC_NAMESPACE_DECL::Sign;
+using LIBC_NAMESPACE::Sign;
 
 } // namespace shared
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
This patch corrects the `using`-declaration in `libc/shared/sign.h`.

The previous change (#150083) incorrectly used the `LIBC_NAMESPACE_DECL` macro. This is corrected to use `LIBC_NAMESPACE`.