### PR TITLE
[Clang] Add generated offloading Xarch args to synthesized args

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1013,6 +1013,7 @@ inferOffloadToolchains(Compilation &C, Action::OffloadKind Kind) {
                      C.getArgs().MakeArgString(Triple.split("-").first),
                      C.getArgs().MakeArgString("--offload-arch=" + Arch));
     C.getArgs().append(A);
+    C.getArgs().AddSynthesizedArg(A);
     Triples.insert(Triple);
   }
 


### PR DESCRIPTION
Summary:
The synthesized args contains a list of unique pointers, so this should
clean this generated argument up once created.
