### PR TITLE
[DTLTO] Add COFF LLD release note for LLVM 21

### DIFF
--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -92,6 +92,9 @@ Breaking changes
 
 COFF Improvements
 -----------------
+* ``/thinlto-distributor`` and ``/thinlto-remote-compiler`` options
+  added to support Integrated Distributed ThinLTO.
+  (`#147265 <https://github.com/llvm/llvm-project/pull/147265>`_)
 
 MinGW Improvements
 ------------------


### PR DESCRIPTION
DTLTO-related COFF LLD changes were cherry-picked to the LLVM 21 release branch in:
  https://github.com/llvm/llvm-project/pull/149979

This commit adds the corresponding release note, modeled after the previously added note for ELF LLD DTLTO support.