### PR TITLE
[PowerPC] fix bug affecting float to int32 conversion on LE PowerPC

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -8457,10 +8457,11 @@ void PPCTargetLowering::LowerFP_TO_INTForReuse(SDValue Op, ReuseLoadInfo &RLI,
 
   // Result is a load from the stack slot.  If loading 4 bytes, make sure to
   // add in a bias on big endian.
-  if (Op.getValueType() == MVT::i32 && !i32Stack) {
+  if (Op.getValueType() == MVT::i32 && !i32Stack &&
+      !Subtarget.isLittleEndian()) {
     FIPtr = DAG.getNode(ISD::ADD, dl, FIPtr.getValueType(), FIPtr,
                         DAG.getConstant(4, dl, FIPtr.getValueType()));
-    MPI = MPI.getWithOffset(Subtarget.isLittleEndian() ? 0 : 4);
+    MPI = MPI.getWithOffset(4);
   }
 
   RLI.Chain = Chain;

--- a/llvm/test/CodeGen/PowerPC/fp_to_uint_endian.ll
+++ b/llvm/test/CodeGen/PowerPC/fp_to_uint_endian.ll
@@ -1,0 +1,17 @@
+; RUN: llc < %s -mcpu=440 -mtriple=ppc32le-unknown-unknown | FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-LE
+; RUN: llc < %s -mcpu=440 -mtriple=ppc32-unknown-unknown   | FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-BE
+
+define i32 @foo(double %a) {
+; CHECK-LABEL: foo:
+; CHECK-DAG:            fctiwz [[FPR_1_i:[0-9]+]], {{[0-9]+}}
+; CHECK-DAG:            stfd [[FPR_1_i]], [[#%u,VAL1_ADDR:]](1)
+; CHECK-LE-DAG:         lwz {{[0-9]+}}, [[#%u,== VAL1_ADDR]](1)
+; CHECK-BE-DAG:         lwz {{[0-9]+}}, [[#%u,== VAL1_ADDR + 4]](1)
+; CHECK-DAG:            fctiwz [[FPR_2:[0-9]+]], {{[0-9]+}}
+; CHECK-DAG:            stfd [[FPR_2]], [[#%u,VAL2_ADDR:]](1)
+; CHECK-LE-DAG:         lwz {{[0-9]+}}, [[#%u,== VAL2_ADDR]](1)
+; CHECK-BE-DAG:         lwz {{[0-9]+}}, [[#%u,== VAL2_ADDR + 4]](1)
+entry:
+        %tmp.1 = fptoui double %a to i32         ; <i32> [#uses=1]
+        ret i32 %tmp.1
+}


### PR DESCRIPTION
when moving fcti results from float registers to normal registers through memory, even though MPI was adjusted to account for endianness, FIPtr was always adjusted for big-endian, which caused loads of wrong half of a value in little-endian mode.