### PR TITLE
[flang][cuda] Use get() to get raw pointer

### DIFF
--- a/flang-rt/unittests/Runtime/CUDA/AllocatorCUF.cpp
+++ b/flang-rt/unittests/Runtime/CUDA/AllocatorCUF.cpp
@@ -79,6 +79,7 @@ TEST(AllocatableCUFTest, CUFSetAllocatorIndex) {
   // REAL(4), DEVICE, ALLOCATABLE :: a(:)
   auto a{createAllocatable(TypeCategory::Real, 4)};
   EXPECT_EQ((int)kDefaultAllocator, a->GetAllocIdx());
-  RTNAME(CUFSetAllocatorIndex)(a, kDeviceAllocatorPos, __FILE__, __LINE__);
+  RTNAME(CUFSetAllocatorIndex)(
+      a.get(), kDeviceAllocatorPos, __FILE__, __LINE__);
   EXPECT_EQ((int)kDeviceAllocatorPos, a->GetAllocIdx());
 }


### PR DESCRIPTION
Fix issue reported in #150136. `createAllocatable` returns an OwingPtr. Use `get()` to get the raw pointer has it is done in the `flang-rt/unittests/Runtime/CUDA/Memory.cpp` tests. 