### PR TITLE
[windows][lldb] implement system logging on Windows

### DIFF
--- a/lldb/include/lldb/Host/Host.h
+++ b/lldb/include/lldb/Host/Host.h
@@ -109,6 +109,10 @@ public:
   /// Emit the given message to the operating system log.
   static void SystemLog(lldb::Severity severity, llvm::StringRef message);
 
+  /// Emit the given message to the stdout or stderr depending on severity.
+  static void SystemLogFallback(lldb::Severity severity,
+                                llvm::StringRef message);
+
   /// Get the process ID for the calling process.
   ///
   /// \return

--- a/lldb/include/lldb/Host/Host.h
+++ b/lldb/include/lldb/Host/Host.h
@@ -109,10 +109,6 @@ public:
   /// Emit the given message to the operating system log.
   static void SystemLog(lldb::Severity severity, llvm::StringRef message);
 
-  /// Emit the given message to the stdout or stderr depending on severity.
-  static void SystemLogFallback(lldb::Severity severity,
-                                llvm::StringRef message);
-
   /// Get the process ID for the calling process.
   ///
   /// \return

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -82,13 +82,26 @@ int __pthread_fchdir(int fildes);
 using namespace lldb;
 using namespace lldb_private;
 
-#if !defined(__APPLE__)
-// The system log is currently only meaningful on Darwin, where this means
-// os_log. The meaning of a "system log" isn't as clear on other platforms, and
-// therefore we don't providate a default implementation. Vendors are free to
+#if !defined(__APPLE__) && !defined(_WIN32)
+// The system log is currently only meaningful on Darwin and Windows.
+// On Darwin, this means os_log. On Windows this means Events Viewer.
+// The meaning of a "system log" isn't as clear on other platforms, and
+// therefore we don't providate a default implementation. Vendors are free
 // to implement this function if they have a use for it.
 void Host::SystemLog(Severity severity, llvm::StringRef message) {}
 #endif
+
+void Host::SystemLogFallback(Severity severity, llvm::StringRef message) {
+  switch (severity) {
+  case lldb::eSeverityInfo:
+  case lldb::eSeverityWarning:
+    llvm::outs() << message;
+    return;
+  case lldb::eSeverityError:
+    llvm::errs() << message;
+    return;
+  }
+}
 
 static constexpr Log::Category g_categories[] = {
     {{"system"}, {"system log"}, SystemLog::System}};

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -91,18 +91,6 @@ using namespace lldb_private;
 void Host::SystemLog(Severity severity, llvm::StringRef message) {}
 #endif
 
-void Host::SystemLogFallback(Severity severity, llvm::StringRef message) {
-  switch (severity) {
-  case lldb::eSeverityInfo:
-  case lldb::eSeverityWarning:
-    llvm::outs() << message;
-    return;
-  case lldb::eSeverityError:
-    llvm::errs() << message;
-    return;
-  }
-}
-
 static constexpr Log::Category g_categories[] = {
     {{"system"}, {"system log"}, SystemLog::System}};
 

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -22,7 +22,9 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StructuredData.h"
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ConvertUTF.h"
+#include "llvm/Support/ManagedStatic.h"
 
 // Windows includes
 #include <tlhelp32.h>
@@ -301,4 +303,65 @@ Environment Host::GetEnvironment() {
     environment_block += current_var_size;
   }
   return env;
+}
+
+/// Manages the lifecycle of a Windows Event's Source.
+/// The destructor will call DeregisterEventSource.
+/// This class is meant to be used with \ref llvm::ManagedStatic.
+class WindowsEventLog {
+public:
+  WindowsEventLog() : handle(RegisterEventSource(nullptr, L"lldb")) {}
+
+  ~WindowsEventLog() {
+    if (handle)
+      DeregisterEventSource(handle);
+  }
+
+  HANDLE GetHandle() const { return handle; }
+
+private:
+  HANDLE handle;
+};
+
+static llvm::ManagedStatic<WindowsEventLog> event_log;
+
+static LPCWSTR AnsiToUtf16(const std::string &ansi) {
+  if (ansi.empty())
+    return nullptr;
+  const int unicode_length =
+      MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, nullptr, 0);
+  WCHAR *unicode = new WCHAR[unicode_length];
+  MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, unicode, unicode_length);
+  return unicode;
+}
+
+void Host::SystemLog(Severity severity, llvm::StringRef message) {
+  HANDLE h = event_log->GetHandle();
+  if (!h) {
+    SystemLogFallback(severity, message);
+    return;
+  }
+
+  LPCWSTR wide_message = AnsiToUtf16(message.str());
+  if (!wide_message) {
+    SystemLogFallback(severity, message);
+    return;
+  }
+
+  WORD event_type;
+  switch (severity) {
+  case lldb::eSeverityWarning:
+    event_type = EVENTLOG_WARNING_TYPE;
+    break;
+  case lldb::eSeverityError:
+    event_type = EVENTLOG_ERROR_TYPE;
+    break;
+  case lldb::eSeverityInfo:
+  default:
+    event_type = EVENTLOG_INFORMATION_TYPE;
+  }
+
+  ReportEventW(h, event_type, 0, 0, nullptr, 1, 0, &wide_message, nullptr);
+
+  delete[] wide_message;
 }

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -338,13 +338,11 @@ static LPCWSTR AnsiToUtf16(const std::string &ansi) {
 void Host::SystemLog(Severity severity, llvm::StringRef message) {
   HANDLE h = event_log->GetHandle();
   if (!h) {
-    SystemLogFallback(severity, message);
     return;
   }
 
   LPCWSTR wide_message = AnsiToUtf16(message.str());
   if (!wide_message) {
-    SystemLogFallback(severity, message);
     return;
   }
 


### PR DESCRIPTION
This patch makes LLDB use the Event Viewer on Windows (equivalent of system logging on Darwin) rather than piping to the standard output (which was deactivated in ca0a5247004b6d692978d10bdbf86e338133e60c.