### PR TITLE
[flang][Lower] Make reduction processing failure a hard error

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2128,8 +2128,8 @@ private:
     bool result = rp.processReductionArguments<fir::DeclareReductionOp>(
         toLocation(), *this, info.reduceOperatorList, reduceVars,
         reduceVarByRef, reductionDeclSymbols, info.reduceSymList);
-    assert(result && "Failed to process `do concurrent` reductions");
-    (void)result;
+    if (!result)
+      TODO(toLocation(), "Lowering unrecognised reduction type");
 
     doConcurrentLoopOp.getReduceVarsMutable().assign(reduceVars);
     doConcurrentLoopOp.setReduceSymsAttr(

--- a/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
+++ b/flang/lib/Lower/OpenMP/ClauseProcessor.cpp
@@ -1121,7 +1121,7 @@ bool ClauseProcessor::processInReduction(
                 std::get<typename omp::clause::ReductionOperatorList>(clause.t),
                 inReductionVars, inReduceVarByRef, inReductionDeclSymbols,
                 inReductionSyms))
-          inReductionSyms.clear();
+          TODO(currentLocation, "Lowering unrecognised reduction type");
 
         // Copy local lists into the output.
         llvm::copy(inReductionVars, std::back_inserter(result.inReductionVars));
@@ -1467,7 +1467,7 @@ bool ClauseProcessor::processReduction(
                 std::get<typename omp::clause::ReductionOperatorList>(clause.t),
                 reductionVars, reduceVarByRef, reductionDeclSymbols,
                 reductionSyms))
-          reductionSyms.clear();
+          TODO(currentLocation, "Lowering unrecognised reduction type");
         // Copy local lists into the output.
         llvm::copy(reductionVars, std::back_inserter(result.reductionVars));
         llvm::copy(reduceVarByRef, std::back_inserter(result.reductionByref));
@@ -1494,7 +1494,7 @@ bool ClauseProcessor::processTaskReduction(
                 std::get<typename omp::clause::ReductionOperatorList>(clause.t),
                 taskReductionVars, taskReduceVarByRef, taskReductionDeclSymbols,
                 taskReductionSyms))
-          taskReductionSyms.clear();
+          TODO(currentLocation, "Lowering unrecognised reduction type");
         // Copy local lists into the output.
         llvm::copy(taskReductionVars,
                    std::back_inserter(result.taskReductionVars));

--- a/flang/test/Lower/OpenMP/Todo/wsloop-reduction-non-intrinsic.f90
+++ b/flang/test/Lower/OpenMP/Todo/wsloop-reduction-non-intrinsic.f90
@@ -1,6 +1,6 @@
 ! Tests reduction processor behavior when a reduction symbol is not supported.
 
-! RUN: %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
+! RUN: %not_todo_cmd %flang_fc1 -emit-hlfir -fopenmp -o - %s 2>&1 | FileCheck %s
 
 subroutine foo
   implicit none
@@ -12,14 +12,9 @@ subroutine foo
     end function
   end interface
 
+  !CHECK: not yet implemented: Lowering unrecognised reduction type
   !$omp do reduction (max: k)
   do i=1,10
   end do
   !$omp end do
 end
-
-! Verify that unsupported reduction is ignored.
-! CHECK: omp.wsloop 
-! CHECK-SAME: private(@{{[^[:space:]]+}} %{{[^[:space:]]+}}
-! CHECK-SAME:         -> %{{[^[:space:]]+}} : !{{[^[:space:]]+}}) {
-! CHECK: }


### PR DESCRIPTION
See #150178

This may regress some test cases which only ever passed by accident.

I've tested SPEC2017 and a sample of applications to check that this doesn't break anything too obvious. Presumably this was not a widely used feature or we would have noticed the bug sooner.

I'm unsure whether this should be backported to LLVM 21 or not: I think it is much better to refuse to compile than to silently produce the wrong result, but there is a chance this could regress something which previously worked by accident. Opinions welcome.