### PR TITLE
[libc] Fix problem with older compilers that do not have __has_builtin.

### DIFF
--- a/libc/src/__support/CPP/type_traits/is_constant_evaluated.h
+++ b/libc/src/__support/CPP/type_traits/is_constant_evaluated.h
@@ -15,7 +15,11 @@ namespace LIBC_NAMESPACE_DECL {
 namespace cpp {
 
 LIBC_INLINE constexpr bool is_constant_evaluated() {
+#if LIBC_HAS_BUILTIN(__builtin_is_constant_evaluated)
   return __builtin_is_constant_evaluated();
+#else
+  return false;
+#endif
 }
 
 } // namespace cpp

--- a/libc/src/__support/macros/attributes.h
+++ b/libc/src/__support/macros/attributes.h
@@ -48,4 +48,10 @@
 #define LIBC_PREFERED_TYPE(TYPE)
 #endif
 
+#ifndef __has_builtin
+#define LIBC_HAS_BUILTIN(X) 0
+#else
+#define LIBC_HAS_BUILTIN(X) __has_builtin(X)
+#endif
+
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_ATTRIBUTES_H


### PR DESCRIPTION
Fixing bot failures: https://lab.llvm.org/buildbot/#/builders/10/builds/10025