### PR TITLE
[lldb] support ieee_single and ieee_double gdbtypes for registers

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4783,7 +4783,8 @@ bool ParseRegisters(
             } else if (gdb_type == "data_ptr" || gdb_type == "code_ptr") {
               reg_info.format = eFormatAddressInfo;
               reg_info.encoding = eEncodingUint;
-            } else if (gdb_type == "float") {
+            } else if (gdb_type == "float" || gdb_type == "ieee_single" ||
+                       gdb_type == "ieee_double") {
               reg_info.format = eFormatFloat;
               reg_info.encoding = eEncodingIEEE754;
             } else if (gdb_type == "aarch64v" ||

--- a/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestGDBServerTargetXML.py
@@ -692,6 +692,9 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
                 "0102030405060708"  # t4
                 "0102030405060708"  # t5
                 "0102030405060708"  # t6
+                "6162636465666768"  # pc
+                "0000C03F"  # ft0
+                "e07a6147a8a40940"  # ft1
             )
 
             def qXferRead(self, obj, annex, offset, length):
@@ -736,6 +739,10 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
                                 <reg name="t5" bitsize="64" type="int"/>
                                 <reg name="t6" bitsize="64" type="int"/>
                                 <reg name="pc" bitsize="64" type="code_ptr"/>
+                            </feature>
+                            <feature name='org.gnu.gdb.riscv.fpu'>
+                                <reg name='ft0' bitsize='32' type='ieee_single'/>
+                                <reg name='ft1' bitsize='64' type='ieee_double'/>
                             </feature>
                         </target>""",
                         False,
@@ -799,6 +806,10 @@ class TestGDBServerTargetXML(GDBRemoteTestBase):
         self.match("register read x29", ["t4 = 0x0807060504030201"])
         self.match("register read x30", ["t5 = 0x0807060504030201"])
         self.match("register read x31", ["t6 = 0x0807060504030201"])
+        self.match("register read pc", ["pc = 0x6867666564636261"])
+        # test FPU registers
+        self.match("register read ft0", ["ft0 = 1.5"])
+        self.match("register read ft1", ["ft1 = 3.2053990913985757"])
 
     @skipIfXmlSupportMissing
     @skipIfRemote


### PR DESCRIPTION
Some gdb remote servers send target.xml that contains 
```
<reg name='ft0' bitsize='32' type='ieee_single' dwarf_regnum='32'/>
  <reg name='ft1' bitsize='32' type='ieee_single' dwarf_regnum='33'/>
  <reg name='ft2' bitsize='32' type='ieee_single' dwarf_regnum='34'/>
  <reg name='ft3' bitsize='32' type='ieee_single' dwarf_regnum='35'/>
  <reg name='ft4' bitsize='32' type='ieee_single' dwarf_regnum='36'/>
  <reg name='ft5' bitsize='32' type='ieee_single' dwarf_regnum='37'/>
  <reg name='ft6' bitsize='32' type='ieee_single' dwarf_regnum='38'/>
  <reg name='ft7' bitsize='32' type='ieee_single' dwarf_regnum='39'/>
```

it seems like a valid and supported type in gdb. 
from gdb16.3/gdb/target_descriptions.c (could not find a way to link it).
```
case TDESC_TYPE_IEEE_SINGLE:
	  m_type = init_float_type (alloc, -1, "builtin_type_ieee_single",
				    floatformats_ieee_single);
	  return;

case TDESC_TYPE_IEEE_DOUBLE:
	  m_type = init_float_type (alloc, -1, "builtin_type_ieee_double",
				    floatformats_ieee_double);
	  return;
```	

### Testplan

updated unittest to test this. 


Reviewers: @clayborg , @jeffreytan81 , @Jlalond 