### PR TITLE
[C23] Handle type compatibility for enumerations better

### DIFF
--- a/clang/test/C/C23/n3037.c
+++ b/clang/test/C/C23/n3037.c
@@ -429,4 +429,9 @@ void gh149965(void) {
   // FIXME: this should be an error in both C17 and C23 mode.
   struct GH149965_3 { int h; };     // c17-note {{previous definition is here}}
   struct GH149965_3 { enum E1 h; }; // c17-error {{redefinition of 'GH149965_3'}}
+
+  // For Clang, the composite type after declaration merging is the enumeration
+  // type rather than an integer type.
+  enum E1 *eptr;
+  [[maybe_unused]] __typeof__(x1.h) *ptr = eptr;
 }

--- a/clang/test/C/C23/n3037.c
+++ b/clang/test/C/C23/n3037.c
@@ -401,3 +401,30 @@ _Static_assert(0 == _Generic(inner_anon_tagged.untagged, struct { int i; } : 1, 
 // unions and structures are both RecordDecl objects, whereas EnumDecl is not).
 enum { E_Untagged1 } nontag_enum; // both-note {{previous definition is here}}
 _Static_assert(0 == _Generic(nontag_enum, enum { E_Untagged1 } : 1, default : 0)); // both-error {{redefinition of enumerator 'E_Untagged1'}}
+
+// Test that enumerations are compatible with their underlying type, but still
+// diagnose when "same type" is required rather than merely "compatible type".
+struct GH149965_1 { int h; };
+struct GH149965_2 { int h; };
+void gh149965(void) {
+  extern struct GH149965_1 x1; // c17-note {{previous declaration is here}}
+  extern struct GH149965_2 x2; // c17-note {{previous declaration is here}}
+
+  enum E1 : int { e1 }; // Fixed underlying type
+  enum E2 { e2 };       // Unfixed underlying type, defaults to int in Clang (unsigned in GCC)
+
+  // Both the structure and the variable declarations are fine because only a
+  // compatible type is required, not the same type, because the structures are
+  // declared in different scopes.
+  struct GH149965_1 { enum E1 h; };
+  struct GH149965_2 { enum E2 h; };
+
+  extern struct GH149965_1 x1; // c17-error {{redeclaration of 'x1'}}
+  extern struct GH149965_2 x2; // c17-error {{redeclaration of 'x2'}}
+
+  // However, in the same scope, the same type is required, not just compatible
+  // types.
+  // FIXME: this should be an error in both C17 and C23 mode.
+  struct GH149965_3 { int h; };     // c17-note {{previous definition is here}}
+  struct GH149965_3 { enum E1 h; }; // c17-error {{redefinition of 'GH149965_3'}}
+}

--- a/clang/test/C/C23/n3037.c
+++ b/clang/test/C/C23/n3037.c
@@ -434,4 +434,6 @@ void gh149965(void) {
   // type rather than an integer type.
   enum E1 *eptr;
   [[maybe_unused]] __typeof__(x1.h) *ptr = eptr;
+  enum E2 *eptr2;
+  [[maybe_unused]] __typeof__(x2.h) *ptr2 = eptr2;
 }

--- a/clang/test/C/C23/n3037.c
+++ b/clang/test/C/C23/n3037.c
@@ -404,14 +404,16 @@ _Static_assert(0 == _Generic(nontag_enum, enum { E_Untagged1 } : 1, default : 0)
 
 // Test that enumerations are compatible with their underlying type, but still
 // diagnose when "same type" is required rather than merely "compatible type".
+enum E1 : int { e1 }; // Fixed underlying type
+enum E2 { e2 };       // Unfixed underlying type, defaults to int or unsigned int
+
 struct GH149965_1 { int h; };
-struct GH149965_2 { int h; };
+// This typeof trick is used to get the underlying type of the enumeration in a
+// platform agnostic way.
+struct GH149965_2 { __typeof__(+(enum E2){}) h; };
 void gh149965(void) {
   extern struct GH149965_1 x1; // c17-note {{previous declaration is here}}
   extern struct GH149965_2 x2; // c17-note {{previous declaration is here}}
-
-  enum E1 : int { e1 }; // Fixed underlying type
-  enum E2 { e2 };       // Unfixed underlying type, defaults to int in Clang (unsigned in GCC)
 
   // Both the structure and the variable declarations are fine because only a
   // compatible type is required, not the same type, because the structures are


### PR DESCRIPTION
An enumeration is compatible with its underlying type, which means that code like the following should be accepted:

  struct A { int h; };
  void func() {
    extern struct A x;
    enum E : int { e };
    struct A { enum E h; };
    extern struct A x;
  }

because the structures are declared in different scopes, the two declarations of 'x' are both compatible.

Note, the structural equivalence checker does not take scope into account, but that is something the C standard requires. This means we are accepting code we should be rejecting per the standard, like:

  void func() {
    struct A { int h; };
    extern struct A x;
    enum E : int { e };
    struct A { enum E h; };
    extern struct A x;
  }

Because the structures are declared in the same scope, the type compatibility rule require the structures to use the same types, not merely compatible ones.

Fixes #149965