### PR TITLE
[Flang] Fix crash with parametrized derived types usage

### DIFF
--- a/flang/lib/Lower/Mangler.cpp
+++ b/flang/lib/Lower/Mangler.cpp
@@ -224,8 +224,18 @@ std::string Fortran::lower::mangle::mangleName(
       assert(paramExpr && "derived type kind param not explicit");
       std::optional<int64_t> init =
           Fortran::evaluate::ToInt64(paramValue->GetExplicit());
-      assert(init && "derived type kind param is not constant");
-      kinds.emplace_back(*init);
+      // TODO: put the assertion check back when parametrized derived types
+      // are supported:
+      // assert(init && "derived type kind param is not constant");
+      //
+      // The init parameter above will require a FoldingContext for proper
+      // expression evaluation to an integer constant, otherwise the
+      // compiler may crash here (see example in issue #127424).
+      if (!init) {
+        TODO_NOLOC("parameterized derived types");
+      } else {
+        kinds.emplace_back(*init);
+      }
     }
   }
   return fir::NameUniquer::doType(modules, procs, blockId, symbolName, kinds);

--- a/flang/test/Lower/parametrized-derived-types.f90
+++ b/flang/test/Lower/parametrized-derived-types.f90
@@ -1,0 +1,19 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+! XFAIL: *
+program main
+  TYPE ty(k1,k2)
+     INTEGER ,KIND::k1,k2=5
+     INTEGER::arr(k1:k2)=10
+     CHARACTER(LEN=k2)::CHARACTER
+  END TYPE ty
+  TYPE,EXTENDS(ty)::ty1(k3)
+     INTEGER,KIND ::k3=4
+     TYPE(ty(2,k3+1))::cmp_ty = ty(2,k3+1)(55,'HI')
+  END TYPE ty1
+  TYPE ty2(l1, l2)
+  !ERROR: not yet implemented: parameterized derived types
+     INTEGER,LEN ::l1,l2
+     TYPE(ty1(2,5)), ALLOCATABLE::ty1_cmp(:)
+  END TYPE ty2
+  TYPE(ty2(4,8)) ::ty2_obj
+end program main


### PR DESCRIPTION
The current mangleName implementation doesn't take a FoldingContext, which prevents the proper evaluation of expressions containing parameter references to an integer constant. Since parametrized derived types are not yet implemented, the compiler will crash there in some cases (see example in issue #127424).

This is a workaround so that doesn't happen until the feature is properly implemented.

Fixes #127424