### PR TITLE
[clang-tidy] Ignore pure-virtual in portability-template...

### DIFF
--- a/clang-tools-extra/clang-tidy/portability/TemplateVirtualMemberFunctionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/portability/TemplateVirtualMemberFunctionCheck.cpp
@@ -18,10 +18,11 @@ AST_MATCHER(CXXMethodDecl, isUsed) { return Node.isUsed(); }
 
 void TemplateVirtualMemberFunctionCheck::registerMatchers(MatchFinder *Finder) {
   Finder->addMatcher(
-      cxxMethodDecl(ofClass(classTemplateSpecializationDecl(
+      cxxMethodDecl(isVirtual(),
+                    ofClass(classTemplateSpecializationDecl(
                                 unless(isExplicitTemplateSpecialization()))
                                 .bind("specialization")),
-                    isVirtual(), unless(isUsed()),
+                    unless(isUsed()), unless(isPure()),
                     unless(cxxDestructorDecl(isDefaulted())))
           .bind("method"),
       this);

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -121,7 +121,11 @@ Changes in existing checks
 
 - Improved :doc:`misc-header-include-cycle
   <clang-tidy/checks/misc/header-include-cycle>` check performance.
-  
+
+- Improved :doc:`portability-template-virtual-member-function
+  <clang-tidy/checks/portability/template-virtual-member-function>` check to
+  avoid false positives on pure virtual member functions.
+
 Removed checks
 ^^^^^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/checkers/portability/template-virtual-member-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/portability/template-virtual-member-function.cpp
@@ -171,3 +171,20 @@ struct NoInstantiation<int, U>{
     };
 };
 } // namespace PartialSpecializationNoInstantiation
+
+namespace PR139031 {
+
+template<typename T>
+struct Base {
+    virtual void foo() = 0;
+};
+
+struct Derived : public Base<int> {
+    void foo() {}
+};
+
+void test() {
+    Derived{}.foo();
+}
+
+}

--- a/clang-tools-extra/test/clang-tidy/checkers/portability/template-virtual-member-function.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/portability/template-virtual-member-function.cpp
@@ -172,7 +172,7 @@ struct NoInstantiation<int, U>{
 };
 } // namespace PartialSpecializationNoInstantiation
 
-namespace PR139031 {
+namespace PureVirtual {
 
 template<typename T>
 struct Base {


### PR DESCRIPTION
Ignore pure virtual member functions in 
portability-template-virtual-member-function check. 
Those functions will be represented in vtable
as __cxa_pure_virtual or something similar.

Fixes #139031.