### PR TITLE
[clang-repl] Disable new test after #148701

### DIFF
--- a/clang/test/Interpreter/pretty-print.c
+++ b/clang/test/Interpreter/pretty-print.c
@@ -3,7 +3,7 @@
 // RUN: cat %s | clang-repl -Xcc -xc  | FileCheck %s
 // RUN: cat %s | clang-repl -Xcc -std=c++11 | FileCheck %s
 
-// UNSUPPORTED: hwasan, asan
+// UNSUPPORTED: hwasan, msan
 
 
 char c = 'a'; c

--- a/clang/test/Interpreter/pretty-print.c
+++ b/clang/test/Interpreter/pretty-print.c
@@ -3,7 +3,7 @@
 // RUN: cat %s | clang-repl -Xcc -xc  | FileCheck %s
 // RUN: cat %s | clang-repl -Xcc -std=c++11 | FileCheck %s
 
-// UNSUPPORTED: hwasan
+// UNSUPPORTED: hwasan, asan
 
 
 char c = 'a'; c


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/148701 adds new tests.
However, these tests never pass on msan buildbots.
https://lab.llvm.org/buildbot/#/builders/94/builds/9132
https://lab.llvm.org/buildbot/#/builders/94/builds/9131
https://lab.llvm.org/buildbot/#/builders/94/builds/9130
