### PR TITLE
[lldb][cmake] Remove unnecessary target dependency

### DIFF
--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -71,12 +71,8 @@ endif()
 find_program(unifdef_EXECUTABLE unifdef)
 
 # Wrap output in a target, so lldb-framework can depend on it.
-add_custom_target(liblldb-resource-headers DEPENDS lldb-sbapi-dwarf-enums ${lldb_staged_headers})
+add_custom_target(liblldb-resource-headers DEPENDS lldb-sbapi-dwarf-enums)
 set_target_properties(liblldb-resource-headers PROPERTIES FOLDER "LLDB/Resources")
-# We're taking the header files from where they've been staged in the build directory's include folder,
-# so create a dependency on the build step that creates that directory.
-add_dependencies(liblldb-resource-headers liblldb-header-staging)
-add_dependencies(liblldb liblldb-resource-headers)
 
 # Copy vendor-specific headers from clang (without staging).
 if(NOT APPLE_EMBEDDED)


### PR DESCRIPTION
On the LLDB GreenDragon standalone build, there's currently an error at config time wherein the target libldlb-resource-headers and the individual targets that run the framework fixup script on the header files for the framework (lldb-framework-fixup-header-<header-filename>) both depend on the header file being staged, but neither of which depend on each other. That dependency could be introduced, but I think it would be better if liblldb-resource-headers no longer had a file-based dependency on the staged headers as this is now taken care of by the target lldb-framework-fixup-all-headers.