### PR TITLE
[clang][test] Specify value of `-fopenmp=libomp` for test.

### DIFF
--- a/clang/test/Driver/offload-target.c
+++ b/clang/test/Driver/offload-target.c
@@ -10,7 +10,7 @@
 // RUN: | FileCheck %s -check-prefix=CUDA
 // CUDA: "nvptx64-nvidia-cuda" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[NV_OBJ:.+]]"
 
-// RUN: %clang -### --offload-targets=amdgcn-amd-amdhsa,nvptx64-nvidia-cuda -fopenmp \
+// RUN: %clang -### --offload-targets=amdgcn-amd-amdhsa,nvptx64-nvidia-cuda -fopenmp=libomp \
 // RUN:   -Xarch_amdgcn --offload-arch=gfx90a -Xarch_nvptx64 --offload-arch=sm_89 \
 // RUN:   -nogpulib -nogpuinc %s -ccc-print-bindings 2>&1 \
 // RUN: | FileCheck %s -check-prefix=OPENMP


### PR DESCRIPTION
`libomp` is the default value when unconfigured in cmake, but llvm can be configured to have `libgomp` be the default instead. Explicitly specify this value so the test does not fail when it assumes libomp is always the default.

This is needed for the test changes in #125556