### PR TITLE
[AMDGPU][True16][CodeGen] 16bit inline constant check for COPY

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -1151,10 +1151,11 @@ public:
 
     if (isCopyInstr(MI)) {
       unsigned Size = getOpSize(MI, OpIdx);
-      assert(Size == 8 || Size == 4);
+      assert(Size == 8 || Size == 4 || Size == 2);
 
-      uint8_t OpType = (Size == 8) ?
-        AMDGPU::OPERAND_REG_IMM_INT64 : AMDGPU::OPERAND_REG_IMM_INT32;
+      uint8_t OpType = (Size == 8)   ? AMDGPU::OPERAND_REG_IMM_INT64
+                       : (Size == 4) ? AMDGPU::OPERAND_REG_IMM_INT32
+                                     : AMDGPU::OPERAND_REG_IMM_INT16;
       return isInlineConstant(ImmVal, OpType);
     }
 


### PR DESCRIPTION
Update the util function to check if the inline constant is overflow in a16bit COPY.