### PR TITLE
[libc] Add support for __builtin_is_constant_evaluated for GCC 9+.

### DIFF
--- a/libc/src/__support/CPP/type_traits/is_constant_evaluated.h
+++ b/libc/src/__support/CPP/type_traits/is_constant_evaluated.h
@@ -15,11 +15,7 @@ namespace LIBC_NAMESPACE_DECL {
 namespace cpp {
 
 LIBC_INLINE constexpr bool is_constant_evaluated() {
-#if LIBC_HAS_BUILTIN(__builtin_is_constant_evaluated)
   return __builtin_is_constant_evaluated();
-#else
-  return false;
-#endif
 }
 
 } // namespace cpp

--- a/libc/src/__support/RPC/rpc_server.h
+++ b/libc/src/__support/RPC/rpc_server.h
@@ -15,13 +15,17 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_RPC_RPC_SERVER_H
 #define LLVM_LIBC_SRC___SUPPORT_RPC_RPC_SERVER_H
 
+#include "src/__support/macros/properties/compiler.h"
+
 // Workaround for missing __has_builtin in < GCC 10.
 #ifndef __has_builtin
 #define __has_builtin(x) 0
 #endif
 
 // Workaround for missing __builtin_is_constant_evaluated in < GCC 10.
-#ifndef __builtin_is_constant_evaluated
+// Also this builtin is defined for GCC 9.
+#if !(__has_builtin(__builtin_is_constant_evaluated) ||                        \
+      (defined(LIBC_COMPILER_IS_GCC) && (LIBC_COMPILER_GCC_VER >= 900)))
 #define __builtin_is_constant_evaluated(x) 0
 #endif
 

--- a/libc/src/__support/macros/attributes.h
+++ b/libc/src/__support/macros/attributes.h
@@ -48,10 +48,4 @@
 #define LIBC_PREFERED_TYPE(TYPE)
 #endif
 
-#ifndef __has_builtin
-#define LIBC_HAS_BUILTIN(X) 0
-#else
-#define LIBC_HAS_BUILTIN(X) __has_builtin(X)
-#endif
-
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_ATTRIBUTES_H


### PR DESCRIPTION
https://lab.llvm.org/buildbot/#/builders/10/builds/10047/steps/5/logs/stdio