### PR TITLE
[ARM] Simplify cmp (a - b), 0 to just cmp (a, b) if the cond is mi or pl

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -4952,6 +4952,15 @@ SDValue ARMTargetLowering::getARMCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC,
     CompareType = ARMISD::CMPZ;
     break;
   }
+
+  // If we have MI or PL and a binop, we can just do that instead of a CMP.
+  if (CondCode == ARMCC::MI || CondCode == ARMCC::PL) {
+    if (LHS.getOpcode() == ISD::SUB && LHS.hasOneUse()) {
+      ARMcc = DAG.getConstant(CondCode, dl, MVT::i32);
+      return DAG.getNode(CompareType, dl, FlagsVT, LHS.getOperand(0),
+                         LHS.getOperand(1));
+    }
+  }
   ARMcc = DAG.getConstant(CondCode, dl, MVT::i32);
   return DAG.getNode(CompareType, dl, FlagsVT, LHS, RHS);
 }

--- a/llvm/test/CodeGen/ARM/hoist-and-by-const-from-lshr-in-eqcmp-zero.ll
+++ b/llvm/test/CodeGen/ARM/hoist-and-by-const-from-lshr-in-eqcmp-zero.ll
@@ -371,8 +371,8 @@ define i1 @scalar_i64_signbit_eq(i64 %x, i64 %y) nounwind {
 define i1 @scalar_i64_lowestbit_eq(i64 %x, i64 %y) nounwind {
 ; ARM6-LABEL: scalar_i64_lowestbit_eq:
 ; ARM6:       @ %bb.0:
-; ARM6-NEXT:    subs r1, r2, #32
 ; ARM6-NEXT:    lsl r0, r0, r2
+; ARM6-NEXT:    cmp r2, #32
 ; ARM6-NEXT:    movpl r0, #0
 ; ARM6-NEXT:    mov r1, #1
 ; ARM6-NEXT:    bic r0, r1, r0
@@ -380,8 +380,8 @@ define i1 @scalar_i64_lowestbit_eq(i64 %x, i64 %y) nounwind {
 ;
 ; ARM78-LABEL: scalar_i64_lowestbit_eq:
 ; ARM78:       @ %bb.0:
-; ARM78-NEXT:    subs r1, r2, #32
 ; ARM78-NEXT:    lsl r0, r0, r2
+; ARM78-NEXT:    cmp r2, #32
 ; ARM78-NEXT:    movwpl r0, #0
 ; ARM78-NEXT:    mov r1, #1
 ; ARM78-NEXT:    bic r0, r1, r0
@@ -400,7 +400,7 @@ define i1 @scalar_i64_lowestbit_eq(i64 %x, i64 %y) nounwind {
 ; THUMB78-LABEL: scalar_i64_lowestbit_eq:
 ; THUMB78:       @ %bb.0:
 ; THUMB78-NEXT:    lsls r0, r2
-; THUMB78-NEXT:    subs.w r1, r2, #32
+; THUMB78-NEXT:    cmp r2, #32
 ; THUMB78-NEXT:    it pl
 ; THUMB78-NEXT:    movpl r0, #0
 ; THUMB78-NEXT:    movs r1, #1

--- a/llvm/test/CodeGen/ARM/hoist-and-by-const-from-shl-in-eqcmp-zero.ll
+++ b/llvm/test/CodeGen/ARM/hoist-and-by-const-from-shl-in-eqcmp-zero.ll
@@ -345,7 +345,7 @@ define i1 @scalar_i64_signbit_eq(i64 %x, i64 %y) nounwind {
 ; ARM6-LABEL: scalar_i64_signbit_eq:
 ; ARM6:       @ %bb.0:
 ; ARM6-NEXT:    lsr r0, r1, r2
-; ARM6-NEXT:    subs r1, r2, #32
+; ARM6-NEXT:    cmp r2, #32
 ; ARM6-NEXT:    movpl r0, #0
 ; ARM6-NEXT:    mvn r0, r0
 ; ARM6-NEXT:    lsr r0, r0, #31
@@ -354,7 +354,7 @@ define i1 @scalar_i64_signbit_eq(i64 %x, i64 %y) nounwind {
 ; ARM78-LABEL: scalar_i64_signbit_eq:
 ; ARM78:       @ %bb.0:
 ; ARM78-NEXT:    lsr r0, r1, r2
-; ARM78-NEXT:    subs r1, r2, #32
+; ARM78-NEXT:    cmp r2, #32
 ; ARM78-NEXT:    movwpl r0, #0
 ; ARM78-NEXT:    mvn r0, r0
 ; ARM78-NEXT:    lsr r0, r0, #31
@@ -374,7 +374,7 @@ define i1 @scalar_i64_signbit_eq(i64 %x, i64 %y) nounwind {
 ; THUMB78-LABEL: scalar_i64_signbit_eq:
 ; THUMB78:       @ %bb.0:
 ; THUMB78-NEXT:    lsr.w r0, r1, r2
-; THUMB78-NEXT:    subs.w r1, r2, #32
+; THUMB78-NEXT:    cmp r2, #32
 ; THUMB78-NEXT:    it pl
 ; THUMB78-NEXT:    movpl r0, #0
 ; THUMB78-NEXT:    mvns r0, r0

--- a/llvm/test/CodeGen/ARM/long_shift.ll
+++ b/llvm/test/CodeGen/ARM/long_shift.ll
@@ -29,14 +29,14 @@ define i32 @f1(i64 %x, i64 %y) {
 ; CHECK-LE-LABEL: f1:
 ; CHECK-LE:       @ %bb.0:
 ; CHECK-LE-NEXT:    lsl r0, r0, r2
-; CHECK-LE-NEXT:    subs r1, r2, #32
+; CHECK-LE-NEXT:    cmp r2, #32
 ; CHECK-LE-NEXT:    movpl r0, #0
 ; CHECK-LE-NEXT:    mov pc, lr
 ;
 ; CHECK-BE-LABEL: f1:
 ; CHECK-BE:       @ %bb.0:
 ; CHECK-BE-NEXT:    lsl r0, r1, r3
-; CHECK-BE-NEXT:    subs r1, r3, #32
+; CHECK-BE-NEXT:    cmp r3, #32
 ; CHECK-BE-NEXT:    movpl r0, #0
 ; CHECK-BE-NEXT:    mov pc, lr
 


### PR DESCRIPTION
Maybe a better solution is to improve the other passes to do this but this works too