### PR TITLE
[clang] Fix crash when diagnosing unsupported attributes

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -2034,7 +2034,8 @@ bool Sema::CheckAttrTarget(const ParsedAttr &AL) {
   // Check whether the attribute is valid on the current target.
   if (!AL.existsInTarget(Context.getTargetInfo())) {
     if (AL.isRegularKeywordAttribute())
-      Diag(AL.getLoc(), diag::err_keyword_not_supported_on_target);
+      Diag(AL.getLoc(), diag::err_keyword_not_supported_on_target)
+          << AL << AL.getRange();
     else
       DiagnoseUnknownAttribute(AL);
     AL.setInvalid();

--- a/clang/test/Sema/unsupported-arm-streaming.cpp
+++ b/clang/test/Sema/unsupported-arm-streaming.cpp
@@ -1,0 +1,3 @@
+// RUN: %clang_cc1 -x c -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s
+
+void arm_streaming(void) __arm_streaming {} // expected-error {{'__arm_streaming' is not supported on this target}}


### PR DESCRIPTION
In #141305, the attribute argument was (unintentionally) removed from the diagnostic emission.

Fixes #150237