### PR TITLE
[WIP][CFI] Use .cfi of aleasee if the function is infact a alias

### DIFF
--- a/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
+++ b/llvm/lib/Transforms/IPO/LowerTypeTests.cpp
@@ -2453,6 +2453,17 @@ bool LowerTypeTestsModule::lower() {
         } else {
           Alias->setName(AliasName);
         }
+
+        if (auto *F = M.getFunction((AliasName + ".cfi").str())) {
+          // Function can be an alias. In such case we need definition of .cfi
+          // of aliasee.
+          if (auto *CfiAleasee = M.getFunction((Aliasee + ".cfi").str())) {
+            F->replaceAllUsesWith(CfiAleasee);
+            F->eraseFromParent();
+          } else {
+            F->setName(Aliasee + ".cfi");
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Merged unit contains jump tables, but no
definition target functions. For each function
with canonical jump table it expects, that the
module with definition will rename function into
".cfi" version. However, it does not happend for
aliases. To overcome that we will use .cfi version
of aliasee.

Fixes #150075.
