### PR TITLE
[lldb][headers] Fix header staging target for RPC

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -302,7 +302,7 @@ list(REMOVE_ITEM root_public_headers ${root_private_headers})
 
 find_program(unifdef_EXECUTABLE unifdef)
 
-add_custom_target(liblldb-header-staging DEPENDS ${lldb_staged_headers} ${lldb_header_staging_dir}/lldb-defines.h)
+add_custom_target(liblldb-header-staging)
 
 if (LLDB_BUILD_FRAMEWORK)
   add_custom_target(lldb-framework-fixup-all-headers)
@@ -326,6 +326,8 @@ foreach(header
     set(copy_command ${CMAKE_COMMAND} -E copy ${header} ${staged_header})
   endif()
 
+  add_custom_target(liblldb-stage-header-${basename} DEPENDS ${staged_header})
+  add_dependencies(liblldb-header-staging liblldb-stage-header-${basename})
   add_custom_command(
     DEPENDS ${header} OUTPUT ${staged_header}
     COMMAND ${copy_command}

--- a/lldb/tools/lldb-rpc/LLDBRPCHeaders.cmake
+++ b/lldb/tools/lldb-rpc/LLDBRPCHeaders.cmake
@@ -79,7 +79,7 @@ function(FixIncludePaths in subfolder out)
 
   add_custom_command(OUTPUT ${parked_header}
     COMMAND ${LLDB_SOURCE_DIR}/scripts/framework-header-fix.py
-            -f lldb_rpc -i ${in} -o ${parked_header} -p ${unifdef_EXECUTABLE} USWIG
+            -f lldb_rpc -i ${in} -o ${parked_header} -p ${unifdef_EXECUTABLE} --unifdef_guards USWIG
     DEPENDS ${in}
     COMMENT "Fixing includes in ${in}"
   )


### PR DESCRIPTION
This commit fixes the target that stages headers in the build dir's include directory so that the headers are staged correctly so that the target for liblldbrpc-headers can depend on it properly