### PR TITLE
[M68k] Add anyext patterns for PCD addressing mode

### DIFF
--- a/llvm/lib/Target/M68k/M68kInstrData.td
+++ b/llvm/lib/Target/M68k/M68kInstrData.td
@@ -701,18 +701,22 @@ def: Pat<(MxExtLoadi16i8 MxCP_ARID:$src),
           (EXTRACT_SUBREG (MOVZXd32p8 MxARID8:$src), MxSubRegIndex16Lo)>;
 def: Pat<(MxExtLoadi16i8 MxCP_ARII:$src),
           (EXTRACT_SUBREG (MOVZXd32f8 MxARII8:$src), MxSubRegIndex16Lo)>;
+def: Pat<(MxExtLoadi16i8 MxCP_PCD:$src),
+          (EXTRACT_SUBREG (MOVZXd32q8 MxPCD8:$src), MxSubRegIndex16Lo)>;
 
 // i32 <- anyext i8
 def: Pat<(i32 (anyext i8:$src)), (MOVZXd32d8 MxDRD8:$src)>;
 def: Pat<(MxExtLoadi32i8 MxCP_ARI :$src), (MOVZXd32j8 MxARI8 :$src)>;
 def: Pat<(MxExtLoadi32i8 MxCP_ARID:$src), (MOVZXd32p8 MxARID8:$src)>;
 def: Pat<(MxExtLoadi32i8 MxCP_ARII:$src), (MOVZXd32f8 MxARII8:$src)>;
+def: Pat<(MxExtLoadi32i8 MxCP_PCD:$src), (MOVZXd32q8 MxPCD8:$src)>;
 
 // i32 <- anyext i16
 def: Pat<(i32 (anyext i16:$src)), (MOVZXd32d16 MxDRD16:$src)>;
 def: Pat<(MxExtLoadi32i16 MxCP_ARI :$src), (MOVZXd32j16 MxARI16 :$src)>;
 def: Pat<(MxExtLoadi32i16 MxCP_ARID:$src), (MOVZXd32p16 MxARID16:$src)>;
 def: Pat<(MxExtLoadi32i16 MxCP_ARII:$src), (MOVZXd32f16 MxARII16:$src)>;
+def: Pat<(MxExtLoadi32i16 MxCP_PCD:$src), (MOVZXd32q16 MxPCD16:$src)>;
 
 // trunc patterns
 def : Pat<(i16 (trunc i32:$src)),

--- a/llvm/test/CodeGen/M68k/Data/load-extend.ll
+++ b/llvm/test/CodeGen/M68k/Data/load-extend.ll
@@ -42,10 +42,9 @@ define i32 @"test_zext_pcd_i16_to_i32"() {
   ret i32 %val2
 }
 
-define i16 @"test_anyext_pcd_i8_to_i16"() {
+define i16 @test_anyext_pcd_i8_to_i16() nounwind {
 ; CHECK-LABEL: test_anyext_pcd_i8_to_i16:
-; CHECK:         .cfi_startproc
-; CHECK-NEXT:  ; %bb.0:
+; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    move.b (__unnamed_1+4,%pc), %d0
 ; CHECK-NEXT:    and.l #255, %d0
 ; CHECK-NEXT:    lsl.w #8, %d0
@@ -57,10 +56,9 @@ define i16 @"test_anyext_pcd_i8_to_i16"() {
   ret i16 %insert_shift
 }
 
-define i32 @"test_anyext_pcd_i8_to_i32"() {
+define i32 @test_anyext_pcd_i8_to_i32() nounwind {
 ; CHECK-LABEL: test_anyext_pcd_i8_to_i32:
-; CHECK:         .cfi_startproc
-; CHECK-NEXT:  ; %bb.0:
+; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    moveq #24, %d1
 ; CHECK-NEXT:    move.b (__unnamed_1+4,%pc), %d0
 ; CHECK-NEXT:    and.l #255, %d0
@@ -72,10 +70,9 @@ define i32 @"test_anyext_pcd_i8_to_i32"() {
   ret i32 %insert_shift
 }
 
-define i32 @"test_anyext_pcd_i16_to_i32"() {
+define i32 @test_anyext_pcd_i16_to_i32() nounwind {
 ; CHECK-LABEL: test_anyext_pcd_i16_to_i32:
-; CHECK:         .cfi_startproc
-; CHECK-NEXT:  ; %bb.0:
+; CHECK:       ; %bb.0:
 ; CHECK-NEXT:    moveq #16, %d1
 ; CHECK-NEXT:    move.w (__unnamed_1+4,%pc), %d0
 ; CHECK-NEXT:    and.l #65535, %d0

--- a/llvm/test/CodeGen/M68k/Data/load-extend.ll
+++ b/llvm/test/CodeGen/M68k/Data/load-extend.ll
@@ -41,3 +41,48 @@ define i32 @"test_zext_pcd_i16_to_i32"() {
   %val2 = zext i16 %val to i32
   ret i32 %val2
 }
+
+define i16 @"test_anyext_pcd_i8_to_i16"() {
+; CHECK-LABEL: test_anyext_pcd_i8_to_i16:
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    move.b (__unnamed_1+4,%pc), %d0
+; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    lsl.w #8, %d0
+; CHECK-NEXT:    ; kill: def $wd0 killed $wd0 killed $d0
+; CHECK-NEXT:    rts
+  %copyload = load i8, ptr getelementptr inbounds nuw (i8, ptr @0, i32 4)
+  %insert_ext = zext i8 %copyload to i16
+  %insert_shift = shl i16 %insert_ext, 8
+  ret i16 %insert_shift
+}
+
+define i32 @"test_anyext_pcd_i8_to_i32"() {
+; CHECK-LABEL: test_anyext_pcd_i8_to_i32:
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    moveq #24, %d1
+; CHECK-NEXT:    move.b (__unnamed_1+4,%pc), %d0
+; CHECK-NEXT:    and.l #255, %d0
+; CHECK-NEXT:    lsl.l %d1, %d0
+; CHECK-NEXT:    rts
+  %copyload = load i8, ptr getelementptr inbounds nuw (i8, ptr @0, i32 4)
+  %insert_ext = zext i8 %copyload to i32
+  %insert_shift = shl i32 %insert_ext, 24
+  ret i32 %insert_shift
+}
+
+define i32 @"test_anyext_pcd_i16_to_i32"() {
+; CHECK-LABEL: test_anyext_pcd_i16_to_i32:
+; CHECK:         .cfi_startproc
+; CHECK-NEXT:  ; %bb.0:
+; CHECK-NEXT:    moveq #16, %d1
+; CHECK-NEXT:    move.w (__unnamed_1+4,%pc), %d0
+; CHECK-NEXT:    and.l #65535, %d0
+; CHECK-NEXT:    lsl.l %d1, %d0
+; CHECK-NEXT:    rts
+  %copyload = load i16, ptr getelementptr inbounds nuw (i8, ptr @0, i32 4)
+  %insert_ext = zext i16 %copyload to i32
+  %insert_shift = shl i32 %insert_ext, 16
+  ret i32 %insert_shift
+}


### PR DESCRIPTION
Does what it says on the tin: anyext loads with the PCD addressing mode were failing addr mode selection, adding the patterns resolved it. 