### PR TITLE
[clang-format] Stop ctor initializer from being inlined

### DIFF
--- a/clang/lib/Format/ContinuationIndenter.cpp
+++ b/clang/lib/Format/ContinuationIndenter.cpp
@@ -1724,7 +1724,8 @@ unsigned ContinuationIndenter::moveStateToNextToken(LineState &State,
   }
   if (Previous && (Previous->isOneOf(TT_BinaryOperator, TT_ConditionalExpr) ||
                    (Previous->isOneOf(tok::l_paren, tok::comma, tok::colon) &&
-                    !Previous->isOneOf(TT_DictLiteral, TT_ObjCMethodExpr)))) {
+                    !Previous->isOneOf(TT_DictLiteral, TT_ObjCMethodExpr,
+                                       TT_CtorInitializerColon)))) {
     CurrentState.NestedBlockInlined =
         !Newline && hasNestedBlockInlined(Previous, Current, Style);
   }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -7771,6 +7771,37 @@ TEST_F(FormatTest, ConstructorInitializers) {
                "Constructor() :\n"
                "    // Comment forcing unwanted break.\n"
                "    aaaa(aaaa) {}");
+
+  // Braced initializers with trailing commas.
+  verifyFormat("MyClass::MyClass()\n"
+               "    : aaaa{\n"
+               "          0,\n"
+               "      } {}",
+               "MyClass::MyClass():aaaa{0,}{}", getGoogleStyle());
+  verifyFormat("MyClass::MyClass()\n"
+               "    : aaaa(0),\n"
+               "      bbbb{\n"
+               "          0,\n"
+               "      } {}",
+               "MyClass::MyClass():aaaa(0),bbbb{0,}{}", getGoogleStyle());
+  verifyFormat("MyClass::MyClass()\n"
+               "    : aaaa(0),\n"
+               "      bbbb{\n"
+               "          0,\n"
+               "      },\n"
+               "      cccc{\n"
+               "          0,\n"
+               "      } {}",
+               "MyClass::MyClass():aaaa(0),bbbb{0,},cccc{0,}{}",
+               getGoogleStyle());
+  verifyFormat("MyClass::MyClass()\n"
+               "    : aaaa{\n"
+               "          0,\n"
+               "      },\n"
+               "      bbbb{\n"
+               "          0,\n"
+               "      } {}",
+               "MyClass::MyClass():aaaa{0,},bbbb{0,}{}", getGoogleStyle());
 }
 
 TEST_F(FormatTest, AllowAllConstructorInitializersOnNextLine) {

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -7776,32 +7776,11 @@ TEST_F(FormatTest, ConstructorInitializers) {
   verifyFormat("MyClass::MyClass()\n"
                "    : aaaa{\n"
                "          0,\n"
-               "      } {}",
-               "MyClass::MyClass():aaaa{0,}{}", getGoogleStyle());
-  verifyFormat("MyClass::MyClass()\n"
-               "    : aaaa(0),\n"
-               "      bbbb{\n"
-               "          0,\n"
-               "      } {}",
-               "MyClass::MyClass():aaaa(0),bbbb{0,}{}", getGoogleStyle());
-  verifyFormat("MyClass::MyClass()\n"
-               "    : aaaa(0),\n"
-               "      bbbb{\n"
-               "          0,\n"
-               "      },\n"
-               "      cccc{\n"
-               "          0,\n"
-               "      } {}",
-               "MyClass::MyClass():aaaa(0),bbbb{0,},cccc{0,}{}",
-               getGoogleStyle());
-  verifyFormat("MyClass::MyClass()\n"
-               "    : aaaa{\n"
-               "          0,\n"
                "      },\n"
                "      bbbb{\n"
                "          0,\n"
                "      } {}",
-               "MyClass::MyClass():aaaa{0,},bbbb{0,}{}", getGoogleStyle());
+               "MyClass::MyClass():aaaa{0,},bbbb{0,}{}");
 }
 
 TEST_F(FormatTest, AllowAllConstructorInitializersOnNextLine) {


### PR DESCRIPTION
The colon in a constructor's initializer list triggers the inlining of a nested block as if it was a conditional operator expression. This prevents line breaks under certain circumstances when the initializer list contains braced initializers, which in turn prevents the line formatter from finding a solution.

In this commit we exclude colons that are a constructor initializer colon from consideration of nested block inlining.

Fixes #97242.
Fixes #81822.