### PR TITLE
[SCEV] Check bitwidth for constant ranges comparison

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -11380,7 +11380,8 @@ bool ScalarEvolution::isKnownPredicateViaConstantRanges(CmpPredicate Pred,
   auto CheckRange = [&](bool IsSigned) {
     auto RangeLHS = IsSigned ? getSignedRange(LHS) : getUnsignedRange(LHS);
     auto RangeRHS = IsSigned ? getSignedRange(RHS) : getUnsignedRange(RHS);
-    return RangeLHS.icmp(Pred, RangeRHS);
+    return RangeLHS.getBitWidth() == RangeRHS.getBitWidth() &&
+           RangeLHS.icmp(Pred, RangeRHS);
   };
 
   // The check at the top of the function catches the case where the values are


### PR DESCRIPTION
Fix a crash if using isKnownPredicate with differing SCEV types.
We don't ever seem to assert that the types are the same and finally
crash when reaching the path of constant range comparisons.
