### PR TITLE
[mlir][tosa] Fix integer-to-boolean cast folder

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1302,9 +1302,13 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
       auto intVal = operand.getSplatValue<APInt>();
       auto bitwidth = outETy.getIntOrFloatBitWidth();
 
+      // i1 types are boolean in TOSA
       if (trunc) {
-        intVal = intVal.trunc(bitwidth);
-        // i1 types are boolean in TOSA
+        if (outETy.isInteger(1)) {
+          intVal = intVal.isZero() ? APInt(bitwidth, 0) : APInt(bitwidth, 1);
+        } else {
+          intVal = intVal.trunc(bitwidth);
+        }
       } else if (unsignIn || inIntType.isInteger(1)) {
         intVal = intVal.zext(bitwidth);
       } else {

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1305,7 +1305,7 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
       // i1 types are boolean in TOSA
       if (trunc) {
         if (outETy.isInteger(1)) {
-          intVal = intVal.isZero() ? APInt(bitwidth, 0) : APInt(bitwidth, 1);
+          intVal = APInt(bitwidth, intVal.isZero() ? 0 : 1);
         } else {
           intVal = intVal.trunc(bitwidth);
         }

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1303,12 +1303,10 @@ OpFoldResult CastOp::fold(FoldAdaptor adaptor) {
       auto bitwidth = outETy.getIntOrFloatBitWidth();
 
       // i1 types are boolean in TOSA
-      if (trunc) {
-        if (outETy.isInteger(1)) {
-          intVal = APInt(bitwidth, intVal.isZero() ? 0 : 1);
-        } else {
-          intVal = intVal.trunc(bitwidth);
-        }
+      if (outETy.isInteger(1)) {
+        intVal = APInt(bitwidth, intVal.isZero() ? 0 : 1);
+      } else if (trunc) {
+        intVal = intVal.trunc(bitwidth);
       } else if (unsignIn || inIntType.isInteger(1)) {
         intVal = intVal.zext(bitwidth);
       } else {

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -1349,3 +1349,14 @@ func.func @test_fold_i1_to_i32_cast() -> tensor<i32> {
   %1 = "tosa.cast"(%0) : (tensor<i1>) -> tensor<i32>
   return %1 : tensor<i32>
 }
+
+// -----
+
+// CHECK-LABEL: @test_fold_i32_to_i1_cast
+// CHECK: %[[OUT:.*]] = "tosa.const"() <{values = dense<true> : tensor<i1>}> : () -> tensor<i1>
+// CHECK: return %[[OUT]] : tensor<i1>
+func.func @test_fold_i32_to_i1_cast() -> tensor<i1> {
+  %0 = "tosa.const"() <{values = dense<10> : tensor<i32>}> : () -> tensor<i32>
+  %1 = "tosa.cast"(%0) : (tensor<i32>) -> tensor<i1>
+  return %1 : tensor<i1>
+}


### PR DESCRIPTION
According to the TOSA spec, casting to boolean should produce true if the input is non-zero, and false otherwise — i.e., `out = (in != 0) ? true : false`. Previous behavior incorrectly relied on truncation, which could yield incorrect results for non-zero values whose least significant bit is zero. Fixes #150302.