### PR TITLE
[clang-format] Fix a bug in `DerivePointerAlignment: true`

### DIFF
--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -2643,13 +2643,14 @@ private:
       for (FormatToken *Tok = Line->First; Tok && Tok->Next; Tok = Tok->Next) {
         if (Tok->isNot(TT_PointerOrReference))
           continue;
-        // Don't treat space in `void foo() &&` as evidence.
+        // Don't treat space in `void foo() &&` or `void() &&` as evidence.
         if (const auto *Prev = Tok->getPreviousNonComment()) {
           if (Prev->is(tok::r_paren) && Prev->MatchingParen) {
             if (const auto *Func =
                     Prev->MatchingParen->getPreviousNonComment()) {
               if (Func->isOneOf(TT_FunctionDeclarationName, TT_StartOfName,
-                                TT_OverloadedOperator)) {
+                                TT_OverloadedOperator) ||
+                  Func->isTypeName(LangOpts)) {
                 continue;
               }
             }

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -12103,6 +12103,8 @@ TEST_F(FormatTest, UnderstandsFunctionRefQualification) {
   Prefix = "void a() const &;\n"
            "void b() const &;\n";
   verifyFormat(Prefix + "int *x;", Prefix + "int* x;", DerivePointerAlignment);
+
+  verifyGoogleFormat("MACRO(int*, std::function<void() &&>);");
 }
 
 TEST_F(FormatTest, PointerAlignmentFallback) {


### PR DESCRIPTION
Fixes #150327