### PR TITLE
[mlir] fix transform dialect doc includes

### DIFF
--- a/mlir/docs/Dialects/Transform.md
+++ b/mlir/docs/Dialects/Transform.md
@@ -415,9 +415,21 @@ ops rather than having the methods directly act on the payload IR.
 
 [include "Dialects/TransformOps.md"]
 
+## Tuning Extension Operaiton
+
+[include "Dialects/TuneExtensionOps.md"]
+
 ## Affine Transform Operations
 
 [include "Dialects/AffineLoopTransformOps.md"]
+
+## ARM Neon Transform Operations
+
+[include "Dialects/ArmNeonVectorTransformOps.md"]
+
+## ARM SVE Transform Operations
+
+[include "Dialects/ArmSVEVectorTransformOps.md"]
 
 ## Bufferization Transform Operations
 


### PR DESCRIPTION
New extensions were added to the code but not to the documentation.