### PR TITLE
[MSan] Fix check overflow in a test case

### DIFF
--- a/compiler-rt/test/msan/msan_check_mem_is_initialized.cpp
+++ b/compiler-rt/test/msan/msan_check_mem_is_initialized.cpp
@@ -12,7 +12,7 @@ int main(void) {
   __msan_poison(p + 10, 2);
 
   __msan_check_mem_is_initialized(p, 10);
-  __msan_check_mem_is_initialized(p + 12, 30);
+  __msan_check_mem_is_initialized(p + 12, 20);
 #ifdef POSITIVE
   __msan_check_mem_is_initialized(p + 5, 20);
   // CHECK: Uninitialized bytes in __msan_check_mem_is_initialized at offset 5 inside [0x{{.*}}, 20)


### PR DESCRIPTION
Supplement to PR #144073

Previously, _msan_check_mem_is_initialized.cpp_ initialized a 32-byte stack array, but checked the shadow for the offset range [12, 42), exceeding the stack array size.

MSan does not guarantee that the shadow corresponding to the overflow part is 0, so it is undefined to require the overflow part to be unpoisoned.