### PR TITLE
[lld][test] Fix unintentional write to a non-writeable dir

### DIFF
--- a/lld/test/ELF/aarch64-build-attributes-malformed.s
+++ b/lld/test/ELF/aarch64-build-attributes-malformed.s
@@ -1,7 +1,7 @@
 # REQUIRES: aarch64
 
 # RUN: llvm-mc -triple=aarch64 -filetype=obj %s -o %t.o
-# RUN: ld.lld %t.o /dev/null 2>&1 | FileCheck %s
+# RUN: ld.lld %t.o -o /dev/null 2>&1 | FileCheck %s
 
 # CHECK: (.ARM.attributes): unexpected end of data at offset 0x3f while reading [0x3d, 0x41)
 


### PR DESCRIPTION
The test added in #147970 fails trying to write `a.out` when run in a non-writeable directory. I believe the intent was to write to /dev/null as the output, but `-o` was omitted, so it's actually linking *in* /dev/null and writing to `a.out`.