### PR TITLE
[mlir][doc] Fix transform dialect tutorial ch3

### DIFF
--- a/mlir/docs/Tutorials/transform/Ch3.md
+++ b/mlir/docs/Tutorials/transform/Ch3.md
@@ -139,7 +139,20 @@ void MyExtension::init() {
 ```
 
 This type is now directly available in the Transform dialect and can be used in operations.
+We modify `$call` type must be `Transform_ConcreteOp<“func.call”>`, let it use the 
+`CallOpInterfaceHandle`.
 
+```tablegen
+def ChangeCallTargetOp : ... {
+    let arguments = (ins
+    // Specify the type constraint on the input accepting only `func.call` payload
+    // operations.
+    AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
+    StrAttr:$new_target); 
+}
+```
+
+We can then add the following to `sequence.mlir` and run it with the interpreter.
 
 ```mlir
   // Cast to our new type.
@@ -172,7 +185,7 @@ def CallToOp : Op<Transform_Dialect, "my.call_to_op",
   let results = (outs TransformHandleTypeInterface:$transformed);
 
   // Provide nice syntax.
-  let assemblyFormat = "$call attr-dict `:` functional-type(inputs, outputs)";
+  let assemblyFormat = "$call attr-dict `:` functional-type(operands, results)";
 
   // Declare the function implementing the interface for a single payload operation.
   let extraClassDeclaration = [{

--- a/mlir/docs/Tutorials/transform/Ch3.md
+++ b/mlir/docs/Tutorials/transform/Ch3.md
@@ -146,8 +146,8 @@ is allowed to be to any op implementing the interface.
 ```tablegen
 def ChangeCallTargetOp : ... {
     let arguments = (ins
-    // Allow the handle to be to concrete func.call ops as well as any op implementing
-    // the CallOpInterface.
+    // Allow the handle to be to concrete `func.call` ops as well as any op implementing
+    // the `CallOpInterface`.
     AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
     StrAttr:$new_target); 
 }

--- a/mlir/docs/Tutorials/transform/Ch3.md
+++ b/mlir/docs/Tutorials/transform/Ch3.md
@@ -140,13 +140,14 @@ void MyExtension::init() {
 
 This type is now directly available in the Transform dialect and can be used in operations.
 In the previous tablegen definition, the type of `$call` must be `Transform_ConcreteOp<“func.call”>`,
-now we make it possible to use `CallOpInterfaceHandle`.
+By adding `CallOpInterfaceHandle` as an allowed type for `$call`, the corresponding handle
+is allowed to be to any op implementing the interface.
 
 ```tablegen
 def ChangeCallTargetOp : ... {
     let arguments = (ins
-    // Specify the type constraint on the input accepting `func.call` and `CallOpInterface`
-    // payload operations.
+    // Allow the handle to be to concrete func.call ops as well as any op implementing
+    // the CallOpInterface.
     AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
     StrAttr:$new_target); 
 }

--- a/mlir/docs/Tutorials/transform/Ch3.md
+++ b/mlir/docs/Tutorials/transform/Ch3.md
@@ -140,13 +140,13 @@ void MyExtension::init() {
 
 This type is now directly available in the Transform dialect and can be used in operations.
 In the previous tablegen definition, the type of `$call` must be `Transform_ConcreteOp<“func.call”>`,
-now we make it can to use `CallOpInterfaceHandle`.
+now we make it possible to use `CallOpInterfaceHandle`.
 
 ```tablegen
 def ChangeCallTargetOp : ... {
     let arguments = (ins
-    // Specify the type constraint on the input accepting only `func.call` payload
-    // operations.
+    // Specify the type constraint on the input accepting `func.call` and `CallOpInterface`
+    // payload operations.
     AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
     StrAttr:$new_target); 
 }

--- a/mlir/docs/Tutorials/transform/Ch3.md
+++ b/mlir/docs/Tutorials/transform/Ch3.md
@@ -139,8 +139,8 @@ void MyExtension::init() {
 ```
 
 This type is now directly available in the Transform dialect and can be used in operations.
-We modify `$call` type must be `Transform_ConcreteOp<“func.call”>`, let it use the 
-`CallOpInterfaceHandle`.
+In the previous tablegen definition, the type of `$call` must be `Transform_ConcreteOp<“func.call”>`,
+now we make it can to use `CallOpInterfaceHandle`.
 
 ```tablegen
 def ChangeCallTargetOp : ... {
@@ -152,7 +152,7 @@ def ChangeCallTargetOp : ... {
 }
 ```
 
-We can then add the following to `sequence.mlir` and run it with the interpreter.
+We can then add the following code to `sequence.mlir` and run it with the interpreter.
 
 ```mlir
   // Cast to our new type.

--- a/mlir/examples/transform/Ch3/include/MyExtension.td
+++ b/mlir/examples/transform/Ch3/include/MyExtension.td
@@ -46,8 +46,8 @@ def ChangeCallTargetOp : Op<Transform_Dialect, "my.change_call_target",
   // We use a string attribute as the symbol may not exist in the transform IR so the 
   // verification may fail. 
   let arguments = (ins
-    // Specify the type constraint on the input accepting `func.call` and `CallOpInterface`
-    // payload operations.
+    // Allow the handle to be to concrete func.call ops as well as any op implementing
+    // the CallOpInterface.
     AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
     StrAttr:$new_target);
 

--- a/mlir/examples/transform/Ch3/include/MyExtension.td
+++ b/mlir/examples/transform/Ch3/include/MyExtension.td
@@ -48,7 +48,7 @@ def ChangeCallTargetOp : Op<Transform_Dialect, "my.change_call_target",
   let arguments = (ins
     // Specify the type constraint on the input accepting only `func.call` payload
     // operations.
-    Transform_ConcreteOpType<"func.call">:$call,
+    AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
     StrAttr:$new_target);
 
   // The results are empty as the transformation does not produce any new payload.

--- a/mlir/examples/transform/Ch3/include/MyExtension.td
+++ b/mlir/examples/transform/Ch3/include/MyExtension.td
@@ -46,8 +46,8 @@ def ChangeCallTargetOp : Op<Transform_Dialect, "my.change_call_target",
   // We use a string attribute as the symbol may not exist in the transform IR so the 
   // verification may fail. 
   let arguments = (ins
-    // Specify the type constraint on the input accepting only `func.call` payload
-    // operations.
+    // Specify the type constraint on the input accepting `func.call` and `CallOpInterface`
+    // payload operations.
     AnyTypeOf<[Transform_ConcreteOpType<"func.call">, CallOpInterfaceHandle]>:$call,
     StrAttr:$new_target);
 

--- a/mlir/test/Examples/transform/Ch3/ops.mlir
+++ b/mlir/test/Examples/transform/Ch3/ops.mlir
@@ -30,9 +30,30 @@ module attributes {transform.with_named_sequence} {
 // -----
 
 func.func private @orig()
+func.func private @updated()
 
 // CHECK-LABEL: func @test2
 func.func @test2() {
+  // CHECK: call @updated
+  call @orig() : () -> ()
+  return
+}
+
+module attributes {transform.with_named_sequence} {
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op) {
+    %call = transform.structured.match ops{["func.call"]} in %arg0 : (!transform.any_op) -> !transform.my.call_op_interface
+    // CHECK: transform.my.change_call_target %{{.*}}, "updated" : !transform.my.call_op_interface
+    transform.my.change_call_target %call, "updated" : !transform.my.call_op_interface
+    transform.yield
+  }
+}
+
+// -----
+
+func.func private @orig()
+
+// CHECK-LABEL: func @test3
+func.func @test3() {
   // CHECK: "my.mm4"
   call @orig() : () -> ()
   return

--- a/mlir/test/Examples/transform/Ch3/sequence.mlir
+++ b/mlir/test/Examples/transform/Ch3/sequence.mlir
@@ -101,11 +101,12 @@ module attributes {transform.with_named_sequence} {
     %_1, %outline_target = transform.structured.fuse_into_containing_op %matmul_fused_2 into %loop_third
         : (!transform.any_op, !transform.any_op) -> (!transform.any_op, !transform.any_op)
     %func, %call = transform.loop.outline %outline_target {func_name = "outlined"}
-        : (!transform.any_op) -> (!transform.any_op, !transform.op<"func.call">)
-  
-    // Rewrite the call target.
-    transform.my.change_call_target %call, "microkernel" : !transform.op<"func.call">
-  
+        : (!transform.any_op) -> (!transform.any_op, !transform.any_op)
+    // Cast to our new type.
+    %casted = transform.cast %call : !transform.any_op to !transform.my.call_op_interface
+    // Using our new operation.
+    transform.my.change_call_target %casted, "microkernel" : !transform.my.call_op_interface
+
     transform.yield
   }
 }


### PR DESCRIPTION
Fixed some bugs in documentation. Add CallOpInterfaceHandle to the arguments of ChangeCallTargetOp, after doing so the section described in the documentation works correctly, Otherwise the following code reports an error.
```
// Cast to our new type.
 %casted = transform.cast %call : !transform.any_op to !transform.my.call_op_interface
// Using our new operation.
 transform.my.change_call_target %casted, "microkernel" : !transform.my.call_op_interface
```