### PR TITLE
[RISCV] Guard against out of bound shifts in expandMul.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -16185,13 +16185,11 @@ static SDValue expandMul(SDNode *N, SelectionDAG &DAG,
     for (uint64_t Offset : {3, 5, 9}) {
       if (isPowerOf2_64(MulAmt + Offset)) {
         unsigned ShAmt = Log2_64(MulAmt + Offset);
-        SDLoc DL(N);
-        SDValue Shift1;
         if (ShAmt >= VT.getSizeInBits())
-          Shift1 = DAG.getConstant(0, DL, VT);
-        else
-          Shift1 =
-              DAG.getNode(ISD::SHL, DL, VT, X, DAG.getConstant(ShAmt, DL, VT));
+          continue;
+        SDLoc DL(N);
+        SDValue Shift1 =
+            DAG.getNode(ISD::SHL, DL, VT, X, DAG.getConstant(ShAmt, DL, VT));
         SDValue Mul359 =
             DAG.getNode(RISCVISD::SHL_ADD, DL, VT, X,
                         DAG.getConstant(Log2_64(Offset - 1), DL, VT), X);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -16184,10 +16184,15 @@ static SDValue expandMul(SDNode *N, SelectionDAG &DAG,
     // 2^N - 3/5/9 --> (sub (shl X, C1), (shXadd X, x))
     for (uint64_t Offset : {3, 5, 9}) {
       if (isPowerOf2_64(MulAmt + Offset)) {
+        unsigned ShAmt = Log2_64(MulAmt + Offset);
         SDLoc DL(N);
-        SDValue Shift1 =
+        SDValue Shift1;
+        if (ShAmt >= VT.getSizeInBits())
+          Shift1 = DAG.getConstant(0, DL, VT);
+        else
+          Shift1 =
             DAG.getNode(ISD::SHL, DL, VT, X,
-                        DAG.getConstant(Log2_64(MulAmt + Offset), DL, VT));
+                        DAG.getConstant(ShAmt, DL, VT));
         SDValue Mul359 =
             DAG.getNode(RISCVISD::SHL_ADD, DL, VT, X,
                         DAG.getConstant(Log2_64(Offset - 1), DL, VT), X);

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -16191,8 +16191,7 @@ static SDValue expandMul(SDNode *N, SelectionDAG &DAG,
           Shift1 = DAG.getConstant(0, DL, VT);
         else
           Shift1 =
-            DAG.getNode(ISD::SHL, DL, VT, X,
-                        DAG.getConstant(ShAmt, DL, VT));
+              DAG.getNode(ISD::SHL, DL, VT, X, DAG.getConstant(ShAmt, DL, VT));
         SDValue Mul359 =
             DAG.getNode(RISCVISD::SHL_ADD, DL, VT, X,
                         DAG.getConstant(Log2_64(Offset - 1), DL, VT), X);


### PR DESCRIPTION
Spotted while reviewing #150211. If we're multiplying by -3 in i32 MulAmt contains 4,294,967,293 since we zero extend to uint64_t. Adding 3 to this gives 0x100000000 which is a power of 2 and the log2 of that is 32, but we can't shift left by 32 in an i32.

Detect this case and skip the transform. We could use 0, but we don't handle the case for i64 so this seemed more consistent.

Normally we don't hit this case because decomposeMulByConstant handles it, but that's disabled by Xqciac. And after #150211 the path in expandMul will also be unreachable. So I didn't add a test to avoid messing with that review.