### PR TITLE
[Offload] Fix olWaitEvents tests after change to events API

### DIFF
--- a/offload/unittests/OffloadAPI/queue/olWaitEvents.cpp
+++ b/offload/unittests/OffloadAPI/queue/olWaitEvents.cpp
@@ -52,7 +52,8 @@ TEST_P(olWaitEventsTest, Success) {
       ASSERT_SUCCESS(olWaitEvents(Queues[I], &Events[I - 1], 1));
 
     ASSERT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
-                                  sizeof(Args), &LaunchArgs, &Events[I]));
+                                  sizeof(Args), &LaunchArgs));
+    ASSERT_SUCCESS(olCreateEvent(Queues[I], &Events[I]));
   }
 
   ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
@@ -85,7 +86,8 @@ TEST_P(olWaitEventsTest, SuccessSingleQueue) {
       ASSERT_SUCCESS(olWaitEvents(Queue, &Events[I - 1], 1));
 
     ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
-                                  &LaunchArgs, &Events[I]));
+                                  &LaunchArgs));
+    ASSERT_SUCCESS(olCreateEvent(Queue, &Events[I]));
   }
 
   ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
@@ -118,7 +120,8 @@ TEST_P(olWaitEventsTest, SuccessMultipleEvents) {
       ASSERT_SUCCESS(olWaitEvents(Queues[I], Events, I));
 
     ASSERT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
-                                  sizeof(Args), &LaunchArgs, &Events[I]));
+                                  sizeof(Args), &LaunchArgs));
+    ASSERT_SUCCESS(olCreateEvent(Queues[I], &Events[I]));
   }
 
   ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));


### PR DESCRIPTION
Fix the olWaitEvents tests after #150217 broke them