### PR TITLE
[ADT] Remove MutableArrayRef(std::nullopt_t) (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -317,10 +317,6 @@ namespace llvm {
     /// Construct an empty MutableArrayRef.
     /*implicit*/ MutableArrayRef() = default;
 
-    /// Construct an empty MutableArrayRef from std::nullopt.
-    /*implicit*/ LLVM_DEPRECATED("Use {} or MutableArrayRef<T>() instead", "{}")
-    MutableArrayRef(std::nullopt_t) : ArrayRef<T>() {}
-
     /// Construct a MutableArrayRef from a single element.
     /*implicit*/ MutableArrayRef(T &OneElt) : ArrayRef<T>(OneElt) {}
 


### PR DESCRIPTION
MutableArrayRef(std::nullopt_t) has been deprecated since:

  commit 9d6cbc3c20923759d9ffdf19b4f0d498f8cf5584
  Author: Kazu Hirata <kazu@google.com>
  Date:   Fri Jun 27 11:31:11 2025 -0700

I've never seen a use outside the LLVM project AFAICT, so this patch
just removes it ahead of ArrayRef(std::nullopt_t) to prevent
backsliding.
