### PR TITLE
[bazel] Add missing clang/unittests targets

### DIFF
--- a/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/BUILD.bazel
@@ -1892,6 +1892,29 @@ cc_library(
 )
 
 cc_library(
+    name = "directory_watcher",
+    srcs = glob([
+        "lib/DirectoryWatcher/*.cpp",
+        "lib/DirectoryWatcher/*.h",
+    ]) + select({
+        "@platforms//os:windows": glob(["lib/DirectoryWatcher/windows/*.cpp"]),
+        "@platforms//os:macos": glob(["lib/DirectoryWatcher/mac/*.cpp"]),
+        "@platforms//os:linux": glob(["lib/DirectoryWatcher/linux/*.cpp"]),
+        "//conditions:default": glob(["lib/DirectoryWatcher/default/*.cpp"]),
+    }),
+    hdrs = glob([
+        "include/clang/DirectoryWatcher/*.h",
+    ]),
+    includes = [
+        "include",
+        "lib/DirectoryWatcher",
+    ],
+    deps = [
+        "//llvm:Support",
+    ],
+)
+
+cc_library(
     name = "install_api",
     srcs = glob([
         "lib/InstallAPI/*.cpp",

--- a/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/clang/unittests/BUILD.bazel
@@ -2,9 +2,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-package(
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
@@ -93,6 +91,37 @@ cc_test(
         "//llvm:Support",
         "//third-party/unittest:gtest",
         "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "dataflow_testing_support",
+    testonly = 1,
+    srcs = ["Analysis/FlowSensitive/TestingSupport.cpp"],
+    hdrs = ["Analysis/FlowSensitive/TestingSupport.h"],
+    deps = [
+        "//clang:analysis",
+        "//clang:ast",
+        "//clang:ast_matchers",
+        "//clang:basic",
+        "//clang:lex",
+        "//clang:serialization",
+        "//clang:tooling",
+        "//llvm:Support",
+        "//llvm:TestingAnnotations",
+        "//third-party/unittest:gtest",
+    ],
+)
+
+cc_library(
+    name = "dataflow_solver_test",
+    testonly = 1,
+    hdrs = ["Analysis/FlowSensitive/SolverTest.h"],
+    deps = [
+        ":dataflow_testing_support",
+        "//clang:analysis",
+        "//third-party/unittest:gmock",
+        "//third-party/unittest:gtest",
     ],
 )
 
@@ -205,7 +234,6 @@ cc_test(
         [
             "Format/*.cpp",
             "Format/*.h",
-            "Tooling/*.h",
         ],
         allow_empty = False,
     ),
@@ -213,10 +241,10 @@ cc_test(
     features = ["-layering_check"],  # #include "../../lib/Format/TokenAnalyzer.h"
     shard_count = 20,
     deps = [
+        ":tooling_tests_hdrs",
         "//clang:basic",
         "//clang:format",
         "//clang:frontend",
-        "//clang:rewrite",
         "//clang:tooling_core",
         "//llvm:Support",
         "//third-party/unittest:gmock",
@@ -280,28 +308,6 @@ cc_test(
     ],
 )
 
-# A library to carefully expose the tooling headers using the include prefix
-# expected by the `rename_tests`.
-cc_library(
-    name = "rename_tests_tooling_hdrs",
-    testonly = 1,
-    hdrs = glob(
-        ["Tooling/*.h"],
-        allow_empty = False,
-    ),
-    include_prefix = "unittests",
-    deps = [
-        "//clang:ast",
-        "//clang:basic",
-        "//clang:frontend",
-        "//clang:rewrite",
-        "//clang:tooling",
-        "//clang:tooling_core",
-        "//llvm:Support",
-        "//third-party/unittest:gtest",
-    ],
-)
-
 cc_test(
     name = "rewrite_tests",
     size = "small",
@@ -349,12 +355,12 @@ cc_library(
         allow_empty = False,
     ),
     deps = [
+        "//clang:analysis",
         "//clang:ast_matchers",
         "//clang:crosstu",
         "//clang:frontend",
         "//clang:static_analyzer_core",
         "//clang:static_analyzer_frontend",
-        "//clang:testing",
         "//clang:tooling",
         "//third-party/unittest:gtest",
     ],
@@ -389,18 +395,35 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "tooling_tests_hdrs",
+    testonly = 1,
+    hdrs = glob(
+        ["Tooling/*.h"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:ast",
+        "//clang:basic",
+        "//clang:frontend",
+        "//clang:rewrite",
+        "//clang:tooling",
+        "//clang:tooling_core",
+        "//llvm:Support",
+        "//third-party/unittest:gtest",
+    ],
+)
+
 cc_test(
     name = "tooling_tests",
     size = "medium",
     srcs = glob(
-        [
-            "Tooling/*.cpp",
-            "Tooling/*.h",
-        ],
+        ["Tooling/*.cpp"],
         allow_empty = False,
     ),
     shard_count = 20,
     deps = [
+        ":tooling_tests_hdrs",
         "//clang:ast",
         "//clang:ast_matchers",
         "//clang:basic",
@@ -523,6 +546,196 @@ cc_test(
     }),
     deps = [
         "//clang:libclang",
+        "//llvm:Support",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "crosstu_tests",
+    size = "small",
+    srcs = glob(
+        ["CrossTU/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:ast",
+        "//clang:crosstu",
+        "//clang:frontend",
+        "//clang:tooling",
+        "//llvm:Support",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "driver_tests",
+    size = "small",
+    srcs = glob(
+        [
+            "Driver/*.cpp",
+            "Driver/*.h",
+        ],
+        allow_empty = False,
+        exclude = [
+            "Driver/GCCVersionTest.cpp",  # Includes private headers
+        ],
+    ),
+    deps = [
+        "//clang:basic",
+        "//clang:driver",
+        "//clang:frontend",
+        "//llvm:FrontendDebug",
+        "//llvm:MC",
+        "//llvm:Support",
+        "//llvm:TargetParser",
+        "//third-party/unittest:gmock",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "parse_tests",
+    size = "small",
+    srcs = glob(
+        ["Parse/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:ast",
+        "//clang:basic",
+        "//clang:lex",
+        "//clang:parse",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "directory_watcher_tests",
+    size = "small",
+    srcs = glob(
+        ["DirectoryWatcher/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:directory_watcher",
+        "//llvm:Support",
+        "//llvm:TestingSupport",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "index_tests",
+    size = "small",
+    srcs = glob(
+        ["Index/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:ast",
+        "//clang:basic",
+        "//clang:frontend",
+        "//clang:index",
+        "//clang:lex",
+        "//clang:tooling",
+        "//llvm:Support",
+        "//third-party/unittest:gmock",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "install_api_tests",
+    size = "small",
+    srcs = glob(
+        ["InstallAPI/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:install_api",
+        "//llvm:Support",
+        "//llvm:TestingSupport",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "interpreter_tests",
+    size = "small",
+    srcs = glob(
+        [
+            "Interpreter/*.cpp",
+            "Interpreter/*.h",
+        ],
+        allow_empty = False,
+    ),
+    args = [
+        # TODO: some tests fail with: "JIT session error: Symbols not found:
+        # [ _ZnwmPv26__clang_Interpreter_NewTag, __clang_Interpreter_SetValueWithAlloc ]
+        "--gtest_filter=-InterpreterTest.*",
+    ],
+    deps = [
+        "//clang:ast",
+        "//clang:basic",
+        "//clang:codegen",
+        "//clang:frontend",
+        "//clang:interpreter",
+        "//clang:lex",
+        "//clang:parse",
+        "//clang:sema",
+        "//llvm:LineEditor",
+        "//llvm:MC",
+        "//llvm:OrcJIT",
+        "//llvm:OrcShared",
+        "//llvm:Support",
+        "//llvm:TargetParser",
+        "//llvm:TestingSupport",
+        "//llvm:ir_headers",
+        "//third-party/unittest:gmock",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "serialization_tests",
+    size = "small",
+    srcs = glob(
+        ["Serialization/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:ast_matchers",
+        "//clang:basic",
+        "//clang:frontend",
+        "//clang:lex",
+        "//clang:parse",
+        "//clang:serialization",
+        "//clang:tooling",
+        "//llvm:Support",
+        "//third-party/unittest:gtest",
+        "//third-party/unittest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "support_tests",
+    size = "small",
+    srcs = glob(
+        ["Support/*.cpp"],
+        allow_empty = False,
+    ),
+    deps = [
+        "//clang:frontend",
+        "//clang:lex",
         "//llvm:Support",
         "//third-party/unittest:gtest",
         "//third-party/unittest:gtest_main",


### PR DESCRIPTION
Mostly just adding tests that are in clang/unittests/CMakeLists.txt, but there a couple other cleanups here:
* Add `directory_watcher` targets in clang so we can add tests for it
* Add some library targets (e.g. `dataflow_testing_support`) for downstream use (e.g. unit tests outside of LLVM that use these headers in tests)
* Remove `rename_tests_tooling_hdrs` which has been unused since `rename_tests` itself was deleted

The InterpreterTest target added here passes on our internal CI, but fails when I run it w/ bazel for some reason:
```
[ RUN      ] InterpreterTest.InstantiateTemplate
JIT session error: Symbols not found: [ __clang_Interpreter_SetValueWithAlloc, _ZnwmPv26__clang_Interpreter_NewTag ]
Failure value returned from cantFail wrapped call
Failed to materialize symbols: { (main, { __orc_init_func.incr_module_133, $.incr_module_133.__inits.0 }) }
```
I'd like to figure out what's going on, but for now I just excluded it w/ a test filter