### PR TITLE
[MemProf] Fix FileCheck prefix in the histogram test.

### DIFF
--- a/llvm/test/tools/llvm-profdata/memprof-padding-histogram.test
+++ b/llvm/test/tools/llvm-profdata/memprof-padding-histogram.test
@@ -21,79 +21,79 @@ CHECK-NEXT:     Offset: 0x{{[[:xdigit:]]+}}
 CHECK-NEXT:   -
 
 CHECK:   Records:
-CHEC-NEXT    FunctionGUID: {{[0-9]+}}
-CHEC-NEXT    AllocSites:
-CHEC-NEXT    -
-CHEC-NEXT      Callstack:
-CHEC-NEXT      -
-CHEC-NEXT        Function: {{[0-9]+}}
-CHEC-NEXT        SymbolName: main
-CHEC-NEXT        LineOffset: 3
-CHEC-NEXT        Column: 10
-CHEC-NEXT        Inline: 0
-CHEC-NEXT      MemInfoBlock:
-CHEC-NEXT        AllocCount: 1
-CHEC-NEXT        TotalAccessCount: 5
-CHEC-NEXT        MinAccessCount: 5
-CHEC-NEXT        MaxAccessCount: 5
-CHEC-NEXT        TotalSize: 24
-CHEC-NEXT        MinSize: 24
-CHEC-NEXT        MaxSize: 24
-CHEC-NEXT        AllocTimestamp: {{[0-9]+}}
-CHEC-NEXT        DeallocTimestamp: {{[0-9]+}}
-CHEC-NEXT        TotalLifetime: 0
-CHEC-NEXT        MinLifetime: 0
-CHEC-NEXT        MaxLifetime: 0
-CHEC-NEXT        AllocCpuId: 11
-CHEC-NEXT        DeallocCpuId: 11
-CHEC-NEXT        NumMigratedCpu: 0
-CHEC-NEXT        NumLifetimeOverlaps: 0
-CHEC-NEXT        NumSameAllocCpu: 0
-CHEC-NEXT        NumSameDeallocCpu: 0
-CHEC-NEXT        DataTypeId: 0
-CHEC-NEXT        TotalAccessDensity: 20
-CHEC-NEXT        MinAccessDensity: 20
-CHEC-NEXT        MaxAccessDensity: 20
-CHEC-NEXT        TotalLifetimeAccessDensity: 20000
-CHEC-NEXT        MinLifetimeAccessDensity: 20000
-CHEC-NEXT        MaxLifetimeAccessDensity: 20000
-CHEC-NEXT        AccessHistogramSize: 3
-CHEC-NEXT        AccessHistogram: {{[0-9]+}}
-CHEC-NEXT        AccessHistogramValues: -2 -1 -2
-CHEC-NEXT    -
-CHEC-NEXT      Callstack:
-CHEC-NEXT      -
-CHEC-NEXT        Function: {{[0-9]+}}
-CHEC-NEXT        SymbolName: main
-CHEC-NEXT        LineOffset: 10
-CHEC-NEXT        Column: 10
-CHEC-NEXT        Inline: 0
-CHEC-NEXT      MemInfoBlock:
-CHEC-NEXT        AllocCount: 1
-CHEC-NEXT        TotalAccessCount: 4
-CHEC-NEXT        MinAccessCount: 4
-CHEC-NEXT        MaxAccessCount: 4
-CHEC-NEXT        TotalSize: 48
-CHEC-NEXT        MinSize: 48
-CHEC-NEXT        MaxSize: 48
-CHEC-NEXT        AllocTimestamp: {{[0-9]+}}
-CHEC-NEXT        DeallocTimestamp: {{[0-9]+}}
-CHEC-NEXT        TotalLifetime: 0
-CHEC-NEXT        MinLifetime: 0
-CHEC-NEXT        MaxLifetime: 0
-CHEC-NEXT        AllocCpuId: 11
-CHEC-NEXT        DeallocCpuId: 11
-CHEC-NEXT        NumMigratedCpu: 0
-CHEC-NEXT        NumLifetimeOverlaps: 0
-CHEC-NEXT        NumSameAllocCpu: 0
-CHEC-NEXT        NumSameDeallocCpu: 0
-CHEC-NEXT        DataTypeId: 0
-CHEC-NEXT        TotalAccessDensity: 8
-CHEC-NEXT        MinAccessDensity: 8
-CHEC-NEXT        MaxAccessDensity: 8
-CHEC-NEXT        TotalLifetimeAccessDensity: 8000
-CHEC-NEXT        MinLifetimeAccessDensity: 8000
-CHEC-NEXT        MaxLifetimeAccessDensity: 8000
-CHEC-NEXT        AccessHistogramSize: 6
-CHEC-NEXT        AccessHistogram: {{[0-9]+}}
-CHEC-NEXT        AccessHistogramValues: -2 -0 -0 -0 -1 -1
+CHECK-NEXT    FunctionGUID: {{[0-9]+}}
+CHECK-NEXT    AllocSites:
+CHECK-NEXT    -
+CHECK-NEXT      Callstack:
+CHECK-NEXT      -
+CHECK-NEXT        Function: {{[0-9]+}}
+CHECK-NEXT        SymbolName: main
+CHECK-NEXT        LineOffset: 3
+CHECK-NEXT        Column: 10
+CHECK-NEXT        Inline: 0
+CHECK-NEXT      MemInfoBlock:
+CHECK-NEXT        AllocCount: 1
+CHECK-NEXT        TotalAccessCount: 5
+CHECK-NEXT        MinAccessCount: 5
+CHECK-NEXT        MaxAccessCount: 5
+CHECK-NEXT        TotalSize: 24
+CHECK-NEXT        MinSize: 24
+CHECK-NEXT        MaxSize: 24
+CHECK-NEXT        AllocTimestamp: {{[0-9]+}}
+CHECK-NEXT        DeallocTimestamp: {{[0-9]+}}
+CHECK-NEXT        TotalLifetime: 0
+CHECK-NEXT        MinLifetime: 0
+CHECK-NEXT        MaxLifetime: 0
+CHECK-NEXT        AllocCpuId: 11
+CHECK-NEXT        DeallocCpuId: 11
+CHECK-NEXT        NumMigratedCpu: 0
+CHECK-NEXT        NumLifetimeOverlaps: 0
+CHECK-NEXT        NumSameAllocCpu: 0
+CHECK-NEXT        NumSameDeallocCpu: 0
+CHECK-NEXT        DataTypeId: 0
+CHECK-NEXT        TotalAccessDensity: 20
+CHECK-NEXT        MinAccessDensity: 20
+CHECK-NEXT        MaxAccessDensity: 20
+CHECK-NEXT        TotalLifetimeAccessDensity: 20000
+CHECK-NEXT        MinLifetimeAccessDensity: 20000
+CHECK-NEXT        MaxLifetimeAccessDensity: 20000
+CHECK-NEXT        AccessHistogramSize: 3
+CHECK-NEXT        AccessHistogram: {{[0-9]+}}
+CHECK-NEXT        AccessHistogramValues: -2 -1 -2
+CHECK-NEXT    -
+CHECK-NEXT      Callstack:
+CHECK-NEXT      -
+CHECK-NEXT        Function: {{[0-9]+}}
+CHECK-NEXT        SymbolName: main
+CHECK-NEXT        LineOffset: 10
+CHECK-NEXT        Column: 10
+CHECK-NEXT        Inline: 0
+CHECK-NEXT      MemInfoBlock:
+CHECK-NEXT        AllocCount: 1
+CHECK-NEXT        TotalAccessCount: 4
+CHECK-NEXT        MinAccessCount: 4
+CHECK-NEXT        MaxAccessCount: 4
+CHECK-NEXT        TotalSize: 48
+CHECK-NEXT        MinSize: 48
+CHECK-NEXT        MaxSize: 48
+CHECK-NEXT        AllocTimestamp: {{[0-9]+}}
+CHECK-NEXT        DeallocTimestamp: {{[0-9]+}}
+CHECK-NEXT        TotalLifetime: 0
+CHECK-NEXT        MinLifetime: 0
+CHECK-NEXT        MaxLifetime: 0
+CHECK-NEXT        AllocCpuId: 11
+CHECK-NEXT        DeallocCpuId: 11
+CHECK-NEXT        NumMigratedCpu: 0
+CHECK-NEXT        NumLifetimeOverlaps: 0
+CHECK-NEXT        NumSameAllocCpu: 0
+CHECK-NEXT        NumSameDeallocCpu: 0
+CHECK-NEXT        DataTypeId: 0
+CHECK-NEXT        TotalAccessDensity: 8
+CHECK-NEXT        MinAccessDensity: 8
+CHECK-NEXT        MaxAccessDensity: 8
+CHECK-NEXT        TotalLifetimeAccessDensity: 8000
+CHECK-NEXT        MinLifetimeAccessDensity: 8000
+CHECK-NEXT        MaxLifetimeAccessDensity: 8000
+CHECK-NEXT        AccessHistogramSize: 6
+CHECK-NEXT        AccessHistogram: {{[0-9]+}}
+CHECK-NEXT        AccessHistogramValues: -2 -0 -0 -0 -1 -1


### PR DESCRIPTION
The test is fine though it seems the checks weren't being enforced because of the typo.