### PR TITLE
Fix a nullptr dereferencing in a `FuncBufferizableOpInterfaceImpl.cpp::getCalledFunction`

### DIFF
--- a/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.cpp
@@ -90,8 +90,9 @@ static FuncOp getCalledFunction(CallOpInterface callOp,
                                 const AnalysisState &state) {
   auto &oneShotAnalysisState = static_cast<const OneShotAnalysisState &>(state);
 
-  if (auto *funcAnalysisState =
-          oneShotAnalysisState.getExtension<FuncAnalysisState>()) {
+  auto *funcAnalysisState =
+      oneShotAnalysisState.getExtension<FuncAnalysisState>();
+  if (funcAnalysisState != nullptr) {
     // Use the cached symbol tables.
     return getCalledFunction(callOp, funcAnalysisState->symbolTables);
   }


### PR DESCRIPTION
There is a potential nullptr dereferencing in the helper function `getCalledFunction` when bufferizing call ops.
The solution is making the nullptr check explicit before dereferencing it.

Fixes #150441.

