### PR TITLE
[libc][bazel] Enable parse_headers feature for llvm-libc.

### DIFF
--- a/libc/src/__support/math/exp.h
+++ b/libc/src/__support/math/exp.h
@@ -234,7 +234,7 @@ static double set_exceptional(double x) {
 
 namespace math {
 
-static double exp(double x) {
+static constexpr double exp(double x) {
   using FPBits = typename fputil::FPBits<double>;
   FPBits xbits(x);
 

--- a/libc/src/math/generic/range_reduction_double_common.h
+++ b/libc/src/math/generic/range_reduction_double_common.h
@@ -278,7 +278,7 @@ private:
 };
 
 #ifndef LIBC_MATH_HAS_SKIP_ACCURATE_PASS
-static Float128 range_reduction_small_f128(double x) {
+LIBC_INLINE static Float128 range_reduction_small_f128(double x) {
   constexpr Float128 PI_OVER_128_F128 = {
       Sign::POS, -133, 0xc90f'daa2'2168'c234'c4c6'628b'80dc'1cd1_u128};
   constexpr double ONE_TWENTY_EIGHT_OVER_PI_D = 0x1.45f306dc9c883p5;

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -19,6 +19,7 @@ load(":platforms.bzl", "PLATFORM_CPU_ARM64", "PLATFORM_CPU_X86_64")
 package(
     default_visibility = ["//visibility:public"],
     features = [
+        "parse_headers",
         "-use_header_modules",
         "-layering_check",
     ],


### PR DESCRIPTION
See https://bazel.build/docs/bazel-and-cpp#toolchain-features for why this feature is recommended for C++ projects.
215dbcb2bc5c1b1bc8775db2a7c22f67f3949fd7 added the necessary default Bazel flag to make this feature functional. It can be enabled on a per-project basis. Do this now for llvm-libc.

After enabling this feature, Blaze tries to parse headers from all header-only libraries, even if the headers are not explicitly used in tests, which allows to detect the issues early on.

Fix a couple of -Wunused-function warnings by marking the static functions as constexpr or inline.