### PR TITLE
[GVN/MemDep] Limit the size of the cache for non-local dependencies.

### DIFF
--- a/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
@@ -81,7 +81,7 @@ static cl::opt<unsigned>
                               "dependency analysis (default = 200)"));
 
 static cl::opt<unsigned> CacheGlobalLimit(
-    "cache-global-limit", cl::Hidden, cl::init(10000),
+    "memdep-cache-global-limit", cl::Hidden, cl::init(10000),
     cl::desc("The max number of entries allowed in a cache (default = 10000)"));
 
 // Limit on the number of memdep results to process.
@@ -1147,9 +1147,8 @@ bool MemoryDependenceResults::getNonLocalPointerDepFromBB(
   }
 
   // If the size of this cache has surpassed the global limit, stop here.
-  if (Cache->size() > CacheGlobalLimit) {
+  if (Cache->size() > CacheGlobalLimit)
     return false;
-  }
 
   // Otherwise, either this is a new block, a block with an invalid cache
   // pointer or one that we're about to invalidate by putting more info into

--- a/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
+++ b/llvm/lib/Analysis/MemoryDependenceAnalysis.cpp
@@ -80,6 +80,10 @@ static cl::opt<unsigned>
                      cl::desc("The number of blocks to scan during memory "
                               "dependency analysis (default = 200)"));
 
+static cl::opt<unsigned> CacheGlobalLimit(
+    "cache-global-limit", cl::Hidden, cl::init(10000),
+    cl::desc("The max number of entries allowed in a cache (default = 10000)"));
+
 // Limit on the number of memdep results to process.
 static const unsigned int NumResultsLimit = 100;
 
@@ -1140,6 +1144,11 @@ bool MemoryDependenceResults::getNonLocalPointerDepFromBB(
     }
     ++NumCacheCompleteNonLocalPtr;
     return true;
+  }
+
+  // If the size of this cache has surpassed the global limit, stop here.
+  if (Cache->size() > CacheGlobalLimit) {
+    return false;
   }
 
   // Otherwise, either this is a new block, a block with an invalid cache


### PR DESCRIPTION
An attempt to resolve the issue flagged in [PR150531](https://github.com/llvm/llvm-project/issues/150531)