### PR TITLE
[MSSAUpdater] Replace recursion with worklist and cap it.

### DIFF
--- a/llvm/include/llvm/Analysis/MemorySSAUpdater.h
+++ b/llvm/include/llvm/Analysis/MemorySSAUpdater.h
@@ -257,7 +257,6 @@ private:
   MemoryAccess *
   getPreviousDefRecursive(BasicBlock *,
                           DenseMap<BasicBlock *, TrackingVH<MemoryAccess>> &);
-  MemoryAccess *recursePhi(MemoryAccess *Phi);
   MemoryAccess *tryRemoveTrivialPhi(MemoryPhi *Phi);
   template <class RangeType>
   MemoryAccess *tryRemoveTrivialPhi(MemoryPhi *Phi, RangeType &Operands);

--- a/llvm/lib/Analysis/MemorySSAUpdater.cpp
+++ b/llvm/lib/Analysis/MemorySSAUpdater.cpp
@@ -229,8 +229,8 @@ MemoryAccess *MemorySSAUpdater::tryRemoveTrivialPhi(MemoryPhi *Phi,
     return nullptr;
 
   // Worklist approach to recursively removing trivial Phis.
-  SmallVector<Value*, 5> Worklist;
-  SmallSetVector<Value*, 5> Visited;
+  SmallVector<Value *, 5> Worklist;
+  SmallSetVector<Value *, 5> Visited;
 
   for (auto U : Same->users()) {
     if (dyn_cast<MemoryPhi>(&*U))

--- a/llvm/lib/Analysis/MemorySSAUpdater.cpp
+++ b/llvm/lib/Analysis/MemorySSAUpdater.cpp
@@ -238,7 +238,7 @@ MemoryAccess *MemorySSAUpdater::tryRemoveTrivialPhi(MemoryPhi *Phi,
       Worklist.push_back(TrackingVH<Value>(U));
   }
 
-  while (!Worklist.empty() || Worklist.size() > TrivialPhiProcessingLimit) {
+  while (!Worklist.empty() && Worklist.size() < TrivialPhiProcessingLimit) {
     MemoryPhi *RecPhi = dyn_cast<MemoryPhi>(&*(Worklist[Worklist.size() - 1]));
     Worklist.pop_back();
 


### PR DESCRIPTION
Replace the recursion used for finding and removing trivial MemoryPhis with a worklist approach and add a cap for it for pathological cases.

This came up in a profile that also found #150531, where a lot of time was found on copying the MemoryPhi operands during the recusion.