### PR TITLE
[libc++][hardening] Don't use `fputs` on Fuchsia.

### DIFF
--- a/libcxx/src/experimental/log_hardening_failure.cpp
+++ b/libcxx/src/experimental/log_hardening_failure.cpp
@@ -18,7 +18,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 void __log_hardening_failure(const char* message) noexcept {
   // Always log the message to `stderr` in case the platform-specific system calls fail.
+#ifndef __Fuchsia__ // `fputs` is not available on Fuchsia.
   std::fputs(message, stderr);
+#endif
 
 #if defined(__BIONIC__)
   // Show error in logcat. The latter two arguments are ignored on Android.


### PR DESCRIPTION
This is a quick fix for a build error on Fuchsia where many C standard
library filesystem-related functions are not available; it effectively
makes the hardening log function a no-op on Fuchsia.

Links:
* https://github.com/llvm/llvm-project/pull/149452#issuecomment-3115230157
* https://ci.chromium.org/ui/p/fuchsia/builders/toolchain.ci/clang-linux-x64/b8708441153070837249/overview
