### PR TITLE
[clang] Fix issue with FoldingSet and DependentTemplateSpecialization…

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -238,9 +238,9 @@ class ASTContext : public RefCountedBase<ASTContext> {
   mutable llvm::FoldingSet<ElaboratedType> ElaboratedTypes{
       GeneralTypesLog2InitSize};
   mutable llvm::FoldingSet<DependentNameType> DependentNameTypes;
-  mutable llvm::ContextualFoldingSet<DependentTemplateSpecializationType,
-                                     ASTContext&>
-    DependentTemplateSpecializationTypes;
+  mutable llvm::DenseMap<llvm::FoldingSetNodeID,
+                         DependentTemplateSpecializationType *>
+      DependentTemplateSpecializationTypes;
   mutable llvm::FoldingSet<PackExpansionType> PackExpansionTypes;
   mutable llvm::FoldingSet<ObjCObjectTypeImpl> ObjCObjectTypes;
   mutable llvm::FoldingSet<ObjCObjectPointerType> ObjCObjectPointerTypes;

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -7276,8 +7276,7 @@ public:
 /// Represents a template specialization type whose template cannot be
 /// resolved, e.g.
 ///   A<T>::template B<T>
-class DependentTemplateSpecializationType : public TypeWithKeyword,
-                                            public llvm::FoldingSetNode {
+class DependentTemplateSpecializationType : public TypeWithKeyword {
   friend class ASTContext; // ASTContext creates these
 
   DependentTemplateStorage Name;

--- a/clang/test/Parser/dep_template_spec_type.cpp
+++ b/clang/test/Parser/dep_template_spec_type.cpp
@@ -1,0 +1,16 @@
+// RUN: seq 100 | xargs -Ifoo %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+// This is a regression test for a non-deterministic stack-overflow.
+
+template <typename C, typename S1, int rbits>
+typename C::A Bar(const S1& x, const C& c = C()) {
+    using T = typename C::A;
+    T result;
+
+    using PreC = typename C::template boop<T::p + rbits>;
+    using ExactC = typename C::template bap<PreC::p + 2>;
+
+    using D = typename ExactC::A;
+
+    return result;
+}


### PR DESCRIPTION
…Type

PR #118288 fixed a re-entrancy issue with the usage of `FoldingSet` and `AutoType`.  The following test case (reduced with `creduce` by @Fznamznon):

```
template <typename C, typename S1, int rbits>
typename C::A Bar(const S1& x, const C& c = C()) {
    using T = typename C::A;
    T result;

    using PreC = typename C::template boop<T::p + rbits>;
    using ExactC = typename C::template bap<PreC::p + 2>;

    using D = typename ExactC::A;

    return result;
}
```

shows a similar non-deterministic recursion with the use of `FoldingSet` but with `DependentTemplateSepcializationType`. A nearly identical fix is needed here too.