### PR TITLE
[TableGen] Strengthen check for what operands can be an immediate in CompressInstEmitter.

### DIFF
--- a/llvm/utils/TableGen/CompressInstEmitter.cpp
+++ b/llvm/utils/TableGen/CompressInstEmitter.cpp
@@ -269,7 +269,7 @@ void CompressInstEmitter::addDagOperandMapping(const Record *Rec,
         OperandMap[OpNo].Kind = OpData::Operand;
       } else if (const auto *II = dyn_cast<IntInit>(Dag->getArg(DAGOpNo))) {
         // Validate that corresponding instruction operand expects an immediate.
-        if (OpndRec->isSubClassOf("RegisterClass"))
+        if (!OpndRec->isSubClassOf("Operand"))
           PrintFatalError(Rec->getLoc(), "Error in Dag '" + Dag->getAsString() +
                                              "' Found immediate: '" +
                                              II->getAsString() +


### PR DESCRIPTION
Registers can be represented by RegisterOperand, not just RegisterClass. Instead of trying to block certain classes, only allow Operand.