### PR TITLE
[mlir][tosa] Use `typeConverter->convertType<T>`

### DIFF
--- a/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
+++ b/mlir/lib/Conversion/TosaToLinalg/TosaToLinalgNamed.cpp
@@ -742,7 +742,7 @@ public:
 
     bool isUnsigned = op.getType().getElementType().isUnsignedInteger();
     ShapedType resultTy =
-        cast<ShapedType>(getTypeConverter()->convertType(op.getType()));
+        getTypeConverter()->convertType<ShapedType>(op.getType());
     if (!resultTy)
       return rewriter.notifyMatchFailure(op, "failed to convert type");
     Type resultETy = inputTy.getElementType();

--- a/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
+++ b/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
@@ -230,7 +230,7 @@ public:
                   ConversionPatternRewriter &rewriter) const final {
     auto loc = reshape.getLoc();
     auto resultType =
-        getTypeConverter()->convertType<ShapedType>(reshape.getType()));
+        getTypeConverter()->convertType<ShapedType>(reshape.getType());
     if (!resultType) {
       return rewriter.notifyMatchFailure(reshape.getLoc(),
                                          "could not convert result type");

--- a/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
+++ b/mlir/lib/Conversion/TosaToTensor/TosaToTensor.cpp
@@ -229,8 +229,8 @@ public:
   matchAndRewrite(tosa::ReshapeOp reshape, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const final {
     auto loc = reshape.getLoc();
-    auto resultType = cast_if_present<ShapedType>(
-        getTypeConverter()->convertType(reshape.getType()));
+    auto resultType =
+        getTypeConverter()->convertType<ShapedType>(reshape.getType()));
     if (!resultType) {
       return rewriter.notifyMatchFailure(reshape.getLoc(),
                                          "could not convert result type");


### PR DESCRIPTION
Since `resultTy` might be nullptr, we should use `dyn_cast` instead of `cast`. Additionally, `typeConverter->convertType<T>` is more appropriate in this context.