### PR TITLE
[Analysis] Prevent revisiting block when searching for noreturn vars

### DIFF
--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -503,8 +503,12 @@ static bool areAllValuesNoReturn(const VarDecl *VD, const CFGBlock &VarBlk,
 
   TransferFunctions TF(VD);
   BackwardDataflowWorklist Worklist(*AC.getCFG(), AC);
+  llvm::DenseSet<const CFGBlock *> Visited;
   Worklist.enqueueBlock(&VarBlk);
   while (const CFGBlock *B = Worklist.dequeue()) {
+    if (Visited.contains(B))
+      continue;
+    Visited.insert(B);
     // First check the current block.
     for (CFGBlock::const_reverse_iterator ri = B->rbegin(), re = B->rend();
          ri != re; ++ri) {

--- a/clang/test/SemaCXX/noreturn-vars.cpp
+++ b/clang/test/SemaCXX/noreturn-vars.cpp
@@ -225,3 +225,20 @@ extern void abc_02(func_type *);
   abc_02(&func_ptr);
   func_ptr();
 } // expected-warning {{function declared 'noreturn' should not return}}
+
+namespace Issue150336 {
+void free(void *);
+typedef void (*sel_freefunc)(void *);
+struct gmx_ana_selmethod_t {
+  sel_freefunc free;
+  int nparams;
+  int *param;
+};
+void gmx_selelem_free_method(struct gmx_ana_selmethod_t* method, void* mdata) {
+    sel_freefunc free_func = 0;
+    for (int i = 0; i < method->nparams; ++i)
+        free(&method->param[i]);
+    if (mdata && free_func)
+        free_func(mdata);
+}
+}

--- a/clang/test/SemaCXX/noreturn-vars.cpp
+++ b/clang/test/SemaCXX/noreturn-vars.cpp
@@ -225,20 +225,3 @@ extern void abc_02(func_type *);
   abc_02(&func_ptr);
   func_ptr();
 } // expected-warning {{function declared 'noreturn' should not return}}
-
-namespace Issue150336 {
-void free(void *);
-typedef void (*sel_freefunc)(void *);
-struct selmethod_t {
-  sel_freefunc free;
-  int nparams;
-  int *param;
-};
-void selelem_free_method(struct selmethod_t* method, void* mdata) {
-    sel_freefunc free_func = 0;
-    for (int i = 0; i < method->nparams; ++i)
-        free(&method->param[i]);
-    if (mdata && free_func)
-        free_func(mdata);
-}
-}

--- a/clang/test/SemaCXX/noreturn-vars.cpp
+++ b/clang/test/SemaCXX/noreturn-vars.cpp
@@ -229,12 +229,12 @@ extern void abc_02(func_type *);
 namespace Issue150336 {
 void free(void *);
 typedef void (*sel_freefunc)(void *);
-struct gmx_ana_selmethod_t {
+struct selmethod_t {
   sel_freefunc free;
   int nparams;
   int *param;
 };
-void gmx_selelem_free_method(struct gmx_ana_selmethod_t* method, void* mdata) {
+void selelem_free_method(struct selmethod_t* method, void* mdata) {
     sel_freefunc free_func = 0;
     for (int i = 0; i < method->nparams; ++i)
         free(&method->param[i]);

--- a/clang/test/SemaCXX/noreturn-weverything.c
+++ b/clang/test/SemaCXX/noreturn-weverything.c
@@ -3,7 +3,6 @@
 void free(void *);
 typedef void (*set_free_func)(void *);
 struct Method {
-  set_free_func free;
   int nparams;
   int *param;
 };

--- a/clang/test/SemaCXX/noreturn-weverything.c
+++ b/clang/test/SemaCXX/noreturn-weverything.c
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only %s -Weverything
+
+void free(void *);
+typedef void (*set_free_func)(void *);
+struct Method {
+  set_free_func free;
+  int nparams;
+  int *param;
+};
+void selelem_free_method(struct Method* method, void* data) {
+    set_free_func free_func = 0;
+    for (int i = 0; i < method->nparams; ++i)
+        free(&method->param[i]);
+    if (data && free_func)
+        free_func(data);
+}


### PR DESCRIPTION
When searching for noreturn variable initializations, do not visit CFG blocks that are already visited, it prevents hanging  the analysis.

It must fix https://github.com/llvm/llvm-project/issues/150336.