### PR TITLE
[libc++][format][NFC] Granularize `__fmt_pair_like`

### DIFF
--- a/libcxx/include/CMakeLists.txt
+++ b/libcxx/include/CMakeLists.txt
@@ -381,6 +381,7 @@ set(files
   __format/enable_insertable.h
   __format/escaped_output_table.h
   __format/extended_grapheme_cluster_table.h
+  __format/fmt_pair_like.h
   __format/format_arg.h
   __format/format_arg_store.h
   __format/format_args.h

--- a/libcxx/include/__format/concepts.h
+++ b/libcxx/include/__format/concepts.h
@@ -15,12 +15,8 @@
 #include <__config>
 #include <__format/format_parse_context.h>
 #include <__fwd/format.h>
-#include <__fwd/tuple.h>
-#include <__tuple/tuple_size.h>
-#include <__type_traits/is_specialization.h>
 #include <__type_traits/remove_const.h>
 #include <__type_traits/remove_reference.h>
-#include <__utility/pair.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -65,16 +61,6 @@ concept __formattable =
 #  if _LIBCPP_STD_VER >= 23
 template <class _Tp, class _CharT>
 concept formattable = __formattable<_Tp, _CharT>;
-
-// [tuple.like] defines a tuple-like exposition only concept. This concept is
-// not related to that. Therefore it uses a different name for the concept.
-//
-// TODO FMT Add a test to validate we fail when using that concept after P2165
-// has been implemented.
-template <class _Tp>
-concept __fmt_pair_like =
-    __is_specialization_v<_Tp, pair> || (__is_specialization_v<_Tp, tuple> && tuple_size_v<_Tp> == 2);
-
 #  endif // _LIBCPP_STD_VER >= 23
 #endif   // _LIBCPP_STD_VER >= 20
 

--- a/libcxx/include/__format/fmt_pair_like.h
+++ b/libcxx/include/__format/fmt_pair_like.h
@@ -13,6 +13,8 @@
 #include <__config>
 #include <__fwd/pair.h>
 #include <__fwd/tuple.h>
+#include <__tuple/tuple_size.h>
+#include <__type_traits/is_specialization.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -29,16 +31,9 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 // [format.range.fmtkind]/2.2.1 and [tab:formatter.range.type]:
 // "U is either a specialization of pair or a specialization of tuple such that tuple_size_v<U> is 2."
-// We use an alternative approach to avoid dragging in many templates.
-template <class>
-inline constexpr bool __is_fmt_pair_like_v = false;
-template <class _Tp, class _Up>
-inline constexpr bool __is_fmt_pair_like_v<pair<_Tp, _Up>> = true;
-template <class _Tp, class _Up>
-inline constexpr bool __is_fmt_pair_like_v<tuple<_Tp, _Up>> = true;
-
 template <class _Tp>
-concept __fmt_pair_like = __is_fmt_pair_like_v<_Tp>;
+concept __fmt_pair_like =
+    __is_specialization_v<_Tp, pair> || (__is_specialization_v<_Tp, tuple> && tuple_size_v<_Tp> == 2);
 
 #endif // _LIBCPP_STD_VER >= 23
 

--- a/libcxx/include/__format/fmt_pair_like.h
+++ b/libcxx/include/__format/fmt_pair_like.h
@@ -1,0 +1,47 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCPP___FORMAT_FMT_PAIR_LIKE_H
+#define _LIBCPP___FORMAT_FMT_PAIR_LIKE_H
+
+#include <__config>
+#include <__fwd/pair.h>
+#include <__fwd/tuple.h>
+
+#if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+#  pragma GCC system_header
+#endif
+
+_LIBCPP_BEGIN_NAMESPACE_STD
+
+#if _LIBCPP_STD_VER >= 23
+
+// [tuple.like] defines a tuple-like exposition only concept. This concept is not related to that. Therefore it uses a
+// different name for the concept.
+//
+// TODO FMT Add a test to validate we fail when using that concept after P2165 has been implemented.
+
+// [format.range.fmtkind]/2.2.1 and [tab:formatter.range.type]:
+// "U is either a specialization of pair or a specialization of tuple such that tuple_size_v<U> is 2."
+// We use an alternative approach to avoid dragging in many templates.
+template <class>
+inline constexpr bool __is_fmt_pair_like_v = false;
+template <class _Tp, class _Up>
+inline constexpr bool __is_fmt_pair_like_v<pair<_Tp, _Up>> = true;
+template <class _Tp, class _Up>
+inline constexpr bool __is_fmt_pair_like_v<tuple<_Tp, _Up>> = true;
+
+template <class _Tp>
+concept __fmt_pair_like = __is_fmt_pair_like_v<_Tp>;
+
+#endif // _LIBCPP_STD_VER >= 23
+
+_LIBCPP_END_NAMESPACE_STD
+
+#endif // _LIBCPP___FORMAT_FMT_PAIR_LIKE_H

--- a/libcxx/include/__format/range_default_formatter.h
+++ b/libcxx/include/__format/range_default_formatter.h
@@ -18,6 +18,7 @@
 #include <__chrono/statically_widen.h>
 #include <__config>
 #include <__format/concepts.h>
+#include <__format/fmt_pair_like.h>
 #include <__format/formatter.h>
 #include <__format/range_format.h>
 #include <__format/range_formatter.h>

--- a/libcxx/include/__format/range_format.h
+++ b/libcxx/include/__format/range_format.h
@@ -16,7 +16,7 @@
 
 #include <__concepts/same_as.h>
 #include <__config>
-#include <__format/concepts.h>
+#include <__format/fmt_pair_like.h>
 #include <__ranges/concepts.h>
 #include <__type_traits/remove_cvref.h>
 

--- a/libcxx/include/__format/range_formatter.h
+++ b/libcxx/include/__format/range_formatter.h
@@ -20,6 +20,7 @@
 #include <__config>
 #include <__format/buffer.h>
 #include <__format/concepts.h>
+#include <__format/fmt_pair_like.h>
 #include <__format/format_context.h>
 #include <__format/format_error.h>
 #include <__format/formatter.h>

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -1338,6 +1338,7 @@ module std [system] {
     module enable_insertable                  { header "__format/enable_insertable.h" }
     module escaped_output_table               { header "__format/escaped_output_table.h" }
     module extended_grapheme_cluster_table    { header "__format/extended_grapheme_cluster_table.h" }
+    module fmt_pair_like                      { header "__format/fmt_pair_like.h" }
     module format_arg                         { header "__format/format_arg.h" }
     module format_arg_store                   { header "__format/format_arg_store.h" }
     module format_args                        { header "__format/format_args.h" }


### PR DESCRIPTION
`<optional>` needs `format_kind` and `range_format` since C++26, but it shouldn't drag in too many other stuffs necessary for `<__format/concepts.h>`.