### PR TITLE
[Clang][AArch64] Remove unwarranted 'cannot be used in non-streaming mode' diagnostic.

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5988,11 +5988,9 @@ bool clang::IsArmStreamingFunction(const FunctionDecl *FD,
     if (FD->hasAttr<ArmLocallyStreamingAttr>())
       return true;
 
-  if (const Type *Ty = FD->getType().getTypePtrOrNull())
-    if (const auto *FPT = Ty->getAs<FunctionProtoType>())
-      if (FPT->getAArch64SMEAttributes() &
-          FunctionType::SME_PStateSMEnabledMask)
-        return true;
+  if (const auto *FPT = FD->getType()->getAs<FunctionProtoType>())
+    if (FPT->getAArch64SMEAttributes() & FunctionType::SME_PStateSMEnabledMask)
+      return true;
 
   return false;
 }

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5988,9 +5988,11 @@ bool clang::IsArmStreamingFunction(const FunctionDecl *FD,
     if (FD->hasAttr<ArmLocallyStreamingAttr>())
       return true;
 
-  if (const auto *FPT = FD->getType()->getAs<FunctionProtoType>())
-    if (FPT->getAArch64SMEAttributes() & FunctionType::SME_PStateSMEnabledMask)
-      return true;
+  if (const Type *Ty = FD->getType().getTypePtrOrNull())
+    if (const auto *FPT = Ty->getAs<FunctionProtoType>())
+      if (FPT->getAArch64SMEAttributes() &
+          FunctionType::SME_PStateSMEnabledMask)
+        return true;
 
   return false;
 }

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -2251,16 +2251,15 @@ void Sema::checkTypeSupport(QualType Ty, SourceLocation Loc, ValueDecl *D) {
     }
 
     // Don't allow SVE types in functions without a SVE target.
-    if (Ty->isSVESizelessBuiltinType() && FD) {
+    if (Ty->isSVESizelessBuiltinType() && FD && !FD->getType().isNull()) {
       llvm::StringMap<bool> CallerFeatureMap;
       Context.getFunctionFeatureMap(CallerFeatureMap, FD);
       if (!Builtin::evaluateRequiredTargetFeatures("sve", CallerFeatureMap)) {
         if (!Builtin::evaluateRequiredTargetFeatures("sme", CallerFeatureMap))
           Diag(Loc, diag::err_sve_vector_in_non_sve_target) << Ty;
         else if (!IsArmStreamingFunction(FD,
-                                         /*IncludeLocallyStreaming=*/true)) {
+                                         /*IncludeLocallyStreaming=*/true))
           Diag(Loc, diag::err_sve_vector_in_non_streaming_function) << Ty;
-        }
       }
     }
 

--- a/clang/test/Sema/aarch64-sme-attrs-without-sve.cpp
+++ b/clang/test/Sema/aarch64-sme-attrs-without-sve.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -target-feature +sme -fsyntax-only -verify %s
+
+#include <arm_sme.h>
+
+void test_streaming(svint32_t *out, svint32_t *in) __arm_streaming {
+  *out = *in;
+}
+
+void test_non_streaming(svint32_t *out, svint32_t *in) {
+  *out = *in; // expected-error {{SVE vector type 'svint32_t' (aka '__SVInt32_t') cannot be used in a non-streaming function}} \
+                 expected-error {{SVE vector type 'svint32_t' (aka '__SVInt32_t') cannot be used in a non-streaming function}}
+}
+
+// This previously led to a diagnostic that '&a' could not be used in a non-streaming function,
+// even though all functions are streaming.
+void test_both_streaming(int32_t *out) __arm_streaming{
+  svint32_t a;
+  [&a, &out]() __arm_streaming {
+    a = svdup_s32(1);
+    svst1(svptrue_b32(), out, a);
+  }();
+}
+
+void test_lambda_streaming(int32_t *out) {
+  svint32_t a; // expected-error {{SVE vector type 'svint32_t' (aka '__SVInt32_t') cannot be used in a non-streaming function}}
+  [&a, &out]() __arm_streaming {
+    a = 1;
+    svst1(svptrue_b32(), out, a);
+  }();
+}
+

--- a/clang/test/Sema/aarch64-sme-attrs-without-sve.cpp
+++ b/clang/test/Sema/aarch64-sme-attrs-without-sve.cpp
@@ -13,7 +13,7 @@ void test_non_streaming(svint32_t *out, svint32_t *in) {
 
 // This previously led to a diagnostic that '&a' could not be used in a non-streaming function,
 // even though all functions are streaming.
-void test_both_streaming(int32_t *out) __arm_streaming{
+void test_both_streaming(int32_t *out) __arm_streaming {
   svint32_t a;
   [&a, &out]() __arm_streaming {
     a = svdup_s32(1);
@@ -29,3 +29,26 @@ void test_lambda_streaming(int32_t *out) {
   }();
 }
 
+void test_lambda_non_streaming_capture_do_nothing() __arm_streaming {
+  svint32_t a;
+  [&a] {
+    // Do nothing.
+  }();
+}
+
+// Error: Non-streaming function attempts to dereference capture:
+void test_lambda_non_streaming_capture_return_vector() __arm_streaming {
+  svint32_t a;
+  [&a] {
+    return a; // expected-error {{SVE vector type 'svint32_t' (aka '__SVInt32_t') cannot be used in a non-streaming function}}
+  }();
+}
+
+// By reference capture, only records and uses the address of `a`:
+// FIXME: This should be okay.
+void test_lambda_non_streaming_capture_return_address() __arm_streaming {
+  svint32_t a;
+  [&a] {
+    return &a; // expected-error {{SVE vector type 'svint32_t' (aka '__SVInt32_t') cannot be used in a non-streaming function}}
+  }();
+}


### PR DESCRIPTION
Previously Clang would give an unwarranted error on the capture of '&a' in the function below, even though the parent function and the lambda are both `__arm_streaming` functions, when the target is compiled with +sme only.

```
  void test_both_streaming(int32_t *out) __arm_streaming {
    svint32_t a;
    [&a, &out]() __arm_streaming {
      ^
      error: SVE vector type 'svint32_t' (aka '__SVInt32_t') cannot be used in a non-streaming function

      a = svdup_s32(1);
      svst1(svptrue_b32(), out, a);
    }();
  }
```

That seems to happen because when `checkTypeSupport` is called the `FunctionDecl` context of the lambda isn't yet complete and `FD->getType()` returns a Null `QualTy`.

This is loosely related to #94976 which removed a `FD->hasBody()` check in the same place, because `hasBody()` may incorrectly return `false` when Clang is still processing a function.