### PR TITLE
[compiler-rt] Fix linux header includes for musl with old kernels

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp
@@ -72,8 +72,6 @@
 #include <malloc.h>
 #include <mntent.h>
 #include <netinet/ether.h>
-#include <sys/sysinfo.h>
-#include <sys/vt.h>
 #include <linux/cdrom.h>
 #include <linux/fd.h>
 #if SANITIZER_ANDROID
@@ -87,6 +85,10 @@
 #include <linux/utsname.h>
 #include <linux/posix_types.h>
 #include <net/if_arp.h>
+#ifndef _LINUX_SYSINFO_H
+#include <sys/sysinfo.h>
+#endif
+#include <sys/vt.h>
 #endif
 
 #if SANITIZER_IOS
@@ -133,9 +135,9 @@ typedef struct user_fpregs elf_fpregset_t;
 #      endif
 #      include <scsi/scsi.h>
 #else
+#include <linux/ppp_defs.h>
 #include <linux/if_ppp.h>
 #include <linux/kd.h>
-#include <linux/ppp_defs.h>
 #endif  // SANITIZER_GLIBC
 
 #if SANITIZER_ANDROID


### PR DESCRIPTION
Fixes this error on musl with old kernels:
```
In file included from /home/caleb/cpp-toolchain/toolchain/build/_deps/llvm-source-src/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp:84:
In file included from /home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/sysctl.h:25:
In file included from /home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/kernel.h:4:
/home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/sysinfo.h:7:8: error: redefinition of 'sysinfo'
    7 | struct sysinfo {
      |        ^
/home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/sys/sysinfo.h:10:8: note: previous definition is here
   10 | struct sysinfo {
      |        ^
In file included from /home/caleb/cpp-toolchain/toolchain/build/_deps/llvm-source-src/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cpp:132:
In file included from /home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/if_ppp.h:1:
/home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/ppp-ioctl.h:55:7: error: ISO C++ forbids forward references to 'enum' types
   55 |         enum NPmode     mode;
      |              ^
/home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/ppp-ioctl.h:55:14: error: field has incomplete type 'enum NPmode'
   55 |         enum NPmode     mode;
      |                         ^
/home/caleb/cpp-toolchain/toolchain/build/aarch64-unknown-linux-musl/toolchain/aarch64-unknown-linux-musl/sysroot/usr/include/linux/ppp-ioctl.h:55:7: note: forward declaration of 'NPmode'
   55 |         enum NPmode     mode;
      |              ^
```
It seems somewhere around 5.x, `linux/kernel.h` stopped including `linux/sysinfo.h`. musl provides its own sysinfo, rather than including `linux/sysinfo.h`, which causes the redefinition error.

The second error is resolved by simply reordering the headers.