### PR TITLE
[RISCV] Remove fixed vector constraint on masked interleave costing

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -983,9 +983,7 @@ InstructionCost RISCVTTIImpl::getInterleavedMemoryOpCost(
   // with an adjacent appropriate memory to vlseg/vsseg intrinsics. vlseg/vsseg
   // only support masking per-iteration (i.e. condition), not per-segment (i.e.
   // gap).
-  // TODO: Support masked interleaved access for fixed length vector.
-  if ((isa<ScalableVectorType>(VecTy) || !UseMaskForCond) && !UseMaskForGaps &&
-      Factor <= TLI->getMaxSupportedInterleaveFactor()) {
+  if (!UseMaskForGaps && Factor <= TLI->getMaxSupportedInterleaveFactor()) {
     auto *VTy = cast<VectorType>(VecTy);
     std::pair<InstructionCost, MVT> LT = getTypeLegalizationCost(VTy);
     // Need to make sure type has't been scalarized


### PR DESCRIPTION
The last of the fixed vector changes for interleaves with masked loads and stores landed last night, so we no longer need the restriction.

Note that our costing in LV will nearly always prefer a scalable type, so this is pretty invisible in practice.  All the lowering paths are tested directly.  