### PR TITLE
[DebugInfo] Slice out a few more users of debug intrinsics

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2238,17 +2238,8 @@ bool IRTranslator::translateKnownIntrinsic(const CallInst &CI, Intrinsic::ID ID,
     return true;
   }
   case Intrinsic::dbg_assign:
-    // A dbg.assign is a dbg.value with more information about stack locations,
-    // typically produced during optimisation of variables with leaked
-    // addresses. We can treat it like a normal dbg_value intrinsic here; to
-    // benefit from the full analysis of stack/SSA locations, GlobalISel would
-    // need to register for and use the AssignmentTrackingAnalysis pass.
-    [[fallthrough]];
   case Intrinsic::dbg_value: {
-    // This form of DBG_VALUE is target-independent.
-    const DbgValueInst &DI = cast<DbgValueInst>(CI);
-    translateDbgValueRecord(DI.getValue(), DI.hasArgList(), DI.getVariable(),
-                       DI.getExpression(), DI.getDebugLoc(), MIRBuilder);
+    llvm_unreachable("Saw debug intrinsic, should no longer exist");
     return true;
   }
   case Intrinsic::uadd_with_overflow:

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -6940,7 +6940,7 @@ static void FixupDebugInfoForOutlinedFunction(
     return NewVar;
   };
 
-  auto UpdateDebugRecord = [&](auto *DR) {
+  auto UpdateDebugRecord = [&](DbgVariableRecord *DR) {
     DILocalVariable *OldVar = DR->getVariable();
     unsigned ArgNo = 0;
     for (auto Loc : DR->location_ops()) {
@@ -6957,9 +6957,6 @@ static void FixupDebugInfoForOutlinedFunction(
   // The location and scope of variable intrinsics and records still point to
   // the parent function of the target region. Update them.
   for (Instruction &I : instructions(Func)) {
-    if (auto *DDI = dyn_cast<llvm::DbgVariableIntrinsic>(&I))
-      UpdateDebugRecord(DDI);
-
     for (DbgVariableRecord &DVR : filterDbgVars(I.getDbgRecordRange()))
       UpdateDebugRecord(&DVR);
   }

--- a/llvm/lib/IR/DebugInfo.cpp
+++ b/llvm/lib/IR/DebugInfo.cpp
@@ -199,9 +199,6 @@ void DebugInfoFinder::processCompileUnit(DICompileUnit *CU) {
 
 void DebugInfoFinder::processInstruction(const Module &M,
                                          const Instruction &I) {
-  if (auto *DVI = dyn_cast<DbgVariableIntrinsic>(&I))
-    processVariable(DVI->getVariable());
-
   if (auto DbgLoc = I.getDebugLoc())
     processLocation(M, DbgLoc.get());
 

--- a/llvm/lib/IR/User.cpp
+++ b/llvm/lib/IR/User.cpp
@@ -33,12 +33,6 @@ bool User::replaceUsesOfWith(Value *From, Value *To) {
       setOperand(i, To);
       Changed = true;
     }
-  if (auto DVI = dyn_cast_or_null<DbgVariableIntrinsic>(this)) {
-    if (is_contained(DVI->location_ops(), From)) {
-      DVI->replaceVariableLocationOp(From, To);
-      Changed = true;
-    }
-  }
 
   return Changed;
 }

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -2058,7 +2058,7 @@ void llvm::salvageDebugInfoForDbgValues(Instruction &I,
     auto DVRLocation = DVR->location_ops();
     assert(
         is_contained(DVRLocation, &I) &&
-        "DbgVariableIntrinsic must use salvaged instruction as its location");
+        "DbgRecord must use salvaged instruction as its location");
     SmallVector<Value *, 4> AdditionalValues;
     // 'I' may appear more than once in DVR's location ops, and each use of 'I'
     // must be updated in the DIExpression and potentially have additional

--- a/llvm/lib/Transforms/Utils/Local.cpp
+++ b/llvm/lib/Transforms/Utils/Local.cpp
@@ -2056,9 +2056,8 @@ void llvm::salvageDebugInfoForDbgValues(Instruction &I,
     bool StackValue =
         DVR->getType() != DbgVariableRecord::LocationType::Declare;
     auto DVRLocation = DVR->location_ops();
-    assert(
-        is_contained(DVRLocation, &I) &&
-        "DbgRecord must use salvaged instruction as its location");
+    assert(is_contained(DVRLocation, &I) &&
+           "DbgRecord must use salvaged instruction as its location");
     SmallVector<Value *, 4> AdditionalValues;
     // 'I' may appear more than once in DVR's location ops, and each use of 'I'
     // must be updated in the DIExpression and potentially have additional

--- a/llvm/unittests/IR/DebugInfoTest.cpp
+++ b/llvm/unittests/IR/DebugInfoTest.cpp
@@ -236,16 +236,14 @@ TEST(MetadataTest, GlobalConstantMetadataUsedByDbgRecord) {
   EXPECT_FALSE(isa<UndefValue>(DVRs[0]->getValue(0)));
 }
 
-TEST(DbgVariableIntrinsic, EmptyMDIsKillLocation) {
+TEST(MetadataTest, EmptyMDIsKillLocation) {
   LLVMContext Ctx;
   std::unique_ptr<Module> M = parseIR(Ctx, R"(
     define dso_local void @fun() local_unnamed_addr #0 !dbg !9 {
     entry:
-      call void @llvm.dbg.declare(metadata !{}, metadata !13, metadata !DIExpression()), !dbg !16
+        #dbg_declare(!{}, !13, !DIExpression(), !16)
       ret void, !dbg !16
     }
-
-    declare void @llvm.dbg.declare(metadata, metadata, metadata)
 
     !llvm.dbg.cu = !{!0}
     !llvm.module.flags = !{!2, !3}

--- a/llvm/unittests/Transforms/Utils/LocalTest.cpp
+++ b/llvm/unittests/Transforms/Utils/LocalTest.cpp
@@ -679,7 +679,6 @@ TEST(Local, FindDbgRecords) {
   findDbgUsers(Arg, Records);
   EXPECT_EQ(Records.size(), 1u);
 
-  SmallVector<DbgValueInst *> Vals;
   Records.clear();
   // Arg (%a) is used twice by a single dbg_assign. Check findDbgValues returns
   // only 1 pointer to it rather than 2.


### PR DESCRIPTION
Here's some more dead code that will never run, due to debug intrinsics being decomissioned. I've also replaced one or two generic lambdas with DbgVariableRecord taking ones.