### PR TITLE
[clang-doc] add option to delete JSON residuals

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
@@ -196,6 +196,9 @@ Error MustacheHTMLGenerator::generateDocs(
     }
   }
 
+  if (!CDCtx.KeepJSON)
+    sys::fs::remove_directories(JSONPath);
+
   return Error::success();
 }
 

--- a/clang-tools-extra/clang-doc/Representation.cpp
+++ b/clang-tools-extra/clang-doc/Representation.cpp
@@ -481,9 +481,9 @@ ClangDocContext::ClangDocContext(tooling::ExecutionContext *ECtx,
                                  StringRef RepositoryUrl,
                                  StringRef RepositoryLinePrefix, StringRef Base,
                                  std::vector<std::string> UserStylesheets,
-                                 bool FTimeTrace)
+                                 bool KeepJSON, bool FTimeTrace)
     : ECtx(ECtx), ProjectName(ProjectName), PublicOnly(PublicOnly),
-      FTimeTrace(FTimeTrace), OutDirectory(OutDirectory),
+      FTimeTrace(FTimeTrace), KeepJSON(KeepJSON), OutDirectory(OutDirectory),
       UserStylesheets(UserStylesheets), Base(Base) {
   llvm::SmallString<128> SourceRootDir(SourceRoot);
   if (SourceRoot.empty())

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -610,11 +610,12 @@ struct ClangDocContext {
                   bool PublicOnly, StringRef OutDirectory, StringRef SourceRoot,
                   StringRef RepositoryUrl, StringRef RepositoryCodeLinePrefix,
                   StringRef Base, std::vector<std::string> UserStylesheets,
-                  bool FTimeTrace = false);
+                  bool KeepJSON, bool FTimeTrace = false);
   tooling::ExecutionContext *ECtx;
   std::string ProjectName; // Name of project clang-doc is documenting.
   bool PublicOnly; // Indicates if only public declarations are documented.
   bool FTimeTrace; // Indicates if ftime trace is turned on
+  bool KeepJSON; // Indicates if JSON files should be kept after HTML generation
   int Granularity; // Granularity of ftime trace
   std::string OutDirectory; // Directory for outputting generated files.
   std::string SourceRoot;   // Directory where processed files are stored. Links

--- a/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
+++ b/clang-tools-extra/clang-doc/tool/ClangDocMain.cpp
@@ -110,6 +110,11 @@ Turn on time profiler. Generates clang-doc-tracing.json)"),
                                       llvm::cl::init(false),
                                       llvm::cl::cat(ClangDocCategory));
 
+static llvm::cl::opt<bool>
+    KeepJSON("keep-json",
+             llvm::cl::desc("Keep JSON residuals after processing."),
+             llvm::cl::init(false), llvm::cl::cat(ClangDocCategory));
+
 enum OutputFormatTy { md, yaml, html, mustache, json };
 
 static llvm::cl::opt<OutputFormatTy> FormatEnum(
@@ -325,6 +330,7 @@ Example usage for a project using a compile commands database:
         RepositoryCodeLinePrefix,
         BaseDirectory,
         {UserStylesheets.begin(), UserStylesheets.end()},
+        KeepJSON,
         FTimeTrace};
 
     if (Format == "html") {

--- a/clang-tools-extra/unittests/clang-doc/HTMLGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLGeneratorTest.cpp
@@ -30,8 +30,8 @@ getClangDocContext(std::vector<std::string> UserStylesheets = {},
                    StringRef RepositoryUrl = "",
                    StringRef RepositoryLinePrefix = "", StringRef Base = "") {
   ClangDocContext CDCtx{
-      {},   "test-project", {}, {}, {}, RepositoryUrl, RepositoryLinePrefix,
-      Base, UserStylesheets};
+      {},   "test-project",  {}, {}, {}, RepositoryUrl, RepositoryLinePrefix,
+      Base, UserStylesheets, {}};
   CDCtx.UserStylesheets.insert(
       CDCtx.UserStylesheets.begin(),
       "../share/clang/clang-doc-default-stylesheet.css");

--- a/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/HTMLMustacheGeneratorTest.cpp
@@ -41,8 +41,8 @@ getClangDocContext(std::vector<std::string> UserStylesheets = {},
                    StringRef RepositoryUrl = "",
                    StringRef RepositoryLinePrefix = "", StringRef Base = "") {
   ClangDocContext CDCtx{
-      {},   "test-project", {}, {}, {}, RepositoryUrl, RepositoryLinePrefix,
-      Base, UserStylesheets};
+      {},   "test-project",  {}, {}, {}, RepositoryUrl, RepositoryLinePrefix,
+      Base, UserStylesheets, {}};
   CDCtx.UserStylesheets.insert(CDCtx.UserStylesheets.begin(), "");
   CDCtx.JsScripts.emplace_back("");
   return CDCtx;


### PR DESCRIPTION
This new option defaults to delete the json dir after HTML generation.