### PR TITLE
[libc++] Add checks for misused hardening macros

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -40,7 +40,7 @@
 
 // HARDENING {
 
-// TODO: Remove in LLVM 23. We're making these an error to catch folks who might not have migrated.
+// TODO(LLVM 23): Remove this. We're making these an error to catch folks who might not have migrated.
 //       Since hardening went through several changes (many of which impacted user-facing macros),
 //       we're keeping these checks around for a bit longer than usual. Failure to properly configure
 //       hardening results in checks being dropped silently, which is a pretty big deal.

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -40,9 +40,21 @@
 
 // HARDENING {
 
-// TODO: Remove in LLVM 21. We're making this an error to catch folks who might not have migrated.
-#  ifdef _LIBCPP_ENABLE_ASSERTIONS
-#    error "_LIBCPP_ENABLE_ASSERTIONS has been removed, please use _LIBCPP_HARDENING_MODE instead"
+// TODO: Remove in LLVM 23. We're making these an error to catch folks who might not have migrated.
+//       Since hardening went through several changes (many of which impacted user-facing macros),
+//       we're keeping these checks around for a bit longer than usual. Failure to properly configure
+//       hardening results in checks being dropped silently, which is a pretty big deal.
+#  if defined(_LIBCPP_ENABLE_ASSERTIONS)
+#    error "_LIBCPP_ENABLE_ASSERTIONS has been removed, please use _LIBCPP_HARDENING_MODE=<mode> instead (see docs)"
+#  endif
+#  if defined(_LIBCPP_ENABLE_HARDENED_MODE)
+#    error "_LIBCPP_ENABLE_HARDENED_MODE has been removed, please use _LIBCPP_HARDENING_MODE=<mode> instead (see docs)"
+#  endif
+#  if defined(_LIBCPP_ENABLE_SAFE_MODE)
+#    error "_LIBCPP_ENABLE_SAFE_MODE has been removed, please use _LIBCPP_HARDENING_MODE=<mode> instead (see docs)"
+#  endif
+#  if defined(_LIBCPP_ENABLE_DEBUG_MODE)
+#    error "_LIBCPP_ENABLE_DEBUG_MODE has been removed, please use _LIBCPP_HARDENING_MODE=<mode> instead (see docs)"
 #  endif
 
 // The library provides the macro `_LIBCPP_HARDENING_MODE` which can be set to one of the following values:


### PR DESCRIPTION
Libc++ hardening went through several iterations, sometimes within a single release. However, some folks in the wild have picked up these macros that were either public at some point or that were used temporarily on `main`, and unfortunately those are now ignored.

This can lead to some users thinking they enable hardening when in reality they don't, which is a pretty big deal. This patch simply checks various old hardening-related macros and ensures that they are not set, which will catch such misuse.