### PR TITLE
[LifetimeSafety] Handle pruned-edges (null blocks) in dataflow

### DIFF
--- a/clang/lib/Analysis/LifetimeSafety.cpp
+++ b/clang/lib/Analysis/LifetimeSafety.cpp
@@ -603,6 +603,8 @@ public:
       OutStates[B] = StateOut;
       Visited.set(B->getBlockID());
       for (const CFGBlock *AdjacentB : isForward() ? B->succs() : B->preds()) {
+        if (!AdjacentB)
+          continue;
         Lattice OldInState = getInState(AdjacentB);
         Lattice NewInState = D.join(OldInState, StateOut);
         // Enqueue the adjacent block if its in-state has changed or if we have


### PR DESCRIPTION
Fix a crash in the lifetime safety dataflow analysis when handling null CFG blocks.

Added a null check for adjacent blocks in the dataflow analysis algorithm to prevent dereferencing null pointers. This occurs when processing CFG blocks with unreachable successors or predecessors.

Original crash: https://compiler-explorer.com/z/qfzfqG5vM

Fixes https://github.com/llvm/llvm-project/issues/150095