### PR TITLE
[Github][libcxx] Run Container Build Workflow on Stacked PRs

### DIFF
--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -18,8 +18,6 @@ on:
       - 'libcxx/utils/ci/**'
       - '.github/workflows/libcxx-build-containers.yml'
   pull_request:
-    branches:
-      - main
     paths:
       - 'libcxx/utils/ci/**'
       - '.github/workflows/libcxx-build-containers.yml'


### PR DESCRIPTION
Currently the container build workflow does not run on stacked PRs that do not have a branch target of main because of how the workflow is configured. This makes the workflow better confirm to the LLVM CI best practices around Github workflows:

https://llvm.org/docs/CIBestPractices.html#ensuring-workflows-run-on-the-correct-events