### PR TITLE
Revert "Adjust LDBG output: surround DebugType between `[` and `]`"

### DIFF
--- a/llvm/include/llvm/Support/DebugLog.h
+++ b/llvm/include/llvm/Support/DebugLog.h
@@ -38,8 +38,8 @@ public:
                  raw_ostream &os)
       : os(os) {
     if (debug_type)
-      os << "[" << debug_type << "] ";
-    os << file << ":" << line << " ";
+      os << debug_type << " ";
+    os << "[" << file << ":" << line << "] ";
   }
   ~LogWithNewline() { os << '\n'; }
   template <typename T> raw_ostream &operator<<(const T &t) && {


### PR DESCRIPTION
Reverts llvm/llvm-project#150671 ; buildbot failure.