### PR TITLE
Fix FULL_LDBG when NDEBUG is defined

### DIFF
--- a/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
@@ -24,8 +24,12 @@
 #define DEBUG_TYPE_FULL "transform-dialect-full"
 #define DEBUG_PRINT_AFTER_ALL "transform-dialect-print-top-level-after-all"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "] ")
+#ifndef NDEBUG
 #define FULL_LDBG(X)                                                           \
   DEBUGLOG_WITH_STREAM_AND_TYPE(llvm::dbgs(), DEBUG_TYPE_FULL)
+#else
+#define FULL_LDBG(X)
+#endif
 
 using namespace mlir;
 


### PR DESCRIPTION
DEBUGLOG_WITH_STREAM_AND_TYPE is an internal implementation detail of LDBG in DebugLog.h.  When NDEBUG is defined, DEBUGLOG_WITH_STREAM_AND_TYPE  is not defined at all.