### PR TITLE
FULL_LDBG does not need to take an argument

### DIFF
--- a/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
+++ b/mlir/lib/Dialect/Transform/Interfaces/TransformInterfaces.cpp
@@ -25,10 +25,10 @@
 #define DEBUG_PRINT_AFTER_ALL "transform-dialect-print-top-level-after-all"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "] ")
 #ifndef NDEBUG
-#define FULL_LDBG(X)                                                           \
+#define FULL_LDBG()                                                           \
   DEBUGLOG_WITH_STREAM_AND_TYPE(llvm::dbgs(), DEBUG_TYPE_FULL)
 #else
-#define FULL_LDBG(X)
+#define FULL_LDBG()
 #endif
 
 using namespace mlir;


### PR DESCRIPTION
FULL_LDBG is currently called without argument; somehow, the preprocessor tolerates that when the implementation is non-empty but rejects that when the implementation is empty.  Instead, let it not take an argument.