### PR TITLE
[libc][bazel] Allow building llvm_libc_types_float128 on Windows.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -159,6 +159,7 @@ libc_support_library(
     hdrs = ["include/llvm-libc-types/float128.h"],
     target_compatible_with = select({
         "@platforms//os:linux": [],
+        "@platforms//os:windows": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
     deps = [":llvm_libc_macros_float_macros"],


### PR DESCRIPTION
This target was marked as Linux-only in 51a4ab287f43c129dd531867be880480a85ecb1e to make "bazel build @llvm-project//libc/..." clean (which it still is).

There's nothing Linux-specific about this header libary, we just use "target_incompatible_with" clause here to ensure that all libc functions for float128 types won't be built on Mac, in lieu of a better exclusion mechanism in Bazel.

However, since llvm_libc_types_float128 is now a transitive dependency of ":libcxx_shared_headers" used for hand-in-hand code sharing with libc++, we may need to build this target even on platforms that don't have float128.

Fow now, mark this target Windows-compatible to unlock the downstream Windows Bazel build of ":libcxx_shared_headers".