### PR TITLE
[AMDGPU] More accurately account for AVGPR pressure

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.cpp
@@ -484,7 +484,7 @@ unsigned GCNIterativeScheduler::tryMaximizeOccupancy(unsigned TargetOcc) {
 }
 
 void GCNIterativeScheduler::scheduleLegacyMaxOccupancy(
-  bool TryMaximizeOccupancy) {
+    bool TryMaximizeOccupancy) {
   SIMachineFunctionInfo *MFI = MF.getInfo<SIMachineFunctionInfo>();
   auto TgtOcc = MFI->getMinAllowedOccupancy();
 
@@ -573,8 +573,7 @@ void GCNIterativeScheduler::scheduleMinReg(bool force) {
 ///////////////////////////////////////////////////////////////////////////////
 // ILP scheduler port
 
-void GCNIterativeScheduler::scheduleILP(
-  bool TryMaximizeOccupancy) {
+void GCNIterativeScheduler::scheduleILP(bool TryMaximizeOccupancy) {
   SIMachineFunctionInfo *MFI = MF.getInfo<SIMachineFunctionInfo>();
   auto TgtOcc = MFI->getMinAllowedOccupancy();
 

--- a/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.h
+++ b/llvm/lib/Target/AMDGPU/GCNIterativeScheduler.h
@@ -94,9 +94,8 @@ protected:
   }
 
   void swapIGLPMutations(const Region &R, bool IsReentry);
-  void setBestSchedule(Region &R,
-                       ScheduleRef Schedule,
-                       const GCNRegPressure &MaxRP = GCNRegPressure());
+  void setBestSchedule(Region &R, ScheduleRef Schedule,
+                       const GCNRegPressure &MaxRP);
 
   void scheduleBest(Region &R);
 
@@ -105,8 +104,7 @@ protected:
   void sortRegionsByPressure(unsigned TargetOcc);
 
   template <typename Range>
-  void scheduleRegion(Region &R, Range &&Schedule,
-                      const GCNRegPressure &MaxRP = GCNRegPressure());
+  void scheduleRegion(Region &R, Range &&Schedule, const GCNRegPressure &MaxRP);
 
   unsigned tryMaximizeOccupancy(unsigned TargetOcc =
                                 std::numeric_limits<unsigned>::max());

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -267,7 +267,7 @@ Printable llvm::print(const GCNRegPressure &RP, const GCNSubtarget *ST,
         OS << ", LVGPR WT: " << RP.getVGPRTuplesWeight(ArchVGPRThreshold)
            << ", LSGPR WT: " << RP.getSGPRTuplesWeight();
         if (ST)
-          OS << " -> Occ: " << RP.getOccupancy(*ST, DynamicVGPRBlockSize, *MF);
+          OS << " -> Occ: " << RP.getOccupancy(*MF);
         OS << '\n';
       });
 }

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -99,7 +99,8 @@ void GCNRegPressure::inc(unsigned Reg,
 bool GCNRegPressure::less(const MachineFunction &MF, const GCNRegPressure &O,
                           unsigned MaxOccupancy) const {
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
-  unsigned ArchVGPRThreshold = ST.getArchVGPRAllocationThreshold(MF);
+  unsigned ArchVGPRThreshold =
+      ST.getRegisterInfo()->getMaxNumVectorRegs(MF).first;
   unsigned DynamicVGPRBlockSize =
       MF.getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize();
 
@@ -250,7 +251,8 @@ bool GCNRegPressure::less(const MachineFunction &MF, const GCNRegPressure &O,
 Printable llvm::print(const GCNRegPressure &RP, const GCNSubtarget *ST,
                       unsigned DynamicVGPRBlockSize,
                       const MachineFunction *MF) {
-  unsigned ArchVGPRThreshold = ST->getArchVGPRAllocationThreshold(*MF);
+  unsigned ArchVGPRThreshold =
+      ST->getRegisterInfo()->getMaxNumVectorRegs(*MF).first;
   return Printable(
       [&RP, ST, DynamicVGPRBlockSize, ArchVGPRThreshold, MF](raw_ostream &OS) {
         OS << "VGPRs: " << RP.getArchVGPRNum(ArchVGPRThreshold) << ' '
@@ -903,10 +905,10 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
   auto printRP = [&MF](const GCNRegPressure &RP) {
     return Printable([&RP, &MF](raw_ostream &OS) {
       OS << format(PFX "  %-5d", RP.getSGPRNum())
-         << format(
-                " %-5d",
-                RP.getVGPRNum(false, MF.getSubtarget<GCNSubtarget>()
-                                         .getArchVGPRAllocationThreshold(MF)));
+         << format(" %-5d", RP.getVGPRNum(false, MF.getSubtarget<GCNSubtarget>()
+                                                     .getRegisterInfo()
+                                                     ->getMaxNumVectorRegs(MF)
+                                                     .first));
     });
   };
 

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -250,7 +250,10 @@ bool GCNRegPressure::less(const MachineFunction &MF, const GCNRegPressure &O,
 Printable llvm::print(const GCNRegPressure &RP, const GCNSubtarget *ST,
                       unsigned DynamicVGPRBlockSize,
                       const MachineFunction *MF) {
-  unsigned ArchVGPRThreshold = ST->getMaxNumVectorRegs(MF->getFunction()).first;
+  unsigned ArchVGPRThreshold = std::numeric_limits<unsigned int>::max();
+  if (ST && MF)
+    ArchVGPRThreshold = ST->getMaxNumVectorRegs(MF->getFunction()).first;
+
   return Printable(
       [&RP, ST, DynamicVGPRBlockSize, ArchVGPRThreshold, MF](raw_ostream &OS) {
         OS << "VGPRs: " << RP.getArchVGPRNum(ArchVGPRThreshold) << ' '

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -99,8 +99,7 @@ void GCNRegPressure::inc(unsigned Reg,
 bool GCNRegPressure::less(const MachineFunction &MF, const GCNRegPressure &O,
                           unsigned MaxOccupancy) const {
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
-  unsigned ArchVGPRThreshold =
-      ST.getMaxNumVectorRegs(MF.getFunction()).first;
+  unsigned ArchVGPRThreshold = ST.getMaxNumVectorRegs(MF.getFunction()).first;
   unsigned DynamicVGPRBlockSize =
       MF.getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize();
 
@@ -251,8 +250,7 @@ bool GCNRegPressure::less(const MachineFunction &MF, const GCNRegPressure &O,
 Printable llvm::print(const GCNRegPressure &RP, const GCNSubtarget *ST,
                       unsigned DynamicVGPRBlockSize,
                       const MachineFunction *MF) {
-  unsigned ArchVGPRThreshold =
-      ST->getMaxNumVectorRegs(MF->getFunction()).first;
+  unsigned ArchVGPRThreshold = ST->getMaxNumVectorRegs(MF->getFunction()).first;
   return Printable(
       [&RP, ST, DynamicVGPRBlockSize, ArchVGPRThreshold, MF](raw_ostream &OS) {
         OS << "VGPRs: " << RP.getArchVGPRNum(ArchVGPRThreshold) << ' '
@@ -906,7 +904,8 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
     return Printable([&RP, &MF](raw_ostream &OS) {
       OS << format(PFX "  %-5d", RP.getSGPRNum())
          << format(" %-5d", RP.getVGPRNum(false, MF.getSubtarget<GCNSubtarget>()
-                                                     .getMaxNumVectorRegs(MF.getFunction())
+                                                     .getMaxNumVectorRegs(
+                                                         MF.getFunction())
                                                      .first));
     });
   };

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.cpp
@@ -100,7 +100,7 @@ bool GCNRegPressure::less(const MachineFunction &MF, const GCNRegPressure &O,
                           unsigned MaxOccupancy) const {
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   unsigned ArchVGPRThreshold =
-      ST.getRegisterInfo()->getMaxNumVectorRegs(MF).first;
+      ST.getMaxNumVectorRegs(MF.getFunction()).first;
   unsigned DynamicVGPRBlockSize =
       MF.getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize();
 
@@ -252,7 +252,7 @@ Printable llvm::print(const GCNRegPressure &RP, const GCNSubtarget *ST,
                       unsigned DynamicVGPRBlockSize,
                       const MachineFunction *MF) {
   unsigned ArchVGPRThreshold =
-      ST->getRegisterInfo()->getMaxNumVectorRegs(*MF).first;
+      ST->getMaxNumVectorRegs(MF->getFunction()).first;
   return Printable(
       [&RP, ST, DynamicVGPRBlockSize, ArchVGPRThreshold, MF](raw_ostream &OS) {
         OS << "VGPRs: " << RP.getArchVGPRNum(ArchVGPRThreshold) << ' '
@@ -906,8 +906,7 @@ bool GCNRegPressurePrinter::runOnMachineFunction(MachineFunction &MF) {
     return Printable([&RP, &MF](raw_ostream &OS) {
       OS << format(PFX "  %-5d", RP.getSGPRNum())
          << format(" %-5d", RP.getVGPRNum(false, MF.getSubtarget<GCNSubtarget>()
-                                                     .getRegisterInfo()
-                                                     ->getMaxNumVectorRegs(MF)
+                                                     .getMaxNumVectorRegs(MF.getFunction())
                                                      .first));
     });
   };

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -132,7 +132,7 @@ struct GCNRegPressure {
         ST.getOccupancyWithNumSGPRs(getSGPRNum()),
         ST.getOccupancyWithNumVGPRs(
             getVGPRNum(ST.hasGFX90AInsts(),
-                       ST.getRegisterInfo()->getMaxNumVectorRegs(MF).first),
+                       ST.getMaxNumVectorRegs(MF.getFunction()).first),
             DynamicVGPRBlockSize));
   }
 

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -108,13 +108,13 @@ struct GCNRegPressure {
   }
   unsigned getSGPRTuplesWeight() const { return Value[TOTAL_KINDS + SGPR]; }
 
-  unsigned getOccupancy(const GCNSubtarget &ST,
-                        unsigned DynamicVGPRBlockSize) const {
-    return std::min(
-        ST.getOccupancyWithNumSGPRs(getSGPRNum()),
-        ST.getOccupancyWithNumVGPRs(
-            getVGPRNum(ST.hasGFX90AInsts(), ST.getAddressableNumArchVGPRs()),
-            DynamicVGPRBlockSize));
+  unsigned getOccupancy(const GCNSubtarget &ST, unsigned DynamicVGPRBlockSize,
+                        const MachineFunction &MF) const {
+    return std::min(ST.getOccupancyWithNumSGPRs(getSGPRNum()),
+                    ST.getOccupancyWithNumVGPRs(
+                        getVGPRNum(ST.hasGFX90AInsts(),
+                                   ST.getArchVGPRAllocationThreshold(MF)),
+                        DynamicVGPRBlockSize));
   }
 
   void inc(unsigned Reg,
@@ -123,9 +123,10 @@ struct GCNRegPressure {
            const MachineRegisterInfo &MRI);
 
   bool higherOccupancy(const GCNSubtarget &ST, const GCNRegPressure &O,
-                       unsigned DynamicVGPRBlockSize) const {
-    return getOccupancy(ST, DynamicVGPRBlockSize) >
-           O.getOccupancy(ST, DynamicVGPRBlockSize);
+                       unsigned DynamicVGPRBlockSize,
+                       const MachineFunction &MF) const {
+    return getOccupancy(ST, DynamicVGPRBlockSize, MF) >
+           O.getOccupancy(ST, DynamicVGPRBlockSize, MF);
   }
 
   /// Compares \p this GCNRegpressure to \p O, returning true if \p this is
@@ -551,7 +552,8 @@ bool isEqual(const GCNRPTracker::LiveRegSet &S1,
              const GCNRPTracker::LiveRegSet &S2);
 
 Printable print(const GCNRegPressure &RP, const GCNSubtarget *ST = nullptr,
-                unsigned DynamicVGPRBlockSize = 0);
+                unsigned DynamicVGPRBlockSize = 0,
+                const MachineFunction *MF = nullptr);
 
 Printable print(const GCNRPTracker::LiveRegSet &LiveRegs,
                 const MachineRegisterInfo &MRI);

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -97,15 +97,17 @@ struct GCNRegPressure {
   /// \returns the ArchVGPR32 pressure, plus the AVGPRS which we assume will be
   /// allocated as VGPR
   unsigned getArchVGPRNum(unsigned AddressableArchVGPR) const {
-    return std::min(Value[VGPR] + Value[AVGPR], AddressableArchVGPR);
+    unsigned AVGPRsAsVGPRs =
+        getAVGPRsAsVGPRsNum(Value[VGPR], Value[AVGPR], AddressableArchVGPR);
+
+    return Value[VGPR] + AVGPRsAsVGPRs;
   }
   /// \returns the AccVGPR32 pressure
   unsigned getAGPRNum(unsigned AddressableArchVGPR) const {
-    unsigned VGPRsForAGPRs =
-        Value[VGPR] + Value[AVGPR] > AddressableArchVGPR
-            ? (Value[VGPR] + Value[AVGPR] - AddressableArchVGPR)
-            : 0;
-    return Value[AGPR] + VGPRsForAGPRs;
+    unsigned AVGPRsAsAGPRs = getAVGPRsAsAGPRsNum(
+        Value[VGPR], Value[AGPR], Value[AVGPR], AddressableArchVGPR);
+
+    return Value[AGPR] + AVGPRsAsAGPRs;
   }
   /// \returns the AVGPR32 pressure
   unsigned getAVGPRNum() const { return Value[AVGPR]; }

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -89,7 +89,6 @@ struct GCNRegPressure {
         getAVGPRsAsVGPRsNum(NumArchVGPRs, NumAVGPRs, AddressableArchVGPR);
     unsigned AVGPRsAsAGPRs = getAVGPRsAsAGPRsNum(
         NumArchVGPRs, NumAGPRs, NumAVGPRs, AddressableArchVGPR);
-    NumAVGPRs > AVGPRsAsVGPRs ? NumAVGPRs - AVGPRsAsVGPRs : 0;
     return alignTo(NumArchVGPRs + AVGPRsAsVGPRs,
                    AMDGPU::IsaInfo::getArchVGPRAllocGranule()) +
            NumAGPRs + AVGPRsAsAGPRs;
@@ -129,11 +128,12 @@ struct GCNRegPressure {
     unsigned DynamicVGPRBlockSize =
         MF.getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize();
 
-    return std::min(ST.getOccupancyWithNumSGPRs(getSGPRNum()),
-                    ST.getOccupancyWithNumVGPRs(
-                        getVGPRNum(ST.hasGFX90AInsts(),
-                                   ST.getArchVGPRAllocationThreshold(MF)),
-                        DynamicVGPRBlockSize));
+    return std::min(
+        ST.getOccupancyWithNumSGPRs(getSGPRNum()),
+        ST.getOccupancyWithNumVGPRs(
+            getVGPRNum(ST.hasGFX90AInsts(),
+                       ST.getRegisterInfo()->getMaxNumVectorRegs(MF).first),
+            DynamicVGPRBlockSize));
   }
 
   void inc(unsigned Reg,

--- a/llvm/lib/Target/AMDGPU/GCNRegPressure.h
+++ b/llvm/lib/Target/AMDGPU/GCNRegPressure.h
@@ -36,6 +36,10 @@ struct GCNRegPressure {
     clear();
   }
 
+  GCNRegPressure(unsigned ArchVGPRThreshold) : ArchVGPRThreshold(ArchVGPRThreshold) {
+    clear();
+  }
+
   bool empty() const {
     return !Value[SGPR] && !Value[VGPR] && !Value[AGPR] && !Value[AVGPR];
   }
@@ -192,6 +196,8 @@ private:
   /// all tuple register kinds).
   unsigned Value[ValueArraySize];
 
+  unsigned ArchVGPRThreshold = std::numeric_limits<unsigned>::max();
+
   static unsigned getRegKind(const TargetRegisterClass *RC,
                              const SIRegisterInfo *STI);
 
@@ -339,7 +345,10 @@ protected:
   const MachineInstr *LastTrackedMI = nullptr;
   mutable const MachineRegisterInfo *MRI = nullptr;
 
-  GCNRPTracker(const LiveIntervals &LIS_) : LIS(LIS_) {}
+  GCNRPTracker(const LiveIntervals &LIS_, const MachineFunction &MF) : LIS(LIS_) {
+    const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
+    unsigned ArchVGPRThreshold = ST.getMaxNumVectorRegs(MF.getFunction()).first;
+  }
 
   void reset(const MachineInstr &MI, const LiveRegSet *LiveRegsCopy,
              bool After);

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -191,8 +191,7 @@ static void getRegisterPressures(
     NewPressure = TempUpwardTracker.getPressure();
   }
   unsigned ArchVGPRThreshold = DAG->MF.getSubtarget<GCNSubtarget>()
-                                   .getRegisterInfo()
-                                   ->getMaxNumVectorRegs(DAG->MF)
+                                   .getMaxNumVectorRegs(DAG->MF.getFunction())
                                    .first;
   Pressure[AMDGPU::RegisterPressureSets::SReg_32] = NewPressure.getSGPRNum();
   Pressure[AMDGPU::RegisterPressureSets::VGPR_32] =
@@ -346,8 +345,7 @@ void GCNSchedStrategy::pickNodeFromQueue(SchedBoundary &Zone,
       SGPRPressure = T->getPressure().getSGPRNum();
       VGPRPressure =
           T->getPressure().getArchVGPRNum(DAG->MF.getSubtarget<GCNSubtarget>()
-                                              .getRegisterInfo()
-                                              ->getMaxNumVectorRegs(DAG->MF)
+                                              .getMaxNumVectorRegs(DAG->MF.getFunction())
                                               .first);
     }
   }
@@ -1290,7 +1288,7 @@ void GCNSchedStage::checkScheduling() {
   LLVM_DEBUG(dbgs() << "Region: " << RegionIdx << ".\n");
 
   unsigned ArchVGPRThreshold =
-      ST.getRegisterInfo()->getMaxNumVectorRegs(MF).first;
+      ST.getMaxNumVectorRegs(MF.getFunction()).first;
   if (PressureAfter.getSGPRNum() <= S.SGPRCriticalLimit &&
       PressureAfter.getVGPRNum(ST.hasGFX90AInsts(), ArchVGPRThreshold) <=
           S.VGPRCriticalLimit) {
@@ -1483,7 +1481,7 @@ bool GCNSchedStage::shouldRevertScheduling(unsigned WavesAfter) {
   // For dynamic VGPR mode, we don't want to waste any VGPR blocks.
   if (DAG.MFI.isDynamicVGPREnabled()) {
     unsigned ArchVGPRThreshold =
-        ST.getRegisterInfo()->getMaxNumVectorRegs(MF).first;
+        ST.getMaxNumVectorRegs(MF.getFunction()).first;
     unsigned BlocksBefore = AMDGPU::IsaInfo::getAllocatedNumVGPRBlocks(
         &ST, DAG.MFI.getDynamicVGPRBlockSize(),
         PressureBefore.getVGPRNum(false, ArchVGPRThreshold));

--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -343,10 +343,10 @@ void GCNSchedStrategy::pickNodeFromQueue(SchedBoundary &Zone,
                             ? static_cast<GCNRPTracker *>(&UpwardTracker)
                             : static_cast<GCNRPTracker *>(&DownwardTracker);
       SGPRPressure = T->getPressure().getSGPRNum();
-      VGPRPressure =
-          T->getPressure().getArchVGPRNum(DAG->MF.getSubtarget<GCNSubtarget>()
-                                              .getMaxNumVectorRegs(DAG->MF.getFunction())
-                                              .first);
+      VGPRPressure = T->getPressure().getArchVGPRNum(
+          DAG->MF.getSubtarget<GCNSubtarget>()
+              .getMaxNumVectorRegs(DAG->MF.getFunction())
+              .first);
     }
   }
   ReadyQueue &Q = Zone.Available;
@@ -1287,8 +1287,7 @@ void GCNSchedStage::checkScheduling() {
                     << print(PressureAfter, &ST, 0, &MF));
   LLVM_DEBUG(dbgs() << "Region: " << RegionIdx << ".\n");
 
-  unsigned ArchVGPRThreshold =
-      ST.getMaxNumVectorRegs(MF.getFunction()).first;
+  unsigned ArchVGPRThreshold = ST.getMaxNumVectorRegs(MF.getFunction()).first;
   if (PressureAfter.getSGPRNum() <= S.SGPRCriticalLimit &&
       PressureAfter.getVGPRNum(ST.hasGFX90AInsts(), ArchVGPRThreshold) <=
           S.VGPRCriticalLimit) {
@@ -1480,8 +1479,7 @@ bool GCNSchedStage::shouldRevertScheduling(unsigned WavesAfter) {
 
   // For dynamic VGPR mode, we don't want to waste any VGPR blocks.
   if (DAG.MFI.isDynamicVGPREnabled()) {
-    unsigned ArchVGPRThreshold =
-        ST.getMaxNumVectorRegs(MF.getFunction()).first;
+    unsigned ArchVGPRThreshold = ST.getMaxNumVectorRegs(MF.getFunction()).first;
     unsigned BlocksBefore = AMDGPU::IsaInfo::getAllocatedNumVGPRBlocks(
         &ST, DAG.MFI.getDynamicVGPRBlockSize(),
         PressureBefore.getVGPRNum(false, ArchVGPRThreshold));

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -1629,6 +1629,15 @@ public:
     return AMDGPU::IsaInfo::getAddressableNumArchVGPRs(this);
   }
 
+  unsigned getArchVGPRAllocationThreshold(const MachineFunction &MF) const {
+    if (hasGFX90AInsts() || !hasMAIInsts())
+      return AMDGPU::IsaInfo::getAddressableNumArchVGPRs(this);
+
+    const Function &F = MF.getFunction();
+    std::pair<unsigned, unsigned> Waves = getWavesPerEU(F);
+    return getMaxNumVGPRs(Waves.first, 0);
+  }
+
   /// \returns Addressable number of VGPRs supported by the subtarget.
   unsigned getAddressableNumVGPRs(unsigned DynamicVGPRBlockSize) const {
     return AMDGPU::IsaInfo::getAddressableNumVGPRs(this, DynamicVGPRBlockSize);

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -1629,15 +1629,6 @@ public:
     return AMDGPU::IsaInfo::getAddressableNumArchVGPRs(this);
   }
 
-  unsigned getArchVGPRAllocationThreshold(const MachineFunction &MF) const {
-    if (hasGFX90AInsts() || !hasMAIInsts())
-      return AMDGPU::IsaInfo::getAddressableNumArchVGPRs(this);
-
-    const Function &F = MF.getFunction();
-    std::pair<unsigned, unsigned> Waves = getWavesPerEU(F);
-    return getMaxNumVGPRs(Waves.first, 0);
-  }
-
   /// \returns Addressable number of VGPRs supported by the subtarget.
   unsigned getAddressableNumVGPRs(unsigned DynamicVGPRBlockSize) const {
     return AMDGPU::IsaInfo::getAddressableNumVGPRs(this, DynamicVGPRBlockSize);

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -209,8 +209,9 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   // tracking does not account for the alignment requirements for SGPRs, or the
   // fragmentation of registers the allocator will need to satisfy.
   if (Occupancy >= MFI->getMinAllowedOccupancy() &&
-      MaxPressure.getVGPRNum(ST->hasGFX90AInsts(),
-                             ST->getArchVGPRAllocationThreshold(*MI.getMF())) <=
+      MaxPressure.getVGPRNum(
+          ST->hasGFX90AInsts(),
+          ST->getRegisterInfo()->getMaxNumVectorRegs(*MI.getMF()).first) <=
           MaxVGPRs / 2 &&
       MaxPressure.getSGPRNum() <= MaxSGPRs / 2) {
     LastRecordedOccupancy = Occupancy;

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -211,7 +211,9 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   // tracking does not account for the alignment requirements for SGPRs, or the
   // fragmentation of registers the allocator will need to satisfy.
   if (Occupancy >= MFI->getMinAllowedOccupancy() &&
-      MaxPressure.getVGPRNum(ST->hasGFX90AInsts()) <= MaxVGPRs / 2 &&
+      MaxPressure.getVGPRNum(ST->hasGFX90AInsts(),
+                             ST->getAddressableNumArchVGPRs()) <=
+          MaxVGPRs / 2 &&
       MaxPressure.getSGPRNum() <= MaxSGPRs / 2) {
     LastRecordedOccupancy = Occupancy;
     return true;

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -197,10 +197,7 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   // pointer becomes dead and could otherwise be reused for destination.
   RPT.advanceToNext();
   GCNRegPressure MaxPressure = RPT.moveMaxPressure();
-  unsigned Occupancy = MaxPressure.getOccupancy(
-      *ST,
-      MI.getMF()->getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize(),
-      *MI.getMF());
+  unsigned Occupancy = MaxPressure.getOccupancy(*MI.getMF());
 
   // Don't push over half the register budget. We don't want to introduce
   // spilling just to form a soft clause.

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -199,7 +199,8 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   GCNRegPressure MaxPressure = RPT.moveMaxPressure();
   unsigned Occupancy = MaxPressure.getOccupancy(
       *ST,
-      MI.getMF()->getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize());
+      MI.getMF()->getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize(),
+      *MI.getMF());
 
   // Don't push over half the register budget. We don't want to introduce
   // spilling just to form a soft clause.
@@ -212,7 +213,7 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   // fragmentation of registers the allocator will need to satisfy.
   if (Occupancy >= MFI->getMinAllowedOccupancy() &&
       MaxPressure.getVGPRNum(ST->hasGFX90AInsts(),
-                             ST->getAddressableNumArchVGPRs()) <=
+                             ST->getArchVGPRAllocationThreshold(*MI.getMF())) <=
           MaxVGPRs / 2 &&
       MaxPressure.getSGPRNum() <= MaxSGPRs / 2) {
     LastRecordedOccupancy = Occupancy;

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -211,7 +211,7 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   if (Occupancy >= MFI->getMinAllowedOccupancy() &&
       MaxPressure.getVGPRNum(
           ST->hasGFX90AInsts(),
-          ST->getRegisterInfo()->getMaxNumVectorRegs(*MI.getMF()).first) <=
+          ST->getMaxNumVectorRegs(MI.getMF()->getFunction()).first) <=
           MaxVGPRs / 2 &&
       MaxPressure.getSGPRNum() <= MaxSGPRs / 2) {
     LastRecordedOccupancy = Occupancy;

--- a/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFormMemoryClauses.cpp
@@ -209,10 +209,7 @@ bool SIFormMemoryClausesImpl::checkPressure(const MachineInstr &MI,
   // tracking does not account for the alignment requirements for SGPRs, or the
   // fragmentation of registers the allocator will need to satisfy.
   if (Occupancy >= MFI->getMinAllowedOccupancy() &&
-      MaxPressure.getVGPRNum(
-          ST->hasGFX90AInsts(),
-          ST->getMaxNumVectorRegs(MI.getMF()->getFunction()).first) <=
-          MaxVGPRs / 2 &&
+      MaxPressure.getVGPRNum(ST->hasGFX90AInsts()) <= MaxVGPRs / 2 &&
       MaxPressure.getSGPRNum() <= MaxSGPRs / 2) {
     LastRecordedOccupancy = Occupancy;
     return true;
@@ -278,7 +275,7 @@ bool SIFormMemoryClausesImpl::run(MachineFunction &MF) {
       "amdgpu-max-memory-clause", MaxClause);
 
   for (MachineBasicBlock &MBB : MF) {
-    GCNDownwardRPTracker RPT(*LIS);
+    GCNDownwardRPTracker RPT(*LIS, &MF);
     MachineBasicBlock::instr_iterator Next;
     for (auto I = MBB.instr_begin(), E = MBB.instr_end(); I != E; I = Next) {
       MachineInstr &MI = *I;

--- a/llvm/test/CodeGen/AMDGPU/avgpr-pressure.mir
+++ b/llvm/test/CodeGen/AMDGPU/avgpr-pressure.mir
@@ -42,6 +42,22 @@
     unreachable
   }
 
+
+  define void @vgpr_rp_occ1() #0 {
+  entry:
+    unreachable
+  }
+
+  define void @vgpr_rp_occ2() #1 {
+  entry:
+    unreachable
+  }
+
+  define void @vgpr_rp_occ3() #2 {
+  entry:
+    unreachable
+  }
+
   attributes #0 = {"amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64"}
   attributes #1 = {"amdgpu-waves-per-eu"="2,2" "amdgpu-flat-work-group-size"="64,64"}
   attributes #2 = {"amdgpu-waves-per-eu"="3,3" "amdgpu-flat-work-group-size"="64,64"}
@@ -194,8 +210,8 @@ machineFunctionInfo:
 body:             |
   bb.0:
    liveins: $vgpr0, $sgpr4_sgpr5
-    %1:vreg_1024 = IMPLICIT_DEF
-    %2:vreg_1024 = IMPLICIT_DEF
+    %1:av_1024 = IMPLICIT_DEF
+    %2:av_1024 = IMPLICIT_DEF
     %3:av_1024 = IMPLICIT_DEF
     %4:av_1024 = IMPLICIT_DEF
     SCHED_BARRIER 0
@@ -210,7 +226,7 @@ body:             |
 # CHECK: Pressure before scheduling:
 # CHECK-NEXT: Region live-ins:
 # CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
-# CHECK-NEXT: Region register pressure: VGPRs: 48 AGPRs: 80(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+# CHECK-NEXT: Region register pressure: VGPRs: 48 AGPRs: 80(O4), SGPRs: 0(O10), LVGPR WT: 80, LSGPR WT: 0 -> Occ: 4
 
 ---
 name:            avgpr_rp_occ5
@@ -229,8 +245,8 @@ machineFunctionInfo:
 body:             |
   bb.0:
    liveins: $vgpr0, $sgpr4_sgpr5
-    %1:vreg_1024 = IMPLICIT_DEF
-    %2:vreg_1024 = IMPLICIT_DEF
+    %1:av_1024 = IMPLICIT_DEF
+    %2:av_1024 = IMPLICIT_DEF
     %3:av_1024 = IMPLICIT_DEF
     %4:av_1024 = IMPLICIT_DEF
     SCHED_BARRIER 0
@@ -245,7 +261,7 @@ body:             |
 # CHECK: Pressure before scheduling:
 # CHECK-NEXT: Region live-ins:
 # CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
-# CHECK-NEXT: Region register pressure: VGPRs: 40 AGPRs: 88(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+# CHECK-NEXT: Region register pressure: VGPRs: 40 AGPRs: 88(O4), SGPRs: 0(O10), LVGPR WT: 88, LSGPR WT: 0 -> Occ: 4
 
 ---
 name:            avgpr_rp_occ6
@@ -264,8 +280,8 @@ machineFunctionInfo:
 body:             |
   bb.0:
    liveins: $vgpr0, $sgpr4_sgpr5
-    %1:vreg_1024 = IMPLICIT_DEF
-    %2:vreg_1024 = IMPLICIT_DEF
+    %1:av_1024 = IMPLICIT_DEF
+    %2:av_1024 = IMPLICIT_DEF
     %3:av_1024 = IMPLICIT_DEF
     %4:av_1024 = IMPLICIT_DEF
     SCHED_BARRIER 0
@@ -280,7 +296,7 @@ body:             |
 # CHECK: Pressure before scheduling:
 # CHECK-NEXT: Region live-ins:
 # CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
-# CHECK-NEXT: Region register pressure: VGPRs: 36 AGPRs: 92(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+# CHECK-NEXT: Region register pressure: VGPRs: 36 AGPRs: 92(O4), SGPRs: 0(O10), LVGPR WT: 92, LSGPR WT: 0 -> Occ: 4
 
 ---
 name:            avgpr_rp_occ7
@@ -299,8 +315,8 @@ machineFunctionInfo:
 body:             |
   bb.0:
    liveins: $vgpr0, $sgpr4_sgpr5
-    %1:vreg_1024 = IMPLICIT_DEF
-    %2:vreg_1024 = IMPLICIT_DEF
+    %1:av_1024 = IMPLICIT_DEF
+    %2:av_1024 = IMPLICIT_DEF
     %3:av_1024 = IMPLICIT_DEF
     %4:av_1024 = IMPLICIT_DEF
     SCHED_BARRIER 0
@@ -315,7 +331,7 @@ body:             |
 # CHECK: Pressure before scheduling:
 # CHECK-NEXT: Region live-ins:
 # CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
-# CHECK-NEXT: Region register pressure: VGPRs: 32 AGPRs: 96(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+# CHECK-NEXT: Region register pressure: VGPRs: 32 AGPRs: 96(O4), SGPRs: 0(O10), LVGPR WT: 96, LSGPR WT: 0 -> Occ: 4
 
 ---
 name:            avgpr_rp_occ8
@@ -334,8 +350,8 @@ machineFunctionInfo:
 body:             |
   bb.0:
    liveins: $vgpr0, $sgpr4_sgpr5
-    %1:vreg_1024 = IMPLICIT_DEF
-    %2:vreg_1024 = IMPLICIT_DEF
+    %1:av_1024 = IMPLICIT_DEF
+    %2:av_1024 = IMPLICIT_DEF
     %3:av_1024 = IMPLICIT_DEF
     %4:av_1024 = IMPLICIT_DEF
     SCHED_BARRIER 0
@@ -346,3 +362,120 @@ body:             |
     S_ENDPGM 0
 ...
 
+# CHECK: vgpr_rp_occ1:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 448 AGPRs: 0(O1), SGPRs: 0(O10), LVGPR WT: 448, LSGPR WT: 0 -> Occ: 1
+
+---
+name:            vgpr_rp_occ1
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:vreg_1024 = IMPLICIT_DEF
+    %4:vreg_1024 = IMPLICIT_DEF
+    %5:vreg_1024 = IMPLICIT_DEF
+    %6:vreg_1024 = IMPLICIT_DEF
+    %7:vreg_1024 = IMPLICIT_DEF
+    %8:vreg_1024 = IMPLICIT_DEF
+    %9:vreg_1024 = IMPLICIT_DEF
+    %10:vreg_1024 = IMPLICIT_DEF
+    %11:vreg_1024 = IMPLICIT_DEF
+    %12:vreg_1024 = IMPLICIT_DEF
+    %13:vreg_1024 = IMPLICIT_DEF
+    %14:vreg_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2, %3, %4, %5, %6, %7
+
+  bb.1:
+    KILL %8, %9, %10, %11, %12, %13, %14
+    S_ENDPGM 0
+...
+
+# CHECK: vgpr_rp_occ2:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 192 AGPRs: 0(O2), SGPRs: 0(O10), LVGPR WT: 192, LSGPR WT: 0 -> Occ: 2
+
+---
+name:            vgpr_rp_occ2
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:vreg_1024 = IMPLICIT_DEF
+    %4:vreg_1024 = IMPLICIT_DEF
+    %5:vreg_1024 = IMPLICIT_DEF
+    %6:vreg_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2, %3
+
+  bb.1:
+    KILL %4, %5, %6
+    S_ENDPGM 0
+...
+
+# CHECK: vgpr_rp_occ3:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 128 AGPRs: 0(O4), SGPRs: 0(O10), LVGPR WT: 128, LSGPR WT: 0 -> Occ: 4
+
+
+---
+name:            vgpr_rp_occ3
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:vreg_1024 = IMPLICIT_DEF
+    %4:vreg_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2
+
+  bb.1:
+    KILL %3, %4
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/avgpr-pressure.mir
+++ b/llvm/test/CodeGen/AMDGPU/avgpr-pressure.mir
@@ -1,0 +1,348 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950  -run-pass=machine-scheduler --debug-only=machine-scheduler -o - %s 2>&1 | FileCheck %s
+# REQUIRES: asserts
+
+--- |
+  define void @avgpr_rp_occ1() #0 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ2() #1 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ3() #2 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ4() #3 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ5() #4 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ6() #5 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ7() #6 {
+  entry:
+    unreachable
+  }
+
+  define void @avgpr_rp_occ8() #7 {
+  entry:
+    unreachable
+  }
+
+  attributes #0 = {"amdgpu-waves-per-eu"="1,1" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #1 = {"amdgpu-waves-per-eu"="2,2" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #2 = {"amdgpu-waves-per-eu"="3,3" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #3 = {"amdgpu-waves-per-eu"="4,4" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #4 = {"amdgpu-waves-per-eu"="5,5" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #5 = {"amdgpu-waves-per-eu"="6,6" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #6 = {"amdgpu-waves-per-eu"="7,7" "amdgpu-flat-work-group-size"="64,64"}
+  attributes #7 = {"amdgpu-waves-per-eu"="8,8" "amdgpu-flat-work-group-size"="64,64"}
+
+
+...
+
+# CHECK: avgpr_rp_occ1:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 256 AGPRs: 192(O1), SGPRs: 0(O10), LVGPR WT: 256, LSGPR WT: 0 -> Occ: 1
+
+---
+name:            avgpr_rp_occ1
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:vreg_1024 = IMPLICIT_DEF
+    %4:vreg_1024 = IMPLICIT_DEF
+    %5:vreg_1024 = IMPLICIT_DEF
+    %6:vreg_1024 = IMPLICIT_DEF
+    %7:vreg_1024 = IMPLICIT_DEF
+    %8:av_1024 = IMPLICIT_DEF
+    %9:av_1024 = IMPLICIT_DEF
+    %10:av_1024 = IMPLICIT_DEF
+    %11:av_1024 = IMPLICIT_DEF
+    %12:av_1024 = IMPLICIT_DEF
+    %13:av_1024 = IMPLICIT_DEF
+    %14:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2, %3, %4, %5, %6, %7
+
+  bb.1:
+    KILL %8, %9, %10, %11, %12, %13, %14
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ2:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 128 AGPRs: 64(O2), SGPRs: 0(O10), LVGPR WT: 128, LSGPR WT: 0 -> Occ: 2
+
+---
+name:            avgpr_rp_occ2
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:vreg_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    %5:av_1024 = IMPLICIT_DEF
+    %6:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2, %3
+
+  bb.1:
+    KILL %4, %5, %6
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ3:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 84 AGPRs: 44(O4), SGPRs: 0(O10), LVGPR WT: 84, LSGPR WT: 0 -> Occ: 4
+
+---
+name:            avgpr_rp_occ3
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:av_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2
+
+  bb.1:
+    KILL %3, %4
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ4:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 64 AGPRs: 64(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+
+---
+name:            avgpr_rp_occ4
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:av_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2 
+
+  bb.1:
+    KILL %3, %4 
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ5:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 48 AGPRs: 80(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+
+---
+name:            avgpr_rp_occ5
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:av_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2 
+
+  bb.1:
+    KILL %3, %4 
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ6:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 40 AGPRs: 88(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+
+---
+name:            avgpr_rp_occ6
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:av_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2 
+
+  bb.1:
+    KILL %3, %4 
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ7:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 36 AGPRs: 92(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+
+---
+name:            avgpr_rp_occ7
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:av_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2 
+
+  bb.1:
+    KILL %3, %4 
+    S_ENDPGM 0
+...
+
+# CHECK: avgpr_rp_occ8:%bb.0
+# CHECK: Pressure before scheduling:
+# CHECK-NEXT: Region live-ins:
+# CHECK-NEXT: Region live-in pressure:  VGPRs: 0 AGPRs: 0(O8), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 8
+# CHECK-NEXT: Region register pressure: VGPRs: 32 AGPRs: 96(O4), SGPRs: 0(O10), LVGPR WT: 64, LSGPR WT: 0 -> Occ: 4
+
+---
+name:            avgpr_rp_occ8
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    kernargSegmentPtr: { reg: '$sgpr4_sgpr5' }
+    workGroupIDX:    { reg: '$sgpr6' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr7' }
+    workItemIDX:     { reg: '$vgpr0' }
+  sgprForEXECCopy: '$sgpr100_sgpr101'
+body:             |
+  bb.0:
+   liveins: $vgpr0, $sgpr4_sgpr5
+    %1:vreg_1024 = IMPLICIT_DEF
+    %2:vreg_1024 = IMPLICIT_DEF
+    %3:av_1024 = IMPLICIT_DEF
+    %4:av_1024 = IMPLICIT_DEF
+    SCHED_BARRIER 0
+    KILL %1, %2 
+
+  bb.1:
+    KILL %3, %4 
+    S_ENDPGM 0
+...
+

--- a/llvm/test/CodeGen/AMDGPU/debug-value-scheduler-liveins.mir
+++ b/llvm/test/CodeGen/AMDGPU/debug-value-scheduler-liveins.mir
@@ -6,7 +6,7 @@
 # CHECK-NEXT: test_get_liveins:%bb.0
 # CHECK: ********** MI Scheduling **********
 # CHECK-NEXT: test_get_liveins:%bb.1
-# CHECK: Region live-in pressure:  VGPRs: 1 AGPRs: 0, SGPRs: 0, LVGPR WT: 0, LSGPR WT: 0
+# CHECK: Region live-in pressure:  VGPRs: 1 AGPRs: 0(O10), SGPRs: 0(O10), LVGPR WT: 0, LSGPR WT: 0 -> Occ: 10
 # CHECK: ScheduleDAGMILive::schedule starting
 
 ---


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/146606 we will only assign %av registers to $agpr after we run out of $vgpr. This teaches our scheduler about this property about the %av registers. 

Still need to the non-unified case, and add some tests.