### PR TITLE
[BOLT] Remove Uses of %T From Lit Tests

### DIFF
--- a/bolt/test/X86/debug-fission-single-convert.s
+++ b/bolt/test/X86/debug-fission-single-convert.s
@@ -14,14 +14,15 @@
 # RUN:   -nostartfiles \
 # RUN:   -Wl,--script=%p/Inputs/debug-fission-script.txt \
 # RUN:   %t.o -o %t.exe
+# RUN: mkdir -p %t.dwarf-output
 # RUN: llvm-bolt %t.exe \
 # RUN:   --reorder-blocks=reverse \
 # RUN:   --update-debug-sections \
-# RUN:   --dwarf-output-path=%T \
+# RUN:   --dwarf-output-path=%t.dwarf-output \
 # RUN:   --always-convert-to-ranges=true \
 # RUN:   -o %t.bolt.1.exe 2>&1 | FileCheck %s
 # RUN: llvm-dwarfdump --show-form --verbose --debug-ranges %t.bolt.1.exe &> %tAddrIndexTest
-# RUN: not llvm-dwarfdump --show-form --verbose --debug-info %T/debug-fission-simple-convert.dwo0.dwo >> %tAddrIndexTest
+# RUN: not llvm-dwarfdump --show-form --verbose --debug-info %t.dwarf-output/debug-fission-simple-convert.dwo0.dwo >> %tAddrIndexTest
 # RUN: cat %tAddrIndexTest | FileCheck %s --check-prefix=CHECK-DWO-DWO
 # RUN: llvm-dwarfdump --show-form --verbose   --debug-addr  %t.bolt.1.exe | FileCheck %s --check-prefix=CHECK-ADDR-SEC
 

--- a/bolt/test/X86/debug-fission-single.s
+++ b/bolt/test/X86/debug-fission-single.s
@@ -14,13 +14,14 @@
 # RUN:   -nostartfiles \
 # RUN:   -Wl,--script=%p/Inputs/debug-fission-script.txt \
 # RUN:   %t.o -o %t.exe
+# RUN: mkdir -p %t.dwarf-output
 # RUN: llvm-bolt %t.exe \
 # RUN:   --reorder-blocks=reverse \
 # RUN:   --update-debug-sections \
-# RUN:   --dwarf-output-path=%T \
+# RUN:   --dwarf-output-path=%t.dwarf-output \
 # RUN:   -o %t.bolt.1.exe 2>&1 | FileCheck %s
 # RUN: llvm-dwarfdump --show-form --verbose --debug-ranges %t.bolt.1.exe &> %tAddrIndexTest
-# RUN: llvm-dwarfdump --show-form --verbose --debug-info %T/debug-fission-simple.dwo0.dwo >> %tAddrIndexTest
+# RUN: llvm-dwarfdump --show-form --verbose --debug-info %t.dwarf-output/debug-fission-simple.dwo0.dwo >> %tAddrIndexTest
 # RUN: cat %tAddrIndexTest | FileCheck %s --check-prefix=CHECK-DWO-DWO
 # RUN: llvm-dwarfdump --show-form --verbose   --debug-addr  %t.bolt.1.exe | FileCheck %s --check-prefix=CHECK-ADDR-SEC
 

--- a/bolt/test/X86/inlined-function-mixed.test
+++ b/bolt/test/X86/inlined-function-mixed.test
@@ -1,9 +1,9 @@
 ## Make sure inlining from a unit with debug info into unit without
 ## debug info does not cause a crash.
 
-RUN: %clangxx %cxxflags %S/Inputs/inlined.cpp -c -o %T/inlined.o
-RUN: %clangxx %cxxflags %S/Inputs/inlinee.cpp -c -o %T/inlinee.o -g
-RUN: %clangxx %cxxflags %T/inlined.o %T/inlinee.o -o %t
+RUN: %clangxx %cxxflags %S/Inputs/inlined.cpp -c -o %t.inlined.o
+RUN: %clangxx %cxxflags %S/Inputs/inlinee.cpp -c -o %t.inlinee.o -g
+RUN: %clangxx %cxxflags %t.inlined.o %t.inlinee.o -o %t
 
 RUN: llvm-bolt %t -o %t.bolt --update-debug-sections --reorder-blocks=reverse \
 RUN:   --inline-small-functions --force-inline=main | FileCheck %s


### PR DESCRIPTION
This patch removes all uses of %T from lit tests within bolt/. %T has been listed as deprecated for ~7 years and should not be used given it is not unique per test which means tests that use the same filenames can race.