### PR TITLE
[Offload] Remove uses of %T from lit tests

### DIFF
--- a/offload/test/offloading/shared_lib_fp_mapping.c
+++ b/offload/test/offloading/shared_lib_fp_mapping.c
@@ -1,6 +1,7 @@
 // clang-format off
-// RUN: %clang-generic -fPIC -shared %S/../Inputs/declare_indirect_func.c -o %T/libslfm.so  -fopenmp-version=51
-// RUN: %libomptarget-compile-generic -rpath %T -L %T -l slfm -o %t  -fopenmp-version=51
+// RUN: mkdir -p %t.testdir
+// RUN: %clang-generic -fPIC -shared %S/../Inputs/declare_indirect_func.c -o %t.testidr/libslfm.so  -fopenmp-version=51
+// RUN: %libomptarget-compile-generic -rpath %t.testdir -L %t.testdir -l slfm -o %t  -fopenmp-version=51
 // RUN: env LIBOMPTARGET_INFO=32 %t 2>&1 | %fcheck-generic
 // clang-format on
 


### PR DESCRIPTION
This patch removes all the instances of %T from offload/ (only one test contained this construction). %T has been deprecated for ~7 years and is not reccomended as it does not use a unique directory per test. Switch to using %t to ensure we use a unique dir per test and so that we can eventually remove %T.

I did not actually test this. A couple feeble attempts at building/running the offload tests just leaves me with a ton of test failures. Given how small this is I'm reasonably sure it works though.