### PR TITLE
[MLIR] Remove uses of %T from lit tests

### DIFF
--- a/mlir/test/mlir-runner/simple.mlir
+++ b/mlir/test/mlir-runner/simple.mlir
@@ -15,10 +15,10 @@
 // RUN: ls %t.o
 // RUN: rm %t.o
 
-// RUN: mlir-runner %s -dump-object-file -object-filename=%T/test.o \
+// RUN: mlir-runner %s -dump-object-file -object-filename=%t.o \
 // RUN:   %if target={{s390x-.*}} %{ -argext-abi-check=false %} | FileCheck %s
-// RUN: ls %T/test.o
-// RUN: rm %T/test.o
+// RUN: ls %t.o
+// RUN: rm %t.o
 
 // Declarations of C library functions.
 llvm.func @logbf(f32) -> f32


### PR DESCRIPTION
%T has been deprecated for about seven years and is to be avoided given it does not use a unique dir per test. Remove it from lit tests in MLIR with the eventual goal to be removing support within llvm-lit.

This patch just reuses %t.o given it is deleted in between sections of the test.