### PR TITLE
[libc][math][c23] Temporarily disable asinpif16 C23 math function

### DIFF
--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -660,7 +660,8 @@ if(LIBC_TYPES_HAS_FLOAT16)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C23 _Float16 entrypoints
     # libc.src.math.acoshf16
-    libc.src.math.asinpif16
+    # Temporarily disabled due to mpfr_asinpi requiring MPFR >= 4.2.0.
+    # libc.src.math.asinpif16
     libc.src.math.canonicalizef16
     libc.src.math.ceilf16
     libc.src.math.copysignf16

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -703,7 +703,8 @@ if(LIBC_TYPES_HAS_FLOAT16)
     libc.src.math.acospif16
     libc.src.math.asinf16
     libc.src.math.asinhf16
-    libc.src.math.asinpif16
+    # Temporarily disabled due to mpfr_asinpi requiring MPFR >= 4.2.0.
+    # libc.src.math.asinpif16
     libc.src.math.atanf16
     libc.src.math.atanhf16
     libc.src.math.canonicalizef16


### PR DESCRIPTION
The MPFR test uses `mpfr_asinpi` which requires MPFR 4.2.0 or later, but
the Buildbots are running an older version of MPFR.

See https://lab.llvm.org/buildbot/#/builders/104/builds/27743 for
example.