### PR TITLE
[clang-tidy] Fix linking regression in clangTidyLLVMModule

### DIFF
--- a/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/llvm/CMakeLists.txt
@@ -17,7 +17,6 @@ add_clang_library(clangTidyLLVMModule STATIC
   clangTidy
   clangTidyReadabilityModule
   clangTidyUtils
-  clangTransformer
 
   DEPENDS
   omp_gen
@@ -31,4 +30,5 @@ clang_target_link_libraries(clangTidyLLVMModule
   clangBasic
   clangLex
   clangTooling
+  clangTransformer
   )


### PR DESCRIPTION
Fix the regression introduced in #149148 that incorrectly explicitly linked `clangTransformer` when dylib was used.  As a result, the executables linking to `clangTidyLLVMModule` would end up linking both the dylib and a number of static clang libraries, leading to complete mayhem and undecipherable segmentation faults.