### PR TITLE
[lldb][Arm32] Remove unused refcount.

### DIFF
--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.h
+++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux_arm.h
@@ -109,7 +109,6 @@ private:
                            // occurred.
     lldb::addr_t real_addr; // Address value that should cause target to stop.
     uint32_t control;       // Breakpoint/watchpoint control value.
-    uint32_t refcount;      // Serves as enable/disable and reference counter.
   };
 
   struct DREG m_hbr_regs[16]; // Arm native linux hardware breakpoints


### PR DESCRIPTION
Already removed in NativeRegisterContextDBReg.h