### PR TITLE
[llvm-config] Append the version number to the llvm-config executable name

### DIFF
--- a/llvm/tools/llvm-config/CMakeLists.txt
+++ b/llvm/tools/llvm-config/CMakeLists.txt
@@ -17,6 +17,14 @@ add_llvm_tool(llvm-config
   DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
+# llvm-config version information
+set(LLVM_CONFIG_EXECUTABLE_VERSION
+    "${LLVM_VERSION_MAJOR}" CACHE STRING
+    "Major version number that will be appended to the llvm-config executable name")
+mark_as_advanced(LLVM_CONFIG_EXECUTABLE_VERSION)
+
+set_target_properties(llvm-config PROPERTIES VERSION ${LLVM_CONFIG_EXECUTABLE_VERSION})
+
 # Compute the substitution values for various items.
 get_property(SUPPORT_SYSTEM_LIBS TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS)
 get_property(WINDOWSMANIFEST_SYSTEM_LIBS TARGET LLVMWindowsManifest PROPERTY LLVM_SYSTEM_LIBS)


### PR DESCRIPTION
- Append the version number to the `llvm-config` executable name.

So `llvm-config` is installed as `llvm-config-20` and `llvm-config` is a symlink to it, the same way `clang` is installed as `clang-20` and `clang` is a symlink to it.

I target the LLVM 20 branch because this is the one I currently use in my development and after having rebased to the current `main` it failed to build and I couldn't test it. By targeting the LLVM 20 branch I made sure I could test it and I tested it and I confirm it works.

I expect this to be merged in any maintained LLVM version branch.

The motivation for this is that when building Mesa, the Mesa build system selected my system's clang 20 because there was a `llvm-config-20` in path that had an higher version number than the `llvm-config` executable I built myself for the sole purpose of being used by my Mesa build. But the system LLVM had a different minor version than the one I built and because Mesa linked against the system LLVM but ran against my self-built LLVM, it faced symbol mismatches and crashed.

It is then required by users to have their self-built LLVM to append the version number to the `llvm-config` binary. In fact the distribution packages already do that, and the system LLVM that mismatched my Mesa build comes from the official [apt.llvm.org](https://apt.llvm.org) that is already doing that.

So by merging this patch we also make possible to simplify all the distro-specific packaging scripts by making possible to remove all the custom code to create after installation a symlink with an appended version number.

This code is the same code used by for appending the version number to the `clang` binary, copy-pasted and adapted to the `llvm-config` binary.

There is one known drawback, it's that once the version number is set in CMake configuration by CMake the first time CMake runs, that version will not change when pulling the repository and the LLVM version has been bumped (`LLVM_CONFIG_EXECUTABLE_VERSION` is set once for all). This limitation is not specific to this branch and is already true for the `clang` binary and the `libclang` library (`CLANG_EXECUTABLE_VERSION` and `LIBCLANG_LIBRARY_VERSION` are set once for all). Fixing that much general problem is not within the scope of that PR.