### PR TITLE
[OpenMP] Remove %preload-tool definition from archer tests

### DIFF
--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -130,10 +130,3 @@ config.substitutions.append(("%deflake", os.path.join(os.path.dirname(__file__),
 config.substitutions.append(("FileCheck", config.test_filecheck))
 config.substitutions.append(("%not", config.test_not))
 config.substitutions.append(("%sort-threads", "sort --numeric-sort --stable"))
-if config.operating_system == 'Windows':
-    # No such environment variable on Windows.
-    config.substitutions.append(("%preload-tool", "true ||"))
-elif config.operating_system == 'Darwin':
-    config.substitutions.append(("%preload-tool", "env DYLD_INSERT_LIBRARIES=%T/tool.so"))
-else:
-    config.substitutions.append(("%preload-tool", "env LD_PRELOAD=%T/tool.so"))


### PR DESCRIPTION
This was added in 2b8115b10b03013b9f8ae0aa56b0cd6a6a6dd4fd and it looks like this wass essentially a copy paste from one of the other lit config files. This substitution is unused within the tests however and contains a deprecated %T directive, so remove it.