### PR TITLE
[Support] Remove get getThreadCount (NFC)

### DIFF
--- a/llvm/include/llvm/Support/ThreadPool.h
+++ b/llvm/include/llvm/Support/ThreadPool.h
@@ -149,10 +149,6 @@ public:
   /// number of threads!
   unsigned getMaxConcurrency() const override { return MaxThreadCount; }
 
-  // TODO: Remove, misleading legacy name warning!
-  LLVM_DEPRECATED("Use getMaxConcurrency instead", "getMaxConcurrency")
-  unsigned getThreadCount() const { return MaxThreadCount; }
-
   /// Returns true if the current thread is a worker thread of this thread pool.
   bool isWorkerThread() const;
 
@@ -232,10 +228,6 @@ public:
 
   /// Returns always 1: there is no concurrency.
   unsigned getMaxConcurrency() const override { return 1; }
-
-  // TODO: Remove, misleading legacy name warning!
-  LLVM_DEPRECATED("Use getMaxConcurrency instead", "getMaxConcurrency")
-  unsigned getThreadCount() const { return 1; }
 
   /// Returns true if the current thread is a worker thread of this thread pool.
   bool isWorkerThread() const;


### PR DESCRIPTION
getThreadCount has been deprecated for more than a year since:

  commit 744616b3aebd008a5ad0e9de9f82f5e284440ab1
  Author: Mehdi Amini <joker.eph@gmail.com>
  Date:   Mon Feb 19 18:07:12 2024 -0800

This patch removes it.
