### PR TITLE
[LLD][COFF] Add ignored linker flags

### DIFF
--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -357,9 +357,9 @@ defm emittoolversioninfo: B<
     "emittoolversioninfo",
     "Emit a tool version info after DOS header (so-called Rich header, default)",
     "Do not emit a tool version info after DOS header (so-scalled Ricb header)">;
-def novcfeature: F<"novcfeature">;
 def nocoffgrpinfo: F<"nocoffgrpinfo">;
 def noexp : F<"noexp">;
+def novcfeature: F<"novcfeature">;
 
 def delay : P_priv<"delay">;
 def errorreport : P_priv<"errorreport">;

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -356,7 +356,7 @@ def emitpogophaseinfo : F<"emitpogophaseinfo">;
 defm emittoolversioninfo: B<
     "emittoolversioninfo",
     "Emit a tool version info after DOS header (so-called Rich header, default)",
-    "Do not emit a tool version info after DOS header (so-scalled Ricb header)">;
+    "Do not emit a tool version info after DOS header (so-called Rich header)">;
 def nocoffgrpinfo: F<"nocoffgrpinfo">;
 def noexp : F<"noexp">;
 def novcfeature: F<"novcfeature">;

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -353,6 +353,12 @@ def fastfail : F<"fastfail">;
 def kernel : F<"kernel">;
 def pdbcompress : F<"pdbcompress">;
 def emitpogophaseinfo : F<"emitpogophaseinfo">;
+defm emittoolversioninfo: B<
+    "emittoolversioninfo",
+    "Emit a tool version info after DOS header (so-called Rich header, default)",
+    "Do not emit a tool version info after DOS header (so-scalled Ricb header)">;
+def novcfeature: F<"novcfeature">;
+def nocoffgrpinfo: F<"nocoffgrpinfo">;
 def noexp : F<"noexp">;
 
 def delay : P_priv<"delay">;


### PR DESCRIPTION
These flags were treated as explicit errors, which could cause compatibility issues with MS link.exe. To address this, LLD was updated to ignore them, aligning its behavior with MS link.exe. The latter two options affect how MS link.exe generates metadata for its PGO. LLD doesn't generate any such metadata right now (and doesn't work with the MSVC PGO feature), so those options are kept as no-ops.

- Added `/emittoolversioninfo[:no]` flag in LLD/COFF options
  - This flag emits a rich header between DOS stub and PE header. LLVM does not emit the rich header at all.
- Added `/novcfeature` flag in LLD/COFF options
- Added `/nocoffgrpinfo` flag in LLD/COFF options
