### PR TITLE
[mlir] Fix compile error in Inliner.cpp when NDEBUG is set

### DIFF
--- a/mlir/lib/Transforms/Utils/Inliner.cpp
+++ b/mlir/lib/Transforms/Utils/Inliner.cpp
@@ -667,9 +667,11 @@ Inliner::Impl::inlineCallsInSCC(InlinerInterfaceImpl &inlinerIface,
     auto historyToString = [](InlineHistoryT h) {
       return h.has_value() ? std::to_string(*h) : "root";
     };
+#ifndef NDEBUG
     LDBG() << "* new inlineHistory entry: " << newInlineHistoryID << ". ["
            << getNodeName(call) << ", " << historyToString(inlineHistoryID)
            << "]";
+#endif
 
     for (unsigned k = prevSize; k != calls.size(); ++k) {
       callHistory.push_back(newInlineHistoryID);


### PR DESCRIPTION
I just noticed this while trying to build the current main branch. The way `LDBG` is defined it must be possible to evaluate its arguments even when it turns into a no-op and there seems to be this one case here where that is not true.