### PR TITLE
[libc] Add missing libc.include.inttypes dependency.

### DIFF
--- a/libc/src/stdio/scanf_core/CMakeLists.txt
+++ b/libc/src/stdio/scanf_core/CMakeLists.txt
@@ -35,6 +35,7 @@ add_header_library(
     core_structs.h
   DEPENDS
     .scanf_config
+    libc.include.inttypes
     libc.src.__support.CPP.string_view
     libc.src.__support.CPP.bitset
     libc.src.__support.FPUtil.fp_bits


### PR DESCRIPTION
https://lab.llvm.org/buildbot/#/builders/11/builds/20218/steps/6/logs/stdio