### PR TITLE
[libc] Add implementation of getcpu syscall wrapper

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -36,6 +36,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.poll.poll
 
     # sched.h entrypoints
+    libc.src.sched.getcpu
     libc.src.sched.sched_get_priority_max
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_getaffinity

--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -18,6 +18,13 @@ functions:
     arguments:
       - type: size_t
       - type: const cpu_set_t *
+  - name: getcpu
+    standards:
+      - POSIX
+    return_type: int
+    arguments:
+      - type: unsigned int *
+      - type: unsigned int *
   - name: sched_get_priority_max
     standards:
       - POSIX

--- a/libc/src/sched/CMakeLists.txt
+++ b/libc/src/sched/CMakeLists.txt
@@ -3,6 +3,13 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${LIBC_TARGET_OS})
 endif()
 
 add_entrypoint_object(
+  getcpu
+  ALIAS
+  DEPENDS
+    .${LIBC_TARGET_OS}.getcpu
+)
+
+add_entrypoint_object(
   sched_getaffinity
   ALIAS
   DEPENDS

--- a/libc/src/sched/getcpu.h
+++ b/libc/src/sched/getcpu.h
@@ -10,7 +10,6 @@
 #define LLVM_LIBC_SRC_SCHED_GETCPU_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sched/getcpu.h
+++ b/libc/src/sched/getcpu.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for getcpu ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_SCHED_GETCPU_H
+#define LLVM_LIBC_SRC_SCHED_GETCPU_H
+
+#include "src/__support/macros/config.h"
+#include <sched.h>
+
+namespace LIBC_NAMESPACE_DECL {
+
+int getcpu(unsigned int *cpu, unsigned int *node);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_SCHED_GETCPU_H

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -1,4 +1,16 @@
 add_entrypoint_object(
+  getcpu
+  SRCS
+    getcpu.cpp
+  HDRS
+    ../getcpu.h
+  DEPENDS
+    libc.include.sched
+    libc.src.__support.OSUtil.osutil
+    libc.src.errno.errno
+)
+
+add_entrypoint_object(
   sched_getaffinity
   SRCS
     sched_getaffinity.cpp

--- a/libc/src/sched/linux/getcpu.cpp
+++ b/libc/src/sched/linux/getcpu.cpp
@@ -13,7 +13,6 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
-#include <sched.h>
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sched/linux/getcpu.cpp
+++ b/libc/src/sched/linux/getcpu.cpp
@@ -18,7 +18,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(int, getcpu, (unsigned int *cpu, unsigned int *node)) {
-  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_getcpu, cpu, node);
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_getcpu, cpu, node, nullptr);
   if (ret < 0) {
     libc_errno = -ret;
     return -1;

--- a/libc/src/sched/linux/getcpu.cpp
+++ b/libc/src/sched/linux/getcpu.cpp
@@ -1,0 +1,30 @@
+//===-- Implementation of getcpu ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/sched/getcpu.h"
+
+#include "src/__support/OSUtil/syscall.h" // For internal syscall function.
+#include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
+#include "src/__support/macros/config.h"
+
+#include <sched.h>
+#include <sys/syscall.h> // For syscall numbers.
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(int, getcpu, (unsigned int *cpu, unsigned int *node)) {
+  int ret = LIBC_NAMESPACE::syscall_impl<int>(SYS_getcpu, cpu, node);
+  if (ret < 0) {
+    libc_errno = -ret;
+    return -1;
+  }
+  return 0;
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -50,6 +50,7 @@ add_libc_unittest(
     libc.include.sched
     libc.src.errno.errno
     libc.src.sched.getcpu
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -41,6 +41,18 @@ add_libc_unittest(
 )
 
 add_libc_unittest(
+  getcpu_test
+  SUITE
+    libc_sched_unittests
+  SRCS
+    getcpu_test.cpp
+  DEPENDS
+    libc.include.sched
+    libc.src.errno.errno
+    libc.src.sched.getcpu
+)
+
+add_libc_unittest(
   scheduler_test
   SUITE
     libc_sched_unittests

--- a/libc/test/src/sched/getcpu_test.cpp
+++ b/libc/test/src/sched/getcpu_test.cpp
@@ -9,15 +9,17 @@
 #include "src/__support/OSUtil/syscall.h"
 #include "src/__support/libc_errno.h"
 #include "src/sched/getcpu.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 
-#include <sched.h>
+using LlvmLibcSchedGetCpuTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST(LlvmLibcSchedGetCpuTest, SmokeTest) {
   unsigned int current_cpu;
   unsigned int current_node;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   ASSERT_THAT(LIBC_NAMESPACE::getcpu(&current_cpu, &current_node), Succeeds(0));
+  ASSERT_ERRNO_SUCCESS();
 }
 
 TEST(LlvmLibcSchedGetCpuTest, BadPointer) {

--- a/libc/test/src/sched/getcpu_test.cpp
+++ b/libc/test/src/sched/getcpu_test.cpp
@@ -14,15 +14,14 @@
 
 using LlvmLibcSchedGetCpuTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcSchedGetCpuTest, SmokeTest) {
+TEST_F(LlvmLibcSchedGetCpuTest, SmokeTest) {
   unsigned int current_cpu;
   unsigned int current_node;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   ASSERT_THAT(LIBC_NAMESPACE::getcpu(&current_cpu, &current_node), Succeeds(0));
-  ASSERT_ERRNO_SUCCESS();
 }
 
-TEST(LlvmLibcSchedGetCpuTest, BadPointer) {
+TEST_F(LlvmLibcSchedGetCpuTest, BadPointer) {
   unsigned int current_cpu;
   unsigned int *current_node = reinterpret_cast<unsigned int *>(-1);
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;

--- a/libc/test/src/sched/getcpu_test.cpp
+++ b/libc/test/src/sched/getcpu_test.cpp
@@ -1,0 +1,29 @@
+//===-- Unittests for getcpu ----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/OSUtil/syscall.h"
+#include "src/__support/libc_errno.h"
+#include "src/sched/getcpu.h"
+#include "test/UnitTest/ErrnoSetterMatcher.h"
+
+#include <sched.h>
+
+TEST(LlvmLibcSchedGetCpuTest, SmokeTest) {
+  unsigned int current_cpu;
+  unsigned int current_node;
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+  ASSERT_THAT(LIBC_NAMESPACE::getcpu(&current_cpu, &current_node), Succeeds(0));
+}
+
+TEST(LlvmLibcSchedGetCpuTest, BadPointer) {
+  unsigned int current_cpu;
+  unsigned int *current_node = reinterpret_cast<unsigned int *>(-1);
+  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
+  ASSERT_THAT(LIBC_NAMESPACE::getcpu(&current_cpu, current_node),
+              Fails(EFAULT));
+}


### PR DESCRIPTION
This patch adds the getcpu syscall wrapper. This has been supported in glibc since v2.29.