### PR TITLE
[OpenMP] Fix td_tdg_task_id underflow when taskloop and taskgraph

### DIFF
--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2667,6 +2667,7 @@ typedef struct kmp_tdg_info {
   kmp_tdg_status_t tdg_status =
       KMP_TDG_NONE; // Status of the TDG (recording, ready...)
   std::atomic<kmp_int32> num_tasks; // Number of TDG nodes
+  std::atomic<kmp_int32> tdg_task_id_next; // Task id of next node
   kmp_bootstrap_lock_t
       graph_lock; // Protect graph attributes when updated via taskloop_recur
   // Taskloop reduction related

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2805,6 +2805,7 @@ struct kmp_taskdata { /* aligned during dynamic allocation       */
 #if OMPX_TASKGRAPH
   bool is_taskgraph = 0; // whether the task is within a TDG
   kmp_tdg_info_t *tdg; // used to associate task with a TDG
+  kmp_node_info_t *td_tdg_node_info; // node representing the task's in the TDG
   kmp_int32 td_tdg_task_id; // local task id in its TDG
 #endif
   kmp_target_data_t td_target_data;

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2676,8 +2676,6 @@ typedef struct kmp_tdg_info {
       KMP_TDG_NONE; // Status of the TDG (recording, ready...)
   std::atomic<kmp_int32> num_tasks; // Number of TDG nodes
   std::atomic<kmp_int32> tdg_task_id_next; // Task id of next node
-  kmp_bootstrap_lock_t
-      graph_lock; // Protect graph attributes when updated via taskloop_recur
   // Taskloop reduction related
   void *rec_taskred_data; // Data to pass to __kmpc_task_reduction_init or
                           // __kmpc_taskred_init

--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -2649,6 +2649,14 @@ typedef struct kmp_node_info {
   kmp_taskdata_t *parent_task; // Parent implicit task
 } kmp_node_info_t;
 
+// Representation of recorded nodes
+typedef struct kmp_node_vector {
+  kmp_node_info_t **blocks;
+  kmp_int32 block_size;
+  std::atomic<kmp_int32> num_of_blocks;
+  kmp_bootstrap_lock_t lock;
+} kmp_node_vector_t;
+
 /// Represent a TDG's current status
 typedef enum kmp_tdg_status {
   KMP_TDG_NONE = 0,
@@ -2660,10 +2668,10 @@ typedef enum kmp_tdg_status {
 typedef struct kmp_tdg_info {
   kmp_int32 tdg_id; // Unique idenfifier of the TDG
   kmp_taskgraph_flags_t tdg_flags; // Flags related to a TDG
-  kmp_int32 map_size; // Number of allocated TDG nodes
+  /* kmp_int32 map_size; // Number of allocated TDG nodes */
   kmp_int32 num_roots; // Number of roots tasks int the TDG
   kmp_int32 *root_tasks; // Array of tasks identifiers that are roots
-  kmp_node_info_t *record_map; // Array of TDG nodes
+  kmp_node_vector_t *record_map; // Array of TDG nodes
   kmp_tdg_status_t tdg_status =
       KMP_TDG_NONE; // Status of the TDG (recording, ready...)
   std::atomic<kmp_int32> num_tasks; // Number of TDG nodes

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -244,13 +244,17 @@ static inline void __kmp_track_dependence(kmp_int32 gtid, kmp_depnode_t *source,
     if (!exists) {
       if (source_info->nsuccessors >= source_info->successors_size) {
         kmp_uint old_size = source_info->successors_size;
-        source_info->successors_size = 2 * source_info->successors_size;
+        source_info->successors_size = old_size == 0
+                                           ? __kmp_successors_size
+                                           : 2 * source_info->successors_size;
         kmp_int32 *old_succ_ids = source_info->successors;
         kmp_int32 *new_succ_ids = (kmp_int32 *)__kmp_allocate(
             source_info->successors_size * sizeof(kmp_int32));
-        KMP_MEMCPY(new_succ_ids, old_succ_ids, old_size * sizeof(kmp_int32));
+        if (old_succ_ids) {
+          KMP_MEMCPY(new_succ_ids, old_succ_ids, old_size * sizeof(kmp_int32));
+          __kmp_free(old_succ_ids);
+        }
         source_info->successors = new_succ_ids;
-        __kmp_free(old_succ_ids);
       }
 
       source_info->successors[source_info->nsuccessors] =
@@ -715,13 +719,11 @@ kmp_int32 __kmpc_omp_task_with_deps(ident_t *loc_ref, kmp_int32 gtid,
         __kmp_free(old_record);
 
         for (kmp_int i = old_size; i < new_size; i++) {
-          kmp_int32 *successorsList = (kmp_int32 *)__kmp_allocate(
-              __kmp_successors_size * sizeof(kmp_int32));
           new_record[i].task = nullptr;
-          new_record[i].successors = successorsList;
+          new_record[i].successors = nullptr;
           new_record[i].nsuccessors = 0;
           new_record[i].npredecessors = 0;
-          new_record[i].successors_size = __kmp_successors_size;
+          new_record[i].successors_size = 0;
           KMP_ATOMIC_ST_REL(&new_record[i].npredecessors_counter, 0);
         }
         // update the size at the end, so that we avoid other

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -704,39 +704,37 @@ kmp_int32 __kmpc_omp_task_with_deps(ident_t *loc_ref, kmp_int32 gtid,
       __kmp_tdg_is_recording(new_taskdata->tdg->tdg_status)) {
     kmp_tdg_info_t *tdg = new_taskdata->tdg;
     // extend record_map if needed
+    __kmp_acquire_bootstrap_lock(&tdg->graph_lock);
     if (new_taskdata->td_tdg_task_id >= tdg->map_size) {
-      __kmp_acquire_bootstrap_lock(&tdg->graph_lock);
-      if (new_taskdata->td_tdg_task_id >= tdg->map_size) {
-        kmp_uint old_size = tdg->map_size;
-        kmp_uint new_size = old_size * 2;
-        kmp_node_info_t *old_record = tdg->record_map;
-        kmp_node_info_t *new_record = (kmp_node_info_t *)__kmp_allocate(
-            new_size * sizeof(kmp_node_info_t));
-        KMP_MEMCPY(new_record, tdg->record_map,
-                   old_size * sizeof(kmp_node_info_t));
-        tdg->record_map = new_record;
+      kmp_uint old_size = tdg->map_size;
+      kmp_uint new_size = old_size * 2;
+      kmp_node_info_t *old_record = tdg->record_map;
+      kmp_node_info_t *new_record =
+          (kmp_node_info_t *)__kmp_allocate(new_size * sizeof(kmp_node_info_t));
+      KMP_MEMCPY(new_record, tdg->record_map,
+                 old_size * sizeof(kmp_node_info_t));
+      tdg->record_map = new_record;
 
-        __kmp_free(old_record);
+      __kmp_free(old_record);
 
-        for (kmp_int i = old_size; i < new_size; i++) {
-          new_record[i].task = nullptr;
-          new_record[i].parent_task = nullptr;
-          new_record[i].successors = nullptr;
-          new_record[i].nsuccessors = 0;
-          new_record[i].npredecessors = 0;
-          new_record[i].successors_size = 0;
-          KMP_ATOMIC_ST_REL(&new_record[i].npredecessors_counter, 0);
-        }
-        // update the size at the end, so that we avoid other
-        // threads use old_record while map_size is already updated
-        tdg->map_size = new_size;
+      for (kmp_int i = old_size; i < new_size; i++) {
+        new_record[i].task = nullptr;
+        new_record[i].parent_task = nullptr;
+        new_record[i].successors = nullptr;
+        new_record[i].nsuccessors = 0;
+        new_record[i].npredecessors = 0;
+        new_record[i].successors_size = 0;
+        KMP_ATOMIC_ST_REL(&new_record[i].npredecessors_counter, 0);
       }
-      __kmp_release_bootstrap_lock(&tdg->graph_lock);
+      // update the size at the end, so that we avoid other
+      // threads use old_record while map_size is already updated
+      tdg->map_size = new_size;
     }
     tdg->record_map[new_taskdata->td_tdg_task_id].task = new_task;
     tdg->record_map[new_taskdata->td_tdg_task_id].parent_task =
         new_taskdata->td_parent;
     KMP_ATOMIC_INC(&tdg->num_tasks);
+    __kmp_release_bootstrap_lock(&tdg->graph_lock);
   }
 #endif
 #if OMPT_SUPPORT

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -720,6 +720,7 @@ kmp_int32 __kmpc_omp_task_with_deps(ident_t *loc_ref, kmp_int32 gtid,
 
         for (kmp_int i = old_size; i < new_size; i++) {
           new_record[i].task = nullptr;
+          new_record[i].parent_task = nullptr;
           new_record[i].successors = nullptr;
           new_record[i].nsuccessors = 0;
           new_record[i].npredecessors = 0;

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -232,8 +232,7 @@ static inline void __kmp_track_dependence(kmp_int32 gtid, kmp_depnode_t *source,
   }
   if (task_sink->is_taskgraph &&
       __kmp_tdg_is_recording(task_sink->tdg->tdg_status)) {
-    kmp_node_info_t *source_info =
-        &task_sink->tdg->record_map[task_source->td_tdg_task_id];
+    kmp_node_info_t *source_info = task_source->td_tdg_node_info;
     bool exists = false;
     for (int i = 0; i < source_info->nsuccessors; i++) {
       if (source_info->successors[i] == task_sink->td_tdg_task_id) {
@@ -261,8 +260,7 @@ static inline void __kmp_track_dependence(kmp_int32 gtid, kmp_depnode_t *source,
           task_sink->td_tdg_task_id;
       source_info->nsuccessors++;
 
-      kmp_node_info_t *sink_info =
-          &(task_sink->tdg->record_map[task_sink->td_tdg_task_id]);
+      kmp_node_info_t *sink_info = task_sink->td_tdg_node_info;
       sink_info->npredecessors++;
     }
   }
@@ -733,6 +731,8 @@ kmp_int32 __kmpc_omp_task_with_deps(ident_t *loc_ref, kmp_int32 gtid,
     tdg->record_map[new_taskdata->td_tdg_task_id].task = new_task;
     tdg->record_map[new_taskdata->td_tdg_task_id].parent_task =
         new_taskdata->td_parent;
+    new_taskdata->td_tdg_node_info =
+        &tdg->record_map[new_taskdata->td_tdg_task_id];
     KMP_ATOMIC_INC(&tdg->num_tasks);
     __kmp_release_bootstrap_lock(&tdg->graph_lock);
   }

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -708,12 +708,10 @@ kmp_int32 __kmpc_omp_task_with_deps(ident_t *loc_ref, kmp_int32 gtid,
       kmp_node_vector_resize(tdg->record_map, new_taskdata->td_tdg_task_id * 2);
       node = kmp_node_vector_get(tdg->record_map, new_taskdata->td_tdg_task_id);
     }
-    __kmp_acquire_bootstrap_lock(&tdg->graph_lock);
     node->task = new_task;
     node->parent_task = new_taskdata->td_parent;
     new_taskdata->td_tdg_node_info = node;
     KMP_ATOMIC_INC(&tdg->num_tasks);
-    __kmp_release_bootstrap_lock(&tdg->graph_lock);
   }
 #endif
 #if OMPT_SUPPORT

--- a/openmp/runtime/src/kmp_taskdeps.h
+++ b/openmp/runtime/src/kmp_taskdeps.h
@@ -93,6 +93,13 @@ static inline void __kmp_dephash_free(kmp_info_t *thread, kmp_dephash_t *h) {
 }
 
 extern void __kmpc_give_task(kmp_task_t *ptask, kmp_int32 start);
+#if OMPX_TASKGRAPH
+extern kmp_node_vector_t *kmp_alloc_tdg_vector(kmp_int32 block_size);
+extern kmp_node_info_t *kmp_node_vector_get(kmp_node_vector_t *vector,
+                                            kmp_int32 id);
+extern void kmp_node_vector_resize(kmp_node_vector_t *vector, kmp_int32 size);
+extern void kmp_node_vector_free(kmp_node_vector_t *vector);
+#endif
 
 static inline void __kmp_release_deps(kmp_int32 gtid, kmp_taskdata_t *task) {
 
@@ -102,7 +109,10 @@ static inline void __kmp_release_deps(kmp_int32 gtid, kmp_taskdata_t *task) {
 
     for (int i = 0; i < TaskInfo->nsuccessors; i++) {
       kmp_int32 successorNumber = TaskInfo->successors[i];
-      kmp_node_info_t *successor = &(task->tdg->record_map[successorNumber]);
+      kmp_node_info_t *successor =
+          kmp_node_vector_get(task->tdg->record_map, successorNumber);
+      /* kmp_node_info_t *successor = &(task->tdg->record_map[successorNumber]);
+       */
       kmp_int32 npredecessors = KMP_ATOMIC_DEC(&successor->npredecessors_counter) - 1;
       if (successor->task != nullptr && npredecessors == 0) {
         __kmp_omp_task(gtid, successor->task, false);

--- a/openmp/runtime/src/kmp_taskdeps.h
+++ b/openmp/runtime/src/kmp_taskdeps.h
@@ -98,7 +98,7 @@ static inline void __kmp_release_deps(kmp_int32 gtid, kmp_taskdata_t *task) {
 
 #if OMPX_TASKGRAPH
   if (task->is_taskgraph && !(__kmp_tdg_is_recording(task->tdg->tdg_status))) {
-    kmp_node_info_t *TaskInfo = &(task->tdg->record_map[task->td_tdg_task_id]);
+    kmp_node_info_t *TaskInfo = task->td_tdg_node_info;
 
     for (int i = 0; i < TaskInfo->nsuccessors; i++) {
       kmp_int32 successorNumber = TaskInfo->successors[i];

--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -1817,13 +1817,11 @@ kmp_int32 __kmp_omp_task(kmp_int32 gtid, kmp_task_t *new_task,
         __kmp_free(old_record);
 
         for (kmp_int i = old_size; i < new_size; i++) {
-          kmp_int32 *successorsList = (kmp_int32 *)__kmp_allocate(
-              __kmp_successors_size * sizeof(kmp_int32));
           new_record[i].task = nullptr;
-          new_record[i].successors = successorsList;
+          new_record[i].successors = nullptr;
           new_record[i].nsuccessors = 0;
           new_record[i].npredecessors = 0;
-          new_record[i].successors_size = __kmp_successors_size;
+          new_record[i].successors_size = 0;
           KMP_ATOMIC_ST_REL(&new_record[i].npredecessors_counter, 0);
         }
         // update the size at the end, so that we avoid other
@@ -5368,13 +5366,12 @@ static inline void __kmp_start_record(kmp_int32 gtid,
   kmp_node_info_t *this_record_map =
       (kmp_node_info_t *)__kmp_allocate(INIT_MAPSIZE * sizeof(kmp_node_info_t));
   for (kmp_int32 i = 0; i < INIT_MAPSIZE; i++) {
-    kmp_int32 *successorsList =
-        (kmp_int32 *)__kmp_allocate(__kmp_successors_size * sizeof(kmp_int32));
     this_record_map[i].task = nullptr;
-    this_record_map[i].successors = successorsList;
+    this_record_map[i].parent_task = nullptr;
+    this_record_map[i].successors = nullptr;
     this_record_map[i].nsuccessors = 0;
     this_record_map[i].npredecessors = 0;
-    this_record_map[i].successors_size = __kmp_successors_size;
+    this_record_map[i].successors_size = 0;
     KMP_ATOMIC_ST_RLX(&this_record_map[i].npredecessors_counter, 0);
   }
 

--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -1800,7 +1800,8 @@ kmp_int32 __kmp_omp_task(kmp_int32 gtid, kmp_task_t *new_task,
       __kmp_tdg_is_recording(new_taskdata->tdg->tdg_status)) {
     kmp_tdg_info_t *tdg = new_taskdata->tdg;
     // extend the record_map if needed
-    if (new_taskdata->td_tdg_task_id >= new_taskdata->tdg->map_size) {
+    if (new_taskdata->td_tdg_task_id >= tdg->map_size ||
+        tdg->record_map[new_taskdata->td_tdg_task_id].task == nullptr) {
       __kmp_acquire_bootstrap_lock(&tdg->graph_lock);
       // map_size could have been updated by another thread if recursive
       // taskloop
@@ -1829,14 +1830,11 @@ kmp_int32 __kmp_omp_task(kmp_int32 gtid, kmp_task_t *new_task,
         // threads use old_record while map_size is already updated
         tdg->map_size = new_size;
       }
-      __kmp_release_bootstrap_lock(&tdg->graph_lock);
-    }
-    // record a task
-    if (tdg->record_map[new_taskdata->td_tdg_task_id].task == nullptr) {
       tdg->record_map[new_taskdata->td_tdg_task_id].task = new_task;
       tdg->record_map[new_taskdata->td_tdg_task_id].parent_task =
           new_taskdata->td_parent;
       KMP_ATOMIC_INC(&tdg->num_tasks);
+      __kmp_release_bootstrap_lock(&tdg->graph_lock);
     }
   }
 #endif

--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -1818,6 +1818,7 @@ kmp_int32 __kmp_omp_task(kmp_int32 gtid, kmp_task_t *new_task,
 
         for (kmp_int i = old_size; i < new_size; i++) {
           new_record[i].task = nullptr;
+          new_record[i].parent_task = nullptr;
           new_record[i].successors = nullptr;
           new_record[i].nsuccessors = 0;
           new_record[i].npredecessors = 0;

--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -1808,12 +1808,10 @@ kmp_int32 __kmp_omp_task(kmp_int32 gtid, kmp_task_t *new_task,
       node = kmp_node_vector_get(tdg->record_map, new_taskdata->td_tdg_task_id);
     }
     if (node->task == nullptr) {
-      __kmp_acquire_bootstrap_lock(&tdg->graph_lock);
       node->task = new_task;
       node->parent_task = new_taskdata->td_parent;
       new_taskdata->td_tdg_node_info = node;
       KMP_ATOMIC_INC(&tdg->num_tasks);
-      __kmp_release_bootstrap_lock(&tdg->graph_lock);
     }
   }
 #endif

--- a/openmp/runtime/src/kmp_tasking.cpp
+++ b/openmp/runtime/src/kmp_tasking.cpp
@@ -1394,6 +1394,7 @@ kmp_task_t *__kmp_task_alloc(ident_t *loc_ref, kmp_int32 gtid,
   taskdata->td_flags.onced = 0;
   taskdata->is_taskgraph = 0;
   taskdata->tdg = nullptr;
+  taskdata->td_tdg_node_info = nullptr;
 #endif
   KMP_ATOMIC_ST_RLX(&taskdata->td_incomplete_child_tasks, 0);
   // start at one because counts current task and children
@@ -1833,6 +1834,8 @@ kmp_int32 __kmp_omp_task(kmp_int32 gtid, kmp_task_t *new_task,
       tdg->record_map[new_taskdata->td_tdg_task_id].task = new_task;
       tdg->record_map[new_taskdata->td_tdg_task_id].parent_task =
           new_taskdata->td_parent;
+      new_taskdata->td_tdg_node_info =
+          &tdg->record_map[new_taskdata->td_tdg_task_id];
       KMP_ATOMIC_INC(&tdg->num_tasks);
       __kmp_release_bootstrap_lock(&tdg->graph_lock);
     }


### PR DESCRIPTION
This patch addresses an issue where the `td_tdg_task_id` could underflow, leading to a negative task ID, when a `taskloop` region was encountered before a taskgraph clause.

Previously, `td_tdg_task_id` was decremented unconditionally within a taskloop, even if that taskloop was not part of an active taskgraph. This caused problems in scenarios like the following:

```cpp
#pragma omp parallel
#pragma omp single
{
// Here, td_tdg_task_id is incorrectly decremented, potentially becoming negative.
#pragma omp taskloop
  for (int i = 0; i < n; i++) {
    initialize(data[i]);
  }
}

#pragma omp parallel
#pragma omp single
{
#pragma omp taskgraph
{
// When this taskgraph is entered, the recording of tasks may fail (e.g., segfault)
// due to the invalid (negative) td_tdg_task_id.
#pragma omp taskloop
  for (int i = 0; i < num_iter;  i++) {
    compute();
  }
}
}
```

**EDIT(18/09/2025)**:
This implementation:
- Allows sporadic holes in the record_map: The record_map, an array of recorded tasks in a task graph, can now have sporadic holes. This change removes the need for a decrement operation and centralizes the control of the index/ID within each task dependence graph (TDG) by moving the count for the next index inside the kmp_node_info structure.
- Removes extra allocation of kmp_node_info successors. Optimizing memory usage by delaying the allocation of kmp_node_info successors until they are actually needed.
- Fixes a data race when resizing the record_map.


