### PR TITLE
[OpenMP] Fix race condition in taskgraph with task dependencies

### DIFF
--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -329,12 +329,6 @@ __kmp_depnode_link_successor(kmp_int32 gtid, kmp_info_t *thread,
           if (!(__kmp_tdg_is_recording(tdg_status)) && task)
 #endif
             __kmp_track_dependence(gtid, dep, node, task);
-#if OMPX_TASKGRAPH
-          else if (KMP_TASK_TO_TASKDATA(dep->dn.task)->td_flags.onced) {
-            KMP_RELEASE_DEPNODE(gtid, dep);
-            continue;
-          }
-#endif
           dep->dn.successors = __kmp_add_node(thread, dep->dn.successors, node);
           KA_TRACE(40, ("__kmp_process_deps: T#%d adding dependence from %p to "
                         "%p\n",

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -321,9 +321,19 @@ __kmp_depnode_link_successor(kmp_int32 gtid, kmp_info_t *thread,
         __kmp_track_dependence(gtid, dep, node, task);
     }
 #endif
-    if (dep->dn.task) {
+    if (dep->dn.task
+#if OMPX_TASKGRAPH
+        && __kmp_tdg_is_recording(tdg_status) &&
+        !KMP_TASK_TO_TASKDATA(dep->dn.task)->td_flags.onced
+#endif
+    ) {
       KMP_ACQUIRE_DEPNODE(gtid, dep);
-      if (dep->dn.task) {
+      if (dep->dn.task
+#if OMPX_TASKGRAPH
+          && __kmp_tdg_is_recording(tdg_status) &&
+          !KMP_TASK_TO_TASKDATA(dep->dn.task)->td_flags.onced
+#endif
+      ) {
         if (!dep->dn.successors || dep->dn.successors->node != node) {
 #if OMPX_TASKGRAPH
           if (!(__kmp_tdg_is_recording(tdg_status)) && task)

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -329,6 +329,12 @@ __kmp_depnode_link_successor(kmp_int32 gtid, kmp_info_t *thread,
           if (!(__kmp_tdg_is_recording(tdg_status)) && task)
 #endif
             __kmp_track_dependence(gtid, dep, node, task);
+#if OMPX_TASKGRAPH
+          else if (KMP_TASK_TO_TASKDATA(dep->dn.task)->td_flags.onced) {
+            KMP_RELEASE_DEPNODE(gtid, dep);
+            continue;
+          }
+#endif
           dep->dn.successors = __kmp_add_node(thread, dep->dn.successors, node);
           KA_TRACE(40, ("__kmp_process_deps: T#%d adding dependence from %p to "
                         "%p\n",

--- a/openmp/runtime/src/kmp_taskdeps.h
+++ b/openmp/runtime/src/kmp_taskdeps.h
@@ -146,6 +146,10 @@ static inline void __kmp_release_deps(kmp_int32 gtid, kmp_taskdata_t *task) {
 #endif
     node->dn.task =
         NULL; // mark this task as finished, so no new dependencies are generated
+#if OMPX_TASKGRAPH
+  else
+    KMP_TASK_TO_TASKDATA(node->dn.task)->td_flags.onced = 1;
+#endif
   KMP_RELEASE_DEPNODE(gtid, node);
 
   kmp_depnode_list_t *next;


### PR DESCRIPTION
This commit resolves a datarace that could occur when taskgraph with dependencies was enabled alongside task stealing. The problem occur because, during task stealing, the stealing thread could incorrectly add an extra node to the task dependency graph, while the original thread might fail to create the correct node, leading to a corrupted graph and potential execution issues.

**EDIT 07/10/2025**:
The above message is incorrect. The issue comes from the same thread setting a successors node to a node that has already been added, meanwhile the predecessor task have been executed and their dependencies released. Leaving the successor node waiting for the already executed task:


Thread 0: [sets](https://github.com/jpinot/llvm-project/blob/cd9a91992a069416a5a2a82dae66eec7d434c31b/openmp/runtime/src/kmp_taskdeps.cpp#L353) Task1 as successor of Task0
Thread 1: [execute](https://github.com/jpinot/llvm-project/blob/cd9a91992a069416a5a2a82dae66eec7d434c31b/openmp/runtime/src/kmp_tasking.cpp#L1513) Task0
Thread 1: [release](https://github.com/jpinot/llvm-project/blob/cd9a91992a069416a5a2a82dae66eec7d434c31b/openmp/runtime/src/kmp_taskdeps.h#L97) successors of Task0
Thread 0: [re-sets](https://github.com/jpinot/llvm-project/blob/cd9a91992a069416a5a2a82dae66eec7d434c31b/openmp/runtime/src/kmp_taskdeps.cpp#L305) Task1 as successor of Task0
....
// Hangs due to Task1 not being executed because the Task0 dependency was re-set as predecessor after it was executed and their successors released.


Without taskgraph, the nodes are removed once executed; in contrast, when taskgraph is used, the nodes are maintained during and after the execution of the entire region. `kmp_tasking_flags_t::onced` is used to mark a task as executed, but it was incorrectly set. This commits solve the issue [setting](https://github.com/llvm/llvm-project/pull/150880/files#diff-1f0fdb8a559b9c74bb320e9cf3a13de2bf2a15dbaacb1ab9fee92ea1a16216b3R149) `onced` before releasing the dependencies and checks for the same flag when linking(`__kmp_depnode_link_successor`).