### PR TITLE
[lldb] [Windows] Silence format string warnings

### DIFF
--- a/lldb/source/Host/windows/MainLoopWindows.cpp
+++ b/lldb/source/Host/windows/MainLoopWindows.cpp
@@ -235,8 +235,8 @@ MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
   } else {
     DWORD file_type = GetFileType(waitable_handle);
     if (file_type != FILE_TYPE_PIPE) {
-      error = Status::FromErrorStringWithFormat("Unsupported file type %d",
-                                                static_cast<int>(file_type));
+      error = Status::FromErrorStringWithFormat("Unsupported file type %ld",
+                                                file_type);
       return nullptr;
     }
 

--- a/lldb/source/Host/windows/MainLoopWindows.cpp
+++ b/lldb/source/Host/windows/MainLoopWindows.cpp
@@ -223,7 +223,7 @@ MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
 
   if (m_read_fds.find(waitable_handle) != m_read_fds.end()) {
     error = Status::FromErrorStringWithFormat(
-        "File descriptor %d already monitored.", waitable_handle);
+        "File descriptor %p already monitored.", waitable_handle);
     return nullptr;
   }
 
@@ -236,7 +236,7 @@ MainLoopWindows::RegisterReadObject(const IOObjectSP &object_sp,
     DWORD file_type = GetFileType(waitable_handle);
     if (file_type != FILE_TYPE_PIPE) {
       error = Status::FromErrorStringWithFormat("Unsupported file type %d",
-                                                file_type);
+                                                static_cast<int>(file_type));
       return nullptr;
     }
 


### PR DESCRIPTION
This fixes the following build warnings in a mingw environment:

    ../../lldb/source/Host/windows/MainLoopWindows.cpp:226:50: warning: format specifies type 'int' but the argument has type 'IOObject::WaitableHandle' (aka 'void *') [-Wformat]
      226 |         "File descriptor %d already monitored.", waitable_handle);
          |                          ~~                      ^~~~~~~~~~~~~~~
    ../../lldb/source/Host/windows/MainLoopWindows.cpp:239:49: warning: format specifies type 'int' but the argument has type 'DWORD' (aka 'unsigned long') [-Wformat]
      238 |       error = Status::FromErrorStringWithFormat("Unsupported file type %d",
          |                                                                        ~~
          |                                                                        %lu
      239 |                                                 file_type);
          |                                                 ^~~~~~~~~
    2 warnings generated.