### PR TITLE
[Flang] Fix grammar in pointer assignment error message

### DIFF
--- a/flang/lib/Semantics/pointer-assignment.cpp
+++ b/flang/lib/Semantics/pointer-assignment.cpp
@@ -281,7 +281,7 @@ bool PointerAssignmentChecker::Check(const evaluate::FunctionRef<T> &f) {
           " function '%s' that is a procedure pointer"_err_en_US;
   } else if (!funcResult->attrs.test(FunctionResult::Attr::Pointer)) {
     msg = "%s is associated with the result of a reference to function '%s'"
-          " that is a not a pointer"_err_en_US;
+          " that is not a pointer"_err_en_US;
   } else if (isContiguous_ &&
       !funcResult->attrs.test(FunctionResult::Attr::Contiguous)) {
     auto restorer{common::ScopedSet(lhs_, symbol)};


### PR DESCRIPTION
This PR corrects a grammatical mistake in an error message emitted during pointer assignment checks in Flang.
The message previously read:

"%s is associated with the result of a reference to function '%s' that is a not a pointer"

The extra "a" before "not a pointer" has been removed.