### PR TITLE
[bazel] add new cmakedefine from #147418 to bazel config file

### DIFF
--- a/utils/bazel/llvm_configs/llvm-config.h.cmake
+++ b/utils/bazel/llvm_configs/llvm-config.h.cmake
@@ -101,6 +101,9 @@
 /* Define if LLVM is using tflite */
 #cmakedefine LLVM_HAVE_TFLITE
 
+/* Define if we want to check profile consistency in lit tests */
+#cmakedefine LLVM_ENABLE_PROFCHECK
+
 /* Define to 1 if you have the <sysexits.h> header file. */
 #cmakedefine HAVE_SYSEXITS_H ${HAVE_SYSEXITS_H}
 


### PR DESCRIPTION
This PR adds the `#cmakedefine LLVM_ENABLE_PROFCHECK` in `llvm-config.h.cmake` introduced in #147418 to the copy of that file in the bazel overlay directory such that that define is also avalable in the bazel build. Not having the define broke the bazel build.