### PR TITLE
Fix `DEBUGLOG_WITH_STREAM_TYPE_AND_FILE` broken in #150750

### DIFF
--- a/llvm/include/llvm/Support/DebugLog.h
+++ b/llvm/include/llvm/Support/DebugLog.h
@@ -40,8 +40,8 @@ namespace llvm {
   DEBUGLOG_WITH_STREAM_TYPE_AND_FILE(STREAM, TYPE, __SHORT_FILE__)
 #else
 #define DEBUGLOG_WITH_STREAM_AND_TYPE(STREAM, TYPE)                            \
-  DEBUGLOG_WITH_STREAM_TYPE_AND_FILE(                                          \
-      STREAM, TYPE, ::llvm::impl::LogWithNewline::getShortFileName(__FILE__))
+  DEBUGLOG_WITH_STREAM_TYPE_AND_FILE(STREAM, TYPE,                             \
+                                     ::llvm::impl::getShortFileName(__FILE__))
 #endif
 
 namespace impl {

--- a/llvm/unittests/Support/DebugLogTest.cpp
+++ b/llvm/unittests/Support/DebugLogTest.cpp
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// This macro is defined in the LLVM build system, but we undefine it here
+// so that we test at least once in-tree the case where __SHORT_FILE__ is not
+// defined.
+#undef __SHORT_FILE__
+
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/raw_ostream.h"
 #include "gmock/gmock.h"


### PR DESCRIPTION
This PR fixes the `DEBUGLOG_WITH_STREAM_TYPE_AND_FILE` macro that got broken in #150750. That PR introduces a more sophisitaced version of that macro and refactored some code in that process, making the `getShortFileName` a free function instead of a class member function, but did not adapt this macro to the refactored code.