### PR TITLE
[MLIR] Fix pipelineInitializationKey never being correctly updated

### DIFF
--- a/mlir/lib/Pass/Pass.cpp
+++ b/mlir/lib/Pass/Pass.cpp
@@ -901,7 +901,7 @@ LogicalResult PassManager::run(Operation *op) {
     if (failed(initialize(context, impl->initializationGeneration + 1)))
       return failure();
     initializationKey = newInitKey;
-    pipelineKey = pipelineInitializationKey;
+    pipelineInitializationKey = pipelineKey;
   }
 
   // Construct a top level analysis manager for the pipeline.


### PR DESCRIPTION
Prior to this change `pipelineInitializationKey` would never be updated so `initialize` would always be called even if the pipeline didn't change 