### PR TITLE
[mlir][memref][spirv] Add SPIR-V Image Lowering

### DIFF
--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
@@ -748,7 +748,7 @@ ImageLoadOpPattern::matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
   // Note that because OpImageFetch returns a rank 4 vector we need to extract
   // the elements corresponding to the load which will since we only support the
   // R[16|32][f|i|ui] formats will always be the R(red) 0th vector element.
-  const auto compositeExtractOp =
+  auto compositeExtractOp =
       rewriter.create<spirv::CompositeExtractOp>(loadOp->getLoc(), fetchOp, 0);
 
   rewriter.replaceOp(loadOp, compositeExtractOp);

--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
@@ -246,7 +246,7 @@ public:
 /// Converts memref.load to spirv.Image + spirv.ImageFetch
 class ImageLoadOpPattern final : public OpConversionPattern<memref::LoadOp> {
 public:
-  using OpConversionPattern<memref::LoadOp>::OpConversionPattern;
+  using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
   matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
@@ -685,14 +685,14 @@ LoadOpPattern::matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
 LogicalResult
 ImageLoadOpPattern::matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
                                     ConversionPatternRewriter &rewriter) const {
-  const auto memrefType = cast<MemRefType>(loadOp.getMemref().getType());
+  auto memrefType = cast<MemRefType>(loadOp.getMemref().getType());
   if (memrefType.getMemorySpace() !=
       spirv::StorageClassAttr::get(rewriter.getContext(),
                                    spirv::StorageClass::Image))
     return failure();
 
-  const auto loadPtr = adaptor.getMemref();
-  const auto memoryRequirements = calculateMemoryRequirements(loadPtr, loadOp);
+  auto loadPtr = adaptor.getMemref();
+  auto memoryRequirements = calculateMemoryRequirements(loadPtr, loadOp);
   if (failed(memoryRequirements))
     return rewriter.notifyMatchFailure(
         loadOp, "failed to determine memory requirements");
@@ -715,7 +715,7 @@ ImageLoadOpPattern::matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
   // for plain images and the OpImageRead instruction needs to be materialized
   // instead or texels need to be accessed via atomics through a texel pointer.
   // Future work will generalize support to plain images.
-  if (const auto convertedPointeeType = cast<spirv::PointerType>(
+  if (auto convertedPointeeType = cast<spirv::PointerType>(
           getTypeConverter()->convertType(loadOp.getMemRefType()));
       !isa<spirv::SampledImageType>(convertedPointeeType.getPointeeType()))
     return rewriter.notifyMatchFailure(loadOp,
@@ -740,7 +740,7 @@ ImageLoadOpPattern::matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
   }
 
   // Fetch the value out of the image.
-  const auto resultVectorType = VectorType::get({4}, loadOp.getType());
+  auto resultVectorType = VectorType::get({4}, loadOp.getType());
   auto fetchOp = rewriter.create<spirv::ImageFetchOp>(
       loadOp->getLoc(), resultVectorType, imageOp, coords,
       mlir::spirv::ImageOperandsAttr{}, ValueRange{});

--- a/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
+++ b/mlir/lib/Conversion/MemRefToSPIRV/MemRefToSPIRV.cpp
@@ -715,9 +715,9 @@ ImageLoadOpPattern::matchAndRewrite(memref::LoadOp loadOp, OpAdaptor adaptor,
   // for plain images and the OpImageRead instruction needs to be materialized
   // instead or texels need to be accessed via atomics through a texel pointer.
   // Future work will generalize support to plain images.
-  if (auto convertedPointeeType = cast<spirv::PointerType>(
-          getTypeConverter()->convertType(loadOp.getMemRefType()));
-      !isa<spirv::SampledImageType>(convertedPointeeType.getPointeeType()))
+  auto convertedPointeeType = cast<spirv::PointerType>(
+      getTypeConverter()->convertType(loadOp.getMemRefType()));
+  if (!isa<spirv::SampledImageType>(convertedPointeeType.getPointeeType()))
     return rewriter.notifyMatchFailure(loadOp,
                                        "cannot lower memrefs which do not "
                                        "convert to SPIR-V sampled images");

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -579,7 +579,7 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
   // may be accessed via image specific ops or directly through a texture
   // pointer.
   if (storageClass == spirv::StorageClass::Image) {
-    const auto rank = type.getRank();
+    const int64_t rank = type.getRank();
     if (rank < 1 || rank > 3) {
       LLVM_DEBUG(llvm::dbgs()
                  << type << " illegal: cannot lower memref of rank " << rank
@@ -602,8 +602,8 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
     }();
 
     // Note that we currently only support lowering to single element texels
-    // e.g. R32f
-    const auto elementType = type.getElementType();
+    // e.g. R32f.
+    auto elementType = type.getElementType();
     if (!elementType.isIntOrFloat()) {
       LLVM_DEBUG(llvm::dbgs() << type << " illegal: cannot lower memref of "
                               << elementType << " to a  SPIR-V Image\n");
@@ -641,15 +641,15 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
     // Currently every memref in the image storage class is converted to a
     // sampled image so we can hardcode the NeedSampler field. Future work
     // will generalize this to support regular non-sampled images.
-    const auto spvImageTy = spirv::ImageType::get(
+    auto spvImageType = spirv::ImageType::get(
         elementType, dim, spirv::ImageDepthInfo::DepthUnknown,
         spirv::ImageArrayedInfo::NonArrayed,
         spirv::ImageSamplingInfo::SingleSampled,
         spirv::ImageSamplerUseInfo::NeedSampler, imageFormat);
-    const auto spvSampledImageTy = spirv::SampledImageType::get(spvImageTy);
-    const auto imagePtrTy = spirv::PointerType::get(
-        spvSampledImageTy, spirv::StorageClass::UniformConstant);
-    return imagePtrTy;
+    auto spvSampledImageType = spirv::SampledImageType::get(spvImageType);
+    auto imagePtrType = spirv::PointerType::get(
+        spvSampledImageType, spirv::StorageClass::UniformConstant);
+    return imagePtrType;
   }
 
   if (isa<IntegerType>(type.getElementType())) {

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -588,17 +588,16 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
     }
 
     const auto dim = [rank]() {
-#define DIM_CASE(DIM)                                                          \
-  case DIM:                                                                    \
-    return spirv::Dim::Dim##DIM##D
       switch (rank) {
-        DIM_CASE(1);
-        DIM_CASE(2);
-        DIM_CASE(3);
+      case 1:
+        return spirv::Dim::Dim1D;
+      case 2:
+        return spirv::Dim::Dim2D;
+      case 3:
+        return spirv::Dim::Dim3D;
       default:
         llvm_unreachable("Invalid memref rank!");
       }
-#undef DIM_CASE
     }();
 
     // Note that we currently only support lowering to single element texels


### PR DESCRIPTION
Adds an initial conversion in the Memref -> SPIR-V lowering for images. Any memref in the "Image" storage-class/address-space will be considered for lowering to the `!spirv.image` type during Memref to SPIR-V conversion. Initially only the reading of sampled images are support and images are read via the `OpImageFetch` instruction. Future work should expand the conversion patterns to target non-sampled images and add support for image write operations.

Images are supported for fp32, fp16, int32, uint32, int16 and uint16 types and lit tests have been added to verify this is the case along with negative testing to check the cases where images aren't supported.