### PR TITLE
[flang][runtime] Remove redundant initialization

### DIFF
--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -856,7 +856,7 @@ private:
 };
 
 class InquireIOLengthState : public NoUnitIoStatementState,
-                             public IoDirectionState<Direction::Output> {
+                             public OutputStatementState {
 public:
   RT_API_ATTRS InquireIOLengthState(
       const char *sourceFile = nullptr, int sourceLine = 0);

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -161,9 +161,6 @@ public:
     lock_.Take();
 #endif
     A &state{u_.emplace<A>(std::forward<X>(xs)...)};
-    if constexpr (!std::is_same_v<A, OpenStatementState>) {
-      state.mutableModes() = ConnectionState::modes;
-    }
     directAccessRecWasSet_ = false;
     io_.emplace(state);
     return *io_;


### PR DESCRIPTION
The assignment to mutableModes() in BeginIoStatement() is redundant, since the mutableModes_ data member is initialized by the constructors of the two classes that now have one.  Remove the assignment to avoid confusion.

Also restores the original OutputStatementState base class name after a recent patch that needlessly changed it to something equivalent but less readable.