### PR TITLE
[compiler-rt][sanitizer_common] Make sanitizer_common tests work for other Apple Platforms

### DIFF
--- a/compiler-rt/test/sanitizer_common/CMakeLists.txt
+++ b/compiler-rt/test/sanitizer_common/CMakeLists.txt
@@ -65,8 +65,6 @@ foreach(tool ${SUPPORTED_TOOLS})
     list(REMOVE_ITEM TEST_ARCH x86_64)
   endif()
 
-  # TODO(dliew): We should iterate over the different
-  # Apple platforms, not just macOS.
   foreach(arch ${TEST_ARCH})
     set(SANITIZER_COMMON_LIT_TEST_MODE ${tool})
     set(SANITIZER_COMMON_TEST_TARGET_ARCH ${arch})
@@ -97,6 +95,60 @@ foreach(tool ${SUPPORTED_TOOLS})
     endif()
   endforeach()
 endforeach()
+
+# iOS and iOS simulator test suites
+# These are not added into "check-all", in order to run these tests, use
+# "check-sanitizer-iossim-arm64" and similar. They also require an extra environment
+# variable to select which iOS device or simulator to use, e.g.:
+# SANITIZER_IOSSIM_TEST_DEVICE_IDENTIFIER="iPhone 16"
+if(APPLE)
+  set(SANITIZER_APPLE_PLATFORMS ${SANITIZER_COMMON_SUPPORTED_OS})
+
+  foreach(platform ${SANITIZER_APPLE_PLATFORMS})
+    if ("${platform}" STREQUAL "osx")
+      # Skip macOS because it's handled by the code above that builds tests for the host machine.
+      continue()
+    endif()
+    list_intersect(
+      SANITIZER_COMMON_TEST_${platform}_ARCHS
+      ALL_SANITIZER_COMMON_SUPPORTED_ARCH
+      DARWIN_${platform}_ARCHS
+    )
+    foreach(arch ${SANITIZER_COMMON_TEST_${platform}_ARCHS})
+      set(SANITIZER_COMMON_TESTSUITES_${platform}_${arch})
+      foreach(tool ${SUPPORTED_TOOLS})
+        if ("${tool}" STREQUAL "lsan")
+          continue()
+        endif()
+
+        set(SANITIZER_COMMON_LIT_TEST_MODE ${tool})
+
+        get_test_cflags_for_apple_platform(
+          "${platform}"
+          "${arch}"
+          SANITIZER_COMMON_TEST_TARGET_CFLAGS)
+        set(CONFIG_NAME "${tool}-${arch}-${platform}")
+        set(SANITIZER_COMMON_TEST_CONFIG_SUFFIX "-${arch}-${platform}")
+        set(SANITIZER_COMMON_TEST_APPLE_PLATFORM "${platform}")
+        set(SANITIZER_COMMON_TEST_TARGET_ARCH "${arch}")
+        set(SANITIZER_COMMON_TEST_MIN_DEPLOYMENT_TARGET_FLAG "${DARWIN_${platform}_MIN_VER_FLAG}")
+        configure_lit_site_cfg(
+          ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+          ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME}/lit.site.cfg.py)
+
+        list(APPEND SANITIZER_COMMON_TESTSUITES_${platform}_${arch}
+             ${CMAKE_CURRENT_BINARY_DIR}/${CONFIG_NAME})
+      endforeach()
+
+      add_lit_testsuite(check-sanitizer-${platform}-${arch}
+        "sanitizer-common ${platform} ${arch} tests"
+        ${SANITIZER_COMMON_TESTSUITES_${platform}_${arch}}
+        EXCLUDE_FROM_CHECK_ALL
+        DEPENDS ${SANITIZER_COMMON_TEST_DEPS})
+    endforeach()
+  endforeach()
+endif()
+
 
 # Unit tests.
 configure_lit_site_cfg(

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/print-stack-trace-in-code-loaded-after-fork.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/print-stack-trace-in-code-loaded-after-fork.cpp
@@ -6,6 +6,8 @@
 // rdar://problem/61793759 and rdar://problem/62126022.
 // UNSUPPORTED: lsan
 
+// XFAIL: iossim
+
 #include <stdio.h>
 
 #ifdef SHARED_LIB

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/symbolizer-function-offset-atos.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/symbolizer-function-offset-atos.cpp
@@ -33,7 +33,7 @@ int main() {
   return 0;
 }
 
-// CHECK: Using atos found at:
+// CHECK: {{Using atos (found at|at user-specified path):}}
 
 // These `function_offset` patterns are designed to disallow `0x0` which is the
 // value printed for `kUnknown`.

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/dedup_token_length_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/dedup_token_length_test.cpp
@@ -11,6 +11,7 @@
 // REQUIRES: stable-runtime
 
 // XFAIL: target={{.*netbsd.*}} && !asan
+// XFAIL: darwin && ubsan
 
 volatile int *null = 0;
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -3,6 +3,10 @@
 // Older versions of Android do not have certain posix_spawn* functions.
 // UNSUPPORTED: android
 
+// Simulators expect certain envars to be set, but this test overwrites
+// env when spawning the child process.
+// XFAIL: iossim
+
 #include <assert.h>
 #include <spawn.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
@@ -6,6 +6,7 @@
 // UNSUPPORTED: x86_64h-darwin && lsan
 // XFAIL: tsan
 // XFAIL: android && asan
+// XFAIL: ios
 
 // RUN: rm -rf %t_workdir
 // RUN: mkdir -p %t_workdir

--- a/compiler-rt/test/sanitizer_common/lit.site.cfg.py.in
+++ b/compiler-rt/test/sanitizer_common/lit.site.cfg.py.in
@@ -4,6 +4,8 @@
 config.name_suffix = "@CONFIG_NAME@"
 config.tool_name = "@SANITIZER_COMMON_LIT_TEST_MODE@"
 config.target_cflags = "@SANITIZER_COMMON_TEST_TARGET_CFLAGS@"
+config.apple_platform = "@SANITIZER_COMMON_TEST_APPLE_PLATFORM@"
+config.apple_platform_min_deployment_target_flag = "@SANITIZER_COMMON_TEST_MIN_DEPLOYMENT_TARGET_FLAG@"
 config.target_arch = "@SANITIZER_COMMON_TEST_TARGET_ARCH@"
 
 config.arm_thumb = "@COMPILER_RT_ARM_THUMB@"


### PR DESCRIPTION
This commit addresses a longstanding TODO comment, by doing the following:
* Modifies the CMakeLists to add the new test configs
* Modifies the relevant lit file to add the required envs
* Fixes the FileCheck match in `Darwin/symbolizer-function-offset-atos.cpp`
* XFAILs any appropriate tests

rdar://107758331