### PR TITLE
[lldb][cmake] Create dependencies for LLDB header targets

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -327,6 +327,7 @@ foreach(header
   endif()
 
   add_custom_target(liblldb-stage-header-${basename} DEPENDS ${staged_header})
+  add_dependencies(liblldb-stage-header-${basename} lldb-sbapi-dwarf-enums)
   add_dependencies(liblldb-header-staging liblldb-stage-header-${basename})
   add_custom_command(
     DEPENDS ${header} OUTPUT ${staged_header}
@@ -339,6 +340,7 @@ foreach(header
     set(output_header $<TARGET_FILE_DIR:liblldb>/Headers/${basename})
 
     add_custom_target(lldb-framework-fixup-header-${basename} DEPENDS ${staged_header})
+    add_dependencies(lldb-framework-fixup-header-${basename} liblldb-stage-header-${basename})
     add_dependencies(lldb-framework-fixup-all-headers lldb-framework-fixup-header-${basename})
 
     add_custom_command(TARGET lldb-framework-fixup-header-${basename} POST_BUILD


### PR DESCRIPTION
The LLDB standalone build using Xcode currently fails due to the headers being attached to multiple targets, but none of these targets depending on each other. This commit resolves this by creating those dependencies.