### PR TITLE
[Bitcode] Fix nondeterministic phi instruction order

### DIFF
--- a/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
+++ b/llvm/lib/Bitcode/Writer/ValueEnumerator.cpp
@@ -186,7 +186,7 @@ static void predictValueUseListOrderImpl(const Value *V, const Function *F,
     return;
 
   bool IsGlobalValue = OM.isGlobalValue(ID);
-  llvm::sort(List, [&](const Entry &L, const Entry &R) {
+  llvm::stable_sort(List, [&](const Entry &L, const Entry &R) {
     const Use *LU = L.first;
     const Use *RU = R.first;
     if (LU == RU)


### PR DESCRIPTION
Currently there can be nondeterminism of the form

```diff
- <INST_PHI op0=307 op1=2 op2=22 op3=67 op4=29 op5=111 op6=57 ...>
+ <INST_PHI op0=307 op1=2 op2=22 op3=67 op4=29 op5=157 op6=71 ...>
```

in generated bitcode. Stably sorting the use-list entries solves that.