### PR TITLE
[clang][DebugInfo] Don't emit VTable debug symbols for -gline-tables-only.

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -2641,6 +2641,8 @@ void CGDebugInfo::emitVTableSymbol(llvm::GlobalVariable *VTable,
                                    const CXXRecordDecl *RD) {
   if (!CGM.getTarget().getCXXABI().isItaniumFamily())
     return;
+  if (DebugKind <= llvm::codegenoptions::DebugLineTablesOnly)
+    return;
 
   ASTContext &Context = CGM.getContext();
   StringRef SymbolName = "_vtable$";

--- a/clang/test/CodeGenCXX/debug-info-gline-tables-only.cpp
+++ b/clang/test/CodeGenCXX/debug-info-gline-tables-only.cpp
@@ -14,9 +14,11 @@ class E : public C {
   // CHECK-NOT: DW_TAG_reference type
   void x(const D& d);
 };
+// CHECK-NOT: DW_TAG_structure_type
 struct F {
   enum X { };
   void func(X);
+  // CHECK-NOT: DW_TAG_member
   virtual ~F();
 };
 F::~F() {


### PR DESCRIPTION
The -gline-tables-only option emits minimal debug info for functions, files and line numbers while omitting variables, parameters and most type information.  VTable debug symbols are emitted to facilitate a debugger's ability to perform automatic type promotion on variables and parameters. With variables and parameters being omitted, the VTable symbols are unnecessary.