### PR TITLE
[BOLT][AArch64] Compensate for missing code markers

### DIFF
--- a/bolt/test/AArch64/missing-code-marker.s
+++ b/bolt/test/AArch64/missing-code-marker.s
@@ -1,0 +1,26 @@
+## Check that llvm-bolt is able to recover a missing code marker.
+
+# RUN: %clang %cflags %s -o %t.exe -nostdlib -fuse-ld=lld -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt 2>&1 | FileCheck %s
+
+# CHECK: BOLT-WARNING: function symbol foo lacks code marker
+
+.text
+.balign 4
+
+.word 0
+
+## Function foo starts immediately after a data object and does not have
+## a matching "$x" symbol to indicate the start of code.
+.global foo
+.type foo, %function
+foo:
+  .word 0xd65f03c0
+.size foo, .-foo
+
+.global _start
+.type _start, %function
+_start:
+  bl foo
+  ret
+.size _start, .-_start


### PR DESCRIPTION
Code written in assembly can have missing code markers. In BOLT, we can compensate by recognizing that a function entry point should start a code sequence.

Seen such code in lua jit library.