### PR TITLE
[IRCE] Check loop clone legality before attempting to do so

### DIFF
--- a/llvm/lib/Transforms/Utils/LoopConstrainer.cpp
+++ b/llvm/lib/Transforms/Utils/LoopConstrainer.cpp
@@ -751,6 +751,13 @@ bool LoopConstrainer::run() {
   const SCEVConstant *MinusOneS =
       cast<SCEVConstant>(SE.getConstant(IVTy, -1, true /* isSigned */));
 
+  if ((NeedsPreLoop || NeedsPostLoop) &&
+      !OriginalLoop.isSafeToCloneConditionally(DT)) {
+    LLVM_DEBUG(dbgs() << "cannot clone loop " << OriginalLoop.getName()
+                      << " because it is not safe to clone.\n");
+    return false;
+  }
+
   if (NeedsPreLoop) {
     const SCEV *ExitPreLoopAtSCEV = nullptr;
 

--- a/llvm/test/Transforms/IRCE/clone-legality-analysis-invalidation.ll
+++ b/llvm/test/Transforms/IRCE/clone-legality-analysis-invalidation.ll
@@ -1,0 +1,68 @@
+; RUN: opt -passes=irce -irce-skip-profitability-checks \
+; RUN:   -verify-analysis-invalidation -S < %s | FileCheck %s
+
+; Parsing the loop structure may need to materialize SCEVs in the preheader.
+; If a later legality check prevents cloning, those speculative instructions
+; must be removed before IRCE reports that it did not change the function.
+
+declare void @cannot_duplicate() noduplicate
+declare void @convergent_call() convergent
+
+define void @no_materialization(ptr %n.ptr) {
+; CHECK-LABEL: define void @no_materialization(
+entry:
+; CHECK: entry:
+; CHECK-NEXT: %n = load i32, ptr %n.ptr, align 4, !range !0
+; CHECK-NEXT: br label %loop
+  %n = load i32, ptr %n.ptr, !range !0
+  br label %loop
+
+loop:
+  %idx = phi i32 [ 0, %entry ], [ %idx.next, %in.bounds ]
+  %idx.next = add i32 %idx, 1
+  %bound = add nsw i32 %n, 1
+  %in.range = icmp slt i32 %idx, 50
+  call void @cannot_duplicate()
+  br i1 %in.range, label %in.bounds, label %out.of.bounds
+
+in.bounds:
+; CHECK: %bound = add nsw i32 %n, 1
+  %next = icmp slt i32 %idx.next, %bound
+  br i1 %next, label %loop, label %exit
+
+out.of.bounds:
+  ret void
+
+exit:
+  ret void
+}
+
+!0 = !{i32 1, i32 1000}
+
+; A loop that does not need pre- or post-loop clones may still be constrained
+; when its body is unsafe to clone.
+
+define void @no_cloning_needed(i32 range(i32 100, 150) %len,
+                               i32 range(i32 1, 50) %n) {
+; CHECK-LABEL: define void @no_cloning_needed(
+entry:
+  br label %loop
+
+loop:
+  %idx = phi i32 [ 0, %entry ], [ %idx.next, %in.bounds ]
+  %in.range = icmp slt i32 %idx, %len
+  call void @convergent_call()
+; CHECK: br i1 true, label %in.bounds, label %out.of.bounds
+  br i1 %in.range, label %in.bounds, label %out.of.bounds
+
+in.bounds:
+  %idx.next = add nuw nsw i32 %idx, 1
+  %next = icmp slt i32 %idx.next, %n
+  br i1 %next, label %loop, label %exit
+
+out.of.bounds:
+  ret void
+
+exit:
+  ret void
+}

--- a/llvm/test/Transforms/IRCE/pre_post_loops_clone.ll
+++ b/llvm/test/Transforms/IRCE/pre_post_loops_clone.ll
@@ -1,0 +1,61 @@
+; RUN: opt -verify-loop-info -irce-print-changed-loops -passes=irce -S < %s 2>&1 | FileCheck %s
+; This test is the same as pre_post_loops.ll, except that the loop body contains a token-generating
+; call. We need to ensure that IRCE does not try to introduce a PHI or otherwise generate invalid IE.
+
+declare token @llvm.source_token()
+declare void @llvm.sink_token(token)
+
+; CHECK: define void @test_01
+define void @test_01(ptr %arr, ptr %a_len_ptr) {
+entry:
+  %len = load i32, ptr %a_len_ptr, !range !0
+  br label %loop
+
+loop:
+  %idx = phi i32 [ 0, %entry ], [ %idx.next, %in.bounds ]
+  %idx.next = add i32 %idx, 1
+  %abc = icmp slt i32 %idx, %len
+  %token = call token @llvm.source_token()
+  br i1 %abc, label %in.bounds, label %out.of.bounds
+
+in.bounds:
+  %addr = getelementptr i32, ptr %arr, i32 %idx
+  store i32 0, ptr %addr
+  %next = icmp slt i32 %idx.next, 2147483647
+  br i1 %next, label %loop, label %exit
+
+out.of.bounds:
+  ret void
+
+exit:
+  call void @llvm.sink_token(token %token)
+  ret void
+}
+
+define void @test_02(ptr %arr, ptr %a_len_ptr) {
+entry:
+  %len = load i32, ptr %a_len_ptr, !range !0
+  br label %loop
+
+loop:
+  %idx = phi i32 [ 2147483647, %entry ], [ %idx.next, %in.bounds ]
+  %idx.next = add i32 %idx, -1
+  %abc = icmp slt i32 %idx, %len
+  %token = call token @llvm.source_token()
+  br i1 %abc, label %in.bounds, label %out.of.bounds
+
+in.bounds:
+  %addr = getelementptr i32, ptr %arr, i32 %idx
+  store i32 0, ptr %addr
+  %next = icmp sgt i32 %idx.next, -1
+  br i1 %next, label %loop, label %exit
+
+out.of.bounds:
+  ret void
+
+exit:
+  call void @llvm.sink_token(token %token)
+  ret void
+}
+
+!0 = !{i32 0, i32 50}

--- a/llvm/test/Transforms/IRCE/token-like-live-out.ll
+++ b/llvm/test/Transforms/IRCE/token-like-live-out.ll
@@ -1,0 +1,33 @@
+; RUN: opt -passes=irce -S < %s | FileCheck %s
+
+; Token-like target extension values cannot be used in PHI nodes. Make sure
+; IRCE does not attempt to clone a loop with a live-out resource handle.
+
+define void @target_type_live_out(ptr %resource.ptr) {
+; CHECK-LABEL: define void @target_type_live_out(
+; CHECK-NOT: preloop
+; CHECK-NOT: postloop
+entry:
+  br label %loop
+
+loop:
+  %idx = phi i32 [ 0, %entry ], [ %idx.next, %in.bounds ]
+  %idx.next = add i32 %idx, 1
+  %resource = load target("dx.RawBuffer", i32, 1, 0), ptr %resource.ptr
+  %in.range = icmp slt i32 %idx, 50
+  br i1 %in.range, label %in.bounds, label %out.of.bounds
+
+in.bounds:
+  %next = icmp slt i32 %idx.next, 2147483647
+  br i1 %next, label %loop, label %exit
+
+out.of.bounds:
+  ret void
+
+exit:
+; CHECK: exit:
+; CHECK-NEXT: store target("dx.RawBuffer", i32, 1, 0) %resource, ptr %resource.ptr
+; CHECK-NEXT: ret void
+  store target("dx.RawBuffer", i32, 1, 0) %resource, ptr %resource.ptr
+  ret void
+}


### PR DESCRIPTION
Not all loop bodies are safe to clone. For example, they may have `noduplicate` call in them. Additionally, if the transformation may cause any of the cloned loop bodies to execute conditionally, we must also disallow `convergent` calls, as well as any call that returns a token that is used outside of the loop. The loop unswitching pass had an appropriate legality check for this, but IRCE did not, causing issues downstream (https://github.com/JuliaLang/julia/issues/48918).

As a particular example, consider the test case in this commit, where `opt -passes=irce`, creates invalid IR:
```
opt --passes=irce llvm/test/Transforms/IRCE/pre_post_loops_clone.ll
WARNING: You're attempting to print out a bitcode file.
This is inadvisable as it may cause display problems. If
you REALLY want to taste LLVM bitcode first-hand, you
can force output with the `-f' option.

Instruction does not dominate all uses!
  %token = call token @llvm.source_token()
  call void @llvm.sink_token(token %token)
Instruction does not dominate all uses!
  %token = call token @llvm.source_token()
  call void @llvm.sink_token(token %token)
LLVM ERROR: Broken module found, compilation aborted!
```

Fix this by factoring out the legality check from the loop unswitch pass and using it in IRCE as well. I personally don't have any code that is `noduplicate` or `convergent`, but I don't see any reason why IRCE would be different here.

I will also mention #56243 as related, which contains some related discussion of LCSSA in the presence of tokens.

Fixes #63984