### PR TITLE
[CIR] Support more declarations without any codegen

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1269,6 +1269,7 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
   // No code generation needed.
   case Decl::ClassTemplate:
   case Decl::Concept:
+  case Decl::CXXDeductionGuide:
   case Decl::Empty:
   case Decl::FunctionTemplate:
   case Decl::StaticAssert:

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -1267,8 +1267,13 @@ void CIRGenModule::emitTopLevelDecl(Decl *decl) {
     break;
 
   // No code generation needed.
-  case Decl::UsingShadow:
+  case Decl::ClassTemplate:
+  case Decl::Concept:
   case Decl::Empty:
+  case Decl::FunctionTemplate:
+  case Decl::StaticAssert:
+  case Decl::TypeAliasTemplate:
+  case Decl::UsingShadow:
     break;
 
   case Decl::CXXConstructor:

--- a/clang/test/CIR/CodeGen/empty.cpp
+++ b/clang/test/CIR/CodeGen/empty.cpp
@@ -23,5 +23,10 @@ namespace N {
     using ::class_template; // UsingShadow
 }
 
+template<typename T>
+struct deduction_guide {};
+
+deduction_guide() -> deduction_guide<int>;
+
 // CIR: module {{.*}} {
 // CIR-NEXT: }

--- a/clang/test/CIR/CodeGen/empty.cpp
+++ b/clang/test/CIR/CodeGen/empty.cpp
@@ -1,0 +1,27 @@
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+// These declarations shouldn't emit any code. Therefore the module is expected to be empty.
+
+template<typename T>
+concept some_concept = true;
+
+template<some_concept T>
+class class_template {};
+
+; // Empty declaration
+
+template<typename T>
+void function_template();
+
+static_assert(true, "top level static assert");
+
+template<typename T>
+using type_alias = T;
+
+namespace N {
+    using ::class_template; // UsingShadow
+}
+
+// CIR: module {{.*}} {
+// CIR-NEXT: }


### PR DESCRIPTION
This patch adds or completes support for a couple of top level declaration types  that don't emit any code: Most notably these include Concepts, static_assert and type aliases.