### PR TITLE
[libc] Fix bazel build by build by adding missing deps.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6379,6 +6379,7 @@ libc_function(
         ":__support_common",
         ":__support_macros_null_check",
         ":types_wchar_t",
+        ":wchar_utils",
     ],
 )
 


### PR DESCRIPTION
This was broken by #150661, which added includes to `wcspbrk.cpp` and `wcschr.cpp` that weren't in the dependencies of the corresponding targets.