### PR TITLE
[libc] Fix bazel build by build by adding missing deps.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -6252,7 +6252,9 @@ libc_function(
     deps = [
         ":__support_common",
         ":__support_macros_config",
+        ":__support_macros_null_check",
         ":types_wchar_t",
+        ":wchar_utils",
     ],
 )
 


### PR DESCRIPTION
This adds two dependencies that I wanted to be part of #151090 but forgot to add them before the last push, which related to `wcschr.cpp` and were originally broken by #150661.