### PR TITLE
[clang][bytecode] Move Pointer::{Prev,Next} into BlockPointer

### DIFF
--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -531,7 +531,7 @@ LLVM_DUMP_METHOD void Block::dump(llvm::raw_ostream &OS) const {
   Desc->dump(OS);
   OS << ")\n";
   unsigned NPointers = 0;
-  for (const Pointer *P = Pointers; P; P = P->Next) {
+  for (const Pointer *P = Pointers; P; P = P->asBlockPointer().Next) {
     ++NPointers;
   }
   OS << "  EvalID: " << EvalID << '\n';

--- a/clang/lib/AST/ByteCode/DynamicAllocator.cpp
+++ b/clang/lib/AST/ByteCode/DynamicAllocator.cpp
@@ -27,7 +27,7 @@ void DynamicAllocator::cleanup() {
       B->invokeDtor();
       if (B->hasPointers()) {
         while (B->Pointers) {
-          Pointer *Next = B->Pointers->Next;
+          Pointer *Next = B->Pointers->asBlockPointer().Next;
           B->Pointers->PointeeStorage.BS.Pointee = nullptr;
           B->Pointers = Next;
         }

--- a/clang/lib/AST/ByteCode/InterpBlock.cpp
+++ b/clang/lib/AST/ByteCode/InterpBlock.cpp
@@ -27,9 +27,9 @@ void Block::addPointer(Pointer *P) {
   assert(!hasPointer(P));
 #endif
   if (Pointers)
-    Pointers->Prev = P;
-  P->Next = Pointers;
-  P->Prev = nullptr;
+    Pointers->PointeeStorage.BS.Prev = P;
+  P->PointeeStorage.BS.Next = Pointers;
+  P->PointeeStorage.BS.Prev = nullptr;
   Pointers = P;
 #ifndef NDEBUG
   assert(hasPointer(P));
@@ -48,13 +48,15 @@ void Block::removePointer(Pointer *P) {
   assert(hasPointer(P));
 #endif
 
-  if (Pointers == P)
-    Pointers = P->Next;
+  BlockPointer &BP = P->PointeeStorage.BS;
 
-  if (P->Prev)
-    P->Prev->Next = P->Next;
-  if (P->Next)
-    P->Next->Prev = P->Prev;
+  if (Pointers == P)
+    Pointers = BP.Next;
+
+  if (BP.Prev)
+    BP.Prev->PointeeStorage.BS.Next = BP.Next;
+  if (BP.Next)
+    BP.Next->PointeeStorage.BS.Prev = BP.Prev;
   P->PointeeStorage.BS.Pointee = nullptr;
 #ifndef NDEBUG
   assert(!hasPointer(P));
@@ -68,7 +70,9 @@ void Block::cleanup() {
 
 void Block::replacePointer(Pointer *Old, Pointer *New) {
   assert(Old);
+  assert(Old->isBlockPointer());
   assert(New);
+  assert(New->isBlockPointer());
   assert(Old != New);
   if (IsStatic) {
     assert(!Pointers);
@@ -78,17 +82,20 @@ void Block::replacePointer(Pointer *Old, Pointer *New) {
   assert(hasPointer(Old));
 #endif
 
-  if (Old->Prev)
-    Old->Prev->Next = New;
-  if (Old->Next)
-    Old->Next->Prev = New;
-  New->Prev = Old->Prev;
-  New->Next = Old->Next;
+  BlockPointer &OldBP = Old->PointeeStorage.BS;
+  BlockPointer &NewBP = New->PointeeStorage.BS;
+
+  if (OldBP.Prev)
+    OldBP.Prev->PointeeStorage.BS.Next = New;
+  if (OldBP.Next)
+    OldBP.Next->PointeeStorage.BS.Prev = New;
+  NewBP.Prev = OldBP.Prev;
+  NewBP.Next = OldBP.Next;
   if (Pointers == Old)
     Pointers = New;
 
-  Old->PointeeStorage.BS.Pointee = nullptr;
-  New->PointeeStorage.BS.Pointee = this;
+  OldBP.Pointee = nullptr;
+  NewBP.Pointee = this;
 #ifndef NDEBUG
   assert(!hasPointer(Old));
   assert(hasPointer(New));
@@ -97,7 +104,7 @@ void Block::replacePointer(Pointer *Old, Pointer *New) {
 
 #ifndef NDEBUG
 bool Block::hasPointer(const Pointer *P) const {
-  for (const Pointer *C = Pointers; C; C = C->Next) {
+  for (const Pointer *C = Pointers; C; C = C->asBlockPointer().Next) {
     if (C == P)
       return true;
   }
@@ -120,7 +127,7 @@ DeadBlock::DeadBlock(DeadBlock *&Root, Block *Blk)
 
   // Transfer pointers.
   B.Pointers = Blk->Pointers;
-  for (Pointer *P = Blk->Pointers; P; P = P->Next)
+  for (Pointer *P = Blk->Pointers; P; P = P->asBlockPointer().Next)
     P->PointeeStorage.BS.Pointee = &B;
   Blk->Pointers = nullptr;
 }

--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -52,7 +52,7 @@ void InterpState::cleanup() {
   // As a last resort, make sure all pointers still pointing to a dead block
   // don't point to it anymore.
   for (DeadBlock *DB = DeadBlocks; DB; DB = DB->Next) {
-    for (Pointer *P = DB->B.Pointers; P; P = P->Next) {
+    for (Pointer *P = DB->B.Pointers; P; P = P->asBlockPointer().Next) {
       P->PointeeStorage.BS.Pointee = nullptr;
     }
   }

--- a/clang/lib/AST/ByteCode/Pointer.cpp
+++ b/clang/lib/AST/ByteCode/Pointer.cpp
@@ -41,7 +41,7 @@ Pointer::Pointer(Block *Pointee, unsigned Base, uint64_t Offset)
     : Offset(Offset), StorageKind(Storage::Block) {
   assert((Base == RootPtrMark || Base % alignof(void *) == 0) && "wrong base");
 
-  PointeeStorage.BS = {Pointee, Base};
+  PointeeStorage.BS = {Pointee, Base, nullptr, nullptr};
 
   if (Pointee)
     Pointee->addPointer(this);
@@ -88,7 +88,6 @@ void Pointer::operator=(const Pointer &P) {
 
   if (P.isBlockPointer()) {
     PointeeStorage.BS = P.PointeeStorage.BS;
-    PointeeStorage.BS.Pointee = P.PointeeStorage.BS.Pointee;
 
     if (PointeeStorage.BS.Pointee)
       PointeeStorage.BS.Pointee->addPointer(this);
@@ -125,7 +124,6 @@ void Pointer::operator=(Pointer &&P) {
 
   if (P.isBlockPointer()) {
     PointeeStorage.BS = P.PointeeStorage.BS;
-    PointeeStorage.BS.Pointee = P.PointeeStorage.BS.Pointee;
 
     if (PointeeStorage.BS.Pointee)
       PointeeStorage.BS.Pointee->addPointer(this);

--- a/clang/lib/AST/ByteCode/Pointer.h
+++ b/clang/lib/AST/ByteCode/Pointer.h
@@ -39,6 +39,10 @@ struct BlockPointer {
   Block *Pointee;
   /// Start of the current subfield.
   unsigned Base;
+  /// Previous link in the pointer chain.
+  Pointer *Prev;
+  /// Next link in the pointer chain.
+  Pointer *Next;
 };
 
 struct IntPointer {
@@ -828,15 +832,10 @@ private:
   /// Offset into the storage.
   uint64_t Offset = 0;
 
-  /// Previous link in the pointer chain.
-  Pointer *Prev = nullptr;
-  /// Next link in the pointer chain.
-  Pointer *Next = nullptr;
-
   Storage StorageKind = Storage::Int;
   union {
-    BlockPointer BS;
     IntPointer Int;
+    BlockPointer BS;
     FunctionPointer Fn;
     TypeidPointer Typeid;
   } PointeeStorage;


### PR DESCRIPTION
They are only relevant for block pointers.