### PR TITLE
[Clang][Driver] Valid `-march` value is not mandatory in AArch64 multilib

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -191,9 +191,10 @@ static void getAArch64MultilibFlags(const Driver &D,
   for (const auto &ArchInfo : AArch64::ArchInfos)
     if (FeatureSet.contains(ArchInfo->ArchFeature))
       ArchName = ArchInfo->Name;
-  assert(!ArchName.empty() && "at least one architecture should be found");
-  MArch.insert(MArch.begin(), ("-march=" + ArchName).str());
-  Result.push_back(llvm::join(MArch, "+"));
+  if (!ArchName.empty()) {
+    MArch.insert(MArch.begin(), ("-march=" + ArchName).str());
+    Result.push_back(llvm::join(MArch, "+"));
+  }
 
   const Arg *BranchProtectionArg =
       Args.getLastArgNoClaim(options::OPT_mbranch_protection_EQ);

--- a/clang/test/Driver/arm-aarch64-multilib-invalid-arch.c
+++ b/clang/test/Driver/arm-aarch64-multilib-invalid-arch.c
@@ -1,0 +1,2 @@
+// RUN: not %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml --target=arm-none-eabi -march=invalid
+// RUN: not %clang -multi-lib-config=%S/Inputs/multilib/empty.yaml --target=aarch64-none-elf -march=invalid


### PR DESCRIPTION
If a user passed an invalid value to `-march`, an assertion failure happened in the AArch64 multilib logic.

But an invalid `-march` value is an expected case that should be handled via error messages.

This patch removes the requirement that the `-march` value must be valid.