### PR TITLE
[libFuzzer] Mark libFuzzer SIGTRAP test unsupported on windows

### DIFF
--- a/compiler-rt/test/fuzzer/sig-trap.test
+++ b/compiler-rt/test/fuzzer/sig-trap.test
@@ -1,3 +1,7 @@
+# Check that libFuzzer handles SIGTRAP; disabled on Windows due to reliance on
+# posix only features
+UNSUPPORTED: target={{.*windows.*}}
+
 RUN: %cpp_compiler %S/SigTrapTest.cpp -o %t
 
 RUN: not %run %t            2>&1 | FileCheck %s


### PR DESCRIPTION
This change is based on the UNSUPPORTED mark from the existing sigusr test https://github.com/llvm/llvm-project/blob/c59cc542844b5b4a25cd222ad0127ca2e74953ad/compiler-rt/test/fuzzer/sigusr.test#L4