### PR TITLE
[lldb][FreeBSD] Add Auxv numbers for HWCAP3 and HWCAP4

### DIFF
--- a/lldb/source/Plugins/Process/Utility/AuxVector.cpp
+++ b/lldb/source/Plugins/Process/Utility/AuxVector.cpp
@@ -92,6 +92,8 @@ const char *AuxVector::GetEntryName(EntryType type) const {
     case ENTRY_NAME(AUXV_AT_L1D_CACHESHAPE); break;
     case ENTRY_NAME(AUXV_AT_L2_CACHESHAPE);  break;
     case ENTRY_NAME(AUXV_AT_L3_CACHESHAPE);  break;
+    case ENTRY_NAME(AUXV_FREEBSD_AT_HWCAP3);  break;
+    case ENTRY_NAME(AUXV_FREEBSD_AT_HWCAP4);  break;
     }
 #undef ENTRY_NAME
 

--- a/lldb/source/Plugins/Process/Utility/AuxVector.h
+++ b/lldb/source/Plugins/Process/Utility/AuxVector.h
@@ -70,6 +70,10 @@ public:
     // Platform specific values which may overlap the Linux values.
 
     AUXV_FREEBSD_AT_HWCAP = 25, ///< FreeBSD specific AT_HWCAP value.
+    // FreeBSD and Linux use the same AT_HWCAP2 value.
+    AUXV_FREEBSD_AT_HWCAP3 = 38, ///< FreeBSD specific AT_HWCAP3 value.
+    AUXV_FREEBSD_AT_HWCAP4 = 39, ///< FreeBSD specific AT_HWCAP4 value.
+
   };
 
   std::optional<uint64_t> GetAuxValue(enum EntryType entry_type) const;


### PR DESCRIPTION
These entries serve the same purpose as the Linux HWCAPs but have been assigned different numbers as FreeBSD had already used the Linux ones.

The numbers were assigned in:
https://github.com/freebsd/freebsd-src/commit/85007872d1227006adf2ce119fe30de856cbe12d

In theory we can read these for the purposes of register field detection, even on earlier versions of FreeBSD. As the aux data is a key-value structure, we simply won't find the new numbers on older systems.

However, FreeBSD has not defined any feature bits for HWACP3 and 4. It is likley that they will match the Linux feature bits, but I have no proof of that yet.

For instance, FEAT_MTE_STORE_ONLY is indicated by a HWCAP3 feature bit on Linux. FreeBSD does not support this feature at all yet.

So for now, these values exist for future use and are not used for register field detection on FreeBSD.