### PR TITLE
[mlir][linalg] Enhance `isaInlinedFillOp`

### DIFF
--- a/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgInterfaces.cpp
@@ -85,8 +85,7 @@ bool linalg::isaCopyOpInterface(LinalgOp op) {
 /// constant. If so, returns the constant value. Otherwise, returns
 /// std::nullopt.
 static std::optional<Value> isaInlinedFillOp(GenericOp op) {
-  if (!op.isAllParallelLoops() || op.getNumDpsInits() != 1 ||
-      op.getNumDpsInputs() != 0)
+  if (!op.isAllParallelLoops() || op.getNumDpsInits() != 1)
     return std::nullopt;
 
   // Init should not be referenced.

--- a/mlir/test/Dialect/Linalg/specialize-generic-ops-fail.mlir
+++ b/mlir/test/Dialect/Linalg/specialize-generic-ops-fail.mlir
@@ -29,20 +29,3 @@ func.func @neither_permutation_nor_broadcast(%init : tensor<8xi32>) -> tensor<8x
   } -> tensor<8xi32>
   return %res : tensor<8xi32>
 }
-
-// -----
-
-#map = affine_map<(d0) -> (d0)>
-// CHECK-LABEL: func @not_copy
-//  CHECK-NOT:    linalg.copy
-//      CHECK:    linalg.generic
-func.func @not_copy(%input: tensor<8xi32>, %init: tensor<8xi32>) -> tensor<8xi32> {
-  %c0_i32 = arith.constant 0 : i32
-  %res = linalg.generic {
-    indexing_maps = [#map, #map], iterator_types = ["parallel"]
-  } ins(%input: tensor<8xi32>) outs(%init: tensor<8xi32>) {
-  ^bb0(%in: i32, %out: i32):
-    linalg.yield %c0_i32 : i32
-  } -> tensor<8xi32>
-  return %res : tensor<8xi32>
-}


### PR DESCRIPTION
This PR extends `isaInlinedFillOp` to support converting a generic operation with unused input operands to `linalg.fill`.