### PR TITLE
[cmake] Don't generate per-file "__SHORT_FILE__" defines on visual studio builds

### DIFF
--- a/llvm/cmake/modules/LLVMProcessSources.cmake
+++ b/llvm/cmake/modules/LLVMProcessSources.cmake
@@ -58,16 +58,19 @@ function(llvm_process_sources OUT_VAR)
   set(sources ${ARG_UNPARSED_ARGUMENTS})
   llvm_check_source_file_list(${sources})
 
-  foreach(fn ${sources})
-    get_filename_component(suf ${fn} EXT)
-    if("${suf}" STREQUAL ".cpp" OR "${suf}" STREQUAL ".c")
-      get_filename_component(short_name ${fn} NAME)
-      set_property(
-          SOURCE ${fn}
-          APPEND
-          PROPERTY COMPILE_DEFINITIONS __SHORT_FILE__="${short_name}")
-    endif()
-  endforeach()
+  # Don't generate __SHORT_FILE__ on MSVC builds as it can force repeated cache regeneration.
+  if(NOT MSVC)
+    foreach(fn ${sources})
+      get_filename_component(suf ${fn} EXT)
+      if("${suf}" STREQUAL ".cpp" OR "${suf}" STREQUAL ".c")
+        get_filename_component(short_name ${fn} NAME)
+        set_property(
+            SOURCE ${fn}
+            APPEND
+            PROPERTY COMPILE_DEFINITIONS __SHORT_FILE__="${short_name}")
+      endif()
+    endforeach()
+  endif()
 
 
   # This adds .td and .h files to the Visual Studio solution:

--- a/llvm/cmake/modules/LLVMProcessSources.cmake
+++ b/llvm/cmake/modules/LLVMProcessSources.cmake
@@ -58,8 +58,8 @@ function(llvm_process_sources OUT_VAR)
   set(sources ${ARG_UNPARSED_ARGUMENTS})
   llvm_check_source_file_list(${sources})
 
-  # Don't generate __SHORT_FILE__ on MSVC builds as it can force repeated cache regeneration.
-  if(NOT MSVC)
+  # Don't generate __SHORT_FILE__ on VS builds as it can prevent build parallelisation.
+  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio")
     foreach(fn ${sources})
       get_filename_component(suf ${fn} EXT)
       if("${suf}" STREQUAL ".cpp" OR "${suf}" STREQUAL ".c")


### PR DESCRIPTION
As reported on #150677 - this is preventing msbuild parallelization as cmake is repeatedly being updated