### PR TITLE
[rtsan][compiler-rt] Fix ioctl test causing segfault on exit

### DIFF
--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -752,8 +752,8 @@ TEST_F(RtsanOpenedFileTest, RewindDieWhenRealtime) {
 }
 #endif
 
-TEST(TestRtsanInterceptors, IoctlDiesWhenRealtime) {
-  auto Func = []() { ioctl(0, FIONREAD); };
+TEST_F(RtsanOpenedFileTest, IoctlDiesWhenRealtime) {
+  auto Func = [this]() { ioctl(GetOpenFd(), FIONREAD); };
   ExpectRealtimeDeath(Func, "ioctl");
   ExpectNonRealtimeSurvival(Func);
 }


### PR DESCRIPTION
I was observing segfaults at executable exit in the rtsan instrumented unit tests. Bisecting the offending test led to observing that this test is not using our safe test fixture for anything involving a file descriptor. Changing to use the fixture eliminated the segfault on exit. 