### PR TITLE
[BOLT] Allow to compile with MSVC

### DIFF
--- a/bolt/lib/Core/Relocation.cpp
+++ b/bolt/lib/Core/Relocation.cpp
@@ -1018,7 +1018,7 @@ void Relocation::print(raw_ostream &OS) const {
     OS << "RType:" << Twine::utohexstr(Type);
     break;
 
-  case Triple::aarch64:
+  case Triple::aarch64: {
     static const char *const AArch64RelocNames[] = {
 #define ELF_RELOC(name, value) #name,
 #include "llvm/BinaryFormat/ELFRelocs/AArch64.def"
@@ -1026,7 +1026,7 @@ void Relocation::print(raw_ostream &OS) const {
     };
     assert(Type < ArrayRef(AArch64RelocNames).size());
     OS << AArch64RelocNames[Type];
-    break;
+  } break;
 
   case Triple::riscv64:
     // RISC-V relocations are not sequentially numbered so we cannot use an
@@ -1043,7 +1043,7 @@ void Relocation::print(raw_ostream &OS) const {
     }
     break;
 
-  case Triple::x86_64:
+  case Triple::x86_64: {
     static const char *const X86RelocNames[] = {
 #define ELF_RELOC(name, value) #name,
 #include "llvm/BinaryFormat/ELFRelocs/x86_64.def"
@@ -1051,7 +1051,7 @@ void Relocation::print(raw_ostream &OS) const {
     };
     assert(Type < ArrayRef(X86RelocNames).size());
     OS << X86RelocNames[Type];
-    break;
+  } break;
   }
   OS << ", 0x" << Twine::utohexstr(Offset);
   if (Symbol) {


### PR DESCRIPTION
This change is necessary to build BOLT with MSVC on Windows.