### PR TITLE
[LLDB][NativePDB] Fix name access for classes in `CVTagRecord::name`

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbUtil.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbUtil.h
@@ -65,7 +65,7 @@ struct CVTagRecord {
   }
 
   llvm::StringRef name() const {
-    if (m_kind == Struct || m_kind == Union)
+    if (m_kind == Struct || m_kind == Class)
       return cvclass.Name;
     if (m_kind == Enum)
       return cvenum.Name;


### PR DESCRIPTION
From https://github.com/llvm/llvm-project/pull/149876#discussion_r2240478480: The `name()` accessor checked for `m_kind == Union` and accessed `cvclass` instead of `cvunion`. This is technically wrong (maybe UB even?).
In practice, this wasn't an issue, because all types in the union (`ClassRecord`/`EnumRecord`/`UnionRecord`) inherit from `TagRecord`.