### PR TITLE
[BOLT] Fixed calling clang++ in tests on Windows

### DIFF
--- a/bolt/test/lsda-section-name.cpp
+++ b/bolt/test/lsda-section-name.cpp
@@ -1,8 +1,8 @@
 // This test check that LSDA section named by .gcc_except_table.main is
 // disassembled by BOLT.
 
-// RUN: %clang++ %cxxflags -O3 -no-pie -c %s -o %t.o
-// RUN: %clang++ %cxxflags -O3 -no-pie -fuse-ld=lld %t.o -o %t
+// RUN: %clangxx %cxxflags -O3 -no-pie -c %s -o %t.o
+// RUN: %clangxx %cxxflags -O3 -no-pie -fuse-ld=lld %t.o -o %t
 // RUN: llvm-objcopy --rename-section .gcc_except_table=.gcc_except_table.main %t
 // RUN: llvm-readelf -SW %t | FileCheck %s
 // RUN: llvm-bolt %t -o %t.bolt


### PR DESCRIPTION
`RUN: %clang++ ` tried to execute `clang.exe++` on Windows. Use `%clangxx` instead.