### PR TITLE
[AArch64] Do a blanket check for all instructions that modify NZCV (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ConditionOptimizer.cpp
@@ -190,21 +190,9 @@ MachineInstr *AArch64ConditionOptimizer::findSuitableCompare(
     // ...
     // fcmp     d8, #0.0
     // b.gt     .LBB0_5
-    case AArch64::FCMPDri:
-    case AArch64::FCMPSri:
-    case AArch64::FCMPESri:
-    case AArch64::FCMPEDri:
-
-    case AArch64::SUBSWrr:
-    case AArch64::SUBSXrr:
-    case AArch64::ADDSWrr:
-    case AArch64::ADDSXrr:
-    case AArch64::FCMPSrr:
-    case AArch64::FCMPDrr:
-    case AArch64::FCMPESrr:
-    case AArch64::FCMPEDrr:
-      // Skip comparison instructions without immediate operands.
-      return nullptr;
+    default:
+      if (I.modifiesRegister(AArch64::NZCV, /*TRI=*/nullptr))
+        return nullptr;
     }
   }
   LLVM_DEBUG(dbgs() << "Flags not defined in " << printMBBReference(*MBB)


### PR DESCRIPTION
Including ands, bics, etc.