### PR TITLE
[lldb] Clear Frames when changing `disable-language-runtime-unwindplans`

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -100,6 +100,7 @@ public:
   void SetStopOnSharedLibraryEvents(bool stop);
   bool GetDisableLangRuntimeUnwindPlans() const;
   void SetDisableLangRuntimeUnwindPlans(bool disable);
+  void DisableLanguageRuntimeUnwindPlansCallback();
   bool GetDetachKeepsStopped() const;
   void SetDetachKeepsStopped(bool keep_stopped);
   bool GetWarningsOptimization() const;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -166,6 +166,9 @@ ProcessProperties::ProcessProperties(lldb_private::Process *process)
     m_collection_sp->SetValueChangedCallback(
         ePropertyPythonOSPluginPath,
         [this] { m_process->LoadOperatingSystemPlugin(true); });
+    m_collection_sp->SetValueChangedCallback(
+        ePropertyDisableLangRuntimeUnwindPlans,
+        [this] { DisableLanguageRuntimeUnwindPlansCallback(); });
   }
 
   m_experimental_properties_up =
@@ -278,6 +281,13 @@ void ProcessProperties::SetDisableLangRuntimeUnwindPlans(bool disable) {
   const uint32_t idx = ePropertyDisableLangRuntimeUnwindPlans;
   SetPropertyAtIndex(idx, disable);
   m_process->Flush();
+}
+
+void ProcessProperties::DisableLanguageRuntimeUnwindPlansCallback() {
+  if (!m_process)
+    return;
+  for (auto thread_sp : m_process->Threads())
+    thread_sp->ClearStackFrames();
 }
 
 bool ProcessProperties::GetDetachKeepsStopped() const {

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -286,8 +286,10 @@ void ProcessProperties::SetDisableLangRuntimeUnwindPlans(bool disable) {
 void ProcessProperties::DisableLanguageRuntimeUnwindPlansCallback() {
   if (!m_process)
     return;
-  for (auto thread_sp : m_process->Threads())
+  for (auto thread_sp : m_process->Threads()) {
     thread_sp->ClearStackFrames();
+    thread_sp->DiscardThreadPlans(/*force*/ true);
+  }
 }
 
 bool ProcessProperties::GetDetachKeepsStopped() const {


### PR DESCRIPTION
This patch uses the "setting changed" callback to clear previously cached stack frames when
`target.process.disable-language-runtime-unwindplans` is changed. This is necessary so that changing the setting followed by a `backtrace` command produces an accurate backtrace.

With this, a user can create a custom command like below in order to quickly inspect a backtrace created without language plugins.

```
debugger.HandleCommand("settings set target.process.disable-language-runtime-unwindplans true")
debugger.HandleCommand("bt " + command)
debugger.HandleCommand("settings set target.process.disable-language-runtime-unwindplans false")
```

In the future, we may consider implementing this as an option to `backtrace`. Currently, this process setting is the only way of affecting the unwinder, and changing the process setting as part of the backtrace implementation doesn't feel right.

There are no upstream users of this flag, so we cannot write a test for it here.

