### PR TITLE
[RISCV] Fix build failure in getIntrinsicInstrCost

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1254,7 +1254,7 @@ RISCVTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     Type *SrcTy = ICA.getArgTypes().front();
     auto SrcLT = getTypeLegalizationCost(SrcTy);
     if (ST->hasVInstructions() && LT.second.isVector()) {
-      ArrayRef<unsigned> Ops;
+      SmallVector<unsigned> Ops;
       unsigned SrcEltSz = DL.getTypeSizeInBits(SrcTy->getScalarType());
       unsigned DstEltSz = DL.getTypeSizeInBits(RetTy->getScalarType());
       if (LT.second.getVectorElementType() == MVT::bf16) {

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -1254,7 +1254,7 @@ RISCVTTIImpl::getIntrinsicInstrCost(const IntrinsicCostAttributes &ICA,
     Type *SrcTy = ICA.getArgTypes().front();
     auto SrcLT = getTypeLegalizationCost(SrcTy);
     if (ST->hasVInstructions() && LT.second.isVector()) {
-      SmallVector<unsigned> Ops;
+      SmallVector<unsigned, 2> Ops;
       unsigned SrcEltSz = DL.getTypeSizeInBits(SrcTy->getScalarType());
       unsigned DstEltSz = DL.getTypeSizeInBits(RetTy->getScalarType());
       if (LT.second.getVectorElementType() == MVT::bf16) {


### PR DESCRIPTION
bd66fd0 (`[CostModel/RISCV] Fix costs of vector [l](lrint|lround)`) introduced buildbot failures by using a temporary ArrayRef when a SmallVector should have been used. Fix this.

Failure: https://lab.llvm.org/buildbot/#/builders/186/builds/11133