### PR TITLE
Ignore FileCheck when profcheck is enabled

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -18,7 +18,17 @@ from lit.llvm.subst import ToolSubst
 config.name = "LLVM"
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+extra_substitutions = extra_substitutions = (
+    [
+        (r"\| not FileCheck .*", "> /dev/null"),
+        (r"\| FileCheck .*", "> /dev/null"),
+    ]
+    if config.enable_profcheck
+    else []
+)
+config.test_format = lit.formats.ShTest(
+    not llvm_config.use_lit_shell, extra_substitutions
+)
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.


### PR DESCRIPTION
When profcheck is enabled (presumably on a specific build bot), we want to ignore FileCheck because we're only interested in profile validation, and some tests are sensitive to the precise IR output, which profile validation alters slightly by inserting profile metadata.

Issue #147390