### PR TITLE
[CIR] Simplify ConstantOp accesses and its getDefiningOp

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -291,6 +291,9 @@ def CIR_ConstantOp : CIR_Op<"const", [
         return ptrAttr.isNullValue();
       return false;
     }
+
+    template <typename T>
+    T getValueAttr() { return mlir::dyn_cast<T>(getValue()); }
   }];
 
   let hasFolder = 1;

--- a/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExpr.cpp
@@ -721,8 +721,8 @@ static const Expr *getSimpleArrayDecayOperand(const Expr *e) {
 
 static cir::IntAttr getConstantIndexOrNull(mlir::Value idx) {
   // TODO(cir): should we consider using MLIRs IndexType instead of IntegerAttr?
-  if (auto constantOp = dyn_cast<cir::ConstantOp>(idx.getDefiningOp()))
-    return mlir::dyn_cast<cir::IntAttr>(constantOp.getValue());
+  if (auto constantOp = idx.getDefiningOp<cir::ConstantOp>())
+    return constantOp.getValueAttr<cir::IntAttr>();
   return {};
 }
 
@@ -730,8 +730,7 @@ static CharUnits getArrayElementAlign(CharUnits arrayAlign, mlir::Value idx,
                                       CharUnits eltSize) {
   // If we have a constant index, we can use the exact offset of the
   // element we're accessing.
-  const cir::IntAttr constantIdx = getConstantIndexOrNull(idx);
-  if (constantIdx) {
+  if (const cir::IntAttr constantIdx = getConstantIndexOrNull(idx)) {
     const CharUnits offset = constantIdx.getValue().getZExtValue() * eltSize;
     return arrayAlign.alignmentAtOffset(offset);
   }

--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -48,8 +48,8 @@ struct BinOpInfo {
   /// Check if the binop can result in integer overflow.
   bool mayHaveIntegerOverflow() const {
     // Without constant input, we can't rule out overflow.
-    auto lhsci = dyn_cast<cir::ConstantOp>(lhs.getDefiningOp());
-    auto rhsci = dyn_cast<cir::ConstantOp>(rhs.getDefiningOp());
+    auto lhsci = lhs.getDefiningOp<cir::ConstantOp>();
+    auto rhsci = rhs.getDefiningOp<cir::ConstantOp>();
     if (!lhsci || !rhsci)
       return true;
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1833,7 +1833,7 @@ LogicalResult cir::GetMemberOp::verify() {
 
 OpFoldResult cir::VecCreateOp::fold(FoldAdaptor adaptor) {
   if (llvm::any_of(getElements(), [](mlir::Value value) {
-        return !mlir::isa<cir::ConstantOp>(value.getDefiningOp());
+        return !value.getDefiningOp<cir::ConstantOp>();
       }))
     return {};
 

--- a/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/CIRSimplify.cpp
@@ -97,8 +97,8 @@ private:
     // Check whether the region/block contains a cir.const followed by a
     // cir.yield that yields the value.
     auto yieldOp = mlir::cast<cir::YieldOp>(onlyBlock.getTerminator());
-    auto yieldValueDefOp = mlir::dyn_cast_if_present<cir::ConstantOp>(
-        yieldOp.getArgs()[0].getDefiningOp());
+    auto yieldValueDefOp =
+        yieldOp.getArgs()[0].getDefiningOp<cir::ConstantOp>();
     return yieldValueDefOp && yieldValueDefOp->getBlock() == &onlyBlock;
   }
 };
@@ -126,18 +126,13 @@ struct SimplifySelect : public OpRewritePattern<SelectOp> {
 
   LogicalResult matchAndRewrite(SelectOp op,
                                 PatternRewriter &rewriter) const final {
-    mlir::Operation *trueValueOp = op.getTrueValue().getDefiningOp();
-    mlir::Operation *falseValueOp = op.getFalseValue().getDefiningOp();
-    auto trueValueConstOp =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(trueValueOp);
-    auto falseValueConstOp =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(falseValueOp);
-    if (!trueValueConstOp || !falseValueConstOp)
+    auto trueValueOp = op.getTrueValue().getDefiningOp<cir::ConstantOp>();
+    auto falseValueOp = op.getFalseValue().getDefiningOp<cir::ConstantOp>();
+    if (!trueValueOp || !falseValueOp)
       return mlir::failure();
 
-    auto trueValue = mlir::dyn_cast<cir::BoolAttr>(trueValueConstOp.getValue());
-    auto falseValue =
-        mlir::dyn_cast<cir::BoolAttr>(falseValueConstOp.getValue());
+    auto trueValue = trueValueOp.getValueAttr<cir::BoolAttr>();
+    auto falseValue = falseValueOp.getValueAttr<cir::BoolAttr>();
     if (!trueValue || !falseValue)
       return mlir::failure();
 
@@ -265,8 +260,7 @@ struct SimplifyVecSplat : public OpRewritePattern<VecSplatOp> {
   LogicalResult matchAndRewrite(VecSplatOp op,
                                 PatternRewriter &rewriter) const override {
     mlir::Value splatValue = op.getValue();
-    auto constant =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(splatValue.getDefiningOp());
+    auto constant = splatValue.getDefiningOp<cir::ConstantOp>();
     if (!constant)
       return mlir::failure();
 

--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -1935,12 +1935,11 @@ mlir::LogicalResult CIRToLLVMSelectOpLowering::matchAndRewrite(
     cir::SelectOp op, OpAdaptor adaptor,
     mlir::ConversionPatternRewriter &rewriter) const {
   auto getConstantBool = [](mlir::Value value) -> cir::BoolAttr {
-    auto definingOp =
-        mlir::dyn_cast_if_present<cir::ConstantOp>(value.getDefiningOp());
+    auto definingOp = value.getDefiningOp<cir::ConstantOp>();
     if (!definingOp)
       return {};
 
-    auto constValue = mlir::dyn_cast<cir::BoolAttr>(definingOp.getValue());
+    auto constValue = definingOp.getValueAttr<cir::BoolAttr>();
     if (!constValue)
       return {};
 


### PR DESCRIPTION
- Replaces  dyn_cast<cir::ConstantOp>(v.getDefiningOp()) and similar with v.getDefiningOp<cir::ConstantOp>()
- Adds `getValueAttr` method to ConstantOp