### PR TITLE
[clang][X86] Update __cpuidex_conflict.c test post #126324

### DIFF
--- a/clang/test/Headers/__cpuidex_conflict.c
+++ b/clang/test/Headers/__cpuidex_conflict.c
@@ -1,19 +1,17 @@
 // Make sure that __cpuidex in cpuid.h doesn't conflict with the MS
 // extensions built in by ensuring compilation succeeds:
-// RUN: %clang_cc1 %s -ffreestanding -fms-extensions -fms-compatibility \
-// RUN:  -fms-compatibility-version=19.00 -triple x86_64-pc-windows-msvc -emit-llvm -o -
-// %clang_cc1 %s -ffreestanding -triple x86_64-w64-windows-gnu -fms-extensions -emit-llvm -o -
-//
-// FIXME: See https://github.com/llvm/llvm-project/pull/121839 and
-// FIXME: https://github.com/llvm/llvm-project/pull/126324
-// RUN: not %clang_cc1 %s -ffreestanding -fopenmp -fopenmp-is-target-device -aux-triple x86_64-unknown-linux-gnu
+// RUN: %clang_cc1 %s -DIS_STATIC="" -ffreestanding -fms-extensions -fms-compatibility -fms-compatibility-version=19.00 -triple x86_64-pc-windows-msvc -emit-llvm -o -
+// RUN: %clang_cc1 %s -DIS_STATIC="" -ffreestanding -triple x86_64-w64-windows-gnu -fms-extensions -emit-llvm -o -
+
+// Ensure that we do not run into conflicts when offloading.
+// RUN: %clang_cc1 %s -DIS_STATIC=static -ffreestanding -fopenmp -fopenmp-is-target-device -aux-triple x86_64-unknown-linux-gnu
 
 typedef __SIZE_TYPE__ size_t;
 
 // We declare __cpuidex here as where the buitlin should be exposed (MSVC), the
 // declaration is in <intrin.h>, but <intrin.h> is not available from all the
 // targets that are being tested here.
-void __cpuidex (int[4], int, int);
+IS_STATIC void __cpuidex (int[4], int, int);
 
 #include <cpuid.h>
 
@@ -22,4 +20,3 @@ int cpuid_info[4];
 void test_cpuidex(unsigned level, unsigned count) {
   __cpuidex(cpuid_info, level, count);
 }
-


### PR DESCRIPTION
It does not look like __cpuidex builtins are being incorrectly included in compilations for offload targets anymore, so change up the test to assume that we are defining __cpuidex as static in cpuid.h now that \#126324 updates the behavior of __has_builtin on offload compilations.

This ensures we are still testing that we are avoiding the conflicts around offloading that were first pointed out in
https://reviews.llvm.org/D150646.