### PR TITLE
[lldb][test][NFC] Add LLDB test for UBSan trap frame recognizer

### DIFF
--- a/lldb/test/Shell/Recognizer/Inputs/ubsan_add_overflow.c
+++ b/lldb/test/Shell/Recognizer/Inputs/ubsan_add_overflow.c
@@ -1,0 +1,3 @@
+#include <limits.h>
+
+int main() { return INT_MAX + 1; }

--- a/lldb/test/Shell/Recognizer/Inputs/ubsan_add_overflow.cpp
+++ b/lldb/test/Shell/Recognizer/Inputs/ubsan_add_overflow.cpp
@@ -1,0 +1,8 @@
+#include <limits.h>
+
+int main() {
+  volatile int a = INT_MAX;
+  volatile int b = 1;
+  volatile int c = a + b;
+  return c;
+}

--- a/lldb/test/Shell/Recognizer/Inputs/ubsan_add_overflow.cpp
+++ b/lldb/test/Shell/Recognizer/Inputs/ubsan_add_overflow.cpp
@@ -1,8 +1,0 @@
-#include <limits.h>
-
-int main() {
-  volatile int a = INT_MAX;
-  volatile int b = 1;
-  volatile int c = a + b;
-  return c;
-}

--- a/lldb/test/Shell/Recognizer/ubsan_add_overflow.test
+++ b/lldb/test/Shell/Recognizer/ubsan_add_overflow.test
@@ -1,15 +1,15 @@
-# REQUIRES: clang
-
-# RUN: %clang_host -g -O0 %S/Inputs/ubsan_add_overflow.cpp -o %t.out \
-# RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow
+# RUN: %clang_host -g -O0 %S/Inputs/ubsan_add_overflow.c -o %t.out \
+# RUN:  -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow
 
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 
 run
 # CHECK: thread #{{.*}} stop reason = Undefined Behavior Sanitizer: Integer addition overflowed
+# CHECK-NEXT: frame #1: {{.*}}`main at ubsan_add_overflow.c
 
-frame info
-# CHECK: frame #{{.*}}`main at ubsan_add_overflow.cpp
+bt
+# CHECK: frame #0: {{.*}}`__clang_trap_msg$Undefined Behavior Sanitizer$Integer addition overflowed{{.*}}
+# CHECK: frame #1: {{.*}}`main at ubsan_add_overflow.c
 
 frame recognizer info 0
 # CHECK: frame 0 is recognized by Verbose Trap StackFrame Recognizer

--- a/lldb/test/Shell/Recognizer/ubsan_add_overflow.test
+++ b/lldb/test/Shell/Recognizer/ubsan_add_overflow.test
@@ -1,0 +1,17 @@
+# REQUIRES: clang
+
+# RUN: %clang_host -g -O0 %S/Inputs/ubsan_add_overflow.cpp -o %t.out \
+# RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow
+
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+run
+# CHECK: thread #{{.*}} stop reason = Undefined Behavior Sanitizer: Integer addition overflowed
+
+frame info
+# CHECK: frame #{{.*}}`main at ubsan_add_overflow.cpp
+
+frame recognizer info 0
+# CHECK: frame 0 is recognized by Verbose Trap StackFrame Recognizer
+
+quit

--- a/lldb/test/Shell/Recognizer/ubsan_add_overflow.test
+++ b/lldb/test/Shell/Recognizer/ubsan_add_overflow.test
@@ -11,6 +11,9 @@ bt
 # CHECK: frame #0: {{.*}}`__clang_trap_msg$Undefined Behavior Sanitizer$Integer addition overflowed{{.*}}
 # CHECK: frame #1: {{.*}}`main at ubsan_add_overflow.c
 
+frame info
+# CHECK: frame #{{.*}}`main at ubsan_add_overflow.c
+
 frame recognizer info 0
 # CHECK: frame 0 is recognized by Verbose Trap StackFrame Recognizer
 


### PR DESCRIPTION
In #145967 Clang was taught to emit trap reasons on UBSan traps in debug info using the same method as `__builtin_verbose_trap`. This patch adds a test case to make sure that the existing "Verbose Trap StackFrame Recognizer" recognizes the trap reason and sets the stop reason and stack frame appropriately.

Part of a GSoC 2025 Project.