### PR TITLE
[Clang] [Diagnostics] Add a new text diagnostics format that supports nested diagnostics

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidyDiagnosticConsumer.cpp
@@ -56,6 +56,7 @@ protected:
   void emitDiagnosticMessage(FullSourceLoc Loc, PresumedLoc PLoc,
                              DiagnosticsEngine::Level Level, StringRef Message,
                              ArrayRef<CharSourceRange> Ranges,
+                             unsigned NestingLevel,
                              DiagOrStoredDiag Info) override {
     // Remove check name from the message.
     // FIXME: Remove this once there's a better way to pass check names than

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -352,7 +352,7 @@ private:
 public:
   /// Helper to increment the global diagnostics nesting level.
   class NestingLevelRAII {
-    DiagnosticsEngine& Diags;
+    DiagnosticsEngine &Diags;
     unsigned TheIncrement;
 
   public:

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -165,9 +165,10 @@ struct DiagnosticStorage {
   /// or in DiagArguments.
   unsigned char DiagArgumentsKind[MaxArguments];
 
-  /// Nesting level of this diagnostic, if any. If unset, this defaults to
-  /// 1 for notes and 0 otherwise. A (default) value of 0 indicates a top-level
-  /// diagnostic.
+  /// Nesting level of this diagnostic, if any.
+  ///
+  /// If unset, the nesting level will be computed by the diagnostics engine
+  /// when the diagnostic is emitted.
   UnsignedOrNone NestingLevel = std::nullopt;
 
   /// The values for the various substitution positions.

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -355,8 +355,7 @@ public:
     unsigned TheIncrement;
 
   public:
-    explicit NestingLevelRAII(DiagnosticsEngine &Diags,
-                              unsigned Increment = 1)
+    explicit NestingLevelRAII(DiagnosticsEngine &Diags, unsigned Increment = 1)
         : Diags(Diags), TheIncrement(Increment) {
       Diags.GlobalNestingLevel += Increment;
     }

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -165,6 +165,11 @@ struct DiagnosticStorage {
   /// or in DiagArguments.
   unsigned char DiagArgumentsKind[MaxArguments];
 
+  /// Nesting level of this diagnostic, if any. If unset, this defaults to
+  /// 1 for notes and 0 otherwise. A (default) value of 0 indicates a top-level
+  /// diagnostic.
+  UnsignedOrNone NestingLevel = std::nullopt;
+
   /// The values for the various substitution positions.
   ///
   /// This is used when the argument is not an std::string. The specific value
@@ -317,6 +322,9 @@ private:
   // Color printing is enabled.
   bool ShowColors = false;
 
+  // Nesting diagnostics is enabled.
+  bool EnableNesting = false;
+
   // Which overload candidates to show.
   OverloadsShown ShowOverloads = Ovl_All;
 
@@ -336,6 +344,25 @@ private:
   // Cap on depth of constexpr evaluation backtrace stack, 0 -> no limit.
   unsigned ConstexprBacktraceLimit = 0;
 
+  // Increment to add to the nesting level of every diagnostic we emit; this is
+  // used to nest e.g. errors inside other errors.
+  unsigned GlobalNestingLevel = 0;
+
+public:
+  class NestingLevelRAII {
+    DiagnosticsEngine& Diags;
+    unsigned Increment;
+
+  public:
+    explicit NestingLevelRAII(DiagnosticsEngine &Diags, unsigned Increment = 1)
+        : Diags(Diags), Increment(Increment) {
+      Diags.GlobalNestingLevel += Increment;
+    }
+
+    ~NestingLevelRAII() { Diags.GlobalNestingLevel -= Increment; }
+  };
+
+private:
   IntrusiveRefCntPtr<DiagnosticIDs> Diags;
   DiagnosticOptions &DiagOpts;
   DiagnosticConsumer *Client = nullptr;
@@ -742,6 +769,10 @@ public:
   /// into the output.
   void setShowColors(bool Val) { ShowColors = Val; }
   bool getShowColors() { return ShowColors; }
+
+  /// Set whether diagnostics should be nested.
+  void setEnableNesting(bool Val) { EnableNesting = Val; }
+  bool getEnableNesting() { return EnableNesting; }
 
   /// Specify which overload candidates to show when overload resolution
   /// fails.
@@ -1187,6 +1218,13 @@ public:
     DiagStorage->FixItHints.push_back(Hint);
   }
 
+  void SetNestingLevel(UnsignedOrNone Level) const {
+    if (!DiagStorage)
+      DiagStorage = getStorage();
+
+    DiagStorage->NestingLevel = Level;
+  }
+
   /// Conversion of StreamingDiagnostic to bool always returns \c true.
   ///
   /// This allows is to be used in boolean error contexts (where \c true is
@@ -1377,6 +1415,14 @@ inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
   return DB;
 }
 
+inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
+                                             diag::NestingLevel Level) {
+  // The 'NestingLevel' type exists solely so we can pass it to this overload
+  // without it being mistaken as a diagnostic parameter.
+  DB.SetNestingLevel(llvm::to_underlying(Level));
+  return DB;
+}
+
 // We use enable_if here to prevent that this overload is selected for
 // pointers or other arguments that are implicitly convertible to bool.
 template <typename T>
@@ -1542,6 +1588,7 @@ class Diagnostic {
   const DiagnosticsEngine *DiagObj;
   SourceLocation DiagLoc;
   unsigned DiagID;
+  unsigned NestingLevel;
   std::string FlagValue;
   const DiagnosticStorage &DiagStorage;
   std::optional<StringRef> StoredDiagMessage;
@@ -1550,7 +1597,7 @@ public:
   Diagnostic(const DiagnosticsEngine *DO, const DiagnosticBuilder &DiagBuilder);
   Diagnostic(const DiagnosticsEngine *DO, SourceLocation DiagLoc,
              unsigned DiagID, const DiagnosticStorage &DiagStorage,
-             StringRef StoredDiagMessage);
+             StringRef StoredDiagMessage, unsigned NestingLevel = 0);
 
   const DiagnosticsEngine *getDiags() const { return DiagObj; }
   unsigned getID() const { return DiagID; }
@@ -1646,6 +1693,14 @@ public:
   /// Return the value associated with this diagnostic flag.
   StringRef getFlagValue() const { return FlagValue; }
 
+  /// Get the nesting level of this diagnostic.
+  unsigned getNestingLevel() const { return NestingLevel; }
+  void setNestingLevel(unsigned Level) { NestingLevel = Level; }
+
+  /// Whether the nesting level of this diagnostic should be replaced
+  /// with its default value (e.g. 1 for notes).
+  bool shouldUseDefaultNestingLevel() const { return !DiagStorage.NestingLevel; }
+
   /// Format this diagnostic into a string, substituting the
   /// formal arguments into the %0 slots.
   ///
@@ -1665,6 +1720,7 @@ public:
 class StoredDiagnostic {
   unsigned ID;
   DiagnosticsEngine::Level Level;
+  UnsignedOrNone NestingLevel = std::nullopt;
   FullSourceLoc Loc;
   std::string Message;
   std::vector<CharSourceRange> Ranges;
@@ -1677,8 +1733,8 @@ public:
                    StringRef Message);
   StoredDiagnostic(DiagnosticsEngine::Level Level, unsigned ID,
                    StringRef Message, FullSourceLoc Loc,
-                   ArrayRef<CharSourceRange> Ranges,
-                   ArrayRef<FixItHint> Fixits);
+                   ArrayRef<CharSourceRange> Ranges, ArrayRef<FixItHint> Fixits,
+                   UnsignedOrNone NestingLevel = std::nullopt);
 
   /// Evaluates true when this object stores a diagnostic.
   explicit operator bool() const { return !Message.empty(); }
@@ -1705,6 +1761,7 @@ public:
   unsigned fixit_size() const { return FixIts.size(); }
 
   ArrayRef<FixItHint> getFixIts() const { return llvm::ArrayRef(FixIts); }
+  UnsignedOrNone getNestingLevel() const { return NestingLevel; }
 };
 
 // Simple debug printing of StoredDiagnostic.

--- a/clang/include/clang/Basic/Diagnostic.h
+++ b/clang/include/clang/Basic/Diagnostic.h
@@ -1070,7 +1070,7 @@ private:
   bool ProcessDiag(const DiagnosticBuilder &DiagBuilder);
 
   /// Forward a diagnostic to the DiagnosticConsumer.
-  void Report(Level DiagLevel, const Diagnostic &Info);
+  void Report(Level DiagLevel, Diagnostic Info);
 
   /// @name Diagnostic Emission
   /// @{
@@ -1699,7 +1699,9 @@ public:
 
   /// Whether the nesting level of this diagnostic should be replaced
   /// with its default value (e.g. 1 for notes).
-  bool shouldUseDefaultNestingLevel() const { return !DiagStorage.NestingLevel; }
+  bool shouldUseDefaultNestingLevel() const {
+    return !DiagStorage.NestingLevel;
+  }
 
   /// Format this diagnostic into a string, substituting the
   /// formal arguments into the %0 slots.

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -92,6 +92,10 @@ namespace clang {
       Remark          ///< A diagnostic that indicates normal progress through
                       ///< compilation.
     };
+
+    /// Diagnostic nesting level; this can be any positive integer; we only
+    /// use an enum for this so we can treat it as a separate type.
+    enum class NestingLevel : unsigned {};
   } // end namespace diag
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -92,20 +92,6 @@ namespace clang {
       Remark          ///< A diagnostic that indicates normal progress through
                       ///< compilation.
     };
-
-    /// Diagnostic nesting level; this can be any positive integer; we only
-    /// use an enum for this so we can treat it as a separate type. The main
-    /// use of this is for diagnostics which need to store the global nesting
-    /// level when they are created because they are emitted at a later point
-    /// in time when the nesting level might have changed.
-    ///
-    /// The intended use case for this type is usually the following:
-    ///
-    ///   Diag(...) << diag::NestingLevel(DiagsEngine.getNestingLevel())
-    ///
-    /// Hard-coding a nesting level (e.g. diag::NestingLevel(2)) is usually
-    /// a bad idea as it fails to take the global nesting level into account.
-    enum class NestingLevel : unsigned {};
   } // end namespace diag
 } // end namespace clang
 

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -94,7 +94,17 @@ namespace clang {
     };
 
     /// Diagnostic nesting level; this can be any positive integer; we only
-    /// use an enum for this so we can treat it as a separate type.
+    /// use an enum for this so we can treat it as a separate type. The main
+    /// use of this is for diagnostics which need to store the global nesting
+    /// level when they are created because they are emitted at a later point
+    /// in time when the nesting level might have changed.
+    ///
+    /// The intended use case for this type is usually the following:
+    ///
+    ///   Diag(...) << diag::NestingLevel(DiagsEngine.getNestingLevel())
+    ///
+    /// Hard-coding a nesting level (e.g. diag::NestingLevel(2)) is usually
+    /// a bad idea as it fails to take the global nesting level into account.
     enum class NestingLevel : unsigned {};
   } // end namespace diag
 } // end namespace clang

--- a/clang/include/clang/Basic/DiagnosticOptions.def
+++ b/clang/include/clang/Basic/DiagnosticOptions.def
@@ -63,7 +63,7 @@ DIAGOPT(ShowNoteIncludeStack, 1, 0) /// Show include stacks for notes.
 VALUE_DIAGOPT(ShowCategories, 2, 0) /// Show categories: 0 -> none, 1 -> Number,
                                     /// 2 -> Full Name.
 
-ENUM_DIAGOPT(Format, TextDiagnosticFormat, 2, Clang) /// Format for diagnostics:
+ENUM_DIAGOPT(Format, TextDiagnosticFormat, 3, Clang) /// Format for diagnostics:
 
 DIAGOPT(ShowColors, 1, 0)       /// Show diagnostics with ANSI color sequences.
 DIAGOPT(UseANSIEscapeCodes, 1, 0)

--- a/clang/include/clang/Basic/DiagnosticOptions.h
+++ b/clang/include/clang/Basic/DiagnosticOptions.h
@@ -74,7 +74,7 @@ class DiagnosticOptions {
   friend class CompilerInvocationBase;
 
 public:
-  enum TextDiagnosticFormat { Clang, MSVC, Vi, SARIF };
+  enum TextDiagnosticFormat { Clang, MSVC, Vi, SARIF, Fancy };
 
   // Default values.
   enum {

--- a/clang/include/clang/Basic/PartialDiagnostic.h
+++ b/clang/include/clang/Basic/PartialDiagnostic.h
@@ -105,6 +105,9 @@ public:
     // Copy fix-its.
     for (unsigned I = 0, N = Other.getNumFixItHints(); I != N; ++I)
       AddFixItHint(Other.getFixItHint(I));
+
+    if (!Other.shouldUseDefaultNestingLevel())
+      SetNestingLevel(Other.getNestingLevel());
   }
 
   PartialDiagnostic &operator=(const PartialDiagnostic &Other) {
@@ -162,6 +165,9 @@ public:
     // Add all fix-its.
     for (const FixItHint &Fix : DiagStorage->FixItHints)
       DB.AddFixItHint(Fix);
+
+    if (DiagStorage->NestingLevel)
+      DB.SetNestingLevel(DiagStorage->NestingLevel);
   }
 
   void EmitToString(DiagnosticsEngine &Diags,

--- a/clang/include/clang/Basic/PartialDiagnostic.h
+++ b/clang/include/clang/Basic/PartialDiagnostic.h
@@ -106,7 +106,9 @@ public:
     for (unsigned I = 0, N = Other.getNumFixItHints(); I != N; ++I)
       AddFixItHint(Other.getFixItHint(I));
 
-    if (!Other.shouldUseDefaultNestingLevel())
+    // If the nesting level for this diagnostic has already been determined
+    // by the diagnostics engine, copy it.
+    if (Other.nestingLevelAlreadyComputed())
       SetNestingLevel(Other.getNestingLevel());
   }
 
@@ -166,8 +168,7 @@ public:
     for (const FixItHint &Fix : DiagStorage->FixItHints)
       DB.AddFixItHint(Fix);
 
-    if (DiagStorage->NestingLevel)
-      DB.SetNestingLevel(DiagStorage->NestingLevel);
+    DB.SetNestingLevel(DiagStorage->NestingLevel);
   }
 
   void EmitToString(DiagnosticsEngine &Diags,

--- a/clang/include/clang/Basic/UnsignedOrNone.h
+++ b/clang/include/clang/Basic/UnsignedOrNone.h
@@ -52,7 +52,6 @@ struct UnsignedOrNone {
     return operator bool() ? *this : val;
   }
 
-
 private:
   constexpr UnsignedOrNone(std::nullopt_t, unsigned Rep) : Rep(Rep) {};
 

--- a/clang/include/clang/Basic/UnsignedOrNone.h
+++ b/clang/include/clang/Basic/UnsignedOrNone.h
@@ -42,6 +42,17 @@ struct UnsignedOrNone {
     return LHS.Rep != RHS.Rep;
   }
 
+  // NOTE: These value_or overloads are included to make this pr compile;
+  // the actual patch introducing them will be #143516.
+  constexpr unsigned value_or(unsigned val) const {
+    return operator bool() ? **this : val;
+  }
+
+  constexpr UnsignedOrNone value_or(UnsignedOrNone val) const {
+    return operator bool() ? *this : val;
+  }
+
+
 private:
   constexpr UnsignedOrNone(std::nullopt_t, unsigned Rep) : Rep(Rep) {};
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7985,11 +7985,14 @@ def diagnostic_serialized_file : Separate<["-"], "serialize-diagnostic-file">,
   MetaVarName<"<filename>">,
   HelpText<"File for serializing diagnostics in a binary format">;
 
-def fdiagnostics_format : Separate<["-"], "fdiagnostics-format">,
-  HelpText<"Change diagnostic formatting to match IDE and command line tools">,
-  Values<"clang,msvc,vi,sarif,SARIF,fancy">,
-  NormalizedValuesScope<"DiagnosticOptions">, NormalizedValues<["Clang", "MSVC", "Vi", "SARIF", "SARIF", "Fancy"]>,
-  MarshallingInfoEnum<DiagnosticOpts<"Format">, "Clang">;
+def fdiagnostics_format
+    : Separate<["-"], "fdiagnostics-format">,
+      HelpText<
+          "Change diagnostic formatting to match IDE and command line tools">,
+      Values<"clang,msvc,vi,sarif,SARIF,fancy">,
+      NormalizedValuesScope<"DiagnosticOptions">,
+      NormalizedValues<["Clang", "MSVC", "Vi", "SARIF", "SARIF", "Fancy"]>,
+      MarshallingInfoEnum<DiagnosticOpts<"Format">, "Clang">;
 def fdiagnostics_show_category : Separate<["-"], "fdiagnostics-show-category">,
   HelpText<"Print diagnostic category">,
   Values<"none,id,name">,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7987,8 +7987,8 @@ def diagnostic_serialized_file : Separate<["-"], "serialize-diagnostic-file">,
 
 def fdiagnostics_format : Separate<["-"], "fdiagnostics-format">,
   HelpText<"Change diagnostic formatting to match IDE and command line tools">,
-  Values<"clang,msvc,vi,sarif,SARIF">,
-  NormalizedValuesScope<"DiagnosticOptions">, NormalizedValues<["Clang", "MSVC", "Vi", "SARIF", "SARIF"]>,
+  Values<"clang,msvc,vi,sarif,SARIF,fancy">,
+  NormalizedValuesScope<"DiagnosticOptions">, NormalizedValues<["Clang", "MSVC", "Vi", "SARIF", "SARIF", "Fancy"]>,
   MarshallingInfoEnum<DiagnosticOpts<"Format">, "Clang">;
 def fdiagnostics_show_category : Separate<["-"], "fdiagnostics-show-category">,
   HelpText<"Print diagnostic category">,

--- a/clang/include/clang/Frontend/DiagnosticRenderer.h
+++ b/clang/include/clang/Frontend/DiagnosticRenderer.h
@@ -76,6 +76,7 @@ protected:
                                      DiagnosticsEngine::Level Level,
                                      StringRef Message,
                                      ArrayRef<CharSourceRange> Ranges,
+                                     unsigned NestingLevel,
                                      DiagOrStoredDiag Info) = 0;
 
   virtual void emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,
@@ -94,12 +95,13 @@ protected:
                                           StringRef ModuleName) = 0;
 
   virtual void beginDiagnostic(DiagOrStoredDiag D,
-                               DiagnosticsEngine::Level Level) {}
+                               DiagnosticsEngine::Level Level,
+                               unsigned NestingLevel) {}
   virtual void endDiagnostic(DiagOrStoredDiag D,
                              DiagnosticsEngine::Level Level) {}
 
 private:
-  void emitBasicNote(StringRef Message);
+  void emitBasicNote(StringRef Message, unsigned CurrentNestingLevel);
   void emitIncludeStack(FullSourceLoc Loc, PresumedLoc PLoc,
                         DiagnosticsEngine::Level Level);
   void emitIncludeStackRecursively(FullSourceLoc Loc);
@@ -110,10 +112,12 @@ private:
                  ArrayRef<CharSourceRange> Ranges, ArrayRef<FixItHint> Hints);
   void emitSingleMacroExpansion(FullSourceLoc Loc,
                                 DiagnosticsEngine::Level Level,
-                                ArrayRef<CharSourceRange> Ranges);
+                                ArrayRef<CharSourceRange> Ranges,
+                                unsigned CurrentNestingLevel);
   void emitMacroExpansions(FullSourceLoc Loc, DiagnosticsEngine::Level Level,
                            ArrayRef<CharSourceRange> Ranges,
-                           ArrayRef<FixItHint> Hints);
+                           ArrayRef<FixItHint> Hints,
+                           unsigned CurrentNestingLevel);
 
 public:
   /// Emit a diagnostic.
@@ -128,9 +132,11 @@ public:
   /// \param Message The diagnostic message to emit.
   /// \param Ranges The underlined ranges for this code snippet.
   /// \param FixItHints The FixIt hints active for this diagnostic.
+  /// \param NestingLevel How deeply this diagnostic is nested.
   void emitDiagnostic(FullSourceLoc Loc, DiagnosticsEngine::Level Level,
                       StringRef Message, ArrayRef<CharSourceRange> Ranges,
                       ArrayRef<FixItHint> FixItHints,
+                      unsigned NestingLevel = 0,
                       DiagOrStoredDiag D = (Diagnostic *)nullptr);
 
   void emitStoredDiagnostic(StoredDiagnostic &Diag);

--- a/clang/include/clang/Frontend/DiagnosticRenderer.h
+++ b/clang/include/clang/Frontend/DiagnosticRenderer.h
@@ -135,8 +135,7 @@ public:
   /// \param NestingLevel How deeply this diagnostic is nested.
   void emitDiagnostic(FullSourceLoc Loc, DiagnosticsEngine::Level Level,
                       StringRef Message, ArrayRef<CharSourceRange> Ranges,
-                      ArrayRef<FixItHint> FixItHints,
-                      unsigned NestingLevel = 0,
+                      ArrayRef<FixItHint> FixItHints, unsigned NestingLevel = 0,
                       DiagOrStoredDiag D = (Diagnostic *)nullptr);
 
   void emitStoredDiagnostic(StoredDiagnostic &Diag);

--- a/clang/include/clang/Frontend/SARIFDiagnostic.h
+++ b/clang/include/clang/Frontend/SARIFDiagnostic.h
@@ -36,6 +36,7 @@ protected:
   void emitDiagnosticMessage(FullSourceLoc Loc, PresumedLoc PLoc,
                              DiagnosticsEngine::Level Level, StringRef Message,
                              ArrayRef<CharSourceRange> Ranges,
+                             unsigned NestingLevel,
                              DiagOrStoredDiag D) override;
 
   void emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,

--- a/clang/include/clang/Frontend/TextDiagnostic.h
+++ b/clang/include/clang/Frontend/TextDiagnostic.h
@@ -35,6 +35,8 @@ namespace clang {
 class TextDiagnostic : public DiagnosticRenderer {
   raw_ostream &OS;
   const Preprocessor *PP;
+  std::vector<std::pair<FullSourceLoc, PresumedLoc>> IncludeStack;
+  unsigned BaseIndent = 0;
 
 public:
   TextDiagnostic(raw_ostream &OS, const LangOptions &LangOpts,
@@ -77,14 +79,21 @@ public:
   /// \param Columns The number of columns to use in line-wrapping, 0 disables
   ///                all line-wrapping.
   /// \param ShowColors Enable colorizing of the message.
+  /// \param NestingLevel Nesting level of the diagnostic.
   static void printDiagnosticMessage(raw_ostream &OS, bool IsSupplemental,
                                      StringRef Message, unsigned CurrentColumn,
-                                     unsigned Columns, bool ShowColors);
+                                     unsigned Columns, bool ShowColors,
+                                     unsigned NestingLevel);
 
 protected:
+  void beginDiagnostic(DiagOrStoredDiag D, DiagnosticsEngine::Level Level,
+                       unsigned NestingLevel) override;
+  void endDiagnostic(DiagOrStoredDiag D, DiagnosticsEngine::Level Level) override;
+
   void emitDiagnosticMessage(FullSourceLoc Loc, PresumedLoc PLoc,
                              DiagnosticsEngine::Level Level, StringRef Message,
                              ArrayRef<CharSourceRange> Ranges,
+                             unsigned NestingLevel,
                              DiagOrStoredDiag D) override;
 
   void emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,

--- a/clang/include/clang/Frontend/TextDiagnostic.h
+++ b/clang/include/clang/Frontend/TextDiagnostic.h
@@ -88,7 +88,8 @@ public:
 protected:
   void beginDiagnostic(DiagOrStoredDiag D, DiagnosticsEngine::Level Level,
                        unsigned NestingLevel) override;
-  void endDiagnostic(DiagOrStoredDiag D, DiagnosticsEngine::Level Level) override;
+  void endDiagnostic(DiagOrStoredDiag D,
+                     DiagnosticsEngine::Level Level) override;
 
   void emitDiagnosticMessage(FullSourceLoc Loc, PresumedLoc PLoc,
                              DiagnosticsEngine::Level Level, StringRef Message,

--- a/clang/include/clang/Frontend/TextDiagnostic.h
+++ b/clang/include/clang/Frontend/TextDiagnostic.h
@@ -35,8 +35,8 @@ namespace clang {
 class TextDiagnostic : public DiagnosticRenderer {
   raw_ostream &OS;
   const Preprocessor *PP;
-  std::vector<std::pair<FullSourceLoc, PresumedLoc>> IncludeStack;
   unsigned BaseIndent = 0;
+  SmallVector<std::pair<FullSourceLoc, PresumedLoc>, 30> IncludeStack;
 
 public:
   TextDiagnostic(raw_ostream &OS, const LangOptions &LangOpts,

--- a/clang/include/clang/Frontend/TextDiagnostic.h
+++ b/clang/include/clang/Frontend/TextDiagnostic.h
@@ -83,7 +83,7 @@ public:
   static void printDiagnosticMessage(raw_ostream &OS, bool IsSupplemental,
                                      StringRef Message, unsigned CurrentColumn,
                                      unsigned Columns, bool ShowColors,
-                                     unsigned NestingLevel);
+                                     unsigned NestingLevel, bool FancyFormat);
 
 protected:
   void beginDiagnostic(DiagOrStoredDiag D, DiagnosticsEngine::Level Level,
@@ -126,6 +126,9 @@ private:
                    ArrayRef<StyleRange> Styles);
 
   void emitParseableFixits(ArrayRef<FixItHint> Hints, const SourceManager &SM);
+
+  void emptyLine();
+  void startLine(unsigned Indent);
 };
 
 } // end namespace clang

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -353,6 +353,9 @@ IntrusiveRefCntPtr<DiagnosticsEngine> CompilerInstance::createDiagnostics(
   } else
     Diags->setClient(new TextDiagnosticPrinter(llvm::errs(), Opts));
 
+  // TODO: Make this configurable.
+  Diags->setEnableNesting(true);
+
   // Chain in -verify checker, if requested.
   if (Opts.VerifyDiagnostics)
     Diags->setClient(new VerifyDiagnosticConsumer(*Diags));

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -350,11 +350,12 @@ IntrusiveRefCntPtr<DiagnosticsEngine> CompilerInstance::createDiagnostics(
     Diags->setClient(Client, ShouldOwnClient);
   } else if (Opts.getFormat() == DiagnosticOptions::SARIF) {
     Diags->setClient(new SARIFDiagnosticPrinter(llvm::errs(), Opts));
-  } else
+  } else {
     Diags->setClient(new TextDiagnosticPrinter(llvm::errs(), Opts));
 
-  // TODO: Make this configurable.
-  Diags->setEnableNesting(true);
+    // Currently, only the 'fancy' format supports nesting.
+    Diags->setEnableNesting(Opts.getFormat() == TextDiagnosticFormat::Fancy);
+  }
 
   // Chain in -verify checker, if requested.
   if (Opts.VerifyDiagnostics)

--- a/clang/lib/Frontend/DiagnosticRenderer.cpp
+++ b/clang/lib/Frontend/DiagnosticRenderer.cpp
@@ -82,13 +82,10 @@ static void mergeFixits(ArrayRef<FixItHint> FixItHints,
   }
 }
 
-void DiagnosticRenderer::emitDiagnostic(FullSourceLoc Loc,
-                                        DiagnosticsEngine::Level Level,
-                                        StringRef Message,
-                                        ArrayRef<CharSourceRange> Ranges,
-                                        ArrayRef<FixItHint> FixItHints,
-                                        unsigned NestingLevel,
-                                        DiagOrStoredDiag D) {
+void DiagnosticRenderer::emitDiagnostic(
+    FullSourceLoc Loc, DiagnosticsEngine::Level Level, StringRef Message,
+    ArrayRef<CharSourceRange> Ranges, ArrayRef<FixItHint> FixItHints,
+    unsigned NestingLevel, DiagOrStoredDiag D) {
   assert(Loc.hasManager() || Loc.isInvalid());
 
   beginDiagnostic(D, Level, NestingLevel);
@@ -129,7 +126,8 @@ void DiagnosticRenderer::emitDiagnostic(FullSourceLoc Loc,
     // If this location is within a macro, walk from UnexpandedLoc up to Loc
     // and produce a macro backtrace.
     if (UnexpandedLoc.isValid() && UnexpandedLoc.isMacroID()) {
-      emitMacroExpansions(UnexpandedLoc, Level, MutableRanges, FixItHints, NestingLevel);
+      emitMacroExpansions(UnexpandedLoc, Level, MutableRanges, FixItHints,
+                          NestingLevel);
     }
   }
 
@@ -142,14 +140,14 @@ void DiagnosticRenderer::emitDiagnostic(FullSourceLoc Loc,
 void DiagnosticRenderer::emitStoredDiagnostic(StoredDiagnostic &Diag) {
   emitDiagnostic(Diag.getLocation(), Diag.getLevel(), Diag.getMessage(),
                  Diag.getRanges(), Diag.getFixIts(),
-                 Diag.getNestingLevel().value_or(0),
-                 &Diag);
+                 Diag.getNestingLevel().value_or(0), &Diag);
 }
 
 void DiagnosticRenderer::emitBasicNote(StringRef Message,
                                        unsigned CurrentNestingLevel) {
   emitDiagnosticMessage(FullSourceLoc(), PresumedLoc(), DiagnosticsEngine::Note,
-                        Message, {}, CurrentNestingLevel + 1, DiagOrStoredDiag());
+                        Message, {}, CurrentNestingLevel + 1,
+                        DiagOrStoredDiag());
 }
 
 /// Prints an include stack when appropriate for a particular
@@ -433,8 +431,7 @@ void DiagnosticRenderer::emitCaret(FullSourceLoc Loc,
 /// macro expansion message
 void DiagnosticRenderer::emitSingleMacroExpansion(
     FullSourceLoc Loc, DiagnosticsEngine::Level Level,
-    ArrayRef<CharSourceRange> Ranges,
-    unsigned CurrentNestingLevel) {
+    ArrayRef<CharSourceRange> Ranges, unsigned CurrentNestingLevel) {
   // Find the spelling location for the macro definition. We must use the
   // spelling location here to avoid emitting a macro backtrace for the note.
   FullSourceLoc SpellingLoc = Loc.getSpellingLoc();
@@ -547,7 +544,8 @@ void DiagnosticRenderer::emitMacroExpansions(FullSourceLoc Loc,
   if (MacroDepth <= MacroLimit || MacroLimit == 0) {
     for (auto I = LocationStack.rbegin(), E = LocationStack.rend();
          I != E; ++I)
-      emitSingleMacroExpansion(FullSourceLoc(*I, SM), Level, Ranges, NestingLevel);
+      emitSingleMacroExpansion(FullSourceLoc(*I, SM), Level, Ranges,
+                               NestingLevel);
     return;
   }
 
@@ -557,7 +555,8 @@ void DiagnosticRenderer::emitMacroExpansions(FullSourceLoc Loc,
   for (auto I = LocationStack.rbegin(),
             E = LocationStack.rbegin() + MacroStartMessages;
        I != E; ++I)
-    emitSingleMacroExpansion(FullSourceLoc(*I, SM), Level, Ranges, NestingLevel);
+    emitSingleMacroExpansion(FullSourceLoc(*I, SM), Level, Ranges,
+                             NestingLevel);
 
   SmallString<200> MessageStorage;
   llvm::raw_svector_ostream Message(MessageStorage);
@@ -569,7 +568,8 @@ void DiagnosticRenderer::emitMacroExpansions(FullSourceLoc Loc,
   for (auto I = LocationStack.rend() - MacroEndMessages,
             E = LocationStack.rend();
        I != E; ++I)
-    emitSingleMacroExpansion(FullSourceLoc(*I, SM), Level, Ranges, NestingLevel);
+    emitSingleMacroExpansion(FullSourceLoc(*I, SM), Level, Ranges,
+                             NestingLevel);
 }
 
 DiagnosticNoteRenderer::~DiagnosticNoteRenderer() = default;

--- a/clang/lib/Frontend/SARIFDiagnostic.cpp
+++ b/clang/lib/Frontend/SARIFDiagnostic.cpp
@@ -39,7 +39,7 @@ SARIFDiagnostic::SARIFDiagnostic(raw_ostream &OS, const LangOptions &LangOpts,
 void SARIFDiagnostic::emitDiagnosticMessage(
     FullSourceLoc Loc, PresumedLoc PLoc, DiagnosticsEngine::Level Level,
     StringRef Message, ArrayRef<clang::CharSourceRange> Ranges,
-    DiagOrStoredDiag D) {
+    unsigned NestingLevel, DiagOrStoredDiag D) {
 
   const auto *Diag = D.dyn_cast<const Diagnostic *>();
 

--- a/clang/lib/Frontend/SARIFDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/SARIFDiagnosticPrinter.cpp
@@ -74,6 +74,7 @@ void SARIFDiagnosticPrinter::HandleDiagnostic(DiagnosticsEngine::Level Level,
 
   SARIFDiag->emitDiagnostic(
       FullSourceLoc(Info.getLocation(), Info.getSourceManager()), Level,
-      DiagMessageStream.str(), Info.getRanges(), Info.getFixItHints(), &Info);
+      DiagMessageStream.str(), Info.getRanges(), Info.getFixItHints(),
+      Info.getNestingLevel(), &Info);
 }
 } // namespace clang

--- a/clang/lib/Frontend/SerializedDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/SerializedDiagnosticPrinter.cpp
@@ -671,8 +671,7 @@ void SDiagsWriter::EmitDiagnosticMessage(FullSourceLoc Loc, PresumedLoc PLoc,
 void SDiagsRenderer::emitDiagnosticMessage(
     FullSourceLoc Loc, PresumedLoc PLoc, DiagnosticsEngine::Level Level,
     StringRef Message, ArrayRef<clang::CharSourceRange> Ranges,
-    unsigned NestingLevel,
-    DiagOrStoredDiag D) {
+    unsigned NestingLevel, DiagOrStoredDiag D) {
   Writer.EmitDiagnosticMessage(Loc, PLoc, Level, Message, D);
 }
 

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -69,9 +69,6 @@ static void applyTemplateHighlighting(raw_ostream &OS, StringRef Str,
   }
 }
 
-/// Number of spaces to indent when word-wrapping.
-constexpr unsigned WordWrapIndentation = 4;
-
 /// Number of spaces per indent level.
 constexpr unsigned IndentWidth = 4;
 
@@ -657,6 +654,7 @@ static bool printWordWrapped(raw_ostream &OS, StringRef Str, unsigned Columns,
 
     // This word does not fit on the current line, so wrap to the next
     // line.
+    unsigned WordWrapIndentation = FancyFormat ? 4 : 6;
     OS << '\n';
     startLineImpl(OS, BaseIndent + WordWrapIndentation, FancyFormat);
     applyTemplateHighlighting(OS, Str.substr(WordStart, WordLength),

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -697,10 +697,13 @@ void TextDiagnostic::emitDiagnosticMessage(
 
   // The fancy format prints things in a different order.
   if (DiagOpts.getFormat() == TextDiagnosticFormat::Fancy) {
-    if (NestingLevel == 0)
-      startLine();
-    else
+    if (NestingLevel == 0) {
+      if (LastLevel != DiagnosticsEngine::Ignored)
+        OS << "\n";
+    } else {
+      emptyLine();
       OS << '|' << std::string(BaseIndent - 2, '-') << ' ';
+    }
 
     printDiagnosticLevel(OS, Level, DiagOpts.ShowColors);
     printDiagnosticMessage(OS,
@@ -724,9 +727,9 @@ void TextDiagnostic::emitDiagnosticMessage(
       emitDiagnosticLoc(Loc, PLoc, Level, Ranges);
       OS.resetColor();
       OS << '\n';
-      emptyLine();
     }
 
+    emptyLine();
     return;
   }
 
@@ -846,10 +849,6 @@ void TextDiagnostic::beginDiagnostic(DiagOrStoredDiag D,
   if (DiagOpts.getFormat() == TextDiagnosticFormat::Fancy) {
     BaseIndent = std::min(NestingLevel * IndentWidth, MaxIndentWidth);
     IncludeStack.clear();
-    if (NestingLevel != 0)
-      startLine();
-    if (LastLevel != DiagnosticsEngine::Ignored)
-      OS << "\n";
   }
 }
 

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -73,7 +73,10 @@ static void applyTemplateHighlighting(raw_ostream &OS, StringRef Str,
 constexpr unsigned IndentWidth = 4;
 
 /// Maximum indentation level.
-constexpr unsigned MaxIndentWidth = 6 * IndentWidth;
+constexpr unsigned MaxIndentLvl = 10;
+
+/// Maximum indent width.
+constexpr unsigned MaxIndentWidth = MaxIndentLvl * IndentWidth;
 
 static int bytesSincePreviousTabOrLineBegin(StringRef SourceLine, size_t i) {
   int bytes = 0;

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -694,8 +694,7 @@ void TextDiagnostic::startLine(unsigned Indent = 0) {
 void TextDiagnostic::emitDiagnosticMessage(
     FullSourceLoc Loc, PresumedLoc PLoc, DiagnosticsEngine::Level Level,
     StringRef Message, ArrayRef<clang::CharSourceRange> Ranges,
-    unsigned NestingLevel,
-    DiagOrStoredDiag D) {
+    unsigned NestingLevel, DiagOrStoredDiag D) {
   uint64_t StartOfLocationInfo = OS.tell();
 
   // The fancy format prints things in a different order.

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -70,7 +70,13 @@ static void applyTemplateHighlighting(raw_ostream &OS, StringRef Str,
 }
 
 /// Number of spaces to indent when word-wrapping.
-const unsigned WordWrapIndentation = 6;
+constexpr unsigned WordWrapIndentation = 4;
+
+/// Number of spaces per indent level.
+constexpr unsigned IndentWidth = 4;
+
+/// Maximum indentation level.
+constexpr unsigned MaxIndentWidth = 6 * IndentWidth;
 
 static int bytesSincePreviousTabOrLineBegin(StringRef SourceLine, size_t i) {
   int bytes = 0;
@@ -604,7 +610,10 @@ static unsigned findEndOfWord(unsigned Start, StringRef Str,
 /// \returns true if word-wrapping was required, or false if the
 /// string fit on the first line.
 static bool printWordWrapped(raw_ostream &OS, StringRef Str, unsigned Columns,
-                             unsigned Column, bool Bold) {
+                             unsigned Column, bool Bold, unsigned NestingLevel) {
+  unsigned BaseIndent = std::min(NestingLevel * IndentWidth, MaxIndentWidth);
+  Columns -= BaseIndent;
+
   const unsigned Length = std::min(Str.find('\n'), Str.size());
   bool TextNormal = true;
 
@@ -636,7 +645,7 @@ static bool printWordWrapped(raw_ostream &OS, StringRef Str, unsigned Columns,
     // This word does not fit on the current line, so wrap to the next
     // line.
     OS << '\n';
-    OS.indent(WordWrapIndentation);
+    OS.indent(BaseIndent + WordWrapIndentation);
     applyTemplateHighlighting(OS, Str.substr(WordStart, WordLength),
                               TextNormal, Bold);
     Column = WordWrapIndentation + WordLength;
@@ -661,8 +670,40 @@ TextDiagnostic::~TextDiagnostic() {}
 void TextDiagnostic::emitDiagnosticMessage(
     FullSourceLoc Loc, PresumedLoc PLoc, DiagnosticsEngine::Level Level,
     StringRef Message, ArrayRef<clang::CharSourceRange> Ranges,
+    unsigned NestingLevel,
     DiagOrStoredDiag D) {
   uint64_t StartOfLocationInfo = OS.tell();
+
+  // The fancy format prints things in a different order.
+  if (DiagOpts.getFormat() == TextDiagnosticFormat::Fancy) {
+    OS.indent(BaseIndent);
+
+    printDiagnosticLevel(OS, Level, DiagOpts.ShowColors);
+    printDiagnosticMessage(OS,
+                           /*IsSupplemental*/ Level == DiagnosticsEngine::Note,
+                           Message, OS.tell() - StartOfLocationInfo,
+                           DiagOpts.MessageLength, DiagOpts.ShowColors,
+                           NestingLevel);
+
+    if (DiagOpts.ShowLocation && Loc.isValid()) {
+      OS << '\n';
+      for (auto [Loc, PLoc] : IncludeStack) {
+        OS.indent(BaseIndent + 6);
+        OS << "- included from ";
+        emitDiagnosticLoc(Loc, PLoc, Level, /*Ranges=*/{});
+        OS.resetColor();
+        OS << '\n';
+      }
+
+      OS.indent(BaseIndent + 6);
+      OS << "- at ";
+      emitDiagnosticLoc(Loc, PLoc, Level, Ranges);
+      OS.resetColor();
+      OS << "\n\n";
+    }
+
+    return;
+  }
 
   // Emit the location of this particular diagnostic.
   if (Loc.isValid())
@@ -676,7 +717,8 @@ void TextDiagnostic::emitDiagnosticMessage(
   printDiagnosticMessage(OS,
                          /*IsSupplemental*/ Level == DiagnosticsEngine::Note,
                          Message, OS.tell() - StartOfLocationInfo,
-                         DiagOpts.MessageLength, DiagOpts.ShowColors);
+                         DiagOpts.MessageLength, DiagOpts.ShowColors,
+                         /*NestingLevel=*/0);
 }
 
 /*static*/ void
@@ -715,7 +757,8 @@ void TextDiagnostic::printDiagnosticMessage(raw_ostream &OS,
                                             bool IsSupplemental,
                                             StringRef Message,
                                             unsigned CurrentColumn,
-                                            unsigned Columns, bool ShowColors) {
+                                            unsigned Columns, bool ShowColors,
+                                            unsigned NestingLevel) {
   bool Bold = false;
   if (ShowColors && !IsSupplemental) {
     // Print primary diagnostic messages in bold and without color, to visually
@@ -725,7 +768,7 @@ void TextDiagnostic::printDiagnosticMessage(raw_ostream &OS,
   }
 
   if (Columns)
-    printWordWrapped(OS, Message, Columns, CurrentColumn, Bold);
+    printWordWrapped(OS, Message, Columns, CurrentColumn, Bold, NestingLevel);
   else {
     bool Normal = true;
     applyTemplateHighlighting(OS, Message, Normal, Bold);
@@ -773,6 +816,20 @@ void TextDiagnostic::emitFilename(StringRef Filename, const SourceManager &SM) {
   OS << Filename;
 }
 
+void TextDiagnostic::beginDiagnostic(DiagOrStoredDiag D,
+                                     DiagnosticsEngine::Level Level,
+                                     unsigned NestingLevel) {
+  if (DiagOpts.getFormat() == TextDiagnosticFormat::Fancy) {
+    BaseIndent = std::min(NestingLevel * IndentWidth, MaxIndentWidth);
+    IncludeStack.clear();
+    if (LastLevel != DiagnosticsEngine::Ignored)
+      OS << "\n";
+  }
+}
+
+void TextDiagnostic::endDiagnostic(DiagOrStoredDiag D,
+                                   DiagnosticsEngine::Level Level) {}
+
 /// Print out the file/line/column information and include trace.
 ///
 /// This method handles the emission of the diagnostic location information.
@@ -804,6 +861,7 @@ void TextDiagnostic::emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,
   switch (DiagOpts.getFormat()) {
   case DiagnosticOptions::SARIF:
   case DiagnosticOptions::Clang:
+  case DiagnosticOptions::Fancy:
     if (DiagOpts.ShowLine)
       OS << ':' << LineNo;
     break;
@@ -827,6 +885,7 @@ void TextDiagnostic::emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,
   switch (DiagOpts.getFormat()) {
   case DiagnosticOptions::SARIF:
   case DiagnosticOptions::Clang:
+  case DiagnosticOptions::Fancy:
   case DiagnosticOptions::Vi:    OS << ':';    break;
   case DiagnosticOptions::MSVC:
     // MSVC2013 and before print 'file(4) : error'. MSVC2015 gets rid of the
@@ -879,7 +938,18 @@ void TextDiagnostic::emitDiagnosticLoc(FullSourceLoc Loc, PresumedLoc PLoc,
 }
 
 void TextDiagnostic::emitIncludeLocation(FullSourceLoc Loc, PresumedLoc PLoc) {
-  if (DiagOpts.ShowLocation && PLoc.isValid()) {
+  if (!DiagOpts.ShowLocation)
+    return;
+
+  if (DiagOpts.getFormat() == TextDiagnosticFormat::Fancy) {
+    if (!PLoc.isValid())
+      return;
+
+    IncludeStack.emplace_back(Loc, PLoc);
+    return;
+  }
+
+  if (PLoc.isValid()) {
     OS << "In file included from ";
     emitFilename(PLoc.getFilename(), Loc.getManager());
     OS << ':' << PLoc.getLine() << ":\n";
@@ -1340,7 +1410,7 @@ void TextDiagnostic::emitSnippetAndCaret(
           : 0;
   auto indentForLineNumbers = [&] {
     if (MaxLineNoDisplayWidth > 0)
-      OS.indent(MaxLineNoDisplayWidth + 2) << "| ";
+      OS.indent(BaseIndent + MaxLineNoDisplayWidth + 2) << "| ";
   };
 
   // Prepare source highlighting information for the lines we're about to
@@ -1451,7 +1521,7 @@ void TextDiagnostic::emitSnippet(StringRef SourceLine,
   // Emit line number.
   if (MaxLineNoDisplayWidth > 0) {
     unsigned LineNoDisplayWidth = getNumDisplayWidth(DisplayLineNo);
-    OS.indent(MaxLineNoDisplayWidth - LineNoDisplayWidth + 1)
+    OS.indent(BaseIndent + MaxLineNoDisplayWidth - LineNoDisplayWidth + 1)
         << DisplayLineNo << " | ";
   }
 

--- a/clang/lib/Frontend/TextDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/TextDiagnosticPrinter.cpp
@@ -137,7 +137,10 @@ void TextDiagnosticPrinter::HandleDiagnostic(DiagnosticsEngine::Level Level,
     TextDiagnostic::printDiagnosticMessage(
         OS, /*IsSupplemental=*/Level == DiagnosticsEngine::Note,
         DiagMessageStream.str(), OS.tell() - StartOfLocationInfo,
-        DiagOpts.MessageLength, DiagOpts.ShowColors);
+        DiagOpts.MessageLength, DiagOpts.ShowColors,
+        DiagOpts.getFormat() == TextDiagnosticFormat::Fancy
+            ? Info.getNestingLevel()
+            : 0);
     OS.flush();
     return;
   }
@@ -149,7 +152,8 @@ void TextDiagnosticPrinter::HandleDiagnostic(DiagnosticsEngine::Level Level,
 
   TextDiag->emitDiagnostic(
       FullSourceLoc(Info.getLocation(), Info.getSourceManager()), Level,
-      DiagMessageStream.str(), Info.getRanges(), Info.getFixItHints());
+      DiagMessageStream.str(), Info.getRanges(), Info.getFixItHints(),
+      Info.getNestingLevel(), &Info);
 
   OS.flush();
 }

--- a/clang/lib/Frontend/TextDiagnosticPrinter.cpp
+++ b/clang/lib/Frontend/TextDiagnosticPrinter.cpp
@@ -133,14 +133,13 @@ void TextDiagnosticPrinter::HandleDiagnostic(DiagnosticsEngine::Level Level,
   // diagnostics in a context that lacks language options, a source manager, or
   // other infrastructure necessary when emitting more rich diagnostics.
   if (!Info.getLocation().isValid()) {
+    bool FancyFormat = DiagOpts.getFormat() == TextDiagnosticFormat::Fancy;
     TextDiagnostic::printDiagnosticLevel(OS, Level, DiagOpts.ShowColors);
     TextDiagnostic::printDiagnosticMessage(
         OS, /*IsSupplemental=*/Level == DiagnosticsEngine::Note,
         DiagMessageStream.str(), OS.tell() - StartOfLocationInfo,
         DiagOpts.MessageLength, DiagOpts.ShowColors,
-        DiagOpts.getFormat() == TextDiagnosticFormat::Fancy
-            ? Info.getNestingLevel()
-            : 0);
+        FancyFormat ? Info.getNestingLevel() : 0, FancyFormat);
     OS.flush();
     return;
   }

--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -2355,10 +2355,8 @@ static void DiagnoseNonTriviallyCopyableReason(Sema &SemaRef,
   if (D->hasDefinition())
     DiagnoseNonTriviallyCopyableReason(SemaRef, Loc, D);
 
-  {
-    DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{SemaRef.Diags};
-    SemaRef.Diag(D->getLocation(), diag::note_defined_here) << D;
-  }
+  IncrementNestingLevel.Increment();
+  SemaRef.Diag(D->getLocation(), diag::note_defined_here) << D;
 }
 
 static void DiagnoseNonAssignableReason(Sema &SemaRef, SourceLocation Loc,
@@ -2452,7 +2450,7 @@ static void DiagnoseIsEmptyReason(Sema &S, SourceLocation Loc, QualType T) {
   if (auto *D = T->getAsCXXRecordDecl()) {
     if (D->hasDefinition()) {
       DiagnoseIsEmptyReason(S, Loc, D);
-      DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{S.Diags};
+      IncrementNestingLevel.Increment();
       S.Diag(D->getLocation(), diag::note_defined_here) << D;
     }
   }

--- a/clang/lib/Sema/SemaTypeTraits.cpp
+++ b/clang/lib/Sema/SemaTypeTraits.cpp
@@ -2343,6 +2343,7 @@ static void DiagnoseNonTriviallyCopyableReason(Sema &SemaRef,
   SemaRef.Diag(Loc, diag::note_unsatisfied_trait)
       << T << diag::TraitName::TriviallyCopyable;
 
+  DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{SemaRef.Diags};
   if (T->isReferenceType())
     SemaRef.Diag(Loc, diag::note_unsatisfied_trait_reason)
         << diag::TraitNotSatisfiedReason::Ref;
@@ -2354,7 +2355,10 @@ static void DiagnoseNonTriviallyCopyableReason(Sema &SemaRef,
   if (D->hasDefinition())
     DiagnoseNonTriviallyCopyableReason(SemaRef, Loc, D);
 
-  SemaRef.Diag(D->getLocation(), diag::note_defined_here) << D;
+  {
+    DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{SemaRef.Diags};
+    SemaRef.Diag(D->getLocation(), diag::note_defined_here) << D;
+  }
 }
 
 static void DiagnoseNonAssignableReason(Sema &SemaRef, SourceLocation Loc,
@@ -2371,6 +2375,7 @@ static void DiagnoseNonAssignableReason(Sema &SemaRef, SourceLocation Loc,
   auto LHS = createDeclValExpr(T);
   auto RHS = createDeclValExpr(U);
 
+  DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{SemaRef.Diags};
   EnterExpressionEvaluationContext Unevaluated(
       SemaRef, Sema::ExpressionEvaluationContext::Unevaluated);
   Sema::ContextRAII TUContext(SemaRef,
@@ -2431,6 +2436,7 @@ static void DiagnoseIsEmptyReason(Sema &S, SourceLocation Loc,
 static void DiagnoseIsEmptyReason(Sema &S, SourceLocation Loc, QualType T) {
   // Emit primary "not empty" diagnostic.
   S.Diag(Loc, diag::note_unsatisfied_trait) << T << diag::TraitName::Empty;
+  DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{S.Diags};
 
   // While diagnosing is_empty<T>, we want to look at the actual type, not a
   // reference or an array of it. So we need to massage the QualType param to
@@ -2446,6 +2452,7 @@ static void DiagnoseIsEmptyReason(Sema &S, SourceLocation Loc, QualType T) {
   if (auto *D = T->getAsCXXRecordDecl()) {
     if (D->hasDefinition()) {
       DiagnoseIsEmptyReason(S, Loc, D);
+      DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{S.Diags};
       S.Diag(D->getLocation(), diag::note_defined_here) << D;
     }
   }

--- a/clang/test/Frontend/Inputs/a.h
+++ b/clang/test/Frontend/Inputs/a.h
@@ -1,0 +1,3 @@
+#include "b.h"
+
+undefined_a;

--- a/clang/test/Frontend/Inputs/b.h
+++ b/clang/test/Frontend/Inputs/b.h
@@ -1,0 +1,3 @@
+#include "c.h"
+
+undefined_b;

--- a/clang/test/Frontend/Inputs/c.h
+++ b/clang/test/Frontend/Inputs/c.h
@@ -1,0 +1,1 @@
+undefined_c;

--- a/clang/test/Frontend/fancy-diags-format.cpp
+++ b/clang/test/Frontend/fancy-diags-format.cpp
@@ -1,0 +1,170 @@
+// RUN: not %clang -fdiagnostics-format=fancy -fsyntax-only -ferror-limit=0 %s 2>&1 | FileCheck %s --strict-whitespace
+
+#define FOO BAR
+#define BAR BAZ
+#define BAZ undefined
+
+struct X { int x; };
+struct Y { Y(const Y&); };
+
+void g() {
+  FOO
+}
+
+static_assert(__is_assignable(int&, void));
+static_assert(__is_empty(X&));
+static_assert(__is_trivially_copyable(Y));
+
+#include "Inputs/a.h"
+
+// CHECK: error: use of undeclared identifier 'undefined'
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - at {{.*}}fancy-diags-format.cpp:11:3:
+// CHECK-NEXT: |
+// CHECK-NEXT: |  11 |   FOO
+// CHECK-NEXT: |     |   ^~~
+// CHECK-NEXT: |
+// CHECK-NEXT: |-- note: expanded from macro 'FOO'
+// CHECK-NEXT: |
+// CHECK-NEXT: |         - at {{.*}}fancy-diags-format.cpp:3:13:
+// CHECK-NEXT: |
+// CHECK-NEXT: |       3 | #define FOO BAR
+// CHECK-NEXT: |         |             ^~~
+// CHECK-NEXT: |
+// CHECK-NEXT: |-- note: expanded from macro 'BAR'
+// CHECK-NEXT: |
+// CHECK-NEXT: |         - at {{.*}}fancy-diags-format.cpp:4:13:
+// CHECK-NEXT: |
+// CHECK-NEXT: |       4 | #define BAR BAZ
+// CHECK-NEXT: |         |             ^~~
+// CHECK-NEXT: |
+// CHECK-NEXT: |-- note: expanded from macro 'BAZ'
+// CHECK-NEXT: |
+// CHECK-NEXT: |         - at {{.*}}fancy-diags-format.cpp:5:13:
+// CHECK-NEXT: |
+// CHECK-NEXT: |       5 | #define BAZ undefined
+// CHECK-NEXT: |         |             ^~~~~~~~~
+// CHECK-EMPTY:
+
+// CHECK: error: static assertion failed due to requirement '__is_assignable(int &, void)'
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - at {{.*}}fancy-diags-format.cpp:14:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |  14 | static_assert(__is_assignable(int&, void));
+// CHECK-NEXT: |     |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: |
+// CHECK-NEXT: |-- error: assigning to 'int' from incompatible type 'void'
+// CHECK-NEXT: |
+// CHECK-NEXT: |         - at {{.*}}fancy-diags-format.cpp:14:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |      14 | static_assert(__is_assignable(int&, void));
+// CHECK-NEXT: |         |               ^~~~~~~~~~~~~~~
+// CHECK-EMPTY:
+
+// CHECK: error: static assertion failed due to requirement '__is_empty(X &)'
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - at {{.*}}fancy-diags-format.cpp:15:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |  15 | static_assert(__is_empty(X&));
+// CHECK-NEXT: |     |               ^~~~~~~~~~~~~~
+// CHECK-NEXT: |
+// CHECK-NEXT: |-- note: 'X &' is not empty
+// CHECK-NEXT: |
+// CHECK-NEXT: |         - at {{.*}}fancy-diags-format.cpp:15:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |
+// CHECK-NEXT: |------ note: because it is a reference type
+// CHECK-NEXT: |
+// CHECK-NEXT: |             - at {{.*}}fancy-diags-format.cpp:15:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |
+// CHECK-NEXT: |------ note: because it has a non-static data member 'x' of type 'int'
+// CHECK-NEXT: |
+// CHECK-NEXT: |             - at {{.*}}fancy-diags-format.cpp:15:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |           7 | struct X { int x; };
+// CHECK-NEXT: |             |            ~~~~~
+// CHECK-NEXT: |           8 | struct Y { Y(const Y&); };
+// CHECK-NEXT: |           9 |
+// CHECK-NEXT: |          10 | void g() {
+// CHECK-NEXT: |          11 |   FOO
+// CHECK-NEXT: |          12 | }
+// CHECK-NEXT: |          13 |
+// CHECK-NEXT: |          14 | static_assert(__is_assignable(int&, void));
+// CHECK-NEXT: |          15 | static_assert(__is_empty(X&));
+// CHECK-NEXT: |             |               ^
+// CHECK-NEXT: |
+// CHECK-NEXT: |---------- note: 'X' defined here
+// CHECK-NEXT: |
+// CHECK-NEXT: |                 - at {{.*}}fancy-diags-format.cpp:7:8:
+// CHECK-NEXT: |
+// CHECK-NEXT: |               7 | struct X { int x; };
+// CHECK-NEXT: |                 |        ^
+// CHECK-EMPTY:
+
+// CHECK: error: static assertion failed due to requirement '__is_trivially_copyable(Y)'
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - at {{.*}}fancy-diags-format.cpp:16:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |  16 | static_assert(__is_trivially_copyable(Y));
+// CHECK-NEXT: |     |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
+// CHECK-NEXT: |
+// CHECK-NEXT: |-- note: 'Y' is not trivially copyable
+// CHECK-NEXT: |
+// CHECK-NEXT: |         - at {{.*}}fancy-diags-format.cpp:16:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |
+// CHECK-NEXT: |------ note: because it has a user provided copy constructor
+// CHECK-NEXT: |
+// CHECK-NEXT: |             - at {{.*}}fancy-diags-format.cpp:16:15:
+// CHECK-NEXT: |
+// CHECK-NEXT: |           8 | struct Y { Y(const Y&); };
+// CHECK-NEXT: |             |            ~~~~~~~~~~~
+// CHECK-NEXT: |           9 |
+// CHECK-NEXT: |          10 | void g() {
+// CHECK-NEXT: |          11 |   FOO
+// CHECK-NEXT: |          12 | }
+// CHECK-NEXT: |          13 |
+// CHECK-NEXT: |          14 | static_assert(__is_assignable(int&, void));
+// CHECK-NEXT: |          15 | static_assert(__is_empty(X&));
+// CHECK-NEXT: |          16 | static_assert(__is_trivially_copyable(Y));
+// CHECK-NEXT: |             |               ^
+// CHECK-NEXT: |
+// CHECK-NEXT: |---------- note: 'Y' defined here
+// CHECK-NEXT: |
+// CHECK-NEXT: |                 - at {{.*}}fancy-diags-format.cpp:8:8:
+// CHECK-NEXT: |
+// CHECK-NEXT: |               8 | struct Y { Y(const Y&); };
+// CHECK-NEXT: |                 |        ^
+// CHECK-EMPTY:
+
+// CHECK: error: a type specifier is required for all declarations
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - included from {{.*}}fancy-diags-format.cpp:18:10:
+// CHECK-NEXT: |     - included from {{.*}}a.h:1:10:
+// CHECK-NEXT: |     - included from {{.*}}b.h:1:10:
+// CHECK-NEXT: |     - at {{.*}}c.h:1:1:
+// CHECK-NEXT: |
+// CHECK-NEXT: |   1 | undefined_c;
+// CHECK-NEXT: |     | ^
+// CHECK-EMPTY:
+
+// CHECK: error: a type specifier is required for all declarations
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - included from {{.*}}fancy-diags-format.cpp:18:10:
+// CHECK-NEXT: |     - included from {{.*}}a.h:1:10:
+// CHECK-NEXT: |     - at {{.*}}b.h:3:1:
+// CHECK-NEXT: |
+// CHECK-NEXT: |   3 | undefined_b;
+// CHECK-NEXT: |     | ^
+// CHECK-EMPTY:
+
+// CHECK: error: a type specifier is required for all declarations
+// CHECK-NEXT: |
+// CHECK-NEXT: |     - included from {{.*}}fancy-diags-format.cpp:18:10:
+// CHECK-NEXT: |     - at {{.*}}a.h:3:1:
+// CHECK-NEXT: |
+// CHECK-NEXT: |   3 | undefined_a;
+// CHECK-NEXT: |     | ^
+
+// CHECK-NEXT: {{.*}} errors generated.

--- a/clang/tools/libclang/CIndexDiagnostic.cpp
+++ b/clang/tools/libclang/CIndexDiagnostic.cpp
@@ -89,7 +89,8 @@ public:
   ~CXDiagnosticRenderer() override {}
 
   void beginDiagnostic(DiagOrStoredDiag D,
-                       DiagnosticsEngine::Level Level) override {
+                       DiagnosticsEngine::Level Level,
+                       unsigned NestingLevel) override {
 
     const StoredDiagnostic *SD =
         dyn_cast_if_present<const StoredDiagnostic *>(D);
@@ -110,6 +111,7 @@ public:
   void emitDiagnosticMessage(FullSourceLoc Loc, PresumedLoc PLoc,
                              DiagnosticsEngine::Level Level, StringRef Message,
                              ArrayRef<CharSourceRange> Ranges,
+                             unsigned NestingLevel,
                              DiagOrStoredDiag D) override {
     if (!D.isNull())
       return;

--- a/clang/tools/libclang/CIndexDiagnostic.cpp
+++ b/clang/tools/libclang/CIndexDiagnostic.cpp
@@ -88,8 +88,7 @@ public:
 
   ~CXDiagnosticRenderer() override {}
 
-  void beginDiagnostic(DiagOrStoredDiag D,
-                       DiagnosticsEngine::Level Level,
+  void beginDiagnostic(DiagOrStoredDiag D, DiagnosticsEngine::Level Level,
                        unsigned NestingLevel) override {
 
     const StoredDiagnostic *SD =


### PR DESCRIPTION
This patch consists of two main parts: the addition of nesting information to the diagnostics (engine) and consumers, as well as a new diagnostics output format to take advantage of that information.

## Nesting
`Diagnostic`, `StoredDiagnostic`, and `DiagnosticStorage` now have a `NestingLevel` member, which is an (optional) `unsigned` value. The diagnostics engine keeps track of a ‘global nesting level’, which can be incremented via an RAII object; when a diagnostic is emitted (i.e. passed to the `DiagnosticConsumer`), the nesting level of the diagnostic is set to the current global nesting level (or that level +1 if it is a note). This means that, by default, the nesting level is `1` for note and `0` for any other type of diagnostic.

`StoredDiagnostic` and `DiagnosticStorage` store an `UnsignedOrNone`, which is unset if the nesting level hasn’t been computed yet; if set, the nesting level will not be recomputed when the diagnostic is emitted. This is to allow diagnostic consumers to store diagnostics and emit them later on without altering their nesting level.

### How to Make Use of Nesting
On the consumer side, in and of itself, the nesting level does nothing; it is up to diagnostic consumers to make use of it.

On the producer side, the intended (and indeed only) way to nest diagnostics is to use the RAII object provided by this patch; I’ve introduced nesting to a few of the `DiagnoseTypeTraitDetails` diagnostics since they were previously pointed out to me as being good candidates for this. An example of this is the following:
```diff
 static void DiagnoseNonTriviallyCopyableReason(Sema &SemaRef,
                                                SourceLocation Loc, QualType T) {
   SemaRef.Diag(Loc, diag::note_unsatisfied_trait)
       << T << diag::TraitName::TriviallyCopyable;

+  DiagnosticsEngine::NestingLevelRAII IncrementNestingLevel{SemaRef.Diags};
   if (T->isReferenceType())
     SemaRef.Diag(Loc, diag::note_unsatisfied_trait_reason)
         << diag::TraitNotSatisfiedReason::Ref;

   const CXXRecordDecl *D = T->getAsCXXRecordDecl();
   if (!D || D->isInvalidDecl())
     return;

   if (D->hasDefinition())
     DiagnoseNonTriviallyCopyableReason(SemaRef, Loc, D);

+  IncrementNestingLevel.Increment();
   SemaRef.Diag(D->getLocation(), diag::note_defined_here) << D;
 }
``` 

(The `Increment()` function allows ‘reusing’ an RAII object rather than having to create a new one every time you want to increment the nesting level. It’s possible to make do w/o it by just adding another scope—which is what I did initially—but I ended up including it because after migrating a mere 4 or so functions, I was already using it in 2 places, so chances are there will be a quite a few more cases where it will come in handy...)

Basically, if you know you’re about to emit diagnostics which you’d like to be more deeply nested, you simply increment the global nesting level, and then any code after that doesn’t have to know or care about what nesting level it’s at. This is also (currently) the only way to alter the nesting level of a diagnostic. The intention of this is to make it possible to introduce nesting without having to fundamentally alter the way (or order) in which diagnostics are emitted—though of course, there will most likely be places where we will want to perform some amount of rearranging or grouping to take full advantage of nesting.

I briefly experimented with making it possible to write something along the lines of `Diag(...) << diag::AddNestingLevel(1)`, which would add an increment to the nesting level of a single diagnostic, but I found the RAII object to be both simpler to implement and easier to reason about. One thing we *definitely* don’t want to start doing is setting the nesting level to an absolute value (e.g. `Diag(...) << diag::SetNestingLevel(5)` or whatever), since that would break in the presence of recursive nesting.

## ‘Fancy’ Diagnostics Format
Pass `-fdiagnostics-format=fancy` to enable it. If someone can think of a better name for this, please let me know (note: I didn’t want to call this the ‘nested’ diagnostic format or anything like that because it does more than just add nesting).

While we could simply update the existing text diagnostic printer to e.g. indent diagnostics by some amount for each nesting level, I don’t think this is a good idea: the current format is fairly well-established, and I wouldn’t be surprised if doing even something as simple as adding leading indentation would mess with systems that expect `<file>:<line>:<col>: error:` at the start of a line.

Moreover, I would argue that our current default format has a few shortcomings, though this might be fairly subjective (a while back I did look into a few papers about writing ergonomic diagnostics in the course of this, but I don’t consider this to be an exact science...); e.g. consider this diagnostic:
```console
In file included from test.cc:17:
/usr/lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/variant:103:21: error: static assertion failed due to requirement '2UL < sizeof...(_Types)'
  103 |       static_assert(_Np < sizeof...(_Types));
      |                     ^~~~~~~~~~~~~~~~~~~~~~~
```
I’d argue that the first thing you’d probably want to see when looking at a compiler error is the actual error message, but in our current format, you first have to make it past the include stack and the file path; in this case, the path is so long that the error message flows off the screen (I’ve been working on improving that part too, but it’s turned out to be more complicated than expected; see #148745 for that).

### New Format: Example
So, what I suggest we do instead is add a completely new format which can both make use of nesting and hopefully be a bit more ergonomic. In the present version of this format, the error above would end up being formatted as
```console
error: static assertion failed due to requirement '2UL < sizeof...(_Types)'
|
|     - included from test.cc:17:10: 
|     - at /usr/lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/variant:103:21: 
|
| 103 |       static_assert(_Np < sizeof...(_Types));
|     |                     ^~~~~~~~~~~~~~~~~~~~~~~
```
which I would argue is a bit clearer structurally speaking. Of course, this is just what I’ve managed to arrive at; if anyone has any suggestions as to how to improve on this (or if you find it completely unreadable or don’t like it at all), please let me know.

### Connecting Lines
The line in the first column might seem a bit odd in isolation, but it’s there to join to any nested diagnostics following it, e.g.
```console
error: static assertion failed due to requirement '__is_trivially_copyable(Y)'
|
|     - at test.cc:14:15: 
|
|  14 | static_assert(__is_trivially_copyable(Y));
|     |               ^~~~~~~~~~~~~~~~~~~~~~~~~~
|
|-- note: 'Y' is not trivially copyable
|
|         - at test.cc:14:15: 
|
|
|------ note: because it has a user provided copy constructor
|
|             - at test.cc:14:15: 
|
|           6 | struct Y { Y(const Y&); }; 
|             |            ~~~~~~~~~~~
|           7 | 
|           8 | void g() {
|           9 |     FOO
|          10 | }
|          11 | 
|          12 | static_assert(__is_assignable(int&, void));
|          13 | static_assert(__is_empty(X&));
|          14 | static_assert(__is_trivially_copyable(Y));
|             |               ^
|
|---------- note: 'Y' defined here
|
|                 - at test.cc:6:8: 
|
|               6 | struct Y { Y(const Y&); }; 
|                 |        ^
```

I will say, I personally prefer this *without* the lines connecting to the notes (I think just the nesting+spacing is enough), but @AaronBallman liked them so I’ve included them here.

### Alternative Formatting Ideas and Buffering
Certain more sophisticated formatting operations would require us to buffer diagnostics. Consider for instance a group of nested diagnostics that we might want to print in the following hypothetical format:
```console
A
|
|-- B
|   |
|   |-- C
|
|-- D
    |
    |-- E
```
Printing this is impossible without buffering: when printing `C`, we need to also print the `|` characters in the first column that make up the line connecting to `D`; conversely, when printing `E`, we *don’t* print any `|`s in the first column, because there is nothing else to connect to. The issue, clearly, is that we have no way of knowing whether there will be some future diagnostic that we need to draw a connecting line to... until we either see that diagnostic or another top-level diagnostic.

As a compromise, the current formatter resorts to printing a tree structure more similar to the following (the indentation is the same; it’s just the connecting lines that are different):
```console
A
|
|-- B
|   
|------ C
|
|-- D
|
|------ E
```

I personally don’t think this looks too good, but I don’t think we can do much better if we want to both draw connecting lines and avoid buffering. At the same time, my plan at least for this format is for us to progressively improve it, which might eventually entail buffering diagnostics. I’ve been experimenting with this and I think it’s not too hard to do, but I also feel like something like that is best left to a follow-up pr.

And just for comparison, if we were to get rid of the lines entirely, the error above would look like this:
```console
error: static assertion failed due to requirement '__is_trivially_copyable(Y)'

      - at test.cc:14:15:

   14 | static_assert(__is_trivially_copyable(Y));
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~

    note: 'Y' is not trivially copyable

          - at test.cc:14:15:


        note: because it has a user provided copy constructor

              - at test.cc:14:15:

            6 | struct Y { Y(const Y&); };
              |            ~~~~~~~~~~~
            7 |
            8 | void g() {
            9 |     FOO
           10 | }
           11 |
           12 | static_assert(__is_assignable(int&, void));
           13 | static_assert(__is_empty(X&));
           14 | static_assert(__is_trivially_copyable(Y));
              |               ^

            note: 'Y' defined here

                  - at test.cc:6:8:

                6 | struct Y { Y(const Y&); };
                  |        ^
```