### PR TITLE
[OpenMP] Use the `libc` malloc for AMDGPU if available

### DIFF
--- a/offload/DeviceRTL/src/State.cpp
+++ b/offload/DeviceRTL/src/State.cpp
@@ -50,7 +50,7 @@ namespace {
 ///
 ///{
 extern "C" {
-#ifdef __AMDGPU__
+#if defined(__AMDGPU__) && !defined(OMPTARGET_HAS_LIBC)
 
 [[gnu::weak]] void *malloc(size_t Size) { return allocator::alloc(Size); }
 [[gnu::weak]] void free(void *Ptr) { allocator::free(Ptr); }


### PR DESCRIPTION
Summary:
This patch enables the OpenMP runtime to use the general-purpose
`malloc` interface in `libc` if the user built OpenMP with it enabled.
All this requires is keeping `malloc` as an external function so it will
be resolved later by the linker.
