### PR TITLE
Fix llvm_process_sources to append source file properties instead of overriding it

### DIFF
--- a/llvm/cmake/modules/LLVMProcessSources.cmake
+++ b/llvm/cmake/modules/LLVMProcessSources.cmake
@@ -62,7 +62,10 @@ function(llvm_process_sources OUT_VAR)
     get_filename_component(suf ${fn} EXT)
     if("${suf}" STREQUAL ".cpp" OR "${suf}" STREQUAL ".c")
       get_filename_component(short_name ${fn} NAME)
-      set_source_files_properties(${fn} PROPERTIES COMPILE_DEFINITIONS "__SHORT_FILE__=\"${short_name}\"")
+      set_property(
+          SOURCE ${fn}
+          APPEND
+          PROPERTY COMPILE_DEFINITIONS __SHORT_FILE__="${short_name}")
     endif()
   endforeach()
 


### PR DESCRIPTION
This fixes the CLANG_VENDOR macro that disappeared because it is set using the same mechanism and one was overriding the other.