### PR TITLE
[LLD][COFF] Add support for ARM64X same-address thunks

### DIFF
--- a/lld/COFF/Chunks.cpp
+++ b/lld/COFF/Chunks.cpp
@@ -875,6 +875,19 @@ void RangeExtensionThunkARM64::writeTo(uint8_t *buf) const {
   applyArm64Imm(buf + 4, target->getRVA() & 0xfff, 0);
 }
 
+void SameAddressThunkARM64EC::setDynamicRelocs(COFFLinkerContext &ctx) const {
+  // Add ARM64X relocations replacing adrp/add instructions with a version using
+  // the hybrid target.
+  RangeExtensionThunkARM64 hybridView(ARM64EC, hybridTarget);
+  uint8_t buf[sizeof(arm64Thunk)];
+  hybridView.setRVA(rva);
+  hybridView.writeTo(buf);
+  uint32_t addrp = *reinterpret_cast<ulittle32_t *>(buf);
+  uint32_t add = *reinterpret_cast<ulittle32_t *>(buf + sizeof(uint32_t));
+  ctx.dynamicRelocs->set(this, addrp);
+  ctx.dynamicRelocs->set(Arm64XRelocVal(this, sizeof(uint32_t)), add);
+}
+
 LocalImportChunk::LocalImportChunk(COFFLinkerContext &c, Defined *s)
     : sym(s), ctx(c) {
   setAlignment(ctx.config.wordsize);
@@ -1258,7 +1271,8 @@ void DynamicRelocsChunk::finalize() {
 }
 
 // Set the reloc value. The reloc entry must be allocated beforehand.
-void DynamicRelocsChunk::set(uint32_t rva, Arm64XRelocVal value) {
+void DynamicRelocsChunk::set(Arm64XRelocVal offset, Arm64XRelocVal value) {
+  uint32_t rva = offset.get();
   auto entry =
       llvm::find_if(arm64xRelocs, [rva](const Arm64XDynamicRelocEntry &e) {
         return e.offset.get() == rva;

--- a/lld/COFF/Chunks.h
+++ b/lld/COFF/Chunks.h
@@ -193,6 +193,8 @@ public:
   // allowed ranges. Return the additional space required for the extension.
   virtual uint32_t extendRanges() { return 0; };
 
+  virtual Defined *getEntryThunk() const { return nullptr; };
+
   static bool classof(const Chunk *c) { return c->kind() >= OtherKind; }
 
 protected:
@@ -633,7 +635,7 @@ public:
   bool verifyRanges() override;
   uint32_t extendRanges() override;
 
-  Defined *exitThunk;
+  Defined *exitThunk = nullptr;
   Defined *sym = nullptr;
   bool extended = false;
 
@@ -673,6 +675,26 @@ public:
 
 private:
   MachineTypes machine;
+};
+
+// A chunk used to guarantee the same address for a function in both views of
+// a hybrid image. Similar to RangeExtensionThunkARM64 chunks, it calls the
+// target symbol using a BR instruction. It also contains an entry thunk for EC
+// compatibility and additional ARM64X relocations that swap targets between
+// views.
+class SameAddressThunkARM64EC : public RangeExtensionThunkARM64 {
+public:
+  explicit SameAddressThunkARM64EC(Defined *t, Defined *hybridTarget,
+                                   Defined *entryThunk)
+      : RangeExtensionThunkARM64(ARM64EC, t), hybridTarget(hybridTarget),
+        entryThunk(entryThunk) {}
+
+  Defined *getEntryThunk() const override { return entryThunk; }
+  void setDynamicRelocs(COFFLinkerContext &ctx) const;
+
+private:
+  Defined *hybridTarget;
+  Defined *entryThunk;
 };
 
 // Windows-specific.
@@ -843,13 +865,13 @@ class Arm64XRelocVal {
 public:
   Arm64XRelocVal(uint64_t value = 0) : value(value) {}
   Arm64XRelocVal(Defined *sym, int32_t offset = 0) : sym(sym), value(offset) {}
-  Arm64XRelocVal(Chunk *chunk, int32_t offset = 0)
+  Arm64XRelocVal(const Chunk *chunk, int32_t offset = 0)
       : chunk(chunk), value(offset) {}
   uint64_t get() const;
 
 private:
   Defined *sym = nullptr;
-  Chunk *chunk = nullptr;
+  const Chunk *chunk = nullptr;
   uint64_t value;
 };
 
@@ -884,7 +906,7 @@ public:
     arm64xRelocs.emplace_back(type, size, offset, value);
   }
 
-  void set(uint32_t rva, Arm64XRelocVal value);
+  void set(Arm64XRelocVal offset, Arm64XRelocVal value);
 
 private:
   std::vector<Arm64XDynamicRelocEntry> arm64xRelocs;
@@ -940,6 +962,8 @@ inline bool Chunk::isHotPatchable() const {
 inline Defined *Chunk::getEntryThunk() const {
   if (auto *c = dyn_cast<const SectionChunkEC>(this))
     return c->entryThunk;
+  if (auto *c = dyn_cast<const NonSectionChunk>(this))
+    return c->getEntryThunk();
   return nullptr;
 }
 

--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -223,6 +223,9 @@ struct Configuration {
   StringRef manifestUIAccess = "'false'";
   StringRef manifestFile;
 
+  // used for /arm64xsameaddress
+  std::vector<std::pair<Symbol *, Symbol *>> sameAddresses;
+
   // used for /dwodir
   StringRef dwoDir;
 

--- a/lld/COFF/Driver.h
+++ b/lld/COFF/Driver.h
@@ -214,6 +214,8 @@ private:
   void parsePDBPageSize(StringRef);
   void parseSection(StringRef);
 
+  void parseSameAddress(StringRef);
+
   // Parses a MS-DOS stub file
   void parseDosStub(StringRef path);
 

--- a/lld/COFF/MarkLive.cpp
+++ b/lld/COFF/MarkLive.cpp
@@ -49,7 +49,10 @@ void markLive(COFFLinkerContext &ctx) {
       addSym(file->impchkThunk->exitThunk);
   };
 
-  addSym = [&](Symbol *b) {
+  addSym = [&](Symbol *s) {
+    Defined *b = s->getDefined();
+    if (!b)
+      return;
     if (auto *sym = dyn_cast<DefinedRegular>(b)) {
       enqueue(sym->getChunk());
     } else if (auto *sym = dyn_cast<DefinedImportData>(b)) {

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -31,6 +31,9 @@ multiclass B_priv<string name> {
 def align   : P<"align", "Section alignment">;
 def aligncomm : P<"aligncomm", "Set common symbol alignment">;
 def alternatename : P<"alternatename", "Define weak alias">;
+def arm64xsameaddress
+    : P<"arm64xsameaddress", "Generate a thunk for the symbol with the same "
+                             "address in both native and EC views on ARM64X.">;
 def base    : P<"base", "Base address of the program">;
 def color_diagnostics: Flag<["--"], "color-diagnostics">,
     HelpText<"Alias for --color-diagnostics=always">;
@@ -373,4 +376,3 @@ def tlbid : P_priv<"tlbid">;
 def tlbout : P_priv<"tlbout">;
 def verbose_all : P_priv<"verbose">;
 def guardsym : P_priv<"guardsym">;
-def arm64xsameaddress : P_priv<"arm64xsameaddress">;

--- a/lld/COFF/SymbolTable.h
+++ b/lld/COFF/SymbolTable.h
@@ -31,6 +31,7 @@ class DefinedAbsolute;
 class DefinedRegular;
 class ImportThunkChunk;
 class LazyArchive;
+class SameAddressThunkARM64EC;
 class SectionChunk;
 class Symbol;
 
@@ -67,7 +68,7 @@ public:
   // Try to resolve any undefined symbols and update the symbol table
   // accordingly, then print an error message for any remaining undefined
   // symbols and warn about imported local symbols.
-  void resolveRemainingUndefines();
+  void resolveRemainingUndefines(std::vector<Undefined *> &aliases);
 
   // Try to resolve undefined symbols with alternate names.
   void resolveAlternateNames();
@@ -140,6 +141,7 @@ public:
   void addEntryThunk(Symbol *from, Symbol *to);
   void addExitThunk(Symbol *from, Symbol *to);
   void initializeECThunks();
+  void initializeSameAddressThunks();
 
   void reportDuplicate(Symbol *existing, InputFile *newFile,
                        SectionChunk *newSc = nullptr,
@@ -158,6 +160,8 @@ public:
 
   // A list of EC EXP+ symbols.
   std::vector<Symbol *> expSymbols;
+
+  std::vector<SameAddressThunkARM64EC *> sameAddressThunks;
 
   // A list of DLL exports.
   std::vector<Export> exports;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -314,6 +314,7 @@ private:
   uint32_t dataDirOffset64;
 
   OutputSection *textSec;
+  OutputSection *wowthkSec;
   OutputSection *hexpthkSec;
   OutputSection *bssSec;
   OutputSection *rdataSec;
@@ -1076,8 +1077,10 @@ void Writer::createSections() {
 
   // Try to match the section order used by link.exe.
   textSec = createSection(".text", code | r | x);
-  if (isArm64EC(ctx.config.machine))
+  if (isArm64EC(ctx.config.machine)) {
+    wowthkSec = createSection(".wowthk", code | r | x);
     hexpthkSec = createSection(".hexpthk", code | r | x);
+  }
   bssSec = createSection(".bss", bss | r | w);
   rdataSec = createSection(".rdata", data | r);
   buildidSec = createSection(".buildid", data | r);
@@ -1128,6 +1131,9 @@ void Writer::createSections() {
 
   if (hasIdata)
     locateImportTables();
+
+  for (auto thunk : ctx.symtab.sameAddressThunks)
+    wowthkSec->addChunk(thunk);
 
   // Then create an OutputSection for each section.
   // '$' and all following characters in input section names are
@@ -2310,6 +2316,14 @@ void Writer::createECChunks() {
       ctx.symtab.findUnderscore("__arm64x_redirection_metadata");
   replaceSymbol<DefinedSynthetic>(entryPointsSym, entryPointsSym->getName(),
                                   entryPoints);
+
+  for (auto thunk : ctx.symtab.sameAddressThunks) {
+    // Relocation values are set later in setECSymbols.
+    ctx.dynamicRelocs->add(IMAGE_DVRT_ARM64X_FIXUP_TYPE_VALUE, sizeof(uint32_t),
+                           thunk);
+    ctx.dynamicRelocs->add(IMAGE_DVRT_ARM64X_FIXUP_TYPE_VALUE, sizeof(uint32_t),
+                           Arm64XRelocVal(thunk, sizeof(uint32_t)));
+  }
 }
 
 // MinGW specific. Gather all relocations that are imported from a DLL even
@@ -2519,6 +2533,9 @@ void Writer::setECSymbols() {
           chpeSym->getRVA() + offsetof(chpe_metadata, ExtraRFETableSize),
           pdata.last->getRVA() + pdata.last->getSize() - pdata.first->getRVA());
   }
+
+  for (SameAddressThunkARM64EC *thunk : ctx.symtab.sameAddressThunks)
+    thunk->setDynamicRelocs(ctx);
 }
 
 // Write section contents to a mmap'ed file.

--- a/lld/test/COFF/arm64x-sameaddress.test
+++ b/lld/test/COFF/arm64x-sameaddress.test
@@ -3,16 +3,103 @@ RUN: split-file %s %t.dir && cd %t.dir
 
 RUN: llvm-mc -filetype=obj -triple=arm64ec-windows func-arm64ec.s -o func-arm64ec.obj
 RUN: llvm-mc -filetype=obj -triple=aarch64-windows func-arm64.s -o func-arm64.obj
+RUN: llvm-mc -filetype=obj -triple=arm64ec-windows ref-arm64ec.s -o ref-arm64ec.obj
+RUN: llvm-mc -filetype=obj -triple=aarch64-windows ref-arm64.s -o ref-arm64.obj
 RUN: llvm-mc -filetype=obj -triple=arm64ec-windows drectve.s -o drectve.obj
 RUN: llvm-mc -filetype=obj -triple=aarch64-windows drectve.s -o drectve-arm64.obj
 RUN: llvm-mc -filetype=obj -triple=arm64ec-windows %S/Inputs/loadconfig-arm64ec.s -o loadconfig-arm64ec.obj
 RUN: llvm-mc -filetype=obj -triple=aarch64-windows %S/Inputs/loadconfig-arm64.s -o loadconfig-arm64.obj
 
 RUN: lld-link -machine:arm64x -dll -noentry -out:out.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
-RUN:          func-arm64.obj func-arm64ec.obj drectve.obj
+RUN:          func-arm64.obj func-arm64ec.obj ref-arm64.obj ref-arm64ec.obj drectve.obj
+
+RUN: llvm-objdump -d out.dll | FileCheck --check-prefix=DISASM %s
+DISASM:      000000180001000 <.text>:
+DISASM-NEXT: 180001000: d2800020     mov     x0, #0x1                // =1
+DISASM-NEXT: 180001004: d65f03c0     ret
+DISASM-NEXT:                 ...
+DISASM-NEXT: 180002000: 00000019     udf     #0x19
+DISASM-NEXT: 180002004: d2800040     mov     x0, #0x2                // =2
+DISASM-NEXT: 180002008: d65f03c0     ret
+DISASM-NEXT: 18000200c: 0000000d     udf     #0xd
+DISASM-NEXT: 180002010: f0fffff0     adrp    x16, 0x180001000 <.text>
+DISASM-NEXT: 180002014: 91000210     add     x16, x16, #0x0
+DISASM-NEXT: 180002018: d61f0200     br      x16
+DISASM-NEXT: 18000201c: d2800060     mov     x0, #0x3                // =3
+DISASM-NEXT: 180002020: d65f03c0     ret
+
+RUN: llvm-readobj --hex-dump=.test out.dll | FileCheck --check-prefix=TESTSEC %s
+TESTSEC: 10200000 10200000 10200000
+
+RUN: llvm-readobj --coff-load-config out.dll | FileCheck --check-prefix=DYNRELOCS %s
+DYNRELOCS:      DynamicRelocations [
+DYNRELOCS-NEXT:   Version: 0x1
+DYNRELOCS-NEXT:   Arm64X [
+DYNRELOCS-NEXT:     Entry [
+DYNRELOCS-NEXT:       RVA: 0x7C
+DYNRELOCS-NEXT:       Type: VALUE
+DYNRELOCS-NEXT:       Size: 0x2
+DYNRELOCS-NEXT:       Value: 0x8664
+DYNRELOCS-NEXT:     ]
+DYNRELOCS-NEXT:     Entry [
+DYNRELOCS-NEXT:       RVA: 0x150
+DYNRELOCS-NEXT:       Type: VALUE
+DYNRELOCS-NEXT:       Size: 0x4
+DYNRELOCS-NEXT:       Value: 0x3150
+DYNRELOCS-NEXT:     ]
+DYNRELOCS-NEXT:     Entry [
+DYNRELOCS-NEXT:       RVA: 0x154
+DYNRELOCS-NEXT:       Type: VALUE
+DYNRELOCS-NEXT:       Size: 0x4
+DYNRELOCS-NEXT:       Value: 0x140
+DYNRELOCS-NEXT:     ]
+DYNRELOCS-NEXT:     Entry [
+DYNRELOCS-NEXT:       RVA: 0x2010
+DYNRELOCS-NEXT:       Type: VALUE
+DYNRELOCS-NEXT:       Size: 0x4
+DYNRELOCS-NEXT:       Value: 0x90000010
+DYNRELOCS-NEXT:     ]
+DYNRELOCS-NEXT:     Entry [
+DYNRELOCS-NEXT:       RVA: 0x2014
+DYNRELOCS-NEXT:       Type: VALUE
+DYNRELOCS-NEXT:       Size: 0x4
+DYNRELOCS-NEXT:       Value: 0x91001210
+DYNRELOCS-NEXT:     ]
+DYNRELOCS-NEXT:   ]
+DYNRELOCS-NEXT: ]
 
 RUN: lld-link -machine:arm64x -dll -noentry -out:out-cmd.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
-RUN:          func-arm64.obj func-arm64ec.obj -arm64xsameaddress:func
+RUN:          func-arm64.obj func-arm64ec.obj ref-arm64.obj ref-arm64ec.obj -arm64xsameaddress:func
+RUN: llvm-objdump -d out-cmd.dll | FileCheck --check-prefix=DISASM %s
+RUN: llvm-readobj --hex-dump=.test out-cmd.dll | FileCheck --check-prefix=TESTSEC %s
+RUN: llvm-readobj --coff-load-config out-cmd.dll | FileCheck --check-prefix=DYNRELOCS %s
+
+RUN: lld-link -machine:arm64x -dll -noentry -out:out-both.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          func-arm64.obj func-arm64ec.obj ref-arm64.obj ref-arm64ec.obj drectve.obj -arm64xsameaddress:func
+RUN: llvm-objdump -d out-both.dll | FileCheck --check-prefix=DISASM %s
+RUN: llvm-readobj --hex-dump=.test out-both.dll | FileCheck --check-prefix=TESTSEC %s
+RUN: llvm-readobj --coff-load-config out-both.dll | FileCheck --check-prefix=DYNRELOCS %s
+
+Check that if any of the sameaddress symbols is not alive, the thunk is not generated.
+
+RUN: lld-link -machine:arm64x -dll -noentry -out:out-live1.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          func-arm64.obj func-arm64ec.obj ref-arm64ec.obj drectve.obj
+RUN: llvm-objdump -d out-live1.dll | FileCheck --check-prefix=DISASM-LIVE1 %s
+DISASM-LIVE1:      0000000180001000 <.text>:
+DISASM-LIVE1-NEXT: 180001000: 00000009     udf     #0x9
+DISASM-LIVE1-NEXT: 180001004: d2800040     mov     x0, #0x2                // =2
+DISASM-LIVE1-NEXT: 180001008: d65f03c0     ret
+DISASM-LIVE1-NEXT: 18000100c: d2800060     mov     x0, #0x3                // =3
+DISASM-LIVE1-NEXT: 180001010: d65f03c0     ret
+DISASM-LIVE1-NOT:  br
+
+RUN: lld-link -machine:arm64x -dll -noentry -out:out-live2.dll loadconfig-arm64.obj loadconfig-arm64ec.obj \
+RUN:          func-arm64.obj func-arm64ec.obj ref-arm64.obj drectve.obj
+RUN: llvm-objdump -d out-live2.dll | FileCheck --check-prefix=DISASM-LIVE2 %s
+DISASM-LIVE2:      0000000180001000 <.text>:
+DISASM-LIVE2-NEXT: 180001000: d2800020     mov     x0, #0x1                // =1
+DISASM-LIVE2-NEXT: 180001004: d65f03c0     ret
+DISASM-LIVE2-NOT:  br
 
 RUN: lld-link -machine:arm64ec -dll -noentry -out:out-ec.dll loadconfig-arm64ec.obj func-arm64ec.obj drectve.obj
 
@@ -20,12 +107,20 @@ RUN: lld-link -machine:arm64x -dll -noentry -out:out-warn.dll loadconfig-arm64.o
 RUN:          func-arm64.obj func-arm64ec.obj drectve-arm64.obj 2>&1 | FileCheck --check-prefix=WARN %s
 WARN: lld-link: warning: -arm64xsameaddress: is not allowed in non-ARM64EC files (drectve-arm64.obj)
 
+RUN: lld-link -machine:arm64 -dll -noentry -out:out-warn2.dll loadconfig-arm64.obj \
+RUN:          func-arm64.obj -arm64xsameaddress:func 2>&1 | FileCheck --check-prefix=WARN2 %s
+WARN2: lld-link: warning: -arm64xsameaddress: is allowed only on EC targets
+
 #--- func-arm64.s
         .section .text,"xr",discard,func
         .globl func
 func:
         mov x0, #1
         ret
+
+#--- ref-arm64.s
+        .section .test,"dr"
+        .rva func
 
 #--- func-arm64ec.s
         .section .text,"xr",discard,"#func"
@@ -43,13 +138,15 @@ entry_thunk:
         mov x0, #3
         ret
 
-        .section .test,"dr"
-        .rva func
-
 	.section .hybmp$x,"yi"
 	.symidx "#func"
 	.symidx entry_thunk
 	.word 1
+
+#--- ref-arm64ec.s
+        .section .test,"dr"
+        .rva func
+        .rva "#func"
 
 #--- drectve.s
         .section .drectve, "yn"


### PR DESCRIPTION
Fixes MSVC CRT thread-local constructors support on hybrid ARM64X targets.

`-arm64xsameaddress` is an undocumented option that ensures the specified function has the same address in both native and EC views of hybrid images. To achieve this, the linker emits additional thunks and replaces the symbols
of those functions with the thunk symbol (the same thunk is used in both views). The thunk code jumps to the native function (similar to range extension thunks), but additional ARM64X relocations are emitted to replace the target with the EC function in the EC view.

MSVC appears to generate thunks even for non-hybrid ARM64EC images. As a side effect, the native symbol is pulled in. Since this is used in the CRT for thread-local constructors, it results in the image containing unnecessary native code. Because these thunks do not appear to be useful in that context, we limit this behavior to actual hybrid targets. This may change if compatibility requires it.

The tricky part is that thunks should be skipped if the symbol is not live in either view, and symbol replacement must be reflected in weak aliases. This requires thunk generation to happen before resolving weak aliases but after the GC pass. To enable this, the `markLive` call was moved earlier, and the final weak alias resolution was postponed until afterward. This requires more code to be aware of weak aliases, which previously could assume they were already resolved.