### PR TITLE
[lldb] Fix libcxx configuration in dotest.py

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -294,9 +294,11 @@ def parseOptionsAndInitTestdirs():
                 "Custom libc++ requires both --libcxx-include-dir and --libcxx-library-dir"
             )
             sys.exit(-1)
-    configuration.libcxx_include_dir = args.libcxx_include_dir
-    configuration.libcxx_include_target_dir = args.libcxx_include_target_dir
-    configuration.libcxx_library_dir = args.libcxx_library_dir
+        else:
+            configuration.libcxx_include_dir = args.libcxx_include_dir
+            configuration.libcxx_include_target_dir = args.libcxx_include_target_dir
+            configuration.libcxx_library_dir = args.libcxx_library_dir
+
     configuration.cmake_build_type = args.cmake_build_type.lower()
 
     if args.channels:


### PR DESCRIPTION
We emit a warning when running the test suite remotely that says the libcxx arguments will be ignored, but because they're set outside the conditional block, we're not actually do this. Fix the logic by moving the configuration in the conditional else-block.