### PR TITLE
[clang][test] Split out staticanalyzer portion of Modules/specializations-lazy-load-parentmap-crash.cpp

### DIFF
--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash-analyzer.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash-analyzer.cpp
@@ -5,13 +5,13 @@
 // RUN: split-file --leading-lines %s %t
 //
 // Prepare the BMIs.
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_a-part1.pcm %t/mod_a-part1.cppm
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_a-part2.pcm %t/mod_a-part2.cppm
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_a.pcm %t/mod_a.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_b.pcm %t/mod_b.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface -o %t/mod_a-part1.pcm %t/mod_a-part1.cppm
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface -o %t/mod_a-part2.pcm %t/mod_a-part2.cppm
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface -o %t/mod_a.pcm %t/mod_a.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
+// RUN: %clang_cc1 -std=c++20 -emit-module-interface -o %t/mod_b.pcm %t/mod_b.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
 
 // Trigger the construction of the parent map (which is necessary to trigger the bug this regression test is for) using ArrayBoundV2 checker:
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -analyze -analyzer-checker=security,alpha.security -analyzer-output=text %t/test-array-bound-v2.cpp -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm -fmodule-file=mod_b=%t/mod_b.pcm
+// RUN: %clang_cc1 -std=c++20 -analyze -analyzer-checker=security,alpha.security -analyzer-output=text %t/test-array-bound-v2.cpp -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm -fmodule-file=mod_b=%t/mod_b.pcm
 
 //--- mod_a-part1.cppm
 module;

--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash-analyzer.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash-analyzer.cpp
@@ -85,14 +85,3 @@ void triggerParentMapContextCreationThroughArrayBoundV2() {
   char buf[100];
   someFunc(&buf[0], &buf[100]);
 }
-
-//--- test-sanitized-build.cpp
-import mod_b;
-
-extern void some();
-void triggerParentMapContextCreationThroughSanitizedBuild(unsigned i) {
-  // This code currently causes UBSan to create the ParentMapContext.
-  // UBSan currently excludes the pattern below to avoid noise, and it relies on ParentMapContext to detect it.
-  while (i--)
-    some();
-}

--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash-analyzer.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash-analyzer.cpp
@@ -10,8 +10,8 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_a.pcm %t/mod_a.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_b.pcm %t/mod_b.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
 
-// Trigger the construction of the parent map (which is necessary to trigger the bug this regression test is for) using ArrayBoundV2 checker using a sanitized build:
-// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fsanitize=unsigned-integer-overflow -fsanitize-undefined-ignore-overflow-pattern=all -emit-llvm -o %t/ignored %t/test-sanitized-build.cpp -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm -fmodule-file=mod_b=%t/mod_b.pcm
+// Trigger the construction of the parent map (which is necessary to trigger the bug this regression test is for) using ArrayBoundV2 checker:
+// RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -analyze -analyzer-checker=security,alpha.security -analyzer-output=text %t/test-array-bound-v2.cpp -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm -fmodule-file=mod_b=%t/mod_b.pcm
 
 //--- mod_a-part1.cppm
 module;

--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: staticanalyzer
+//
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file --leading-lines %s %t

--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
@@ -1,5 +1,3 @@
-// REQUIRES: staticanalyzer
-//
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file --leading-lines %s %t

--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
@@ -10,7 +10,7 @@
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_a.pcm %t/mod_a.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -emit-module-interface -o %t/mod_b.pcm %t/mod_b.cppm -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm
 
-// Trigger the construction of the parent map (which is necessary to trigger the bug this regression test is for) using ArrayBoundV2 checker using a sanitized build:
+// Trigger the construction of the parent map (which is necessary to trigger the bug this regression test is for) using a sanitized build:
 // RUN: %clang_cc1 -std=c++20 -triple x86_64-unknown-linux-gnu -fsanitize=unsigned-integer-overflow -fsanitize-undefined-ignore-overflow-pattern=all -emit-llvm -o %t/ignored %t/test-sanitized-build.cpp -fmodule-file=mod_a:part2=%t/mod_a-part2.pcm -fmodule-file=mod_a=%t/mod_a.pcm -fmodule-file=mod_a:part1=%t/mod_a-part1.pcm -fmodule-file=mod_b=%t/mod_b.pcm
 
 //--- mod_a-part1.cppm

--- a/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
+++ b/clang/test/Modules/specializations-lazy-load-parentmap-crash.cpp
@@ -74,18 +74,6 @@ void a() {
   mod_a::instantiate2<42>();
 }
 
-//--- test-array-bound-v2.cpp
-import mod_b;
-
-extern void someFunc(char* first, char* last);
-void triggerParentMapContextCreationThroughArrayBoundV2() {
-  // This code currently causes the ArrayBoundV2 checker to create the ParentMapContext.
-  // Once it detects an access to buf[100], the checker looks through the parents to find '&' operator.
-  // (this is needed since taking the address of past-the-end pointer is allowed by the checker)
-  char buf[100];
-  someFunc(&buf[0], &buf[100]);
-}
-
 //--- test-sanitized-build.cpp
 import mod_b;
 


### PR DESCRIPTION
When the static analyzer is disabled with
-DCLANG_ENABLE_STATIC_ANALYZER=OFF, the newly added
specializations-lazy-load-parentmap-crash.cpp test fails with:

  error: action RunAnalysis not compiled in

  --

  ********************
  ********************
  Failed Tests (1):
    Clang :: Modules/specializations-lazy-load-parentmap-crash.cpp

Split out the part of the test that requires the static analyzer so that
it does not run when the static analyzer is unavailable.