### PR TITLE
[llvm-profgen][NFC] Show only mmap events in convertPerfDataToTrace

### DIFF
--- a/llvm/tools/llvm-profgen/PerfReader.cpp
+++ b/llvm/tools/llvm-profgen/PerfReader.cpp
@@ -393,9 +393,9 @@ PerfScriptReader::convertPerfDataToTrace(ProfiledBinary *Binary, bool SkipPID,
 
   std::string PIDs;
   if (!SkipPID) {
-    StringRef ScriptMMapArgs[] = {PerfPath, "script",   "--show-mmap-events",
-                                  "-F",     "comm,pid", "-i",
-                                  PerfData};
+    StringRef ScriptMMapArgs[] = {PerfPath,    "script",   "--show-mmap-events",
+                                  "-F",        "comm,pid", "--dsos",
+                                  "NOT_EXIST", "-i",       PerfData};
     sys::ExecuteAndWait(PerfPath, ScriptMMapArgs, std::nullopt, Redirects);
 
     // Collect the PIDs


### PR DESCRIPTION
In the first pass of converting perfdata to perf script, only mmap events are parsed. Using a fake DSO name to show mmap events. May speed things a little bit if the file is huge.