### PR TITLE
[lldb] Pick the builder for the target platform

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -229,7 +229,8 @@ def hasChattyStderr(test_case):
 
 
 def builder_module():
-    return get_builder(sys.platform)
+    """Return the builder for the target platform."""
+    return get_builder(getPlatform())
 
 
 def getArchitecture():


### PR DESCRIPTION
Pick the builder for the target platform, not the host platform. This is necessary when running the test suite remotely on a different platform. Unlike for Darwin, both Windows and Linux us the default builder, which is why this went unnoticed on the remote-linux bots.