### PR TITLE
[compiler-rt] Remove %T from tests

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/long-object-path.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/long-object-path.cpp
@@ -1,6 +1,6 @@
-// RUN: mkdir -p %T/a-long-directory-name-to-test-allocations-for-exceptions-in-_dl_lookup_symbol_x-since-glibc-2.27
-// RUN: %clangxx_asan -g %s -o %T/long-object-path
-// RUN: %run %T/a-*/../a-*/../a-*/../a-*/../a-*/../a-*/../a-*/../a-*/../long-object-path
+// RUN: mkdir -p %t.a-long-directory-name-to-test-allocations-for-exceptions-in-_dl_lookup_symbol_x-since-glibc-2.27
+// RUN: %clangxx_asan -g %s -o %t.long-object-path
+// RUN: %run %t.a-*/../a-*/../a-*/../a-*/../a-*/../a-*/../a-*/../a-*/../long-object-path
 
 int main(void) {
     return 0;

--- a/compiler-rt/test/fuzzer/afl-driver-stderr.test
+++ b/compiler-rt/test/fuzzer/afl-driver-stderr.test
@@ -7,7 +7,8 @@ RUN: %no_fuzzer_cpp_compiler %S/AFLDriverTest.cpp %libfuzzer_src/afl/afl_driver.
 RUN: env -u AFL_DRIVER_STDERR_DUPLICATE_FILENAME %run %t-AFLDriverTest
 
 ; Test that specifying an invalid file causes a crash.
-RUN: env ASAN_OPTIONS= AFL_DRIVER_STDERR_DUPLICATE_FILENAME="%T" not --crash %run %t-AFLDriverTest
+RUN: mkdir -p %t.dir
+RUN: env ASAN_OPTIONS= AFL_DRIVER_STDERR_DUPLICATE_FILENAME="%t.dir" not --crash %run %t-AFLDriverTest
 
 ; Test that a file is created when specified as the duplicate stderr.
 RUN: env AFL_DRIVER_STDERR_DUPLICATE_FILENAME=%t %run %t-AFLDriverTest

--- a/compiler-rt/test/sanitizer_common/TestCases/suffix-log-path_test.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/suffix-log-path_test.c
@@ -1,12 +1,13 @@
-// RUN: %clang %s -o %T/suffix-log-path_test-binary
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir
+// RUN: %clang %s -o %t.dir/suffix-log-path_test-binary
 
 // The glob below requires bash.
 // REQUIRES: shell
 
 // Good log_path with suffix.
-// RUN: rm -f %T/sanitizer.log.*.txt
-// RUN: %env_tool_opts=log_path=%T/sanitizer.log:log_exe_name=1:log_suffix=.txt %run %T/suffix-log-path_test-binary 2> %t.out
-// RUN: FileCheck %s < %T/sanitizer.log.suffix-log-path_test-binary.*.txt
+// RUN: %env_tool_opts=log_path=%t.dir/sanitizer.log:log_exe_name=1:log_suffix=.txt %run %t.dir/suffix-log-path_test-binary 2> %t.out
+// RUN: FileCheck %s < %t.dir/sanitizer.log.suffix-log-path_test-binary.*.txt
 
 // UNSUPPORTED: ios, android
 

--- a/compiler-rt/test/xray/TestCases/Posix/fdr-mode-inmemory.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/fdr-mode-inmemory.cpp
@@ -1,12 +1,14 @@
 // RUN: %clangxx_xray -g -std=c++11 %s -o %t -fxray-modes=xray-fdr
-// RUN: rm -f fdr-inmemory-test-*
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir
+// RUN: cd %t.dir
 // RUN: XRAY_OPTIONS="patch_premain=false xray_logfile_base=fdr-inmemory-test- \
 // RUN:     verbosity=1" \
 // RUN: XRAY_FDR_OPTIONS="no_file_flush=true func_duration_threshold_us=0" \
 // RUN:     %run %t 2>&1 | FileCheck %s
-// RUN: FILES=`find %T -name 'fdr-inmemory-test-*' | wc -l`
+// RUN: FILES=`find %t.dir -name 'fdr-inmemory-test-*' | wc -l`
 // RUN: [ $FILES -eq 0 ]
-// RUN: rm -f fdr-inmemory-test-*
+// RUN: rm -rf %t.dir
 //
 // REQUIRES: built-in-llvm-tree
 

--- a/compiler-rt/test/xray/TestCases/Posix/fdr-mode-multiple.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/fdr-mode-multiple.cpp
@@ -1,12 +1,14 @@
 // RUN: %clangxx_xray -g -std=c++11 %s -o %t -fxray-modes=xray-fdr
-// RUN: rm -f fdr-inmemory-test-*
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir
+// RUN: cd %t.dir
 // RUN: XRAY_OPTIONS="patch_premain=false xray_logfile_base=fdr-inmemory-test- \
 // RUN:     verbosity=1" \
 // RUN: XRAY_FDR_OPTIONS="no_file_flush=true func_duration_threshold_us=0" \
 // RUN:     %run %t 2>&1 | FileCheck %s
-// RUN: FILES=`find %T -name 'fdr-inmemory-test-*' | wc -l`
+// RUN: FILES=`find %t.dir -name 'fdr-inmemory-test-*' | wc -l`
 // RUN: [ $FILES -eq 0 ]
-// RUN: rm -f fdr-inmemory-test-*
+// RUN: rm -rf %t.dir
 //
 // REQUIRES: built-in-llvm-tree
 


### PR DESCRIPTION
%T has been deprecated for about seven years and use is to be avoided given it doesn't actually create a unique test directory per test, which can lead to races. Remove it from compiler-rt so we can hopefully remove it from within llvm-lit.

This patch just touches the tests. There are still uses in some substitutions defined in compiler-rt/test/lit.common.cfg.py that I want to leave for a separate patch because it is quite a bit more thorny.