### PR TITLE
[IR] Remove getDestAlignment and getSourceAlignment

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicInst.h
+++ b/llvm/include/llvm/IR/IntrinsicInst.h
@@ -996,14 +996,6 @@ public:
     return cast<PointerType>(getRawDest()->getType())->getAddressSpace();
   }
 
-  /// FIXME: Remove this function once transition to Align is over.
-  /// Use getDestAlign() instead.
-  LLVM_DEPRECATED("Use getDestAlign() instead", "getDestAlign")
-  unsigned getDestAlignment() const {
-    if (auto MA = getParamAlign(ARG_DEST))
-      return MA->value();
-    return 0;
-  }
   MaybeAlign getDestAlign() const { return getParamAlign(ARG_DEST); }
 
   /// Set the specified arguments of the instruction.
@@ -1055,15 +1047,6 @@ public:
 
   unsigned getSourceAddressSpace() const {
     return cast<PointerType>(getRawSource()->getType())->getAddressSpace();
-  }
-
-  /// FIXME: Remove this function once transition to Align is over.
-  /// Use getSourceAlign() instead.
-  LLVM_DEPRECATED("Use getSourceAlign() instead", "getSourceAlign")
-  unsigned getSourceAlignment() const {
-    if (auto MA = BaseCL::getParamAlign(ARG_SOURCE))
-      return MA->value();
-    return 0;
   }
 
   MaybeAlign getSourceAlign() const {


### PR DESCRIPTION
This patch removes getDestAlignment and getSourceAlignment as they
have been deprecated for more than two years since:

  commit 135f23d67bf5397745be1897afd0a3a50119089f
  Author: Guillaume Chatelet <gchatelet@google.com>
  Date:   Mon Jan 16 12:34:40 2023 +0000

I'm not aware of any downstream users AFAIK.
