### PR TITLE
[AArch64] Remove wrong processor feature

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Processors.td
+++ b/llvm/lib/Target/AArch64/AArch64Processors.td
@@ -318,7 +318,6 @@ def TuneAppleA7  : SubtargetFeature<"apple-a7", "ARMProcFamily", "AppleA7",
                                     FeatureFuseAES, FeatureFuseCryptoEOR,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing,
                                     FeatureZCZeroingFPWorkaround]>;
 
@@ -332,7 +331,6 @@ def TuneAppleA10 : SubtargetFeature<"apple-a10", "ARMProcFamily", "AppleA10",
                                     FeatureFuseCryptoEOR,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA11 : SubtargetFeature<"apple-a11", "ARMProcFamily", "AppleA11",
@@ -345,7 +343,6 @@ def TuneAppleA11 : SubtargetFeature<"apple-a11", "ARMProcFamily", "AppleA11",
                                     FeatureFuseCryptoEOR,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA12 : SubtargetFeature<"apple-a12", "ARMProcFamily", "AppleA12",
@@ -358,7 +355,6 @@ def TuneAppleA12 : SubtargetFeature<"apple-a12", "ARMProcFamily", "AppleA12",
                                     FeatureFuseCryptoEOR,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA13 : SubtargetFeature<"apple-a13", "ARMProcFamily", "AppleA13",
@@ -371,7 +367,6 @@ def TuneAppleA13 : SubtargetFeature<"apple-a13", "ARMProcFamily", "AppleA13",
                                     FeatureFuseCryptoEOR,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA14 : SubtargetFeature<"apple-a14", "ARMProcFamily", "AppleA14",
@@ -389,7 +384,6 @@ def TuneAppleA14 : SubtargetFeature<"apple-a14", "ARMProcFamily", "AppleA14",
                                     FeatureFuseLiterals,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA15 : SubtargetFeature<"apple-a15", "ARMProcFamily", "AppleA15",
@@ -407,7 +401,6 @@ def TuneAppleA15 : SubtargetFeature<"apple-a15", "ARMProcFamily", "AppleA15",
                                     FeatureFuseLiterals,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA16 : SubtargetFeature<"apple-a16", "ARMProcFamily", "AppleA16",
@@ -425,7 +418,6 @@ def TuneAppleA16 : SubtargetFeature<"apple-a16", "ARMProcFamily", "AppleA16",
                                     FeatureFuseLiterals,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleA17 : SubtargetFeature<"apple-a17", "ARMProcFamily", "AppleA17",
@@ -443,7 +435,6 @@ def TuneAppleA17 : SubtargetFeature<"apple-a17", "ARMProcFamily", "AppleA17",
                                     FeatureFuseLiterals,
                                     FeatureStorePairSuppress,
                                     FeatureZCRegMoveGPR64,
-                                    FeatureZCRegMoveFPR64,
                                     FeatureZCZeroing]>;
 
 def TuneAppleM4 : SubtargetFeature<"apple-m4", "ARMProcFamily", "AppleM4",
@@ -460,7 +451,6 @@ def TuneAppleM4 : SubtargetFeature<"apple-m4", "ARMProcFamily", "AppleM4",
                                      FeatureFuseCryptoEOR,
                                      FeatureFuseLiterals,
                                      FeatureZCRegMoveGPR64,
-                                     FeatureZCRegMoveFPR64,
                                      FeatureZCZeroing
                                      ]>;
 

--- a/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmov-fpr.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-zero-cycle-regmov-fpr.ll
@@ -1,7 +1,5 @@
 ; RUN: llc < %s -mtriple=arm64-linux-gnu | FileCheck %s -check-prefixes=NOTCPU-LINUX --match-full-lines
 ; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=generic | FileCheck %s -check-prefixes=NOTCPU-APPLE --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 | FileCheck %s -check-prefixes=CPU --match-full-lines
-; RUN: llc < %s -mtriple=arm64-apple-macosx -mcpu=apple-m1 -mattr=-zcm-fpr64 | FileCheck %s -check-prefixes=NOTATTR --match-full-lines
 ; RUN: llc < %s -mtriple=arm64-apple-macosx -mattr=+zcm-fpr64 | FileCheck %s -check-prefixes=ATTR --match-full-lines
 
 define void @zero_cycle_regmov_FPR32(float %a, float %b, float %c, float %d) {
@@ -22,22 +20,6 @@ entry:
 ; NOTCPU-APPLE-NEXT: bl {{_?foo_float}}
 ; NOTCPU-APPLE: fmov s0, [[REG1]]
 ; NOTCPU-APPLE: fmov s1, [[REG2]]
-
-; CPU: fmov [[REG2:d[0-9]+]], d3
-; CPU: fmov [[REG1:d[0-9]+]], d2
-; CPU: fmov d0, d2
-; CPU: fmov d1, d3
-; CPU-NEXT: bl {{_?foo_float}}
-; CPU: fmov d0, [[REG1]]
-; CPU: fmov d1, [[REG2]]
-
-; NOTATTR: fmov [[REG2:s[0-9]+]], s3
-; NOTATTR: fmov [[REG1:s[0-9]+]], s2
-; NOTATTR: fmov s0, s2
-; NOTATTR: fmov s1, s3
-; NOTATTR-NEXT: bl {{_?foo_float}}
-; NOTATTR: fmov s0, [[REG1]]
-; NOTATTR: fmov s1, [[REG2]]
 
 ; ATTR: fmov d0, d2
 ; ATTR: fmov d1, d3
@@ -71,22 +53,6 @@ entry:
 ; NOTCPU-APPLE-NEXT: bl {{_?foo_half}}
 ; NOTCPU-APPLE: fmov s0, [[REG1]]
 ; NOTCPU-APPLE: fmov s1, [[REG2]]
-
-; CPU: fmov [[REG2:d[0-9]+]], d3
-; CPU: fmov [[REG1:d[0-9]+]], d2
-; CPU: fmov d0, d2
-; CPU: fmov d1, d3
-; CPU-NEXT: bl {{_?foo_half}}
-; CPU: fmov d0, [[REG1]]
-; CPU: fmov d1, [[REG2]]
-
-; NOTATTR: fmov [[REG2:s[0-9]+]], s3
-; NOTATTR: fmov [[REG1:s[0-9]+]], s2
-; NOTATTR: fmov s0, s2
-; NOTATTR: fmov s1, s3
-; NOTATTR-NEXT: bl {{_?foo_half}}
-; NOTATTR: fmov s0, [[REG1]]
-; NOTATTR: fmov s1, [[REG2]]
 
 ; ATTR: fmov d0, d2
 ; ATTR: fmov d1, d3


### PR DESCRIPTION
`fmov dX, dY` is not a preferred instruction.

Previously introduced by: https://github.com/llvm/llvm-project/pull/144152