### PR TITLE
[MLIR][Transform] Prefer entry points in current module

### DIFF
--- a/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
+++ b/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
@@ -121,14 +121,11 @@ ModuleOp transform::detail::getPreloadedTransformModule(MLIRContext *context) {
       ->getLibraryModule();
 }
 
-namespace {
-
-transform::TransformOpInterface
+static transform::TransformOpInterface
 findTransformEntryPointNonRecursive(Operation *op, StringRef entryPoint) {
   for (Region &region : op->getRegions()) {
     for (Block &block : region.getBlocks()) {
-      auto namedSequenceOps = block.getOps<transform::NamedSequenceOp>();
-      for (transform::NamedSequenceOp namedSequenceOp : namedSequenceOps) {
+      for (auto namedSequenceOp : block.getOps<transform::NamedSequenceOp>()) {
         if (namedSequenceOp.getSymName() == entryPoint) {
           return cast<transform::TransformOpInterface>(
               namedSequenceOp.getOperation());
@@ -139,7 +136,7 @@ findTransformEntryPointNonRecursive(Operation *op, StringRef entryPoint) {
   return nullptr;
 }
 
-transform::TransformOpInterface
+static transform::TransformOpInterface
 findTransformEntryPointRecursive(Operation *op, StringRef entryPoint) {
   transform::TransformOpInterface transform = nullptr;
   op->walk<WalkOrder::PreOrder>(
@@ -189,7 +186,7 @@ findTransformEntryPointRecursive(Operation *op, StringRef entryPoint) {
 //      }
 //    }
 //    ```
-transform::TransformOpInterface
+static transform::TransformOpInterface
 findTransformEntryPointInOp(Operation *op, StringRef entryPoint) {
   transform::TransformOpInterface transform =
       findTransformEntryPointNonRecursive(op, entryPoint);
@@ -197,8 +194,6 @@ findTransformEntryPointInOp(Operation *op, StringRef entryPoint) {
     transform = findTransformEntryPointRecursive(op, entryPoint);
   return transform;
 }
-
-} // namespace
 
 transform::TransformOpInterface
 transform::detail::findTransformEntryPoint(Operation *root, ModuleOp module,

--- a/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
+++ b/mlir/lib/Dialect/Transform/Transforms/TransformInterpreterUtils.cpp
@@ -154,6 +154,15 @@ findTransformEntryPointRecursive(Operation *op, StringRef entryPoint) {
   return transform;
 }
 
+transform::TransformOpInterface
+findTransformEntryPointInOp(Operation *op, StringRef entryPoint) {
+  transform::TransformOpInterface transform =
+      findTransformEntryPointNonRecursive(op, entryPoint);
+  if (!transform)
+    transform = findTransformEntryPointRecursive(op, entryPoint);
+  return transform;
+}
+
 } // namespace
 
 transform::TransformOpInterface
@@ -164,9 +173,7 @@ transform::detail::findTransformEntryPoint(Operation *root, ModuleOp module,
     l.push_back(module);
   for (Operation *op : l) {
     TransformOpInterface transform =
-        findTransformEntryPointNonRecursive(op, entryPoint);
-    if (!transform)
-      transform = findTransformEntryPointRecursive(op, entryPoint);
+        findTransformEntryPointInOp(op, entryPoint);
     if (transform)
       return transform;
   }

--- a/mlir/test/Dialect/Transform/interpreter-entry-point-2.mlir
+++ b/mlir/test/Dialect/Transform/interpreter-entry-point-2.mlir
@@ -1,5 +1,4 @@
-// RUN: mlir-opt %s -transform-interpreter \
-// RUN:   -split-input-file -verify-diagnostics | FileCheck %s
+// RUN: mlir-opt %s --transform-interpreter | FileCheck %s
 
 module @td_module_4 attributes {transform.with_named_sequence} {
   module @foo_module attributes {transform.with_named_sequence} {

--- a/mlir/test/Dialect/Transform/interpreter-entry-point-2.mlir
+++ b/mlir/test/Dialect/Transform/interpreter-entry-point-2.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt %s -transform-interpreter \
+// RUN:   -split-input-file -verify-diagnostics | FileCheck %s
+
+module @td_module_4 attributes {transform.with_named_sequence} {
+  module @foo_module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) -> () {
+      // CHECK: IR printer: foo_module top-level
+      transform.print {name="foo_module"}
+      transform.yield
+    }
+  }
+  module @bar_module attributes {transform.with_named_sequence} {
+    transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) -> () {
+      // CHECK: IR printer: bar_module top-level
+      transform.print {name="bar_module"}
+      transform.yield
+    }
+  }
+  transform.named_sequence @__transform_main(%arg0: !transform.any_op {transform.readonly}) -> () {
+    transform.include @foo_module::@__transform_main failures(suppress) (%arg0) : (!transform.any_op) -> ()
+    transform.include @bar_module::@__transform_main failures(suppress) (%arg0) : (!transform.any_op) -> ()
+    transform.yield
+  }
+}


### PR DESCRIPTION
The transform interpreter previously looked for the entry point using a recursive walk in pre-order. This makes it so that any named_sequence operation with an arbitrary level of nested-ness will be used as the entry point for the transform interpreter as long as it is placed before another one.

This change makes it so that code like the one reported in https://github.com/llvm/llvm-project/issues/119578 works as expected.

Closes #119578 

Some comments: alternatively, it would also be possible to solve this issue in a slightly more elegant manner. We could define a new walker iterator that iterates through the operations in a breadth first search. 