### PR TITLE
[libc++] std::cmp_less and other integer comparison functions could be improved

### DIFF
--- a/libcxx/include/__utility/cmp.h
+++ b/libcxx/include/__utility/cmp.h
@@ -28,7 +28,13 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 template <__signed_or_unsigned_integer _Tp, __signed_or_unsigned_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept {
-  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
+  if constexpr (sizeof(_Tp) < sizeof(int) && sizeof(_Up) < sizeof(int)) {
+    __builtin_assume(__t < numeric_limits<int>::max() && __u < numeric_limits<int>::max());
+    return static_cast<int>(__t) == static_cast<int>(__u);
+  } else if constexpr (sizeof(_Tp) < sizeof(long long) && sizeof(_Up) < sizeof(long long)) {
+    __builtin_assume(__t < numeric_limits<long long>::max() && __u < numeric_limits<long long>::max());
+    return static_cast<long long>(__t) == static_cast<long long>(__u);
+  } else if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
     return __t == __u;
   else if constexpr (is_signed_v<_Tp>)
     return __t < 0 ? false : make_unsigned_t<_Tp>(__t) == __u;
@@ -43,7 +49,13 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_not_equal(_Tp __t, _Up __u) noexcept {
 
 template <__signed_or_unsigned_integer _Tp, __signed_or_unsigned_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept {
-  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
+  if constexpr (sizeof(_Tp) < sizeof(int) && sizeof(_Up) < sizeof(int)) {
+    __builtin_assume(__t < numeric_limits<int>::max() && __u < numeric_limits<int>::max());
+    return static_cast<int>(__t) < static_cast<int>(__u);
+  } else if constexpr (sizeof(_Tp) < sizeof(long long) && sizeof(_Up) < sizeof(long long)) {
+    __builtin_assume(__t < numeric_limits<long long>::max() && __u < numeric_limits<long long>::max());
+    return static_cast<long long>(__t) < static_cast<long long>(__u);
+  } else if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
     return __t < __u;
   else if constexpr (is_signed_v<_Tp>)
     return __t < 0 ? true : make_unsigned_t<_Tp>(__t) < __u;

--- a/libcxx/include/__utility/cmp.h
+++ b/libcxx/include/__utility/cmp.h
@@ -26,16 +26,18 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 
 #if _LIBCPP_STD_VER >= 20
 
+template <typename _Tp, typename _Ip>
+concept __comparison_can_promote_to =
+    sizeof(_Tp) < sizeof(_Ip) || (sizeof(_Tp) == sizeof(_Ip) && __signed_integer<_Tp>);
+
 template <__signed_or_unsigned_integer _Tp, __signed_or_unsigned_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept {
-  if constexpr (sizeof(_Tp) < sizeof(int) && sizeof(_Up) < sizeof(int)) {
-    __builtin_assume(__t < numeric_limits<int>::max() && __u < numeric_limits<int>::max());
-    return static_cast<int>(__t) == static_cast<int>(__u);
-  } else if constexpr (sizeof(_Tp) < sizeof(long long) && sizeof(_Up) < sizeof(long long)) {
-    __builtin_assume(__t < numeric_limits<long long>::max() && __u < numeric_limits<long long>::max());
-    return static_cast<long long>(__t) == static_cast<long long>(__u);
-  } else if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
+  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
     return __t == __u;
+  else if constexpr (__comparison_can_promote_to<_Tp, int> && __comparison_can_promote_to<_Up, int>)
+    return static_cast<int>(__t) == static_cast<int>(__u);
+  else if constexpr (__comparison_can_promote_to<_Tp, long long> && __comparison_can_promote_to<_Up, long long>)
+    return static_cast<long long>(__t) == static_cast<long long>(__u);
   else if constexpr (is_signed_v<_Tp>)
     return __t < 0 ? false : make_unsigned_t<_Tp>(__t) == __u;
   else
@@ -49,14 +51,12 @@ _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_not_equal(_Tp __t, _Up __u) noexcept {
 
 template <__signed_or_unsigned_integer _Tp, __signed_or_unsigned_integer _Up>
 _LIBCPP_HIDE_FROM_ABI constexpr bool cmp_less(_Tp __t, _Up __u) noexcept {
-  if constexpr (sizeof(_Tp) < sizeof(int) && sizeof(_Up) < sizeof(int)) {
-    __builtin_assume(__t < numeric_limits<int>::max() && __u < numeric_limits<int>::max());
-    return static_cast<int>(__t) < static_cast<int>(__u);
-  } else if constexpr (sizeof(_Tp) < sizeof(long long) && sizeof(_Up) < sizeof(long long)) {
-    __builtin_assume(__t < numeric_limits<long long>::max() && __u < numeric_limits<long long>::max());
-    return static_cast<long long>(__t) < static_cast<long long>(__u);
-  } else if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
+  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
     return __t < __u;
+  else if constexpr (__comparison_can_promote_to<_Tp, int> && __comparison_can_promote_to<_Up, int>)
+    return static_cast<int>(__t) < static_cast<int>(__u);
+  else if constexpr (__comparison_can_promote_to<_Tp, long long> && __comparison_can_promote_to<_Up, long long>)
+    return static_cast<long long>(__t) < static_cast<long long>(__u);
   else if constexpr (is_signed_v<_Tp>)
     return __t < 0 ? true : make_unsigned_t<_Tp>(__t) < __u;
   else

--- a/libcxx/test/benchmarks/utility/cmp.bench.cpp
+++ b/libcxx/test/benchmarks/utility/cmp.bench.cpp
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <utility>
+#include "../CartesianBenchmarks.h"
+#include "benchmark/benchmark.h"
+
+namespace {
+
+enum ValueType : size_t {
+  SChar,
+  UChar,
+  Short,
+  UShort,
+  Int,
+  UInt,
+  Long,
+  ULong,
+  LongLong,
+  ULongLong,
+#ifndef TEST_HAS_NO_INT128
+  Int128,
+  UInt128,
+#endif
+};
+
+struct AllValueTypes : EnumValuesAsTuple<AllValueTypes, ValueType, 6> {
+  static constexpr const char* Names[] = {
+      "schar",
+      "uchar",
+      "short",
+      "ushort",
+      "int",
+      "uint",
+      "long",
+      "ulong",
+      "longlong",
+      "ulonglong",
+#ifndef TEST_HAS_NO_INT128
+      "int128",
+      "uint128"
+#endif
+  };
+};
+
+using TestType =
+    std::tuple< signed char,
+                unsigned char,
+                short,
+                unsigned short,
+                int,
+                unsigned int,
+                long,
+                unsigned long,
+                long long,
+                unsigned long long
+#ifndef TEST_HAS_NO_INT128
+                ,
+                __int128_t,
+                __uint128_t
+#endif
+                >;
+
+template <typename TType, typename UType>
+struct CmpEqual {
+  static void run(benchmark::State& state) {
+    using T = std::tuple_element_t<TType::value, TestType>;
+    using U = std::tuple_element_t<UType::value, TestType>;
+
+    T x1 = T{127}, x2 = T{111};
+    U y1 = U{123}, y2 = U{1};
+    for (auto _ : state) {
+      benchmark::DoNotOptimize(x1);
+      benchmark::DoNotOptimize(x2);
+      benchmark::DoNotOptimize(y1);
+      benchmark::DoNotOptimize(y2);
+      benchmark::DoNotOptimize(std::cmp_equal(x1, y1));
+      benchmark::DoNotOptimize(std::cmp_equal(y1, x1));
+      benchmark::DoNotOptimize(std::cmp_equal(x1, x1));
+      benchmark::DoNotOptimize(std::cmp_equal(y1, y1));
+
+      benchmark::DoNotOptimize(std::cmp_equal(x2, y2));
+      benchmark::DoNotOptimize(std::cmp_equal(y2, x2));
+      benchmark::DoNotOptimize(std::cmp_equal(x2, x2));
+      benchmark::DoNotOptimize(std::cmp_equal(y2, y2));
+    }
+  }
+
+  static std::string name() { return "BM_CmpEqual" + TType::name() + UType::name(); }
+};
+
+template <typename TType, typename UType>
+struct CmpLess {
+  static void run(benchmark::State& state) {
+    using T = std::tuple_element_t<TType::value, TestType>;
+    using U = std::tuple_element_t<UType::value, TestType>;
+
+    T x1 = T{127}, x2 = T{111};
+    U y1 = U{123}, y2 = U{1};
+    for (auto _ : state) {
+      benchmark::DoNotOptimize(x1);
+      benchmark::DoNotOptimize(x2);
+      benchmark::DoNotOptimize(y1);
+      benchmark::DoNotOptimize(y2);
+      benchmark::DoNotOptimize(std::cmp_less(x1, y1));
+      benchmark::DoNotOptimize(std::cmp_less(y1, x1));
+      benchmark::DoNotOptimize(std::cmp_less(x1, x1));
+      benchmark::DoNotOptimize(std::cmp_less(y1, y1));
+
+      benchmark::DoNotOptimize(std::cmp_less(x2, y2));
+      benchmark::DoNotOptimize(std::cmp_less(y2, x2));
+      benchmark::DoNotOptimize(std::cmp_less(x2, x2));
+      benchmark::DoNotOptimize(std::cmp_less(y2, y2));
+    }
+  }
+
+  static std::string name() { return "BM_CmpLess" + TType::name() + UType::name(); }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  benchmark::Initialize(&argc, argv);
+  if (benchmark::ReportUnrecognizedArguments(argc, argv))
+    return 1;
+
+  makeCartesianProductBenchmark<CmpEqual, AllValueTypes, AllValueTypes>();
+  makeCartesianProductBenchmark<CmpLess, AllValueTypes, AllValueTypes>();
+  benchmark::RunSpecifiedBenchmarks();
+
+  return 0;
+}


### PR DESCRIPTION
Fix #65136 

|Benchmark                 |   Baseline | Candidate   |  Difference  |  % Difference
|------------------------- | ---------- | ----------- | ------------ | --------------
|BM_CmpEqual_int_int       |       0.46 |        0.46 |        -0.00 |          -0.62
|BM_CmpEqual_int_schar     |       0.45 |        0.45 |        -0.00 |          -0.40
|BM_CmpEqual_int_short     |       0.45 |        0.45 |         0.00 |           0.34
|BM_CmpEqual_int_uchar     |       0.78 |        0.44 |        -0.34 |         -43.18
|BM_CmpEqual_int_uint      |       0.90 |        0.66 |        -0.24 |         -26.84
|BM_CmpEqual_int_ushort    |       0.78 |        0.45 |        -0.33 |         -42.20
|BM_CmpEqual_schar_int     |       0.45 |        0.45 |        -0.00 |          -0.77
|BM_CmpEqual_schar_schar   |       0.54 |        0.57 |         0.03 |           5.64
|BM_CmpEqual_schar_short   |       0.92 |        0.88 |        -0.04 |          -4.80
|BM_CmpEqual_schar_uchar   |       1.84 |        0.66 |        -1.18 |         -64.16
|BM_CmpEqual_schar_uint    |       0.78 |        0.66 |        -0.12 |         -15.18
|BM_CmpEqual_schar_ushort  |       1.01 |        0.66 |        -0.35 |         -34.53
|BM_CmpEqual_short_int     |       0.45 |        0.45 |         0.00 |           0.03
|BM_CmpEqual_short_schar   |       0.89 |        0.88 |        -0.01 |          -0.80
|BM_CmpEqual_short_short   |       0.47 |        0.46 |        -0.01 |          -1.28
|BM_CmpEqual_short_uchar   |       1.11 |        0.66 |        -0.45 |         -40.63
|BM_CmpEqual_short_uint    |       0.77 |        0.66 |        -0.12 |         -14.88
|BM_CmpEqual_short_ushort  |       1.76 |        0.66 |        -1.10 |         -62.64
|BM_CmpEqual_uchar_int     |       0.79 |        0.44 |        -0.35 |         -44.06
|BM_CmpEqual_uchar_schar   |       1.76 |        0.66 |        -1.11 |         -62.68
|BM_CmpEqual_uchar_short   |       1.11 |        0.66 |        -0.45 |         -40.33
|BM_CmpEqual_uchar_uchar   |       0.57 |        0.51 |        -0.06 |         -10.61
|BM_CmpEqual_uchar_uint    |       0.45 |        0.44 |        -0.01 |          -1.74
|BM_CmpEqual_uchar_ushort  |       0.77 |        0.77 |        -0.00 |          -0.64
|BM_CmpEqual_uint_int      |       0.88 |        0.66 |        -0.23 |         -25.69
|BM_CmpEqual_uint_schar    |       0.77 |        0.66 |        -0.11 |         -14.85
|BM_CmpEqual_uint_short    |       0.77 |        0.66 |        -0.11 |         -14.56
|BM_CmpEqual_uint_uchar    |       0.44 |        0.44 |        -0.00 |          -0.57
|BM_CmpEqual_uint_uint     |       0.47 |        0.51 |         0.04 |           8.62
|BM_CmpEqual_uint_ushort   |       0.45 |        0.44 |        -0.00 |          -0.47
|BM_CmpEqual_ushort_int    |       0.77 |        0.45 |        -0.33 |         -42.02
|BM_CmpEqual_ushort_schar  |       1.02 |        0.66 |        -0.36 |         -35.30
|BM_CmpEqual_ushort_short  |       1.76 |        0.66 |        -1.10 |         -62.60
|BM_CmpEqual_ushort_uchar  |       0.78 |        0.77 |        -0.01 |          -1.84
|BM_CmpEqual_ushort_uint   |       0.45 |        0.45 |         0.00 |           0.24
|BM_CmpEqual_ushort_ushort |       0.46 |        0.51 |         0.05 |          11.00
|BM_CmpLess_int_int        |       0.67 |        0.66 |        -0.01 |          -0.99
|BM_CmpLess_int_schar      |       0.66 |        0.66 |        -0.01 |          -0.86
|BM_CmpLess_int_short      |       0.66 |        0.66 |        -0.00 |          -0.57
|BM_CmpLess_int_uchar      |       0.88 |        0.66 |        -0.23 |         -25.48
|BM_CmpLess_int_uint       |       1.76 |        0.66 |        -1.11 |         -62.68
|BM_CmpLess_int_ushort     |       0.89 |        0.66 |        -0.23 |         -25.50
|BM_CmpLess_schar_int      |       0.66 |        0.66 |        -0.00 |          -0.44
|BM_CmpLess_schar_schar    |       0.66 |        0.66 |        -0.00 |          -0.40
|BM_CmpLess_schar_short    |       0.88 |        0.88 |        -0.00 |          -0.50
|BM_CmpLess_schar_uchar    |       1.10 |        0.71 |        -0.39 |         -35.24
|BM_CmpLess_schar_uint     |       0.89 |        0.66 |        -0.23 |         -25.66
|BM_CmpLess_schar_ushort   |       0.99 |        0.77 |        -0.22 |         -22.49
|BM_CmpLess_short_int      |       0.66 |        0.66 |        -0.00 |          -0.35
|BM_CmpLess_short_schar    |       0.89 |        0.88 |        -0.00 |          -0.48
|BM_CmpLess_short_short    |       0.66 |        0.66 |        -0.00 |          -0.34
|BM_CmpLess_short_uchar    |       1.10 |        0.71 |        -0.39 |         -35.36
|BM_CmpLess_short_uint     |       0.88 |        0.66 |        -0.22 |         -25.39
|BM_CmpLess_short_ushort   |       1.77 |        0.77 |        -1.00 |         -56.42
|BM_CmpLess_uchar_int      |       0.97 |        0.66 |        -0.31 |         -31.95
|BM_CmpLess_uchar_schar    |       1.11 |        0.66 |        -0.44 |         -40.17
|BM_CmpLess_uchar_short    |       1.19 |        0.66 |        -0.53 |         -44.59
|BM_CmpLess_uchar_uchar    |       0.66 |        0.66 |        -0.00 |          -0.67
|BM_CmpLess_uchar_uint     |       0.67 |        0.66 |        -0.01 |          -1.19
|BM_CmpLess_uchar_ushort   |       0.77 |        0.77 |        -0.00 |          -0.40
|BM_CmpLess_uint_int       |       1.76 |        0.66 |        -1.10 |         -62.59
|BM_CmpLess_uint_schar     |       0.89 |        0.66 |        -0.23 |         -25.99
|BM_CmpLess_uint_short     |       0.88 |        0.66 |        -0.22 |         -25.41
|BM_CmpLess_uint_uchar     |       0.66 |        0.66 |        -0.01 |          -0.81
|BM_CmpLess_uint_uint      |       0.66 |        0.66 |        -0.00 |          -0.71
|BM_CmpLess_uint_ushort    |       0.66 |        0.66 |        -0.00 |          -0.29
|BM_CmpLess_ushort_int     |       0.98 |        0.66 |        -0.32 |         -33.00
|BM_CmpLess_ushort_schar   |       1.29 |        0.77 |        -0.52 |         -40.56
|BM_CmpLess_ushort_short   |       1.77 |        0.77 |        -1.00 |         -56.55
|BM_CmpLess_ushort_uchar   |       0.77 |        0.77 |        -0.01 |          -0.72
|BM_CmpLess_ushort_uint    |       0.66 |        0.66 |        -0.00 |          -0.46
|BM_CmpLess_ushort_ushort  |       0.66 |        0.66 |        -0.00 |          -0.71