### PR TITLE
[clang][bytecode] Fix diagnostics for int128 enums

### DIFF
--- a/clang/lib/AST/ByteCode/Opcodes.td
+++ b/clang/lib/AST/ByteCode/Opcodes.td
@@ -412,7 +412,7 @@ def CheckDecl : Opcode {
 
 def CheckEnumValue : Opcode {
   let Args = [ArgEnumDecl];
-  let Types = [FixedSizeIntegralTypeClass];
+  let Types = [IntegralTypeClass];
   let HasGroup = 1;
 }
 

--- a/clang/test/AST/ByteCode/intap.cpp
+++ b/clang/test/AST/ByteCode/intap.cpp
@@ -292,7 +292,19 @@ constexpr int shifts() { // both-error {{never produces a constant expression}}
   (void)(2 << b); // ref-warning {{shift count is negative}}
   return 1;
 }
-#endif
 
+namespace UnderlyingInt128 {
+  enum F  {
+    a = (__int128)-1
+  };
+
+  constexpr int foo() { // both-error {{never produces a constant expression}}
+    F f = (F)(__int128)10; // both-note 2{{integer value 10 is outside the valid range of values [-1, 0] for the enumeration type 'F'}}
+    return (int)f;
+  }
+  static_assert(foo() == 0, ""); // both-error {{not an integral constant expression}} \
+                                 // both-note {{in call to}}
+}
+#endif
 
 #endif


### PR DESCRIPTION
CheckEnumValue was not handling PT_IntAP/PT_IntAPS.