### PR TITLE
[lldb] Remove %T from lit tests

### DIFF
--- a/lldb/test/Shell/Commands/command-disassemble-process.yaml
+++ b/lldb/test/Shell/Commands/command-disassemble-process.yaml
@@ -1,19 +1,20 @@
 # REQUIRES: x86
 
-# RUN: yaml2obj --docnum=1 -DMAIN_SIZE=8 %s -o %T/command-disassemble-process.exe
-# RUN: yaml2obj --docnum=1 -DMAIN_SIZE=8000 %s -o %T/command-disassemble-process.big.exe
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj --docnum=1 -DMAIN_SIZE=8 %s -o %t.dir/command-disassemble-process.exe
+# RUN: yaml2obj --docnum=1 -DMAIN_SIZE=8000 %s -o %t.dir/command-disassemble-process.big.exe
 # RUN: yaml2obj --docnum=2 %s -o %t
 
-# RUN: %lldb -c %t %T/command-disassemble-process.exe \
+# RUN: %lldb -c %t %t.dir/command-disassemble-process.exe \
 # RUN:   -o "settings set interpreter.stop-command-source-on-error false" \
 # RUN:   -s %S/Inputs/command-disassemble-process.lldbinit -o exit \
 # RUN:   | FileCheck %s
 
-# RUN: %lldb -c %t %T/command-disassemble-process.big.exe \
+# RUN: %lldb -c %t %t.dir/command-disassemble-process.big.exe \
 # RUN:   -o "settings set stop-disassembly-max-size 8000" \
 # RUN:   -o disassemble -o exit 2>&1 | FileCheck %s --check-prefix=BIG
 
-# RUN: %lldb -c %t %T/command-disassemble-process.exe \
+# RUN: %lldb -c %t %t.dir/command-disassemble-process.exe \
 # RUN:   -o "settings set interpreter.stop-command-source-on-error false" \
 # RUN:   -o "disassemble --address 0xdead" -o exit 2>&1 \
 # RUN:   | FileCheck %s --check-prefix=INVALID

--- a/lldb/test/Shell/Commands/command-image-lookup.yaml
+++ b/lldb/test/Shell/Commands/command-image-lookup.yaml
@@ -1,7 +1,8 @@
-# RUN: yaml2obj %s -o %T/a.out
-# RUN: %lldb %T/a.out -o "image lookup --verbose --address 0x0000000100003fa1" -o exit | FileCheck %s --check-prefix=NOINLINE
-# RUN: %lldb %T/a.out -o "image lookup --verbose --address 0x0000000100003fa2" -o exit | FileCheck %s --check-prefix=INLINE_1
-# RUN: %lldb %T/a.out -o "image lookup --verbose --address 0x0000000100003fa8" -o exit | FileCheck %s --check-prefix=INLINE_2
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %s -o %t.dir/a.out
+# RUN: %lldb %t.dir/a.out -o "image lookup --verbose --address 0x0000000100003fa1" -o exit | FileCheck %s --check-prefix=NOINLINE
+# RUN: %lldb %t.dir/a.out -o "image lookup --verbose --address 0x0000000100003fa2" -o exit | FileCheck %s --check-prefix=INLINE_1
+# RUN: %lldb %t.dir/a.out -o "image lookup --verbose --address 0x0000000100003fa8" -o exit | FileCheck %s --check-prefix=INLINE_2
 
 #      NOINLINE: Summary: a.out`main + 33 at main.cpp:10
 # NOINLINE-NEXT: Module: file =

--- a/lldb/test/Shell/Minidump/Windows/arm-fp-unwind.test
+++ b/lldb/test/Shell/Minidump/Windows/arm-fp-unwind.test
@@ -2,10 +2,11 @@ Test that unwind plans use the frame pointer register correctly.
 
 REQUIRES: arm
 
-RUN: yaml2obj %S/Inputs/arm-fp-unwind.exe.yaml -o %T/arm-fp-unwind.exe
-RUN: yaml2obj %S/Inputs/arm-fp-unwind.dmp.yaml -o %T/arm-fp-unwind.dmp
-RUN: %lldb -O "settings set target.exec-search-paths %T" \
-RUN:   -c %T/arm-fp-unwind.dmp -o "image show-unwind -a 0x00c71010" -b \
+RUN: mkdir -p %t.dir
+RUN: yaml2obj %S/Inputs/arm-fp-unwind.exe.yaml -o %t.dir/arm-fp-unwind.exe
+RUN: yaml2obj %S/Inputs/arm-fp-unwind.dmp.yaml -o %t.dir/arm-fp-unwind.dmp
+RUN: %lldb -O "settings set target.exec-search-paths %t.dir" \
+RUN:   -c %t.dir/arm-fp-unwind.dmp -o "image show-unwind -a 0x00c71010" -b \
 RUN:   | FileCheck %s
 
 CHECK: Assembly language inspection UnwindPlan:

--- a/lldb/test/Shell/Minidump/Windows/broken-unwind.test
+++ b/lldb/test/Shell/Minidump/Windows/broken-unwind.test
@@ -1,7 +1,8 @@
 Test that we can cope with broken unwind information that suggests
 reading out of bounds.
 
-RUN: yaml2obj %S/Inputs/broken-unwind.exe.yaml -o %T/broken-unwind.exe
-RUN: yaml2obj %S/Inputs/broken-unwind.dmp.yaml -o %T/broken-unwind.dmp
-RUN: %lldb -O "settings set target.exec-search-paths %T" \
-RUN:   -c %T/broken-unwind.dmp -o "image show-unwind -a 0xb1000" -o exit
+RUN: mkdir -p %t.dir
+RUN: yaml2obj %S/Inputs/broken-unwind.exe.yaml -o %t.dir/broken-unwind.exe
+RUN: yaml2obj %S/Inputs/broken-unwind.dmp.yaml -o %t.dir/broken-unwind.dmp
+RUN: %lldb -O "settings set target.exec-search-paths %t.dir" \
+RUN:   -c %t.dir/broken-unwind.dmp -o "image show-unwind -a 0xb1000" -o exit

--- a/lldb/test/Shell/Minidump/Windows/find-module.test
+++ b/lldb/test/Shell/Minidump/Windows/find-module.test
@@ -3,18 +3,19 @@ use it when opening minidumps.
 
 XFAIL: system-windows && remote-linux
 
-RUN: yaml2obj %S/Inputs/find-module.exe.yaml -o %T/find-module.exe
-RUN: yaml2obj %S/Inputs/find-module.dmp.yaml -o %T/find-module.dmp
-RUN: %lldb -O "settings set target.exec-search-paths %T" \
-RUN:   -c %T/find-module.dmp -o "image dump objfile" -o "target list" -o exit \
+RUN: mkdir -p %t.dir
+RUN: yaml2obj %S/Inputs/find-module.exe.yaml -o %t.dir/find-module.exe
+RUN: yaml2obj %S/Inputs/find-module.dmp.yaml -o %t.dir/find-module.dmp
+RUN: %lldb -O "settings set target.exec-search-paths %t.dir" \
+RUN:   -c %t.dir/find-module.dmp -o "image dump objfile" -o "target list" -o exit \
 RUN:   | FileCheck --check-prefix=DEFAULT %s
 
 RUN: %lldb -O "settings set plugin.object-file.pe-coff.abi msvc" \
-RUN:   -O "settings set target.exec-search-paths %T" -c %T/find-module.dmp \
+RUN:   -O "settings set target.exec-search-paths %t.dir" -c %t.dir/find-module.dmp \
 RUN:   -o "target list" -o exit | FileCheck --check-prefix=MSVC %s
 
 RUN: %lldb -O "settings set plugin.object-file.pe-coff.abi gnu" \
-RUN:   -O "settings set target.exec-search-paths %T" -c %T/find-module.dmp \
+RUN:   -O "settings set target.exec-search-paths %t.dir" -c %t.dir/find-module.dmp \
 RUN:   -o "target list" -o exit | FileCheck --check-prefix=GNU %s
 
 DEFAULT-LABEL: image dump objfile

--- a/lldb/test/Shell/Minidump/memory-region-from-module.yaml
+++ b/lldb/test/Shell/Minidump/memory-region-from-module.yaml
@@ -3,14 +3,14 @@
 
 # RUN: yaml2obj --docnum=1 %s -o %t1.dmp
 # RUN: yaml2obj --docnum=2 %s -o %t2.dmp
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/memory-region-from-module.exe
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.memory-region-from-module.exe
 
-# RUN: %lldb -b -c %t1.dmp %T/memory-region-from-module.exe \
+# RUN: %lldb -b -c %t1.dmp %t.memory-region-from-module.exe \
 # RUN:   -o "memory region 0" -o "memory region 0x4000" \
 # RUN:   -o "memory region 0x5000" -o "memory region 0x6000" \
 # RUN:   | FileCheck --check-prefix=ALL --check-prefix=CHECK1 %s
 
-# RUN: %lldb -b -c %t2.dmp %T/memory-region-from-module.exe \
+# RUN: %lldb -b -c %t2.dmp %t.memory-region-from-module.exe \
 # RUN:   -o "memory region 0" -o "memory region 0x4000" \
 # RUN:   -o "memory region 0x5000" -o "memory region 0x6000" \
 # RUN:   | FileCheck --check-prefix=ALL --check-prefix=CHECK2 %s

--- a/lldb/test/Shell/ObjectFile/Breakpad/uuid-matching-mac.test
+++ b/lldb/test/Shell/ObjectFile/Breakpad/uuid-matching-mac.test
@@ -1,6 +1,7 @@
-# RUN: yaml2obj %S/Inputs/uuid-matching-mac.yaml -o %T/uuid-matching-mac.out
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/uuid-matching-mac.yaml -o %t.dir/uuid-matching-mac.out
 # RUN: cd %S
-# RUN: %lldb %T/uuid-matching-mac.out -s %s -o exit | FileCheck %s
+# RUN: %lldb %t.dir/uuid-matching-mac.out -s %s -o exit | FileCheck %s
 
 target symbols add Inputs/uuid-matching-mac.syms
 # CHECK-LABEL: target symbols add

--- a/lldb/test/Shell/ObjectFile/ELF/minidebuginfo-set-and-hit-breakpoint.test
+++ b/lldb/test/Shell/ObjectFile/ELF/minidebuginfo-set-and-hit-breakpoint.test
@@ -2,8 +2,8 @@
 
 # We want to keep the symbol "multiplyByThree" in the .dynamic section and not
 # have it put the default .symtab section.
-# RUN: echo "{multiplyByThree;};" > %T/dynmic-symbols.txt
-# RUN: %clang_host -Wl,--dynamic-list=%T/dynmic-symbols.txt -g -o %t.binary %p/Inputs/minidebuginfo-main.c
+# RUN: echo "{multiplyByThree;};" > %t.dynmic-symbols.txt
+# RUN: %clang_host -Wl,--dynamic-list=%t.dynmic-symbols.txt -g -o %t.binary %p/Inputs/minidebuginfo-main.c
 
 # The following section is adapted from GDB's official documentation:
 # http://sourceware.org/gdb/current/onlinedocs/gdb/MiniDebugInfo.html#MiniDebugInfo

--- a/lldb/test/Shell/SymbolFile/Breakpad/inline-record.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/inline-record.test
@@ -1,5 +1,6 @@
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/inline-record.out
-# RUN: %lldb %T/inline-record.out -o "target symbols add -s inline-record.out %S/Inputs/inline-record.syms" \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/inline-record.out
+# RUN: %lldb %t.dir/inline-record.out -o "target symbols add -s inline-record.out %S/Inputs/inline-record.syms" \
 # RUN:   -s %s | FileCheck --match-full-lines %s
 
 # CHECK-LABEL: (lldb) image lookup -a 0x400010 -v

--- a/lldb/test/Shell/SymbolFile/Breakpad/line-table-discontinuous-file-ids.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/line-table-discontinuous-file-ids.test
@@ -1,7 +1,8 @@
 # Test that we handle files which has gaps in the FILE record IDs.
 
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/line-table-discontinuous-file-ids.out
-# RUN: %lldb %T/line-table-discontinuous-file-ids.out \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/line-table-discontinuous-file-ids.out
+# RUN: %lldb %t.dir/line-table-discontinuous-file-ids.out \
 # RUN:   -o "target symbols add -s line-table-discontinuous-file-ids.out %S/Inputs/line-table-discontinuous-file-ids.syms" \
 # RUN:   -s %s -o exit | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/Breakpad/line-table-edgecases.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/line-table-edgecases.test
@@ -2,8 +2,9 @@
 # input contains a LINE record which does not belong to any function as well as
 # a FUNC record without any LINE records.
 
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/line-table-edgecases.out
-# RUN: %lldb %T/line-table-edgecases.out \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/line-table-edgecases.out
+# RUN: %lldb %t.dir/line-table-edgecases.out \
 # RUN:   -o "target symbols add -s line-table-edgecases.out %S/Inputs/line-table-edgecases.syms" \
 # RUN:   -s %s -o exit | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/Breakpad/line-table-missing-file.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/line-table-missing-file.test
@@ -3,8 +3,9 @@
 # Right now, "something reasonable" means creating a line entry with an empty
 # file.
 
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/line-table-missing-file.out
-# RUN: %lldb %T/line-table-missing-file.out \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/line-table-missing-file.out
+# RUN: %lldb %t.dir/line-table-missing-file.out \
 # RUN:   -o "target symbols add -s line-table-missing-file.out %S/Inputs/line-table-missing-file.syms" \
 # RUN:   -s %s -o exit | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/Breakpad/line-table-mixed-path-styles.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/line-table-mixed-path-styles.test
@@ -1,5 +1,6 @@
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/line-table-mixed-path-styles.out
-# RUN: %lldb %T/line-table-mixed-path-styles.out \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/line-table-mixed-path-styles.out
+# RUN: %lldb %t.dir/line-table-mixed-path-styles.out \
 # RUN:   -o "target symbols add -s line-table-mixed-path-styles.out %S/Inputs/line-table-mixed-path-styles.syms" \
 # RUN:   -s %s -o exit | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/Breakpad/line-table.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/line-table.test
@@ -1,5 +1,6 @@
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/line-table.out
-# RUN: %lldb %T/line-table.out -o "target symbols add -s line-table.out %S/Inputs/line-table.syms" \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/line-table.out
+# RUN: %lldb %t.dir/line-table.out -o "target symbols add -s line-table.out %S/Inputs/line-table.syms" \
 # RUN:   -s %s -o exit | FileCheck %s
 
 # We create a compile unit for each function. The compile unit name is the first

--- a/lldb/test/Shell/SymbolFile/Breakpad/symtab-macho.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/symtab-macho.test
@@ -1,5 +1,6 @@
-# RUN: yaml2obj %S/Inputs/basic-macho.yaml -o %T/symtab-macho.out
-# RUN: %lldb %T/symtab-macho.out -o "target symbols add %S/Inputs/symtab-macho.syms" \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-macho.yaml -o %t.dir/symtab-macho.out
+# RUN: %lldb %t.dir/symtab-macho.out -o "target symbols add %S/Inputs/symtab-macho.syms" \
 # RUN:   -s %s | FileCheck %s
 
 image dump symtab symtab-macho.out

--- a/lldb/test/Shell/SymbolFile/Breakpad/symtab-sorted-by-size.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/symtab-sorted-by-size.test
@@ -1,5 +1,6 @@
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/symtab-sorted-by-size.out
-# RUN: %lldb %T/symtab-sorted-by-size.out -o "target symbols add -s symtab-sorted-by-size.out %S/Inputs/symtab.syms" \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/symtab-sorted-by-size.out
+# RUN: %lldb %t.dir/symtab-sorted-by-size.out -o "target symbols add -s symtab-sorted-by-size.out %S/Inputs/symtab.syms" \
 # RUN:   -s %s | FileCheck %s
 
 # CHECK: num_symbols = 4 (sorted by size):

--- a/lldb/test/Shell/SymbolFile/Breakpad/symtab.test
+++ b/lldb/test/Shell/SymbolFile/Breakpad/symtab.test
@@ -1,5 +1,6 @@
-# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %T/symtab.out
-# RUN: %lldb %T/symtab.out -o "target symbols add -s symtab.out %S/Inputs/symtab.syms" \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/basic-elf.yaml -o %t.dir/symtab.out
+# RUN: %lldb %t.dir/symtab.out -o "target symbols add -s symtab.out %S/Inputs/symtab.syms" \
 # RUN:   -s %s | FileCheck %s
 
 # CHECK-LABEL: (lldb) image dump symtab symtab.out

--- a/lldb/test/Shell/SymbolFile/Breakpad/unwind-via-stack-win-no-memory-info.yaml
+++ b/lldb/test/Shell/SymbolFile/Breakpad/unwind-via-stack-win-no-memory-info.yaml
@@ -1,8 +1,9 @@
 # REQUIRES: x86
 
 # RUN: yaml2obj --docnum=1 %s -o %t.dmp
-# RUN: yaml2obj --docnum=2 %s -o %T/unwind-via-stack-win-no-memory-info.exe
-# RUN: %lldb -c %t.dmp %T/unwind-via-stack-win-no-memory-info.exe \
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj --docnum=2 %s -o %t.dir/unwind-via-stack-win-no-memory-info.exe
+# RUN: %lldb -c %t.dmp %t.dir/unwind-via-stack-win-no-memory-info.exe \
 # RUN:   -o "target symbols add %S/Inputs/unwind-via-raSearch.syms" \
 # RUN:   -o "thread backtrace" -b | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/DWARF/dwo-missing-error.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwo-missing-error.test
@@ -9,7 +9,6 @@
 # Creating and compiling to %t.compdir makes it easy to remove the dwo files.
 # DW_AT_comp_dir should be "./a/b/", and DW_AT_dwo_name should be
 # "a.out-dwo-missing-error.dwo".
-# since %T is deprecated.
 # RUN: rm -rf %t.compdir/
 # RUN: mkdir -p %t.compdir/a/b/
 # RUN: cd %t.compdir/a/b/

--- a/lldb/test/Shell/SymbolFile/DWARF/dwo-relative-path.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwo-relative-path.s
@@ -3,12 +3,13 @@
 
 # REQUIRES: x86
 
-# RUN: llvm-mc --filetype=obj --triple x86_64-pc-linux %s -o %t.o
-# RUN: llvm-objcopy --split-dwo=%T/dwo-relative-path.dwo %t.o
+# RUN: mkdir -p %t.dir
+# RUN: llvm-mc --filetype=obj --triple x86_64-pc-linux %s -o %t.dir/obj.o
+# RUN: llvm-objcopy --split-dwo=%t.dir/dwo-relative-path.dwo %t.dir/obj.o
 
 # RUN: cd ../..
 
-# RUN: %lldb %t.o -o "target var x" -b 2>&1 | FileCheck %s
+# RUN: %lldb %t.dir/obj.o -o "target var x" -b 2>&1 | FileCheck %s
 
 # CHECK: x = 10
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug_loclists-dwo.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug_loclists-dwo.s
@@ -1,4 +1,5 @@
-# RUN: cd %T
+# RUN: mkdir -p %t.dir
+# RUN: cd %t.dir
 # RUN: llvm-mc -triple=x86_64-pc-linux -filetype=obj %s >debug_loclists-dwo.o
 # RUN: %lldb debug_loclists-dwo.o -o "image lookup -v -s lookup_loclists" -o exit | FileCheck %s
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug_rnglists-dwo.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug_rnglists-dwo.s
@@ -1,4 +1,5 @@
-# RUN: cd %T
+# RUN: mkdir -p %t.dir
+# RUN: cd %t.dir
 # RUN: llvm-mc -triple=x86_64-pc-linux -filetype=obj %s >debug_rnglists-dwo.o
 # RUN: %lldb debug_rnglists-dwo.o -o "image lookup -v -s lookup_rnglists" \
 # RUN:   -o exit | FileCheck %s

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwo-type-in-main-file.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwo-type-in-main-file.s
@@ -3,9 +3,9 @@
 # file.
 
 # RUN: mkdir -p %t.dir
-# RUN: llvm-mc %s -o %t --triple=x86_64-pc-linux --filetype=obj --defsym MAIN=0
+# RUN: llvm-mc %s -o %t.dir/obj.o --triple=x86_64-pc-linux --filetype=obj --defsym MAIN=0
 # RUN: llvm-mc %s -o %t.dir/dwo-type-in-main-file-cu2.dwo --triple=x86_64-pc-linux --filetype=obj --defsym DWO=0
-# RUN: %lldb %t -o "target var a" -b 2>&1 | FileCheck %s
+# RUN: %lldb %t.dir/obj.o -o "target var a" -b 2>&1 | FileCheck %s
 
 # CHECK: (A) a = (b = 47)
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwo-type-in-main-file.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwo-type-in-main-file.s
@@ -2,8 +2,9 @@
 # type, but that type is defined in another compile unit in the main object
 # file.
 
+# RUN: mkdir -p %t.dir
 # RUN: llvm-mc %s -o %t --triple=x86_64-pc-linux --filetype=obj --defsym MAIN=0
-# RUN: llvm-mc %s -o %T/dwo-type-in-main-file-cu2.dwo --triple=x86_64-pc-linux --filetype=obj --defsym DWO=0
+# RUN: llvm-mc %s -o %t.dir/dwo-type-in-main-file-cu2.dwo --triple=x86_64-pc-linux --filetype=obj --defsym DWO=0
 # RUN: %lldb %t -o "target var a" -b 2>&1 | FileCheck %s
 
 # CHECK: (A) a = (b = 47)

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwo-type-in-main-file.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwo-type-in-main-file.s
@@ -4,7 +4,6 @@
 
 # RUN: llvm-mc %s -o %t --triple=x86_64-pc-linux --filetype=obj --defsym MAIN=0
 # RUN: llvm-mc %s -o %T/dwo-type-in-main-file-cu2.dwo --triple=x86_64-pc-linux --filetype=obj --defsym DWO=0
-# RUN: cd %T
 # RUN: %lldb %t -o "target var a" -b 2>&1 | FileCheck %s
 
 # CHECK: (A) a = (b = 47)

--- a/lldb/test/Shell/SymbolFile/PDB/class-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/class-layout.test
@@ -1,16 +1,17 @@
 REQUIRES: target-windows, msvc
-RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/ClassLayoutTest.cpp.obj %S/Inputs/ClassLayoutTest.cpp
-RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/ClassLayoutTest.cpp.exe %T/ClassLayoutTest.cpp.obj
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=ENUM %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=UNION %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=STRUCT %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=COMPLEX %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=LIST %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=UNNAMED-STRUCT %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=BASE %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=FRIEND %s
-RUN: lldb-test symbols %T/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=CLASS %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/ClassLayoutTest.cpp.obj %S/Inputs/ClassLayoutTest.cpp
+RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/ClassLayoutTest.cpp.exe %t.dir/ClassLayoutTest.cpp.obj
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=ENUM %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=UNION %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=STRUCT %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=COMPLEX %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=LIST %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=UNNAMED-STRUCT %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=BASE %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=FRIEND %s
+RUN: lldb-test symbols %t.dir/ClassLayoutTest.cpp.exe | FileCheck --check-prefix=CLASS %s
 
 CHECK: Module [[MOD:.*]]
 CHECK: SymbolFile pdb ([[MOD]])

--- a/lldb/test/Shell/SymbolFile/PDB/compilands.test
+++ b/lldb/test/Shell/SymbolFile/PDB/compilands.test
@@ -1,8 +1,9 @@
 REQUIRES: target-windows, msvc
-RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/CompilandsTest.cpp.obj %S/Inputs/CompilandsTest.cpp
-RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/CompilandsTest.cpp.exe %T/CompilandsTest.cpp.obj
-RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %T/CompilandsTest.cpp.exe | FileCheck %s
-RUN: lldb-test symbols %T/CompilandsTest.cpp.exe | FileCheck %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/CompilandsTest.cpp.obj %S/Inputs/CompilandsTest.cpp
+RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/CompilandsTest.cpp.exe %t.dir/CompilandsTest.cpp.obj
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/CompilandsTest.cpp.exe | FileCheck %s
+RUN: lldb-test symbols %t.dir/CompilandsTest.cpp.exe | FileCheck %s
 
 ; Link default libraries
 

--- a/lldb/test/Shell/SymbolFile/PDB/enums-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/enums-layout.test
@@ -1,11 +1,12 @@
 REQUIRES: system-windows, msvc
-RUN: %build --compiler=msvc --arch=32 --nodefaultlib --output=%T/SimpleTypesTest.cpp.enums.exe %S/Inputs/SimpleTypesTest.cpp
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=ENUM %s
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=CONST-ENUM %s
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=EMPTY-ENUM %s
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=UCHAR-ENUM %s
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=CLASS-ENUM %s
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=STRUCT-ENUM %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=msvc --arch=32 --nodefaultlib --output=%t.dir/SimpleTypesTest.cpp.enums.exe %S/Inputs/SimpleTypesTest.cpp
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=ENUM %s
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=CONST-ENUM %s
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=EMPTY-ENUM %s
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=UCHAR-ENUM %s
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=CLASS-ENUM %s
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.enums.exe | FileCheck --check-prefix=STRUCT-ENUM %s
 
 ; FIXME: PDB does not have information about scoped enumeration (Enum class) so the  
 ; compiler type used is the same as the one for unscoped enumeration.

--- a/lldb/test/Shell/SymbolFile/PDB/func-symbols.test
+++ b/lldb/test/Shell/SymbolFile/PDB/func-symbols.test
@@ -1,7 +1,8 @@
 REQUIRES: target-windows, lld
-RUN: %build --compiler=clang-cl --arch=32 --nodefaultlib --output=%T/FuncSymbolsTest.exe %S/Inputs/FuncSymbolsTestMain.cpp %S/Inputs/FuncSymbols.cpp
-RUN: lldb-test symbols %T/FuncSymbolsTest.exe | FileCheck --check-prefix=CHECK-ONE %s
-RUN: lldb-test symbols %T/FuncSymbolsTest.exe | FileCheck --check-prefix=CHECK-TWO %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=clang-cl --arch=32 --nodefaultlib --output=%t.dir/FuncSymbolsTest.exe %S/Inputs/FuncSymbolsTestMain.cpp %S/Inputs/FuncSymbols.cpp
+RUN: lldb-test symbols %t.dir/FuncSymbolsTest.exe | FileCheck --check-prefix=CHECK-ONE %s
+RUN: lldb-test symbols %t.dir/FuncSymbolsTest.exe | FileCheck --check-prefix=CHECK-TWO %s
 
 ; Link multiple objects
 ; In this test, We don't check demangled name of a mangled function.

--- a/lldb/test/Shell/SymbolFile/PDB/pointers.test
+++ b/lldb/test/Shell/SymbolFile/PDB/pointers.test
@@ -1,11 +1,12 @@
 REQUIRES: target-windows, msvc
-RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/PointerTypeTest.cpp.obj %S/Inputs/PointerTypeTest.cpp
-RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/PointerTypeTest.cpp.exe %T/PointerTypeTest.cpp.obj
-RUN: lldb-test symbols %T/PointerTypeTest.cpp.exe | FileCheck %s
-RUN: lldb-test symbols %T/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-F %s
-RUN: lldb-test symbols %T/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST %s
-RUN: lldb-test symbols %T/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN %s
-RUN: lldb-test symbols %T/PointerTypeTest.cpp.exe | FileCheck --check-prefix=F %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/PointerTypeTest.cpp.obj %S/Inputs/PointerTypeTest.cpp
+RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/PointerTypeTest.cpp.exe %t.dir/PointerTypeTest.cpp.obj
+RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck %s
+RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST-F %s
+RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN-ST %s
+RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=MAIN %s
+RUN: lldb-test symbols %t.dir/PointerTypeTest.cpp.exe | FileCheck --check-prefix=F %s
 
 CHECK: Module [[MOD:.*]]
 CHECK: {{^[0-9A-F]+}}:   CompileUnit{{[{]0x[0-9a-f]+[}]}}, language = "c++", file = '{{.*}}\PointerTypeTest.cpp'

--- a/lldb/test/Shell/SymbolFile/PDB/type-quals.test
+++ b/lldb/test/Shell/SymbolFile/PDB/type-quals.test
@@ -1,7 +1,8 @@
 REQUIRES: target-windows, msvc
-RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%T/TypeQualsTest.cpp.obj %S/Inputs/TypeQualsTest.cpp
-RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%T/TypeQualsTest.cpp.exe %T/TypeQualsTest.cpp.obj
-RUN: lldb-test symbols %T/TypeQualsTest.cpp.exe | FileCheck %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/TypeQualsTest.cpp.obj %S/Inputs/TypeQualsTest.cpp
+RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/TypeQualsTest.cpp.exe %t.dir/TypeQualsTest.cpp.obj
+RUN: lldb-test symbols %t.dir/TypeQualsTest.cpp.exe | FileCheck %s
 
 CHECK: Module [[MOD:.*]]
 CHECK-DAG: SymbolFile pdb ([[MOD]])

--- a/lldb/test/Shell/SymbolFile/PDB/typedefs.test
+++ b/lldb/test/Shell/SymbolFile/PDB/typedefs.test
@@ -1,6 +1,7 @@
 REQUIRES: system-windows, msvc
-RUN: %build --compiler=msvc --arch=32 --nodefaultlib --output=%T/SimpleTypesTest.cpp.typedefs.exe %S/Inputs/SimpleTypesTest.cpp
-RUN: lldb-test symbols %T/SimpleTypesTest.cpp.typedefs.exe | FileCheck %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=msvc --arch=32 --nodefaultlib --output=%t.dir/SimpleTypesTest.cpp.typedefs.exe %S/Inputs/SimpleTypesTest.cpp
+RUN: lldb-test symbols %t.dir/SimpleTypesTest.cpp.typedefs.exe | FileCheck %s
 
 ; Generate 32-bit target
 

--- a/lldb/test/Shell/SymbolFile/PDB/variables.test
+++ b/lldb/test/Shell/SymbolFile/PDB/variables.test
@@ -1,12 +1,13 @@
 REQUIRES: system-windows, msvc
-RUN: %build --compiler=clang-cl --mode=compile --arch=64 --nodefaultlib --output=%T/VariablesTest.cpp.obj %S/Inputs/VariablesTest.cpp
-RUN: %build --compiler=msvc --mode=link --arch=64 --nodefaultlib --output=%T/VariablesTest.cpp.exe %T/VariablesTest.cpp.obj
-RUN: lldb-test symbols %T/VariablesTest.cpp.exe > %T/VariablesTest.out
-RUN: FileCheck --check-prefix=GLOBALS --input-file=%T/VariablesTest.out %s
-RUN: FileCheck --check-prefix=FUNC-F --input-file=%T/VariablesTest.out %s
-RUN: FileCheck --check-prefix=FUNC-MAIN --input-file=%T/VariablesTest.out %s
-RUN: FileCheck --check-prefix=FUNC-CONSTRUCTOR --input-file=%T/VariablesTest.out %s
-RUN: FileCheck --check-prefix=FUNC-MEMBER --input-file=%T/VariablesTest.out %s
+RUN: mkdir -p %t.dir
+RUN: %build --compiler=clang-cl --mode=compile --arch=64 --nodefaultlib --output=%t.dir/VariablesTest.cpp.obj %S/Inputs/VariablesTest.cpp
+RUN: %build --compiler=msvc --mode=link --arch=64 --nodefaultlib --output=%t.dir/VariablesTest.cpp.exe %t.dir/VariablesTest.cpp.obj
+RUN: lldb-test symbols %t.dir/VariablesTest.cpp.exe > %t.dir/VariablesTest.out
+RUN: FileCheck --check-prefix=GLOBALS --input-file=%t.dir/VariablesTest.out %s
+RUN: FileCheck --check-prefix=FUNC-F --input-file=%t.dir/VariablesTest.out %s
+RUN: FileCheck --check-prefix=FUNC-MAIN --input-file=%t.dir/VariablesTest.out %s
+RUN: FileCheck --check-prefix=FUNC-CONSTRUCTOR --input-file=%t.dir/VariablesTest.out %s
+RUN: FileCheck --check-prefix=FUNC-MEMBER --input-file=%t.dir/VariablesTest.out %s
 
 GLOBALS: Module [[MOD:.*]]
 GLOBALS: SymbolFile pdb ([[MOD]])


### PR DESCRIPTION
%T has been deprecated for about seven years, mostly because it is not unique to each test which can lead to races. This patch updates the few remaining tests in lldb that use %T to not use it (either directly using files or creating their own temp dir). The eventual goal is to remove support for %T from llvm-lit given few tests use it and it still has racey behavior.

This patch errors on the side of creating new temp dirs even when not strictly necessary to avoid needing to update filenames inside filecheck matchers.