### PR TITLE
[lldb] Add `ValueObject::CreateValueObjectFromScalar` and fix `Scalar::GetData`

### DIFF
--- a/lldb/include/lldb/Utility/Scalar.h
+++ b/lldb/include/lldb/Utility/Scalar.h
@@ -84,11 +84,15 @@ public:
   /// Store the binary representation of this value into the given storage.
   /// Exactly GetByteSize() bytes will be stored, and the buffer must be large
   /// enough to hold this data.
+  void GetBytes(uint8_t *storage, size_t length) const;
   void GetBytes(llvm::MutableArrayRef<uint8_t> storage) const;
 
   size_t GetByteSize() const;
 
-  bool GetData(DataExtractor &data, size_t limit_byte_size = UINT32_MAX) const;
+  /// Get data with a byte size of GetByteSize().
+  bool GetData(DataExtractor &data) const;
+  /// Get data with a byte size forced to \p result_byte_size.
+  bool GetData(DataExtractor &data, size_t result_byte_size) const;
 
   size_t GetAsMemoryData(void *dst, size_t dst_len,
                          lldb::ByteOrder dst_byte_order, Status &error) const;

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -737,6 +737,12 @@ public:
   CreateValueObjectFromAPFloat(lldb::TargetSP target, const llvm::APFloat &v,
                                CompilerType type, llvm::StringRef name);
 
+  /// Create a value object containing the given Scalar value.
+  static lldb::ValueObjectSP CreateValueObjectFromScalar(lldb::TargetSP target,
+                                                         Scalar &s,
+                                                         CompilerType type,
+                                                         llvm::StringRef name);
+
   /// Create a value object containing the given boolean value.
   static lldb::ValueObjectSP CreateValueObjectFromBool(lldb::TargetSP target,
                                                        bool value,

--- a/lldb/include/lldb/ValueObject/ValueObjectConstResult.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectConstResult.h
@@ -60,6 +60,11 @@ public:
                                     Value &value, ConstString name,
                                     Module *module = nullptr);
 
+  static lldb::ValueObjectSP Create(ExecutionContextScope *exe_scope,
+                                    const CompilerType &compiler_type,
+                                    Scalar &scalar, ConstString name,
+                                    Module *module = nullptr);
+
   // When an expression fails to evaluate, we return an error
   static lldb::ValueObjectSP Create(ExecutionContextScope *exe_scope,
                                     Status &&error);
@@ -144,6 +149,12 @@ private:
   ValueObjectConstResult(ExecutionContextScope *exe_scope,
                          ValueObjectManager &manager, const Value &value,
                          ConstString name, Module *module = nullptr);
+
+  ValueObjectConstResult(ExecutionContextScope *exe_scope,
+                         ValueObjectManager &manager,
+                         const CompilerType &compiler_type,
+                         const Scalar &scalar, ConstString name,
+                         Module *module = nullptr);
 
   ValueObjectConstResult(ExecutionContextScope *exe_scope,
                          ValueObjectManager &manager, Status &&error);

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -347,15 +347,9 @@ Status Value::GetValueAsData(ExecutionContext *exe_ctx, DataExtractor &data,
     else
       data.SetAddressByteSize(sizeof(void *));
 
-    uint32_t limit_byte_size = UINT32_MAX;
-
-    if (type_size)
-      limit_byte_size = *type_size;
-
-    if (limit_byte_size <= m_value.GetByteSize()) {
-      if (m_value.GetData(data, limit_byte_size))
-        return error; // Success;
-    }
+    uint32_t result_byte_size = *type_size;
+    if (m_value.GetData(data, result_byte_size))
+      return error; // Success;
 
     error = Status::FromErrorString("extracting data from value failed");
     break;

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -3589,6 +3589,13 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromAPFloat(
   return CreateValueObjectFromAPInt(target, v.bitcastToAPInt(), type, name);
 }
 
+lldb::ValueObjectSP ValueObject::CreateValueObjectFromScalar(
+    lldb::TargetSP target, Scalar &s, CompilerType type, llvm::StringRef name) {
+  ExecutionContext exe_ctx(target.get(), false);
+  return ValueObjectConstResult::Create(exe_ctx.GetBestExecutionContextScope(),
+                                        type, s, ConstString(name));
+}
+
 lldb::ValueObjectSP
 ValueObject::CreateValueObjectFromBool(lldb::TargetSP target, bool value,
                                        llvm::StringRef name) {

--- a/lldb/source/ValueObject/ValueObjectConstResult.cpp
+++ b/lldb/source/ValueObject/ValueObjectConstResult.cpp
@@ -105,6 +105,16 @@ ValueObjectSP ValueObjectConstResult::Create(ExecutionContextScope *exe_scope,
       ->GetSP();
 }
 
+ValueObjectSP ValueObjectConstResult::Create(ExecutionContextScope *exe_scope,
+                                             const CompilerType &compiler_type,
+                                             Scalar &scalar, ConstString name,
+                                             Module *module) {
+  auto manager_sp = ValueObjectManager::Create();
+  return (new ValueObjectConstResult(exe_scope, *manager_sp, compiler_type,
+                                     scalar, name, module))
+      ->GetSP();
+}
+
 ValueObjectConstResult::ValueObjectConstResult(
     ExecutionContextScope *exe_scope, ValueObjectManager &manager,
     const CompilerType &compiler_type, ConstString name,
@@ -191,6 +201,23 @@ ValueObjectConstResult::ValueObjectConstResult(ExecutionContextScope *exe_scope,
   ExecutionContext exe_ctx;
   exe_scope->CalculateExecutionContext(exe_ctx);
   m_error = m_value.GetValueAsData(&exe_ctx, m_data, module);
+}
+
+ValueObjectConstResult::ValueObjectConstResult(
+    ExecutionContextScope *exe_scope, ValueObjectManager &manager,
+    const CompilerType &compiler_type, const Scalar &scalar, ConstString name,
+    Module *module)
+    : ValueObject(exe_scope, manager), m_impl(this) {
+  m_value = Value(scalar);
+  m_value.SetCompilerType(compiler_type);
+  m_value.SetValueType(Value::ValueType::Scalar);
+  m_name = name;
+  ExecutionContext exe_ctx;
+  exe_scope->CalculateExecutionContext(exe_ctx);
+  m_error = m_value.GetValueAsData(&exe_ctx, m_data, module);
+  SetIsConstant();
+  SetValueIsValid(true);
+  SetAddressTypeOfChildren(eAddressTypeInvalid);
 }
 
 ValueObjectConstResult::~ValueObjectConstResult() = default;

--- a/lldb/source/ValueObject/ValueObjectConstResult.cpp
+++ b/lldb/source/ValueObject/ValueObjectConstResult.cpp
@@ -217,7 +217,7 @@ ValueObjectConstResult::ValueObjectConstResult(
   m_error = m_value.GetValueAsData(&exe_ctx, m_data, module);
   SetIsConstant();
   SetValueIsValid(true);
-  SetAddressTypeOfChildren(eAddressTypeInvalid);
+  SetAddressTypeOfChildren(eAddressTypeLoad);
 }
 
 ValueObjectConstResult::~ValueObjectConstResult() = default;

--- a/lldb/unittests/Utility/ScalarTest.cpp
+++ b/lldb/unittests/Utility/ScalarTest.cpp
@@ -191,6 +191,24 @@ TEST(ScalarTest, GetData) {
   EXPECT_THAT(
       get_data(llvm::APSInt::getMaxValue(/*numBits=*/9, /*Unsigned=*/true)),
       vec({0x01, 0xff}));
+
+  auto get_data_with_size = [](llvm::APInt v, size_t size) {
+    DataExtractor data;
+    Scalar(v).GetData(data, size);
+    return data.GetData().vec();
+  };
+
+  EXPECT_THAT(get_data_with_size(llvm::APInt(16, 0x0123), 8),
+              vec({0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x23}));
+
+  EXPECT_THAT(get_data_with_size(llvm::APInt(32, 0x01234567), 4),
+              vec({0x01, 0x23, 0x45, 0x67}));
+
+  EXPECT_THAT(get_data_with_size(llvm::APInt(48, 0xABCD01234567UL), 4),
+              vec({0x01, 0x23, 0x45, 0x67}));
+
+  EXPECT_THAT(get_data_with_size(llvm::APInt(64, 0xABCDEF0123456789UL), 2),
+              vec({0x67, 0x89}));
 }
 
 TEST(ScalarTest, SetValueFromData) {


### PR DESCRIPTION
Add `ValueObject::CreateValueObjectFromScalar` function and adjust `Scalar::GetData` to be able to both extend and truncate the data bytes in Scalar to a desired size.
