### PR TITLE
[clang][ARM] Fix build failure in <arm_acle.h> for __swp

### DIFF
--- a/clang/lib/Headers/arm_acle.h
+++ b/clang/lib/Headers/arm_acle.h
@@ -67,13 +67,10 @@ __swp(uint32_t __x, volatile uint32_t *__p) {
    * use it if there's no other option. */
   __asm__("swp %0, %1, [%2]" : "=r"(__v) : "r"(__x), "r"(__p) : "memory");
 #else
-  /* Armv6-M doesn't have either of LDREX or SWP. ACLE suggests this
-   * implementation, which Clang lowers to the 'cmpxchg' operation in LLVM IR.
-   * On Armv6-M, LLVM turns that into a libcall to __atomic_compare_exchange_4,
-   * so the runtime will need to implement that. */
-  do
-    __v = *__p;
-  while (__sync_bool_compare_and_swap(__p, __v, __x));
+  /* Armv6-M doesn't have either of LDREX or SWP. LLVM turns the following
+   * builtin into a libcall to __atomic_exchange_4, so the runtime will need to
+   * implement that. */
+  __v = __atomic_exchange_n(__p, __x, __ATOMIC_RELAXED);
 #endif
   return __v;
 }

--- a/clang/test/CodeGen/arm_acle.c
+++ b/clang/test/CodeGen/arm_acle.c
@@ -139,29 +139,10 @@ void test_dbg(void) {
 #endif
 
 /* 8.5 Swap */
-// AArch32-LABEL: @test_swp(
-// AArch32-NEXT:  entry:
-// AArch32-NEXT:    br label [[DO_BODY_I:%.*]]
-// AArch32:       do.body.i:
-// AArch32-NEXT:    [[LDREX_I:%.*]] = call i32 @llvm.arm.ldrex.p0(ptr elementtype(i32) [[P:%.*]])
-// AArch32-NEXT:    [[STREX_I:%.*]] = call i32 @llvm.arm.strex.p0(i32 [[X:%.*]], ptr elementtype(i32) [[P]])
-// AArch32-NEXT:    [[TOBOOL_I:%.*]] = icmp ne i32 [[STREX_I]], 0
-// AArch32-NEXT:    br i1 [[TOBOOL_I]], label [[DO_BODY_I]], label [[__SWP_EXIT:%.*]], !llvm.loop [[LOOP3:![0-9]+]]
-// AArch32:       __swp.exit:
-// AArch32-NEXT:    ret void
-//
-// AArch64-LABEL: @test_swp(
-// AArch64-NEXT:  entry:
-// AArch64-NEXT:    br label [[DO_BODY_I:%.*]]
-// AArch64:       do.body.i:
-// AArch64-NEXT:    [[LDXR_I:%.*]] = call i64 @llvm.aarch64.ldxr.p0(ptr elementtype(i32) [[P:%.*]])
-// AArch64-NEXT:    [[TMP0:%.*]] = trunc i64 [[LDXR_I]] to i32
-// AArch64-NEXT:    [[TMP1:%.*]] = zext i32 [[X:%.*]] to i64
-// AArch64-NEXT:    [[STXR_I:%.*]] = call i32 @llvm.aarch64.stxr.p0(i64 [[TMP1]], ptr elementtype(i32) [[P]])
-// AArch64-NEXT:    [[TOBOOL_I:%.*]] = icmp ne i32 [[STXR_I]], 0
-// AArch64-NEXT:    br i1 [[TOBOOL_I]], label [[DO_BODY_I]], label [[__SWP_EXIT:%.*]], !llvm.loop [[LOOP2:![0-9]+]]
-// AArch64:       __swp.exit:
-// AArch64-NEXT:    ret void
+// ARM-LABEL: @test_swp(
+// ARM-NEXT:  entry:
+// ARM-NEXT:    [[TMP0:%.*]] = atomicrmw volatile xchg ptr [[P:%.*]], i32 [[X:%.*]] monotonic, align 4
+// ARM-NEXT:    ret void
 //
 void test_swp(uint32_t x, volatile void *p) {
   __swp(x, p);

--- a/clang/test/CodeGen/arm_acle_swp.c
+++ b/clang/test/CodeGen/arm_acle_swp.c
@@ -1,19 +1,19 @@
 // RUN: %clang_cc1 -ffreestanding -triple thumbv7m-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=LDREX
 // RUN: %clang_cc1 -ffreestanding -triple armv7a-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=LDREX
 // RUN: %clang_cc1 -ffreestanding -triple armv6-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=LDREX
-// RUN: %clang_cc1 -ffreestanding -triple thumbv6m-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=SYNC
+// RUN: %clang_cc1 -ffreestanding -triple thumbv6m-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=ATOMIC
 // RUN: %clang_cc1 -ffreestanding -triple armv5-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=SWP
 
 // REQUIRES: arm-registered-target
 
 #include <arm_acle.h>
 
-// LDREX: call i32 @llvm.arm.ldrex.p0(ptr elementtype(i32) {{.*}})
-// LDREX: call i32 @llvm.arm.strex.p0(i32 {{.*}}, ptr elementtype(i32) {{.*}})
+// LDREX:  call i32 @llvm.arm.ldrex.p0(ptr elementtype(i32) {{.*}})
+// LDREX:  call i32 @llvm.arm.strex.p0(i32 {{.*}}, ptr elementtype(i32) {{.*}})
 
-// SWP:   call i32 asm "swp $0, $1, [$2]", "=r,r,r,~{memory}"(i32 {{.*}}, ptr {{.*}})
+// SWP:    call i32 asm "swp $0, $1, [$2]", "=r,r,r,~{memory}"(i32 {{.*}}, ptr {{.*}})
 
-// SYNC:  cmpxchg ptr {{.*}}, i32 {{.*}}, i32 {{.*}} seq_cst seq_cst, align 4
+// ATOMIC: atomicrmw volatile xchg ptr {{.*}}, i32 {{.*}} monotonic, align 4
 uint32_t test_swp(uint32_t x, volatile void *p) {
   return __swp(x, p);
 }

--- a/clang/test/CodeGen/arm_acle_swp.c
+++ b/clang/test/CodeGen/arm_acle_swp.c
@@ -1,15 +1,13 @@
-// RUN: %clang_cc1 -ffreestanding -triple thumbv7m-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=LDREX
-// RUN: %clang_cc1 -ffreestanding -triple armv7a-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=LDREX
-// RUN: %clang_cc1 -ffreestanding -triple armv6-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=LDREX
+// RUN: %clang_cc1 -ffreestanding -triple thumbv7m-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=ATOMIC
+// RUN: %clang_cc1 -ffreestanding -triple armv7a-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=ATOMIC
+// RUN: %clang_cc1 -ffreestanding -triple armv6-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=ATOMIC
 // RUN: %clang_cc1 -ffreestanding -triple thumbv6m-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=ATOMIC
+// RUN: %clang_cc1 -ffreestanding -triple armv5-unknown-linux-gnu -target-abi aapcs -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=ATOMIC
 // RUN: %clang_cc1 -ffreestanding -triple armv5-none-eabi -O0 -disable-O0-optnone -emit-llvm -o - %s | opt -S -passes=mem2reg | FileCheck %s -check-prefix=SWP
 
 // REQUIRES: arm-registered-target
 
 #include <arm_acle.h>
-
-// LDREX:  call i32 @llvm.arm.ldrex.p0(ptr elementtype(i32) {{.*}})
-// LDREX:  call i32 @llvm.arm.strex.p0(i32 {{.*}}, ptr elementtype(i32) {{.*}})
 
 // SWP:    call i32 asm "swp $0, $1, [$2]", "=r,r,r,~{memory}"(i32 {{.*}}, ptr {{.*}})
 


### PR DESCRIPTION
In commit d5985905ae8e5b2 I introduced a Sema check that prohibits `__builtin_arm_ldrex` and `__builtin_arm_strex` for data sizes not supported by the target architecture version. However, `arm_acle.h` unconditionally uses those builtins with a 32-bit data size. So now including that header will cause a build failure on Armv6-M, or historic architectures like Armv5.

To fix it, `arm_acle.h` now queries the compiler-defined `__ARM_FEATURE_LDREX` macro (also fixed recently in commit 34f59d79209268e so that it matches the target architecture). If 32-bit LDREX isn't available it can fall back to the older SWP instruction, or a libcall if nothing else is available (on Armv6-M). We also prefer to use a libcall if the target is Linux, because Linux is known to provide a suitable API. Most of this is done automatically by calling clang's `__atomic_exchange_n` builtin; the only case we have to do separately by inline asm is the `SWP`.

While I was modifying the header anyway, I also renamed the local variable `v` inside `__swp` so that it starts with `__`, avoiding any risk of user code having #defined `v`.