### PR TITLE
Revert "[lldb] Pick the builder for the target platform"

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -229,8 +229,7 @@ def hasChattyStderr(test_case):
 
 
 def builder_module():
-    """Return the builder for the target platform."""
-    return get_builder(getPlatform())
+    return get_builder(sys.platform)
 
 
 def getArchitecture():


### PR DESCRIPTION
Reverts llvm/llvm-project#151262 while I investigate why this breaks GreenDragon. 