### PR TITLE
[mlir] Add VCIX dialect maintainer

### DIFF
--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -44,6 +44,12 @@ MLIR components pertaining to egress flows from MLIR, in particular to LLVM IR.
   [@gysit](https://github.com/gysit) (GitHub),
   gysit (Discourse)
 
+### Dialects
+
+#### CPU Dialects
+
+* 'vcix' Dialect ([@mshockwave](https://github.com/mshockwave))
+
 ## Tensor Compiler
 
 MLIR components specific to construction of compilers for tensor algebra, in


### PR DESCRIPTION
As per https://discourse.llvm.org/t/mlir-project-maintainers/87189

This patch adds myself as the maintainer for the VCIX dialect in the egress dialect category.

------

@llvm/mlir-area-team
@matthias-springer 
@banach-space 
@gysit 