### PR TITLE
[analyzer] Retain address space information in getElementRegion

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1219,6 +1219,16 @@ MemRegionManager::getElementRegion(QualType elementType, NonLoc Idx,
                                    const ASTContext &Ctx) {
   QualType T = Ctx.getCanonicalType(elementType).getUnqualifiedType();
 
+  // The address space must be preserved because some target-specific address
+  // spaces influence the size of the pointer value which is represented by the
+  // element region.
+  LangAS AS = elementType.getAddressSpace();
+  if (AS != LangAS::Default) {
+    Qualifiers Quals;
+    Quals.setAddressSpace(AS);
+    T = Ctx.getQualifiedType(T, Quals);
+  }
+
   llvm::FoldingSetNodeID ID;
   ElementRegion::ProfileRegion(ID, T, Idx, superRegion);
 

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1222,8 +1222,7 @@ MemRegionManager::getElementRegion(QualType elementType, NonLoc Idx,
   // The address space must be preserved because some target-specific address
   // spaces influence the size of the pointer value which is represented by the
   // element region.
-  LangAS AS = elementType.getAddressSpace();
-  if (AS != LangAS::Default) {
+  if (LangAS AS = elementType.getAddressSpace()) {
     Qualifiers Quals;
     Quals.setAddressSpace(AS);
     T = Ctx.getQualifiedType(T, Quals);

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1222,7 +1222,8 @@ MemRegionManager::getElementRegion(QualType elementType, NonLoc Idx,
   // The address space must be preserved because some target-specific address
   // spaces influence the size of the pointer value which is represented by the
   // element region.
-  if (LangAS AS = elementType.getAddressSpace()) {
+  LangAS AS = elementType.getAddressSpace();
+  if (AS != LangAS::Default) {
     Qualifiers Quals;
     Quals.setAddressSpace(AS);
     T = Ctx.getQualifiedType(T, Quals);

--- a/clang/test/Analysis/element-region-address-space.c
+++ b/clang/test/Analysis/element-region-address-space.c
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -triple amdgcn-unknown-unknown \
-// RUN: -analyzer-checker=core,unix.Malloc -verify %s
+// RUN:   -analyzer-checker=core -verify %s
 
 // expected-no-diagnostics
 //
@@ -7,5 +7,5 @@
 #define ADDRESS_SPACE_32BITS __attribute__((address_space(3)))
 
 int test(ADDRESS_SPACE_32BITS int *p, ADDRESS_SPACE_32BITS void *q) {
-  return p == q;
+  return p == q; // no-crash
 }

--- a/clang/test/Analysis/element-region-address-space.c
+++ b/clang/test/Analysis/element-region-address-space.c
@@ -1,0 +1,11 @@
+// RUN: %clang_analyze_cc1 -triple amdgcn-unknown-unknown \
+// RUN: -analyzer-checker=core,unix.Malloc -verify %s
+
+// expected-no-diagnostics
+//
+// By default, pointers are 64-bits.
+#define ADDRESS_SPACE_32BITS __attribute__((address_space(3)))
+
+int test(ADDRESS_SPACE_32BITS int *p, ADDRESS_SPACE_32BITS void *q) {
+  return p == q;
+}


### PR DESCRIPTION
The factory method `MemRegionManager::getElementRegion()` is the main way of constructing `ElementRegion` objects, which are widespread in the analysis and may represent array elements (as lvalues), pointer arithmetics and type conversions.

This factory method used to strip all qualifiers from the type associated with the element (after canonicalizing it), but the address space qualifier can affect the size of a pointer type, so stripping it caused an assertion failure (in `evalBinOpLL`):

clang: clang/lib/StaticAnalyzer/Core/SimpleSValBuilder.cpp:785: void assertEqualBitWidths(clang::ento::ProgramStateRef, clang::ento::Loc, clang::ento::Loc): Assertion `RhsBitwidth == LhsBitwidth && "RhsLoc and LhsLoc bitwidth must be same!"' failed.