### PR TITLE
[lldb] Fix testing on macOS

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/__init__.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/__init__.py
@@ -8,7 +8,7 @@ factory method below hands out builders based on the given platform.
 
 def get_builder(platform):
     """Returns a Builder instance for the given platform."""
-    if platform == "darwin":
+    if platform in ("darwin", "macosx"):
         from .darwin import BuilderDarwin
 
         return BuilderDarwin()


### PR DESCRIPTION
When running `lldb-dotest -p SomeTest`, this exception was raised:

```python
raise Exception("Don't know how to build binary")
```

@felipepiovezan hit the same exception when running `ninja check-lldb`.

This change is _a_ fix to the problem.