### PR TITLE
[lldb] Don't use NamedTemporaryFile to test compiler support

### DIFF
--- a/lldb/packages/Python/lldbsuite/support/temp_file.py
+++ b/lldb/packages/Python/lldbsuite/support/temp_file.py
@@ -1,0 +1,23 @@
+"""
+Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+See https://llvm.org/LICENSE.txt for license information.
+SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""
+
+import os
+import tempfile
+
+
+class OnDiskTempFile:
+    def __init__(self, delete=True):
+        self.path = None
+
+    def __enter__(self):
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        self.path = path
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if os.path.exists(self.path):
+            os.remove(self.path)

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -43,6 +43,7 @@ from . import lldbtest_config
 from . import test_categories
 from . import test_result
 from ..support import seven
+from ..support import temp_file
 
 
 def is_exe(fpath):
@@ -780,8 +781,8 @@ def canRunLibcxxTests():
         return True, "libc++ always present"
 
     if platform == "linux":
-        with tempfile.NamedTemporaryFile() as f:
-            cmd = [configuration.compiler, "-xc++", "-stdlib=libc++", "-o", f.name, "-"]
+        with temp_file.OnDiskTempFile() as f:
+            cmd = [configuration.compiler, "-xc++", "-stdlib=libc++", "-o", f.path, "-"]
             p = subprocess.Popen(
                 cmd,
                 stdin=subprocess.PIPE,
@@ -840,8 +841,8 @@ def canRunMsvcStlTests():
     if platform != "windows":
         return False, f"Don't know how to build with MSVC's STL on {platform}"
 
-    with tempfile.NamedTemporaryFile() as f:
-        cmd = [configuration.compiler, "-xc++", "-o", f.name, "-E", "-"]
+    with temp_file.OnDiskTempFile() as f:
+        cmd = [configuration.compiler, "-xc++", "-o", f.path, "-E", "-"]
         p = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,


### PR DESCRIPTION
You cannot use a NamedTempFile with an external process because it may not be flushed to disk.  The safest and most portable approach is to close the file, call the other process and then unlink the file manually.

Presumably this works fine on Linux, but it fails on Darwin when targeting remote-linux.

See https://bugs.python.org/issue29573