### PR TITLE
[Support] [Windows] Conditionally compile the SetThreadInformation calls

### DIFF
--- a/llvm/lib/Support/Windows/Threading.inc
+++ b/llvm/lib/Support/Windows/Threading.inc
@@ -136,6 +136,7 @@ HMODULE loadSystemModuleSecure(LPCWSTR lpModuleName) {
 } // namespace llvm::sys::windows
 
 SetThreadPriorityResult llvm::set_thread_priority(ThreadPriority Priority) {
+#ifdef THREAD_POWER_THROTTLING_CURRENT_VERSION
   HMODULE kernelM = llvm::sys::windows::loadSystemModuleSecure(L"kernel32.dll");
   if (kernelM) {
     // SetThreadInformation is only available on Windows 8 and later. Since we
@@ -166,6 +167,7 @@ SetThreadPriorityResult llvm::set_thread_priority(ThreadPriority Priority) {
                                : 0);
     }
   }
+#endif
 
   // https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-setthreadpriority
   // Begin background processing mode. The system lowers the resource scheduling


### PR DESCRIPTION
The declarations for this API are missing in older mingw-w64 headers (versions before v12). This API is also hidden if building with MS WinSDK if targeting versions before Windows 10.

Check whether THREAD_POWER_THROTTLING_CURRENT_VERSION is defined before using this API; this constant is a #define in both WinSDK and mingw-w64.