### PR TITLE
[MemProf] Add sanitizer interface decls for histogram funcs.

### DIFF
--- a/compiler-rt/lib/memprof/memprof_interface_internal.h
+++ b/compiler-rt/lib/memprof/memprof_interface_internal.h
@@ -36,7 +36,13 @@ SANITIZER_INTERFACE_ATTRIBUTE
 void __memprof_record_access(void const volatile *addr);
 
 SANITIZER_INTERFACE_ATTRIBUTE
+void __memprof_record_access_hist(void const volatile *addr);
+
+SANITIZER_INTERFACE_ATTRIBUTE
 void __memprof_record_access_range(void const volatile *addr, uptr size);
+
+SANITIZER_INTERFACE_ATTRIBUTE
+void __memprof_record_access_range_hist(void const volatile *addr, uptr size);
 
 SANITIZER_INTERFACE_ATTRIBUTE void __memprof_print_accumulated_stats();
 
@@ -51,6 +57,10 @@ extern uptr __memprof_shadow_memory_dynamic_address;
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE extern char
     __memprof_profile_filename[1];
+
+SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE extern bool
+    __memprof_histogram;
+
 SANITIZER_INTERFACE_ATTRIBUTE int __memprof_profile_dump();
 SANITIZER_INTERFACE_ATTRIBUTE void __memprof_profile_reset();
 

--- a/compiler-rt/test/memprof/TestCases/memprof_histogram_uint8.cpp
+++ b/compiler-rt/test/memprof/TestCases/memprof_histogram_uint8.cpp
@@ -3,8 +3,7 @@
 // aggregating counts across multiple objects are 64b.
 
 // RUN: %clangxx_memprof -O0 -mllvm -memprof-histogram -mllvm -memprof-use-callbacks=true %s -o %t
-// RUN: %env_memprof_opts=print_text=1:histogram=1:log_path=stdout %run %t 2>&1 > /tmp/test.log
-// RUN: cat /tmp/test.log | FileCheck %s
+// RUN: %env_memprof_opts=print_text=1:histogram=1:log_path=stdout %run %t 2>&1 | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/memprof/TestCases/memprof_histogram_uint8.cpp
+++ b/compiler-rt/test/memprof/TestCases/memprof_histogram_uint8.cpp
@@ -1,0 +1,39 @@
+// Test the histogram support in memprof using the text format output.
+// Shadow memory counters per object are limited to 8b. In memory counters
+// aggregating counts across multiple objects are 64b.
+
+// RUN: %clangxx_memprof -O0 -mllvm -memprof-histogram -mllvm -memprof-use-callbacks=true %s -o %t
+// RUN: %env_memprof_opts=print_text=1:histogram=1:log_path=stdout %run %t 2>&1 > /tmp/test.log
+// RUN: cat /tmp/test.log | FileCheck %s
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  // Allocate memory that will create a histogram
+  char *buffer = (char *)malloc(1024);
+  if (!buffer)
+    return 1;
+
+  for (int i = 0; i < 10; ++i) {
+    // Access every 8th byte (since shadow granularity is 8b.
+    buffer[i * 8] = 'A';
+  }
+
+  for (int j = 0; j < 200; ++j) {
+    buffer[8] = 'B'; // Count = previous count + 200
+  }
+
+  for (int j = 0; j < 400; ++j) {
+    buffer[16] = 'B'; // Count is saturated at 255
+  }
+
+  // Free the memory to trigger MIB creation with histogram
+  free(buffer);
+
+  printf("Test completed successfully\n");
+  return 0;
+}
+
+// CHECK: AccessCountHistogram[128]: 1 201 255 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+// CHECK: Test completed successfully


### PR DESCRIPTION
This was a latent issue since we didn't add tests for the histogram feature in memprof. While doing so in #147854 I encountered test failures for the dynamic runtime. These tests are run with `ninja check-memprof-dynamic`. When reapplying the other PR I'll remove the histogram runtime test from it. With these changes #147854 can be reapplied safely.