### PR TITLE
[libc][math] Refactor atanhf implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -28,6 +28,7 @@
 #include "math/atan2f128.h"
 #include "math/atanf.h"
 #include "math/atanf16.h"
+#include "math/atanhf.h"
 #include "math/erff.h"
 #include "math/exp.h"
 #include "math/exp10.h"

--- a/libc/shared/math/atanhf.h
+++ b/libc/shared/math/atanhf.h
@@ -1,4 +1,4 @@
-//===-- Single-precision atanh function -----------------------------------===//
+//===-- Shared atanhf function ----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/atanhf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_ATANHF_H
+#define LLVM_LIBC_SHARED_MATH_ATANHF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/atanhf.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, atanhf, (float x)) { return math::atanhf(x); }
+using math::atanhf;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_ATANHF_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -276,6 +276,17 @@ add_header_library(
 )
 
 add_header_library(
+  atanhf
+  HDRS
+    atanhf.h
+  DEPENDS
+    .acoshf_utils
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   asinf
   HDRS
     asinf.h

--- a/libc/src/__support/math/atanhf.h
+++ b/libc/src/__support/math/atanhf.h
@@ -1,0 +1,76 @@
+//===-- Implementation header for atanhf ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_ATANHF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_ATANHF_H
+
+#include "acoshf_utils.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr float atanhf(float x) {
+  using namespace acoshf_internal;
+  using FPBits = typename fputil::FPBits<float>;
+
+  FPBits xbits(x);
+  Sign sign = xbits.sign();
+  uint32_t x_abs = xbits.abs().uintval();
+
+  // |x| >= 1.0
+  if (LIBC_UNLIKELY(x_abs >= 0x3F80'0000U)) {
+    if (xbits.is_nan()) {
+      if (xbits.is_signaling_nan()) {
+        fputil::raise_except_if_required(FE_INVALID);
+        return FPBits::quiet_nan().get_val();
+      }
+      return x;
+    }
+    // |x| == 1.0
+    if (x_abs == 0x3F80'0000U) {
+      fputil::set_errno_if_required(ERANGE);
+      fputil::raise_except_if_required(FE_DIVBYZERO);
+      return FPBits::inf(sign).get_val();
+    } else {
+      fputil::set_errno_if_required(EDOM);
+      fputil::raise_except_if_required(FE_INVALID);
+      return FPBits::quiet_nan().get_val();
+    }
+  }
+
+  // |x| < ~0.10
+  if (LIBC_UNLIKELY(x_abs <= 0x3dcc'0000U)) {
+    // |x| <= 2^-26
+    if (LIBC_UNLIKELY(x_abs <= 0x3280'0000U)) {
+      return static_cast<float>(LIBC_UNLIKELY(x_abs == 0)
+                                    ? x
+                                    : (x + 0x1.5555555555555p-2 * x * x * x));
+    }
+
+    double xdbl = x;
+    double x2 = xdbl * xdbl;
+    // Pure Taylor series.
+    double pe = fputil::polyeval(x2, 0.0, 0x1.5555555555555p-2,
+                                 0x1.999999999999ap-3, 0x1.2492492492492p-3,
+                                 0x1.c71c71c71c71cp-4, 0x1.745d1745d1746p-4);
+    return static_cast<float>(fputil::multiply_add(xdbl, pe, xdbl));
+  }
+  double xdbl = x;
+  return static_cast<float>(0.5 * log_eval((xdbl + 1.0) / (xdbl - 1.0)));
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_ATANHF_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -3922,10 +3922,7 @@ add_entrypoint_object(
   HDRS
     ../atanhf.h
   DEPENDS
-    .explogxf
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.fenv_impl
-    libc.src.__support.macros.optimization
+    libc.src.__support.math.atanhf
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -24,6 +24,7 @@ add_fp_unittest(
     libc.src.__support.math.atan2f128
     libc.src.__support.math.atanf
     libc.src.__support.math.atanf16
+    libc.src.__support.math.atanhf
     libc.src.__support.math.erff
     libc.src.__support.math.exp
     libc.src.__support.math.exp10

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -47,6 +47,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::asinhf(0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atan2f(0.0f, 0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atanf(0.0f));
+  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atanhf(0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::erff(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp10f(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::expf(0.0f));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2374,6 +2374,18 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_atanhf",
+    hdrs = ["src/__support/math/atanhf.h"],
+    deps = [
+        ":__support_math_acoshf_utils",
+        ":__support_fputil_fenv_impl",
+        ":__support_fputil_fp_bits",
+        ":__support_macros_config",
+        ":__support_macros_optimization",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_erff",
     hdrs = ["src/__support/math/erff.h"],
     deps = [
@@ -2998,13 +3010,7 @@ libc_math_function(
 libc_math_function(
     name = "atanhf",
     additional_deps = [
-        ":__support_fputil_fma",
-        ":__support_fputil_multiply_add",
-        ":__support_fputil_nearest_integer",
-        ":__support_fputil_polyeval",
-        ":__support_macros_optimization",
-        ":common_constants",
-        ":explogxf",
+        ":__support_math_atanhf",
     ],
 )
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450