### PR TITLE
[lldb] Support Darwin cross compilation for remote Linux test suite runs

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/builders/builder.py
+++ b/lldb/packages/Python/lldbsuite/test/builders/builder.py
@@ -26,7 +26,7 @@ class Builder:
 
     def getTriple(self, arch):
         """Returns the triple for the given architecture or None."""
-        return None
+        return configuration.triple
 
     def getExtraMakeArgs(self):
         """
@@ -37,6 +37,9 @@ class Builder:
 
     def getArchCFlags(self, architecture):
         """Returns the ARCH_CFLAGS for the make system."""
+        triple = self.getTriple(architecture)
+        if triple:
+            return ["ARCH_CFLAGS=-target {}".format(triple)]
         return []
 
     def getMake(self, test_subdir, test_name):

--- a/lldb/packages/Python/lldbsuite/test/configuration.py
+++ b/lldb/packages/Python/lldbsuite/test/configuration.py
@@ -45,6 +45,9 @@ dsymutil = None
 sdkroot = None
 make_path = None
 
+# Allow specifying a triple for cross compilation.
+triple = None
+
 # The overriden dwarf verison.
 # Don't use this to test the current compiler's
 # DWARF version, as this won't be set if the
@@ -140,6 +143,7 @@ enabled_plugins = []
 # the build type of lldb
 # Typical values include Debug, Release, RelWithDebInfo and MinSizeRel
 cmake_build_type = None
+
 
 def shouldSkipBecauseOfCategories(test_categories):
     if use_categories:

--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -321,8 +321,13 @@ def parseOptionsAndInitTestdirs():
             logging.error("No SDK found with the name %s; aborting...", args.apple_sdk)
             sys.exit(-1)
 
+    if args.triple:
+        configuration.triple = args.triple
+
     if args.arch:
         configuration.arch = args.arch
+    elif args.triple:
+        configuration.arch = args.triple.split("-")[0]
     else:
         configuration.arch = platform_machine
 

--- a/lldb/packages/Python/lldbsuite/test/dotest_args.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest_args.py
@@ -58,6 +58,14 @@ def create_parser():
             """Specify the path to sysroot. This overrides apple_sdk sysroot."""
         ),
     )
+    group.add_argument(
+        "--triple",
+        metavar="triple",
+        dest="triple",
+        help=textwrap.dedent(
+            """Specify the target triple. Used for cross compilation."""
+        ),
+    )
     if sys.platform == "darwin":
         group.add_argument(
             "--apple-sdk",

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -149,6 +149,16 @@ else
 endif
 
 #----------------------------------------------------------------------
+# Use LLD when cross compiling on Darwin.
+#----------------------------------------------------------------------
+ifeq "$(HOST_OS)" "Darwin"
+	ifneq (,$(filter $(OS), FreeBSD Linux NetBSD Windows_NT))
+		LDFLAGS += -fuse-ld=lld
+	endif
+endif
+
+
+#----------------------------------------------------------------------
 # ARCHFLAG is the flag used to tell the compiler which architecture
 # to compile for. The default is the flag that clang accepts.
 #----------------------------------------------------------------------

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -152,7 +152,7 @@ endif
 # Use LLD when cross compiling on Darwin.
 #----------------------------------------------------------------------
 ifeq "$(HOST_OS)" "Darwin"
-	ifneq (,$(filter $(OS), FreeBSD Linux NetBSD Windows_NT))
+	ifneq (,$(filter $(OS), Android FreeBSD Linux NetBSD Windows_NT))
 		LDFLAGS += -fuse-ld=lld
 	endif
 endif


### PR DESCRIPTION
Fix cross-compilation of test inferiors on Darwin, targeting remote Linux. This requires specifying the target triple and using LLD for linking.

Fixes #150806