### PR TITLE
[sanitizer] Print diagnostic if ptrace syscall fails

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -429,15 +429,18 @@ static void TestPTrace() {
   if (pid == 0) {
     // Child subprocess
     internal_ptrace(PTRACE_ATTACH, 0, nullptr, nullptr);
-    _exit (0);
+    _exit(0);
   } else {
     int wstatus;
     internal_waitpid(pid, &wstatus, 0);
 
     if (WIFSIGNALED(wstatus)) {
-      VReport(0, "Warning: ptrace appears to be blocked (is seccomp enabled?). LeakSanitizer may hang.\n");
+      VReport(0,
+              "Warning: ptrace appears to be blocked (is seccomp enabled?). "
+              "LeakSanitizer may hang.\n");
       VReport(0, "Child exited with signal %d.\n", WTERMSIG(wstatus));
-      // We don't abort the sanitizer - it's still worth letting the sanitizer try.
+      // We don't abort the sanitizer - it's still worth letting the sanitizer
+      // try.
     }
   }
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -504,7 +504,8 @@ void StopTheWorld(StopTheWorldCallback callback, void *argument) {
     internal_prctl(PR_SET_PTRACER, tracer_pid, 0, 0, 0);
     // Allow the tracer thread to start.
     tracer_thread_argument.mutex.Unlock();
-    // NOTE: errno is shared between this thread and the tracer thread.
+    // NOTE: errno is shared between this thread and the tracer thread
+    //       (clone was called without CLONE_SETTLS / newtls).
     // internal_waitpid() may call syscall() which can access/spoil errno,
     // so we can't call it now. Instead we for the tracer thread to finish using
     // the spin loop below. Man page for sched_yield() says "In the Linux

--- a/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stoptheworld_linux_libcdep.cpp
@@ -406,8 +406,8 @@ struct ScopedSetTracerPID {
 // This detects whether ptrace is blocked (e.g., by seccomp), by forking and
 // then attempting ptrace.
 // This separate check is necessary because StopTheWorld() creates a child
-// process with a shared virtual address space, and therefore cannot use
-// waitpid() due to the shared errno.
+// process with a shared virtual address space and shared TLS, and therefore
+// cannot use waitpid() due to the shared errno.
 static void TestPTrace() {
   // Heuristic: only check the first time this is called. This is not always
   // correct (e.g., user manually triggers leak detection, then updates


### PR DESCRIPTION
StopTheWorld() clones a child process (with shared virtual address space and shared TLS) that calls ptrace before releasing a mutex; the parent process yields until the mutex is unlocked. If seccomp kills the child process, the parent process will silently hang. The parent process cannot use waitpid to detect that the child process has been killed, because the processes share errno.

This patch forks the process one-time to test whether ptrace is allowed. If it fails, it prints an informational message (though it does not abort the sanitizer).

Fixes https://github.com/llvm/llvm-project/issues/150380 and https://github.com/google/sanitizers/issues/777