### PR TITLE
[win][arm64ec] More fixes for building and testing Arm64EC Windows

### DIFF
--- a/llvm/.gitattributes
+++ b/llvm/.gitattributes
@@ -32,3 +32,4 @@ test/tools/split-file/basic.test text eol=lf
 test/tools/split-file/Inputs/basic-*.txt eol=lf
 test/tools/split-file/basic.crlf.test text eol=crlf
 test/tools/split-file/Inputs/basic-*.crlf eol=crlf
+test/tools/llvm-objcopy/MachO/Inputs/macho_sections.s text eol=lf

--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -735,9 +735,6 @@ AArch64Arm64ECCallLowering::buildPatchableThunk(GlobalAlias *UnmangledAlias,
 
 // Lower an indirect call with inline code.
 void AArch64Arm64ECCallLowering::lowerCall(CallBase *CB) {
-  assert(CB->getModule()->getTargetTriple().isOSWindows() &&
-         "Only applicable for Windows targets");
-
   IRBuilder<> B(CB);
   Value *CalledOperand = CB->getCalledOperand();
 

--- a/llvm/test/CodeGen/Generic/allow-check.ll
+++ b/llvm/test/CodeGen/Generic/allow-check.ll
@@ -6,6 +6,7 @@
 ; XFAIL: target=nvptx{{.*}}
 ; XFAIL: target=sparc{{.*}}
 ; XFAIL: target=hexagon-{{.*}}
+; XFAIL: target=arm64ec-{{.*}}
 
 ; RUN: llc < %s -O3 -global-isel=0 -fast-isel=0
 ; RUN: llc < %s -O3 -global-isel=1 -fast-isel=0


### PR DESCRIPTION
* `tools/llvm-objcopy/MachO/update-section-object.test` was failing on Windows since the input file (`macho_sections.s`) might be checked out with the wrong line ending, resulting in difference in the size of sections being checked.
* Removed the check for Windows in `AArch64Arm64ECCallLowering`: when `llc` is run without an explicit target, the module's target triple is unknown so this assert fires.
* Expect `llvm/test/CodeGen/Generic/allow-check.ll` to fail for Arm64EC: Global ISel is not supported.