### PR TITLE
[LLVM][Support] Fix tests on Cygwin

### DIFF
--- a/llvm/unittests/Support/DynamicLibrary/PipSqueak.h
+++ b/llvm/unittests/Support/DynamicLibrary/PipSqueak.h
@@ -22,7 +22,7 @@
 #include <vector>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #define PIPSQUEAK_EXPORT __declspec(dllexport)
 #elif defined(__MVS__)
 #define PIPSQUEAK_EXPORT __attribute__((__visibility__("default")))

--- a/llvm/unittests/Support/VirtualFileSystemTest.cpp
+++ b/llvm/unittests/Support/VirtualFileSystemTest.cpp
@@ -558,6 +558,10 @@ TEST(VirtualFileSystemTest, PhysicalFileSystemWorkingDirFailure) {
     // Some platforms (e.g. Solaris) disallow removal of the working directory.
     GTEST_SKIP() << "test requires deletion of working directory";
 
+#ifdef __CYGWIN__
+  GTEST_SKIP() << "Cygwin getcwd succeeds with unlinked working directory";
+#endif
+
   // Verify that we still get two separate working directories.
   auto FS1 = vfs::createPhysicalFileSystem();
   auto FS2 = vfs::createPhysicalFileSystem();


### PR DESCRIPTION
Cygwin returns -1 for `getconf(_SC_ARG_MAX)`, which makes `llvm::sys::commandLineFitsWithinSystemLimits` always return true, so skip the `ArgumentLimit` test in that case.  Skip the `ArgumentLimitWindows` and `ResponseFileWindows` tests on Cygwin also as it doesn't suffer from the Windows limits either.

Cygwin requires the same `dllexport` annotation as Win32 in the `DynamicLibrary` test, so add its preprocessor check to PipSqueak.h.

Cygwin's `getcwd` function does not fail with `ENOENT` if the current working directory is unlinked.  According to POSIX issue 8, this is not required.  Skip the `PhysicalFileSystemWorkingDirFailure` test on Cygwin as it relies on this behavior.