### PR TITLE
[CIR] Fix fallthrough warning

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenFunction.cpp
@@ -943,6 +943,7 @@ void CIRGenFunction::emitVariablyModifiedType(QualType type) {
     case Type::HLSLInlineSpirv:
     case Type::PredefinedSugar:
       cgm.errorNYI("CIRGenFunction::emitVariablyModifiedType");
+      break;
 
 #define TYPE(Class, Base)
 #define ABSTRACT_TYPE(Class, Base)


### PR DESCRIPTION
This fixes a warning about an unannotated fallthrough.