### PR TITLE
[flang][openacc] fix a bug with checking data mapping clause when there is no default

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -1545,6 +1545,7 @@ void AccAttributeVisitor::Post(const parser::AccDefaultClause &x) {
 void AccAttributeVisitor::Post(const parser::Name &name) {
   auto *symbol{name.symbol};
   if (symbol && !dirContext_.empty() && GetContext().withinConstruct) {
+    symbol = &symbol->GetUltimate();
     if (!symbol->owner().IsDerivedType() && !symbol->has<ProcEntityDetails>() &&
         !symbol->has<SubprogramDetails>() && !IsObjectWithDSA(*symbol)) {
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
@@ -1553,8 +1554,7 @@ void AccAttributeVisitor::Post(const parser::Name &name) {
         } else if (GetContext().defaultDSA == Symbol::Flag::AccNone) {
           // 2.5.14.
           context_.Say(name.source,
-              "The DEFAULT(NONE) clause requires that '%s' must be listed in "
-              "a data-mapping clause"_err_en_US,
+              "The DEFAULT(NONE) clause requires that '%s' must be listed in a data-mapping clause"_err_en_US,
               symbol->name());
         }
       }

--- a/flang/test/Semantics/OpenACC/acc-default-none-function.f90
+++ b/flang/test/Semantics/OpenACC/acc-default-none-function.f90
@@ -17,4 +17,4 @@ program main
     res = dosomething(res)
     !$acc end serial
 end program
-    
+

--- a/flang/test/Semantics/OpenACC/acc-default-none-function.f90
+++ b/flang/test/Semantics/OpenACC/acc-default-none-function.f90
@@ -1,0 +1,20 @@
+! RUN: %python %S/../test_errors.py %s %flang -fopenacc -pedantic
+
+module mm_acc_rout_function
+contains
+    integer function dosomething(res)
+        !$acc routine seq
+        integer :: res
+        dosomething = res + 1
+    end function
+end module
+    
+program main
+    use mm_acc_rout_function
+    implicit none
+    integer :: res = 1
+    !$acc serial default(none) copy(res)
+    res = dosomething(res)
+    !$acc end serial
+end program
+    


### PR DESCRIPTION
Test case used to complain about `dosomething` requiring a data mapping clause. Now no such error exists.