### PR TITLE
[libc] Remove some sched.h includes

### DIFF
--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -6,7 +6,9 @@ add_entrypoint_object(
     ../sched_getaffinity.h
   DEPENDS
     libc.hdr.stdint_proxy
-    libc.include.sched
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.pid_t
+    libc.hdr.types.size_t
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -18,7 +20,9 @@ add_entrypoint_object(
   HDRS
     ../sched_setaffinity.h
   DEPENDS
-    libc.include.sched
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.pid_t
+    libc.hdr.types.size_t
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -30,7 +34,8 @@ add_entrypoint_object(
   HDRS
     ../sched_getcpucount.h
   DEPENDS
-    libc.include.sched
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.size_t
 )
 
 add_entrypoint_object(
@@ -94,7 +99,7 @@ add_entrypoint_object(
   HDRS
     ../sched_getscheduler.h
   DEPENDS
-    libc.include.sched
+    libc.hdr.types.pid_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -131,8 +136,9 @@ add_entrypoint_object(
   HDRS
     ../sched_rr_get_interval.h
   DEPENDS
+    libc.hdr.types.pid_t
+    libc.hdr.types.struct_timespec
     libc.include.sys_syscall
-    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/sched/linux/sched_getaffinity.cpp
+++ b/libc/src/sched/linux/sched_getaffinity.cpp
@@ -14,7 +14,9 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
-#include <sched.h>
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/pid_t.h"
+#include "hdr/types/size_t.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sched/linux/sched_getcpucount.cpp
+++ b/libc/src/sched/linux/sched_getcpucount.cpp
@@ -12,7 +12,8 @@
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
-#include <sched.h>
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/size_t.h"
 #include <stddef.h>
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sched/linux/sched_getscheduler.cpp
+++ b/libc/src/sched/linux/sched_getscheduler.cpp
@@ -13,6 +13,7 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
+#include "hdr/types/pid_t.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sched/linux/sched_rr_get_interval.cpp
+++ b/libc/src/sched/linux/sched_rr_get_interval.cpp
@@ -13,6 +13,8 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
+#include "hdr/types/pid_t.h"
+#include "hdr/types/struct_timespec.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 #ifdef SYS_sched_rr_get_interval_time64

--- a/libc/src/sched/linux/sched_setaffinity.cpp
+++ b/libc/src/sched/linux/sched_setaffinity.cpp
@@ -13,7 +13,9 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
-#include <sched.h>
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/pid_t.h"
+#include "hdr/types/size_t.h"
 #include <sys/syscall.h> // For syscall numbers.
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sched/sched_getaffinity.h
+++ b/libc/src/sched/sched_getaffinity.h
@@ -10,7 +10,10 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_GETAFFINITY_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/pid_t.h"
+#include "hdr/types/size_t.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sched/sched_getcpucount.h
+++ b/libc/src/sched/sched_getcpucount.h
@@ -10,7 +10,8 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_GETCPUCOUNT_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/cpu_set_t.h"
 #include <stddef.h>
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/sched/sched_getscheduler.h
+++ b/libc/src/sched/sched_getscheduler.h
@@ -10,7 +10,8 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_GETSCHEDULER_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/pid_t.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sched/sched_rr_get_interval.h
+++ b/libc/src/sched/sched_rr_get_interval.h
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_RR_GET_INTERVAL_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/pid_t.h"
+#include "hdr/types/struct_timespec.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sched/sched_setaffinity.h
+++ b/libc/src/sched/sched_setaffinity.h
@@ -10,7 +10,10 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_SETAFFINITY_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/pid_t.h"
+#include "hdr/types/size_t.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -7,7 +7,8 @@ add_libc_unittest(
   SRCS
     affinity_test.cpp
   DEPENDS
-    libc.include.sched
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.pid_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
@@ -34,7 +35,7 @@ add_libc_unittest(
   SRCS
     get_priority_test.cpp
   DEPENDS
-    libc.include.sched
+    libc.hdr.sched_macros
     libc.src.errno.errno
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_get_priority_max
@@ -65,7 +66,7 @@ add_libc_unittest(
   SRCS
     sched_rr_get_interval_test.cpp
   DEPENDS
-    libc.include.sched
+    libc.hdr.types.struct_timespec
     libc.src.errno.errno
     libc.src.sched.sched_getscheduler
     libc.src.sched.sched_setscheduler
@@ -81,7 +82,9 @@ add_libc_unittest(
   SRCS
     cpu_count_test.cpp
   DEPENDS
-    libc.include.sched
+    libc.hdr.sched_macros
+    libc.hdr.types.cpu_set_t
+    libc.hdr.types.pid_t
     libc.include.sys_syscall
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno

--- a/libc/test/src/sched/affinity_test.cpp
+++ b/libc/test/src/sched/affinity_test.cpp
@@ -12,7 +12,8 @@
 #include "src/sched/sched_setaffinity.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 
-#include <sched.h>
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/pid_t.h"
 #include <sys/syscall.h>
 
 TEST(LlvmLibcSchedAffinityTest, SmokeTest) {

--- a/libc/test/src/sched/cpu_count_test.cpp
+++ b/libc/test/src/sched/cpu_count_test.cpp
@@ -12,8 +12,9 @@
 #include "src/sched/sched_getcpucount.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 
-#include <sched.h>
-#include <sys/syscall.h>
+#include "hdr/sched_macros.h"
+#include "hdr/types/cpu_set_t.h"
+#include "hdr/types/pid_t.h"
 
 TEST(LlvmLibcSchedCpuCountTest, SmokeTest) {
   cpu_set_t mask;

--- a/libc/test/src/sched/get_priority_test.cpp
+++ b/libc/test/src/sched/get_priority_test.cpp
@@ -11,7 +11,7 @@
 #include "src/sched/sched_get_priority_min.h"
 #include "test/UnitTest/Test.h"
 
-#include <sched.h>
+#include "hdr/sched_macros.h"
 
 TEST(LlvmLibcSchedGetPriorityTest, HandleBadPolicyTest) {
 

--- a/libc/test/src/sched/sched_rr_get_interval_test.cpp
+++ b/libc/test/src/sched/sched_rr_get_interval_test.cpp
@@ -14,7 +14,7 @@
 #include "src/unistd/getuid.h"
 #include "test/UnitTest/Test.h"
 
-#include <sched.h>
+#include "hdr/types/struct_timespec.h"
 
 TEST(LlvmLibcSchedRRGetIntervalTest, SmokeTest) {
   libc_errno = 0;


### PR DESCRIPTION
This patch removes some sched.h includes, preferring the proxy headers. This patch does not clean them all up as some proxy type headers need to be added, like for `struct sched_param`.