### PR TITLE
[RegAlloc] Fix use-after-free in `RegAllocBase::cleanupFailedVReg`

### DIFF
--- a/llvm/lib/CodeGen/RegAllocBase.cpp
+++ b/llvm/lib/CodeGen/RegAllocBase.cpp
@@ -178,10 +178,8 @@ void RegAllocBase::cleanupFailedVReg(Register FailedReg, MCRegister PhysReg,
     for (MCRegAliasIterator Aliases(PhysReg, TRI, true); Aliases.isValid();
          ++Aliases) {
       for (MachineOperand &MO : MRI->reg_operands(*Aliases)) {
-        if (MO.readsReg()) {
+        if (MO.readsReg())
           MO.setIsUndef(true);
-          LIS->removeAllRegUnitsForPhysReg(MO.getReg());
-        }
       }
     }
   }

--- a/llvm/test/CodeGen/AMDGPU/use-after-free-after-cleanup-failed-vreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/use-after-free-after-cleanup-failed-vreg.ll
@@ -1,6 +1,7 @@
 ; RUN: not llc -mcpu=gfx1100 -mtriple=amdgcn-amd-amdhsa -stress-regalloc=4 -filetype=null -verify-machineinstrs %s 2>&1 | FileCheck %s
 
 ; CHECK: error: <unknown>:0:0: ran out of registers during register allocation in function 'f'
+; CHECK-NOT: Bad machine code
 
 define <16 x half> @f(i1 %LGV2, <16 x half> %0) {
 BB:

--- a/llvm/test/CodeGen/AMDGPU/use-after-free-after-cleanup-failed-vreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/use-after-free-after-cleanup-failed-vreg.ll
@@ -1,6 +1,6 @@
-; RUN: not llc -mcpu=gfx1100 -mtriple=amdgcn-amd-amdhsa -stress-regalloc=4 %s 2>&1 | FileCheck %s
+; RUN: not llc -mcpu=gfx1100 -mtriple=amdgcn-amd-amdhsa -stress-regalloc=4 -filetype=null -verify-machineinstrs %s 2>&1 | FileCheck %s
 
-; CHECK: ran out of registers during register allocation in function 'f'
+; CHECK: error: <unknown>:0:0: ran out of registers during register allocation in function 'f'
 
 define <16 x half> @f(i1 %LGV2, <16 x half> %0) {
 BB:

--- a/llvm/test/CodeGen/AMDGPU/use-after-free-after-cleanup-failed-vreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/use-after-free-after-cleanup-failed-vreg.ll
@@ -1,0 +1,15 @@
+; RUN: not llc -mcpu=gfx1100 -mtriple=amdgcn-amd-amdhsa -stress-regalloc=4 %s 2>&1 | FileCheck %s
+
+; CHECK: ran out of registers during register allocation in function 'f'
+
+define <16 x half> @f(i1 %LGV2, <16 x half> %0) {
+BB:
+  br i1 %LGV2, label %SW_C3, label %SW_C
+
+SW_C:                                             ; preds = %BB
+  %B1 = fmul <16 x half> %0, zeroinitializer
+  ret <16 x half> %B1
+
+SW_C3:                                            ; preds = %BB
+  ret <16 x half> <half 0xH0000, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison, half poison>
+}


### PR DESCRIPTION
#128400 introduced a use-after-free bug in `RegAllocBase::cleanupFailedVReg` when removing intervals from regunits. The issue is from the `InterferenceCache` in `RAGreedy`, which holds `LiveRange*`. The current `InterferenceCache` APIs make it difficult to update it, and there isn't a straightforward way to do that.

Since #128400 already mentions it's not clear about the necessity of removing intervals from regunits, this PR avoids the issue by simply skipping that step.

Fixes SWDEV-527146.
