### PR TITLE
[RISCV] Improvements to .note.gnu.property section.

### DIFF
--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
@@ -68,11 +68,14 @@ void RISCVTargetStreamer::emitNoteGnuPropertySection(
 
   const Triple &Triple = Ctx.getTargetTriple();
   Align NoteAlign;
+  uint64_t DescSize;
   if (Triple.isArch64Bit()) {
     NoteAlign = Align(8);
+    DescSize = 16;
   } else {
     assert(Triple.isArch32Bit());
     NoteAlign = Align(4);
+    DescSize = 12;
   }
 
   assert(Ctx.getObjectFileType() == MCContext::Environment::IsELF);
@@ -84,28 +87,20 @@ void RISCVTargetStreamer::emitNoteGnuPropertySection(
 
   // Emit the note header
   OutStreamer.emitValueToAlignment(NoteAlign);
-  OutStreamer.emitIntValue(4, 4); // n_namsz
-
-  MCSymbol *const NDescBeginSym = Ctx.createTempSymbol();
-  MCSymbol *const NDescEndSym = Ctx.createTempSymbol();
-  const MCExpr *const NDescSzExpr =
-      MCBinaryExpr::createSub(MCSymbolRefExpr::create(NDescEndSym, Ctx),
-                              MCSymbolRefExpr::create(NDescBeginSym, Ctx), Ctx);
-
-  OutStreamer.emitValue(NDescSzExpr, 4);                    // n_descsz
+  OutStreamer.emitIntValue(4, 4);                           // n_namsz
+  OutStreamer.emitIntValue(DescSize, 4);                    // n_descsz
   OutStreamer.emitIntValue(ELF::NT_GNU_PROPERTY_TYPE_0, 4); // n_type
   OutStreamer.emitBytes(StringRef("GNU", 4));               // n_name
 
   // Emit n_desc field
-  OutStreamer.emitLabel(NDescBeginSym);
 
   // Emit the feature_1_and property
   OutStreamer.emitIntValue(ELF::GNU_PROPERTY_RISCV_FEATURE_1_AND, 4); // pr_type
   OutStreamer.emitIntValue(4, 4);              // pr_datasz
   OutStreamer.emitIntValue(Feature1And, 4);    // pr_data
-  OutStreamer.emitValueToAlignment(NoteAlign); // pr_padding
+  if (Triple.isArch64Bit())
+    OutStreamer.emitIntValue(0, 4);            // pr_padding
 
-  OutStreamer.emitLabel(NDescEndSym);
   OutStreamer.popSection();
 }
 

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
@@ -83,6 +83,7 @@ void RISCVTargetStreamer::emitNoteGnuPropertySection(
   OutStreamer.switchSection(NoteSection);
 
   // Emit the note header
+  OutStreamer.emitValueToAlignment(NoteAlign);
   OutStreamer.emitIntValue(4, 4); // n_namsz
 
   MCSymbol *const NDescBeginSym = Ctx.createTempSymbol();
@@ -97,7 +98,6 @@ void RISCVTargetStreamer::emitNoteGnuPropertySection(
 
   // Emit n_desc field
   OutStreamer.emitLabel(NDescBeginSym);
-  OutStreamer.emitValueToAlignment(NoteAlign);
 
   // Emit the feature_1_and property
   OutStreamer.emitIntValue(ELF::GNU_PROPERTY_RISCV_FEATURE_1_AND, 4); // pr_type

--- a/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
+++ b/llvm/lib/Target/RISCV/MCTargetDesc/RISCVTargetStreamer.cpp
@@ -81,7 +81,6 @@ void RISCVTargetStreamer::emitNoteGnuPropertySection(
   assert(Ctx.getObjectFileType() == MCContext::Environment::IsELF);
   MCSection *const NoteSection =
       Ctx.getELFSection(".note.gnu.property", ELF::SHT_NOTE, ELF::SHF_ALLOC);
-  NoteSection->setAlignment(NoteAlign);
   OutStreamer.pushSection();
   OutStreamer.switchSection(NoteSection);
 
@@ -98,8 +97,7 @@ void RISCVTargetStreamer::emitNoteGnuPropertySection(
   OutStreamer.emitIntValue(ELF::GNU_PROPERTY_RISCV_FEATURE_1_AND, 4); // pr_type
   OutStreamer.emitIntValue(4, 4);              // pr_datasz
   OutStreamer.emitIntValue(Feature1And, 4);    // pr_data
-  if (Triple.isArch64Bit())
-    OutStreamer.emitIntValue(0, 4);            // pr_padding
+  OutStreamer.emitValueToAlignment(NoteAlign); // pr_padding
 
   OutStreamer.popSection();
 }

--- a/llvm/test/CodeGen/RISCV/note-gnu-property-zicfiss.ll
+++ b/llvm/test/CodeGen/RISCV/note-gnu-property-zicfiss.ll
@@ -7,13 +7,13 @@
 
 ; ASM:                .section        ".note.GNU-stack","",@progbits
 ; ASM-NEXT:           .section        .note.gnu.property,"a",@note
+; ASM32-NEXT:         .p2align        2, 0x0
+; ASM64-NEXT:         .p2align        3, 0x0
 ; ASM-NEXT:           .word   4
 ; ASM-NEXT:           .word   .Ltmp1-.Ltmp0
 ; ASM-NEXT:           .word   5
 ; ASM-NEXT:           .asciz  "GNU"
 ; ASM-NEXT:   .Ltmp0:
-; ASM32-NEXT:         .p2align        2, 0x0
-; ASM64-NEXT:         .p2align        3, 0x0
 ; ASM-NEXT:           .word   3221225472
 ; ASM-NEXT:           .word   4
 ; ASM-NEXT:           .word   2

--- a/llvm/test/CodeGen/RISCV/note-gnu-property-zicfiss.ll
+++ b/llvm/test/CodeGen/RISCV/note-gnu-property-zicfiss.ll
@@ -10,16 +10,14 @@
 ; ASM32-NEXT:         .p2align        2, 0x0
 ; ASM64-NEXT:         .p2align        3, 0x0
 ; ASM-NEXT:           .word   4
-; ASM-NEXT:           .word   .Ltmp1-.Ltmp0
+; ASM32-NEXT:         .word   12
+; ASM64-NEXT:         .word   16
 ; ASM-NEXT:           .word   5
 ; ASM-NEXT:           .asciz  "GNU"
-; ASM-NEXT:   .Ltmp0:
 ; ASM-NEXT:           .word   3221225472
 ; ASM-NEXT:           .word   4
 ; ASM-NEXT:           .word   2
-; ASM32-NEXT:         .p2align        2, 0x0
-; ASM64-NEXT:         .p2align        3, 0x0
-; ASM-NEXT:   .Ltmp1:
+; ASM64-NEXT:         .word   0
 
 define i32 @f() "hw-shadow-stack" {
 entry:

--- a/llvm/test/CodeGen/RISCV/note-gnu-property-zicfiss.ll
+++ b/llvm/test/CodeGen/RISCV/note-gnu-property-zicfiss.ll
@@ -17,7 +17,8 @@
 ; ASM-NEXT:           .word   3221225472
 ; ASM-NEXT:           .word   4
 ; ASM-NEXT:           .word   2
-; ASM64-NEXT:         .word   0
+; ASM32-NEXT:         .p2align        2, 0x0
+; ASM64-NEXT:         .p2align        3, 0x0
 
 define i32 @f() "hw-shadow-stack" {
 entry:


### PR DESCRIPTION
Put the .p2align at the beginning instead of in the middle.

Emit the descsz directly instead of using the difference of 2 labels.

Remove the section alignment. emitValueToAlignment will increase the section alignment if necessary.