### PR TITLE
[Basic] Remove deprecated methods in CustomizableOptional

### DIFF
--- a/clang/include/clang/Basic/CustomizableOptional.h
+++ b/clang/include/clang/Basic/CustomizableOptional.h
@@ -70,15 +70,6 @@ public:
 
   void reset() { Storage.reset(); }
 
-  LLVM_DEPRECATED("Use &*X instead.", "&*X")
-  constexpr const T *getPointer() const { return &Storage.value(); }
-  LLVM_DEPRECATED("Use &*X instead.", "&*X")
-  T *getPointer() { return &Storage.value(); }
-  LLVM_DEPRECATED("std::optional::value is throwing. Use *X instead", "*X")
-  constexpr const T &value() const & { return Storage.value(); }
-  LLVM_DEPRECATED("std::optional::value is throwing. Use *X instead", "*X")
-  T &value() & { return Storage.value(); }
-
   constexpr explicit operator bool() const { return has_value(); }
   constexpr bool has_value() const { return Storage.has_value(); }
   constexpr const T *operator->() const { return &Storage.value(); }
@@ -90,8 +81,6 @@ public:
     return has_value() ? operator*() : std::forward<U>(alt);
   }
 
-  LLVM_DEPRECATED("std::optional::value is throwing. Use *X instead", "*X")
-  T &&value() && { return std::move(Storage.value()); }
   T &&operator*() && { return std::move(Storage.value()); }
 
   template <typename U> T value_or(U &&alt) && {


### PR DESCRIPTION
This patch removes deprecated methods in CustomizableOptional.

These methods come from llvm::Optional, which later got renamed to
CustomizableOptional.  Since CustomizableOptional is used only in
OptionalDirectoryEntryRef and OptionalFileEntryRef, we do not need to
have full std::optional-like support in CustomizableOptional.
