### PR TITLE
ELF: Synthesize R_RISCV_ALIGN at input section start

### DIFF
--- a/lld/ELF/OutputSections.cpp
+++ b/lld/ELF/OutputSections.cpp
@@ -889,9 +889,14 @@ void OutputSection::sortInitFini() {
 std::array<uint8_t, 4> OutputSection::getFiller(Ctx &ctx) {
   if (filler)
     return *filler;
-  if (flags & SHF_EXECINSTR)
-    return ctx.target->trapInstr;
-  return {0, 0, 0, 0};
+  if (!(flags & SHF_EXECINSTR))
+    return {0, 0, 0, 0};
+  if (ctx.arg.relocatable && ctx.arg.emachine == EM_RISCV) {
+    if (ctx.arg.eflags & EF_RISCV_RVC)
+      return {1, 0, 1, 0};
+    return {0x13, 0, 0, 0};
+  }
+  return ctx.target->trapInstr;
 }
 
 void OutputSection::checkDynRelAddends(Ctx &ctx) {

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -96,6 +96,9 @@ public:
 
   // Do a linker relaxation pass and return true if we changed something.
   virtual bool relaxOnce(int pass) const { return false; }
+  virtual bool maybeSynthesizeAlign(uint64_t &dot, InputSection *sec) {
+    return false;
+  }
   // Do finalize relaxation after collecting relaxation infos.
   virtual void finalizeRelax(int passes) const {}
 

--- a/lld/ELF/Writer.cpp
+++ b/lld/ELF/Writer.cpp
@@ -1543,6 +1543,8 @@ template <class ELFT> void Writer<ELFT>::finalizeAddressDependentContent() {
 
   uint32_t pass = 0, assignPasses = 0;
   for (;;) {
+    if (ctx.arg.relocatable)
+      break;
     bool changed = ctx.target->needsThunks
                        ? tc.createThunks(pass, ctx.outputSections)
                        : ctx.target->relaxOnce(pass);

--- a/lld/test/ELF/riscv-relocatable-align.s
+++ b/lld/test/ELF/riscv-relocatable-align.s
@@ -1,0 +1,111 @@
+# RUN: rm -rf %t && split-file %s %t && cd %t
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax a.s -o ac.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax b.s -o bc.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax b1.s -o b1c.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax c.s -o cc.o
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax d.s -o dc.o
+# RUN: ld.lld -r bc.o bc.o ac.o bc.o b1c.o cc.o dc.o -o out.ro
+# RUN: llvm-objdump -dr -M no-aliases out.ro | FileCheck %s
+
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax a.s -o a.o
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax b.s -o b.o
+# RUN: llvm-mc -filetype=obj -triple=riscv32 -mattr=+relax d.s -o d.o
+# RUN: ld.lld -r a.o b.o d.o -o out0.ro
+# RUN: ld.lld -Ttext=0x10000 out0.ro -o out0
+# RUN: llvm-objdump -dr -M no-aliases out0 | FileCheck %s --check-prefix=CHECK1
+
+# RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax a.s -o acrel.o
+# RUN: ld.lld -r bc.o bc.o ac.o bc.o b1c.o cc.o dc.o -o out.crel.ro
+
+# CHECK:      <b0>:
+# CHECK-NEXT:   0: 00158513             addi    a0, a1, 0x1
+# CHECK-NEXT:   4: 0001                 c.nop
+# CHECK-NEXT:   6: 0001                 c.nop
+# CHECK-EMPTY:
+# CHECK-NEXT: <b0>:
+# CHECK-NEXT:   8: 00158513             addi    a0, a1, 0x1
+# CHECK-EMPTY:
+# CHECK-NEXT: <_start>:
+# CHECK-NEXT:   c: 00000097             auipc   ra, 0x0
+# CHECK-NEXT:           000000000000000c:  R_RISCV_CALL_PLT     foo
+# CHECK-NEXT:           000000000000000c:  R_RISCV_RELAX        *ABS*
+# CHECK-NEXT:  10: 000080e7             jalr    ra, 0x0(ra) <_start>
+# CHECK-NEXT:  14: 0001                 c.nop
+# CHECK-NEXT:           0000000000000014:  R_RISCV_ALIGN        *ABS*+0x6
+# CHECK-NEXT:  16: 0001                 c.nop
+# CHECK-NEXT:  18: 0001                 c.nop
+# CHECK-EMPTY:
+# CHECK-NEXT: <b0>:
+# CHECK-NEXT:  1a: 00158513             addi    a0, a1, 0x1
+# CHECK-NEXT:  1e: 0001                 c.nop
+# CHECK-NEXT:  20: 0001                 c.nop
+# CHECK-NEXT:           0000000000000020:  R_RISCV_ALIGN        *ABS*+0x6
+# CHECK-NEXT:  22: 0001                 c.nop
+# CHECK-NEXT:  24: 00000013             addi    zero, zero, 0x0
+# CHECK-EMPTY:
+# CHECK-NEXT: <b0>:
+# CHECK-NEXT:  28: 00158513             addi    a0, a1, 0x1
+# CHECK-EMPTY:
+# CHECK-NEXT: <c0>:
+# CHECK-NEXT:  2c: 00000097             auipc   ra, 0x0
+# CHECK-NEXT:           000000000000002c:  R_RISCV_CALL_PLT     foo
+# CHECK-NEXT:           000000000000002c:  R_RISCV_RELAX        *ABS*
+# CHECK-NEXT:  30: 000080e7             jalr    ra, 0x0(ra) <c0>
+# CHECK-NEXT:  34: 0001                 c.nop
+# CHECK-NEXT:           0000000000000034:  R_RISCV_ALIGN        *ABS*+0x2
+# CHECK-EMPTY:
+# CHECK-NEXT: <d0>:
+# CHECK-NEXT:  36: 00258513             addi    a0, a1, 0x2
+
+# CHECK1:      <_start>:
+# CHECK1-NEXT:    010000ef      jal     ra, 0x10010 <foo>
+# CHECK1-NEXT:    00000013      addi zero, zero, 0x0
+# CHECK1-EMPTY: 
+# CHECK1-NEXT: <b0>:
+# CHECK1-NEXT:    00158513      addi    a0, a1, 0x1
+# CHECK1-EMPTY: 
+# CHECK1-NEXT: <d0>:
+# CHECK1-NEXT:    00258513      addi    a0, a1, 0x2
+
+#--- a.s
+.globl _start
+_start:
+  call foo
+
+.section .text1,"ax"
+.globl foo
+foo:
+
+#--- b.s
+## Needs synthesized ALIGN
+.option push
+.option norelax
+.balign 8
+b0:
+  addi a0, a1, 1
+.option pop
+
+#--- b1.s
+.option push
+.option norelax
+  .reloc ., R_RISCV_ALIGN, 6
+  addi x0, x0, 0
+  c.nop
+.balign 8
+b0:
+  addi a0, a1, 1
+.option pop
+
+#--- c.s
+.balign 2
+c0:
+  call foo
+
+#--- d.s
+## Needs synthesized ALIGN
+.option push
+.option norelax
+.balign 4
+d0:
+  addi a0, a1, 2
+.option pop


### PR DESCRIPTION
Without linker relaxation enabled for a particular relocatable file or
section (e.g., using .option norelax), the assembler will not generate
R_RISCV_ALIGN relocations for alignment directives. This becomes
problematic in a two-stage linking process:

```
ld -r a.o b.o -o ab.o
// b.o is norelax. Its alignment information is lost in ab.o.
ld ab.o -o ab
```

When ab.o is linked into an executable, the preceding relaxed section
(a.o's content) might shrink. Since there's no R_RISCV_ALIGN relocation
in b.o for the linker to act upon, the `.word 0x3a393837` data in b.o
may end up unaligned in the final executable.

To address the issue, this patch inserts NOP bytes and synthesizes an
R_RISCV_ALIGN relocation at the beginning of a text section when the
alignment >= 4.

For simplicity, when RVC is disabled, we synthesize an ALIGN relocation
(addend: 2) for a 4-byte aligned section, allowing the linker to trim
the excess 2 bytes.

See also https://sourceware.org/bugzilla/show_bug.cgi?id=33236

