### PR TITLE
[clang][Sema] Create ConstantExprs in AnalyzeComparison

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -11374,11 +11374,27 @@ static void AnalyzeComparison(Sema &S, BinaryOperator *E) {
         LHS->getIntegerConstantExpr(S.Context);
 
     // We don't care about expressions whose result is a constant.
-    if (RHSValue && LHSValue)
+    if (RHSValue && LHSValue) {
+      auto *LHSCE = ConstantExpr::Create(S.Context, LHS, APValue(*LHSValue));
+      auto *RHSCE = ConstantExpr::Create(S.Context, RHS, APValue(*RHSValue));
+      E->setLHS(LHSCE);
+      E->setRHS(RHSCE);
       return AnalyzeImpConvsInComparison(S, E);
+    }
 
     // We only care about expressions where just one side is literal
     if ((bool)RHSValue ^ (bool)LHSValue) {
+
+      if (LHSValue) {
+        auto *LHSCE = ConstantExpr::Create(S.Context, LHS, APValue(*LHSValue));
+        E->setLHS(LHSCE);
+        LHS = LHSCE;
+      } else if (RHSValue) {
+        auto *RHSCE = ConstantExpr::Create(S.Context, RHS, APValue(*RHSValue));
+        E->setRHS(RHSCE);
+        RHS = RHSCE;
+      }
+
       // Is the constant on the RHS or LHS?
       const bool RhsConstant = (bool)RHSValue;
       Expr *Const = RhsConstant ? RHS : LHS;


### PR DESCRIPTION
If the `getIntegerConstantExpr()` calls succeed, we can as well replace the `BinaryOperator` children with `ConstantExpr`s wrapping the previous LHS/RHS.

This shows small speedups: https://llvm-compile-time-tracker.com/compare.php?from=cc8c941e17558ba427de06e72c8ad96d7b17ced1&to=112af8e62e734938547d50eeb7b416c8dd666f45&stat=instructions:u