### PR TITLE
[RISCV][EVL] Drop EVLIndVarSimplifyPass from the pipeline

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -114,6 +114,11 @@ static cl::opt<bool>
                            cl::desc("Enable Machine Pipeliner for RISC-V"),
                            cl::init(false), cl::Hidden);
 
+static cl::opt<bool>
+    EnableEVLIndVarSimplify("riscv-simplify-evl-iv",
+                            cl::desc("Enable the EVLIndVarSimplify pass."),
+                            cl::init(false), cl::Hidden);
+
 extern "C" LLVM_ABI LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   RegisterTargetMachine<RISCVTargetMachine> X(getTheRISCV32Target());
   RegisterTargetMachine<RISCVTargetMachine> Y(getTheRISCV64Target());
@@ -645,7 +650,7 @@ void RISCVTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
 
   PB.registerVectorizerEndEPCallback(
       [](FunctionPassManager &FPM, OptimizationLevel Level) {
-        if (Level.isOptimizingForSpeed())
+        if (Level.isOptimizingForSpeed() && EnableEVLIndVarSimplify)
           FPM.addPass(createFunctionToLoopPassAdaptor(EVLIndVarSimplifyPass()));
       });
 }

--- a/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetMachine.cpp
@@ -114,11 +114,6 @@ static cl::opt<bool>
                            cl::desc("Enable Machine Pipeliner for RISC-V"),
                            cl::init(false), cl::Hidden);
 
-static cl::opt<bool>
-    EnableEVLIndVarSimplify("riscv-simplify-evl-iv",
-                            cl::desc("Enable the EVLIndVarSimplify pass."),
-                            cl::init(false), cl::Hidden);
-
 extern "C" LLVM_ABI LLVM_EXTERNAL_VISIBILITY void LLVMInitializeRISCVTarget() {
   RegisterTargetMachine<RISCVTargetMachine> X(getTheRISCV32Target());
   RegisterTargetMachine<RISCVTargetMachine> Y(getTheRISCV64Target());
@@ -647,12 +642,6 @@ void RISCVTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
                                                  OptimizationLevel Level) {
     LPM.addPass(LoopIdiomVectorizePass(LoopIdiomVectorizeStyle::Predicated));
   });
-
-  PB.registerVectorizerEndEPCallback(
-      [](FunctionPassManager &FPM, OptimizationLevel Level) {
-        if (Level.isOptimizingForSpeed() && EnableEVLIndVarSimplify)
-          FPM.addPass(createFunctionToLoopPassAdaptor(EVLIndVarSimplifyPass()));
-      });
 }
 
 yaml::MachineFunctionInfo *


### PR DESCRIPTION
With the VPlan-based canonical induction variable replacement landed in #147222, it appears to cover the functionality previously provided by the EVLIndVarSimplify pass introduced in #131005.

This patch suggests removing EVLIndVarSimplify from the RISC-V pipeline as a follow-up step. Feedback is very welcome!