### PR TITLE
[lldb][DWARFIndex][NFC] Change GetFunctions return type to IterationAction

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/AppleDWARFIndex.h
@@ -61,12 +61,13 @@ public:
                 llvm::function_ref<bool(DWARFDIE die)> callback) override;
   void GetNamespaces(ConstString name,
                      llvm::function_ref<bool(DWARFDIE die)> callback) override;
-  void GetFunctions(const Module::LookupInfo &lookup_info,
-                    SymbolFileDWARF &dwarf,
-                    const CompilerDeclContext &parent_decl_ctx,
-                    llvm::function_ref<bool(DWARFDIE die)> callback) override;
-  void GetFunctions(const RegularExpression &regex,
-                    llvm::function_ref<bool(DWARFDIE die)> callback) override;
+  void GetFunctions(
+      const Module::LookupInfo &lookup_info, SymbolFileDWARF &dwarf,
+      const CompilerDeclContext &parent_decl_ctx,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback) override;
+  void GetFunctions(
+      const RegularExpression &regex,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback) override;
 
   void Dump(Stream &s) override;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFIndex.h
@@ -16,6 +16,7 @@
 
 #include "lldb/Core/Module.h"
 #include "lldb/Target/Statistics.h"
+#include "lldb/lldb-private-enumerations.h"
 
 namespace lldb_private::plugin {
 namespace dwarf {
@@ -82,10 +83,10 @@ public:
   virtual void
   GetFunctions(const Module::LookupInfo &lookup_info, SymbolFileDWARF &dwarf,
                const CompilerDeclContext &parent_decl_ctx,
-               llvm::function_ref<bool(DWARFDIE die)> callback) = 0;
+               llvm::function_ref<IterationAction(DWARFDIE die)> callback) = 0;
   virtual void
   GetFunctions(const RegularExpression &regex,
-               llvm::function_ref<bool(DWARFDIE die)> callback) = 0;
+               llvm::function_ref<IterationAction(DWARFDIE die)> callback) = 0;
 
   virtual void Dump(Stream &s) = 0;
 
@@ -101,9 +102,10 @@ protected:
   /// the function given by "die" matches search criteria given by
   /// "parent_decl_ctx" and "name_type_mask", it calls the callback with the
   /// given die.
-  bool ProcessFunctionDIE(const Module::LookupInfo &lookup_info, DWARFDIE die,
-                          const CompilerDeclContext &parent_decl_ctx,
-                          llvm::function_ref<bool(DWARFDIE die)> callback);
+  IterationAction ProcessFunctionDIE(
+      const Module::LookupInfo &lookup_info, DWARFDIE die,
+      const CompilerDeclContext &parent_decl_ctx,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback);
 
   class DIERefCallbackImpl {
   public:
@@ -140,6 +142,25 @@ protected:
   bool ProcessNamespaceDieMatchParents(
       const CompilerDeclContext &parent_decl_ctx, DWARFDIE die,
       llvm::function_ref<bool(DWARFDIE die)> callback);
+
+  /// Helper to convert callbacks that return an \c IterationAction
+  /// to a callback that returns a \c bool, where \c true indicates
+  /// we should continue iterating. This will be used to incrementally
+  /// migrate the callbacks to return an \c IterationAction.
+  ///
+  /// FIXME: remove once all callbacks in the DWARFIndex APIs return
+  /// IterationAction.
+  struct IterationActionAdaptor {
+    IterationActionAdaptor(
+        llvm::function_ref<IterationAction(DWARFDIE die)> callback)
+        : m_callback_ref(callback) {}
+
+    bool operator()(DWARFDIE die) {
+      return m_callback_ref(std::move(die)) == IterationAction::Continue;
+    }
+
+    llvm::function_ref<IterationAction(DWARFDIE die)> m_callback_ref;
+  };
 };
 } // namespace dwarf
 } // namespace lldb_private::plugin

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.h
@@ -58,12 +58,13 @@ public:
   void GetNamespacesWithParents(
       ConstString name, const CompilerDeclContext &parent_decl_ctx,
       llvm::function_ref<bool(DWARFDIE die)> callback) override;
-  void GetFunctions(const Module::LookupInfo &lookup_info,
-                    SymbolFileDWARF &dwarf,
-                    const CompilerDeclContext &parent_decl_ctx,
-                    llvm::function_ref<bool(DWARFDIE die)> callback) override;
-  void GetFunctions(const RegularExpression &regex,
-                    llvm::function_ref<bool(DWARFDIE die)> callback) override;
+  void GetFunctions(
+      const Module::LookupInfo &lookup_info, SymbolFileDWARF &dwarf,
+      const CompilerDeclContext &parent_decl_ctx,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback) override;
+  void GetFunctions(
+      const RegularExpression &regex,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback) override;
 
   void Dump(Stream &s) override;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/Timer.h"
+#include "lldb/lldb-private-enumerations.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/ThreadPool.h"
 #include <atomic>
@@ -471,60 +472,62 @@ void ManualDWARFIndex::GetNamespaces(
 void ManualDWARFIndex::GetFunctions(
     const Module::LookupInfo &lookup_info, SymbolFileDWARF &dwarf,
     const CompilerDeclContext &parent_decl_ctx,
-    llvm::function_ref<bool(DWARFDIE die)> callback) {
+    llvm::function_ref<IterationAction(DWARFDIE die)> callback) {
   Index();
   ConstString name = lookup_info.GetLookupName();
   FunctionNameType name_type_mask = lookup_info.GetNameTypeMask();
 
   if (name_type_mask & eFunctionNameTypeFull) {
     if (!m_set.function_fullnames.Find(
-            name, DIERefCallback(
-                      [&](DWARFDIE die) {
-                        if (!SymbolFileDWARF::DIEInDeclContext(parent_decl_ctx,
-                                                               die))
-                          return true;
-                        return callback(die);
-                      },
-                      name.GetStringRef())))
+            name, DIERefCallback(IterationActionAdaptor([&](DWARFDIE die) {
+                                   if (!SymbolFileDWARF::DIEInDeclContext(
+                                           parent_decl_ctx, die))
+                                     return IterationAction::Continue;
+                                   return callback(die);
+                                 }),
+                                 name.GetStringRef())))
       return;
   }
   if (name_type_mask & eFunctionNameTypeBase) {
     if (!m_set.function_basenames.Find(
-            name, DIERefCallback(
-                      [&](DWARFDIE die) {
-                        if (!SymbolFileDWARF::DIEInDeclContext(parent_decl_ctx,
-                                                               die))
-                          return true;
-                        return callback(die);
-                      },
-                      name.GetStringRef())))
+            name, DIERefCallback(IterationActionAdaptor([&](DWARFDIE die) {
+                                   if (!SymbolFileDWARF::DIEInDeclContext(
+                                           parent_decl_ctx, die))
+                                     return IterationAction::Continue;
+                                   return callback(die);
+                                 }),
+                                 name.GetStringRef())))
       return;
   }
 
   if (name_type_mask & eFunctionNameTypeMethod && !parent_decl_ctx.IsValid()) {
     if (!m_set.function_methods.Find(
-            name, DIERefCallback(callback, name.GetStringRef())))
+            name, DIERefCallback(IterationActionAdaptor(callback),
+                                 name.GetStringRef())))
       return;
   }
 
   if (name_type_mask & eFunctionNameTypeSelector &&
       !parent_decl_ctx.IsValid()) {
     if (!m_set.function_selectors.Find(
-            name, DIERefCallback(callback, name.GetStringRef())))
+            name, DIERefCallback(IterationActionAdaptor(callback),
+                                 name.GetStringRef())))
       return;
   }
 }
 
 void ManualDWARFIndex::GetFunctions(
     const RegularExpression &regex,
-    llvm::function_ref<bool(DWARFDIE die)> callback) {
+    llvm::function_ref<IterationAction(DWARFDIE die)> callback) {
   Index();
 
-  if (!m_set.function_basenames.Find(regex,
-                                     DIERefCallback(callback, regex.GetText())))
+  if (!m_set.function_basenames.Find(
+          regex,
+          DIERefCallback(IterationActionAdaptor(callback), regex.GetText())))
     return;
-  if (!m_set.function_fullnames.Find(regex,
-                                     DIERefCallback(callback, regex.GetText())))
+  if (!m_set.function_fullnames.Find(
+          regex,
+          DIERefCallback(IterationActionAdaptor(callback), regex.GetText())))
     return;
 }
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/ManualDWARFIndex.h
@@ -50,12 +50,13 @@ public:
                 llvm::function_ref<bool(DWARFDIE die)> callback) override;
   void GetNamespaces(ConstString name,
                      llvm::function_ref<bool(DWARFDIE die)> callback) override;
-  void GetFunctions(const Module::LookupInfo &lookup_info,
-                    SymbolFileDWARF &dwarf,
-                    const CompilerDeclContext &parent_decl_ctx,
-                    llvm::function_ref<bool(DWARFDIE die)> callback) override;
-  void GetFunctions(const RegularExpression &regex,
-                    llvm::function_ref<bool(DWARFDIE die)> callback) override;
+  void GetFunctions(
+      const Module::LookupInfo &lookup_info, SymbolFileDWARF &dwarf,
+      const CompilerDeclContext &parent_decl_ctx,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback) override;
+  void GetFunctions(
+      const RegularExpression &regex,
+      llvm::function_ref<IterationAction(DWARFDIE die)> callback) override;
 
   void Dump(Stream &s) override;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -74,6 +74,7 @@
 #include "ManualDWARFIndex.h"
 #include "SymbolFileDWARFDebugMap.h"
 #include "SymbolFileDWARFDwo.h"
+#include "lldb/lldb-private-enumerations.h"
 
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h"
@@ -2539,7 +2540,7 @@ void SymbolFileDWARF::FindFunctions(const Module::LookupInfo &lookup_info,
   m_index->GetFunctions(lookup_info, *this, parent_decl_ctx, [&](DWARFDIE die) {
     if (resolved_dies.insert(die.GetDIE()).second)
       ResolveFunction(die, include_inlines, sc_list);
-    return true;
+    return IterationAction::Continue;
   });
   // With -gsimple-template-names, a templated type's DW_AT_name will not
   // contain the template parameters. Try again stripping '<' and anything
@@ -2556,7 +2557,7 @@ void SymbolFileDWARF::FindFunctions(const Module::LookupInfo &lookup_info,
                             [&](DWARFDIE die) {
                               if (resolved_dies.insert(die.GetDIE()).second)
                                 ResolveFunction(die, include_inlines, sc_list);
-                              return true;
+                              return IterationAction::Continue;
                             });
     }
   }
@@ -2592,7 +2593,7 @@ void SymbolFileDWARF::FindFunctions(const RegularExpression &regex,
   m_index->GetFunctions(regex, [&](DWARFDIE die) {
     if (resolved_dies.insert(die.GetDIE()).second)
       ResolveFunction(die, include_inlines, sc_list);
-    return true;
+    return IterationAction::Continue;
   });
 }
 


### PR DESCRIPTION
The ultimate goal is to replace the return types of all the `DWARFIndex` callbacks to `IterationAction`. To reduce the blast radius and do this incrementally I'm doing this for `GetFunctions` only here. I added a `IterationActionAdaptor` helper (that will ultimately get removed once all APIs have been migrated) to avoid having to change too many other APIs that `GetFunctions` interacts with.