### PR TITLE
[flang] Support for warning and error compiler directives.

### DIFF
--- a/flang/include/flang/Parser/dump-parse-tree.h
+++ b/flang/include/flang/Parser/dump-parse-tree.h
@@ -208,6 +208,8 @@ public:
   NODE(CompilerDirective, NameValue)
   NODE(CompilerDirective, Unrecognized)
   NODE(CompilerDirective, VectorAlways)
+  NODE(CompilerDirective, Error)
+  NODE(CompilerDirective, Warning)
   NODE(parser, ComplexLiteralConstant)
   NODE(parser, ComplexPart)
   NODE(parser, ComponentArraySpec)

--- a/flang/include/flang/Parser/parse-tree.h
+++ b/flang/include/flang/Parser/parse-tree.h
@@ -3363,6 +3363,12 @@ struct CompilerDirective {
     TUPLE_CLASS_BOILERPLATE(AssumeAligned);
     std::tuple<common::Indirection<Designator>, uint64_t> t;
   };
+  struct Error {
+    WRAPPER_CLASS_BOILERPLATE(Error, std::string);
+  };
+  struct Warning {
+    WRAPPER_CLASS_BOILERPLATE(Warning, std::string);
+  };
   EMPTY_CLASS(VectorAlways);
   struct NameValue {
     TUPLE_CLASS_BOILERPLATE(NameValue);
@@ -3370,8 +3376,8 @@ struct CompilerDirective {
   };
   EMPTY_CLASS(Unrecognized);
   CharBlock source;
-  std::variant<std::list<IgnoreTKR>, LoopCount, std::list<AssumeAligned>,
-      VectorAlways, std::list<NameValue>, Unrecognized>
+  std::variant<std::list<IgnoreTKR>, LoopCount, std::list<AssumeAligned>, Error,
+      Warning, VectorAlways, std::list<NameValue>, Unrecognized>
       u;
 };
 

--- a/flang/lib/Parser/Fortran-parsers.cpp
+++ b/flang/lib/Parser/Fortran-parsers.cpp
@@ -1294,6 +1294,8 @@ TYPE_PARSER(construct<StatOrErrmsg>("STAT =" >> statVariable) ||
 // !DIR$ LOOP COUNT (n1[, n2]...)
 // !DIR$ name[=value] [, name[=value]]...
 // !DIR$ <anything else>
+// !DIR$ ERROR  error-string
+// !DIR$ WARNING warning-string
 constexpr auto ignore_tkr{
     "IGNORE_TKR" >> optionalList(construct<CompilerDirective::IgnoreTKR>(
                         maybe(parenthesized(many(letter))), name))};
@@ -1305,11 +1307,17 @@ constexpr auto assumeAligned{"ASSUME_ALIGNED" >>
         indirect(designator), ":"_tok >> digitString64))};
 constexpr auto vectorAlways{
     "VECTOR ALWAYS" >> construct<CompilerDirective::VectorAlways>()};
+constexpr auto error{"ERROR" >>
+    construct<CompilerDirective::Error>(charLiteralConstantWithoutKind)};
+constexpr auto warning{"WARNING" >>
+    construct<CompilerDirective::Warning>(charLiteralConstantWithoutKind)};
 TYPE_PARSER(beginDirective >> "DIR$ "_tok >>
     sourced((construct<CompilerDirective>(ignore_tkr) ||
                 construct<CompilerDirective>(loopCount) ||
                 construct<CompilerDirective>(assumeAligned) ||
                 construct<CompilerDirective>(vectorAlways) ||
+                construct<CompilerDirective>(error) ||
+                construct<CompilerDirective>(warning) ||
                 construct<CompilerDirective>(
                     many(construct<CompilerDirective::NameValue>(
                         name, maybe(("="_tok || ":"_tok) >> digitString64))))) /

--- a/flang/lib/Parser/unparse.cpp
+++ b/flang/lib/Parser/unparse.cpp
@@ -1847,6 +1847,8 @@ public:
             [&](const std::list<CompilerDirective::NameValue> &names) {
               Walk("!DIR$ ", names, " ");
             },
+            [&](const CompilerDirective::Error &) { Word("!DIR$ ERROR"); },
+            [&](const CompilerDirective::Warning &) { Word("!DIR$ WARNING"); },
             [&](const CompilerDirective::Unrecognized &) {
               Word("!DIR$ ");
               Word(x.source.ToString());

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -9248,7 +9248,12 @@ void ResolveNamesVisitor::Post(const parser::CompilerDirective &x) {
   if (std::holds_alternative<parser::CompilerDirective::VectorAlways>(x.u)) {
     return;
   }
-  if (const auto *tkr{
+  if (const auto *err{std::get_if<parser::CompilerDirective::Error>(&x.u)}) {
+    Say(err->v, "%s"_err_en_US);
+  }
+  else if (const auto *warn{std::get_if<parser::CompilerDirective::Warning>(&x.u)}) {
+    Say(warn->v, "%s"_warn_en_US);
+  } else if (const auto *tkr{
           std::get_if<std::list<parser::CompilerDirective::IgnoreTKR>>(&x.u)}) {
     if (currScope().IsTopLevel() ||
         GetProgramUnitContaining(currScope()).kind() !=

--- a/flang/test/Parser/compiler-directive-error.f90
+++ b/flang/test/Parser/compiler-directive-error.f90
@@ -1,0 +1,8 @@
+! RUN: not %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+! Test that error compiler directive issues error
+program error
+!dir$ error "Error!"
+!CHECK: error: Error!
+end program
+

--- a/flang/test/Parser/compiler-directive-warning.f90
+++ b/flang/test/Parser/compiler-directive-warning.f90
@@ -1,0 +1,8 @@
+! RUN: %flang_fc1 -fsyntax-only %s 2>&1 | FileCheck %s
+
+! Test that warning compiler directive issues warning
+program warn
+!dir$ warning "Warning!"
+!CHECK: warning: Warning!
+end program
+


### PR DESCRIPTION
The warning directive ```!$dir warning "warning message"``` can be used to issue warning in the codepath. Similarly, the directive ```!$dir error "error message"```  can be used to issue error in the codepath.

These directives can be used to inform the user about deprecated features. 