### PR TITLE
[Orc] Strip weak in assertion for requested symbol flags

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/Core.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/Core.cpp
@@ -923,7 +923,8 @@ Error JITDylib::resolve(MaterializationResponsibility &MR,
                      "Resolving symbol with incorrect flags");
 
             } else
-              assert(KV.second.getFlags() == SymI->second.getFlags() &&
+              assert(KV.second.getFlags() ==
+                         (SymI->second.getFlags() & ~JITSymbolFlags::Weak) &&
                      "Resolved flags should match the declared flags");
 
             Worklist.push_back(
@@ -2909,7 +2910,7 @@ Error ExecutionSession::OL_notifyResolved(MaterializationResponsibility &MR,
                  (I->second & ~JITSymbolFlags::Common) &&
              "Resolving symbol with incorrect flags");
     } else
-      assert(KV.second.getFlags() == I->second &&
+      assert(KV.second.getFlags() == (I->second & ~JITSymbolFlags::Weak) &&
              "Resolving symbol with incorrect flags");
   }
 #endif

--- a/llvm/test/ExecutionEngine/Orc/comdat-any.ll
+++ b/llvm/test/ExecutionEngine/Orc/comdat-any.ll
@@ -1,0 +1,21 @@
+; MachO doesn't support COMDATs
+; UNSUPPORTED: system-darwin
+;
+; Works with MCJIT:
+; RUN: lli --jit-kind=mcjit %s
+;
+; Fails assertion in ORC: Resolving symbol with incorrect flags
+; RUN: lli --jit-kind=orc %s
+
+$f = comdat any
+
+define i32 @f() comdat {
+entry:
+  ret i32 0
+}
+
+define i32 @main() {
+entry:
+  %0 = call i32 @f()
+  ret i32 %0
+}


### PR DESCRIPTION
I recently ran into this assertion, reduced my repro and came up with this quick-fix. The case for common symbols looks similar, so for the moment I didn't spend more time investigating. Should we take it like this?