### PR TITLE
[Clang] Flush minimization hints after writing

### DIFF
--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -226,6 +226,8 @@ private:
     }
     *OS << "  ]\n";
     *OS << "}\n";
+
+    OS->flush();
   }
 };
 


### PR DESCRIPTION
This helps to get well-formed output if Clang crashes after that point.