### PR TITLE
[libc] Change LIBC_THREAD_LOCAL to be dependent on LIBC_THREAD_MODE

### DIFF
--- a/cmake/Modules/FindLibcCommonUtils.cmake
+++ b/cmake/Modules/FindLibcCommonUtils.cmake
@@ -12,6 +12,9 @@ if(NOT TARGET llvm-libc-common-utilities)
     add_library(llvm-libc-common-utilities INTERFACE)
     # TODO: Reorganize the libc shared section so that it can be included without
     # adding the root "libc" directory to the include path.
+    if (NOT(LIBCXX_ENABLE_THREADS))
+      target_compile_definitions(llvm-libc-common-utilities INTERFACE LIBC_THREAD_MODE=LIBC_THREAD_MODE_SINGLE)
+    endif()
     target_include_directories(llvm-libc-common-utilities INTERFACE ${libc_path})
     target_compile_definitions(llvm-libc-common-utilities INTERFACE LIBC_NAMESPACE=__llvm_libc_common_utils)
     target_compile_features(llvm-libc-common-utilities INTERFACE cxx_std_17)

--- a/libc/src/__support/macros/attributes.h
+++ b/libc/src/__support/macros/attributes.h
@@ -37,6 +37,22 @@
 // Vendor provides implementation
 #define LIBC_THREAD_MODE_EXTERNAL 2
 
+// libcxx doesn't define LIBC_THREAD_MODE, unless that is passed in the command
+// line in the CMake invocation. This defaults to the original implementation
+// (before changes in https://github.com/llvm/llvm-project/pull/145358)
+#ifndef LIBC_THREAD_MODE
+#define LIBC_THREAD_MODE LIBC_THREAD_MODE_PLATFORM
+#endif // LIBC_THREAD_MODE
+
+#if LIBC_THREAD_MODE != LIBC_THREAD_MODE_PLATFORM &&                           \
+    LIBC_THREAD_MODE != LIBC_THREAD_MODE_SINGLE &&                             \
+    LIBC_THREAD_MODE != LIBC_THREAD_MODE_EXTERNAL
+#error LIBC_THREAD_MODE must be one of the following values: \
+LIBC_THREAD_MODE_PLATFORM, \
+LIBC_THREAD_MODE_SINGLE, \
+LIBC_THREAD_MODE_EXTERNAL.
+#endif
+
 #if LIBC_THREAD_MODE == LIBC_THREAD_MODE_SINGLE
 #define LIBC_THREAD_LOCAL
 #else

--- a/libc/src/__support/macros/attributes.h
+++ b/libc/src/__support/macros/attributes.h
@@ -28,7 +28,16 @@
 #define LIBC_INLINE_ASM __asm__ __volatile__
 #define LIBC_UNUSED __attribute__((unused))
 
-#ifdef LIBC_TARGET_ARCH_IS_GPU
+// Uses the platform specific specialization
+#define LIBC_THREAD_MODE_PLATFORM 0
+
+// Mutex guards nothing, used in single-threaded implementations
+#define LIBC_THREAD_MODE_SINGLE 1
+
+// Vendor provides implementation
+#define LIBC_THREAD_MODE_EXTERNAL 2
+
+#if LIBC_THREAD_MODE == LIBC_THREAD_MODE_SINGLE
 #define LIBC_THREAD_LOCAL
 #else
 #define LIBC_THREAD_LOCAL thread_local

--- a/libc/src/__support/threads/mutex.h
+++ b/libc/src/__support/threads/mutex.h
@@ -12,15 +12,6 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 
-// Uses the platform specific specialization
-#define LIBC_THREAD_MODE_PLATFORM 0
-
-// Mutex guards nothing, used in single-threaded implementations
-#define LIBC_THREAD_MODE_SINGLE 1
-
-// Vendor provides implementation
-#define LIBC_THREAD_MODE_EXTERNAL 2
-
 #if !defined(LIBC_THREAD_MODE)
 #error LIBC_THREAD_MODE is undefined
 #endif // LIBC_THREAD_MODE

--- a/libc/src/__support/threads/mutex.h
+++ b/libc/src/__support/threads/mutex.h
@@ -12,19 +12,6 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 
-#if !defined(LIBC_THREAD_MODE)
-#error LIBC_THREAD_MODE is undefined
-#endif // LIBC_THREAD_MODE
-
-#if LIBC_THREAD_MODE != LIBC_THREAD_MODE_PLATFORM &&                           \
-    LIBC_THREAD_MODE != LIBC_THREAD_MODE_SINGLE &&                             \
-    LIBC_THREAD_MODE != LIBC_THREAD_MODE_EXTERNAL
-#error LIBC_THREAD_MODE must be one of the following values: \
-LIBC_THREAD_MODE_PLATFORM, \
-LIBC_THREAD_MODE_SINGLE, \
-LIBC_THREAD_MODE_EXTERNAL.
-#endif
-
 #if LIBC_THREAD_MODE == LIBC_THREAD_MODE_PLATFORM
 
 // Platform independent code will include this header file which pulls


### PR DESCRIPTION
When single-threaded mode is selected, all instances of the keyword `LIBC_THREAD_LOCAL` are stubbed out, similar to how it currently works on the GPU. This allows baremetal builds to avoid using thread_local.

However, libcxx uses shared headers, so we need to be careful there. Thankfully, there is already an option to disable multithreading in libcxx, so a flag is added such that single-threaded mode is propagated down to libc. 