### PR TITLE
[clang-tools-extra] Remove %T from lit tests

### DIFF
--- a/clang-tools-extra/test/clang-apply-replacements/basic.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/basic.cpp
@@ -1,17 +1,17 @@
-// RUN: mkdir -p %T/Inputs/basic
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/basic/basic.h > %T/Inputs/basic/basic.h
-// RUN: sed "s#\$(path)#%/T/Inputs/basic#" %S/Inputs/basic/file1.yaml > %T/Inputs/basic/file1.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/basic#" %S/Inputs/basic/file2.yaml > %T/Inputs/basic/file2.yaml
-// RUN: clang-apply-replacements %T/Inputs/basic
-// RUN: FileCheck -input-file=%T/Inputs/basic/basic.h %S/Inputs/basic/basic.h
+// RUN: mkdir -p %t.dir/Inputs/basic
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/basic/basic.h > %t.dir/Inputs/basic/basic.h
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/basic#" %S/Inputs/basic/file1.yaml > %t.dir/Inputs/basic/file1.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/basic#" %S/Inputs/basic/file2.yaml > %t.dir/Inputs/basic/file2.yaml
+// RUN: clang-apply-replacements %t.dir/Inputs/basic
+// RUN: FileCheck -input-file=%t.dir/Inputs/basic/basic.h %S/Inputs/basic/basic.h
 //
 // Check that the yaml files are *not* deleted after running clang-apply-replacements without remove-change-desc-files.
-// RUN: ls -1 %T/Inputs/basic | FileCheck %s --check-prefix=YAML
+// RUN: ls -1 %t.dir/Inputs/basic | FileCheck %s --check-prefix=YAML
 //
 // Check that the yaml files *are* deleted after running clang-apply-replacements with remove-change-desc-files.
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/basic/basic.h > %T/Inputs/basic/basic.h
-// RUN: clang-apply-replacements -remove-change-desc-files %T/Inputs/basic
-// RUN: ls -1 %T/Inputs/basic | FileCheck %s --check-prefix=NO_YAML
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/basic/basic.h > %t.dir/Inputs/basic/basic.h
+// RUN: clang-apply-replacements -remove-change-desc-files %t.dir/Inputs/basic
+// RUN: ls -1 %t.dir/Inputs/basic | FileCheck %s --check-prefix=NO_YAML
 //
 // YAML: {{^file.\.yaml$}}
 // NO_YAML-NOT: {{^file.\.yaml$}}

--- a/clang-tools-extra/test/clang-apply-replacements/conflict.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/conflict.cpp
@@ -1,17 +1,17 @@
-// RUN: mkdir -p %T/Inputs/conflict
-// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/file1.yaml > %T/Inputs/conflict/file1.yaml
-// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/file2.yaml > %T/Inputs/conflict/file2.yaml
-// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/file3.yaml > %T/Inputs/conflict/file3.yaml
-// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/expected.txt > %T/Inputs/conflict/expected.txt
-// RUN: not clang-apply-replacements %T/Inputs/conflict > %T/Inputs/conflict/output.txt 2>&1
-// RUN: diff -b %T/Inputs/conflict/output.txt %T/Inputs/conflict/expected.txt
+// RUN: mkdir -p %t.dir/Inputs/conflict
+// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/file1.yaml > %t.dir/Inputs/conflict/file1.yaml
+// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/file2.yaml > %t.dir/Inputs/conflict/file2.yaml
+// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/file3.yaml > %t.dir/Inputs/conflict/file3.yaml
+// RUN: sed "s#\$(path)#%/S/Inputs/conflict#" %S/Inputs/conflict/expected.txt > %t.dir/Inputs/conflict/expected.txt
+// RUN: not clang-apply-replacements %t.dir/Inputs/conflict > %t.dir/Inputs/conflict/output.txt 2>&1
+// RUN: diff -b %t.dir/Inputs/conflict/output.txt %t.dir/Inputs/conflict/expected.txt
 //
 // Check that the yaml files are *not* deleted after running clang-apply-replacements without remove-change-desc-files even when there is a failure.
-// RUN: ls -1 %T/Inputs/conflict | FileCheck %s --check-prefix=YAML
+// RUN: ls -1 %t.dir/Inputs/conflict | FileCheck %s --check-prefix=YAML
 //
 // Check that the yaml files *are* deleted after running clang-apply-replacements with remove-change-desc-files even when there is a failure.
-// RUN: not clang-apply-replacements %T/Inputs/conflict -remove-change-desc-files > %T/Inputs/conflict/output.txt 2>&1
-// RUN: ls -1 %T/Inputs/conflict | FileCheck %s --check-prefix=NO_YAML
+// RUN: not clang-apply-replacements %t.dir/Inputs/conflict -remove-change-desc-files > %t.dir/Inputs/conflict/output.txt 2>&1
+// RUN: ls -1 %t.dir/Inputs/conflict | FileCheck %s --check-prefix=NO_YAML
 //
 // YAML: {{^file.\.yaml$}}
 // NO_YAML-NOT: {{^file.\.yaml$}}

--- a/clang-tools-extra/test/clang-apply-replacements/crlf.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/crlf.cpp
@@ -1,5 +1,5 @@
-// RUN: mkdir -p %T/Inputs/crlf
-// RUN: cat %S/Inputs/crlf/crlf.cpp > %T/Inputs/crlf/crlf.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/crlf#" %S/Inputs/crlf/file1.yaml > %T/Inputs/crlf/file1.yaml
-// RUN: clang-apply-replacements %T/Inputs/crlf
-// RUN: diff %T/Inputs/crlf/crlf.cpp %S/Inputs/crlf/crlf.cpp.expected
+// RUN: mkdir -p %t.dir/Inputs/crlf
+// RUN: cat %S/Inputs/crlf/crlf.cpp > %t.dir/Inputs/crlf/crlf.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/crlf#" %S/Inputs/crlf/file1.yaml > %t.dir/Inputs/crlf/file1.yaml
+// RUN: clang-apply-replacements %t.dir/Inputs/crlf
+// RUN: diff %t.dir/Inputs/crlf/crlf.cpp %S/Inputs/crlf/crlf.cpp.expected

--- a/clang-tools-extra/test/clang-apply-replacements/format-header.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/format-header.cpp
@@ -1,13 +1,13 @@
-// RUN: mkdir -p %T/Inputs/format_header_yes
-// RUN: mkdir -p %T/Inputs/format_header_no
+// RUN: mkdir -p %t.dir/Inputs/format_header_yes
+// RUN: mkdir -p %t.dir/Inputs/format_header_no
 //
 //
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format_header/yes.cpp > %T/Inputs/format_header_yes/yes.cpp
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format_header/no.cpp > %T/Inputs/format_header_no/no.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/format_header_yes#" %S/Inputs/format_header/yes.yaml > %T/Inputs/format_header_yes/yes.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/format_header_no#" %S/Inputs/format_header/no.yaml > %T/Inputs/format_header_no/no.yaml
-// RUN: clang-apply-replacements -format -style="{BasedOnStyle: llvm, SortIncludes: CaseSensitive}" %T/Inputs/format_header_yes
-// RUN: clang-apply-replacements %T/Inputs/format_header_no
-// RUN: FileCheck --strict-whitespace -input-file=%T/Inputs/format_header_yes/yes.cpp %S/Inputs/format_header/yes.cpp
-// RUN: FileCheck --strict-whitespace -input-file=%T/Inputs/format_header_no/no.cpp %S/Inputs/format_header/no.cpp
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format_header/yes.cpp > %t.dir/Inputs/format_header_yes/yes.cpp
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format_header/no.cpp > %t.dir/Inputs/format_header_no/no.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/format_header_yes#" %S/Inputs/format_header/yes.yaml > %t.dir/Inputs/format_header_yes/yes.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/format_header_no#" %S/Inputs/format_header/no.yaml > %t.dir/Inputs/format_header_no/no.yaml
+// RUN: clang-apply-replacements -format -style="{BasedOnStyle: llvm, SortIncludes: CaseSensitive}" %t.dir/Inputs/format_header_yes
+// RUN: clang-apply-replacements %t.dir/Inputs/format_header_no
+// RUN: FileCheck --strict-whitespace -input-file=%t.dir/Inputs/format_header_yes/yes.cpp %S/Inputs/format_header/yes.cpp
+// RUN: FileCheck --strict-whitespace -input-file=%t.dir/Inputs/format_header_no/no.cpp %S/Inputs/format_header/no.cpp
 //

--- a/clang-tools-extra/test/clang-apply-replacements/format.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/format.cpp
@@ -1,15 +1,15 @@
-// RUN: mkdir -p %T/Inputs/format
+// RUN: mkdir -p %t.dir/Inputs/format
 //
 // yes.cpp requires formatting after replacements are applied. no.cpp does not.
 // The presence of no.cpp ensures that files that don't need formatting still
 // have their new state written to disk after applying replacements.
 //
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format/yes.cpp > %T/Inputs/format/yes.cpp
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format/no.cpp > %T/Inputs/format/no.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/format#" %S/Inputs/format/yes.yaml > %T/Inputs/format/yes.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/format#" %S/Inputs/format/no.yaml > %T/Inputs/format/no.yaml
-// RUN: clang-apply-replacements -format %T/Inputs/format
-// RUN: FileCheck --strict-whitespace -input-file=%T/Inputs/format/yes.cpp %S/Inputs/format/yes.cpp
-// RUN: FileCheck --strict-whitespace -input-file=%T/Inputs/format/no.cpp %S/Inputs/format/no.cpp
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format/yes.cpp > %t.dir/Inputs/format/yes.cpp
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/format/no.cpp > %t.dir/Inputs/format/no.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/format#" %S/Inputs/format/yes.yaml > %t.dir/Inputs/format/yes.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/format#" %S/Inputs/format/no.yaml > %t.dir/Inputs/format/no.yaml
+// RUN: clang-apply-replacements -format %t.dir/Inputs/format
+// RUN: FileCheck --strict-whitespace -input-file=%t.dir/Inputs/format/yes.cpp %S/Inputs/format/yes.cpp
+// RUN: FileCheck --strict-whitespace -input-file=%t.dir/Inputs/format/no.cpp %S/Inputs/format/no.cpp
 //
-// RUN not clang-apply-replacements -format=blah %T/Inputs/format
+// RUN not clang-apply-replacements -format=blah %t.dir/Inputs/format

--- a/clang-tools-extra/test/clang-apply-replacements/identical-in-TU.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/identical-in-TU.cpp
@@ -1,10 +1,10 @@
-// RUN: mkdir -p %T/Inputs/identical-in-TU
+// RUN: mkdir -p %t.dir/Inputs/identical-in-TU
 
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/identical-in-TU/identical-in-TU.cpp > %T/Inputs/identical-in-TU/identical-in-TU.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/identical-in-TU#" %S/Inputs/identical-in-TU/file1.yaml > %T/Inputs/identical-in-TU/file1.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/identical-in-TU#" %S/Inputs/identical-in-TU/file2.yaml > %T/Inputs/identical-in-TU/file2.yaml
-// RUN: clang-apply-replacements %T/Inputs/identical-in-TU
-// RUN: FileCheck -input-file=%T/Inputs/identical-in-TU/identical-in-TU.cpp %S/Inputs/identical-in-TU/identical-in-TU.cpp
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/identical-in-TU/identical-in-TU.cpp > %t.dir/Inputs/identical-in-TU/identical-in-TU.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/identical-in-TU#" %S/Inputs/identical-in-TU/file1.yaml > %t.dir/Inputs/identical-in-TU/file1.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/identical-in-TU#" %S/Inputs/identical-in-TU/file2.yaml > %t.dir/Inputs/identical-in-TU/file2.yaml
+// RUN: clang-apply-replacements %t.dir/Inputs/identical-in-TU
+// RUN: FileCheck -input-file=%t.dir/Inputs/identical-in-TU/identical-in-TU.cpp %S/Inputs/identical-in-TU/identical-in-TU.cpp
 
 // Similar to identical test but each yaml file contains the same fix twice. 
 // This check ensures that only the duplicated replacements in a single yaml 

--- a/clang-tools-extra/test/clang-apply-replacements/identical.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/identical.cpp
@@ -1,6 +1,6 @@
-// RUN: mkdir -p %T/Inputs/identical
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/identical/identical.cpp > %T/Inputs/identical/identical.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/identical#" %S/Inputs/identical/file1.yaml > %T/Inputs/identical/file1.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/identical#" %S/Inputs/identical/file2.yaml > %T/Inputs/identical/file2.yaml
-// RUN: clang-apply-replacements %T/Inputs/identical
-// RUN: FileCheck -input-file=%T/Inputs/identical/identical.cpp %S/Inputs/identical/identical.cpp
+// RUN: mkdir -p %t.dir/Inputs/identical
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/identical/identical.cpp > %t.dir/Inputs/identical/identical.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/identical#" %S/Inputs/identical/file1.yaml > %t.dir/Inputs/identical/file1.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/identical#" %S/Inputs/identical/file2.yaml > %t.dir/Inputs/identical/file2.yaml
+// RUN: clang-apply-replacements %t.dir/Inputs/identical
+// RUN: FileCheck -input-file=%t.dir/Inputs/identical/identical.cpp %S/Inputs/identical/identical.cpp

--- a/clang-tools-extra/test/clang-apply-replacements/ignore-conflict.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/ignore-conflict.cpp
@@ -1,5 +1,5 @@
-// RUN: mkdir -p %T/Inputs/ignore-conflict
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/ignore-conflict/ignore-conflict.cpp > %T/Inputs/ignore-conflict/ignore-conflict.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/ignore-conflict#" %S/Inputs/ignore-conflict/file1.yaml > %T/Inputs/ignore-conflict/file1.yaml
-// RUN: clang-apply-replacements --ignore-insert-conflict %T/Inputs/ignore-conflict
-// RUN: FileCheck -input-file=%T/Inputs/ignore-conflict/ignore-conflict.cpp %S/Inputs/ignore-conflict/ignore-conflict.cpp
+// RUN: mkdir -p %t.dir/Inputs/ignore-conflict
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/ignore-conflict/ignore-conflict.cpp > %t.dir/Inputs/ignore-conflict/ignore-conflict.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/ignore-conflict#" %S/Inputs/ignore-conflict/file1.yaml > %t.dir/Inputs/ignore-conflict/file1.yaml
+// RUN: clang-apply-replacements --ignore-insert-conflict %t.dir/Inputs/ignore-conflict
+// RUN: FileCheck -input-file=%t.dir/Inputs/ignore-conflict/ignore-conflict.cpp %S/Inputs/ignore-conflict/ignore-conflict.cpp

--- a/clang-tools-extra/test/clang-apply-replacements/invalid-files.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/invalid-files.cpp
@@ -1,6 +1,6 @@
-// RUN: mkdir -p %T/invalid-files
-// RUN: cp %S/Inputs/invalid-files/invalid-files.yaml %T/invalid-files/invalid-files.yaml
-// RUN: clang-apply-replacements %T/invalid-files
+// RUN: mkdir -p %t.dir/invalid-files
+// RUN: cp %S/Inputs/invalid-files/invalid-files.yaml %t.dir/invalid-files/invalid-files.yaml
+// RUN: clang-apply-replacements %t.dir/invalid-files
 //
 // Check that the yaml files are *not* deleted after running clang-apply-replacements without remove-change-desc-files.
-// RUN: ls %T/invalid-files/invalid-files.yaml
+// RUN: ls %t.dir/invalid-files/invalid-files.yaml

--- a/clang-tools-extra/test/clang-apply-replacements/order-dependent.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/order-dependent.cpp
@@ -1,7 +1,7 @@
-// RUN: mkdir -p %T/Inputs/order-dependent
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/order-dependent/order-dependent.cpp > %T/Inputs/order-dependent/order-dependent.cpp
-// RUN: sed "s#\$(path)#%/T/Inputs/order-dependent#" %S/Inputs/order-dependent/file1.yaml > %T/Inputs/order-dependent/file1.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/order-dependent#" %S/Inputs/order-dependent/file2.yaml > %T/Inputs/order-dependent/file2.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/order-dependent#" %S/Inputs/order-dependent/expected.txt > %T/Inputs/order-dependent/expected.txt
-// RUN: not clang-apply-replacements %T/Inputs/order-dependent > %T/Inputs/order-dependent/output.txt 2>&1
-// RUN: diff -b %T/Inputs/order-dependent/output.txt %T/Inputs/order-dependent/expected.txt
+// RUN: mkdir -p %t.dir/Inputs/order-dependent
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/order-dependent/order-dependent.cpp > %t.dir/Inputs/order-dependent/order-dependent.cpp
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/order-dependent#" %S/Inputs/order-dependent/file1.yaml > %t.dir/Inputs/order-dependent/file1.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/order-dependent#" %S/Inputs/order-dependent/file2.yaml > %t.dir/Inputs/order-dependent/file2.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/order-dependent#" %S/Inputs/order-dependent/expected.txt > %t.dir/Inputs/order-dependent/expected.txt
+// RUN: not clang-apply-replacements %t.dir/Inputs/order-dependent > %t.dir/Inputs/order-dependent/output.txt 2>&1
+// RUN: diff -b %t.dir/Inputs/order-dependent/output.txt %t.dir/Inputs/order-dependent/expected.txt

--- a/clang-tools-extra/test/clang-apply-replacements/relative-paths.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/relative-paths.cpp
@@ -1,7 +1,7 @@
-// RUN: mkdir -p %T/Inputs/relative-paths
-// RUN: mkdir -p %T/Inputs/relative-paths/subdir
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/relative-paths/basic.h > %T/Inputs/relative-paths/basic.h
-// RUN: sed "s#\$(path)#%/T/Inputs/relative-paths#" %S/Inputs/relative-paths/file1.yaml > %T/Inputs/relative-paths/file1.yaml
-// RUN: sed "s#\$(path)#%/T/Inputs/relative-paths#" %S/Inputs/relative-paths/file2.yaml > %T/Inputs/relative-paths/file2.yaml
-// RUN: clang-apply-replacements %T/Inputs/relative-paths
-// RUN: FileCheck -input-file=%T/Inputs/relative-paths/basic.h %S/Inputs/relative-paths/basic.h
+// RUN: mkdir -p %t.dir/Inputs/relative-paths
+// RUN: mkdir -p %t.dir/Inputs/relative-paths/subdir
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/relative-paths/basic.h > %t.dir/Inputs/relative-paths/basic.h
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/relative-paths#" %S/Inputs/relative-paths/file1.yaml > %t.dir/Inputs/relative-paths/file1.yaml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/relative-paths#" %S/Inputs/relative-paths/file2.yaml > %t.dir/Inputs/relative-paths/file2.yaml
+// RUN: clang-apply-replacements %t.dir/Inputs/relative-paths
+// RUN: FileCheck -input-file=%t.dir/Inputs/relative-paths/basic.h %S/Inputs/relative-paths/basic.h

--- a/clang-tools-extra/test/clang-apply-replacements/yml-basic.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/yml-basic.cpp
@@ -1,17 +1,17 @@
-// RUN: mkdir -p %T/Inputs/yml-basic
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/yml-basic/basic.h > %T/Inputs/yml-basic/basic.h
-// RUN: sed "s#\$(path)#%/T/Inputs/yml-basic#" %S/Inputs/yml-basic/file1.yml > %T/Inputs/yml-basic/file1.yml
-// RUN: sed "s#\$(path)#%/T/Inputs/yml-basic#" %S/Inputs/yml-basic/file2.yml > %T/Inputs/yml-basic/file2.yml
-// RUN: clang-apply-replacements %T/Inputs/yml-basic
-// RUN: FileCheck -input-file=%T/Inputs/yml-basic/basic.h %S/Inputs/yml-basic/basic.h
+// RUN: mkdir -p %t.dir/Inputs/yml-basic
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/yml-basic/basic.h > %t.dir/Inputs/yml-basic/basic.h
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/yml-basic#" %S/Inputs/yml-basic/file1.yml > %t.dir/Inputs/yml-basic/file1.yml
+// RUN: sed "s#\$(path)#%/t.dir/Inputs/yml-basic#" %S/Inputs/yml-basic/file2.yml > %t.dir/Inputs/yml-basic/file2.yml
+// RUN: clang-apply-replacements %t.dir/Inputs/yml-basic
+// RUN: FileCheck -input-file=%t.dir/Inputs/yml-basic/basic.h %S/Inputs/yml-basic/basic.h
 //
 // Check that the yml files are *not* deleted after running clang-apply-replacements without remove-change-desc-files.
-// RUN: ls -1 %T/Inputs/yml-basic | FileCheck %s --check-prefix=YML
+// RUN: ls -1 %t.dir/Inputs/yml-basic | FileCheck %s --check-prefix=YML
 //
 // Check that the yml files *are* deleted after running clang-apply-replacements with remove-change-desc-files.
-// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/yml-basic/basic.h > %T/Inputs/yml-basic/basic.h
-// RUN: clang-apply-replacements -remove-change-desc-files %T/Inputs/yml-basic
-// RUN: ls -1 %T/Inputs/yml-basic | FileCheck %s --check-prefix=NO_YML
+// RUN: grep -Ev "// *[A-Z-]+:" %S/Inputs/yml-basic/basic.h > %t.dir/Inputs/yml-basic/basic.h
+// RUN: clang-apply-replacements -remove-change-desc-files %t.dir/Inputs/yml-basic
+// RUN: ls -1 %t.dir/Inputs/yml-basic | FileCheck %s --check-prefix=NO_YML
 //
 // YML: {{^file.\.yml$}}
 // NO_YML-NOT: {{^file.\.yml$}}

--- a/clang-tools-extra/test/clang-change-namespace/allow-list.cpp
+++ b/clang-tools-extra/test/clang-change-namespace/allow-list.cpp
@@ -1,5 +1,5 @@
-// RUN: echo "^std::.*$" > %T/allow-list.txt
-// RUN: clang-change-namespace -old_namespace "na::nb" -new_namespace "x::y" --file_pattern ".*" --allowed_file %T/allow-list.txt %s -- | sed 's,// CHECK.*,,' | FileCheck %s
+// RUN: echo "^std::.*$" > %t.allow-list.txt
+// RUN: clang-change-namespace -old_namespace "na::nb" -new_namespace "x::y" --file_pattern ".*" --allowed_file %t.allow-list.txt %s -- | sed 's,// CHECK.*,,' | FileCheck %s
 
 #include "Inputs/fake-std.h"
 

--- a/clang-tools-extra/test/clang-change-namespace/macro.cpp
+++ b/clang-tools-extra/test/clang-change-namespace/macro.cpp
@@ -1,15 +1,16 @@
-// RUN: cp %S/macro.cpp %T/macro.cpp
-// RUN: echo "#define USING using na::nc::X" > %T/macro.h
+// RUN: mkdir -p %t.dir
+// RUN: cp %S/macro.cpp %t.dir/macro.cpp
+// RUN: echo "#define USING using na::nc::X" > %t.dir/macro.h
 //
-// RUN: clang-change-namespace -old_namespace "na::nb" -new_namespace "x::y" --file_pattern "macro.cpp$" --i %T/macro.cpp --
-// RUN: FileCheck -input-file=%T/macro.cpp -check-prefix=CHECK-CC %s
-// RUN: FileCheck -input-file=%T/macro.h -check-prefix=CHECK-HEADER %s
+// RUN: clang-change-namespace -old_namespace "na::nb" -new_namespace "x::y" --file_pattern "macro.cpp$" --i %t.dir/macro.cpp --
+// RUN: FileCheck -input-file=%t.dir/macro.cpp -check-prefix=CHECK-CC %s
+// RUN: FileCheck -input-file=%t.dir/macro.h -check-prefix=CHECK-HEADER %s
 //
-// RUN: cp %S/macro.cpp %T/macro.cpp
-// RUN: echo "#define USING using na::nc::X" > %T/macro.h
-// RUN: clang-change-namespace -old_namespace "na::nb" -new_namespace "x::y" --file_pattern ".*" --i %T/macro.cpp --
-// RUN: FileCheck -input-file=%T/macro.cpp -check-prefix=CHECK-CC %s
-// RUN: FileCheck -input-file=%T/macro.h -check-prefix=CHECK-CHANGED-HEADER %s
+// RUN: cp %S/macro.cpp %t.dir/macro.cpp
+// RUN: echo "#define USING using na::nc::X" > %t.dir/macro.h
+// RUN: clang-change-namespace -old_namespace "na::nb" -new_namespace "x::y" --file_pattern ".*" --i %t.dir/macro.cpp --
+// RUN: FileCheck -input-file=%t.dir/macro.cpp -check-prefix=CHECK-CC %s
+// RUN: FileCheck -input-file=%t.dir/macro.h -check-prefix=CHECK-CHANGED-HEADER %s
 #include "macro.h"
 namespace na { namespace nc { class X{}; } }
 

--- a/clang-tools-extra/test/clang-include-fixer/include_path.cpp
+++ b/clang-tools-extra/test/clang-include-fixer/include_path.cpp
@@ -1,18 +1,18 @@
-// RUN: mkdir -p %T/clang-include-fixer/include
-// RUN: mkdir -p %T/clang-include-fixer/symbols
-// RUN: mkdir -p %T/clang-include-fixer/build
-// RUN: mkdir -p %T/clang-include-fixer/src
-// RUN: sed 's|test_dir|%/T/clang-include-fixer|g' %S/Inputs/database_template.json > %T/clang-include-fixer/build/compile_commands.json
-// RUN: echo -e '#include "bar.h"\nb::a::bar f;' > %T/clang-include-fixer/src/bar.cpp
-// RUN: echo 'namespace b { namespace a { class bar {}; } }' > %T/clang-include-fixer/include/bar.h
-// RUN: cd %T/clang-include-fixer/build
-// RUN: find-all-symbols -output-dir=%T/clang-include-fixer/symbols -p=. %T/clang-include-fixer/src/bar.cpp
-// RUN: find-all-symbols -merge-dir=%T/clang-include-fixer/symbols %T/clang-include-fixer/build/find_all_symbols.yaml
-// RUN: FileCheck -input-file=%T/clang-include-fixer/build/find_all_symbols.yaml -check-prefix=CHECK-YAML %s
+// RUN: mkdir -p %t.dir/clang-include-fixer/include
+// RUN: mkdir -p %t.dir/clang-include-fixer/symbols
+// RUN: mkdir -p %t.dir/clang-include-fixer/build
+// RUN: mkdir -p %t.dir/clang-include-fixer/src
+// RUN: sed 's|test_dir|%/t.dir/clang-include-fixer|g' %S/Inputs/database_template.json > %t.dir/clang-include-fixer/build/compile_commands.json
+// RUN: echo -e '#include "bar.h"\nb::a::bar f;' > %t.dir/clang-include-fixer/src/bar.cpp
+// RUN: echo 'namespace b { namespace a { class bar {}; } }' > %t.dir/clang-include-fixer/include/bar.h
+// RUN: cd %t.dir/clang-include-fixer/build
+// RUN: find-all-symbols -output-dir=%t.dir/clang-include-fixer/symbols -p=. %t.dir/clang-include-fixer/src/bar.cpp
+// RUN: find-all-symbols -merge-dir=%t.dir/clang-include-fixer/symbols %t.dir/clang-include-fixer/build/find_all_symbols.yaml
+// RUN: FileCheck -input-file=%t.dir/clang-include-fixer/build/find_all_symbols.yaml -check-prefix=CHECK-YAML %s
 //
-// RUN: echo 'b::a::bar f;' > %T/clang-include-fixer/src/bar.cpp
-// RUN: clang-include-fixer -db=yaml -input=%T/clang-include-fixer/build/find_all_symbols.yaml -minimize-paths=true -p=. %T/clang-include-fixer/src/bar.cpp
-// RUN: FileCheck -input-file=%T/clang-include-fixer/src/bar.cpp %s
+// RUN: echo 'b::a::bar f;' > %t.dir/clang-include-fixer/src/bar.cpp
+// RUN: clang-include-fixer -db=yaml -input=%t.dir/clang-include-fixer/build/find_all_symbols.yaml -minimize-paths=true -p=. %t.dir/clang-include-fixer/src/bar.cpp
+// RUN: FileCheck -input-file=%t.dir/clang-include-fixer/src/bar.cpp %s
 
 // CHECK-YAML: ..{{[/\\]}}include{{[/\\]}}bar.h
 // CHECK: #include "bar.h"

--- a/clang-tools-extra/test/clang-include-fixer/multiple_fixes.cpp
+++ b/clang-tools-extra/test/clang-include-fixer/multiple_fixes.cpp
@@ -1,11 +1,11 @@
 // REQUIRES: shell
 // RUN: sed -e 's#//.*$##' %s > %t.cpp
-// RUN: mkdir -p %T/clang-include-fixer/multiple-fixes
-// RUN: echo 'foo f;' > %T/clang-include-fixer/multiple-fixes/foo.cpp
-// RUN: echo 'bar b;' > %T/clang-include-fixer/multiple-fixes/bar.cpp
-// RUN: clang-include-fixer -db=fixed -input='foo= "foo.h";bar= "bar.h"' %T/clang-include-fixer/multiple-fixes/*.cpp --
-// RUN: FileCheck -input-file=%T/clang-include-fixer/multiple-fixes/bar.cpp %s -check-prefix=CHECK-BAR
-// RUN: FileCheck -input-file=%T/clang-include-fixer/multiple-fixes/foo.cpp %s -check-prefix=CHECK-FOO
+// RUN: mkdir -p %t.dir/clang-include-fixer/multiple-fixes
+// RUN: echo 'foo f;' > %t.dir/clang-include-fixer/multiple-fixes/foo.cpp
+// RUN: echo 'bar b;' > %t.dir/clang-include-fixer/multiple-fixes/bar.cpp
+// RUN: clang-include-fixer -db=fixed -input='foo= "foo.h";bar= "bar.h"' %t.dir/clang-include-fixer/multiple-fixes/*.cpp --
+// RUN: FileCheck -input-file=%t.dir/clang-include-fixer/multiple-fixes/bar.cpp %s -check-prefix=CHECK-BAR
+// RUN: FileCheck -input-file=%t.dir/clang-include-fixer/multiple-fixes/foo.cpp %s -check-prefix=CHECK-FOO
 //
 // CHECK-FOO: #include "foo.h"
 // CHECK-FOO: foo f;

--- a/clang-tools-extra/test/clang-include-fixer/yamldb_autodetect.cpp
+++ b/clang-tools-extra/test/clang-include-fixer/yamldb_autodetect.cpp
@@ -1,6 +1,6 @@
-// RUN: mkdir -p %T/foo/bar
-// RUN: cp %p/Inputs/fake_yaml_db.yaml %T/find_all_symbols_db.yaml
-// RUN: cd %T/foo
+// RUN: mkdir -p %t.dir/foo/bar
+// RUN: cp %p/Inputs/fake_yaml_db.yaml %t.dir/find_all_symbols_db.yaml
+// RUN: cd %t.dir/foo
 // RUN: sed -e 's#//.*$##' %s > bar/test.cpp
 // RUN: clang-include-fixer -db=yaml bar/test.cpp --
 // RUN: FileCheck %s -input-file=bar/test.cpp

--- a/clang-tools-extra/test/clang-move/move-class.cpp
+++ b/clang-tools-extra/test/clang-move/move-class.cpp
@@ -1,25 +1,25 @@
-// RUN: mkdir -p %T/clang-move/build
-// RUN: mkdir -p %T/clang-move/include
-// RUN: mkdir -p %T/clang-move/src
-// RUN: sed 's|$test_dir|%/T/clang-move|g' %S/Inputs/database_template.json > %T/clang-move/compile_commands.json
-// RUN: cp %S/Inputs/test.h  %T/clang-move/include
-// RUN: cp %S/Inputs/test.cpp %T/clang-move/src
-// RUN: touch %T/clang-move/include/test2.h
-// RUN: cd %T/clang-move/build
-// RUN: clang-move -names="a::Foo" -new_cc=%T/clang-move/new_test.cpp -new_header=%T/clang-move/new_test.h -old_cc=../src/test.cpp -old_header=../include/test.h %T/clang-move/src/test.cpp
-// RUN: FileCheck -input-file=%T/clang-move/new_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
-// RUN: FileCheck -input-file=%T/clang-move/new_test.h -check-prefix=CHECK-NEW-TEST-H %s
-// RUN: FileCheck -input-file=%T/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: mkdir -p %t.dir/clang-move/build
+// RUN: mkdir -p %t.dir/clang-move/include
+// RUN: mkdir -p %t.dir/clang-move/src
+// RUN: sed 's|$test_dir|%/t.dir/clang-move|g' %S/Inputs/database_template.json > %t.dir/clang-move/compile_commands.json
+// RUN: cp %S/Inputs/test.h  %t.dir/clang-move/include
+// RUN: cp %S/Inputs/test.cpp %t.dir/clang-move/src
+// RUN: touch %t.dir/clang-move/include/test2.h
+// RUN: cd %t.dir/clang-move/build
+// RUN: clang-move -names="a::Foo" -new_cc=%t.dir/clang-move/new_test.cpp -new_header=%t.dir/clang-move/new_test.h -old_cc=../src/test.cpp -old_header=../include/test.h %t.dir/clang-move/src/test.cpp
+// RUN: FileCheck -input-file=%t.dir/clang-move/new_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
+// RUN: FileCheck -input-file=%t.dir/clang-move/new_test.h -check-prefix=CHECK-NEW-TEST-H %s
+// RUN: FileCheck -input-file=%t.dir/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%t.dir/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
 //
-// RUN: cp %S/Inputs/test.h  %T/clang-move/include
-// RUN: cp %S/Inputs/test.cpp %T/clang-move/src
-// RUN: cd %T/clang-move/build
-// RUN: clang-move -names="a::Foo" -new_cc=%T/clang-move/new_test.cpp -new_header=%T/clang-move/new_test.h -old_cc=%T/clang-move/src/test.cpp -old_header=%T/clang-move/include/test.h %T/clang-move/src/test.cpp
-// RUN: FileCheck -input-file=%T/clang-move/new_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
-// RUN: FileCheck -input-file=%T/clang-move/new_test.h -check-prefix=CHECK-NEW-TEST-H %s
-// RUN: FileCheck -input-file=%T/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: cp %S/Inputs/test.h  %t.dir/clang-move/include
+// RUN: cp %S/Inputs/test.cpp %t.dir/clang-move/src
+// RUN: cd %t.dir/clang-move/build
+// RUN: clang-move -names="a::Foo" -new_cc=%t.dir/clang-move/new_test.cpp -new_header=%t.dir/clang-move/new_test.h -old_cc=%t.dir/clang-move/src/test.cpp -old_header=%t.dir/clang-move/include/test.h %t.dir/clang-move/src/test.cpp
+// RUN: FileCheck -input-file=%t.dir/clang-move/new_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
+// RUN: FileCheck -input-file=%t.dir/clang-move/new_test.h -check-prefix=CHECK-NEW-TEST-H %s
+// RUN: FileCheck -input-file=%t.dir/clang-move/src/test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%t.dir/clang-move/include/test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
 //
 //
 // CHECK-NEW-TEST-H: #ifndef TEST_H // comment 1

--- a/clang-tools-extra/test/clang-move/move-enum-decl.cpp
+++ b/clang-tools-extra/test/clang-move/move-enum-decl.cpp
@@ -1,14 +1,14 @@
-// RUN: mkdir -p %T/move-enum
-// RUN: cp %S/Inputs/enum.h  %T/move-enum/enum.h
-// RUN: echo '#include "enum.h"' > %T/move-enum/enum.cpp
-// RUN: cd %T/move-enum
+// RUN: mkdir -p %t.dir/move-enum
+// RUN: cp %S/Inputs/enum.h  %t.dir/move-enum/enum.h
+// RUN: echo '#include "enum.h"' > %t.dir/move-enum/enum.cpp
+// RUN: cd %t.dir/move-enum
 //
 // -----------------------------------------------------------------------------
 // Test moving enum declarations.
 // -----------------------------------------------------------------------------
-// RUN: clang-move -names="a::E1" -new_cc=%T/move-enum/new_test.cpp -new_header=%T/move-enum/new_test.h -old_cc=%T/move-enum/enum.cpp -old_header=%T/move-enum/enum.h %T/move-enum/enum.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-enum/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
-// RUN: FileCheck -input-file=%T/move-enum/enum.h -check-prefix=CHECK-OLD-TEST-H-CASE1 %s
+// RUN: clang-move -names="a::E1" -new_cc=%t.dir/move-enum/new_test.cpp -new_header=%t.dir/move-enum/new_test.h -old_cc=%t.dir/move-enum/enum.cpp -old_header=%t.dir/move-enum/enum.h %t.dir/move-enum/enum.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-enum/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
+// RUN: FileCheck -input-file=%t.dir/move-enum/enum.h -check-prefix=CHECK-OLD-TEST-H-CASE1 %s
 //
 // CHECK-NEW-TEST-H-CASE1: namespace a {
 // CHECK-NEW-TEST-H-CASE1-NEXT: enum E1 { Green, Red };
@@ -20,11 +20,11 @@
 // -----------------------------------------------------------------------------
 // Test moving scoped enum declarations.
 // -----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/enum.h  %T/move-enum/enum.h
-// RUN: echo '#include "enum.h"' > %T/move-enum/enum.cpp
-// RUN: clang-move -names="a::E2" -new_cc=%T/move-enum/new_test.cpp -new_header=%T/move-enum/new_test.h -old_cc=%T/move-enum/enum.cpp -old_header=%T/move-enum/enum.h %T/move-enum/enum.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-enum/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-enum/enum.h -check-prefix=CHECK-OLD-TEST-H-CASE2 %s
+// RUN: cp %S/Inputs/enum.h  %t.dir/move-enum/enum.h
+// RUN: echo '#include "enum.h"' > %t.dir/move-enum/enum.cpp
+// RUN: clang-move -names="a::E2" -new_cc=%t.dir/move-enum/new_test.cpp -new_header=%t.dir/move-enum/new_test.h -old_cc=%t.dir/move-enum/enum.cpp -old_header=%t.dir/move-enum/enum.h %t.dir/move-enum/enum.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-enum/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-enum/enum.h -check-prefix=CHECK-OLD-TEST-H-CASE2 %s
 
 // CHECK-NEW-TEST-H-CASE2: namespace a {
 // CHECK-NEW-TEST-H-CASE2-NEXT: enum class E2 { Yellow };
@@ -36,9 +36,9 @@
 // -----------------------------------------------------------------------------
 // Test not moving class-insided enum declarations.
 // -----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/enum.h  %T/move-enum/enum.h
-// RUN: echo '#include "enum.h"' > %T/move-enum/enum.cpp
-// RUN: clang-move -names="a::C::E3" -new_cc=%T/move-enum/new_test.cpp -new_header=%T/move-enum/new_test.h -old_cc=%T/move-enum/enum.cpp -old_header=%T/move-enum/enum.h %T/move-enum/enum.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-enum/new_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: cp %S/Inputs/enum.h  %t.dir/move-enum/enum.h
+// RUN: echo '#include "enum.h"' > %t.dir/move-enum/enum.cpp
+// RUN: clang-move -names="a::C::E3" -new_cc=%t.dir/move-enum/new_test.cpp -new_header=%t.dir/move-enum/new_test.h -old_cc=%t.dir/move-enum/enum.cpp -old_header=%t.dir/move-enum/enum.h %t.dir/move-enum/enum.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-enum/new_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
 
 // CHECK-EMPTY: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/move-function.cpp
+++ b/clang-tools-extra/test/clang-move/move-function.cpp
@@ -1,9 +1,9 @@
-// RUN: mkdir -p %T/move-function
-// RUN: cat %S/Inputs/function_test.h > %T/move-function/function_test.h
-// RUN: cat %S/Inputs/function_test.cpp > %T/move-function/function_test.cpp
-// RUN: cd %T/move-function
-// RUN: clang-move -names="g" -new_header=%T/move-function/new_function_test.h -old_header=../move-function/function_test.h %T/move-function/function_test.cpp --
-// RUN: FileCheck -input-file=%T/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
+// RUN: mkdir -p %t.dir/move-function
+// RUN: cat %S/Inputs/function_test.h > %t.dir/move-function/function_test.h
+// RUN: cat %S/Inputs/function_test.cpp > %t.dir/move-function/function_test.cpp
+// RUN: cd %t.dir/move-function
+// RUN: clang-move -names="g" -new_header=%t.dir/move-function/new_function_test.h -old_header=../move-function/function_test.h %t.dir/move-function/function_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
 //
 // CHECK-NEW-TEST-H-CASE1: #ifndef {{.*}}NEW_FUNCTION_TEST_H
 // CHECK-NEW-TEST-H-CASE1: #define {{.*}}NEW_FUNCTION_TEST_H
@@ -12,9 +12,9 @@
 // CHECK-NEW-TEST-H-CASE1: {{[[:space:]]+}}
 // CHECK-NEW-TEST-H-CASE1: #endif // {{.*}}NEW_FUNCTION_TEST_H
 //
-// RUN: cp %S/Inputs/function_test*  %T/move-function
-// RUN: clang-move -names="h" -new_header=%T/move-function/new_function_test.h -old_header=../move-function/function_test.h %T/move-function/function_test.cpp --
-// RUN: FileCheck -input-file=%T/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
+// RUN: cp %S/Inputs/function_test*  %t.dir/move-function
+// RUN: clang-move -names="h" -new_header=%t.dir/move-function/new_function_test.h -old_header=../move-function/function_test.h %t.dir/move-function/function_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
 //
 // CHECK-NEW-TEST-H-CASE2: #ifndef {{.*}}NEW_FUNCTION_TEST_H
 // CHECK-NEW-TEST-H-CASE2: #define {{.*}}NEW_FUNCTION_TEST_H
@@ -25,10 +25,10 @@
 // CHECK-NEW-TEST-H-CASE2: {{[[:space:]]+}}
 // CHECK-NEW-TEST-H-CASE2: #endif // {{.*}}NEW_FUNCTION_TEST_H
 //
-// RUN: cp %S/Inputs/function_test*  %T/move-function
-// RUN: clang-move -names="f" -new_header=%T/move-function/new_function_test.h -new_cc=%T/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %T/move-function/function_test.cpp --
-// RUN: FileCheck -input-file=%T/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE3 %s
-// RUN: FileCheck -input-file=%T/move-function/new_function_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE3 %s
+// RUN: cp %S/Inputs/function_test*  %t.dir/move-function
+// RUN: clang-move -names="f" -new_header=%t.dir/move-function/new_function_test.h -new_cc=%t.dir/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %t.dir/move-function/function_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE3 %s
+// RUN: FileCheck -input-file=%t.dir/move-function/new_function_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE3 %s
 //
 // CHECK-NEW-TEST-H-CASE3: #ifndef {{.*}}NEW_FUNCTION_TEST_H
 // CHECK-NEW-TEST-H-CASE3: #define {{.*}}NEW_FUNCTION_TEST_H
@@ -40,17 +40,17 @@
 // CHECK-NEW-TEST-CPP-CASE3: {{[[:space:]]+}}
 // CHECK-NEW-TEST-CPP-CASE3: void f() {}
 //
-// RUN: cat %S/Inputs/function_test.h > %T/move-function/function_test.h
-// RUN: cat %S/Inputs/function_test.cpp > %T/move-function/function_test.cpp
-// RUN: clang-move -names="A::f" -new_header=%T/move-function/new_function_test.h -new_cc=%T/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %T/move-function/function_test.cpp -dump_result -- | FileCheck %s -check-prefix=CHECK-EMPTY
+// RUN: cat %S/Inputs/function_test.h > %t.dir/move-function/function_test.h
+// RUN: cat %S/Inputs/function_test.cpp > %t.dir/move-function/function_test.cpp
+// RUN: clang-move -names="A::f" -new_header=%t.dir/move-function/new_function_test.h -new_cc=%t.dir/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %t.dir/move-function/function_test.cpp -dump_result -- | FileCheck %s -check-prefix=CHECK-EMPTY
 //
 // CHECK-EMPTY: [{{[[:space:]]*}}]
 //
-// RUN: cat %S/Inputs/function_test.h > %T/move-function/function_test.h
-// RUN: cat %S/Inputs/function_test.cpp > %T/move-function/function_test.cpp
-// RUN: clang-move -names="f,A" -new_header=%T/move-function/new_function_test.h -new_cc=%T/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %T/move-function/function_test.cpp --
-// RUN: FileCheck -input-file=%T/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE4 %s
-// RUN: FileCheck -input-file=%T/move-function/new_function_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE4 %s
+// RUN: cat %S/Inputs/function_test.h > %t.dir/move-function/function_test.h
+// RUN: cat %S/Inputs/function_test.cpp > %t.dir/move-function/function_test.cpp
+// RUN: clang-move -names="f,A" -new_header=%t.dir/move-function/new_function_test.h -new_cc=%t.dir/move-function/new_function_test.cpp -old_header=../move-function/function_test.h -old_cc=../move-function/function_test.cpp %t.dir/move-function/function_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-function/new_function_test.h -check-prefix=CHECK-NEW-TEST-H-CASE4 %s
+// RUN: FileCheck -input-file=%t.dir/move-function/new_function_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE4 %s
 
 // CHECK-NEW-TEST-H-CASE4: #ifndef {{.*}}NEW_FUNCTION_TEST_H
 // CHECK-NEW-TEST-H-CASE4: #define {{.*}}NEW_FUNCTION_TEST_H

--- a/clang-tools-extra/test/clang-move/move-multiple-classes.cpp
+++ b/clang-tools-extra/test/clang-move/move-multiple-classes.cpp
@@ -1,12 +1,12 @@
-// RUN: mkdir -p %T/move-multiple-classes
-// RUN: cp %S/Inputs/multiple_class_test*  %T/move-multiple-classes/
-// RUN: cd %T/move-multiple-classes
-// RUN: clang-move -names="c::EnclosingMove5::Nested" -new_cc=%T/move-multiple-classes/new_multiple_class_test.cpp -new_header=%T/move-multiple-classes/new_multiple_class_test.h -old_cc=%T/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h -dump_result %T/move-multiple-classes/multiple_class_test.cpp -- -std=c++11| FileCheck %s -check-prefix=CHECK-EMPTY
-// RUN: clang-move -names="a::Move1, b::Move2,c::Move3,c::Move4,c::EnclosingMove5" -new_cc=%T/move-multiple-classes/new_multiple_class_test.cpp -new_header=%T/move-multiple-classes/new_multiple_class_test.h -old_cc=%T/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h %T/move-multiple-classes/multiple_class_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-multiple-classes/new_multiple_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
-// RUN: FileCheck -input-file=%T/move-multiple-classes/new_multiple_class_test.h -check-prefix=CHECK-NEW-TEST-H %s
-// RUN: FileCheck -input-file=%T/move-multiple-classes/multiple_class_test.cpp -check-prefix=CHECK-OLD-TEST-CPP %s
-// RUN: FileCheck -input-file=%T/move-multiple-classes/multiple_class_test.h -check-prefix=CHECK-OLD-TEST-H %s
+// RUN: mkdir -p %t.dir/move-multiple-classes
+// RUN: cp %S/Inputs/multiple_class_test*  %t.dir/move-multiple-classes/
+// RUN: cd %t.dir/move-multiple-classes
+// RUN: clang-move -names="c::EnclosingMove5::Nested" -new_cc=%t.dir/move-multiple-classes/new_multiple_class_test.cpp -new_header=%t.dir/move-multiple-classes/new_multiple_class_test.h -old_cc=%t.dir/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h -dump_result %t.dir/move-multiple-classes/multiple_class_test.cpp -- -std=c++11| FileCheck %s -check-prefix=CHECK-EMPTY
+// RUN: clang-move -names="a::Move1, b::Move2,c::Move3,c::Move4,c::EnclosingMove5" -new_cc=%t.dir/move-multiple-classes/new_multiple_class_test.cpp -new_header=%t.dir/move-multiple-classes/new_multiple_class_test.h -old_cc=%t.dir/move-multiple-classes/multiple_class_test.cpp -old_header=../move-multiple-classes/multiple_class_test.h %t.dir/move-multiple-classes/multiple_class_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-multiple-classes/new_multiple_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP %s
+// RUN: FileCheck -input-file=%t.dir/move-multiple-classes/new_multiple_class_test.h -check-prefix=CHECK-NEW-TEST-H %s
+// RUN: FileCheck -input-file=%t.dir/move-multiple-classes/multiple_class_test.cpp -check-prefix=CHECK-OLD-TEST-CPP %s
+// RUN: FileCheck -input-file=%t.dir/move-multiple-classes/multiple_class_test.h -check-prefix=CHECK-OLD-TEST-H %s
 //
 // CHECK-EMPTY: [{{[[:space:]]*}}]
 //

--- a/clang-tools-extra/test/clang-move/move-template-class.cpp
+++ b/clang-tools-extra/test/clang-move/move-template-class.cpp
@@ -1,18 +1,18 @@
-// RUN: mkdir -p %T/move-template-class
-// RUN: cp %S/Inputs/template_class_test*  %T/move-template-class
-// RUN: cd %T/move-template-class
-// RUN: clang-move -names="A,B" -new_cc=%T/move-template-class/new_template_class_test.cpp -new_header=%T/move-template-class/new_template_class_test.h -old_cc=%T/move-template-class/template_class_test.cpp -old_header=../move-template-class/template_class_test.h %T/move-template-class/template_class_test.cpp --
-// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
-// RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE1 %s
-// RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
+// RUN: mkdir -p %t.dir/move-template-class
+// RUN: cp %S/Inputs/template_class_test*  %t.dir/move-template-class
+// RUN: cd %t.dir/move-template-class
+// RUN: clang-move -names="A,B" -new_cc=%t.dir/move-template-class/new_template_class_test.cpp -new_header=%t.dir/move-template-class/new_template_class_test.h -old_cc=%t.dir/move-template-class/template_class_test.cpp -old_header=../move-template-class/template_class_test.h %t.dir/move-template-class/template_class_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-template-class/template_class_test.cpp -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%t.dir/move-template-class/template_class_test.h -check-prefix=CHECK-OLD-TEST-EMPTY -allow-empty %s
+// RUN: FileCheck -input-file=%t.dir/move-template-class/new_template_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE1 %s
+// RUN: FileCheck -input-file=%t.dir/move-template-class/new_template_class_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
 //
-// RUN: cp %S/Inputs/template_class_test*  %T/move-template-class
-// RUN: clang-move -names="A" -new_cc=%T/move-template-class/new_template_class_test.cpp -new_header=%T/move-template-class/new_template_class_test.h -old_cc=%T/move-template-class/template_class_test.cpp -old_header=../move-template-class/template_class_test.h %T/move-template-class/template_class_test.cpp --
-// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.h -check-prefix=CHECK-OLD-TEST-H-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-template-class/template_class_test.cpp -check-prefix=CHECK-OLD-TEST-CPP-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-template-class/new_template_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE2 %s
+// RUN: cp %S/Inputs/template_class_test*  %t.dir/move-template-class
+// RUN: clang-move -names="A" -new_cc=%t.dir/move-template-class/new_template_class_test.cpp -new_header=%t.dir/move-template-class/new_template_class_test.h -old_cc=%t.dir/move-template-class/template_class_test.cpp -old_header=../move-template-class/template_class_test.h %t.dir/move-template-class/template_class_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-template-class/template_class_test.h -check-prefix=CHECK-OLD-TEST-H-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-template-class/template_class_test.cpp -check-prefix=CHECK-OLD-TEST-CPP-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-template-class/new_template_class_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-template-class/new_template_class_test.cpp -check-prefix=CHECK-NEW-TEST-CPP-CASE2 %s
 //
 //
 // CHECK-OLD-TEST-EMPTY: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/move-type-alias.cpp
+++ b/clang-tools-extra/test/clang-move/move-type-alias.cpp
@@ -1,14 +1,14 @@
-// RUN: mkdir -p %T/move-type-alias
-// RUN: cp %S/Inputs/type_alias.h  %T/move-type-alias/type_alias.h
-// RUN: echo '#include "type_alias.h"' > %T/move-type-alias/type_alias.cpp
-// RUN: cd %T/move-type-alias
+// RUN: mkdir -p %t.dir/move-type-alias
+// RUN: cp %S/Inputs/type_alias.h  %t.dir/move-type-alias/type_alias.h
+// RUN: echo '#include "type_alias.h"' > %t.dir/move-type-alias/type_alias.cpp
+// RUN: cd %t.dir/move-type-alias
 //
 // -----------------------------------------------------------------------------
 // Test moving typedef declarations.
 // -----------------------------------------------------------------------------
-// RUN: clang-move -names="Int1" -new_cc=%T/move-type-alias/new_test.cpp -new_header=%T/move-type-alias/new_test.h -old_cc=%T/move-type-alias/type_alias.cpp -old_header=%T/move-type-alias/type_alias.h %T/move-type-alias/type_alias.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-type-alias/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
-// RUN: FileCheck -input-file=%T/move-type-alias/type_alias.h -check-prefix=CHECK-OLD-TEST-H-CASE1 %s
+// RUN: clang-move -names="Int1" -new_cc=%t.dir/move-type-alias/new_test.cpp -new_header=%t.dir/move-type-alias/new_test.h -old_cc=%t.dir/move-type-alias/type_alias.cpp -old_header=%t.dir/move-type-alias/type_alias.h %t.dir/move-type-alias/type_alias.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-type-alias/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE1 %s
+// RUN: FileCheck -input-file=%t.dir/move-type-alias/type_alias.h -check-prefix=CHECK-OLD-TEST-H-CASE1 %s
 
 // CHECK-NEW-TEST-H-CASE1: typedef int Int1;
 
@@ -18,11 +18,11 @@
 // -----------------------------------------------------------------------------
 // Test moving type alias declarations.
 // -----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/type_alias.h  %T/move-type-alias/type_alias.h
-// RUN: echo '#include "type_alias.h"' > %T/move-type-alias/type_alias.cpp
-// RUN: clang-move -names="Int2" -new_cc=%T/move-type-alias/new_test.cpp -new_header=%T/move-type-alias/new_test.h -old_cc=%T/move-type-alias/type_alias.cpp -old_header=%T/move-type-alias/type_alias.h %T/move-type-alias/type_alias.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-type-alias/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-type-alias/type_alias.h -check-prefix=CHECK-OLD-TEST-H-CASE2 %s
+// RUN: cp %S/Inputs/type_alias.h  %t.dir/move-type-alias/type_alias.h
+// RUN: echo '#include "type_alias.h"' > %t.dir/move-type-alias/type_alias.cpp
+// RUN: clang-move -names="Int2" -new_cc=%t.dir/move-type-alias/new_test.cpp -new_header=%t.dir/move-type-alias/new_test.h -old_cc=%t.dir/move-type-alias/type_alias.cpp -old_header=%t.dir/move-type-alias/type_alias.h %t.dir/move-type-alias/type_alias.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-type-alias/new_test.h -check-prefix=CHECK-NEW-TEST-H-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-type-alias/type_alias.h -check-prefix=CHECK-OLD-TEST-H-CASE2 %s
 
 // CHECK-NEW-TEST-H-CASE2: using Int2 = int;
 
@@ -32,10 +32,10 @@
 // -----------------------------------------------------------------------------
 // Test moving template type alias declarations.
 // -----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/type_alias.h  %T/move-type-alias/type_alias.h
-// RUN: echo '#include "type_alias.h"' > %T/move-type-alias/type_alias.cpp
-// RUN: clang-move -names="B" -new_cc=%T/move-type-alias/new_test.cpp -new_header=%T/move-type-alias/new_test.h -old_cc=%T/move-type-alias/type_alias.cpp -old_header=%T/move-type-alias/type_alias.h %T/move-type-alias/type_alias.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-type-alias/new_test.h -check-prefix=CHECK-OLD-TEST-H-CASE3 %s
+// RUN: cp %S/Inputs/type_alias.h  %t.dir/move-type-alias/type_alias.h
+// RUN: echo '#include "type_alias.h"' > %t.dir/move-type-alias/type_alias.cpp
+// RUN: clang-move -names="B" -new_cc=%t.dir/move-type-alias/new_test.cpp -new_header=%t.dir/move-type-alias/new_test.h -old_cc=%t.dir/move-type-alias/type_alias.cpp -old_header=%t.dir/move-type-alias/type_alias.h %t.dir/move-type-alias/type_alias.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-type-alias/new_test.h -check-prefix=CHECK-OLD-TEST-H-CASE3 %s
 
 // CHECK-NEW-TEST-H-CASE3: template<class T> using B = A<T>;
 // CHECK-OLD-TEST-H-CASE3-NOT: template<class T> using B = A<T>;
@@ -44,9 +44,9 @@
 // -----------------------------------------------------------------------------
 // Test not moving class-insided typedef declarations.
 // -----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/type_alias.h  %T/move-type-alias/type_alias.h
-// RUN: echo '#include "type_alias.h"' > %T/move-type-alias/type_alias.cpp
-// RUN: clang-move -names="C::Int3" -new_cc=%T/move-type-alias/new_test.cpp -new_header=%T/move-type-alias/new_test.h -old_cc=%T/move-type-alias/type_alias.cpp -old_header=%T/move-type-alias/type_alias.h %T/move-type-alias/type_alias.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/move-type-alias/new_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: cp %S/Inputs/type_alias.h  %t.dir/move-type-alias/type_alias.h
+// RUN: echo '#include "type_alias.h"' > %t.dir/move-type-alias/type_alias.cpp
+// RUN: clang-move -names="C::Int3" -new_cc=%t.dir/move-type-alias/new_test.cpp -new_header=%t.dir/move-type-alias/new_test.h -old_cc=%t.dir/move-type-alias/type_alias.cpp -old_header=%t.dir/move-type-alias/type_alias.h %t.dir/move-type-alias/type_alias.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/move-type-alias/new_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
 
 // CHECK-EMPTY: {{^}}{{$}}

--- a/clang-tools-extra/test/clang-move/move-used-helper-decls.cpp
+++ b/clang-tools-extra/test/clang-move/move-used-helper-decls.cpp
@@ -1,13 +1,13 @@
-// RUN: mkdir -p %T/used-helper-decls
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: cd %T/used-helper-decls
+// RUN: mkdir -p %t.dir/used-helper-decls
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: cd %t.dir/used-helper-decls
 
 // ----------------------------------------------------------------------------
 // Test moving used helper function and its transitively used functions.
 // ----------------------------------------------------------------------------
-// RUN: clang-move -names="a::Class1" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS1-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS1-CPP %s
+// RUN: clang-move -names="a::Class1" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS1-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS1-CPP %s
 
 // CHECK-NEW-CLASS1-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS1-CPP-SAME: {{[[:space:]]}}
@@ -31,10 +31,10 @@
 // ----------------------------------------------------------------------------
 // Test moving used helper function and its transitively used static variables.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class2" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS2-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS2-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class2" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS2-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS2-CPP %s
 
 // CHECK-NEW-CLASS2-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS2-CPP-SAME: {{[[:space:]]}}
@@ -67,10 +67,10 @@
 // ----------------------------------------------------------------------------
 // Test using a static member variable of a helper class.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class3" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS3-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS3-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class3" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS3-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS3-CPP %s
 
 // CHECK-NEW-CLASS3-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS3-CPP-SAME: {{[[:space:]]}}
@@ -99,10 +99,10 @@
 // ----------------------------------------------------------------------------
 // Test moving helper classes.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class4" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS4-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS4-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class4" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS4-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS4-CPP %s
 
 // CHECK-NEW-CLASS4-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS4-CPP-SAME: {{[[:space:]]}}
@@ -120,10 +120,10 @@
 // ----------------------------------------------------------------------------
 // Test moving helper variables and helper functions together.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class5" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS5-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS5-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class5" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS5-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS5-CPP %s
 
 // CHECK-NEW-CLASS5-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS5-CPP-SAME: {{[[:space:]]}}
@@ -153,10 +153,10 @@
 // ----------------------------------------------------------------------------
 // Test moving helper variables and their transitively used helper classes.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class6" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS6-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS6-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class6" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS6-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS6-CPP %s
 
 // CHECK-NEW-CLASS6-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS6-CPP-SAME: {{[[:space:]]}}
@@ -186,10 +186,10 @@
 // ----------------------------------------------------------------------------
 // Test moving classes where its methods use helpers.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class7" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS7-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS7-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class7" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CLASS7-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-CLASS7-CPP %s
 
 // CHECK-NEW-CLASS7-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-CLASS7-CPP-SAME: {{[[:space:]]}}
@@ -218,10 +218,10 @@
 // ----------------------------------------------------------------------------
 // Test moving helper function and its transitively used helper variables.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Fun1" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-FUN1-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-FUN1-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Fun1" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-FUN1-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-FUN1-CPP %s
 
 // CHECK-NEW-FUN1-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-FUN1-CPP-SAME: {{[[:space:]]}}
@@ -244,11 +244,11 @@
 // ----------------------------------------------------------------------------
 // Test no moving helpers when moving inline functions in header.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Fun2" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-FUN2-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.h -check-prefix=CHECK-NEW-FUN2-H %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.h -check-prefix=CHECK-OLD-FUN2-H %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Fun2" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-FUN2-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.h -check-prefix=CHECK-NEW-FUN2-H %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.h -check-prefix=CHECK-OLD-FUN2-H %s
 
 // CHECK-NEW-FUN2-H: namespace a {
 // CHECK-NEW-FUN2-H-NEXT: inline void Fun2() {}
@@ -262,10 +262,10 @@
 // ----------------------------------------------------------------------------
 // Test moving used helper function and its transitively used functions.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="b::Fun3" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-FUN3-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-FUN3-CPP %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="b::Fun3" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-FUN3-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -check-prefix=CHECK-OLD-FUN3-CPP %s
 
 // CHECK-NEW-FUN3-CPP: #include "{{.*}}new_helper_decls_test.h"
 // CHECK-NEW-FUN3-CPP-SAME: {{[[:space:]]}}
@@ -294,12 +294,12 @@
 // ----------------------------------------------------------------------------
 // Test moving all symbols in headers.
 // ----------------------------------------------------------------------------
-// RUN: cp %S/Inputs/helper_decls_test*  %T/used-helper-decls/
-// RUN: clang-move -names="a::Class1, a::Class2, a::Class3, a::Class4, a::Class5, a::Class5, a::Class6, a::Class7, a::Fun1, a::Fun2, b::Fun3" -new_cc=%T/used-helper-decls/new_helper_decls_test.cpp -new_header=%T/used-helper-decls/new_helper_decls_test.h -old_cc=%T/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %T/used-helper-decls/helper_decls_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.h -check-prefix=CHECK-NEW-H %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CPP %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
-// RUN: FileCheck -input-file=%T/used-helper-decls/helper_decls_test.cpp -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: cp %S/Inputs/helper_decls_test*  %t.dir/used-helper-decls/
+// RUN: clang-move -names="a::Class1, a::Class2, a::Class3, a::Class4, a::Class5, a::Class5, a::Class6, a::Class7, a::Fun1, a::Fun2, b::Fun3" -new_cc=%t.dir/used-helper-decls/new_helper_decls_test.cpp -new_header=%t.dir/used-helper-decls/new_helper_decls_test.h -old_cc=%t.dir/used-helper-decls/helper_decls_test.cpp -old_header=../used-helper-decls/helper_decls_test.h %t.dir/used-helper-decls/helper_decls_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.h -check-prefix=CHECK-NEW-H %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/new_helper_decls_test.cpp -check-prefix=CHECK-NEW-CPP %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%t.dir/used-helper-decls/helper_decls_test.cpp -allow-empty -check-prefix=CHECK-EMPTY %s
 
 
 // CHECK-NEW-H: namespace a {

--- a/clang-tools-extra/test/clang-move/move-var.cpp
+++ b/clang-tools-extra/test/clang-move/move-var.cpp
@@ -1,11 +1,11 @@
-// RUN: mkdir -p %T/move-var
-// RUN: cp %S/Inputs/var_test*  %T/move-var
-// RUN: cd %T/move-var
-// RUN: clang-move -names="a::kGlobalInt" -new_header=%T/move-var/new_var_test.h -old_header=../move-var/var_test.h -old_cc=../move-var/var_test.cpp -new_cc=%T/move-var/new_var_test.cpp %T/move-var/var_test.cpp --
-// RUN: FileCheck -input-file=%T/move-var/var_test.h -check-prefix=CHECK-OLD-VAR-H-CASE1 %s
-// RUN: FileCheck -input-file=%T/move-var/var_test.cpp -check-prefix=CHECK-OLD-VAR-CPP-CASE1 %s
-// RUN: FileCheck -input-file=%T/move-var/new_var_test.h -check-prefix=CHECK-NEW-VAR-H-CASE1 %s
-// RUN: FileCheck -input-file=%T/move-var/new_var_test.cpp -check-prefix=CHECK-NEW-VAR-CPP-CASE1 %s
+// RUN: mkdir -p %t.dir/move-var
+// RUN: cp %S/Inputs/var_test*  %t.dir/move-var
+// RUN: cd %t.dir/move-var
+// RUN: clang-move -names="a::kGlobalInt" -new_header=%t.dir/move-var/new_var_test.h -old_header=../move-var/var_test.h -old_cc=../move-var/var_test.cpp -new_cc=%t.dir/move-var/new_var_test.cpp %t.dir/move-var/var_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-var/var_test.h -check-prefix=CHECK-OLD-VAR-H-CASE1 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/var_test.cpp -check-prefix=CHECK-OLD-VAR-CPP-CASE1 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/new_var_test.h -check-prefix=CHECK-NEW-VAR-H-CASE1 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/new_var_test.cpp -check-prefix=CHECK-NEW-VAR-CPP-CASE1 %s
 
 // CHECK-OLD-VAR-H-CASE1-NOT: extern int kGlobalInt;
 // CHECK-OLD-VAR-H-CASE1: int kGlobalInt = 3;
@@ -18,12 +18,12 @@
 // CHECK-NEW-VAR-CPP-CASE1: int kGlobalInt = 1;
 
 
-// RUN: cp %S/Inputs/var_test*  %T/move-var
-// RUN: clang-move -names="a::kGlobalStr" -new_header=%T/move-var/new_var_test.h -old_header=../move-var/var_test.h -old_cc=../move-var/var_test.cpp -new_cc=%T/move-var/new_var_test.cpp %T/move-var/var_test.cpp --
-// RUN: FileCheck -input-file=%T/move-var/var_test.h -check-prefix=CHECK-OLD-VAR-H-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-var/var_test.cpp -check-prefix=CHECK-OLD-VAR-CPP-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-var/new_var_test.h -check-prefix=CHECK-NEW-VAR-H-CASE2 %s
-// RUN: FileCheck -input-file=%T/move-var/new_var_test.cpp -check-prefix=CHECK-NEW-VAR-CPP-CASE2 %s
+// RUN: cp %S/Inputs/var_test*  %t.dir/move-var
+// RUN: clang-move -names="a::kGlobalStr" -new_header=%t.dir/move-var/new_var_test.h -old_header=../move-var/var_test.h -old_cc=../move-var/var_test.cpp -new_cc=%t.dir/move-var/new_var_test.cpp %t.dir/move-var/var_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-var/var_test.h -check-prefix=CHECK-OLD-VAR-H-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/var_test.cpp -check-prefix=CHECK-OLD-VAR-CPP-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/new_var_test.h -check-prefix=CHECK-NEW-VAR-H-CASE2 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/new_var_test.cpp -check-prefix=CHECK-NEW-VAR-CPP-CASE2 %s
 
 // CHECK-OLD-VAR-H-CASE2-NOT: extern const char *const kGlobalStr;
 // CHECK-OLD-VAR-H-CASE2: const char *const kGlobalStr = "Hello2";
@@ -36,10 +36,10 @@
 // CHECK-NEW-VAR-CPP-CASE2: const char *const kGlobalStr = "Hello";
 
 
-// RUN: cp %S/Inputs/var_test*  %T/move-var
-// RUN: clang-move -names="kEvilInt" -new_header=%T/move-var/new_var_test.h -old_header=../move-var/var_test.h -old_cc=../move-var/var_test.cpp -new_cc=%T/move-var/new_var_test.cpp %T/move-var/var_test.cpp --
-// RUN: FileCheck -input-file=%T/move-var/var_test.h -check-prefix=CHECK-OLD-VAR-H-CASE3 %s
-// RUN: FileCheck -input-file=%T/move-var/new_var_test.h -check-prefix=CHECK-NEW-VAR-H-CASE3 %s
+// RUN: cp %S/Inputs/var_test*  %t.dir/move-var
+// RUN: clang-move -names="kEvilInt" -new_header=%t.dir/move-var/new_var_test.h -old_header=../move-var/var_test.h -old_cc=../move-var/var_test.cpp -new_cc=%t.dir/move-var/new_var_test.cpp %t.dir/move-var/var_test.cpp --
+// RUN: FileCheck -input-file=%t.dir/move-var/var_test.h -check-prefix=CHECK-OLD-VAR-H-CASE3 %s
+// RUN: FileCheck -input-file=%t.dir/move-var/new_var_test.h -check-prefix=CHECK-NEW-VAR-H-CASE3 %s
 
 // CHECK-OLD-VAR-H-CASE3-NOT: int kEvilInt = 2;
 

--- a/clang-tools-extra/test/clang-move/no-move-macro-helpers.cpp
+++ b/clang-tools-extra/test/clang-move/no-move-macro-helpers.cpp
@@ -1,16 +1,16 @@
-// RUN: mkdir -p %T/no-move-macro-helper
-// RUN: cat %S/Inputs/macro_helper_test.h > %T/no-move-macro-helper/macro_helper_test.h
-// RUN: cat %S/Inputs/macro_helper_test.cpp > %T/no-move-macro-helper/macro_helper_test.cpp
-// RUN: cd %T/no-move-macro-helper
+// RUN: mkdir -p %t.dir/no-move-macro-helper
+// RUN: cat %S/Inputs/macro_helper_test.h > %t.dir/no-move-macro-helper/macro_helper_test.h
+// RUN: cat %S/Inputs/macro_helper_test.cpp > %t.dir/no-move-macro-helper/macro_helper_test.cpp
+// RUN: cd %t.dir/no-move-macro-helper
 //
 // -----------------------------------------------------------------------------
 // Test no moving helpers in macro.
 // -----------------------------------------------------------------------------
-// RUN: clang-move -names="A" -new_cc=%T/no-move-macro-helper/new_test.cpp -new_header=%T/no-move-macro-helper/new_test.h -old_cc=%T/no-move-macro-helper/macro_helper_test.cpp -old_header=%T/no-move-macro-helper/macro_helper_test.h %T/no-move-macro-helper/macro_helper_test.cpp -- -std=c++11
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/new_test.h -check-prefix=CHECK-NEW-TEST-CASE1-H %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/new_test.cpp -check-prefix=CHECK-NEW-TEST-CASE1-CPP %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.h -check-prefix=CHECK-OLD-TEST-CASE1-H %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.cpp -check-prefix=CHECK-OLD-TEST-CASE1-CPP %s
+// RUN: clang-move -names="A" -new_cc=%t.dir/no-move-macro-helper/new_test.cpp -new_header=%t.dir/no-move-macro-helper/new_test.h -old_cc=%t.dir/no-move-macro-helper/macro_helper_test.cpp -old_header=%t.dir/no-move-macro-helper/macro_helper_test.h %t.dir/no-move-macro-helper/macro_helper_test.cpp -- -std=c++11
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/new_test.h -check-prefix=CHECK-NEW-TEST-CASE1-H %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/new_test.cpp -check-prefix=CHECK-NEW-TEST-CASE1-CPP %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/macro_helper_test.h -check-prefix=CHECK-OLD-TEST-CASE1-H %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/macro_helper_test.cpp -check-prefix=CHECK-OLD-TEST-CASE1-CPP %s
 
 // CHECK-NEW-TEST-CASE1-H: class A {};
 
@@ -24,14 +24,14 @@
 // -----------------------------------------------------------------------------
 // Test moving all.
 // -----------------------------------------------------------------------------
-// RUN: cat %S/Inputs/macro_helper_test.h > %T/no-move-macro-helper/macro_helper_test.h
-// RUN: cat %S/Inputs/macro_helper_test.cpp > %T/no-move-macro-helper/macro_helper_test.cpp
-// RUN: clang-move -names="A, f1" -new_cc=%T/no-move-macro-helper/new_test.cpp -new_header=%T/no-move-macro-helper/new_test.h -old_cc=%T/no-move-macro-helper/macro_helper_test.cpp -old_header=%T/no-move-macro-helper/macro_helper_test.h %T/no-move-macro-helper/macro_helper_test.cpp -- -std=c++11
+// RUN: cat %S/Inputs/macro_helper_test.h > %t.dir/no-move-macro-helper/macro_helper_test.h
+// RUN: cat %S/Inputs/macro_helper_test.cpp > %t.dir/no-move-macro-helper/macro_helper_test.cpp
+// RUN: clang-move -names="A, f1" -new_cc=%t.dir/no-move-macro-helper/new_test.cpp -new_header=%t.dir/no-move-macro-helper/new_test.h -old_cc=%t.dir/no-move-macro-helper/macro_helper_test.cpp -old_header=%t.dir/no-move-macro-helper/macro_helper_test.h %t.dir/no-move-macro-helper/macro_helper_test.cpp -- -std=c++11
 //
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/new_test.h -check-prefix=CHECK-NEW-TEST-CASE2-H %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/new_test.cpp -check-prefix=CHECK-NEW-TEST-CASE2-CPP %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
-// RUN: FileCheck -input-file=%T/no-move-macro-helper/macro_helper_test.cpp -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/new_test.h -check-prefix=CHECK-NEW-TEST-CASE2-H %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/new_test.cpp -check-prefix=CHECK-NEW-TEST-CASE2-CPP %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/macro_helper_test.h -allow-empty -check-prefix=CHECK-EMPTY %s
+// RUN: FileCheck -input-file=%t.dir/no-move-macro-helper/macro_helper_test.cpp -allow-empty -check-prefix=CHECK-EMPTY %s
 
 // CHECK-NEW-TEST-CASE2-H: class A {};
 // CHECK-NEW-TEST-CASE2-H-NEXT:void f1();

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/header-include-cycle.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/header-include-cycle.cpp
@@ -1,15 +1,15 @@
-// RUN: rm -rf %T/misc-header-include-cycle-headers
-// RUN: mkdir %T/misc-header-include-cycle-headers
-// RUN: cp -r %S/Inputs/header-include-cycle* %T/misc-header-include-cycle-headers/
-// RUN: mkdir %T/misc-header-include-cycle-headers/system
-// RUN: cp -r %S/Inputs/system/header-include-cycle* %T/misc-header-include-cycle-headers/system
-// RUN: cp %s %T/header-include-cycle.cpp
-// RUN: clang-tidy %T%{fs-sep}header-include-cycle.cpp -checks='-*,misc-header-include-cycle' -header-filter=.* \
+// RUN: rm -rf %t.dir/misc-header-include-cycle-headers
+// RUN: mkdir -p %t.dir/misc-header-include-cycle-headers
+// RUN: cp -r %S/Inputs/header-include-cycle* %t.dir/misc-header-include-cycle-headers/
+// RUN: mkdir %t.dir/misc-header-include-cycle-headers/system
+// RUN: cp -r %S/Inputs/system/header-include-cycle* %t.dir/misc-header-include-cycle-headers/system
+// RUN: cp %s %t.dir/header-include-cycle.cpp
+// RUN: clang-tidy %t.dir%{fs-sep}header-include-cycle.cpp -checks='-*,misc-header-include-cycle' -header-filter=.* \
 // RUN: -config="{CheckOptions: {misc-header-include-cycle.IgnoredFilesList: 'header-include-cycle.self-e.hpp'}}" \
-// RUN: -- -I%T%{fs-sep}misc-header-include-cycle-headers -isystem %T%{fs-sep}misc-header-include-cycle-headers%{fs-sep}system \
-// RUN: --include %T%{fs-sep}misc-header-include-cycle-headers%{fs-sep}header-include-cycle.self-i.hpp | FileCheck %s \
+// RUN: -- -I%t.dir%{fs-sep}misc-header-include-cycle-headers -isystem %t.dir%{fs-sep}misc-header-include-cycle-headers%{fs-sep}system \
+// RUN: --include %t.dir%{fs-sep}misc-header-include-cycle-headers%{fs-sep}header-include-cycle.self-i.hpp | FileCheck %s \
 // RUN: -check-prefix=CHECK-MESSAGES "-implicit-check-not={{note|warning|error}}:" --dump-input=fail
-// RUN: rm -rf %T/misc-header-include-cycle-headers
+// RUN: rm -rf %t.dir/misc-header-include-cycle-headers
 
 #ifndef MAIN_GUARD
 #define MAIN_GUARD

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -1,7 +1,7 @@
 // RUN: mkdir -p %t.dir
 // RUN: echo "static void staticFunctionHeader(int i) {;}" > %t.dir/header.h
 // RUN: echo "static void staticFunctionHeader(int  /*i*/) {;}" > %t.dir/header-fixed.h
-// RUN: %check_clang_tidy  --match-partial-fixes -std=c++11 %s misc-unused-parameters %t.dir/code -- -header-filter='.*' -- -fno-delayed-template-parsing > /tmp/test6
+// RUN: %check_clang_tidy  --match-partial-fixes -std=c++11 %s misc-unused-parameters %t.dir/code -- -header-filter='.*' -- -fno-delayed-template-parsing
 // RUN: diff %t.dir/header.h %t.dir/header-fixed.h
 // FIXME: Make the test work in all language modes.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc/unused-parameters.cpp
@@ -1,11 +1,11 @@
-// RUN: echo "static void staticFunctionHeader(int i) {;}" > %T/header.h
-// RUN: echo "static void staticFunctionHeader(int  /*i*/) {;}" > %T/header-fixed.h
-// RUN: %check_clang_tidy  --match-partial-fixes -std=c++11 %s misc-unused-parameters %t -- -header-filter='.*' -- -fno-delayed-template-parsing
-// RUN: diff %T/header.h %T/header-fixed.h
+// RUN: mkdir -p %t.dir
+// RUN: echo "static void staticFunctionHeader(int i) {;}" > %t.dir/header.h
+// RUN: echo "static void staticFunctionHeader(int  /*i*/) {;}" > %t.dir/header-fixed.h
+// RUN: %check_clang_tidy  --match-partial-fixes -std=c++11 %s misc-unused-parameters %t.dir/code -- -header-filter='.*' -- -fno-delayed-template-parsing > /tmp/test6
+// RUN: diff %t.dir/header.h %t.dir/header-fixed.h
 // FIXME: Make the test work in all language modes.
 
 #include "header.h"
-// CHECK-MESSAGES: header.h:1:38: warning
 
 // Basic removal
 // =============
@@ -306,3 +306,5 @@ void test() {
 // Do not warn on naked functions.
 [[gnu::naked]] int nakedFunction(int a, float b, const char *c) { ; }
 __attribute__((naked)) void nakedFunction(int a, int b) { ; }
+
+// CHECK-MESSAGES: header.h:1:38: warning

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/concat-nested-namespaces.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/concat-nested-namespaces.cpp
@@ -1,10 +1,11 @@
-// RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %T/modernize-concat-nested-namespaces.h
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++17 -check-suffix=NORMAL %s modernize-concat-nested-namespaces %t -- -header-filter=".*" -- -I %T
-// RUN: FileCheck -input-file=%T/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
+// RUN: mkdir -p %t.dir
+// RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %t.dir/modernize-concat-nested-namespaces.h
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++17 -check-suffix=NORMAL %s modernize-concat-nested-namespaces %t.dir/code -- -header-filter=".*" -- -I %t.dir
+// RUN: FileCheck -input-file=%t.dir/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
 // Restore header file and re-run with c++20:
-// RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %T/modernize-concat-nested-namespaces.h
-// RUN: %check_clang_tidy --match-partial-fixes -std=c++20 -check-suffixes=NORMAL,CPP20 %s modernize-concat-nested-namespaces %t -- -header-filter=".*" -- -I %T
-// RUN: FileCheck -input-file=%T/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
+// RUN: cp %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h %t.dir/modernize-concat-nested-namespaces.h
+// RUN: %check_clang_tidy --match-partial-fixes -std=c++20 -check-suffixes=NORMAL,CPP20 %s modernize-concat-nested-namespaces %t.dir/code -- -header-filter=".*" -- -I %t.dir
+// RUN: FileCheck -input-file=%t.dir/modernize-concat-nested-namespaces.h %S/Inputs/concat-nested-namespaces/modernize-concat-nested-namespaces.h -check-prefix=CHECK-FIXES
 
 #include "modernize-concat-nested-namespaces.h"
 // CHECK-MESSAGES-NORMAL-DAG: modernize-concat-nested-namespaces.h:1:1: warning: nested namespaces can be concatenated [modernize-concat-nested-namespaces]

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-header.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-header.cpp
@@ -1,6 +1,7 @@
-// RUN: cp %S/Inputs/pass-by-value/header.h %T/pass-by-value-header.h
-// RUN: clang-tidy %s -checks='-*,modernize-pass-by-value' -header-filter='.*' -fix -- -std=c++11 -I %T | FileCheck %s -check-prefix=CHECK-MESSAGES -implicit-check-not="{{warning|error}}:"
-// RUN: FileCheck -input-file=%T/pass-by-value-header.h %s -check-prefix=CHECK-FIXES
+// RUN: mkdir -p %t.dir
+// RUN: cp %S/Inputs/pass-by-value/header.h %t.dir/pass-by-value-header.h
+// RUN: clang-tidy %s -checks='-*,modernize-pass-by-value' -header-filter='.*' -fix -- -std=c++11 -I %t.dir | FileCheck %s -check-prefix=CHECK-MESSAGES -implicit-check-not="{{warning|error}}:"
+// RUN: FileCheck -input-file=%t.dir/pass-by-value-header.h %s -check-prefix=CHECK-FIXES
 // FIXME: Make the test work in all language modes.
 
 #include "pass-by-value-header.h"

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-multi-fixes.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/pass-by-value-multi-fixes.cpp
@@ -1,12 +1,13 @@
-// RUN: cat %S/Inputs/pass-by-value/header-with-fix.h > %T/pass-by-value-header-with-fix.h
-// RUN: sed -e 's#//.*$##' %s > %t.cpp
-// RUN: clang-tidy %t.cpp -checks='-*,modernize-pass-by-value' -header-filter='.*' -fix -- -std=c++11 -I %T | FileCheck %s -check-prefix=CHECK-MESSAGES -implicit-check-not="{{warning|error}}:"
-// RUN: FileCheck -input-file=%t.cpp %s -check-prefix=CHECK-FIXES
-// RUN: FileCheck -input-file=%T/pass-by-value-header-with-fix.h %s -check-prefix=CHECK-HEADER-FIXES
+// RUN: mkdir -p %t.dir
+// RUN: cat %S/Inputs/pass-by-value/header-with-fix.h > %t.dir/pass-by-value-header-with-fix.h
+// RUN: sed -e 's#//.*$##' %s > %t.dir/code.cpp
+// RUN: clang-tidy %t.dir/code.cpp -checks='-*,modernize-pass-by-value' -header-filter='.*' -fix -- -std=c++11 -I %t.dir | FileCheck %s -check-prefix=CHECK-MESSAGES -implicit-check-not="{{warning|error}}:"
+// RUN: FileCheck -input-file=%t.dir/code.cpp %s -check-prefix=CHECK-FIXES
+// RUN: FileCheck -input-file=%t.dir/pass-by-value-header-with-fix.h %s -check-prefix=CHECK-HEADER-FIXES
 
 #include "pass-by-value-header-with-fix.h"
 // CHECK-HEADER-FIXES: Foo(S s);
 Foo::Foo(const S &s) : s(s) {}
-// CHECK-MESSAGES: :9:10: warning: pass by value and use std::move [modernize-pass-by-value]
+// CHECK-MESSAGES: :10:10: warning: pass by value and use std::move [modernize-pass-by-value]
 // CHECK-FIXES: #include <utility>
 // CHECK-FIXES: Foo::Foo(S s) : s(std::move(s)) {}

--- a/clang-tools-extra/test/clang-tidy/checkers/portability/restrict-system-includes-transitive.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/portability/restrict-system-includes-transitive.cpp
@@ -1,12 +1,12 @@
-// RUN: rm -rf %T/Headers
-// RUN: mkdir %T/Headers
-// RUN: cp -r %S/Inputs/restrict-system-includes %T/Headers/portability-restrict-system-includes
+// RUN: rm -rf %t.dir/Headers
+// RUN: mkdir -p %t.dir/Headers
+// RUN: cp -r %S/Inputs/restrict-system-includes %t.dir/Headers/portability-restrict-system-includes
 // RUN: %check_clang_tidy -std=c++11 %s portability-restrict-system-includes %t \
 // RUN:   -- -config="{CheckOptions: {portability-restrict-system-includes.Includes: 'transitive.h,s.h'}}" \
 // RUN:   -system-headers -header-filter=.* \
-// RUN:   -- -I %T/Headers/portability-restrict-system-includes -isystem %T/Headers/portability-restrict-system-includes/system
-// RUN: FileCheck -input-file=%T/Headers/portability-restrict-system-includes/transitive2.h %s -check-prefix=CHECK-FIXES
-// RUN: rm -rf %T/Headers
+// RUN:   -- -I %t.dir/Headers/portability-restrict-system-includes -isystem %t.dir/Headers/portability-restrict-system-includes/system
+// RUN: FileCheck -input-file=%t.dir/Headers/portability-restrict-system-includes/transitive2.h %s -check-prefix=CHECK-FIXES
+// RUN: rm -rf %t.dir/Headers
 // FIXME: Make the test work in all language modes.
 
 // transitive.h includes <r.h> and <t.h>

--- a/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-symlink.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/readability/identifier-naming-symlink.cpp
@@ -2,11 +2,12 @@
 // in the header file so it fails if runs multiple times with different
 // `-std` flags as check_clang_tidy doesn by default.
 //
-// RUN: rm -rf %T/symlink
-// RUN: cp -r %S/Inputs/identifier-naming/symlink %T/symlink
-// RUN: mkdir -p %T/symlink/build
-// RUN: ln -s %T/symlink/include/test.h %T/symlink/build/test.h
-// RUN: %check_clang_tidy -std=c++20 %s readability-identifier-naming %t -- --header-filter="test.h" --config-file=%S/Inputs/identifier-naming/symlink/include/.clang-tidy -- -I %T/symlink/build
+// RUN: rm -rf %t.dir
+// RUN: mkdir -p %t.dir
+// RUN: cp -r %S/Inputs/identifier-naming/symlink %t.dir/symlink
+// RUN: mkdir -p %t.dir/symlink/build
+// RUN: ln -s %t.dir/symlink/include/test.h %t.dir/symlink/build/test.h
+// RUN: %check_clang_tidy -std=c++20 %s readability-identifier-naming %t.dir -- --header-filter="test.h" --config-file=%S/Inputs/identifier-naming/symlink/include/.clang-tidy -- -I %t.dir/symlink/build
 // UNSUPPORTED: system-windows
 
 #include "test.h"

--- a/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-diff.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-diff.cpp
@@ -3,9 +3,9 @@
 // RUN: clang-tidy -checks=-*,modernize-use-override %t.cpp -- -std=c++11 | FileCheck -check-prefix=CHECK-SANITY %s
 // RUN: not diff -U0 %s %t.cpp | %clang_tidy_diff -checks=-*,modernize-use-override -- -std=c++11 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-JMAX
 // RUN: not diff -U0 %s %t.cpp | %clang_tidy_diff -checks=-*,modernize-use-override -quiet -- -std=c++11 2>&1 | FileCheck -check-prefix=CHECK-QUIET %s
-// RUN: mkdir -p %T/compilation-database-test/
-// RUN: echo '[{"directory": "%T", "command": "clang++ -o test.o -std=c++11 %t.cpp", "file": "%t.cpp"}]' > %T/compilation-database-test/compile_commands.json
-// RUN: not diff -U0 %s %t.cpp | %clang_tidy_diff -checks=-*,modernize-use-override -path %T/compilation-database-test 2>&1 | FileCheck -check-prefix=CHECK %s
+// RUN: mkdir -p %t.dir/compilation-database-test/
+// RUN: echo '[{"directory": "%t.dir", "command": "clang++ -o test.o -std=c++11 %t.cpp", "file": "%t.cpp"}]' > %t.dir/compilation-database-test/compile_commands.json
+// RUN: not diff -U0 %s %t.cpp | %clang_tidy_diff -checks=-*,modernize-use-override -path %t.dir/compilation-database-test 2>&1 | FileCheck -check-prefix=CHECK %s
 
 // RUN: not diff -U0 %s %t.cpp | %clang_tidy_diff -checks=-*,modernize-use-override -j 1 -- -std=c++11 2>&1 | FileCheck %s --check-prefix=CHECK-J1
 // CHECK-J1: Running clang-tidy in 1 threads...

--- a/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-run-with-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-run-with-database.cpp
@@ -1,28 +1,28 @@
-// RUN: mkdir -p %T/compilation-database-test/include
-// RUN: mkdir -p %T/compilation-database-test/a
-// RUN: mkdir -p %T/compilation-database-test/b
-// RUN: echo 'int *AA = 0;' > %T/compilation-database-test/a/a.cpp
-// RUN: echo 'int *AB = 0;' > %T/compilation-database-test/a/b.cpp
-// RUN: echo 'int *BB = 0;' > %T/compilation-database-test/b/b.cpp
-// RUN: echo 'int *BC = 0;' > %T/compilation-database-test/b/c.cpp
-// RUN: echo 'int *BD = 0;' > %T/compilation-database-test/b/d.cpp
-// RUN: echo 'int *HP = 0;' > %T/compilation-database-test/include/header.h
-// RUN: echo '#include "header.h"' > %T/compilation-database-test/include.cpp
-// RUN: sed 's|test_dir|%/T/compilation-database-test|g' %S/Inputs/compilation-database/template.json > %T/compile_commands.json
+// RUN: mkdir -p %t.dir/compilation-database-test/include
+// RUN: mkdir -p %t.dir/compilation-database-test/a
+// RUN: mkdir -p %t.dir/compilation-database-test/b
+// RUN: echo 'int *AA = 0;' > %t.dir/compilation-database-test/a/a.cpp
+// RUN: echo 'int *AB = 0;' > %t.dir/compilation-database-test/a/b.cpp
+// RUN: echo 'int *BB = 0;' > %t.dir/compilation-database-test/b/b.cpp
+// RUN: echo 'int *BC = 0;' > %t.dir/compilation-database-test/b/c.cpp
+// RUN: echo 'int *BD = 0;' > %t.dir/compilation-database-test/b/d.cpp
+// RUN: echo 'int *HP = 0;' > %t.dir/compilation-database-test/include/header.h
+// RUN: echo '#include "header.h"' > %t.dir/compilation-database-test/include.cpp
+// RUN: sed 's|test_dir|%/t.dir/compilation-database-test|g' %S/Inputs/compilation-database/template.json > %t.dir/compile_commands.json
 
 // Regression test: shouldn't crash.
-// RUN: not clang-tidy --checks=-*,modernize-use-nullptr -p %T %T/compilation-database-test/b/not-exist -header-filter=.* 2>&1 | FileCheck %s -check-prefix=CHECK-NOT-EXIST
+// RUN: not clang-tidy --checks=-*,modernize-use-nullptr -p %t.dir %t.dir/compilation-database-test/b/not-exist -header-filter=.* 2>&1 | FileCheck %s -check-prefix=CHECK-NOT-EXIST
 // CHECK-NOT-EXIST: Error while processing {{.*[/\\]}}not-exist.
 // CHECK-NOT-EXIST: unable to handle compilation
 // CHECK-NOT-EXIST: Found compiler error
 
-// RUN: clang-tidy --checks=-*,modernize-use-nullptr -p %T %T/compilation-database-test/a/a.cpp %T/compilation-database-test/a/b.cpp %T/compilation-database-test/b/b.cpp %T/compilation-database-test/b/c.cpp %T/compilation-database-test/b/d.cpp %T/compilation-database-test/include.cpp -header-filter=.* -fix
-// RUN: FileCheck -input-file=%T/compilation-database-test/a/a.cpp %s -check-prefix=CHECK-FIX1
-// RUN: FileCheck -input-file=%T/compilation-database-test/a/b.cpp %s -check-prefix=CHECK-FIX2
-// RUN: FileCheck -input-file=%T/compilation-database-test/b/b.cpp %s -check-prefix=CHECK-FIX3
-// RUN: FileCheck -input-file=%T/compilation-database-test/b/c.cpp %s -check-prefix=CHECK-FIX4
-// RUN: FileCheck -input-file=%T/compilation-database-test/b/d.cpp %s -check-prefix=CHECK-FIX5
-// RUN: FileCheck -input-file=%T/compilation-database-test/include/header.h %s -check-prefix=CHECK-FIX6
+// RUN: clang-tidy --checks=-*,modernize-use-nullptr -p %t.dir %t.dir/compilation-database-test/a/a.cpp %t.dir/compilation-database-test/a/b.cpp %t.dir/compilation-database-test/b/b.cpp %t.dir/compilation-database-test/b/c.cpp %t.dir/compilation-database-test/b/d.cpp %t.dir/compilation-database-test/include.cpp -header-filter=.* -fix
+// RUN: FileCheck -input-file=%t.dir/compilation-database-test/a/a.cpp %s -check-prefix=CHECK-FIX1
+// RUN: FileCheck -input-file=%t.dir/compilation-database-test/a/b.cpp %s -check-prefix=CHECK-FIX2
+// RUN: FileCheck -input-file=%t.dir/compilation-database-test/b/b.cpp %s -check-prefix=CHECK-FIX3
+// RUN: FileCheck -input-file=%t.dir/compilation-database-test/b/c.cpp %s -check-prefix=CHECK-FIX4
+// RUN: FileCheck -input-file=%t.dir/compilation-database-test/b/d.cpp %s -check-prefix=CHECK-FIX5
+// RUN: FileCheck -input-file=%t.dir/compilation-database-test/include/header.h %s -check-prefix=CHECK-FIX6
 
 // CHECK-FIX1: int *AA = nullptr;
 // CHECK-FIX2: int *AB = nullptr;

--- a/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-store-check-profile-one-tu.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/clang-tidy-store-check-profile-one-tu.cpp
@@ -1,9 +1,9 @@
-// RUN: rm -rf %T/out
-// RUN: clang-tidy -enable-check-profile -checks='-*,readability-function-size' -store-check-profile=%T/out %s -- 2>&1 | not FileCheck --match-full-lines -implicit-check-not='{{warning:|error:}}' -check-prefix=CHECK-CONSOLE %s
-// RUN: cat %T/out/*-clang-tidy-store-check-profile-one-tu.cpp.json | FileCheck --match-full-lines -implicit-check-not='{{warning:|error:}}' -check-prefix=CHECK-FILE %s
-// RUN: rm -rf %T/out
-// RUN: clang-tidy -enable-check-profile -checks='-*,readability-function-size' -store-check-profile=%T/out %s -- 2>&1
-// RUN: cat %T/out/*-clang-tidy-store-check-profile-one-tu.cpp.json | FileCheck --match-full-lines -implicit-check-not='{{warning:|error:}}' -check-prefix=CHECK-FILE %s
+// RUN: rm -rf %t.dir/out
+// RUN: clang-tidy -enable-check-profile -checks='-*,readability-function-size' -store-check-profile=%t.dir/out %s -- 2>&1 | not FileCheck --match-full-lines -implicit-check-not='{{warning:|error:}}' -check-prefix=CHECK-CONSOLE %s
+// RUN: cat %t.dir/out/*-clang-tidy-store-check-profile-one-tu.cpp.json | FileCheck --match-full-lines -implicit-check-not='{{warning:|error:}}' -check-prefix=CHECK-FILE %s
+// RUN: rm -rf %t.dir/out
+// RUN: clang-tidy -enable-check-profile -checks='-*,readability-function-size' -store-check-profile=%t.dir/out %s -- 2>&1
+// RUN: cat %t.dir/out/*-clang-tidy-store-check-profile-one-tu.cpp.json | FileCheck --match-full-lines -implicit-check-not='{{warning:|error:}}' -check-prefix=CHECK-FILE %s
 
 // CHECK-CONSOLE-NOT: ===-------------------------------------------------------------------------===
 // CHECK-CONSOLE-NOT: {{.*}}  --- Name ---

--- a/clang-tools-extra/test/clang-tidy/infrastructure/diagnostic.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/diagnostic.cpp
@@ -14,15 +14,15 @@
 // Now create a directory with a compilation database file and ensure we don't
 // use it after failing to parse commands from the command line:
 //
-// RUN: mkdir -p %T/diagnostics/
-// RUN: echo '[{"directory": "%/T/diagnostics/","command": "clang++ -fan-option-from-compilation-database -c %/T/diagnostics/input.cpp", "file": "%/T/diagnostics/input.cpp"}]' > %T/diagnostics/compile_commands.json
-// RUN: cat %s > %T/diagnostics/input.cpp
-// RUN: not clang-tidy -checks='-*,modernize-use-override' %T/diagnostics/nonexistent.cpp -- 2>&1 | FileCheck -check-prefix=CHECK1 -implicit-check-not='{{warning:|error:}}' %s
-// RUN: not clang-tidy -checks='-*,clang-diagnostic-*,google-explicit-constructor' %T/diagnostics/input.cpp -- -fan-unknown-option 2>&1 | FileCheck -check-prefix=CHECK2 -implicit-check-not='{{warning:|error:}}' %s
-// RUN: not clang-tidy -checks='-*,google-explicit-constructor,clang-diagnostic-literal-conversion' %T/diagnostics/input.cpp -- -fan-unknown-option 2>&1 | FileCheck -check-prefix=CHECK3 -implicit-check-not='{{warning:|error:}}' %s
-// RUN: clang-tidy -checks='-*,modernize-use-override,clang-diagnostic-macro-redefined' %T/diagnostics/input.cpp -- -DMACRO_FROM_COMMAND_LINE 2>&1 | FileCheck -check-prefix=CHECK4 -implicit-check-not='{{warning:|error:}}' %s
-// RUN: not clang-tidy -checks='-*,clang-diagnostic-*,google-explicit-constructor' %T/diagnostics/input.cpp 2>&1 | FileCheck -check-prefix=CHECK5 -implicit-check-not='{{warning:|error:}}' %s
-// RUN: not clang-tidy -checks='-*,modernize-use-override' %T/diagnostics/input.cpp -- -DCOMPILATION_ERROR 2>&1 | FileCheck -check-prefix=CHECK6 -implicit-check-not='{{warning:|error:}}' %s
+// RUN: mkdir -p %t.dir/diagnostics/
+// RUN: echo '[{"directory": "%/t.dir/diagnostics/","command": "clang++ -fan-option-from-compilation-database -c %/T/diagnostics/input.cpp", "file": "%/T/diagnostics/input.cpp"}]' > %t.dir/diagnostics/compile_commands.json
+// RUN: cat %s > %t.dir/diagnostics/input.cpp
+// RUN: not clang-tidy -checks='-*,modernize-use-override' %t.dir/diagnostics/nonexistent.cpp -- 2>&1 | FileCheck -check-prefix=CHECK1 -implicit-check-not='{{warning:|error:}}' %s
+// RUN: not clang-tidy -checks='-*,clang-diagnostic-*,google-explicit-constructor' %t.dir/diagnostics/input.cpp -- -fan-unknown-option 2>&1 | FileCheck -check-prefix=CHECK2 -implicit-check-not='{{warning:|error:}}' %s
+// RUN: not clang-tidy -checks='-*,google-explicit-constructor,clang-diagnostic-literal-conversion' %t.dir/diagnostics/input.cpp -- -fan-unknown-option 2>&1 | FileCheck -check-prefix=CHECK3 -implicit-check-not='{{warning:|error:}}' %s
+// RUN: clang-tidy -checks='-*,modernize-use-override,clang-diagnostic-macro-redefined' %t.dir/diagnostics/input.cpp -- -DMACRO_FROM_COMMAND_LINE 2>&1 | FileCheck -check-prefix=CHECK4 -implicit-check-not='{{warning:|error:}}' %s
+// RUN: not clang-tidy -checks='-*,clang-diagnostic-*,google-explicit-constructor' %t.dir/diagnostics/input.cpp 2>&1 | FileCheck -check-prefix=CHECK5 -implicit-check-not='{{warning:|error:}}' %s
+// RUN: not clang-tidy -checks='-*,modernize-use-override' %t.dir/diagnostics/input.cpp -- -DCOMPILATION_ERROR 2>&1 | FileCheck -check-prefix=CHECK6 -implicit-check-not='{{warning:|error:}}' %s
 // RUN: clang-tidy -checks='-*,modernize-use-override,clang-diagnostic-macro-redefined' %s -- -DMACRO_FROM_COMMAND_LINE -std=c++20 | FileCheck -check-prefix=CHECK4 -implicit-check-not='{{warning:|error:}}' %s
 // RUN: clang-tidy -checks='-*,modernize-use-override,clang-diagnostic-macro-redefined,clang-diagnostic-literal-conversion' %s -- -DMACRO_FROM_COMMAND_LINE -std=c++20 -Wno-macro-redefined | FileCheck --check-prefix=CHECK7 -implicit-check-not='{{warning:|error:}}' %s
 // RUN: clang-tidy -checks='-*,modernize-use-override' %s -- -std=c++20 -DPR64602

--- a/clang-tools-extra/test/clang-tidy/infrastructure/export-relpath.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/export-relpath.cpp
@@ -1,14 +1,15 @@
-// RUN: rm -rf %T/clang-tidy/export-relpath
-// RUN: mkdir -p %T/clang-tidy/export-relpath/subdir
-// RUN: cp %s %T/clang-tidy/export-relpath/subdir/source.cpp
-// RUN: echo '[{ "directory": "%/T/clang-tidy/export-relpath/subdir", "command": "clang++ source.cpp", "file": "%/T/clang-tidy/export-relpath/subdir/source.cpp"}]' > %T/clang-tidy/export-relpath/subdir/compile_commands.json
+// RUN: mkdir -p %t.dir
+// RUN: rm -rf %t.dir/clang-tidy/export-relpath
+// RUN: mkdir -p %t.dir/clang-tidy/export-relpath/subdir
+// RUN: cp %s %t.dir/clang-tidy/export-relpath/subdir/source.cpp
+// RUN: echo '[{ "directory": "%/t.dir/clang-tidy/export-relpath/subdir", "command": "clang++ source.cpp", "file": "%/T/clang-tidy/export-relpath/subdir/source.cpp"}]' > %t.dir/clang-tidy/export-relpath/subdir/compile_commands.json
 //
 // Check that running clang-tidy in './subdir' and storing results
 // in './fixes.yaml' works as expected.
 //
-// RUN: cd %T/clang-tidy/export-relpath
+// RUN: cd %t.dir/clang-tidy/export-relpath
 // RUN: clang-tidy -p subdir subdir/source.cpp -checks='-*,google-explicit-constructor,llvm-namespace-comment' -export-fixes=./fixes.yaml
-// RUN: FileCheck -input-file=%T/clang-tidy/export-relpath/fixes.yaml -check-prefix=CHECK-YAML %s
+// RUN: FileCheck -input-file=%t.dir/clang-tidy/export-relpath/fixes.yaml -check-prefix=CHECK-YAML %s
 
 namespace i {
 void f(); // So that the namespace isn't empty.

--- a/clang-tools-extra/test/clang-tidy/infrastructure/list-checks.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/list-checks.cpp
@@ -1,4 +1,4 @@
-// RUN: mkdir -p %T/clang-tidy/list-checks/
-// RUN: echo '{Checks: "-*,google-*"}' > %T/clang-tidy/.clang-tidy
-// RUN: cd %T/clang-tidy/list-checks
+// RUN: mkdir -p %t.dir/clang-tidy/list-checks/
+// RUN: echo '{Checks: "-*,google-*"}' > %t.dir/clang-tidy/.clang-tidy
+// RUN: cd %t.dir/clang-tidy/list-checks
 // RUN: clang-tidy -list-checks | grep "^ *google-"

--- a/clang-tools-extra/test/clang-tidy/infrastructure/read_file_config.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/read_file_config.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: static-analyzer
-// RUN: mkdir -p %T/read-file-config/
-// RUN: cp %s %T/read-file-config/test.cpp
-// RUN: echo 'Checks: "-*,modernize-use-nullptr"' > %T/read-file-config/.clang-tidy
-// RUN: echo '[{"command": "cc -c -o test.o test.cpp", "directory": "%/T/read-file-config", "file": "%/T/read-file-config/test.cpp"}]' > %T/read-file-config/compile_commands.json
-// RUN: clang-tidy %T/read-file-config/test.cpp | not grep "warning: .*\[clang-analyzer-deadcode.DeadStores\]$"
-// RUN: clang-tidy -checks="-*,clang-analyzer-*" %T/read-file-config/test.cpp | grep "warning: .*\[clang-analyzer-deadcode.DeadStores\]$"
+// RUN: mkdir -p %t.dir/read-file-config/
+// RUN: cp %s %t.dir/read-file-config/test.cpp
+// RUN: echo 'Checks: "-*,modernize-use-nullptr"' > %t.dir/read-file-config/.clang-tidy
+// RUN: echo '[{"command": "cc -c -o test.o test.cpp", "directory": "%/t.dir/read-file-config", "file": "%/t.dir/read-file-config/test.cpp"}]' > %t.dir/read-file-config/compile_commands.json
+// RUN: clang-tidy %t.dir/read-file-config/test.cpp | not grep "warning: .*\[clang-analyzer-deadcode.DeadStores\]$"
+// RUN: clang-tidy -checks="-*,clang-analyzer-*" %t.dir/read-file-config/test.cpp | grep "warning: .*\[clang-analyzer-deadcode.DeadStores\]$"
 
 void f() {
   int x;

--- a/clang-tools-extra/test/clang-tidy/infrastructure/verify-config.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/verify-config.cpp
@@ -19,22 +19,22 @@
 // CHECK-VERIFY: command-line option '-checks': warning: unknown check 'llvm-includeorder'; did you mean 'llvm-include-order' [-verify-config]
 // CHECK-VERIFY: command-line option '-checks': warning: unknown check 'my-made-up-check' [-verify-config]
 
-// RUN: echo -e 'Checks: |\n bugprone-argument-comment\n bugprone-assert-side-effect,\n bugprone-bool-pointer-implicit-conversion\n readability-use-anyof*' > %T/MyClangTidyConfig
+// RUN: echo -e 'Checks: |\n bugprone-argument-comment\n bugprone-assert-side-effect,\n bugprone-bool-pointer-implicit-conversion\n readability-use-anyof*' > %t.MyClangTidyConfig
 // RUN: clang-tidy -verify-config \
-// RUN: --config-file=%T/MyClangTidyConfig | FileCheck %s -check-prefix=CHECK-VERIFY-BLOCK-OK
+// RUN: --config-file=%t.MyClangTidyConfig | FileCheck %s -check-prefix=CHECK-VERIFY-BLOCK-OK
 // CHECK-VERIFY-BLOCK-OK: No config errors detected.
 
-// RUN: echo -e 'Checks: |\n bugprone-arguments-*\n bugprone-assert-side-effects\n bugprone-bool-pointer-implicit-conversion' > %T/MyClangTidyConfigBad
+// RUN: echo -e 'Checks: |\n bugprone-arguments-*\n bugprone-assert-side-effects\n bugprone-bool-pointer-implicit-conversion' > %t.MyClangTidyConfigBad
 // RUN: not clang-tidy -verify-config \
-// RUN: --config-file=%T/MyClangTidyConfigBad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-BLOCK-BAD
+// RUN: --config-file=%t.MyClangTidyConfigBad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-BLOCK-BAD
 // CHECK-VERIFY-BLOCK-BAD: command-line option '-config': warning: check glob 'bugprone-arguments-*' doesn't match any known check [-verify-config]
 // CHECK-VERIFY-BLOCK-BAD: command-line option '-config': warning: unknown check 'bugprone-assert-side-effects'; did you mean 'bugprone-assert-side-effect' [-verify-config]
 
-// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic: true' > %T/MyClangTidyConfigCSA
-// RUN: clang-tidy --verify-config --config-file=%T/MyClangTidyConfigCSA 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-OK -implicit-check-not='{{warnings|error}}'
+// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic: true' > %t.MyClangTidyConfigCSA
+// RUN: clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSA 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-OK -implicit-check-not='{{warnings|error}}'
 // CHECK-VERIFY-CSA-OK: No config errors detected.
 
-// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic: true' > %T/MyClangTidyConfigCSABad
-// RUN: not clang-tidy --verify-config --config-file=%T/MyClangTidyConfigCSABad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-BAD -implicit-check-not='{{warnings|error}}'
+// RUN: echo -e 'Checks: "-*,clang-analyzer-optin.cplusplus.UninitializedObject"\nCheckOptions:\n clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic: true' > %t.MyClangTidyConfigCSABad
+// RUN: not clang-tidy --verify-config --config-file=%t.MyClangTidyConfigCSABad 2>&1 | FileCheck %s -check-prefix=CHECK-VERIFY-CSA-BAD -implicit-check-not='{{warnings|error}}'
 // CHECK-VERIFY-CSA-BAD: command-line option '-config': warning: unknown check option 'clang-analyzer-optin.cplusplus.UninitializedObject.Pedantic'; did you mean 'clang-analyzer-optin.cplusplus.UninitializedObject:Pedantic' [-verify-config]
 

--- a/clang-tools-extra/test/modularize/NoProblemsAssistant.modularize
+++ b/clang-tools-extra/test/modularize/NoProblemsAssistant.modularize
@@ -1,5 +1,7 @@
+# RUN: mkdir -p %t.dir/Output
+# RUN: cd %t.dir
 # RUN: modularize -module-map-path=Output/NoProblemsAssistant.txt -root-module=Root -prefix=%S/Input %s
-# RUN: FileCheck --input-file=%T/NoProblemsAssistant.txt %s
+# RUN: FileCheck --input-file=Output/NoProblemsAssistant.txt %s
 
 SomeTypes.h
 SomeDecls.h


### PR DESCRIPTION
%T has been deprecated for about seven years since it is not unique to each test and can thus lead to races. This patch removes uses of %T from clang-tools-extra with the eventual goal of removing support for %T from lit.