### PR TITLE
[bazel] Port #145358: LIBC_THREAD_MODE

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
@@ -46,4 +46,7 @@ LIBC_CONFIGURE_OPTIONS = [
 
     # Documentation in libc/src/__support/libc_assert.h
     # "LIBC_COPT_USE_C_ASSERT",
+
+    # Documentation in libc/docs/configure.rst
+    "LIBC_THREAD_MODE=LIBC_THREAD_MODE_PLATFORM",
 ]


### PR DESCRIPTION
I'm not sure how libc should be configuring this in bazel, but for now it seems like `LIBC_THREAD_MODE_PLATFORM` restores the default behavior.

Defining this param is required:
```
ERROR: /var/lib/buildkite-agent/.cache/bazel/_bazel_buildkite-agent/c9d34ded3a9d94cc250207948aceadfc/external/llvm-project/libc/BUILD.bazel:5788:14: Compiling libc/src/stdio/generic/vprintf.cpp failed: (Exit 1): clang failed: error executing CppCompile command (from target @@llvm-project//libc:vprintf) /usr/lib/llvm-18/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer ... (remaining 31 arguments skipped)
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from external/llvm-project/libc/src/stdio/generic/vprintf.cpp:11:
In file included from external/llvm-project/libc/src/__support/File/file.h:19:
external/llvm-project/libc/src/__support/threads/mutex.h:25:2: error: LIBC_THREAD_MODE is undefined
   25 | #error LIBC_THREAD_MODE is undefined
      |  ^
```

As an alternative to this PR, we could make the libc header default to `LIBC_THREAD_MODE_PLATFORM` if not provided, instead of an `#error`