### PR TITLE
[ARM] getOppositeCondition should match AArch64 (NFC)

### DIFF
--- a/llvm/lib/Target/ARM/Utils/ARMBaseInfo.h
+++ b/llvm/lib/Target/ARM/Utils/ARMBaseInfo.h
@@ -46,23 +46,9 @@ enum CondCodes { // Meaning (integer)          Meaning (floating-point)
 };
 
 inline static CondCodes getOppositeCondition(CondCodes CC) {
-  switch (CC) {
-  default: llvm_unreachable("Unknown condition code");
-  case EQ: return NE;
-  case NE: return EQ;
-  case HS: return LO;
-  case LO: return HS;
-  case MI: return PL;
-  case PL: return MI;
-  case VS: return VC;
-  case VC: return VS;
-  case HI: return LS;
-  case LS: return HI;
-  case GE: return LT;
-  case LT: return GE;
-  case GT: return LE;
-  case LE: return GT;
-  }
+  // To reverse a condition it's necessary to only invert the low bit:
+
+  return static_cast<CondCodes>(static_cast<unsigned>(CC) ^ 0x1);
 }
 
 /// getSwappedCondition - assume the flags are set by MI(a,b), return


### PR DESCRIPTION
This also means we don't need a jump table very time we find the opposite condition.