### PR TITLE
[LLVM][IR] Fix a couple of StringRef OOB error in AsmParser

### DIFF
--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -94,6 +94,7 @@ namespace llvm {
     lltok::Kind LexToken();
 
     int getNextChar();
+    bool isLabelTail();
     void SkipLineComment();
     bool SkipCComment();
     lltok::Kind ReadString(lltok::Kind kind);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -6917,7 +6917,8 @@ bool LLParser::parseFunctionBody(Function &Fn, unsigned FunctionNumber,
                                  ArrayRef<unsigned> UnnamedArgNums) {
   if (Lex.getKind() != lltok::lbrace)
     return tokError("expected '{' in function body");
-  Lex.Lex();  // eat the {.
+  if (Lex.Lex() == lltok::Error) // eat the {.
+    return tokError("Invalid token");
 
   PerFunctionState PFS(*this, Fn, FunctionNumber, UnnamedArgNums);
 

--- a/llvm/lib/AsmParser/Parser.cpp
+++ b/llvm/lib/AsmParser/Parser.cpp
@@ -26,7 +26,8 @@ static bool parseAssemblyInto(MemoryBufferRef F, Module *M,
                               SlotMapping *Slots, bool UpgradeDebugInfo,
                               DataLayoutCallbackTy DataLayoutCallback) {
   SourceMgr SM;
-  std::unique_ptr<MemoryBuffer> Buf = MemoryBuffer::getMemBuffer(F);
+  std::unique_ptr<MemoryBuffer> Buf =
+      MemoryBuffer::getMemBuffer(F, /*RequiresNullTerminator*/ false);
   SM.AddNewSourceBuffer(std::move(Buf), SMLoc());
 
   std::optional<LLVMContext> OptContext;


### PR DESCRIPTION
- Fix LLLexer::getNextChar() to not index OOB into the CurBuf.
- Change `isLabelTail` and `SkipLineComment` to not increment `CurPtr` directly but rely on `getNextChar` so that they don't access the input StringRef OOB.
- Add unit tests that exercise these cases using a heap allocated StringRef. They show asan failures.