### PR TITLE
[CIR] Add diagnostic for NYI AST visitor handlers

### DIFF
--- a/clang/include/clang/CIR/CIRGenerator.h
+++ b/clang/include/clang/CIR/CIRGenerator.h
@@ -79,7 +79,10 @@ public:
   void HandleTranslationUnit(clang::ASTContext &astContext) override;
   void HandleInlineFunctionDefinition(clang::FunctionDecl *d) override;
   void HandleTagDeclDefinition(clang::TagDecl *d) override;
+  void HandleTagDeclRequiredDefinition(const clang::TagDecl *D) override;
+  void HandleCXXStaticMemberVarInstantiation(clang::VarDecl *D) override;
   void CompleteTentativeDefinition(clang::VarDecl *d) override;
+  void HandleVTable(clang::CXXRecordDecl *rd) override;
 
   mlir::ModuleOp getModule() const;
   mlir::MLIRContext &getMLIRContext() { return *mlirContext; };

--- a/clang/lib/CIR/CodeGen/CIRGenerator.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenerator.cpp
@@ -152,9 +152,30 @@ void CIRGenerator::HandleTagDeclDefinition(TagDecl *d) {
     cgm->errorNYI(d->getSourceRange(), "HandleTagDeclDefinition: OpenMP");
 }
 
+void CIRGenerator::HandleTagDeclRequiredDefinition(const TagDecl *D) {
+  if (diags.hasErrorOccurred())
+    return;
+
+  assert(!cir::MissingFeatures::generateDebugInfo());
+}
+
+void CIRGenerator::HandleCXXStaticMemberVarInstantiation(VarDecl *D) {
+  if (diags.hasErrorOccurred())
+    return;
+
+  cgm->errorNYI(D->getSourceRange(), "HandleCXXStaticMemberVarInstantiation");
+}
+
 void CIRGenerator::CompleteTentativeDefinition(VarDecl *d) {
   if (diags.hasErrorOccurred())
     return;
 
   cgm->emitTentativeDefinition(d);
+}
+
+void CIRGenerator::HandleVTable(CXXRecordDecl *rd) {
+  if (diags.hasErrorOccurred())
+    return;
+
+  cgm->errorNYI(rd->getSourceRange(), "HandleVTable");
 }

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -84,6 +84,10 @@ public:
     return true;
   }
 
+  void HandleCXXStaticMemberVarInstantiation(clang::VarDecl *VD) override {
+    Gen->HandleCXXStaticMemberVarInstantiation(VD);
+  }
+
   void HandleInlineFunctionDefinition(FunctionDecl *D) override {
     Gen->HandleInlineFunctionDefinition(D);
   }
@@ -147,9 +151,15 @@ public:
     Gen->HandleTagDeclDefinition(D);
   }
 
+  void HandleTagDeclRequiredDefinition(const TagDecl *D) override {
+    Gen->HandleTagDeclRequiredDefinition(D);
+  }
+
   void CompleteTentativeDefinition(VarDecl *D) override {
     Gen->CompleteTentativeDefinition(D);
   }
+
+  void HandleVTable(CXXRecordDecl *RD) override { Gen->HandleVTable(RD); }
 };
 } // namespace cir
 


### PR DESCRIPTION
A couple of handlers that were missing from the CIRGenerator AST visitor allowed important features to be silently ignored during CIR generation. This change adds these handlers with diagnostics to report that they are not yet handled (except in the case where only debug information is missed).