### PR TITLE
[CGData] Fix assertions when skipping name

### DIFF
--- a/llvm/lib/CGData/StableFunctionMapRecord.cpp
+++ b/llvm/lib/CGData/StableFunctionMapRecord.cpp
@@ -162,12 +162,18 @@ void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr,
         endian::readNext<stable_hash, endianness::little, unaligned>(Ptr);
     auto FunctionNameId =
         endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    assert(FunctionMap->getNameForId(FunctionNameId) &&
-           "FunctionNameId out of range");
+    (void)FunctionNameId;
     auto ModuleNameId =
         endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    assert(FunctionMap->getNameForId(ModuleNameId) &&
-           "ModuleNameId out of range");
+    (void)ModuleNameId;
+    // Only validate IDs if we've read the names
+    if (ReadStableFunctionMapNames) {
+      assert(FunctionMap->getNameForId(FunctionNameId) &&
+             "FunctionNameId out of range");
+      assert(FunctionMap->getNameForId(ModuleNameId) &&
+             "ModuleNameId out of range");
+    }
+
     auto InstCount =
         endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
 

--- a/llvm/lib/CGData/StableFunctionMapRecord.cpp
+++ b/llvm/lib/CGData/StableFunctionMapRecord.cpp
@@ -160,12 +160,10 @@ void StableFunctionMapRecord::deserialize(const unsigned char *&Ptr,
   for (unsigned I = 0; I < NumFuncs; ++I) {
     auto Hash =
         endian::readNext<stable_hash, endianness::little, unaligned>(Ptr);
-    auto FunctionNameId =
+    [[maybe_unused]] auto FunctionNameId =
         endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    (void)FunctionNameId;
-    auto ModuleNameId =
+    [[maybe_unused]] auto ModuleNameId =
         endian::readNext<uint32_t, endianness::little, unaligned>(Ptr);
-    (void)ModuleNameId;
     // Only validate IDs if we've read the names
     if (ReadStableFunctionMapNames) {
       assert(FunctionMap->getNameForId(FunctionNameId) &&

--- a/llvm/test/ThinLTO/AArch64/cgdata-merge-read.ll
+++ b/llvm/test/ThinLTO/AArch64/cgdata-merge-read.ll
@@ -1,5 +1,3 @@
-; REQUIRES: asserts
-
 ; This test demonstrates how similar functions are handled during global outlining.
 ; Currently, we do not attempt to share an merged function for identical sequences.
 ; Instead, each merging instance is created uniquely.

--- a/llvm/test/ThinLTO/AArch64/cgdata-merge-read.ll
+++ b/llvm/test/ThinLTO/AArch64/cgdata-merge-read.ll
@@ -1,3 +1,5 @@
+; REQUIRES: asserts
+
 ; This test demonstrates how similar functions are handled during global outlining.
 ; Currently, we do not attempt to share an merged function for identical sequences.
 ; Instead, each merging instance is created uniquely.
@@ -19,6 +21,20 @@
 ; Now run with -codegen-data-use-path=%tout.cgdata to optimize the binary.
 ; Each module has its own merging instance as it is matched against the merged cgdata.
 ; RUN: llvm-lto2 run -enable-global-merge-func=true \
+; RUN:    -codegen-data-use-path=%tout.cgdata \
+; RUN:    %t-foo.bc %t-goo.bc -o %tout-read \
+; RUN:    -r %t-foo.bc,_f1,px \
+; RUN:    -r %t-goo.bc,_f2,px \
+; RUN:    -r %t-foo.bc,_g,l -r %t-foo.bc,_g1,l -r %t-foo.bc,_g2,l \
+; RUN:    -r %t-goo.bc,_g,l -r %t-goo.bc,_g1,l -r %t-goo.bc,_g2,l
+; RUN: llvm-nm %tout-read.1 | FileCheck %s --check-prefix=READ1
+; RUN: llvm-nm %tout-read.2 | FileCheck %s --check-prefix=READ2
+; RUN: llvm-objdump -d %tout-read.1 | FileCheck %s --check-prefix=THUNK1
+; RUN: llvm-objdump -d %tout-read.2 | FileCheck %s --check-prefix=THUNK2
+
+; It runs the same if we use -indexed-codegen-data-read-function-map-names=false.
+; RUN: llvm-lto2 run -enable-global-merge-func=true \
+; RUN:    -indexed-codegen-data-read-function-map-names=false \
 ; RUN:    -codegen-data-use-path=%tout.cgdata \
 ; RUN:    %t-foo.bc %t-goo.bc -o %tout-read \
 ; RUN:    -r %t-foo.bc,_f1,px \


### PR DESCRIPTION
This fixes assertion failures when using `-indexed-codegen-data-read-function-map-names=false`