### PR TITLE
Avoid unnecessary erasing of constant Locs

### DIFF
--- a/mlir/lib/Transforms/Utils/FoldUtils.cpp
+++ b/mlir/lib/Transforms/Utils/FoldUtils.cpp
@@ -154,11 +154,14 @@ bool OperationFolder::insertKnownConstant(Operation *op, Attribute constValue) {
   // already at the front of the block, or the previous operation is already a
   // constant we unique'd (i.e. one we inserted), then we don't need to do
   // anything. Otherwise, we move the constant to the insertion block.
+  // The location info is erased if the constant is moved to a different block.
   Block *insertBlock = &insertRegion->front();
-  if (opBlock != insertBlock || (&insertBlock->front() != op &&
-                                 !isFolderOwnedConstant(op->getPrevNode()))) {
+  if (opBlock != insertBlock) {
     op->moveBefore(&insertBlock->front());
     op->setLoc(erasedFoldedLocation);
+  } else if (&insertBlock->front() != op &&
+             !isFolderOwnedConstant(op->getPrevNode())) {
+    op->moveBefore(&insertBlock->front());
   }
 
   folderConstOp = op;

--- a/mlir/test/Transforms/canonicalize-debuginfo.mlir
+++ b/mlir/test/Transforms/canonicalize-debuginfo.mlir
@@ -15,7 +15,7 @@ func.func @merge_constants() -> (index, index, index, index) {
 
 // CHECK-LABEL: func @simple_hoist
 func.func @simple_hoist(%arg0: memref<8xi32>) -> i32 {
-  // CHECK: arith.constant 88 : i32 loc(#[[UnknownLoc:.*]])
+  // CHECK: arith.constant 88 : i32 loc(#[[ConstLoc2:.*]])
   // CHECK: arith.constant 42 : i32 loc(#[[ConstLoc0:.*]])
   // CHECK: arith.constant 0 : index loc(#[[ConstLoc1:.*]])
   %0 = arith.constant 42 : i32 loc("simple_hoist":0:0)
@@ -26,9 +26,9 @@ func.func @simple_hoist(%arg0: memref<8xi32>) -> i32 {
 
   return %2 : i32
 }
-// CHECK-DAG: #[[UnknownLoc]] = loc(unknown)
 // CHECK-DAG: #[[ConstLoc0]] = loc("simple_hoist":0:0)
 // CHECK-DAG: #[[ConstLoc1]] = loc("simple_hoist":1:0)
+// CHECK-DAG: #[[ConstLoc2]] = loc("simple_hoist":2:0)
 
 // -----
 


### PR DESCRIPTION
Do not erase location info when moving an op within the same block.

Since  #75415 , the FoldUtils.cpp erases the location information when moving an operation. This was being done even when an operation was moved to the front of a block it was already in.

In TFLite, this location information is used to provide meaningful names for tensors, which aids in debugging and mapping compiled tensors back to their original layers. The aggressive erasure of location info caused many tensors in TFLite models to receive generic names (e.g., tfl.pseudo_qconst), making the models harder to inspect.

This change modifies the logic to preserve the location of an operation when it is moved within the same block. The location is now only erased when the operation is moved from a different block entirely. This ensures that most tensor names are preserved, improving the debugging experience for TFLite models.
