### PR TITLE
[AMDGPU] Regenerate checks in the CodeGen/AMDGPU/fptrunc.f16.ll. NFC.

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/fptrunc.f16.ll
+++ b/llvm/test/CodeGen/AMDGPU/fptrunc.f16.ll
@@ -1499,60 +1499,13 @@ define amdgpu_kernel void @fptrunc_f64_to_f16_afn(
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s8, s2
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s9, s3
-; GFX1250-SDAG-FAKE16-NEXT:    buffer_load_b64 v[0:1], off, s[8:11], null
-; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s2, v1
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s3, s2, 0x1ff
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s5, s2, 8
-; GFX1250-SDAG-FAKE16-NEXT:    v_or_b32_e32 v0, s3, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_bfe_u32 s3, s2, 0xb0014
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s5, s5, 0xffe
-; GFX1250-SDAG-FAKE16-NEXT:    s_sub_co_i32 s4, 0x3f1, s3
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX1250-SDAG-FAKE16-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v0
-; GFX1250-SDAG-FAKE16-NEXT:    v_med3_i32 v1, s4, 0, 13
-; GFX1250-SDAG-FAKE16-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s8, v1
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s4, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s4, s5, s4
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s5, s4, 0x1000
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s9, s5, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshl_b32 s8, s9, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lg_u32 s8, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s5, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_addk_co_i32 s3, 0xfc10
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s5, s9, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshl_b32 s8, s3, 12
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s8, s4, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lt_i32 s3, 1
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s5, s5, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s8, s5, 7
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_gt_i32 s8, 5
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s9, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s8, 3
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s8, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s5, s5, 2
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s8, s8, s9
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_add_co_i32 s5, s5, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lt_i32 s3, 31
-; GFX1250-SDAG-FAKE16-NEXT:    s_movk_i32 s8, 0x7e00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s5, s5, 0x7c00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lg_u32 s4, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s4, s8, 0x7c00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s3, 0x40f
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s3, s4, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s2, s2, 16
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s4, s0
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s2, s2, 0x8000
+; GFX1250-SDAG-FAKE16-NEXT:    buffer_load_b64 v[0:1], off, s[8:11], null
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s5, s1
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s2, s2, s3
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_f32_f64_e32 v0, v[0:1]
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_f16_f32_e32 v0, v0
 ; GFX1250-SDAG-FAKE16-NEXT:    buffer_store_b16 v0, off, s[4:7], null
 ; GFX1250-SDAG-FAKE16-NEXT:    s_endpgm
 ;
@@ -3538,109 +3491,14 @@ define amdgpu_kernel void @fptrunc_v2f64_to_v2f16_afn(
 ; GFX1250-SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s8, s2
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s9, s3
-; GFX1250-SDAG-FAKE16-NEXT:    buffer_load_b128 v[0:3], off, s[8:11], null
-; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s2, v3
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s3, s2, 0x1ff
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s5, s2, 8
-; GFX1250-SDAG-FAKE16-NEXT:    v_or_b32_e32 v2, s3, v2
-; GFX1250-SDAG-FAKE16-NEXT:    s_bfe_u32 s3, s2, 0xb0014
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s5, s5, 0xffe
-; GFX1250-SDAG-FAKE16-NEXT:    s_sub_co_i32 s4, 0x3f1, s3
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(VALU_DEP_2)
-; GFX1250-SDAG-FAKE16-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v2
-; GFX1250-SDAG-FAKE16-NEXT:    v_med3_i32 v3, s4, 0, 13
-; GFX1250-SDAG-FAKE16-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc_lo
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s8, v3
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s4, v2
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s4, s5, s4
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s5, s4, 0x1000
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s9, s5, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshl_b32 s8, s9, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lg_u32 s8, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s5, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_addk_co_i32 s3, 0xfc10
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s5, s9, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshl_b32 s8, s3, 12
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s8, s4, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lt_i32 s3, 1
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s5, s5, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s8, s5, 7
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_gt_i32 s8, 5
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s9, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s8, 3
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s8, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s5, s5, 2
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s8, s8, s9
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_add_co_i32 s5, s5, s8
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lt_i32 s3, 31
-; GFX1250-SDAG-FAKE16-NEXT:    s_movk_i32 s8, 0x7e00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s5, s5, 0x7c00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lg_u32 s4, 0
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s4, v1
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s9, s8, 0x7c00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s3, 0x40f
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s3, s9, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s5, s4, 0x1ff
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s10, s4, 8
-; GFX1250-SDAG-FAKE16-NEXT:    v_or_b32_e32 v0, s5, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_bfe_u32 s5, s4, 0xb0014
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s10, s10, 0xffe
-; GFX1250-SDAG-FAKE16-NEXT:    s_sub_co_i32 s9, 0x3f1, s5
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s2, s2, 16
-; GFX1250-SDAG-FAKE16-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v0
-; GFX1250-SDAG-FAKE16-NEXT:    v_med3_i32 v1, s9, 0, 13
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s2, s2, 0x8000
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_2)
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s2, s2, s3
-; GFX1250-SDAG-FAKE16-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc_lo
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s11, v1
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_readfirstlane_b32 s9, v0
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s9, s10, s9
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s10, s9, 0x1000
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s12, s10, s11
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshl_b32 s11, s12, s11
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lg_u32 s11, s10
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s3, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_addk_co_i32 s5, 0xfc10
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s3, s12, s3
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshl_b32 s10, s5, 12
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s10, s9, s10
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lt_i32 s5, 1
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s3, s3, s10
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s10, s3, 7
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_gt_i32 s10, 5
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s11, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s10, 3
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s10, 1, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s3, s3, 2
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s10, s10, s11
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_add_co_i32 s3, s3, s10
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lt_i32 s5, 31
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s3, s3, 0x7c00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_lg_u32 s9, 0
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s8, s8, 0x7c00
-; GFX1250-SDAG-FAKE16-NEXT:    s_cmp_eq_u32 s5, 0x40f
-; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s5, s1
-; GFX1250-SDAG-FAKE16-NEXT:    s_cselect_b32 s3, s8, s3
-; GFX1250-SDAG-FAKE16-NEXT:    s_lshr_b32 s4, s4, 16
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    s_and_b32 s4, s4, 0x8000
-; GFX1250-SDAG-FAKE16-NEXT:    s_or_b32 s3, s4, s3
 ; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s4, s0
-; GFX1250-SDAG-FAKE16-NEXT:    s_pack_ll_b32_b16 s2, s3, s2
-; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX1250-SDAG-FAKE16-NEXT:    v_mov_b32_e32 v0, s2
+; GFX1250-SDAG-FAKE16-NEXT:    buffer_load_b128 v[0:3], off, s[8:11], null
+; GFX1250-SDAG-FAKE16-NEXT:    s_mov_b32 s5, s1
+; GFX1250-SDAG-FAKE16-NEXT:    s_wait_loadcnt 0x0
+; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_f32_f64_e32 v2, v[2:3]
+; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_f32_f64_e32 v0, v[0:1]
+; GFX1250-SDAG-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX1250-SDAG-FAKE16-NEXT:    v_cvt_pk_f16_f32 v0, v0, v2
 ; GFX1250-SDAG-FAKE16-NEXT:    buffer_store_b32 v0, off, s[4:7], null
 ; GFX1250-SDAG-FAKE16-NEXT:    s_endpgm
 ;


### PR DESCRIPTION
Fixes buildbot break.