### PR TITLE
[Flang] Avoid crash when a function return is undefined

### DIFF
--- a/flang/test/Lower/undef-func-result.f90
+++ b/flang/test/Lower/undef-func-result.f90
@@ -1,0 +1,7 @@
+!RUN: %flang -c %s -### 2>&1
+function s(x) result(i)
+!CHECK-WARNING: Function result is never defined
+integer::x
+procedure():: i
+end function
+end


### PR DESCRIPTION
Properly terminate the StatementContext cleanup when a function return value is undefined.

Fixes #126452