### PR TITLE
Suppress -Wuninitialized-const-pointer warning

### DIFF
--- a/llvm/unittests/Frontend/HLSLBindingTest.cpp
+++ b/llvm/unittests/Frontend/HLSLBindingTest.cpp
@@ -155,8 +155,10 @@ TEST(HLSLBindingTest, TestExactOverlap) {
 
   // Since the bindings overlap exactly we need sigil values to differentiate
   // them.
-  char ID1;
-  char ID2;
+  // Note: We initialize these to 0 to suppress a -Wuninitialized-const-pointer,
+  // but we really are just using the stack addresses here.
+  char ID1 = 0;
+  char ID2 = 0;
 
   // StructuredBuffer<float> A  : register(t5);
   // StructuredBuffer<float> B  : register(t5);


### PR DESCRIPTION
Recent clang (as of #148337) introduced a warning on passing unitialized pointers to functions that take const pointers. This is entirely spurious on this code, but this works around it to keep the bots happy.

Build failure: https://lab.llvm.org/buildbot/#/builders/168/builds/14779