### PR TITLE
[HIP] Fix compression arguments being passed to linker wrapper

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3014,12 +3014,12 @@ void tools::addOffloadCompressArgs(const llvm::opt::ArgList &TCArgs,
                                    llvm::opt::ArgStringList &CmdArgs) {
   if (TCArgs.hasFlag(options::OPT_offload_compress,
                      options::OPT_no_offload_compress, false))
-    CmdArgs.push_back("-compress");
+    CmdArgs.push_back("--compress");
   if (TCArgs.hasArg(options::OPT_v))
-    CmdArgs.push_back("-verbose");
+    CmdArgs.push_back("--verbose");
   if (auto *Arg = TCArgs.getLastArg(options::OPT_offload_compression_level_EQ))
     CmdArgs.push_back(
-        TCArgs.MakeArgString(Twine("-compression-level=") + Arg->getValue()));
+        TCArgs.MakeArgString(Twine("--compression-level=") + Arg->getValue()));
 }
 
 void tools::addMCModel(const Driver &D, const llvm::opt::ArgList &Args,

--- a/clang/test/Driver/hip-offload-compress-zlib.hip
+++ b/clang/test/Driver/hip-offload-compress-zlib.hip
@@ -14,7 +14,7 @@
 
 // CHECK: clang-offload-bundler{{.*}} -type=bc
 // CHECK-SAME: -targets={{.*}}hip-amdgcn-amd-amdhsa-unknown-gfx1100,hip-amdgcn-amd-amdhsa-unknown-gfx1101
-// CHECK-SAME: -compress -verbose -compression-level=9
+// CHECK-SAME: --compress --verbose --compression-level=9
 // CHECK: Compressed bundle format
 
 // Test uncompress of bundled bitcode.
@@ -41,4 +41,4 @@
 
 // CO: clang-offload-bundler{{.*}} "-type=o"
 // CO-SAME: -targets={{.*}}hipv4-amdgcn-amd-amdhsa--gfx1100,hipv4-amdgcn-amd-amdhsa--gfx1101
-// CO-SAME: "-compress" "-verbose"
+// CO-SAME: "--compress" "--verbose"

--- a/clang/test/Driver/hip-offload-compress-zstd.hip
+++ b/clang/test/Driver/hip-offload-compress-zstd.hip
@@ -14,7 +14,7 @@
 
 // CHECK: clang-offload-bundler{{.*}} -type=bc
 // CHECK-SAME: -targets={{.*}}hip-amdgcn-amd-amdhsa-unknown-gfx1100,hip-amdgcn-amd-amdhsa-unknown-gfx1101
-// CHECK-SAME: -compress -verbose -compression-level=9
+// CHECK-SAME: --compress --verbose --compression-level=9
 // CHECK: Compressed bundle format
 
 // Test uncompress of bundled bitcode.
@@ -41,4 +41,16 @@
 
 // CO: clang-offload-bundler{{.*}} "-type=o"
 // CO-SAME: -targets={{.*}}hipv4-amdgcn-amd-amdhsa--gfx1100,hipv4-amdgcn-amd-amdhsa--gfx1101
-// CO-SAME: "-compress" "-verbose"
+// CO-SAME: "--compress" "--verbose"
+
+// RUN: rm -rf %t.bc
+// RUN: %clang -### -v --target=x86_64-linux-gnu \
+// RUN:   -x hip --offload-arch=gfx1100 --offload-arch=gfx1101 \
+// RUN:   --offload-new-driver -fgpu-rdc -nogpuinc -nogpulib \
+// RUN:   %S/Inputs/hip_multiple_inputs/a.cu \
+// RUN:   --offload-compress --offload-compression-level=9 \
+// RUN:   --gpu-bundle-output \
+// RUN:   -o %t.bc \
+// RUN: 2>&1 | FileCheck %s --check-prefix=NEWDRIVER
+
+// NEWDRIVER: clang-linker-wrapper{{.*}}"--compress" "--verbose" "--compression-level=9"


### PR DESCRIPTION
Summary:
The new driver's behavior forwards all unrecognized command line
arguments to the host linker. It only knew `--compress` so when
`-compress` was passed it didn't forward it correctly. This patch
changes the spelling because multi word arguments should have two
dashes.
