### PR TITLE
[lldb] Fix TLS support on Darwin platforms

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -1159,9 +1159,8 @@ DynamicLoaderDarwin::GetThreadLocalData(const lldb::ModuleSP module_sp,
   //  size_t offset;
   // }
   //
-  // The strategy is to take get_addr, call it with the address of the
-  // containing TLS_Thunk structure, and add the offset to the resulting
-  // pointer to get the data block.
+  // The strategy is to take get_addr and call it with the address of the
+  // containing TLS_Thunk structure.
   //
   // On older apple platforms, the key is treated as a pthread_key_t and passed
   // to pthread_getspecific. The pointer returned from that call is added to
@@ -1190,7 +1189,7 @@ DynamicLoaderDarwin::GetThreadLocalData(const lldb::ModuleSP module_sp,
       const addr_t tls_data = evaluate_tls_address(
           thunk_load_addr, llvm::ArrayRef<addr_t>(tls_load_addr));
       if (tls_data != LLDB_INVALID_ADDRESS)
-        return tls_data + tls_offset;
+        return tls_data;
     }
   }
 

--- a/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
+++ b/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
@@ -74,6 +74,11 @@ class TlsGlobalTestCase(TestBase):
             patterns=[r"\(int\) \$.* = 88"],
         )
         self.expect(
+            "expr var_static2",
+            VARIABLES_DISPLAYED_CORRECTLY,
+            patterns=[r"\(int\) \$.* = 66"],
+        )
+        self.expect(
             "expr var_shared",
             VARIABLES_DISPLAYED_CORRECTLY,
             patterns=[r"\(int\) \$.* = 66"],
@@ -103,6 +108,11 @@ class TlsGlobalTestCase(TestBase):
             "expr var_static",
             VARIABLES_DISPLAYED_CORRECTLY,
             patterns=[r"\(int\) \$.* = 44"],
+        )
+        self.expect(
+            "expr var_static2",
+            VARIABLES_DISPLAYED_CORRECTLY,
+            patterns=[r"\(int\) \$.* = 22"],
         )
         self.expect(
             "expr var_shared",

--- a/lldb/test/API/lang/c/tls_globals/main.c
+++ b/lldb/test/API/lang/c/tls_globals/main.c
@@ -15,7 +15,7 @@ __thread int var_static2 = 22;
 void *fn_static(void *param)
 {
 	var_static *= 2;
-  var_static2 *= 3;
+	var_static2 *= 3;
 	shared_check();
 	usleep(1); // thread breakpoint
 	for(;;)

--- a/lldb/test/API/lang/c/tls_globals/main.c
+++ b/lldb/test/API/lang/c/tls_globals/main.c
@@ -10,10 +10,12 @@ touch_shared();
 
 // Create some TLS storage within the static executable.
 __thread int var_static = 44;
+__thread int var_static2 = 22;
 
 void *fn_static(void *param)
 {
 	var_static *= 2;
+  var_static2 *= 3;
 	shared_check();
 	usleep(1); // thread breakpoint
 	for(;;)


### PR DESCRIPTION
When I wrote this previously, I was unaware that the TLS function already adds the offset. The test was working previously because the offset was 0 in this case (only 1 thread-local variable). I added another thread-local variable to the test to make sure the offset is indeed handled correctly.

rdar://156547548