### PR TITLE
[lldb][rpc] Fix build failures when building lldb-rpc-gen

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -323,13 +323,11 @@ else()
     set(LLDB_CAN_USE_DEBUGSERVER OFF)
 endif()
 
-# In a cross-compile build, we need to skip building the generated
-# lldb-rpc sources in the first phase of host build so that they can
-# get built using the just-built Clang toolchain in the second phase.
 if (NOT DEFINED LLDB_CAN_USE_LLDB_RPC_SERVER)
-  set(LLDB_CAN_USE_LLDB_RPC_SERVER OFF)
-else()
-  if ((CMAKE_CROSSCOMPILING OR LLVM_HOST_TRIPLE MATCHES "${LLVM_DEFAULT_TARGET_TRIPLE}") AND
+  # In a cross-compile build, we don't want to try to build a lldb-rpc-gen, as
+  # as that essentially forces rebuilding a whole separate native copy of clang.
+  # Allow the caller to set this variable manually to opt in/out of it.
+  if (NOT CMAKE_CROSSCOMPILING AND
       CMAKE_SYSTEM_NAME MATCHES "AIX|Android|Darwin|FreeBSD|Linux|NetBSD|OpenBSD|Windows")
     set(LLDB_CAN_USE_LLDB_RPC_SERVER ON)
   else()
@@ -337,16 +335,11 @@ else()
   endif()
 endif()
 
-
-if (NOT DEFINED LLDB_BUILD_LLDBRPC)
-  set(LLDB_BUILD_LLDBRPC OFF)
+if (CMAKE_CROSSCOMPILING)
+  set(LLDB_BUILD_LLDBRPC OFF CACHE BOOL "")
+  get_host_tool_path(lldb-rpc-gen LLDB_RPC_GEN_EXE lldb_rpc_gen_exe lldb_rpc_gen_target)
 else()
-  if (CMAKE_CROSSCOMPILING)
-    set(LLDB_BUILD_LLDBRPC OFF CACHE BOOL "")
-    get_host_tool_path(lldb-rpc-gen LLDB_RPC_GEN_EXE lldb_rpc_gen_exe lldb_rpc_gen_target)
-  else()
-    set(LLDB_BUILD_LLDBRPC ON CACHE BOOL "")
-  endif()
+  set(LLDB_BUILD_LLDBRPC ON CACHE BOOL "")
 endif()
 
 include(LLDBGenerateConfig)

--- a/lldb/tools/lldb-rpc-gen/CMakeLists.txt
+++ b/lldb/tools/lldb-rpc-gen/CMakeLists.txt
@@ -17,7 +17,5 @@ add_lldb_tool(lldb-rpc-gen
     LINK_COMPONENTS
       Support
   )
-
-if (NOT DEFINED LLDB_RPC_GEN_EXE)
-  set(LLDB_RPC_GEN_EXE $<TARGET_FILE:lldb-rpc-gen> CACHE STRING "Executable that generates lldb-rpc-server")
-endif()
+add_dependencies(lldb-rpc-gen clang-resource-headers)
+setup_host_tool(lldb-rpc-gen LLDB_RPC_GEN_EXE lldb_rpc_gen_exe lldb_rpc_gen_target)

--- a/lldb/tools/lldb-rpc/LLDBRPCGeneration.cmake
+++ b/lldb/tools/lldb-rpc/LLDBRPCGeneration.cmake
@@ -60,14 +60,14 @@ add_custom_command(OUTPUT ${lldb_rpc_gen_byproducts}
   COMMAND ${CMAKE_COMMAND} -E make_directory
     ${lldb_rpc_server_generated_source_dir}
 
-  COMMAND ${LLDB_RPC_GEN_EXE}
+  COMMAND ${lldb_rpc_gen_exe}
     -p ${CMAKE_BINARY_DIR}
     --output-dir=${lldb_rpc_generated_dir}
     ${sysroot_arg}
     --extra-arg="-USWIG"
     ${api_headers}
 
-  DEPENDS ${LLDB_RPC_GEN_EXE} ${api_headers}
+  DEPENDS ${lldb_rpc_gen_exe} ${api_headers}
   COMMENT "Generating sources for lldb-rpc-server..."
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
On some cross compile builds, the tool is not correctly set and the command that runs the tool has an empty path for the tool, causing the build to fail. We can setup the tool as a build host tool using setup_host_tool.