### PR TITLE
[LLDB] Update DIL handling of array subscripting.

### DIFF
--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -323,7 +323,6 @@ Interpreter::Visit(const MemberOfNode *node) {
       m_expr, errMsg, node->GetLocation(), node->GetFieldName().size());
 }
 
-
 llvm::Expected<lldb::ValueObjectSP>
 Interpreter::Visit(const ArraySubscriptNode *node) {
   auto lhs_or_err = Evaluate(node->GetBase());
@@ -340,27 +339,25 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
   if (base_type.IsPointerType()) {
     child_valobj_sp = base->GetSyntheticArrayMember(child_idx, true);
     if (!child_valobj_sp) {
-      std::string err_msg =
-          llvm::formatv("failed to use pointer as array for index {0} for "
-                        "\"({1}) {2}\"", child_idx,
-                        base->GetTypeName().AsCString("<invalid type>"),
-                        var_expr_path_strm.GetData());
+      std::string err_msg = llvm::formatv(
+          "failed to use pointer as array for index {0} for "
+          "\"({1}) {2}\"",
+          child_idx, base->GetTypeName().AsCString("<invalid type>"),
+          var_expr_path_strm.GetData());
       if (base_type.IsPointerToVoid())
         err_msg = "subscript of pointer to incomplete type 'void'";
       return llvm::make_error<DILDiagnosticError>(m_expr, err_msg,
                                                   node->GetLocation());
     }
-  } else if (base_type.IsArrayType(
-      nullptr, nullptr, &is_incomplete_array)) {
+  } else if (base_type.IsArrayType(nullptr, nullptr, &is_incomplete_array)) {
     child_valobj_sp = base->GetChildAtIndex(child_idx);
     if (!child_valobj_sp && (is_incomplete_array || m_use_synthetic))
       child_valobj_sp = base->GetSyntheticArrayMember(child_idx, true);
     if (!child_valobj_sp) {
-      std::string err_msg =
-          llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
-                        child_idx,
-                        base->GetTypeName().AsCString("<invalid type>"),
-                        var_expr_path_strm.GetData());
+      std::string err_msg = llvm::formatv(
+          "array index {0} is not valid for \"({1}) {2}\"", child_idx,
+          base->GetTypeName().AsCString("<invalid type>"),
+          var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, err_msg,
                                                   node->GetLocation());
     }
@@ -368,11 +365,10 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
     child_valobj_sp =
         base->GetSyntheticBitFieldChild(child_idx, child_idx, true);
     if (!child_valobj_sp) {
-      std::string err_msg =
-          llvm::formatv("bitfield range {0}-{1} is not valid for \"({2}) {3}\"",
-                        child_idx, child_idx,
-                        base->GetTypeName().AsCString("<invalid type>"),
-                        var_expr_path_strm.GetData());
+      std::string err_msg = llvm::formatv(
+          "bitfield range {0}-{1} is not valid for \"({2}) {3}\"", child_idx,
+          child_idx, base->GetTypeName().AsCString("<invalid type>"),
+          var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, err_msg,
                                                   node->GetLocation(), 1);
     }
@@ -386,22 +382,20 @@ Interpreter::Visit(const ArraySubscriptNode *node) {
                                                   node->GetLocation(), 1);
     }
     if (static_cast<uint32_t>(child_idx) >=
-        synthetic->GetNumChildrenIgnoringErrors(child_idx+1)) {
-      std::string err_msg =
-          llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
-                        child_idx,
-                        base->GetTypeName().AsCString("<invalid type>"),
-                        var_expr_path_strm.GetData());
+        synthetic->GetNumChildrenIgnoringErrors(child_idx + 1)) {
+      std::string err_msg = llvm::formatv(
+          "array index {0} is not valid for \"({1}) {2}\"", child_idx,
+          base->GetTypeName().AsCString("<invalid type>"),
+          var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, err_msg,
                                                   node->GetLocation(), 1);
     }
     child_valobj_sp = synthetic->GetChildAtIndex(child_idx);
     if (!child_valobj_sp) {
-      std::string err_msg =
-          llvm::formatv("array index {0} is not valid for \"({1}) {2}\"",
-                        child_idx,
-                        base->GetTypeName().AsCString("<invalid type>"),
-                        var_expr_path_strm.GetData());
+      std::string err_msg = llvm::formatv(
+          "array index {0} is not valid for \"({1}) {2}\"", child_idx,
+          base->GetTypeName().AsCString("<invalid type>"),
+          var_expr_path_strm.GetData());
       return llvm::make_error<DILDiagnosticError>(m_expr, err_msg,
                                                   node->GetLocation(), 1);
     }

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -106,6 +106,8 @@ class TestFrameVarDILArraySubscript(TestBase):
         )
 
         self.runCmd("settings set target.experimental.use-DIL true")
+        self.runCmd("script from myArraySynthProvider import *")
+        self.runCmd("type synth add -l myArraySynthProvider myArray")
 
         # Test synthetic value subscription
         self.expect_var_path("vector[1]", value="2")
@@ -113,4 +115,8 @@ class TestFrameVarDILArraySubscript(TestBase):
             "frame var 'vector[100]'",
             error=True,
             substrs=["array index 100 is not valid"],
+        )
+        self.expect(
+            "frame var 'ma_ptr[0]'",
+            substrs=["(myArray) ma_ptr[0] = ([0] = 7, [1] = 8, [2] = 9, [3] = 10)"],
         )

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -74,7 +74,7 @@ class TestFrameVarDILArraySubscript(TestBase):
         self.expect_var_path("idx_1[0]", value="1")
         self.expect_var_path("idx_1[1]", value="0")
 
-        # Bit acess not valid for a reference.
+        # Bit adcess not valid for a reference.
         self.expect(
             "frame var 'idx_1_ref[0]'",
             error=True,

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -69,7 +69,6 @@ class TestFrameVarDILArraySubscript(TestBase):
             substrs=["expected 'r_square', got: <'.'"],
         )
 
-
         # Test accessing bits in scalar types.
         self.expect_var_path("idx_1[0]", value="1")
         self.expect_var_path("idx_1[1]", value="0")

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/TestFrameVarDILArraySubscript.py
@@ -69,17 +69,19 @@ class TestFrameVarDILArraySubscript(TestBase):
             substrs=["expected 'r_square', got: <'.'"],
         )
 
-        # Base should be a "pointer to T" and index should be of an integral type.
-        self.expect(
-            "frame var 'idx_1[0]'",
-            error=True,
-            substrs=["subscripted value is not an array or pointer"],
-        )
+
+        # Test accessing bits in scalar types.
+        self.expect_var_path("idx_1[0]", value="1")
+        self.expect_var_path("idx_1[1]", value="0")
+
+        # Bit acess not valid for a reference.
         self.expect(
             "frame var 'idx_1_ref[0]'",
             error=True,
-            substrs=["subscripted value is not an array or pointer"],
+            substrs=["bitfield range 0-0 is not valid"],
         )
+
+        # Base should be a "pointer to T" and index should be of an integral type.
         self.expect(
             "frame var 'int_arr[int_ptr]'",
             error=True,

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/main.cpp
@@ -1,5 +1,11 @@
 #include <vector>
 
+class myArray {
+public:
+  int m_array[4] = {7, 8, 9, 10};
+  int m_arr_size = 4;
+};
+
 int main(int argc, char **argv) {
   int int_arr[] = {1, 2, 3};
   int *int_ptr = int_arr;
@@ -28,6 +34,9 @@ int main(int argc, char **argv) {
   Enum &enum_ref = enum_one;
 
   std::vector<int> vector = {1, 2, 3};
+
+  myArray ma;
+  myArray *ma_ptr = &ma;
 
   return 0; // Set a breakpoint here
 }

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
@@ -1,0 +1,32 @@
+import lldb
+
+class myArraySynthProvider:
+  def __init__(self, valobj, dict):
+    self.valobj = valobj
+
+  def num_children(self):
+    size_valobj = self.valobj.GetChildMemberWithName("m_arr_size")
+    if size_valobj:
+      return size_valobj.GetValueAsUnsigned(0)
+    return 0
+
+  def get_child_at_index(self, index):
+    size_valobj = self.valobj.GetChildMemberWithName("m_arr_size")
+    arr = self.valobj.GetChildMemberWithName("m_array")
+    if not size_valobj or not arr:
+      return None
+    max_idx = size_valobj.GetValueAsUnsigned(0)
+    if index >= max_idx:
+      return None
+    return arr.GetChildAtIndex(index)
+
+  def get_child_index(self, name):
+    if name == "[0]":
+      return 0
+    if name == "[1]":
+      return
+    if name == "[2]":
+      return 2
+    if name == "[3]":
+      return 3
+    return -1

--- a/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
+++ b/lldb/test/API/commands/frame/var-dil/basics/ArraySubscript/myArraySynthProvider.py
@@ -1,32 +1,33 @@
 import lldb
 
+
 class myArraySynthProvider:
-  def __init__(self, valobj, dict):
-    self.valobj = valobj
+    def __init__(self, valobj, dict):
+        self.valobj = valobj
 
-  def num_children(self):
-    size_valobj = self.valobj.GetChildMemberWithName("m_arr_size")
-    if size_valobj:
-      return size_valobj.GetValueAsUnsigned(0)
-    return 0
+    def num_children(self):
+        size_valobj = self.valobj.GetChildMemberWithName("m_arr_size")
+        if size_valobj:
+            return size_valobj.GetValueAsUnsigned(0)
+        return 0
 
-  def get_child_at_index(self, index):
-    size_valobj = self.valobj.GetChildMemberWithName("m_arr_size")
-    arr = self.valobj.GetChildMemberWithName("m_array")
-    if not size_valobj or not arr:
-      return None
-    max_idx = size_valobj.GetValueAsUnsigned(0)
-    if index >= max_idx:
-      return None
-    return arr.GetChildAtIndex(index)
+    def get_child_at_index(self, index):
+        size_valobj = self.valobj.GetChildMemberWithName("m_arr_size")
+        arr = self.valobj.GetChildMemberWithName("m_array")
+        if not size_valobj or not arr:
+            return None
+        max_idx = size_valobj.GetValueAsUnsigned(0)
+        if index >= max_idx:
+            return None
+        return arr.GetChildAtIndex(index)
 
-  def get_child_index(self, name):
-    if name == "[0]":
-      return 0
-    if name == "[1]":
-      return
-    if name == "[2]":
-      return 2
-    if name == "[3]":
-      return 3
-    return -1
+    def get_child_index(self, name):
+        if name == "[0]":
+            return 0
+        if name == "[1]":
+            return
+        if name == "[2]":
+            return 2
+        if name == "[3]":
+            return 3
+        return -1


### PR DESCRIPTION
This updates the DIL code for handling array subscripting to more closely match and handle all the cases from the original 'frame var' implementation. Also updates the DIL array subscripting test. This particularly fixes some issues with handling synthetic children, objc pointers, and accessing specific bits within scalar data types.