### PR TITLE
[MachineInstrBuilder]: Add BuildMIAfter variant

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -454,6 +454,21 @@ inline MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
       .setMMRAMetadata(MIMD.getMMRAMetadata());
 }
 
+/// This version of the builder inserts the newly-built instruction after the
+/// given position in the given MachineBasicBlock, and does NOT take a
+/// destination register.
+inline MachineInstrBuilder BuildMIAfter(MachineBasicBlock &BB,
+                                   MachineBasicBlock::iterator I,
+                                   const MIMetadata &MIMD,
+                                   const MCInstrDesc &MCID) {
+  MachineFunction &MF = *BB.getParent();
+  MachineInstr *MI = MF.CreateMachineInstr(MCID, MIMD.getDL());
+  BB.insertAfter(I, MI);
+  return MachineInstrBuilder(MF, MI)
+      .setPCSections(MIMD.getPCSections())
+      .setMMRAMetadata(MIMD.getMMRAMetadata());
+}
+
 inline MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
                                    MachineBasicBlock::instr_iterator I,
                                    const MIMetadata &MIMD,

--- a/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
+++ b/llvm/include/llvm/CodeGen/MachineInstrBuilder.h
@@ -458,9 +458,9 @@ inline MachineInstrBuilder BuildMI(MachineBasicBlock &BB,
 /// given position in the given MachineBasicBlock, and does NOT take a
 /// destination register.
 inline MachineInstrBuilder BuildMIAfter(MachineBasicBlock &BB,
-                                   MachineBasicBlock::iterator I,
-                                   const MIMetadata &MIMD,
-                                   const MCInstrDesc &MCID) {
+                                        MachineBasicBlock::iterator I,
+                                        const MIMetadata &MIMD,
+                                        const MCInstrDesc &MCID) {
   MachineFunction &MF = *BB.getParent();
   MachineInstr *MI = MF.CreateMachineInstr(MCID, MIMD.getDL());
   BB.insertAfter(I, MI);


### PR DESCRIPTION
I didn't see any version that had the `insertAfter` functionality.

This makes life easier for clients who want to `insertAfter` a given MI. Otherwise, they will need to create an ad-hoc implementation or do manipulate the iterators to work with the insert before versions.