### PR TITLE
[win][arm64ec] Handle empty function names

### DIFF
--- a/llvm/lib/IR/Mangler.cpp
+++ b/llvm/lib/IR/Mangler.cpp
@@ -292,6 +292,9 @@ void llvm::emitLinkerFlagsForUsedCOFF(raw_ostream &OS, const GlobalValue *GV,
 }
 
 std::optional<std::string> llvm::getArm64ECMangledFunctionName(StringRef Name) {
+  assert(!Name.empty() &&
+         "getArm64ECMangledFunctionName requires non-empty name");
+
   if (Name[0] != '?') {
     // For non-C++ symbols, prefix the name with "#" unless it's already
     // mangled.

--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -597,6 +597,14 @@ Function *AArch64Arm64ECCallLowering::buildEntryThunk(Function *F) {
   return Thunk;
 }
 
+std::optional<std::string> getArm64ECMangledFunctionName(GlobalValue &GV) {
+  if (!GV.hasName()) {
+    GV.setName("__unnamed");
+  }
+
+  return llvm::getArm64ECMangledFunctionName(GV.getName());
+}
+
 // Builds the "guest exit thunk", a helper to call a function which may or may
 // not be an exit thunk. (We optimistically assume non-dllimport function
 // declarations refer to functions defined in AArch64 code; if the linker
@@ -608,7 +616,7 @@ Function *AArch64Arm64ECCallLowering::buildGuestExitThunk(Function *F) {
   getThunkType(F->getFunctionType(), F->getAttributes(),
                Arm64ECThunkType::GuestExit, NullThunkName, Arm64Ty, X64Ty,
                ArgTranslations);
-  auto MangledName = getArm64ECMangledFunctionName(F->getName().str());
+  auto MangledName = getArm64ECMangledFunctionName(*F);
   assert(MangledName && "Can't guest exit to function that's already native");
   std::string ThunkName = *MangledName;
   if (ThunkName[0] == '?' && ThunkName.find("@") != std::string::npos) {
@@ -790,7 +798,7 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
     if (!F)
       continue;
     if (std::optional<std::string> MangledName =
-            getArm64ECMangledFunctionName(A.getName().str())) {
+            getArm64ECMangledFunctionName(A)) {
       F->addMetadata("arm64ec_unmangled_name",
                      *MDNode::get(M->getContext(),
                                   MDString::get(M->getContext(), A.getName())));
@@ -807,7 +815,7 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
           cast<GlobalValue>(F.getPersonalityFn()->stripPointerCasts());
       if (PersFn->getValueType() && PersFn->getValueType()->isFunctionTy()) {
         if (std::optional<std::string> MangledName =
-                getArm64ECMangledFunctionName(PersFn->getName().str())) {
+                getArm64ECMangledFunctionName(*PersFn)) {
           PersFn->setName(MangledName.value());
         }
       }
@@ -821,7 +829,7 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
     // Rename hybrid patchable functions and change callers to use a global
     // alias instead.
     if (std::optional<std::string> MangledName =
-            getArm64ECMangledFunctionName(F.getName().str())) {
+            getArm64ECMangledFunctionName(F)) {
       std::string OrigName(F.getName());
       F.setName(MangledName.value() + HybridPatchableTargetSuffix);
 
@@ -926,7 +934,7 @@ bool AArch64Arm64ECCallLowering::processFunction(
   // FIXME: Handle functions with weak linkage?
   if (!F.hasLocalLinkage() || F.hasAddressTaken()) {
     if (std::optional<std::string> MangledName =
-            getArm64ECMangledFunctionName(F.getName().str())) {
+            getArm64ECMangledFunctionName(F)) {
       F.addMetadata("arm64ec_unmangled_name",
                     *MDNode::get(M->getContext(),
                                  MDString::get(M->getContext(), F.getName())));

--- a/llvm/test/CodeGen/AArch64/arm64ec-empty-name.ll
+++ b/llvm/test/CodeGen/AArch64/arm64ec-empty-name.ll
@@ -1,0 +1,15 @@
+; RUN: llc -mtriple=arm64ec-pc-windows-msvc %s -o - | FileCheck %s
+
+; Regression test: Arm64EC needs to look at the first character of a function
+; to decide if it will be mangled like a C or C++ function name, which caused
+; it to crash for empty function names.
+define void @""() {
+        ret void
+}
+
+define void @""() {
+        ret void
+}
+
+; CHECK: "#__unnamed":
+; CHECK: "#__unnamed.1":


### PR DESCRIPTION
While testing Arm64EC, I observed that LLVM crashes when an empty function name is used. My original fix in #151409 was to raise an error, but this change now handles the empty name via `Mangler::getNameWithPrefix` (which assigns a name to the function).

To get this working, I had to create the `Mangler` in `TargetLoweringObjectFile` early so it would be available to Arm64EC's lowering. There's no reason why `Mangler` is only created when `Initialize` is called (or re-created if it exists), and so I moved creation to the constructor and switched the raw pointer for a `unique_ptr` to avoid the explicit `delete` in the destructor.