### PR TITLE
[win][arm64ec] Handle `available_externally` functions

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Arm64ECCallLowering.cpp
@@ -813,8 +813,8 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
       }
     }
 
-    if (!F.hasFnAttribute(Attribute::HybridPatchable) || F.isDeclaration() ||
-        F.hasLocalLinkage() ||
+    if (!F.hasFnAttribute(Attribute::HybridPatchable) ||
+        F.isDeclarationForLinker() || F.hasLocalLinkage() ||
         F.getName().ends_with(HybridPatchableTargetSuffix))
       continue;
 
@@ -857,7 +857,7 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
 
   SetVector<GlobalValue *> DirectCalledFns;
   for (Function &F : Mod)
-    if (!F.isDeclaration() &&
+    if (!F.isDeclarationForLinker() &&
         F.getCallingConv() != CallingConv::ARM64EC_Thunk_Native &&
         F.getCallingConv() != CallingConv::ARM64EC_Thunk_X64)
       processFunction(F, DirectCalledFns, FnsMap);
@@ -869,7 +869,8 @@ bool AArch64Arm64ECCallLowering::runOnModule(Module &Mod) {
   };
   SmallVector<ThunkInfo> ThunkMapping;
   for (Function &F : Mod) {
-    if (!F.isDeclaration() && (!F.hasLocalLinkage() || F.hasAddressTaken()) &&
+    if (!F.isDeclarationForLinker() &&
+        (!F.hasLocalLinkage() || F.hasAddressTaken()) &&
         F.getCallingConv() != CallingConv::ARM64EC_Thunk_Native &&
         F.getCallingConv() != CallingConv::ARM64EC_Thunk_X64) {
       if (!F.hasComdat())
@@ -959,7 +960,7 @@ bool AArch64Arm64ECCallLowering::processFunction(
       // unprototyped functions in C)
       if (Function *F = CB->getCalledFunction()) {
         if (!LowerDirectToIndirect || F->hasLocalLinkage() ||
-            F->isIntrinsic() || !F->isDeclaration())
+            F->isIntrinsic() || !F->isDeclarationForLinker())
           continue;
 
         DirectCalledFns.insert(F);

--- a/llvm/test/CodeGen/AArch64/arm64ec-available-externally.ll
+++ b/llvm/test/CodeGen/AArch64/arm64ec-available-externally.ll
@@ -1,0 +1,24 @@
+; RUN: llc -mtriple arm64ec-windows-msvc -o - %s | FileCheck %s
+
+; Arm64EC Regression Test: The Arm64EC Call Lowering was placing "available
+; externally" items in COMDATs, which is not permitted by the module verifier.
+
+define available_externally float @f() {
+entry:
+  ret float 0x0
+}
+
+define i32 @caller() {
+entry:
+  call float @f()
+  ret i32 0
+}
+
+; Normal function gets an entry thunk, but not an exit thunk.
+; CHECK-DAG:    $ientry_thunk$cdecl$i8$v:
+; CHECK-NOT:    $iexit_thunk$cdecl$i8$v:
+
+; Available Externally function gets an exit thunk, but not an entry thunk.
+; CHECK-DAG:    $iexit_thunk$cdecl$f$v:
+; CHECK-DAG:    "#f$exit_thunk":
+; CHECK-NOT:    $ientry_thunk$cdecl$f$v:


### PR DESCRIPTION
While testing Arm64EC, I observed that LLVM crashes when an `available_externally` function is used as it tries to place it in a COMDAT, which is not permitted by the verifier.

This the fix from #151409 plus a dedicated test.