### PR TITLE
[clang] Remove %T from tests

### DIFF
--- a/clang/test/Analysis/undef-call.c
+++ b/clang/test/Analysis/undef-call.c
@@ -1,6 +1,6 @@
-// RUN: rm -rf %T/ctudir
-// RUN: mkdir %T/ctudir
-// RUN: %clang_analyze_cc1 -analyzer-checker=debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%T/ctudir -verify %s
+// RUN: rm -rf %t.dir/ctudir
+// RUN: mkdir -p %t.dir/ctudir
+// RUN: %clang_analyze_cc1 -analyzer-checker=debug.ExprInspection -analyzer-config experimental-enable-naive-ctu-analysis=true -analyzer-config ctu-dir=%t.dir/ctudir -verify %s
 // expected-no-diagnostics
 
 struct S {

--- a/clang/test/CodeGen/thinlto_backend.ll
+++ b/clang/test/CodeGen/thinlto_backend.ll
@@ -29,16 +29,16 @@
 ; Ensure f2 was imported. Check for all 3 flavors of -save-temps[=cwd|obj].
 ; RUN: %clang -target x86_64-unknown-linux-gnu -O2 -o %t3.o -x ir %t1.o -c -fthinlto-index=%t.thinlto.bc -save-temps=obj
 ; RUN: llvm-dis %t1.s.3.import.bc -o - | FileCheck --check-prefix=CHECK-IMPORT %s
-; RUN: mkdir -p %T/dir1
-; RUN: cd %T/dir1
+; RUN: mkdir -p %t.dir/dir1
+; RUN: cd %t.dir/dir1
 ; RUN: %clang -target x86_64-unknown-linux-gnu -O2 -o %t3.o -x ir %t1.o -c -fthinlto-index=%t.thinlto.bc -save-temps=cwd
 ; RUN: cd ../..
-; RUN: llvm-dis %T/dir1/*1.s.3.import.bc -o - | FileCheck --check-prefix=CHECK-IMPORT %s
-; RUN: mkdir -p %T/dir2
-; RUN: cd %T/dir2
+; RUN: llvm-dis %t.dir/dir1/*1.s.3.import.bc -o - | FileCheck --check-prefix=CHECK-IMPORT %s
+; RUN: mkdir -p %t.dir/dir2
+; RUN: cd %t.dir/dir2
 ; RUN: %clang -target x86_64-unknown-linux-gnu -O2 -o %t3.o -x ir %t1.o -c -fthinlto-index=%t.thinlto.bc -save-temps
 ; RUN: cd ../..
-; RUN: llvm-dis %T/dir2/*1.s.3.import.bc -o - | FileCheck --check-prefix=CHECK-IMPORT %s
+; RUN: llvm-dis %t.dir/dir2/*1.s.3.import.bc -o - | FileCheck --check-prefix=CHECK-IMPORT %s
 ; CHECK-IMPORT: define available_externally void @f2()
 ; RUN: llvm-nm %t3.o | FileCheck --check-prefix=CHECK-OBJ %s
 ; CHECK-OBJ: T f1

--- a/clang/test/CodeGenCXX/module-intializer-pmf.cpp
+++ b/clang/test/CodeGenCXX/module-intializer-pmf.cpp
@@ -1,7 +1,7 @@
 
 // RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 %s \
-// RUN:    -emit-module-interface -o %T/HasPMF.pcm
-// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 %T/HasPMF.pcm \
+// RUN:    -emit-module-interface -o %t.HasPMF.pcm
+// RUN: %clang_cc1 -triple %itanium_abi_triple -std=c++20 %t.HasPMF.pcm \
 // RUN:  -emit-llvm -o - | FileCheck %s
 
 module;

--- a/clang/test/CodeGenCXX/profile-remap.cpp
+++ b/clang/test/CodeGenCXX/profile-remap.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: x86-registered-target
 //
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -fprofile-sample-use=%S/Inputs/profile-remap.samples -fprofile-remapping-file=%S/Inputs/profile-remap.map -O2 %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SAMPLES
-// RUN: llvm-profdata merge -output %T.profdata %S/Inputs/profile-remap.proftext
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fprofile-instrument-use-path=%T.profdata -fprofile-remapping-file=%S/Inputs/profile-remap.map -O2 %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-INSTR
-// RUN: llvm-profdata merge -output %T.profdata %S/Inputs/profile-remap_entry.proftext
-// RUN: %clang_cc1 -triple x86_64-linux-gnu -fprofile-instrument-use-path=%T.profdata -fprofile-remapping-file=%S/Inputs/profile-remap.map -O2 %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-INSTR
+// RUN: llvm-profdata merge -output %t.profdata %S/Inputs/profile-remap.proftext
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fprofile-instrument-use-path=%t.profdata -fprofile-remapping-file=%S/Inputs/profile-remap.map -O2 %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-INSTR
+// RUN: llvm-profdata merge -output %t.profdata %S/Inputs/profile-remap_entry.proftext
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -fprofile-instrument-use-path=%t.profdata -fprofile-remapping-file=%S/Inputs/profile-remap.map -O2 %s -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-INSTR
 
 namespace Foo {
   struct X {};

--- a/clang/test/Driver/HLSL/metal-converter.hlsl
+++ b/clang/test/Driver/HLSL/metal-converter.hlsl
@@ -1,14 +1,15 @@
-// RUN: echo "dxv" > %T/dxv && chmod 754 %T/dxv
+// RUN: mkdir -p %t.dir
+// RUN: echo "dxv" > %t.dir/dxv && chmod 754 %t.dir/dxv
 
 // RUN: env PATH="" %clang_dxc -T cs_6_0 %s -metal -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
 // RUN: env PATH="" %clang_dxc -T cs_6_0 %s -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
-// RUN: env PATH="" %clang_dxc -T cs_6_0 %s --dxv-path=%T -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
+// RUN: env PATH="" %clang_dxc -T cs_6_0 %s --dxv-path=%t.dir -metal -Vd -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=NO_DXV %s
 // NO_DXV: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.mtl"
 
 // RUN: %clang_dxc -T cs_6_0 %s -metal -### 2>&1 | FileCheck --check-prefix=NO_MTL %s
 // NO_MTL-NOT: metal-shaderconverter
 
-// RUN: %clang_dxc -T cs_6_0 %s --dxv-path=%T -metal -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=DXV %s
+// RUN: %clang_dxc -T cs_6_0 %s --dxv-path=%t.dir -metal -Fo %t.mtl -### 2>&1 | FileCheck --check-prefix=DXV %s
 // DXV: "{{.*}}dxv{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.dxo"
 // DXV: "{{.*}}metal-shaderconverter{{(.exe)?}}" "{{.*}}.dxo" "-o" "{{.*}}.mtl"
 

--- a/clang/test/Driver/baremetal-sysroot.cpp
+++ b/clang/test/Driver/baremetal-sysroot.cpp
@@ -4,12 +4,12 @@
 // Test that when a --sysroot is not provided, driver picks the default
 // location correctly if available.
 
-// RUN: rm -rf %T/baremetal_default_sysroot
-// RUN: mkdir -p %T/baremetal_default_sysroot/bin
-// RUN: mkdir -p %T/baremetal_default_sysroot/lib/clang-runtimes/armv6m-none-eabi
-// RUN: ln -s %clang %T/baremetal_default_sysroot/bin/clang
+// RUN: rm -rf %t.dir/baremetal_default_sysroot
+// RUN: mkdir -p %t.dir/baremetal_default_sysroot/bin
+// RUN: mkdir -p %t.dir/baremetal_default_sysroot/lib/clang-runtimes/armv6m-none-eabi
+// RUN: ln -s %clang %t.dir/baremetal_default_sysroot/bin/clang
 
-// RUN: %T/baremetal_default_sysroot/bin/clang -no-canonical-prefixes %s -### -o %t.out 2>&1 \
+// RUN: %t.dir/baremetal_default_sysroot/bin/clang -no-canonical-prefixes %s -### -o %t.out 2>&1 \
 // RUN:     -target armv6m-none-eabi --sysroot= \
 // RUN:   | FileCheck --check-prefix=CHECK-V6M-C %s
 // CHECK-V6M-C: "{{.*}}clang{{.*}}" "-cc1" "-triple" "thumbv6m-unknown-none-eabi"

--- a/clang/test/Driver/baremetal.cpp
+++ b/clang/test/Driver/baremetal.cpp
@@ -126,11 +126,11 @@
 // CHECK-V6M-NDL: "-Bstatic" "-m" "armelf" "-EL"
 // CHECK-V6M-NDL-SAME: "-L{{[^"]*}}{{[/\\]+}}Inputs{{[/\\]+}}baremetal_arm{{[/\\]+}}lib"
 
-// RUN: rm -rf %T/baremetal_cxx_sysroot
-// RUN: mkdir -p %T/baremetal_cxx_sysroot/usr/include/c++/v1
+// RUN: rm -rf %t.dir/baremetal_cxx_sysroot
+// RUN: mkdir -p %t.dir/baremetal_cxx_sysroot/usr/include/c++/v1
 // RUN: %clangxx %s -### 2>&1 \
 // RUN:     --target=armv6m-none-eabi \
-// RUN:     --sysroot=%T/baremetal_cxx_sysroot \
+// RUN:     --sysroot=%t.dir/baremetal_cxx_sysroot \
 // RUN:     -stdlib=libc++ \
 // RUN:   | FileCheck --check-prefix=CHECK-V6M-LIBCXX-USR %s
 // CHECK-V6M-LIBCXX-USR: "-resource-dir" "[[RESOURCE_DIR:[^"]+]]"
@@ -568,24 +568,24 @@
 
 // Check that compiler-rt library without the arch filename suffix will
 // be used if present.
-// RUN: rm -rf %T/baremetal_clang_rt_noarch
-// RUN: mkdir -p %T/baremetal_clang_rt_noarch/lib
-// RUN: touch %T/baremetal_clang_rt_noarch/lib/libclang_rt.builtins.a
+// RUN: rm -rf %t.dir/baremetal_clang_rt_noarch
+// RUN: mkdir -p %t.dir/baremetal_clang_rt_noarch/lib
+// RUN: touch %t.dir/baremetal_clang_rt_noarch/lib/libclang_rt.builtins.a
 // RUN: %clang %s -### 2>&1 \
 // RUN:     --target=armv6m-none-eabi \
-// RUN:     --sysroot=%T/baremetal_clang_rt_noarch \
+// RUN:     --sysroot=%t.dir/baremetal_clang_rt_noarch \
 // RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-NOARCH %s
 // CHECK-CLANGRT-NOARCH: "{{[^"]*}}libclang_rt.builtins.a"
 // CHECK-CLANGRT-NOARCH-NOT: "{{[^"]*}}libclang_rt.builtins.a"
 
 // Check that compiler-rt library with the arch filename suffix will be
 // used if present.
-// RUN: rm -rf %T/baremetal_clang_rt_arch
-// RUN: mkdir -p %T/baremetal_clang_rt_arch/lib
-// RUN: touch %T/baremetal_clang_rt_arch/lib/libclang_rt.builtins-armv6m.a
+// RUN: rm -rf %t.dir/baremetal_clang_rt_arch
+// RUN: mkdir -p %t.dir/baremetal_clang_rt_arch/lib
+// RUN: touch %t.dir/baremetal_clang_rt_arch/lib/libclang_rt.builtins-armv6m.a
 // RUN: %clang %s -### 2>&1 \
 // RUN:     --target=armv6m-none-eabi \
-// RUN:     --sysroot=%T/baremetal_clang_rt_arch \
+// RUN:     --sysroot=%t.dir/baremetal_clang_rt_arch \
 // RUN:   | FileCheck --check-prefix=CHECK-CLANGRT-ARCH %s
 // CHECK-CLANGRT-ARCH: "{{[^"]*}}libclang_rt.builtins.a"
 // CHECK-CLANGRT-ARCH-NOT: "{{[^"]*}}libclang_rt.builtins.a"

--- a/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
+++ b/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
@@ -5,7 +5,7 @@
 // RUN:   | FileCheck %s
 
 // CHECK-DAG: "name": "ParseDeclarationOrFunctionDefinition"
-// CHECK-DAG: "detail": "{{.*}}check-time-trace-ParseDeclarationOrFunctionDefinition.cpp:17:1"
+// CHECK-DAG: "detail": "{{.*}}check-time-trace-ParseDeclarationOrFunctionDefinition.cpp:16:1"
 // CHECK-DAG: "name": "ParseFunctionDefinition"
 // CHECK-DAG: "detail": "foo"
 // CHECK-DAG: "name": "ParseFunctionDefinition"

--- a/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
+++ b/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
@@ -1,10 +1,12 @@
-// RUN: %clangxx -S -ftime-trace -ftime-trace-granularity=0 -o %T/check-time-trace-ParseDeclarationOrFunctionDefinition %s
-// RUN: cat %T/check-time-trace-ParseDeclarationOrFunctionDefinition.json \
+// RUN: mkdir -p %t.dir
+// RUN: %clangxx -S -ftime-trace -ftime-trace-granularity=0 -o %t.dir/check-time-trace-ParseDeclarationOrFunctionDefinition %s
+// RUN: cp %t.dir/check-time-trace-ParseDeclarationOrFunctionDefinition.json /tmp/test5
+// RUN: cat %t.dir/check-time-trace-ParseDeclarationOrFunctionDefinition.json \
 // RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 // RUN:   | FileCheck %s
 
 // CHECK-DAG: "name": "ParseDeclarationOrFunctionDefinition"
-// CHECK-DAG: "detail": "{{.*}}check-time-trace-ParseDeclarationOrFunctionDefinition.cpp:15:1"
+// CHECK-DAG: "detail": "{{.*}}check-time-trace-ParseDeclarationOrFunctionDefinition.cpp:17:1"
 // CHECK-DAG: "name": "ParseFunctionDefinition"
 // CHECK-DAG: "detail": "foo"
 // CHECK-DAG: "name": "ParseFunctionDefinition"

--- a/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
+++ b/clang/test/Driver/check-time-trace-ParseDeclarationOrFunctionDefinition.cpp
@@ -1,6 +1,5 @@
 // RUN: mkdir -p %t.dir
 // RUN: %clangxx -S -ftime-trace -ftime-trace-granularity=0 -o %t.dir/check-time-trace-ParseDeclarationOrFunctionDefinition %s
-// RUN: cp %t.dir/check-time-trace-ParseDeclarationOrFunctionDefinition.json /tmp/test5
 // RUN: cat %t.dir/check-time-trace-ParseDeclarationOrFunctionDefinition.json \
 // RUN:   | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' \
 // RUN:   | FileCheck %s

--- a/clang/test/Driver/cl-showfilenames.c
+++ b/clang/test/Driver/cl-showfilenames.c
@@ -10,11 +10,12 @@
 //       There is currently a discussion of this going on at:
 //         https://reviews.llvm.org/D69825
 
-// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%T/ /showFilenames -- %s 2>&1 | FileCheck -check-prefix=show %s
-// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%T/ /showFilenames -- %s %S/Inputs/wildcard*.c 2>&1 | FileCheck -check-prefix=multiple %s
+// RUN: mkdir -p %t.dir
+// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%t.dir/ /showFilenames -- %s 2>&1 | FileCheck -check-prefix=show %s
+// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%t.dir/ /showFilenames -- %s %S/Inputs/wildcard*.c 2>&1 | FileCheck -check-prefix=multiple %s
 
-// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%T/ -- %s 2>&1 | FileCheck -check-prefix=noshow %s
-// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%T/ /showFilenames /showFilenames- -- %s 2>&1 | FileCheck -check-prefix=noshow %s
+// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%t.dir/ -- %s 2>&1 | FileCheck -check-prefix=noshow %s
+// RUN: %clang_cl -fno-integrated-cc1 --target=i686-pc-win32 /c /Fo%t.dir/ /showFilenames /showFilenames- -- %s 2>&1 | FileCheck -check-prefix=noshow %s
 
 
 #pragma message "Hello"

--- a/clang/test/Driver/clang-offload-bundler.c
+++ b/clang/test/Driver/clang-offload-bundler.c
@@ -413,15 +413,16 @@
 // bundle and archives them. Therefore for each target, the output is an
 // archive of unbundled bitcodes.
 //
+// RUN: mkdir -p %t.dir
 // RUN: clang-offload-bundler -type=bc -targets=hip-amdgcn-amd-amdhsa--gfx900,hip-amdgcn-amd-amdhsa--gfx906 \
-// RUN:   -input=%t.tgt1 -input=%t.tgt2 -output=%T/hip_bundle1.bc
+// RUN:   -input=%t.tgt1 -input=%t.tgt2 -output=%t.dir/hip_bundle1.bc
 // RUN: clang-offload-bundler -type=bc -targets=hip-amdgcn-amd-amdhsa--gfx900,hip-amdgcn-amd-amdhsa--gfx906 \
-// RUN:   -input=%t.tgt1 -input=%t.tgt2 -output=%T/hip_bundle2.bc
-// RUN: llvm-ar cr %T/hip_archive.a %T/hip_bundle1.bc %T/hip_bundle2.bc
+// RUN:   -input=%t.tgt1 -input=%t.tgt2 -output=%t.dir/hip_bundle2.bc
+// RUN: llvm-ar cr %t.dir/hip_archive.a %t.dir/hip_bundle1.bc %t.dir/hip_bundle2.bc
 // RUN: clang-offload-bundler -unbundle -type=a -targets=hip-amdgcn-amd-amdhsa--gfx900,hip-amdgcn-amd-amdhsa--gfx906 \
-// RUN:   -output=%T/hip_900.a -output=%T/hip_906.a -input=%T/hip_archive.a
-// RUN: llvm-ar t %T/hip_900.a | FileCheck -check-prefix=HIP-AR-900 %s
-// RUN: llvm-ar t %T/hip_906.a | FileCheck -check-prefix=HIP-AR-906 %s
+// RUN:   -output=%t.dir/hip_900.a -output=%t.dir/hip_906.a -input=%t.dir/hip_archive.a
+// RUN: llvm-ar t %t.dir/hip_900.a | FileCheck -check-prefix=HIP-AR-900 %s
+// RUN: llvm-ar t %t.dir/hip_906.a | FileCheck -check-prefix=HIP-AR-906 %s
 // HIP-AR-900-DAG: hip_bundle1-hip-amdgcn-amd-amdhsa--gfx900
 // HIP-AR-900-DAG: hip_bundle2-hip-amdgcn-amd-amdhsa--gfx900
 // HIP-AR-906-DAG: hip_bundle1-hip-amdgcn-amd-amdhsa--gfx906
@@ -553,14 +554,14 @@
 
 // Check compatibility of HIP code objects found in the heterogeneous archive library with OpenMP code objects of the target
 // RUN: clang-offload-bundler -unbundle -type=a -targets=openmp-amdgcn-amd-amdhsa--gfx906 \
-// RUN:   -output=%T/hip-openmp_906.a -input=%T/hip_archive.a -hip-openmp-compatible
-// RUN: llvm-ar t %T/hip-openmp_906.a | FileCheck -check-prefix=OPENMPHIPCOMPAT %s
+// RUN:   -output=%t.dir/hip-openmp_906.a -input=%t.dir/hip_archive.a -hip-openmp-compatible
+// RUN: llvm-ar t %t.dir/hip-openmp_906.a | FileCheck -check-prefix=OPENMPHIPCOMPAT %s
 // OPENMPHIPCOMPAT: hip_bundle1-hip-amdgcn-amd-amdhsa--gfx906
 
 // Check if a malformat bundle id can be detected and an error can be emitted.
-// RUN: not clang-offload-bundler -unbundle -type=a -targets=openmp-amdgcn-amd-amdhsa -output=%T/hip-openmp_906.a -input=%T/hip_archive.a -hip-openmp-compatible 2>&1 | FileCheck %s -check-prefix=ERROR-WRONG-FORMAT
+// RUN: not clang-offload-bundler -unbundle -type=a -targets=openmp-amdgcn-amd-amdhsa -output=%t.dir/hip-openmp_906.a -input=%t.dir/hip_archive.a -hip-openmp-compatible 2>&1 | FileCheck %s -check-prefix=ERROR-WRONG-FORMAT
 // ERROR-WRONG-FORMAT: error: Targets need to follow the format '<offload kind>-<target triple>', where '<target triple>' follows the format '<kind>-<arch>-<vendor>-<os>-<env>[-<target id>[:target features]]'.
-// RUN: not clang-offload-bundler -unbundle -type=a -targets=openmp-amdgcn-amd-amdhsa-gfx906 -output=%T/hip-openmp_906.a -input=%T/hip_archive.a -hip-openmp-compatible 2>&1 | FileCheck %s -check-prefix=ERROR-NO-ENV
+// RUN: not clang-offload-bundler -unbundle -type=a -targets=openmp-amdgcn-amd-amdhsa-gfx906 -output=%t.dir/hip-openmp_906.a -input=%t.dir/hip_archive.a -hip-openmp-compatible 2>&1 | FileCheck %s -check-prefix=ERROR-NO-ENV
 // ERROR-NO-ENV: error: no compatible code object found for the target 'openmp-amdgcn-amd-amdhsa--'
 
 // Some code so that we can create a binary out of this file.

--- a/clang/test/Driver/clang-sycl-linker-test.cpp
+++ b/clang/test/Driver/clang-sycl-linker-test.cpp
@@ -11,9 +11,10 @@
 // SIMPLE-FO-NEXT: SPIR-V Backend: input: [[LLVMLINKOUT]].bc, output: a_0.spv
 //
 // Test the dry run of a simple case with device library files specified.
-// RUN: touch %T/lib1.bc
-// RUN: touch %T/lib2.bc
-// RUN: clang-sycl-linker --dry-run -v -triple=spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
+// RUN: mkdir -p %t.dir
+// RUN: touch %t.dir/lib1.bc
+// RUN: touch %t.dir/lib2.bc
+// RUN: clang-sycl-linker --dry-run -v -triple=spirv64 %t_1.bc %t_2.bc --library-path=%t.dir --device-libs=lib1.bc,lib2.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBS
 // DEVLIBS: sycl-device-link: inputs: {{.*}}.bc  libfiles: {{.*}}lib1.bc, {{.*}}lib2.bc  output: [[LLVMLINKOUT:.*]].bc
 // DEVLIBS-NEXT: SPIR-V Backend: input: [[LLVMLINKOUT]].bc, output: a_0.spv
@@ -25,10 +26,10 @@
 // FILETYPEERROR: Unsupported file type
 //
 // Test to see if device library related errors are emitted.
-// RUN: not clang-sycl-linker --dry-run -triple=spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs= -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run -triple=spirv64 %t_1.bc %t_2.bc --library-path=%t.dir --device-libs= -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR1
 // DEVLIBSERR1: Number of device library files cannot be zero
-// RUN: not clang-sycl-linker --dry-run -triple=spirv64 %t_1.bc %t_2.bc --library-path=%T --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
+// RUN: not clang-sycl-linker --dry-run -triple=spirv64 %t_1.bc %t_2.bc --library-path=%t.dir --device-libs=lib1.bc,lib2.bc,lib3.bc -o a.spv 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=DEVLIBSERR2
 // DEVLIBSERR2: '{{.*}}lib3.bc' SYCL device library file is not found
 //

--- a/clang/test/Driver/dxc_dxv_path.hlsl
+++ b/clang/test/Driver/dxc_dxv_path.hlsl
@@ -1,20 +1,21 @@
-// RUN: env PATH="" %clang_dxc -I test -Tlib_6_3 -Fo %T/a.dxo  -### %s 2>&1 | FileCheck %s
+// RUN: mkdir -p %t.dir
+// RUN: env PATH="" %clang_dxc -I test -Tlib_6_3 -Fo %t.dir/a.dxo  -### %s 2>&1 | FileCheck %s
 
 // Make sure report warning.
 // CHECK:dxv not found
 
-// RUN: echo "dxv" > %T/dxv && chmod 754 %T/dxv && %clang_dxc --dxv-path=%T %s -Tlib_6_3 -Fo %T/a.dxo -### 2>&1 | FileCheck %s --check-prefix=DXV_PATH
+// RUN: echo "dxv" > %t.dir/dxv && chmod 754 %t.dir/dxv && %clang_dxc --dxv-path=%t.dir %s -Tlib_6_3 -Fo %t.dir/a.dxo -### 2>&1 | FileCheck %s --check-prefix=DXV_PATH
 // DXV_PATH:dxv{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}/a.dxo"
 
 // RUN: %clang_dxc -I test -Vd -Tlib_6_3  -### %s 2>&1 | FileCheck %s --check-prefix=VD
 // VD:"-cc1"{{.*}}"-triple" "dxilv1.3-unknown-shadermodel6.3-library"
 // VD-NOT:dxv not found
 
-// RUN: %clang_dxc -Tlib_6_3 -ccc-print-bindings --dxv-path=%T -Fo %t.dxo  %s 2>&1 | FileCheck %s --check-prefix=BINDINGS
+// RUN: %clang_dxc -Tlib_6_3 -ccc-print-bindings --dxv-path=%t.dir -Fo %t.dxo  %s 2>&1 | FileCheck %s --check-prefix=BINDINGS
 // BINDINGS: "dxilv1.3-unknown-shadermodel6.3-library" - "clang", inputs: ["[[INPUT:.+]]"], output: "[[obj:.+]].obj"
 // BINDINGS-NEXT: "dxilv1.3-unknown-shadermodel6.3-library" - "hlsl::Validator", inputs: ["[[obj]].obj"], output: "{{.+}}.dxo"
 
-// RUN: %clang_dxc -Tlib_6_3 -ccc-print-phases --dxv-path=%T -Fo %t.dxc  %s 2>&1 | FileCheck %s --check-prefix=PHASES
+// RUN: %clang_dxc -Tlib_6_3 -ccc-print-phases --dxv-path=%t.dir -Fo %t.dxc  %s 2>&1 | FileCheck %s --check-prefix=PHASES
 
 // PHASES: 0: input, "[[INPUT:.+]]", hlsl
 // PHASES-NEXT: 1: preprocessor, {0}, c++-cpp-output

--- a/clang/test/Driver/mingw-sysroot.cpp
+++ b/clang/test/Driver/mingw-sysroot.cpp
@@ -1,29 +1,29 @@
 // REQUIRES: shell
 // UNSUPPORTED: system-windows
 
-// RUN: rm -rf %T/testroot-gcc
-// RUN: mkdir -p %T/testroot-gcc/bin
-// RUN: ln -s %clang %T/testroot-gcc/bin/x86_64-w64-mingw32-gcc
-// RUN: ln -s %clang %T/testroot-gcc/bin/x86_64-w64-mingw32-clang
-// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/x86_64-w64-mingw32 %T/testroot-gcc/x86_64-w64-mingw32
-// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/lib %T/testroot-gcc/lib
+// RUN: rm -rf %t.dir/testroot-gcc
+// RUN: mkdir -p %t.dir/testroot-gcc/bin
+// RUN: ln -s %clang %t.dir/testroot-gcc/bin/x86_64-w64-mingw32-gcc
+// RUN: ln -s %clang %t.dir/testroot-gcc/bin/x86_64-w64-mingw32-clang
+// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/x86_64-w64-mingw32 %t.dir/testroot-gcc/x86_64-w64-mingw32
+// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/lib %t.dir/testroot-gcc/lib
 
-// RUN: rm -rf %T/testroot-clang
-// RUN: mkdir -p %T/testroot-clang/bin
-// RUN: ln -s %clang %T/testroot-clang/bin/x86_64-w64-mingw32-clang
-// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/x86_64-w64-mingw32 %T/testroot-clang/x86_64-w64-mingw32
-// RUN: ln -s %S/Inputs/mingw_arch_tree/usr/i686-w64-mingw32 %T/testroot-clang/i686-w64-mingw32
+// RUN: rm -rf %t.dir/testroot-clang
+// RUN: mkdir -p %t.dir/testroot-clang/bin
+// RUN: ln -s %clang %t.dir/testroot-clang/bin/x86_64-w64-mingw32-clang
+// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/x86_64-w64-mingw32 %t.dir/testroot-clang/x86_64-w64-mingw32
+// RUN: ln -s %S/Inputs/mingw_arch_tree/usr/i686-w64-mingw32 %t.dir/testroot-clang/i686-w64-mingw32
 
-// RUN: rm -rf %T/testroot-clang-native
-// RUN: mkdir -p %T/testroot-clang-native/bin
-// RUN: ln -s %clang %T/testroot-clang-native/bin/clang
-// RUN: mkdir -p %T/testroot-clang-native/include/_mingw.h
-// RUN: mkdir -p %T/testroot-clang-native/lib/libkernel32.a
+// RUN: rm -rf %t.dir/testroot-clang-native
+// RUN: mkdir -p %t.dir/testroot-clang-native/bin
+// RUN: ln -s %clang %t.dir/testroot-clang-native/bin/clang
+// RUN: mkdir -p %t.dir/testroot-clang-native/include/_mingw.h
+// RUN: mkdir -p %t.dir/testroot-clang-native/lib/libkernel32.a
 
-// RUN: rm -rf %T/testroot-custom-triple
-// RUN: mkdir -p %T/testroot-custom-triple/bin
-// RUN: ln -s %clang %T/testroot-custom-triple/bin/clang
-// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/x86_64-w64-mingw32 %T/testroot-custom-triple/x86_64-w64-mingw32foo
+// RUN: rm -rf %t.dir/testroot-custom-triple
+// RUN: mkdir -p %t.dir/testroot-custom-triple/bin
+// RUN: ln -s %clang %t.dir/testroot-custom-triple/bin/clang
+// RUN: ln -s %S/Inputs/mingw_ubuntu_posix_tree/usr/x86_64-w64-mingw32 %t.dir/testroot-custom-triple/x86_64-w64-mingw32foo
 
 // If we find a gcc in the path with the right triplet prefix, pick that as
 // sysroot:
@@ -33,7 +33,7 @@
 // directory to the path - this would end up including /usr/include for
 // cross toolchains installed in /usr.
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s --implicit-check-not="\"{{.*}}/testroot-gcc{{/|\\\\}}include\""
+// RUN: env "PATH=%t.dir/testroot-gcc/bin:%PATH%" %clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s --implicit-check-not="\"{{.*}}/testroot-gcc{{/|\\\\}}include\""
 // CHECK_TESTROOT_GCC: "-internal-isystem" "[[BASE:[^"]+]]/testroot-gcc{{/|\\\\}}lib{{/|\\\\}}gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}10.2-posix{{/|\\\\}}include{{/|\\\\}}c++"
 // CHECK_TESTROOT_GCC-SAME: {{^}} "-internal-isystem" "[[BASE]]/testroot-gcc{{/|\\\\}}lib{{/|\\\\}}gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}10.2-posix{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}x86_64-w64-mingw32"
 // CHECK_TESTROOT_GCC-SAME: {{^}} "-internal-isystem" "[[BASE]]/testroot-gcc{{/|\\\\}}lib{{/|\\\\}}gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}10.2-posix{{/|\\\\}}include{{/|\\\\}}c++{{/|\\\\}}backward"
@@ -45,7 +45,7 @@
 
 // If we pass --sysroot explicitly, then we do include <sysroot>/include
 // even when cross compiling.
-// RUN: %clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="%T/testroot-gcc" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC_EXPLICIT %s
+// RUN: %clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="%t.dir/testroot-gcc" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC_EXPLICIT %s
 
 // CHECK_TESTROOT_GCC_EXPLICIT: "-internal-isystem" "{{[^"]+}}/testroot-gcc{{/|\\\\}}include"
 
@@ -53,8 +53,8 @@
 // If -no-canonical-prefixes and there's a matching sysroot next to the clang binary itself, prefer that
 // over a gcc in the path:
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-clang/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC2 %s
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-clang/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s -no-canonical-prefixes 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG %s
+// RUN: env "PATH=%t.dir/testroot-gcc/bin:%PATH%" %t.dir/testroot-clang/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC2 %s
+// RUN: env "PATH=%t.dir/testroot-gcc/bin:%PATH%" %t.dir/testroot-clang/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s -no-canonical-prefixes 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG %s
 // CHECK_TESTROOT_GCC2: "{{[^"]+}}/testroot-gcc{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}include"
 // CHECK_TESTROOT_CLANG: "{{[^"]+}}/testroot-clang{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}include"
 
@@ -63,7 +63,7 @@
 // happens to be in the same directory as gcc, make sure we still can pick up
 // the libgcc directory:
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-gcc/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s
+// RUN: env "PATH=%t.dir/testroot-gcc/bin:%PATH%" %t.dir/testroot-gcc/bin/x86_64-w64-mingw32-clang --target=x86_64-w64-mingw32 -rtlib=platform -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_GCC %s
 
 
 // If we're executing clang from a directory with what looks like a mingw sysroot,
@@ -84,7 +84,7 @@
 // that indicates that we did choose the right base, even if this particular directory
 // actually doesn't exist here.
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-clang-native/bin/clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG_NATIVE %s
+// RUN: env "PATH=%t.dir/testroot-gcc/bin:%PATH%" %t.dir/testroot-clang-native/bin/clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG_NATIVE %s
 // CHECK_TESTROOT_CLANG_NATIVE: "{{[^"]+}}/testroot-clang-native{{/|\\\\}}x86_64-w64-mingw32{{/|\\\\}}include"
 
 
@@ -95,12 +95,12 @@
 // that defaults to x86_64 mingw, but it's easier to test this in cross setups
 // with symlinks, like the other tests here.)
 
-// RUN: env "PATH=%T/testroot-gcc/bin:%PATH%" %T/testroot-clang/bin/x86_64-w64-mingw32-clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -m32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG_I686 %s
+// RUN: env "PATH=%t.dir/testroot-gcc/bin:%PATH%" %t.dir/testroot-clang/bin/x86_64-w64-mingw32-clang -no-canonical-prefixes --target=x86_64-w64-mingw32 -m32 -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CLANG_I686 %s
 // CHECK_TESTROOT_CLANG_I686: "{{[^"]+}}/testroot-clang{{/|\\\\}}i686-w64-mingw32{{/|\\\\}}include"
 
 
 // If the user calls clang with a custom literal triple, make sure this maps
 // to sysroots with the matching spelling.
 
-// RUN: %T/testroot-custom-triple/bin/clang -no-canonical-prefixes --target=x86_64-w64-mingw32foo -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CUSTOM_TRIPLE %s
+// RUN: %t.dir/testroot-custom-triple/bin/clang -no-canonical-prefixes --target=x86_64-w64-mingw32foo -rtlib=compiler-rt -stdlib=libstdc++ --sysroot="" -c -### %s 2>&1 | FileCheck -check-prefix=CHECK_TESTROOT_CUSTOM_TRIPLE %s
 // CHECK_TESTROOT_CUSTOM_TRIPLE: "{{[^"]+}}/testroot-custom-triple{{/|\\\\}}x86_64-w64-mingw32foo{{/|\\\\}}include"

--- a/clang/test/Modules/implicit-module-header-maps.cpp
+++ b/clang/test/Modules/implicit-module-header-maps.cpp
@@ -7,7 +7,6 @@
 //
 // RUN: %clang -Rmodule-build -fmodules -fimplicit-modules -fimplicit-module-maps -fmodule-map-file=module.modulemap -fsyntax-only -I hmap -fmodules-cache-path=%t test.cpp
 //
-// RUN: cd %T
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: cd %t

--- a/clang/test/Preprocessor/lang-std.cpp
+++ b/clang/test/Preprocessor/lang-std.cpp
@@ -1,14 +1,14 @@
 /// Test default standards.
 
-// RUN: %clang_cc1 -dM -E %s | grep __cplusplus >%T-cpp-std.txt
-// RUN: FileCheck --input-file %T-cpp-std.txt --check-prefix=CXX17 %s
+// RUN: %clang_cc1 -dM -E %s | grep __cplusplus > %t-cpp-std.txt
+// RUN: FileCheck --input-file %t-cpp-std.txt --check-prefix=CXX17 %s
 
 /// Check that CUDA/HIP uses the same default standards as C++.
 
-// RUN: %clang_cc1 -dM -E -x cuda %s | grep __cplusplus >%T-cuda-std.txt
-// RUN: %clang_cc1 -dM -E -x hip %s | grep __cplusplus >%T-hip-std.txt
-// RUN: diff %T-cpp-std.txt %T-cuda-std.txt
-// RUN: diff %T-cpp-std.txt %T-hip-std.txt
+// RUN: %clang_cc1 -dM -E -x cuda %s | grep __cplusplus > %t-cuda-std.txt
+// RUN: %clang_cc1 -dM -E -x hip %s | grep __cplusplus > %t-hip-std.txt
+// RUN: diff %t-cpp-std.txt %t-cuda-std.txt
+// RUN: diff %t-cpp-std.txt %t-hip-std.txt
 
 // RUN: %clang_cc1 -dM -E -x cuda -std=c++14 %s | FileCheck --check-prefix=CXX14 %s
 // RUN: %clang_cc1 -dM -E -x cuda -std=c++17 %s | FileCheck --check-prefix=CXX17 %s


### PR DESCRIPTION
This patch removes %T from clang lit tests. %T has been deprecated for about seven years and is not reccomended as it is not unique to each test, which can lead to races. This patch is intended to remove usage in tree with the end goal of removing support for %T within lit.