### PR TITLE
[clang] Remove use of %T from crash-report-modules.m

### DIFF
--- a/clang/test/Driver/crash-report-modules.m
+++ b/clang/test/Driver/crash-report-modules.m
@@ -1,15 +1,12 @@
-// FIXME: Instead of %T/crmdir, it would be nice to just use %t, but the
-// filename ran into path length limits for the rm command on some Windows
-// bots.
-// RUN: rm -rf %T/crmdir
-// RUN: mkdir -p %T/crmdir/i %T/crmdir/m
+// RUN: rm -rf %t/crmdir
+// RUN: mkdir -p %t/crmdir/i %t/crmdir/m
 
-// RUN: env FORCE_CLANG_DIAGNOSTICS_CRASH= TMPDIR=%T/crmdir TEMP=%T/crmdir TMP=%T/crmdir \
+// RUN: env FORCE_CLANG_DIAGNOSTICS_CRASH= TMPDIR=%t/crmdir TEMP=%t/crmdir TMP=%t/crmdir \
 // RUN: not %clang -fsyntax-only %s -I %S/Inputs/module -isysroot %/t/i/                 \
-// RUN: -fmodules -fmodules-cache-path=%T/crmdir/m/ -DFOO=BAR 2>&1 | FileCheck %s
+// RUN: -fmodules -fmodules-cache-path=%t/crmdir/m/ -DFOO=BAR 2>&1 | FileCheck %s
 
-// RUN: FileCheck --check-prefix=CHECKSRC %s -input-file %T/crmdir/crash-report-*.m
-// RUN: FileCheck --check-prefix=CHECKSH %s -input-file %T/crmdir/crash-report-*.sh
+// RUN: FileCheck --check-prefix=CHECKSRC %s -input-file %t/crmdir/crash-report-*.m
+// RUN: FileCheck --check-prefix=CHECKSH %s -input-file %t/crmdir/crash-report-*.sh
 // REQUIRES: crash-recovery
 
 // FIXME: This test creates excessively deep directory hierarchies that cause


### PR DESCRIPTION
This patch removes the use of %T from crash-report-modules.m. %T has been deprecated for about seven years, and is to be avoided as it can lead to races between tests.

Posting this one as a separate patch given it was explicitly ported to %T in 5c268f078ddbaa7cc1e9ea0ef658eb90563ff5db. Given 36bb47c70802629df98276ce90b0f8163f959e28 was landed seven years ago to completely disable the test on Windows due to continued failures, I think it should be fine to just leave this test unsupported on Windows.