### PR TITLE
[llvm] Remove uses of %T in tests

### DIFF
--- a/llvm/test/DebugInfo/PDB/obj-globalhash.test
+++ b/llvm/test/DebugInfo/PDB/obj-globalhash.test
@@ -1,15 +1,15 @@
-RUN: yaml2obj %p/Inputs/obj-hashes-1.yaml -o %T/obj-hashes-1.obj
-RUN: yaml2obj %p/Inputs/obj-hashes-2.yaml -o %T/obj-hashes-2.obj
-RUN: echo obj-hashes-1 > %T/hashes-combined.out
-RUN: llvm-pdbutil dump -type-extras %T/obj-hashes-1.obj >> %T/hashes-combined.out
-RUN: echo obj-hashes-2 >> %T/hashes-combined.out
-RUN: llvm-pdbutil dump -type-extras %T/obj-hashes-2.obj >> %T/hashes-combined.out
-RUN: cat %T/hashes-combined.out | FileCheck --check-prefix=CHECK-ONE %s
-RUN: cat %T/hashes-combined.out | FileCheck --check-prefix=CHECK-TWO %s
-RUN: cat %T/hashes-combined.out | FileCheck --check-prefix=CHECK-THREE %s
-RUN: cat %T/hashes-combined.out | FileCheck --check-prefix=CHECK-FOUR %s
-RUN: cat %T/hashes-combined.out | FileCheck --check-prefix=CHECK-FIVE %s
-RUN: cat %T/hashes-combined.out | FileCheck --check-prefix=CHECK-SIX %s
+RUN: yaml2obj %p/Inputs/obj-hashes-1.yaml -o %t.obj-hashes-1.obj
+RUN: yaml2obj %p/Inputs/obj-hashes-2.yaml -o %t.obj-hashes-2.obj
+RUN: echo obj-hashes-1 > %t.hashes-combined.out
+RUN: llvm-pdbutil dump -type-extras %t.obj-hashes-1.obj >> %t.hashes-combined.out
+RUN: echo obj-hashes-2 >> %t.hashes-combined.out
+RUN: llvm-pdbutil dump -type-extras %t.obj-hashes-2.obj >> %t.hashes-combined.out
+RUN: cat %t.hashes-combined.out | FileCheck --check-prefix=CHECK-ONE %s
+RUN: cat %t.hashes-combined.out | FileCheck --check-prefix=CHECK-TWO %s
+RUN: cat %t.hashes-combined.out | FileCheck --check-prefix=CHECK-THREE %s
+RUN: cat %t.hashes-combined.out | FileCheck --check-prefix=CHECK-FOUR %s
+RUN: cat %t.hashes-combined.out | FileCheck --check-prefix=CHECK-FIVE %s
+RUN: cat %t.hashes-combined.out | FileCheck --check-prefix=CHECK-SIX %s
 
 ; char**.  Both the local and global hashes should be the same, since the only
 ; back-references are for simple types which have fixed indices.

--- a/llvm/test/Examples/OrcV2Examples/lljit-with-thinlto-summaries.test
+++ b/llvm/test/Examples/OrcV2Examples/lljit-with-thinlto-summaries.test
@@ -1,15 +1,15 @@
-# RUN: opt -module-summary %p/Inputs/main-mod.ll -o %T/main-mod.bc
-# RUN: opt -module-summary %p/Inputs/foo-mod.ll -o %T/foo-mod.bc
-# RUN: opt -module-summary %p/Inputs/bar-mod.ll -o %T/bar-mod.bc
+# RUN: opt -module-summary %p/Inputs/main-mod.ll -o %t.main-mod.bc
+# RUN: opt -module-summary %p/Inputs/foo-mod.ll -o %t.foo-mod.bc
+# RUN: opt -module-summary %p/Inputs/bar-mod.ll -o %t.bar-mod.bc
 
 # REQUIRES: default_triple
 # UNSUPPORTED: target=powerpc64{{.*}}
 
-# RUN: llvm-lto -thinlto -o %T/main-foo-bar %T/main-mod.bc %T/foo-mod.bc %T/bar-mod.bc
+# RUN: llvm-lto -thinlto -o %t.main-foo-bar %t.main-mod.bc %t.foo-mod.bc %t.bar-mod.bc
 
-# RUN: LLJITWithThinLTOSummaries %T/main-foo-bar.thinlto.bc 2>&1 | FileCheck %s
+# RUN: LLJITWithThinLTOSummaries %t.main-foo-bar.thinlto.bc 2>&1 | FileCheck %s
 
-# CHECK: About to load module: {{.*}}/main-mod.bc
-# CHECK-DAG: About to load module: {{.*}}/foo-mod.bc
-# CHECK-DAG: About to load module: {{.*}}/bar-mod.bc
+# CHECK: About to load module: {{.*}}main-mod.bc
+# CHECK-DAG: About to load module: {{.*}}foo-mod.bc
+# CHECK-DAG: About to load module: {{.*}}bar-mod.bc
 # CHECK: 'main' finished with exit code: 0

--- a/llvm/test/ExecutionEngine/JITLink/x86-64/MachO_foo-in-weak-dylib.s
+++ b/llvm/test/ExecutionEngine/JITLink/x86-64/MachO_foo-in-weak-dylib.s
@@ -1,8 +1,8 @@
-# RUN: yaml2obj -o %T/libfoo.dylib %S/Inputs/libFooUniversalDylib.yaml
+# RUN: yaml2obj -o %t.libfoo.dylib %S/Inputs/libFooUniversalDylib.yaml
 # RUN: llvm-mc -triple=x86_64-apple-macosx10.9 -filetype=obj \
-# RUN:     -o %T/MachO_foo-in-weak-dylib.o %s
-# RUN: llvm-jitlink -noexec %T/MachO_foo-in-weak-dylib.o \
-# RUN:     -weak_library %T/libfoo.dylib
+# RUN:     -o %t.MachO_foo-in-weak-dylib.o %s
+# RUN: llvm-jitlink -noexec %t.MachO_foo-in-weak-dylib.o \
+# RUN:     -weak_library %t.libfoo.dylib
 #
 # Check that -weak_library supports universal binaries.
 

--- a/llvm/test/MC/AArch64/ELF_ARM64_large-relocations.s
+++ b/llvm/test/MC/AArch64/ELF_ARM64_large-relocations.s
@@ -1,7 +1,8 @@
-# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %T/large-reloc.o %s
-# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
-# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %T/large-reloc.o %s
-# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %T/large-reloc.o
+# RUN: mkdir -p %t.dir/dir
+# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %t.dir/large-reloc.o %s
+# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %t.dir/large-reloc.o
+# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %t.dir/large-reloc.o %s
+# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %t.dir/large-reloc.o
 
         .text
         .globl  g

--- a/llvm/test/MC/AArch64/ELF_ARM64_large-relocations.s
+++ b/llvm/test/MC/AArch64/ELF_ARM64_large-relocations.s
@@ -1,8 +1,8 @@
-# RUN: mkdir -p %t.dir/dir
-# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o %t.dir/large-reloc.o %s
-# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %t.dir/large-reloc.o
-# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o %t.dir/large-reloc.o %s
-# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s %t.dir/large-reloc.o
+# RUN: rm -rf %t && mkdir %t && cd %t
+# RUN: llvm-mc -triple=arm64-none-linux-gnu -large-code-model -filetype=obj -o large-reloc.o %s
+# RUN: llvm-rtdyld -triple=arm64-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s large-reloc.o
+# RUN: llvm-mc -triple=aarch64_be-none-linux-gnu -large-code-model -filetype=obj -o large-reloc.o %s
+# RUN: llvm-rtdyld -triple=aarch64_be-none-linux-gnu -verify -map-section large-reloc.o,.eh_frame=0x10000 -map-section large-reloc.o,.text=0xffff000000000000 -check=%s large-reloc.o
 
         .text
         .globl  g

--- a/llvm/test/Object/archive-darwin-duplicates.test
+++ b/llvm/test/Object/archive-darwin-duplicates.test
@@ -4,13 +4,13 @@ The two members with the duplicated name "test.o" must have unique
 non-zero timestamps, while baz.o, being unique, remains a zero
 timestamp.
 
-RUN: mkdir -p %T/sub1
-RUN: printf test > %T/test.o
-RUN: printf sub1/test > %T/sub1/test.o
-RUN: printf baz > %T/baz.o
+RUN: mkdir -p %t.dir/sub1
+RUN: printf test > %t.dir/test.o
+RUN: printf sub1/test > %t.dir/sub1/test.o
+RUN: printf baz > %t.dir/baz.o
 
 RUN: rm -f %t.a
-RUN: llvm-ar --format=darwin rcs %t.a %T/sub1/test.o %T/test.o %T/baz.o
+RUN: llvm-ar --format=darwin rcs %t.a %t.dir/sub1/test.o %t.dir/test.o %t.dir/baz.o
 RUN: FileCheck -strict-whitespace %s < %t.a
 
 CHECK:#1/12           1           0     0     644     28        `

--- a/llvm/test/TableGen/GlobalISelEmitter/ContextlessPredicates.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/ContextlessPredicates.td
@@ -1,7 +1,7 @@
-// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=false %s -o %T/context-non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK_NOPT -input-file=%T/context-non-optimized.cpp
-// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=true  %s -o %T/context-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK_OPT -input-file=%T/context-optimized.cpp
+// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=false %s -o %t.context-non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK_NOPT -input-file=%t.context-non-optimized.cpp
+// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=true  %s -o %t.context-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK_OPT -input-file=%t.context-optimized.cpp
 
 
 

--- a/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/GlobalISelEmitter.td
@@ -1,26 +1,26 @@
-// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=false %s -o %T/non-optimized.cpp
-// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=true  %s -o %T/optimized.cpp
-// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common %s -o %T/default.cpp
+// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=false %s -o %t.non-optimized.cpp
+// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=true  %s -o %t.optimized.cpp
+// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common %s -o %t.default.cpp
 
-// RUN: FileCheck %s --check-prefixes=CHECK,R19C,R19N -input-file=%T/non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK,R19C,R19O -input-file=%T/optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R19C,R19N -input-file=%t.non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R19C,R19O -input-file=%t.optimized.cpp
 
-// RUN: FileCheck %s --check-prefixes=CHECK,R21C,R21N -input-file=%T/non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK,R21C,R21O -input-file=%T/optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R21C,R21N -input-file=%t.non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R21C,R21O -input-file=%t.optimized.cpp
 
-// RUN: FileCheck %s --check-prefixes=CHECK,R20C,R20N -input-file=%T/non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK,R20C,R20O -input-file=%T/optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R20C,R20N -input-file=%t.non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R20C,R20O -input-file=%t.optimized.cpp
 
-// RUN: FileCheck %s --check-prefixes=CHECK,R00C,R00N -input-file=%T/non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK,R00C,R00O -input-file=%T/optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R00C,R00N -input-file=%t.non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R00C,R00O -input-file=%t.optimized.cpp
 
-// RUN: FileCheck %s --check-prefixes=CHECK,R01C,R01N -input-file=%T/non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK,R01C,R01O -input-file=%T/optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R01C,R01N -input-file=%t.non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R01C,R01O -input-file=%t.optimized.cpp
 
-// RUN: FileCheck %s --check-prefixes=CHECK,R02C,R02N,NOOPT -input-file=%T/non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK,R02C,R02O       -input-file=%T/optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R02C,R02N,NOOPT -input-file=%t.non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK,R02C,R02O       -input-file=%t.optimized.cpp
 
-// RUN: diff %T/default.cpp %T/optimized.cpp
+// RUN: diff %t.default.cpp %t.optimized.cpp
 
 include "llvm/Target/Target.td"
 include "GlobalISelEmitterCommon.td"

--- a/llvm/test/TableGen/GlobalISelEmitter/HwModes.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/HwModes.td
@@ -1,5 +1,5 @@
-// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=false %s -o %T/hwmode-non-optimized.cpp
-// RUN: FileCheck %s --check-prefixes=CHECK -input-file=%T/hwmode-non-optimized.cpp
+// RUN: llvm-tblgen -gen-global-isel -I %p/../../../include -I %p/../Common -optimize-match-table=false %s -o %t.hwmode-non-optimized.cpp
+// RUN: FileCheck %s --check-prefixes=CHECK -input-file=%t.hwmode-non-optimized.cpp
 
 include "llvm/Target/Target.td"
 

--- a/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/amdgpu-no-merge-comments.test
+++ b/llvm/test/tools/UpdateTestChecks/update_llc_test_checks/amdgpu-no-merge-comments.test
@@ -3,6 +3,7 @@
 
 # Replace llc with cat, so we can simulate hypothetical output without actually running llc.
 # Copy the simulated output to the temporary directory.
-# RUN: cp -f %S/Inputs/amdgpu_no_merge_comments-O0.s %T/ && cp -f %S/Inputs/amdgpu_no_merge_comments-O3.s %T/
-# RUN: cp -f %S/Inputs/amdgpu_no_merge_comments.ll %t.ll && %update_llc_test_checks --llc-binary cat %t.ll
-# RUN: diff -u %S/Inputs/amdgpu_no_merge_comments.ll.expected %t.ll
+# RUN: mkdir -p %t.dir
+# RUN: cp -f %S/Inputs/amdgpu_no_merge_comments-O0.s %t.dir/ && cp -f %S/Inputs/amdgpu_no_merge_comments-O3.s %t.dir/
+# RUN: cp -f %S/Inputs/amdgpu_no_merge_comments.ll %t.dir/file.ll && %update_llc_test_checks --llc-binary cat %t.dir/file.ll
+# RUN: diff -u %S/Inputs/amdgpu_no_merge_comments.ll.expected %t.dir/file.ll

--- a/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
@@ -1,13 +1,13 @@
-RUN: mkdir -p %t.dir
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
-RUN: llvm-readobj --sections --section-data %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
-RUN: llvm-dwarfdump --show-section-sizes %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
+RUN: rm -rf %t && mkdir %t
+RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
+RUN: llvm-readobj --sections --section-data %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
+RUN: llvm-dwarfdump --show-section-sizes %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 
-RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
-RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
-RUN: llvm-readobj --sections --section-data %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
-RUN: llvm-dwarfdump --show-section-sizes %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
+RUN: llvm-readobj --sections --section-data %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
+RUN: llvm-dwarfdump --show-section-sizes %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 
 
 The tested object file has been created by the dummy Swift code:
@@ -28,5 +28,5 @@ READOBJ-NEXT: |.|
 
 DWARFDUMP: __swift_ast
 
-RUN: dsymutil -s %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
+RUN: dsymutil -s %t/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
 NAST-NOT: N_AST

--- a/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
+++ b/llvm/test/tools/dsymutil/X86/swift-ast-x86_64.test
@@ -1,12 +1,13 @@
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
-RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
-RUN: llvm-readobj --sections --section-data %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
-RUN: llvm-dwarfdump --show-section-sizes %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
+RUN: mkdir -p %t.dir
+RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
+RUN: llvm-readobj --sections --section-data %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
+RUN: llvm-dwarfdump --show-section-sizes %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 
-RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
-RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %T/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
-RUN: llvm-readobj --sections --section-data %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
-RUN: llvm-dwarfdump --show-section-sizes %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose -no-swiftmodule-timestamp | FileCheck %s --check-prefix=DSYMUTIL
+RUN: dsymutil --linker parallel -oso-prepend-path %p/.. %p/../Inputs/swift-ast.macho.x86_64 -o %t.dir/swift-ast.dSYM -verbose | FileCheck %s --check-prefix=DSYMUTIL
+RUN: llvm-readobj --sections --section-data %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=READOBJ
+RUN: llvm-dwarfdump --show-section-sizes %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=DWARFDUMP
 
 
 The tested object file has been created by the dummy Swift code:
@@ -27,5 +28,5 @@ READOBJ-NEXT: |.|
 
 DWARFDUMP: __swift_ast
 
-RUN: dsymutil -s %T/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
+RUN: dsymutil -s %t.dir/swift-ast.dSYM/Contents/Resources/DWARF/swift-ast.macho.x86_64 | FileCheck %s --check-prefix=NAST
 NAST-NOT: N_AST

--- a/llvm/test/tools/llvm-dwarfdump/dump_dwo.test
+++ b/llvm/test/tools/llvm-dwarfdump/dump_dwo.test
@@ -1,9 +1,10 @@
 ## Check that llvm-dwarfdump works when dumping .o files with .dwo files.
 
-# RUN: yaml2obj %p/Inputs/dump_dwo.o.yaml -o %T/dump_dwo.o
-# RUN: yaml2obj %p/Inputs/dump_dwo.dwo.yaml -o %T/dump_dwo.dwo
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %p/Inputs/dump_dwo.o.yaml -o %t.dir/dump_dwo.o
+# RUN: yaml2obj %p/Inputs/dump_dwo.dwo.yaml -o %t.dir/dump_dwo.dwo
 ## We need to be in the same directory so we can find .dwo file
-# RUN: cd %T
+# RUN: cd %t.dir
 # RUN: llvm-dwarfdump --dwo dump_dwo.o | FileCheck %s
 # RUN: llvm-dwarfdump --dwo --name int --name char dump_dwo.o | FileCheck %s --check-prefix=NAMES
 # RUN: llvm-dwarfdump --name int --name char dump_dwo.o | FileCheck %s --check-prefix=NAMES_NO_DWO

--- a/llvm/test/tools/llvm-libtool-darwin/L-and-l.test
+++ b/llvm/test/tools/llvm-libtool-darwin/L-and-l.test
@@ -1,112 +1,113 @@
 ## This test checks that -l and -L options work correctly.
 
-# RUN: yaml2obj %S/Inputs/input1.yaml -o %t-input1.o
-# RUN: yaml2obj %S/Inputs/input2.yaml -o %t-input2.o
+# RUN: mkdir -p %t.dir
+# RUN: yaml2obj %S/Inputs/input1.yaml -o %t.dir/input1.o
+# RUN: yaml2obj %S/Inputs/input2.yaml -o %t.dir/input2.o
 
 ## Check that the library is recognised when it ends with '.o':
-# RUN: llvm-libtool-darwin -static -o %t.lib -l%basename_t.tmp-input1.o -l%basename_t.tmp-input2.o -L%T
+# RUN: llvm-libtool-darwin -static -o %t.lib -linput1.o -linput2.o -L%t.dir
 # RUN: llvm-ar t %t.lib | \
-# RUN:   FileCheck %s --check-prefix=CHECK-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp
+# RUN:   FileCheck %s --check-prefix=CHECK-NAMES --implicit-check-not={{.}}
 # RUN: llvm-nm --print-armap %t.lib | \
-# RUN:   FileCheck %s --check-prefix=CHECK-SYMBOLS -DPREFIX=%basename_t.tmp --match-full-lines
+# RUN:   FileCheck %s --check-prefix=CHECK-SYMBOLS --match-full-lines
 
-# CHECK-NAMES:      [[PREFIX]]-input1.o
-# CHECK-NAMES-NEXT: [[PREFIX]]-input2.o
+# CHECK-NAMES:      input1.o
+# CHECK-NAMES-NEXT: input2.o
 
 # CHECK-SYMBOLS:      Archive map
-# CHECK-SYMBOLS-NEXT: _symbol1 in [[PREFIX]]-input1.o
-# CHECK-SYMBOLS-NEXT: _symbol2 in [[PREFIX]]-input2.o
+# CHECK-SYMBOLS-NEXT: _symbol1 in input1.o
+# CHECK-SYMBOLS-NEXT: _symbol2 in input2.o
 # CHECK-SYMBOLS-EMPTY:
 
 ## Check that the library is recognised when prepended with 'lib' and appended with '.a':
 # RUN: rm -rf %t/dirname && mkdir -p %t/dirname
-# RUN: llvm-ar cr %t/dirname/libinput2.a %t-input2.o
+# RUN: llvm-ar cr %t/dirname/libinput2.a %t.dir/input2.o
 
 # RUN: llvm-libtool-darwin -static -o %t.lib -linput2 -L%t/dirname
 # RUN: llvm-ar t %t.lib | \
-# RUN:   FileCheck %s --check-prefix=SINGLE-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp
+# RUN:   FileCheck %s --check-prefix=SINGLE-NAMES --implicit-check-not={{.}}
 # RUN: llvm-nm --print-armap %t.lib | \
-# RUN:   FileCheck %s --check-prefix=SINGLE-SYMBOLS -DPREFIX=%basename_t.tmp --match-full-lines
+# RUN:   FileCheck %s --check-prefix=SINGLE-SYMBOLS --match-full-lines
 
-# SINGLE-NAMES: [[PREFIX]]-input2.o
+# SINGLE-NAMES: input2.o
 
 # SINGLE-SYMBOLS:      Archive map
-# SINGLE-SYMBOLS-NEXT: _symbol2 in [[PREFIX]]-input2.o
+# SINGLE-SYMBOLS-NEXT: _symbol2 in input2.o
 # SINGLE-SYMBOLS-EMPTY:
 
 ## -l and -L option specified multiple times:
 # RUN: rm -rf %t/otherDirname && mkdir -p %t/otherDirname
-# RUN: llvm-ar cr %t/otherDirname/libinput1.a %t-input1.o
+# RUN: llvm-ar cr %t/otherDirname/libinput1.a %t.dir/input1.o
 
 # RUN: llvm-libtool-darwin -static -o %t.lib -linput2 -linput1 -L%t/dirname -L%t/otherDirname
 # RUN: llvm-ar t %t.lib | \
-# RUN:   FileCheck %s --check-prefix=OTHER-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp
+# RUN:   FileCheck %s --check-prefix=OTHER-NAMES --implicit-check-not={{.}}
 # RUN: llvm-nm --print-armap %t.lib | \
-# RUN:   FileCheck %s --check-prefix=OTHER-SYMBOLS -DPREFIX=%basename_t.tmp --match-full-lines
+# RUN:   FileCheck %s --check-prefix=OTHER-SYMBOLS --match-full-lines
 
 ## Check it is possible to pass arguments to -l and -L separated from the option
 ## and the options specified multiple times:
 # RUN: rm -rf %t/otherDirname && mkdir -p %t/otherDirname
-# RUN: llvm-ar cr %t/otherDirname/libinput1.a %t-input1.o
+# RUN: llvm-ar cr %t/otherDirname/libinput1.a %t.dir/input1.o
 
 # RUN: llvm-libtool-darwin -static -o %t.lib -l input2 -l input1 -L %t/dirname -L %t/otherDirname
 # RUN: llvm-ar t %t.lib | \
-# RUN:   FileCheck %s --check-prefix=OTHER-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp
+# RUN:   FileCheck %s --check-prefix=OTHER-NAMES --implicit-check-not={{.}}
 # RUN: llvm-nm --print-armap %t.lib | \
-# RUN:   FileCheck %s --check-prefix=OTHER-SYMBOLS -DPREFIX=%basename_t.tmp --match-full-lines
+# RUN:   FileCheck %s --check-prefix=OTHER-SYMBOLS --match-full-lines
 
-# OTHER-NAMES:      [[PREFIX]]-input2.o
-# OTHER-NAMES-NEXT: [[PREFIX]]-input1.o
+# OTHER-NAMES:      input2.o
+# OTHER-NAMES-NEXT: input1.o
 
 # OTHER-SYMBOLS:      Archive map
-# OTHER-SYMBOLS-NEXT: _symbol2 in [[PREFIX]]-input2.o
-# OTHER-SYMBOLS-NEXT: _symbol1 in [[PREFIX]]-input1.o
+# OTHER-SYMBOLS-NEXT: _symbol2 in input2.o
+# OTHER-SYMBOLS-NEXT: _symbol1 in input1.o
 # OTHER-SYMBOLS-EMPTY:
 
 ## Check that if multiple directories specified with -L have the same named file
 ## in them, the file from the first directory is selected.
-# RUN: llvm-ar cr %t/otherDirname/libinput2.a %t-input1.o
+# RUN: llvm-ar cr %t/otherDirname/libinput2.a %t.dir/input1.o
 
 # RUN: llvm-libtool-darwin -static -o %t.lib -linput2 -L%t/dirname -L%t/otherDirname
 # RUN: llvm-ar t %t.lib | \
-# RUN:   FileCheck %s --check-prefix=SINGLE-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp
+# RUN:   FileCheck %s --check-prefix=SINGLE-NAMES --implicit-check-not={{.}}
 # RUN: llvm-nm --print-armap %t.lib | \
-# RUN:   FileCheck %s --check-prefix=SINGLE-SYMBOLS -DPREFIX=%basename_t.tmp --match-full-lines
+# RUN:   FileCheck %s --check-prefix=SINGLE-SYMBOLS --match-full-lines
 
 ## Check that if two different files with the same names are explicitly
 ## specified, the command gives a warning.
-# RUN: cp %t-input2.o %t/dirname
+# RUN: cp %t.dir/input2.o %t/dirname
 # RUN: llvm-libtool-darwin -static -o %t.lib \
-# RUN:   %t/dirname/%basename_t.tmp-input2.o %t-input2.o 2>&1 | \
+# RUN:   %t/dirname/input2.o %t.dir/input2.o 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=DUPLICATE-INPUT \
-# RUN:     -DFILE=%basename_t.tmp-input2.o \
-# RUN:     -DINPUTA=%t/dirname/%basename_t.tmp-input2.o \
-# RUN:     -DINPUTB=%t-input2.o
+# RUN:     -DFILE=input2.o \
+# RUN:     -DINPUTA=%t/dirname/input2.o \
+# RUN:     -DINPUTB=%t.dir/input2.o
 
 # DUPLICATE-INPUT:     warning: file '[[FILE]]' was specified multiple times.
 # DUPLICATE-INPUT-DAG: [[INPUTA]]
 # DUPLICATE-INPUT-DAG: [[INPUTB]]
 
 ## -l option combined with an input file:
-# RUN: llvm-libtool-darwin -static -o %t.lib %t-input1.o -linput2 -L%t/dirname
+# RUN: llvm-libtool-darwin -static -o %t.lib %t.dir/input1.o -linput2 -L%t/dirname
 # RUN: llvm-ar t %t.lib | \
-# RUN:   FileCheck %s --check-prefix=CHECK-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp
+# RUN:   FileCheck %s --check-prefix=CHECK-NAMES --implicit-check-not={{.}}
 # RUN: llvm-nm --print-armap %t.lib | \
-# RUN:   FileCheck %s --check-prefix=CHECK-SYMBOLS -DPREFIX=%basename_t.tmp --match-full-lines
+# RUN:   FileCheck %s --check-prefix=CHECK-SYMBOLS --match-full-lines
 
 ## Specify the same file with a -l option and an input file:
 # RUN: rm -rf %t/copy
 # RUN: mkdir -p %t/copy
-# RUN: cp %t-input1.o %t/copy
+# RUN: cp %t.dir/input1.o %t/copy
 # RUN: llvm-libtool-darwin -static -o %t.lib \
-# RUN:   %t/copy/%basename_t.tmp-input1.o -l%basename_t.tmp-input1.o -L%t/copy 2>&1 | \
-# RUN:   FileCheck %s --check-prefix=DUPLICATE-L-INPUT -DFILE=%basename_t.tmp-input1.o
+# RUN:   %t/copy/input1.o -linput1.o -L%t/copy 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=DUPLICATE-L-INPUT -DFILE=input1.o
 
 ## Specify same -l option twice:
-# RUN: llvm-libtool-darwin -static -o %t.lib -l%basename_t.tmp-input1.o \
-# RUN:  -l%basename_t.tmp-input1.o -L%t/copy 2>&1 | \
+# RUN: llvm-libtool-darwin -static -o %t.lib -linput1.o \
+# RUN:  -linput1.o -L%t/copy 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=DUPLICATE-L-INPUT \
-# RUN:     -DFILE=%basename_t.tmp-input1.o
+# RUN:     -DFILE=input1.o
 
 # DUPLICATE-L-INPUT:     warning: file '[[FILE]]' was specified multiple times.
 
@@ -123,11 +124,11 @@
 
 ## Check that an error is thrown when the input library cannot be found
 ## (since 'lib' and '.a' are added):
-# RUN: llvm-ar cr %t/dirname/file-does-exist %t-input1.o
+# RUN: llvm-ar cr %t/dirname/file-does-exist %t.dir/input1.o
 # RUN: not llvm-libtool-darwin -static -o %t.lib -lfile-does-exist -L%t/dirname 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=NOT-FOUND -DFILE=libfile-does-exist.a
 
-# RUN: llvm-ar cr %t/dirname/libfile-does-exist.a %t-input1.o
+# RUN: llvm-ar cr %t/dirname/libfile-does-exist.a %t.dir/input1.o
 # RUN: not llvm-libtool-darwin -static -o %t.lib -llibfile-does-exist.a -L%t/dirname 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=NOT-FOUND -DFILE=liblibfile-does-exist.a.a
 
@@ -145,13 +146,13 @@
 # RUN:   FileCheck %s --check-prefix=NOT-VALID -DFILE=libnot-valid.a
 
 ## Check that 'lib' and '.a' are not added to a file ending in '.o':
-# RUN: llvm-ar cr %t/dirname/libfoo.o.a %t-input1.o
+# RUN: llvm-ar cr %t/dirname/libfoo.o.a %t.dir/input1.o
 # RUN: not llvm-libtool-darwin -static -o %t.lib -lfoo.o -L%t/dirname 2>&1 | \
 # RUN:   FileCheck %s --check-prefix=NOT-FOUND -DFILE=foo.o
 
 ## Check that 'lib' and '.a' are added to a file ending in any other extension
 ## beside '.o' (e.g. '.ext'):
-# RUN: llvm-ar cr %t/dirname/libbar.ext.a %t-input2.o
+# RUN: llvm-ar cr %t/dirname/libbar.ext.a %t.dir/input2.o
 # RUN: llvm-libtool-darwin -static -o %t.lib -lbar.ext -L%t/dirname
 # RUN: llvm-ar t %t.lib | \
 # RUN:   FileCheck %s --check-prefix=SINGLE-NAMES --implicit-check-not={{.}} -DPREFIX=%basename_t.tmp

--- a/llvm/test/tools/llvm-objcopy/COFF/dump-section.test
+++ b/llvm/test/tools/llvm-objcopy/COFF/dump-section.test
@@ -4,7 +4,7 @@
 # RUN: llvm-objcopy --dump-section .text.f=%t.txt %t.obj
 # RUN: od -t x1 %t.txt | FileCheck %s --ignore-case -check-prefix CHECK-TEXT-F
 # RUN: not llvm-objcopy --dump-section non-existent=/dev/null %t.obj 2>&1 | FileCheck %s -check-prefix CHECK-NO-SECTION
-# RUN: not llvm-objcopy --dump-section .text=%T %t.obj 2>&1 | FileCheck -DOBJ=%t.obj -DMSG=%errc_EISDIR %s -check-prefix CHECK-INVALID-DESTINATION
+# RUN: not llvm-objcopy --dump-section .text=%S %t.obj 2>&1 | FileCheck -DOBJ=%t.obj -DMSG=%errc_EISDIR %s -check-prefix CHECK-INVALID-DESTINATION
 
 # CHECK-EMPTY-SIZE: 0
 


### PR DESCRIPTION
This patch removes all uses of %T from within LLVM tests. %T has been deprecated for about seven years and use is not advised given it is not unique per test and can thus lead to races. The goal of this is to eventually remove support for %T from lit.