### PR TITLE
[Analysis] Avoid creating a temporary instance of std::string (NFC)

### DIFF
--- a/clang/lib/Analysis/RetainSummaryManager.cpp
+++ b/clang/lib/Analysis/RetainSummaryManager.cpp
@@ -147,8 +147,7 @@ static bool isSubclass(const Decl *D,
 
 static bool isExactClass(const Decl *D, StringRef ClassName) {
   using namespace ast_matchers;
-  DeclarationMatcher sameClassM =
-      cxxRecordDecl(hasName(std::string(ClassName)));
+  DeclarationMatcher sameClassM = cxxRecordDecl(hasName(ClassName));
   return !(match(sameClassM, *D, D->getASTContext()).empty());
 }
 


### PR DESCRIPTION
hasName takes StringRef, so we don't need to create a temporary
instance of std::string.
