### PR TITLE
[lldb] Ensure that TestMemoryCache.py reads allocated memory

### DIFF
--- a/lldb/test/API/functionalities/memory/cache/main.cpp
+++ b/lldb/test/API/functionalities/memory/cache/main.cpp
@@ -1,5 +1,11 @@
-int main ()
+int test()
 {
     int my_ints[] = {0x42};
     return 0; // Set break point at this line.
+}
+
+int main ()
+{
+    int dummy[100];
+    return test();
 }

--- a/lldb/test/API/functionalities/memory/cache/main.cpp
+++ b/lldb/test/API/functionalities/memory/cache/main.cpp
@@ -1,11 +1,9 @@
-int test()
-{
-    int my_ints[] = {0x42};
-    return 0; // Set break point at this line.
+int test() {
+  int my_ints[] = {0x42};
+  return 0; // Set break point at this line.
 }
 
-int main ()
-{
-    int dummy[100];
-    return test();
+int main() {
+  int dummy[100];
+  return test();
 }


### PR DESCRIPTION
The test reads 400 bytes of memory above the local variable. If the stack is shallow, this can reach non-allocated space, resulting in a test failure.