### PR TITLE
[libclc] Refine id in async_work_group_copy STRIDED_COPY

### DIFF
--- a/libclc/opencl/lib/generic/async/async_work_group_strided_copy.inc
+++ b/libclc/opencl/lib/generic/async/async_work_group_strided_copy.inc
@@ -8,8 +8,8 @@
 
 #define STRIDED_COPY(dst, src, num_gentypes, dst_stride, src_stride)           \
   size_t size = get_local_size(0) * get_local_size(1) * get_local_size(2);     \
-  size_t id = (get_local_size(1) * get_local_size(2) * get_local_id(0)) +      \
-              (get_local_size(2) * get_local_id(1)) + get_local_id(2);         \
+  size_t id = (get_local_size(0) * get_local_size(1) * get_local_id(2)) +      \
+              (get_local_size(0) * get_local_id(1)) + get_local_id(0);         \
   size_t i;                                                                    \
                                                                                \
   for (i = id; i < num_gentypes; i += size) {                                  \


### PR DESCRIPTION
Move id first along 0th dimension to achieve coalesced memory access when stride is 1.