### PR TITLE
[SPIRV] Addition of entry-point-interfaces.ll, get_global_size.ll, layout.ll test files

### DIFF
--- a/llvm/test/CodeGen/SPIRV/entry-point-interfaces.ll
+++ b/llvm/test/CodeGen/SPIRV/entry-point-interfaces.ll
@@ -1,0 +1,31 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpEntryPoint Kernel %[[#Func:]] "test" %[[#Interface1:]] %[[#Interface2:]] %[[#Interface3:]] %[[#Interface4:]]
+; CHECK-DAG: OpName %[[#Func]] "test"
+; CHECK-DAG: OpName %[[#Interface1]] "var"
+; CHECK-DAG: OpName %[[#Interface3]] "var2"
+; CHECK-DAG: OpName %[[#Interface2]] "var.const"
+; CHECK-DAG: OpName %[[#Interface4]] "var2.const"
+; CHECK-DAG: %[[#TypeInt:]] = OpTypeInt  32 0
+; CHECK-DAG: %[[#Const1:]] = OpConstant %[[#TypeInt]] 1
+; CHECK-DAG: %[[#Const2:]] = OpConstant %[[#TypeInt]] 3
+
+; CHECK: %[[#Interface1]] = OpVariable %[[#]] UniformConstant %[[#Const1]]
+; CHECK: %[[#Interface3]] = OpVariable %[[#]] UniformConstant %[[#Const2]]
+; CHECK: %[[#Interface2]] = OpVariable %[[#]] UniformConstant %[[#Const1]]
+; CHECK: %[[#Interface4]] = OpVariable %[[#]] UniformConstant %[[#Const2]]
+
+@var = dso_local addrspace(2) constant i32 1, align 4
+@var2 = dso_local addrspace(2) constant i32 3, align 4
+@var.const = private unnamed_addr addrspace(2) constant i32 1, align 4
+@var2.const = private unnamed_addr addrspace(2) constant i32 3, align 4
+
+define dso_local spir_kernel void @test() {
+entry:
+  %0 = load i32, ptr addrspace(2) @var.const, align 4
+  %1 = load i32, ptr addrspace(2) @var2.const, align 4
+  %mul = mul nsw i32 %0, %1
+  %mul1 = mul nsw i32 %mul, 2
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/get_global_size.ll
+++ b/llvm/test/CodeGen/SPIRV/get_global_size.ll
@@ -1,0 +1,50 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: %[[#int32:]] = OpTypeInt 32 0
+; CHECK: %[[#int64:]] = OpTypeInt 64 0
+; CHECK: %[[#vec3:]] = OpTypeVector %[[#int64]] 3
+; CHECK: %[[#ptr_input_vec3:]] = OpTypePointer Input %[[#vec3]]
+; CHECK: %[[#global_size_var:]] = OpVariable %[[#ptr_input_vec3]] Input
+
+; CHECK: %[[#load_gs1:]] = OpLoad %[[#vec3]] %[[#global_size_var]] Aligned 1
+; CHECK: %[[#extract3:]] = OpCompositeExtract %[[#int64]] %[[#load_gs1]] 0
+
+; CHECK: %[[#bitcast1:]] = OpBitcast %[[#]] %[[#]]
+; CHECK: %[[#load_out1:]] = OpLoad %[[#]] %[[#bitcast1]] Aligned 8
+; CHECK: %[[#gep1:]] = OpInBoundsPtrAccessChain %[[#]] %[[#load_out1]] %[[#]]
+; CHECK: OpStore %[[#gep1]] %[[#extract3]] Aligned 8
+
+; CHECK: %[[#load_param_x:]] = OpLoad %[[#int32]] %[[#]]
+; CHECK: %[[#load_gs2:]] = OpLoad %[[#vec3]] %[[#global_size_var]] Aligned 1
+; CHECK: %[[#dyn_extract:]] = OpVectorExtractDynamic %[[#int64]] %[[#load_gs2]] %[[#load_param_x]]
+; CHECK: %[[#cmp:]] = OpULessThan %[[#]] %[[#load_param_x]] %[[#]]
+; CHECK: %[[#select2:]] = OpSelect %[[#int64]] %[[#cmp]] %[[#dyn_extract]] %[[#]]
+; CHECK: %[[#bitcast2:]] = OpBitcast %[[#]] %[[#]]
+; CHECK: %[[#load_out2:]] = OpLoad %[[#]] %[[#bitcast2]] Aligned 8
+; CHECK: %[[#gep2:]] = OpInBoundsPtrAccessChain %[[#]] %[[#load_out2]] %[[#]]
+; CHECK: OpStore %[[#gep2]] %[[#select2]] Aligned 8
+
+define dso_local spir_kernel void @ggs(ptr noundef align 8 %out, i32 noundef %x) {
+entry:
+  %out.addr = alloca ptr, align 8
+  %x.addr = alloca i32, align 4
+  store ptr %out, ptr %out.addr, align 8
+  store i32 %x, ptr %x.addr, align 4
+  %call = call i64 @_Z15get_global_sizej(i32 noundef 0)
+  %0 = load ptr, ptr %out.addr, align 8
+  %arrayidx = getelementptr inbounds i64, ptr %0, i64 0
+  store i64 %call, ptr %arrayidx, align 8
+  %call1 = call i64 @_Z15get_global_sizej(i32 noundef 3)
+  %1 = load ptr, ptr %out.addr, align 8
+  %arrayidx2 = getelementptr inbounds i64, ptr %1, i64 1
+  store i64 %call1, ptr %arrayidx2, align 8
+  %2 = load i32, ptr %x.addr, align 4
+  %call3 = call i64 @_Z15get_global_sizej(i32 noundef %2)
+  %3 = load ptr, ptr %out.addr, align 8
+  %arrayidx4 = getelementptr inbounds i64, ptr %3, i64 2
+  store i64 %call3, ptr %arrayidx4, align 8
+  ret void
+}
+
+declare i64 @_Z15get_global_sizej(i32 noundef)

--- a/llvm/test/CodeGen/SPIRV/layout.ll
+++ b/llvm/test/CodeGen/SPIRV/layout.ll
@@ -1,0 +1,84 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpCapability Kernel
+; CHECK: OpCapability Addresses
+; CHECK: OpCapability GenericPointer
+; CHECK: OpCapability Int64
+; CHECK: OpCapability Int8
+; CHECK: OpCapability Linkage
+
+; CHECK: OpExtInstImport "OpenCL.std"
+; CHECK: OpMemoryModel Physical64 OpenCL
+; CHECK: OpEntryPoint Kernel %[[#]] "foo" %[[#]]
+; CHECK: OpSource OpenCL_C 200000
+
+; CHECK-DAG: OpName %[[#]]
+; CHECK-DAG: OpDecorate %[[#]]
+
+
+; CHECK: %[[#I8:]] = OpTypeInt 8 0
+; CHECK: %[[#PTR_CW_I8:]] = OpTypePointer CrossWorkgroup %[[#I8]]
+; CHECK: %[[#I32:]] = OpTypeInt 32 0
+; CHECK: %[[#VEC4:]] = OpTypeVector %[[#I32]] 4
+; CHECK: %[[#VOID:]] = OpTypeVoid
+; CHECK: %[[#FUNC_TYPE0:]] = OpTypeFunction %[[#VOID]] %[[#PTR_CW_I8]] %[[#VEC4]]
+; CHECK: %[[#FUNC_TYPE1:]] = OpTypeFunction %[[#VOID]] %[[#PTR_CW_I8]]
+; CHECK: %[[#VEC3:]] = OpTypeVector %[[#I32]] 3
+; CHECK: %[[#FUNC_TYPE2:]] = OpTypeFunction %[[#VOID]] %[[#PTR_CW_I8]] %[[#VEC3]]
+; CHECK: %[[#PTR_GEN_I8:]] = OpTypePointer Generic %[[#I8]]
+; CHECK: %[[#STRUCT_B:]] = OpTypeStruct %[[#I32]] %[[#PTR_GEN_I8]]
+; CHECK: %[[#STRUCT_C:]] = OpTypeStruct %[[#I32]] %[[#STRUCT_B]]
+; CHECK: %[[#STRUCT_A:]] = OpTypeStruct %[[#I32]] %[[#STRUCT_C]]
+; CHECK: %[[#F32:]] = OpTypeFloat 32
+; CHECK: %[[#CONST_2:]] = OpConstant %[[#I32]] 2
+; CHECK: %[[#ARRAY_F:]] = OpTypeArray %[[#F32]] %[[#CONST_2]]
+; CHECK: %[[#ARRAY_I:]] = OpTypeArray %[[#I32]] %[[#CONST_2]]
+; CHECK: %[[#PTR_CW_STRUCT_A:]] = OpTypePointer CrossWorkgroup %[[#STRUCT_A]]
+; CHECK: %[[#PTR_UC_VEC4:]] = OpTypePointer UniformConstant %[[#VEC4]]
+; CHECK: %[[#PTR_UC_ARRAY_F:]] = OpTypePointer UniformConstant %[[#ARRAY_F]]
+; CHECK: %[[#PTR_CW_PTR_CW_I8:]] = OpTypePointer CrossWorkgroup %[[#PTR_CW_I8]]
+; CHECK: %[[#I64:]] = OpTypeInt 64 0
+; CHECK: %[[#PTR_CW_ARRAY_I:]] = OpTypePointer CrossWorkgroup %[[#ARRAY_I]]
+
+; CHECK: %[[#NULL_I32:]] = OpConstantNull %[[#I32]]
+; CHECK: %[[#CONST_I64_4:]] = OpConstant %[[#I64]] 4
+; CHECK: %[[#CONST_I32_1:]] = OpConstant %[[#I32]] 1
+; CHECK: %[[#COMP_I32:]] = OpConstantComposite %[[#ARRAY_I]] %[[#CONST_I32_1]] %[[#CONST_2]]
+
+; CHECK: %[[#VAR_V:]] = OpVariable %[[#PTR_CW_ARRAY_I]] CrossWorkgroup %[[#COMP_I32]]
+; CHECK: %[[#SPECCONSTOP:]] = OpSpecConstantOp %[[#PTR_CW_I8]] InBoundsPtrAccessChain %[[#VAR_V]] %[[#NULL_I32]] %[[#CONST_I64_4]]
+; CHECK: %[[#VAR_S:]] = OpVariable %[[#PTR_CW_PTR_CW_I8]] CrossWorkgroup %[[#SPECCONSTOP]]
+; CHECK: %[[#NULL_ARRAY_F:]] = OpConstantNull %[[#ARRAY_F]]
+; CHECK: %[[#VAR_F:]] = OpVariable %[[#PTR_UC_ARRAY_F]] UniformConstant %[[#NULL_ARRAY_F]]
+; CHECK: %[[#NULL_STRUCT_A:]] = OpConstantNull %[[#STRUCT_A]]
+; CHECK: %[[#VAR_A:]] = OpVariable %[[#PTR_CW_STRUCT_A]] CrossWorkgroup %[[#NULL_STRUCT_A]]
+
+; CHECK: %[[#FN_BAR1:]] = OpFunction %[[#VOID]] None %[[#FUNC_TYPE1]]
+; CHECK: %[[#P_BAR1:]] = OpFunctionParameter %[[#PTR_CW_I8]]
+; CHECK: OpFunctionEnd
+
+@v = addrspace(1) global [2 x i32] [i32 1, i32 2], align 4
+@s = addrspace(1) global ptr addrspace(1) getelementptr inbounds ([2 x i32], ptr addrspace(1) @v, i32 0, i32 1), align 4
+
+%struct.A = type { i32, %struct.C }
+%struct.C = type { i32, %struct.B }
+%struct.B = type { i32, ptr addrspace(4) }
+
+@f = addrspace(2) constant [2 x float] zeroinitializer, align 4
+@b = external addrspace(2) constant <4 x i32>
+@a = common addrspace(1) global %struct.A zeroinitializer, align 4
+
+define spir_kernel void @foo(ptr addrspace(1) %a, <4 x i32> %vec_in) {
+entry:
+  call spir_func void @bar1(ptr addrspace(1) %a)
+  %extractVec = shufflevector <4 x i32> %vec_in, <4 x i32> %vec_in, <3 x i32> <i32 0, i32 1, i32 2>
+  call spir_func void @bar2(ptr addrspace(1) %a, <3 x i32> %extractVec)
+  ret void
+}
+
+declare spir_func void @bar1(ptr addrspace(1))
+declare spir_func void @bar2(ptr addrspace(1), <3 x i32>)
+
+!opencl.ocl.version = !{!7}
+!7 = !{i32 2, i32 0}


### PR DESCRIPTION
--Test that verifies correct emission of OpEntryPoint and interface variables for SPIR-V when using multiple global constants in the kernel entry point.
--Test that verifies code generation for get_global_size() calls.
--Test that verifies SPIR-V layout and initialization of various global variables.