### PR TITLE
[libc++] Remove SFINAE on __tuple_impl constructors

### DIFF
--- a/libcxx/include/__fwd/tuple.h
+++ b/libcxx/include/__fwd/tuple.h
@@ -26,6 +26,11 @@ struct tuple_element;
 template <class...>
 class tuple;
 
+template <size_t _Ip, class... _Tp>
+struct tuple_element<_Ip, tuple<_Tp...> > {
+  using type _LIBCPP_NODEBUG = __type_pack_element<_Ip, _Tp...>;
+};
+
 template <class>
 struct tuple_size;
 

--- a/libcxx/include/__memory/uses_allocator_construction.h
+++ b/libcxx/include/__memory/uses_allocator_construction.h
@@ -17,6 +17,7 @@
 #include <__type_traits/remove_cv.h>
 #include <__utility/declval.h>
 #include <__utility/pair.h>
+#include <__utility/piecewise_construct.h>
 #include <tuple>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)

--- a/libcxx/include/__memory_resource/polymorphic_allocator.h
+++ b/libcxx/include/__memory_resource/polymorphic_allocator.h
@@ -18,6 +18,7 @@
 #include <__new/exceptions.h>
 #include <__new/placement_new_delete.h>
 #include <__utility/exception_guard.h>
+#include <__utility/piecewise_construct.h>
 #include <limits>
 #include <tuple>
 

--- a/libcxx/include/__tuple/sfinae_helpers.h
+++ b/libcxx/include/__tuple/sfinae_helpers.h
@@ -10,20 +10,6 @@
 #define _LIBCPP___TUPLE_SFINAE_HELPERS_H
 
 #include <__config>
-#include <__cstddef/size_t.h>
-#include <__fwd/tuple.h>
-#include <__tuple/make_tuple_types.h>
-#include <__tuple/tuple_element.h>
-#include <__tuple/tuple_like_ext.h>
-#include <__tuple/tuple_size.h>
-#include <__tuple/tuple_types.h>
-#include <__type_traits/conjunction.h>
-#include <__type_traits/enable_if.h>
-#include <__type_traits/integral_constant.h>
-#include <__type_traits/is_constructible.h>
-#include <__type_traits/is_same.h>
-#include <__type_traits/remove_cvref.h>
-#include <__type_traits/remove_reference.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -32,35 +18,6 @@
 _LIBCPP_BEGIN_NAMESPACE_STD
 
 #ifndef _LIBCPP_CXX03_LANG
-
-struct __tuple_sfinae_base {
-  template <template <class, class...> class _Trait, class... _LArgs, class... _RArgs>
-  static auto __do_test(__tuple_types<_LArgs...>,
-                        __tuple_types<_RArgs...>) -> __all<__enable_if_t<_Trait<_LArgs, _RArgs>::value, bool>{true}...>;
-  template <template <class...> class>
-  static auto __do_test(...) -> false_type;
-
-  template <class _FromArgs, class _ToArgs>
-  using __constructible _LIBCPP_NODEBUG = decltype(__do_test<is_constructible>(_ToArgs{}, _FromArgs{}));
-};
-
-// __tuple_constructible
-
-template <class _Tp,
-          class _Up,
-          bool = __tuple_like_ext<__libcpp_remove_reference_t<_Tp> >::value,
-          bool = __tuple_like_ext<_Up>::value>
-struct __tuple_constructible : public false_type {};
-
-template <class _Tp, class _Up>
-struct __tuple_constructible<_Tp, _Up, true, true>
-    : public __tuple_sfinae_base::__constructible< typename __make_tuple_types<_Tp>::type,
-                                                   typename __make_tuple_types<_Up>::type > {};
-
-template <size_t _Ip, class... _Tp>
-struct tuple_element<_Ip, tuple<_Tp...> > {
-  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, __tuple_types<_Tp...> >::type;
-};
 
 struct _LIBCPP_EXPORTED_FROM_ABI __check_tuple_constructor_fail {
   static _LIBCPP_HIDE_FROM_ABI constexpr bool __enable_explicit_default() { return false; }

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -2168,7 +2168,10 @@ module std [system] {
     module is_valid_range             { header "__utility/is_valid_range.h" }
     module move                       { header "__utility/move.h" }
     module no_destroy                 { header "__utility/no_destroy.h" }
-    module pair                       { header "__utility/pair.h" }
+    module pair                       {
+      header "__utility/pair.h"
+      export std.utility.piecewise_construct
+    }
     module piecewise_construct        { header "__utility/piecewise_construct.h" }
     module priority_tag               { header "__utility/priority_tag.h" }
     module private_constructor_tag    { header "__utility/private_constructor_tag.h" }

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -227,7 +227,6 @@ template <class... Types>
 #  include <__tuple/find_index.h>
 #  include <__tuple/ignore.h>
 #  include <__tuple/make_tuple_types.h>
-#  include <__tuple/sfinae_helpers.h>
 #  include <__tuple/tuple_element.h>
 #  include <__tuple/tuple_like_ext.h>
 #  include <__tuple/tuple_size.h>
@@ -240,7 +239,6 @@ template <class... Types>
 #  include <__type_traits/disjunction.h>
 #  include <__type_traits/enable_if.h>
 #  include <__type_traits/invoke.h>
-#  include <__type_traits/is_arithmetic.h>
 #  include <__type_traits/is_assignable.h>
 #  include <__type_traits/is_constructible.h>
 #  include <__type_traits/is_convertible.h>
@@ -267,7 +265,6 @@ template <class... Types>
 #  include <__utility/forward.h>
 #  include <__utility/integer_sequence.h>
 #  include <__utility/move.h>
-#  include <__utility/piecewise_construct.h>
 #  include <__utility/swap.h>
 #  include <version>
 
@@ -471,7 +468,7 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES
       allocator_arg_t, const _Alloc& __alloc, __forward_args, _Args&&... __args)
       : __tuple_leaf<_Indx, _Tp>(__uses_alloc_ctor<_Tp, _Alloc, _Args>(), __alloc, std::forward<_Args>(__args))... {}
 
-  template <class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...> >::value, int> = 0>
+  template <class _Tuple>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __tuple_impl(_Tuple&& __t) noexcept(
       (__all<is_nothrow_constructible<
            _Tp,
@@ -480,7 +477,7 @@ struct _LIBCPP_DECLSPEC_EMPTY_BASES
             std::forward<typename tuple_element<_Indx, typename __make_tuple_types<_Tuple>::type>::type>(
                 std::get<_Indx>(__t)))... {}
 
-  template <class _Alloc, class _Tuple, __enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...> >::value, int> = 0>
+  template <class _Alloc, class _Tuple>
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 __tuple_impl(allocator_arg_t, const _Alloc& __a, _Tuple&& __t)
       : __tuple_leaf<_Indx, _Tp>(
             __uses_alloc_ctor<_Tp,

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.verify.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.helper/tuple_element.verify.cpp
@@ -23,4 +23,4 @@
 using T =  std::tuple<int, long, void*>;
 using E1 = typename std::tuple_element<1, T &>::type; // expected-error{{undefined template}}
 using E2 = typename std::tuple_element<3, T>::type;
-using E3 = typename std::tuple_element<4, T const>::type; // expected-error@*:* 2 {{static assertion failed}}
+using E3 = typename std::tuple_element<4, T const>::type; // expected-error@*:* 2 {{out of bounds index}}


### PR DESCRIPTION
The SFINAE isn't required, since the primary `tuple` class already does the SFINAE checks. This removes a bit of code that was only used for these constraints.

This also moves the `tuple_element` specialization for `tuple` to `__fwd/tuple.h` to avoid a dependency on `__tuple/sfinae_helpers.h` (which should be moved in a follow-up).
