### PR TITLE
[clang-format][NFC] Maximize usage of isOneOf() in TokenAnnotator

### DIFF
--- a/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
+++ b/clang/lib/Format/IntegerLiteralSeparatorFixer.cpp
@@ -117,7 +117,7 @@ IntegerLiteralSeparatorFixer::process(const Environment &Env,
     }
     if (Style.isCpp()) {
       // Hex alpha digits a-f/A-F must be at the end of the string literal.
-      StringRef Suffixes = "_himnsuyd";
+      static constexpr StringRef Suffixes("_himnsuyd");
       if (const auto Pos =
               Text.find_first_of(IsBase16 ? Suffixes.drop_back() : Suffixes);
           Pos != StringRef::npos) {


### PR DESCRIPTION
Also make a StringRef literal `static constexpr`.