### PR TITLE
[SPIRV] Porting tests to transcoding directory from translator

### DIFF
--- a/llvm/test/CodeGen/SPIRV/transcoding/OpVariable_Initializer.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpVariable_Initializer.ll
@@ -1,0 +1,11 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-SPIRV: [[#PtrT:]] = OpTypePointer Workgroup %[[#]]
+; CHECK-SPIRV: %[[#]] = OpVariable %[[#PtrT]] Workgroup
+
+@test_atomic_fn.L = internal addrspace(3) global [64 x i32] zeroinitializer, align 4
+
+define spir_kernel void @test_atomic_fn() {
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpVariable_Initializer.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpVariable_Initializer.ll
@@ -1,4 +1,4 @@
-; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
 
 ; CHECK-SPIRV: [[#PtrT:]] = OpTypePointer Workgroup %[[#]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/builtin_vars_gep.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/builtin_vars_gep.ll
@@ -1,0 +1,16 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK: OpDecorate %[[#Id:]] BuiltIn GlobalInvocationId
+; CHECK: %[[#Id]] = OpVariable %[[#]] CrossWorkgroup
+
+@__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+define spir_kernel void @f() {
+entry:
+  %0 = load i64, ptr addrspace(1) @__spirv_BuiltInGlobalInvocationId, align 32
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/transcoding/decoration-forward-decl.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/decoration-forward-decl.ll
@@ -1,0 +1,30 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Check saturation conversion is translated when there is forward declaration
+; of SPIRV entry.
+
+; CHECK: OpDecorate %[[#SAT:]] SaturatedConversion
+; CHECK: %[[#SAT]] = OpConvertFToU %[[#]] %[[#]]
+
+declare spir_func zeroext i8 @_Z30__spirv_ConvertFToU_Ruchar_satf(float)
+
+define spir_func void @forward(float %val, i8 %initval, ptr addrspace(1) %dst) {
+entry:
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.body, %entry
+  %new_val.0 = phi i8 [ %initval, %entry ], [ %call1, %for.body ]
+  %i.0 = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %cmp = icmp ult i32 %i.0, 1
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %call1 = call spir_func zeroext i8 @_Z30__spirv_ConvertFToU_Ruchar_satf(float noundef %val)
+  %inc = add i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  store i8 %new_val.0, ptr addrspace(1) %dst, align 1
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/transcoding/float16.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/float16.ll
@@ -1,0 +1,25 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv32-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; CHECK-SPIRV: %[[#HALF:]] = OpTypeFloat 16
+; CHECK-SPIRV: %[[#HALFPTR:]] = OpTypePointer Function %[[#HALF]]
+; CHECK-SPIRV: %[[#HALFV2:]] = OpTypeVector %[[#HALF]] 2
+; CHECK-SPIRV: %[[#HALFV2PTR:]] = OpTypePointer Function %[[#HALFV2]]
+; CHECK-SPIRV: %[[#CONST:]] = OpConstant %[[#HALF]] 14788
+; CHECK-SPIRV: %[[#ADDR:]] = OpVariable %[[#HALFPTR]] Function
+; CHECK-SPIRV: %[[#ADDR2:]] = OpVariable %[[#HALFV2PTR]] Function
+; CHECK-SPIRV: %[[#]] = OpExtInst %[[#HALF]] %[[#]] fract %[[#CONST]] %[[#ADDR]]
+; CHECK-SPIRV: %[[#]] = OpExtInst %[[#HALFV2]] %[[#]] fract %[[#]] %[[#ADDR2]]
+
+define spir_kernel void @test() {
+entry:
+  %addr = alloca half
+  %addr2 = alloca <2 x half>
+  %res = call spir_func noundef half @_Z17__spirv_ocl_fractDF16_PU3AS0DF16_(half noundef 0xH39C4, ptr noundef %addr)
+  %res2 = call spir_func noundef <2 x half> @_Z17__spirv_ocl_fractDv2_DF16_PU3AS0S_(<2 x half> noundef <half 0xH39C4, half 0xH0000>, ptr noundef %addr2)
+  ret void
+}
+
+declare spir_func noundef half @_Z17__spirv_ocl_fractDF16_PU3AS0DF16_(half noundef, ptr noundef) local_unnamed_addr
+
+declare spir_func noundef <2 x half> @_Z17__spirv_ocl_fractDv2_DF16_PU3AS0S_(<2 x half> noundef, ptr noundef) local_unnamed_addr


### PR DESCRIPTION
Checks for built-in variables, saturating conversion, half precision fract, and workgroup variable initialization