### PR TITLE
Relax muldc3 test to avoid precision issue

### DIFF
--- a/compiler-rt/test/builtins/Unit/muldc3_test.c
+++ b/compiler-rt/test/builtins/Unit/muldc3_test.c
@@ -7,7 +7,7 @@
 #include <complex.h>
 #include <stdio.h>
 
-#define RELATIVE_TOLERANCE 1e-4
+#define RELATIVE_TOLERANCE 1e-9
 
 // Returns: the product of a + ib and c + id
 

--- a/compiler-rt/test/builtins/Unit/muldc3_test.c
+++ b/compiler-rt/test/builtins/Unit/muldc3_test.c
@@ -7,6 +7,7 @@
 #include <complex.h>
 #include <stdio.h>
 
+#define RELATIVE_TOLERANCE 1e-4
 
 // Returns: the product of a + ib and c + id
 
@@ -14,6 +15,19 @@ COMPILER_RT_ABI double _Complex
 __muldc3(double __a, double __b, double __c, double __d);
 
 enum {zero, non_zero, inf, NaN, non_zero_nan};
+
+int check_complex_equal(double _Complex r1, double _Complex r2)
+{
+    double max_magnitude = fmax(cabs(r1), cabs(r2));
+    double real_diff = fabs(creal(r1) - creal(r2));
+    double imag_diff = fabs(cimag(r1) - cimag(r2));
+    if (real_diff >= max_magnitude * RELATIVE_TOLERANCE)
+      return 0;
+    if (imag_diff >= max_magnitude * RELATIVE_TOLERANCE)
+      return 0;
+
+    return 1;
+}
 
 int
 classify(double _Complex x)
@@ -46,11 +60,15 @@ int test__muldc3(double a, double b, double c, double d)
 //             a, b, c, d, creal(r), cimag(r));
 	double _Complex dividend;
 	double _Complex divisor;
-	
+  double _Complex temp;	
+
 	__real__ dividend = a;
 	__imag__ dividend = b;
 	__real__ divisor = c;
 	__imag__ divisor = d;
+
+  __real__ temp = a * c - b * d;
+  __imag__ temp = a * d + b * c;
 	
     switch (classify(dividend))
     {
@@ -89,7 +107,7 @@ int test__muldc3(double a, double b, double c, double d)
         case non_zero:
             if (classify(r) != non_zero)
                 return 1;
-            if (r != a * c - b * d + _Complex_I*(a * d + b * c))
+            if (!check_complex_equal(r, temp))
                 return 1;
             break;
         case inf:


### PR DESCRIPTION
muldc3_test will check whether the results of __muldc3 and simple math formula "a * c - b * d + _Complex_I*(a * d + b * c)" are exactly same in bits. For the input value, they should be same in theory but the bits check is too restrict, failure recently reported in our prec-ci for 32-bit x86 target, the dumped results are:
(7.040584e-29, 2.000000e-12) VS (0.000000e+00 2.000000e-12)
This PR relaxes the check a little.