### PR TITLE
[lld][ELF] filter out section symbols when use BP reorder

### DIFF
--- a/lld/ELF/BPSectionOrderer.cpp
+++ b/lld/ELF/BPSectionOrderer.cpp
@@ -76,10 +76,12 @@ DenseMap<const InputSectionBase *, int> elf::runBalancedPartitioning(
     if (!d)
       return;
     auto *sec = dyn_cast_or_null<InputSection>(d->section);
-    // Skip empty, discarded, ICF folded sections, .bss. Skipping ICF folded
-    // sections reduces duplicate detection work in BPSectionOrderer.
-    if (!sec || sec->size == 0 || !sec->isLive() || sec->repl != sec ||
-        !sec->content().data() || !orderer.secToSym.try_emplace(sec, d).second)
+    // Skip section symbols. Skip empty, discarded, ICF folded sections, .bss.
+    // Skipping ICF folded sections reduces duplicate detection work in
+    // BPSectionOrderer.
+    if (sym.isSection() || !sec || sec->size == 0 || !sec->isLive() ||
+        sec->repl != sec || !sec->content().data() ||
+        !orderer.secToSym.try_emplace(sec, d).second)
       return;
     rootSymbolToSectionIdxs[CachedHashStringRef(
                                 lld::utils::getRootSymbol(sym.getName()))]


### PR DESCRIPTION
When using Temporal Profiling with the BP algorithm, we encounter an issue with the internal function reorder. In cases where the symbol table contains entries like:
```
Symbol table '.symtab' contains 45 entries:
   Num:    Value          Size Type    Bind   Vis       Ndx Name
    10: 0000000000000000     0 SECTION LOCAL  DEFAULT    18 .text.L1
    11: 0000000000000000    24 FUNC    LOCAL  DEFAULT    18 L1
````
The zero-sized section symbol .text.L1 gets stored in the secToSym map first. However, when the function lookup searches for L1 (as seen in [BPSectionOrdererBase.inc:191](https://github.com/llvm/llvm-project/blob/main/lld/include/lld/Common/BPSectionOrdererBase.inc#L191)), it fails to find the correct entry in rootSymbolToSectionIdxs because the section symbol has already claimed that slot.
This patch fixes the issue by skipping zero-sized symbols during the addSections process, ensuring that function symbols are properly registered for lookup.