### PR TITLE
[llvm-reduce] Do not convert lifetime operand to argument

### DIFF
--- a/llvm/test/tools/llvm-reduce/operands-to-args-lifetimes.ll
+++ b/llvm/test/tools/llvm-reduce/operands-to-args-lifetimes.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=operands-to-args --test FileCheck --test-arg %s --test-arg --check-prefix=INTERESTING --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefix=REDUCED
+
+; INTERESTING: store
+; REDUCED: define void @test(ptr %a) {
+; REDUCED-NEXT: %a1 = alloca i32
+; REDUCED-NEXT: call void @llvm.lifetime.start.p0(i64 4, ptr %a1)
+; REDUCED-NEXT: store i32 0, ptr %a
+; REDUCED-NEXT: store i32 1, ptr %a
+; REDUCED-NEXT: call void @llvm.lifetime.end.p0(i64 4, ptr %a1)
+define void @test() {
+  %a = alloca i32
+  call void @llvm.lifetime.start.p0(i64 4, ptr %a)
+  store i32 0, ptr %a
+  store i32 1, ptr %a
+  call void @llvm.lifetime.end.p0(i64 4, ptr %a)
+  ret void
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperandsToArgs.cpp
@@ -13,6 +13,7 @@
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Cloning.h"
@@ -48,6 +49,10 @@ static bool canReduceUse(Use &Op) {
   if (auto *CI = dyn_cast<CallBase>(Op.getUser()))
     if (&CI->getCalledOperandUse() == &Op)
       return false;
+
+  // lifetime.start/lifetime.end require alloca argument.
+  if (isa<LifetimeIntrinsic>(Op.getUser()))
+    return false;
 
   return true;
 }


### PR DESCRIPTION
The lifetime argument is now required to be an alloca, so do not try to convert it to a function argument.

The reduction is now going to leave behind an unused alloca with lifetime markers, which should be cleaned up separately.

I'd say this fixes https://github.com/llvm/llvm-project/issues/93713. It doesn't remove the lifetime markers as the issue suggests, but at least they're now not going to be on the argument.