### PR TITLE
[llvm-reduce] Do not replace lifetime pointer arg with zero/one/poison

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-operands-alloca.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-operands-alloca.ll
@@ -67,3 +67,15 @@ define void @alloca_constexpr_elt() {
  store i32 0, ptr %alloca
  ret void
 }
+
+; CHECK-LABEL: @alloca_lifetimes(
+; ZERO: call void @llvm.lifetime.start.p0(i64 4, ptr %alloca)
+; ONE: call void @llvm.lifetime.start.p0(i64 4, ptr %alloca)
+; POISON: call void @llvm.lifetime.start.p0(i64 4, ptr %alloca)
+define void @alloca_lifetimes() {
+  %alloca = alloca i32
+  call void @llvm.lifetime.start.p0(i64 4, ptr %alloca)
+  store i32 0, ptr %alloca
+  call void @llvm.lifetime.end.p0(i64 4, ptr %alloca)
+  ret void
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceOperands.cpp
@@ -73,6 +73,9 @@ static bool shouldReduceOperand(Use &Op) {
     if (&CB->getCalledOperandUse() == &Op)
       return false;
   }
+  // lifetime intrinsic argument must be an alloca.
+  if (isa<LifetimeIntrinsic>(Op.getUser()))
+    return false;
   return true;
 }
 


### PR DESCRIPTION
The lifetime argument is now required to be an alloca, so we should not try to replace it with a constant.

We also shouldn't try to change the size argument to zero/one, similar to how we avoid zero-size allocas.