### PR TITLE
[LV] Increase vectorize-memory-check-threshold to 256

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -203,7 +203,7 @@ static cl::opt<unsigned> TinyTripCountVectorThreshold(
              "are incurred."));
 
 static cl::opt<unsigned> VectorizeMemoryCheckThreshold(
-    "vectorize-memory-check-threshold", cl::init(128), cl::Hidden,
+    "vectorize-memory-check-threshold", cl::init(256), cl::Hidden,
     cl::desc("The maximum allowed number of runtime memory checks"));
 
 // Option prefer-predicate-over-epilogue indicates that an epilogue is undesired,


### PR DESCRIPTION
We have a benchmark with large loops that benefit from vectorisation; however, they currently require several thousands runtime checks due to the way `LoopAccessAnalysis` is implemented. I would like to improve LAA to enable vectorisation with significantly fewer checks - though still somewhat more than the current limit of 128. Before committing to this task, I need to know whether we can raise this threshold. I checked and found that increasing it to 256 caused no performance or compile-time regressions, including when using the benchmarks from https://llvm-compile-time-tracker.com/