### PR TITLE
[Offload][UnitTests] Build device code as C++

### DIFF
--- a/offload/unittests/CMakeLists.txt
+++ b/offload/unittests/CMakeLists.txt
@@ -38,7 +38,7 @@ function(add_offload_test_device_code test_filename test_name)
       set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${test_name}.nvptx64.bin")
       add_custom_command(
         OUTPUT ${output_file}
-        COMMAND ${CMAKE_C_COMPILER}
+        COMMAND ${CMAKE_CXX_COMPILER}
         --target=nvptx64-nvidia-cuda -march=${nvptx_arch}
         -nogpulib --cuda-path=${cuda_path} -flto ${ARGN}
         ${SRC_PATH} -o ${output_file}
@@ -62,7 +62,7 @@ function(add_offload_test_device_code test_filename test_name)
       set(output_file "${CMAKE_CURRENT_BINARY_DIR}/${test_name}.amdgpu.bin")
       add_custom_command(
         OUTPUT ${output_file}
-        COMMAND ${CMAKE_C_COMPILER}
+        COMMAND ${CMAKE_CXX_COMPILER}
         --target=amdgcn-amd-amdhsa -mcpu=${amdgpu_arch}
         -nogpulib -flto ${ARGN} ${SRC_PATH} -o ${output_file}
         DEPENDS ${SRC_PATH}

--- a/offload/unittests/Conformance/device_code/CMakeLists.txt
+++ b/offload/unittests/Conformance/device_code/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_offload_test_device_code(LLVMLibm.c llvm-libm -stdlib -fno-builtin)
+add_offload_test_device_code(LLVMLibm.cpp llvm-libm -stdlib -fno-builtin)
 
 add_custom_target(conformance_device_binaries DEPENDS llvm-libm.bin)
 set(OFFLOAD_CONFORMANCE_DEVICE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)

--- a/offload/unittests/Conformance/device_code/LLVMLibm.cpp
+++ b/offload/unittests/Conformance/device_code/LLVMLibm.cpp
@@ -19,6 +19,8 @@
 
 typedef _Float16 float16;
 
+extern "C" {
+
 __gpu_kernel void hypotf16Kernel(const float16 *X, float16 *Y, float16 *Out,
                                  size_t NumElements) {
   uint32_t Index =
@@ -35,3 +37,4 @@ __gpu_kernel void logfKernel(const float *X, float *Out, size_t NumElements) {
   if (Index < NumElements)
     Out[Index] = logf(X[Index]);
 }
+} // extern "C"

--- a/offload/unittests/OffloadAPI/device_code/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/device_code/CMakeLists.txt
@@ -1,14 +1,14 @@
-add_offload_test_device_code(foo.c foo)
-add_offload_test_device_code(bar.c bar)
+add_offload_test_device_code(foo.cpp foo)
+add_offload_test_device_code(bar.cpp bar)
 # Compile with optimizations to eliminate AMDGPU implicit arguments.
-add_offload_test_device_code(noargs.c noargs -O3)
-add_offload_test_device_code(localmem.c localmem)
-add_offload_test_device_code(localmem_reduction.c localmem_reduction)
-add_offload_test_device_code(localmem_static.c localmem_static)
-add_offload_test_device_code(global.c global)
-add_offload_test_device_code(global_ctor.c global_ctor)
-add_offload_test_device_code(global_dtor.c global_dtor)
-add_offload_test_device_code(sequence.c sequence)
+add_offload_test_device_code(noargs.cpp noargs -O3)
+add_offload_test_device_code(localmem.cpp localmem)
+add_offload_test_device_code(localmem_reduction.cpp localmem_reduction)
+add_offload_test_device_code(localmem_static.cpp localmem_static)
+add_offload_test_device_code(global.cpp global)
+add_offload_test_device_code(global_ctor.cpp global_ctor)
+add_offload_test_device_code(global_dtor.cpp global_dtor)
+add_offload_test_device_code(sequence.cpp sequence)
 
 add_custom_target(offload_device_binaries DEPENDS
     foo.bin

--- a/offload/unittests/OffloadAPI/device_code/bar.cpp
+++ b/offload/unittests/OffloadAPI/device_code/bar.cpp
@@ -1,5 +1,5 @@
 #include <gpuintrin.h>
 
-__gpu_kernel void foo(int *out) {
+extern "C" __gpu_kernel void foo(int *out) {
   out[__gpu_thread_id(0)] = __gpu_thread_id(0) + 1;
 }

--- a/offload/unittests/OffloadAPI/device_code/foo.cpp
+++ b/offload/unittests/OffloadAPI/device_code/foo.cpp
@@ -1,6 +1,6 @@
 #include <gpuintrin.h>
 #include <stdint.h>
 
-__gpu_kernel void foo(uint32_t *out) {
+extern "C" __gpu_kernel void foo(uint32_t *out) {
   out[__gpu_thread_id(0)] = __gpu_thread_id(0);
 }

--- a/offload/unittests/OffloadAPI/device_code/global.cpp
+++ b/offload/unittests/OffloadAPI/device_code/global.cpp
@@ -1,6 +1,8 @@
 #include <gpuintrin.h>
 #include <stdint.h>
 
+extern "C" {
+
 [[gnu::visibility("default")]]
 uint32_t global[64];
 
@@ -13,3 +15,4 @@ __gpu_kernel void read(uint32_t *out) {
   out[__gpu_thread_id(0) + (__gpu_num_threads(0) * __gpu_block_id(0))] =
       global[__gpu_thread_id(0)];
 }
+} // extern "C"

--- a/offload/unittests/OffloadAPI/device_code/global_ctor.cpp
+++ b/offload/unittests/OffloadAPI/device_code/global_ctor.cpp
@@ -1,6 +1,8 @@
 #include <gpuintrin.h>
 #include <stdint.h>
 
+extern "C" {
+
 uint32_t global[64];
 
 [[gnu::constructor(202)]] void ctorc() {
@@ -23,3 +25,4 @@ __gpu_kernel void global_ctor(uint32_t *out) {
   out[__gpu_thread_id(0) + (__gpu_num_threads(0) * __gpu_block_id(0))] =
       global[__gpu_thread_id(0)];
 }
+} // extern "C"

--- a/offload/unittests/OffloadAPI/device_code/global_dtor.cpp
+++ b/offload/unittests/OffloadAPI/device_code/global_dtor.cpp
@@ -1,6 +1,8 @@
 #include <gpuintrin.h>
 #include <stdint.h>
 
+extern "C" {
+
 uint32_t global[64];
 
 [[gnu::destructor]] void dtor() {
@@ -11,3 +13,4 @@ uint32_t global[64];
 __gpu_kernel void global_dtor() {
   // no-op
 }
+} // extern "C"

--- a/offload/unittests/OffloadAPI/device_code/localmem.cpp
+++ b/offload/unittests/OffloadAPI/device_code/localmem.cpp
@@ -3,7 +3,7 @@
 
 extern __gpu_local uint32_t shared_mem[];
 
-__gpu_kernel void localmem(uint32_t *out) {
+extern "C" __gpu_kernel void localmem(uint32_t *out) {
   shared_mem[__gpu_thread_id(0)] = __gpu_thread_id(0);
   shared_mem[__gpu_thread_id(0)] *= 2;
   out[__gpu_thread_id(0) + (__gpu_num_threads(0) * __gpu_block_id(0))] =

--- a/offload/unittests/OffloadAPI/device_code/localmem_reduction.cpp
+++ b/offload/unittests/OffloadAPI/device_code/localmem_reduction.cpp
@@ -3,7 +3,7 @@
 
 extern __gpu_local uint32_t shared_mem[];
 
-__gpu_kernel void localmem_reduction(uint32_t *out) {
+extern "C" __gpu_kernel void localmem_reduction(uint32_t *out) {
   shared_mem[__gpu_thread_id(0)] = 2;
 
   __gpu_sync_threads();

--- a/offload/unittests/OffloadAPI/device_code/localmem_static.cpp
+++ b/offload/unittests/OffloadAPI/device_code/localmem_static.cpp
@@ -4,7 +4,7 @@
 [[clang::loader_uninitialized]]
 __gpu_local uint32_t shared_mem[64];
 
-__gpu_kernel void localmem_static(uint32_t *out) {
+extern "C" __gpu_kernel void localmem_static(uint32_t *out) {
   shared_mem[__gpu_thread_id(0)] = 2;
 
   __gpu_sync_threads();

--- a/offload/unittests/OffloadAPI/device_code/noargs.c
+++ b/offload/unittests/OffloadAPI/device_code/noargs.c
@@ -1,3 +1,0 @@
-#include <gpuintrin.h>
-
-__gpu_kernel void noargs() { (void)0; }

--- a/offload/unittests/OffloadAPI/device_code/noargs.cpp
+++ b/offload/unittests/OffloadAPI/device_code/noargs.cpp
@@ -1,0 +1,3 @@
+#include <gpuintrin.h>
+
+extern "C" __gpu_kernel void noargs() { (void)0; }

--- a/offload/unittests/OffloadAPI/device_code/sequence.cpp
+++ b/offload/unittests/OffloadAPI/device_code/sequence.cpp
@@ -1,7 +1,7 @@
 #include <gpuintrin.h>
 #include <stdint.h>
 
-__gpu_kernel void sequence(uint32_t idx, uint32_t *inout) {
+extern "C" __gpu_kernel void sequence(uint32_t idx, uint32_t *inout) {
   if (idx == 0)
     inout[idx] = 0;
   else if (idx == 1)


### PR DESCRIPTION
This commit refactors the `add_offload_test_device_code` CMake function to compile device code using the C++ compiler (`CMAKE_CXX_COMPILER`) instead of the C compiler.

This change enables the use of C++ features, such as templates, within device-side test kernels. This will allow for more advanced and reusable kernel wrappers, reducing boilerplate code in the conformance test suite.

As part of this change:
- All `.c` files for device code in `unittests/` have been renamed to `.cpp`.
- Kernel definitions are now wrapped in `extern "C"` to ensure C linkage and prevent name mangling.

This change affects the `OffloadAPI` and `Conformance` test suites.