### PR TITLE
[Analyzer] No longer crash with VLA operands to unary type traits

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -241,6 +241,8 @@ Static Analyzer
 ---------------
 - The Clang Static Analyzer now handles parenthesized initialization.
   (#GH148875)
+- ``__datasizeof`` (C++) and ``_Countof`` (C) no longer cause a failed assertion
+  when given an operand of VLA type. (#GH151711)
 
 New features
 ^^^^^^^^^^^^

--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -868,7 +868,8 @@ VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *Ex,
   QualType T = Ex->getTypeOfArgument();
 
   for (ExplodedNode *N : CheckedSet) {
-    if (Ex->getKind() == UETT_SizeOf) {
+    if (Ex->getKind() == UETT_SizeOf || Ex->getKind() == UETT_DataSizeOf ||
+        Ex->getKind() == UETT_CountOf) {
       if (!T->isIncompleteType() && !T->isConstantSizeType()) {
         assert(T->isVariableArrayType() && "Unknown non-constant-sized type.");
 

--- a/clang/test/Analysis/engine/gh151711.cpp
+++ b/clang/test/Analysis/engine/gh151711.cpp
@@ -1,18 +1,18 @@
-// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
-// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify -x c -std=c2y %s
-// expected-no-diagnostics
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify -x c %s
+
+void clang_analyzer_dump(int);
 
 // Ensure that VLA types are correctly handled by unary type traits in the
 // expression engine. Previously, __datasizeof and _Countof both caused failed
 // assertions.
 void gh151711(int i) {
-  (void)sizeof(int[i++]);
-
+  clang_analyzer_dump(sizeof(int[i++]));       // expected-warning {{Unknown}}
 #ifdef __cplusplus
   // __datasizeof is only available in C++.
-  (void)__datasizeof(int[i++]);
+  clang_analyzer_dump(__datasizeof(int[i++])); // expected-warning {{Unknown}}
 #else
   // _Countof is only available in C.
-  (void)_Countof(int[i++]);
+  clang_analyzer_dump(_Countof(int[i++]));     // expected-warning {{Unknown}}
 #endif
 }

--- a/clang/test/Analysis/engine/gh151711.cpp
+++ b/clang/test/Analysis/engine/gh151711.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify -x c -std=c2y %s
+// expected-no-diagnostics
+
+// Ensure that VLA types are correctly handled by unary type traits in the
+// expression engine. Previously, __datasizeof and _Countof both caused failed
+// assertions.
+void gh151711(int i) {
+  (void)sizeof(int[i++]);
+
+#ifdef __cplusplus
+  // __datasizeof is only available in C++.
+  (void)__datasizeof(int[i++]);
+#else
+  // _Countof is only available in C.
+  (void)_Countof(int[i++]);
+#endif
+}


### PR DESCRIPTION
sizeof was handled correctly, but __datasizeof and _Countof were not.

Fixes #151711