### PR TITLE
[MLIR] Add Egress dialects maintainers

### DIFF
--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -51,8 +51,8 @@ with the point-of-contact being the maintainers above. Named maintainers, if
 available, should be contacted first, as they're more active in those areas.
 
 #### Lowering Dialects
-* ‘llvm’ Dialect (egress)
-* ‘SPIR-V Dialect ([@kuhar](https://github.com/kuhar), [@antiagainst](https://github.com/antiagainst))
+* `llvm’ Dialect (egress)
+* ‘SPIR-V' Dialect ([@kuhar](https://github.com/kuhar), [@antiagainst](https://github.com/antiagainst))
 * ‘emitc’ Dialect ([@aniragil](https://github.com/aniragil), [@marbre](https://github.com/marbre))
 
 #### GPU Dialects
@@ -62,20 +62,21 @@ available, should be contacted first, as they're more active in those areas.
 * ‘nvgpu’ Dialect ([@grypp](https://github.com/grypp))
 * ‘nvvm’ Dialect ([@grypp](https://github.com/grypp))
 * ‘xegpu’ Dialect ([@chencha3](https://github.com/chencha3), [@Jianhui-Li](https://github.com/Jianhui-Li))
+* 'xevm' Dialect ([@silee2](https://github.com/silee2))
 
 #### CPU Dialects
 * ‘arm_neon’ Dialect ([@banach-space](https://github.com/banach-space))
 * ‘arm_sve’ Dialect ([@banach-space](https://github.com/banach-space))
 * ‘ArmSME’ Dialect ([@banach-space](https://github.com/banach-space))
-* ‘amx’ Dialect ([@asiem](https://github.com/adam-smnk))
-* ‘x86vector’ Dialect ([@asiem](https://github.com/adam-smnk))
+* ‘amx’ Dialect ([@adam-smnk](https://github.com/adam-smnk))
+* ‘x86vector’ Dialect ([@adam-smkk](https://github.com/adam-smnk))
 * ‘vcix’ Dialect ([@mshockwave](https://github.com/mshockwave))
 
 #### Paradigm Dialects
 * ‘omp’ Dialect ([@tblah](https://github.com/tblah), [@skatrak](https://github.com/skatrak))
 * ‘acc’ Dialect ([@clementval](https://github.com/clementval), [@razvanlupusoru](https://github.com/razvanlupusoru))
 * ‘mpi’ Dialect ([@fschlimb](https://github.com/fschlimb))
-* ‘mesh’ Dialect ([@fschlimb](https://github.com/fschlimb))
+* ‘shard’ Dialect ([@fschlimb](https://github.com/fschlimb))
 
 ## Tensor Compiler
 

--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -44,6 +44,39 @@ MLIR components pertaining to egress flows from MLIR, in particular to LLVM IR.
   [@gysit](https://github.com/gysit) (GitHub),
   gysit (Discourse)
 
+### Dialects
+
+The `egress` maintainer refers to the people working in the Egress category,
+with the point-of-contact being the maintainers above. Named maintainers, if
+available, should be contacted first, as they're more active in those areas.
+
+#### Lowering Dialects
+* ‘llvm’ Dialect (egress)
+* ‘SPIR-V Dialect ([@kuhar](https://github.com/kuhar), [@antiagainst](https://github.com/antiagainst))
+* ‘emitc’ Dialect ([@aniragil](https://github.com/aniragil), [@marbre](https://github.com/marbre))
+
+#### GPU Dialects
+* ‘gpu’ Dialect ([@fabianmcg](https://github.com/fabianmcg))
+* ‘amdgpu’ Dialect ([@krzysz00](https://github.com/krzysz00))
+* ‘rocdl’ Dialect ([@krzysz00](https://github.com/krzysz00))
+* ‘nvgpu’ Dialect ([@grypp](https://github.com/grypp))
+* ‘nvvm’ Dialect ([@grypp](https://github.com/grypp))
+* ‘xegpu’ Dialect ([@chencha3](https://github.com/chencha3), [@Jianhui-Li](https://github.com/Jianhui-Li))
+
+#### CPU Dialects
+* ‘arm_neon’ Dialect ([@banach-space](https://github.com/banach-space))
+* ‘arm_sve’ Dialect ([@banach-space](https://github.com/banach-space))
+* ‘ArmSME’ Dialect ([@banach-space](https://github.com/banach-space))
+* ‘amx’ Dialect ([@asiem](https://github.com/adam-smnk))
+* ‘x86vector’ Dialect ([@asiem](https://github.com/adam-smnk))
+* ‘vcix’ Dialect ([@mshockwave](https://github.com/mshockwave))
+
+#### Paradigm Dialects
+* ‘omp’ Dialect ([@tblah](https://github.com/tblah), [@skatrak](https://github.com/skatrak))
+* ‘acc’ Dialect ([@clementval](https://github.com/clementval), [@razvanlupusoru](https://github.com/razvanlupusoru))
+* ‘mpi’ Dialect ([@fschlimb](https://github.com/fschlimb))
+* ‘mesh’ Dialect ([@fschlimb](https://github.com/fschlimb))
+
 ## Tensor Compiler
 
 MLIR components specific to construction of compilers for tensor algebra, in

--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -51,8 +51,8 @@ with the point-of-contact being the maintainers above. Named maintainers, if
 available, should be contacted first, as they're more active in those areas.
 
 #### Lowering Dialects
-* `llvm’ Dialect (egress)
-* ‘SPIR-V' Dialect ([@kuhar](https://github.com/kuhar), [@antiagainst](https://github.com/antiagainst))
+* ‘llvm’ Dialect (egress)
+* ‘SPIR-V’ Dialect ([@kuhar](https://github.com/kuhar), [@antiagainst](https://github.com/antiagainst))
 * ‘emitc’ Dialect ([@aniragil](https://github.com/aniragil), [@marbre](https://github.com/marbre))
 
 #### GPU Dialects

--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -69,7 +69,7 @@ available, should be contacted first, as they're more active in those areas.
 * ‘arm_sve’ Dialect ([@banach-space](https://github.com/banach-space))
 * ‘ArmSME’ Dialect ([@banach-space](https://github.com/banach-space))
 * ‘amx’ Dialect ([@adam-smnk](https://github.com/adam-smnk))
-* ‘x86vector’ Dialect ([@adam-smkk](https://github.com/adam-smnk))
+* ‘x86vector’ Dialect ([@adam-smnk](https://github.com/adam-smnk))
 * ‘vcix’ Dialect ([@mshockwave](https://github.com/mshockwave))
 
 #### Paradigm Dialects


### PR DESCRIPTION
As per https://discourse.llvm.org/t/mlir-project-maintainers/87189, this PR adds maintainers for the "egress" dialects. 

Compared to the original proposal, two changes are included:
* The "mesh" dialect has been renamed to "shard" (https://discourse.llvm.org/t/mlir-mesh-cleanup-mesh/).
* The "XeVM" dialect has been added (https://discourse.llvm.org/t/rfc-proposal-for-new-xevm-dialect/).