### PR TITLE
[libc] Add struct_sched_param proxy header

### DIFF
--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -451,3 +451,11 @@ add_proxy_header_library(
     libc.include.llvm-libc-types.ACTION
     libc.include.search
 )
+
+add_proxy_header_library(
+  struct_sched_param
+  HDRS
+    struct_sched_param.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.struct_sched_param
+)

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -432,6 +432,7 @@ add_proxy_header_library(
     cpu_set_t.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.cpu_set_t
+    libc.include.sched
 )
 
 add_proxy_header_library(
@@ -458,4 +459,5 @@ add_proxy_header_library(
     struct_sched_param.h
   FULL_BUILD_DEPENDS
     libc.include.llvm-libc-types.struct_sched_param
+    libc.include.sched
 )

--- a/libc/hdr/types/struct_sched_param.h
+++ b/libc/hdr/types/struct_sched_param.h
@@ -1,0 +1,22 @@
+//===-- Proxy for struct sched_param --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_HDR_TYPES_STRUCT_SCHED_PARAM_H
+#define LLVM_LIBC_HDR_TYPES_STRUCT_SCHED_PARAM_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/struct_sched_param.h"
+
+#else // Overlay mode
+
+#include <sched.h>
+
+#endif // LLVM_LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_SCHED_PARAM_H

--- a/libc/src/sched/linux/CMakeLists.txt
+++ b/libc/src/sched/linux/CMakeLists.txt
@@ -5,7 +5,6 @@ add_entrypoint_object(
   HDRS
     ../getcpu.h
   DEPENDS
-    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -69,9 +68,10 @@ add_entrypoint_object(
   HDRS
     ../sched_setparam.h
   DEPENDS
+    libc.hdr.types.pid_t
+    libc.hdr.types.struct_sched_param
     libc.include.sys_syscall
     libc.include.time
-    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -83,9 +83,10 @@ add_entrypoint_object(
   HDRS
     ../sched_getparam.h
   DEPENDS
+    libc.hdr.types.pid_t
+    libc.hdr.types.struct_sched_param
     libc.include.sys_syscall
     libc.include.time
-    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )
@@ -97,9 +98,10 @@ add_entrypoint_object(
   HDRS
     ../sched_setscheduler.h
   DEPENDS
+    libc.hdr.types.pid_t
+    libc.hdr.types.struct_sched_param
     libc.include.sys_syscall
     libc.include.time
-    libc.include.sched
     libc.src.__support.OSUtil.osutil
     libc.src.errno.errno
 )

--- a/libc/src/sched/sched_getparam.h
+++ b/libc/src/sched/sched_getparam.h
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_GETPARAM_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/pid_t.h"
+#include "hdr/types/struct_sched_param.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sched/sched_setparam.h
+++ b/libc/src/sched/sched_setparam.h
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_SETPARAM_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/pid_t.h"
+#include "hdr/types/struct_sched_param.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/sched/sched_setscheduler.h
+++ b/libc/src/sched/sched_setscheduler.h
@@ -10,7 +10,9 @@
 #define LLVM_LIBC_SRC_SCHED_SCHED_SETSCHEDULER_H
 
 #include "src/__support/macros/config.h"
-#include <sched.h>
+
+#include "hdr/types/pid_t.h"
+#include "hdr/types/struct_sched_param.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -48,7 +48,6 @@ add_libc_unittest(
   SRCS
     getcpu_test.cpp
   DEPENDS
-    libc.include.sched
     libc.src.errno.errno
     libc.src.sched.getcpu
     libc.test.UnitTest.ErrnoCheckingTest
@@ -61,7 +60,8 @@ add_libc_unittest(
   SRCS
     param_and_scheduler_test.cpp
   DEPENDS
-    libc.include.sched
+    libc.hdr.sched_macros
+    libc.hdr.types.struct_sched_param
     libc.src.errno.errno
     libc.src.sched.sched_getscheduler
     libc.src.sched.sched_setscheduler
@@ -79,6 +79,7 @@ add_libc_unittest(
   SRCS
     sched_rr_get_interval_test.cpp
   DEPENDS
+    libc.hdr.sched_macros
     libc.hdr.types.struct_timespec
     libc.src.errno.errno
     libc.src.sched.sched_getscheduler

--- a/libc/test/src/sched/param_and_scheduler_test.cpp
+++ b/libc/test/src/sched/param_and_scheduler_test.cpp
@@ -16,7 +16,8 @@
 #include "src/unistd/getuid.h"
 #include "test/UnitTest/Test.h"
 
-#include <sched.h>
+#include "hdr/sched_macros.h"
+#include "hdr/types/struct_sched_param.h"
 
 // We Test:
 // SCHED_OTHER, SCHED_FIFO, SCHED_RR

--- a/libc/test/src/sched/sched_rr_get_interval_test.cpp
+++ b/libc/test/src/sched/sched_rr_get_interval_test.cpp
@@ -14,6 +14,7 @@
 #include "src/unistd/getuid.h"
 #include "test/UnitTest/Test.h"
 
+#include "hdr/sched_macros.h"
 #include "hdr/types/struct_timespec.h"
 
 TEST(LlvmLibcSchedRRGetIntervalTest, SmokeTest) {


### PR DESCRIPTION
This enables cleaning up the remaining sched.h includes littered around the code base.