### PR TITLE
[CIR] Fix outdated bitfield iteration logic in accumulateFields

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenRecordLayoutBuilder.cpp
@@ -499,11 +499,7 @@ void CIRRecordLowering::accumulateFields() {
                                   fieldEnd = recordDecl->field_end();
        field != fieldEnd;) {
     if (field->isBitField()) {
-      RecordDecl::field_iterator start = field;
-      // Iterate to gather the list of bitfields.
-      for (++field; field != fieldEnd && field->isBitField(); ++field)
-        ;
-      field = accumulateBitFields(start, field);
+      field = accumulateBitFields(field, fieldEnd);
       assert((field == fieldEnd || !field->isBitField()) &&
              "Failed to accumulate all the bitfields");
     } else if (!field->isZeroSize(astContext)) {

--- a/clang/test/CIR/CodeGen/bitfields.c
+++ b/clang/test/CIR/CodeGen/bitfields.c
@@ -71,12 +71,23 @@ typedef struct {
 // LLVM-DAG: %struct.U = type <{ i8, i8, i8, i8, i64 }>
 // OGCG-DAG: %struct.U = type <{ i8, i8, i8, i8, i64 }>
 
+typedef struct{
+    int a : 24;
+    char b;
+    int c: 30;
+} Clip;
+
+// CIR-DAG: !rec_Clip = !cir.record<struct "Clip" {!cir.array<!u8i x 3>, !s8i, !u32i}>
+// LLVM-DAG: %struct.Clip = type { [3 x i8], i8, i32 }
+// OGCG-DAG: %struct.Clip = type { [3 x i8], i8, i32 }
+
 void def() {
   A a;
   D d;
   S s;
   T t;
   U u;
+  Clip c;
 }
 
 int load_field(S* s) {


### PR DESCRIPTION
This PR fixes the outdated logic for accumulating bitfields in `accumulateFields`. The old approach remained after the algorithm was updated. A non-bitfield member would act as a barrier, causing `accumulateBitFields` to receive an incomplete range of fields. As a result, it failed to accumulate them properly when clipping was necessary.

For reference, in ClangIR we already handle this correctly:
[https://github.com/llvm/clangir/blob/b647f4b97b1f936fd7700ec0fd0d896a12fe581b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp#L711-L714](https://github.com/llvm/clangir/blob/b647f4b97b1f936fd7700ec0fd0d896a12fe581b/clang/lib/CIR/CodeGen/CIRRecordLayoutBuilder.cpp#L711-L714)