### PR TITLE
[CG] Add VTs for v[567]i1 and v[567]f16

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -92,258 +92,264 @@ def v1i1    : VTVec<1,    i1, 17>;  //    1 x i1 vector value
 def v2i1    : VTVec<2,    i1, 18>;  //    2 x i1 vector value
 def v3i1    : VTVec<3,    i1, 19>;  //    3 x i1 vector value
 def v4i1    : VTVec<4,    i1, 20>;  //    4 x i1 vector value
-def v8i1    : VTVec<8,    i1, 21>;  //    8 x i1 vector value
-def v16i1   : VTVec<16,   i1, 22>;  //   16 x i1 vector value
-def v32i1   : VTVec<32,   i1, 23>;  //   32 x i1 vector value
-def v64i1   : VTVec<64,   i1, 24>;  //   64 x i1 vector value
-def v128i1  : VTVec<128,  i1, 25>;  //  128 x i1 vector value
-def v256i1  : VTVec<256,  i1, 26>;  //  256 x i1 vector value
-def v512i1  : VTVec<512,  i1, 27>;  //  512 x i1 vector value
-def v1024i1 : VTVec<1024, i1, 28>;  // 1024 x i1 vector value
-def v2048i1 : VTVec<2048, i1, 29>;  // 2048 x i1 vector value
-def v4096i1 : VTVec<4096, i1, 30>;  // 4096 x i1 vector value
+def v5i1    : VTVec<5,    i1, 21>;  //    5 x i1 vector value
+def v6i1    : VTVec<6,    i1, 22>;  //    6 x i1 vector value
+def v7i1    : VTVec<7,    i1, 23>;  //    7 x i1 vector value
+def v8i1    : VTVec<8,    i1, 24>;  //    8 x i1 vector value
+def v16i1   : VTVec<16,   i1, 25>;  //   16 x i1 vector value
+def v32i1   : VTVec<32,   i1, 26>;  //   32 x i1 vector value
+def v64i1   : VTVec<64,   i1, 27>;  //   64 x i1 vector value
+def v128i1  : VTVec<128,  i1, 28>;  //  128 x i1 vector value
+def v256i1  : VTVec<256,  i1, 29>;  //  256 x i1 vector value
+def v512i1  : VTVec<512,  i1, 30>;  //  512 x i1 vector value
+def v1024i1 : VTVec<1024, i1, 31>;  // 1024 x i1 vector value
+def v2048i1 : VTVec<2048, i1, 32>;  // 2048 x i1 vector value
+def v4096i1 : VTVec<4096, i1, 33>;  // 4096 x i1 vector value
 
-def v128i2  : VTVec<128,  i2, 31>;   //  128 x i2 vector value
-def v256i2  : VTVec<256,  i2, 32>;   //  256 x i2 vector value
+def v128i2  : VTVec<128,  i2, 34>;   //  128 x i2 vector value
+def v256i2  : VTVec<256,  i2, 35>;   //  256 x i2 vector value
 
-def v64i4   : VTVec<64,   i4, 33>;   //   64 x i4 vector value
-def v128i4  : VTVec<128,  i4, 34>;   //  128 x i4 vector value
+def v64i4   : VTVec<64,   i4, 36>;   //   64 x i4 vector value
+def v128i4  : VTVec<128,  i4, 37>;   //  128 x i4 vector value
 
-def v1i8    : VTVec<1,    i8, 35>;  //    1 x i8 vector value
-def v2i8    : VTVec<2,    i8, 36>;  //    2 x i8 vector value
-def v3i8    : VTVec<3,    i8, 37>;  //    3 x i8 vector value
-def v4i8    : VTVec<4,    i8, 38>;  //    4 x i8 vector value
-def v8i8    : VTVec<8,    i8, 39>;  //    8 x i8 vector value
-def v16i8   : VTVec<16,   i8, 40>;  //   16 x i8 vector value
-def v32i8   : VTVec<32,   i8, 41>;  //   32 x i8 vector value
-def v64i8   : VTVec<64,   i8, 42>;  //   64 x i8 vector value
-def v128i8  : VTVec<128,  i8, 43>;  //  128 x i8 vector value
-def v256i8  : VTVec<256,  i8, 44>;  //  256 x i8 vector value
-def v512i8  : VTVec<512,  i8, 45>;  //  512 x i8 vector value
-def v1024i8 : VTVec<1024, i8, 46>;  // 1024 x i8 vector value
+def v1i8    : VTVec<1,    i8, 38>;  //    1 x i8 vector value
+def v2i8    : VTVec<2,    i8, 39>;  //    2 x i8 vector value
+def v3i8    : VTVec<3,    i8, 40>;  //    3 x i8 vector value
+def v4i8    : VTVec<4,    i8, 41>;  //    4 x i8 vector value
+def v8i8    : VTVec<8,    i8, 42>;  //    8 x i8 vector value
+def v16i8   : VTVec<16,   i8, 43>;  //   16 x i8 vector value
+def v32i8   : VTVec<32,   i8, 44>;  //   32 x i8 vector value
+def v64i8   : VTVec<64,   i8, 45>;  //   64 x i8 vector value
+def v128i8  : VTVec<128,  i8, 46>;  //  128 x i8 vector value
+def v256i8  : VTVec<256,  i8, 47>;  //  256 x i8 vector value
+def v512i8  : VTVec<512,  i8, 48>;  //  512 x i8 vector value
+def v1024i8 : VTVec<1024, i8, 49>;  // 1024 x i8 vector value
 
-def v1i16    : VTVec<1,    i16, 47>;  //    1 x i16 vector value
-def v2i16    : VTVec<2,    i16, 48>;  //    2 x i16 vector value
-def v3i16    : VTVec<3,    i16, 49>;  //    3 x i16 vector value
-def v4i16    : VTVec<4,    i16, 50>;  //    4 x i16 vector value
-def v8i16    : VTVec<8,    i16, 51>;  //    8 x i16 vector value
-def v16i16   : VTVec<16,   i16, 52>;  //   16 x i16 vector value
-def v32i16   : VTVec<32,   i16, 53>;  //   32 x i16 vector value
-def v64i16   : VTVec<64,   i16, 54>;  //   64 x i16 vector value
-def v128i16  : VTVec<128,  i16, 55>;  //  128 x i16 vector value
-def v256i16  : VTVec<256,  i16, 56>;  //  256 x i16 vector value
-def v512i16  : VTVec<512,  i16, 57>;  //  512 x i16 vector value
-def v4096i16 : VTVec<4096, i16, 58>;  // 4096 x i16 vector value
+def v1i16    : VTVec<1,    i16, 50>;  //    1 x i16 vector value
+def v2i16    : VTVec<2,    i16, 51>;  //    2 x i16 vector value
+def v3i16    : VTVec<3,    i16, 52>;  //    3 x i16 vector value
+def v4i16    : VTVec<4,    i16, 53>;  //    4 x i16 vector value
+def v8i16    : VTVec<8,    i16, 54>;  //    8 x i16 vector value
+def v16i16   : VTVec<16,   i16, 55>;  //   16 x i16 vector value
+def v32i16   : VTVec<32,   i16, 56>;  //   32 x i16 vector value
+def v64i16   : VTVec<64,   i16, 57>;  //   64 x i16 vector value
+def v128i16  : VTVec<128,  i16, 58>;  //  128 x i16 vector value
+def v256i16  : VTVec<256,  i16, 59>;  //  256 x i16 vector value
+def v512i16  : VTVec<512,  i16, 60>;  //  512 x i16 vector value
+def v4096i16 : VTVec<4096, i16, 61>;  // 4096 x i16 vector value
 
-def v1i32    : VTVec<1,    i32, 59>;  //    1 x i32 vector value
-def v2i32    : VTVec<2,    i32, 60>;  //    2 x i32 vector value
-def v3i32    : VTVec<3,    i32, 61>;  //    3 x i32 vector value
-def v4i32    : VTVec<4,    i32, 62>;  //    4 x i32 vector value
-def v5i32    : VTVec<5,    i32, 63>;  //    5 x i32 vector value
-def v6i32    : VTVec<6,    i32, 64>;  //    6 x f32 vector value
-def v7i32    : VTVec<7,    i32, 65>;  //    7 x f32 vector value
-def v8i32    : VTVec<8,    i32, 66>;  //    8 x i32 vector value
-def v9i32    : VTVec<9,    i32, 67>;  //    9 x i32 vector value
-def v10i32   : VTVec<10,   i32, 68>;  //   10 x i32 vector value
-def v11i32   : VTVec<11,   i32, 69>;  //   11 x i32 vector value
-def v12i32   : VTVec<12,   i32, 70>;  //   12 x i32 vector value
-def v16i32   : VTVec<16,   i32, 71>;  //   16 x i32 vector value
-def v32i32   : VTVec<32,   i32, 72>;  //   32 x i32 vector value
-def v64i32   : VTVec<64,   i32, 73>;  //   64 x i32 vector value
-def v128i32  : VTVec<128,  i32, 74>;  //  128 x i32 vector value
-def v256i32  : VTVec<256,  i32, 75>;  //  256 x i32 vector value
-def v512i32  : VTVec<512,  i32, 76>;  //  512 x i32 vector value
-def v1024i32 : VTVec<1024, i32, 77>;  // 1024 x i32 vector value
-def v2048i32 : VTVec<2048, i32, 78>;  // 2048 x i32 vector value
-def v4096i32 : VTVec<4096, i32, 79>;  // 4096 x i32 vector value
+def v1i32    : VTVec<1,    i32, 62>;  //    1 x i32 vector value
+def v2i32    : VTVec<2,    i32, 63>;  //    2 x i32 vector value
+def v3i32    : VTVec<3,    i32, 64>;  //    3 x i32 vector value
+def v4i32    : VTVec<4,    i32, 65>;  //    4 x i32 vector value
+def v5i32    : VTVec<5,    i32, 66>;  //    5 x i32 vector value
+def v6i32    : VTVec<6,    i32, 67>;  //    6 x i32 vector value
+def v7i32    : VTVec<7,    i32, 68>;  //    7 x i32 vector value
+def v8i32    : VTVec<8,    i32, 69>;  //    8 x i32 vector value
+def v9i32    : VTVec<9,    i32, 70>;  //    9 x i32 vector value
+def v10i32   : VTVec<10,   i32, 71>;  //   10 x i32 vector value
+def v11i32   : VTVec<11,   i32, 72>;  //   11 x i32 vector value
+def v12i32   : VTVec<12,   i32, 73>;  //   12 x i32 vector value
+def v16i32   : VTVec<16,   i32, 74>;  //   16 x i32 vector value
+def v32i32   : VTVec<32,   i32, 75>;  //   32 x i32 vector value
+def v64i32   : VTVec<64,   i32, 76>;  //   64 x i32 vector value
+def v128i32  : VTVec<128,  i32, 77>;  //  128 x i32 vector value
+def v256i32  : VTVec<256,  i32, 78>;  //  256 x i32 vector value
+def v512i32  : VTVec<512,  i32, 79>;  //  512 x i32 vector value
+def v1024i32 : VTVec<1024, i32, 80>;  // 1024 x i32 vector value
+def v2048i32 : VTVec<2048, i32, 81>;  // 2048 x i32 vector value
+def v4096i32 : VTVec<4096, i32, 82>;  // 4096 x i32 vector value
 
-def v1i64   : VTVec<1,   i64, 80>;  //   1 x i64 vector value
-def v2i64   : VTVec<2,   i64, 81>;  //   2 x i64 vector value
-def v3i64   : VTVec<3,   i64, 82>;  //   3 x i64 vector value
-def v4i64   : VTVec<4,   i64, 83>;  //   4 x i64 vector value
-def v8i64   : VTVec<8,   i64, 84>;  //   8 x i64 vector value
-def v16i64  : VTVec<16,  i64, 85>;  //  16 x i64 vector value
-def v32i64  : VTVec<32,  i64, 86>;  //  32 x i64 vector value
-def v64i64  : VTVec<64,  i64, 87>;  //  64 x i64 vector value
-def v128i64 : VTVec<128, i64, 88>;  // 128 x i64 vector value
-def v256i64 : VTVec<256, i64, 89>;  // 256 x i64 vector value
+def v1i64   : VTVec<1,   i64, 83>;  //   1 x i64 vector value
+def v2i64   : VTVec<2,   i64, 84>;  //   2 x i64 vector value
+def v3i64   : VTVec<3,   i64, 85>;  //   3 x i64 vector value
+def v4i64   : VTVec<4,   i64, 86>;  //   4 x i64 vector value
+def v8i64   : VTVec<8,   i64, 87>;  //   8 x i64 vector value
+def v16i64  : VTVec<16,  i64, 88>;  //  16 x i64 vector value
+def v32i64  : VTVec<32,  i64, 89>;  //  32 x i64 vector value
+def v64i64  : VTVec<64,  i64, 90>;  //  64 x i64 vector value
+def v128i64 : VTVec<128, i64, 91>;  // 128 x i64 vector value
+def v256i64 : VTVec<256, i64, 92>;  // 256 x i64 vector value
 
-def v1i128  : VTVec<1,  i128, 90>;  //  1 x i128 vector value
+def v1i128  : VTVec<1,  i128, 93>;  //  1 x i128 vector value
 
-def v1f16    : VTVec<1,    f16,  91>;  //    1 x f16 vector value
-def v2f16    : VTVec<2,    f16,  92>;  //    2 x f16 vector value
-def v3f16    : VTVec<3,    f16,  93>;  //    3 x f16 vector value
-def v4f16    : VTVec<4,    f16,  94>;  //    4 x f16 vector value
-def v8f16    : VTVec<8,    f16,  95>;  //    8 x f16 vector value
-def v16f16   : VTVec<16,   f16,  96>;  //   16 x f16 vector value
-def v32f16   : VTVec<32,   f16,  97>;  //   32 x f16 vector value
-def v64f16   : VTVec<64,   f16,  98>;  //   64 x f16 vector value
-def v128f16  : VTVec<128,  f16,  99>;  //  128 x f16 vector value
-def v256f16  : VTVec<256,  f16, 100>;  //  256 x f16 vector value
-def v512f16  : VTVec<512,  f16, 101>;  //  512 x f16 vector value
-def v4096f16 : VTVec<4096, f16, 102>;  // 4096 x f16 vector value
+def v1f16    : VTVec<1,    f16,  94>;  //    1 x f16 vector value
+def v2f16    : VTVec<2,    f16,  95>;  //    2 x f16 vector value
+def v3f16    : VTVec<3,    f16,  96>;  //    3 x f16 vector value
+def v4f16    : VTVec<4,    f16,  97>;  //    4 x f16 vector value
+def v5f16    : VTVec<5,    f16,  98>;  //    5 x f16 vector value
+def v6f16    : VTVec<6,    f16,  99>;  //    6 x f16 vector value
+def v7f16    : VTVec<7,    f16, 100>;  //    7 x f16 vector value
+def v8f16    : VTVec<8,    f16, 101>;  //    8 x f16 vector value
+def v16f16   : VTVec<16,   f16, 102>;  //   16 x f16 vector value
+def v32f16   : VTVec<32,   f16, 103>;  //   32 x f16 vector value
+def v64f16   : VTVec<64,   f16, 104>;  //   64 x f16 vector value
+def v128f16  : VTVec<128,  f16, 105>;  //  128 x f16 vector value
+def v256f16  : VTVec<256,  f16, 106>;  //  256 x f16 vector value
+def v512f16  : VTVec<512,  f16, 107>;  //  512 x f16 vector value
+def v4096f16 : VTVec<4096, f16, 108>;  // 4096 x f16 vector value
 
-def v1bf16    : VTVec<1,    bf16, 103>;  //    1 x bf16 vector value
-def v2bf16    : VTVec<2,    bf16, 104>;  //    2 x bf16 vector value
-def v3bf16    : VTVec<3,    bf16, 105>;  //    3 x bf16 vector value
-def v4bf16    : VTVec<4,    bf16, 106>;  //    4 x bf16 vector value
-def v8bf16    : VTVec<8,    bf16, 107>;  //    8 x bf16 vector value
-def v16bf16   : VTVec<16,   bf16, 108>;  //   16 x bf16 vector value
-def v32bf16   : VTVec<32,   bf16, 109>;  //   32 x bf16 vector value
-def v64bf16   : VTVec<64,   bf16, 110>;  //   64 x bf16 vector value
-def v128bf16  : VTVec<128,  bf16, 111>;  //  128 x bf16 vector value
-def v4096bf16 : VTVec<4096, bf16, 112>;  // 4096 x bf16 vector value
+def v1bf16    : VTVec<1,    bf16, 109>;  //    1 x bf16 vector value
+def v2bf16    : VTVec<2,    bf16, 110>;  //    2 x bf16 vector value
+def v3bf16    : VTVec<3,    bf16, 111>;  //    3 x bf16 vector value
+def v4bf16    : VTVec<4,    bf16, 112>;  //    4 x bf16 vector value
+def v8bf16    : VTVec<8,    bf16, 113>;  //    8 x bf16 vector value
+def v16bf16   : VTVec<16,   bf16, 114>;  //   16 x bf16 vector value
+def v32bf16   : VTVec<32,   bf16, 115>;  //   32 x bf16 vector value
+def v64bf16   : VTVec<64,   bf16, 116>;  //   64 x bf16 vector value
+def v128bf16  : VTVec<128,  bf16, 117>;  //  128 x bf16 vector value
+def v4096bf16 : VTVec<4096, bf16, 118>;  // 4096 x bf16 vector value
 
-def v1f32    : VTVec<1,    f32, 113>;  //    1 x f32 vector value
-def v2f32    : VTVec<2,    f32, 114>;  //    2 x f32 vector value
-def v3f32    : VTVec<3,    f32, 115>;  //    3 x f32 vector value
-def v4f32    : VTVec<4,    f32, 116>;  //    4 x f32 vector value
-def v5f32    : VTVec<5,    f32, 117>;  //    5 x f32 vector value
-def v6f32    : VTVec<6,    f32, 118>;  //    6 x f32 vector value
-def v7f32    : VTVec<7,    f32, 119>;  //    7 x f32 vector value
-def v8f32    : VTVec<8,    f32, 120>;  //    8 x f32 vector value
-def v9f32    : VTVec<9,    f32, 121>;  //    9 x f32 vector value
-def v10f32   : VTVec<10,   f32, 122>;  //   10 x f32 vector value
-def v11f32   : VTVec<11,   f32, 123>;  //   11 x f32 vector value
-def v12f32   : VTVec<12,   f32, 124>;  //   12 x f32 vector value
-def v16f32   : VTVec<16,   f32, 125>;  //   16 x f32 vector value
-def v32f32   : VTVec<32,   f32, 126>;  //   32 x f32 vector value
-def v64f32   : VTVec<64,   f32, 127>;  //   64 x f32 vector value
-def v128f32  : VTVec<128,  f32, 128>;  //  128 x f32 vector value
-def v256f32  : VTVec<256,  f32, 129>;  //  256 x f32 vector value
-def v512f32  : VTVec<512,  f32, 130>;  //  512 x f32 vector value
-def v1024f32 : VTVec<1024, f32, 131>;  // 1024 x f32 vector value
-def v2048f32 : VTVec<2048, f32, 132>;  // 2048 x f32 vector value
+def v1f32    : VTVec<1,    f32, 119>;  //    1 x f32 vector value
+def v2f32    : VTVec<2,    f32, 120>;  //    2 x f32 vector value
+def v3f32    : VTVec<3,    f32, 121>;  //    3 x f32 vector value
+def v4f32    : VTVec<4,    f32, 122>;  //    4 x f32 vector value
+def v5f32    : VTVec<5,    f32, 123>;  //    5 x f32 vector value
+def v6f32    : VTVec<6,    f32, 124>;  //    6 x f32 vector value
+def v7f32    : VTVec<7,    f32, 125>;  //    7 x f32 vector value
+def v8f32    : VTVec<8,    f32, 126>;  //    8 x f32 vector value
+def v9f32    : VTVec<9,    f32, 127>;  //    9 x f32 vector value
+def v10f32   : VTVec<10,   f32, 128>;  //   10 x f32 vector value
+def v11f32   : VTVec<11,   f32, 129>;  //   11 x f32 vector value
+def v12f32   : VTVec<12,   f32, 130>;  //   12 x f32 vector value
+def v16f32   : VTVec<16,   f32, 131>;  //   16 x f32 vector value
+def v32f32   : VTVec<32,   f32, 132>;  //   32 x f32 vector value
+def v64f32   : VTVec<64,   f32, 133>;  //   64 x f32 vector value
+def v128f32  : VTVec<128,  f32, 134>;  //  128 x f32 vector value
+def v256f32  : VTVec<256,  f32, 135>;  //  256 x f32 vector value
+def v512f32  : VTVec<512,  f32, 136>;  //  512 x f32 vector value
+def v1024f32 : VTVec<1024, f32, 137>;  // 1024 x f32 vector value
+def v2048f32 : VTVec<2048, f32, 138>;  // 2048 x f32 vector value
 
-def v1f64    : VTVec<1,    f64, 133>;  //    1 x f64 vector value
-def v2f64    : VTVec<2,    f64, 134>;  //    2 x f64 vector value
-def v3f64    : VTVec<3,    f64, 135>;  //    3 x f64 vector value
-def v4f64    : VTVec<4,    f64, 136>;  //    4 x f64 vector value
-def v8f64    : VTVec<8,    f64, 137>;  //    8 x f64 vector value
-def v16f64   : VTVec<16,   f64, 138>;  //   16 x f64 vector value
-def v32f64   : VTVec<32,   f64, 139>;  //   32 x f64 vector value
-def v64f64   : VTVec<64,   f64, 140>;  //   64 x f64 vector value
-def v128f64  : VTVec<128,  f64, 141>;  //  128 x f64 vector value
-def v256f64  : VTVec<256,  f64, 142>;  //  256 x f64 vector value
+def v1f64    : VTVec<1,    f64, 139>;  //    1 x f64 vector value
+def v2f64    : VTVec<2,    f64, 140>;  //    2 x f64 vector value
+def v3f64    : VTVec<3,    f64, 141>;  //    3 x f64 vector value
+def v4f64    : VTVec<4,    f64, 142>;  //    4 x f64 vector value
+def v8f64    : VTVec<8,    f64, 143>;  //    8 x f64 vector value
+def v16f64   : VTVec<16,   f64, 144>;  //   16 x f64 vector value
+def v32f64   : VTVec<32,   f64, 145>;  //   32 x f64 vector value
+def v64f64   : VTVec<64,   f64, 146>;  //   64 x f64 vector value
+def v128f64  : VTVec<128,  f64, 147>;  //  128 x f64 vector value
+def v256f64  : VTVec<256,  f64, 148>;  //  256 x f64 vector value
 
-def nxv1i1  : VTScalableVec<1,  i1, 143>;  // n x  1 x i1  vector value
-def nxv2i1  : VTScalableVec<2,  i1, 144>;  // n x  2 x i1  vector value
-def nxv4i1  : VTScalableVec<4,  i1, 145>;  // n x  4 x i1  vector value
-def nxv8i1  : VTScalableVec<8,  i1, 146>;  // n x  8 x i1  vector value
-def nxv16i1 : VTScalableVec<16, i1, 147>;  // n x 16 x i1  vector value
-def nxv32i1 : VTScalableVec<32, i1, 148>;  // n x 32 x i1  vector value
-def nxv64i1 : VTScalableVec<64, i1, 149>;  // n x 64 x i1  vector value
+def nxv1i1  : VTScalableVec<1,  i1, 149>;  // n x  1 x i1  vector value
+def nxv2i1  : VTScalableVec<2,  i1, 150>;  // n x  2 x i1  vector value
+def nxv4i1  : VTScalableVec<4,  i1, 151>;  // n x  4 x i1  vector value
+def nxv8i1  : VTScalableVec<8,  i1, 152>;  // n x  8 x i1  vector value
+def nxv16i1 : VTScalableVec<16, i1, 153>;  // n x 16 x i1  vector value
+def nxv32i1 : VTScalableVec<32, i1, 154>;  // n x 32 x i1  vector value
+def nxv64i1 : VTScalableVec<64, i1, 155>;  // n x 64 x i1  vector value
 
-def nxv1i8  : VTScalableVec<1,  i8, 150>;  // n x  1 x i8  vector value
-def nxv2i8  : VTScalableVec<2,  i8, 151>;  // n x  2 x i8  vector value
-def nxv4i8  : VTScalableVec<4,  i8, 152>;  // n x  4 x i8  vector value
-def nxv8i8  : VTScalableVec<8,  i8, 153>;  // n x  8 x i8  vector value
-def nxv16i8 : VTScalableVec<16, i8, 154>;  // n x 16 x i8  vector value
-def nxv32i8 : VTScalableVec<32, i8, 155>;  // n x 32 x i8  vector value
-def nxv64i8 : VTScalableVec<64, i8, 156>;  // n x 64 x i8  vector value
+def nxv1i8  : VTScalableVec<1,  i8, 156>;  // n x  1 x i8  vector value
+def nxv2i8  : VTScalableVec<2,  i8, 157>;  // n x  2 x i8  vector value
+def nxv4i8  : VTScalableVec<4,  i8, 158>;  // n x  4 x i8  vector value
+def nxv8i8  : VTScalableVec<8,  i8, 159>;  // n x  8 x i8  vector value
+def nxv16i8 : VTScalableVec<16, i8, 160>;  // n x 16 x i8  vector value
+def nxv32i8 : VTScalableVec<32, i8, 161>;  // n x 32 x i8  vector value
+def nxv64i8 : VTScalableVec<64, i8, 162>;  // n x 64 x i8  vector value
 
-def nxv1i16  : VTScalableVec<1,  i16, 157>;  // n x  1 x i16 vector value
-def nxv2i16  : VTScalableVec<2,  i16, 158>;  // n x  2 x i16 vector value
-def nxv4i16  : VTScalableVec<4,  i16, 159>;  // n x  4 x i16 vector value
-def nxv8i16  : VTScalableVec<8,  i16, 160>;  // n x  8 x i16 vector value
-def nxv16i16 : VTScalableVec<16, i16, 161>;  // n x 16 x i16 vector value
-def nxv32i16 : VTScalableVec<32, i16, 162>;  // n x 32 x i16 vector value
+def nxv1i16  : VTScalableVec<1,  i16, 163>;  // n x  1 x i16 vector value
+def nxv2i16  : VTScalableVec<2,  i16, 164>;  // n x  2 x i16 vector value
+def nxv4i16  : VTScalableVec<4,  i16, 165>;  // n x  4 x i16 vector value
+def nxv8i16  : VTScalableVec<8,  i16, 166>;  // n x  8 x i16 vector value
+def nxv16i16 : VTScalableVec<16, i16, 167>;  // n x 16 x i16 vector value
+def nxv32i16 : VTScalableVec<32, i16, 168>;  // n x 32 x i16 vector value
 
-def nxv1i32  : VTScalableVec<1,  i32, 163>;  // n x  1 x i32 vector value
-def nxv2i32  : VTScalableVec<2,  i32, 164>;  // n x  2 x i32 vector value
-def nxv4i32  : VTScalableVec<4,  i32, 165>;  // n x  4 x i32 vector value
-def nxv8i32  : VTScalableVec<8,  i32, 166>;  // n x  8 x i32 vector value
-def nxv16i32 : VTScalableVec<16, i32, 167>;  // n x 16 x i32 vector value
-def nxv32i32 : VTScalableVec<32, i32, 168>;  // n x 32 x i32 vector value
+def nxv1i32  : VTScalableVec<1,  i32, 169>;  // n x  1 x i32 vector value
+def nxv2i32  : VTScalableVec<2,  i32, 170>;  // n x  2 x i32 vector value
+def nxv4i32  : VTScalableVec<4,  i32, 171>;  // n x  4 x i32 vector value
+def nxv8i32  : VTScalableVec<8,  i32, 172>;  // n x  8 x i32 vector value
+def nxv16i32 : VTScalableVec<16, i32, 173>;  // n x 16 x i32 vector value
+def nxv32i32 : VTScalableVec<32, i32, 174>;  // n x 32 x i32 vector value
 
-def nxv1i64  : VTScalableVec<1,  i64, 169>;  // n x  1 x i64 vector value
-def nxv2i64  : VTScalableVec<2,  i64, 170>;  // n x  2 x i64 vector value
-def nxv4i64  : VTScalableVec<4,  i64, 171>;  // n x  4 x i64 vector value
-def nxv8i64  : VTScalableVec<8,  i64, 172>;  // n x  8 x i64 vector value
-def nxv16i64 : VTScalableVec<16, i64, 173>;  // n x 16 x i64 vector value
-def nxv32i64 : VTScalableVec<32, i64, 174>;  // n x 32 x i64 vector value
+def nxv1i64  : VTScalableVec<1,  i64, 175>;  // n x  1 x i64 vector value
+def nxv2i64  : VTScalableVec<2,  i64, 176>;  // n x  2 x i64 vector value
+def nxv4i64  : VTScalableVec<4,  i64, 177>;  // n x  4 x i64 vector value
+def nxv8i64  : VTScalableVec<8,  i64, 178>;  // n x  8 x i64 vector value
+def nxv16i64 : VTScalableVec<16, i64, 179>;  // n x 16 x i64 vector value
+def nxv32i64 : VTScalableVec<32, i64, 180>;  // n x 32 x i64 vector value
 
-def nxv1f16  : VTScalableVec<1,  f16, 175>;  // n x  1 x  f16 vector value
-def nxv2f16  : VTScalableVec<2,  f16, 176>;  // n x  2 x  f16 vector value
-def nxv4f16  : VTScalableVec<4,  f16, 177>;  // n x  4 x  f16 vector value
-def nxv8f16  : VTScalableVec<8,  f16, 178>;  // n x  8 x  f16 vector value
-def nxv16f16 : VTScalableVec<16, f16, 179>;  // n x 16 x  f16 vector value
-def nxv32f16 : VTScalableVec<32, f16, 180>;  // n x 32 x  f16 vector value
+def nxv1f16  : VTScalableVec<1,  f16, 181>;  // n x  1 x  f16 vector value
+def nxv2f16  : VTScalableVec<2,  f16, 182>;  // n x  2 x  f16 vector value
+def nxv4f16  : VTScalableVec<4,  f16, 183>;  // n x  4 x  f16 vector value
+def nxv8f16  : VTScalableVec<8,  f16, 184>;  // n x  8 x  f16 vector value
+def nxv16f16 : VTScalableVec<16, f16, 185>;  // n x 16 x  f16 vector value
+def nxv32f16 : VTScalableVec<32, f16, 186>;  // n x 32 x  f16 vector value
 
-def nxv1bf16  : VTScalableVec<1,  bf16, 181>;  // n x  1 x bf16 vector value
-def nxv2bf16  : VTScalableVec<2,  bf16, 182>;  // n x  2 x bf16 vector value
-def nxv4bf16  : VTScalableVec<4,  bf16, 183>;  // n x  4 x bf16 vector value
-def nxv8bf16  : VTScalableVec<8,  bf16, 184>;  // n x  8 x bf16 vector value
-def nxv16bf16 : VTScalableVec<16, bf16, 185>;  // n x 16 x bf16 vector value
-def nxv32bf16 : VTScalableVec<32, bf16, 186>;  // n x 32 x bf16 vector value
+def nxv1bf16  : VTScalableVec<1,  bf16, 187>;  // n x  1 x bf16 vector value
+def nxv2bf16  : VTScalableVec<2,  bf16, 188>;  // n x  2 x bf16 vector value
+def nxv4bf16  : VTScalableVec<4,  bf16, 189>;  // n x  4 x bf16 vector value
+def nxv8bf16  : VTScalableVec<8,  bf16, 190>;  // n x  8 x bf16 vector value
+def nxv16bf16 : VTScalableVec<16, bf16, 191>;  // n x 16 x bf16 vector value
+def nxv32bf16 : VTScalableVec<32, bf16, 192>;  // n x 32 x bf16 vector value
 
-def nxv1f32  : VTScalableVec<1,  f32, 187>;  // n x  1 x  f32 vector value
-def nxv2f32  : VTScalableVec<2,  f32, 188>;  // n x  2 x  f32 vector value
-def nxv4f32  : VTScalableVec<4,  f32, 189>;  // n x  4 x  f32 vector value
-def nxv8f32  : VTScalableVec<8,  f32, 190>;  // n x  8 x  f32 vector value
-def nxv16f32 : VTScalableVec<16, f32, 191>;  // n x 16 x  f32 vector value
+def nxv1f32  : VTScalableVec<1,  f32, 193>;  // n x  1 x  f32 vector value
+def nxv2f32  : VTScalableVec<2,  f32, 194>;  // n x  2 x  f32 vector value
+def nxv4f32  : VTScalableVec<4,  f32, 195>;  // n x  4 x  f32 vector value
+def nxv8f32  : VTScalableVec<8,  f32, 196>;  // n x  8 x  f32 vector value
+def nxv16f32 : VTScalableVec<16, f32, 197>;  // n x 16 x  f32 vector value
 
-def nxv1f64  : VTScalableVec<1,  f64, 192>;  // n x  1 x  f64 vector value
-def nxv2f64  : VTScalableVec<2,  f64, 193>;  // n x  2 x  f64 vector value
-def nxv4f64  : VTScalableVec<4,  f64, 194>;  // n x  4 x  f64 vector value
-def nxv8f64  : VTScalableVec<8,  f64, 195>;  // n x  8 x  f64 vector value
+def nxv1f64  : VTScalableVec<1,  f64, 198>;  // n x  1 x  f64 vector value
+def nxv2f64  : VTScalableVec<2,  f64, 199>;  // n x  2 x  f64 vector value
+def nxv4f64  : VTScalableVec<4,  f64, 200>;  // n x  4 x  f64 vector value
+def nxv8f64  : VTScalableVec<8,  f64, 201>;  // n x  8 x  f64 vector value
 
 // Sz = NF * MinNumElts * 8(bits)
-def riscv_nxv1i8x2   : VTVecTup<16,  2, i8, 196>;  // RISCV vector tuple(min_num_elts=1,  nf=2)
-def riscv_nxv1i8x3   : VTVecTup<24,  3, i8, 197>;  // RISCV vector tuple(min_num_elts=1,  nf=3)
-def riscv_nxv1i8x4   : VTVecTup<32,  4, i8, 198>;  // RISCV vector tuple(min_num_elts=1,  nf=4)
-def riscv_nxv1i8x5   : VTVecTup<40,  5, i8, 199>;  // RISCV vector tuple(min_num_elts=1,  nf=5)
-def riscv_nxv1i8x6   : VTVecTup<48,  6, i8, 200>;  // RISCV vector tuple(min_num_elts=1,  nf=6)
-def riscv_nxv1i8x7   : VTVecTup<56,  7, i8, 201>;  // RISCV vector tuple(min_num_elts=1,  nf=7)
-def riscv_nxv1i8x8   : VTVecTup<64,  8, i8, 202>;  // RISCV vector tuple(min_num_elts=1,  nf=8)
-def riscv_nxv2i8x2   : VTVecTup<32,  2, i8, 203>;  // RISCV vector tuple(min_num_elts=2,  nf=2)
-def riscv_nxv2i8x3   : VTVecTup<48,  3, i8, 204>;  // RISCV vector tuple(min_num_elts=2,  nf=3)
-def riscv_nxv2i8x4   : VTVecTup<64,  4, i8, 205>;  // RISCV vector tuple(min_num_elts=2,  nf=4)
-def riscv_nxv2i8x5   : VTVecTup<80,  5, i8, 206>;  // RISCV vector tuple(min_num_elts=2,  nf=5)
-def riscv_nxv2i8x6   : VTVecTup<96,  6, i8, 207>;  // RISCV vector tuple(min_num_elts=2,  nf=6)
-def riscv_nxv2i8x7   : VTVecTup<112, 7, i8, 208>;  // RISCV vector tuple(min_num_elts=2,  nf=7)
-def riscv_nxv2i8x8   : VTVecTup<128, 8, i8, 209>;  // RISCV vector tuple(min_num_elts=2,  nf=8)
-def riscv_nxv4i8x2   : VTVecTup<64,  2, i8, 210>;  // RISCV vector tuple(min_num_elts=4,  nf=2)
-def riscv_nxv4i8x3   : VTVecTup<96,  3, i8, 211>;  // RISCV vector tuple(min_num_elts=4,  nf=3)
-def riscv_nxv4i8x4   : VTVecTup<128, 4, i8, 212>;  // RISCV vector tuple(min_num_elts=4,  nf=4)
-def riscv_nxv4i8x5   : VTVecTup<160, 5, i8, 213>;  // RISCV vector tuple(min_num_elts=4,  nf=5)
-def riscv_nxv4i8x6   : VTVecTup<192, 6, i8, 214>;  // RISCV vector tuple(min_num_elts=4,  nf=6)
-def riscv_nxv4i8x7   : VTVecTup<224, 7, i8, 215>;  // RISCV vector tuple(min_num_elts=4,  nf=7)
-def riscv_nxv4i8x8   : VTVecTup<256, 8, i8, 216>;  // RISCV vector tuple(min_num_elts=4,  nf=8)
-def riscv_nxv8i8x2   : VTVecTup<128, 2, i8, 217>;  // RISCV vector tuple(min_num_elts=8,  nf=2)
-def riscv_nxv8i8x3   : VTVecTup<192, 3, i8, 218>;  // RISCV vector tuple(min_num_elts=8,  nf=3)
-def riscv_nxv8i8x4   : VTVecTup<256, 4, i8, 219>;  // RISCV vector tuple(min_num_elts=8,  nf=4)
-def riscv_nxv8i8x5   : VTVecTup<320, 5, i8, 220>;  // RISCV vector tuple(min_num_elts=8,  nf=5)
-def riscv_nxv8i8x6   : VTVecTup<384, 6, i8, 221>;  // RISCV vector tuple(min_num_elts=8,  nf=6)
-def riscv_nxv8i8x7   : VTVecTup<448, 7, i8, 222>;  // RISCV vector tuple(min_num_elts=8,  nf=7)
-def riscv_nxv8i8x8   : VTVecTup<512, 8, i8, 223>;  // RISCV vector tuple(min_num_elts=8,  nf=8)
-def riscv_nxv16i8x2  : VTVecTup<256, 2, i8, 224>;  // RISCV vector tuple(min_num_elts=16, nf=2)
-def riscv_nxv16i8x3  : VTVecTup<384, 3, i8, 225>;  // RISCV vector tuple(min_num_elts=16, nf=3)
-def riscv_nxv16i8x4  : VTVecTup<512, 4, i8, 226>;  // RISCV vector tuple(min_num_elts=16, nf=4)
-def riscv_nxv32i8x2  : VTVecTup<512, 2, i8, 227>;  // RISCV vector tuple(min_num_elts=32, nf=2)
+def riscv_nxv1i8x2   : VTVecTup<16,  2, i8, 202>;  // RISCV vector tuple(min_num_elts=1,  nf=2)
+def riscv_nxv1i8x3   : VTVecTup<24,  3, i8, 203>;  // RISCV vector tuple(min_num_elts=1,  nf=3)
+def riscv_nxv1i8x4   : VTVecTup<32,  4, i8, 204>;  // RISCV vector tuple(min_num_elts=1,  nf=4)
+def riscv_nxv1i8x5   : VTVecTup<40,  5, i8, 205>;  // RISCV vector tuple(min_num_elts=1,  nf=5)
+def riscv_nxv1i8x6   : VTVecTup<48,  6, i8, 206>;  // RISCV vector tuple(min_num_elts=1,  nf=6)
+def riscv_nxv1i8x7   : VTVecTup<56,  7, i8, 207>;  // RISCV vector tuple(min_num_elts=1,  nf=7)
+def riscv_nxv1i8x8   : VTVecTup<64,  8, i8, 208>;  // RISCV vector tuple(min_num_elts=1,  nf=8)
+def riscv_nxv2i8x2   : VTVecTup<32,  2, i8, 209>;  // RISCV vector tuple(min_num_elts=2,  nf=2)
+def riscv_nxv2i8x3   : VTVecTup<48,  3, i8, 210>;  // RISCV vector tuple(min_num_elts=2,  nf=3)
+def riscv_nxv2i8x4   : VTVecTup<64,  4, i8, 211>;  // RISCV vector tuple(min_num_elts=2,  nf=4)
+def riscv_nxv2i8x5   : VTVecTup<80,  5, i8, 212>;  // RISCV vector tuple(min_num_elts=2,  nf=5)
+def riscv_nxv2i8x6   : VTVecTup<96,  6, i8, 213>;  // RISCV vector tuple(min_num_elts=2,  nf=6)
+def riscv_nxv2i8x7   : VTVecTup<112, 7, i8, 214>;  // RISCV vector tuple(min_num_elts=2,  nf=7)
+def riscv_nxv2i8x8   : VTVecTup<128, 8, i8, 215>;  // RISCV vector tuple(min_num_elts=2,  nf=8)
+def riscv_nxv4i8x2   : VTVecTup<64,  2, i8, 216>;  // RISCV vector tuple(min_num_elts=4,  nf=2)
+def riscv_nxv4i8x3   : VTVecTup<96,  3, i8, 217>;  // RISCV vector tuple(min_num_elts=4,  nf=3)
+def riscv_nxv4i8x4   : VTVecTup<128, 4, i8, 218>;  // RISCV vector tuple(min_num_elts=4,  nf=4)
+def riscv_nxv4i8x5   : VTVecTup<160, 5, i8, 219>;  // RISCV vector tuple(min_num_elts=4,  nf=5)
+def riscv_nxv4i8x6   : VTVecTup<192, 6, i8, 220>;  // RISCV vector tuple(min_num_elts=4,  nf=6)
+def riscv_nxv4i8x7   : VTVecTup<224, 7, i8, 221>;  // RISCV vector tuple(min_num_elts=4,  nf=7)
+def riscv_nxv4i8x8   : VTVecTup<256, 8, i8, 222>;  // RISCV vector tuple(min_num_elts=4,  nf=8)
+def riscv_nxv8i8x2   : VTVecTup<128, 2, i8, 223>;  // RISCV vector tuple(min_num_elts=8,  nf=2)
+def riscv_nxv8i8x3   : VTVecTup<192, 3, i8, 224>;  // RISCV vector tuple(min_num_elts=8,  nf=3)
+def riscv_nxv8i8x4   : VTVecTup<256, 4, i8, 225>;  // RISCV vector tuple(min_num_elts=8,  nf=4)
+def riscv_nxv8i8x5   : VTVecTup<320, 5, i8, 226>;  // RISCV vector tuple(min_num_elts=8,  nf=5)
+def riscv_nxv8i8x6   : VTVecTup<384, 6, i8, 227>;  // RISCV vector tuple(min_num_elts=8,  nf=6)
+def riscv_nxv8i8x7   : VTVecTup<448, 7, i8, 228>;  // RISCV vector tuple(min_num_elts=8,  nf=7)
+def riscv_nxv8i8x8   : VTVecTup<512, 8, i8, 229>;  // RISCV vector tuple(min_num_elts=8,  nf=8)
+def riscv_nxv16i8x2  : VTVecTup<256, 2, i8, 230>;  // RISCV vector tuple(min_num_elts=16, nf=2)
+def riscv_nxv16i8x3  : VTVecTup<384, 3, i8, 231>;  // RISCV vector tuple(min_num_elts=16, nf=3)
+def riscv_nxv16i8x4  : VTVecTup<512, 4, i8, 232>;  // RISCV vector tuple(min_num_elts=16, nf=4)
+def riscv_nxv32i8x2  : VTVecTup<512, 2, i8, 233>;  // RISCV vector tuple(min_num_elts=32, nf=2)
 
-def x86mmx    : ValueType<64,   228>;  // X86 MMX value
-def Glue      : ValueType<0,    229>;  // Pre-RA sched glue
-def isVoid    : ValueType<0,    230>;  // Produces no value
-def untyped   : ValueType<8,    231> { // Produces an untyped value
+def x86mmx    : ValueType<64,   234>;  // X86 MMX value
+def Glue      : ValueType<0,    235>;  // Pre-RA sched glue
+def isVoid    : ValueType<0,    236>;  // Produces no value
+def untyped   : ValueType<8,    237> { // Produces an untyped value
   let LLVMName = "Untyped";
 }
-def funcref   : ValueType<0,    232>;  // WebAssembly's funcref type
-def externref : ValueType<0,    233>;  // WebAssembly's externref type
-def exnref    : ValueType<0,    234>;  // WebAssembly's exnref type
-def x86amx    : ValueType<8192, 235>;  // X86 AMX value
-def i64x8     : ValueType<512,  236>;  // 8 Consecutive GPRs (AArch64)
+def funcref   : ValueType<0,    238>;  // WebAssembly's funcref type
+def externref : ValueType<0,    239>;  // WebAssembly's externref type
+def exnref    : ValueType<0,    240>;  // WebAssembly's exnref type
+def x86amx    : ValueType<8192, 241>;  // X86 AMX value
+def i64x8     : ValueType<512,  242>;  // 8 Consecutive GPRs (AArch64)
 def aarch64svcount
-              : ValueType<16,  237>;  // AArch64 predicate-as-counter
-def spirvbuiltin : ValueType<0, 238>; // SPIR-V's builtin type
+              : ValueType<16,  243>;  // AArch64 predicate-as-counter
+def spirvbuiltin : ValueType<0, 244>; // SPIR-V's builtin type
 // AMDGPU buffer fat pointer, buffer rsrc + offset, rewritten before MIR translation.
 // FIXME: Remove this and the getPointerType() override if MVT::i160 is added.
-def amdgpuBufferFatPointer : ValueType<160, 239>;
+def amdgpuBufferFatPointer : ValueType<160, 245>;
 // AMDGPU buffer strided pointer, buffer rsrc + index + offset, doesn't reach MIR.
 // FIXME: Remove this and the getPointerType() override if MVT::i82 is added.
-def amdgpuBufferStridedPointer : ValueType<192, 240>;
+def amdgpuBufferStridedPointer : ValueType<192, 246>;
 
-def aarch64mfp8 : ValueType<8,  241>;  // 8-bit value in FPR (AArch64)
+def aarch64mfp8 : ValueType<8,  247>;  // 8-bit value in FPR (AArch64)
 
 let isNormalValueType = false in {
 def token      : ValueType<0, 504>;  // TokenTy

--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -116,240 +116,246 @@ def v1i8    : VTVec<1,    i8, 38>;  //    1 x i8 vector value
 def v2i8    : VTVec<2,    i8, 39>;  //    2 x i8 vector value
 def v3i8    : VTVec<3,    i8, 40>;  //    3 x i8 vector value
 def v4i8    : VTVec<4,    i8, 41>;  //    4 x i8 vector value
-def v8i8    : VTVec<8,    i8, 42>;  //    8 x i8 vector value
-def v16i8   : VTVec<16,   i8, 43>;  //   16 x i8 vector value
-def v32i8   : VTVec<32,   i8, 44>;  //   32 x i8 vector value
-def v64i8   : VTVec<64,   i8, 45>;  //   64 x i8 vector value
-def v128i8  : VTVec<128,  i8, 46>;  //  128 x i8 vector value
-def v256i8  : VTVec<256,  i8, 47>;  //  256 x i8 vector value
-def v512i8  : VTVec<512,  i8, 48>;  //  512 x i8 vector value
-def v1024i8 : VTVec<1024, i8, 49>;  // 1024 x i8 vector value
+def v5i8    : VTVec<5,    i8, 42>;  //    5 x i8 vector value
+def v6i8    : VTVec<6,    i8, 43>;  //    6 x i8 vector value
+def v7i8    : VTVec<7,    i8, 44>;  //    7 x i8 vector value
+def v8i8    : VTVec<8,    i8, 45>;  //    8 x i8 vector value
+def v16i8   : VTVec<16,   i8, 46>;  //   16 x i8 vector value
+def v32i8   : VTVec<32,   i8, 47>;  //   32 x i8 vector value
+def v64i8   : VTVec<64,   i8, 48>;  //   64 x i8 vector value
+def v128i8  : VTVec<128,  i8, 49>;  //  128 x i8 vector value
+def v256i8  : VTVec<256,  i8, 50>;  //  256 x i8 vector value
+def v512i8  : VTVec<512,  i8, 51>;  //  512 x i8 vector value
+def v1024i8 : VTVec<1024, i8, 52>;  // 1024 x i8 vector value
 
-def v1i16    : VTVec<1,    i16, 50>;  //    1 x i16 vector value
-def v2i16    : VTVec<2,    i16, 51>;  //    2 x i16 vector value
-def v3i16    : VTVec<3,    i16, 52>;  //    3 x i16 vector value
-def v4i16    : VTVec<4,    i16, 53>;  //    4 x i16 vector value
-def v8i16    : VTVec<8,    i16, 54>;  //    8 x i16 vector value
-def v16i16   : VTVec<16,   i16, 55>;  //   16 x i16 vector value
-def v32i16   : VTVec<32,   i16, 56>;  //   32 x i16 vector value
-def v64i16   : VTVec<64,   i16, 57>;  //   64 x i16 vector value
-def v128i16  : VTVec<128,  i16, 58>;  //  128 x i16 vector value
-def v256i16  : VTVec<256,  i16, 59>;  //  256 x i16 vector value
-def v512i16  : VTVec<512,  i16, 60>;  //  512 x i16 vector value
-def v4096i16 : VTVec<4096, i16, 61>;  // 4096 x i16 vector value
+def v1i16    : VTVec<1,    i16, 53>;  //    1 x i16 vector value
+def v2i16    : VTVec<2,    i16, 54>;  //    2 x i16 vector value
+def v3i16    : VTVec<3,    i16, 55>;  //    3 x i16 vector value
+def v4i16    : VTVec<4,    i16, 56>;  //    4 x i16 vector value
+def v5i16    : VTVec<5,    i16, 57>;  //    5 x i16 vector value
+def v6i16    : VTVec<6,    i16, 58>;  //    6 x i16 vector value
+def v7i16    : VTVec<7,    i16, 59>;  //    7 x i16 vector value
+def v8i16    : VTVec<8,    i16, 60>;  //    8 x i16 vector value
+def v16i16   : VTVec<16,   i16, 61>;  //   16 x i16 vector value
+def v32i16   : VTVec<32,   i16, 62>;  //   32 x i16 vector value
+def v64i16   : VTVec<64,   i16, 63>;  //   64 x i16 vector value
+def v128i16  : VTVec<128,  i16, 64>;  //  128 x i16 vector value
+def v256i16  : VTVec<256,  i16, 65>;  //  256 x i16 vector value
+def v512i16  : VTVec<512,  i16, 66>;  //  512 x i16 vector value
+def v4096i16 : VTVec<4096, i16, 67>;  // 4096 x i16 vector value
 
-def v1i32    : VTVec<1,    i32, 62>;  //    1 x i32 vector value
-def v2i32    : VTVec<2,    i32, 63>;  //    2 x i32 vector value
-def v3i32    : VTVec<3,    i32, 64>;  //    3 x i32 vector value
-def v4i32    : VTVec<4,    i32, 65>;  //    4 x i32 vector value
-def v5i32    : VTVec<5,    i32, 66>;  //    5 x i32 vector value
-def v6i32    : VTVec<6,    i32, 67>;  //    6 x i32 vector value
-def v7i32    : VTVec<7,    i32, 68>;  //    7 x i32 vector value
-def v8i32    : VTVec<8,    i32, 69>;  //    8 x i32 vector value
-def v9i32    : VTVec<9,    i32, 70>;  //    9 x i32 vector value
-def v10i32   : VTVec<10,   i32, 71>;  //   10 x i32 vector value
-def v11i32   : VTVec<11,   i32, 72>;  //   11 x i32 vector value
-def v12i32   : VTVec<12,   i32, 73>;  //   12 x i32 vector value
-def v16i32   : VTVec<16,   i32, 74>;  //   16 x i32 vector value
-def v32i32   : VTVec<32,   i32, 75>;  //   32 x i32 vector value
-def v64i32   : VTVec<64,   i32, 76>;  //   64 x i32 vector value
-def v128i32  : VTVec<128,  i32, 77>;  //  128 x i32 vector value
-def v256i32  : VTVec<256,  i32, 78>;  //  256 x i32 vector value
-def v512i32  : VTVec<512,  i32, 79>;  //  512 x i32 vector value
-def v1024i32 : VTVec<1024, i32, 80>;  // 1024 x i32 vector value
-def v2048i32 : VTVec<2048, i32, 81>;  // 2048 x i32 vector value
-def v4096i32 : VTVec<4096, i32, 82>;  // 4096 x i32 vector value
+def v1i32    : VTVec<1,    i32, 68>;  //    1 x i32 vector value
+def v2i32    : VTVec<2,    i32, 69>;  //    2 x i32 vector value
+def v3i32    : VTVec<3,    i32, 70>;  //    3 x i32 vector value
+def v4i32    : VTVec<4,    i32, 71>;  //    4 x i32 vector value
+def v5i32    : VTVec<5,    i32, 72>;  //    5 x i32 vector value
+def v6i32    : VTVec<6,    i32, 73>;  //    6 x i32 vector value
+def v7i32    : VTVec<7,    i32, 74>;  //    7 x i32 vector value
+def v8i32    : VTVec<8,    i32, 75>;  //    8 x i32 vector value
+def v9i32    : VTVec<9,    i32, 76>;  //    9 x i32 vector value
+def v10i32   : VTVec<10,   i32, 77>;  //   10 x i32 vector value
+def v11i32   : VTVec<11,   i32, 78>;  //   11 x i32 vector value
+def v12i32   : VTVec<12,   i32, 79>;  //   12 x i32 vector value
+def v16i32   : VTVec<16,   i32, 80>;  //   16 x i32 vector value
+def v32i32   : VTVec<32,   i32, 81>;  //   32 x i32 vector value
+def v64i32   : VTVec<64,   i32, 82>;  //   64 x i32 vector value
+def v128i32  : VTVec<128,  i32, 83>;  //  128 x i32 vector value
+def v256i32  : VTVec<256,  i32, 84>;  //  256 x i32 vector value
+def v512i32  : VTVec<512,  i32, 85>;  //  512 x i32 vector value
+def v1024i32 : VTVec<1024, i32, 86>;  // 1024 x i32 vector value
+def v2048i32 : VTVec<2048, i32, 87>;  // 2048 x i32 vector value
+def v4096i32 : VTVec<4096, i32, 88>;  // 4096 x i32 vector value
 
-def v1i64   : VTVec<1,   i64, 83>;  //   1 x i64 vector value
-def v2i64   : VTVec<2,   i64, 84>;  //   2 x i64 vector value
-def v3i64   : VTVec<3,   i64, 85>;  //   3 x i64 vector value
-def v4i64   : VTVec<4,   i64, 86>;  //   4 x i64 vector value
-def v8i64   : VTVec<8,   i64, 87>;  //   8 x i64 vector value
-def v16i64  : VTVec<16,  i64, 88>;  //  16 x i64 vector value
-def v32i64  : VTVec<32,  i64, 89>;  //  32 x i64 vector value
-def v64i64  : VTVec<64,  i64, 90>;  //  64 x i64 vector value
-def v128i64 : VTVec<128, i64, 91>;  // 128 x i64 vector value
-def v256i64 : VTVec<256, i64, 92>;  // 256 x i64 vector value
+def v1i64   : VTVec<1,   i64, 89>;  //   1 x i64 vector value
+def v2i64   : VTVec<2,   i64, 90>;  //   2 x i64 vector value
+def v3i64   : VTVec<3,   i64, 91>;  //   3 x i64 vector value
+def v4i64   : VTVec<4,   i64, 92>;  //   4 x i64 vector value
+def v8i64   : VTVec<8,   i64, 93>;  //   8 x i64 vector value
+def v16i64  : VTVec<16,  i64, 94>;  //  16 x i64 vector value
+def v32i64  : VTVec<32,  i64, 95>;  //  32 x i64 vector value
+def v64i64  : VTVec<64,  i64, 96>;  //  64 x i64 vector value
+def v128i64 : VTVec<128, i64, 97>;  // 128 x i64 vector value
+def v256i64 : VTVec<256, i64, 98>;  // 256 x i64 vector value
 
-def v1i128  : VTVec<1,  i128, 93>;  //  1 x i128 vector value
+def v1i128  : VTVec<1,  i128, 99>;  //  1 x i128 vector value
 
-def v1f16    : VTVec<1,    f16,  94>;  //    1 x f16 vector value
-def v2f16    : VTVec<2,    f16,  95>;  //    2 x f16 vector value
-def v3f16    : VTVec<3,    f16,  96>;  //    3 x f16 vector value
-def v4f16    : VTVec<4,    f16,  97>;  //    4 x f16 vector value
-def v5f16    : VTVec<5,    f16,  98>;  //    5 x f16 vector value
-def v6f16    : VTVec<6,    f16,  99>;  //    6 x f16 vector value
-def v7f16    : VTVec<7,    f16, 100>;  //    7 x f16 vector value
-def v8f16    : VTVec<8,    f16, 101>;  //    8 x f16 vector value
-def v16f16   : VTVec<16,   f16, 102>;  //   16 x f16 vector value
-def v32f16   : VTVec<32,   f16, 103>;  //   32 x f16 vector value
-def v64f16   : VTVec<64,   f16, 104>;  //   64 x f16 vector value
-def v128f16  : VTVec<128,  f16, 105>;  //  128 x f16 vector value
-def v256f16  : VTVec<256,  f16, 106>;  //  256 x f16 vector value
-def v512f16  : VTVec<512,  f16, 107>;  //  512 x f16 vector value
-def v4096f16 : VTVec<4096, f16, 108>;  // 4096 x f16 vector value
+def v1f16    : VTVec<1,    f16, 100>;  //    1 x f16 vector value
+def v2f16    : VTVec<2,    f16, 101>;  //    2 x f16 vector value
+def v3f16    : VTVec<3,    f16, 102>;  //    3 x f16 vector value
+def v4f16    : VTVec<4,    f16, 103>;  //    4 x f16 vector value
+def v5f16    : VTVec<5,    f16, 104>;  //    5 x f16 vector value
+def v6f16    : VTVec<6,    f16, 105>;  //    6 x f16 vector value
+def v7f16    : VTVec<7,    f16, 106>;  //    7 x f16 vector value
+def v8f16    : VTVec<8,    f16, 107>;  //    8 x f16 vector value
+def v16f16   : VTVec<16,   f16, 108>;  //   16 x f16 vector value
+def v32f16   : VTVec<32,   f16, 109>;  //   32 x f16 vector value
+def v64f16   : VTVec<64,   f16, 110>;  //   64 x f16 vector value
+def v128f16  : VTVec<128,  f16, 111>;  //  128 x f16 vector value
+def v256f16  : VTVec<256,  f16, 112>;  //  256 x f16 vector value
+def v512f16  : VTVec<512,  f16, 113>;  //  512 x f16 vector value
+def v4096f16 : VTVec<4096, f16, 114>;  // 4096 x f16 vector value
 
-def v1bf16    : VTVec<1,    bf16, 109>;  //    1 x bf16 vector value
-def v2bf16    : VTVec<2,    bf16, 110>;  //    2 x bf16 vector value
-def v3bf16    : VTVec<3,    bf16, 111>;  //    3 x bf16 vector value
-def v4bf16    : VTVec<4,    bf16, 112>;  //    4 x bf16 vector value
-def v8bf16    : VTVec<8,    bf16, 113>;  //    8 x bf16 vector value
-def v16bf16   : VTVec<16,   bf16, 114>;  //   16 x bf16 vector value
-def v32bf16   : VTVec<32,   bf16, 115>;  //   32 x bf16 vector value
-def v64bf16   : VTVec<64,   bf16, 116>;  //   64 x bf16 vector value
-def v128bf16  : VTVec<128,  bf16, 117>;  //  128 x bf16 vector value
-def v4096bf16 : VTVec<4096, bf16, 118>;  // 4096 x bf16 vector value
+def v1bf16    : VTVec<1,    bf16, 115>;  //    1 x bf16 vector value
+def v2bf16    : VTVec<2,    bf16, 116>;  //    2 x bf16 vector value
+def v3bf16    : VTVec<3,    bf16, 117>;  //    3 x bf16 vector value
+def v4bf16    : VTVec<4,    bf16, 118>;  //    4 x bf16 vector value
+def v8bf16    : VTVec<8,    bf16, 119>;  //    8 x bf16 vector value
+def v16bf16   : VTVec<16,   bf16, 120>;  //   16 x bf16 vector value
+def v32bf16   : VTVec<32,   bf16, 121>;  //   32 x bf16 vector value
+def v64bf16   : VTVec<64,   bf16, 122>;  //   64 x bf16 vector value
+def v128bf16  : VTVec<128,  bf16, 123>;  //  128 x bf16 vector value
+def v4096bf16 : VTVec<4096, bf16, 124>;  // 4096 x bf16 vector value
 
-def v1f32    : VTVec<1,    f32, 119>;  //    1 x f32 vector value
-def v2f32    : VTVec<2,    f32, 120>;  //    2 x f32 vector value
-def v3f32    : VTVec<3,    f32, 121>;  //    3 x f32 vector value
-def v4f32    : VTVec<4,    f32, 122>;  //    4 x f32 vector value
-def v5f32    : VTVec<5,    f32, 123>;  //    5 x f32 vector value
-def v6f32    : VTVec<6,    f32, 124>;  //    6 x f32 vector value
-def v7f32    : VTVec<7,    f32, 125>;  //    7 x f32 vector value
-def v8f32    : VTVec<8,    f32, 126>;  //    8 x f32 vector value
-def v9f32    : VTVec<9,    f32, 127>;  //    9 x f32 vector value
-def v10f32   : VTVec<10,   f32, 128>;  //   10 x f32 vector value
-def v11f32   : VTVec<11,   f32, 129>;  //   11 x f32 vector value
-def v12f32   : VTVec<12,   f32, 130>;  //   12 x f32 vector value
-def v16f32   : VTVec<16,   f32, 131>;  //   16 x f32 vector value
-def v32f32   : VTVec<32,   f32, 132>;  //   32 x f32 vector value
-def v64f32   : VTVec<64,   f32, 133>;  //   64 x f32 vector value
-def v128f32  : VTVec<128,  f32, 134>;  //  128 x f32 vector value
-def v256f32  : VTVec<256,  f32, 135>;  //  256 x f32 vector value
-def v512f32  : VTVec<512,  f32, 136>;  //  512 x f32 vector value
-def v1024f32 : VTVec<1024, f32, 137>;  // 1024 x f32 vector value
-def v2048f32 : VTVec<2048, f32, 138>;  // 2048 x f32 vector value
+def v1f32    : VTVec<1,    f32, 125>;  //    1 x f32 vector value
+def v2f32    : VTVec<2,    f32, 126>;  //    2 x f32 vector value
+def v3f32    : VTVec<3,    f32, 127>;  //    3 x f32 vector value
+def v4f32    : VTVec<4,    f32, 128>;  //    4 x f32 vector value
+def v5f32    : VTVec<5,    f32, 129>;  //    5 x f32 vector value
+def v6f32    : VTVec<6,    f32, 130>;  //    6 x f32 vector value
+def v7f32    : VTVec<7,    f32, 131>;  //    7 x f32 vector value
+def v8f32    : VTVec<8,    f32, 132>;  //    8 x f32 vector value
+def v9f32    : VTVec<9,    f32, 133>;  //    9 x f32 vector value
+def v10f32   : VTVec<10,   f32, 134>;  //   10 x f32 vector value
+def v11f32   : VTVec<11,   f32, 135>;  //   11 x f32 vector value
+def v12f32   : VTVec<12,   f32, 136>;  //   12 x f32 vector value
+def v16f32   : VTVec<16,   f32, 137>;  //   16 x f32 vector value
+def v32f32   : VTVec<32,   f32, 138>;  //   32 x f32 vector value
+def v64f32   : VTVec<64,   f32, 139>;  //   64 x f32 vector value
+def v128f32  : VTVec<128,  f32, 140>;  //  128 x f32 vector value
+def v256f32  : VTVec<256,  f32, 141>;  //  256 x f32 vector value
+def v512f32  : VTVec<512,  f32, 142>;  //  512 x f32 vector value
+def v1024f32 : VTVec<1024, f32, 143>;  // 1024 x f32 vector value
+def v2048f32 : VTVec<2048, f32, 144>;  // 2048 x f32 vector value
 
-def v1f64    : VTVec<1,    f64, 139>;  //    1 x f64 vector value
-def v2f64    : VTVec<2,    f64, 140>;  //    2 x f64 vector value
-def v3f64    : VTVec<3,    f64, 141>;  //    3 x f64 vector value
-def v4f64    : VTVec<4,    f64, 142>;  //    4 x f64 vector value
-def v8f64    : VTVec<8,    f64, 143>;  //    8 x f64 vector value
-def v16f64   : VTVec<16,   f64, 144>;  //   16 x f64 vector value
-def v32f64   : VTVec<32,   f64, 145>;  //   32 x f64 vector value
-def v64f64   : VTVec<64,   f64, 146>;  //   64 x f64 vector value
-def v128f64  : VTVec<128,  f64, 147>;  //  128 x f64 vector value
-def v256f64  : VTVec<256,  f64, 148>;  //  256 x f64 vector value
+def v1f64    : VTVec<1,    f64, 145>;  //    1 x f64 vector value
+def v2f64    : VTVec<2,    f64, 146>;  //    2 x f64 vector value
+def v3f64    : VTVec<3,    f64, 147>;  //    3 x f64 vector value
+def v4f64    : VTVec<4,    f64, 148>;  //    4 x f64 vector value
+def v8f64    : VTVec<8,    f64, 149>;  //    8 x f64 vector value
+def v16f64   : VTVec<16,   f64, 150>;  //   16 x f64 vector value
+def v32f64   : VTVec<32,   f64, 151>;  //   32 x f64 vector value
+def v64f64   : VTVec<64,   f64, 152>;  //   64 x f64 vector value
+def v128f64  : VTVec<128,  f64, 153>;  //  128 x f64 vector value
+def v256f64  : VTVec<256,  f64, 154>;  //  256 x f64 vector value
 
-def nxv1i1  : VTScalableVec<1,  i1, 149>;  // n x  1 x i1  vector value
-def nxv2i1  : VTScalableVec<2,  i1, 150>;  // n x  2 x i1  vector value
-def nxv4i1  : VTScalableVec<4,  i1, 151>;  // n x  4 x i1  vector value
-def nxv8i1  : VTScalableVec<8,  i1, 152>;  // n x  8 x i1  vector value
-def nxv16i1 : VTScalableVec<16, i1, 153>;  // n x 16 x i1  vector value
-def nxv32i1 : VTScalableVec<32, i1, 154>;  // n x 32 x i1  vector value
-def nxv64i1 : VTScalableVec<64, i1, 155>;  // n x 64 x i1  vector value
+def nxv1i1  : VTScalableVec<1,  i1, 155>;  // n x  1 x i1  vector value
+def nxv2i1  : VTScalableVec<2,  i1, 156>;  // n x  2 x i1  vector value
+def nxv4i1  : VTScalableVec<4,  i1, 157>;  // n x  4 x i1  vector value
+def nxv8i1  : VTScalableVec<8,  i1, 158>;  // n x  8 x i1  vector value
+def nxv16i1 : VTScalableVec<16, i1, 159>;  // n x 16 x i1  vector value
+def nxv32i1 : VTScalableVec<32, i1, 160>;  // n x 32 x i1  vector value
+def nxv64i1 : VTScalableVec<64, i1, 161>;  // n x 64 x i1  vector value
 
-def nxv1i8  : VTScalableVec<1,  i8, 156>;  // n x  1 x i8  vector value
-def nxv2i8  : VTScalableVec<2,  i8, 157>;  // n x  2 x i8  vector value
-def nxv4i8  : VTScalableVec<4,  i8, 158>;  // n x  4 x i8  vector value
-def nxv8i8  : VTScalableVec<8,  i8, 159>;  // n x  8 x i8  vector value
-def nxv16i8 : VTScalableVec<16, i8, 160>;  // n x 16 x i8  vector value
-def nxv32i8 : VTScalableVec<32, i8, 161>;  // n x 32 x i8  vector value
-def nxv64i8 : VTScalableVec<64, i8, 162>;  // n x 64 x i8  vector value
+def nxv1i8  : VTScalableVec<1,  i8, 162>;  // n x  1 x i8  vector value
+def nxv2i8  : VTScalableVec<2,  i8, 163>;  // n x  2 x i8  vector value
+def nxv4i8  : VTScalableVec<4,  i8, 164>;  // n x  4 x i8  vector value
+def nxv8i8  : VTScalableVec<8,  i8, 165>;  // n x  8 x i8  vector value
+def nxv16i8 : VTScalableVec<16, i8, 166>;  // n x 16 x i8  vector value
+def nxv32i8 : VTScalableVec<32, i8, 167>;  // n x 32 x i8  vector value
+def nxv64i8 : VTScalableVec<64, i8, 168>;  // n x 64 x i8  vector value
 
-def nxv1i16  : VTScalableVec<1,  i16, 163>;  // n x  1 x i16 vector value
-def nxv2i16  : VTScalableVec<2,  i16, 164>;  // n x  2 x i16 vector value
-def nxv4i16  : VTScalableVec<4,  i16, 165>;  // n x  4 x i16 vector value
-def nxv8i16  : VTScalableVec<8,  i16, 166>;  // n x  8 x i16 vector value
-def nxv16i16 : VTScalableVec<16, i16, 167>;  // n x 16 x i16 vector value
-def nxv32i16 : VTScalableVec<32, i16, 168>;  // n x 32 x i16 vector value
+def nxv1i16  : VTScalableVec<1,  i16, 169>;  // n x  1 x i16 vector value
+def nxv2i16  : VTScalableVec<2,  i16, 170>;  // n x  2 x i16 vector value
+def nxv4i16  : VTScalableVec<4,  i16, 171>;  // n x  4 x i16 vector value
+def nxv8i16  : VTScalableVec<8,  i16, 172>;  // n x  8 x i16 vector value
+def nxv16i16 : VTScalableVec<16, i16, 173>;  // n x 16 x i16 vector value
+def nxv32i16 : VTScalableVec<32, i16, 174>;  // n x 32 x i16 vector value
 
-def nxv1i32  : VTScalableVec<1,  i32, 169>;  // n x  1 x i32 vector value
-def nxv2i32  : VTScalableVec<2,  i32, 170>;  // n x  2 x i32 vector value
-def nxv4i32  : VTScalableVec<4,  i32, 171>;  // n x  4 x i32 vector value
-def nxv8i32  : VTScalableVec<8,  i32, 172>;  // n x  8 x i32 vector value
-def nxv16i32 : VTScalableVec<16, i32, 173>;  // n x 16 x i32 vector value
-def nxv32i32 : VTScalableVec<32, i32, 174>;  // n x 32 x i32 vector value
+def nxv1i32  : VTScalableVec<1,  i32, 175>;  // n x  1 x i32 vector value
+def nxv2i32  : VTScalableVec<2,  i32, 176>;  // n x  2 x i32 vector value
+def nxv4i32  : VTScalableVec<4,  i32, 177>;  // n x  4 x i32 vector value
+def nxv8i32  : VTScalableVec<8,  i32, 178>;  // n x  8 x i32 vector value
+def nxv16i32 : VTScalableVec<16, i32, 179>;  // n x 16 x i32 vector value
+def nxv32i32 : VTScalableVec<32, i32, 180>;  // n x 32 x i32 vector value
 
-def nxv1i64  : VTScalableVec<1,  i64, 175>;  // n x  1 x i64 vector value
-def nxv2i64  : VTScalableVec<2,  i64, 176>;  // n x  2 x i64 vector value
-def nxv4i64  : VTScalableVec<4,  i64, 177>;  // n x  4 x i64 vector value
-def nxv8i64  : VTScalableVec<8,  i64, 178>;  // n x  8 x i64 vector value
-def nxv16i64 : VTScalableVec<16, i64, 179>;  // n x 16 x i64 vector value
-def nxv32i64 : VTScalableVec<32, i64, 180>;  // n x 32 x i64 vector value
+def nxv1i64  : VTScalableVec<1,  i64, 181>;  // n x  1 x i64 vector value
+def nxv2i64  : VTScalableVec<2,  i64, 182>;  // n x  2 x i64 vector value
+def nxv4i64  : VTScalableVec<4,  i64, 183>;  // n x  4 x i64 vector value
+def nxv8i64  : VTScalableVec<8,  i64, 184>;  // n x  8 x i64 vector value
+def nxv16i64 : VTScalableVec<16, i64, 185>;  // n x 16 x i64 vector value
+def nxv32i64 : VTScalableVec<32, i64, 186>;  // n x 32 x i64 vector value
 
-def nxv1f16  : VTScalableVec<1,  f16, 181>;  // n x  1 x  f16 vector value
-def nxv2f16  : VTScalableVec<2,  f16, 182>;  // n x  2 x  f16 vector value
-def nxv4f16  : VTScalableVec<4,  f16, 183>;  // n x  4 x  f16 vector value
-def nxv8f16  : VTScalableVec<8,  f16, 184>;  // n x  8 x  f16 vector value
-def nxv16f16 : VTScalableVec<16, f16, 185>;  // n x 16 x  f16 vector value
-def nxv32f16 : VTScalableVec<32, f16, 186>;  // n x 32 x  f16 vector value
+def nxv1f16  : VTScalableVec<1,  f16, 187>;  // n x  1 x  f16 vector value
+def nxv2f16  : VTScalableVec<2,  f16, 188>;  // n x  2 x  f16 vector value
+def nxv4f16  : VTScalableVec<4,  f16, 189>;  // n x  4 x  f16 vector value
+def nxv8f16  : VTScalableVec<8,  f16, 190>;  // n x  8 x  f16 vector value
+def nxv16f16 : VTScalableVec<16, f16, 191>;  // n x 16 x  f16 vector value
+def nxv32f16 : VTScalableVec<32, f16, 192>;  // n x 32 x  f16 vector value
 
-def nxv1bf16  : VTScalableVec<1,  bf16, 187>;  // n x  1 x bf16 vector value
-def nxv2bf16  : VTScalableVec<2,  bf16, 188>;  // n x  2 x bf16 vector value
-def nxv4bf16  : VTScalableVec<4,  bf16, 189>;  // n x  4 x bf16 vector value
-def nxv8bf16  : VTScalableVec<8,  bf16, 190>;  // n x  8 x bf16 vector value
-def nxv16bf16 : VTScalableVec<16, bf16, 191>;  // n x 16 x bf16 vector value
-def nxv32bf16 : VTScalableVec<32, bf16, 192>;  // n x 32 x bf16 vector value
+def nxv1bf16  : VTScalableVec<1,  bf16, 193>;  // n x  1 x bf16 vector value
+def nxv2bf16  : VTScalableVec<2,  bf16, 194>;  // n x  2 x bf16 vector value
+def nxv4bf16  : VTScalableVec<4,  bf16, 195>;  // n x  4 x bf16 vector value
+def nxv8bf16  : VTScalableVec<8,  bf16, 196>;  // n x  8 x bf16 vector value
+def nxv16bf16 : VTScalableVec<16, bf16, 197>;  // n x 16 x bf16 vector value
+def nxv32bf16 : VTScalableVec<32, bf16, 198>;  // n x 32 x bf16 vector value
 
-def nxv1f32  : VTScalableVec<1,  f32, 193>;  // n x  1 x  f32 vector value
-def nxv2f32  : VTScalableVec<2,  f32, 194>;  // n x  2 x  f32 vector value
-def nxv4f32  : VTScalableVec<4,  f32, 195>;  // n x  4 x  f32 vector value
-def nxv8f32  : VTScalableVec<8,  f32, 196>;  // n x  8 x  f32 vector value
-def nxv16f32 : VTScalableVec<16, f32, 197>;  // n x 16 x  f32 vector value
+def nxv1f32  : VTScalableVec<1,  f32, 199>;  // n x  1 x  f32 vector value
+def nxv2f32  : VTScalableVec<2,  f32, 200>;  // n x  2 x  f32 vector value
+def nxv4f32  : VTScalableVec<4,  f32, 201>;  // n x  4 x  f32 vector value
+def nxv8f32  : VTScalableVec<8,  f32, 202>;  // n x  8 x  f32 vector value
+def nxv16f32 : VTScalableVec<16, f32, 203>;  // n x 16 x  f32 vector value
 
-def nxv1f64  : VTScalableVec<1,  f64, 198>;  // n x  1 x  f64 vector value
-def nxv2f64  : VTScalableVec<2,  f64, 199>;  // n x  2 x  f64 vector value
-def nxv4f64  : VTScalableVec<4,  f64, 200>;  // n x  4 x  f64 vector value
-def nxv8f64  : VTScalableVec<8,  f64, 201>;  // n x  8 x  f64 vector value
+def nxv1f64  : VTScalableVec<1,  f64, 204>;  // n x  1 x  f64 vector value
+def nxv2f64  : VTScalableVec<2,  f64, 205>;  // n x  2 x  f64 vector value
+def nxv4f64  : VTScalableVec<4,  f64, 206>;  // n x  4 x  f64 vector value
+def nxv8f64  : VTScalableVec<8,  f64, 207>;  // n x  8 x  f64 vector value
 
 // Sz = NF * MinNumElts * 8(bits)
-def riscv_nxv1i8x2   : VTVecTup<16,  2, i8, 202>;  // RISCV vector tuple(min_num_elts=1,  nf=2)
-def riscv_nxv1i8x3   : VTVecTup<24,  3, i8, 203>;  // RISCV vector tuple(min_num_elts=1,  nf=3)
-def riscv_nxv1i8x4   : VTVecTup<32,  4, i8, 204>;  // RISCV vector tuple(min_num_elts=1,  nf=4)
-def riscv_nxv1i8x5   : VTVecTup<40,  5, i8, 205>;  // RISCV vector tuple(min_num_elts=1,  nf=5)
-def riscv_nxv1i8x6   : VTVecTup<48,  6, i8, 206>;  // RISCV vector tuple(min_num_elts=1,  nf=6)
-def riscv_nxv1i8x7   : VTVecTup<56,  7, i8, 207>;  // RISCV vector tuple(min_num_elts=1,  nf=7)
-def riscv_nxv1i8x8   : VTVecTup<64,  8, i8, 208>;  // RISCV vector tuple(min_num_elts=1,  nf=8)
-def riscv_nxv2i8x2   : VTVecTup<32,  2, i8, 209>;  // RISCV vector tuple(min_num_elts=2,  nf=2)
-def riscv_nxv2i8x3   : VTVecTup<48,  3, i8, 210>;  // RISCV vector tuple(min_num_elts=2,  nf=3)
-def riscv_nxv2i8x4   : VTVecTup<64,  4, i8, 211>;  // RISCV vector tuple(min_num_elts=2,  nf=4)
-def riscv_nxv2i8x5   : VTVecTup<80,  5, i8, 212>;  // RISCV vector tuple(min_num_elts=2,  nf=5)
-def riscv_nxv2i8x6   : VTVecTup<96,  6, i8, 213>;  // RISCV vector tuple(min_num_elts=2,  nf=6)
-def riscv_nxv2i8x7   : VTVecTup<112, 7, i8, 214>;  // RISCV vector tuple(min_num_elts=2,  nf=7)
-def riscv_nxv2i8x8   : VTVecTup<128, 8, i8, 215>;  // RISCV vector tuple(min_num_elts=2,  nf=8)
-def riscv_nxv4i8x2   : VTVecTup<64,  2, i8, 216>;  // RISCV vector tuple(min_num_elts=4,  nf=2)
-def riscv_nxv4i8x3   : VTVecTup<96,  3, i8, 217>;  // RISCV vector tuple(min_num_elts=4,  nf=3)
-def riscv_nxv4i8x4   : VTVecTup<128, 4, i8, 218>;  // RISCV vector tuple(min_num_elts=4,  nf=4)
-def riscv_nxv4i8x5   : VTVecTup<160, 5, i8, 219>;  // RISCV vector tuple(min_num_elts=4,  nf=5)
-def riscv_nxv4i8x6   : VTVecTup<192, 6, i8, 220>;  // RISCV vector tuple(min_num_elts=4,  nf=6)
-def riscv_nxv4i8x7   : VTVecTup<224, 7, i8, 221>;  // RISCV vector tuple(min_num_elts=4,  nf=7)
-def riscv_nxv4i8x8   : VTVecTup<256, 8, i8, 222>;  // RISCV vector tuple(min_num_elts=4,  nf=8)
-def riscv_nxv8i8x2   : VTVecTup<128, 2, i8, 223>;  // RISCV vector tuple(min_num_elts=8,  nf=2)
-def riscv_nxv8i8x3   : VTVecTup<192, 3, i8, 224>;  // RISCV vector tuple(min_num_elts=8,  nf=3)
-def riscv_nxv8i8x4   : VTVecTup<256, 4, i8, 225>;  // RISCV vector tuple(min_num_elts=8,  nf=4)
-def riscv_nxv8i8x5   : VTVecTup<320, 5, i8, 226>;  // RISCV vector tuple(min_num_elts=8,  nf=5)
-def riscv_nxv8i8x6   : VTVecTup<384, 6, i8, 227>;  // RISCV vector tuple(min_num_elts=8,  nf=6)
-def riscv_nxv8i8x7   : VTVecTup<448, 7, i8, 228>;  // RISCV vector tuple(min_num_elts=8,  nf=7)
-def riscv_nxv8i8x8   : VTVecTup<512, 8, i8, 229>;  // RISCV vector tuple(min_num_elts=8,  nf=8)
-def riscv_nxv16i8x2  : VTVecTup<256, 2, i8, 230>;  // RISCV vector tuple(min_num_elts=16, nf=2)
-def riscv_nxv16i8x3  : VTVecTup<384, 3, i8, 231>;  // RISCV vector tuple(min_num_elts=16, nf=3)
-def riscv_nxv16i8x4  : VTVecTup<512, 4, i8, 232>;  // RISCV vector tuple(min_num_elts=16, nf=4)
-def riscv_nxv32i8x2  : VTVecTup<512, 2, i8, 233>;  // RISCV vector tuple(min_num_elts=32, nf=2)
+def riscv_nxv1i8x2   : VTVecTup<16,  2, i8, 208>;  // RISCV vector tuple(min_num_elts=1,  nf=2)
+def riscv_nxv1i8x3   : VTVecTup<24,  3, i8, 209>;  // RISCV vector tuple(min_num_elts=1,  nf=3)
+def riscv_nxv1i8x4   : VTVecTup<32,  4, i8, 210>;  // RISCV vector tuple(min_num_elts=1,  nf=4)
+def riscv_nxv1i8x5   : VTVecTup<40,  5, i8, 211>;  // RISCV vector tuple(min_num_elts=1,  nf=5)
+def riscv_nxv1i8x6   : VTVecTup<48,  6, i8, 212>;  // RISCV vector tuple(min_num_elts=1,  nf=6)
+def riscv_nxv1i8x7   : VTVecTup<56,  7, i8, 213>;  // RISCV vector tuple(min_num_elts=1,  nf=7)
+def riscv_nxv1i8x8   : VTVecTup<64,  8, i8, 214>;  // RISCV vector tuple(min_num_elts=1,  nf=8)
+def riscv_nxv2i8x2   : VTVecTup<32,  2, i8, 215>;  // RISCV vector tuple(min_num_elts=2,  nf=2)
+def riscv_nxv2i8x3   : VTVecTup<48,  3, i8, 216>;  // RISCV vector tuple(min_num_elts=2,  nf=3)
+def riscv_nxv2i8x4   : VTVecTup<64,  4, i8, 217>;  // RISCV vector tuple(min_num_elts=2,  nf=4)
+def riscv_nxv2i8x5   : VTVecTup<80,  5, i8, 218>;  // RISCV vector tuple(min_num_elts=2,  nf=5)
+def riscv_nxv2i8x6   : VTVecTup<96,  6, i8, 219>;  // RISCV vector tuple(min_num_elts=2,  nf=6)
+def riscv_nxv2i8x7   : VTVecTup<112, 7, i8, 220>;  // RISCV vector tuple(min_num_elts=2,  nf=7)
+def riscv_nxv2i8x8   : VTVecTup<128, 8, i8, 221>;  // RISCV vector tuple(min_num_elts=2,  nf=8)
+def riscv_nxv4i8x2   : VTVecTup<64,  2, i8, 222>;  // RISCV vector tuple(min_num_elts=4,  nf=2)
+def riscv_nxv4i8x3   : VTVecTup<96,  3, i8, 223>;  // RISCV vector tuple(min_num_elts=4,  nf=3)
+def riscv_nxv4i8x4   : VTVecTup<128, 4, i8, 224>;  // RISCV vector tuple(min_num_elts=4,  nf=4)
+def riscv_nxv4i8x5   : VTVecTup<160, 5, i8, 225>;  // RISCV vector tuple(min_num_elts=4,  nf=5)
+def riscv_nxv4i8x6   : VTVecTup<192, 6, i8, 226>;  // RISCV vector tuple(min_num_elts=4,  nf=6)
+def riscv_nxv4i8x7   : VTVecTup<224, 7, i8, 227>;  // RISCV vector tuple(min_num_elts=4,  nf=7)
+def riscv_nxv4i8x8   : VTVecTup<256, 8, i8, 228>;  // RISCV vector tuple(min_num_elts=4,  nf=8)
+def riscv_nxv8i8x2   : VTVecTup<128, 2, i8, 229>;  // RISCV vector tuple(min_num_elts=8,  nf=2)
+def riscv_nxv8i8x3   : VTVecTup<192, 3, i8, 230>;  // RISCV vector tuple(min_num_elts=8,  nf=3)
+def riscv_nxv8i8x4   : VTVecTup<256, 4, i8, 231>;  // RISCV vector tuple(min_num_elts=8,  nf=4)
+def riscv_nxv8i8x5   : VTVecTup<320, 5, i8, 232>;  // RISCV vector tuple(min_num_elts=8,  nf=5)
+def riscv_nxv8i8x6   : VTVecTup<384, 6, i8, 233>;  // RISCV vector tuple(min_num_elts=8,  nf=6)
+def riscv_nxv8i8x7   : VTVecTup<448, 7, i8, 234>;  // RISCV vector tuple(min_num_elts=8,  nf=7)
+def riscv_nxv8i8x8   : VTVecTup<512, 8, i8, 235>;  // RISCV vector tuple(min_num_elts=8,  nf=8)
+def riscv_nxv16i8x2  : VTVecTup<256, 2, i8, 236>;  // RISCV vector tuple(min_num_elts=16, nf=2)
+def riscv_nxv16i8x3  : VTVecTup<384, 3, i8, 237>;  // RISCV vector tuple(min_num_elts=16, nf=3)
+def riscv_nxv16i8x4  : VTVecTup<512, 4, i8, 238>;  // RISCV vector tuple(min_num_elts=16, nf=4)
+def riscv_nxv32i8x2  : VTVecTup<512, 2, i8, 239>;  // RISCV vector tuple(min_num_elts=32, nf=2)
 
-def x86mmx    : ValueType<64,   234>;  // X86 MMX value
-def Glue      : ValueType<0,    235>;  // Pre-RA sched glue
-def isVoid    : ValueType<0,    236>;  // Produces no value
-def untyped   : ValueType<8,    237> { // Produces an untyped value
+def x86mmx    : ValueType<64,   240>;  // X86 MMX value
+def Glue      : ValueType<0,    241>;  // Pre-RA sched glue
+def isVoid    : ValueType<0,    242>;  // Produces no value
+def untyped   : ValueType<8,    243> { // Produces an untyped value
   let LLVMName = "Untyped";
 }
-def funcref   : ValueType<0,    238>;  // WebAssembly's funcref type
-def externref : ValueType<0,    239>;  // WebAssembly's externref type
-def exnref    : ValueType<0,    240>;  // WebAssembly's exnref type
-def x86amx    : ValueType<8192, 241>;  // X86 AMX value
-def i64x8     : ValueType<512,  242>;  // 8 Consecutive GPRs (AArch64)
+def funcref   : ValueType<0,    244>;  // WebAssembly's funcref type
+def externref : ValueType<0,    245>;  // WebAssembly's externref type
+def exnref    : ValueType<0,    246>;  // WebAssembly's exnref type
+def x86amx    : ValueType<8192, 247>;  // X86 AMX value
+def i64x8     : ValueType<512,  248>;  // 8 Consecutive GPRs (AArch64)
 def aarch64svcount
-              : ValueType<16,  243>;  // AArch64 predicate-as-counter
-def spirvbuiltin : ValueType<0, 244>; // SPIR-V's builtin type
+              : ValueType<16,  249>;  // AArch64 predicate-as-counter
+def spirvbuiltin : ValueType<0, 250>; // SPIR-V's builtin type
 // AMDGPU buffer fat pointer, buffer rsrc + offset, rewritten before MIR translation.
 // FIXME: Remove this and the getPointerType() override if MVT::i160 is added.
-def amdgpuBufferFatPointer : ValueType<160, 245>;
+def amdgpuBufferFatPointer : ValueType<160, 251>;
 // AMDGPU buffer strided pointer, buffer rsrc + index + offset, doesn't reach MIR.
 // FIXME: Remove this and the getPointerType() override if MVT::i82 is added.
-def amdgpuBufferStridedPointer : ValueType<192, 246>;
+def amdgpuBufferStridedPointer : ValueType<192, 252>;
 
-def aarch64mfp8 : ValueType<8,  247>;  // 8-bit value in FPR (AArch64)
+def aarch64mfp8 : ValueType<8,  253>;  // 8-bit value in FPR (AArch64)
 
 let isNormalValueType = false in {
 def token      : ValueType<0, 504>;  // TokenTy

--- a/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelLowering.cpp
@@ -367,6 +367,18 @@ AMDGPUTargetLowering::AMDGPUTargetLowering(const TargetMachine &TM,
   setTruncStoreAction(MVT::v4f64, MVT::v4bf16, Expand);
   setTruncStoreAction(MVT::v4f64, MVT::v4f16, Expand);
 
+  setTruncStoreAction(MVT::v5i32, MVT::v5i1, Expand);
+  setTruncStoreAction(MVT::v5i32, MVT::v5i8, Expand);
+  setTruncStoreAction(MVT::v5i32, MVT::v5i16, Expand);
+
+  setTruncStoreAction(MVT::v6i32, MVT::v6i1, Expand);
+  setTruncStoreAction(MVT::v6i32, MVT::v6i8, Expand);
+  setTruncStoreAction(MVT::v6i32, MVT::v6i16, Expand);
+
+  setTruncStoreAction(MVT::v7i32, MVT::v7i1, Expand);
+  setTruncStoreAction(MVT::v7i32, MVT::v7i8, Expand);
+  setTruncStoreAction(MVT::v7i32, MVT::v7i16, Expand);
+
   setTruncStoreAction(MVT::v8f64, MVT::v8f32, Expand);
   setTruncStoreAction(MVT::v8f64, MVT::v8bf16, Expand);
   setTruncStoreAction(MVT::v8f64, MVT::v8f16, Expand);


### PR DESCRIPTION
We already had corresponding f32 and i32 vector types for these sizes.