### PR TITLE
[lldb] Fix incorrect conversion from boolean in RegisterContextThreadMemory

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
@@ -153,14 +153,14 @@ uint32_t RegisterContextThreadMemory::ConvertRegisterKindToRegisterNumber(
   UpdateRegisterContext();
   if (m_reg_ctx_sp)
     return m_reg_ctx_sp->ConvertRegisterKindToRegisterNumber(kind, num);
-  return false;
+  return LLDB_INVALID_REGNUM;
 }
 
 uint32_t RegisterContextThreadMemory::NumSupportedHardwareBreakpoints() {
   UpdateRegisterContext();
   if (m_reg_ctx_sp)
     return m_reg_ctx_sp->NumSupportedHardwareBreakpoints();
-  return false;
+  return 0;
 }
 
 uint32_t RegisterContextThreadMemory::SetHardwareBreakpoint(lldb::addr_t addr,


### PR DESCRIPTION

The method ConvertRegisterKindToRegisterNumber should return INVALID_REGNUM, and not "false" upon failure: false would mean 0 which is usually the number for generic PC.

Likewise, NumSupportedHardwareBreakpoints should return 0 instead of false (though for this one they are equivalent).