### PR TITLE
[flang][runtime] Handle empty NAMELIST value list

### DIFF
--- a/flang-rt/lib/runtime/namelist.cpp
+++ b/flang-rt/lib/runtime/namelist.cpp
@@ -570,12 +570,14 @@ bool IODEF(InputNamelist)(Cookie cookie, const NamelistGroup &group) {
         addendum && addendum->derivedType()) {
       const NonTbpDefinedIoTable *table{group.nonTbpDefinedIo};
       listInput->ResetForNextNamelistItem(/*inNamelistSequence=*/true);
-      if (!IONAME(InputDerivedType)(cookie, *useDescriptor, table)) {
+      if (!IONAME(InputDerivedType)(cookie, *useDescriptor, table) &&
+          handler.InError()) {
         return false;
       }
     } else {
       listInput->ResetForNextNamelistItem(useDescriptor->rank() > 0);
-      if (!descr::DescriptorIO<Direction::Input>(io, *useDescriptor)) {
+      if (!descr::DescriptorIO<Direction::Input>(io, *useDescriptor) &&
+          handler.InError()) {
         return false;
       }
     }


### PR DESCRIPTION
InputNamelist() returns early if any value list read in by InputDerivedType() or DescriptorIo<Input>() is empty, since they return false.  But an empty value list is okay, and the early return should occur only on error.

Fixes https://github.com/llvm/llvm-project/issues/151756.