### PR TITLE
[clang-tidy] Skip declarations in system headers in RenamerClangTidyC…

### DIFF
--- a/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
@@ -432,6 +432,10 @@ RenamerClangTidyCheck::addUsage(
   if (FixLocation.isInvalid())
     return {NamingCheckFailures.end(), false};
 
+  // Skip if in system system header
+  if (SourceMgr.isInSystemHeader(FixLocation))
+    return {NamingCheckFailures.end(), false};
+
   auto EmplaceResult = NamingCheckFailures.try_emplace(FailureId);
   NamingCheckFailure &Failure = EmplaceResult.first->second;
 
@@ -455,6 +459,9 @@ RenamerClangTidyCheck::addUsage(
 void RenamerClangTidyCheck::addUsage(const NamedDecl *Decl,
                                      SourceRange UsageRange,
                                      const SourceManager &SourceMgr) {
+  if (SourceMgr.isInSystemHeader(Decl->getLocation()))
+    return;
+
   if (hasNoName(Decl))
     return;
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -130,6 +130,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/infinite-loop>` check by adding detection for
   variables introduced by structured bindings.
 
+- Improved :doc:`bugprone-reserved-identifier
+  <clang-tidy/checks/bugprone/reserved-identifier>` check by ignoring
+  declarations in system headers.
+
 - Improved :doc:`bugprone-signed-char-misuse
   <clang-tidy/checks/bugprone/signed-char-misuse>` check by fixing
   false positives on C23 enums with the fixed underlying type of signed char.
@@ -159,6 +163,10 @@ Changes in existing checks
 - Improved :doc:`portability-template-virtual-member-function
   <clang-tidy/checks/portability/template-virtual-member-function>` check to
   avoid false positives on pure virtual member functions.
+
+- Improved :doc:`readability-identifier-naming
+  <clang-tidy/checks/readability/identifier-naming>` check by ignoring
+  declarations in system headers.
 
 - Improved :doc:`readability-qualified-auto
   <clang-tidy/checks/readability/qualified-auto>` check by adding the option


### PR DESCRIPTION
…heck

One typically only wants to perform renaming operations in user code, not in system headers (which are out of the user's control). Let's skip those altogether.

This leads to performance improvements in clang-tidy. As a benchmark, I run all checks on a .cpp file that #includes all C++ standard headers.

On trunk:

```
Suppressed 213362 warnings (213362 in non-user code).

real	0m14.422s
user	0m14.236s
sys	0m0.184s
```

On this patch:

```
Suppressed 75411 warnings (75411 in non-user code).

real	0m12.472s
user	0m12.334s
sys	0m0.136s
```