### PR TITLE
[lldb] Reimplment PyRun_SimpleString using the Python stable C API

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -1492,6 +1492,22 @@ PyObject *RunString(const char *str, int start, PyObject *globals,
 
   return result;
 }
+
+int RunSimpleString(const char *str) {
+  PyObject *main_module = PyImport_AddModule("__main__");
+  if (!main_module)
+    return -1;
+
+  PyObject *globals = PyModule_GetDict(main_module);
+  if (!globals)
+    return -1;
+
+  PyObject *result = RunString(str, Py_file_input, globals, globals);
+  if (!result)
+    return -1;
+
+  return 0;
+}
 } // namespace python
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
@@ -782,6 +782,7 @@ private:
 
 PyObject *RunString(const char *str, int start, PyObject *globals,
                     PyObject *locals);
+int RunSimpleString(const char *str);
 
 } // namespace python
 } // namespace lldb_private

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPythonImpl.h
@@ -475,7 +475,7 @@ public:
         StreamString run_string;
         run_string.Printf("run_python_interpreter (%s)",
                           m_python->GetDictionaryName());
-        PyRun_SimpleString(run_string.GetData());
+        python::RunSimpleString(run_string.GetData());
       }
     }
     SetIsDone(true);

--- a/lldb/unittests/ScriptInterpreter/Python/PythonTestSuite.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonTestSuite.cpp
@@ -22,7 +22,7 @@ void PythonTestSuite::SetUp() {
   // test suite.
   Py_InitializeEx(0);
   m_gil_state = PyGILState_Ensure();
-  PyRun_SimpleString("import sys");
+  python::RunSimpleString("import sys");
 }
 
 void PythonTestSuite::TearDown() {


### PR DESCRIPTION
Reimplment `PyRun_SimpleString` using the Python stable C API and the `RunString` helper.

Part of https://github.com/llvm/llvm-project/issues/151617