### PR TITLE
[lldb] Remove unused PythonObject::Dump (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
@@ -250,13 +250,6 @@ public:
 
   void Reset();
 
-  void Dump() const {
-    if (m_py_obj)
-      _PyObject_Dump(m_py_obj);
-    else
-      puts("NULL");
-  }
-
   void Dump(Stream &strm) const;
 
   PyObject *get() const { return m_py_obj; }


### PR DESCRIPTION
PythonObject::Dump isn't called and uses `_PyObject_Dump`, which isn't part of the stable API.

Part of https://github.com/llvm/llvm-project/issues/151617.