### PR TITLE
Fix error caused by reference to local binding

### DIFF
--- a/llvm/lib/Frontend/Offloading/PropertySet.cpp
+++ b/llvm/lib/Frontend/Offloading/PropertySet.cpp
@@ -19,8 +19,9 @@ void llvm::offloading::writePropertiesToJSON(
   json::OStream J(Out);
   J.object([&] {
     for (const auto &[CategoryName, PropSet] : PSRegistry) {
+      auto PropSetCapture = PropSet;
       J.attributeObject(CategoryName, [&] {
-        for (const auto &[PropName, PropVal] : PropSet) {
+        for (const auto &[PropName, PropVal] : PropSetCapture) {
           switch (PropVal.index()) {
           case 0:
             J.attribute(PropName, std::get<uint32_t>(PropVal));


### PR DESCRIPTION
This change fixes one of the failures in https://github.com/llvm/llvm-project/pull/147321

Following code snippet:
`
for (const auto &[CategoryName, PropSet] : PSRegistry) {
        J.attributeObject(CategoryName, [&] {
                   for (const auto &[PropName, PropVal] : PropSet) {
`
causes a build warning that is emitted as an error.
error: reference to local binding 'PropSet' declared in enclosing lambda expression

This is resolved by capturing PropSet in a local variable.

Thanks
