### PR TITLE
[clang][diagnostics] Fix fix-it hint parenthesis placement for fold expressions

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -123,6 +123,8 @@ Improvements to Clang's diagnostics
   Moved the warning for a missing (though implied) attribute on a redeclaration into this group.
   Added a new warning in this group for the case where the attribute is missing/implicit on
   an override of a virtual method.
+- Fixed fix-it hint for fold expressions. Clang now correctly places the suggested right 
+  parenthesis when diagnosing malformed fold expressions.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -124,7 +124,7 @@ Improvements to Clang's diagnostics
   Added a new warning in this group for the case where the attribute is missing/implicit on
   an override of a virtual method.
 - Fixed fix-it hint for fold expressions. Clang now correctly places the suggested right 
-  parenthesis when diagnosing malformed fold expressions.
+  parenthesis when diagnosing malformed fold expressions. (#GH151787)
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1387,7 +1387,7 @@ static void CheckFoldOperand(Sema &S, Expr *E) {
     S.Diag(E->getExprLoc(), diag::err_fold_expression_bad_operand)
         << E->getSourceRange()
         << FixItHint::CreateInsertion(E->getBeginLoc(), "(")
-        << FixItHint::CreateInsertion(E->getEndLoc().getLocWithOffset(1), ")");
+        << FixItHint::CreateInsertion(S.getLocForEndOfToken(E->getEndLoc()), ")");
   }
 }
 

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1387,7 +1387,7 @@ static void CheckFoldOperand(Sema &S, Expr *E) {
     S.Diag(E->getExprLoc(), diag::err_fold_expression_bad_operand)
         << E->getSourceRange()
         << FixItHint::CreateInsertion(E->getBeginLoc(), "(")
-        << FixItHint::CreateInsertion(E->getEndLoc(), ")");
+        << FixItHint::CreateInsertion(E->getEndLoc().getLocWithOffset(1), ")");
   }
 }
 

--- a/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -1387,7 +1387,8 @@ static void CheckFoldOperand(Sema &S, Expr *E) {
     S.Diag(E->getExprLoc(), diag::err_fold_expression_bad_operand)
         << E->getSourceRange()
         << FixItHint::CreateInsertion(E->getBeginLoc(), "(")
-        << FixItHint::CreateInsertion(S.getLocForEndOfToken(E->getEndLoc()), ")");
+        << FixItHint::CreateInsertion(S.getLocForEndOfToken(E->getEndLoc()),
+                                      ")");
   }
 }
 

--- a/clang/test/FixIt/fixit-c++17.cpp
+++ b/clang/test/FixIt/fixit-c++17.cpp
@@ -7,7 +7,23 @@
    apply in C++17. */
 template<int... args>
 int foo() {
-    return (args + 1 + ...); // expected-error {{expression not permitted as operand of fold expression}}
+    int a = (args + 1 + ...); // expected-error {{expression not permitted as operand of fold expression}}
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:14-[[@LINE-1]]:14}:"("
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:22-[[@LINE-2]]:22}:")"
+    int b = (args + 123 + ...); // expected-error {{expression not permitted as operand of fold expression}}
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:14-[[@LINE-1]]:14}:"("
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:24-[[@LINE-2]]:24}:")"
+    int c = (args + 1 + 2 + ...); // expected-error {{expression not permitted as operand of fold expression}}
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:14-[[@LINE-1]]:14}:"("
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:26-[[@LINE-2]]:26}:")"
+    int e = (... + 1 + args); // expected-error {{expression not permitted as operand of fold expression}}
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:20-[[@LINE-1]]:20}:"("
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:28-[[@LINE-2]]:28}:")"
+    int f = (1 + ... + args + 1); // expected-error {{expression not permitted as operand of fold expression}}
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:24-[[@LINE-1]]:24}:"("
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:32-[[@LINE-2]]:32}:")"
+    int g = (args + 1 + ... + 1); // expected-error {{expression not permitted as operand of fold expression}}
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-1]]:14-[[@LINE-1]]:14}:"("
+    // CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:22-[[@LINE-2]]:22}:")"
+    return a + b + c + e + f + g;
 }
-// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:13-[[@LINE-2]]:13}:"("
-// CHECK: fix-it:"{{.*}}":{[[@LINE-3]]:21-[[@LINE-3]]:21}:")"

--- a/clang/test/FixIt/fixit-c++17.cpp
+++ b/clang/test/FixIt/fixit-c++17.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -verify -std=c++17 -pedantic-errors %s
+// RUN: cp %s %t
+// RUN: not %clang_cc1 -x c++ -std=c++17 -fixit %t
+// RUN: %clang_cc1 -Wall -pedantic-errors -x c++ -std=c++17 %t
+
+/* This is a test of the various code modification hints that only
+   apply in C++17. */
+template<int... args>
+int foo() {
+    return (args + 1 + ...); // expected-error {{expression not permitted as operand of fold expression}}
+}
+// CHECK: fix-it:"{{.*}}":{[[@LINE-2]]:13-[[@LINE-2]]:13}:"("
+// CHECK: fix-it:"{{.*}}":{[[@LINE-3]]:21-[[@LINE-3]]:21}:")"


### PR DESCRIPTION
- Closes #151787

Insert the right parenthesis one token later to correctly enclose the expression.