### PR TITLE
Add missing link component for Frontend offloading test

### DIFF
--- a/llvm/unittests/Frontend/CMakeLists.txt
+++ b/llvm/unittests/Frontend/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Analysis
   Core
   FrontendHLSL
+  FrontendOffloading
   FrontendOpenACC
   FrontendOpenMP
   Passes


### PR DESCRIPTION
This change fixes one of the failures in https://github.com/llvm/llvm-project/pull/147321

/usr/bin/ld: unittests/Frontend/CMakeFiles/LLVMFrontendTests.dir/PropertySetRegistryTest.cpp.o: undefined reference to symbol '_ZN4llvm10offloading21writePropertiesToJSONERKSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES1_IS7_St7variantIJjNS_11SmallVectorIhLj0EEEEESt4lessIS7_ESaISt4pairIKS7_SB_EEESD_SaISE_ISF_SI_EEERNS_11raw_ostreamE'

Need to add a missing LLVM link component in CMakeLists.txt.

Thanks