### PR TITLE
[llvm-objdump] Remove an unnecessary cast (NFC)

### DIFF
--- a/llvm/tools/llvm-objdump/COFFDump.cpp
+++ b/llvm/tools/llvm-objdump/COFFDump.cpp
@@ -187,7 +187,7 @@ void COFFDumper::printPEHeader(const PEHeader &Hdr) const {
       Size = Data->Size;
     }
     outs() << format("Entry %x ", I) << formatAddr(Addr)
-           << format(" %08x %s\n", uint32_t(Size), DirName[I]);
+           << format(" %08x %s\n", Size, DirName[I]);
   }
 }
 


### PR DESCRIPTION
Size is already of uint32_t.
