### PR TITLE
[lldb] Avoid a crash after selecting an unknown platform

### DIFF
--- a/lldb/source/Target/Platform.cpp
+++ b/lldb/source/Target/Platform.cpp
@@ -2234,7 +2234,8 @@ PlatformSP PlatformList::GetOrCreate(llvm::ArrayRef<ArchSpec> archs,
 PlatformSP PlatformList::Create(llvm::StringRef name) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   PlatformSP platform_sp = Platform::Create(name);
-  m_platforms.push_back(platform_sp);
+  if (platform_sp)
+    m_platforms.push_back(platform_sp);
   return platform_sp;
 }
 

--- a/lldb/unittests/Platform/PlatformTest.cpp
+++ b/lldb/unittests/Platform/PlatformTest.cpp
@@ -157,3 +157,9 @@ TEST_F(PlatformTest, GetPlatformForArchitecturesCandidates) {
 
   PlatformThumb::Terminate();
 }
+
+TEST_F(PlatformTest, CreateUnknown) {
+  SetHostPlatform(std::make_shared<PlatformIntel>());
+  ASSERT_EQ(list.Create("unknown-platform-name"), nullptr);
+  ASSERT_EQ(list.GetOrCreate("dummy"), nullptr);
+}


### PR DESCRIPTION
`PlatformList::Create()` added an item in the list even if `Platform::Create()` returned `nullptr`. Other methods use items of the list without checking, which can lead to a crash. For example:

```
> lldb
(lldb) platform select unknown
error: unable to find a plug-in for the platform named "unknown"
(lldb) file a.out-arm64
PLEASE submit a bug report to...
Stack dump:
0.      Program arguments: lldb
1.      HandleCommand(command = "file a.out-arm64 ")
...
```