### PR TITLE
[BOLT] Use llvm-nm by default on Windows

### DIFF
--- a/bolt/test/link_fdata.py
+++ b/bolt/test/link_fdata.py
@@ -9,6 +9,7 @@ respective anchor symbols, and prints the resulting file to stdout.
 
 import argparse
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -19,7 +20,11 @@ parser.add_argument("input")
 parser.add_argument("objfile", help="Object file to extract symbol values from")
 parser.add_argument("output")
 parser.add_argument("prefix", nargs="?", default="FDATA", help="Custom FDATA prefix")
-parser.add_argument("--nmtool", default="nm", help="Path to nm tool")
+parser.add_argument(
+    "--nmtool",
+    default="llvm-nm" if platform.system() == "Windows" else "nm",
+    help="Path to nm tool",
+)
 parser.add_argument("--no-lbr", action="store_true")
 parser.add_argument("--no-redefine", action="store_true")
 
@@ -86,7 +91,10 @@ with open(args.input, "r") as f:
             exit("ERROR: unexpected input:\n%s" % line)
 
 # Read nm output: <symbol value> <symbol type> <symbol name>
-is_llvm_nm = os.path.basename(os.path.realpath(shutil.which(args.nmtool))) == "llvm-nm"
+# Ignore .exe on Windows host.
+is_llvm_nm = os.path.basename(os.path.realpath(shutil.which(args.nmtool))).startswith(
+    "llvm-nm"
+)
 nm_output = subprocess.run(
     [
         args.nmtool,


### PR DESCRIPTION
Use `llvm-nm` by default instead of `nm` in case of Windows host.