### PR TITLE
[flang] Fix failure of regression tests on macOS

### DIFF
--- a/flang/test/Driver/lit.local.cfg
+++ b/flang/test/Driver/lit.local.cfg
@@ -1,0 +1,10 @@
+import re
+from lit.llvm import llvm_config
+
+# Drop -isysroot flag for darwin-version.f90.
+idx, driver = next(((i, subst)
+    for i, subst in enumerate(config.substitutions) if "flang" in subst[0]))
+subst_key, command = driver
+command = re.sub(' -isysroot [^ ]+', '', command)
+config.substitutions.insert(idx, (subst_key, command))
+config.substitutions.remove(driver)

--- a/flang/test/Lower/OpenMP/target-enter-data-default-openmp52.f90
+++ b/flang/test/Lower/OpenMP/target-enter-data-default-openmp52.f90
@@ -1,7 +1,7 @@
 ! This test checks the lowering and application of default map types for the target enter/exit data constructs and map clauses
 
-!RUN: %flang -fc1 -emit-fir -fopenmp -fopenmp-version=52 -o - %s | FileCheck %s --check-prefix=CHECK-52
-!RUN: not %flang -fc1 -emit-fir -fopenmp -fopenmp-version=51 -o - %s 2>&1| FileCheck %s --check-prefix=CHECK-51
+!RUN: %flang_fc1 -emit-fir -fopenmp -fopenmp-version=52 -o - %s | FileCheck %s --check-prefix=CHECK-52
+!RUN: not %flang_fc1 -emit-fir -fopenmp -fopenmp-version=51 -o - %s 2>&1| FileCheck %s --check-prefix=CHECK-51
 
 module test
   real, allocatable :: A


### PR DESCRIPTION
Some tests in flang fail on macOS because of `SDKROOT`. It appends`-isysroot` flag, but some tests did not handle it appropriately. This patch fixes #150765.