### PR TITLE
[Offload][UnitTests] Fix incorrect CUDA path variable in CMake helper

### DIFF
--- a/offload/unittests/CMakeLists.txt
+++ b/offload/unittests/CMakeLists.txt
@@ -40,7 +40,7 @@ function(add_offload_test_device_code test_filename test_name)
         OUTPUT ${output_file}
         COMMAND ${CMAKE_C_COMPILER}
         --target=nvptx64-nvidia-cuda -march=${nvptx_arch}
-        -nogpulib --cuda-path=${CUDA_ROOT} -flto ${ARGN}
+        -nogpulib --cuda-path=${cuda_path} -flto ${ARGN}
         ${SRC_PATH} -o ${output_file}
         DEPENDS ${SRC_PATH}
       )


### PR DESCRIPTION
This PR fixes a minor bug in the `add_offload_test_device_code` CMake helper function in `offload/unittests/CMakeLists.txt`.

The function was discovering the local CUDA Toolkit path and storing it in the `cuda_path` variable but was then using the incorrect `CUDA_ROOT` variable in the `add_custom_command` call for the NVPTX target.

This change corrects the command to use the intended `cuda_path` variable.