### PR TITLE
[clang][bytecode] Use SmallVector for Function::Code

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -135,7 +135,7 @@ int32_t ByteCodeEmitter::getOffset(LabelTy Label) {
 /// Helper to write bytecode and bail out if 32-bit offsets become invalid.
 /// Pointers will be automatically marshalled as 32-bit IDs.
 template <typename T>
-static void emit(Program &P, std::vector<std::byte> &Code, const T &Val,
+static void emit(Program &P, llvm::SmallVector<std::byte> &Code, const T &Val,
                  bool &Success) {
   size_t ValPos = Code.size();
   size_t Size;
@@ -153,7 +153,7 @@ static void emit(Program &P, std::vector<std::byte> &Code, const T &Val,
   // Access must be aligned!
   assert(aligned(ValPos));
   assert(aligned(ValPos + Size));
-  Code.resize(ValPos + Size);
+  Code.resize_for_overwrite(ValPos + Size);
 
   if constexpr (!std::is_pointer_v<T>) {
     new (Code.data() + ValPos) T(Val);
@@ -166,7 +166,7 @@ static void emit(Program &P, std::vector<std::byte> &Code, const T &Val,
 /// Emits a serializable value. These usually (potentially) contain
 /// heap-allocated memory and aren't trivially copyable.
 template <typename T>
-static void emitSerialized(std::vector<std::byte> &Code, const T &Val,
+static void emitSerialized(llvm::SmallVector<std::byte> &Code, const T &Val,
                            bool &Success) {
   size_t ValPos = Code.size();
   size_t Size = align(Val.bytesToSerialize());
@@ -179,31 +179,31 @@ static void emitSerialized(std::vector<std::byte> &Code, const T &Val,
   // Access must be aligned!
   assert(aligned(ValPos));
   assert(aligned(ValPos + Size));
-  Code.resize(ValPos + Size);
+  Code.resize_for_overwrite(ValPos + Size);
 
   Val.serialize(Code.data() + ValPos);
 }
 
 template <>
-void emit(Program &P, std::vector<std::byte> &Code, const Floating &Val,
+void emit(Program &P, llvm::SmallVector<std::byte> &Code, const Floating &Val,
           bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 
 template <>
-void emit(Program &P, std::vector<std::byte> &Code,
+void emit(Program &P, llvm::SmallVector<std::byte> &Code,
           const IntegralAP<false> &Val, bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 
 template <>
-void emit(Program &P, std::vector<std::byte> &Code, const IntegralAP<true> &Val,
-          bool &Success) {
+void emit(Program &P, llvm::SmallVector<std::byte> &Code,
+          const IntegralAP<true> &Val, bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 
 template <>
-void emit(Program &P, std::vector<std::byte> &Code, const FixedPoint &Val,
+void emit(Program &P, llvm::SmallVector<std::byte> &Code, const FixedPoint &Val,
           bool &Success) {
   emitSerialized(Code, Val, Success);
 }

--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -135,8 +135,8 @@ int32_t ByteCodeEmitter::getOffset(LabelTy Label) {
 /// Helper to write bytecode and bail out if 32-bit offsets become invalid.
 /// Pointers will be automatically marshalled as 32-bit IDs.
 template <typename T>
-static void emit(Program &P, llvm::SmallVector<std::byte> &Code, const T &Val,
-                 bool &Success) {
+static void emit(Program &P, llvm::SmallVectorImpl<std::byte> &Code,
+                 const T &Val, bool &Success) {
   size_t ValPos = Code.size();
   size_t Size;
 
@@ -166,7 +166,7 @@ static void emit(Program &P, llvm::SmallVector<std::byte> &Code, const T &Val,
 /// Emits a serializable value. These usually (potentially) contain
 /// heap-allocated memory and aren't trivially copyable.
 template <typename T>
-static void emitSerialized(llvm::SmallVector<std::byte> &Code, const T &Val,
+static void emitSerialized(llvm::SmallVectorImpl<std::byte> &Code, const T &Val,
                            bool &Success) {
   size_t ValPos = Code.size();
   size_t Size = align(Val.bytesToSerialize());
@@ -185,26 +185,26 @@ static void emitSerialized(llvm::SmallVector<std::byte> &Code, const T &Val,
 }
 
 template <>
-void emit(Program &P, llvm::SmallVector<std::byte> &Code, const Floating &Val,
-          bool &Success) {
+void emit(Program &P, llvm::SmallVectorImpl<std::byte> &Code,
+          const Floating &Val, bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 
 template <>
-void emit(Program &P, llvm::SmallVector<std::byte> &Code,
+void emit(Program &P, llvm::SmallVectorImpl<std::byte> &Code,
           const IntegralAP<false> &Val, bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 
 template <>
-void emit(Program &P, llvm::SmallVector<std::byte> &Code,
+void emit(Program &P, llvm::SmallVectorImpl<std::byte> &Code,
           const IntegralAP<true> &Val, bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 
 template <>
-void emit(Program &P, llvm::SmallVector<std::byte> &Code, const FixedPoint &Val,
-          bool &Success) {
+void emit(Program &P, llvm::SmallVectorImpl<std::byte> &Code,
+          const FixedPoint &Val, bool &Success) {
   emitSerialized(Code, Val, Success);
 }
 

--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.h
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.h
@@ -88,7 +88,7 @@ private:
   /// Location of label relocations.
   llvm::DenseMap<LabelTy, llvm::SmallVector<unsigned, 5>> LabelRelocs;
   /// Program code.
-  std::vector<std::byte> Code;
+  llvm::SmallVector<std::byte> Code;
   /// Opcode to expression mapping.
   SourceMap SrcMap;
 

--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -44,12 +44,12 @@ bool Context::isPotentialConstantExpr(State &Parent, const FunctionDecl *FD) {
   Compiler<ByteCodeEmitter>(*this, *P).compileFunc(
       FD, const_cast<Function *>(Func));
 
-  ++EvalID;
-  // And run it.
-  if (!Run(Parent, Func))
+  if (!Func->isValid())
     return false;
 
-  return Func->isValid();
+  ++EvalID;
+  // And run it.
+  return Run(Parent, Func);
 }
 
 void Context::isPotentialConstantExprUnevaluated(State &Parent, const Expr *E,

--- a/clang/lib/AST/ByteCode/Function.h
+++ b/clang/lib/AST/ByteCode/Function.h
@@ -236,7 +236,7 @@ private:
            bool HasRVO, bool IsLambdaStaticInvoker);
 
   /// Sets the code of a function.
-  void setCode(unsigned NewFrameSize, std::vector<std::byte> &&NewCode,
+  void setCode(unsigned NewFrameSize, llvm::SmallVector<std::byte> &&NewCode,
                SourceMap &&NewSrcMap, llvm::SmallVector<Scope, 2> &&NewScopes,
                bool NewHasBody) {
     FrameSize = NewFrameSize;
@@ -266,7 +266,7 @@ private:
   /// Size of the argument stack.
   unsigned ArgSize;
   /// Program code.
-  std::vector<std::byte> Code;
+  llvm::SmallVector<std::byte> Code;
   /// Opcode-to-expression mapping.
   SourceMap SrcMap;
   /// List of block descriptors.


### PR DESCRIPTION
This way we can use resize_for_overwrite, which is slightly more efficient:
https://llvm-compile-time-tracker.com/compare.php?from=7bdab76350970a3ac471da6a30035dd5b7ef14f3&to=b55bd2c74f230e2150e54b0523db6a8426eab54d&stat=instructions:u