### PR TITLE
[vscode-lldb] Fix race condition when changing lldb-dap arguments

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -39,10 +39,7 @@ export class LLDBDapServer implements vscode.Disposable {
       const process = child_process.spawn(dapPath, dapArgs, options);
       process.on("error", (error) => {
         reject(error);
-        if (this.serverProcess === process) {
-          this.serverProcess = undefined;
-          this.serverInfo = undefined;
-        }
+        this.cleanUp(process);
       });
       process.on("exit", (code, signal) => {
         let errorMessage = "Server process exited early";
@@ -52,10 +49,7 @@ export class LLDBDapServer implements vscode.Disposable {
           errorMessage += ` due to signal ${signal}`;
         }
         reject(new Error(errorMessage));
-        if (this.serverProcess === process) {
-          this.serverProcess = undefined;
-          this.serverInfo = undefined;
-        }
+        this.cleanUp(process);
       });
       process.stdout.setEncoding("utf8").on("data", (data) => {
         const connection = /connection:\/\/\[([^\]]+)\]:(\d+)/.exec(
@@ -130,7 +124,16 @@ Restarting the server will interrupt any existing debug sessions and start a new
       return;
     }
     this.serverProcess.kill();
-    this.serverProcess = undefined;
-    this.serverInfo = undefined;
+    this.cleanUp(this.serverProcess);
+  }
+
+  cleanUp(process: child_process.ChildProcessWithoutNullStreams) {
+    // If the following don't equal, then the fields have already been updated
+    // (either a new process has started, or the fields were already cleaned
+    // up), and so the cleanup should be skipped.
+    if (this.serverProcess === process) {
+      this.serverProcess = undefined;
+      this.serverInfo = undefined;
+    }
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -39,8 +39,10 @@ export class LLDBDapServer implements vscode.Disposable {
       const process = child_process.spawn(dapPath, dapArgs, options);
       process.on("error", (error) => {
         reject(error);
-        this.serverProcess = undefined;
-        this.serverInfo = undefined;
+        if (this.serverProcess === process) {
+          this.serverProcess = undefined;
+          this.serverInfo = undefined;
+        }
       });
       process.on("exit", (code, signal) => {
         let errorMessage = "Server process exited early";
@@ -50,8 +52,10 @@ export class LLDBDapServer implements vscode.Disposable {
           errorMessage += ` due to signal ${signal}`;
         }
         reject(new Error(errorMessage));
-        this.serverProcess = undefined;
-        this.serverInfo = undefined;
+        if (this.serverProcess === process) {
+          this.serverProcess = undefined;
+          this.serverInfo = undefined;
+        }
       });
       process.stdout.setEncoding("utf8").on("data", (data) => {
         const connection = /connection:\/\/\[([^\]]+)\]:(\d+)/.exec(


### PR DESCRIPTION
# Problem

When the user changes lldb-dap's arguments (e.g. path), there is a race condition, where the new lldb-dap process could be started first and have set the extension's `serverProcess` and `serverInfo` according to the new process, while the old lldb-dap process exits later and wipes out these two fields.

Consequences:
1. This causes `getServerProcess()` to return `undefined` when it should return the new process.
2. This also causes wrong behavior when starting the next debug session that a new lldb-dap process will be started and the old not reused nor killed.

# Fix

When wiping the two fields, check if `serverProcess` equals to the process captured by the handler. If they equal, wipe the fields. If not, then the fields have already been updated (either new process has started, or the fields were already wiped out by another handler), and so the wiping should be skipped.