### PR TITLE
[vscode-lldb] Fix format

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -169,7 +169,9 @@ export async function createDebugAdapterExecutable(
   workspaceFolder: vscode.WorkspaceFolder | undefined,
   configuration: vscode.DebugConfiguration,
 ): Promise<vscode.DebugAdapterExecutable> {
-  const config = vscode.workspace.workspaceFile ? vscode.workspace.getConfiguration("lldb-dap") : vscode.workspace.getConfiguration("lldb-dap", workspaceFolder);
+  const config = vscode.workspace.workspaceFile
+    ? vscode.workspace.getConfiguration("lldb-dap")
+    : vscode.workspace.getConfiguration("lldb-dap", workspaceFolder);
   const log_path = config.get<string>("log-path");
   let env: { [key: string]: string } = {};
   if (log_path) {

--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -26,7 +26,7 @@ export class LLDBDapServer implements vscode.Disposable {
     args: string[],
     options?: child_process.SpawnOptionsWithoutStdio,
   ): Promise<{ host: string; port: number } | undefined> {
-    const dapArgs = [...args, "--connection", "listen://localhost:0" ];
+    const dapArgs = [...args, "--connection", "listen://localhost:0"];
     if (!(await this.shouldContinueStartup(dapPath, dapArgs))) {
       return undefined;
     }


### PR DESCRIPTION
Generated by running the formatter:
```
royshi-mac-home ~/public_llvm/llvm-project/lldb/tools/lldb-dap % yarn format
yarn run v1.22.22
warning package.json: License should be a valid SPDX license expression
warning lldb-dap@0.2.15: The engine "vscode" appears to be invalid.
$ npx prettier './src-ts/' --write
src-ts/debug-adapter-factory.ts 65ms
src-ts/debug-configuration-provider.ts 17ms (unchanged)
src-ts/debug-session-tracker.ts 11ms (unchanged)
src-ts/disposable-context.ts 2ms (unchanged)
src-ts/extension.ts 3ms (unchanged)
src-ts/lldb-dap-server.ts 7ms
src-ts/ui/error-with-notification.ts 4ms (unchanged)
src-ts/ui/modules-data-provider.ts 5ms (unchanged)
src-ts/ui/show-error-message.ts 6ms (unchanged)
src-ts/uri-launch-handler.ts 5ms (unchanged)
✨  Done in 0.99s.
```