### PR TITLE
[clang][bytecode] Try to load primitive values directly

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -282,6 +282,10 @@ bool EvalEmitter::emitGetLocal(uint32_t I, const SourceInfo &Info) {
   using T = typename PrimConv<OpType>::T;
 
   Block *B = getLocal(I);
+
+  if (!CheckLocalLoad(S, OpPC, Pointer(B)))
+    return false;
+
   S.Stk.push<T>(*reinterpret_cast<T *>(B->data()));
   return true;
 }

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -289,3 +289,16 @@ namespace OverlappingStrings {
 
 
 }
+
+namespace NonConstLocal {
+  int a() {
+    const int t=t; // both-note {{declared here}}
+
+    switch(1) {
+      case t:; // both-note {{initializer of 't' is not a constant expression}} \
+               // both-error {{case value is not a constant expression}}
+    }
+  }
+}
+
+


### PR DESCRIPTION
Instead of doing a GetPtrLocal + Load or GetPtrGlobal + Load pair, try to load the value directly.