### PR TITLE
[clang][sema]: Error when SEH __try is used in a function with C++ dtors

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -8264,6 +8264,8 @@ def err_mixing_cxx_try_seh_try : Error<
   "in the same function as SEH '__try'">;
 def err_seh_try_unsupported : Error<
   "SEH '__try' is not supported on this target">;
+def err_seh_try_dtor : Error<"cannot use C++ object with a destructor "
+                             "in the same function as SEH '__try'">;
 def note_conflicting_try_here : Note<
   "conflicting %0 here">;
 def warn_jump_out_of_seh_finally : Warning<

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -400,6 +400,47 @@ static bool isNoexcept(const FunctionDecl *FD) {
 }
 
 //===----------------------------------------------------------------------===//
+// Check for SEH __try in a function with C++ objects that have destructors.
+//===----------------------------------------------------------------------===//
+
+static void emitDiagForSehTryUnwind(Sema &S, CFGElement &E) {
+  if (auto AD = E.getAs<CFGAutomaticObjDtor>()) {
+    const auto *VD = AD->getVarDecl();
+    S.Diag(VD->getLocation(), diag::err_seh_try_dtor);
+  } else if (auto TD = E.getAs<CFGTemporaryDtor>()) {
+    const auto *E = TD->getBindTemporaryExpr();
+    S.Diag(E->getBeginLoc(), diag::err_seh_try_dtor);
+  } else
+    llvm_unreachable("emitDiagForSehTryUnwind should only be used with "
+                     "AutomaticObjectDtor or TemporaryDtor");
+}
+
+static void checkSehTryNeedsUnwind(Sema &S, const FunctionDecl *FD,
+                                   AnalysisDeclContext &AC) {
+  if (!FD->usesSEHTry())
+    return;
+  CFG *BodyCFG = AC.getCFG();
+  if (!BodyCFG)
+    return;
+  if (BodyCFG->getExit().pred_empty())
+    return;
+
+  llvm::BitVector Reachable(BodyCFG->getNumBlockIDs());
+  clang::reachable_code::ScanReachableFromBlock(&BodyCFG->getEntry(),
+                                                Reachable);
+  for (CFGBlock *B : *BodyCFG) {
+    if (!Reachable[B->getBlockID()])
+      continue;
+    for (CFGElement &E : *B) {
+      auto Kind = E.getKind();
+      if (Kind == CFGElement::AutomaticObjectDtor ||
+          Kind == CFGElement::TemporaryDtor)
+        emitDiagForSehTryUnwind(S, E);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Check for missing return value.
 //===----------------------------------------------------------------------===//
 
@@ -2820,6 +2861,10 @@ void clang::sema::AnalysisBasedWarnings::IssueWarnings(
     if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D))
       if (S.getLangOpts().CPlusPlus && !fscope->isCoroutine() && isNoexcept(FD))
         checkThrowInNonThrowingFunc(S, FD, AC);
+
+  if (S.getLangOpts().CPlusPlus)
+    if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D))
+      checkSehTryNeedsUnwind(S, FD, AC);
 
   // If none of the previous checks caused a CFG build, trigger one here
   // for the logical error handler.

--- a/clang/test/Sema/seh-cxx-dtors.cpp
+++ b/clang/test/Sema/seh-cxx-dtors.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -triple=x86_64-pc-win32 -fsyntax-only -fms-extensions -verify %s
+
+struct Foo {
+  ~Foo() {}
+};
+
+// These need '-fms-extensions'
+void f1() {
+  Foo foo {}; // expected-error {{destructor}}
+  __try {} __except (1) {}
+}
+
+void bar(Foo foo);
+
+void f2() {
+  bar(Foo {}); // expected-error {{destructor}}
+  __try {} __except (1) {}
+}


### PR DESCRIPTION
~~Don't generate calls to llvm.seh.scope.{begin,end} if c++ exceptions are disabled. Currently clang sometimes causes LLVM to crash due to invalid usage of the seh intrinsics when c++ objects with destructors are in scope with __try/__except when using -fasync-exceptions (see https://github.com/llvm/llvm-project/issues/82917). I am not sure why the assert that I removed fails with the changes, it would be nice if someone who knows more about the seh code would comment on this. CC @phoebewang~~
Add a sema check to make sure that there are no C++ objects with non-trivial destructors in a function where SEH __try is used.