### PR TITLE
[libc] Enable float math functions on the GPU

### DIFF
--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -489,6 +489,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.tan
     libc.src.math.tanf
     libc.src.math.tanhf
+    libc.src.math.tanpif
     libc.src.math.tgamma
     libc.src.math.tgammaf
     libc.src.math.totalorder

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -490,6 +490,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     libc.src.math.tan
     libc.src.math.tanf
     libc.src.math.tanhf
+    libc.src.math.tanpif
     libc.src.math.tgamma
     libc.src.math.tgammaf
     libc.src.math.totalorder

--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -283,6 +283,12 @@ functions:
     return_type: float
     arguments:
       - type: float
+  - name: cospif
+    standards:
+      - stdc
+    return_type: float
+    arguments:
+      - type: float
   - name: cospif16
     standards:
       - stdc
@@ -2453,6 +2459,12 @@ functions:
     arguments:
       - type: _Float16
     guard: LIBC_TYPES_HAS_FLOAT16
+  - name: sinpif
+    standards:
+      - stdc
+    return_type: float
+    arguments:
+      - type: float
   - name: sinpif16
     standards:
       - stdc


### PR DESCRIPTION
This patch adds the `tanpif` math functions to the GPU build. It also adds the `cospif` and `sinpif` math functions to the `math.h` header.