### PR TITLE
[X86] Update large-displacement.ll

### DIFF
--- a/llvm/test/CodeGen/X86/large-displacements.ll
+++ b/llvm/test/CodeGen/X86/large-displacements.ll
@@ -6,6 +6,7 @@
 
 define i32 @main() #0 {
 ; ERR-i686: error: <unknown>:0:0: 64-bit offset calculated but target is 32-bit
+; ERR-i686: warning: <unknown>:0:0: stack frame size (4294967324) exceeds limit (4294967295) in function 'main'
 ;
 ; x86_64-LABEL: main:
 ; x86_64:       # %bb.0: # %entry
@@ -44,6 +45,7 @@ entry:
 ; Same test as above but for an anonymous function.
 define i32 @0() #0 {
 ; ERR-i686: error: <unknown>:0:0: 64-bit offset calculated but target is 32-bit
+; ERR-i686: warning: <unknown>:0:0: stack frame size (4294967324) exceeds limit (4294967295) in function '@0'
 ;
 ; x86_64-LABEL: __unnamed_1:
 ; x86_64:       # %bb.0: # %entry

--- a/llvm/test/CodeGen/X86/large-displacements.ll
+++ b/llvm/test/CodeGen/X86/large-displacements.ll
@@ -1,4 +1,4 @@
-; RUN: not llc < %s -mtriple=i686 -filetype=null 2>&1 | FileCheck %s -check-prefix=ERR-i686
+; RUN: not llc < %s -mtriple=i686 --verify-machineinstrs=0 -filetype=null 2>&1 | FileCheck %s -check-prefix=ERR-i686
 ; RUN: llc < %s -mtriple=x86_64 | FileCheck %s -check-prefix=x86_64
 
 ; Regression test for #121932, #113856, #106352, #69365, #25051 which are caused by


### PR DESCRIPTION
After 69bec0afbb8f2aa0021d18ea38768360b16583a9 was merged, this test was failing.