### PR TITLE
Fix GetElementPtr article link

### DIFF
--- a/llvm/docs/FAQ.rst
+++ b/llvm/docs/FAQ.rst
@@ -138,7 +138,7 @@ facilities for lexical nor semantic analysis.
 
 I don't understand the ``GetElementPtr`` instruction. Help!
 -----------------------------------------------------------
-See `The Often Misunderstood GEP Instruction <GetElementPtr.html>`_.
+See `The Often Misunderstood GEP Instruction <GetElementPtr.rst>`_.
 
 
 Using the C and C++ Front Ends


### PR DESCRIPTION
I got 404 when reading FAQ on github, after clicking GetElementPtr.html, it probably should be .rst
Probably some more .html links should be updated.
I'm not sure if this is correct change, I tested that link now works on github.