### PR TITLE
[NFC][run-clang-tidy] Add minor type hints

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -236,7 +236,7 @@ def print_profile_data(aggregated_data: Dict[str, float]) -> None:
         checkers.items(), key=lambda x: x[1]["user"] + x[1]["sys"], reverse=True
     )
 
-    def print_stderr(*args, **kwargs) -> None:
+    def print_stderr(*args: Any, **kwargs: Any) -> None:
         print(*args, file=sys.stderr, **kwargs)
 
     print_stderr(


### PR DESCRIPTION

This script passes
```
python3 -m mypy --strict clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
```

`args` and `kwargs` can be typed with what we expect for a single argument. In this case, since we forward to `print`, `Any` seems best.
