### PR TITLE
[lldb] Include bit.h instead of SwapByteOrder.h (NFC)

### DIFF
--- a/lldb/include/lldb/Core/Opcode.h
+++ b/lldb/include/lldb/Core/Opcode.h
@@ -12,7 +12,7 @@
 #include "lldb/Utility/Endian.h"
 #include "lldb/lldb-enumerations.h"
 
-#include "llvm/Support/SwapByteOrder.h"
+#include "llvm/ADT/bit.h"
 
 #include <cassert>
 #include <cstdint>


### PR DESCRIPTION
We use llvm::byteswap from bit.h, but we don't use any feature from
SwapByteOrder.h.
