### PR TITLE
[mlir][IR] Mark `getParentBlock()` and `getParentRegion()` as const (NFC)

### DIFF
--- a/mlir/include/mlir/IR/Value.h
+++ b/mlir/include/mlir/IR/Value.h
@@ -131,10 +131,10 @@ public:
   void setLoc(Location loc);
 
   /// Return the Region in which this Value is defined.
-  Region *getParentRegion();
+  Region *getParentRegion() const;
 
   /// Return the Block in which this Value is defined.
-  Block *getParentBlock();
+  Block *getParentBlock() const;
 
   //===--------------------------------------------------------------------===//
   // UseLists

--- a/mlir/lib/IR/Value.cpp
+++ b/mlir/lib/IR/Value.cpp
@@ -36,14 +36,14 @@ void Value::setLoc(Location loc) {
 }
 
 /// Return the Region in which this Value is defined.
-Region *Value::getParentRegion() {
+Region *Value::getParentRegion() const {
   if (auto *op = getDefiningOp())
     return op->getParentRegion();
   return llvm::cast<BlockArgument>(*this).getOwner()->getParent();
 }
 
 /// Return the Block in which this Value is defined.
-Block *Value::getParentBlock() {
+Block *Value::getParentBlock() const {
   if (Operation *op = getDefiningOp())
     return op->getBlock();
   return llvm::cast<BlockArgument>(*this).getOwner();


### PR DESCRIPTION
This PR marks `Value::getParentBlock()` and `Value::getParentRegion()` as `const` member functions. These methods do not modify the internal state of `Value` and are often used in read-only contexts. Marking them as `const` improves API clarity, allows greater flexibility in calling code.