### PR TITLE
[IR] Introduce hash_value for FMF, GEPNoWrapFlags

### DIFF
--- a/llvm/include/llvm/IR/FMF.h
+++ b/llvm/include/llvm/IR/FMF.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_IR_FMF_H
 #define LLVM_IR_FMF_H
 
+#include "llvm/ADT/Hashing.h"
 #include "llvm/Support/Compiler.h"
 
 namespace llvm {
@@ -121,6 +122,9 @@ public:
     const unsigned ValueMask = NoNaNs | NoInfs | NoSignedZeros;
     return FastMathFlags(ValueMask & (LHS.Flags | RHS.Flags));
   }
+
+  // Hashing.
+  friend hash_code hash_value(const FastMathFlags &FMF);
 };
 
 inline FastMathFlags operator|(FastMathFlags LHS, FastMathFlags RHS) {
@@ -138,6 +142,9 @@ inline raw_ostream &operator<<(raw_ostream &O, FastMathFlags FMF) {
   return O;
 }
 
+inline hash_code hash_value(const FastMathFlags &FMF) {
+  return hash_value(FMF.Flags);
+}
 } // end namespace llvm
 
 #endif // LLVM_IR_FMF_H

--- a/llvm/include/llvm/IR/GEPNoWrapFlags.h
+++ b/llvm/include/llvm/IR/GEPNoWrapFlags.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_IR_GEPNOWRAPFLAGS_H
 #define LLVM_IR_GEPNOWRAPFLAGS_H
 
+#include "llvm/ADT/Hashing.h"
 #include <assert.h>
 
 namespace llvm {
@@ -101,8 +102,14 @@ public:
     Flags |= Other.Flags;
     return *this;
   }
+
+  // Hashing.
+  friend hash_code hash_value(const GEPNoWrapFlags &NW);
 };
 
+inline hash_code hash_value(const GEPNoWrapFlags &NW) {
+  return hash_value(NW.Flags);
+}
 } // end namespace llvm
 
 #endif // LLVM_IR_GEPNOWRAPFLAGS_H


### PR DESCRIPTION
This patch is motivated by wanting to do CSE at the VPlan-level: as VPlan stores FMF and GEPNoWrapFlags among other things in its recipes, de-duplicating them for common-subexpression-elimination would require hashing the VPlan recipes along with their embedded information.