### PR TITLE
[Flang] Search flang_rt in clang_rt path

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -855,10 +855,7 @@ void ToolChain::addFortranRuntimeLibs(const ArgList &Args,
 
 void ToolChain::addFortranRuntimeLibraryPath(const llvm::opt::ArgList &Args,
                                              ArgStringList &CmdArgs) const {
-  auto AddLibrarySearchPathIfExists = [&](const Twine &Path) {
-    if (!llvm::sys::fs::is_directory(Path))
-      return;
-
+  auto AddLibrarySearchPath = [&](const Twine &Path) {
     if (getTriple().isKnownWindowsMSVCEnvironment())
       CmdArgs.push_back(Args.MakeArgString("-libpath:" + Path));
     else
@@ -869,7 +866,7 @@ void ToolChain::addFortranRuntimeLibraryPath(const llvm::opt::ArgList &Args,
   // LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=0. On most platforms, flang_rt is
   // located at the path returned by getRuntimePath() which is already added to
   // the library search path. This exception is for Apple-Darwin.
-  AddLibrarySearchPathIfExists(getCompilerRTPath());
+  AddLibrarySearchPath(getCompilerRTPath());
 
   // Fall back to the non-resource directory <driver-path>/../lib. We will
   // probably have to re-fine this in the future. In particular, on some
@@ -877,7 +874,7 @@ void ToolChain::addFortranRuntimeLibraryPath(const llvm::opt::ArgList &Args,
   SmallString<256> DefaultLibPath =
       llvm::sys::path::parent_path(getDriver().Dir);
   llvm::sys::path::append(DefaultLibPath, "lib");
-  AddLibrarySearchPathIfExists(DefaultLibPath);
+  AddLibrarySearchPath(DefaultLibPath);
 }
 
 void ToolChain::addFlangRTLibPath(const ArgList &Args,

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -855,17 +855,29 @@ void ToolChain::addFortranRuntimeLibs(const ArgList &Args,
 
 void ToolChain::addFortranRuntimeLibraryPath(const llvm::opt::ArgList &Args,
                                              ArgStringList &CmdArgs) const {
-  // Default to the <driver-path>/../lib directory. This works fine on the
-  // platforms that we have tested so far. We will probably have to re-fine
-  // this in the future. In particular, on some platforms, we may need to use
-  // lib64 instead of lib.
+  auto AddLibrarySearchPathIfExists = [&](const Twine &Path) {
+    if (!llvm::sys::fs::is_directory(Path))
+      return;
+
+    if (getTriple().isKnownWindowsMSVCEnvironment())
+      CmdArgs.push_back(Args.MakeArgString("-libpath:" + Path));
+    else
+      CmdArgs.push_back(Args.MakeArgString("-L" + Path));
+  };
+
+  // Search for flang_rt.* at the same location as clang_rt.* with
+  // LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=0. On most platforms, flang_rt is
+  // located at the path returned by getRuntimePath() which is already added to
+  // the library search path. This exception is for Apple-Darwin.
+  AddLibrarySearchPathIfExists(getCompilerRTPath());
+
+  // Fall back to the non-resource directory <driver-path>/../lib. We will
+  // probably have to re-fine this in the future. In particular, on some
+  // platforms, we may need to use lib64 instead of lib.
   SmallString<256> DefaultLibPath =
       llvm::sys::path::parent_path(getDriver().Dir);
   llvm::sys::path::append(DefaultLibPath, "lib");
-  if (getTriple().isKnownWindowsMSVCEnvironment())
-    CmdArgs.push_back(Args.MakeArgString("-libpath:" + DefaultLibPath));
-  else
-    CmdArgs.push_back(Args.MakeArgString("-L" + DefaultLibPath));
+  AddLibrarySearchPathIfExists(DefaultLibPath);
 }
 
 void ToolChain::addFlangRTLibPath(const ArgList &Args,

--- a/flang-rt/cmake/modules/GetToolchainDirs.cmake
+++ b/flang-rt/cmake/modules/GetToolchainDirs.cmake
@@ -34,8 +34,14 @@
 function (get_toolchain_library_subdir outvar)
   set(outval "lib")
 
-  get_toolchain_arch_dirname(arch_dirname)
-  set(outval "${outval}/${arch_dirname}")
+  if (APPLE)
+    # Required to be "darwin" for MachO toolchain.
+    get_toolchain_os_dirname(os_dirname)
+    set(outval "${outval}/${os_dirname}")
+  else ()
+    get_toolchain_arch_dirname(arch_dirname)
+    set(outval "${outval}/${arch_dirname}")
+  endif ()
 
   set(${outvar} "${outval}" PARENT_SCOPE)
 endfunction ()

--- a/flang-rt/cmake/modules/GetToolchainDirs.cmake
+++ b/flang-rt/cmake/modules/GetToolchainDirs.cmake
@@ -34,14 +34,8 @@
 function (get_toolchain_library_subdir outvar)
   set(outval "lib")
 
-  if (APPLE)
-    # Required to be "darwin" for MachO toolchain.
-    get_toolchain_os_dirname(os_dirname)
-    set(outval "${outval}/${os_dirname}")
-  else ()
-    get_toolchain_arch_dirname(arch_dirname)
-    set(outval "${outval}/${arch_dirname}")
-  endif ()
+  get_toolchain_arch_dirname(arch_dirname)
+  set(outval "${outval}/${arch_dirname}")
 
   set(${outvar} "${outval}" PARENT_SCOPE)
 endfunction ()


### PR DESCRIPTION
The clang/flang driver has two separate systems for find the location of clang_rt (simplified):

 * `getCompilerRTPath()`,  e.g. `../lib/clang/22/lib/windows`, used when `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=0`
 * `getRuntimePath()`, e.g. `../lib/clang/22/lib/x86_64-pc-windows-msvc`, used when `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=1`

To simplify the search path, Flang-RT normally assumes only `getRuntimePath()`, i.e. ignoring `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` and always using the `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=1` mechanism. There is an exception for Apple Darwin triples where `getRuntimePath()` returns nothing. The flang-rt/compiler-rt CMake code for library location also ignores `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` but uses the `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR=0` path instead. Since only `getRuntimePath()` is automatically added to the linker command line, this patch explicitly adds `getCompilerRTPath()` to the search path when linking flang_rt.

Fixes #151031