### PR TITLE
[Clang] Hide `offload-arch` initialization errors behind verbose flag

### DIFF
--- a/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
+++ b/clang/tools/offload-arch/AMDGPUArchByHIP.cpp
@@ -165,8 +165,9 @@ int printGPUsByHIP() {
       llvm::sys::DynamicLibrary::getPermanentLibrary(DynamicHIPPath.c_str(),
                                                      &ErrMsg));
   if (!DynlibHandle->isValid()) {
-    llvm::errs() << "Failed to load " << DynamicHIPPath << ": " << ErrMsg
-                 << '\n';
+    if (Verbose)
+      llvm::errs() << "Failed to load " << DynamicHIPPath << ": " << ErrMsg
+                   << '\n';
     return 1;
   }
 

--- a/clang/tools/offload-arch/NVPTXArch.cpp
+++ b/clang/tools/offload-arch/NVPTXArch.cpp
@@ -21,6 +21,8 @@
 
 using namespace llvm;
 
+extern cl::opt<bool> Verbose;
+
 typedef enum cudaError_enum {
   CUDA_SUCCESS = 0,
   CUDA_ERROR_NO_DEVICE = 100,
@@ -78,7 +80,10 @@ static int handleError(CUresult Err) {
 int printGPUsByCUDA() {
   // Attempt to load the NVPTX driver runtime.
   if (llvm::Error Err = loadCUDA()) {
-    logAllUnhandledErrors(std::move(Err), llvm::errs());
+    if (Verbose)
+      logAllUnhandledErrors(std::move(Err), llvm::errs());
+    else
+      consumeError(std::move(Err));
     return 1;
   }
 


### PR DESCRIPTION
Summary:
This tool tries to print the offloading architectures. If the user
doesn't have the HIP libraries or the CUDA libraries it will print and error.
This isn't super helpful since we're just querying things. So, for
example, if we're on an AMD machine with no CUDA you'll get the AMD GPUs
and then an error message saying that CUDA wasn't found. This silences
the error just on failing to find the library unless verbose is on.
