### PR TITLE
[StackLifetime] Remove handling for lifetime size mismatch

### DIFF
--- a/llvm/include/llvm/Analysis/StackLifetime.h
+++ b/llvm/include/llvm/Analysis/StackLifetime.h
@@ -121,8 +121,6 @@ private:
   DenseMap<const BasicBlock *, SmallVector<std::pair<unsigned, Marker>, 4>>
       BBMarkers;
 
-  bool HasUnknownLifetimeStartOrEnd = false;
-
   void dumpAllocas() const;
   void dumpBlockLiveness() const;
   void dumpLiveRanges() const;

--- a/llvm/lib/Analysis/StackLifetime.cpp
+++ b/llvm/lib/Analysis/StackLifetime.cpp
@@ -59,35 +59,10 @@ bool StackLifetime::isAliveAfter(const AllocaInst *AI,
   return getLiveRange(AI).test(InstNum);
 }
 
-// Returns unique alloca annotated by lifetime marker only if
-// markers has the same size and points to the alloca start.
-static const AllocaInst *findMatchingAlloca(const IntrinsicInst &II,
-                                            const DataLayout &DL) {
-  const AllocaInst *AI = dyn_cast<AllocaInst>(II.getArgOperand(1));
-  if (!AI)
-    return nullptr;
-
-  auto AllocaSize = AI->getAllocationSize(DL);
-  if (!AllocaSize)
-    return nullptr;
-
-  auto *Size = dyn_cast<ConstantInt>(II.getArgOperand(0));
-  if (!Size)
-    return nullptr;
-  int64_t LifetimeSize = Size->getSExtValue();
-
-  if (LifetimeSize != -1 && uint64_t(LifetimeSize) != *AllocaSize)
-    return nullptr;
-
-  return AI;
-}
-
 void StackLifetime::collectMarkers() {
   InterestingAllocas.resize(NumAllocas);
   DenseMap<const BasicBlock *, SmallDenseMap<const IntrinsicInst *, Marker>>
       BBMarkerSet;
-
-  const DataLayout &DL = F.getDataLayout();
 
   // Compute the set of start/end markers per basic block.
   for (const BasicBlock *BB : depth_first(&F)) {
@@ -95,11 +70,9 @@ void StackLifetime::collectMarkers() {
       const IntrinsicInst *II = dyn_cast<IntrinsicInst>(&I);
       if (!II || !II->isLifetimeStartOrEnd())
         continue;
-      const AllocaInst *AI = findMatchingAlloca(*II, DL);
-      if (!AI) {
-        HasUnknownLifetimeStartOrEnd = true;
+      const AllocaInst *AI = dyn_cast<AllocaInst>(II->getArgOperand(1));
+      if (!AI)
         continue;
-      }
       auto It = AllocaNumbering.find(AI);
       if (It == AllocaNumbering.end())
         continue;
@@ -328,20 +301,6 @@ StackLifetime::StackLifetime(const Function &F,
 }
 
 void StackLifetime::run() {
-  if (HasUnknownLifetimeStartOrEnd) {
-    // There is marker which we can't assign to a specific alloca, so we
-    // fallback to the most conservative results for the type.
-    switch (Type) {
-    case LivenessType::May:
-      LiveRanges.resize(NumAllocas, getFullLiveRange());
-      break;
-    case LivenessType::Must:
-      LiveRanges.resize(NumAllocas, LiveRange(Instructions.size()));
-      break;
-    }
-    return;
-  }
-
   LiveRanges.resize(NumAllocas, LiveRange(Instructions.size()));
   for (unsigned I = 0; I < NumAllocas; ++I)
     if (!InterestingAllocas.test(I))

--- a/llvm/test/Analysis/StackSafetyAnalysis/lifetime.ll
+++ b/llvm/test/Analysis/StackSafetyAnalysis/lifetime.ll
@@ -786,27 +786,6 @@ end:
   ret void
 }
 
-define void @alloca_size() {
-; CHECK-LABEL: define void @alloca_size
-entry:
-; CHECK: entry:
-; MAY-NEXT: Alive: <x>
-; MUST-NEXT: Alive: <>
-  %x = alloca [5 x i32], align 4
-
-  call void @llvm.lifetime.start.p0(i64 15, ptr %x)
-; CHECK: call void @llvm.lifetime.start.p0(i64 15, ptr %x)
-; MAY-NEXT: Alive: <x>
-; MUST-NEXT: Alive: <>
-
-  call void @llvm.lifetime.end.p0(i64 15, ptr %x)
-; CHECK: call void @llvm.lifetime.end.p0(i64 15, ptr %x)
-; MAY-NEXT: Alive: <x>
-; MUST-NEXT: Alive: <>
-
-  ret void
-}
-
 define void @multiple_start_end() {
 ; CHECK-LABEL: define void @multiple_start_end
 entry:

--- a/llvm/test/Instrumentation/AddressSanitizer/lifetime-uar-uas.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/lifetime-uar-uas.ll
@@ -18,11 +18,11 @@ entry:
   %retval = alloca i32, align 4
   %c = alloca [2 x i8], align 1
 
-  ; Memory is poisoned in prologue: F1F1F1F104F3F8F2
-  ; CHECK-UAS: store i64 -866676825215864335, ptr %{{[0-9]+}}
+  ; Memory is poisoned in prologue: F1F1F1F1F8F3F3F3
+  ; CHECK-UAS: store i64 -868082052615769615, ptr %{{[0-9]+}}
   ; CHECK-UAS-SS-NOT: store i64
 
-  call void @llvm.lifetime.start.p0(i64 1, ptr %c)
+  call void @llvm.lifetime.start.p0(i64 2, ptr %c)
   ; Memory is unpoisoned at llvm.lifetime.start: 01
   ; CHECK-UAS: store i8 2, ptr %{{[0-9]+}}
 
@@ -30,7 +30,7 @@ entry:
   store volatile i32 0, ptr %retval
   store volatile i8 0, ptr %ci, align 1
 
-  call void @llvm.lifetime.end.p0(i64 1, ptr %c)
+  call void @llvm.lifetime.end.p0(i64 2, ptr %c)
   ; Memory is poisoned at llvm.lifetime.end: F8
   ; CHECK-UAS: store i8 -8, ptr %{{[0-9]+}}
   ; CHECK-UAS-SS-NOT: store i8 -8,


### PR DESCRIPTION
Split out from #150248:

Since #150944 the size passed to lifetime.start/end is considered meaningless. The lifetime always applies to the whole alloca.

Accordingly remove handling for size mismatch in the StackLifetime analysis.