### PR TITLE
[mlir][llvm] Add builder for llvm.call_intrinsic op

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2432,6 +2432,7 @@ def LLVM_CallIntrinsicOp
     OpBuilder<(ins "StringAttr":$intrin, "ValueRange":$args)>,
     OpBuilder<(ins "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>,
     OpBuilder<(ins "Type": $resultType, "StringAttr":$intrin, "ValueRange":$args)>,
+    OpBuilder<(ins "TypeRange": $resultTypes, "StringAttr":$intrin, "ValueRange":$args)>,
     OpBuilder<(ins "TypeRange": $resultTypes, "StringAttr":$intrin, "ValueRange":$args, "FastmathFlagsAttr":$fastMathFlags)>
   ];
 

--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -3792,6 +3792,14 @@ void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
 
 void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
                             mlir::TypeRange resultTypes,
+                            mlir::StringAttr intrin, mlir::ValueRange args) {
+  build(builder, state, resultTypes, intrin, args, FastmathFlagsAttr{},
+        /*op_bundle_operands=*/{}, /*op_bundle_tags=*/{}, /*arg_attrs=*/{},
+        /*res_attrs=*/{});
+}
+
+void CallIntrinsicOp::build(OpBuilder &builder, OperationState &state,
+                            mlir::TypeRange resultTypes,
                             mlir::StringAttr intrin, mlir::ValueRange args,
                             mlir::LLVM::FastmathFlagsAttr fastMathFlags) {
   build(builder, state, resultTypes, intrin, args, fastMathFlags,

--- a/mlir/lib/Target/LLVMIR/LLVMImportInterface.cpp
+++ b/mlir/lib/Target/LLVMIR/LLVMImportInterface.cpp
@@ -43,7 +43,7 @@ LogicalResult mlir::LLVMImportInterface::convertUnregisteredIntrinsic(
       builder, moduleImport.translateLoc(inst->getDebugLoc()),
       isa<LLVMVoidType>(resultType) ? TypeRange{} : TypeRange{resultType},
       StringAttr::get(builder.getContext(), intrinName),
-      ValueRange{mlirOperands}, FastmathFlagsAttr{});
+      ValueRange{mlirOperands});
 
   moduleImport.setFastmathFlagsAttr(inst, op);
   moduleImport.convertArgAndResultAttrs(inst, op);


### PR DESCRIPTION
Add new builder function to make build llvm.call_intrinsic op more convenient.