### PR TITLE
[Clang] Fix warning on synthetic offload arch argument in host only mode

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1012,6 +1012,7 @@ inferOffloadToolchains(Compilation &C, Action::OffloadKind Kind) {
     Arg *A = new Arg(Opt, C.getArgs().getArgString(Index), Index,
                      C.getArgs().MakeArgString(Triple.split("-").first),
                      C.getArgs().MakeArgString("--offload-arch=" + Arch));
+    A->claim();
     C.getArgs().append(A);
     C.getArgs().AddSynthesizedArg(A);
     Triples.insert(Triple);

--- a/clang/test/Driver/hip-options.hip
+++ b/clang/test/Driver/hip-options.hip
@@ -241,7 +241,7 @@
 // Check --offload-compress --offload-jobs=N does not cause warning.
 // RUN: %clang -### -Werror --target=x86_64-unknown-linux-gnu -nogpuinc -nogpulib \
 // RUN:   --offload-arch=gfx1100 --offload-compress --offload-host-only -M %s \
-// RUN:   --offload-jobs=4
+// RUN:   --offload-jobs=4 --offload-new-driver
 
 // Check --offload-jobs=N option.
 


### PR DESCRIPTION
Summary:
These arguments are synthetically generated and should always be
considered used. This was emitting a warning on the new driver.
