### PR TITLE
[nfc][profcheck] fix cl::desc typo

### DIFF
--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -224,7 +224,8 @@ static cl::opt<bool> EnableProfileVerification(
 #else
     cl::init(false),
 #endif
-    cl::desc("Start the pipeline with prof-inject and end it with prof-check"));
+    cl::desc(
+        "Start the pipeline with prof-inject and end it with prof-verify"));
 
 static cl::opt<std::string> ClDataLayout("data-layout",
                                          cl::desc("data layout string to use"),


### PR DESCRIPTION
The pass is `prof-verify`, not `prof-check`. (Meanwhile, `profcheck` is an informal handle we could use for the whole feature in the [RFC](https://discourse.llvm.org/t/rfc-profile-information-propagation-unittesting/73595))