### PR TITLE
[clang][bytecode] Return success for pointers to locals

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -233,6 +233,14 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(const SourceInfo &Info) {
       return false;
     }
   } else {
+    // If this is pointing to a local variable, just return
+    // the result, even if the pointer is dead.
+    // This will later be diagnosed by CheckLValueConstantExpression.
+    if (Ptr.isBlockPointer() && !Ptr.block()->isStatic()) {
+      EvalResult.setValue(Ptr.toAPValue(Ctx.getASTContext()));
+      return true;
+    }
+
     if (!Ptr.isLive() && !Ptr.isTemporary())
       return false;
 

--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -301,4 +301,11 @@ namespace NonConstLocal {
   }
 }
 
+#define ATTR __attribute__((require_constant_initialization))
+int somefunc() {
+  const int non_global = 42; // both-note {{declared here}}
+  ATTR static const int &local_init = non_global; // both-error {{variable does not have a constant initializer}} \
+                                                  // both-note {{required by}} \
+                                                  // both-note {{reference to 'non_global' is not a constant expression}}
+}
 


### PR DESCRIPTION
They aren't valid, but we leave them successful here and CheckLValueConstantExpression will diagnose them later.