### PR TITLE
ARM: Remove CPU from computeTargetABI

### DIFF
--- a/llvm/include/llvm/TargetParser/ARMTargetParser.h
+++ b/llvm/include/llvm/TargetParser/ARMTargetParser.h
@@ -270,10 +270,9 @@ LLVM_ABI ProfileKind parseArchProfile(StringRef Arch);
 LLVM_ABI unsigned parseArchVersion(StringRef Arch);
 
 LLVM_ABI void fillValidCPUArchList(SmallVectorImpl<StringRef> &Values);
-LLVM_ABI StringRef computeDefaultTargetABI(const Triple &TT, StringRef CPU);
+LLVM_ABI StringRef computeDefaultTargetABI(const Triple &TT);
 
-LLVM_ABI ARMABI computeTargetABI(const Triple &TT, StringRef CPU,
-                                 StringRef ABIName = "");
+LLVM_ABI ARMABI computeTargetABI(const Triple &TT, StringRef ABIName = "");
 
 /// Get the (LLVM) name of the minimum ARM CPU for the arch we are targeting.
 ///

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -121,10 +121,10 @@ static std::unique_ptr<TargetLoweringObjectFile> createTLOF(const Triple &TT) {
   return std::make_unique<ARMElfTargetObjectFile>();
 }
 
-static std::string computeDataLayout(const Triple &TT, StringRef CPU,
+static std::string computeDataLayout(const Triple &TT,
                                      const TargetOptions &Options,
                                      bool isLittle) {
-  auto ABI = ARM::computeTargetABI(TT, CPU, Options.MCOptions.ABIName);
+  auto ABI = ARM::computeTargetABI(TT, Options.MCOptions.ABIName);
   std::string Ret;
 
   if (isLittle)
@@ -202,11 +202,10 @@ ARMBaseTargetMachine::ARMBaseTargetMachine(const Target &T, const Triple &TT,
                                            std::optional<Reloc::Model> RM,
                                            std::optional<CodeModel::Model> CM,
                                            CodeGenOptLevel OL, bool isLittle)
-    : CodeGenTargetMachineImpl(T, computeDataLayout(TT, CPU, Options, isLittle),
-                               TT, CPU, FS, Options,
-                               getEffectiveRelocModel(TT, RM),
+    : CodeGenTargetMachineImpl(T, computeDataLayout(TT, Options, isLittle), TT,
+                               CPU, FS, Options, getEffectiveRelocModel(TT, RM),
                                getEffectiveCodeModel(CM, CodeModel::Small), OL),
-      TargetABI(ARM::computeTargetABI(TT, CPU, Options.MCOptions.ABIName)),
+      TargetABI(ARM::computeTargetABI(TT, Options.MCOptions.ABIName)),
       TLOF(createTLOF(getTargetTriple())), isLittle(isLittle) {
 
   // Default to triple-appropriate float ABI

--- a/llvm/lib/TargetParser/ARMTargetParser.cpp
+++ b/llvm/lib/TargetParser/ARMTargetParser.cpp
@@ -535,9 +535,8 @@ void ARM::fillValidCPUArchList(SmallVectorImpl<StringRef> &Values) {
   }
 }
 
-StringRef ARM::computeDefaultTargetABI(const Triple &TT, StringRef CPU) {
-  StringRef ArchName =
-      CPU.empty() ? TT.getArchName() : getArchName(parseCPUArch(CPU));
+StringRef ARM::computeDefaultTargetABI(const Triple &TT) {
+  StringRef ArchName = TT.getArchName();
 
   if (TT.isOSBinFormatMachO()) {
     if (TT.getEnvironment() == Triple::EABI ||
@@ -575,10 +574,9 @@ StringRef ARM::computeDefaultTargetABI(const Triple &TT, StringRef CPU) {
   }
 }
 
-ARM::ARMABI ARM::computeTargetABI(const Triple &TT, StringRef CPU,
-                                  StringRef ABIName) {
+ARM::ARMABI ARM::computeTargetABI(const Triple &TT, StringRef ABIName) {
   if (ABIName.empty())
-    ABIName = ARM::computeDefaultTargetABI(TT, CPU);
+    ABIName = ARM::computeDefaultTargetABI(TT);
 
   if (ABIName == "aapcs16")
     return ARM_ABI_AAPCS16;


### PR DESCRIPTION
The target CPU is a subtarget / function level concept, which
should not influence the module level ABI decisions. No tests fail
so it appears nothing is relying on this.