### PR TITLE
ADT: Expose typedef for Bitset's storage type

### DIFF
--- a/llvm/include/llvm/ADT/Bitset.h
+++ b/llvm/include/llvm/ADT/Bitset.h
@@ -35,12 +35,17 @@ class Bitset {
   static_assert(BITWORD_SIZE == 64 || BITWORD_SIZE == 32,
                 "Unsupported word size");
 
-  static constexpr unsigned NumWords = (NumBits + BITWORD_SIZE-1) / BITWORD_SIZE;
-  std::array<BitWord, NumWords> Bits{};
+  static constexpr unsigned NumWords =
+      (NumBits + BITWORD_SIZE - 1) / BITWORD_SIZE;
 
 protected:
-  constexpr Bitset(const std::array<BitWord, NumWords> &B)
-      : Bits{B} {}
+  using StorageType = std::array<BitWord, NumWords>;
+
+private:
+  StorageType Bits{};
+
+protected:
+  constexpr Bitset(const StorageType &B) : Bits{B} {}
 
 public:
   constexpr Bitset() = default;


### PR DESCRIPTION
Allows subclasses to directly initialize the underlying storage.
This will enable tablegen to emit a smaller initializer list to
initialize constant bitsets. For runtime libcalls we need to
initialize many hundreds of bits in many different sets so this
shrinks the generated output to a more manageable size.

Extracted from #151948