### PR TITLE
[lldb][nfc] Use delegating ctor for ExecutionContext

### DIFF
--- a/lldb/include/lldb/Target/ExecutionContext.h
+++ b/lldb/include/lldb/Target/ExecutionContext.h
@@ -318,7 +318,9 @@ public:
   // These two variants take in a locker, and grab the target, lock the API
   // mutex into locker, then fill in the rest of the shared pointers.
   ExecutionContext(const ExecutionContextRef &exe_ctx_ref,
-                   std::unique_lock<std::recursive_mutex> &locker);
+                   std::unique_lock<std::recursive_mutex> &locker)
+      : ExecutionContext(&exe_ctx_ref, locker) {}
+
   ExecutionContext(const ExecutionContextRef *exe_ctx_ref,
                    std::unique_lock<std::recursive_mutex> &locker);
   // Create execution contexts from execution context scopes

--- a/lldb/source/Target/ExecutionContext.cpp
+++ b/lldb/source/Target/ExecutionContext.cpp
@@ -140,19 +140,6 @@ ExecutionContext::ExecutionContext(const ExecutionContextRef *exe_ctx_ref_ptr,
   }
 }
 
-ExecutionContext::ExecutionContext(const ExecutionContextRef &exe_ctx_ref,
-                                   std::unique_lock<std::recursive_mutex> &lock)
-    : m_target_sp(exe_ctx_ref.GetTargetSP()), m_process_sp(), m_thread_sp(),
-      m_frame_sp() {
-  if (m_target_sp) {
-    lock = std::unique_lock<std::recursive_mutex>(m_target_sp->GetAPIMutex());
-
-    m_process_sp = exe_ctx_ref.GetProcessSP();
-    m_thread_sp = exe_ctx_ref.GetThreadSP();
-    m_frame_sp = exe_ctx_ref.GetFrameSP();
-  }
-}
-
 ExecutionContext::ExecutionContext(ExecutionContextScope *exe_scope_ptr)
     : m_target_sp(), m_process_sp(), m_thread_sp(), m_frame_sp() {
   if (exe_scope_ptr)


### PR DESCRIPTION
The ctor that takes a reference to ExecutionContextRef can be implemented in terms of the ctor that takes a pointer to that object, removing code duplication.