### PR TITLE
[MLIR][LLVM] Model llvm.module_asm instruction

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -2399,6 +2399,29 @@ def LLVM_InlineAsmOp : LLVM_Op<"inline_asm", [DeclareOpInterfaceMethods<MemoryEf
   let hasVerifier = 1;
 }
 
+def LLVM_ModuleAsmOp : LLVM_Op<"module_asm"> {
+  let description = [{
+    The ModuleAsmOp mirrors the underlying LLVM "module asm" semantics, 
+    allowing target-specific assembly code to be embedded at module level.
+    
+    Module asm blocks are concatenated and emitted outside of any function,
+    corresponding to GCC's file scope inline assembly. The assembly string
+    must be parseable by LLVM's integrated assembler and can reference 
+    module-level symbols but not local variables.
+
+    Example:
+    ```
+    llvm.module_asm "my_function: ret"
+    llvm.module_asm ".globl my_symbol"
+    ```
+  }];
+  let arguments = (ins StrAttr:$asm_string);
+
+  let assemblyFormat = [{
+    attr-dict $asm_string
+   }];
+}
+
 //===--------------------------------------------------------------------===//
 // CallIntrinsicOp
 //===--------------------------------------------------------------------===//

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -505,6 +505,12 @@ convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
     return success();
   }
 
+  if (auto moduleAsmOp = dyn_cast<LLVM::ModuleAsmOp>(opInst)) {
+    moduleTranslation.getLLVMModule()->appendModuleInlineAsm(
+        moduleAsmOp.getAsmString());
+    return success();
+  }
+
   if (auto invOp = dyn_cast<LLVM::InvokeOp>(opInst)) {
     auto operands = moduleTranslation.lookupValues(invOp.getCalleeOperands());
     SmallVector<llvm::OperandBundleDef> opBundles =

--- a/mlir/test/Dialect/LLVMIR/canonicalize.mlir
+++ b/mlir/test/Dialect/LLVMIR/canonicalize.mlir
@@ -307,3 +307,11 @@ llvm.func @inline_asm_side_effects(%x : i32) {
   llvm.inline_asm has_side_effects "inline asm with side effects", "r" %x : (i32) -> ()
   llvm.return
 }
+
+// -----
+
+// CHECK-LABEL: llvm.module_asm
+// CHECK-SAME: ".global some_symbol"
+// CHECK-NEXT: llvm.module_asm ".global another_symbol"
+llvm.module_asm ".global some_symbol"
+llvm.module_asm ".global another_symbol"

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2088,6 +2088,15 @@ llvm.func @useInlineAsm2(%arg0: !llvm.ptr, %arg1: i64, %arg2: !llvm.ptr, %arg3: 
 
 // -----
 
+module {
+  // CHECK: module asm ".global file_scope_asm_symbol"
+  // CHECK-NEXT: module asm "some_asm_label:"
+  llvm.module_asm ".global file_scope_asm_symbol"
+  llvm.module_asm "some_asm_label:"
+}
+
+// -----
+
 llvm.func @fastmathFlagsFunc(f32) -> f32
 
 // CHECK-LABEL: @fastmathFlags


### PR DESCRIPTION
This patch adds a new llvm.module_asm operator which models LLVM's `module asm` blocks. It provides translation to LLVM IR but does not check for the validity of asm_string.