### PR TITLE
[LLD][COFF] Don't resolve weak aliases when performing local import

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2714,8 +2714,10 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
   }
 
   ctx.symtab.initializeSameAddressThunks();
-  for (auto alias : aliases)
+  for (auto alias : aliases) {
+    assert(alias->kind() == Symbol::UndefinedKind);
     alias->resolveWeakAlias();
+  }
 
   if (config->mingw) {
     // Make sure the crtend.o object is the last object file. This object

--- a/lld/test/COFF/import_weak_alias.test
+++ b/lld/test/COFF/import_weak_alias.test
@@ -4,17 +4,24 @@
 # RUN: llvm-mc --filetype=obj -triple=x86_64-windows-msvc %t.dir/foo.s -o %t.foo.obj
 # RUN: llvm-mc --filetype=obj -triple=x86_64-windows-msvc %t.dir/qux.s -o %t.qux.obj
 # RUN: lld-link %t.qux.obj %t.foo.obj -out:%t.dll -dll
+# RUN: lld-link %t.foo.obj %t.qux.obj -out:%t.dll -dll
 #
 #--- foo.s
 .text
 bar:
   ret
 
-.weak foo
-.set foo, bar
+.weak a
+.weak b
+.weak c
+.set a, bar
+.set b, bar
+.set c, bar
 #--- qux.s
 .text
 .global _DllMainCRTStartup
 _DllMainCRTStartup:
-  call *__imp_foo(%rip)
+  call *__imp_a(%rip)
+  call *__imp_b(%rip)
+  call *__imp_c(%rip)
   ret


### PR DESCRIPTION
Fixes crashes reported in #151255.

The alias may have already been stored for later resolution, which can lead to treating a resolved alias as if it were still undefined. Instead, use the alias target directly for the import.

Also extended the test to make reproducing the problem more likely, and added an assert that catches the issue.