### PR TITLE
[vscode-lldb] Fix `yarn package`

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -45,7 +45,7 @@
     "vscode:prepublish": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "format": "npx prettier './src-ts/' --write",
-    "package": "vsce package --out ./out/lldb-dap.vsix",
+    "package": "rm -rf ./out/lldb-dap.vsix && vsce package --out ./out/lldb-dap.vsix",
     "publish": "vsce publish",
     "vscode-uninstall": "code --uninstall-extension llvm-vs-code-extensions.lldb-dap",
     "vscode-install": "code --install-extension ./out/lldb-dap.vsix"


### PR DESCRIPTION
# Problem
`yarn package` cannot be run twice in a row - the second time will error out:
> Error: ENOENT: no such file or directory, stat '<path>/llvm-project/lldb/tools/lldb-dap/out/lldb-dap.vsix'

This error is also weird, because the file actually exists. See the end of this [full output](https://gist.github.com/royitaqi/f3f4838ed30d7ade846f53f0fb7d68f4).

# Fix

Delete the `lldb-dap.vsix` file at the start of each run. See consecutive runs [being successful](https://gist.github.com/royitaqi/9609181b4fe6a8a4e71880c36cd0c7c9).