### PR TITLE
[lldb] Eliminate PyGILState_Check (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -261,7 +261,6 @@ PythonObject PythonObject::GetAttributeValue(llvm::StringRef attr) const {
 }
 
 StructuredData::ObjectSP PythonObject::CreateStructuredObject() const {
-  assert(PyGILState_Check());
   switch (GetObjectType()) {
   case PyObjectType::Dictionary:
     return PythonDictionary(PyRefType::Borrowed, m_py_obj)

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -139,11 +139,12 @@ public:
     PyConfig_Clear(&config);
 
     // The only case we should go further and acquire the GIL: it is unlocked.
-    if (PyGILState_Check())
+    PyGILState_STATE gil_state = PyGILState_Ensure();
+    if (gil_state != PyGILState_UNLOCKED)
       return;
 
     m_was_already_initialized = true;
-    m_gil_state = PyGILState_Ensure();
+    m_gil_state = gil_state;
     LLDB_LOGV(GetLog(LLDBLog::Script),
               "Ensured PyGILState. Previous state = {0}",
               m_gil_state == PyGILState_UNLOCKED ? "unlocked" : "locked");


### PR DESCRIPTION
Eliminate calls to PyGILState_Check, which is not part of the Python Limited C API. In the Locker, we can use PyGILState_Ensure directly. We could do something similar to replace the assert, but I don't think it's worth it. We don't assert that we hold the GIL anywhere else.