### PR TITLE
[lldb] Guard SBFrame/SBThread methods against running processes

### DIFF
--- a/lldb/include/lldb/API/SBError.h
+++ b/lldb/include/lldb/API/SBError.h
@@ -87,6 +87,7 @@ protected:
   friend class SBDebugger;
   friend class SBFile;
   friend class SBFormat;
+  friend class SBFrame;
   friend class SBHostOS;
   friend class SBPlatform;
   friend class SBProcess;

--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -233,6 +233,10 @@ protected:
 
   void SetFrameSP(const lldb::StackFrameSP &lldb_object_sp);
 
+  /// Return an SBValue with an error message warning that the process is not
+  /// currently stopped.
+  static SBValue CreateProcessIsRunningExprEvalError();
+
   lldb::ExecutionContextRefSP m_opaque_sp;
 };
 

--- a/lldb/include/lldb/API/SBFrame.h
+++ b/lldb/include/lldb/API/SBFrame.h
@@ -233,8 +233,8 @@ protected:
 
   void SetFrameSP(const lldb::StackFrameSP &lldb_object_sp);
 
-  /// Return an SBValue with an error message warning that the process is not
-  /// currently stopped.
+  /// Return an SBValue containing an error message that warns the process is
+  /// not currently stopped.
   static SBValue CreateProcessIsRunningExprEvalError();
 
   lldb::ExecutionContextRefSP m_opaque_sp;

--- a/lldb/include/lldb/Host/ProcessRunLock.h
+++ b/lldb/include/lldb/Host/ProcessRunLock.h
@@ -44,6 +44,14 @@ public:
     ProcessRunLocker(ProcessRunLocker &&other) : m_lock(other.m_lock) {
       other.m_lock = nullptr;
     }
+    ProcessRunLocker &operator=(ProcessRunLocker &&other) {
+      if (this != &other) {
+        Unlock();
+        m_lock = other.m_lock;
+        other.m_lock = nullptr;
+      }
+      return *this;
+    }
 
     ~ProcessRunLocker() { Unlock(); }
 

--- a/lldb/include/lldb/Host/ProcessRunLock.h
+++ b/lldb/include/lldb/Host/ProcessRunLock.h
@@ -41,8 +41,13 @@ public:
   class ProcessRunLocker {
   public:
     ProcessRunLocker() = default;
+    ProcessRunLocker(ProcessRunLocker &&other) : m_lock(other.m_lock) {
+      other.m_lock = nullptr;
+    }
 
     ~ProcessRunLocker() { Unlock(); }
+
+    bool IsLocked() const { return m_lock; }
 
     // Try to lock the read lock, but only do so if there are no writers.
     bool TryLock(ProcessRunLock *lock) {

--- a/lldb/include/lldb/Target/ExecutionContext.h
+++ b/lldb/include/lldb/Target/ExecutionContext.h
@@ -594,7 +594,7 @@ struct StoppedExecutionContext : ExecutionContext {
   /// Clears this context, unlocking the ProcessRunLock and returning the
   /// locked API lock. Like after a move operation, this object is no longer
   /// usable.
-  [[nodiscard]] std::unique_lock<std::recursive_mutex> ClearAndGetAPILock();
+  [[nodiscard]] std::unique_lock<std::recursive_mutex> Destroy();
 
 private:
   std::unique_lock<std::recursive_mutex> m_api_lock;

--- a/lldb/include/lldb/Target/ExecutionContext.h
+++ b/lldb/include/lldb/Target/ExecutionContext.h
@@ -562,14 +562,14 @@ protected:
 /// A wrapper class representing an execution context with non-null Target
 /// and Process pointers, a locked API mutex and a locked ProcessRunLock.
 /// The locks are private by design: to unlock them, destroy the
-/// CompleteExecutionContext.
-struct CompleteExecutionContext : ExecutionContext {
-  CompleteExecutionContext(lldb::TargetSP &target_sp,
-                           lldb::ProcessSP &process_sp,
-                           lldb::ThreadSP &thread_sp,
-                           lldb::StackFrameSP &frame_sp,
-                           std::unique_lock<std::recursive_mutex> api_lock,
-                           ProcessRunLock::ProcessRunLocker stop_locker)
+/// StoppedExecutionContext.
+struct StoppedExecutionContext : ExecutionContext {
+  StoppedExecutionContext(lldb::TargetSP &target_sp,
+                          lldb::ProcessSP &process_sp,
+                          lldb::ThreadSP &thread_sp,
+                          lldb::StackFrameSP &frame_sp,
+                          std::unique_lock<std::recursive_mutex> api_lock,
+                          ProcessRunLock::ProcessRunLocker stop_locker)
       : m_api_lock(std::move(api_lock)), m_stop_locker(std::move(stop_locker)) {
     assert(target_sp);
     assert(process_sp);
@@ -583,11 +583,11 @@ struct CompleteExecutionContext : ExecutionContext {
 
   /// Transfers ownership of the locks from `other` to `this`, making `other`
   /// unusable.
-  CompleteExecutionContext(CompleteExecutionContext &&other)
-      : CompleteExecutionContext(other.m_target_sp, other.m_process_sp,
-                                 other.m_thread_sp, other.m_frame_sp,
-                                 std::move(other.m_api_lock),
-                                 std::move(other.m_stop_locker)) {
+  StoppedExecutionContext(StoppedExecutionContext &&other)
+      : StoppedExecutionContext(other.m_target_sp, other.m_process_sp,
+                                other.m_thread_sp, other.m_frame_sp,
+                                std::move(other.m_api_lock),
+                                std::move(other.m_stop_locker)) {
     other.Clear();
   }
 
@@ -601,10 +601,10 @@ private:
   ProcessRunLock::ProcessRunLocker m_stop_locker;
 };
 
-llvm::Expected<CompleteExecutionContext>
-GetCompleteExecutionContext(const ExecutionContextRef *exe_ctx_ref_ptr);
-llvm::Expected<CompleteExecutionContext>
-GetCompleteExecutionContext(const lldb::ExecutionContextRefSP &exe_ctx_ref_ptr);
+llvm::Expected<StoppedExecutionContext>
+GetStoppedExecutionContext(const ExecutionContextRef *exe_ctx_ref_ptr);
+llvm::Expected<StoppedExecutionContext>
+GetStoppedExecutionContext(const lldb::ExecutionContextRefSP &exe_ctx_ref_ptr);
 
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Target/ExecutionContext.h
+++ b/lldb/include/lldb/Target/ExecutionContext.h
@@ -11,6 +11,7 @@
 
 #include <mutex>
 
+#include "lldb/Host/ProcessRunLock.h"
 #include "lldb/Target/StackID.h"
 #include "lldb/lldb-private.h"
 
@@ -318,11 +319,13 @@ public:
   // These two variants take in a locker, and grab the target, lock the API
   // mutex into locker, then fill in the rest of the shared pointers.
   ExecutionContext(const ExecutionContextRef &exe_ctx_ref,
-                   std::unique_lock<std::recursive_mutex> &locker)
-      : ExecutionContext(&exe_ctx_ref, locker) {}
+                   std::unique_lock<std::recursive_mutex> &locker,
+                   ProcessRunLock::ProcessRunLocker &stop_locker)
+      : ExecutionContext(&exe_ctx_ref, locker, stop_locker) {}
 
   ExecutionContext(const ExecutionContextRef *exe_ctx_ref,
-                   std::unique_lock<std::recursive_mutex> &locker);
+                   std::unique_lock<std::recursive_mutex> &locker,
+                   ProcessRunLock::ProcessRunLocker &stop_locker);
   // Create execution contexts from execution context scopes
   ExecutionContext(ExecutionContextScope *exe_scope);
   ExecutionContext(ExecutionContextScope &exe_scope);

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -100,7 +100,7 @@ SBFrame::operator bool() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -115,7 +115,7 @@ SBSymbolContext SBFrame::GetSymbolContext(uint32_t resolve_scope) const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return sb_sym_ctx;
   }
 
@@ -132,7 +132,7 @@ SBModule SBFrame::GetModule() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBModule();
   }
 
@@ -153,7 +153,7 @@ SBCompileUnit SBFrame::GetCompileUnit() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBCompileUnit();
   }
 
@@ -169,7 +169,7 @@ SBFunction SBFrame::GetFunction() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBFunction();
   }
 
@@ -184,7 +184,7 @@ SBSymbol SBFrame::GetSymbol() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBSymbol();
   }
 
@@ -199,7 +199,7 @@ SBBlock SBFrame::GetBlock() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBBlock();
   }
 
@@ -214,7 +214,7 @@ SBBlock SBFrame::GetFrameBlock() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBBlock();
   }
 
@@ -229,7 +229,7 @@ SBLineEntry SBFrame::GetLineEntry() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBLineEntry();
   }
 
@@ -247,7 +247,7 @@ uint32_t SBFrame::GetFrameID() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return error_frame_idx;
   }
 
@@ -262,7 +262,7 @@ lldb::addr_t SBFrame::GetCFA() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -278,7 +278,7 @@ addr_t SBFrame::GetPC() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return addr;
   }
 
@@ -297,7 +297,7 @@ bool SBFrame::SetPC(addr_t new_pc) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return error_ret_val;
   }
 
@@ -314,7 +314,7 @@ addr_t SBFrame::GetSP() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -331,7 +331,7 @@ addr_t SBFrame::GetFP() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return LLDB_INVALID_ADDRESS;
   }
 
@@ -348,7 +348,7 @@ SBAddress SBFrame::GetPCAddress() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBAddress();
   }
 
@@ -370,7 +370,7 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return sb_value;
   }
 
@@ -394,7 +394,7 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return sb_value;
   }
 
@@ -417,7 +417,7 @@ SBValue SBFrame::FindVariable(const char *name) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBValue();
   }
 
@@ -443,7 +443,7 @@ SBValue SBFrame::FindVariable(const char *name,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return sb_value;
   }
 
@@ -461,7 +461,7 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return value;
   }
 
@@ -488,7 +488,7 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type,
       GetStoppedExecutionContext(m_opaque_sp);
 
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return value_sp;
   } else {
     Target *target = exe_ctx->GetTargetPtr();
@@ -614,7 +614,7 @@ SBThread SBFrame::GetThread() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBThread();
   }
 
@@ -630,7 +630,7 @@ const char *SBFrame::Disassemble() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return nullptr;
   }
 
@@ -648,7 +648,7 @@ SBValueList SBFrame::GetVariables(bool arguments, bool locals, bool statics,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return value_list;
   }
 
@@ -681,7 +681,7 @@ lldb::SBValueList SBFrame::GetVariables(bool arguments, bool locals,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBValueList();
   }
 
@@ -705,7 +705,7 @@ SBValueList SBFrame::GetVariables(const lldb::SBVariablesOptions &options) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBValueList();
   } else {
     const bool statics = options.GetIncludeStatics();
@@ -812,7 +812,7 @@ SBValueList SBFrame::GetRegisters() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBValueList();
   } else {
     Target *target = exe_ctx->GetTargetPtr();
@@ -842,7 +842,7 @@ SBValue SBFrame::FindRegister(const char *name) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBValue();
   } else {
     Target *target = exe_ctx->GetTargetPtr();
@@ -898,7 +898,7 @@ bool SBFrame::GetDescription(SBStream &description) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     strm.PutCString("Error: process is not stopped.");
     return true;
   }
@@ -915,7 +915,7 @@ SBValue SBFrame::EvaluateExpression(const char *expr) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return CreateProcessIsRunningExprEvalError();
   }
 
@@ -948,7 +948,7 @@ SBFrame::EvaluateExpression(const char *expr,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return CreateProcessIsRunningExprEvalError();
   }
 
@@ -970,7 +970,7 @@ SBValue SBFrame::EvaluateExpression(const char *expr,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return CreateProcessIsRunningExprEvalError();
   }
 
@@ -1013,7 +1013,7 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     expr_result = CreateProcessIsRunningExprEvalError();
   } else {
     Target *target = exe_ctx->GetTargetPtr();
@@ -1063,7 +1063,7 @@ SBStructuredData SBFrame::GetLanguageSpecificData() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return sb_data;
   }
   StackFrame *frame = exe_ctx->GetFramePtr();
@@ -1087,7 +1087,7 @@ bool SBFrame::IsInlined() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1108,7 +1108,7 @@ bool SBFrame::IsArtificial() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1124,7 +1124,7 @@ bool SBFrame::IsHidden() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1146,7 +1146,7 @@ lldb::LanguageType SBFrame::GuessLanguage() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return eLanguageTypeUnknown;
   }
 
@@ -1161,7 +1161,7 @@ const char *SBFrame::GetFunctionName() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return nullptr;
   }
 
@@ -1176,7 +1176,7 @@ const char *SBFrame::GetDisplayFunctionName() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return nullptr;
   }
 

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -97,41 +97,31 @@ bool SBFrame::IsValid() const {
 }
 SBFrame::operator bool() const {
   LLDB_INSTRUMENT_VA(this);
-  if (!m_opaque_sp)
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return false;
-
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return false;
-
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    return GetFrameSP().get() != nullptr;
   }
 
-  // Without a target & process we can't have a valid stack frame.
-  return false;
+  return GetFrameSP().get() != nullptr;
 }
 
 SBSymbolContext SBFrame::GetSymbolContext(uint32_t resolve_scope) const {
   LLDB_INSTRUMENT_VA(this, resolve_scope);
 
   SBSymbolContext sb_sym_ctx;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return sb_sym_ctx;
-  SymbolContextItem scope = static_cast<SymbolContextItem>(resolve_scope);
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    if (StackFrame *frame = exe_ctx.GetFramePtr())
-      sb_sym_ctx = frame->GetSymbolContext(scope);
   }
+
+  SymbolContextItem scope = static_cast<SymbolContextItem>(resolve_scope);
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    sb_sym_ctx = frame->GetSymbolContext(scope);
 
   return sb_sym_ctx;
 }
@@ -139,193 +129,144 @@ SBSymbolContext SBFrame::GetSymbolContext(uint32_t resolve_scope) const {
 SBModule SBFrame::GetModule() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBModule sb_module;
-  ModuleSP module_sp;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_module;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      module_sp = frame->GetSymbolContext(eSymbolContextModule).module_sp;
-      sb_module.SetSP(module_sp);
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBModule();
   }
 
+  ModuleSP module_sp;
+  StackFrame *frame = exe_ctx->GetFramePtr();
+  if (!frame)
+    return SBModule();
+
+  SBModule sb_module;
+  module_sp = frame->GetSymbolContext(eSymbolContextModule).module_sp;
+  sb_module.SetSP(module_sp);
   return sb_module;
 }
 
 SBCompileUnit SBFrame::GetCompileUnit() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBCompileUnit sb_comp_unit;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_comp_unit;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      sb_comp_unit.reset(
-          frame->GetSymbolContext(eSymbolContextCompUnit).comp_unit);
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBCompileUnit();
   }
 
-  return sb_comp_unit;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBCompileUnit(
+        frame->GetSymbolContext(eSymbolContextCompUnit).comp_unit);
+  return SBCompileUnit();
 }
 
 SBFunction SBFrame::GetFunction() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBFunction sb_function;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_function;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      sb_function.reset(
-          frame->GetSymbolContext(eSymbolContextFunction).function);
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBFunction();
   }
 
-  return sb_function;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBFunction(frame->GetSymbolContext(eSymbolContextFunction).function);
+  return SBFunction();
 }
 
 SBSymbol SBFrame::GetSymbol() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBSymbol sb_symbol;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_symbol;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      sb_symbol.reset(frame->GetSymbolContext(eSymbolContextSymbol).symbol);
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBSymbol();
   }
 
-  return sb_symbol;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBSymbol(frame->GetSymbolContext(eSymbolContextSymbol).symbol);
+  return SBSymbol();
 }
 
 SBBlock SBFrame::GetBlock() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBBlock sb_block;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_block;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame)
-      sb_block.SetPtr(frame->GetSymbolContext(eSymbolContextBlock).block);
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBBlock();
   }
-  return sb_block;
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBBlock(frame->GetSymbolContext(eSymbolContextBlock).block);
+  return SBBlock();
 }
 
 SBBlock SBFrame::GetFrameBlock() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBBlock sb_block;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_block;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame)
-      sb_block.SetPtr(frame->GetFrameBlock());
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBBlock();
   }
-  return sb_block;
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBBlock(frame->GetFrameBlock());
+  return SBBlock();
 }
 
 SBLineEntry SBFrame::GetLineEntry() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBLineEntry sb_line_entry;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_line_entry;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      sb_line_entry.SetLineEntry(
-          frame->GetSymbolContext(eSymbolContextLineEntry).line_entry);
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBLineEntry();
   }
-  return sb_line_entry;
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBLineEntry(
+        &frame->GetSymbolContext(eSymbolContextLineEntry).line_entry);
+  return SBLineEntry();
 }
 
 uint32_t SBFrame::GetFrameID() const {
   LLDB_INSTRUMENT_VA(this);
 
-  uint32_t frame_idx = UINT32_MAX;
+  constexpr uint32_t error_frame_idx = UINT32_MAX;
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return frame_idx;
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return error_frame_idx;
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  if (frame)
-    frame_idx = frame->GetFrameIndex();
-
-  return frame_idx;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return frame->GetFrameIndex();
+  return error_frame_idx;
 }
 
 lldb::addr_t SBFrame::GetCFA() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return LLDB_INVALID_ADDRESS;
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  if (frame)
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
     return frame->GetStackID().GetCallFrameAddress();
   return LLDB_INVALID_ADDRESS;
 }
@@ -334,22 +275,17 @@ addr_t SBFrame::GetPC() const {
   LLDB_INSTRUMENT_VA(this);
 
   addr_t addr = LLDB_INVALID_ADDRESS;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return addr;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      addr = frame->GetFrameCodeAddress().GetOpcodeLoadAddress(
-          target, AddressClass::eCode);
-    }
   }
+
+  Target *target = exe_ctx->GetTargetPtr();
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return frame->GetFrameCodeAddress().GetOpcodeLoadAddress(
+        target, AddressClass::eCode);
 
   return addr;
 }
@@ -357,91 +293,68 @@ addr_t SBFrame::GetPC() const {
 bool SBFrame::SetPC(addr_t new_pc) {
   LLDB_INSTRUMENT_VA(this, new_pc);
 
-  bool ret_val = false;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return ret_val;
-
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    if (StackFrame *frame = exe_ctx.GetFramePtr()) {
-      if (RegisterContextSP reg_ctx_sp = frame->GetRegisterContext()) {
-        ret_val = reg_ctx_sp->SetPC(new_pc);
-      }
-    }
+  constexpr bool error_ret_val = false;
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return error_ret_val;
   }
 
-  return ret_val;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    if (RegisterContextSP reg_ctx_sp = frame->GetRegisterContext())
+      return reg_ctx_sp->SetPC(new_pc);
+
+  return error_ret_val;
 }
 
 addr_t SBFrame::GetSP() const {
   LLDB_INSTRUMENT_VA(this);
 
-  addr_t addr = LLDB_INVALID_ADDRESS;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return addr;
-
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    if (StackFrame *frame = exe_ctx.GetFramePtr()) {
-      if (RegisterContextSP reg_ctx_sp = frame->GetRegisterContext()) {
-        addr = reg_ctx_sp->GetSP();
-      }
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return LLDB_INVALID_ADDRESS;
   }
 
-  return addr;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    if (RegisterContextSP reg_ctx_sp = frame->GetRegisterContext())
+      return reg_ctx_sp->GetSP();
+
+  return LLDB_INVALID_ADDRESS;
 }
 
 addr_t SBFrame::GetFP() const {
   LLDB_INSTRUMENT_VA(this);
 
-  addr_t addr = LLDB_INVALID_ADDRESS;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return addr;
-
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    if (StackFrame *frame = exe_ctx.GetFramePtr()) {
-      if (RegisterContextSP reg_ctx_sp = frame->GetRegisterContext()) {
-        addr = reg_ctx_sp->GetFP();
-      }
-    }
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return LLDB_INVALID_ADDRESS;
   }
 
-  return addr;
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    if (RegisterContextSP reg_ctx_sp = frame->GetRegisterContext())
+      return reg_ctx_sp->GetFP();
+
+  return LLDB_INVALID_ADDRESS;
 }
 
 SBAddress SBFrame::GetPCAddress() const {
   LLDB_INSTRUMENT_VA(this);
 
-  SBAddress sb_addr;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return sb_addr;
-
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame)
-      sb_addr.SetAddress(frame->GetFrameCodeAddress());
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBAddress();
   }
-  return sb_addr;
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return SBAddress(frame->GetFrameCodeAddress());
+  return SBAddress();
 }
 
 void SBFrame::Clear() {
@@ -454,15 +367,14 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path) {
   LLDB_INSTRUMENT_VA(this, var_path);
 
   SBValue sb_value;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return sb_value;
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  if (frame && target) {
+  if (StackFrame *frame = exe_ctx->GetFramePtr()) {
     lldb::DynamicValueType use_dynamic =
         frame->CalculateTarget()->GetPreferDynamicValue();
     sb_value = GetValueForVariablePath(var_path, use_dynamic);
@@ -479,27 +391,22 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path,
     return sb_value;
   }
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return sb_value;
+  }
 
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      VariableSP var_sp;
-      Status error;
-      ValueObjectSP value_sp(frame->GetValueForVariableExpressionPath(
-          var_path, eNoDynamicValues,
-          StackFrame::eExpressionPathOptionCheckPtrVsMember |
-              StackFrame::eExpressionPathOptionsAllowDirectIVarAccess,
-          var_sp, error));
-      sb_value.SetSP(value_sp, use_dynamic);
-    }
+  if (StackFrame *frame = exe_ctx->GetFramePtr()) {
+    VariableSP var_sp;
+    Status error;
+    ValueObjectSP value_sp(frame->GetValueForVariableExpressionPath(
+        var_path, eNoDynamicValues,
+        StackFrame::eExpressionPathOptionCheckPtrVsMember |
+            StackFrame::eExpressionPathOptionsAllowDirectIVarAccess,
+        var_sp, error));
+    sb_value.SetSP(value_sp, use_dynamic);
   }
   return sb_value;
 }
@@ -507,21 +414,19 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path,
 SBValue SBFrame::FindVariable(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
-  SBValue value;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return value;
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBValue();
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  if (frame && target) {
+  if (StackFrame *frame = exe_ctx->GetFramePtr()) {
     lldb::DynamicValueType use_dynamic =
         frame->CalculateTarget()->GetPreferDynamicValue();
-    value = FindVariable(name, use_dynamic);
+    return FindVariable(name, use_dynamic);
   }
-  return value;
+  return SBValue();
 }
 
 SBValue SBFrame::FindVariable(const char *name,
@@ -535,25 +440,16 @@ SBValue SBFrame::FindVariable(const char *name,
     return sb_value;
   }
 
-  ValueObjectSP value_sp;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return sb_value;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      value_sp = frame->FindVariable(ConstString(name));
-
-      if (value_sp)
-        sb_value.SetSP(value_sp, use_dynamic);
-    }
   }
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    if (ValueObjectSP value_sp = frame->FindVariable(ConstString(name)))
+      sb_value.SetSP(value_sp, use_dynamic);
 
   return sb_value;
 }
@@ -562,15 +458,14 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type) {
   LLDB_INSTRUMENT_VA(this, name, value_type);
 
   SBValue value;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return value;
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  if (frame && target) {
+  if (StackFrame *frame = exe_ctx->GetFramePtr()) {
     lldb::DynamicValueType use_dynamic =
         frame->CalculateTarget()->GetPreferDynamicValue();
     value = FindValue(name, value_type, use_dynamic);
@@ -589,17 +484,17 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type,
   }
 
   ValueObjectSP value_sp;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
 
-  if (stop_locker.IsLocked()) {
-    StackFrame *frame = nullptr;
-    Target *target = exe_ctx.GetTargetPtr();
-    Process *process = exe_ctx.GetProcessPtr();
-    if (target && process) {
-      frame = exe_ctx.GetFramePtr();
-      if (frame) {
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return value_sp;
+  } else {
+    Target *target = exe_ctx->GetTargetPtr();
+    Process *process = exe_ctx->GetProcessPtr();
+    if (target && process) { // FIXME: this check is redundant.
+      if (StackFrame *frame = exe_ctx->GetFramePtr()) {
         VariableList variable_list;
 
         switch (value_type) {
@@ -716,13 +611,14 @@ bool SBFrame::operator!=(const SBFrame &rhs) const {
 SBThread SBFrame::GetThread() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return SBThread();
+  }
 
-  ThreadSP thread_sp(exe_ctx.GetThreadSP());
+  ThreadSP thread_sp(exe_ctx->GetThreadSP());
   SBThread sb_thread(thread_sp);
 
   return sb_thread;
@@ -731,17 +627,14 @@ SBThread SBFrame::GetThread() const {
 const char *SBFrame::Disassemble() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (!target || !process)
-    return nullptr;
+  }
 
-  if (auto *frame = exe_ctx.GetFramePtr())
+  if (auto *frame = exe_ctx->GetFramePtr())
     return ConstString(frame->Disassemble()).GetCString();
 
   return nullptr;
@@ -752,15 +645,15 @@ SBValueList SBFrame::GetVariables(bool arguments, bool locals, bool statics,
   LLDB_INSTRUMENT_VA(this, arguments, locals, statics, in_scope_only);
 
   SBValueList value_list;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return value_list;
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  if (frame && target) {
+  if (StackFrame *frame = exe_ctx->GetFramePtr()) {
+    Target *target = exe_ctx->GetTargetPtr();
     lldb::DynamicValueType use_dynamic =
         frame->CalculateTarget()->GetPreferDynamicValue();
     const bool include_runtime_support_values =
@@ -785,17 +678,16 @@ lldb::SBValueList SBFrame::GetVariables(bool arguments, bool locals,
   LLDB_INSTRUMENT_VA(this, arguments, locals, statics, in_scope_only,
                      use_dynamic);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked()) {
-    SBValueList empty_list;
-    return empty_list;
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBValueList();
   }
 
-  Target *target = exe_ctx.GetTargetPtr();
+  Target *target = exe_ctx->GetTargetPtr();
   const bool include_runtime_support_values =
-      target ? target->GetDisplayRuntimeSupportValues() : false;
+      target->GetDisplayRuntimeSupportValues();
   SBVariablesOptions options;
   options.SetIncludeArguments(arguments);
   options.SetIncludeLocals(locals);
@@ -810,18 +702,16 @@ SBValueList SBFrame::GetVariables(const lldb::SBVariablesOptions &options) {
   LLDB_INSTRUMENT_VA(this, options);
 
   SBValueList value_list;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (stop_locker.IsLocked()) {
-
-    StackFrame *frame = nullptr;
-    Target *target = exe_ctx.GetTargetPtr();
-
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBValueList();
+  } else {
     const bool statics = options.GetIncludeStatics();
     const bool arguments = options.GetIncludeArguments();
     const bool recognized_arguments =
-        options.GetIncludeRecognizedArguments(SBTarget(exe_ctx.GetTargetSP()));
+        options.GetIncludeRecognizedArguments(SBTarget(exe_ctx->GetTargetSP()));
     const bool locals = options.GetIncludeLocals();
     const bool in_scope_only = options.GetInScopeOnly();
     const bool include_runtime_support_values =
@@ -829,10 +719,9 @@ SBValueList SBFrame::GetVariables(const lldb::SBVariablesOptions &options) {
     const lldb::DynamicValueType use_dynamic = options.GetUseDynamic();
 
     std::set<VariableSP> variable_set;
-    Process *process = exe_ctx.GetProcessPtr();
-    if (target && process) {
-      frame = exe_ctx.GetFramePtr();
-      if (frame) {
+    Process *process = exe_ctx->GetProcessPtr();
+    if (process) { // FIXME: this check is redundant.
+      if (StackFrame *frame = exe_ctx->GetFramePtr()) {
         Debugger &dbg = process->GetTarget().GetDebugger();
         VariableList *variable_list = nullptr;
         Status var_error;
@@ -920,17 +809,16 @@ SBValueList SBFrame::GetRegisters() {
   LLDB_INSTRUMENT_VA(this);
 
   SBValueList value_list;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (stop_locker.IsLocked()) {
-
-    StackFrame *frame = nullptr;
-    Target *target = exe_ctx.GetTargetPtr();
-    Process *process = exe_ctx.GetProcessPtr();
-    if (target && process) {
-      frame = exe_ctx.GetFramePtr();
-      if (frame) {
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBValueList();
+  } else {
+    Target *target = exe_ctx->GetTargetPtr();
+    Process *process = exe_ctx->GetProcessPtr();
+    if (target && process) { // FIXME: this check is redundant.
+      if (StackFrame *frame = exe_ctx->GetFramePtr()) {
         RegisterContextSP reg_ctx(frame->GetRegisterContext());
         if (reg_ctx) {
           const uint32_t num_sets = reg_ctx->GetRegisterSetCount();
@@ -951,16 +839,16 @@ SBValue SBFrame::FindRegister(const char *name) {
 
   SBValue result;
   ValueObjectSP value_sp;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (stop_locker.IsLocked()) {
-    StackFrame *frame = nullptr;
-    Target *target = exe_ctx.GetTargetPtr();
-    Process *process = exe_ctx.GetProcessPtr();
-    if (target && process) {
-      frame = exe_ctx.GetFramePtr();
-      if (frame) {
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return SBValue();
+  } else {
+    Target *target = exe_ctx->GetTargetPtr();
+    Process *process = exe_ctx->GetProcessPtr();
+    if (target && process) { // FIXME: this check is redundant.
+      if (StackFrame *frame = exe_ctx->GetFramePtr()) {
         RegisterContextSP reg_ctx(frame->GetRegisterContext());
         if (reg_ctx) {
           if (const RegisterInfo *reg_info =
@@ -980,15 +868,11 @@ SBError SBFrame::GetDescriptionWithFormat(const SBFormat &format,
                                           SBStream &output) {
   Stream &strm = output.ref();
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return "Process is not stopped";
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx)
+    return Status::FromError(exe_ctx.takeError());
 
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
   SBError error;
 
   if (!format) {
@@ -996,13 +880,9 @@ SBError SBFrame::GetDescriptionWithFormat(const SBFormat &format,
     return error;
   }
 
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame &&
-        frame->DumpUsingFormat(strm, format.GetFormatEntrySP().get())) {
-      return error;
-    }
-  }
+  if (StackFrame *frame = exe_ctx->GetFramePtr();
+      frame && frame->DumpUsingFormat(strm, format.GetFormatEntrySP().get()))
+    return error;
   error.SetErrorStringWithFormat(
       "It was not possible to generate a frame "
       "description with the given format string '%s'",
@@ -1015,24 +895,16 @@ bool SBFrame::GetDescription(SBStream &description) {
 
   Stream &strm = description.ref();
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked()) {
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     strm.PutCString("Error: process is not stopped.");
     return true;
   }
 
-  StackFrame *frame;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      frame->DumpUsingSettingsFormat(&strm);
-    }
-  } else
-    strm.PutCString("No value");
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    frame->DumpUsingSettingsFormat(&strm);
 
   return true;
 }
@@ -1040,25 +912,24 @@ bool SBFrame::GetDescription(SBStream &description) {
 SBValue SBFrame::EvaluateExpression(const char *expr) {
   LLDB_INSTRUMENT_VA(this, expr);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return CreateProcessIsRunningExprEvalError();
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
   SBExpressionOptions options;
-  if (frame && target) {
+  StackFrame *frame = exe_ctx->GetFramePtr();
+  if (frame) {
     lldb::DynamicValueType fetch_dynamic_value =
         frame->CalculateTarget()->GetPreferDynamicValue();
     options.SetFetchDynamicValue(fetch_dynamic_value);
   }
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
-  SourceLanguage language;
-  if (target)
-    language = target->GetLanguage();
+  Target *target = exe_ctx->GetTargetPtr();
+  SourceLanguage language = target->GetLanguage();
   if (!language && frame)
     language = frame->GetLanguage();
   options.SetLanguage((SBSourceLanguageName)language.name, language.version);
@@ -1074,17 +945,16 @@ SBFrame::EvaluateExpression(const char *expr,
   options.SetFetchDynamicValue(fetch_dynamic_value);
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return CreateProcessIsRunningExprEvalError();
+  }
 
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  SourceLanguage language;
-  if (target)
-    language = target->GetLanguage();
+  StackFrame *frame = exe_ctx->GetFramePtr();
+  Target *target = exe_ctx->GetTargetPtr();
+  SourceLanguage language = target->GetLanguage();
   if (!language && frame)
     language = frame->GetLanguage();
   options.SetLanguage((SBSourceLanguageName)language.name, language.version);
@@ -1097,20 +967,19 @@ SBValue SBFrame::EvaluateExpression(const char *expr,
   LLDB_INSTRUMENT_VA(this, expr, fetch_dynamic_value, unwind_on_error);
 
   SBExpressionOptions options;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return CreateProcessIsRunningExprEvalError();
+  }
 
   options.SetFetchDynamicValue(fetch_dynamic_value);
   options.SetUnwindOnError(unwind_on_error);
   options.SetIgnoreBreakpoints(true);
-  StackFrame *frame = exe_ctx.GetFramePtr();
-  Target *target = exe_ctx.GetTargetPtr();
-  SourceLanguage language;
-  if (target)
-    language = target->GetLanguage();
+  StackFrame *frame = exe_ctx->GetFramePtr();
+  Target *target = exe_ctx->GetTargetPtr();
+  SourceLanguage language = target->GetLanguage();
   if (!language && frame)
     language = frame->GetLanguage();
   options.SetLanguage((SBSourceLanguageName)language.name, language.version);
@@ -1141,18 +1010,16 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
 
   ValueObjectSP expr_value_sp;
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (stop_locker.IsLocked()) {
-
-    StackFrame *frame = nullptr;
-    Target *target = exe_ctx.GetTargetPtr();
-    Process *process = exe_ctx.GetProcessPtr();
-
-    if (target && process) {
-      frame = exe_ctx.GetFramePtr();
-      if (frame) {
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    expr_result = CreateProcessIsRunningExprEvalError();
+  } else {
+    Target *target = exe_ctx->GetTargetPtr();
+    Process *process = exe_ctx->GetProcessPtr();
+    if (target && process) { // FIXME: this check is redundant.
+      if (StackFrame *frame = exe_ctx->GetFramePtr()) {
         std::unique_ptr<llvm::PrettyStackTraceFormat> stack_trace;
         if (target->GetDisplayExpressionsInCrashlogs()) {
           StreamString frame_description;
@@ -1173,8 +1040,7 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
       expr_value_sp = ValueObjectConstResult::Create(nullptr, std::move(error));
       expr_result.SetSP(expr_value_sp, false);
     }
-  } else
-    expr_result = CreateProcessIsRunningExprEvalError();
+  }
 
   if (expr_result.GetError().Success())
     LLDB_LOGF(expr_log,
@@ -1194,12 +1060,13 @@ SBStructuredData SBFrame::GetLanguageSpecificData() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBStructuredData sb_data;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return sb_data;
-  StackFrame *frame = exe_ctx.GetFramePtr();
+  }
+  StackFrame *frame = exe_ctx->GetFramePtr();
   if (!frame)
     return sb_data;
 
@@ -1217,20 +1084,15 @@ bool SBFrame::IsInlined() {
 bool SBFrame::IsInlined() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return false;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame)
-      return frame->IsInlined();
   }
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return frame->IsInlined();
   return false;
 }
 
@@ -1243,13 +1105,14 @@ bool SBFrame::IsArtificial() {
 bool SBFrame::IsArtificial() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return false;
+  }
 
-  if (StackFrame *frame = exe_ctx.GetFramePtr())
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
     return frame->IsArtificial();
 
   return false;
@@ -1258,13 +1121,14 @@ bool SBFrame::IsArtificial() const {
 bool SBFrame::IsHidden() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return false;
+  }
 
-  if (StackFrame *frame = exe_ctx.GetFramePtr())
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
     return frame->IsHidden();
 
   return false;
@@ -1279,63 +1143,44 @@ const char *SBFrame::GetFunctionName() {
 lldb::LanguageType SBFrame::GuessLanguage() const {
   LLDB_INSTRUMENT_VA(this);
 
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
     return eLanguageTypeUnknown;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame) {
-      return frame->GuessLanguage().AsLanguageType();
-    }
   }
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return frame->GuessLanguage().AsLanguageType();
   return eLanguageTypeUnknown;
 }
 
 const char *SBFrame::GetFunctionName() const {
   LLDB_INSTRUMENT_VA(this);
 
-  const char *name = nullptr;
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return name;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame)
-      return frame->GetFunctionName();
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return nullptr;
   }
-  return name;
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return frame->GetFunctionName();
+  return nullptr;
 }
 
 const char *SBFrame::GetDisplayFunctionName() {
   LLDB_INSTRUMENT_VA(this);
 
-  const char *name = nullptr;
-
-  std::unique_lock<std::recursive_mutex> lock;
-  Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
-  if (!stop_locker.IsLocked())
-    return name;
-
-  StackFrame *frame = nullptr;
-  Target *target = exe_ctx.GetTargetPtr();
-  Process *process = exe_ctx.GetProcessPtr();
-  if (target && process) {
-    frame = exe_ctx.GetFramePtr();
-    if (frame)
-      return frame->GetDisplayFunctionName();
+  llvm::Expected<CompleteExecutionContext> exe_ctx =
+      GetCompleteExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    llvm::consumeError(exe_ctx.takeError());
+    return nullptr;
   }
-  return name;
+
+  if (StackFrame *frame = exe_ctx->GetFramePtr())
+    return frame->GetDisplayFunctionName();
+  return nullptr;
 }

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -97,8 +97,8 @@ bool SBFrame::IsValid() const {
 }
 SBFrame::operator bool() const {
   LLDB_INSTRUMENT_VA(this);
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -112,8 +112,8 @@ SBSymbolContext SBFrame::GetSymbolContext(uint32_t resolve_scope) const {
 
   SBSymbolContext sb_sym_ctx;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return sb_sym_ctx;
@@ -129,8 +129,8 @@ SBSymbolContext SBFrame::GetSymbolContext(uint32_t resolve_scope) const {
 SBModule SBFrame::GetModule() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBModule();
@@ -150,8 +150,8 @@ SBModule SBFrame::GetModule() const {
 SBCompileUnit SBFrame::GetCompileUnit() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBCompileUnit();
@@ -166,8 +166,8 @@ SBCompileUnit SBFrame::GetCompileUnit() const {
 SBFunction SBFrame::GetFunction() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBFunction();
@@ -181,8 +181,8 @@ SBFunction SBFrame::GetFunction() const {
 SBSymbol SBFrame::GetSymbol() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBSymbol();
@@ -196,8 +196,8 @@ SBSymbol SBFrame::GetSymbol() const {
 SBBlock SBFrame::GetBlock() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBBlock();
@@ -211,8 +211,8 @@ SBBlock SBFrame::GetBlock() const {
 SBBlock SBFrame::GetFrameBlock() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBBlock();
@@ -226,8 +226,8 @@ SBBlock SBFrame::GetFrameBlock() const {
 SBLineEntry SBFrame::GetLineEntry() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBLineEntry();
@@ -244,8 +244,8 @@ uint32_t SBFrame::GetFrameID() const {
 
   constexpr uint32_t error_frame_idx = UINT32_MAX;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return error_frame_idx;
@@ -259,8 +259,8 @@ uint32_t SBFrame::GetFrameID() const {
 lldb::addr_t SBFrame::GetCFA() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return LLDB_INVALID_ADDRESS;
@@ -275,8 +275,8 @@ addr_t SBFrame::GetPC() const {
   LLDB_INSTRUMENT_VA(this);
 
   addr_t addr = LLDB_INVALID_ADDRESS;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return addr;
@@ -294,8 +294,8 @@ bool SBFrame::SetPC(addr_t new_pc) {
   LLDB_INSTRUMENT_VA(this, new_pc);
 
   constexpr bool error_ret_val = false;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return error_ret_val;
@@ -311,8 +311,8 @@ bool SBFrame::SetPC(addr_t new_pc) {
 addr_t SBFrame::GetSP() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return LLDB_INVALID_ADDRESS;
@@ -328,8 +328,8 @@ addr_t SBFrame::GetSP() const {
 addr_t SBFrame::GetFP() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return LLDB_INVALID_ADDRESS;
@@ -345,8 +345,8 @@ addr_t SBFrame::GetFP() const {
 SBAddress SBFrame::GetPCAddress() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBAddress();
@@ -367,8 +367,8 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path) {
   LLDB_INSTRUMENT_VA(this, var_path);
 
   SBValue sb_value;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return sb_value;
@@ -391,8 +391,8 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path,
     return sb_value;
   }
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return sb_value;
@@ -414,8 +414,8 @@ lldb::SBValue SBFrame::GetValueForVariablePath(const char *var_path,
 SBValue SBFrame::FindVariable(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBValue();
@@ -440,8 +440,8 @@ SBValue SBFrame::FindVariable(const char *name,
     return sb_value;
   }
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return sb_value;
@@ -458,8 +458,8 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type) {
   LLDB_INSTRUMENT_VA(this, name, value_type);
 
   SBValue value;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return value;
@@ -484,8 +484,8 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type,
   }
 
   ValueObjectSP value_sp;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
 
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
@@ -611,8 +611,8 @@ bool SBFrame::operator!=(const SBFrame &rhs) const {
 SBThread SBFrame::GetThread() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBThread();
@@ -627,8 +627,8 @@ SBThread SBFrame::GetThread() const {
 const char *SBFrame::Disassemble() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return nullptr;
@@ -645,8 +645,8 @@ SBValueList SBFrame::GetVariables(bool arguments, bool locals, bool statics,
   LLDB_INSTRUMENT_VA(this, arguments, locals, statics, in_scope_only);
 
   SBValueList value_list;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return value_list;
@@ -678,8 +678,8 @@ lldb::SBValueList SBFrame::GetVariables(bool arguments, bool locals,
   LLDB_INSTRUMENT_VA(this, arguments, locals, statics, in_scope_only,
                      use_dynamic);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBValueList();
@@ -702,8 +702,8 @@ SBValueList SBFrame::GetVariables(const lldb::SBVariablesOptions &options) {
   LLDB_INSTRUMENT_VA(this, options);
 
   SBValueList value_list;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBValueList();
@@ -809,8 +809,8 @@ SBValueList SBFrame::GetRegisters() {
   LLDB_INSTRUMENT_VA(this);
 
   SBValueList value_list;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBValueList();
@@ -839,8 +839,8 @@ SBValue SBFrame::FindRegister(const char *name) {
 
   SBValue result;
   ValueObjectSP value_sp;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBValue();
@@ -868,8 +868,8 @@ SBError SBFrame::GetDescriptionWithFormat(const SBFormat &format,
                                           SBStream &output) {
   Stream &strm = output.ref();
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx)
     return Status::FromError(exe_ctx.takeError());
 
@@ -895,8 +895,8 @@ bool SBFrame::GetDescription(SBStream &description) {
 
   Stream &strm = description.ref();
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     strm.PutCString("Error: process is not stopped.");
@@ -912,8 +912,8 @@ bool SBFrame::GetDescription(SBStream &description) {
 SBValue SBFrame::EvaluateExpression(const char *expr) {
   LLDB_INSTRUMENT_VA(this, expr);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return CreateProcessIsRunningExprEvalError();
@@ -945,8 +945,8 @@ SBFrame::EvaluateExpression(const char *expr,
   options.SetFetchDynamicValue(fetch_dynamic_value);
   options.SetUnwindOnError(true);
   options.SetIgnoreBreakpoints(true);
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return CreateProcessIsRunningExprEvalError();
@@ -967,8 +967,8 @@ SBValue SBFrame::EvaluateExpression(const char *expr,
   LLDB_INSTRUMENT_VA(this, expr, fetch_dynamic_value, unwind_on_error);
 
   SBExpressionOptions options;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return CreateProcessIsRunningExprEvalError();
@@ -1010,8 +1010,8 @@ lldb::SBValue SBFrame::EvaluateExpression(const char *expr,
 
   ValueObjectSP expr_value_sp;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     expr_result = CreateProcessIsRunningExprEvalError();
@@ -1060,8 +1060,8 @@ SBStructuredData SBFrame::GetLanguageSpecificData() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBStructuredData sb_data;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return sb_data;
@@ -1084,8 +1084,8 @@ bool SBFrame::IsInlined() {
 bool SBFrame::IsInlined() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1105,8 +1105,8 @@ bool SBFrame::IsArtificial() {
 bool SBFrame::IsArtificial() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1121,8 +1121,8 @@ bool SBFrame::IsArtificial() const {
 bool SBFrame::IsHidden() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1143,8 +1143,8 @@ const char *SBFrame::GetFunctionName() {
 lldb::LanguageType SBFrame::GuessLanguage() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return eLanguageTypeUnknown;
@@ -1158,8 +1158,8 @@ lldb::LanguageType SBFrame::GuessLanguage() const {
 const char *SBFrame::GetFunctionName() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return nullptr;
@@ -1173,8 +1173,8 @@ const char *SBFrame::GetFunctionName() const {
 const char *SBFrame::GetDisplayFunctionName() {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return nullptr;

--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -97,6 +97,8 @@ bool SBFrame::IsValid() const {
 }
 SBFrame::operator bool() const {
   LLDB_INSTRUMENT_VA(this);
+  if (!m_opaque_sp)
+    return false;
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -93,7 +93,7 @@ lldb::SBQueue SBThread::GetQueue() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBQueue();
   }
 
@@ -119,7 +119,7 @@ SBThread::operator bool() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -139,7 +139,7 @@ StopReason SBThread::GetStopReason() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return reason;
   }
 
@@ -205,7 +205,7 @@ size_t SBThread::GetStopReasonDataCount() {
       }
     }
   } else {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return 0;
   }
   return 0;
@@ -279,7 +279,7 @@ uint64_t SBThread::GetStopReasonDataAtIndex(uint32_t idx) {
       }
     }
   } else {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return 0;
   }
   return 0;
@@ -293,7 +293,7 @@ bool SBThread::GetStopReasonExtendedInfoAsJSON(lldb::SBStream &stream) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -319,7 +319,7 @@ SBThread::GetStopReasonExtendedBacktraces(InstrumentationRuntimeType type) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBThreadCollection();
   }
 
@@ -347,7 +347,7 @@ size_t SBThread::GetStopDescription(char *dst, size_t dst_len) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return 0;
   }
 
@@ -373,7 +373,7 @@ SBValue SBThread::GetStopReturnValue() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBValue();
   }
 
@@ -415,7 +415,7 @@ const char *SBThread::GetName() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return nullptr;
   }
 
@@ -431,7 +431,7 @@ const char *SBThread::GetQueueName() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return nullptr;
   }
 
@@ -448,7 +448,7 @@ lldb::queue_id_t SBThread::GetQueueID() const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return id;
   }
 
@@ -500,7 +500,7 @@ bool SBThread::GetInfoItemByPathAsString(const char *path, SBStream &strm) {
       }
     }
   } else {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return success;
   }
 
@@ -1079,7 +1079,7 @@ bool SBThread::Resume(SBError &error) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     error = Status::FromErrorString("process is running");
     return false;
   }
@@ -1100,7 +1100,7 @@ bool SBThread::IsSuspended() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1115,7 +1115,7 @@ bool SBThread::IsStopped() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1131,7 +1131,7 @@ SBProcess SBThread::GetProcess() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBProcess();
   }
 
@@ -1150,7 +1150,7 @@ uint32_t SBThread::GetNumFrames() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return 0;
   }
 
@@ -1167,7 +1167,7 @@ SBFrame SBThread::GetFrameAtIndex(uint32_t idx) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBFrame();
   }
 
@@ -1186,7 +1186,7 @@ lldb::SBFrame SBThread::GetSelectedFrame() {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBFrame();
   }
 
@@ -1207,7 +1207,7 @@ lldb::SBFrame SBThread::SetSelectedFrame(uint32_t idx) {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return SBFrame();
   }
 
@@ -1263,7 +1263,7 @@ bool SBThread::GetStatus(SBStream &status) const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1290,7 +1290,7 @@ bool SBThread::GetDescription(SBStream &description, bool stop_format) const {
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return false;
   }
 
@@ -1316,7 +1316,7 @@ SBError SBThread::GetDescriptionWithFormat(const SBFormat &format,
   llvm::Expected<StoppedExecutionContext> exe_ctx =
       GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
     return error;
   }
 
@@ -1362,7 +1362,7 @@ SBThread SBThread::GetExtendedBacktraceThread(const char *type) {
       }
     }
   } else {
-    llvm::consumeError(exe_ctx.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
   }
 
   return sb_origin_thread;

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -525,8 +525,7 @@ static Status ResumeNewPlan(StoppedExecutionContext exe_ctx,
   process->GetThreadList().SetSelectedThreadByID(thread->GetID());
 
   // Release the run lock but keep the API lock.
-  std::unique_lock<std::recursive_mutex> api_lock =
-      exe_ctx.ClearAndGetAPILock();
+  std::unique_lock<std::recursive_mutex> api_lock = exe_ctx.Destroy();
   if (process->GetTarget().GetDebugger().GetAsyncExecution())
     return process->Resume();
   return process->ResumeSynchronous(nullptr);

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -90,8 +90,8 @@ lldb::SBQueue SBThread::GetQueue() const {
 
   SBQueue sb_queue;
   QueueSP queue_sp;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBQueue();
@@ -116,8 +116,8 @@ SBThread::operator bool() const {
   if (!m_opaque_sp)
     return false;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -136,8 +136,8 @@ StopReason SBThread::GetStopReason() {
   LLDB_INSTRUMENT_VA(this);
 
   StopReason reason = eStopReasonInvalid;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return reason;
@@ -152,8 +152,8 @@ StopReason SBThread::GetStopReason() {
 size_t SBThread::GetStopReasonDataCount() {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (exe_ctx) {
     if (exe_ctx->HasThreadScope()) {
       StopInfoSP stop_info_sp = exe_ctx->GetThreadPtr()->GetStopInfo();
@@ -214,8 +214,8 @@ size_t SBThread::GetStopReasonDataCount() {
 uint64_t SBThread::GetStopReasonDataAtIndex(uint32_t idx) {
   LLDB_INSTRUMENT_VA(this, idx);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (exe_ctx) {
     if (exe_ctx->HasThreadScope()) {
       Thread *thread = exe_ctx->GetThreadPtr();
@@ -290,8 +290,8 @@ bool SBThread::GetStopReasonExtendedInfoAsJSON(lldb::SBStream &stream) {
 
   Stream &strm = stream.ref();
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -316,8 +316,8 @@ SBThread::GetStopReasonExtendedBacktraces(InstrumentationRuntimeType type) {
 
   SBThreadCollection threads;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBThreadCollection();
@@ -344,8 +344,8 @@ size_t SBThread::GetStopDescription(char *dst, size_t dst_len) {
   if (dst)
     *dst = 0;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return 0;
@@ -370,8 +370,8 @@ SBValue SBThread::GetStopReturnValue() {
   LLDB_INSTRUMENT_VA(this);
 
   ValueObjectSP return_valobj_sp;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBValue();
@@ -412,8 +412,8 @@ uint32_t SBThread::GetIndexID() const {
 const char *SBThread::GetName() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return nullptr;
@@ -428,8 +428,8 @@ const char *SBThread::GetName() const {
 const char *SBThread::GetQueueName() const {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return nullptr;
@@ -445,8 +445,8 @@ lldb::queue_id_t SBThread::GetQueueID() const {
   LLDB_INSTRUMENT_VA(this);
 
   queue_id_t id = LLDB_INVALID_QUEUE_ID;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return id;
@@ -463,8 +463,8 @@ bool SBThread::GetInfoItemByPathAsString(const char *path, SBStream &strm) {
   LLDB_INSTRUMENT_VA(this, path, strm);
 
   bool success = false;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (exe_ctx) {
     if (exe_ctx->HasThreadScope()) {
       Thread *thread = exe_ctx->GetThreadPtr();
@@ -507,7 +507,7 @@ bool SBThread::GetInfoItemByPathAsString(const char *path, SBStream &strm) {
   return success;
 }
 
-static Status ResumeNewPlan(CompleteExecutionContext exe_ctx,
+static Status ResumeNewPlan(StoppedExecutionContext exe_ctx,
                             ThreadPlan *new_plan) {
   Thread *thread = exe_ctx.GetThreadPtr();
   if (!thread)
@@ -542,8 +542,8 @@ void SBThread::StepOver(lldb::RunMode stop_other_threads) {
 void SBThread::StepOver(lldb::RunMode stop_other_threads, SBError &error) {
   LLDB_INSTRUMENT_VA(this, stop_other_threads, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return;
@@ -593,8 +593,8 @@ void SBThread::StepInto(const char *target_name, uint32_t end_line,
                         SBError &error, lldb::RunMode stop_other_threads) {
   LLDB_INSTRUMENT_VA(this, target_name, end_line, error, stop_other_threads);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return;
@@ -654,8 +654,8 @@ void SBThread::StepOut() {
 void SBThread::StepOut(SBError &error) {
   LLDB_INSTRUMENT_VA(this, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return;
@@ -693,8 +693,8 @@ void SBThread::StepOutOfFrame(SBFrame &sb_frame) {
 void SBThread::StepOutOfFrame(SBFrame &sb_frame, SBError &error) {
   LLDB_INSTRUMENT_VA(this, sb_frame, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return;
@@ -741,8 +741,8 @@ void SBThread::StepInstruction(bool step_over) {
 void SBThread::StepInstruction(bool step_over, SBError &error) {
   LLDB_INSTRUMENT_VA(this, step_over, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return;
@@ -774,8 +774,8 @@ void SBThread::RunToAddress(lldb::addr_t addr) {
 void SBThread::RunToAddress(lldb::addr_t addr, SBError &error) {
   LLDB_INSTRUMENT_VA(this, addr, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return;
@@ -810,8 +810,8 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
   SBError sb_error;
   char path[PATH_MAX];
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx)
     return Status::FromError(exe_ctx.takeError());
 
@@ -946,8 +946,8 @@ SBError SBThread::StepUsingScriptedThreadPlan(const char *script_class_name,
 
   SBError error;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx)
     return Status::FromError(exe_ctx.takeError());
 
@@ -984,8 +984,8 @@ SBError SBThread::JumpToLine(lldb::SBFileSpec &file_spec, uint32_t line) {
 
   SBError sb_error;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx)
     return Status::FromError(exe_ctx.takeError());
 
@@ -1006,8 +1006,8 @@ SBError SBThread::ReturnFromFrame(SBFrame &frame, SBValue &return_value) {
 
   SBError sb_error;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx)
     return Status::FromError(exe_ctx.takeError());
 
@@ -1025,8 +1025,8 @@ SBError SBThread::UnwindInnermostExpression() {
 
   SBError sb_error;
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx)
     return Status::FromError(exe_ctx.takeError());
 
@@ -1050,8 +1050,8 @@ bool SBThread::Suspend() {
 bool SBThread::Suspend(SBError &error) {
   LLDB_INSTRUMENT_VA(this, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     error = Status::FromError(exe_ctx.takeError());
     return false;
@@ -1076,8 +1076,8 @@ bool SBThread::Resume() {
 bool SBThread::Resume(SBError &error) {
   LLDB_INSTRUMENT_VA(this, error);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     error = Status::FromErrorString("process is running");
@@ -1097,8 +1097,8 @@ bool SBThread::Resume(SBError &error) {
 bool SBThread::IsSuspended() {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1112,8 +1112,8 @@ bool SBThread::IsSuspended() {
 bool SBThread::IsStopped() {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1128,8 +1128,8 @@ SBProcess SBThread::GetProcess() {
   LLDB_INSTRUMENT_VA(this);
 
   SBProcess sb_process;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBProcess();
@@ -1147,8 +1147,8 @@ SBProcess SBThread::GetProcess() {
 uint32_t SBThread::GetNumFrames() {
   LLDB_INSTRUMENT_VA(this);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return 0;
@@ -1164,8 +1164,8 @@ SBFrame SBThread::GetFrameAtIndex(uint32_t idx) {
   LLDB_INSTRUMENT_VA(this, idx);
 
   SBFrame sb_frame;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBFrame();
@@ -1183,8 +1183,8 @@ lldb::SBFrame SBThread::GetSelectedFrame() {
   LLDB_INSTRUMENT_VA(this);
 
   SBFrame sb_frame;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBFrame();
@@ -1204,8 +1204,8 @@ lldb::SBFrame SBThread::SetSelectedFrame(uint32_t idx) {
 
   SBFrame sb_frame;
   StackFrameSP frame_sp;
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return SBFrame();
@@ -1260,8 +1260,8 @@ bool SBThread::GetStatus(SBStream &status) const {
 
   Stream &strm = status.ref();
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1287,8 +1287,8 @@ bool SBThread::GetDescription(SBStream &description, bool stop_format) const {
 
   Stream &strm = description.ref();
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return false;
@@ -1313,8 +1313,8 @@ SBError SBThread::GetDescriptionWithFormat(const SBFormat &format,
     return error;
   }
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   if (!exe_ctx) {
     llvm::consumeError(exe_ctx.takeError());
     return error;
@@ -1337,8 +1337,8 @@ SBError SBThread::GetDescriptionWithFormat(const SBFormat &format,
 SBThread SBThread::GetExtendedBacktraceThread(const char *type) {
   LLDB_INSTRUMENT_VA(this, type);
 
-  llvm::Expected<CompleteExecutionContext> exe_ctx =
-      GetCompleteExecutionContext(m_opaque_sp);
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
   SBThread sb_origin_thread;
   if (exe_ctx) {
     if (exe_ctx->HasThreadScope()) {

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -339,14 +339,14 @@ SBThread::GetStopReasonExtendedBacktraces(InstrumentationRuntimeType type) {
 size_t SBThread::GetStopDescription(char *dst, size_t dst_len) {
   LLDB_INSTRUMENT_VA(this, dst, dst_len);
 
+  if (dst)
+    *dst = 0;
+
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
   ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
   if (!stop_locker.IsLocked())
     return 0;
-
-  if (dst)
-    *dst = 0;
 
   if (!exe_ctx.HasThreadScope())
     return 0;

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -112,6 +112,8 @@ bool SBThread::IsValid() const {
 }
 SBThread::operator bool() const {
   LLDB_INSTRUMENT_VA(this);
+  if (!m_opaque_sp)
+    return false;
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
@@ -537,7 +539,7 @@ void SBThread::StepOver(lldb::RunMode stop_other_threads, SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return;
 
@@ -587,7 +589,7 @@ void SBThread::StepInto(const char *target_name, uint32_t end_line,
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return;
 
@@ -647,7 +649,7 @@ void SBThread::StepOut(SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return;
 
@@ -685,7 +687,7 @@ void SBThread::StepOutOfFrame(SBFrame &sb_frame, SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return;
 
@@ -732,7 +734,7 @@ void SBThread::StepInstruction(bool step_over, SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return;
 
@@ -764,7 +766,7 @@ void SBThread::RunToAddress(lldb::addr_t addr, SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return;
 
@@ -799,7 +801,8 @@ SBError SBThread::StepOverUntil(lldb::SBFrame &sb_frame,
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker,
+                           &sb_error.ref());
   if (!stop_locker.IsLocked())
     return sb_error;
 
@@ -937,7 +940,7 @@ SBError SBThread::StepUsingScriptedThreadPlan(const char *script_class_name,
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked())
     return error;
 
@@ -976,7 +979,8 @@ SBError SBThread::JumpToLine(lldb::SBFileSpec &file_spec, uint32_t line) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker,
+                           &sb_error.ref());
   if (!stop_locker.IsLocked())
     return sb_error;
 
@@ -999,7 +1003,8 @@ SBError SBThread::ReturnFromFrame(SBFrame &frame, SBValue &return_value) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker,
+                           &sb_error.ref());
   if (!stop_locker.IsLocked())
     return sb_error;
 
@@ -1019,7 +1024,8 @@ SBError SBThread::UnwindInnermostExpression() {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker,
+                           &sb_error.ref());
   if (!stop_locker.IsLocked())
     return sb_error;
 
@@ -1045,7 +1051,7 @@ bool SBThread::Suspend(SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked()) {
     error = Status::FromErrorString("process is running");
     return false;
@@ -1072,7 +1078,7 @@ bool SBThread::Resume(SBError &error) {
 
   std::unique_lock<std::recursive_mutex> lock;
   Process::StopLocker stop_locker;
-  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker);
+  ExecutionContext exe_ctx(m_opaque_sp.get(), lock, stop_locker, &error.ref());
   if (!stop_locker.IsLocked()) {
     error = Status::FromErrorString("process is running");
     return false;

--- a/lldb/source/Target/ExecutionContext.cpp
+++ b/lldb/source/Target/ExecutionContext.cpp
@@ -164,8 +164,7 @@ lldb_private::GetStoppedExecutionContext(
                                  std::move(api_lock), std::move(stop_locker));
 }
 
-std::unique_lock<std::recursive_mutex>
-StoppedExecutionContext::ClearAndGetAPILock() {
+std::unique_lock<std::recursive_mutex> StoppedExecutionContext::Destroy() {
   Clear();
   m_stop_locker = ProcessRunLock::ProcessRunLocker();
   return std::move(m_api_lock);

--- a/lldb/source/Target/ExecutionContext.cpp
+++ b/lldb/source/Target/ExecutionContext.cpp
@@ -127,14 +127,14 @@ ExecutionContext::ExecutionContext(const ExecutionContextRef *exe_ctx_ref_ptr,
   }
 }
 
-llvm::Expected<CompleteExecutionContext>
-lldb_private::GetCompleteExecutionContext(
+llvm::Expected<StoppedExecutionContext>
+lldb_private::GetStoppedExecutionContext(
     const lldb::ExecutionContextRefSP &exe_ctx_ref_ptr) {
-  return GetCompleteExecutionContext(exe_ctx_ref_ptr.get());
+  return GetStoppedExecutionContext(exe_ctx_ref_ptr.get());
 }
 
-llvm::Expected<CompleteExecutionContext>
-lldb_private::GetCompleteExecutionContext(
+llvm::Expected<StoppedExecutionContext>
+lldb_private::GetStoppedExecutionContext(
     const ExecutionContextRef *exe_ctx_ref_ptr) {
   if (!exe_ctx_ref_ptr)
     return llvm::createStringError(
@@ -163,12 +163,12 @@ lldb_private::GetCompleteExecutionContext(
 
   auto thread_sp = exe_ctx_ref_ptr->GetThreadSP();
   auto frame_sp = exe_ctx_ref_ptr->GetFrameSP();
-  return CompleteExecutionContext(target_sp, process_sp, thread_sp, frame_sp,
-                                  std::move(api_lock), std::move(stop_locker));
+  return StoppedExecutionContext(target_sp, process_sp, thread_sp, frame_sp,
+                                 std::move(api_lock), std::move(stop_locker));
 }
 
 std::unique_lock<std::recursive_mutex>
-CompleteExecutionContext::ClearAndGetAPILock() {
+StoppedExecutionContext::ClearAndGetAPILock() {
   Clear();
   m_stop_locker = ProcessRunLock::ProcessRunLocker();
   return std::move(m_api_lock);

--- a/lldb/source/Target/ExecutionContext.cpp
+++ b/lldb/source/Target/ExecutionContext.cpp
@@ -156,7 +156,7 @@ lldb_private::GetStoppedExecutionContext(
   ProcessRunLock::ProcessRunLocker stop_locker;
   if (!stop_locker.TryLock(&process_sp->GetRunLock()))
     return llvm::createStringError(
-        "Attempted to create an ExecutionContext with a running process");
+        "attempted to create an ExecutionContext with a running process");
 
   auto thread_sp = exe_ctx_ref_ptr->GetThreadSP();
   auto frame_sp = exe_ctx_ref_ptr->GetFrameSP();

--- a/lldb/source/Target/ExecutionContext.cpp
+++ b/lldb/source/Target/ExecutionContext.cpp
@@ -154,12 +154,9 @@ lldb_private::GetStoppedExecutionContext(
         "ExecutionContext created with a null process");
 
   ProcessRunLock::ProcessRunLocker stop_locker;
-  if (!stop_locker.TryLock(&process_sp->GetRunLock())) {
-    auto *error_msg =
-        "Attempted to create an ExecutionContext with a running process";
-    LLDB_LOG(GetLog(LLDBLog::API), error_msg);
-    return llvm::createStringError(error_msg);
-  }
+  if (!stop_locker.TryLock(&process_sp->GetRunLock()))
+    return llvm::createStringError(
+        "Attempted to create an ExecutionContext with a running process");
 
   auto thread_sp = exe_ctx_ref_ptr->GetThreadSP();
   auto frame_sp = exe_ctx_ref_ptr->GetFrameSP();

--- a/lldb/test/API/python_api/run_locker/TestRunLocker.py
+++ b/lldb/test/API/python_api/run_locker/TestRunLocker.py
@@ -107,4 +107,6 @@ class TestRunLocker(TestBase):
             "script var = lldb.frame.EvaluateExpression('SomethingToCall()'); var.GetError().GetCString()",
             result,
         )
-        self.assertIn("sbframe object is not valid", result.GetOutput())
+        self.assertIn(
+            "can't evaluate expressions when the process is running", result.GetOutput()
+        )


### PR DESCRIPTION
Prior to this patch, SBFrame/SBThread methods exhibit racy behavior if called while the process is running, because they do not lock the `Process::RetRunLock` mutex. If they did, they would fail, correctly identifying that the process is not running.

Some methods _attempt_ to protect against this with the pattern:

```
ExecutionContext exe_ctx(m_opaque_sp.get(), lock); // this is a different lock
Process *process = exe_ctx.GetProcessPtr();
if (process) {
  Process::StopLocker stop_locker;
  if (stop_locker.TryLock(&process->GetRunLock()))
        .... do work ...
```

However, this is also racy: the constructor of `ExecutionContext` will access the frame list, which is something that can only be done once the process is stopped.

With this patch:

1. The constructor of `ExecutionContext` now expects a `ProcessRunLock` as an argument. It attempts to lock the run lock, and only fills in information about frames and threads if the lock can be acquired. Callers of the constructor are expected to check the lock.
2. All uses of ExecutionContext are adjusted to conform to the above.
3. The SBThread.cpp-defined helper function ResumeNewPlan now expects a locked ProcessRunLock as _proof_ that the execution is stopped. It will unlock the mutex prior to resuming the process.

This commit exposes many opportunities for early-returns, but these would increase the diff of this patch and distract from the important changes, so we opt not to do it here.