### PR TITLE
[libc] Update clang to v22 in the fullbuild tests

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -21,37 +21,37 @@ jobs:
           - os: ubuntu-24.04
             build_type: Debug
             ccache-variant: sccache
-            c_compiler: clang-20
-            cpp_compiler: clang++-20
+            c_compiler: clang-22
+            cpp_compiler: clang++-22
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
             build_type: Release
             ccache-variant: sccache
-            c_compiler: clang-20
-            cpp_compiler: clang++-20
+            c_compiler: clang-22
+            cpp_compiler: clang++-22
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
             build_type: MinSizeRel
             ccache-variant: sccache
-            c_compiler: clang-20
-            cpp_compiler: clang++-20
+            c_compiler: clang-22
+            cpp_compiler: clang++-22
             target: x86_64-unknown-linux-llvm
             include_scudo: ON
           # TODO: remove ccache logic when https://github.com/hendrikmuhs/ccache-action/issues/279 is resolved.
           - os: ubuntu-24.04-arm
             build_type: Debug
             ccache-variant: ccache
-            c_compiler: clang-20
-            cpp_compiler: clang++-20
+            c_compiler: clang-22
+            cpp_compiler: clang++-22
             target: aarch64-unknown-linux-llvm
             include_scudo: ON
           - os: ubuntu-24.04
             build_type: Debug
             ccache-variant: ccache
-            c_compiler: clang-20
-            cpp_compiler: clang++-20
+            c_compiler: clang-22
+            cpp_compiler: clang++-22
             target: x86_64-unknown-uefi-llvm
             include_scudo: OFF
           # TODO: add back gcc build when it is fixed
@@ -81,7 +81,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 20
+        sudo ./llvm.sh 22
         sudo apt-get update
         sudo apt-get install -y libmpfr-dev libgmp-dev libmpc-dev ninja-build linux-libc-dev
         sudo ln -sf /usr/include/$(uname -p)-linux-gnu/asm /usr/include/asm


### PR DESCRIPTION
The apt repository has been updated so installing version 22 actually works now.

Fixes #151215.