### PR TITLE
[AMDGCNSPIRV][NFC] Match AMDGPU's `__builtin_va_list` type

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -438,6 +438,10 @@ public:
 
   ArrayRef<const char *> getGCCRegNames() const override;
 
+  BuiltinVaListKind getBuiltinVaListKind() const override {
+    return TargetInfo::CharPtrBuiltinVaList;
+  }
+
   bool initFeatureMap(llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags,
                       StringRef,
                       const std::vector<std::string> &) const override;

--- a/clang/test/Sema/amdgcn-va-list-type.c
+++ b/clang/test/Sema/amdgcn-va-list-type.c
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 %s -triple amdgcn-amd-amdhsa -fsyntax-only -verify
+// RUN: %clang_cc1 %s -triple spirv64-amd-amdhsa -fsyntax-only -verify
+
+// expected-no-diagnostics
+
+typedef char* va_list;
+
+void foo(const char* f, ...) {
+    int r;
+    va_list args;
+    __builtin_va_start(args, f);
+    __builtin_va_end(args);
+}


### PR DESCRIPTION
AMDGCN flavoured SPIRV should math AMDGPU TI as much as possible, and the va_list difference was spurious.