### PR TITLE
[libc][obvious] Removed mbstate_t include

### DIFF
--- a/libc/src/__support/wchar/mbrtowc.cpp
+++ b/libc/src/__support/wchar/mbrtowc.cpp
@@ -8,7 +8,6 @@
 
 #include "src/__support/wchar/mbrtowc.h"
 #include "hdr/errno_macros.h"
-#include "hdr/types/mbstate_t.h"
 #include "hdr/types/size_t.h"
 #include "hdr/types/wchar_t.h"
 #include "src/__support/common.h"


### PR DESCRIPTION
Internal function does not use the external mbstate_t but still had the include for it.