### PR TITLE
[libc][Github] Use lld to link libc CI jobs

### DIFF
--- a/.github/workflows/libc-fullbuild-tests.yml
+++ b/.github/workflows/libc-fullbuild-tests.yml
@@ -118,6 +118,7 @@ jobs:
         -DLLVM_RUNTIME_TARGETS=${{ matrix.target }} \
         -DLLVM_ENABLE_RUNTIMES="$RUNTIMES" \
         -DLLVM_LIBC_FULL_BUILD=ON \
+        -DLLVM_ENABLE_LLD=ON \
         -G Ninja \
         -S ${{ github.workspace }}/runtimes \
         $CMAKE_FLAGS

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -102,6 +102,7 @@ jobs:
         -DCMAKE_POLICY_DEFAULT_CMP0141=NEW
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
         -DLLVM_ENABLE_RUNTIMES=libc
+        -DLLVM_ENABLE_LLD=ON
         -G Ninja
         -S ${{ github.workspace }}/runtimes
 

--- a/.github/workflows/libc-overlay-tests.yml
+++ b/.github/workflows/libc-overlay-tests.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Prepare dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install ninja
+        brew install ninja lld
 
     - name: Set reusable strings
       id: strings


### PR DESCRIPTION
libc does a lot of linking during its builds for all of the unit tests. Using something than GNU ld for a theoretical speed increase.