### PR TITLE
[flang][NFC] Update flang/unittests to the new create APIs

### DIFF
--- a/flang/unittests/Optimizer/Builder/Runtime/AllocatableTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/AllocatableTest.cpp
@@ -17,9 +17,9 @@ TEST_F(RuntimeCallTest, genMoveAlloc) {
   mlir::Location loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value from = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value to = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value errMsg = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value from = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value to = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value errMsg = fir::UndefOp::create(*firBuilder, loc, seqTy);
   mlir::Value hasStat = firBuilder->createBool(loc, false);
   fir::runtime::genMoveAlloc(*firBuilder, loc, to, from, hasStat, errMsg);
   checkCallOpFromResultBox(to, "_FortranAMoveAlloc", 5);

--- a/flang/unittests/Optimizer/Builder/Runtime/AssignTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/AssignTest.cpp
@@ -14,8 +14,8 @@ TEST_F(RuntimeCallTest, genDerivedTypeAssign) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value dest = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value source = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value dest = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genAssign(*firBuilder, loc, dest, source);
   checkCallOpFromResultBox(dest, "_FortranAAssign", 2);
 }

--- a/flang/unittests/Optimizer/Builder/Runtime/CharacterTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/CharacterTest.cpp
@@ -15,16 +15,16 @@ using namespace mlir;
 
 TEST_F(RuntimeCallTest, genAdjustLTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value string = firBuilder->create<fir::UndefOp>(loc, boxTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value string = fir::UndefOp::create(*firBuilder, loc, boxTy);
   fir::runtime::genAdjustL(*firBuilder, loc, result, string);
   checkCallOpFromResultBox(result, "_FortranAAdjustl", 2);
 }
 
 TEST_F(RuntimeCallTest, genAdjustRTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value string = firBuilder->create<fir::UndefOp>(loc, boxTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value string = fir::UndefOp::create(*firBuilder, loc, boxTy);
   fir::runtime::genAdjustR(*firBuilder, loc, result, string);
   checkCallOpFromResultBox(result, "_FortranAAdjustr", 2);
 }
@@ -115,11 +115,11 @@ TEST_F(RuntimeCallTest, genIndexTest) {
 
 TEST_F(RuntimeCallTest, genIndexDescriptorTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value resultBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value stringBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value substringBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value backOpt = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value kind = firBuilder->create<fir::UndefOp>(loc, i32Ty);
+  mlir::Value resultBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value stringBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value substringBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value backOpt = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value kind = fir::UndefOp::create(*firBuilder, loc, i32Ty);
   fir::runtime::genIndexDescriptor(
       *firBuilder, loc, resultBox, stringBox, substringBox, backOpt, kind);
   checkCallOpFromResultBox(resultBox, "_FortranAIndex", 5);
@@ -127,28 +127,28 @@ TEST_F(RuntimeCallTest, genIndexDescriptorTest) {
 
 TEST_F(RuntimeCallTest, genRepeatTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value resultBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value stringBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value ncopies = firBuilder->create<fir::UndefOp>(loc, i32Ty);
+  mlir::Value resultBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value stringBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value ncopies = fir::UndefOp::create(*firBuilder, loc, i32Ty);
   fir::runtime::genRepeat(*firBuilder, loc, resultBox, stringBox, ncopies);
   checkCallOpFromResultBox(resultBox, "_FortranARepeat", 3);
 }
 
 TEST_F(RuntimeCallTest, genTrimTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value resultBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value stringBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
+  mlir::Value resultBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value stringBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
   fir::runtime::genTrim(*firBuilder, loc, resultBox, stringBox);
   checkCallOpFromResultBox(resultBox, "_FortranATrim", 2);
 }
 
 TEST_F(RuntimeCallTest, genScanDescriptorTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value resultBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value stringBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value setBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value backBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value kind = firBuilder->create<fir::UndefOp>(loc, i32Ty);
+  mlir::Value resultBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value stringBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value setBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value backBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value kind = fir::UndefOp::create(*firBuilder, loc, i32Ty);
   fir::runtime::genScanDescriptor(
       *firBuilder, loc, resultBox, stringBox, setBox, backBox, kind);
   checkCallOpFromResultBox(resultBox, "_FortranAScan", 5);
@@ -178,11 +178,11 @@ TEST_F(RuntimeCallTest, genScanTest) {
 
 TEST_F(RuntimeCallTest, genVerifyDescriptorTest) {
   auto loc = firBuilder->getUnknownLoc();
-  mlir::Value resultBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value stringBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value setBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value backBox = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value kind = firBuilder->create<fir::UndefOp>(loc, i32Ty);
+  mlir::Value resultBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value stringBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value setBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value backBox = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value kind = fir::UndefOp::create(*firBuilder, loc, i32Ty);
   fir::runtime::genVerifyDescriptor(
       *firBuilder, loc, resultBox, stringBox, setBox, backBox, kind);
   checkCallOpFromResultBox(resultBox, "_FortranAVerify", 5);

--- a/flang/unittests/Optimizer/Builder/Runtime/CommandTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/CommandTest.cpp
@@ -21,10 +21,10 @@ TEST_F(RuntimeCallTest, genGetCommandArgument) {
   mlir::Location loc = firBuilder->getUnknownLoc();
   mlir::Type intTy = firBuilder->getDefaultIntegerType();
   mlir::Type boxTy = fir::BoxType::get(firBuilder->getNoneType());
-  mlir::Value number = firBuilder->create<fir::UndefOp>(loc, intTy);
-  mlir::Value value = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value length = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value errmsg = firBuilder->create<fir::UndefOp>(loc, boxTy);
+  mlir::Value number = fir::UndefOp::create(*firBuilder, loc, intTy);
+  mlir::Value value = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value length = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value errmsg = fir::UndefOp::create(*firBuilder, loc, boxTy);
   mlir::Value result = fir::runtime::genGetCommandArgument(
       *firBuilder, loc, number, value, length, errmsg);
   checkCallOp(result.getDefiningOp(), "_FortranAGetCommandArgument",
@@ -34,11 +34,11 @@ TEST_F(RuntimeCallTest, genGetCommandArgument) {
 
 TEST_F(RuntimeCallTest, genGetEnvVariable) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value name = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value value = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value length = firBuilder->create<fir::UndefOp>(loc, boxTy);
-  mlir::Value trimName = firBuilder->create<fir::UndefOp>(loc, i1Ty);
-  mlir::Value errmsg = firBuilder->create<fir::UndefOp>(loc, boxTy);
+  mlir::Value name = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value value = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value length = fir::UndefOp::create(*firBuilder, loc, boxTy);
+  mlir::Value trimName = fir::UndefOp::create(*firBuilder, loc, i1Ty);
+  mlir::Value errmsg = fir::UndefOp::create(*firBuilder, loc, boxTy);
   mlir::Value result = fir::runtime::genGetEnvVariable(
       *firBuilder, loc, name, value, length, trimName, errmsg);
   checkCallOp(result.getDefiningOp(), "_FortranAGetEnvVariable", /*nbArgs=*/5,

--- a/flang/unittests/Optimizer/Builder/Runtime/DerivedTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/DerivedTest.cpp
@@ -14,7 +14,7 @@ TEST_F(RuntimeCallTest, genDerivedTypeInitialize) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value box = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value box = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genDerivedTypeInitialize(*firBuilder, loc, box);
   checkCallOpFromResultBox(box, "_FortranAInitialize", 1);
 }
@@ -23,7 +23,7 @@ TEST_F(RuntimeCallTest, genDerivedTypeDestroy) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value box = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value box = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genDerivedTypeDestroy(*firBuilder, loc, box);
   checkCallOpFromResultBox(box, "_FortranADestroy", 1, /*addLocArg=*/false);
 }

--- a/flang/unittests/Optimizer/Builder/Runtime/RaggedTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/RaggedTest.cpp
@@ -14,7 +14,7 @@ TEST_F(RuntimeCallTest, genRaggedArrayAllocateTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::TupleType headerTy =
       fir::factory::getRaggedArrayHeaderType(*firBuilder);
-  mlir::Value header = firBuilder->create<fir::UndefOp>(loc, headerTy);
+  mlir::Value header = fir::UndefOp::create(*firBuilder, loc, headerTy);
   mlir::Value eleSize = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   mlir::Value extent = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   // Use a dummy header just to test the correctness of the generated call.
@@ -29,7 +29,7 @@ TEST_F(RuntimeCallTest, genRaggedArrayDeallocateTest) {
   mlir::TupleType headerTy =
       fir::factory::getRaggedArrayHeaderType(*firBuilder);
   // Use a dummy header just to test the correctness of the generated call.
-  mlir::Value header = firBuilder->create<fir::UndefOp>(loc, headerTy);
+  mlir::Value header = fir::UndefOp::create(*firBuilder, loc, headerTy);
   fir::runtime::genRaggedArrayDeallocate(loc, *firBuilder, header);
   checkCallOpFromResultBox(
       header, "_FortranARaggedArrayDeallocate", 1, /*addLocArgs=*/false);

--- a/flang/unittests/Optimizer/Builder/Runtime/ReductionTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/ReductionTest.cpp
@@ -12,7 +12,7 @@
 
 TEST_F(RuntimeCallTest, genAllTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value undef = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value undef = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   mlir::Value all = fir::runtime::genAll(*firBuilder, loc, undef, dim);
   checkCallOp(all.getDefiningOp(), "_FortranAAll", 2);
@@ -20,8 +20,8 @@ TEST_F(RuntimeCallTest, genAllTest) {
 
 TEST_F(RuntimeCallTest, genAllDescriptorTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy10);
-  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy10);
+  mlir::Value mask = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   fir::runtime::genAllDescriptor(*firBuilder, loc, result, mask, dim);
   checkCallOpFromResultBox(result, "_FortranAAllDim", 3);
@@ -29,7 +29,7 @@ TEST_F(RuntimeCallTest, genAllDescriptorTest) {
 
 TEST_F(RuntimeCallTest, genAnyTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value undef = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value undef = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   mlir::Value any = fir::runtime::genAny(*firBuilder, loc, undef, dim);
   checkCallOp(any.getDefiningOp(), "_FortranAAny", 2);
@@ -37,8 +37,8 @@ TEST_F(RuntimeCallTest, genAnyTest) {
 
 TEST_F(RuntimeCallTest, genAnyDescriptorTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy10);
-  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy10);
+  mlir::Value mask = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   fir::runtime::genAnyDescriptor(*firBuilder, loc, result, mask, dim);
   checkCallOpFromResultBox(result, "_FortranAAnyDim", 3);
@@ -46,7 +46,7 @@ TEST_F(RuntimeCallTest, genAnyDescriptorTest) {
 
 TEST_F(RuntimeCallTest, genCountTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value undef = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value undef = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   mlir::Value count = fir::runtime::genCount(*firBuilder, loc, undef, dim);
   checkCallOp(count.getDefiningOp(), "_FortranACount", 2);
@@ -54,8 +54,8 @@ TEST_F(RuntimeCallTest, genCountTest) {
 
 TEST_F(RuntimeCallTest, genCountDimTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy10);
-  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy10);
+  mlir::Value mask = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   mlir::Value kind = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   fir::runtime::genCountDim(*firBuilder, loc, result, mask, dim, kind);
@@ -114,7 +114,7 @@ TEST_F(RuntimeCallTest, genMinValTest) {
 
 TEST_F(RuntimeCallTest, genParityTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value undef = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value undef = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   mlir::Value parity = fir::runtime::genParity(*firBuilder, loc, undef, dim);
   checkCallOp(parity.getDefiningOp(), "_FortranAParity", 2);
@@ -122,8 +122,8 @@ TEST_F(RuntimeCallTest, genParityTest) {
 
 TEST_F(RuntimeCallTest, genParityDescriptorTest) {
   mlir::Location loc = firBuilder->getUnknownLoc();
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy10);
-  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy10);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy10);
+  mlir::Value mask = fir::UndefOp::create(*firBuilder, loc, seqTy10);
   mlir::Value dim = firBuilder->createIntegerConstant(loc, i32Ty, 1);
   fir::runtime::genParityDescriptor(*firBuilder, loc, result, mask, dim);
   checkCallOpFromResultBox(result, "_FortranAParityDim", 3);

--- a/flang/unittests/Optimizer/Builder/Runtime/TransformationalTest.cpp
+++ b/flang/unittests/Optimizer/Builder/Runtime/TransformationalTest.cpp
@@ -100,10 +100,10 @@ TEST_F(RuntimeCallTest, genCshiftTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value dim = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value array = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value shift = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value dim = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genCshift(*firBuilder, loc, result, array, shift, dim);
   checkCallOpFromResultBox(result, "_FortranACshift", 4);
 }
@@ -112,9 +112,9 @@ TEST_F(RuntimeCallTest, genCshiftVectorTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value array = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value shift = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genCshiftVector(*firBuilder, loc, result, array, shift);
   checkCallOpFromResultBox(result, "_FortranACshiftVector", 3);
 }
@@ -123,11 +123,11 @@ TEST_F(RuntimeCallTest, genEoshiftTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value bound = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value dim = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value array = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value shift = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value bound = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value dim = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genEoshift(*firBuilder, loc, result, array, shift, bound, dim);
   checkCallOpFromResultBox(result, "_FortranAEoshift", 5);
 }
@@ -136,10 +136,10 @@ TEST_F(RuntimeCallTest, genEoshiftVectorTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value shift = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value bound = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value array = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value shift = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value bound = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genEoshiftVector(*firBuilder, loc, result, array, shift, bound);
   checkCallOpFromResultBox(result, "_FortranAEoshiftVector", 4);
 }
@@ -185,10 +185,10 @@ TEST_F(RuntimeCallTest, genPackTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value array = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value vector = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value array = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value mask = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value vector = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genPack(*firBuilder, loc, result, array, mask, vector);
   checkCallOpFromResultBox(result, "_FortranAPack", 4);
 }
@@ -197,11 +197,11 @@ TEST_F(RuntimeCallTest, genReshapeTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value shape = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value pad = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value order = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value source = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value shape = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value pad = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value order = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genReshape(*firBuilder, loc, result, source, shape, pad, order);
   checkCallOpFromResultBox(result, "_FortranAReshape", 5);
 }
@@ -210,10 +210,10 @@ TEST_F(RuntimeCallTest, genSpreadTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value dim = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value ncopies = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value source = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value dim = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value ncopies = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genSpread(*firBuilder, loc, result, source, dim, ncopies);
   checkCallOpFromResultBox(result, "_FortranASpread", 4);
 }
@@ -222,8 +222,8 @@ TEST_F(RuntimeCallTest, genTransposeTest) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value source = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value source = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genTranspose(*firBuilder, loc, result, source);
   checkCallOpFromResultBox(result, "_FortranATranspose", 2);
 }
@@ -232,10 +232,10 @@ TEST_F(RuntimeCallTest, genUnpack) {
   auto loc = firBuilder->getUnknownLoc();
   mlir::Type seqTy =
       fir::SequenceType::get(fir::SequenceType::Shape(1, 10), i32Ty);
-  mlir::Value result = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value vector = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value mask = firBuilder->create<fir::UndefOp>(loc, seqTy);
-  mlir::Value field = firBuilder->create<fir::UndefOp>(loc, seqTy);
+  mlir::Value result = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value vector = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value mask = fir::UndefOp::create(*firBuilder, loc, seqTy);
+  mlir::Value field = fir::UndefOp::create(*firBuilder, loc, seqTy);
   fir::runtime::genUnpack(*firBuilder, loc, result, vector, mask, field);
   checkCallOpFromResultBox(result, "_FortranAUnpack", 4);
 }

--- a/flang/unittests/Optimizer/FortranVariableTest.cpp
+++ b/flang/unittests/Optimizer/FortranVariableTest.cpp
@@ -35,7 +35,7 @@ public:
   }
 
   mlir::Value createShape(llvm::ArrayRef<mlir::Value> extents) {
-    return builder->create<fir::ShapeOp>(getLoc(), extents);
+    return fir::ShapeOp::create(*builder, getLoc(), extents);
   }
   mlir::MLIRContext context;
   std::unique_ptr<mlir::OpBuilder> builder;
@@ -45,9 +45,9 @@ public:
 TEST_F(FortranVariableTest, SimpleScalar) {
   mlir::Location loc = getLoc();
   mlir::Type eleType = mlir::Float32Type::get(&context);
-  mlir::Value addr = builder->create<fir::AllocaOp>(loc, eleType);
+  mlir::Value addr = fir::AllocaOp::create(*builder, loc, eleType);
   auto name = mlir::StringAttr::get(&context, "x");
-  auto declare = builder->create<fir::DeclareOp>(loc, addr.getType(), addr,
+  auto declare = fir::DeclareOp::create(*builder, loc, addr.getType(), addr,
       /*shape=*/mlir::Value{}, /*typeParams=*/mlir::ValueRange{},
       /*dummy_scope=*/nullptr, name,
       /*fortran_attrs=*/fir::FortranVariableFlagsAttr{},
@@ -71,10 +71,10 @@ TEST_F(FortranVariableTest, CharacterScalar) {
   mlir::Type eleType = fir::CharacterType::getUnknownLen(&context, 4);
   mlir::Value len = createConstant(42);
   llvm::SmallVector<mlir::Value> typeParams{len};
-  mlir::Value addr = builder->create<fir::AllocaOp>(
-      loc, eleType, /*pinned=*/false, typeParams);
+  mlir::Value addr = fir::AllocaOp::create(
+      *builder, loc, eleType, /*pinned=*/false, typeParams);
   auto name = mlir::StringAttr::get(&context, "x");
-  auto declare = builder->create<fir::DeclareOp>(loc, addr.getType(), addr,
+  auto declare = fir::DeclareOp::create(*builder, loc, addr.getType(), addr,
       /*shape=*/mlir::Value{}, typeParams, /*dummy_scope=*/nullptr, name,
       /*fortran_attrs=*/fir::FortranVariableFlagsAttr{},
       /*data_attr=*/cuf::DataAttributeAttr{});
@@ -101,11 +101,11 @@ TEST_F(FortranVariableTest, SimpleArray) {
   fir::SequenceType::Shape typeShape(
       extents.size(), fir::SequenceType::getUnknownExtent());
   mlir::Type seqTy = fir::SequenceType::get(typeShape, eleType);
-  mlir::Value addr = builder->create<fir::AllocaOp>(
-      loc, seqTy, /*pinned=*/false, /*typeParams=*/mlir::ValueRange{}, extents);
+  mlir::Value addr = fir::AllocaOp::create(*builder, loc, seqTy,
+      /*pinned=*/false, /*typeParams=*/mlir::ValueRange{}, extents);
   mlir::Value shape = createShape(extents);
   auto name = mlir::StringAttr::get(&context, "x");
-  auto declare = builder->create<fir::DeclareOp>(loc, addr.getType(), addr,
+  auto declare = fir::DeclareOp::create(*builder, loc, addr.getType(), addr,
       shape, /*typeParams=*/mlir::ValueRange{}, /*dummy_scope=*/nullptr, name,
       /*fortran_attrs=*/fir::FortranVariableFlagsAttr{},
       /*data_attr=*/cuf::DataAttributeAttr{});
@@ -132,11 +132,11 @@ TEST_F(FortranVariableTest, CharacterArray) {
   fir::SequenceType::Shape typeShape(
       extents.size(), fir::SequenceType::getUnknownExtent());
   mlir::Type seqTy = fir::SequenceType::get(typeShape, eleType);
-  mlir::Value addr = builder->create<fir::AllocaOp>(
-      loc, seqTy, /*pinned=*/false, typeParams, extents);
+  mlir::Value addr = fir::AllocaOp::create(
+      *builder, loc, seqTy, /*pinned=*/false, typeParams, extents);
   mlir::Value shape = createShape(extents);
   auto name = mlir::StringAttr::get(&context, "x");
-  auto declare = builder->create<fir::DeclareOp>(loc, addr.getType(), addr,
+  auto declare = fir::DeclareOp::create(*builder, loc, addr.getType(), addr,
       shape, typeParams, /*dummy_scope=*/nullptr, name,
       /*fortran_attrs=*/fir::FortranVariableFlagsAttr{},
       /*data_attr=*/cuf::DataAttributeAttr{});


### PR DESCRIPTION
While I was updating the creation of CUF operation in #152050, I noticed some other places in flang that were not updated. This patch updates the FIR operation creations in `flang/unittests`