### PR TITLE
[DAGCombine][RISCV] fold select_cc seteq (and x, 1) 0, 0, -1 -> neg(and(x, 1))

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -29000,8 +29000,8 @@ SDValue DAGCombiner::SimplifySelectCC(const SDLoc &DL, SDValue N0, SDValue N1,
 
   // fold select_cc seteq (and x, 1), 0, 0, -1 -> neg(and(x, 1))
   if (CC == ISD::SETEQ && N0->getOpcode() == ISD::AND &&
-      N0->getValueType(0) == VT && isNullConstant(N1) &&
-      isAllOnesConstant(N2) && isOneConstant(N0->getOperand(1))) {
+      N0->getValueType(0) == VT && isNullConstant(N1) && isNullConstant(N2) &&
+      isAllOnesConstant(N3) && isOneConstant(N0->getOperand(1))) {
     SDValue AndLHS = N0->getOperand(0);
     SDValue Neg =
         DAG.getNode(ISD::AND, DL, VT, AndLHS, DAG.getConstant(1, DL, VT));

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -28999,9 +28999,12 @@ SDValue DAGCombiner::SimplifySelectCC(const SDLoc &DL, SDValue N0, SDValue N1,
     return V;
 
   // fold select_cc seteq (and x, 1), 0, 0, -1 -> neg(and(x, 1))
-  if (CC == ISD::SETEQ && N0->getOpcode() == ISD::AND &&
-      N0->getValueType(0) == VT && isNullConstant(N1) && isNullConstant(N2) &&
-      isAllOnesConstant(N3) && isOneConstant(N0->getOperand(1))) {
+  // and also: select_cc setne (and x, 1), 1, 0, -1 -> neg(and(x, 1))
+  if (N0->getOpcode() == ISD::AND && N0->getValueType(0) == VT &&
+      isNullConstant(N2) && isAllOnesConstant(N3) &&
+      isOneConstant(N0->getOperand(1)) &&
+      ((CC == ISD::SETEQ && isNullConstant(N1)) ||
+       (CC == ISD::SETNE && isOneConstant(N1)))) {
     SDValue AndLHS = N0->getOperand(0);
     SDValue Neg =
         DAG.getNode(ISD::AND, DL, VT, AndLHS, DAG.getConstant(1, DL, VT));

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -24864,6 +24864,10 @@ static SDValue LowerSELECTWithCmpZero(SDValue CmpVal, SDValue LHS, SDValue RHS,
       return DAG.getNegative(Neg, DL, SplatVT); // -(and (x, 0x1))
     };
 
+    // SELECT (AND(X,1) == 0), 0, -1 -> NEG(AND(X,1))
+    if (isNullConstant(LHS) && isAllOnesConstant(RHS))
+      return SplatLSB(VT);
+
     // SELECT (AND(X,1) == 0), C1, C2 -> XOR(C1,AND(NEG(AND(X,1)),XOR(C1,C2))
     if (!Subtarget.canUseCMOV() && isa<ConstantSDNode>(LHS) &&
         isa<ConstantSDNode>(RHS)) {

--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -24864,10 +24864,6 @@ static SDValue LowerSELECTWithCmpZero(SDValue CmpVal, SDValue LHS, SDValue RHS,
       return DAG.getNegative(Neg, DL, SplatVT); // -(and (x, 0x1))
     };
 
-    // SELECT (AND(X,1) == 0), 0, -1 -> NEG(AND(X,1))
-    if (isNullConstant(LHS) && isAllOnesConstant(RHS))
-      return SplatLSB(VT);
-
     // SELECT (AND(X,1) == 0), C1, C2 -> XOR(C1,AND(NEG(AND(X,1)),XOR(C1,C2))
     if (!Subtarget.canUseCMOV() && isa<ConstantSDNode>(LHS) &&
         isa<ConstantSDNode>(RHS)) {

--- a/llvm/test/CodeGen/RISCV/pr148084.ll
+++ b/llvm/test/CodeGen/RISCV/pr148084.ll
@@ -10,15 +10,14 @@ define fastcc void @search_tx_type() #0 {
 ; CHECK:       # %bb.0: # %._crit_edge.i
 ; CHECK-NEXT:  # %bb.1: # %bb
 ; CHECK-NEXT:    lbu a1, 0(zero)
-; CHECK-NEXT:    lw a0, 0(zero)
 ; CHECK-NEXT:    lh a2, 0(zero)
+; CHECK-NEXT:    lw a0, 0(zero)
 ; CHECK-NEXT:    seqz a1, a1
-; CHECK-NEXT:    srai a3, a0, 63
 ; CHECK-NEXT:    addi a1, a1, -1
 ; CHECK-NEXT:    and a1, a1, a2
-; CHECK-NEXT:    andi a2, a1, 1
-; CHECK-NEXT:    addi a2, a2, -1
-; CHECK-NEXT:    or a3, a3, a0
+; CHECK-NEXT:    slli a2, a1, 63
+; CHECK-NEXT:    srai a2, a2, 63
+; CHECK-NEXT:    srai a3, a0, 63
 ; CHECK-NEXT:    or a2, a2, a3
 ; CHECK-NEXT:    bgez a2, .LBB0_3
 ; CHECK-NEXT:  # %bb.2:
@@ -36,14 +35,13 @@ define fastcc void @search_tx_type() #0 {
 ; CHECK-NEXT:  # %bb.6: # %bb
 ; CHECK-NEXT:    mv a3, a2
 ; CHECK-NEXT:  .LBB0_7: # %bb
-; CHECK-NEXT:    andi a5, a1, 8
-; CHECK-NEXT:    sext.w a4, a3
+; CHECK-NEXT:    andi a4, a1, 8
 ; CHECK-NEXT:    mv a2, a3
-; CHECK-NEXT:    beqz a5, .LBB0_9
+; CHECK-NEXT:    beqz a4, .LBB0_9
 ; CHECK-NEXT:  # %bb.8: # %bb
 ; CHECK-NEXT:    mv a2, a0
 ; CHECK-NEXT:  .LBB0_9: # %bb
-; CHECK-NEXT:    blt a4, a0, .LBB0_11
+; CHECK-NEXT:    blt a3, a0, .LBB0_11
 ; CHECK-NEXT:  # %bb.10: # %bb
 ; CHECK-NEXT:    mv a2, a3
 ; CHECK-NEXT:  .LBB0_11: # %bb

--- a/llvm/test/CodeGen/RISCV/select.ll
+++ b/llvm/test/CodeGen/RISCV/select.ll
@@ -2241,3 +2241,77 @@ entry:
   store ptr %4, ptr %1, align 8
   ret void
 }
+
+define i16 @select_neg_1(i16 %A, i8 %cond) {
+; RV32IM-LABEL: select_neg_1:
+; RV32IM:       # %bb.0: # %entry
+; RV32IM-NEXT:    slli a0, a1, 31
+; RV32IM-NEXT:    srai a0, a0, 31
+; RV32IM-NEXT:    ret
+;
+; RV64IM-LABEL: select_neg_1:
+; RV64IM:       # %bb.0: # %entry
+; RV64IM-NEXT:    slli a0, a1, 63
+; RV64IM-NEXT:    srai a0, a0, 63
+; RV64IM-NEXT:    ret
+;
+; RV64IMXVTCONDOPS-LABEL: select_neg_1:
+; RV64IMXVTCONDOPS:       # %bb.0: # %entry
+; RV64IMXVTCONDOPS-NEXT:    slli a0, a1, 63
+; RV64IMXVTCONDOPS-NEXT:    srai a0, a0, 63
+; RV64IMXVTCONDOPS-NEXT:    ret
+;
+; RV32IMZICOND-LABEL: select_neg_1:
+; RV32IMZICOND:       # %bb.0: # %entry
+; RV32IMZICOND-NEXT:    slli a0, a1, 31
+; RV32IMZICOND-NEXT:    srai a0, a0, 31
+; RV32IMZICOND-NEXT:    ret
+;
+; RV64IMZICOND-LABEL: select_neg_1:
+; RV64IMZICOND:       # %bb.0: # %entry
+; RV64IMZICOND-NEXT:    slli a0, a1, 63
+; RV64IMZICOND-NEXT:    srai a0, a0, 63
+; RV64IMZICOND-NEXT:    ret
+entry:
+ %and = and i8 %cond, 1
+ %cmp10 = icmp eq i8 %and, 0
+ %1 = select i1 %cmp10, i16 0, i16 -1
+ ret i16 %1
+}
+
+define i16 @select_neg_1(i16 %A, i8 %cond) {
+; RV32IM-LABEL: select_neg_1:
+; RV32IM:       # %bb.0: # %entry
+; RV32IM-NEXT:    slli a0, a1, 31
+; RV32IM-NEXT:    srai a0, a0, 31
+; RV32IM-NEXT:    ret
+;
+; RV64IM-LABEL: select_neg_1:
+; RV64IM:       # %bb.0: # %entry
+; RV64IM-NEXT:    slli a0, a1, 63
+; RV64IM-NEXT:    srai a0, a0, 63
+; RV64IM-NEXT:    ret
+;
+; RV64IMXVTCONDOPS-LABEL: select_neg_1:
+; RV64IMXVTCONDOPS:       # %bb.0: # %entry
+; RV64IMXVTCONDOPS-NEXT:    slli a0, a1, 63
+; RV64IMXVTCONDOPS-NEXT:    srai a0, a0, 63
+; RV64IMXVTCONDOPS-NEXT:    ret
+;
+; RV32IMZICOND-LABEL: select_neg_1:
+; RV32IMZICOND:       # %bb.0: # %entry
+; RV32IMZICOND-NEXT:    slli a0, a1, 31
+; RV32IMZICOND-NEXT:    srai a0, a0, 31
+; RV32IMZICOND-NEXT:    ret
+;
+; RV64IMZICOND-LABEL: select_neg_1:
+; RV64IMZICOND:       # %bb.0: # %entry
+; RV64IMZICOND-NEXT:    slli a0, a1, 63
+; RV64IMZICOND-NEXT:    srai a0, a0, 63
+; RV64IMZICOND-NEXT:    ret
+entry:
+ %and = and i8 %cond, 1
+ %cmp10 = icmp ne i8 %and, 1
+ %1 = select i1 %cmp10, i16 0, i16 -1
+ ret i16 %1
+}


### PR DESCRIPTION
Unlike the fold below, this does not rely on shouldAvoidTransformToShift, so it works for all cases.