### PR TITLE
[clang][bytecode][NFC] Only collect non-null args if we have to

### DIFF
--- a/clang/lib/AST/ByteCode/InterpShared.cpp
+++ b/clang/lib/AST/ByteCode/InterpShared.cpp
@@ -16,23 +16,23 @@ namespace interp {
 llvm::BitVector collectNonNullArgs(const FunctionDecl *F,
                                    ArrayRef<const Expr *> Args) {
   llvm::BitVector NonNullArgs;
-  if (!F)
-    return NonNullArgs;
 
   assert(F);
+  assert(F->hasAttr<NonNullAttr>());
   NonNullArgs.resize(Args.size());
 
   for (const auto *Attr : F->specific_attrs<NonNullAttr>()) {
     if (!Attr->args_size()) {
       NonNullArgs.set();
       break;
-    } else
-      for (auto Idx : Attr->args()) {
-        unsigned ASTIdx = Idx.getASTIndex();
-        if (ASTIdx >= Args.size())
-          continue;
-        NonNullArgs[ASTIdx] = true;
-      }
+    }
+
+    for (auto Idx : Attr->args()) {
+      unsigned ASTIdx = Idx.getASTIndex();
+      if (ASTIdx >= Args.size())
+        continue;
+      NonNullArgs[ASTIdx] = true;
+    }
   }
 
   return NonNullArgs;

--- a/clang/test/AST/ByteCode/nullable.cpp
+++ b/clang/test/AST/ByteCode/nullable.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify=expected,both %s
-// RUN: %clang_cc1 -verify=ref,both %s
+// RUN: %clang_cc1 -verify=expected,both %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -verify=ref,both      %s
 
 
 constexpr int dummy = 1;


### PR DESCRIPTION
Only do this if the function really has a NonNullArg.