### PR TITLE
[clang] Respect [[gnu::error]] on functions passed to [[gnu::cleanup]]

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -152,6 +152,8 @@ Bug Fixes to Attribute Support
 
 - ``[[nodiscard]]`` is now respected on Objective-C and Objective-C++ methods.
   (#GH141504)
+- Using ``[[gnu::cleanup(some_func)]]`` where some_func is annotated with
+  ``[[gnu::error("some error")]]`` now correctly triggers an error. (#GH146520)
 
 Bug Fixes to C++ Support
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -624,8 +624,15 @@ namespace {
       CallArgList Args;
       Args.add(RValue::get(Arg),
                CGF.getContext().getPointerType(Var.getType()));
-      auto Callee = CGCallee::forDirect(CleanupFn);
-      CGF.EmitCall(FnInfo, Callee, ReturnValueSlot(), Args);
+      bool HasCleanupAttr = Var.hasAttr<CleanupAttr>();
+      GlobalDecl GD = HasCleanupAttr
+                          ? (Var.getAttr<CleanupAttr>()->getFunctionDecl())
+                          : GlobalDecl();
+      SourceLocation Loc = HasCleanupAttr ? Var.getAttr<CleanupAttr>()->getLoc()
+                                          : SourceLocation();
+      auto Callee = CGCallee::forDirect(CleanupFn, CGCalleeInfo(GD));
+      CGF.EmitCall(FnInfo, Callee, ReturnValueSlot(), Args,
+                   /*callOrInvoke*/ nullptr, /*IsMustTail*/ false, Loc);
     }
   };
 } // end anonymous namespace

--- a/clang/test/Frontend/backend-attribute-error-warning-optimize.c
+++ b/clang/test/Frontend/backend-attribute-error-warning-optimize.c
@@ -20,3 +20,13 @@ void indirect(void) {
   quux = foo;
   quux();
 }
+
+// https://github.com/llvm/llvm-project/issues/146520
+
+[[gnu::error("error please")]]
+void cleaner_function(char*);
+
+void asdf(void){
+	[[gnu::cleanup(cleaner_function)]] // expected-error {{call to 'cleaner_function' declared with 'error' attribute: error please}}
+	char x; 
+}


### PR DESCRIPTION
Forward SourceLocation to `EmitCall` so that clang triggers an error when a function inside `[[gnu::cleanup(func)]]` is annotated with `[[gnu::error("some message")]]`.

resolves #146520