### PR TITLE
Revert "[libc] make integration test malloc work properly when threaded"

### DIFF
--- a/libc/test/IntegrationTest/CMakeLists.txt
+++ b/libc/test/IntegrationTest/CMakeLists.txt
@@ -13,6 +13,5 @@ add_object_library(
   DEPENDS
     libc.hdr.stdint_proxy
     libc.src.__support.OSUtil.osutil
-    libc.src.__support.CPP.atomic
     ${arch_specific_deps}
 )

--- a/libc/test/IntegrationTest/test.cpp
+++ b/libc/test/IntegrationTest/test.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #include "hdr/stdint_proxy.h"
-#include "src/__support/CPP/atomic.h"
 #include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 #include <stddef.h>
@@ -65,19 +65,14 @@ int atexit(void (*func)(void)) { return LIBC_NAMESPACE::atexit(func); }
 
 static constexpr uint64_t MEMORY_SIZE = 16384;
 static uint8_t memory[MEMORY_SIZE];
-static LIBC_NAMESPACE::cpp::Atomic<size_t> used = 0;
+static uint8_t *ptr = memory;
 
 extern "C" {
 
-// For simple test purposes.
 void *malloc(size_t s) {
-  // Emulate the alignment of std::max_align_t.
-  constexpr size_t DEFAULT_ALIGNMENT = alignof(long double);
-  s += (-s) & (DEFAULT_ALIGNMENT - 1); // Align to default alignment.
-  auto res = used.fetch_add(s, LIBC_NAMESPACE::cpp::MemoryOrder::RELAXED);
-  if (res + s > MEMORY_SIZE)
-    return nullptr; // Out of memory.
-  return &memory[res];
+  void *mem = ptr;
+  ptr += s;
+  return static_cast<uint64_t>(ptr - memory) >= MEMORY_SIZE ? nullptr : mem;
 }
 
 void free(void *) {}


### PR DESCRIPTION
Reverts llvm/llvm-project#151622

This broke our libc on GPU bot: https://lab.llvm.org/buildbot/#/builders/10/builds/10864