### PR TITLE
[LLVM][IR] Switch from manual pointer incrementation to function in Lexer

### DIFF
--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -93,7 +93,7 @@ namespace llvm {
   private:
     lltok::Kind LexToken();
 
-    // Return closes pointer after `Ptr` that is an end of a label.
+    // Return closest pointer after `Ptr` that is an end of a label.
     // Returns nullptr if `Ptr` doesn't point into a label.
     const char *getLabelTail(const char *Ptr);
     int getNextChar();

--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -94,6 +94,8 @@ namespace llvm {
     lltok::Kind LexToken();
 
     int getNextChar();
+    const char *skipNChars(unsigned N);
+    void advancePositionTo(const char *Ptr);
     void SkipLineComment();
     bool SkipCComment();
     lltok::Kind ReadString(lltok::Kind kind);

--- a/llvm/include/llvm/AsmParser/LLLexer.h
+++ b/llvm/include/llvm/AsmParser/LLLexer.h
@@ -93,6 +93,9 @@ namespace llvm {
   private:
     lltok::Kind LexToken();
 
+    // Return closes pointer after `Ptr` that is an end of a label.
+    // Returns nullptr if `Ptr` doesn't point into a label.
+    const char *getLabelTail(const char *Ptr);
     int getNextChar();
     const char *skipNChars(unsigned N);
     void advancePositionTo(const char *Ptr);

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -198,10 +198,8 @@ const char *LLLexer::skipNChars(unsigned N) {
 
 void LLLexer::advancePositionTo(const char *Ptr) {
   while (CurPtr != Ptr) {
-    // FIXME: Assumes that if moving back, we stay in that line
     if (CurPtr > Ptr) {
       --CurPtr;
-      --CurColNum;
     } else
       getNextChar();
   }

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -165,7 +165,6 @@ LLLexer::LLLexer(StringRef StartBuf, SourceMgr &SM, SMDiagnostic &Err,
   CurPtr = CurBuf.begin();
 }
 
-/// getLabelTail - Return true if this pointer points to a valid end of a label.
 const char *LLLexer::getLabelTail(const char *Ptr) {
   while (Ptr != CurBuf.end()) {
     if (Ptr[0] == ':')


### PR DESCRIPTION
The IR Lexer has a `getNextChar()` function implemented. But it is used only once, on other places the pointer pointing to the current position in the lexed string (`CurPtr`) is incremented manually, this can lead to some OOB errors (see #151556 and [Discourse thread](https://discourse.llvm.org/t/llvm-ir-lexer-not-using-getnextchar/87625/4)).

To mitigate the issue, this PR changes the `getNextChar()` to be more straight forward, changes all manual pointer increments to `getNextChar()` or adds checks, so that no OOB occurs.

Two helper functions were used `skipNChars` and `advancePositionTo`. Where `skipNChars(N)` calls `getNextChar()` N-times, while `advancePositionTo(Ptr)` is used insead of `CurPtr = Ptr`.

One helper function `isLabelTail` was moved into the Lexer class, to be able to check the bounds, and renamed to `getLabelTail` to better reflect it's function.