### PR TITLE
[clang][bytecode][NFC] Add a c++11 test case

### DIFF
--- a/clang/test/AST/ByteCode/cxx11.cpp
+++ b/clang/test/AST/ByteCode/cxx11.cpp
@@ -309,3 +309,12 @@ int somefunc() {
                                                   // both-note {{reference to 'non_global' is not a constant expression}}
 }
 
+namespace PR19010 {
+  struct Empty {};
+  struct Empty2 : Empty {};
+  struct Test : Empty2 {
+    constexpr Test() {}
+    Empty2 array[2];
+  };
+  void test() { constexpr Test t; }
+}


### PR DESCRIPTION
This test case breaks when ignoring trivial CXXConstructExprs of array types, so make sure we don't do that.