### PR TITLE
ARM: Remove check for isAAPCS_ABI when enabling various aeabi calls

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -588,8 +588,8 @@ ARMTargetLowering::ARMTargetLowering(const TargetMachine &TM_,
   }
 
   // RTLIB
-  if (TM.isAAPCS_ABI() && (TT.isTargetAEABI() || TT.isTargetGNUAEABI() ||
-                           TT.isTargetMuslAEABI() || TT.isAndroid())) {
+  if (TT.isTargetAEABI() || TT.isTargetGNUAEABI() || TT.isTargetMuslAEABI() ||
+      TT.isAndroid()) {
     // FIXME: This does not depend on the subtarget and should go directly into
     // RuntimeLibcalls. This is only here because of missing support for setting
     // the calling convention of an implementation.


### PR DESCRIPTION
Based on computeDefaultTargetABI, this appears to be redundant.

The only test using the explicit -target-abi flag with a value different
than one implied by the triple (i.e. assert(TM.isAAPCS_ABI()) under
the condition) is arm-abi-attr.ll and it doesn't stress the libcalls
used.