### PR TITLE
[AArch64] Drop poison flags when lowering absolute difference patterns.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11403,12 +11403,12 @@ SDValue AArch64TargetLowering::LowerSELECT_CC(
     if (TVal.getOpcode() == ISD::SUB && FVal.getOpcode() == ISD::SUB) {
       if (TVal.getOperand(0) == LHS && TVal.getOperand(1) == RHS &&
           FVal.getOperand(0) == RHS && FVal.getOperand(1) == LHS) {
-        FVal = DAG.getNegative(TVal, DL, TVal.getValueType());
         TVal->dropFlags(SDNodeFlags::PoisonGeneratingFlags);
+        FVal = DAG.getNegative(TVal, DL, TVal.getValueType());
       } else if (TVal.getOperand(0) == RHS && TVal.getOperand(1) == LHS &&
                  FVal.getOperand(0) == LHS && FVal.getOperand(1) == RHS) {
-        TVal = DAG.getNegative(FVal, DL, FVal.getValueType());
         FVal->dropFlags(SDNodeFlags::PoisonGeneratingFlags);
+        TVal = DAG.getNegative(FVal, DL, FVal.getValueType());
       }
     }
 

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11398,13 +11398,18 @@ SDValue AArch64TargetLowering::LowerSELECT_CC(
     //   select_cc lhs, rhs, sub(rhs, lhs), sub(lhs, rhs), cc ->
     //   select_cc lhs, rhs, neg(sub(lhs, rhs)), sub(lhs, rhs), cc
     // The second forms can be matched into subs+cneg.
+    // NOTE: Drop poison generating flags from the negated operand to avoid
+    // inadvertently propagating poison after the canonicalisation.
     if (TVal.getOpcode() == ISD::SUB && FVal.getOpcode() == ISD::SUB) {
       if (TVal.getOperand(0) == LHS && TVal.getOperand(1) == RHS &&
-          FVal.getOperand(0) == RHS && FVal.getOperand(1) == LHS)
+          FVal.getOperand(0) == RHS && FVal.getOperand(1) == LHS) {
         FVal = DAG.getNegative(TVal, DL, TVal.getValueType());
-      else if (TVal.getOperand(0) == RHS && TVal.getOperand(1) == LHS &&
-               FVal.getOperand(0) == LHS && FVal.getOperand(1) == RHS)
+        TVal->dropFlags(SDNodeFlags::PoisonGeneratingFlags);
+      } else if (TVal.getOperand(0) == RHS && TVal.getOperand(1) == LHS &&
+                 FVal.getOperand(0) == LHS && FVal.getOperand(1) == RHS) {
         TVal = DAG.getNegative(FVal, DL, FVal.getValueType());
+        FVal->dropFlags(SDNodeFlags::PoisonGeneratingFlags);
+      }
     }
 
     unsigned Opcode = AArch64ISD::CSEL;


### PR DESCRIPTION
As a follow-up to #151177, when lowering SELECT_CC nodes of absolute difference patterns, drop poison-generating flags from the negated operand to avoid inadvertently propagating poison.

As discussed in https://github.com/llvm/llvm-project/pull/151177#discussion_r2250788112, I didn't find practical issues with the current code, but it seems safer to drop flags preemptively.

I don't know of a good way to test this other than by matching SDAG logs directly.