### PR TITLE
[MLIR][Maintainers] Add maintainer list for core sub-categories

### DIFF
--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -30,6 +30,7 @@ dialects, build system and language bindings.
 ### Code
 
 #### Standalone subcategories
+* Core tooling (ODS, DRR, PDLL, LSP) (core)
 * CMake ([christopherbate](https://github.com/christopherbate))
 * Dialect Conversion ([matthias-springer](https://github.com/matthias-springer), [zero9178](https://github.com/zero9178))
 * Python Bindings ([makslevental](https://github.com/makslevental), [rolfmorel](https://github.com/rolfmorel))
@@ -59,7 +60,7 @@ dialects, build system and language bindings.
 * ‘shape’ Dialect ([jpienaar](https://github.com/jpienaar))
 * ‘smt’ Dialect ([fabianschuiki](https://github.com/fabianschuiki), [maerhart](https://github.com/maerhart))
 * ‘ub’ Dialect ([Hardcode84](https://github.com/Hardcode84))
-* ‘complex’ Dialect (unmaintained)
+* ‘complex’ Dialect (core)
 * ‘async’ Dialect (unmaintained)
 
 ## Egress

--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -27,6 +27,41 @@ dialects, build system and language bindings.
   [@joker-eph](https://github.com/joker-eph) (GitHub),
   mehdi_amini (Discourse)
 
+### Code
+
+#### Standalone subcategories
+* CMake ([christopherbate](https://github.com/christopherbate))
+* Dialect Conversion ([matthias-springer](https://github.com/matthias-springer), [zero9178](https://github.com/zero9178))
+* Python Bindings ([makslevental](https://github.com/makslevental), [rolfmorel](https://github.com/rolfmorel))
+
+### Dialects
+
+#### Code Structure Dialects
+* Builtin Dialect (core)
+* ‘func’ Dialect (core)
+* ‘scf’ Dialect (core)
+* ‘cf’ Dialect (core)
+* ‘index’ Dialect (core)
+* ‘ptr’ Dialect ([fabianmcg](https://github.com/fabianmcg))
+
+#### Basic Compute Dialects
+* ‘arith’ Dialect (core)
+* ‘math’ Dialect (core)
+* Rewrite System Dialects (core)
+* Transform Dialect ([martin-luecke](https://github.com/martin-luecke), [ftynse](https://github.com/ftynse), [rolfmorel](https://github.com/rolfmorel))
+* ‘pdl_interp’ Dialect ([jpienaar](https://github.com/jpienaar))
+* ‘pdl’ Dialect ([jpienaar](https://github.com/jpienaar))
+
+#### Accessory Dialects
+* ‘affine’ Dialect ([ftynse](https://github.com/ftynse))
+* ‘dlti’ Dialect ([rolfmorel](https://github.com/rolfmorel))
+* ‘irdl’ Dialect ([math-fehr](https://github.com/math-fehr), [moxinilian](https://github.com/moxinilian))
+* ‘shape’ Dialect ([jpienaar](https://github.com/jpienaar))
+* ‘smt’ Dialect ([fabianschuiki](https://github.com/fabianschuiki), [maerhart](https://github.com/maerhart))
+* ‘ub’ Dialect ([Hardcode84](https://github.com/Hardcode84))
+* ‘complex’ Dialect (unmaintained)
+* ‘async’ Dialect (unmaintained)
+
 ## Egress
 
 MLIR components pertaining to egress flows from MLIR, in particular to LLVM IR.


### PR DESCRIPTION
Ref: https://discourse.llvm.org/t/mlir-project-maintainers/87189

See also:
 * #151721 
 * #150945

Compared to the original proposal, one change is included:
* The `ub` dialect has @Hardcode84 as maintainer.

Please accept to validate your nomination, let's keep new nominations for follow up PRs.