### PR TITLE
[libc] Enable the `acoshf` math function on AMD GPUs

### DIFF
--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -282,6 +282,7 @@ set(TARGET_LIBM_ENTRYPOINTS
     # math.h entrypoints
     libc.src.math.acos
     libc.src.math.acosf
+    libc.src.math.acoshf
     libc.src.math.asin
     libc.src.math.asinf
     libc.src.math.asinhf


### PR DESCRIPTION
This patch adds the `acoshf` math function to the AMDGPU build.