### PR TITLE
[analyzer] Add missing expected-warning after #151908

### DIFF
--- a/clang/test/Analysis/cxx23-assume-attribute.cpp
+++ b/clang/test/Analysis/cxx23-assume-attribute.cpp
@@ -73,4 +73,5 @@ int assume_and_fallthrough_at_the_same_attrstmt(int a, int b) {
 void assume_opaque_gh151854_no_crash() {
   extern bool opaque();
   [[assume(opaque())]]; // no-crash
+  // expected-warning@-1 {{assumption is ignored because it contains (potential) side-effects}}
 }


### PR DESCRIPTION
This should fix the bots like:
https://lab.llvm.org/buildbot/#/builders/10/builds/10899/steps/7/logs/FAIL__Clang__cxx23-assume-attribute_cpp

```
******************** TEST 'Clang :: Analysis/cxx23-assume-attribute.cpp' FAILED ********************
Exit Code: 1
Command Output (stderr):
--
/home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/bin/clang -cc1 -internal-isystem /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib/clang/22/include -nostdsysteminc -analyze -setup-static-analyzer -std=c++23 -triple x86_64-pc-linux-gnu    -analyzer-checker=core,debug.ExprInspection -verify /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.src/clang/test/Analysis/cxx23-assume-attribute.cpp # RUN: at line 1
+ /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/bin/clang -cc1 -internal-isystem /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib/clang/22/include -nostdsysteminc -analyze -setup-static-analyzer -std=c++23 -triple x86_64-pc-linux-gnu -analyzer-checker=core,debug.ExprInspection -verify /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.src/clang/test/Analysis/cxx23-assume-attribute.cpp
error: 'expected-warning' diagnostics seen but not expected: 
  File /home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.src/clang/test/Analysis/cxx23-assume-attribute.cpp Line 75: assumption is ignored because it contains (potential) side-effects
1 error generated.
--
********************
```