### PR TITLE
[ARM] Fix inline asm register validation for vector types

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -20351,7 +20351,8 @@ static bool isIncompatibleReg(const MCPhysReg &PR, MVT VT) {
   if (PR == 0 || VT == MVT::Other)
     return false;
   return (ARM::SPRRegClass.contains(PR) && VT != MVT::f32 && VT != MVT::i32) ||
-         (ARM::DPRRegClass.contains(PR) && VT != MVT::f64);
+         (ARM::DPRRegClass.contains(PR) && VT != MVT::f64 &&
+          !VT.is64BitVector());
 }
 
 using RCPair = std::pair<unsigned, const TargetRegisterClass *>;

--- a/llvm/test/CodeGen/ARM/bad-constraint.ll
+++ b/llvm/test/CodeGen/ARM/bad-constraint.ll
@@ -1,6 +1,7 @@
 ; RUN: not llc -filetype=obj %s -o /dev/null 2>&1 | FileCheck %s
 ; CHECK:      error: couldn't allocate input reg for constraint '{d2}'
 ; CHECK-NEXT: error: couldn't allocate input reg for constraint '{s2}'
+; CHECK-NEXT: error: couldn't allocate input reg for constraint '{d3}'
 
 target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
 target triple = "armv8a-unknown-linux-gnueabihf"
@@ -23,3 +24,8 @@ entry:
   ret void
 }
 
+define void @_Z1dv() local_unnamed_addr {
+entry:
+  tail call void asm sideeffect "", "{d3}"(<16 x i8> splat (i8 -1))
+  ret void
+}

--- a/llvm/test/CodeGen/ARM/inlineasm-vec-to-double.ll
+++ b/llvm/test/CodeGen/ARM/inlineasm-vec-to-double.ll
@@ -1,0 +1,14 @@
+; RUN: llc %s -filetype=asm -o - | FileCheck %s
+
+; CHECK: vmov.i8 d3, #0xff
+
+target datalayout = "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64"
+target triple = "armv8a-unknown-linux-gnueabihf"
+
+; Function Attrs: mustprogress noimplicitfloat nounwind
+define void @cvt_vec() local_unnamed_addr {
+entry:
+  tail call void asm sideeffect "", "{d3}"(<8 x i8> splat (i8 -1))
+  ret void
+}
+


### PR DESCRIPTION
Patch allows following piece of code to be successfully compiled:
```
register uint8x8_t V asm("d3") = vdup_n_u8(0xff);
```