### PR TITLE
[flang] Minor speed-up to module file parsing

### DIFF
--- a/flang/lib/Parser/parsing.cpp
+++ b/flang/lib/Parser/parsing.cpp
@@ -285,6 +285,8 @@ void Parsing::Parse(llvm::raw_ostream &out) {
       .set_log(&log_);
   ParseState parseState{cooked()};
   parseState.set_inFixedForm(options_.isFixedForm).set_userState(&userState);
+  // Don't bother managing message buffers when parsing module files.
+  parseState.set_deferMessages(options_.isModuleFile);
   parseTree_ = program.Parse(parseState);
   CHECK(
       !parseState.anyErrorRecovery() || parseState.messages().AnyFatalError());


### PR DESCRIPTION
Module files shouldn't ever produce parsing errors, and if they did in the case of a badly-generated module file, the compiler will notice and crash.  So we can run the parser on module files with message deferral enabled, and that saves time that would otherwise be spent generating messages on failed parsing alternatives that are discarded anyway when backtracking.  It's not a big savings (single digit percentage on overall compilation time for a big application with lots of modules), but worth doing.