### PR TITLE
[llvm] annotate recently added interfaces for DLL export

### DIFF
--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -649,8 +649,8 @@ public:
   bool hasOverlappingBinding() const { return HasOverlappingBinding; }
   void setHasOverlappingBinding(bool Value) { HasOverlappingBinding = Value; }
 
-  std::optional<uint32_t>
-  findAvailableBinding(dxil::ResourceClass RC, uint32_t Space, int32_t Size) {
+  std::optional<uint32_t> findAvailableBinding(dxil::ResourceClass RC,
+                                               uint32_t Space, int32_t Size) {
     return Bindings.findAvailableBinding(RC, Space, Size);
   }
 

--- a/llvm/include/llvm/Analysis/DXILResource.h
+++ b/llvm/include/llvm/Analysis/DXILResource.h
@@ -649,7 +649,7 @@ public:
   bool hasOverlappingBinding() const { return HasOverlappingBinding; }
   void setHasOverlappingBinding(bool Value) { HasOverlappingBinding = Value; }
 
-  LLVM_ABI std::optional<uint32_t>
+  std::optional<uint32_t>
   findAvailableBinding(dxil::ResourceClass RC, uint32_t Space, int32_t Size) {
     return Bindings.findAvailableBinding(RC, Space, Size);
   }

--- a/llvm/include/llvm/CodeGen/MachineFunction.h
+++ b/llvm/include/llvm/CodeGen/MachineFunction.h
@@ -523,7 +523,7 @@ public:
     /// Extracts the numeric type id from the CallBase's callee_type Metadata,
     /// and sets CalleeTypeIds. This is used as type id for the indirect call in
     /// the call graph section.
-    CallSiteInfo(const CallBase &CB);
+    LLVM_ABI CallSiteInfo(const CallBase &CB);
   };
 
   struct CalledGlobalInfo {

--- a/llvm/include/llvm/Frontend/HLSL/HLSLBinding.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLBinding.h
@@ -13,9 +13,9 @@
 #ifndef LLVM_FRONTEND_HLSL_HLSLBINDING_H
 #define LLVM_FRONTEND_HLSL_HLSLBINDING_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ErrorHandling.h"
 

--- a/llvm/include/llvm/Frontend/HLSL/HLSLBinding.h
+++ b/llvm/include/llvm/Frontend/HLSL/HLSLBinding.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_FRONTEND_HLSL_HLSLBINDING_H
 #define LLVM_FRONTEND_HLSL_HLSLBINDING_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/DXILABI.h"
@@ -138,7 +139,7 @@ public:
   }
   /// Calculate the binding info - \c ReportOverlap will be called once for each
   /// overlapping binding.
-  BindingInfo calculateBindingInfo(
+  LLVM_ABI BindingInfo calculateBindingInfo(
       llvm::function_ref<void(const BindingInfoBuilder &Builder,
                               const Binding &Overlapping)>
           ReportOverlap);
@@ -153,7 +154,7 @@ public:
 
   /// For use in the \c ReportOverlap callback of \c calculateBindingInfo -
   /// finds a binding that the \c ReportedBinding overlaps with.
-  const Binding &findOverlapping(const Binding &ReportedBinding) const;
+  LLVM_ABI const Binding &findOverlapping(const Binding &ReportedBinding) const;
 };
 
 } // namespace hlsl

--- a/llvm/include/llvm/Frontend/HLSL/RootSignatureMetadata.h
+++ b/llvm/include/llvm/Frontend/HLSL/RootSignatureMetadata.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_FRONTEND_HLSL_ROOTSIGNATUREMETADATA_H
 #define LLVM_FRONTEND_HLSL_ROOTSIGNATUREMETADATA_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 #include "llvm/IR/Constants.h"
@@ -49,7 +50,7 @@ public:
 
 class GenericRSMetadataError : public ErrorInfo<GenericRSMetadataError> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   StringRef Message;
   MDNode *MD;
 
@@ -71,7 +72,7 @@ public:
 
 class InvalidRSMetadataFormat : public ErrorInfo<InvalidRSMetadataFormat> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   StringRef ElementName;
 
   InvalidRSMetadataFormat(StringRef ElementName) : ElementName(ElementName) {}
@@ -87,7 +88,7 @@ public:
 
 class InvalidRSMetadataValue : public ErrorInfo<InvalidRSMetadataValue> {
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   StringRef ParamName;
 
   InvalidRSMetadataValue(StringRef ParamName) : ParamName(ParamName) {}

--- a/llvm/include/llvm/Frontend/HLSL/RootSignatureMetadata.h
+++ b/llvm/include/llvm/Frontend/HLSL/RootSignatureMetadata.h
@@ -14,11 +14,11 @@
 #ifndef LLVM_FRONTEND_HLSL_ROOTSIGNATUREMETADATA_H
 #define LLVM_FRONTEND_HLSL_ROOTSIGNATUREMETADATA_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/MC/DXContainerRootSignature.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class LLVMContext;

--- a/llvm/include/llvm/Frontend/Offloading/PropertySet.h
+++ b/llvm/include/llvm/Frontend/Offloading/PropertySet.h
@@ -9,6 +9,7 @@
 /// provides helper functions to translate PropertySetRegistry from/to JSON.
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 
@@ -26,8 +27,8 @@ using PropertyValue = std::variant<uint32_t, ByteArray>;
 using PropertySet = std::map<std::string, PropertyValue>;
 using PropertySetRegistry = std::map<std::string, PropertySet>;
 
-void writePropertiesToJSON(const PropertySetRegistry &P, raw_ostream &O);
-Expected<PropertySetRegistry> readPropertiesFromJSON(MemoryBufferRef Buf);
+LLVM_ABI void writePropertiesToJSON(const PropertySetRegistry &P, raw_ostream &O);
+LLVM_ABI Expected<PropertySetRegistry> readPropertiesFromJSON(MemoryBufferRef Buf);
 
 } // namespace offloading
 } // namespace llvm

--- a/llvm/include/llvm/Frontend/Offloading/PropertySet.h
+++ b/llvm/include/llvm/Frontend/Offloading/PropertySet.h
@@ -9,8 +9,8 @@
 /// provides helper functions to translate PropertySetRegistry from/to JSON.
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 
 #include <map>
@@ -27,8 +27,10 @@ using PropertyValue = std::variant<uint32_t, ByteArray>;
 using PropertySet = std::map<std::string, PropertyValue>;
 using PropertySetRegistry = std::map<std::string, PropertySet>;
 
-LLVM_ABI void writePropertiesToJSON(const PropertySetRegistry &P, raw_ostream &O);
-LLVM_ABI Expected<PropertySetRegistry> readPropertiesFromJSON(MemoryBufferRef Buf);
+LLVM_ABI void writePropertiesToJSON(const PropertySetRegistry &P,
+                                    raw_ostream &O);
+LLVM_ABI Expected<PropertySetRegistry>
+readPropertiesFromJSON(MemoryBufferRef Buf);
 
 } // namespace offloading
 } // namespace llvm

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -2614,7 +2614,7 @@ public:
     return CreateShuffleVector(V, PoisonValue::get(V->getType()), Mask, Name);
   }
 
-  Value *CreateVectorInterleave(ArrayRef<Value *> Ops, const Twine &Name = "");
+  LLVM_ABI Value *CreateVectorInterleave(ArrayRef<Value *> Ops, const Twine &Name = "");
 
   Value *CreateExtractValue(Value *Agg, ArrayRef<unsigned> Idxs,
                             const Twine &Name = "") {

--- a/llvm/include/llvm/IR/IRBuilder.h
+++ b/llvm/include/llvm/IR/IRBuilder.h
@@ -2614,7 +2614,8 @@ public:
     return CreateShuffleVector(V, PoisonValue::get(V->getType()), Mask, Name);
   }
 
-  LLVM_ABI Value *CreateVectorInterleave(ArrayRef<Value *> Ops, const Twine &Name = "");
+  LLVM_ABI Value *CreateVectorInterleave(ArrayRef<Value *> Ops,
+                                         const Twine &Name = "");
 
   Value *CreateExtractValue(Value *Agg, ArrayRef<unsigned> Idxs,
                             const Twine &Name = "") {

--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -586,7 +586,7 @@ public:
   }
 };
 
-class DXContainerObjectFile : public ObjectFile {
+class LLVM_ABI DXContainerObjectFile : public ObjectFile {
 private:
   friend class ObjectFile;
   DXContainer Container;

--- a/llvm/include/llvm/Transforms/HipStdPar/HipStdPar.h
+++ b/llvm/include/llvm/Transforms/HipStdPar/HipStdPar.h
@@ -43,7 +43,7 @@ public:
 
 class HipStdParMathFixupPass : public PassInfoMixin<HipStdParMathFixupPass> {
 public:
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 
   static bool isRequired() { return true; }
 };

--- a/llvm/include/llvm/Transforms/Utils/SplitModuleByCategory.h
+++ b/llvm/include/llvm/Transforms/Utils/SplitModuleByCategory.h
@@ -11,8 +11,8 @@
 #ifndef LLVM_TRANSFORM_UTILS_SPLIT_MODULE_BY_CATEGORY_H
 #define LLVM_TRANSFORM_UTILS_SPLIT_MODULE_BY_CATEGORY_H
 
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/Support/Compiler.h"
 
 #include <memory>
 #include <optional>

--- a/llvm/include/llvm/Transforms/Utils/SplitModuleByCategory.h
+++ b/llvm/include/llvm/Transforms/Utils/SplitModuleByCategory.h
@@ -11,6 +11,7 @@
 #ifndef LLVM_TRANSFORM_UTILS_SPLIT_MODULE_BY_CATEGORY_H
 #define LLVM_TRANSFORM_UTILS_SPLIT_MODULE_BY_CATEGORY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 
 #include <memory>
@@ -54,7 +55,7 @@ class Function;
 ///
 /// FIXME: For now, the algorithm assumes no recursion in the input Module. This
 /// will be addressed in the near future.
-void splitModuleTransitiveFromEntryPoints(
+LLVM_ABI void splitModuleTransitiveFromEntryPoints(
     std::unique_ptr<Module> M,
     function_ref<std::optional<int>(const Function &F)> EntryPointCategorizer,
     function_ref<void(std::unique_ptr<Module> Part)> Callback);

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1279,7 +1279,7 @@ public:
 
   /// Create a new VPIRPhi for \p \I, if it is a PHINode, otherwise create a
   /// VPIRInstruction.
-  static VPIRInstruction *create(Instruction &I);
+  LLVM_ABI_FOR_TEST static VPIRInstruction *create(Instruction &I);
 
   VP_CLASSOF_IMPL(VPDef::VPIRInstructionSC)
 
@@ -1293,7 +1293,7 @@ public:
   void execute(VPTransformState &State) override;
 
   /// Return the cost of this VPIRInstruction.
-  InstructionCost computeCost(ElementCount VF,
+  LLVM_ABI_FOR_TEST InstructionCost computeCost(ElementCount VF,
                               VPCostContext &Ctx) const override;
 
   Instruction &getInstruction() const { return I; }
@@ -1332,7 +1332,7 @@ public:
 /// cast/dyn_cast/isa and execute() implementation. A single VPValue operand is
 /// allowed, and it is used to add a new incoming value for the single
 /// predecessor VPBB.
-struct VPIRPhi : public VPIRInstruction, public VPPhiAccessors {
+struct LLVM_ABI_FOR_TEST VPIRPhi : public VPIRInstruction, public VPPhiAccessors {
   VPIRPhi(PHINode &PN) : VPIRInstruction(PN) {}
 
   static inline bool classof(const VPRecipeBase *U) {

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -1293,8 +1293,8 @@ public:
   void execute(VPTransformState &State) override;
 
   /// Return the cost of this VPIRInstruction.
-  LLVM_ABI_FOR_TEST InstructionCost computeCost(ElementCount VF,
-                              VPCostContext &Ctx) const override;
+  LLVM_ABI_FOR_TEST InstructionCost
+  computeCost(ElementCount VF, VPCostContext &Ctx) const override;
 
   Instruction &getInstruction() const { return I; }
 
@@ -1332,7 +1332,8 @@ public:
 /// cast/dyn_cast/isa and execute() implementation. A single VPValue operand is
 /// allowed, and it is used to add a new incoming value for the single
 /// predecessor VPBB.
-struct LLVM_ABI_FOR_TEST VPIRPhi : public VPIRInstruction, public VPPhiAccessors {
+struct LLVM_ABI_FOR_TEST VPIRPhi : public VPIRInstruction,
+                                   public VPPhiAccessors {
   VPIRPhi(PHINode &PN) : VPIRInstruction(PN) {}
 
   static inline bool classof(const VPRecipeBase *U) {


### PR DESCRIPTION
## Purpose
This patch is one in a series of code-mods that annotate LLVM’s public interface for export. This patch annotates symbols that were recently added to LLVM and fixes incorrectly annotated symbols.

## Background
This effort is tracked in #109483. Additional context is provided in [this discourse](https://discourse.llvm.org/t/psa-annotating-llvm-public-interface/85307), and documentation for `LLVM_ABI` and related annotations is found in the LLVM repo [here](https://github.com/llvm/llvm-project/blob/main/llvm/docs/InterfaceExportAnnotations.rst).  

## Overview

The bulk of these changes were generated automatically using the [Interface Definition Scanner (IDS)](https://github.com/compnerd/ids) tool, followed formatting with `git clang-format`.

The following manual adjustments were also applied after running IDS:
- Add `LLVM_EXPORT_TEMPLATE` and `LLVM_TEMPLATE_ABI` annotations to explicitly instantiated instances of `llvm::object::SFrameParser`.

## Validation

On Windows 11:
```
cmake -B build -S llvm -G Ninja -DLLVM_ENABLE_PROJECTS="llvm;clang;clang-tools-extra;lldb;lld" -DLLVM_OPTIMIZED_TABLEGEN=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB_VIS=ON -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_BUILD_TESTS=ON -DCLANG_LINK_CLANG_DYLIB=OFF -DCMAKE_BUILD_TYPE=Release
ninja -C build
```