### PR TITLE
[lldb] Move the generic MCP code into Protocol/MCP (NFC)

### DIFF
--- a/lldb/include/lldb/Protocol/MCP/MCPError.h
+++ b/lldb/include/lldb/Protocol/MCP/MCPError.h
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef LLDB_PROTOCOL_MCP_MCPERROR_H
+#define LLDB_PROTOCOL_MCP_MCPERROR_H
+
 #include "lldb/Protocol/MCP/Protocol.h"
 #include "llvm/Support/Error.h"
 #include <string>
-
-#ifndef LLDB_PROTOCOL_MCP_MCPERROR_H
-#define LLDB_PROTOCOL_MCP_MCPERROR_H
 
 namespace lldb_protocol::mcp {
 

--- a/lldb/include/lldb/Protocol/MCP/MCPError.h
+++ b/lldb/include/lldb/Protocol/MCP/MCPError.h
@@ -1,4 +1,4 @@
-//===-- MCPError.h --------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,10 +8,12 @@
 
 #include "lldb/Protocol/MCP/Protocol.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/FormatVariadic.h"
 #include <string>
 
-namespace lldb_private::mcp {
+#ifndef LLDB_PROTOCOL_MCP_MCPERROR_H
+#define LLDB_PROTOCOL_MCP_MCPERROR_H
+
+namespace lldb_protocol::mcp {
 
 class MCPError : public llvm::ErrorInfo<MCPError> {
 public:
@@ -47,4 +49,6 @@ private:
   std::string m_uri;
 };
 
-} // namespace lldb_private::mcp
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/include/lldb/Protocol/MCP/Resource.h
+++ b/lldb/include/lldb/Protocol/MCP/Resource.h
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PROTOCOL_MCP_RESOURCE_H
+#define LLDB_PROTOCOL_MCP_RESOURCE_H
+
+#include "lldb/Protocol/MCP/Protocol.h"
+#include <vector>
+
+namespace lldb_protocol::mcp {
+
+class ResourceProvider {
+public:
+  ResourceProvider() = default;
+  virtual ~ResourceProvider() = default;
+
+  virtual std::vector<lldb_protocol::mcp::Resource> GetResources() const = 0;
+  virtual llvm::Expected<lldb_protocol::mcp::ResourceResult>
+  ReadResource(llvm::StringRef uri) const = 0;
+};
+
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/include/lldb/Protocol/MCP/Tool.h
+++ b/lldb/include/lldb/Protocol/MCP/Tool.h
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PROTOCOL_MCP_TOOL_H
+#define LLDB_PROTOCOL_MCP_TOOL_H
+
+#include "lldb/Protocol/MCP/Protocol.h"
+#include "llvm/Support/JSON.h"
+#include <string>
+
+namespace lldb_protocol::mcp {
+
+class Tool {
+public:
+  Tool(std::string name, std::string description);
+  virtual ~Tool() = default;
+
+  virtual llvm::Expected<lldb_protocol::mcp::TextResult>
+  Call(const lldb_protocol::mcp::ToolArguments &args) = 0;
+
+  virtual std::optional<llvm::json::Value> GetSchema() const {
+    return llvm::json::Object{{"type", "object"}};
+  }
+
+  lldb_protocol::mcp::ToolDefinition GetDefinition() const;
+
+  const std::string &GetName() { return m_name; }
+
+private:
+  std::string m_name;
+  std::string m_description;
+};
+
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/source/Plugins/Protocol/MCP/CMakeLists.txt
+++ b/lldb/source/Plugins/Protocol/MCP/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_lldb_library(lldbPluginProtocolServerMCP PLUGIN
-  MCPError.cpp
   ProtocolServerMCP.cpp
   Resource.cpp
   Tool.cpp

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -7,8 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "ProtocolServerMCP.h"
-#include "MCPError.h"
+#include "Resource.h"
+#include "Tool.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Protocol/MCP/MCPError.h"
+#include "lldb/Protocol/MCP/Tool.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "llvm/ADT/StringExtras.h"
@@ -18,6 +21,7 @@
 
 using namespace lldb_private;
 using namespace lldb_private::mcp;
+using namespace lldb_protocol::mcp;
 using namespace llvm;
 
 LLDB_PLUGIN_DEFINE(ProtocolServerMCP)
@@ -112,7 +116,7 @@ void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
   auto read_handle_up = m_loop.RegisterReadObject(
       io_sp,
       [this, client](MainLoopBase &loop) {
-        if (Error error = ReadCallback(*client)) {
+        if (llvm::Error error = ReadCallback(*client)) {
           LLDB_LOG_ERROR(GetLog(LLDBLog::Host), std::move(error), "{0}");
           client->read_handle_up.reset();
         }

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
@@ -9,12 +9,12 @@
 #ifndef LLDB_PLUGINS_PROTOCOL_MCP_PROTOCOLSERVERMCP_H
 #define LLDB_PLUGINS_PROTOCOL_MCP_PROTOCOLSERVERMCP_H
 
-#include "Resource.h"
-#include "Tool.h"
 #include "lldb/Core/ProtocolServer.h"
 #include "lldb/Host/MainLoop.h"
 #include "lldb/Host/Socket.h"
 #include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/Protocol/MCP/Resource.h"
+#include "lldb/Protocol/MCP/Tool.h"
 #include "llvm/ADT/StringMap.h"
 #include <thread>
 
@@ -47,8 +47,9 @@ protected:
   using NotificationHandler =
       std::function<void(const lldb_protocol::mcp::Notification &)>;
 
-  void AddTool(std::unique_ptr<Tool> tool);
-  void AddResourceProvider(std::unique_ptr<ResourceProvider> resource_provider);
+  void AddTool(std::unique_ptr<lldb_protocol::mcp::Tool> tool);
+  void AddResourceProvider(
+      std::unique_ptr<lldb_protocol::mcp::ResourceProvider> resource_provider);
 
   void AddRequestHandler(llvm::StringRef method, RequestHandler handler);
   void AddNotificationHandler(llvm::StringRef method,
@@ -99,8 +100,9 @@ private:
   std::vector<std::unique_ptr<Client>> m_clients;
 
   std::mutex m_server_mutex;
-  llvm::StringMap<std::unique_ptr<Tool>> m_tools;
-  std::vector<std::unique_ptr<ResourceProvider>> m_resource_providers;
+  llvm::StringMap<std::unique_ptr<lldb_protocol::mcp::Tool>> m_tools;
+  std::vector<std::unique_ptr<lldb_protocol::mcp::ResourceProvider>>
+      m_resource_providers;
 
   llvm::StringMap<RequestHandler> m_request_handlers;
   llvm::StringMap<NotificationHandler> m_notification_handlers;

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -5,13 +5,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "Resource.h"
-#include "MCPError.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Protocol/MCP/MCPError.h"
 #include "lldb/Target/Platform.h"
 
 using namespace lldb_private;
 using namespace lldb_private::mcp;
+using namespace lldb_protocol::mcp;
 
 namespace {
 struct DebuggerResource {

--- a/lldb/source/Plugins/Protocol/MCP/Resource.h
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.h
@@ -10,22 +10,13 @@
 #define LLDB_PLUGINS_PROTOCOL_MCP_RESOURCE_H
 
 #include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/Protocol/MCP/Resource.h"
 #include "lldb/lldb-private.h"
 #include <vector>
 
 namespace lldb_private::mcp {
 
-class ResourceProvider {
-public:
-  ResourceProvider() = default;
-  virtual ~ResourceProvider() = default;
-
-  virtual std::vector<lldb_protocol::mcp::Resource> GetResources() const = 0;
-  virtual llvm::Expected<lldb_protocol::mcp::ResourceResult>
-  ReadResource(llvm::StringRef uri) const = 0;
-};
-
-class DebuggerResourceProvider : public ResourceProvider {
+class DebuggerResourceProvider : public lldb_protocol::mcp::ResourceProvider {
 public:
   using ResourceProvider::ResourceProvider;
   virtual ~DebuggerResourceProvider() = default;

--- a/lldb/source/Plugins/Protocol/MCP/Tool.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.cpp
@@ -41,20 +41,6 @@ static lldb_protocol::mcp::TextResult createTextResult(std::string output,
 
 } // namespace
 
-Tool::Tool(std::string name, std::string description)
-    : m_name(std::move(name)), m_description(std::move(description)) {}
-
-lldb_protocol::mcp::ToolDefinition Tool::GetDefinition() const {
-  lldb_protocol::mcp::ToolDefinition definition;
-  definition.name = m_name;
-  definition.description = m_description;
-
-  if (std::optional<llvm::json::Value> input_schema = GetSchema())
-    definition.inputSchema = *input_schema;
-
-  return definition;
-}
-
 llvm::Expected<lldb_protocol::mcp::TextResult>
 CommandTool::Call(const lldb_protocol::mcp::ToolArguments &args) {
   if (!std::holds_alternative<json::Value>(args))

--- a/lldb/source/Plugins/Protocol/MCP/Tool.h
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.h
@@ -11,35 +11,15 @@
 
 #include "lldb/Core/Debugger.h"
 #include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/Protocol/MCP/Tool.h"
 #include "llvm/Support/JSON.h"
 #include <string>
 
 namespace lldb_private::mcp {
 
-class Tool {
+class CommandTool : public lldb_protocol::mcp::Tool {
 public:
-  Tool(std::string name, std::string description);
-  virtual ~Tool() = default;
-
-  virtual llvm::Expected<lldb_protocol::mcp::TextResult>
-  Call(const lldb_protocol::mcp::ToolArguments &args) = 0;
-
-  virtual std::optional<llvm::json::Value> GetSchema() const {
-    return llvm::json::Object{{"type", "object"}};
-  }
-
-  lldb_protocol::mcp::ToolDefinition GetDefinition() const;
-
-  const std::string &GetName() { return m_name; }
-
-private:
-  std::string m_name;
-  std::string m_description;
-};
-
-class CommandTool : public mcp::Tool {
-public:
-  using mcp::Tool::Tool;
+  using lldb_protocol::mcp::Tool::Tool;
   ~CommandTool() = default;
 
   virtual llvm::Expected<lldb_protocol::mcp::TextResult>

--- a/lldb/source/Protocol/MCP/CMakeLists.txt
+++ b/lldb/source/Protocol/MCP/CMakeLists.txt
@@ -1,8 +1,11 @@
 add_lldb_library(lldbProtocolMCP NO_PLUGIN_DEPENDENCIES
+  MCPError.cpp
   Protocol.cpp
+  Tool.cpp
 
   LINK_COMPONENTS
     Support
   LINK_LIBS
     lldbUtility
 )
+

--- a/lldb/source/Protocol/MCP/MCPError.cpp
+++ b/lldb/source/Protocol/MCP/MCPError.cpp
@@ -1,4 +1,4 @@
-//===-- MCPError.cpp ------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "MCPError.h"
+#include "lldb/Protocol/MCP/MCPError.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 #include <system_error>
 
-using namespace lldb_private::mcp;
+using namespace lldb_protocol::mcp;
 
 char MCPError::ID;
 char UnsupportedURI::ID;

--- a/lldb/source/Protocol/MCP/Tool.cpp
+++ b/lldb/source/Protocol/MCP/Tool.cpp
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Protocol/MCP/Tool.h"
+
+using namespace lldb_protocol::mcp;
+
+Tool::Tool(std::string name, std::string description)
+    : m_name(std::move(name)), m_description(std::move(description)) {}
+
+lldb_protocol::mcp::ToolDefinition Tool::GetDefinition() const {
+  lldb_protocol::mcp::ToolDefinition definition;
+  definition.name = m_name;
+  definition.description = m_description;
+
+  if (std::optional<llvm::json::Value> input_schema = GetSchema())
+    definition.inputSchema = *input_schema;
+
+  return definition;
+}

--- a/lldb/unittests/ProtocolServer/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/ProtocolServer/ProtocolMCPServerTest.cpp
@@ -7,15 +7,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
-#include "Plugins/Protocol/MCP/MCPError.h"
 #include "Plugins/Protocol/MCP/ProtocolServerMCP.h"
 #include "TestingSupport/Host/SocketTestUtilities.h"
 #include "TestingSupport/SubsystemRAII.h"
+#include "lldb/Core/Debugger.h"
 #include "lldb/Core/ProtocolServer.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
 #include "lldb/Host/JSONTransport.h"
 #include "lldb/Host/Socket.h"
+#include "lldb/Protocol/MCP/MCPError.h"
 #include "lldb/Protocol/MCP/Protocol.h"
 #include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
@@ -44,9 +45,9 @@ public:
 };
 
 /// Test tool that returns it argument as text.
-class TestTool : public mcp::Tool {
+class TestTool : public Tool {
 public:
-  using mcp::Tool::Tool;
+  using Tool::Tool;
 
   virtual llvm::Expected<TextResult> Call(const ToolArguments &args) override {
     std::string argument;
@@ -63,8 +64,8 @@ public:
   }
 };
 
-class TestResourceProvider : public mcp::ResourceProvider {
-  using mcp::ResourceProvider::ResourceProvider;
+class TestResourceProvider : public ResourceProvider {
+  using ResourceProvider::ResourceProvider;
 
   virtual std::vector<Resource> GetResources() const override {
     std::vector<Resource> resources;
@@ -82,7 +83,7 @@ class TestResourceProvider : public mcp::ResourceProvider {
   virtual llvm::Expected<ResourceResult>
   ReadResource(llvm::StringRef uri) const override {
     if (uri != "lldb://foo/bar")
-      return llvm::make_error<mcp::UnsupportedURI>(uri.str());
+      return llvm::make_error<UnsupportedURI>(uri.str());
 
     ResourceContents contents;
     contents.uri = "lldb://foo/bar";
@@ -96,9 +97,9 @@ class TestResourceProvider : public mcp::ResourceProvider {
 };
 
 /// Test tool that returns an error.
-class ErrorTool : public mcp::Tool {
+class ErrorTool : public Tool {
 public:
-  using mcp::Tool::Tool;
+  using Tool::Tool;
 
   virtual llvm::Expected<TextResult> Call(const ToolArguments &args) override {
     return llvm::createStringError("error");
@@ -106,9 +107,9 @@ public:
 };
 
 /// Test tool that fails but doesn't return an error.
-class FailTool : public mcp::Tool {
+class FailTool : public Tool {
 public:
-  using mcp::Tool::Tool;
+  using Tool::Tool;
 
   virtual llvm::Expected<TextResult> Call(const ToolArguments &args) override {
     TextResult text_result;


### PR DESCRIPTION
This moves all the generic MCP code into the new ProtocolMCP library so it can be shared between the MCP implementation in LLDB (built on the private API) and lldb-mcp (built on the public API).

This PR doesn't include the actual MCP server. The reason is that the transport mechanism will be different between the LLDB implementation (using sockets) and the lldb-mcp implementation (using stdio). The goal s to abstract away that difference by making the server use JSONTransport (again) but I'm saving that for a separate PR.