### PR TITLE
[BOLT] Fix unit test failures with LLVM_LINK_LLVM_DYLIB=ON

### DIFF
--- a/bolt/unittests/Core/CMakeLists.txt
+++ b/bolt/unittests/Core/CMakeLists.txt
@@ -11,6 +11,11 @@ add_bolt_unittest(CoreTests
   MemoryMaps.cpp
   DynoStats.cpp
 
+  # FIXME CoreTests uses `llvm::detail::TakeError(llvm::Error)`, but linking
+  #       to LLVMTestingSupport introduces a transitive dependency on the
+  #       dynamic LLVM library when LLVM_LINK_LLVM_DYLIB is ON.
+  ${LLVM_MAIN_SRC_DIR}/lib/Testing/Support/Error.cpp
+
   DISABLE_LLVM_LINK_LLVM_DYLIB
   )
 
@@ -20,7 +25,6 @@ target_link_libraries(CoreTests
   LLVMBOLTRewrite
   LLVMBOLTProfile
   LLVMBOLTUtils
-  LLVMTestingSupport
   )
 
 foreach (tgt ${BOLT_TARGETS_TO_BUILD})

--- a/bolt/unittests/Profile/CMakeLists.txt
+++ b/bolt/unittests/Profile/CMakeLists.txt
@@ -16,7 +16,6 @@ target_link_libraries(ProfileTests
   LLVMBOLTCore
   LLVMBOLTProfile
   LLVMTargetParser
-  LLVMTestingSupport
   )
 
 foreach (tgt ${BOLT_TARGETS_TO_BUILD})


### PR DESCRIPTION
When LLVM_LINK_LLVM_DYLIB is ON, `check-bolt` target reports unit test failures:

    BOLT-Unit :: Core/./CoreTests/failed_to_discover_tests_from_gtest
    BOLT-Unit :: Profile/./ProfileTests/failed_to_discover_tests_from_gtest

The reason is that when llvm-lit runs a unit-test executable:

    /path/to/CoreTests --gtest_list_tests '--gtest_filter=-*DISABLED_*'

an assertion is triggered with the following message:

    LLVM ERROR: Option 'default' already exists!

This assertion triggers when the initializer of defaultListDAGScheduler defined at SelectionDAGISel.cpp:219 is called as a statically-linked function after already being called during the initialization of libLLVM.

The issue can be traced down to LLVMTestingSupport library which depends on libLLVM as neither COMPONENT_LIB nor DISABLE_LLVM_LINK_LLVM_DYLIB is specified in a call to `add_llvm_library(LLVMTestingSupport ...)`.

Specifying DISABLE_LLVM_LINK_LLVM_DYLIB for LLVMTestingSupport makes Clang unit test fail and COMPONENT_LIB is probably inappropriate for a testing-specific library, thus as a workaround, added Error.cpp source from LLVMTestingSupport directly to the list of source files of CoreTests target (as it depends on `llvm::detail::TakeError(llvm::Error)`) and removed LLVMTestingSupport from the list of dependencies of ProfileTests.