### PR TITLE
[HLSL][DirectX] Add the `Qdx-rootsignature-strip` driver option

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -478,6 +478,9 @@ CODEGENOPT(StaticClosure, 1, 0, Benign)
 /// Assume that UAVs/SRVs may alias
 CODEGENOPT(ResMayAlias, 1, 0, Benign)
 
+/// Omit the root signature from produced DXContainer
+CODEGENOPT(HLSLRootSigStrip, 1, 0, Benign)
+
 /// Controls how unwind v2 (epilog) information should be generated for x64
 /// Windows.
 ENUM_CODEGENOPT(WinX64EHUnwindV2, WinX64EHUnwindV2Mode,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9354,6 +9354,16 @@ def res_may_alias : Option<["/", "-"], "res-may-alias", KIND_FLAG>,
   Visibility<[DXCOption, ClangOption, CC1Option]>,
   HelpText<"Assume that UAVs/SRVs may alias">,
   MarshallingInfoFlag<CodeGenOpts<"ResMayAlias">>;
+def Qdx_rootsignature_strip : Option<["-"], "Qdx-rootsignature-strip", KIND_FLAG>,
+  Group<dxc_Group>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Omit the root signature from produced DXContainer">,
+  MarshallingInfoFlag<CodeGenOpts<"HLSLRootSigStrip">>;
+def dxc_Qstrip_rootsignature :
+  Option<["/", "-"], "Qstrip-rootsignature", KIND_FLAG>,
+  Alias<Qdx_rootsignature_strip>,
+  Group<dxc_Group>,
+  Visibility<[DXCOption]>;
 def target_profile : DXCJoinedOrSeparate<"T">, MetaVarName<"<profile>">,
   HelpText<"Set target profile">,
   Values<"ps_6_0, ps_6_1, ps_6_2, ps_6_3, ps_6_4, ps_6_5, ps_6_6, ps_6_7,"

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3790,18 +3790,18 @@ static void RenderOpenCLOptions(const ArgList &Args, ArgStringList &CmdArgs,
 
 static void RenderHLSLOptions(const ArgList &Args, ArgStringList &CmdArgs,
                               types::ID InputType) {
-  const unsigned ForwardedArguments[] = {
-      options::OPT_dxil_validator_version,
-      options::OPT_res_may_alias,
-      options::OPT_D,
-      options::OPT_I,
-      options::OPT_O,
-      options::OPT_emit_llvm,
-      options::OPT_emit_obj,
-      options::OPT_disable_llvm_passes,
-      options::OPT_fnative_half_type,
-      options::OPT_hlsl_entrypoint,
-      options::OPT_fdx_rootsignature_version};
+  const unsigned ForwardedArguments[] = {options::OPT_dxil_validator_version,
+                                         options::OPT_res_may_alias,
+                                         options::OPT_D,
+                                         options::OPT_I,
+                                         options::OPT_O,
+                                         options::OPT_emit_llvm,
+                                         options::OPT_emit_obj,
+                                         options::OPT_disable_llvm_passes,
+                                         options::OPT_fnative_half_type,
+                                         options::OPT_hlsl_entrypoint,
+                                         options::OPT_fdx_rootsignature_version,
+                                         options::OPT_Qdx_rootsignature_strip};
   if (!types::isHLSL(InputType))
     return;
   for (const auto &Arg : ForwardedArguments)

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -304,6 +304,12 @@ HLSLToolChain::TranslateArgs(const DerivedArgList &Args, StringRef BoundArch,
       A->claim();
       continue;
     }
+    if (A->getOption().getID() == options::OPT_dxc_Qstrip_rootsignature) {
+      DAL->AddFlagArg(nullptr,
+                      Opts.getOption(options::OPT_Qdx_rootsignature_strip));
+      A->claim();
+      continue;
+    }
     if (A->getOption().getID() == options::OPT__SLASH_O) {
       StringRef OStr = A->getValue();
       if (OStr == "d") {

--- a/clang/test/CodeGenHLSL/RootSignature.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature.hlsl
@@ -1,7 +1,9 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -emit-llvm -o - %s | FileCheck %s
 
-// CHECK: !dx.rootsignatures = !{![[#EMPTY_ENTRY:]], ![[#DT_ENTRY:]],
+// CHECK: !dx.rootsignatures = !{![[#LOWER_INFO:]], ![[#EMPTY_ENTRY:]], ![[#DT_ENTRY:]],
 // CHECK-SAME: ![[#RF_ENTRY:]], ![[#RC_ENTRY:]], ![[#RD_ENTRY:]], ![[#SS_ENTRY:]]}
+
+// CHECK: ![[#LOWER_INFO]] = !{i1 false}
 
 // CHECK: ![[#EMPTY_ENTRY]] = !{ptr @EmptyEntry, ![[#EMPTY:]], i32 2}
 // CHECK: ![[#EMPTY]] = !{}

--- a/clang/test/CodeGenHLSL/dx-rootsignature-strip.hlsl
+++ b/clang/test/CodeGenHLSL/dx-rootsignature-strip.hlsl
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -Qdx-rootsignature-strip -triple dxil-pc-shadermodel6.3-compute -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK,FLAG
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-compute -emit-llvm %s -o - | FileCheck %s --check-prefixes=CHECK,NOFLAG
+
+// CHECK: !dx.rootsignatures = !{![[#LOWER_INFO:]], ![[#EMPTY_ENTRY:]]}
+// FLAG: ![[#LOWER_INFO]] = !{i1 true}
+// NOFLAG: ![[#LOWER_INFO]] = !{i1 false}
+
+// Ensure root signature metadata is still generated in either case
+// CHECK: ![[#EMPTY_ENTRY]] = !{ptr @EmptyEntry, ![[#EMPTY:]], i32 2}
+// CHECK: ![[#EMPTY]] = !{}
+
+[shader("compute"), RootSignature("")]
+[numthreads(1,1,1)]
+void EmptyEntry() {}
+

--- a/clang/test/Driver/dxc_Qstrip-rootsignature.hlsl
+++ b/clang/test/Driver/dxc_Qstrip-rootsignature.hlsl
@@ -1,0 +1,17 @@
+// RUN: %clang_dxc -Qstrip-rootsignature -T cs_6_3 -HV 202x -Vd -Xclang -emit-llvm %s | FileCheck %s --check-prefixes=CHECK,FLAG
+// RUN: %clang_dxc -T cs_6_3 -HV 202x -Vd -Xclang -emit-llvm %s | FileCheck %s --check-prefixes=CHECK,NOFLAG
+
+// Test to demonstrate that we can specify when to strip the root signature
+// in its metadata
+
+// CHECK: !dx.rootsignatures = !{![[#LOWER_INFO:]], ![[#EMPTY_ENTRY:]]}
+// FLAG: ![[#LOWER_INFO]] = !{i1 true}
+// NOFLAG: ![[#LOWER_INFO]] = !{i1 false}
+
+// Ensure root signature metadata is still generated in either case
+// CHECK: ![[#EMPTY_ENTRY]] = !{ptr @EmptyEntry, ![[#EMPTY:]], i32 2}
+// CHECK: ![[#EMPTY]] = !{}
+
+[shader("compute"), RootSignature("")]
+[numthreads(1,1,1)]
+void EmptyEntry() {}

--- a/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
+++ b/llvm/include/llvm/Analysis/DXILMetadataAnalysis.h
@@ -37,6 +37,7 @@ struct ModuleMetadataInfo {
   Triple::EnvironmentType ShaderProfile{Triple::UnknownEnvironment};
   VersionTuple ValidatorVersion{};
   SmallVector<EntryProperties> EntryPropertyVec{};
+  bool StripRootSignature{true};
   void print(raw_ostream &OS) const;
 };
 

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -154,6 +154,10 @@ void DXContainerGlobals::addRootSignature(Module &M,
   dxil::ModuleMetadataInfo &MMI =
       getAnalysis<DXILMetadataAnalysisWrapperPass>().getModuleMetadata();
 
+  // Compiler flag denotes to not output the root signature part (RTS0)
+  if (MMI.StripRootSignature)
+    return;
+
   // Root Signature in Library don't compile to DXContainer.
   if (MMI.ShaderProfile == llvm::Triple::Library)
     return;

--- a/llvm/lib/Target/DirectX/DXILRootSignature.cpp
+++ b/llvm/lib/Target/DirectX/DXILRootSignature.cpp
@@ -527,8 +527,17 @@ analyzeModule(Module &M) {
   NamedMDNode *RootSignatureNode = M.getNamedMetadata("dx.rootsignatures");
   if (RootSignatureNode == nullptr)
     return RSDMap;
+  if (RootSignatureNode->getNumOperands() == 0) {
+    reportError(Ctx, "Invalid Root Signature metadata - expected lowering "
+                     "info and then Root Signature operands.");
+    return RSDMap;
+  }
 
-  for (const auto &RSDefNode : RootSignatureNode->operands()) {
+  // Ignore the lowering info metadata
+  auto Begin = std::next(RootSignatureNode->op_begin());
+  auto RSNodes = iterator_range(Begin, RootSignatureNode->op_end());
+
+  for (const auto &RSDefNode : RSNodes) {
     if (RSDefNode->getNumOperands() != 3) {
       reportError(Ctx, "Invalid Root Signature metadata - expected function, "
                        "signature, and version.");

--- a/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.0.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.0.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel6.0-vertex"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:   Function Shader Stage : vertex
 ; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.8.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/dxilVer-1.8.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel6.8-compute"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:   Function Shader Stage : compute
 ; CHECK-NEXT: NumThreads: 1,2,1
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/entry-properties.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/entry-properties.ll
@@ -14,6 +14,7 @@ target triple = "dxil-pc-shadermodel6.8-library"
 ; CHECK-NEXT: entry_cs
 ; CHECK-NEXT:   Function Shader Stage : compute
 ; CHECK-NEXT:   NumThreads: 1,2,1
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry_as() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/keep-rootsignature.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/keep-rootsignature.ll
@@ -1,0 +1,24 @@
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.0-compute"
+
+; CHECK: Shader Model Version : 6.0
+; CHECK-NEXT: DXIL Version : 1.0
+; CHECK-NEXT: Shader Stage : compute
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:   Function Shader Stage : compute
+; CHECK-NEXT:   NumThreads: 1,1,1
+; CHECK-NEXT: Strip Root Signature: 0
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 false} ; don't strip root signature
+!2 = !{ ptr @entry, !3, i32 2 } ; function, root signature, version
+!3 = !{} ; empty root signature

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-as.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-as.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel6-amplification"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : amplification
 ; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs-val-ver-0.0.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs-val-ver-0.0.ll
@@ -20,4 +20,5 @@ attributes #0 = { noinline nounwind "exp-shader"="cs" "hlsl.numthreads"="1,2,1" 
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : compute
 ; CHECK-NEXT:   NumThreads: 1,2,1
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-cs.ll
@@ -9,6 +9,7 @@ target triple = "dxil-pc-shadermodel6.6-compute"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : compute
 ; CHECK-NEXT:   NumThreads: 1,2,1
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-gs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-gs.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel6.6-geometry"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : geometry
 ; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-hs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-hs.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel6.6-hull"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : hull
 ; CHECK-NEXT:  NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ms.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ms.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel6.6-mesh"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : mesh
 ; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ps.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-ps.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel5.0-pixel"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : pixel
 ; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-vs.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/shaderModel-vs.ll
@@ -8,6 +8,7 @@ target triple = "dxil-pc-shadermodel-vertex"
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:  Function Shader Stage : vertex
 ; CHECK-NEXT:   NumThreads: 0,0,0
+; CHECK-NEXT: Strip Root Signature: 1
 ; CHECK-EMPTY:
 
 define void @entry() #0 {

--- a/llvm/test/Analysis/DXILMetadataAnalysis/strip-rootsignature.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/strip-rootsignature.ll
@@ -1,0 +1,25 @@
+
+; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
+target triple = "dxil-pc-shadermodel6.0-compute"
+
+; CHECK: Shader Model Version : 6.0
+; CHECK-NEXT: DXIL Version : 1.0
+; CHECK-NEXT: Shader Stage : compute
+; CHECK-NEXT: Validator Version : 0
+; CHECK-NEXT: entry
+; CHECK-NEXT:   Function Shader Stage : compute
+; CHECK-NEXT:   NumThreads: 1,1,1
+; CHECK-NEXT: Strip Root Signature: 1
+; CHECK-EMPTY:
+
+define void @entry() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 true} ; don't strip root signature
+!2 = !{ ptr @entry, !3, i32 2 } ; function, root signature, version
+!3 = !{} ; empty root signature

--- a/llvm/test/Analysis/DXILMetadataAnalysis/strip-rootsignature.ll
+++ b/llvm/test/Analysis/DXILMetadataAnalysis/strip-rootsignature.ll
@@ -1,4 +1,3 @@
-
 ; RUN: opt -S -passes="print<dxil-metadata>" -disable-output %s 2>&1 | FileCheck %s
 target triple = "dxil-pc-shadermodel6.0-compute"
 
@@ -20,6 +19,6 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 !dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
-!0 = !{i1 true} ; don't strip root signature
+!0 = !{i1 true} ; strip root signature
 !2 = !{ ptr @entry, !3, i32 2 } ; function, root signature, version
 !3 = !{} ; empty root signature

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-AllValidFlagCombinations.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-AllValidFlagCombinations.ll
@@ -9,7 +9,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-AllValidFlagCombinationsV1.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-AllValidFlagCombinationsV1.ll
@@ -9,7 +9,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 1 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6, !7 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-Flag.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-Flag.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6, !7 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-NumDescriptors.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-NumDescriptors.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6}

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-RangeType.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-RangeType.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6, !7 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-RegisterSpace.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable-Invalid-RegisterSpace.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6, !7 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-DescriptorTable.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"DescriptorTable", i32 0, !6, !7 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-function.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-function.ll
@@ -17,7 +17,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2, !5} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-value.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-is-not-value.ll
@@ -17,7 +17,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2, !5} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-no-root-element-list.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-no-root-element-list.ll
@@ -17,7 +17,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2, !5} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, null, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-root-element-not-mdnode.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error-root-element-not-mdnode.ll
@@ -17,7 +17,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2, !5} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, i32 -1, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Error.ll
@@ -14,5 +14,6 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!1} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !1} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !1= !{ !"RootFlags" } ; function, root signature

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags-Error.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags-Error.ll
@@ -14,7 +14,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"NOTRootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Flags.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-MultipleEntryFunctions.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-MultipleEntryFunctions.ll
@@ -15,7 +15,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2, !5} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-NullFunction-Error.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-NullFunction-Error.ll
@@ -12,7 +12,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2, !5} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2, !5} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Parameters-Invalid-ParameterIsNotString.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Parameters-Invalid-ParameterIsNotString.ll
@@ -13,7 +13,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!0}
-!0 = !{ ptr @main, !1, i32 2 }
-!1 = !{ !2 }
-!2 = !{ i32 0 }
+!dx.rootsignatures = !{!0, !1}
+!0 = !{i1 0} ; strip root signature
+!1 = !{ ptr @main, !2, i32 2 }
+!2 = !{ !3 }
+!3 = !{ i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Parameters-Validation-Error.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Parameters-Validation-Error.ll
@@ -14,7 +14,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootConstants", i32 255, i32 1, i32 2, i32 3 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Parameters.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Parameters.ll
@@ -10,7 +10,8 @@ entry:
 
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4, !5, !6, !7 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants-Invalid-Num32BitValues.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants-Invalid-Num32BitValues.ll
@@ -10,7 +10,8 @@ entry:
   ret void
 }
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootConstants", i32 0, i32 1, i32 2, !"Invalid" }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants-Invalid-RegisterSpace.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants-Invalid-RegisterSpace.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootConstants", i32 0, i32 1, !"Invalid", i32 3 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants-Invalid-ShaderRegister.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants-Invalid-ShaderRegister.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootConstants", i32 0, !"Invalid", i32 2, i32 3 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootConstants.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootConstants", i32 0, i32 1, i32 2, i32 3 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-Flags.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-Flags.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootCBV", i32 0, i32 1, i32 2, i32 3  }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-Multiple-Flags.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-Multiple-Flags.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootCBV", i32 0, i32 1, i32 2, i32 10 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-RegisterKind.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-RegisterKind.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"Invalid", i32 0, i32 1, i32 2, i32 3  }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-RegisterSpace.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-RegisterSpace.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootCBV", i32 0, i32 1, i32 4294967280, i32 0  }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-RegisterValue.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor-Invalid-RegisterValue.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootCBV", i32 0, i32 4294967295, i32 2, i32 3  }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootCBV", i32 0, i32 1, i32 2, i32 8  }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor_V1.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootDescriptor_V1.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 1 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"RootCBV", i32 0, i32 1, i32 2, i32 2  }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootElement-Error.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootElement-Error.ll
@@ -14,6 +14,7 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !"NOTRootElements" } ; list of root signature elements

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootFlags-VisibilityValidationError.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-RootFlags-VisibilityValidationError.ll
@@ -14,7 +14,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 2147487744 } ; 1 = allow_input_assembler_input_layout

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-AddressU.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-AddressU.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 666, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-AddressV.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-AddressV.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 666, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-AddressW.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-AddressW.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 666, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-BorderColor.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-BorderColor.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 666, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-ComparisonFunc.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-ComparisonFunc.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 666, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-Filter.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-Filter.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 45, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MaxAnisotropy.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MaxAnisotropy.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 666, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MaxLod.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MaxLod.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 0x7FF8000000000000, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MinLod.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MinLod.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float 0x7FF8000000000000, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MinLopBias.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-MinLopBias.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 6.660000e+02, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-RegisterSpace.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-RegisterSpace.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 4294967280, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-ShaderRegister.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-ShaderRegister.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 4294967295, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-ShaderVisibility.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers-Invalid-ShaderVisibility.ll
@@ -13,7 +13,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 666 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-StaticSamplers.ll
@@ -12,7 +12,8 @@ entry:
 attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
 
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0} ; strip root signature
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !5 } ; list of root signature elements
 !5 = !{ !"StaticSampler", i32 4, i32 2, i32 3, i32 5, float 0x3FF6CCCCC0000000, i32 9, i32 3, i32 2, float -1.280000e+02, float 1.280000e+02, i32 42, i32 0, i32 0 }

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Stripped.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Stripped.ll
@@ -1,0 +1,31 @@
+; RUN: opt %s -dxil-embed -dxil-globals -S -o - | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+
+target triple = "dxil-unknown-shadermodel6.0-compute"
+
+define void @main() #0 {
+entry:
+  ret void
+}
+attributes #0 = { "hlsl.numthreads"="1,1,1" "hlsl.shader"="compute" }
+
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 true} ; strip root signature
+!2 = !{ ptr @main, !3, i32 2 } ; function, root signature
+!3 = !{ !5 } ; list of root signature elements
+!5 = !{ !"DescriptorTable", i32 0, !6, !7 }
+!6 = !{ !"SRV", i32 1, i32 1, i32 0, i32 -1, i32 4 }
+!7 = !{ !"UAV", i32 5, i32 1, i32 10, i32 5, i32 2 }
+
+; Check "required" parts are present
+; DXC: - Name:             DXIL
+; DXC: - Name:             HASH
+; DXC: - Name:             PSV0
+
+; CHECK:     @dx.dxil = private constant
+; CHECK:     @dx.hash = private constant
+; CHECK:     @dx.psv0 = private constant
+
+; But no RTS0 (root signature) part
+; DXC-NOT: - Name:            RTS0
+; CHECK-NOT: @dx.rts0 = private constant

--- a/llvm/test/CodeGen/DirectX/strip-rootsignatures.ll
+++ b/llvm/test/CodeGen/DirectX/strip-rootsignatures.ll
@@ -12,7 +12,8 @@ entry:
 ; CHECK-NOT: !dx.rootsignatures
 ; CHECK-NOT: {{^!}}
 
-!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!dx.rootsignatures = !{!0, !2} ; list of function/root signature pairs
+!0 = !{i1 0}
 !2 = !{ ptr @main, !3, i32 2 } ; function, root signature
 !3 = !{ !4 } ; list of root signature elements
 !4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout


### PR DESCRIPTION
This pr adds the `Qdx-rootsignature-strip` to the `Clang` and `CC1` driver options.
It also adds `Qstrip-rootsignature` as the DXC compatible alias.

It implements this by storing the flag information as part of the named `dx.rootsignature` metadata as the first operand. This allows us to contain all root signature associated metadata field in a single node. Given the nature of its construction this will also be easily extendible to any other root signature specific metadata in the future.

The other option is to have a separate named metadata like `dx.striprootsignature`, similar to `dx.resmayalias`. But this becomes significantly less handy if any more options are added.

Relevant added tests are:

- `clang/test/CodeGenHLSL/dx-rootsignature-strip.hlsl`
- `clang/test/Driver/dxc_Qstrip-rootsignature.hlsl`
- `llvm/test/Analysis/DXILMetadataAnalysis/keep-rootsignature.ll`
- `llvm/test/Analysis/DXILMetadataAnalysis/strip-rootsignature.ll`
- `llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Stripped.ll`

All other test modifications are just to account for changes in metadata format.

Resolves: https://github.com/llvm/llvm-project/issues/150275.