### PR TITLE
[lldb] Preserve original symbol of Mangled function names

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2509,7 +2509,9 @@ Function *DWARFASTParserClang::ParseFunctionFromDWARF(
       // If the mangled name is not present in the DWARF, generate the
       // demangled name using the decl context. We skip if the function is
       // "main" as its name is never mangled.
-      func_name.SetValue(ConstructDemangledNameFromDWARF(die));
+      func_name.SetDemangledName(ConstructDemangledNameFromDWARF(die));
+      // Ensure symbol is preserved (as the mangled name).
+      func_name.SetMangledName(ConstString(name));
     } else
       func_name.SetValue(ConstString(name));
 

--- a/lldb/test/API/lang/cpp/extern_c/main.cpp
+++ b/lldb/test/API/lang/cpp/extern_c/main.cpp
@@ -8,7 +8,7 @@ extern "C"
 
 int foo()
 {
-    puts("foo");
+    puts("foo"); //% self.expect("image lookup -v -a $pc", substrs=['mangled = "foo"'])
     return 2;
 }
 

--- a/lldb/test/API/lang/cpp/extern_c/main.cpp
+++ b/lldb/test/API/lang/cpp/extern_c/main.cpp
@@ -8,8 +8,10 @@ extern "C"
 
 int foo()
 {
-    puts("foo"); //% self.expect("image lookup -v -a $pc", substrs=['mangled = "foo"'])
-    return 2;
+  puts("foo"); //% self.expect("image lookup -va $pc",
+  //%                          substrs=[' name = "::foo()"',
+  //%                                   ' mangled = "foo"'])
+  return 2;
 }
 
 int main (int argc, char const *argv[], char const *envp[])

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-address-ranges.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-address-ranges.s
@@ -11,7 +11,7 @@
 # RUN: %lldb %t -o "image lookup -a 0x48000 -v" -o exit | FileCheck %s
 
 # CHECK:   CompileUnit: id = {0x00000001}, file = "/tmp/a.cc", language = "c++"
-# CHECK:      Function: id = {0x0000006a}, name = "::_start({{.*}})", range = [0x0000000000048000-0x000000000004800c)
+# CHECK:      Function: id = {0x0000006a}, name = "::_start({{.*}})", mangled = "_start", range = [0x0000000000048000-0x000000000004800c)
 # CHECK:     LineEntry: [0x0000000000048000-0x000000000004800a): /tmp/a.cc:4
 # CHECK:        Symbol: id = {0x00000002}, range = [0x0000000000048000-0x000000000004800c), name="_start"
 # CHECK:      Variable: id = {0x00000075}, name = "v1", {{.*}} decl = a.cc:4


### PR DESCRIPTION
Fixes a bug that surfaces in frame recognizers.

Details about the bug:

A new frame recognizer is configured to match a specific symbol (`swift_willThrow`). This is an `extern "C"` symbol defined in a C++ source file. When Swift is built with debug info, the function `ParseFunctionFromDWARF` will use the debug info to construct a function name that looks like a C++ declaration (`::swift_willThrow(void *, SwiftError**)`). The `Mangled` instance will have this string as its `m_demangled` field, and have _no_ string for its `m_mangled` field.

The result is the frame recognizer would not match the symbol to the name (`swift_willThrow` != `::swift_willThrow(void *, SwiftError**)`.

By changing `ParseFunctionFromDWARF` to assign both a demangled name and a mangled, frame recognizers can successfully match symbols in this configuration.