### PR TITLE
[Flang] Legalize the hlfir.exactly_once operation

### DIFF
--- a/flang/test/HLFIR/bufferize-exactly_once.f90
+++ b/flang/test/HLFIR/bufferize-exactly_once.f90
@@ -1,0 +1,20 @@
+! RUN: bbc -emit-hlfir %s -o - | FileCheck %s
+
+program main
+  call test06()
+  print *,'pass'
+end program main
+
+subroutine test06()
+  type ty1
+     integer ,allocatable :: a(:,:,:)
+  end type ty1
+  type(ty1) :: str(1)
+  integer ,allocatable :: b(:,:,:)
+  allocate(str(1)%a(1,1,1),b(1,1,1))
+  b=1
+  write(6,*) "b                                 = ", b
+  write(6,*) "reshape((/(b,jj=1,1)/),(/1,1,1/)) = ", reshape((/(b,jj=1,1)/),(/1,1,1/))
+  where ((/.true./)) str=(/(ty1(reshape((/(b,jj=1,1)/),(/1,1,1/))),ii=1,1)/)
+  ! CHECK: hlfir.exactly_once : !hlfir.expr<1x1x1xi32>
+end subroutine test06


### PR DESCRIPTION
When reshape is used with allocatable components in derived types within a where construct, a hlfir.exactly_once operation is generated. This commit implements the conversion pattern for it in the HLFIR bufferization pass.

Fixes #130532