### PR TITLE
[libcxx] [ci] Update Clang on Windows

### DIFF
--- a/.github/workflows/libcxx-build-and-test.yaml
+++ b/.github/workflows/libcxx-build-and-test.yaml
@@ -260,11 +260,11 @@ jobs:
       - name: Install a current LLVM
         if: ${{ matrix.mingw != true }}
         run: |
-          choco install -y llvm --version=19.1.7 --allow-downgrade
+          choco install -y llvm --version=20.1.8 --allow-downgrade
       - name: Install llvm-mingw
         if: ${{ matrix.mingw == true }}
         run: |
-          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-x86_64.zip
+          curl -LO https://github.com/mstorsjo/llvm-mingw/releases/download/20250709/llvm-mingw-20250709-ucrt-x86_64.zip
           powershell Expand-Archive llvm-mingw*.zip -DestinationPath .
           del llvm-mingw*.zip
           mv llvm-mingw* c:\llvm-mingw


### PR DESCRIPTION
Update clang-cl/LLVM to 20.1.8.

Update to llvm-mingw 20250709 (with also is built on LLVM 20.1.8). This release of llvm-mingw is the first release to be built with PGO, making it significantly faster for the CI runs (on par with the clang-cl cases); running the current tests in around 1 h rather than 1 h 20 min.