### PR TITLE
[CI][NFC] Explicitly add libcxx/libcxxabi/libunwind to excludes

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -100,6 +100,9 @@ EXCLUDE_WINDOWS = {
     "libc",  # No Windows Support.
     "lldb",  # TODO(issues/132800): Needs environment setup.
     "bolt",  # No Windows Support.
+    "libcxx",
+    "libcxxabi",
+    "libunwind",
 }
 
 # These are projects that we should test if the project itself is changed but
@@ -118,6 +121,9 @@ EXCLUDE_MAC = {
     "lldb",
     "openmp",
     "polly",
+    "libcxx",
+    "libcxxabi",
+    "libunwind",
 }
 
 PROJECT_CHECK_TARGETS = {

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -45,16 +45,14 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["project_check_targets"],
             "check-clang check-clang-tools check-lld check-llvm check-mlir check-polly",
         )
-        self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
-        )
+        self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(
             env_variables["runtimes_check_targets"],
             "",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],
-            "check-cxx check-cxxabi check-unwind",
+            "",
         )
 
     def test_llvm_mac(self):
@@ -69,16 +67,14 @@ class TestComputeProjects(unittest.TestCase):
             env_variables["project_check_targets"],
             "check-clang check-clang-tools check-lld check-llvm check-mlir",
         )
-        self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
-        )
+        self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(
             env_variables["runtimes_check_targets"],
             "",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],
-            "check-cxx check-cxxabi check-unwind",
+            "",
         )
 
     def test_clang(self):
@@ -119,16 +115,14 @@ class TestComputeProjects(unittest.TestCase):
         self.assertEqual(
             env_variables["project_check_targets"], "check-clang check-clang-tools"
         )
-        self.assertEqual(
-            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
-        )
+        self.assertEqual(env_variables["runtimes_to_build"], "")
         self.assertEqual(
             env_variables["runtimes_check_targets"],
             "",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],
-            "check-cxx check-cxxabi check-unwind",
+            "",
         )
         self.assertEqual(env_variables["enable_cir"], "OFF")
 
@@ -298,18 +292,15 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["runtimes_to_build"],
-            "libcxx;libcxxabi;libunwind",
+            "",
         )
         self.assertEqual(
             env_variables["runtimes_check_targets"],
             "",
         )
-        # TODO(boomanaiden154): We should not be emitting these on Windows.
-        # It does not currently impact anything because we do not build the
-        # runtimes on Windows though.
         self.assertEqual(
             env_variables["runtimes_check_targets_needs_reconfig"],
-            "check-cxx check-cxxabi check-unwind",
+            "",
         )
 
     def test_lldb(self):


### PR DESCRIPTION
This patch adds libcxx/libcxxabi/libunwind to the excludes list in compute_projects.py for both Windows and MacOS. Neither of these platforms have ever built the runtimes as the scripts do not have support for it. Explicitly disable them so that compute_projects_test.py is more consistent.