### PR TITLE
[lldb] Support the Python stable C API in PythonString::AsUTF8

### DIFF
--- a/lldb/bindings/python/python-wrapper.swig
+++ b/lldb/bindings/python/python-wrapper.swig
@@ -173,7 +173,7 @@ bool lldb_private::python::SWIGBridge::LLDBSwigPythonCallTypeScript(
   else
     result = pfunc(value_arg, dict, SWIGBridge::ToSWIGWrapper(*options_sp));
 
-  retval = result.Str().GetString().str();
+  retval = result.Str().GetString();
 
   return true;
 }
@@ -604,7 +604,7 @@ lldb_private::python::SWIGBridge::LLDBSwigPythonGetRepeatCommandForScriptedComma
   if (result.IsNone())
     return std::nullopt;
 
-  return result.Str().GetString().str();
+  return result.Str().GetString();
 }
 
 StructuredData::DictionarySP
@@ -807,7 +807,7 @@ bool lldb_private::python::SWIGBridge::LLDBSWIGPythonRunScriptKeywordProcess(
 
   auto result = pfunc(SWIGBridge::ToSWIGWrapper(process), dict);
 
-  output = result.Str().GetString().str();
+  output = result.Str().GetString();
 
   return true;
 }
@@ -831,7 +831,7 @@ std::optional<std::string> lldb_private::python::SWIGBridge::LLDBSWIGPythonRunSc
 
   auto result = pfunc(SWIGBridge::ToSWIGWrapper(std::move(thread)), dict);
 
-  return result.Str().GetString().str();
+  return result.Str().GetString();
 }
 
 bool lldb_private::python::SWIGBridge::LLDBSWIGPythonRunScriptKeywordTarget(
@@ -854,7 +854,7 @@ bool lldb_private::python::SWIGBridge::LLDBSWIGPythonRunScriptKeywordTarget(
 
   auto result = pfunc(SWIGBridge::ToSWIGWrapper(target), dict);
 
-  output = result.Str().GetString().str();
+  output = result.Str().GetString();
 
   return true;
 }
@@ -878,7 +878,7 @@ std::optional<std::string> lldb_private::python::SWIGBridge::LLDBSWIGPythonRunSc
 
   auto result = pfunc(SWIGBridge::ToSWIGWrapper(std::move(frame)), dict);
 
-  return result.Str().GetString().str();
+  return result.Str().GetString();
 }
 
 bool lldb_private::python::SWIGBridge::LLDBSWIGPythonRunScriptKeywordValue(
@@ -901,7 +901,7 @@ bool lldb_private::python::SWIGBridge::LLDBSWIGPythonRunScriptKeywordValue(
 
   auto result = pfunc(SWIGBridge::ToSWIGWrapper(value), dict);
 
-  output = result.Str().GetString().str();
+  output = result.Str().GetString();
 
   return true;
 }

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.h
@@ -460,9 +460,9 @@ public:
 
   static bool Check(PyObject *py_obj);
 
-  llvm::StringRef GetString() const; // safe, empty string on error
+  std::string GetString() const; // safe, empty string on error
 
-  llvm::Expected<llvm::StringRef> AsUTF8() const;
+  llvm::Expected<std::string> AsUTF8() const;
 
   size_t GetSize() const;
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -2715,8 +2715,8 @@ bool ScriptInterpreterPythonImpl::GetShortHelpForCommandObject(
 
   if (py_return.IsAllocated() && PythonString::Check(py_return.get())) {
     PythonString py_string(PyRefType::Borrowed, py_return.get());
-    llvm::StringRef return_data(py_string.GetString());
-    dest.assign(return_data.data(), return_data.size());
+    std::string return_data = py_string.GetString();
+    dest.assign(return_data.c_str(), return_data.size());
     return true;
   }
 
@@ -2996,8 +2996,8 @@ bool ScriptInterpreterPythonImpl::GetLongHelpForCommandObject(
   bool got_string = false;
   if (py_return.IsAllocated() && PythonString::Check(py_return.get())) {
     PythonString str(PyRefType::Borrowed, py_return.get());
-    llvm::StringRef str_data(str.GetString());
-    dest.assign(str_data.data(), str_data.size());
+    std::string str_data = str.GetString();
+    dest.assign(str_data.c_str(), str_data.size());
     got_string = true;
   }
 


### PR DESCRIPTION
This conditionally reimplements `PythonString::AsUTF8` using `PyUnicode_AsUTF8String` instead of `PyUnicode_AsUTF8AndSize`. The latter is slightly more efficient because it caches the result, which also means we can return an `llvm::StringRef` instead of having to allocate a `std::string`.

We pick the most efficient one depending on whether or not we're targeting the Python 3.10 stable API, however we now always return the result as a `std::string`.