### PR TITLE
[LLVM][Intrinsics] Reduce stack size for `Intrinsic::getAttributes`

### DIFF
--- a/llvm/test/TableGen/intrinsic-attrs.td
+++ b/llvm/test/TableGen/intrinsic-attrs.td
@@ -30,12 +30,11 @@ def int_deref_ptr_ret : Intrinsic<[llvm_ptr_ty], [], [Dereferenceable<RetIndex, 
 
 // CHECK: getAttributes(LLVMContext &C, ID id,
 // CHECK-NEXT: FunctionType *FT) {
-// CHECK: case 1:
-// CHECK-NEXT: return AttributeList::get(C, {
-// CHECK-NEXT:   {AttributeList::FunctionIndex, getIntrinsicFnAttributeSet(C, FnAttrID)}
-// CHECK-NEXT: });
+// CHECK:      case 1:
+// CHECK-NEXT:   HasFnAttr = true;
+// CHECK-NEXT:   break;
 // CHECK-NEXT: case 0:
-// CHECK-NEXT: return AttributeList::get(C, {
-// CHECK-NEXT:   {0, getIntrinsicArgAttributeSet(C, 0, FT->getContainedType(0))},
-// CHECK-NEXT:   {AttributeList::FunctionIndex, getIntrinsicFnAttributeSet(C, FnAttrID)}
-// CHECK-NEXT: });
+// CHECK-NEXT:   AS[0] = {0, getIntrinsicArgAttributeSet(C, 0, FT->getContainedType(0))};
+// CHECK-NEXT:   HasFnAttr = true;
+// CHECK-NEXT:   NumAttrs = 1
+// CHECK-NEXT:   break;


### PR DESCRIPTION
This change fixes a stack size regression that got introduced in https://github.com/llvm/llvm-project/commit/0de0354aa8dcd6afab625c6833cb0f40309c2961. That change did 2 independent things: 

1. Uniquify argument and function attributes separately so that we generate a smaller number of unique sets as opposed to uniquifying them together. This is beneficial for code size.
2. Eliminate the fixed size array `AS` and `NumAttrs` variable and instead build the returned AttribteList in each case using an initializer list.

The second part seems to have caused a regression in the stack size usage of this function for Windows. This change essentially undoes part 2 and reinstates the use of the fixed size array `AS` which fixes this stack size regression. The actual measured stack frame size for this function before/after this change is as follows:

```
  Current trunk data for release build (x86_64 builds for Linux, x86 build for Windows):
  Compiler                              gcc-13.3.0      clang-18.1.3      MSVC 19.43.34810.0
  DLLVM_ENABLE_ASSERTIONS=OFF           0x120           0x110             0x54B0   
  DLLVM_ENABLE_ASSERTIONS=ON            0x2880          0x110             0x5250

  After applying the fix:
  Compiler                              gcc-13.3.0      clang-18.1.3      MSVC 19.43.34810.0
  DLLVM_ENABLE_ASSERTIONS=OFF           0x120           0x118             0x1240h                                               
  DLLVM_ENABLE_ASSERTIONS=ON            0x120           0x118             0x1240h  
```
Note that for Windows builds with assertions disabled, the stack frame size for this function reduces from 21680 to 4672 which is a 4.6x reduction. Stack frame size for GCC build with assertions also improved and clang builds are unimpacted. The speculation is that clang and gcc is able to reuse the stack space across these switch cases better with existing code, but MSVC is not, and re-introducing the `AS` variable forces all cases to use the same local variable, addressing the stack space regression.