### PR TITLE
[libc][dlfcn] Remove unused errno dep

### DIFF
--- a/libc/src/dlfcn/CMakeLists.txt
+++ b/libc/src/dlfcn/CMakeLists.txt
@@ -14,7 +14,6 @@ add_entrypoint_object(
     dlerror.h
   DEPENDS
     libc.include.dlfcn
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(
@@ -25,7 +24,6 @@ add_entrypoint_object(
     dlopen.h
   DEPENDS
     libc.include.dlfcn
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(
@@ -36,7 +34,6 @@ add_entrypoint_object(
     dlsym.h
   DEPENDS
     libc.include.dlfcn
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(
@@ -47,7 +44,6 @@ add_entrypoint_object(
     dlinfo.h
   DEPENDS
     libc.include.dlfcn
-    libc.src.errno.errno
 )
 
 add_entrypoint_object(
@@ -58,5 +54,4 @@ add_entrypoint_object(
     dladdr.h
   DEPENDS
     libc.include.dlfcn
-    libc.src.errno.errno
 )


### PR DESCRIPTION
This removes the errno dep for the stub libdl functions, since there is no need for it.