### PR TITLE
[OpenACC] Improve C++20 compatibility of private/firstprivate test

### DIFF
--- a/clang/test/SemaOpenACC/private_firstprivate_reduction_required_ops.cpp
+++ b/clang/test/SemaOpenACC/private_firstprivate_reduction_required_ops.cpp
@@ -37,26 +37,12 @@ struct ImplicitDelDtor {
 };
 
 struct DeletedCopy {
-#if __cplusplus >= 202002L
-  // C++20 performs value-initialization while previous language versions
-  // performed aggregate-initialization. This class is also not eligible for
-  // an implicit default constructor. Therefore, the constructor must be
-  // explicitly declared for value-initialization to avoid additional
-  // diagnostics.
   DeletedCopy();
-#endif
   DeletedCopy(const DeletedCopy&) = delete;
 };
 
 struct DefaultedCopy {
-#if __cplusplus >= 202002L
-  // C++20 performs value-initialization while previous language versions
-  // performed aggregate-initialization. This class is also not eligible for
-  // an implicit default constructor. Therefore, the constructor must be
-  // explicitly declared for value-initialization to avoid additional
-  // diagnostics.
   DefaultedCopy();
-#endif
   DefaultedCopy(const DefaultedCopy&) = default;
 };
 struct UserCopy {

--- a/clang/test/SemaOpenACC/private_firstprivate_reduction_required_ops.cpp
+++ b/clang/test/SemaOpenACC/private_firstprivate_reduction_required_ops.cpp
@@ -37,10 +37,26 @@ struct ImplicitDelDtor {
 };
 
 struct DeletedCopy {
+#if __cplusplus >= 202002L
+  // C++20 performs value-initialization while previous language versions
+  // performed aggregate-initialization. This class is also not eligible for
+  // an implicit default constructor. Therefore, the constructor must be
+  // explicitly declared for value-initialization to avoid additional
+  // diagnostics.
+  DeletedCopy();
+#endif
   DeletedCopy(const DeletedCopy&) = delete;
 };
 
 struct DefaultedCopy {
+#if __cplusplus >= 202002L
+  // C++20 performs value-initialization while previous language versions
+  // performed aggregate-initialization. This class is also not eligible for
+  // an implicit default constructor. Therefore, the constructor must be
+  // explicitly declared for value-initialization to avoid additional
+  // diagnostics.
+  DefaultedCopy();
+#endif
   DefaultedCopy(const DefaultedCopy&) = default;
 };
 struct UserCopy {


### PR DESCRIPTION
Under C++17, `DeletedCopy` and `DefaultedCopy` in the test `clang/test/SemaOpenACC/private_firstprivate_reduction_required_ops.cpp` are eligible for aggregate initialization. Under C++20 and up, that is no longer the case. Therefore, an explicit constructor must be declared to avoid additional diagnostics which the test does not expect.

This test was failing in our downstream testing where our toolchain uses C++20 as the default dialect.

See this reduced example for more details: https://godbolt.org/z/46oErYT43