### PR TITLE
Remove reference to reverted PR #130742

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -55,7 +55,7 @@ C/C++ Language Potentially Breaking Changes
   case for old-style offsetof idioms like ``((int)(&(((struct S *)0)->field)))``, to
   ensure they are not caught by these optimizations.  It is also possible to use
   ``-fwrapv-pointer`` or   ``-fno-delete-null-pointer-checks`` to make pointer arithmetic
-  on null pointers well-defined. (#GH130734, #GH130742, #GH130952)
+  on null pointers well-defined. (#GH130734, #GH130952)
 
 C++ Specific Potentially Breaking Changes
 -----------------------------------------


### PR DESCRIPTION
Based on the file history in https://github.com/dtcxzyw/llvm-project/commits/main/llvm/test/CodeGen/AMDGPU/memcpy-crash-issue63986.ll, it appears #130742 was reverted by #138168 and never re-applied.