### PR TITLE
[Clang][RISCV] Loosen the requirement of -fcf-protection=return to zimop

### DIFF
--- a/clang/lib/Basic/Targets/RISCV.h
+++ b/clang/lib/Basic/Targets/RISCV.h
@@ -147,7 +147,7 @@ public:
 
   bool
   checkCFProtectionReturnSupported(DiagnosticsEngine &Diags) const override {
-    if (ISAInfo->hasExtension("zicfiss"))
+    if (ISAInfo->hasExtension("zimop"))
       return true;
     return TargetInfo::checkCFProtectionReturnSupported(Diags);
   }

--- a/clang/test/CodeGen/RISCV/attr-hw-shadow-stack.c
+++ b/clang/test/CodeGen/RISCV/attr-hw-shadow-stack.c
@@ -1,7 +1,7 @@
-// RUN: %clang_cc1 -triple riscv64 -target-feature +experimental-zicfiss -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
-// RUN: %clang_cc1 -triple riscv64 -target-feature +experimental-zicfiss -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
-// RUN: %clang_cc1 -triple riscv32 -target-feature +experimental-zicfiss -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
-// RUN: %clang_cc1 -triple riscv32 -target-feature +experimental-zicfiss -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
+// RUN: %clang_cc1 -triple riscv64 -target-feature +zimop -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
+// RUN: %clang_cc1 -triple riscv64 -target-feature +zimop -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
+// RUN: %clang_cc1 -triple riscv32 -target-feature +zimop -emit-llvm -o - %s -fcf-protection=return | FileCheck %s
+// RUN: %clang_cc1 -triple riscv32 -target-feature +zimop -emit-llvm -o - %s | FileCheck -check-prefix=NOSHADOWSTACK %s
 
 int foo(int *a) { return *a; }
 


### PR DESCRIPTION
Following https://github.com/llvm/llvm-project/pull/152251
We can now loosen the requirement of `-fcf-protection=return` from Zicfiss to Zimop