### PR TITLE
[libc++] Fix incorrect down cast in __tree::operator=

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -1388,8 +1388,9 @@ __tree<_Tp, _Compare, _Allocator>& __tree<_Tp, _Compare, _Allocator>::operator=(
     if (__root())
       __root()->__parent_ = __end_node();
   }
-  __begin_node_ = static_cast<__end_node_pointer>(std::__tree_min(static_cast<__node_base_pointer>(__end_node())));
-  __size_       = __t.size();
+  __begin_node_ =
+      __end_node()->__left_ ? static_cast<__end_node_pointer>(std::__tree_min(__end_node()->__left_)) : __end_node();
+  __size_ = __t.size();
 
   return *this;
 }


### PR DESCRIPTION
This has been introduced by #151304. This problem is diagnosed by UBSan
with optimizations enabled. Since we run UBSan only with optimizations
disabled currently, this isn't caught in our CI. We should look into
enabling UBSan with optimizations enabled to catch these sorts of issues
before landing a patch.
