### PR TITLE
[SPIRV] Addition of image_store.ll and signed_arithmetic_overflow.ll

### DIFF
--- a/llvm/test/CodeGen/SPIRV/image_store.ll
+++ b/llvm/test/CodeGen/SPIRV/image_store.ll
@@ -1,0 +1,22 @@
+; RUN: llc -O0 -verify-machineinstrs -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -o - -filetype=obj | spirv-val %}
+
+; Image types may be represented in two ways while translating to SPIR-V:
+; - OpenCL form, for example, '%opencl.image2d_ro_t',
+; - SPIR-V form, for example, '%spirv.Image._void_1_0_0_0_0_0_0',
+; but it is still one type which should be translated to one SPIR-V type.
+;
+; The test checks that the code below is successfully translated and only one
+; SPIR-V type for images is generated.
+
+; CHECK:     %[[#]] = OpTypeImage %[[#]] 2D
+; CHECK-NOT: %[[#]] = OpTypeImage %[[#]] 2D
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_ff(ptr addrspace(1), ptr addrspace(2), <2 x float>, float)
+
+define spir_kernel void @read_image(ptr addrspace(1) %srcimg, ptr addrspace(2) %sampler){
+entry:
+  %spirvimg.addr = alloca target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), align 8
+  %val = call <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_ff(ptr addrspace(1) %srcimg, ptr addrspace(2) %sampler, <2 x float> zeroinitializer, float 0.0)
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/image_store.ll
+++ b/llvm/test/CodeGen/SPIRV/image_store.ll
@@ -7,7 +7,7 @@
 ; but it is still one type which should be translated to one SPIR-V type.
 ;
 ; The test checks that the code below is successfully translated and only one
-; SPIR-V type for images is generated.
+; SPIR-V type for images is generated (no duplicate OpTypeImage instructions).
 
 ; CHECK:     %[[#]] = OpTypeImage %[[#]] 2D
 ; CHECK-NOT: %[[#]] = OpTypeImage %[[#]] 2D

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/signed_arithmetic_overflow.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/signed_arithmetic_overflow.ll
@@ -1,0 +1,30 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+; RUN: %if spirv-tools %{ llc -O0 -mtriple=spirv64-unknown-unknown %s -filetype=obj -o - | spirv-val %}
+; XFAIL: *
+;@llvm.sadd.with.overflow and @llvm.ssub.with.overflow has not been implemented.
+
+define spir_func void @test_sadd_overflow(ptr %out_result, ptr %out_overflow, i32 %a, i32 %b) {
+entry:
+  %res = call { i32, i1 } @llvm.sadd.with.overflow.i32(i32 %a, i32 %b)
+  %val = extractvalue { i32, i1 } %res, 0
+  %ofl = extractvalue { i32, i1 } %res, 1
+  store i32 %val, ptr %out_result
+  %zext_ofl = zext i1 %ofl to i8
+  store i8 %zext_ofl, ptr %out_overflow
+  ret void
+}
+
+declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32)
+
+define spir_func void @test_ssub_overflow(ptr %out_result, ptr %out_overflow, i32 %a, i32 %b) {
+entry:
+  %res = call { i32, i1 } @llvm.ssub.with.overflow.i32(i32 %a, i32 %b)
+  %val = extractvalue { i32, i1 } %res, 0
+  %ofl = extractvalue { i32, i1 } %res, 1
+  store i32 %val, ptr %out_result
+  %zext_ofl = zext i1 %ofl to i8
+  store i8 %zext_ofl, ptr %out_overflow
+  ret void
+}
+
+declare { i32, i1 } @llvm.ssub.with.overflow.i32(i32, i32)


### PR DESCRIPTION
--Test for signed arithmetic overflow intrinsics, which is for now expectedly failing
--Test checking that no duplicate image types are emitted.