### PR TITLE
[mlir][Transforms] More detailed error message when new IR cannot be legalized

### DIFF
--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2316,7 +2316,7 @@ reportNewIrLegalizationFatalError(const Pattern &pattern,
       ", ");
   std::string modifiedOpNames = llvm::join(
       llvm::map_range(
-          newOps, [](Operation *op) { return op->getName().getStringRef(); }),
+          modifiedOps, [](Operation *op) { return op->getName().getStringRef(); }),
       ", ");
   std::string insertedBlockNames = llvm::join(
       llvm::map_range(insertedBlocks,

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2309,28 +2309,22 @@ reportNewIrLegalizationFatalError(const Pattern &pattern,
                                   const SetVector<Operation *> &newOps,
                                   const SetVector<Operation *> &modifiedOps,
                                   const SetVector<Block *> &insertedBlocks) {
+  auto newOpNames = llvm::map_range(
+      newOps, [](Operation *op) { return op->getName().getStringRef(); });
+  auto modifiedOpNames = llvm::map_range(
+      modifiedOps, [](Operation *op) { return op->getName().getStringRef(); });
   StringRef detachedBlockStr = "(detached block)";
-  std::string newOpNames = llvm::join(
-      llvm::map_range(
-          newOps, [](Operation *op) { return op->getName().getStringRef(); }),
-      ", ");
-  std::string modifiedOpNames = llvm::join(
-      llvm::map_range(
-          modifiedOps, [](Operation *op) { return op->getName().getStringRef(); }),
-      ", ");
-  std::string insertedBlockNames = llvm::join(
-      llvm::map_range(insertedBlocks,
-                      [&](Block *block) {
-                        if (block->getParentOp())
-                          return block->getParentOp()->getName().getStringRef();
-                        return detachedBlockStr;
-                      }),
-      ", ");
+  auto insertedBlockNames = llvm::map_range(insertedBlocks, [&](Block *block) {
+    if (block->getParentOp())
+      return block->getParentOp()->getName().getStringRef();
+    return detachedBlockStr;
+  });
   llvm::report_fatal_error(
       "pattern '" + pattern.getDebugName() +
       "' produced IR that could not be legalized. " + "new ops: {" +
-      newOpNames + "}, " + "modified ops: {" + modifiedOpNames + "}, " +
-      "inserted block into ops: {" + insertedBlockNames + "}");
+      llvm::join(newOpNames, ", ") + "}, " + "modified ops: {" +
+      llvm::join(modifiedOpNames, ", ") + "}, " + "inserted block into ops: {" +
+      llvm::join(insertedBlockNames, ", ") + "}");
 }
 
 LogicalResult


### PR DESCRIPTION
Print a more detailed error message when new/modified IR could not be legalized with `allowPatternRollback = false`. This is useful to understand why a pattern is incompatible with the new One-Shot Dialect Conversion driver.
