### PR TITLE
[llvm][cmake] Turn runtime in PROJECTS warnings into FATAL_ERROR

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -180,29 +180,20 @@ if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
 endif()
 
 if ("libc" IN_LIST LLVM_ENABLE_PROJECTS)
-  message(WARNING "Using LLVM_ENABLE_PROJECTS=libc is deprecated.  Please use "
+  message(FATAL_ERROR "Using LLVM_ENABLE_PROJECTS=libc is no longer supported.  Please use "
     "-DLLVM_ENABLE_RUNTIMES=libc or see the instructions at "
     "https://libc.llvm.org/ for building the runtimes.")
 endif()
 
 if ("compiler-rt" IN_LIST LLVM_ENABLE_PROJECTS)
-  message(WARNING "Using LLVM_ENABLE_PROJECTS=compiler-rt is deprecated now, and will "
-    "become a fatal error in the LLVM 21 release.  Please use "
-    "-DLLVM_ENABLE_RUNTIMES=compiler-rt or see the instructions at "
+  message(FATAL_ERROR "Using LLVM_ENABLE_PROJECTS=compiler-rt is no longer supported. "
+    "Please use -DLLVM_ENABLE_RUNTIMES=compiler-rt or see the instructions at "
     "https://compiler-rt.llvm.org/ for building the runtimes.")
 endif()
 
-if ("offload" IN_LIST LLVM_ENABLE_PROJECTS)
-  message(WARNING "Using LLVM_ENABLE_PROJECTS=offload is deprecated now, and will "
-    "become a fatal error in the LLVM 21 release.  Please use "
-    "-DLLVM_ENABLE_RUNTIMES=offload or see the instructions at "
-    "https://openmp.llvm.org/ for building the runtimes.")
-endif()
-
 if ("openmp" IN_LIST LLVM_ENABLE_PROJECTS)
-  message(WARNING "Using LLVM_ENABLE_PROJECTS=openmp is deprecated now, and will "
-    "become a fatal error in the LLVM 21 release.  Please use "
-    "-DLLVM_ENABLE_RUNTIMES=openmp or see the instructions at "
+  message(FATAL_ERROR "Using LLVM_ENABLE_PROJECTS=openmp is no longer supported. "
+    "Please use -DLLVM_ENABLE_RUNTIMES=openmp or see the instructions at "
     "https://openmp.llvm.org/ for building the runtimes.")
 endif()
 
@@ -213,9 +204,8 @@ if ("flang-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
 endif ()
 
 if ("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
-  message(WARNING "Using LLVM_ENABLE_PROJECTS=libclc is deprecated now, and will "
-    "become a fatal error in the LLVM 21 release.  Please use "
-    "-DLLVM_ENABLE_RUNTIMES=libclc or see the instructions at "
+  message(FATAL_ERROR "Using LLVM_ENABLE_PROJECTS=libclc is no longer supported. "
+    "Please use -DLLVM_ENABLE_RUNTIMES=libclc or see the instructions at "
     "https://libclc.llvm.org/ for building the runtimes.")
 endif()
 

--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -595,12 +595,7 @@ enabled sub-projects. Nearly all of these variable names begin with
 
   The full list is:
 
-  ``bolt;clang;clang-tools-extra;compiler-rt;cross-project-tests;libc;libclc;lld;lldb;mlir;openmp;polly``
-
-  .. note::
-    Some projects listed here can also go in ``LLVM_ENABLE_RUNTIMES``. They
-    should only appear in one of the two lists. If a project is a valid possibility
-    for both, prefer putting it in ``LLVM_ENABLE_RUNTIMES``.
+  ``bolt;clang;clang-tools-extra;cross-project-tests;lld;lldb;mlir;polly``
 
 **LLVM_ENABLE_RTTI**:BOOL
   Build LLVM with run-time type information. Defaults to OFF.
@@ -617,7 +612,7 @@ enabled sub-projects. Nearly all of these variable names begin with
 
   The full list is:
 
-  ``libc;libunwind;libcxxabi;libcxx;compiler-rt;openmp;llvm-libgcc;offload``
+  ``libc;libclc;libunwind;libcxxabi;libcxx;compiler-rt;openmp;llvm-libgcc;offload``
 
   To enable all of them, use:
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -90,6 +90,11 @@ Changes to LLVM infrastructure
 Changes to building LLVM
 ------------------------
 
+* The runtimes `libc`, `compiler-rt`, `openmp` and `libclc` now must be enabled
+  in `LLVM_ENABLE_RUNTIMES`, rather than `LLVM_ENABLE_PROJECTS`. Prior to LLVM 21,
+  they were allowed in `LLVM_ENABLE_PROJECTS`, but a warning was emitted. This
+  is now a fatal error.
+
 Changes to TableGen
 -------------------
 


### PR DESCRIPTION
As promised by the current warning message:
CMake Warning at CMakeLists.txt:209 (message):
  Using LLVM_ENABLE_PROJECTS=openmp is deprecated now, and will become a
  fatal error in the LLVM 21 release.  Please use
  -DLLVM_ENABLE_RUNTIMES=openmp or see the instructions at
  https://openmp.llvm.org/ for building the runtimes.

I have changed this to:
CMake Error at CMakeLists.txt:202 (message):
  Using LLVM_ENABLE_PROJECTS=openmp is no longer supported.  Please use
  -DLLVM_ENABLE_RUNTIMES=openmp or see the instructions at
  https://openmp.llvm.org/ for building the runtimes.

I removed the check for offload because offload never hits the warning, it errors earlier with:
CMake Error at CMakeLists.txt:143 (MESSAGE):
  offload isn't a known project:
  bolt;clang;clang-tools-extra;compiler-rt;cross-project-tests;libclc;lld;lldb;mlir;openmp;polly;flang;libc.
  Did you mean to enable it as a runtime in LLVM_ENABLE_RUNTIMES?

We could remove the FATAL_ERRORs entirely but I thought leaving them in 21.x and removing them on main made more sense.

So this change is specifically for 21.x.