### PR TITLE
[libc] Fix integration tests on w64 amdgpu targets

### DIFF
--- a/libc/test/IntegrationTest/test.cpp
+++ b/libc/test/IntegrationTest/test.cpp
@@ -63,8 +63,8 @@ int atexit(void (*func)(void)) { return LIBC_NAMESPACE::atexit(func); }
 // which just hands out continuous blocks from a statically allocated chunk of
 // memory.
 
-static constexpr uint64_t ALIGNMENT = alignof(long double);
-static constexpr uint64_t MEMORY_SIZE = 65336;
+static constexpr uint64_t ALIGNMENT = alignof(double);
+static constexpr uint64_t MEMORY_SIZE = 256 * 1024 /* 256 KiB */;
 alignas(ALIGNMENT) static uint8_t memory[MEMORY_SIZE];
 static size_t ptr = 0;
 
@@ -75,7 +75,7 @@ void *malloc(size_t size) {
   size = (size + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
   size_t old_ptr =
       ref.fetch_add(size, LIBC_NAMESPACE::cpp::MemoryOrder::RELAXED);
-  if (static_cast<size_t>(old_ptr + size) > MEMORY_SIZE)
+  if (static_cast<size_t>(old_ptr + size) >= MEMORY_SIZE)
     return nullptr;
   return &memory[old_ptr];
 }

--- a/libc/test/integration/src/__support/GPU/match.cpp
+++ b/libc/test/integration/src/__support/GPU/match.cpp
@@ -21,7 +21,9 @@ static void test_match() {
             gpu::match_any(mask, gpu::get_lane_id()));
   EXPECT_EQ(mask, gpu::match_any(mask, 1));
 
-  uint64_t expected = gpu::get_lane_id() < 16 ? 0xffff : 0xffff0000;
+  uint64_t full_mask =
+      gpu::get_lane_size() > 32 ? 0xffffffffffffffff : 0xffffffff;
+  uint64_t expected = gpu::get_lane_id() < 16 ? 0xffff : full_mask & ~0xffff;
   EXPECT_EQ(expected, gpu::match_any(mask, gpu::get_lane_id() < 16));
   EXPECT_EQ(mask, gpu::match_all(mask, 1));
   EXPECT_EQ(0ull, gpu::match_all(mask, gpu::get_lane_id()));


### PR DESCRIPTION
Summary:
We need `malloc` to return a larger size now that it's aligned properly
and we use a bunch of threads. Also the `match_any` test was wrong
because it assumed a 32-bit lanemask.
