### PR TITLE
[flang][cmake] Fix bbc dependencies

### DIFF
--- a/flang/tools/bbc/CMakeLists.txt
+++ b/flang/tools/bbc/CMakeLists.txt
@@ -30,6 +30,11 @@ target_link_libraries(bbc PRIVATE
   flangFrontend
   flangPasses
   FlangOpenMPTransforms
+  FortranSupport
+  FortranParser
+  FortranEvaluate
+  FortranSemantics
+  FortranLower
 )
 
 mlir_target_link_libraries(bbc PRIVATE
@@ -37,9 +42,4 @@ mlir_target_link_libraries(bbc PRIVATE
   ${extension_libs}
   MLIRAffineToStandard
   MLIRSCFToControlFlow
-  FortranSupport
-  FortranParser
-  FortranEvaluate
-  FortranSemantics
-  FortranLower
 )


### PR DESCRIPTION
Re-apply "[flang][cmake] Fix bcc dependencies (#125822)"

It was overwritten due to an automatic merge gone wrong for https://github.com/llvm/llvm-project/pull/124416

`git cherry-pick f9af5c145f40480d46874b643ca2b1237e9fbb2a` applied in 97cf061e83a0d0cada38d8a2d75c8a840b01ba26 ignored the renaming of FortranCommon into FortranSupport after #125822.

Original commit message:

The Fortran libraries are not part of MLIR, so they should use target_link_libraries() rather than mlir_target_link_libraries().
This fixes an issue introduced in #20966.