### PR TITLE
[Clang][Headers] Fix <gpuintrin.h> for SYCL

### DIFF
--- a/clang/lib/Headers/amdgpuintrin.h
+++ b/clang/lib/Headers/amdgpuintrin.h
@@ -165,14 +165,22 @@ __gpu_match_all_u64(uint64_t __lane_mask, uint64_t __x) {
 
 // Returns true if the flat pointer points to AMDGPU 'shared' memory.
 _DEFAULT_FN_ATTRS static __inline__ bool __gpu_is_ptr_local(void *ptr) {
-  return __builtin_amdgcn_is_shared((void [[clang::address_space(0)]] *)((
-      void [[clang::opencl_generic]] *)ptr));
+#if (!defined(__OPENCL_C_VERSION__) && !defined(__OPENCL_CPP_VERSION__)) ||    \
+    defined(__opencl_c_generic_address_space)
+  return __builtin_amdgcn_is_shared((void [[clang::address_space(0)]] *)(ptr));
+#else
+  return false;
+#endif
 }
 
 // Returns true if the flat pointer points to AMDGPU 'private' memory.
 _DEFAULT_FN_ATTRS static __inline__ bool __gpu_is_ptr_private(void *ptr) {
-  return __builtin_amdgcn_is_private((void [[clang::address_space(0)]] *)((
-      void [[clang::opencl_generic]] *)ptr));
+#if (!defined(__OPENCL_C_VERSION__) && !defined(__OPENCL_CPP_VERSION__)) ||    \
+    defined(__opencl_c_generic_address_space)
+  return __builtin_amdgcn_is_shared((void [[clang::address_space(0)]] *)(ptr));
+#else
+  return true;
+#endif
 }
 
 // Terminates execution of the associated wavefront.


### PR DESCRIPTION
`#include <gpuintrin.h>` was leading to a compile error in `HandleAddressSpaceTypeAttribute` (SemaType.cpp) when compiling SYCL code. This happens when parsing the `[[clang::opencl_generic]]` attribute in `__gpu_is_ptr_(local|private)` functions.
As far as I can tell that attribute and cast is there to allow the code to compile in OpenCL mode without generic address space support.

This patch instead explicitly checks for OpenCL without generic address spaces and always returns true/false from `__gpu_is_ptr_(local|private)`. In that case unqualified pointers belong to the private address space by definition as per the OpenCL spec:

> If the generic address space is supported i.e. for OpenCL C 2.0
> or OpenCL C 3.0 with __opencl_c_generic_address_space feature,
> pointers that are declared without pointing to a named address space
> point to the generic address space.
> ...
> For all other cases that are not listed above the address space is
> inferred to __private. This includes:
> - All function arguments as well as return values are in the private
> address space.