### PR TITLE
[Support] Forward references should be forwarded, not moved (NFC)

### DIFF
--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -428,7 +428,7 @@ std::enable_if_t<!std::is_reference_v<OStream> &&
                  OStream &&>
 operator<<(OStream &&OS, const T &Value) {
   OS << Value;
-  return std::forward<OStream>(OS);
+  return std::move(OS);
 }
 
 /// An abstract base class for streams implementations that also support a

--- a/llvm/include/llvm/Support/raw_ostream.h
+++ b/llvm/include/llvm/Support/raw_ostream.h
@@ -428,7 +428,7 @@ std::enable_if_t<!std::is_reference_v<OStream> &&
                  OStream &&>
 operator<<(OStream &&OS, const T &Value) {
   OS << Value;
-  return std::move(OS);
+  return std::forward<OStream>(OS);
 }
 
 /// An abstract base class for streams implementations that also support a

--- a/llvm/lib/TextAPI/TextStubV5.cpp
+++ b/llvm/lib/TextAPI/TextStubV5.cpp
@@ -791,7 +791,7 @@ template <typename ContainerT = Array>
 bool insertNonEmptyValues(Object &Obj, TBDKey Key, ContainerT &&Contents) {
   if (Contents.empty())
     return false;
-  Obj[Keys[Key]] = std::move(Contents);
+  Obj[Keys[Key]] = std::forward<ContainerT>(Contents);
   return true;
 }
 


### PR DESCRIPTION
It is a forwarding reference, after all.