### PR TITLE
[lldb] Add "settings modified" command

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValueProperties.h
+++ b/lldb/include/lldb/Interpreter/OptionValueProperties.h
@@ -163,6 +163,9 @@ public:
     return false;
   }
 
+  auto begin() const { return m_properties.begin(); }
+  auto end() const { return m_properties.end(); }
+
 protected:
   Property *ProtectedGetPropertyAtIndex(size_t idx) {
     assert(idx < m_properties.size() && "invalid property index");

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -1052,3 +1052,14 @@ class SettingsCommandTestCase(TestBase):
         # NULL execution context (not one with an empty Target...) and in the
         # special handling for load-script-from-symbol-file this wasn't checked.
         self.runCmd("settings set -g target.load-script-from-symbol-file true")
+
+    def test_modified(self):
+        self.runCmd("settings set notify-void true")
+        self.runCmd("settings set target.process.optimization-warnings false")
+        self.expect(
+            "settings modified",
+            substrs=[
+                "notify-void = true",
+                "target.process.optimization-warnings = false",
+            ],
+        )


### PR DESCRIPTION
Adds `settings modified` which prints the settings which have been assigned in the current session. This command would be helpful for getting context about a debug session, to help explain debugger behavior.

rdar://157673186