### PR TITLE
Check for Res first before checking if we are to export it

### DIFF
--- a/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
+++ b/llvm/lib/Transforms/IPO/WholeProgramDevirt.cpp
@@ -1648,7 +1648,7 @@ bool DevirtModule::tryUniformRetValOpt(
     if (Target.RetVal != TheRetVal)
       return false;
 
-  if (CSInfo.isExported()) {
+  if (Res && CSInfo.isExported()) {
     Res->TheKind = WholeProgramDevirtResolution::ByArg::UniformRetVal;
     Res->Info = TheRetVal;
   }


### PR DESCRIPTION
Res can be null, though it is unclear if res is always set if the cs info is exported. Better to be safe just in case.