### PR TITLE
[NFCI][TableGen] Make `Intrinsic::getAttributes` table driven

### DIFF
--- a/llvm/test/TableGen/intrinsic-attrs.td
+++ b/llvm/test/TableGen/intrinsic-attrs.td
@@ -27,14 +27,16 @@ def int_deref_ptr_ret : Intrinsic<[llvm_ptr_ty], [], [Dereferenceable<RetIndex, 
 // CHECK: static constexpr uint16_t IntrinsicsToAttributesMap[] = {
 // CHECK: 0 << 8 | 0, // llvm.deref.ptr.ret
 // CHECK: 1 << 8 | 1, // llvm.random.gen
+// CHECK: }; // IntrinsicsToAttributesMap
+
+// CHECK: static constexpr ArgNoAttrIDPair ArgAttrIdTable[] = {
+// CHECK-NEXT:   {0, 0},
+// CHECK: }; // ArgAttrIdTable
+
+// CHECK: static constexpr ArgAttributesInfo ArgAttributesInfoTable[] = {
+// CHECK-NEXT:  {0, 1},
+// CHECK-NEXT:  {0, 0},
+// CHECK-NEXT: }; // ArgAttributesInfoTable
 
 // CHECK: getAttributes(LLVMContext &C, ID id,
 // CHECK-NEXT: FunctionType *FT) {
-// CHECK:      case 1:
-// CHECK-NEXT:   HasFnAttr = true;
-// CHECK-NEXT:   break;
-// CHECK-NEXT: case 0:
-// CHECK-NEXT:   AS[0] = {0, getIntrinsicArgAttributeSet(C, 0, FT->getContainedType(0))};
-// CHECK-NEXT:   HasFnAttr = true;
-// CHECK-NEXT:   NumAttrs = 1
-// CHECK-NEXT:   break;


### PR DESCRIPTION
This a follow on to https://github.com/llvm/llvm-project/pull/152219 to reduce both code and frame size of `Intrinsic::getAttributes` further.

Currently, this function consists of several switch cases (one per unique argument attributes) that populates the local `AS` array with all non-empty argument attributes for that intrinsic by calling `getIntrinsicArgAttributeSet`. This change makes this code table driven and implements `Intrinsic::getAttributes` without any switch cases, which reduces the code size of this function on all platforms and in addition reduces the frame size by a factor of 10 on Windows.

This is achieved by:
1. Emitting table `ArgAttrIdTable` containing a concatenated list of `<ArgNo, AttrID>` entries across all unique arguments.
2. Emitting table `ArgAttributesInfoTable` (indexed by unique arguments-ID) to store the starting index and number of non-empty arg attributes.
3. Reserving unique function-ID 255 to indicate that the intrinsic has no function attributes (to replace `HasFnAttr` setup in each switch case).
4. Using a simple table lookup and for loop to build the list of argument and function attributes for a given intrinsic.

Experimental data shows that with release builds and assertions disabled, this change reduces the code size for GCC and Clang builds on Linux by ~9KB for a modest (80/152 byte) increase in frame size. For Windows, it reduces the code size by 20KB and frame size from 4736 bytes to 461 bytes which is 10x reduction. Actual data is as follows:

```
 Current trunk:
  Compiler                              gcc-13.3.0      clang-18.1.3      MSVC 19.43.34810.0
  code size                             0x35a9          0x370c            0x5581
  frame size                            0x120           0x118             0x1280

 table driven Intrinsic::getAttributes:
  code size                             0xcfb            0xcd0            0x1cf
  frame size                            0x1b8            0x188            0x1A0
  Total savings (code + data)           9212 bytes       9790 bytes       20119 bytes
```

Total savings above accounts for the additional data size for the 2 new tables, which in this experiment was: `ArgAttributesInfoTable` = 314 bytes and `ArgAttrIdTable` = 888 bytes. Coupled with the earlier https://github.com/llvm/llvm-project/pull/152219, this achieves a 46x reduction in frame size for this function in Windows release builds.
