### PR TITLE
[ObjCARC] Move autorelease-to-release conversion to pool pop site instead of converting in place

### DIFF
--- a/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
@@ -133,9 +133,6 @@ static const Value *FindSingleUseIdentifiedObject(const Value *Arg) {
 //
 // The second retain and autorelease can be deleted.
 
-// TODO: Autorelease calls followed by objc_autoreleasePoolPop calls (perhaps in
-// ObjC++ code after inlining) can be turned into plain release calls.
-
 // TODO: Critical-edge splitting. If the optimial insertion point is
 // a critical edge, the current algorithm has to fail, because it doesn't
 // know how to split edges. It should be possible to make the optimizer
@@ -499,6 +496,14 @@ class ObjCARCOpt {
 
   DenseMap<BasicBlock *, ColorVector> BlockEHColors;
 
+  /// Cache mapping autorelease instructions to their following
+  /// autoreleasePoolPop in the same basic block (or nullptr if none).
+  DenseMap<Instruction *, Instruction *> FollowingPoolPopCache;
+
+  /// Find the autoreleasePoolPop that will drain the given autorelease
+  /// instruction in the same basic block, skipping nested pools.
+  Instruction *FindFollowingAutoreleasePoolPop(Instruction *AutoreleaseInst);
+
   bool OptimizeRetainRVCall(Function &F, Instruction *RetainRV);
   void OptimizeAutoreleaseRVCall(Function &F, Instruction *AutoreleaseRV,
                                  ARCInstKind &Class);
@@ -601,6 +606,66 @@ class ObjCARCOpt {
 };
 } // end anonymous namespace
 
+/// Find the autoreleasePoolPop that will drain the given autorelease
+/// instruction in the same basic block, skipping over nested pools.
+///
+/// Since objc_autorelease does not change the refcount (it only registers the
+/// object for a deferred release at pool drain), we can move the release to
+/// just before the pool pop instead of converting in place. This avoids the
+/// need to check for uses of the pointer between the autorelease and the pop.
+Instruction *
+ObjCARCOpt::FindFollowingAutoreleasePoolPop(Instruction *AutoreleaseInst) {
+  assert(GetBasicARCInstKind(AutoreleaseInst) == ARCInstKind::Autorelease);
+
+  auto It = FollowingPoolPopCache.find(AutoreleaseInst);
+  if (It != FollowingPoolPopCache.end()) {
+    // The cached value is a raw pointer to a pool pop. The cache is only
+    // consulted during OptimizeIndividualCalls, which runs before
+    // OptimizeAutoreleasePools can erase pool pops.
+    return It->second;
+  }
+
+  BasicBlock *BB = AutoreleaseInst->getParent();
+
+  SmallVector<SmallVector<Instruction *, 2>, 4> AutoreleasesByDepth(1);
+  AutoreleasesByDepth[0].push_back(AutoreleaseInst);
+
+  unsigned Depth = 0;
+  for (BasicBlock::iterator I = std::next(AutoreleaseInst->getIterator()),
+                            E = BB->end();
+       I != E; ++I) {
+    ARCInstKind Class = GetBasicARCInstKind(&*I);
+
+    if (Class == ARCInstKind::AutoreleasepoolPush) {
+      if (++Depth >= AutoreleasesByDepth.size())
+        AutoreleasesByDepth.emplace_back();
+      else
+        assert(AutoreleasesByDepth[Depth].empty() &&
+               "reused bucket must be empty");
+    } else if (Class == ARCInstKind::AutoreleasepoolPop) {
+      for (Instruction *J : AutoreleasesByDepth[Depth])
+        FollowingPoolPopCache[J] = &*I;
+      AutoreleasesByDepth[Depth].clear();
+      if (Depth == 0)
+        return &*I;
+      --Depth;
+    } else if (Class == ARCInstKind::Autorelease) {
+      AutoreleasesByDepth[Depth].push_back(&*I);
+    } else if (Class == ARCInstKind::Call || Class == ARCInstKind::CallOrUser) {
+      // A call can push or pop an autorelease pool, which dynamically
+      // changes the pool stack. We cannot rely on the syntactic scan anymore.
+      // Break out and cache the nullptr result for all accumulated
+      // autoreleases.
+      break;
+    }
+  }
+
+  for (const auto &Autoreleases : AutoreleasesByDepth)
+    for (Instruction *I : Autoreleases)
+      FollowingPoolPopCache[I] = nullptr;
+  return nullptr;
+}
+
 /// Turn objc_retainAutoreleasedReturnValue into objc_retain if the operand is
 /// not a return value.
 bool
@@ -610,9 +675,9 @@ ObjCARCOpt::OptimizeRetainRVCall(Function &F, Instruction *RetainRV) {
   if (const Instruction *Call = dyn_cast<CallBase>(Arg)) {
     if (Call->getParent() == RetainRV->getParent()) {
       BasicBlock::const_iterator I(Call);
-      ++I;
-      while (IsNoopInstruction(&*I))
+      do
         ++I;
+      while (IsNoopInstruction(&*I));
       if (&*I == RetainRV)
         return false;
     } else if (const InvokeInst *II = dyn_cast<InvokeInst>(Call)) {
@@ -761,6 +826,8 @@ void ObjCARCOpt::OptimizeIndividualCalls(Function &F) {
   LLVM_DEBUG(dbgs() << "\n== ObjCARCOpt::OptimizeIndividualCalls ==\n");
   // Reset all the flags in preparation for recomputing them.
   UsedInThisFunction = 0;
+  // Clear the autorelease pool pop cache for this function
+  FollowingPoolPopCache.clear();
 
   // Store any delayed AutoreleaseRV intrinsics, so they can be easily paired
   // with RetainRV and UnsafeClaimRV.
@@ -986,19 +1053,53 @@ void ObjCARCOpt::OptimizeIndividualCallImpl(Function &F, Instruction *Inst,
       Changed = true;
       ++NumAutoreleases;
 
-      // Create the declaration lazily.
       LLVMContext &C = Inst->getContext();
-
       Function *Decl = EP.get(ARCRuntimeEntryPointKind::Release);
       CallInst *NewCall = CallInst::Create(Decl, Call->getArgOperand(0), "",
                                            Call->getIterator());
       NewCall->setMetadata(MDKindCache.get(ARCMDKindID::ImpreciseRelease),
                            MDNode::get(C, {}));
 
-      LLVM_DEBUG(dbgs() << "Replacing autorelease{,RV}(x) with objc_release(x) "
-                           "since x is otherwise unused.\nOld: "
+      LLVM_DEBUG(
+          dbgs() << "Replacing objc_autorelease(x) with objc_release(x)\n");
+
+      FollowingPoolPopCache.erase(Call);
+      EraseInstruction(Call);
+      Inst = NewCall;
+      Class = ARCInstKind::Release;
+    }
+  }
+
+  // objc_autorelease(x) -> objc_release(x) moved to just before the
+  // autoreleasePoolPop. Since autorelease only registers a deferred release
+  // at pool drain time without changing the refcount, placing the release at
+  // the drain point is semantically equivalent and avoids use-after-free
+  // concerns with in-place conversion.
+  if (Class == ARCInstKind::Autorelease) {
+    if (Instruction *PoolPop = FindFollowingAutoreleasePoolPop(Inst)) {
+      CallInst *Call = cast<CallInst>(Inst);
+      Changed = true;
+      ++NumAutoreleases;
+
+      LLVMContext &C = Inst->getContext();
+      Function *Decl = EP.get(ARCRuntimeEntryPointKind::Release);
+      CallInst *NewCall = CallInst::Create(Decl, Call->getArgOperand(0), "",
+                                           PoolPop->getIterator());
+      NewCall->setMetadata(MDKindCache.get(ARCMDKindID::ImpreciseRelease),
+                           MDNode::get(C, {}));
+
+      LLVM_DEBUG(dbgs() << "Converting autorelease to release before pool pop."
+                           "\nOld: "
                         << *Call << "\nNew: " << *NewCall << "\n");
 
+      assert(Call->getType() == Call->getArgOperand(0)->getType() &&
+             "objc_autorelease result and argument types must match");
+      Call->replaceAllUsesWith(Call->getArgOperand(0));
+      // Inserting each release before the pop in visitation order changes the
+      // drain order from LIFO to FIFO. This is acceptable because the pass
+      // already does not preserve pool drain order elsewhere (e.g., the
+      // use_empty() conversion above releases immediately in place).
+      FollowingPoolPopCache.erase(Call);
       EraseInstruction(Call);
       Inst = NewCall;
       Class = ARCInstKind::Release;
@@ -1163,6 +1264,7 @@ void ObjCARCOpt::OptimizeIndividualCallImpl(Function &F, Instruction *Inst,
     }
     // Erase the original call.
     LLVM_DEBUG(dbgs() << "Erasing: " << *CInst << "\n");
+    FollowingPoolPopCache.erase(CInst);
     EraseInstruction(CInst);
   } while (!Worklist.empty());
 }
@@ -2368,6 +2470,7 @@ void ObjCARCOpt::OptimizeReturns(Function &F) {
     LLVM_DEBUG(dbgs() << "Erasing: " << *Retain << "\nErasing: " << *Autorelease
                       << "\n");
     BundledInsts->eraseInst(Retain);
+    FollowingPoolPopCache.erase(Autorelease);
     EraseInstruction(Autorelease);
   }
 }

--- a/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
+++ b/llvm/lib/Transforms/ObjCARC/ObjCARCOpts.cpp
@@ -133,9 +133,6 @@ static const Value *FindSingleUseIdentifiedObject(const Value *Arg) {
 //
 // The second retain and autorelease can be deleted.
 
-// TODO: Autorelease calls followed by objc_autoreleasePoolPop calls (perhaps in
-// ObjC++ code after inlining) can be turned into plain release calls.
-
 // TODO: Critical-edge splitting. If the optimial insertion point is
 // a critical edge, the current algorithm has to fail, because it doesn't
 // know how to split edges. It should be possible to make the optimizer
@@ -499,6 +496,14 @@ class ObjCARCOpt {
 
   DenseMap<BasicBlock *, ColorVector> BlockEHColors;
 
+  /// Cache mapping autorelease instructions to their following
+  /// autoreleasePoolPop in the same basic block (or nullptr if none).
+  DenseMap<Instruction *, Instruction *> FollowingPoolPopCache;
+
+  /// Find the autoreleasePoolPop that will drain the given autorelease
+  /// instruction in the same basic block, skipping nested pools.
+  Instruction *FindFollowingAutoreleasePoolPop(Instruction *AutoreleaseInst);
+
   bool OptimizeRetainRVCall(Function &F, Instruction *RetainRV);
   void OptimizeAutoreleaseRVCall(Function &F, Instruction *AutoreleaseRV,
                                  ARCInstKind &Class);
@@ -600,6 +605,64 @@ class ObjCARCOpt {
     bool hasCFGChanged() const { return CFGChanged; }
 };
 } // end anonymous namespace
+
+/// Find the autoreleasePoolPop that will drain the given autorelease
+/// instruction in the same basic block, skipping over nested pools.
+///
+/// Since objc_autorelease does not change the refcount (it only registers the
+/// object for a deferred release at pool drain), we can move the release to
+/// just before the pool pop instead of converting in place. This avoids the
+/// need to check for uses of the pointer between the autorelease and the pop.
+Instruction *
+ObjCARCOpt::FindFollowingAutoreleasePoolPop(Instruction *AutoreleaseInst) {
+  assert(IsAutorelease(GetBasicARCInstKind(AutoreleaseInst)));
+
+  auto It = FollowingPoolPopCache.find(AutoreleaseInst);
+  if (It != FollowingPoolPopCache.end())
+    return It->second;
+
+  BasicBlock *BB = AutoreleaseInst->getParent();
+  Instruction *Result = nullptr;
+
+  SmallVector<Instruction *, 4> ScopeSiblings;
+
+  for (BasicBlock::iterator I = std::next(AutoreleaseInst->getIterator()),
+                            E = BB->end();
+       I != E; ++I) {
+    ARCInstKind Class = GetBasicARCInstKind(&*I);
+
+    if (Class == ARCInstKind::AutoreleasepoolPop) {
+      Result = &*I;
+      break;
+    }
+
+    if (Class == ARCInstKind::AutoreleasepoolPush) {
+      int Depth = 1;
+      BasicBlock::iterator J = std::next(I);
+      for (; J != E && Depth > 0; ++J) {
+        ARCInstKind NestedClass = GetBasicARCInstKind(&*J);
+        if (NestedClass == ARCInstKind::AutoreleasepoolPush)
+          ++Depth;
+        else if (NestedClass == ARCInstKind::AutoreleasepoolPop)
+          --Depth;
+      }
+      if (Depth == 0) {
+        I = std::prev(J);
+        continue;
+      }
+      break;
+    }
+
+    if (Class == ARCInstKind::Autorelease ||
+        Class == ARCInstKind::AutoreleaseRV)
+      ScopeSiblings.push_back(&*I);
+  }
+
+  FollowingPoolPopCache[AutoreleaseInst] = Result;
+  for (Instruction *I : ScopeSiblings)
+    FollowingPoolPopCache[I] = Result;
+  return Result;
+}
 
 /// Turn objc_retainAutoreleasedReturnValue into objc_retain if the operand is
 /// not a return value.
@@ -761,6 +824,8 @@ void ObjCARCOpt::OptimizeIndividualCalls(Function &F) {
   LLVM_DEBUG(dbgs() << "\n== ObjCARCOpt::OptimizeIndividualCalls ==\n");
   // Reset all the flags in preparation for recomputing them.
   UsedInThisFunction = 0;
+  // Clear the autorelease pool pop cache for this function
+  FollowingPoolPopCache.clear();
 
   // Store any delayed AutoreleaseRV intrinsics, so they can be easily paired
   // with RetainRV and UnsafeClaimRV.
@@ -986,9 +1051,7 @@ void ObjCARCOpt::OptimizeIndividualCallImpl(Function &F, Instruction *Inst,
       Changed = true;
       ++NumAutoreleases;
 
-      // Create the declaration lazily.
       LLVMContext &C = Inst->getContext();
-
       Function *Decl = EP.get(ARCRuntimeEntryPointKind::Release);
       CallInst *NewCall = CallInst::Create(Decl, Call->getArgOperand(0), "",
                                            Call->getIterator());
@@ -999,6 +1062,35 @@ void ObjCARCOpt::OptimizeIndividualCallImpl(Function &F, Instruction *Inst,
                            "since x is otherwise unused.\nOld: "
                         << *Call << "\nNew: " << *NewCall << "\n");
 
+      EraseInstruction(Call);
+      Inst = NewCall;
+      Class = ARCInstKind::Release;
+    }
+  }
+
+  // objc_autorelease(x) -> objc_release(x) moved to just before the
+  // autoreleasePoolPop. Since autorelease only registers a deferred release
+  // at pool drain time without changing the refcount, placing the release at
+  // the drain point is semantically equivalent and avoids use-after-free
+  // concerns with in-place conversion.
+  if (IsAutorelease(Class)) {
+    if (Instruction *PoolPop = FindFollowingAutoreleasePoolPop(Inst)) {
+      CallInst *Call = cast<CallInst>(Inst);
+      Changed = true;
+      ++NumAutoreleases;
+
+      LLVMContext &C = Inst->getContext();
+      Function *Decl = EP.get(ARCRuntimeEntryPointKind::Release);
+      CallInst *NewCall = CallInst::Create(Decl, Call->getArgOperand(0), "",
+                                           PoolPop->getIterator());
+      NewCall->setMetadata(MDKindCache.get(ARCMDKindID::ImpreciseRelease),
+                           MDNode::get(C, {}));
+
+      LLVM_DEBUG(dbgs() << "Moving autorelease{,RV}(x) to objc_release(x) "
+                           "before autoreleasePoolPop.\nOld: "
+                        << *Call << "\nNew: " << *NewCall << "\n");
+
+      Call->replaceAllUsesWith(Call->getArgOperand(0));
       EraseInstruction(Call);
       Inst = NewCall;
       Class = ARCInstKind::Release;
@@ -2508,6 +2600,7 @@ bool MayAutorelease(const CallBase &CB, unsigned Depth = 0) {
       SmallVector<bool, 4> PoolStack;
       for (const Instruction &I : BB) {
         ARCInstKind InstKind = GetBasicARCInstKind(&I);
+
         switch (InstKind) {
         case ARCInstKind::AutoreleasepoolPush:
           PoolStack.push_back(false);
@@ -2581,9 +2674,9 @@ void ObjCARCOpt::OptimizeAutoreleasePools(Function &F) {
   // TODO: Can we optimize inter-block autorelease pool pairs?
   // This would involve tracking autorelease pool state across blocks.
   for (BasicBlock &BB : F) {
-    // Use a stack to track nested autorelease pools
-    SmallVector<std::pair<CallInst *, bool>, 4>
-        PoolStack; // {push_inst, has_autorelease_in_scope}
+    // Stack tracks nested autorelease pools: {push_inst,
+    // has_autorelease_in_scope}
+    SmallVector<std::pair<CallInst *, bool>, 4> PoolStack;
 
     for (Instruction &Inst : llvm::make_early_inc_range(BB)) {
       ARCInstKind Class = GetBasicARCInstKind(&Inst);
@@ -2592,8 +2685,7 @@ void ObjCARCOpt::OptimizeAutoreleasePools(Function &F) {
       case ARCInstKind::AutoreleasepoolPush: {
         // Start tracking a new autorelease pool scope
         auto *Push = cast<CallInst>(&Inst);
-        PoolStack.push_back(
-            {Push, false}); // {push_inst, has_autorelease_in_scope}
+        PoolStack.push_back({Push, false});
         LLVM_DEBUG(dbgs() << "Found autorelease pool push: " << *Push << "\n");
         break;
       }
@@ -2601,55 +2693,72 @@ void ObjCARCOpt::OptimizeAutoreleasePools(Function &F) {
       case ARCInstKind::AutoreleasepoolPop: {
         auto *Pop = cast<CallInst>(&Inst);
 
+        // Skip if no matching push found
         if (PoolStack.empty())
           break;
 
-        auto &TopPool = PoolStack.back();
-        CallInst *PendingPush = TopPool.first;
-        bool HasAutoreleaseInScope = TopPool.second;
+        // Get the matching push and whether autoreleases were present
+        CallInst *MatchingPush = PoolStack.back().first;
+        bool HadAutoreleaseInScope = PoolStack.back().second;
+
+        // Verify this pop matches the push (handle pointer casts).
+        // The pop's argument should be the push result, possibly cast.
+        if (Pop->getArgOperand(0)->stripPointerCasts() != MatchingPush) {
+          // Mismatched pop.
+          // We can't trust the stack anymore, invalidating optimization for
+          // this block.
+          PoolStack.clear();
+          LLVM_DEBUG(dbgs() << "Autorelease pool mismatch: pop argument "
+                            << *Pop->getArgOperand(0)
+                            << " does not match most recent push "
+                            << *MatchingPush << "\n");
+          break;
+        }
 
         // Pop the stack - remove this pool scope
         PoolStack.pop_back();
 
-        // Bail if this pop doesn't match the pending push
-        if (Pop->getArgOperand(0)->stripPointerCasts() != PendingPush)
+        // Only eliminate pools that had no autoreleases in their scope.
+        // Note: autoreleases may have been converted to releases by
+        // OptimizeIndividualCalls, so we check if any were originally present.
+        if (HadAutoreleaseInScope)
           break;
 
-        // Bail if there were autoreleases in this scope
-        if (HasAutoreleaseInScope)
-          break;
-
-        // Optimize: eliminate this empty autorelease pool pair
+        // Emit the remark before erasing the instructions
         ORE.emit([&]() {
           return OptimizationRemark(DEBUG_TYPE, "AutoreleasePoolElimination",
-                                    PendingPush)
+                                    MatchingPush)
                  << "eliminated empty autorelease pool pair";
         });
 
         // Replace all uses of push with poison before deletion
-        PendingPush->replaceAllUsesWith(
-            PoisonValue::get(PendingPush->getType()));
+        MatchingPush->replaceAllUsesWith(
+            PoisonValue::get(MatchingPush->getType()));
 
+        MatchingPush->eraseFromParent();
         Pop->eraseFromParent();
-        PendingPush->eraseFromParent();
 
         Changed = true;
+
         ++NumNoops;
         break;
       }
+
       case ARCInstKind::CallOrUser:
       case ARCInstKind::Call:
+        // Check if this call might produce autoreleases
         if (!MayAutorelease(cast<CallBase>(Inst)))
           break;
         [[fallthrough]];
+
       case ARCInstKind::Autorelease:
       case ARCInstKind::AutoreleaseRV:
       case ARCInstKind::FusedRetainAutorelease:
       case ARCInstKind::FusedRetainAutoreleaseRV:
       case ARCInstKind::LoadWeak: {
-        // Track that we have autorelease calls in the current pool scope
+        // Mark that we have autorelease operations in the current pool scope
         if (!PoolStack.empty()) {
-          PoolStack.back().second = true; // Set has_autorelease_in_scope = true
+          PoolStack.back().second = true;
           LLVM_DEBUG(
               dbgs()
               << "Found autorelease or potential autorelease in pool scope: "

--- a/llvm/test/Transforms/ObjCARC/basic.ll
+++ b/llvm/test/Transforms/ObjCARC/basic.ll
@@ -1860,16 +1860,16 @@ entry:
   ret void
 }
 
-; Don't the known-incremented retain+release elimination if the pointer is
-; autoreleased and there's an autoreleasePoolPop.
+; The autorelease is moved to a release just before the autoreleasePoolPop.
+; The retain+release pair is not eliminated.
 
 ; CHECK-LABEL: define void @test43(
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT: call ptr @llvm.objc.retain(ptr %p)
-; CHECK-NEXT: call ptr @llvm.objc.autorelease(ptr %p)
 ; CHECK-NEXT: call ptr @llvm.objc.retain
 ; CHECK-NEXT: call void @use_pointer(ptr %p)
 ; CHECK-NEXT: call void @use_pointer(ptr %p)
+; CHECK-NEXT: call void @llvm.objc.release(ptr %p) {{.*}}, !clang.imprecise_release
 ; CHECK-NEXT: call void @llvm.objc.autoreleasePoolPop(ptr undef)
 ; CHECK-NEXT: call void @llvm.objc.release
 ; CHECK-NEXT: ret void

--- a/llvm/test/Transforms/ObjCARC/basic.ll
+++ b/llvm/test/Transforms/ObjCARC/basic.ll
@@ -1860,7 +1860,7 @@ entry:
   ret void
 }
 
-; Don't the known-incremented retain+release elimination if the pointer is
+; Don't do the known-incremented retain+release elimination if the pointer is
 ; autoreleased and there's an autoreleasePoolPop.
 
 ; CHECK-LABEL: define void @test43(

--- a/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
+++ b/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
@@ -36,16 +36,17 @@ define void @test_autorelease_to_release() {
   ret void
 }
 
-; Pool with autoreleases should not be optimized
+; Autoreleases are converted to releases before the pool pop.
+; Pool is kept because use_object may autorelease.
 define void @test_multiple_autoreleases() {
 ; CHECK-LABEL: define void @test_multiple_autoreleases() {
 ; CHECK-NEXT:    [[OBJ1:%.*]] = call ptr @create_object()
 ; CHECK-NEXT:    [[OBJ2:%.*]] = call ptr @create_object()
 ; CHECK-NEXT:    [[POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
 ; CHECK-NEXT:    call void @use_object(ptr [[OBJ1]])
-; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ1]]) #[[ATTR0]]
 ; CHECK-NEXT:    call void @use_object(ptr [[OBJ2]])
-; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ2]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ2]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
 ; CHECK-NEXT:    ret void
 ;
@@ -212,9 +213,7 @@ define void @test_complex_shadowing() {
 ; CHECK-NEXT:    [[OBJ3:%.*]] = call ptr @create_object()
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ2]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
-; CHECK-NEXT:    [[INNER2_POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
-; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ3]]) #[[ATTR0]]
-; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[INNER2_POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ3]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    ret void
 ;
   %obj1 = call ptr @create_object()
@@ -222,7 +221,8 @@ define void @test_complex_shadowing() {
   %obj3 = call ptr @create_object()
   %outer_pool = call ptr @llvm.objc.autoreleasePoolPush()
 
-  ; This autorelease is outside inner pools - prevents optimization
+  ; This autorelease is outside inner pools, but is converted to a release
+  ; before the outer pool pop, so the outer pool can still be optimized.
   call ptr @llvm.objc.autorelease(ptr %obj1)
 
   ; Inner pool 1 with shadowed autorelease
@@ -333,11 +333,9 @@ define void @test_cross_function_inner_pool_caller() {
 define void @test_autoreleaseRV_optimization(ptr %obj) {
 ; CHECK-LABEL: define void @test_autoreleaseRV_optimization(
 ; CHECK-SAME: ptr [[OBJ:%.*]]) {
-; CHECK-NEXT:    [[POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
-; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ]]) #[[ATTR0]]
-; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ]]) #[[ATTR0]]
-; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    ret void
 ;
   %pool = call ptr @llvm.objc.autoreleasePoolPush()
@@ -362,6 +360,41 @@ define void @test_cross_function_inner_pool_callee() {
   %obj = call ptr @create_object()
   %ar = call ptr @llvm.objc.autorelease(ptr %obj)
   call void @llvm.objc.autoreleasePoolPop(ptr %inner_pool)
+  ret void
+}
+
+; Use of autoreleased object between autorelease and pool pop is safe because
+; the release is moved to just before the pool pop, not converted in place.
+define void @test_use_after_autorelease_prevents_optimization(ptr %obj) {
+; CHECK-LABEL: define void @test_use_after_autorelease_prevents_optimization(
+; CHECK-SAME: ptr [[OBJ:%.*]]) {
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr [[OBJ]], align 4
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call ptr @llvm.objc.autorelease(ptr %obj)
+  ; This load uses %obj - safe because the release is placed before the pool pop,
+  ; after this load.
+  %val = load i32, ptr %obj
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
+  ret void
+}
+
+; Use of a DIFFERENT object between autorelease and pool pop should still
+; allow the optimization.
+define void @test_use_of_different_ptr_allows_optimization(ptr %obj1, ptr %obj2) {
+; CHECK-LABEL: define void @test_use_of_different_ptr_allows_optimization(
+; CHECK-SAME: ptr [[OBJ1:%.*]], ptr [[OBJ2:%.*]]) {
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr [[OBJ2]], align 4
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call ptr @llvm.objc.autorelease(ptr %obj1)
+  ; This load uses %obj2, not %obj1, so it's safe to convert the autorelease.
+  %val = load i32, ptr %obj2
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
   ret void
 }
 

--- a/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
+++ b/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
@@ -5,6 +5,7 @@
 declare ptr @llvm.objc.autoreleasePoolPush()
 declare void @llvm.objc.autoreleasePoolPop(ptr)
 declare ptr @llvm.objc.autorelease(ptr)
+declare ptr @llvm.objc.autoreleaseReturnValue(ptr)
 declare ptr @llvm.objc.retain(ptr)
 declare ptr @create_object()
 declare void @use_object(ptr)
@@ -324,6 +325,27 @@ define void @test_cross_function_inner_pool_caller() {
 ;
   %pool = call ptr @llvm.objc.autoreleasePoolPush()
   call void @test_cross_function_inner_pool_callee()
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
+  ret void
+}
+
+; Function that uses autoreleaseRV instead of autorelease
+define void @test_autoreleaseRV_optimization(ptr %obj) {
+; CHECK-LABEL: define void @test_autoreleaseRV_optimization(
+; CHECK-SAME: ptr [[OBJ:%.*]]) {
+; CHECK-NEXT:    [[POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ]]) #[[ATTR0]]
+; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+
+  %1 = call ptr @llvm.objc.autoreleaseReturnValue(ptr %obj)
+  %2 = call ptr @llvm.objc.autoreleaseReturnValue(ptr %obj)
+  %3 = call ptr @llvm.objc.autoreleaseReturnValue(ptr %obj)
+
   call void @llvm.objc.autoreleasePoolPop(ptr %pool)
   ret void
 }

--- a/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
+++ b/llvm/test/Transforms/ObjCARC/test_autorelease_pool.ll
@@ -36,7 +36,8 @@ define void @test_autorelease_to_release() {
   ret void
 }
 
-; Pool with autoreleases should not be optimized
+; Autoreleases are converted to releases before the pool pop.
+; Pool is kept because use_object may autorelease.
 define void @test_multiple_autoreleases() {
 ; CHECK-LABEL: define void @test_multiple_autoreleases() {
 ; CHECK-NEXT:    [[OBJ1:%.*]] = call ptr @create_object()
@@ -45,7 +46,7 @@ define void @test_multiple_autoreleases() {
 ; CHECK-NEXT:    call void @use_object(ptr [[OBJ1]])
 ; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ1]]) #[[ATTR0]]
 ; CHECK-NEXT:    call void @use_object(ptr [[OBJ2]])
-; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ2]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ2]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
 ; CHECK-NEXT:    ret void
 ;
@@ -212,9 +213,7 @@ define void @test_complex_shadowing() {
 ; CHECK-NEXT:    [[OBJ3:%.*]] = call ptr @create_object()
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ2]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
-; CHECK-NEXT:    [[INNER2_POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
-; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ3]]) #[[ATTR0]]
-; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[INNER2_POOL]]) #[[ATTR0]]
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ3]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
 ; CHECK-NEXT:    ret void
 ;
   %obj1 = call ptr @create_object()
@@ -222,7 +221,8 @@ define void @test_complex_shadowing() {
   %obj3 = call ptr @create_object()
   %outer_pool = call ptr @llvm.objc.autoreleasePoolPush()
 
-  ; This autorelease is outside inner pools - prevents optimization
+  ; This autorelease is outside inner pools, but is converted to a release
+  ; before the outer pool pop, so the outer pool can still be optimized.
   call ptr @llvm.objc.autorelease(ptr %obj1)
 
   ; Inner pool 1 with shadowed autorelease
@@ -329,25 +329,21 @@ define void @test_cross_function_inner_pool_caller() {
   ret void
 }
 
-; Function that uses autoreleaseRV instead of autorelease
-define void @test_autoreleaseRV_optimization(ptr %obj) {
-; CHECK-LABEL: define void @test_autoreleaseRV_optimization(
+; Demonstrate that autoreleaseRV is not incorrectly converted to a deferred
+; release. Converting autoreleaseRV to release before pool pop would prevent
+; the retain/autoreleaseRV pairing optimization from eliminating the pair.
+define ptr @test_retainRV_autoreleaseRV_pairing_in_pool(ptr %obj) {
+; CHECK-LABEL: define ptr @test_retainRV_autoreleaseRV_pairing_in_pool(
 ; CHECK-SAME: ptr [[OBJ:%.*]]) {
-; CHECK-NEXT:    [[POOL:%.*]] = call ptr @llvm.objc.autoreleasePoolPush() #[[ATTR0]]
-; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
-; CHECK-NEXT:    [[TMP1:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ]]) #[[ATTR0]]
-; CHECK-NEXT:    [[TMP2:%.*]] = call ptr @llvm.objc.autorelease(ptr [[OBJ]]) #[[ATTR0]]
-; CHECK-NEXT:    call void @llvm.objc.autoreleasePoolPop(ptr [[POOL]]) #[[ATTR0]]
-; CHECK-NEXT:    ret void
+; CHECK-NEXT:    ret ptr [[OBJ]]
 ;
   %pool = call ptr @llvm.objc.autoreleasePoolPush()
 
-  %1 = call ptr @llvm.objc.autoreleaseReturnValue(ptr %obj)
-  %2 = call ptr @llvm.objc.autoreleaseReturnValue(ptr %obj)
-  %3 = call ptr @llvm.objc.autoreleaseReturnValue(ptr %obj)
+  %retain = call ptr @llvm.objc.retain(ptr %obj)
+  %autorelease = call ptr @llvm.objc.autoreleaseReturnValue(ptr %retain)
 
   call void @llvm.objc.autoreleasePoolPop(ptr %pool)
-  ret void
+  ret ptr %autorelease
 }
 
 define void @test_cross_function_inner_pool_callee() {
@@ -395,6 +391,41 @@ define void @test_exotic_cast_bailout() {
   %int_val = ptrtoint ptr %pool to i64
   %ptr_val = inttoptr i64 %int_val to ptr
   call void @llvm.objc.autoreleasePoolPop(ptr %ptr_val)
+  ret void
+}
+
+; Use of autoreleased object between autorelease and pool pop is safe because
+; the release is moved to just before the pool pop, not converted in place.
+define void @test_use_between_autorelease_and_pop(ptr %obj) {
+; CHECK-LABEL: define void @test_use_between_autorelease_and_pop(
+; CHECK-SAME: ptr [[OBJ:%.*]]) {
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr [[OBJ]], align 4
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call ptr @llvm.objc.autorelease(ptr %obj)
+  ; This load uses %obj - safe because the release is placed before the pool pop,
+  ; after this load.
+  %val = load i32, ptr %obj
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
+  ret void
+}
+
+; Use of a DIFFERENT object between autorelease and pool pop should still
+; allow the optimization.
+define void @test_use_of_different_ptr_allows_optimization(ptr %obj1, ptr %obj2) {
+; CHECK-LABEL: define void @test_use_of_different_ptr_allows_optimization(
+; CHECK-SAME: ptr [[OBJ1:%.*]], ptr [[OBJ2:%.*]]) {
+; CHECK-NEXT:    call void @llvm.objc.release(ptr [[OBJ1]]) #[[ATTR0]], !clang.imprecise_release [[META0]]
+; CHECK-NEXT:    [[VAL:%.*]] = load i32, ptr [[OBJ2]], align 4
+; CHECK-NEXT:    ret void
+;
+  %pool = call ptr @llvm.objc.autoreleasePoolPush()
+  call ptr @llvm.objc.autorelease(ptr %obj1)
+  ; This load uses %obj2, not %obj1, so it's safe to convert the autorelease.
+  %val = load i32, ptr %obj2
+  call void @llvm.objc.autoreleasePoolPop(ptr %pool)
   ret void
 }
 


### PR DESCRIPTION
Instead of converting objc_autorelease(x) to objc_release(x) in place (which requires checking for uses of x between the autorelease and the pool pop), insert the release just before the matching autoreleasePoolPop. This is safe because objc_autorelease does not change the refcount; it only registers the object for a deferred release at pool drain time. Removing the autorelease and placing an explicit release at the drain point is semantically equivalent.