### PR TITLE
[libc] Move CharacterConverter template specialization to cpp file

### DIFF
--- a/libc/src/__support/wchar/character_converter.cpp
+++ b/libc/src/__support/wchar/character_converter.cpp
@@ -164,5 +164,13 @@ ErrorOr<char8_t> CharacterConverter::pop_utf8() {
   return static_cast<char8_t>(output);
 }
 
+template <> ErrorOr<char8_t> CharacterConverter::pop() { return pop_utf8(); }
+template <> ErrorOr<char32_t> CharacterConverter::pop() { return pop_utf32(); }
+
+template <> size_t CharacterConverter::sizeAs<char8_t>() {
+  return state->total_bytes;
+}
+template <> size_t CharacterConverter::sizeAs<char32_t>() { return 1; }
+
 } // namespace internal
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/__support/wchar/character_converter.h
+++ b/libc/src/__support/wchar/character_converter.h
@@ -33,8 +33,6 @@ public:
   bool isValidState();
 
   template <typename CharType> size_t sizeAs();
-  template <> size_t sizeAs<char8_t>() { return state->total_bytes; }
-  template <> size_t sizeAs<char32_t>() { return 1; }
 
   int push(char8_t utf8_byte);
   int push(char32_t utf32);
@@ -42,8 +40,6 @@ public:
   ErrorOr<char8_t> pop_utf8();
   ErrorOr<char32_t> pop_utf32();
   template <typename CharType> ErrorOr<CharType> pop();
-  template <> ErrorOr<char8_t> pop() { return pop_utf8(); }
-  template <> ErrorOr<char32_t> pop() { return pop_utf32(); }
 };
 
 } // namespace internal


### PR DESCRIPTION
Fixes build errors caused by #152204
