### PR TITLE
[LLDB] Avoid initializing the DarwinDYLD for all unknown os cases

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -178,6 +178,10 @@ DynamicLoader *DynamicLoaderDarwinKernel::CreateInstance(Process *process,
     // If we have triple like armv7-unknown-unknown, we should try looking for
     // a Darwin kernel.
     case llvm::Triple::UnknownOS:
+      // limiting it to only arm arch to handle cases like armv7-unknown-unknown
+      if (triple_ref.getArch() != llvm::Triple::arm) {
+        return nullptr;
+      }
       break;
     default:
       return nullptr;


### PR DESCRIPTION
Currently we are initializing the DynamicLoaderDarwinKernel for all the cases when OS is unknown. 

for example we have a baremetal use case for a riscv, where the triple is riscv64-unknown-unknown but DarwinDYLD is getting initialized which is not relevant. 