### PR TITLE
[libc] Fix typo and amend restrict qualifier

### DIFF
--- a/libc/include/dlfcn.yaml
+++ b/libc/include/dlfcn.yaml
@@ -46,7 +46,7 @@ enums:
     standards:
       - gnu
     value: 2
-  - name: RTLD_DI_CONFIGADDR,
+  - name: RTLD_DI_CONFIGADDR
     standards:
       - gnu
     value: 3
@@ -127,5 +127,5 @@ functions:
       - POSIX
     return_type: int
     arguments:
-      - type: const void *
-      - type: Dl_info *
+      - type: const void *__restrict
+      - type: Dl_info *__restrict

--- a/libc/src/dlfcn/dladdr.cpp
+++ b/libc/src/dlfcn/dladdr.cpp
@@ -14,7 +14,8 @@
 namespace LIBC_NAMESPACE_DECL {
 
 // TODO: https:// github.com/llvm/llvm-project/issues/97929
-LLVM_LIBC_FUNCTION(int, dladdr, (const void *addr, Dl_info *info)) {
+LLVM_LIBC_FUNCTION(int, dladdr,
+                   (const void *__restrict addr, Dl_info *__restrict info)) {
   return -1;
 }
 

--- a/libc/src/dlfcn/dladdr.h
+++ b/libc/src/dlfcn/dladdr.h
@@ -13,7 +13,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-int dladdr(const void *, Dl_info *);
+int dladdr(const void *__restrict, Dl_info *__restrict);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/dlfcn/dlinfo.cpp
+++ b/libc/src/dlfcn/dlinfo.cpp
@@ -15,7 +15,9 @@
 namespace LIBC_NAMESPACE_DECL {
 
 // TODO: https://github.com/llvm/llvm-project/issues/149911
-LLVM_LIBC_FUNCTION(int, dlinfo, (void *handle, int request, void *info)) {
+LLVM_LIBC_FUNCTION(int, dlinfo,
+                   (void *__restrict handle, int request,
+                    void *__restrict info)) {
   return -1;
 }
 

--- a/libc/src/dlfcn/dlinfo.cpp
+++ b/libc/src/dlfcn/dlinfo.cpp
@@ -15,8 +15,7 @@
 namespace LIBC_NAMESPACE_DECL {
 
 // TODO: https://github.com/llvm/llvm-project/issues/149911
-LLVM_LIBC_FUNCTION(int, dlinfo,
-                   (void *restrict handle, int request, void *restrict info)) {
+LLVM_LIBC_FUNCTION(int, dlinfo, (void *handle, int request, void *info)) {
   return -1;
 }
 

--- a/libc/src/dlfcn/dlinfo.h
+++ b/libc/src/dlfcn/dlinfo.h
@@ -13,7 +13,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-int dlinfo(void *restrict, int, void *restrict);
+int dlinfo(void *, int, void *);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/dlfcn/dlinfo.h
+++ b/libc/src/dlfcn/dlinfo.h
@@ -13,7 +13,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-int dlinfo(void *, int, void *);
+int dlinfo(void *__restrict, int, void *__restrict);
 
 } // namespace LIBC_NAMESPACE_DECL
 

--- a/libc/src/dlfcn/dlsym.cpp
+++ b/libc/src/dlfcn/dlsym.cpp
@@ -14,6 +14,8 @@
 namespace LIBC_NAMESPACE_DECL {
 
 // TODO(@izaakschroeder): https://github.com/llvm/llvm-project/issues/97920
-LLVM_LIBC_FUNCTION(void *, dlsym, (void *, const char *)) { return nullptr; }
+LLVM_LIBC_FUNCTION(void *, dlsym, (void *__restrict, const char *__restrict)) {
+  return nullptr;
+}
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/dlfcn/dlsym.h
+++ b/libc/src/dlfcn/dlsym.h
@@ -13,7 +13,7 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-void *dlsym(void *, const char *);
+void *dlsym(void *__restrict, const char *__restrict);
 
 } // namespace LIBC_NAMESPACE_DECL
 


### PR DESCRIPTION
This removes an extraneous ',' in the generated dlfcn header.

This also adds `__restrict` to `dladdr`'s declaration per POSIX. Another fix is made: the C standard `restrict` keyword is removed from dlinfo.cpp/dlinfo.h (but note that dlfcn.yaml still annotates `__restrict` for dlinfo's decl).