### PR TITLE
[ARM] [IR] [Builtins] Give the data barrier instructions the same attributes they have in AArch64

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsARM.td
+++ b/llvm/include/llvm/IR/IntrinsicsARM.td
@@ -299,13 +299,12 @@ def int_arm_ldaexd : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_ptr_ty]>;
 //===----------------------------------------------------------------------===//
 // Data barrier instructions
 
-// TODO: Add applicable default attributes.
 def int_arm_dmb : ClangBuiltin<"__builtin_arm_dmb">, MSBuiltin<"__dmb">,
-                  Intrinsic<[], [llvm_i32_ty]>;
+                  Intrinsic<[], [llvm_i32_ty], [IntrNoFree, IntrWillReturn]>;
 def int_arm_dsb : ClangBuiltin<"__builtin_arm_dsb">, MSBuiltin<"__dsb">,
-                  Intrinsic<[], [llvm_i32_ty]>;
+                  Intrinsic<[], [llvm_i32_ty], [IntrNoFree, IntrWillReturn]>;
 def int_arm_isb : ClangBuiltin<"__builtin_arm_isb">, MSBuiltin<"__isb">,
-                  Intrinsic<[], [llvm_i32_ty]>;
+                  Intrinsic<[], [llvm_i32_ty], [IntrNoFree, IntrWillReturn]>;
 
 //===----------------------------------------------------------------------===//
 // VFP

--- a/llvm/include/llvm/IR/IntrinsicsARM.td
+++ b/llvm/include/llvm/IR/IntrinsicsARM.td
@@ -409,8 +409,8 @@ def int_arm_cmse_ttat : ClangBuiltin<"__builtin_arm_cmse_TTAT">,
 //===----------------------------------------------------------------------===//
 // HINT
 
+def int_arm_hint : DefaultAttrsIntrinsic<[], [llvm_i32_ty]>;
 // TODO: Add applicable default attributes.
-def int_arm_hint : Intrinsic<[], [llvm_i32_ty]>;
 def int_arm_dbg : Intrinsic<[], [llvm_i32_ty]>;
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
They are IntrNoFree and IntrWillReturn, so give them that.