### PR TITLE
[NFC][Support] Add an include file for time profiler helpers for tools

### DIFF
--- a/llvm/include/llvm/Support/TimeProfilerTool.inc
+++ b/llvm/include/llvm/Support/TimeProfilerTool.inc
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines command line options and helper class for tools that want
+// to use time trace profiling. It is intended for inclusion in a tool's .cpp
+// file.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_TIMEROFILER_TOOL_INC
+#define LLVM_SUPPORT_TIMEROFILER_TOOL_INC
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/TimeProfiler.h"
+
+static llvm::cl::opt<bool> TimeTrace("time-trace",
+                                     llvm::cl::desc("Record time trace"));
+
+static llvm::cl::opt<unsigned> TimeTraceGranularity(
+    "time-trace-granularity",
+    llvm::cl::desc(
+        "Minimum time granularity (in microseconds) traced by time profiler"),
+    llvm::cl::init(500), llvm::cl::Hidden);
+
+static llvm::cl::opt<std::string>
+    TimeTraceFile("time-trace-file",
+                  llvm::cl::desc("Specify time trace file destination"),
+                  llvm::cl::value_desc("filename"));
+
+namespace {
+
+/// The TimeTraceProfilerRAII is a helper class to initialize and write the time
+/// trace profile, intended for use in various tools.
+class TimeTraceProfilerRAII {
+private:
+  llvm::StringRef OutputFilename;
+
+public:
+  TimeTraceProfilerRAII(llvm::StringRef ProgramName,
+                        llvm::StringRef OutputFilename)
+      : OutputFilename(OutputFilename) {
+    if (TimeTrace)
+      llvm::timeTraceProfilerInitialize(TimeTraceGranularity, ProgramName);
+  }
+  ~TimeTraceProfilerRAII() {
+    if (!TimeTrace)
+      return;
+    if (auto E = llvm::timeTraceProfilerWrite(TimeTraceFile, OutputFilename)) {
+      llvm::logAllUnhandledErrors(std::move(E), llvm::errs());
+      return;
+    }
+    llvm::timeTraceProfilerCleanup();
+  }
+};
+
+} // namespace
+
+#endif // LLVM_SUPPORT_TIMEROFILER_TOOL_INC

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -47,7 +47,7 @@
 #include "llvm/Support/PluginLoader.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/TimeProfilerTool.inc"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
@@ -87,19 +87,6 @@ static cl::opt<unsigned>
 TimeCompilations("time-compilations", cl::Hidden, cl::init(1u),
                  cl::value_desc("N"),
                  cl::desc("Repeat compilation N times for timing"));
-
-static cl::opt<bool> TimeTrace("time-trace", cl::desc("Record time trace"));
-
-static cl::opt<unsigned> TimeTraceGranularity(
-    "time-trace-granularity",
-    cl::desc(
-        "Minimum time granularity (in microseconds) traced by time profiler"),
-    cl::init(500), cl::Hidden);
-
-static cl::opt<std::string>
-    TimeTraceFile("time-trace-file",
-                  cl::desc("Specify time trace file destination"),
-                  cl::value_desc("filename"));
 
 static cl::opt<std::string>
     BinutilsVersion("binutils-version", cl::Hidden,
@@ -367,19 +354,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (TimeTrace)
-    timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
-  auto TimeTraceScopeExit = make_scope_exit([]() {
-    if (TimeTrace) {
-      if (auto E = timeTraceProfilerWrite(TimeTraceFile, OutputFilename)) {
-        handleAllErrors(std::move(E), [&](const StringError &SE) {
-          errs() << SE.getMessage() << "\n";
-        });
-        return;
-      }
-      timeTraceProfilerCleanup();
-    }
-  });
+  TimeTraceProfilerRAII TimeTracer(argv[0], OutputFilename);
 
   LLVMContext Context;
   Context.setDiscardValueNames(DiscardValueNames);

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -38,7 +38,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/TimeProfilerTool.inc"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/WithColor.h"
 #include "llvm/TargetParser/Host.h"
@@ -246,19 +246,6 @@ static cl::opt<unsigned>
     NumBenchmarkRuns("runs", cl::desc("Number of runs for benchmarking"),
                      cl::cat(MCCategory));
 
-static cl::opt<bool> TimeTrace("time-trace", cl::desc("Record time trace"));
-
-static cl::opt<unsigned> TimeTraceGranularity(
-    "time-trace-granularity",
-    cl::desc(
-        "Minimum time granularity (in microseconds) traced by time profiler"),
-    cl::init(500), cl::Hidden);
-
-static cl::opt<std::string>
-    TimeTraceFile("time-trace-file",
-                  cl::desc("Specify time trace file destination"),
-                  cl::value_desc("filename"));
-
 static const Target *GetTarget(const char *ProgName) {
   // Figure out the target triple.
   if (TripleName.empty())
@@ -391,18 +378,7 @@ int main(int argc, char **argv) {
   cl::HideUnrelatedOptions({&MCCategory, &getColorCategory()});
   cl::ParseCommandLineOptions(argc, argv, "llvm machine code playground\n");
 
-  if (TimeTrace)
-    timeTraceProfilerInitialize(TimeTraceGranularity, argv[0]);
-
-  auto TimeTraceScopeExit = make_scope_exit([]() {
-    if (!TimeTrace)
-      return;
-    if (auto E = timeTraceProfilerWrite(TimeTraceFile, OutputFilename)) {
-      logAllUnhandledErrors(std::move(E), errs());
-      return;
-    }
-    timeTraceProfilerCleanup();
-  });
+  TimeTraceProfilerRAII TimeTracer(argv[0], OutputFilename);
 
   MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
   MCOptions.CompressDebugSections = CompressDebugSections.getValue();

--- a/llvm/tools/opt/optdriver.cpp
+++ b/llvm/tools/opt/optdriver.cpp
@@ -47,7 +47,7 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/SystemUtils.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/TimeProfilerTool.inc"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Target/TargetMachine.h"
@@ -252,19 +252,6 @@ static cl::opt<bool> DiscardValueNames(
     cl::desc("Discard names from Value (other than GlobalValue)."),
     cl::init(false), cl::Hidden);
 
-static cl::opt<bool> TimeTrace("time-trace", cl::desc("Record time trace"));
-
-static cl::opt<unsigned> TimeTraceGranularity(
-    "time-trace-granularity",
-    cl::desc(
-        "Minimum time granularity (in microseconds) traced by time profiler"),
-    cl::init(500), cl::Hidden);
-
-static cl::opt<std::string>
-    TimeTraceFile("time-trace-file",
-                  cl::desc("Specify time trace file destination"),
-                  cl::value_desc("filename"));
-
 static cl::opt<bool> RemarksWithHotness(
     "pass-remarks-with-hotness",
     cl::desc("With PGO, include profile count in optimization remarks"),
@@ -305,24 +292,6 @@ static cl::list<std::string>
 static CodeGenOptLevel GetCodeGenOptLevel() {
   return static_cast<CodeGenOptLevel>(unsigned(CodeGenOptLevelCL));
 }
-
-struct TimeTracerRAII {
-  TimeTracerRAII(StringRef ProgramName) {
-    if (TimeTrace)
-      timeTraceProfilerInitialize(TimeTraceGranularity, ProgramName);
-  }
-  ~TimeTracerRAII() {
-    if (TimeTrace) {
-      if (auto E = timeTraceProfilerWrite(TimeTraceFile, OutputFilename)) {
-        handleAllErrors(std::move(E), [&](const StringError &SE) {
-          errs() << SE.getMessage() << "\n";
-        });
-        return;
-      }
-      timeTraceProfilerCleanup();
-    }
-  }
-};
 
 // For use in NPM transition. Currently this contains most codegen-specific
 // passes. Remove passes from here when porting to the NPM.
@@ -503,7 +472,7 @@ extern "C" int optMain(
     return 0;
   }
 
-  TimeTracerRAII TimeTracer(argv[0]);
+  TimeTraceProfilerRAII TimeTracer(argv[0], OutputFilename);
 
   SMDiagnostic Err;
 


### PR DESCRIPTION
Add an include file that defines time profiler related command line options, move the TimeProfiler RAII helper class from `optdriver.cpp` to this file, and adopt this in various LLVM tools.