### PR TITLE
[sanitizer] Warn if allocator size exceeds max user virtual address

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -119,9 +119,10 @@ class SizeClassAllocator64 {
     VReport(3, "Max user virtual address: 0x%zx\n", MaxAddr);
     VReport(3, "Total space size for primary allocator: 0x%zx\n",
             TotalSpaceSize);
-    // TODO: hypothetical edge case: on >48-bit VMA systems, Linux by default
-    //       maps as if it was a 48-bit VMA, but a sanitizer could
-    //       theoretically map beyond the 48-bit limit (N.B. 2**48 == 256TB).
+    // TODO: revise the check if we ever configure sanitizers to deliberately
+    //       map beyond the 2**48 barrier (note that Linux pretends the VMA is
+    //       limited to 48-bit for backwards compatibility, but allows apps to
+    //       explicitly specify an address beyond that).
     if (heap_start + TotalSpaceSize >= MaxAddr) {
       // We can't easily adjust the requested heap size, because kSpaceSize is
       // const (for optimization) and used throughout the code.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -113,6 +113,18 @@ class SizeClassAllocator64 {
   // ~(uptr)0.
   void Init(s32 release_to_os_interval_ms, uptr heap_start = 0) {
     uptr TotalSpaceSize = kSpaceSize + AdditionalSize();
+
+    uptr MaxAddr = GetMaxUserVirtualAddress();
+    // VReport does not call the sanitizer allocator.
+    VReport(3, "Max user virtual address: 0x%zx\n", MaxAddr);
+    VReport(3, "Total space size for primary allocator: 0x%zx\n",
+            TotalSpaceSize);
+    if (TotalSpaceSize >= MaxAddr)
+      VReport(0, "Error: heap size %zx exceeds max user virtual address %zx\n",
+              TotalSpaceSize, MaxAddr);
+    // We can't easily adjust the requested heap size, because kSpaceSize is
+    // const (for optimization) and used throughout the code.
+
     PremappedHeap = heap_start != 0;
     if (PremappedHeap) {
       CHECK(!kUsingConstantSpaceBeg);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -119,12 +119,14 @@ class SizeClassAllocator64 {
     VReport(3, "Max user virtual address: 0x%zx\n", MaxAddr);
     VReport(3, "Total space size for primary allocator: 0x%zx\n",
             TotalSpaceSize);
-    if (TotalSpaceSize >= MaxAddr)
+    if (TotalSpaceSize >= MaxAddr) {
+      // We can't easily adjust the requested heap size, because kSpaceSize is
+      // const (for optimization) and used throughout the code.
       VReport(0, "Error: heap size %zx exceeds max user virtual address %zx\n",
               TotalSpaceSize, MaxAddr);
-    // We can't easily adjust the requested heap size, because kSpaceSize is
-    // const (for optimization) and used throughout the code.
-
+      VReport(
+          0, "Try using a kernel that allows a larger virtual address space\n");
+    }
     PremappedHeap = heap_start != 0;
     if (PremappedHeap) {
       CHECK(!kUsingConstantSpaceBeg);

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -119,6 +119,9 @@ class SizeClassAllocator64 {
     VReport(3, "Max user virtual address: 0x%zx\n", MaxAddr);
     VReport(3, "Total space size for primary allocator: 0x%zx\n",
             TotalSpaceSize);
+    // TODO: hypothetical edge case: on >48-bit VMA systems, Linux by default
+    //       maps as if it was a 48-bit VMA, but a sanitizer could
+    //       theoretically map beyond the 48-bit limit (N.B. 2**48 == 256TB).
     if (TotalSpaceSize >= MaxAddr) {
       // We can't easily adjust the requested heap size, because kSpaceSize is
       // const (for optimization) and used throughout the code.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_primary64.h
@@ -122,7 +122,7 @@ class SizeClassAllocator64 {
     // TODO: hypothetical edge case: on >48-bit VMA systems, Linux by default
     //       maps as if it was a 48-bit VMA, but a sanitizer could
     //       theoretically map beyond the 48-bit limit (N.B. 2**48 == 256TB).
-    if (TotalSpaceSize >= MaxAddr) {
+    if (heap_start + TotalSpaceSize >= MaxAddr) {
       // We can't easily adjust the requested heap size, because kSpaceSize is
       // const (for optimization) and used throughout the code.
       VReport(0, "Error: heap size %zx exceeds max user virtual address %zx\n",


### PR DESCRIPTION
This warns the user of incompatible configurations, such as 39-bit and 42-bit VMAs for AArch64 non-Android Linux ASan (https://github.com/llvm/llvm-project/issues/145259).