### PR TITLE
[LoongArch] Fix implicit PesudoXVINSGR2VR error

### DIFF
--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
@@ -6042,22 +6042,24 @@ static MachineBasicBlock *
 emitPseudoXVINSGR2VR(MachineInstr &MI, MachineBasicBlock *BB,
                      const LoongArchSubtarget &Subtarget) {
   unsigned InsOp;
+  unsigned BroadcastOp;
   unsigned HalfSize;
   switch (MI.getOpcode()) {
   default:
     llvm_unreachable("Unexpected opcode");
   case LoongArch::PseudoXVINSGR2VR_B:
     HalfSize = 16;
-    InsOp = LoongArch::VINSGR2VR_B;
+    BroadcastOp = LoongArch::XVREPLGR2VR_B;
+    InsOp = LoongArch::XVEXTRINS_B;
     break;
   case LoongArch::PseudoXVINSGR2VR_H:
     HalfSize = 8;
-    InsOp = LoongArch::VINSGR2VR_H;
+    BroadcastOp = LoongArch::XVREPLGR2VR_H;
+    InsOp = LoongArch::XVEXTRINS_H;
     break;
   }
   const TargetInstrInfo *TII = Subtarget.getInstrInfo();
   const TargetRegisterClass *RC = &LoongArch::LASX256RegClass;
-  const TargetRegisterClass *SubRC = &LoongArch::LSX128RegClass;
   DebugLoc DL = MI.getDebugLoc();
   MachineRegisterInfo &MRI = BB->getParent()->getRegInfo();
   // XDst = vector_insert XSrc, Elt, Idx
@@ -6066,37 +6068,19 @@ emitPseudoXVINSGR2VR(MachineInstr &MI, MachineBasicBlock *BB,
   Register Elt = MI.getOperand(2).getReg();
   unsigned Idx = MI.getOperand(3).getImm();
 
-  Register ScratchReg1 = XSrc;
-  if (Idx >= HalfSize) {
-    ScratchReg1 = MRI.createVirtualRegister(RC);
-    BuildMI(*BB, MI, DL, TII->get(LoongArch::XVPERMI_D), ScratchReg1)
-        .addReg(XSrc)
-        .addImm(14);
-  }
+  Register ScratchReg1 = MRI.createVirtualRegister(RC);
+  Register ScratchReg2 = MRI.createVirtualRegister(RC);
+  BuildMI(*BB, MI, DL, TII->get(BroadcastOp), ScratchReg1).addReg(Elt);
 
-  Register ScratchSubReg1 = MRI.createVirtualRegister(SubRC);
-  Register ScratchSubReg2 = MRI.createVirtualRegister(SubRC);
-  BuildMI(*BB, MI, DL, TII->get(LoongArch::COPY), ScratchSubReg1)
-      .addReg(ScratchReg1, 0, LoongArch::sub_128);
-  BuildMI(*BB, MI, DL, TII->get(InsOp), ScratchSubReg2)
-      .addReg(ScratchSubReg1)
-      .addReg(Elt)
-      .addImm(Idx >= HalfSize ? Idx - HalfSize : Idx);
+  BuildMI(*BB, MI, DL, TII->get(LoongArch::XVPERMI_Q), ScratchReg2)
+      .addReg(ScratchReg1)
+      .addReg(XSrc)
+      .addImm(Idx >= HalfSize ? 48 : 18);
 
-  Register ScratchReg2 = XDst;
-  if (Idx >= HalfSize)
-    ScratchReg2 = MRI.createVirtualRegister(RC);
-
-  BuildMI(*BB, MI, DL, TII->get(LoongArch::SUBREG_TO_REG), ScratchReg2)
-      .addImm(0)
-      .addReg(ScratchSubReg2)
-      .addImm(LoongArch::sub_128);
-
-  if (Idx >= HalfSize)
-    BuildMI(*BB, MI, DL, TII->get(LoongArch::XVPERMI_Q), XDst)
-        .addReg(XSrc)
-        .addReg(ScratchReg2)
-        .addImm(2);
+  BuildMI(*BB, MI, DL, TII->get(InsOp), XDst)
+      .addReg(XSrc)
+      .addReg(ScratchReg2)
+      .addImm((Idx >= HalfSize ? Idx - HalfSize : Idx) * 17);
 
   MI.eraseFromParent();
   return BB;

--- a/llvm/test/CodeGen/LoongArch/lasx/build-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/build-vector.ll
@@ -233,7 +233,7 @@ define void @buildvector_v32i8(ptr %dst, i8 %a0, i8 %a1, i8 %a2, i8 %a3, i8 %a4,
 ; CHECK-NEXT:    fst.d $fs5, $sp, 32 # 8-byte Folded Spill
 ; CHECK-NEXT:    fst.d $fs6, $sp, 24 # 8-byte Folded Spill
 ; CHECK-NEXT:    fst.d $fs7, $sp, 16 # 8-byte Folded Spill
-; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
+; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
 ; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
 ; CHECK-NEXT:    xvreplgr2vr.b $xr2, $a3
 ; CHECK-NEXT:    xvreplgr2vr.b $xr3, $a4
@@ -290,8 +290,6 @@ define void @buildvector_v32i8(ptr %dst, i8 %a0, i8 %a1, i8 %a2, i8 %a3, i8 %a4,
 ; CHECK-NEXT:    xvreplgr2vr.b $xr29, $a3
 ; CHECK-NEXT:    xvreplgr2vr.b $xr30, $a1
 ; CHECK-NEXT:    xvreplgr2vr.b $xr31, $a4
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
-; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 0
 ; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
 ; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
 ; CHECK-NEXT:    xvpermi.q $xr2, $xr0, 18
@@ -413,9 +411,7 @@ define void @buildvector_v32i8_partial(ptr %dst, i8 %a0, i8 %a1, i8 %a2, i8 %a5,
 ; CHECK-NEXT:    ld.b $t5, $sp, 16
 ; CHECK-NEXT:    ld.b $t6, $sp, 8
 ; CHECK-NEXT:    ld.b $t7, $sp, 0
-; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
-; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 0
+; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
 ; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
 ; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
 ; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
@@ -605,9 +601,7 @@ define void @buildvector_v16i16(ptr %dst, i16 %a0, i16 %a1, i16 %a2, i16 %a3, i1
 ; CHECK-NEXT:    ld.h $t6, $sp, 16
 ; CHECK-NEXT:    ld.h $t7, $sp, 8
 ; CHECK-NEXT:    ld.h $t8, $sp, 0
-; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
-; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 0
+; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 0
 ; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
 ; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
 ; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 17
@@ -679,9 +673,7 @@ entry:
 define void @buildvector_v16i16_partial(ptr %dst, i16 %a0, i16 %a2, i16 %a5, i16 %a6, i16 %a7, i16 %a12, i16 %a13) nounwind {
 ; CHECK-LABEL: buildvector_v16i16_partial:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
-; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 0
+; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 0
 ; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
 ; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
 ; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 34

--- a/llvm/test/CodeGen/LoongArch/lasx/build-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/build-vector.ll
@@ -224,96 +224,146 @@ entry:
 define void @buildvector_v32i8(ptr %dst, i8 %a0, i8 %a1, i8 %a2, i8 %a3, i8 %a4, i8 %a5, i8 %a6, i8 %a7, i8 %a8, i8 %a9, i8 %a10, i8 %a11, i8 %a12, i8 %a13, i8 %a14, i8 %a15, i8 %a16, i8 %a17, i8 %a18, i8 %a19, i8 %a20, i8 %a21, i8 %a22, i8 %a23, i8 %a24, i8 %a25, i8 %a26, i8 %a27, i8 %a28, i8 %a29, i8 %a30, i8 %a31) nounwind {
 ; CHECK-LABEL: buildvector_v32i8:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 1
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a3, 2
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a4, 3
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a5, 4
-; CHECK-NEXT:    ld.b $a1, $sp, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a6, 5
-; CHECK-NEXT:    ld.b $a2, $sp, 8
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a7, 6
-; CHECK-NEXT:    ld.b $a3, $sp, 16
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 7
-; CHECK-NEXT:    ld.b $a1, $sp, 24
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 8
-; CHECK-NEXT:    ld.b $a2, $sp, 32
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a3, 9
-; CHECK-NEXT:    ld.b $a3, $sp, 40
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 10
-; CHECK-NEXT:    ld.b $a1, $sp, 48
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 11
-; CHECK-NEXT:    ld.b $a2, $sp, 56
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a3, 12
-; CHECK-NEXT:    ld.b $a3, $sp, 64
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 13
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 14
-; CHECK-NEXT:    ld.b $a1, $sp, 72
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a3, 15
+; CHECK-NEXT:    addi.d $sp, $sp, -80
+; CHECK-NEXT:    fst.d $fs0, $sp, 72 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs1, $sp, 64 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs2, $sp, 56 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs3, $sp, 48 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs4, $sp, 40 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs5, $sp, 32 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs6, $sp, 24 # 8-byte Folded Spill
+; CHECK-NEXT:    fst.d $fs7, $sp, 16 # 8-byte Folded Spill
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
+; CHECK-NEXT:    xvreplgr2vr.b $xr2, $a3
+; CHECK-NEXT:    xvreplgr2vr.b $xr3, $a4
+; CHECK-NEXT:    ld.b $a1, $sp, 264
+; CHECK-NEXT:    xvreplgr2vr.b $xr4, $a5
 ; CHECK-NEXT:    ld.b $a2, $sp, 80
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 0
-; CHECK-NEXT:    ld.b $a1, $sp, 88
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 1
-; CHECK-NEXT:    ld.b $a2, $sp, 96
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 2
-; CHECK-NEXT:    ld.b $a1, $sp, 104
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 3
-; CHECK-NEXT:    ld.b $a2, $sp, 112
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 4
-; CHECK-NEXT:    ld.b $a1, $sp, 120
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 5
+; CHECK-NEXT:    xvreplgr2vr.b $xr5, $a6
+; CHECK-NEXT:    ld.b $a3, $sp, 88
+; CHECK-NEXT:    xvreplgr2vr.b $xr6, $a7
+; CHECK-NEXT:    ld.b $a4, $sp, 96
+; CHECK-NEXT:    xvreplgr2vr.b $xr7, $a2
+; CHECK-NEXT:    ld.b $a2, $sp, 104
+; CHECK-NEXT:    xvreplgr2vr.b $xr8, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 112
+; CHECK-NEXT:    xvreplgr2vr.b $xr9, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 120
+; CHECK-NEXT:    xvreplgr2vr.b $xr10, $a2
 ; CHECK-NEXT:    ld.b $a2, $sp, 128
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 6
-; CHECK-NEXT:    ld.b $a1, $sp, 136
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 7
-; CHECK-NEXT:    ld.b $a2, $sp, 144
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 8
-; CHECK-NEXT:    ld.b $a1, $sp, 152
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 9
-; CHECK-NEXT:    ld.b $a2, $sp, 160
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 10
-; CHECK-NEXT:    ld.b $a1, $sp, 168
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 11
+; CHECK-NEXT:    xvreplgr2vr.b $xr11, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 136
+; CHECK-NEXT:    xvreplgr2vr.b $xr12, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 144
+; CHECK-NEXT:    xvreplgr2vr.b $xr13, $a2
+; CHECK-NEXT:    ld.b $a2, $sp, 152
+; CHECK-NEXT:    xvreplgr2vr.b $xr14, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 160
+; CHECK-NEXT:    xvreplgr2vr.b $xr15, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 168
+; CHECK-NEXT:    xvreplgr2vr.b $xr16, $a2
 ; CHECK-NEXT:    ld.b $a2, $sp, 176
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 12
-; CHECK-NEXT:    ld.b $a1, $sp, 184
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 13
-; CHECK-NEXT:    ld.b $a2, $sp, 192
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a1, 14
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 15
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.b $xr17, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 184
+; CHECK-NEXT:    xvreplgr2vr.b $xr18, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 192
+; CHECK-NEXT:    xvreplgr2vr.b $xr19, $a2
+; CHECK-NEXT:    ld.b $a2, $sp, 200
+; CHECK-NEXT:    xvreplgr2vr.b $xr20, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 208
+; CHECK-NEXT:    xvreplgr2vr.b $xr21, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 216
+; CHECK-NEXT:    xvreplgr2vr.b $xr22, $a2
+; CHECK-NEXT:    ld.b $a2, $sp, 224
+; CHECK-NEXT:    xvreplgr2vr.b $xr23, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 232
+; CHECK-NEXT:    xvreplgr2vr.b $xr24, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 240
+; CHECK-NEXT:    xvreplgr2vr.b $xr25, $a2
+; CHECK-NEXT:    ld.b $a2, $sp, 248
+; CHECK-NEXT:    xvreplgr2vr.b $xr26, $a3
+; CHECK-NEXT:    ld.b $a3, $sp, 256
+; CHECK-NEXT:    xvreplgr2vr.b $xr27, $a4
+; CHECK-NEXT:    ld.b $a4, $sp, 272
+; CHECK-NEXT:    xvreplgr2vr.b $xr28, $a2
+; CHECK-NEXT:    xvreplgr2vr.b $xr29, $a3
+; CHECK-NEXT:    xvreplgr2vr.b $xr30, $a1
+; CHECK-NEXT:    xvreplgr2vr.b $xr31, $a4
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 0
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
+; CHECK-NEXT:    xvpermi.q $xr2, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr2, 34
+; CHECK-NEXT:    xvpermi.q $xr3, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr3, 51
+; CHECK-NEXT:    xvpermi.q $xr4, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr4, 68
+; CHECK-NEXT:    xvpermi.q $xr5, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr5, 85
+; CHECK-NEXT:    xvpermi.q $xr6, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr6, 102
+; CHECK-NEXT:    xvpermi.q $xr7, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr7, 119
+; CHECK-NEXT:    xvpermi.q $xr8, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr8, 136
+; CHECK-NEXT:    xvpermi.q $xr9, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr9, 153
+; CHECK-NEXT:    xvpermi.q $xr10, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr10, 170
+; CHECK-NEXT:    xvpermi.q $xr11, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr11, 187
+; CHECK-NEXT:    xvpermi.q $xr12, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr12, 204
+; CHECK-NEXT:    xvpermi.q $xr13, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr13, 221
+; CHECK-NEXT:    xvpermi.q $xr14, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr14, 238
+; CHECK-NEXT:    xvpermi.q $xr15, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr15, 255
+; CHECK-NEXT:    xvpermi.q $xr16, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr16, 0
+; CHECK-NEXT:    xvpermi.q $xr17, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr17, 17
+; CHECK-NEXT:    xvpermi.q $xr18, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr18, 34
+; CHECK-NEXT:    xvpermi.q $xr19, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr19, 51
+; CHECK-NEXT:    xvpermi.q $xr20, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr20, 68
+; CHECK-NEXT:    xvpermi.q $xr21, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr21, 85
+; CHECK-NEXT:    xvpermi.q $xr22, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr22, 102
+; CHECK-NEXT:    xvpermi.q $xr23, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr23, 119
+; CHECK-NEXT:    xvpermi.q $xr24, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr24, 136
+; CHECK-NEXT:    xvpermi.q $xr25, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr25, 153
+; CHECK-NEXT:    xvpermi.q $xr26, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr26, 170
+; CHECK-NEXT:    xvpermi.q $xr27, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr27, 187
+; CHECK-NEXT:    xvpermi.q $xr28, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr28, 204
+; CHECK-NEXT:    xvpermi.q $xr29, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr29, 221
+; CHECK-NEXT:    xvpermi.q $xr30, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr30, 238
+; CHECK-NEXT:    xvpermi.q $xr31, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr31, 255
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
+; CHECK-NEXT:    fld.d $fs7, $sp, 16 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs6, $sp, 24 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs5, $sp, 32 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs4, $sp, 40 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs3, $sp, 48 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs2, $sp, 56 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs1, $sp, 64 # 8-byte Folded Reload
+; CHECK-NEXT:    fld.d $fs0, $sp, 72 # 8-byte Folded Reload
+; CHECK-NEXT:    addi.d $sp, $sp, 80
 ; CHECK-NEXT:    ret
 entry:
   %ins0  = insertelement <32 x i8> undef,  i8 %a0,  i32 0
@@ -363,37 +413,51 @@ define void @buildvector_v32i8_partial(ptr %dst, i8 %a0, i8 %a1, i8 %a2, i8 %a5,
 ; CHECK-NEXT:    ld.b $t5, $sp, 16
 ; CHECK-NEXT:    ld.b $t6, $sp, 8
 ; CHECK-NEXT:    ld.b $t7, $sp, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 1
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a3, 2
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a4, 5
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a5, 7
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a6, 8
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a7, 15
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t7, 1
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t6, 2
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t5, 4
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t4, 6
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t3, 7
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t2, 11
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t1, 12
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t0, 15
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 0
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 85
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 119
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 136
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 255
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 68
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 102
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 119
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 187
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t1
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 204
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t0
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 255
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -445,37 +509,51 @@ define void @buildvector_v32i8_with_constant(ptr %dst, i8 %a0, i8 %a1, i8 %a2, i
 ; CHECK-NEXT:    ld.b $t6, $sp, 8
 ; CHECK-NEXT:    ld.b $t7, $sp, 0
 ; CHECK-NEXT:    xvrepli.b $xr0, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 1
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a3, 2
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a4, 5
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a5, 8
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a6, 9
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a7, 15
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t7, 1
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t6, 2
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t5, 4
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t4, 6
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t3, 7
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t2, 11
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t1, 12
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $t0, 15
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a1
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 0
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 85
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 136
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 153
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 255
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 68
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 102
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 119
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 187
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t1
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 204
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $t0
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 255
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -527,38 +605,54 @@ define void @buildvector_v16i16(ptr %dst, i16 %a0, i16 %a1, i16 %a2, i16 %a3, i1
 ; CHECK-NEXT:    ld.h $t6, $sp, 16
 ; CHECK-NEXT:    ld.h $t7, $sp, 8
 ; CHECK-NEXT:    ld.h $t8, $sp, 0
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a2, 1
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a3, 2
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a4, 3
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a5, 4
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a6, 5
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a7, 6
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $t8, 7
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t7, 0
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t6, 1
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t5, 2
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t4, 3
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t3, 4
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t2, 5
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t1, 6
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $t0, 7
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 0
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 17
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 51
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 68
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 85
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 102
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t8
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 119
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 0
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 17
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 51
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 68
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 85
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t1
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 102
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $t0
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 119
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -585,17 +679,27 @@ entry:
 define void @buildvector_v16i16_partial(ptr %dst, i16 %a0, i16 %a2, i16 %a5, i16 %a6, i16 %a7, i16 %a12, i16 %a13) nounwind {
 ; CHECK-LABEL: buildvector_v16i16_partial:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 0
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a2, 2
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a3, 5
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a4, 6
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a5, 7
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $a6, 4
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $a7, 5
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 0
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 85
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 102
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 119
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 68
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 85
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:
@@ -623,17 +727,27 @@ define void @buildvector_v16i16_with_constant(ptr %dst, i16 %a2, i16 %a3, i16 %a
 ; CHECK-LABEL: buildvector_v16i16_with_constant:
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    xvrepli.h $xr0, 2
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 2
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a2, 3
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a3, 5
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a4, 6
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a5, 7
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $a6, 4
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $a7, 5
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a1
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 34
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 51
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a3
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 85
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a4
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 102
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a5
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 119
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a6
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 68
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a7
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 85
 ; CHECK-NEXT:    xvst $xr0, $a0, 0
 ; CHECK-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insert-extract-element.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insert-extract-element.ll
@@ -6,7 +6,9 @@ define <32 x i8> @insert_extract_v32i8(<32 x i8> %a) nounwind {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
 ; CHECK-NEXT:    vpickve2gr.b $a0, $vr1, 15
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a0, 1
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a0
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
 ; CHECK-NEXT:    ret
 entry:
   %b = extractelement <32 x i8> %a, i32 31
@@ -19,7 +21,9 @@ define <16 x i16> @insert_extract_v16i16(<16 x i16> %a) nounwind {
 ; CHECK:       # %bb.0: # %entry
 ; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
 ; CHECK-NEXT:    vpickve2gr.h $a0, $vr1, 7
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a0, 1
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a0
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 17
 ; CHECK-NEXT:    ret
 entry:
   %b = extractelement <16 x i16> %a, i32 15

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insertelement.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insertelement.ll
@@ -31,6 +31,30 @@ define void @insert_32xi8_upper(ptr %src, ptr %dst, i8 %in) nounwind {
   ret void
 }
 
+define void @insert_32xi8_undef(ptr %dst, i8 %in) nounwind {
+; CHECK-LABEL: insert_32xi8_undef:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vinsgr2vr.b $vr0, $a1, 1
+; CHECK-NEXT:    xvst $xr0, $a0, 0
+; CHECK-NEXT:    ret
+  %v = insertelement <32 x i8> poison, i8 %in, i32 1
+  store <32 x i8> %v, ptr %dst
+  ret void
+}
+
+define void @insert_32xi8_undef_upper(ptr %dst, i8 %in) nounwind {
+; CHECK-LABEL: insert_32xi8_undef_upper:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a1
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 102
+; CHECK-NEXT:    xvst $xr0, $a0, 0
+; CHECK-NEXT:    ret
+  %v = insertelement <32 x i8> poison, i8 %in, i32 22
+  store <32 x i8> %v, ptr %dst
+  ret void
+}
+
 define void @insert_16xi16(ptr %src, ptr %dst, i16 %in) nounwind {
 ; CHECK-LABEL: insert_16xi16:
 ; CHECK:       # %bb.0:
@@ -58,6 +82,30 @@ define void @insert_16xi16_upper(ptr %src, ptr %dst, i16 %in) nounwind {
   %v = load volatile <16 x i16>, ptr %src
   %v_new = insertelement <16 x i16> %v, i16 %in, i32 8
   store <16 x i16> %v_new, ptr %dst
+  ret void
+}
+
+define void @insert_16xi16_undef(ptr %dst, i16 %in) nounwind {
+; CHECK-LABEL: insert_16xi16_undef:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    vinsgr2vr.h $vr0, $a1, 1
+; CHECK-NEXT:    xvst $xr0, $a0, 0
+; CHECK-NEXT:    ret
+  %v = insertelement <16 x i16> poison, i16 %in, i32 1
+  store <16 x i16> %v, ptr %dst
+  ret void
+}
+
+define void @insert_16xi16_undef_upper(ptr %dst, i16 %in) nounwind {
+; CHECK-LABEL: insert_16xi16_undef_upper:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a1
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 34
+; CHECK-NEXT:    xvst $xr0, $a0, 0
+; CHECK-NEXT:    ret
+  %v = insertelement <16 x i16> poison, i16 %in, i32 10
+  store <16 x i16> %v, ptr %dst
   ret void
 }
 
@@ -118,8 +166,8 @@ define void @insert_4xdouble(ptr %src, ptr %dst, double %in) nounwind {
 define void @insert_32xi8_idx(ptr %src, ptr %dst, i8 %in, i32 %idx) nounwind {
 ; CHECK-LABEL: insert_32xi8_idx:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI8_0)
-; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI8_0)
+; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI12_0)
+; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI12_0)
 ; CHECK-NEXT:    xvld $xr1, $a0, 0
 ; CHECK-NEXT:    bstrpick.d $a0, $a3, 31, 0
 ; CHECK-NEXT:    xvreplgr2vr.b $xr2, $a0
@@ -137,8 +185,8 @@ define void @insert_32xi8_idx(ptr %src, ptr %dst, i8 %in, i32 %idx) nounwind {
 define void @insert_16xi16_idx(ptr %src, ptr %dst, i16 %in, i32 %idx) nounwind {
 ; CHECK-LABEL: insert_16xi16_idx:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI9_0)
-; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI9_0)
+; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI13_0)
+; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI13_0)
 ; CHECK-NEXT:    xvld $xr1, $a0, 0
 ; CHECK-NEXT:    bstrpick.d $a0, $a3, 31, 0
 ; CHECK-NEXT:    xvreplgr2vr.h $xr2, $a0
@@ -156,8 +204,8 @@ define void @insert_16xi16_idx(ptr %src, ptr %dst, i16 %in, i32 %idx) nounwind {
 define void @insert_8xi32_idx(ptr %src, ptr %dst, i32 %in, i32 %idx) nounwind {
 ; CHECK-LABEL: insert_8xi32_idx:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI10_0)
-; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI10_0)
+; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI14_0)
+; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI14_0)
 ; CHECK-NEXT:    xvld $xr1, $a0, 0
 ; CHECK-NEXT:    bstrpick.d $a0, $a3, 31, 0
 ; CHECK-NEXT:    xvreplgr2vr.w $xr2, $a0
@@ -175,8 +223,8 @@ define void @insert_8xi32_idx(ptr %src, ptr %dst, i32 %in, i32 %idx) nounwind {
 define void @insert_4xi64_idx(ptr %src, ptr %dst, i64 %in, i32 %idx) nounwind {
 ; CHECK-LABEL: insert_4xi64_idx:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI11_0)
-; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI11_0)
+; CHECK-NEXT:    pcalau12i $a4, %pc_hi20(.LCPI15_0)
+; CHECK-NEXT:    xvld $xr0, $a4, %pc_lo12(.LCPI15_0)
 ; CHECK-NEXT:    xvld $xr1, $a0, 0
 ; CHECK-NEXT:    bstrpick.d $a0, $a3, 31, 0
 ; CHECK-NEXT:    xvreplgr2vr.d $xr2, $a0
@@ -195,8 +243,8 @@ define void @insert_8xfloat_idx(ptr %src, ptr %dst, float %in, i32 %idx) nounwin
 ; CHECK-LABEL: insert_8xfloat_idx:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    # kill: def $f0 killed $f0 def $xr0
-; CHECK-NEXT:    pcalau12i $a3, %pc_hi20(.LCPI12_0)
-; CHECK-NEXT:    xvld $xr1, $a3, %pc_lo12(.LCPI12_0)
+; CHECK-NEXT:    pcalau12i $a3, %pc_hi20(.LCPI16_0)
+; CHECK-NEXT:    xvld $xr1, $a3, %pc_lo12(.LCPI16_0)
 ; CHECK-NEXT:    xvld $xr2, $a0, 0
 ; CHECK-NEXT:    bstrpick.d $a0, $a2, 31, 0
 ; CHECK-NEXT:    xvreplgr2vr.w $xr3, $a0
@@ -215,8 +263,8 @@ define void @insert_4xdouble_idx(ptr %src, ptr %dst, double %in, i32 %idx) nounw
 ; CHECK-LABEL: insert_4xdouble_idx:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    # kill: def $f0_64 killed $f0_64 def $xr0
-; CHECK-NEXT:    pcalau12i $a3, %pc_hi20(.LCPI13_0)
-; CHECK-NEXT:    xvld $xr1, $a3, %pc_lo12(.LCPI13_0)
+; CHECK-NEXT:    pcalau12i $a3, %pc_hi20(.LCPI17_0)
+; CHECK-NEXT:    xvld $xr1, $a3, %pc_lo12(.LCPI17_0)
 ; CHECK-NEXT:    xvld $xr2, $a0, 0
 ; CHECK-NEXT:    bstrpick.d $a0, $a2, 31, 0
 ; CHECK-NEXT:    xvreplgr2vr.d $xr3, $a0

--- a/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insertelement.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/ir-instruction/insertelement.ll
@@ -5,7 +5,9 @@ define void @insert_32xi8(ptr %src, ptr %dst, i8 %in) nounwind {
 ; CHECK-LABEL: insert_32xi8:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    xvld $xr0, $a0, 0
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a2, 1
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 17
 ; CHECK-NEXT:    xvst $xr0, $a1, 0
 ; CHECK-NEXT:    ret
   %v = load volatile <32 x i8>, ptr %src
@@ -18,9 +20,9 @@ define void @insert_32xi8_upper(ptr %src, ptr %dst, i8 %in) nounwind {
 ; CHECK-LABEL: insert_32xi8_upper:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    xvld $xr0, $a0, 0
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.b $vr1, $a2, 0
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.b $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.b $xr0, $xr1, 0
 ; CHECK-NEXT:    xvst $xr0, $a1, 0
 ; CHECK-NEXT:    ret
   %v = load volatile <32 x i8>, ptr %src
@@ -33,7 +35,9 @@ define void @insert_16xi16(ptr %src, ptr %dst, i16 %in) nounwind {
 ; CHECK-LABEL: insert_16xi16:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    xvld $xr0, $a0, 0
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a2, 1
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 17
 ; CHECK-NEXT:    xvst $xr0, $a1, 0
 ; CHECK-NEXT:    ret
   %v = load volatile <16 x i16>, ptr %src
@@ -46,9 +50,9 @@ define void @insert_16xi16_upper(ptr %src, ptr %dst, i16 %in) nounwind {
 ; CHECK-LABEL: insert_16xi16_upper:
 ; CHECK:       # %bb.0:
 ; CHECK-NEXT:    xvld $xr0, $a0, 0
-; CHECK-NEXT:    xvpermi.d $xr1, $xr0, 14
-; CHECK-NEXT:    vinsgr2vr.h $vr1, $a2, 0
-; CHECK-NEXT:    xvpermi.q $xr0, $xr1, 2
+; CHECK-NEXT:    xvreplgr2vr.h $xr1, $a2
+; CHECK-NEXT:    xvpermi.q $xr1, $xr0, 48
+; CHECK-NEXT:    xvextrins.h $xr0, $xr1, 0
 ; CHECK-NEXT:    xvst $xr0, $a1, 0
 ; CHECK-NEXT:    ret
   %v = load volatile <16 x i16>, ptr %src

--- a/llvm/test/CodeGen/LoongArch/lasx/scalar-to-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/scalar-to-vector.ll
@@ -6,9 +6,7 @@
 define <32 x i8> @scalar_to_32xi8(i8 %val) {
 ; CHECK-LABEL: scalar_to_32xi8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a0
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
-; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 0
+; CHECK-NEXT:    vinsgr2vr.b $vr0, $a0, 0
 ; CHECK-NEXT:    ret
   %ret = insertelement <32 x i8> poison, i8 %val, i32 0
   ret <32 x i8> %ret
@@ -17,9 +15,7 @@ define <32 x i8> @scalar_to_32xi8(i8 %val) {
 define <16 x i16> @scalar_to_16xi16(i16 %val) {
 ; CHECK-LABEL: scalar_to_16xi16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a0
-; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
-; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 0
+; CHECK-NEXT:    vinsgr2vr.h $vr0, $a0, 0
 ; CHECK-NEXT:    ret
   %ret = insertelement <16 x i16> poison, i16 %val, i32 0
   ret <16 x i16> %ret

--- a/llvm/test/CodeGen/LoongArch/lasx/scalar-to-vector.ll
+++ b/llvm/test/CodeGen/LoongArch/lasx/scalar-to-vector.ll
@@ -6,7 +6,9 @@
 define <32 x i8> @scalar_to_32xi8(i8 %val) {
 ; CHECK-LABEL: scalar_to_32xi8:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.b $vr0, $a0, 0
+; CHECK-NEXT:    xvreplgr2vr.b $xr0, $a0
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
+; CHECK-NEXT:    xvextrins.b $xr0, $xr0, 0
 ; CHECK-NEXT:    ret
   %ret = insertelement <32 x i8> poison, i8 %val, i32 0
   ret <32 x i8> %ret
@@ -15,7 +17,9 @@ define <32 x i8> @scalar_to_32xi8(i8 %val) {
 define <16 x i16> @scalar_to_16xi16(i16 %val) {
 ; CHECK-LABEL: scalar_to_16xi16:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    vinsgr2vr.h $vr0, $a0, 0
+; CHECK-NEXT:    xvreplgr2vr.h $xr0, $a0
+; CHECK-NEXT:    xvpermi.q $xr0, $xr0, 18
+; CHECK-NEXT:    xvextrins.h $xr0, $xr0, 0
 ; CHECK-NEXT:    ret
   %ret = insertelement <16 x i16> poison, i16 %val, i32 0
   ret <16 x i16> %ret


### PR DESCRIPTION
According to the instructions manual, when `vr0` is changed, high 128 bit of `xr0` is undefined.
Use `vinsgr2vr.b/h` to insert an `i8/i16` to low 128bit of a 256 vector may cause undefined behavior when high 128bit is used in later instructions.
