### PR TITLE
[lldb] Don't crash if no default unwind plan

### DIFF
--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -426,9 +426,12 @@ void RegisterContextUnwind::InitializeNonZerothFrame() {
       }
     }
 
-    if (abi_sp) {
-      m_fast_unwind_plan_sp.reset();
+    m_fast_unwind_plan_sp.reset();
+    m_full_unwind_plan_sp.reset();
+    if (abi_sp)
       m_full_unwind_plan_sp = abi_sp->CreateDefaultUnwindPlan();
+
+    if (m_full_unwind_plan_sp) {
       if (m_frame_type != eSkipFrame) // don't override eSkipFrame
       {
         m_frame_type = eNormalFrame;


### PR DESCRIPTION
The code was assuming that if abi_sp is not null, then it will also return a non-null default unwind plan. However, this is not the case at least on s390x, so check for that. In that case, we'll treat it as an invalid frame.