### PR TITLE
WIP: [Bolt] Add support for DT_INIT_ARRAY

### DIFF
--- a/bolt/CMakeLists.txt
+++ b/bolt/CMakeLists.txt
@@ -89,8 +89,7 @@ if ((CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64"
     OR CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$"
     OR CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
     AND (CMAKE_SYSTEM_NAME STREQUAL "Linux"
-      OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    AND (NOT CMAKE_CROSSCOMPILING))
+      OR CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
   set(BOLT_ENABLE_RUNTIME_default ON)
 endif()
 option(BOLT_ENABLE_RUNTIME "Enable BOLT runtime" ${BOLT_ENABLE_RUNTIME_default})
@@ -140,36 +139,110 @@ if (LLVM_INCLUDE_TESTS)
   endif()
 endif()
 
-if (BOLT_ENABLE_RUNTIME)
-  message(STATUS "Building BOLT runtime libraries for ${CMAKE_SYSTEM_PROCESSOR}")
-  set(extra_args "")
-  if(CMAKE_SYSROOT)
-    list(APPEND extra_args -DCMAKE_SYSROOT=${CMAKE_SYSROOT})
+function(bolt_rt_target_supported target supported)
+
+    if(${target} STREQUAL ${HOST_NAME})
+      set(${supported} TRUE PARENT_SCOPE)
+      return()
+    elseif(${target} STREQUAL "X86")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=x86_64-linux-gnu")
+    elseif(${target} STREQUAL "AArch64")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=aarch64-linux-gnu")
+    elseif(${target} STREQUAL "RISCV")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=riscv64-linux-gnu")
+    endif()
+
+    try_compile(CROSS_COMP
+      ${CMAKE_BINARY_DIR}/CMakeFiles/CMakeScratch
+      SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test/test.cpp
+      CMAKE_FLAGS ""
+      TRY_COMP_OUTPUT)
+
+  if(CROSS_COMP)
+    message(STATUS "cross compilation test for ${target} was successful")
+    set(${supported} TRUE PARENT_SCOPE)
+  else()
+    message(STATUS "cross compilation test for ${target} was NOT successful")
+    set(${supported} FALSE PARENT_SCOPE)
   endif()
 
-  include(ExternalProject)
-  ExternalProject_Add(bolt_rt
-    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime"
-    STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-stamps
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-bins
-    CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-               -DCMAKE_BUILD_TYPE=Release
-               -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
-               -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX}
-               -DLLVM_LIBRARY_DIR=${LLVM_LIBRARY_DIR}
-               -DBOLT_BUILT_STANDALONE=${BOLT_BUILT_STANDALONE}
-               ${extra_args}
-    INSTALL_COMMAND ""
-    BUILD_ALWAYS True
+endfunction()
+
+if(BOLT_ENABLE_RUNTIME)
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set(HOST_NAME "X86")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    set(HOST_NAME "AArch64")
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
+    set(HOST_NAME "RISCV")
+  endif()
+
+  # Further filter BOLT runtime targets: check if the runtime can be compiled
+  set(BOLT_RT_TARGETS_TO_BUILD)
+  if(CMAKE_C_COMPILER_ID MATCHES ".*Clang.*" AND CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*")
+    foreach(tgt ${BOLT_TARGETS_TO_BUILD})
+        bolt_rt_target_supported(${tgt} supported)
+        if(${supported})
+          list(APPEND BOLT_RT_TARGETS_TO_BUILD ${tgt})
+        endif()
+    endforeach()
+  else()
+    message(WARNING "BOLT runtime libraries require Clang")
+  endif()
+endif()
+
+if(BOLT_ENABLE_RUNTIME)
+
+  foreach(tgt ${BOLT_RT_TARGETS_TO_BUILD})
+    message(STATUS "Building BOLT runtime libraries for ${tgt}")
+    set(extra_args "")
+    if(CMAKE_SYSROOT)
+      list(APPEND extra_args -DCMAKE_SYSROOT=${CMAKE_SYSROOT})
+    endif()
+
+    # set up paths: target-specific libs will be generated under lib/${tgt}/
+    set(BOLT_RT_LIBRARY_DIR "${LLVM_LIBRARY_DIR}")
+    set(SUBDIR "${tgt}")
+    cmake_path(APPEND BOLT_RT_LIBRARY_DIR ${BOLT_RT_LIBRARY_DIR} ${SUBDIR})
+    file(MAKE_DIRECTORY ${BOLT_RT_LIBRARY_DIR})
+
+    if(${tgt} STREQUAL ${HOST_NAME})
+      set(BOLT_RT_FLAGS)
+    elseif(${tgt} STREQUAL "AArch64")
+      set(BOLT_RT_FLAGS "--target=aarch64-linux-gnu")
+    elseif(${tgt} STREQUAL "X86")
+      set(BOLT_RT_FLAGS "--target=x86_64-linux-gnu")
+    elseif(${tgt} STREQUAL "RISCV")
+      set(BOLT_RT_FLAGS "--target=riscv64-linux-gnu")
+    endif()
+
+    include(ExternalProject)
+    ExternalProject_Add(bolt_rt_${tgt}
+      SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/runtime"
+      STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-${tgt}-stamps
+      BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-${tgt}-bins
+      CMAKE_ARGS
+      -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+      -DCMAKE_BUILD_TYPE=Release
+      -DBOLT_RT_FLAGS=${BOLT_RT_FLAGS}
+      -DBOLT_RT_TARGET=${tgt}
+      -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+      -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX}
+      -DLLVM_LIBRARY_DIR=${BOLT_RT_LIBRARY_DIR}
+      -DBOLT_BUILT_STANDALONE=${BOLT_BUILT_STANDALONE}
+      ${extra_args}
+      INSTALL_COMMAND ""
+      BUILD_ALWAYS True
     )
-  install(CODE "execute_process\(COMMAND \${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=\${CMAKE_INSTALL_PREFIX} -P ${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-bins/cmake_install.cmake \)"
-    COMPONENT bolt)
-  add_llvm_install_targets(install-bolt_rt
-    DEPENDS bolt_rt bolt
-    COMPONENT bolt)
-  set(LIBBOLT_RT_INSTR "${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-bins/lib${LLVM_LIBDIR_SUFFIX}/libbolt_rt_instr.a")
-  set(LIBBOLT_RT_HUGIFY "${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-bins/lib${LLVM_LIBDIR_SUFFIX}/libbolt_rt_hugify.a")
+    install(CODE "execute_process\(COMMAND \${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=\${CMAKE_INSTALL_PREFIX} -P ${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-${tgt}-bins/cmake_install.cmake \)"
+      COMPONENT bolt)
+    add_llvm_install_targets(install-bolt_rt_${tgt}
+      DEPENDS bolt_rt_${tgt} bolt
+      COMPONENT bolt)
+    set(LIBBOLT_RT_INSTR "${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-${tgt}-bins/lib/libbolt_rt_instr.a")
+    set(LIBBOLT_RT_HUGIFY "${CMAKE_CURRENT_BINARY_DIR}/bolt_rt-${tgt}-bins/lib/libbolt_rt_hugify.a")
+  endforeach()
 endif()
 
 find_program(GNU_LD_EXECUTABLE NAMES ${LLVM_DEFAULT_TARGET_TRIPLE}-ld.bfd ld.bfd DOC "GNU ld")

--- a/bolt/cmake/test/test.cpp
+++ b/bolt/cmake/test/test.cpp
@@ -1,0 +1,3 @@
+#include <stdio.h>
+
+int main() { return 0; }

--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -800,6 +800,15 @@ public:
   /// the execution of the binary is completed.
   std::optional<uint64_t> FiniFunctionAddress;
 
+  /// DT_INIT. Used when DT_INIT is available.
+  std::optional<uint64_t> InitAddress;
+
+  /// DT_INIT_ARRAY. Only used when DT_INIT is not set.
+  std::optional<uint64_t> InitArrayAddress;
+
+  /// DT_INIT_ARRAYSZ. Only used when DT_INIT is not set.
+  std::optional<uint64_t> InitArraySize;
+
   /// DT_FINI.
   std::optional<uint64_t> FiniAddress;
 

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -93,10 +93,19 @@ private:
   /// section allocations if found.
   void discoverBOLTReserved();
 
+  /// Check whether we should use DT_INIT or DT_INIT_ARRAY for instrumentation.
+  /// DT_INIT is preferred; DT_INIT_ARRAY is only used when no DT_INIT entry was
+  /// found.
+  Error discoverRtInitAddress();
+
   /// Check whether we should use DT_FINI or DT_FINI_ARRAY for instrumentation.
   /// DT_FINI is preferred; DT_FINI_ARRAY is only used when no DT_FINI entry was
   /// found.
   Error discoverRtFiniAddress();
+
+  /// If DT_INIT_ARRAY is used for instrumentation, update the relocation of its
+  /// first entry to point to the instrumentation library's init address.
+  void updateRtInitReloc();
 
   /// If DT_FINI_ARRAY is used for instrumentation, update the relocation of its
   /// first entry to point to the instrumentation library's fini address.

--- a/bolt/include/bolt/RuntimeLibs/RuntimeLibrary.h
+++ b/bolt/include/bolt/RuntimeLibs/RuntimeLibrary.h
@@ -61,14 +61,19 @@ protected:
   /// Get the full path to a runtime library specified by \p LibFileName and \p
   /// ToolPath.
   static std::string getLibPathByToolPath(StringRef ToolPath,
+                                          StringRef ToolSubPath,
                                           StringRef LibFileName);
 
+  /// Create architecture-specific ToolSubPath to be used in the full path
+  static std::string createToolSubPath(StringRef ArchName);
+
   /// Get the full path to a runtime library by the install directory.
-  static std::string getLibPathByInstalled(StringRef LibFileName);
+  static std::string getLibPathByInstalled(StringRef ToolSubPath, StringRef LibFileName);
 
   /// Gets the full path to a runtime library based on whether it exists
   /// in the install libdir or runtime libdir.
-  static std::string getLibPath(StringRef ToolPath, StringRef LibFileName);
+  static std::string getLibPath(StringRef ToolPath, StringRef ToolSubPath,
+                                StringRef LibFileName);
 
   /// Load a static runtime library specified by \p LibPath.
   static void loadLibrary(StringRef LibPath, BOLTLinker &Linker,

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -705,12 +705,15 @@ Error RewriteInstance::run() {
     return E;
   if (Error E = readSpecialSections())
     return E;
-  adjustCommandLineOptions();
   discoverFileObjects();
 
-  if (opts::Instrument && !BC->IsStaticExecutable)
+  if (opts::Instrument && !BC->IsStaticExecutable) {
+    if (Error E = discoverRtInitAddress())
+      return E;
     if (Error E = discoverRtFiniAddress())
       return E;
+  }
+  adjustCommandLineOptions();
 
   preprocessProfileData();
 
@@ -752,8 +755,10 @@ Error RewriteInstance::run() {
 
   updateMetadata();
 
-  if (opts::Instrument && !BC->IsStaticExecutable)
+  if (opts::Instrument && !BC->IsStaticExecutable) {
+    updateRtInitReloc();
     updateRtFiniReloc();
+  }
 
   if (opts::OutputFilename == "/dev/null") {
     BC->outs() << "BOLT-INFO: skipping writing final binary to disk\n";
@@ -1381,6 +1386,49 @@ void RewriteInstance::discoverBOLTReserved() {
   NextAvailableAddress = BC->BOLTReserved.start();
 }
 
+Error RewriteInstance::discoverRtInitAddress() {
+  // Use ELF e_entry
+  if (BC->StartFunctionAddress.has_value() &&
+      BC->StartFunctionAddress.value() != 0 && !BC->InitAddress)
+    return Error::success();
+
+  // Use init address if it is available.
+  if (BC->InitAddress) {
+    BC->StartFunctionAddress = BC->InitAddress;
+    return Error::success();
+  }
+
+  if (!BC->InitArrayAddress || !BC->InitArraySize) {
+    return createStringError(
+        std::errc::not_supported,
+        "Instrumentation needs either DT_INIT or DT_INIT_ARRAY");
+  }
+
+  if (*BC->InitArraySize < BC->AsmInfo->getCodePointerSize()) {
+    return createStringError(std::errc::not_supported,
+                             "Need at least 1 DT_INIT_ARRAY slot");
+  }
+
+  ErrorOr<BinarySection &> InitArraySection =
+      BC->getSectionForAddress(*BC->InitArrayAddress);
+  if (auto EC = InitArraySection.getError())
+    return errorCodeToError(EC);
+
+  if (const Relocation *Reloc = InitArraySection->getDynamicRelocationAt(0)) {
+    BC->StartFunctionAddress = Reloc->Addend;
+    return Error::success();
+  }
+
+  if (const Relocation *Reloc = InitArraySection->getRelocationAt(0)) {
+    BC->StartFunctionAddress = Reloc->Value;
+    return Error::success();
+  }
+
+  dbgs() << "REturn with error!\n";
+  return createStringError(std::errc::not_supported,
+                           "No relocation for first DT_INIT_ARRAY slot");
+}
+
 Error RewriteInstance::discoverRtFiniAddress() {
   // Use DT_FINI if it's available.
   if (BC->FiniAddress) {
@@ -1450,6 +1498,40 @@ void RewriteInstance::updateRtFiniReloc() {
   FiniArraySection->addPendingRelocation(Relocation{
       /*Offset*/ 0, /*Symbol*/ nullptr, /*Type*/ Relocation::getAbs64(),
       /*Addend*/ RT->getRuntimeFiniAddress(), /*Value*/ 0});
+}
+
+void RewriteInstance::updateRtInitReloc() {
+  // Updating DT_INIT is handled by patchELFDynamic.
+  if (BC->InitAddress || !BC->InitArrayAddress)
+    return;
+
+  const RuntimeLibrary *RT = BC->getRuntimeLibrary();
+  if (!RT || !RT->getRuntimeStartAddress())
+    return;
+
+  assert(BC->InitArrayAddress && BC->InitArraySize &&
+         "inconsistent .init_array state");
+
+  ErrorOr<BinarySection &> InitArraySection =
+      BC->getSectionForAddress(*BC->InitArrayAddress);
+  assert(InitArraySection && ".init_array removed");
+
+  if (std::optional<Relocation> Reloc =
+          InitArraySection->takeDynamicRelocationAt(0)) {
+    assert(Reloc->Addend == BC->StartFunctionAddress &&
+           "inconsistent .init_array dynamic relocation");
+    Reloc->Addend = RT->getRuntimeStartAddress();
+    InitArraySection->addDynamicRelocation(*Reloc);
+  }
+
+  // Update the static relocation by adding a pending relocation which will get
+  // patched when flushPendingRelocations is called in rewriteFile. Note that
+  // flushPendingRelocations will calculate the value to patch as
+  // "Symbol + Addend". Since we don't have a symbol, just set the addend to the
+  // desired value.
+  InitArraySection->addPendingRelocation(Relocation{
+      /*Offset*/ 0, /*Symbol*/ nullptr, /*Type*/ Relocation::getAbs64(),
+      /*Addend*/ RT->getRuntimeStartAddress(), /*Value*/ 0});
 }
 
 void RewriteInstance::registerFragments() {
@@ -5705,8 +5787,18 @@ Error RewriteInstance::readELFDynamic(ELFObjectFile<ELFT> *File) {
     switch (Dyn.d_tag) {
     case ELF::DT_INIT:
       if (!BC->HasInterpHeader) {
-        LLVM_DEBUG(dbgs() << "BOLT-DEBUG: Set start function address\n");
-        BC->StartFunctionAddress = Dyn.getPtr();
+        LLVM_DEBUG(dbgs() << "BOLT-DEBUG: Set init address\n");
+        BC->InitAddress = Dyn.getPtr();
+      }
+      break;
+    case ELF::DT_INIT_ARRAY:
+      if (!BC->HasInterpHeader) {
+        BC->InitArrayAddress = Dyn.getPtr();
+      }
+      break;
+    case ELF::DT_INIT_ARRAYSZ:
+      if (!BC->HasInterpHeader) {
+        BC->InitArraySize = Dyn.getPtr();
       }
       break;
     case ELF::DT_FINI:

--- a/bolt/lib/RuntimeLibs/HugifyRuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/HugifyRuntimeLibrary.cpp
@@ -63,7 +63,14 @@ void HugifyRuntimeLibrary::link(BinaryContext &BC, StringRef ToolPath,
                                 BOLTLinker &Linker,
                                 BOLTLinker::SectionsMapper MapSections) {
 
-  std::string LibPath = getLibPath(ToolPath, opts::RuntimeHugifyLib);
+  // If the default filename is selected, add architecture-specific Target
+  // subdirectory to it.
+  std::string ToolSubPath = "";
+  if (opts::RuntimeHugifyLib == "libbolt_rt_hugify.a") {
+    ToolSubPath = createToolSubPath(BC.TheTriple->getArchName().str().c_str());
+  }
+  std::string LibPath =
+      getLibPath(ToolPath, ToolSubPath, opts::RuntimeHugifyLib);
   loadLibrary(LibPath, Linker, MapSections);
 
   assert(!RuntimeStartAddress &&

--- a/bolt/lib/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
@@ -197,7 +197,15 @@ void InstrumentationRuntimeLibrary::emitBinary(BinaryContext &BC,
 void InstrumentationRuntimeLibrary::link(
     BinaryContext &BC, StringRef ToolPath, BOLTLinker &Linker,
     BOLTLinker::SectionsMapper MapSections) {
-  std::string LibPath = getLibPath(ToolPath, opts::RuntimeInstrumentationLib);
+
+  // If the default filename is selected, add architecture-specific Target
+  // subdirectory to it.
+  std::string ToolSubPath = "";
+  if (opts::RuntimeInstrumentationLib == "libbolt_rt_instr.a") {
+    ToolSubPath = createToolSubPath(BC.TheTriple->getArchName().str().c_str());
+  }
+  std::string LibPath =
+      getLibPath(ToolPath, ToolSubPath, opts::RuntimeInstrumentationLib);
   loadLibrary(LibPath, Linker, MapSections);
 
   if (BC.isMachO())

--- a/bolt/lib/RuntimeLibs/RuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/RuntimeLibrary.cpp
@@ -28,6 +28,7 @@ using namespace bolt;
 void RuntimeLibrary::anchor() {}
 
 std::string RuntimeLibrary::getLibPathByToolPath(StringRef ToolPath,
+                                                 StringRef ToolSubPath,
                                                  StringRef LibFileName) {
   StringRef Dir = llvm::sys::path::parent_path(ToolPath);
   SmallString<128> LibPath = llvm::sys::path::parent_path(Dir);
@@ -38,45 +39,45 @@ std::string RuntimeLibrary::getLibPathByToolPath(StringRef ToolPath,
     LibPath = llvm::sys::path::parent_path(llvm::sys::path::parent_path(Dir));
     llvm::sys::path::append(LibPath, "lib" LLVM_LIBDIR_SUFFIX);
   }
+  llvm::sys::path::append(LibPath, ToolSubPath);
   llvm::sys::path::append(LibPath, LibFileName);
-  if (!llvm::sys::fs::exists(LibPath)) {
-    // If it is a symlink, check the directory that the symlink points to.
-    if (llvm::sys::fs::is_symlink_file(ToolPath)) {
-      SmallString<256> RealPath;
-      llvm::sys::fs::real_path(ToolPath, RealPath);
-      if (llvm::ErrorOr<std::string> P =
-              llvm::sys::findProgramByName(RealPath)) {
-        outs() << "BOLT-INFO: library not found: " << LibPath << "\n"
-               << "BOLT-INFO: " << ToolPath << " is a symlink; will look up "
-               << LibFileName
-               << " at the target directory that the symlink points to\n";
-        return getLibPath(*P, LibFileName);
-      }
-    }
-    errs() << "BOLT-ERROR: library not found: " << LibPath << "\n";
-    exit(1);
-  }
   return std::string(LibPath);
 }
 
-std::string RuntimeLibrary::getLibPathByInstalled(StringRef LibFileName) {
+std::string RuntimeLibrary::createToolSubPath(StringRef ArchName) {
+  std::string ToolSubPath = "";
+  if (ArchName == "x86_64")
+    ToolSubPath = "X86";
+  else if (ArchName == "aarch64")
+    ToolSubPath = "AArch64";
+  else if (ArchName == "riscv64")
+    ToolSubPath = "RISCV";
+  else
+    llvm_unreachable("Unsupported architecture");
+
+  return ToolSubPath;
+}
+
+std::string RuntimeLibrary::getLibPathByInstalled(StringRef ToolSubPath, StringRef LibFileName) {
   SmallString<128> LibPath(CMAKE_INSTALL_FULL_LIBDIR);
+  llvm::sys::path::append(LibPath, ToolSubPath);
   llvm::sys::path::append(LibPath, LibFileName);
   return std::string(LibPath);
 }
 
 std::string RuntimeLibrary::getLibPath(StringRef ToolPath,
+                                       StringRef ToolSubPath,
                                        StringRef LibFileName) {
   if (llvm::sys::fs::exists(LibFileName)) {
     return std::string(LibFileName);
   }
 
-  std::string ByTool = getLibPathByToolPath(ToolPath, LibFileName);
+  std::string ByTool = getLibPathByToolPath(ToolPath, ToolSubPath, LibFileName);
   if (llvm::sys::fs::exists(ByTool)) {
     return ByTool;
   }
 
-  std::string ByInstalled = getLibPathByInstalled(LibFileName);
+  std::string ByInstalled = getLibPathByInstalled(ToolSubPath, LibFileName);
   if (llvm::sys::fs::exists(ByInstalled)) {
     return ByInstalled;
   }

--- a/bolt/runtime/CMakeLists.txt
+++ b/bolt/runtime/CMakeLists.txt
@@ -29,8 +29,8 @@ if(NOT BOLT_BUILT_STANDALONE)
   add_custom_command(TARGET bolt_rt_hugify POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/libbolt_rt_hugify.a" "${LLVM_LIBRARY_DIR}")
 endif()
-
-set(BOLT_RT_FLAGS
+# In case of compiling with clang, the '--target' option is passed in BOLT_RT_FLAGS.
+set(BOLT_RT_FLAGS ${BOLT_RT_FLAGS}
   -ffreestanding
   -fno-exceptions
   -fno-rtti
@@ -41,15 +41,15 @@ set(BOLT_RT_FLAGS
   # Refs: llvm/llvm-project#148595 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77882
   -fomit-frame-pointer
 )
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
+if(${BOLT_RT_TARGET} STREQUAL "X86")
   set(BOLT_RT_FLAGS ${BOLT_RT_FLAGS} 
     -mno-sse 
     -mgeneral-regs-only)
 endif()
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+if (${BOLT_RT_TARGET} STREQUAL "riscv64")
   set(BOLT_RT_FLAGS ${BOLT_RT_FLAGS})
 endif()
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+if(${BOLT_RT_TARGET} STREQUAL "AArch64")
   check_cxx_compiler_flag("-mno-outline-atomics" CXX_SUPPORTS_OUTLINE_ATOMICS)
   if (CXX_SUPPORTS_OUTLINE_ATOMICS)
     set(BOLT_RT_FLAGS ${BOLT_RT_FLAGS} 
@@ -64,8 +64,8 @@ target_include_directories(bolt_rt_instr PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_options(bolt_rt_hugify PRIVATE ${BOLT_RT_FLAGS})
 target_include_directories(bolt_rt_hugify PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-install(TARGETS bolt_rt_instr DESTINATION "lib${LLVM_LIBDIR_SUFFIX}")
-install(TARGETS bolt_rt_hugify DESTINATION "lib${LLVM_LIBDIR_SUFFIX}")
+install(TARGETS bolt_rt_instr DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}/${BOLT_RT_TARGET}")
+install(TARGETS bolt_rt_hugify DESTINATION "${CMAKE_INSTALL_LIBDIR}${LLVM_LIBDIR_SUFFIX}/${BOLT_RT_TARGET}")
 
 if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang.*" AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   add_library(bolt_rt_instr_osx STATIC

--- a/bolt/tools/driver/CMakeLists.txt
+++ b/bolt/tools/driver/CMakeLists.txt
@@ -6,7 +6,9 @@ set(LLVM_LINK_COMPONENTS
   )
 
 if (BOLT_ENABLE_RUNTIME)
-  set(BOLT_DRIVER_DEPS "bolt_rt")
+  foreach(tgt ${BOLT_RT_TARGETS_TO_BUILD})
+    set(BOLT_DRIVER_DEPS ${BOLT_DRIVER_DEPS} "bolt_rt_${tgt}")
+  endforeach()
 else()
   set(BOLT_DRIVER_DEPS "")
 endif()


### PR DESCRIPTION
Currently Bolt relies on ELF 'e_entry' field or DT_INIT to determine entry point of an ELF file for the instrumentation. There is a case when an ELF file only has DT_INIT_ARRAY/DT_FINI_ARRAY sections, and the ELF 'e_entry' holds zero, ie. if it is a shared object.