### PR TITLE
[clang][bytecode][NFC] Refactor DynamicAllocator a bit

### DIFF
--- a/clang/lib/AST/ByteCode/DynamicAllocator.cpp
+++ b/clang/lib/AST/ByteCode/DynamicAllocator.cpp
@@ -128,7 +128,7 @@ bool DynamicAllocator::deallocate(const Expr *Source,
     return false;
 
   auto &Site = It->second;
-  assert(Site.size() > 0);
+  assert(!Site.empty());
 
   // Find the Block to delete.
   auto AllocIt = llvm::find_if(Site.Allocations, [&](const Allocation &A) {
@@ -144,7 +144,7 @@ bool DynamicAllocator::deallocate(const Expr *Source,
   S.deallocate(B);
   Site.Allocations.erase(AllocIt);
 
-  if (Site.size() == 0)
+  if (Site.empty())
     AllocationSites.erase(It);
 
   return true;

--- a/clang/lib/AST/ByteCode/DynamicAllocator.h
+++ b/clang/lib/AST/ByteCode/DynamicAllocator.h
@@ -55,6 +55,7 @@ private:
     }
 
     size_t size() const { return Allocations.size(); }
+    bool empty() const { return Allocations.empty(); }
   };
 
 public:
@@ -64,8 +65,6 @@ public:
   ~DynamicAllocator();
 
   void cleanup();
-
-  unsigned getNumAllocations() const { return AllocationSites.size(); }
 
   /// Allocate ONE element of the given descriptor.
   Block *allocate(const Descriptor *D, unsigned EvalID, Form AllocForm);
@@ -95,6 +94,8 @@ public:
   llvm::iterator_range<const_virtual_iter> allocation_sites() const {
     return llvm::make_range(AllocationSites.begin(), AllocationSites.end());
   }
+
+  bool hasAllocations() const { return !AllocationSites.empty(); }
 
 private:
   llvm::DenseMap<const Expr *, AllocationSite> AllocationSites;

--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -101,15 +101,14 @@ void InterpState::deallocate(Block *B) {
 }
 
 bool InterpState::maybeDiagnoseDanglingAllocations() {
-  bool NoAllocationsLeft = (Alloc.getNumAllocations() == 0);
+  bool NoAllocationsLeft = !Alloc.hasAllocations();
 
   if (!checkingPotentialConstantExpression()) {
-    for (const auto &It : Alloc.allocation_sites()) {
-      assert(It.second.size() > 0);
+    for (const auto &[Source, Site] : Alloc.allocation_sites()) {
+      assert(!Site.empty());
 
-      const Expr *Source = It.first;
       CCEDiag(Source->getExprLoc(), diag::note_constexpr_memory_leak)
-          << (It.second.size() - 1) << Source->getSourceRange();
+          << (Site.size() - 1) << Source->getSourceRange();
     }
   }
   // Keep evaluating before C++20, since the CXXNewExpr wasn't valid there


### PR DESCRIPTION
Use empty()-style functions instead of exposing the size if we don't need it.