### PR TITLE
[PowecPC] Hint branch `bne-` for atomic operation  after the store-conditional

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13051,7 +13051,9 @@ PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI, MachineBasicBlock *BB,
   BuildMI(BB, dl, TII->get(StoreMnemonic))
     .addReg(TmpReg).addReg(ptrA).addReg(ptrB);
   BuildMI(BB, dl, TII->get(PPC::BCC))
-    .addImm(PPC::PRED_NE_MINUS).addReg(PPC::CR0).addMBB(loopMBB);
+      .addImm(PPC::PRED_NE_MINUS)
+      .addReg(PPC::CR0)
+      .addMBB(loopMBB);
   BB->addSuccessor(loopMBB);
   BB->addSuccessor(exitMBB);
 

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -13051,7 +13051,7 @@ PPCTargetLowering::EmitAtomicBinary(MachineInstr &MI, MachineBasicBlock *BB,
   BuildMI(BB, dl, TII->get(StoreMnemonic))
     .addReg(TmpReg).addReg(ptrA).addReg(ptrB);
   BuildMI(BB, dl, TII->get(PPC::BCC))
-    .addImm(PPC::PRED_NE).addReg(PPC::CR0).addMBB(loopMBB);
+    .addImm(PPC::PRED_NE_MINUS).addReg(PPC::CR0).addMBB(loopMBB);
   BB->addSuccessor(loopMBB);
   BB->addSuccessor(exitMBB);
 
@@ -13309,7 +13309,7 @@ MachineBasicBlock *PPCTargetLowering::EmitPartwordAtomicBinary(
       .addReg(ZeroReg)
       .addReg(PtrReg);
   BuildMI(BB, dl, TII->get(PPC::BCC))
-      .addImm(PPC::PRED_NE)
+      .addImm(PPC::PRED_NE_MINUS)
       .addReg(PPC::CR0)
       .addMBB(loopMBB);
   BB->addSuccessor(loopMBB);
@@ -14140,7 +14140,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
         .addReg(dest)
         .addReg(oldval);
     BuildMI(BB, dl, TII->get(PPC::BCC))
-        .addImm(PPC::PRED_NE)
+        .addImm(PPC::PRED_NE_MINUS)
         .addReg(CrReg)
         .addMBB(exitMBB);
     BB->addSuccessor(loop2MBB);
@@ -14152,7 +14152,7 @@ PPCTargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
         .addReg(ptrA)
         .addReg(ptrB);
     BuildMI(BB, dl, TII->get(PPC::BCC))
-        .addImm(PPC::PRED_NE)
+        .addImm(PPC::PRED_NE_MINUS)
         .addReg(PPC::CR0)
         .addMBB(loop1MBB);
     BuildMI(BB, dl, TII->get(PPC::B)).addMBB(exitMBB);

--- a/llvm/test/CodeGen/PowerPC/all-atomics.ll
+++ b/llvm/test/CodeGen/PowerPC/all-atomics.ll
@@ -33,7 +33,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 5, 0, 4
 ; CHECK-NEXT:    addi 5, 5, 1
 ; CHECK-NEXT:    stbcx. 5, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_1
+; CHECK-NEXT:    bne- 0, .LBB0_1
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    addis 5, 2, uc@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -44,7 +44,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 6, 0, 5
 ; CHECK-NEXT:    addi 6, 6, 1
 ; CHECK-NEXT:    stbcx. 6, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_3
+; CHECK-NEXT:    bne- 0, .LBB0_3
 ; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    addis 6, 2, ss@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -55,7 +55,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 7, 0, 6
 ; CHECK-NEXT:    addi 7, 7, 1
 ; CHECK-NEXT:    sthcx. 7, 0, 6
-; CHECK-NEXT:    bne 0, .LBB0_5
+; CHECK-NEXT:    bne- 0, .LBB0_5
 ; CHECK-NEXT:  # %bb.6: # %entry
 ; CHECK-NEXT:    addis 7, 2, us@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -66,7 +66,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 7, 0, 8
 ; CHECK-NEXT:    addi 7, 7, 1
 ; CHECK-NEXT:    sthcx. 7, 0, 8
-; CHECK-NEXT:    bne 0, .LBB0_7
+; CHECK-NEXT:    bne- 0, .LBB0_7
 ; CHECK-NEXT:  # %bb.8: # %entry
 ; CHECK-NEXT:    addis 7, 2, si@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -77,7 +77,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 7, 0, 9
 ; CHECK-NEXT:    addi 7, 7, 1
 ; CHECK-NEXT:    stwcx. 7, 0, 9
-; CHECK-NEXT:    bne 0, .LBB0_9
+; CHECK-NEXT:    bne- 0, .LBB0_9
 ; CHECK-NEXT:  # %bb.10: # %entry
 ; CHECK-NEXT:    addis 7, 2, ui@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -88,7 +88,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 7, 0, 10
 ; CHECK-NEXT:    addi 7, 7, 1
 ; CHECK-NEXT:    stwcx. 7, 0, 10
-; CHECK-NEXT:    bne 0, .LBB0_11
+; CHECK-NEXT:    bne- 0, .LBB0_11
 ; CHECK-NEXT:  # %bb.12: # %entry
 ; CHECK-NEXT:    addis 7, 2, sll@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -100,7 +100,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 12, 0, 11
 ; CHECK-NEXT:    addi 12, 12, 1
 ; CHECK-NEXT:    stdcx. 12, 0, 11
-; CHECK-NEXT:    bne 0, .LBB0_13
+; CHECK-NEXT:    bne- 0, .LBB0_13
 ; CHECK-NEXT:  # %bb.14: # %entry
 ; CHECK-NEXT:    addis 12, 2, ull@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -111,7 +111,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 30, 0, 12
 ; CHECK-NEXT:    addi 0, 30, 1
 ; CHECK-NEXT:    stdcx. 0, 0, 12
-; CHECK-NEXT:    bne 0, .LBB0_15
+; CHECK-NEXT:    bne- 0, .LBB0_15
 ; CHECK-NEXT:  # %bb.16: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -120,7 +120,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    sub 0, 0, 3
 ; CHECK-NEXT:    stbcx. 0, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_17
+; CHECK-NEXT:    bne- 0, .LBB0_17
 ; CHECK-NEXT:  # %bb.18: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -129,7 +129,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 5
 ; CHECK-NEXT:    sub 0, 0, 3
 ; CHECK-NEXT:    stbcx. 0, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_19
+; CHECK-NEXT:    bne- 0, .LBB0_19
 ; CHECK-NEXT:  # %bb.20: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -138,7 +138,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 6
 ; CHECK-NEXT:    sub 0, 0, 3
 ; CHECK-NEXT:    sthcx. 0, 0, 6
-; CHECK-NEXT:    bne 0, .LBB0_21
+; CHECK-NEXT:    bne- 0, .LBB0_21
 ; CHECK-NEXT:  # %bb.22: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -147,7 +147,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 8
 ; CHECK-NEXT:    sub 0, 0, 3
 ; CHECK-NEXT:    sthcx. 0, 0, 8
-; CHECK-NEXT:    bne 0, .LBB0_23
+; CHECK-NEXT:    bne- 0, .LBB0_23
 ; CHECK-NEXT:  # %bb.24: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -156,7 +156,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 9
 ; CHECK-NEXT:    sub 0, 0, 3
 ; CHECK-NEXT:    stwcx. 0, 0, 9
-; CHECK-NEXT:    bne 0, .LBB0_25
+; CHECK-NEXT:    bne- 0, .LBB0_25
 ; CHECK-NEXT:  # %bb.26: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -165,7 +165,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 10
 ; CHECK-NEXT:    sub 0, 0, 3
 ; CHECK-NEXT:    stwcx. 0, 0, 10
-; CHECK-NEXT:    bne 0, .LBB0_27
+; CHECK-NEXT:    bne- 0, .LBB0_27
 ; CHECK-NEXT:  # %bb.28: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -174,7 +174,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 11
 ; CHECK-NEXT:    sub 0, 0, 7
 ; CHECK-NEXT:    stdcx. 0, 0, 11
-; CHECK-NEXT:    bne 0, .LBB0_29
+; CHECK-NEXT:    bne- 0, .LBB0_29
 ; CHECK-NEXT:  # %bb.30: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -183,7 +183,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 12
 ; CHECK-NEXT:    sub 0, 0, 7
 ; CHECK-NEXT:    stdcx. 0, 0, 12
-; CHECK-NEXT:    bne 0, .LBB0_31
+; CHECK-NEXT:    bne- 0, .LBB0_31
 ; CHECK-NEXT:  # %bb.32: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -192,7 +192,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    stbcx. 0, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_33
+; CHECK-NEXT:    bne- 0, .LBB0_33
 ; CHECK-NEXT:  # %bb.34: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -201,7 +201,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 5
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    stbcx. 0, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_35
+; CHECK-NEXT:    bne- 0, .LBB0_35
 ; CHECK-NEXT:  # %bb.36: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -210,7 +210,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 6
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    sthcx. 0, 0, 6
-; CHECK-NEXT:    bne 0, .LBB0_37
+; CHECK-NEXT:    bne- 0, .LBB0_37
 ; CHECK-NEXT:  # %bb.38: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -219,7 +219,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 8
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    sthcx. 0, 0, 8
-; CHECK-NEXT:    bne 0, .LBB0_39
+; CHECK-NEXT:    bne- 0, .LBB0_39
 ; CHECK-NEXT:  # %bb.40: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -228,7 +228,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 9
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    stwcx. 0, 0, 9
-; CHECK-NEXT:    bne 0, .LBB0_41
+; CHECK-NEXT:    bne- 0, .LBB0_41
 ; CHECK-NEXT:  # %bb.42: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -237,7 +237,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 10
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    stwcx. 0, 0, 10
-; CHECK-NEXT:    bne 0, .LBB0_43
+; CHECK-NEXT:    bne- 0, .LBB0_43
 ; CHECK-NEXT:  # %bb.44: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -246,7 +246,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 11
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    stdcx. 0, 0, 11
-; CHECK-NEXT:    bne 0, .LBB0_45
+; CHECK-NEXT:    bne- 0, .LBB0_45
 ; CHECK-NEXT:  # %bb.46: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -255,7 +255,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 12
 ; CHECK-NEXT:    ori 0, 0, 1
 ; CHECK-NEXT:    stdcx. 0, 0, 12
-; CHECK-NEXT:    bne 0, .LBB0_47
+; CHECK-NEXT:    bne- 0, .LBB0_47
 ; CHECK-NEXT:  # %bb.48: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -264,7 +264,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    stbcx. 0, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_49
+; CHECK-NEXT:    bne- 0, .LBB0_49
 ; CHECK-NEXT:  # %bb.50: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -273,7 +273,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 5
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    stbcx. 0, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_51
+; CHECK-NEXT:    bne- 0, .LBB0_51
 ; CHECK-NEXT:  # %bb.52: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -282,7 +282,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 6
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    sthcx. 0, 0, 6
-; CHECK-NEXT:    bne 0, .LBB0_53
+; CHECK-NEXT:    bne- 0, .LBB0_53
 ; CHECK-NEXT:  # %bb.54: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -291,7 +291,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 8
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    sthcx. 0, 0, 8
-; CHECK-NEXT:    bne 0, .LBB0_55
+; CHECK-NEXT:    bne- 0, .LBB0_55
 ; CHECK-NEXT:  # %bb.56: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -300,7 +300,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 9
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    stwcx. 0, 0, 9
-; CHECK-NEXT:    bne 0, .LBB0_57
+; CHECK-NEXT:    bne- 0, .LBB0_57
 ; CHECK-NEXT:  # %bb.58: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -309,7 +309,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 10
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    stwcx. 0, 0, 10
-; CHECK-NEXT:    bne 0, .LBB0_59
+; CHECK-NEXT:    bne- 0, .LBB0_59
 ; CHECK-NEXT:  # %bb.60: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -318,7 +318,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 11
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    stdcx. 0, 0, 11
-; CHECK-NEXT:    bne 0, .LBB0_61
+; CHECK-NEXT:    bne- 0, .LBB0_61
 ; CHECK-NEXT:  # %bb.62: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -327,7 +327,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 12
 ; CHECK-NEXT:    xori 0, 0, 1
 ; CHECK-NEXT:    stdcx. 0, 0, 12
-; CHECK-NEXT:    bne 0, .LBB0_63
+; CHECK-NEXT:    bne- 0, .LBB0_63
 ; CHECK-NEXT:  # %bb.64: # %entry
 ; CHECK-NEXT:    addis 30, 2, u128@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -361,7 +361,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    nand 0, 3, 0
 ; CHECK-NEXT:    stbcx. 0, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_69
+; CHECK-NEXT:    bne- 0, .LBB0_69
 ; CHECK-NEXT:  # %bb.70: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -370,7 +370,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 5
 ; CHECK-NEXT:    nand 0, 3, 0
 ; CHECK-NEXT:    stbcx. 0, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_71
+; CHECK-NEXT:    bne- 0, .LBB0_71
 ; CHECK-NEXT:  # %bb.72: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -379,7 +379,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 6
 ; CHECK-NEXT:    nand 0, 3, 0
 ; CHECK-NEXT:    sthcx. 0, 0, 6
-; CHECK-NEXT:    bne 0, .LBB0_73
+; CHECK-NEXT:    bne- 0, .LBB0_73
 ; CHECK-NEXT:  # %bb.74: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -388,7 +388,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 0, 0, 8
 ; CHECK-NEXT:    nand 0, 3, 0
 ; CHECK-NEXT:    sthcx. 0, 0, 8
-; CHECK-NEXT:    bne 0, .LBB0_75
+; CHECK-NEXT:    bne- 0, .LBB0_75
 ; CHECK-NEXT:  # %bb.76: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -397,7 +397,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 9
 ; CHECK-NEXT:    nand 0, 3, 0
 ; CHECK-NEXT:    stwcx. 0, 0, 9
-; CHECK-NEXT:    bne 0, .LBB0_77
+; CHECK-NEXT:    bne- 0, .LBB0_77
 ; CHECK-NEXT:  # %bb.78: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -406,7 +406,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 0, 0, 10
 ; CHECK-NEXT:    nand 0, 3, 0
 ; CHECK-NEXT:    stwcx. 0, 0, 10
-; CHECK-NEXT:    bne 0, .LBB0_79
+; CHECK-NEXT:    bne- 0, .LBB0_79
 ; CHECK-NEXT:  # %bb.80: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -415,7 +415,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 11
 ; CHECK-NEXT:    nand 0, 7, 0
 ; CHECK-NEXT:    stdcx. 0, 0, 11
-; CHECK-NEXT:    bne 0, .LBB0_81
+; CHECK-NEXT:    bne- 0, .LBB0_81
 ; CHECK-NEXT:  # %bb.82: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -424,7 +424,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 0, 0, 12
 ; CHECK-NEXT:    nand 0, 7, 0
 ; CHECK-NEXT:    stdcx. 0, 0, 12
-; CHECK-NEXT:    bne 0, .LBB0_83
+; CHECK-NEXT:    bne- 0, .LBB0_83
 ; CHECK-NEXT:  # %bb.84: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -433,7 +433,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 0, 0, 4
 ; CHECK-NEXT:    and 0, 3, 0
 ; CHECK-NEXT:    stbcx. 0, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_85
+; CHECK-NEXT:    bne- 0, .LBB0_85
 ; CHECK-NEXT:  # %bb.86: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -442,7 +442,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 4, 0, 5
 ; CHECK-NEXT:    and 4, 3, 4
 ; CHECK-NEXT:    stbcx. 4, 0, 5
-; CHECK-NEXT:    bne 0, .LBB0_87
+; CHECK-NEXT:    bne- 0, .LBB0_87
 ; CHECK-NEXT:  # %bb.88: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -451,7 +451,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 4, 0, 6
 ; CHECK-NEXT:    and 4, 3, 4
 ; CHECK-NEXT:    sthcx. 4, 0, 6
-; CHECK-NEXT:    bne 0, .LBB0_89
+; CHECK-NEXT:    bne- 0, .LBB0_89
 ; CHECK-NEXT:  # %bb.90: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -460,7 +460,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 4, 0, 8
 ; CHECK-NEXT:    and 4, 3, 4
 ; CHECK-NEXT:    sthcx. 4, 0, 8
-; CHECK-NEXT:    bne 0, .LBB0_91
+; CHECK-NEXT:    bne- 0, .LBB0_91
 ; CHECK-NEXT:  # %bb.92: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -469,7 +469,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 4, 0, 9
 ; CHECK-NEXT:    and 4, 3, 4
 ; CHECK-NEXT:    stwcx. 4, 0, 9
-; CHECK-NEXT:    bne 0, .LBB0_93
+; CHECK-NEXT:    bne- 0, .LBB0_93
 ; CHECK-NEXT:  # %bb.94: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -478,7 +478,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 4, 0, 10
 ; CHECK-NEXT:    and 4, 3, 4
 ; CHECK-NEXT:    stwcx. 4, 0, 10
-; CHECK-NEXT:    bne 0, .LBB0_95
+; CHECK-NEXT:    bne- 0, .LBB0_95
 ; CHECK-NEXT:  # %bb.96: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -487,7 +487,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 3, 0, 11
 ; CHECK-NEXT:    and 3, 7, 3
 ; CHECK-NEXT:    stdcx. 3, 0, 11
-; CHECK-NEXT:    bne 0, .LBB0_97
+; CHECK-NEXT:    bne- 0, .LBB0_97
 ; CHECK-NEXT:  # %bb.98: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sync
@@ -496,7 +496,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 3, 0, 12
 ; CHECK-NEXT:    and 3, 7, 3
 ; CHECK-NEXT:    stdcx. 3, 0, 12
-; CHECK-NEXT:    bne 0, .LBB0_99
+; CHECK-NEXT:    bne- 0, .LBB0_99
 ; CHECK-NEXT:  # %bb.100: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    ld 30, -16(1) # 8-byte Folded Reload
@@ -545,7 +545,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB0_1
+; AIX32-NEXT:    bne- 0, L..BB0_1
 ; AIX32-NEXT:  # %bb.2: # %entry
 ; AIX32-NEXT:    lwz 3, L..C1(2) # @uc
 ; AIX32-NEXT:    lwsync
@@ -564,7 +564,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 27
-; AIX32-NEXT:    bne 0, L..BB0_3
+; AIX32-NEXT:    bne- 0, L..BB0_3
 ; AIX32-NEXT:  # %bb.4: # %entry
 ; AIX32-NEXT:    lwz 3, L..C2(2) # @ss
 ; AIX32-NEXT:    lwsync
@@ -584,7 +584,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB0_5
+; AIX32-NEXT:    bne- 0, L..BB0_5
 ; AIX32-NEXT:  # %bb.6: # %entry
 ; AIX32-NEXT:    lwz 3, L..C3(2) # @us
 ; AIX32-NEXT:    lwsync
@@ -604,7 +604,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 23
-; AIX32-NEXT:    bne 0, L..BB0_7
+; AIX32-NEXT:    bne- 0, L..BB0_7
 ; AIX32-NEXT:  # %bb.8: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 20, L..C4(2) # @si
@@ -614,7 +614,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 20
 ; AIX32-NEXT:    addi 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 20
-; AIX32-NEXT:    bne 0, L..BB0_9
+; AIX32-NEXT:    bne- 0, L..BB0_9
 ; AIX32-NEXT:  # %bb.10: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 19, L..C5(2) # @ui
@@ -624,7 +624,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 19
 ; AIX32-NEXT:    addi 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 19
-; AIX32-NEXT:    bne 0, L..BB0_11
+; AIX32-NEXT:    bne- 0, L..BB0_11
 ; AIX32-NEXT:  # %bb.12: # %entry
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
 ; AIX32-NEXT:    lwsync
@@ -652,7 +652,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB0_13
+; AIX32-NEXT:    bne- 0, L..BB0_13
 ; AIX32-NEXT:  # %bb.14: # %entry
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    lwsync
@@ -666,7 +666,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 27
-; AIX32-NEXT:    bne 0, L..BB0_15
+; AIX32-NEXT:    bne- 0, L..BB0_15
 ; AIX32-NEXT:  # %bb.16: # %entry
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -681,7 +681,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB0_17
+; AIX32-NEXT:    bne- 0, L..BB0_17
 ; AIX32-NEXT:  # %bb.18: # %entry
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -696,7 +696,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 23
-; AIX32-NEXT:    bne 0, L..BB0_19
+; AIX32-NEXT:    bne- 0, L..BB0_19
 ; AIX32-NEXT:  # %bb.20: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -705,7 +705,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 20
 ; AIX32-NEXT:    sub 3, 3, 15
 ; AIX32-NEXT:    stwcx. 3, 0, 20
-; AIX32-NEXT:    bne 0, L..BB0_21
+; AIX32-NEXT:    bne- 0, L..BB0_21
 ; AIX32-NEXT:  # %bb.22: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -714,7 +714,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 19
 ; AIX32-NEXT:    sub 3, 3, 15
 ; AIX32-NEXT:    stwcx. 3, 0, 19
-; AIX32-NEXT:    bne 0, L..BB0_23
+; AIX32-NEXT:    bne- 0, L..BB0_23
 ; AIX32-NEXT:  # %bb.24: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -740,7 +740,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB0_25
+; AIX32-NEXT:    bne- 0, L..BB0_25
 ; AIX32-NEXT:  # %bb.26: # %entry
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    lwsync
@@ -754,7 +754,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 27
-; AIX32-NEXT:    bne 0, L..BB0_27
+; AIX32-NEXT:    bne- 0, L..BB0_27
 ; AIX32-NEXT:  # %bb.28: # %entry
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -769,7 +769,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB0_29
+; AIX32-NEXT:    bne- 0, L..BB0_29
 ; AIX32-NEXT:  # %bb.30: # %entry
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -784,7 +784,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 23
-; AIX32-NEXT:    bne 0, L..BB0_31
+; AIX32-NEXT:    bne- 0, L..BB0_31
 ; AIX32-NEXT:  # %bb.32: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -793,7 +793,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 20
 ; AIX32-NEXT:    ori 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 20
-; AIX32-NEXT:    bne 0, L..BB0_33
+; AIX32-NEXT:    bne- 0, L..BB0_33
 ; AIX32-NEXT:  # %bb.34: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -802,7 +802,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 19
 ; AIX32-NEXT:    ori 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 19
-; AIX32-NEXT:    bne 0, L..BB0_35
+; AIX32-NEXT:    bne- 0, L..BB0_35
 ; AIX32-NEXT:  # %bb.36: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -828,7 +828,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB0_37
+; AIX32-NEXT:    bne- 0, L..BB0_37
 ; AIX32-NEXT:  # %bb.38: # %entry
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    lwsync
@@ -842,7 +842,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 27
-; AIX32-NEXT:    bne 0, L..BB0_39
+; AIX32-NEXT:    bne- 0, L..BB0_39
 ; AIX32-NEXT:  # %bb.40: # %entry
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -857,7 +857,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB0_41
+; AIX32-NEXT:    bne- 0, L..BB0_41
 ; AIX32-NEXT:  # %bb.42: # %entry
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -872,7 +872,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 23
-; AIX32-NEXT:    bne 0, L..BB0_43
+; AIX32-NEXT:    bne- 0, L..BB0_43
 ; AIX32-NEXT:  # %bb.44: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -881,7 +881,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 20
 ; AIX32-NEXT:    xori 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 20
-; AIX32-NEXT:    bne 0, L..BB0_45
+; AIX32-NEXT:    bne- 0, L..BB0_45
 ; AIX32-NEXT:  # %bb.46: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -890,7 +890,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 19
 ; AIX32-NEXT:    xori 3, 3, 1
 ; AIX32-NEXT:    stwcx. 3, 0, 19
-; AIX32-NEXT:    bne 0, L..BB0_47
+; AIX32-NEXT:    bne- 0, L..BB0_47
 ; AIX32-NEXT:  # %bb.48: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -986,7 +986,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB0_53
+; AIX32-NEXT:    bne- 0, L..BB0_53
 ; AIX32-NEXT:  # %bb.54: # %atomicrmw.end
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    lwsync
@@ -1001,7 +1001,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 27
-; AIX32-NEXT:    bne 0, L..BB0_55
+; AIX32-NEXT:    bne- 0, L..BB0_55
 ; AIX32-NEXT:  # %bb.56: # %atomicrmw.end
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -1017,7 +1017,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB0_57
+; AIX32-NEXT:    bne- 0, L..BB0_57
 ; AIX32-NEXT:  # %bb.58: # %atomicrmw.end
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -1033,7 +1033,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 23
-; AIX32-NEXT:    bne 0, L..BB0_59
+; AIX32-NEXT:    bne- 0, L..BB0_59
 ; AIX32-NEXT:  # %bb.60: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -1042,7 +1042,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 20
 ; AIX32-NEXT:    nand 3, 29, 3
 ; AIX32-NEXT:    stwcx. 3, 0, 20
-; AIX32-NEXT:    bne 0, L..BB0_61
+; AIX32-NEXT:    bne- 0, L..BB0_61
 ; AIX32-NEXT:  # %bb.62: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -1051,7 +1051,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 19
 ; AIX32-NEXT:    nand 3, 29, 3
 ; AIX32-NEXT:    stwcx. 3, 0, 19
-; AIX32-NEXT:    bne 0, L..BB0_63
+; AIX32-NEXT:    bne- 0, L..BB0_63
 ; AIX32-NEXT:  # %bb.64: # %atomicrmw.end
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
 ; AIX32-NEXT:    lwsync
@@ -1079,7 +1079,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB0_65
+; AIX32-NEXT:    bne- 0, L..BB0_65
 ; AIX32-NEXT:  # %bb.66: # %atomicrmw.end
 ; AIX32-NEXT:    li 3, 255
 ; AIX32-NEXT:    lwsync
@@ -1093,7 +1093,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 27
-; AIX32-NEXT:    bne 0, L..BB0_67
+; AIX32-NEXT:    bne- 0, L..BB0_67
 ; AIX32-NEXT:  # %bb.68: # %atomicrmw.end
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -1108,7 +1108,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB0_69
+; AIX32-NEXT:    bne- 0, L..BB0_69
 ; AIX32-NEXT:  # %bb.70: # %atomicrmw.end
 ; AIX32-NEXT:    li 3, 0
 ; AIX32-NEXT:    lwsync
@@ -1123,7 +1123,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 4, 5, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 23
-; AIX32-NEXT:    bne 0, L..BB0_71
+; AIX32-NEXT:    bne- 0, L..BB0_71
 ; AIX32-NEXT:  # %bb.72: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -1132,7 +1132,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 20
 ; AIX32-NEXT:    and 3, 29, 3
 ; AIX32-NEXT:    stwcx. 3, 0, 20
-; AIX32-NEXT:    bne 0, L..BB0_73
+; AIX32-NEXT:    bne- 0, L..BB0_73
 ; AIX32-NEXT:  # %bb.74: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    sync
@@ -1141,7 +1141,7 @@ define dso_local void @test_op_ignore() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 19
 ; AIX32-NEXT:    and 3, 29, 3
 ; AIX32-NEXT:    stwcx. 3, 0, 19
-; AIX32-NEXT:    bne 0, L..BB0_75
+; AIX32-NEXT:    bne- 0, L..BB0_75
 ; AIX32-NEXT:  # %bb.76: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -1252,7 +1252,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 5, 0, 6
 ; CHECK-NEXT:    addi 7, 5, 11
 ; CHECK-NEXT:    stbcx. 7, 0, 6
-; CHECK-NEXT:    bne 0, .LBB1_1
+; CHECK-NEXT:    bne- 0, .LBB1_1
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 5, sc@toc@l(4)
@@ -1264,7 +1264,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 7, 0, 8
 ; CHECK-NEXT:    addi 9, 7, 11
 ; CHECK-NEXT:    stbcx. 9, 0, 8
-; CHECK-NEXT:    bne 0, .LBB1_3
+; CHECK-NEXT:    bne- 0, .LBB1_3
 ; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 7, uc@toc@l(5)
@@ -1276,7 +1276,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 9, 0, 10
 ; CHECK-NEXT:    addi 11, 9, 11
 ; CHECK-NEXT:    sthcx. 11, 0, 10
-; CHECK-NEXT:    bne 0, .LBB1_5
+; CHECK-NEXT:    bne- 0, .LBB1_5
 ; CHECK-NEXT:  # %bb.6: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 9, ss@toc@l(7)
@@ -1288,7 +1288,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 11, 0, 0
 ; CHECK-NEXT:    addi 12, 11, 11
 ; CHECK-NEXT:    sthcx. 12, 0, 0
-; CHECK-NEXT:    bne 0, .LBB1_7
+; CHECK-NEXT:    bne- 0, .LBB1_7
 ; CHECK-NEXT:  # %bb.8: # %entry
 ; CHECK-NEXT:    addis 12, 2, si@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -1300,7 +1300,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 11, 0, 29
 ; CHECK-NEXT:    addi 30, 11, 11
 ; CHECK-NEXT:    stwcx. 30, 0, 29
-; CHECK-NEXT:    bne 0, .LBB1_9
+; CHECK-NEXT:    bne- 0, .LBB1_9
 ; CHECK-NEXT:  # %bb.10: # %entry
 ; CHECK-NEXT:    addis 30, 2, ui@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -1312,7 +1312,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 11, 0, 27
 ; CHECK-NEXT:    addi 28, 11, 11
 ; CHECK-NEXT:    stwcx. 28, 0, 27
-; CHECK-NEXT:    bne 0, .LBB1_11
+; CHECK-NEXT:    bne- 0, .LBB1_11
 ; CHECK-NEXT:  # %bb.12: # %entry
 ; CHECK-NEXT:    addis 28, 2, sll@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -1325,7 +1325,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 26, 0, 25
 ; CHECK-NEXT:    addi 24, 26, 11
 ; CHECK-NEXT:    stdcx. 24, 0, 25
-; CHECK-NEXT:    bne 0, .LBB1_13
+; CHECK-NEXT:    bne- 0, .LBB1_13
 ; CHECK-NEXT:  # %bb.14: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 26, sll@toc@l(28)
@@ -1337,7 +1337,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 24
 ; CHECK-NEXT:    addi 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 24
-; CHECK-NEXT:    bne 0, .LBB1_15
+; CHECK-NEXT:    bne- 0, .LBB1_15
 ; CHECK-NEXT:  # %bb.16: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, ull@toc@l(26)
@@ -1347,7 +1347,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 6
 ; CHECK-NEXT:    sub 22, 23, 3
 ; CHECK-NEXT:    stbcx. 22, 0, 6
-; CHECK-NEXT:    bne 0, .LBB1_17
+; CHECK-NEXT:    bne- 0, .LBB1_17
 ; CHECK-NEXT:  # %bb.18: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, sc@toc@l(4)
@@ -1357,7 +1357,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 8
 ; CHECK-NEXT:    sub 22, 23, 3
 ; CHECK-NEXT:    stbcx. 22, 0, 8
-; CHECK-NEXT:    bne 0, .LBB1_19
+; CHECK-NEXT:    bne- 0, .LBB1_19
 ; CHECK-NEXT:  # %bb.20: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, uc@toc@l(5)
@@ -1367,7 +1367,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 10
 ; CHECK-NEXT:    sub 22, 23, 3
 ; CHECK-NEXT:    sthcx. 22, 0, 10
-; CHECK-NEXT:    bne 0, .LBB1_21
+; CHECK-NEXT:    bne- 0, .LBB1_21
 ; CHECK-NEXT:  # %bb.22: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, ss@toc@l(7)
@@ -1377,7 +1377,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 0
 ; CHECK-NEXT:    sub 22, 23, 3
 ; CHECK-NEXT:    sthcx. 22, 0, 0
-; CHECK-NEXT:    bne 0, .LBB1_23
+; CHECK-NEXT:    bne- 0, .LBB1_23
 ; CHECK-NEXT:  # %bb.24: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, us@toc@l(9)
@@ -1387,7 +1387,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 29
 ; CHECK-NEXT:    sub 22, 23, 3
 ; CHECK-NEXT:    stwcx. 22, 0, 29
-; CHECK-NEXT:    bne 0, .LBB1_25
+; CHECK-NEXT:    bne- 0, .LBB1_25
 ; CHECK-NEXT:  # %bb.26: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, si@toc@l(12)
@@ -1397,7 +1397,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 27
 ; CHECK-NEXT:    sub 22, 23, 3
 ; CHECK-NEXT:    stwcx. 22, 0, 27
-; CHECK-NEXT:    bne 0, .LBB1_27
+; CHECK-NEXT:    bne- 0, .LBB1_27
 ; CHECK-NEXT:  # %bb.28: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, ui@toc@l(30)
@@ -1407,7 +1407,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    sub 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 25
-; CHECK-NEXT:    bne 0, .LBB1_29
+; CHECK-NEXT:    bne- 0, .LBB1_29
 ; CHECK-NEXT:  # %bb.30: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, sll@toc@l(28)
@@ -1417,7 +1417,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 24
 ; CHECK-NEXT:    sub 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 24
-; CHECK-NEXT:    bne 0, .LBB1_31
+; CHECK-NEXT:    bne- 0, .LBB1_31
 ; CHECK-NEXT:  # %bb.32: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, ull@toc@l(26)
@@ -1427,7 +1427,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 6
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    stbcx. 22, 0, 6
-; CHECK-NEXT:    bne 0, .LBB1_33
+; CHECK-NEXT:    bne- 0, .LBB1_33
 ; CHECK-NEXT:  # %bb.34: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, sc@toc@l(4)
@@ -1437,7 +1437,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 8
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    stbcx. 22, 0, 8
-; CHECK-NEXT:    bne 0, .LBB1_35
+; CHECK-NEXT:    bne- 0, .LBB1_35
 ; CHECK-NEXT:  # %bb.36: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, uc@toc@l(5)
@@ -1447,7 +1447,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 10
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    sthcx. 22, 0, 10
-; CHECK-NEXT:    bne 0, .LBB1_37
+; CHECK-NEXT:    bne- 0, .LBB1_37
 ; CHECK-NEXT:  # %bb.38: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, ss@toc@l(7)
@@ -1457,7 +1457,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 0
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    sthcx. 22, 0, 0
-; CHECK-NEXT:    bne 0, .LBB1_39
+; CHECK-NEXT:    bne- 0, .LBB1_39
 ; CHECK-NEXT:  # %bb.40: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, us@toc@l(9)
@@ -1467,7 +1467,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 29
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    stwcx. 22, 0, 29
-; CHECK-NEXT:    bne 0, .LBB1_41
+; CHECK-NEXT:    bne- 0, .LBB1_41
 ; CHECK-NEXT:  # %bb.42: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, si@toc@l(12)
@@ -1477,7 +1477,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 27
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    stwcx. 22, 0, 27
-; CHECK-NEXT:    bne 0, .LBB1_43
+; CHECK-NEXT:    bne- 0, .LBB1_43
 ; CHECK-NEXT:  # %bb.44: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, ui@toc@l(30)
@@ -1487,7 +1487,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 25
-; CHECK-NEXT:    bne 0, .LBB1_45
+; CHECK-NEXT:    bne- 0, .LBB1_45
 ; CHECK-NEXT:  # %bb.46: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, sll@toc@l(28)
@@ -1497,7 +1497,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 24
 ; CHECK-NEXT:    ori 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 24
-; CHECK-NEXT:    bne 0, .LBB1_47
+; CHECK-NEXT:    bne- 0, .LBB1_47
 ; CHECK-NEXT:  # %bb.48: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, ull@toc@l(26)
@@ -1507,7 +1507,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 6
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    stbcx. 22, 0, 6
-; CHECK-NEXT:    bne 0, .LBB1_49
+; CHECK-NEXT:    bne- 0, .LBB1_49
 ; CHECK-NEXT:  # %bb.50: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, sc@toc@l(4)
@@ -1517,7 +1517,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 8
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    stbcx. 22, 0, 8
-; CHECK-NEXT:    bne 0, .LBB1_51
+; CHECK-NEXT:    bne- 0, .LBB1_51
 ; CHECK-NEXT:  # %bb.52: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, uc@toc@l(5)
@@ -1527,7 +1527,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 10
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    sthcx. 22, 0, 10
-; CHECK-NEXT:    bne 0, .LBB1_53
+; CHECK-NEXT:    bne- 0, .LBB1_53
 ; CHECK-NEXT:  # %bb.54: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, ss@toc@l(7)
@@ -1537,7 +1537,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 0
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    sthcx. 22, 0, 0
-; CHECK-NEXT:    bne 0, .LBB1_55
+; CHECK-NEXT:    bne- 0, .LBB1_55
 ; CHECK-NEXT:  # %bb.56: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, us@toc@l(9)
@@ -1547,7 +1547,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 29
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    stwcx. 22, 0, 29
-; CHECK-NEXT:    bne 0, .LBB1_57
+; CHECK-NEXT:    bne- 0, .LBB1_57
 ; CHECK-NEXT:  # %bb.58: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, si@toc@l(12)
@@ -1557,7 +1557,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 27
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    stwcx. 22, 0, 27
-; CHECK-NEXT:    bne 0, .LBB1_59
+; CHECK-NEXT:    bne- 0, .LBB1_59
 ; CHECK-NEXT:  # %bb.60: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, ui@toc@l(30)
@@ -1567,7 +1567,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 25
-; CHECK-NEXT:    bne 0, .LBB1_61
+; CHECK-NEXT:    bne- 0, .LBB1_61
 ; CHECK-NEXT:  # %bb.62: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, sll@toc@l(28)
@@ -1577,7 +1577,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 24
 ; CHECK-NEXT:    xori 22, 23, 11
 ; CHECK-NEXT:    stdcx. 22, 0, 24
-; CHECK-NEXT:    bne 0, .LBB1_63
+; CHECK-NEXT:    bne- 0, .LBB1_63
 ; CHECK-NEXT:  # %bb.64: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, ull@toc@l(26)
@@ -1587,7 +1587,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 6
 ; CHECK-NEXT:    nand 22, 3, 23
 ; CHECK-NEXT:    stbcx. 22, 0, 6
-; CHECK-NEXT:    bne 0, .LBB1_65
+; CHECK-NEXT:    bne- 0, .LBB1_65
 ; CHECK-NEXT:  # %bb.66: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, sc@toc@l(4)
@@ -1597,7 +1597,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 8
 ; CHECK-NEXT:    nand 22, 3, 23
 ; CHECK-NEXT:    stbcx. 22, 0, 8
-; CHECK-NEXT:    bne 0, .LBB1_67
+; CHECK-NEXT:    bne- 0, .LBB1_67
 ; CHECK-NEXT:  # %bb.68: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, uc@toc@l(5)
@@ -1607,7 +1607,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 10
 ; CHECK-NEXT:    nand 22, 3, 23
 ; CHECK-NEXT:    sthcx. 22, 0, 10
-; CHECK-NEXT:    bne 0, .LBB1_69
+; CHECK-NEXT:    bne- 0, .LBB1_69
 ; CHECK-NEXT:  # %bb.70: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, ss@toc@l(7)
@@ -1617,7 +1617,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 23, 0, 0
 ; CHECK-NEXT:    nand 22, 3, 23
 ; CHECK-NEXT:    sthcx. 22, 0, 0
-; CHECK-NEXT:    bne 0, .LBB1_71
+; CHECK-NEXT:    bne- 0, .LBB1_71
 ; CHECK-NEXT:  # %bb.72: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 23, us@toc@l(9)
@@ -1627,7 +1627,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 29
 ; CHECK-NEXT:    nand 22, 3, 23
 ; CHECK-NEXT:    stwcx. 22, 0, 29
-; CHECK-NEXT:    bne 0, .LBB1_73
+; CHECK-NEXT:    bne- 0, .LBB1_73
 ; CHECK-NEXT:  # %bb.74: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, si@toc@l(12)
@@ -1637,7 +1637,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 23, 0, 27
 ; CHECK-NEXT:    nand 22, 3, 23
 ; CHECK-NEXT:    stwcx. 22, 0, 27
-; CHECK-NEXT:    bne 0, .LBB1_75
+; CHECK-NEXT:    bne- 0, .LBB1_75
 ; CHECK-NEXT:  # %bb.76: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 23, ui@toc@l(30)
@@ -1647,7 +1647,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 25
 ; CHECK-NEXT:    nand 22, 11, 23
 ; CHECK-NEXT:    stdcx. 22, 0, 25
-; CHECK-NEXT:    bne 0, .LBB1_77
+; CHECK-NEXT:    bne- 0, .LBB1_77
 ; CHECK-NEXT:  # %bb.78: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, sll@toc@l(28)
@@ -1657,7 +1657,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 23, 0, 24
 ; CHECK-NEXT:    nand 22, 11, 23
 ; CHECK-NEXT:    stdcx. 22, 0, 24
-; CHECK-NEXT:    bne 0, .LBB1_79
+; CHECK-NEXT:    bne- 0, .LBB1_79
 ; CHECK-NEXT:  # %bb.80: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 23, ull@toc@l(26)
@@ -1667,7 +1667,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 23, 0, 6
 ; CHECK-NEXT:    and 22, 3, 23
 ; CHECK-NEXT:    stbcx. 22, 0, 6
-; CHECK-NEXT:    bne 0, .LBB1_81
+; CHECK-NEXT:    bne- 0, .LBB1_81
 ; CHECK-NEXT:  # %bb.82: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 23, sc@toc@l(4)
@@ -1677,7 +1677,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 4, 0, 8
 ; CHECK-NEXT:    and 6, 3, 4
 ; CHECK-NEXT:    stbcx. 6, 0, 8
-; CHECK-NEXT:    bne 0, .LBB1_83
+; CHECK-NEXT:    bne- 0, .LBB1_83
 ; CHECK-NEXT:  # %bb.84: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 4, uc@toc@l(5)
@@ -1687,7 +1687,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 4, 0, 10
 ; CHECK-NEXT:    and 5, 3, 4
 ; CHECK-NEXT:    sthcx. 5, 0, 10
-; CHECK-NEXT:    bne 0, .LBB1_85
+; CHECK-NEXT:    bne- 0, .LBB1_85
 ; CHECK-NEXT:  # %bb.86: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 4, ss@toc@l(7)
@@ -1697,7 +1697,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 4, 0, 0
 ; CHECK-NEXT:    and 5, 3, 4
 ; CHECK-NEXT:    sthcx. 5, 0, 0
-; CHECK-NEXT:    bne 0, .LBB1_87
+; CHECK-NEXT:    bne- 0, .LBB1_87
 ; CHECK-NEXT:  # %bb.88: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 4, us@toc@l(9)
@@ -1707,7 +1707,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 4, 0, 29
 ; CHECK-NEXT:    and 5, 3, 4
 ; CHECK-NEXT:    stwcx. 5, 0, 29
-; CHECK-NEXT:    bne 0, .LBB1_89
+; CHECK-NEXT:    bne- 0, .LBB1_89
 ; CHECK-NEXT:  # %bb.90: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 4, si@toc@l(12)
@@ -1717,7 +1717,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 4, 0, 27
 ; CHECK-NEXT:    and 5, 3, 4
 ; CHECK-NEXT:    stwcx. 5, 0, 27
-; CHECK-NEXT:    bne 0, .LBB1_91
+; CHECK-NEXT:    bne- 0, .LBB1_91
 ; CHECK-NEXT:  # %bb.92: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 4, ui@toc@l(30)
@@ -1727,7 +1727,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 3, 0, 25
 ; CHECK-NEXT:    and 4, 11, 3
 ; CHECK-NEXT:    stdcx. 4, 0, 25
-; CHECK-NEXT:    bne 0, .LBB1_93
+; CHECK-NEXT:    bne- 0, .LBB1_93
 ; CHECK-NEXT:  # %bb.94: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 3, sll@toc@l(28)
@@ -1737,7 +1737,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 3, 0, 24
 ; CHECK-NEXT:    and 4, 11, 3
 ; CHECK-NEXT:    stdcx. 4, 0, 24
-; CHECK-NEXT:    bne 0, .LBB1_95
+; CHECK-NEXT:    bne- 0, .LBB1_95
 ; CHECK-NEXT:  # %bb.96: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 3, ull@toc@l(26)
@@ -1794,7 +1794,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 25
-; AIX32-NEXT:    bne 0, L..BB1_1
+; AIX32-NEXT:    bne- 0, L..BB1_1
 ; AIX32-NEXT:  # %bb.2: # %entry
 ; AIX32-NEXT:    srw 3, 4, 26
 ; AIX32-NEXT:    lwsync
@@ -1817,7 +1817,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 21
-; AIX32-NEXT:    bne 0, L..BB1_3
+; AIX32-NEXT:    bne- 0, L..BB1_3
 ; AIX32-NEXT:  # %bb.4: # %entry
 ; AIX32-NEXT:    srw 3, 4, 22
 ; AIX32-NEXT:    lwz 23, L..C2(2) # @ss
@@ -1840,7 +1840,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 17
-; AIX32-NEXT:    bne 0, L..BB1_5
+; AIX32-NEXT:    bne- 0, L..BB1_5
 ; AIX32-NEXT:  # %bb.6: # %entry
 ; AIX32-NEXT:    srw 3, 4, 18
 ; AIX32-NEXT:    lwz 19, L..C3(2) # @us
@@ -1863,7 +1863,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 14
-; AIX32-NEXT:    bne 0, L..BB1_7
+; AIX32-NEXT:    bne- 0, L..BB1_7
 ; AIX32-NEXT:  # %bb.8: # %entry
 ; AIX32-NEXT:    srw 3, 4, 15
 ; AIX32-NEXT:    lwsync
@@ -1876,7 +1876,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    addi 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne 0, L..BB1_9
+; AIX32-NEXT:    bne- 0, L..BB1_9
 ; AIX32-NEXT:  # %bb.10: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 3, 0(29)
@@ -1887,7 +1887,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 28
 ; AIX32-NEXT:    addi 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB1_11
+; AIX32-NEXT:    bne- 0, L..BB1_11
 ; AIX32-NEXT:  # %bb.12: # %entry
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
 ; AIX32-NEXT:    lwsync
@@ -1920,7 +1920,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 25
-; AIX32-NEXT:    bne 0, L..BB1_13
+; AIX32-NEXT:    bne- 0, L..BB1_13
 ; AIX32-NEXT:  # %bb.14: # %entry
 ; AIX32-NEXT:    srw 3, 4, 26
 ; AIX32-NEXT:    lwsync
@@ -1938,7 +1938,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 21
-; AIX32-NEXT:    bne 0, L..BB1_15
+; AIX32-NEXT:    bne- 0, L..BB1_15
 ; AIX32-NEXT:  # %bb.16: # %entry
 ; AIX32-NEXT:    srw 3, 4, 22
 ; AIX32-NEXT:    lwsync
@@ -1957,7 +1957,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 17
-; AIX32-NEXT:    bne 0, L..BB1_17
+; AIX32-NEXT:    bne- 0, L..BB1_17
 ; AIX32-NEXT:  # %bb.18: # %entry
 ; AIX32-NEXT:    srw 3, 4, 18
 ; AIX32-NEXT:    lwsync
@@ -1975,7 +1975,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 14
-; AIX32-NEXT:    bne 0, L..BB1_19
+; AIX32-NEXT:    bne- 0, L..BB1_19
 ; AIX32-NEXT:  # %bb.20: # %entry
 ; AIX32-NEXT:    srw 3, 4, 15
 ; AIX32-NEXT:    lwsync
@@ -1987,7 +1987,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    sub 4, 3, 7
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne 0, L..BB1_21
+; AIX32-NEXT:    bne- 0, L..BB1_21
 ; AIX32-NEXT:  # %bb.22: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 3, 0(29)
@@ -1997,7 +1997,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 28
 ; AIX32-NEXT:    sub 4, 3, 7
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB1_23
+; AIX32-NEXT:    bne- 0, L..BB1_23
 ; AIX32-NEXT:  # %bb.24: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -2028,7 +2028,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 25
-; AIX32-NEXT:    bne 0, L..BB1_25
+; AIX32-NEXT:    bne- 0, L..BB1_25
 ; AIX32-NEXT:  # %bb.26: # %entry
 ; AIX32-NEXT:    srw 3, 4, 26
 ; AIX32-NEXT:    lwsync
@@ -2046,7 +2046,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 21
-; AIX32-NEXT:    bne 0, L..BB1_27
+; AIX32-NEXT:    bne- 0, L..BB1_27
 ; AIX32-NEXT:  # %bb.28: # %entry
 ; AIX32-NEXT:    srw 3, 4, 22
 ; AIX32-NEXT:    lwsync
@@ -2064,7 +2064,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 17
-; AIX32-NEXT:    bne 0, L..BB1_29
+; AIX32-NEXT:    bne- 0, L..BB1_29
 ; AIX32-NEXT:  # %bb.30: # %entry
 ; AIX32-NEXT:    srw 3, 4, 18
 ; AIX32-NEXT:    lwsync
@@ -2082,7 +2082,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 14
-; AIX32-NEXT:    bne 0, L..BB1_31
+; AIX32-NEXT:    bne- 0, L..BB1_31
 ; AIX32-NEXT:  # %bb.32: # %entry
 ; AIX32-NEXT:    srw 3, 4, 15
 ; AIX32-NEXT:    lwsync
@@ -2094,7 +2094,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    ori 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne 0, L..BB1_33
+; AIX32-NEXT:    bne- 0, L..BB1_33
 ; AIX32-NEXT:  # %bb.34: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 3, 0(29)
@@ -2104,7 +2104,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 28
 ; AIX32-NEXT:    ori 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB1_35
+; AIX32-NEXT:    bne- 0, L..BB1_35
 ; AIX32-NEXT:  # %bb.36: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -2135,7 +2135,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 25
-; AIX32-NEXT:    bne 0, L..BB1_37
+; AIX32-NEXT:    bne- 0, L..BB1_37
 ; AIX32-NEXT:  # %bb.38: # %entry
 ; AIX32-NEXT:    srw 3, 4, 26
 ; AIX32-NEXT:    lwsync
@@ -2153,7 +2153,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 21
-; AIX32-NEXT:    bne 0, L..BB1_39
+; AIX32-NEXT:    bne- 0, L..BB1_39
 ; AIX32-NEXT:  # %bb.40: # %entry
 ; AIX32-NEXT:    srw 3, 4, 22
 ; AIX32-NEXT:    lwsync
@@ -2171,7 +2171,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 17
-; AIX32-NEXT:    bne 0, L..BB1_41
+; AIX32-NEXT:    bne- 0, L..BB1_41
 ; AIX32-NEXT:  # %bb.42: # %entry
 ; AIX32-NEXT:    srw 3, 4, 18
 ; AIX32-NEXT:    lwsync
@@ -2189,7 +2189,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 14
-; AIX32-NEXT:    bne 0, L..BB1_43
+; AIX32-NEXT:    bne- 0, L..BB1_43
 ; AIX32-NEXT:  # %bb.44: # %entry
 ; AIX32-NEXT:    srw 3, 4, 15
 ; AIX32-NEXT:    lwsync
@@ -2201,7 +2201,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    xori 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne 0, L..BB1_45
+; AIX32-NEXT:    bne- 0, L..BB1_45
 ; AIX32-NEXT:  # %bb.46: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 3, 0(29)
@@ -2211,7 +2211,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 28
 ; AIX32-NEXT:    xori 4, 3, 11
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB1_47
+; AIX32-NEXT:    bne- 0, L..BB1_47
 ; AIX32-NEXT:  # %bb.48: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -2242,7 +2242,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 25
-; AIX32-NEXT:    bne 0, L..BB1_49
+; AIX32-NEXT:    bne- 0, L..BB1_49
 ; AIX32-NEXT:  # %bb.50: # %entry
 ; AIX32-NEXT:    srw 3, 4, 26
 ; AIX32-NEXT:    lwsync
@@ -2261,7 +2261,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 21
-; AIX32-NEXT:    bne 0, L..BB1_51
+; AIX32-NEXT:    bne- 0, L..BB1_51
 ; AIX32-NEXT:  # %bb.52: # %entry
 ; AIX32-NEXT:    srw 3, 4, 22
 ; AIX32-NEXT:    lwsync
@@ -2279,7 +2279,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 17
-; AIX32-NEXT:    bne 0, L..BB1_53
+; AIX32-NEXT:    bne- 0, L..BB1_53
 ; AIX32-NEXT:  # %bb.54: # %entry
 ; AIX32-NEXT:    srw 3, 4, 18
 ; AIX32-NEXT:    lwsync
@@ -2297,7 +2297,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 14
-; AIX32-NEXT:    bne 0, L..BB1_55
+; AIX32-NEXT:    bne- 0, L..BB1_55
 ; AIX32-NEXT:  # %bb.56: # %entry
 ; AIX32-NEXT:    srw 3, 4, 15
 ; AIX32-NEXT:    lwsync
@@ -2309,7 +2309,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    nand 4, 7, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne 0, L..BB1_57
+; AIX32-NEXT:    bne- 0, L..BB1_57
 ; AIX32-NEXT:  # %bb.58: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 3, 0(29)
@@ -2319,7 +2319,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 28
 ; AIX32-NEXT:    nand 4, 7, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB1_59
+; AIX32-NEXT:    bne- 0, L..BB1_59
 ; AIX32-NEXT:  # %bb.60: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -2350,7 +2350,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 25
-; AIX32-NEXT:    bne 0, L..BB1_61
+; AIX32-NEXT:    bne- 0, L..BB1_61
 ; AIX32-NEXT:  # %bb.62: # %entry
 ; AIX32-NEXT:    srw 3, 4, 26
 ; AIX32-NEXT:    lwsync
@@ -2368,7 +2368,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 21
-; AIX32-NEXT:    bne 0, L..BB1_63
+; AIX32-NEXT:    bne- 0, L..BB1_63
 ; AIX32-NEXT:  # %bb.64: # %entry
 ; AIX32-NEXT:    srw 3, 4, 22
 ; AIX32-NEXT:    lwsync
@@ -2387,7 +2387,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 17
-; AIX32-NEXT:    bne 0, L..BB1_65
+; AIX32-NEXT:    bne- 0, L..BB1_65
 ; AIX32-NEXT:  # %bb.66: # %entry
 ; AIX32-NEXT:    srw 3, 4, 18
 ; AIX32-NEXT:    lwsync
@@ -2405,7 +2405,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 5, 5, 3
 ; AIX32-NEXT:    or 5, 5, 6
 ; AIX32-NEXT:    stwcx. 5, 0, 14
-; AIX32-NEXT:    bne 0, L..BB1_67
+; AIX32-NEXT:    bne- 0, L..BB1_67
 ; AIX32-NEXT:  # %bb.68: # %entry
 ; AIX32-NEXT:    srw 3, 4, 15
 ; AIX32-NEXT:    lwsync
@@ -2417,7 +2417,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 29
 ; AIX32-NEXT:    and 4, 7, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 29
-; AIX32-NEXT:    bne 0, L..BB1_69
+; AIX32-NEXT:    bne- 0, L..BB1_69
 ; AIX32-NEXT:  # %bb.70: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 3, 0(29)
@@ -2427,7 +2427,7 @@ define dso_local void @test_fetch_and_op() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 3, 0, 28
 ; AIX32-NEXT:    and 4, 7, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 28
-; AIX32-NEXT:    bne 0, L..BB1_71
+; AIX32-NEXT:    bne- 0, L..BB1_71
 ; AIX32-NEXT:  # %bb.72: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    li 4, 0
@@ -2599,7 +2599,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 8, 0, 7
 ; CHECK-NEXT:    add 8, 6, 8
 ; CHECK-NEXT:    stbcx. 8, 0, 7
-; CHECK-NEXT:    bne 0, .LBB2_1
+; CHECK-NEXT:    bne- 0, .LBB2_1
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 8, sc@toc@l(5)
@@ -2610,7 +2610,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 8, 0, 4
 ; CHECK-NEXT:    add 8, 6, 8
 ; CHECK-NEXT:    stbcx. 8, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_3
+; CHECK-NEXT:    bne- 0, .LBB2_3
 ; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    addis 6, 2, ss@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -2623,7 +2623,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 10, 0, 9
 ; CHECK-NEXT:    add 10, 8, 10
 ; CHECK-NEXT:    sthcx. 10, 0, 9
-; CHECK-NEXT:    bne 0, .LBB2_5
+; CHECK-NEXT:    bne- 0, .LBB2_5
 ; CHECK-NEXT:  # %bb.6: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    addis 8, 2, us@toc@ha
@@ -2636,7 +2636,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 12, 0, 11
 ; CHECK-NEXT:    add 12, 10, 12
 ; CHECK-NEXT:    sthcx. 12, 0, 11
-; CHECK-NEXT:    bne 0, .LBB2_7
+; CHECK-NEXT:    bne- 0, .LBB2_7
 ; CHECK-NEXT:  # %bb.8: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    addis 10, 2, si@toc@ha
@@ -2649,7 +2649,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 30, 0, 0
 ; CHECK-NEXT:    add 30, 12, 30
 ; CHECK-NEXT:    stwcx. 30, 0, 0
-; CHECK-NEXT:    bne 0, .LBB2_9
+; CHECK-NEXT:    bne- 0, .LBB2_9
 ; CHECK-NEXT:  # %bb.10: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    addis 12, 2, ui@toc@ha
@@ -2662,7 +2662,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 28, 0, 29
 ; CHECK-NEXT:    add 28, 30, 28
 ; CHECK-NEXT:    stwcx. 28, 0, 29
-; CHECK-NEXT:    bne 0, .LBB2_11
+; CHECK-NEXT:    bne- 0, .LBB2_11
 ; CHECK-NEXT:  # %bb.12: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    addis 30, 2, sll@toc@ha
@@ -2675,7 +2675,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 26, 0, 27
 ; CHECK-NEXT:    add 26, 28, 26
 ; CHECK-NEXT:    stdcx. 26, 0, 27
-; CHECK-NEXT:    bne 0, .LBB2_13
+; CHECK-NEXT:    bne- 0, .LBB2_13
 ; CHECK-NEXT:  # %bb.14: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    addis 28, 2, ull@toc@ha
@@ -2688,7 +2688,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 26
 ; CHECK-NEXT:    add 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 26
-; CHECK-NEXT:    bne 0, .LBB2_15
+; CHECK-NEXT:    bne- 0, .LBB2_15
 ; CHECK-NEXT:  # %bb.16: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, ull@toc@l(28)
@@ -2699,7 +2699,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 7
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    stbcx. 24, 0, 7
-; CHECK-NEXT:    bne 0, .LBB2_17
+; CHECK-NEXT:    bne- 0, .LBB2_17
 ; CHECK-NEXT:  # %bb.18: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, sc@toc@l(5)
@@ -2710,7 +2710,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 4
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    stbcx. 24, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_19
+; CHECK-NEXT:    bne- 0, .LBB2_19
 ; CHECK-NEXT:  # %bb.20: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, uc@toc@l(3)
@@ -2721,7 +2721,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 9
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    sthcx. 24, 0, 9
-; CHECK-NEXT:    bne 0, .LBB2_21
+; CHECK-NEXT:    bne- 0, .LBB2_21
 ; CHECK-NEXT:  # %bb.22: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, ss@toc@l(6)
@@ -2732,7 +2732,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 11
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    sthcx. 24, 0, 11
-; CHECK-NEXT:    bne 0, .LBB2_23
+; CHECK-NEXT:    bne- 0, .LBB2_23
 ; CHECK-NEXT:  # %bb.24: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, us@toc@l(8)
@@ -2743,7 +2743,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 0
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    stwcx. 24, 0, 0
-; CHECK-NEXT:    bne 0, .LBB2_25
+; CHECK-NEXT:    bne- 0, .LBB2_25
 ; CHECK-NEXT:  # %bb.26: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, si@toc@l(10)
@@ -2754,7 +2754,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 29
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    stwcx. 24, 0, 29
-; CHECK-NEXT:    bne 0, .LBB2_27
+; CHECK-NEXT:    bne- 0, .LBB2_27
 ; CHECK-NEXT:  # %bb.28: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, ui@toc@l(12)
@@ -2765,7 +2765,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 27
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    stdcx. 24, 0, 27
-; CHECK-NEXT:    bne 0, .LBB2_29
+; CHECK-NEXT:    bne- 0, .LBB2_29
 ; CHECK-NEXT:  # %bb.30: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, sll@toc@l(30)
@@ -2776,7 +2776,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 26
 ; CHECK-NEXT:    sub 24, 24, 25
 ; CHECK-NEXT:    stdcx. 24, 0, 26
-; CHECK-NEXT:    bne 0, .LBB2_31
+; CHECK-NEXT:    bne- 0, .LBB2_31
 ; CHECK-NEXT:  # %bb.32: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, ull@toc@l(28)
@@ -2787,7 +2787,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 7
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 7
-; CHECK-NEXT:    bne 0, .LBB2_33
+; CHECK-NEXT:    bne- 0, .LBB2_33
 ; CHECK-NEXT:  # %bb.34: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, sc@toc@l(5)
@@ -2798,7 +2798,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 4
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_35
+; CHECK-NEXT:    bne- 0, .LBB2_35
 ; CHECK-NEXT:  # %bb.36: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, uc@toc@l(3)
@@ -2809,7 +2809,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 9
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    sthcx. 24, 0, 9
-; CHECK-NEXT:    bne 0, .LBB2_37
+; CHECK-NEXT:    bne- 0, .LBB2_37
 ; CHECK-NEXT:  # %bb.38: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, ss@toc@l(6)
@@ -2820,7 +2820,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 11
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    sthcx. 24, 0, 11
-; CHECK-NEXT:    bne 0, .LBB2_39
+; CHECK-NEXT:    bne- 0, .LBB2_39
 ; CHECK-NEXT:  # %bb.40: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, us@toc@l(8)
@@ -2831,7 +2831,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 0
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    stwcx. 24, 0, 0
-; CHECK-NEXT:    bne 0, .LBB2_41
+; CHECK-NEXT:    bne- 0, .LBB2_41
 ; CHECK-NEXT:  # %bb.42: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, si@toc@l(10)
@@ -2842,7 +2842,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 29
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    stwcx. 24, 0, 29
-; CHECK-NEXT:    bne 0, .LBB2_43
+; CHECK-NEXT:    bne- 0, .LBB2_43
 ; CHECK-NEXT:  # %bb.44: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, ui@toc@l(12)
@@ -2853,7 +2853,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 27
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 27
-; CHECK-NEXT:    bne 0, .LBB2_45
+; CHECK-NEXT:    bne- 0, .LBB2_45
 ; CHECK-NEXT:  # %bb.46: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, sll@toc@l(30)
@@ -2864,7 +2864,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 26
 ; CHECK-NEXT:    or 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 26
-; CHECK-NEXT:    bne 0, .LBB2_47
+; CHECK-NEXT:    bne- 0, .LBB2_47
 ; CHECK-NEXT:  # %bb.48: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, ull@toc@l(28)
@@ -2875,7 +2875,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 7
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 7
-; CHECK-NEXT:    bne 0, .LBB2_49
+; CHECK-NEXT:    bne- 0, .LBB2_49
 ; CHECK-NEXT:  # %bb.50: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, sc@toc@l(5)
@@ -2886,7 +2886,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 4
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_51
+; CHECK-NEXT:    bne- 0, .LBB2_51
 ; CHECK-NEXT:  # %bb.52: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, uc@toc@l(3)
@@ -2897,7 +2897,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 9
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    sthcx. 24, 0, 9
-; CHECK-NEXT:    bne 0, .LBB2_53
+; CHECK-NEXT:    bne- 0, .LBB2_53
 ; CHECK-NEXT:  # %bb.54: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, ss@toc@l(6)
@@ -2908,7 +2908,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 11
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    sthcx. 24, 0, 11
-; CHECK-NEXT:    bne 0, .LBB2_55
+; CHECK-NEXT:    bne- 0, .LBB2_55
 ; CHECK-NEXT:  # %bb.56: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, us@toc@l(8)
@@ -2919,7 +2919,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 0
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    stwcx. 24, 0, 0
-; CHECK-NEXT:    bne 0, .LBB2_57
+; CHECK-NEXT:    bne- 0, .LBB2_57
 ; CHECK-NEXT:  # %bb.58: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, si@toc@l(10)
@@ -2930,7 +2930,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 29
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    stwcx. 24, 0, 29
-; CHECK-NEXT:    bne 0, .LBB2_59
+; CHECK-NEXT:    bne- 0, .LBB2_59
 ; CHECK-NEXT:  # %bb.60: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, ui@toc@l(12)
@@ -2941,7 +2941,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 27
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 27
-; CHECK-NEXT:    bne 0, .LBB2_61
+; CHECK-NEXT:    bne- 0, .LBB2_61
 ; CHECK-NEXT:  # %bb.62: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, sll@toc@l(30)
@@ -2952,7 +2952,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 26
 ; CHECK-NEXT:    xor 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 26
-; CHECK-NEXT:    bne 0, .LBB2_63
+; CHECK-NEXT:    bne- 0, .LBB2_63
 ; CHECK-NEXT:  # %bb.64: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, ull@toc@l(28)
@@ -2963,7 +2963,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 7
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 7
-; CHECK-NEXT:    bne 0, .LBB2_65
+; CHECK-NEXT:    bne- 0, .LBB2_65
 ; CHECK-NEXT:  # %bb.66: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, sc@toc@l(5)
@@ -2974,7 +2974,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 4
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_67
+; CHECK-NEXT:    bne- 0, .LBB2_67
 ; CHECK-NEXT:  # %bb.68: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, uc@toc@l(3)
@@ -2985,7 +2985,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 9
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    sthcx. 24, 0, 9
-; CHECK-NEXT:    bne 0, .LBB2_69
+; CHECK-NEXT:    bne- 0, .LBB2_69
 ; CHECK-NEXT:  # %bb.70: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, ss@toc@l(6)
@@ -2996,7 +2996,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 24, 0, 11
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    sthcx. 24, 0, 11
-; CHECK-NEXT:    bne 0, .LBB2_71
+; CHECK-NEXT:    bne- 0, .LBB2_71
 ; CHECK-NEXT:  # %bb.72: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 24, us@toc@l(8)
@@ -3007,7 +3007,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 0
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    stwcx. 24, 0, 0
-; CHECK-NEXT:    bne 0, .LBB2_73
+; CHECK-NEXT:    bne- 0, .LBB2_73
 ; CHECK-NEXT:  # %bb.74: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, si@toc@l(10)
@@ -3018,7 +3018,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 24, 0, 29
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    stwcx. 24, 0, 29
-; CHECK-NEXT:    bne 0, .LBB2_75
+; CHECK-NEXT:    bne- 0, .LBB2_75
 ; CHECK-NEXT:  # %bb.76: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 24, ui@toc@l(12)
@@ -3029,7 +3029,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 27
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 27
-; CHECK-NEXT:    bne 0, .LBB2_77
+; CHECK-NEXT:    bne- 0, .LBB2_77
 ; CHECK-NEXT:  # %bb.78: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, sll@toc@l(30)
@@ -3040,7 +3040,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 24, 0, 26
 ; CHECK-NEXT:    nand 24, 25, 24
 ; CHECK-NEXT:    stdcx. 24, 0, 26
-; CHECK-NEXT:    bne 0, .LBB2_79
+; CHECK-NEXT:    bne- 0, .LBB2_79
 ; CHECK-NEXT:  # %bb.80: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 24, ull@toc@l(28)
@@ -3085,7 +3085,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 24, 0, 7
 ; CHECK-NEXT:    and 24, 25, 24
 ; CHECK-NEXT:    stbcx. 24, 0, 7
-; CHECK-NEXT:    bne 0, .LBB2_85
+; CHECK-NEXT:    bne- 0, .LBB2_85
 ; CHECK-NEXT:  # %bb.86: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 24, sc@toc@l(5)
@@ -3096,7 +3096,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lbarx 5, 0, 4
 ; CHECK-NEXT:    and 5, 7, 5
 ; CHECK-NEXT:    stbcx. 5, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_87
+; CHECK-NEXT:    bne- 0, .LBB2_87
 ; CHECK-NEXT:  # %bb.88: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 5, uc@toc@l(3)
@@ -3106,7 +3106,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 4, 0, 9
 ; CHECK-NEXT:    and 4, 5, 4
 ; CHECK-NEXT:    sthcx. 4, 0, 9
-; CHECK-NEXT:    bne 0, .LBB2_89
+; CHECK-NEXT:    bne- 0, .LBB2_89
 ; CHECK-NEXT:  # %bb.90: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 4, ss@toc@l(6)
@@ -3117,7 +3117,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lharx 5, 0, 11
 ; CHECK-NEXT:    and 5, 4, 5
 ; CHECK-NEXT:    sthcx. 5, 0, 11
-; CHECK-NEXT:    bne 0, .LBB2_91
+; CHECK-NEXT:    bne- 0, .LBB2_91
 ; CHECK-NEXT:  # %bb.92: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 5, us@toc@l(8)
@@ -3128,7 +3128,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 5, 0, 0
 ; CHECK-NEXT:    and 5, 4, 5
 ; CHECK-NEXT:    stwcx. 5, 0, 0
-; CHECK-NEXT:    bne 0, .LBB2_93
+; CHECK-NEXT:    bne- 0, .LBB2_93
 ; CHECK-NEXT:  # %bb.94: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 5, si@toc@l(10)
@@ -3139,7 +3139,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    lwarx 5, 0, 29
 ; CHECK-NEXT:    and 5, 4, 5
 ; CHECK-NEXT:    stwcx. 5, 0, 29
-; CHECK-NEXT:    bne 0, .LBB2_95
+; CHECK-NEXT:    bne- 0, .LBB2_95
 ; CHECK-NEXT:  # %bb.96: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 5, ui@toc@l(12)
@@ -3150,7 +3150,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 5, 0, 27
 ; CHECK-NEXT:    and 5, 4, 5
 ; CHECK-NEXT:    stdcx. 5, 0, 27
-; CHECK-NEXT:    bne 0, .LBB2_97
+; CHECK-NEXT:    bne- 0, .LBB2_97
 ; CHECK-NEXT:  # %bb.98: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 5, sll@toc@l(30)
@@ -3161,7 +3161,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; CHECK-NEXT:    ldarx 4, 0, 26
 ; CHECK-NEXT:    and 4, 3, 4
 ; CHECK-NEXT:    stdcx. 4, 0, 26
-; CHECK-NEXT:    bne 0, .LBB2_99
+; CHECK-NEXT:    bne- 0, .LBB2_99
 ; CHECK-NEXT:  # %bb.100: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 4, ull@toc@l(28)
@@ -3225,7 +3225,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 22
-; AIX32-NEXT:    bne 0, L..BB2_1
+; AIX32-NEXT:    bne- 0, L..BB2_1
 ; AIX32-NEXT:  # %bb.2: # %entry
 ; AIX32-NEXT:    srw 4, 6, 24
 ; AIX32-NEXT:    lwsync
@@ -3248,7 +3248,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 19
-; AIX32-NEXT:    bne 0, L..BB2_3
+; AIX32-NEXT:    bne- 0, L..BB2_3
 ; AIX32-NEXT:  # %bb.4: # %entry
 ; AIX32-NEXT:    srw 4, 6, 21
 ; AIX32-NEXT:    lwz 23, L..C2(2) # @ss
@@ -3273,7 +3273,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 16
-; AIX32-NEXT:    bne 0, L..BB2_5
+; AIX32-NEXT:    bne- 0, L..BB2_5
 ; AIX32-NEXT:  # %bb.6: # %entry
 ; AIX32-NEXT:    srw 4, 6, 18
 ; AIX32-NEXT:    lwz 20, L..C3(2) # @us
@@ -3298,7 +3298,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 14
-; AIX32-NEXT:    bne 0, L..BB2_7
+; AIX32-NEXT:    bne- 0, L..BB2_7
 ; AIX32-NEXT:  # %bb.8: # %entry
 ; AIX32-NEXT:    srw 4, 6, 15
 ; AIX32-NEXT:    lwsync
@@ -3313,7 +3313,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 13
 ; AIX32-NEXT:    add 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 13
-; AIX32-NEXT:    bne 0, L..BB2_9
+; AIX32-NEXT:    bne- 0, L..BB2_9
 ; AIX32-NEXT:  # %bb.10: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(13)
@@ -3325,7 +3325,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    add 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB2_11
+; AIX32-NEXT:    bne- 0, L..BB2_11
 ; AIX32-NEXT:  # %bb.12: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
@@ -3367,7 +3367,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 22
-; AIX32-NEXT:    bne 0, L..BB2_13
+; AIX32-NEXT:    bne- 0, L..BB2_13
 ; AIX32-NEXT:  # %bb.14: # %entry
 ; AIX32-NEXT:    srw 4, 6, 24
 ; AIX32-NEXT:    lwsync
@@ -3387,7 +3387,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 19
-; AIX32-NEXT:    bne 0, L..BB2_15
+; AIX32-NEXT:    bne- 0, L..BB2_15
 ; AIX32-NEXT:  # %bb.16: # %entry
 ; AIX32-NEXT:    srw 4, 6, 21
 ; AIX32-NEXT:    li 5, 0
@@ -3408,7 +3408,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 16
-; AIX32-NEXT:    bne 0, L..BB2_17
+; AIX32-NEXT:    bne- 0, L..BB2_17
 ; AIX32-NEXT:  # %bb.18: # %entry
 ; AIX32-NEXT:    srw 4, 6, 18
 ; AIX32-NEXT:    lwsync
@@ -3429,7 +3429,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 14
-; AIX32-NEXT:    bne 0, L..BB2_19
+; AIX32-NEXT:    bne- 0, L..BB2_19
 ; AIX32-NEXT:  # %bb.20: # %entry
 ; AIX32-NEXT:    srw 4, 6, 15
 ; AIX32-NEXT:    lwsync
@@ -3443,7 +3443,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 13
 ; AIX32-NEXT:    sub 4, 4, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 13
-; AIX32-NEXT:    bne 0, L..BB2_21
+; AIX32-NEXT:    bne- 0, L..BB2_21
 ; AIX32-NEXT:  # %bb.22: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(13)
@@ -3454,7 +3454,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    sub 4, 4, 3
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB2_23
+; AIX32-NEXT:    bne- 0, L..BB2_23
 ; AIX32-NEXT:  # %bb.24: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(25)
@@ -3493,7 +3493,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 22
-; AIX32-NEXT:    bne 0, L..BB2_25
+; AIX32-NEXT:    bne- 0, L..BB2_25
 ; AIX32-NEXT:  # %bb.26: # %entry
 ; AIX32-NEXT:    srw 4, 6, 24
 ; AIX32-NEXT:    lwsync
@@ -3513,7 +3513,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 19
-; AIX32-NEXT:    bne 0, L..BB2_27
+; AIX32-NEXT:    bne- 0, L..BB2_27
 ; AIX32-NEXT:  # %bb.28: # %entry
 ; AIX32-NEXT:    srw 4, 6, 21
 ; AIX32-NEXT:    li 5, 0
@@ -3534,7 +3534,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 16
-; AIX32-NEXT:    bne 0, L..BB2_29
+; AIX32-NEXT:    bne- 0, L..BB2_29
 ; AIX32-NEXT:  # %bb.30: # %entry
 ; AIX32-NEXT:    srw 4, 6, 18
 ; AIX32-NEXT:    lwsync
@@ -3555,7 +3555,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 14
-; AIX32-NEXT:    bne 0, L..BB2_31
+; AIX32-NEXT:    bne- 0, L..BB2_31
 ; AIX32-NEXT:  # %bb.32: # %entry
 ; AIX32-NEXT:    srw 4, 6, 15
 ; AIX32-NEXT:    lwsync
@@ -3569,7 +3569,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 13
 ; AIX32-NEXT:    or 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 13
-; AIX32-NEXT:    bne 0, L..BB2_33
+; AIX32-NEXT:    bne- 0, L..BB2_33
 ; AIX32-NEXT:  # %bb.34: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(13)
@@ -3580,7 +3580,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    or 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB2_35
+; AIX32-NEXT:    bne- 0, L..BB2_35
 ; AIX32-NEXT:  # %bb.36: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(25)
@@ -3617,7 +3617,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 22
-; AIX32-NEXT:    bne 0, L..BB2_37
+; AIX32-NEXT:    bne- 0, L..BB2_37
 ; AIX32-NEXT:  # %bb.38: # %entry
 ; AIX32-NEXT:    srw 4, 6, 24
 ; AIX32-NEXT:    lwsync
@@ -3637,7 +3637,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 19
-; AIX32-NEXT:    bne 0, L..BB2_39
+; AIX32-NEXT:    bne- 0, L..BB2_39
 ; AIX32-NEXT:  # %bb.40: # %entry
 ; AIX32-NEXT:    srw 4, 6, 21
 ; AIX32-NEXT:    li 5, 0
@@ -3658,7 +3658,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 16
-; AIX32-NEXT:    bne 0, L..BB2_41
+; AIX32-NEXT:    bne- 0, L..BB2_41
 ; AIX32-NEXT:  # %bb.42: # %entry
 ; AIX32-NEXT:    srw 4, 6, 18
 ; AIX32-NEXT:    lwsync
@@ -3679,7 +3679,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 14
-; AIX32-NEXT:    bne 0, L..BB2_43
+; AIX32-NEXT:    bne- 0, L..BB2_43
 ; AIX32-NEXT:  # %bb.44: # %entry
 ; AIX32-NEXT:    srw 4, 6, 15
 ; AIX32-NEXT:    lwsync
@@ -3693,7 +3693,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 13
 ; AIX32-NEXT:    xor 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 13
-; AIX32-NEXT:    bne 0, L..BB2_45
+; AIX32-NEXT:    bne- 0, L..BB2_45
 ; AIX32-NEXT:  # %bb.46: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(13)
@@ -3704,7 +3704,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    xor 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB2_47
+; AIX32-NEXT:    bne- 0, L..BB2_47
 ; AIX32-NEXT:  # %bb.48: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(25)
@@ -3741,7 +3741,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 22
-; AIX32-NEXT:    bne 0, L..BB2_49
+; AIX32-NEXT:    bne- 0, L..BB2_49
 ; AIX32-NEXT:  # %bb.50: # %entry
 ; AIX32-NEXT:    srw 4, 6, 24
 ; AIX32-NEXT:    lwsync
@@ -3761,7 +3761,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 19
-; AIX32-NEXT:    bne 0, L..BB2_51
+; AIX32-NEXT:    bne- 0, L..BB2_51
 ; AIX32-NEXT:  # %bb.52: # %entry
 ; AIX32-NEXT:    srw 4, 6, 21
 ; AIX32-NEXT:    li 5, 0
@@ -3782,7 +3782,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 16
-; AIX32-NEXT:    bne 0, L..BB2_53
+; AIX32-NEXT:    bne- 0, L..BB2_53
 ; AIX32-NEXT:  # %bb.54: # %entry
 ; AIX32-NEXT:    srw 4, 6, 18
 ; AIX32-NEXT:    lwsync
@@ -3803,7 +3803,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 14
-; AIX32-NEXT:    bne 0, L..BB2_55
+; AIX32-NEXT:    bne- 0, L..BB2_55
 ; AIX32-NEXT:  # %bb.56: # %entry
 ; AIX32-NEXT:    srw 4, 6, 15
 ; AIX32-NEXT:    lwsync
@@ -3817,7 +3817,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 13
 ; AIX32-NEXT:    nand 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 13
-; AIX32-NEXT:    bne 0, L..BB2_57
+; AIX32-NEXT:    bne- 0, L..BB2_57
 ; AIX32-NEXT:  # %bb.58: # %entry
 ; AIX32-NEXT:    stw 23, 56(1) # 4-byte Folded Spill
 ; AIX32-NEXT:    stw 27, 60(1) # 4-byte Folded Spill
@@ -3830,7 +3830,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    nand 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB2_59
+; AIX32-NEXT:    bne- 0, L..BB2_59
 ; AIX32-NEXT:  # %bb.60: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(25)
@@ -3951,7 +3951,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 22
-; AIX32-NEXT:    bne 0, L..BB2_65
+; AIX32-NEXT:    bne- 0, L..BB2_65
 ; AIX32-NEXT:  # %bb.66: # %atomicrmw.end
 ; AIX32-NEXT:    srw 4, 6, 24
 ; AIX32-NEXT:    lwsync
@@ -3973,7 +3973,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 19
-; AIX32-NEXT:    bne 0, L..BB2_67
+; AIX32-NEXT:    bne- 0, L..BB2_67
 ; AIX32-NEXT:  # %bb.68: # %atomicrmw.end
 ; AIX32-NEXT:    srw 4, 6, 21
 ; AIX32-NEXT:    li 5, 0
@@ -3993,7 +3993,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 16
-; AIX32-NEXT:    bne 0, L..BB2_69
+; AIX32-NEXT:    bne- 0, L..BB2_69
 ; AIX32-NEXT:  # %bb.70: # %atomicrmw.end
 ; AIX32-NEXT:    srw 4, 6, 18
 ; AIX32-NEXT:    lwsync
@@ -4014,7 +4014,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    and 7, 7, 5
 ; AIX32-NEXT:    or 7, 7, 8
 ; AIX32-NEXT:    stwcx. 7, 0, 14
-; AIX32-NEXT:    bne 0, L..BB2_71
+; AIX32-NEXT:    bne- 0, L..BB2_71
 ; AIX32-NEXT:  # %bb.72: # %atomicrmw.end
 ; AIX32-NEXT:    srw 4, 6, 15
 ; AIX32-NEXT:    lwsync
@@ -4028,7 +4028,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 13
 ; AIX32-NEXT:    and 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 13
-; AIX32-NEXT:    bne 0, L..BB2_73
+; AIX32-NEXT:    bne- 0, L..BB2_73
 ; AIX32-NEXT:  # %bb.74: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(13)
@@ -4039,7 +4039,7 @@ define dso_local void @test_op_and_fetch() local_unnamed_addr #0 {
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    and 4, 3, 4
 ; AIX32-NEXT:    stwcx. 4, 0, 25
-; AIX32-NEXT:    bne 0, L..BB2_75
+; AIX32-NEXT:    bne- 0, L..BB2_75
 ; AIX32-NEXT:  # %bb.76: # %atomicrmw.end
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(25)
@@ -5371,7 +5371,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lbarx 5, 0, 4
 ; CHECK-NEXT:    stbcx. 7, 0, 4
-; CHECK-NEXT:    bne 0, .LBB4_1
+; CHECK-NEXT:    bne- 0, .LBB4_1
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    addis 4, 2, uc@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -5382,7 +5382,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lbarx 5, 0, 6
 ; CHECK-NEXT:    stbcx. 7, 0, 6
-; CHECK-NEXT:    bne 0, .LBB4_3
+; CHECK-NEXT:    bne- 0, .LBB4_3
 ; CHECK-NEXT:  # %bb.4: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stb 5, uc@toc@l(4)
@@ -5393,7 +5393,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lharx 6, 0, 8
 ; CHECK-NEXT:    sthcx. 7, 0, 8
-; CHECK-NEXT:    bne 0, .LBB4_5
+; CHECK-NEXT:    bne- 0, .LBB4_5
 ; CHECK-NEXT:  # %bb.6: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 6, ss@toc@l(5)
@@ -5404,7 +5404,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lharx 8, 0, 9
 ; CHECK-NEXT:    sthcx. 7, 0, 9
-; CHECK-NEXT:    bne 0, .LBB4_7
+; CHECK-NEXT:    bne- 0, .LBB4_7
 ; CHECK-NEXT:  # %bb.8: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    sth 8, us@toc@l(6)
@@ -5415,7 +5415,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lwarx 9, 0, 10
 ; CHECK-NEXT:    stwcx. 7, 0, 10
-; CHECK-NEXT:    bne 0, .LBB4_9
+; CHECK-NEXT:    bne- 0, .LBB4_9
 ; CHECK-NEXT:  # %bb.10: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 9, si@toc@l(8)
@@ -5426,7 +5426,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lwarx 10, 0, 11
 ; CHECK-NEXT:    stwcx. 7, 0, 11
-; CHECK-NEXT:    bne 0, .LBB4_11
+; CHECK-NEXT:    bne- 0, .LBB4_11
 ; CHECK-NEXT:  # %bb.12: # %entry
 ; CHECK-NEXT:    addis 7, 2, sll@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -5438,7 +5438,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    ldarx 12, 0, 10
 ; CHECK-NEXT:    stdcx. 11, 0, 10
-; CHECK-NEXT:    bne 0, .LBB4_13
+; CHECK-NEXT:    bne- 0, .LBB4_13
 ; CHECK-NEXT:  # %bb.14: # %entry
 ; CHECK-NEXT:    addis 10, 2, ull@toc@ha
 ; CHECK-NEXT:    lwsync
@@ -5449,7 +5449,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    ldarx 12, 0, 0
 ; CHECK-NEXT:    stdcx. 11, 0, 0
-; CHECK-NEXT:    bne 0, .LBB4_15
+; CHECK-NEXT:    bne- 0, .LBB4_15
 ; CHECK-NEXT:  # %bb.16: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    std 12, ull@toc@l(10)
@@ -5504,7 +5504,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; AIX32-NEXT:    andc 9, 8, 6
 ; AIX32-NEXT:    or 9, 7, 9
 ; AIX32-NEXT:    stwcx. 9, 0, 5
-; AIX32-NEXT:    bne 0, L..BB4_1
+; AIX32-NEXT:    bne- 0, L..BB4_1
 ; AIX32-NEXT:  # %bb.2: # %entry
 ; AIX32-NEXT:    srw 4, 8, 4
 ; AIX32-NEXT:    lwz 28, L..C1(2) # @uc
@@ -5525,7 +5525,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; AIX32-NEXT:    andc 9, 8, 6
 ; AIX32-NEXT:    or 9, 7, 9
 ; AIX32-NEXT:    stwcx. 9, 0, 5
-; AIX32-NEXT:    bne 0, L..BB4_3
+; AIX32-NEXT:    bne- 0, L..BB4_3
 ; AIX32-NEXT:  # %bb.4: # %entry
 ; AIX32-NEXT:    srw 4, 8, 4
 ; AIX32-NEXT:    lwz 27, L..C2(2) # @ss
@@ -5547,7 +5547,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; AIX32-NEXT:    andc 9, 8, 6
 ; AIX32-NEXT:    or 9, 7, 9
 ; AIX32-NEXT:    stwcx. 9, 0, 5
-; AIX32-NEXT:    bne 0, L..BB4_5
+; AIX32-NEXT:    bne- 0, L..BB4_5
 ; AIX32-NEXT:  # %bb.6: # %entry
 ; AIX32-NEXT:    srw 4, 8, 4
 ; AIX32-NEXT:    lwz 26, L..C3(2) # @us
@@ -5569,7 +5569,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; AIX32-NEXT:    andc 9, 8, 6
 ; AIX32-NEXT:    or 9, 7, 9
 ; AIX32-NEXT:    stwcx. 9, 0, 5
-; AIX32-NEXT:    bne 0, L..BB4_7
+; AIX32-NEXT:    bne- 0, L..BB4_7
 ; AIX32-NEXT:  # %bb.8: # %entry
 ; AIX32-NEXT:    srw 4, 8, 4
 ; AIX32-NEXT:    lwsync
@@ -5581,7 +5581,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 4, 0, 25
 ; AIX32-NEXT:    stwcx. 3, 0, 25
-; AIX32-NEXT:    bne 0, L..BB4_9
+; AIX32-NEXT:    bne- 0, L..BB4_9
 ; AIX32-NEXT:  # %bb.10: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 4, 0(25)
@@ -5591,7 +5591,7 @@ define dso_local void @test_lock() local_unnamed_addr #0 {
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    lwarx 4, 0, 24
 ; AIX32-NEXT:    stwcx. 3, 0, 24
-; AIX32-NEXT:    bne 0, L..BB4_11
+; AIX32-NEXT:    bne- 0, L..BB4_11
 ; AIX32-NEXT:  # %bb.12: # %entry
 ; AIX32-NEXT:    lwz 31, L..C6(2) # @sll
 ; AIX32-NEXT:    lwsync
@@ -5695,7 +5695,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 3, 0, 6
-; CHECK-NEXT:    bne 0, .LBB5_1
+; CHECK-NEXT:    bne- 0, .LBB5_1
 ; CHECK-NEXT:  .LBB5_3: # %entry
 ; CHECK-NEXT:    stw 5, ui@toc@l(4)
 ; CHECK-NEXT:    addis 5, 2, si@toc@ha
@@ -5709,7 +5709,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; CHECK-NEXT:  # %bb.5: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 3, 0, 7
-; CHECK-NEXT:    bne 0, .LBB5_4
+; CHECK-NEXT:    bne- 0, .LBB5_4
 ; CHECK-NEXT:  .LBB5_6: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 8, si@toc@l(5)
@@ -5721,7 +5721,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; CHECK-NEXT:  # %bb.8: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 3, 0, 6
-; CHECK-NEXT:    bne 0, .LBB5_7
+; CHECK-NEXT:    bne- 0, .LBB5_7
 ; CHECK-NEXT:  .LBB5_9: # %entry
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    stw 8, ui@toc@l(4)
@@ -5734,7 +5734,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; CHECK-NEXT:  # %bb.11: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 3, 0, 7
-; CHECK-NEXT:    bne 0, .LBB5_10
+; CHECK-NEXT:    bne- 0, .LBB5_10
 ; CHECK-NEXT:  .LBB5_12: # %entry
 ; CHECK-NEXT:    stw 4, si@toc@l(5)
 ; CHECK-NEXT:    blr
@@ -5751,7 +5751,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; AIX32-NEXT:  # %bb.2: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    stwcx. 3, 0, 4
-; AIX32-NEXT:    bne 0, L..BB5_1
+; AIX32-NEXT:    bne- 0, L..BB5_1
 ; AIX32-NEXT:  L..BB5_3: # %entry
 ; AIX32-NEXT:    stw 5, 0(4)
 ; AIX32-NEXT:    lwz 5, L..C4(2) # @si
@@ -5764,7 +5764,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; AIX32-NEXT:  # %bb.5: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    stwcx. 3, 0, 5
-; AIX32-NEXT:    bne 0, L..BB5_4
+; AIX32-NEXT:    bne- 0, L..BB5_4
 ; AIX32-NEXT:  L..BB5_6: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 6, 0(5)
@@ -5776,7 +5776,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; AIX32-NEXT:  # %bb.8: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    stwcx. 3, 0, 4
-; AIX32-NEXT:    bne 0, L..BB5_7
+; AIX32-NEXT:    bne- 0, L..BB5_7
 ; AIX32-NEXT:  L..BB5_9: # %entry
 ; AIX32-NEXT:    lwsync
 ; AIX32-NEXT:    stw 6, 0(4)
@@ -5789,7 +5789,7 @@ define dso_local void @test_atomic() local_unnamed_addr #0 {
 ; AIX32-NEXT:  # %bb.11: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    stwcx. 3, 0, 5
-; AIX32-NEXT:    bne 0, L..BB5_10
+; AIX32-NEXT:    bne- 0, L..BB5_10
 ; AIX32-NEXT:  L..BB5_12: # %entry
 ; AIX32-NEXT:    stw 4, 0(5)
 ; AIX32-NEXT:    blr
@@ -5870,7 +5870,7 @@ define dso_local i64 @atommax8(ptr nocapture noundef %ptr, i64 noundef %val) loc
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stdcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB7_1
+; CHECK-NEXT:    bne- 0, .LBB7_1
 ; CHECK-NEXT:  .LBB7_3: # %entry
 ; CHECK-NEXT:    li 3, 55
 ; CHECK-NEXT:    li 4, 66
@@ -5954,7 +5954,7 @@ define dso_local signext i32 @atommax4(ptr nocapture noundef %ptr, i32 noundef s
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB8_1
+; CHECK-NEXT:    bne- 0, .LBB8_1
 ; CHECK-NEXT:  .LBB8_3: # %entry
 ; CHECK-NEXT:    li 3, 55
 ; CHECK-NEXT:    li 4, 66
@@ -5973,7 +5973,7 @@ define dso_local signext i32 @atommax4(ptr nocapture noundef %ptr, i32 noundef s
 ; AIX32-NEXT:  # %bb.2: # %entry
 ; AIX32-NEXT:    #
 ; AIX32-NEXT:    stwcx. 4, 0, 3
-; AIX32-NEXT:    bne 0, L..BB8_1
+; AIX32-NEXT:    bne- 0, L..BB8_1
 ; AIX32-NEXT:  L..BB8_3: # %entry
 ; AIX32-NEXT:    li 3, 55
 ; AIX32-NEXT:    li 4, 66
@@ -6000,7 +6000,7 @@ define dso_local signext i16 @atommax2(ptr nocapture noundef %ptr, i16 noundef s
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB9_1
+; CHECK-NEXT:    bne- 0, .LBB9_1
 ; CHECK-NEXT:  .LBB9_3: # %entry
 ; CHECK-NEXT:    li 3, 55
 ; CHECK-NEXT:    li 4, 66
@@ -6033,7 +6033,7 @@ define dso_local signext i16 @atommax2(ptr nocapture noundef %ptr, i16 noundef s
 ; AIX32-NEXT:    andc 10, 9, 7
 ; AIX32-NEXT:    or 10, 8, 10
 ; AIX32-NEXT:    stwcx. 10, 0, 3
-; AIX32-NEXT:    bne 0, L..BB9_1
+; AIX32-NEXT:    bne- 0, L..BB9_1
 ; AIX32-NEXT:  L..BB9_3: # %entry
 ; AIX32-NEXT:    srw 3, 9, 6
 ; AIX32-NEXT:    lwsync
@@ -6063,7 +6063,7 @@ define dso_local zeroext i8 @atommax1(ptr nocapture noundef %ptr, i8 noundef zer
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stbcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB10_1
+; CHECK-NEXT:    bne- 0, .LBB10_1
 ; CHECK-NEXT:  .LBB10_3: # %entry
 ; CHECK-NEXT:    li 3, 55
 ; CHECK-NEXT:    li 4, 66
@@ -6092,7 +6092,7 @@ define dso_local zeroext i8 @atommax1(ptr nocapture noundef %ptr, i8 noundef zer
 ; AIX32-NEXT:    andc 10, 9, 7
 ; AIX32-NEXT:    or 10, 8, 10
 ; AIX32-NEXT:    stwcx. 10, 0, 3
-; AIX32-NEXT:    bne 0, L..BB10_1
+; AIX32-NEXT:    bne- 0, L..BB10_1
 ; AIX32-NEXT:  L..BB10_3: # %entry
 ; AIX32-NEXT:    srw 3, 9, 5
 ; AIX32-NEXT:    lwsync

--- a/llvm/test/CodeGen/PowerPC/atomic-minmax.ll
+++ b/llvm/test/CodeGen/PowerPC/atomic-minmax.ll
@@ -14,7 +14,7 @@ define void @a32min(ptr nocapture dereferenceable(4) %minimum, i32 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB0_1
+; CHECK-NEXT:    bne- 0, .LBB0_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -34,7 +34,7 @@ define void @a32max(ptr nocapture dereferenceable(4) %minimum, i32 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB1_1
+; CHECK-NEXT:    bne- 0, .LBB1_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -54,7 +54,7 @@ define void @a32umin(ptr nocapture dereferenceable(4) %minimum, i32 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB2_1
+; CHECK-NEXT:    bne- 0, .LBB2_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -74,7 +74,7 @@ define void @a32umax(ptr nocapture dereferenceable(4) %minimum, i32 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB3_1
+; CHECK-NEXT:    bne- 0, .LBB3_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -96,7 +96,7 @@ define void @a16min(ptr nocapture dereferenceable(4) %minimum, i16 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB4_1
+; CHECK-NEXT:    bne- 0, .LBB4_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -118,7 +118,7 @@ define void @a16max(ptr nocapture dereferenceable(4) %minimum, i16 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB5_1
+; CHECK-NEXT:    bne- 0, .LBB5_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -138,7 +138,7 @@ define void @a16umin(ptr nocapture dereferenceable(4) %minimum, i16 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB6_1
+; CHECK-NEXT:    bne- 0, .LBB6_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -158,7 +158,7 @@ define void @a16umax(ptr nocapture dereferenceable(4) %minimum, i16 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB7_1
+; CHECK-NEXT:    bne- 0, .LBB7_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -180,7 +180,7 @@ define void @a8min(ptr nocapture dereferenceable(4) %minimum, i8 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stbcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB8_1
+; CHECK-NEXT:    bne- 0, .LBB8_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -202,7 +202,7 @@ define void @a8max(ptr nocapture dereferenceable(4) %minimum, i8 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stbcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB9_1
+; CHECK-NEXT:    bne- 0, .LBB9_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -222,7 +222,7 @@ define void @a8umin(ptr nocapture dereferenceable(4) %minimum, i8 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stbcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB10_1
+; CHECK-NEXT:    bne- 0, .LBB10_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -242,7 +242,7 @@ define void @a8umax(ptr nocapture dereferenceable(4) %minimum, i8 %val) #1 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stbcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB11_1
+; CHECK-NEXT:    bne- 0, .LBB11_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -262,7 +262,7 @@ define void @a64min(ptr nocapture dereferenceable(4) %minimum, i64 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stdcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB12_1
+; CHECK-NEXT:    bne- 0, .LBB12_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -282,7 +282,7 @@ define void @a64max(ptr nocapture dereferenceable(4) %minimum, i64 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stdcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB13_1
+; CHECK-NEXT:    bne- 0, .LBB13_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -302,7 +302,7 @@ define void @a64umin(ptr nocapture dereferenceable(4) %minimum, i64 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stdcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB14_1
+; CHECK-NEXT:    bne- 0, .LBB14_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -322,7 +322,7 @@ define void @a64umax(ptr nocapture dereferenceable(4) %minimum, i64 %val) #0 {
 ; CHECK-NEXT:  # %bb.2: # %entry
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stdcx. 4, 0, 3
-; CHECK-NEXT:    bne 0, .LBB15_1
+; CHECK-NEXT:    bne- 0, .LBB15_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -356,7 +356,7 @@ define void @ae16min(ptr nocapture dereferenceable(4) %minimum, i16 %val) #0 {
 ; CHECK-NEXT:    andc 8, 8, 6
 ; CHECK-NEXT:    or 8, 7, 8
 ; CHECK-NEXT:    stwcx. 8, 0, 3
-; CHECK-NEXT:    bne 0, .LBB16_1
+; CHECK-NEXT:    bne- 0, .LBB16_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -390,7 +390,7 @@ define void @ae16max(ptr nocapture dereferenceable(4) %minimum, i16 %val) #0 {
 ; CHECK-NEXT:    andc 8, 8, 6
 ; CHECK-NEXT:    or 8, 7, 8
 ; CHECK-NEXT:    stwcx. 8, 0, 3
-; CHECK-NEXT:    bne 0, .LBB17_1
+; CHECK-NEXT:    bne- 0, .LBB17_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -421,7 +421,7 @@ define void @ae16umin(ptr nocapture dereferenceable(4) %minimum, i16 %val) #0 {
 ; CHECK-NEXT:    andc 7, 7, 5
 ; CHECK-NEXT:    or 7, 6, 7
 ; CHECK-NEXT:    stwcx. 7, 0, 3
-; CHECK-NEXT:    bne 0, .LBB18_1
+; CHECK-NEXT:    bne- 0, .LBB18_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -452,7 +452,7 @@ define void @ae16umax(ptr nocapture dereferenceable(4) %minimum, i16 %val) #0 {
 ; CHECK-NEXT:    andc 7, 7, 5
 ; CHECK-NEXT:    or 7, 6, 7
 ; CHECK-NEXT:    stwcx. 7, 0, 3
-; CHECK-NEXT:    bne 0, .LBB19_1
+; CHECK-NEXT:    bne- 0, .LBB19_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -485,7 +485,7 @@ define void @ae8min(ptr nocapture dereferenceable(4) %minimum, i8 %val) #0 {
 ; CHECK-NEXT:    andc 8, 8, 6
 ; CHECK-NEXT:    or 8, 7, 8
 ; CHECK-NEXT:    stwcx. 8, 0, 3
-; CHECK-NEXT:    bne 0, .LBB20_1
+; CHECK-NEXT:    bne- 0, .LBB20_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -518,7 +518,7 @@ define void @ae8max(ptr nocapture dereferenceable(4) %minimum, i8 %val) #0 {
 ; CHECK-NEXT:    andc 8, 8, 6
 ; CHECK-NEXT:    or 8, 7, 8
 ; CHECK-NEXT:    stwcx. 8, 0, 3
-; CHECK-NEXT:    bne 0, .LBB21_1
+; CHECK-NEXT:    bne- 0, .LBB21_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -548,7 +548,7 @@ define void @ae8umin(ptr nocapture dereferenceable(4) %minimum, i8 %val) #0 {
 ; CHECK-NEXT:    andc 7, 7, 5
 ; CHECK-NEXT:    or 7, 6, 7
 ; CHECK-NEXT:    stwcx. 7, 0, 3
-; CHECK-NEXT:    bne 0, .LBB22_1
+; CHECK-NEXT:    bne- 0, .LBB22_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:
@@ -578,7 +578,7 @@ define void @ae8umax(ptr nocapture dereferenceable(4) %minimum, i8 %val) #0 {
 ; CHECK-NEXT:    andc 7, 7, 5
 ; CHECK-NEXT:    or 7, 6, 7
 ; CHECK-NEXT:    stwcx. 7, 0, 3
-; CHECK-NEXT:    bne 0, .LBB23_1
+; CHECK-NEXT:    bne- 0, .LBB23_1
 ; CHECK-NEXT:  # %bb.3: # %entry
 ; CHECK-NEXT:    blr
 entry:

--- a/llvm/test/CodeGen/PowerPC/atomics-regression.ll
+++ b/llvm/test/CodeGen/PowerPC/atomics-regression.ll
@@ -2291,7 +2291,7 @@ define i8 @test120(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB120_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB120_1
+; PPC64LE-NEXT:    bne- 0, .LBB120_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2306,7 +2306,7 @@ define i8 @test121(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB121_1:
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    stbcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB121_1
+; PPC64LE-NEXT:    bne- 0, .LBB121_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2321,7 +2321,7 @@ define i8 @test122(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB122_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB122_1
+; PPC64LE-NEXT:    bne- 0, .LBB122_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2336,7 +2336,7 @@ define i8 @test123(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB123_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB123_1
+; PPC64LE-NEXT:    bne- 0, .LBB123_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2352,7 +2352,7 @@ define i8 @test124(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB124_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB124_1
+; PPC64LE-NEXT:    bne- 0, .LBB124_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2367,7 +2367,7 @@ define i16 @test125(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB125_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB125_1
+; PPC64LE-NEXT:    bne- 0, .LBB125_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2382,7 +2382,7 @@ define i16 @test126(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB126_1:
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    sthcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB126_1
+; PPC64LE-NEXT:    bne- 0, .LBB126_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2397,7 +2397,7 @@ define i16 @test127(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB127_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB127_1
+; PPC64LE-NEXT:    bne- 0, .LBB127_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2412,7 +2412,7 @@ define i16 @test128(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB128_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB128_1
+; PPC64LE-NEXT:    bne- 0, .LBB128_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2428,7 +2428,7 @@ define i16 @test129(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB129_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB129_1
+; PPC64LE-NEXT:    bne- 0, .LBB129_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2443,7 +2443,7 @@ define i32 @test130(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB130_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB130_1
+; PPC64LE-NEXT:    bne- 0, .LBB130_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2458,7 +2458,7 @@ define i32 @test131(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB131_1:
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB131_1
+; PPC64LE-NEXT:    bne- 0, .LBB131_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2473,7 +2473,7 @@ define i32 @test132(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB132_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB132_1
+; PPC64LE-NEXT:    bne- 0, .LBB132_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2488,7 +2488,7 @@ define i32 @test133(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB133_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB133_1
+; PPC64LE-NEXT:    bne- 0, .LBB133_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2504,7 +2504,7 @@ define i32 @test134(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB134_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB134_1
+; PPC64LE-NEXT:    bne- 0, .LBB134_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2519,7 +2519,7 @@ define i64 @test135(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB135_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB135_1
+; PPC64LE-NEXT:    bne- 0, .LBB135_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2534,7 +2534,7 @@ define i64 @test136(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB136_1:
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB136_1
+; PPC64LE-NEXT:    bne- 0, .LBB136_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2549,7 +2549,7 @@ define i64 @test137(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB137_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB137_1
+; PPC64LE-NEXT:    bne- 0, .LBB137_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2564,7 +2564,7 @@ define i64 @test138(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB138_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB138_1
+; PPC64LE-NEXT:    bne- 0, .LBB138_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2580,7 +2580,7 @@ define i64 @test139(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB139_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB139_1
+; PPC64LE-NEXT:    bne- 0, .LBB139_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2596,7 +2596,7 @@ define i8 @test140(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB140_1
+; PPC64LE-NEXT:    bne- 0, .LBB140_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2612,7 +2612,7 @@ define i8 @test141(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB141_1
+; PPC64LE-NEXT:    bne- 0, .LBB141_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2628,7 +2628,7 @@ define i8 @test142(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB142_1
+; PPC64LE-NEXT:    bne- 0, .LBB142_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2644,7 +2644,7 @@ define i8 @test143(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB143_1
+; PPC64LE-NEXT:    bne- 0, .LBB143_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2661,7 +2661,7 @@ define i8 @test144(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB144_1
+; PPC64LE-NEXT:    bne- 0, .LBB144_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2677,7 +2677,7 @@ define i16 @test145(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB145_1
+; PPC64LE-NEXT:    bne- 0, .LBB145_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2693,7 +2693,7 @@ define i16 @test146(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB146_1
+; PPC64LE-NEXT:    bne- 0, .LBB146_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2709,7 +2709,7 @@ define i16 @test147(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB147_1
+; PPC64LE-NEXT:    bne- 0, .LBB147_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2725,7 +2725,7 @@ define i16 @test148(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB148_1
+; PPC64LE-NEXT:    bne- 0, .LBB148_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2742,7 +2742,7 @@ define i16 @test149(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB149_1
+; PPC64LE-NEXT:    bne- 0, .LBB149_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2758,7 +2758,7 @@ define i32 @test150(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB150_1
+; PPC64LE-NEXT:    bne- 0, .LBB150_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2774,7 +2774,7 @@ define i32 @test151(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB151_1
+; PPC64LE-NEXT:    bne- 0, .LBB151_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2790,7 +2790,7 @@ define i32 @test152(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB152_1
+; PPC64LE-NEXT:    bne- 0, .LBB152_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2806,7 +2806,7 @@ define i32 @test153(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB153_1
+; PPC64LE-NEXT:    bne- 0, .LBB153_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2823,7 +2823,7 @@ define i32 @test154(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB154_1
+; PPC64LE-NEXT:    bne- 0, .LBB154_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2839,7 +2839,7 @@ define i64 @test155(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB155_1
+; PPC64LE-NEXT:    bne- 0, .LBB155_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2855,7 +2855,7 @@ define i64 @test156(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB156_1
+; PPC64LE-NEXT:    bne- 0, .LBB156_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2871,7 +2871,7 @@ define i64 @test157(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB157_1
+; PPC64LE-NEXT:    bne- 0, .LBB157_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2887,7 +2887,7 @@ define i64 @test158(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB158_1
+; PPC64LE-NEXT:    bne- 0, .LBB158_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2904,7 +2904,7 @@ define i64 @test159(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB159_1
+; PPC64LE-NEXT:    bne- 0, .LBB159_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2920,7 +2920,7 @@ define i8 @test160(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB160_1
+; PPC64LE-NEXT:    bne- 0, .LBB160_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2936,7 +2936,7 @@ define i8 @test161(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB161_1
+; PPC64LE-NEXT:    bne- 0, .LBB161_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -2952,7 +2952,7 @@ define i8 @test162(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB162_1
+; PPC64LE-NEXT:    bne- 0, .LBB162_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -2968,7 +2968,7 @@ define i8 @test163(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB163_1
+; PPC64LE-NEXT:    bne- 0, .LBB163_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -2985,7 +2985,7 @@ define i8 @test164(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB164_1
+; PPC64LE-NEXT:    bne- 0, .LBB164_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3001,7 +3001,7 @@ define i16 @test165(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB165_1
+; PPC64LE-NEXT:    bne- 0, .LBB165_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3017,7 +3017,7 @@ define i16 @test166(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB166_1
+; PPC64LE-NEXT:    bne- 0, .LBB166_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3033,7 +3033,7 @@ define i16 @test167(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB167_1
+; PPC64LE-NEXT:    bne- 0, .LBB167_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3049,7 +3049,7 @@ define i16 @test168(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB168_1
+; PPC64LE-NEXT:    bne- 0, .LBB168_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3066,7 +3066,7 @@ define i16 @test169(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB169_1
+; PPC64LE-NEXT:    bne- 0, .LBB169_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3082,7 +3082,7 @@ define i32 @test170(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB170_1
+; PPC64LE-NEXT:    bne- 0, .LBB170_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3098,7 +3098,7 @@ define i32 @test171(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB171_1
+; PPC64LE-NEXT:    bne- 0, .LBB171_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3114,7 +3114,7 @@ define i32 @test172(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB172_1
+; PPC64LE-NEXT:    bne- 0, .LBB172_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3130,7 +3130,7 @@ define i32 @test173(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB173_1
+; PPC64LE-NEXT:    bne- 0, .LBB173_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3147,7 +3147,7 @@ define i32 @test174(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB174_1
+; PPC64LE-NEXT:    bne- 0, .LBB174_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3163,7 +3163,7 @@ define i64 @test175(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB175_1
+; PPC64LE-NEXT:    bne- 0, .LBB175_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3179,7 +3179,7 @@ define i64 @test176(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB176_1
+; PPC64LE-NEXT:    bne- 0, .LBB176_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3195,7 +3195,7 @@ define i64 @test177(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB177_1
+; PPC64LE-NEXT:    bne- 0, .LBB177_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3211,7 +3211,7 @@ define i64 @test178(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB178_1
+; PPC64LE-NEXT:    bne- 0, .LBB178_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3228,7 +3228,7 @@ define i64 @test179(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB179_1
+; PPC64LE-NEXT:    bne- 0, .LBB179_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3244,7 +3244,7 @@ define i8 @test180(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB180_1
+; PPC64LE-NEXT:    bne- 0, .LBB180_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3260,7 +3260,7 @@ define i8 @test181(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB181_1
+; PPC64LE-NEXT:    bne- 0, .LBB181_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3276,7 +3276,7 @@ define i8 @test182(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB182_1
+; PPC64LE-NEXT:    bne- 0, .LBB182_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3292,7 +3292,7 @@ define i8 @test183(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB183_1
+; PPC64LE-NEXT:    bne- 0, .LBB183_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3309,7 +3309,7 @@ define i8 @test184(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB184_1
+; PPC64LE-NEXT:    bne- 0, .LBB184_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3325,7 +3325,7 @@ define i16 @test185(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB185_1
+; PPC64LE-NEXT:    bne- 0, .LBB185_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3341,7 +3341,7 @@ define i16 @test186(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB186_1
+; PPC64LE-NEXT:    bne- 0, .LBB186_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3357,7 +3357,7 @@ define i16 @test187(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB187_1
+; PPC64LE-NEXT:    bne- 0, .LBB187_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3373,7 +3373,7 @@ define i16 @test188(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB188_1
+; PPC64LE-NEXT:    bne- 0, .LBB188_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3390,7 +3390,7 @@ define i16 @test189(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB189_1
+; PPC64LE-NEXT:    bne- 0, .LBB189_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3406,7 +3406,7 @@ define i32 @test190(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB190_1
+; PPC64LE-NEXT:    bne- 0, .LBB190_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3422,7 +3422,7 @@ define i32 @test191(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB191_1
+; PPC64LE-NEXT:    bne- 0, .LBB191_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3438,7 +3438,7 @@ define i32 @test192(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB192_1
+; PPC64LE-NEXT:    bne- 0, .LBB192_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3454,7 +3454,7 @@ define i32 @test193(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB193_1
+; PPC64LE-NEXT:    bne- 0, .LBB193_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3471,7 +3471,7 @@ define i32 @test194(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB194_1
+; PPC64LE-NEXT:    bne- 0, .LBB194_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3487,7 +3487,7 @@ define i64 @test195(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB195_1
+; PPC64LE-NEXT:    bne- 0, .LBB195_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3503,7 +3503,7 @@ define i64 @test196(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB196_1
+; PPC64LE-NEXT:    bne- 0, .LBB196_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3519,7 +3519,7 @@ define i64 @test197(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB197_1
+; PPC64LE-NEXT:    bne- 0, .LBB197_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3535,7 +3535,7 @@ define i64 @test198(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB198_1
+; PPC64LE-NEXT:    bne- 0, .LBB198_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3552,7 +3552,7 @@ define i64 @test199(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB199_1
+; PPC64LE-NEXT:    bne- 0, .LBB199_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3568,7 +3568,7 @@ define i8 @test200(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB200_1
+; PPC64LE-NEXT:    bne- 0, .LBB200_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3584,7 +3584,7 @@ define i8 @test201(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB201_1
+; PPC64LE-NEXT:    bne- 0, .LBB201_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3600,7 +3600,7 @@ define i8 @test202(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB202_1
+; PPC64LE-NEXT:    bne- 0, .LBB202_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3616,7 +3616,7 @@ define i8 @test203(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB203_1
+; PPC64LE-NEXT:    bne- 0, .LBB203_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3633,7 +3633,7 @@ define i8 @test204(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB204_1
+; PPC64LE-NEXT:    bne- 0, .LBB204_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3649,7 +3649,7 @@ define i16 @test205(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB205_1
+; PPC64LE-NEXT:    bne- 0, .LBB205_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3665,7 +3665,7 @@ define i16 @test206(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB206_1
+; PPC64LE-NEXT:    bne- 0, .LBB206_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3681,7 +3681,7 @@ define i16 @test207(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB207_1
+; PPC64LE-NEXT:    bne- 0, .LBB207_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3697,7 +3697,7 @@ define i16 @test208(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB208_1
+; PPC64LE-NEXT:    bne- 0, .LBB208_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3714,7 +3714,7 @@ define i16 @test209(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB209_1
+; PPC64LE-NEXT:    bne- 0, .LBB209_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3730,7 +3730,7 @@ define i32 @test210(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB210_1
+; PPC64LE-NEXT:    bne- 0, .LBB210_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3746,7 +3746,7 @@ define i32 @test211(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB211_1
+; PPC64LE-NEXT:    bne- 0, .LBB211_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3762,7 +3762,7 @@ define i32 @test212(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB212_1
+; PPC64LE-NEXT:    bne- 0, .LBB212_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3778,7 +3778,7 @@ define i32 @test213(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB213_1
+; PPC64LE-NEXT:    bne- 0, .LBB213_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3795,7 +3795,7 @@ define i32 @test214(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB214_1
+; PPC64LE-NEXT:    bne- 0, .LBB214_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3811,7 +3811,7 @@ define i64 @test215(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB215_1
+; PPC64LE-NEXT:    bne- 0, .LBB215_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3827,7 +3827,7 @@ define i64 @test216(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB216_1
+; PPC64LE-NEXT:    bne- 0, .LBB216_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3843,7 +3843,7 @@ define i64 @test217(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB217_1
+; PPC64LE-NEXT:    bne- 0, .LBB217_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3859,7 +3859,7 @@ define i64 @test218(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB218_1
+; PPC64LE-NEXT:    bne- 0, .LBB218_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3876,7 +3876,7 @@ define i64 @test219(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB219_1
+; PPC64LE-NEXT:    bne- 0, .LBB219_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3892,7 +3892,7 @@ define i8 @test220(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB220_1
+; PPC64LE-NEXT:    bne- 0, .LBB220_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3908,7 +3908,7 @@ define i8 @test221(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB221_1
+; PPC64LE-NEXT:    bne- 0, .LBB221_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -3924,7 +3924,7 @@ define i8 @test222(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB222_1
+; PPC64LE-NEXT:    bne- 0, .LBB222_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3940,7 +3940,7 @@ define i8 @test223(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB223_1
+; PPC64LE-NEXT:    bne- 0, .LBB223_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3957,7 +3957,7 @@ define i8 @test224(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB224_1
+; PPC64LE-NEXT:    bne- 0, .LBB224_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -3973,7 +3973,7 @@ define i16 @test225(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB225_1
+; PPC64LE-NEXT:    bne- 0, .LBB225_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -3989,7 +3989,7 @@ define i16 @test226(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB226_1
+; PPC64LE-NEXT:    bne- 0, .LBB226_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4005,7 +4005,7 @@ define i16 @test227(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB227_1
+; PPC64LE-NEXT:    bne- 0, .LBB227_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4021,7 +4021,7 @@ define i16 @test228(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB228_1
+; PPC64LE-NEXT:    bne- 0, .LBB228_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4038,7 +4038,7 @@ define i16 @test229(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB229_1
+; PPC64LE-NEXT:    bne- 0, .LBB229_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4054,7 +4054,7 @@ define i32 @test230(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB230_1
+; PPC64LE-NEXT:    bne- 0, .LBB230_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4070,7 +4070,7 @@ define i32 @test231(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB231_1
+; PPC64LE-NEXT:    bne- 0, .LBB231_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4086,7 +4086,7 @@ define i32 @test232(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB232_1
+; PPC64LE-NEXT:    bne- 0, .LBB232_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4102,7 +4102,7 @@ define i32 @test233(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB233_1
+; PPC64LE-NEXT:    bne- 0, .LBB233_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4119,7 +4119,7 @@ define i32 @test234(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB234_1
+; PPC64LE-NEXT:    bne- 0, .LBB234_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4135,7 +4135,7 @@ define i64 @test235(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB235_1
+; PPC64LE-NEXT:    bne- 0, .LBB235_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4151,7 +4151,7 @@ define i64 @test236(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB236_1
+; PPC64LE-NEXT:    bne- 0, .LBB236_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4167,7 +4167,7 @@ define i64 @test237(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB237_1
+; PPC64LE-NEXT:    bne- 0, .LBB237_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4183,7 +4183,7 @@ define i64 @test238(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB238_1
+; PPC64LE-NEXT:    bne- 0, .LBB238_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4200,7 +4200,7 @@ define i64 @test239(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB239_1
+; PPC64LE-NEXT:    bne- 0, .LBB239_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4216,7 +4216,7 @@ define i8 @test240(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB240_1
+; PPC64LE-NEXT:    bne- 0, .LBB240_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4232,7 +4232,7 @@ define i8 @test241(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB241_1
+; PPC64LE-NEXT:    bne- 0, .LBB241_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4248,7 +4248,7 @@ define i8 @test242(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB242_1
+; PPC64LE-NEXT:    bne- 0, .LBB242_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4264,7 +4264,7 @@ define i8 @test243(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB243_1
+; PPC64LE-NEXT:    bne- 0, .LBB243_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4281,7 +4281,7 @@ define i8 @test244(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB244_1
+; PPC64LE-NEXT:    bne- 0, .LBB244_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4297,7 +4297,7 @@ define i16 @test245(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB245_1
+; PPC64LE-NEXT:    bne- 0, .LBB245_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4313,7 +4313,7 @@ define i16 @test246(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB246_1
+; PPC64LE-NEXT:    bne- 0, .LBB246_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4329,7 +4329,7 @@ define i16 @test247(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB247_1
+; PPC64LE-NEXT:    bne- 0, .LBB247_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4345,7 +4345,7 @@ define i16 @test248(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB248_1
+; PPC64LE-NEXT:    bne- 0, .LBB248_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4362,7 +4362,7 @@ define i16 @test249(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB249_1
+; PPC64LE-NEXT:    bne- 0, .LBB249_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4378,7 +4378,7 @@ define i32 @test250(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB250_1
+; PPC64LE-NEXT:    bne- 0, .LBB250_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4394,7 +4394,7 @@ define i32 @test251(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB251_1
+; PPC64LE-NEXT:    bne- 0, .LBB251_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4410,7 +4410,7 @@ define i32 @test252(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB252_1
+; PPC64LE-NEXT:    bne- 0, .LBB252_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4426,7 +4426,7 @@ define i32 @test253(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB253_1
+; PPC64LE-NEXT:    bne- 0, .LBB253_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4443,7 +4443,7 @@ define i32 @test254(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB254_1
+; PPC64LE-NEXT:    bne- 0, .LBB254_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4459,7 +4459,7 @@ define i64 @test255(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB255_1
+; PPC64LE-NEXT:    bne- 0, .LBB255_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4475,7 +4475,7 @@ define i64 @test256(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB256_1
+; PPC64LE-NEXT:    bne- 0, .LBB256_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4491,7 +4491,7 @@ define i64 @test257(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB257_1
+; PPC64LE-NEXT:    bne- 0, .LBB257_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4507,7 +4507,7 @@ define i64 @test258(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB258_1
+; PPC64LE-NEXT:    bne- 0, .LBB258_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4524,7 +4524,7 @@ define i64 @test259(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB259_1
+; PPC64LE-NEXT:    bne- 0, .LBB259_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4544,7 +4544,7 @@ define i8 @test260(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB260_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB260_1
+; PPC64LE-NEXT:    bne- 0, .LBB260_1
 ; PPC64LE-NEXT:  .LBB260_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -4563,7 +4563,7 @@ define i8 @test261(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB261_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB261_1
+; PPC64LE-NEXT:    bne- 0, .LBB261_1
 ; PPC64LE-NEXT:  .LBB261_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4584,7 +4584,7 @@ define i8 @test262(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB262_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB262_1
+; PPC64LE-NEXT:    bne- 0, .LBB262_1
 ; PPC64LE-NEXT:  .LBB262_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -4604,7 +4604,7 @@ define i8 @test263(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB263_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB263_1
+; PPC64LE-NEXT:    bne- 0, .LBB263_1
 ; PPC64LE-NEXT:  .LBB263_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4625,7 +4625,7 @@ define i8 @test264(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB264_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB264_1
+; PPC64LE-NEXT:    bne- 0, .LBB264_1
 ; PPC64LE-NEXT:  .LBB264_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4645,7 +4645,7 @@ define i16 @test265(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB265_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB265_1
+; PPC64LE-NEXT:    bne- 0, .LBB265_1
 ; PPC64LE-NEXT:  .LBB265_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -4664,7 +4664,7 @@ define i16 @test266(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB266_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB266_1
+; PPC64LE-NEXT:    bne- 0, .LBB266_1
 ; PPC64LE-NEXT:  .LBB266_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4685,7 +4685,7 @@ define i16 @test267(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB267_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB267_1
+; PPC64LE-NEXT:    bne- 0, .LBB267_1
 ; PPC64LE-NEXT:  .LBB267_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -4705,7 +4705,7 @@ define i16 @test268(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB268_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB268_1
+; PPC64LE-NEXT:    bne- 0, .LBB268_1
 ; PPC64LE-NEXT:  .LBB268_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4726,7 +4726,7 @@ define i16 @test269(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB269_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB269_1
+; PPC64LE-NEXT:    bne- 0, .LBB269_1
 ; PPC64LE-NEXT:  .LBB269_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4744,7 +4744,7 @@ define i32 @test270(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB270_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB270_1
+; PPC64LE-NEXT:    bne- 0, .LBB270_1
 ; PPC64LE-NEXT:  .LBB270_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4762,7 +4762,7 @@ define i32 @test271(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB271_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB271_1
+; PPC64LE-NEXT:    bne- 0, .LBB271_1
 ; PPC64LE-NEXT:  .LBB271_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4780,7 +4780,7 @@ define i32 @test272(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB272_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB272_1
+; PPC64LE-NEXT:    bne- 0, .LBB272_1
 ; PPC64LE-NEXT:  .LBB272_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4798,7 +4798,7 @@ define i32 @test273(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB273_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB273_1
+; PPC64LE-NEXT:    bne- 0, .LBB273_1
 ; PPC64LE-NEXT:  .LBB273_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4817,7 +4817,7 @@ define i32 @test274(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB274_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB274_1
+; PPC64LE-NEXT:    bne- 0, .LBB274_1
 ; PPC64LE-NEXT:  .LBB274_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4835,7 +4835,7 @@ define i64 @test275(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB275_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB275_1
+; PPC64LE-NEXT:    bne- 0, .LBB275_1
 ; PPC64LE-NEXT:  .LBB275_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4853,7 +4853,7 @@ define i64 @test276(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB276_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB276_1
+; PPC64LE-NEXT:    bne- 0, .LBB276_1
 ; PPC64LE-NEXT:  .LBB276_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -4871,7 +4871,7 @@ define i64 @test277(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB277_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB277_1
+; PPC64LE-NEXT:    bne- 0, .LBB277_1
 ; PPC64LE-NEXT:  .LBB277_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -4889,7 +4889,7 @@ define i64 @test278(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB278_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB278_1
+; PPC64LE-NEXT:    bne- 0, .LBB278_1
 ; PPC64LE-NEXT:  .LBB278_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4908,7 +4908,7 @@ define i64 @test279(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB279_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB279_1
+; PPC64LE-NEXT:    bne- 0, .LBB279_1
 ; PPC64LE-NEXT:  .LBB279_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -4928,7 +4928,7 @@ define i8 @test280(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB280_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB280_1
+; PPC64LE-NEXT:    bne- 0, .LBB280_1
 ; PPC64LE-NEXT:  .LBB280_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -4947,7 +4947,7 @@ define i8 @test281(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB281_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB281_1
+; PPC64LE-NEXT:    bne- 0, .LBB281_1
 ; PPC64LE-NEXT:  .LBB281_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -4968,7 +4968,7 @@ define i8 @test282(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB282_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB282_1
+; PPC64LE-NEXT:    bne- 0, .LBB282_1
 ; PPC64LE-NEXT:  .LBB282_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -4988,7 +4988,7 @@ define i8 @test283(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB283_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB283_1
+; PPC64LE-NEXT:    bne- 0, .LBB283_1
 ; PPC64LE-NEXT:  .LBB283_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -5009,7 +5009,7 @@ define i8 @test284(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB284_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB284_1
+; PPC64LE-NEXT:    bne- 0, .LBB284_1
 ; PPC64LE-NEXT:  .LBB284_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -5029,7 +5029,7 @@ define i16 @test285(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB285_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB285_1
+; PPC64LE-NEXT:    bne- 0, .LBB285_1
 ; PPC64LE-NEXT:  .LBB285_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -5048,7 +5048,7 @@ define i16 @test286(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB286_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB286_1
+; PPC64LE-NEXT:    bne- 0, .LBB286_1
 ; PPC64LE-NEXT:  .LBB286_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -5069,7 +5069,7 @@ define i16 @test287(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB287_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB287_1
+; PPC64LE-NEXT:    bne- 0, .LBB287_1
 ; PPC64LE-NEXT:  .LBB287_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -5089,7 +5089,7 @@ define i16 @test288(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB288_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB288_1
+; PPC64LE-NEXT:    bne- 0, .LBB288_1
 ; PPC64LE-NEXT:  .LBB288_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -5110,7 +5110,7 @@ define i16 @test289(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB289_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB289_1
+; PPC64LE-NEXT:    bne- 0, .LBB289_1
 ; PPC64LE-NEXT:  .LBB289_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -5128,7 +5128,7 @@ define i32 @test290(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB290_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB290_1
+; PPC64LE-NEXT:    bne- 0, .LBB290_1
 ; PPC64LE-NEXT:  .LBB290_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5146,7 +5146,7 @@ define i32 @test291(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB291_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB291_1
+; PPC64LE-NEXT:    bne- 0, .LBB291_1
 ; PPC64LE-NEXT:  .LBB291_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5164,7 +5164,7 @@ define i32 @test292(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB292_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB292_1
+; PPC64LE-NEXT:    bne- 0, .LBB292_1
 ; PPC64LE-NEXT:  .LBB292_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5182,7 +5182,7 @@ define i32 @test293(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB293_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB293_1
+; PPC64LE-NEXT:    bne- 0, .LBB293_1
 ; PPC64LE-NEXT:  .LBB293_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5201,7 +5201,7 @@ define i32 @test294(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB294_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB294_1
+; PPC64LE-NEXT:    bne- 0, .LBB294_1
 ; PPC64LE-NEXT:  .LBB294_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5219,7 +5219,7 @@ define i64 @test295(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB295_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB295_1
+; PPC64LE-NEXT:    bne- 0, .LBB295_1
 ; PPC64LE-NEXT:  .LBB295_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5237,7 +5237,7 @@ define i64 @test296(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB296_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB296_1
+; PPC64LE-NEXT:    bne- 0, .LBB296_1
 ; PPC64LE-NEXT:  .LBB296_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5255,7 +5255,7 @@ define i64 @test297(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB297_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB297_1
+; PPC64LE-NEXT:    bne- 0, .LBB297_1
 ; PPC64LE-NEXT:  .LBB297_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5273,7 +5273,7 @@ define i64 @test298(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB298_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB298_1
+; PPC64LE-NEXT:    bne- 0, .LBB298_1
 ; PPC64LE-NEXT:  .LBB298_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5292,7 +5292,7 @@ define i64 @test299(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB299_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB299_1
+; PPC64LE-NEXT:    bne- 0, .LBB299_1
 ; PPC64LE-NEXT:  .LBB299_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5310,7 +5310,7 @@ define i8 @test300(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB300_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB300_1
+; PPC64LE-NEXT:    bne- 0, .LBB300_1
 ; PPC64LE-NEXT:  .LBB300_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5328,7 +5328,7 @@ define i8 @test301(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB301_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB301_1
+; PPC64LE-NEXT:    bne- 0, .LBB301_1
 ; PPC64LE-NEXT:  .LBB301_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5346,7 +5346,7 @@ define i8 @test302(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB302_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB302_1
+; PPC64LE-NEXT:    bne- 0, .LBB302_1
 ; PPC64LE-NEXT:  .LBB302_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5364,7 +5364,7 @@ define i8 @test303(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB303_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB303_1
+; PPC64LE-NEXT:    bne- 0, .LBB303_1
 ; PPC64LE-NEXT:  .LBB303_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5383,7 +5383,7 @@ define i8 @test304(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB304_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB304_1
+; PPC64LE-NEXT:    bne- 0, .LBB304_1
 ; PPC64LE-NEXT:  .LBB304_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5401,7 +5401,7 @@ define i16 @test305(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB305_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB305_1
+; PPC64LE-NEXT:    bne- 0, .LBB305_1
 ; PPC64LE-NEXT:  .LBB305_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5419,7 +5419,7 @@ define i16 @test306(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB306_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB306_1
+; PPC64LE-NEXT:    bne- 0, .LBB306_1
 ; PPC64LE-NEXT:  .LBB306_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5437,7 +5437,7 @@ define i16 @test307(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB307_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB307_1
+; PPC64LE-NEXT:    bne- 0, .LBB307_1
 ; PPC64LE-NEXT:  .LBB307_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5455,7 +5455,7 @@ define i16 @test308(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB308_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB308_1
+; PPC64LE-NEXT:    bne- 0, .LBB308_1
 ; PPC64LE-NEXT:  .LBB308_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5474,7 +5474,7 @@ define i16 @test309(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB309_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB309_1
+; PPC64LE-NEXT:    bne- 0, .LBB309_1
 ; PPC64LE-NEXT:  .LBB309_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5492,7 +5492,7 @@ define i32 @test310(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB310_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB310_1
+; PPC64LE-NEXT:    bne- 0, .LBB310_1
 ; PPC64LE-NEXT:  .LBB310_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5510,7 +5510,7 @@ define i32 @test311(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB311_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB311_1
+; PPC64LE-NEXT:    bne- 0, .LBB311_1
 ; PPC64LE-NEXT:  .LBB311_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5528,7 +5528,7 @@ define i32 @test312(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB312_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB312_1
+; PPC64LE-NEXT:    bne- 0, .LBB312_1
 ; PPC64LE-NEXT:  .LBB312_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5546,7 +5546,7 @@ define i32 @test313(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB313_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB313_1
+; PPC64LE-NEXT:    bne- 0, .LBB313_1
 ; PPC64LE-NEXT:  .LBB313_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5565,7 +5565,7 @@ define i32 @test314(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB314_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB314_1
+; PPC64LE-NEXT:    bne- 0, .LBB314_1
 ; PPC64LE-NEXT:  .LBB314_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5583,7 +5583,7 @@ define i64 @test315(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB315_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB315_1
+; PPC64LE-NEXT:    bne- 0, .LBB315_1
 ; PPC64LE-NEXT:  .LBB315_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5601,7 +5601,7 @@ define i64 @test316(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB316_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB316_1
+; PPC64LE-NEXT:    bne- 0, .LBB316_1
 ; PPC64LE-NEXT:  .LBB316_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5619,7 +5619,7 @@ define i64 @test317(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB317_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB317_1
+; PPC64LE-NEXT:    bne- 0, .LBB317_1
 ; PPC64LE-NEXT:  .LBB317_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5637,7 +5637,7 @@ define i64 @test318(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB318_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB318_1
+; PPC64LE-NEXT:    bne- 0, .LBB318_1
 ; PPC64LE-NEXT:  .LBB318_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5656,7 +5656,7 @@ define i64 @test319(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB319_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB319_1
+; PPC64LE-NEXT:    bne- 0, .LBB319_1
 ; PPC64LE-NEXT:  .LBB319_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5674,7 +5674,7 @@ define i8 @test320(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB320_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB320_1
+; PPC64LE-NEXT:    bne- 0, .LBB320_1
 ; PPC64LE-NEXT:  .LBB320_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5692,7 +5692,7 @@ define i8 @test321(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB321_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB321_1
+; PPC64LE-NEXT:    bne- 0, .LBB321_1
 ; PPC64LE-NEXT:  .LBB321_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5710,7 +5710,7 @@ define i8 @test322(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB322_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB322_1
+; PPC64LE-NEXT:    bne- 0, .LBB322_1
 ; PPC64LE-NEXT:  .LBB322_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5728,7 +5728,7 @@ define i8 @test323(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB323_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB323_1
+; PPC64LE-NEXT:    bne- 0, .LBB323_1
 ; PPC64LE-NEXT:  .LBB323_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5747,7 +5747,7 @@ define i8 @test324(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB324_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB324_1
+; PPC64LE-NEXT:    bne- 0, .LBB324_1
 ; PPC64LE-NEXT:  .LBB324_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5765,7 +5765,7 @@ define i16 @test325(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB325_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB325_1
+; PPC64LE-NEXT:    bne- 0, .LBB325_1
 ; PPC64LE-NEXT:  .LBB325_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5783,7 +5783,7 @@ define i16 @test326(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB326_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB326_1
+; PPC64LE-NEXT:    bne- 0, .LBB326_1
 ; PPC64LE-NEXT:  .LBB326_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5801,7 +5801,7 @@ define i16 @test327(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB327_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB327_1
+; PPC64LE-NEXT:    bne- 0, .LBB327_1
 ; PPC64LE-NEXT:  .LBB327_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5819,7 +5819,7 @@ define i16 @test328(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB328_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB328_1
+; PPC64LE-NEXT:    bne- 0, .LBB328_1
 ; PPC64LE-NEXT:  .LBB328_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5838,7 +5838,7 @@ define i16 @test329(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB329_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB329_1
+; PPC64LE-NEXT:    bne- 0, .LBB329_1
 ; PPC64LE-NEXT:  .LBB329_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5856,7 +5856,7 @@ define i32 @test330(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB330_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB330_1
+; PPC64LE-NEXT:    bne- 0, .LBB330_1
 ; PPC64LE-NEXT:  .LBB330_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5874,7 +5874,7 @@ define i32 @test331(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB331_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB331_1
+; PPC64LE-NEXT:    bne- 0, .LBB331_1
 ; PPC64LE-NEXT:  .LBB331_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5892,7 +5892,7 @@ define i32 @test332(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB332_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB332_1
+; PPC64LE-NEXT:    bne- 0, .LBB332_1
 ; PPC64LE-NEXT:  .LBB332_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5910,7 +5910,7 @@ define i32 @test333(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB333_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB333_1
+; PPC64LE-NEXT:    bne- 0, .LBB333_1
 ; PPC64LE-NEXT:  .LBB333_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5929,7 +5929,7 @@ define i32 @test334(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB334_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB334_1
+; PPC64LE-NEXT:    bne- 0, .LBB334_1
 ; PPC64LE-NEXT:  .LBB334_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -5947,7 +5947,7 @@ define i64 @test335(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB335_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB335_1
+; PPC64LE-NEXT:    bne- 0, .LBB335_1
 ; PPC64LE-NEXT:  .LBB335_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -5965,7 +5965,7 @@ define i64 @test336(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB336_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB336_1
+; PPC64LE-NEXT:    bne- 0, .LBB336_1
 ; PPC64LE-NEXT:  .LBB336_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -5983,7 +5983,7 @@ define i64 @test337(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB337_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB337_1
+; PPC64LE-NEXT:    bne- 0, .LBB337_1
 ; PPC64LE-NEXT:  .LBB337_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6001,7 +6001,7 @@ define i64 @test338(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB338_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB338_1
+; PPC64LE-NEXT:    bne- 0, .LBB338_1
 ; PPC64LE-NEXT:  .LBB338_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6020,7 +6020,7 @@ define i64 @test339(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB339_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB339_1
+; PPC64LE-NEXT:    bne- 0, .LBB339_1
 ; PPC64LE-NEXT:  .LBB339_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6035,7 +6035,7 @@ define i8 @test340(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB340_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB340_1
+; PPC64LE-NEXT:    bne- 0, .LBB340_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6050,7 +6050,7 @@ define i8 @test341(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB341_1:
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    stbcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB341_1
+; PPC64LE-NEXT:    bne- 0, .LBB341_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6065,7 +6065,7 @@ define i8 @test342(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB342_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB342_1
+; PPC64LE-NEXT:    bne- 0, .LBB342_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6080,7 +6080,7 @@ define i8 @test343(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB343_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB343_1
+; PPC64LE-NEXT:    bne- 0, .LBB343_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6096,7 +6096,7 @@ define i8 @test344(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:  .LBB344_1:
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB344_1
+; PPC64LE-NEXT:    bne- 0, .LBB344_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6111,7 +6111,7 @@ define i16 @test345(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB345_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB345_1
+; PPC64LE-NEXT:    bne- 0, .LBB345_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6126,7 +6126,7 @@ define i16 @test346(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB346_1:
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    sthcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB346_1
+; PPC64LE-NEXT:    bne- 0, .LBB346_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6141,7 +6141,7 @@ define i16 @test347(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB347_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB347_1
+; PPC64LE-NEXT:    bne- 0, .LBB347_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6156,7 +6156,7 @@ define i16 @test348(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB348_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB348_1
+; PPC64LE-NEXT:    bne- 0, .LBB348_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6172,7 +6172,7 @@ define i16 @test349(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:  .LBB349_1:
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB349_1
+; PPC64LE-NEXT:    bne- 0, .LBB349_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6187,7 +6187,7 @@ define i32 @test350(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB350_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB350_1
+; PPC64LE-NEXT:    bne- 0, .LBB350_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6202,7 +6202,7 @@ define i32 @test351(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB351_1:
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB351_1
+; PPC64LE-NEXT:    bne- 0, .LBB351_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6217,7 +6217,7 @@ define i32 @test352(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB352_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB352_1
+; PPC64LE-NEXT:    bne- 0, .LBB352_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6232,7 +6232,7 @@ define i32 @test353(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB353_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB353_1
+; PPC64LE-NEXT:    bne- 0, .LBB353_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6248,7 +6248,7 @@ define i32 @test354(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:  .LBB354_1:
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB354_1
+; PPC64LE-NEXT:    bne- 0, .LBB354_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6263,7 +6263,7 @@ define i64 @test355(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB355_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB355_1
+; PPC64LE-NEXT:    bne- 0, .LBB355_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6278,7 +6278,7 @@ define i64 @test356(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB356_1:
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB356_1
+; PPC64LE-NEXT:    bne- 0, .LBB356_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6293,7 +6293,7 @@ define i64 @test357(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB357_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB357_1
+; PPC64LE-NEXT:    bne- 0, .LBB357_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6308,7 +6308,7 @@ define i64 @test358(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB358_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB358_1
+; PPC64LE-NEXT:    bne- 0, .LBB358_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6324,7 +6324,7 @@ define i64 @test359(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:  .LBB359_1:
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB359_1
+; PPC64LE-NEXT:    bne- 0, .LBB359_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6340,7 +6340,7 @@ define i8 @test360(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB360_1
+; PPC64LE-NEXT:    bne- 0, .LBB360_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6356,7 +6356,7 @@ define i8 @test361(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB361_1
+; PPC64LE-NEXT:    bne- 0, .LBB361_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6372,7 +6372,7 @@ define i8 @test362(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB362_1
+; PPC64LE-NEXT:    bne- 0, .LBB362_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6388,7 +6388,7 @@ define i8 @test363(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB363_1
+; PPC64LE-NEXT:    bne- 0, .LBB363_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6405,7 +6405,7 @@ define i8 @test364(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB364_1
+; PPC64LE-NEXT:    bne- 0, .LBB364_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6421,7 +6421,7 @@ define i16 @test365(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB365_1
+; PPC64LE-NEXT:    bne- 0, .LBB365_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6437,7 +6437,7 @@ define i16 @test366(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB366_1
+; PPC64LE-NEXT:    bne- 0, .LBB366_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6453,7 +6453,7 @@ define i16 @test367(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB367_1
+; PPC64LE-NEXT:    bne- 0, .LBB367_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6469,7 +6469,7 @@ define i16 @test368(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB368_1
+; PPC64LE-NEXT:    bne- 0, .LBB368_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6486,7 +6486,7 @@ define i16 @test369(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB369_1
+; PPC64LE-NEXT:    bne- 0, .LBB369_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6502,7 +6502,7 @@ define i32 @test370(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB370_1
+; PPC64LE-NEXT:    bne- 0, .LBB370_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6518,7 +6518,7 @@ define i32 @test371(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB371_1
+; PPC64LE-NEXT:    bne- 0, .LBB371_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6534,7 +6534,7 @@ define i32 @test372(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB372_1
+; PPC64LE-NEXT:    bne- 0, .LBB372_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6550,7 +6550,7 @@ define i32 @test373(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB373_1
+; PPC64LE-NEXT:    bne- 0, .LBB373_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6567,7 +6567,7 @@ define i32 @test374(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB374_1
+; PPC64LE-NEXT:    bne- 0, .LBB374_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6583,7 +6583,7 @@ define i64 @test375(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB375_1
+; PPC64LE-NEXT:    bne- 0, .LBB375_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6599,7 +6599,7 @@ define i64 @test376(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    add 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB376_1
+; PPC64LE-NEXT:    bne- 0, .LBB376_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6615,7 +6615,7 @@ define i64 @test377(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB377_1
+; PPC64LE-NEXT:    bne- 0, .LBB377_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6631,7 +6631,7 @@ define i64 @test378(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB378_1
+; PPC64LE-NEXT:    bne- 0, .LBB378_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6648,7 +6648,7 @@ define i64 @test379(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    add 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB379_1
+; PPC64LE-NEXT:    bne- 0, .LBB379_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6664,7 +6664,7 @@ define i8 @test380(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB380_1
+; PPC64LE-NEXT:    bne- 0, .LBB380_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6680,7 +6680,7 @@ define i8 @test381(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB381_1
+; PPC64LE-NEXT:    bne- 0, .LBB381_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6696,7 +6696,7 @@ define i8 @test382(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB382_1
+; PPC64LE-NEXT:    bne- 0, .LBB382_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6712,7 +6712,7 @@ define i8 @test383(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB383_1
+; PPC64LE-NEXT:    bne- 0, .LBB383_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6729,7 +6729,7 @@ define i8 @test384(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB384_1
+; PPC64LE-NEXT:    bne- 0, .LBB384_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6745,7 +6745,7 @@ define i16 @test385(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB385_1
+; PPC64LE-NEXT:    bne- 0, .LBB385_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6761,7 +6761,7 @@ define i16 @test386(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB386_1
+; PPC64LE-NEXT:    bne- 0, .LBB386_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6777,7 +6777,7 @@ define i16 @test387(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB387_1
+; PPC64LE-NEXT:    bne- 0, .LBB387_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6793,7 +6793,7 @@ define i16 @test388(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB388_1
+; PPC64LE-NEXT:    bne- 0, .LBB388_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6810,7 +6810,7 @@ define i16 @test389(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB389_1
+; PPC64LE-NEXT:    bne- 0, .LBB389_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6826,7 +6826,7 @@ define i32 @test390(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB390_1
+; PPC64LE-NEXT:    bne- 0, .LBB390_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6842,7 +6842,7 @@ define i32 @test391(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB391_1
+; PPC64LE-NEXT:    bne- 0, .LBB391_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6858,7 +6858,7 @@ define i32 @test392(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB392_1
+; PPC64LE-NEXT:    bne- 0, .LBB392_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6874,7 +6874,7 @@ define i32 @test393(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB393_1
+; PPC64LE-NEXT:    bne- 0, .LBB393_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6891,7 +6891,7 @@ define i32 @test394(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB394_1
+; PPC64LE-NEXT:    bne- 0, .LBB394_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6907,7 +6907,7 @@ define i64 @test395(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB395_1
+; PPC64LE-NEXT:    bne- 0, .LBB395_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6923,7 +6923,7 @@ define i64 @test396(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    sub 6, 3, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB396_1
+; PPC64LE-NEXT:    bne- 0, .LBB396_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -6939,7 +6939,7 @@ define i64 @test397(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB397_1
+; PPC64LE-NEXT:    bne- 0, .LBB397_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -6955,7 +6955,7 @@ define i64 @test398(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB398_1
+; PPC64LE-NEXT:    bne- 0, .LBB398_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6972,7 +6972,7 @@ define i64 @test399(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    sub 6, 5, 4
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB399_1
+; PPC64LE-NEXT:    bne- 0, .LBB399_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -6988,7 +6988,7 @@ define i8 @test400(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB400_1
+; PPC64LE-NEXT:    bne- 0, .LBB400_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7004,7 +7004,7 @@ define i8 @test401(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB401_1
+; PPC64LE-NEXT:    bne- 0, .LBB401_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7020,7 +7020,7 @@ define i8 @test402(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB402_1
+; PPC64LE-NEXT:    bne- 0, .LBB402_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7036,7 +7036,7 @@ define i8 @test403(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB403_1
+; PPC64LE-NEXT:    bne- 0, .LBB403_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7053,7 +7053,7 @@ define i8 @test404(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB404_1
+; PPC64LE-NEXT:    bne- 0, .LBB404_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7069,7 +7069,7 @@ define i16 @test405(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB405_1
+; PPC64LE-NEXT:    bne- 0, .LBB405_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7085,7 +7085,7 @@ define i16 @test406(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB406_1
+; PPC64LE-NEXT:    bne- 0, .LBB406_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7101,7 +7101,7 @@ define i16 @test407(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB407_1
+; PPC64LE-NEXT:    bne- 0, .LBB407_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7117,7 +7117,7 @@ define i16 @test408(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB408_1
+; PPC64LE-NEXT:    bne- 0, .LBB408_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7134,7 +7134,7 @@ define i16 @test409(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB409_1
+; PPC64LE-NEXT:    bne- 0, .LBB409_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7150,7 +7150,7 @@ define i32 @test410(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB410_1
+; PPC64LE-NEXT:    bne- 0, .LBB410_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7166,7 +7166,7 @@ define i32 @test411(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB411_1
+; PPC64LE-NEXT:    bne- 0, .LBB411_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7182,7 +7182,7 @@ define i32 @test412(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB412_1
+; PPC64LE-NEXT:    bne- 0, .LBB412_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7198,7 +7198,7 @@ define i32 @test413(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB413_1
+; PPC64LE-NEXT:    bne- 0, .LBB413_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7215,7 +7215,7 @@ define i32 @test414(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB414_1
+; PPC64LE-NEXT:    bne- 0, .LBB414_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7231,7 +7231,7 @@ define i64 @test415(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB415_1
+; PPC64LE-NEXT:    bne- 0, .LBB415_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7247,7 +7247,7 @@ define i64 @test416(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    and 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB416_1
+; PPC64LE-NEXT:    bne- 0, .LBB416_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7263,7 +7263,7 @@ define i64 @test417(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB417_1
+; PPC64LE-NEXT:    bne- 0, .LBB417_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7279,7 +7279,7 @@ define i64 @test418(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB418_1
+; PPC64LE-NEXT:    bne- 0, .LBB418_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7296,7 +7296,7 @@ define i64 @test419(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    and 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB419_1
+; PPC64LE-NEXT:    bne- 0, .LBB419_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7312,7 +7312,7 @@ define i8 @test420(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB420_1
+; PPC64LE-NEXT:    bne- 0, .LBB420_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7328,7 +7328,7 @@ define i8 @test421(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB421_1
+; PPC64LE-NEXT:    bne- 0, .LBB421_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7344,7 +7344,7 @@ define i8 @test422(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB422_1
+; PPC64LE-NEXT:    bne- 0, .LBB422_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7360,7 +7360,7 @@ define i8 @test423(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB423_1
+; PPC64LE-NEXT:    bne- 0, .LBB423_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7377,7 +7377,7 @@ define i8 @test424(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB424_1
+; PPC64LE-NEXT:    bne- 0, .LBB424_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7393,7 +7393,7 @@ define i16 @test425(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB425_1
+; PPC64LE-NEXT:    bne- 0, .LBB425_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7409,7 +7409,7 @@ define i16 @test426(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB426_1
+; PPC64LE-NEXT:    bne- 0, .LBB426_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7425,7 +7425,7 @@ define i16 @test427(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB427_1
+; PPC64LE-NEXT:    bne- 0, .LBB427_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7441,7 +7441,7 @@ define i16 @test428(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB428_1
+; PPC64LE-NEXT:    bne- 0, .LBB428_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7458,7 +7458,7 @@ define i16 @test429(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB429_1
+; PPC64LE-NEXT:    bne- 0, .LBB429_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7474,7 +7474,7 @@ define i32 @test430(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB430_1
+; PPC64LE-NEXT:    bne- 0, .LBB430_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7490,7 +7490,7 @@ define i32 @test431(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB431_1
+; PPC64LE-NEXT:    bne- 0, .LBB431_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7506,7 +7506,7 @@ define i32 @test432(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB432_1
+; PPC64LE-NEXT:    bne- 0, .LBB432_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7522,7 +7522,7 @@ define i32 @test433(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB433_1
+; PPC64LE-NEXT:    bne- 0, .LBB433_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7539,7 +7539,7 @@ define i32 @test434(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB434_1
+; PPC64LE-NEXT:    bne- 0, .LBB434_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7555,7 +7555,7 @@ define i64 @test435(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB435_1
+; PPC64LE-NEXT:    bne- 0, .LBB435_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7571,7 +7571,7 @@ define i64 @test436(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    nand 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB436_1
+; PPC64LE-NEXT:    bne- 0, .LBB436_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7587,7 +7587,7 @@ define i64 @test437(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB437_1
+; PPC64LE-NEXT:    bne- 0, .LBB437_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7603,7 +7603,7 @@ define i64 @test438(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB438_1
+; PPC64LE-NEXT:    bne- 0, .LBB438_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7620,7 +7620,7 @@ define i64 @test439(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    nand 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB439_1
+; PPC64LE-NEXT:    bne- 0, .LBB439_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7636,7 +7636,7 @@ define i8 @test440(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB440_1
+; PPC64LE-NEXT:    bne- 0, .LBB440_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7652,7 +7652,7 @@ define i8 @test441(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB441_1
+; PPC64LE-NEXT:    bne- 0, .LBB441_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7668,7 +7668,7 @@ define i8 @test442(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB442_1
+; PPC64LE-NEXT:    bne- 0, .LBB442_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7684,7 +7684,7 @@ define i8 @test443(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB443_1
+; PPC64LE-NEXT:    bne- 0, .LBB443_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7701,7 +7701,7 @@ define i8 @test444(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB444_1
+; PPC64LE-NEXT:    bne- 0, .LBB444_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7717,7 +7717,7 @@ define i16 @test445(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB445_1
+; PPC64LE-NEXT:    bne- 0, .LBB445_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7733,7 +7733,7 @@ define i16 @test446(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB446_1
+; PPC64LE-NEXT:    bne- 0, .LBB446_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7749,7 +7749,7 @@ define i16 @test447(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB447_1
+; PPC64LE-NEXT:    bne- 0, .LBB447_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7765,7 +7765,7 @@ define i16 @test448(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB448_1
+; PPC64LE-NEXT:    bne- 0, .LBB448_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7782,7 +7782,7 @@ define i16 @test449(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB449_1
+; PPC64LE-NEXT:    bne- 0, .LBB449_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7798,7 +7798,7 @@ define i32 @test450(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB450_1
+; PPC64LE-NEXT:    bne- 0, .LBB450_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7814,7 +7814,7 @@ define i32 @test451(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB451_1
+; PPC64LE-NEXT:    bne- 0, .LBB451_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7830,7 +7830,7 @@ define i32 @test452(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB452_1
+; PPC64LE-NEXT:    bne- 0, .LBB452_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7846,7 +7846,7 @@ define i32 @test453(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB453_1
+; PPC64LE-NEXT:    bne- 0, .LBB453_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7863,7 +7863,7 @@ define i32 @test454(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB454_1
+; PPC64LE-NEXT:    bne- 0, .LBB454_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7879,7 +7879,7 @@ define i64 @test455(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB455_1
+; PPC64LE-NEXT:    bne- 0, .LBB455_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7895,7 +7895,7 @@ define i64 @test456(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    or 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB456_1
+; PPC64LE-NEXT:    bne- 0, .LBB456_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7911,7 +7911,7 @@ define i64 @test457(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB457_1
+; PPC64LE-NEXT:    bne- 0, .LBB457_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7927,7 +7927,7 @@ define i64 @test458(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB458_1
+; PPC64LE-NEXT:    bne- 0, .LBB458_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7944,7 +7944,7 @@ define i64 @test459(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    or 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB459_1
+; PPC64LE-NEXT:    bne- 0, .LBB459_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -7960,7 +7960,7 @@ define i8 @test460(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB460_1
+; PPC64LE-NEXT:    bne- 0, .LBB460_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -7976,7 +7976,7 @@ define i8 @test461(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    stbcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB461_1
+; PPC64LE-NEXT:    bne- 0, .LBB461_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -7992,7 +7992,7 @@ define i8 @test462(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB462_1
+; PPC64LE-NEXT:    bne- 0, .LBB462_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8008,7 +8008,7 @@ define i8 @test463(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB463_1
+; PPC64LE-NEXT:    bne- 0, .LBB463_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8025,7 +8025,7 @@ define i8 @test464(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    lbarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stbcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB464_1
+; PPC64LE-NEXT:    bne- 0, .LBB464_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8041,7 +8041,7 @@ define i16 @test465(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB465_1
+; PPC64LE-NEXT:    bne- 0, .LBB465_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8057,7 +8057,7 @@ define i16 @test466(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    sthcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB466_1
+; PPC64LE-NEXT:    bne- 0, .LBB466_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8073,7 +8073,7 @@ define i16 @test467(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB467_1
+; PPC64LE-NEXT:    bne- 0, .LBB467_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8089,7 +8089,7 @@ define i16 @test468(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB468_1
+; PPC64LE-NEXT:    bne- 0, .LBB468_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8106,7 +8106,7 @@ define i16 @test469(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    lharx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    sthcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB469_1
+; PPC64LE-NEXT:    bne- 0, .LBB469_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8122,7 +8122,7 @@ define i32 @test470(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB470_1
+; PPC64LE-NEXT:    bne- 0, .LBB470_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8138,7 +8138,7 @@ define i32 @test471(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    stwcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB471_1
+; PPC64LE-NEXT:    bne- 0, .LBB471_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8154,7 +8154,7 @@ define i32 @test472(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB472_1
+; PPC64LE-NEXT:    bne- 0, .LBB472_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8170,7 +8170,7 @@ define i32 @test473(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB473_1
+; PPC64LE-NEXT:    bne- 0, .LBB473_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8187,7 +8187,7 @@ define i32 @test474(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    lwarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stwcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB474_1
+; PPC64LE-NEXT:    bne- 0, .LBB474_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8203,7 +8203,7 @@ define i64 @test475(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB475_1
+; PPC64LE-NEXT:    bne- 0, .LBB475_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8219,7 +8219,7 @@ define i64 @test476(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 3, 0, 5
 ; PPC64LE-NEXT:    xor 6, 4, 3
 ; PPC64LE-NEXT:    stdcx. 6, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB476_1
+; PPC64LE-NEXT:    bne- 0, .LBB476_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8235,7 +8235,7 @@ define i64 @test477(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB477_1
+; PPC64LE-NEXT:    bne- 0, .LBB477_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8251,7 +8251,7 @@ define i64 @test478(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB478_1
+; PPC64LE-NEXT:    bne- 0, .LBB478_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8268,7 +8268,7 @@ define i64 @test479(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    ldarx 5, 0, 3
 ; PPC64LE-NEXT:    xor 6, 4, 5
 ; PPC64LE-NEXT:    stdcx. 6, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB479_1
+; PPC64LE-NEXT:    bne- 0, .LBB479_1
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8288,7 +8288,7 @@ define i8 @test480(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB480_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB480_1
+; PPC64LE-NEXT:    bne- 0, .LBB480_1
 ; PPC64LE-NEXT:  .LBB480_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8307,7 +8307,7 @@ define i8 @test481(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB481_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB481_1
+; PPC64LE-NEXT:    bne- 0, .LBB481_1
 ; PPC64LE-NEXT:  .LBB481_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8328,7 +8328,7 @@ define i8 @test482(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB482_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB482_1
+; PPC64LE-NEXT:    bne- 0, .LBB482_1
 ; PPC64LE-NEXT:  .LBB482_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8348,7 +8348,7 @@ define i8 @test483(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB483_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB483_1
+; PPC64LE-NEXT:    bne- 0, .LBB483_1
 ; PPC64LE-NEXT:  .LBB483_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8369,7 +8369,7 @@ define i8 @test484(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB484_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB484_1
+; PPC64LE-NEXT:    bne- 0, .LBB484_1
 ; PPC64LE-NEXT:  .LBB484_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8389,7 +8389,7 @@ define i16 @test485(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB485_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB485_1
+; PPC64LE-NEXT:    bne- 0, .LBB485_1
 ; PPC64LE-NEXT:  .LBB485_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8408,7 +8408,7 @@ define i16 @test486(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB486_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB486_1
+; PPC64LE-NEXT:    bne- 0, .LBB486_1
 ; PPC64LE-NEXT:  .LBB486_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8429,7 +8429,7 @@ define i16 @test487(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB487_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB487_1
+; PPC64LE-NEXT:    bne- 0, .LBB487_1
 ; PPC64LE-NEXT:  .LBB487_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8449,7 +8449,7 @@ define i16 @test488(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB488_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB488_1
+; PPC64LE-NEXT:    bne- 0, .LBB488_1
 ; PPC64LE-NEXT:  .LBB488_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8470,7 +8470,7 @@ define i16 @test489(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB489_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB489_1
+; PPC64LE-NEXT:    bne- 0, .LBB489_1
 ; PPC64LE-NEXT:  .LBB489_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8488,7 +8488,7 @@ define i32 @test490(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB490_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB490_1
+; PPC64LE-NEXT:    bne- 0, .LBB490_1
 ; PPC64LE-NEXT:  .LBB490_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8506,7 +8506,7 @@ define i32 @test491(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB491_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB491_1
+; PPC64LE-NEXT:    bne- 0, .LBB491_1
 ; PPC64LE-NEXT:  .LBB491_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8524,7 +8524,7 @@ define i32 @test492(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB492_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB492_1
+; PPC64LE-NEXT:    bne- 0, .LBB492_1
 ; PPC64LE-NEXT:  .LBB492_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8542,7 +8542,7 @@ define i32 @test493(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB493_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB493_1
+; PPC64LE-NEXT:    bne- 0, .LBB493_1
 ; PPC64LE-NEXT:  .LBB493_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8561,7 +8561,7 @@ define i32 @test494(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB494_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB494_1
+; PPC64LE-NEXT:    bne- 0, .LBB494_1
 ; PPC64LE-NEXT:  .LBB494_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8579,7 +8579,7 @@ define i64 @test495(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB495_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB495_1
+; PPC64LE-NEXT:    bne- 0, .LBB495_1
 ; PPC64LE-NEXT:  .LBB495_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8597,7 +8597,7 @@ define i64 @test496(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB496_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB496_1
+; PPC64LE-NEXT:    bne- 0, .LBB496_1
 ; PPC64LE-NEXT:  .LBB496_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8615,7 +8615,7 @@ define i64 @test497(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB497_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB497_1
+; PPC64LE-NEXT:    bne- 0, .LBB497_1
 ; PPC64LE-NEXT:  .LBB497_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8633,7 +8633,7 @@ define i64 @test498(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB498_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB498_1
+; PPC64LE-NEXT:    bne- 0, .LBB498_1
 ; PPC64LE-NEXT:  .LBB498_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8652,7 +8652,7 @@ define i64 @test499(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB499_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB499_1
+; PPC64LE-NEXT:    bne- 0, .LBB499_1
 ; PPC64LE-NEXT:  .LBB499_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8672,7 +8672,7 @@ define i8 @test500(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB500_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB500_1
+; PPC64LE-NEXT:    bne- 0, .LBB500_1
 ; PPC64LE-NEXT:  .LBB500_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8691,7 +8691,7 @@ define i8 @test501(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB501_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB501_1
+; PPC64LE-NEXT:    bne- 0, .LBB501_1
 ; PPC64LE-NEXT:  .LBB501_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8712,7 +8712,7 @@ define i8 @test502(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB502_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB502_1
+; PPC64LE-NEXT:    bne- 0, .LBB502_1
 ; PPC64LE-NEXT:  .LBB502_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8732,7 +8732,7 @@ define i8 @test503(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB503_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB503_1
+; PPC64LE-NEXT:    bne- 0, .LBB503_1
 ; PPC64LE-NEXT:  .LBB503_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8753,7 +8753,7 @@ define i8 @test504(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB504_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB504_1
+; PPC64LE-NEXT:    bne- 0, .LBB504_1
 ; PPC64LE-NEXT:  .LBB504_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8773,7 +8773,7 @@ define i16 @test505(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB505_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB505_1
+; PPC64LE-NEXT:    bne- 0, .LBB505_1
 ; PPC64LE-NEXT:  .LBB505_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8792,7 +8792,7 @@ define i16 @test506(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB506_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB506_1
+; PPC64LE-NEXT:    bne- 0, .LBB506_1
 ; PPC64LE-NEXT:  .LBB506_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8813,7 +8813,7 @@ define i16 @test507(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB507_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB507_1
+; PPC64LE-NEXT:    bne- 0, .LBB507_1
 ; PPC64LE-NEXT:  .LBB507_3:
 ; PPC64LE-NEXT:    mr 3, 4
 ; PPC64LE-NEXT:    blr
@@ -8833,7 +8833,7 @@ define i16 @test508(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB508_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB508_1
+; PPC64LE-NEXT:    bne- 0, .LBB508_1
 ; PPC64LE-NEXT:  .LBB508_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8854,7 +8854,7 @@ define i16 @test509(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB509_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 5, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB509_1
+; PPC64LE-NEXT:    bne- 0, .LBB509_1
 ; PPC64LE-NEXT:  .LBB509_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 4
@@ -8872,7 +8872,7 @@ define i32 @test510(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB510_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB510_1
+; PPC64LE-NEXT:    bne- 0, .LBB510_1
 ; PPC64LE-NEXT:  .LBB510_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8890,7 +8890,7 @@ define i32 @test511(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB511_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB511_1
+; PPC64LE-NEXT:    bne- 0, .LBB511_1
 ; PPC64LE-NEXT:  .LBB511_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8908,7 +8908,7 @@ define i32 @test512(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB512_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB512_1
+; PPC64LE-NEXT:    bne- 0, .LBB512_1
 ; PPC64LE-NEXT:  .LBB512_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8926,7 +8926,7 @@ define i32 @test513(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB513_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB513_1
+; PPC64LE-NEXT:    bne- 0, .LBB513_1
 ; PPC64LE-NEXT:  .LBB513_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8945,7 +8945,7 @@ define i32 @test514(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB514_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB514_1
+; PPC64LE-NEXT:    bne- 0, .LBB514_1
 ; PPC64LE-NEXT:  .LBB514_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -8963,7 +8963,7 @@ define i64 @test515(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB515_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB515_1
+; PPC64LE-NEXT:    bne- 0, .LBB515_1
 ; PPC64LE-NEXT:  .LBB515_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -8981,7 +8981,7 @@ define i64 @test516(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB516_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB516_1
+; PPC64LE-NEXT:    bne- 0, .LBB516_1
 ; PPC64LE-NEXT:  .LBB516_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -8999,7 +8999,7 @@ define i64 @test517(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB517_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB517_1
+; PPC64LE-NEXT:    bne- 0, .LBB517_1
 ; PPC64LE-NEXT:  .LBB517_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9017,7 +9017,7 @@ define i64 @test518(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB518_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB518_1
+; PPC64LE-NEXT:    bne- 0, .LBB518_1
 ; PPC64LE-NEXT:  .LBB518_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9036,7 +9036,7 @@ define i64 @test519(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB519_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB519_1
+; PPC64LE-NEXT:    bne- 0, .LBB519_1
 ; PPC64LE-NEXT:  .LBB519_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9054,7 +9054,7 @@ define i8 @test520(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB520_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB520_1
+; PPC64LE-NEXT:    bne- 0, .LBB520_1
 ; PPC64LE-NEXT:  .LBB520_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9072,7 +9072,7 @@ define i8 @test521(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB521_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB521_1
+; PPC64LE-NEXT:    bne- 0, .LBB521_1
 ; PPC64LE-NEXT:  .LBB521_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9090,7 +9090,7 @@ define i8 @test522(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB522_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB522_1
+; PPC64LE-NEXT:    bne- 0, .LBB522_1
 ; PPC64LE-NEXT:  .LBB522_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9108,7 +9108,7 @@ define i8 @test523(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB523_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB523_1
+; PPC64LE-NEXT:    bne- 0, .LBB523_1
 ; PPC64LE-NEXT:  .LBB523_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9127,7 +9127,7 @@ define i8 @test524(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB524_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB524_1
+; PPC64LE-NEXT:    bne- 0, .LBB524_1
 ; PPC64LE-NEXT:  .LBB524_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9145,7 +9145,7 @@ define i16 @test525(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB525_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB525_1
+; PPC64LE-NEXT:    bne- 0, .LBB525_1
 ; PPC64LE-NEXT:  .LBB525_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9163,7 +9163,7 @@ define i16 @test526(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB526_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB526_1
+; PPC64LE-NEXT:    bne- 0, .LBB526_1
 ; PPC64LE-NEXT:  .LBB526_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9181,7 +9181,7 @@ define i16 @test527(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB527_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB527_1
+; PPC64LE-NEXT:    bne- 0, .LBB527_1
 ; PPC64LE-NEXT:  .LBB527_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9199,7 +9199,7 @@ define i16 @test528(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB528_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB528_1
+; PPC64LE-NEXT:    bne- 0, .LBB528_1
 ; PPC64LE-NEXT:  .LBB528_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9218,7 +9218,7 @@ define i16 @test529(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB529_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB529_1
+; PPC64LE-NEXT:    bne- 0, .LBB529_1
 ; PPC64LE-NEXT:  .LBB529_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9236,7 +9236,7 @@ define i32 @test530(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB530_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB530_1
+; PPC64LE-NEXT:    bne- 0, .LBB530_1
 ; PPC64LE-NEXT:  .LBB530_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9254,7 +9254,7 @@ define i32 @test531(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB531_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB531_1
+; PPC64LE-NEXT:    bne- 0, .LBB531_1
 ; PPC64LE-NEXT:  .LBB531_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9272,7 +9272,7 @@ define i32 @test532(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB532_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB532_1
+; PPC64LE-NEXT:    bne- 0, .LBB532_1
 ; PPC64LE-NEXT:  .LBB532_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9290,7 +9290,7 @@ define i32 @test533(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB533_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB533_1
+; PPC64LE-NEXT:    bne- 0, .LBB533_1
 ; PPC64LE-NEXT:  .LBB533_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9309,7 +9309,7 @@ define i32 @test534(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB534_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB534_1
+; PPC64LE-NEXT:    bne- 0, .LBB534_1
 ; PPC64LE-NEXT:  .LBB534_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9327,7 +9327,7 @@ define i64 @test535(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB535_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB535_1
+; PPC64LE-NEXT:    bne- 0, .LBB535_1
 ; PPC64LE-NEXT:  .LBB535_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9345,7 +9345,7 @@ define i64 @test536(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB536_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB536_1
+; PPC64LE-NEXT:    bne- 0, .LBB536_1
 ; PPC64LE-NEXT:  .LBB536_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9363,7 +9363,7 @@ define i64 @test537(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB537_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB537_1
+; PPC64LE-NEXT:    bne- 0, .LBB537_1
 ; PPC64LE-NEXT:  .LBB537_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9381,7 +9381,7 @@ define i64 @test538(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB538_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB538_1
+; PPC64LE-NEXT:    bne- 0, .LBB538_1
 ; PPC64LE-NEXT:  .LBB538_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9400,7 +9400,7 @@ define i64 @test539(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    bgt 0, .LBB539_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB539_1
+; PPC64LE-NEXT:    bne- 0, .LBB539_1
 ; PPC64LE-NEXT:  .LBB539_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9418,7 +9418,7 @@ define i8 @test540(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB540_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB540_1
+; PPC64LE-NEXT:    bne- 0, .LBB540_1
 ; PPC64LE-NEXT:  .LBB540_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9436,7 +9436,7 @@ define i8 @test541(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB541_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB541_1
+; PPC64LE-NEXT:    bne- 0, .LBB541_1
 ; PPC64LE-NEXT:  .LBB541_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9454,7 +9454,7 @@ define i8 @test542(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB542_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB542_1
+; PPC64LE-NEXT:    bne- 0, .LBB542_1
 ; PPC64LE-NEXT:  .LBB542_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9472,7 +9472,7 @@ define i8 @test543(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB543_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB543_1
+; PPC64LE-NEXT:    bne- 0, .LBB543_1
 ; PPC64LE-NEXT:  .LBB543_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9491,7 +9491,7 @@ define i8 @test544(ptr %ptr, i8 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB544_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stbcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB544_1
+; PPC64LE-NEXT:    bne- 0, .LBB544_1
 ; PPC64LE-NEXT:  .LBB544_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9509,7 +9509,7 @@ define i16 @test545(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB545_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB545_1
+; PPC64LE-NEXT:    bne- 0, .LBB545_1
 ; PPC64LE-NEXT:  .LBB545_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9527,7 +9527,7 @@ define i16 @test546(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB546_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB546_1
+; PPC64LE-NEXT:    bne- 0, .LBB546_1
 ; PPC64LE-NEXT:  .LBB546_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9545,7 +9545,7 @@ define i16 @test547(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB547_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB547_1
+; PPC64LE-NEXT:    bne- 0, .LBB547_1
 ; PPC64LE-NEXT:  .LBB547_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9563,7 +9563,7 @@ define i16 @test548(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB548_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB548_1
+; PPC64LE-NEXT:    bne- 0, .LBB548_1
 ; PPC64LE-NEXT:  .LBB548_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9582,7 +9582,7 @@ define i16 @test549(ptr %ptr, i16 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB549_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    sthcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB549_1
+; PPC64LE-NEXT:    bne- 0, .LBB549_1
 ; PPC64LE-NEXT:  .LBB549_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9600,7 +9600,7 @@ define i32 @test550(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB550_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB550_1
+; PPC64LE-NEXT:    bne- 0, .LBB550_1
 ; PPC64LE-NEXT:  .LBB550_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9618,7 +9618,7 @@ define i32 @test551(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB551_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB551_1
+; PPC64LE-NEXT:    bne- 0, .LBB551_1
 ; PPC64LE-NEXT:  .LBB551_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9636,7 +9636,7 @@ define i32 @test552(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB552_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB552_1
+; PPC64LE-NEXT:    bne- 0, .LBB552_1
 ; PPC64LE-NEXT:  .LBB552_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9654,7 +9654,7 @@ define i32 @test553(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB553_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB553_1
+; PPC64LE-NEXT:    bne- 0, .LBB553_1
 ; PPC64LE-NEXT:  .LBB553_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9673,7 +9673,7 @@ define i32 @test554(ptr %ptr, i32 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB554_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stwcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB554_1
+; PPC64LE-NEXT:    bne- 0, .LBB554_1
 ; PPC64LE-NEXT:  .LBB554_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9691,7 +9691,7 @@ define i64 @test555(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB555_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB555_1
+; PPC64LE-NEXT:    bne- 0, .LBB555_1
 ; PPC64LE-NEXT:  .LBB555_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9709,7 +9709,7 @@ define i64 @test556(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB556_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 5
-; PPC64LE-NEXT:    bne 0, .LBB556_1
+; PPC64LE-NEXT:    bne- 0, .LBB556_1
 ; PPC64LE-NEXT:  .LBB556_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    blr
@@ -9727,7 +9727,7 @@ define i64 @test557(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB557_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB557_1
+; PPC64LE-NEXT:    bne- 0, .LBB557_1
 ; PPC64LE-NEXT:  .LBB557_3:
 ; PPC64LE-NEXT:    mr 3, 5
 ; PPC64LE-NEXT:    blr
@@ -9745,7 +9745,7 @@ define i64 @test558(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB558_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB558_1
+; PPC64LE-NEXT:    bne- 0, .LBB558_1
 ; PPC64LE-NEXT:  .LBB558_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5
@@ -9764,7 +9764,7 @@ define i64 @test559(ptr %ptr, i64 %val) {
 ; PPC64LE-NEXT:    blt 0, .LBB559_3
 ; PPC64LE-NEXT:  # %bb.2:
 ; PPC64LE-NEXT:    stdcx. 4, 0, 3
-; PPC64LE-NEXT:    bne 0, .LBB559_1
+; PPC64LE-NEXT:    bne- 0, .LBB559_1
 ; PPC64LE-NEXT:  .LBB559_3:
 ; PPC64LE-NEXT:    lwsync
 ; PPC64LE-NEXT:    mr 3, 5

--- a/llvm/test/CodeGen/PowerPC/atomics.ll
+++ b/llvm/test/CodeGen/PowerPC/atomics.ll
@@ -191,7 +191,6 @@ define i8 @cas_strong_i8_sc_sc(ptr %mem) {
 ; PPC64-NEXT:    and r8, r4, r6
 ; PPC64-NEXT:    or r8, r8, r7
 ; PPC64-NEXT:    stwcx. r8, 0, r5
-; PPC64-NEXT:    beq+ cr0, .LBB8_4
 ; PPC64-NEXT:  # %bb.3: # %cmpxchg.releasedload
 ; PPC64-NEXT:    #
 ; PPC64-NEXT:    lwarx r4, 0, r5
@@ -271,7 +270,7 @@ define i32 @cas_strong_i32_acqrel_acquire(ptr %mem) {
 ; CHECK-NEXT:  .LBB10_2: # %cmpxchg.trystore
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. r5, 0, r4
-; CHECK-NEXT:    beq+ cr0, .LBB10_4
+; CHECK-NEXT:    beq cr0, .LBB10_4
 ; CHECK-NEXT:  # %bb.3: # %cmpxchg.releasedload
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lwarx r3, 0, r4
@@ -341,7 +340,7 @@ define i8 @add_i8_monotonic(ptr %mem, i8 %operand) {
 ; PPC32-NEXT:    and r8, r8, r6
 ; PPC32-NEXT:    or r8, r8, r9
 ; PPC32-NEXT:    stwcx. r8, 0, r5
-; PPC32-NEXT:    bne cr0, .LBB12_1
+; PPC32-NEXT:    bne- cr0, .LBB12_1
 ; PPC32-NEXT:  # %bb.2:
 ; PPC32-NEXT:    srw r3, r7, r3
 ; PPC32-NEXT:    clrlwi r3, r3, 24
@@ -362,7 +361,7 @@ define i8 @add_i8_monotonic(ptr %mem, i8 %operand) {
 ; PPC64-NEXT:    and r8, r8, r6
 ; PPC64-NEXT:    or r8, r8, r9
 ; PPC64-NEXT:    stwcx. r8, 0, r5
-; PPC64-NEXT:    bne cr0, .LBB12_1
+; PPC64-NEXT:    bne- cr0, .LBB12_1
 ; PPC64-NEXT:  # %bb.2:
 ; PPC64-NEXT:    srw r3, r7, r3
 ; PPC64-NEXT:    clrlwi r3, r3, 24
@@ -388,7 +387,7 @@ define i16 @xor_i16_seq_cst(ptr %mem, i16 %operand) {
 ; PPC32-NEXT:    and r8, r8, r6
 ; PPC32-NEXT:    or r8, r8, r9
 ; PPC32-NEXT:    stwcx. r8, 0, r3
-; PPC32-NEXT:    bne cr0, .LBB13_1
+; PPC32-NEXT:    bne- cr0, .LBB13_1
 ; PPC32-NEXT:  # %bb.2:
 ; PPC32-NEXT:    srw r3, r7, r5
 ; PPC32-NEXT:    clrlwi r3, r3, 16
@@ -412,7 +411,7 @@ define i16 @xor_i16_seq_cst(ptr %mem, i16 %operand) {
 ; PPC64-NEXT:    and r8, r8, r6
 ; PPC64-NEXT:    or r8, r8, r9
 ; PPC64-NEXT:    stwcx. r8, 0, r3
-; PPC64-NEXT:    bne cr0, .LBB13_1
+; PPC64-NEXT:    bne- cr0, .LBB13_1
 ; PPC64-NEXT:  # %bb.2:
 ; PPC64-NEXT:    srw r3, r7, r5
 ; PPC64-NEXT:    clrlwi r3, r3, 16
@@ -428,7 +427,7 @@ define i32 @xchg_i32_acq_rel(ptr %mem, i32 %operand) {
 ; CHECK-NEXT:  .LBB14_1:
 ; CHECK-NEXT:    lwarx r5, 0, r3
 ; CHECK-NEXT:    stwcx. r4, 0, r3
-; CHECK-NEXT:    bne cr0, .LBB14_1
+; CHECK-NEXT:    bne- cr0, .LBB14_1
 ; CHECK-NEXT:  # %bb.2:
 ; CHECK-NEXT:    mr r3, r5
 ; CHECK-NEXT:    lwsync
@@ -458,7 +457,7 @@ define i64 @and_i64_release(ptr %mem, i64 %operand) {
 ; PPC64-NEXT:    ldarx r5, 0, r3
 ; PPC64-NEXT:    and r6, r4, r5
 ; PPC64-NEXT:    stdcx. r6, 0, r3
-; PPC64-NEXT:    bne cr0, .LBB15_1
+; PPC64-NEXT:    bne- cr0, .LBB15_1
 ; PPC64-NEXT:  # %bb.2:
 ; PPC64-NEXT:    mr r3, r5
 ; PPC64-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/atomics.ll
+++ b/llvm/test/CodeGen/PowerPC/atomics.ll
@@ -191,6 +191,7 @@ define i8 @cas_strong_i8_sc_sc(ptr %mem) {
 ; PPC64-NEXT:    and r8, r4, r6
 ; PPC64-NEXT:    or r8, r8, r7
 ; PPC64-NEXT:    stwcx. r8, 0, r5
+; PPC64-NEXT:    beq+ cr0, .LBB8_4
 ; PPC64-NEXT:  # %bb.3: # %cmpxchg.releasedload
 ; PPC64-NEXT:    #
 ; PPC64-NEXT:    lwarx r4, 0, r5
@@ -270,7 +271,7 @@ define i32 @cas_strong_i32_acqrel_acquire(ptr %mem) {
 ; CHECK-NEXT:  .LBB10_2: # %cmpxchg.trystore
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    stwcx. r5, 0, r4
-; CHECK-NEXT:    beq cr0, .LBB10_4
+; CHECK-NEXT:    beq+ cr0, .LBB10_4
 ; CHECK-NEXT:  # %bb.3: # %cmpxchg.releasedload
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    lwarx r3, 0, r4

--- a/llvm/test/CodeGen/PowerPC/ppc-partword-atomic.ll
+++ b/llvm/test/CodeGen/PowerPC/ppc-partword-atomic.ll
@@ -25,7 +25,7 @@ define dso_local zeroext i32 @testI8(i8 zeroext %val) local_unnamed_addr #0 {
 ; PWR7-NEXT:    andc 8, 7, 3
 ; PWR7-NEXT:    or 8, 6, 8
 ; PWR7-NEXT:    stwcx. 8, 0, 5
-; PWR7-NEXT:    bne 0, .LBB0_1
+; PWR7-NEXT:    bne- 0, .LBB0_1
 ; PWR7-NEXT:  # %bb.2: # %entry
 ; PWR7-NEXT:    srw 3, 7, 4
 ; PWR7-NEXT:    addis 4, 2, global_int@toc@ha
@@ -44,7 +44,7 @@ define dso_local zeroext i32 @testI8(i8 zeroext %val) local_unnamed_addr #0 {
 ; PWR9-NEXT:    #
 ; PWR9-NEXT:    lbarx 4, 0, 5
 ; PWR9-NEXT:    stbcx. 3, 0, 5
-; PWR9-NEXT:    bne 0, .LBB0_1
+; PWR9-NEXT:    bne- 0, .LBB0_1
 ; PWR9-NEXT:  # %bb.2: # %entry
 ; PWR9-NEXT:    addis 3, 2, global_int@toc@ha
 ; PWR9-NEXT:    lwsync
@@ -78,7 +78,7 @@ define dso_local zeroext i32 @testI16(i16 zeroext %val) local_unnamed_addr #0 {
 ; PWR7-NEXT:    andc 8, 7, 3
 ; PWR7-NEXT:    or 8, 6, 8
 ; PWR7-NEXT:    stwcx. 8, 0, 5
-; PWR7-NEXT:    bne 0, .LBB1_1
+; PWR7-NEXT:    bne- 0, .LBB1_1
 ; PWR7-NEXT:  # %bb.2: # %entry
 ; PWR7-NEXT:    srw 3, 7, 4
 ; PWR7-NEXT:    addis 4, 2, global_int@toc@ha
@@ -97,7 +97,7 @@ define dso_local zeroext i32 @testI16(i16 zeroext %val) local_unnamed_addr #0 {
 ; PWR9-NEXT:    #
 ; PWR9-NEXT:    lharx 4, 0, 5
 ; PWR9-NEXT:    sthcx. 3, 0, 5
-; PWR9-NEXT:    bne 0, .LBB1_1
+; PWR9-NEXT:    bne- 0, .LBB1_1
 ; PWR9-NEXT:  # %bb.2: # %entry
 ; PWR9-NEXT:    addis 3, 2, global_int@toc@ha
 ; PWR9-NEXT:    lwsync

--- a/llvm/test/CodeGen/PowerPC/pr61882.ll
+++ b/llvm/test/CodeGen/PowerPC/pr61882.ll
@@ -27,7 +27,7 @@ define void @foo(ptr %a, i32 %x) {
 ; CHECK-NEXT:    andc r8, r8, r6
 ; CHECK-NEXT:    or r8, r7, r8
 ; CHECK-NEXT:    stwcx. r8, 0, r3
-; CHECK-NEXT:    bne cr0, .LBB0_1
+; CHECK-NEXT:    bne- cr0, .LBB0_1
 ; CHECK-NEXT:  .LBB0_3:
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    blr
@@ -43,7 +43,7 @@ define void @foo(ptr %a, i32 %x) {
 ; PWR8-NEXT:    bgt cr0, .LBB0_3
 ; PWR8-NEXT:  # %bb.2:
 ; PWR8-NEXT:    stbcx. r4, 0, r3
-; PWR8-NEXT:    bne cr0, .LBB0_1
+; PWR8-NEXT:    bne- cr0, .LBB0_1
 ; PWR8-NEXT:  .LBB0_3:
 ; PWR8-NEXT:    lwsync
 ; PWR8-NEXT:    blr

--- a/llvm/test/CodeGen/PowerPC/sign-ext-atomics.ll
+++ b/llvm/test/CodeGen/PowerPC/sign-ext-atomics.ll
@@ -16,7 +16,7 @@ define i16 @SEXTParam(i16 signext %0) #0 {
 ; CHECK-NEXT:  # %bb.2: # %top
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 3, 0, 4
-; CHECK-NEXT:    bne 0, .LBB0_1
+; CHECK-NEXT:    bne- 0, .LBB0_1
 ; CHECK-NEXT:  .LBB0_3: # %top
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    lhz 3, -4(1)
@@ -49,7 +49,7 @@ define i16 @noSEXTParam(i16 %0) #0 {
 ; CHECK-NEXT:  # %bb.2: # %top
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 3, 0, 4
-; CHECK-NEXT:    bne 0, .LBB1_1
+; CHECK-NEXT:    bne- 0, .LBB1_1
 ; CHECK-NEXT:  .LBB1_3: # %top
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    lhz 3, -4(1)
@@ -82,7 +82,7 @@ define i16 @noSEXTLoad(ptr %p) #0 {
 ; CHECK-NEXT:  # %bb.2: # %top
 ; CHECK-NEXT:    #
 ; CHECK-NEXT:    sthcx. 3, 0, 4
-; CHECK-NEXT:    bne 0, .LBB2_1
+; CHECK-NEXT:    bne- 0, .LBB2_1
 ; CHECK-NEXT:  .LBB2_3: # %top
 ; CHECK-NEXT:    lwsync
 ; CHECK-NEXT:    lhz 3, -4(1)


### PR DESCRIPTION
The branches emitted for atomic operations  after the store-conditional are currently not hinted, even though they should be.

According to the Power10 Processor Chip User’s Manual:

   ` “Without static prediction, if the lock is not acquired in the first iteration, the branch history mechanism works to update the prediction to predict taken; that is, predict lock acquisition failure and cause more lwarx traffic for the next iteration.”`

This patch addresses the issue by adding explicit branch hints for atomic operations  after the store-conditional.