### PR TITLE
[UBSan] Fix incorrect alignment reported when global new returns an o…

### DIFF
--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -1747,7 +1747,7 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
   SourceManager &SM = getContext().getSourceManager();
   SourceLocation Loc = E->getOperatorNew()->getLocation();
   bool IsCustomOverload = !SM.isInSystemHeader(Loc);
-  if (SanOpts.has(SanitizerKind::Alignment) && IsCustomOverload &&
+  if (SanOpts.has(SanitizerKind::Alignment) &&
       (DefaultTargetAlignment >
        CGM.getContext().getTypeAlignInChars(allocType).getQuantity()))
     checkKind = CodeGenFunction::TCK_ConstructorCallOverloadedNew;

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -1744,9 +1744,6 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
   TypeCheckKind checkKind = CodeGenFunction::TCK_ConstructorCall;
   const TargetInfo &TI = getContext().getTargetInfo();
   unsigned DefaultTargetAlignment = TI.getNewAlign() / TI.getCharWidth();
-  SourceManager &SM = getContext().getSourceManager();
-  SourceLocation Loc = E->getOperatorNew()->getLocation();
-  bool IsCustomOverload = !SM.isInSystemHeader(Loc);
   if (SanOpts.has(SanitizerKind::Alignment) &&
       (DefaultTargetAlignment >
        CGM.getContext().getTypeAlignInChars(allocType).getQuantity()))

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3293,7 +3293,7 @@ public:
     /// Checking the operand of a dynamic_cast or a typeid expression.  Must be
     /// null or an object within its lifetime.
     TCK_DynamicOperation,
-    /// Checking the 'this' poiner for a constructor call, including that the 
+    /// Checking the 'this' poiner for a constructor call, including that the
     /// alignment is greater or equal to the targets minimum alignment
     TCK_ConstructorCallOverloadedNew
   };

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3292,7 +3292,10 @@ public:
     TCK_NonnullAssign,
     /// Checking the operand of a dynamic_cast or a typeid expression.  Must be
     /// null or an object within its lifetime.
-    TCK_DynamicOperation
+    TCK_DynamicOperation,
+    /// Checking the 'this' poiner for a constructor call, including that the 
+    /// alignment is greater or equal to the targets minimum alignment
+    TCK_ConstructorCallOverloadedNew
   };
 
   /// Determine whether the pointer type check \p TCK permits null pointers.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -3295,7 +3295,7 @@ public:
     TCK_DynamicOperation,
     /// Checking the 'this' poiner for a constructor call, including that the
     /// alignment is greater or equal to the targets minimum alignment
-    TCK_ConstructorCallOverloadedNew
+    TCK_ConstructorCallMinimumAlign
   };
 
   /// Determine whether the pointer type check \p TCK permits null pointers.

--- a/compiler-rt/lib/ubsan/ubsan_checks.inc
+++ b/compiler-rt/lib/ubsan/ubsan_checks.inc
@@ -28,6 +28,7 @@ UBSAN_CHECK(NullptrAfterNonZeroOffset, "nullptr-after-nonzero-offset",
 UBSAN_CHECK(PointerOverflow, "pointer-overflow", "pointer-overflow")
 UBSAN_CHECK(MisalignedPointerUse, "misaligned-pointer-use", "alignment")
 UBSAN_CHECK(AlignmentAssumption, "alignment-assumption", "alignment")
+UBSAN_CHECK(AlignmentOnOverloadedNew, "alignment-new", "alignment")
 UBSAN_CHECK(InsufficientObjectSize, "insufficient-object-size", "object-size")
 UBSAN_CHECK(SignedIntegerOverflow, "signed-integer-overflow",
             "signed-integer-overflow")

--- a/compiler-rt/lib/ubsan/ubsan_checks.inc
+++ b/compiler-rt/lib/ubsan/ubsan_checks.inc
@@ -28,7 +28,7 @@ UBSAN_CHECK(NullptrAfterNonZeroOffset, "nullptr-after-nonzero-offset",
 UBSAN_CHECK(PointerOverflow, "pointer-overflow", "pointer-overflow")
 UBSAN_CHECK(MisalignedPointerUse, "misaligned-pointer-use", "alignment")
 UBSAN_CHECK(AlignmentAssumption, "alignment-assumption", "alignment")
-UBSAN_CHECK(AlignmentOnOverloadedNew, "alignment-new", "alignment")
+UBSAN_CHECK(MinumumAssumedAlignment, "minimum-assumed-alignment", "alignment")
 UBSAN_CHECK(InsufficientObjectSize, "insufficient-object-size", "object-size")
 UBSAN_CHECK(SignedIntegerOverflow, "signed-integer-overflow",
             "signed-integer-overflow")

--- a/compiler-rt/lib/ubsan/ubsan_handlers.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_handlers.cpp
@@ -73,14 +73,17 @@ enum TypeCheckKind {
   TCK_NonnullAssign,
   /// Checking the operand of a dynamic_cast or a typeid expression.  Must be
   /// null or an object within its lifetime.
-  TCK_DynamicOperation
+  TCK_DynamicOperation,
+  /// Checking the 'this' poiner for a constructor call, including that the 
+  /// alignment is greater or equal to the targets minimum alignment
+  TCK_ConstructorCallOverloadedNew
 };
 
 extern const char *const TypeCheckKinds[] = {
     "load of", "store to", "reference binding to", "member access within",
     "member call on", "constructor call on", "downcast of", "downcast of",
     "upcast of", "cast to virtual base of", "_Nonnull binding to",
-    "dynamic operation on"};
+    "dynamic operation on", "constructor call with pointer from overloaded operator new on"};
 }
 
 static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
@@ -94,7 +97,9 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
              ? ErrorType::NullPointerUseWithNullability
              : ErrorType::NullPointerUse;
   else if (Pointer & (Alignment - 1))
-    ET = ErrorType::MisalignedPointerUse;
+    ET = (Data->TypeCheckKind == TCK_ConstructorCallOverloadedNew)
+            ? ErrorType::AlignmentOnOverloadedNew
+            : ErrorType::MisalignedPointerUse;
   else
     ET = ErrorType::InsufficientObjectSize;
 
@@ -116,6 +121,12 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
   case ErrorType::NullPointerUseWithNullability:
     Diag(Loc, DL_Error, ET, "%0 null pointer of type %1")
         << TypeCheckKinds[Data->TypeCheckKind] << Data->Type;
+    break;
+  case ErrorType::AlignmentOnOverloadedNew:
+    Diag(Loc, DL_Error, ET, "%0 misaligned address %1 for type %2, "
+                        "which requires target minimum assumed alignment of %3")
+        << TypeCheckKinds[Data->TypeCheckKind] << (void *)Pointer
+        << Data->Type << Alignment;
     break;
   case ErrorType::MisalignedPointerUse:
     Diag(Loc, DL_Error, ET, "%0 misaligned address %1 for type %3, "

--- a/compiler-rt/lib/ubsan/ubsan_handlers.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_handlers.cpp
@@ -74,16 +74,25 @@ enum TypeCheckKind {
   /// Checking the operand of a dynamic_cast or a typeid expression.  Must be
   /// null or an object within its lifetime.
   TCK_DynamicOperation,
-  /// Checking the 'this' poiner for a constructor call, including that the 
+  /// Checking the 'this' poiner for a constructor call, including that the
   /// alignment is greater or equal to the targets minimum alignment
   TCK_ConstructorCallOverloadedNew
 };
 
 extern const char *const TypeCheckKinds[] = {
-    "load of", "store to", "reference binding to", "member access within",
-    "member call on", "constructor call on", "downcast of", "downcast of",
-    "upcast of", "cast to virtual base of", "_Nonnull binding to",
-    "dynamic operation on", "constructor call with pointer from overloaded operator new on"};
+    "load of",
+    "store to",
+    "reference binding to",
+    "member access within",
+    "member call on",
+    "constructor call on",
+    "downcast of",
+    "downcast of",
+    "upcast of",
+    "cast to virtual base of",
+    "_Nonnull binding to",
+    "dynamic operation on",
+    "constructor call with pointer from overloaded operator new on"};
 }
 
 static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
@@ -98,8 +107,8 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
              : ErrorType::NullPointerUse;
   else if (Pointer & (Alignment - 1))
     ET = (Data->TypeCheckKind == TCK_ConstructorCallOverloadedNew)
-            ? ErrorType::AlignmentOnOverloadedNew
-            : ErrorType::MisalignedPointerUse;
+             ? ErrorType::AlignmentOnOverloadedNew
+             : ErrorType::MisalignedPointerUse;
   else
     ET = ErrorType::InsufficientObjectSize;
 
@@ -123,10 +132,11 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
         << TypeCheckKinds[Data->TypeCheckKind] << Data->Type;
     break;
   case ErrorType::AlignmentOnOverloadedNew:
-    Diag(Loc, DL_Error, ET, "%0 misaligned address %1 for type %2, "
-                        "which requires target minimum assumed alignment of %3")
-        << TypeCheckKinds[Data->TypeCheckKind] << (void *)Pointer
-        << Data->Type << Alignment;
+    Diag(Loc, DL_Error, ET,
+         "%0 misaligned address %1 for type %2, "
+         "which requires target minimum assumed alignment of %3")
+        << TypeCheckKinds[Data->TypeCheckKind] << (void *)Pointer << Data->Type
+        << Alignment;
     break;
   case ErrorType::MisalignedPointerUse:
     Diag(Loc, DL_Error, ET, "%0 misaligned address %1 for type %3, "

--- a/compiler-rt/lib/ubsan/ubsan_handlers.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_handlers.cpp
@@ -92,7 +92,7 @@ extern const char *const TypeCheckKinds[] = {
     "cast to virtual base of",
     "_Nonnull binding to",
     "dynamic operation on",
-    "constructor call with pointer from overloaded operator new on"};
+    "constructor call with pointer from operator new on"};
 }
 
 static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
@@ -134,7 +134,7 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
   case ErrorType::AlignmentOnOverloadedNew:
     Diag(Loc, DL_Error, ET,
          "%0 misaligned address %1 for type %2, "
-         "which requires target minimum assumed alignment of %3")
+         "which requires target minimum assumed %3 byte alignment")
         << TypeCheckKinds[Data->TypeCheckKind] << (void *)Pointer << Data->Type
         << Alignment;
     break;

--- a/compiler-rt/lib/ubsan/ubsan_handlers.cpp
+++ b/compiler-rt/lib/ubsan/ubsan_handlers.cpp
@@ -76,7 +76,7 @@ enum TypeCheckKind {
   TCK_DynamicOperation,
   /// Checking the 'this' poiner for a constructor call, including that the
   /// alignment is greater or equal to the targets minimum alignment
-  TCK_ConstructorCallOverloadedNew
+  TCK_ConstructorCallMinimumAlign
 };
 
 extern const char *const TypeCheckKinds[] = {
@@ -106,8 +106,8 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
              ? ErrorType::NullPointerUseWithNullability
              : ErrorType::NullPointerUse;
   else if (Pointer & (Alignment - 1))
-    ET = (Data->TypeCheckKind == TCK_ConstructorCallOverloadedNew)
-             ? ErrorType::AlignmentOnOverloadedNew
+    ET = (Data->TypeCheckKind == TCK_ConstructorCallMinimumAlign)
+             ? ErrorType::MinumumAssumedAlignment
              : ErrorType::MisalignedPointerUse;
   else
     ET = ErrorType::InsufficientObjectSize;
@@ -131,7 +131,7 @@ static void handleTypeMismatchImpl(TypeMismatchData *Data, ValueHandle Pointer,
     Diag(Loc, DL_Error, ET, "%0 null pointer of type %1")
         << TypeCheckKinds[Data->TypeCheckKind] << Data->Type;
     break;
-  case ErrorType::AlignmentOnOverloadedNew:
+  case ErrorType::MinumumAssumedAlignment:
     Diag(Loc, DL_Error, ET,
          "%0 misaligned address %1 for type %2, "
          "which requires target minimum assumed %3 byte alignment")

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/minimum-alignment.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/minimum-alignment.cpp
@@ -1,0 +1,39 @@
+// RUN: %clangxx %gmlt -fsanitize=alignment %s -o %t
+// RUN: %run %t 2>&1 | FileCheck %s
+
+// UNSUPPORTED: i386 
+// UNSUPPORTED: armv7l
+
+// These sanitizers already overload the new operator so won't compile this test
+// UNSUPPORTED: ubsan-msan
+// UNSUPPORTED: ubsan-tsan
+
+#include <cassert>
+#include <cstdlib>
+
+void* operator new(std::size_t count)
+{
+    constexpr const size_t offset = 8;
+
+    // allocate a bit more so we can safely offset it
+    void* ptr = std::malloc(count + offset);
+
+    // verify malloc returned 16 bytes aligned mem
+    static_assert(__STDCPP_DEFAULT_NEW_ALIGNMENT__ == 16);
+    assert(((std::ptrdiff_t)ptr & (__STDCPP_DEFAULT_NEW_ALIGNMENT__ - 1)) == 0);
+
+    return (char*)ptr + offset;
+}
+
+struct Foo
+{
+    void* _cookie1, *_cookie2;
+};
+
+static_assert(alignof(Foo) == 8);
+int main()
+{
+    // CHECK: runtime error: constructor call with pointer from overloaded operator new on misaligned address 0x{{.*}} for type 'Foo', which requires target minimum assumed alignment of 16
+    Foo* f = new Foo;
+    return 0;
+}

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/minimum-alignment.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/minimum-alignment.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx %gmlt -fsanitize=alignment %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s
 
-// UNSUPPORTED: i386 
+// UNSUPPORTED: i386
 // UNSUPPORTED: armv7l
 
 // These sanitizers already overload the new operator so won't compile this test
@@ -11,29 +11,26 @@
 #include <cassert>
 #include <cstdlib>
 
-void* operator new(std::size_t count)
-{
-    constexpr const size_t offset = 8;
+void *operator new(std::size_t count) {
+  constexpr const size_t offset = 8;
 
-    // allocate a bit more so we can safely offset it
-    void* ptr = std::malloc(count + offset);
+  // allocate a bit more so we can safely offset it
+  void *ptr = std::malloc(count + offset);
 
-    // verify malloc returned 16 bytes aligned mem
-    static_assert(__STDCPP_DEFAULT_NEW_ALIGNMENT__ == 16);
-    assert(((std::ptrdiff_t)ptr & (__STDCPP_DEFAULT_NEW_ALIGNMENT__ - 1)) == 0);
+  // verify malloc returned 16 bytes aligned mem
+  static_assert(__STDCPP_DEFAULT_NEW_ALIGNMENT__ == 16);
+  assert(((std::ptrdiff_t)ptr & (__STDCPP_DEFAULT_NEW_ALIGNMENT__ - 1)) == 0);
 
-    return (char*)ptr + offset;
+  return (char *)ptr + offset;
 }
 
-struct Foo
-{
-    void* _cookie1, *_cookie2;
+struct Foo {
+  void *_cookie1, *_cookie2;
 };
 
 static_assert(alignof(Foo) == 8);
-int main()
-{
-    // CHECK: runtime error: constructor call with pointer from overloaded operator new on misaligned address 0x{{.*}} for type 'Foo', which requires target minimum assumed alignment of 16
-    Foo* f = new Foo;
-    return 0;
+int main() {
+  // CHECK: runtime error: constructor call with pointer from overloaded operator new on misaligned address 0x{{.*}} for type 'Foo', which requires target minimum assumed alignment of 16
+  Foo *f = new Foo;
+  return 0;
 }

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/minimum-alignment.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/minimum-alignment.cpp
@@ -30,7 +30,7 @@ struct Foo {
 
 static_assert(alignof(Foo) == 8);
 int main() {
-  // CHECK: runtime error: constructor call with pointer from overloaded operator new on misaligned address 0x{{.*}} for type 'Foo', which requires target minimum assumed alignment of 16
+  // CHECK: runtime error: constructor call with pointer from operator new on misaligned address 0x{{.*}} for type 'Foo', which requires target minimum assumed 16 byte alignment
   Foo *f = new Foo;
   return 0;
 }

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/misaligned.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/misaligned.cpp
@@ -101,7 +101,7 @@ int main(int, char **argv) {
     return s->f() && 0;
 
   case 'n':
-    // CHECK-NEW: misaligned.cpp:[[@LINE+4]]{{(:21)?}}: runtime error: constructor call on misaligned address [[PTR:0x[0-9a-f]*]] for type 'S', which requires 4 byte alignment
+    // CHECK-NEW: misaligned.cpp:[[@LINE+4]]{{(:21)?}}: runtime error: constructor call with pointer from operator new on misaligned address [[PTR:0x[0-9a-f]*]] for type 'S', which requires target minimum assumed 4 byte alignment
     // CHECK-NEW-NEXT: [[PTR]]: note: pointer points here
     // CHECK-NEW-NEXT: {{^ 00 00 00 01 02 03 04  05}}
     // CHECK-NEW-NEXT: {{^             \^}}


### PR DESCRIPTION
…ffset pointer

This problem and fix was originally raised on Phabricator, https://reviews.llvm.org/D116861, by belkiss. I wasn't able to find them on github or the discourse so I'm re-raising this. The problem was reported as follows

> I found that ubsan will report an incorrect alignment for a type in case it is allocated with the global operator new (without alignment), if we have it return an offset ptr.
> 
> I wrote a small repro: https://godbolt.org/z/n8Yh8eoaE
> 
> The type is aligned on 8 bytes (verified by static_assert on its alignof), but ubsan reports: "constructor call on misaligned address 0x000002af8fd8 for type 'Param', which requires 16 byte alignment".
