### PR TITLE
Work around documented Linux mmap bug.

### DIFF
--- a/llvm/lib/Support/MemoryBuffer.cpp
+++ b/llvm/lib/Support/MemoryBuffer.cpp
@@ -502,12 +502,11 @@ getOpenFileImpl(sys::fs::file_t FD, const Twine &Filename, uint64_t FileSize,
         new (NamedBufferAlloc(Filename)) MemoryBufferMMapFile<MB>(
             RequiresNullTerminator, FD, MapSize, Offset, EC));
     if (!EC) {
-#ifdef __linux__
-      // On Linux, mmap may return pages from the page cache that are not
-      // properly filled with trailing zeroes, if some prior user of the page
-      // wrote non-zero bytes. Detect this and don't use mmap in that case.
+      // On at least Linux, and possibly on other systems, mmap may return pages
+      // from the page cache that are not properly filled with trailing zeroes,
+      // if some prior user of the page wrote non-zero bytes. Detect this and
+      // don't use mmap in that case.
       if (!RequiresNullTerminator || *Result->getBufferEnd() == '\0')
-#endif
         return std::move(Result);
     }
   }

--- a/llvm/lib/Support/MemoryBuffer.cpp
+++ b/llvm/lib/Support/MemoryBuffer.cpp
@@ -501,8 +501,15 @@ getOpenFileImpl(sys::fs::file_t FD, const Twine &Filename, uint64_t FileSize,
     std::unique_ptr<MB> Result(
         new (NamedBufferAlloc(Filename)) MemoryBufferMMapFile<MB>(
             RequiresNullTerminator, FD, MapSize, Offset, EC));
-    if (!EC)
-      return std::move(Result);
+    if (!EC) {
+#ifdef __linux__
+      // On Linux, mmap may return pages from the page cache that are not
+      // properly filled with trailing zeroes, if some prior user of the page
+      // wrote non-zero bytes. Detect this and don't use mmap in that case.
+      if (!RequiresNullTerminator || *Result->getBufferEnd() == '\0')
+#endif
+        return std::move(Result);
+    }
   }
 
 #ifdef __MVS__


### PR DESCRIPTION
On Linux, mmap doesn't always zero-fill slack bytes ([man page]), despite being required to do so by POSIX. If the final page of a file is in the page cache and the bytes past the end of the file get overwritten by some process, those bytes then remain non-zero until the page falls out of the cache or another process overwrites them.

Stop trusting that mmap behaves properly on Linux and instead check whether the buffer was indeed properly terminated. If not, fall back to using `read` to read the file contents.

This fixes an obscure clang crash bug that can occur if another program (such as an editor) mmap's a source file and writes past the end of the mmap'd region shortly before clang or clangd attempts to parse the file.

 [man page]: https://man7.org/linux/man-pages/man2/mmap.2.html#BUGS