### PR TITLE
Revert "[BOLT][NFC] Register profiled functions once (#150622)"

### DIFF
--- a/bolt/include/bolt/Profile/DataAggregator.h
+++ b/bolt/include/bolt/Profile/DataAggregator.h
@@ -502,9 +502,6 @@ private:
   /// entries).
   void imputeFallThroughs();
 
-  /// Register profiled functions for lite mode.
-  void registerProfiledFunctions();
-
   /// Debugging dump methods
   void dump() const;
   void dump(const PerfBranchSample &Sample) const;

--- a/bolt/lib/Profile/DataAggregator.cpp
+++ b/bolt/lib/Profile/DataAggregator.cpp
@@ -581,26 +581,6 @@ void DataAggregator::imputeFallThroughs() {
     outs() << "BOLT-INFO: imputed " << InferredTraces << " traces\n";
 }
 
-void DataAggregator::registerProfiledFunctions() {
-  DenseSet<uint64_t> Addrs;
-  for (const auto &Trace : llvm::make_first_range(Traces)) {
-    if (Trace.Branch != Trace::FT_ONLY &&
-        Trace.Branch != Trace::FT_EXTERNAL_ORIGIN)
-      Addrs.insert(Trace.Branch);
-    Addrs.insert(Trace.From);
-  }
-
-  for (const auto [PC, _] : BasicSamples)
-    Addrs.insert(PC);
-
-  for (const PerfMemSample &MemSample : MemSamples)
-    Addrs.insert(MemSample.PC);
-
-  for (const uint64_t Addr : Addrs)
-    if (BinaryFunction *Func = getBinaryFunctionContainingAddress(Addr))
-      Func->setHasProfileAvailable();
-}
-
 Error DataAggregator::preprocessProfile(BinaryContext &BC) {
   this->BC = &BC;
 
@@ -623,7 +603,6 @@ Error DataAggregator::preprocessProfile(BinaryContext &BC) {
       exit(0);
   }
 
-  registerProfiledFunctions();
   return Error::success();
 }
 
@@ -1368,6 +1347,10 @@ std::error_code DataAggregator::parseAggregatedLBREntry() {
   }
 
   const uint64_t FromOffset = Addr[0]->Offset;
+  BinaryFunction *FromFunc = getBinaryFunctionContainingAddress(FromOffset);
+  if (FromFunc)
+    FromFunc->setHasProfileAvailable();
+
   int64_t Count = Counters[0];
   int64_t Mispreds = Counters[1];
 
@@ -1377,6 +1360,11 @@ std::error_code DataAggregator::parseAggregatedLBREntry() {
     NumTotalSamples += Count;
     return std::error_code();
   }
+
+  const uint64_t ToOffset = Addr[1]->Offset;
+  BinaryFunction *ToFunc = getBinaryFunctionContainingAddress(ToOffset);
+  if (ToFunc)
+    ToFunc->setHasProfileAvailable();
 
   /// For fall-through types, adjust locations to match Trace container.
   if (Type == FT || Type == FT_EXTERNAL_ORIGIN || Type == FT_EXTERNAL_RETURN) {
@@ -1625,6 +1613,9 @@ std::error_code DataAggregator::parseBranchEvents() {
   Traces.reserve(TraceMap.size());
   for (const auto &[Trace, Info] : TraceMap) {
     Traces.emplace_back(Trace, Info);
+    for (const uint64_t Addr : {Trace.Branch, Trace.From})
+      if (BinaryFunction *BF = getBinaryFunctionContainingAddress(Addr))
+        BF->setHasProfileAvailable();
   }
   clear(TraceMap);
 
@@ -1685,6 +1676,9 @@ std::error_code DataAggregator::parseBasicEvents() {
       continue;
     ++NumTotalSamples;
 
+    if (BinaryFunction *BF = getBinaryFunctionContainingAddress(Sample->PC))
+      BF->setHasProfileAvailable();
+
     ++BasicSamples[Sample->PC];
     EventNames.insert(Sample->EventName);
   }
@@ -1721,6 +1715,9 @@ std::error_code DataAggregator::parseMemEvents() {
     ErrorOr<PerfMemSample> Sample = parseMemSample();
     if (std::error_code EC = Sample.getError())
       return EC;
+
+    if (BinaryFunction *BF = getBinaryFunctionContainingAddress(Sample->PC))
+      BF->setHasProfileAvailable();
 
     MemSamples.emplace_back(std::move(Sample.get()));
   }


### PR DESCRIPTION
In perf2bolt, we are observing sporadic crashes in the recently added
registerProfiledFunctions from #150622. Addresses provided by the
hardware (from LBR) might be -1, which clashes with what LLVM uses in
DenseSet as empty tombstones records. This causes DenseSet to assert
with "can't insert empty tombstone into map" when ingesting this
data. Revert this change for now to unbreak perf2bolt.