### PR TITLE
Enable early elimination of fall-through B in ARM analyzeBranch

### DIFF
--- a/llvm/test/CodeGen/ARM/ifcvt-diamond-unanalyzable-common.mir
+++ b/llvm/test/CodeGen/ARM/ifcvt-diamond-unanalyzable-common.mir
@@ -33,7 +33,6 @@ body:             |
   ; CHECK-NEXT:   t2CMPri $sp, 34, 14 /* CC::al */, $noreg, implicit-def $cpsr
   ; CHECK-NEXT:   t2Bcc %bb.2, 1 /* CC::ne */, $cpsr
   ; CHECK-NEXT:   t2Bcc %bb.2, 2 /* CC::hs */, killed $cpsr
-  ; CHECK-NEXT:   t2B %bb.1, 14 /* CC::al */, $noreg
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   INLINEASM &"", 1 /* sideeffect attdialect */


### PR DESCRIPTION
This patch enables the ARM backend’s analyzeBranch() to fold away an unconditional branch targeting its layout-successor, mirroring the existing AArch64 behavior. When AllowModify is true and a lone B instruction jumps to the very next block in layout, the branch is removed and the block simply falls through.