### PR TITLE
[mlir][EmitC] Expand the MemRefToEmitC pass - Lowering `reinterpret_cast`

### DIFF
--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
@@ -319,24 +319,11 @@ struct ConvertReinterpretCastOp final
     };
 
     auto srcPtr = createPointerFromEmitcArray(srcArrayValue);
-    // 1. Create a TypeAttr for the target type.
-    TypeAttr targetTypeAttr =
-        TypeAttr::get(emitc::PointerType::get(targetInEmitC));
-    IntegerAttr resty = rewriter.getIndexAttr(0);
 
-    // 2. Create an ArrayAttr with the TypeAttr. This will be the
-    // templateArgsAttr.
-    ArrayAttr templateArgsAttr = rewriter.getArrayAttr({targetTypeAttr});
+    auto castCall = rewriter.create<emitc::CastOp>(
+        loc, emitc::PointerType::get(targetInEmitC), srcPtr.getResult());
 
-    auto reinterpretCastCall = rewriter.create<emitc::CallOpaqueOp>(
-        loc,
-        /*result types=*/TypeRange{emitc::PointerType::get(targetInEmitC)},
-        /*callee=*/"reinterpret_cast",
-        /*args*/ rewriter.getArrayAttr({resty}),
-        /*template_args=*/templateArgsAttr,
-        /*operands=*/ValueRange{srcPtr.getResult()});
-
-    rewriter.replaceOp(castOp, reinterpretCastCall.getResults());
+    rewriter.replaceOp(castOp, castCall);
     return success();
   }
 };

--- a/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
+++ b/mlir/lib/Conversion/MemRefToEmitC/MemRefToEmitC.cpp
@@ -21,7 +21,9 @@
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Value.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/FormatVariadic.h"
 #include <cstdint>
+#include <string>
 
 using namespace mlir;
 
@@ -269,6 +271,85 @@ struct ConvertLoad final : public OpConversionPattern<memref::LoadOp> {
   }
 };
 
+struct ConvertReinterpretCastOp final
+    : public OpConversionPattern<memref::ReinterpretCastOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::ReinterpretCastOp castOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    MemRefType srcType = cast<MemRefType>(castOp.getSource().getType());
+
+    MemRefType targetMemRefType =
+        cast<MemRefType>(castOp.getResult().getType());
+
+    auto srcInEmitC = convertMemRefType(srcType, getTypeConverter());
+    auto targetInEmitC =
+        convertMemRefType(targetMemRefType, getTypeConverter());
+    if (!srcInEmitC || !targetInEmitC) {
+      return rewriter.notifyMatchFailure(castOp.getLoc(),
+                                         "cannot convert memref type");
+    }
+    Location loc = castOp.getLoc();
+
+    auto srcArrayValue =
+        cast<TypedValue<emitc::ArrayType>>(adaptor.getSource());
+
+    emitc::ConstantOp zeroIndex = rewriter.create<emitc::ConstantOp>(
+        loc, rewriter.getIndexType(), rewriter.getIndexAttr(0));
+
+    auto createPointerFromEmitcArray =
+        [loc, &rewriter, &zeroIndex](
+            mlir::TypedValue<emitc::ArrayType> arrayValue) -> emitc::ApplyOp {
+      int64_t rank = arrayValue.getType().getRank();
+      llvm::SmallVector<mlir::Value> indices;
+      for (int i = 0; i < rank; ++i) {
+        indices.push_back(zeroIndex);
+      }
+
+      emitc::SubscriptOp subPtr = rewriter.create<emitc::SubscriptOp>(
+          loc, arrayValue, mlir::ValueRange(indices));
+      emitc::ApplyOp ptr = rewriter.create<emitc::ApplyOp>(
+          loc, emitc::PointerType::get(arrayValue.getType().getElementType()),
+          rewriter.getStringAttr("&"), subPtr);
+
+      return ptr;
+    };
+    auto [strides, offset] = targetMemRefType.getStridesAndOffset();
+    // Value offsetValue = rewriter.create<emitc::ConstantOp>(
+    //     loc, rewriter.getIndexType(), rewriter.getIndexAttr(offset));
+
+    auto srcPtr = createPointerFromEmitcArray(srcArrayValue);
+    // emitc::PointerType targetPointerType =
+    //     emitc::PointerType::get(srcArrayValue.getType().getElementType());
+
+    auto dimensions = targetMemRefType.getShape();
+    std::string reinterpretCastName = llvm::formatv(
+        "reinterpret_cast<{0}(*)", srcArrayValue.getType().getElementType());
+    std::string dimensionsStr;
+    for (auto dim : dimensions) {
+      dimensionsStr += llvm::formatv("[{0}]", dim);
+    }
+    reinterpretCastName += llvm::formatv("{0}>", dimensionsStr);
+    reinterpretCastName += ">";
+
+    reinterpretCastName += llvm::formatv("{0}", srcPtr->getResult(0));
+
+    std::string outputStr = llvm::formatv(
+        "{0}(*){1}", srcArrayValue.getType().getElementType(), dimensionsStr);
+    auto outputType = emitc::PointerType::get(
+        emitc::OpaqueType::get(rewriter.getContext(), outputStr));
+
+    emitc::ConstantOp reinterpretOp = rewriter.create<emitc::ConstantOp>(
+        loc, outputType,
+        emitc::OpaqueAttr::get(rewriter.getContext(), reinterpretCastName));
+
+    rewriter.replaceOp(castOp, reinterpretOp.getResult());
+    return success();
+  }
+};
+
 struct ConvertStore final : public OpConversionPattern<memref::StoreOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -321,5 +402,6 @@ void mlir::populateMemRefToEmitCTypeConversion(TypeConverter &typeConverter) {
 void mlir::populateMemRefToEmitCConversionPatterns(
     RewritePatternSet &patterns, const TypeConverter &converter) {
   patterns.add<ConvertAlloca, ConvertAlloc, ConvertGlobal, ConvertGetGlobal,
-               ConvertLoad, ConvertStore>(converter, patterns.getContext());
+               ConvertLoad, ConvertReinterpretCastOp, ConvertStore>(
+      converter, patterns.getContext());
 }

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -1756,6 +1756,20 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
 
 LogicalResult CppEmitter::emitVariableDeclaration(Location loc, Type type,
                                                   StringRef name) {
+  if (auto pType = dyn_cast<emitc::PointerType>(type)) {
+    if (auto aType = dyn_cast<emitc::ArrayType>(pType.getPointee())) {
+      if (failed(emitType(loc, aType.getElementType())))
+        return failure();
+      os << " (*" << name << ")";
+      for (auto dim : aType.getShape())
+        os << "[" << dim << "]";
+      return success();
+    }
+    if (failed(emitType(loc, pType.getPointee())))
+      return failure();
+    os << " *" << name;
+    return success();
+  }
   if (auto arrType = dyn_cast<emitc::ArrayType>(type)) {
     if (failed(emitType(loc, arrType.getElementType())))
       return failure();

--- a/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-reinterpret-cast.mlir
+++ b/mlir/test/Conversion/MemRefToEmitC/memref-to-emitc-reinterpret-cast.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-opt -convert-memref-to-emitc %s -split-input-file | FileCheck %s
+
+func.func @casting(%arg0: memref<999xi32>) {
+  %reinterpret_cast_5 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1, 1, 999], strides: [999, 999, 1] : memref<999xi32> to memref<1x1x999xi32>
+  return
+}
+
+//CHECK: module {
+//CHECK-NEXT:   func.func @casting(%arg0: memref<999xi32>) {
+//CHECK-NEXT:     %0 = builtin.unrealized_conversion_cast %arg0 : memref<999xi32> to !emitc.array<999xi32>
+//CHECK-NEXT:     %1 = "emitc.constant"() <{value = 0 : index}> : () -> index
+//CHECK-NEXT:     %2 = emitc.subscript %0[%1] : (!emitc.array<999xi32>, index) -> !emitc.lvalue<i32>
+//CHECK-NEXT:     %3 = emitc.apply "&"(%2) : (!emitc.lvalue<i32>) -> !emitc.ptr<i32>
+//CHECK-NEXT:     %4 = emitc.call_opaque "reinterpret_cast"(%3) {args = [0 : index], template_args = [!emitc.ptr<!emitc.array<1x1x999xi32>>]} : (!emitc.ptr<i32>) -> !emitc.ptr<!emitc.array<1x1x999xi32>>
+//CHECK-NEXT:     return
+


### PR DESCRIPTION
This patch lowers `memref.reinterpret_cast`.
From:
```
func.func @casting(%arg0: memref<999xi32>) {
  %reinterpret_cast_5 = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1, 1, 999], strides: [999, 999, 1] : memref<999xi32> to memref<1x1x999xi32>
  return
}
```
To:
```cpp
void casting(int32_t v1[999]) {
  std::size_t v2 = 0;
  int32_t* v3 = &v1[v2];
  int32_t(*v4)[1][1][999]  = reinterpret_cast<int32_t(*)[1][1][999]>(v3);
  return;
}
```