### PR TITLE
[CIR] Change unreachable to diagnostic for ill-equipped clang

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -132,6 +132,8 @@ def err_fe_no_pch_in_dir : Error<
     "no suitable precompiled header file found in directory '%0'">;
 def err_fe_action_not_available : Error<
     "action %0 not compiled in">;
+def err_fe_cir_not_built : Error<"clang IR support not available, rebuild "
+                                 "clang with -DCLANG_ENABLE_CIR=ON">;
 def err_fe_invalid_multiple_actions : Error<
     "'%0' action ignored; '%1' action specified previously">;
 def err_fe_invalid_alignment : Error<

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -81,7 +81,8 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
 #if CLANG_ENABLE_CIR
     return std::make_unique<cir::EmitCIRAction>();
 #else
-    llvm_unreachable("CIR suppport not built into clang");
+    CI.getDiagnostics().Report(diag::err_fe_cir_not_built);
+    return nullptr;
 #endif
   case EmitHTML:               return std::make_unique<HTMLPrintAction>();
   case EmitLLVM: {

--- a/clang/test/Frontend/cir-not-built.c
+++ b/clang/test/Frontend/cir-not-built.c
@@ -2,7 +2,7 @@
 // instead of crashing.
 
 // This test should only run when CIR support is NOT enabled
-// REQUIRES: !cir-support
+// UNSUPPORTED: cir-support
 
 // RUN: not %clang_cc1 -emit-cir %s 2>&1 | FileCheck %s
 // CHECK: error: clang IR support not available, rebuild clang with -DCLANG_ENABLE_CIR=ON

--- a/clang/test/Frontend/cir-not-built.c
+++ b/clang/test/Frontend/cir-not-built.c
@@ -1,0 +1,12 @@
+// Test that using -emit-cir when clang is not built with CIR support gives a proper error message
+// instead of crashing.
+
+// This test should only run when CIR support is NOT enabled
+// REQUIRES: !cir-support
+
+// RUN: not %clang_cc1 -emit-cir %s 2>&1 | FileCheck %s
+// CHECK: error: clang IR support not available, rebuild clang with -DCLANG_ENABLE_CIR=ON
+
+int main(void) {
+  return 0;
+}

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -224,6 +224,10 @@ if config.clang_staticanalyzer:
         )
     )
 
+# ClangIR support
+if config.clang_enable_cir:
+    config.available_features.add("cir-support")
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 config.substitutions.append(


### PR DESCRIPTION
Using a clang binary that wasn't built with MLIR/CIR support and using `-emit-cir` results in an unfriendly crash. We really shouldn't be abusing unreachables to inform users of mis-configurations.

Add a new frontend diagnostic that informs users with ill-equipped clang binaries that they need to rebuild with `-DCLANG_ENABLE_CIR=ON` to use `-emit-cir`. This matches how the frontend action diagnostics behave in `ExecuteCompilerInvocation.cpp` with `err_fe_action_not_available`.

Getting a worthwhile test involves adding some plumbing for a new `cir-support` lit option.

As an aside, does Clang have any methods of hiding features in `--help` when they are not compiled in? It might be a good idea to hide `-emit-cir` from the help text in this case.