### PR TITLE
[IR] Remove Intrinsic::getDeclaration

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -104,12 +104,6 @@ namespace Intrinsic {
   LLVM_ABI Function *getOrInsertDeclaration(Module *M, ID id,
                                             ArrayRef<Type *> Tys = {});
 
-  LLVM_DEPRECATED("Use getOrInsertDeclaration instead",
-                  "getOrInsertDeclaration")
-  inline Function *getDeclaration(Module *M, ID id, ArrayRef<Type *> Tys = {}) {
-    return getOrInsertDeclaration(M, id, Tys);
-  }
-
   /// Look up the Function declaration of the intrinsic \p id in the Module
   /// \p M and return it if it exists. Otherwise, return nullptr. This version
   /// supports non-overloaded intrinsics.


### PR DESCRIPTION
Intrinsic::getDeclaration has been deprecated for more than 9 months
since:

  commit b9f08676abcfbb226c67b5ac2a7bc5b33254b915
  Author: Rahul Joshi <rjoshi@nvidia.com>
  Date:   Mon Oct 14 19:21:28 2024 -0700

This patch removes it.  I'm not aware of any downstream use AFAIK.
