### PR TITLE
[libclc] Fix libclc bitcodes install on windows when cmake msvc generator is used

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -426,7 +426,7 @@ function(add_libclc_builtin_set)
   add_dependencies( ${ARG_PARENT_TARGET} prepare-${ARG_TRIPLE} )
 
   install(
-    FILES ${libclc_builtins_lib}
+    FILES $<TARGET_PROPERTY:prepare-${obj_suffix},TARGET_FILE>
     DESTINATION "${CMAKE_INSTALL_DATADIR}/clc"
   )
 


### PR DESCRIPTION
Install command in tools\libclc\cmake_install.cmake is not correctly configured as there is a unresolved $(Configuration):
  file(INSTALL ... FILES "/$(Configuration)/lib/../lib/clang/22/lib/libclc/amdgcn--amdhsa.bc")
The issue is not observable if ninja generator is used.
It is likely due to $libclc_builtins_lib} isn't generated yet during cmake configuration.
This PR uses the TARGET_FILE as install input.