### PR TITLE
Update debug output string

### DIFF
--- a/clang-tools-extra/clangd/CodeComplete.cpp
+++ b/clang-tools-extra/clangd/CodeComplete.cpp
@@ -2434,6 +2434,9 @@ CompletionItem CodeCompletion::render(const CodeCompleteOptions &Opts) const {
 }
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const CodeCompletion &C) {
+  OS << "Signature: " << "\"" << C.Signature << "\", "
+     << "SnippetSuffix: " << "\"" << C.SnippetSuffix << "\""
+     << ", Rendered:";
   // For now just lean on CompletionItem.
   return OS << C.render(CodeCompleteOptions());
 }


### PR DESCRIPTION
Include `Signature` and `SnippetSuffix` in the output, when test fails


Before: <pre><code>Value of: Result.Completions
Expected: has 1 element that (named (Name: "bar")) and (signature (S: "(A self, int arg)")) and (snippet suffix (Text: "(${1:A self}, ${2:int arg})"))
  Actual: {  bar - {"detail":"void","filterText":"bar","insertText":"bar","insertTextFormat":1,"kind":2,"label":" bar","labelDetails":{"detail":"(int arg)"},"score":0.65507817268371582,"sortText":"40d84cccbar","textEdit":{"newText":"bar","range":{"end":{"character":13,"line":10},"start":{"character":11,"line":10}}}} }, whose element #0 doesn't match
</code></pre>

After: <pre><code>Value of: Result.Completions
Expected: has 1 element that (named (Name: "bar")) and (signature (S: "(A self, int arg)")) and (snippet suffix (Text: "(${1:A self}, ${2:int arg})"))
  Actual: { <mark>Signature: "(A self, int arg)", SnippetSuffix: "", Rendered:</mark> bar - {"detail":"void","filterText":"bar","insertText":"bar","insertTextFormat":1,"kind":2,"label":" bar","labelDetails":{"detail":"(A self, int arg)"},"score":0.65507817268371582,"sortText":"40d84cccbar","textEdit":{"newText":"bar","range":{"end":{"character":13,"line":10},"start":{"character":11,"line":10}}}} }, whose element #0 doesn't match
</code></pre>