### PR TITLE
[BOLT] Improve regexp in link_fdata.py

### DIFF
--- a/bolt/test/link_fdata.py
+++ b/bolt/test/link_fdata.py
@@ -27,7 +27,7 @@ args = parser.parse_args()
 
 # Regexes to extract FDATA lines from input and parse FDATA and pre-aggregated
 # profile data
-prefix_pat = re.compile(f"^# {args.prefix}: (.*)")
+prefix_pat = re.compile(f"^(#|//) {args.prefix}: (.*)")
 
 # FDATA records:
 # <is symbol?> <closest elf symbol or DSO name> <relative FROM address>
@@ -56,7 +56,7 @@ with open(args.input, "r") as f:
         prefix_match = prefix_pat.match(line)
         if not prefix_match:
             continue
-        profile_line = prefix_match.group(1)
+        profile_line = prefix_match.group(2)
         fdata_match = fdata_pat.match(profile_line)
         preagg_match = preagg_pat.match(profile_line)
         nolbr_match = nolbr_pat.match(profile_line)

--- a/bolt/test/timers.c
+++ b/bolt/test/timers.c
@@ -1,22 +1,21 @@
-/* This test checks timers for metadata manager phases.
-# RUN: %clang %cflags %s -o %t.exe
-# RUN: link_fdata %s %t.exe %t.fdata
-# RUN: llvm-bolt %t.exe -o %t.null --data %t.fdata -w %t.yaml --time-rewrite \
-# RUN:   2>&1 | FileCheck %s
-# RUN: link_fdata %s %t.exe %t.preagg PREAGG
-# RUN: perf2bolt %t.exe -o %t.null -p %t.preagg --pa --time-rewrite \
-# RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-P2B
+// This test checks timers for metadata manager phases.
+// RUN: %clang %cflags %s -o %t.exe
+// RUN: link_fdata %s %t.exe %t.fdata
+// RUN: llvm-bolt %t.exe -o %t.null --data %t.fdata -w %t.yaml --time-rewrite \
+// RUN:   2>&1 | FileCheck %s
+// RUN: link_fdata %s %t.exe %t.preagg PREAGG
+// RUN: perf2bolt %t.exe -o %t.null -p %t.preagg --pa --time-rewrite \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-P2B
 
-# CHECK-DAG: update metadata post-emit
-# CHECK-DAG: process section metadata
-# CHECK-DAG: process metadata pre-CFG
-# CHECK-DAG: process metadata post-CFG
-# CHECK-DAG: finalize metadata pre-emit
+// CHECK-DAG: update metadata post-emit
+// CHECK-DAG: process section metadata
+// CHECK-DAG: process metadata pre-CFG
+// CHECK-DAG: process metadata post-CFG
+// CHECK-DAG: finalize metadata pre-emit
 
-# CHECK-P2B-DAG: process section metadata
-# CHECK-P2B-DAG: process metadata pre-CFG
+// CHECK-P2B-DAG: process section metadata
+// CHECK-P2B-DAG: process metadata pre-CFG
 
-# FDATA: 0 [unknown] 0 1 main 0 1 0
-# PREAGG: B X:0 #main# 1 0
-*/
+// FDATA: 0 [unknown] 0 1 main 0 1 0
+// PREAGG: B X:0 #main# 1 0
 int main() { return 0; }


### PR DESCRIPTION
FileCheck accepts both '#' and '//' as leading chars for commands, but link_fdata.py only searched for lines starting with '#'. This changes the regexps in link_fdata.py to mirror FileCheck's behaviour.
The comment syntax in test/timers.c is modified to present this capability.