### PR TITLE
[clang][bytecode][NFC] Dead blocks are always uninitialized

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBlock.cpp
+++ b/clang/lib/AST/ByteCode/InterpBlock.cpp
@@ -133,8 +133,7 @@ DeadBlock::DeadBlock(DeadBlock *&Root, Block *Blk)
 }
 
 void DeadBlock::free() {
-  if (B.IsInitialized)
-    B.invokeDtor();
+  assert(!B.isInitialized());
 
   if (Prev)
     Prev->Next = Next;

--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -85,6 +85,7 @@ void InterpState::deallocate(Block *B) {
   if (B->IsInitialized)
     B->invokeDtor();
 
+  assert(!B->isInitialized());
   if (B->hasPointers()) {
     size_t Size = B->getSize();
     // Allocate a new block, transferring over pointers.
@@ -94,10 +95,7 @@ void InterpState::deallocate(Block *B) {
     // Since the block doesn't hold any actual data anymore, we can just
     // memcpy() everything over.
     std::memcpy(D->rawData(), B->rawData(), B->getSize());
-    D->B.IsInitialized = B->IsInitialized;
-
-    // We moved the contents over to the DeadBlock.
-    B->IsInitialized = false;
+    D->B.IsInitialized = false;
   }
 }
 


### PR DESCRIPTION
We always call the descriptor dtor before, so they are never initialized.