### PR TITLE
[LV] Stop using the legacy cost model for udiv + friends

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4278,6 +4278,9 @@ VectorizationFactor LoopVectorizationPlanner::selectVectorizationFactor() {
           if (!VPI)
             continue;
           switch (VPI->getOpcode()) {
+          // Selects are not modelled in the legacy cost model if they are
+          // inserted for reductions.
+          case Instruction::Select:
           case VPInstruction::ActiveLaneMask:
           case VPInstruction::ExplicitVectorLength:
             C += VPI->cost(VF, CostCtx);

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4278,14 +4278,13 @@ VectorizationFactor LoopVectorizationPlanner::selectVectorizationFactor() {
           if (!VPI)
             continue;
           switch (VPI->getOpcode()) {
-          // Selects are not modelled in the legacy cost model if they are
-          // inserted for reductions.
+          // Selects are only modelled in the legacy cost model for safe
+          // divisors.
           case Instruction::Select: {
-            VPValue *V =
-                R.getNumDefinedValues() == 1 ? R.getVPSingleValue() : nullptr;
-            if (V && V->getNumUsers() == 1) {
-              if (auto *UR = dyn_cast<VPWidenRecipe>(*V->user_begin())) {
-                switch (UR->getOpcode()) {
+            VPValue *VPV = VPI->getVPSingleValue();
+            if (VPV->getNumUsers() == 1) {
+              if (auto *WR = dyn_cast<VPWidenRecipe>(*VPV->user_begin())) {
+                switch (WR->getOpcode()) {
                 case Instruction::UDiv:
                 case Instruction::SDiv:
                 case Instruction::URem:

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -1033,8 +1033,12 @@ InstructionCost VPInstruction::computeCost(ElementCount VF,
     // TODO: It may be possible to improve this by analyzing where the
     // condition operand comes from.
     CmpInst::Predicate Pred = CmpInst::BAD_ICMP_PREDICATE;
-    auto *CondTy = toVectorTy(Ctx.Types.inferScalarType(getOperand(0)), VF);
-    auto *VecTy = toVectorTy(Ctx.Types.inferScalarType(getOperand(1)), VF);
+    auto *CondTy = Ctx.Types.inferScalarType(getOperand(0));
+    auto *VecTy = Ctx.Types.inferScalarType(getOperand(1));
+    if (!vputils::onlyFirstLaneUsed(this)) {
+      CondTy = toVectorTy(CondTy, VF);
+      VecTy = toVectorTy(VecTy, VF);
+    }
     return Ctx.TTI.getCmpSelInstrCost(Instruction::Select, VecTy, CondTy, Pred,
                                       Ctx.CostKind);
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2116,6 +2116,7 @@ InstructionCost VPWidenRecipe::computeCost(ElementCount VF,
     // predication, then the only way we can even create a vplan is to insert
     // a select on the second input operand to ensure we use the value of 1
     // for the inactive lanes. The select will be costed separately.
+  case Instruction::FNeg:
   case Instruction::Add:
   case Instruction::FAdd:
   case Instruction::Sub:


### PR DESCRIPTION
In VPWidenRecipe::computeCost for the instructions udiv, sdiv, urem and srem we fall back on the legacy cost unnecessarily. At this point we know that the vplan must be functionally correct, i.e. if the divide/remainder is not safe to speculatively execute then we must have either:

1. Scalarised the operation, in which case we wouldn't be using a VPWidenRecipe, or
2. We've inserted a select for the second operand to ensure we don't fault through divide-by-zero.

For 2) it's necessary to add the select operation to VPInstruction::computeCost so that we mirror the cost of the legacy cost model. The only problem with this is that we also generate selects in vplan for predicated loops with reductions, which *aren't* accounted for in the legacy cost model. In order to prevent asserts firing I've also added the selects to precomputeCosts to ensure the legacy costs match the vplan costs for reductions.