### PR TITLE
[clang][bytecode][NFC] Use an existing local variable

### DIFF
--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -94,7 +94,7 @@ void InterpState::deallocate(Block *B) {
     auto *D = new (Memory) DeadBlock(DeadBlocks, B);
     // Since the block doesn't hold any actual data anymore, we can just
     // memcpy() everything over.
-    std::memcpy(D->rawData(), B->rawData(), B->getSize());
+    std::memcpy(D->rawData(), B->rawData(), Size);
     D->B.IsInitialized = false;
   }
 }


### PR DESCRIPTION
Instead of calling getSize() again.