### PR TITLE
[lldb][SymbolFileDWARF][NFC] Add FindFunctionDefinition helper

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -799,7 +799,7 @@ ResolveFunctionCallLabel(const FunctionCallLabel &label,
   auto sc_or_err = symbol_file->ResolveFunctionCallLabel(label);
   if (!sc_or_err)
     return llvm::joinErrors(
-        llvm::createStringError("failed to resolve function by UID"),
+        llvm::createStringError("failed to resolve function by UID:"),
         sc_or_err.takeError());
 
   SymbolContextList sc_list;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -373,6 +373,13 @@ public:
   /// Returns the DWARFIndex for this symbol, if it exists.
   DWARFIndex *getIndex() { return m_index.get(); }
 
+private:
+  /// Find the definition DIE for the specified \c label in this
+  /// SymbolFile.
+  ///
+  /// \returns A valid definition DIE on success.
+  DWARFDIE FindFunctionDefinition(const FunctionCallLabel &label);
+
 protected:
   SymbolFileDWARF(const SymbolFileDWARF &) = delete;
   const SymbolFileDWARF &operator=(const SymbolFileDWARF &) = delete;


### PR DESCRIPTION
Factors out code to locate a definition DIE from a `FunctionCallLabel` into a helper. This will be useful for an upcoming refactor that extends `FindFunctionDefinition`.

Drive-by:
* adjusts some error messages in the `FunctionCallLabel` support code.