### PR TITLE
[X86] Fix equality operator ambiguity

### DIFF
--- a/llvm/lib/Target/X86/X86WinEHUnwindV2.cpp
+++ b/llvm/lib/Target/X86/X86WinEHUnwindV2.cpp
@@ -303,7 +303,7 @@ runAnalysisOnFuncOrFunclet(MachineFunction &MF, MachineFunction::iterator &Iter,
         if (State == FunctionState::InEpilog) {
           Register Reg = MI.getOperand(0).getReg();
           if (HasStackAlloc && (PoppedRegCount == 0) &&
-              !llvm::is_contained(PushedRegs, Reg)) {
+              !llvm::is_contained(PushedRegs, Reg.id())) {
             // If this is a pop that doesn't correspond to the set of pushed
             // registers, then assume it was used to adjust the stack pointer.
             HasStackDealloc = true;


### PR DESCRIPTION
When compiling LLVM `21.1.0-rc2` on Ubuntu 22.04 with Clang 14 in C++20 mode I noticed a single compilation error. I know that the LLVM project is currently only at C++17 but given this is the only issue and trivial to fix I wonder if it could be included in `main` and later into the `release/21.x` branch.

To reproduce install Ubuntu 22.04 with the `clang-14` package provided by Ubuntu.

Then configure:
```
cmake ../llvm -DCMAKE_C_COMPILER=clang-14 -DCMAKE_CXX_COMPILER=clang++-14 -DCMAKE_CXX_STANDARD=20 -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD=X86 '-DLLVM_ENABLE_PROJECTS=clang;clang-tools-extra'
```

and build:
```
ninja lib/Target/X86/CMakeFiles/LLVMX86CodeGen.dir/X86WinEHUnwindV2.cpp.o
```

You'll see the following error:
```
[1/45] Building CXX object lib/Target/X86/CMakeFiles/LLVMX86CodeGen.dir/X86WinEHUnwindV2.cpp.o
FAILED: lib/Target/X86/CMakeFiles/LLVMX86CodeGen.dir/X86WinEHUnwindV2.cpp.o
/usr/bin/clang++-14 -DEXPERIMENTAL_KEY_INSTRUCTIONS -DGTEST_HAS_RTTI=0 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Isrc/llvm-project/_build/lib/Target/X86 -Isrc/llvm-project/llvm/lib/Target/X86 -Isrc/llvm-project/_build/include -Isrc/llvm-project/llvm/include -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -fvisibility=hidden  -fno-exceptions -funwind-tables -fno-rtti -std=c++20 -MD -MT lib/Target/X86/CMakeFiles/LLVMX86CodeGen.dir/X86WinEHUnwindV2.cpp.o -MF lib/Target/X86/CMakeFiles/LLVMX86CodeGen.dir/X86WinEHUnwindV2.cpp.o.d -o lib/Target/X86/CMakeFiles/LLVMX86CodeGen.dir/X86WinEHUnwindV2.cpp.o -c src/llvm-project/llvm/lib/Target/X86/X86WinEHUnwindV2.cpp
src/llvm-project/llvm/lib/Target/X86/X86WinEHUnwindV2.cpp:234:62: error: use of overloaded operator '!=' is ambiguous (with operand types 'long' and 'llvm::Register')
          if (PushedRegs[PushedRegs.size() - PoppedRegCount] !=
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
src/llvm-project/llvm/include/llvm/CodeGen/Register.h:126:18: note: candidate function (with reversed parameter order)
  constexpr bool operator==(unsigned Other) const { return Reg == Other; }
                 ^
src/llvm-project/llvm/include/llvm/CodeGen/Register.h:128:18: note: candidate function (with reversed parameter order)
  constexpr bool operator==(int Other) const { return Reg == unsigned(Other); }
                 ^
src/llvm-project/llvm/include/llvm/CodeGen/Register.h:131:18: note: candidate function (with reversed parameter order)
  constexpr bool operator==(MCPhysReg Other) const {
                 ^
src/llvm-project/llvm/include/llvm/CodeGen/Register.h:110:18: note: candidate function (with reversed parameter order)
  constexpr bool operator==(const Register &Other) const {
                 ^
src/llvm-project/llvm/include/llvm/CodeGen/Register.h:116:18: note: candidate function (with reversed parameter order)
  constexpr bool operator==(const MCRegister &Other) const {
                 ^
```

The failing code has been added by @dpaoliello in #143577.