### PR TITLE
[AArch64][SVE] Remove isSVECC() in favour of changing the calling convention

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -1356,8 +1356,7 @@ void AArch64AsmPrinter::emitFunctionEntryLabel() {
   if (TT.isOSBinFormatELF() &&
       (MF->getFunction().getCallingConv() == CallingConv::AArch64_VectorCall ||
        MF->getFunction().getCallingConv() ==
-           CallingConv::AArch64_SVE_VectorCall ||
-       MF->getInfo<AArch64FunctionInfo>()->isSVECC())) {
+           CallingConv::AArch64_SVE_VectorCall)) {
     auto *TS =
         static_cast<AArch64TargetStreamer *>(OutStreamer->getTargetStreamer());
     TS->emitDirectiveVariantPCS(CurrentFnSym);

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -209,10 +209,6 @@ class AArch64FunctionInfo final : public MachineFunctionInfo {
 
   bool IsMTETagged = false;
 
-  /// The function has Scalable Vector or Scalable Predicate register argument
-  /// or return type
-  bool IsSVECC = false;
-
   /// The frame-index for the TPIDR2 object used for lazy saves.
   TPIDR2Object TPIDR2;
 
@@ -279,9 +275,6 @@ public:
 
   int64_t getStreamingVGIdx() const { return StreamingVGIdx; };
   void setStreamingVGIdx(unsigned FrameIdx) { StreamingVGIdx = FrameIdx; };
-
-  bool isSVECC() const { return IsSVECC; };
-  void setIsSVECC(bool s) { IsSVECC = s; };
 
   TPIDR2Object &getTPIDR2Obj() { return TPIDR2; }
 

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.cpp
@@ -104,8 +104,6 @@ AArch64RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
     if (MF->getFunction().getCallingConv() ==
         CallingConv::AArch64_SVE_VectorCall)
       return CSR_Win_AArch64_SVE_AAPCS_SaveList;
-    if (MF->getInfo<AArch64FunctionInfo>()->isSVECC())
-      return CSR_Win_AArch64_SVE_AAPCS_SaveList;
     return CSR_Win_AArch64_AAPCS_SaveList;
   }
   if (MF->getFunction().getCallingConv() == CallingConv::AArch64_VectorCall)
@@ -148,8 +146,6 @@ AArch64RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
     // This is for OSes other than Windows; Windows is a separate case further
     // above.
     return CSR_AArch64_AAPCS_X18_SaveList;
-  if (MF->getInfo<AArch64FunctionInfo>()->isSVECC())
-    return CSR_AArch64_SVE_AAPCS_SaveList;
   return CSR_AArch64_AAPCS_SaveList;
 }
 
@@ -165,8 +161,7 @@ AArch64RegisterInfo::getDarwinCalleeSavedRegs(const MachineFunction *MF) const {
   if (MF->getFunction().getCallingConv() == CallingConv::AArch64_VectorCall)
     return CSR_Darwin_AArch64_AAVPCS_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::AArch64_SVE_VectorCall)
-    report_fatal_error(
-        "Calling convention SVE_VectorCall is unsupported on Darwin.");
+    return CSR_Darwin_AArch64_SVE_AAPCS_SaveList;
   if (MF->getFunction().getCallingConv() ==
           CallingConv::AArch64_SME_ABI_Support_Routines_PreserveMost_From_X0)
     report_fatal_error(
@@ -205,8 +200,6 @@ AArch64RegisterInfo::getDarwinCalleeSavedRegs(const MachineFunction *MF) const {
     return CSR_Darwin_AArch64_RT_AllRegs_SaveList;
   if (MF->getFunction().getCallingConv() == CallingConv::Win64)
     return CSR_Darwin_AArch64_AAPCS_Win64_SaveList;
-  if (MF->getInfo<AArch64FunctionInfo>()->isSVECC())
-    return CSR_Darwin_AArch64_SVE_AAPCS_SaveList;
   return CSR_Darwin_AArch64_AAPCS_SaveList;
 }
 

--- a/llvm/test/CodeGen/AArch64/arm64-darwin-cc.ll
+++ b/llvm/test/CodeGen/AArch64/arm64-darwin-cc.ll
@@ -1,9 +1,7 @@
 ; RUN: sed -e "s,CC,cfguard_checkcc,g" %s | not --crash llc -mtriple=arm64-apple-darwin -o - 2>&1 | FileCheck %s --check-prefix=CFGUARD
-; RUN: sed -e "s,CC,aarch64_sve_vector_pcs,g" %s | not --crash llc -mtriple=arm64-apple-darwin -o - 2>&1 | FileCheck %s --check-prefix=SVE_VECTOR_PCS
 
 define CC void @f0() {
   unreachable
 }
 
 ; CFGUARD: Calling convention CFGuard_Check is unsupported on Darwin.
-; SVE_VECTOR_PCS: Calling convention SVE_VectorCall is unsupported on Darwin.

--- a/llvm/test/CodeGen/AArch64/win-sve.ll
+++ b/llvm/test/CodeGen/AArch64/win-sve.ll
@@ -784,8 +784,6 @@ define void @f6(<vscale x 2 x i64> %x, [8 x i64] %pad, i64 %n9) personality ptr 
 ; CHECK-NEXT:  .seh_proc f6
 ; CHECK-NEXT:    .seh_handler __CxxFrameHandler3, @unwind, @except
 ; CHECK-NEXT:  // %bb.0:
-; CHECK-NEXT:    sub sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
 ; CHECK-NEXT:    addvl sp, sp, #-18
 ; CHECK-NEXT:    .seh_allocz 18
 ; CHECK-NEXT:    str p4, [sp] // 2-byte Folded Spill
@@ -853,21 +851,21 @@ define void @f6(<vscale x 2 x i64> %x, [8 x i64] %pad, i64 %n9) personality ptr 
 ; CHECK-NEXT:    add x29, sp, #16
 ; CHECK-NEXT:    .seh_add_fp 16
 ; CHECK-NEXT:    .seh_endprologue
-; CHECK-NEXT:    sub sp, sp, #64
+; CHECK-NEXT:    sub sp, sp, #80
 ; CHECK-NEXT:    mov x0, #-2 // =0xfffffffffffffffe
 ; CHECK-NEXT:    addvl x8, x29, #18
 ; CHECK-NEXT:    mov x19, sp
-; CHECK-NEXT:    stur x0, [x8, #16]
+; CHECK-NEXT:    stur x0, [x8]
 ; CHECK-NEXT:    addvl x8, x29, #18
-; CHECK-NEXT:    ldr x1, [x8, #32]
-; CHECK-NEXT:  .Ltmp0:
+; CHECK-NEXT:    ldr x1, [x8, #16]
+; CHECK-NEXT:  .Ltmp0: // EH_LABEL
 ; CHECK-NEXT:    add x0, x19, #0
 ; CHECK-NEXT:    bl g6
-; CHECK-NEXT:  .Ltmp1:
+; CHECK-NEXT:  .Ltmp1: // EH_LABEL
 ; CHECK-NEXT:  // %bb.1: // %invoke.cont
 ; CHECK-NEXT:    .seh_startepilogue
-; CHECK-NEXT:    add sp, sp, #64
-; CHECK-NEXT:    .seh_stackalloc 64
+; CHECK-NEXT:    add sp, sp, #80
+; CHECK-NEXT:    .seh_stackalloc 80
 ; CHECK-NEXT:    ldp x29, x30, [sp, #16] // 16-byte Folded Reload
 ; CHECK-NEXT:    .seh_save_fplr 16
 ; CHECK-NEXT:    ldr x28, [sp, #8] // 8-byte Folded Reload
@@ -932,12 +930,8 @@ define void @f6(<vscale x 2 x i64> %x, [8 x i64] %pad, i64 %n9) personality ptr 
 ; CHECK-NEXT:    .seh_save_preg p14, 10
 ; CHECK-NEXT:    ldr p15, [sp, #11, mul vl] // 2-byte Folded Reload
 ; CHECK-NEXT:    .seh_save_preg p15, 11
-; CHECK-NEXT:    add sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
 ; CHECK-NEXT:    addvl sp, sp, #18
 ; CHECK-NEXT:    .seh_allocz 18
-; CHECK-NEXT:    add sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
 ; CHECK-NEXT:    .seh_endepilogue
 ; CHECK-NEXT:    ret
 ; CHECK-NEXT:    .seh_endfunclet
@@ -1157,64 +1151,6 @@ define void @f8(<vscale x 2 x i64> %v) {
 ; CHECK-NEXT:    .seh_endfunclet
 ; CHECK-NEXT:    .seh_endproc
   call void asm "", "~{d8}"()
-  ret void
-}
-
-define void @f9(<vscale x 2 x i64> %v, ...) {
-; CHECK-LABEL: f9:
-; CHECK:       .seh_proc f9
-; CHECK-NEXT:  // %bb.0:
-; CHECK-NEXT:    sub sp, sp, #64
-; CHECK-NEXT:    .seh_stackalloc 64
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    .seh_allocz 1
-; CHECK-NEXT:    str z8, [sp] // 16-byte Folded Spill
-; CHECK-NEXT:    .seh_save_zreg z8, 0
-; CHECK-NEXT:    str x30, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    .seh_save_reg_x x30, 16
-; CHECK-NEXT:    .seh_endprologue
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    add x9, sp, #8
-; CHECK-NEXT:    str x2, [x8, #32]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x0, [x8, #16]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x1, [x8, #24]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x3, [x8, #40]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x4, [x8, #48]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x5, [x8, #56]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x6, [x8, #64]
-; CHECK-NEXT:    addvl x8, sp, #1
-; CHECK-NEXT:    str x7, [x8, #72]
-; CHECK-NEXT:    add x8, sp, #16
-; CHECK-NEXT:    addvl x8, x8, #1
-; CHECK-NEXT:    str x8, [sp, #8]
-; CHECK-NEXT:    //APP
-; CHECK-NEXT:    //NO_APP
-; CHECK-NEXT:    .seh_startepilogue
-; CHECK-NEXT:    ldr x30, [sp] // 8-byte Folded Reload
-; CHECK-NEXT:    .seh_save_reg x30, 0
-; CHECK-NEXT:    add sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
-; CHECK-NEXT:    ldr z8, [sp] // 16-byte Folded Reload
-; CHECK-NEXT:    .seh_save_zreg z8, 0
-; CHECK-NEXT:    add sp, sp, #64
-; CHECK-NEXT:    .seh_stackalloc 64
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    .seh_allocz 1
-; CHECK-NEXT:    add sp, sp, #64
-; CHECK-NEXT:    .seh_stackalloc 64
-; CHECK-NEXT:    .seh_endepilogue
-; CHECK-NEXT:    ret
-; CHECK-NEXT:    .seh_endfunclet
-; CHECK-NEXT:    .seh_endproc
-  %va_list = alloca ptr
-  call void @llvm.va_start.p0(ptr %va_list)
-  call void asm "", "r,~{d8},~{memory}"(ptr %va_list)
   ret void
 }
 
@@ -1546,40 +1482,33 @@ define tailcc void @f15(double %d, <vscale x 4 x i32> %vs, [9 x i64], i32 %i) {
 ; CHECK-LABEL: f15:
 ; CHECK:       .seh_proc f15
 ; CHECK-NEXT:  // %bb.0:
-; CHECK-NEXT:    addvl sp, sp, #-1
-; CHECK-NEXT:    .seh_allocz 1
-; CHECK-NEXT:    str z8, [sp] // 16-byte Folded Spill
-; CHECK-NEXT:    .seh_save_zreg z8, 0
-; CHECK-NEXT:    str x28, [sp, #-16]! // 8-byte Folded Spill
-; CHECK-NEXT:    .seh_save_reg_x x28, 16
+; CHECK-NEXT:    str x28, [sp, #-32]! // 8-byte Folded Spill
+; CHECK-NEXT:    .seh_save_reg_x x28, 32
 ; CHECK-NEXT:    str x30, [sp, #8] // 8-byte Folded Spill
 ; CHECK-NEXT:    .seh_save_reg x30, 8
-; CHECK-NEXT:    sub sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
+; CHECK-NEXT:    str d8, [sp, #16] // 8-byte Folded Spill
+; CHECK-NEXT:    .seh_save_freg d8, 16
 ; CHECK-NEXT:    addvl sp, sp, #-1
 ; CHECK-NEXT:    .seh_allocz 1
 ; CHECK-NEXT:    .seh_endprologue
-; CHECK-NEXT:    addvl x8, sp, #2
+; CHECK-NEXT:    addvl x8, sp, #1
+; CHECK-NEXT:    addvl x9, sp, #1
 ; CHECK-NEXT:    //APP
 ; CHECK-NEXT:    //NO_APP
-; CHECK-NEXT:    stp d0, d0, [sp, #8]
 ; CHECK-NEXT:    ldr w8, [x8, #104]
-; CHECK-NEXT:    str w8, [sp, #8]
+; CHECK-NEXT:    str d0, [x9, #24]
+; CHECK-NEXT:    addvl x9, sp, #1
+; CHECK-NEXT:    str d0, [sp]
+; CHECK-NEXT:    str w8, [x9, #24]
 ; CHECK-NEXT:    .seh_startepilogue
 ; CHECK-NEXT:    addvl sp, sp, #1
 ; CHECK-NEXT:    .seh_allocz 1
-; CHECK-NEXT:    add sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
+; CHECK-NEXT:    ldr d8, [sp, #16] // 8-byte Folded Reload
+; CHECK-NEXT:    .seh_save_freg d8, 16
 ; CHECK-NEXT:    ldr x30, [sp, #8] // 8-byte Folded Reload
 ; CHECK-NEXT:    .seh_save_reg x30, 8
-; CHECK-NEXT:    ldr x28, [sp] // 8-byte Folded Reload
-; CHECK-NEXT:    .seh_save_reg x28, 0
-; CHECK-NEXT:    add sp, sp, #16
-; CHECK-NEXT:    .seh_stackalloc 16
-; CHECK-NEXT:    ldr z8, [sp] // 16-byte Folded Reload
-; CHECK-NEXT:    .seh_save_zreg z8, 0
-; CHECK-NEXT:    addvl sp, sp, #1
-; CHECK-NEXT:    .seh_allocz 1
+; CHECK-NEXT:    ldr x28, [sp], #32 // 8-byte Folded Reload
+; CHECK-NEXT:    .seh_save_reg_x x28, 32
 ; CHECK-NEXT:    add sp, sp, #80
 ; CHECK-NEXT:    .seh_stackalloc 80
 ; CHECK-NEXT:    .seh_endepilogue


### PR DESCRIPTION
We essentially had two different ways of setting the calling convention for a function: the proper calling convention and a target flag to override the calling convention. Removing the flag in favour of setting the calling convention is an NFC except in some (somewhat unsupported) cases.

The cases that needed changes were:

1. Removing the "SVE_VectorCall is unsupported on Darwin" failure
    - The previous method of setting the SVE calling convention means that it has been possible to use the SVE CC on Darwin for a while now (and some tests depend on that).
    - It is unclear if this really should be allowed or not (but does pose a question for SME functions on Darwin that have SVE params)
2. Removing a Windows SVE test that used varargs and SVE arguments
   - This is not supported (and already fails LowerCall)
3. Updating the checks for a Windows + exceptions SVE test

Note: The updated logic intends to closely match the code in `AArch64TargetLowering::LowerCall` (which also changes the CC).