### PR TITLE
[OpenMP][Test][NFC] output tool data as hex to improve readibility

### DIFF
--- a/openmp/runtime/test/ompt/callback.h
+++ b/openmp/runtime/test/ompt/callback.h
@@ -176,8 +176,8 @@ static void print_ids(int level)
   char buffer[2048];
   format_task_type(task_type, buffer);
   if (frame) {
-    printf("%" PRIu64 ": task level %d: parallel_id=%" PRIu64
-           ", task_id=%" PRIu64 ", exit_frame=%p, reenter_frame=%p, "
+    printf("%" PRIu64 ": task level %d: parallel_id=%" PRIx64
+           ", task_id=%" PRIx64 ", exit_frame=%p, reenter_frame=%p, "
            "task_type=%s=%d, thread_num=%d\n",
            ompt_get_thread_data()->value, level,
            exists_task ? task_parallel_data->value : 0,
@@ -557,8 +557,8 @@ on_ompt_callback_sync_region(
   }
   uint64_t parallel_data_value = parallel_data ? parallel_data->value : 0;
   const char *begin_or_end = (endpoint == ompt_scope_begin) ? "begin" : "end";
-  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_%s_%s: parallel_id=%" PRIu64
-         ", task_id=%" PRIu64 ", codeptr_ra=%p\n",
+  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_%s_%s: parallel_id=%" PRIx64
+         ", task_id=%" PRIx64 ", codeptr_ra=%p\n",
          ompt_get_thread_data()->value, ompt_sync_region_t_values[kind],
          begin_or_end, parallel_data_value, task_data->value, codeptr_ra);
   switch (kind) {
@@ -595,7 +595,7 @@ on_ompt_callback_sync_region_wait(
   uint64_t parallel_data_value = parallel_data ? parallel_data->value : 0;
   const char *begin_or_end = (endpoint == ompt_scope_begin) ? "begin" : "end";
   printf("%" PRIu64 ":" _TOOL_PREFIX
-         " ompt_event_wait_%s_%s: parallel_id=%" PRIu64 ", task_id=%" PRIu64
+         " ompt_event_wait_%s_%s: parallel_id=%" PRIx64 ", task_id=%" PRIx64
          ", codeptr_ra=%p\n",
          ompt_get_thread_data()->value, ompt_sync_region_t_values[kind],
          begin_or_end, parallel_data_value, task_data->value, codeptr_ra);
@@ -609,16 +609,16 @@ static void on_ompt_callback_reduction(ompt_sync_region_t kind,
   switch (endpoint) {
   case ompt_scope_begin:
     printf("%" PRIu64 ":" _TOOL_PREFIX
-           " ompt_event_reduction_begin: parallel_id=%" PRIu64
-           ", task_id=%" PRIu64 ", codeptr_ra=%p\n",
+           " ompt_event_reduction_begin: parallel_id=%" PRIx64
+           ", task_id=%" PRIx64 ", codeptr_ra=%p\n",
            ompt_get_thread_data()->value,
            (parallel_data) ? parallel_data->value : 0, task_data->value,
            codeptr_ra);
     break;
   case ompt_scope_end:
     printf("%" PRIu64 ":" _TOOL_PREFIX
-           " ompt_event_reduction_end: parallel_id=%" PRIu64
-           ", task_id=%" PRIu64 ", codeptr_ra=%p\n",
+           " ompt_event_reduction_end: parallel_id=%" PRIx64
+           ", task_id=%" PRIx64 ", codeptr_ra=%p\n",
            ompt_get_thread_data()->value,
            (parallel_data) ? parallel_data->value : 0, task_data->value,
            codeptr_ra);
@@ -662,7 +662,7 @@ on_ompt_callback_cancel(
   else if(flags & ompt_cancel_discarded_task)
     second_flag_value = ompt_cancel_flag_t_values[6];
 
-  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_cancel: task_data=%" PRIu64
+  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_cancel: task_id=%" PRIx64
          ", flags=%s|%s=%" PRIu32 ", codeptr_ra=%p\n",
          ompt_get_thread_data()->value, task_data->value, first_flag_value,
          second_flag_value, flags, codeptr_ra);
@@ -696,15 +696,15 @@ on_ompt_callback_implicit_task(
           printf("%s\n", "0: parallel_data initially not null");
         parallel_data->value = ompt_get_unique_id();
         printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_initial_task_begin: parallel_id=%" PRIu64
-               ", task_id=%" PRIu64 ", actual_parallelism=%" PRIu32
+               " ompt_event_initial_task_begin: parallel_id=%" PRIx64
+               ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32
                ", index=%" PRIu32 ", flags=%" PRIu32 "\n",
                ompt_get_thread_data()->value, parallel_data->value,
                task_data->value, team_size, thread_num, flags);
       } else {
         printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_implicit_task_begin: parallel_id=%" PRIu64
-               ", task_id=%" PRIu64 ", team_size=%" PRIu32
+               " ompt_event_implicit_task_begin: parallel_id=%" PRIx64
+               ", task_id=%" PRIx64 ", team_size=%" PRIu32
                ", thread_num=%" PRIu32 "\n",
                ompt_get_thread_data()->value, parallel_data->value,
                task_data->value, team_size, thread_num);
@@ -714,16 +714,16 @@ on_ompt_callback_implicit_task(
     case ompt_scope_end:
       if(flags & ompt_task_initial){
         printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_initial_task_end: parallel_id=%" PRIu64
-               ", task_id=%" PRIu64 ", actual_parallelism=%" PRIu32
+               " ompt_event_initial_task_end: parallel_id=%" PRIx64
+               ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32
                ", index=%" PRIu32 "\n",
                ompt_get_thread_data()->value,
                (parallel_data) ? parallel_data->value : 0, task_data->value,
                team_size, thread_num);
       } else {
         printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_implicit_task_end: parallel_id=%" PRIu64
-               ", task_id=%" PRIu64 ", team_size=%" PRIu32
+               " ompt_event_implicit_task_end: parallel_id=%" PRIx64
+               ", task_id=%" PRIx64 ", team_size=%" PRIu32
                ", thread_num=%" PRIu32 "\n",
                ompt_get_thread_data()->value,
                (parallel_data) ? parallel_data->value : 0, task_data->value,
@@ -799,14 +799,14 @@ on_ompt_callback_work(
   switch(endpoint)
   {
   case ompt_scope_begin:
-    printf("%" PRIu64 ":" _TOOL_PREFIX " %s_begin: parallel_id=%" PRIu64
-           ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
+    printf("%" PRIu64 ":" _TOOL_PREFIX " %s_begin: parallel_id=%" PRIx64
+           ", task_id=%" PRIx64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
            ompt_get_thread_data()->value, ompt_work_events_t_values[wstype],
            parallel_data->value, task_data->value, codeptr_ra, count);
     break;
   case ompt_scope_end:
-    printf("%" PRIu64 ":" _TOOL_PREFIX " %s_end: parallel_id=%" PRIu64
-           ", task_id=%" PRIu64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
+    printf("%" PRIu64 ":" _TOOL_PREFIX " %s_end: parallel_id=%" PRIx64
+           ", task_id=%" PRIx64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
            ompt_get_thread_data()->value, ompt_work_events_t_values[wstype],
            parallel_data->value, task_data->value, codeptr_ra, count);
     break;
@@ -844,10 +844,10 @@ static void on_ompt_callback_dispatch(
   default:
     event_name = "ompt_ws_loop_iteration_begin";
   }
-  printf("%" PRIu64 ":" _TOOL_PREFIX
-         " %s: parallel_id=%" PRIu64 ", task_id=%" PRIu64
-         ", codeptr_ra=%p, chunk_start=%" PRIu64 ", chunk_iterations=%" PRIu64
-         "\n", ompt_get_thread_data()->value, event_name, parallel_data->value,
+  printf("%" PRIu64 ":" _TOOL_PREFIX " %s: parallel_id=%" PRIx64
+         ", task_id=%" PRIx64 ", codeptr_ra=%p, chunk_start=%" PRIu64
+         ", chunk_iterations=%" PRIu64 "\n",
+         ompt_get_thread_data()->value, event_name, parallel_data->value,
          task_data->value, codeptr_ra,
          dispatch_chunk ? dispatch_chunk->start : 0,
          dispatch_chunk ? dispatch_chunk->iterations : 0);
@@ -861,14 +861,14 @@ static void on_ompt_callback_masked(ompt_scope_endpoint_t endpoint,
   {
     case ompt_scope_begin:
       printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_masked_begin: parallel_id=%" PRIu64
-             ", task_id=%" PRIu64 ", codeptr_ra=%p\n",
+             " ompt_event_masked_begin: parallel_id=%" PRIx64
+             ", task_id=%" PRIx64 ", codeptr_ra=%p\n",
              ompt_get_thread_data()->value, parallel_data->value,
              task_data->value, codeptr_ra);
       break;
     case ompt_scope_end:
       printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_masked_end: parallel_id=%" PRIu64 ", task_id=%" PRIu64
+             " ompt_event_masked_end: parallel_id=%" PRIx64 ", task_id=%" PRIx64
              ", codeptr_ra=%p\n",
              ompt_get_thread_data()->value, parallel_data->value,
              task_data->value, codeptr_ra);
@@ -890,9 +890,9 @@ static void on_ompt_callback_parallel_begin(
   const char *event = (flag & ompt_parallel_team) ? "parallel" : "teams";
   const char *size = (flag & ompt_parallel_team) ? "team_size" : "num_teams";
   printf("%" PRIu64 ":" _TOOL_PREFIX
-         " ompt_event_%s_begin: parent_task_id=%" PRIu64
+         " ompt_event_%s_begin: parent_task_id=%" PRIx64
          ", parent_task_frame.exit=%p, parent_task_frame.reenter=%p, "
-         "parallel_id=%" PRIu64 ", requested_%s=%" PRIu32
+         "parallel_id=%" PRIx64 ", requested_%s=%" PRIu32
          ", codeptr_ra=%p, invoker=%d\n",
          ompt_get_thread_data()->value, event, encountering_task_data->value,
          encountering_task_frame->exit_frame.ptr,
@@ -905,8 +905,8 @@ static void on_ompt_callback_parallel_end(ompt_data_t *parallel_data,
                                           int flag, const void *codeptr_ra) {
   int invoker = flag & 0xF;
   const char *event = (flag & ompt_parallel_team) ? "parallel" : "teams";
-  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_%s_end: parallel_id=%" PRIu64
-         ", task_id=%" PRIu64 ", invoker=%d, codeptr_ra=%p\n",
+  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_%s_end: parallel_id=%" PRIx64
+         ", task_id=%" PRIx64 ", invoker=%d, codeptr_ra=%p\n",
          ompt_get_thread_data()->value, event, parallel_data->value,
          encountering_task_data->value, invoker, codeptr_ra);
 }
@@ -929,9 +929,9 @@ on_ompt_callback_task_create(
 
   printf(
       "%" PRIu64 ":" _TOOL_PREFIX
-      " ompt_event_task_create: parent_task_id=%" PRIu64
+      " ompt_event_task_create: parent_task_id=%" PRIx64
       ", parent_task_frame.exit=%p, parent_task_frame.reenter=%p, "
-      "new_task_id=%" PRIu64
+      "new_task_id=%" PRIx64
       ", codeptr_ra=%p, task_type=%s=%d, has_dependences=%s\n",
       ompt_get_thread_data()->value,
       encountering_task_data ? encountering_task_data->value : 0,
@@ -948,16 +948,17 @@ on_ompt_callback_task_schedule(
     ompt_data_t *second_task_data)
 {
   printf("%" PRIu64 ":" _TOOL_PREFIX
-         " ompt_event_task_schedule: first_task_id=%" PRIu64
-         ", second_task_id=%" PRIu64 ", prior_task_status=%s=%d\n",
+         " ompt_event_task_schedule: first_task_id=%" PRIx64
+         ", second_task_id=%" PRIx64 ", prior_task_status=%s=%d\n",
          ompt_get_thread_data()->value, first_task_data->value,
          (second_task_data ? second_task_data->value : -1),
          ompt_task_status_t_values[prior_task_status], prior_task_status);
   if (prior_task_status == ompt_task_complete ||
       prior_task_status == ompt_task_late_fulfill ||
       prior_task_status == ompt_taskwait_complete) {
-    printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_task_end: task_id=%" PRIu64
-           "\n", ompt_get_thread_data()->value, first_task_data->value);
+    printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_task_end: task_id=%" PRIx64
+           "\n",
+           ompt_get_thread_data()->value, first_task_data->value);
   }
 }
 
@@ -983,7 +984,7 @@ on_ompt_callback_dependences(
   }
   if (ndeps > 0)
     progress[-2] = 0;
-  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_dependences: task_id=%" PRIu64
+  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_dependences: task_id=%" PRIx64
          ", deps=[%s], ndeps=%d\n",
          ompt_get_thread_data()->value, task_data->value, buffer, ndeps);
 }
@@ -994,8 +995,8 @@ on_ompt_callback_task_dependence(
   ompt_data_t *second_task_data)
 {
   printf("%" PRIu64 ":" _TOOL_PREFIX
-         " ompt_event_task_dependence_pair: first_task_id=%" PRIu64
-         ", second_task_id=%" PRIu64 "\n",
+         " ompt_event_task_dependence_pair: first_task_id=%" PRIx64
+         ", second_task_id=%" PRIx64 "\n",
          ompt_get_thread_data()->value, first_task_data->value,
          second_task_data->value);
 }
@@ -1046,7 +1047,7 @@ on_ompt_callback_control_tool(
   ompt_data_t *task_data;
   while (ompt_get_task_info(task_level, NULL, (ompt_data_t **)&task_data, NULL,
                             NULL, NULL)) {
-    printf("%" PRIu64 ":" _TOOL_PREFIX " task level %d: task_id=%" PRIu64 "\n",
+    printf("%" PRIu64 ":" _TOOL_PREFIX " task level %d: task_id=%" PRIx64 "\n",
            ompt_get_thread_data()->value, task_level, task_data->value);
     task_level++;
   }
@@ -1056,8 +1057,8 @@ on_ompt_callback_control_tool(
   ompt_data_t *parallel_data;
   while (ompt_get_parallel_info(parallel_level, (ompt_data_t **)&parallel_data,
                                 NULL)) {
-    printf("%" PRIu64 ":" _TOOL_PREFIX " parallel level %d: parallel_id=%" PRIu64
-           "\n",
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " parallel level %d: parallel_id=%" PRIx64 "\n",
            ompt_get_thread_data()->value, parallel_level, parallel_data->value);
     parallel_level++;
   }

--- a/openmp/runtime/test/ompt/callback.h
+++ b/openmp/runtime/test/ompt/callback.h
@@ -39,15 +39,11 @@ static const char *ompt_task_status_t_values[] = {
     "ompt_task_switch", // 7
     "ompt_taskwait_complete" // 8
 };
-static const char* ompt_cancel_flag_t_values[] = {
-  "ompt_cancel_parallel",
-  "ompt_cancel_sections",
-  "ompt_cancel_loop",
-  "ompt_cancel_taskgroup",
-  "ompt_cancel_activated",
-  "ompt_cancel_detected",
-  "ompt_cancel_discarded_task"
-};
+static const char *ompt_cancel_flag_t_values[] = {
+    "ompt_cancel_parallel",      "ompt_cancel_sections",
+    "ompt_cancel_loop",          "ompt_cancel_taskgroup",
+    "ompt_cancel_activated",     "ompt_cancel_detected",
+    "ompt_cancel_discarded_task"};
 
 static const char *ompt_work_t_values[] = {"undefined",
                                            "ompt_work_loop",
@@ -88,9 +84,32 @@ static const char *ompt_dependence_type_t_values[36] = {
     "ompt_dependence_type_source", // 5
     "ompt_dependence_type_sink", // 6
     "ompt_dependence_type_inoutset", // 7
-    "", "", "", "", "", "", // 8-13
-    "", "", "", "", "", "", "", "", "", "", // 14-23
-    "", "", "", "", "", "", "", "", "", "", // 24-33
+    "",
+    "",
+    "",
+    "",
+    "",
+    "", // 8-13
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "", // 14-23
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "", // 24-33
     "ompt_dependence_type_out_all_memory", // 34
     "ompt_dependence_type_inout_all_memory" // 35
 };
@@ -165,8 +184,7 @@ void assert_frame_flags(int enterf, int exitf) {
   assert(exitf == (ompt_frame_application | ompt_frame_cfa) ||
          exitf == (ompt_frame_runtime | ompt_frame_cfa));
 }
-static void print_ids(int level)
-{
+static void print_ids(int level) {
   int task_type, thread_num;
   ompt_frame_t *frame;
   ompt_data_t *task_parallel_data;
@@ -193,18 +211,21 @@ static void print_ids(int level)
   printf("%" PRIu64 ": __builtin_frame_address(%d)=%p\n",                      \
          ompt_get_thread_data()->value, level, get_frame_address(level))
 
-// clang (version 5.0 and above) adds an intermediate function call with debug flag (-g)
+// clang (version 5.0 and above) adds an intermediate function call with debug
+// flag (-g)
 #if defined(TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN)
-  #if defined(DEBUG) && defined(__clang__) && __clang_major__ >= 5
-    #define print_frame_from_outlined_fn(level) print_frame(level+1)
-  #else
-    #define print_frame_from_outlined_fn(level) print_frame(level)
-  #endif
+#if defined(DEBUG) && defined(__clang__) && __clang_major__ >= 5
+#define print_frame_from_outlined_fn(level) print_frame(level + 1)
+#else
+#define print_frame_from_outlined_fn(level) print_frame(level)
+#endif
 
-  #if defined(__clang__) && __clang_major__ >= 5
-    #warning "Clang 5.0 and later add an additional wrapper for outlined functions when compiling with debug information."
-    #warning "Please define -DDEBUG iff you manually pass in -g to make the tests succeed!"
-  #endif
+#if defined(__clang__) && __clang_major__ >= 5
+#warning                                                                       \
+    "Clang 5.0 and later add an additional wrapper for outlined functions when compiling with debug information."
+#warning                                                                       \
+    "Please define -DDEBUG iff you manually pass in -g to make the tests succeed!"
+#endif
 #endif
 
 // This macro helps to define a label at the current position that can be used
@@ -218,36 +239,39 @@ static void print_ids(int level)
 //
 // (The empty block between "#pragma omp ..." and the __asm__ statement is a
 // workaround for a bug in the Intel Compiler.)
-#define define_ompt_label(id) \
-  {} \
-  __asm__("nop"); \
-ompt_label_##id:
+#define define_ompt_label(id)                                                  \
+  {                                                                            \
+  }                                                                            \
+  __asm__("nop");                                                              \
+  ompt_label_##id:
 
 // This macro helps to get the address of a label that is inserted by the above
 // macro define_ompt_label(). The address is obtained with a GNU extension
 // (&&label) that has been tested with gcc, clang and icc.
-#define get_ompt_label_address(id) (&& ompt_label_##id)
+#define get_ompt_label_address(id) (&&ompt_label_##id)
 
 // This macro prints the exact address that a previously called runtime function
 // returns to.
-#define print_current_address(id) \
-  define_ompt_label(id) \
-  print_possible_return_addresses(get_ompt_label_address(id))
+#define print_current_address(id)                                              \
+  define_ompt_label(id)                                                        \
+      print_possible_return_addresses(get_ompt_label_address(id))
 
 #if KMP_ARCH_X86 || KMP_ARCH_X86_64
 // On X86 the NOP instruction is 1 byte long. In addition, the compiler inserts
 // a MOV instruction for non-void runtime functions which is 3 bytes long.
-#define print_possible_return_addresses(addr) \
-  printf("%" PRIu64 ": current_address=%p or %p for non-void functions\n", \
-         ompt_get_thread_data()->value, ((char *)addr) - 1, ((char *)addr) - 4)
+#define print_possible_return_addresses(addr)                                  \
+  printf("%" PRIu64 ": current_address=%p or %p for non-void functions\n",     \
+         ompt_get_thread_data()->value, ((char *)addr) - 1,                    \
+         ((char *)addr) - 4)
 #elif KMP_ARCH_PPC64
 // On Power the NOP instruction is 4 bytes long. In addition, the compiler
 // inserts a second NOP instruction (another 4 bytes). For non-void runtime
 // functions Clang inserts a STW instruction (but only if compiling under
 // -fno-PIC which will be the default with Clang 8.0, another 4 bytes).
-#define print_possible_return_addresses(addr) \
-  printf("%" PRIu64 ": current_address=%p or %p\n", ompt_get_thread_data()->value, \
-         ((char *)addr) - 8, ((char *)addr) - 12)
+#define print_possible_return_addresses(addr)                                  \
+  printf("%" PRIu64 ": current_address=%p or %p\n",                            \
+         ompt_get_thread_data()->value, ((char *)addr) - 8,                    \
+         ((char *)addr) - 12)
 #elif KMP_ARCH_AARCH64 || KMP_ARCH_AARCH64_32
 // On AArch64 the NOP instruction is 4 bytes long, can be followed by inserted
 // store instruction (another 4 bytes long).
@@ -266,18 +290,20 @@ ompt_label_##id:
 // accounts for another 4 bytes. Finally, an additional J instruction may
 // appear (adding 4 more bytes) when the C.NOP is referenced elsewhere (ie.
 // another branch).
-#define print_possible_return_addresses(addr) \
-  printf("%" PRIu64 ": current_address=%p or %p\n", \
-         ompt_get_thread_data()->value, ((char *)addr) - 6, ((char *)addr) - 10)
+#define print_possible_return_addresses(addr)                                  \
+  printf("%" PRIu64 ": current_address=%p or %p\n",                            \
+         ompt_get_thread_data()->value, ((char *)addr) - 6,                    \
+         ((char *)addr) - 10)
 #else
 // On RV64G the NOP instruction is 4 byte long. In addition, the compiler
 // inserts a J instruction (targeting the successor basic block), which
 // accounts for another 4 bytes. Finally, an additional J instruction may
 // appear (adding 4 more bytes) when the NOP is referenced elsewhere (ie.
 // another branch).
-#define print_possible_return_addresses(addr) \
-  printf("%" PRIu64 ": current_address=%p or %p\n", \
-         ompt_get_thread_data()->value, ((char *)addr) - 8, ((char *)addr) - 12)
+#define print_possible_return_addresses(addr)                                  \
+  printf("%" PRIu64 ": current_address=%p or %p\n",                            \
+         ompt_get_thread_data()->value, ((char *)addr) - 8,                    \
+         ((char *)addr) - 12)
 #endif
 #elif KMP_ARCH_LOONGARCH64
 // On LoongArch64 the NOP instruction is 4 bytes long, can be followed by
@@ -323,7 +349,6 @@ ompt_label_##id:
 #error Unsupported target architecture, cannot determine address offset!
 #endif
 
-
 // This macro performs a somewhat similar job to print_current_address(), except
 // that it discards a certain number of nibbles from the address and only prints
 // the most significant bits / nibbles. This can be used for cases where the
@@ -332,9 +357,8 @@ ompt_label_##id:
 // To account for overflows (ie the most significant bits / nibbles have just
 // changed as we are a few bytes above the relevant power of two) the addresses
 // of the "current" and of the "previous block" are printed.
-#define print_fuzzy_address(id) \
-  define_ompt_label(id) \
-  print_fuzzy_address_blocks(get_ompt_label_address(id))
+#define print_fuzzy_address(id)                                                \
+  define_ompt_label(id) print_fuzzy_address_blocks(get_ompt_label_address(id))
 
 // If you change this define you need to adapt all capture patterns in the tests
 // to include or discard the new number of nibbles!
@@ -359,193 +383,169 @@ ompt_label_##id:
 #define register_ompt_callback(name) register_ompt_callback_t(name, name##_t)
 
 #ifndef USE_PRIVATE_TOOL
-static void
-on_ompt_callback_mutex_acquire(
-  ompt_mutex_t kind,
-  unsigned int hint,
-  unsigned int impl,
-  ompt_wait_id_t wait_id,
-  const void *codeptr_ra)
-{
-  switch(kind)
-  {
-    case ompt_mutex_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_test_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_test_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_nest_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_test_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_test_nest_lock: wait_id=%" PRIu64
-             ", hint=%" PRIu32 ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_critical:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_critical: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_atomic:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_atomic: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_ordered:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_wait_ordered: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    default:
-      break;
+static void on_ompt_callback_mutex_acquire(ompt_mutex_t kind, unsigned int hint,
+                                           unsigned int impl,
+                                           ompt_wait_id_t wait_id,
+                                           const void *codeptr_ra) {
+  switch (kind) {
+  case ompt_mutex_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_wait_lock: wait_id=%" PRIu64
+           ", hint=%" PRIu32 ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_test_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_wait_test_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_wait_nest_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_test_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_wait_test_nest_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_critical:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_wait_critical: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_atomic:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_wait_atomic: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_ordered:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_wait_ordered: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  default:
+    break;
   }
 }
 
-static void
-on_ompt_callback_mutex_acquired(
-  ompt_mutex_t kind,
-  ompt_wait_id_t wait_id,
-  const void *codeptr_ra)
-{
-  switch(kind)
-  {
-    case ompt_mutex_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_lock: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_test_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_test_lock: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_nest_lock_first: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_test_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_test_nest_lock_first: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_critical:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_critical: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_atomic:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_atomic: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_ordered:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_ordered: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    default:
-      break;
+static void on_ompt_callback_mutex_acquired(ompt_mutex_t kind,
+                                            ompt_wait_id_t wait_id,
+                                            const void *codeptr_ra) {
+  switch (kind) {
+  case ompt_mutex_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_lock: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_test_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_test_lock: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_nest_lock_first: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_test_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_test_nest_lock_first: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_critical:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_critical: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_atomic:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_atomic: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_ordered:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_ordered: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  default:
+    break;
   }
 }
 
-static void
-on_ompt_callback_mutex_released(
-  ompt_mutex_t kind,
-  ompt_wait_id_t wait_id,
-  const void *codeptr_ra)
-{
-  switch(kind)
-  {
-    case ompt_mutex_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_release_lock: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_release_nest_lock_last: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_critical:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_release_critical: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_atomic:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_release_atomic: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_ordered:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_release_ordered: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    default:
-      break;
+static void on_ompt_callback_mutex_released(ompt_mutex_t kind,
+                                            ompt_wait_id_t wait_id,
+                                            const void *codeptr_ra) {
+  switch (kind) {
+  case ompt_mutex_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_release_lock: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_release_nest_lock_last: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_critical:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_release_critical: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_atomic:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_release_atomic: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_ordered:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_release_ordered: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  default:
+    break;
   }
 }
 
-static void
-on_ompt_callback_nest_lock(
-    ompt_scope_endpoint_t endpoint,
-    ompt_wait_id_t wait_id,
-    const void *codeptr_ra)
-{
-  switch(endpoint)
-  {
-    case ompt_scope_begin:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_acquired_nest_lock_next: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_scope_end:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_release_nest_lock_prev: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_scope_beginend:
-      printf("ompt_scope_beginend should never be passed to %s\n", __func__);
-      exit(-1);
+static void on_ompt_callback_nest_lock(ompt_scope_endpoint_t endpoint,
+                                       ompt_wait_id_t wait_id,
+                                       const void *codeptr_ra) {
+  switch (endpoint) {
+  case ompt_scope_begin:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_acquired_nest_lock_next: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_scope_end:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_release_nest_lock_prev: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_scope_beginend:
+    printf("ompt_scope_beginend should never be passed to %s\n", __func__);
+    exit(-1);
   }
 }
 
-static void
-on_ompt_callback_sync_region(
-  ompt_sync_region_t kind,
-  ompt_scope_endpoint_t endpoint,
-  ompt_data_t *parallel_data,
-  ompt_data_t *task_data,
-  const void *codeptr_ra)
-{
+static void on_ompt_callback_sync_region(ompt_sync_region_t kind,
+                                         ompt_scope_endpoint_t endpoint,
+                                         ompt_data_t *parallel_data,
+                                         ompt_data_t *task_data,
+                                         const void *codeptr_ra) {
   if (endpoint == ompt_scope_beginend) {
     printf("ompt_scope_beginend should never be passed to %s\n", __func__);
     exit(-1);
@@ -575,14 +575,11 @@ on_ompt_callback_sync_region(
   }
 }
 
-static void
-on_ompt_callback_sync_region_wait(
-  ompt_sync_region_t kind,
-  ompt_scope_endpoint_t endpoint,
-  ompt_data_t *parallel_data,
-  ompt_data_t *task_data,
-  const void *codeptr_ra)
-{
+static void on_ompt_callback_sync_region_wait(ompt_sync_region_t kind,
+                                              ompt_scope_endpoint_t endpoint,
+                                              ompt_data_t *parallel_data,
+                                              ompt_data_t *task_data,
+                                              const void *codeptr_ra) {
   if (endpoint == ompt_scope_beginend) {
     printf("ompt_scope_beginend should never be passed to %s\n", __func__);
     exit(-1);
@@ -629,37 +626,30 @@ static void on_ompt_callback_reduction(ompt_sync_region_t kind,
   }
 }
 
-static void
-on_ompt_callback_flush(
-    ompt_data_t *thread_data,
-    const void *codeptr_ra)
-{
+static void on_ompt_callback_flush(ompt_data_t *thread_data,
+                                   const void *codeptr_ra) {
   printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_flush: codeptr_ra=%p\n",
          thread_data->value, codeptr_ra);
 }
 
-static void
-on_ompt_callback_cancel(
-    ompt_data_t *task_data,
-    int flags,
-    const void *codeptr_ra)
-{
-  const char* first_flag_value;
-  const char* second_flag_value;
-  if(flags & ompt_cancel_parallel)
+static void on_ompt_callback_cancel(ompt_data_t *task_data, int flags,
+                                    const void *codeptr_ra) {
+  const char *first_flag_value;
+  const char *second_flag_value;
+  if (flags & ompt_cancel_parallel)
     first_flag_value = ompt_cancel_flag_t_values[0];
-  else if(flags & ompt_cancel_sections)
+  else if (flags & ompt_cancel_sections)
     first_flag_value = ompt_cancel_flag_t_values[1];
-  else if(flags & ompt_cancel_loop)
+  else if (flags & ompt_cancel_loop)
     first_flag_value = ompt_cancel_flag_t_values[2];
-  else if(flags & ompt_cancel_taskgroup)
+  else if (flags & ompt_cancel_taskgroup)
     first_flag_value = ompt_cancel_flag_t_values[3];
 
-  if(flags & ompt_cancel_activated)
+  if (flags & ompt_cancel_activated)
     second_flag_value = ompt_cancel_flag_t_values[4];
-  else if(flags & ompt_cancel_detected)
+  else if (flags & ompt_cancel_detected)
     second_flag_value = ompt_cancel_flag_t_values[5];
-  else if(flags & ompt_cancel_discarded_task)
+  else if (flags & ompt_cancel_discarded_task)
     second_flag_value = ompt_cancel_flag_t_values[6];
 
   printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_cancel: task_id=%" PRIx64
@@ -668,136 +658,115 @@ on_ompt_callback_cancel(
          second_flag_value, flags, codeptr_ra);
 }
 
-static void
-on_ompt_callback_implicit_task(
-    ompt_scope_endpoint_t endpoint,
-    ompt_data_t *parallel_data,
-    ompt_data_t *task_data,
-    unsigned int team_size,
-    unsigned int thread_num,
-    int flags)
-{
-  switch(endpoint)
-  {
-    case ompt_scope_begin:
-      if(task_data->ptr)
-        printf("%s\n", "0: task_data initially not null");
-      task_data->value = ompt_get_unique_id();
+static void on_ompt_callback_implicit_task(ompt_scope_endpoint_t endpoint,
+                                           ompt_data_t *parallel_data,
+                                           ompt_data_t *task_data,
+                                           unsigned int team_size,
+                                           unsigned int thread_num, int flags) {
+  switch (endpoint) {
+  case ompt_scope_begin:
+    if (task_data->ptr)
+      printf("%s\n", "0: task_data initially not null");
+    task_data->value = ompt_get_unique_id();
 
-      //there is no parallel_begin callback for implicit parallel region
-      //thus it is initialized in initial task
-      if(flags & ompt_task_initial)
-      {
-        char buffer[2048];
+    // there is no parallel_begin callback for implicit parallel region
+    // thus it is initialized in initial task
+    if (flags & ompt_task_initial) {
+      char buffer[2048];
 
-        format_task_type(flags, buffer);
-        // Only check initial task not created by teams construct
-        if (team_size == 1 && thread_num == 1 && parallel_data->ptr)
-          printf("%s\n", "0: parallel_data initially not null");
-        parallel_data->value = ompt_get_unique_id();
-        printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_initial_task_begin: parallel_id=%" PRIx64
-               ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32
-               ", index=%" PRIu32 ", flags=%" PRIu32 "\n",
-               ompt_get_thread_data()->value, parallel_data->value,
-               task_data->value, team_size, thread_num, flags);
-      } else {
-        printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_implicit_task_begin: parallel_id=%" PRIx64
-               ", task_id=%" PRIx64 ", team_size=%" PRIu32
-               ", thread_num=%" PRIu32 "\n",
-               ompt_get_thread_data()->value, parallel_data->value,
-               task_data->value, team_size, thread_num);
-      }
+      format_task_type(flags, buffer);
+      // Only check initial task not created by teams construct
+      if (team_size == 1 && thread_num == 1 && parallel_data->ptr)
+        printf("%s\n", "0: parallel_data initially not null");
+      parallel_data->value = ompt_get_unique_id();
+      printf("%" PRIu64 ":" _TOOL_PREFIX
+             " ompt_event_initial_task_begin: parallel_id=%" PRIx64
+             ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32
+             ", index=%" PRIu32 ", flags=%" PRIu32 "\n",
+             ompt_get_thread_data()->value, parallel_data->value,
+             task_data->value, team_size, thread_num, flags);
+    } else {
+      printf("%" PRIu64 ":" _TOOL_PREFIX
+             " ompt_event_implicit_task_begin: parallel_id=%" PRIx64
+             ", task_id=%" PRIx64 ", team_size=%" PRIu32 ", thread_num=%" PRIu32
+             "\n",
+             ompt_get_thread_data()->value, parallel_data->value,
+             task_data->value, team_size, thread_num);
+    }
 
-      break;
-    case ompt_scope_end:
-      if(flags & ompt_task_initial){
-        printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_initial_task_end: parallel_id=%" PRIx64
-               ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32
-               ", index=%" PRIu32 "\n",
-               ompt_get_thread_data()->value,
-               (parallel_data) ? parallel_data->value : 0, task_data->value,
-               team_size, thread_num);
-      } else {
-        printf("%" PRIu64 ":" _TOOL_PREFIX
-               " ompt_event_implicit_task_end: parallel_id=%" PRIx64
-               ", task_id=%" PRIx64 ", team_size=%" PRIu32
-               ", thread_num=%" PRIu32 "\n",
-               ompt_get_thread_data()->value,
-               (parallel_data) ? parallel_data->value : 0, task_data->value,
-               team_size, thread_num);
-      }
-      break;
-    case ompt_scope_beginend:
-      printf("ompt_scope_beginend should never be passed to %s\n", __func__);
-      exit(-1);
+    break;
+  case ompt_scope_end:
+    if (flags & ompt_task_initial) {
+      printf("%" PRIu64 ":" _TOOL_PREFIX
+             " ompt_event_initial_task_end: parallel_id=%" PRIx64
+             ", task_id=%" PRIx64 ", actual_parallelism=%" PRIu32
+             ", index=%" PRIu32 "\n",
+             ompt_get_thread_data()->value,
+             (parallel_data) ? parallel_data->value : 0, task_data->value,
+             team_size, thread_num);
+    } else {
+      printf("%" PRIu64 ":" _TOOL_PREFIX
+             " ompt_event_implicit_task_end: parallel_id=%" PRIx64
+             ", task_id=%" PRIx64 ", team_size=%" PRIu32 ", thread_num=%" PRIu32
+             "\n",
+             ompt_get_thread_data()->value,
+             (parallel_data) ? parallel_data->value : 0, task_data->value,
+             team_size, thread_num);
+    }
+    break;
+  case ompt_scope_beginend:
+    printf("ompt_scope_beginend should never be passed to %s\n", __func__);
+    exit(-1);
   }
 }
 
-static void
-on_ompt_callback_lock_init(
-  ompt_mutex_t kind,
-  unsigned int hint,
-  unsigned int impl,
-  ompt_wait_id_t wait_id,
-  const void *codeptr_ra)
-{
-  switch(kind)
-  {
-    case ompt_mutex_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_init_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    case ompt_mutex_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_init_nest_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
-             ", impl=%" PRIu32 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
-      break;
-    default:
-      break;
+static void on_ompt_callback_lock_init(ompt_mutex_t kind, unsigned int hint,
+                                       unsigned int impl,
+                                       ompt_wait_id_t wait_id,
+                                       const void *codeptr_ra) {
+  switch (kind) {
+  case ompt_mutex_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_init_lock: wait_id=%" PRIu64
+           ", hint=%" PRIu32 ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  case ompt_mutex_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_init_nest_lock: wait_id=%" PRIu64 ", hint=%" PRIu32
+           ", impl=%" PRIu32 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, hint, impl, codeptr_ra);
+    break;
+  default:
+    break;
   }
 }
 
-static void
-on_ompt_callback_lock_destroy(
-  ompt_mutex_t kind,
-  ompt_wait_id_t wait_id,
-  const void *codeptr_ra)
-{
-  switch(kind)
-  {
-    case ompt_mutex_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_destroy_lock: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    case ompt_mutex_nest_lock:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_destroy_nest_lock: wait_id=%" PRIu64
-             ", codeptr_ra=%p \n",
-             ompt_get_thread_data()->value, wait_id, codeptr_ra);
-      break;
-    default:
-      break;
+static void on_ompt_callback_lock_destroy(ompt_mutex_t kind,
+                                          ompt_wait_id_t wait_id,
+                                          const void *codeptr_ra) {
+  switch (kind) {
+  case ompt_mutex_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_destroy_lock: wait_id=%" PRIu64 ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  case ompt_mutex_nest_lock:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_destroy_nest_lock: wait_id=%" PRIu64
+           ", codeptr_ra=%p \n",
+           ompt_get_thread_data()->value, wait_id, codeptr_ra);
+    break;
+  default:
+    break;
   }
 }
 
-static void
-on_ompt_callback_work(
-  ompt_work_t wstype,
-  ompt_scope_endpoint_t endpoint,
-  ompt_data_t *parallel_data,
-  ompt_data_t *task_data,
-  uint64_t count,
-  const void *codeptr_ra)
-{
-  switch(endpoint)
-  {
+static void on_ompt_callback_work(ompt_work_t wstype,
+                                  ompt_scope_endpoint_t endpoint,
+                                  ompt_data_t *parallel_data,
+                                  ompt_data_t *task_data, uint64_t count,
+                                  const void *codeptr_ra) {
+  switch (endpoint) {
   case ompt_scope_begin:
     printf("%" PRIu64 ":" _TOOL_PREFIX " %s_begin: parallel_id=%" PRIx64
            ", task_id=%" PRIx64 ", codeptr_ra=%p, count=%" PRIu64 "\n",
@@ -816,11 +785,10 @@ on_ompt_callback_work(
   }
 }
 
-static void on_ompt_callback_dispatch(
-    ompt_data_t *parallel_data,
-    ompt_data_t *task_data,
-    ompt_dispatch_t kind,
-    ompt_data_t instance) {
+static void on_ompt_callback_dispatch(ompt_data_t *parallel_data,
+                                      ompt_data_t *task_data,
+                                      ompt_dispatch_t kind,
+                                      ompt_data_t instance) {
   char *event_name = NULL;
   void *codeptr_ra = NULL;
   ompt_dispatch_chunk_t *dispatch_chunk = NULL;
@@ -857,25 +825,24 @@ static void on_ompt_callback_masked(ompt_scope_endpoint_t endpoint,
                                     ompt_data_t *parallel_data,
                                     ompt_data_t *task_data,
                                     const void *codeptr_ra) {
-  switch(endpoint)
-  {
-    case ompt_scope_begin:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_masked_begin: parallel_id=%" PRIx64
-             ", task_id=%" PRIx64 ", codeptr_ra=%p\n",
-             ompt_get_thread_data()->value, parallel_data->value,
-             task_data->value, codeptr_ra);
-      break;
-    case ompt_scope_end:
-      printf("%" PRIu64 ":" _TOOL_PREFIX
-             " ompt_event_masked_end: parallel_id=%" PRIx64 ", task_id=%" PRIx64
-             ", codeptr_ra=%p\n",
-             ompt_get_thread_data()->value, parallel_data->value,
-             task_data->value, codeptr_ra);
-      break;
-    case ompt_scope_beginend:
-      printf("ompt_scope_beginend should never be passed to %s\n", __func__);
-      exit(-1);
+  switch (endpoint) {
+  case ompt_scope_begin:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_masked_begin: parallel_id=%" PRIx64 ", task_id=%" PRIx64
+           ", codeptr_ra=%p\n",
+           ompt_get_thread_data()->value, parallel_data->value,
+           task_data->value, codeptr_ra);
+    break;
+  case ompt_scope_end:
+    printf("%" PRIu64 ":" _TOOL_PREFIX
+           " ompt_event_masked_end: parallel_id=%" PRIx64 ", task_id=%" PRIx64
+           ", codeptr_ra=%p\n",
+           ompt_get_thread_data()->value, parallel_data->value,
+           task_data->value, codeptr_ra);
+    break;
+  case ompt_scope_beginend:
+    printf("ompt_scope_beginend should never be passed to %s\n", __func__);
+    exit(-1);
   }
 }
 
@@ -883,7 +850,7 @@ static void on_ompt_callback_parallel_begin(
     ompt_data_t *encountering_task_data,
     const ompt_frame_t *encountering_task_frame, ompt_data_t *parallel_data,
     uint32_t requested_team_size, int flag, const void *codeptr_ra) {
-  if(parallel_data->ptr)
+  if (parallel_data->ptr)
     printf("0: parallel_data initially not null\n");
   parallel_data->value = ompt_get_unique_id();
   int invoker = flag & 0xF;
@@ -912,15 +879,11 @@ static void on_ompt_callback_parallel_end(ompt_data_t *parallel_data,
 }
 
 static void
-on_ompt_callback_task_create(
-    ompt_data_t *encountering_task_data,
-    const ompt_frame_t *encountering_task_frame,
-    ompt_data_t* new_task_data,
-    int type,
-    int has_dependences,
-    const void *codeptr_ra)
-{
-  if(new_task_data->ptr)
+on_ompt_callback_task_create(ompt_data_t *encountering_task_data,
+                             const ompt_frame_t *encountering_task_frame,
+                             ompt_data_t *new_task_data, int type,
+                             int has_dependences, const void *codeptr_ra) {
+  if (new_task_data->ptr)
     printf("0: new_task_data initially not null\n");
   new_task_data->value = ompt_get_unique_id();
   char buffer[2048];
@@ -941,12 +904,9 @@ on_ompt_callback_task_create(
       has_dependences ? "yes" : "no");
 }
 
-static void
-on_ompt_callback_task_schedule(
-    ompt_data_t *first_task_data,
-    ompt_task_status_t prior_task_status,
-    ompt_data_t *second_task_data)
-{
+static void on_ompt_callback_task_schedule(ompt_data_t *first_task_data,
+                                           ompt_task_status_t prior_task_status,
+                                           ompt_data_t *second_task_data) {
   printf("%" PRIu64 ":" _TOOL_PREFIX
          " ompt_event_task_schedule: first_task_id=%" PRIx64
          ", second_task_id=%" PRIx64 ", prior_task_status=%s=%d\n",
@@ -962,12 +922,9 @@ on_ompt_callback_task_schedule(
   }
 }
 
-static void
-on_ompt_callback_dependences(
-  ompt_data_t *task_data,
-  const ompt_dependence_t *deps,
-  int ndeps)
-{
+static void on_ompt_callback_dependences(ompt_data_t *task_data,
+                                         const ompt_dependence_t *deps,
+                                         int ndeps) {
   char buffer[2048];
   char *progress = buffer;
   int i;
@@ -989,11 +946,8 @@ on_ompt_callback_dependences(
          ompt_get_thread_data()->value, task_data->value, buffer, ndeps);
 }
 
-static void
-on_ompt_callback_task_dependence(
-  ompt_data_t *first_task_data,
-  ompt_data_t *second_task_data)
-{
+static void on_ompt_callback_task_dependence(ompt_data_t *first_task_data,
+                                             ompt_data_t *second_task_data) {
   printf("%" PRIu64 ":" _TOOL_PREFIX
          " ompt_event_task_dependence_pair: first_task_id=%" PRIx64
          ", second_task_id=%" PRIx64 "\n",
@@ -1001,12 +955,9 @@ on_ompt_callback_task_dependence(
          second_task_data->value);
 }
 
-static void
-on_ompt_callback_thread_begin(
-  ompt_thread_t thread_type,
-  ompt_data_t *thread_data)
-{
-  if(thread_data->ptr)
+static void on_ompt_callback_thread_begin(ompt_thread_t thread_type,
+                                          ompt_data_t *thread_data) {
+  if (thread_data->ptr)
     printf("%s\n", "0: thread_data initially not null");
   thread_data->value = ompt_get_unique_id();
   printf("%" PRIu64 ":" _TOOL_PREFIX
@@ -1015,26 +966,18 @@ on_ompt_callback_thread_begin(
          thread_type, thread_data->value);
 }
 
-static void
-on_ompt_callback_thread_end(
-  ompt_data_t *thread_data)
-{
-  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_thread_end: thread_id=%" PRIu64
-         "\n",
+static void on_ompt_callback_thread_end(ompt_data_t *thread_data) {
+  printf("%" PRIu64 ":" _TOOL_PREFIX
+         " ompt_event_thread_end: thread_id=%" PRIu64 "\n",
          ompt_get_thread_data()->value, thread_data->value);
 }
 
-static int
-on_ompt_callback_control_tool(
-  uint64_t command,
-  uint64_t modifier,
-  void *arg,
-  const void *codeptr_ra)
-{
-  ompt_frame_t* omptTaskFrame;
-  ompt_get_task_info(0, NULL, (ompt_data_t**) NULL, &omptTaskFrame, NULL, NULL);
-  printf("%" PRIu64 ":" _TOOL_PREFIX " ompt_event_control_tool: command=%" PRIu64
-         ", modifier=%" PRIu64
+static int on_ompt_callback_control_tool(uint64_t command, uint64_t modifier,
+                                         void *arg, const void *codeptr_ra) {
+  ompt_frame_t *omptTaskFrame;
+  ompt_get_task_info(0, NULL, (ompt_data_t **)NULL, &omptTaskFrame, NULL, NULL);
+  printf("%" PRIu64 ":" _TOOL_PREFIX
+         " ompt_event_control_tool: command=%" PRIu64 ", modifier=%" PRIu64
          ", arg=%p, codeptr_ra=%p, current_task_frame.exit=%p, "
          "current_task_frame.reenter=%p \n",
          ompt_get_thread_data()->value, command, modifier, arg, codeptr_ra,
@@ -1063,7 +1006,7 @@ on_ompt_callback_control_tool(
     parallel_level++;
   }
 #endif
-  return 0; //success
+  return 0; // success
 }
 
 static void on_ompt_callback_error(ompt_severity_t severity,
@@ -1075,44 +1018,49 @@ static void on_ompt_callback_error(ompt_severity_t severity,
          codeptr_ra);
 }
 
-int ompt_initialize(
-  ompt_function_lookup_t lookup,
-  int initial_device_num,
-  ompt_data_t *tool_data)
-{
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
-  ompt_get_callback = (ompt_get_callback_t) lookup("ompt_get_callback");
-  ompt_get_state = (ompt_get_state_t) lookup("ompt_get_state");
-  ompt_get_task_info = (ompt_get_task_info_t) lookup("ompt_get_task_info");
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
+                    ompt_data_t *tool_data) {
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
+  ompt_get_callback = (ompt_get_callback_t)lookup("ompt_get_callback");
+  ompt_get_state = (ompt_get_state_t)lookup("ompt_get_state");
+  ompt_get_task_info = (ompt_get_task_info_t)lookup("ompt_get_task_info");
   ompt_get_task_memory = (ompt_get_task_memory_t)lookup("ompt_get_task_memory");
-  ompt_get_thread_data = (ompt_get_thread_data_t) lookup("ompt_get_thread_data");
-  ompt_get_parallel_info = (ompt_get_parallel_info_t) lookup("ompt_get_parallel_info");
-  ompt_get_unique_id = (ompt_get_unique_id_t) lookup("ompt_get_unique_id");
+  ompt_get_thread_data = (ompt_get_thread_data_t)lookup("ompt_get_thread_data");
+  ompt_get_parallel_info =
+      (ompt_get_parallel_info_t)lookup("ompt_get_parallel_info");
+  ompt_get_unique_id = (ompt_get_unique_id_t)lookup("ompt_get_unique_id");
   ompt_finalize_tool = (ompt_finalize_tool_t)lookup("ompt_finalize_tool");
 
   ompt_get_unique_id();
 
-  ompt_get_num_procs = (ompt_get_num_procs_t) lookup("ompt_get_num_procs");
-  ompt_get_num_places = (ompt_get_num_places_t) lookup("ompt_get_num_places");
-  ompt_get_place_proc_ids = (ompt_get_place_proc_ids_t) lookup("ompt_get_place_proc_ids");
-  ompt_get_place_num = (ompt_get_place_num_t) lookup("ompt_get_place_num");
-  ompt_get_partition_place_nums = (ompt_get_partition_place_nums_t) lookup("ompt_get_partition_place_nums");
-  ompt_get_proc_id = (ompt_get_proc_id_t) lookup("ompt_get_proc_id");
-  ompt_enumerate_states = (ompt_enumerate_states_t) lookup("ompt_enumerate_states");
-  ompt_enumerate_mutex_impls = (ompt_enumerate_mutex_impls_t) lookup("ompt_enumerate_mutex_impls");
+  ompt_get_num_procs = (ompt_get_num_procs_t)lookup("ompt_get_num_procs");
+  ompt_get_num_places = (ompt_get_num_places_t)lookup("ompt_get_num_places");
+  ompt_get_place_proc_ids =
+      (ompt_get_place_proc_ids_t)lookup("ompt_get_place_proc_ids");
+  ompt_get_place_num = (ompt_get_place_num_t)lookup("ompt_get_place_num");
+  ompt_get_partition_place_nums =
+      (ompt_get_partition_place_nums_t)lookup("ompt_get_partition_place_nums");
+  ompt_get_proc_id = (ompt_get_proc_id_t)lookup("ompt_get_proc_id");
+  ompt_enumerate_states =
+      (ompt_enumerate_states_t)lookup("ompt_enumerate_states");
+  ompt_enumerate_mutex_impls =
+      (ompt_enumerate_mutex_impls_t)lookup("ompt_enumerate_mutex_impls");
 
   register_ompt_callback(ompt_callback_mutex_acquire);
   register_ompt_callback_t(ompt_callback_mutex_acquired, ompt_callback_mutex_t);
   register_ompt_callback_t(ompt_callback_mutex_released, ompt_callback_mutex_t);
   register_ompt_callback(ompt_callback_nest_lock);
   register_ompt_callback(ompt_callback_sync_region);
-  register_ompt_callback_t(ompt_callback_sync_region_wait, ompt_callback_sync_region_t);
-  register_ompt_callback_t(ompt_callback_reduction, ompt_callback_sync_region_t);
+  register_ompt_callback_t(ompt_callback_sync_region_wait,
+                           ompt_callback_sync_region_t);
+  register_ompt_callback_t(ompt_callback_reduction,
+                           ompt_callback_sync_region_t);
   register_ompt_callback(ompt_callback_control_tool);
   register_ompt_callback(ompt_callback_flush);
   register_ompt_callback(ompt_callback_cancel);
   register_ompt_callback(ompt_callback_implicit_task);
-  register_ompt_callback_t(ompt_callback_lock_init, ompt_callback_mutex_acquire_t);
+  register_ompt_callback_t(ompt_callback_lock_init,
+                           ompt_callback_mutex_acquire_t);
   register_ompt_callback_t(ompt_callback_lock_destroy, ompt_callback_mutex_t);
   register_ompt_callback(ompt_callback_work);
   register_ompt_callback(ompt_callback_dispatch);
@@ -1126,23 +1074,21 @@ int ompt_initialize(
   register_ompt_callback(ompt_callback_thread_begin);
   register_ompt_callback(ompt_callback_thread_end);
   register_ompt_callback(ompt_callback_error);
-  printf("0: NULL_POINTER=%p\n", (void*)NULL);
-  return 1; //success
+  printf("0: NULL_POINTER=%p\n", (void *)NULL);
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{
+void ompt_finalize(ompt_data_t *tool_data) {
   printf("0: ompt_event_runtime_shutdown\n");
 }
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-ompt_start_tool_result_t* ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #ifdef __cplusplus

--- a/openmp/runtime/test/ompt/cancel/cancel_parallel.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_parallel.c
@@ -9,19 +9,21 @@
 #include "omp.h"
 
 int main() {
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
     if (omp_get_thread_num() == 0) {
       print_fuzzy_address_blocks(get_ompt_label_address(1));
-      #pragma omp cancel parallel
+#pragma omp cancel parallel
       define_ompt_label(1);
-      // We cannot print at this location because the parallel region is cancelled!
+      // We cannot print at this location because the parallel region is
+      // cancelled!
     } else {
       delay(100);
       print_fuzzy_address_blocks(get_ompt_label_address(2));
-      #pragma omp cancellation point parallel
+#pragma omp cancellation point parallel
       define_ompt_label(2);
-      // We cannot print at this location because the parallel region is cancelled!
+      // We cannot print at this location because the parallel region is
+      // cancelled!
     }
   }
 

--- a/openmp/runtime/test/ompt/cancel/cancel_parallel.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_parallel.c
@@ -28,12 +28,12 @@ int main() {
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_cancel'
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, actual_parallelism=1, index=1, flags=1 
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_data=[[TASK_ID:[0-9]+]], flags=ompt_cancel_parallel|ompt_cancel_activated=17, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, actual_parallelism=1, index=1, flags=1 
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_parallel|ompt_cancel_activated=17, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-DAG: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin
-  // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_cancel: task_data=[[TASK_ID:[0-9]+]], flags=ompt_cancel_parallel|ompt_cancel_detected=33, codeptr_ra=[[OTHER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_parallel|ompt_cancel_detected=33, codeptr_ra=[[OTHER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-DAG: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[OTHER_RETURN_ADDRESS]]
 
   return 0;

--- a/openmp/runtime/test/ompt/cancel/cancel_parallel.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_parallel.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_CANCELLATION=true %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Current GOMP interface implementation does not support cancellation
 // XFAIL: gcc
+// clang-format on
 
 #include "callback.h"
 #include "omp.h"
@@ -23,6 +25,7 @@ int main() {
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_cancel'
@@ -35,6 +38,7 @@ int main() {
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_parallel|ompt_cancel_detected=33, codeptr_ra=[[OTHER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-DAG: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[OTHER_RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
@@ -7,57 +7,56 @@
 // clang-format on
 
 #include "callback.h"
-#include <unistd.h>  
+#include <unistd.h>
 #include <stdio.h>
 
-int main()
-{
-  int condition=0;
-  #pragma omp parallel num_threads(2)
+int main() {
+  int condition = 0;
+#pragma omp parallel num_threads(2)
   {}
 
   print_frame(0);
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
-      #pragma omp taskgroup
+#pragma omp taskgroup
       {
-        #pragma omp task shared(condition)
+#pragma omp task shared(condition)
         {
           printf("start execute task 1\n");
           OMPT_SIGNAL(condition);
-          OMPT_WAIT(condition,2);
-          #pragma omp cancellation point taskgroup
+          OMPT_WAIT(condition, 2);
+#pragma omp cancellation point taskgroup
           printf("end execute task 1\n");
         }
-        #pragma omp task shared(condition)
+#pragma omp task shared(condition)
         {
           printf("start execute task 2\n");
           OMPT_SIGNAL(condition);
-          OMPT_WAIT(condition,2);
-          #pragma omp cancellation point taskgroup
+          OMPT_WAIT(condition, 2);
+#pragma omp cancellation point taskgroup
           printf("end execute task 2\n");
         }
-      #pragma omp task shared(condition)
+#pragma omp task shared(condition)
         {
           printf("start execute task 3\n");
           OMPT_SIGNAL(condition);
-          OMPT_WAIT(condition,2);
-          #pragma omp cancellation point taskgroup
+          OMPT_WAIT(condition, 2);
+#pragma omp cancellation point taskgroup
           printf("end execute task 3\n");
         }
-      #pragma omp task if(0) shared(condition)
+#pragma omp task if (0) shared(condition)
         {
           printf("start execute task 4\n");
-          OMPT_WAIT(condition,1);
-          #pragma omp cancel taskgroup
+          OMPT_WAIT(condition, 1);
+#pragma omp cancel taskgroup
           printf("end execute task 4\n");
         }
         OMPT_SIGNAL(condition);
       }
     }
-    #pragma omp barrier
+#pragma omp barrier
   }
 
   // clang-format off

--- a/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
@@ -67,24 +67,24 @@ int main()
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_masked_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-  // CHECK-SAME: task_id=[[PARENT_TASK_ID:[0-9]+]],
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
+  // CHECK-SAME: task_id=[[PARENT_TASK_ID:[0-f]+]],
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]*}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[FIRST_TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit=4, has_dependences=no
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[SECOND_TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit=4, has_dependences=no
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[THIRD_TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit=4, has_dependences=no
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[FIRST_TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit=4, has_dependences=no
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[SECOND_TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit=4, has_dependences=no
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[THIRD_TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit=4, has_dependences=no
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[CANCEL_TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[PARENT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]*}}, parent_task_frame.reenter={{(0x)?[0-f]*}}, new_task_id=[[CANCEL_TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]*}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule: first_task_id=[[PARENT_TASK_ID]], second_task_id=[[CANCEL_TASK_ID]], prior_task_status=ompt_task_switch=7
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_data=[[CANCEL_TASK_ID]], flags=ompt_cancel_taskgroup|ompt_cancel_activated=24, codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_id=[[CANCEL_TASK_ID]], flags=ompt_cancel_taskgroup|ompt_cancel_activated=24, codeptr_ra={{(0x)?[0-f]*}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule: first_task_id=[[CANCEL_TASK_ID]], second_task_id=[[PARENT_TASK_ID]], prior_task_status=ompt_task_cancel=3
 
-  // CHECK-DAG: {{^}}{{[0-9]+}}: ompt_event_cancel: task_data={{[0-9]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_discarded_task=72, codeptr_ra=[[NULL]]
-  // CHECK-DAG: {{^}}{{[0-9]+}}: ompt_event_cancel: task_data={{[0-9]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_discarded_task=72, codeptr_ra=[[NULL]]
+  // CHECK-DAG: {{^}}{{[0-9]+}}: ompt_event_cancel: task_id={{[0-f]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_discarded_task=72, codeptr_ra=[[NULL]]
+  // CHECK-DAG: {{^}}{{[0-9]+}}: ompt_event_cancel: task_id={{[0-f]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_discarded_task=72, codeptr_ra=[[NULL]]
   
   // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
-  // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_cancel: task_data={{[0-9]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_detected=40, codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_cancel: task_id={{[0-f]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_detected=40, codeptr_ra={{(0x)?[0-f]*}}
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_taskgroup.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN:  %libomp-compile && env OMP_CANCELLATION=true %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: clang-3, clang-4.0.0
 // Current GOMP interface implementation does not support cancellation; icc 16 has a bug
 // XFAIL: gcc, icc-16
+// clang-format on
 
 #include "callback.h"
 #include <unistd.h>  
@@ -58,6 +60,7 @@ int main()
     #pragma omp barrier
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_masked'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
@@ -85,6 +88,7 @@ int main()
   
   // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_cancel: task_id={{[0-f]+}}, flags=ompt_cancel_taskgroup|ompt_cancel_detected=40, codeptr_ra={{(0x)?[0-f]*}}
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_CANCELLATION=true %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Current GOMP interface implementation does not support cancellation; icc 16 does not distinguish between sections and loops
 // XFAIL: icc-16
+// clang-format on
 
 #include "callback.h"
 #include <unistd.h>
@@ -49,7 +51,7 @@ int main()
     }
   }
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_cancel'
@@ -62,6 +64,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_sections|ompt_cancel_{{activated=18|detected=34}}, codeptr_ra={{(0x)?[0-f]*}}
   // CHECK: {{^}}[[OTHER_THREAD_ID:[0-9]+]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_loop|ompt_cancel_detected=36, codeptr_ra={{(0x)?[0-f]*}}
   // CHECK: {{^}}[[OTHER_THREAD_ID:[0-9]+]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_sections|ompt_cancel_{{activated=18|detected=34}}, codeptr_ra={{(0x)?[0-f]*}}
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
@@ -8,45 +8,40 @@
 #include "callback.h"
 #include <unistd.h>
 
-int main()
-{
-  int condition=0;
-  #pragma omp parallel num_threads(2)
+int main() {
+  int condition = 0;
+#pragma omp parallel num_threads(2)
   {
     int x = 0;
     int i;
-    #pragma omp for
-    for(i = 0; i < 2; i++)
-    {
-      if(i == 0)
-      {
+#pragma omp for
+    for (i = 0; i < 2; i++) {
+      if (i == 0) {
         x++;
         OMPT_SIGNAL(condition);
-        #pragma omp cancel for
-      }
-      else
-      {
+#pragma omp cancel for
+      } else {
         x++;
-        OMPT_WAIT(condition,1);
+        OMPT_WAIT(condition, 1);
         delay(10000);
-        #pragma omp cancellation point for
+#pragma omp cancellation point for
       }
     }
   }
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp sections
+#pragma omp sections
     {
-      #pragma omp section
+#pragma omp section
       {
         OMPT_SIGNAL(condition);
-        #pragma omp cancel sections
+#pragma omp cancel sections
       }
-      #pragma omp section
+#pragma omp section
       {
-        OMPT_WAIT(condition,2);
+        OMPT_WAIT(condition, 2);
         delay(10000);
-        #pragma omp cancellation point sections
+#pragma omp cancellation point sections
       }
     }
   }

--- a/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
+++ b/openmp/runtime/test/ompt/cancel/cancel_worksharing.c
@@ -55,13 +55,13 @@ int main()
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_cancel'
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, actual_parallelism=1, index=1, flags=1
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, actual_parallelism=1, index=1, flags=1
  
   // cancel for and sections
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_data=[[TASK_ID:[0-9]+]], flags=ompt_cancel_loop|ompt_cancel_activated=20, codeptr_ra={{(0x)?[0-f]*}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_data=[[TASK_ID:[0-9]+]], flags=ompt_cancel_sections|ompt_cancel_{{activated=18|detected=34}}, codeptr_ra={{(0x)?[0-f]*}}
-  // CHECK: {{^}}[[OTHER_THREAD_ID:[0-9]+]]: ompt_event_cancel: task_data=[[TASK_ID:[0-9]+]], flags=ompt_cancel_loop|ompt_cancel_detected=36, codeptr_ra={{(0x)?[0-f]*}}
-  // CHECK: {{^}}[[OTHER_THREAD_ID:[0-9]+]]: ompt_event_cancel: task_data=[[TASK_ID:[0-9]+]], flags=ompt_cancel_sections|ompt_cancel_{{activated=18|detected=34}}, codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_loop|ompt_cancel_activated=20, codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_sections|ompt_cancel_{{activated=18|detected=34}}, codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK: {{^}}[[OTHER_THREAD_ID:[0-9]+]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_loop|ompt_cancel_detected=36, codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK: {{^}}[[OTHER_THREAD_ID:[0-9]+]]: ompt_event_cancel: task_id=[[TASK_ID:[0-f]+]], flags=ompt_cancel_sections|ompt_cancel_{{activated=18|detected=34}}, codeptr_ra={{(0x)?[0-f]*}}
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/loadtool/tool_available.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_available.c
@@ -107,9 +107,8 @@
 #ifdef CODE
 #include "omp.h"
 
-int main()
-{
-  #pragma omp parallel num_threads(2)
+int main() {
+#pragma omp parallel num_threads(2)
   {
   }
 
@@ -133,20 +132,18 @@ int main()
 
 int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
                     ompt_data_t *tool_data) {
-  printf("0: NULL_POINTER=%p\n", (void*)NULL);
-  return 1; //success
+  printf("0: NULL_POINTER=%p\n", (void *)NULL);
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t* tool_data)
-{
+void ompt_finalize(ompt_data_t *tool_data) {
   printf("0: ompt_event_runtime_shutdown\n");
 }
 
-ompt_start_tool_result_t* ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #endif /* TOOL */

--- a/openmp/runtime/test/ompt/loadtool/tool_available.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_available.c
@@ -1,3 +1,4 @@
+// clang-format off
 // The OpenMP standard defines 3 ways of providing ompt_start_tool:
 
 // RUN: mkdir -p %t.tool_dir
@@ -74,6 +75,7 @@
 
 
 // REQUIRES: ompt
+// clang-format on
 
 /*
  *  This file contains code for an OMPT shared library tool to be
@@ -82,6 +84,7 @@
  *  -DCODE enables the code for the executable during compilation
  */
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -99,6 +102,7 @@
 // TOOLLIB-SAME: [[PARENTPATH]]/tool.so... Success.
 // TOOLLIB-NEXT: Tool was started and is using the OMPT interface.
 // TOOLLIB-NEXT: ----- END LOGGING OF TOOL REGISTRATION -----
+// clang-format on
 
 #ifdef CODE
 #include "omp.h"
@@ -109,11 +113,13 @@ int main()
   {
   }
 
+  // clang-format off
   // CHECK-NOT: ----- START LOGGING OF TOOL REGISTRATION -----
   // CHECK-NOT: ----- END LOGGING OF TOOL REGISTRATION -----
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
   // CHECK: {{^}}0: ompt_event_runtime_shutdown
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/loadtool/tool_available_search.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_available_search.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: mkdir -p %t.tool_dir
 // RUN: %clang %flags -shared -fPIC %s -o %t.tool_dir/first_tool.so
 // RUN: %clang %flags -DTOOL -DSECOND_TOOL -shared -fPIC %s -o %t.tool_dir/second_tool.so
@@ -8,6 +9,7 @@
 
 // REQUIRES: ompt
 // XFAIL: darwin
+// clang-format on
 
 /*
  *  This file contains code for three OMPT shared library tool to be
@@ -19,6 +21,7 @@
  *  -DCODE enables the code for the executable during compilation
  */
 
+// clang-format off
 // CHECK: ----- START LOGGING OF TOOL REGISTRATION -----
 // CHECK-NEXT: Search for OMP tool in current address space... Failed.
 // CHECK-NEXT: Searching tool libraries...
@@ -53,7 +56,7 @@
 // CHECK-DAG: {{^}}0: ompt_event_thread_begin
 // CHECK-DAG: {{^}}0: control_tool()=-1
 // CHECK: {{^}}0: Tool finalized
-
+// clang-format on
 
 #ifdef CODE
 #include "stdio.h"

--- a/openmp/runtime/test/ompt/loadtool/tool_available_search.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_available_search.c
@@ -63,17 +63,15 @@
 #include "omp.h"
 #include "omp-tools.h"
 
-int main()
-{
-  #pragma omp parallel num_threads(2)
+int main() {
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
       int result = omp_control_tool(omp_control_tool_start, 0, NULL);
       printf("0: control_tool()=%d\n", result);
     }
   }
-
 
   return 0;
 }
@@ -87,10 +85,8 @@ int main()
 
 #ifdef SECOND_TOOL
 // The second tool has an implementation of ompt_start_tool that returns NULL
-ompt_start_tool_result_t* ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
   printf("0: Do not initialize tool\n");
   return NULL;
 }
@@ -98,33 +94,28 @@ ompt_start_tool_result_t* ompt_start_tool(
 // The third tool has an implementation of ompt_start_tool that returns a
 // pointer to a valid instance of ompt_start_tool_result_t
 
-static void
-on_ompt_callback_thread_begin(
-  ompt_thread_t thread_type,
-  ompt_data_t *thread_data)
-{
+static void on_ompt_callback_thread_begin(ompt_thread_t thread_type,
+                                          ompt_data_t *thread_data) {
   printf("0: ompt_event_thread_begin\n");
 }
 
 int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
                     ompt_data_t *tool_data) {
-  ompt_set_callback_t ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
-  ompt_set_callback(ompt_callback_thread_begin, (ompt_callback_t)on_ompt_callback_thread_begin);
+  ompt_set_callback_t ompt_set_callback =
+      (ompt_set_callback_t)lookup("ompt_set_callback");
+  ompt_set_callback(ompt_callback_thread_begin,
+                    (ompt_callback_t)on_ompt_callback_thread_begin);
   printf("0: Tool initialized\n");
   return 1;
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{
-  printf("0: Tool finalized\n");
-}
+void ompt_finalize(ompt_data_t *tool_data) { printf("0: Tool finalized\n"); }
 
-ompt_start_tool_result_t* ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
   printf("0: Do initialize tool\n");
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }
 #endif

--- a/openmp/runtime/test/ompt/loadtool/tool_not_available.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_not_available.c
@@ -1,3 +1,4 @@
+// clang-format off
 // The OpenMP standard defines 3 ways of providing ompt_start_tool:
 
 // RUN: mkdir -p %t.tool_dir
@@ -44,6 +45,7 @@
 // RUN:    FileCheck %s -DPARENTPATH=%t.tool_dir --check-prefixes CHECK,TOOLLIB
 
 // REQUIRES: ompt
+// clang-format on
 
 /*
  *  This file contains code for an OMPT shared library tool to be 
@@ -68,7 +70,7 @@ int main()
     }
   }
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -98,7 +100,7 @@ int main()
   // TOOLLIB-NEXT: ----- END LOGGING OF TOOL REGISTRATION -----
 
   // CHECK: {{^}}0: control_tool()=-2
-  
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/loadtool/tool_not_available.c
+++ b/openmp/runtime/test/ompt/loadtool/tool_not_available.c
@@ -48,8 +48,8 @@
 // clang-format on
 
 /*
- *  This file contains code for an OMPT shared library tool to be 
- *  loaded and the code for the OpenMP executable. 
+ *  This file contains code for an OMPT shared library tool to be
+ *  loaded and the code for the OpenMP executable.
  *  -DTOOL enables the code for the tool during compilation
  *  -DCODE enables the code for the executable during compilation
  */
@@ -59,11 +59,10 @@
 #include "omp.h"
 #include "omp-tools.h"
 
-int main()
-{
-  #pragma omp parallel num_threads(2)
+int main() {
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
       int result = omp_control_tool(omp_control_tool_start, 0, NULL);
       printf("0: control_tool()=%d\n", result);
@@ -112,10 +111,8 @@ int main()
 #include <omp-tools.h>
 #include "stdio.h"
 
-ompt_start_tool_result_t* ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
   printf("0: Do not initialize tool\n");
   return NULL;
 }

--- a/openmp/runtime/test/ompt/misc/api_calls_from_other_thread.cpp
+++ b/openmp/runtime/test/ompt/misc/api_calls_from_other_thread.cpp
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-cxx-compile-and-run | FileCheck %s
 // REQUIRES: ompt, linux
+// clang-format on
 
 #include <thread>
 #include "callback.h"
@@ -58,6 +60,7 @@ int main() {
   std::thread t1(f);
   t1.join();
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
@@ -87,6 +90,7 @@ int main() {
   // CHECK: {{^}}[[MASTER_ID]]: ompt_get_parallel_info()=0
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_get_task_info()=0
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/api_calls_misc.c
+++ b/openmp/runtime/test/ompt/misc/api_calls_misc.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile && %libomp-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -52,6 +54,7 @@ int main() {
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
@@ -67,6 +70,7 @@ int main() {
 
   // CHECK-NOT: {{^}}[[THREAD_ID]]: impl_name is NULL
   // CHECK-NOT: {{^}}[[THREAD_ID]]: mutex_impls enumeration did not end
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/api_calls_places.c
+++ b/openmp/runtime/test/ompt/misc/api_calls_places.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_PLACES=cores %libomp-run | FileCheck %s
 // REQUIRES: ompt, linux
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 #define __USE_GNU
@@ -58,6 +60,7 @@ int main() {
            ompt_get_thread_data()->value, ompt_get_num_procs());
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
@@ -83,6 +86,7 @@ int main() {
 
   // CHECK: {{^}}[[MASTER_ID]]: omp_get_num_procs()=[[NUM_PROCS:[-]?[0-9]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_get_num_procs()=[[NUM_PROCS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/api_calls_without_ompt.c
+++ b/openmp/runtime/test/ompt/misc/api_calls_without_ompt.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #define _BSD_SOURCE
 #define _DEFAULT_SOURCE
@@ -76,6 +78,7 @@ int main() {
   printf("%" PRIu64 ": ompt_get_task_info()=%d\n", tvalue,
          ompt_get_task_info(0, NULL, NULL, NULL, NULL, NULL));
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
@@ -105,6 +108,7 @@ int main() {
   // CHECK: {{^}}[[MASTER_ID]]: ompt_get_parallel_info()=0
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_get_task_info()=0
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/control_tool.c
+++ b/openmp/runtime/test/ompt/misc/control_tool.c
@@ -7,9 +7,8 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  #pragma omp parallel num_threads(1)
+int main() {
+#pragma omp parallel num_threads(1)
   {
     print_frame_from_outlined_fn(1);
     print_frame(0);

--- a/openmp/runtime/test/ompt/misc/control_tool.c
+++ b/openmp/runtime/test/ompt/misc/control_tool.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>
@@ -15,6 +17,7 @@ int main()
     print_current_address(0);
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_control_tool'
 
@@ -24,6 +27,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address(0)=[[REENTER_FRAME:(0x)?[0-f]*]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_control_tool: command=3, modifier=1, arg=[[NULL]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]*]], current_task_frame.exit=[[EXIT_FRAME]], current_task_frame.reenter={{(0x)?[0-f]*}}
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/control_tool_no_ompt_support.c
+++ b/openmp/runtime/test/ompt/misc/control_tool_no_ompt_support.c
@@ -1,4 +1,6 @@
+// clang-format off
 // RUN: %libomp-compile-and-run
+// clang-format on
 
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/misc/control_tool_no_ompt_support.c
+++ b/openmp/runtime/test/ompt/misc/control_tool_no_ompt_support.c
@@ -4,9 +4,8 @@
 
 #include <omp.h>
 
-int main()
-{
-  #pragma omp parallel num_threads(1)
+int main() {
+#pragma omp parallel num_threads(1)
   {
     omp_control_tool(omp_control_tool_flush, 1, NULL);
   }

--- a/openmp/runtime/test/ompt/misc/finalize_tool.c
+++ b/openmp/runtime/test/ompt/misc/finalize_tool.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include "omp_testsuite.h"
 
@@ -13,6 +15,7 @@ int main() {
   return get_exit_value();
 }
 
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin:
 // CHECK-SAME: thread_type=ompt_thread_initial=1
@@ -26,3 +29,4 @@ int main() {
 // CHECK: 0: ompt_event_runtime_shutdown
 
 // CHECK: {{^}}After ompt_finalize_tool
+// clang-format on

--- a/openmp/runtime/test/ompt/misc/interoperability.cpp
+++ b/openmp/runtime/test/ompt/misc/interoperability.cpp
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-cxx-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include <iostream>
 #include <thread>
@@ -43,6 +45,7 @@ int main() {
   t2.join();
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_schedule'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
@@ -120,3 +123,4 @@ int main() {
 
 // CHECK: {{^}}[[THREAD_ID_2]]: ompt_event_thread_end:
 // CHECK-SAME: thread_id=[[THREAD_ID_2]]
+// clang-format on

--- a/openmp/runtime/test/ompt/misc/interoperability.cpp
+++ b/openmp/runtime/test/ompt/misc/interoperability.cpp
@@ -57,7 +57,7 @@ int main() {
 // CHECK-SAME: thread_type=ompt_thread_initial=1, thread_id=[[MASTER_ID_1]]
 
 
-// CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}
+// CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}
 // CHECK-SAME: task_id=[[PARENT_TASK_ID_1:[0-9]+]], actual_parallelism=1,
 // CHECK-SAME: index=1, flags=1
 
@@ -73,7 +73,7 @@ int main() {
 // CHECK-SAME: invoker={{[0-9]+}}
 
 // CHECK: {{^}}[[MASTER_ID_1]]: ompt_event_initial_task_end:
-// CHECK-SAME: parallel_id={{[0-9]+}}, task_id=[[PARENT_TASK_ID_1]],
+// CHECK-SAME: parallel_id={{[0-f]+}}, task_id=[[PARENT_TASK_ID_1]],
 // CHECK-SAME: actual_parallelism=0, index=1
 
 // CHECK: {{^}}[[MASTER_ID_1]]: ompt_event_thread_end:
@@ -83,7 +83,7 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID_2:[0-9]+]]: ompt_event_thread_begin:
 // CHECK-SAME: thread_type=ompt_thread_initial=1, thread_id=[[MASTER_ID_2]]
 
-// CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}
+// CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}
 // CHECK-SAME: task_id=[[PARENT_TASK_ID_2:[0-9]+]], actual_parallelism=1,
 // CHECK-SAME: index=1, flags=1
 
@@ -100,7 +100,7 @@ int main() {
 // CHECK-SAME: invoker={{[0-9]+}}
 
 // CHECK: {{^}}[[MASTER_ID_2]]: ompt_event_initial_task_end:
-// CHECK-SAME: parallel_id={{[0-9]+}}, task_id=[[PARENT_TASK_ID_2]],
+// CHECK-SAME: parallel_id={{[0-f]+}}, task_id=[[PARENT_TASK_ID_2]],
 // CHECK-SAME: actual_parallelism=0, index=1
 
 // CHECK: {{^}}[[MASTER_ID_2]]: ompt_event_thread_end:

--- a/openmp/runtime/test/ompt/misc/lock_double_destroy.cpp
+++ b/openmp/runtime/test/ompt/misc/lock_double_destroy.cpp
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-cxx-compile-and-run | FileCheck %s
 
 // disabled until fixed, see: https://github.com/llvm/llvm-project/pull/145625#issuecomment-3007625680
 // remove "needs-fix", after fixing the issue in the runtime
 // REQUIRES: ompt, needs-fix
+// clang-format on
 #include "callback.h"
 #include "omp_testsuite.h"
 
@@ -26,6 +28,7 @@ int main() {
   return get_exit_value();
 }
 
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin:
 // CHECK-SAME: thread_type=ompt_thread_initial=1
@@ -41,3 +44,4 @@ int main() {
 // CHECK: 0: ompt_event_runtime_shutdown
 
 // CHECK: {{^}}After ompt_finalize_tool
+// clang-format on

--- a/openmp/runtime/test/ompt/misc/pause_stop_tool.c
+++ b/openmp/runtime/test/ompt/misc/pause_stop_tool.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 int main() {
@@ -23,6 +25,7 @@ int main() {
   printf("x = %d\n", x);
   return 0;
 
+  // clang-format off
   // Check if
   // -- omp_pause_resource/resource_all returns expected code
   // -- OMPT interface is shut down as expected
@@ -41,4 +44,5 @@ int main() {
   // CHECK: omp_pause_resource_all succeeded
 
   // CHECK-NOT: ompt_event
+  // clang-format on
 }

--- a/openmp/runtime/test/ompt/misc/runtime_error.c
+++ b/openmp/runtime/test/ompt/misc/runtime_error.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run 2>&1 | sort | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include <string.h>
 #include <stdio.h>
@@ -21,6 +23,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: {{^}}0: Message length=[[LENGTH:[0-9]+]]
 // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
@@ -33,3 +36,4 @@ int main() {
 
 // Message from runtime
 // CHECK: {{^}}OMP: Warning{{.*}}User message goes here
+// clang-format on

--- a/openmp/runtime/test/ompt/misc/threads.c
+++ b/openmp/runtime/test/ompt/misc/threads.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -11,6 +13,7 @@ int main() {
     x++;
   }
 
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_thread_begin:
@@ -29,6 +32,7 @@ int main() {
   // CHECK-SAME: thread_type=ompt_thread_worker=2, thread_id=[[WORKER_ID3]]
   // CHECK: {{^}}[[WORKER_ID3]]: ompt_event_thread_end:
   // CHECK-SAME: thread_id=[[WORKER_ID3]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/threads_nested.c
+++ b/openmp/runtime/test/ompt/misc/threads_nested.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -17,6 +19,7 @@ int main() {
     }
   }
 
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_thread_begin:
@@ -35,6 +38,7 @@ int main() {
   // CHECK-SAME: thread_type=ompt_thread_worker=2, thread_id=[[WORKER_ID3]]
   // CHECK: {{^}}[[WORKER_ID3]]: ompt_event_thread_end:
   // CHECK-SAME: thread_id=[[WORKER_ID3]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/misc/unset_callback.c
+++ b/openmp/runtime/test/ompt/misc/unset_callback.c
@@ -6,8 +6,7 @@
 #include "omp_testsuite.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   go_parallel_nthreads(1);
   ompt_set_callback(ompt_callback_parallel_begin, NULL);
   go_parallel_nthreads(1);

--- a/openmp/runtime/test/ompt/misc/unset_callback.c
+++ b/openmp/runtime/test/ompt/misc/unset_callback.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include "omp_testsuite.h"
 #include <omp.h>
@@ -10,6 +12,7 @@ int main()
   ompt_set_callback(ompt_callback_parallel_begin, NULL);
   go_parallel_nthreads(1);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_idle'
 
@@ -19,6 +22,7 @@ int main()
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_parallel_end:
   // CHECK-NOT: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin:
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_parallel_end:
+  // clang-format on
 
   return get_exit_value();
 }

--- a/openmp/runtime/test/ompt/ompt-signal.h
+++ b/openmp/runtime/test/ompt/ompt-signal.h
@@ -6,26 +6,25 @@
 #define delay(t) usleep(t);
 #endif
 
-// These functions are used to provide a signal-wait mechanism to enforce expected scheduling for the test cases.
-// Conditional variable (s) needs to be shared! Initialize to 0
+// These functions are used to provide a signal-wait mechanism to enforce
+// expected scheduling for the test cases. Conditional variable (s) needs to be
+// shared! Initialize to 0
 
 #define OMPT_SIGNAL(s) ompt_signal(&s)
-//inline 
-void ompt_signal(int* s) 
-{                
-  #pragma omp atomic
+// inline
+void ompt_signal(int *s) {
+#pragma omp atomic
   (*s)++;
 }
-                
-#define OMPT_WAIT(s,v) ompt_wait(&s,v)
+
+#define OMPT_WAIT(s, v) ompt_wait(&s, v)
 // wait for s >= v
-//inline 
-void ompt_wait(int *s, int v)
-{
-  int wait=0;
-  do{
+// inline
+void ompt_wait(int *s, int v) {
+  int wait = 0;
+  do {
     delay(10);
-    #pragma omp atomic read
-	  wait = (*s);
-  }while(wait<v);
+#pragma omp atomic read
+    wait = (*s);
+  } while (wait < v);
 }

--- a/openmp/runtime/test/ompt/parallel/dynamic_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/dynamic_enough_threads.c
@@ -4,11 +4,10 @@
 // clang-format on
 #include "callback.h"
 
-int main()
-{
+int main() {
   omp_set_dynamic(1);
 
-  #pragma omp parallel num_threads(4)
+#pragma omp parallel num_threads(4)
   {
     print_ids(0);
     print_ids(1);

--- a/openmp/runtime/test/ompt/parallel/dynamic_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/dynamic_enough_threads.c
@@ -29,12 +29,12 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]], team_size={{[1-4]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]], team_size={{[1-4]}}
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]

--- a/openmp/runtime/test/ompt/parallel/dynamic_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/dynamic_enough_threads.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 
 int main()
@@ -13,6 +15,7 @@ int main()
   }
   print_fuzzy_address(1);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_thread_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_thread_end'
@@ -38,6 +41,7 @@ int main()
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/dynamic_not_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/dynamic_not_enough_threads.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_THREAD_LIMIT=2 %libomp-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 
 int main()
@@ -13,6 +15,7 @@ int main()
   }
   print_fuzzy_address(1);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_thread_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_thread_end'
@@ -38,6 +41,7 @@ int main()
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/dynamic_not_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/dynamic_not_enough_threads.c
@@ -4,11 +4,10 @@
 // clang-format on
 #include "callback.h"
 
-int main()
-{
+int main() {
   omp_set_dynamic(1);
 
-  #pragma omp parallel num_threads(4)
+#pragma omp parallel num_threads(4)
   {
     print_ids(0);
     print_ids(1);

--- a/openmp/runtime/test/ompt/parallel/dynamic_not_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/dynamic_not_enough_threads.c
@@ -29,12 +29,12 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]], team_size={{[1-4]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]], team_size={{[1-4]}}
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]

--- a/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
@@ -39,35 +39,35 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=2, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=2, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
   
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=2, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=2, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=2, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=2, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -24,6 +26,7 @@ int main()
   }
   print_fuzzy_address(2);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
@@ -68,6 +71,7 @@ int main()
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/max_active_levels_serialized.c
@@ -7,16 +7,15 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   omp_set_nested(1);
   omp_set_max_active_levels(1);
 
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
     print_ids(0);
     print_ids(1);
-    #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
     {
       print_ids(0);
       print_ids(1);

--- a/openmp/runtime/test/ompt/parallel/nested.c
+++ b/openmp/runtime/test/ompt/parallel/nested.c
@@ -58,20 +58,20 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // Note that we cannot ensure that the worker threads have already called barrier_end and implicit_task_end before parallel_end!
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
@@ -80,16 +80,16 @@ int main()
 
   // THREADS: {{^}}0: NULL_POINTER=[[NULL:.*$]]
   // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: __builtin_frame_address(0)=[[MAIN_REENTER:(0x)?[0-f]+]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
   // nested parallel masters
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
-  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
+  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
   // THREADS: {{^}}[[MASTER_ID]]: __builtin_frame_address(0)=[[REENTER:(0x)?[0-f]+]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: __builtin_frame_address({{.}})=[[NESTED_EXIT:(0x)?[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_EXIT]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame={{(0x)?[0-f]+}}
@@ -105,8 +105,8 @@ int main()
   // implicit barrier
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]], codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]], codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]], codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
@@ -114,185 +114,185 @@ int main()
   // implicit barrier
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]], codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // nested parallel worker threads
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/parallel/nested.c
+++ b/openmp/runtime/test/ompt/parallel/nested.c
@@ -9,23 +9,22 @@
 #include <omp.h>
 #include <unistd.h>
 
-int main()
-{
-  int condition=0;
+int main() {
+  int condition = 0;
   omp_set_nested(1);
   print_frame(0);
 
-  #pragma omp parallel num_threads(4)
+#pragma omp parallel num_threads(4)
   {
     print_frame_from_outlined_fn(1);
     print_ids(0);
     print_ids(1);
     print_frame(0);
 
-    //get all implicit task events before starting nested:
-    #pragma omp barrier
-    
-    #pragma omp parallel num_threads(4)
+// get all implicit task events before starting nested:
+#pragma omp barrier
+
+#pragma omp parallel num_threads(4)
     {
       print_frame_from_outlined_fn(1);
       print_ids(0);
@@ -33,8 +32,8 @@ int main()
       print_ids(2);
       print_frame(0);
       OMPT_SIGNAL(condition);
-      OMPT_WAIT(condition,16);
-      #pragma omp barrier
+      OMPT_WAIT(condition, 16);
+#pragma omp barrier
       print_fuzzy_address(1);
       print_ids(0);
     }

--- a/openmp/runtime/test/ompt/parallel/nested.c
+++ b/openmp/runtime/test/ompt/parallel/nested.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/parallel/nested_lwt.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt.c
@@ -54,281 +54,281 @@ int main()
   // CHECK-NOT: 0: parallel_data initially not null
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // Note that we cannot ensure that the worker threads have already called barrier_end and implicit_task_end before parallel_end!
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
 
 
   // THREADS: 0: NULL_POINTER=[[NULL:.*$]]
-  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter=[[TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter=[[TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
   // nested parallel masters
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
-  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
+  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
 
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
 
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 2: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[NESTED_NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit=[[NESTED_NESTED_TASK_FRAME_EXIT]], parent_task_frame.reenter=[[NESTED_NESTED_TASK_FRAME_ENTER:(0x)?[0-f]+]], parallel_id=[[NESTED_NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_NESTED_TASK_FRAME_EXIT:(0x)?[0-f]+]], reenter_frame=[[NULL]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame=[[NESTED_NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NESTED_TASK_FRAME_EXIT]], reenter_frame=[[NESTED_TASK_FRAME_ENTER]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // nested parallel worker threads
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // can't reliably tell which parallel region is the parent...
-  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
-  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
+  // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}
   // THREADS: {{^}}[[THREAD_ID]]: task level 3: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[TASK_FRAME_ENTER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/parallel/nested_lwt.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt.c
@@ -8,32 +8,31 @@
 #include <omp.h>
 #include <unistd.h>
 
-int main()
-{
+int main() {
   omp_set_nested(1);
   int condition = 0;
 
-  #pragma omp parallel num_threads(4)
+#pragma omp parallel num_threads(4)
   {
     print_ids(0);
     print_ids(1);
-    //get all implicit task events before starting nested:
-    #pragma omp barrier
-    #pragma omp parallel num_threads(1)
+// get all implicit task events before starting nested:
+#pragma omp barrier
+#pragma omp parallel num_threads(1)
     {
       print_ids(0);
       print_ids(1);
       print_ids(2);
-      //get all implicit task events before starting nested:
-      #pragma omp barrier
-      #pragma omp parallel num_threads(4)
+// get all implicit task events before starting nested:
+#pragma omp barrier
+#pragma omp parallel num_threads(4)
       {
         print_ids(0);
         print_ids(1);
         print_ids(2);
         print_ids(3);
-      OMPT_SIGNAL(condition);
-      OMPT_WAIT(condition,16);
+        OMPT_SIGNAL(condition);
+        OMPT_WAIT(condition, 16);
       }
       print_fuzzy_address(1);
     }

--- a/openmp/runtime/test/ompt/parallel/nested_lwt.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 #include <unistd.h>

--- a/openmp/runtime/test/ompt/parallel/nested_lwt_thread_num.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt_thread_num.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -70,7 +72,7 @@ int main()
     }
   }
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
@@ -128,6 +130,7 @@ int main()
   // CHECK: {{^}}[[WORKER_ID]]: ancestor_level=2 id=1
   // CHECK-SAME: parallel_id=[[PARALLEL_ID_1]] task_id=[[TASK_ID_2]]
   // CHECK-SAME: thread_num=1
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/nested_lwt_thread_num.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt_thread_num.c
@@ -19,7 +19,7 @@ void print_task_info_at(int ancestor_level, int id)
                        &parallel_data, &thread_num);
     format_task_type(task_type, buffer);
     printf("%" PRIu64 ": ancestor_level=%d id=%d task_type=%s=%d "
-                      "parallel_id=%" PRIu64 " task_id=%" PRIu64
+                      "parallel_id=%" PRIx64 " task_id=%" PRIx64
                       " thread_num=%d\n",
         ompt_get_thread_data()->value, ancestor_level, id, buffer,
         task_type, parallel_data->value, task_data->value, thread_num);

--- a/openmp/runtime/test/ompt/parallel/nested_lwt_thread_num.c
+++ b/openmp/runtime/test/ompt/parallel/nested_lwt_thread_num.c
@@ -6,27 +6,26 @@
 #include "callback.h"
 #include <omp.h>
 
-
 __attribute__ ((noinline)) // workaround for bug in icc
 void print_task_info_at(int ancestor_level, int id)
 {
 #pragma omp critical
   {
     int task_type;
-    char buffer[2048];
-    ompt_data_t *parallel_data;
-    ompt_data_t *task_data;
-    int thread_num;
-    ompt_get_task_info(ancestor_level, &task_type, &task_data, NULL,
-                       &parallel_data, &thread_num);
-    format_task_type(task_type, buffer);
-    printf("%" PRIu64 ": ancestor_level=%d id=%d task_type=%s=%d "
-                      "parallel_id=%" PRIx64 " task_id=%" PRIx64
-                      " thread_num=%d\n",
-        ompt_get_thread_data()->value, ancestor_level, id, buffer,
-        task_type, parallel_data->value, task_data->value, thread_num);
-  }
-};
+char buffer[2048];
+ompt_data_t *parallel_data;
+ompt_data_t *task_data;
+int thread_num;
+ompt_get_task_info(ancestor_level, &task_type, &task_data, NULL, &parallel_data,
+                   &thread_num);
+format_task_type(task_type, buffer);
+printf("%" PRIu64 ": ancestor_level=%d id=%d task_type=%s=%d "
+       "parallel_id=%" PRIx64 " task_id=%" PRIx64 " thread_num=%d\n",
+       ompt_get_thread_data()->value, ancestor_level, id, buffer, task_type,
+       parallel_data->value, task_data->value, thread_num);
+}
+}
+;
 
 __attribute__ ((noinline)) // workaround for bug in icc
 void print_innermost_task_info(int id)
@@ -34,9 +33,7 @@ void print_innermost_task_info(int id)
   print_task_info_at(0, id);
 }
 
-
-int main()
-{
+int main() {
 
 #pragma omp parallel num_threads(2)
   {
@@ -65,9 +62,7 @@ int main()
           print_task_info_at(0, 3);
           print_task_info_at(1, 2);
           print_task_info_at(2, 1);
-
         }
-
       }
     }
   }

--- a/openmp/runtime/test/ompt/parallel/nested_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/parallel/nested_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized.c
@@ -39,91 +39,91 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // Note that we cannot ensure that the worker threads have already called barrier_end and implicit_task_end before parallel_end!
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
 
 
   // THREADS: 0: NULL_POINTER=[[NULL:.*$]]
-  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[NESTED_RETURN_ADDRESS]]
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/parallel/nested_serialized.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized.c
@@ -7,15 +7,14 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   omp_set_nested(0);
 
-  #pragma omp parallel num_threads(4)
+#pragma omp parallel num_threads(4)
   {
     print_ids(0);
     print_ids(1);
-    #pragma omp parallel num_threads(4)
+#pragma omp parallel num_threads(4)
     {
       print_ids(0);
       print_ids(1);

--- a/openmp/runtime/test/ompt/parallel/nested_serialized_task_frames.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized_task_frames.c
@@ -33,7 +33,7 @@ int main()
 
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id=[[INITIAL_PARALLEL_ID:[0-9]+]], task_id=[[INITIAL_TASK_ID:[0-9]+]], actual_parallelism=1, index=1, flags=1
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id=[[INITIAL_PARALLEL_ID:[0-f]+]], task_id=[[INITIAL_TASK_ID:[0-f]+]], actual_parallelism=1, index=1, flags=1
 
   // region 0
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin

--- a/openmp/runtime/test/ompt/parallel/nested_serialized_task_frames.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized_task_frames.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -27,6 +29,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
@@ -76,6 +79,7 @@ int main()
   // CHECK-SAME: exit_frame=[[NULL]]
   // CHECK-SAME: reenter_frame=[[INITIAL_TASK_FRAME_ENTER]]
   // CHECK-SAME: task_type=ompt_task_initial
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/nested_serialized_task_frames.c
+++ b/openmp/runtime/test/ompt/parallel/nested_serialized_task_frames.c
@@ -6,8 +6,7 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
 #pragma omp parallel num_threads(1)
   {
     // region 0

--- a/openmp/runtime/test/ompt/parallel/nested_thread_num.c
+++ b/openmp/runtime/test/ompt/parallel/nested_thread_num.c
@@ -53,10 +53,10 @@ int main() {
 // CHECK-NOT: 0: thread_data initially not null
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-// CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]],
+// CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
 // CHECK-SAME: requested_team_size=2,
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
 // CHECK-SAME: invoker=[[PARALLEL_INVOKER:[0-9]+]]
@@ -77,17 +77,17 @@ int main() {
 // THREADS: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 // THREADS: __builtin_frame_address(0)=[[MAIN_REENTER:(0x)?[0-f]+]]
 // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-// THREADS-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], 
+// THREADS-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], 
 // THREADS-SAME: parent_task_frame.exit=[[NULL]],
 // THREADS-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// THREADS-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=2,
+// THREADS-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=2,
 // THREADS-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
 // THREADS-SAME: invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
 // nested parallel masters
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
 // THREADS-SAME: parallel_id=[[PARALLEL_ID]], 
-// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]],
+// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]],
 // THREADS-SAME: team_size=2, thread_num=0
 
 // THREADS: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
@@ -98,7 +98,7 @@ int main() {
 // THREADS-SAME: thread_num=0
 
 // THREADS: {{^}}[[MASTER_ID]]: task level 1:
-// THREADS-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], 
+// THREADS-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], 
 // THREADS-SAME: task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], 
 // THREADS-SAME: reenter_frame={{(0x)?[0-f]+}}
 
@@ -108,14 +108,14 @@ int main() {
 // THREADS-SAME: parent_task_id=[[IMPLICIT_TASK_ID]], 
 // THREADS-SAME: parent_task_frame.exit=[[EXIT]],
 // THREADS-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], 
+// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], 
 // THREADS-SAME: requested_team_size=2,
 // THREADS-SAME: codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
 // THREADS-SAME: invoker=[[PARALLEL_INVOKER]]
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
 // THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID]],
-// THREADS-SAME: task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]], team_size=2, 
+// THREADS-SAME: task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]], team_size=2, 
 // THREADS-SAME: thread_num=0
 
 // THREADS: __builtin_frame_address({{.}})=[[NESTED_EXIT:(0x)?[0-f]+]]
@@ -173,11 +173,11 @@ int main() {
 // THREADS-SAME: exit_frame=[[NULL]], reenter_frame=[[NULL]]
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]],
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]],
 // THREADS-SAME: codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}}
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end:
 // THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID]], 
@@ -203,11 +203,11 @@ int main() {
 // THREADS-SAME: reenter_frame=[[NULL]]
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]],
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]],
 // THREADS-SAME: codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end:
 // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]],
@@ -220,7 +220,7 @@ int main() {
 
 // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin:
 // THREADS-SAME: parallel_id=[[PARALLEL_ID]], 
-// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]], team_size=2, 
+// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]], team_size=2, 
 // THREADS-SAME: thread_num=[[OUTER_THREADNUM:[0-9]+]]
 
 // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
@@ -235,13 +235,13 @@ int main() {
 // THREADS-SAME: parent_task_id=[[IMPLICIT_TASK_ID]], 
 // THREADS-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // THREADS-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=2,
+// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=2,
 // THREADS-SAME: codeptr_ra=[[NESTED_RETURN_ADDRESS]]{{[0-f][0-f]}},
 // THREADS-SAME: invoker=[[PARALLEL_INVOKER]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin:
 // THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID]],
-// THREADS-SAME: task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// THREADS-SAME: task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // THREADS-SAME: thread_num=[[INNER_THREADNUM:[0-9]+]]
 
 // THREADS: {{^}}[[THREAD_ID]]: task level 0:
@@ -264,10 +264,10 @@ int main() {
 // THREADS-SAME: task_id=[[NESTED_IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[NESTED_IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_parallel_end:
 // THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID]], 
@@ -279,16 +279,16 @@ int main() {
 // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
 // nested parallel worker threads
 
 // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin:
-// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]],
-// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]],
+// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 // THREADS-SAME: thread_num=[[THREADNUM:[0-9]+]]
 
 // THREADS: {{^}}[[THREAD_ID]]: task level 0:
@@ -298,8 +298,8 @@ int main() {
 
 // can't reliably tell which parallel region is the parent...
 
-// THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}},
-// THREADS-SAME: task_id={{[0-9]+}}
+// THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}},
+// THREADS-SAME: task_id={{[0-f]+}}
 // THREADS-SAME: thread_num={{[01]}}
 
 // THREADS: {{^}}[[THREAD_ID]]: task level 2:
@@ -314,16 +314,16 @@ int main() {
 // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
 // other nested parallel worker threads
 
 // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin:
-// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]],
-// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// THREADS-SAME: parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]],
+// THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 // THREADS-SAME: thread_num=[[THREADNUM:[0-9]+]]
 
 // THREADS: {{^}}[[THREAD_ID]]: task level 0:
@@ -333,8 +333,8 @@ int main() {
 
 // can't reliably tell which parallel region is the parent...
 
-// THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-9]+}},
-// THREADS-SAME: task_id={{[0-9]+}}
+// THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id={{[0-f]+}},
+// THREADS-SAME: task_id={{[0-f]+}}
 // THREADS-SAME: thread_num={{[01]}}
 
 // THREADS: {{^}}[[THREAD_ID]]: task level 2:
@@ -349,8 +349,8 @@ int main() {
 // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end:
-// THREADS-SAME: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+// THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 

--- a/openmp/runtime/test/ompt/parallel/nested_thread_num.c
+++ b/openmp/runtime/test/ompt/parallel/nested_thread_num.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>
@@ -42,6 +44,7 @@ int main() {
 
   return 0;
 }
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -353,4 +356,4 @@ int main() {
 
 // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end:
 // THREADS-SAME: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
-
+// clang-format on

--- a/openmp/runtime/test/ompt/parallel/nested_threadnum.c
+++ b/openmp/runtime/test/ompt/parallel/nested_threadnum.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include <omp.h>
 #include "callback.h"
 
@@ -12,6 +14,7 @@ int main() {
     { print_frame(0); }
   }
 
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
@@ -57,6 +60,7 @@ int main() {
   // CHECK-SAME: thread_num=[[INNER_THREAD_NUM4:[0-9]+]]
   // CHECK: {{^}}[[WORKER_ID3]]: ompt_event_implicit_task_end
   // CHECK-SAME: thread_num=[[INNER_THREAD_NUM4]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/nested_threadnum.c
+++ b/openmp/runtime/test/ompt/parallel/nested_threadnum.c
@@ -15,7 +15,7 @@ int main() {
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
   // CHECK-SAME: thread_num=[[OUTER_THREAD_NUM1:[0-9]+]]

--- a/openmp/runtime/test/ompt/parallel/no_thread_num_clause.c
+++ b/openmp/runtime/test/ompt/parallel/no_thread_num_clause.c
@@ -31,20 +31,20 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
-  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
+  // CHECK-DAG: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // Note that we cannot ensure that the worker threads have already called barrier_end and implicit_task_end before parallel_end!
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-DAG: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK-DAG: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
@@ -52,46 +52,46 @@ int main()
 
   // THREADS: 0: NULL_POINTER=[[NULL:.*$]]
   // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_thread_begin: thread_type=ompt_thread_initial=1, thread_id=[[MASTER_ID]]
-  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, actual_parallelism=1, index=1, flags=1 
+  // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, actual_parallelism=1, index=1, flags=1 
 
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker={{[0-9]+}}
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker={{[0-9]+}}
 
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
   // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
   // THREADS: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_thread_begin: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/parallel/no_thread_num_clause.c
+++ b/openmp/runtime/test/ompt/parallel/no_thread_num_clause.c
@@ -5,10 +5,9 @@
 // clang-format on
 #include "callback.h"
 
-int main()
-{
+int main() {
   omp_set_num_threads(4);
-  #pragma omp parallel
+#pragma omp parallel
   {
     print_ids(0);
     print_ids(1);

--- a/openmp/runtime/test/ompt/parallel/no_thread_num_clause.c
+++ b/openmp/runtime/test/ompt/parallel/no_thread_num_clause.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 
 int main()

--- a/openmp/runtime/test/ompt/parallel/normal.c
+++ b/openmp/runtime/test/ompt/parallel/normal.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | %sort-threads \
 // RUN:                         | FileCheck --check-prefix=THREADS %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 
 int main() {
@@ -12,6 +14,7 @@ int main() {
   }
   print_fuzzy_address(1);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -130,6 +133,7 @@ int main() {
   // THREADS-SAME: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS-SAME: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/normal.c
+++ b/openmp/runtime/test/ompt/parallel/normal.c
@@ -46,19 +46,19 @@ int main() {
   // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_thread_begin
   // THREADS-SAME: thread_type=ompt_thread_initial=1, thread_id=[[MASTER_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin
-  // THREADS-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]]
   // THREADS-SAME: parent_task_frame.exit=[[NULL]]
   // THREADS-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // THREADS-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4
+  // THREADS-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4
   // THREADS-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
 
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]]
-  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1
-  // THREADS-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]]
+  // THREADS-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]]
   // THREADS-SAME: task_id=[[PARENT_TASK_ID]]
   // THREADS-NOT: ompt_event_implicit_task_end
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin
@@ -78,7 +78,7 @@ int main() {
   // THREADS-SAME: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]]
-  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1
@@ -97,7 +97,7 @@ int main() {
   // THREADS-SAME: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]]
-  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1
@@ -116,7 +116,7 @@ int main() {
   // THREADS-SAME: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]]
-  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1

--- a/openmp/runtime/test/ompt/parallel/not_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/not_enough_threads.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_THREAD_LIMIT=2 %libomp-run | FileCheck %s
 // RUN: %libomp-compile && env OMP_THREAD_LIMIT=2 %libomp-run | %sort-threads \
 // RUN:     | FileCheck --check-prefix=THREADS %s
 
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 
@@ -14,6 +16,7 @@ int main() {
   }
   print_fuzzy_address(1);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -85,6 +88,7 @@ int main() {
   // THREADS-SAME: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // THREADS-SAME: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/not_enough_threads.c
+++ b/openmp/runtime/test/ompt/parallel/not_enough_threads.c
@@ -40,19 +40,19 @@ int main() {
   // THREADS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_thread_begin
   // THREADS-SAME: thread_type=ompt_thread_initial=1, thread_id=[[MASTER_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin
-  // THREADS-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]]
   // THREADS-SAME: parent_task_frame.exit=[[NULL]]
   // THREADS-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // THREADS-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4
+  // THREADS-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4
   // THREADS-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
 
   // THREADS: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]]
-  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 0
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[MASTER_ID]]: task level 1
-  // THREADS-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]]
+  // THREADS-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]]
   // THREADS-SAME: task_id=[[PARENT_TASK_ID]]
 
   // THREADS-NOT: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end
@@ -71,7 +71,7 @@ int main() {
   // THREADS-SAME: thread_type=ompt_thread_worker=2, thread_id=[[THREAD_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_begin
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]]
-  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // THREADS-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 0
   // THREADS-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // THREADS: {{^}}[[THREAD_ID]]: task level 1

--- a/openmp/runtime/test/ompt/parallel/parallel_if0.c
+++ b/openmp/runtime/test/ompt/parallel/parallel_if0.c
@@ -5,25 +5,24 @@
 // clang-format on
 #include "callback.h"
 
-int main()
-{
-//  print_frame(0);
-  #pragma omp parallel if(0)
+int main() {
+  //  print_frame(0);
+#pragma omp parallel if (0)
   {
-//    print_frame(1);
+    //    print_frame(1);
     print_ids(0);
     print_ids(1);
-//    print_frame(0);
-    #pragma omp parallel if(0)
+    //    print_frame(0);
+#pragma omp parallel if (0)
     {
-//      print_frame(1);
+      //      print_frame(1);
       print_ids(0);
       print_ids(1);
       print_ids(2);
-//      print_frame(0);
-      #pragma omp task
+      //      print_frame(0);
+#pragma omp task
       {
-//        print_frame(1);
+        //        print_frame(1);
         print_ids(0);
         print_ids(1);
         print_ids(2);

--- a/openmp/runtime/test/ompt/parallel/parallel_if0.c
+++ b/openmp/runtime/test/ompt/parallel/parallel_if0.c
@@ -45,18 +45,18 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[NESTED_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[EXPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[EXPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule: first_task_id=[[NESTED_IMPLICIT_TASK_ID]], second_task_id=[[EXPLICIT_TASK_ID]], prior_task_status=ompt_task_switch=7
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[EXPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame={{(0x)?[0-f]+}}

--- a/openmp/runtime/test/ompt/parallel/parallel_if0.c
+++ b/openmp/runtime/test/ompt/parallel/parallel_if0.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 
 int main()
@@ -32,6 +34,7 @@ int main()
   }
   print_fuzzy_address(2);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
@@ -71,6 +74,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/region_in_expl_task_task_frames.c
+++ b/openmp/runtime/test/ompt/parallel/region_in_expl_task_task_frames.c
@@ -38,7 +38,7 @@ int main()
 
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id=[[INITIAL_PARALLEL_ID:[0-9]+]], task_id=[[INITIAL_TASK_ID:[0-9]+]], actual_parallelism=1, index=1, flags=1
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id=[[INITIAL_PARALLEL_ID:[0-f]+]], task_id=[[INITIAL_TASK_ID:[0-f]+]], actual_parallelism=1, index=1, flags=1
 
   // region 0
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin

--- a/openmp/runtime/test/ompt/parallel/region_in_expl_task_task_frames.c
+++ b/openmp/runtime/test/ompt/parallel/region_in_expl_task_task_frames.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -32,6 +34,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
@@ -82,6 +85,7 @@ int main()
   // CHECK-SAME: exit_frame=[[NULL]]
   // CHECK-SAME: reenter_frame=[[INITIAL_TASK_FRAME_ENTER]]
   // CHECK-SAME: task_type=ompt_task_initial
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/region_in_expl_task_task_frames.c
+++ b/openmp/runtime/test/ompt/parallel/region_in_expl_task_task_frames.c
@@ -6,13 +6,12 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
 #pragma omp parallel num_threads(2)
   {
     if (omp_get_thread_num() == 0) {
       // region 0
-#pragma omp task if(0)
+#pragma omp task if (0)
       {
         // explicit task immediately executed by the initial master thread
 #pragma omp parallel num_threads(2)

--- a/openmp/runtime/test/ompt/parallel/repeated_calls.c
+++ b/openmp/runtime/test/ompt/parallel/repeated_calls.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #define USE_PRIVATE_TOOL 1
 #include "callback.h"
@@ -31,6 +33,7 @@ int main() {
   y = foo(y);
   return 0;
 
+  // clang-format off
   // CHECK-NOT: {{^}}0: Could not register callback
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
@@ -44,7 +47,7 @@ int main() {
   // Second call to foo
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin
   // CHECK-SAME: {{.*}}codeptr_ra=[[RETURN_ADDRESS]]
-
+  // clang-format on
 }
 
 static void on_ompt_callback_thread_begin(

--- a/openmp/runtime/test/ompt/parallel/repeated_calls.c
+++ b/openmp/runtime/test/ompt/parallel/repeated_calls.c
@@ -6,8 +6,7 @@
 #define USE_PRIVATE_TOOL 1
 #include "callback.h"
 
-__attribute__((noinline))
-int foo(int x) {
+__attribute__((noinline)) int foo(int x) {
 #pragma omp parallel num_threads(2)
   {
 #pragma omp atomic
@@ -16,8 +15,7 @@ int foo(int x) {
   return x;
 }
 
-__attribute__((noinline))
-int bar(int x) {
+__attribute__((noinline)) int bar(int x) {
 #pragma omp parallel num_threads(2)
   {
 #pragma omp critical
@@ -50,9 +48,8 @@ int main() {
   // clang-format on
 }
 
-static void on_ompt_callback_thread_begin(
-    ompt_thread_t thread_type,
-    ompt_data_t *thread_data) {
+static void on_ompt_callback_thread_begin(ompt_thread_t thread_type,
+                                          ompt_data_t *thread_data) {
   if (thread_data->ptr)
     printf("%s\n", "0: thread_data initially not null");
   thread_data->value = ompt_get_unique_id();

--- a/openmp/runtime/test/ompt/parallel/serialized.c
+++ b/openmp/runtime/test/ompt/parallel/serialized.c
@@ -5,25 +5,24 @@
 // clang-format on
 #include "callback.h"
 
-int main()
-{
-//  print_frame(0);
-  #pragma omp parallel num_threads(1)
+int main() {
+  //  print_frame(0);
+#pragma omp parallel num_threads(1)
   {
-//    print_frame(1);
+    //    print_frame(1);
     print_ids(0);
     print_ids(1);
-//    print_frame(0);
-    #pragma omp parallel num_threads(1)
+    //    print_frame(0);
+#pragma omp parallel num_threads(1)
     {
-//      print_frame(1);
+      //      print_frame(1);
       print_ids(0);
       print_ids(1);
       print_ids(2);
-//      print_frame(0);
-      #pragma omp task
+      //      print_frame(0);
+#pragma omp task
       {
-//        print_frame(1);
+        //        print_frame(1);
         print_ids(0);
         print_ids(1);
         print_ids(2);

--- a/openmp/runtime/test/ompt/parallel/serialized.c
+++ b/openmp/runtime/test/ompt/parallel/serialized.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 
 int main()
@@ -32,6 +34,7 @@ int main()
   }
   print_fuzzy_address(2);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_end'
@@ -72,6 +75,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], invoker=[[PARALLEL_INVOKER]], codeptr_ra=[[OUTER_RETURN_ADDRESS]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[OUTER_RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/parallel/serialized.c
+++ b/openmp/runtime/test/ompt/parallel/serialized.c
@@ -45,18 +45,18 @@ int main()
   // CHECK-NOT: 0: task_data initially not null
   // CHECK-NOT: 0: thread_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[OUTER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[OUTER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra=[[INNER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[NESTED_PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra=[[INNER_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker=[[PARALLEL_INVOKER]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[EXPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[NESTED_IMPLICIT_TASK_ID]], parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[EXPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule: first_task_id=[[NESTED_IMPLICIT_TASK_ID]], second_task_id=[[EXPLICIT_TASK_ID]], prior_task_status=ompt_task_switch=7
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[EXPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame=[[NULL]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[NESTED_PARALLEL_ID]], task_id=[[NESTED_IMPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}, reenter_frame={{(0x)?[0-f]+}}

--- a/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
@@ -6,19 +6,18 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   int x = 0;
 
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp atomic
+#pragma omp atomic
     x++;
 
-    #pragma omp barrier
+#pragma omp barrier
     print_current_address();
 
-    #pragma omp atomic
+#pragma omp atomic
     x++;
   }
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/explicit.c
@@ -28,31 +28,31 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread explicit barrier
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_explicit_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_explicit_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_explicit_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_explicit_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_explicit_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_explicit_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_explicit_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_explicit_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
 
   // master thread implicit barrier at parallel end
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
 
   // worker thread explicit barrier
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_explicit_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_explicit_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_explicit_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_explicit_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_explicit_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_explicit_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_explicit_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_explicit_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[THREAD_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
 
   // worker thread implicit barrier at parallel end
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
@@ -28,28 +28,28 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread implicit barrier at loop end
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
   // master thread implicit barrier at parallel end
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
   // worker thread implicit barrier at loop end
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
   // worker thread implicit barrier after parallel
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_loop.c
@@ -6,17 +6,15 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  int y[] = {0,1,2,3};
+int main() {
+  int y[] = {0, 1, 2, 3};
 
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    //implicit barrier at end of for loop
+    // implicit barrier at end of for loop
     int i;
-    #pragma omp for
-    for (i = 0; i < 4; i++)
-    {
+#pragma omp for
+    for (i = 0; i < 4; i++) {
       y[i]++;
     }
     print_current_address();

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_simd.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_simd.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // XFAIL: gcc-4
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_simd.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_simd.c
@@ -7,14 +7,12 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  int y[] = {0,1,2,3};
+int main() {
+  int y[] = {0, 1, 2, 3};
 
   int i;
-  #pragma omp for simd
-  for (i = 0; i < 4; i++)
-  {
+#pragma omp for simd
+  for (i = 0; i < 4; i++) {
     y[i]++;
   }
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/for_simd.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/for_simd.c
@@ -24,10 +24,10 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread implicit barrier at simd loop end
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/barrier/implicit_task_data.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/implicit_task_data.c
@@ -16,21 +16,16 @@
 #include <omp.h>
 #include <omp-tools.h>
 
-static const char* ompt_thread_t_values[] = {
-  NULL,
-  "ompt_thread_initial",
-  "ompt_thread_worker",
-  "ompt_thread_other"
-};
+static const char *ompt_thread_t_values[] = {
+    NULL, "ompt_thread_initial", "ompt_thread_worker", "ompt_thread_other"};
 
 static ompt_get_unique_id_t ompt_get_unique_id;
 static ompt_get_thread_data_t ompt_get_thread_data;
 
-int main()
-{
-  #pragma omp parallel num_threads(4)
+int main() {
+#pragma omp parallel num_threads(4)
   {
-    #pragma omp master
+#pragma omp master
     {
       sleep(1);
     }
@@ -60,25 +55,23 @@ int main()
   return 0;
 }
 
-static void
-on_ompt_callback_thread_begin(
-  ompt_thread_t thread_type,
-  ompt_data_t *thread_data)
-{
-  if(thread_data->ptr)
+static void on_ompt_callback_thread_begin(ompt_thread_t thread_type,
+                                          ompt_data_t *thread_data) {
+  if (thread_data->ptr)
     printf("%s\n", "0: thread_data initially not null");
   thread_data->value = ompt_get_unique_id();
-  printf("%" PRIu64 ": ompt_event_thread_begin: thread_type=%s=%d, thread_id=%" PRIu64 "\n", ompt_get_thread_data()->value, ompt_thread_t_values[thread_type], thread_type, thread_data->value);
+  printf("%" PRIu64
+         ": ompt_event_thread_begin: thread_type=%s=%d, thread_id=%" PRIu64
+         "\n",
+         ompt_get_thread_data()->value, ompt_thread_t_values[thread_type],
+         thread_type, thread_data->value);
 }
 
-static void
-on_ompt_callback_sync_region(
-  ompt_sync_region_t kind,
-  ompt_scope_endpoint_t endpoint,
-  ompt_data_t *parallel_data,
-  ompt_data_t *task_data,
-  const void *codeptr_ra)
-{
+static void on_ompt_callback_sync_region(ompt_sync_region_t kind,
+                                         ompt_scope_endpoint_t endpoint,
+                                         ompt_data_t *parallel_data,
+                                         ompt_data_t *task_data,
+                                         const void *codeptr_ra) {
   // We only expect implicit parallel barrier in this code.
   if (kind != ompt_sync_region_barrier_implicit_parallel) {
     printf("unexpected ompt_sync_region_t passed to %s\n", __func__);
@@ -101,14 +94,11 @@ on_ompt_callback_sync_region(
          codeptr_ra);
 }
 
-static void
-on_ompt_callback_sync_region_wait(
-  ompt_sync_region_t kind,
-  ompt_scope_endpoint_t endpoint,
-  ompt_data_t *parallel_data,
-  ompt_data_t *task_data,
-  const void *codeptr_ra)
-{
+static void on_ompt_callback_sync_region_wait(ompt_sync_region_t kind,
+                                              ompt_scope_endpoint_t endpoint,
+                                              ompt_data_t *parallel_data,
+                                              ompt_data_t *task_data,
+                                              const void *codeptr_ra) {
   if (kind != ompt_sync_region_barrier_implicit_parallel) {
     printf("unexpected ompt_sync_region_t passed to %s\n", __func__);
     exit(-1);
@@ -129,38 +119,36 @@ on_ompt_callback_sync_region_wait(
          codeptr_ra);
 }
 
-#define register_ompt_callback_t(name, type)                       \
-do{                                                           \
-  type f_##name = &on_##name;                                 \
-  if (ompt_set_callback(name, (ompt_callback_t)f_##name) ==   \
-      ompt_set_never)                                         \
-    printf("0: Could not register callback '" #name "'\n");   \
-}while(0)
+#define register_ompt_callback_t(name, type)                                   \
+  do {                                                                         \
+    type f_##name = &on_##name;                                                \
+    if (ompt_set_callback(name, (ompt_callback_t)f_##name) == ompt_set_never)  \
+      printf("0: Could not register callback '" #name "'\n");                  \
+  } while (0)
 
 #define register_ompt_callback(name) register_ompt_callback_t(name, name##_t)
 
 int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num,
                     ompt_data_t *tool_data) {
   ompt_set_callback_t ompt_set_callback;
-  ompt_set_callback = (ompt_set_callback_t) lookup("ompt_set_callback");
-  ompt_get_unique_id = (ompt_get_unique_id_t) lookup("ompt_get_unique_id");
-  ompt_get_thread_data = (ompt_get_thread_data_t) lookup("ompt_get_thread_data");
+  ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
+  ompt_get_unique_id = (ompt_get_unique_id_t)lookup("ompt_get_unique_id");
+  ompt_get_thread_data = (ompt_get_thread_data_t)lookup("ompt_get_thread_data");
   register_ompt_callback(ompt_callback_sync_region);
-  register_ompt_callback_t(ompt_callback_sync_region_wait, ompt_callback_sync_region_t);
+  register_ompt_callback_t(ompt_callback_sync_region_wait,
+                           ompt_callback_sync_region_t);
   register_ompt_callback(ompt_callback_thread_begin);
-  printf("0: NULL_POINTER=%p\n", (void*)NULL);
-  return 1; //success
+  printf("0: NULL_POINTER=%p\n", (void *)NULL);
+  return 1; // success
 }
 
-void ompt_finalize(ompt_data_t *tool_data)
-{
+void ompt_finalize(ompt_data_t *tool_data) {
   printf("0: ompt_event_runtime_shutdown\n");
 }
 
-ompt_start_tool_result_t* ompt_start_tool(
-  unsigned int omp_version,
-  const char *runtime_version)
-{
-  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,&ompt_finalize, 0};
+ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
+                                          const char *runtime_version) {
+  static ompt_start_tool_result_t ompt_start_tool_result = {&ompt_initialize,
+                                                            &ompt_finalize, 0};
   return &ompt_start_tool_result;
 }

--- a/openmp/runtime/test/ompt/synchronization/barrier/implicit_task_data.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/implicit_task_data.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 
@@ -6,6 +7,7 @@
 // Therefore, callback implementations different from the ones in callback.h are necessary.
 // This is a test for an issue reported in 
 // https://github.com/OpenMPToolsInterface/LLVM-openmp/issues/39
+// clang-format on
 
 #define _BSD_SOURCE
 #include <stdio.h>

--- a/openmp/runtime/test/ompt/synchronization/barrier/implicit_task_data.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/implicit_task_data.c
@@ -42,14 +42,14 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread implicit barrier at parallel end
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=0, task_id=[[TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]*}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=0, task_id=[[TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]*}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id=0, task_id=[[TASK_ID]], codeptr_ra={{(0x)?[0-f]*}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id=0, task_id=[[TASK_ID]], codeptr_ra={{(0x)?[0-f]*}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id=0, task_id=[[TASK_ID]], codeptr_ra={{(0x)?[0-f]*}}
 
 
   // worker thread implicit barrier at parallel end
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=0, task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=0, task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[NULL]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id=0, task_id=[[TASK_ID]], codeptr_ra=[[NULL]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id=0, task_id=[[TASK_ID]], codeptr_ra=[[NULL]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id=0, task_id=[[TASK_ID]], codeptr_ra=[[NULL]]

--- a/openmp/runtime/test/ompt/synchronization/barrier/parallel_region.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/parallel_region.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/parallel_region.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/parallel_region.c
@@ -5,14 +5,13 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   int x = 0;
 
-  //implicit barrier at end of a parallel region
-  #pragma omp parallel num_threads(2)
+// implicit barrier at end of a parallel region
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp atomic
+#pragma omp atomic
     x++;
   }
   print_fuzzy_address();

--- a/openmp/runtime/test/ompt/synchronization/barrier/parallel_region.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/parallel_region.c
@@ -23,18 +23,18 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread implicit barrier at parallel end
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
 
   // worker thread implicit barrier at parallel end
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/barrier/sections.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/sections.c
@@ -5,25 +5,24 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   int x = 0;
 
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    //implicit barrier after sections with nowait but with lastprivates
-    //implicit barrier at end of sections
-    #pragma omp sections
+// implicit barrier after sections with nowait but with lastprivates
+// implicit barrier at end of sections
+#pragma omp sections
     {
-      #pragma omp section 
+#pragma omp section
       {
-        #pragma omp atomic
+#pragma omp atomic
         x++;
       }
-      
-      #pragma omp section 
+
+#pragma omp section
       {
-        #pragma omp atomic
+#pragma omp atomic
         x++;
       }
     }

--- a/openmp/runtime/test/ompt/synchronization/barrier/sections.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/sections.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads  | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/sections.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/sections.c
@@ -35,29 +35,29 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread implicit barrier at sections end
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
   // master thread implicit barrier at parallel end
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
 
   // worker thread implicit barrier at sections end
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
   // worker thread implicit barrier at parallel end
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/barrier/single.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/single.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 

--- a/openmp/runtime/test/ompt/synchronization/barrier/single.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/single.c
@@ -6,20 +6,19 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   int x = 0;
 
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    //implicit barrier at end of single
-    #pragma omp single
+// implicit barrier at end of single
+#pragma omp single
     {
       x++;
     }
     print_fuzzy_address();
-    //critical section to avoid merge of two barriers into one
-    #pragma omp critical
+// critical section to avoid merge of two barriers into one
+#pragma omp critical
     {
       x++;
     }

--- a/openmp/runtime/test/ompt/synchronization/barrier/single.c
+++ b/openmp/runtime/test/ompt/synchronization/barrier/single.c
@@ -31,31 +31,31 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // master thread implicit barrier at single end
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
   // master thread implicit barrier at parallel end
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
 
 
   // worker thread implicit barrier at single end
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_workshare_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
   // worker thread implicit barrier at parallel end
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_wait_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[NULL]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/critical.c
+++ b/openmp/runtime/test/ompt/synchronization/critical.c
@@ -6,9 +6,8 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  #pragma omp critical
+int main() {
+#pragma omp critical
   {
     print_current_address(1);
     print_ids(0);

--- a/openmp/runtime/test/ompt/synchronization/critical.c
+++ b/openmp/runtime/test/ompt/synchronization/critical.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -13,7 +15,7 @@ int main()
   }
   print_current_address(2);
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -27,6 +29,7 @@ int main()
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_release_critical: wait_id=[[WAIT_ID]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/flush.c
+++ b/openmp/runtime/test/ompt/synchronization/flush.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the flush construct
 // XFAIL: gcc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -17,6 +19,7 @@ int main() {
 
   return 0;
 }
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_flush'
 
@@ -28,3 +31,4 @@ int main() {
 // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_flush:
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
 // CHECK: {{^}}[[THREAD_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
+// clang-format on

--- a/openmp/runtime/test/ompt/synchronization/lock.c
+++ b/openmp/runtime/test/ompt/synchronization/lock.c
@@ -5,14 +5,14 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  //need to use an OpenMP construct so that OMPT will be initialized
-  #pragma omp parallel num_threads(1)
-    print_ids(0);
+int main() {
+// need to use an OpenMP construct so that OMPT will be initialized
+#pragma omp parallel num_threads(1)
+  print_ids(0);
 
   omp_lock_t lock;
-  printf("%" PRIu64 ": &lock: %" PRIu64 "\n", ompt_get_thread_data()->value, (ompt_wait_id_t)(uintptr_t) &lock);
+  printf("%" PRIu64 ": &lock: %" PRIu64 "\n", ompt_get_thread_data()->value,
+         (ompt_wait_id_t)(uintptr_t)&lock);
   omp_init_lock(&lock);
   print_fuzzy_address(1);
   omp_set_lock(&lock);

--- a/openmp/runtime/test/ompt/synchronization/lock.c
+++ b/openmp/runtime/test/ompt/synchronization/lock.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -20,7 +22,7 @@ int main()
   omp_destroy_lock(&lock);
   print_fuzzy_address(4);
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -39,6 +41,7 @@ int main()
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_destroy_lock: wait_id=[[WAIT_ID]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
- 
+  // clang-format on
+
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/masked.c
+++ b/openmp/runtime/test/ompt/synchronization/masked.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the master construct
 // XFAIL: gcc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -23,6 +25,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_masked'
 
@@ -36,3 +39,4 @@ int main() {
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS_END:(0x)?[0-f]+]]
 // CHECK: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS_END]]
+// clang-format on

--- a/openmp/runtime/test/ompt/synchronization/masked.c
+++ b/openmp/runtime/test/ompt/synchronization/masked.c
@@ -29,7 +29,7 @@ int main() {
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_masked_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]], task_id=[[TASK_ID:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
 // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_masked_end:

--- a/openmp/runtime/test/ompt/synchronization/master.c
+++ b/openmp/runtime/test/ompt/synchronization/master.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the master construct
 // XFAIL: gcc
+// clang-format on
 
 #define USE_PRIVATE_TOOL 1
 #include "callback.h"
@@ -76,6 +78,7 @@ ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
   return &ompt_start_tool_result;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_master'
 
@@ -87,3 +90,4 @@ ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_master_end:
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS_END:(0x)?[0-f]+]]
 // CHECK: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS_END]]
+// clang-format on

--- a/openmp/runtime/test/ompt/synchronization/nest_lock.c
+++ b/openmp/runtime/test/ompt/synchronization/nest_lock.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -25,7 +27,7 @@ int main()
   omp_destroy_nest_lock(&nest_lock);
   print_fuzzy_address(6);
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -48,6 +50,7 @@ int main()
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_destroy_nest_lock: wait_id=[[WAIT_ID]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/nest_lock.c
+++ b/openmp/runtime/test/ompt/synchronization/nest_lock.c
@@ -5,11 +5,10 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  //need to use an OpenMP construct so that OMPT will be initialized
-  #pragma omp parallel num_threads(1)
-    print_ids(0);
+int main() {
+// need to use an OpenMP construct so that OMPT will be initialized
+#pragma omp parallel num_threads(1)
+  print_ids(0);
 
   omp_nest_lock_t nest_lock;
   printf("%" PRIu64 ": &nest_lock: %" PRIu64 "\n",

--- a/openmp/runtime/test/ompt/synchronization/ordered.c
+++ b/openmp/runtime/test/ompt/synchronization/ordered.c
@@ -6,9 +6,8 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  #pragma omp ordered
+int main() {
+#pragma omp ordered
   {
     print_current_address(1);
     print_ids(0);

--- a/openmp/runtime/test/ompt/synchronization/ordered.c
+++ b/openmp/runtime/test/ompt/synchronization/ordered.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -12,8 +14,8 @@ int main()
     print_ids(0);
   }
   print_current_address(2);
-  
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -27,6 +29,7 @@ int main()
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_release_ordered: wait_id=[[WAIT_ID]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
-  
+  // clang-format on
+
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/ordered_dependences.c
+++ b/openmp/runtime/test/ompt/synchronization/ordered_dependences.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-c99-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -21,6 +23,7 @@ int main() {
 
   return 0;
 }
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK: {{^}}[[MASTER:[0-9]+]]: ompt_event_loop_static_begin:
@@ -58,3 +61,4 @@ int main() {
 // CHECK: {{^}}[[WORKER]]: ompt_event_dependences: task_id=[[ITASK]],
 // CHECK-SAME: deps=[(1, ompt_dependence_type_source), (1,
 // CHECK-SAME: ompt_dependence_type_source)], ndeps=2
+// clang-format on

--- a/openmp/runtime/test/ompt/synchronization/ordered_dependences.c
+++ b/openmp/runtime/test/ompt/synchronization/ordered_dependences.c
@@ -24,7 +24,7 @@ int main() {
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK: {{^}}[[MASTER:[0-9]+]]: ompt_event_loop_static_begin:
-// CHECK-SAME: parallel_id={{[0-9]+}}, task_id=[[ITASK:[0-9]+]],
+// CHECK-SAME: parallel_id={{[0-f]+}}, task_id=[[ITASK:[0-9]+]],
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_dependences: task_id=[[ITASK]],
 // CHECK-SAME: deps=[(0, ompt_dependence_type_source), (0,
@@ -39,7 +39,7 @@ int main() {
 // CHECK-SAME: ompt_dependence_type_source)], ndeps=2
 
 // CHECK: {{^}}[[WORKER:[0-9]+]]: ompt_event_loop_static_begin:
-// CHECK-SAME: parallel_id={{[0-9]+}}, task_id=[[ITASK:[0-9]+]],
+// CHECK-SAME: parallel_id={{[0-f]+}}, task_id=[[ITASK:[0-9]+]],
 
 // CHECK: {{^}}[[WORKER]]: ompt_event_dependences: task_id=[[ITASK]],
 // CHECK-SAME: deps=[(0, ompt_dependence_type_sink), (0,

--- a/openmp/runtime/test/ompt/synchronization/reduction/empty_reduce.c
+++ b/openmp/runtime/test/ompt/synchronization/reduction/empty_reduce.c
@@ -23,9 +23,9 @@ int main() {
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-f]+]]
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_reduction_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]],

--- a/openmp/runtime/test/ompt/synchronization/reduction/empty_reduce.c
+++ b/openmp/runtime/test/ompt/synchronization/reduction/empty_reduce.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile -DNOWAIT && %libomp-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -20,6 +22,7 @@ int main() {
     sum += i;
   }
 
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
@@ -33,6 +36,7 @@ int main() {
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_reduction_end:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]],
   // CHECK-SAME: task_id=[[TASK_ID]], codeptr_ra=
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/reduction/tree_reduce.c
+++ b/openmp/runtime/test/ompt/synchronization/reduction/tree_reduce.c
@@ -23,7 +23,6 @@ int main() {
     a = b = sum += i;
   }
 
-
   printf("%i\n", sum);
   // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]

--- a/openmp/runtime/test/ompt/synchronization/reduction/tree_reduce.c
+++ b/openmp/runtime/test/ompt/synchronization/reduction/tree_reduce.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // RUN: %libomp-compile -DNOWAIT && %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -23,6 +25,7 @@ int main() {
 
 
   printf("%i\n", sum);
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
@@ -47,6 +50,7 @@ int main() {
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_end:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/reduction/tree_reduce.c
+++ b/openmp/runtime/test/ompt/synchronization/reduction/tree_reduce.c
@@ -26,27 +26,27 @@ int main() {
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-f]+]]
 
   // order and distribution to threads not determined
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_end:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_end:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_end:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
   // CHECK: {{^}}{{[0-f]+}}: ompt_event_reduction_end:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/taskgroup.c
+++ b/openmp/runtime/test/ompt/synchronization/taskgroup.c
@@ -37,7 +37,7 @@ int main()
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_taskgroup_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_taskgroup_begin: parallel_id=[[PARALLEL_ID:[0-f]+]], task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskgroup_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskgroup_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra=[[RETURN_ADDRESS]]

--- a/openmp/runtime/test/ompt/synchronization/taskgroup.c
+++ b/openmp/runtime/test/ompt/synchronization/taskgroup.c
@@ -5,23 +5,22 @@
 // clang-format on
 
 #include "callback.h"
-#include <unistd.h>  
+#include <unistd.h>
 #include <stdio.h>
 
-int main()
-{
-  int condition=0;
-  int x=0;
-  #pragma omp parallel num_threads(2)
+int main() {
+  int condition = 0;
+  int x = 0;
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
-      #pragma omp taskgroup
+#pragma omp taskgroup
       {
         print_current_address(1);
-        #pragma omp task
+#pragma omp task
         {
-          #pragma omp atomic
+#pragma omp atomic
           x++;
         }
       }

--- a/openmp/runtime/test/ompt/synchronization/taskgroup.c
+++ b/openmp/runtime/test/ompt/synchronization/taskgroup.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN:  %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 
 #include "callback.h"
 #include <unistd.h>  
@@ -27,7 +29,7 @@ int main()
     }
   }
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_schedule'
@@ -43,6 +45,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskgroup_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_taskgroup_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/taskwait.c
+++ b/openmp/runtime/test/ompt/synchronization/taskwait.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -20,6 +22,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_sync_region'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_sync_region_wait'
@@ -31,6 +34,7 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskwait_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: ompt_event_taskwait_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/taskwait.c
+++ b/openmp/runtime/test/ompt/synchronization/taskwait.c
@@ -26,10 +26,10 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_taskwait_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskwait_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskwait_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
-  // CHECK-NEXT: {{^}}[[MASTER_ID]]: ompt_event_taskwait_end: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_taskwait_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskwait_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_taskwait_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
+  // CHECK-NEXT: {{^}}[[MASTER_ID]]: ompt_event_taskwait_end: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, codeptr_ra=[[RETURN_ADDRESS]]
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: current_address={{.*}}[[RETURN_ADDRESS]]
 
   return 0;

--- a/openmp/runtime/test/ompt/synchronization/taskwait.c
+++ b/openmp/runtime/test/ompt/synchronization/taskwait.c
@@ -6,18 +6,17 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   int x = 0;
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
-      #pragma omp task
+#pragma omp task
       {
         x++;
       }
-      #pragma omp taskwait
+#pragma omp taskwait
       print_current_address(1);
     }
   }

--- a/openmp/runtime/test/ompt/synchronization/test_lock.c
+++ b/openmp/runtime/test/ompt/synchronization/test_lock.c
@@ -6,8 +6,7 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   omp_lock_t lock;
   omp_init_lock(&lock);
   print_fuzzy_address(1);

--- a/openmp/runtime/test/ompt/synchronization/test_lock.c
+++ b/openmp/runtime/test/ompt/synchronization/test_lock.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -25,6 +27,7 @@ int main()
   omp_destroy_lock(&lock);
   print_fuzzy_address(7);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -49,6 +52,7 @@ int main()
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_destroy_lock: wait_id=[[WAIT_ID]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-NEXT: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/test_nest_lock.c
+++ b/openmp/runtime/test/ompt/synchronization/test_nest_lock.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -19,6 +21,7 @@ int main()
 
   omp_destroy_nest_lock(&nest_lock);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -36,7 +39,8 @@ int main()
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_wait_test_nest_lock: wait_id=[[WAIT_ID]], hint=0, impl={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_acquired_nest_lock_next: wait_id=[[WAIT_ID]], codeptr_ra={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_release_nest_lock_prev: wait_id=[[WAIT_ID]], codeptr_ra={{(0x)?[0-f]+}}  
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_release_nest_lock_last: wait_id=[[WAIT_ID]], codeptr_ra={{(0x)?[0-f]+}}  
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_release_nest_lock_last: wait_id=[[WAIT_ID]], codeptr_ra={{(0x)?[0-f]+}}
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/test_nest_lock.c
+++ b/openmp/runtime/test/ompt/synchronization/test_nest_lock.c
@@ -6,8 +6,7 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   omp_nest_lock_t nest_lock;
   omp_init_nest_lock(&nest_lock);
 

--- a/openmp/runtime/test/ompt/synchronization/test_nest_lock_parallel.c
+++ b/openmp/runtime/test/ompt/synchronization/test_nest_lock_parallel.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 
@@ -31,6 +33,7 @@ int main()
 
   omp_destroy_nest_lock(&nest_lock);
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquire'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_mutex_acquired'
@@ -55,6 +58,7 @@ int main()
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_wait_test_nest_lock: wait_id=[[WAIT_ID]], hint=0, impl={{[0-9]+}}, codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-NOT: {{^}}[[THREAD_ID]]: ompt_event_acquired_test_nest_lock_next: wait_id=[[WAIT_ID]]
   // CHECK-NEXT: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/synchronization/test_nest_lock_parallel.c
+++ b/openmp/runtime/test/ompt/synchronization/test_nest_lock_parallel.c
@@ -6,23 +6,22 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   omp_nest_lock_t nest_lock;
   omp_init_nest_lock(&nest_lock);
 
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
       omp_set_nest_lock(&nest_lock);
       print_fuzzy_address(1);
     }
-    #pragma omp barrier
-    omp_test_nest_lock(&nest_lock); //should fail for non-master
+#pragma omp barrier
+    omp_test_nest_lock(&nest_lock); // should fail for non-master
     print_fuzzy_address(2);
-    #pragma omp barrier
-    #pragma omp master
+#pragma omp barrier
+#pragma omp master
     {
       omp_unset_nest_lock(&nest_lock);
       print_fuzzy_address(3);

--- a/openmp/runtime/test/ompt/tasks/dependences.c
+++ b/openmp/runtime/test/ompt/tasks/dependences.c
@@ -48,8 +48,8 @@ int main() {
 // CHECK-NOT: 0: new_task_data initially not null
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
 // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT:(0x)?[0-f]+]],
@@ -57,7 +57,7 @@ int main() {
 
 // CHECK: {{^}}[[MASTER_ID]]: address of x: [[ADDRX:(0x)?[0-f]+]]
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[FIRST_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
@@ -73,7 +73,7 @@ int main() {
 // CHECK-SAME: reenter_frame=[[NULL]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[SECOND_TASK:[0-f]+]], codeptr_ra={{(0x)?[0-f]+}},
 // CHECK-SAME: task_type=ompt_task_explicit=4, has_dependences=yes

--- a/openmp/runtime/test/ompt/tasks/dependences.c
+++ b/openmp/runtime/test/ompt/tasks/dependences.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -37,6 +39,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_dependences'
@@ -88,3 +91,4 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
 // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]],
 // CHECK-SAME: reenter_frame=[[NULL]]
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/dependences.c
+++ b/openmp/runtime/test/ompt/tasks/dependences.c
@@ -11,7 +11,7 @@
 
 int main() {
   int x = 0;
-  int condition=0;
+  int condition = 0;
 #pragma omp parallel num_threads(2)
   {
 #pragma omp master
@@ -22,7 +22,7 @@ int main() {
 #pragma omp task depend(out : x) shared(condition)
       {
         x++;
-        OMPT_WAIT(condition,1);
+        OMPT_WAIT(condition, 1);
       }
       print_fuzzy_address(1);
       print_ids(0);

--- a/openmp/runtime/test/ompt/tasks/dependences_mutexinoutset.c
+++ b/openmp/runtime/test/ompt/tasks/dependences_mutexinoutset.c
@@ -62,8 +62,8 @@ int main() {
 // CHECK-NOT: 0: new_task_data initially not null
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
 // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT:(0x)?[0-f]+]],
@@ -71,7 +71,7 @@ int main() {
 
 // CHECK: {{^}}[[MASTER_ID]]: address of x: [[ADDRX:(0x)?[0-f]+]]
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[FIRST_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
@@ -87,7 +87,7 @@ int main() {
 // CHECK-SAME: reenter_frame=[[NULL]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[SECOND_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
@@ -103,7 +103,7 @@ int main() {
 // CHECK-SAME: reenter_frame=[[NULL]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[THIRD_TASK:[0-f]+]], codeptr_ra={{(0x)?[0-f]+}},
 // CHECK-SAME: task_type=ompt_task_explicit=4, has_dependences=yes

--- a/openmp/runtime/test/ompt/tasks/dependences_mutexinoutset.c
+++ b/openmp/runtime/test/ompt/tasks/dependences_mutexinoutset.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 
@@ -9,6 +10,7 @@
 
 // clang 9 introduced codegen for mutexinoutset
 // UNSUPPORTED: clang-4, clang-5, clang-6, clang-7, clang-8
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -51,6 +53,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_dependences'
@@ -115,3 +118,4 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
 // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]],
 // CHECK-SAME: reenter_frame=[[NULL]]
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/explicit_task.c
+++ b/openmp/runtime/test/ompt/tasks/explicit_task.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h> 

--- a/openmp/runtime/test/ompt/tasks/explicit_task.c
+++ b/openmp/runtime/test/ompt/tasks/explicit_task.c
@@ -53,16 +53,16 @@ int main()
   // CHECK-NOT: 0: new_task_data initially not null
   
   // CHECK--doesnotwork: {{^}}[[MASTER_ID:[0-9]+]]: __builtin_frame_address(0)=[[MAIN_REENTER:(0x)?[0-f]+]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
   // nested parallel masters
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address(0)=[[REENTER:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // <- ompt_event_task_create would be expected here
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // explicit barrier after master
@@ -72,10 +72,10 @@ int main()
   // implicit barrier parallel
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
@@ -93,8 +93,8 @@ int main()
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_explicit_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/tasks/explicit_task.c
+++ b/openmp/runtime/test/ompt/tasks/explicit_task.c
@@ -5,23 +5,22 @@
 // clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
-#include <omp.h> 
+#include <omp.h>
 
-int main()
-{
-  int condition=0;
+int main() {
+  int condition = 0;
   omp_set_nested(0);
   print_frame(0);
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
     print_frame_from_outlined_fn(1);
     print_ids(0);
     print_ids(1);
     print_frame(0);
-    #pragma omp master
+#pragma omp master
     {
       print_ids(0);
-      #pragma omp task shared(condition)
+#pragma omp task shared(condition)
       {
         OMPT_SIGNAL(condition);
         print_frame(1);
@@ -30,10 +29,10 @@ int main()
         print_ids(2);
       }
       print_fuzzy_address(1);
-      OMPT_WAIT(condition,1);
+      OMPT_WAIT(condition, 1);
       print_ids(0);
     }
-    #pragma omp barrier
+#pragma omp barrier
     print_ids(0);
   }
 

--- a/openmp/runtime/test/ompt/tasks/explicit_task_thread_num.c
+++ b/openmp/runtime/test/ompt/tasks/explicit_task_thread_num.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -45,6 +47,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_event_parallel_begin'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
@@ -62,6 +65,7 @@ int main()
   // CHECK-SAME: thread_num=1
   // CHECK: {{^}}[[WID]]: ancestor_level=1 id=0 task_type=ompt_task_implicit
   // CHECK-SAME: thread_num=1
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/explicit_task_thread_num.c
+++ b/openmp/runtime/test/ompt/tasks/explicit_task_thread_num.c
@@ -6,30 +6,28 @@
 #include "callback.h"
 #include <omp.h>
 
-
 __attribute__ ((noinline)) // workaround for bug in icc
 void print_task_info_at(int ancestor_level, int id)
 {
 #pragma omp critical
   {
     int task_type;
-    char buffer[2048];
-    ompt_data_t *parallel_data;
-    ompt_data_t *task_data;
-    int thread_num;
-    ompt_get_task_info(ancestor_level, &task_type, &task_data, NULL,
-                       &parallel_data, &thread_num);
-    format_task_type(task_type, buffer);
-    printf("%" PRIu64 ": ancestor_level=%d id=%d task_type=%s=%d "
-                      "parallel_id=%" PRIu64 " task_id=%" PRIu64
-                      " thread_num=%d\n",
-        ompt_get_thread_data()->value, ancestor_level, id, buffer,
-        task_type, parallel_data->value, task_data->value, thread_num);
-  }
-};
+char buffer[2048];
+ompt_data_t *parallel_data;
+ompt_data_t *task_data;
+int thread_num;
+ompt_get_task_info(ancestor_level, &task_type, &task_data, NULL, &parallel_data,
+                   &thread_num);
+format_task_type(task_type, buffer);
+printf("%" PRIu64 ": ancestor_level=%d id=%d task_type=%s=%d "
+       "parallel_id=%" PRIu64 " task_id=%" PRIu64 " thread_num=%d\n",
+       ompt_get_thread_data()->value, ancestor_level, id, buffer, task_type,
+       parallel_data->value, task_data->value, thread_num);
+}
+}
+;
 
-int main()
-{
+int main() {
 
 #pragma omp parallel num_threads(2)
   {
@@ -38,7 +36,7 @@ int main()
       // To assert that task is executed by the worker thread,
       // if(0) is used in order to ensure that the task is immediately
       // executed after its creation.
-#pragma omp task if(0)
+#pragma omp task if (0)
       {
         // thread_num should be equal to 1 for both explicit and implicit task
         print_task_info_at(0, 1);

--- a/openmp/runtime/test/ompt/tasks/kmp_task_depend_all.c
+++ b/openmp/runtime/test/ompt/tasks/kmp_task_depend_all.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 
@@ -66,6 +67,7 @@
 // CHECK: ompt_event_dependences:
 // CHECK-SAME: ompt_dependence_type_in
 // CHECK-SAME: ndeps=1
+// clang-format on
 
 #include "callback.h"
 #include <stdio.h>

--- a/openmp/runtime/test/ompt/tasks/omp_task_depend_all.c
+++ b/openmp/runtime/test/ompt/tasks/omp_task_depend_all.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 
@@ -65,6 +66,7 @@
 // CHECK: ompt_event_dependences:
 // CHECK-SAME: ompt_dependence_type_in
 // CHECK-SAME: ndeps=1
+// clang-format on
 
 #include "callback.h"
 #include <stdio.h>

--- a/openmp/runtime/test/ompt/tasks/serialized.c
+++ b/openmp/runtime/test/ompt/tasks/serialized.c
@@ -51,22 +51,22 @@ int main() {
   // make sure initial data pointers are null
   // CHECK-NOT: 0: new_task_data initially not null
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}
-  // CHECK-SAME: task_id={{[0-9]+}}, actual_parallelism=1, index=1, flags=1 
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}
+  // CHECK-SAME: task_id={{[0-f]+}}, actual_parallelism=1, index=1, flags=1 
 
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address(0)
   // CHECK-SAME: =[[MAIN_REENTER:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin
-  // CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]]
+  // CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]]
   // CHECK-SAME: parent_task_frame.exit=[[NULL]]
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=2
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=2
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
 
   // nested parallel masters
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
-  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address
   // CHECK-SAME: =[[EXIT:(0x)?[0-f]+]]
 
@@ -75,7 +75,7 @@ int main() {
   // CHECK-SAME: exit_frame=[[EXIT]], reenter_frame=[[NULL]]
 
   // CHECK: {{^}}[[MASTER_ID]]: task level 1
-  // CHECK-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]]
   // CHECK-SAME: task_id=[[PARENT_TASK_ID]],
   // CHECK-SAME: exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
 
@@ -84,7 +84,7 @@ int main() {
   // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID]]
   // CHECK-SAME: parent_task_frame.exit=[[EXIT]]
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: new_task_id=[[TASK_ID:[0-9]+]]
+  // CHECK-SAME: new_task_id=[[TASK_ID:[0-f]+]]
   // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule:
@@ -127,7 +127,7 @@ int main() {
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
-  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: __builtin_frame_address
   // CHECK-SAME: =[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 0

--- a/openmp/runtime/test/ompt/tasks/serialized.c
+++ b/openmp/runtime/test/ompt/tasks/serialized.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h>
@@ -43,6 +45,7 @@ int main() {
     print_ids(0);
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -150,6 +153,7 @@ int main() {
 
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end
   // CHECK-SAME: parallel_id=0, task_id=[[IMPLICIT_TASK_ID]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/serialized.c
+++ b/openmp/runtime/test/ompt/tasks/serialized.c
@@ -25,14 +25,16 @@ int main() {
 #pragma omp task if (t)
       {
         if (creator_frame == get_frame_address(0)) {
-          printf("Assume this code was inlined which the compiler is allowed to do:\n");
+          printf("Assume this code was inlined which the compiler is allowed "
+                 "to do:\n");
           print_frame(0);
         } else if (creator_frame == get_frame_address(1)) {
           printf("Assume this code was called from the application:\n");
           print_frame(1);
         } else {
           // The exit frame must be our parent!
-          printf("Assume this code was not inlined, exit frame must be our parent:\n");
+          printf("Assume this code was not inlined, exit frame must be our "
+                 "parent:\n");
           print_frame_from_outlined_fn(1);
         }
         print_ids(0);

--- a/openmp/runtime/test/ompt/tasks/task_early_fulfill.c
+++ b/openmp/runtime/test/ompt/tasks/task_early_fulfill.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_NUM_THREADS='3' \
 // RUN:    %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
@@ -10,6 +11,7 @@
 // UNSUPPORTED: clang-10, clang-9, clang-8, clang-7
 // icc compiler does not support detach clause.
 // UNSUPPORTED: icc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -26,6 +28,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_schedule'
@@ -69,3 +72,4 @@ int main() {
 // CHECK-SAME: first_task_id=[[TASK_ID]],
 // CHECK-SAME: second_task_id=[[IMPLICIT_TASK_ID]],
 // CHECK-SAME: prior_task_status=ompt_task_complete=1
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/task_early_fulfill.c
+++ b/openmp/runtime/test/ompt/tasks/task_early_fulfill.c
@@ -39,21 +39,21 @@ int main() {
 // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-// CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]],
+// CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
 // CHECK-SAME: requested_team_size=3,
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]],
-// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
 // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: new_task_id=[[TASK_ID:[0-9]+]],
+// CHECK-SAME: new_task_id=[[TASK_ID:[0-f]+]],
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_task_schedule:
 // CHECK-SAME: first_task_id=[[IMPLICIT_TASK_ID]],
@@ -62,7 +62,7 @@ int main() {
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_task_schedule:
 // CHECK-SAME: first_task_id=[[TASK_ID]],
-// CHECK-SAME: second_task_id=18446744073709551615,
+// CHECK-SAME: second_task_id=ffffffffffffffff,
 // CHECK-SAME: prior_task_status=ompt_task_early_fulfill=5
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_task_schedule:

--- a/openmp/runtime/test/ompt/tasks/task_if0-depend.c
+++ b/openmp/runtime/test/ompt/tasks/task_if0-depend.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -25,6 +27,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_dependences'
@@ -73,3 +76,4 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_end: task_id=[[SECOND_TASK]]
 
 // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/task_if0-depend.c
+++ b/openmp/runtime/test/ompt/tasks/task_if0-depend.c
@@ -36,8 +36,8 @@ int main() {
 // CHECK-NOT: 0: new_task_data initially not null
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
 // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT:(0x)?[0-f]+]],
@@ -46,7 +46,7 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: address of x: [[ADDRX:(0x)?[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[FIRST_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
@@ -59,7 +59,7 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[SECOND_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},

--- a/openmp/runtime/test/ompt/tasks/task_in_joinbarrier.c
+++ b/openmp/runtime/test/ompt/tasks/task_in_joinbarrier.c
@@ -4,23 +4,22 @@
 // clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
-#include <omp.h> 
+#include <omp.h>
 
-int main()
-{
-  int condition=0;
+int main() {
+  int condition = 0;
   omp_set_nested(0);
   print_frame(0);
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
     print_frame_from_outlined_fn(1);
     print_ids(0);
     print_ids(1);
     print_frame(0);
-    #pragma omp master
+#pragma omp master
     {
       print_ids(0);
-      #pragma omp task shared(condition)
+#pragma omp task shared(condition)
       {
         OMPT_SIGNAL(condition);
         print_frame(1);
@@ -28,7 +27,7 @@ int main()
         print_ids(1);
         print_ids(2);
       }
-      OMPT_WAIT(condition,1);
+      OMPT_WAIT(condition, 1);
       print_ids(0);
     }
     print_ids(0);

--- a/openmp/runtime/test/ompt/tasks/task_in_joinbarrier.c
+++ b/openmp/runtime/test/ompt/tasks/task_in_joinbarrier.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h> 

--- a/openmp/runtime/test/ompt/tasks/task_in_joinbarrier.c
+++ b/openmp/runtime/test/ompt/tasks/task_in_joinbarrier.c
@@ -50,24 +50,24 @@ int main()
   // CHECK-NOT: 0: new_task_data initially not null
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: __builtin_frame_address(0)=[[MAIN_REENTER:(0x)?[0-f]+]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
   // nested parallel masters
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address(0)=[[REENTER:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // <- ompt_event_task_create would be expected here
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[TASK_FUNCTION:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[TASK_FUNCTION:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // implicit barrier parallel
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
@@ -82,8 +82,8 @@ int main()
   // CHECK: {{^}}[[THREAD_ID]]: task level 2: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_task_schedule: first_task_id=[[TASK_ID]], second_task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_task_end: task_id=[[TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/tasks/task_late_fulfill.c
+++ b/openmp/runtime/test/ompt/tasks/task_late_fulfill.c
@@ -47,15 +47,15 @@ int main() {
 // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-// CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-9]+]],
+// CHECK-SAME: parent_task_id=[[PARENT_TASK_ID:[0-f]+]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
 // CHECK-SAME: requested_team_size=3,
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]],
-// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 
 // The following is to match the taskwait task created in __kmpc_omp_wait_deps
 // this should go away, once codegen for "detached if(0)" is fixed
@@ -68,7 +68,7 @@ int main() {
 // CHECK-SAME: parent_task_id=[[IMPLICIT_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: new_task_id=[[TASK_ID:[0-9]+]],
+// CHECK-SAME: new_task_id=[[TASK_ID:[0-f]+]],
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_task_schedule:
 // CHECK-SAME: first_task_id=[[IMPLICIT_TASK_ID]],
@@ -82,5 +82,5 @@ int main() {
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_task_schedule:
 // CHECK-SAME: first_task_id=[[TASK_ID]],
-// CHECK-SAME: second_task_id=18446744073709551615,
+// CHECK-SAME: second_task_id=ffffffffffffffff,
 // CHECK-SAME: prior_task_status=ompt_task_late_fulfill=6

--- a/openmp/runtime/test/ompt/tasks/task_late_fulfill.c
+++ b/openmp/runtime/test/ompt/tasks/task_late_fulfill.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile && env OMP_NUM_THREADS='3' \
 // RUN:    %libomp-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
@@ -10,6 +11,7 @@
 // UNSUPPORTED: clang-10, clang-9, clang-8, clang-7
 // icc compiler does not support detach clause.
 // UNSUPPORTED: icc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -34,6 +36,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_schedule'
@@ -84,3 +87,4 @@ int main() {
 // CHECK-SAME: first_task_id=[[TASK_ID]],
 // CHECK-SAME: second_task_id=ffffffffffffffff,
 // CHECK-SAME: prior_task_status=ompt_task_late_fulfill=6
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/task_memory.c
+++ b/openmp/runtime/test/ompt/tasks/task_memory.c
@@ -95,7 +95,7 @@ ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
 
 // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
-// CHECK: ompt_event_implicit_task_begin: task_id=[[TASK_ID:[0-9]+]]
+// CHECK: ompt_event_implicit_task_begin: task_id=[[TASK_ID:[0-f]+]]
 // CHECK-SAME: memory_addr=[[NULL]], memory_size=0, result=0
 
 // CHECK: ompt_event_task_create: task_id=[[TASK_ID_0:[0-9]+]]

--- a/openmp/runtime/test/ompt/tasks/task_memory.c
+++ b/openmp/runtime/test/ompt/tasks/task_memory.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 #define USE_PRIVATE_TOOL 1
 #include "callback.h"
 #include <omp.h>
@@ -93,6 +95,7 @@ ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
   return &ompt_start_tool_result;
 }
 
+// clang-format off
 // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK: ompt_event_implicit_task_begin: task_id=[[TASK_ID:[0-f]+]]
@@ -109,3 +112,4 @@ ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version,
 
 // CHECK: ompt_event_implicit_task_end: task_id=[[TASK_ID]]
 // CHECK-SAME: memory_addr=[[NULL]], memory_size=0, result=0
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/task_types.c
+++ b/openmp/runtime/test/ompt/tasks/task_types.c
@@ -7,7 +7,7 @@
 #include <math.h>
 
 int main() {
-  //initialize the OpenMP runtime
+  // initialize the OpenMP runtime
   omp_get_num_threads();
 
   // initial task

--- a/openmp/runtime/test/ompt/tasks/task_types.c
+++ b/openmp/runtime/test/ompt/tasks/task_types.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #include "callback.h"
 #include <omp.h>
 #include <math.h>
@@ -85,6 +87,7 @@ int main() {
     // TODO: merged task
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
@@ -215,6 +218,7 @@ int main() {
   // CHECK-SAME: task_type=ompt_task_explicit|ompt_task_undeferred
   // CHECK-SAME:|ompt_task_final=671088644
   // CHECK-SAME: thread_num={{[01]}}
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/task_types.c
+++ b/openmp/runtime/test/ompt/tasks/task_types.c
@@ -91,29 +91,29 @@ int main() {
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}
-  // CHECK-SAME: task_id=[[INITIAL_TASK_ID:[0-9]+]], actual_parallelism=1, index=1, flags=1 
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}
+  // CHECK-SAME: task_id=[[INITIAL_TASK_ID:[0-f]+]], actual_parallelism=1, index=1, flags=1 
 
   // CHECK-NOT: 0: parallel_data initially not null
 
   // initial task
-  // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id={{[0-9]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id={{[0-f]+}}
   // CHECK-SAME: task_id=[[INITIAL_TASK_ID]], exit_frame=[[NULL]]
   // CHECK-SAME: reenter_frame=[[NULL]]
   // CHECK-SAME: task_type=ompt_task_initial=1, thread_num=0
 
   // implicit task
-  // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id={{[0-9]+}}
-  // CHECK-SAME: task_id={{[0-9]+}}, exit_frame={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id={{[0-f]+}}
+  // CHECK-SAME: task_id={{[0-f]+}}, exit_frame={{(0x)?[0-f]+}}
   // CHECK-SAME: reenter_frame=[[NULL]]
   // CHECK-SAME: task_type=ompt_task_implicit|ompt_task_undeferred=134217730
   // CHECK-SAME: thread_num=0
 
   // explicit task
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}
   // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}}
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: new_task_id=[[EXPLICIT_TASK_ID:[0-9]+]]
+  // CHECK-SAME: new_task_id=[[EXPLICIT_TASK_ID:[0-f]+]]
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
   // CHECK-SAME: task_type=ompt_task_explicit=4
   // CHECK-SAME: has_dependences=no
@@ -121,16 +121,16 @@ int main() {
   // CHECK: [[THREAD_ID_1:[0-9]+]]: ompt_event_task_schedule:
   // CHECK-SAME: second_task_id=[[EXPLICIT_TASK_ID]]
 
-  // CHECK: [[THREAD_ID_1]]: task level 0: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK: [[THREAD_ID_1]]: task level 0: parallel_id=[[PARALLEL_ID:[0-f]+]]
   // CHECK-SAME: task_id=[[EXPLICIT_TASK_ID]], exit_frame={{(0x)?[0-f]+}}
   // CHECK-SAME: reenter_frame=[[NULL]], task_type=ompt_task_explicit=4
   // CHECK-SAME: thread_num={{[01]}}
 
   // explicit task with undeferred
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}
   // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}}
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: new_task_id=[[EXPLICIT_UNDEFERRED_TASK_ID:[0-9]+]]
+  // CHECK-SAME: new_task_id=[[EXPLICIT_UNDEFERRED_TASK_ID:[0-f]+]]
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
   // CHECK-SAME: task_type=ompt_task_explicit|ompt_task_undeferred=134217732
   // CHECK-SAME: has_dependences=no
@@ -145,10 +145,10 @@ int main() {
   // CHECK-SAME: thread_num={{[01]}}
 
   // explicit task with untied
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}
   // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}}
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: new_task_id=[[EXPLICIT_UNTIED_TASK_ID:[0-9]+]]
+  // CHECK-SAME: new_task_id=[[EXPLICIT_UNTIED_TASK_ID:[0-f]+]]
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
   // CHECK-SAME: task_type=ompt_task_explicit|ompt_task_untied=268435460
   // CHECK-SAME: has_dependences=no
@@ -179,10 +179,10 @@ int main() {
   // CHECK-SAME: thread_num={{[01]}}
 
   // explicit task with final
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}
   // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}}
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: new_task_id=[[EXPLICIT_FINAL_TASK_ID:[0-9]+]]
+  // CHECK-SAME: new_task_id=[[EXPLICIT_FINAL_TASK_ID:[0-f]+]]
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
   // CHECK-SAME: task_type=ompt_task_explicit|ompt_task_final=536870916
   // CHECK-SAME: has_dependences=no
@@ -197,10 +197,10 @@ int main() {
   // CHECK-SAME: thread_num={{[01]}}
 
   // nested explicit task with final and undeferred
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}
   // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}}
   // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}}
-  // CHECK-SAME: new_task_id=[[NESTED_FINAL_UNDEFERRED_TASK_ID:[0-9]+]]
+  // CHECK-SAME: new_task_id=[[NESTED_FINAL_UNDEFERRED_TASK_ID:[0-f]+]]
   // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}
   // CHECK-SAME: task_type=ompt_task_explicit|ompt_task_undeferred
   // CHECK-SAME:|ompt_task_final=671088644

--- a/openmp/runtime/test/ompt/tasks/task_types_serialized.c
+++ b/openmp/runtime/test/ompt/tasks/task_types_serialized.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -80,7 +82,7 @@ int main()
     //TODO: merged task
   }
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
@@ -109,6 +111,7 @@ int main()
 
   // ___CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
   // ___CHECK: {{^[0-9]+}}: id=7 task_type=ompt_task_explicit|ompt_task_undeferred=134217732
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/task_types_serialized.c
+++ b/openmp/runtime/test/ompt/tasks/task_types_serialized.c
@@ -9,77 +9,78 @@
 __attribute__ ((noinline)) // workaround for bug in icc
 void print_task_type(int id)
 {
-  #pragma omp critical
+#pragma omp critical
   {
     int task_type;
-    char buffer[2048];
-    ompt_get_task_info(0, &task_type, NULL, NULL, NULL, NULL);
-    format_task_type(task_type, buffer);
-    printf("%" PRIu64 ": id=%d task_type=%s=%d\n", ompt_get_thread_data()->value, id, buffer, task_type);
-  }
-};
+char buffer[2048];
+ompt_get_task_info(0, &task_type, NULL, NULL, NULL, NULL);
+format_task_type(task_type, buffer);
+printf("%" PRIu64 ": id=%d task_type=%s=%d\n", ompt_get_thread_data()->value,
+       id, buffer, task_type);
+}
+}
+;
 
-int main()
-{
-  //initial task
+int main() {
+  // initial task
   print_task_type(0);
 
   int x;
-  //implicit task
-  #pragma omp parallel num_threads(1)
+// implicit task
+#pragma omp parallel num_threads(1)
   {
     print_task_type(1);
     x++;
   }
 
-  #pragma omp parallel num_threads(1)
-  #pragma omp master
+#pragma omp parallel num_threads(1)
+#pragma omp master
   {
-    //explicit task
-    #pragma omp task
+// explicit task
+#pragma omp task
     {
       print_task_type(2);
       x++;
     }
 
-    //explicit task with undeferred
-    #pragma omp task if(0)
+// explicit task with undeferred
+#pragma omp task if (0)
     {
       print_task_type(3);
       x++;
     }
 
-    //explicit task with untied
-    #pragma omp task untied
+// explicit task with untied
+#pragma omp task untied
     {
       print_task_type(4);
       x++;
     }
 
-    //explicit task with final
-    #pragma omp task final(1)
+// explicit task with final
+#pragma omp task final(1)
     {
       print_task_type(5);
       x++;
-      //nested explicit task with final and undeferred
-      #pragma omp task
+// nested explicit task with final and undeferred
+#pragma omp task
       {
         print_task_type(6);
         x++;
       }
     }
 
-/*
-    //TODO:not working
-    //explicit task with mergeable
-    #pragma omp task mergeable
-    {
-      print_task_type(7);
-      x++;
-    }
-*/
+    /*
+        //TODO:not working
+        //explicit task with mergeable
+        #pragma omp task mergeable
+        {
+          print_task_type(7);
+          x++;
+        }
+    */
 
-    //TODO: merged task
+    // TODO: merged task
   }
 
   // clang-format off

--- a/openmp/runtime/test/ompt/tasks/task_types_serialized.c
+++ b/openmp/runtime/test/ompt/tasks/task_types_serialized.c
@@ -88,26 +88,26 @@ int main()
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
   
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-9]+}}, task_id={{[0-9]+}}, actual_parallelism=1, index=1, flags=1
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id={{[0-f]+}}, task_id={{[0-f]+}}, actual_parallelism=1, index=1, flags=1
   // CHECK: {{^}}[[MASTER_ID]]: id=0 task_type=ompt_task_initial=1
   // CHECK: {{^}}[[MASTER_ID]]: id=1 task_type=ompt_task_implicit|ompt_task_undeferred=134217730
 
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
   // CHECK: {{^[0-9]+}}: id=2 task_type=ompt_task_explicit|ompt_task_undeferred=134217732
 
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
   // CHECK: {{^[0-9]+}}: id=3 task_type=ompt_task_explicit|ompt_task_undeferred=134217732
 
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_untied=402653188, has_dependences=no
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_untied=402653188, has_dependences=no
   // CHECK: {{^[0-9]+}}: id=4 task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_untied=402653188
 
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_final=671088644, has_dependences=no
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_final=671088644, has_dependences=no
   // CHECK: {{^[0-9]+}}: id=5 task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_final=671088644
 
-  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_final=671088644, has_dependences=no
+  // CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_final=671088644, has_dependences=no
   // CHECK: {{^[0-9]+}}: id=6 task_type=ompt_task_explicit|ompt_task_undeferred|ompt_task_final=671088644
 
-  // ___CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
+  // ___CHECK: {{^[0-9]+}}: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit|ompt_task_undeferred=134217732, has_dependences=no
   // ___CHECK: {{^[0-9]+}}: id=7 task_type=ompt_task_explicit|ompt_task_undeferred=134217732
 
   return 0;

--- a/openmp/runtime/test/ompt/tasks/taskloop.c
+++ b/openmp/runtime/test/ompt/tasks/taskloop.c
@@ -26,8 +26,8 @@ int main() {
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-  // CHECK-SAME: parent_task_id={{[0-9]+}}
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parent_task_id={{[0-f]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
   // CHECK-SAME: requested_team_size=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
@@ -64,16 +64,16 @@ int main() {
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]
 
-  // TASKS: ompt_event_initial_task_begin:{{.*}} task_id={{[0-9]+}}
+  // TASKS: ompt_event_initial_task_begin:{{.*}} task_id={{[0-f]+}}
   // TASKS: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_taskloop_begin:
   // TASKS: ompt_event_task_create:{{.*}} new_task_id=[[TASK_ID1:[0-9]+]]
   // TASKS-SAME: task_type=ompt_task_explicit
   // TASKS-DAG: ompt_event_task_create:{{.*}} new_task_id=[[TASK_ID2:[0-9]+]]
   // Schedule events:
-  // TASKS-DAG: {{^.*}}first_task_id={{[0-9]+}}, second_task_id=[[TASK_ID1]]
-  // TASKS-DAG: {{^.*}}first_task_id=[[TASK_ID1]], second_task_id={{[0-9]+}}
-  // TASKS-DAG: {{^.*}}first_task_id={{[0-9]+}}, second_task_id=[[TASK_ID2]]
-  // TASKS-DAG: {{^.*}}first_task_id=[[TASK_ID2]], second_task_id={{[0-9]+}}
+  // TASKS-DAG: {{^.*}}first_task_id={{[0-f]+}}, second_task_id=[[TASK_ID1]]
+  // TASKS-DAG: {{^.*}}first_task_id=[[TASK_ID1]], second_task_id={{[0-f]+}}
+  // TASKS-DAG: {{^.*}}first_task_id={{[0-f]+}}, second_task_id=[[TASK_ID2]]
+  // TASKS-DAG: {{^.*}}first_task_id=[[TASK_ID2]], second_task_id={{[0-f]+}}
   // TASKS-NOT: ompt_event_task_schedule
 
   return 0;

--- a/openmp/runtime/test/ompt/tasks/taskloop.c
+++ b/openmp/runtime/test/ompt/tasks/taskloop.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // RUN: %libomp-compile-and-run | FileCheck --check-prefix=TASKS %s
 // REQUIRES: ompt
@@ -6,6 +7,7 @@
 // UNSUPPORTED: gcc-4, gcc-5, icc-16
 // GCC 6 has support for taskloops, but at least 6.3.0 is crashing on this test
 // UNSUPPORTED: gcc-6
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -23,6 +25,7 @@ int main() {
       x++;
     }
   }
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
@@ -75,6 +78,7 @@ int main() {
   // TASKS-DAG: {{^.*}}first_task_id={{[0-f]+}}, second_task_id=[[TASK_ID2]]
   // TASKS-DAG: {{^.*}}first_task_id=[[TASK_ID2]], second_task_id={{[0-f]+}}
   // TASKS-NOT: ompt_event_task_schedule
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/taskloop_dispatch.c
+++ b/openmp/runtime/test/ompt/tasks/taskloop_dispatch.c
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gnu, intel-16.0
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -19,6 +21,7 @@ int main() {
       delay(1000);
     }
   }
+  // clang-format off
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
@@ -48,6 +51,7 @@ int main() {
   // CHECK-DAG: {{.*}}: ompt_event_taskloop_chunk_begin:{{.*}}task_id=[[TASK_ID1]]{{.*}}chunk_iterations=4
   // CHECK-DAG: {{.*}}: ompt_event_taskloop_chunk_begin:{{.*}}task_id=[[TASK_ID2]]{{.*}}chunk_iterations=4
   // CHECK-DAG: {{.*}}: ompt_event_taskloop_chunk_begin:{{.*}}task_id=[[TASK_ID3]]{{.*}}chunk_iterations=4
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/taskloop_dispatch.c
+++ b/openmp/runtime/test/ompt/tasks/taskloop_dispatch.c
@@ -22,8 +22,8 @@ int main() {
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin:
-  // CHECK-SAME: parent_task_id={{[0-9]+}}
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parent_task_id={{[0-f]+}}
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
   // CHECK-SAME: requested_team_size=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]]

--- a/openmp/runtime/test/ompt/tasks/taskwait-depend.c
+++ b/openmp/runtime/test/ompt/tasks/taskwait-depend.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 
@@ -9,6 +10,7 @@
 
 // support for taskwait with depend clause introduced in clang-14
 // UNSUPPORTED: clang-5, clang-6, clang-6, clang-8, clang-9, clang-10, clang-11, clang-12, clang-13
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -33,6 +35,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_dependences'
@@ -81,3 +84,4 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_end: task_id=[[SECOND_TASK]]
 
 // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
+// clang-format on

--- a/openmp/runtime/test/ompt/tasks/taskwait-depend.c
+++ b/openmp/runtime/test/ompt/tasks/taskwait-depend.c
@@ -44,8 +44,8 @@ int main() {
 // CHECK-NOT: 0: new_task_data initially not null
 
 // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]],
 // CHECK-SAME: task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT:(0x)?[0-f]+]],
@@ -54,7 +54,7 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: address of x: [[ADDRX:(0x)?[0-f]+]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[FIRST_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},
@@ -67,7 +67,7 @@ int main() {
 // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[RETURN_ADDRESS]]
 
 // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create:
-// CHECK-SAME: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[EXIT]],
+// CHECK-SAME: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[EXIT]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
 // CHECK-SAME: new_task_id=[[SECOND_TASK:[0-f]+]],
 // CHECK-SAME: codeptr_ra=[[RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}},

--- a/openmp/runtime/test/ompt/tasks/taskwait-depend.c
+++ b/openmp/runtime/test/ompt/tasks/taskwait-depend.c
@@ -27,7 +27,7 @@ int main() {
 #pragma omp task depend(out : x)
       { x++; }
       print_fuzzy_address(1);
-      #pragma omp taskwait depend(in: x)
+#pragma omp taskwait depend(in : x)
       print_fuzzy_address(2);
     }
   }

--- a/openmp/runtime/test/ompt/tasks/taskyield.c
+++ b/openmp/runtime/test/ompt/tasks/taskyield.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Current GOMP interface implements taskyield as stub
 // XFAIL: gcc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>   
@@ -31,7 +33,7 @@ int main()
     }
   }
 
-
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_schedule'
@@ -53,10 +55,7 @@ int main()
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_task_schedule: first_task_id={{[0-f]+}}, second_task_id=[[WORKER_TASK]], prior_task_status=ompt_task_switch=7
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_task_schedule: first_task_id=[[WORKER_TASK]], second_task_id={{[0-f]+}}, prior_task_status=ompt_task_complete=1
-
-
-
-
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/tasks/taskyield.c
+++ b/openmp/runtime/test/ompt/tasks/taskyield.c
@@ -6,30 +6,29 @@
 // clang-format on
 
 #include "callback.h"
-#include <omp.h>   
+#include <omp.h>
 #include <unistd.h>
 
-int main()
-{
-  int condition=0, x=0;
-  #pragma omp parallel num_threads(2)
+int main() {
+  int condition = 0, x = 0;
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp master
+#pragma omp master
     {
-        #pragma omp task shared(condition)
-        {
-          OMPT_SIGNAL(condition);
-          OMPT_WAIT(condition,2);
-        }
-        OMPT_WAIT(condition,1);
-        #pragma omp task shared(x)
-        {
-          x++;
-        }
-        printf("%" PRIu64 ": before yield\n", ompt_get_thread_data()->value);
-        #pragma omp taskyield
-        printf("%" PRIu64 ": after yield\n", ompt_get_thread_data()->value);
+#pragma omp task shared(condition)
+      {
         OMPT_SIGNAL(condition);
+        OMPT_WAIT(condition, 2);
+      }
+      OMPT_WAIT(condition, 1);
+#pragma omp task shared(x)
+      {
+        x++;
+      }
+      printf("%" PRIu64 ": before yield\n", ompt_get_thread_data()->value);
+#pragma omp taskyield
+      printf("%" PRIu64 ": after yield\n", ompt_get_thread_data()->value);
+      OMPT_SIGNAL(condition);
     }
   }
 

--- a/openmp/runtime/test/ompt/tasks/taskyield.c
+++ b/openmp/runtime/test/ompt/tasks/taskyield.c
@@ -43,16 +43,16 @@ int main()
   // make sure initial data pointers are null
   // CHECK-NOT: 0: new_task_data initially not null
   
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID:[0-9]+]], team_size={{[0-9]+}}, thread_num={{[0-9]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID:[0-f]+]], team_size={{[0-9]+}}, thread_num={{[0-9]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[WORKER_TASK:[0-9]+]], codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4, has_dependences=no
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id={{[0-9]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[MAIN_TASK:[0-9]+]], codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4, has_dependences=no
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[WORKER_TASK:[0-9]+]], codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4, has_dependences=no
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id={{[0-f]+}}, parent_task_frame.exit={{(0x)?[0-f]+}}, parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[MAIN_TASK:[0-9]+]], codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4, has_dependences=no
 
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule: first_task_id=[[IMPLICIT_TASK_ID]], second_task_id=[[MAIN_TASK]], prior_task_status=ompt_task_yield=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_schedule: first_task_id=[[MAIN_TASK]], second_task_id=[[IMPLICIT_TASK_ID]], prior_task_status=ompt_task_complete=1
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_task_schedule: first_task_id={{[0-9]+}}, second_task_id=[[WORKER_TASK]], prior_task_status=ompt_task_switch=7
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_task_schedule: first_task_id=[[WORKER_TASK]], second_task_id={{[0-9]+}}, prior_task_status=ompt_task_complete=1
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_task_schedule: first_task_id={{[0-f]+}}, second_task_id=[[WORKER_TASK]], prior_task_status=ompt_task_switch=7
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_task_schedule: first_task_id=[[WORKER_TASK]], second_task_id={{[0-f]+}}, prior_task_status=ompt_task_complete=1
 
 
 

--- a/openmp/runtime/test/ompt/tasks/untied_task.c
+++ b/openmp/runtime/test/ompt/tasks/untied_task.c
@@ -4,30 +4,29 @@
 // clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
-#include <omp.h> 
+#include <omp.h>
 
-int main()
-{
-  int condition=0;
+int main() {
+  int condition = 0;
   omp_set_nested(0);
   print_frame(0);
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
     print_frame_from_outlined_fn(1);
     print_ids(0);
     print_ids(1);
     print_frame(0);
-    #pragma omp master
+#pragma omp master
     {
       print_ids(0);
-      #pragma omp task untied shared(condition)
+#pragma omp task untied shared(condition)
       {
         OMPT_SIGNAL(condition);
         print_frame(1);
         print_ids(0);
         print_ids(1);
         print_ids(2);
-        #pragma omp task if(0)
+#pragma omp task if (0)
         {
           print_ids(0);
           print_ids(1);
@@ -37,10 +36,10 @@ int main()
         print_ids(1);
         print_ids(2);
       }
-      OMPT_WAIT(condition,1);
+      OMPT_WAIT(condition, 1);
       print_ids(0);
     }
-    #pragma omp barrier
+#pragma omp barrier
     print_ids(0);
   }
 

--- a/openmp/runtime/test/ompt/tasks/untied_task.c
+++ b/openmp/runtime/test/ompt/tasks/untied_task.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 #define TEST_NEED_PRINT_FRAME_FROM_OUTLINED_FN
 #include "callback.h"
 #include <omp.h> 

--- a/openmp/runtime/test/ompt/tasks/untied_task.c
+++ b/openmp/runtime/test/ompt/tasks/untied_task.c
@@ -60,16 +60,16 @@ int main()
   // CHECK-NOT: 0: new_task_data initially not null
   
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: __builtin_frame_address(0)=[[MAIN_REENTER:(0x)?[0-f]+]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker=[[PARALLEL_INVOKER:[0-9]+]]
   // nested parallel masters
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-9]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[MASTER_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID:[0-f]+]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: __builtin_frame_address(0)=[[REENTER:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // <- ompt_event_task_create would be expected here
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[TASK_FUNCTION:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_task_create: parent_task_id=[[IMPLICIT_TASK_ID]], parent_task_frame.exit=[[EXIT]], parent_task_frame.reenter={{(0x)?[0-f]+}}, new_task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[TASK_FUNCTION:(0x)?[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // explicit barrier after master
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_explicit_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
@@ -78,10 +78,10 @@ int main()
   // implicit barrier parallel
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: __builtin_frame_address({{.}})=[[EXIT:(0x)?[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[EXIT]], reenter_frame=[[NULL]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 1: parallel_id=[[IMPLICIT_PARALLEL_ID]], task_id=[[PARENT_TASK_ID]], exit_frame=[[NULL]], reenter_frame={{(0x)?[0-f]+}}
@@ -99,8 +99,8 @@ int main()
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_explicit_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[THREAD_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], exit_frame=[[NULL]], reenter_frame=[[NULL]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_barrier_implicit_parallel_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/teams/distribute_dispatch.c
+++ b/openmp/runtime/test/ompt/teams/distribute_dispatch.c
@@ -1,9 +1,11 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 
 /// GCC lowering of distribute results in calls to 
 /// omp_get_num_teams/omp_get_team_num rather than region calls
 // UNSUPPORTED: gcc
+// clang-format on
 #include "callback.h"
 
 #define WORK_SIZE 64
@@ -17,6 +19,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_work'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_dispatch'
 
@@ -49,3 +52,4 @@ int main() {
 // CHECK: {{^}}[[THREAD_ID3]]: ompt_event_distribute_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID3]], task_id=[[TASK_ID3]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations=16
+// clang-format on

--- a/openmp/runtime/test/ompt/teams/distribute_dispatch.c
+++ b/openmp/runtime/test/ompt/teams/distribute_dispatch.c
@@ -14,7 +14,8 @@ int main() {
   int i;
 #pragma omp teams num_teams(4) thread_limit(1)
 #pragma omp distribute dist_schedule(static, WORK_SIZE / 4)
-  for (i = 0; i < WORK_SIZE; i++) {}
+  for (i = 0; i < WORK_SIZE; i++) {
+  }
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/teams/parallel_team.c
+++ b/openmp/runtime/test/ompt/teams/parallel_team.c
@@ -19,7 +19,7 @@ int main() {
 // CHECK-NOT: 0: thread_data initially not null
 
 // CHECK: {{^}}[[MASTER:[0-9]+]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK:[0-9]+]], {{.*}}, index=1
+// CHECK-SAME: task_id=[[INIT_TASK:[0-f]+]], {{.*}}, index=1
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_teams_begin:
 // CHECK-SAME: parent_task_id=[[INIT_TASK]]
@@ -31,33 +31,33 @@ int main() {
 //
 // initial task in the teams construct
 // CHECK: {{^}}[[MASTER]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK_0:[0-9]+]], actual_parallelism=1, index=0
+// CHECK-SAME: task_id=[[INIT_TASK_0:[0-f]+]], actual_parallelism=1, index=0
 
 // parallel region forked by runtime
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[INIT_TASK_0]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_0:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_0:[0-f]+]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-f]+]]
 
 // user parallel region
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[IMPL_TASK_0]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_00:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_00:[0-f]+]]
 // CHECK-SAME: {{.*}} requested_team_size=2
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_00:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_00:[0-f]+]]
 // CHECK-SAME: {{.*}} team_size=2, thread_num=0
 //
 // barrier event is here
 //
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_00]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_00]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_0]]
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_0]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_0]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[INIT_TASK_0]]
 
@@ -74,10 +74,10 @@ int main() {
 // team 0/thread 1
 //
 // CHECK: {{^}}[[WORKER:[0-9]+]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_01:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_01:[0-f]+]]
 // CHECK-SAME: {{.*}} team_size=2, thread_num=1
 //
 // barrier event is here
 //
 // CHECK: {{^}}[[WORKER]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_01]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_01]]

--- a/openmp/runtime/test/ompt/teams/parallel_team.c
+++ b/openmp/runtime/test/ompt/teams/parallel_team.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt, multicpu
 // UNSUPPORTED: gcc
 // Compilation fails for icc
 // XFAIL: icc
+// clang-format on
 #include "callback.h"
 
 int main() {
@@ -12,6 +14,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK-NOT: 0: parallel_data initially not null
@@ -81,3 +84,4 @@ int main() {
 //
 // CHECK: {{^}}[[WORKER]]: ompt_event_implicit_task_end:
 // CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_01]]
+// clang-format on

--- a/openmp/runtime/test/ompt/teams/serial_teams.c
+++ b/openmp/runtime/test/ompt/teams/serial_teams.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt, multicpu
 // UNSUPPORTED: gcc
 // Compilation fails for icc
 // XFAIL: icc
+// clang-format on
 #include "callback.h"
 
 int main() {
@@ -12,6 +14,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK-NOT: 0: parallel_data initially not null
@@ -89,3 +92,4 @@ int main() {
 
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_initial_task_end:
 // CHECK-SAME: task_id=[[INIT_TASK_1]], actual_parallelism=0, index=1
+// clang-format on

--- a/openmp/runtime/test/ompt/teams/serial_teams.c
+++ b/openmp/runtime/test/ompt/teams/serial_teams.c
@@ -19,7 +19,7 @@ int main() {
 // CHECK-NOT: 0: thread_data initially not null
 
 // CHECK: {{^}}[[MASTER_0:[0-9]+]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK:[0-9]+]], {{.*}}, index=1
+// CHECK-SAME: task_id=[[INIT_TASK:[0-f]+]], {{.*}}, index=1
 
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_teams_begin:
 // CHECK-SAME: parent_task_id=[[INIT_TASK]]
@@ -31,24 +31,24 @@ int main() {
 //
 // initial task in the teams construct
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK_0:[0-9]+]], actual_parallelism=2, index=0
+// CHECK-SAME: task_id=[[INIT_TASK_0:[0-f]+]], actual_parallelism=2, index=0
 
 // parallel region forked by runtime
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[INIT_TASK_0]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_0:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_0:[0-f]+]]
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-f]+]]
 
 // user parallel region
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[IMPL_TASK_0]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_00:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_00:[0-f]+]]
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_0]]
 
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_0]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_0]]
 // CHECK: {{^}}[[MASTER_0]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[INIT_TASK_0]]
 
@@ -66,24 +66,24 @@ int main() {
 //
 // initial task in the teams construct
 // CHECK: {{^}}[[MASTER_1:[0-9]+]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK_1:[0-9]+]], actual_parallelism=2, index=1
+// CHECK-SAME: task_id=[[INIT_TASK_1:[0-f]+]], actual_parallelism=2, index=1
 
 // parallel region forked by runtime
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[INIT_TASK_1]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_1:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_1:[0-f]+]]
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_1]], task_id=[[IMPL_TASK_1:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_1]], task_id=[[IMPL_TASK_1:[0-f]+]]
 
 // user parallel region
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[IMPL_TASK_1]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_11:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_11:[0-f]+]]
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_11]], task_id=[[IMPL_TASK_1]]
 
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_1]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_1]]
 // CHECK: {{^}}[[MASTER_1]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_ID_1]], task_id=[[INIT_TASK_1]]
 

--- a/openmp/runtime/test/ompt/teams/serialized.c
+++ b/openmp/runtime/test/ompt/teams/serialized.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc
 // Compilation fails for icc
 // XFAIL: icc
+// clang-format on
 
 #include "callback.h"
 
@@ -13,6 +15,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK-NOT: 0: parallel_data initially not null
@@ -63,3 +66,4 @@ int main() {
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_initial_task_end:
 // CHECK-SAME: task_id=[[INIT_TASK]], {{.*}}, index=1
+// clang-format on

--- a/openmp/runtime/test/ompt/teams/serialized.c
+++ b/openmp/runtime/test/ompt/teams/serialized.c
@@ -20,7 +20,7 @@ int main() {
 // CHECK-NOT: 0: thread_data initially not null
 
 // CHECK: {{^}}[[MASTER:[0-9]+]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK:[0-9]+]], {{.*}}, index=1
+// CHECK-SAME: task_id=[[INIT_TASK:[0-f]+]], {{.*}}, index=1
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_teams_begin:
 // CHECK-SAME: parent_task_id=[[INIT_TASK]]
@@ -29,25 +29,25 @@ int main() {
 
 // initial task in the teams construct starts
 // CHECK: {{^}}[[MASTER]]: ompt_event_initial_task_begin:
-// CHECK-SAME: task_id=[[INIT_TASK_0:[0-9]+]], actual_parallelism=1, index=0
+// CHECK-SAME: task_id=[[INIT_TASK_0:[0-f]+]], actual_parallelism=1, index=0
 
 // parallel region forked by runtime
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[INIT_TASK_0]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_0:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_0:[0-f]+]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-f]+]]
 
 // user parallel region
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_begin:
 // CHECK-SAME: {{.*}} parent_task_id=[[IMPL_TASK_0]]
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_00:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_00:[0-f]+]]
 // CHECK-SAME: {{.*}} requested_team_size=1
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_begin:
-// CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_00:[0-9]+]]
+// CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_00:[0-f]+]]
 // CHECK-SAME: {{.*}} team_size=1, thread_num=0
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_00]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_00]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_00]], task_id=[[IMPL_TASK_0]]
 

--- a/openmp/runtime/test/ompt/teams/team.c
+++ b/openmp/runtime/test/ompt/teams/team.c
@@ -36,7 +36,7 @@ int main() {
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_begin:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[IMPL_TASK_0:[0-9]+]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_implicit_task_end:
-// CHECK-SAME: {{.*}} parallel_id={{[0-9]+}}, task_id=[[IMPL_TASK_0]]
+// CHECK-SAME: {{.*}} parallel_id={{[0-f]+}}, task_id=[[IMPL_TASK_0]]
 // CHECK: {{^}}[[MASTER]]: ompt_event_parallel_end:
 // CHECK-SAME: {{.*}} parallel_id=[[PAR_0]], task_id=[[INIT_TASK_0]]
 

--- a/openmp/runtime/test/ompt/teams/team.c
+++ b/openmp/runtime/test/ompt/teams/team.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: gcc
 // Compilation fails for icc
 // XFAIL: icc
+// clang-format on
 #include "callback.h"
 
 int main() {
@@ -11,6 +13,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
 // CHECK-NOT: 0: parallel_data initially not null
@@ -49,3 +52,4 @@ int main() {
 
 // CHECK: {{^}}[[MASTER]]: ompt_event_initial_task_end:
 // CHECK-SAME: task_id=[[INIT_TASK]], {{.*}}, index=1
+// clang-format on

--- a/openmp/runtime/test/ompt/worksharing/for/auto.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
+// clang-format on
 
 #define SCHEDULE auto
 // The runtime uses guided schedule for auto,

--- a/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_serialized.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
+// clang-format on
 
 #define SCHEDULE auto
 // The runtime uses static schedule for serialized loop,

--- a/openmp/runtime/test/ompt/worksharing/for/auto_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/auto_split.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for auto = static schedule
 // XFAIL: gcc
+// clang-format on
 
 #define SCHEDULE auto
 // The runtime uses guided schedule for auto,

--- a/openmp/runtime/test/ompt/worksharing/for/base.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base.h
@@ -26,27 +26,27 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
   // CHECK: 0: Schedule: [[SCHED:[a-z]+]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra=
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-9]+}}, task_id=[[IMPLICIT_TASK_ID]]
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_implicit_task_end: parallel_id={{[0-f]+}}, task_id=[[IMPLICIT_TASK_ID]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/for/base.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base.h
@@ -8,8 +8,7 @@
 #define SCHED_OUTPUT STR(SCHEDULE)
 #endif
 
-int main()
-{
+int main() {
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
 

--- a/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
@@ -27,9 +27,9 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
   // CHECK: 0: Schedule: [[SCHED:[a-z]+]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-9]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=1, codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id=[[PARENT_TASK_ID:[0-f]+]], parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=1, codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[IMPLICIT_TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID:[0-f]+]], task_id=[[IMPLICIT_TASK_ID:[0-f]+]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]], codeptr_ra={{(0x)?[0-f]+}}
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id=[[IMPLICIT_TASK_ID]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_end: parallel_id={{[PARALLEL_ID,0]}}, task_id=[[IMPLICIT_TASK_ID]]

--- a/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_serialized.h
@@ -8,8 +8,7 @@
 #define SCHED_OUTPUT STR(SCHEDULE)
 #endif
 
-int main()
-{
+int main() {
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
 

--- a/openmp/runtime/test/ompt/worksharing/for/base_split.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_split.h
@@ -40,33 +40,33 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
   // CHECK: 0: Schedule: [[SCHED:[a-z]+]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra=[[PARALLEL_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker={{[0-9]+}}
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra=[[PARALLEL_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}, invoker={{[0-9]+}}
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, invoker={{[0-9]+}}, codeptr_ra=[[PARALLEL_RETURN_ADDRESS]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_parallel_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, invoker={{[0-9]+}}, codeptr_ra=[[PARALLEL_RETURN_ADDRESS]]
   // CHECK: {{^}}[[MASTER_ID]]: fuzzy_address={{.*}}[[PARALLEL_RETURN_ADDRESS]]
   
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra={{(0x)?[0-f]+}}
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra={{(0x)?[0-f]+}}
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_loop_[[SCHED]]_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[LOOP_END_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK: {{^}}[[THREAD_ID]]: fuzzy_address={{.*}}[[LOOP_END_RETURN_ADDRESS]]
 
 
   // CHECK-LOOP: 0: NULL_POINTER=[[NULL:.*$]]
   // CHECK-LOOP: 0: Schedule: [[SCHED:[a-z]+]]
   // CHECK-LOOP: 0: ompt_event_runtime_shutdown
-  // CHECK-LOOP: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-9]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-9]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
-  // CHECK-LOOP: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
+  // CHECK-LOOP: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin: parent_task_id={{[0-f]+}}, parent_task_frame.exit=[[NULL]], parent_task_frame.reenter={{(0x)?[0-f]+}}, parallel_id=[[PARALLEL_ID:[0-f]+]], requested_team_size=4, codeptr_ra={{(0x)?[0-f]+}}, invoker={{[0-9]+}}
+  // CHECK-LOOP: {{^}}[[MASTER_ID]]: ompt_event_loop_[[SCHED]]_begin: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[LOOP_BEGIN_RETURN_ADDRESS:(0x)?[0-f]+]]{{[0-f][0-f]}}
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]
   // CHECK-LOOP: {{^}}{{[0-9]+}}: fuzzy_address={{.*}}[[LOOP_BEGIN_RETURN_ADDRESS]]

--- a/openmp/runtime/test/ompt/worksharing/for/base_split.h
+++ b/openmp/runtime/test/ompt/worksharing/for/base_split.h
@@ -8,21 +8,21 @@
 #define SCHED_OUTPUT STR(SCHEDULE)
 #endif
 
-/* With the combined parallel-for construct (base.h), the return-addresses are hard to compare.
-   With the separate parallel and for-nowait construct, the addresses become more predictable,
-   but the begin of the for-loop still generates additional code, so the offset of loop-begin 
-   to the label is >4 Byte.
+/* With the combined parallel-for construct (base.h), the return-addresses are
+   hard to compare. With the separate parallel and for-nowait construct, the
+   addresses become more predictable, but the begin of the for-loop still
+   generates additional code, so the offset of loop-begin to the label is >4
+   Byte.
 */
 
-int main()
-{
+int main() {
   unsigned int i;
   printf("0: Schedule: " SCHED_OUTPUT "\n");
 
 #pragma omp parallel num_threads(4)
   {
     print_current_address(0);
-    #pragma omp for schedule(SCHEDULE) nowait
+#pragma omp for schedule(SCHEDULE) nowait
     for (i = 0; i < 64; i++) {
       print_fuzzy_address(1);
     }

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
 // REQUIRES: ompt
+// clang-format on
 
 #define SCHEDULE dynamic
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic_serialized.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
 // REQUIRES: ompt
+// clang-format on
 
 #define SCHEDULE dynamic
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/dynamic_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/dynamic_split.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 
 #define SCHEDULE dynamic
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
 // REQUIRES: ompt
+// clang-format on
 
 #define SCHEDULE guided
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_serialized.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
 // REQUIRES: ompt
+// clang-format on
 
 #define SCHEDULE guided
 // The runtime uses static schedule for serialized loop,

--- a/openmp/runtime/test/ompt/worksharing/for/guided_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/guided_split.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 
 #define SCHEDULE guided
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // XFAIL: gcc
 // GCC doesn't call runtime for static schedule
+// clang-format on
 
 #include "callback.h"
 
@@ -42,6 +44,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_parallel_begin'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
 // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_work'
@@ -125,3 +128,4 @@ int main() {
 // CHECK: {{^}}[[THREAD_ID3]]: ompt_event_ws_loop_chunk_begin:
 // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID3]]
 // CHECK-SAME: chunk_start={{[0-9]+}}, chunk_iterations={{[1-9][0-9]*}}
+// clang-format on

--- a/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
@@ -18,7 +18,8 @@ int main() {
     int wait_id = 0;
     int team_size = omp_get_num_threads();
 #pragma omp for schedule(static, WORK_SIZE / 4)
-    for (i = 0; i < WORK_SIZE; i++) {}
+    for (i = 0; i < WORK_SIZE; i++) {
+    }
 
 #pragma omp for schedule(dynamic)
     for (i = 0; i < WORK_SIZE; i++) {

--- a/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/for/loop_dispatch.c
@@ -49,7 +49,7 @@ int main() {
 
 // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 // CHECK: {{^}}[[THREAD_ID0:[0-9]+]]: ompt_event_parallel_begin:
-// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+// CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
 
 // Each thread should have at least one ws-loop-chunk-begin event for each
 // for loop.

--- a/openmp/runtime/test/ompt/worksharing/for/runtime.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
 // REQUIRES: ompt
+// clang-format on
 
 #define SCHEDULE runtime
 // Without any schedule specified, the runtime uses static schedule,

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_serialized.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
 // REQUIRES: ompt
+// clang-format on
 
 #define SCHEDULE runtime
 // Without any schedule specified, the runtime uses static schedule,

--- a/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/runtime_split.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // UNSUPPORTED: gcc-4, gcc-5, gcc-6, gcc-7
+// clang-format on
 
 #define SCHEDULE runtime
 // Without any schedule specified, the runtime uses static schedule,

--- a/openmp/runtime/test/ompt/worksharing/for/static.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
+// clang-format on
 
 #define SCHEDULE static
 #include "base.h"

--- a/openmp/runtime/test/ompt/worksharing/for/static_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static_serialized.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_serialized.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
+// clang-format on
 
 #define SCHEDULE static
 #include "base_serialized.h"

--- a/openmp/runtime/test/ompt/worksharing/for/static_split.c
+++ b/openmp/runtime/test/ompt/worksharing/for/static_split.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %S/base_split.h
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck --check-prefix=CHECK-LOOP %S/base_split.h
 // REQUIRES: ompt
 // GCC doesn't call runtime for static schedule
 // XFAIL: gcc
+// clang-format on
 
 #define SCHEDULE static
 #include "base_split.h"

--- a/openmp/runtime/test/ompt/worksharing/sections.c
+++ b/openmp/runtime/test/ompt/worksharing/sections.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // Some compilers generate code that does not distinguish between sections and loops
 // XFAIL: gcc, clang-3, clang-4, clang-5, icc-16, icc-17
 // UNSUPPORTED: icc-18
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/worksharing/sections.c
+++ b/openmp/runtime/test/ompt/worksharing/sections.c
@@ -9,15 +9,14 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  #pragma omp parallel sections num_threads(2)
+int main() {
+#pragma omp parallel sections num_threads(2)
   {
-    #pragma omp section
+#pragma omp section
     {
       printf("%lu: section 1\n", ompt_get_thread_data()->value);
     }
-    #pragma omp section
+#pragma omp section
     {
       printf("%lu: section 2\n", ompt_get_thread_data()->value);
     }

--- a/openmp/runtime/test/ompt/worksharing/sections.c
+++ b/openmp/runtime/test/ompt/worksharing/sections.c
@@ -27,11 +27,11 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN:(0x)?[0-f]+]], count=2
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[SECT_END:(0x)?[0-f]+]]
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID:[0-f]+]], task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[SECT_BEGIN:(0x)?[0-f]+]], count=2
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[SECT_END:(0x)?[0-f]+]]
 
-  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra=[[SECT_BEGIN]], count=2
-  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}}, codeptr_ra=[[SECT_END]]
+  // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-f]+]], codeptr_ra=[[SECT_BEGIN]], count=2
+  // CHECK: {{^}}[[THREAD_ID]]: ompt_event_sections_end: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}}, codeptr_ra=[[SECT_END]]
   // clang-format on
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // UNSUPPORTED: intel-15.0, intel-16.0, intel-17.0, intel-18.0
 // GCC generates code that does not distinguish between sections and loops
 // UNSUPPORTED: gcc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -21,6 +23,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_work'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_dispatch'
@@ -47,6 +50,7 @@ int main()
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_sections_end:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}},
   // CHECK-SAME: codeptr_ra=[[SECT_END]]
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
@@ -9,15 +9,14 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
-  #pragma omp parallel sections num_threads(2)
+int main() {
+#pragma omp parallel sections num_threads(2)
   {
-    #pragma omp section
+#pragma omp section
     {
       printf("%lu: section 1\n", ompt_get_thread_data()->value);
     }
-    #pragma omp section
+#pragma omp section
     {
       printf("%lu: section 2\n", ompt_get_thread_data()->value);
     }

--- a/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
+++ b/openmp/runtime/test/ompt/worksharing/sections_dispatch.c
@@ -28,24 +28,24 @@ int main()
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_sections_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]],
-  // CHECK-SAME: task_id=[[TASK_ID:[0-9]+]],
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]],
+  // CHECK-SAME: task_id=[[TASK_ID:[0-f]+]],
   // CHECK-SAME: codeptr_ra=[[SECT_BEGIN:(0x)?[0-f]+]], count=2
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_section_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]]
   // CHECK-SAME: codeptr_ra=[[SECT_BEGIN]]
   // CHECK: {{^}}[[MASTER_ID]]: ompt_event_sections_end:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}},
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}},
   // CHECK-SAME: codeptr_ra=[[SECT_END:(0x)?[0-f]+]]
 
   // CHECK: {{^}}[[THREAD_ID:[0-9]+]]: ompt_event_sections_begin:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]],
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-f]+]],
   // CHECK-SAME: codeptr_ra=[[SECT_BEGIN]], count=2
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_section_begin:
   // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]]
   // CHECK-SAME: codeptr_ra=[[SECT_BEGIN]]
   // CHECK: {{^}}[[THREAD_ID]]: ompt_event_sections_end:
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-9]+}},
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID]], task_id={{[0-f]+}},
   // CHECK-SAME: codeptr_ra=[[SECT_END]]
 
   return 0;

--- a/openmp/runtime/test/ompt/worksharing/single.c
+++ b/openmp/runtime/test/ompt/worksharing/single.c
@@ -26,11 +26,11 @@ int main()
 
   // CHECK: 0: NULL_POINTER=[[NULL:.*$]]
 
-  // CHECK-DAG: {{^}}[[THREAD_ID_1:[0-9]+]]: ompt_event_single_in_block_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]+}}, count=1
+  // CHECK-DAG: {{^}}[[THREAD_ID_1:[0-9]+]]: ompt_event_single_in_block_begin: parallel_id=[[PARALLEL_ID:[0-f]+]], task_id=[[TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]+}}, count=1
   // CHECK-DAG: {{^}}[[THREAD_ID_1]]: in single
   // CHECK-DAG: {{^}}[[THREAD_ID_1]]: ompt_event_single_in_block_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra={{(0x)?[0-f]+}}, count=1
 
-  // CHECK-DAG: {{^}}[[THREAD_ID_2:[0-9]+]]: ompt_event_single_others_begin: parallel_id=[[PARALLEL_ID:[0-9]+]], task_id=[[TASK_ID:[0-9]+]], codeptr_ra={{(0x)?[0-f]+}}, count=1
+  // CHECK-DAG: {{^}}[[THREAD_ID_2:[0-9]+]]: ompt_event_single_others_begin: parallel_id=[[PARALLEL_ID:[0-f]+]], task_id=[[TASK_ID:[0-f]+]], codeptr_ra={{(0x)?[0-f]+}}, count=1
   // CHECK-DAG: {{^}}[[THREAD_ID_2]]: ompt_event_single_others_end: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]], codeptr_ra={{(0x)?[0-f]+}}, count=1
   // clang-format on
 

--- a/openmp/runtime/test/ompt/worksharing/single.c
+++ b/openmp/runtime/test/ompt/worksharing/single.c
@@ -1,7 +1,9 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
 // GCC generates code that does not call the runtime for the single construct
 // XFAIL: gcc
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>

--- a/openmp/runtime/test/ompt/worksharing/single.c
+++ b/openmp/runtime/test/ompt/worksharing/single.c
@@ -8,12 +8,11 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
   int x = 0;
-  #pragma omp parallel num_threads(2)
+#pragma omp parallel num_threads(2)
   {
-    #pragma omp single
+#pragma omp single
     {
       printf("%" PRIu64 ": in single\n", ompt_get_thread_data()->value);
       x++;

--- a/openmp/runtime/test/ompt/worksharing/taskinfo/sections_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/taskinfo/sections_serialized.c
@@ -6,8 +6,7 @@
 #include "callback.h"
 #include <omp.h>
 
-int main()
-{
+int main() {
 #pragma omp parallel sections num_threads(1)
   {
 #pragma omp section

--- a/openmp/runtime/test/ompt/worksharing/taskinfo/sections_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/taskinfo/sections_serialized.c
@@ -1,5 +1,7 @@
+// clang-format off
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
+// clang-format on
 
 #include "callback.h"
 #include <omp.h>
@@ -17,6 +19,7 @@ int main()
     }
   }
 
+  // clang-format off
   // Check if libomp supports the callbacks for this test.
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_task_create'
   // CHECK-NOT: {{^}}0: Could not register callback 'ompt_callback_implicit_task'
@@ -43,6 +46,7 @@ int main()
   // CHECK-SAME: exit_frame=[[NULL]]
   // CHECK-SAME: reenter_frame=[[INITIAL_TASK_FRAME_ENTER]]
   // CHECK-SAME: task_type=ompt_task_initial
+  // clang-format on
 
   return 0;
 }

--- a/openmp/runtime/test/ompt/worksharing/taskinfo/sections_serialized.c
+++ b/openmp/runtime/test/ompt/worksharing/taskinfo/sections_serialized.c
@@ -23,14 +23,14 @@ int main()
 
 
   // CHECK: {{^}}0: NULL_POINTER=[[NULL:.*$]]
-  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id=[[INITIAL_PARALLEL_ID:[0-9]+]], task_id=[[INITIAL_TASK_ID:[0-9]+]], actual_parallelism=1, index=1, flags=1
+  // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_initial_task_begin: parallel_id=[[INITIAL_PARALLEL_ID:[0-f]+]], task_id=[[INITIAL_TASK_ID:[0-f]+]], actual_parallelism=1, index=1, flags=1
 
   // region 0
   // CHECK: {{^}}[[MASTER_ID:[0-9]+]]: ompt_event_parallel_begin
   // CHECK-SAME: parent_task_frame.exit=[[NULL]], parent_task_frame.reenter=[[INITIAL_TASK_FRAME_ENTER:(0x)?[0-f]+]],
-  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-9]+]]
+  // CHECK-SAME: parallel_id=[[PARALLEL_ID:[0-f]+]]
 
-  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-9]+]]
+  // CHECK: {{^}}[[MASTER_ID]]: ompt_event_implicit_task_begin: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID:[0-f]+]]
 
   // information about implicit task (exit frame should be set, while enter should be NULL)
   // CHECK: {{^}}[[MASTER_ID]]: task level 0: parallel_id=[[PARALLEL_ID]], task_id=[[TASK_ID]]

--- a/openmp/tools/multiplex/tests/custom_data_storage/custom_data_storage.c
+++ b/openmp/tools/multiplex/tests/custom_data_storage/custom_data_storage.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-tool -DFIRST_TOOL -o %t.first.tool.so %s && \
 // RUN: %libomp-tool -DSECOND_TOOL -o %t.second.tool.so %s && \
 // RUN: %libomp-compile && \
@@ -8,6 +9,7 @@
 // For GCC we don't get an event for master,
 // see runtime/test/ompt/sycnchronization/master.c
 // UNSUPPORTED: gcc
+// clang-format on
 
 #if defined(FIRST_TOOL)
 #include "first-tool.h"
@@ -36,6 +38,7 @@ int main() {
   }
   return 0;
 }
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -329,5 +332,6 @@ int main() {
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool: ompt_event_thread_end:
 // CHECK-SAME: thread_id=[[_2ND_WRKR_TID]]
+// clang-format on
 
 #endif /* APP */

--- a/openmp/tools/multiplex/tests/custom_data_storage/custom_data_storage.c
+++ b/openmp/tools/multiplex/tests/custom_data_storage/custom_data_storage.c
@@ -49,19 +49,19 @@ int main() {
 // CHECK-SAME: thread_id=[[_1ST_MSTR_TID]]
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_initial_task_begin:
-// CHECK-SAME: parallel_id=[[_FIRST_INIT_PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[_FIRST_INITIAL_TASK_ID:[0-9]+]], actual_parallelism=1,
+// CHECK-SAME: parallel_id=[[_FIRST_INIT_PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[_FIRST_INITIAL_TASK_ID:[0-f]+]], actual_parallelism=1,
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[_FIRST_INITIAL_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID:[0-9]+]], requested_team_size=2,
+// CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID:[0-f]+]], requested_team_size=2,
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, invoker
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=0
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_masked_begin:
@@ -73,7 +73,7 @@ int main() {
 // CHECK-SAME: parent_task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: new_task_id=[[_FIRST_EXPLICIT_TASK_ID:[0-9]+]],
+// CHECK-SAME: new_task_id=[[_FIRST_EXPLICIT_TASK_ID:[0-f]+]],
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4,
 // CHECK-SAME: has_dependences=no
 
@@ -154,20 +154,20 @@ int main() {
 // CHECK-SAME: thread_id=[[_2ND_MSTR_TID]]
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_initial_task_begin:
-// CHECK-SAME: parallel_id=[[SECOND_INIT_PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[SECOND_INITIAL_TASK_ID:[0-9]+]], actual_parallelism=1,
+// CHECK-SAME: parallel_id=[[SECOND_INIT_PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[SECOND_INITIAL_TASK_ID:[0-f]+]], actual_parallelism=1,
 // CHECK-SAME: index=1, flags=1
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[SECOND_INITIAL_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID:[0-9]+]], requested_team_size=2,
+// CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID:[0-f]+]], requested_team_size=2,
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, invoker
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=0
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_masked_begin:
@@ -179,7 +179,7 @@ int main() {
 // CHECK-SAME: parent_task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: new_task_id=[[SECOND_EXPLICIT_TASK_ID:[0-9]+]],
+// CHECK-SAME: new_task_id=[[SECOND_EXPLICIT_TASK_ID:[0-f]+]],
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4,
 // CHECK-SAME: has_dependences=no
 
@@ -262,7 +262,7 @@ int main() {
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=1
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
@@ -299,7 +299,7 @@ int main() {
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=1
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:

--- a/openmp/tools/multiplex/tests/custom_data_storage/first-tool.h
+++ b/openmp/tools/multiplex/tests/custom_data_storage/first-tool.h
@@ -240,7 +240,7 @@ ompt_data_t *ompt_get_own_thread_data() {
   return get_own_ompt_data(ompt_cds_get_thread_data());
 }
 
-#define register_ompt_callback2_t(name, type)                                       \
+#define register_ompt_callback2_t(name, type)                                  \
   do {                                                                         \
     type f_##name = &on_cds_##name;                                            \
     if (ompt_set_callback(name, (ompt_callback_t)f_##name) == ompt_set_never)  \
@@ -261,12 +261,13 @@ int ompt_cds_initialize(ompt_function_lookup_t lookup, int initial_device_num,
   register_ompt_callback(ompt_callback_nest_lock);
   register_ompt_callback2(ompt_callback_sync_region);
   register_ompt_callback2_t(ompt_callback_sync_region_wait,
-                       ompt_callback_sync_region_t);
+                            ompt_callback_sync_region_t);
   register_ompt_callback2(ompt_callback_control_tool);
   register_ompt_callback2(ompt_callback_flush);
   register_ompt_callback2(ompt_callback_cancel);
   register_ompt_callback2(ompt_callback_implicit_task);
-  register_ompt_callback_t(ompt_callback_lock_init, ompt_callback_mutex_acquire_t);
+  register_ompt_callback_t(ompt_callback_lock_init,
+                           ompt_callback_mutex_acquire_t);
   register_ompt_callback_t(ompt_callback_lock_destroy, ompt_callback_mutex_t);
   register_ompt_callback2(ompt_callback_work);
   register_ompt_callback2(ompt_callback_master);

--- a/openmp/tools/multiplex/tests/custom_data_storage/first-tool.h
+++ b/openmp/tools/multiplex/tests/custom_data_storage/first-tool.h
@@ -216,7 +216,7 @@ static int on_cds_ompt_callback_control_tool(uint64_t command,
   while (ompt_get_task_info(task_level, NULL, (ompt_data_t **)&task_data, NULL,
                             NULL, NULL)) {
     task_data = get_own_ompt_data(task_data);
-    printf("%" PRIu64 ": _first_tool: task level %d: task_id=%" PRIu64 "\n",
+    printf("%" PRIu64 ": _first_tool: task level %d: task_id=%" PRIx64 "\n",
            ompt_get_thread_data()->value, task_level, task_data->value);
     task_level++;
   }
@@ -227,7 +227,7 @@ static int on_cds_ompt_callback_control_tool(uint64_t command,
   while (ompt_get_parallel_info(parallel_level, (ompt_data_t **)&parallel_data,
                                 NULL)) {
     parallel_data = get_own_ompt_data(parallel_data);
-    printf("%" PRIu64 ": _first_tool: parallel level %d: parallel_id=%" PRIu64
+    printf("%" PRIu64 ": _first_tool: parallel level %d: parallel_id=%" PRIx64
            "\n",
            ompt_get_thread_data()->value, parallel_level, parallel_data->value);
     parallel_level++;

--- a/openmp/tools/multiplex/tests/print/print.c
+++ b/openmp/tools/multiplex/tests/print/print.c
@@ -49,20 +49,20 @@ int main() {
 // CHECK-SAME: thread_type=ompt_thread_initial=1, thread_id=[[_1ST_MSTR_TID]]
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_initial_task_begin:
-// CHECK-SAME: parallel_id=[[_FIRST_INIT_PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[_FIRST_INITIAL_TASK_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[_FIRST_INIT_PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[_FIRST_INITIAL_TASK_ID:[0-f]+]],
 // CHECK-SAME: actual_parallelism=1, index=1, flags=1
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[_FIRST_INITIAL_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID:[0-f]+]],
 // CHECK-SAME: requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=0
 
 // CHECK: {{^}}[[_1ST_MSTR_TID]]: _first_tool: ompt_event_masked_begin:
@@ -74,7 +74,7 @@ int main() {
 // CHECK-SAME: parent_task_id=[[_FIRST_MASTER_IMPLICIT_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: new_task_id=[[_FIRST_EXPLICIT_TASK_ID:[0-9]+]],
+// CHECK-SAME: new_task_id=[[_FIRST_EXPLICIT_TASK_ID:[0-f]+]],
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4,
 // CHECK-SAME: has_dependences=no
 
@@ -151,20 +151,20 @@ int main() {
 // CHECK-SAME: thread_type=ompt_thread_initial=1, thread_id=[[_2ND_MSTR_TID]]
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_initial_task_begin:
-// CHECK-SAME: parallel_id=[[SECOND_INIT_PARALLEL_ID:[0-9]+]],
-// CHECK-SAME: task_id=[[SECOND_INITIAL_TASK_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[SECOND_INIT_PARALLEL_ID:[0-f]+]],
+// CHECK-SAME: task_id=[[SECOND_INITIAL_TASK_ID:[0-f]+]],
 // CHECK-SAME: actual_parallelism=1, index=1, flags=1
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_parallel_begin:
 // CHECK-SAME: parent_task_id=[[SECOND_INITIAL_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit=[[NULL]],
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID:[0-9]+]],
+// CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID:[0-f]+]],
 // CHECK-SAME: requested_team_size=2, codeptr_ra={{(0x)?[0-f]+}}, invoker
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=0
 
 // CHECK: {{^}}[[_2ND_MSTR_TID]]: second_tool: ompt_event_masked_begin:
@@ -176,7 +176,7 @@ int main() {
 // CHECK-SAME: parent_task_id=[[SECOND_MASTER_IMPLICIT_TASK_ID]],
 // CHECK-SAME: parent_task_frame.exit={{(0x)?[0-f]+}},
 // CHECK-SAME: parent_task_frame.reenter={{(0x)?[0-f]+}},
-// CHECK-SAME: new_task_id=[[SECOND_EXPLICIT_TASK_ID:[0-9]+]],
+// CHECK-SAME: new_task_id=[[SECOND_EXPLICIT_TASK_ID:[0-f]+]],
 // CHECK-SAME: codeptr_ra={{(0x)?[0-f]+}}, task_type=ompt_task_explicit=4,
 // CHECK-SAME: has_dependences=no
 
@@ -255,7 +255,7 @@ int main() {
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[_FIRST_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID:[0-9]+]], team_size=2,
+// CHECK-SAME: task_id=[[_FIRST_WORKER_IMPLICIT_TASK_ID:[0-f]+]], team_size=2,
 // CHECK-SAME: thread_num=1
 
 // CHECK: {{^}}[[_1ST_WRKR_TID]]: _first_tool:
@@ -291,7 +291,7 @@ int main() {
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool: ompt_event_implicit_task_begin:
 // CHECK-SAME: parallel_id=[[SECOND_PARALLEL_ID]],
-// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID:[0-9]+]],
+// CHECK-SAME: task_id=[[SECOND_WORKER_IMPLICIT_TASK_ID:[0-f]+]],
 // CHECK-SAME: team_size=2, thread_num=1
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool:

--- a/openmp/tools/multiplex/tests/print/print.c
+++ b/openmp/tools/multiplex/tests/print/print.c
@@ -1,3 +1,4 @@
+// clang-format off
 // RUN: %libomp-tool -DFIRST_TOOL -o %t.first.tool.so %s && \
 // RUN: %libomp-tool -DSECOND_TOOL -o %t.second.tool.so %s && \
 // RUN: %libomp-compile && \
@@ -8,6 +9,7 @@
 // For GCC we don't get an event for master,
 // see runtime/test/ompt/sycnchronization/master.c
 // UNSUPPORTED: gcc
+// clang-format on
 
 #if defined(FIRST_TOOL)
 #include "first-tool.h"
@@ -37,6 +39,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // Check if libomp supports the callbacks for this test.
 // CHECK-NOT: {{^}}0: Could not register callback
 
@@ -320,5 +323,6 @@ int main() {
 
 // CHECK: {{^}}[[_2ND_WRKR_TID]]: second_tool: ompt_event_thread_end:
 // CHECK-SAME: thread_id=[[_2ND_WRKR_TID]]
+// clang-format on
 
 #endif /* APP */


### PR DESCRIPTION
Using hex format allows to better interpret IDs: 
the first digits represent the thread number, the last digits represent the ID within a thread

The main change is in callback.h