### PR TITLE
[libc++] Check for _newlib_version.h instead of picolibc.h

### DIFF
--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -45,7 +45,9 @@
 // This is required in order for _NEWLIB_VERSION to be defined in places where we use it.
 // TODO: We shouldn't be including arbitrarily-named headers from libc++ since this can break valid
 //       user code. Move code paths that need _NEWLIB_VERSION to another customization mechanism.
-#if __has_include(<picolibc.h>)
+#if __has_include(<_newlib_version.h>)
+#  include <_newlib_version.h>
+#elif __has_include(<picolibc.h>)
 #  include <picolibc.h>
 #endif
 


### PR DESCRIPTION
Fixes #152763.

https://github.com/llvm/llvm-project/pull/131921 added some code to pull in a definition of _NEWLIB_VERSION if it exists. It does this by checking __has_include(<picolibc.h>) and including it if so. However, this does not work for systems that have newlib rather than picolibc. This change instead checks for and includes _newlib_version.h, which should work for both newlib and picolibc.