### PR TITLE
[Support] Add missing LLVM_ABI annotations in Atomic.h

### DIFF
--- a/llvm/include/llvm/Support/Atomic.h
+++ b/llvm/include/llvm/Support/Atomic.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_SUPPORT_ATOMIC_H
 #define LLVM_SUPPORT_ATOMIC_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/DataTypes.h"
 
 // Windows will at times define MemoryFence.
@@ -26,16 +27,15 @@
 
 namespace llvm {
   namespace sys {
-    void MemoryFence();
+  LLVM_ABI void MemoryFence();
 
 #ifdef _MSC_VER
-    typedef long cas_flag;
+  typedef long cas_flag;
 #else
-    typedef uint32_t cas_flag;
+  typedef uint32_t cas_flag;
 #endif
-    cas_flag CompareAndSwap(volatile cas_flag* ptr,
-                            cas_flag new_value,
-                            cas_flag old_value);
+  LLVM_ABI cas_flag CompareAndSwap(volatile cas_flag *ptr, cas_flag new_value,
+                                   cas_flag old_value);
   }
 }
 


### PR DESCRIPTION
This fixes building LLD for mingw targets with
LLVM_BUILD_LLVM_DYLIB_VIS=ON with Clang. This has been missed for other platforms, as those platforms have LLVM_THREADING_USE_STD_CALL_ONCE=1 in llvm/Support/Threading.h, while it ends up set to 0, using CompareAndSwap() and MemoryFence() instead, for mingw targets.