### PR TITLE
[LLVM][lit] add system-cygwin feature

### DIFF
--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -107,6 +107,8 @@ class LLVMConfig(object):
             features.add("system-solaris")
         elif platform.system() == "OS/390":
             features.add("system-zos")
+        elif sys.platform == "cygwin":
+            features.add("system-cygwin")
 
         # Native compilation: host arch == default triple arch
         # Both of these values should probably be in every site config (e.g. as


### PR DESCRIPTION
There are a few tests in clang that gate on system-windows but also don't work on Cygwin, so add a system-cygwin feature for them to use.