### PR TITLE
[HLSL][DirectX] Fix `dot2add` DXIL operation to use float overload

### DIFF
--- a/clang/test/CodeGenHLSL/builtins/dot2add.hlsl
+++ b/clang/test/CodeGenHLSL/builtins/dot2add.hlsl
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -finclude-default-header -fnative-half-type -triple \
-// RUN:   dxil-pc-shadermodel6.3-compute %s -emit-llvm -o - | \
+// RUN:   dxil-pc-shadermodel6.4-compute %s -emit-llvm -o - | \
 // RUN:   FileCheck %s --check-prefixes=CHECK,CHECK-DXIL
 // RUN: %clang_cc1 -finclude-default-header -fnative-half-type -triple \
 // RUN:   spirv-pc-vulkan-compute %s -emit-llvm -o - | \

--- a/llvm/lib/Target/DirectX/DXIL.td
+++ b/llvm/lib/Target/DirectX/DXIL.td
@@ -1108,11 +1108,11 @@ def RawBufferStore : DXILOp<140, rawBufferStore> {
 def Dot2AddHalf : DXILOp<162, dot2AddHalf> {
   let Doc = "2D half dot product with accumulate to float";
   let intrinsics = [IntrinSelect<int_dx_dot2add>];
-  let arguments = [FloatTy, HalfTy, HalfTy, HalfTy, HalfTy];
-  let result = FloatTy;
-  let overloads = [Overloads<DXIL1_0, []>];
-  let stages = [Stages<DXIL1_0, [all_stages]>];
-  let attributes = [Attributes<DXIL1_0, [ReadNone]>];
+  let arguments = [OverloadTy, HalfTy, HalfTy, HalfTy, HalfTy];
+  let result = OverloadTy;
+  let overloads = [Overloads<DXIL1_4, [FloatTy]>];
+  let stages = [Stages<DXIL1_4, [all_stages]>];
+  let attributes = [Attributes<DXIL1_4, [ReadNone]>];
 }
 
 def Dot4AddI8Packed : DXILOp<163, dot4AddPacked> {

--- a/llvm/test/CodeGen/DirectX/dot2add.ll
+++ b/llvm/test/CodeGen/DirectX/dot2add.ll
@@ -1,4 +1,4 @@
-; RUN: opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-compute %s | FileCheck %s
+; RUN: opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.4-compute %s | FileCheck %s
 
 define noundef float @dot2add_simple(<2 x half> noundef %a, <2 x half> noundef %b, float %acc) {
 entry:
@@ -7,7 +7,7 @@ entry:
   %bx = extractelement <2 x half> %b, i32 0
   %by = extractelement <2 x half> %b, i32 1
 
-; CHECK: call float @dx.op.dot2AddHalf(i32 162, float %acc, half %ax, half %ay, half %bx, half %by)
+; CHECK: call float @dx.op.dot2AddHalf.f32(i32 162, float %acc, half %ax, half %ay, half %bx, half %by)
   %ret = call float @llvm.dx.dot2add(float %acc, half %ax, half %ay, half %bx, half %by)
   ret float %ret
 }

--- a/llvm/test/CodeGen/DirectX/dot2add_error.ll
+++ b/llvm/test/CodeGen/DirectX/dot2add_error.ll
@@ -1,0 +1,15 @@
+; RUN: not opt -S -dxil-op-lower -mtriple=dxil-pc-shadermodel6.3-compute %s 2>&1 | FileCheck %s
+
+; CHECK: in function f
+; CHECK-SAME: Cannot create Dot2AddHalf operation: No valid overloads for DXIL version 1.3
+
+define noundef float @f(<2 x half> noundef %a, <2 x half> noundef %b, float %acc) {
+entry:
+  %ax = extractelement <2 x half> %a, i32 0
+  %ay = extractelement <2 x half> %a, i32 1
+  %bx = extractelement <2 x half> %b, i32 0
+  %by = extractelement <2 x half> %b, i32 1
+  
+  %ret = call float @llvm.dx.dot2add(float %acc, half %ax, half %ay, half %bx, half %by)
+  ret float %ret
+}


### PR DESCRIPTION
Fixes #152585.

The `dot2add` DXILOpFunction should be `dx.op.dot2AddHalf.f32` (i.e. it has [a single overload that's a float](https://github.com/microsoft/DirectXShaderCompiler/blob/main/utils/hct/hctdb.py#L3960), rather than no overloads). It was also being defined for too low of a DXIL version - [dxc says SM6.4](https://github.com/microsoft/DirectXShaderCompiler/blob/main/utils/hct/hctdb.py#L740).