### PR TITLE
[flang][cuda] Set correct bind(c) name for __popc

### DIFF
--- a/flang/module/cudadevice.f90
+++ b/flang/module/cudadevice.f90
@@ -754,11 +754,11 @@ implicit none
   end interface
 
   interface __popc
-    attributes(device) integer function __popc(i) bind(c)
+    attributes(device) integer function __popc(i) bind(c, name='__nv_popc')
       !dir$ ignore_tkr (d) i
       integer, value :: i
     end function
-    attributes(device) integer function __popcll(i) bind(c)
+    attributes(device) integer function __popcll(i) bind(c, name='__nv_popcll')
       !dir$ ignore_tkr (d) i
       integer(8), value :: i
     end function

--- a/flang/test/Lower/CUDA/cuda-device-proc.cuf
+++ b/flang/test/Lower/CUDA/cuda-device-proc.cuf
@@ -11,6 +11,7 @@ attributes(global) subroutine devsub()
   integer(8) :: al
   integer(8) :: time
   integer :: smalltime
+  integer(4) :: res
 
   call syncthreads()
   call syncwarp(1)
@@ -49,6 +50,9 @@ attributes(global) subroutine devsub()
   smalltime = clock()
   time = clock64()
   time = globalTimer()
+
+  res = __popc(ai)
+  res = __popc(al)
 end
 
 ! CHECK-LABEL: func.func @_QPdevsub() attributes {cuf.proc_attr = #cuf.cuda_proc<global>}
@@ -88,6 +92,9 @@ end
 ! CHECK: %{{.*}} = nvvm.read.ptx.sreg.clock : i32
 ! CHECK: %{{.*}} = nvvm.read.ptx.sreg.clock64 : i64
 ! CHECK: %{{.*}} = nvvm.read.ptx.sreg.globaltimer : i64
+
+! CHECK: %{{.*}} = fir.call @__nv_popc(%{{.*}}) proc_attrs<bind_c> fastmath<contract> : (i32) -> i32
+! CHECK: %{{.*}} = fir.call @__nv_popcll(%{{.*}}) proc_attrs<bind_c> fastmath<contract> : (i64) -> i32
 
 subroutine host1()
   integer, device :: a(32)


### PR DESCRIPTION
The `__popc` interface is used to call lib device functions `__nv_popc`  and `__nv_popcll`. Update the module with the correct bind(c) name