### PR TITLE
[mlir][linalg][test] Fix flaky test linalg-morph-multi-step.mlir

### DIFF
--- a/mlir/test/Dialect/Linalg/linalg-morph-multi-step.mlir
+++ b/mlir/test/Dialect/Linalg/linalg-morph-multi-step.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s -linalg-morph-ops=named-to-generic |  FileCheck %s  --check-prefix=NAMED_TO_GENERIC
-// RUN: mlir-opt %s -linalg-morph-ops=named-to-generic |  mlir-opt %s -linalg-morph-ops=generic-to-named | \
+// RUN: mlir-opt %s -linalg-morph-ops=named-to-generic |  mlir-opt -linalg-morph-ops=generic-to-named | \
 // RUN:   FileCheck %s  --check-prefix=ROUND_TRIP
 
 func.func @exp(%A : tensor<16x8xf32>, %B : tensor<16x8xf32>) ->  tensor<16x8xf32> {


### PR DESCRIPTION
This test runs `mlir-opt %s | mlir-opt %s | FileCheck` to test the round trip behavior, but the second command takes input from the pipe, not the lit test, so it should be `mlir-opt %s | mlir-opt | FileCheck`.

For some reason I haven't figured out, this causes ~50% flakiness when testing in certain environments (not reproducible in my shell, but reproduces in an internal buildbot), due to the pipeline raising `SIGPIPE`.

Test added in #148424.