### PR TITLE
Fix MSVC warning in CompilerInvocation.cpp

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4441,7 +4441,7 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
     StringRef Ver = A->getValue();
     std::pair<StringRef, StringRef> VerParts = Ver.split('.');
-    unsigned Major, Minor = 0;
+    int Major, Minor = 0;
 
     // Check the version number is valid: either 3.x (0 <= x <= 9) or
     // y or y.0 (4 <= y <= current version).
@@ -4454,7 +4454,7 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
              : VerParts.first.size() == Ver.size() || VerParts.second == "0")) {
       // Got a valid version number.
 #define ABI_VER_MAJOR_MINOR(Major_, Minor_)                                    \
-  if (std::tie(Major, Minor) <= std::tuple(Major_, Minor_))                    \
+  if (std::tuple(Major, Minor) <= std::tuple(Major_, Minor_))                  \
     Opts.setClangABICompat(LangOptions::ClangABI::Ver##Major_##_##Minor_);     \
   else
 #define ABI_VER_MAJOR(Major_)                                                  \


### PR DESCRIPTION
Building Clang using MSVC was resulting in the following warning:

```
tuple(791): warning C4018: '<': signed/unsigned mismatch
```

I traced this to CompilerInvocation.cpp where it was creating a `std::tuple` to compare version numbers.

This change adds an explicit type for the `tuple` created from the version macros to match the type of the variables, and uses the `tuple` constructor instead of `tie` since the integers are smaller than a reference to the integers.