### PR TITLE
[win][arm64ec] Fix duplicate errors with the dontcall attribute

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2786,11 +2786,14 @@ bool IRTranslator::translateCall(const User &U, MachineIRBuilder &MIRBuilder) {
   if (CI.isInlineAsm())
     return translateInlineAsm(CI, MIRBuilder);
 
-  diagnoseDontCall(CI);
-
   Intrinsic::ID ID = F ? F->getIntrinsicID() : Intrinsic::not_intrinsic;
-  if (!F || ID == Intrinsic::not_intrinsic)
-    return translateCallBase(CI, MIRBuilder);
+  if (!F || ID == Intrinsic::not_intrinsic) {
+    if (translateCallBase(CI, MIRBuilder)) {
+      diagnoseDontCall(CI);
+      return true;
+    }
+    return false;
+  }
 
   assert(ID != Intrinsic::not_intrinsic && "unknown intrinsic");
 

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1148,9 +1148,12 @@ bool FastISel::lowerCall(const CallInst *CI) {
   CLI.setCallee(RetTy, FuncTy, CI->getCalledOperand(), std::move(Args), *CI)
       .setTailCall(IsTailCall);
 
-  diagnoseDontCall(*CI);
+  if (lowerCallTo(CLI)) {
+    diagnoseDontCall(*CI);
+    return true;
+  }
 
-  return lowerCallTo(CLI);
+  return false;
 }
 
 bool FastISel::selectCall(const User *I) {

--- a/llvm/test/CodeGen/AArch64/arm64ec-dont-call.ll
+++ b/llvm/test/CodeGen/AArch64/arm64ec-dont-call.ll
@@ -1,0 +1,22 @@
+; RUN: not llc -mtriple=arm64ec-windows-msvc -filetype=null %s 2>&1 | FileCheck %s
+; RUN: not llc -mtriple=arm64ec-windows-msvc -filetype=null -global-isel=1 -global-isel-abort=0 %s 2>&1 | FileCheck %s
+
+define void @baz() #0 {
+  call void @foo()
+  ret void
+}
+
+define void @foo() #1 {
+  ret void
+}
+
+attributes #0 = { noinline optnone }
+attributes #1 = { "dontcall-error"="oh no foo" }
+
+; Regression test for `dontcall-error` for Arm64EC. Since this attribute is
+; checked both by FastISel and SelectionDAGBuilder, and FastISel was bailing for
+; Arm64EC AFTER doing the check, we ended up with duplicate copies of this
+; error.
+
+; CHECK: error: call to #foo marked "dontcall-error": oh no foo
+; CHECK-NOT: error:

--- a/llvm/test/CodeGen/X86/attr-dontcall.ll
+++ b/llvm/test/CodeGen/X86/attr-dontcall.ll
@@ -1,6 +1,6 @@
 ; RUN: not llc -mtriple=x86_64 -global-isel=0 -fast-isel=0 -stop-after=finalize-isel < %s 2>&1 | FileCheck %s
 ; RUN: not llc -mtriple=x86_64 -global-isel=0 -fast-isel=1 -stop-after=finalize-isel < %s 2>&1 | FileCheck %s
-; RUN: not llc -mtriple=x86_64 -global-isel=1 -fast-isel=0 -stop-after=irtranslator -global-isel-abort=0 < %s 2>&1 | FileCheck %s
+; RUN: not llc -mtriple=x86_64 -global-isel=1 -fast-isel=0 -global-isel-abort=0 < %s 2>&1 | FileCheck %s
 
 declare void @foo() "dontcall-error"="e"
 define void @bar() {


### PR DESCRIPTION
Since the `dontcall-*` attributes are checked both by `FastISel`/`GlobalISel` and `SelectionDAGBuilder`, and both `FastISel` and `GlobalISel` bail for calls on Arm64EC for AFTER doing the check, we ended up emitting duplicate copies of this error.

This change moves the checking for `dontcall-*` in `FastISel` and `GlobalISel` to after it has been successfully lowered.