### PR TITLE
[Support] Fix CRTP for GraphWriter (NFC)

### DIFF
--- a/llvm/include/llvm/Support/GraphWriter.h
+++ b/llvm/include/llvm/Support/GraphWriter.h
@@ -62,6 +62,7 @@ LLVM_ABI bool DisplayGraph(StringRef Filename, bool wait = true,
                            GraphProgram::Name program = GraphProgram::DOT);
 
 template <typename GraphType, typename Derived> class GraphWriterBase {
+protected:
   raw_ostream &O;
   const GraphType &G;
   bool RenderUsingHTML = false;


### PR DESCRIPTION
Commit 474bbc1 forgot to change `GraphWriterBase`'s members from private to protected.
Because of this, `GraphWriter` can't be properly partially specialized using CRTP.
This commit corrects that, allowing `GraphWriterBase` to be partially specialized using CRTP as intended.