### PR TITLE
[mlir][affine] Fix crash in affine-loop-fusion by validating access relation IDs

### DIFF
--- a/mlir/lib/Dialect/Affine/Analysis/AffineAnalysis.cpp
+++ b/mlir/lib/Dialect/Affine/Analysis/AffineAnalysis.cpp
@@ -469,7 +469,21 @@ LogicalResult MemRefAccess::getAccessRelation(IntegerRelation &rel) const {
 
   // Merge and align domain ids of `rel` with ids of `domain`. Since the domain
   // of the access map is a subset of the domain of access, the domain ids of
-  // `rel` are guranteed to be a subset of ids of `domain`.
+  // `rel` should be a subset of ids of `domain`. If not, return failure.
+
+  for (unsigned i = 0; i < rel.getNumDimVars(); ++i) {
+    if (rel.getVarKindAt(i) != VarKind::SetDim)
+      continue;
+    Identifier idi = rel.getIds(VarKind::SetDim)[i];
+    if (!idi.hasValue()) {
+      continue;
+    }
+    ArrayRef<Identifier> domainIds = domain.getIds(VarKind::SetDim);
+    if (!llvm::is_contained(domainIds, idi)) {
+      return failure();
+    }
+  }
+
   unsigned inserts = 0;
   for (unsigned i = 0, e = domain.getNumDimVars(); i < e; ++i) {
     const Identifier domainIdi = Identifier(domain.getValue(i));

--- a/mlir/test/Dialect/Affine/loop-fusion-4.mlir
+++ b/mlir/test/Dialect/Affine/loop-fusion-4.mlir
@@ -884,3 +884,19 @@ func.func @high_trip_count(%arg0: memref<1024x4096xf32>, %arg1: memref<8192x4096
   }
   return %alloc : memref<1024x8192xf32>
 }
+
+// Exercises fix for crash reported at https://github.com/llvm/llvm-project/issues/54541
+
+func.func @load_linearized_index() {
+  %0 = memref.alloc() : memref<128xi8>
+  %2 = arith.constant 1 : i8
+  affine.for %i0 = 0 to 128 {
+    %3 = affine.linearize_index [%i0] by (1) : index
+    affine.store %2, %0[%3] : memref<128xi8>
+  }
+  affine.for %i0 = 0 to 128 {
+    %3 = affine.linearize_index [%i0] by (1) : index
+    %4 = affine.load %0[%3] : memref<128xi8>
+  }
+  return
+}


### PR DESCRIPTION
Fixes #149507

`MemRefAccess::getAccessRelation` assumed that access relation’s IDs are always a subset of domain relation IDs.
When this invariant was violated (e.g., in the `affine-loop-fusion` pass), it led to crashes.

This change adds an explicit check: if any ID is missing from the domain, the function returns `failure()`.