### PR TITLE
[mlgo] Remove tests involving the size estimator, after PR #139357

### DIFF
--- a/llvm/test/Transforms/Inline/ML/development-training-log.ll
+++ b/llvm/test/Transforms/Inline/ML/development-training-log.ll
@@ -5,12 +5,6 @@
 ; RUN: %python %S/../../../../lib/Analysis/models/gen-inline-oz-test-model.py %t_savedmodel
 ; RUN: %python %S/../../../../lib/Analysis/models/saved-model-to-tflite.py %t_savedmodel %t
 ;
-; RUN: opt -enable-ml-inliner=development -passes=scc-oz-module-inliner -training-log=%t1 -ml-inliner-model-under-training=%t -ml-inliner-ir2native-model=%S/../../../../unittests/Analysis/Inputs/ir2native_x86_64_model -S < %s
-; RUN: %python %S/../../../../lib/Analysis/models/log_reader.py %t1 | FileCheck %s
-; RUN: opt -enable-ml-inliner=development -passes=scc-oz-module-inliner -training-log=%t2 -ml-inliner-model-under-training=%t -ml-inliner-ir2native-model=%S/../../../../unittests/Analysis/Inputs/ir2native_x86_64_model -ml-inliner-output-spec-override=%S/Inputs/test_output_spec.json -S < %s
-; RUN: %python %S/../../../../lib/Analysis/models/log_reader.py %t2 | FileCheck %s --check-prefixes=EXTRA-OUTPUTS,CHECK
-; RUN: opt -enable-ml-inliner=development -passes=scc-oz-module-inliner -training-log=%t3 -ml-inliner-ir2native-model=%S/../../../../unittests/Analysis/Inputs/ir2native_x86_64_model -S < %s
-; RUN: %python %S/../../../../lib/Analysis/models/log_reader.py %t3 | FileCheck %s
 ; RUN: opt -enable-ml-inliner=development -passes=scc-oz-module-inliner -training-log=%t4 -ml-inliner-model-under-training=%t -S < %s
 ; RUN: %python %S/../../../../lib/Analysis/models/log_reader.py %t4 | FileCheck %s --check-prefix=NOREWARD
 ; RUN: opt -enable-ml-inliner=development -passes=scc-oz-module-inliner -training-log=%t5 -S < %s

--- a/llvm/test/Transforms/Inline/ML/size-estimator-default.ll
+++ b/llvm/test/Transforms/Inline/ML/size-estimator-default.ll
@@ -1,4 +1,0 @@
-; REQUIRES: !have_tflite
-; RUN: opt -passes='print<inliner-size-estimator>' -S < %S/Inputs/size-estimator.ll 2>&1 | FileCheck %s
-
-; CHECK: [InlineSizeEstimatorAnalysis] size estimate for branches: None

--- a/llvm/test/Transforms/Inline/ML/size-estimator-training.ll
+++ b/llvm/test/Transforms/Inline/ML/size-estimator-training.ll
@@ -1,6 +1,0 @@
-; REQUIRES: have_tflite
-; RUN: opt -passes='print<inliner-size-estimator>' -S < %S/Inputs/size-estimator.ll 2>&1 | FileCheck %s --check-prefix=DEFAULT
-; RUN: opt -passes='print<inliner-size-estimator>' -ml-inliner-ir2native-model=%S/../../../../unittests/Analysis/Inputs/ir2native_x86_64_model -S < %S/Inputs/size-estimator.ll 2>&1 | FileCheck %s
-
-; DEFAULT: [InlineSizeEstimatorAnalysis] size estimate for branches: None
-; CHECK: [InlineSizeEstimatorAnalysis] size estimate for branches: 28


### PR DESCRIPTION
We'll remove the size estimator after, this change is to get the `ml-*` build bots green after the aforementioned PR.

We never used the size estimator again after the initial DQN-based training. Should we want to again, we now have IR2Vec, which the old estimator was approximating in functionality.