### PR TITLE
Limit Alloca->LDS promotion based on speculations as to eventual register pressure

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -1500,7 +1500,7 @@ size_t AMDGPUPromoteAllocaImpl::getSGPRPressureEstimate(AllocaInst &I) {
 
     for (auto RIt = BB->rbegin(); RIt != BB->rend(); RIt++) {
       if (&*RIt == &I)
-        return (MaxLive + CurrentlyLive.size()) / 2;
+        return MaxLive;
 
       MaxLive = std::max(MaxLive, CurrentlyLive.size());
 
@@ -1532,7 +1532,7 @@ size_t AMDGPUPromoteAllocaImpl::getVGPRPressureEstimate(AllocaInst &I) {
 
     for (auto RIt = BB->rbegin(); RIt != BB->rend(); RIt++) {
       if (&*RIt == &I)
-        return (MaxLive + CurrentlyLive.size() / 2);
+        return MaxLive;
 
       MaxLive = std::max(MaxLive, CurrentlyLive.size());
 
@@ -1555,10 +1555,10 @@ bool AMDGPUPromoteAllocaImpl::tryPromoteAllocaToLDS(AllocaInst &I,
   const unsigned SGPRPressureLimit = AMDGPU::SGPR_32RegClass.getNumRegs();
   const unsigned VGPRPressureLimit = AMDGPU::VGPR_32RegClass.getNumRegs();
 
-  if (getSGPRPressureEstimate(I) < SGPRPressureLimit &&
-      getVGPRPressureEstimate(I) < VGPRPressureLimit) {
+  if (getSGPRPressureEstimate(I) > SGPRPressureLimit ||
+      getVGPRPressureEstimate(I) > VGPRPressureLimit) {
     LLVM_DEBUG(dbgs() << "Declining to promote " << I
-                      << " to LDS since pressure is relatively low.\n");
+                      << " to LDS since pressure is relatively high.\n");
     return false;
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -1512,6 +1512,8 @@ size_t AMDGPUPromoteAllocaImpl::getSGPRPressureEstimate(AllocaInst &I) {
       if (!RIt->getType()->isVectorTy())
         CurrentlyLive.erase(&*RIt);
     }
+
+    SGPRLiveIns[BB] = CurrentlyLive;
   }
 
   llvm_unreachable("Woops, we fell off the edge of the world.  Bye bye.");
@@ -1544,6 +1546,8 @@ size_t AMDGPUPromoteAllocaImpl::getVGPRPressureEstimate(AllocaInst &I) {
       if (RIt->getType()->isVectorTy())
         CurrentlyLive.erase(&*RIt);
     }
+
+    VGPRLiveIns[BB] = CurrentlyLive;
   }
 
   llvm_unreachable("Woops, we fell off the edge of the world.  Bye bye.");

--- a/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -1486,7 +1486,7 @@ bool AMDGPUPromoteAllocaImpl::hasSufficientLocalMem(const Function &F) {
 }
 
 size_t AMDGPUPromoteAllocaImpl::getSGPRPressureEstimate(AllocaInst &I) {
-  Function &F = *I.getParent()->getParent();
+  Function &F = *I.getFunction();
   size_t MaxLive = 0;
   for (BasicBlock *BB : post_order(&F)) {
     if (SGPRLiveIns.count(BB))


### PR DESCRIPTION
This attempts to resolve SWDEV-547512 by inhibiting alloca to LDS promotion when register pressure is high.  Draft because:
- There are no tests.
- The heuristic probably needs to be refined.
- This may not even be a good idea; performance testing must be completed to determine that.
