### PR TITLE
[ADT] Use range-based for loops in SmallPtrSet.h (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/ADL.h"
 #include "llvm/ADT/EpochTracker.h"
 #include "llvm/ADT/STLForwardCompat.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/ReverseIteration.h"
@@ -147,17 +148,23 @@ protected:
     return isSmall() ? CurArray + NumNonEmpty : CurArray + CurArraySize;
   }
 
+  iterator_range<const void **> smallBuckets() {
+    return make_range(CurArray, CurArray + NumNonEmpty);
+  }
+
+  iterator_range<const void *const *> smallBuckets() const {
+    return {CurArray, CurArray + NumNonEmpty};
+  }
+
   /// insert_imp - This returns true if the pointer was new to the set, false if
   /// it was already in the set.  This is hidden from the client so that the
   /// derived class can check that the right type of pointer is passed in.
   std::pair<const void *const *, bool> insert_imp(const void *Ptr) {
     if (isSmall()) {
       // Check to see if it is already in the set.
-      for (const void **APtr = CurArray, **E = CurArray + NumNonEmpty;
-           APtr != E; ++APtr) {
-        const void *Value = *APtr;
-        if (Value == Ptr)
-          return std::make_pair(APtr, false);
+      for (const void *&Bucket : smallBuckets()) {
+        if (Bucket == Ptr)
+          return std::make_pair(&Bucket, false);
       }
 
       // Nope, there isn't.  If we stay small, just 'pushback' now.
@@ -177,10 +184,9 @@ protected:
   /// in.
   bool erase_imp(const void * Ptr) {
     if (isSmall()) {
-      for (const void **APtr = CurArray, **E = CurArray + NumNonEmpty;
-           APtr != E; ++APtr) {
-        if (*APtr == Ptr) {
-          *APtr = CurArray[--NumNonEmpty];
+      for (const void *&Bucket : smallBuckets()) {
+        if (Bucket == Ptr) {
+          Bucket = CurArray[--NumNonEmpty];
           incrementEpoch();
           return true;
         }
@@ -206,11 +212,9 @@ protected:
   const void *const * find_imp(const void * Ptr) const {
     if (isSmall()) {
       // Linear search for the item.
-      for (const void *const *APtr = CurArray, *const *E =
-                                                   CurArray + NumNonEmpty;
-           APtr != E; ++APtr)
-        if (*APtr == Ptr)
-          return APtr;
+      for (const void *const &Bucket : smallBuckets())
+        if (Bucket == Ptr)
+          return &Bucket;
       return EndPointer();
     }
 
@@ -223,10 +227,8 @@ protected:
   bool contains_imp(const void *Ptr) const {
     if (isSmall()) {
       // Linear search for the item.
-      const void *const *APtr = CurArray;
-      const void *const *E = CurArray + NumNonEmpty;
-      for (; APtr != E; ++APtr)
-        if (*APtr == Ptr)
+      for (const void *const &Bucket : smallBuckets())
+        if (Bucket == Ptr)
           return true;
       return false;
     }

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -148,11 +148,11 @@ protected:
     return isSmall() ? CurArray + NumNonEmpty : CurArray + CurArraySize;
   }
 
-  iterator_range<const void **> smallBuckets() {
+  iterator_range<const void **> small_buckets() {
     return make_range(CurArray, CurArray + NumNonEmpty);
   }
 
-  iterator_range<const void *const *> smallBuckets() const {
+  iterator_range<const void *const *> small_buckets() const {
     return {CurArray, CurArray + NumNonEmpty};
   }
 
@@ -162,7 +162,7 @@ protected:
   std::pair<const void *const *, bool> insert_imp(const void *Ptr) {
     if (isSmall()) {
       // Check to see if it is already in the set.
-      for (const void *&Bucket : smallBuckets()) {
+      for (const void *&Bucket : small_buckets()) {
         if (Bucket == Ptr)
           return std::make_pair(&Bucket, false);
       }
@@ -184,7 +184,7 @@ protected:
   /// in.
   bool erase_imp(const void * Ptr) {
     if (isSmall()) {
-      for (const void *&Bucket : smallBuckets()) {
+      for (const void *&Bucket : small_buckets()) {
         if (Bucket == Ptr) {
           Bucket = CurArray[--NumNonEmpty];
           incrementEpoch();
@@ -212,7 +212,7 @@ protected:
   const void *const * find_imp(const void * Ptr) const {
     if (isSmall()) {
       // Linear search for the item.
-      for (const void *const &Bucket : smallBuckets())
+      for (const void *const &Bucket : small_buckets())
         if (Bucket == Ptr)
           return &Bucket;
       return EndPointer();
@@ -227,7 +227,7 @@ protected:
   bool contains_imp(const void *Ptr) const {
     if (isSmall()) {
       // Linear search for the item.
-      for (const void *const &Bucket : smallBuckets())
+      for (const void *const &Bucket : small_buckets())
         if (Bucket == Ptr)
           return true;
       return false;


### PR DESCRIPTION
This patch defines a couple of helper functions so that we can convert
four loops to range-based for loops.
