### PR TITLE
[llvm] Fix fabs simplification

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -6304,7 +6304,8 @@ static Value *simplifyUnaryIntrinsic(Function *F, Value *Op0,
   Value *X;
   switch (IID) {
   case Intrinsic::fabs:
-    if (computeKnownFPSignBit(Op0, Q) == false)
+    if (std::optional<bool> KnownSignBit = computeKnownFPSignBit(Op0, Q);
+        KnownSignBit && *KnownSignBit == false)
       return Op0;
     break;
   case Intrinsic::bswap:


### PR DESCRIPTION
The existing code hits the std::optional<bool> is of comparing to a bool being "correct" for the std::optional and the intended comparison.

This corrects the comparison while reinforcing the idea that we need some way to diagnose this.

Fixes #152824