### PR TITLE
[ExecutionEngine] Remove an unnecessary cast (NFC)

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/EPCIndirectionUtils.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/EPCIndirectionUtils.cpp
@@ -169,7 +169,7 @@ Error EPCIndirectStubsManager::createStubs(const StubInitsMap &StubInits) {
     std::vector<tpctypes::UInt64Write> PtrUpdates;
     for (auto &SI : StubInits)
       PtrUpdates.push_back({(*AvailableStubInfos)[ASIdx++].PointerAddress,
-                            static_cast<uint64_t>(SI.second.first.getValue())});
+                            SI.second.first.getValue()});
     return MemAccess.writeUInt64s(PtrUpdates);
   }
   default:


### PR DESCRIPTION
getValue() already returns uint64_t.
