### PR TITLE
[clang] Forward Correct SourceLocation for Unreachable Code Diagnostics

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -178,6 +178,8 @@ Bug Fixes to C++ Support
 - Diagnose binding a reference to ``*nullptr`` during constant evaluation. (#GH48665)
 - Suppress ``-Wdeprecated-declarations`` in implicitly generated functions. (#GH147293)
 - Fix a crash when deleting a pointer to an incomplete array (#GH150359).
+- Diagnosing the correct location for a function with non-POD data return-type being
+  labeled ``[[noreturn]]``.
 - Fix an assertion failure when expression in assumption attribute
   (``[[assume(expr)]]``) creates temporary objects.
 

--- a/clang/lib/Analysis/ReachableCode.cpp
+++ b/clang/lib/Analysis/ReachableCode.cpp
@@ -601,6 +601,11 @@ static SourceLocation GetUnreachableLoc(const Stmt *S,
     S = Ex->IgnoreParenImpCasts();
 
   switch (S->getStmtClass()) {
+  case Expr::CXXBindTemporaryExprClass: {
+    const CXXBindTemporaryExpr *TemporaryExpr = cast<CXXBindTemporaryExpr>(S);
+    R1 = TemporaryExpr->getTemporary()->getDestructor()->getSourceRange();
+    return R1.getBegin();
+  }
     case Expr::BinaryOperatorClass: {
       const BinaryOperator *BO = cast<BinaryOperator>(S);
       return BO->getOperatorLoc();

--- a/clang/test/SemaCXX/warn-unreachable.cpp
+++ b/clang/test/SemaCXX/warn-unreachable.cpp
@@ -414,3 +414,16 @@ void tautological_compare(bool x, int y) {
     calledFun();
 
 }
+
+namespace GH152477{
+    class A{
+    public:
+        ~A(); // expected-warning {{will never be executed}}
+    };
+
+    [[noreturn]] A never_return_so_destructor_never_called();
+
+    void func(){
+        never_return_so_destructor_never_called();
+    }
+};


### PR DESCRIPTION
Unreachable destructor of temporary object leads to confusing diagnostics messages.

This patch forwards the correct source location for better and less confusing diagnostics.

fixes #152477