### PR TITLE
[analyzer] Remove trivially true condition

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/UnixAPIChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/UnixAPIChecker.cpp
@@ -124,8 +124,7 @@ ProgramStateRef UnixAPIMisuseChecker::EnsurePtrNotNull(
       auto R = std::make_unique<PathSensitiveBugReport>(
           BT.value_or(std::cref(BT_ArgumentNull)),
           (PtrDescr + " pointer might be NULL.").str(), N);
-      if (PtrExpr)
-        bugreporter::trackExpressionValue(N, PtrExpr, *R);
+      bugreporter::trackExpressionValue(N, PtrExpr, *R);
       C.emitReport(std::move(R));
     }
     return nullptr;


### PR DESCRIPTION
Addresses https://github.com/llvm/llvm-project/pull/83027#discussion_r2264102109

We can only reach this part by a non-null `Ptr`, which also implies a dereference of `PtrExpr`. Consequently, `PtrExpr` cannot be null here so the check is pointless.