### PR TITLE
Thread Safety Analysis: Graduate ACQUIRED_BEFORE() and ACQUIRED_AFTER() from beta features

### DIFF
--- a/clang/docs/ThreadSafetyAnalysis.rst
+++ b/clang/docs/ThreadSafetyAnalysis.rst
@@ -825,13 +825,6 @@ doesn't know that munl.mu == mutex.  The SCOPED_CAPABILITY attribute handles
 aliasing for MutexLocker, but does so only for that particular pattern.
 
 
-ACQUIRED_BEFORE(...) and ACQUIRED_AFTER(...) support is still experimental.
----------------------------------------------------------------------------
-
-ACQUIRED_BEFORE(...) and ACQUIRED_AFTER(...) are currently being developed under
-the ``-Wthread-safety-beta`` flag.
-
-
 .. _mutexheader:
 
 mutex.h

--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1338,8 +1338,7 @@ void ThreadSafetyAnalyzer::addLock(FactSet &FSet,
   }
 
   // Check before/after constraints
-  if (Handler.issueBetaWarnings() &&
-      !Entry->asserted() && !Entry->declared()) {
+  if (!Entry->asserted() && !Entry->declared()) {
     GlobalBeforeSet->checkBeforeAfter(Entry->valueDecl(), FSet, *this,
                                       Entry->loc(), Entry->getKind());
   }


### PR DESCRIPTION
Both these attributes were introduced in ab1dc2d54db5 ("Thread Safety Analysis: add support for before/after annotations on mutexes") back in 2015 as "beta" features.

Anecdotally, we've been using `-Wthread-safety-beta` for years without problems.

Furthermore, this feature requires the user to explicitly use these attributes in the first place.

After 10 years, let's graduate the feature to the stable feature set, and reserve `-Wthread-safety-beta` for new upcoming features.