### PR TITLE
Add `REQUIRES: riscv` to test added in 151639 to skip the test when riscv is not built.

### DIFF
--- a/lld/test/ELF/riscv-relocatable-align.s
+++ b/lld/test/ELF/riscv-relocatable-align.s
@@ -1,3 +1,4 @@
+# REQUIRES: riscv
 # RUN: rm -rf %t && split-file %s %t && cd %t
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax a.s -o ac.o
 # RUN: llvm-mc -filetype=obj -triple=riscv64 -mattr=+c,+relax b.s -o bc.o


### PR DESCRIPTION
A test was added in #151639 which fails if the RISCV backend is not built, so add a `REQUIRES: riscv` to skip it when the backend is not present.