### PR TITLE
[Bolt] Fix integer division bug in computeEdgeWeights fallback weights

### DIFF
--- a/bolt/lib/Passes/MCF.cpp
+++ b/bolt/lib/Passes/MCF.cpp
@@ -153,7 +153,7 @@ void computeEdgeWeights(BinaryBasicBlock *BB, EdgeWeightMap &EdgeWeights) {
                                           E = GraphT::child_end(BB);
        CI != E; ++CI) {
     typename GraphT::NodeRef Child = *CI;
-    double Weight = 1 / (GraphT::child_end(BB) - GraphT::child_begin(BB));
+    double Weight = 1.0 / (GraphT::child_end(BB) - GraphT::child_begin(BB));
     if (TotalChildrenCount != 0.0)
       Weight = ChildrenExecCount[ChildIndex] / TotalChildrenCount;
     updateEdgeWeight<NodeT>(EdgeWeights, BB, Child, Weight);


### PR DESCRIPTION
The fallback edge weight calculation in Bolt computeEdgeWeights() incorrectly used integer division when computing weights as `1 / numChildren`. This caused zero weights for fallback cases when `numChildren > 1`, leading to incorrect edge weight assignments in the absence of profile data.

This fix improves correctness and stability of edge weight computations by changing the division to floating-point to ensure correct fallback weights calculation.