### PR TITLE
[asan] Add test case for alignment of FakeStack frames

### DIFF
--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -51,12 +51,12 @@ int main(int argc, char **argv) {
 #endif
 
   pthread_t threads[THREAD_COUNT];
-  for (pthread_t& t : threads)
+  for (pthread_t &t : threads)
     pthread_create(&t, &attr, Thread, 0);
 
   pthread_attr_destroy(&attr);
 
-  for (pthread_t& t : threads)
+  for (pthread_t &t : threads)
     pthread_join(t, 0);
 
   if (misaligned) {

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -1,10 +1,20 @@
+// Regression test 1:
 // This deterministically fails: when the stack size is 1<<16, FakeStack's
 // GetFrame() is out of alignment, because SizeRequiredForFlags(16) == 2K.
-// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=4096 -DTHREAD_COUNT=1 -DTHREAD_STACK_SIZE=65536 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=4096  -DTHREAD_COUNT=1 -DTHREAD_STACK_SIZE=65536 %s -o %t && %run %t 2>&1
 
+// Regression test 2:
 // The FakeStack frame is not guaranteed to be aligned, but alignment can
 // happen by chance, so try this on many threads.
-// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=8192 -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=131072 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=8192  -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=131072 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=16384 -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=131072 %s -o %t && %run %t 2>&1
+
+// Extra tests:
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=4096  -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=65536 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=8192  -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=65536 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=16384 -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=65536 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=4096  -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=131072 %s -o %t && %run %t 2>&1
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=8192  -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=131072 %s -o %t && %run %t 2>&1
 // RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 -DALIGNMENT=16384 -DTHREAD_COUNT=32 -DTHREAD_STACK_SIZE=131072 %s -o %t && %run %t 2>&1
 
 // XFAIL: *
@@ -26,10 +36,10 @@ bool misaligned = false;
 void *Thread(void *unused) {
   big_object x;
   uint alignment = (unsigned long)&x % alignof(big_object);
-  printf("Thread: address modulo alignment is %u\n", alignment);
-  if (alignment != 0)
+  if (alignment != 0) {
+    printf("Thread: address modulo alignment is %u\n", alignment);
     misaligned = true;
-
+  }
   return NULL;
 }
 

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -8,11 +8,11 @@
 #include <string.h>
 
 struct alignas(4096) page {
-    int x;
+  int x;
 };
 
 struct alignas(16384) larry {
-    int x;
+  int x;
 };
 
 bool misaligned = false;
@@ -23,7 +23,7 @@ void grandchild(void) {
   if (alignment != 0)
     misaligned = true;
 
-  printf ("Grandchild: address modulo alignment %u\n", alignment);
+  printf("Grandchild: address modulo alignment %u\n", alignment);
 }
 
 // Even if the FakeStack frame is aligned by chance to 16384, we can use an
@@ -31,7 +31,7 @@ void grandchild(void) {
 void child(void) {
   page p1;
   uint alignment = (unsigned long)&p1 % alignof(page);
-  printf ("Child: address modulo alignment is %u\n", alignment);
+  printf("Child: address modulo alignment is %u\n", alignment);
   if (alignment != 0)
     misaligned = true;
 
@@ -40,10 +40,10 @@ void child(void) {
 
 // Check whether the FakeStack frame is sufficiently aligned. Alignment can
 // happen by chance, so try this on many threads if you don't want
-void *Thread(void *unused)  {
+void *Thread(void *unused) {
   larry l1;
   uint alignment = (unsigned long)&l1 % alignof(larry);
-  printf ("Thread: address modulo alignment is %u\n", alignment);
+  printf("Thread: address modulo alignment is %u\n", alignment);
   if (alignment != 0)
     misaligned = true;
 
@@ -58,15 +58,15 @@ int main(int argc, char **argv) {
 
   pthread_t t[10];
   for (int i = 0; i < 10; i++) {
-     pthread_create(&t[i], &attr, Thread, 0);
+    pthread_create(&t[i], &attr, Thread, 0);
   }
   pthread_attr_destroy(&attr);
   for (int i = 0; i < 10; i++) {
-     pthread_join(t[i], 0);
+    pthread_join(t[i], 0);
   }
 
   if (misaligned) {
-    printf ("Test failed: not perfectly aligned\n");
+    printf("Test failed: not perfectly aligned\n");
     exit(1);
   }
 

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -40,7 +40,7 @@ void *Thread(void *unused) {
   if (alignment != 0)
     misaligned = true;
 
-  return NULL;
+  return nullptr;
 }
 
 int main(int argc, char **argv) {
@@ -50,14 +50,14 @@ int main(int argc, char **argv) {
   pthread_attr_setstacksize(&attr, THREAD_STACK_SIZE);
 #endif
 
-  pthread_t t[THREAD_COUNT];
-  for (int i = 0; i < THREAD_COUNT; i++)
-    pthread_create(&t[i], &attr, Thread, 0);
+  pthread_t threads[THREAD_COUNT];
+  for (pthread_t& t : threads)
+    pthread_create(&t, &attr, Thread, 0);
 
   pthread_attr_destroy(&attr);
 
-  for (int i = 0; i < THREAD_COUNT; i++)
-    pthread_join(t[i], 0);
+  for (pthread_t& t : threads)
+    pthread_join(t, 0);
 
   if (misaligned) {
     printf("Test failed: not perfectly aligned\n");

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -46,9 +46,9 @@ void *Thread(void *unused) {
 int main(int argc, char **argv) {
   pthread_attr_t attr;
   pthread_attr_init(&attr);
-  #ifdef THREAD_STACK_SIZE
+#ifdef THREAD_STACK_SIZE
   pthread_attr_setstacksize(&attr, THREAD_STACK_SIZE);
-  #endif
+#endif
 
   pthread_t t[THREAD_COUNT];
   for (int i = 0; i < THREAD_COUNT; i++)

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -1,0 +1,74 @@
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 %s -o %t && %run %t 2>&1
+// XFAIL: *
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct alignas(4096) page {
+    int x;
+};
+
+struct alignas(16384) larry {
+    int x;
+};
+
+bool misaligned = false;
+
+void grandchild(void) {
+  larry l2;
+  uint alignment = (unsigned long)&l2 % alignof(larry);
+  if (alignment != 0)
+    misaligned = true;
+
+  printf ("Grandchild: address modulo alignment %u\n", alignment);
+}
+
+// Even if the FakeStack frame is aligned by chance to 16384, we can use an
+// intervening stack frame to knock it out of alignment.
+void child(void) {
+  page p1;
+  uint alignment = (unsigned long)&p1 % alignof(page);
+  printf ("Child: address modulo alignment is %u\n", alignment);
+  if (alignment != 0)
+    misaligned = true;
+
+  grandchild();
+}
+
+// Check whether the FakeStack frame is sufficiently aligned. Alignment can
+// happen by chance, so try this on many threads if you don't want
+void *Thread(void *unused)  {
+  larry l1;
+  uint alignment = (unsigned long)&l1 % alignof(larry);
+  printf ("Thread: address modulo alignment is %u\n", alignment);
+  if (alignment != 0)
+    misaligned = true;
+
+  child();
+
+  return NULL;
+}
+
+int main(int argc, char **argv) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+
+  pthread_t t[10];
+  for (int i = 0; i < 10; i++) {
+     pthread_create(&t[i], &attr, Thread, 0);
+  }
+  pthread_attr_destroy(&attr);
+  for (int i = 0; i < 10; i++) {
+     pthread_join(t[i], 0);
+  }
+
+  if (misaligned) {
+    printf ("Test failed: not perfectly aligned\n");
+    exit(1);
+  }
+
+  return 0;
+}

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -17,29 +17,8 @@ struct alignas(16384) larry {
 
 bool misaligned = false;
 
-void grandchild(void) {
-  larry l2;
-  uint alignment = (unsigned long)&l2 % alignof(larry);
-  if (alignment != 0)
-    misaligned = true;
-
-  printf("Grandchild: address modulo alignment %u\n", alignment);
-}
-
-// Even if the FakeStack frame is aligned by chance to 16384, we can use an
-// intervening stack frame to knock it out of alignment.
-void child(void) {
-  page p1;
-  uint alignment = (unsigned long)&p1 % alignof(page);
-  printf("Child: address modulo alignment is %u\n", alignment);
-  if (alignment != 0)
-    misaligned = true;
-
-  grandchild();
-}
-
 // Check whether the FakeStack frame is sufficiently aligned. Alignment can
-// happen by chance, so try this on many threads if you don't want
+// happen by chance, so try this on many threads.
 void *Thread(void *unused) {
   larry l1;
   uint alignment = (unsigned long)&l1 % alignof(larry);
@@ -56,12 +35,12 @@ int main(int argc, char **argv) {
   pthread_attr_t attr;
   pthread_attr_init(&attr);
 
-  pthread_t t[10];
-  for (int i = 0; i < 10; i++) {
+  pthread_t t[32];
+  for (int i = 0; i < 32; i++) {
     pthread_create(&t[i], &attr, Thread, 0);
   }
   pthread_attr_destroy(&attr);
-  for (int i = 0; i < 10; i++) {
+  for (int i = 0; i < 32; i++) {
     pthread_join(t[i], 0);
   }
 

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment.cpp
@@ -36,10 +36,10 @@ bool misaligned = false;
 void *Thread(void *unused) {
   big_object x;
   uint alignment = (unsigned long)&x % alignof(big_object);
-  if (alignment != 0) {
-    printf("Thread: address modulo alignment is %u\n", alignment);
+
+  if (alignment != 0)
     misaligned = true;
-  }
+
   return NULL;
 }
 


### PR DESCRIPTION
This test case demonstrates that ASan does not currently align FakeStack frames correctly:
- for 4KB objects on a 64KB stack, alignment is deterministically incorrect
- for objects larger than 4KB, even with large stack sizes, alignment is not guaranteed

https://github.com/llvm/llvm-project/pull/152819 will fix it.