### PR TITLE
[asan] Add test case for alignment of FakeStack frames for 4KB objects with smaller thread stack sizes

### DIFF
--- a/compiler-rt/test/asan/TestCases/fakestack_alignment2.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment2.cpp
@@ -8,13 +8,13 @@
 #include <string.h>
 
 struct alignas(4096) page {
-    int x;
+  int x;
 };
 
-void *Thread(void *unused)  {
+void *Thread(void *unused) {
   page p1;
   uint alignment = (unsigned long)&p1 % alignof(page);
-  printf ("Thread: address modulo alignment is %u\n", alignment);
+  printf("Thread: address modulo alignment is %u\n", alignment);
   assert(alignment == 0);
 
   return NULL;
@@ -26,7 +26,7 @@ int main(int argc, char **argv) {
 
   // When the stack size is 1<<16, FakeStack's GetFrame() is out of alignment,
   // because SizeRequiredForFlags(16) == 2K.
-  pthread_attr_setstacksize(&attr, 1<<16);
+  pthread_attr_setstacksize(&attr, 1 << 16);
 
   pthread_t t;
   pthread_create(&t, &attr, Thread, 0);

--- a/compiler-rt/test/asan/TestCases/fakestack_alignment2.cpp
+++ b/compiler-rt/test/asan/TestCases/fakestack_alignment2.cpp
@@ -1,0 +1,37 @@
+// RUN: %clangxx_asan -fsanitize-address-use-after-return=always -O0 %s -o %t && %run %t 2>&1
+// XFAIL: *
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct alignas(4096) page {
+    int x;
+};
+
+void *Thread(void *unused)  {
+  page p1;
+  uint alignment = (unsigned long)&p1 % alignof(page);
+  printf ("Thread: address modulo alignment is %u\n", alignment);
+  assert(alignment == 0);
+
+  return NULL;
+}
+
+int main(int argc, char **argv) {
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+
+  // When the stack size is 1<<16, FakeStack's GetFrame() is out of alignment,
+  // because SizeRequiredForFlags(16) == 2K.
+  pthread_attr_setstacksize(&attr, 1<<16);
+
+  pthread_t t;
+  pthread_create(&t, &attr, Thread, 0);
+  pthread_attr_destroy(&attr);
+  pthread_join(t, 0);
+
+  return 0;
+}


### PR DESCRIPTION
This test case demonstrates that ASan does not currently align FakeStack frames correctly for 4KB objects when using a smaller thread stack size (64KB), which forces the FakeStack frames to no longer be 4KB aligned.

This differs from https://github.com/llvm/llvm-project/pull/152889, which is a test case for objects >4KB, which relies on the fact that the default 4KB alignment for fake stack sizes >64KB is insufficient.

https://github.com/llvm/llvm-project/pull/152819 will fix both issues.