### PR TITLE
[Clang][Parser] Fix assertion failure with explicit(bool) in pre-C++20 modes

### DIFF
--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -842,6 +842,8 @@ def warn_cxx17_compat_explicit_bool : Warning<
   InGroup<CXXPre20Compat>, DefaultIgnore;
 def ext_explicit_bool : ExtWarn<"explicit(bool) is a C++20 extension">,
   InGroup<CXX20>;
+def err_explicit_bool_requires_cpp20
+    : Error<"explicit(bool) requires C++20 or later">;
 
 /// C++ Templates
 def err_expected_template : Error<"expected template">;

--- a/clang/test/Parser/explicit-bool-pre-cxx17.cpp
+++ b/clang/test/Parser/explicit-bool-pre-cxx17.cpp
@@ -1,0 +1,16 @@
+// Regression test for assertion failure when explicit(bool) is used in pre-C++17
+// This test ensures no crash occurs and appropriate error messages are shown.
+// RUN: %clang_cc1 -std=c++03 -verify %s
+// RUN: %clang_cc1 -std=c++11 -verify %s
+// RUN: %clang_cc1 -std=c++14 -verify %s
+
+struct S {
+  // Before the fix, this would cause assertion failure in BuildConvertedConstantExpression
+  // Now it should produce a proper error message in C++14 and earlier modes
+  // Note: C++17 allows this as an extension for compatibility
+  explicit(true) S(int);
+  // expected-error@-1 {{explicit(bool) requires C++20 or later}}
+  
+  explicit(false) S(float);
+  // expected-error@-1 {{explicit(bool) requires C++20 or later}}
+};


### PR DESCRIPTION
  ## Summary

  Fixes assertion failure when using `explicit(bool)` syntax in C++98 and C++11 modes. The crash occurred in
  `BuildConvertedConstantExpression` when parsing `explicit(true)` or `explicit(false)` in these older C++ standards.

  ## Problem

  The assertion failure only occurs in C++98/C++11 modes:
  ```cpp
  // C++98/C++11 mode - CRASH
  struct S {
    explicit(true) S(int);  // Assertion failure in BuildConvertedConstantExpression
  };
 ```

  The assertion that failed:
  ```
  assert((S.getLangOpts().CPlusPlus11 || CCE == CCEKind::TempArgStrict) &&
         "converted constant expression outside C++11 or TTP matching");
  ```
  ## Solution

  - Added Parser-level error handling for explicit(bool) in pre-C++20 modes
  - Added new diagnostic: err_explicit_bool_requires_cpp20
  - Maintains C++17 extension behavior for backward compatibility
  - Prevents reaching the problematic Sema code path that caused crashes

  ## Implementation Strategy

  While crashes only occur in C++98/C++11, the fix applies to all pre-C++20 modes (C++98/C++11/C++14) following consistent language
  feature boundaries, with C++17 maintained as an extension for compatibility.

 ## Changes

  - clang/include/clang/Basic/DiagnosticParseKinds.td: Added new error diagnostic
  - clang/lib/Parse/ParseDecl.cpp: Enhanced explicit specifier parsing with proper language version checks
  - clang/test/Parser/explicit-bool-pre-cxx17.cpp: Added regression test covering C++03/C++11/C++14