### PR TITLE
[NFC][MC] Removed unused switch case in `emitCATTR`

### DIFF
--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -71,8 +71,6 @@ static void emitCATTR(raw_ostream &OS, StringRef Name, GOFF::ESDRmode Rmode,
     case GOFF::ESD_RMODE_64:
       OS << "64";
       break;
-    case GOFF::ESD_RMODE_None:
-      break;
     }
     OS << ')';
   }


### PR DESCRIPTION
The switch statement `switch (Rmode)` is in an if-block that checks if `Rmode != GOFF::ESD_RMODE_None` making the  `case GOFF::ESD_RMODE_None:` unnecessary.