### PR TITLE
Revert "[NFC][MC] Removed unused switch case in `emitCATTR`"

### DIFF
--- a/llvm/lib/MC/MCAsmInfoGOFF.cpp
+++ b/llvm/lib/MC/MCAsmInfoGOFF.cpp
@@ -71,6 +71,8 @@ static void emitCATTR(raw_ostream &OS, StringRef Name, GOFF::ESDRmode Rmode,
     case GOFF::ESD_RMODE_64:
       OS << "64";
       break;
+    case GOFF::ESD_RMODE_None:
+      break;
     }
     OS << ')';
   }


### PR DESCRIPTION
Reverts llvm/llvm-project#152907

This is causing some build failures.