### PR TITLE
[clang-tidy] Fix `modernize-use-constraints` crash on uses of nonstandard `enable_if`s

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -8,6 +8,7 @@
 
 #include "UseConstraintsCheck.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/AST/DeclTemplate.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 #include "clang/Lex/Lexer.h"
 
@@ -76,6 +77,15 @@ matchEnableIfSpecializationImplTypename(TypeLoc TheType) {
     const TemplateDecl *TD =
         Specialization->getTemplateName().getAsTemplateDecl();
     if (!TD || TD->getName() != "enable_if")
+      return std::nullopt;
+
+    const TemplateParameterList *Params = TD->getTemplateParameters();
+    if (Params->size() != 2)
+      return std::nullopt;
+
+    const auto *FirstParam =
+        dyn_cast<NonTypeTemplateParmDecl>(Params->getParam(0));
+    if (!FirstParam || !FirstParam->getType()->isBooleanType())
       return std::nullopt;
 
     int NumArgs = SpecializationLoc.getNumArgs();

--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -79,6 +79,8 @@ matchEnableIfSpecializationImplTypename(TypeLoc TheType) {
     if (!TD || TD->getName() != "enable_if")
       return std::nullopt;
 
+    assert(!TD->getTemplateParameters()->empty() &&
+           "found template with no template parameters?");
     const auto *FirstParam = dyn_cast<NonTypeTemplateParmDecl>(
         TD->getTemplateParameters()->getParam(0));
     if (!FirstParam || !FirstParam->getType()->isBooleanType())
@@ -114,6 +116,8 @@ matchEnableIfSpecializationImplTrait(TypeLoc TheType) {
     if (!Specialization->isTypeAlias())
       return std::nullopt;
 
+    assert(!TD->getTemplateParameters()->empty() &&
+           "found template with no template parameters?");
     const auto *FirstParam = dyn_cast<NonTypeTemplateParmDecl>(
         TD->getTemplateParameters()->getParam(0));
     if (!FirstParam || !FirstParam->getType()->isBooleanType())

--- a/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseConstraintsCheck.cpp
@@ -79,12 +79,8 @@ matchEnableIfSpecializationImplTypename(TypeLoc TheType) {
     if (!TD || TD->getName() != "enable_if")
       return std::nullopt;
 
-    const TemplateParameterList *Params = TD->getTemplateParameters();
-    if (Params->size() != 2)
-      return std::nullopt;
-
-    const auto *FirstParam =
-        dyn_cast<NonTypeTemplateParmDecl>(Params->getParam(0));
+    const auto *FirstParam = dyn_cast<NonTypeTemplateParmDecl>(
+        TD->getTemplateParameters()->getParam(0));
     if (!FirstParam || !FirstParam->getType()->isBooleanType())
       return std::nullopt;
 
@@ -116,6 +112,11 @@ matchEnableIfSpecializationImplTrait(TypeLoc TheType) {
       return std::nullopt;
 
     if (!Specialization->isTypeAlias())
+      return std::nullopt;
+
+    const auto *FirstParam = dyn_cast<NonTypeTemplateParmDecl>(
+        TD->getTemplateParameters()->getParam(0));
+    if (!FirstParam || !FirstParam->getType()->isBooleanType())
       return std::nullopt;
 
     if (const auto *AliasedType =

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -136,6 +136,11 @@ Changes in existing checks
 - Improved :doc:`misc-header-include-cycle
   <clang-tidy/checks/misc/header-include-cycle>` check performance.
 
+- Fixed a :doc:`modernize-use-constraints
+  <clang-tidy/checks/modernize/use-constraints>` crash on uses of
+  nonstandard ``enable_if``s with a signature different from
+  ``std::enable_if`` (such as ``boost::enable_if``).
+
 - Improved :doc:`modernize-use-designated-initializers
   <clang-tidy/checks/modernize/use-designated-initializers>` check to
   suggest using designated initializers for aliased aggregate types.

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -136,9 +136,9 @@ Changes in existing checks
 - Improved :doc:`misc-header-include-cycle
   <clang-tidy/checks/misc/header-include-cycle>` check performance.
 
-- Fixed a :doc:`modernize-use-constraints
-  <clang-tidy/checks/modernize/use-constraints>` crash on uses of
-  nonstandard ``enable_if``s with a signature different from
+- Improved :doc:`modernize-use-constraints
+  <clang-tidy/checks/modernize/use-constraints>` check by fixing a crash on
+  uses of non-standard ``enable_if`` with a signature different from
   ``std::enable_if`` (such as ``boost::enable_if``).
 
 - Improved :doc:`modernize-use-designated-initializers

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
@@ -762,7 +762,7 @@ struct some_type_trait {
   static constexpr bool value = true;
 };
 
-// Fix-its are offered even for a nonstandard enable_if.
+// Fix-its are offered even for a non-standard enable_if.
 namespace nonstd {
 
 template <bool Condition, typename T = void>
@@ -775,7 +775,7 @@ typename nonstd::enable_if<some_type_trait<T>::value, void>::type nonstd_enable_
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
 // CHECK-FIXES: {{^}}void nonstd_enable_if() requires some_type_trait<T>::value {}{{$}}
 
-// But only if the nonstandard enable_if has the same signature as the standard one.
+// But only if the non-standard enable_if has the same signature as the standard one.
 namespace boost {
 
 template <typename Condition, typename T = void>

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
@@ -783,7 +783,21 @@ nonstd::enable_if_t<some_type_trait<T>::value, void> nonstd_enable_if_t() {}
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
 // CHECK-FIXES: {{^}}void nonstd_enable_if_t() requires some_type_trait<T>::value {}{{$}}
 
-// But only if the non-standard enable_if has the same signature as the standard one.
+template <>
+nonstd::enable_if_t<some_type_trait<int>::value, void> nonstd_enable_if_t<int>() {}
+// FIXME - Support non-dependent enable_ifs.
+
+template <typename T>
+typename nonstd::enable_if<some_type_trait<T>::value>::type nonstd_enable_if_one_param() {}
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
+// CHECK-FIXES: {{^}}void nonstd_enable_if_one_param() requires some_type_trait<T>::value {}{{$}}
+
+template <typename T>
+nonstd::enable_if_t<some_type_trait<T>::value> nonstd_enable_if_t_one_param() {}
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
+// CHECK-FIXES: {{^}}void nonstd_enable_if_t_one_param() requires some_type_trait<T>::value {}{{$}}
+
+// No fix-its are offered for an enable_if with a different signature from the standard one.
 namespace boost {
 
 template <typename Condition, typename T = void>
@@ -799,3 +813,12 @@ typename boost::enable_if<some_type_trait<T>, void>::type boost_enable_if() {}
 
 template <typename T>
 boost::enable_if_t<some_type_trait<T>, void> boost_enable_if_t() {}
+
+template <>
+boost::enable_if_t<some_type_trait<int>, void> boost_enable_if_t<int>() {}
+
+template <typename T>
+typename boost::enable_if<some_type_trait<T>>::type boost_enable_if_one_param() {}
+
+template <typename T>
+boost::enable_if_t<some_type_trait<T>> boost_enable_if_t_one_param() {}

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/use-constraints.cpp
@@ -768,6 +768,9 @@ namespace nonstd {
 template <bool Condition, typename T = void>
 struct enable_if : std::enable_if<Condition, T> {};
 
+template <bool Condition, typename T = void>
+using enable_if_t = typename enable_if<Condition, T>::type;
+
 }
 
 template <typename T>
@@ -775,13 +778,24 @@ typename nonstd::enable_if<some_type_trait<T>::value, void>::type nonstd_enable_
 // CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
 // CHECK-FIXES: {{^}}void nonstd_enable_if() requires some_type_trait<T>::value {}{{$}}
 
+template <typename T>
+nonstd::enable_if_t<some_type_trait<T>::value, void> nonstd_enable_if_t() {}
+// CHECK-MESSAGES: :[[@LINE-1]]:1: warning: use C++20 requires constraints instead of enable_if [modernize-use-constraints]
+// CHECK-FIXES: {{^}}void nonstd_enable_if_t() requires some_type_trait<T>::value {}{{$}}
+
 // But only if the non-standard enable_if has the same signature as the standard one.
 namespace boost {
 
 template <typename Condition, typename T = void>
 struct enable_if : std::enable_if<Condition::value, T> {};
 
+template <typename Condition, typename T = void>
+using enable_if_t = typename enable_if<Condition, T>::type;
+
 }
 
 template <typename T>
 typename boost::enable_if<some_type_trait<T>, void>::type boost_enable_if() {}
+
+template <typename T>
+boost::enable_if_t<some_type_trait<T>, void> boost_enable_if_t() {}


### PR DESCRIPTION
Fixes #152868. See that issue for details.
Fixes #123726.