### PR TITLE
[libc][bazel] Set LIBC_ERRNO_MODE_SYSTEM_INLINE by default.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
+++ b/utils/bazel/llvm-project-overlay/libc/libc_configure_options.bzl
@@ -49,4 +49,7 @@ LIBC_CONFIGURE_OPTIONS = [
 
     # Documentation in libc/docs/configure.rst
     "LIBC_THREAD_MODE=LIBC_THREAD_MODE_PLATFORM",
+
+    # Documentation in libc/src/__support/libc_errno.h
+    "LIBC_ERRNO_MODE=LIBC_ERRNO_MODE_SYSTEM_INLINE",
 ]


### PR DESCRIPTION
Bazel only supports overlay build currently, so there's always system libc (and system errno_ present. Use the new
LIBC_ERRNO_MODE_SYSTEM_INLINE by default, instead of using thread-local one in the unit tests and system errno for "public packaging" (i.e. prod build). This way, we can ensure that we're testing the same configuration as the one that will be used in production.

This is the second attempt to do that after f9146cc was reverted in 279e82f. Since then, many tests have been migrated to ErrnoCheckingTest so the change should be safe even for those downstream customers that clobber system errno value before unit tests are being called.