### PR TITLE
[rtsan] Support legacy pthread_cond variables

### DIFF
--- a/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_interceptors_posix.cpp
@@ -66,7 +66,7 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
 };
 } // namespace
 
-// See note in tsan or ddsan as to why this is necessary
+// See note in tsan as to why this is necessary
 static pthread_cond_t *init_cond(pthread_cond_t *c, bool force = false) {
   if (!common_flags()->legacy_pthread_cond)
     return c;

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_interceptors_posix.cpp
@@ -1232,6 +1232,24 @@ TEST(TestRtsanInterceptors, SpinLockLockDiesWhenRealtime) {
 }
 #endif
 
+TEST(TestRtsanInterceptors, PthreadCondInitDiesWhenRealtime) {
+  pthread_cond_t cond{};
+  auto Func = [&cond]() { pthread_cond_init(&cond, nullptr); };
+  ExpectRealtimeDeath(Func, "pthread_cond_init");
+  ExpectNonRealtimeSurvival(Func);
+}
+
+TEST(TestRtsanInterceptors, PthreadCondDestroyDiesWhenRealtime) {
+  pthread_cond_t cond{};
+  ASSERT_EQ(0, pthread_cond_init(&cond, nullptr));
+
+  auto Func = [&cond]() { pthread_cond_destroy(&cond); };
+  ExpectRealtimeDeath(Func, "pthread_cond_destroy");
+  ExpectNonRealtimeSurvival(Func);
+
+  pthread_cond_destroy(&cond);
+}
+
 TEST(TestRtsanInterceptors, PthreadCondSignalDiesWhenRealtime) {
   pthread_cond_t cond{};
   ASSERT_EQ(0, pthread_cond_init(&cond, nullptr));


### PR DESCRIPTION
fixes #146120 

Follows a pattern put forward in tsan:
https://github.com/llvm/llvm-project/blob/71ffa2a4d3c220c97fbffa6078a446cc17bbaada/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L1366-L1371

https://github.com/llvm/llvm-project/blob/71ffa2a4d3c220c97fbffa6078a446cc17bbaada/compiler-rt/lib/tsan/dd/dd_interceptors.cpp#L204-L208

To properly deal with memory corruption on older versions of pthread_cond variables.


I was never able to repro this problem, but I'm hopeful it's in the right direction considering the crash report. Seeing as it's basically behind a feature flag, I think introducing it to see if it fixes the problem is low risk.
