### PR TITLE
[ARM] Give ADJCALLSTACKUP and ADJCALLSTACKDOWN empty scheduling info

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -2203,18 +2203,16 @@ def JUMPTABLE_TBH :
 PseudoInst<(outs), (ins cpinst_operand:$instid, cpinst_operand:$cpidx,
                         i32imm:$size), NoItinerary, []>;
 
-
-// FIXME: Marking these as hasSideEffects is necessary to prevent machine DCE
-// from removing one half of the matched pairs. That breaks PEI, which assumes
-// these will always be in pairs, and asserts if it finds otherwise. Better way?
-let Defs = [SP], Uses = [SP], hasSideEffects = 1 in {
+// We set Sched to empty list because we expect these instructions to simply get
+// removed in most cases.
+let Defs = [SP], Uses = [SP], hasSideEffects = 1, isCodeGenOnly = 1 in {
 def ADJCALLSTACKUP :
 PseudoInst<(outs), (ins i32imm:$amt1, i32imm:$amt2, pred:$p), NoItinerary,
-           [(ARMcallseq_end timm:$amt1, timm:$amt2)]>;
+           [(ARMcallseq_end timm:$amt1, timm:$amt2)]>, Sched<[]>;
 
 def ADJCALLSTACKDOWN :
 PseudoInst<(outs), (ins i32imm:$amt, i32imm:$amt2, pred:$p), NoItinerary,
-           [(ARMcallseq_start timm:$amt, timm:$amt2)]>;
+           [(ARMcallseq_start timm:$amt, timm:$amt2)]>, Sched<[]>;
 }
 
 def HINT : AI<(outs), (ins imm0_239:$imm), MiscFrm, NoItinerary,

--- a/llvm/lib/Target/ARM/ARMInstrThumb.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb.td
@@ -297,19 +297,18 @@ def non_imm32 : PatLeaf<(i32 GPR), [{ return !isa<ConstantSDNode>(N); }]>;
 //  Miscellaneous Instructions.
 //
 
-// FIXME: Marking these as hasSideEffects is necessary to prevent machine DCE
-// from removing one half of the matched pairs. That breaks PEI, which assumes
-// these will always be in pairs, and asserts if it finds otherwise. Better way?
-let Defs = [SP], Uses = [SP], hasSideEffects = 1 in {
+// We set Sched to empty list because we expect these instructions to simply get
+// removed in most cases.
+let Defs = [SP], Uses = [SP], hasSideEffects = 1, isCodeGenOnly = 1 in {
 def tADJCALLSTACKUP :
   PseudoInst<(outs), (ins i32imm:$amt1, i32imm:$amt2), NoItinerary,
              [(ARMcallseq_end imm:$amt1, imm:$amt2)]>,
-            Requires<[IsThumb, IsThumb1Only]>;
+            Requires<[IsThumb, IsThumb1Only]>, Sched<[]>;
 
 def tADJCALLSTACKDOWN :
   PseudoInst<(outs), (ins i32imm:$amt, i32imm:$amt2), NoItinerary,
              [(ARMcallseq_start imm:$amt, imm:$amt2)]>,
-            Requires<[IsThumb, IsThumb1Only]>;
+            Requires<[IsThumb, IsThumb1Only]>, Sched<[]>;
 }
 
 class T1SystemEncoding<bits<8> opc>


### PR DESCRIPTION
Also label is isCodeGenOnly. Finally, we can keep the hasSideEffects, as there is no other way to do this.