### PR TITLE
[mlir][linalg] Fix UnPackOp::getTiledOuterDims

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1690,7 +1690,7 @@ struct DecomposeOuterUnitDimsPackOpPattern
 /// Rewrites a linalg::UnPackOp into a sequence of rank-reduced
 ///   * tensor::ExtractSliceOp + linalg::TransposeOp + tensor::InsertSliceOp
 ///
-/// Requires that all the tile outer dims of the input linalg::PackOp are 1.
+/// Requires that all the tiled outer dims of the input linalg::PackOp are 1.
 ///
 /// Before:
 /// ```

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1690,7 +1690,7 @@ struct DecomposeOuterUnitDimsPackOpPattern
 /// Rewrites a linalg::UnPackOp into a sequence of rank-reduced
 ///   * tensor::ExtractSliceOp + linalg::TransposeOp + tensor::InsertSliceOp
 ///
-/// Requires that all the outer dims of the input linalg::PackOp are 1.
+/// Requires that all the tile outer dims of the input linalg::PackOp are 1.
 ///
 /// Before:
 /// ```

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -5770,8 +5770,7 @@ SmallVector<int64_t> UnPackOp::getTiledOuterDims() {
   SmallVector<int64_t> outerDims(getAllOuterDims());
   SmallVector<int64_t> res;
 
-  // Invert outer-dims-perm and use it to restore the original order
-  // of the outer dims.
+  // Recover the original order of the outer dims.
   SmallVector<int64_t> outerDimPermInv(getOuterDimsPerm());
   invertPermutationVector(outerDimPermInv);
   if (!outerDimPermInv.empty())

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -5765,33 +5765,6 @@ ArrayRef<int64_t> UnPackOp::getAllOuterDims() {
   return getSourceType().getShape().take_front(destRank);
 }
 
-static SmallVector<int64_t>
-inversePerm(const llvm::SmallVector<int64_t> &perm) {
-  const size_t n = perm.size();
-  llvm::SmallVector<int64_t> invPerm(n);
-
-  for (size_t i = 0; i < n; ++i) {
-    assert(perm[i] >= 0 && static_cast<size_t>(perm[i]) < n &&
-           "Invalid permutation entry");
-    invPerm[perm[i]] = i;
-  }
-
-  return invPerm;
-}
-
-/// Compute the inverse of a permutation. Assumes `perm` is a valid permutation
-/// of 0...n-1.
-static SmallVector<int64_t> invertPermutation(SmallVector<int64_t> perm) {
-  const size_t permLen = perm.size();
-  llvm::SmallVector<int64_t> inv(permLen);
-  for (size_t i = 0; i < permLen; ++i) {
-    assert(perm[i] >= 0 && static_cast<size_t>(perm[i]) < permLen &&
-           "Invalid permutation entry");
-    inv[perm[i]] = i;
-  }
-  return inv;
-}
-
 SmallVector<int64_t> UnPackOp::getTiledOuterDims() {
   auto innerDimsPos = getInnerDimsPos();
   SmallVector<int64_t> outerDims(getAllOuterDims());
@@ -5800,7 +5773,7 @@ SmallVector<int64_t> UnPackOp::getTiledOuterDims() {
   // Invert outer-dims-perm and use it to restore the original order
   // of the outer dims.
   SmallVector<int64_t> outerDimPermInv(getOuterDimsPerm());
-  inversePerm(outerDimPermInv);
+  invertPermutationVector(outerDimPermInv);
   if (!outerDimPermInv.empty())
     applyPermutationToVector(outerDims, outerDimPermInv);
 

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2310,6 +2310,7 @@ RankedTensorType ExtractSliceOp::inferResultType(
                                sourceTensorType.getEncoding());
 }
 
+// TODO: This uses neither offsets nor strides!
 RankedTensorType ExtractSliceOp::inferResultType(
     RankedTensorType sourceTensorType, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes, ArrayRef<OpFoldResult> strides) {

--- a/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
+++ b/mlir/lib/Dialect/Tensor/IR/TensorOps.cpp
@@ -2310,7 +2310,6 @@ RankedTensorType ExtractSliceOp::inferResultType(
                                sourceTensorType.getEncoding());
 }
 
-// TODO: This uses neither offsets nor strides!
 RankedTensorType ExtractSliceOp::inferResultType(
     RankedTensorType sourceTensorType, ArrayRef<OpFoldResult> offsets,
     ArrayRef<OpFoldResult> sizes, ArrayRef<OpFoldResult> strides) {

--- a/mlir/test/Dialect/Linalg/decompose-unpack.mlir
+++ b/mlir/test/Dialect/Linalg/decompose-unpack.mlir
@@ -218,3 +218,5 @@ func.func @negative_non_unit_tiled_outer_dim(%src: tensor<1x126x1x1x8xf32>, %des
 
   return %unpack : tensor<1x1x1x1001xf32>
 }
+// CHECK-LABEL: @negative_non_unit_tiled_outer_dim(
+// CHECK: linalg.unpack

--- a/mlir/test/Dialect/Linalg/decompose-unpack.mlir
+++ b/mlir/test/Dialect/Linalg/decompose-unpack.mlir
@@ -203,3 +203,18 @@ func.func @unpack_with_non_trailing_dimensions_in_inner_dims(%arg0: tensor<1x1x1
 // CHECK-SAME:                      outs(%[[EMPTY]] : tensor<1x4xf32>) permutation = [1, 0]
 // CHECK:        %[[INSERT:.+]] = tensor.insert_slice %transposed into %[[DEST]][0, 0, 0] [1, 1, 4] [1, 1, 1] : tensor<1x4xf32> into tensor<1x1x4xf32>
 // CHECK:        return %[[INSERT]]
+
+// -----
+
+/// Note "126", which is a non-unit tile-outer-dim. This is not supported.
+
+func.func @negative_non_unit_tiled_outer_dim(%src: tensor<1x126x1x1x8xf32>, %dest: tensor<1x1x1x1001xf32>) -> tensor<1x1x1x1001xf32> {
+  %unpack = linalg.unpack %src
+    outer_dims_perm = [0, 3, 2, 1]
+    inner_dims_pos = [3]
+    inner_tiles = [8]
+    into %dest : tensor<1x126x1x1x8xf32>
+    -> tensor<1x1x1x1001xf32>
+
+  return %unpack : tensor<1x1x1x1001xf32>
+}


### PR DESCRIPTION
Fixes `getTiledOuterDims` by making sure that the `outer_dims_perm`
attribute from `linalg.unpack` is taken into account.

Fixes #152037

- [ ] Implement similar fix for `linalg.pack`
