### PR TITLE
[TTI] Remove hasActiveVectorLength hook. NFC

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -21387,14 +21387,6 @@ A vector operation ``<opcode>`` on vectors ``A`` and ``B`` calculates:
        A <opcode> B =  {  A[i] <opcode> B[i]   M[i] = True, and
                        {  undef otherwise
 
-Optimization Hint
-^^^^^^^^^^^^^^^^^
-
-Some targets, such as AVX512, do not support the %evl parameter in hardware.
-The use of an effective %evl is discouraged for those targets.  The function
-``TargetTransformInfo::hasActiveVectorLength()`` returns true when the target
-has native support for %evl.
-
 .. _int_vp_select:
 
 '``llvm.vp.select.*``' Intrinsics

--- a/llvm/include/llvm/Analysis/TargetTransformInfo.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfo.h
@@ -1860,13 +1860,6 @@ public:
   /// \return true when scalable vectorization is preferred.
   LLVM_ABI bool enableScalableVectorization() const;
 
-  /// \name Vector Predication Information
-  /// @{
-  /// Whether the target supports the %evl parameter of VP intrinsic efficiently
-  /// in hardware. (see LLVM Language Reference - "Vector Predication
-  /// Intrinsics"). Use of %evl is discouraged when that is not the case.
-  LLVM_ABI bool hasActiveVectorLength() const;
-
   /// Return true if sinking I's operands to the same basic block as I is
   /// profitable, e.g. because the operands can be folded into a target
   /// instruction during instruction selection. After calling the function
@@ -1915,7 +1908,6 @@ public:
   /// transformed.
   LLVM_ABI VPLegalization
   getVPLegalizationStrategy(const VPIntrinsic &PI) const;
-  /// @}
 
   /// \returns Whether a 32-bit branch instruction is available in Arm or Thumb
   /// state.

--- a/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -1112,8 +1112,6 @@ public:
 
   virtual bool enableScalableVectorization() const { return false; }
 
-  virtual bool hasActiveVectorLength() const { return false; }
-
   virtual bool isProfitableToSinkOperands(Instruction *I,
                                           SmallVectorImpl<Use *> &Ops) const {
     return false;

--- a/llvm/lib/Analysis/TargetTransformInfo.cpp
+++ b/llvm/lib/Analysis/TargetTransformInfo.cpp
@@ -1461,10 +1461,6 @@ bool TargetTransformInfo::enableScalableVectorization() const {
   return TTIImpl->enableScalableVectorization();
 }
 
-bool TargetTransformInfo::hasActiveVectorLength() const {
-  return TTIImpl->hasActiveVectorLength();
-}
-
 bool TargetTransformInfo::isProfitableToSinkOperands(
     Instruction *I, SmallVectorImpl<Use *> &OpsToSink) const {
   return TTIImpl->isProfitableToSinkOperands(I, OpsToSink);

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -282,10 +282,6 @@ RISCVTTIImpl::getIntImmCostIntrin(Intrinsic::ID IID, unsigned Idx,
   return TTI::TCC_Free;
 }
 
-bool RISCVTTIImpl::hasActiveVectorLength() const {
-  return ST->hasVInstructions();
-}
-
 TargetTransformInfo::PopcntSupportKind
 RISCVTTIImpl::getPopcntSupport(unsigned TyWidth) const {
   assert(isPowerOf2_32(TyWidth) && "Ty width must be power of 2");

--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.h
@@ -88,15 +88,6 @@ public:
   getIntImmCostIntrin(Intrinsic::ID IID, unsigned Idx, const APInt &Imm,
                       Type *Ty, TTI::TargetCostKind CostKind) const override;
 
-  /// \name EVL Support for predicated vectorization.
-  /// Whether the target supports the %evl parameter of VP intrinsic efficiently
-  /// in hardware. (see LLVM Language Reference - "Vector Predication
-  /// Intrinsics",
-  /// https://llvm.org/docs/LangRef.html#vector-predication-intrinsics and
-  /// "IR-level VP intrinsics",
-  /// https://llvm.org/docs/Proposals/VectorPredication.html#ir-level-vp-intrinsics).
-  bool hasActiveVectorLength() const override;
-
   TargetTransformInfo::PopcntSupportKind
   getPopcntSupport(unsigned TyWidth) const override;
 

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1368,8 +1368,7 @@ public:
       return;
     // Override EVL styles if needed.
     // FIXME: Investigate opportunity for fixed vector factor.
-    bool EVLIsLegal = UserIC <= 1 && IsScalableVF &&
-                      TTI.hasActiveVectorLength() && !EnableVPlanNativePath;
+    bool EVLIsLegal = UserIC <= 1 && IsScalableVF && !EnableVPlanNativePath;
     if (EVLIsLegal)
       return;
     // If for some reason EVL mode is unsupported, fallback to a scalar epilogue


### PR DESCRIPTION
RISC-V is the only target that implements this, and the loop vectorizer is the only user of this. In any case, the loop vectorizer only checks it when the target requests EVL tail folding, and RISC-V is also the only target to do so. So it doesn't seem to affect anything.

This removes it to simplify the TTI interface.

As for the IsEVLLegal check, if a target doesn't support the EVL argument to VP intrinsics it should avoid selecting the DataWithEVL tail folding style anyway.
