### PR TITLE
[clang] Fix assertion failure with explicit(bool) in pre-C++11 modes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -194,6 +194,7 @@ Bug Fixes to C++ Support
 - Fix the dynamic_cast to final class optimization to correctly handle
   casts that are guaranteed to fail (#GH137518).
 - Fix bug rejecting partial specialization of variable templates with auto NTTPs (#GH118190).
+- Fix a crash when using ``explicit(bool)`` in pre-C++11 language modes. (#GH152729)
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -6275,8 +6275,8 @@ static ExprResult BuildConvertedConstantExpression(Sema &S, Expr *From,
                                                    QualType T, CCEKind CCE,
                                                    NamedDecl *Dest,
                                                    APValue &PreNarrowingValue) {
-  bool isCCEAllowedPreCXX11 =
-    (CCE == CCEKind::TempArgStrict || CCE == CCEKind::ExplicitBool);
+  [[maybe_unused]] bool isCCEAllowedPreCXX11 =
+      (CCE == CCEKind::TempArgStrict || CCE == CCEKind::ExplicitBool);
   assert((S.getLangOpts().CPlusPlus11 || isCCEAllowedPreCXX11) &&
          "converted constant expression outside C++11 or TTP matching");
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -6275,7 +6275,9 @@ static ExprResult BuildConvertedConstantExpression(Sema &S, Expr *From,
                                                    QualType T, CCEKind CCE,
                                                    NamedDecl *Dest,
                                                    APValue &PreNarrowingValue) {
-  assert((S.getLangOpts().CPlusPlus11 || CCE == CCEKind::TempArgStrict) &&
+  bool isCCEAllowedPreCXX11 =
+    (CCE == CCEKind::TempArgStrict || CCE == CCEKind::ExplicitBool);
+  assert((S.getLangOpts().CPlusPlus11 || isCCEAllowedPreCXX11) &&
          "converted constant expression outside C++11 or TTP matching");
 
   if (checkPlaceholderForOverload(S, From))

--- a/clang/test/Parser/explicit-bool-pre-cxx17.cpp
+++ b/clang/test/Parser/explicit-bool-pre-cxx17.cpp
@@ -1,0 +1,14 @@
+// Regression test for assertion failure when explicit(bool) is used in pre-C++20
+// Fixes GitHub issue #152729
+// RUN: %clang_cc1 -std=c++03 -verify %s
+// RUN: %clang_cc1 -std=c++11 -verify %s
+// RUN: %clang_cc1 -std=c++14 -verify %s
+// RUN: %clang_cc1 -std=c++17 -verify %s
+
+struct S {
+  explicit(true) S(int);
+  // expected-warning@-1 {{explicit(bool) is a C++20 extension}}
+  
+  explicit(false) S(float);
+  // expected-warning@-1 {{explicit(bool) is a C++20 extension}}
+};

--- a/clang/test/Parser/explicit-bool-pre-cxx17.cpp
+++ b/clang/test/Parser/explicit-bool-pre-cxx17.cpp
@@ -1,5 +1,6 @@
 // Regression test for assertion failure when explicit(bool) is used in pre-C++20
 // Fixes GitHub issue #152729
+// RUN: %clang_cc1 -std=c++98 -verify %s
 // RUN: %clang_cc1 -std=c++03 -verify %s
 // RUN: %clang_cc1 -std=c++11 -verify %s
 // RUN: %clang_cc1 -std=c++14 -verify %s


### PR DESCRIPTION
Allow CCEKind::ExplicitBool in BuildConvertedConstantExpression for pre-C++11 contexts, similar to the existing TempArgStrict exception. This enables explicit(bool) to work as a C++20 extension in earlier language modes without triggering assertion failures.

Fixes #152729