### PR TITLE
[BOLT] Add dump-dot-func option for selective function CFG dumping

### DIFF
--- a/bolt/docs/CommandLineArgumentReference.md
+++ b/bolt/docs/CommandLineArgumentReference.md
@@ -138,6 +138,11 @@
   Dump function CFGs to graphviz format after each stage;enable '-print-loops'
   for color-coded blocks
 
+- `--dump-dot-func=<func1,func2,func3...>`
+
+  Dump function CFGs to graphviz format for specified functions only;
+  takes function name patterns (regex supported)
+
 - `--dump-linux-exceptions`
 
   Dump Linux kernel exception table

--- a/bolt/docs/CommandLineArgumentReference.md
+++ b/bolt/docs/CommandLineArgumentReference.md
@@ -141,7 +141,8 @@
 - `--dump-dot-func=<func1,func2,func3...>`
 
   Dump function CFGs to graphviz format for specified functions only;
-  takes function name patterns (regex supported)
+  takes function name patterns (regex supported). Note: C++ function names
+  must be passed using their mangled names
 
 - `--dump-linux-exceptions`
 

--- a/bolt/include/bolt/Utils/CommandLineOpts.h
+++ b/bolt/include/bolt/Utils/CommandLineOpts.h
@@ -15,6 +15,12 @@
 
 #include "llvm/Support/CommandLine.h"
 
+namespace llvm {
+namespace bolt {
+class BinaryFunction;
+}
+} // namespace llvm
+
 namespace opts {
 
 enum HeatmapModeKind {
@@ -99,6 +105,9 @@ extern llvm::cl::opt<unsigned> Verbosity;
 
 /// Return true if we should process all functions in the binary.
 bool processAllFunctions();
+
+/// Return true if we should dump dot graphs for the given function.
+bool shouldDumpDot(const llvm::bolt::BinaryFunction &Function);
 
 enum GadgetScannerKind { GS_PACRET, GS_PAUTH, GS_ALL };
 

--- a/bolt/lib/Rewrite/BinaryPassManager.cpp
+++ b/bolt/lib/Rewrite/BinaryPassManager.cpp
@@ -52,6 +52,7 @@ namespace opts {
 extern cl::opt<bool> PrintAll;
 extern cl::opt<bool> PrintDynoStats;
 extern cl::opt<bool> DumpDotAll;
+extern bool shouldDumpDot(const bolt::BinaryFunction &Function);
 extern cl::opt<std::string> AsmDump;
 extern cl::opt<bolt::PLTCall::OptType> PLT;
 extern cl::opt<bolt::IdenticalCodeFolding::ICFLevel, false,
@@ -340,7 +341,7 @@ Error BinaryFunctionPassManager::runPasses() {
 
       Function.print(BC.outs(), Message);
 
-      if (opts::DumpDotAll)
+      if (opts::shouldDumpDot(Function))
         Function.dumpGraphForPass(PassIdName);
     }
   }

--- a/bolt/lib/Rewrite/RewriteInstance.cpp
+++ b/bolt/lib/Rewrite/RewriteInstance.cpp
@@ -114,6 +114,35 @@ cl::opt<bool> DumpDotAll(
              "enable '-print-loops' for color-coded blocks"),
     cl::Hidden, cl::cat(BoltCategory));
 
+cl::list<std::string> DumpDotFunc(
+    "dump-dot-func", cl::CommaSeparated,
+    cl::desc(
+        "dump function CFGs to graphviz format for specified functions only;"
+        "takes function name patterns (regex supported)"),
+    cl::value_desc("func1,func2,func3,..."), cl::Hidden, cl::cat(BoltCategory));
+
+bool shouldDumpDot(const bolt::BinaryFunction &Function) {
+  // If dump-dot-all is enabled, dump all functions
+  if (DumpDotAll)
+    return !Function.isIgnored();
+
+  // If no specific functions specified in dump-dot-func, don't dump any
+  if (DumpDotFunc.empty())
+    return false;
+
+  if (Function.isIgnored())
+    return false;
+
+  // Check if function matches any of the specified patterns
+  for (const std::string &Name : DumpDotFunc) {
+    if (Function.hasNameRegex(Name)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 static cl::list<std::string>
 ForceFunctionNames("funcs",
   cl::CommaSeparated,
@@ -3570,7 +3599,7 @@ void RewriteInstance::postProcessFunctions() {
     if (opts::PrintAll || opts::PrintCFG)
       Function.print(BC->outs(), "after building cfg");
 
-    if (opts::DumpDotAll)
+    if (opts::shouldDumpDot(Function))
       Function.dumpGraphForPass("00_build-cfg");
 
     if (opts::PrintLoopInfo) {

--- a/bolt/test/Inputs/multi-func.c
+++ b/bolt/test/Inputs/multi-func.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+// Multiple functions to test selective dumping
+int add(int a, int b) { return a + b; }
+
+int multiply(int a, int b) { return a * b; }
+
+int main_helper() {
+  printf("Helper function\n");
+  return 42;
+}
+
+int main_secondary() { return add(5, 3); }
+
+void other_function() { printf("Other function\n"); }
+
+int main() {
+  int result = add(10, 20);
+  result = multiply(result, 2);
+  main_helper();
+  main_secondary();
+  other_function();
+  return result;
+}

--- a/bolt/test/Inputs/multi-func.cpp
+++ b/bolt/test/Inputs/multi-func.cpp
@@ -1,4 +1,4 @@
-#include <stdio.h>
+#include <iostream>
 
 // Multiple functions to test selective dumping
 int add(int a, int b) { return a + b; }
@@ -6,13 +6,13 @@ int add(int a, int b) { return a + b; }
 int multiply(int a, int b) { return a * b; }
 
 int main_helper() {
-  printf("Helper function\n");
+  std::cout << "Helper function" << std::endl;
   return 42;
 }
 
 int main_secondary() { return add(5, 3); }
 
-void other_function() { printf("Other function\n"); }
+void other_function() { std::cout << "Other function" << std::endl; }
 
 int main() {
   int result = add(10, 20);

--- a/bolt/test/dump-dot-func.test
+++ b/bolt/test/dump-dot-func.test
@@ -4,60 +4,40 @@
 RUN: %clang++ %p/Inputs/multi-func.cpp -o %t.exe -Wl,-q
 
 # Test 1: --dump-dot-func with specific function name (mangled)
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt1 --dump-dot-func=_Z3addii -v=1 2>&1 | FileCheck %s --check-prefix=ADD
-RUN: test -f _Z3addii-00_build-cfg.dot
-RUN: test ! -f main-00_build-cfg.dot
-RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Test 2: --dump-dot-func with regex pattern (main.*)
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt2 --dump-dot-func="main.*" -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-REGEX
-RUN: test -f main-00_build-cfg.dot
-RUN: test ! -f _Z3addii-00_build-cfg.dot
-RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Test 3: --dump-dot-func with multiple specific functions (mangled names)
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt3 --dump-dot-func=_Z3addii,_Z8multiplyii -v=1 2>&1 | FileCheck %s --check-prefix=MULTI
-RUN: test -f _Z3addii-00_build-cfg.dot
-RUN: test -f _Z8multiplyii-00_build-cfg.dot
-RUN: test ! -f main-00_build-cfg.dot
-RUN: test ! -f _Z11main_helperv-00_build-cfg.dot
 
 # Test 4: No option specified should create no dot files
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt4 2>&1 | FileCheck %s --check-prefix=NONE
-RUN: test ! -f _Z3addii-00_build-cfg.dot
-RUN: test ! -f main-00_build-cfg.dot
-RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Test 5: --dump-dot-func with non-existent function
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt5 --dump-dot-func=nonexistent -v=1 2>&1 | FileCheck %s --check-prefix=NONEXISTENT
-RUN: test ! -f nonexistent-00_build-cfg.dot
-RUN: test ! -f _Z3addii-00_build-cfg.dot
-RUN: test ! -f main-00_build-cfg.dot
 
 # Test 6: Backward compatibility - --dump-dot-all should still work
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt6 --dump-dot-all -v=1 2>&1 | FileCheck %s --check-prefix=ALL
-RUN: test -f main-00_build-cfg.dot
 
 # Test 7: Test with unmangled function name (main function)
-RUN: rm -f *.dot
 RUN: llvm-bolt %t.exe -o %t.bolt7 --dump-dot-func=main -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-UNMANGLED
-RUN: test -f main-00_build-cfg.dot
-RUN: test ! -f _Z3addii-00_build-cfg.dot
-RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Check that specific functions are dumped
 ADD: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
+ADD-NOT: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+ADD-NOT: BOLT-INFO: dumping CFG to _Z8multiplyii-00_build-cfg.dot
+ADD-NOT: BOLT-INFO: dumping CFG to _Z11main_helperv-00_build-cfg.dot
 
 MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+MAIN-REGEX-NOT: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
+MAIN-REGEX-NOT: BOLT-INFO: dumping CFG to _Z8multiplyii-00_build-cfg.dot
 
 MULTI-DAG: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
 MULTI-DAG: BOLT-INFO: dumping CFG to _Z8multiplyii-00_build-cfg.dot
+MULTI-NOT: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+MULTI-NOT: BOLT-INFO: dumping CFG to _Z11main_helperv-00_build-cfg.dot
 
 # Should be no dumping messages when no option is specified
 NONE-NOT: BOLT-INFO: dumping CFG
@@ -67,5 +47,6 @@ NONEXISTENT-NOT: BOLT-INFO: dumping CFG
 
 ALL: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
 
-# Test that unmangled function names still work
 MAIN-UNMANGLED: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+MAIN-UNMANGLED-NOT: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
+MAIN-UNMANGLED-NOT: BOLT-INFO: dumping CFG to _Z8multiplyii-00_build-cfg.dot

--- a/bolt/test/dump-dot-func.test
+++ b/bolt/test/dump-dot-func.test
@@ -1,32 +1,55 @@
 # Test the --dump-dot-func option with multiple functions 
-# (includes tests for both mangled/unmangled names)
+# (includes tests for both mangled/unmangled names)
 
 RUN: %clang++ %p/Inputs/multi-func.cpp -o %t.exe -Wl,-q
 
 # Test 1: --dump-dot-func with specific function name (mangled)
-RUN: llvm-bolt %t.exe -o %t.bolt1 --dump-dot-func=_Z3addii --print-only=_Z3addii -v=1 2>&1 | FileCheck %s --check-prefix=ADD
-RUN: ls _Z3addii-*.dot | wc -l | FileCheck %s --check-prefix=COUNT-ONE
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt1 --dump-dot-func=_Z3addii -v=1 2>&1 | FileCheck %s --check-prefix=ADD
+RUN: test -f _Z3addii-00_build-cfg.dot
+RUN: test ! -f main-00_build-cfg.dot
+RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Test 2: --dump-dot-func with regex pattern (main.*)
-RUN: llvm-bolt %t.exe -o %t.bolt2 --dump-dot-func="main.*" --print-only=main,main_helper,main_secondary -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-REGEX
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt2 --dump-dot-func="main.*" -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-REGEX
+RUN: test -f main-00_build-cfg.dot
+RUN: test ! -f _Z3addii-00_build-cfg.dot
+RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Test 3: --dump-dot-func with multiple specific functions (mangled names)
-RUN: llvm-bolt %t.exe -o %t.bolt3 --dump-dot-func=_Z3addii,_Z8multiplyii --print-only=_Z3addii,_Z8multiplyii -v=1 2>&1 | FileCheck %s --check-prefix=MULTI
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt3 --dump-dot-func=_Z3addii,_Z8multiplyii -v=1 2>&1 | FileCheck %s --check-prefix=MULTI
+RUN: test -f _Z3addii-00_build-cfg.dot
+RUN: test -f _Z8multiplyii-00_build-cfg.dot
+RUN: test ! -f main-00_build-cfg.dot
+RUN: test ! -f _Z11main_helperv-00_build-cfg.dot
 
 # Test 4: No option specified should create no dot files
-RUN: llvm-bolt %t.exe -o %t.bolt4 --print-only=main 2>&1 | FileCheck %s --check-prefix=NONE
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt4 2>&1 | FileCheck %s --check-prefix=NONE
+RUN: test ! -f _Z3addii-00_build-cfg.dot
+RUN: test ! -f main-00_build-cfg.dot
+RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Test 5: --dump-dot-func with non-existent function
-RUN: llvm-bolt %t.exe -o %t.bolt5 --dump-dot-func=nonexistent --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=NONEXISTENT
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt5 --dump-dot-func=nonexistent -v=1 2>&1 | FileCheck %s --check-prefix=NONEXISTENT
+RUN: test ! -f nonexistent-00_build-cfg.dot
+RUN: test ! -f _Z3addii-00_build-cfg.dot
+RUN: test ! -f main-00_build-cfg.dot
 
 # Test 6: Backward compatibility - --dump-dot-all should still work
-RUN: llvm-bolt %t.exe -o %t.bolt6 --dump-dot-all --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=ALL
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt6 --dump-dot-all -v=1 2>&1 | FileCheck %s --check-prefix=ALL
+RUN: test -f main-00_build-cfg.dot
 
-# Test 7: Test with helper function (mangled name)
-RUN: llvm-bolt %t.exe -o %t.bolt7 --dump-dot-func=_Z11main_helperv --print-only=_Z11main_helperv -v=1 2>&1 | FileCheck %s --check-prefix=HELPER
-
-# Test 8: Test with unmangled function name (main function)
-RUN: llvm-bolt %t.exe -o %t.bolt8 --dump-dot-func=main --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-UNMANGLED
+# Test 7: Test with unmangled function name (main function)
+RUN: rm -f *.dot
+RUN: llvm-bolt %t.exe -o %t.bolt7 --dump-dot-func=main -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-UNMANGLED
+RUN: test -f main-00_build-cfg.dot
+RUN: test ! -f _Z3addii-00_build-cfg.dot
+RUN: test ! -f _Z8multiplyii-00_build-cfg.dot
 
 # Check that specific functions are dumped
 ADD: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
@@ -44,10 +67,5 @@ NONEXISTENT-NOT: BOLT-INFO: dumping CFG
 
 ALL: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
 
-HELPER: BOLT-INFO: dumping CFG to _Z11main_helperv-00_build-cfg.dot
-
 # Test that unmangled function names still work
 MAIN-UNMANGLED: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
-
-# Count checks
-COUNT-ONE: 1

--- a/bolt/test/dump-dot-func.test
+++ b/bolt/test/dump-dot-func.test
@@ -1,16 +1,17 @@
-# Test the --dump-dot-func option with multiple functions
+# Test the --dump-dot-func option with multiple functions 
+# (includes tests for both mangled/unmangled names)
 
-RUN: %clang %p/Inputs/multi-func.c -o %t.exe -Wl,-q
+RUN: %clang++ %p/Inputs/multi-func.cpp -o %t.exe -Wl,-q
 
-# Test 1: --dump-dot-func with specific function name
-RUN: llvm-bolt %t.exe -o %t.bolt1 --dump-dot-func=add --print-only=add -v=1 2>&1 | FileCheck %s --check-prefix=ADD
-RUN: ls add-*.dot | wc -l | FileCheck %s --check-prefix=COUNT-ONE
+# Test 1: --dump-dot-func with specific function name (mangled)
+RUN: llvm-bolt %t.exe -o %t.bolt1 --dump-dot-func=_Z3addii --print-only=_Z3addii -v=1 2>&1 | FileCheck %s --check-prefix=ADD
+RUN: ls _Z3addii-*.dot | wc -l | FileCheck %s --check-prefix=COUNT-ONE
 
 # Test 2: --dump-dot-func with regex pattern (main.*)
 RUN: llvm-bolt %t.exe -o %t.bolt2 --dump-dot-func="main.*" --print-only=main,main_helper,main_secondary -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-REGEX
 
-# Test 3: --dump-dot-func with multiple specific functions
-RUN: llvm-bolt %t.exe -o %t.bolt3 --dump-dot-func=add,multiply --print-only=add,multiply -v=1 2>&1 | FileCheck %s --check-prefix=MULTI
+# Test 3: --dump-dot-func with multiple specific functions (mangled names)
+RUN: llvm-bolt %t.exe -o %t.bolt3 --dump-dot-func=_Z3addii,_Z8multiplyii --print-only=_Z3addii,_Z8multiplyii -v=1 2>&1 | FileCheck %s --check-prefix=MULTI
 
 # Test 4: No option specified should create no dot files
 RUN: llvm-bolt %t.exe -o %t.bolt4 --print-only=main 2>&1 | FileCheck %s --check-prefix=NONE
@@ -21,15 +22,19 @@ RUN: llvm-bolt %t.exe -o %t.bolt5 --dump-dot-func=nonexistent --print-only=main 
 # Test 6: Backward compatibility - --dump-dot-all should still work
 RUN: llvm-bolt %t.exe -o %t.bolt6 --dump-dot-all --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=ALL
 
+# Test 7: Test with helper function (mangled name)
+RUN: llvm-bolt %t.exe -o %t.bolt7 --dump-dot-func=_Z11main_helperv --print-only=_Z11main_helperv -v=1 2>&1 | FileCheck %s --check-prefix=HELPER
+
+# Test 8: Test with unmangled function name (main function)
+RUN: llvm-bolt %t.exe -o %t.bolt8 --dump-dot-func=main --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-UNMANGLED
+
 # Check that specific functions are dumped
-ADD: BOLT-INFO: dumping CFG to add-00_build-cfg.dot
+ADD: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
 
 MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
-MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main_helper-00_build-cfg.dot
-MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main_secondary-00_build-cfg.dot
 
-MULTI-DAG: BOLT-INFO: dumping CFG to add-00_build-cfg.dot
-MULTI-DAG: BOLT-INFO: dumping CFG to multiply-00_build-cfg.dot
+MULTI-DAG: BOLT-INFO: dumping CFG to _Z3addii-00_build-cfg.dot
+MULTI-DAG: BOLT-INFO: dumping CFG to _Z8multiplyii-00_build-cfg.dot
 
 # Should be no dumping messages when no option is specified
 NONE-NOT: BOLT-INFO: dumping CFG
@@ -38,6 +43,11 @@ NONE-NOT: BOLT-INFO: dumping CFG
 NONEXISTENT-NOT: BOLT-INFO: dumping CFG
 
 ALL: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+
+HELPER: BOLT-INFO: dumping CFG to _Z11main_helperv-00_build-cfg.dot
+
+# Test that unmangled function names still work
+MAIN-UNMANGLED: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
 
 # Count checks
 COUNT-ONE: 1

--- a/bolt/test/dump-dot-func.test
+++ b/bolt/test/dump-dot-func.test
@@ -1,0 +1,43 @@
+# Test the --dump-dot-func option with multiple functions
+
+RUN: %clang %p/Inputs/multi-func.c -o %t.exe -Wl,-q
+
+# Test 1: --dump-dot-func with specific function name
+RUN: llvm-bolt %t.exe -o %t.bolt1 --dump-dot-func=add --print-only=add -v=1 2>&1 | FileCheck %s --check-prefix=ADD
+RUN: ls add-*.dot | wc -l | FileCheck %s --check-prefix=COUNT-ONE
+
+# Test 2: --dump-dot-func with regex pattern (main.*)
+RUN: llvm-bolt %t.exe -o %t.bolt2 --dump-dot-func="main.*" --print-only=main,main_helper,main_secondary -v=1 2>&1 | FileCheck %s --check-prefix=MAIN-REGEX
+
+# Test 3: --dump-dot-func with multiple specific functions
+RUN: llvm-bolt %t.exe -o %t.bolt3 --dump-dot-func=add,multiply --print-only=add,multiply -v=1 2>&1 | FileCheck %s --check-prefix=MULTI
+
+# Test 4: No option specified should create no dot files
+RUN: llvm-bolt %t.exe -o %t.bolt4 --print-only=main 2>&1 | FileCheck %s --check-prefix=NONE
+
+# Test 5: --dump-dot-func with non-existent function
+RUN: llvm-bolt %t.exe -o %t.bolt5 --dump-dot-func=nonexistent --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=NONEXISTENT
+
+# Test 6: Backward compatibility - --dump-dot-all should still work
+RUN: llvm-bolt %t.exe -o %t.bolt6 --dump-dot-all --print-only=main -v=1 2>&1 | FileCheck %s --check-prefix=ALL
+
+# Check that specific functions are dumped
+ADD: BOLT-INFO: dumping CFG to add-00_build-cfg.dot
+
+MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main_helper-00_build-cfg.dot
+MAIN-REGEX-DAG: BOLT-INFO: dumping CFG to main_secondary-00_build-cfg.dot
+
+MULTI-DAG: BOLT-INFO: dumping CFG to add-00_build-cfg.dot
+MULTI-DAG: BOLT-INFO: dumping CFG to multiply-00_build-cfg.dot
+
+# Should be no dumping messages when no option is specified
+NONE-NOT: BOLT-INFO: dumping CFG
+
+# Should be no dumping messages for non-existent function
+NONEXISTENT-NOT: BOLT-INFO: dumping CFG
+
+ALL: BOLT-INFO: dumping CFG to main-00_build-cfg.dot
+
+# Count checks
+COUNT-ONE: 1


### PR DESCRIPTION
## Change:
* Added `--dump-dot-func` command-line option that allows users to dump CFGs only for specific functions instead of dumping all functions (the current only available option being `--dump-dot-all`)

## Usage:
* Users can now specify function names or regex patterns (e.g., `--dump-dot-func=main,helper` or `--dump-dot-func="init.*`") to generate .dot files only for functions of interest
* Aims to save time when analysing specific functions in large binaries (e.g., only dumping graphs for performance-critical functions identified through profiling) and we can now avoid reduce output clutter from generating thousands of unnecessary .dot files when analysing large binaries

## Testing
The introduced test `dump-dot-func.test` confirms the new option does the following:

- [x] 1. `dump-dot-func` can correctly filter a specified functions
- [x] 2. Can achieve the above with regexes
- [x] 3. Can do 1. with a list of functions
- [x] No option specified creates no dot files
- [x] Passing in a non-existent function generates no dumping messages
- [x] `dump-dot-all` continues to work as expected