### PR TITLE
[llvm-dis] Add --opaque-pointers option to control whether to output typed or opaque pointers

### DIFF
--- a/llvm/tools/llvm-dis/llvm-dis.cpp
+++ b/llvm/tools/llvm-dis/llvm-dis.cpp
@@ -80,6 +80,10 @@ static cl::opt<bool> PrintThinLTOIndexOnly(
     cl::desc("Only read thinlto index and print the index as LLVM assembly."),
     cl::init(false), cl::Hidden, cl::cat(DisCategory));
 
+static cl::opt<bool> OpaquePointers("opaque-pointers",
+                                    cl::desc("Use opaque pointers"),
+                                    cl::init(true), cl::cat(DisCategory));
+
 namespace {
 
 static void printDebugLoc(const DebugLoc &DL, formatted_raw_ostream &OS) {
@@ -168,6 +172,7 @@ int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv, "llvm .bc -> .ll disassembler\n");
 
   LLVMContext Context;
+  Context.setOpaquePointers(OpaquePointers);
   Context.setDiagnosticHandler(
       std::make_unique<LLVMDisDiagnosticHandler>(argv[0]));
 


### PR DESCRIPTION
This adds a flag to explicitly control whether to disassemble with the typed or opaque pointers syntax. Without this patch even bytecode with typed pointers outputs IR with opaque pointers. This option is enabled by default, preserving the previous behavior if not specified. This is only relevant up to LLVM 16, as later versions don't support typed pointers at all.