### PR TITLE
[libcxx] Fix container build and bump clang version

### DIFF
--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -1,6 +1,10 @@
 x-versions: &compiler_versions
   GCC_HEAD_VERSION: 16
-  LLVM_HEAD_VERSION: 21
+  LLVM_HEAD_VERSION: 22
+
+x-image-versions: &image_versions
+  BASE_IMAGE: ubuntu:jammy
+  ACTIONS_BASE_IMAGE: builder-base
 
 services:
   builder-base:
@@ -10,8 +14,7 @@ services:
       dockerfile: Dockerfile
       target: builder-base
       args:
-        BASE_IMAGE: ubuntu:jammy
-        <<: *compiler_versions
+        <<: [*image_versions, *compiler_versions]
 
   actions-builder:
     image: ghcr.io/llvm/libcxx-linux-builder:${TAG}
@@ -20,10 +23,8 @@ services:
       dockerfile: Dockerfile
       target: actions-builder
       args:
-        BASE_IMAGE: ubuntu:jammy
-        ACTIONS_BASE_IMAGE: builder-base
         GITHUB_RUNNER_VERSION: "2.326.0"
-        <<: *compiler_versions
+        <<: [*image_versions, *compiler_versions]
 
   android-buildkite-builder:
     image: ghcr.io/llvm/libcxx-android-builder:${TAG}
@@ -32,8 +33,7 @@ services:
       dockerfile: Dockerfile
       target: android-buildkite-builder
       args:
-        BASE_IMAGE: ubuntu:noble
         ANDROID_CLANG_VERSION: r563880
         ANDROID_CLANG_PREBUILTS_COMMIT: 6ae4184bb8706f9731569b9a0a82be3fcdcb951c
         ANDROID_SYSROOT_COMMIT: f8b85cc5262c6e5cbc9a92c1bab2b18b32a4c63f
-        <<: *compiler_versions
+        <<: [*image_versions, *compiler_versions]

--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -33,7 +33,8 @@ services:
       dockerfile: Dockerfile
       target: android-buildkite-builder
       args:
+        BASE_IMAGE: ubuntu:noble
         ANDROID_CLANG_VERSION: r563880
         ANDROID_CLANG_PREBUILTS_COMMIT: 6ae4184bb8706f9731569b9a0a82be3fcdcb951c
         ANDROID_SYSROOT_COMMIT: f8b85cc5262c6e5cbc9a92c1bab2b18b32a4c63f
-        <<: [*image_versions, *compiler_versions]
+        <<: *compiler_versions


### PR DESCRIPTION
This patch fixes the libcxx container build. There was a missing env variable that would cause the containers to not be built. Now that clang 22 is out, we also want to bump the LLVM head version to 22.