### PR TITLE
[AIX] Implement the ifunc attribute.

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -6684,6 +6684,13 @@ Not all targets support this attribute:
   with an indirect call. The function pointer is initialized by a constructor
   that calls the resolver.
 - Baremetal target supports it on AVR.
+- AIX/XCOFF supports it via a compiler-only solution. An ifunc appears as a
+  regular function (has an entry point ``.foo[PR]`` and a function descriptor
+  ``foo[DS]``). The entry point is a stub that branches to the function address
+  in the descriptor, and the descriptor is initialized via a constructor
+  function (``__init_ifuncs``) that is linked into every shared object and
+  executable. ``__init_ifuncs`` calls the resolver of each ifunc and stores the
+  result in the corresponding descriptor.
 - Other targets currently do not support this attribute.
   }];
 }

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1575,6 +1575,8 @@ public:
       return true;
     if (getTriple().getArch() == llvm::Triple::ArchType::avr)
       return true;
+    if (getTriple().isOSAIX())
+      return true;
     return getTriple().isOSBinFormatELF() &&
            ((getTriple().isOSLinux() && !getTriple().isMusl()) ||
             getTriple().isOSFreeBSD());

--- a/clang/include/clang/Basic/TargetInfo.h
+++ b/clang/include/clang/Basic/TargetInfo.h
@@ -1576,7 +1576,8 @@ public:
     if (getTriple().getArch() == llvm::Triple::ArchType::avr)
       return true;
     if (getTriple().isOSAIX())
-      return true;
+      return getTriple().getOSMajorVersion() == 0 ||
+             getTriple().getOSVersion() >= VersionTuple(7, 2);
     return getTriple().isOSBinFormatELF() &&
            ((getTriple().isOSLinux() && !getTriple().isMusl()) ||
             getTriple().isOSFreeBSD());

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -147,9 +147,11 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-bforceimprw");
   }
 
-  // ifunc support, which is ON by default, generates named sections.
-  CmdArgs.push_back("-bdbg:namedsects:ss");
-
+  // PGO and ifunc support depends on the named sections linker feature that is
+  // available on AIX 7.2 TL5 SP5 onwards.
+  if (ToolChain.getTriple().getOSMajorVersion() == 0 ||
+      ToolChain.getTriple().getOSVersion() >= VersionTuple(7, 2))
+    CmdArgs.push_back("-bdbg:namedsects:ss");
 
   if (Arg *A = Args.getLastArg(options::OPT_mxcoff_build_id_EQ)) {
     StringRef BuildId = A->getValue();

--- a/clang/lib/Driver/ToolChains/AIX.cpp
+++ b/clang/lib/Driver/ToolChains/AIX.cpp
@@ -147,26 +147,9 @@ void aix::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-bforceimprw");
   }
 
-  // PGO instrumentation generates symbols belonging to special sections, and
-  // the linker needs to place all symbols in a particular section together in
-  // memory; the AIX linker does that under an option.
-  if (Args.hasFlag(options::OPT_fprofile_arcs, options::OPT_fno_profile_arcs,
-                    false) ||
-       Args.hasFlag(options::OPT_fprofile_generate,
-                    options::OPT_fno_profile_generate, false) ||
-       Args.hasFlag(options::OPT_fprofile_generate_EQ,
-                    options::OPT_fno_profile_generate, false) ||
-       Args.hasFlag(options::OPT_fprofile_instr_generate,
-                    options::OPT_fno_profile_instr_generate, false) ||
-       Args.hasFlag(options::OPT_fprofile_instr_generate_EQ,
-                    options::OPT_fno_profile_instr_generate, false) ||
-       Args.hasFlag(options::OPT_fcs_profile_generate,
-                    options::OPT_fno_profile_generate, false) ||
-       Args.hasFlag(options::OPT_fcs_profile_generate_EQ,
-                    options::OPT_fno_profile_generate, false) ||
-       Args.hasArg(options::OPT_fcreate_profile) ||
-       Args.hasArg(options::OPT_coverage))
-    CmdArgs.push_back("-bdbg:namedsects:ss");
+  // ifunc support, which is ON by default, generates named sections.
+  CmdArgs.push_back("-bdbg:namedsects:ss");
+
 
   if (Arg *A = Args.getLastArg(options::OPT_mxcoff_build_id_EQ)) {
     StringRef BuildId = A->getValue();

--- a/clang/test/CodeGen/attr-ifunc.c
+++ b/clang/test/CodeGen/attr-ifunc.c
@@ -4,6 +4,8 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macosx -verify -emit-llvm-only %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-gnu -verify -emit-llvm-only %s
 // RUN: %clang_cc1 -triple aarch64-pc-windows-msvcu -verify -emit-llvm-only %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix-xcoff -verify -emit-llvm-only %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix-xcoff -verify -emit-llvm-only -DCHECK_ALIASES %s
 
 #if defined(_WIN32) && !defined(__aarch64__)
 void foo(void) {}

--- a/clang/test/CodeGen/attr-ifunc.cpp
+++ b/clang/test/CodeGen/attr-ifunc.cpp
@@ -1,9 +1,11 @@
 // RUN: %clang_cc1 -triple x86_64-linux -verify -emit-llvm-only %s
 // RUN: %clang_cc1 -triple x86_64-apple-macosx -verify -emit-llvm-only %s
 // RUN: %clang_cc1 -triple arm64-apple-macosx -verify -emit-llvm-only %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix-xcoff -verify -emit-llvm-only %s
 // RUN: not %clang_cc1 -triple x86_64-linux -emit-llvm-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 // RUN: not %clang_cc1 -triple x86_64-apple-macosx -emit-llvm-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 // RUN: not %clang_cc1 -triple arm64-apple-macosx -emit-llvm-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -triple powerpc64-ibm-aix-xcoff -emit-llvm-only -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 
 void *f1_ifunc(void) { return nullptr; }
 void f1(void) __attribute__((ifunc("f1_ifunc")));

--- a/clang/test/CodeGen/ifunc.c
+++ b/clang/test/CodeGen/ifunc.c
@@ -16,6 +16,8 @@
 // RUN: %clang_cc1 -triple aarch64-none-linux-gnu -O2 -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple aarch64-none-linux-gnu -fsanitize=thread -O2 -emit-llvm -o - %s | FileCheck %s --check-prefix=SAN
 // RUN: %clang_cc1 -triple aarch64-none-linux-gnu -fsanitize=address -O2 -emit-llvm -o - %s | FileCheck %s --check-prefix=SAN
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix-xcoff -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix-xcoff -O2 -emit-llvm -o - %s | FileCheck %s
 
 
 /// The ifunc is emitted before its resolver.
@@ -65,7 +67,7 @@ extern void hoo(int) __attribute__ ((ifunc("hoo_ifunc")));
 // AVR: @goo = ifunc void (), ptr addrspace(1) @goo_ifunc
 // AVR: @hoo = ifunc void (i16), ptr addrspace(1) @hoo_ifunc
 
-// CHECK: call i32 @foo(i32
+// CHECK: call {{(signext )?}}i32 @foo(i32
 // CHECK: call void @goo()
 
 // SAN: define {{(dso_local )?}}noalias {{(noundef )?}}ptr @goo_ifunc() #[[#GOO_IFUNC:]] {

--- a/clang/test/CodeGenCXX/externc-ifunc-resolver.cpp
+++ b/clang/test/CodeGenCXX/externc-ifunc-resolver.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-linux-gnu -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple x86_64-apple-macosx -emit-llvm -o - %s | FileCheck %s
 // RUN: %clang_cc1 -triple arm64-apple-macosx -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple powerpc64-ibm-aix-xcoff -emit-llvm -o - %s | FileCheck %s
 
 extern "C" {
 __attribute__((used)) static void *resolve_foo() { return 0; }

--- a/clang/test/SemaCXX/ifunc-has-attribute.cpp
+++ b/clang/test/SemaCXX/ifunc-has-attribute.cpp
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -emit-llvm-only -triple x86_64-apple-macosx -verify %s -DSUPPORTED=1
 // RUN: %clang_cc1 -emit-llvm-only -triple arm64-apple-macosx -verify %s -DSUPPORTED=1
 // RUN: %clang_cc1 -emit-llvm-only -triple x86_64-pc-win32 -verify %s -DNOT_SUPPORTED=1
+// RUN: %clang_cc1 -emit-llvm-only -triple powerpc64-ibm-aix-xcoff -verify %s -DSUPPORTED=1
 
 // expected-no-diagnostics
 

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -839,6 +839,16 @@ if (NOT OS_NAME MATCHES "AIX")
     ${powerpc64_SOURCES}
   )
 endif()
+if (OS_NAME MATCHES "AIX")
+  set(powerpc_SOURCES
+    ppc/init_ifuncs.c
+    ${powerpc_SOURCES}
+  )
+  set(powerpc64_SOURCES
+    ppc/init_ifuncs.c
+    ${powerpc64_SOURCES}
+  )
+endif()
 set(powerpc64le_SOURCES ${powerpc64_SOURCES})
 
 set(riscv_SOURCES

--- a/compiler-rt/lib/builtins/ppc/init_ifuncs.c
+++ b/compiler-rt/lib/builtins/ppc/init_ifuncs.c
@@ -1,28 +1,38 @@
-typedef void* Ptr;
-typedef struct { Ptr addr, toc, env; } Descr;
-typedef struct { Descr* desc; Ptr (*resolver)(); } IFUNC_PAIR;
+typedef void *Ptr;
+typedef struct {
+  Ptr addr, toc, env;
+} Descr;
+typedef struct {
+  Descr *desc;
+  Ptr (*resolver)();
+} IFUNCPair;
 
-// A zero-length entry in section "ifunc_sec" to satisfy the __start_ifunc_sec
-// and __stop_ifunc_sec references in this file, when no user code has any.
-__attribute__((section("ifunc_sec"))) static int dummy_ifunc_sec[0];
+#define CONC2(A, B) A##B
+#define CONC(A, B) CONC2(A, B)
 
-extern IFUNC_PAIR __start_ifunc_sec, __stop_ifunc_sec;
+#define IFUNC_SEC __ifunc_sec
+#define IFUNC_SEC_STR "__ifunc_sec"
+#define START_SEC CONC(__start_, IFUNC_SEC)
+#define STOP_SEC CONC(__stop_, IFUNC_SEC)
 
-__attribute__((constructor))
-void __init_ifuncs() {
+// A zero-length entry in section "__ifunc_sec" to satisfy the START_SEC and
+// STOP_SEC references in this file,  when no user code has any ifuncs.
+__attribute__((section(IFUNC_SEC_STR))) static int dummy_ifunc_sec[0];
+
+extern IFUNCPair START_SEC, STOP_SEC;
+
+__attribute__((constructor)) void __init_ifuncs() {
   void *volatile ref = &dummy_ifunc_sec; // hack to keep dummy_ifunc_sec alive
 
-  // hack to prevent compiler from assuming __start_ifunc_sec and
-  // __stop_ifunc_sec occupy different addresses.
-  IFUNC_PAIR *volatile volatile_end = &__stop_ifunc_sec;
-  for (IFUNC_PAIR *pair = &__start_ifunc_sec, *end = volatile_end; pair != end;
-       pair++) {
+  // hack to prevent compiler from assuming START_SEC and STOP_SEC
+  // occupy different addresses.
+  IFUNCPair *volatile volatile_end = &STOP_SEC;
+  for (IFUNCPair *pair = &START_SEC, *end = volatile_end; pair != end; pair++) {
     // Call the resolver and copy the entire descriptor because:
     //  - the resolved function might be in another DSO, so copy the TOC address
     //  - we might be linking with objects from a language that uses the
     //    enviroment pointer, so copy it too.
-    Descr *result = (Descr*)pair->resolver();
+    Descr *result = (Descr *)pair->resolver();
     *(pair->desc) = *result;
   }
 }
-

--- a/compiler-rt/lib/builtins/ppc/init_ifuncs.c
+++ b/compiler-rt/lib/builtins/ppc/init_ifuncs.c
@@ -1,0 +1,14 @@
+typedef void* Ptr;
+typedef struct { Ptr addr, toc, env; } Descr;
+typedef struct { Descr* desc; Ptr (*resolver)(); } IFUNC_PAIR;
+
+extern IFUNC_PAIR __start_ifunc_sec, __stop_ifunc_sec;
+
+__attribute__((constructor))
+void __init_ifuncs() {
+  for (IFUNC_PAIR *pair = &__start_ifunc_sec;
+       pair != &__stop_ifunc_sec;
+       pair++)
+    pair->desc->addr = ((Descr*)(pair->resolver()))->addr;
+}
+

--- a/compiler-rt/lib/builtins/ppc/init_ifuncs.c
+++ b/compiler-rt/lib/builtins/ppc/init_ifuncs.c
@@ -2,12 +2,20 @@ typedef void* Ptr;
 typedef struct { Ptr addr, toc, env; } Descr;
 typedef struct { Descr* desc; Ptr (*resolver)(); } IFUNC_PAIR;
 
+// A zero-length entry in section "ifunc_sec" to satisfy the __start_ifunc_sec
+// and __stop_ifunc_sec references in this file, when no user code has any.
+__attribute__((section("ifunc_sec"))) static int dummy_ifunc_sec[0];
+
 extern IFUNC_PAIR __start_ifunc_sec, __stop_ifunc_sec;
 
 __attribute__((constructor))
 void __init_ifuncs() {
-  for (IFUNC_PAIR *pair = &__start_ifunc_sec;
-       pair != &__stop_ifunc_sec;
+  void *volatile ref = &dummy_ifunc_sec; // hack to keep dummy_ifunc_sec alive
+
+  // hack to prevent compiler from assuming __start_ifunc_sec and
+  // __stop_ifunc_sec occupy different addresses.
+  IFUNC_PAIR *volatile volatile_end = &__stop_ifunc_sec;
+  for (IFUNC_PAIR *pair = &__start_ifunc_sec, *end = volatile_end; pair != end;
        pair++)
     pair->desc->addr = ((Descr*)(pair->resolver()))->addr;
 }

--- a/compiler-rt/lib/builtins/ppc/init_ifuncs.c
+++ b/compiler-rt/lib/builtins/ppc/init_ifuncs.c
@@ -16,7 +16,13 @@ void __init_ifuncs() {
   // __stop_ifunc_sec occupy different addresses.
   IFUNC_PAIR *volatile volatile_end = &__stop_ifunc_sec;
   for (IFUNC_PAIR *pair = &__start_ifunc_sec, *end = volatile_end; pair != end;
-       pair++)
-    pair->desc->addr = ((Descr*)(pair->resolver()))->addr;
+       pair++) {
+    // Call the resolver and copy the entire descriptor because:
+    //  - the resolved function might be in another DSO, so copy the TOC address
+    //  - we might be linking with objects from a language that uses the
+    //    enviroment pointer, so copy it too.
+    Descr *result = (Descr*)pair->resolver();
+    *(pair->desc) = *result;
+  }
 }
 

--- a/compiler-rt/test/builtins/Unit/ppc/aix_ifunc.c
+++ b/compiler-rt/test/builtins/Unit/ppc/aix_ifunc.c
@@ -1,17 +1,23 @@
-// RUN: %clang %s -fno-integrated-as -Wl,-bmap:%t.map
-// RUN: FileCheck %s < %t.map
-// RUN: %clang %s -m64 -fno-integrated-as -Wl,-bmap:%t.map
-// RUN: FileCheck %s --check-prefix=CHECK64 < %t.map
+// We created a constructor function in compiler-rt/lib/builtins/ppc/init_ifuncs.c
+// that reads an array contained in a certain named section of the object file.
+// The compiler generates extra globals (one per ifunc) in that section.
+// This test is to make sure the section name in the builtins library and the
+// compiler match by checking the distance between the start and end of the
+// section is "2*sizeof(void*)" because there's one ifunc in the entire program.
+//
+// REQUIRES: target={{.*aix.*}}
+// RUN: %clang_builtins %s %librt -fno-integrated-as -o a.out
+// RUN: llvm-nm -Xany --numeric-sort a.out | \
+// RUN:   FileCheck %s %if target-is-powerpc64 %{ --check-prefix=CHECK64 %} \
+// RUN:                %else %{ --check-prefix=CHECK %}
 
-// CHECK: [[#%X,ADDR:]]          RW LD S{{.*}}   {__start___ifunc_sec}
-// CHECK: [[#ADDR+8]]          RW LD S{{.*}}   {__stop___ifunc_sec}
-// CHECK64: [[#%X,ADDR:]]          RW LD S{{.*}}   {__start___ifunc_sec}
-// CHECK64: [[#ADDR+16]]          RW LD S{{.*}}   {__stop___ifunc_sec}
-
+// CHECK: [[#%x,ADDR:]] W __start___ifunc_sec
+// CHECK: [[#ADDR+8]] W __stop___ifunc_sec
+// CHECK64: [[#%x,ADDR:]] W __start___ifunc_sec
+// CHECK64: [[#ADDR+16]] W __stop___ifunc_sec
 
 static int my_foo() { return 5; }
-static void* foo_resolver() { return &my_foo; };
+static void *foo_resolver() { return &my_foo; };
 
-__attribute__ ((ifunc ("foo_resolver")))
-int foo();
+__attribute__((ifunc("foo_resolver"))) int foo();
 int main() { return foo(); }

--- a/compiler-rt/test/builtins/Unit/ppc/aix_ifunc.c
+++ b/compiler-rt/test/builtins/Unit/ppc/aix_ifunc.c
@@ -1,0 +1,17 @@
+// RUN: %clang %s -fno-integrated-as -Wl,-bmap:%t.map
+// RUN: FileCheck %s < %t.map
+// RUN: %clang %s -m64 -fno-integrated-as -Wl,-bmap:%t.map
+// RUN: FileCheck %s --check-prefix=CHECK64 < %t.map
+
+// CHECK: [[#%X,ADDR:]]          RW LD S{{.*}}   {__start___ifunc_sec}
+// CHECK: [[#ADDR+8]]          RW LD S{{.*}}   {__stop___ifunc_sec}
+// CHECK64: [[#%X,ADDR:]]          RW LD S{{.*}}   {__start___ifunc_sec}
+// CHECK64: [[#ADDR+16]]          RW LD S{{.*}}   {__stop___ifunc_sec}
+
+
+static int my_foo() { return 5; }
+static void* foo_resolver() { return &my_foo; };
+
+__attribute__ ((ifunc ("foo_resolver")))
+int foo();
+int main() { return foo(); }

--- a/compiler-rt/test/profile/AIX/ifunc.c
+++ b/compiler-rt/test/profile/AIX/ifunc.c
@@ -1,0 +1,16 @@
+// RUN: %clang_pgogen %s -fno-integrated-as -o %t.out && %t.out
+
+// candidates
+__attribute__((visibility("hidden"))) int my_foo () { return 4; }
+static int my_foo2() { return 5; }
+
+// resolver
+extern int x;
+static void* foo_resolver() { return x ? &my_foo : &my_foo2; };
+
+// ifunc
+__attribute__ ((ifunc ("foo_resolver")))
+int foo();
+
+int x = 1;
+int main() { return foo() - 4; }

--- a/compiler-rt/test/profile/AIX/ifunc.c
+++ b/compiler-rt/test/profile/AIX/ifunc.c
@@ -1,16 +1,15 @@
 // RUN: %clang_pgogen %s -fno-integrated-as -o %t.out && %t.out
 
 // candidates
-__attribute__((visibility("hidden"))) int my_foo () { return 4; }
+__attribute__((visibility("hidden"))) int my_foo() { return 4; }
 static int my_foo2() { return 5; }
 
 // resolver
 extern int x;
-static void* foo_resolver() { return x ? &my_foo : &my_foo2; };
+static void *foo_resolver() { return x ? &my_foo : &my_foo2; };
 
 // ifunc
-__attribute__ ((ifunc ("foo_resolver")))
-int foo();
+__attribute__((ifunc("foo_resolver"))) int foo();
 
 int x = 1;
 int main() { return foo() - 4; }

--- a/llvm/include/llvm/CodeGen/AsmPrinter.h
+++ b/llvm/include/llvm/CodeGen/AsmPrinter.h
@@ -974,7 +974,7 @@ private:
   virtual void emitModuleCommandLines(Module &M);
 
   GCMetadataPrinter *getOrCreateGCPrinter(GCStrategy &S);
-  void emitGlobalIFunc(Module &M, const GlobalIFunc &GI);
+  virtual void emitGlobalIFunc(Module &M, const GlobalIFunc &GI);
 
   /// This method decides whether the specified basic block requires a label.
   bool shouldEmitLabelForBasicBlock(const MachineBasicBlock &MBB) const;

--- a/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
+++ b/llvm/include/llvm/CodeGen/TargetLoweringObjectFileImpl.h
@@ -289,7 +289,7 @@ public:
   static XCOFF::StorageClass getStorageClassForGlobal(const GlobalValue *GV);
 
   MCSection *
-  getSectionForFunctionDescriptor(const Function *F,
+  getSectionForFunctionDescriptor(const GlobalObject *F,
                                   const TargetMachine &TM) const override;
   MCSection *getSectionForTOCEntry(const MCSymbol *Sym,
                                    const TargetMachine &TM) const override;

--- a/llvm/include/llvm/Target/TargetLoweringObjectFile.h
+++ b/llvm/include/llvm/Target/TargetLoweringObjectFile.h
@@ -269,7 +269,7 @@ public:
   /// On targets that use separate function descriptor symbols, return a section
   /// for the descriptor given its symbol. Use only with defined functions.
   virtual MCSection *
-  getSectionForFunctionDescriptor(const Function *F,
+  getSectionForFunctionDescriptor(const GlobalObject *F,
                                   const TargetMachine &TM) const {
     return nullptr;
   }

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2891,6 +2891,15 @@ bool AsmPrinter::doFinalization(Module &M) {
   // sections after DWARF.
   for (const auto &IFunc : M.ifuncs())
     emitGlobalIFunc(M, IFunc);
+  if (TM.getTargetTriple().isOSBinFormatXCOFF() && hasDebugInfo()) {
+    // Emit section end. This is used to tell the debug line section where the
+    // end is for a text section if we don't use .loc to represent the debug
+    // line.
+    auto *Sec = OutContext.getObjectFileInfo()->getTextSection();
+    OutStreamer->switchSectionNoPrint(Sec);
+    MCSymbol *Sym = Sec->getEndSymbol(OutContext);
+    OutStreamer->emitLabel(Sym);
+  }
 
   // Finalize debug and EH information.
   for (auto &Handler : Handlers)

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2547,7 +2547,8 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
 }
 
 void AsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
-
+  assert(!TM.getTargetTriple().isOSBinFormatXCOFF() &&
+         "AIX has non-default implementation.");
   auto EmitLinkage = [&](MCSymbol *Sym) {
     if (GI.hasExternalLinkage() || !MAI->getWeakRefDirective())
       OutStreamer->emitSymbolAttribute(Sym, MCSA_Global);

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2547,8 +2547,6 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
 }
 
 void AsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
-  assert(!TM.getTargetTriple().isOSBinFormatXCOFF() &&
-         "IFunc is not supported on AIX.");
 
   auto EmitLinkage = [&](MCSymbol *Sym) {
     if (GI.hasExternalLinkage() || !MAI->getWeakRefDirective())

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -2547,8 +2547,6 @@ void AsmPrinter::emitGlobalAlias(const Module &M, const GlobalAlias &GA) {
 }
 
 void AsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
-  assert(!TM.getTargetTriple().isOSBinFormatXCOFF() &&
-         "AIX has non-default implementation.");
   auto EmitLinkage = [&](MCSymbol *Sym) {
     if (GI.hasExternalLinkage() || !MAI->getWeakRefDirective())
       OutStreamer->emitSymbolAttribute(Sym, MCSA_Global);

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2391,7 +2391,8 @@ MCSymbol *
 TargetLoweringObjectFileXCOFF::getTargetSymbol(const GlobalValue *GV,
                                                const TargetMachine &TM) const {
   // We always use a qualname symbol for a GV that represents
-  // a declaration, a function descriptor, or a common symbol.
+  // a declaration, a function descriptor, or a common symbol. An IFunc is
+  // lowered as a function, so it has an entry point and a descriptor.
   // If a GV represents a GlobalVariable and -fdata-sections is enabled, we
   // also return a qualname so that a label symbol could be avoided.
   // It is inherently ambiguous when the GO represents the address of a
@@ -2409,6 +2410,11 @@ TargetLoweringObjectFileXCOFF::getTargetSymbol(const GlobalValue *GV,
         return static_cast<const MCSectionXCOFF *>(
                    SectionForGlobal(GVar, SectionKind::getData(), TM))
             ->getQualNameSymbol();
+
+    if (isa<GlobalIFunc>(GO))
+      return static_cast<const MCSectionXCOFF *>(
+                 getSectionForFunctionDescriptor(GO, TM))
+          ->getQualNameSymbol();
 
     SectionKind GOKind = getKindForGlobal(GO, TM);
     if (GOKind.isText())
@@ -2682,7 +2688,7 @@ TargetLoweringObjectFileXCOFF::getStorageClassForGlobal(const GlobalValue *GV) {
 
 MCSymbol *TargetLoweringObjectFileXCOFF::getFunctionEntryPointSymbol(
     const GlobalValue *Func, const TargetMachine &TM) const {
-  assert((isa<Function>(Func) ||
+  assert((isa<Function>(Func) || isa<GlobalIFunc>(Func) ||
           (isa<GlobalAlias>(Func) &&
            isa_and_nonnull<Function>(
                cast<GlobalAlias>(Func)->getAliaseeObject()))) &&
@@ -2699,7 +2705,7 @@ MCSymbol *TargetLoweringObjectFileXCOFF::getFunctionEntryPointSymbol(
   // undefined symbols gets treated as csect with XTY_ER property.
   if (((TM.getFunctionSections() && !Func->hasSection()) ||
        Func->isDeclarationForLinker()) &&
-      isa<Function>(Func)) {
+      (isa<Function>(Func) || isa<GlobalIFunc>(Func))) {
     return getContext()
         .getXCOFFSection(
             NameStr, SectionKind::getText(),
@@ -2713,7 +2719,9 @@ MCSymbol *TargetLoweringObjectFileXCOFF::getFunctionEntryPointSymbol(
 }
 
 MCSection *TargetLoweringObjectFileXCOFF::getSectionForFunctionDescriptor(
-    const Function *F, const TargetMachine &TM) const {
+    const GlobalObject *F, const TargetMachine &TM) const {
+  assert((isa<Function>(F) || isa<GlobalIFunc>(F)) &&
+         "F must be a function or ifunc object.");
   SmallString<128> NameStr;
   getNameWithPrefix(NameStr, F, TM);
   return getContext().getXCOFFSection(

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -2392,7 +2392,8 @@ TargetLoweringObjectFileXCOFF::getTargetSymbol(const GlobalValue *GV,
                                                const TargetMachine &TM) const {
   // We always use a qualname symbol for a GV that represents
   // a declaration, a function descriptor, or a common symbol. An IFunc is
-  // lowered as a function, so it has an entry point and a descriptor.
+  // lowered as a special trampoline function which has an entry point and a
+  // descriptor.
   // If a GV represents a GlobalVariable and -fdata-sections is enabled, we
   // also return a qualname so that a label symbol could be avoided.
   // It is inherently ambiguous when the GO represents the address of a

--- a/llvm/lib/LTO/LTOModule.cpp
+++ b/llvm/lib/LTO/LTOModule.cpp
@@ -401,7 +401,7 @@ void LTOModule::addDefinedFunctionSymbol(ModuleSymbolTable::Symbol Sym) {
   }
 
   auto *GV = cast<GlobalValue *>(Sym);
-  assert((isa<Function>(GV) ||
+  assert((isa<Function>(GV) || isa<GlobalIFunc>(GV) ||
           (isa<GlobalAlias>(GV) &&
            isa<Function>(cast<GlobalAlias>(GV)->getAliasee()))) &&
          "Not function or function alias");
@@ -608,6 +608,11 @@ void LTOModule::parseSymbols() {
 
     if (isa<GlobalVariable>(GV)) {
       addDefinedDataSymbol(Sym);
+      continue;
+    }
+
+    if (getTargetTriple().isOSBinFormatXCOFF() && isa<GlobalIFunc>(GV)) {
+      addDefinedFunctionSymbol(Sym);
       continue;
     }
 

--- a/llvm/lib/Target/PowerPC/CMakeLists.txt
+++ b/llvm/lib/Target/PowerPC/CMakeLists.txt
@@ -42,6 +42,7 @@ add_llvm_target(PowerPCCodeGen
   PPCMachineScheduler.cpp
   PPCMacroFusion.cpp
   PPCMIPeephole.cpp
+  PPCPrepareIFuncsOnAIX.cpp
   PPCRegisterInfo.cpp
   PPCSelectionDAGInfo.cpp
   PPCSubtarget.cpp

--- a/llvm/lib/Target/PowerPC/PPC.h
+++ b/llvm/lib/Target/PowerPC/PPC.h
@@ -53,6 +53,7 @@ class ModulePass;
   FunctionPass *createPPCPreEmitPeepholePass();
   FunctionPass *createPPCExpandAtomicPseudoPass();
   FunctionPass *createPPCCTRLoopsPass();
+  ModulePass *createPPCPrepareIFuncsOnAIXPass();
   void LowerPPCMachineInstrToMCInst(const MachineInstr *MI, MCInst &OutMI,
                                     AsmPrinter &AP);
   bool LowerPPCMachineOperandToMCOperand(const MachineOperand &MO,
@@ -78,6 +79,7 @@ class ModulePass;
   void initializePPCExpandAtomicPseudoPass(PassRegistry &);
   void initializePPCCTRLoopsPass(PassRegistry &);
   void initializePPCDAGToDAGISelLegacyPass(PassRegistry &);
+  void initializePPCPrepareIFuncsOnAIXPass(PassRegistry &);
   void initializePPCLinuxAsmPrinterPass(PassRegistry &);
   void initializePPCAIXAsmPrinterPass(PassRegistry &);
 

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3584,7 +3584,7 @@ void PPCAIXAsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
     if (!IFuncWarnInsteadOfError)
       reportFatalUsageError(Msg);
     else
-      dbgs() << Msg;
+      dbgs() << Msg << "\n";
   }
 
   auto FnDescTOCEntryType = getTOCEntryTypeForLinkage(GI.getLinkage());

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3432,11 +3432,9 @@ static bool TOCRestoreNeededForCallToImplementation(const GlobalIFunc &GI) {
 
   // Query if the given function is local to the load module.
   auto IsLocalFunc = [](const Function *F) -> IsLocal {
-    // We require a definition, because the AIX linker chooses the visibility
-    // of a symbol based on the definition (ignoring the declaration).
-    bool Result = F->isStrongDefinitionForLinker() && F->isDSOLocal();
+    bool Result = F->isDSOLocal();
     LLVM_DEBUG(dbgs() << F->getName() << " is "
-                      << (Result ? "local\n" : "not local\n"));
+                      << (Result ? "dso_local\n" : "not dso_local\n"));
     return Result ? IsLocal::True : IsLocal::False;
   };
 

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3272,17 +3272,6 @@ void PPCAIXAsmPrinter::emitInstruction(const MachineInstr *MI) {
 }
 
 bool PPCAIXAsmPrinter::doFinalization(Module &M) {
-  // Do streamer related finalization for DWARF.
-  if (hasDebugInfo()) {
-    // Emit section end. This is used to tell the debug line section where the
-    // end is for a text section if we don't use .loc to represent the debug
-    // line.
-    auto *Sec = OutContext.getObjectFileInfo()->getTextSection();
-    OutStreamer->switchSectionNoPrint(Sec);
-    MCSymbol *Sym = Sec->getEndSymbol(OutContext);
-    OutStreamer->emitLabel(Sym);
-  }
-
   for (MCSymbol *Sym : ExtSymSDNodeSymbols)
     OutStreamer->emitSymbolAttribute(Sym, MCSA_Extern);
   return PPCAsmPrinter::doFinalization(M);

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3371,7 +3371,10 @@ void PPCAIXAsmPrinter::emitRefMetadata(const GlobalObject *GO) {
   for (const MDNode *MD : MDs) {
     const ValueAsMetadata *VAM = cast<ValueAsMetadata>(MD->getOperand(0).get());
     const GlobalValue *GV = cast<GlobalValue>(VAM->getValue());
-    MCSymbol *Referenced = isa<Function>(GV) ? getObjFileLowering().getFunctionEntryPointSymbol(GV, TM) : TM.getSymbol(GV);
+    MCSymbol *Referenced =
+        isa<Function>(GV)
+            ? getObjFileLowering().getFunctionEntryPointSymbol(GV, TM)
+            : TM.getSymbol(GV);
     OutStreamer->emitXCOFFRefDirective(Referenced);
   }
 }
@@ -3535,9 +3538,8 @@ static bool TOCRestoreNeededForCallToImplementation(const GlobalIFunc &GI) {
  *                          # -- End function
  */
 
-cl::opt<bool> UseImplicitRef(
-    "use-implicit-ref", cl::init(false),
-    cl::desc("Use implicit.ref metadata"), cl::Hidden);
+cl::opt<bool> UseImplicitRef("use-implicit-ref", cl::init(true),
+                             cl::desc("Use implicit.ref metadata"), cl::Hidden);
 
 void PPCAIXAsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
   // Set the Subtarget to that of the resolver.
@@ -3569,8 +3571,7 @@ void PPCAIXAsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
     const ValueAsMetadata *VAM = cast<ValueAsMetadata>(MD->getOperand(0).get());
     const GlobalVariable *IFuncUpdateGV = cast<GlobalVariable>(VAM->getValue());
     IFuncUpdateSym = getSymbol(IFuncUpdateGV);
-  }
-  else if (GI.hasMetadata(LLVMContext::MD_implicit_ref))
+  } else if (GI.hasMetadata(LLVMContext::MD_implicit_ref))
     emitRefMetadata(&GI);
 
   // generate linkage for foo and .foo

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3464,9 +3464,11 @@ static bool TOCRestoreNeededForCallToImplementation(const GlobalIFunc &GI) {
       }
       return Res;
     }
+    // clang-format off
     // @switch.table.resolve_foo = private unnamed_addr constant [3 x ptr] [ptr @foo_static, ptr @foo_hidden, ptr @foo_protected]
     // %switch.gep = getelementptr inbounds nuw ptr, ptr @switch.table, i64 %2
     // V = load ptr, ptr %switch.gep,
+    // clang-format on
     else if (auto *Op = getPointerOperand(I)) {
       while (isa<GEPOperator>(Op))
         Op = cast<GEPOperator>(Op)->getPointerOperand();

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3366,7 +3366,7 @@ void PPCAIXAsmPrinter::emitTTypeReference(const GlobalValue *GV,
 void PPCAIXAsmPrinter::emitRefMetadata(const GlobalObject *GO) {
   SmallVector<MDNode *> MDs;
   GO->getMetadata(LLVMContext::MD_implicit_ref, MDs);
-  assert(MDs.size() && "Expected asscoiated metadata nodes");
+  assert(MDs.size() && "Expected !implicit.ref metadata nodes");
 
   for (const MDNode *MD : MDs) {
     const ValueAsMetadata *VAM = cast<ValueAsMetadata>(MD->getOperand(0).get());

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3371,7 +3371,7 @@ void PPCAIXAsmPrinter::emitRefMetadata(const GlobalObject *GO) {
   for (const MDNode *MD : MDs) {
     const ValueAsMetadata *VAM = cast<ValueAsMetadata>(MD->getOperand(0).get());
     const GlobalValue *GV = cast<GlobalValue>(VAM->getValue());
-    MCSymbol *Referenced = TM.getSymbol(GV);
+    MCSymbol *Referenced = isa<Function>(GV) ? getObjFileLowering().getFunctionEntryPointSymbol(GV, TM) : TM.getSymbol(GV);
     OutStreamer->emitXCOFFRefDirective(Referenced);
   }
 }

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3415,7 +3415,17 @@ void PPCAIXAsmPrinter::emitModuleCommandLines(Module &M) {
 }
 
 static bool TOCRestoreNeededForCallToImplementation(const GlobalIFunc &GI) {
-  enum class IsLocal { Unknown, True, False };
+  enum class IsLocal {
+    Unknown, // Structure of the llvm::Value is not one of the recognizable
+             // structures, and so it's unknown if the llvm::Value is the
+             // address of a local function at runtime.
+    True,    // We can statically prove that all runtime values of the
+             // llvm::Value is an address of a local function.
+    False    // We can statically prove that one of the runtime values of the
+             // llvm::Value is the address of a non-local function; it could be
+             // the case that at runtime the non-local function is never
+             // selected but we don't care.
+  };
   auto Combine = [](IsLocal LHS, IsLocal RHS) -> IsLocal {
     if (LHS == IsLocal::False || RHS == IsLocal::False)
       return IsLocal::False;

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3418,20 +3418,7 @@ void PPCAIXAsmPrinter::emitModuleCommandLines(Module &M) {
 static bool TOCRestoreNeededForCallToImplementation(const GlobalIFunc &GI) {
   // Query if the given function is local to the load module.
   auto IsLocalFunc = [](const Function *F) {
-    // Static functions are local
-    if (F->getLinkage() == GlobalValue::InternalLinkage)
-      return true;
-    // We treat declarations as non-local because the visibility attribute
-    // on a declaration might not match the definition, and AIX linker
-    // ignores the visibility on a reference.
-    if (F->isDeclarationForLinker())
-      return false;
-    // hidden or protected visibility definitions cannot be preempted.
-    if (F->getVisibility() == GlobalValue::HiddenVisibility ||
-        F->getVisibility() == GlobalValue::ProtectedVisibility)
-      return true;
-
-    return false;
+    return F->isStrongDefinitionForLinker() && F->isDSOLocal();
   };
   // Recursive walker that checks if all possible runtime values of the given
   // llvm::Value are addresses of local functions.

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2890,8 +2890,7 @@ void PPCAIXAsmPrinter::emitFunctionDescriptor() {
       static_cast<MCSymbolXCOFF *>(CurrentFnDescSym)->getRepresentedCsect());
 
   // Emit aliasing label for function descriptor csect.
-  if (MF) // TODO MF is unset when processing an ifunc, handle it better than
-          // this.
+  if (MF)
     for (const GlobalAlias *Alias : GOAliasMap[&MF->getFunction()])
       OutStreamer->emitLabel(getSymbol(Alias));
 
@@ -2911,19 +2910,15 @@ void PPCAIXAsmPrinter::emitFunctionDescriptor() {
 }
 
 void PPCAIXAsmPrinter::emitFunctionEntryLabel() {
-  if (!MF) { // TODO: MF is unset when processing an ifunc, handle it better.
-    if (!TM.getFunctionSections())
-      PPCAsmPrinter::emitFunctionEntryLabel();
-    return;
-  }
-
   // For functions without user defined section, it's not necessary to emit the
   // label when we have individual function in its own csect.
-  if (!TM.getFunctionSections() || MF->getFunction().hasSection())
+  if (!TM.getFunctionSections() || (MF && MF->getFunction().hasSection()))
     PPCAsmPrinter::emitFunctionEntryLabel();
 
-  const Function *F = &MF->getFunction();
+  if (!MF)
+    return;
 
+  const Function *F = &MF->getFunction();
   // Emit aliasing label for function entry point label.
   for (const GlobalAlias *Alias : GOAliasMap[F])
     OutStreamer->emitLabel(

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3436,6 +3436,8 @@ static bool TOCRestoreNeededForCallToImplementation(const GlobalIFunc &GI) {
 
   // Query if the given function is local to the load module.
   auto IsLocalFunc = [](const Function *F) -> IsLocal {
+    // We require a definition, because the AIX linker chooses the visibility
+    // of a symbol based on the definition (ignoring the declaration).
     bool Result = F->isStrongDefinitionForLinker() && F->isDSOLocal();
     LLVM_DEBUG(dbgs() << F->getName() << " is "
                       << (Result ? "local\n" : "not local\n"));

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -2892,6 +2892,7 @@ void PPCAIXAsmPrinter::emitFunctionDescriptor() {
       static_cast<MCSymbolXCOFF *>(CurrentFnDescSym)->getRepresentedCsect());
 
   // Emit aliasing label for function descriptor csect.
+  // An Ifunc doesn't have a corresponding machine function.
   if (MF)
     for (const GlobalAlias *Alias : GOAliasMap[&MF->getFunction()])
       OutStreamer->emitLabel(getSymbol(Alias));
@@ -2917,6 +2918,7 @@ void PPCAIXAsmPrinter::emitFunctionEntryLabel() {
   if (!TM.getFunctionSections() || (MF && MF->getFunction().hasSection()))
     PPCAsmPrinter::emitFunctionEntryLabel();
 
+  // an ifunc does not have an associated MachineFunction
   if (!MF)
     return;
 

--- a/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
+++ b/llvm/lib/Target/PowerPC/PPCAsmPrinter.cpp
@@ -3599,10 +3599,9 @@ void PPCAIXAsmPrinter::emitGlobalIFunc(Module &M, const GlobalIFunc &GI) {
   // generate the code for .foo now:
   if (TOCRestoreNeededForCallToImplementation(GI)) {
     reportFatalUsageError(
-        "unimplemented: TOC register save/restore needed for function " +
-        Twine(GI.getName()) +
-        ", because couldn't prove all candidates are static or hidden/protected"
-        " visibility definitions");
+        "unimplemented: TOC register save/restore needed for ifunc \"" +
+        Twine(GI.getName()) + "\", because couldn't prove all candidates are "
+        "static or hidden/protected visibility definitions");
     return;
   }
 

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -5436,7 +5436,7 @@ static SDValue transformCallee(const SDValue &Callee, SelectionDAG &DAG,
     const GlobalValue *GV = cast<GlobalAddressSDNode>(Callee)->getGlobal();
 
     if (Subtarget.isAIXABI()) {
-      assert(!isa<GlobalIFunc>(GV) && "IFunc is not supported on AIX.");
+      // TODO: convert ifunc to indirect call
       return getAIXFuncEntryPointSymbolSDNode(GV);
     }
     return DAG.getTargetGlobalAddress(GV, dl, Callee.getValueType(), 0,

--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -5436,7 +5436,6 @@ static SDValue transformCallee(const SDValue &Callee, SelectionDAG &DAG,
     const GlobalValue *GV = cast<GlobalAddressSDNode>(Callee)->getGlobal();
 
     if (Subtarget.isAIXABI()) {
-      // TODO: convert ifunc to indirect call
       return getAIXFuncEntryPointSymbolSDNode(GV);
     }
     return DAG.getTargetGlobalAddress(GV, dl, Callee.getValueType(), 0,

--- a/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
@@ -19,6 +19,7 @@
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
 #include <cassert>
 
 using namespace llvm;
@@ -26,6 +27,8 @@ using namespace llvm;
 #define DEBUG_TYPE "ppc-prep-ifunc-aix"
 
 STATISTIC(NumIFuncs, "Number of IFuncs prepared");
+
+extern cl::opt<bool> UseImplicitRef;
 
 namespace {
 class PPCPrepareIFuncsOnAIX : public ModulePass {
@@ -98,18 +101,24 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
     Constant *InitVals[] = {&IFunc, IFunc.getResolver()};
     GV->setInitializer(ConstantStruct::get(IFuncPairType, InitVals));
 
-    // Associate liveness of function foo with the liveness of update_foo.
-    IFunc.setMetadata(LLVMContext::MD_associated,
+    // Liveness of __update_foo is dependent on liveness of ifunc foo.
+    IFunc.setMetadata(UseImplicitRef ? LLVMContext::MD_implicit_ref : LLVMContext::MD_associated,
                       MDNode::get(Ctx, ValueAsMetadata::get(GV)));
-    // Make function foo depend on the constructor that calls each ifunc's
-    // resolver and updaTes the ifunc's function descriptor with the result.
-    // Note: technically, we can associate both the update_foo variable and
-    // the constructor function to function foo, but only one MD_associated
-    // is allowed on an llvm::Value, so associate the constructor to update_foo
-    // here.
-    GV->setMetadata(
-        LLVMContext::MD_associated,
-        MDNode::get(Ctx, ValueAsMetadata::get(IFuncConstructorDecl)));
+
+    // An implicit.ref creates linkage dependency, so make function foo require
+    // the constructor that calls each ifunc's resolver and saves the result in
+    // the ifunc's function descriptor.
+    if (UseImplicitRef)
+      IFunc.addMetadata(LLVMContext::MD_implicit_ref,
+         *MDNode::get(Ctx, ValueAsMetadata::get(IFuncConstructorDecl)));
+    else
+      // Note: technically, we can associate both the update_foo variable and
+      // the constructor function to function foo, but only one MD_associated
+      // is allowed on an llvm::Value, so associate the constructor to
+      // update_foo here.
+      GV->setMetadata(
+          LLVMContext::MD_associated,
+          MDNode::get(Ctx, ValueAsMetadata::get(IFuncConstructorDecl)));
   }
 
   return true;

--- a/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
@@ -83,13 +83,12 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
   for (GlobalIFunc &IFunc : M.ifuncs()) {
     NumIFuncs++;
     LLVM_DEBUG(dbgs() << "doing ifunc " << IFunc.getName() << "\n");
-    // @update_foo = internal global { ptr @foo, ptr @foo_resolver }, section
-    // "ifunc_sec", align 8
+    // @__update_foo = private global { ptr @foo, ptr @foo_resolver },
+    //   section "ifunc_sec"
     std::string Name = (Twine(IFuncUpdatePrefix) + IFunc.getName()).str();
     auto *GV = new GlobalVariable(M, IFuncPairType, /*isConstant*/ false,
                                   GlobalValue::PrivateLinkage, nullptr, Name);
     GV->setAlignment(DL.getPointerPrefAlignment());
-    GV->setVisibility(GlobalValue::DefaultVisibility);
     GV->setSection(IFuncUpdateSectionName);
 
     // Note that on AIX, the address of a function is the address of it's

--- a/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
@@ -81,6 +81,7 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
                        IFuncConstructorName, M);
 
   for (GlobalIFunc &IFunc : M.ifuncs()) {
+    NumIFuncs++;
     LLVM_DEBUG(dbgs() << "doing ifunc " << IFunc.getName() << "\n");
     // @update_foo = internal global { ptr @foo, ptr @foo_resolver }, section
     // "ifunc_sec", align 8
@@ -109,15 +110,7 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
     GV->setMetadata(
         LLVMContext::MD_associated,
         MDNode::get(Ctx, ValueAsMetadata::get(IFuncConstructorDecl)));
-
-    MDNode *MD = GV->getMetadata(LLVMContext::MD_associated);
-    assert(MD);
-    LLVM_DEBUG(MD->dump());
-    MD = IFunc.getMetadata(LLVMContext::MD_associated);
-    assert(MD);
-    LLVM_DEBUG(MD->dump());
   }
-  LLVM_DEBUG(M.dump());
 
   return true;
 }

--- a/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
@@ -71,7 +71,7 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
   LLVMContext &Ctx = M.getContext();
   auto *PtrTy = PointerType::getUnqual(Ctx);
   StringRef IFuncUpdatePrefix = "__update_";
-  StringRef IFuncUpdateSectionName = "ifunc_sec";
+  StringRef IFuncUpdateSectionName = "__ifunc_sec";
   StructType *IFuncPairType = StructType::get(PtrTy, PtrTy);
 
   StringRef IFuncConstructorName = "__init_ifuncs";
@@ -83,7 +83,7 @@ bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
 
   for (GlobalIFunc &IFunc : M.ifuncs()) {
     NumIFuncs++;
-    LLVM_DEBUG(dbgs() << "doing ifunc " << IFunc.getName() << "\n");
+    LLVM_DEBUG(dbgs() << "expanding ifunc " << IFunc.getName() << "\n");
     // @__update_foo = private global { ptr @foo, ptr @foo_resolver },
     //   section "ifunc_sec"
     std::string Name = (Twine(IFuncUpdatePrefix) + IFunc.getName()).str();

--- a/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
+++ b/llvm/lib/Target/PowerPC/PPCPrepareIFuncsOnAIX.cpp
@@ -1,0 +1,123 @@
+//===-- PPCPrepareIFuncsOnAIX.cpp - Prepare for ifunc lowering in codegen ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass generates...
+//
+//===----------------------------------------------------------------------===//
+
+#include "PPC.h"
+#include "PPCSubtarget.h"
+#include "PPCTargetMachine.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/CodeGen/TargetPassConfig.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include <cassert>
+
+using namespace llvm;
+
+#define DEBUG_TYPE "ppc-prep-ifunc-aix"
+
+STATISTIC(NumIFuncs, "Number of IFuncs prepared");
+
+namespace {
+class PPCPrepareIFuncsOnAIX : public ModulePass {
+public:
+  static char ID;
+
+  PPCPrepareIFuncsOnAIX() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+
+  StringRef getPassName() const override {
+    return "PPC Prepare for AIX IFunc lowering";
+  }
+};
+} // namespace
+
+char PPCPrepareIFuncsOnAIX::ID = 0;
+
+INITIALIZE_PASS(PPCPrepareIFuncsOnAIX, DEBUG_TYPE,
+                "PPC Prepare for AIX IFunc lowering", false, false)
+
+ModulePass *llvm::createPPCPrepareIFuncsOnAIXPass() {
+  return new PPCPrepareIFuncsOnAIX();
+}
+
+// @foo = ifunc i32 (), ptr @foo_resolver, !associated !0
+// define ptr @foo_resolver() {
+//  ...
+//
+// %struct.IFUNC_PAIR = type { ptr, ptr }
+// @update_foo = internal global %struct.IFUNC_PAIR { ptr @foo, ptr
+// @foo_resolver }, section "ifunc_sec", align 8, !associated !1 declare void
+// @__init_ifuncs(...)
+//
+// !0 = !{ptr @update_foo}
+// !1 = !{ptr @__init_ifuncs}
+bool PPCPrepareIFuncsOnAIX::runOnModule(Module &M) {
+  if (M.ifuncs().empty())
+    return false;
+
+  const DataLayout &DL = M.getDataLayout();
+  LLVMContext &Ctx = M.getContext();
+  auto *PtrTy = PointerType::getUnqual(Ctx);
+  StringRef IFuncUpdatePrefix = "__update_";
+  StringRef IFuncUpdateSectionName = "ifunc_sec";
+  StructType *IFuncPairType = StructType::get(PtrTy, PtrTy);
+
+  StringRef IFuncConstructorName = "__init_ifuncs";
+  auto *IFuncConstructorFnType =
+      FunctionType::get(Type::getVoidTy(Ctx), {}, /*isVarArg=*/false);
+  auto *IFuncConstructorDecl =
+      Function::Create(IFuncConstructorFnType, GlobalValue::ExternalLinkage,
+                       IFuncConstructorName, M);
+
+  for (GlobalIFunc &IFunc : M.ifuncs()) {
+    LLVM_DEBUG(dbgs() << "doing ifunc " << IFunc.getName() << "\n");
+    // @update_foo = internal global { ptr @foo, ptr @foo_resolver }, section
+    // "ifunc_sec", align 8
+    std::string Name = (Twine(IFuncUpdatePrefix) + IFunc.getName()).str();
+    auto *GV = new GlobalVariable(M, IFuncPairType, /*isConstant*/ false,
+                                  GlobalValue::PrivateLinkage, nullptr, Name);
+    GV->setAlignment(DL.getPointerPrefAlignment());
+    GV->setVisibility(GlobalValue::DefaultVisibility);
+    GV->setSection(IFuncUpdateSectionName);
+
+    // Note that on AIX, the address of a function is the address of it's
+    // function descriptor, which is what these two values end up being
+    // in assembly.
+    Constant *InitVals[] = {&IFunc, IFunc.getResolver()};
+    GV->setInitializer(ConstantStruct::get(IFuncPairType, InitVals));
+
+    // Associate liveness of function foo with the liveness of update_foo.
+    IFunc.setMetadata(LLVMContext::MD_associated,
+                      MDNode::get(Ctx, ValueAsMetadata::get(GV)));
+    // Make function foo depend on the constructor that calls each ifunc's
+    // resolver and updaTes the ifunc's function descriptor with the result.
+    // Note: technically, we can associate both the update_foo variable and
+    // the constructor function to function foo, but only one MD_associated
+    // is allowed on an llvm::Value, so associate the constructor to update_foo
+    // here.
+    GV->setMetadata(
+        LLVMContext::MD_associated,
+        MDNode::get(Ctx, ValueAsMetadata::get(IFuncConstructorDecl)));
+
+    MDNode *MD = GV->getMetadata(LLVMContext::MD_associated);
+    assert(MD);
+    LLVM_DEBUG(MD->dump());
+    MD = IFunc.getMetadata(LLVMContext::MD_associated);
+    assert(MD);
+    LLVM_DEBUG(MD->dump());
+  }
+  LLVM_DEBUG(M.dump());
+
+  return true;
+}

--- a/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
+++ b/llvm/lib/Target/PowerPC/PPCTargetMachine.cpp
@@ -145,6 +145,7 @@ LLVMInitializePowerPCTarget() {
   initializeGlobalISel(PR);
   initializePPCCTRLoopsPass(PR);
   initializePPCDAGToDAGISelLegacyPass(PR);
+  initializePPCPrepareIFuncsOnAIXPass(PR);
   initializePPCLinuxAsmPrinterPass(PR);
   initializePPCAIXAsmPrinterPass(PR);
 }
@@ -437,6 +438,9 @@ void PPCPassConfig::addIRPasses() {
     // invariant.
     addPass(createLICMPass());
   }
+
+  if (TM->getTargetTriple().isOSAIX())
+    addPass(createPPCPrepareIFuncsOnAIXPass());
 
   TargetPassConfig::addIRPasses();
 }

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-alias.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-alias.ll
@@ -1,0 +1,16 @@
+; XFAIL: *
+; RUN: llc -mtriple=powerpc64-ibm-aix-xcoff %s -o - | FileCheck %s
+
+@foo_alias = alias i32 (...), ptr @my_foo
+@foo = ifunc i32 (...), ptr @foo.resolver
+
+define hidden i32 @my_foo() {
+entry:
+  ret i32 4
+}
+
+define internal ptr @foo.resolver() {
+entry:
+  ret ptr @my_foo
+}
+

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-debug.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-debug.ll
@@ -1,0 +1,33 @@
+; RUN: llc -mtriple=powerpc64-ibm-aix-xcoff -verify-machineinstrs %s -o - | FileCheck %s
+; RUN: llc -mtriple=powerpc-ibm-aix-xcoff -verify-machineinstrs %s -o - | FileCheck %s
+
+; CHECK:     .foo:
+; CHECK:         bctr
+; CHECK-NEXT: L..sec_end0:
+
+@foo = ifunc i32 (...), ptr @foo.resolver
+
+define internal ptr @foo.resolver() #0 !dbg !7 {
+entry:
+  ret ptr @my_foo2, !dbg !10
+}
+
+; Function Attrs: nounwind
+define internal i32 @my_foo2() #1 !dbg !11 {
+entry:
+  ret i32 5, !dbg !12
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 22.0.0git (git@github.ibm.com:compiler/llvm-project.git e963806df98c6d2e52573efbb8890ec72e5dd745)", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/home/wyehia/Source/scripts.fmv/fmv/ifunc/proto2")
+!2 = !{i32 7, !"Dwarf Version", i32 3}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = distinct !DISubprogram(name: "foo_resolver", scope: !1, file: !1, line: 7, type: !8, scopeLine: 7, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, keyInstructions: true)
+!8 = !DISubroutineType(types: !9)
+!9 = !{}
+!10 = !DILocation(line: 7, scope: !7, atomGroup: 1, atomRank: 1)
+!11 = distinct !DISubprogram(name: "my_foo2", scope: !1, file: !1, line: 2, type: !8, scopeLine: 2, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition | DISPFlagOptimized, unit: !0, keyInstructions: true)
+!12 = !DILocation(line: 2, scope: !11, atomGroup: 1, atomRank: 1)

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-obj.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-obj.ll
@@ -1,0 +1,66 @@
+; RUN: llc -mtriple=powerpc64-ibm-aix-xcoff %s --filetype=obj -o %t.o
+; RUN: llvm-objdump -D -r --symbol-description %t.o | FileCheck %s --check-prefixes=CHECK,CHECK-NO-FS
+
+; RUN: llc -mtriple=powerpc64-ibm-aix-xcoff %s --function-sections --filetype=obj -o %t.o
+; RUN: llvm-objdump -D -r --symbol-description %t.o | FileCheck %s --check-prefixes=CHECK,CHECK-FS
+
+; CHECK: Disassembly of section .text:
+;;;; R_REF relocations associating .foo to (1) the __init_ifuncs constructor
+;;;; and (2) the __update_foo variable.
+; CHECK-NO-FS:          0000000000000000:  R_REF  {{.*}} __ifunc_sec[RW]
+; CHECK-NO-FS-NEXT:     0000000000000000:  R_REF  {{.*}} .__init_ifuncs[PR]
+
+;;;; .foo ifunc stub
+; CHECK-NO-FS:   .foo:
+; CHECK-NO-FS-NEXT:   ld 12, 8(2)
+; CHECK-NO-FS-NEXT:      R_TOC {{.*}} foo[TC]
+; CHECK-NO-FS-NEXT:   ld 11, 16(12)
+; CHECK-NO-FS-NEXT:   ld 12, 0(12)
+; CHECK-NO-FS-NEXT:   mtctr 12
+; CHECK-NO-FS-NEXT:   bctr
+
+; CHECK-FS:   .foo[PR]:
+; CHECK-FS-NEXT:   ld 12, 8(2)
+; CHECK-FS-NEXT:      R_REF {{.*}} __ifunc_sec[RW]
+; CHECK-FS-NEXT:      R_REF {{.*}} .__init_ifuncs[PR]
+; CHECK-FS-NEXT:      R_TOC {{.*}} foo[TC]
+; CHECK-FS-NEXT:   ld 11, 16(12)
+; CHECK-FS-NEXT:   ld 12, 0(12)
+; CHECK-FS-NEXT:   mtctr 12
+; CHECK-FS-NEXT:   bctr
+
+; CHECK:   Disassembly of section .data:
+;;;; section __ifunc_sec holding the [foo:foo_resolver] pairs
+;;;; @__update_foo = private global { ptr, ptr } { ptr @foo, ptr @foo.resolver }, section "__ifunc_sec", align 8
+; CHECK:  {{.*}} __ifunc_sec[RW]:
+; CHECK-NEXT:  00 00 00 00   <unknown>
+; CHECK-NEXT:       R_POS  {{.*}} foo[DS]
+; CHECK-NEXT:  {{.*}}  <unknown>
+; CHECK-NEXT:  00 00 00 00   <unknown>
+; CHECK-NEXT:       R_POS  {{.*}} foo.resolver[DS]
+
+;;;; A function descriptor for foo
+; CHECK:  {{.*}} foo[DS]:
+; CHECK-NEXT:  00 00 00 00   <unknown>
+; CHECK-NEXT:       R_POS  {{.*}} .foo
+; CHECK-NEXT:  {{.*}}  <unknown>
+; CHECK-NEXT:  00 00 00 00  <unknown>
+; CHECK-NEXT:       R_POS  {{.*}} TOC[TC0]
+
+;;;; foo's TOC
+; CHECK: {{.*}} foo[TC]:
+; CHECK-NEXT:  00 00 00 00   <unknown>
+; CHECK-NEXT:       R_POS  {{.*}} foo[DS]
+; CHECK-NEXT:  {{.*}}  <unknown>
+
+@foo = ifunc i32 (...), ptr @foo.resolver
+
+define hidden i32 @my_foo() {
+entry:
+  ret i32 4
+}
+
+define internal ptr @foo.resolver() {
+entry:
+  ret ptr @my_foo
+}

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query-neg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query-neg.ll
@@ -3,57 +3,92 @@
 
 ; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff -test-ifunc-warn-noerror -filetype=obj -o /dev/null 2>&1 | FileCheck %s
 
-; CHECK: TOC register save/restore needed for ifunc "foo_extern"
-; CHECK: TOC register save/restore needed for ifunc "foo_decl"
-; CHECK: TOC register save/restore needed for ifunc "foo_weak_hidden"
-; CHECK: TOC register save/restore needed for ifunc "foo_weak_protected"
-; CHECK: TOC register save/restore needed for ifunc "foo_weak_extern"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_decl_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_default_decl_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_weak_decl_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_hidden_weak_decl_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_protected_weak_decl_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_default_weak_decl_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_def_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_default_def_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_weak_def_ifunc"
+; CHECK: TOC register save/restore needed for ifunc "foo_ext_default_weak_def_ifunc"
 
-@foo_extern = ifunc i32 (...), ptr @resolve_extern
-@foo_decl = ifunc i32 (...), ptr @resolve_decl
-@foo_weak_hidden = ifunc i32 (...), ptr @resolve_weak_hidden
-@foo_weak_protected = ifunc i32 (...), ptr @resolve_weak_protected
-@foo_weak_extern = ifunc i32 (...), ptr @resolve_weak_extern
 
-define i32 @bar_extern() {
+define void @foo_ext_def() {
 entry:
-  ret i32 5
+  ret void
 }
-define internal nonnull ptr @resolve_extern() {
+define void @foo_ext_default_def() {
 entry:
-  ret ptr @bar_extern
+  ret void
+}
+define weak void @foo_ext_default_weak_def() {
+entry:
+  ret void
+}
+define weak void @foo_ext_weak_def() {
+entry:
+  ret void
+}
+declare void @foo_ext_decl(...) 
+declare void @foo_ext_default_decl(...) 
+declare extern_weak void @foo_ext_weak_decl(...) 
+declare extern_weak hidden void @foo_ext_hidden_weak_decl(...) 
+declare extern_weak protected void @foo_ext_protected_weak_decl(...) 
+declare extern_weak void @foo_ext_default_weak_decl(...) 
+
+
+define internal ptr @foo_ext_decl_resolver() {
+entry:
+  ret ptr @foo_ext_decl
+}
+define internal ptr @foo_ext_default_decl_resolver() {
+entry:
+  ret ptr @foo_ext_default_decl
+}
+define internal ptr @foo_ext_weak_decl_resolver() {
+entry:
+  ret ptr @foo_ext_weak_decl
+}
+define internal ptr @foo_ext_hidden_weak_decl_resolver() {
+entry:
+  ret ptr @foo_ext_hidden_weak_decl
+}
+define internal ptr @foo_ext_protected_weak_decl_resolver() {
+entry:
+  ret ptr @foo_ext_protected_weak_decl
+}
+define internal ptr @foo_ext_default_weak_decl_resolver() {
+entry:
+  ret ptr @foo_ext_default_weak_decl
+}
+define internal ptr @foo_ext_def_resolver() {
+entry:
+  ret ptr @foo_ext_def
+}
+define internal ptr @foo_ext_default_def_resolver() {
+entry:
+  ret ptr @foo_ext_default_def
+}
+define internal ptr @foo_ext_weak_def_resolver() {
+entry:
+  ret ptr @foo_ext_weak_def
+}
+define internal ptr @foo_ext_default_weak_def_resolver() {
+entry:
+  ret ptr @foo_ext_default_weak_def
 }
 
-declare i32 @bar_decl()
-define internal nonnull ptr @resolve_decl() {
-entry:
-  ret ptr @bar_decl
-}
+@foo_ext_decl_ifunc = ifunc i32 (...), ptr @foo_ext_decl_resolver
+@foo_ext_default_decl_ifunc = ifunc i32 (...), ptr @foo_ext_default_decl_resolver
+@foo_ext_weak_decl_ifunc = ifunc i32 (...), ptr @foo_ext_weak_decl_resolver
+@foo_ext_hidden_weak_decl_ifunc = ifunc i32 (...), ptr @foo_ext_hidden_weak_decl_resolver
+@foo_ext_protected_weak_decl_ifunc = ifunc i32 (...), ptr @foo_ext_protected_weak_decl_resolver
+@foo_ext_default_weak_decl_ifunc = ifunc i32 (...), ptr @foo_ext_default_weak_decl_resolver
+@foo_ext_def_ifunc = ifunc i32 (...), ptr @foo_ext_def_resolver
+@foo_ext_default_def_ifunc = ifunc i32 (...), ptr @foo_ext_default_def_resolver
+@foo_ext_weak_def_ifunc = ifunc i32 (...), ptr @foo_ext_weak_def_resolver
+@foo_ext_default_weak_def_ifunc = ifunc i32 (...), ptr @foo_ext_default_weak_def_resolver
 
-define weak hidden i32 @bar_weak_hidden() {
-entry:
-  ret i32 2
-}
-define internal nonnull ptr @resolve_weak_hidden() {
-entry:
-  ret ptr @bar_weak_hidden
-}
-
-define weak protected i32 @bar_weak_protected() {
-entry:
-  ret i32 3
-}
-define internal nonnull ptr @resolve_weak_protected() {
-entry:
-  ret ptr @bar_weak_protected
-}
-
-define weak i32 @bar_weak_extern() {
-entry:
-  ret i32 5
-}
-define internal nonnull ptr @resolve_weak_extern() {
-entry:
-  ret ptr @bar_weak_extern
-}
 

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query-neg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query-neg.ll
@@ -57,9 +57,3 @@ entry:
   ret ptr @bar_weak_extern
 }
 
-!llvm.module.flags = !{!0, !1, !2}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 8, !"PIC Level", i32 2}
-!2 = !{i32 7, !"frame-pointer", i32 2}
-

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query-neg.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query-neg.ll
@@ -1,0 +1,65 @@
+; This testcase is for testing the negative return values of the
+; TOCRestoreNeededForCallToImplementation query.
+
+; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff -test-ifunc-warn-noerror -filetype=obj -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: TOC register save/restore needed for ifunc "foo_extern"
+; CHECK: TOC register save/restore needed for ifunc "foo_decl"
+; CHECK: TOC register save/restore needed for ifunc "foo_weak_hidden"
+; CHECK: TOC register save/restore needed for ifunc "foo_weak_protected"
+; CHECK: TOC register save/restore needed for ifunc "foo_weak_extern"
+
+@foo_extern = ifunc i32 (...), ptr @resolve_extern
+@foo_decl = ifunc i32 (...), ptr @resolve_decl
+@foo_weak_hidden = ifunc i32 (...), ptr @resolve_weak_hidden
+@foo_weak_protected = ifunc i32 (...), ptr @resolve_weak_protected
+@foo_weak_extern = ifunc i32 (...), ptr @resolve_weak_extern
+
+define i32 @bar_extern() {
+entry:
+  ret i32 5
+}
+define internal nonnull ptr @resolve_extern() {
+entry:
+  ret ptr @bar_extern
+}
+
+declare i32 @bar_decl()
+define internal nonnull ptr @resolve_decl() {
+entry:
+  ret ptr @bar_decl
+}
+
+define weak hidden i32 @bar_weak_hidden() {
+entry:
+  ret i32 2
+}
+define internal nonnull ptr @resolve_weak_hidden() {
+entry:
+  ret ptr @bar_weak_hidden
+}
+
+define weak protected i32 @bar_weak_protected() {
+entry:
+  ret i32 3
+}
+define internal nonnull ptr @resolve_weak_protected() {
+entry:
+  ret ptr @bar_weak_protected
+}
+
+define weak i32 @bar_weak_extern() {
+entry:
+  ret i32 5
+}
+define internal nonnull ptr @resolve_weak_extern() {
+entry:
+  ret ptr @bar_weak_extern
+}
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query.ll
@@ -2,38 +2,76 @@
 ; TOCRestoreNeededForCallToImplementation query, specifically the type of
 ; functions that are considered DSO local on AIX.
 
-; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff --function-sections  -filetype=obj -o /dev/null
-; RUN: llc < %s -mtriple=powerpc-ibm-aix-xcoff --function-sections  -filetype=obj -o /dev/null
-; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff -ifunc-local-if-proven=1 -o /dev/null
+; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff --function-sections  -filetype=obj -o /dev/null -debug-only=asmprinter 2>&1 | FileCheck %s
+; RUN: llc < %s -mtriple=powerpc-ibm-aix-xcoff --function-sections  -filetype=obj -o /dev/null -debug-only=asmprinter 2>&1 | FileCheck %s
+; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff -ifunc-local-if-proven=1 -o /dev/null -debug-only=asmprinter 2>&1 | FileCheck %s
+
+; CHECK: foo_ext_hidden_decl is dso_local
+; CHECK: foo_ext_hidden_def is dso_local
+; CHECK: foo_ext_hidden_weak_def is dso_local
+; CHECK: foo_ext_protected_decl is dso_local
+; CHECK: foo_ext_protected_def is dso_local
+; CHECK: foo_ext_protected_weak_def is dso_local
+; CHECK: foo_static is dso_local
+
+; The following decls/defs are dso_local in the IR, and it matches the behaviour on AIX in practice
+; (1) a hidden/protected declaration should have a matching definition in the same shared object,
+;     with the matching visibility. So the definition is not interposable due to hidden/protected.
+; (2) a hidden/protected definition is not interposable.
+; (3) attribute weak has no effect on interposition, and if a strong definition in the same shared object
+;     exists, then it's a user error to have that definition have conflicting visibility.
+;     In practice, on AIX the linker will silently pick the strong definition and keep it's visibility
+;     ignoring what's on the weak definition.
+;     On Linux, both ld and lld pick the strong definition but give it the most restrictive visibility based
+;     on the candidates available (so a weak hidden and a strong default will yield a hidden strong)
+;
+declare hidden void @foo_ext_hidden_decl(...)                 ; (1)
+
+declare protected void @foo_ext_protected_decl(...)           ; (1)
+
+define hidden void @foo_ext_hidden_def() {                    ; (2)
+entry:
+  ret void
+}
+
+define protected void @foo_ext_protected_def() {              ; (2)
+entry:
+  ret void
+}
+
+define weak hidden void @foo_ext_hidden_weak_def() {          ; (3)
+entry:
+  ret void
+}
+
+define weak protected void @foo_ext_protected_weak_def() {    ; (3)
+entry:
+  ret void
+}
+
+define internal void @foo_static() {
+entry:
+  ret void
+}
+
+@foo = ifunc void (...), ptr @resolve_foo
 
 @x = global i32 0, align 4
 
-; "hidden" or "internal" visibility function. "internal" would also have the
-; local_unnamed_addr IR attribute but we don't test it here because it's
-; considered by the query we're testing.
-define hidden i32 @foo_hidden() #0 {
-entry:
-  ret i32 2
-}
-
-define protected i32 @foo_protected() #0 {
-entry:
-  ret i32 3
-}
-
-define internal i32 @foo_static() #0 {
-entry:
-  ret i32 1
-}
-
-@foo = ifunc i32 (...), ptr @resolve_foo
+@switch.table.bar = private unnamed_addr constant [6 x ptr] [ptr @foo_ext_hidden_decl, ptr @foo_ext_hidden_def, ptr @foo_ext_hidden_weak_def, ptr @foo_ext_protected_decl, ptr @foo_ext_protected_def, ptr @foo_ext_protected_weak_def], align 4
 
 define internal nonnull ptr @resolve_foo() {
 entry:
-  %0 = load i32, ptr @x, align 4
-  %switch.selectcmp = icmp eq i32 %0, 1
-  %switch.select = select i1 %switch.selectcmp, ptr @foo_hidden, ptr @foo_static
-  %switch.selectcmp3 = icmp eq i32 %0, 2
-  %switch.select4 = select i1 %switch.selectcmp3, ptr @foo_protected, ptr %switch.select
-  ret ptr %switch.select4
+  %x = load i32, ptr @x, align 4
+  %0 = icmp ult i32 %x, 6
+  br i1 %0, label %switch.lookup, label %return
+
+switch.lookup:                                    ; preds = %entry
+  %switch.gep = getelementptr inbounds nuw ptr, ptr @switch.table.bar, i32 %x
+  %switch.load = load ptr, ptr %switch.gep, align 4
+  br label %return
+
+return:                                           ; preds = %entry, %switch.lookup
+  %retval.0 = phi ptr [ %switch.load, %switch.lookup ], [ @foo_static, %entry ]
+  ret ptr %retval.0
 }

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query.ll
@@ -37,9 +37,3 @@ entry:
   %switch.select4 = select i1 %switch.selectcmp3, ptr @foo_protected, ptr %switch.select
   ret ptr %switch.select4
 }
-
-!llvm.module.flags = !{!0, !1, !2}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 8, !"PIC Level", i32 2}
-!2 = !{i32 7, !"frame-pointer", i32 2}

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc-toc-restore-query.ll
@@ -1,0 +1,45 @@
+; This testcase is for testing the positive return values of the
+; TOCRestoreNeededForCallToImplementation query, specifically the type of
+; functions that are considered DSO local on AIX.
+
+; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff --function-sections  -filetype=obj -o /dev/null
+; RUN: llc < %s -mtriple=powerpc-ibm-aix-xcoff --function-sections  -filetype=obj -o /dev/null
+; RUN: llc < %s -mtriple=powerpc64-ibm-aix-xcoff -ifunc-local-if-proven=1 -o /dev/null
+
+@x = global i32 0, align 4
+
+; "hidden" or "internal" visibility function. "internal" would also have the
+; local_unnamed_addr IR attribute but we don't test it here because it's
+; considered by the query we're testing.
+define hidden i32 @foo_hidden() #0 {
+entry:
+  ret i32 2
+}
+
+define protected i32 @foo_protected() #0 {
+entry:
+  ret i32 3
+}
+
+define internal i32 @foo_static() #0 {
+entry:
+  ret i32 1
+}
+
+@foo = ifunc i32 (...), ptr @resolve_foo
+
+define internal nonnull ptr @resolve_foo() {
+entry:
+  %0 = load i32, ptr @x, align 4
+  %switch.selectcmp = icmp eq i32 %0, 1
+  %switch.select = select i1 %switch.selectcmp, ptr @foo_hidden, ptr @foo_static
+  %switch.selectcmp3 = icmp eq i32 %0, 2
+  %switch.select4 = select i1 %switch.selectcmp3, ptr @foo_protected, ptr %switch.select
+  ret ptr %switch.select4
+}
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"frame-pointer", i32 2}

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc.ll
@@ -19,15 +19,17 @@
 
 ;;;; declare foo[DS] and .foo[PR]
 ; FUNCSECT-NEXT:       .csect .foo[PR],5
+; FUNCSECT-NEXT:       .ref L..__update_foo
+; FUNCSECT-NEXT:       .ref .__init_ifuncs[PR]
 ; FUNCSECT-NEXT:       .globl  foo[DS]
 ; FUNCSECT-NEXT:       .globl  .foo[PR]
-; FUNCSECT-NEXT:       .lglobl L..__update_foo
 ; FUNCSECT-NEXT:       .align  2
 
 ; NO-FUNCSECT-NEXT:    .csect ..text..[PR],5
+; NO-FUNCSECT-NEXT:    .ref L..__update_foo
+; NO-FUNCSECT-NEXT:    .ref .__init_ifuncs[PR]
 ; NO-FUNCSECT-NEXT:    .globl  foo[DS]
 ; NO-FUNCSECT-NEXT:    .globl  .foo
-; NO-FUNCSECT-NEXT:    .lglobl L..__update_foo
 ; NO-FUNCSECT-NEXT:    .align  2
 
 ;;;; define foo's descriptor
@@ -41,8 +43,6 @@
 ; FUNCSECT-NEXT:       .csect .foo[PR],5
 ; NO-FUNCSECT-NEXT:    .csect ..text..[PR],5
 ; NO-FUNCSECT-NEXT: .foo:
-; COMMON-NEXT:         .ref L..__update_foo
-; COMMON-NEXT:         .ref .__init_ifuncs[PR]
 ; COMMON-NEXT:         [[LOAD]] 12, [[FOO_TOC:.*]](2)
 ; COMMON-NEXT:         [[LOAD]] 11, [[OFF]](12)
 ; COMMON-NEXT:         [[LOAD]] 12, 0(12)

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc.ll
@@ -73,8 +73,3 @@ define internal ptr @foo.resolver() {
 entry:
   ret ptr @my_foo
 }
-
-!llvm.module.flags = !{!0, !1}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 8, !"PIC Level", i32 2}

--- a/llvm/test/CodeGen/PowerPC/aix-ifunc.ll
+++ b/llvm/test/CodeGen/PowerPC/aix-ifunc.ll
@@ -1,0 +1,69 @@
+; RUN: llc -mtriple=powerpc64-ibm-aix-xcoff %s -o - | FileCheck %s --check-prefixes=COMMON,NO-FUNCSECT -DALIGN=3 -DPTR_SIZE=8 -DLOAD=ld -DOFF=16
+; RUN: llc -mtriple=powerpc-ibm-aix-xcoff %s -o - | FileCheck %s --check-prefixes=COMMON,NO-FUNCSECT -DALIGN=2 -DPTR_SIZE=4 -DLOAD=lwz -DOFF=8
+
+; RUN: llc -mtriple=powerpc64-ibm-aix-xcoff --function-sections %s -o - | FileCheck %s --check-prefixes=COMMON,FUNCSECT -DALIGN=3 -DPTR_SIZE=8 -DLOAD=ld -DOFF=16
+; RUN: llc -mtriple=powerpc-ibm-aix-xcoff --function-sections %s -o - | FileCheck %s --check-prefixes=COMMON,FUNCSECT -DALIGN=2 -DPTR_SIZE=4 -DLOAD=lwz -DOFF=8
+
+;;;; section __ifunc_sec holding the [foo:foo_resolver] pairs
+; COMMON:              .csect __ifunc_sec[RW],2
+; COMMON-NEXT:         .align  [[ALIGN]]
+; COMMON-NEXT: L..__update_foo:
+; COMMON-NEXT:         .vbyte  [[PTR_SIZE]], foo[DS]
+; COMMON-NEXT:         .vbyte  [[PTR_SIZE]], foo.resolver[DS]
+
+;;;; forward declare the __init_ifuncs constructor
+; COMMON-NEXT:         .extern .__init_ifuncs[PR]
+
+;;;; declare foo[DS] and .foo[PR]
+; FUNCSECT-NEXT:       .csect .foo[PR],5
+; FUNCSECT-NEXT:       .globl  foo[DS]
+; FUNCSECT-NEXT:       .globl  .foo[PR]
+; FUNCSECT-NEXT:       .lglobl L..__update_foo
+; FUNCSECT-NEXT:       .align  2
+
+; NO-FUNCSECT-NEXT:    .csect ..text..[PR],5
+; NO-FUNCSECT-NEXT:    .globl  foo[DS]
+; NO-FUNCSECT-NEXT:    .globl  .foo
+; NO-FUNCSECT-NEXT:    .lglobl L..__update_foo
+; NO-FUNCSECT-NEXT:    .align  2
+
+;;;; define foo's descriptor
+; COMMON-NEXT:         .csect foo[DS],[[ALIGN]]
+; FUNCSECT-NEXT:       .vbyte  [[PTR_SIZE]], .foo[PR]
+; NO-FUNCSECT-NEXT:    .vbyte  [[PTR_SIZE]], .foo
+; COMMON-NEXT:         .vbyte  [[PTR_SIZE]], TOC[TC0]
+; COMMON-NEXT:         .vbyte  [[PTR_SIZE]], 0
+
+;;;; emit foo's body
+; FUNCSECT-NEXT:       .csect .foo[PR],5
+; NO-FUNCSECT-NEXT:    .csect ..text..[PR],5
+; NO-FUNCSECT-NEXT: .foo:
+; COMMON-NEXT:         .ref L..__update_foo
+; COMMON-NEXT:         .ref .__init_ifuncs[PR]
+; COMMON-NEXT:         [[LOAD]] 12, [[FOO_TOC:.*]](2)
+; COMMON-NEXT:         [[LOAD]] 11, [[OFF]](12)
+; COMMON-NEXT:         [[LOAD]] 12, 0(12)
+; COMMON-NEXT:         mtctr 12
+; COMMON-NEXT:         bctr
+
+;;;; foo's TOC entry
+; COMMON: [[FOO_TOC]]:
+; COMMON-NEXT:         .tc foo[TC],foo[DS]
+
+
+@foo = ifunc i32 (...), ptr @foo.resolver
+
+define hidden i32 @my_foo() {
+entry:
+  ret i32 4
+}
+
+define internal ptr @foo.resolver() {
+entry:
+  ret ptr @my_foo
+}
+
+!llvm.module.flags = !{!0, !1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}

--- a/llvm/test/CodeGen/PowerPC/ifunc-prepare.ll
+++ b/llvm/test/CodeGen/PowerPC/ifunc-prepare.ll
@@ -1,15 +1,13 @@
-; RUN: opt -ppc-prep-ifunc-aix -mtriple=powerpc64-ibm-aix-xcoff %s -S | FileCheck %s --check-prefixes=CHECK,CHECK64
-; RUN: opt -ppc-prep-ifunc-aix -mtriple=powerpc-ibm-aix-xcoff %s -S | FileCheck %s --check-prefixes=CHECK,CHECK32
+; RUN: opt -ppc-prep-ifunc-aix -mtriple=powerpc64-ibm-aix-xcoff %s -S | FileCheck %s -DALIGN=8
+; RUN: opt -ppc-prep-ifunc-aix -mtriple=powerpc-ibm-aix-xcoff %s -S | FileCheck %s -DALIGN=4
 
-; CHECK64: @__update_foo = private global { ptr, ptr } { ptr @foo, ptr @foo.resolver }, section "__ifunc_sec", align 8, !associated ![[#INIT_IFUNC:]]
-; CHECK64: @__update_bar = private global { ptr, ptr } { ptr @bar, ptr @bar.resolver }, section "__ifunc_sec", align 8, !associated ![[#INIT_IFUNC]]
-; CHECK32: @__update_foo = private global { ptr, ptr } { ptr @foo, ptr @foo.resolver }, section "__ifunc_sec", align 4, !associated ![[#INIT_IFUNC:]]
-; CHECK32: @__update_bar = private global { ptr, ptr } { ptr @bar, ptr @bar.resolver }, section "__ifunc_sec", align 4, !associated ![[#INIT_IFUNC]]
-; CHECK: @foo = ifunc i32 (...), ptr @foo.resolver, !associated ![[#UPDATE_FOO:]]
-; CHECK: @bar = ifunc void (i32, i1), ptr @bar.resolver, !associated ![[#UPDATE_BAR:]]
+; CHECK: @__update_foo = private global { ptr, ptr } { ptr @foo, ptr @foo.resolver }, section "__ifunc_sec", align [[ALIGN]] 
+; CHECK: @__update_bar = private global { ptr, ptr } { ptr @bar, ptr @bar.resolver }, section "__ifunc_sec", align [[ALIGN]]
+; CHECK: @foo = ifunc i32 (...), ptr @foo.resolver, !implicit.ref ![[#UPDATE_FOO:]], !implicit.ref ![[#INIT_IFUNC:]]
+; CHECK: @bar = ifunc void (i32, i1), ptr @bar.resolver, !implicit.ref ![[#UPDATE_BAR:]], !implicit.ref ![[#INIT_IFUNC]]
 ; CHECK: declare void @__init_ifuncs()
-; CHECK: ![[#INIT_IFUNC]] = !{ptr @__init_ifuncs}
 ; CHECK: ![[#UPDATE_FOO]] = !{ptr @__update_foo}
+; CHECK: ![[#INIT_IFUNC]] = !{ptr @__init_ifuncs}
 ; CHECK: ![[#UPDATE_BAR]] = !{ptr @__update_bar}
 
 @foo = ifunc i32 (...), ptr @foo.resolver

--- a/llvm/test/CodeGen/PowerPC/ifunc-prepare.ll
+++ b/llvm/test/CodeGen/PowerPC/ifunc-prepare.ll
@@ -1,0 +1,34 @@
+; RUN: opt -ppc-prep-ifunc-aix -mtriple=powerpc64-ibm-aix-xcoff %s -S | FileCheck %s --check-prefixes=CHECK,CHECK64
+; RUN: opt -ppc-prep-ifunc-aix -mtriple=powerpc-ibm-aix-xcoff %s -S | FileCheck %s --check-prefixes=CHECK,CHECK32
+
+; CHECK64: @__update_foo = private global { ptr, ptr } { ptr @foo, ptr @foo.resolver }, section "__ifunc_sec", align 8, !associated ![[#INIT_IFUNC:]]
+; CHECK64: @__update_bar = private global { ptr, ptr } { ptr @bar, ptr @bar.resolver }, section "__ifunc_sec", align 8, !associated ![[#INIT_IFUNC]]
+; CHECK32: @__update_foo = private global { ptr, ptr } { ptr @foo, ptr @foo.resolver }, section "__ifunc_sec", align 4, !associated ![[#INIT_IFUNC:]]
+; CHECK32: @__update_bar = private global { ptr, ptr } { ptr @bar, ptr @bar.resolver }, section "__ifunc_sec", align 4, !associated ![[#INIT_IFUNC]]
+; CHECK: @foo = ifunc i32 (...), ptr @foo.resolver, !associated ![[#UPDATE_FOO:]]
+; CHECK: @bar = ifunc void (i32, i1), ptr @bar.resolver, !associated ![[#UPDATE_BAR:]]
+; CHECK: declare void @__init_ifuncs()
+; CHECK: ![[#INIT_IFUNC]] = !{ptr @__init_ifuncs}
+; CHECK: ![[#UPDATE_FOO]] = !{ptr @__update_foo}
+; CHECK: ![[#UPDATE_BAR]] = !{ptr @__update_bar}
+
+@foo = ifunc i32 (...), ptr @foo.resolver
+@bar = ifunc void (i32, i1), ptr @bar.resolver
+
+define hidden signext i32 @my_foo() {
+entry:
+  ret i32 4
+}
+
+define internal ptr @foo.resolver() {
+entry:
+  ret ptr @my_foo
+}
+
+declare void @my_bar(i32, i1)
+
+define ptr @bar.resolver() {
+entry:
+  ret ptr @my_bar
+}
+

--- a/llvm/test/LTO/PowerPC/ifunc-aix.ll
+++ b/llvm/test/LTO/PowerPC/ifunc-aix.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-as < %s > %t
+; RUN: llvm-lto -list-symbols-only %t | FileCheck %s
+
+; CHECK: foo    { function defined default }
+
+target triple = "powerpc-ibm-aix7.2.0.0"
+
+@foo = ifunc i32 (...), ptr @foo.resolver
+
+define internal ptr @foo.resolver() {
+entry:
+  ret ptr @my_foo2
+}
+
+define internal i32 @my_foo2() {
+entry:
+  ret i32 5
+}

--- a/llvm/utils/gn/secondary/llvm/lib/Target/PowerPC/BUILD.gn
+++ b/llvm/utils/gn/secondary/llvm/lib/Target/PowerPC/BUILD.gn
@@ -90,6 +90,7 @@ static_library("LLVMPowerPCCodeGen") {
     "PPCMachineScheduler.cpp",
     "PPCMacroFusion.cpp",
     "PPCPreEmitPeephole.cpp",
+    "PPCPrepareIFuncsOnAIX.cpp",
     "PPCReduceCRLogicals.cpp",
     "PPCRegisterInfo.cpp",
     "PPCSelectionDAGInfo.cpp",


### PR DESCRIPTION
Currently, the AIX linker and loader do not provide a mechanism to implement ifuncs similar to GNU_ifunc on ELF Linux.
On AIX, we will lower `__attribute__((ifunc("resolver"))` to the llvm `ifunc` as other platforms do. The llvm `ifunc` in turn will get lowered at late stages of the optimization pipeline to an AIX-specific implementation. No special linkage or relocations are needed when generating assembly/object output.

On AIX, a function `foo` has two symbols associated with it: a function descriptor (`foo`) residing in the `.data` section, and an entry point (`.foo`) residing in the `.text` section. The first field of the descriptor is the address of the entry point. Typically, the address field in the descriptor is initialized once: statically, at load time (?), or at runtime if runtime linking is enabled.

Here we would like to use the address field in the descriptor to implement the `ifunc` semantics. Specifically, the ifunc function will become a stub that jumps to the entry point in the address field. A constructor function is linked into every linkage module. The constructor walks an array of `{descriptor, resolver}` pairs, calling the resolver and saving the result in the address field in the descriptor (thus setting `foo`'s descriptor to point to the resolved version early during program runtime).

Known limitations:
 - Due to bug #161576, which affects object generation path, you will need either `-ffunction-sections` or `-fno-integrated-as` to generate a correct/linkable object file.
 - aliases to ifuncs are not supported, a testcase has been added and marked XFAIL. I'm planning to address in a follow-up PR because it's not important enough, IMHO, for this PR
 - dead ifuncs in a CU that contains at least one live ifunc, will result in all ifuncs being kept by the linker. The fix for this is common with a similar problem we have with PGO. PR #159435 is trying to provide a mechanism that will allow the ifunc and PGO implementations to avoid the dead code retention at the link step.
 - the resolver must return a function that is in the same DSO as the ifunc; the compiler will try to detect if this condition is violated and report it, but it cannot detect it in general. To be safe, all candidate functions (returned by a particular resolver) must either be static or have hidden/protected visibility. This is so that the ifunc stub doesn't have to save and restore the TOC register r2. In future work, this case will be supported and the requirement will be lifted.