### PR TITLE
[clang-repl] disable tests on AIX (NFC)

### DIFF
--- a/clang/test/Interpreter/bad_percent_command.cpp
+++ b/clang/test/Interpreter/bad_percent_command.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-aix
 // RUN: cat %s | clang-repl 2>&1 | FileCheck %s
 %foobar
 // CHECK: Invalid % command "%foobar", use "%help" to list commands

--- a/clang/test/Interpreter/dynamic-library-bad-args.cpp
+++ b/clang/test/Interpreter/dynamic-library-bad-args.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-aix
 // RUN: cat %s | clang-repl 2>&1 | FileCheck %s
 %lib
 // CHECK: %lib expects 1 argument: the path to a dynamic library

--- a/clang/test/Interpreter/help.cpp
+++ b/clang/test/Interpreter/help.cpp
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-aix
 // RUN: cat %s | clang-repl | FileCheck %s
 %help
 // CHECK: %help   list clang-repl %commands


### PR DESCRIPTION
`clang-repl` is not supported on AIX. The tests added in https://github.com/llvm/llvm-project/commit/2444c4a69861c643c6628b736affe5861cc79080 are disabled for AIX.

@aadanen Please review. Somehow I cannot add you to the reviewer list. 