### PR TITLE
[CI][Github] Fix Premerge Summary for Build Failures

### DIFF
--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -26,7 +26,7 @@ function at-exit {
   mkdir -p artifacts
   sccache --show-stats >> artifacts/sccache_stats.txt
   cp "${BUILD_DIR}"/.ninja_log artifacts/.ninja_log
-  cp "${BUILD_DIR}"/*.log artifacts/ || :
+  cp "${MONOREPO_ROOT}"/*.log artifacts/ || :
   cp "${BUILD_DIR}"/test-results.*.xml artifacts/ || :
 
   # If building fails there will be no results files.
@@ -34,7 +34,7 @@ function at-exit {
 
   if [[ "$GITHUB_STEP_SUMMARY" != "" ]]; then
     python "${MONOREPO_ROOT}"/.ci/generate_test_report_github.py \
-      $retcode "${BUILD_DIR}"/test-results.*.xml "${BUILD_DIR}"/ninja*.log \
+      $retcode "${BUILD_DIR}"/test-results.*.xml "${MONOREPO_ROOT}"/ninja*.log \
       >> $GITHUB_STEP_SUMMARY
   fi
 }

--- a/.ci/utils.sh
+++ b/.ci/utils.sh
@@ -26,6 +26,7 @@ function at-exit {
   mkdir -p artifacts
   sccache --show-stats >> artifacts/sccache_stats.txt
   cp "${BUILD_DIR}"/.ninja_log artifacts/.ninja_log
+  cp "${BUILD_DIR}"/*.log artifacts/ || :
   cp "${BUILD_DIR}"/test-results.*.xml artifacts/ || :
 
   # If building fails there will be no results files.

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -31,8 +31,6 @@
 #include <type_traits>
 #include <utility>
 
-THIS WILL CAUSE A BUILD ERROR
-
 namespace llvm {
 
 template <typename T> class ArrayRef;

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -31,6 +31,8 @@
 #include <type_traits>
 #include <utility>
 
+THIS WILL CAUSE A BUILD ERROR
+
 namespace llvm {
 
 template <typename T> class ArrayRef;


### PR DESCRIPTION
We were passing the wrong directory to `generate_test_report_github.py`, so no logs actually got passed there. This fixes that and ensures that the logs are uploaded as artifacts to enable future debugging.