### PR TITLE
[mlir][linalg][test] Fix flaky test linalg-morph-category-ops.mlir

### DIFF
--- a/mlir/test/Dialect/Linalg/linalg-morph-category-ops.mlir
+++ b/mlir/test/Dialect/Linalg/linalg-morph-category-ops.mlir
@@ -2,7 +2,7 @@
 // RUN: mlir-opt %s -linalg-morph-ops=named-to-category | FileCheck %s  --check-prefix=NAMED_TO_CATEGORY
 
 // RUN: mlir-opt %s -linalg-morph-ops=named-to-category |  \
-// RUN:   mlir-opt %s -linalg-morph-ops=category-to-generic | FileCheck %s  --check-prefix=CATEGORY_TO_GENERIC
+// RUN:   mlir-opt -linalg-morph-ops=category-to-generic | FileCheck %s  --check-prefix=CATEGORY_TO_GENERIC
 
 func.func @exp(%A : tensor<16x8xf32>, %B : tensor<16x8xf32>) ->  tensor<16x8xf32> {
   %exp = linalg.exp ins(%A : tensor<16x8xf32>) outs(%B :  tensor<16x8xf32>) -> tensor<16x8xf32>


### PR DESCRIPTION
This is another followup to a test added in #148424 that I missed in #152805

This test runs `mlir-opt %s | mlir-opt %s | FileCheck` to test the round trip behavior, but the second command takes input from the pipe, not the lit test, so it should be `mlir-opt %s | mlir-opt | FileCheck`.