### PR TITLE
[MLIR] Add replace-operands option to mlir-reduce

### DIFF
--- a/mlir/include/mlir/Reducer/Passes.td
+++ b/mlir/include/mlir/Reducer/Passes.td
@@ -31,6 +31,10 @@ def ReductionTreePass : Pass<"reduction-tree"> {
     Option<"traversalModeId", "traversal-mode", "unsigned",
            /* default */"0",
            "The graph traversal mode, the default is single-path mode">,
+    Option<"replaceOperands", "replace-operands", "bool",
+           /* default */"false",
+           "Whether the pass should replace operands with previously defined values with the same type">,
+
   ] # CommonReductionPassOptions.options;
 }
 

--- a/mlir/lib/Reducer/ReductionTreePass.cpp
+++ b/mlir/lib/Reducer/ReductionTreePass.cpp
@@ -68,8 +68,10 @@ static void applyPatterns(Region &region,
         size_t index = operandTie.index();
         auto operand = operandTie.value();
         for (auto candidate : valueMap[operand.getType()])
-          if (domInfo.properlyDominates(candidate, op))
+          if (domInfo.properlyDominates(candidate, op)) {
             op->setOperand(index, candidate);
+            break;
+          }
       }
 
     // `applyOpPatternsGreedily` with folding returns whether the op is

--- a/mlir/test/mlir-reduce/replace-operands.mlir
+++ b/mlir/test/mlir-reduce/replace-operands.mlir
@@ -3,7 +3,7 @@
 
 // CHECK-LABEL: func.func @main
 func.func @main() {
-  // CHECK-NEXT: %[[RESULT:.*]] = arith.constant 2 : i32
+  // CHECK-NEXT: %[[RESULT:.*]] = arith.constant 3 : i32
   // CHECK-NEXT: {{.*}} = "test.op_crash"(%[[RESULT]], %[[RESULT]]) : (i32, i32) -> i32
   // CHECK-NEXT return
 

--- a/mlir/test/mlir-reduce/replace-operands.mlir
+++ b/mlir/test/mlir-reduce/replace-operands.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-reduce %s -reduction-tree='traversal-mode=0 test=%S/failure-test.sh replace-operands=true' | FileCheck %s
+
+// CHECK-LABEL: func.func @main
+func.func @main() {
+  // CHECK-NEXT: %[[RESULT:.*]] = arith.constant 2 : i32
+  // CHECK-NEXT: {{.*}} = "test.op_crash"(%[[RESULT]], %[[RESULT]]) : (i32, i32) -> i32
+  // CHECK-NEXT return
+
+  %c1 = arith.constant 3 : i32
+  %c2 = arith.constant 2 : i32
+  %2 = "test.op_crash" (%c1, %c2) : (i32, i32) -> i32
+  return
+}

--- a/mlir/test/mlir-reduce/replace-operands.mlir
+++ b/mlir/test/mlir-reduce/replace-operands.mlir
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: mlir-reduce %s -reduction-tree='traversal-mode=0 test=%S/failure-test.sh replace-operands=true' | FileCheck %s
 
 // CHECK-LABEL: func.func @main


### PR DESCRIPTION
This PR adds an option to mlir-reduce that enables operation replacement during each reduction step in the reduction tree algorithm. The key idea is that preserving the syntactic properties of operands is sufficient to maintain interestingness of a test case, allowing us to replace operands with previously defined values with the same type.