### PR TITLE
Basic: Update the rule for whether to use FEATURE or EXTENSION.

### DIFF
--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -18,9 +18,10 @@
 // extension will be made available.
 //
 // FEATURE(...) should be used to advertise support for standard language
-// features, whereas EXTENSION(...) should be used for clang extensions. Note
-// that many of the identifiers in this file don't follow this rule for backward
-// compatibility reasons.
+// features or ABI-affecting clang extensions, whereas EXTENSION(...) should be
+// used for clang extensions which do not affect ABI. Note that many of the
+// identifiers in this file don't follow this rule for backward compatibility
+// reasons.
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
It was discovered that EXTENSION has some unexpected implications for
ABI-affecting extensions due to being influenced by warning flags,
so update the rule to allow ABI-affecting extensions to be FEATUREs.
