### PR TITLE
Revert "[libFuzzer] always install signal handler with SA_ONSTACK"

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerUtilPosix.cpp
@@ -78,14 +78,10 @@ static void SetSigaction(int signum,
   }
 
   struct sigaction new_sigact = {};
-  // SA_ONSTACK is required for certain runtimes that use small stacks, for
-  // instance the Go runtime.
-  // See https://github.com/golang/go/issues/49075
-  // Address sanitizer also wants SA_ONSTACK, and the fuzzer and sanitizer
-  // often run together.
-  // SA_ONSTACK is a no-op unless someone also calls sigaltstack. That is left
-  // up to code that needs it.
-  new_sigact.sa_flags = SA_SIGINFO | SA_ONSTACK;
+  // Address sanitizer needs SA_ONSTACK (causing the signal handler to run on a
+  // dedicated stack) in order to be able to detect stack overflows; keep the
+  // flag if it's set.
+  new_sigact.sa_flags = SA_SIGINFO | (sigact.sa_flags & SA_ONSTACK);
   new_sigact.sa_sigaction = callback;
   if (sigaction(signum, &new_sigact, nullptr)) {
     Printf("libFuzzer: sigaction failed with %d\n", errno);


### PR DESCRIPTION
Reverts llvm/llvm-project#147422

Seems to be causing problems with tracebacks. Probably the trackback code doesn't know how to switch back to the regular stack after it gets to the top of the signal stack.
