### PR TITLE
[Support] Make IsLittleEndianHost constexpr (NFC)

### DIFF
--- a/llvm/include/llvm/Support/SwapByteOrder.h
+++ b/llvm/include/llvm/Support/SwapByteOrder.h
@@ -26,7 +26,7 @@ namespace sys {
 constexpr bool IsBigEndianHost =
     llvm::endianness::native == llvm::endianness::big;
 
-static const bool IsLittleEndianHost = !IsBigEndianHost;
+constexpr bool IsLittleEndianHost = !IsBigEndianHost;
 
 inline unsigned char      getSwappedBytes(unsigned char      C) { return llvm::byteswap(C); }
 inline   signed char      getSwappedBytes( signed  char      C) { return llvm::byteswap(C); }


### PR DESCRIPTION
IsLittleEndianHost is a compile-time constant because IsBigEndianHost
also is.
