### PR TITLE
[ADT] Simplify getFirstEl (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -128,8 +128,8 @@ protected:
   /// SmallVectorStorage is properly-aligned even for small-size of 0.
   void *getFirstEl() const {
     return const_cast<void *>(reinterpret_cast<const void *>(
-        reinterpret_cast<const char *>(this) +
-        offsetof(SmallVectorAlignmentAndSize<T>, FirstEl)));
+        reinterpret_cast<const SmallVectorAlignmentAndSize<T> *>(this)
+            ->FirstEl));
   }
   // Space after 'FirstEl' is clobbered, do not add any instance vars after it.
 


### PR DESCRIPTION
getFirstEl computes the address of FirstEl.  This patch computes the
address by first casting this to SmallVectorAlignmentAndSize<T> and
letting the C++ language compute the field address instead of adding
the offset to this on our own.
