### PR TITLE
[mlir][ExecutionEngine] fix default free function in `OwningMemRef`.

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
@@ -151,7 +151,7 @@ public:
       AllocFunType allocFun = &::malloc,
       std::function<void(StridedMemRefType<T, Rank>)> freeFun =
           [](StridedMemRefType<T, Rank> descriptor) {
-            ::free(descriptor.data);
+            ::free(descriptor.basePtr);
           })
       : freeFunc(freeFun) {
     if (shapeAlloc.empty())

--- a/mlir/unittests/ExecutionEngine/Invoke.cpp
+++ b/mlir/unittests/ExecutionEngine/Invoke.cpp
@@ -205,7 +205,14 @@ TEST(NativeMemRefJit, SKIP_WITHOUT_JIT(BasicMemref)) {
   };
   int64_t shape[] = {k, m};
   int64_t shapeAlloc[] = {k + 1, m + 1};
-  OwningMemRef<float, 2> a(shape, shapeAlloc, init);
+  // Use a large alignment to stress the case where the memref data/basePtr are
+  // disjoint.
+  int alignment = 8192;
+  OwningMemRef<float, 2> a(shape, shapeAlloc, init, alignment);
+  ASSERT_NE(a->basePtr, a->data);
+  ASSERT_EQ(
+      (void *)(((uintptr_t)a->basePtr + alignment - 1) & ~(alignment - 1)),
+      a->data);
   ASSERT_EQ(a->sizes[0], k);
   ASSERT_EQ(a->sizes[1], m);
   ASSERT_EQ(a->strides[0], m + 1);

--- a/mlir/unittests/ExecutionEngine/Invoke.cpp
+++ b/mlir/unittests/ExecutionEngine/Invoke.cpp
@@ -209,7 +209,6 @@ TEST(NativeMemRefJit, SKIP_WITHOUT_JIT(BasicMemref)) {
   // disjoint.
   int alignment = 8192;
   OwningMemRef<float, 2> a(shape, shapeAlloc, init, alignment);
-  ASSERT_NE(a->basePtr, a->data);
   ASSERT_EQ(
       (void *)(((uintptr_t)a->basePtr + alignment - 1) & ~(alignment - 1)),
       a->data);


### PR DESCRIPTION
`basePtr` should be freed instead of `data` because it is the one which is storing the output of `malloc`. In `allocAligned()`, the `data` is malloced and then assigned to `basePtr`.

For details, take a look at:
https://github.com/llvm/llvm-project/blob/e0df5f8/mlir/include/mlir/ExecutionEngine/MemRefUtils.h#L111 https://github.com/llvm/llvm-project/blob/e0df5f8/mlir/include/mlir/ExecutionEngine/MemRefUtils.h#L167-L170 https://github.com/llvm/llvm-project/blob/e0df5f8/mlir/include/mlir/ExecutionEngine/MemRefUtils.h#L59-L96
