### PR TITLE
[RISCV] Fix Immediate Check for Xqcibi UGT

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -2523,11 +2523,10 @@ static void translateSetCCForBranch(const SDLoc &DL, SDValue &LHS, SDValue &RHS,
       }
       break;
     case ISD::SETUGT:
-      if (Subtarget.hasVendorXqcibi() && C != INT64_MAX && isInt<16>(C + 1) &&
-          C != -1) {
+      if (Subtarget.hasVendorXqcibi() && C != INT64_MAX && isUInt<16>(C + 1)) {
         // We have a branch immediate instruction for SETUGE but not SETUGT.
         // Convert X > C to X >= C + 1, if (C + 1) is a 16-bit signed immediate.
-        RHS = DAG.getSignedConstant(C + 1, DL, RHS.getValueType());
+        RHS = DAG.getConstant(C + 1, DL, RHS.getValueType());
         CC = ISD::SETUGE;
         return;
       }

--- a/llvm/test/CodeGen/RISCV/xqcibi.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibi.ll
@@ -341,9 +341,7 @@ define i32 @bgeuimm16(i32 %a) {
 ;
 ; RV32IXQCIBI-LABEL: bgeuimm16:
 ; RV32IXQCIBI:       # %bb.0:
-; RV32IXQCIBI-NEXT:    lui a1, 16
-; RV32IXQCIBI-NEXT:    addi a1, a1, -2
-; RV32IXQCIBI-NEXT:    bltu a1, a0, .LBB11_2
+; RV32IXQCIBI-NEXT:    qc.e.bgeui a0, 65535, .LBB11_2
 ; RV32IXQCIBI-NEXT:  # %bb.1: # %f
 ; RV32IXQCIBI-NEXT:    li a0, 0
 ; RV32IXQCIBI-NEXT:    ret

--- a/llvm/test/CodeGen/RISCV/xqcibi.ll
+++ b/llvm/test/CodeGen/RISCV/xqcibi.ll
@@ -329,7 +329,8 @@ t:
 define i32 @bgeuimm16(i32 %a) {
 ; RV32I-LABEL: bgeuimm16:
 ; RV32I:       # %bb.0:
-; RV32I-NEXT:    li a1, 99
+; RV32I-NEXT:    lui a1, 16
+; RV32I-NEXT:    addi a1, a1, -2
 ; RV32I-NEXT:    bltu a1, a0, .LBB11_2
 ; RV32I-NEXT:  # %bb.1: # %f
 ; RV32I-NEXT:    li a0, 0
@@ -340,14 +341,16 @@ define i32 @bgeuimm16(i32 %a) {
 ;
 ; RV32IXQCIBI-LABEL: bgeuimm16:
 ; RV32IXQCIBI:       # %bb.0:
-; RV32IXQCIBI-NEXT:    qc.e.bgeui a0, 100, .LBB11_2
+; RV32IXQCIBI-NEXT:    lui a1, 16
+; RV32IXQCIBI-NEXT:    addi a1, a1, -2
+; RV32IXQCIBI-NEXT:    bltu a1, a0, .LBB11_2
 ; RV32IXQCIBI-NEXT:  # %bb.1: # %f
 ; RV32IXQCIBI-NEXT:    li a0, 0
 ; RV32IXQCIBI-NEXT:    ret
 ; RV32IXQCIBI-NEXT:  .LBB11_2: # %t
 ; RV32IXQCIBI-NEXT:    li a0, 1
 ; RV32IXQCIBI-NEXT:    ret
-  %1 = icmp uge i32 %a, 100
+  %1 = icmp uge i32 %a, 65535
   br i1 %1, label %t, label %f, !prof !0
 f:
   ret i32 0


### PR DESCRIPTION
The check should be about unsigned 16-bit immediates, not signed ones.

This is not a bug per-se, as the old codegen was correct for the uint16_max case, it just didn't end up using `qc.e.bgeui`, which we would prefer it did.