### PR TITLE
[AMDGPU] Teach the driver to infer a libclc library to link with

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -395,8 +395,6 @@ def warn_drv_fraw_string_literals_in_cxx11 : Warning<
   InGroup<UnusedCommandLineArgument>;
 
 def err_drv_libclc_not_found : Error<"no libclc library '%0' found in the clang resource directory">;
-def err_drv_libclc_not_inferred : Error<
-  "could not infer a libclc library for this target; try providing a namespec or full path">;
 
 def err_drv_invalid_malign_branch_EQ : Error<
   "invalid argument '%0' to -malign-branch=; each element must be one of: %1">;

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -395,6 +395,8 @@ def warn_drv_fraw_string_literals_in_cxx11 : Warning<
   InGroup<UnusedCommandLineArgument>;
 
 def err_drv_libclc_not_found : Error<"no libclc library '%0' found in the clang resource directory">;
+def err_drv_libclc_not_inferred : Error<
+  "could not infer a libclc library for this target; try providing a namespec or full path">;
 
 def err_drv_invalid_malign_branch_EQ : Error<
   "invalid argument '%0' to -malign-branch=; each element must be one of: %1">;

--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -218,7 +218,8 @@ void addOpenMPDeviceRTL(const Driver &D, const llvm::opt::ArgList &DriverArgs,
                         const ToolChain &HostTC);
 
 void addOpenCLBuiltinsLib(const Driver &D, const llvm::opt::ArgList &DriverArgs,
-                          llvm::opt::ArgStringList &CC1Args);
+                          llvm::opt::ArgStringList &CC1Args,
+                          const StringRef InferredLibclcLibName = "");
 
 void addOutlineAtomicsArgs(const Driver &D, const ToolChain &TC,
                            const llvm::opt::ArgList &Args,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1435,6 +1435,8 @@ def openacc_macro_override_EQ
 
 // End Clang specific/exclusive options for OpenACC.
 
+def libclc_lib : Joined<["--"], "libclc-lib">, Group<opencl_Group>,
+  HelpText<"Link with the libclc OpenCL bitcode library">;
 def libclc_lib_EQ : Joined<["--"], "libclc-lib=">, Group<opencl_Group>,
   HelpText<"Namespec of libclc OpenCL bitcode library to link">;
 def libomptarget_amdgpu_bc_path_EQ : Joined<["--"], "libomptarget-amdgpu-bc-path=">, Group<i_Group>,

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -2999,27 +2999,42 @@ void tools::addHIPRuntimeLibArgs(const ToolChain &TC, Compilation &C,
 
 void tools::addOpenCLBuiltinsLib(const Driver &D,
                                  const llvm::opt::ArgList &DriverArgs,
-                                 llvm::opt::ArgStringList &CC1Args) {
+                                 llvm::opt::ArgStringList &CC1Args,
+                                 const StringRef InferredLibclcLibName) {
   // Check whether user specifies a libclc bytecode library
-  const Arg *A = DriverArgs.getLastArg(options::OPT_libclc_lib_EQ);
+  const Arg *A = DriverArgs.getLastArg(options::OPT_libclc_lib,
+                                       options::OPT_libclc_lib_EQ);
   if (!A)
     return;
+
+  bool IsEQOpt = A->getOption().matches(options::OPT_libclc_lib_EQ);
 
   // Find device libraries in <LLVM_DIR>/lib/clang/<ver>/lib/libclc/
   SmallString<128> LibclcPath(D.ResourceDir);
   llvm::sys::path::append(LibclcPath, "lib", "libclc");
 
   // If the namespec is of the form :filename, search for that file.
-  StringRef LibclcNamespec(A->getValue());
-  bool FilenameSearch = LibclcNamespec.consume_front(":");
-  SmallString<128> LibclcTargetFile(LibclcNamespec);
+  bool FilenameSearch = false;
+  SmallString<128> LibclcTargetFile;
+
+  if (IsEQOpt) {
+    StringRef LibclcNamespec(A->getValue());
+    FilenameSearch = LibclcNamespec.consume_front(":");
+    LibclcTargetFile = LibclcNamespec;
+  } else {
+    if (InferredLibclcLibName.empty()) {
+      D.Diag(diag::err_drv_libclc_not_inferred);
+      return;
+    }
+    LibclcTargetFile = InferredLibclcLibName;
+  }
 
   if (FilenameSearch && llvm::sys::fs::exists(LibclcTargetFile)) {
     CC1Args.push_back("-mlink-builtin-bitcode");
     CC1Args.push_back(DriverArgs.MakeArgString(LibclcTargetFile));
   } else {
     // Search the library paths for the file
-    if (!FilenameSearch)
+    if (!FilenameSearch && IsEQOpt)
       LibclcTargetFile += ".bc";
 
     llvm::sys::path::append(LibclcPath, LibclcTargetFile);

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3022,10 +3022,7 @@ void tools::addOpenCLBuiltinsLib(const Driver &D,
     FilenameSearch = LibclcNamespec.consume_front(":");
     LibclcTargetFile = LibclcNamespec;
   } else {
-    if (InferredLibclcLibName.empty()) {
-      D.Diag(diag::err_drv_libclc_not_inferred);
-      return;
-    }
+    assert(!InferredLibclcLibName.empty() && "No inferred libclc name");
     LibclcTargetFile = InferredLibclcLibName;
   }
 

--- a/clang/test/Driver/opencl-libclc.cl
+++ b/clang/test/Driver/opencl-libclc.cl
@@ -1,9 +1,17 @@
 // RUN: %clang -### -target amdgcn-amd-amdhsa --no-offloadlib --libclc-lib=:%S/Inputs/libclc/libclc.bc %s 2>&1 | FileCheck %s
 // RUN: %clang -### -target amdgcn-amd-amdhsa --no-offloadlib --libclc-lib=:%S/Inputs/libclc/subdir/libclc.bc %s 2>&1 | FileCheck %s --check-prefix CHECK-SUBDIR
 
+// RUN: %clang -### -target amdgcn-amd-amdhsa -mcpu=gfx908 --no-offloadlib -resource-dir=%S/Inputs/resource_dir --libclc-lib %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix CHECK-INFER
+// RUN: %clang -### -target amdgcn-mesa-mesa3d -mcpu=gfx908 --no-offloadlib -resource-dir=%S/Inputs/resource_dir --libclc-lib %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix CHECK-INFER-MESA3D
+
 // RUN: not %clang -### -target amdgcn-amd-amdhsa --no-offloadlib --libclc-lib=:%S/Inputs/libclc/subdir/not-here.bc %s 2>&1 | FileCheck %s --check-prefix CHECK-ERROR
 
 // CHECK: -mlink-builtin-bitcode{{.*}}Inputs{{/|\\\\}}libclc{{/|\\\\}}libclc.bc
 // CHECK-SUBDIR: -mlink-builtin-bitcode{{.*}}Inputs{{/|\\\\}}libclc{{/|\\\\}}subdir{{/|\\\\}}libclc.bc
+
+// CHECK-INFER: -mlink-builtin-bitcode{{.*}}Inputs{{/|\\\\}}resource_dir{{/|\\\\}}lib{{/|\\\\}}libclc{{/|\\\\}}gfx908-amdgcn--.bc
+// CHECK-INFER-MESA3D: -mlink-builtin-bitcode{{.*}}Inputs{{/|\\\\}}resource_dir{{/|\\\\}}lib{{/|\\\\}}libclc{{/|\\\\}}gfx908-amdgcn-mesa-mesa3d.bc
 
 // CHECK-ERROR: no libclc library{{.*}}not-here.bc' found in the clang resource directory


### PR DESCRIPTION
This commit introduces a new compiler option which lets the target infer the name of the libclc builtins library to link with. This is contrasted with the previous option where the user explicitly provides a namespec.

For the AMDGPU target, the general form of libclc libraries is gfxXYZ-amdgcn--.bc or gfxXYZ-amdgcn-mesa-mesa3d.bc. The target will try to link with either of these libraries, based on the triple and GPU architecture.

Note that this patch doesn't guarantee that a library will necessary be found for all CPUs or GFX architectures. For example, some libclc libraries use another naming scheme, for example 'tonga' instead of 'gfx802'. These are not accounted for. If an inferred library isn't found then the compiler will error as if the user had provided the path themselves. Future patches will focus on libclc and standardize the naming system to reduce the likelihood of this happening.