### PR TITLE
[TableGen] Move hasCompleteDecoder bit from Operand to DAGOperand

### DIFF
--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -250,6 +250,7 @@ class RegisterWithSubRegs<string n, list<Register> subregs> : Register<n> {
 class DAGOperand {
   string OperandNamespace = "MCOI";
   string DecoderMethod = "";
+  bit hasCompleteDecoder = true;
 }
 
 // RegisterClass - Now that all of the registers are defined, and aliases
@@ -1003,7 +1004,6 @@ class Operand<ValueType ty> : DAGOperand {
   ValueType Type = ty;
   string PrintMethod = "printOperand";
   string EncoderMethod = "";
-  bit hasCompleteDecoder = true;
   string OperandType = "OPERAND_UNKNOWN";
   dag MIOperandInfo = (ops);
 


### PR DESCRIPTION
The bit works with any kind of instruction operands, not only `Operand`. Move it to the base class of all operands so that targets are aware of it and can use "let hasCompleteDecoder = ..." in records derived from RegisterClass/RegisterOperand.