### PR TITLE
[compiler-rt][hwasan][test] Tweak check in release-shadow.c

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/Linux/release-shadow.c
+++ b/compiler-rt/test/hwasan/TestCases/Linux/release-shadow.c
@@ -57,7 +57,7 @@ int test_rss_difference(void *p) {
   size_t diff = rss_before - rss_after;
   fprintf(stderr, "diff %zu\n", diff);
   // Check that the difference is at least close to kNumShadowPages.
-  return diff > kNumShadowPages / 2;
+  return diff >= kNumShadowPages / 2;
 }
 
 int main() {


### PR DESCRIPTION
Since we (Linaro) moved out bots to a new machine, this test has been failing:
https://lab.llvm.org/buildbot/#/builders/121/builds/1566

Most of the time, the rss difference is greater than 512 on the first iteration then settles down to 512 for all the rest.
```
starting rss 512
shadow pages: 1024
p = 0xe083e0800000
1536 -> 740
diff 796
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
1252 -> 740
diff 512
p = 0xe083e0800000
passed 1 out of 10
release-shadow.c.tmp: /home/tcwg-buildbot/worker/clang-aarch64-lld-2stage/llvm/compiler-rt/test/hwasan/TestCases/Linux/release-shadow.c:81: int main(): Assertion `success_count > total_count * 0.8' failed.
```
Given that the test was looking for a diff of at least 513, I guess that 512 is ok too.

For future reference, the original bot host was running this kernel: Linux 5.15.0-136-generic #147-Ubuntu SMP Sat Mar 15 15:51:36 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux

And the new host:
Linux 6.8.0-64-generic #67-Ubuntu SMP PREEMPT_DYNAMIC Sun Jun 15 20:23:40 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux

Though the new host also has more RAM, so the kernel may be less aggresive with memory management.