### PR TITLE
[compiler-rt][libFuzzer] Add %run directives to focus-function.test

### DIFF
--- a/compiler-rt/test/fuzzer/focus-function.test
+++ b/compiler-rt/test/fuzzer/focus-function.test
@@ -7,15 +7,15 @@ UNSUPPORTED: target=aarch64{{.*}}
 
 RUN: %cpp_compiler %S/OnlySomeBytesTest.cpp -o %t-exe
 
-RUN: %t-exe -runs=100 2>&1 | FileCheck %s --check-prefix=FOCUS_NONE
+RUN: %run %t-exe -runs=100 2>&1 | FileCheck %s --check-prefix=FOCUS_NONE
 FOCUS_NONE-NOT: INFO: Focus function is set to
 FOCUS_NONE-NOT: INFO: {{.*}} inputs touch the focus function
 
-RUN: not %t-exe -runs=100 -focus_function=WRONG 2>&1 | FileCheck %s --check-prefix=FOCUS_WRONG
+RUN: not %run %t-exe -runs=100 -focus_function=WRONG 2>&1 | FileCheck %s --check-prefix=FOCUS_WRONG
 FOCUS_WRONG-NOT: INFO: Focus function is set to
 FOCUS_WRONG: ERROR: Failed to set focus function
 
-RUN: %t-exe -runs=100 -focus_function=f0 2>&1 | FileCheck %s --check-prefix=FOCUS_F0
+RUN: %run %t-exe -runs=100 -focus_function=f0 2>&1 | FileCheck %s --check-prefix=FOCUS_F0
 FOCUS_F0: INFO: Focus function is set to 'f0'
 FOCUS_F0: INFO: 0/1 inputs touch the focus function
 
@@ -26,6 +26,6 @@ RUN: echo ABC$(for((i=0;i<2048;i++)); do echo -n x; done) > %t-corpus/ABC
 RUN: echo AXY$(for((i=0;i<2048;i++)); do echo -n x; done) > %t-corpus/AXY
 RUN: echo ABX$(for((i=0;i<2048;i++)); do echo -n x; done) > %t-corpus/ABX
 
-RUN: %t-exe -runs=10000 -focus_function=f0 %t-corpus 2>&1 | FileCheck %s --check-prefix=CORPUS_1_3
+RUN: %run %t-exe -runs=10000 -focus_function=f0 %t-corpus 2>&1 | FileCheck %s --check-prefix=CORPUS_1_3
 CORPUS_1_3: INFO: 1/3 inputs touch the focus function
 CORPUS_1_3: DONE {{.*}} focus:


### PR DESCRIPTION
Contrary to most testcases in the libFuzzer test suite, `focus-function.test` seems to lack the `%run` directives, which is an inconvenience in cases when `%run` actually gets substituted for something. This PR adds said directives.