### PR TITLE
[OMPIRBuilder] Avoid invalid debug location.

### DIFF
--- a/clang/test/OpenMP/amdgcn_debug_nowait.c
+++ b/clang/test/OpenMP/amdgcn_debug_nowait.c
@@ -1,0 +1,16 @@
+// REQUIRES: amdgpu-registered-target
+
+// RUN: %clang_cc1 -debug-info-kind=line-tables-only -fopenmp -triple x86_64-unknown-unknown -fopenmp-targets=amdgcn-amd-amdhsa -emit-llvm-bc %s -o %t-host.bc
+
+int test() {
+  int c;
+
+#pragma omp target data map(tofrom: c)
+{
+  #pragma omp target nowait
+  {
+      c = 2;
+  }
+}
+  return c;
+}

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -7247,7 +7247,7 @@ OpenMPIRBuilder::InsertPointOrErrorTy OpenMPIRBuilder::createTargetData(
           BodyGenCB(Builder.saveIP(), BodyGenTy::NoPriv);
       if (!AfterIP)
         return AfterIP.takeError();
-      Builder.restoreIP(*AfterIP);
+      restoreIPandDebugLoc(Builder, *AfterIP);
 
       if (IfCond)
         return emitIfClause(IfCond, EndThenGen, EndElseGen, AllocaIP);


### PR DESCRIPTION
Fixes #153043.

This is another case of debug location not getting updated when the insert point is changed by the `restoreIP`. Fixed by using the wrapper function that updates the debug location.