### PR TITLE
[libc][math][c++23] Add bf16div{,f,l,f128} math functions

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -760,6 +760,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull
@@ -780,6 +783,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
     libc.src.math.bf16addf128
+    libc.src.math.bf16divf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -763,6 +763,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull
@@ -783,6 +786,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
     libc.src.math.bf16addf128
+    libc.src.math.bf16divf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -763,6 +763,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull
@@ -783,6 +786,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
     libc.src.math.bf16addf128
+    libc.src.math.bf16divf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/darwin/aarch64/entrypoints.txt
+++ b/libc/config/darwin/aarch64/entrypoints.txt
@@ -593,6 +593,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull

--- a/libc/config/darwin/x86_64/entrypoints.txt
+++ b/libc/config/darwin/x86_64/entrypoints.txt
@@ -236,6 +236,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull

--- a/libc/config/gpu/amdgpu/entrypoints.txt
+++ b/libc/config/gpu/amdgpu/entrypoints.txt
@@ -619,6 +619,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull

--- a/libc/config/gpu/nvptx/entrypoints.txt
+++ b/libc/config/gpu/nvptx/entrypoints.txt
@@ -620,6 +620,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull

--- a/libc/config/linux/aarch64/entrypoints.txt
+++ b/libc/config/linux/aarch64/entrypoints.txt
@@ -847,6 +847,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull
@@ -867,6 +870,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
     libc.src.math.bf16addf128
+    libc.src.math.bf16divf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/linux/arm/entrypoints.txt
+++ b/libc/config/linux/arm/entrypoints.txt
@@ -463,6 +463,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull

--- a/libc/config/linux/riscv/entrypoints.txt
+++ b/libc/config/linux/riscv/entrypoints.txt
@@ -866,6 +866,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull
@@ -886,6 +889,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
     libc.src.math.bf16addf128
+    libc.src.math.bf16divf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -898,6 +898,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull
@@ -918,6 +921,7 @@ if(LIBC_TYPES_HAS_FLOAT128)
   list(APPEND TARGET_LIBM_ENTRYPOINTS
     # math.h C++23 mixed bfloat16 and _Float128 entrypoints
     libc.src.math.bf16addf128
+    libc.src.math.bf16divf128
     libc.src.math.bf16mulf128
     libc.src.math.bf16subf128
   )

--- a/libc/config/windows/entrypoints.txt
+++ b/libc/config/windows/entrypoints.txt
@@ -309,6 +309,9 @@ list(APPEND TARGET_LIBM_ENTRYPOINTS
   libc.src.math.bf16add
   libc.src.math.bf16addf
   libc.src.math.bf16addl
+  libc.src.math.bf16div
+  libc.src.math.bf16divf
+  libc.src.math.bf16divl
   libc.src.math.bf16mul
   libc.src.math.bf16mulf
   libc.src.math.bf16mull

--- a/libc/src/math/CMakeLists.txt
+++ b/libc/src/math/CMakeLists.txt
@@ -571,6 +571,11 @@ add_math_entrypoint_object(bf16addf)
 add_math_entrypoint_object(bf16addl)
 add_math_entrypoint_object(bf16addf128)
 
+add_math_entrypoint_object(bf16div)
+add_math_entrypoint_object(bf16divf)
+add_math_entrypoint_object(bf16divl)
+add_math_entrypoint_object(bf16divf128)
+
 add_math_entrypoint_object(bf16mul)
 add_math_entrypoint_object(bf16mulf)
 add_math_entrypoint_object(bf16mull)

--- a/libc/src/math/bf16div.h
+++ b/libc/src/math/bf16div.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for bf16div -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_BF16DIV_H
+#define LLVM_LIBC_SRC_MATH_BF16DIV_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+bfloat16 bf16div(double x, double y);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_BF16DIV_H

--- a/libc/src/math/bf16divf.h
+++ b/libc/src/math/bf16divf.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for bf16divf ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_BF16DIVF_H
+#define LLVM_LIBC_SRC_MATH_BF16DIVF_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+bfloat16 bf16divf(float x, float y);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_BF16DIVF_H

--- a/libc/src/math/bf16divf128.h
+++ b/libc/src/math/bf16divf128.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for bf16divf128 -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_BF16DIVF128_H
+#define LLVM_LIBC_SRC_MATH_BF16DIVF128_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+bfloat16 bf16divf128(float128 x, float128 y);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_BF16DIVF128_H

--- a/libc/src/math/bf16divl.h
+++ b/libc/src/math/bf16divl.h
@@ -1,0 +1,21 @@
+//===-- Implementation header for bf16divl ----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC_MATH_BF16DIVL_H
+#define LLVM_LIBC_SRC_MATH_BF16DIVL_H
+
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/properties/types.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+bfloat16 bf16divl(long double x, long double y);
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC_MATH_BF16DIVL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -4929,6 +4929,61 @@ add_entrypoint_object(
     libc.src.__support.macros.properties.types
 )
 
+add_entrypoint_object(
+  bf16div
+  SRCS
+    bf16div.cpp
+  HDRS
+    ../bf16div.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.macros.config
+    libc.src.__support.macros.properties.types
+)
+
+add_entrypoint_object(
+  bf16divf
+  SRCS
+    bf16divf.cpp
+  HDRS
+    ../bf16divf.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.macros.config
+    libc.src.__support.macros.properties.types
+)
+
+add_entrypoint_object(
+  bf16divl
+  SRCS
+    bf16divl.cpp
+  HDRS
+    ../bf16divl.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.macros.config
+    libc.src.__support.macros.properties.types
+)
+
+add_entrypoint_object(
+  bf16divf128
+  SRCS
+    bf16divf128.cpp
+  HDRS
+    ../bf16divf128.h
+  DEPENDS
+    libc.src.__support.common
+    libc.src.__support.FPUtil.bfloat16
+    libc.src.__support.FPUtil.generic.div
+    libc.src.__support.macros.config
+    libc.src.__support.macros.properties.types
+)
 
 add_entrypoint_object(
   bf16sub

--- a/libc/src/math/generic/bf16div.cpp
+++ b/libc/src/math/generic/bf16div.cpp
@@ -8,9 +8,9 @@
 
 #include "src/math/bf16div.h"
 
-#include "src/__support/common.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/math/generic/bf16div.cpp
+++ b/libc/src/math/generic/bf16div.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of bf16div function --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/bf16div.h"
+
+#include "src/__support/common.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(bfloat16, bf16div, (double x, double y)) {
+  return fputil::generic::div<bfloat16>(x, y);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/bf16div.cpp
+++ b/libc/src/math/generic/bf16div.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/bf16div.h"
-
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
 #include "src/__support/common.h"

--- a/libc/src/math/generic/bf16divf.cpp
+++ b/libc/src/math/generic/bf16divf.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of bf16divf function -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/bf16divf.h"
+
+#include "src/__support/common.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(bfloat16, bf16divf, (float x, float y)) {
+  return fputil::generic::div<bfloat16>(x, y);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/bf16divf.cpp
+++ b/libc/src/math/generic/bf16divf.cpp
@@ -8,9 +8,9 @@
 
 #include "src/math/bf16divf.h"
 
-#include "src/__support/common.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/math/generic/bf16divf.cpp
+++ b/libc/src/math/generic/bf16divf.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/bf16divf.h"
-
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
 #include "src/__support/common.h"

--- a/libc/src/math/generic/bf16divf128.cpp
+++ b/libc/src/math/generic/bf16divf128.cpp
@@ -8,9 +8,9 @@
 
 #include "src/math/bf16divf128.h"
 
-#include "src/__support/common.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/math/generic/bf16divf128.cpp
+++ b/libc/src/math/generic/bf16divf128.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of bf16divf128 function ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/bf16divf128.h"
+
+#include "src/__support/common.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(bfloat16, bf16divf128, (float128 x, float128 y)) {
+  return fputil::generic::div<bfloat16>(x, y);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/bf16divf128.cpp
+++ b/libc/src/math/generic/bf16divf128.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/bf16divf128.h"
-
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
 #include "src/__support/common.h"

--- a/libc/src/math/generic/bf16divl.cpp
+++ b/libc/src/math/generic/bf16divl.cpp
@@ -1,0 +1,22 @@
+//===-- Implementation of bf16divl function -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/math/bf16divl.h"
+
+#include "src/__support/common.h"
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+LLVM_LIBC_FUNCTION(bfloat16, bf16divl, (long double x, long double y)) {
+  return fputil::generic::div<bfloat16>(x, y);
+}
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/bf16divl.cpp
+++ b/libc/src/math/generic/bf16divl.cpp
@@ -8,9 +8,9 @@
 
 #include "src/math/bf16divl.h"
 
-#include "src/__support/common.h"
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
+#include "src/__support/common.h"
 #include "src/__support/macros/config.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/math/generic/bf16divl.cpp
+++ b/libc/src/math/generic/bf16divl.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/bf16divl.h"
-
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/__support/FPUtil/generic/div.h"
 #include "src/__support/common.h"

--- a/libc/test/src/math/CMakeLists.txt
+++ b/libc/test/src/math/CMakeLists.txt
@@ -3029,6 +3029,62 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  bf16div_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    bf16div_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.src.math.bf16div
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
+  bf16divf_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    bf16divf_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.src.math.bf16divf
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
+  bf16divl_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    bf16divl_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.src.math.bf16divl
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
+  bf16divf128_test
+  NEED_MPFR
+  SUITE
+    libc-math-unittests
+  SRCS
+    bf16divf128_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.src.math.bf16divf128
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
   bf16mul_test
   NEED_MPFR
   SUITE

--- a/libc/test/src/math/bf16div_test.cpp
+++ b/libc/test/src/math/bf16div_test.cpp
@@ -1,0 +1,14 @@
+//===-- Unittests for bf16div ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DivTest.h"
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/math/bf16div.h"
+
+LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)

--- a/libc/test/src/math/bf16divf128_test.cpp
+++ b/libc/test/src/math/bf16divf128_test.cpp
@@ -1,0 +1,14 @@
+//===-- Unittests for bf16divf128 -----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DivTest.h"
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/math/bf16divf128.h"
+
+LIST_DIV_TESTS(bfloat16, float128, LIBC_NAMESPACE::bf16divf128)

--- a/libc/test/src/math/bf16divf_test.cpp
+++ b/libc/test/src/math/bf16divf_test.cpp
@@ -1,0 +1,14 @@
+//===-- Unittests for bf16divf --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DivTest.h"
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/math/bf16divf.h"
+
+LIST_DIV_TESTS(bfloat16, float, LIBC_NAMESPACE::bf16divf)

--- a/libc/test/src/math/bf16divl_test.cpp
+++ b/libc/test/src/math/bf16divl_test.cpp
@@ -1,0 +1,14 @@
+//===-- Unittests for bf16divl --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "DivTest.h"
+
+#include "src/__support/FPUtil/bfloat16.h"
+#include "src/math/bf16divl.h"
+
+LIST_DIV_TESTS(bfloat16, long double, LIBC_NAMESPACE::bf16divl)

--- a/libc/test/src/math/smoke/CMakeLists.txt
+++ b/libc/test/src/math/smoke/CMakeLists.txt
@@ -5561,13 +5561,73 @@ add_fp_unittest(
 )
 
 add_fp_unittest(
+  bf16div_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    bf16div_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.src.math.bf16div
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
+  bf16divf_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    bf16divf_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.src.math.bf16divf
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
+  bf16divl_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    bf16divl_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.src.math.bf16divl
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
+  bf16divf128_test
+  SUITE
+    libc-math-smoke-tests
+  SRCS
+    bf16divf128_test.cpp
+  HDRS
+    DivTest.h
+  DEPENDS
+    libc.hdr.errno_macros
+    libc.hdr.fenv_macros
+    libc.src.math.bf16divf128
+    libc.src.__support.FPUtil.bfloat16
+)
+
+add_fp_unittest(
   bf16mul_test
   SUITE
     libc-math-smoke-tests
   SRCS
     bf16mul_test.cpp
   HDRS
-    AddTest.h
+    MulTest.h
   DEPENDS
     libc.hdr.errno_macros
     libc.hdr.fenv_macros

--- a/libc/test/src/math/smoke/bf16add_test.cpp
+++ b/libc/test/src/math/smoke/bf16add_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for bf16div ---------------------------------------------===//
+//===-- Unittests for bf16add ---------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "DivTest.h"
+#include "AddTest.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
-#include "src/math/bf16div.h"
+#include "src/math/bf16add.h"
 
-LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)
+LIST_ADD_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16add)

--- a/libc/test/src/math/smoke/bf16div_test.cpp
+++ b/libc/test/src/math/smoke/bf16div_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "AddTest.h"
+#include "DivTest.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/math/bf16div.h"
 
-LIST_ADD_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)
+LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)

--- a/libc/test/src/math/smoke/bf16div_test.cpp
+++ b/libc/test/src/math/smoke/bf16div_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "DivTest.h"
+#include "AddTest.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
 #include "src/math/bf16div.h"
 
-LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)
+LIST_ADD_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)

--- a/libc/test/src/math/smoke/bf16divf128_test.cpp
+++ b/libc/test/src/math/smoke/bf16divf128_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for bf16div ---------------------------------------------===//
+//===-- Unittests for bf16divf128 -----------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +9,6 @@
 #include "DivTest.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
-#include "src/math/bf16div.h"
+#include "src/math/bf16divf128.h"
 
-LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)
+LIST_DIV_TESTS(bfloat16, float128, LIBC_NAMESPACE::bf16divf128)

--- a/libc/test/src/math/smoke/bf16divf_test.cpp
+++ b/libc/test/src/math/smoke/bf16divf_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for bf16div ---------------------------------------------===//
+//===-- Unittests for bf16divf --------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +9,6 @@
 #include "DivTest.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
-#include "src/math/bf16div.h"
+#include "src/math/bf16divf.h"
 
-LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)
+LIST_DIV_TESTS(bfloat16, float, LIBC_NAMESPACE::bf16divf)

--- a/libc/test/src/math/smoke/bf16divl_test.cpp
+++ b/libc/test/src/math/smoke/bf16divl_test.cpp
@@ -1,4 +1,4 @@
-//===-- Unittests for bf16div ---------------------------------------------===//
+//===-- Unittests for bf16divl --------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +9,6 @@
 #include "DivTest.h"
 
 #include "src/__support/FPUtil/bfloat16.h"
-#include "src/math/bf16div.h"
+#include "src/math/bf16divl.h"
 
-LIST_DIV_TESTS(bfloat16, double, LIBC_NAMESPACE::bf16div)
+LIST_DIV_TESTS(bfloat16, long double, LIBC_NAMESPACE::bf16divl)


### PR DESCRIPTION
This PR adds the following basic math functions for BFloat16 type along with the tests:
- bf16div
- bf16divf
- bf16divl
- bf16divf128
