### PR TITLE
WIP: [Bolt] Add support for DT_INIT_ARRAY

### DIFF
--- a/bolt/include/bolt/Core/BinaryContext.h
+++ b/bolt/include/bolt/Core/BinaryContext.h
@@ -800,6 +800,15 @@ public:
   /// the execution of the binary is completed.
   std::optional<uint64_t> FiniFunctionAddress;
 
+  /// DT_INIT. Used when DT_INIT is available.
+  std::optional<uint64_t> InitAddress;
+
+  /// DT_INIT_ARRAY. Only used when DT_INIT is not set.
+  std::optional<uint64_t> InitArrayAddress;
+
+  /// DT_INIT_ARRAYSZ. Only used when DT_INIT is not set.
+  std::optional<uint64_t> InitArraySize;
+
   /// DT_FINI.
   std::optional<uint64_t> FiniAddress;
 

--- a/bolt/include/bolt/Rewrite/RewriteInstance.h
+++ b/bolt/include/bolt/Rewrite/RewriteInstance.h
@@ -93,10 +93,19 @@ private:
   /// section allocations if found.
   void discoverBOLTReserved();
 
+  /// Check whether we should use DT_INIT or DT_INIT_ARRAY for instrumentation.
+  /// DT_INIT is preferred; DT_INIT_ARRAY is only used when no DT_INIT entry was
+  /// found.
+  Error discoverRtInitAddress();
+
   /// Check whether we should use DT_FINI or DT_FINI_ARRAY for instrumentation.
   /// DT_FINI is preferred; DT_FINI_ARRAY is only used when no DT_FINI entry was
   /// found.
   Error discoverRtFiniAddress();
+
+  /// If DT_INIT_ARRAY is used for instrumentation, update the relocation of its
+  /// first entry to point to the instrumentation library's init address.
+  void updateRtInitReloc();
 
   /// If DT_FINI_ARRAY is used for instrumentation, update the relocation of its
   /// first entry to point to the instrumentation library's fini address.

--- a/bolt/lib/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
+++ b/bolt/lib/RuntimeLibs/InstrumentationRuntimeLibrary.cpp
@@ -51,12 +51,6 @@ void InstrumentationRuntimeLibrary::adjustCommandLineOptions(
     opts::JumpTables = JTS_MOVE;
     outs() << "BOLT-INFO: forcing -jump-tables=move for instrumentation\n";
   }
-  if (!BC.StartFunctionAddress) {
-    errs() << "BOLT-ERROR: instrumentation runtime libraries require a known "
-              "entry point of "
-              "the input binary\n";
-    exit(1);
-  }
 
   if (BC.IsStaticExecutable && !opts::InstrumentationSleepTime) {
     errs() << "BOLT-ERROR: instrumentation of static binary currently does not "
@@ -78,6 +72,13 @@ void InstrumentationRuntimeLibrary::adjustCommandLineOptions(
 
 void InstrumentationRuntimeLibrary::emitBinary(BinaryContext &BC,
                                                MCStreamer &Streamer) {
+  /*  if (!BC.StartFunctionAddress) {
+      errs() << "BOLT-ERROR: instrumentation runtime libraries require a known "
+                "entry point of "
+                "the input binary\n";
+      exit(1);
+    }*/
+
   MCSection *Section = BC.isELF()
                            ? static_cast<MCSection *>(BC.Ctx->getELFSection(
                                  ".bolt.instr.counters", ELF::SHT_PROGBITS,

--- a/bolt/test/AArch64/hook-init.s
+++ b/bolt/test/AArch64/hook-init.s
@@ -1,0 +1,96 @@
+## Test the different ways of handling entry point for instrumentation.
+## Bolt is hooking its runtime function via Elf entry, DT_INIT or DT_INIT_ARRAYS.
+## Bolt uses Elf e_entry address for ELF executable, and DT_INIT address
+## for ELF shared object to determine the start address.
+## The Test is checking the following cases:
+## - For executable, check ELF e_entry is pathced.
+## - For shared object:
+##   - Bolt use DT_INIT for hooking runtime start function if that exists.
+##   - If it doesn't exists, DT_INIT_ARRAY takes its place.
+# REQUIRES: system-linux,bolt-runtime,target=aarch64{{.*}}
+
+## Check e_entry address is updated with ELF PIE executable.
+# RUN: %clang %cflags -pie %s -Wl,-q -o %t.exe
+# RUN: llvm-readelf -l %t.exe | FileCheck --check-prefix=CHECK-INTERP %s
+# RUN: llvm-readelf -r %t.exe | FileCheck --check-prefix=RELOC-PIE %s
+# RUN: llvm-readelf -hs %t.exe | FileCheck --check-prefix=CHECK-START %s
+# RUN: llvm-bolt %t.exe -o %t --instrument
+# RUN: llvm-readelf -dhs %t | FileCheck --check-prefix=CHECK-ENTRY %s
+
+## Create a shared library to use DT_INIT for the instrumentation.
+# RUN: %clang %cflags -fPIC -shared %s -Wl,-q -o %t-init.so
+# RUN: llvm-bolt %t-init.so -o %t-init --instrument
+# RUN: llvm-readelf -drs %t-init | FileCheck --check-prefix=CHECK-INIT %s
+
+# Create a shared library with no init to use DT_INIT_ARRAY for the instrumentation.
+# RUN: %clang %cflags -shared %s -Wl,-q,-init=0 -o %t-no-init.so
+# RUN: llvm-bolt %t-no-init.so -o %t-no-init --instrument
+# RUN: llvm-readelf -drs %t-no-init | FileCheck --check-prefix=CHECK-NO-INIT %s
+
+## Check the binary has InterP header
+# CHECK-INTERP: Program Headers:
+# CHECK-INTERP: INTERP
+
+## With PIE: binary should have relative relocations
+# RELOC-PIE: R_AARCH64_RELATIVE
+
+## ELF excecutable where e_entry is set to __bolt_runtime_start (PIE).
+## Check the input that e_entry points to _start by default.
+# CHECK-START: ELF Header:
+# CHECK-START-DAG:   Entry point address: 0x[[ENTRY:[[:xdigit:]]+]]
+# CHECK-START: Symbol table '.symtab' contains {{.*}} entries:
+# CHECK-START-DAG: {{0+}}[[ENTRY]] {{.*}} _start
+## Check that e_entry is set to __bolt_runtime_start after the instrumentation.
+# CHECK-ENTRY: ELF Header:
+# CHECK-ENTRY-DAG:   Entry point address: 0x[[ENTRY:[[:xdigit:]]+]]
+# CHECK-ENTRY: Symbol table '.symtab' contains {{.*}} entries:
+# CHECK-ENTRY-DAG: {{0+}}[[ENTRY]] {{.*}} __bolt_runtime_start
+
+## Check that DT_INIT is set to __bolt_runtime_start.
+# CHECK-INIT:     Dynamic section at offset {{.*}} contains {{.*}} entries:
+# CHECK-INIT-DAG: (INIT) 0x[[INIT:[[:xdigit:]]+]]
+# CHECK-INIT-DAG: (INIT_ARRAY) 0x[[INIT_ARRAY:[[:xdigit:]]+]]
+## Check that the dynamic relocation at .init_array was not patched
+# CHECK-INIT:     Relocation section '.rela.dyn' at offset {{.*}} contains {{.*}} entries
+# CHECK-INIT:     {{0+}}[[INIT_ARRAY]] {{.*}} R_AARCH64_RELATIVE [[MYINIT_ADDR:[[:xdigit:]]+]
+]
+# CHECK-INIT:     Symbol table '.symtab' contains {{.*}} entries:
+# CHECK-INIT-DAG: {{0+}}[[MYINIT_ADDR]] {{.*}} _myinit
+
+## Check that DT_INIT_ARRAY is set to __bolt_runtime_start.
+# CHECK-NO-INIT:     Dynamic section at offset {{.*}} contains {{.*}} entries:
+# CHECK-NO-INIT-NOT: (INIT)
+# CHECK-NO-INIT:     (INIT_ARRAY) 0x[[INIT_ARRAY:[a-f0-9]+]]
+# CHECK-NO-INIT:     Relocation section '.rela.dyn' at offset {{.*}} contains {{.*}} entries
+# CHECK-NO-INIT:     {{0+}}[[INIT_ARRAY]] {{.*}} R_AARCH64_RELATIVE [[INIT_ADDR:[[:xdigit:]]+]]
+# CHECK-NO-INIT:     Symbol table '.symtab' contains {{.*}} entries:
+# CHECK-NO-INIT-DAG: {{0+}}[[INIT_ADDR]] {{.*}} __bolt_runtime_start
+
+  .globl _start
+  .type _start, %function
+_start:
+  # Dummy relocation to force relocation mode.
+  .reloc 0, R_AARCH64_NONE
+  ret
+.size _start, .-_start
+
+  .globl _init
+  .type _init, %function
+_init:
+  ret
+  .size _init, .-_init
+
+  .globl _fini
+  .type _fini, %function
+_fini:
+  ret
+  .size _fini, .-_fini
+
+  .section .text
+_myinit:
+  ret
+  .size _myinit, .-_myinit
+
+  .section .init_array,"aw"
+  .align 3
+  .dword _myinit # For relative relocation


### PR DESCRIPTION
Currently Bolt relies on ELF 'e_entry' field or DT_INIT to determine entry point of an ELF file for the instrumentation. There is a case when an ELF file only has DT_INIT_ARRAY/DT_FINI_ARRAY sections, and ELF 'e_entry' holds zero.