### PR TITLE
[Clang] Optimize tok::isLiteral with range-based condition

### DIFF
--- a/clang/include/clang/Basic/TokenKinds.h
+++ b/clang/include/clang/Basic/TokenKinds.h
@@ -95,10 +95,7 @@ inline bool isStringLiteral(TokenKind K) {
 /// Return true if this is a "literal" kind, like a numeric
 /// constant, string, etc.
 inline bool isLiteral(TokenKind K) {
-  return K == tok::numeric_constant || K == tok::char_constant ||
-         K == tok::wide_char_constant || K == tok::utf8_char_constant ||
-         K == tok::utf16_char_constant || K == tok::utf32_char_constant ||
-         isStringLiteral(K) || K == tok::header_name || K == tok::binary_data;
+  return K >= tok::numeric_constant && K <= tok::utf32_string_literal;
 }
 
 /// Return true if this is any of tok::annot_* kinds.

--- a/clang/include/clang/Basic/TokenKinds.h
+++ b/clang/include/clang/Basic/TokenKinds.h
@@ -104,10 +104,9 @@ inline bool isLiteral(TokenKind K) {
       K == tok::wide_char_constant || K == tok::utf8_char_constant ||
       K == tok::utf16_char_constant || K == tok::utf32_char_constant ||
       isStringLiteral(K) || K == tok::header_name || K == tok::binary_data;
-#endif
-
   assert(isInLiteralRange == isLiteralExplicit &&
-         "TokenKind literals should be contiguous");
+         "TokenKind literals should be contiguous");         
+#endif  
 
   return isInLiteralRange;
 }

--- a/clang/include/clang/Basic/TokenKinds.h
+++ b/clang/include/clang/Basic/TokenKinds.h
@@ -105,8 +105,8 @@ inline bool isLiteral(TokenKind K) {
       K == tok::utf16_char_constant || K == tok::utf32_char_constant ||
       isStringLiteral(K) || K == tok::header_name || K == tok::binary_data;
   assert(isInLiteralRange == isLiteralExplicit &&
-         "TokenKind literals should be contiguous");         
-#endif  
+         "TokenKind literals should be contiguous");
+#endif
 
   return isInLiteralRange;
 }

--- a/clang/include/clang/Basic/TokenKinds.h
+++ b/clang/include/clang/Basic/TokenKinds.h
@@ -95,7 +95,21 @@ inline bool isStringLiteral(TokenKind K) {
 /// Return true if this is a "literal" kind, like a numeric
 /// constant, string, etc.
 inline bool isLiteral(TokenKind K) {
-  return K >= tok::numeric_constant && K <= tok::utf32_string_literal;
+  const bool isInLiteralRange =
+      K >= tok::numeric_constant && K <= tok::utf32_string_literal;
+
+#if !NDEBUG
+  const bool isLiteralExplicit =
+      K == tok::numeric_constant || K == tok::char_constant ||
+      K == tok::wide_char_constant || K == tok::utf8_char_constant ||
+      K == tok::utf16_char_constant || K == tok::utf32_char_constant ||
+      isStringLiteral(K) || K == tok::header_name || K == tok::binary_data;
+#endif
+
+  assert(isInLiteralRange == isLiteralExplicit &&
+         "TokenKind literals should be contiguous");
+
+  return isInLiteralRange;
 }
 
 /// Return true if this is any of tok::annot_* kinds.


### PR DESCRIPTION
This commit optimizes `tok::isLiteral` by replacing a succession of `13` conditions with a range-based check.

I am not sure whether this is allowed. I believe it is done nowhere else in the codebase ; however, I have seen range-based conditions being used with other enums.