### PR TITLE
[lldb] Add flag to "settings show" to include default values

### DIFF
--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -340,11 +340,17 @@ protected:
   // DeepCopy to it. Inherit from Cloneable to avoid doing this manually.
   virtual lldb::OptionValueSP Clone() const = 0;
 
-  struct DefaultValueFormat {
+  class DefaultValueFormat {
+  public:
     DefaultValueFormat(Stream &stream) : stream(stream) {
       stream.PutCString(" (default: ");
     }
     ~DefaultValueFormat() { stream.PutChar(')'); }
+
+    DefaultValueFormat(const DefaultValueFormat &) = delete;
+    DefaultValueFormat &operator=(const DefaultValueFormat &) = delete;
+
+  private:
     Stream &stream;
   };
 

--- a/lldb/include/lldb/Interpreter/OptionValue.h
+++ b/lldb/include/lldb/Interpreter/OptionValue.h
@@ -17,6 +17,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/Status.h"
+#include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StringList.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-defines.h"
@@ -61,6 +62,7 @@ public:
     eDumpOptionDescription = (1u << 3),
     eDumpOptionRaw = (1u << 4),
     eDumpOptionCommand = (1u << 5),
+    eDumpOptionDefaultValue = (1u << 6),
     eDumpGroupValue = (eDumpOptionName | eDumpOptionType | eDumpOptionValue),
     eDumpGroupHelp =
         (eDumpOptionName | eDumpOptionType | eDumpOptionDescription),
@@ -337,6 +339,14 @@ protected:
   // Must be overriden by a derived class for correct downcasting the result of
   // DeepCopy to it. Inherit from Cloneable to avoid doing this manually.
   virtual lldb::OptionValueSP Clone() const = 0;
+
+  struct DefaultValueFormat {
+    DefaultValueFormat(Stream &stream) : stream(stream) {
+      stream.PutCString(" (default: ");
+    }
+    ~DefaultValueFormat() { stream.PutChar(')'); }
+    Stream &stream;
+  };
 
   lldb::OptionValueWP m_parent_wp;
   std::function<void()> m_callback;

--- a/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
+++ b/lldb/include/lldb/Interpreter/OptionValueEnumeration.h
@@ -72,6 +72,7 @@ public:
 
 protected:
   void SetEnumerations(const OptionEnumValues &enumerators);
+  void DumpEnum(Stream &strm, enum_type value);
 
   enum_type m_current_value;
   enum_type m_default_value;

--- a/lldb/include/lldb/Utility/ArchSpec.h
+++ b/lldb/include/lldb/Utility/ArchSpec.h
@@ -564,6 +564,7 @@ protected:
 /// \return true if \a lhs is less than \a rhs
 bool operator<(const ArchSpec &lhs, const ArchSpec &rhs);
 bool operator==(const ArchSpec &lhs, const ArchSpec &rhs);
+bool operator!=(const ArchSpec &lhs, const ArchSpec &rhs);
 
 bool ParseMachCPUDashSubtypeTriple(llvm::StringRef triple_str, ArchSpec &arch);
 

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -237,28 +237,62 @@ private:
 };
 
 // CommandObjectSettingsShow -- Show current values
+#define LLDB_OPTIONS_settings_show
+#include "CommandOptions.inc"
 
 class CommandObjectSettingsShow : public CommandObjectParsed {
 public:
   CommandObjectSettingsShow(CommandInterpreter &interpreter)
       : CommandObjectParsed(interpreter, "settings show",
                             "Show matching debugger settings and their current "
-                            "values.  Defaults to showing all settings.",
-                            nullptr) {
+                            "values.  Defaults to showing all settings.") {
     AddSimpleArgumentList(eArgTypeSettingVariableName, eArgRepeatOptional);
   }
 
   ~CommandObjectSettingsShow() override = default;
 
+  Options *GetOptions() override { return &m_options; }
+
+  class CommandOptions : public Options {
+  public:
+    ~CommandOptions() override = default;
+
+    Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_arg,
+                          ExecutionContext *execution_context) override {
+      const int short_option = m_getopt_table[option_idx].val;
+      switch (short_option) {
+      case 'v':
+        m_verbose = true;
+        break;
+      default:
+        llvm_unreachable("Unimplemented option");
+      }
+      return {};
+    }
+
+    void OptionParsingStarting(ExecutionContext *execution_context) override {
+      m_verbose = false;
+    }
+
+    llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
+      return g_settings_show_options;
+    }
+
+    bool m_verbose = false;
+  };
+
 protected:
   void DoExecute(Args &args, CommandReturnObject &result) override {
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
+    uint32_t dump_mask = OptionValue::eDumpGroupValue;
+    if (m_options.m_verbose)
+      dump_mask |= OptionValue::eDumpOptionDefaultValue;
+
     if (!args.empty()) {
       for (const auto &arg : args) {
         Status error(GetDebugger().DumpPropertyValue(
-            &m_exe_ctx, result.GetOutputStream(), arg.ref(),
-            OptionValue::eDumpGroupValue));
+            &m_exe_ctx, result.GetOutputStream(), arg.ref(), dump_mask));
         if (error.Success()) {
           result.GetOutputStream().EOL();
         } else {
@@ -267,9 +301,12 @@ protected:
       }
     } else {
       GetDebugger().DumpAllPropertyValues(&m_exe_ctx, result.GetOutputStream(),
-                                          OptionValue::eDumpGroupValue);
+                                          dump_mask);
     }
   }
+
+private:
+  CommandOptions m_options;
 };
 
 // CommandObjectSettingsWrite -- Write settings to file

--- a/lldb/source/Commands/CommandObjectSettings.cpp
+++ b/lldb/source/Commands/CommandObjectSettings.cpp
@@ -261,8 +261,8 @@ public:
                           ExecutionContext *execution_context) override {
       const int short_option = m_getopt_table[option_idx].val;
       switch (short_option) {
-      case 'v':
-        m_verbose = true;
+      case 'd':
+        m_include_defaults = true;
         break;
       default:
         llvm_unreachable("Unimplemented option");
@@ -271,14 +271,14 @@ public:
     }
 
     void OptionParsingStarting(ExecutionContext *execution_context) override {
-      m_verbose = false;
+      m_include_defaults = false;
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
       return g_settings_show_options;
     }
 
-    bool m_verbose = false;
+    bool m_include_defaults = false;
   };
 
 protected:
@@ -286,7 +286,7 @@ protected:
     result.SetStatus(eReturnStatusSuccessFinishResult);
 
     uint32_t dump_mask = OptionValue::eDumpGroupValue;
-    if (m_options.m_verbose)
+    if (m_options.m_include_defaults)
       dump_mask |= OptionValue::eDumpOptionDefaultValue;
 
     if (!args.empty()) {

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -57,7 +57,7 @@ let Command = "settings clear" in {
 }
 
 let Command = "settings show" in {
-  def setshow_include_defaults : Option<"include-defaults", "d">,
+  def setshow_defaults : Option<"defaults", "d">,
     Desc<"Include default values if defined.">;
 }
 

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -56,6 +56,11 @@ let Command = "settings clear" in {
     Desc<"Clear all settings.">;
 }
 
+let Command = "settings show" in {
+  def setshow_verbose : Option<"verbose", "v">,
+    Desc<"Enable verbose output.">;
+}
+
 let Command = "breakpoint list" in {
   // FIXME: We need to add an "internal" command, and then add this sort of
   // thing to it. But I need to see it for now, and don't want to wait.

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -57,8 +57,8 @@ let Command = "settings clear" in {
 }
 
 let Command = "settings show" in {
-  def setshow_verbose : Option<"verbose", "v">,
-    Desc<"Enable verbose output.">;
+  def setshow_include_defaults : Option<"include-defaults", "d">,
+    Desc<"Include default values if defined.">;
 }
 
 let Command = "breakpoint list" in {

--- a/lldb/source/Interpreter/OptionValueArch.cpp
+++ b/lldb/source/Interpreter/OptionValueArch.cpp
@@ -11,6 +11,7 @@
 #include "lldb/DataFormatters/FormatManager.h"
 #include "lldb/Interpreter/CommandCompletions.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/State.h"
 
@@ -29,6 +30,12 @@ void OptionValueArch::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
       const char *arch_name = m_current_value.GetArchitectureName();
       if (arch_name)
         strm.PutCString(arch_name);
+    }
+
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value && m_default_value.IsValid()) {
+      DefaultValueFormat label{strm};
+      strm.PutCString(m_default_value.GetArchitectureName());
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueArch.cpp
+++ b/lldb/source/Interpreter/OptionValueArch.cpp
@@ -34,7 +34,7 @@ void OptionValueArch::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
 
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value && m_default_value.IsValid()) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.PutCString(m_default_value.GetArchitectureName());
     }
   }

--- a/lldb/source/Interpreter/OptionValueArray.cpp
+++ b/lldb/source/Interpreter/OptionValueArray.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/OptionValueArray.h"
 
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/Stream.h"
 
@@ -27,8 +28,15 @@ void OptionValueArray::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
   if (dump_mask & eDumpOptionValue) {
     const bool one_line = dump_mask & eDumpOptionCommand;
     const uint32_t size = m_values.size();
-    if (dump_mask & eDumpOptionType)
-      strm.Printf(" =%s", (m_values.size() > 0 && !one_line) ? "\n" : "");
+    if (dump_mask & (eDumpOptionType | eDumpOptionDefaultValue)) {
+      strm.PutCString(" =");
+      if (dump_mask & eDumpOptionDefaultValue && !m_values.empty()) {
+        DefaultValueFormat label(strm);
+        strm.PutCString("empty");
+      }
+      if (!m_values.empty() && !one_line)
+        strm.PutCString("\n");
+    }
     if (!one_line)
       strm.IndentMore();
     for (uint32_t i = 0; i < size; ++i) {

--- a/lldb/source/Interpreter/OptionValueBoolean.cpp
+++ b/lldb/source/Interpreter/OptionValueBoolean.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/Host/PosixApi.h"
 #include "lldb/Interpreter/OptionArgParser.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StringList.h"
 #include "llvm/ADT/STLExtras.h"
@@ -27,6 +28,11 @@ void OptionValueBoolean::DumpValue(const ExecutionContext *exe_ctx,
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
     strm.PutCString(m_current_value ? "true" : "false");
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value) {
+      DefaultValueFormat label{strm};
+      strm.PutCString(m_default_value ? "true" : "false");
+    }
   }
 }
 

--- a/lldb/source/Interpreter/OptionValueBoolean.cpp
+++ b/lldb/source/Interpreter/OptionValueBoolean.cpp
@@ -30,7 +30,7 @@ void OptionValueBoolean::DumpValue(const ExecutionContext *exe_ctx,
     strm.PutCString(m_current_value ? "true" : "false");
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.PutCString(m_default_value ? "true" : "false");
     }
   }

--- a/lldb/source/Interpreter/OptionValueChar.cpp
+++ b/lldb/source/Interpreter/OptionValueChar.cpp
@@ -35,7 +35,7 @@ void OptionValueChar::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     DumpChar(strm, m_current_value);
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       DumpChar(strm, m_default_value);
     }
   }

--- a/lldb/source/Interpreter/OptionValueChar.cpp
+++ b/lldb/source/Interpreter/OptionValueChar.cpp
@@ -9,12 +9,20 @@
 #include "lldb/Interpreter/OptionValueChar.h"
 
 #include "lldb/Interpreter/OptionArgParser.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StringList.h"
 #include "llvm/ADT/STLExtras.h"
 
 using namespace lldb;
 using namespace lldb_private;
+
+static void DumpChar(Stream &strm, char value) {
+  if (value != '\0')
+    strm.PutChar(value);
+  else
+    strm.PutCString("(null)");
+}
 
 void OptionValueChar::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
                                 uint32_t dump_mask) {
@@ -24,10 +32,12 @@ void OptionValueChar::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
   if (dump_mask & eDumpOptionValue) {
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
-    if (m_current_value != '\0')
-      strm.PutChar(m_current_value);
-    else
-      strm.PutCString("(null)");
+    DumpChar(strm, m_current_value);
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value) {
+      DefaultValueFormat label{strm};
+      DumpChar(strm, m_default_value);
+    }
   }
 }
 

--- a/lldb/source/Interpreter/OptionValueDictionary.cpp
+++ b/lldb/source/Interpreter/OptionValueDictionary.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Interpreter/OptionValueDictionary.h"
 
 #include "lldb/DataFormatters/FormatManager.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Interpreter/OptionValueEnumeration.h"
 #include "lldb/Interpreter/OptionValueString.h"
 #include "lldb/Utility/Args.h"
@@ -30,8 +31,13 @@ void OptionValueDictionary::DumpValue(const ExecutionContext *exe_ctx,
   }
   if (dump_mask & eDumpOptionValue) {
     const bool one_line = dump_mask & eDumpOptionCommand;
-    if (dump_mask & eDumpOptionType)
+    if (dump_mask & (eDumpOptionType | eDumpOptionDefaultValue)) {
       strm.PutCString(" =");
+      if (dump_mask & eDumpOptionDefaultValue && !m_values.empty()) {
+        DefaultValueFormat label(strm);
+        strm.PutCString("empty");
+      }
+    }
 
     if (!one_line)
       strm.IndentMore();

--- a/lldb/source/Interpreter/OptionValueEnumeration.cpp
+++ b/lldb/source/Interpreter/OptionValueEnumeration.cpp
@@ -41,7 +41,7 @@ void OptionValueEnumeration::DumpValue(const ExecutionContext *exe_ctx,
     DumpEnum(strm, m_current_value);
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       DumpEnum(strm, m_default_value);
     }
   }

--- a/lldb/source/Interpreter/OptionValueEnumeration.cpp
+++ b/lldb/source/Interpreter/OptionValueEnumeration.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/OptionValueEnumeration.h"
 
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/StringList.h"
 
 using namespace lldb;
@@ -19,6 +20,17 @@ OptionValueEnumeration::OptionValueEnumeration(
   SetEnumerations(enumerators);
 }
 
+void OptionValueEnumeration::DumpEnum(Stream &strm, enum_type value) {
+  const size_t count = m_enumerations.GetSize();
+  for (size_t i = 0; i < count; ++i)
+    if (m_enumerations.GetValueAtIndexUnchecked(i).value == value) {
+      strm.PutCString(m_enumerations.GetCStringAtIndex(i));
+      return;
+    }
+
+  strm.Printf("%" PRIu64, (uint64_t)value);
+}
+
 void OptionValueEnumeration::DumpValue(const ExecutionContext *exe_ctx,
                                        Stream &strm, uint32_t dump_mask) {
   if (dump_mask & eDumpOptionType)
@@ -26,14 +38,12 @@ void OptionValueEnumeration::DumpValue(const ExecutionContext *exe_ctx,
   if (dump_mask & eDumpOptionValue) {
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
-    const size_t count = m_enumerations.GetSize();
-    for (size_t i = 0; i < count; ++i) {
-      if (m_enumerations.GetValueAtIndexUnchecked(i).value == m_current_value) {
-        strm.PutCString(m_enumerations.GetCStringAtIndex(i).GetStringRef());
-        return;
-      }
+    DumpEnum(strm, m_current_value);
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value) {
+      DefaultValueFormat label{strm};
+      DumpEnum(strm, m_default_value);
     }
-    strm.Printf("%" PRIu64, (uint64_t)m_current_value);
   }
 }
 

--- a/lldb/source/Interpreter/OptionValueFileSpec.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpec.cpp
@@ -42,12 +42,12 @@ void OptionValueFileSpec::DumpValue(const ExecutionContext *exe_ctx,
       strm.PutCString(" = ");
 
     if (m_current_value) {
-      strm.QuotedCString(m_current_value.GetPath().data());
+      strm << '"' << m_current_value.GetPath() << '"';
     }
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value && m_default_value) {
       DefaultValueFormat label(strm);
-      strm.QuotedCString(m_default_value.GetPath().data());
+      strm << '"' << m_default_value.GetPath() << '"';
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueFileSpec.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpec.cpp
@@ -46,7 +46,7 @@ void OptionValueFileSpec::DumpValue(const ExecutionContext *exe_ctx,
     }
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value && m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.QuotedCString(m_default_value.GetPath().data());
     }
   }

--- a/lldb/source/Interpreter/OptionValueFileSpec.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpec.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Interpreter/CommandCompletions.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/State.h"
 
@@ -41,7 +42,12 @@ void OptionValueFileSpec::DumpValue(const ExecutionContext *exe_ctx,
       strm.PutCString(" = ");
 
     if (m_current_value) {
-      strm << '"' << m_current_value.GetPath().c_str() << '"';
+      strm.QuotedCString(m_current_value.GetPath().data());
+    }
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value && m_default_value) {
+      DefaultValueFormat label{strm};
+      strm.QuotedCString(m_default_value.GetPath().data());
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueFileSpecList.cpp
+++ b/lldb/source/Interpreter/OptionValueFileSpecList.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/OptionValueFileSpecList.h"
 
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/Stream.h"
 
@@ -22,9 +23,15 @@ void OptionValueFileSpecList::DumpValue(const ExecutionContext *exe_ctx,
   if (dump_mask & eDumpOptionValue) {
     const bool one_line = dump_mask & eDumpOptionCommand;
     const uint32_t size = m_current_value.GetSize();
-    if (dump_mask & eDumpOptionType)
-      strm.Printf(" =%s",
-                  (m_current_value.GetSize() > 0 && !one_line) ? "\n" : "");
+    if (dump_mask & (eDumpOptionType | eDumpOptionDefaultValue)) {
+      strm.Printf(" =");
+      if (dump_mask & eDumpOptionDefaultValue && !m_current_value.IsEmpty()) {
+        DefaultValueFormat label(strm);
+        strm.PutCString("empty");
+      }
+      if (!m_current_value.IsEmpty() && !one_line)
+        strm.PutCString("\n");
+    }
     if (!one_line)
       strm.IndentMore();
     for (uint32_t i = 0; i < size; ++i) {

--- a/lldb/source/Interpreter/OptionValueFormat.cpp
+++ b/lldb/source/Interpreter/OptionValueFormat.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/DataFormatters/FormatManager.h"
 #include "lldb/Interpreter/OptionArgParser.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 
 using namespace lldb;
@@ -23,6 +24,11 @@ void OptionValueFormat::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
     strm.PutCString(FormatManager::GetFormatAsCString(m_current_value));
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value) {
+      DefaultValueFormat label{strm};
+      strm.PutCString(FormatManager::GetFormatAsCString(m_default_value));
+    }
   }
 }
 

--- a/lldb/source/Interpreter/OptionValueFormat.cpp
+++ b/lldb/source/Interpreter/OptionValueFormat.cpp
@@ -26,7 +26,7 @@ void OptionValueFormat::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     strm.PutCString(FormatManager::GetFormatAsCString(m_current_value));
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.PutCString(FormatManager::GetFormatAsCString(m_default_value));
     }
   }

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -55,11 +55,11 @@ void OptionValueFormatEntity::DumpValue(const ExecutionContext *exe_ctx,
   if (dump_mask & eDumpOptionValue) {
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
-    strm.QuotedCString(EscapeBackticks(m_current_format).data());
+    strm << '"' << EscapeBackticks(m_current_format) << '"';
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_format != m_default_format) {
       DefaultValueFormat label(strm);
-      strm.QuotedCString(EscapeBackticks(m_default_format).data());
+      strm << '"' << EscapeBackticks(m_default_format) << '"';
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -36,6 +36,7 @@ void OptionValueFormatEntity::Clear() {
 
 static std::string EscapeBackticks(llvm::StringRef str) {
   std::string dst;
+  dst.reserve(str.size());
   for (size_t i = 0, e = str.size(); i != e; ++i) {
     char c = str[i];
     if (c == '`') {

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -57,7 +57,7 @@ void OptionValueFormatEntity::DumpValue(const ExecutionContext *exe_ctx,
     strm.QuotedCString(EscapeBackticks(m_current_format).data());
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_format != m_default_format) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.QuotedCString(EscapeBackticks(m_default_format).data());
     }
   }

--- a/lldb/source/Interpreter/OptionValueFormatEntity.cpp
+++ b/lldb/source/Interpreter/OptionValueFormatEntity.cpp
@@ -10,6 +10,7 @@
 
 #include "lldb/Core/Module.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StringList.h"
 using namespace lldb;
@@ -33,10 +34,8 @@ void OptionValueFormatEntity::Clear() {
   m_value_was_set = false;
 }
 
-static void EscapeBackticks(llvm::StringRef str, std::string &dst) {
-  dst.clear();
-  dst.reserve(str.size());
-
+static std::string EscapeBackticks(llvm::StringRef str) {
+  std::string dst;
   for (size_t i = 0, e = str.size(); i != e; ++i) {
     char c = str[i];
     if (c == '`') {
@@ -45,6 +44,7 @@ static void EscapeBackticks(llvm::StringRef str, std::string &dst) {
     }
     dst += c;
   }
+  return dst;
 }
 
 void OptionValueFormatEntity::DumpValue(const ExecutionContext *exe_ctx,
@@ -54,17 +54,18 @@ void OptionValueFormatEntity::DumpValue(const ExecutionContext *exe_ctx,
   if (dump_mask & eDumpOptionValue) {
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
-    std::string escaped;
-    EscapeBackticks(m_current_format, escaped);
-    strm << '"' << escaped << '"';
+    strm.QuotedCString(EscapeBackticks(m_current_format).data());
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_format != m_default_format) {
+      DefaultValueFormat label{strm};
+      strm.QuotedCString(EscapeBackticks(m_default_format).data());
+    }
   }
 }
 
 llvm::json::Value
 OptionValueFormatEntity::ToJSON(const ExecutionContext *exe_ctx) const {
-  std::string escaped;
-  EscapeBackticks(m_current_format, escaped);
-  return escaped;
+  return EscapeBackticks(m_current_format);
 }
 
 Status OptionValueFormatEntity::SetValueFromString(llvm::StringRef value_str,

--- a/lldb/source/Interpreter/OptionValueLanguage.cpp
+++ b/lldb/source/Interpreter/OptionValueLanguage.cpp
@@ -9,8 +9,9 @@
 #include "lldb/Interpreter/OptionValueLanguage.h"
 
 #include "lldb/DataFormatters/FormatManager.h"
-#include "lldb/Target/Language.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Symbol/TypeSystem.h"
+#include "lldb/Target/Language.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/Stream.h"
 
@@ -26,6 +27,12 @@ void OptionValueLanguage::DumpValue(const ExecutionContext *exe_ctx,
       strm.PutCString(" = ");
     if (m_current_value != eLanguageTypeUnknown)
       strm.PutCString(Language::GetNameForLanguageType(m_current_value));
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value &&
+        m_default_value != eLanguageTypeUnknown) {
+      DefaultValueFormat label{strm};
+      strm.PutCString(Language::GetNameForLanguageType(m_default_value));
+    }
   }
 }
 

--- a/lldb/source/Interpreter/OptionValueLanguage.cpp
+++ b/lldb/source/Interpreter/OptionValueLanguage.cpp
@@ -30,7 +30,7 @@ void OptionValueLanguage::DumpValue(const ExecutionContext *exe_ctx,
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value &&
         m_default_value != eLanguageTypeUnknown) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.PutCString(Language::GetNameForLanguageType(m_default_value));
     }
   }

--- a/lldb/source/Interpreter/OptionValuePathMappings.cpp
+++ b/lldb/source/Interpreter/OptionValuePathMappings.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Interpreter/OptionValuePathMappings.h"
 
 #include "lldb/Host/FileSystem.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Stream.h"
@@ -28,8 +29,15 @@ void OptionValuePathMappings::DumpValue(const ExecutionContext *exe_ctx,
   if (dump_mask & eDumpOptionType)
     strm.Printf("(%s)", GetTypeAsCString());
   if (dump_mask & eDumpOptionValue) {
-    if (dump_mask & eDumpOptionType)
-      strm.Printf(" =%s", (m_path_mappings.GetSize() > 0) ? "\n" : "");
+    if (dump_mask & (eDumpOptionType | eDumpOptionDefaultValue)) {
+      strm.Printf(" =");
+      if (dump_mask & eDumpOptionDefaultValue && !m_path_mappings.IsEmpty()) {
+        DefaultValueFormat label(strm);
+        strm.PutCString("empty");
+      }
+      if (!m_path_mappings.IsEmpty())
+        strm.PutCString("\n");
+    }
     m_path_mappings.Dump(&strm);
   }
 }

--- a/lldb/source/Interpreter/OptionValueRegex.cpp
+++ b/lldb/source/Interpreter/OptionValueRegex.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/OptionValueRegex.h"
 
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 
 using namespace lldb;
@@ -23,6 +24,12 @@ void OptionValueRegex::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     if (m_regex.IsValid()) {
       llvm::StringRef regex_text = m_regex.GetText();
       strm.Printf("%s", regex_text.str().c_str());
+    }
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_regex.GetText() != m_default_regex_str &&
+        !m_default_regex_str.empty()) {
+      DefaultValueFormat label{strm};
+      strm.PutCString(m_default_regex_str);
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueRegex.cpp
+++ b/lldb/source/Interpreter/OptionValueRegex.cpp
@@ -28,7 +28,7 @@ void OptionValueRegex::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     if (dump_mask & eDumpOptionDefaultValue &&
         m_regex.GetText() != m_default_regex_str &&
         !m_default_regex_str.empty()) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.PutCString(m_default_regex_str);
     }
   }

--- a/lldb/source/Interpreter/OptionValueSInt64.cpp
+++ b/lldb/source/Interpreter/OptionValueSInt64.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/OptionValueSInt64.h"
 
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 
 using namespace lldb;
@@ -26,6 +27,11 @@ void OptionValueSInt64::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
     strm.Printf("%" PRIi64, m_current_value);
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value) {
+      DefaultValueFormat label{strm};
+      strm.Printf("%" PRIi64, m_default_value);
+    }
   }
 }
 

--- a/lldb/source/Interpreter/OptionValueSInt64.cpp
+++ b/lldb/source/Interpreter/OptionValueSInt64.cpp
@@ -29,7 +29,7 @@ void OptionValueSInt64::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     strm.Printf("%" PRIi64, m_current_value);
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.Printf("%" PRIi64, m_default_value);
     }
   }

--- a/lldb/source/Interpreter/OptionValueString.cpp
+++ b/lldb/source/Interpreter/OptionValueString.cpp
@@ -20,7 +20,7 @@ static void DumpString(Stream &strm, const std::string &str, bool escape,
                        bool raw) {
   if (escape) {
     std::string escaped_str;
-    Args::ExpandEscapedCharacters(str.data(), escaped_str);
+    Args::ExpandEscapedCharacters(str.c_str(), escaped_str);
     DumpString(strm, escaped_str, false, raw);
     return;
   }
@@ -28,7 +28,7 @@ static void DumpString(Stream &strm, const std::string &str, bool escape,
   if (raw)
     strm.PutCString(str);
   else
-    strm.QuotedCString(str.data());
+    strm.QuotedCString(str.c_str());
 }
 
 void OptionValueString::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,

--- a/lldb/source/Interpreter/OptionValueString.cpp
+++ b/lldb/source/Interpreter/OptionValueString.cpp
@@ -45,7 +45,7 @@ void OptionValueString::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
 
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value && !m_default_value.empty()) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       ::DumpValue(strm, m_default_value, escape, raw);
     }
   }

--- a/lldb/source/Interpreter/OptionValueString.cpp
+++ b/lldb/source/Interpreter/OptionValueString.cpp
@@ -9,11 +9,27 @@
 #include "lldb/Interpreter/OptionValueString.h"
 
 #include "lldb/Host/OptionParser.h"
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Args.h"
 #include "lldb/Utility/Stream.h"
 
 using namespace lldb;
 using namespace lldb_private;
+
+static void DumpValue(Stream &strm, const std::string &str, bool escape,
+                      bool raw) {
+  if (escape) {
+    std::string escaped_str;
+    Args::ExpandEscapedCharacters(str.data(), escaped_str);
+    ::DumpValue(strm, escaped_str, false, raw);
+    return;
+  }
+
+  if (raw)
+    strm.PutCString(str);
+  else
+    strm.QuotedCString(str.data());
+}
 
 void OptionValueString::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
                                   uint32_t dump_mask) {
@@ -22,21 +38,15 @@ void OptionValueString::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
   if (dump_mask & eDumpOptionValue) {
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
-    if (!m_current_value.empty() || m_value_was_set) {
-      if (m_options.Test(eOptionEncodeCharacterEscapeSequences)) {
-        std::string expanded_escape_value;
-        Args::ExpandEscapedCharacters(m_current_value.c_str(),
-                                      expanded_escape_value);
-        if (dump_mask & eDumpOptionRaw)
-          strm.Printf("%s", expanded_escape_value.c_str());
-        else
-          strm.Printf("\"%s\"", expanded_escape_value.c_str());
-      } else {
-        if (dump_mask & eDumpOptionRaw)
-          strm.Printf("%s", m_current_value.c_str());
-        else
-          strm.Printf("\"%s\"", m_current_value.c_str());
-      }
+    const bool escape = m_options.Test(eOptionEncodeCharacterEscapeSequences);
+    const bool raw = dump_mask & eDumpOptionRaw;
+    if (!m_current_value.empty() || m_value_was_set)
+      ::DumpValue(strm, m_current_value, escape, raw);
+
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value && !m_default_value.empty()) {
+      DefaultValueFormat label{strm};
+      ::DumpValue(strm, m_default_value, escape, raw);
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueString.cpp
+++ b/lldb/source/Interpreter/OptionValueString.cpp
@@ -16,12 +16,12 @@
 using namespace lldb;
 using namespace lldb_private;
 
-static void DumpValue(Stream &strm, const std::string &str, bool escape,
-                      bool raw) {
+static void DumpString(Stream &strm, const std::string &str, bool escape,
+                       bool raw) {
   if (escape) {
     std::string escaped_str;
     Args::ExpandEscapedCharacters(str.data(), escaped_str);
-    ::DumpValue(strm, escaped_str, false, raw);
+    DumpString(strm, escaped_str, false, raw);
     return;
   }
 
@@ -41,12 +41,12 @@ void OptionValueString::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     const bool escape = m_options.Test(eOptionEncodeCharacterEscapeSequences);
     const bool raw = dump_mask & eDumpOptionRaw;
     if (!m_current_value.empty() || m_value_was_set)
-      ::DumpValue(strm, m_current_value, escape, raw);
+      DumpString(strm, m_current_value, escape, raw);
 
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value && !m_default_value.empty()) {
       DefaultValueFormat label(strm);
-      ::DumpValue(strm, m_default_value, escape, raw);
+      DumpString(strm, m_default_value, escape, raw);
     }
   }
 }

--- a/lldb/source/Interpreter/OptionValueUInt64.cpp
+++ b/lldb/source/Interpreter/OptionValueUInt64.cpp
@@ -33,7 +33,7 @@ void OptionValueUInt64::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     strm.Printf("%" PRIu64, m_current_value);
     if (dump_mask & eDumpOptionDefaultValue &&
         m_current_value != m_default_value) {
-      DefaultValueFormat label{strm};
+      DefaultValueFormat label(strm);
       strm.Printf("%" PRIu64, m_default_value);
     }
   }

--- a/lldb/source/Interpreter/OptionValueUInt64.cpp
+++ b/lldb/source/Interpreter/OptionValueUInt64.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/OptionValueUInt64.h"
 
+#include "lldb/Interpreter/OptionValue.h"
 #include "lldb/Utility/Stream.h"
 
 using namespace lldb;
@@ -30,6 +31,11 @@ void OptionValueUInt64::DumpValue(const ExecutionContext *exe_ctx, Stream &strm,
     if (dump_mask & eDumpOptionType)
       strm.PutCString(" = ");
     strm.Printf("%" PRIu64, m_current_value);
+    if (dump_mask & eDumpOptionDefaultValue &&
+        m_current_value != m_default_value) {
+      DefaultValueFormat label{strm};
+      strm.Printf("%" PRIu64, m_default_value);
+    }
   }
 }
 

--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -1439,6 +1439,10 @@ bool lldb_private::operator==(const ArchSpec &lhs, const ArchSpec &rhs) {
   return lhs.GetCore() == rhs.GetCore();
 }
 
+bool lldb_private::operator!=(const ArchSpec &lhs, const ArchSpec &rhs) {
+  return !(lhs == rhs);
+}
+
 bool ArchSpec::IsFullySpecifiedTriple() const {
   if (!TripleOSWasSpecified())
     return false;

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -1039,6 +1039,50 @@ class SettingsCommandTestCase(TestBase):
             "settings show --defaults disassembly-format",
             patterns=[r'= "dollar" \(default: ".+"\)'],
         )
+        # arrays
+        self.expect(
+            "settings show --defaults target.unset-env-vars",
+            matching=False,
+            substrs=["(default: empty)"],
+        )
+        self.runCmd("settings set target.unset-env-vars PATH")
+        self.expect(
+            "settings show --defaults target.unset-env-vars",
+            substrs=["(default: empty)", '[0]: "PATH"'],
+        )
+        # dictionaries
+        self.expect(
+            "settings show --defaults target.env-vars",
+            matching=False,
+            substrs=["(default: empty)"],
+        )
+        self.runCmd("settings set target.env-vars THING=value")
+        self.expect(
+            "settings show --defaults target.env-vars",
+            substrs=["(default: empty)", "THING=value"],
+        )
+        # file list
+        self.expect(
+            "settings show --defaults target.exec-search-paths",
+            matching=False,
+            substrs=["(default: empty)"],
+        )
+        self.runCmd("settings set target.exec-search-paths /tmp")
+        self.expect(
+            "settings show --defaults target.exec-search-paths",
+            substrs=["(default: empty)", "[0]: /tmp"],
+        )
+        # path map
+        self.expect(
+            "settings show --defaults target.source-map",
+            matching=False,
+            substrs=["(default: empty)"],
+        )
+        self.runCmd("settings set target.source-map /abc /tmp")
+        self.expect(
+            "settings show --defaults target.source-map",
+            substrs=["(default: empty)", '[0] "/abc" -> "/tmp"'],
+        )
 
     def get_setting_json(self, setting_path=None):
         settings_data = self.dbg.GetSetting(setting_path)

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -972,6 +972,74 @@ class SettingsCommandTestCase(TestBase):
         # A known option should fail if its argument is invalid.
         self.expect("settings set auto-confirm bogus", error=True)
 
+    def test_settings_show_defaults(self):
+        # boolean
+        self.expect(
+            "settings show --defaults auto-one-line-summaries",
+            matching=False,
+            substrs=["(default: true)"],
+        )
+        self.runCmd("settings set auto-one-line-summaries false")
+        self.expect(
+            "settings show --defaults auto-one-line-summaries",
+            substrs=["= false (default: true)"],
+        )
+        # unsigned
+        self.expect(
+            "settings show --defaults stop-line-count-before",
+            matching=False,
+            patterns=[r"\(default: \d+\)"],
+        )
+        self.runCmd("settings set stop-line-count-before 99")
+        self.expect(
+            "settings show --defaults stop-line-count-before",
+            patterns=[r"= 99 \(default: \d+\)"],
+        )
+        # string
+        self.expect(
+            "settings show --defaults prompt",
+            matching=False,
+            patterns=[r'\(default: ".+"\)'],
+        )
+        self.runCmd("settings set prompt '<LlDb> '")
+        self.expect(
+            "settings show --defaults prompt",
+            patterns=[r'= "<LlDb> " \(default: ".+"\)'],
+        )
+        # enum
+        self.expect(
+            "settings show --defaults stop-disassembly-display",
+            matching=False,
+            patterns=[r"\(default: .+\)"],
+        )
+        self.runCmd("settings set stop-disassembly-display no-source")
+        self.expect(
+            "settings show --defaults stop-disassembly-display",
+            patterns=[r"= no-source \(default: .+\)"],
+        )
+        # regex
+        self.expect(
+            "settings show --defaults target.process.thread.step-avoid-regexp",
+            matching=False,
+            patterns=[r"\(default: .+\)"],
+        )
+        self.runCmd("settings set target.process.thread.step-avoid-regexp dotstar")
+        self.expect(
+            "settings show --defaults target.process.thread.step-avoid-regexp",
+            patterns=[r"= dotstar \(default: .+\)"],
+        )
+        # format-string
+        self.expect(
+            "settings show --defaults disassembly-format",
+            matching=False,
+            patterns=[r'\(default: ".+"\)'],
+        )
+        self.runCmd("settings set disassembly-format dollar")
+        self.expect(
+            "settings show --defaults disassembly-format",
+            patterns=[r'= "dollar" \(default: ".+"\)'],
+        )
+
     def get_setting_json(self, setting_path=None):
         settings_data = self.dbg.GetSetting(setting_path)
         stream = lldb.SBStream()


### PR DESCRIPTION
Adds a `--defaults`/`-d` flag to `settings show`. This mode will _optionally_ show a setting's default value. In other words, this does not always print a default value for every setting.

A default value is not shown when the current value _is_ the default.

Note: some setting types do not print empty or invalid values. For these setting types, if the default value is empty or invalid, the same elision logic is applied to printing the default value.