### PR TITLE
[CAS] Fix a link error introduced by CAS

### DIFF
--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -5,4 +5,7 @@ add_llvm_component_library(LLVMCAS
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/CAS
+
+  LINK_COMPONENTS
+  Support
 )


### PR DESCRIPTION
It is missing link components which can cause link error when building as a shared library.