### PR TITLE
[CIR] Fix CIR build after recent commit

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenClass.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenClass.cpp
@@ -284,7 +284,8 @@ void CIRGenFunction::initializeVTablePointer(mlir::Location loc,
   } else {
     // We can just use the base offset in the complete class.
     nonVirtualOffset = vptr.base.getBaseOffset();
-    baseValueTy = convertType(getContext().getTagDeclType(vptr.base.getBase()));
+    baseValueTy =
+        convertType(getContext().getCanonicalTagType(vptr.base.getBase()));
   }
 
   // Apply the offsets.


### PR DESCRIPTION
A recent commit introduced a call to a function that was removed in an unrelated clang change that was merged earlier. This fixes the problem.