### PR TITLE
[MIR] Further cleanup on mutliple save/restore point support [nfc]

### DIFF
--- a/llvm/include/llvm/CodeGen/MIRYamlMapping.h
+++ b/llvm/include/llvm/CodeGen/MIRYamlMapping.h
@@ -644,8 +644,6 @@ struct SaveRestorePointEntry {
   }
 };
 
-using SaveRestorePoints = std::vector<SaveRestorePointEntry>;
-
 template <> struct MappingTraits<SaveRestorePointEntry> {
   static void mapping(IO &YamlIO, SaveRestorePointEntry &Entry) {
     YamlIO.mapRequired("point", Entry.Point);
@@ -695,8 +693,8 @@ struct MachineFrameInfo {
   bool HasTailCall = false;
   bool IsCalleeSavedInfoValid = false;
   unsigned LocalFrameSize = 0;
-  SaveRestorePoints SavePoints;
-  SaveRestorePoints RestorePoints;
+  std::vector<SaveRestorePointEntry> SavePoints;
+  std::vector<SaveRestorePointEntry> RestorePoints;
 
   bool operator==(const MachineFrameInfo &Other) const {
     return IsFrameAddressTaken == Other.IsFrameAddressTaken &&

--- a/llvm/include/llvm/CodeGen/MachineFrameInfo.h
+++ b/llvm/include/llvm/CodeGen/MachineFrameInfo.h
@@ -836,15 +836,6 @@ public:
     RestorePoints = SmallVector<MachineBasicBlock *>(NewRestorePoints);
   }
 
-  static SmallVector<MachineBasicBlock *> constructSaveRestorePoints(
-      ArrayRef<MachineBasicBlock *> SRPoints,
-      const DenseMap<MachineBasicBlock *, MachineBasicBlock *> &BBMap) {
-    SmallVector<MachineBasicBlock *> Pts;
-    for (auto &Src : SRPoints)
-      Pts.push_back(BBMap.find(Src)->second);
-    return Pts;
-  }
-
   uint64_t getUnsafeStackSize() const { return UnsafeStackSize; }
   void setUnsafeStackSize(uint64_t Size) { UnsafeStackSize = Size; }
 

--- a/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIRParser.cpp
@@ -126,7 +126,7 @@ public:
 
   bool initializeSaveRestorePoints(
       PerFunctionMIParsingState &PFS,
-      const yaml::SaveRestorePoints &YamlSRPoints,
+      const std::vector<yaml::SaveRestorePointEntry> &YamlSRPoints,
       SmallVectorImpl<MachineBasicBlock *> &SaveRestorePoints);
 
   bool initializeCallSiteInfo(PerFunctionMIParsingState &PFS,
@@ -1096,7 +1096,8 @@ bool MIRParserImpl::initializeConstantPool(PerFunctionMIParsingState &PFS,
 
 // Return true if basic block was incorrectly specified in MIR
 bool MIRParserImpl::initializeSaveRestorePoints(
-    PerFunctionMIParsingState &PFS, const yaml::SaveRestorePoints &YamlSRPoints,
+    PerFunctionMIParsingState &PFS,
+    const std::vector<yaml::SaveRestorePointEntry> &YamlSRPoints,
     SmallVectorImpl<MachineBasicBlock *> &SaveRestorePoints) {
   MachineBasicBlock *MBB = nullptr;
   for (const yaml::SaveRestorePointEntry &Entry : YamlSRPoints) {

--- a/llvm/lib/CodeGen/MIRPrinter.cpp
+++ b/llvm/lib/CodeGen/MIRPrinter.cpp
@@ -150,9 +150,10 @@ static void convertMJTI(ModuleSlotTracker &MST, yaml::MachineJumpTable &YamlJTI,
                         const MachineJumpTableInfo &JTI);
 static void convertMFI(ModuleSlotTracker &MST, yaml::MachineFrameInfo &YamlMFI,
                        const MachineFrameInfo &MFI);
-static void convertSRPoints(ModuleSlotTracker &MST,
-                            yaml::SaveRestorePoints &YamlSRPoints,
-                            ArrayRef<MachineBasicBlock *> SaveRestorePoints);
+static void
+convertSRPoints(ModuleSlotTracker &MST,
+                std::vector<yaml::SaveRestorePointEntry> &YamlSRPoints,
+                ArrayRef<MachineBasicBlock *> SaveRestorePoints);
 static void convertStackObjects(yaml::MachineFunction &YMF,
                                 const MachineFunction &MF,
                                 ModuleSlotTracker &MST, MFPrintState &State);
@@ -615,9 +616,10 @@ static void convertMCP(yaml::MachineFunction &MF,
   }
 }
 
-static void convertSRPoints(ModuleSlotTracker &MST,
-                            yaml::SaveRestorePoints &YamlSRPoints,
-                            ArrayRef<MachineBasicBlock *> SRPoints) {
+static void
+convertSRPoints(ModuleSlotTracker &MST,
+                std::vector<yaml::SaveRestorePointEntry> &YamlSRPoints,
+                ArrayRef<MachineBasicBlock *> SRPoints) {
   for (const auto &MBB : SRPoints) {
     SmallString<16> Str;
     yaml::SaveRestorePointEntry Entry;


### PR DESCRIPTION
Remove the type alias now that the std::variant aspect is gone, directly using std::vector in the few places that need it is more idiomatic.

Move a routine from a core header to single user.