### PR TITLE
[win][arm64ec] Disable the LP64 test feature for Arm64EC

### DIFF
--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -316,7 +316,7 @@ if re.match(r".*-(windows-msvc)$", config.target_triple):
 
 # [PR8833] LLP64-incompatible tests
 if not re.match(
-    r"^(aarch64|x86_64).*-(windows-msvc|windows-gnu)$", config.target_triple
+    r"^(aarch64|arm64ec|x86_64).*-(windows-msvc|windows-gnu)$", config.target_triple
 ):
     config.available_features.add("LP64")
 


### PR DESCRIPTION
As with other 64-bit Windows platforms, Arm64EC uses `LLP64` not `LP64`