### PR TITLE
[Docs] Add HelpText for -mimplicit-float so it shows up in the webpage documentation.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5589,7 +5589,8 @@ def mno_outline_atomics : Flag<["-"], "mno-outline-atomics">, Group<f_clang_Grou
   HelpText<"Don't generate local calls to out-of-line atomic operations">;
 def mno_implicit_float : Flag<["-"], "mno-implicit-float">, Group<m_Group>,
   HelpText<"Don't generate implicit floating point or vector instructions">;
-def mimplicit_float : Flag<["-"], "mimplicit-float">, Group<m_Group>;
+def mimplicit_float : Flag<["-"], "mimplicit-float">, Group<m_Group>,
+  HelpText<"Generate implicit floating point or vector instructions">;
 def mrecip : Flag<["-"], "mrecip">, Group<m_Group>,
   Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Equivalent to '-mrecip=all'">;


### PR DESCRIPTION
There is no documentation for -mimplicit-float, -mno-implicit-float here https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-mimplicit-float

I believe this is because the text is taken from the positive option when there is no- version. Add HelpText to the positive option to hopefully fix this.

These options also affect vector and not just FP so having text here that mentions vectors is helpful to users.