### PR TITLE
[win][arm64ec] Workaround VC Runtime defining __security_check_cookie for Arm64EC

### DIFF
--- a/llvm/include/llvm/IR/RuntimeLibcalls.h
+++ b/llvm/include/llvm/IR/RuntimeLibcalls.h
@@ -24,6 +24,12 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/TargetParser/Triple.h"
 
+// VC Runtime creates a macro for __security_check_cookie on Arm64EC, which
+// conflicts with the generated name in RuntimeLibcalls.inc.
+#if defined _M_ARM64EC
+#undef __security_check_cookie
+#endif
+
 /// TableGen will produce 2 enums, RTLIB::Libcall and
 /// RTLIB::LibcallImpl. RTLIB::Libcall describes abstract functionality the
 /// compiler may choose to access, RTLIB::LibcallImpl describes a particular ABI


### PR DESCRIPTION
`vcruntime.h` has the following `#define`:

```cpp
#if defined _M_ARM64EC
    #define __security_check_cookie __security_check_cookie_arm64ec
#endif
```

This causes issues in `RuntimeLibcalls.h` as it defines a variable with the same name.