### PR TITLE
Fix handling of dontcall attributes for arches that lower calls via fastSelectInstruction

### DIFF
--- a/llvm/lib/Target/ARM/ARMFastISel.cpp
+++ b/llvm/lib/Target/ARM/ARMFastISel.cpp
@@ -2504,6 +2504,7 @@ bool ARMFastISel::SelectCall(const Instruction *I,
   // Set all unused physreg defs as dead.
   static_cast<MachineInstr *>(MIB)->setPhysRegsDeadExcept(UsedRegs, TRI);
 
+  diagnoseDontCall(*CI);
   return true;
 }
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyFastISel.cpp
@@ -912,6 +912,8 @@ bool WebAssemblyFastISel::selectCall(const Instruction *I) {
 
   if (!IsVoid)
     updateValueMap(Call, ResultReg);
+
+  diagnoseDontCall(*Call);
   return true;
 }
 


### PR DESCRIPTION
Recently my change to avoid duplicate `dontcall` attribute errors (#152810) caused the Clang `Frontend/backend-attribute-error-warning.c` test to fail on Arm32: <https://lab.llvm.org/buildbot/#/builders/154/builds/20134>

The root cause is that, if the default `IFastSel` path bails, then targets are given the opportunity to lower instructions via `fastSelectInstruction`. That's the path taken by Arm32 and since its implementation of `selectCall` didn't call `diagnoseDontCall` no error was emitted.

I've checked the other implementations of `fastSelectInstruction` and the only other one that lowers call instructions in WebAssembly, so I've fixed that too.