### PR TITLE
[HLSL] Fix deprecation warnings in HLSL

### DIFF
--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -187,7 +187,9 @@ static bool ShouldDiagnoseAvailabilityInContext(
   // For libraries the availability will be checked later in
   // DiagnoseHLSLAvailability class once where the specific environment/shader
   // stage of the caller is known.
-  if (S.getLangOpts().HLSL) {
+  // We only do this for APIs that are not explicitly deprecated. Any API that
+  // is explicitly deprecated we always issue a diagnostic on.
+  if (S.getLangOpts().HLSL && K != AR_Deprecated) {
     if (!S.getLangOpts().HLSLStrictAvailability ||
         (DeclEnv != nullptr &&
          S.getASTContext().getTargetInfo().getTriple().getEnvironment() ==

--- a/clang/test/SemaHLSL/Availability/attr-deprecated.hlsl
+++ b/clang/test/SemaHLSL/Availability/attr-deprecated.hlsl
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.2-compute -std=hlsl202x -verify %s
+
+[[deprecated("Woah!")]] // expected-note{{'myFn' has been explicitly marked deprecated here}}
+void myFn() {}
+
+[[deprecated("X is bad... chose Y instead")]] // expected-note{{'X' has been explicitly marked deprecated here}}
+static const int X = 5;
+
+enum States {
+  Inactive,
+  Active,
+  Bored,
+  Sleep [[deprecated("We don't allow sleep anymore!")]], // expected-note{{'Sleep' has been explicitly marked deprecated here}}
+  Tired,
+};
+
+__attribute__((availability(shadermodel, introduced = 6.0, deprecated = 6.5)))
+void fn65() {}
+
+__attribute__((availability(shadermodel, introduced = 6.0, deprecated = 6.2)))
+void fn62() {} // expected-note{{'fn62' has been explicitly marked deprecated here}}
+
+void myOtherFn() {}
+
+void otherFn() {
+  myFn(); // expected-warning{{'myFn' is deprecated: Woah!}}
+
+  int Y = X; // expected-warning{{'X' is deprecated: X is bad... chose Y instead}}
+
+  States S = Bored;
+  S = Sleep; // expected-warning{{'Sleep' is deprecated: We don't allow sleep anymore!}}
+  S = Tired;
+
+  fn65(); // No warning here because we're targeting 6.2 where this isn't yet deprecated.
+
+  fn62(); // expected-warning{{'fn62' is deprecated: first deprecated in Shader Model 6.2}}
+}


### PR DESCRIPTION
A previous change to support HLSL strict availability had an unintended side effect of silencing deprecation warnings. This change fixes that issue and adds test coverage.

Fixes #132978
