### PR TITLE
[compiler-rt] Don't run arm64e builtins tests on darwin.

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -194,13 +194,15 @@ function(darwin_filter_host_archs input output)
     endif()
   endif()
 
+  # arm64e isn't usually supported out of the box on darwin, because of ABI.
+  list(REMOVE_ITEM tmp_var arm64e)
+
   if(ARM_HOST)
     list(REMOVE_ITEM tmp_var i386)
     list(REMOVE_ITEM tmp_var x86_64)
     list(REMOVE_ITEM tmp_var x86_64h)
   else()
     list(REMOVE_ITEM tmp_var arm64)
-    list(REMOVE_ITEM tmp_var arm64e)
     execute_process(
       COMMAND sysctl hw.cpusubtype
       OUTPUT_VARIABLE SUBTYPE)


### PR DESCRIPTION
The compiler-rt build gradually learned to target arm64e. With that, we build builtins for arm64e, but running their tests usually isn't possible, because most versions of macOS so far restrict arm64e (on account of its unstable ABI).

Starting with macOS 26, arm64e executables can be run, because the aligned linker automatically targets ptrauth ABI version 1. Without that, (at ABI version 0) these can't be executed.

We can't rely or require new linkers (and we elsewhere explicitly fallback to ld classic anyway), so in the meantime one way to execute these would be to explicitly ask for ABI version 1, which we generally try to avoid, and don't support in our llvm (which unconditionally targets ABI version 0).

This is also an uncommon situation;  sanitizer runtime tests aren't run on arm64e today, because we haven't listed arm64e as a supported arch yet.
Everything other than builtins also tests for execution in cmake first;  we should consider that, but it has its own problems.

So we can simply disable arm64e from tests, by filtering it out as a valid darwin host arch, which accurately reflects reality.

When we try to add arm64e sanitizer runtime build and test support, we'll want to change that, but that's a bigger problem than builtins.