### PR TITLE
Revert "[lldb] Use the Python limited API with SWIG 4.2 or later"

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -68,6 +68,7 @@ add_optional_dependency(LLDB_ENABLE_FBSDVMCORE "Enable libfbsdvmcore support in 
 option(LLDB_USE_ENTITLEMENTS "When codesigning, use entitlements if available" ON)
 option(LLDB_BUILD_FRAMEWORK "Build LLDB.framework (Darwin only)" OFF)
 option(LLDB_ENABLE_PROTOCOL_SERVERS "Enable protocol servers (e.g. MCP) in LLDB" ON)
+option(LLDB_ENABLE_PYTHON_LIMITED_API "Force LLDB to only use the Python Limited API (requires SWIG 4.2 or later)" OFF)
 option(LLDB_NO_INSTALL_DEFAULT_RPATH "Disable default RPATH settings in binaries" OFF)
 option(LLDB_USE_SYSTEM_DEBUGSERVER "Use the system's debugserver for testing (Darwin only)." OFF)
 option(LLDB_SKIP_STRIP "Whether to skip stripping of binaries when installing lldb." OFF)
@@ -171,14 +172,6 @@ if (LLDB_ENABLE_PYTHON)
   option(LLDB_EMBED_PYTHON_HOME
     "Embed PYTHONHOME in the binary. If set to OFF, PYTHONHOME environment variable will be used to to locate Python."
     ${default_embed_python_home})
-
-  if (SWIG_VERSION VERSION_GREATER_EQUAL "4.2")
-    set(default_enable_python_limited_api ON)
-  else()
-    set(default_enable_python_limited_api OFF)
-  endif()
-  option(LLDB_ENABLE_PYTHON_LIMITED_API "Force LLDB to only use the Python Limited API (requires SWIG 4.2 or later)"
-    ${default_enable_python_limited_api})
 
   include_directories(${Python3_INCLUDE_DIRS})
   if (LLDB_EMBED_PYTHON_HOME)


### PR DESCRIPTION
Reverts llvm/llvm-project#153119 because with `LLDB_USE_LIBEDIT_READLINE_COMPAT_MODULE`, we're using `PyImport_Inittab` which isn't part of the stable API.