### PR TITLE
[mlir][cmake] Fix mlir target export

### DIFF
--- a/mlir/cmake/modules/AddMLIR.cmake
+++ b/mlir/cmake/modules/AddMLIR.cmake
@@ -641,8 +641,8 @@ function(add_mlir_library_install name)
                               COMPONENT ${name})
     endif()
     set_property(GLOBAL APPEND PROPERTY MLIR_ALL_LIBS ${name})
-    set_property(GLOBAL APPEND PROPERTY MLIR_EXPORTS ${name})
   endif()
+  set_property(GLOBAL APPEND PROPERTY MLIR_EXPORTS ${name})
 endfunction()
 
 # Declare an mlir library which is part of the public C-API.


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/152195, target export was accidentally moved inside a conditional, but it should have been left outside. This patch undoes that change.