### PR TITLE
[clang] fix getTrivialTemplateArgumentLoc template template argument

### DIFF
--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -2911,11 +2911,7 @@ Sema::getTrivialTemplateArgumentLoc(const TemplateArgument &Arg,
     case TemplateArgument::TemplateExpansion: {
       NestedNameSpecifierLocBuilder Builder;
       TemplateName Template = Arg.getAsTemplateOrTemplatePattern();
-      if (DependentTemplateName *DTN = Template.getAsDependentTemplateName())
-        Builder.MakeTrivial(Context, DTN->getQualifier(), Loc);
-      else if (QualifiedTemplateName *QTN =
-                   Template.getAsQualifiedTemplateName())
-        Builder.MakeTrivial(Context, QTN->getQualifier(), Loc);
+      Builder.MakeTrivial(Context, Template.getQualifier(), Loc);
       return TemplateArgumentLoc(
           Context, Arg, Loc, Builder.getWithLocInContext(Context), Loc,
           /*EllipsisLoc=*/Arg.getKind() == TemplateArgument::TemplateExpansion

--- a/clang/test/SemaTemplate/ctad.cpp
+++ b/clang/test/SemaTemplate/ctad.cpp
@@ -90,3 +90,17 @@ namespace AsValueParameter {
   // cxx17-error@-1 {{value of type 'foo::A<int>' is not implicitly convertible to 'int'}}
   // cxx20-error@-2 {{non-type template parameter has non-literal type 'foo::A<int>' (aka 'AsValueParameter::foo::A<int>')}}
 } // namespace AsValueParameter
+
+namespace ConvertDeducedTemplateArgument {
+  namespace A {
+    template <class> struct B {};
+  }
+
+  template <template <class> class TT1> struct C {
+    C(TT1<int>);
+  };
+
+  template <template <class> class TT2> using D = TT2<int>;
+
+  auto x = C(D<A::B>());
+}


### PR DESCRIPTION
This fixes a regression reported here https://github.com/llvm/llvm-project/pull/147835#issuecomment-3181811371, where getTrivialTemplateArgumentLoc can't see through template name sugar when producing a trivial TemplateArgumentLoc for template template arguments.

Since this regression was never released, there are no release notes.