### PR TITLE
[LLDB][NativePDB] Ignore functions with no type in name lookup

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -1675,7 +1675,7 @@ void SymbolFileNativePDB::CacheFunctionNames() {
         llvm::cantFail(SymbolDeserializer::deserializeAs<ProcSym>(*iter));
     if ((proc.Flags & ProcSymFlags::IsUnreachable) != ProcSymFlags::None)
       continue;
-    if (proc.Name.empty() || proc.FunctionType.isNoneType())
+    if (proc.Name.empty() || proc.FunctionType.isSimple())
       continue;
 
     // The function/procedure symbol only contains the demangled name.

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -1675,7 +1675,7 @@ void SymbolFileNativePDB::CacheFunctionNames() {
         llvm::cantFail(SymbolDeserializer::deserializeAs<ProcSym>(*iter));
     if ((proc.Flags & ProcSymFlags::IsUnreachable) != ProcSymFlags::None)
       continue;
-    if (proc.Name.empty())
+    if (proc.Name.empty() || proc.FunctionType.isNoneType())
       continue;
 
     // The function/procedure symbol only contains the demangled name.


### PR DESCRIPTION
Some functions don't have the `FunctionType` set. We can't look these up and won't be able to call them, so ignore them when caching the function names.

This does fix the failures caused by https://github.com/llvm/llvm-project/pull/153160 mentioned in https://github.com/llvm/llvm-project/pull/153160#issuecomment-3183062431. However, in `lldb-shell::msstl_smoke.cpp` there's another failure not introduced by #153160 (fixed with #153386).