### PR TITLE
[AMDGPU][AsmParser][NFC] Give isImmLiteral() a better name.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPUInstructions.td
@@ -134,7 +134,7 @@ class CustomOperand<ValueType type, bit optional = 0, string name = NAME>
 class ImmOperand<ValueType type, string name = NAME, bit optional = 0,
                  string printer = "print"#name>
     : CustomOperand<type, optional, name> {
-  let ImmTy = "ImmTyNone";
+  let ImmTy = "ImmTyPlain";
   let ParserMethod = "";
   let PrintMethod = printer;
 }


### PR DESCRIPTION
We used to call literals what are not inline immediates. We seem already call them plain immediates in the code, so maybe use that.

Also rename ImmTyNone, which is confusing as well, since they are not really immediates of no kind.

Simplify related code while there.