### PR TITLE
[clang] [test] Improve XFAIL patterns for aarch64 msvc

### DIFF
--- a/clang/test/CodeGen/c-strings.c
+++ b/clang/test/CodeGen/c-strings.c
@@ -15,8 +15,8 @@
 // MSABI: @f4.x = internal global %struct.s { ptr @"??_C@_05CJBACGMB@hello?$AA@" }
 // CHECK: @x = {{(dso_local )?}}global [3 x i8] c"ola", align [[ALIGN]]
 
-// XFAIL: target=aarch64-pc-windows-{{.*}}, target=arm64ec-pc-windows-{{.*}}
-// Arm64 aligns arrays to either 32-bit or 64-bit boundaries, which fails
+// XFAIL: target=aarch64-{{.*}}-windows-msvc, target=arm64ec-{{.*}}-windows-msvc
+// Arm64 in MSVC mode aligns arrays to either 32-bit or 64-bit boundaries, which fails
 // various checks above, since ALIGN is derived from the alignment of a single
 // i8, which is still 1.
 


### PR DESCRIPTION
Unless relevant (which it very seldom is), avoid checking specifically for the "pc" vendor field; mingw environments often use "w64" as vendor - but not always.

In this case, this test has been passing in mingw configurations lately; the previous XFAIL pattern would cause the test to unexpectedly succeed if running with a triple with a "pc" vendor field.

Instead reinstate the checking for an -msvc environment here; this essentially reverts 8e029d9e35092d1440dafc8991e73fb8c3b323d7 (and the related typo fix 301f3da5162499965287338a0cd52309fb28e8b8).

I'm not sure how 8e029d9e35092d1440dafc8991e73fb8c3b323d7 concluded that this issue affected the gnu ABI (mingw) as well; I rechecked building that commit, and at that point, this test did pass for an aarch64 mingw target. (Due to the -pc- triple, the false positive XFAIL match hasn't been noticed before.)