### PR TITLE
[Offload] In unit tests, use EXPECT_ rather than ASSERT_

### DIFF
--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -15,6 +15,17 @@
 
 #pragma once
 
+#ifndef EXPECT_SUCCESS
+#define EXPECT_SUCCESS(ACTUAL)                                                 \
+  do {                                                                         \
+    ol_result_t Res = ACTUAL;                                                  \
+    if (Res && Res->Code != OL_ERRC_SUCCESS) {                                 \
+      ADD_FAILURE() << #ACTUAL " returned " << Res->Code << ": "               \
+                    << Res->Details;                                           \
+    }                                                                          \
+  } while (0)
+#endif
+
 #ifndef ASSERT_SUCCESS
 #define ASSERT_SUCCESS(ACTUAL)                                                 \
   do {                                                                         \
@@ -27,19 +38,19 @@
 #endif
 
 // TODO: rework this so the EXPECTED/ACTUAL results are readable
-#ifndef ASSERT_ERROR
-#define ASSERT_ERROR(EXPECTED, ACTUAL)                                         \
+#ifndef EXPECT_ERROR
+#define EXPECT_ERROR(EXPECTED, ACTUAL)                                         \
   do {                                                                         \
     ol_result_t Res = ACTUAL;                                                  \
-    ASSERT_TRUE(Res && (Res->Code == EXPECTED));                               \
+    EXPECT_TRUE(Res && (Res->Code == EXPECTED));                               \
   } while (0)
 #endif
 
-#ifndef ASSERT_ANY_ERROR
-#define ASSERT_ANY_ERROR(ACTUAL)                                               \
+#ifndef EXPECT_ANY_ERROR
+#define EXPECT_ANY_ERROR(ACTUAL)                                               \
   do {                                                                         \
     ol_result_t Res = ACTUAL;                                                  \
-    ASSERT_TRUE(Res);                                                          \
+    EXPECT_TRUE(Res);                                                          \
   } while (0)
 #endif
 
@@ -127,14 +138,14 @@ struct OffloadProgramTest : OffloadDeviceTest {
     RETURN_ON_FATAL_FAILURE(OffloadDeviceTest::SetUp());
     ASSERT_TRUE(
         TestEnvironment::loadDeviceBinary(ProgramName, Device, DeviceBin));
-    ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+    EXPECT_GE(DeviceBin->getBufferSize(), 0lu);
     ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
   }
 
   void TearDown() override {
     if (Program) {
-      olDestroyProgram(Program);
+      EXPECT_SUCCESS(olDestroyProgram(Program));
     }
     RETURN_ON_FATAL_FAILURE(OffloadDeviceTest::TearDown());
   }
@@ -178,7 +189,7 @@ struct OffloadQueueTest : OffloadDeviceTest {
 
   void TearDown() override {
     if (Queue) {
-      olDestroyQueue(Queue);
+      EXPECT_SUCCESS(olDestroyQueue(Queue));
     }
     RETURN_ON_FATAL_FAILURE(OffloadDeviceTest::TearDown());
   }
@@ -190,12 +201,12 @@ struct OffloadEventTest : OffloadQueueTest {
   void SetUp() override {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
     ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
-    ASSERT_SUCCESS(olSyncQueue(Queue));
+    EXPECT_SUCCESS(olSyncQueue(Queue));
   }
 
   void TearDown() override {
     if (Event)
-      olDestroyEvent(Event);
+      EXPECT_SUCCESS(olDestroyEvent(Event));
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::TearDown());
   }
 

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfo.cpp
@@ -15,115 +15,119 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetDeviceInfoTest);
 
 TEST_P(olGetDeviceInfoTest, SuccessType) {
   ol_device_type_t DeviceType;
-  ASSERT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_TYPE,
+  EXPECT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_TYPE,
                                  sizeof(ol_device_type_t), &DeviceType));
 }
 
 TEST_P(olGetDeviceInfoTest, HostSuccessType) {
   ol_device_type_t DeviceType;
-  ASSERT_SUCCESS(olGetDeviceInfo(Host, OL_DEVICE_INFO_TYPE,
+  EXPECT_SUCCESS(olGetDeviceInfo(Host, OL_DEVICE_INFO_TYPE,
                                  sizeof(ol_device_type_t), &DeviceType));
-  ASSERT_EQ(DeviceType, OL_DEVICE_TYPE_HOST);
+  EXPECT_EQ(DeviceType, OL_DEVICE_TYPE_HOST);
 }
 
 TEST_P(olGetDeviceInfoTest, SuccessPlatform) {
   ol_platform_handle_t Platform = nullptr;
-  ASSERT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_PLATFORM,
+  EXPECT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_PLATFORM,
                                  sizeof(ol_platform_handle_t), &Platform));
-  ASSERT_NE(Platform, nullptr);
+  EXPECT_NE(Platform, nullptr);
 }
 
 TEST_P(olGetDeviceInfoTest, SuccessName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_NAME, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_NAME, &Size));
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> Name;
   Name.resize(Size);
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetDeviceInfo(Device, OL_DEVICE_INFO_NAME, Size, Name.data()));
-  ASSERT_EQ(std::strlen(Name.data()), Size - 1);
+  EXPECT_EQ(std::strlen(Name.data()), Size - 1);
 }
 
 TEST_P(olGetDeviceInfoTest, HostName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Host, OL_DEVICE_INFO_NAME, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Host, OL_DEVICE_INFO_NAME, &Size));
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> Name;
   Name.resize(Size);
-  ASSERT_SUCCESS(olGetDeviceInfo(Host, OL_DEVICE_INFO_NAME, Size, Name.data()));
-  ASSERT_EQ(std::strlen(Name.data()), Size - 1);
+  EXPECT_SUCCESS(olGetDeviceInfo(Host, OL_DEVICE_INFO_NAME, Size, Name.data()));
+  EXPECT_EQ(std::strlen(Name.data()), Size - 1);
 }
 
 TEST_P(olGetDeviceInfoTest, SuccessVendor) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_VENDOR, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_VENDOR, &Size));
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> Vendor;
   Vendor.resize(Size);
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetDeviceInfo(Device, OL_DEVICE_INFO_VENDOR, Size, Vendor.data()));
-  ASSERT_EQ(std::strlen(Vendor.data()), Size - 1);
+  EXPECT_EQ(std::strlen(Vendor.data()), Size - 1);
 }
 
 TEST_P(olGetDeviceInfoTest, SuccessDriverVersion) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetDeviceInfoSize(Device, OL_DEVICE_INFO_DRIVER_VERSION, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> DriverVersion;
   DriverVersion.resize(Size);
-  ASSERT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_DRIVER_VERSION, Size,
+  EXPECT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_DRIVER_VERSION, Size,
                                  DriverVersion.data()));
-  ASSERT_EQ(std::strlen(DriverVersion.data()), Size - 1);
+  EXPECT_EQ(std::strlen(DriverVersion.data()), Size - 1);
 }
 
 TEST_P(olGetDeviceInfoTest, SuccessMaxWorkGroupSize) {
   uint32_t Value;
-  ASSERT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
+  EXPECT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
                                  sizeof(Value), &Value));
-  ASSERT_GT(Value, 0u);
+  EXPECT_GT(Value, 0u);
 }
 
 TEST_P(olGetDeviceInfoTest, SuccessMaxWorkGroupSizePerDimension) {
   ol_dimensions_t Value{0, 0, 0};
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetDeviceInfo(Device, OL_DEVICE_INFO_MAX_WORK_GROUP_SIZE_PER_DIMENSION,
                       sizeof(Value), &Value));
-  ASSERT_GT(Value.x, 0u);
-  ASSERT_GT(Value.y, 0u);
-  ASSERT_GT(Value.z, 0u);
+  EXPECT_GT(Value.x, 0u);
+  EXPECT_GT(Value.y, 0u);
+  EXPECT_GT(Value.z, 0u);
 }
 
 TEST_P(olGetDeviceInfoTest, InvalidNullHandleDevice) {
   ol_device_type_t DeviceType;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetDeviceInfo(nullptr, OL_DEVICE_INFO_TYPE,
                                sizeof(ol_device_type_t), &DeviceType));
 }
 
 TEST_P(olGetDeviceInfoTest, InvalidEnumerationInfoType) {
   ol_device_type_t DeviceType;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetDeviceInfo(Device, OL_DEVICE_INFO_FORCE_UINT32,
                                sizeof(ol_device_type_t), &DeviceType));
 }
 
 TEST_P(olGetDeviceInfoTest, InvalidSizePropSize) {
   ol_device_type_t DeviceType;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetDeviceInfo(Device, OL_DEVICE_INFO_TYPE, 0, &DeviceType));
 }
 
 TEST_P(olGetDeviceInfoTest, InvalidSizePropSizeSmall) {
   ol_device_type_t DeviceType;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetDeviceInfo(Device, OL_DEVICE_INFO_TYPE,
                                sizeof(DeviceType) - 1, &DeviceType));
 }
 
 TEST_P(olGetDeviceInfoTest, InvalidNullPointerPropValue) {
   ol_device_type_t DeviceType;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetDeviceInfo(Device, OL_DEVICE_INFO_TYPE, sizeof(DeviceType),
                                nullptr));
 }

--- a/offload/unittests/OffloadAPI/device/olGetDeviceInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/device/olGetDeviceInfoSize.cpp
@@ -15,63 +15,63 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetDeviceInfoSizeTest);
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessType) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_TYPE, &Size));
-  ASSERT_EQ(Size, sizeof(ol_device_type_t));
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_TYPE, &Size));
+  EXPECT_EQ(Size, sizeof(ol_device_type_t));
 }
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessPlatform) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_PLATFORM, &Size));
-  ASSERT_EQ(Size, sizeof(ol_platform_handle_t));
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_PLATFORM, &Size));
+  EXPECT_EQ(Size, sizeof(ol_platform_handle_t));
 }
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_NAME, &Size));
-  ASSERT_NE(Size, 0ul);
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_NAME, &Size));
+  EXPECT_NE(Size, 0ul);
 }
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessVendor) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_VENDOR, &Size));
-  ASSERT_NE(Size, 0ul);
+  EXPECT_SUCCESS(olGetDeviceInfoSize(Device, OL_DEVICE_INFO_VENDOR, &Size));
+  EXPECT_NE(Size, 0ul);
 }
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessDriverVersion) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetDeviceInfoSize(Device, OL_DEVICE_INFO_DRIVER_VERSION, &Size));
-  ASSERT_NE(Size, 0ul);
+  EXPECT_NE(Size, 0ul);
 }
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessMaxWorkGroupSize) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetDeviceInfoSize(Device, OL_DEVICE_INFO_MAX_WORK_GROUP_SIZE, &Size));
-  ASSERT_EQ(Size, sizeof(uint32_t));
+  EXPECT_EQ(Size, sizeof(uint32_t));
 }
 
 TEST_P(olGetDeviceInfoSizeTest, SuccessMaxWorkGroupSizePerDimension) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetDeviceInfoSize(
+  EXPECT_SUCCESS(olGetDeviceInfoSize(
       Device, OL_DEVICE_INFO_MAX_WORK_GROUP_SIZE_PER_DIMENSION, &Size));
-  ASSERT_EQ(Size, sizeof(ol_dimensions_t));
-  ASSERT_EQ(Size, sizeof(uint32_t) * 3);
+  EXPECT_EQ(Size, sizeof(ol_dimensions_t));
+  EXPECT_EQ(Size, sizeof(uint32_t) * 3);
 }
 
 TEST_P(olGetDeviceInfoSizeTest, InvalidNullHandle) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetDeviceInfoSize(nullptr, OL_DEVICE_INFO_TYPE, &Size));
 }
 
 TEST_P(olGetDeviceInfoSizeTest, InvalidDeviceInfoEnumeration) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetDeviceInfoSize(Device, OL_DEVICE_INFO_FORCE_UINT32, &Size));
 }
 
 TEST_P(olGetDeviceInfoSizeTest, InvalidNullPointer) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetDeviceInfoSize(Device, OL_DEVICE_INFO_TYPE, nullptr));
 }

--- a/offload/unittests/OffloadAPI/device/olIterateDevices.cpp
+++ b/offload/unittests/OffloadAPI/device/olIterateDevices.cpp
@@ -13,7 +13,7 @@
 using olIterateDevicesTest = OffloadTest;
 
 TEST_F(olIterateDevicesTest, SuccessEmptyCallback) {
-  ASSERT_SUCCESS(olIterateDevices(
+  EXPECT_SUCCESS(olIterateDevices(
       [](ol_device_handle_t, void *) { return false; }, nullptr));
 }
 
@@ -21,7 +21,7 @@ TEST_F(olIterateDevicesTest, SuccessGetDevice) {
   uint32_t DeviceCount = 0;
   ol_device_handle_t Device = nullptr;
 
-  ASSERT_SUCCESS(olIterateDevices(
+  EXPECT_SUCCESS(olIterateDevices(
       [](ol_device_handle_t, void *Data) {
         auto Count = static_cast<uint32_t *>(Data);
         *Count += 1;
@@ -33,7 +33,7 @@ TEST_F(olIterateDevicesTest, SuccessGetDevice) {
     GTEST_SKIP() << "No available devices.";
   }
 
-  ASSERT_SUCCESS(olIterateDevices(
+  EXPECT_SUCCESS(olIterateDevices(
       [](ol_device_handle_t D, void *Data) {
         auto DevicePtr = static_cast<ol_device_handle_t *>(Data);
         *DevicePtr = D;
@@ -41,5 +41,5 @@ TEST_F(olIterateDevicesTest, SuccessGetDevice) {
       },
       &Device));
 
-  ASSERT_NE(Device, nullptr);
+  EXPECT_NE(Device, nullptr);
 }

--- a/offload/unittests/OffloadAPI/event/olCreateEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olCreateEvent.cpp
@@ -15,15 +15,15 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olCreateEventTest);
 
 TEST_P(olCreateEventTest, Success) {
   ol_event_handle_t Event = nullptr;
-  ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
-  ASSERT_NE(Event, nullptr);
+  EXPECT_SUCCESS(olCreateEvent(Queue, &Event));
+  EXPECT_NE(Event, nullptr);
 }
 
 TEST_P(olCreateEventTest, InvalidNullQueue) {
   ol_event_handle_t Event;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olCreateEvent(nullptr, &Event));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olCreateEvent(nullptr, &Event));
 }
 
 TEST_P(olCreateEventTest, InvalidNullDest) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olCreateEvent(Queue, nullptr));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olCreateEvent(Queue, nullptr));
 }

--- a/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olDestroyEvent.cpp
@@ -16,11 +16,11 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olDestroyEventTest);
 TEST_P(olDestroyEventTest, Success) {
   ol_event_handle_t Event = nullptr;
   ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
-  ASSERT_NE(Event, nullptr);
-  ASSERT_SUCCESS(olSyncQueue(Queue));
-  ASSERT_SUCCESS(olDestroyEvent(Event));
+  EXPECT_NE(Event, nullptr);
+  EXPECT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olDestroyEvent(Event));
 }
 
 TEST_P(olDestroyEventTest, InvalidNullEvent) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyEvent(nullptr));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyEvent(nullptr));
 }

--- a/offload/unittests/OffloadAPI/event/olGetEventInfo.cpp
+++ b/offload/unittests/OffloadAPI/event/olGetEventInfo.cpp
@@ -15,41 +15,41 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetEventInfoTest);
 
 TEST_P(olGetEventInfoTest, SuccessDevice) {
   ol_queue_handle_t RetrievedQueue;
-  ASSERT_SUCCESS(olGetEventInfo(Event, OL_EVENT_INFO_QUEUE,
+  EXPECT_SUCCESS(olGetEventInfo(Event, OL_EVENT_INFO_QUEUE,
                                 sizeof(ol_queue_handle_t), &RetrievedQueue));
-  ASSERT_EQ(Queue, RetrievedQueue);
+  EXPECT_EQ(Queue, RetrievedQueue);
 }
 
 TEST_P(olGetEventInfoTest, InvalidNullHandle) {
   ol_queue_handle_t RetrievedQueue;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetEventInfo(nullptr, OL_EVENT_INFO_QUEUE,
                               sizeof(RetrievedQueue), &RetrievedQueue));
 }
 
 TEST_P(olGetEventInfoTest, InvalidEventInfoEnumeration) {
   ol_queue_handle_t RetrievedQueue;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetEventInfo(Event, OL_EVENT_INFO_FORCE_UINT32,
                               sizeof(RetrievedQueue), &RetrievedQueue));
 }
 
 TEST_P(olGetEventInfoTest, InvalidSizeZero) {
   ol_queue_handle_t RetrievedQueue;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetEventInfo(Event, OL_EVENT_INFO_QUEUE, 0, &RetrievedQueue));
 }
 
 TEST_P(olGetEventInfoTest, InvalidSizeSmall) {
   ol_queue_handle_t RetrievedQueue;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetEventInfo(Event, OL_EVENT_INFO_QUEUE,
                               sizeof(RetrievedQueue) - 1, &RetrievedQueue));
 }
 
 TEST_P(olGetEventInfoTest, InvalidNullPointerPropValue) {
   ol_queue_handle_t RetrievedQueue;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetEventInfo(Event, OL_EVENT_INFO_QUEUE,
                               sizeof(RetrievedQueue), nullptr));
 }

--- a/offload/unittests/OffloadAPI/event/olGetEventInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/event/olGetEventInfoSize.cpp
@@ -15,23 +15,23 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetEventInfoSizeTest);
 
 TEST_P(olGetEventInfoSizeTest, SuccessQueue) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetEventInfoSize(Event, OL_EVENT_INFO_QUEUE, &Size));
-  ASSERT_EQ(Size, sizeof(ol_queue_handle_t));
+  EXPECT_SUCCESS(olGetEventInfoSize(Event, OL_EVENT_INFO_QUEUE, &Size));
+  EXPECT_EQ(Size, sizeof(ol_queue_handle_t));
 }
 
 TEST_P(olGetEventInfoSizeTest, InvalidNullHandle) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetEventInfoSize(nullptr, OL_EVENT_INFO_QUEUE, &Size));
 }
 
 TEST_P(olGetEventInfoSizeTest, InvalidEventInfoEnumeration) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetEventInfoSize(Event, OL_EVENT_INFO_FORCE_UINT32, &Size));
 }
 
 TEST_P(olGetEventInfoSizeTest, InvalidNullPointer) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetEventInfoSize(Event, OL_EVENT_INFO_QUEUE, nullptr));
 }

--- a/offload/unittests/OffloadAPI/event/olSyncEvent.cpp
+++ b/offload/unittests/OffloadAPI/event/olSyncEvent.cpp
@@ -16,22 +16,22 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olSyncEventTest);
 TEST_P(olSyncEventTest, Success) {
   ol_event_handle_t Event = nullptr;
   ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
-  ASSERT_NE(Event, nullptr);
-  ASSERT_SUCCESS(olSyncEvent(Event));
-  ASSERT_SUCCESS(olDestroyEvent(Event));
+  EXPECT_NE(Event, nullptr);
+  EXPECT_SUCCESS(olSyncEvent(Event));
+  EXPECT_SUCCESS(olDestroyEvent(Event));
 }
 
 TEST_P(olSyncEventTest, InvalidNullEvent) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olSyncEvent(nullptr));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olSyncEvent(nullptr));
 }
 
 TEST_P(olSyncEventTest, SuccessMultipleSync) {
   ol_event_handle_t Event = nullptr;
   ASSERT_SUCCESS(olCreateEvent(Queue, &Event));
-  ASSERT_NE(Event, nullptr);
+  EXPECT_NE(Event, nullptr);
 
   for (size_t I = 0; I < 10; I++)
-    ASSERT_SUCCESS(olSyncEvent(Event));
+    EXPECT_SUCCESS(olSyncEvent(Event));
 
-  ASSERT_SUCCESS(olDestroyEvent(Event));
+  EXPECT_SUCCESS(olDestroyEvent(Event));
 }

--- a/offload/unittests/OffloadAPI/init/olInit.cpp
+++ b/offload/unittests/OffloadAPI/init/olInit.cpp
@@ -16,19 +16,19 @@
 struct olInitTest : ::testing::Test {};
 
 TEST_F(olInitTest, Success) {
-  ASSERT_SUCCESS(olInit());
-  ASSERT_SUCCESS(olShutDown());
+  EXPECT_SUCCESS(olInit());
+  EXPECT_SUCCESS(olShutDown());
 }
 
 TEST_F(olInitTest, Uninitialized) {
-  ASSERT_ERROR(OL_ERRC_UNINITIALIZED,
+  EXPECT_ERROR(OL_ERRC_UNINITIALIZED,
                olIterateDevices(
                    [](ol_device_handle_t, void *) { return false; }, nullptr));
 }
 
 TEST_F(olInitTest, RepeatedInit) {
   for (size_t I = 0; I < 10; I++) {
-    ASSERT_SUCCESS(olInit());
-    ASSERT_SUCCESS(olShutDown());
+    EXPECT_SUCCESS(olInit());
+    EXPECT_SUCCESS(olShutDown());
   }
 }

--- a/offload/unittests/OffloadAPI/memory/olMemAlloc.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemAlloc.cpp
@@ -16,31 +16,31 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olMemAllocTest);
 TEST_P(olMemAllocTest, SuccessAllocManaged) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED, 1024, &Alloc));
-  ASSERT_NE(Alloc, nullptr);
-  olMemFree(Alloc);
+  EXPECT_NE(Alloc, nullptr);
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemAllocTest, SuccessAllocHost) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_HOST, 1024, &Alloc));
-  ASSERT_NE(Alloc, nullptr);
-  olMemFree(Alloc);
+  EXPECT_NE(Alloc, nullptr);
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemAllocTest, SuccessAllocDevice) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
-  ASSERT_NE(Alloc, nullptr);
-  olMemFree(Alloc);
+  EXPECT_NE(Alloc, nullptr);
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemAllocTest, InvalidNullDevice) {
   void *Alloc = nullptr;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olMemAlloc(nullptr, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
 }
 
 TEST_P(olMemAllocTest, InvalidNullOutPtr) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, nullptr));
 }

--- a/offload/unittests/OffloadAPI/memory/olMemFree.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFree.cpp
@@ -16,24 +16,24 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olMemFreeTest);
 TEST_P(olMemFreeTest, SuccessFreeManaged) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED, 1024, &Alloc));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemFreeTest, SuccessFreeHost) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_HOST, 1024, &Alloc));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemFreeTest, SuccessFreeDevice) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemFreeTest, InvalidNullPtr) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olMemFree(nullptr));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olMemFree(nullptr));
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }

--- a/offload/unittests/OffloadAPI/memory/olMemcpy.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemcpy.cpp
@@ -21,7 +21,7 @@ struct olMemcpyGlobalTest : OffloadGlobalTest {
     ASSERT_SUCCESS(
         olGetSymbol(Program, "write", OL_SYMBOL_KIND_KERNEL, &WriteKernel));
     ASSERT_SUCCESS(olCreateQueue(Device, &Queue));
-    ASSERT_SUCCESS(olGetSymbolInfo(
+    EXPECT_SUCCESS(olGetSymbolInfo(
         Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS, sizeof(Addr), &Addr));
 
     LaunchArgs.Dimensions = 1;
@@ -44,7 +44,7 @@ TEST_P(olMemcpyTest, SuccessHtoD) {
   void *Alloc;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, &Alloc));
   std::vector<uint8_t> Input(Size, 42);
-  ASSERT_SUCCESS(olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size));
+  EXPECT_SUCCESS(olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size));
   olSyncQueue(Queue);
   olMemFree(Alloc);
 }
@@ -56,13 +56,13 @@ TEST_P(olMemcpyTest, SuccessDtoH) {
   std::vector<uint8_t> Output(Size, 0);
 
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, &Alloc));
-  ASSERT_SUCCESS(olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size));
-  ASSERT_SUCCESS(olMemcpy(Queue, Output.data(), Host, Alloc, Device, Size));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size));
+  EXPECT_SUCCESS(olMemcpy(Queue, Output.data(), Host, Alloc, Device, Size));
+  EXPECT_SUCCESS(olSyncQueue(Queue));
   for (uint8_t Val : Output) {
-    ASSERT_EQ(Val, 42);
+    EXPECT_EQ(Val, 42);
   }
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemcpyTest, SuccessDtoD) {
@@ -74,15 +74,15 @@ TEST_P(olMemcpyTest, SuccessDtoD) {
 
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, &AllocA));
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, &AllocB));
-  ASSERT_SUCCESS(olMemcpy(Queue, AllocA, Device, Input.data(), Host, Size));
-  ASSERT_SUCCESS(olMemcpy(Queue, AllocB, Device, AllocA, Device, Size));
-  ASSERT_SUCCESS(olMemcpy(Queue, Output.data(), Host, AllocB, Device, Size));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olMemcpy(Queue, AllocA, Device, Input.data(), Host, Size));
+  EXPECT_SUCCESS(olMemcpy(Queue, AllocB, Device, AllocA, Device, Size));
+  EXPECT_SUCCESS(olMemcpy(Queue, Output.data(), Host, AllocB, Device, Size));
+  EXPECT_SUCCESS(olSyncQueue(Queue));
   for (uint8_t Val : Output) {
-    ASSERT_EQ(Val, 42);
+    EXPECT_EQ(Val, 42);
   }
-  ASSERT_SUCCESS(olMemFree(AllocA));
-  ASSERT_SUCCESS(olMemFree(AllocB));
+  EXPECT_SUCCESS(olMemFree(AllocA));
+  EXPECT_SUCCESS(olMemFree(AllocB));
 }
 
 TEST_P(olMemcpyTest, SuccessHtoHSync) {
@@ -90,11 +90,11 @@ TEST_P(olMemcpyTest, SuccessHtoHSync) {
   std::vector<uint8_t> Input(Size, 42);
   std::vector<uint8_t> Output(Size, 0);
 
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olMemcpy(nullptr, Output.data(), Host, Input.data(), Host, Size));
 
   for (uint8_t Val : Output) {
-    ASSERT_EQ(Val, 42);
+    EXPECT_EQ(Val, 42);
   }
 }
 
@@ -105,12 +105,12 @@ TEST_P(olMemcpyTest, SuccessDtoHSync) {
   std::vector<uint8_t> Output(Size, 0);
 
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, Size, &Alloc));
-  ASSERT_SUCCESS(olMemcpy(nullptr, Alloc, Device, Input.data(), Host, Size));
-  ASSERT_SUCCESS(olMemcpy(nullptr, Output.data(), Host, Alloc, Device, Size));
+  EXPECT_SUCCESS(olMemcpy(nullptr, Alloc, Device, Input.data(), Host, Size));
+  EXPECT_SUCCESS(olMemcpy(nullptr, Output.data(), Host, Alloc, Device, Size));
   for (uint8_t Val : Output) {
-    ASSERT_EQ(Val, 42);
+    EXPECT_EQ(Val, 42);
   }
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  EXPECT_SUCCESS(olMemFree(Alloc));
 }
 
 TEST_P(olMemcpyTest, SuccessSizeZero) {
@@ -120,7 +120,7 @@ TEST_P(olMemcpyTest, SuccessSizeZero) {
 
   // As with std::memcpy, size 0 is allowed. Keep all other arguments valid even
   // if they aren't used.
-  ASSERT_SUCCESS(olMemcpy(nullptr, Output.data(), Host, Input.data(), Host, 0));
+  EXPECT_SUCCESS(olMemcpy(nullptr, Output.data(), Host, Input.data(), Host, 0));
 }
 
 TEST_P(olMemcpyGlobalTest, SuccessRoundTrip) {
@@ -135,19 +135,19 @@ TEST_P(olMemcpyGlobalTest, SuccessRoundTrip) {
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
                             64 * sizeof(uint32_t), &DestMem));
 
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olMemcpy(Queue, Addr, Device, SourceMem, Host, 64 * sizeof(uint32_t)));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(
       olMemcpy(Queue, DestMem, Host, Addr, Device, 64 * sizeof(uint32_t)));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *DestData = (uint32_t *)DestMem;
   for (uint32_t I = 0; I < 64; I++)
-    ASSERT_EQ(DestData[I], I);
+    EXPECT_EQ(DestData[I], I);
 
-  ASSERT_SUCCESS(olMemFree(DestMem));
-  ASSERT_SUCCESS(olMemFree(SourceMem));
+  EXPECT_SUCCESS(olMemFree(DestMem));
+  EXPECT_SUCCESS(olMemFree(SourceMem));
 }
 
 TEST_P(olMemcpyGlobalTest, SuccessWrite) {
@@ -160,26 +160,26 @@ TEST_P(olMemcpyGlobalTest, SuccessWrite) {
     SourceData[I] = I;
 
   void *DestMem;
-  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
+  EXPECT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED,
                             LaunchArgs.GroupSize.x * sizeof(uint32_t),
                             &DestMem));
   struct {
     void *Mem;
   } Args{DestMem};
 
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olMemcpy(Queue, Addr, Device, SourceMem, Host, 64 * sizeof(uint32_t)));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
-  ASSERT_SUCCESS(olLaunchKernel(Queue, Device, ReadKernel, &Args, sizeof(Args),
+  EXPECT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olLaunchKernel(Queue, Device, ReadKernel, &Args, sizeof(Args),
                                 &LaunchArgs));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *DestData = (uint32_t *)DestMem;
   for (uint32_t I = 0; I < 64; I++)
-    ASSERT_EQ(DestData[I], I);
+    EXPECT_EQ(DestData[I], I);
 
-  ASSERT_SUCCESS(olMemFree(DestMem));
-  ASSERT_SUCCESS(olMemFree(SourceMem));
+  EXPECT_SUCCESS(olMemFree(DestMem));
+  EXPECT_SUCCESS(olMemFree(SourceMem));
 }
 
 TEST_P(olMemcpyGlobalTest, SuccessRead) {
@@ -188,16 +188,16 @@ TEST_P(olMemcpyGlobalTest, SuccessRead) {
                             LaunchArgs.GroupSize.x * sizeof(uint32_t),
                             &DestMem));
 
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olLaunchKernel(Queue, Device, WriteKernel, nullptr, 0, &LaunchArgs));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(
       olMemcpy(Queue, DestMem, Host, Addr, Device, 64 * sizeof(uint32_t)));
-  ASSERT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olSyncQueue(Queue));
 
   uint32_t *DestData = (uint32_t *)DestMem;
   for (uint32_t I = 0; I < 64; I++)
-    ASSERT_EQ(DestData[I], I * 2);
+    EXPECT_EQ(DestData[I], I * 2);
 
-  ASSERT_SUCCESS(olMemFree(DestMem));
+  EXPECT_SUCCESS(olMemFree(DestMem));
 }

--- a/offload/unittests/OffloadAPI/platform/olGetPlatformInfo.cpp
+++ b/offload/unittests/OffloadAPI/platform/olGetPlatformInfo.cpp
@@ -15,76 +15,79 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetPlatformInfoTest);
 
 TEST_P(olGetPlatformInfoTest, SuccessName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_NAME, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_SUCCESS(olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_NAME, &Size));
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> Name;
   Name.resize(Size);
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetPlatformInfo(Platform, OL_PLATFORM_INFO_NAME, Size, Name.data()));
-  ASSERT_EQ(std::strlen(Name.data()), Size - 1);
+  EXPECT_EQ(std::strlen(Name.data()), Size - 1);
 }
 
 TEST_P(olGetPlatformInfoTest, SuccessVendorName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_VENDOR_NAME, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> VendorName;
   VendorName.resize(Size);
-  ASSERT_SUCCESS(olGetPlatformInfo(Platform, OL_PLATFORM_INFO_VENDOR_NAME, Size,
+  EXPECT_SUCCESS(olGetPlatformInfo(Platform, OL_PLATFORM_INFO_VENDOR_NAME, Size,
                                    VendorName.data()));
-  ASSERT_EQ(std::strlen(VendorName.data()), Size - 1);
+  EXPECT_EQ(std::strlen(VendorName.data()), Size - 1);
 }
 
 TEST_P(olGetPlatformInfoTest, SuccessVersion) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_VERSION, &Size));
-  ASSERT_GT(Size, 0ul);
+  EXPECT_GT(Size, 0ul);
+  ASSERT_LT(Size, 0x1000);
   std::vector<char> Version;
   Version.resize(Size);
-  ASSERT_SUCCESS(olGetPlatformInfo(Platform, OL_PLATFORM_INFO_VERSION, Size,
+  EXPECT_SUCCESS(olGetPlatformInfo(Platform, OL_PLATFORM_INFO_VERSION, Size,
                                    Version.data()));
-  ASSERT_EQ(std::strlen(Version.data()), Size - 1);
+  EXPECT_EQ(std::strlen(Version.data()), Size - 1);
 }
 
 TEST_P(olGetPlatformInfoTest, SuccessBackend) {
   ol_platform_backend_t Backend;
-  ASSERT_SUCCESS(olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND,
+  EXPECT_SUCCESS(olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND,
                                    sizeof(ol_platform_backend_t), &Backend));
 }
 
 TEST_P(olGetPlatformInfoTest, InvalidNullHandle) {
   ol_platform_backend_t Backend;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetPlatformInfo(nullptr, OL_PLATFORM_INFO_BACKEND,
                                  sizeof(Backend), &Backend));
 }
 
 TEST_P(olGetPlatformInfoTest, InvalidPlatformInfoEnumeration) {
   ol_platform_backend_t Backend;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetPlatformInfo(Platform, OL_PLATFORM_INFO_FORCE_UINT32,
                                  sizeof(Backend), &Backend));
 }
 
 TEST_P(olGetPlatformInfoTest, InvalidSizeZero) {
   ol_platform_backend_t Backend;
-  ASSERT_ERROR(
+  EXPECT_ERROR(
       OL_ERRC_INVALID_SIZE,
       olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND, 0, &Backend));
 }
 
 TEST_P(olGetPlatformInfoTest, InvalidSizeSmall) {
   ol_platform_backend_t Backend;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND,
                                  sizeof(Backend) - 1, &Backend));
 }
 
 TEST_P(olGetPlatformInfoTest, InvalidNullPointerPropValue) {
   ol_platform_backend_t Backend;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND,
                                  sizeof(Backend), nullptr));
 }

--- a/offload/unittests/OffloadAPI/platform/olGetPlatformInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/platform/olGetPlatformInfoSize.cpp
@@ -15,46 +15,46 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetPlatformInfoSizeTest);
 
 TEST_P(olGetPlatformInfoSizeTest, SuccessName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_NAME, &Size));
-  ASSERT_NE(Size, 0ul);
+  EXPECT_SUCCESS(olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_NAME, &Size));
+  EXPECT_NE(Size, 0ul);
 }
 
 TEST_P(olGetPlatformInfoSizeTest, SuccessVendorName) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_VENDOR_NAME, &Size));
-  ASSERT_NE(Size, 0ul);
+  EXPECT_NE(Size, 0ul);
 }
 
 TEST_P(olGetPlatformInfoSizeTest, SuccessVersion) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_VERSION, &Size));
-  ASSERT_NE(Size, 0ul);
+  EXPECT_NE(Size, 0ul);
 }
 
 TEST_P(olGetPlatformInfoSizeTest, SuccessBackend) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_BACKEND, &Size));
-  ASSERT_EQ(Size, sizeof(ol_platform_backend_t));
+  EXPECT_EQ(Size, sizeof(ol_platform_backend_t));
 }
 
 TEST_P(olGetPlatformInfoSizeTest, InvalidNullHandle) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetPlatformInfoSize(nullptr, OL_PLATFORM_INFO_BACKEND, &Size));
 }
 
 TEST_P(olGetPlatformInfoSizeTest, InvalidPlatformInfoEnumeration) {
   size_t Size = 0;
-  ASSERT_ERROR(
+  EXPECT_ERROR(
       OL_ERRC_INVALID_ENUMERATION,
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_FORCE_UINT32, &Size));
 }
 
 TEST_P(olGetPlatformInfoSizeTest, InvalidNullPointer) {
-  ASSERT_ERROR(
+  EXPECT_ERROR(
       OL_ERRC_INVALID_NULL_POINTER,
       olGetPlatformInfoSize(Platform, OL_PLATFORM_INFO_BACKEND, nullptr));
 }

--- a/offload/unittests/OffloadAPI/program/olCreateProgram.cpp
+++ b/offload/unittests/OffloadAPI/program/olCreateProgram.cpp
@@ -17,12 +17,12 @@ TEST_P(olCreateProgramTest, Success) {
 
   std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
   ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
-  ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+  EXPECT_GE(DeviceBin->getBufferSize(), 0lu);
 
   ol_program_handle_t Program;
   ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
                                  DeviceBin->getBufferSize(), &Program));
-  ASSERT_NE(Program, nullptr);
+  EXPECT_NE(Program, nullptr);
 
-  ASSERT_SUCCESS(olDestroyProgram(Program));
+  EXPECT_SUCCESS(olDestroyProgram(Program));
 }

--- a/offload/unittests/OffloadAPI/program/olDestroyProgram.cpp
+++ b/offload/unittests/OffloadAPI/program/olDestroyProgram.cpp
@@ -14,10 +14,10 @@ using olDestroyProgramTest = OffloadProgramTest;
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olDestroyProgramTest);
 
 TEST_P(olDestroyProgramTest, Success) {
-  ASSERT_SUCCESS(olDestroyProgram(Program));
+  EXPECT_SUCCESS(olDestroyProgram(Program));
   Program = nullptr;
 }
 
 TEST_P(olDestroyProgramTest, InvalidNullHandle) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyProgram(nullptr));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyProgram(nullptr));
 }

--- a/offload/unittests/OffloadAPI/queue/olCreateQueue.cpp
+++ b/offload/unittests/OffloadAPI/queue/olCreateQueue.cpp
@@ -15,15 +15,15 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olCreateQueueTest);
 
 TEST_P(olCreateQueueTest, Success) {
   ol_queue_handle_t Queue = nullptr;
-  ASSERT_SUCCESS(olCreateQueue(Device, &Queue));
-  ASSERT_NE(Queue, nullptr);
+  EXPECT_SUCCESS(olCreateQueue(Device, &Queue));
+  EXPECT_NE(Queue, nullptr);
 }
 
 TEST_P(olCreateQueueTest, InvalidNullHandleDevice) {
   ol_queue_handle_t Queue = nullptr;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olCreateQueue(nullptr, &Queue));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olCreateQueue(nullptr, &Queue));
 }
 
 TEST_P(olCreateQueueTest, InvalidNullPointerQueue) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olCreateQueue(Device, nullptr));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olCreateQueue(Device, nullptr));
 }

--- a/offload/unittests/OffloadAPI/queue/olDestroyQueue.cpp
+++ b/offload/unittests/OffloadAPI/queue/olDestroyQueue.cpp
@@ -14,10 +14,10 @@ using olDestroyQueueTest = OffloadQueueTest;
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olDestroyQueueTest);
 
 TEST_P(olDestroyQueueTest, Success) {
-  ASSERT_SUCCESS(olDestroyQueue(Queue));
+  EXPECT_SUCCESS(olDestroyQueue(Queue));
   Queue = nullptr;
 }
 
 TEST_P(olDestroyQueueTest, InvalidNullHandle) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyQueue(nullptr));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olDestroyQueue(nullptr));
 }

--- a/offload/unittests/OffloadAPI/queue/olGetQueueInfo.cpp
+++ b/offload/unittests/OffloadAPI/queue/olGetQueueInfo.cpp
@@ -15,47 +15,47 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetQueueInfoTest);
 
 TEST_P(olGetQueueInfoTest, SuccessDevice) {
   ol_device_handle_t RetrievedDevice;
-  ASSERT_SUCCESS(olGetQueueInfo(Queue, OL_QUEUE_INFO_DEVICE,
+  EXPECT_SUCCESS(olGetQueueInfo(Queue, OL_QUEUE_INFO_DEVICE,
                                 sizeof(ol_device_handle_t), &RetrievedDevice));
-  ASSERT_EQ(Device, RetrievedDevice);
+  EXPECT_EQ(Device, RetrievedDevice);
 }
 
 TEST_P(olGetQueueInfoTest, SuccessEmpty) {
   bool Empty;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetQueueInfo(Queue, OL_QUEUE_INFO_EMPTY, sizeof(Empty), &Empty));
 }
 
 TEST_P(olGetQueueInfoTest, InvalidNullHandle) {
   ol_device_handle_t RetrievedDevice;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetQueueInfo(nullptr, OL_QUEUE_INFO_DEVICE,
                               sizeof(RetrievedDevice), &RetrievedDevice));
 }
 
 TEST_P(olGetQueueInfoTest, InvalidQueueInfoEnumeration) {
   ol_device_handle_t RetrievedDevice;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetQueueInfo(Queue, OL_QUEUE_INFO_FORCE_UINT32,
                               sizeof(RetrievedDevice), &RetrievedDevice));
 }
 
 TEST_P(olGetQueueInfoTest, InvalidSizeZero) {
   ol_device_handle_t RetrievedDevice;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE, olGetQueueInfo(Queue, OL_QUEUE_INFO_DEVICE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE, olGetQueueInfo(Queue, OL_QUEUE_INFO_DEVICE,
                                                     0, &RetrievedDevice));
 }
 
 TEST_P(olGetQueueInfoTest, InvalidSizeSmall) {
   ol_device_handle_t RetrievedDevice;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetQueueInfo(Queue, OL_QUEUE_INFO_DEVICE,
                               sizeof(RetrievedDevice) - 1, &RetrievedDevice));
 }
 
 TEST_P(olGetQueueInfoTest, InvalidNullPointerPropValue) {
   ol_device_handle_t RetrievedDevice;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetQueueInfo(Queue, OL_QUEUE_INFO_DEVICE,
                               sizeof(RetrievedDevice), nullptr));
 }

--- a/offload/unittests/OffloadAPI/queue/olGetQueueInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/queue/olGetQueueInfoSize.cpp
@@ -15,29 +15,29 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetQueueInfoSizeTest);
 
 TEST_P(olGetQueueInfoSizeTest, SuccessDevice) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetQueueInfoSize(Queue, OL_QUEUE_INFO_DEVICE, &Size));
-  ASSERT_EQ(Size, sizeof(ol_device_handle_t));
+  EXPECT_SUCCESS(olGetQueueInfoSize(Queue, OL_QUEUE_INFO_DEVICE, &Size));
+  EXPECT_EQ(Size, sizeof(ol_device_handle_t));
 }
 
 TEST_P(olGetQueueInfoSizeTest, SuccessEmpty) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetQueueInfoSize(Queue, OL_QUEUE_INFO_EMPTY, &Size));
-  ASSERT_EQ(Size, sizeof(bool));
+  EXPECT_SUCCESS(olGetQueueInfoSize(Queue, OL_QUEUE_INFO_EMPTY, &Size));
+  EXPECT_EQ(Size, sizeof(bool));
 }
 
 TEST_P(olGetQueueInfoSizeTest, InvalidNullHandle) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetQueueInfoSize(nullptr, OL_QUEUE_INFO_DEVICE, &Size));
 }
 
 TEST_P(olGetQueueInfoSizeTest, InvalidQueueInfoEnumeration) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetQueueInfoSize(Queue, OL_QUEUE_INFO_FORCE_UINT32, &Size));
 }
 
 TEST_P(olGetQueueInfoSizeTest, InvalidNullPointer) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetQueueInfoSize(Queue, OL_QUEUE_INFO_DEVICE, nullptr));
 }

--- a/offload/unittests/OffloadAPI/queue/olSyncQueue.cpp
+++ b/offload/unittests/OffloadAPI/queue/olSyncQueue.cpp
@@ -14,5 +14,5 @@ using olSyncQueueTest = OffloadQueueTest;
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olSyncQueueTest);
 
 TEST_P(olSyncQueueTest, SuccessEmptyQueue) {
-  ASSERT_SUCCESS(olSyncQueue(Queue));
+  EXPECT_SUCCESS(olSyncQueue(Queue));
 }

--- a/offload/unittests/OffloadAPI/queue/olWaitEvents.cpp
+++ b/offload/unittests/OffloadAPI/queue/olWaitEvents.cpp
@@ -49,18 +49,18 @@ TEST_P(olWaitEventsTest, Success) {
     ASSERT_SUCCESS(olCreateQueue(Device, &Queues[I]));
 
     if (I > 0)
-      ASSERT_SUCCESS(olWaitEvents(Queues[I], &Events[I - 1], 1));
+      EXPECT_SUCCESS(olWaitEvents(Queues[I], &Events[I - 1], 1));
 
-    ASSERT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
+    EXPECT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
                                   sizeof(Args), &LaunchArgs));
     ASSERT_SUCCESS(olCreateEvent(Queues[I], &Events[I]));
   }
 
-  ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
+  EXPECT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 2; i < NUM_KERNELS; i++) {
-    ASSERT_EQ(Data[i], Data[i - 1] + Data[i - 2]);
+    EXPECT_EQ(Data[i], Data[i - 1] + Data[i - 2]);
   }
 }
 
@@ -83,18 +83,18 @@ TEST_P(olWaitEventsTest, SuccessSingleQueue) {
     Args.Idx = I;
 
     if (I > 0)
-      ASSERT_SUCCESS(olWaitEvents(Queue, &Events[I - 1], 1));
+      EXPECT_SUCCESS(olWaitEvents(Queue, &Events[I - 1], 1));
 
-    ASSERT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
+    EXPECT_SUCCESS(olLaunchKernel(Queue, Device, Kernel, &Args, sizeof(Args),
                                   &LaunchArgs));
     ASSERT_SUCCESS(olCreateEvent(Queue, &Events[I]));
   }
 
-  ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
+  EXPECT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 2; i < NUM_KERNELS; i++) {
-    ASSERT_EQ(Data[i], Data[i - 1] + Data[i - 2]);
+    EXPECT_EQ(Data[i], Data[i - 1] + Data[i - 2]);
   }
 }
 
@@ -117,35 +117,35 @@ TEST_P(olWaitEventsTest, SuccessMultipleEvents) {
     ASSERT_SUCCESS(olCreateQueue(Device, &Queues[I]));
 
     if (I > 0)
-      ASSERT_SUCCESS(olWaitEvents(Queues[I], Events, I));
+      EXPECT_SUCCESS(olWaitEvents(Queues[I], Events, I));
 
-    ASSERT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
+    EXPECT_SUCCESS(olLaunchKernel(Queues[I], Device, Kernel, &Args,
                                   sizeof(Args), &LaunchArgs));
     ASSERT_SUCCESS(olCreateEvent(Queues[I], &Events[I]));
   }
 
-  ASSERT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
+  EXPECT_SUCCESS(olSyncEvent(Events[NUM_KERNELS - 1]));
 
   uint32_t *Data = (uint32_t *)Mem;
   for (uint32_t i = 2; i < NUM_KERNELS; i++) {
-    ASSERT_EQ(Data[i], Data[i - 1] + Data[i - 2]);
+    EXPECT_EQ(Data[i], Data[i - 1] + Data[i - 2]);
   }
 }
 
 TEST_P(olWaitEventsTest, InvalidNullQueue) {
   ol_event_handle_t Event;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvents(nullptr, &Event, 1));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvents(nullptr, &Event, 1));
 }
 
 TEST_P(olWaitEventsTest, InvalidNullEvent) {
   ol_queue_handle_t Queue;
   ASSERT_SUCCESS(olCreateQueue(Device, &Queue));
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olWaitEvents(Queue, nullptr, 1));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olWaitEvents(Queue, nullptr, 1));
 }
 
 TEST_P(olWaitEventsTest, InvalidNullInnerEvent) {
   ol_queue_handle_t Queue;
   ASSERT_SUCCESS(olCreateQueue(Device, &Queue));
   ol_event_handle_t Event = nullptr;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvents(Queue, &Event, 1));
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olWaitEvents(Queue, &Event, 1));
 }

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbol.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbol.cpp
@@ -17,14 +17,14 @@ struct olGetSymbolGlobalTest : OffloadQueueTest {
   void SetUp() override {
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::SetUp());
     ASSERT_TRUE(TestEnvironment::loadDeviceBinary("global", Device, DeviceBin));
-    ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+    EXPECT_GE(DeviceBin->getBufferSize(), 0lu);
     ASSERT_SUCCESS(olCreateProgram(Device, DeviceBin->getBufferStart(),
                                    DeviceBin->getBufferSize(), &Program));
   }
 
   void TearDown() override {
     if (Program) {
-      olDestroyProgram(Program);
+      EXPECT_SUCCESS(olDestroyProgram(Program));
     }
     RETURN_ON_FATAL_FAILURE(OffloadQueueTest::TearDown());
   }
@@ -37,75 +37,75 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolGlobalTest);
 
 TEST_P(olGetSymbolKernelTest, Success) {
   ol_symbol_handle_t Kernel = nullptr;
-  ASSERT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &Kernel));
-  ASSERT_NE(Kernel, nullptr);
+  EXPECT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &Kernel));
+  EXPECT_NE(Kernel, nullptr);
 }
 
 TEST_P(olGetSymbolKernelTest, SuccessSamePtr) {
   ol_symbol_handle_t KernelA = nullptr;
   ol_symbol_handle_t KernelB = nullptr;
-  ASSERT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &KernelA));
-  ASSERT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &KernelB));
-  ASSERT_EQ(KernelA, KernelB);
+  EXPECT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &KernelA));
+  EXPECT_SUCCESS(olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, &KernelB));
+  EXPECT_EQ(KernelA, KernelB);
 }
 
 TEST_P(olGetSymbolKernelTest, InvalidNullProgram) {
   ol_symbol_handle_t Kernel = nullptr;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetSymbol(nullptr, "foo", OL_SYMBOL_KIND_KERNEL, &Kernel));
 }
 
 TEST_P(olGetSymbolKernelTest, InvalidNullKernelPointer) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetSymbol(Program, "foo", OL_SYMBOL_KIND_KERNEL, nullptr));
 }
 
 TEST_P(olGetSymbolKernelTest, InvalidKernelName) {
   ol_symbol_handle_t Kernel = nullptr;
-  ASSERT_ERROR(OL_ERRC_NOT_FOUND, olGetSymbol(Program, "invalid_kernel_name",
+  EXPECT_ERROR(OL_ERRC_NOT_FOUND, olGetSymbol(Program, "invalid_kernel_name",
                                               OL_SYMBOL_KIND_KERNEL, &Kernel));
 }
 
 TEST_P(olGetSymbolKernelTest, InvalidKind) {
   ol_symbol_handle_t Kernel = nullptr;
-  ASSERT_ERROR(
+  EXPECT_ERROR(
       OL_ERRC_INVALID_ENUMERATION,
       olGetSymbol(Program, "foo", OL_SYMBOL_KIND_FORCE_UINT32, &Kernel));
 }
 
 TEST_P(olGetSymbolGlobalTest, Success) {
   ol_symbol_handle_t Global = nullptr;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetSymbol(Program, "global", OL_SYMBOL_KIND_GLOBAL_VARIABLE, &Global));
-  ASSERT_NE(Global, nullptr);
+  EXPECT_NE(Global, nullptr);
 }
 
 TEST_P(olGetSymbolGlobalTest, SuccessSamePtr) {
   ol_symbol_handle_t GlobalA = nullptr;
   ol_symbol_handle_t GlobalB = nullptr;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetSymbol(Program, "global", OL_SYMBOL_KIND_GLOBAL_VARIABLE, &GlobalA));
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetSymbol(Program, "global", OL_SYMBOL_KIND_GLOBAL_VARIABLE, &GlobalB));
-  ASSERT_EQ(GlobalA, GlobalB);
+  EXPECT_EQ(GlobalA, GlobalB);
 }
 
 TEST_P(olGetSymbolGlobalTest, InvalidNullProgram) {
   ol_symbol_handle_t Global = nullptr;
-  ASSERT_ERROR(
+  EXPECT_ERROR(
       OL_ERRC_INVALID_NULL_HANDLE,
       olGetSymbol(nullptr, "global", OL_SYMBOL_KIND_GLOBAL_VARIABLE, &Global));
 }
 
 TEST_P(olGetSymbolGlobalTest, InvalidNullGlobalPointer) {
-  ASSERT_ERROR(
+  EXPECT_ERROR(
       OL_ERRC_INVALID_NULL_POINTER,
       olGetSymbol(Program, "global", OL_SYMBOL_KIND_GLOBAL_VARIABLE, nullptr));
 }
 
 TEST_P(olGetSymbolGlobalTest, InvalidGlobalName) {
   ol_symbol_handle_t Global = nullptr;
-  ASSERT_ERROR(OL_ERRC_NOT_FOUND,
+  EXPECT_ERROR(OL_ERRC_NOT_FOUND,
                olGetSymbol(Program, "invalid_global",
                            OL_SYMBOL_KIND_GLOBAL_VARIABLE, &Global));
 }

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbolInfo.cpp
@@ -18,76 +18,76 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolInfoGlobalTest);
 
 TEST_P(olGetSymbolInfoKernelTest, SuccessKind) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_SUCCESS(olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
+  EXPECT_SUCCESS(olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
                                  sizeof(RetrievedKind), &RetrievedKind));
-  ASSERT_EQ(RetrievedKind, OL_SYMBOL_KIND_KERNEL);
+  EXPECT_EQ(RetrievedKind, OL_SYMBOL_KIND_KERNEL);
 }
 
 TEST_P(olGetSymbolInfoGlobalTest, SuccessKind) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_KIND,
+  EXPECT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_KIND,
                                  sizeof(RetrievedKind), &RetrievedKind));
-  ASSERT_EQ(RetrievedKind, OL_SYMBOL_KIND_GLOBAL_VARIABLE);
+  EXPECT_EQ(RetrievedKind, OL_SYMBOL_KIND_GLOBAL_VARIABLE);
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidAddress) {
   void *RetrievedAddr;
-  ASSERT_ERROR(OL_ERRC_SYMBOL_KIND,
+  EXPECT_ERROR(OL_ERRC_SYMBOL_KIND,
                olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS,
                                sizeof(RetrievedAddr), &RetrievedAddr));
 }
 
 TEST_P(olGetSymbolInfoGlobalTest, SuccessAddress) {
   void *RetrievedAddr = nullptr;
-  ASSERT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS,
+  EXPECT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS,
                                  sizeof(RetrievedAddr), &RetrievedAddr));
-  ASSERT_NE(RetrievedAddr, nullptr);
+  EXPECT_NE(RetrievedAddr, nullptr);
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidSize) {
   size_t RetrievedSize;
-  ASSERT_ERROR(OL_ERRC_SYMBOL_KIND,
+  EXPECT_ERROR(OL_ERRC_SYMBOL_KIND,
                olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
                                sizeof(RetrievedSize), &RetrievedSize));
 }
 
 TEST_P(olGetSymbolInfoGlobalTest, SuccessSize) {
   size_t RetrievedSize = 0;
-  ASSERT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
+  EXPECT_SUCCESS(olGetSymbolInfo(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE,
                                  sizeof(RetrievedSize), &RetrievedSize));
-  ASSERT_EQ(RetrievedSize, 64 * sizeof(uint32_t));
+  EXPECT_EQ(RetrievedSize, 64 * sizeof(uint32_t));
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidNullHandle) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetSymbolInfo(nullptr, OL_SYMBOL_INFO_KIND,
                                sizeof(RetrievedKind), &RetrievedKind));
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidSymbolInfoEnumeration) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_FORCE_UINT32,
                                sizeof(RetrievedKind), &RetrievedKind));
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidSizeZero) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND, 0, &RetrievedKind));
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidSizeSmall) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_ERROR(OL_ERRC_INVALID_SIZE,
+  EXPECT_ERROR(OL_ERRC_INVALID_SIZE,
                olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
                                sizeof(RetrievedKind) - 1, &RetrievedKind));
 }
 
 TEST_P(olGetSymbolInfoKernelTest, InvalidNullPointerPropValue) {
   ol_symbol_kind_t RetrievedKind;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetSymbolInfo(Kernel, OL_SYMBOL_INFO_KIND,
                                sizeof(RetrievedKind), nullptr));
 }

--- a/offload/unittests/OffloadAPI/symbol/olGetSymbolInfoSize.cpp
+++ b/offload/unittests/OffloadAPI/symbol/olGetSymbolInfoSize.cpp
@@ -18,43 +18,43 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olGetSymbolInfoSizeGlobalTest);
 
 TEST_P(olGetSymbolInfoSizeKernelTest, SuccessKind) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_KIND, &Size));
-  ASSERT_EQ(Size, sizeof(ol_symbol_kind_t));
+  EXPECT_SUCCESS(olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_KIND, &Size));
+  EXPECT_EQ(Size, sizeof(ol_symbol_kind_t));
 }
 
 TEST_P(olGetSymbolInfoSizeGlobalTest, SuccessKind) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetSymbolInfoSize(Global, OL_SYMBOL_INFO_KIND, &Size));
-  ASSERT_EQ(Size, sizeof(ol_symbol_kind_t));
+  EXPECT_SUCCESS(olGetSymbolInfoSize(Global, OL_SYMBOL_INFO_KIND, &Size));
+  EXPECT_EQ(Size, sizeof(ol_symbol_kind_t));
 }
 
 TEST_P(olGetSymbolInfoSizeGlobalTest, SuccessAddress) {
   size_t Size = 0;
-  ASSERT_SUCCESS(olGetSymbolInfoSize(
+  EXPECT_SUCCESS(olGetSymbolInfoSize(
       Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_ADDRESS, &Size));
-  ASSERT_EQ(Size, sizeof(void *));
+  EXPECT_EQ(Size, sizeof(void *));
 }
 
 TEST_P(olGetSymbolInfoSizeGlobalTest, SuccessSize) {
   size_t Size = 0;
-  ASSERT_SUCCESS(
+  EXPECT_SUCCESS(
       olGetSymbolInfoSize(Global, OL_SYMBOL_INFO_GLOBAL_VARIABLE_SIZE, &Size));
-  ASSERT_EQ(Size, sizeof(size_t));
+  EXPECT_EQ(Size, sizeof(size_t));
 }
 
 TEST_P(olGetSymbolInfoSizeKernelTest, InvalidNullHandle) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_HANDLE,
                olGetSymbolInfoSize(nullptr, OL_SYMBOL_INFO_KIND, &Size));
 }
 
 TEST_P(olGetSymbolInfoSizeKernelTest, InvalidSymbolInfoEnumeration) {
   size_t Size = 0;
-  ASSERT_ERROR(OL_ERRC_INVALID_ENUMERATION,
+  EXPECT_ERROR(OL_ERRC_INVALID_ENUMERATION,
                olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_FORCE_UINT32, &Size));
 }
 
 TEST_P(olGetSymbolInfoSizeKernelTest, InvalidNullPointer) {
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+  EXPECT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
                olGetSymbolInfoSize(Kernel, OL_SYMBOL_INFO_KIND, nullptr));
 }


### PR DESCRIPTION
`EXPECT_` allows the test to continue after reaching a failure. Switch
many cases of `ASSERT_` over to `EXPECT_` to be consistent with other
LLVM code.

Some uses of `ASSERT_` remain for calls whose failure would result in
crashes if the test were to continue. This is mostly the various
handle creation functions to prevent accessing invalid pointers. Strings
returned from GetInfo are also capped so that a misbehaving GetInfo call
does not allocate too much memory.
