### PR TITLE
[lit] Make a separate tmpdir for every test in the suite

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1369,7 +1369,7 @@ def getTempPaths(test):
     root, not test source root."""
     execpath = test.getExecPath()
     execdir, execbase = os.path.split(execpath)
-    tmpDir = os.path.join(execdir, "Output")
+    tmpDir = os.path.join(execdir, "Output", f"{execbase}.dir")
     tmpBase = os.path.join(tmpDir, execbase)
     return tmpDir, tmpBase
 


### PR DESCRIPTION
I would like every test in the test suite to have its own temporary directory so that is it easier to track execution artifacts of each test. The suggested change is the simplest one that can be made and it should not break anything since tests should not rely on sharing the temporary directory. We can also make this change configurable so that users can specify desired behavior in their local lit config.