### PR TITLE
[libc][math] Refactor coshf implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -35,6 +35,7 @@
 #include "math/cos.h"
 #include "math/cosf.h"
 #include "math/cosf16.h"
+#include "math/coshf.h"
 #include "math/erff.h"
 #include "math/exp.h"
 #include "math/exp10.h"

--- a/libc/shared/math/coshf.h
+++ b/libc/shared/math/coshf.h
@@ -1,4 +1,4 @@
-//===-- Single-precision cosh function ------------------------------------===//
+//===-- Shared coshf function -----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/coshf.h"
+#ifndef LLVM_LIBC_SHARED_MATH_COSHF_H
+#define LLVM_LIBC_SHARED_MATH_COSHF_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/coshf.h"
 
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(float, coshf, (float x)) { return math::coshf(x); }
+using math::coshf;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_COSHF_H

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -408,6 +408,18 @@ add_header_library(
 )
 
 add_header_library(
+  coshf
+  HDRS
+    coshf.h
+  DEPENDS
+    .sinhfcoshf_utils
+    libc.src.__support.FPUtil.fp_bits
+    libc.src.__support.FPUtil.multiply_add
+    libc.src.__support.FPUtil.rounding_mode
+    libc.src.__support.macros.optimization
+)
+
+add_header_library(
   erff
   HDRS
     erff.h
@@ -725,4 +737,13 @@ add_header_library(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.nearest_integer
     libc.src.__support.common
+)
+
+add_header_library(
+  sinhfcoshf_utils
+  HDRS
+    sinhfcoshf_utils.h
+  DEPENDS
+    .exp10f_utils
+    libc.src.__support.FPUtil.multiply_add
 )

--- a/libc/src/__support/math/coshf.h
+++ b/libc/src/__support/math/coshf.h
@@ -1,0 +1,65 @@
+//===-- Implementation header for coshf -------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_COSHF_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_COSHF_H
+
+#include "sinhfcoshf_utils.h"
+#include "src/__support/FPUtil/FEnvImpl.h"
+#include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/FPUtil/rounding_mode.h"
+#include "src/__support/macros/config.h"
+#include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr float coshf(float x) {
+  using namespace sinhfcoshf_internal;
+  using FPBits = typename fputil::FPBits<float>;
+
+  FPBits xbits(x);
+  xbits.set_sign(Sign::POS);
+  x = xbits.get_val();
+
+  uint32_t x_u = xbits.uintval();
+
+  // When |x| >= 90, or x is inf or nan
+  if (LIBC_UNLIKELY(x_u >= 0x42b4'0000U || x_u <= 0x3280'0000U)) {
+    // |x| <= 2^-26
+    if (x_u <= 0x3280'0000U) {
+      return 1.0f + x;
+    }
+
+    if (xbits.is_inf_or_nan())
+      return x + FPBits::inf().get_val();
+
+    int rounding = fputil::quick_get_round();
+    if (LIBC_UNLIKELY(rounding == FE_DOWNWARD || rounding == FE_TOWARDZERO))
+      return FPBits::max_normal().get_val();
+
+    fputil::set_errno_if_required(ERANGE);
+    fputil::raise_except_if_required(FE_OVERFLOW);
+
+    return x + FPBits::inf().get_val();
+  }
+
+  // TODO: We should be able to reduce the latency and reciprocal throughput
+  // further by using a low degree (maybe 3-7 ?) minimax polynomial for small
+  // but not too small inputs, such as |x| < 2^-2, or |x| < 2^-3.
+
+  // cosh(x) = (e^x + e^(-x)) / 2.
+  return static_cast<float>(exp_pm_eval</*is_sinh*/ false>(x));
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_COSHF_H

--- a/libc/src/__support/math/sinhfcoshf_utils.h
+++ b/libc/src/__support/math/sinhfcoshf_utils.h
@@ -1,4 +1,4 @@
-//===-- Single-precision general exp/log functions ------------------------===//
+//===-- Single-precision general sinhf/coshf functions --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,21 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIBC_SRC_MATH_GENERIC_EXPLOGXF_H
-#define LLVM_LIBC_SRC_MATH_GENERIC_EXPLOGXF_H
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_SINHFCOSHF_UTILS_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_SINHFCOSHF_UTILS_H
 
-#include "common_constants.h"
-
-#include "src/__support/common.h"
-#include "src/__support/macros/properties/cpu_features.h"
-#include "src/__support/math/acoshf_utils.h"
-#include "src/__support/math/exp10f_utils.h"
-#include "src/__support/math/exp_utils.h"
+#include "exp10f_utils.h"
+#include "src/__support/FPUtil/multiply_add.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
-constexpr int LOG_P1_BITS = 6;
-constexpr int LOG_P1_SIZE = 1 << LOG_P1_BITS;
+namespace math {
+
+namespace sinhfcoshf_internal {
 
 // The function correctly calculates sinh(x) and cosh(x) by calculating exp(x)
 // and exp(-x) simultaneously.
@@ -121,6 +117,10 @@ template <bool is_sinh> LIBC_INLINE double exp_pm_eval(float x) {
   return r;
 }
 
+} // namespace sinhfcoshf_internal
+
+} // namespace math
+
 } // namespace LIBC_NAMESPACE_DECL
 
-#endif // LLVM_LIBC_SRC_MATH_GENERIC_EXPLOGXF_H
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_SINHFCOSHF_UTILS_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -1344,7 +1344,6 @@ add_entrypoint_object(
     ../exp2.h
   DEPENDS
     .common_constants
-    .explogxf
     libc.src.__support.CPP.bit
     libc.src.__support.CPP.optional
     libc.src.__support.FPUtil.dyadic_float
@@ -1357,6 +1356,7 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.triple_double
     libc.src.__support.integer_literals
     libc.src.__support.macros.optimization
+    libc.src.__support.math.exp_utils
     libc.src.errno.errno
 )
 
@@ -1365,7 +1365,6 @@ add_header_library(
   HDRS
     exp2f_impl.h
   DEPENDS
-    .explogxf
     libc.src.__support.FPUtil.except_value_utils
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits
@@ -1374,6 +1373,7 @@ add_header_library(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
+    libc.src.__support.math.exp10f_utils
     libc.src.__support.common
     libc.src.errno.errno
 )
@@ -1413,7 +1413,6 @@ add_entrypoint_object(
   HDRS
     ../exp2m1f.h
   DEPENDS
-    .explogxf
     libc.src.errno.errno
     libc.src.__support.common
     libc.src.__support.FPUtil.except_value_utils
@@ -1424,6 +1423,7 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
     libc.src.__support.macros.properties.cpu_features
+    libc.src.__support.math.exp10f_utils
 )
 
 add_entrypoint_object(
@@ -1488,7 +1488,6 @@ add_entrypoint_object(
   HDRS
     ../exp10m1f.h
   DEPENDS
-    .explogxf
     libc.src.errno.errno
     libc.src.__support.common
     libc.src.__support.FPUtil.except_value_utils
@@ -1498,6 +1497,7 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
+    libc.src.__support.math.exp10f_utils
 )
 
 add_entrypoint_object(
@@ -1529,14 +1529,11 @@ add_entrypoint_object(
     ../expm1.h
   DEPENDS
     .common_constants
-    .explogxf
     libc.src.__support.CPP.bit
-    libc.src.__support.CPP.optional
     libc.src.__support.FPUtil.dyadic_float
     libc.src.__support.FPUtil.fenv_impl
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.FPUtil.nearest_integer
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.FPUtil.triple_double
@@ -1593,7 +1590,6 @@ add_entrypoint_object(
   DEPENDS
     .common_constants
     .exp2f_impl
-    .explogxf
     libc.src.__support.math.exp10f
     libc.src.__support.CPP.bit
     libc.src.__support.FPUtil.fenv_impl
@@ -3905,19 +3901,6 @@ add_entrypoint_object(
     libc.src.__support.FPUtil.nearest_integer_operations
 )
 
-#TODO: Add errno include to the hyperbolic functions.
-add_header_library(
-  explogxf
-  HDRS
-    explogxf.h
-  DEPENDS
-    .common_constants
-    libc.src.__support.math.exp_utils
-    libc.src.__support.math.acoshf_utils
-    libc.src.__support.macros.properties.cpu_features
-    libc.src.errno.errno
-)
-
 add_entrypoint_object(
   coshf
   SRCS
@@ -3925,11 +3908,7 @@ add_entrypoint_object(
   HDRS
     ../coshf.h
   DEPENDS
-    .explogxf
-    libc.src.__support.FPUtil.fp_bits
-    libc.src.__support.FPUtil.multiply_add
-    libc.src.__support.FPUtil.rounding_mode
-    libc.src.__support.macros.optimization
+    libc.src.__support.math.coshf
 )
 
 add_entrypoint_object(
@@ -3956,10 +3935,10 @@ add_entrypoint_object(
   HDRS
     ../sinhf.h
   DEPENDS
-    .explogxf
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
+    libc.src.__support.math.sinhfcoshf_utils
 )
 
 add_entrypoint_object(
@@ -3973,7 +3952,7 @@ add_entrypoint_object(
     libc.hdr.errno_macros
     libc.hdr.fenv_macros
     libc.src.__support.FPUtil.except_value_utils
-    libc.src.__support.FPUtil.fenv_impl
+    libc.src.__support.FPUtil.fenv_impl 
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.macros.optimization
@@ -3986,12 +3965,12 @@ add_entrypoint_object(
   HDRS
     ../tanhf.h
   DEPENDS
-    .explogxf
     libc.src.__support.FPUtil.fp_bits
     libc.src.__support.FPUtil.rounding_mode
     libc.src.__support.FPUtil.multiply_add
     libc.src.__support.FPUtil.polyeval
     libc.src.__support.macros.optimization
+    libc.src.__support.math.exp10f_utils
 )
 
 add_entrypoint_object(
@@ -4022,7 +4001,6 @@ add_entrypoint_object(
   HDRS
     ../acoshf.h
   DEPENDS
-    .explogxf
     libc.src.__support.math.acoshf
 )
 

--- a/libc/src/math/generic/acoshf.cpp
+++ b/libc/src/math/generic/acoshf.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/math/acoshf.h"
-
 #include "src/__support/math/acoshf.h"
 
 namespace LIBC_NAMESPACE_DECL {

--- a/libc/src/math/generic/exp10m1f.cpp
+++ b/libc/src/math/generic/exp10m1f.cpp
@@ -17,8 +17,7 @@
 #include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
-
-#include "explogxf.h"
+#include "src/__support/math/exp10f_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/math/generic/exp2.cpp
+++ b/libc/src/math/generic/exp2.cpp
@@ -8,7 +8,6 @@
 
 #include "src/math/exp2.h"
 #include "common_constants.h" // Lookup tables EXP2_MID1 and EXP_M2.
-#include "explogxf.h"         // ziv_test_denorm.
 #include "src/__support/CPP/bit.h"
 #include "src/__support/CPP/optional.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
@@ -24,6 +23,7 @@
 #include "src/__support/integer_literals.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
+#include "src/__support/math/exp_utils.h"      // ziv_test_denorm.
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/math/generic/exp2f_impl.h
+++ b/libc/src/math/generic/exp2f_impl.h
@@ -20,8 +20,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 #include "src/__support/macros/properties/cpu_features.h"
-
-#include "explogxf.h"
+#include "src/__support/math/exp10f_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace generic {

--- a/libc/src/math/generic/exp2m1f.cpp
+++ b/libc/src/math/generic/exp2m1f.cpp
@@ -18,8 +18,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h"
 #include "src/__support/macros/properties/cpu_features.h"
-
-#include "explogxf.h"
+#include "src/__support/math/exp10f_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/src/math/generic/expm1.cpp
+++ b/libc/src/math/generic/expm1.cpp
@@ -8,9 +8,7 @@
 
 #include "src/math/expm1.h"
 #include "common_constants.h" // Lookup tables EXP_M1 and EXP_M2.
-#include "explogxf.h"         // ziv_test_denorm.
 #include "src/__support/CPP/bit.h"
-#include "src/__support/CPP/optional.h"
 #include "src/__support/FPUtil/FEnvImpl.h"
 #include "src/__support/FPUtil/FPBits.h"
 #include "src/__support/FPUtil/PolyEval.h"
@@ -18,7 +16,6 @@
 #include "src/__support/FPUtil/dyadic_float.h"
 #include "src/__support/FPUtil/except_value_utils.h"
 #include "src/__support/FPUtil/multiply_add.h"
-#include "src/__support/FPUtil/nearest_integer.h"
 #include "src/__support/FPUtil/rounding_mode.h"
 #include "src/__support/FPUtil/triple_double.h"
 #include "src/__support/common.h"

--- a/libc/src/math/generic/sinhf.cpp
+++ b/libc/src/math/generic/sinhf.cpp
@@ -12,7 +12,7 @@
 #include "src/__support/FPUtil/rounding_mode.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
-#include "src/math/generic/explogxf.h"
+#include "src/__support/math/sinhfcoshf_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 
@@ -73,7 +73,8 @@ LLVM_LIBC_FUNCTION(float, sinhf, (float x)) {
   }
 
   // sinh(x) = (e^x - e^(-x)) / 2.
-  return static_cast<float>(exp_pm_eval</*is_sinh*/ true>(x));
+  return static_cast<float>(
+      math::sinhfcoshf_internal::exp_pm_eval</*is_sinh*/ true>(x));
 }
 
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/src/math/generic/tanhf.cpp
+++ b/libc/src/math/generic/tanhf.cpp
@@ -14,7 +14,7 @@
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/optimization.h" // LIBC_UNLIKELY
 #include "src/__support/macros/properties/cpu_features.h"
-#include "src/math/generic/explogxf.h"
+#include "src/__support/math/exp10f_utils.h"
 
 namespace LIBC_NAMESPACE_DECL {
 

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -31,6 +31,7 @@ add_fp_unittest(
     libc.src.__support.math.cos
     libc.src.__support.math.cosf
     libc.src.__support.math.cosf16
+    libc.src.__support.math.coshf
     libc.src.__support.math.erff
     libc.src.__support.math.exp
     libc.src.__support.math.exp10

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -51,6 +51,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::atanhf(0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::cbrtf(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::cosf(0.0f));
+  EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::coshf(0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::erff(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp10f(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::expf(0.0f));

--- a/libc/test/src/math/explogxf_test.cpp
+++ b/libc/test/src/math/explogxf_test.cpp
@@ -9,11 +9,11 @@
 #include "hdr/math_macros.h"
 #include "in_float_range_test_helper.h"
 #include "src/__support/FPUtil/FPBits.h"
+#include "src/__support/math/acoshf_utils.h"
+#include "src/__support/math/exp10f_utils.h"
 #include "src/math/fabs.h"
 #include "src/math/fabsf.h"
-#include "src/math/generic/explogxf.h"
 #include "test/UnitTest/FPMatcher.h"
-#include "test/UnitTest/Test.h"
 #include "utils/MPFRWrapper/MPFRUtils.h"
 
 using LlvmLibcExplogfTest = LIBC_NAMESPACE::testing::FPTest<float>;

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1954,22 +1954,6 @@ libc_support_library(
 )
 
 libc_support_library(
-    name = "explogxf",
-    hdrs = ["src/math/generic/explogxf.h"],
-    deps = [
-        ":__support_fputil_fenv_impl",
-        ":__support_fputil_fma",
-        ":__support_fputil_multiply_add",
-        ":__support_fputil_nearest_integer",
-        ":__support_macros_properties_cpu_features",
-        ":__support_math_acoshf_utils",
-        ":__support_math_exp10f_utils",
-        ":__support_math_exp_utils",
-        ":common_constants",
-    ],
-)
-
-libc_support_library(
     name = "log_range_reduction",
     hdrs = ["src/math/generic/log_range_reduction.h"],
     deps = [
@@ -1991,8 +1975,8 @@ libc_support_library(
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_macros_optimization",
+        ":__support_math_exp10f_utils",
         ":common_constants",
-        ":explogxf",
     ],
 )
 
@@ -2395,6 +2379,18 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_coshf",
+    hdrs = ["src/__support/math/coshf.h"],
+    deps = [
+        ":__support_fputil_fp_bits",
+        ":__support_fputil_multiply_add",
+        ":__support_fputil_rounding_mode",
+        ":__support_macros_optimization",
+        ":__support_math_sinhfcoshf_utils",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_erff",
     hdrs = ["src/__support/math/erff.h"],
     deps = [
@@ -2718,6 +2714,15 @@ libc_support_library(
     ],
 )
 
+libc_support_library(
+    name = "__support_math_sinhfcoshf_utils",
+    hdrs = ["src/__support/math/sinhfcoshf_utils.h"],
+    deps = [
+        ":__support_math_exp10f_utils",
+        ":__support_fputil_multiply_add",
+    ],
+)
+
 ############################### complex targets ################################
 
 libc_function(
@@ -2989,7 +2994,6 @@ libc_math_function(
     name = "acoshf",
     additional_deps = [
         ":__support_math_acoshf",
-        ":explogxf",
     ],
 )
 
@@ -3188,14 +3192,7 @@ libc_math_function(
 libc_math_function(
     name = "coshf",
     additional_deps = [
-        ":__support_fputil_fma",
-        ":__support_fputil_multiply_add",
-        ":__support_fputil_nearest_integer",
-        ":__support_fputil_polyeval",
-        ":__support_fputil_rounding_mode",
-        ":__support_macros_optimization",
-        ":common_constants",
-        ":explogxf",
+        ":__support_math_coshf",
     ],
 )
 
@@ -3215,9 +3212,8 @@ libc_math_function(
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_macros_optimization",
-        ":common_constants",
-        ":explogxf",
         ":__support_sincosf_utils",
+        ":common_constants",
     ],
 )
 
@@ -3339,7 +3335,7 @@ libc_math_function(
 libc_math_function(
     name = "exp10m1f",
     additional_deps = [
-        ":explogxf",
+        ":__support_math_exp10f_utils",
     ],
 )
 
@@ -3355,8 +3351,8 @@ libc_math_function(
         ":__support_fputil_triple_double",
         ":__support_integer_literals",
         ":__support_macros_optimization",
+        ":__support_math_exp_utils",
         ":common_constants",
-        ":explogxf",
     ],
 )
 
@@ -3378,7 +3374,7 @@ libc_math_function(
     name = "exp2m1f",
     additional_deps = [
         ":__support_fputil_polyeval",
-        ":explogxf",
+        ":__support_math_exp10f_utils",
     ],
 )
 
@@ -3395,14 +3391,12 @@ libc_math_function(
         ":__support_fputil_double_double",
         ":__support_fputil_dyadic_float",
         ":__support_fputil_multiply_add",
-        ":__support_fputil_nearest_integer",
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_fputil_triple_double",
         ":__support_integer_literals",
         ":__support_macros_optimization",
         ":common_constants",
-        ":explogxf",
     ],
 )
 
@@ -4180,7 +4174,6 @@ libc_math_function(
         ":__support_macros_optimization",
         ":__support_math_exp10f",
         ":common_constants",
-        ":explogxf",
         ":exp2f_impl",
     ],
 )
@@ -4340,8 +4333,8 @@ libc_math_function(
         ":__support_fputil_polyeval",
         ":__support_fputil_rounding_mode",
         ":__support_macros_optimization",
+        ":__support_math_sinhfcoshf_utils",
         ":common_constants",
-        ":explogxf",
     ],
 )
 
@@ -4447,8 +4440,8 @@ libc_math_function(
         ":__support_fputil_rounding_mode",
         ":__support_macros_optimization",
         ":__support_macros_properties_cpu_features",
+        ":__support_math_exp10f_utils",
         ":common_constants",
-        ":explogxf",
     ],
 )
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450