### PR TITLE
[Clang] Honor -flax-vector-conversions=none on some tests

### DIFF
--- a/clang/test/AST/ByteCode/vectors.cpp
+++ b/clang/test/AST/ByteCode/vectors.cpp
@@ -56,6 +56,11 @@ namespace Vector {
   static_assert(__builtin_vectorelements(v2) == (32 / sizeof(double)), "");
 }
 
+namespace {
+  typedef float __attribute__((vector_size(16))) VI42;
+  constexpr VI42 A2 = {1.f, 2.f, 3.f, 4.f};
+}
+
 namespace BoolToSignedIntegralCast{
   typedef __attribute__((__ext_vector_type__(4))) unsigned int int4;
   constexpr int4 intsT = (int4)true;

--- a/clang/test/AST/ByteCode/vectors.cpp
+++ b/clang/test/AST/ByteCode/vectors.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify=expected,both %s
-// RUN: %clang_cc1 -verify=ref,both %s
+// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -verify=expected,both -flax-vector-conversions=none %s
+// RUN: %clang_cc1 -verify=ref,both -flax-vector-conversions=none %s
 
 typedef int __attribute__((vector_size(16))) VI4;
 constexpr VI4 A = {1,2,3,4};
@@ -54,11 +54,6 @@ namespace Vector {
   }
   constexpr auto v2 = g(4);
   static_assert(__builtin_vectorelements(v2) == (32 / sizeof(double)), "");
-}
-
-namespace {
-  typedef float __attribute__((vector_size(16))) VI42;
-  constexpr VI42 A2 = A;
 }
 
 namespace BoolToSignedIntegralCast{

--- a/clang/test/CodeGen/2007-01-20-VectorICE.c
+++ b/clang/test/CodeGen/2007-01-20-VectorICE.c
@@ -6,6 +6,6 @@ typedef int __v4si __attribute__((__vector_size__(16)));
 
 __v2di bar(void);
 void foo(int X, __v4si *P) {
-	*P = X == 2 ? (__v4si)(bar()) : (__v4si)(bar());
+	*P = X == 2 ? (__v4si)bar() : (__v4si)bar();
 }
 

--- a/clang/test/CodeGen/2007-01-20-VectorICE.c
+++ b/clang/test/CodeGen/2007-01-20-VectorICE.c
@@ -1,11 +1,11 @@
-// RUN: %clang_cc1 %s -emit-llvm -o - 
+// RUN: %clang_cc1 %s -emit-llvm -flax-vector-conversions=none -o -
 
 typedef float __m128 __attribute__((__vector_size__(16)));
 typedef long long __v2di __attribute__((__vector_size__(16)));
 typedef int __v4si __attribute__((__vector_size__(16)));
 
-__v2di  bar(void);
+__v2di bar(void);
 void foo(int X, __v4si *P) {
-	*P = X == 2 ? bar() : bar();
+	*P = X == 2 ? (__v4si)(bar()) : (__v4si)(bar());
 }
 

--- a/clang/test/CodeGen/palignr.c
+++ b/clang/test/CodeGen/palignr.c
@@ -2,15 +2,15 @@
 // RUN: %clang_cc1 %s -triple=i686-apple-darwin -target-feature +ssse3 -O1 -S -flax-vector-conversions=none -o - | FileCheck %s
 
 #define _mm_alignr_epi8(a, b, n) (__builtin_ia32_palignr128((a), (b), (n)))
-typedef long long __m128i __attribute__((__vector_size__(16), __aligned__(16)));
+typedef char __v16qi __attribute__((__vector_size__(16)));
 
 // CHECK: palignr $15, %xmm1, %xmm0
-__m128i align1(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 15); }
+__v16qi align1(__v16qi a, __v16qi b) { return _mm_alignr_epi8(a, b, 15); }
 // CHECK: ret
 // CHECK: ret
 // CHECK-NOT: palignr
-__m128i align2(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 16); }
+__v16qi align2(__v16qi a, __v16qi b) { return _mm_alignr_epi8(a, b, 16); }
 // CHECK: psrldq $1, %xmm0
-__m128i align3(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 17); }
+__v16qi align3(__v16qi a, __v16qi b) { return _mm_alignr_epi8(a, b, 17); }
 // CHECK: xor
-__m128i align4(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 32); }
+__v16qi align4(__v16qi a, __v16qi b) { return _mm_alignr_epi8(a, b, 32); }

--- a/clang/test/CodeGen/palignr.c
+++ b/clang/test/CodeGen/palignr.c
@@ -1,16 +1,16 @@
 // REQUIRES: x86-registered-target
-// RUN: %clang_cc1 %s -triple=i686-apple-darwin -target-feature +ssse3 -O1 -S -o - | FileCheck %s
+// RUN: %clang_cc1 %s -triple=i686-apple-darwin -target-feature +ssse3 -O1 -S -flax-vector-conversions=none -o - | FileCheck %s
 
 #define _mm_alignr_epi8(a, b, n) (__builtin_ia32_palignr128((a), (b), (n)))
-typedef __attribute__((vector_size(16))) int int4;
+typedef long long __m128i __attribute__((__vector_size__(16), __aligned__(16)));
 
 // CHECK: palignr $15, %xmm1, %xmm0
-int4 align1(int4 a, int4 b) { return _mm_alignr_epi8(a, b, 15); }
+__m128i align1(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 15); }
 // CHECK: ret
 // CHECK: ret
 // CHECK-NOT: palignr
-int4 align2(int4 a, int4 b) { return _mm_alignr_epi8(a, b, 16); }
+__m128i align2(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 16); }
 // CHECK: psrldq $1, %xmm0
-int4 align3(int4 a, int4 b) { return _mm_alignr_epi8(a, b, 17); }
+__m128i align3(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 17); }
 // CHECK: xor
-int4 align4(int4 a, int4 b) { return _mm_alignr_epi8(a, b, 32); }
+__m128i align4(__m128i a, __m128i b) { return _mm_alignr_epi8(a, b, 32); }


### PR DESCRIPTION
As in title. This is done as a step towards enabling the `-flax-vector-conversions=none` globally as a default