### PR TITLE
[MLIR] XeVM Target: Add missing SPIR-V backend dependency libraries.

### DIFF
--- a/mlir/lib/Target/LLVM/CMakeLists.txt
+++ b/mlir/lib/Target/LLVM/CMakeLists.txt
@@ -213,7 +213,8 @@ endif()
 if ("SPIRV" IN_LIST LLVM_TARGETS_TO_BUILD)
   set(SPIRV_LIBS
     SPIRVCodeGen
-
+    SPIRVDesc
+    SPIRVInfo
   )
 endif()
 


### PR DESCRIPTION
Adding missing dependency SPIRVDesc, SPIRVInfo 
Fixes post commit build issue with #148286 