### PR TITLE
[clang] Add an ABI_EXTENSION concept that is testable under -pedantic…

### DIFF
--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -24,8 +24,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !defined(FEATURE) && !defined(EXTENSION)
-#  error Define either the FEATURE or EXTENSION macro to handle features
+#if !defined(FEATURE) && !defined(EXTENSION) && !defined(ABI_EXTENSION)
+#  error Define either the FEATURE, EXTENSION, or ABI_EXTENSION macro to handle features
 #endif
 
 #ifndef FEATURE
@@ -34,6 +34,10 @@
 
 #ifndef EXTENSION
 #define EXTENSION(Name, Predicate)
+#endif
+
+#ifndef ABI_EXTENSION
+#define ABI_EXTENSION(Name, Predicate)
 #endif
 
 FEATURE(speculative_load_hardening, LangOpts.SpeculativeLoadHardening)
@@ -148,7 +152,7 @@ FEATURE(thread_sanitizer, LangOpts.Sanitize.has(SanitizerKind::Thread))
 FEATURE(dataflow_sanitizer, LangOpts.Sanitize.has(SanitizerKind::DataFlow))
 FEATURE(scudo, LangOpts.Sanitize.hasOneOf(SanitizerKind::Scudo))
 FEATURE(ptrauth_intrinsics, LangOpts.PointerAuthIntrinsics)
-EXTENSION(ptrauth_qualifier, LangOpts.PointerAuthIntrinsics)
+ABI_EXTENSION(ptrauth_qualifier, LangOpts.PointerAuthIntrinsics)
 FEATURE(ptrauth_calls, LangOpts.PointerAuthCalls)
 FEATURE(ptrauth_returns, LangOpts.PointerAuthReturns)
 FEATURE(ptrauth_vtable_pointer_address_discrimination, LangOpts.PointerAuthVTPtrAddressDiscrimination)
@@ -385,3 +389,4 @@ EXTENSION(cxx_type_aware_allocators, true)
 
 #undef EXTENSION
 #undef FEATURE
+#undef ABI_EXTENSION

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -1183,11 +1183,15 @@ void DumpCompilerOptionsAction::ExecuteAction() {
   OS << "\n\"extensions\" : [\n";
   {
     llvm::SmallString<128> Str;
-#define EXTENSION(Name, Predicate)                                             \
+#define EXTENSION_OPTION(Name, Predicate)                                          \
   ("\t{\"" #Name "\" : " + llvm::Twine(Predicate ? "true" : "false") + "},\n") \
       .toVector(Str);
+#define EXTENSION(Name, Predicate) EXTENSION_OPTION(Name, Predicate)
+#define ABI_EXTENSION(Name, Predicate) EXTENSION_OPTION(Name, Predicate)
 #include "clang/Basic/Features.def"
 #undef EXTENSION
+#undef ABI_EXTENSION
+#undef EXTENSION_OPTION
     // Remove the newline and comma from the last entry to ensure this remains
     // valid JSON.
     OS << Str.substr(0, Str.size() - 2);

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -1183,7 +1183,7 @@ void DumpCompilerOptionsAction::ExecuteAction() {
   OS << "\n\"extensions\" : [\n";
   {
     llvm::SmallString<128> Str;
-#define EXTENSION_OPTION(Name, Predicate)                                          \
+#define EXTENSION_OPTION(Name, Predicate)                                      \
   ("\t{\"" #Name "\" : " + llvm::Twine(Predicate ? "true" : "false") + "},\n") \
       .toVector(Str);
 #define EXTENSION(Name, Predicate) EXTENSION_OPTION(Name, Predicate)

--- a/clang/lib/Lex/PPMacroExpansion.cpp
+++ b/clang/lib/Lex/PPMacroExpansion.cpp
@@ -1118,7 +1118,7 @@ static bool HasExtension(const Preprocessor &PP, StringRef Extension) {
 #define ABI_EXTENSION(Name, Predicate) .Case(#Name, Predicate)
   bool IsABIExtension = llvm::StringSwitch<bool>(Extension)
 #include "clang/Basic/Features.def"
-      .Default(false);
+                            .Default(false);
 #undef ABI_EXTENSION
   if (IsABIExtension)
     return true;

--- a/clang/test/Sema/ptrauth-qualifier.c
+++ b/clang/test/Sema/ptrauth-qualifier.c
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -triple arm64-apple-ios -std=c23 -fsyntax-only -verify -fptrauth-intrinsics %s
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -std=c23 -fsyntax-only -verify -fptrauth-intrinsics %s
+// RUN: %clang_cc1 -triple aarch64-linux-gnu -std=c23 -fsyntax-only -verify -fptrauth-intrinsics -pedantic-errors -Wno-c2y-extensions %s
 
 #if !__has_extension(ptrauth_qualifier)
 // This error means that the __ptrauth qualifier availability test says  that it


### PR DESCRIPTION
…-errors

This is a targeted change to allow us to specify that an extension test should return true even if -pedantic-errors is enabled.

In the longer term we may want to consider changing the behavior of -pedantic-errors to not gate __has_extension checks, and become more in line with `-Wpedantic -Werror`.