### PR TITLE
[OpenCLCpp] Avoid inferred adding address-space to function types

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -5373,6 +5373,12 @@ public:
       return Result;
     }
 
+    ExtProtoInfo withoutAddressSpace() {
+      ExtProtoInfo Result(*this);
+      Result.TypeQuals = TypeQuals.withoutAddressSpace();
+      return Result;
+    }
+
     bool requiresFunctionProtoTypeExtraBitfields() const {
       return ExceptionSpec.Type == EST_Dynamic ||
              requiresFunctionProtoTypeArmAttributes() ||

--- a/clang/include/clang/Sema/SemaOpenCL.h
+++ b/clang/include/clang/Sema/SemaOpenCL.h
@@ -100,6 +100,9 @@ public:
   bool checkBuiltinKernelWorkGroupSize(CallExpr *TheCall);
 
   bool checkBuiltinNDRangeAndBlock(CallExpr *TheCall);
+
+  void removeFriendFunctionAddressSpace(FunctionDecl *FD,
+                                        TypeSourceInfo *TInfo);
 };
 
 } // namespace clang

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -51,6 +51,7 @@
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/SemaObjC.h"
 #include "clang/Sema/SemaOpenACC.h"
+#include "clang/Sema/SemaOpenCL.h"
 #include "clang/Sema/SemaOpenMP.h"
 #include "clang/Sema/SemaPPC.h"
 #include "clang/Sema/SemaRISCV.h"
@@ -10324,6 +10325,11 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
       }
       NewFD->setObjectOfFriendDecl();
       NewFD->setAccess(AS_public);
+      // For OpenCLCPlusPlus dialect remove address space from free friend
+      // function prototype, since it is non-member and none should be present.
+      if (!isa<CXXMethodDecl>(NewFD) && getLangOpts().OpenCLCPlusPlus) {
+        OpenCL().removeFriendFunctionAddressSpace(NewFD, TInfo);
+      }
     }
 
     // If a function is defined as defaulted or deleted, mark it as such now.

--- a/clang/lib/Sema/SemaOpenCL.cpp
+++ b/clang/lib/Sema/SemaOpenCL.cpp
@@ -576,4 +576,16 @@ bool SemaOpenCL::checkBuiltinToAddr(unsigned BuiltinID, CallExpr *Call) {
   return false;
 }
 
+void SemaOpenCL::removeFriendFunctionAddressSpace(FunctionDecl *FD,
+                                                  TypeSourceInfo *TInfo) {
+  assert(!isa<CXXMethodDecl>(FD) && "Only free function should be adjusted");
+
+  // For generic address space remove __generic, otherwise remove __private
+  QualType R = TInfo->getType();
+  const FunctionProtoType *FPT = R->getAs<FunctionProtoType>();
+  FD->setType(SemaRef.Context.getFunctionType(
+      FPT->getReturnType(), FPT->getParamTypes(),
+      FPT->getExtProtoInfo().withoutAddressSpace()));
+}
+
 } // namespace clang

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -29,6 +29,7 @@
 #include "clang/Sema/SemaCUDA.h"
 #include "clang/Sema/SemaHLSL.h"
 #include "clang/Sema/SemaObjC.h"
+#include "clang/Sema/SemaOpenCL.h"
 #include "clang/Sema/SemaOpenMP.h"
 #include "clang/Sema/SemaSwift.h"
 #include "clang/Sema/Template.h"
@@ -2825,6 +2826,11 @@ Decl *TemplateDeclInstantiator::VisitFunctionDecl(
 
   if (isFriend) {
     Function->setObjectOfFriendDecl();
+    // For OpenCLCPlusPlus dialect remove address space (__generic/__private)
+    // of dependend or template free friend function instantiation.
+    if (SemaRef.getLangOpts().OpenCLCPlusPlus) {
+      SemaRef.OpenCL().removeFriendFunctionAddressSpace(Function, TInfo);
+    }
     if (FunctionTemplateDecl *FT = Function->getDescribedFunctionTemplate())
       FT->setObjectOfFriendDecl();
   }

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1794,9 +1794,11 @@ bool Sema::CheckQualifiedFunctionForTypeId(QualType T, SourceLocation Loc) {
 }
 
 // Helper to deduce addr space of a pointee type in OpenCL mode.
-static QualType deduceOpenCLPointeeAddrSpace(Sema &S, QualType PointeeType) {
+static QualType deduceOpenCLPointeeAddrSpace(Sema &S, QualType PointeeType,
+                                             bool IsBlock) {
   if (!PointeeType->isUndeducedAutoType() && !PointeeType->isDependentType() &&
       !PointeeType->isSamplerT() &&
+      (!PointeeType->isFunctionType() || IsBlock) &&
       !PointeeType.hasAddressSpace())
     PointeeType = S.getASTContext().getAddrSpaceQualType(
         PointeeType, S.getASTContext().getDefaultOpenCLPointeeAddrSpace());
@@ -1835,7 +1837,7 @@ QualType Sema::BuildPointerType(QualType T,
     T = inferARCLifetimeForPointee(*this, T, Loc, /*reference*/ false);
 
   if (getLangOpts().OpenCL)
-    T = deduceOpenCLPointeeAddrSpace(*this, T);
+    T = deduceOpenCLPointeeAddrSpace(*this, T, /*IsBlock*/ false);
 
   // In WebAssembly, pointers to reference types and pointers to tables are
   // illegal.
@@ -1912,7 +1914,7 @@ QualType Sema::BuildReferenceType(QualType T, bool SpelledAsLValue,
     T = inferARCLifetimeForPointee(*this, T, Loc, /*reference*/ true);
 
   if (getLangOpts().OpenCL)
-    T = deduceOpenCLPointeeAddrSpace(*this, T);
+    T = deduceOpenCLPointeeAddrSpace(*this, T, /*IsBlock*/ false);
 
   // In WebAssembly, references to reference types and tables are illegal.
   if (getASTContext().getTargetInfo().getTriple().isWasm() &&
@@ -2767,7 +2769,7 @@ QualType Sema::BuildBlockPointerType(QualType T,
     return QualType();
 
   if (getLangOpts().OpenCL)
-    T = deduceOpenCLPointeeAddrSpace(*this, T);
+    T = deduceOpenCLPointeeAddrSpace(*this, T, /*IsBlock*/ true);
 
   return Context.getBlockPointerType(T);
 }

--- a/clang/test/SemaCXX/friend-template-redecl.cpp
+++ b/clang/test/SemaCXX/friend-template-redecl.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c++17 -verify -emit-llvm-only %s
+// RUN: %clang_cc1 -cl-std=clc++2021 -verify -emit-llvm-only %s
 
 template <class T> void bar(const T &t) { foo(t); }
 

--- a/clang/test/SemaCXX/friend.cpp
+++ b/clang/test/SemaCXX/friend.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++14
+// RUN: %clang_cc1 -fsyntax-only -verify %s -cl-std=clc++2021
 
 friend class A; // expected-error {{'friend' used outside of class}}
 void f() { friend class A; } // expected-error {{'friend' used outside of class}}

--- a/clang/test/SemaCXX/friend2.cpp
+++ b/clang/test/SemaCXX/friend2.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s -std=c++11
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,expected-noncl %s -std=c++11
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,expected-cl %s -cl-std=clc++2021
 
 // If a friend function is defined in several non-template classes,
 // it is an error.
@@ -62,16 +63,16 @@ template<typename T> struct C6b {
   friend void func6(int) {}  // expected-error{{redefinition of 'func6'}}
 };
 C6a<long> c6a;
-C6b<int*> c6b;  // expected-note{{in instantiation of template class 'C6b<int *>' requested here}}
-
+C6b<int*> c6b;  // expected-noncl-note{{in instantiation of template class 'C6b<int *>' requested here}}
+                // expected-cl-note@-1{{in instantiation of template class 'C6b<__generic int *>' requested here}}
 void func7(int);
 template<typename T> struct C7 {
   friend void func7(int) {}  // expected-error{{redefinition of 'func7'}}
                              // expected-note@-1{{previous definition is here}}
 };
 C7<long> c7a;
-C7<int*> c7b;  // expected-note{{in instantiation of template class 'C7<int *>' requested here}}
-
+C7<int*> c7b;  // expected-noncl-note{{in instantiation of template class 'C7<int *>' requested here}}
+               // expected-cl-note@-1{{in instantiation of template class 'C7<__generic int *>' requested here}}
 
 // Even if clases are not instantiated and hence friend functions defined in them are not
 // available, their declarations can be checked.

--- a/clang/test/SemaOpenCLCXX/address-space-traits.clcpp
+++ b/clang/test/SemaOpenCLCXX/address-space-traits.clcpp
@@ -1,0 +1,29 @@
+//RUN: %clang_cc1 %s -triple spirv64-unknown-unknown -pedantic -fsyntax-only -verify -cl-ext=+__cl_clang_function_pointers,+__opencl_c_generic_address_space
+
+#pragma OPENCL EXTENSION __cl_clang_function_pointers : enable
+
+template <class T> using remove_pointer_t = __remove_pointer(T);
+static_assert(__is_same(remove_pointer_t<int (*)()>, int()));
+
+static_assert(__is_same(remove_pointer_t<int (*)()>, int()));
+
+static_assert(__is_same(remove_pointer_t<int (&)()>, int (&)()));
+
+template <class T> using remove_reference_t = __remove_reference_t(T);
+
+static_assert(__is_same(remove_reference_t<int (&)()>, int()));
+static_assert(__is_same(remove_reference_t<int (&)()>, void()));
+  // expected-error@-1 {{static assertion failed due to requirement '__is_same(int (), void ())'}}
+
+static_assert(!__is_same(remove_reference_t<__add_lvalue_reference(int (*)())>, int));
+
+struct S {
+  int foo() __local;
+};
+
+// FIXME: this fails since address-space is not preserved on member-function when speciefied (2nd parameter)
+//static_assert(!__is_same(remove_pointer_t<decltype(&S::foo)>, int (S::*)() const __local));
+//static_assert(__is_same(remove_pointer_t<decltype(&S::foo)>, int (S::*)() __local));
+
+//static_assert(!__is_same(remove_reference_t<decltype(&S::foo)>, int (S::*)() const __local));
+//static_assert(__is_same(remove_reference_t<decltype(&S::foo)>, int (S::*)() __local));


### PR DESCRIPTION
The default OpenCL address-space was added for function types, which was
breaking transform type builtins for function types, in particular:

- __remove_reference_t
- __remove_cvref
- __remove_pointer

This change fixes SemaCXX/type-traits.cpp pass for clc++ dialect.
(In feature set of clc++ and extension - ie. no VLA, _Atomic etc...)

There is still unaddressed issue with address space of member-fn-ptr
in __is_same trait builtin as address-space specified by user is
ignored on such types.

This is separate unrelated issue and won't be addressed in this change.

Note for reviewers:

I consider this change non-trivial and might have deeper consequnces in OpenCL  drivers codegen in areas of intriniscs and blocks lowering CG, but it might affect vendor passes.
