### PR TITLE
[flang] Finalize allocatable components in expression results

### DIFF
--- a/flang-rt/lib/runtime/assign.cpp
+++ b/flang-rt/lib/runtime/assign.cpp
@@ -373,7 +373,8 @@ RT_API_ATTRS int AssignTicket::Begin(WorkQueue &workQueue) {
       // is executed, any noncoarray allocated allocatable subobject of the
       // variable is deallocated before the assignment takes place."
       if (int status{
-              workQueue.BeginDestroy(to_, *toDerived_, /*finalize=*/false)};
+              workQueue.BeginDestroy(to_, *toDerived_, /*finalize=*/false,
+                  /*isNestedFinalizationPossible=*/false)};
           status != StatOk && status != StatContinue) {
         return status;
       }
@@ -683,8 +684,9 @@ RT_API_ATTRS int DerivedAssignTicket<IS_COMPONENTWISE>::Continue(
         if (toDesc->IsAllocated()) {
           if (this->phase_ == 0) {
             if (componentDerived && !componentDerived->noDestructionNeeded()) {
-              if (int status{workQueue.BeginDestroy(
-                      *toDesc, *componentDerived, /*finalize=*/false)};
+              if (int status{workQueue.BeginDestroy(*toDesc, *componentDerived,
+                      /*finalize=*/false,
+                      /*isNestedFinalizationPossible=*/false)};
                   status != StatOk) {
                 this->phase_++;
                 return status;

--- a/flang-rt/lib/runtime/derived-api.cpp
+++ b/flang-rt/lib/runtime/derived-api.cpp
@@ -46,7 +46,7 @@ void RTDEF(Destroy)(const Descriptor &descriptor) {
       if (!derived->noDestructionNeeded()) {
         // TODO: Pass source file & line information to the API
         // so that a good Terminator can be passed
-        Destroy(descriptor, true, *derived, nullptr);
+        Destroy(descriptor, /*finalize=*/true, *derived, nullptr);
       }
     }
   }
@@ -144,6 +144,10 @@ bool RTDEF(ExtendsTypeOf)(const Descriptor &a, const Descriptor &mold) {
   }
 }
 
+// The object will be destroyed without finalization at the top level,
+// but allocated allocatable subobjects must be deallocated, and
+// deallocation is a finalization-triggering event, so they will
+// be finalized regardless.
 void RTDEF(DestroyWithoutFinalization)(const Descriptor &descriptor) {
   if (const DescriptorAddendum * addendum{descriptor.Addendum()}) {
     if (const auto *derived{addendum->derivedType()}) {

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -817,20 +817,12 @@ end
   `INDEX` include an optional `BACK=` argument, but it doesn't actually
   work.
 
-* Allocatable components of array and structure constructors are deallocated
-  after use without calling final subroutines.
-  The standard does not specify when and how deallocation of array and structure
-  constructors allocatable components should happen. All compilers free the
-  memory after use, but the behavior when the allocatable component is a derived
-  type with finalization differ, especially when dealing with nested array and
-  structure constructors expressions. Some compilers call final routine for the
-  allocatable components of each constructor sub-expressions, some call it only
-  for the allocatable component of the top level constructor, and some only
-  deallocate the memory. Deallocating only the memory offers the most
-  flexibility when lowering such expressions, and it is not clear finalization
-  is desirable in such context (Fortran interop 1.6.2 in F2018 standards require
-  array and structure constructors not to be finalized, so it also makes sense
-  not to finalize their allocatable components when releasing their storage).
+* Allocatable components nested in expression results are finalized before being
+  deallocated.  F'2023 identifies expression results as "data entities", and
+  the deallocation of non-coarray allocatables as being an event that triggers
+  finalization.  Compilers differ widely in their finalization behavior in
+  expression results, especially with structure constructors, but at least two
+  others match this interpretation and it seems clear enough in the standard.
 
 * F'2023 19.4 paragraph 5: "If integer-type-spec appears in data-implied-do or
   ac-implied-do-control it has the specified type and type parameters; otherwise


### PR DESCRIPTION
    An expression result is a "data entity" (F'2023 3.41), and thus
    can be "finalizable" (3.71); however, they are not finalized
    in general because there is no item in the list of events that trigger
    finalization (7.5.6.3p2) that applies, apart from two relevant
    exceptions.  One of them we handle correctly (allocatable function
    results) we handle correctly, the other we do not.
    
    The second exception is the case of allocated allocatables which
    may appear as subobjects in an expression result.  They are
    automatically deallocated (9.7.3.2p9), and deallocation is on that
    list of finalization-triggering events (7.5.6.3p2).
    So this patch makes sure to finalize any allocatable finalizable
    subobject, unless the destruction is part of the left-hand side of
    an intrinsic assignment -- in which case it will have already been
    finalized (7.5.6.3p1) anyway.
    
    Note: the "stop 171" case in the test
      llvm-test-suite/Fortran/gfortran/regression/finalize_38.f90
    will now fail, and a companion patch will disable that test when
    this patch is merged.
