### PR TITLE
[bazel] More port of #148286: only include spirv dep when enabled

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -8,6 +8,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("//llvm:targets.bzl", "llvm_targets")
 load(
     ":build_defs.bzl",
     "cc_headers_only",
@@ -13839,11 +13840,13 @@ cc_library(
         "//llvm:BitWriter",
         "//llvm:Core",
         "//llvm:Object",
-        "//llvm:SPIRVCodeGen",
         "//llvm:Support",
         "//llvm:Target",
         "//llvm:config",
-    ],
+    ] + ([
+        "//llvm:SPIRVCodeGen",
+        "//llvm:SPIRVUtilsAndDesc",
+    ] if "SPIRV" in llvm_targets else []),
 )
 
 cc_library(


### PR DESCRIPTION
The fix in #153520 works so long as SPIRV is actually an enabled target. Otherwise, the build fails w/ `target 'SPIRVCodeGen' not declared in package ...`