### PR TITLE
[MLIR][GPU][XeVM] Add missing #include for standalone header build

### DIFF
--- a/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
+++ b/mlir/include/mlir/Target/LLVM/XeVM/Utils.h
@@ -14,6 +14,7 @@
 #define MLIR_TARGET_LLVM_XEVM_UTILS_H
 
 #include "mlir/Dialect/GPU/IR/CompilationInterfaces.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/XeVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/Target/LLVM/ModuleToObject.h"


### PR DESCRIPTION
This header uses GPUModuleOp but does not directly include the header: `error: no type named 'GPUModuleOp' in namespace 'mlir::gpu'; did you mean 'ModuleOp'?`

Needed for #148286