### PR TITLE
[compiler-rt] Avoid depending on the libnvmm header for NetBSD

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_netbsd.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_netbsd.cpp
@@ -498,7 +498,6 @@ struct urio_command {
 #include <md5.h>
 #include <rmd160.h>
 #include <soundcard.h>
-#include <term.h>
 #include <termios.h>
 #include <time.h>
 #include <ttyent.h>
@@ -515,7 +514,7 @@ struct urio_command {
 #include <stringlist.h>
 
 #if defined(__x86_64__)
-#include <nvmm.h>
+#include <dev/nvmm/nvmm_ioctl.h>
 #endif
 // clang-format on
 


### PR DESCRIPTION
Use the system headers instead since we don't actually need anything from libnvmm; we only care about ioctls and related structures.

This makes it possible to cross-compile TSan for NetBSD with `zig cc` which does not provide libnvmm when cross-compiling.

I also removed a `term.h` include (ncurses) which appeared to be unnecessary and likewise prevented cross-compilation with `zig cc` from working.