### PR TITLE
[RISCV] Add a release note about tail folding being enabled. NFC

### DIFF
--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -109,6 +109,9 @@ Changes to the PowerPC Backend
 Changes to the RISC-V Backend
 -----------------------------
 
+* The loop vectorizer now performs tail folding by default on RISC-V, which
+  removes the need for a scalar epilogue loop. To restore the previous behaviour
+  use `-mllvm -prefer-predicate-over-epilogue=scalar-epilogue`.
 * `llvm-objdump` now has basic support for switching between disassembling code
   and data using mapping symbols such as `$x` and `$d`. Switching architectures
   using `$x` with an architecture string suffix is not yet supported.

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -111,7 +111,7 @@ Changes to the RISC-V Backend
 
 * The loop vectorizer now performs tail folding by default on RISC-V, which
   removes the need for a scalar epilogue loop. To restore the previous behaviour
-  use `-mllvm -prefer-predicate-over-epilogue=scalar-epilogue`.
+  use `-prefer-predicate-over-epilogue=scalar-epilogue`.
 * `llvm-objdump` now has basic support for switching between disassembling code
   and data using mapping symbols such as `$x` and `$d`. Switching architectures
   using `$x` with an architecture string suffix is not yet supported.


### PR DESCRIPTION
It's probably useful for users to know how to get the old scalar epilogue back if they need it.
