### PR TITLE
[vscode-lldb] Support lldb-dap environment in debug configuration

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -370,6 +370,15 @@
                 },
                 "markdownDescription": "The list of additional arguments used to launch the debug adapter executable. Overrides any user or workspace settings."
               },
+              "debugAdapterEnv": {
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `{ \"FOO\": \"1\" }`"
+              },
               "program": {
                 "type": "string",
                 "description": "Path to the program to debug."

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -371,13 +371,27 @@
                 "markdownDescription": "The list of additional arguments used to launch the debug adapter executable. Overrides any user or workspace settings."
               },
               "debugAdapterEnv": {
-                "type": "object",
-                "patternProperties": {
-                  ".*": {
-                    "type": "string"
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `{ \"FOO\": \"1\" }`",
+                    "patternProperties": {
+                      ".*": {
+                        "type": "string"
+                      }
+                    },
+                    "default": {}
+                  },
+                  {
+                    "type": "array",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `[\"FOO=1\", \"BAR\"]`",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^((\\w+=.*)|^\\w+)$"
+                    },
+                    "default": []
                   }
-                },
-                "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `{ \"FOO\": \"1\" }`"
+                ]
               },
               "program": {
                 "type": "string",

--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -76,12 +76,10 @@ async function findDAPExecutable(): Promise<string | undefined> {
  * @returns Whether or not the DAP environment is valid
  */
 function validateDAPEnv(debugConfigEnv: any): boolean {
-  // If the env is an object, it should have string keys and values.
+  // If the env is an object, it should have string values.
+  // The keys are guaranteed to be strings.
   if (
     typeof debugConfigEnv === "object" &&
-    Object.keys(debugConfigEnv).findIndex(
-      (entry) => typeof entry !== "string",
-    ) !== -1 &&
     Object.values(debugConfigEnv).findIndex(
       (entry) => typeof entry !== "string",
     ) !== -1

--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -89,7 +89,7 @@ export class LLDBDapServer implements vscode.Disposable {
     args: string[],
     env: NodeJS.ProcessEnv | { [key: string]: string } | undefined,
   ): Promise<boolean> {
-    if (!this.serverProcess || !this.serverInfo) {
+    if (!this.serverProcess || !this.serverInfo || !this.serverSpawnInfo) {
       return true;
     }
 

--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -11,6 +11,7 @@ import * as vscode from "vscode";
 export class LLDBDapServer implements vscode.Disposable {
   private serverProcess?: child_process.ChildProcessWithoutNullStreams;
   private serverInfo?: Promise<{ host: string; port: number }>;
+  private serverSpawnInfo?: string[];
 
   constructor() {
     vscode.commands.registerCommand(
@@ -34,7 +35,7 @@ export class LLDBDapServer implements vscode.Disposable {
     options?: child_process.SpawnOptionsWithoutStdio,
   ): Promise<{ host: string; port: number } | undefined> {
     const dapArgs = [...args, "--connection", "listen://localhost:0"];
-    if (!(await this.shouldContinueStartup(dapPath, dapArgs))) {
+    if (!(await this.shouldContinueStartup(dapPath, dapArgs, options?.env))) {
       return undefined;
     }
 
@@ -70,6 +71,7 @@ export class LLDBDapServer implements vscode.Disposable {
         }
       });
       this.serverProcess = process;
+      this.serverSpawnInfo = this.getSpawnInfo(dapPath, dapArgs, options?.env);
     });
     return this.serverInfo;
   }
@@ -85,12 +87,14 @@ export class LLDBDapServer implements vscode.Disposable {
   private async shouldContinueStartup(
     dapPath: string,
     args: string[],
+    env: NodeJS.ProcessEnv | { [key: string]: string } | undefined,
   ): Promise<boolean> {
     if (!this.serverProcess || !this.serverInfo) {
       return true;
     }
 
-    if (isDeepStrictEqual(this.serverProcess.spawnargs, [dapPath, ...args])) {
+    const newSpawnInfo = this.getSpawnInfo(dapPath, args, env);
+    if (isDeepStrictEqual(this.serverSpawnInfo, newSpawnInfo)) {
       return true;
     }
 
@@ -102,11 +106,11 @@ export class LLDBDapServer implements vscode.Disposable {
 
 The previous lldb-dap server was started with:
 
-${this.serverProcess.spawnargs.join(" ")}
+${this.serverSpawnInfo.join(" ")}
 
 The new lldb-dap server will be started with:
 
-${dapPath} ${args.join(" ")}
+${newSpawnInfo.join(" ")}
 
 Restarting the server will interrupt any existing debug sessions and start a new server.`,
       },
@@ -142,5 +146,19 @@ Restarting the server will interrupt any existing debug sessions and start a new
       this.serverProcess = undefined;
       this.serverInfo = undefined;
     }
+  }
+
+  getSpawnInfo(
+    path: string,
+    args: string[],
+    env: NodeJS.ProcessEnv | { [key: string]: string } | undefined,
+  ): string[] {
+    return [
+      path,
+      ...args,
+      ...Object.entries(env ?? {}).map(
+        (entry) => String(entry[0]) + "=" + String(entry[1]),
+      ),
+    ];
   }
 }


### PR DESCRIPTION
# Changes
1. Add a new debug configuration field called `debugAdapterEnv`. It accepts a string-valued dictionary or array.
    1. This input format is consistent with the (program's) `env` debug configuration.
2. In the adapter descriptor factory, honor the said field before looking at the VS Code settings `Lldb-dap: Environment `.
    1. This order is consistent with how things are done for other debug configuration fields, e.g. lldb-dap path and args.
3. In the lldb-dap server, note down the environment entries as a part of the adapter spawn info (now it becomes "path + args + env"), and prompt the user to restart server if such info has changed.

# Motivation
1. Adapter environment can be set in `launch.json`.
3. Other debugger extensions can invoke the lldb-dap extension with adapter environment (via debug configuration).

# Tests
Manually verified the following.
- [ v ] Test 1: Environment entries in settings are effective (no regress).
- [ v ] Test 2: Ill-formatted environment entries in launch.json are rejected.
- [ v ] Test 3: Environment entries in launch.json are effective.
- [ v ] Test 4: When debug configuration has environment entries (from launch.json), the ones in the settings are ignored.
- [ v ] Test 5: In server mode, changing environment entries will prompt the user to restart server.
- [ v ] Test 6: If the user choose to keep the existing server, environment entries shouldn't change.
- [ v ] Test 7: If the user choose to restart server, environment entries should reflect new value.

I have test videos as proof, but not sure if it's needed or where to upload.