### PR TITLE
[lld][WebAssembly] Allow linker-synthetic symbols to be undefine when building shared libraries

### DIFF
--- a/lld/test/wasm/shared-synthetic-symbols.s
+++ b/lld/test/wasm/shared-synthetic-symbols.s
@@ -1,0 +1,75 @@
+## Check that synthetic data-layout symbols such as __heap_base and __heap_end
+## can be referenced from shared libraries and pie executables without
+## generating undefined symbols.
+
+# RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.o %s
+# RUN: wasm-ld --experimental-pic -pie --import-memory -o %t.wasm %t.o
+# RUN: obj2yaml %t.wasm | FileCheck %s
+# RUN: wasm-ld --experimental-pic -shared -o %t.so %t.o
+# RUN: obj2yaml %t.so | FileCheck %s
+
+.globl _start
+
+_start:
+  .functype _start () -> ()
+  i32.const __heap_base@GOT
+  drop
+  i32.const __heap_end@GOT
+  drop
+  i32.const __stack_low@GOT
+  drop
+  i32.const __stack_high@GOT
+  drop
+  i32.const __global_base@GOT
+  drop
+  i32.const __data_end@GOT
+  drop
+  end_function
+
+# CHECK:        - Type:            IMPORT
+# CHECK-NEXT:     Imports:
+# CHECK-NEXT:       - Module:          env
+# CHECK-NEXT:         Field:           memory
+# CHECK-NEXT:         Kind:            MEMORY
+# CHECK-NEXT:         Memory:
+# CHECK-NEXT:           Minimum:         0x0
+# CHECK-NEXT:       - Module:          env
+# CHECK-NEXT:         Field:           __memory_base
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   false
+# CHECK-NEXT:       - Module:          env
+# CHECK-NEXT:         Field:           __table_base
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   false
+# CHECK-NEXT:       - Module:          GOT.mem
+# CHECK-NEXT:         Field:           __heap_base
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   true
+# CHECK-NEXT:       - Module:          GOT.mem
+# CHECK-NEXT:         Field:           __heap_end
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   true
+# CHECK-NEXT:       - Module:          GOT.mem
+# CHECK-NEXT:         Field:           __stack_low
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   true
+# CHECK-NEXT:       - Module:          GOT.mem
+# CHECK-NEXT:         Field:           __stack_high
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   true
+# CHECK-NEXT:       - Module:          GOT.mem
+# CHECK-NEXT:         Field:           __global_base
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   true
+# CHECK-NEXT:       - Module:          GOT.mem
+# CHECK-NEXT:         Field:           __data_end
+# CHECK-NEXT:         Kind:            GLOBAL
+# CHECK-NEXT:         GlobalType:      I32
+# CHECK-NEXT:         GlobalMutable:   true

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -988,18 +988,29 @@ static void createOptionalSymbols() {
 
   ctx.sym.dsoHandle = symtab->addOptionalDataSymbol("__dso_handle");
 
-  if (!ctx.arg.shared) {
-    ctx.sym.dataEnd = symtab->addOptionalDataSymbol("__data_end");
-    ctx.sym.rodataStart = symtab->addOptionalDataSymbol("__rodata_start");
-    ctx.sym.rodataEnd = symtab->addOptionalDataSymbol("__rodata_end");
-  }
+  auto addDataLayoutSymbol = [&](StringRef s) -> DefinedData * {
+    // Data layout symbols are either defined by lld, or (in the case
+    // of PIC code) defined by the dynamic linker / embedder.
+    if (ctx.isPic) {
+      ctx.arg.allowUndefinedSymbols.insert(s);
+      return nullptr;
+    } else {
+      return symtab->addOptionalDataSymbol(s);
+    }
+  };
 
+  ctx.sym.dataEnd = addDataLayoutSymbol("__data_end");
+  ctx.sym.rodataStart = addDataLayoutSymbol("__rodata_start");
+  ctx.sym.rodataEnd = addDataLayoutSymbol("__rodata_end");
+  ctx.sym.stackLow = addDataLayoutSymbol("__stack_low");
+  ctx.sym.stackHigh = addDataLayoutSymbol("__stack_high");
+  ctx.sym.globalBase = addDataLayoutSymbol("__global_base");
+  ctx.sym.heapBase = addDataLayoutSymbol("__heap_base");
+  ctx.sym.heapEnd = addDataLayoutSymbol("__heap_end");
+
+  // for pic, __memory_base and __table_base are handled in
+  // createSyntheticSymbols.
   if (!ctx.isPic) {
-    ctx.sym.stackLow = symtab->addOptionalDataSymbol("__stack_low");
-    ctx.sym.stackHigh = symtab->addOptionalDataSymbol("__stack_high");
-    ctx.sym.globalBase = symtab->addOptionalDataSymbol("__global_base");
-    ctx.sym.heapBase = symtab->addOptionalDataSymbol("__heap_base");
-    ctx.sym.heapEnd = symtab->addOptionalDataSymbol("__heap_end");
     ctx.sym.memoryBase = createOptionalGlobal("__memory_base", false);
     ctx.sym.tableBase = createOptionalGlobal("__table_base", false);
   }


### PR DESCRIPTION
Fixes: #103592