### PR TITLE
[clang][LoongArch] Ensure `target("lasx")` implies LSX support

### DIFF
--- a/clang/lib/Basic/Targets/LoongArch.cpp
+++ b/clang/lib/Basic/Targets/LoongArch.cpp
@@ -461,6 +461,8 @@ LoongArchTargetInfo::parseTargetAttr(StringRef Features) const {
 
     case AttrFeatureKind::Feature:
       Ret.Features.push_back("+" + Value.str());
+      if (Value == "lasx")
+        Ret.Features.push_back("+lsx");
       break;
     }
   }

--- a/clang/test/CodeGen/LoongArch/targetattr-lasx.c
+++ b/clang/test/CodeGen/LoongArch/targetattr-lasx.c
@@ -4,4 +4,4 @@ __attribute__((target("lasx")))
 // CHECK: #[[ATTR0:[0-9]+]] {
 void testlasx() {}
 
-// CHECK: attributes #[[ATTR0]] = { {{.*}}"target-features"="+64bit,+lasx,-lsx"{{.*}} }
+// CHECK: attributes #[[ATTR0]] = { {{.*}}"target-features"="+64bit,+lasx,+lsx"{{.*}} }


### PR DESCRIPTION
Currently, `__attribute__((target("lasx")))` does not automatically
enable LSX support, causing Clang to fail with `-mno-lsx`. Since
LASX depends on LSX, enabling LASX should implicitly enable LSX to
avoid clang error.
    
Fixes #149512.

Depends on #153541