### PR TITLE
[DebugInfo] Emit skeleton to avoid mismatching inlining flags

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -558,18 +558,14 @@ void DwarfDebug::constructAbstractSubprogramScopeDIE(DwarfCompileUnit &SrcCU,
 
   // Find the subprogram's DwarfCompileUnit in the SPMap in case the subprogram
   // was inlined from another compile unit.
-  if (useSplitDwarf() && !shareAcrossDWOCUs() && !SP->getUnit()->getSplitDebugInlining())
-    // Avoid building the original CU if it won't be used
-    SrcCU.constructAbstractSubprogramScopeDIE(Scope);
-  else {
-    auto &CU = getOrCreateDwarfCompileUnit(SP->getUnit());
-    if (auto *SkelCU = CU.getSkeleton()) {
-      (shareAcrossDWOCUs() ? CU : SrcCU)
-          .constructAbstractSubprogramScopeDIE(Scope);
-      if (CU.getCUNode()->getSplitDebugInlining())
-        SkelCU->constructAbstractSubprogramScopeDIE(Scope);
-    } else
-      CU.constructAbstractSubprogramScopeDIE(Scope);
+  auto &CU = getOrCreateDwarfCompileUnit(SP->getUnit());
+  if (auto *SkelCU = CU.getSkeleton()) {
+    (shareAcrossDWOCUs() ? CU : SrcCU)
+        .constructAbstractSubprogramScopeDIE(Scope);
+    if (CU.getCUNode()->getSplitDebugInlining())
+      SkelCU->constructAbstractSubprogramScopeDIE(Scope);
+  } else {
+    CU.constructAbstractSubprogramScopeDIE(Scope);
   }
 }
 

--- a/llvm/test/DebugInfo/X86/split-dwarf-inline.ll
+++ b/llvm/test/DebugInfo/X86/split-dwarf-inline.ll
@@ -1,0 +1,36 @@
+; RUN: llc -split-dwarf-file=foo.dwo %s -filetype=obj -o - | llvm-dwarfdump -debug-info - | FileCheck %s
+
+; CHECK: .debug_info contents:
+; CHECK: DW_TAG_subprogram
+; CHECK: caller_func
+; CHECK: DW_TAG_inlined_subroutine
+; CHECK: inlined_func
+
+; CHECK: .debug_info.dwo contents
+; CHECK: DW_TAG_subprogram
+; CHECK: caller_func
+; CHECK: DW_TAG_inlined_subroutine
+; CHECK: inlined_func
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define void @caller_func() !dbg !9 {
+entry:
+  ret void, !dbg !13
+}
+
+!llvm.dbg.cu = !{!0, !3}
+!llvm.module.flags = !{!5, !6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang trunk", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false)
+!1 = !DIFile(filename: "a.cpp", directory: "/tmp")
+!3 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !4, producer: "clang trunk", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: true)
+!4 = !DIFile(filename: "b.cpp", directory: "/tmp")
+!5 = !{i32 2, !"Dwarf Version", i32 4}
+!6 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = distinct !DISubprogram(name: "caller_func", scope: !4, file: !4, line: 2, type: !10, isLocal: false, isDefinition: true, scopeLine: 2, unit: !3)
+!10 = !DISubroutineType(types: !11)
+!11 = !{null}
+!12 = distinct !DISubprogram(name: "inlined_func", scope: !1, file: !1, line: 1, type: !10, isLocal: false, isDefinition: true, scopeLine: 1, unit: !0)
+!13 = !DILocation(line: 1, column: 5, scope: !12, inlinedAt: !14)
+!14 = distinct !DILocation(line: 3, column: 3, scope: !9)


### PR DESCRIPTION
This actually reverts 418120556398c01550d42500d56e6d328290185b.

The original commit omits unit with all symbols inlined into current one, which leads to crash when a module using split-dwarf inlined a function from another module with mismatched split-dwarf-inlining option. This revert guarantees that DIEs are created in both DWO and the skeleton sections whenever split-dwarf is active.