### PR TITLE
[MLIR][Build] Adding find_package for pybind

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -661,6 +661,7 @@ function(add_mlir_python_extension libname extname)
   # sources that must be compiled in accordance with pybind11 needs (RTTI and
   # exceptions).
   if(NOT DEFINED ARG_PYTHON_BINDINGS_LIBRARY OR ARG_PYTHON_BINDINGS_LIBRARY STREQUAL "pybind11")
+    find_package(pybind11 REQUIRED)
     pybind11_add_module(${libname}
       ${ARG_SOURCES}
     )


### PR DESCRIPTION
In different build environments when building with python bindings, LLVM build occasionally fail on not being able to find the pybind package. Adding this help LLVM find it and fix the build failure for me.