### PR TITLE
[lldb] Call FixUpPointer in WritePointerToMemory (try 2)

### DIFF
--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -641,7 +641,8 @@ void IRMemoryMap::WritePointerToMemory(lldb::addr_t process_address,
   error.Clear();
 
   /// Only ask the Process to fix the address if this address belongs to the
-  /// process (host allocations are stored in m_data).
+  /// process. An address belongs to the process if the Allocation contains a
+  /// non-empty m_data member.
   if (auto it = FindAllocation(process_address, 1);
       it != m_allocations.end() && it->second.m_data.GetByteSize() == 0)
     if (auto process_sp = GetProcessWP().lock())

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -644,9 +644,10 @@ void IRMemoryMap::WritePointerToMemory(lldb::addr_t process_address,
   /// process. An address belongs to the process if the Allocation contains a
   /// non-empty m_data member.
   if (auto it = FindAllocation(process_address, 1);
-      it != m_allocations.end() && it->second.m_data.GetByteSize() == 0)
+      it != m_allocations.end() && it->second.m_data.GetByteSize() == 0) {
     if (auto process_sp = GetProcessWP().lock())
       address = process_sp->FixAnyAddress(address);
+  }
 
   Scalar scalar(address);
 

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -640,6 +640,13 @@ void IRMemoryMap::WritePointerToMemory(lldb::addr_t process_address,
                                        lldb::addr_t address, Status &error) {
   error.Clear();
 
+  /// Only ask the Process to fix the address if this address belongs to the
+  /// process (host allocations are stored in m_data).
+  if (auto it = FindAllocation(process_address, 1);
+      it != m_allocations.end() && it->second.m_data.GetByteSize() == 0)
+    if (auto process_sp = GetProcessWP().lock())
+      address = process_sp->FixAnyAddress(address);
+
   Scalar scalar(address);
 
   WriteScalarToMemory(process_address, scalar, GetAddressByteSize(), error);

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -641,13 +641,13 @@ void IRMemoryMap::WritePointerToMemory(lldb::addr_t process_address,
   error.Clear();
 
   /// Only ask the Process to fix the address if this address belongs to the
-  /// process. An address belongs to the process if the Allocation contains a
-  /// non-empty m_data member.
-  if (auto it = FindAllocation(process_address, 1);
-      it != m_allocations.end() && it->second.m_data.GetByteSize() == 0) {
+  /// process. An address belongs to the process if the Allocation policy is not
+  /// eAllocationPolicyHostOnly.
+  auto it = FindAllocation(address, 1);
+  if (it == m_allocations.end() ||
+      it->second.m_policy != AllocationPolicy::eAllocationPolicyHostOnly)
     if (auto process_sp = GetProcessWP().lock())
       address = process_sp->FixAnyAddress(address);
-  }
 
   Scalar scalar(address);
 

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/Makefile
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/Makefile
@@ -1,0 +1,2 @@
+C_SOURCES := main.c
+include Makefile.rules

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/TestArmPointerMetadataStripping.py
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/TestArmPointerMetadataStripping.py
@@ -1,0 +1,50 @@
+import lldb
+import json
+import os
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+@skipIf(archs=no_match(["arm64", "arm64e"]))
+class TestArmPointerMetadataStripping(TestBase):
+    # Use extra_symbols.json as a template to add a new symbol whose address
+    # contains non-zero high order bits set.
+    def create_symbols_file(self):
+        template_path = os.path.join(self.getSourceDir(), "extra_symbols.json")
+        with open(template_path, "r") as f:
+            symbols_data = json.load(f)
+
+        target = self.dbg.GetSelectedTarget()
+        symbols_data["triple"] = target.GetTriple()
+
+        module = target.GetModuleAtIndex(0)
+        symbols_data["uuid"] = module.GetUUIDString()
+
+        json_filename = self.getBuildArtifact("extra_symbols.json")
+        with open(json_filename, "w") as file:
+            json.dump(symbols_data, file, indent=4)
+
+        return json_filename
+
+    def test(self):
+        self.build()
+        src = lldb.SBFileSpec("main.c")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", src
+        )
+
+        self.expect_expr("get_high_bits(&x)", result_value="0")
+        self.expect_expr("get_high_bits(&myglobal)", result_value="0")
+
+        symbols_file = self.create_symbols_file()
+
+        # The high order bits should be stripped.
+        self.runCmd(f"target module add {symbols_file}")
+        self.expect_expr("get_high_bits(&myglobal_json)", result_value="0")
+
+        # Mark all bits as used for addresses and ensure bits are no longer stripped.
+        self.runCmd("settings set target.process.virtual-addressable-bits 64")
+        self.expect_expr(
+            "get_high_bits(&myglobal_json)", result_value=str(0x1200000000000000)
+        )

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/TestArmPointerMetadataStripping.py
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/TestArmPointerMetadataStripping.py
@@ -5,7 +5,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-
+@skipUnlessDarwin
 @skipIf(archs=no_match(["arm64", "arm64e"]))
 class TestArmPointerMetadataStripping(TestBase):
     # Use extra_symbols.json as a template to add a new symbol whose address
@@ -34,13 +34,10 @@ class TestArmPointerMetadataStripping(TestBase):
             self, "break here", src
         )
 
-        self.expect_expr("get_high_bits(&x)", result_value="0")
-        self.expect_expr("get_high_bits(&myglobal)", result_value="0")
-
         symbols_file = self.create_symbols_file()
+        self.runCmd(f"target module add {symbols_file}")
 
         # The high order bits should be stripped.
-        self.runCmd(f"target module add {symbols_file}")
         self.expect_expr("get_high_bits(&myglobal_json)", result_value="0")
 
         # Mark all bits as used for addresses and ensure bits are no longer stripped.

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/TestArmPointerMetadataStripping.py
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/TestArmPointerMetadataStripping.py
@@ -5,6 +5,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
+
 @skipUnlessDarwin
 @skipIf(archs=no_match(["arm64", "arm64e"]))
 class TestArmPointerMetadataStripping(TestBase):

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/extra_symbols.json
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/extra_symbols.json
@@ -1,0 +1,21 @@
+{
+    "triple": "replace me",
+    "uuid": "replace me",
+    "type": "executable",
+    "sections": [
+        {   
+            "name": "__DATA",
+            "type": "data",
+            "address": 1297224342667202580,
+            "size": 16
+        }   
+    ],  
+    "symbols": [
+        {
+            "name": "myglobal_json",
+            "size": 8,
+            "type": "data",
+            "address": 1297224342667202580
+        }   
+    ]   
+}

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/extra_symbols.json
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/extra_symbols.json
@@ -3,19 +3,19 @@
     "uuid": "replace me",
     "type": "executable",
     "sections": [
-        {   
+        {
             "name": "__DATA",
             "type": "data",
             "address": 1297224342667202580,
             "size": 16
-        }   
-    ],  
+        }
+    ],
     "symbols": [
         {
             "name": "myglobal_json",
             "size": 8,
             "type": "data",
             "address": 1297224342667202580
-        }   
-    ]   
+        }
+    ]
 }

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/main.c
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/main.c
@@ -2,7 +2,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-
 int myglobal = 41;
 
 uint64_t get_high_bits(void *ptr) {
@@ -13,8 +12,8 @@ uint64_t get_high_bits(void *ptr) {
   return high_bits;
 }
 
-int main (){
+int main() {
   int x = 42;
   assert(0 == get_high_bits(&x));
-  return 0; //break here
+  return 0; // break here
 }

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/main.c
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/main.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+
+int myglobal = 41;
+
+uint64_t get_high_bits(void *ptr) {
+  uint64_t mask = ~((1ULL << 48) - 1);
+  uint64_t ptrtoint = (uint64_t)ptr;
+  uint64_t high_bits = ptrtoint & mask;
+  printf("Higher bits are = %llx\n", high_bits);
+  return high_bits;
+}
+
+int main (){
+  int x = 42;
+  assert(0 == get_high_bits(&x));
+  return 0; //break here
+}

--- a/lldb/test/API/macosx/arm-pointer-metadata-stripping/main.c
+++ b/lldb/test/API/macosx/arm-pointer-metadata-stripping/main.c
@@ -1,19 +1,13 @@
-#include <assert.h>
 #include <stdint.h>
-#include <stdio.h>
 
-int myglobal = 41;
-
-uint64_t get_high_bits(void *ptr) {
-  uint64_t mask = ~((1ULL << 48) - 1);
-  uint64_t ptrtoint = (uint64_t)ptr;
-  uint64_t high_bits = ptrtoint & mask;
-  printf("Higher bits are = %llx\n", high_bits);
+uintptr_t get_high_bits(void *ptr) {
+  uintptr_t address_bits = 56;
+  uintptr_t mask = ~((1ULL << address_bits) - 1);
+  uintptr_t ptrtoint = (uintptr_t)ptr;
+  uintptr_t high_bits = ptrtoint & mask;
   return high_bits;
 }
 
 int main() {
-  int x = 42;
-  assert(0 == get_high_bits(&x));
   return 0; // break here
 }


### PR DESCRIPTION
In architectures where pointers may contain metadata, such as arm64e, the metadata may need to be cleaned prior to sending this pointer to be used in expression evaluation generated code.

This patch is a step towards allowing consumers of pointers to decide whether they want to keep or remove metadata, as opposed to discarding metadata at the moment pointers are created. See #150537.

This was tested running the LLDB test suite on arm64e.

(The first attempt at this patch caused a failure in TestScriptedProcessEmptyMemoryRegion.py. This test exercises a case where IRMemoryMap uses host memory in its allocations; pointers to such allocations should not be fixed, which is what the original patch failed to account for).