### PR TITLE
[libc] Add _Returns_twice to C++ code

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -47,6 +47,9 @@
 #define __NOEXCEPT throw()
 #endif
 
+#undef _Returns_twice
+#define _Returns_twice [[gnu::returns_twice]]
+
 // This macro serves as a generic cast implementation for use in both C and C++,
 // similar to `__BIONIC_CAST` in Android.
 #undef __LLVM_LIBC_CAST

--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -48,7 +48,11 @@
 #endif
 
 #undef _Returns_twice
+#if __cplusplus >= 201103L
 #define _Returns_twice [[gnu::returns_twice]]
+#else
+#define _Returns_twice __attribute__((returns_twice))
+#endif
 
 // This macro serves as a generic cast implementation for use in both C and C++,
 // similar to `__BIONIC_CAST` in Android.


### PR DESCRIPTION
Fixes issue with `<csetjmp>` which requires `_Returns_twice` but in C++ mode