### PR TITLE
[MLIR][Linalg] Add `maximumf` as an binary `linalg.elementwise` fn

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/IR/LinalgEnums.td
+++ b/mlir/include/mlir/Dialect/Linalg/IR/LinalgEnums.td
@@ -44,7 +44,8 @@ def BinaryFn : I32EnumAttr<"BinaryFn", "", [
   I32EnumAttrCase<"min_signed", 6>,
   I32EnumAttrCase<"max_unsigned", 7>,
   I32EnumAttrCase<"min_unsigned", 8>,
-  I32EnumAttrCase<"powf", 9>
+  I32EnumAttrCase<"powf", 9>,
+  I32EnumAttrCase<"maximumf", 10>
 ]> {
   let genSpecializedAttr = 0;
   let cppNamespace = "::mlir::linalg";

--- a/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
+++ b/mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp
@@ -590,6 +590,9 @@ public:
     case BinaryFn::powf:
       assert(allFloatingPoint);
       return math::PowFOp::create(builder, arg0.getLoc(), arg0, arg1);
+    case BinaryFn::maximumf:
+      assert(allFloatingPoint);
+      return arith::MaximumFOp::create(builder, arg0.getLoc(), arg0, arg1);
     }
     if (emitError) {
       emitError() << "unsupported binary function";

--- a/mlir/test/python/dialects/linalg/ops.py
+++ b/mlir/test/python/dialects/linalg/ops.py
@@ -831,6 +831,22 @@ def testElementwiseOp():
                         ],
                     )
 
+                    # CHECK: linalg.elementwise kind=#linalg.elementwise_kind<maximumf>
+                    # CHECK-SAME: indexing_maps = [#[[$VertLineBCastMap]], #[[$HorLineBCastMap]], #[[$IdentMap2D]]]
+                    # CHECK-SAME: ins(%[[VertLine]], %[[HorLine]] : tensor<8xf32>, tensor<16xf32>)
+                    # CHECK-SAME: outs(%[[OutRect]] : tensor<8x16xf32>) -> tensor<8x16xf32>
+                    linalg.elementwise(
+                        vert_line,
+                        hor_line,
+                        outs=(out_rect,),
+                        kind=linalg.ElementwiseKind.maximumf,
+                        indexing_maps=[
+                            vert_line_bcast_map,
+                            hor_line_bcast_map,
+                            ident_map_2d,
+                        ],
+                    )
+
                 if _ops_with_non_ident_and_transposed_input_maps := True:
                     # CHECK: %[[VertLineBoolsMem:.*]] = memref.alloca() : memref<8xi1>
                     vert_line_bools_mem = memref.alloca(


### PR DESCRIPTION
Is a proper generalisation of `linalg.max` as `linalg.elementwise` allows for folding broadcasts and transposes into the op.