### PR TITLE
[asan] Fix-forward undefined type in test from #153142

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/fakestack_alignment.cpp
@@ -21,8 +21,8 @@
 
 #include <assert.h>
 #include <pthread.h>
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -37,7 +37,7 @@ bool misaligned = false;
 void *Thread(void *unused) {
   big_object x;
   uintptr_t alignment = (uintptr_t)&x % alignof(big_object);
-
+a
   if (alignment != 0)
     misaligned = true;
 

--- a/compiler-rt/test/asan/TestCases/Posix/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/fakestack_alignment.cpp
@@ -37,7 +37,7 @@ bool misaligned = false;
 void *Thread(void *unused) {
   big_object x;
   uintptr_t alignment = (uintptr_t)&x % alignof(big_object);
-a
+
   if (alignment != 0)
     misaligned = true;
 

--- a/compiler-rt/test/asan/TestCases/Posix/fakestack_alignment.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/fakestack_alignment.cpp
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -35,7 +36,7 @@ bool misaligned = false;
 // happen by chance, so try this on many threads.
 void *Thread(void *unused) {
   big_object x;
-  uint alignment = (unsigned long)&x % alignof(big_object);
+  uintptr_t alignment = (uintptr_t)&x % alignof(big_object);
 
   if (alignment != 0)
     misaligned = true;


### PR DESCRIPTION
Fix Mac build breakage (reported by aeubanks in https://github.com/llvm/llvm-project/pull/153142#issuecomment-3189202274) by including stdint.h and using uintptr_t