### PR TITLE
[clang][SPIRV] Default AS generic for Intel-flavored SPIR-V

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -219,8 +219,11 @@ public:
     setAddressSpaceMap(
         /*DefaultIsGeneric=*/Opts.SYCLIsDevice ||
         // The address mapping from HIP/CUDA language for device code is only
-        // defined for SPIR-V.
-        (getTriple().isSPIRV() && Opts.CUDAIsDevice));
+        // defined for SPIR-V, and all Intel SPIR-V code should have the default
+        // AS as generic.
+        (getTriple().isSPIRV() &&
+         (Opts.CUDAIsDevice ||
+          getTriple().getVendor() == llvm::Triple::Intel)));
   }
 
   void setSupportedOpenCLOpts() override {

--- a/clang/test/CodeGenSPIRV/spirv-intel.c
+++ b/clang/test/CodeGenSPIRV/spirv-intel.c
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple spirv64-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITH %s
+// RUN: %clang_cc1 -triple spirv32-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITH %s
+// RUN: %clang_cc1 -triple spir-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITHOUT %s
+// RUN: %clang_cc1 -triple spir64-intel %s -emit-llvm -o - | FileCheck -check-prefix=CHECK-WITHOUT %s
+
+// CHECK-WITH: spir_func void @foo(ptr addrspace(4) noundef %param) #0 {
+// CHECK-WITHOUT: spir_func void @foo(ptr noundef %param) #0 {
+void foo(int *param) {
+}


### PR DESCRIPTION
Use the generic AS as the default AS for Intel-flavored SPIR-V.

Nobody is using the `spirv64-intel` triple right now as far as I know, I'm planning to use it for OpenMP offload and we will definitely need generic AS as default there.