### PR TITLE
Add dependency on `ProfileData` from ScalarOpts

### DIFF
--- a/llvm/lib/Transforms/Scalar/CMakeLists.txt
+++ b/llvm/lib/Transforms/Scalar/CMakeLists.txt
@@ -95,6 +95,7 @@ add_llvm_component_library(LLVMScalarOpts
   Analysis
   Core
   InstCombine
+  ProfileData
   Support
   TransformUtils
   )

--- a/llvm/lib/Transforms/Scalar/JumpTableToSwitch.cpp
+++ b/llvm/lib/Transforms/Scalar/JumpTableToSwitch.cpp
@@ -22,7 +22,6 @@
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Transforms/Instrumentation/PGOInstrumentation.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include <limits>
 
@@ -182,8 +181,14 @@ expandToSwitch(CallBase *CB, const JumpTableTy &JT, DomTreeUpdater &DTU,
   if (HadProfile && !ProfcheckDisableMetadataFixes) {
     // At least one of the targets must've been taken.
     assert(llvm::any_of(BranchWeights, [](uint64_t V) { return V != 0; }));
-    setProfMetadata(F.getParent(), Switch, BranchWeights,
-                    *llvm::max_element(BranchWeights));
+    // FIXME: this duplicates logic in instrumentation. Note: since there's at
+    // least a nonzero and these are unsigned values, it follows MaxBW != 0.
+    uint64_t MaxBW = *llvm::max_element(BranchWeights);
+    SmallVector<uint32_t> ScaledBranchWeights(
+        llvm::map_range(BranchWeights, [MaxBW](uint64_t V) {
+          return static_cast<uint32_t>(V / MaxBW);
+        }));
+    setBranchWeights(*Switch, ScaledBranchWeights, /*IsExpected=*/false);
   } else
     setExplicitlyUnknownBranchWeights(*Switch);
   if (PHI)


### PR DESCRIPTION
Fixing buildbot failures after PR #153305, e.g. https://lab.llvm.org/buildbot/#/builders/203/builds/19861

Analysis already depends on `ProfileData`, so the transitive closure of the dependencies of `ScalarOpts` doesn't change.

Also avoided an extra dependency (and very unnecessary) on `Instrumentation`. The API previously used doesn't need to live in Instrumentation to begin with, but that's something to address in a follow-up.