### PR TITLE
[Clang][Bytecode][NFC] Move Result into APSInt constructor

### DIFF
--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
@@ -2285,7 +2285,7 @@ static bool interp__builtin_elementwise_sat(InterpState &S, CodePtr OpPC,
       llvm_unreachable("Wrong builtin ID");
     }
 
-    pushInteger(S, APSInt(Result, !LHS.isSigned()), Call->getType());
+    pushInteger(S, APSInt(std::move(Result), !LHS.isSigned()), Call->getType());
     return true;
   }
 


### PR DESCRIPTION
Static analysis flagged this line because we are copying Result instead of moving it.