### PR TITLE
[Clang][Bytecode][NFS] Init Semantics non-static member of class Floating

### DIFF
--- a/clang/lib/AST/ByteCode/Floating.h
+++ b/clang/lib/AST/ByteCode/Floating.h
@@ -38,7 +38,7 @@ private:
     uint64_t Val = 0;
     uint64_t *Memory;
   };
-  llvm::APFloatBase::Semantics Semantics;
+  llvm::APFloatBase::Semantics Semantics{};
 
   APFloat getValue() const {
     unsigned BitWidth = bitWidth();


### PR DESCRIPTION
Static analysis flagged that the non-static member Semantics was not initialized by the default default constructor. Fix is to initialize it using in class member initialization.