### PR TITLE
[OpenMP][wip] Rework 'containing struct'/overlapped mapping handling

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -7108,8 +7108,8 @@ private:
                             Address BP, Address LB, bool IsNonContiguous,
                             uint64_t DimSize)
         : CGF(CGF), CombinedInfo(CombinedInfo), Flags(Flags), MapDecl(MapDecl),
-          MapExpr(MapExpr), BP(BP), LB(LB), IsNonContiguous(IsNonContiguous),
-          DimSize(DimSize) {}
+          MapExpr(MapExpr), BP(BP), IsNonContiguous(IsNonContiguous),
+          DimSize(DimSize), LB(LB) {}
 
     void processField(
         const OMPClauseMappableExprCommon::MappableComponent &MC,


### PR DESCRIPTION
This patch is an early outline for a rework of several mapping features, intended to support 'containing structures' in the middle of expressions as well as at the top level (https://github.com/llvm/llvm-project/issues/141042).  Key ideas are:

  - struct information is gathered using several pre-passes before `generateInfoForComponentList`.

  - "PartialStruct" is turned into a map, keyed on the "effective base" of each containing structure in a set of expressions in OpenMP 'map' clauses.

  - the reverse iterator over component lists (visiting the base decl, then walking out to the full expression) has a new 'ComponentListRefPtrPteeIterator' adapter that (a) visits reference-type list components twice, and (b) provides a few useful utility methods.

The current state is that a couple of tests work up to a point, but I'm hitting problems with the runtime that will probably be helped by the in-progress patches to support ATTACH operations.

This is obviously all full of debug code and not at all ready for review! Posting FYI.