### PR TITLE
[flang][runtime] OPEN(existingUnit,POSITION=)

### DIFF
--- a/flang-rt/include/flang-rt/runtime/file.h
+++ b/flang-rt/include/flang-rt/runtime/file.h
@@ -68,7 +68,7 @@ public:
   void WaitAll(IoErrorHandler &);
 
   // INQUIRE(POSITION=)
-  Position InquirePosition() const;
+  Position InquirePosition(FileOffset offset) const;
 
 private:
   struct Pending {
@@ -80,7 +80,7 @@ private:
   void CheckOpen(const Terminator &);
   bool Seek(FileOffset, IoErrorHandler &);
   bool RawSeek(FileOffset);
-  bool RawSeekToEnd();
+  bool SeekToEnd(IoErrorHandler &);
   int PendingResult(const Terminator &, int);
   void SetPosition(FileOffset pos) {
     position_ = pos;

--- a/flang-rt/lib/runtime/external-unit.cpp
+++ b/flang-rt/lib/runtime/external-unit.cpp
@@ -57,7 +57,7 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreate(
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
-    Direction dir, Fortran::common::optional<bool> isUnformatted,
+    Direction dir, common::optional<bool> isUnformatted,
     IoErrorHandler &handler) {
   // Make sure that the returned anonymous unit has been opened,
   // not just created in the unitMap.
@@ -109,8 +109,8 @@ ExternalFileUnit &ExternalFileUnit::NewUnit(
   return unit;
 }
 
-bool ExternalFileUnit::OpenUnit(Fortran::common::optional<OpenStatus> status,
-    Fortran::common::optional<Action> action, Position position,
+bool ExternalFileUnit::OpenUnit(common::optional<OpenStatus> status,
+    common::optional<Action> action, Position position,
     OwningPtr<char> &&newPath, std::size_t newPathLength, Convert convert,
     IoErrorHandler &handler) {
   if (convert == Convert::Unknown) {
@@ -131,6 +131,7 @@ bool ExternalFileUnit::OpenUnit(Fortran::common::optional<OpenStatus> status,
     if (!newPath.get() || isSamePath) {
       // OPEN of existing unit, STATUS='OLD' or unspecified, not new FILE=
       newPath.reset();
+      Open(status.value_or(OpenStatus::Old), action, position, handler);
       return impliedClose;
     }
     // Otherwise, OPEN on open unit with new FILE= implies CLOSE
@@ -194,10 +195,9 @@ bool ExternalFileUnit::OpenUnit(Fortran::common::optional<OpenStatus> status,
   return impliedClose;
 }
 
-bool ExternalFileUnit::OpenAnonymousUnit(
-    Fortran::common::optional<OpenStatus> status,
-    Fortran::common::optional<Action> action, Position position,
-    Convert convert, IoErrorHandler &handler) {
+bool ExternalFileUnit::OpenAnonymousUnit(common::optional<OpenStatus> status,
+    common::optional<Action> action, Position position, Convert convert,
+    IoErrorHandler &handler) {
   // I/O to an unconnected unit reads/creates a local file, e.g. fort.7
   std::size_t pathMaxLen{32};
   auto path{SizedNew<char>{handler}(pathMaxLen)};

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -197,6 +197,10 @@ public:
 
   RT_API_ATTRS int GetAsynchronousId(IoErrorHandler &);
   RT_API_ATTRS bool Wait(int);
+  RT_API_ATTRS Position InquirePosition() const {
+    return OpenFile::InquirePosition(
+        static_cast<FileOffset>(frameOffsetInFile_ + recordOffsetInFrame_));
+  }
 
 private:
   static RT_API_ATTRS UnitMap &CreateUnitMap();


### PR DESCRIPTION
Ensure that when a connected unit is reopened with POSITION='REWIND' or 'APPEND', and a STATUS='OLD' or unspecified, that it is actually repositioned as requested.

Fixes https://github.com/llvm/llvm-project/issues/153426.