### PR TITLE
[LegacyPM][CGSCC] Print banner with newline when filter-print-funcs is given.

### DIFF
--- a/llvm/lib/Analysis/CallGraphSCCPass.cpp
+++ b/llvm/lib/Analysis/CallGraphSCCPass.cpp
@@ -678,14 +678,13 @@ namespace {
       auto PrintBannerOnce = [&]() {
         if (BannerPrinted)
           return;
-        OS << Banner;
+        OS << Banner << "\n";
         BannerPrinted = true;
       };
 
       bool NeedModule = llvm::forcePrintModuleIR();
       if (isFunctionInPrintList("*") && NeedModule) {
         PrintBannerOnce();
-        OS << "\n";
         SCC.getCallGraph().getModule().print(OS, nullptr);
         return false;
       }
@@ -701,12 +700,11 @@ namespace {
           }
         } else if (isFunctionInPrintList("*")) {
           PrintBannerOnce();
-          OS << "\nPrinting <null> Function\n";
+          OS << "Printing <null> Function\n";
         }
       }
       if (NeedModule && FoundFunction) {
         PrintBannerOnce();
-        OS << "\n";
         SCC.getCallGraph().getModule().print(OS, nullptr);
       }
       return false;


### PR DESCRIPTION
When using the legacy PM, if `-filter-print-funcs` is given with `-print-after-all`, the banner for CGSCC passes is printed without a newline for the first function printed, e.g:

```
*** IR Dump After Function Integration/Inlining (inline) ***; Function attrs:
define @foo() {
...
```

instead of the correct output:

```
*** IR Dump After Function Integration/Inlining (inline) ***
; Function attrs:
define @foo() {
...
```

This patch fixes the behavior by changing `PrintBannerOnce()` to emit a newline after the banner unconditionally.