### PR TITLE
[Clang][Sema] Add nullptr check in IsFunctionConversion

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -1979,7 +1979,7 @@ bool Sema::IsFunctionConversion(QualType FromType, QualType ToType,
   }
 
   // Drop 'noexcept' if not present in target type.
-  if (FromFPT) {
+  if (FromFPT && ToFPT) {
     if (FromFPT->isNothrow() && !ToFPT->isNothrow()) {
       FromFn = cast<FunctionType>(
           Context.getFunctionTypeWithExceptionSpec(QualType(FromFPT, 0),


### PR DESCRIPTION
Static analysis flagged this code b/c ToFPT could be nullptr but we were not checking it even though in the previous if statement we did. It looks like this was a mistaken refactor from:

https://github.com/llvm/llvm-project/pull/135836

In the older code ToFPT was set using a cast which would have asserted but no longer in the new code.