### PR TITLE
[libc] Fix mbrtowc test

### DIFF
--- a/libc/test/src/wchar/mbrtowc_test.cpp
+++ b/libc/test/src/wchar/mbrtowc_test.cpp
@@ -37,18 +37,18 @@ TEST_F(LlvmLibcMBRToWCTest, TwoByte) {
   const char ch[2] = {static_cast<char>(0xC2),
                       static_cast<char>(0x8E)}; //  car symbol
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 2, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 2, &mb);
   ASSERT_EQ(static_cast<int>(*dest), 142);
   ASSERT_EQ(static_cast<int>(n), 2);
   ASSERT_ERRNO_SUCCESS();
 
   // Should fail since we have not read enough
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, &mb);
   ASSERT_EQ(static_cast<int>(n), -2);
   // Should pass after reading one more byte
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 1, 1, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 1, 1, &mb);
   ASSERT_EQ(static_cast<int>(n), 1);
   ASSERT_EQ(static_cast<int>(*dest), 142);
   ASSERT_ERRNO_SUCCESS();
@@ -58,19 +58,19 @@ TEST_F(LlvmLibcMBRToWCTest, ThreeByte) {
   const char ch[3] = {static_cast<char>(0xE2), static_cast<char>(0x88),
                       static_cast<char>(0x91)}; // ∑ sigma symbol
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 3, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 3, &mb);
   ASSERT_EQ(static_cast<int>(*dest), 8721);
   ASSERT_EQ(static_cast<int>(n), 3);
   ASSERT_ERRNO_SUCCESS();
 
   // Should fail since we have not read enough
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, &mb);
   ASSERT_EQ(static_cast<int>(n), -2);
   ASSERT_ERRNO_SUCCESS();
   // Should pass after reading two more bytes
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 1, 2, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 1, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), 2);
   ASSERT_EQ(static_cast<int>(*dest), 8721);
   ASSERT_ERRNO_SUCCESS();
@@ -81,18 +81,18 @@ TEST_F(LlvmLibcMBRToWCTest, FourByte) {
                       static_cast<char>(0xA4),
                       static_cast<char>(0xA1)}; // 🤡 clown emoji
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 4, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 4, &mb);
   ASSERT_EQ(static_cast<int>(*dest), 129313);
   ASSERT_EQ(static_cast<int>(n), 4);
   ASSERT_ERRNO_SUCCESS();
   // Should fail since we have not read enough
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 2, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), -2);
   ASSERT_ERRNO_SUCCESS();
   // Should pass after reading two more bytes
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 2, 2, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 2, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), 2);
   ASSERT_EQ(static_cast<int>(*dest), 129313);
   ASSERT_ERRNO_SUCCESS();
@@ -101,9 +101,9 @@ TEST_F(LlvmLibcMBRToWCTest, FourByte) {
 TEST_F(LlvmLibcMBRToWCTest, InvalidByte) {
   const char ch[1] = {static_cast<char>(0x80)};
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, &mb);
   ASSERT_EQ(static_cast<int>(n), -1);
   ASSERT_ERRNO_EQ(EILSEQ);
 }
@@ -113,18 +113,18 @@ TEST_F(LlvmLibcMBRToWCTest, InvalidMultiByte) {
                       static_cast<char>(0x80),
                       static_cast<char>(0x00)}; // invalid sequence of bytes
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
   // Trying to push all 4 should error
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 4, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 4, &mb);
   ASSERT_EQ(static_cast<int>(n), -1);
   ASSERT_ERRNO_EQ(EILSEQ);
   // Trying to push just the first one should error
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, &mb);
   ASSERT_EQ(static_cast<int>(n), -1);
   ASSERT_ERRNO_EQ(EILSEQ);
   // Trying to push the second and third should correspond to null wc
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 1, 2, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch + 1, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), 0);
   ASSERT_TRUE(*dest == L'\0');
   ASSERT_ERRNO_SUCCESS();
@@ -136,10 +136,10 @@ TEST_F(LlvmLibcMBRToWCTest, InvalidLastByte) {
   const char ch[4] = {static_cast<char>(0xF1), static_cast<char>(0x80),
                       static_cast<char>(0x80), static_cast<char>(0xC0)};
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
   // Trying to push all 4 should error
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 4, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 4, &mb);
   ASSERT_EQ(static_cast<int>(n), -1);
   ASSERT_ERRNO_EQ(EILSEQ);
 }
@@ -148,10 +148,10 @@ TEST_F(LlvmLibcMBRToWCTest, ValidTwoByteWithExtraRead) {
   const char ch[3] = {static_cast<char>(0xC2), static_cast<char>(0x8E),
                       static_cast<char>(0x80)};
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
   // Trying to push all 3 should return valid 2 byte
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 3, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 3, &mb);
   ASSERT_EQ(static_cast<int>(n), 2);
   ASSERT_EQ(static_cast<int>(*dest), 142);
   ASSERT_ERRNO_SUCCESS();
@@ -161,14 +161,14 @@ TEST_F(LlvmLibcMBRToWCTest, TwoValidTwoBytes) {
   const char ch[4] = {static_cast<char>(0xC2), static_cast<char>(0x8E),
                       static_cast<char>(0xC7), static_cast<char>(0x8C)};
   wchar_t dest[2];
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
   // mbstate should reset after reading first one
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 2, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, ch, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), 2);
   ASSERT_EQ(static_cast<int>(*dest), 142);
   ASSERT_ERRNO_SUCCESS();
-  n = LIBC_NAMESPACE::mbrtowc(dest + 1, ch + 2, 2, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest + 1, ch + 2, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), 2);
   ASSERT_EQ(static_cast<int>(*(dest + 1)), 460);
   ASSERT_ERRNO_SUCCESS();
@@ -176,16 +176,16 @@ TEST_F(LlvmLibcMBRToWCTest, TwoValidTwoBytes) {
 
 TEST_F(LlvmLibcMBRToWCTest, NullString) {
   wchar_t dest[2] = {L'O', L'K'};
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
   // reading on nullptr should return 0
-  size_t n = LIBC_NAMESPACE::mbrtowc(dest, nullptr, 2, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(dest, nullptr, 2, &mb);
   ASSERT_EQ(static_cast<int>(n), 0);
   ASSERT_TRUE(dest[0] == L'O');
   ASSERT_ERRNO_SUCCESS();
   // reading a null terminator should return 0
   const char *ch = "\0";
-  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, mb);
+  n = LIBC_NAMESPACE::mbrtowc(dest, ch, 1, &mb);
   ASSERT_EQ(static_cast<int>(n), 0);
   ASSERT_ERRNO_SUCCESS();
 }
@@ -194,10 +194,10 @@ TEST_F(LlvmLibcMBRToWCTest, NullDest) {
   const char ch[4] = {static_cast<char>(0xF0), static_cast<char>(0x9F),
                       static_cast<char>(0xA4),
                       static_cast<char>(0xA1)}; // 🤡 clown emoji
-  mbstate_t *mb;
+  mbstate_t mb;
   LIBC_NAMESPACE::memset(&mb, 0, sizeof(mbstate_t));
   // reading nullptr should return correct size
-  size_t n = LIBC_NAMESPACE::mbrtowc(nullptr, ch, 10, mb);
+  size_t n = LIBC_NAMESPACE::mbrtowc(nullptr, ch, 10, &mb);
   ASSERT_EQ(static_cast<int>(n), 4);
   ASSERT_ERRNO_SUCCESS();
 }


### PR DESCRIPTION
Previously, we were trying to memset a pointer that wasn't being initialized, and the test would randomly fail.

This PR replaces the pointers with actual objects.