### PR TITLE
[llvm] fix mustache template whitespace

### DIFF
--- a/llvm/lib/Support/Mustache.cpp
+++ b/llvm/lib/Support/Mustache.cpp
@@ -166,7 +166,7 @@ private:
   void renderSectionLambdas(const llvm::json::Value &Contexts,
                             llvm::raw_ostream &OS, SectionLambda &L);
 
-  void indentTextNode(std::string &body, size_t Indentation, bool lastChild);
+  void indentTextNode(std::string &Body, size_t Indentation, bool FinalNode);
 
   void indentNodes(ASTNode *Node, bool isPartial);
 
@@ -685,17 +685,19 @@ void ASTNode::renderChild(const json::Value &Contexts, llvm::raw_ostream &OS) {
     Child->render(Contexts, OS);
 }
 
-void ASTNode::indentTextNode(std::string &body, size_t Indentation,
-                             bool lastChild) {
+void ASTNode::indentTextNode(std::string &Body, size_t Indentation,
+                             bool FinalNode) {
   std::string spaces(Indentation, ' ');
   size_t pos = 0;
+  size_t LastChar = std::string::npos;
 
-  if (lastChild)
-    body.erase(body.find_last_not_of(" \t\r\f\v") + 1); // .rtrim??
+  if (FinalNode)
+    // body.erase(body.find_last_not_of(" \t\r\f\v") + 1);
+    LastChar = Body.find_last_not_of(" \t\r\f\v");
 
-  while ((pos = body.find('\n', pos)) != std::string::npos) {
-    if ((!lastChild) || (pos != body.size() - 1)) {
-      body.insert(pos + 1, spaces);
+  while ((pos = Body.find('\n', pos)) != std::string::npos) {
+    if ((!FinalNode) || (pos != LastChar)) {
+      Body.insert(pos + 1, spaces);
       pos += 1 + Indentation;
     } else {
       break;

--- a/llvm/lib/Support/Mustache.cpp
+++ b/llvm/lib/Support/Mustache.cpp
@@ -168,7 +168,7 @@ private:
 
   void indentTextNode(std::string &Body, size_t Indentation, bool FinalNode);
 
-  void indentNodes(ASTNode *Node, bool isPartial);
+  void indentNodes(ASTNode *Node, bool IsPartial);
 
   void renderPartial(const llvm::json::Value &Contexts, llvm::raw_ostream &OS,
                      ASTNode *Partial);
@@ -687,40 +687,41 @@ void ASTNode::renderChild(const json::Value &Contexts, llvm::raw_ostream &OS) {
 
 void ASTNode::indentTextNode(std::string &Body, size_t Indentation,
                              bool FinalNode) {
-  std::string spaces(Indentation, ' ');
-  size_t pos = 0;
+  std::string Spaces(Indentation, ' ');
+  size_t Pos = 0;
   size_t LastChar = std::string::npos;
 
   if (FinalNode)
-    // body.erase(body.find_last_not_of(" \t\r\f\v") + 1);
     LastChar = Body.find_last_not_of(" \t\r\f\v");
 
   while ((pos = Body.find('\n', pos)) != std::string::npos) {
-    if ((!FinalNode) || (pos != LastChar)) {
-      Body.insert(pos + 1, spaces);
-      pos += 1 + Indentation;
-    } else {
+    if (FinalNode && (pos == LastChar))
       break;
-    }
+
+    Body.insert(pos + 1, Spaces);
+    pos += 1 + Indentation;
   }
 }
 
-void ASTNode::indentNodes(ASTNode *Node, bool isPartial) {
-  size_t size = Node->Children.size();
+void ASTNode::indentNodes(ASTNode *Node, bool IsPartial) {
+  size_t Size = Node->Children.size();
 
-  for (size_t i = 0; i < size; ++i) {
-    ASTNode *child = Node->Children[i].get();
-    switch (child->Ty) {
+  for (size_t i = 0; i < Size; ++i) {
+    ASTNode *Child = Node->Children[i].get();
+    switch (Child->Ty) {
     case ASTNode::Text: {
-      indentTextNode(child->Body, Indentation, ((i == size - 1) && isPartial));
+      // Only track the final node for partials.
+      bool IsFinalNode = ((i == Size - 1) && IsPartial);
+      indentTextNode(Child->Body, Indentation, IsFinalNode);
       break;
     }
     case ASTNode::Section: {
-      indentNodes(child, false);
+      indentNodes(Child, false);
       break;
     }
     case ASTNode::Partial: {
-      indentNodes(child, true);
+      indentNodes(Child, true);
+      break;
     }
     case ASTNode::Root:
     case ASTNode::Variable:

--- a/llvm/lib/Support/Mustache.cpp
+++ b/llvm/lib/Support/Mustache.cpp
@@ -694,12 +694,13 @@ void ASTNode::indentTextNode(std::string &Body, size_t Indentation,
   if (FinalNode)
     LastChar = Body.find_last_not_of(" \t\r\f\v");
 
-  while ((pos = Body.find('\n', pos)) != std::string::npos) {
-    if (FinalNode && (pos == LastChar))
+  while ((Pos = Body.find('\n', Pos)) != std::string::npos) {
+    if (FinalNode && (Pos == LastChar))
       break;
 
-    Body.insert(pos + 1, Spaces);
-    pos += 1 + Indentation;
+    Body.insert(Pos + 1, Spaces);
+    Pos += 1 + Indentation;
+    LastChar += Indentation;
   }
 }
 

--- a/llvm/utils/llvm-test-mustache-spec/llvm-test-mustache-spec.cpp
+++ b/llvm/utils/llvm-test-mustache-spec/llvm-test-mustache-spec.cpp
@@ -141,7 +141,6 @@ static const StringMap<StringSet<>> XFailTestNames = {{
          "Triple Mustache - Standalone",
          "Triple Mustache With Padding",
      }},
-    {"partials.json", {"Standalone Indentation"}},
     {"sections.json", {"Implicit Iterator - Triple mustache"}},
 }};
 


### PR DESCRIPTION
Quick go at trying to fix the template whitespace issue. It's not pretty, but I suspect it is a long way from where it needs to be. Wanted to get some thoughts on where to go from here. Maybe this work  needs to be synced with the JSON generator to make it go smoothly.

I'll create some simple tests unless someone has something already.

Just a thought... if we have JSON, and we have the templates, there are probably already tools that can do this better...

fixes #149844