### PR TITLE
[mlir][spirv] Add missing #include in SPIRVImageInterfaces.h

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/Interfaces/SPIRVImageInterfaces.h
+++ b/mlir/include/mlir/Dialect/SPIRV/Interfaces/SPIRVImageInterfaces.h
@@ -9,6 +9,8 @@
 #ifndef MLIR_DIALECT_SPIRV_IMAGE_INTERFACES_H_
 #define MLIR_DIALECT_SPIRV_IMAGE_INTERFACES_H_
 
+#include "mlir/IR/OpDefinition.h"
+
 #include "mlir/Dialect/SPIRV/Interfaces/SPIRVImageInterfaces.h.inc"
 
 #endif // MLIR_DIALECT_SPIRV_IMAGE_INTERFACES_H_


### PR DESCRIPTION
SPIRVImageInterfaces.h.inc uses some types, e.g. mlir::TypedValue, without #include the necessary headers. This is fine most of the time, but we did run into a weird case where bazel fails to compile //mlir:SPIRVImageInterfaces on clang19 for ChromiumOS when parse_headers (see [1]) is specified.

[1]: https://bazel.build/docs/bazel-and-cpp#toolchain-features