### PR TITLE
[Headers][X86] Remove duplicate __v8hu, NFCI

### DIFF
--- a/clang/lib/Headers/emmintrin.h
+++ b/clang/lib/Headers/emmintrin.h
@@ -31,7 +31,6 @@ typedef char __v16qi __attribute__((__vector_size__(16)));
 
 /* Unsigned types */
 typedef unsigned long long __v2du __attribute__((__vector_size__(16)));
-typedef unsigned short __v8hu __attribute__((__vector_size__(16)));
 typedef unsigned char __v16qu __attribute__((__vector_size__(16)));
 
 /* We need an explicitly signed variant for char. Note that this shouldn't


### PR DESCRIPTION
Newly added in xmmintrin.h by c8312bdd1665225c585dd2b0bff5e46d569edd45