### PR TITLE
github: Add llvm:mc label for generic MC interface

### DIFF
--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -618,9 +618,11 @@ llvm:adt:
 llvm:support:
   - llvm/**/Support/**
 
-# Skip llvm/test/MC, which includes target-specific directories
+# Skip llvm/test/MC and llvm/unittests/MC, which includes target-specific directories.
 llvm:mc:
+  - llvm/include/llvm/MC/**
   - llvm/lib/MC/**
+  - llvm/tools/llvm-mc/**
 
 llvm:transforms:
   - llvm/lib/Transforms/**

--- a/.github/new-prs-labeler.yml
+++ b/.github/new-prs-labeler.yml
@@ -90,9 +90,6 @@ LTO:
   - llvm/lib/Transforms/*/FunctionImport*
   - llvm/tools/gold/**
 
-mc:
-  - llvm/*/MC/**
-
 clang:driver:
   - clang/*/Driver/**
 
@@ -620,6 +617,10 @@ llvm:adt:
 
 llvm:support:
   - llvm/**/Support/**
+
+# Skip llvm/test/MC, which includes target-specific directories
+llvm:mc:
+  - llvm/lib/MC/**
 
 llvm:transforms:
   - llvm/lib/Transforms/**


### PR DESCRIPTION
As a member of github.com/orgs/llvm/teams/pr-subscribers-llvm-mc , I was not notified about PR #149935.

This commit introduces the `llvm:mc` label to cover the generic MC
interface, excluding target-specific MCTargetDesc files.

- Rename the `mc` label to `llvm:mc` for consistency with other LLVM subdirectory labels.
- Exclude `llvm/test/MC` from the label scope, as it contains many target-specific directories.

Admin: please change the name of https://github.com/orgs/llvm/teams/pr-subscribers-llvm-mc
to "pr-subscribers-llvm:mc", similar to pr-subscribers-llvm:ir

