### PR TITLE
[clangd] Add feature modules registry

### DIFF
--- a/clang-tools-extra/clangd/FeatureModule.cpp
+++ b/clang-tools-extra/clangd/FeatureModule.cpp
@@ -9,8 +9,6 @@
 #include "FeatureModule.h"
 #include "support/Logger.h"
 
-LLVM_INSTANTIATE_REGISTRY(clang::clangd::FeatureModuleRegistry)
-
 namespace clang {
 namespace clangd {
 
@@ -22,6 +20,10 @@ void FeatureModule::initialize(const Facilities &F) {
 FeatureModule::Facilities &FeatureModule::facilities() {
   assert(Fac && "Not initialized yet");
   return *Fac;
+}
+
+void FeatureModuleSet::add(std::unique_ptr<FeatureModule> M) {
+  Modules.push_back(std::move(M));
 }
 
 bool FeatureModuleSet::addImpl(void *Key, std::unique_ptr<FeatureModule> M,
@@ -37,3 +39,5 @@ bool FeatureModuleSet::addImpl(void *Key, std::unique_ptr<FeatureModule> M,
 
 } // namespace clangd
 } // namespace clang
+
+LLVM_INSTANTIATE_REGISTRY(clang::clangd::FeatureModuleRegistry)

--- a/clang-tools-extra/clangd/FeatureModule.cpp
+++ b/clang-tools-extra/clangd/FeatureModule.cpp
@@ -9,6 +9,8 @@
 #include "FeatureModule.h"
 #include "support/Logger.h"
 
+LLVM_INSTANTIATE_REGISTRY(clang::clangd::FeatureModuleRegistry)
+
 namespace clang {
 namespace clangd {
 

--- a/clang-tools-extra/clangd/FeatureModule.h
+++ b/clang-tools-extra/clangd/FeatureModule.h
@@ -15,6 +15,7 @@
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/Registry.h"
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -143,9 +144,14 @@ private:
 
 /// A FeatureModuleSet is a collection of feature modules installed in clangd.
 ///
-/// Modules can be looked up by type, or used via the FeatureModule interface.
-/// This allows individual modules to expose a public API.
-/// For this reason, there can be only one feature module of each type.
+/// Modules added with explicit type specification can be looked up by type, or
+/// used via the FeatureModule interface. This allows individual modules to
+/// expose a public API. For this reason, there can be only one feature module
+/// of each type.
+///
+/// Modules added using a base class pointer can be used only via the
+/// FeatureModule interface and can't be looked up by type, thus custom public
+/// API (if provided by the module) can't be used.
 ///
 /// The set owns the modules. It is itself owned by main, not ClangdServer.
 class FeatureModuleSet {
@@ -172,6 +178,9 @@ public:
   const_iterator begin() const { return const_iterator(Modules.begin()); }
   const_iterator end() const { return const_iterator(Modules.end()); }
 
+  void add(std::unique_ptr<FeatureModule> M) {
+    Modules.push_back(std::move(M));
+  }
   template <typename Mod> bool add(std::unique_ptr<Mod> M) {
     return addImpl(&ID<Mod>::Key, std::move(M), LLVM_PRETTY_FUNCTION);
   }
@@ -184,6 +193,8 @@ public:
 };
 
 template <typename Mod> int FeatureModuleSet::ID<Mod>::Key;
+
+typedef llvm::Registry<FeatureModule> FeatureModuleRegistry;
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/FeatureModule.h
+++ b/clang-tools-extra/clangd/FeatureModule.h
@@ -178,9 +178,7 @@ public:
   const_iterator begin() const { return const_iterator(Modules.begin()); }
   const_iterator end() const { return const_iterator(Modules.end()); }
 
-  void add(std::unique_ptr<FeatureModule> M) {
-    Modules.push_back(std::move(M));
-  }
+  void add(std::unique_ptr<FeatureModule> M);
   template <typename Mod> bool add(std::unique_ptr<Mod> M) {
     return addImpl(&ID<Mod>::Key, std::move(M), LLVM_PRETTY_FUNCTION);
   }
@@ -194,7 +192,7 @@ public:
 
 template <typename Mod> int FeatureModuleSet::ID<Mod>::Key;
 
-typedef llvm::Registry<FeatureModule> FeatureModuleRegistry;
+using FeatureModuleRegistry = llvm::Registry<FeatureModule>;
 
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -1017,6 +1017,13 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
                : static_cast<int>(ErrorResultCode::CheckFailed);
   }
 
+  FeatureModuleSet ModuleSet;
+  for (FeatureModuleRegistry::entry E : FeatureModuleRegistry::entries()) {
+    vlog("Adding feature module '{0}' ({1})", E.getName(), E.getDesc());
+    ModuleSet.add(E.instantiate());
+  }
+  Opts.FeatureModules = &ModuleSet;
+
   // Initialize and run ClangdLSPServer.
   // Change stdin to binary to not lose \r\n on windows.
   llvm::sys::ChangeStdinToBinary();

--- a/clang-tools-extra/clangd/tool/ClangdMain.cpp
+++ b/clang-tools-extra/clangd/tool/ClangdMain.cpp
@@ -1022,7 +1022,8 @@ clangd accepts flags on the commandline, and in the CLANGD_FLAGS environment var
     vlog("Adding feature module '{0}' ({1})", E.getName(), E.getDesc());
     ModuleSet.add(E.instantiate());
   }
-  Opts.FeatureModules = &ModuleSet;
+  if (ModuleSet.begin() != ModuleSet.end())
+    Opts.FeatureModules = &ModuleSet;
 
   // Initialize and run ClangdLSPServer.
   // Change stdin to binary to not lose \r\n on windows.


### PR DESCRIPTION
This patch adds feature modules registry, as discussed with @kadircet in [discourse](https://discourse.llvm.org/t/rfc-registry-for-feature-modules/87733).
Feature modules, which added into the feature module set from registry entries, can't expose public API, but still can be used via `FeatureModule` interface.