### PR TITLE
[libc++][jthread] LWG3788: `jthread::operator=(jthread&&)` postconditions are unimplementable under self-assignment

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -230,7 +230,7 @@
 "`LWG3782 <https://wg21.link/LWG3782>`__","Should ``<math.h>`` declare ``::lerp``?","2022-11 (Kona)","|Complete|","17",""
 "`LWG3784 <https://wg21.link/LWG3784>`__","std.compat should not provide ``::byte`` and its friends","2022-11 (Kona)","|Complete|","19",""
 "`LWG3785 <https://wg21.link/LWG3785>`__","``ranges::to`` is over-constrained on the destination type being a range","2022-11 (Kona)","","",""
-"`LWG3788 <https://wg21.link/LWG3788>`__","``jthread::operator=(jthread&&)`` postconditions are unimplementable under self-assignment","2022-11 (Kona)","","",""
+"`LWG3788 <https://wg21.link/LWG3788>`__","``jthread::operator=(jthread&&)`` postconditions are unimplementable under self-assignment","2022-11 (Kona)","|Complete|","18",""
 "`LWG3792 <https://wg21.link/LWG3792>`__","``__cpp_lib_constexpr_algorithms`` should also be defined in ``<utility>``","2022-11 (Kona)","|Complete|","16",""
 "`LWG3795 <https://wg21.link/LWG3795>`__","Self-move-assignment of ``std::future`` and ``std::shared_future`` have unimplementable postconditions","2022-11 (Kona)","","",""
 "`LWG3796 <https://wg21.link/LWG3796>`__","``movable-box`` as member should use ``default-initialization`` instead of ``copy-initialization``","2022-11 (Kona)","","",""

--- a/libcxx/test/std/thread/thread.jthread/assign.move.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/assign.move.pass.cpp
@@ -112,5 +112,14 @@ int main(int, char**) {
     assert(j1.get_id() == j2Id);
   }
 
+  // LWG3788: self-assignement
+  {
+    std::jthread j = support::make_test_jthread([] {});
+    auto oldId     = j.get_id();
+    j              = std::move(j);
+
+    assert(j.get_id() == oldId);
+  }
+
   return 0;
 }


### PR DESCRIPTION
Already implemented in LLVM18: [695138c](https://github.com/llvm/llvm-project/commit/695138ca8405779c2b7756cc31d887aa54f56bb8)

For details see: https://github.com/llvm/llvm-project/issues/105045#issuecomment-3190674947

Closes #105045