### PR TITLE
[clang] Skip suggesting unqualified members in explicit-object member functions

### DIFF
--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -4478,11 +4478,14 @@ TEST(CompletionTest, MemberAccessInExplicitObjMemfn) {
   Annotations Code(R"cpp(
     struct A {
       int member {};
+      int memberFnA(int a);
+      int memberFnA(this A&, float a);
 
       void foo(this A& self) {
-        // Should not offer `member` here, since it needs to be 
-        // referenced as `self.member`.
+        // Should not offer any members here, since 
+        // it needs to be referenced through `self`.
         mem$c1^;
+        // should offer all results
         self.mem$c2^;
       }
     };
@@ -4509,7 +4512,13 @@ TEST(CompletionTest, MemberAccessInExplicitObjMemfn) {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c2"),
                                Preamble.get(), Inputs, Opts);
 
-    EXPECT_THAT(Result.Completions, ElementsAre(named("member")));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(named("member"),
+                             AllOf(named("memberFnA"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("memberFnA"), signature("(float a)"),
+                                   snippetSuffix("(${1:float a})"))));
   }
 }
 } // namespace

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -4487,6 +4487,11 @@ TEST(CompletionTest, MemberAccessInExplicitObjMemfn) {
         mem$c1^;
         // should offer all results
         self.mem$c2^;
+
+        [&]() {
+          // should not offer any results
+          mem$c3^;
+        }();
       }
     };
   )cpp");
@@ -4519,6 +4524,12 @@ TEST(CompletionTest, MemberAccessInExplicitObjMemfn) {
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("memberFnA"), signature("(float a)"),
                                    snippetSuffix("(${1:float a})"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c3"),
+                               Preamble.get(), Inputs, Opts);
+
+    EXPECT_THAT(Result.Completions, ElementsAre());
   }
 }
 } // namespace

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -1428,6 +1428,16 @@ void ResultBuilder::AddResult(Result R, DeclContext *CurContext,
 
   AdjustResultPriorityForDecl(R);
 
+  if (isa<FieldDecl>(R.Declaration)) {
+    // If result is a member in the context of an explicit-object member
+    // function, drop it because it must be accessed through the object
+    // parameter
+    if (auto *MethodDecl = dyn_cast<CXXMethodDecl>(CurContext);
+        MethodDecl && MethodDecl->isExplicitObjectMemberFunction()) {
+      return;
+    }
+  }
+
   if (HasObjectTypeQualifiers)
     if (const auto *Method = dyn_cast<CXXMethodDecl>(R.Declaration))
       if (Method->isInstance()) {

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -197,6 +197,9 @@ private:
   /// Whether the \p ObjectTypeQualifiers field is active.
   bool HasObjectTypeQualifiers;
 
+  // Whether the member function is using an explicit object parameter
+  bool IsExplicitObjectMemberFunction;
+
   /// The selector that we prefer.
   Selector PreferredSelector;
 
@@ -218,8 +221,8 @@ public:
                          LookupFilter Filter = nullptr)
       : SemaRef(SemaRef), Allocator(Allocator), CCTUInfo(CCTUInfo),
         Filter(Filter), AllowNestedNameSpecifiers(false),
-        HasObjectTypeQualifiers(false), CompletionContext(CompletionContext),
-        ObjCImplementation(nullptr) {
+        HasObjectTypeQualifiers(false), IsExplicitObjectMemberFunction(false),
+        CompletionContext(CompletionContext), ObjCImplementation(nullptr) {
     // If this is an Objective-C instance method definition, dig out the
     // corresponding implementation.
     switch (CompletionContext.getKind()) {
@@ -273,6 +276,10 @@ public:
     ObjectTypeQualifiers = Quals;
     ObjectKind = Kind;
     HasObjectTypeQualifiers = true;
+  }
+
+  void setExplicitObjectMemberFn(bool IsExplicitObjectFn) {
+    IsExplicitObjectMemberFunction = IsExplicitObjectFn;
   }
 
   /// Set the preferred selector.
@@ -1428,14 +1435,13 @@ void ResultBuilder::AddResult(Result R, DeclContext *CurContext,
 
   AdjustResultPriorityForDecl(R);
 
-  if (isa<FieldDecl>(R.Declaration)) {
+  if (IsExplicitObjectMemberFunction &&
+      R.Kind == CodeCompletionResult::RK_Declaration &&
+      (isa<CXXMethodDecl>(R.Declaration) || isa<FieldDecl>(R.Declaration))) {
     // If result is a member in the context of an explicit-object member
     // function, drop it because it must be accessed through the object
     // parameter
-    if (auto *MethodDecl = dyn_cast<CXXMethodDecl>(CurContext);
-        MethodDecl && MethodDecl->isExplicitObjectMemberFunction()) {
-      return;
-    }
+    return;
   }
 
   if (HasObjectTypeQualifiers)
@@ -4646,12 +4652,19 @@ void SemaCodeCompletion::CodeCompleteOrdinaryName(
     break;
   }
 
-  // If we are in a C++ non-static member function, check the qualifiers on
-  // the member function to filter/prioritize the results list.
   auto ThisType = SemaRef.getCurrentThisType();
-  if (!ThisType.isNull())
+  if (ThisType.isNull()) {
+    // check if function scope is an explicit object function
+    if (auto *MethodDecl = llvm::dyn_cast_if_present<CXXMethodDecl>(
+            SemaRef.getCurFunctionDecl()))
+      Results.setExplicitObjectMemberFn(
+          MethodDecl->isExplicitObjectMemberFunction());
+  } else {
+    // If we are in a C++ non-static member function, check the qualifiers on
+    // the member function to filter/prioritize the results list.
     Results.setObjectTypeQualifiers(ThisType->getPointeeType().getQualifiers(),
                                     VK_LValue);
+  }
 
   CodeCompletionDeclConsumer Consumer(Results, SemaRef.CurContext);
   SemaRef.LookupVisibleDecls(S, SemaRef.LookupOrdinaryName, Consumer,

--- a/clang/test/CodeCompletion/cpp23-explicit-object.cpp
+++ b/clang/test/CodeCompletion/cpp23-explicit-object.cpp
@@ -42,7 +42,23 @@ int func3() {
 
 int func4() {
   // TODO (&A::foo)(
-  (&A::bar)(
+  (&A::bar)()
 }
 // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-2):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC5 %s
 // CHECK-CC5: OVERLOAD: [#void#](<#A#>, int)
+
+struct C {
+  int member {};
+  void foo(this C& self) {
+    // Should not offer `member` here, since it needs to be 
+    // referenced as `self.member`.
+    mem
+  }
+  void bar(this C& self) {
+    self.mem
+  }
+};
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-8):8 -std=c++23 %s | FileCheck --allow-empty %s
+// CHECK-NOT: COMPLETION: member : [#int#]member
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-5):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC6 %s
+// CHECK-CC6: COMPLETION: member : [#int#]member

--- a/clang/test/CodeCompletion/cpp23-explicit-object.cpp
+++ b/clang/test/CodeCompletion/cpp23-explicit-object.cpp
@@ -56,17 +56,28 @@ struct C {
     // Should not offer any members here, since 
     // it needs to be referenced through `self`.
     mem
+    // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-1):8 -std=c++23 %s | FileCheck --allow-empty %s
+    // CHECK-NOT: COMPLETION: member : [#int#]member
+    // CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
+    // CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)
   }
   void bar(this C& self) {
     // should offer all results
     self.mem
+    // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-1):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC6 %s
+    // CHECK-CC6: COMPLETION: member : [#int#]member
+    // CHECK-CC6: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
+    // CHECK-CC6: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)
+  }
+  void baz(this C& self) {
+    [&]() {
+      // Should not offer any results
+      mem
+      // RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-1):10 -std=c++23 %s | FileCheck --allow-empty %s
+      // CHECK-NOT: COMPLETION: member : [#int#]member
+      // CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
+      // CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)
+    }();
   }
 };
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-7):8 -std=c++23 %s | FileCheck --allow-empty %s
-// CHECK-NOT: COMPLETION: member : [#int#]member
-// CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
-// CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-7):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC6 %s
-// CHECK-CC6: COMPLETION: member : [#int#]member
-// CHECK-CC6: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
-// CHECK-CC6: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)
+

--- a/clang/test/CodeCompletion/cpp23-explicit-object.cpp
+++ b/clang/test/CodeCompletion/cpp23-explicit-object.cpp
@@ -49,16 +49,24 @@ int func4() {
 
 struct C {
   int member {};
+  int memberFnA(int a);
+  int memberFnA(this C&, float a);
+
   void foo(this C& self) {
-    // Should not offer `member` here, since it needs to be 
-    // referenced as `self.member`.
+    // Should not offer any members here, since 
+    // it needs to be referenced through `self`.
     mem
   }
   void bar(this C& self) {
+    // should offer all results
     self.mem
   }
 };
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-8):8 -std=c++23 %s | FileCheck --allow-empty %s
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-7):8 -std=c++23 %s | FileCheck --allow-empty %s
 // CHECK-NOT: COMPLETION: member : [#int#]member
-// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-5):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC6 %s
+// CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
+// CHECK-NOT: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)
+// RUN: %clang_cc1 -fsyntax-only -code-completion-at=%s:%(line-7):13 -std=c++23 %s | FileCheck -check-prefix=CHECK-CC6 %s
 // CHECK-CC6: COMPLETION: member : [#int#]member
+// CHECK-CC6: COMPLETION: memberFnA : [#int#]memberFnA(<#int a#>)
+// CHECK-CC6: COMPLETION: memberFnA : [#int#]memberFnA(<#float a#>)


### PR DESCRIPTION
Fixes #141291

Skip suggesting members when not using `self.` in explicit object methods. 
