### PR TITLE
[WebAssembly] Add __builtin_wasm_js_catch for catching JSPI SuspendError

### DIFF
--- a/clang/include/clang/Basic/BuiltinsWebAssembly.def
+++ b/clang/include/clang/Basic/BuiltinsWebAssembly.def
@@ -205,6 +205,8 @@ TARGET_BUILTIN(__builtin_wasm_ref_null_func, "i", "nct", "reference-types")
 // ref.test to test the type.
 TARGET_BUILTIN(__builtin_wasm_test_function_pointer_signature, "i.", "nct", "gc")
 
+TARGET_BUILTIN(__builtin_wasm_js_catch, "ii*", "nctj", "exception-handling")
+
 // Table builtins
 TARGET_BUILTIN(__builtin_wasm_table_set,  "viii", "t", "reference-types")
 TARGET_BUILTIN(__builtin_wasm_table_get,  "iii", "t", "reference-types")

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13241,6 +13241,8 @@ def err_wasm_builtin_test_fp_sig_cannot_include_struct_or_union
     : Error<"not supported with the multivalue ABI for "
             "function pointers with a struct/union as %select{return "
             "value|parameter}0">;
+def err_wasm_builtin_arg_must_be_pointer_to_integer_type
+    : Error<"%ordinal0 argument must be a pointer to an integer">;
 
 // OpenACC diagnostics.
 def warn_acc_routine_unimplemented

--- a/clang/include/clang/Sema/SemaWasm.h
+++ b/clang/include/clang/Sema/SemaWasm.h
@@ -39,6 +39,7 @@ public:
   bool BuiltinWasmTableCopy(CallExpr *TheCall);
   bool BuiltinWasmTestFunctionPointerSignature(const TargetInfo &TI,
                                                CallExpr *TheCall);
+  bool BuiltinWasmJsCatch(CallExpr *TheCall);
 
   WebAssemblyImportNameAttr *
   mergeImportNameAttr(Decl *D, const WebAssemblyImportNameAttr &AL);

--- a/clang/test/Sema/builtins-wasm.c
+++ b/clang/test/Sema/builtins-wasm.c
@@ -87,3 +87,19 @@ void test_function_pointer_signature() {
   (void)__builtin_wasm_test_function_pointer_signature((F4)0);
 #endif
 }
+
+void test_js_catch() {
+  // Test argument count validation
+  __builtin_wasm_js_catch(); // expected-error {{too few arguments to function call, expected 1, have 0}}
+  __builtin_wasm_js_catch(0, 0); // expected-error {{too many arguments to function call, expected 1, have 2}}
+
+  // // Test argument type validation - should require pointer to int
+  __builtin_wasm_js_catch((void*)0); // expected-error {{1st argument must be a pointer to an integer}}
+  __builtin_wasm_js_catch(((int)0));   // expected-error {{1st argument must be a pointer to an integer}}
+
+  int res;
+  __externref_t exception = __builtin_wasm_js_catch(&res);
+
+  // Test return type
+  _Static_assert(EXPR_HAS_TYPE(__builtin_wasm_js_catch(&res), __externref_t), "");
+}

--- a/llvm/include/llvm/CodeGen/WasmEHFuncInfo.h
+++ b/llvm/include/llvm/CodeGen/WasmEHFuncInfo.h
@@ -24,7 +24,7 @@ class Function;
 class MachineBasicBlock;
 
 namespace WebAssembly {
-enum Tag { CPP_EXCEPTION = 0, C_LONGJMP = 1 };
+enum Tag { CPP_EXCEPTION = 0, C_LONGJMP = 1, JS_EXCEPTION = 2 };
 }
 
 using BBOrMBB = PointerUnion<const BasicBlock *, MachineBasicBlock *>;

--- a/llvm/include/llvm/IR/IntrinsicsWebAssembly.td
+++ b/llvm/include/llvm/IR/IntrinsicsWebAssembly.td
@@ -147,6 +147,7 @@ def int_wasm_get_ehselector :
 def int_wasm_catch :
   DefaultAttrsIntrinsic<[llvm_ptr_ty], [llvm_i32_ty],
                         [IntrHasSideEffects, ImmArg<ArgIndex<0>>]>;
+def int_wasm_catch_js : DefaultAttrsIntrinsic<[llvm_externref_ty], []>;
 
 // WebAssembly EH must maintain the landingpads in the order assigned to them
 // by WasmEHPrepare pass to generate landingpad table in EHStreamer. This is

--- a/llvm/test/CodeGen/WebAssembly/lower-js-catch.ll
+++ b/llvm/test/CodeGen/WebAssembly/lower-js-catch.ll
@@ -1,0 +1,87 @@
+; RUN: opt < %s  -wasm-lower-em-ehsjlj -wasm-enable-sjlj -S | FileCheck %s
+
+target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128"
+target triple = "wasm32-unknown-unknown"
+
+; Function Attrs: nounwind
+define i32 @test_func() #0 {
+; CHECK-LABEL: define i32 @test_func()
+entry:
+  %res = alloca i32, align 4
+  %0 = call ptr addrspace(10) @__builtin_wasm_js_catch(ptr nonnull %res) #1
+  %1 = load i32, ptr %res, align 4
+  %cmp = icmp eq i32 %1, 0
+  br i1 %cmp, label %if.then, label %if.else
+; CHECK:    entry:
+; CHECK-NEXT: %res = alloca i32, align 4
+; CHECK-NEXT: %DispatchTarget = alloca i32, align 4
+; CHECK-NEXT: %DispatchArgument = alloca ptr, align 4
+; CHECK-NEXT: store i32 0, ptr %DispatchTarget, align 4
+; CHECK-NEXT: %nullref = call ptr addrspace(10) @llvm.wasm.ref.null.extern()
+; CHECK-NEXT: br label %jscatch.dispatch
+
+; CHECK: jscatch.dispatch:
+; CHECK-NEXT: %thrown{{[0-9]+}} = phi ptr addrspace(10)
+; CHECK-NEXT: %label.phi = phi i32
+; CHECK-NEXT: switch i32 %label.phi, label %entry.split [
+; CHECK-NEXT: i32 1, label %entry.split.split
+; CHECK-NEXT: ]
+
+; CHECK: entry.split:
+; CHECK-NEXT: store i32 0, ptr %res, align 4
+; CHECK-NEXT: store i32 1, ptr %DispatchTarget, align 4
+; CHECK-NEXT: store ptr %res, ptr %DispatchArgument, align 4
+
+; CHECK: entry.split.split:
+; CHECK-NEXT: %jscatch.ret = phi ptr addrspace(10)
+; CHECK-NEXT: %{{[0-9]+}} = load i32, ptr %res, align 4
+
+
+if.then:                                          ; preds = %entry
+  call void @jsfunc1() #1
+  br label %cleanup
+
+; CHECK: if.then:
+; CHECK-NEXT: invoke void @jsfunc1()
+; CHECK-NEXT: to label %{{.*}} unwind label %catch.dispatch.jserror
+
+if.else:                                          ; preds = %entry
+  %call = call i32 @handle_error(ptr addrspace(10) %0) #1
+  br label %cleanup
+
+; CHECK: if.else:
+; CHECK-NEXT: invoke i32 @handle_error(ptr addrspace(10) %jscatch.ret)
+; CHECK-NEXT: to label %{{.*}} unwind label %catch.dispatch.jserror
+
+cleanup:                                          ; preds = %if.then, %if.else
+  %retval.0 = phi i32 [ 0, %if.then ], [ %call, %if.else ]
+  ret i32 %retval.0
+
+; CHECK: catch.dispatch.jserror:
+; CHECK-NEXT: %{{[0-9]+}} = catchswitch within none [label %catch.jserror] unwind to caller
+
+; CHECK: catch.jserror:
+; CHECK-NEXT: %{{[0-9]+}} = catchpad within %{{[0-9]+}} []
+; CHECK-NEXT: %thrown = call ptr addrspace(10) @llvm.wasm.catch.js()
+; CHECK-NEXT: %dispatch.target.value = load i32, ptr %DispatchTarget, align 4
+; CHECK-NEXT: %{{[0-9]+}} = icmp eq i32 %dispatch.target.value, 0
+; CHECK-NEXT: br i1 %{{[0-9]+}}, label %if.then1, label %if.end
+
+; CHECK: if.then1:
+; CHECK-NEXT: call void @llvm.wasm.rethrow() [ "funclet"(token %{{[0-9]+}}) ]
+; CHECK-NEXT: unreachable
+
+; CHECK: if.end:
+; CHECK-NEXT: %dispatch.argument.value = load ptr, ptr %DispatchArgument, align 4
+; CHECK-NEXT: store i32 1, ptr %dispatch.argument.value, align 4
+; CHECK-NEXT: catchret from %{{[0-9]+}} to label %jscatch.dispatch
+}
+
+declare ptr addrspace(10) @__builtin_wasm_js_catch(ptr) #2
+declare void @jsfunc1()
+declare i32 @handle_error(ptr addrspace(10))
+
+
+attributes #0 = { nounwind "target-features"="+exception-handling" }
+attributes #1 = { nounwind }
+attributes #2 = { "returns_twice" }


### PR DESCRIPTION
This is a setjmp-like API that catches JavaScript errors. Its signature is `externref_t __builtin_wasm_js_catch(int *status);` The first time it returns, the return value is `null` and *status is set to 0. If we later call a function that raises a JavaScript error, control jumps back to the most recently executed call to `__builtin_wasm_js_catch()` which this time sets `*status` to 1 and returns the caught JS error.

I think this is a generally useful thing to be able to do to handle errors in `EM_JS` functions, but it is possible to use JS try/catch for that. However, this is necessary in order to catch a SuspendError since it is generated within the import wrapper internally to the runtime and there is no way to catch the SuspendError in JavaScript.

For implementation details, see the comment at the top of WebAssemblyLowerEmscriptenEHSjLj.cpp.
The implementation is copied from the sjlj implementation with modifications. There were a couple of areas where we can directly share code so I factored them out of the sjlj implementation. I didn't bother to support js eh because JSPI doesn't work with js eh anyways.

Example:
<details><summary>Details</summary>
<p>


```C
int main(void) {
    int res1 = -7;
    int res2 = -7;
    // jsfunc1();

    __externref_t caught = __builtin_wasm_js_catch(&res1);
    printf("catch1 res1: %d, res2: %d\n", res1, res2);
    if (res1 == 0) {
      printf("calling jsfunc1\n");
      jsfunc1();
    } else {
      printf("calling handle_error (1)\n");
      handle_error(caught);
    }
    __externref_t caught2 = __builtin_wasm_js_catch(&res2);
    printf("catch2 res1: %d, res2: %d\n", res1, res2);
    if (res2 == 0) {
      printf("calling jsfunc2\n");
      jsfunc2();
    } else {
      printf("calling handle_error (2)\n");
      handle_error(caught2);
    }
    return 0;
}

EM_JS(int, handle_error, (__externref_t err), {
    console.log(err);
    return 8;
});

EM_JS(void, jsfunc1, (), {
    throw new Error("jsfunc1");
})

EM_JS(void, jsfunc2, (), {
    throw new Error("jsfunc2");
})
```

Output:

```
catch1 res1: 0, res2: -7
calling jsfunc1
catch1 res1: 1, res2: -7
calling handle_error (1)
Error: jsfunc1
    at <... JS stack trace>
catch2 res1: 1, res2: 0
calling jsfunc2
catch2 res1: 1, res2: 1
calling handle_error (2)
Error: jsfunc2
    at <... JS stack trace>
```

</p>
</details> 

cc @sbc100 @dschuff @tlively @aheejin