### PR TITLE
[mlir] Enable setting alias on AsmState.

### DIFF
--- a/mlir/include/mlir/IR/AsmState.h
+++ b/mlir/include/mlir/IR/AsmState.h
@@ -560,6 +560,15 @@ public:
            FallbackAsmResourceMap *map = nullptr);
   ~AsmState();
 
+  /// Add an alias for the given attribute. The alias will be used as a
+  /// suggestion when printing. The final alias may be modified to resolve
+  /// conflicts.
+  void addAlias(Attribute attr, StringRef alias);
+
+  /// Add an alias for the given type. The alias will be used as a suggestion
+  /// when printing. The final alias may be modified to resolve conflicts.
+  void addAlias(Type type, StringRef alias);
+
   /// Get the printer flags.
   const OpPrintingFlags &getPrinterFlags() const;
 


### PR DESCRIPTION
This is useful for application output where a more useful name can be given to a type or where type is rather long and cumbersome.