### PR TITLE
[Mips] Convert -mnan=legacy to nan2008 when architecture support nan2008

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -620,6 +620,10 @@ def warn_target_unsupported_nan2008 : Warning<
 def warn_target_unsupported_nanlegacy : Warning<
   "ignoring '-mnan=legacy' option because the '%0' architecture does not support it">,
   InGroup<UnsupportedNan>;
+def warn_target_unsupported_convertnanlegacytonan2008 : Warning<
+  "ignoring unsupported '-mnan=legacy' option and instead set to `-mnan=2008` option "
+  "because the '%0' architecture supports it">,
+  InGroup<UnsupportedNan>;
 def warn_target_unsupported_abslegacy : Warning<
   "ignoring '-mabs=legacy' option because the '%0' architecture does not support it">,
   InGroup<UnsupportedAbs>;

--- a/clang/lib/Driver/ToolChains/Arch/Mips.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/Mips.cpp
@@ -301,10 +301,13 @@ void mips::getMIPSTargetFeatures(const Driver &D, const llvm::Triple &Triple,
         D.Diag(diag::warn_target_unsupported_nan2008) << CPUName;
       }
     } else if (Val == "legacy") {
-      if (mips::getIEEE754Standard(CPUName) & mips::Legacy)
-        Features.push_back("-nan2008");
-      else {
+      if (mips::getIEEE754Standard(CPUName) & mips::Std2008) {
         Features.push_back("+nan2008");
+        HasNaN2008Opt = true;
+        D.Diag(diag::warn_target_unsupported_convertnanlegacytonan2008)
+            << CPUName;
+      } else {
+        Features.push_back("-nan2008");
         D.Diag(diag::warn_target_unsupported_nanlegacy) << CPUName;
       }
     } else

--- a/clang/test/CodeGen/builtin-nan-legacy.c
+++ b/clang/test/CodeGen/builtin-nan-legacy.c
@@ -1,6 +1,6 @@
 // RUN: %clang -target mipsel-unknown-linux -mnan=legacy -emit-llvm -S %s -o - | FileCheck %s
-// CHECK: float 0x7FFC000000000000, float 0x7FF8000000000000
-// CHECK: double 0x7FF4000000000000, double 0x7FF8000000000000
+// CHECK: float 0x7FF8000000000000, float 0x7FFC000000000000
+// CHECK: double 0x7FF8000000000000, double 0x7FF4000000000000
 
 // The first line shows an unintended consequence.
 // __builtin_nan() creates a legacy QNAN double with an empty payload

--- a/clang/test/CodeGen/mips-unsupported-nan.c
+++ b/clang/test/CodeGen/mips-unsupported-nan.c
@@ -35,9 +35,9 @@
 // CHECK-MIPS3: warning: ignoring '-mnan=2008' option because the 'mips3' architecture does not support it
 // CHECK-MIPS4: warning: ignoring '-mnan=2008' option because the 'mips4' architecture does not support it
 // CHECK-MIPS32: warning: ignoring '-mnan=2008' option because the 'mips32' architecture does not support it
-// CHECK-MIPS32R6: warning: ignoring '-mnan=legacy' option because the 'mips32r6' architecture does not support it
+// CHECK-MIPS32R6: warning: ignoring unsupported '-mnan=legacy' option and instead set to `-mnan=2008` option because the 'mips32r6' architecture supports it
 // CHECK-MIPS64: warning: ignoring '-mnan=2008' option because the 'mips64' architecture does not support it
-// CHECK-MIPS64R6: warning: ignoring '-mnan=legacy' option because the 'mips64r6' architecture does not support it
+// CHECK-MIPS64R6: warning: ignoring unsupported '-mnan=legacy' option and instead set to `-mnan=2008` option because the 'mips64r6' architecture supports it
 
 // This call creates a QNAN double with an empty payload.
 // The quiet bit is inverted in legacy mode: it is clear to indicate QNAN,

--- a/clang/test/Driver/mips-as.c
+++ b/clang/test/Driver/mips-as.c
@@ -246,7 +246,7 @@
 // RUN:   -fno-integrated-as -fno-pic -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=MIPS-NAN-LEGACY %s
 // MIPS-NAN-LEGACY: as{{(.exe)?}}"
-// MIPS-NAN-LEGACY-NOT: "{{[ A-Za-z\\\/]*}}as{{(.exe)?}}{{.*}}"-mnan={{.*}}"
+// MIPS-NAN-LEGACY: "-target-feature" "+nan2008" "-target-feature" "+abs2008"
 //
 // RUN: %clang --target=mips-linux-gnu -mfp64 -mfpxx -mfp32 -### \
 // RUN:   -fno-integrated-as -fno-pic -c %s 2>&1 \

--- a/clang/test/Driver/mips-features.c
+++ b/clang/test/Driver/mips-features.c
@@ -227,11 +227,10 @@
 // RUN:   | FileCheck --check-prefix=CHECK-ABSLEGACYNAN2008 %s
 // CHECK-ABSLEGACYNAN2008: "-target-feature" "+nan2008" "-target-feature" "-abs2008"
 //
-// -mnan=legacy
+// -mnan=2008
 // RUN: %clang --target=mips-linux-gnu -march=mips32r3 -### -c %s \
 // RUN:     -mnan=2008 -mnan=legacy 2>&1 \
-// RUN:   | FileCheck --check-prefix=CHECK-NANLEGACY %s
-// CHECK-NANLEGACY: "-target-feature" "-nan2008"
+// RUN:   | FileCheck --check-prefix=CHECK-NAN2008 %s
 //
 // -mabs=2008 on pre R2
 // RUN: %clang --target=mips-linux-gnu -march=mips32 -### -c %s \

--- a/clang/test/Driver/mips-integrated-as.s
+++ b/clang/test/Driver/mips-integrated-as.s
@@ -58,9 +58,7 @@
 // NAN-DEFAULT-NOT: "-target-feature" "{{[-+]}}nan2008"
 
 // RUN: %clang --target=mips-linux-gnu -### -fintegrated-as -c %s -mnan=legacy 2>&1 | \
-// RUN:   FileCheck -check-prefix=NAN-LEGACY %s
-// NAN-LEGACY: -cc1as
-// NAN-LEGACY: "-target-feature" "-nan2008"
+// RUN:   FileCheck -check-prefix=NAN-2008 %s
 
 // RUN: %clang --target=mips-linux-gnu -march=mips32r6 -### -fintegrated-as -c %s -mnan=2008 2>&1 | \
 // RUN:   FileCheck -check-prefix=NAN-2008 %s


### PR DESCRIPTION
Because we now do not really support legacy, so let us do the following:
    a. Convert -mnan=legacy to nan2008 when architecture support nan2008;
    b. Ignore -mnan=legacy when architecture does not support nan2008;
    c. All the above report a warning.

Fix #100495.