### PR TITLE
[JITLink][RISC-V] Support R_RISCV_SET_ULEB128/R_RISCV_SUB_ULEB128 for…

### DIFF
--- a/lld/ELF/InputSection.cpp
+++ b/lld/ELF/InputSection.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/LEB128.h"
 #include "llvm/Support/xxhash.h"
 #include <algorithm>
 #include <optional>

--- a/lld/ELF/Target.h
+++ b/lld/ELF/Target.h
@@ -326,15 +326,6 @@ inline void write64(Ctx &ctx, void *p, uint64_t v) {
   llvm::support::endian::write64(p, v, ctx.arg.endianness);
 }
 
-// Overwrite a ULEB128 value and keep the original length.
-inline uint64_t overwriteULEB128(uint8_t *bufLoc, uint64_t val) {
-  while (*bufLoc & 0x80) {
-    *bufLoc++ = 0x80 | (val & 0x7f);
-    val >>= 7;
-  }
-  *bufLoc = val;
-  return val;
-}
 } // namespace elf
 } // namespace lld
 

--- a/llvm/include/llvm/ExecutionEngine/JITLink/riscv.h
+++ b/llvm/include/llvm/ExecutionEngine/JITLink/riscv.h
@@ -221,6 +221,18 @@ enum EdgeKind_riscv : Edge::Kind {
   /// Fixup expression:
   ///   Fixup <- Fixup - Target + Addend
   NegDelta32,
+
+  /// Set ULEB128-encoded value
+  ///
+  /// Fixup expression:
+  ///   Fixup <- Target + Addend
+  R_RISCV_SET_ULEB128,
+
+  /// Subtract from ULEB128-encoded value
+  ///
+  /// Fixup expression:
+  ///   Fixup <- V - Target - Addend
+  R_RISCV_SUB_ULEB128,
 };
 
 /// Returns a string name for the given riscv edge. For debugging purposes

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -221,6 +221,16 @@ inline uint64_t decodeULEB128AndIncUnsafe(const uint8_t *&p) {
   return decodeULEB128AndInc(p, nullptr);
 }
 
+/// Overwrite a ULEB128 value and keep the original length.
+inline uint64_t overwriteULEB128(uint8_t *bufLoc, uint64_t val) {
+  while (*bufLoc & 0x80) {
+    *bufLoc++ = 0x80 | (val & 0x7f);
+    val >>= 7;
+  }
+  *bufLoc = val;
+  return val;
+}
+
 enum class LEB128Sign { Unsigned, Signed };
 
 template <LEB128Sign Sign, typename T, typename U = char,

--- a/llvm/lib/ExecutionEngine/JITLink/riscv.cpp
+++ b/llvm/lib/ExecutionEngine/JITLink/riscv.cpp
@@ -84,6 +84,10 @@ const char *getEdgeKindName(Edge::Kind K) {
     return "AlignRelaxable";
   case NegDelta32:
     return "NegDelta32";
+  case R_RISCV_SET_ULEB128:
+    return "R_RISCV_SET_ULEB128";
+  case R_RISCV_SUB_ULEB128:
+    return "R_RISCV_SUB_ULEB128";
   }
   return getGenericEdgeKindName(K);
 }

--- a/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_reloc_uleb128.s
+++ b/llvm/test/ExecutionEngine/JITLink/RISCV/ELF_reloc_uleb128.s
@@ -1,0 +1,21 @@
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc -triple=riscv64 -filetype=obj -o %t/riscv64_reloc_uleb128.o %s
+# RUN: llvm-mc -triple=riscv32 -filetype=obj -o %t/riscv32_reloc_uleb128.o %s
+# RUN: llvm-jitlink -noexec -check %s %t/riscv64_reloc_uleb128.o
+# RUN: llvm-jitlink -noexec -check %s %t/riscv32_reloc_uleb128.o
+
+# jitlink-check: *{4}(foo+8) = 0x180
+
+.global main
+main:
+  lw a0, foo
+
+.section ".text","",@progbits
+.type foo,@function
+foo:
+  nop
+  nop
+  .reloc ., R_RISCV_SET_ULEB128, foo+129
+  .reloc ., R_RISCV_SUB_ULEB128, foo+1
+  .uleb128 0x80
+  .size foo, 8


### PR DESCRIPTION
This patch is try to fix the issue https://github.com/llvm/llvm-project/issues/153775 . Now the LLVM JITLink don't support R_RISCV_SET_ULEB128 and R_RISCV_SUB_ULEB128 relocation type, so the bolt can't instrument the elf binary which has exception handling table.