### PR TITLE
[MLIR][NVVM] Print readable modifer (NFC)

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h
@@ -44,9 +44,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   case PTXRegisterMod::ReadWrite:
     return os << "ReadWrite";
   }
-  default:
-    llvm_unreachable("Unknown PTXRegisterMod value");
-  }
+  llvm_unreachable("Unknown PTXRegisterMod value");
 }
 } // namespace NVVM
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h
@@ -44,7 +44,9 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   case PTXRegisterMod::ReadWrite:
     return os << "ReadWrite";
   }
-  return os << "Unknown";
+  default:
+    llvm_unreachable("Unknown PTXRegisterMod value");
+  }
 }
 } // namespace NVVM
 } // namespace mlir

--- a/mlir/include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h
+++ b/mlir/include/mlir/Dialect/LLVMIR/BasicPtxBuilderInterface.h
@@ -33,6 +33,19 @@ enum class PTXRegisterMod {
   /// set read and write for the same operand.
   ReadWrite = 1,
 };
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     PTXRegisterMod mod) {
+  switch (mod) {
+  case PTXRegisterMod::Read:
+    return os << "Read";
+  case PTXRegisterMod::Write:
+    return os << "Write";
+  case PTXRegisterMod::ReadWrite:
+    return os << "ReadWrite";
+  }
+  return os << "Unknown";
+}
 } // namespace NVVM
 } // namespace mlir
 

--- a/mlir/lib/Conversion/NVVMToLLVM/NVVMToLLVM.cpp
+++ b/mlir/lib/Conversion/NVVMToLLVM/NVVMToLLVM.cpp
@@ -61,7 +61,7 @@ struct PtxLowering
 
     op.getAsmValues(rewriter, asmValues);
     for (auto &[asmValue, modifier] : asmValues) {
-      LDBG() << asmValue << "\t Modifier : " << &modifier;
+      LDBG() << asmValue << "\t Modifier : " << modifier;
       generator.insertValue(asmValue, modifier);
     }
 


### PR DESCRIPTION
Currently, modifier is printed as address, so it is not readable and not useful. This PR adds readable printing for it.