### PR TITLE
Revert "[lldb] Fallback to expression eval when Dump of variable fails in dwim-print"

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -18,14 +18,11 @@
 #include "lldb/Interpreter/OptionGroupValueObjectDisplay.h"
 #include "lldb/Target/StackFrame.h"
 #include "lldb/Utility/ConstString.h"
-#include "lldb/Utility/LLDBLog.h"
-#include "lldb/Utility/Log.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Error.h"
 
 #include <regex>
 
@@ -135,22 +132,27 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
   };
 
   // Dump `valobj` according to whether `po` was requested or not.
-  auto dump_val_object = [&](ValueObject &valobj) -> Error {
+  auto dump_val_object = [&](ValueObject &valobj) {
     if (is_po) {
       StreamString temp_result_stream;
-      if (Error err = valobj.Dump(temp_result_stream, dump_options))
-        return err;
+      if (llvm::Error error = valobj.Dump(temp_result_stream, dump_options)) {
+        result.AppendError(toString(std::move(error)));
+        return;
+      }
       llvm::StringRef output = temp_result_stream.GetString();
       maybe_add_hint(output);
       result.GetOutputStream() << output;
     } else {
-      if (Error err = valobj.Dump(result.GetOutputStream(), dump_options))
-        return err;
+      llvm::Error error =
+        valobj.Dump(result.GetOutputStream(), dump_options);
+      if (error) {
+        result.AppendError(toString(std::move(error)));
+        return;
+      }
     }
     m_interpreter.PrintWarningsIfNecessary(result.GetOutputStream(),
                                            m_cmd_name);
     result.SetStatus(eReturnStatusSuccessFinishResult);
-    return Error::success();
   };
 
   // First, try `expr` as a _limited_ frame variable expression path: only the
@@ -184,13 +186,8 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
                                      expr);
       }
 
-      Error err = dump_val_object(*valobj_sp);
-      if (!err)
-        return;
-
-      // Dump failed, continue on to expression evaluation.
-      LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions), std::move(err),
-                     "could not print frame variable '{1}': {0}", expr);
+      dump_val_object(*valobj_sp);
+      return;
     }
   }
 
@@ -199,14 +196,8 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     if (auto *state = target.GetPersistentExpressionStateForLanguage(language))
       if (auto var_sp = state->GetVariable(expr))
         if (auto valobj_sp = var_sp->GetValueObject()) {
-          Error err = dump_val_object(*valobj_sp);
-          if (!err)
-            return;
-
-          // Dump failed, continue on to expression evaluation.
-          LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions), std::move(err),
-                         "could not print persistent variable '{1}': {0}",
-                         expr);
+          dump_val_object(*valobj_sp);
+          return;
         }
 
   // Third, and lastly, try `expr` as a source expression to evaluate.
@@ -257,12 +248,10 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
       result.AppendNoteWithFormatv("ran `expression {0}{1}`", flags, expr);
     }
 
-    if (valobj_sp->GetError().GetError() != UserExpression::kNoResult) {
-      if (Error err = dump_val_object(*valobj_sp))
-        result.SetError(std::move(err));
-    } else {
+    if (valobj_sp->GetError().GetError() != UserExpression::kNoResult)
+      dump_val_object(*valobj_sp);
+    else
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
-    }
 
     if (suppress_result)
       if (auto result_var_sp =


### PR DESCRIPTION
Reverts llvm/llvm-project#151374

Superseded by https://github.com/llvm/llvm-project/pull/152417