### PR TITLE
[HLSL] Refactoring DXILABI.h to not depend on scope printer

### DIFF
--- a/llvm/include/llvm/Support/DXILABI.h
+++ b/llvm/include/llvm/Support/DXILABI.h
@@ -18,7 +18,6 @@
 #define LLVM_SUPPORT_DXILABI_H
 
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/ScopedPrinter.h"
 #include <cstdint>
 
 namespace llvm {
@@ -101,9 +100,8 @@ enum class SamplerFeedbackType : uint32_t {
 const unsigned MinWaveSize = 4;
 const unsigned MaxWaveSize = 128;
 
-LLVM_ABI ArrayRef<EnumEntry<ResourceClass>> getResourceClasses();
-
 LLVM_ABI StringRef getResourceClassName(ResourceClass RC);
+LLVM_ABI StringRef getResourceClassName(uint8_t RC);
 
 } // namespace dxil
 } // namespace llvm

--- a/llvm/include/llvm/Support/DXILABI.h
+++ b/llvm/include/llvm/Support/DXILABI.h
@@ -101,7 +101,6 @@ const unsigned MinWaveSize = 4;
 const unsigned MaxWaveSize = 128;
 
 LLVM_ABI StringRef getResourceClassName(ResourceClass RC);
-LLVM_ABI StringRef getResourceClassName(uint8_t RC);
 
 } // namespace dxil
 } // namespace llvm

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -94,7 +94,8 @@ static raw_ostream &operator<<(raw_ostream &OS,
 }
 
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
-  OS << dxil::getResourceClassName(llvm::to_underlying(Type));
+  OS << dxil::getResourceClassName(
+      dxil::ResourceClass(llvm::to_underlying(Type)));
   return OS;
 }
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -94,7 +94,7 @@ static raw_ostream &operator<<(raw_ostream &OS,
 }
 
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
-  OS << dxil::getResourceClassName(dxil::ResourceClass(Type));
+  OS << dxil::getResourceClassName(Type);
   return OS;
 }
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -95,7 +95,7 @@ static raw_ostream &operator<<(raw_ostream &OS,
 
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
   OS << dxil::getResourceClassName(
-      dxil::ResourceClass(llvm::to_underlying(Type)));
+      dxil::ResourceClass(Type));
   return OS;
 }
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -94,8 +94,7 @@ static raw_ostream &operator<<(raw_ostream &OS,
 }
 
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
-  OS << dxil::getResourceClassName(
-      dxil::ResourceClass(Type));
+  OS << dxil::getResourceClassName(dxil::ResourceClass(Type));
   return OS;
 }
 

--- a/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
+++ b/llvm/lib/Frontend/HLSL/HLSLRootSignature.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Frontend/HLSL/HLSLRootSignature.h"
+#include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ScopedPrinter.h"
 
 namespace llvm {
@@ -93,9 +94,7 @@ static raw_ostream &operator<<(raw_ostream &OS,
 }
 
 static raw_ostream &operator<<(raw_ostream &OS, const ClauseType &Type) {
-  OS << enumToStringRef(dxil::ResourceClass(llvm::to_underlying(Type)),
-                        dxil::getResourceClasses());
-
+  OS << dxil::getResourceClassName(llvm::to_underlying(Type));
   return OS;
 }
 

--- a/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
+++ b/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
@@ -119,7 +119,8 @@ MDNode *MetadataBuilder::BuildRootConstants(const RootConstants &Constants) {
 
 MDNode *MetadataBuilder::BuildRootDescriptor(const RootDescriptor &Descriptor) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName = dxil::getResourceClassName(to_underlying(Descriptor.Type));
+  StringRef ResName = dxil::getResourceClassName(
+      dxil::ResourceClass(to_underlying(Descriptor.Type)));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   SmallString<7> Name({"Root", ResName});
   Metadata *Operands[] = {
@@ -159,7 +160,8 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName = dxil::getResourceClassName(to_underlying(Clause.Type));
+  StringRef ResName = dxil::getResourceClassName(
+      dxil::ResourceClass(to_underlying(Clause.Type)));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   Metadata *Operands[] = {
       MDString::get(Ctx, ResName),

--- a/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
+++ b/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
@@ -120,7 +120,7 @@ MDNode *MetadataBuilder::BuildRootConstants(const RootConstants &Constants) {
 MDNode *MetadataBuilder::BuildRootDescriptor(const RootDescriptor &Descriptor) {
   IRBuilder<> Builder(Ctx);
   StringRef ResName = dxil::getResourceClassName(
-      dxil::ResourceClass(to_underlying(Descriptor.Type)));
+      dxil::ResourceClass(Descriptor.Type));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   SmallString<7> Name({"Root", ResName});
   Metadata *Operands[] = {
@@ -161,7 +161,7 @@ MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> Builder(Ctx);
   StringRef ResName = dxil::getResourceClassName(
-      dxil::ResourceClass(to_underlying(Clause.Type)));
+      dxil::ResourceClass(Clause.Type));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   Metadata *Operands[] = {
       MDString::get(Ctx, ResName),

--- a/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
+++ b/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Frontend/HLSL/RootSignatureValidations.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Metadata.h"
+#include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ScopedPrinter.h"
 
 using namespace llvm;
@@ -119,9 +120,7 @@ MDNode *MetadataBuilder::BuildRootConstants(const RootConstants &Constants) {
 
 MDNode *MetadataBuilder::BuildRootDescriptor(const RootDescriptor &Descriptor) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName =
-      enumToStringRef(dxil::ResourceClass(to_underlying(Descriptor.Type)),
-                      dxil::getResourceClasses());
+  StringRef ResName = dxil::getResourceClassName(to_underlying(Descriptor.Type));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   SmallString<7> Name({"Root", ResName});
   Metadata *Operands[] = {
@@ -161,9 +160,7 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName =
-      enumToStringRef(dxil::ResourceClass(to_underlying(Clause.Type)),
-                      dxil::getResourceClasses());
+  StringRef ResName = dxil::getResourceClassName(to_underlying(Clause.Type));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   Metadata *Operands[] = {
       MDString::get(Ctx, ResName),

--- a/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
+++ b/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
@@ -119,8 +119,8 @@ MDNode *MetadataBuilder::BuildRootConstants(const RootConstants &Constants) {
 
 MDNode *MetadataBuilder::BuildRootDescriptor(const RootDescriptor &Descriptor) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName = dxil::getResourceClassName(
-      dxil::ResourceClass(Descriptor.Type));
+  StringRef ResName =
+      dxil::getResourceClassName(dxil::ResourceClass(Descriptor.Type));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   SmallString<7> Name({"Root", ResName});
   Metadata *Operands[] = {
@@ -160,8 +160,8 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName = dxil::getResourceClassName(
-      dxil::ResourceClass(Clause.Type));
+  StringRef ResName =
+      dxil::getResourceClassName(dxil::ResourceClass(Clause.Type));
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   Metadata *Operands[] = {
       MDString::get(Ctx, ResName),

--- a/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
+++ b/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
@@ -15,7 +15,6 @@
 #include "llvm/Frontend/HLSL/RootSignatureValidations.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Metadata.h"
-#include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ScopedPrinter.h"
 
 using namespace llvm;

--- a/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
+++ b/llvm/lib/Frontend/HLSL/RootSignatureMetadata.cpp
@@ -15,6 +15,7 @@
 #include "llvm/Frontend/HLSL/RootSignatureValidations.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Metadata.h"
+#include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ScopedPrinter.h"
 
 using namespace llvm;
@@ -160,8 +161,7 @@ MDNode *MetadataBuilder::BuildDescriptorTable(const DescriptorTable &Table) {
 MDNode *MetadataBuilder::BuildDescriptorTableClause(
     const DescriptorTableClause &Clause) {
   IRBuilder<> Builder(Ctx);
-  StringRef ResName =
-      dxil::getResourceClassName(dxil::ResourceClass(Clause.Type));
+  StringRef ResName = dxil::getResourceClassName(Clause.Type);
   assert(!ResName.empty() && "Provided an invalid Resource Class");
   Metadata *Operands[] = {
       MDString::get(Ctx, ResName),

--- a/llvm/lib/Support/DXILABI.cpp
+++ b/llvm/lib/Support/DXILABI.cpp
@@ -16,7 +16,6 @@
 
 #include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ScopedPrinter.h"
-
 using namespace llvm;
 
 static const EnumEntry<dxil::ResourceClass> ResourceClassNames[] = {

--- a/llvm/lib/Support/DXILABI.cpp
+++ b/llvm/lib/Support/DXILABI.cpp
@@ -15,24 +15,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/DXILABI.h"
-#include "llvm/Support/ScopedPrinter.h"
+#include "llvm/Support/ErrorHandling.h"
 using namespace llvm;
 
-static const EnumEntry<dxil::ResourceClass> ResourceClassNames[] = {
-    {"SRV", llvm::dxil::ResourceClass::SRV},
-    {"UAV", llvm::dxil::ResourceClass::UAV},
-    {"CBV", llvm::dxil::ResourceClass::CBuffer},
-    {"Sampler", llvm::dxil::ResourceClass::Sampler},
-};
-
-ArrayRef<EnumEntry<llvm::dxil::ResourceClass>> getResourceClasses() {
-  return ArrayRef(ResourceClassNames);
-}
-
 StringRef dxil::getResourceClassName(dxil::ResourceClass RC) {
-  return enumToStringRef(RC, getResourceClasses());
-}
-
-StringRef dxil::getResourceClassName(uint8_t RC) {
-  return enumToStringRef(ResourceClass(RC), getResourceClasses());
+  switch (RC) {
+  case dxil::ResourceClass::SRV:
+    return "SRV";
+  case dxil::ResourceClass::UAV:
+    return "UAV";
+  case dxil::ResourceClass::CBuffer:
+    return "CBV";
+  case dxil::ResourceClass::Sampler:
+    return "Sampler";
+  }
+  llvm_unreachable("Invalid ResourceClass enum value");
 }

--- a/llvm/lib/Support/DXILABI.cpp
+++ b/llvm/lib/Support/DXILABI.cpp
@@ -16,6 +16,7 @@
 
 #include "llvm/Support/DXILABI.h"
 #include "llvm/Support/ScopedPrinter.h"
+
 using namespace llvm;
 
 static const EnumEntry<dxil::ResourceClass> ResourceClassNames[] = {
@@ -25,10 +26,14 @@ static const EnumEntry<dxil::ResourceClass> ResourceClassNames[] = {
     {"Sampler", llvm::dxil::ResourceClass::Sampler},
 };
 
-ArrayRef<EnumEntry<llvm::dxil::ResourceClass>> dxil::getResourceClasses() {
+ArrayRef<EnumEntry<llvm::dxil::ResourceClass>> getResourceClasses() {
   return ArrayRef(ResourceClassNames);
 }
 
 StringRef dxil::getResourceClassName(dxil::ResourceClass RC) {
   return enumToStringRef(RC, getResourceClasses());
+}
+
+StringRef dxil::getResourceClassName(uint8_t RC) {
+  return enumToStringRef(ResourceClass(RC), getResourceClasses());
 }


### PR DESCRIPTION
This patch refactors DXILABI to remove the dependency on scope printer. 
Closes: #153827