### PR TITLE
[Clang][CodeGen][Sanitizers] Add extra context for trap messages

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -38,12 +38,14 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/OpenMP/OMPIRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/Utils/SanitizerStats.h"
 #include <optional>
+#include <string>
 
 namespace llvm {
 class BasicBlock;
@@ -635,6 +637,14 @@ public:
   /// attribute can be added. \p HasConstantCond indicates whether the branch
   /// condition is a known constant.
   bool checkIfLoopMustProgress(const Expr *, bool HasEmptyBody);
+
+  std::string BuildSanitizerTrapMessage(SanitizerHandler Handler,
+                                        QualType LhsTy, QualType OpType,
+                                        bool IsLeftShift = false,
+                                        bool isSigned = false,
+                                        std::string ReasonStr = "",
+                                        bool IsDivideByZero = false,
+                                        bool IsTruncation = false);
 
   const CodeGen::CGBlockInfo *BlockInfo = nullptr;
   llvm::Value *BlockPointer = nullptr;
@@ -5273,7 +5283,7 @@ public:
   EmitCheck(ArrayRef<std::pair<llvm::Value *, SanitizerKind::SanitizerOrdinal>>
                 Checked,
             SanitizerHandler Check, ArrayRef<llvm::Constant *> StaticArgs,
-            ArrayRef<llvm::Value *> DynamicArgs);
+            ArrayRef<llvm::Value *> DynamicArgs, std::string TrapMessage = "");
 
   /// Emit a slow path cross-DSO CFI check which calls __cfi_slowpath
   /// if Cond if false.
@@ -5289,7 +5299,7 @@ public:
   /// Create a basic block that will call the trap intrinsic, and emit a
   /// conditional branch to it, for the -ftrapv checks.
   void EmitTrapCheck(llvm::Value *Checked, SanitizerHandler CheckHandlerID,
-                     bool NoMerge = false);
+                     bool NoMerge = false, std::string TrapMesage = "");
 
   /// Emit a call to trap or debugtrap and attach function attribute
   /// "trap-func-name" if specified.

--- a/clang/test/CodeGen/ubsan-trap-reason-add-overflow.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-add-overflow.c
@@ -1,9 +1,19 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
-// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s
+// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=SIO
 
-int add_overflow(int a, int b) { return a + b; }
+int signed_add_overflow(int a, int b) { return a + b; }
 
-// CHECK-LABEL: @add_overflow
-// CHECK: call void @llvm.ubsantrap(i8 0) {{.*}}!dbg [[LOC:![0-9]+]]
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer addition overflowed"
+// SIO-LABEL: @signed_add_overflow
+// SIO: call void @llvm.ubsantrap(i8 0) {{.*}}!dbg [[LOC:![0-9]+]]
+// SIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// SIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Signed integer addition overflow on type 'int'"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: -fsanitize=unsigned-integer-overflow -fsanitize-trap=unsigned-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=UIO
+
+unsigned int unsigned_add_overflow(unsigned int a, unsigned int b) { return a + b; }
+
+// UIO-LABEL: @unsigned_add_overflow
+// UIO: call void @llvm.ubsantrap(i8 0) {{.*}}!dbg [[LOC:![0-9]+]]
+// UIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// UIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Unsigned integer addition overflow on type 'unsigned int'"

--- a/clang/test/CodeGen/ubsan-trap-reason-div-rem-overflow.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-div-rem-overflow.c
@@ -1,9 +1,17 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
-// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s
+// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=SIO
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: -fsanitize=integer-divide-by-zero -fsanitize-trap=integer-divide-by-zero -emit-llvm %s -o - | FileCheck %s --check-prefix=DBZ
 
 int div_rem_overflow(int a, int b) { return a / b; }
 
-// CHECK-LABEL: @div_rem_overflow
-// CHECK: call void @llvm.ubsantrap(i8 3) {{.*}}!dbg [[LOC:![0-9]+]]
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer divide or remainder overflowed"
+// SIO-LABEL: @div_rem_overflow
+// SIO: call void @llvm.ubsantrap(i8 3) {{.*}}!dbg [[LOC:![0-9]+]]
+// SIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// SIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Signed integer division overflow on type 'int'"
+
+// DBZ-LABEL: @div_rem_overflow
+// DBZ: call void @llvm.ubsantrap(i8 3) {{.*}}!dbg [[LOC:![0-9]+]]
+// DBZ: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// DBZ: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Division by zero on type 'int'"

--- a/clang/test/CodeGen/ubsan-trap-reason-flag.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-flag.c
@@ -15,7 +15,7 @@ int add_overflow(int a, int b) { return a + b; }
 // ANNOTATE-LABEL: @add_overflow
 // ANNOTATE: call void @llvm.ubsantrap(i8 0) {{.*}}!dbg [[LOC:![0-9]+]]
 // ANNOTATE: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// ANNOTATE: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer addition overflowed"
+// ANNOTATE: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Signed integer addition overflow on type 'int'"
 
 // NO-ANNOTATE-LABEL: @add_overflow
 // NO-ANNOTATE: call void @llvm.ubsantrap(i8 0) {{.*}}!dbg [[LOC:![0-9]+]]

--- a/clang/test/CodeGen/ubsan-trap-reason-float-cast-overflow.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-float-cast-overflow.c
@@ -6,4 +6,4 @@ int float_cast_overflow(float x) { return (int)x; }
 // CHECK-LABEL: @float_cast_overflow
 // CHECK: call void @llvm.ubsantrap(i8 5) {{.*}}!dbg [[LOC:![0-9]+]]
 // CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Floating-point to integer conversion overflowed"
+// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Float cast overflow converting from floating-point type 'float' to integer type 'int'"

--- a/clang/test/CodeGen/ubsan-trap-reason-function-type-mismatch.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-function-type-mismatch.c
@@ -15,4 +15,4 @@ int function_type_mismatch(void) {
 // CHECK-LABEL: @function_type_mismatch
 // CHECK: call void @llvm.ubsantrap(i8 6) {{.*}}!dbg [[LOC:![0-9]+]]
 // CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Function called with mismatched signature"
+// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Call through function pointer of type 'int (int)' with an incompatible target"

--- a/clang/test/CodeGen/ubsan-trap-reason-implicit-conversion.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-implicit-conversion.c
@@ -1,11 +1,43 @@
-// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
-// RUN: -fsanitize=implicit-unsigned-integer-truncation -fsanitize-trap=implicit-unsigned-integer-truncation -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 -fsanitize=implicit-signed-integer-truncation \
+// RUN: -fsanitize-trap=implicit-signed-integer-truncation -emit-llvm %s -o - | FileCheck %s --check-prefix=SIC
 
-unsigned long long big;
+long long signedBig;
 
-unsigned implicit_conversion(void) { return big; }
+int signed_implicit_conversion_truncation(void) { return signedBig; }
 
-// CHECK-LABEL: @implicit_conversion
-// CHECK: call void @llvm.ubsantrap(i8 7) {{.*}}!dbg [[LOC:![0-9]+]]
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Implicit integer conversion overflowed or lost data"
+// SIC-LABEL: @signed_implicit_conversion_truncation
+// SIC: call void @llvm.ubsantrap(i8 7) {{.*}}!dbg [[LOC:![0-9]+]]
+// SIC: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// SIC: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Implicit signed conversion from 'long long' to 'int' caused truncation"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 -fsanitize=implicit-unsigned-integer-truncation \
+// RUN: -fsanitize-trap=implicit-unsigned-integer-truncation -emit-llvm %s -o - | FileCheck %s --check-prefix=UIC
+
+unsigned long long unsignedBig;
+
+unsigned unsigned_implicit_conversion_truncation(void) { return unsignedBig; }
+
+// UIC-LABEL: @unsigned_implicit_conversion_truncation
+// UIC: call void @llvm.ubsantrap(i8 7) {{.*}}!dbg [[LOC:![0-9]+]]
+// UIC: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// UIC: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Implicit unsigned conversion from 'unsigned long long' to 'unsigned int' caused truncation"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 -fsanitize=implicit-integer-sign-change \
+// RUN: -fsanitize-trap=implicit-integer-sign-change -emit-llvm %s -o - | FileCheck %s --check-prefix=ISCUFS
+
+unsigned to_unsigned_from_signed(int x) { return x; }
+
+// ISCUFS-LABEL: @to_unsigned_from_signed
+// ISCUFS: call void @llvm.ubsantrap(i8 7) {{.*}}!dbg [[LOC1:![0-9]+]]
+// ISCUFS: [[LOC1]] = !DILocation(line: 0, scope: [[MSG1:![0-9]+]], {{.+}})
+// ISCUFS: [[MSG1]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Implicit conversion from 'int' to 'unsigned int' caused sign-change"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 -fsanitize=implicit-integer-sign-change \
+// RUN: -fsanitize-trap=implicit-integer-sign-change -emit-llvm %s -o - | FileCheck %s --check-prefix=ISCSFU
+
+int to_signed_from_unsigned(unsigned x) { return x; }
+
+// ISCSFU-LABEL: @to_signed_from_unsigned
+// ISCSFU: call void @llvm.ubsantrap(i8 7) {{.*}}!dbg [[LOC2:![0-9]+]]
+// ISCSFU: [[LOC2]] = !DILocation(line: 0, scope: [[MSG2:![0-9]+]], {{.+}})
+// ISCSFU: [[MSG2]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Implicit conversion from 'unsigned int' to 'int' caused sign-change"

--- a/clang/test/CodeGen/ubsan-trap-reason-mul-overflow.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-mul-overflow.c
@@ -1,9 +1,19 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
-// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s
+// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=SIO
 
-int mul_overflow(int a, int b) { return a * b; }
+int signed_mul_overflow(int a, int b) { return a * b; }
 
-// CHECK-LABEL: @mul_overflow
-// CHECK: call void @llvm.ubsantrap(i8 12) {{.*}}!dbg [[LOC:![0-9]+]]
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer multiplication overflowed"
+// SIO-LABEL: @signed_mul_overflow
+// SIO: call void @llvm.ubsantrap(i8 12) {{.*}}!dbg [[LOC:![0-9]+]]
+// SIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// SIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Signed integer multiplication overflow on type 'int'"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: -fsanitize=unsigned-integer-overflow -fsanitize-trap=unsigned-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=UIO
+
+unsigned unsigned_mul_overflow(unsigned a, unsigned b) { return a * b; }
+
+// UIO-LABEL: @unsigned_mul_overflow
+// UIO: call void @llvm.ubsantrap(i8 12) {{.*}}!dbg [[LOC:![0-9]+]]
+// UIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// UIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Unsigned integer multiplication overflow on type 'unsigned int'"

--- a/clang/test/CodeGen/ubsan-trap-reason-negate-overflow.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-negate-overflow.c
@@ -9,4 +9,4 @@ int negate_overflow() {
 // CHECK-LABEL: @negate_overflow
 // CHECK: call void @llvm.ubsantrap(i8 13) {{.*}}!dbg [[LOC:![0-9]+]]
 // CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer negation overflowed"
+// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer negation overflow on type 'int'"

--- a/clang/test/CodeGen/ubsan-trap-reason-shift-out-of-bounds.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-shift-out-of-bounds.c
@@ -1,12 +1,25 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
-// RUN: -fsanitize=shift-base -fsanitize-trap=shift-base -emit-llvm %s -o - | FileCheck %s
+// RUN: -fsanitize=shift-exponent -fsanitize-trap=shift-exponent -emit-llvm %s -o - | FileCheck %s --check-prefix=RS
 
-int shift_out_of_bounds(void) {
+int right_shift_out_of_bounds(void) {
+  int sh = 32;
+  return 1 >> sh;
+}
+
+// RS-LABEL: @right_shift_out_of_bounds
+// RS: call void @llvm.ubsantrap(i8 20) {{.*}}!dbg [[LOC:![0-9]+]]
+// RS: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// RS: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Right shift is too large for 32-bit type 'int'"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: -fsanitize=shift-exponent -fsanitize-trap=shift-exponent -emit-llvm %s -o - | FileCheck %s --check-prefix=LS
+
+int left_shift_out_of_bounds(void) {
   int sh = 32;
   return 1 << sh;
 }
 
-// CHECK-LABEL: @shift_out_of_bounds
-// CHECK: call void @llvm.ubsantrap(i8 20) {{.*}}!dbg [[LOC:![0-9]+]]
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Shift exponent is too large for the type"
+// LS-LABEL: @left_shift_out_of_bounds
+// LS: call void @llvm.ubsantrap(i8 20) {{.*}}!dbg [[LOC:![0-9]+]]
+// LS: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// LS: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Left shift is too large for 32-bit type 'int'"

--- a/clang/test/CodeGen/ubsan-trap-reason-sub-overflow.c
+++ b/clang/test/CodeGen/ubsan-trap-reason-sub-overflow.c
@@ -1,9 +1,19 @@
 // RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
-// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s
+// RUN: -fsanitize=signed-integer-overflow -fsanitize-trap=signed-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=SIO
 
-int sub_overflow(int a, int b) { return a - b; }
+int signed_sub_overflow(int a, int b) { return a - b; }
 
-// CHECK-LABEL: @sub_overflow
-// CHECK: call void @llvm.ubsantrap(i8 21) {{.*}}!dbg [[LOC:![0-9]+]]
-// CHECK: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
-// CHECK: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Integer subtraction overflowed"
+// SIO-LABEL: @signed_sub_overflow
+// SIO: call void @llvm.ubsantrap(i8 21) {{.*}}!dbg [[LOC:![0-9]+]]
+// SIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// SIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Signed integer subtraction overflow on type 'int'"
+
+// RUN: %clang_cc1 -triple arm64-apple-macosx14.0.0 -O0 -debug-info-kind=standalone -dwarf-version=5 \
+// RUN: -fsanitize=unsigned-integer-overflow -fsanitize-trap=unsigned-integer-overflow -emit-llvm %s -o - | FileCheck %s --check-prefix=UIO
+
+unsigned int unsigned_sub_overflow(unsigned int a, unsigned int b) { return a - b; }
+
+// UIO-LABEL: @unsigned_sub_overflow
+// UIO: call void @llvm.ubsantrap(i8 21) {{.*}}!dbg [[LOC:![0-9]+]]
+// UIO: [[LOC]] = !DILocation(line: 0, scope: [[MSG:![0-9]+]], {{.+}})
+// UIO: [[MSG]] = distinct !DISubprogram(name: "__clang_trap_msg$Undefined Behavior Sanitizer$Unsigned integer subtraction overflow on type 'unsigned int'"


### PR DESCRIPTION
Serves as an improvement to the current [`-fsanitize-debug-trap-reasons`](https://github.com/llvm/llvm-project/pull/145967) by providing additional context to the user regarding the trap reason.

Part of a GSoC 2025 Project.