### PR TITLE
[llvm] Ignore coding assistant artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,11 @@ autoconf/autom4te.cache
 # CLion project configuration
 /.idea
 /cmake-build*
+# Coding assistants' stuff
+/CLAUDE.md
+/.claude/
+/GEMINI.md
+/.gemini/
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).


### PR DESCRIPTION
Now that "vibe coding" is a thing, ignore the documentation artifacts that coding assistants, like Claude and Gemini, use to retain coding workflows and other metadata.