### PR TITLE
compiler-rt: Make the tests pass on AArch64 and with page size != 4096.

### DIFF
--- a/compiler-rt/lib/gwp_asan/tests/basic.cpp
+++ b/compiler-rt/lib/gwp_asan/tests/basic.cpp
@@ -65,11 +65,12 @@ TEST_F(DefaultGuardedPoolAllocator, NonPowerOfTwoAlignment) {
 
 // Added multi-page slots? You'll need to expand this test.
 TEST_F(DefaultGuardedPoolAllocator, TooBigForSinglePageSlots) {
-  EXPECT_EQ(nullptr, GPA.allocate(0x1001, 0));
-  EXPECT_EQ(nullptr, GPA.allocate(0x1001, 1));
-  EXPECT_EQ(nullptr, GPA.allocate(0x1001, 0x1000));
-  EXPECT_EQ(nullptr, GPA.allocate(1, 0x2000));
-  EXPECT_EQ(nullptr, GPA.allocate(0, 0x2000));
+  size_t PageSize = sysconf(_SC_PAGESIZE);
+  EXPECT_EQ(nullptr, GPA.allocate(PageSize + 1, 0));
+  EXPECT_EQ(nullptr, GPA.allocate(PageSize + 1, 1));
+  EXPECT_EQ(nullptr, GPA.allocate(PageSize + 1, PageSize));
+  EXPECT_EQ(nullptr, GPA.allocate(1, 2 * PageSize));
+  EXPECT_EQ(nullptr, GPA.allocate(0, 2 * PageSize));
 }
 
 TEST_F(CustomGuardedPoolAllocator, AllocAllSlots) {

--- a/compiler-rt/lib/gwp_asan/tests/never_allocated.cpp
+++ b/compiler-rt/lib/gwp_asan/tests/never_allocated.cpp
@@ -13,8 +13,10 @@
 #include "gwp_asan/tests/harness.h"
 
 TEST_P(BacktraceGuardedPoolAllocatorDeathTest, NeverAllocated) {
+  size_t PageSize = sysconf(_SC_PAGESIZE);
+
   SCOPED_TRACE("");
-  void *Ptr = GPA.allocate(0x1000);
+  void *Ptr = GPA.allocate(PageSize);
   GPA.deallocate(Ptr);
 
   std::string DeathNeedle =
@@ -23,7 +25,7 @@ TEST_P(BacktraceGuardedPoolAllocatorDeathTest, NeverAllocated) {
   // Trigger a guard page in a completely different slot that's never allocated.
   // Previously, there was a bug that this would result in nullptr-dereference
   // in the posix crash handler.
-  char *volatile NeverAllocatedPtr = static_cast<char *>(Ptr) + 0x3000;
+  char *volatile NeverAllocatedPtr = static_cast<char *>(Ptr) + 3 * PageSize;
   if (!Recoverable) {
     EXPECT_DEATH(*NeverAllocatedPtr = 0, DeathNeedle);
     return;
@@ -37,8 +39,8 @@ TEST_P(BacktraceGuardedPoolAllocatorDeathTest, NeverAllocated) {
   GetOutputBuffer().clear();
   for (size_t i = 0; i < 100; ++i) {
     *NeverAllocatedPtr = 0;
-    *(NeverAllocatedPtr + 0x2000) = 0;
-    *(NeverAllocatedPtr + 0x3000) = 0;
+    *(NeverAllocatedPtr + 2 * PageSize) = 0;
+    *(NeverAllocatedPtr + 3 * PageSize) = 0;
     ASSERT_TRUE(GetOutputBuffer().empty());
   }
 

--- a/compiler-rt/test/asan/TestCases/Linux/release_to_os_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/release_to_os_test.cpp
@@ -6,6 +6,7 @@
 // RUN: %env_asan_opts=allocator_release_to_os_interval_ms=-1 %run %t force 2>&1 | FileCheck %s --check-prefix=FORCE_RELEASE
 
 // REQUIRES: x86_64-target-arch
+// REQUIRES: page-size-4096
 
 #include <algorithm>
 #include <assert.h>

--- a/compiler-rt/test/cfi/cross-dso/lit.local.cfg.py
+++ b/compiler-rt/test/cfi/cross-dso/lit.local.cfg.py
@@ -12,3 +12,7 @@ if root.target_os not in ["Linux", "FreeBSD", "NetBSD"]:
 # Android O (API level 26) has support for cross-dso cfi in libdl.so.
 if config.android and "android-26" not in config.available_features:
     config.unsupported = True
+
+# The runtime library only supports 4K pages.
+if "page-size-4096" not in config.available_features:
+    config.unsupported = True

--- a/compiler-rt/test/dfsan/atomic.cpp
+++ b/compiler-rt/test/dfsan/atomic.cpp
@@ -1,11 +1,8 @@
-// RUN: %clangxx_dfsan %s -fno-exceptions -D_GLIBCXX_NO_ASSERTIONS -o %t && %run %t
-// RUN: %clangxx_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 %s -fno-exceptions -D_GLIBCXX_NO_ASSERTIONS -o %t && %run %t
+// RUN: %clangxx_dfsan %s -fno-exceptions -o %t && %run %t
+// RUN: %clangxx_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 %s -fno-exceptions -o %t && %run %t
 //
 // Use -fno-exceptions to turn off exceptions to avoid instrumenting
 // __cxa_begin_catch, std::terminate and __gxx_personality_v0.
-//
-// Use -D_GLIBCXX_NO_ASSERTIONS to avoid depending on
-// std::__glibcxx_assert_fail.
 //
 // TODO: Support builtin atomics. For example, https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
 // DFSan instrumentation pass cannot identify builtin callsites yet.

--- a/compiler-rt/test/dfsan/atomic.cpp
+++ b/compiler-rt/test/dfsan/atomic.cpp
@@ -1,8 +1,11 @@
-// RUN: %clangxx_dfsan %s -fno-exceptions -o %t && %run %t
-// RUN: %clangxx_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 %s -fno-exceptions -o %t && %run %t
+// RUN: %clangxx_dfsan %s -fno-exceptions -D_GLIBCXX_NO_ASSERTIONS -o %t && %run %t
+// RUN: %clangxx_dfsan -DORIGIN_TRACKING -mllvm -dfsan-track-origins=1 %s -fno-exceptions -D_GLIBCXX_NO_ASSERTIONS -o %t && %run %t
 //
 // Use -fno-exceptions to turn off exceptions to avoid instrumenting
 // __cxa_begin_catch, std::terminate and __gxx_personality_v0.
+//
+// Use -D_GLIBCXX_NO_ASSERTIONS to avoid depending on
+// std::__glibcxx_assert_fail.
 //
 // TODO: Support builtin atomics. For example, https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html
 // DFSan instrumentation pass cannot identify builtin callsites yet.

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -965,13 +965,20 @@ if config.memprof_shadow_scale:
 else:
     config.available_features.add("memprof-shadow-scale-3")
 
+
 def target_page_size():
     try:
-        proc = subprocess.Popen(f"{emulator or ""} python3", shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        proc = subprocess.Popen(
+            f"{emulator or ""} python3",
+            shell=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
         out, err = proc.communicate(b'import os; print(os.sysconf("SC_PAGESIZE"))')
         return int(out)
     except:
         return 4096
+
 
 config.available_features.add(f"page-size-{target_page_size()}")
 

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -965,6 +965,16 @@ if config.memprof_shadow_scale:
 else:
     config.available_features.add("memprof-shadow-scale-3")
 
+def target_page_size():
+    try:
+        proc = subprocess.Popen(f"{emulator or ""} python3", shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        out, err = proc.communicate(b'import os; print(os.sysconf("SC_PAGESIZE"))')
+        return int(out)
+    except:
+        return 4096
+
+config.available_features.add(f"page-size-{target_page_size()}")
+
 if config.expensive_checks:
     config.available_features.add("expensive_checks")
 

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -969,7 +969,7 @@ else:
 def target_page_size():
     try:
         proc = subprocess.Popen(
-            f"{emulator or ""} python3",
+            f"{emulator or ''} python3",
             shell=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,

--- a/compiler-rt/test/msan/dtls_test.c
+++ b/compiler-rt/test/msan/dtls_test.c
@@ -11,6 +11,7 @@
 
    // Reports use-of-uninitialized-value, not analyzed
    XFAIL: target={{.*netbsd.*}}
+   XFAIL: aarch64-target-arch
 
 */
 

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/odd_stack_size.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/odd_stack_size.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx -O1 %s -o %t && %run %t
+// REQUIRES: page-size-4096
 // UNSUPPORTED: android
 
 // Fail on powerpc64 bots with:

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/release_to_os_test.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/release_to_os_test.cpp
@@ -11,6 +11,9 @@
 // FIXME: This mode uses 32bit allocator without purge.
 // UNSUPPORTED: hwasan-aliasing
 
+// Page size is hardcoded below, but test still fails even if not hardcoded.
+// REQUIRES: page-size-4096
+
 #include <algorithm>
 #include <assert.h>
 #include <fcntl.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/resize_tls_dynamic.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/resize_tls_dynamic.cpp
@@ -11,6 +11,9 @@
 // FIXME: Investigate
 // UNSUPPORTED: target=powerpc64{{.*}}
 
+// Fails because AArch64 uses TLSDESC instead of __tls_get_addr.
+// UNSUPPORTED: aarch64-target-arch
+
 #include <string.h>
 
 #ifndef BUILD_DSO

--- a/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_get_addr.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Linux/tls_get_addr.c
@@ -13,6 +13,9 @@
 // FIXME: Fails for unknown reasons.
 // UNSUPPORTED: powerpc64le-target-arch
 
+// Fails because AArch64 uses TLSDESC instead of __tls_get_addr.
+// UNSUPPORTED: aarch64-target-arch
+
 #ifndef BUILD_SO
 #  include <assert.h>
 #  include <dlfcn.h>


### PR DESCRIPTION
This makes the tests pass on my AArch64 machine with 16K pages.

Not sure why some of the AArch64-specific test failures don't seem to
occur on sanitizer-aarch64-linux. I could also reproduce them by running
buildbot_cmake.sh on my machine.
