### PR TITLE
[mlir][python] handle more undefined symbols not covered by nanobind

### DIFF
--- a/mlir/cmake/modules/AddMLIRPython.cmake
+++ b/mlir/cmake/modules/AddMLIRPython.cmake
@@ -704,7 +704,12 @@ function(add_mlir_python_extension libname extname)
       # NanobindAdaptors.h uses PyClassMethod_New to build `pure_subclass`es but nanobind
       # doesn't declare this API as undefined in its linker flags. So we need to declare it as such
       # for downstream users that do not do something like `-undefined dynamic_lookup`.
-      target_link_options(${libname} PUBLIC "LINKER:-U,_PyClassMethod_New")
+      # Same for the rest.
+      target_link_options(${libname} PUBLIC
+        "LINKER:-U,_PyClassMethod_New"
+        "LINKER:-U,_PyCode_Addr2Location"
+        "LINKER:-U,_PyFrame_GetLasti"
+      )
     endif()
   endif()
 

--- a/mlir/lib/Bindings/Python/IRCore.cpp
+++ b/mlir/lib/Bindings/Python/IRCore.cpp
@@ -2810,7 +2810,7 @@ private:
 
 // bpo-42262 added Py_XNewRef()
 #if !defined(Py_XNewRef)
-PyObject *_Py_XNewRef(PyObject *obj) {
+[[maybe_unused]] PyObject *_Py_XNewRef(PyObject *obj) {
   Py_XINCREF(obj);
   return obj;
 }
@@ -2819,7 +2819,7 @@ PyObject *_Py_XNewRef(PyObject *obj) {
 
 // bpo-42262 added Py_NewRef()
 #if !defined(Py_NewRef)
-PyObject *_Py_NewRef(PyObject *obj) {
+[[maybe_unused]] PyObject *_Py_NewRef(PyObject *obj) {
   Py_INCREF(obj);
   return obj;
 }


### PR DESCRIPTION
Introduced (but omitted from this CMake) in https://github.com/llvm/llvm-project/pull/151246.