### PR TITLE
[Clang][NFC] Avoid repeating copy of std::string in lambda implementation

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -205,7 +205,7 @@ public:
       std::vector<P1689ModuleInfo> Requires) override {
     ModuleName = Provided ? Provided->ModuleName : "";
     llvm::transform(Requires, std::back_inserter(NamedModuleDeps),
-                    [](const auto &Module) { return Module.ModuleName; });
+                    [](const auto &Module) -> const auto & { return Module.ModuleName; });
   }
 
   TranslationUnitDeps takeTranslationUnitDeps();

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -204,8 +204,9 @@ public:
       std::optional<P1689ModuleInfo> Provided,
       std::vector<P1689ModuleInfo> Requires) override {
     ModuleName = Provided ? Provided->ModuleName : "";
-    llvm::transform(Requires, std::back_inserter(NamedModuleDeps),
-                    [](const auto &Module) -> const auto & { return Module.ModuleName; });
+    llvm::transform(
+        Requires, std::back_inserter(NamedModuleDeps),
+        [](const auto &Module) -> const auto & { return Module.ModuleName; });
   }
 
   TranslationUnitDeps takeTranslationUnitDeps();


### PR DESCRIPTION
Static analysis flagged this code because it will cause unneeded copies of std::string. This fix is merely to use const auto & in the trailing return type.