### PR TITLE
[clang-tidy][docs] Add description of "clang-diagnostic-error"

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/index.rst
+++ b/clang-tools-extra/docs/clang-tidy/index.rst
@@ -111,6 +111,13 @@ Diagnostics which have a corresponding warning option, are named
 ``-Wliteral-conversion`` will be reported with check name
 ``clang-diagnostic-literal-conversion``.
 
+Clang compiler errors (such as syntax errors, semantic errors, or other failures
+that prevent Clang from compiling the code) are reported with the check name
+``clang-diagnostic-error``. These represent fundamental compilation failures that
+must be fixed before :program:`clang-tidy` can perform its analysis. Unlike other
+diagnostics, ``clang-diagnostic-error`` cannot be disabled, as :program:`clang-tidy`
+requires valid code to function.
+
 The ``-fix`` flag instructs :program:`clang-tidy` to fix found errors if
 supported by corresponding checks.
 


### PR DESCRIPTION
~~This helps better distinguish warnings that could be disabled via `.clang-tidy` config (like `clang-diagnostic-literal-conversion`) from errors that could not be suppressed at all (like `clang-diagnostic-error`) because it's a hard compiler error.~~

After https://github.com/llvm/llvm-project/pull/153870#issuecomment-3194275812, decided to just add documentation about `clang-diagnostic-error`