### PR TITLE
[bazel] Add yaml2obj to mlir/Test/Target/BUILD.bazel

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/Target/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/Target/BUILD.bazel
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
         srcs = [src],
         data = [
             "//llvm:split-file",
+            "//llvm:yaml2obj",
             "//mlir:mlir-opt",
             "//mlir:mlir-translate",
             "//mlir/test:lit_data",


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/152131 uses yaml2obj, which is not listed as a dependency of the lit tests in bazel. This is causing LLVM CI failures, e.g [1].

[1]: https://buildkite.com/llvm-project/upstream-bazel/builds/146788/steps/canvas?sid=0198af37-f624-470f-aac1-d9e0b42fab56