### PR TITLE
[ADT] Use llvm::copy in SmallPtrSet.cpp (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -160,6 +160,10 @@ protected:
     return make_range(CurArray, EndPointer());
   }
 
+  iterator_range<const void *const *> buckets() const {
+    return make_range(CurArray, EndPointer());
+  }
+
   /// insert_imp - This returns true if the pointer was new to the set, false if
   /// it was already in the set.  This is hidden from the client so that the
   /// derived class can check that the right type of pointer is passed in.


### PR DESCRIPTION
This patch uses llvm::copy in combination with buckets() and
small_buckets().
