### PR TITLE
[libc++][flat_set] LWG3751, LWG3774

### DIFF
--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -223,7 +223,7 @@
 "`LWG3766 <https://wg21.link/LWG3766>`__","``view_interface::cbegin`` is underconstrained","2022-11 (Kona)","","",""
 "`LWG3770 <https://wg21.link/LWG3770>`__","``const_sentinel_t`` is missing","2022-11 (Kona)","","",""
 "`LWG3773 <https://wg21.link/LWG3773>`__","``views::zip_transform`` still requires ``F`` to be ``copy_constructible`` when empty pack","2022-11 (Kona)","|Complete|","22",""
-"`LWG3774 <https://wg21.link/LWG3774>`__","``<flat_set>`` should include ``<compare>``","2022-11 (Kona)","","",""
+"`LWG3774 <https://wg21.link/LWG3774>`__","``<flat_set>`` should include ``<compare>``","2022-11 (Kona)","|Complete|","21",""
 "`LWG3775 <https://wg21.link/LWG3775>`__","Broken dependencies in the ``Cpp17Allocator`` requirements","2022-11 (Kona)","","",""
 "`LWG3778 <https://wg21.link/LWG3778>`__","``vector<bool>`` missing exception specifications","2022-11 (Kona)","|Complete|","3.7",""
 "`LWG3781 <https://wg21.link/LWG3781>`__","The exposition-only alias templates ``cont-key-type`` and ``cont-mapped-type`` should be removed","2022-11 (Kona)","|Nothing To Do|","",""

--- a/libcxx/docs/Status/Cxx23Issues.csv
+++ b/libcxx/docs/Status/Cxx23Issues.csv
@@ -209,7 +209,7 @@
 "`LWG3746 <https://wg21.link/LWG3746>`__","``optional``'s spaceship with ``U`` with a type derived from optional causes infinite constraint meta-recursion","2022-11 (Kona)","|Complete|","17",""
 "`LWG3747 <https://wg21.link/LWG3747>`__","``ranges::uninitialized_copy_n``, ``ranges::uninitialized_move_n``, and ``ranges::destroy_n`` should use ``std::move``","2022-11 (Kona)","","",""
 "`LWG3750 <https://wg21.link/LWG3750>`__","Too many papers bump ``__cpp_lib_format``","2022-11 (Kona)","|Partial|","","Only ``__cpp_lib_format_ranges`` is fully implemented"
-"`LWG3751 <https://wg21.link/LWG3751>`__","Missing feature macro for ``flat_set``","2022-11 (Kona)","","",""
+"`LWG3751 <https://wg21.link/LWG3751>`__","Missing feature macro for ``flat_set``","2022-11 (Kona)","|Complete|","21",""
 "`LWG3753 <https://wg21.link/LWG3753>`__","Clarify entity vs. freestanding entity","2022-11 (Kona)","","",""
 "`LWG3754 <https://wg21.link/LWG3754>`__","Class template expected synopsis contains declarations that do not match the detailed description","2022-11 (Kona)","|Nothing To Do|","",""
 "`LWG3755 <https://wg21.link/LWG3755>`__","``tuple-for-each`` can call ``user-defined`` ``operator,``","2022-11 (Kona)","|Complete|","17",""


### PR DESCRIPTION
- LWG3751: Missing feature macro for `flat_set`

Implemented  in LLVM21:  https://github.com/llvm/llvm-project/commit/7013b51548c0bd2c7e5564735c44506909a2f8dc

Closes  #105021

- LWG3774: `<flat_set>` should include `<compare>`

Implemented in LLVM21: https://github.com/llvm/llvm-project/commit/2f1416bbcde898d65e9762e6ce498bb0121e4610
https://github.com/llvm/llvm-project/blob/684797b6446073b5afd23022449aeecef84c404c/libcxx/include/flat_set#L77

Closes #105036