### PR TITLE
[clang-tidy] Fix `cppcoreguidelines-prefer-member-initializer` false positive for inherited members

### DIFF
--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp
@@ -191,6 +191,9 @@ void PreferMemberInitializerCheck::check(
     if (!AssignmentToMember)
       continue;
     const FieldDecl *Field = AssignmentToMember->Field;
+    // Skip if the field is inherited from a base class.
+    if (Field->getParent() != Class)
+      continue;
     const Expr *InitValue = AssignmentToMember->Init;
     updateAssignmentLevel(Field, InitValue, Ctor, AssignedFields);
     if (!canAdvanceAssignment(AssignedFields[Field]))

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -163,6 +163,10 @@ Changes in existing checks
   an additional matcher that generalizes the copy-and-swap idiom pattern
   detection.
 
+- Improved :doc:`cppcoreguidelines-prefer-member-initializer
+  <clang-tidy/checks/cppcoreguidelines/prefer-member-initializer>` check to
+  avoid false positives on inherited members in class templates.
+
 - Improved :doc:`misc-header-include-cycle
   <clang-tidy/checks/misc/header-include-cycle>` check performance.
 

--- a/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cppcoreguidelines/prefer-member-initializer.cpp
@@ -650,3 +650,16 @@ struct InitFromBindingDecl {
   }
 };
 } // namespace GH82970
+
+struct A {
+  int m;
+};
+
+struct B : A {
+  B() { m = 0; }
+};
+
+template <class T>
+struct C : A {
+  C() { m = 0; }
+};


### PR DESCRIPTION
```cpp
struct Base {
  int m;
};

template <class T>
struct Derived : Base {
  Derived() { m = 0; }
};
```

would previously generate the following output:

```
<source>:7:15: warning: 'm' should be initialized in a member initializer of the constructor [cppcoreguidelines-prefer-member-initializer]
    7 |   Derived() { m = 0; }
      |               ^~~~~~
      |             : m(0)
```

This patch fixes this false positive.

Note that before this patch the checker won't give false positive for

```cpp
struct Derived : Base {
  Derived() { m = 0; }
};
```

and the constructor's AST is

```
`-CXXConstructorDecl 0x557df03d1fb0 <line:7:3, col:22> col:3 Derived 'void ()' implicit-inline
    |-CXXCtorInitializer 'Base'
    | `-CXXConstructExpr 0x557df03d2748 <col:3> 'Base' 'void () noexcept'
    `-CompoundStmt 0x557df03d2898 <col:13, col:22>
      `-BinaryOperator 0x557df03d2878 <col:15, col:19> 'int' lvalue '='
        |-MemberExpr 0x557df03d2828 <col:15> 'int' lvalue ->m 0x557df03d1c40
        | `-ImplicitCastExpr 0x557df03d2808 <col:15> 'Base *' <UncheckedDerivedToBase (Base)>
        |   `-CXXThisExpr 0x557df03d27f8 <col:15> 'Derived *' implicit this
        `-IntegerLiteral 0x557df03d2858 <col:19> 'int' 0
```

so `isAssignmentToMemberOf` would return empty due to

https://github.com/llvm/llvm-project/blob/f0967fca04c880e9aabd5be043a85127faabb4c6/clang-tools-extra/clang-tidy/cppcoreguidelines/PreferMemberInitializerCheck.cpp#L118-L119

Fixes #104400