### PR TITLE
[OpenMP][OMPD] Fix GDB plugin to work correctly when installed

### DIFF
--- a/openmp/libompd/gdb-plugin/ompd/__init__.py
+++ b/openmp/libompd/gdb-plugin/ompd/__init__.py
@@ -4,7 +4,7 @@ import traceback
 
 if __name__ == "__main__":
     try:
-        sys.path.append(os.path.dirname(__file__))
+        sys.path.insert(0, os.path.dirname(__file__))
 
         import ompd
 


### PR DESCRIPTION
Fix the `sys.path` logic in the GDB plugin to insert the intended self-path in the first position rather than appending it to the end. The latter implied that if `sys.path` (naturally) contained the GDB's `gdb-plugin` directory, `import ompd` would return the top-level `ompd/__init__.py` module rather than the `ompd/ompd.py` submodule, as intended by adding the `ompd/` directory to `sys.path`.

This is intended to be a minimal change necessary to fix the issue. Alternatively, the code could be modified to import `ompd.ompd` and stop modifying `sys.path` entirely. However, I do not know why this option was chosen in the first place, so I can't tell if this won't break something.

Fixes #153954