### PR TITLE
[flang] clang-format Semantics sources, NFC

### DIFF
--- a/flang/include/flang/Semantics/scope.h
+++ b/flang/include/flang/Semantics/scope.h
@@ -39,8 +39,8 @@ class SemanticsContext;
 struct EquivalenceObject {
   EquivalenceObject(Symbol &symbol, std::vector<ConstantSubscript> subscripts,
       std::optional<ConstantSubscript> substringStart, parser::CharBlock source)
-      : symbol{symbol}, subscripts{subscripts},
-        substringStart{substringStart}, source{source} {}
+      : symbol{symbol}, subscripts{subscripts}, substringStart{substringStart},
+        source{source} {}
   explicit EquivalenceObject(Symbol &symbol)
       : symbol{symbol}, source{symbol.name()} {}
 

--- a/flang/include/flang/Semantics/symbol.h
+++ b/flang/include/flang/Semantics/symbol.h
@@ -32,7 +32,7 @@ namespace Fortran::parser {
 struct Expr;
 struct OpenMPDeclareReductionConstruct;
 struct OmpMetadirectiveDirective;
-}
+} // namespace Fortran::parser
 
 namespace Fortran::semantics {
 

--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -203,7 +203,7 @@ bool IsDeviceAllocatable(const Symbol &symbol);
 
 inline bool IsCUDADeviceContext(const Scope *scope) {
   if (scope) {
-    if (const Symbol * symbol{scope->symbol()}) {
+    if (const Symbol *symbol{scope->symbol()}) {
       if (const auto *subp{symbol->detailsIf<SubprogramDetails>()}) {
         if (auto attrs{subp->cudaSubprogramAttrs()}) {
           return *attrs != common::CUDASubprogramAttrs::Host;
@@ -305,7 +305,7 @@ const Symbol *FindExternallyVisibleObject(const A &, const Scope &) {
 template <typename T>
 const Symbol *FindExternallyVisibleObject(
     const evaluate::Designator<T> &designator, const Scope &scope) {
-  if (const Symbol * symbol{designator.GetBaseObject().symbol()}) {
+  if (const Symbol *symbol{designator.GetBaseObject().symbol()}) {
     return FindExternallyVisibleObject(*symbol, scope, false);
   } else if (std::holds_alternative<evaluate::CoarrayRef>(designator.u)) {
     // Coindexed values are visible even if their image-local objects are not.
@@ -670,8 +670,8 @@ public:
   LabelEnforce(SemanticsContext &context, std::set<parser::Label> &&labels,
       parser::CharBlock constructSourcePosition, const char *construct)
       : context_{context}, labels_{labels},
-        constructSourcePosition_{constructSourcePosition}, construct_{
-                                                               construct} {}
+        constructSourcePosition_{constructSourcePosition},
+        construct_{construct} {}
   template <typename T> bool Pre(const T &) { return true; }
   template <typename T> bool Pre(const parser::Statement<T> &statement) {
     currentStatementSourcePosition_ = statement.source;

--- a/flang/include/flang/Semantics/unparse-with-symbols.h
+++ b/flang/include/flang/Semantics/unparse-with-symbols.h
@@ -32,6 +32,6 @@ void UnparseWithSymbols(llvm::raw_ostream &, const parser::Program &,
 void UnparseWithModules(llvm::raw_ostream &, SemanticsContext &,
     const parser::Program &,
     parser::Encoding encoding = parser::Encoding::UTF_8);
-}
+} // namespace Fortran::semantics
 
 #endif // FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_

--- a/flang/lib/Semantics/assignment.cpp
+++ b/flang/lib/Semantics/assignment.cpp
@@ -62,7 +62,7 @@ private:
 };
 
 void AssignmentContext::Analyze(const parser::AssignmentStmt &stmt) {
-  if (const evaluate::Assignment * assignment{GetAssignment(stmt)}) {
+  if (const evaluate::Assignment *assignment{GetAssignment(stmt)}) {
     const SomeExpr &lhs{assignment->lhs};
     const SomeExpr &rhs{assignment->rhs};
     auto lhsLoc{std::get<parser::Variable>(stmt.t).GetSource()};
@@ -72,8 +72,8 @@ void AssignmentContext::Analyze(const parser::AssignmentStmt &stmt) {
         std::holds_alternative<evaluate::ProcedureRef>(assignment->u)};
     if (isDefinedAssignment) {
       flags.set(DefinabilityFlag::AllowEventLockOrNotifyType);
-    } else if (const Symbol *
-        whole{evaluate::UnwrapWholeSymbolOrComponentDataRef(lhs)}) {
+    } else if (const Symbol *whole{
+                   evaluate::UnwrapWholeSymbolOrComponentDataRef(lhs)}) {
       if (IsAllocatable(whole->GetUltimate())) {
         flags.set(DefinabilityFlag::PotentialDeallocation);
       }
@@ -101,7 +101,7 @@ void AssignmentContext::Analyze(const parser::AssignmentStmt &stmt) {
 
 void AssignmentContext::Analyze(const parser::PointerAssignmentStmt &stmt) {
   CHECK(whereDepth_ == 0);
-  if (const evaluate::Assignment * assignment{GetAssignment(stmt)}) {
+  if (const evaluate::Assignment *assignment{GetAssignment(stmt)}) {
     parser::CharBlock at{context_.location().value()};
     auto restorer{foldingContext().messages().SetLocation(at)};
     CheckPointerAssignment(context_, *assignment, context_.FindScope(at));
@@ -125,7 +125,7 @@ static std::optional<std::string> GetPointerComponentDesignatorName(
 bool CheckCopyabilityInPureScope(parser::ContextualMessages &messages,
     const SomeExpr &expr, const Scope &scope) {
   if (auto pointer{GetPointerComponentDesignatorName(expr)}) {
-    if (const Symbol * base{GetFirstSymbol(expr)}) {
+    if (const Symbol *base{GetFirstSymbol(expr)}) {
       const char *why{WhyBaseObjectIsSuspicious(base->GetUltimate(), scope)};
       if (!why) {
         if (auto coarray{evaluate::ExtractCoarrayRef(expr)}) {

--- a/flang/lib/Semantics/canonicalize-acc.cpp
+++ b/flang/lib/Semantics/canonicalize-acc.cpp
@@ -68,7 +68,7 @@ private:
           return; // Tile is not allowed on DO CONCURRENT
         }
         for (const parser::DoConstruct *loop{&outer}; loop && tileArgNb > 0;
-             --tileArgNb) {
+            --tileArgNb) {
           const auto &block{std::get<parser::Block>(loop->t)};
           const auto it{block.begin()};
           loop = it != block.end() ? parser::Unwrap<parser::DoConstruct>(*it)

--- a/flang/lib/Semantics/check-acc-structure.cpp
+++ b/flang/lib/Semantics/check-acc-structure.cpp
@@ -667,8 +667,8 @@ void AccStructureChecker::Enter(const parser::OpenACCCacheConstruct &x) {
   PushContextAndClauseSets(verbatim.source, llvm::acc::Directive::ACCD_cache);
   SetContextDirectiveSource(verbatim.source);
   if (loopNestLevel == 0) {
-    context_.Say(verbatim.source,
-          "The CACHE directive must be inside a loop"_err_en_US);
+    context_.Say(
+        verbatim.source, "The CACHE directive must be inside a loop"_err_en_US);
   }
 }
 void AccStructureChecker::Leave(const parser::OpenACCCacheConstruct &x) {

--- a/flang/lib/Semantics/check-allocate.cpp
+++ b/flang/lib/Semantics/check-allocate.cpp
@@ -74,7 +74,7 @@ private:
     if (type_->category() == DeclTypeSpec::Category::Character) {
       hasDeferredTypeParameter_ =
           type_->characterTypeSpec().length().isDeferred();
-    } else if (const DerivedTypeSpec * derivedTypeSpec{type_->AsDerived()}) {
+    } else if (const DerivedTypeSpec *derivedTypeSpec{type_->AsDerived()}) {
       for (const auto &pair : derivedTypeSpec->parameters()) {
         hasDeferredTypeParameter_ |= pair.second.isDeferred();
       }
@@ -114,7 +114,7 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
     }
     info.gotTypeSpec = true;
     info.typeSpecLoc = parser::FindSourceLocation(*typeSpec);
-    if (const DerivedTypeSpec * derived{info.typeSpec->AsDerived()}) {
+    if (const DerivedTypeSpec *derived{info.typeSpec->AsDerived()}) {
       // C937
       if (auto it{FindCoarrayUltimateComponent(*derived)}) {
         context
@@ -224,8 +224,8 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
       }
       info.sourceExprRank = expr->Rank();
       info.sourceExprLoc = parserSourceExpr->source;
-      if (const DerivedTypeSpec *
-          derived{evaluate::GetDerivedTypeSpec(info.sourceExprType)}) {
+      if (const DerivedTypeSpec *derived{
+              evaluate::GetDerivedTypeSpec(info.sourceExprType)}) {
         // C949
         if (auto it{FindCoarrayUltimateComponent(*derived)}) {
           context
@@ -279,13 +279,13 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
 // in this test.
 static bool IsTypeCompatible(
     const DeclTypeSpec &type1, const DerivedTypeSpec &derivedType2) {
-  if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
+  if (const DerivedTypeSpec *derivedType1{type1.AsDerived()}) {
     if (type1.category() == DeclTypeSpec::Category::TypeDerived) {
       return evaluate::AreSameDerivedTypeIgnoringTypeParameters(
           *derivedType1, derivedType2);
     } else if (type1.category() == DeclTypeSpec::Category::ClassDerived) {
       for (const DerivedTypeSpec *parent{&derivedType2}; parent;
-           parent = parent->typeSymbol().GetParentTypeSpec()) {
+          parent = parent->typeSymbol().GetParentTypeSpec()) {
         if (evaluate::AreSameDerivedTypeIgnoringTypeParameters(
                 *derivedType1, *parent)) {
           return true;
@@ -303,13 +303,13 @@ static bool IsTypeCompatible(
     // cannot be allocatable (C709)
     return true;
   }
-  if (const IntrinsicTypeSpec * intrinsicType2{type2.AsIntrinsic()}) {
-    if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+  if (const IntrinsicTypeSpec *intrinsicType2{type2.AsIntrinsic()}) {
+    if (const IntrinsicTypeSpec *intrinsicType1{type1.AsIntrinsic()}) {
       return intrinsicType1->category() == intrinsicType2->category();
     } else {
       return false;
     }
-  } else if (const DerivedTypeSpec * derivedType2{type2.AsDerived()}) {
+  } else if (const DerivedTypeSpec *derivedType2{type2.AsDerived()}) {
     return IsTypeCompatible(type1, *derivedType2);
   }
   return false;
@@ -323,7 +323,7 @@ static bool IsTypeCompatible(
     return true;
   }
   if (type2.category() != evaluate::TypeCategory::Derived) {
-    if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+    if (const IntrinsicTypeSpec *intrinsicType1{type1.AsIntrinsic()}) {
       return intrinsicType1->category() == type2.category();
     } else {
       return false;
@@ -348,16 +348,16 @@ static bool HaveSameAssumedTypeParameters(
     }
     // It is possible to reach this if type1 is unlimited polymorphic
     return !type2LengthIsAssumed;
-  } else if (const DerivedTypeSpec * derivedType2{type2.AsDerived()}) {
+  } else if (const DerivedTypeSpec *derivedType2{type2.AsDerived()}) {
     int type2AssumedParametersCount{0};
     int type1AssumedParametersCount{0};
     for (const auto &pair : derivedType2->parameters()) {
       type2AssumedParametersCount += pair.second.isAssumed();
     }
     // type1 may be unlimited polymorphic
-    if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
+    if (const DerivedTypeSpec *derivedType1{type1.AsDerived()}) {
       for (auto it{derivedType1->parameters().begin()};
-           it != derivedType1->parameters().end(); ++it) {
+          it != derivedType1->parameters().end(); ++it) {
         if (it->second.isAssumed()) {
           ++type1AssumedParametersCount;
           const ParamValue *param{derivedType2->FindParameter(it->first)};
@@ -378,8 +378,8 @@ static bool HaveSameAssumedTypeParameters(
 
 static std::optional<std::int64_t> GetTypeParameterInt64Value(
     const Symbol &parameterSymbol, const DerivedTypeSpec &derivedType) {
-  if (const ParamValue *
-      paramValue{derivedType.FindParameter(parameterSymbol.name())}) {
+  if (const ParamValue *paramValue{
+          derivedType.FindParameter(parameterSymbol.name())}) {
     return evaluate::ToInt64(paramValue->GetExplicit());
   }
   return std::nullopt;
@@ -403,11 +403,11 @@ static bool HaveCompatibleTypeParameters(
   if (type1.category() == DeclTypeSpec::Category::ClassStar) {
     return true;
   }
-  if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+  if (const IntrinsicTypeSpec *intrinsicType1{type1.AsIntrinsic()}) {
     return evaluate::ToInt64(intrinsicType1->kind()).value() == type2.kind();
   } else if (type2.IsUnlimitedPolymorphic()) {
     return false;
-  } else if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
+  } else if (const DerivedTypeSpec *derivedType1{type1.AsDerived()}) {
     return HaveCompatibleTypeParameters(
         *derivedType1, type2.GetDerivedTypeSpec());
   } else {
@@ -419,10 +419,10 @@ static bool HaveCompatibleTypeParameters(
     const DeclTypeSpec &type1, const DeclTypeSpec &type2) {
   if (type1.category() == DeclTypeSpec::Category::ClassStar) {
     return true;
-  } else if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+  } else if (const IntrinsicTypeSpec *intrinsicType1{type1.AsIntrinsic()}) {
     const IntrinsicTypeSpec *intrinsicType2{type2.AsIntrinsic()};
     return !intrinsicType2 || intrinsicType1->kind() == intrinsicType2->kind();
-  } else if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
+  } else if (const DerivedTypeSpec *derivedType1{type1.AsDerived()}) {
     const DerivedTypeSpec *derivedType2{type2.AsDerived()};
     return !derivedType2 ||
         HaveCompatibleTypeParameters(*derivedType1, *derivedType2);
@@ -699,8 +699,7 @@ bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
   if (evaluate::IsCoarray(*ultimate_)) {
     if (allocateInfo_.gotTypeSpec) {
       // C938
-      if (const DerivedTypeSpec *
-          derived{allocateInfo_.typeSpec->AsDerived()}) {
+      if (const DerivedTypeSpec *derived{allocateInfo_.typeSpec->AsDerived()}) {
         if (IsTeamType(derived)) {
           context
               .Say(allocateInfo_.typeSpecLoc.value(),
@@ -784,8 +783,8 @@ bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
       return false;
     }
   }
-  if (const parser::CoindexedNamedObject *
-      coindexedObject{parser::GetCoindexedNamedObject(allocateObject_)}) {
+  if (const parser::CoindexedNamedObject *coindexedObject{
+          parser::GetCoindexedNamedObject(allocateObject_)}) {
     // C950
     context.Say(parser::FindSourceLocation(*coindexedObject),
         "Allocatable object must not be coindexed in ALLOCATE"_err_en_US);

--- a/flang/lib/Semantics/check-arithmeticif.h
+++ b/flang/lib/Semantics/check-arithmeticif.h
@@ -18,7 +18,7 @@ struct ArithmeticIfStmt;
 namespace Fortran::semantics {
 class ArithmeticIfStmtChecker : public virtual BaseChecker {
 public:
-  ArithmeticIfStmtChecker(SemanticsContext &context) : context_(context){};
+  ArithmeticIfStmtChecker(SemanticsContext &context) : context_(context) {}
   void Leave(const parser::ArithmeticIfStmt &);
 
 private:

--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -43,7 +43,7 @@ static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
     } else if (type->IsUnlimitedPolymorphic()) {
       messages.Say(
           "Unlimited polymorphic actual argument requires an explicit interface"_err_en_US);
-    } else if (const DerivedTypeSpec * derived{GetDerivedTypeSpec(type)}) {
+    } else if (const DerivedTypeSpec *derived{GetDerivedTypeSpec(type)}) {
       if (!derived->parameters().empty()) {
         messages.Say(
             "Parameterized derived type actual argument requires an explicit interface"_err_en_US);
@@ -56,7 +56,7 @@ static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
         "%VAL argument must be a scalar numeric or logical expression"_err_en_US);
   }
   if (const auto *expr{arg.UnwrapExpr()}) {
-    if (const Symbol * base{GetFirstSymbol(*expr)};
+    if (const Symbol *base{GetFirstSymbol(*expr)};
         base && IsFunctionResult(*base)) {
       context.NoteDefinedSymbol(*base);
     }
@@ -92,7 +92,7 @@ static void CheckImplicitInterfaceArg(evaluate::ActualArgument &arg,
               "Non-intrinsic ELEMENTAL procedure '%s' may not be passed as an actual argument"_err_en_US,
               argProcSymbol->name());
         } else if (const auto *subp{argProcSymbol->GetUltimate()
-                                        .detailsIf<SubprogramDetails>()}) {
+                           .detailsIf<SubprogramDetails>()}) {
           if (subp->stmtFunction()) {
             evaluate::SayWithDeclaration(messages, *argProcSymbol,
                 "Statement function '%s' may not be passed as an actual argument"_err_en_US,
@@ -480,10 +480,10 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
             "Actual argument associated with TYPE(*) %s may not have a parameterized derived type"_err_en_US,
             dummyName);
       }
-      if (const Symbol *
-          tbp{FindImmediateComponent(*actualDerived, [](const Symbol &symbol) {
-            return symbol.has<ProcBindingDetails>();
-          })}) { // 15.5.2.4(2)
+      if (const Symbol *tbp{
+              FindImmediateComponent(*actualDerived, [](const Symbol &symbol) {
+                return symbol.has<ProcBindingDetails>();
+              })}) { // 15.5.2.4(2)
         evaluate::SayWithDeclaration(messages, *tbp,
             "Actual argument associated with TYPE(*) %s may not have type-bound procedure '%s'"_err_en_US,
             dummyName, tbp->name());
@@ -509,8 +509,8 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
         }
       }
       const Symbol &coarray{actualCoarrayRef->GetLastSymbol()};
-      if (const DeclTypeSpec * type{coarray.GetType()}) { // C1537
-        if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+      if (const DeclTypeSpec *type{coarray.GetType()}) { // C1537
+        if (const DerivedTypeSpec *derived{type->AsDerived()}) {
           if (auto bad{semantics::FindPointerUltimateComponent(*derived)}) {
             evaluate::SayWithDeclaration(messages, coarray,
                 "Coindexed object '%s' with POINTER ultimate component '%s' cannot be associated with %s"_err_en_US,
@@ -764,7 +764,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     } else if (dummy.intent != common::Intent::In ||
         (dummyIsPointer && !actualIsPointer)) {
       if (auto named{evaluate::ExtractNamedEntity(actual)}) {
-        if (const Symbol & base{named->GetFirstSymbol()};
+        if (const Symbol &base{named->GetFirstSymbol()};
             IsFunctionResult(base)) {
           context.NoteDefinedSymbol(base);
         }
@@ -1104,7 +1104,7 @@ static void CheckProcedureArg(evaluate::ActualArgument &arg,
   parser::ContextualMessages &messages{foldingContext.messages()};
   parser::CharBlock location{arg.sourceLocation().value_or(messages.at())};
   auto restorer{messages.SetLocation(location)};
-  const characteristics::Procedure &interface { dummy.procedure.value() };
+  const characteristics::Procedure &interface{dummy.procedure.value()};
   if (const auto *expr{arg.UnwrapExpr()}) {
     bool dummyIsPointer{
         dummy.attrs.test(characteristics::DummyProcedure::Attr::Pointer)};
@@ -1343,8 +1343,8 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
                     messages.Say(
                         "Actual argument associated with %s is a NULL() pointer without a MOLD= to provide a character length"_err_en_US,
                         dummyName);
-                  } else if (const DerivedTypeSpec *
-                      derived{GetDerivedTypeSpec(object.type.type())}) {
+                  } else if (const DerivedTypeSpec *derived{
+                                 GetDerivedTypeSpec(object.type.type())}) {
                     for (const auto &[pName, pValue] : derived->parameters()) {
                       if (pValue.isAssumed()) {
                         messages.Say(
@@ -1870,7 +1870,7 @@ static void CheckFree(evaluate::ActualArguments &arguments,
     messages.Say("FREE expects a single argument"_err_en_US);
   }
   auto arg = arguments[0];
-  if (const Symbol * symbol{evaluate::UnwrapWholeSymbolDataRef(arg)};
+  if (const Symbol *symbol{evaluate::UnwrapWholeSymbolDataRef(arg)};
       !symbol || !symbol->test(Symbol::Flag::CrayPointer)) {
     messages.Say("FREE should only be used with Cray pointers"_warn_en_US);
   }
@@ -1904,8 +1904,8 @@ static void CheckMove_Alloc(evaluate::ActualArguments &arguments,
   }
   if (arguments.size() >= 2 && arguments[0] && arguments[1]) {
     for (int j{0}; j < 2; ++j) {
-      if (const Symbol *
-              whole{UnwrapWholeSymbolOrComponentDataRef(arguments[j])};
+      if (const Symbol *whole{
+              UnwrapWholeSymbolOrComponentDataRef(arguments[j])};
           !whole || !IsAllocatable(whole->GetUltimate())) {
         messages.Say(*arguments[j]->sourceLocation(),
             "Argument #%d to MOVE_ALLOC must be allocatable"_err_en_US, j + 1);
@@ -2136,8 +2136,8 @@ static void CheckTransfer(evaluate::ActualArguments &arguments,
       }
     }
     if (arguments.size() > 2) { // SIZE=
-      if (const Symbol *
-          whole{UnwrapWholeSymbolOrComponentDataRef(arguments[2])}) {
+      if (const Symbol *whole{
+              UnwrapWholeSymbolOrComponentDataRef(arguments[2])}) {
         if (IsOptional(*whole)) {
           messages.Say(
               "SIZE= argument may not be the optional dummy argument '%s'"_err_en_US,
@@ -2307,7 +2307,7 @@ bool CheckPPCIntrinsic(const Symbol &generic, const Symbol &specific,
       for (const auto &pair : derived->parameters()) {
         if (pair.first == "element_kind") {
           auto vecElemKind{Fortran::evaluate::ToInt64(pair.second.GetExplicit())
-                               .value_or(0)};
+                  .value_or(0)};
           auto numElem{vecElemKind == 0 ? 0 : (16 / vecElemKind)};
           return CheckArgumentIsConstantExprInRange(
               actuals, 1, 0, numElem - 1, messages);

--- a/flang/lib/Semantics/check-case.cpp
+++ b/flang/lib/Semantics/check-case.cpp
@@ -117,7 +117,7 @@ private:
 
   using PairOfValues = std::pair<std::optional<Value>, std::optional<Value>>;
   PairOfValues ComputeBounds(const parser::CaseValueRange &range) {
-    return common::visit(
+    return common::visit( //
         common::visitors{
             [&](const parser::CaseValue &x) {
               auto value{GetValue(x)};

--- a/flang/lib/Semantics/check-coarray.cpp
+++ b/flang/lib/Semantics/check-coarray.cpp
@@ -322,7 +322,7 @@ void CoarrayChecker::Leave(const parser::EventWaitStmt &x) {
 
 static void CheckLockVariable(
     SemanticsContext &context, const parser::LockVariable &lockVar) {
-  if (const SomeExpr * expr{GetExpr(lockVar)}) {
+  if (const SomeExpr *expr{GetExpr(lockVar)}) {
     if (auto dyType{expr->GetType()}) {
       auto at{parser::FindSourceLocation(lockVar)};
       if (dyType->category() != TypeCategory::Derived ||

--- a/flang/lib/Semantics/check-cuda.cpp
+++ b/flang/lib/Semantics/check-cuda.cpp
@@ -77,7 +77,7 @@ struct DeviceExprChecker
   explicit DeviceExprChecker(SemanticsContext &c) : Base(*this), context_{c} {}
   using Base::operator();
   Result operator()(const evaluate::ProcedureDesignator &x) const {
-    if (const Symbol * sym{x.GetInterfaceSymbol()}) {
+    if (const Symbol *sym{x.GetInterfaceSymbol()}) {
       const auto *subp{
           sym->GetUltimate().detailsIf<semantics::SubprogramDetails>()};
       if (subp) {
@@ -402,7 +402,7 @@ private:
   void ErrorIfHostSymbol(const A &expr, parser::CharBlock source) {
     if (isHostDevice)
       return;
-    if (const Symbol * hostArray{FindHostArray{}(expr)}) {
+    if (const Symbol *hostArray{FindHostArray{}(expr)}) {
       context_.Say(source,
           "Host array '%s' cannot be present in device context"_err_en_US,
           hostArray->name());
@@ -467,8 +467,8 @@ private:
               Check(x.value());
             },
             [&](const common::Indirection<parser::AssignmentStmt> &x) {
-              if (const evaluate::Assignment *
-                  assign{semantics::GetAssignment(x.value())}) {
+              if (const evaluate::Assignment *assign{
+                      semantics::GetAssignment(x.value())}) {
                 ErrorIfHostSymbol(assign->lhs, source);
                 ErrorIfHostSymbol(assign->rhs, source);
               }

--- a/flang/lib/Semantics/check-deallocate.cpp
+++ b/flang/lib/Semantics/check-deallocate.cpp
@@ -64,11 +64,10 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
               // analyzed by expression analysis.
               auto source{structureComponent.component.source};
               if (const auto *expr{GetExpr(context_, allocateObject)}) {
-                if (const Symbol *
-                        symbol{structureComponent.component.symbol
-                                ? &structureComponent.component.symbol
-                                       ->GetUltimate()
-                                : nullptr};
+                if (const Symbol *symbol{structureComponent.component.symbol
+                            ? &structureComponent.component.symbol
+                                  ->GetUltimate()
+                            : nullptr};
                     !IsAllocatableOrObjectPointer(symbol)) { // F'2023 C936
                   context_.Say(source,
                       "Component in DEALLOCATE statement must have the ALLOCATABLE or POINTER attribute"_err_en_US);

--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -481,7 +481,7 @@ void CheckHelper::Check(const Symbol &symbol) {
     }
   }
   if (IsAutomatic(symbol)) {
-    if (const Symbol * common{FindCommonBlockContaining(symbol)}) {
+    if (const Symbol *common{FindCommonBlockContaining(symbol)}) {
       messages_.Say(
           "Automatic data object '%s' may not appear in COMMON block /%s/"_err_en_US,
           symbol.name(), common->name());
@@ -573,7 +573,7 @@ void CheckHelper::CheckExplicitSave(const Symbol &symbol) {
     messages_.Say(
         "The function result variable '%s' may not have an explicit SAVE attribute"_err_en_US,
         symbol.name());
-  } else if (const Symbol * common{FindCommonBlockContaining(ultimate)}) {
+  } else if (const Symbol *common{FindCommonBlockContaining(ultimate)}) {
     messages_.Say(
         "The entity '%s' in COMMON block /%s/ may not have an explicit SAVE attribute"_err_en_US,
         symbol.name(), common->name());
@@ -1090,8 +1090,7 @@ void CheckHelper::CheckObjectEntity(
             "Object '%s' with ATTRIBUTES(CONSTANT) may not be allocatable, pointer, or target"_err_en_US,
             symbol.name());
       } else if (auto shape{evaluate::GetShape(foldingContext_, symbol)};
-                 !shape ||
-                 !evaluate::AsConstantExtents(foldingContext_, *shape)) {
+          !shape || !evaluate::AsConstantExtents(foldingContext_, *shape)) {
         messages_.Say(
             "Object '%s' with ATTRIBUTES(CONSTANT) must have constant array bounds"_err_en_US,
             symbol.name());
@@ -1177,8 +1176,8 @@ void CheckHelper::CheckObjectEntity(
     if (isComponent) {
       if (attr == common::CUDADataAttr::Device) {
         const DeclTypeSpec *type{symbol.GetType()};
-        if (const DerivedTypeSpec *
-            derived{type ? type->AsDerived() : nullptr}) {
+        if (const DerivedTypeSpec *derived{
+                type ? type->AsDerived() : nullptr}) {
           DirectComponentIterator directs{*derived};
           if (auto iter{std::find_if(directs.begin(), directs.end(),
                   [](const Symbol &) { return false; })}) {
@@ -1547,7 +1546,7 @@ void CheckHelper::CheckSubprogram(
         iter != symbol.owner().end()) {
       const Symbol &resNameSym{*iter->second};
       if (const auto *resNameSubp{resNameSym.detailsIf<SubprogramDetails>()}) {
-        if (const Scope * resNameEntryScope{resNameSubp->entryScope()}) {
+        if (const Scope *resNameEntryScope{resNameSubp->entryScope()}) {
           const Scope *myScope{
               details.entryScope() ? details.entryScope() : symbol.scope()};
           if (resNameEntryScope == myScope) {
@@ -1562,7 +1561,7 @@ void CheckHelper::CheckSubprogram(
       }
     }
   }
-  if (const MaybeExpr & stmtFunction{details.stmtFunction()}) {
+  if (const MaybeExpr &stmtFunction{details.stmtFunction()}) {
     if (auto msg{evaluate::CheckStatementFunction(
             symbol, *stmtFunction, context_.foldingContext())}) {
       SayWithDeclaration(symbol, std::move(*msg));
@@ -1571,8 +1570,8 @@ void CheckHelper::CheckSubprogram(
           "A statement function must not have the POINTER attribute"_err_en_US);
     } else if (details.result().flags().test(Symbol::Flag::Implicit)) {
       // 15.6.4 p2 weird requirement
-      if (const Symbol *
-          host{symbol.owner().parent().FindSymbol(symbol.name())}) {
+      if (const Symbol *host{
+              symbol.owner().parent().FindSymbol(symbol.name())}) {
         evaluate::AttachDeclaration(
             Warn(common::LanguageFeature::StatementFunctionExtensions,
                 symbol.name(),
@@ -1647,7 +1646,7 @@ void CheckHelper::CheckSubprogram(
         "A subroutine may not have LAUNCH_BOUNDS() or CLUSTER_DIMS() unless it has ATTRIBUTES(GLOBAL) or ATTRIBUTES(GRID_GLOBAL)"_err_en_US);
   }
   if (!IsStmtFunction(symbol)) {
-    if (const Scope * outerDevice{FindCUDADeviceContext(&symbol.owner())};
+    if (const Scope *outerDevice{FindCUDADeviceContext(&symbol.owner())};
         outerDevice && outerDevice->symbol()) {
       if (auto *msg{messages_.Say(symbol.name(),
               "'%s' may not be an internal procedure of CUDA device subprogram '%s'"_err_en_US,
@@ -1665,8 +1664,7 @@ void CheckHelper::CheckExternal(const Symbol &symbol) {
     if (const auto *bind{symbol.GetBindName()}) {
       interfaceName = *bind;
     }
-    if (const Symbol * global{FindGlobal(symbol)};
-        global && global != &symbol) {
+    if (const Symbol *global{FindGlobal(symbol)}; global && global != &symbol) {
       std::string definitionName{global->name().ToString()};
       if (const auto *bind{global->GetBindName()}) {
         definitionName = *bind;
@@ -1709,7 +1707,7 @@ void CheckHelper::CheckExternal(const Symbol &symbol) {
         }
       }
     } else if (auto iter{externalNames_.find(interfaceName)};
-               iter != externalNames_.end()) {
+        iter != externalNames_.end()) {
       const Symbol &previous{*iter->second};
       if (auto chars{Characterize(symbol)}) {
         if (auto previousChars{Characterize(previous)}) {
@@ -2031,8 +2029,8 @@ void CheckHelper::CollectSpecifics(DistinguishabilityHelper &helper,
       }
     }
   }
-  if (const Scope * parent{generic.owner().GetDerivedTypeParent()}) {
-    if (const Symbol * inherited{parent->FindComponent(generic.name())}) {
+  if (const Scope *parent{generic.owner().GetDerivedTypeParent()}) {
+    if (const Symbol *inherited{parent->FindComponent(generic.name())}) {
       if (IsAccessible(*inherited, generic.owner().parent())) {
         if (const auto *details{inherited->detailsIf<GenericDetails>()}) {
           // Include specifics of inherited generic of the same name, too
@@ -2236,7 +2234,7 @@ bool CheckHelper::CheckDefinedOperatorArg(const SourceName &opName,
     msg =
         "In %s function '%s', dummy argument '%s' may not be OPTIONAL"_err_en_US;
   } else if (const auto *dataObject{std::get_if<DummyDataObject>(&arg.u)};
-             dataObject == nullptr) {
+      dataObject == nullptr) {
     msg =
         "In %s function '%s', dummy argument '%s' must be a data object"_err_en_US;
   } else if (dataObject->intent == common::Intent::Out) {
@@ -2468,9 +2466,7 @@ void CheckHelper::CheckPassArg(
     return;
   }
   const auto &name{proc.name()};
-  const Symbol *interface {
-    interface0 ? FindInterface(*interface0) : nullptr
-  };
+  const Symbol *interface{interface0 ? FindInterface(*interface0) : nullptr};
   if (!interface) {
     messages_.Say(name,
         "Procedure component '%s' must have NOPASS attribute or explicit interface"_err_en_US,
@@ -3137,9 +3133,9 @@ parser::Messages CheckHelper::WhyNotInteroperableDerivedType(
             msgs.Annex(std::move(bad));
           }
         } else if (auto dyType{evaluate::DynamicType::From(*type)}; dyType &&
-                   !evaluate::IsInteroperableIntrinsicType(
-                       *dyType, &context_.languageFeatures())
-                        .value_or(false)) {
+            !evaluate::IsInteroperableIntrinsicType(
+                *dyType, &context_.languageFeatures())
+                .value_or(false)) {
           if (type->category() == DeclTypeSpec::Logical) {
             if (context_.ShouldWarn(common::UsageWarning::LogicalVsCBool)) {
               msgs.Say(common::UsageWarning::LogicalVsCBool, component.name(),
@@ -3228,7 +3224,7 @@ parser::Messages CheckHelper::WhyNotInteroperableObject(
             .Attach(derived->typeSymbol().name(), "Non-BIND(C) type"_en_US);
       } else if (auto bad{
                      WhyNotInteroperableDerivedType(derived->typeSymbol())};
-                 bad.AnyFatalError()) {
+          bad.AnyFatalError()) {
         bad.AttachTo(
             msgs.Say(symbol.name(),
                     "The derived type of an interoperable object must be interoperable, but is not"_err_en_US)
@@ -3297,7 +3293,7 @@ parser::Messages CheckHelper::WhyNotInteroperableFunctionResult(
     msgs.Say(symbol.name(),
         "Interoperable function result may not have ALLOCATABLE or POINTER attribute"_err_en_US);
   }
-  if (const DeclTypeSpec * type{symbol.GetType()};
+  if (const DeclTypeSpec *type{symbol.GetType()};
       type && type->category() == DeclTypeSpec::Character) {
     bool isConstOne{false}; // 18.3.1(1)
     if (const auto &len{type->characterTypeSpec().length().GetExplicit()}) {
@@ -3401,7 +3397,7 @@ void CheckHelper::CheckBindC(const Symbol &symbol) {
     // procedure interface) but is not itself BIND(C).
   }
   parser::Messages whyNot;
-  if (const std::string * bindName{symbol.GetBindName()};
+  if (const std::string *bindName{symbol.GetBindName()};
       bindName) { // has a binding name
     if (!bindName->empty()) {
       bool ok{bindName->front() == '_' || parser::IsLetter(bindName->front())};
@@ -3490,7 +3486,7 @@ void CheckHelper::CheckAlreadySeenDefinedIo(const DerivedTypeSpec &derivedType,
   if (generic.owner().IsDerivedType()) {
     return;
   }
-  if (const Scope * dtScope{derivedType.scope()}) {
+  if (const Scope *dtScope{derivedType.scope()}) {
     if (auto iter{dtScope->find(generic.name())}; iter != dtScope->end() &&
         IsAccessible(*iter->second, generic.owner())) {
       for (auto specRef : iter->second->get<GenericDetails>().specificProcs()) {
@@ -3784,8 +3780,8 @@ void CheckHelper::CheckSymbolType(const Symbol &symbol) {
           symbol.name(), dyType->AsFortran());
     }
     if (!symbol.has<ObjectEntityDetails>()) {
-      if (const DerivedTypeSpec *
-          derived{evaluate::GetDerivedTypeSpec(*dyType)}) {
+      if (const DerivedTypeSpec *derived{
+              evaluate::GetDerivedTypeSpec(*dyType)}) {
         if (IsEventTypeOrLockType(derived)) {
           messages_.Say(
               "Entity '%s' with EVENT_TYPE or LOCK_TYPE must be an object"_err_en_US,
@@ -3807,13 +3803,12 @@ void CheckHelper::CheckModuleProcedureDef(const Symbol &symbol) {
       (procClass == ProcedureDefinitionClass::Module &&
           symbol.attrs().test(Attr::MODULE)) &&
       !subprogram->bindName() && !subprogram->isInterface()) {
-    const Symbol &interface {
-      subprogram->moduleInterface() ? *subprogram->moduleInterface() : symbol
-    };
-    if (const Symbol *
-            module{interface.owner().kind() == Scope::Kind::Module
-                    ? interface.owner().symbol()
-                    : nullptr};
+    const Symbol &interface{subprogram->moduleInterface()
+            ? *subprogram->moduleInterface()
+            : symbol};
+    if (const Symbol *module{interface.owner().kind() == Scope::Kind::Module
+                ? interface.owner().symbol()
+                : nullptr};
         module && module->has<ModuleDetails>()) {
       std::pair<SourceName, const Symbol *> key{symbol.name(), module};
       auto iter{moduleProcs_.find(key)};

--- a/flang/lib/Semantics/check-do-forall.cpp
+++ b/flang/lib/Semantics/check-do-forall.cpp
@@ -162,8 +162,8 @@ public:
     }
     // Check the components
     if (const auto *details{symbol.detailsIf<ObjectEntityDetails>()}) {
-      if (const DeclTypeSpec * entityType{details->type()}) {
-        if (const DerivedTypeSpec * derivedType{entityType->AsDerived()}) {
+      if (const DeclTypeSpec *entityType{details->type()}) {
+        if (const DerivedTypeSpec *derivedType{entityType->AsDerived()}) {
           UltimateComponentIterator ultimates{*derivedType};
           for (const auto &ultimate : ultimates) {
             if (WillDeallocatePolymorphic(ultimate, WillDeallocate)) {
@@ -208,7 +208,7 @@ public:
             MightDeallocatePolymorphic(entity, DeallocateAll)) {
           SayDeallocateOfPolymorphic(endBlockStmt.source, entity, reason);
         }
-        if (const Symbol * impure{HasImpureFinal(entity)}) {
+        if (const Symbol *impure{HasImpureFinal(entity)}) {
           SayDeallocateWithImpureFinal(entity, reason, *impure);
         }
       }
@@ -219,14 +219,14 @@ public:
   // Note that this case does not cause deallocation of coarray components
   void Post(const parser::AssignmentStmt &stmt) {
     const auto &variable{std::get<parser::Variable>(stmt.t)};
-    if (const Symbol * entity{GetLastName(variable).symbol}) {
+    if (const Symbol *entity{GetLastName(variable).symbol}) {
       const char *reason{"assignment"};
       if (MightDeallocatePolymorphic(*entity, DeallocateNonCoarray)) {
         SayDeallocateOfPolymorphic(variable.GetSource(), *entity, reason);
       }
       if (const auto *assignment{GetAssignment(stmt)}) {
         const auto &lhs{assignment->lhs};
-        if (const Symbol * impure{HasImpureFinal(*entity, lhs.Rank())}) {
+        if (const Symbol *impure{HasImpureFinal(*entity, lhs.Rank())}) {
           SayDeallocateWithImpureFinal(*entity, reason, *impure);
         }
       }
@@ -260,7 +260,7 @@ public:
           SayDeallocateOfPolymorphic(
               currentStatementSourcePosition_, entity, reason);
         }
-        if (const Symbol * impure{HasImpureFinal(entity)}) {
+        if (const Symbol *impure{HasImpureFinal(entity)}) {
           SayDeallocateWithImpureFinal(entity, reason, *impure);
         }
       }
@@ -296,7 +296,7 @@ public:
       if (name->symbol) {
         const Symbol &ultimate{name->symbol->GetUltimate()};
         const Scope &scope{ultimate.owner()};
-        if (const Symbol * module{scope.IsModule() ? scope.symbol() : nullptr};
+        if (const Symbol *module{scope.IsModule() ? scope.symbol() : nullptr};
             module &&
             (module->name() == "__fortran_ieee_arithmetic" ||
                 module->name() == "__fortran_ieee_exceptions")) {
@@ -356,7 +356,7 @@ public:
 
   // Check to see if the name is a variable from an enclosing scope
   void Post(const parser::Name &name) {
-    if (const Symbol * symbol{name.symbol}) {
+    if (const Symbol *symbol{name.symbol}) {
       if (IsVariableName(*symbol)) {
         const Scope &variableScope{symbol->owner()};
         if (DoesScopeContain(&variableScope, blockScope_)) {
@@ -443,8 +443,7 @@ public:
   }
 
   void Check(const parser::ForallAssignmentStmt &stmt) {
-    if (const evaluate::Assignment *
-        assignment{common::visit(
+    if (const evaluate::Assignment *assignment{common::visit(
             common::visitors{[&](const auto &x) { return GetAssignment(x); }},
             stmt.u)}) {
       CheckForallIndexesUsed(*assignment);
@@ -452,7 +451,7 @@ public:
       CheckForImpureCall(assignment->rhs, kind_);
 
       if (IsVariable(assignment->lhs)) {
-        if (const Symbol * symbol{GetLastSymbol(assignment->lhs)}) {
+        if (const Symbol *symbol{GetLastSymbol(assignment->lhs)}) {
           if (auto impureFinal{
                   HasImpureFinal(*symbol, assignment->lhs.Rank())}) {
             context_.SayWithDecl(*symbol, parser::FindSourceLocation(stmt),
@@ -504,7 +503,7 @@ private:
 
   void CheckDoVariable(const parser::ScalarName &scalarName) {
     const parser::CharBlock &sourceLocation{scalarName.thing.source};
-    if (const Symbol * symbol{scalarName.thing.symbol}) {
+    if (const Symbol *symbol{scalarName.thing.symbol}) {
       if (!IsVariableName(*symbol)) {
         context_.Say(
             sourceLocation, "DO control must be an INTEGER variable"_err_en_US);
@@ -532,7 +531,7 @@ private:
 
   // Semantic checks for the limit and step expressions
   void CheckDoExpression(const parser::ScalarExpr &scalarExpression) {
-    if (const SomeExpr * expr{GetExpr(context_, scalarExpression)}) {
+    if (const SomeExpr *expr{GetExpr(context_, scalarExpression)}) {
       if (!ExprHasTypeCategory(*expr, TypeCategory::Integer)) {
         // No warnings or errors for type INTEGER
         const parser::CharBlock &loc{scalarExpression.thing.value().source};
@@ -592,7 +591,7 @@ private:
         // Loop through the names in the Local locality-spec getting their
         // symbols
         for (const parser::Name &name : names->v) {
-          if (const Symbol * symbol{parentScope.FindSymbol(name.source)}) {
+          if (const Symbol *symbol{parentScope.FindSymbol(name.source)}) {
             symbols.insert(ResolveAssociations(*symbol));
           }
         }
@@ -1077,8 +1076,8 @@ static void CheckIfArgIsDoVar(const evaluate::ActualArgument &arg,
     const parser::CharBlock location, SemanticsContext &context) {
   common::Intent intent{arg.dummyIntent()};
   if (intent == common::Intent::Out || intent == common::Intent::InOut) {
-    if (const SomeExpr * argExpr{arg.UnwrapExpr()}) {
-      if (const Symbol * var{evaluate::UnwrapWholeSymbolDataRef(*argExpr)}) {
+    if (const SomeExpr *argExpr{arg.UnwrapExpr()}) {
+      if (const Symbol *var{evaluate::UnwrapWholeSymbolDataRef(*argExpr)}) {
         if (intent == common::Intent::Out) {
           context.CheckIndexVarRedefine(location, *var);
         } else {
@@ -1153,7 +1152,7 @@ void DoForallChecker::Enter(const parser::Expr &parsedExpr) { ++exprDepth_; }
 void DoForallChecker::Leave(const parser::Expr &parsedExpr) {
   CHECK(exprDepth_ > 0);
   if (--exprDepth_ == 0) { // Only check top level expressions
-    if (const SomeExpr * expr{GetExpr(context_, parsedExpr)}) {
+    if (const SomeExpr *expr{GetExpr(context_, parsedExpr)}) {
       ActualArgumentSet argSet{CollectActualArguments(*expr)};
       for (const evaluate::ActualArgumentRef &argRef : argSet) {
         CheckIfArgIsDoVar(*argRef, parsedExpr.source, context_);

--- a/flang/lib/Semantics/check-io.cpp
+++ b/flang/lib/Semantics/check-io.cpp
@@ -552,7 +552,7 @@ void IoChecker::Enter(const parser::IoControlSpec::Size &var) {
 }
 
 void IoChecker::Enter(const parser::IoUnit &spec) {
-  if (const parser::Variable * var{std::get_if<parser::Variable>(&spec.u)}) {
+  if (const parser::Variable *var{std::get_if<parser::Variable>(&spec.u)}) {
     // Only now after generic resolution can it be known whether a function
     // call appearing as UNIT=f() is an integer scalar external unit number
     // or a character pointer for internal I/O.
@@ -783,7 +783,7 @@ void IoChecker::Leave(const parser::PrintStmt &) {
 static const parser::Name *FindNamelist(
     const std::list<parser::IoControlSpec> &controls) {
   for (const auto &control : controls) {
-    if (const parser::Name * namelist{std::get_if<parser::Name>(&control.u)}) {
+    if (const parser::Name *namelist{std::get_if<parser::Name>(&control.u)}) {
       if (namelist->symbol &&
           namelist->symbol->GetUltimate().has<NamelistDetails>()) {
         return namelist;
@@ -797,8 +797,8 @@ static void CheckForDoVariable(
     const parser::ReadStmt &readStmt, SemanticsContext &context) {
   const std::list<parser::InputItem> &items{readStmt.items};
   for (const auto &item : items) {
-    if (const parser::Variable *
-        variable{std::get_if<parser::Variable>(&item.u)}) {
+    if (const parser::Variable *variable{
+            std::get_if<parser::Variable>(&item.u)}) {
       context.CheckIndexVarRedefine(*variable);
     }
   }
@@ -808,7 +808,7 @@ void IoChecker::Leave(const parser::ReadStmt &readStmt) {
   if (!flags_.test(Flag::InternalUnit)) {
     CheckForPureSubprogram();
   }
-  if (const parser::Name * namelist{FindNamelist(readStmt.controls)}) {
+  if (const parser::Name *namelist{FindNamelist(readStmt.controls)}) {
     if (namelist->symbol) {
       CheckNamelist(*namelist->symbol, common::DefinedIo::ReadFormatted,
           namelist->source);
@@ -863,7 +863,7 @@ void IoChecker::Leave(const parser::WriteStmt &writeStmt) {
   if (!flags_.test(Flag::InternalUnit)) {
     CheckForPureSubprogram();
   }
-  if (const parser::Name * namelist{FindNamelist(writeStmt.controls)}) {
+  if (const parser::Name *namelist{FindNamelist(writeStmt.controls)}) {
     if (namelist->symbol) {
       CheckNamelist(*namelist->symbol, common::DefinedIo::WriteFormatted,
           namelist->source);
@@ -1106,18 +1106,17 @@ static const Symbol *FindUnsafeIoDirectComponent(common::DefinedIo which,
   if (HasDefinedIo(which, derived, &scope)) {
     return nullptr;
   }
-  if (const Scope * dtScope{derived.scope()}) {
+  if (const Scope *dtScope{derived.scope()}) {
     for (const auto &pair : *dtScope) {
       const Symbol &symbol{*pair.second};
       if (IsAllocatableOrPointer(symbol)) {
         return &symbol;
       }
       if (const auto *details{symbol.detailsIf<ObjectEntityDetails>()}) {
-        if (const DeclTypeSpec * type{details->type()}) {
+        if (const DeclTypeSpec *type{details->type()}) {
           if (type->category() == DeclTypeSpec::Category::TypeDerived) {
             const DerivedTypeSpec &componentDerived{type->derivedTypeSpec()};
-            if (const Symbol *
-                bad{FindUnsafeIoDirectComponent(
+            if (const Symbol *bad{FindUnsafeIoDirectComponent(
                     which, componentDerived, scope)}) {
               return bad;
             }
@@ -1134,8 +1133,8 @@ static const Symbol *FindUnsafeIoDirectComponent(common::DefinedIo which,
 // in which the type was defined.
 static const Symbol *FindInaccessibleComponent(common::DefinedIo which,
     const DerivedTypeSpec &derived, const Scope &scope) {
-  if (const Scope * dtScope{derived.scope()}) {
-    if (const Scope * module{FindModuleContaining(*dtScope)}) {
+  if (const Scope *dtScope{derived.scope()}) {
+    if (const Scope *module{FindModuleContaining(*dtScope)}) {
       for (const auto &pair : *dtScope) {
         const Symbol &symbol{*pair.second};
         if (IsAllocatableOrPointer(symbol)) {
@@ -1143,7 +1142,7 @@ static const Symbol *FindInaccessibleComponent(common::DefinedIo which,
         }
         if (const auto *details{symbol.detailsIf<ObjectEntityDetails>()}) {
           const DerivedTypeSpec *componentDerived{nullptr};
-          if (const DeclTypeSpec * type{details->type()}) {
+          if (const DeclTypeSpec *type{details->type()}) {
             if (type->category() == DeclTypeSpec::Category::TypeDerived) {
               componentDerived = &type->derivedTypeSpec();
             }
@@ -1159,8 +1158,7 @@ static const Symbol *FindInaccessibleComponent(common::DefinedIo which,
             }
           }
           if (componentDerived) {
-            if (const Symbol *
-                bad{FindInaccessibleComponent(
+            if (const Symbol *bad{FindInaccessibleComponent(
                     which, *componentDerived, scope)}) {
               return bad;
             }
@@ -1181,8 +1179,7 @@ parser::Message *IoChecker::CheckForBadIoType(const evaluate::DynamicType &type,
   } else if (type.category() == TypeCategory::Derived) {
     const auto &derived{type.GetDerivedTypeSpec()};
     const Scope &scope{context_.FindScope(where)};
-    if (const Symbol *
-        bad{FindUnsafeIoDirectComponent(which, derived, scope)}) {
+    if (const Symbol *bad{FindUnsafeIoDirectComponent(which, derived, scope)}) {
       return &context_.SayWithDecl(*bad, where,
           "Derived type '%s' in I/O cannot have an allocatable or pointer direct component '%s' unless using defined I/O"_err_en_US,
           derived.name(), bad->name());
@@ -1199,8 +1196,7 @@ parser::Message *IoChecker::CheckForBadIoType(const evaluate::DynamicType &type,
         // Bypass the check below for c_ptr and c_devptr.
         return nullptr;
       }
-      if (const Symbol *
-          bad{FindInaccessibleComponent(which, derived, scope)}) {
+      if (const Symbol *bad{FindInaccessibleComponent(which, derived, scope)}) {
         return &context_.Say(where,
             "I/O of the derived type '%s' may not be performed without defined I/O in a scope in which a direct component like '%s' is inaccessible"_err_en_US,
             derived.name(), bad->name());

--- a/flang/lib/Semantics/check-io.h
+++ b/flang/lib/Semantics/check-io.h
@@ -87,7 +87,7 @@ private:
 
   template <typename R, typename T> std::optional<R> GetConstExpr(const T &x) {
     using DefaultCharConstantType = evaluate::Ascii;
-    if (const SomeExpr * expr{GetExpr(context_, x)}) {
+    if (const SomeExpr *expr{GetExpr(context_, x)}) {
       const auto foldExpr{
           evaluate::Fold(context_.foldingContext(), common::Clone(*expr))};
       if constexpr (std::is_same_v<R, std::string>) {

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3046,7 +3046,7 @@ void OmpStructureChecker::CheckReductionModifier(
   if (modifier.v == ReductionModifier::Value::Task) {
     // "Task" is only allowed on worksharing or "parallel" directive.
     static llvm::omp::Directive worksharing[]{
-        llvm::omp::Directive::OMPD_do,
+        llvm::omp::Directive::OMPD_do, //
         llvm::omp::Directive::OMPD_scope,
         llvm::omp::Directive::OMPD_sections,
         // There are more worksharing directives, but they do not apply:

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -3047,7 +3047,7 @@ void OmpStructureChecker::CheckReductionModifier(
     // "Task" is only allowed on worksharing or "parallel" directive.
     static llvm::omp::Directive worksharing[]{
         llvm::omp::Directive::OMPD_do, //
-        llvm::omp::Directive::OMPD_scope,
+        llvm::omp::Directive::OMPD_scope, //
         llvm::omp::Directive::OMPD_sections,
         // There are more worksharing directives, but they do not apply:
         // "for" is C++ only,

--- a/flang/lib/Semantics/check-omp-structure.cpp
+++ b/flang/lib/Semantics/check-omp-structure.cpp
@@ -2460,8 +2460,8 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
                                                         &objs,
                                                     std::string clause) {
             for (const auto &obj : objs.v) {
-              if (const parser::Name *
-                  objName{parser::Unwrap<parser::Name>(obj)}) {
+              if (const parser::Name *objName{
+                      parser::Unwrap<parser::Name>(obj)}) {
                 if (&objName->symbol->GetUltimate() == eventHandleSym) {
                   context_.Say(GetContext().clauseSource,
                       "A variable: `%s` that appears in a DETACH clause cannot appear on %s clause on the same construct"_err_en_US,
@@ -3046,7 +3046,8 @@ void OmpStructureChecker::CheckReductionModifier(
   if (modifier.v == ReductionModifier::Value::Task) {
     // "Task" is only allowed on worksharing or "parallel" directive.
     static llvm::omp::Directive worksharing[]{
-        llvm::omp::Directive::OMPD_do, llvm::omp::Directive::OMPD_scope,
+        llvm::omp::Directive::OMPD_do,
+        llvm::omp::Directive::OMPD_scope,
         llvm::omp::Directive::OMPD_sections,
         // There are more worksharing directives, but they do not apply:
         // "for" is C++ only,

--- a/flang/lib/Semantics/check-select-rank.cpp
+++ b/flang/lib/Semantics/check-select-rank.cpp
@@ -31,7 +31,7 @@ void SelectRankConstructChecker::Leave(
   // R1149 select-rank-stmt checks
   const Symbol *saveSelSymbol{nullptr};
   if (const auto selExpr{GetExprFromSelector(selectRankStmtSel)}) {
-    if (const Symbol * sel{evaluate::UnwrapWholeSymbolDataRef(*selExpr)}) {
+    if (const Symbol *sel{evaluate::UnwrapWholeSymbolDataRef(*selExpr)}) {
       if (!evaluate::IsAssumedRank(*sel)) { // C1150
         context_.Say(parser::FindSourceLocation(selectRankStmtSel),
             "Selector '%s' is not an assumed-rank array variable"_err_en_US,

--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -191,7 +191,7 @@ void ComputeOffsetsHelper::Compute(Scope &scope) {
       }
       DoSymbol(*symbol, newAlign);
       if (auto *generic{symbol->detailsIf<GenericDetails>()}) {
-        if (Symbol * specific{generic->specific()};
+        if (Symbol *specific{generic->specific()};
             specific && !FindCommonBlockContaining(*specific)) {
           // might be a shadowed procedure pointer
           DoSymbol(*specific);
@@ -379,8 +379,8 @@ std::size_t ComputeOffsetsHelper::ComputeOffset(
   auto result{offset * GetSizeAndAlignment(object.symbol, false).size};
   if (object.substringStart) {
     int kind{context_.defaultKinds().GetDefaultKind(TypeCategory::Character)};
-    if (const DeclTypeSpec * type{object.symbol.GetType()}) {
-      if (const IntrinsicTypeSpec * intrinsic{type->AsIntrinsic()}) {
+    if (const DeclTypeSpec *type{object.symbol.GetType()}) {
+      if (const IntrinsicTypeSpec *intrinsic{type->AsIntrinsic()}) {
         kind = ToInt64(intrinsic->kind()).value_or(kind);
       }
     }

--- a/flang/lib/Semantics/data-to-inits.cpp
+++ b/flang/lib/Semantics/data-to-inits.cpp
@@ -216,7 +216,7 @@ bool DataInitializationCompiler<DSV>::Scan(const parser::DataImpliedDo &ido) {
         auto &value{context.StartImpliedDo(name.source, *lower)};
         bool result{true};
         for (auto n{(*upper - value + stepVal) / stepVal}; n > 0;
-             --n, value += stepVal) {
+            --n, value += stepVal) {
           for (const auto &object :
               std::get<std::list<parser::DataIDoObject>>(ido.t)) {
             if (!Scan(object)) {
@@ -511,7 +511,7 @@ static const DerivedTypeSpec *HasDefaultInitialization(const Symbol &symbol) {
     if (object->init().has_value()) {
       return nullptr; // init is explicit, not default
     } else if (!object->isDummy() && object->type()) {
-      if (const DerivedTypeSpec * derived{object->type()->AsDerived()}) {
+      if (const DerivedTypeSpec *derived{object->type()->AsDerived()}) {
         DirectComponentIterator directs{*derived};
         if (llvm::any_of(directs, [](const Symbol &component) {
               return !IsAllocatable(component) &&
@@ -544,7 +544,7 @@ static void PopulateWithComponentDefaults(SymbolDataInitialization &init,
       stride = ((stride + alignment - 1) / alignment) * alignment;
     }
     for (auto elements{evaluate::GetSize(*extents)}; elements-- > 0;
-         offset += stride) {
+        offset += stride) {
       PopulateWithComponentDefaults(init, offset, derived, foldingContext);
     }
   }
@@ -588,8 +588,8 @@ static void PopulateWithComponentDefaults(SymbolDataInitialization &init,
                   foldingContext);
             }
           }
-        } else if (const DeclTypeSpec * type{component.GetType()}) {
-          if (const DerivedTypeSpec * componentDerived{type->AsDerived()}) {
+        } else if (const DeclTypeSpec *type{component.GetType()}) {
+          if (const DerivedTypeSpec *componentDerived{type->AsDerived()}) {
             PopulateWithComponentDefaults(init, componentOffset,
                 *componentDerived, foldingContext, component);
           }
@@ -829,7 +829,7 @@ static bool CombineEquivalencedInitialization(
         !HasDeclarationInitializer(symbol) && IsSaved(symbol) &&
         equivalenced.find(symbol) == equivalenced.end()) {
       // Static object, no local storage association, no explicit initialization
-      if (const DerivedTypeSpec * derived{HasDefaultInitialization(symbol)}) {
+      if (const DerivedTypeSpec *derived{HasDefaultInitialization(symbol)}) {
         auto newInitIter{inits.emplace(&symbol, symbol.size())};
         CHECK(newInitIter.second);
         auto &newInit{newInitIter.first->second};

--- a/flang/lib/Semantics/definable.cpp
+++ b/flang/lib/Semantics/definable.cpp
@@ -65,8 +65,7 @@ static std::optional<parser::Message> CheckDefinabilityInPureScope(
 // F'2023 9.4.2p5
 static bool DefinesComponentPointerTarget(
     const evaluate::DataRef &dataRef, DefinabilityFlags flags) {
-  if (const evaluate::Component *
-      component{common::visit(
+  if (const evaluate::Component *component{common::visit(
           common::visitors{
               [](const SymbolRef &) -> const evaluate::Component * {
                 return nullptr;
@@ -134,7 +133,7 @@ static std::optional<parser::Message> WhyNotDefinableBase(parser::CharBlock at,
   } else if (!flags.test(DefinabilityFlag::DoNotNoteDefinition)) {
     scope.context().NoteDefinedSymbol(ultimate);
   }
-  if (const Scope * pure{FindPureProcedureContaining(scope)}) {
+  if (const Scope *pure{FindPureProcedureContaining(scope)}) {
     // Additional checking for pure subprograms.
     if (!isTargetDefinition || isComponentPointerTarget) {
       if (auto msg{CheckDefinabilityInPureScope(
@@ -142,15 +141,14 @@ static std::optional<parser::Message> WhyNotDefinableBase(parser::CharBlock at,
         return msg;
       }
     }
-    if (const Symbol *
-        visible{FindExternallyVisibleObject(
+    if (const Symbol *visible{FindExternallyVisibleObject(
             ultimate, *pure, isPointerDefinition)}) {
       return BlameSymbol(at,
           "'%s' is externally visible via '%s' and not definable in a pure subprogram"_en_US,
           original, visible->name());
     }
   }
-  if (const Scope * deviceContext{FindCUDADeviceContext(&scope)}) {
+  if (const Scope *deviceContext{FindCUDADeviceContext(&scope)}) {
     bool isOwnedByDeviceCode{deviceContext->Contains(ultimate.owner())};
     if (isPointerDefinition && !acceptAllocatable) {
       return BlameSymbol(at,
@@ -220,12 +218,12 @@ static std::optional<parser::Message> WhyNotDefinableLast(parser::CharBlock at,
         original);
   }
   if (dyType && inPure) {
-    if (const Symbol * impure{HasImpureFinal(ultimate)}) {
+    if (const Symbol *impure{HasImpureFinal(ultimate)}) {
       return BlameSymbol(at, "'%s' has an impure FINAL procedure '%s'"_en_US,
           original, impure->name());
     }
     if (!flags.test(DefinabilityFlag::PolymorphicOkInPure)) {
-      if (const DerivedTypeSpec * derived{GetDerivedTypeSpec(dyType)}) {
+      if (const DerivedTypeSpec *derived{GetDerivedTypeSpec(dyType)}) {
         if (auto bad{FindPolymorphicAllocatablePotentialComponent(*derived)}) {
           return BlameSymbol(at,
               "'%s' has polymorphic component '%s' in a pure subprogram"_en_US,
@@ -336,7 +334,7 @@ std::optional<parser::Message> WhyNotDefinable(parser::CharBlock at,
                 anyElemental |= ultimate.attrs().test(Attr::ELEMENTAL);
                 if (const auto *subp{ultimate.detailsIf<SubprogramDetails>()}) {
                   if (!subp->dummyArgs().empty()) {
-                    if (const Symbol * arg{subp->dummyArgs()[0]}) {
+                    if (const Symbol *arg{subp->dummyArgs()[0]}) {
                       const auto *object{arg->detailsIf<ObjectEntityDetails>()};
                       if (arg->Rank() == rank ||
                           (object && object->IsAssumedRank())) {
@@ -388,7 +386,7 @@ std::optional<parser::Message> WhyNotDefinable(parser::CharBlock at,
     if (const auto *procDesignator{
             std::get_if<evaluate::ProcedureDesignator>(&expr.u)}) {
       // Defining a procedure pointer
-      if (const Symbol * procSym{procDesignator->GetSymbol()}) {
+      if (const Symbol *procSym{procDesignator->GetSymbol()}) {
         if (evaluate::ExtractCoarrayRef(expr)) { // C1027
           return BlameSymbol(at,
               "Procedure pointer '%s' may not be a coindexed object"_err_en_US,

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -250,7 +250,7 @@ MaybeExpr ExpressionAnalyzer::Designate(DataRef &&ref) {
       }
     } else if (auto interface{context_.intrinsics().IsSpecificIntrinsicFunction(
                    symbol.name().ToString())};
-               interface && !interface->isRestrictedSpecific) {
+        interface && !interface->isRestrictedSpecific) {
       SpecificIntrinsic intrinsic{
           symbol.name().ToString(), std::move(*interface)};
       intrinsic.isRestrictedSpecific = interface->isRestrictedSpecific;
@@ -1070,8 +1070,8 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Name &n) {
         // instantiations.
         int kind{SubscriptInteger::kind};
         if (const auto *typeSpec{ultimate.GetType()}) {
-          if (const semantics::IntrinsicTypeSpec *
-              intrinType{typeSpec->AsIntrinsic()}) {
+          if (const semantics::IntrinsicTypeSpec *intrinType{
+                  typeSpec->AsIntrinsic()}) {
             if (auto k{ToInt64(Fold(semantics::KindExpr{intrinType->kind()}))};
                 k &&
                 common::IsValidKindOfIntrinsicType(TypeCategory::Integer, *k)) {
@@ -1956,7 +1956,7 @@ void ArrayConstructorContext::Add(const parser::AcImpliedDo &impliedDo) {
   exprAnalyzer_.Analyze(bounds.name);
   parser::CharBlock name{bounds.name.thing.thing.source};
   int kind{ImpliedDoIntType::kind};
-  if (const Symbol * symbol{bounds.name.thing.thing.symbol}) {
+  if (const Symbol *symbol{bounds.name.thing.thing.symbol}) {
     if (auto dynamicType{DynamicType::From(symbol)}) {
       if (dynamicType->category() == TypeCategory::Integer) {
         kind = dynamicType->kind();
@@ -2045,8 +2045,8 @@ void ArrayConstructorContext::UnrollConstantImpliedDo(
   auto &foldingContext{exprAnalyzer_.GetFoldingContext()};
   auto restorer{exprAnalyzer_.DoNotUseSavedTypedExprs()};
   for (auto &at{foldingContext.StartImpliedDo(name, lower)};
-       (stride > 0 && at <= upper) || (stride < 0 && at >= upper);
-       at += stride) {
+      (stride > 0 && at <= upper) || (stride < 0 && at >= upper);
+      at += stride) {
     for (const auto &value :
         std::get<std::list<parser::AcValue>>(impliedDo.t)) {
       Add(value);
@@ -2172,7 +2172,7 @@ MaybeExpr ExpressionAnalyzer::CheckStructureConstructor(
       if (nextAnonymous == components.begin() && parentComponent && valueType &&
           context().IsEnabled(LanguageFeature::AnonymousParents)) {
         for (auto parent{components.begin()};
-             parent != afterLastParentComponentIter; ++parent) {
+            parent != afterLastParentComponentIter; ++parent) {
           if (auto parentType{DynamicType::From(*parent)}; parentType &&
               parent->test(Symbol::Flag::ParentComp) &&
               valueType->IsEquivalentTo(*parentType)) {
@@ -2279,8 +2279,7 @@ MaybeExpr ExpressionAnalyzer::CheckStructureConstructor(
                      evaluate::DynamicType::From(*symbol))}) {
         if (auto iter{FindPointerPotentialComponent(*derived)};
             iter && pureContext) { // F'2023 C15104(4)
-          if (const Symbol *
-              visible{semantics::FindExternallyVisibleObject(
+          if (const Symbol *visible{semantics::FindExternallyVisibleObject(
                   value, *pureContext)}) {
             Say(exprSource,
                 "The externally visible object '%s' may not be used in a pure procedure as the value for component '%s' which has the pointer component '%s'"_err_en_US,
@@ -2445,9 +2444,7 @@ static std::optional<parser::CharBlock> GetPassName(
 static std::optional<int> GetPassIndex(const Symbol &proc) {
   CHECK(!proc.attrs().test(semantics::Attr::NOPASS));
   std::optional<parser::CharBlock> passName{GetPassName(proc)};
-  const auto *interface {
-    semantics::FindInterface(proc)
-  };
+  const auto *interface{semantics::FindInterface(proc)};
   if (!passName || !interface) {
     return 0; // first argument is passed-object
   }
@@ -2552,9 +2549,9 @@ auto ExpressionAnalyzer::AnalyzeProcedureComponentRef(
           // binding to be overridden by a PRIVATE one.
           CHECK(dyType && dyType->category() == TypeCategory::Derived &&
               !dyType->IsUnlimitedPolymorphic());
-          if (const Symbol *
-              latest{DEREF(dyType->GetDerivedTypeSpec().typeSymbol().scope())
-                         .FindComponent(sym->name())}) {
+          if (const Symbol *latest{
+                  DEREF(dyType->GetDerivedTypeSpec().typeSymbol().scope())
+                      .FindComponent(sym->name())}) {
             if (sym->attrs().test(semantics::Attr::PRIVATE)) {
               const auto *bindingModule{FindModuleContaining(generic.owner())};
               const Symbol *s{latest};
@@ -2951,7 +2948,7 @@ std::pair<const Symbol *, bool> ExpressionAnalyzer::ResolveGeneric(
   // Is there a derived type of the same name?
   const Symbol *derivedType{nullptr};
   if (mightBeStructureConstructor && !isSubroutine && genericDetails) {
-    if (const Symbol * dt{genericDetails->derivedType()}) {
+    if (const Symbol *dt{genericDetails->derivedType()}) {
       const Symbol &ultimate{dt->GetUltimate()};
       if (ultimate.has<semantics::DerivedTypeDetails>()) {
         derivedType = &ultimate;
@@ -2965,7 +2962,7 @@ std::pair<const Symbol *, bool> ExpressionAnalyzer::ResolveGeneric(
           common::LanguageFeature::AmbiguousStructureConstructor)) {
     // See whethr there's ambiguity with a structure constructor.
     bool possiblyAmbiguous{true};
-    if (const semantics::Scope * dtScope{derivedType->scope()}) {
+    if (const semantics::Scope *dtScope{derivedType->scope()}) {
       parser::Messages buffer;
       auto restorer{GetContextualMessages().SetMessages(buffer)};
       std::list<ComponentSpec> componentSpecs;
@@ -3022,7 +3019,7 @@ std::pair<const Symbol *, bool> ExpressionAnalyzer::ResolveGeneric(
   }
   // Check parent derived type
   if (const auto *parentScope{symbol.owner().GetDerivedTypeParent()}) {
-    if (const Symbol * extended{parentScope->FindComponent(symbol.name())}) {
+    if (const Symbol *extended{parentScope->FindComponent(symbol.name())}) {
       auto pair{ResolveGeneric(
           *extended, actuals, adjustActuals, isSubroutine, false)};
       if (pair.first) {
@@ -3037,8 +3034,8 @@ std::pair<const Symbol *, bool> ExpressionAnalyzer::ResolveGeneric(
   // Check for generic or explicit INTRINSIC of the same name in outer scopes.
   // See 15.5.5.2 for details.
   if (!symbol.owner().IsGlobal() && !symbol.owner().IsDerivedType()) {
-    if (const Symbol *
-        outer{symbol.owner().parent().FindSymbol(symbol.name())}) {
+    if (const Symbol *outer{
+            symbol.owner().parent().FindSymbol(symbol.name())}) {
       auto pair{ResolveGeneric(*outer, actuals, adjustActuals, isSubroutine,
           mightBeStructureConstructor)};
       if (pair.first) {
@@ -3438,7 +3435,7 @@ void ExpressionAnalyzer::Analyze(const parser::CallStmt &callStmt) {
       ProcedureDesignator *proc{std::get_if<ProcedureDesignator>(&callee->u)};
       CHECK(proc);
       bool isKernel{false};
-      if (const Symbol * procSym{proc->GetSymbol()}) {
+      if (const Symbol *procSym{proc->GetSymbol()}) {
         const Symbol &ultimate{procSym->GetUltimate()};
         if (const auto *subpDetails{
                 ultimate.detailsIf<semantics::SubprogramDetails>()}) {
@@ -3648,8 +3645,7 @@ std::optional<characteristics::Procedure> ExpressionAnalyzer::CheckCall(
         /*ignoreImplicitVsExplicit=*/false, specificIntrinsic);
   }
   if (procSymbol && !IsPureProcedure(*procSymbol)) {
-    if (const semantics::Scope *
-        pure{semantics::FindPureProcedureContaining(
+    if (const semantics::Scope *pure{semantics::FindPureProcedureContaining(
             context_.FindScope(callSite))}) {
       Say(callSite,
           "Procedure '%s' referenced in pure subprogram '%s' must be pure too"_err_en_US,
@@ -4027,7 +4023,8 @@ static void FixMisparsedFunctionReference(
       }
     }
     auto &proc{std::get<parser::ProcedureDesignator>(funcRef.v.t)};
-    if (Symbol *origSymbol{
+    if (Symbol *
+        origSymbol{
             common::visit(common::visitors{
                               [&](parser::Name &name) { return name.symbol; },
                               [&](parser::ProcComponentRef &pcr) {
@@ -4586,7 +4583,7 @@ bool ArgumentAnalyzer::CheckConformance() {
         if (!evaluate::CheckConformance(foldingContext.messages(), *lhShape,
                 *rhShape, CheckConformanceFlags::EitherScalarExpandable,
                 "left operand", "right operand")
-                 .value_or(false /*fail when conformance is not known now*/)) {
+                .value_or(false /*fail when conformance is not known now*/)) {
           fatalErrors_ = true;
           return false;
         }
@@ -4608,7 +4605,7 @@ bool ArgumentAnalyzer::CheckAssignmentConformance() {
         if (!evaluate::CheckConformance(foldingContext.messages(), *lhShape,
                 *rhShape, CheckConformanceFlags::RightScalarExpandable,
                 "left-hand side", "right-hand side")
-                 .value_or(true /*ok when conformance is not known now*/)) {
+                .value_or(true /*ok when conformance is not known now*/)) {
           fatalErrors_ = true;
           return false;
         }
@@ -4732,7 +4729,7 @@ MaybeExpr ArgumentAnalyzer::TryDefinedOp(
       }
     }};
 
-    if (Symbol * generic{scope.FindSymbol(oprName)}; generic && !fatalErrors_) {
+    if (Symbol *generic{scope.FindSymbol(oprName)}; generic && !fatalErrors_) {
       parser::Name name{generic->name(), generic};
       const Symbol *resultSymbol{nullptr};
       MaybeExpr possibleResult{context_.AnalyzeDefinedOp(
@@ -4742,8 +4739,7 @@ MaybeExpr ArgumentAnalyzer::TryDefinedOp(
     for (std::size_t passIndex{0}; passIndex < actuals_.size(); ++passIndex) {
       buffer.clear();
       const Symbol *generic{nullptr};
-      if (const Symbol *
-          binding{FindBoundOp(
+      if (const Symbol *binding{FindBoundOp(
               oprName, passIndex, generic, /*isSubroutine=*/false)}) {
         FoundOne(TryBoundOp(*binding, passIndex), DEREF(generic), binding);
       }

--- a/flang/lib/Semantics/mod-file.cpp
+++ b/flang/lib/Semantics/mod-file.cpp
@@ -249,7 +249,7 @@ static void HarvestSymbolsNeededFromOtherModules(
       HarvestSymbolsNeededFromOtherModules(set, *symbol.scope());
     }
   } else if (const auto &generic{symbol.detailsIf<GenericDetails>()};
-             generic && generic->derivedType()) {
+      generic && generic->derivedType()) {
     const Symbol &dtSym{*generic->derivedType()};
     if (dtSym.has<DerivedTypeDetails>()) {
       if (dtSym.scope()) {
@@ -324,7 +324,7 @@ void ModFileWriter::PrepareRenamings(const Scope &scope) {
       continue;
     }
     SourceName rename{s->name()};
-    if (const Symbol * found{scope.FindSymbol(s->name())}) {
+    if (const Symbol *found{scope.FindSymbol(s->name())}) {
       if (found == &*s) {
         continue; // available in scope
       }
@@ -553,7 +553,7 @@ void ModFileWriter::PutDerivedType(
     return;
   }
   PutAttrs(decls_ << "type", typeSymbol.attrs());
-  if (const DerivedTypeSpec * extends{typeSymbol.GetParentTypeSpec()}) {
+  if (const DerivedTypeSpec *extends{typeSymbol.GetParentTypeSpec()}) {
     decls_ << ",extends(" << extends->name() << ')';
   }
   decls_ << "::" << typeSymbol.name();
@@ -685,7 +685,7 @@ static void PutOpenACCRoutineInfo(
 
 void ModFileWriter::PutSubprogram(const Symbol &symbol) {
   auto &details{symbol.get<SubprogramDetails>()};
-  if (const Symbol * interface{details.moduleInterface()}) {
+  if (const Symbol *interface{details.moduleInterface()}) {
     const Scope *module{FindModuleContaining(interface->owner())};
     if (module && module != &symbol.owner()) {
       // Interface is in ancestor module
@@ -1345,7 +1345,7 @@ static void GetModuleDependences(
   std::size_t limit{content.size()};
   std::string_view str{content.data(), limit};
   for (std::size_t j{ModHeader::len};
-       str.substr(j, ModHeader::needLen) == ModHeader::need; ++j) {
+      str.substr(j, ModHeader::needLen) == ModHeader::need; ++j) {
     j += 7;
     auto checkSum{ExtractCheckSum(str.substr(j, ModHeader::sumLen))};
     if (!checkSum) {
@@ -1673,7 +1673,7 @@ void SubprogramSymbolCollector::Collect() {
         needed = needed || (spec && useSet_.count(spec->GetUltimate()) > 0) ||
             (dt && useSet_.count(dt->GetUltimate()) > 0);
       } else if (const auto *subp{ultimate.detailsIf<SubprogramDetails>()}) {
-        const Symbol *interface { subp->moduleInterface() };
+        const Symbol *interface{subp->moduleInterface()};
         needed = needed || (interface && useSet_.count(*interface) > 0);
       }
       if (needed) {
@@ -1736,7 +1736,7 @@ void SubprogramSymbolCollector::DoSymbol(
                         DoBound(spec.lbound());
                         DoBound(spec.ubound());
                       }
-                      if (const Symbol * commonBlock{details.commonBlock()}) {
+                      if (const Symbol *commonBlock{details.commonBlock()}) {
                         DoSymbol(*commonBlock);
                       }
                     },
@@ -1789,7 +1789,7 @@ void SubprogramSymbolCollector::DoType(const DeclTypeSpec *type) {
     DoParamValue(type->characterTypeSpec().length());
     break;
   default:
-    if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+    if (const DerivedTypeSpec *derived{type->AsDerived()}) {
       const auto &typeSymbol{derived->typeSymbol()};
       for (const auto &pair : derived->parameters()) {
         DoParamValue(pair.second);
@@ -1798,7 +1798,7 @@ void SubprogramSymbolCollector::DoType(const DeclTypeSpec *type) {
       // any) matter to IMPORT symbol collection only for derived types
       // defined in the subprogram.
       if (typeSymbol.owner() == scope_) {
-        if (const DerivedTypeSpec * extends{typeSymbol.GetParentTypeSpec()}) {
+        if (const DerivedTypeSpec *extends{typeSymbol.GetParentTypeSpec()}) {
           DoSymbol(extends->name(), extends->typeSymbol());
         }
         for (const auto &pair : *typeSymbol.scope()) {
@@ -1811,7 +1811,7 @@ void SubprogramSymbolCollector::DoType(const DeclTypeSpec *type) {
 }
 
 void SubprogramSymbolCollector::DoBound(const Bound &bound) {
-  if (const MaybeSubscriptIntExpr & expr{bound.GetExplicit()}) {
+  if (const MaybeSubscriptIntExpr &expr{bound.GetExplicit()}) {
     DoExpr(*expr);
   }
 }

--- a/flang/lib/Semantics/pointer-assignment.cpp
+++ b/flang/lib/Semantics/pointer-assignment.cpp
@@ -43,8 +43,8 @@ class PointerAssignmentChecker {
 public:
   PointerAssignmentChecker(SemanticsContext &context, const Scope &scope,
       parser::CharBlock source, const std::string &description)
-      : context_{context}, scope_{scope}, source_{source}, description_{
-                                                               description} {}
+      : context_{context}, scope_{scope}, source_{source},
+        description_{description} {}
   PointerAssignmentChecker(
       SemanticsContext &context, const Scope &scope, const Symbol &lhs)
       : context_{context}, scope_{scope}, source_{lhs.name()},
@@ -203,7 +203,7 @@ bool PointerAssignmentChecker::Check(const SomeExpr &rhs) {
   }
   if (const auto *pureProc{FindPureProcedureContaining(scope_)}) {
     if (pointerComponentLHS_) { // F'2023 C15104(4) is a hard error
-      if (const Symbol * object{FindExternallyVisibleObject(rhs, *pureProc)}) {
+      if (const Symbol *object{FindExternallyVisibleObject(rhs, *pureProc)}) {
         if (auto *msg{Say(
                 "Externally visible object '%s' may not be associated with pointer component '%s' in a pure procedure"_err_en_US,
                 object->name(), pointerComponentLHS_->name())}) {
@@ -213,7 +213,7 @@ bool PointerAssignmentChecker::Check(const SomeExpr &rhs) {
         }
         return false;
       }
-    } else if (const Symbol * base{GetFirstSymbol(rhs)}) {
+    } else if (const Symbol *base{GetFirstSymbol(rhs)}) {
       if (const char *why{WhyBaseObjectIsSuspicious(
               base->GetUltimate(), scope_)}) { // C1594(3)
         evaluate::SayWithDeclaration(foldingContext_.messages(), *base,

--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -949,7 +949,7 @@ const parser::Name *DirectiveAttributeVisitor<T>::GetLoopIndex(
     const parser::DoConstruct &x) {
   using Bounds = parser::LoopControl::Bounds;
   if (x.GetLoopControl()) {
-    if (const Bounds * b{std::get_if<Bounds>(&x.GetLoopControl()->u)}) {
+    if (const Bounds *b{std::get_if<Bounds>(&x.GetLoopControl()->u)}) {
       return &b->name.thing;
     } else {
       return nullptr;
@@ -1310,7 +1310,7 @@ bool AccAttributeVisitor::Pre(const parser::OpenACCCombinedConstruct &x) {
 static bool IsLastNameArray(const parser::Designator &designator) {
   const auto &name{GetLastName(designator)};
   const evaluate::DataRef dataRef{*(name.symbol)};
-  return common::visit(
+  return common::visit( //
       common::visitors{
           [](const evaluate::SymbolRef &ref) {
             return ref->Rank() > 0 ||
@@ -1481,10 +1481,10 @@ void AccAttributeVisitor::CheckAssociatedLoop(
   using Bounds = parser::LoopControl::Bounds;
   for (const parser::DoConstruct *loop{&outerDoConstruct}; loop && level > 0;) {
     // Go through all nested loops to ensure index variable exists.
-    if (const parser::Name * ivName{GetLoopIndex(*loop)}) {
+    if (const parser::Name *ivName{GetLoopIndex(*loop)}) {
       if (auto *symbol{ResolveAcc(*ivName, flag, currScope())}) {
         if (auto &control{loop->GetLoopControl()}) {
-          if (const Bounds * b{std::get_if<Bounds>(&control->u)}) {
+          if (const Bounds *b{std::get_if<Bounds>(&control->u)}) {
             if (auto lowerExpr{semantics::AnalyzeExpr(context_, b->lower)}) {
               semantics::UnorderedSymbolSet lowerSyms =
                   evaluate::CollectSymbols(*lowerExpr);
@@ -1906,7 +1906,7 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
   }
   // If this symbol already has a data-sharing attribute then there is nothing
   // to do here.
-  if (const Symbol * symbol{iv.symbol}) {
+  if (const Symbol *symbol{iv.symbol}) {
     for (auto symMap : targetIt->objectWithDSA) {
       if (symMap.first->name() == symbol->name()) {
         return;
@@ -2732,7 +2732,7 @@ Symbol *OmpAttributeVisitor::ResolveOmpCommonBlockName(
     return nullptr;
   }
   if (auto *cb{GetProgramUnitOrBlockConstructContaining(GetContext().scope)
-                   .FindCommonBlock(name->source)}) {
+              .FindCommonBlock(name->source)}) {
     name->symbol = cb;
     return cb;
   }
@@ -3107,19 +3107,18 @@ void ResolveOmpTopLevelParts(
   // Combine global REQUIRES information from all program units except modules
   // and submodules.
   processProgramUnits([&](Symbol &symbol, WithOmpDeclarative &details) {
-    if (const WithOmpDeclarative::RequiresFlags *
-        flags{details.ompRequires()}) {
+    if (const WithOmpDeclarative::RequiresFlags *flags{details.ompRequires()}) {
       combinedFlags |= *flags;
     }
-    if (const common::OmpMemoryOrderType *
-        memOrder{details.ompAtomicDefaultMemOrder()}) {
+    if (const common::OmpMemoryOrderType *memOrder{
+            details.ompAtomicDefaultMemOrder()}) {
       if (combinedMemOrder && *combinedMemOrder != *memOrder) {
         context.Say(symbol.scope()->sourceRange(),
             "Conflicting '%s' REQUIRES clauses found in compilation "
             "unit"_err_en_US,
             parser::ToUpperCaseLetters(llvm::omp::getOpenMPClauseName(
                 llvm::omp::Clause::OMPC_atomic_default_mem_order)
-                                           .str()));
+                    .str()));
       }
       combinedMemOrder = *memOrder;
     }
@@ -3345,8 +3344,8 @@ void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
             if constexpr (std::is_convertible_v<decltype(&details),
                               WithOmpDeclarative *>) {
               if (flags.any()) {
-                if (const WithOmpDeclarative::RequiresFlags *
-                    otherFlags{details.ompRequires()}) {
+                if (const WithOmpDeclarative::RequiresFlags *otherFlags{
+                        details.ompRequires()}) {
                   flags |= *otherFlags;
                 }
                 details.set_ompRequires(flags);
@@ -3359,7 +3358,7 @@ void OmpAttributeVisitor::AddOmpRequiresToScope(Scope &scope,
                       "unit"_err_en_US,
                       parser::ToUpperCaseLetters(llvm::omp::getOpenMPClauseName(
                           llvm::omp::Clause::OMPC_atomic_default_mem_order)
-                                                     .str()));
+                              .str()));
                 }
                 details.set_ompAtomicDefaultMemOrder(*memOrder);
               }

--- a/flang/lib/Semantics/resolve-labels.cpp
+++ b/flang/lib/Semantics/resolve-labels.cpp
@@ -383,9 +383,9 @@ public:
   template <typename FIRST, typename CONSTRUCT, typename STMT>
   void CheckOptionalName(const char *constructTag, const CONSTRUCT &a,
       const parser::Statement<STMT> &stmt) {
-    if (const parser::CharBlock * name{GetStmtName(stmt)}) {
+    if (const parser::CharBlock *name{GetStmtName(stmt)}) {
       const auto &firstStmt{std::get<parser::Statement<FIRST>>(a.t)};
-      if (const parser::CharBlock * firstName{GetStmtName(firstStmt)}) {
+      if (const parser::CharBlock *firstName{GetStmtName(firstStmt)}) {
         if (*firstName != *name) {
           context_.Say(*name, "%s name mismatch"_err_en_US, constructTag)
               .Attach(*firstName, "should be"_en_US);
@@ -504,9 +504,9 @@ public:
       progName = &program->statement.v.source;
       upperCaseCharBlock(*progName);
     }
-    if (const parser::CharBlock *
-        endName{GetStmtName(std::get<parser::Statement<parser::EndProgramStmt>>(
-            mainProgram.t))}) {
+    if (const parser::CharBlock *endName{
+            GetStmtName(std::get<parser::Statement<parser::EndProgramStmt>>(
+                mainProgram.t))}) {
       upperCaseCharBlock(*endName);
       if (progName) {
         if (*endName != *progName) {
@@ -716,7 +716,7 @@ private:
     const auto &constructStmt{std::get<parser::Statement<FIRST>>(a.t)};
     const auto &endStmt{std::get<parser::Statement<END>>(a.t)};
     const parser::CharBlock *endName{GetStmtName(endStmt)};
-    if (const parser::CharBlock * constructName{GetStmtName(constructStmt)}) {
+    if (const parser::CharBlock *constructName{GetStmtName(constructStmt)}) {
       if (endName) {
         if (*constructName != *endName) {
           context_
@@ -1072,7 +1072,7 @@ void CheckScopeConstraints(const SourceStmtList &stmts,
       bool isFatal{false};
       ProxyForScope fromScope{scope};
       for (ProxyForScope toScope{target.proxyForScope}; HasScope(toScope);
-           toScope = scopes[toScope].parent) {
+          toScope = scopes[toScope].parent) {
         while (scopes[fromScope].depth > scopes[toScope].depth) {
           fromScope = scopes[fromScope].parent;
         }

--- a/flang/lib/Semantics/resolve-names-utils.cpp
+++ b/flang/lib/Semantics/resolve-names-utils.cpp
@@ -352,7 +352,7 @@ void EquivalenceSets::AddToSet(const parser::Designator &designator) {
       }
       auto subscripts{currObject_.subscripts};
       if (subscripts.empty()) {
-        if (const ArraySpec * shape{symbol->GetShape()};
+        if (const ArraySpec *shape{symbol->GetShape()};
             shape && shape->IsExplicitShape()) {
           // record a whole array as its first element
           for (const ShapeSpec &spec : *shape) {
@@ -645,9 +645,9 @@ bool EquivalenceSets::IsSequenceType(const DeclTypeSpec *type,
     std::function<bool(const IntrinsicTypeSpec &)> predicate) {
   if (!type) {
     return false;
-  } else if (const IntrinsicTypeSpec * intrinsic{type->AsIntrinsic()}) {
+  } else if (const IntrinsicTypeSpec *intrinsic{type->AsIntrinsic()}) {
     return predicate(*intrinsic);
-  } else if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+  } else if (const DerivedTypeSpec *derived{type->AsDerived()}) {
     for (const auto &pair : *derived->typeSymbol().scope()) {
       const Symbol &component{*pair.second};
       if (IsAllocatableOrPointer(component) ||
@@ -744,8 +744,8 @@ Symbol *SymbolMapper::CopySymbol(const Symbol *symbol) {
 void SymbolMapper::MapSymbolExprs(Symbol &symbol) {
   common::visit(
       common::visitors{[&](ObjectEntityDetails &object) {
-                         if (const DeclTypeSpec * type{object.type()}) {
-                           if (const DeclTypeSpec * newType{MapType(*type)}) {
+                         if (const DeclTypeSpec *type{object.type()}) {
+                           if (const DeclTypeSpec *newType{MapType(*type)}) {
                              object.ReplaceType(*newType);
                            }
                          }
@@ -757,11 +757,11 @@ void SymbolMapper::MapSymbolExprs(Symbol &symbol) {
                          }
                        },
           [&](ProcEntityDetails &proc) {
-            if (const Symbol *
-                mappedSymbol{MapInterface(proc.rawProcInterface())}) {
+            if (const Symbol *mappedSymbol{
+                    MapInterface(proc.rawProcInterface())}) {
               proc.set_procInterfaces(
                   *mappedSymbol, BypassGeneric(mappedSymbol->GetUltimate()));
-            } else if (const DeclTypeSpec * mappedType{MapType(proc.type())}) {
+            } else if (const DeclTypeSpec *mappedType{MapType(proc.type())}) {
               if (proc.type()) {
                 CHECK(*proc.type() == *mappedType);
               } else {
@@ -769,13 +769,13 @@ void SymbolMapper::MapSymbolExprs(Symbol &symbol) {
               }
             }
             if (proc.init()) {
-              if (const Symbol * mapped{MapSymbol(*proc.init())}) {
+              if (const Symbol *mapped{MapSymbol(*proc.init())}) {
                 proc.set_init(*mapped);
               }
             }
           },
           [&](const HostAssocDetails &hostAssoc) {
-            if (const Symbol * mapped{MapSymbol(hostAssoc.symbol())}) {
+            if (const Symbol *mapped{MapSymbol(hostAssoc.symbol())}) {
               symbol.set_details(HostAssocDetails{*mapped});
             }
           },
@@ -838,7 +838,7 @@ const Symbol *SymbolMapper::MapInterface(const Symbol *interface) {
     if (&interface->owner() != &scope_) {
       return interface;
     } else if (const auto *subp{interface->detailsIf<SubprogramDetails>()};
-               subp && subp->isInterface()) {
+        subp && subp->isInterface()) {
       return CopySymbol(interface);
     }
   }

--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -2315,7 +2315,7 @@ void AttrsVisitor::SetBindNameOn(Symbol &symbol) {
   }
   symbol.SetBindName(std::move(*label));
   if (!oldBindName.empty()) {
-    if (const std::string * newBindName{symbol.GetBindName()}) {
+    if (const std::string *newBindName{symbol.GetBindName()}) {
       if (oldBindName != *newBindName) {
         Say(symbol.name(),
             "The entity '%s' has multiple BIND names ('%s' and '%s')"_err_en_US,
@@ -2438,7 +2438,7 @@ void DeclTypeSpecVisitor::Post(const parser::TypeSpec &typeSpec) {
   // expression semantics if the DeclTypeSpec is a valid TypeSpec.
   // The grammar ensures that it's an intrinsic or derived type spec,
   // not TYPE(*) or CLASS(*) or CLASS(T).
-  if (const DeclTypeSpec * spec{state_.declTypeSpec}) {
+  if (const DeclTypeSpec *spec{state_.declTypeSpec}) {
     switch (spec->category()) {
     case DeclTypeSpec::Numeric:
     case DeclTypeSpec::Logical:
@@ -2446,7 +2446,7 @@ void DeclTypeSpecVisitor::Post(const parser::TypeSpec &typeSpec) {
       typeSpec.declTypeSpec = spec;
       break;
     case DeclTypeSpec::TypeDerived:
-      if (const DerivedTypeSpec * derived{spec->AsDerived()}) {
+      if (const DerivedTypeSpec *derived{spec->AsDerived()}) {
         CheckForAbstractType(derived->typeSymbol()); // C703
         typeSpec.declTypeSpec = spec;
       }
@@ -2991,8 +2991,8 @@ Symbol &ScopeHandler::MakeSymbol(const parser::Name &name, Attrs attrs) {
 Symbol &ScopeHandler::MakeHostAssocSymbol(
     const parser::Name &name, const Symbol &hostSymbol) {
   Symbol &symbol{*NonDerivedTypeScope()
-                      .try_emplace(name.source, HostAssocDetails{hostSymbol})
-                      .first->second};
+          .try_emplace(name.source, HostAssocDetails{hostSymbol})
+          .first->second};
   name.symbol = &symbol;
   symbol.attrs() = hostSymbol.attrs(); // TODO: except PRIVATE, PUBLIC?
   // These attributes can be redundantly reapplied without error
@@ -3080,7 +3080,7 @@ void ScopeHandler::ApplyImplicitRules(
   if (context().HasError(symbol) || !NeedsType(symbol)) {
     return;
   }
-  if (const DeclTypeSpec * type{GetImplicitType(symbol)}) {
+  if (const DeclTypeSpec *type{GetImplicitType(symbol)}) {
     if (!skipImplicitTyping_) {
       symbol.set(Symbol::Flag::Implicit);
       symbol.SetType(*type);
@@ -3180,7 +3180,7 @@ const DeclTypeSpec *ScopeHandler::GetImplicitType(
   const auto *type{implicitRulesMap_->at(scope).GetType(
       symbol.name(), respectImplicitNoneType)};
   if (type) {
-    if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+    if (const DerivedTypeSpec *derived{type->AsDerived()}) {
       // Resolve any forward-referenced derived type; a quick no-op else.
       auto &instantiatable{*const_cast<DerivedTypeSpec *>(derived)};
       instantiatable.Instantiate(currScope());
@@ -3895,10 +3895,10 @@ void ModuleVisitor::DoAddUse(SourceName location, SourceName localName,
     } else if (IsPointer(p1) || IsPointer(p2)) {
       return false;
     } else if (const auto *subp{p1.detailsIf<SubprogramDetails>()};
-               subp && !subp->isInterface()) {
+        subp && !subp->isInterface()) {
       return false; // defined in module, not an external
     } else if (const auto *subp{p2.detailsIf<SubprogramDetails>()};
-               subp && !subp->isInterface()) {
+        subp && !subp->isInterface()) {
       return false; // defined in module, not an external
     } else {
       // Both are external interfaces, perhaps to the same procedure
@@ -4158,7 +4158,7 @@ Scope *ModuleVisitor::FindModule(const parser::Name &name,
   if (scope) {
     if (DoesScopeContain(scope, currScope())) { // 14.2.2(1)
       std::optional<SourceName> submoduleName;
-      if (const Scope * container{FindModuleOrSubmoduleContaining(currScope())};
+      if (const Scope *container{FindModuleOrSubmoduleContaining(currScope())};
           container && container->IsSubmodule()) {
         submoduleName = container->GetName();
       }
@@ -4263,7 +4263,7 @@ bool InterfaceVisitor::isAbstract() const {
 
 void InterfaceVisitor::AddSpecificProcs(
     const std::list<parser::Name> &names, ProcedureKind kind) {
-  if (Symbol * symbol{GetGenericInfo().symbol};
+  if (Symbol *symbol{GetGenericInfo().symbol};
       symbol && symbol->has<GenericDetails>()) {
     for (const auto &name : names) {
       specificsForGenericProcs_.emplace(symbol, std::make_pair(&name, kind));
@@ -4363,7 +4363,7 @@ void GenericHandler::DeclaredPossibleSpecificProc(Symbol &proc) {
 }
 
 void InterfaceVisitor::ResolveNewSpecifics() {
-  if (Symbol * generic{genericInfo_.top().symbol};
+  if (Symbol *generic{genericInfo_.top().symbol};
       generic && generic->has<GenericDetails>()) {
     ResolveSpecificsInGeneric(*generic, false);
   }
@@ -4448,7 +4448,7 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
           name.source);
       MakeSymbol(name, Attrs{}, UnknownDetails{});
     } else if (auto *entity{ultimate.detailsIf<EntityDetails>()};
-               entity && !ultimate.has<ProcEntityDetails>()) {
+        entity && !ultimate.has<ProcEntityDetails>()) {
       resultType = entity->type();
       ultimate.details() = UnknownDetails{}; // will be replaced below
     } else {
@@ -4504,7 +4504,7 @@ bool SubprogramVisitor::Pre(const parser::Suffix &suffix) {
     } else {
       Message &msg{Say(*suffix.resultName,
           "RESULT(%s) may appear only in a function"_err_en_US)};
-      if (const Symbol * subprogram{InclusiveScope().symbol()}) {
+      if (const Symbol *subprogram{InclusiveScope().symbol()}) {
         msg.Attach(subprogram->name(), "Containing subprogram"_en_US);
       }
     }
@@ -5022,7 +5022,7 @@ Symbol *ScopeHandler::FindSeparateModuleProcedureInterface(
       symbol = generic->specific();
     }
   }
-  if (const Symbol * defnIface{FindSeparateModuleSubprogramInterface(symbol)}) {
+  if (const Symbol *defnIface{FindSeparateModuleSubprogramInterface(symbol)}) {
     // Error recovery in case of multiple definitions
     symbol = const_cast<Symbol *>(defnIface);
   }
@@ -5159,8 +5159,8 @@ bool SubprogramVisitor::HandlePreviousCalls(
     return generic->specific() &&
         HandlePreviousCalls(name, *generic->specific(), subpFlag);
   } else if (const auto *proc{symbol.detailsIf<ProcEntityDetails>()}; proc &&
-             !proc->isDummy() &&
-             !symbol.attrs().HasAny(Attrs{Attr::INTRINSIC, Attr::POINTER})) {
+      !proc->isDummy() &&
+      !symbol.attrs().HasAny(Attrs{Attr::INTRINSIC, Attr::POINTER})) {
     // There's a symbol created for previous calls to this subprogram or
     // ENTRY's name.  We have to replace that symbol in situ to avoid the
     // obligation to rewrite symbol pointers in the parse tree.
@@ -5201,7 +5201,7 @@ void SubprogramVisitor::CheckExtantProc(
   if (auto *prev{FindSymbol(name)}) {
     if (IsDummy(*prev)) {
     } else if (auto *entity{prev->detailsIf<EntityDetails>()};
-               IsPointer(*prev) && entity && !entity->type()) {
+        IsPointer(*prev) && entity && !entity->type()) {
       // POINTER attribute set before interface
     } else if (inInterfaceBlock() && currScope() != prev->owner()) {
       // Procedures in an INTERFACE block do not resolve to symbols
@@ -5257,7 +5257,7 @@ Symbol &SubprogramVisitor::PushSubprogramScope(const parser::Name &name,
     }
     set_inheritFromParent(false); // interfaces don't inherit, even if MODULE
   }
-  if (Symbol * found{FindSymbol(name)};
+  if (Symbol *found{FindSymbol(name)};
       found && found->has<HostAssocDetails>()) {
     found->set(subpFlag); // PushScope() created symbol
   }
@@ -6104,9 +6104,9 @@ void DeclarationVisitor::Post(const parser::VectorTypeSpec &x) {
     vectorDerivedType.CookParameters(GetFoldingContext());
   }
 
-  if (const DeclTypeSpec *
-      extant{ppcBuiltinTypesScope->FindInstantiatedDerivedType(
-          vectorDerivedType, DeclTypeSpec::Category::TypeDerived)}) {
+  if (const DeclTypeSpec *extant{
+          ppcBuiltinTypesScope->FindInstantiatedDerivedType(
+              vectorDerivedType, DeclTypeSpec::Category::TypeDerived)}) {
     // This derived type and parameter expressions (if any) are already present
     // in the __ppc_intrinsics scope.
     SetDeclTypeSpec(*extant);
@@ -6128,7 +6128,7 @@ bool DeclarationVisitor::Pre(const parser::DeclarationTypeSpec::Type &) {
 
 void DeclarationVisitor::Post(const parser::DeclarationTypeSpec::Type &type) {
   const parser::Name &derivedName{std::get<parser::Name>(type.derived.t)};
-  if (const Symbol * derivedSymbol{derivedName.symbol}) {
+  if (const Symbol *derivedSymbol{derivedName.symbol}) {
     CheckForAbstractType(*derivedSymbol); // C706
   }
 }
@@ -6197,8 +6197,8 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
   if (!spec->MightBeParameterized()) {
     spec->EvaluateParameters(context());
   }
-  if (const DeclTypeSpec *
-      extant{currScope().FindInstantiatedDerivedType(*spec, category)}) {
+  if (const DeclTypeSpec *extant{
+          currScope().FindInstantiatedDerivedType(*spec, category)}) {
     // This derived type and parameter expressions (if any) are already present
     // in this scope.
     SetDeclTypeSpec(*extant);
@@ -6229,8 +6229,7 @@ void DeclarationVisitor::Post(const parser::DeclarationTypeSpec::Record &rec) {
   if (auto spec{ResolveDerivedType(typeName)}) {
     spec->CookParameters(GetFoldingContext());
     spec->EvaluateParameters(context());
-    if (const DeclTypeSpec *
-        extant{currScope().FindInstantiatedDerivedType(
+    if (const DeclTypeSpec *extant{currScope().FindInstantiatedDerivedType(
             *spec, DeclTypeSpec::TypeDerived)}) {
       SetDeclTypeSpec(*extant);
     } else {
@@ -7150,7 +7149,7 @@ void DeclarationVisitor::CheckCommonBlocks() {
     } else if (symbol->IsFuncResult()) {
       Say(name,
           "Function result '%s' may not appear in a COMMON block"_err_en_US);
-    } else if (const DeclTypeSpec * type{symbol->GetType()}) {
+    } else if (const DeclTypeSpec *type{symbol->GetType()}) {
       if (type->category() == DeclTypeSpec::ClassStar) {
         Say(name,
             "Unlimited polymorphic pointer '%s' may not appear in a COMMON block"_err_en_US);
@@ -7303,7 +7302,7 @@ bool DeclarationVisitor::PassesLocalityChecks(
         "Coarray '%s' not allowed in a %s locality-spec"_err_en_US, specName);
     return false;
   }
-  if (const DeclTypeSpec * type{symbol.GetType()}) {
+  if (const DeclTypeSpec *type{symbol.GetType()}) {
     if (type->IsPolymorphic() && IsDummy(symbol) && !IsPointer(symbol) &&
         !isReduce) { // F'2023 C1130
       SayWithDecl(name, symbol,
@@ -7530,7 +7529,7 @@ Symbol *DeclarationVisitor::NoteInterfaceName(const parser::Name &name) {
 }
 
 void DeclarationVisitor::CheckExplicitInterface(const parser::Name &name) {
-  if (const Symbol * symbol{name.symbol}) {
+  if (const Symbol *symbol{name.symbol}) {
     const Symbol &ultimate{symbol->GetUltimate()};
     if (!context().HasError(*symbol) && !context().HasError(ultimate) &&
         !BypassGeneric(ultimate).HasExplicitInterface()) {
@@ -7848,7 +7847,7 @@ bool ConstructVisitor::Pre(const parser::DataStmtValue &x) {
   auto &mutableData{const_cast<parser::DataStmtConstant &>(data)};
   if (auto *elem{parser::Unwrap<parser::ArrayElement>(mutableData)}) {
     if (const auto *name{std::get_if<parser::Name>(&elem->base.u)}) {
-      if (const Symbol * symbol{FindSymbol(*name)};
+      if (const Symbol *symbol{FindSymbol(*name)};
           symbol && symbol->GetUltimate().has<DerivedTypeDetails>()) {
         mutableData.u = elem->ConvertToStructureConstructor(
             DerivedTypeSpec{name->source, *symbol});
@@ -7994,15 +7993,15 @@ void ConstructVisitor::Post(const parser::SelectTypeStmt &x) {
       }
     }
   } else {
-    if (const Symbol *
-        whole{UnwrapWholeSymbolDataRef(association.selector.expr)}) {
+    if (const Symbol *whole{
+            UnwrapWholeSymbolDataRef(association.selector.expr)}) {
       ConvertToObjectEntity(const_cast<Symbol &>(*whole));
       if (!IsVariableName(*whole)) {
         Say(association.selector.source, // C901
             "Selector is not a variable"_err_en_US);
         association = {};
       }
-      if (const DeclTypeSpec * type{whole->GetType()}) {
+      if (const DeclTypeSpec *type{whole->GetType()}) {
         if (!type->IsPolymorphic()) { // C1159
           Say(association.selector.source,
               "Selector '%s' in SELECT TYPE statement must be "
@@ -8142,8 +8141,8 @@ Symbol *ConstructVisitor::MakeAssocEntity() {
           "The associate name '%s' is already used in this associate statement"_err_en_US);
       return nullptr;
     }
-  } else if (const Symbol *
-      whole{UnwrapWholeSymbolDataRef(association.selector.expr)}) {
+  } else if (const Symbol *whole{
+                 UnwrapWholeSymbolDataRef(association.selector.expr)}) {
     symbol = &MakeSymbol(whole->name());
   } else {
     return nullptr;
@@ -8770,7 +8769,7 @@ bool DeclarationVisitor::CheckForHostAssociatedImplicit(
   if (name.symbol) {
     ApplyImplicitRules(*name.symbol, true);
   }
-  if (Scope * host{GetHostProcedure()}; host && !isImplicitNoneType(*host)) {
+  if (Scope *host{GetHostProcedure()}; host && !isImplicitNoneType(*host)) {
     Symbol *hostSymbol{nullptr};
     if (!name.symbol) {
       if (currScope().CanImport(name.source)) {
@@ -8841,7 +8840,7 @@ const parser::Name *DeclarationVisitor::FindComponent(
   if (!type) {
     return nullptr; // should have already reported error
   }
-  if (const IntrinsicTypeSpec * intrinsic{type->AsIntrinsic()}) {
+  if (const IntrinsicTypeSpec *intrinsic{type->AsIntrinsic()}) {
     auto category{intrinsic->category()};
     MiscDetails::Kind miscKind{MiscDetails::Kind::None};
     if (component.source == "kind") {
@@ -8863,7 +8862,7 @@ const parser::Name *DeclarationVisitor::FindComponent(
     }
   } else if (DerivedTypeSpec * derived{type->AsDerived()}) {
     derived->Instantiate(currScope()); // in case of forward referenced type
-    if (const Scope * scope{derived->scope()}) {
+    if (const Scope *scope{derived->scope()}) {
       if (Resolve(component, scope->FindComponent(component.source))) {
         if (auto msg{CheckAccessibleSymbol(currScope(), *component.symbol)}) {
           context().Say(component.source, *msg);
@@ -9011,8 +9010,8 @@ void DeclarationVisitor::PointerInitialization(
             if (evaluate::IsNullProcedurePointer(&*expr)) {
               CHECK(!details->init());
               details->set_init(nullptr);
-            } else if (const Symbol *
-                targetSymbol{evaluate::UnwrapWholeSymbolDataRef(*expr)}) {
+            } else if (const Symbol *targetSymbol{
+                           evaluate::UnwrapWholeSymbolDataRef(*expr)}) {
               CHECK(!details->init());
               details->set_init(*targetSymbol);
             } else {
@@ -9531,7 +9530,7 @@ void ResolveNamesVisitor::EarlyDummyTypeDeclaration(
       for (const auto &ent : entities) {
         const auto &objName{std::get<parser::ObjectName>(ent.t)};
         Resolve(objName, FindInScope(currScope(), objName));
-        if (Symbol * symbol{objName.symbol};
+        if (Symbol *symbol{objName.symbol};
             symbol && IsDummy(*symbol) && NeedsType(*symbol)) {
           if (!type) {
             type = ProcessTypeSpec(declTypeSpec);
@@ -9670,7 +9669,7 @@ void ResolveNamesVisitor::FinishSpecificationPart(
     if (auto *proc{symbol.detailsIf<ProcEntityDetails>()}; proc &&
         !proc->isDummy() && !IsPointer(symbol) &&
         !symbol.attrs().test(Attr::BIND_C)) {
-      if (const Symbol * iface{proc->procInterface()};
+      if (const Symbol *iface{proc->procInterface()};
           iface && IsBindCProcedure(*iface)) {
         SetImplicitAttr(symbol, Attr::BIND_C);
         SetBindNameOn(symbol);
@@ -9803,7 +9802,7 @@ bool ResolveNamesVisitor::Pre(const parser::PointerAssignmentStmt &x) {
   Symbol *ptrSymbol{parser::GetLastName(dataRef).symbol};
   Walk(bounds);
   // Resolve unrestricted specific intrinsic procedures as in "p => cos".
-  if (const parser::Name * name{parser::Unwrap<parser::Name>(expr)}) {
+  if (const parser::Name *name{parser::Unwrap<parser::Name>(expr)}) {
     if (NameIsKnownOrIntrinsic(*name)) {
       if (Symbol * symbol{name->symbol}) {
         if (IsProcedurePointer(ptrSymbol) &&
@@ -10244,8 +10243,8 @@ void ResolveNamesVisitor::ResolveSpecificationParts(ProgramTree &node) {
     // implied SAVE so that evaluate::IsSaved() will return true.
     if (node.scope()->kind() == Scope::Kind::MainProgram) {
       if (const auto *object{symbol.detailsIf<ObjectEntityDetails>()}) {
-        if (const DeclTypeSpec * type{object->type()}) {
-          if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+        if (const DeclTypeSpec *type{object->type()}) {
+          if (const DerivedTypeSpec *derived{type->AsDerived()}) {
             if (!IsSaved(symbol) && FindCoarrayPotentialComponent(*derived)) {
               SetImplicitAttr(symbol, Attr::SAVE);
             }
@@ -10498,7 +10497,7 @@ void ResolveNamesVisitor::FinishDerivedTypeInstantiation(Scope &scope) {
   if (DerivedTypeSpec * spec{scope.derivedTypeSpec()}) {
     spec->Instantiate(currScope());
     const Symbol &origTypeSymbol{spec->typeSymbol()};
-    if (const Scope * origTypeScope{origTypeSymbol.scope()}) {
+    if (const Scope *origTypeScope{origTypeSymbol.scope()}) {
       CHECK(origTypeScope->IsDerivedType() &&
           origTypeScope->symbol() == &origTypeSymbol);
       auto &foldingContext{GetFoldingContext()};
@@ -10509,7 +10508,7 @@ void ResolveNamesVisitor::FinishDerivedTypeInstantiation(Scope &scope) {
         if (IsPointer(comp)) {
           if (auto *details{comp.detailsIf<ObjectEntityDetails>()}) {
             auto origDetails{origComp.get<ObjectEntityDetails>()};
-            if (const MaybeExpr & init{origDetails.init()}) {
+            if (const MaybeExpr &init{origDetails.init()}) {
               SomeExpr newInit{*init};
               MaybeExpr folded{FoldExpr(std::move(newInit))};
               details->set_init(std::move(folded));

--- a/flang/lib/Semantics/rewrite-parse-tree.cpp
+++ b/flang/lib/Semantics/rewrite-parse-tree.cpp
@@ -104,7 +104,7 @@ void RewriteMutator::Post(parser::Name &name) {
 }
 
 static bool ReturnsDataPointer(const Symbol &symbol) {
-  if (const Symbol * funcRes{FindFunctionResult(symbol)}) {
+  if (const Symbol *funcRes{FindFunctionResult(symbol)}) {
     return IsPointer(*funcRes) && !IsProcedure(*funcRes);
   } else if (const auto *generic{symbol.detailsIf<GenericDetails>()}) {
     for (auto ref : generic->specificProcs()) {
@@ -254,8 +254,8 @@ void RewriteMutator::FixMisparsedStmtFuncs(
     if (auto *stmt{std::get_if<
             parser::Statement<common::Indirection<parser::StmtFunctionStmt>>>(
             &it->u)}) {
-      if (const Symbol *
-          symbol{std::get<parser::Name>(stmt->statement.value().t).symbol}) {
+      if (const Symbol *symbol{
+              std::get<parser::Name>(stmt->statement.value().t).symbol}) {
         const Symbol &ultimate{symbol->GetUltimate()};
         convert =
             ultimate.has<ObjectEntityDetails>() || ReturnsDataPointer(ultimate);
@@ -459,7 +459,7 @@ template <typename READ_OR_WRITE>
 void FixMisparsedUntaggedNamelistName(READ_OR_WRITE &x) {
   if (x.iounit && x.format &&
       std::holds_alternative<parser::Expr>(x.format->u)) {
-    if (const parser::Name * name{parser::Unwrap<parser::Name>(x.format)}) {
+    if (const parser::Name *name{parser::Unwrap<parser::Name>(x.format)}) {
       if (name->symbol && name->symbol->GetUltimate().has<NamelistDetails>()) {
         x.controls.emplace_front(parser::IoControlSpec{std::move(*name)});
         x.format.reset();

--- a/flang/lib/Semantics/runtime-type-info.cpp
+++ b/flang/lib/Semantics/runtime-type-info.cpp
@@ -118,7 +118,7 @@ private:
     }
     if (expr) {
       if (parameters) {
-        if (const Symbol * lenParam{evaluate::ExtractBareLenParameter(*expr)}) {
+        if (const Symbol *lenParam{evaluate::ExtractBareLenParameter(*expr)}) {
           return PackageIntValue(
               lenParameterEnum_, FindLenParameterIndex(*parameters, *lenParam));
         }
@@ -208,7 +208,7 @@ static SomeExpr SaveDerivedPointerTarget(Scope &scope, SourceName name,
     const auto &derivedType{dyType.GetDerivedTypeSpec()};
     ObjectEntityDetails object;
     DeclTypeSpec typeSpec{DeclTypeSpec::TypeDerived, derivedType};
-    if (const DeclTypeSpec * spec{scope.FindType(typeSpec)}) {
+    if (const DeclTypeSpec *spec{scope.FindType(typeSpec)}) {
       object.set_type(*spec);
     } else {
       object.set_type(scope.MakeDerivedType(
@@ -225,9 +225,9 @@ static SomeExpr SaveDerivedPointerTarget(Scope &scope, SourceName name,
         evaluate::AsGenericExpr(evaluate::Constant<evaluate::SomeDerived>{
             derivedType, std::move(x), std::move(shape)}));
     Symbol &symbol{*scope
-                        .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
-                            std::move(object))
-                        .first->second};
+            .try_emplace(
+                name, Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
+            .first->second};
     SetReadOnlyCompilerCreatedFlags(symbol);
     return evaluate::AsGenericExpr(
         evaluate::Designator<evaluate::SomeDerived>{symbol});
@@ -341,9 +341,9 @@ static SomeExpr SaveNumericPointerTarget(
     object.set_init(evaluate::AsGenericExpr(evaluate::Constant<T>{
         std::move(x), evaluate::ConstantSubscripts{elements}}));
     Symbol &symbol{*scope
-                        .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
-                            std::move(object))
-                        .first->second};
+            .try_emplace(
+                name, Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
+            .first->second};
     SetReadOnlyCompilerCreatedFlags(symbol);
     return evaluate::AsGenericExpr(
         evaluate::Expr<T>{evaluate::Designator<T>{symbol}});
@@ -353,9 +353,9 @@ static SomeExpr SaveNumericPointerTarget(
 static SomeExpr SaveObjectInit(
     Scope &scope, SourceName name, const ObjectEntityDetails &object) {
   Symbol &symbol{*scope
-                      .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
-                          ObjectEntityDetails{object})
-                      .first->second};
+          .try_emplace(name, Attrs{Attr::TARGET, Attr::SAVE},
+              ObjectEntityDetails{object})
+          .first->second};
   CHECK(symbol.get<ObjectEntityDetails>().init().has_value());
   SetReadOnlyCompilerCreatedFlags(symbol);
   return evaluate::AsGenericExpr(
@@ -397,7 +397,7 @@ static std::optional<std::string> GetSuffixIfTypeKindParameters(
 
 const Symbol *RuntimeTableBuilder::DescribeType(
     Scope &dtScope, bool wantUninstantiatedPDT) {
-  if (const Symbol * info{dtScope.runtimeDerivedTypeDescription()}) {
+  if (const Symbol *info{dtScope.runtimeDerivedTypeDescription()}) {
     return info;
   }
   const DerivedTypeSpec *derivedTypeSpec{dtScope.derivedTypeSpec()};
@@ -410,8 +410,8 @@ const Symbol *RuntimeTableBuilder::DescribeType(
     // a module but used only by clients and submodules, enabling the
     // run-time "no initialization needed here" flag to work.
     DerivedTypeSpec derived{dtScope.symbol()->name(), *dtScope.symbol()};
-    if (const SymbolVector *
-        lenParameters{GetTypeParameters(*dtScope.symbol())}) {
+    if (const SymbolVector *lenParameters{
+            GetTypeParameters(*dtScope.symbol())}) {
       // Create dummy deferred values for the length parameters so that the
       // DerivedTypeSpec is complete and can be used in helpers.
       for (SymbolRef lenParam : *lenParameters) {
@@ -479,8 +479,7 @@ const Symbol *RuntimeTableBuilder::DescribeType(
     AddValue(
         dtValues, derivedTypeSchema_, "sizeinbytes"s, IntToExpr(sizeInBytes));
   }
-  if (const Symbol *
-      uninstDescObject{isPDTInstantiation
+  if (const Symbol *uninstDescObject{isPDTInstantiation
               ? DescribeType(DEREF(const_cast<Scope *>(dtSymbol->scope())),
                     /*wantUninstantiatedPDT=*/true)
               : nullptr}) {
@@ -752,12 +751,10 @@ SomeExpr RuntimeTableBuilder::SaveNameAsPointerTarget(
   using evaluate::Ascii;
   using AsciiExpr = evaluate::Expr<Ascii>;
   object.set_init(evaluate::AsGenericExpr(AsciiExpr{name}));
-  Symbol &symbol{
-      *scope
-           .try_emplace(
-               SaveObjectName((fir::kNameStringSeparator + name).str()),
-               Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
-           .first->second};
+  Symbol &symbol{*scope
+          .try_emplace(SaveObjectName((fir::kNameStringSeparator + name).str()),
+              Attrs{Attr::TARGET, Attr::SAVE}, std::move(object))
+          .first->second};
   SetReadOnlyCompilerCreatedFlags(symbol);
   return evaluate::AsGenericExpr(
       AsciiExpr{evaluate::Designator<Ascii>{symbol}});
@@ -787,8 +784,8 @@ evaluate::StructureConstructor RuntimeTableBuilder::DescribeComponent(
   AddValue(values, componentSchema_, "offset"s, IntExpr<8>(symbol.offset()));
   // CHARACTER length
   auto len{typeAndShape->LEN()};
-  if (const semantics::DerivedTypeSpec *
-      pdtInstance{dtScope.derivedTypeSpec()}) {
+  if (const semantics::DerivedTypeSpec *pdtInstance{
+          dtScope.derivedTypeSpec()}) {
     auto restorer{foldingContext.WithPDTInstance(*pdtInstance)};
     len = Fold(foldingContext, std::move(len));
   }
@@ -814,21 +811,19 @@ evaluate::StructureConstructor RuntimeTableBuilder::DescribeComponent(
     const DerivedTypeSpec &spec{dyType.GetDerivedTypeSpec()};
     Scope *derivedScope{const_cast<Scope *>(
         spec.scope() ? spec.scope() : spec.typeSymbol().scope())};
-    if (const Symbol *
-        derivedDescription{DescribeType(
+    if (const Symbol *derivedDescription{DescribeType(
             DEREF(derivedScope), /*wantUninstantiatedPDT=*/false)}) {
       AddValue(values, componentSchema_, "derived"s,
           evaluate::AsGenericExpr(evaluate::Expr<evaluate::SomeDerived>{
               evaluate::Designator<evaluate::SomeDerived>{
                   DEREF(derivedDescription)}}));
       // Package values of LEN parameters, if any
-      if (const SymbolVector *
-          specParams{GetTypeParameters(spec.typeSymbol())}) {
+      if (const SymbolVector *specParams{
+              GetTypeParameters(spec.typeSymbol())}) {
         for (SymbolRef ref : *specParams) {
           const auto &tpd{ref->get<TypeParamDetails>()};
           if (tpd.attr() && *tpd.attr() == common::TypeParamAttr::Len) {
-            if (const ParamValue *
-                paramValue{spec.FindParameter(ref->name())}) {
+            if (const ParamValue *paramValue{spec.FindParameter(ref->name())}) {
               lenParams.emplace_back(GetValue(*paramValue, parameters));
             } else {
               lenParams.emplace_back(GetValue(tpd.init(), parameters));
@@ -849,7 +844,7 @@ evaluate::StructureConstructor RuntimeTableBuilder::DescribeComponent(
         SaveDerivedPointerTarget(scope,
             SaveObjectName((fir::kLenParameterSeparator + distinctName +
                 fir::kNameSeparator + symbol.name().ToString())
-                               .str()),
+                    .str()),
             std::move(lenParams),
             evaluate::ConstantSubscripts{
                 static_cast<evaluate::ConstantSubscript>(lenParams.size())}));
@@ -874,7 +869,7 @@ evaluate::StructureConstructor RuntimeTableBuilder::DescribeComponent(
         SaveDerivedPointerTarget(scope,
             SaveObjectName((fir::kBoundsSeparator + distinctName +
                 fir::kNameSeparator + symbol.name().ToString())
-                               .str()),
+                    .str()),
             std::move(bounds), evaluate::ConstantSubscripts{2, rank}));
   } else {
     AddValue(
@@ -898,7 +893,7 @@ evaluate::StructureConstructor RuntimeTableBuilder::DescribeComponent(
           SaveObjectInit(scope,
               SaveObjectName((fir::kComponentInitSeparator + distinctName +
                   fir::kNameSeparator + symbol.name().ToString())
-                                 .str()),
+                      .str()),
               object));
     }
   }
@@ -949,7 +944,7 @@ bool RuntimeTableBuilder::InitializeDataPointer(
   if (object.init().has_value()) {
     SourceName ptrDtName{SaveObjectName((fir::kDataPtrInitSeparator +
         distinctName + fir::kNameSeparator + symbol.name().ToString())
-                                            .str())};
+            .str())};
     Symbol &ptrDtSym{
         *scope.try_emplace(ptrDtName, Attrs{}, UnknownDetails{}).first->second};
     SetReadOnlyCompilerCreatedFlags(ptrDtSym);
@@ -959,9 +954,9 @@ bool RuntimeTableBuilder::InitializeDataPointer(
     ptrDtObj.set_type(DEREF(object.type()));
     ptrDtObj.set_shape(object.shape());
     Symbol &ptrDtComp{*ptrDtScope
-                           .try_emplace(symbol.name(), Attrs{Attr::POINTER},
-                               std::move(ptrDtObj))
-                           .first->second};
+            .try_emplace(
+                symbol.name(), Attrs{Attr::POINTER}, std::move(ptrDtObj))
+            .first->second};
     DerivedTypeDetails ptrDtDetails;
     ptrDtDetails.add_component(ptrDtComp);
     ptrDtSym.set_details(std::move(ptrDtDetails));
@@ -984,7 +979,7 @@ bool RuntimeTableBuilder::InitializeDataPointer(
         SaveObjectInit(scope,
             SaveObjectName((fir::kComponentInitSeparator + distinctName +
                 fir::kNameSeparator + symbol.name().ToString())
-                               .str()),
+                    .str()),
             ptrInitObj));
     return true;
   } else {
@@ -1016,7 +1011,7 @@ SymbolVector CollectBindings(const Scope &dtScope) {
       binding->set_numPrivatesNotOverridden(0);
     }
   }
-  if (const Scope * parentScope{dtScope.GetDerivedTypeParent()}) {
+  if (const Scope *parentScope{dtScope.GetDerivedTypeParent()}) {
     result = CollectBindings(*parentScope);
     // Apply overrides from the local bindings of the extended type
     for (auto iter{result.begin()}; iter != result.end(); ++iter) {
@@ -1068,7 +1063,7 @@ RuntimeTableBuilder::DescribeSpecialGenerics(const Scope &dtScope,
     const Scope &thisScope, const DerivedTypeSpec *derivedTypeSpec,
     const SymbolVector &bindings) const {
   std::map<int, evaluate::StructureConstructor> specials;
-  if (const Scope * parentScope{dtScope.GetDerivedTypeParent()}) {
+  if (const Scope *parentScope{dtScope.GetDerivedTypeParent()}) {
     specials = DescribeSpecialGenerics(
         *parentScope, thisScope, derivedTypeSpec, bindings);
   }
@@ -1325,11 +1320,11 @@ static const DeclTypeSpec *GetDefinedIoSpecificArgType(const Symbol &specific) {
     interface = procEntity->procInterface();
   }
   if (interface) {
-    if (const SubprogramDetails *
-            subprogram{interface->detailsIf<SubprogramDetails>()};
+    if (const SubprogramDetails *subprogram{
+            interface->detailsIf<SubprogramDetails>()};
         subprogram && !subprogram->dummyArgs().empty()) {
-      if (const Symbol * dtvArg{subprogram->dummyArgs().at(0)}) {
-        if (const DeclTypeSpec * declType{dtvArg->GetType()}) {
+      if (const Symbol *dtvArg{subprogram->dummyArgs().at(0)}) {
+        if (const DeclTypeSpec *declType{dtvArg->GetType()}) {
           return declType->AsDerived() ? declType : nullptr;
         }
       }
@@ -1342,7 +1337,7 @@ static const DeclTypeSpec *GetDefinedIoSpecificArgType(const Symbol &specific) {
 // defined I/O.
 static const Symbol *FindGenericDefinedIo(
     const Scope &scope, common::DefinedIo which) {
-  if (const Symbol * symbol{scope.FindSymbol(GenericKind::AsFortran(which))}) {
+  if (const Symbol *symbol{scope.FindSymbol(GenericKind::AsFortran(which))}) {
     const Symbol &generic{symbol->GetUltimate()};
     const auto &genericDetails{generic.get<GenericDetails>()};
     CHECK(std::holds_alternative<common::DefinedIo>(genericDetails.kind().u));
@@ -1368,13 +1363,12 @@ CollectNonTbpDefinedIoGenericInterfaces(
         {common::DefinedIo::ReadFormatted, common::DefinedIo::ReadUnformatted,
             common::DefinedIo::WriteFormatted,
             common::DefinedIo::WriteUnformatted}) {
-      if (const Symbol * generic{FindGenericDefinedIo(scope, which)}) {
+      if (const Symbol *generic{FindGenericDefinedIo(scope, which)}) {
         for (auto specific : generic->get<GenericDetails>().specificProcs()) {
-          if (const DeclTypeSpec *
-              declType{GetDefinedIoSpecificArgType(*specific)}) {
+          if (const DeclTypeSpec *declType{
+                  GetDefinedIoSpecificArgType(*specific)}) {
             const DerivedTypeSpec &derived{DEREF(declType->AsDerived())};
-            if (const Symbol *
-                dtDesc{derived.scope()
+            if (const Symbol *dtDesc{derived.scope()
                         ? derived.scope()->runtimeDerivedTypeDescription()
                         : nullptr}) {
               if (useRuntimeTypeInfoEntries &&
@@ -1395,7 +1389,7 @@ CollectNonTbpDefinedIoGenericInterfaces(
                   flags |= DefinedIoInteger8;
                 }
                 for (auto [iter, end]{result.equal_range(dtDesc)}; iter != end;
-                     ++iter) {
+                    ++iter) {
                   NonTbpDefinedIo &nonTbp{iter->second};
                   if (nonTbp.definedIo == which) {
                     nonTbp.subroutine = &*specific;
@@ -1437,11 +1431,10 @@ CollectNonTbpDefinedIoGenericInterfaces(
 
 static const Symbol *FindSpecificDefinedIo(const Scope &scope,
     const evaluate::DynamicType &derived, common::DefinedIo which) {
-  if (const Symbol * generic{FindGenericDefinedIo(scope, which)}) {
+  if (const Symbol *generic{FindGenericDefinedIo(scope, which)}) {
     for (auto ref : generic->get<GenericDetails>().specificProcs()) {
       const Symbol &specific{*ref};
-      if (const DeclTypeSpec *
-          thisType{GetDefinedIoSpecificArgType(specific)}) {
+      if (const DeclTypeSpec *thisType{GetDefinedIoSpecificArgType(specific)}) {
         if (evaluate::DynamicType{DEREF(thisType->AsDerived()), true}
                 .IsTkCompatibleWith(derived)) {
           return &specific.GetUltimate();
@@ -1464,8 +1457,8 @@ bool ShouldIgnoreRuntimeTypeInfoNonTbpGenericInterfaces(
       {common::DefinedIo::ReadFormatted, common::DefinedIo::ReadUnformatted,
           common::DefinedIo::WriteFormatted,
           common::DefinedIo::WriteUnformatted}) {
-    if (const Symbol *
-        specific{FindSpecificDefinedIo(typeScope, dyType, which)}) {
+    if (const Symbol *specific{
+            FindSpecificDefinedIo(typeScope, dyType, which)}) {
       // There's a non-TBP defined I/O procedure in the scope of the type's
       // definition that applies to this type.  It will appear in the type's
       // runtime information.  Determine whether it still applies in the

--- a/flang/lib/Semantics/scope.cpp
+++ b/flang/lib/Semantics/scope.cpp
@@ -104,7 +104,7 @@ Symbol *Scope::FindComponent(SourceName name) const {
   auto found{find(name)};
   if (found != end()) {
     return &*found->second;
-  } else if (const Scope * parent{GetDerivedTypeParent()}) {
+  } else if (const Scope *parent{GetDerivedTypeParent()}) {
     return parent->FindComponent(name);
   } else {
     return nullptr;
@@ -220,7 +220,7 @@ const DeclTypeSpec *Scope::GetType(const SomeExpr &expr) {
       case TypeCategory::Complex:
         return &MakeNumericType(dyType->category(), KindExpr{dyType->kind()});
       case TypeCategory::Character:
-        if (const ParamValue * lenParam{dyType->charLengthParamValue()}) {
+        if (const ParamValue *lenParam{dyType->charLengthParamValue()}) {
           return &MakeCharacterType(
               ParamValue{*lenParam}, KindExpr{dyType->kind()});
         } else {
@@ -332,8 +332,8 @@ void Scope::AddSourceRange(parser::CharBlock source) {
       const auto describe{[&](parser::CharBlock src) {
         if (auto range{allCookedSources.GetProvenanceRange(src)}) {
           std::size_t offset;
-          if (const parser::SourceFile *
-              file{allSources.GetSourceFile(range->start(), &offset)}) {
+          if (const parser::SourceFile *file{
+                  allSources.GetSourceFile(range->start(), &offset)}) {
             return "'"s + file->path() + "' at " + std::to_string(offset) +
                 " for " + std::to_string(range->size());
           } else {
@@ -414,7 +414,7 @@ template <common::TypeParamAttr ParamAttr> struct IsTypeParamHelper<ParamAttr> {
 template <common::TypeParamAttr... ParamAttr>
 static bool IsParameterizedDerivedTypeHelper(const Scope &scope) {
   if (scope.IsDerivedType()) {
-    if (const Scope * parent{scope.GetDerivedTypeParent()}) {
+    if (const Scope *parent{scope.GetDerivedTypeParent()}) {
       if (IsParameterizedDerivedTypeHelper<ParamAttr...>(*parent)) {
         return true;
       }
@@ -451,8 +451,8 @@ const DeclTypeSpec *Scope::FindInstantiatedDerivedType(
 }
 
 const Scope *Scope::GetDerivedTypeParent() const {
-  if (const Symbol * symbol{GetSymbol()}) {
-    if (const DerivedTypeSpec * parent{symbol->GetParentTypeSpec(this)}) {
+  if (const Symbol *symbol{GetSymbol()}) {
+    if (const DerivedTypeSpec *parent{symbol->GetParentTypeSpec(this)}) {
       return parent->scope();
     }
   }
@@ -462,7 +462,7 @@ const Scope *Scope::GetDerivedTypeParent() const {
 const Scope &Scope::GetDerivedTypeBase() const {
   const Scope *child{this};
   for (const Scope *parent{GetDerivedTypeParent()}; parent != nullptr;
-       parent = child->GetDerivedTypeParent()) {
+      parent = child->GetDerivedTypeParent()) {
     child = parent;
   }
   return *child;

--- a/flang/lib/Semantics/semantics.cpp
+++ b/flang/lib/Semantics/semantics.cpp
@@ -167,7 +167,7 @@ static void WarnUndefinedFunctionResult(
         IsInitialized(symbol, /*ignoreDataStatements=*/true,
             /*ignoreAllocatable=*/true, /*ignorePointer=*/true);
   }};
-  if (const Symbol * symbol{scope.symbol()}) {
+  if (const Symbol *symbol{scope.symbol()}) {
     if (const auto *subp{symbol->detailsIf<SubprogramDetails>()}) {
       if (subp->isFunction() && !subp->isInterface() && !subp->stmtFunction()) {
         bool wasDefined{WasDefined(subp->result())};
@@ -456,7 +456,7 @@ void SemanticsContext::UpdateScopeIndex(
 
 bool SemanticsContext::IsInModuleFile(parser::CharBlock source) const {
   for (const Scope *scope{&FindScope(source)}; !scope->IsGlobal();
-       scope = &scope->parent()) {
+      scope = &scope->parent()) {
     if (scope->IsModuleFile()) {
       return true;
     }
@@ -501,13 +501,13 @@ void SemanticsContext::CheckIndexVarRedefine(
 }
 
 void SemanticsContext::CheckIndexVarRedefine(const parser::Variable &variable) {
-  if (const Symbol * entity{GetLastName(variable).symbol}) {
+  if (const Symbol *entity{GetLastName(variable).symbol}) {
     CheckIndexVarRedefine(variable.GetSource(), *entity);
   }
 }
 
 void SemanticsContext::CheckIndexVarRedefine(const parser::Name &name) {
-  if (const Symbol * entity{name.symbol}) {
+  if (const Symbol *entity{name.symbol}) {
     CheckIndexVarRedefine(name.source, *entity);
   }
 }
@@ -515,7 +515,7 @@ void SemanticsContext::CheckIndexVarRedefine(const parser::Name &name) {
 void SemanticsContext::ActivateIndexVar(
     const parser::Name &name, IndexVarKind kind) {
   CheckIndexVarRedefine(name);
-  if (const Symbol * indexVar{name.symbol}) {
+  if (const Symbol *indexVar{name.symbol}) {
     activeIndexVars_.emplace(
         ResolveAssociations(*indexVar), IndexVarInfo{name.source, kind});
   }

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -532,7 +532,7 @@ llvm::raw_ostream &operator<<(
   DumpOptional(os, "bindName", x.bindName());
   DumpOptional(os, "passName", x.passName());
   if (x.init()) {
-    if (const Symbol * target{*x.init()}) {
+    if (const Symbol *target{*x.init()}) {
       os << " => " << target->name();
     } else {
       os << " => NULL()";
@@ -741,7 +741,7 @@ llvm::raw_ostream &DumpForUnparse(
 }
 
 const DerivedTypeSpec *Symbol::GetParentTypeSpec(const Scope *scope) const {
-  if (const Symbol * parentComponent{GetParentComponent(scope)}) {
+  if (const Symbol *parentComponent{GetParentComponent(scope)}) {
     const auto &object{parentComponent->get<ObjectEntityDetails>()};
     return &object.type()->derivedTypeSpec();
   } else {
@@ -751,7 +751,7 @@ const DerivedTypeSpec *Symbol::GetParentTypeSpec(const Scope *scope) const {
 
 const Symbol *Symbol::GetParentComponent(const Scope *scope) const {
   if (const auto *dtDetails{detailsIf<DerivedTypeDetails>()}) {
-    if (const Scope * localScope{scope ? scope : scope_}) {
+    if (const Scope *localScope{scope ? scope : scope_}) {
       return dtDetails->GetParentComponent(DEREF(localScope));
     }
   }
@@ -768,7 +768,7 @@ void DerivedTypeDetails::add_component(const Symbol &symbol) {
 const Symbol *DerivedTypeDetails::GetParentComponent(const Scope &scope) const {
   if (auto extends{GetParentComponentName()}) {
     if (auto iter{scope.find(*extends)}; iter != scope.cend()) {
-      if (const Symbol & symbol{*iter->second};
+      if (const Symbol &symbol{*iter->second};
           symbol.test(Symbol::Flag::ParentComp)) {
         return &symbol;
       }
@@ -782,7 +782,7 @@ const Symbol *DerivedTypeDetails::GetFinalForRank(int rank) const {
     const Symbol &symbol{*pair.second};
     if (const auto *details{symbol.detailsIf<SubprogramDetails>()}) {
       if (details->dummyArgs().size() == 1) {
-        if (const Symbol * arg{details->dummyArgs().at(0)}) {
+        if (const Symbol *arg{details->dummyArgs().at(0)}) {
           if (const auto *object{arg->detailsIf<ObjectEntityDetails>()}) {
             if (rank == object->shape().Rank() || object->IsAssumedRank() ||
                 IsElementalProcedure(symbol)) {

--- a/flang/lib/Semantics/tools.cpp
+++ b/flang/lib/Semantics/tools.cpp
@@ -274,7 +274,7 @@ bool IsHostAssociatedIntoSubprogram(const Symbol &symbol, const Scope &scope) {
 }
 
 bool IsInStmtFunction(const Symbol &symbol) {
-  if (const Symbol * function{symbol.owner().symbol()}) {
+  if (const Symbol *function{symbol.owner().symbol()}) {
     return IsStmtFunction(*function);
   }
   return false;
@@ -304,7 +304,7 @@ bool IsBindCProcedure(const Symbol &original) {
 }
 
 bool IsBindCProcedure(const Scope &scope) {
-  if (const Symbol * symbol{scope.GetSymbol()}) {
+  if (const Symbol *symbol{scope.GetSymbol()}) {
     return IsBindCProcedure(*symbol);
   } else {
     return false;
@@ -330,7 +330,7 @@ const Symbol *FindExternallyVisibleObject(
   } else if (&GetProgramUnitContaining(ultimate) !=
       &GetProgramUnitContaining(scope)) {
     return &object;
-  } else if (const Symbol * block{FindCommonBlockContaining(ultimate)}) {
+  } else if (const Symbol *block{FindCommonBlockContaining(ultimate)}) {
     return block;
   }
   return nullptr;
@@ -339,7 +339,7 @@ const Symbol *FindExternallyVisibleObject(
 const Symbol &BypassGeneric(const Symbol &symbol) {
   const Symbol &ultimate{symbol.GetUltimate()};
   if (const auto *generic{ultimate.detailsIf<GenericDetails>()}) {
-    if (const Symbol * specific{generic->specific()}) {
+    if (const Symbol *specific{generic->specific()}) {
       return *specific;
     }
   }
@@ -475,11 +475,11 @@ const Symbol *FindOverriddenBinding(
     const Symbol &symbol, bool &isInaccessibleDeferred) {
   isInaccessibleDeferred = false;
   if (symbol.has<ProcBindingDetails>()) {
-    if (const DeclTypeSpec * parentType{FindParentTypeSpec(symbol.owner())}) {
-      if (const DerivedTypeSpec * parentDerived{parentType->AsDerived()}) {
-        if (const Scope * parentScope{parentDerived->typeSymbol().scope()}) {
-          if (const Symbol *
-              overridden{parentScope->FindComponent(symbol.name())}) {
+    if (const DeclTypeSpec *parentType{FindParentTypeSpec(symbol.owner())}) {
+      if (const DerivedTypeSpec *parentDerived{parentType->AsDerived()}) {
+        if (const Scope *parentScope{parentDerived->typeSymbol().scope()}) {
+          if (const Symbol *overridden{
+                  parentScope->FindComponent(symbol.name())}) {
             // 7.5.7.3 p1: only accessible bindings are overridden
             if (IsAccessible(*overridden, symbol.owner())) {
               return overridden;
@@ -530,7 +530,7 @@ const DeclTypeSpec *FindParentTypeSpec(const DerivedTypeSpec &derived) {
 }
 
 const DeclTypeSpec *FindParentTypeSpec(const DeclTypeSpec &decl) {
-  if (const DerivedTypeSpec * derived{decl.AsDerived()}) {
+  if (const DerivedTypeSpec *derived{decl.AsDerived()}) {
     return FindParentTypeSpec(*derived);
   } else {
     return nullptr;
@@ -547,9 +547,9 @@ const DeclTypeSpec *FindParentTypeSpec(const Scope &scope) {
 }
 
 const DeclTypeSpec *FindParentTypeSpec(const Symbol &symbol) {
-  if (const Scope * scope{symbol.scope()}) {
+  if (const Scope *scope{symbol.scope()}) {
     if (const auto *details{symbol.detailsIf<DerivedTypeDetails>()}) {
-      if (const Symbol * parent{details->GetParentComponent(*scope)}) {
+      if (const Symbol *parent{details->GetParentComponent(*scope)}) {
         return parent->GetType();
       }
     }
@@ -572,8 +572,8 @@ const EquivalenceSet *FindEquivalenceSet(const Symbol &symbol) {
 bool IsOrContainsEventOrLockComponent(const Symbol &original) {
   const Symbol &symbol{ResolveAssociations(original, /*stopAtTypeGuard=*/true)};
   if (evaluate::IsVariable(symbol)) {
-    if (const DeclTypeSpec * type{symbol.GetType()}) {
-      if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+    if (const DeclTypeSpec *type{symbol.GetType()}) {
+      if (const DerivedTypeSpec *derived{type->AsDerived()}) {
         return IsEventTypeOrLockType(derived) ||
             FindEventOrLockPotentialComponent(*derived);
       }
@@ -689,8 +689,8 @@ SymbolVector FinalsForDerivedTypeInstantiation(const DerivedTypeSpec &spec) {
       // in check-declarations.cpp.
       if (const auto *subprog{subr.detailsIf<SubprogramDetails>()};
           subprog && subprog->dummyArgs().size() == 1) {
-        if (const Symbol * arg{subprog->dummyArgs()[0]}) {
-          if (const DeclTypeSpec * type{arg->GetType()}) {
+        if (const Symbol *arg{subprog->dummyArgs()[0]}) {
+          if (const DeclTypeSpec *type{arg->GetType()}) {
             if (type->category() == DeclTypeSpec::TypeDerived &&
                 evaluate::AreSameDerivedType(spec, type->derivedTypeSpec())) {
               result.emplace_back(subr);
@@ -713,7 +713,7 @@ const Symbol *IsFinalizable(const Symbol &symbol,
       return nullptr;
     }
     const DeclTypeSpec *type{object->type()};
-    if (const DerivedTypeSpec * typeSpec{type ? type->AsDerived() : nullptr}) {
+    if (const DerivedTypeSpec *typeSpec{type ? type->AsDerived() : nullptr}) {
       return IsFinalizable(
           *typeSpec, inProgress, withImpureFinalizer, symbol.Rank());
     }
@@ -738,8 +738,8 @@ const Symbol *IsFinalizable(const DerivedTypeSpec &derived,
       elemental = symbol;
     } else {
       if (rank) {
-        if (const SubprogramDetails *
-            subp{symbol->detailsIf<SubprogramDetails>()}) {
+        if (const SubprogramDetails *subp{
+                symbol->detailsIf<SubprogramDetails>()}) {
           if (const auto &args{subp->dummyArgs()}; !args.empty() &&
               args.at(0) && !evaluate::IsAssumedRank(*args.at(0)) &&
               args.at(0)->Rank() != *rank) {
@@ -788,8 +788,8 @@ static const Symbol *HasImpureFinal(
 const Symbol *HasImpureFinal(const Symbol &original, std::optional<int> rank) {
   const Symbol &symbol{ResolveAssociations(original, /*stopAtTypeGuard=*/true)};
   if (symbol.has<ObjectEntityDetails>()) {
-    if (const DeclTypeSpec * symType{symbol.GetType()}) {
-      if (const DerivedTypeSpec * derived{symType->AsDerived()}) {
+    if (const DeclTypeSpec *symType{symbol.GetType()}) {
+      if (const DerivedTypeSpec *derived{symType->AsDerived()}) {
         if (evaluate::IsAssumedRank(symbol)) {
           // finalizable assumed-rank not allowed (C839)
           return nullptr;
@@ -846,7 +846,7 @@ bool MayHaveDefinedAssignment(const DerivedTypeSpec &derived) {
 }
 
 bool IsAssumedLengthCharacter(const Symbol &symbol) {
-  if (const DeclTypeSpec * type{symbol.GetType()}) {
+  if (const DeclTypeSpec *type{symbol.GetType()}) {
     return type->category() == DeclTypeSpec::Character &&
         type->characterTypeSpec().length().isAssumed();
   } else {
@@ -1051,21 +1051,21 @@ bool HasCoarray(const parser::Expr &expression) {
 }
 
 bool IsAssumedType(const Symbol &symbol) {
-  if (const DeclTypeSpec * type{symbol.GetType()}) {
+  if (const DeclTypeSpec *type{symbol.GetType()}) {
     return type->IsAssumedType();
   }
   return false;
 }
 
 bool IsPolymorphic(const Symbol &symbol) {
-  if (const DeclTypeSpec * type{symbol.GetType()}) {
+  if (const DeclTypeSpec *type{symbol.GetType()}) {
     return type->IsPolymorphic();
   }
   return false;
 }
 
 bool IsUnlimitedPolymorphic(const Symbol &symbol) {
-  if (const DeclTypeSpec * type{symbol.GetType()}) {
+  if (const DeclTypeSpec *type{symbol.GetType()}) {
     return type->IsUnlimitedPolymorphic();
   }
   return false;
@@ -1188,7 +1188,7 @@ std::optional<parser::MessageFormattedText> CheckAccessibleSymbol(
 
 SymbolVector OrderParameterNames(const Symbol &typeSymbol) {
   SymbolVector result;
-  if (const DerivedTypeSpec * spec{typeSymbol.GetParentTypeSpec()}) {
+  if (const DerivedTypeSpec *spec{typeSymbol.GetParentTypeSpec()}) {
     result = OrderParameterNames(spec->typeSymbol());
   }
   const auto &paramNames{typeSymbol.get<DerivedTypeDetails>().paramNameOrder()};
@@ -1198,7 +1198,7 @@ SymbolVector OrderParameterNames(const Symbol &typeSymbol) {
 
 SymbolVector OrderParameterDeclarations(const Symbol &typeSymbol) {
   SymbolVector result;
-  if (const DerivedTypeSpec * spec{typeSymbol.GetParentTypeSpec()}) {
+  if (const DerivedTypeSpec *spec{typeSymbol.GetParentTypeSpec()}) {
     result = OrderParameterDeclarations(spec->typeSymbol());
   }
   const auto &paramDecls{typeSymbol.get<DerivedTypeDetails>().paramDeclOrder()};
@@ -1209,8 +1209,8 @@ SymbolVector OrderParameterDeclarations(const Symbol &typeSymbol) {
 const DeclTypeSpec &FindOrInstantiateDerivedType(
     Scope &scope, DerivedTypeSpec &&spec, DeclTypeSpec::Category category) {
   spec.EvaluateParameters(scope.context());
-  if (const DeclTypeSpec *
-      type{scope.FindInstantiatedDerivedType(spec, category)}) {
+  if (const DeclTypeSpec *type{
+          scope.FindInstantiatedDerivedType(spec, category)}) {
     return *type;
   }
   // Create a new instantiation of this parameterized derived type
@@ -1223,7 +1223,7 @@ const DeclTypeSpec &FindOrInstantiateDerivedType(
 const Symbol *FindSeparateModuleSubprogramInterface(const Symbol *proc) {
   if (proc) {
     if (const auto *subprogram{proc->detailsIf<SubprogramDetails>()}) {
-      if (const Symbol * iface{subprogram->moduleInterface()}) {
+      if (const Symbol *iface{subprogram->moduleInterface()}) {
         return iface;
       }
     }
@@ -1251,7 +1251,7 @@ ProcedureDefinitionClass ClassifyProcedure(const Symbol &symbol) { // 15.2.2
     case SubprogramKind::Internal:
       return ProcedureDefinitionClass::Internal;
     }
-  } else if (const Symbol * subp{FindSubprogram(symbol)}) {
+  } else if (const Symbol *subp{FindSubprogram(symbol)}) {
     if (const auto *subpDetails{subp->detailsIf<SubprogramDetails>()}) {
       if (subpDetails->stmtFunction()) {
         return ProcedureDefinitionClass::StatementFunction;
@@ -1290,7 +1290,7 @@ const DerivedTypeSpec *
 ComponentIterator<componentKind>::const_iterator::PlanComponentTraversal(
     const Symbol &component) const {
   if (const auto *details{component.detailsIf<ObjectEntityDetails>()}) {
-    if (const DeclTypeSpec * type{details->type()}) {
+    if (const DeclTypeSpec *type{details->type()}) {
       if (const auto *derived{type->AsDerived()}) {
         bool traverse{false};
         if constexpr (componentKind == ComponentKind::Ordered) {
@@ -1363,8 +1363,8 @@ void ComponentIterator<componentKind>::const_iterator::Increment() {
     if (deepest.component()) {
       if (!deepest.descended()) {
         deepest.set_descended(true);
-        if (const DerivedTypeSpec *
-            derived{PlanComponentTraversal(*deepest.component())}) {
+        if (const DerivedTypeSpec *derived{
+                PlanComponentTraversal(*deepest.component())}) {
           componentPath_.emplace_back(*derived);
           continue;
         }
@@ -1460,7 +1460,7 @@ PotentialComponentIterator::const_iterator FindEventOrLockPotentialComponent(
   for (auto end{potentials.end()}; iter != end; ++iter) {
     const Symbol &component{*iter};
     if (const auto *object{component.detailsIf<ObjectEntityDetails>()}) {
-      if (const DeclTypeSpec * type{object->type()}) {
+      if (const DeclTypeSpec *type{object->type()}) {
         if (IsEventTypeOrLockType(type->AsDerived())) {
           if (!ignoreCoarrays) {
             break; // found one
@@ -1526,7 +1526,7 @@ const Symbol *FindUltimateComponent(const Symbol &symbol,
 
 const Symbol *FindImmediateComponent(const DerivedTypeSpec &type,
     const std::function<bool(const Symbol &)> &predicate) {
-  if (const Scope * scope{type.scope()}) {
+  if (const Scope *scope{type.scope()}) {
     const Symbol *parent{nullptr};
     for (const auto &pair : *scope) {
       const Symbol *symbol{&*pair.second};
@@ -1552,7 +1552,7 @@ const Symbol *FindImmediateComponent(const DerivedTypeSpec &type,
 
 const Symbol *IsFunctionResultWithSameNameAsFunction(const Symbol &symbol) {
   if (IsFunctionResult(symbol)) {
-    if (const Symbol * function{symbol.owner().symbol()}) {
+    if (const Symbol *function{symbol.owner().symbol()}) {
       if (symbol.name() == function->name()) {
         return function;
       }
@@ -1704,7 +1704,7 @@ const DerivedTypeSpec *GetDtvArgDerivedType(const Symbol &proc) {
 
 bool HasDefinedIo(common::DefinedIo which, const DerivedTypeSpec &derived,
     const Scope *scope) {
-  if (const Scope * dtScope{derived.scope()}) {
+  if (const Scope *dtScope{derived.scope()}) {
     for (const auto &pair : *dtScope) {
       const Symbol &symbol{*pair.second};
       if (const auto *generic{symbol.detailsIf<GenericDetails>()}) {
@@ -1726,7 +1726,7 @@ bool HasDefinedIo(common::DefinedIo which, const DerivedTypeSpec &derived,
         const auto &generic{iter->second->GetUltimate().get<GenericDetails>()};
         for (auto ref : generic.specificProcs()) {
           const Symbol &procSym{ref->GetUltimate()};
-          if (const DeclTypeSpec * dtSpec{GetDtvArgTypeSpec(procSym)}) {
+          if (const DeclTypeSpec *dtSpec{GetDtvArgTypeSpec(procSym)}) {
             if (auto dyDummy{evaluate::DynamicType::From(*dtSpec)}) {
               if (dyDummy->IsTkCompatibleWith(dyDerived)) {
                 return true; // GENERIC or INTERFACE not in type
@@ -1777,10 +1777,10 @@ void WarnOnDeferredLengthCharacterScalar(SemanticsContext &context,
     const SomeExpr *expr, parser::CharBlock at, const char *what) {
   if (context.languageFeatures().ShouldWarn(
           common::UsageWarning::F202XAllocatableBreakingChange)) {
-    if (const Symbol *
-        symbol{evaluate::UnwrapWholeSymbolOrComponentDataRef(expr)}) {
+    if (const Symbol *symbol{
+            evaluate::UnwrapWholeSymbolOrComponentDataRef(expr)}) {
       const Symbol &ultimate{ResolveAssociations(*symbol)};
-      if (const DeclTypeSpec * type{ultimate.GetType()}; type &&
+      if (const DeclTypeSpec *type{ultimate.GetType()}; type &&
           type->category() == DeclTypeSpec::Category::Character &&
           type->characterTypeSpec().length().isDeferred() &&
           IsAllocatable(ultimate) && ultimate.Rank() == 0) {
@@ -1795,7 +1795,7 @@ void WarnOnDeferredLengthCharacterScalar(SemanticsContext &context,
 bool CouldBeDataPointerValuedFunction(const Symbol *original) {
   if (original) {
     const Symbol &ultimate{original->GetUltimate()};
-    if (const Symbol * result{FindFunctionResult(ultimate)}) {
+    if (const Symbol *result{FindFunctionResult(ultimate)}) {
       return IsPointer(*result) && !IsProcedure(*result);
     }
     if (const auto *generic{ultimate.detailsIf<GenericDetails>()}) {
@@ -1819,7 +1819,7 @@ std::string GetModuleOrSubmoduleName(const Symbol &symbol) {
 }
 
 std::string GetCommonBlockObjectName(const Symbol &common, bool underscoring) {
-  if (const std::string * bind{common.GetBindName()}) {
+  if (const std::string *bind{common.GetBindName()}) {
     return *bind;
   }
   if (common.name().empty()) {

--- a/flang/lib/Semantics/type.cpp
+++ b/flang/lib/Semantics/type.cpp
@@ -121,7 +121,7 @@ void DerivedTypeSpec::EvaluateParameters(SemanticsContext &context) {
     // Compute the integer kind value of the type parameter,
     // which may depend on the values of earlier ones.
     if (const auto *typeSpec{symbol.GetType()}) {
-      if (const IntrinsicTypeSpec * intrinType{typeSpec->AsIntrinsic()};
+      if (const IntrinsicTypeSpec *intrinType{typeSpec->AsIntrinsic()};
           intrinType && intrinType->category() == TypeCategory::Integer) {
         auto restorer{foldingContext.WithPDTInstance(*this)};
         auto folded{Fold(foldingContext, KindExpr{intrinType->kind()})};
@@ -142,7 +142,7 @@ void DerivedTypeSpec::EvaluateParameters(SemanticsContext &context) {
       // the scope of the derived type being instantiated, as the expressions
       // themselves are not in that scope and cannot reference its type
       // parameters.
-      if (const MaybeIntExpr & expr{paramValue->GetExplicit()}) {
+      if (const MaybeIntExpr &expr{paramValue->GetExplicit()}) {
         evaluate::DynamicType dyType{TypeCategory::Integer, parameterKind};
         if (auto converted{evaluate::ConvertToType(dyType, SomeExpr{*expr})}) {
           SomeExpr folded{
@@ -243,8 +243,8 @@ static bool MatchKindParams(const Symbol &typeSymbol,
       }
     }
   }
-  if (const DerivedTypeSpec *
-      parent{typeSymbol.GetParentTypeSpec(typeSymbol.scope())}) {
+  if (const DerivedTypeSpec *parent{
+          typeSymbol.GetParentTypeSpec(typeSymbol.scope())}) {
     return MatchKindParams(parent->typeSymbol(), thisSpec, thatSpec);
   } else {
     return true;
@@ -254,8 +254,8 @@ static bool MatchKindParams(const Symbol &typeSymbol,
 bool DerivedTypeSpec::MatchesOrExtends(const DerivedTypeSpec &that) const {
   const Symbol *typeSymbol{&typeSymbol_};
   while (typeSymbol != &that.typeSymbol_) {
-    if (const DerivedTypeSpec *
-        parent{typeSymbol->GetParentTypeSpec(typeSymbol->scope())}) {
+    if (const DerivedTypeSpec *parent{
+            typeSymbol->GetParentTypeSpec(typeSymbol->scope())}) {
       typeSymbol = &parent->typeSymbol_;
     } else {
       return false;
@@ -387,7 +387,7 @@ void DerivedTypeSpec::Instantiate(Scope &containingScope) {
           }
         }
         if (!instanceDetails.type()) {
-          if (const DeclTypeSpec * type{details.type()}) {
+          if (const DeclTypeSpec *type{details.type()}) {
             instanceDetails.set_type(*type);
           }
         }
@@ -466,7 +466,7 @@ void InstantiateHelper::InstantiateComponent(const Symbol &oldSymbol) {
   }
   newSymbol.flags() = oldSymbol.flags();
   if (auto *details{newSymbol.detailsIf<ObjectEntityDetails>()}) {
-    if (const DeclTypeSpec * newType{InstantiateType(newSymbol)}) {
+    if (const DeclTypeSpec *newType{InstantiateType(newSymbol)}) {
       details->ReplaceType(*newType);
     }
     for (ShapeSpec &dim : details->shape()) {
@@ -509,7 +509,7 @@ void InstantiateHelper::InstantiateComponent(const Symbol &oldSymbol) {
     }
   } else if (auto *procDetails{newSymbol.detailsIf<ProcEntityDetails>()}) {
     // We have a procedure pointer.  Instantiate its return type
-    if (const DeclTypeSpec * returnType{InstantiateType(newSymbol)}) {
+    if (const DeclTypeSpec *returnType{InstantiateType(newSymbol)}) {
       if (!procDetails->procInterface()) {
         procDetails->ReplaceType(*returnType);
       }
@@ -521,7 +521,7 @@ const DeclTypeSpec *InstantiateHelper::InstantiateType(const Symbol &symbol) {
   const DeclTypeSpec *type{symbol.GetType()};
   if (!type) {
     return nullptr; // error has occurred
-  } else if (const DerivedTypeSpec * spec{type->AsDerived()}) {
+  } else if (const DerivedTypeSpec *spec{type->AsDerived()}) {
     return &FindOrInstantiateDerivedType(scope_,
         CreateDerivedTypeSpec(*spec, symbol.test(Symbol::Flag::ParentComp)),
         type->category());
@@ -847,7 +847,7 @@ bool DeclTypeSpec::IsNumeric(TypeCategory tc) const {
   return category_ == Numeric && numericTypeSpec().category() == tc;
 }
 bool DeclTypeSpec::IsSequenceType() const {
-  if (const DerivedTypeSpec * derivedType{AsDerived()}) {
+  if (const DerivedTypeSpec *derivedType{AsDerived()}) {
     const auto *typeDetails{
         derivedType->typeSymbol().detailsIf<DerivedTypeDetails>()};
     return typeDetails && typeDetails->sequence();


### PR DESCRIPTION
There a a bunch of relatively simple changes, mostly the position of the * or & in declarations, or line breaks in declarations (usually) within if-statements.

Three manual changes:
- remove tailing ; in the constructor of ArithmeticIfStmtChecker,
- prevent re-indentation of visitor functions in check-case.cpp and resolve-directives.cpp