### PR TITLE
[flang][runtime] Allow child NAMELIST input to advance records

### DIFF
--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -696,6 +696,7 @@ public:
   RT_API_ATTRS ChildListIoStatementState(
       ChildIo &, const char *sourceFile = nullptr, int sourceLine = 0);
   using ListDirectedStatementState<DIR>::GetNextDataEdit;
+  RT_API_ATTRS bool AdvanceRecord(int = 1);
   RT_API_ATTRS int EndIoStatement();
 };
 

--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -1095,10 +1095,14 @@ ChildListIoStatementState<DIR>::ChildListIoStatementState(
 }
 
 template <Direction DIR>
-bool ChildUnformattedIoStatementState<DIR>::Receive(
-    char *data, std::size_t bytes, std::size_t elementBytes) {
+bool ChildListIoStatementState<DIR>::AdvanceRecord(int n) {
 #if !defined(RT_DEVICE_AVOID_RECURSION)
-  return this->child().parent().Receive(data, bytes, elementBytes);
+  // Allow child NAMELIST input to advance
+  if (DIR == Direction::Input && this->mutableModes().inNamelist) {
+    return this->child().parent().AdvanceRecord(n);
+  } else {
+    return false;
+  }
 #else
   this->ReportUnsupportedChildIo();
 #endif
@@ -1112,6 +1116,16 @@ template <Direction DIR> int ChildListIoStatementState<DIR>::EndIoStatement() {
     }
   }
   return ChildIoStatementState<DIR>::EndIoStatement();
+}
+
+template <Direction DIR>
+bool ChildUnformattedIoStatementState<DIR>::Receive(
+    char *data, std::size_t bytes, std::size_t elementBytes) {
+#if !defined(RT_DEVICE_AVOID_RECURSION)
+  return this->child().parent().Receive(data, bytes, elementBytes);
+#else
+  this->ReportUnsupportedChildIo();
+#endif
 }
 
 template class InternalIoStatementState<Direction::Output>;


### PR DESCRIPTION
NAMELIST input in child I/O is rare, and it's not clear in the standard whether it should be allowed to advance to later records in the parent unit.  But GNU Fortran supports it, and there's no good reason not to do so since a NAMELIST input group that isn't terminated on the same line is otherwise going to be a fatal error.

Fixes https://github.com/llvm/llvm-project/issues/153416.