### PR TITLE
[flang][runtime] Account for missing READ(SIZE=) characters

### DIFF
--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -663,6 +663,7 @@ static RT_API_ATTRS bool TryFastPathRealDecimalInput(
   *reinterpret_cast<decimal::BinaryFloatingPointNumber<PRECISION> *>(n) =
       converted.binary;
   io.HandleRelativePosition(p - str);
+  io.GotChar(p - str);
   // Set FP exception flags
   if (converted.flags != decimal::ConversionResultFlags::Exact) {
     RaiseFPExceptions(converted.flags);


### PR DESCRIPTION
One of the two formatted real input paths was failing to call GotChar() to account for the characters that it consumes.

Fixes https://github.com/llvm/llvm-project/issues/153830.