### PR TITLE
[libcxx] fix mi_mode_test failure with libc++-21

### DIFF
--- a/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
+++ b/libcxx/test/libcxx/gdb/gdb_pretty_printer_test.sh.cpp
@@ -684,7 +684,7 @@ void mi_mode_test() {
   one_two_three_umap.insert({2, "two"});
   one_two_three_umap.insert({1, "one"});
   CompareListChildrenToChars(
-      one_two_three_umap, R"([{"key": 3, "value": "three"}, {"key": 2, "value": "two"}, {"key": 1, "value": "one"}])");
+      one_two_three_umap, R"([{"key": 1, "value": "one"}, {"key": 2, "value": "two"}, {"key": 3, "value": "three"}])");
 
   std::deque<int> one_two_three_deque{1, 2, 3};
   CompareListChildrenToChars(one_two_three_deque, "[1, 2, 3]");


### PR DESCRIPTION
Update the reference string to use the same order as in current `std::unordered_map` implementation.

The issue was never detected by CI, because related test used `gdb.execute_mi` method, available inly since GDB 14.2 (while CI use GDB 12).
Now test provides a polyfill for older GDB releases.

Closes https://github.com/llvm/llvm-project/issues/153940