### PR TITLE
[libc] Setup hdrgen for ioctl

### DIFF
--- a/libc/include/sys/ioctl.yaml
+++ b/libc/include/sys/ioctl.yaml
@@ -7,6 +7,8 @@ enums: []
 objects: []
 functions:
   - name: ioctl
+    standards:
+      - Linux
     return_type: int
     arguments:
       - type: int

--- a/libc/include/sys/ioctl.yaml
+++ b/libc/include/sys/ioctl.yaml
@@ -5,4 +5,10 @@ macros: []
 types: []
 enums: []
 objects: []
-functions: []
+functions:
+  - name: ioctl
+    return_type: int
+    arguments:
+      - type: int
+      - type: unsigned long
+      - type: '...'


### PR DESCRIPTION
This patch adds some hdrgen yaml for ioctl(). Otherwise the function never actually ends up being available in a full build. This is the last thing that is needed to enable turning on LIBCXX_ENABLE_RANDOM_DEVICE.