### PR TITLE
[mlir][doc] fixup code block

### DIFF
--- a/mlir/docs/Tutorials/Toy/Ch-4.md
+++ b/mlir/docs/Tutorials/Toy/Ch-4.md
@@ -170,7 +170,7 @@ let arguments = (ins
   OptionalAttr<DictArrayAttr>:$arg_attrs,
   OptionalAttr<DictArrayAttr>:$res_attrs
 );
-
+```
 
 We have already provided the definition in the `extraClassDeclaration`
 field of the `FuncOp` class:


### PR DESCRIPTION
This fixes a small typo in the toy tutorial. A code block was not correctly terminated, causing it to run into the subsequent block.