### PR TITLE
[libc] Correct standard for getcpu

### DIFF
--- a/libc/include/sched.yaml
+++ b/libc/include/sched.yaml
@@ -20,7 +20,7 @@ functions:
       - type: const cpu_set_t *
   - name: getcpu
     standards:
-      - POSIX
+      - Linux
     return_type: int
     arguments:
       - type: unsigned int *


### PR DESCRIPTION
Given this is a syscall wrapper and not in POSIX, this should actually be defined under the Linux standard.

https://man7.org/linux/man-pages/man2/getcpu.2.html confirms.