### PR TITLE
[lldb] Make step/s alias for new _regexp-step

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -956,7 +956,8 @@ void CommandInterpreter::LoadCommandDictionary() {
           "_regexp-step <function-name> // Step into the named function\n",
           0, false));
   if (step_regex_cmd_sp) {
-    if (step_regex_cmd_sp->AddRegexCommand("^$", "thread step-in") &&
+    if (step_regex_cmd_sp->AddRegexCommand("^[[:space:]]*$",
+                                           "thread step-in") &&
         step_regex_cmd_sp->AddRegexCommand("^[[:space:]]*(-.*)$",
                                            "thread step-in %1") &&
         step_regex_cmd_sp->AddRegexCommand(

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -335,7 +335,7 @@ void CommandInterpreter::Initialize() {
     AddAlias("ni", cmd_obj_sp);
   }
 
-  cmd_obj_sp = GetCommandSPExact("thread step-in");
+  cmd_obj_sp = GetCommandSPExact("_regexp-step");
   if (cmd_obj_sp) {
     AddAlias("s", cmd_obj_sp);
     AddAlias("step", cmd_obj_sp);
@@ -944,6 +944,26 @@ void CommandInterpreter::LoadCommandDictionary() {
       CommandObjectSP jump_regex_cmd_sp(jump_regex_cmd_up.release());
       m_command_dict[std::string(jump_regex_cmd_sp->GetCommandName())] =
           jump_regex_cmd_sp;
+    }
+  }
+
+  std::shared_ptr<CommandObjectRegexCommand> step_regex_cmd_sp(
+      new CommandObjectRegexCommand(
+          *this, "_regexp-step",
+          "Single step, optionally to a specific function.",
+          "\n"
+          "_regexp-step                 // Single step\n"
+          "_regexp-step <function-name> // Step into the named function\n",
+          0, false));
+  if (step_regex_cmd_sp) {
+    if (step_regex_cmd_sp->AddRegexCommand("^$", "thread step-in") &&
+        step_regex_cmd_sp->AddRegexCommand("^[[:space:]]*(-.*)$",
+                                           "thread step-in %1") &&
+        step_regex_cmd_sp->AddRegexCommand(
+            "^[[:space:]]*(.+)[[:space:]]*$",
+            "thread step-in --end-linenumber block --step-in-target %1")) {
+      m_command_dict[std::string(step_regex_cmd_sp->GetCommandName())] =
+          step_regex_cmd_sp;
     }
   }
 }

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -958,7 +958,7 @@ void CommandInterpreter::LoadCommandDictionary() {
   if (step_regex_cmd_sp) {
     if (step_regex_cmd_sp->AddRegexCommand("^[[:space:]]*$",
                                            "thread step-in") &&
-        step_regex_cmd_sp->AddRegexCommand("^[[:space:]]*(-.*)$",
+        step_regex_cmd_sp->AddRegexCommand("^[[:space:]]*(-.+)$",
                                            "thread step-in %1") &&
         step_regex_cmd_sp->AddRegexCommand(
             "^[[:space:]]*(.+)[[:space:]]*$",

--- a/lldb/test/API/lang/c/step-target/TestStepTarget.py
+++ b/lldb/test/API/lang/c/step-target/TestStepTarget.py
@@ -83,14 +83,16 @@ class TestStepTarget(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr32343")
     def test_with_command_and_block(self):
         """Test stepping over vrs. hitting breakpoints & subsequent stepping in various forms."""
+        self.do_command_and_block()
+        self.do_command_and_block(True)
 
+    def do_command_and_block(self, use_regexp_step=False):
         thread = self.get_to_start()
 
-        result = lldb.SBCommandReturnObject()
-        self.dbg.GetCommandInterpreter().HandleCommand(
-            'thread step-in -t "lotsOfArgs" -e block', result
-        )
-        self.assertTrue(result.Succeeded(), "thread step-in command succeeded.")
+        if use_regexp_step:
+            self.expect("s lotsOfArgs")
+        else:
+            self.expect('thread step-in -t "lotsOfArgs" -e block')
 
         frame = thread.frames[0]
         self.assertEqual(frame.name, "lotsOfArgs", "Stepped to lotsOfArgs.")
@@ -98,14 +100,16 @@ class TestStepTarget(TestBase):
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr32343")
     def test_with_command_and_block_and_bad_name(self):
         """Test stepping over vrs. hitting breakpoints & subsequent stepping in various forms."""
+        self.do_with_command_and_block_and_bad_name()
+        self.do_with_command_and_block_and_bad_name(True)
 
+    def do_with_command_and_block_and_bad_name(self, use_regexp_step=False):
         thread = self.get_to_start()
 
-        result = lldb.SBCommandReturnObject()
-        self.dbg.GetCommandInterpreter().HandleCommand(
-            'thread step-in -t "lotsOfArgsssss" -e block', result
-        )
-        self.assertTrue(result.Succeeded(), "thread step-in command succeeded.")
+        if use_regexp_step:
+            self.expect("s lotsOfArgsssss")
+        else:
+            self.expect('thread step-in -t "lotsOfArgsssss" -e block')
 
         frame = thread.frames[0]
 


### PR DESCRIPTION
Introduces `_regexp-step`, a step command which additionally allows for stepping into a target function. This change updates `step` and `s` to be aliases for `_regexp-step`.

The existing `sif` alias ("Step Into Function") is not well known amongst users. This change updates `step` and `s` to also work like `sif`, taking an optional function name.

This is implemented to not break uses of `step` or `s` with a flag, for example running `step -r func_to_avoid` works as expected.
