### PR TITLE
[clang] fix redecl chain assumption when checking linkage consistency

### DIFF
--- a/clang/test/Modules/GH153933.cpp
+++ b/clang/test/Modules/GH153933.cpp
@@ -1,0 +1,23 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang_cc1 -std=c++20 %t/B.cppm -emit-module-interface -o %t/B.pcm
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -fprebuilt-module-path=%t %t/C.cpp
+
+//--- A.hpp
+template<class> struct A {};
+template<class T> struct B {
+  virtual A<T> v() { return {}; }
+};
+B<void> x;
+
+//--- B.cppm
+module;
+#include "A.hpp"
+export module B;
+using ::x;
+
+//--- C.cpp
+#include "A.hpp"
+import B;


### PR DESCRIPTION
In C++, it can be assumed the same linkage will be computed for all redeclarations of an entity, and we have assertions to check this.

However, the linkage for a declaration can be requested in the middle of deserealization, and at this point the redecl chain is not well formed, as computation of the most recent declaration is deferred.

This patch makes that assertion work even in such conditions.

This fixes a regression introduced in https://github.com/llvm/llvm-project/pull/147835, which was never released, so there are no release notes for this.

Fixes #153933