### PR TITLE
[clang-tidy] Improve "-quiet" option by suppressing "xxx warnings generated"

### DIFF
--- a/clang-tools-extra/clang-tidy/ClangTidy.cpp
+++ b/clang-tools-extra/clang-tidy/ClangTidy.cpp
@@ -540,7 +540,7 @@ runClangTidy(clang::tidy::ClangTidyContext &Context,
              ArrayRef<std::string> InputFiles,
              llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> BaseFS,
              bool ApplyAnyFix, bool EnableCheckProfile,
-             llvm::StringRef StoreCheckProfile) {
+             llvm::StringRef StoreCheckProfile, bool Quiet) {
   ClangTool Tool(Compilations, InputFiles,
                  std::make_shared<PCHContainerOperations>(), BaseFS);
 
@@ -577,8 +577,9 @@ runClangTidy(clang::tidy::ClangTidyContext &Context,
   class ActionFactory : public FrontendActionFactory {
   public:
     ActionFactory(ClangTidyContext &Context,
-                  IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> BaseFS)
-        : ConsumerFactory(Context, std::move(BaseFS)) {}
+                  IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> BaseFS,
+                  bool Quiet)
+        : ConsumerFactory(Context, std::move(BaseFS)), Quiet(Quiet) {}
     std::unique_ptr<FrontendAction> create() override {
       return std::make_unique<Action>(&ConsumerFactory);
     }
@@ -589,6 +590,8 @@ runClangTidy(clang::tidy::ClangTidyContext &Context,
                        DiagnosticConsumer *DiagConsumer) override {
       // Explicitly ask to define __clang_analyzer__ macro.
       Invocation->getPreprocessorOpts().SetUpStaticAnalyzer = true;
+      if (Quiet)
+        Invocation->getDiagnosticOpts().ShowCarets = false;
       return FrontendActionFactory::runInvocation(
           Invocation, Files, PCHContainerOps, DiagConsumer);
     }
@@ -607,9 +610,10 @@ runClangTidy(clang::tidy::ClangTidyContext &Context,
     };
 
     ClangTidyASTConsumerFactory ConsumerFactory;
+    bool Quiet;
   };
 
-  ActionFactory Factory(Context, std::move(BaseFS));
+  ActionFactory Factory(Context, std::move(BaseFS), Quiet);
   Tool.run(&Factory);
   return DiagConsumer.take();
 }

--- a/clang-tools-extra/clang-tidy/ClangTidy.h
+++ b/clang-tools-extra/clang-tidy/ClangTidy.h
@@ -94,7 +94,8 @@ runClangTidy(clang::tidy::ClangTidyContext &Context,
              ArrayRef<std::string> InputFiles,
              llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> BaseFS,
              bool ApplyAnyFix, bool EnableCheckProfile = false,
-             llvm::StringRef StoreCheckProfile = StringRef());
+             llvm::StringRef StoreCheckProfile = StringRef(),
+             bool Quiet = false);
 
 /// Controls what kind of fixes clang-tidy is allowed to apply.
 enum FixBehaviour {

--- a/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
+++ b/clang-tools-extra/clang-tidy/tool/ClangTidyMain.cpp
@@ -717,7 +717,7 @@ int clangTidyMain(int argc, const char **argv) {
                            EnableModuleHeadersParsing);
   std::vector<ClangTidyError> Errors =
       runClangTidy(Context, OptionsParser->getCompilations(), PathList, BaseFS,
-                   FixNotes, EnableCheckProfile, ProfilePrefix);
+                   FixNotes, EnableCheckProfile, ProfilePrefix, Quiet);
   bool FoundErrors = llvm::any_of(Errors, [](const ClangTidyError &E) {
     return E.DiagLevel == ClangTidyError::Error;
   });

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -112,6 +112,9 @@ Improvements to clang-tidy
 - Improved documentation of the `-line-filter` command-line flag of
   :program:`clang-tidy` and :program:`run-clang-tidy.py`.
 
+- Improved :program:`clang-tidy` option `quiet` to suppresses diagnostic count
+  messages.
+
 New checks
 ^^^^^^^^^^
 

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -112,8 +112,8 @@ Improvements to clang-tidy
 - Improved documentation of the `-line-filter` command-line flag of
   :program:`clang-tidy` and :program:`run-clang-tidy.py`.
 
-- Improved :program:`clang-tidy` option `quiet` to suppresses diagnostic count
-  messages.
+- Improved :program:`clang-tidy` option `-quiet` by suppressing diagnostic
+  count messages.
 
 New checks
 ^^^^^^^^^^

--- a/clang-tools-extra/test/clang-tidy/infrastructure/file-filter-symlinks.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/file-filter-symlinks.cpp
@@ -10,7 +10,7 @@
 // RUN: clang-tidy -checks='-*,google-explicit-constructor' -header-filter='header_alias\.h' %s -- -I %t 2>&1 | FileCheck --check-prefix=CHECK_HEADER_ALIAS %s
 // RUN: clang-tidy -checks='-*,google-explicit-constructor' -header-filter='header_alias\.h' -quiet %s -- -I %t 2>&1 | FileCheck --check-prefix=CHECK_HEADER_ALIAS %s
 // RUN: clang-tidy -checks='-*,google-explicit-constructor' -header-filter='header\.h' %s -- -I %t 2>&1 | FileCheck --check-prefix=CHECK_HEADER %s
-// RUN: clang-tidy -checks='-*,google-explicit-constructor' -header-filter='header\.h' -quiet %s -- -I %t 2>&1 | FileCheck --check-prefix=CHECK_HEADER %s
+// RUN: clang-tidy -checks='-*,google-explicit-constructor' -header-filter='header\.h' -quiet %s -- -I %t 2>&1 | FileCheck --check-prefix=CHECK_HEADER --allow-empty %s
 
 // Check that `-header-filter` operates on the same file paths as paths in
 // diagnostics printed by ClangTidy.

--- a/clang-tools-extra/test/clang-tidy/infrastructure/quiet-flag.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/quiet-flag.cpp
@@ -1,14 +1,14 @@
-// RUN: clang-tidy -checks=-*,readability-magic-numbers %t.cpp -- 2>&1 | FileCheck %s --check-prefix=CHECK-NORMAL
-// RUN: clang-tidy -checks=-*,readability-magic-numbers -quiet %t.cpp -- 2>&1 | FileCheck %s --check-prefix=CHECK-QUIET
+// RUN: clang-tidy -checks=-*,readability-magic-numbers %s -- 2>&1 | FileCheck %s --check-prefix=CHECK-NORMAL
+// RUN: clang-tidy -checks=-*,readability-magic-numbers -quiet %s -- 2>&1 | FileCheck %s --check-prefix=CHECK-QUIET
 
 // Normal mode should show warning count
 // CHECK-NORMAL: 1 warning generated
 // CHECK-NORMAL: warning: 42 is a magic number
 
-// Quiet mode should suppress warning count 
-// CHECK-QUIET-NOT: 1 warning generated
+// Quiet mode should suppress warning count but show diagnostic
 // CHECK-QUIET: warning: 42 is a magic number
+// CHECK-QUIET-NOT: {{[0-9]+}} warning{{s?}} generated
 
 int main() {
-  int x = 42;
+  int x = 42; // This will trigger readability-magic-numbers
 }

--- a/clang-tools-extra/test/clang-tidy/infrastructure/quiet-flag.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/quiet-flag.cpp
@@ -1,14 +1,26 @@
-// RUN: clang-tidy -checks=-*,readability-magic-numbers %s -- 2>&1 | FileCheck %s --check-prefix=CHECK-NORMAL
-// RUN: clang-tidy -checks=-*,readability-magic-numbers -quiet %s -- 2>&1 | FileCheck %s --check-prefix=CHECK-QUIET
+// This test ensures that the --quiet flag only suppresses the "X warnings generated" 
+// message while keeping all diagnostic information including caret indicators (^).
 
-// Normal mode should show warning count
-// CHECK-NORMAL: 1 warning generated
-// CHECK-NORMAL: warning: 42 is a magic number
+// RUN: clang-tidy -checks=-*,readability-magic-numbers,clang-diagnostic-sign-compare %s -- \
+// RUN:   -Wsign-compare 2>&1 | FileCheck %s --check-prefix=CHECK-NORMAL
+// RUN: clang-tidy -checks=-*,readability-magic-numbers,clang-diagnostic-sign-compare -quiet %s -- \
+// RUN:   -Wsign-compare 2>&1 | FileCheck %s --check-prefix=CHECK-QUIET
 
-// Quiet mode should suppress warning count but show diagnostic
-// CHECK-QUIET: warning: 42 is a magic number
+// CHECK-NORMAL: 2 warnings generated
+// CHECK-NORMAL-DAG: warning: 42 is a magic number
+// CHECK-NORMAL-DAG: {{[ ]*\^}}
+// CHECK-NORMAL-DAG: warning: comparison of integers of different signs
+// CHECK-NORMAL-DAG: {{[ ]*~ \^ ~}}
+
 // CHECK-QUIET-NOT: {{[0-9]+}} warning{{s?}} generated
+// CHECK-QUIET-DAG: warning: 42 is a magic number
+// CHECK-QUIET-DAG: {{[ ]*\^}}
+// CHECK-QUIET-DAG: warning: comparison of integers of different signs
+// CHECK-QUIET-DAG: {{[ ]*~ \^ ~}}
 
 int main() {
-  int x = 42; // This will trigger readability-magic-numbers
+  const int CONST_VAL = 10;
+  int x = 42; // trigger 'readability-magic-numbers' with caret: ^
+  unsigned int y = CONST_VAL;
+  return x < y; // trigger 'clang-diagnostic-sign-compare' with caret: ^
 }

--- a/clang-tools-extra/test/clang-tidy/infrastructure/quiet-flag.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/quiet-flag.cpp
@@ -1,0 +1,14 @@
+// RUN: clang-tidy -checks=-*,readability-magic-numbers %t.cpp -- 2>&1 | FileCheck %s --check-prefix=CHECK-NORMAL
+// RUN: clang-tidy -checks=-*,readability-magic-numbers -quiet %t.cpp -- 2>&1 | FileCheck %s --check-prefix=CHECK-QUIET
+
+// Normal mode should show warning count
+// CHECK-NORMAL: 1 warning generated
+// CHECK-NORMAL: warning: 42 is a magic number
+
+// Quiet mode should suppress warning count 
+// CHECK-QUIET-NOT: 1 warning generated
+// CHECK-QUIET: warning: 42 is a magic number
+
+int main() {
+  int x = 42;
+}


### PR DESCRIPTION
Before this change, `-quiet` mode in clang-tidy generated meaningless messages `xxx warnings generated` in output:
```cpp
// main.cpp
#include <iostream>

int main() {
  std::cout << 42;
}
```
```console
> clang-tidy -checks='-*,readability-magic-numbers' -quiet main.cpp

82 warnings generated.
main.cpp:4:16: warning: 42 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
    4 |   std::cout << 42;
      |                ^
```

As you can see, `82 warnings generated.` does not say much `quiet` mode, this patch removes this message completely:

```console
> ./build/bin/clang-tidy -p build -checks='-*,readability-magic-numbers' -quiet main.cpp

main.cpp:4:16: warning: 42 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
    4 |   std::cout << 42;
      |                ^
```

In contrast, when running without `quiet`, It gives some meaningful information because we know how many messages were suppressed thus calculating total messages count:
```console
> clang-tidy -checks='-*,readability-magic-numbers' main.cpp

82 warnings generated.
main.cpp:4:16: warning: 42 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
    4 |   std::cout << 42;
      |                ^
Suppressed 81 warnings (81 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
```

Fixes #47042