### PR TITLE
[clang] Include explicit object methods in overload suggestions

### DIFF
--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -4532,6 +4532,126 @@ TEST(CompletionTest, MemberAccessInExplicitObjMemfn) {
     EXPECT_THAT(Result.Completions, ElementsAre());
   }
 }
+
+TEST(CompletionTest, ListExplicitObjectOverloads) {
+  Annotations Code(R"cpp(
+    struct S {
+      void foo1(int a);
+      void foo2(int a) const;
+      void foo3(this const S& self, int a);
+      void foo4(this S& self, int a);
+    };
+
+    void S::foo1(int a) {
+      this->$c1^;
+    }
+
+    void S::foo2(int a) const {
+      this->$c2^;
+    }
+
+    void S::foo3(this const S& self, int a) {
+      self.$c3^;
+    }
+
+    void S::foo4(this S& self, int a) {
+      self.$c4^;
+    }
+
+    void test1(S s) {
+      s.$c5^;
+    }
+
+    void test2(const S s) {
+      s.$c6^;
+    }
+  )cpp");
+
+  auto TU = TestTU::withCode(Code.code());
+  TU.ExtraArgs = {"-std=c++23"};
+
+  auto Preamble = TU.preamble();
+  ASSERT_TRUE(Preamble);
+
+  CodeCompleteOptions Opts{};
+
+  MockFS FS;
+  auto Inputs = TU.inputs(FS);
+
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c1"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("foo1"), signature("(int a)"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo2"), signature("(int a) const"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo3"), signature("(int a)" /* const */),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo4"), signature("(int a)"),
+                          snippetSuffix("(${1:int a})"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c2"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("foo2"), signature("(int a) const"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo3"), signature("(int a)" /* const */),
+                          snippetSuffix("(${1:int a})"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c3"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("foo2"), signature("(int a) const"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo3"), signature("(int a)" /* const */),
+                          snippetSuffix("(${1:int a})"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c4"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("foo1"), signature("(int a)"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo2"), signature("(int a) const"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo3"), signature("(int a)" /* const */),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo4"), signature("(int a)"),
+                          snippetSuffix("(${1:int a})"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c5"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("foo1"), signature("(int a)"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo2"), signature("(int a) const"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo3"), signature("(int a)" /* const */),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo4"), signature("(int a)"),
+                          snippetSuffix("(${1:int a})"))));
+  }
+  {
+    auto Result = codeComplete(testPath(TU.Filename), Code.point("c6"),
+                               Preamble.get(), Inputs, Opts);
+    EXPECT_THAT(Result.Completions,
+                UnorderedElementsAre(
+                    AllOf(named("foo2"), signature("(int a) const"),
+                          snippetSuffix("(${1:int a})")),
+                    AllOf(named("foo3"), signature("(int a)" /* const */),
+                          snippetSuffix("(${1:int a})"))));
+  }
+}
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -4538,6 +4538,7 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
     struct S {
       void foo1(int a);
       void foo2(int a) const;
+      void foo2(this const S& self, float a);
       void foo3(this const S& self, int a);
       void foo4(this S& self, int a);
     };
@@ -4587,6 +4588,8 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("foo2"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(float a) const"),
+                                   snippetSuffix("(${1:float a})")),
                              AllOf(named("foo3"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("foo4"), signature("(int a)"),
@@ -4599,6 +4602,8 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
         Result.Completions,
         UnorderedElementsAre(AllOf(named("foo2"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(float a) const"),
+                                   snippetSuffix("(${1:float a})")),
                              AllOf(named("foo3"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})"))));
   }
@@ -4609,6 +4614,8 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
         Result.Completions,
         UnorderedElementsAre(AllOf(named("foo2"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(float a) const"),
+                                   snippetSuffix("(${1:float a})")),
                              AllOf(named("foo3"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})"))));
   }
@@ -4621,6 +4628,8 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("foo2"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(float a) const"),
+                                   snippetSuffix("(${1:float a})")),
                              AllOf(named("foo3"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("foo4"), signature("(int a)"),
@@ -4635,6 +4644,8 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("foo2"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(float a) const"),
+                                   snippetSuffix("(${1:float a})")),
                              AllOf(named("foo3"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
                              AllOf(named("foo4"), signature("(int a)"),
@@ -4647,6 +4658,8 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
         Result.Completions,
         UnorderedElementsAre(AllOf(named("foo2"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(float a) const"),
+                                   snippetSuffix("(${1:float a})")),
                              AllOf(named("foo3"), signature("(int a) const"),
                                    snippetSuffix("(${1:int a})"))));
   }

--- a/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
+++ b/clang-tools-extra/clangd/unittests/CodeCompleteTests.cpp
@@ -4581,74 +4581,74 @@ TEST(CompletionTest, ListExplicitObjectOverloads) {
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c1"),
                                Preamble.get(), Inputs, Opts);
-    EXPECT_THAT(Result.Completions,
-                UnorderedElementsAre(
-                    AllOf(named("foo1"), signature("(int a)"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo2"), signature("(int a) const"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo3"), signature("(int a)" /* const */),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo4"), signature("(int a)"),
-                          snippetSuffix("(${1:int a})"))));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(AllOf(named("foo1"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo3"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo4"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})"))));
   }
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c2"),
                                Preamble.get(), Inputs, Opts);
-    EXPECT_THAT(Result.Completions,
-                UnorderedElementsAre(
-                    AllOf(named("foo2"), signature("(int a) const"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo3"), signature("(int a)" /* const */),
-                          snippetSuffix("(${1:int a})"))));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(AllOf(named("foo2"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo3"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})"))));
   }
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c3"),
                                Preamble.get(), Inputs, Opts);
-    EXPECT_THAT(Result.Completions,
-                UnorderedElementsAre(
-                    AllOf(named("foo2"), signature("(int a) const"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo3"), signature("(int a)" /* const */),
-                          snippetSuffix("(${1:int a})"))));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(AllOf(named("foo2"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo3"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})"))));
   }
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c4"),
                                Preamble.get(), Inputs, Opts);
-    EXPECT_THAT(Result.Completions,
-                UnorderedElementsAre(
-                    AllOf(named("foo1"), signature("(int a)"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo2"), signature("(int a) const"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo3"), signature("(int a)" /* const */),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo4"), signature("(int a)"),
-                          snippetSuffix("(${1:int a})"))));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(AllOf(named("foo1"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo3"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo4"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})"))));
   }
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c5"),
                                Preamble.get(), Inputs, Opts);
-    EXPECT_THAT(Result.Completions,
-                UnorderedElementsAre(
-                    AllOf(named("foo1"), signature("(int a)"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo2"), signature("(int a) const"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo3"), signature("(int a)" /* const */),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo4"), signature("(int a)"),
-                          snippetSuffix("(${1:int a})"))));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(AllOf(named("foo1"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo2"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo3"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo4"), signature("(int a)"),
+                                   snippetSuffix("(${1:int a})"))));
   }
   {
     auto Result = codeComplete(testPath(TU.Filename), Code.point("c6"),
                                Preamble.get(), Inputs, Opts);
-    EXPECT_THAT(Result.Completions,
-                UnorderedElementsAre(
-                    AllOf(named("foo2"), signature("(int a) const"),
-                          snippetSuffix("(${1:int a})")),
-                    AllOf(named("foo3"), signature("(int a)" /* const */),
-                          snippetSuffix("(${1:int a})"))));
+    EXPECT_THAT(
+        Result.Completions,
+        UnorderedElementsAre(AllOf(named("foo2"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})")),
+                             AllOf(named("foo3"), signature("(int a) const"),
+                                   snippetSuffix("(${1:int a})"))));
   }
 }
 

--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3434,9 +3434,36 @@ static void AddQualifierToCompletionString(CodeCompletionBuilder &Result,
     Result.AddTextChunk(Result.getAllocator().CopyString(PrintedNNS));
 }
 
+// Sets the function qualifiers completion string by inspecting the explicit
+// object
+static void AddCXXExplicitObjectFunctionTypeQualsToCompletionString(
+    CodeCompletionBuilder &Result, const CXXMethodDecl *Function) {
+  const auto Quals = Function->getFunctionObjectParameterType();
+
+  if (!Quals.hasQualifiers())
+    return;
+
+  std::string QualsStr;
+  if (Quals.getQualifiers().hasConst())
+    QualsStr += " const";
+  if (Quals.getQualifiers().hasVolatile())
+    QualsStr += " volatile";
+  if (Quals.getQualifiers().hasRestrict())
+    QualsStr += " restrict";
+  Result.AddInformativeChunk(Result.getAllocator().CopyString(QualsStr));
+}
+
 static void
 AddFunctionTypeQualsToCompletionString(CodeCompletionBuilder &Result,
                                        const FunctionDecl *Function) {
+  if (auto *CxxMethodDecl = llvm::dyn_cast_if_present<CXXMethodDecl>(Function);
+      CxxMethodDecl && CxxMethodDecl->hasCXXExplicitFunctionObjectParameter()) {
+    // if explicit object method, infer quals from the object parameter
+    AddCXXExplicitObjectFunctionTypeQualsToCompletionString(Result,
+                                                            CxxMethodDecl);
+    return;
+  }
+
   const auto *Proto = Function->getType()->getAs<FunctionProtoType>();
   if (!Proto || !Proto->getMethodQuals())
     return;


### PR DESCRIPTION
Fix for #109608. 

Include methods that use explicit object in code complete suggestions. 

```cpp
struct S {
  void foo1(int a) const;
  void foo2(int a);
  void foo2(this const S& self, float a); // shows up as overload of foo2
  void foo3(this const S& self, int a);
  void foo4(this S& self, int a);
};

int foo(const S arg) {
  arg.f^ // Now suggests foo3 as well 
}
```
