### PR TITLE
Fix lambda *this capture crash - Fixes #154054

### DIFF
--- a/clang/test/SemaCXX/lambda-this-capture-crash.cpp
+++ b/clang/test/SemaCXX/lambda-this-capture-crash.cpp
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 -std=c++23 -verify -fsyntax-only %s
+
+// Test case for crash when combining lambda *this capture with explicit this parameter
+// This should not crash the compiler
+
+struct S {
+  int x;
+  auto byval() {
+    return [*this](this auto) { return this->x; }; // expected-no-diagnostics
+  }
+};
+
+// Variation with explicit type
+struct S1 {
+  int x;
+  auto byval() {
+    return [*this](this auto&& self) { return this->x; }; // expected-no-diagnostics
+  }
+};
+
+// Using captured member without this->
+struct S2 {
+  int x;
+  auto byval() {
+    return [*this](this auto&& self) { return x; }; // expected-no-diagnostics
+  }
+};
+
+// More complex case with multiple members
+struct S3 {
+  int x;
+  int y;
+  auto complex() {
+    return [*this](this auto&& self, int z) { 
+      return this->x + this->y + z; 
+    }; // expected-no-diagnostics
+  }
+};
+
+// Test that the code actually works
+int test() {
+  S s{ 42 };
+  auto lambda = s.byval();
+  return lambda(); // Should return 42
+} 

--- a/clang/test/SemaCXX/lambda-this-capture-crash.cpp
+++ b/clang/test/SemaCXX/lambda-this-capture-crash.cpp
@@ -1,16 +1,18 @@
 // RUN: %clang_cc1 -std=c++23 -verify -fsyntax-only %s
 
-// Test case for crash when combining lambda *this capture with explicit this parameter
-// This should not crash the compiler
+// Test case for ensuring lambda *this capture with explicit this parameter doesn't crash
+// This reproduces a crash that occurs in some clang distributions (e.g., Apple clang 17.0.0)
+// when combining lambda capture by copy of *this with explicit this parameters
 
 struct S {
   int x;
   auto byval() {
+    // This combination should not crash the compiler
     return [*this](this auto) { return this->x; }; // expected-no-diagnostics
   }
 };
 
-// Variation with explicit type
+// Variation with explicit type and parameter name
 struct S1 {
   int x;
   auto byval() {
@@ -18,7 +20,7 @@ struct S1 {
   }
 };
 
-// Using captured member without this->
+// Using captured member without explicit this->
 struct S2 {
   int x;
   auto byval() {
@@ -26,7 +28,7 @@ struct S2 {
   }
 };
 
-// More complex case with multiple members
+// More complex case with multiple members and parameters
 struct S3 {
   int x;
   int y;
@@ -37,9 +39,21 @@ struct S3 {
   }
 };
 
-// Test that the code actually works
-int test() {
+// Nested lambda case
+struct S4 {
+  int x;
+  auto nested() {
+    return [*this](this auto&& self) {
+      return [*this](this auto&& inner) { return this->x; };
+    }; // expected-no-diagnostics
+  }
+};
+
+// Test that the code actually compiles and works semantically
+constexpr int test() {
   S s{ 42 };
   auto lambda = s.byval();
   return lambda(); // Should return 42
-} 
+}
+
+static_assert(test() == 42); 


### PR DESCRIPTION
## Summary (#154054)

This PR adds a regression test to ensure that combining lambda capture by copy of `*this` with explicit `this` parameters doesn't crash the compiler.

## Background

This test case addresses a crash that occurs in some clang distributions (notably Apple clang 17.0.0) when compiling valid C++23 code that combines:
- Lambda capture by copy of `*this` (`[*this]`)  
- Explicit `this` parameter (`this auto`)

## Minimal Reproduction

```cpp
struct S {
  int x;
  auto byval() {
    return [*this](this auto) { return this->x; };
  }
};
```

This code is valid C++23 but crashes Apple clang 17.0.0 with "Trace/BPT trap: 5".

## Test Coverage

The test verifies multiple variations:
- Basic `[*this](this auto)` syntax compiles
- Variations with different parameter types (`this auto&&`)
- Using captured members with and without explicit `this->`
- Complex cases with multiple members and parameters  
- Nested lambda scenarios
- Constexpr usage to verify semantic correctness

## Impact

- ✅ Ensures this valid C++23 pattern continues to work in LLVM clang
- ✅ Provides regression protection against similar crashes
- ✅ No functional changes to the compiler itself
- ✅ Test passes with current LLVM main branch

The syntax is already supported correctly in LLVM mainline, so this is purely a regression test to prevent future issues.