### PR TITLE
[SPIRV] Added tests for extensions and marked XFAIL

### DIFF
--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_io_pipes/PipeStorageIOINTEL.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_io_pipes/PipeStorageIOINTEL.ll
@@ -1,0 +1,32 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_io_pipes %s -o - | FileCheck %s
+; XFAIL: *
+
+; CHECK: OpCapability PipeStorage
+; CHECK: OpCapability IOPipeINTEL
+; CHECK: OpExtension "SPV_INTEL_io_pipes"
+
+; CHECK: OpName %[[#MYPIPE_ID:]] "mygpipe"
+; CHECK: OpDecorate %[[#MYPIPE_ID]] IOPipeStorageINTEL 1
+
+; CHECK: %[[#PIPE_STORAGE_ID:]] = OpTypePipeStorage
+; TODO: struct should have TypePipeStorage, not TypePointer
+; CHECK: %[[#CL_PIPE_STORAGE_ID:]] = OpTypeStruct
+; CHECK: %[[#CL_PIPE_STORAGE_PTR_ID:]] = OpTypePointer CrossWorkgroup %[[#CL_PIPE_STORAGE_ID]]
+
+; CHECK: %[[#CPS_ID:]] = OpConstantPipeStorage %[[#PIPE_STORAGE_ID]] 16 16 1
+; CHECK: %[[#COMPOSITE_ID:]] = OpConstantComposite  %[[#CL_PIPE_STORAGE_ID]] %[[#CPS_ID]]
+; CHECK:  %[[#MYPIPE_ID]] = OpVariable %[[#CL_PIPE_STORAGE_PTR_ID]] CrossWorkgroup %[[#COMPOSITE_ID]]
+
+%spirv.ConstantPipeStorage = type { i32, i32, i32 }
+%"class.cl::pipe_storage<int __attribute__((ext_vector_type(4))), 1>" = type { ptr addrspace(1) }
+%spirv.PipeStorage = type opaque
+
+@_ZN2cl9__details29OpConstantPipeStorage_CreatorILi16ELi16ELi1EE5valueE = linkonce_odr addrspace(1) global %spirv.ConstantPipeStorage { i32 16, i32 16, i32 1 }, align 4
+@mygpipe = addrspace(1) global %"class.cl::pipe_storage<int __attribute__((ext_vector_type(4))), 1>" { ptr addrspace(1) @_ZN2cl9__details29OpConstantPipeStorage_CreatorILi16ELi16ELi1EE5valueE }, align 4, !io_pipe_id !0
+
+define spir_kernel void @worker() {
+entry:
+  ret void
+}
+
+!0 = !{i32 1}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/intel_fpga_function_attributes.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/intel_fpga_function_attributes.ll
@@ -1,0 +1,95 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_kernel_attributes,+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse,+SPV_INTEL_fpga_invocation_pipelining_attributes %s -o - | FileCheck %s
+; XFAIL: *
+
+; CHECK: OpCapability FPGAKernelAttributesINTEL
+; CHECK: OpCapability FPGAClusterAttributesINTEL
+; CHECK: OpCapability LoopFuseINTEL
+; CHECK: OpCapability FPGAInvocationPipeliningAttributesINTEL
+; CHECK: OpExtension "SPV_INTEL_fpga_cluster_attributes"
+; CHECK: OpExtension "SPV_INTEL_fpga_invocation_pipelining_attributes"
+; CHECK: OpExtension "SPV_INTEL_loop_fuse"
+; CHECK: OpEntryPoint Kernel %[[#FUNCENTRY2:]] "_ZTSZ3barvE11kernel_name3"
+; CHECK: OpExecutionMode %[[#FUNCENTRY:]] MaxWorkgroupSizeINTEL 1 1 1
+; CHECK: OpExecutionMode %[[#FUNCENTRY]] MaxWorkDimINTEL 1
+; CHECK: OpExecutionMode %[[#FUNCENTRY]] NoGlobalOffsetINTEL
+; CHECK: OpExecutionMode %[[#FUNCENTRY]] NumSIMDWorkitemsINTEL 8
+; CHECK: OpExecutionMode %[[#FUNCENTRY]] SchedulerTargetFmaxMhzINTEL 1000
+; CHECK-DAG: OpDecorate %[[#FUNCENTRY]] StallEnableINTEL
+; CHECK-DAG: OpDecorate %[[#FUNCENTRY]] FuseLoopsInFunctionINTEL 3 1
+; CHECK-DAG: OpDecorate %[[#FUNCENTRY]] InitiationIntervalINTEL 10
+; CHECK-DAG: OpDecorate %[[#FUNCENTRY]] MaxConcurrencyINTEL 12
+; CHECK-DAG: OpDecorate %[[#FUNCENTRY]] PipelineEnableINTEL 0
+; CHECK: OpDecorate %[[#FUNCENTRY2]] PipelineEnableINTEL 1
+; CHECK: %[[#FUNCENTRY]] = OpFunction
+; CHECK: %[[#FUNCENTRY2]] = OpFunction
+
+%class._ZTS3Foo.Foo = type { i8 }
+%"class._ZTSZ3barvE3$_0.anon" = type { i8 }
+
+$_ZN3FooclEv = comdat any
+
+define spir_kernel void @_ZTSZ3barvE11kernel_name() !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 !num_simd_work_items !5 !max_work_group_size !6 !max_global_work_dim !7 !no_global_work_offset !4 !stall_enable !7 !scheduler_target_fmax_mhz !12 !loop_fuse !13 !initiation_interval !14 !max_concurrency !15 !pipeline_kernel !16 {
+entry:
+  %Foo = alloca %class._ZTS3Foo.Foo, align 1
+  call void @llvm.lifetime.start.p0(i64 1, ptr %Foo) #4
+  %0 = addrspacecast ptr %Foo to ptr addrspace(4)
+  call spir_func void @_ZN3FooclEv(ptr addrspace(4) %0)
+  call void @llvm.lifetime.end.p0(i64 1, ptr %Foo) #4
+  ret void
+}
+
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none))
+
+define linkonce_odr spir_func void @_ZN3FooclEv(ptr addrspace(4) %this) comdat align 2 {
+entry:
+  %this.addr = alloca ptr addrspace(4), align 8
+  store ptr addrspace(4) %this, ptr %this.addr, align 8, !tbaa !8
+  %this1 = load ptr addrspace(4), ptr %this.addr, align 8
+  ret void
+}
+
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr captures(none))
+define spir_kernel void @_ZTSZ3barvE12kernel_name2() !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
+entry:
+  %0 = alloca %"class._ZTSZ3barvE3$_0.anon", align 1
+  call void @llvm.lifetime.start.p0(i64 1, ptr %0)
+  %1 = addrspacecast ptr %0 to ptr addrspace(4)
+  call spir_func void @"_ZZ3barvENK3$_0clEv"(ptr addrspace(4) %1)
+  call void @llvm.lifetime.end.p0(i64 1, ptr %0)
+  ret void
+}
+define internal spir_func void @"_ZZ3barvENK3$_0clEv"(ptr addrspace(4) %this) align 2 {
+entry:
+  %this.addr = alloca ptr addrspace(4), align 8
+  store ptr addrspace(4) %this, ptr %this.addr, align 8, !tbaa !8
+  %this1 = load ptr addrspace(4), ptr %this.addr, align 8
+  ret void
+}
+
+define spir_kernel void @_ZTSZ3barvE11kernel_name3() !pipeline_kernel !7 {
+entry:
+  %Foo = alloca %class._ZTS3Foo.Foo, align 1
+  call void @llvm.lifetime.start.p0(i64 1, ptr %Foo)
+  %0 = addrspacecast ptr %Foo to ptr addrspace(4)
+  call spir_func void @_ZN3FooclEv(ptr addrspace(4) %0)
+  call void @llvm.lifetime.end.p0(i64 1, ptr %Foo)
+  ret void
+}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 4, i32 100000}
+!3 = !{!"clang version 11.0.0"}
+!4 = !{}
+!5 = !{i32 8}
+!6 = !{i32 1, i32 1, i32 1}
+!7 = !{i32 1}
+!8 = !{!9, !9, i64 0}
+!9 = !{!"any pointer", !10, i64 0}
+!10 = !{!"omnipotent char", !11, i64 0}
+!11 = !{!"Simple C++ TBAA"}
+!12 = !{i32 1000}
+!13 = !{i32 3, i32 1}
+!14 = !{i32 10}
+!15 = !{i32 12}
+!16 = !{i32 0}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/max_work_group_size.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/max_work_group_size.ll
@@ -1,0 +1,30 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_kernel_attributes %s -o - | FileCheck %s
+; XFAIL: *
+
+; CHECK: OpCapability FPGAKernelAttributesINTEL
+; CHECK: OpExtension "SPV_INTEL_kernel_attributes"
+; CHECK: OpEntryPoint Kernel %[[DIM1:]] "Dim1"
+; CHECK: OpEntryPoint Kernel %[[DIM2:]] "Dim2"
+; CHECK: OpEntryPoint Kernel %[[DIM3:]] "Dim3"
+; CHECK: OpExecutionMode %[[DIM1]] MaxWorkgroupSizeINTEL 4 1 1
+; CHECK: OpExecutionMode %[[DIM2]] MaxWorkgroupSizeINTEL 8 4 1
+; CHECK: OpExecutionMode %[[DIM3]] MaxWorkgroupSizeINTEL 16 8 4
+; CHECK: %[[DIM1]] = OpFunction
+; CHECK: %[[DIM2]] = OpFunction
+; CHECK: %[[DIM3]] = OpFunction
+
+define spir_kernel void @Dim1() !max_work_group_size !0 {
+  ret void
+}
+
+define spir_kernel void @Dim2() !max_work_group_size !1 {
+  ret void
+}
+
+define spir_kernel void @Dim3() !max_work_group_size !2 {
+  ret void
+}
+
+!0 = !{i32 4}
+!1 = !{i32 8, i32 4}
+!2 = !{i32 16, i32 8, i32 4}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/register_map_interface_attribute.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/register_map_interface_attribute.ll
@@ -1,0 +1,28 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_kernel_attributes %s -o - | FileCheck %s
+; XFAIL: *
+
+; FPGAKernelAttributesv2INTEL implicitly defines FPGAKernelAttributesINTEL
+; CHECK: OpCapability FPGAKernelAttributesINTEL
+; CHECK: OpCapability FPGAKernelAttributesv2INTEL
+; CHECK: OpExtension "SPV_INTEL_kernel_attributes"
+; CHECK: OpEntryPoint Kernel %[[KERNEL1:]] "test_1"
+; CHECK: OpEntryPoint Kernel %[[KERNEL2:]] "test_2"
+; CHECK: OpExecutionMode %[[KERNEL1]] RegisterMapInterfaceINTEL 0
+; CHECK: OpExecutionMode %[[KERNEL2]] RegisterMapInterfaceINTEL 1
+; CHECK: %[[KERNEL1]] = OpFunction
+; CHECK: %[[KERNEL2]] = OpFunction
+
+define spir_kernel void @test_1() !ip_interface !0
+{
+entry:
+  ret void
+}
+
+define spir_kernel void @test_2() !ip_interface !1
+{
+entry:
+  ret void
+}
+
+!0 = !{!"csr"}
+!1 = !{!"csr", !"wait_for_done_write"}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/streaming_interface_attribute.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_kernel_attributes/streaming_interface_attribute.ll
@@ -1,0 +1,26 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_kernel_attributes %s -o - | FileCheck %s
+; XFAIL: *
+
+; CHECK: OpCapability FPGAKernelAttributesINTEL
+; CHECK: OpExtension "SPV_INTEL_kernel_attributes"
+; CHECK: OpEntryPoint Kernel %[[KERNEL1:]] "test_1"
+; CHECK: OpEntryPoint Kernel %[[KERNEL2:]] "test_2"
+; CHECK: OpExecutionMode %[[KERNEL1]] StreamingInterfaceINTEL 0
+; CHECK: OpExecutionMode %[[KERNEL2]] StreamingInterfaceINTEL 1
+; CHECK: %[[KERNEL1]] = OpFunction
+; CHECK: %[[KERNEL2]] = OpFunction
+
+define spir_kernel void @test_1() !ip_interface !0
+{
+entry:
+  ret void
+}
+
+define spir_kernel void @test_2() !ip_interface !1
+{
+entry:
+  ret void
+}
+
+!0 = !{!"streaming"}
+!1 = !{!"streaming", !"stall_free_return"}

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_masked_gather_scatter/intel-basic-vector-pointers-opaque.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_masked_gather_scatter/intel-basic-vector-pointers-opaque.ll
@@ -1,0 +1,42 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_masked_gather_scatter %s -o - | FileCheck %s
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-ERROR
+; XFAIL: *
+
+; CHECK-ERROR: RequiresExtension: Feature requires the following SPIR-V extension:
+; CHECK-ERROR-NEXT: SPV_INTEL_masked_gather_scatter
+
+; CHECK-DAG: OpCapability MaskedGatherScatterINTEL
+; CHECK-DAG: OpExtension "SPV_INTEL_masked_gather_scatter"
+
+; CHECK-DAG: %[[#TYPEINT1:]] = OpTypeInt 8 0
+; CHECK-DAG: %[[#TYPEINT2:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#TYPEPTR1:]] = OpTypePointer CrossWorkgroup %[[#TYPEINT1]]
+; CHECK-DAG: %[[#TYPEVEC1:]] = OpTypeVector %[[#TYPEPTR1]] 4
+; CHECK-DAG: %[[#TYPEVOID:]] = OpTypeVoid
+; CHECK-DAG: %[[#TYPEPTR2:]] = OpTypePointer Generic %[[#TYPEINT1]]
+; CHECK-DAG: %[[#TYPEVEC2:]] = OpTypeVector %[[#TYPEPTR2]] 4
+; CHECK-DAG: %[[#PTRTOVECTYPE:]] = OpTypePointer Function %[[#TYPEVEC2]]
+; CHECK-DAG: %[[#TYPEPTR4:]] = OpTypePointer CrossWorkgroup %[[#TYPEINT2]]
+; CHECK-DAG: %[[#TYPEVEC3:]] = OpTypeVector %[[#TYPEPTR4]] 4
+
+; CHECK: OpVariable %[[#PTRTOVECTYPE]]
+; CHECK: OpVariable %[[#PTRTOVECTYPE]]
+; CHECK: OpLoad %[[#TYPEVEC2]]
+; CHECK: OpStore
+; CHECK: OpGenericCastToPtr %[[#TYPEVEC1]]
+; CHECK: OpFunctionCall %[[#TYPEVEC3]]
+; CHECK: OpInBoundsPtrAccessChain %[[#TYPEVEC3]]
+
+define spir_kernel void @foo() {
+entry:
+  %arg1 = alloca <4 x ptr addrspace(4)>
+  %arg2 = alloca <4 x ptr addrspace(4)>
+  %0 = load <4 x ptr addrspace(4)>, ptr %arg1
+  store <4 x ptr addrspace(4)> %0, ptr %arg2
+  %tmp1 = addrspacecast <4 x ptr addrspace(4)> %0 to  <4 x ptr addrspace(1)>
+  %tmp2 = call <4 x ptr addrspace(1)> @boo(<4 x ptr addrspace(1)> %tmp1)
+  %tmp3 = getelementptr inbounds i32, <4 x ptr addrspace(1)> %tmp2, i32 1
+  ret void
+}
+
+declare <4 x ptr addrspace(1)> @boo(<4 x ptr addrspace(1)> %a)

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
@@ -1,0 +1,41 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_masked_gather_scatter %s -o - | FileCheck %s
+; XFAIL: *
+
+; CHECK-NOT: Name %[[#]] "llvm.masked.gather.v4i32.v4p4"
+; CHECK-NOT: Name %[[#]] "llvm.masked.scatter.v4i32.v4p4"
+
+; CHECK-DAG: OpCapability MaskedGatherScatterINTEL
+; CHECK-DAG: OpExtension "SPV_INTEL_masked_gather_scatter"
+
+; CHECK-DAG: %[[#TYPEINT:]] = OpTypeInt 32 0
+; CHECK-DAG: %[[#TYPEPTRINT:]] = OpTypePointer Generic %[[#TYPEINT]]
+; CHECK-DAG: %[[#TYPEVECPTR:]] = OpTypeVector %[[#TYPEPTRINT]] 4
+; CHECK-DAG: %[[#TYPEVECINT:]] = OpTypeVector %[[#TYPEINT]] 4
+
+; CHECK-DAG: %[[#CONST4:]] = OpConstant %[[#TYPEINT]]  4
+; CHECK-DAG: %[[#CONST0:]] = OpConstant %[[#TYPEINT]]  0
+; CHECK-DAG: %[[#CONST1:]] = OpConstant %[[#TYPEINT]]  1
+; CHECK-DAG: %[[#TRUE:]] = OpConstantTrue %[[#]] 
+; CHECK-DAG: %[[#FALSE:]] = OpConstantFalse %[[#]] 
+; CHECK-DAG: %[[#MASK1:]] = OpConstantComposite %[[#]] %[[#TRUE]] %[[#FALSE]] %[[#TRUE]] %[[#TRUE]]
+; CHECK-DAG: %[[#FILL:]] = OpConstantComposite %[[#]] %[[#CONST4]] %[[#CONST0]] %[[#CONST1]] %[[#CONST0]]
+; CHECK-DAG: %[[#MASK2:]] = OpConstantComposite %[[#]] %[[#TRUE]] %[[#TRUE]] %[[#TRUE]] %[[#TRUE]]
+
+; CHECK: %[[#VECGATHER:]] = OpLoad %[[#TYPEVECPTR]] 
+; CHECK: %[[#VECSCATTER:]] = OpLoad %[[#TYPEVECPTR]] 
+; CHECK: %[[#GATHER:]] = OpMaskedGatherINTEL %[[#TYPEVECINT]] %[[#VECGATHER]] 4 %[[#MASK1]] %[[#FILL]]
+; CHECK: OpMaskedScatterINTEL %[[#GATHER]] %[[#VECSCATTER]] 4 %[[#MASK2]]
+
+define spir_kernel void @foo() {
+entry:
+  %arg0 = alloca <4 x ptr addrspace(4)>
+  %arg1 = alloca <4 x ptr addrspace(4)>
+  %0 = load <4 x ptr addrspace(4)>, ptr %arg0
+  %1 = load <4 x ptr addrspace(4)>, ptr %arg1
+  %res = call <4 x i32> @llvm.masked.gather.v4i32.v4p4(<4 x ptr addrspace(4)> %0, i32 4, <4 x i1> <i1 true, i1 false, i1 true, i1 true>, <4 x i32> <i32 4, i32 0, i32 1, i32 0>)
+  call void @llvm.masked.scatter.v4i32.v4p4(<4 x i32> %res, <4 x ptr addrspace(4)> %1, i32 4, <4 x i1> splat (i1 true))
+  ret void
+}
+
+declare <4 x i32> @llvm.masked.gather.v4i32.v4p4(<4 x ptr addrspace(4)>, i32, <4 x i1>, <4 x i32>)
+declare void @llvm.masked.scatter.v4i32.v4p4(<4 x i32>, <4 x ptr addrspace(4)>, i32, <4 x i1>)

--- a/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_runtime_aligned/RuntimeAligned.ll
+++ b/llvm/test/CodeGen/SPIRV/extensions/SPV_INTEL_runtime_aligned/RuntimeAligned.ll
@@ -1,0 +1,39 @@
+; RUN: llc -verify-machineinstrs -O0 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_runtime_aligned %s -o - | FileCheck %s
+; XFAIL: *
+
+; CHECK: OpCapability RuntimeAlignedAttributeINTEL
+; CHECK: OpExtension "SPV_INTEL_runtime_aligned"
+; CHECK: OpName %[[#ARGA:]] "a"
+; CHECK: OpName %[[#ARGB:]] "b"
+; CHECK: OpName %[[#ARGC:]] "c"
+; CHECK: OpName %[[#ARGD:]] "d"
+; CHECK: OpName %[[#ARGE:]] "e"
+; CHECK: OpDecorate %[[#ARGA]] FuncParamAttr RuntimeAlignedINTEL
+; CHECK-NOT: OpDecorate %[[#ARGB]] FuncParamAttr RuntimeAlignedINTEL
+; CHECK: OpDecorate %[[#ARGC]] FuncParamAttr RuntimeAlignedINTEL
+; CHECK-NOT: OpDecorate %[[#ARGD]] FuncParamAttr RuntimeAlignedINTEL
+; CHECK-NOT: OpDecorate %[[#ARGE]] FuncParamAttr RuntimeAlignedINTEL
+
+; CHECK: OpFunction
+; CHECK: %[[#ARGA]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#ARGB]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#ARGC]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#ARGD]] = OpFunctionParameter %[[#]]
+; CHECK: %[[#ARGE]] = OpFunctionParameter %[[#]]
+
+define spir_kernel void @test(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %c, i32 %d, i32 %e) !kernel_arg_addr_space !5 !kernel_arg_access_qual !6 !kernel_arg_type !7 !kernel_arg_type_qual !8 !kernel_arg_base_type !9 !kernel_arg_runtime_aligned !10 {
+entry:
+  ret void
+}
+
+!0 = !{i32 2, i32 2}
+!1 = !{i32 0, i32 0}
+!2 = !{i32 1, i32 2}
+!3 = !{}
+!4 = !{i16 6, i16 14}
+!5 = !{i32 1, i32 1, i32 1, i32 0, i32 0}
+!6 = !{!"none", !"none", !"none", !"none", !"none"}
+!7 = !{!"int*", !"float*", !"int*"}
+!8 = !{!"", !"", !"", !"", !""}
+!9 = !{!"int*", !"float*", !"int*", !"int", !"int"}
+!10 = !{i1 true, i1 false, i1 true, i1 false, i1 false}


### PR DESCRIPTION
Added tests for the following extensions and marked it as XFAIL:
- SPV_INTEL_masked_gather_scatter
- SPV_INTEL_io_pipes
- SPV_INTEL_kernel_attributes
- SPV_INTEL_runtime_aligned