### PR TITLE
[CIR] Handle FunctionToPointerDecay casts (#153657)

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenExprScalar.cpp
@@ -1905,6 +1905,8 @@ mlir::Value ScalarExprEmitter::VisitCastExpr(CastExpr *ce) {
         cgf.getLoc(subExpr->getSourceRange()), cgf.convertType(destTy),
         Visit(subExpr));
   }
+  case CK_FunctionToPointerDecay:
+    return cgf.emitLValue(subExpr).getPointer();
 
   default:
     cgf.getCIRGenModule().errorNYI(subExpr->getSourceRange(),

--- a/clang/test/CIR/CodeGen/function-to-pointer-decay.c
+++ b/clang/test/CIR/CodeGen/function-to-pointer-decay.c
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s -check-prefix=CIR
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -fclangir -emit-llvm %s -o %t-cir.ll
+// RUN: FileCheck --input-file=%t-cir.ll %s -check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -Wno-unused-value -emit-llvm %s -o %t.ll
+// RUN: FileCheck --input-file=%t.ll %s -check-prefix=OGCG
+
+void f(void);
+
+void f1() {
+  (void (*)())f;
+}
+
+void f2() {
+  (*(void (*)(void))f)();
+}
+
+void test_lvalue_cast() {
+  (*(void (*)(int))f)(42);
+}
+
+// CIR-LABEL:   cir.func{{.*}} @f()
+// CIR:         cir.func{{.*}} @f1()
+// CIR:         cir.return{{.*}}
+
+// CIR-LABEL:   cir.func{{.*}} @f2()
+// CIR:         cir.call @f() : () -> ()
+
+// CIR-LABEL:   cir.func{{.*}} @test_lvalue_cast()
+// CIR:         %[[S0:.+]] = {{.*}}@f : !cir.ptr<!cir.func<()>>{{.*}}
+// CIR:         %[[S1:.+]] = cir.cast{{.*}}%[[S0]] : !cir.ptr<!cir.func<()>>{{.*}}
+// CIR:         %[[S2:.+]] = cir.const #cir.int<42> : !s32i
+// CIR:         cir.call %[[S1]](%[[S2]]) : (!cir.ptr<!cir.func<(!s32i)>>, !s32i) -> ()
+
+// LLVM-LABEL:  define{{.*}} void @f1()
+// LLVM:        ret void
+// LLVM:        define{{.*}} void @f2()
+// LLVM:        call void @f()
+// LLVM:        define{{.*}} void @test_lvalue_cast()
+// LLVM:        call void @f(i32 42)
+
+// OGCG-LABEL:  define{{.*}} void @f1()
+// OGCG:        ret void
+// OGCG:        define{{.*}} void @f2()
+// OGCG:        call void @f()
+// OGCG:        define{{.*}} void @test_lvalue_cast()
+// OGCG:        call void @f(i32 noundef 42)


### PR DESCRIPTION
Add upstream support for handling implicit FunctionToPointerDecay casts in ClangIR, for task #153657, migrate code from clangir repo

Passes `check-clang` test target, have run `git-clang-format` from repo as instructed

Appreciate any feedback, my first LLVM PR so any pointers/improvements/where I'm wrong/conventions I should be aware of etc. please let me know, thanks

Notes:
- Omitted `clang::CIRGen::TBAAAccessInfo` from `emitPointerWithAlignment` as it looks like a large task to include that and not necessary
- Omitted `KnownNonNull_t` param too, although this is much smaller but would have to alter all sites where it's currently used in clangir, in llvm
- Copied `emitFunctionDeclLValue` from clangir
- Have just used the simple example test given in the task + the existing `function-to-pointer-decay.c` test, maybe the CHECKs can be improved or more test cases are needed (if so please specify what, am a CIR noob)
- Left `llvm_unreachable("NYI");` as those rather than a longer string, other instances in file have the same