### PR TITLE
[RISCV] Rename MIPS_PREFETCH->MIPS_PREF. NFC

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXMips.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXMips.td
@@ -129,20 +129,20 @@ class Mips_prefetch_ri<dag outs, dag ins, string opcodestr, string argstr>
 // MIPS extensions
 //===----------------------------------------------------------------------===//
 let Predicates = [HasVendorXMIPSCBOP] ,DecoderNamespace = "Xmipscbop" in {
-  def MIPS_PREFETCH : Mips_prefetch_ri<(outs), (ins GPR:$rs1, uimm9:$imm9, uimm5:$hint),
-                                        "mips.pref", "$hint, ${imm9}(${rs1})">,
-                       Sched<[]>;
+  def MIPS_PREF : Mips_prefetch_ri<(outs), (ins GPR:$rs1, uimm9:$imm9, uimm5:$hint),
+                                    "mips.pref", "$hint, ${imm9}(${rs1})">,
+                   Sched<[]>;
 }
 
 let Predicates = [HasVendorXMIPSCBOP] in {
   // Prefetch Data Write.
   def : Pat<(prefetch (AddrRegImm9  (XLenVT GPR:$rs1), uimm9:$imm9),
              (i32 1), timm, (i32 1)),
-            (MIPS_PREFETCH GPR:$rs1, uimm9:$imm9, 9)>;
+            (MIPS_PREF GPR:$rs1, uimm9:$imm9, 9)>;
   // Prefetch Data Read.
   def : Pat<(prefetch (AddrRegImm9 (XLenVT GPR:$rs1), uimm9:$imm9),
              (i32 0), timm, (i32 1)),
-            (MIPS_PREFETCH GPR:$rs1, uimm9:$imm9, 8)>;
+            (MIPS_PREF GPR:$rs1, uimm9:$imm9, 8)>;
 }
 
 let Predicates = [HasVendorXMIPSCMov], hasSideEffects = 0, mayLoad = 0, mayStore = 0,

--- a/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVRegisterInfo.cpp
@@ -589,7 +589,7 @@ bool RISCVRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
                (Lo12 & 0b11111) != 0) {
       // Prefetch instructions require the offset to be 32 byte aligned.
       MI.getOperand(FIOperandNum + 1).ChangeToImmediate(0);
-    } else if (Opc == RISCV::MIPS_PREFETCH && !isUInt<9>(Val)) {
+    } else if (Opc == RISCV::MIPS_PREF && !isUInt<9>(Val)) {
       // MIPS Prefetch instructions require the offset to be 9 bits encoded.
       MI.getOperand(FIOperandNum + 1).ChangeToImmediate(0);
     } else if ((Opc == RISCV::PseudoRV32ZdinxLD ||


### PR DESCRIPTION
This matches the instruction's assembler mnemonic.