### PR TITLE
[hwasan] Fix suppression of leaks from dlsym

### DIFF
--- a/compiler-rt/lib/hwasan/hwasan_allocation_functions.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_allocation_functions.cpp
@@ -14,6 +14,7 @@
 
 #include "hwasan.h"
 #include "interception/interception.h"
+#include "lsan/lsan_common.h"
 #include "sanitizer_common/sanitizer_allocator_dlsym.h"
 #include "sanitizer_common/sanitizer_allocator_interface.h"
 #include "sanitizer_common/sanitizer_mallinfo.h"


### PR DESCRIPTION
Header "lsan/lsan_common.h" is not included, CAN_SANITIZE_LEAKS macro is expanded to 0, so suppression of leaks from dlsym doesn't take effect.