### PR TITLE
[RISC-V] Add P-ext MC Support for More Pair Operations

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -98,6 +98,24 @@ class PLUI_i<bits<7> funct7, string opcodestr>
   let Inst{23-15} = imm10{9-1};
 }
 
+// Common base for widening binary ops
+class RVPWideningBase<bits<2> w, bit arith_shift, string opcodestr>
+  : RVInst<(outs GPRPairRV32:$rd), (ins GPR:$rs1, GPR:$rs2), opcodestr,
+           "$rd, $rs1, $rs2", [], InstFormatOther> {
+  bits<5> rs2;
+  bits<5> rs1;
+  bits<5> rd;
+
+  let Inst{31}    = 0b0;
+  let Inst{26-25} = w;
+  let Inst{24-20} = rs2;
+  let Inst{19-15} = rs1;
+  let Inst{14-12} = 0b010;
+  let Inst{11-8}  = rd{4-1};
+  let Inst{7}     = arith_shift;
+  let Inst{6-0}   = OPC_OP_32.Value;
+}
+
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPShift_ri<bits<3> f, bits<3> funct3, string opcodestr, Operand ImmType>
     : RVInstIBase<funct3, OPC_OP_IMM_32, (outs GPR:$rd),
@@ -140,9 +158,10 @@ class RVPShiftB_ri<bits<3> f, bits<3> funct3, string opcodestr>
   let Inst{22-20} = shamt;
 }
 
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPWideningShift_ri<bits<3> f, string opcodestr, Operand ImmType>
     : RVInst<(outs GPRPairRV32:$rd), (ins GPR:$rs1, ImmType:$shamt), opcodestr,
-                  "$rd, $rs1, $shamt"> {
+                  "$rd, $rs1, $shamt", [], InstFormatOther> {
   bits<5> rs1;
   bits<5> rd;
 
@@ -185,6 +204,13 @@ class RVPWideningShiftB_ri<bits<3> f, string opcodestr>
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPWideningShift_rr<bits<3> f, bits<2> w, string opcodestr>
+    : RVPWideningBase<w, 0b0, opcodestr> {
+  let Inst{30-28} = f;
+  let Inst{27} = 0b1;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPUnary_ri<bits<2> w, bits<5> uf, string opcodestr>
     : RVInstIBase<0b010, OPC_OP_IMM_32, (outs GPR:$rd), (ins GPR:$rs1),
                   opcodestr, "$rd, $rs1">  {
@@ -210,6 +236,12 @@ class RVPBinary_rr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
   let Inst{31} = 0b1;
   let Inst{30-27} = f;
   let Inst{26-25} = w;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPWideningBinary_rr<bits<4> f, bits<2> w, string opcodestr>
+    : RVPWideningBase<w, 0b1, opcodestr> {
+  let Inst{30-27} = f;
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
@@ -935,11 +967,92 @@ let Predicates = [HasStdExtP, IsRV32] in {
 }
 
 let Predicates = [HasStdExtP, IsRV32] in {
-  def PWSLLI_B : RVPWideningShiftB_ri<0b000, "pwslli.b">;
-  def PWSLLI_H : RVPWideningShiftH_ri<0b000, "pwslli.h">;
-  def WSLLI    : RVPWideningShiftW_ri<0b000, "wslli">;
+  def PWSLLI_B     : RVPWideningShiftB_ri<0b000, "pwslli.b">;
+  def PWSLLI_H     : RVPWideningShiftH_ri<0b000, "pwslli.h">;
+  def WSLLI        : RVPWideningShiftW_ri<0b000, "wslli">;
 
-  def PWSLAI_B : RVPWideningShiftB_ri<0b100, "pwslai.b">;
-  def PWSLAI_H : RVPWideningShiftH_ri<0b100, "pwslai.h">;
-  def WSLAI    : RVPWideningShiftW_ri<0b100, "wslai">;
+  def PWSLAI_B     : RVPWideningShiftB_ri<0b100, "pwslai.b">;
+  def PWSLAI_H     : RVPWideningShiftH_ri<0b100, "pwslai.h">;
+  def WSLAI        : RVPWideningShiftW_ri<0b100, "wslai">;
+
+  def PWSLL_BS     : RVPWideningShift_rr<0b000, 0b00, "pwsll.bs">;
+  def PWSLL_HS     : RVPWideningShift_rr<0b000, 0b01, "pwsll.hs">;
+  def WSLL         : RVPWideningShift_rr<0b000, 0b11, "wsll">;
+
+  def PWSLA_BS     : RVPWideningShift_rr<0b100, 0b00, "pwsla.bs">;
+  def PWSLA_HS     : RVPWideningShift_rr<0b100, 0b01, "pwsla.hs">;
+  def WSLA         : RVPWideningShift_rr<0b100, 0b11, "wsla">;
+
+  def WZIP8P       : RVPWideningShift_rr<0b111, 0b00, "wzip8p">;
+  def WZIP16P      : RVPWideningShift_rr<0b111, 0b01, "wzip16p">;
+
+  def PWADD_H      : RVPWideningBinary_rr<0b0000, 0b00, "pwadd.h">;
+  def WADD         : RVPWideningBinary_rr<0b0000, 0b01, "wadd">;
+  def PWADD_B      : RVPWideningBinary_rr<0b0000, 0b10, "pwadd.b">;
+  def PW2WADD_H    : RVPWideningBinary_rr<0b0000, 0b11, "pw2wadd.h">;
+
+  def PWADDA_H     : RVPWideningBinary_rr<0b0001, 0b00, "pwadda.h">;
+  def WADDA        : RVPWideningBinary_rr<0b0001, 0b01, "wadda">;
+  def PWADDA_B     : RVPWideningBinary_rr<0b0001, 0b10, "pwadda.b">;
+  def PW2WADDA_H   : RVPWideningBinary_rr<0b0001, 0b11, "pw2wadda.h">;
+
+  def PWADDU_H     : RVPWideningBinary_rr<0b0010, 0b00, "pwaddu.h">;
+  def WADDU        : RVPWideningBinary_rr<0b0010, 0b01, "waddu">;
+  def PWADDU_B     : RVPWideningBinary_rr<0b0010, 0b10, "pwaddu.b">;
+  def PW2WADD_HX   : RVPWideningBinary_rr<0b0010, 0b11, "pw2wadd.hx">;
+
+  def PWADDAU_H    : RVPWideningBinary_rr<0b0011, 0b00, "pwaddau.h">;
+  def WADDAU       : RVPWideningBinary_rr<0b0011, 0b01, "waddau">;
+  def PWADDAU_B    : RVPWideningBinary_rr<0b0011, 0b10, "pwaddau.b">;
+  def PW2WADDA_HX  : RVPWideningBinary_rr<0b0011, 0b11, "pw2wadda.hx">;
+
+  def PWMUL_H      : RVPWideningBinary_rr<0b0100, 0b00, "pwmul.h">;
+  def WMUL         : RVPWideningBinary_rr<0b0100, 0b01, "wmul">;
+  def PWMUL_B      : RVPWideningBinary_rr<0b0100, 0b10, "pwmul.b">;
+  def PW2WADDU_H   : RVPWideningBinary_rr<0b0100, 0b11, "pw2waddu.h">;
+
+  def PWMACC_H     : RVPWideningBinary_rr<0b0101, 0b00, "pwmacc.h">;
+  def WMACC        : RVPWideningBinary_rr<0b0101, 0b01, "wmacc">;
+  def PM2WADDAU_H  : RVPWideningBinary_rr<0b0101, 0b11, "pm2waddau.h">;
+
+  def PWMULU_H     : RVPWideningBinary_rr<0b0110, 0b00, "pwmulu.h">;
+  def WMULU        : RVPWideningBinary_rr<0b0110, 0b01, "wmulu">;
+  def PWMULU_B     : RVPWideningBinary_rr<0b0110, 0b10, "pwmulu.b">;
+
+  def PWMACCU_H    : RVPWideningBinary_rr<0b0111, 0b00, "pwmaccu.h">;
+  def WMACCU       : RVPWideningBinary_rr<0b0111, 0b01, "wmaccu">;
+
+  def PWSUB_H      : RVPWideningBinary_rr<0b1000, 0b00, "pwsub.h">;
+  def WSUB         : RVPWideningBinary_rr<0b1000, 0b01, "wsub">;
+  def PWSUB_B      : RVPWideningBinary_rr<0b1000, 0b10, "pwsub.b">;
+  def PW2WSUB_H    : RVPWideningBinary_rr<0b1000, 0b11, "pw2wsub.h">;
+
+  def PWSUBA_H     : RVPWideningBinary_rr<0b1001, 0b00, "pwsuba.h">;
+  def WSUBA        : RVPWideningBinary_rr<0b1001, 0b01, "wsuba">;
+  def PWSUBA_B     : RVPWideningBinary_rr<0b1001, 0b10, "pwsuba.b">;
+  def PW2WSUBA_H   : RVPWideningBinary_rr<0b1001, 0b11, "pw2wsuba.h">;
+
+  def PWSUBU_H     : RVPWideningBinary_rr<0b1010, 0b00, "pwsubu.h">;
+  def WSUBU        : RVPWideningBinary_rr<0b1010, 0b01, "wsubu">;
+  def PWSUBU_B     : RVPWideningBinary_rr<0b1010, 0b10, "pwsubu.b">;
+  def PW2WSUB_HX   : RVPWideningBinary_rr<0b1010, 0b11, "pw2wsub.hx">;
+
+  def PWSUBAU_H    : RVPWideningBinary_rr<0b1011, 0b00, "pwsubau.h">;
+  def WSUBAU       : RVPWideningBinary_rr<0b1011, 0b01, "wsubau">;
+  def PWSUBAU_B    : RVPWideningBinary_rr<0b1011, 0b10, "pwsubau.b">;
+  def PW2WSUBA_HX  : RVPWideningBinary_rr<0b1011, 0b11, "pw2wsuba.hx">;
+  
+  def PWMULSU_H    : RVPWideningBinary_rr<0b1100, 0b00, "pwmulsu.h">;
+  def WMULSU       : RVPWideningBinary_rr<0b1100, 0b01, "wmulsu">;
+  def PWMULSU_B    : RVPWideningBinary_rr<0b1100, 0b10, "pwmulsu.b">;
+  def PM2WADDSU_H  : RVPWideningBinary_rr<0b1100, 0b11, "pm2waddsu.h">;
+
+  def PWMACCSU_H   : RVPWideningBinary_rr<0b1101, 0b00, "pwmaccsu.h">;
+  def WMACCSU      : RVPWideningBinary_rr<0b1101, 0b01, "wmaccsu">;
+  def PM2WADDASU_H : RVPWideningBinary_rr<0b1101, 0b11, "pm2waddasu.h">;
+
+  def PMQWACC_H    : RVPWideningBinary_rr<0b1111, 0b00, "pmqwacc.h">;
+  def PMQWACC      : RVPWideningBinary_rr<0b1111, 0b01, "pmqwacc">;
+  def PMQRWACC_H   : RVPWideningBinary_rr<0b1111, 0b10, "pmqrwacc.h">;
+  def PMQRWACC     : RVPWideningBinary_rr<0b1111, 0b11, "pmqrwacc">;
 } // Predicates = [HasStdExtP, IsRV32]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -140,6 +140,48 @@ class RVPShiftB_ri<bits<3> f, bits<3> funct3, string opcodestr>
   let Inst{22-20} = shamt;
 }
 
+class RVPPairShift_ri<bits<3> f, string opcodestr, Operand ImmType>
+    : RVInst<(outs GPRPairRV32:$rd), (ins GPR:$rs1, ImmType:$shamt), opcodestr,
+                  "$rd, $rs1, $shamt"> {
+  bits<5> rd;
+
+  let Inst{31}    = 0b0;
+  let Inst{30-28} = f;
+  let Inst{27}    = 0b0;
+  let Inst{14-12} = 0b010;
+  let Inst{11-8}  = rd{4-1};
+  let Inst{7}     = 0b0;
+  let Inst{6-0}   = OPC_OP_IMM_32.Value;
+
+  let hasSideEffects = 0;
+  let mayLoad = 0;
+  let mayStore = 0;
+}
+
+class RVPPairShiftW_ri<bits<3> f, string opcodestr>
+    : RVPPairShift_ri<f, opcodestr, uimm6> {
+  bits<6> shamt;
+
+  let Inst{26} = 0b1;
+  let Inst{25-20} = shamt;
+}
+
+class RVPPairShiftH_ri<bits<3> f, string opcodestr>
+    : RVPPairShift_ri<f, opcodestr, uimm5> {
+  bits<5> shamt;
+
+  let Inst{26-25} = 0b01;
+  let Inst{24-20} = shamt;
+}
+
+class RVPPairShiftB_ri<bits<3> f, string opcodestr>
+    : RVPPairShift_ri<f, opcodestr, uimm4> {
+  bits<4> shamt;
+
+  let Inst{26-24} = 0b001;
+  let Inst{23-20} = shamt;
+}
+
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPUnary_ri<bits<2> w, bits<5> uf, string opcodestr>
     : RVInstIBase<0b010, OPC_OP_IMM_32, (outs GPR:$rd), (ins GPR:$rs1),
@@ -889,3 +931,13 @@ let Predicates = [HasStdExtP, IsRV32] in {
     let Inst{23-15} = imm10{9-1};
   }
 }
+
+let Predicates = [HasStdExtP, IsRV32] in {
+  def PWSLLI_B : RVPPairShiftB_ri<0b000, "pwslli.b">;
+  def PWSLLI_H : RVPPairShiftH_ri<0b000, "pwslli.h">;
+  def WSLLI    : RVPPairShiftW_ri<0b000, "wslli">;
+
+  def PWSLAI_B : RVPPairShiftB_ri<0b100, "pwslai.b">;
+  def PWSLAI_H : RVPPairShiftH_ri<0b100, "pwslai.h">;
+  def WSLAI    : RVPPairShiftW_ri<0b100, "wslai">;
+} // Predicates = [HasStdExtP, IsRV32]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -140,14 +140,16 @@ class RVPShiftB_ri<bits<3> f, bits<3> funct3, string opcodestr>
   let Inst{22-20} = shamt;
 }
 
-class RVPPairShift_ri<bits<3> f, string opcodestr, Operand ImmType>
+class RVPWideningShift_ri<bits<3> f, string opcodestr, Operand ImmType>
     : RVInst<(outs GPRPairRV32:$rd), (ins GPR:$rs1, ImmType:$shamt), opcodestr,
                   "$rd, $rs1, $shamt"> {
+  bits<5> rs1;
   bits<5> rd;
 
   let Inst{31}    = 0b0;
   let Inst{30-28} = f;
   let Inst{27}    = 0b0;
+  let Inst{19-15} = rs1;
   let Inst{14-12} = 0b010;
   let Inst{11-8}  = rd{4-1};
   let Inst{7}     = 0b0;
@@ -158,24 +160,24 @@ class RVPPairShift_ri<bits<3> f, string opcodestr, Operand ImmType>
   let mayStore = 0;
 }
 
-class RVPPairShiftW_ri<bits<3> f, string opcodestr>
-    : RVPPairShift_ri<f, opcodestr, uimm6> {
+class RVPWideningShiftW_ri<bits<3> f, string opcodestr>
+    : RVPWideningShift_ri<f, opcodestr, uimm6> {
   bits<6> shamt;
 
   let Inst{26} = 0b1;
   let Inst{25-20} = shamt;
 }
 
-class RVPPairShiftH_ri<bits<3> f, string opcodestr>
-    : RVPPairShift_ri<f, opcodestr, uimm5> {
+class RVPWideningShiftH_ri<bits<3> f, string opcodestr>
+    : RVPWideningShift_ri<f, opcodestr, uimm5> {
   bits<5> shamt;
 
   let Inst{26-25} = 0b01;
   let Inst{24-20} = shamt;
 }
 
-class RVPPairShiftB_ri<bits<3> f, string opcodestr>
-    : RVPPairShift_ri<f, opcodestr, uimm4> {
+class RVPWideningShiftB_ri<bits<3> f, string opcodestr>
+    : RVPWideningShift_ri<f, opcodestr, uimm4> {
   bits<4> shamt;
 
   let Inst{26-24} = 0b001;
@@ -933,11 +935,11 @@ let Predicates = [HasStdExtP, IsRV32] in {
 }
 
 let Predicates = [HasStdExtP, IsRV32] in {
-  def PWSLLI_B : RVPPairShiftB_ri<0b000, "pwslli.b">;
-  def PWSLLI_H : RVPPairShiftH_ri<0b000, "pwslli.h">;
-  def WSLLI    : RVPPairShiftW_ri<0b000, "wslli">;
+  def PWSLLI_B : RVPWideningShiftB_ri<0b000, "pwslli.b">;
+  def PWSLLI_H : RVPWideningShiftH_ri<0b000, "pwslli.h">;
+  def WSLLI    : RVPWideningShiftW_ri<0b000, "wslli">;
 
-  def PWSLAI_B : RVPPairShiftB_ri<0b100, "pwslai.b">;
-  def PWSLAI_H : RVPPairShiftH_ri<0b100, "pwslai.h">;
-  def WSLAI    : RVPPairShiftW_ri<0b100, "wslai">;
+  def PWSLAI_B : RVPWideningShiftB_ri<0b100, "pwslai.b">;
+  def PWSLAI_H : RVPWideningShiftH_ri<0b100, "pwslai.h">;
+  def WSLAI    : RVPWideningShiftW_ri<0b100, "wslai">;
 } // Predicates = [HasStdExtP, IsRV32]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -98,10 +98,10 @@ class PLUI_i<bits<7> funct7, string opcodestr>
   let Inst{23-15} = imm10{9-1};
 }
 
-// Common base for widening binary ops
-class RVPWideningBase<bits<2> w, bit arith_shift, string opcodestr>
-  : RVInst<(outs GPRPairRV32:$rd), (ins GPR:$rs1, GPR:$rs2), opcodestr,
-           "$rd, $rs1, $rs2", [], InstFormatOther> {
+// Common base for widening Binary/Ternary ops
+class RVPWideningBase<bits<2> w, bit arith_shift, dag outs, dag ins,
+                      string opcodestr>
+  : RVInst<outs, ins, opcodestr, "$rd, $rs1, $rs2", [], InstFormatOther> {
   bits<5> rs2;
   bits<5> rs1;
   bits<5> rd;
@@ -113,7 +113,23 @@ class RVPWideningBase<bits<2> w, bit arith_shift, string opcodestr>
   let Inst{14-12} = 0b010;
   let Inst{11-8}  = rd{4-1};
   let Inst{7}     = arith_shift;
-  let Inst{6-0}   = OPC_OP_32.Value;
+  let Inst{6-0}   = OPC_OP_IMM_32.Value;
+}
+
+// Common base for narrowing ops
+class RVPNarrowingBase<bits<3> f, bit r, bits<4> funct4, dag outs, dag ins,
+                      string opcodestr, string argstr>
+  : RVInst<outs, ins, opcodestr, argstr, [], InstFormatOther> {
+  bits<5> rs1;
+  bits<5> rd;
+
+  let Inst{31}    = 0b0;
+  let Inst{30-28} = f;
+  let Inst{27}    = r;
+  let Inst{19-16} = rs1{4-1};
+  let Inst{15-12} = funct4;
+  let Inst{11-7}  = rd;
+  let Inst{6-0}   = OPC_OP_IMM_32.Value;
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
@@ -161,7 +177,7 @@ class RVPShiftB_ri<bits<3> f, bits<3> funct3, string opcodestr>
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPWideningShift_ri<bits<3> f, string opcodestr, Operand ImmType>
     : RVInst<(outs GPRPairRV32:$rd), (ins GPR:$rs1, ImmType:$shamt), opcodestr,
-                  "$rd, $rs1, $shamt", [], InstFormatOther> {
+             "$rd, $rs1, $shamt", [], InstFormatOther> {
   bits<5> rs1;
   bits<5> rd;
 
@@ -204,8 +220,50 @@ class RVPWideningShiftB_ri<bits<3> f, string opcodestr>
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPNarrowingShift_ri<bits<3> f, string opcodestr, Operand ImmType>
+    : RVPNarrowingBase<f, 0b0, 0b1100, (outs GPR:$rd),
+                       (ins GPRPairRV32:$rs1, ImmType:$shamt), opcodestr,
+                       "$rd, $rs1, $shamt">;
+
+class RVPNarrowingShiftW_ri<bits<3> f, string opcodestr>
+    : RVPNarrowingShift_ri<f, opcodestr, uimm6> {
+  bits<6> shamt;
+
+  let Inst{26} = 0b1;
+  let Inst{25-20} = shamt;
+}
+
+class RVPNarrowingShiftH_ri<bits<3> f, string opcodestr>
+    : RVPNarrowingShift_ri<f, opcodestr, uimm5> {
+  bits<5> shamt;
+
+  let Inst{26-25} = 0b01;
+  let Inst{24-20} = shamt;
+}
+
+class RVPNarrowingShiftB_ri<bits<3> f, string opcodestr>
+    : RVPNarrowingShift_ri<f, opcodestr, uimm4> {
+  bits<4> shamt;
+
+  let Inst{26-24} = 0b001;
+  let Inst{23-20} = shamt;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPNarrowingShift_rr<bits<3> f, bits<2> w, string opcodestr>
+    : RVPNarrowingBase<f, 0b1, 0b1100, (outs GPR:$rd),
+                       (ins GPRPairRV32:$rs1, GPR:$rs2), opcodestr,
+                       "$rd, $rs1, $rs2"> {
+  bits<5> rs2;
+
+  let Inst{26-25} = w;
+  let Inst{24-20} = rs2;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPWideningShift_rr<bits<3> f, bits<2> w, string opcodestr>
-    : RVPWideningBase<w, 0b0, opcodestr> {
+    : RVPWideningBase<w, 0b0, (outs GPRPairRV32:$rd), (ins GPR:$rs1, GPR:$rs2),
+                      opcodestr> {
   let Inst{30-28} = f;
   let Inst{27} = 0b1;
 }
@@ -240,8 +298,20 @@ class RVPBinary_rr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPWideningBinary_rr<bits<4> f, bits<2> w, string opcodestr>
-    : RVPWideningBase<w, 0b1, opcodestr> {
+    : RVPWideningBase<w, 0b1, (outs GPRPairRV32:$rd), (ins GPR:$rs1, GPR:$rs2),
+                      opcodestr> {
   let Inst{30-27} = f;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPNarrowingBinary_rr<bits<3> f, bits<2> w, string opcodestr>
+    : RVPNarrowingBase<f, 0b1, 0b0100, (outs GPR:$rd),
+                       (ins GPRPairRV32:$rs1, GPR:$rs2), opcodestr,
+                       "$rd, $rs1, $rs2"> {
+  bits<5> rs2;
+
+  let Inst{26-25} = w;
+  let Inst{24-20} = rs2;
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
@@ -252,6 +322,15 @@ class RVPTernary_rrr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
   let Inst{31} = 0b1;
   let Inst{30-27} = f;
   let Inst{26-25} = w;
+
+  let Constraints = "$rd = $rd_wb";
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPWideningTernary_rrr<bits<4> f, bits<2> w, string opcodestr>
+    : RVPWideningBase<w, 0b1, (outs GPRPairRV32:$rd_wb),
+                     (ins GPR:$rd, GPR:$rs1, GPR:$rs2), opcodestr> {
+  let Inst{30-27} = f;
 
   let Constraints = "$rd = $rd_wb";
 }
@@ -989,70 +1068,132 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PWADD_H      : RVPWideningBinary_rr<0b0000, 0b00, "pwadd.h">;
   def WADD         : RVPWideningBinary_rr<0b0000, 0b01, "wadd">;
   def PWADD_B      : RVPWideningBinary_rr<0b0000, 0b10, "pwadd.b">;
-  def PW2WADD_H    : RVPWideningBinary_rr<0b0000, 0b11, "pw2wadd.h">;
+  def PM2WADD_H    : RVPWideningBinary_rr<0b0000, 0b11, "pm2wadd.h">;
 
-  def PWADDA_H     : RVPWideningBinary_rr<0b0001, 0b00, "pwadda.h">;
-  def WADDA        : RVPWideningBinary_rr<0b0001, 0b01, "wadda">;
-  def PWADDA_B     : RVPWideningBinary_rr<0b0001, 0b10, "pwadda.b">;
-  def PW2WADDA_H   : RVPWideningBinary_rr<0b0001, 0b11, "pw2wadda.h">;
+  def PWADDA_H     : RVPWideningTernary_rrr<0b0001, 0b00, "pwadda.h">;
+  def WADDA        : RVPWideningTernary_rrr<0b0001, 0b01, "wadda">;
+  def PWADDA_B     : RVPWideningTernary_rrr<0b0001, 0b10, "pwadda.b">;
+  def PM2WADDA_H   : RVPWideningTernary_rrr<0b0001, 0b11, "pm2wadda.h">;
 
   def PWADDU_H     : RVPWideningBinary_rr<0b0010, 0b00, "pwaddu.h">;
   def WADDU        : RVPWideningBinary_rr<0b0010, 0b01, "waddu">;
   def PWADDU_B     : RVPWideningBinary_rr<0b0010, 0b10, "pwaddu.b">;
-  def PW2WADD_HX   : RVPWideningBinary_rr<0b0010, 0b11, "pw2wadd.hx">;
+  def PM2WADD_HX   : RVPWideningBinary_rr<0b0010, 0b11, "pm2wadd.hx">;
 
-  def PWADDAU_H    : RVPWideningBinary_rr<0b0011, 0b00, "pwaddau.h">;
-  def WADDAU       : RVPWideningBinary_rr<0b0011, 0b01, "waddau">;
-  def PWADDAU_B    : RVPWideningBinary_rr<0b0011, 0b10, "pwaddau.b">;
-  def PW2WADDA_HX  : RVPWideningBinary_rr<0b0011, 0b11, "pw2wadda.hx">;
+  def PWADDAU_H    : RVPWideningTernary_rrr<0b0011, 0b00, "pwaddau.h">;
+  def WADDAU       : RVPWideningTernary_rrr<0b0011, 0b01, "waddau">;
+  def PWADDAU_B    : RVPWideningTernary_rrr<0b0011, 0b10, "pwaddau.b">;
+  def PM2WADDA_HX  : RVPWideningTernary_rrr<0b0011, 0b11, "pm2wadda.hx">;
 
   def PWMUL_H      : RVPWideningBinary_rr<0b0100, 0b00, "pwmul.h">;
   def WMUL         : RVPWideningBinary_rr<0b0100, 0b01, "wmul">;
   def PWMUL_B      : RVPWideningBinary_rr<0b0100, 0b10, "pwmul.b">;
-  def PW2WADDU_H   : RVPWideningBinary_rr<0b0100, 0b11, "pw2waddu.h">;
+  def PM2WADDU_H   : RVPWideningBinary_rr<0b0100, 0b11, "pm2waddu.h">;
 
-  def PWMACC_H     : RVPWideningBinary_rr<0b0101, 0b00, "pwmacc.h">;
-  def WMACC        : RVPWideningBinary_rr<0b0101, 0b01, "wmacc">;
-  def PM2WADDAU_H  : RVPWideningBinary_rr<0b0101, 0b11, "pm2waddau.h">;
+  def PWMACC_H     : RVPWideningTernary_rrr<0b0101, 0b00, "pwmacc.h">;
+  def WMACC        : RVPWideningTernary_rrr<0b0101, 0b01, "wmacc">;
+  def PM2WADDAU_H  : RVPWideningTernary_rrr<0b0101, 0b11, "pm2waddau.h">;
 
   def PWMULU_H     : RVPWideningBinary_rr<0b0110, 0b00, "pwmulu.h">;
   def WMULU        : RVPWideningBinary_rr<0b0110, 0b01, "wmulu">;
   def PWMULU_B     : RVPWideningBinary_rr<0b0110, 0b10, "pwmulu.b">;
 
-  def PWMACCU_H    : RVPWideningBinary_rr<0b0111, 0b00, "pwmaccu.h">;
-  def WMACCU       : RVPWideningBinary_rr<0b0111, 0b01, "wmaccu">;
+  def PWMACCU_H    : RVPWideningTernary_rrr<0b0111, 0b00, "pwmaccu.h">;
+  def WMACCU       : RVPWideningTernary_rrr<0b0111, 0b01, "wmaccu">;
 
   def PWSUB_H      : RVPWideningBinary_rr<0b1000, 0b00, "pwsub.h">;
   def WSUB         : RVPWideningBinary_rr<0b1000, 0b01, "wsub">;
   def PWSUB_B      : RVPWideningBinary_rr<0b1000, 0b10, "pwsub.b">;
-  def PW2WSUB_H    : RVPWideningBinary_rr<0b1000, 0b11, "pw2wsub.h">;
+  def PM2WSUB_H    : RVPWideningBinary_rr<0b1000, 0b11, "pm2wsub.h">;
 
-  def PWSUBA_H     : RVPWideningBinary_rr<0b1001, 0b00, "pwsuba.h">;
-  def WSUBA        : RVPWideningBinary_rr<0b1001, 0b01, "wsuba">;
-  def PWSUBA_B     : RVPWideningBinary_rr<0b1001, 0b10, "pwsuba.b">;
-  def PW2WSUBA_H   : RVPWideningBinary_rr<0b1001, 0b11, "pw2wsuba.h">;
+  def PWSUBA_H     : RVPWideningTernary_rrr<0b1001, 0b00, "pwsuba.h">;
+  def WSUBA        : RVPWideningTernary_rrr<0b1001, 0b01, "wsuba">;
+  def PWSUBA_B     : RVPWideningTernary_rrr<0b1001, 0b10, "pwsuba.b">;
+  def PM2WSUBA_H   : RVPWideningTernary_rrr<0b1001, 0b11, "pm2wsuba.h">;
 
   def PWSUBU_H     : RVPWideningBinary_rr<0b1010, 0b00, "pwsubu.h">;
   def WSUBU        : RVPWideningBinary_rr<0b1010, 0b01, "wsubu">;
   def PWSUBU_B     : RVPWideningBinary_rr<0b1010, 0b10, "pwsubu.b">;
-  def PW2WSUB_HX   : RVPWideningBinary_rr<0b1010, 0b11, "pw2wsub.hx">;
+  def PM2WSUB_HX   : RVPWideningBinary_rr<0b1010, 0b11, "pm2wsub.hx">;
 
-  def PWSUBAU_H    : RVPWideningBinary_rr<0b1011, 0b00, "pwsubau.h">;
-  def WSUBAU       : RVPWideningBinary_rr<0b1011, 0b01, "wsubau">;
-  def PWSUBAU_B    : RVPWideningBinary_rr<0b1011, 0b10, "pwsubau.b">;
-  def PW2WSUBA_HX  : RVPWideningBinary_rr<0b1011, 0b11, "pw2wsuba.hx">;
+  def PWSUBAU_H    : RVPWideningTernary_rrr<0b1011, 0b00, "pwsubau.h">;
+  def WSUBAU       : RVPWideningTernary_rrr<0b1011, 0b01, "wsubau">;
+  def PWSUBAU_B    : RVPWideningTernary_rrr<0b1011, 0b10, "pwsubau.b">;
+  def PM2WSUBA_HX  : RVPWideningTernary_rrr<0b1011, 0b11, "pm2wsuba.hx">;
   
   def PWMULSU_H    : RVPWideningBinary_rr<0b1100, 0b00, "pwmulsu.h">;
   def WMULSU       : RVPWideningBinary_rr<0b1100, 0b01, "wmulsu">;
   def PWMULSU_B    : RVPWideningBinary_rr<0b1100, 0b10, "pwmulsu.b">;
   def PM2WADDSU_H  : RVPWideningBinary_rr<0b1100, 0b11, "pm2waddsu.h">;
 
-  def PWMACCSU_H   : RVPWideningBinary_rr<0b1101, 0b00, "pwmaccsu.h">;
-  def WMACCSU      : RVPWideningBinary_rr<0b1101, 0b01, "wmaccsu">;
-  def PM2WADDASU_H : RVPWideningBinary_rr<0b1101, 0b11, "pm2waddasu.h">;
+  def PWMACCSU_H   : RVPWideningTernary_rrr<0b1101, 0b00, "pwmaccsu.h">;
+  def WMACCSU      : RVPWideningTernary_rrr<0b1101, 0b01, "wmaccsu">;
+  def PM2WADDASU_H : RVPWideningTernary_rrr<0b1101, 0b11, "pm2waddasu.h">;
 
-  def PMQWACC_H    : RVPWideningBinary_rr<0b1111, 0b00, "pmqwacc.h">;
-  def PMQWACC      : RVPWideningBinary_rr<0b1111, 0b01, "pmqwacc">;
-  def PMQRWACC_H   : RVPWideningBinary_rr<0b1111, 0b10, "pmqrwacc.h">;
-  def PMQRWACC     : RVPWideningBinary_rr<0b1111, 0b11, "pmqrwacc">;
+  def PMQWACC_H    : RVPWideningTernary_rrr<0b1111, 0b00, "pmqwacc.h">;
+  def PMQWACC      : RVPWideningTernary_rrr<0b1111, 0b01, "pmqwacc">;
+  def PMQRWACC_H   : RVPWideningTernary_rrr<0b1111, 0b10, "pmqrwacc.h">;
+  def PMQRWACC     : RVPWideningTernary_rrr<0b1111, 0b11, "pmqrwacc">;
+
+  def PREDSUM_DHS  : RVPNarrowingBinary_rr<0b001, 0b00, "predsum.dhs">;
+  def PREDSUM_DBS  : RVPNarrowingBinary_rr<0b001, 0b10, "predsum.dbs">;
+
+  def PREDSUMU_DHS : RVPNarrowingBinary_rr<0b011, 0b00, "predsumu.dhs">;
+  def PREDSUMU_DBS : RVPNarrowingBinary_rr<0b011, 0b10, "predsumu.dbs">;
+
+  def PNSRLI_B     : RVPNarrowingShiftB_ri<0b000, "pnsrli.b">;
+  def PNSRLI_H     : RVPNarrowingShiftH_ri<0b000, "pnsrli.h">;
+  def NSRLI        : RVPNarrowingShiftW_ri<0b000, "nsrli">;
+
+  def PNCLIPIU_B   : RVPNarrowingShiftB_ri<0b010, "pnclipiu.b">;
+  def PNCLIPIU_H   : RVPNarrowingShiftH_ri<0b010, "pnclipiu.h">;
+  def NCLIPIU      : RVPNarrowingShiftW_ri<0b010, "nclipiu">;
+
+  def PNCLIPRIU_B  : RVPNarrowingShiftB_ri<0b011, "pnclipriu.b">;
+  def PNCLIPRIU_H  : RVPNarrowingShiftH_ri<0b011, "pnclipriu.h">;
+  def NCLIPRIU     : RVPNarrowingShiftW_ri<0b011, "nclipriu">;
+
+  def PNSRAI_B     : RVPNarrowingShiftB_ri<0b100, "pnsrai.b">;
+  def PNSRAI_H     : RVPNarrowingShiftH_ri<0b100, "pnsrai.h">;
+  def NSRAI        : RVPNarrowingShiftW_ri<0b100, "nsrai">;
+
+  def PNSARI_B     : RVPNarrowingShiftB_ri<0b101, "pnsari.b">;
+  def PNSARI_H     : RVPNarrowingShiftH_ri<0b101, "pnsari.h">;
+  def NSARI        : RVPNarrowingShiftW_ri<0b101, "nsari">;
+
+  def PNCLIPI_B    : RVPNarrowingShiftB_ri<0b110, "pnclipi.b">;
+  def PNCLIPI_H    : RVPNarrowingShiftH_ri<0b110, "pnclipi.h">;
+  def NCLIPI       : RVPNarrowingShiftW_ri<0b110, "nclipi">;
+
+  def PNCLIPRI_B   : RVPNarrowingShiftB_ri<0b111, "pnclipri.b">;
+  def PNCLIPRI_H   : RVPNarrowingShiftH_ri<0b111, "pnclipri.h">;
+  def NCLIPRI      : RVPNarrowingShiftW_ri<0b111, "nclipri">;
+
+  def PNSRL_BS     : RVPNarrowingShift_rr<0b000, 0b00, "pnsrl.bs">;
+  def PNSRL_HS     : RVPNarrowingShift_rr<0b000, 0b01, "pnsrl.hs">;
+  def NSRL         : RVPNarrowingShift_rr<0b000, 0b11, "nsrl">;
+
+  def PNCLIPU_BS   : RVPNarrowingShift_rr<0b010, 0b00, "pnclipu.bs">;
+  def PNCLIPU_HS   : RVPNarrowingShift_rr<0b010, 0b01, "pnclipu.hs">;
+  def NCLIPU       : RVPNarrowingShift_rr<0b010, 0b11, "nclipu">;
+
+  def PNCLIPRU_BS  : RVPNarrowingShift_rr<0b011, 0b00, "pnclipru.bs">;
+  def PNCLIPRU_HS  : RVPNarrowingShift_rr<0b011, 0b01, "pnclipru.hs">;
+  def NCLIPRU      : RVPNarrowingShift_rr<0b011, 0b11, "nclipru">;
+
+  def PNSRA_BS     : RVPNarrowingShift_rr<0b100, 0b00, "pnsra.bs">;
+  def PNSRA_HS     : RVPNarrowingShift_rr<0b100, 0b01, "pnsra.hs">;
+  def NSRA         : RVPNarrowingShift_rr<0b100, 0b11, "nsra">;
+
+  def PNSRAR_BS    : RVPNarrowingShift_rr<0b101, 0b00, "pnsrar.bs">;
+  def PNSRAR_HS    : RVPNarrowingShift_rr<0b101, 0b01, "pnsrar.hs">;
+  def NSRAR        : RVPNarrowingShift_rr<0b101, 0b11, "nsrar">;
+
+  def PNCLIP_BS    : RVPNarrowingShift_rr<0b110, 0b00, "pnclip.bs">;
+  def PNCLIP_HS    : RVPNarrowingShift_rr<0b110, 0b01, "pnclip.hs">;
+  def NCLIP        : RVPNarrowingShift_rr<0b110, 0b11, "nclip">;
+
+  def PNCLIPR_BS   : RVPNarrowingShift_rr<0b111, 0b00, "pnclipr.bs">;
+  def PNCLIPR_HS   : RVPNarrowingShift_rr<0b111, 0b01, "pnclipr.hs">;
+  def NCLIPR       : RVPNarrowingShift_rr<0b111, 0b11, "nclipr">;
 } // Predicates = [HasStdExtP, IsRV32]

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -673,3 +673,141 @@ plui.dh tp, 32
 # CHECK-ASM-AND-OBJ: plui.dh tp, -412
 # CHECK-ASM: encoding: [0x1b,0x22,0x99,0x70]
 plui.dh tp, 612
+# CHECK-ASM-AND-OBJ: predsum.dhs s0, t3, a0
+# CHECK-ASM: encoding: [0x1b,0x44,0xae,0x18]
+predsum.dhs s0, t3, a0
+# CHECK-ASM-AND-OBJ: predsum.dbs a2, s0, t3
+# CHECK-ASM: encoding: [0x1b,0x46,0xc4,0x1d]
+predsum.dbs a2, s0, t3
+# CHECK-ASM-AND-OBJ: predsumu.dhs a2, a2, t3
+# CHECK-ASM: encoding: [0x1b,0x46,0xc6,0x39]
+predsumu.dhs a2, a2, t3
+# CHECK-ASM-AND-OBJ: predsumu.dbs a2, a0, s0
+# CHECK-ASM: encoding: [0x1b,0x46,0x85,0x3c]
+predsumu.dbs a2, a0, s0
+# CHECK-ASM-AND-OBJ: pnsrli.b a2, a0
+# CHECK-ASM: encoding: [0x1b,0xc6,0x05,0x01]
+pnsrli.b a2, a0, 0
+# CHECK-ASM-AND-OBJ: pnsrli.h a0, t3
+# CHECK-ASM: encoding: [0x1b,0xc5,0x1e,0x02]
+pnsrli.h a0, t3, 1
+# CHECK-ASM-AND-OBJ: nsrli a2, a0
+# CHECK-ASM: encoding: [0x1b,0xc6,0x35,0x04]
+nsrli a2, a0, 3
+# CHECK-ASM-AND-OBJ: pnclipiu.b a4, t3
+# CHECK-ASM: encoding: [0x1b,0xc7,0x2e,0x21]
+pnclipiu.b a4, t3, 2
+# CHECK-ASM-AND-OBJ: pnclipiu.h t1, s2
+# CHECK-ASM: encoding: [0x1b,0xc3,0x39,0x22]
+pnclipiu.h t1, s2, 3
+# CHECK-ASM-AND-OBJ: nclipiu s0, a2
+# CHECK-ASM: encoding: [0x1b,0xc4,0x46,0x24]
+nclipiu s0, a2, 4
+# CHECK-ASM-AND-OBJ: pnclipriu.b s2, s0
+# CHECK-ASM: encoding: [0x1b,0xc9,0x14,0x31]
+pnclipriu.b s2, s0, 1
+# CHECK-ASM-AND-OBJ: pnclipriu.h s0, s0
+# CHECK-ASM: encoding: [0x1b,0xc4,0x24,0x32]
+pnclipriu.h s0, s0, 2
+# CHECK-ASM-AND-OBJ: nclipriu t3, t3
+# CHECK-ASM: encoding: [0x1b,0xce,0x4e,0x34]
+nclipriu t3, t3, 4
+# CHECK-ASM-AND-OBJ: pnsrai.b s2, t5
+# CHECK-ASM: encoding: [0x1b,0xc9,0x3f,0x41]
+pnsrai.b s2, t5, 3
+# CHECK-ASM-AND-OBJ: pnsrai.h s0, a0
+# CHECK-ASM: encoding: [0x1b,0xc4,0x25,0x42]
+pnsrai.h s0, a0, 2
+# CHECK-ASM-AND-OBJ: nsrai a4, t3
+# CHECK-ASM: encoding: [0x1b,0xc7,0x4e,0x44]
+nsrai a4, t3, 4
+# CHECK-ASM-AND-OBJ: pnsari.b t5, t5
+# CHECK-ASM: encoding: [0x1b,0xcf,0x0f,0x51]
+pnsari.b t5, t5, 0
+# CHECK-ASM-AND-OBJ: pnsari.h t1, a4
+# CHECK-ASM: encoding: [0x1b,0xc3,0x37,0x52]
+pnsari.h t1, a4, 3
+# CHECK-ASM-AND-OBJ: nsari s0, t1
+# CHECK-ASM: encoding: [0x1b,0xc4,0x53,0x54]
+nsari s0, t1, 5
+# CHECK-ASM-AND-OBJ: pnclipi.b t1, a4
+# CHECK-ASM: encoding: [0x1b,0xc3,0x77,0x61]
+pnclipi.b t1, a4, 7
+# CHECK-ASM-AND-OBJ: pnclipi.h a0, a4
+# CHECK-ASM: encoding: [0x1b,0xc5,0x27,0x62]
+pnclipi.h a0, a4, 2
+# CHECK-ASM-AND-OBJ: nclipi t5, t5
+# CHECK-ASM: encoding: [0x1b,0xcf,0x5f,0x64]
+nclipi t5, t5, 5
+# CHECK-ASM-AND-OBJ: pnclipri.b a0, s0
+# CHECK-ASM: encoding: [0x1b,0xc5,0x24,0x71]
+pnclipri.b a0, s0, 2
+# CHECK-ASM-AND-OBJ: pnclipri.h s2, t5
+# CHECK-ASM: encoding: [0x1b,0xc9,0x3f,0x72]
+pnclipri.h s2, t5, 3
+# CHECK-ASM-AND-OBJ: nclipri t3, s0
+# CHECK-ASM: encoding: [0x1b,0xce,0x54,0x74]
+nclipri t3, s0, 5
+# CHECK-ASM-AND-OBJ: pnsrl.bs t3, s0, a4
+# CHECK-ASM: encoding: [0x1b,0xce,0xe4,0x08]
+pnsrl.bs t3, s0, a4
+# CHECK-ASM-AND-OBJ: pnsrl.hs a2, t1, a4
+# CHECK-ASM: encoding: [0x1b,0xc6,0xe3,0x0a]
+pnsrl.hs a2, t1, a4
+# CHECK-ASM-AND-OBJ: nsrl a2, a2, a0
+# CHECK-ASM: encoding: [0x1b,0xc6,0xa6,0x0e]
+nsrl a2, a2, a0
+# CHECK-ASM-AND-OBJ: pnclipu.bs a4, t5, a2
+# CHECK-ASM: encoding: [0x1b,0xc7,0xcf,0x28]
+pnclipu.bs a4, t5, a2
+# CHECK-ASM-AND-OBJ: pnclipu.hs t1, a2, a4
+# CHECK-ASM: encoding: [0x1b,0xc3,0xe6,0x2a]
+pnclipu.hs t1, a2, a4
+# CHECK-ASM-AND-OBJ: nclipu t5, s2, t1
+# CHECK-ASM: encoding: [0x1b,0xcf,0x69,0x2e]
+nclipu t5, s2, t1
+# CHECK-ASM-AND-OBJ: pnclipru.bs t5, s2, s2
+# CHECK-ASM: encoding: [0x1b,0xcf,0x29,0x39]
+pnclipru.bs t5, s2, s2
+# CHECK-ASM-AND-OBJ: pnclipru.hs t5, s2, a0
+# CHECK-ASM: encoding: [0x1b,0xcf,0xa9,0x3a]
+pnclipru.hs t5, s2, a0
+# CHECK-ASM-AND-OBJ: nclipru a4, t5, t5
+# CHECK-ASM: encoding: [0x1b,0xc7,0xef,0x3f]
+nclipru a4, t5, t5
+# CHECK-ASM-AND-OBJ: pnsra.bs a4, t1, a4
+# CHECK-ASM: encoding: [0x1b,0xc7,0xe3,0x48]
+pnsra.bs a4, t1, a4
+# CHECK-ASM-AND-OBJ: pnsra.hs s0, s2, t3
+# CHECK-ASM: encoding: [0x1b,0xc4,0xc9,0x4b]
+pnsra.hs s0, s2, t3
+# CHECK-ASM-AND-OBJ: nsra t1, s0, a4
+# CHECK-ASM: encoding: [0x1b,0xc3,0xe4,0x4e]
+nsra t1, s0, a4
+# CHECK-ASM-AND-OBJ: pnsrar.bs a2, s0, a4
+# CHECK-ASM: encoding: [0x1b,0xc6,0xe4,0x58]
+pnsrar.bs a2, s0, a4
+# CHECK-ASM-AND-OBJ: pnsrar.hs s0, a4, a0
+# CHECK-ASM: encoding: [0x1b,0xc4,0xa7,0x5a]
+pnsrar.hs s0, a4, a0
+# CHECK-ASM-AND-OBJ: nsrar a4, a4, s0
+# CHECK-ASM: encoding: [0x1b,0xc7,0x87,0x5e]
+nsrar a4, a4, s0
+# CHECK-ASM-AND-OBJ: pnclip.bs t1, t5, t3
+# CHECK-ASM: encoding: [0x1b,0xc3,0xcf,0x69]
+pnclip.bs t1, t5, t3
+# CHECK-ASM-AND-OBJ: pnclip.hs a0, a2, a0
+# CHECK-ASM: encoding: [0x1b,0xc5,0xa6,0x6a]
+pnclip.hs a0, a2, a0
+# CHECK-ASM-AND-OBJ: nclip t3, t5, t3
+# CHECK-ASM: encoding: [0x1b,0xce,0xcf,0x6f]
+nclip t3, t5, t3
+# CHECK-ASM-AND-OBJ: pnclipr.bs t1, a2, a0
+# CHECK-ASM: encoding: [0x1b,0xc3,0xa6,0x78]
+pnclipr.bs t1, a2, a0
+# CHECK-ASM-AND-OBJ: pnclipr.hs a4, s2, t3
+# CHECK-ASM: encoding: [0x1b,0xc7,0xc9,0x7b]
+pnclipr.hs a4, s2, t3
+# CHECK-ASM-AND-OBJ: nclipr t1, t5, a2
+# CHECK-ASM: encoding: [0x1b,0xc3,0xcf,0x7e]
+nclipr t1, t5, a2

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -657,7 +657,24 @@ mqacc.h11 t5, t5, s0
 # CHECK-ASM-AND-OBJ: mqracc.h11 s0, t5, s2
 # CHECK-ASM: encoding: [0x3b,0x74,0x2f,0xfd]
 mqracc.h11 s0, t5, s2
-
+# CHECK-ASM-AND-OBJ: pwslli.b a0, t1
+# CHECK-ASM: encoding: [0x1b,0x25,0x03,0x01]
+pwslli.b a0, t1, 0
+# CHECK-ASM-AND-OBJ: pwslli.h s0, a0
+# CHECK-ASM: encoding: [0x1b,0x24,0xf5,0x03]
+pwslli.h s0, a0, 31
+# CHECK-ASM-AND-OBJ: wslli s2, t3
+# CHECK-ASM: encoding: [0x1b,0x29,0xfe,0x07]
+wslli s2, t3, 63
+# CHECK-ASM-AND-OBJ: pwslai.b t5, t5
+# CHECK-ASM: encoding: [0x1b,0x2f,0x8f,0x41]
+pwslai.b t5, t5, 8
+# CHECK-ASM-AND-OBJ: pwslai.h t5, a4
+# CHECK-ASM: encoding: [0x1b,0x2f,0xf7,0x43]
+pwslai.h t5, a4, 31
+# CHECK-ASM-AND-OBJ: wslai t1, a2
+# CHECK-ASM: encoding: [0x1b,0x23,0xf6,0x47]
+wslai t1, a2, 63
 # CHECK-ASM-AND-OBJ: pli.dh a4, 16
 # CHECK-ASM: encoding: [0x1b,0x27,0x10,0x30]
 pli.dh a4, 16
@@ -673,6 +690,195 @@ plui.dh tp, 32
 # CHECK-ASM-AND-OBJ: plui.dh tp, -412
 # CHECK-ASM: encoding: [0x1b,0x22,0x99,0x70]
 plui.dh tp, 612
+# CHECK-ASM-AND-OBJ: pwsll.bs t3, t1, s0
+# CHECK-ASM: encoding: [0x1b,0x2e,0x83,0x08]
+pwsll.bs t3, t1, s0
+# CHECK-ASM-AND-OBJ: pwsll.hs s0, a4, t1
+# CHECK-ASM: encoding: [0x1b,0x24,0x67,0x0a]
+pwsll.hs s0, a4, t1
+# CHECK-ASM-AND-OBJ: wsll a0, s0, s2
+# CHECK-ASM: encoding: [0x1b,0x25,0x24,0x0f]
+wsll a0, s0, s2
+# CHECK-ASM-AND-OBJ: pwsla.bs s0, s0, s0
+# CHECK-ASM: encoding: [0x1b,0x24,0x84,0x48]
+pwsla.bs s0, s0, s0
+# CHECK-ASM-AND-OBJ: pwsla.hs a4, a2, t5
+# CHECK-ASM: encoding: [0x1b,0x27,0xe6,0x4b]
+pwsla.hs a4, a2, t5
+# CHECK-ASM-AND-OBJ: wsla s0, a0, s2
+# CHECK-ASM: encoding: [0x1b,0x24,0x25,0x4f]
+wsla s0, a0, s2
+# CHECK-ASM-AND-OBJ: wzip8p t1, s2, a2
+# CHECK-ASM: encoding: [0x1b,0x23,0xc9,0x78]
+wzip8p t1, s2, a2
+# CHECK-ASM-AND-OBJ: wzip16p s2, t3, s2
+# CHECK-ASM: encoding: [0x1b,0x29,0x2e,0x7b]
+wzip16p s2, t3, s2
+# CHECK-ASM-AND-OBJ: pwadd.h a4, a2, a0
+# CHECK-ASM: encoding: [0x9b,0x27,0xa6,0x00]
+pwadd.h a4, a2, a0
+# CHECK-ASM-AND-OBJ: wadd t1, t5, t5
+# CHECK-ASM: encoding: [0x9b,0x23,0xef,0x03]
+wadd t1, t5, t5
+# CHECK-ASM-AND-OBJ: pwadd.b s0, t3, a4
+# CHECK-ASM: encoding: [0x9b,0x24,0xee,0x04]
+pwadd.b s0, t3, a4
+# CHECK-ASM-AND-OBJ: pm2wadd.h t3, t3, a4
+# CHECK-ASM: encoding: [0x9b,0x2e,0xee,0x06]
+pm2wadd.h t3, t3, a4
+# CHECK-ASM-AND-OBJ: pwadda.h t1, t3, s2
+# CHECK-ASM: encoding: [0x9b,0x23,0x2e,0x09]
+pwadda.h t1, t3, s2
+# CHECK-ASM-AND-OBJ: wadda s2, t1, a0
+# CHECK-ASM: encoding: [0x9b,0x29,0xa3,0x0a]
+wadda s2, t1, a0
+# CHECK-ASM-AND-OBJ: pwadda.b a2, a2, s2
+# CHECK-ASM: encoding: [0x9b,0x26,0x26,0x0d]
+pwadda.b a2, a2, s2
+# CHECK-ASM-AND-OBJ: pm2wadda.h t3, t1, t1
+# CHECK-ASM: encoding: [0x9b,0x2e,0x63,0x0e]
+pm2wadda.h t3, t1, t1
+# CHECK-ASM-AND-OBJ: pwaddu.h a2, t1, a4
+# CHECK-ASM: encoding: [0x9b,0x26,0xe3,0x10]
+pwaddu.h a2, t1, a4
+# CHECK-ASM-AND-OBJ: waddu t1, s0, t1
+# CHECK-ASM: encoding: [0x9b,0x23,0x64,0x12]
+waddu t1, s0, t1
+# CHECK-ASM-AND-OBJ: pwaddu.b s2, a0, t3
+# CHECK-ASM: encoding: [0x9b,0x29,0xc5,0x15]
+pwaddu.b s2, a0, t3
+# CHECK-ASM-AND-OBJ: pm2wadd.hx a0, s0, t1
+# CHECK-ASM: encoding: [0x9b,0x25,0x64,0x16]
+pm2wadd.hx a0, s0, t1
+# CHECK-ASM-AND-OBJ: pwaddau.h t1, t5, t3
+# CHECK-ASM: encoding: [0x9b,0x23,0xcf,0x19]
+pwaddau.h t1, t5, t3
+# CHECK-ASM-AND-OBJ: waddau t3, s0, s0
+# CHECK-ASM: encoding: [0x9b,0x2e,0x84,0x1a]
+waddau t3, s0, s0
+# CHECK-ASM-AND-OBJ: pwaddau.b a0, a0, t1
+# CHECK-ASM: encoding: [0x9b,0x25,0x65,0x1c]
+pwaddau.b a0, a0, t1
+# CHECK-ASM-AND-OBJ: pm2wadda.hx a4, a2, t3
+# CHECK-ASM: encoding: [0x9b,0x27,0xc6,0x1f]
+pm2wadda.hx a4, a2, t3
+# CHECK-ASM-AND-OBJ: pwmul.h s2, t1, a0
+# CHECK-ASM: encoding: [0x9b,0x29,0xa3,0x20]
+pwmul.h s2, t1, a0
+# CHECK-ASM-AND-OBJ: wmul t3, a2, t5
+# CHECK-ASM: encoding: [0x9b,0x2e,0xe6,0x23]
+wmul t3, a2, t5
+# CHECK-ASM-AND-OBJ: pwmul.b a0, s0, s2
+# CHECK-ASM: encoding: [0x9b,0x25,0x24,0x25]
+pwmul.b a0, s0, s2
+# CHECK-ASM-AND-OBJ: pm2waddu.h s2, s2, a0
+# CHECK-ASM: encoding: [0x9b,0x29,0xa9,0x26]
+pm2waddu.h s2, s2, a0
+# CHECK-ASM-AND-OBJ: pwmacc.h s0, a2, a2
+# CHECK-ASM: encoding: [0x9b,0x24,0xc6,0x28]
+pwmacc.h s0, a2, a2
+# CHECK-ASM-AND-OBJ: wmacc a0, a2, a2
+# CHECK-ASM: encoding: [0x9b,0x25,0xc6,0x2a]
+wmacc a0, a2, a2
+# CHECK-ASM-AND-OBJ: pm2waddau.h t5, a2, t5
+# CHECK-ASM: encoding: [0x9b,0x2f,0xe6,0x2f]
+pm2waddau.h t5, a2, t5
+# CHECK-ASM-AND-OBJ: pwmulu.h a2, a0, t5
+# CHECK-ASM: encoding: [0x9b,0x26,0xe5,0x31]
+pwmulu.h a2, a0, t5
+# CHECK-ASM-AND-OBJ: wmulu s2, a0, t3
+# CHECK-ASM: encoding: [0x9b,0x29,0xc5,0x33]
+wmulu s2, a0, t3
+# CHECK-ASM-AND-OBJ: pwmulu.b a2, a4, a2
+# CHECK-ASM: encoding: [0x9b,0x26,0xc7,0x34]
+pwmulu.b a2, a4, a2
+# CHECK-ASM-AND-OBJ: pwmaccu.h t1, a4, a2
+# CHECK-ASM: encoding: [0x9b,0x23,0xc7,0x38]
+pwmaccu.h t1, a4, a2
+# CHECK-ASM-AND-OBJ: wmaccu a2, a0, t1
+# CHECK-ASM: encoding: [0x9b,0x26,0x65,0x3a]
+wmaccu a2, a0, t1
+# CHECK-ASM-AND-OBJ: pwsub.h s0, s2, t3
+# CHECK-ASM: encoding: [0x9b,0x24,0xc9,0x41]
+pwsub.h s0, s2, t3
+# CHECK-ASM-AND-OBJ: wsub t1, s2, a4
+# CHECK-ASM: encoding: [0x9b,0x23,0xe9,0x42]
+wsub t1, s2, a4
+# CHECK-ASM-AND-OBJ: pwsub.b a4, s2, s2
+# CHECK-ASM: encoding: [0x9b,0x27,0x29,0x45]
+pwsub.b a4, s2, s2
+# CHECK-ASM-AND-OBJ: pm2wsub.h t1, a4, t3
+# CHECK-ASM: encoding: [0x9b,0x23,0xc7,0x47]
+pm2wsub.h t1, a4, t3
+# CHECK-ASM-AND-OBJ: pwsuba.h a4, t5, t1
+# CHECK-ASM: encoding: [0x9b,0x27,0x6f,0x48]
+pwsuba.h a4, t5, t1
+# CHECK-ASM-AND-OBJ: wsuba a0, s0, t5
+# CHECK-ASM: encoding: [0x9b,0x25,0xe4,0x4b]
+wsuba a0, s0, t5
+# CHECK-ASM-AND-OBJ: pwsuba.b a0, a2, s2
+# CHECK-ASM: encoding: [0x9b,0x25,0x26,0x4d]
+pwsuba.b a0, a2, s2
+# CHECK-ASM-AND-OBJ: pm2wsuba.h t5, s0, s2
+# CHECK-ASM: encoding: [0x9b,0x2f,0x24,0x4f]
+pm2wsuba.h t5, s0, s2
+# CHECK-ASM-AND-OBJ: pwsubu.h t5, s2, a2
+# CHECK-ASM: encoding: [0x9b,0x2f,0xc9,0x50]
+pwsubu.h t5, s2, a2
+# CHECK-ASM-AND-OBJ: wsubu a2, a4, a0
+# CHECK-ASM: encoding: [0x9b,0x26,0xa7,0x52]
+wsubu a2, a4, a0
+# CHECK-ASM-AND-OBJ: pwsubu.b a2, a2, t5
+# CHECK-ASM: encoding: [0x9b,0x26,0xe6,0x55]
+pwsubu.b a2, a2, t5
+# CHECK-ASM-AND-OBJ: pm2wsub.hx t5, a2, a0
+# CHECK-ASM: encoding: [0x9b,0x2f,0xa6,0x56]
+pm2wsub.hx t5, a2, a0
+# CHECK-ASM-AND-OBJ: pwsubau.h t5, s0, s2
+# CHECK-ASM: encoding: [0x9b,0x2f,0x24,0x59]
+pwsubau.h t5, s0, s2
+# CHECK-ASM-AND-OBJ: wsubau t5, a0, t1
+# CHECK-ASM: encoding: [0x9b,0x2f,0x65,0x5a]
+wsubau t5, a0, t1
+# CHECK-ASM-AND-OBJ: pwsubau.b a2, a4, a0
+# CHECK-ASM: encoding: [0x9b,0x26,0xa7,0x5c]
+pwsubau.b a2, a4, a0
+# CHECK-ASM-AND-OBJ: pm2wsuba.hx a2, a3, t5
+# CHECK-ASM: encoding: [0x9b,0xa6,0xe6,0x5f]
+pm2wsuba.hx a2, a3, t5
+# CHECK-ASM-AND-OBJ: pwmulsu.h s0, a2, t3
+# CHECK-ASM: encoding: [0x9b,0x24,0xc6,0x61]
+pwmulsu.h s0, a2, t3
+# CHECK-ASM-AND-OBJ: wmulsu a0, s2, a0
+# CHECK-ASM: encoding: [0x9b,0x25,0xa9,0x62]
+wmulsu a0, s2, a0
+# CHECK-ASM-AND-OBJ: pwmulsu.b t3, t5, t1
+# CHECK-ASM: encoding: [0x9b,0x2e,0x6f,0x64]
+pwmulsu.b t3, t5, t1
+# CHECK-ASM-AND-OBJ: pm2waddsu.h a4, a2, s2
+# CHECK-ASM: encoding: [0x9b,0x27,0x26,0x67]
+pm2waddsu.h a4, a2, s2
+# CHECK-ASM-AND-OBJ: pwmaccsu.h t5, s2, a2
+# CHECK-ASM: encoding: [0x9b,0x2f,0xc9,0x68]
+pwmaccsu.h t5, s2, a2
+# CHECK-ASM-AND-OBJ: wmaccsu t3, s0, a4
+# CHECK-ASM: encoding: [0x9b,0x2e,0xe4,0x6a]
+wmaccsu t3, s0, a4
+# CHECK-ASM-AND-OBJ: pm2waddasu.h t3, t5, a0
+# CHECK-ASM: encoding: [0x9b,0x2e,0xaf,0x6e]
+pm2waddasu.h t3, t5, a0
+# CHECK-ASM-AND-OBJ: pmqwacc.h t5, t5, a2
+# CHECK-ASM: encoding: [0x9b,0x2f,0xcf,0x78]
+pmqwacc.h t5, t5, a2
+# CHECK-ASM-AND-OBJ: pmqwacc s2, a4, a2
+# CHECK-ASM: encoding: [0x9b,0x29,0xc7,0x7a]
+pmqwacc s2, a4, a2
+# CHECK-ASM-AND-OBJ: pmqrwacc.h a4, t3, a4
+# CHECK-ASM: encoding: [0x9b,0x27,0xee,0x7c]
+pmqrwacc.h a4, t3, a4
+# CHECK-ASM-AND-OBJ: pmqrwacc s0, s2, t5
+# CHECK-ASM: encoding: [0x9b,0x24,0xe9,0x7f]
+pmqrwacc s0, s2, t5
 # CHECK-ASM-AND-OBJ: predsum.dhs s0, t3, a0
 # CHECK-ASM: encoding: [0x1b,0x44,0xae,0x18]
 predsum.dhs s0, t3, a0


### PR DESCRIPTION
This patch implements pages 18-20 from jhauser.us/RISCV/ext-P/RVP-instrEncodings-015.pdf

Documentation:
jhauser.us/RISCV/ext-P/RVP-baseInstrs-014.pdf
jhauser.us/RISCV/ext-P/RVP-instrEncodings-015.pdf