### PR TITLE
[clang][ObjC] Fix incorrect return type inference for discarded blocks

### DIFF
--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3342,7 +3342,8 @@ ExprResult Parser::ParseBlockLiteralExpression() {
     Actions.ActOnBlockError(CaretLoc, getCurScope());
     return ExprError();
   }
-
+ EnterExpressionEvaluationContextForFunction PotentiallyEvaluated(
+       Actions, Sema::ExpressionEvaluationContext::PotentiallyEvaluated);
   StmtResult Stmt(ParseCompoundStatementBody());
   BlockScope.Exit();
   if (!Stmt.isInvalid())

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3342,7 +3342,7 @@ ExprResult Parser::ParseBlockLiteralExpression() {
     Actions.ActOnBlockError(CaretLoc, getCurScope());
     return ExprError();
   }
- EnterExpressionEvaluationContextForFunction PotentiallyEvaluated(
+  EnterExpressionEvaluationContextForFunction PotentiallyEvaluated(
        Actions, Sema::ExpressionEvaluationContext::PotentiallyEvaluated);
   StmtResult Stmt(ParseCompoundStatementBody());
   BlockScope.Exit();

--- a/clang/test/CXX/stmt.stmt/stmt.select/stmt.if/p2.cpp
+++ b/clang/test/CXX/stmt.stmt/stmt.select/stmt.if/p2.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -std=c++1z -verify %s
+// RUN: %clang_cc1 -std=c++1z -fblocks -verify %s -DBLOCK_TEST
 // RUN: %clang_cc1 -std=c++1z -verify %s -DUNDEFINED
 
 #ifdef UNDEFINED
@@ -254,6 +255,15 @@ namespace GH153884 {
     // expected-note@-1 {{in instantiation of function template specialization 'GH153884::f2()}}
     return false;
   }
+
+#if BLOCK_TEST
+void  block_receiver(int (^)() );
+int f3() {
+  if constexpr (0)
+    (block_receiver)(^{ return 2; });
+  return 1;
+}
+#endif
 }
 
 #endif

--- a/clang/test/CXX/stmt.stmt/stmt.select/stmt.if/p2.cpp
+++ b/clang/test/CXX/stmt.stmt/stmt.select/stmt.if/p2.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -std=c++1z -verify %s
-// RUN: %clang_cc1 -std=c++1z -fblocks -verify %s -DBLOCK_TEST
 // RUN: %clang_cc1 -std=c++1z -verify %s -DUNDEFINED
 
 #ifdef UNDEFINED
@@ -255,15 +254,6 @@ namespace GH153884 {
     // expected-note@-1 {{in instantiation of function template specialization 'GH153884::f2()}}
     return false;
   }
-
-#if BLOCK_TEST
-void  block_receiver(int (^)() );
-int f3() {
-  if constexpr (0)
-    (block_receiver)(^{ return 2; });
-  return 1;
-}
-#endif
 }
 
 #endif

--- a/clang/test/SemaObjCXX/discarded-block-type-inference.mm
+++ b/clang/test/SemaObjCXX/discarded-block-type-inference.mm
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -std=c++23 -fsyntax-only -fobjc-arc -fblocks %s
+
+void  block_receiver(int (^)() );
+
+int f1() {
+  if constexpr (0)
+    (block_receiver)(^{ return 2; });
+  return 1;
+}
+
+int f2() {
+  if constexpr (0)
+    return (^{ return 2; })();
+  return 1;
+}


### PR DESCRIPTION
When parsing a block expression we were not entering a new eval context and as a result when parsing the block body we continue to treat any return statements as discarded so infer a `void` result.

This fixes the problem by introducing an evaluation context around the parsing of the body.