### PR TITLE
[DAG] visitTRUNCATE - early out from computeKnownBits/ComputeNumSignBits failures. NFC.

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -16342,12 +16342,12 @@ SDValue DAGCombiner::visitTRUNCATE(SDNode *N) {
 
       if (N0.getOpcode() == ISD::ABDU) {
         APInt UpperBits = APInt::getBitsSetFrom(SrcBits, TruncBits);
-        CanFold = DAG.MaskedValueIsZero(A, UpperBits) &&
-                  DAG.MaskedValueIsZero(B, UpperBits);
+        CanFold = DAG.MaskedValueIsZero(B, UpperBits) &&
+                  DAG.MaskedValueIsZero(A, UpperBits);
       } else {
         unsigned NeededBits = SrcBits - TruncBits;
-        CanFold = DAG.ComputeNumSignBits(A) > NeededBits &&
-                  DAG.ComputeNumSignBits(B) > NeededBits;
+        CanFold = DAG.ComputeNumSignBits(B) > NeededBits &&
+                  DAG.ComputeNumSignBits(A) > NeededBits;
       }
 
       if (CanFold) {

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -16332,25 +16332,22 @@ SDValue DAGCombiner::visitTRUNCATE(SDNode *N) {
     // (trunc (abdu/abds a, b)) -> (abdu/abds (trunc a), (trunc b))
     if ((!LegalOperations || N0.hasOneUse()) &&
         TLI.isOperationLegal(N0.getOpcode(), VT)) {
-      EVT SrcVT = N0.getValueType();
       EVT TruncVT = VT;
       unsigned SrcBits = SrcVT.getScalarSizeInBits();
       unsigned TruncBits = TruncVT.getScalarSizeInBits();
-      unsigned NeededBits = SrcBits - TruncBits;
 
       SDValue A = N0.getOperand(0);
       SDValue B = N0.getOperand(1);
       bool CanFold = false;
 
       if (N0.getOpcode() == ISD::ABDU) {
-        KnownBits KnownA = DAG.computeKnownBits(A);
-        KnownBits KnownB = DAG.computeKnownBits(B);
-        CanFold = KnownA.countMinLeadingZeros() >= NeededBits &&
-                  KnownB.countMinLeadingZeros() >= NeededBits;
+        APInt UpperBits = APInt::getBitsSetFrom(SrcBits, TruncBits);
+        CanFold = DAG.MaskedValueIsZero(A, UpperBits) &&
+                  DAG.MaskedValueIsZero(B, UpperBits);
       } else {
-        unsigned SignBitsA = DAG.ComputeNumSignBits(A);
-        unsigned SignBitsB = DAG.ComputeNumSignBits(B);
-        CanFold = SignBitsA > NeededBits && SignBitsB > NeededBits;
+        unsigned NeededBits = SrcBits - TruncBits;
+        CanFold = DAG.ComputeNumSignBits(A) > NeededBits &&
+                  DAG.ComputeNumSignBits(B) > NeededBits;
       }
 
       if (CanFold) {


### PR DESCRIPTION
Avoid unnecessary (costly) computeKnownBits/ComputeNumSignBits calls - use MaskedValueIsZero instead of computeKnownBits directly to simplify code.