### PR TITLE
[clang][bytecode] Disable EndLifetime op for array elements

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1852,6 +1852,11 @@ bool EndLifetime(InterpState &S, CodePtr OpPC) {
   const auto &Ptr = S.Stk.peek<Pointer>();
   if (Ptr.isBlockPointer() && !CheckDummy(S, OpPC, Ptr.block(), AK_Destroy))
     return false;
+
+  // FIXME: We need per-element lifetime information for primitive arrays.
+  if (Ptr.isArrayElement())
+    return true;
+
   endLifetimeRecurse(Ptr.narrow());
   return true;
 }
@@ -1861,6 +1866,11 @@ bool EndLifetimePop(InterpState &S, CodePtr OpPC) {
   const auto &Ptr = S.Stk.pop<Pointer>();
   if (Ptr.isBlockPointer() && !CheckDummy(S, OpPC, Ptr.block(), AK_Destroy))
     return false;
+
+  // FIXME: We need per-element lifetime information for primitive arrays.
+  if (Ptr.isArrayElement())
+    return true;
+
   endLifetimeRecurse(Ptr.narrow());
   return true;
 }

--- a/clang/test/AST/ByteCode/builtin-functions.cpp
+++ b/clang/test/AST/ByteCode/builtin-functions.cpp
@@ -1789,9 +1789,11 @@ namespace WithinLifetime {
   } xstd; // both-error {{is not a constant expression}} \
           // both-note {{in call to}}
 
+  /// FIXME: We do not have per-element lifetime information for primitive arrays.
+  /// See https://github.com/llvm/llvm-project/issues/147528
   consteval bool test_dynamic(bool read_after_deallocate) {
     std::allocator<int> a;
-    int* p = a.allocate(1);
+    int* p = a.allocate(1); // expected-note 2{{allocation performed here was not deallocated}}
     // a.allocate starts the lifetime of an array,
     // the complete object of *p has started its lifetime
     if (__builtin_is_within_lifetime(p))
@@ -1804,12 +1806,12 @@ namespace WithinLifetime {
       return false;
     a.deallocate(p, 1);
     if (read_after_deallocate)
-      __builtin_is_within_lifetime(p); // both-note {{read of heap allocated object that has been deleted}}
+      __builtin_is_within_lifetime(p); // ref-note {{read of heap allocated object that has been deleted}}
     return true;
   }
-  static_assert(test_dynamic(false));
+  static_assert(test_dynamic(false)); // expected-error {{not an integral constant expression}}
   static_assert(test_dynamic(true)); // both-error {{not an integral constant expression}} \
-                                     // both-note {{in call to}}
+                                     // ref-note {{in call to}}
 }
 
 #ifdef __SIZEOF_INT128__


### PR DESCRIPTION
This breaks a ton of libc++ tests otherwise, since calling std::destroy_at will currently end the lifetime of the entire array not just the given element.

See https://github.com/llvm/llvm-project/issues/147528