### PR TITLE
[Global-ISel][AArch64] Port ShouldBeAdjustedToZero and allow negative cmp immediates

### DIFF
--- a/llvm/test/CodeGen/AArch64/GlobalISel/postlegalizer-lowering-adjust-icmp-imm.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/postlegalizer-lowering-adjust-icmp-imm.mir
@@ -649,8 +649,8 @@ body:             |
     ; LOWER-NEXT: {{  $}}
     ; LOWER-NEXT: %reg0:_(s32) = COPY $w0
     ; LOWER-NEXT: %reg1:_(s32) = COPY $w1
-    ; LOWER-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; LOWER-NEXT: %cmp:_(s32) = G_ICMP intpred(slt), %reg0(s32), [[C]]
+    ; LOWER-NEXT: %cst:_(s32) = G_CONSTANT i32 -1
+    ; LOWER-NEXT: %cmp:_(s32) = G_ICMP intpred(sle), %reg0(s32), %cst
     ; LOWER-NEXT: %select:_(s32) = G_SELECT %cmp(s32), %reg0, %reg1
     ; LOWER-NEXT: $w0 = COPY %select(s32)
     ; LOWER-NEXT: RET_ReallyLR implicit $w0
@@ -660,8 +660,8 @@ body:             |
     ; SELECT-NEXT: {{  $}}
     ; SELECT-NEXT: %reg0:gpr32common = COPY $w0
     ; SELECT-NEXT: %reg1:gpr32 = COPY $w1
-    ; SELECT-NEXT: [[SUBSWri:%[0-9]+]]:gpr32 = SUBSWri %reg0, 0, 0, implicit-def $nzcv
-    ; SELECT-NEXT: %select:gpr32 = CSELWr %reg0, %reg1, 4, implicit $nzcv
+    ; SELECT-NEXT: [[ADDSWri:%[0-9]+]]:gpr32 = ADDSWri %reg0, 1, 0, implicit-def $nzcv
+    ; SELECT-NEXT: %select:gpr32 = CSELWr %reg0, %reg1, 13, implicit $nzcv
     ; SELECT-NEXT: $w0 = COPY %select
     ; SELECT-NEXT: RET_ReallyLR implicit $w0
     %reg0:_(s32) = COPY $w0

--- a/llvm/test/CodeGen/AArch64/check-sign-bit-before-extension.ll
+++ b/llvm/test/CodeGen/AArch64/check-sign-bit-before-extension.ll
@@ -14,8 +14,8 @@ define i32 @f_i8_sign_extend_inreg(i8 %in, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: f_i8_sign_extend_inreg:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    sxtb w8, w0
-; CHECK-NEXT:    cmn w8, #1
-; CHECK-NEXT:    csel w8, w1, w2, gt
+; CHECK-NEXT:    cmp w8, #0
+; CHECK-NEXT:    csel w8, w1, w2, pl
 ; CHECK-NEXT:    add w0, w8, w0, uxtb
 ; CHECK-NEXT:    ret
 entry:
@@ -36,8 +36,8 @@ define i32 @f_i16_sign_extend_inreg(i16 %in, i32 %a, i32 %b) nounwind {
 ; CHECK-LABEL: f_i16_sign_extend_inreg:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    sxth w8, w0
-; CHECK-NEXT:    cmn w8, #1
-; CHECK-NEXT:    csel w8, w1, w2, gt
+; CHECK-NEXT:    cmp w8, #0
+; CHECK-NEXT:    csel w8, w1, w2, pl
 ; CHECK-NEXT:    add w0, w8, w0, uxth
 ; CHECK-NEXT:    ret
 entry:
@@ -145,8 +145,8 @@ define i64 @f_i32_sign_extend_i64(i32 %in, i64 %a, i64 %b) nounwind {
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    // kill: def $w0 killed $w0 def $x0
 ; CHECK-NEXT:    sxtw x8, w0
-; CHECK-NEXT:    cmn x8, #1
-; CHECK-NEXT:    csel x8, x1, x2, gt
+; CHECK-NEXT:    cmp x8, #0
+; CHECK-NEXT:    csel x8, x1, x2, pl
 ; CHECK-NEXT:    add x0, x8, w0, uxtw
 ; CHECK-NEXT:    ret
 entry:

--- a/llvm/test/CodeGen/AArch64/cmp-to-cmn.ll
+++ b/llvm/test/CodeGen/AArch64/cmp-to-cmn.ll
@@ -501,281 +501,161 @@ define i1 @cmn_large_imm(i32 %a) {
 }
 
 define i1 @almost_immediate_neg_slt(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_slt:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, le
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_slt:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #4097 // =0x1001
-; CHECK-GI-NEXT:    movk w8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, lt
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_slt:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, le
+; CHECK-NEXT:    ret
   %cmp = icmp slt i32 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_slt_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_slt_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, le
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_slt_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-61439 // =0xffffffffffff1001
-; CHECK-GI-NEXT:    movk x8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, lt
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_slt_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, le
+; CHECK-NEXT:    ret
   %cmp = icmp slt i64 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_sge(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_sge:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, gt
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_sge:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #4097 // =0x1001
-; CHECK-GI-NEXT:    movk w8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, ge
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_sge:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, gt
+; CHECK-NEXT:    ret
   %cmp = icmp sge i32 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_sge_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_sge_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, gt
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_sge_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-61439 // =0xffffffffffff1001
-; CHECK-GI-NEXT:    movk x8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, ge
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_sge_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, gt
+; CHECK-NEXT:    ret
   %cmp = icmp sge i64 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_uge(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_uge:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, hi
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_uge:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #4097 // =0x1001
-; CHECK-GI-NEXT:    movk w8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, hs
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_uge:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, hi
+; CHECK-NEXT:    ret
   %cmp = icmp uge i32 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_uge_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_uge_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, hi
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_uge_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-61439 // =0xffffffffffff1001
-; CHECK-GI-NEXT:    movk x8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, hs
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_uge_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, hi
+; CHECK-NEXT:    ret
   %cmp = icmp uge i64 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_ult(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_ult:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, ls
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_ult:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #4097 // =0x1001
-; CHECK-GI-NEXT:    movk w8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, lo
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_ult:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, ls
+; CHECK-NEXT:    ret
   %cmp = icmp ult i32 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_ult_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_ult_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4079, lsl #12 // =16707584
-; CHECK-SD-NEXT:    cset w0, ls
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_ult_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-61439 // =0xffffffffffff1001
-; CHECK-GI-NEXT:    movk x8, #65281, lsl #16
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, lo
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_ult_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4079, lsl #12 // =16707584
+; CHECK-NEXT:    cset w0, ls
+; CHECK-NEXT:    ret
   %cmp = icmp ult i64 %x, -16707583
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_sle(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_sle:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, lt
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_sle:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #-16773121 // =0xff000fff
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, le
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_sle:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, lt
+; CHECK-NEXT:    ret
   %cmp = icmp sle i32 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_sle_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_sle_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, lt
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_sle_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-16773121 // =0xffffffffff000fff
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, le
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_sle_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, lt
+; CHECK-NEXT:    ret
   %cmp = icmp sle i64 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_sgt(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_sgt:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, ge
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_sgt:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #-16773121 // =0xff000fff
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, gt
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_sgt:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, ge
+; CHECK-NEXT:    ret
   %cmp = icmp sgt i32 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_sgt_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_sgt_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, ge
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_sgt_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-16773121 // =0xffffffffff000fff
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, gt
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_sgt_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, ge
+; CHECK-NEXT:    ret
   %cmp = icmp sgt i64 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_ule(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_ule:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, lo
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_ule:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #-16773121 // =0xff000fff
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, ls
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_ule:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, lo
+; CHECK-NEXT:    ret
   %cmp = icmp ule i32 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_ule_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_ule_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, lo
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_ule_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-16773121 // =0xffffffffff000fff
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, ls
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_ule_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, lo
+; CHECK-NEXT:    ret
   %cmp = icmp ule i64 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_ugt(i32 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_ugt:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, hs
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_ugt:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov w8, #-16773121 // =0xff000fff
-; CHECK-GI-NEXT:    cmp w0, w8
-; CHECK-GI-NEXT:    cset w0, hi
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_ugt:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn w0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, hs
+; CHECK-NEXT:    ret
   %cmp = icmp ugt i32 %x, -16773121
   ret i1 %cmp
 }
 
 define i1 @almost_immediate_neg_ugt_64(i64 %x) {
-; CHECK-SD-LABEL: almost_immediate_neg_ugt_64:
-; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn x0, #4095, lsl #12 // =16773120
-; CHECK-SD-NEXT:    cset w0, hs
-; CHECK-SD-NEXT:    ret
-;
-; CHECK-GI-LABEL: almost_immediate_neg_ugt_64:
-; CHECK-GI:       // %bb.0:
-; CHECK-GI-NEXT:    mov x8, #-16773121 // =0xffffffffff000fff
-; CHECK-GI-NEXT:    cmp x0, x8
-; CHECK-GI-NEXT:    cset w0, hi
-; CHECK-GI-NEXT:    ret
+; CHECK-LABEL: almost_immediate_neg_ugt_64:
+; CHECK:       // %bb.0:
+; CHECK-NEXT:    cmn x0, #4095, lsl #12 // =16773120
+; CHECK-NEXT:    cset w0, hs
+; CHECK-NEXT:    ret
   %cmp = icmp ugt i64 %x, -16773121
   ret i1 %cmp
 }

--- a/llvm/test/CodeGen/AArch64/fptosi-sat-scalar.ll
+++ b/llvm/test/CodeGen/AArch64/fptosi-sat-scalar.ll
@@ -33,8 +33,8 @@ define i1 @test_signed_i1_f32(float %f) nounwind {
 ; CHECK-GI-NEXT:    fcvtzs w8, s0
 ; CHECK-GI-NEXT:    cmp w8, #0
 ; CHECK-GI-NEXT:    csel w8, w8, wzr, mi
-; CHECK-GI-NEXT:    cmp w8, #0
-; CHECK-GI-NEXT:    csinv w8, w8, wzr, pl
+; CHECK-GI-NEXT:    cmn w8, #1
+; CHECK-GI-NEXT:    csinv w8, w8, wzr, gt
 ; CHECK-GI-NEXT:    and w0, w8, #0x1
 ; CHECK-GI-NEXT:    ret
     %x = call i1 @llvm.fptosi.sat.i1.f32(float %f)
@@ -278,8 +278,8 @@ define i1 @test_signed_i1_f64(double %f) nounwind {
 ; CHECK-GI-NEXT:    fcvtzs w8, d0
 ; CHECK-GI-NEXT:    cmp w8, #0
 ; CHECK-GI-NEXT:    csel w8, w8, wzr, mi
-; CHECK-GI-NEXT:    cmp w8, #0
-; CHECK-GI-NEXT:    csinv w8, w8, wzr, pl
+; CHECK-GI-NEXT:    cmn w8, #1
+; CHECK-GI-NEXT:    csinv w8, w8, wzr, gt
 ; CHECK-GI-NEXT:    and w0, w8, #0x1
 ; CHECK-GI-NEXT:    ret
     %x = call i1 @llvm.fptosi.sat.i1.f64(double %f)
@@ -537,8 +537,8 @@ define i1 @test_signed_i1_f16(half %f) nounwind {
 ; CHECK-GI-CVT-NEXT:    fcvtzs w8, s0
 ; CHECK-GI-CVT-NEXT:    cmp w8, #0
 ; CHECK-GI-CVT-NEXT:    csel w8, w8, wzr, mi
-; CHECK-GI-CVT-NEXT:    cmp w8, #0
-; CHECK-GI-CVT-NEXT:    csinv w8, w8, wzr, pl
+; CHECK-GI-CVT-NEXT:    cmn w8, #1
+; CHECK-GI-CVT-NEXT:    csinv w8, w8, wzr, gt
 ; CHECK-GI-CVT-NEXT:    and w0, w8, #0x1
 ; CHECK-GI-CVT-NEXT:    ret
 ;
@@ -547,8 +547,8 @@ define i1 @test_signed_i1_f16(half %f) nounwind {
 ; CHECK-GI-FP16-NEXT:    fcvtzs w8, h0
 ; CHECK-GI-FP16-NEXT:    cmp w8, #0
 ; CHECK-GI-FP16-NEXT:    csel w8, w8, wzr, mi
-; CHECK-GI-FP16-NEXT:    cmp w8, #0
-; CHECK-GI-FP16-NEXT:    csinv w8, w8, wzr, pl
+; CHECK-GI-FP16-NEXT:    cmn w8, #1
+; CHECK-GI-FP16-NEXT:    csinv w8, w8, wzr, gt
 ; CHECK-GI-FP16-NEXT:    and w0, w8, #0x1
 ; CHECK-GI-FP16-NEXT:    ret
     %x = call i1 @llvm.fptosi.sat.i1.f16(half %f)

--- a/llvm/test/CodeGen/AArch64/select-constant-xor.ll
+++ b/llvm/test/CodeGen/AArch64/select-constant-xor.ll
@@ -168,8 +168,8 @@ define i32 @icmpasreq(i32 %input, i32 %a, i32 %b) {
 define i32 @icmpasrne(i32 %input, i32 %a, i32 %b) {
 ; CHECK-SD-LABEL: icmpasrne:
 ; CHECK-SD:       // %bb.0:
-; CHECK-SD-NEXT:    cmn w0, #1
-; CHECK-SD-NEXT:    csel w0, w1, w2, gt
+; CHECK-SD-NEXT:    cmp w0, #0
+; CHECK-SD-NEXT:    csel w0, w1, w2, pl
 ; CHECK-SD-NEXT:    ret
 ;
 ; CHECK-GI-LABEL: icmpasrne:

--- a/llvm/test/CodeGen/AArch64/signbit-shift.ll
+++ b/llvm/test/CodeGen/AArch64/signbit-shift.ll
@@ -43,8 +43,8 @@ define i32 @sel_ifpos_tval_bigger(i32 %x) {
 ; CHECK-LABEL: sel_ifpos_tval_bigger:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov w8, #41 // =0x29
-; CHECK-NEXT:    cmn w0, #1
-; CHECK-NEXT:    cinc w0, w8, gt
+; CHECK-NEXT:    cmp w0, #0
+; CHECK-NEXT:    cinc w0, w8, pl
 ; CHECK-NEXT:    ret
   %c = icmp sgt i32 %x, -1
   %r = select i1 %c, i32 42, i32 41
@@ -91,8 +91,8 @@ define i32 @sel_ifpos_fval_bigger(i32 %x) {
 ; CHECK-LABEL: sel_ifpos_fval_bigger:
 ; CHECK:       // %bb.0:
 ; CHECK-NEXT:    mov w8, #41 // =0x29
-; CHECK-NEXT:    cmn w0, #1
-; CHECK-NEXT:    cinc w0, w8, le
+; CHECK-NEXT:    cmp w0, #0
+; CHECK-NEXT:    cinc w0, w8, mi
 ; CHECK-NEXT:    ret
   %c = icmp sgt i32 %x, -1
   %r = select i1 %c, i32 41, i32 42

--- a/llvm/test/CodeGen/AArch64/signbit-test.ll
+++ b/llvm/test/CodeGen/AArch64/signbit-test.ll
@@ -5,8 +5,8 @@ define i64 @test_clear_mask_i64_i32(i64 %x) nounwind {
 ; CHECK-LABEL: test_clear_mask_i64_i32:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    mov w8, #42 // =0x2a
-; CHECK-NEXT:    cmn w0, #1
-; CHECK-NEXT:    csel x0, x8, x0, gt
+; CHECK-NEXT:    cmp w0, #0
+; CHECK-NEXT:    csel x0, x8, x0, pl
 ; CHECK-NEXT:    ret
 entry:
   %a = and i64 %x, 2147483648

--- a/llvm/test/CodeGen/AArch64/typepromotion-signed.ll
+++ b/llvm/test/CodeGen/AArch64/typepromotion-signed.ll
@@ -60,9 +60,9 @@ define i32 @test_signext_b(ptr nocapture readonly %ptr, i8 signext %arg) {
 ; CHECK-NEXT:    mov w8, #20894 // =0x519e
 ; CHECK-NEXT:    add w9, w9, w1
 ; CHECK-NEXT:    sxtb w9, w9
-; CHECK-NEXT:    cmn w9, #1
+; CHECK-NEXT:    cmp w9, #0
 ; CHECK-NEXT:    mov w9, #42 // =0x2a
-; CHECK-NEXT:    csel w0, w9, w8, gt
+; CHECK-NEXT:    csel w0, w9, w8, pl
 ; CHECK-NEXT:    ret
 entry:
   %0 = load i8, ptr %ptr, align 1
@@ -100,9 +100,9 @@ define i32 @test_signext_h(ptr nocapture readonly %ptr, i16 signext %arg) {
 ; CHECK-NEXT:    mov w8, #20894 // =0x519e
 ; CHECK-NEXT:    add w9, w9, w1
 ; CHECK-NEXT:    sxth w9, w9
-; CHECK-NEXT:    cmn w9, #1
+; CHECK-NEXT:    cmp w9, #0
 ; CHECK-NEXT:    mov w9, #42 // =0x2a
-; CHECK-NEXT:    csel w0, w9, w8, gt
+; CHECK-NEXT:    csel w0, w9, w8, pl
 ; CHECK-NEXT:    ret
 entry:
   %0 = load i16, ptr %ptr, align 1


### PR DESCRIPTION
To undo the mitigations, shouldBeAdjustedToZero also includes one-use checks for cmn 1 to cmp 0 because of the pl/mi favoritism. This was also brought to SelectionDAG.