### PR TITLE
[clang][AST] Added assert to prevent infinite recursion in computing layout

### DIFF
--- a/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -187,6 +187,7 @@ void EmptySubobjectMap::ComputeEmptySubobjectSizes() {
   // Check the bases.
   for (const CXXBaseSpecifier &Base : Class->bases()) {
     const CXXRecordDecl *BaseDecl = Base.getType()->getAsCXXRecordDecl();
+    assert(BaseDecl != Class && "Class cannot inherit from itself.");
 
     CharUnits EmptySize;
     const ASTRecordLayout &Layout = Context.getASTRecordLayout(BaseDecl);


### PR DESCRIPTION
While computing class layout, I met with infinite recursion. This happened while executing user expression in lldb as record type was incorrectly received from dwarf. This assert will replace the infinite recursion with an error and will simplify further debugging of such cases.