### PR TITLE
[flang] Include flang in Windows Installer

### DIFF
--- a/llvm/utils/release/build_llvm_release.bat
+++ b/llvm/utils/release/build_llvm_release.bat
@@ -165,7 +165,7 @@ set common_cmake_flags=^
   -DCMAKE_C_FLAGS="%common_compiler_flags%" ^
   -DCMAKE_CXX_FLAGS="%common_compiler_flags%" ^
   -DLLVM_ENABLE_RPMALLOC=ON ^
-  -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;compiler-rt;lldb;openmp"
+  -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;compiler-rt;lldb;openmp;flang"
 
 if "%force-msvc%" == "" (
   where /q clang-cl


### PR DESCRIPTION
Copy of/supersedes #153618 with email connected to author

As far as I understood the current history of things, flang should be available as a binary but no one seems to have informed the Windows installer script about that.

Might also need -DFLANG_PARALLEL_COMPILE_JOBS=1 ?

Related
https://github.com/llvm/llvm-project/issues/112789
https://blog.llvm.org/posts/2025-03-11-flang-new/

closes
https://github.com/llvm/llvm-project/issues/113033

cc @tstellar @h-vetinari