### PR TITLE
[CI] Run LLDB tests on Clang changes in pre-merge CI

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -49,8 +49,7 @@ DEPENDENTS_TO_TEST = {
         "flang",
     },
     "lld": {"bolt", "cross-project-tests"},
-    # TODO(issues/132795): LLDB should be enabled on clang changes.
-    "clang": {"clang-tools-extra", "cross-project-tests"},
+    "clang": {"clang-tools-extra", "cross-project-tests", "lldb"},
     "mlir": {"flang"},
     # Test everything if ci scripts are changed.
     ".ci": {

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -162,7 +162,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-cir check-clang-tools",
+            "check-clang check-clang-cir check-clang-tools check-lldb",
         )
         self.assertEqual(
             env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -83,11 +83,11 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;llvm",
+            "clang;clang-tools-extra;lld;lldb;llvm",
         )
         self.assertEqual(
             env_variables["project_check_targets"],
-            "check-clang check-clang-tools",
+            "check-clang check-clang-tools check-lldb",
         )
         self.assertEqual(
             env_variables["runtimes_to_build"], "compiler-rt;libcxx;libcxxabi;libunwind"
@@ -158,7 +158,7 @@ class TestComputeProjects(unittest.TestCase):
         )
         self.assertEqual(
             env_variables["projects_to_build"],
-            "clang;clang-tools-extra;lld;llvm;mlir",
+            "clang;clang-tools-extra;lld;lldb;llvm;mlir",
         )
         self.assertEqual(
             env_variables["project_check_targets"],


### PR DESCRIPTION
This attempts https://github.com/llvm/llvm-project/issues/132795 again. Last time we tried this we didn't have enough infra capacity, so had to revert. According to recent communication from the Infrastructure Area Team, we should now have enough capacity to re-enable the LLDB tests.