### PR TITLE
Revert "[lldb] Relax the error message in TestProcessCrashInfo.py"

### DIFF
--- a/lldb/test/API/functionalities/process_crash_info/TestProcessCrashInfo.py
+++ b/lldb/test/API/functionalities/process_crash_info/TestProcessCrashInfo.py
@@ -38,7 +38,7 @@ class PlatformProcessCrashInfoTestCase(TestBase):
             patterns=[
                 "Extended Crash Information",
                 "Crash-Info Annotations",
-                "BUG IN CLIENT OF LIBMALLOC",
+                "pointer being freed was not allocated",
             ],
         )
 
@@ -67,7 +67,7 @@ class PlatformProcessCrashInfoTestCase(TestBase):
 
         self.assertTrue(crash_info.IsValid())
 
-        self.assertIn("BUG IN CLIENT OF LIBMALLOC", stream.GetData())
+        self.assertIn("pointer being freed was not allocated", stream.GetData())
 
     # dyld leaves permanent crash_info records when testing on device.
     @skipIfDarwinEmbedded


### PR DESCRIPTION
Reverts llvm/llvm-project#153653 because older versions of macOS do not use the same prefix.