### PR TITLE
[BOLT] Fix perf2bolt/perf_test.test

### DIFF
--- a/bolt/test/perf2bolt/Inputs/perf_test.lds
+++ b/bolt/test/perf2bolt/Inputs/perf_test.lds
@@ -1,13 +1,12 @@
 SECTIONS {
-  . = SIZEOF_HEADERS;
+  . = 0x400000 + SIZEOF_HEADERS;
   .interp : { *(.interp) }
   .note.gnu.build-id : { *(.note.gnu.build-id) }
-  . = 0x212e8;
   .dynsym         : { *(.dynsym) }
-  . = 0x31860;
+  . = 0x801000;
   .text : { *(.text*) }
-  . = 0x41c20;
+  . = 0x803000;
   .fini_array : { *(.fini_array) }
-  . = 0x54e18;
+  . = 0x805000;
   .data : { *(.data) }
 }

--- a/bolt/test/perf2bolt/Inputs/perf_test.lds
+++ b/bolt/test/perf2bolt/Inputs/perf_test.lds
@@ -1,12 +1,13 @@
 SECTIONS {
-  . = 0x400000 + SIZEOF_HEADERS;
+  . = SIZEOF_HEADERS;
   .interp : { *(.interp) }
   .note.gnu.build-id : { *(.note.gnu.build-id) }
+  . = 0x212e8;
   .dynsym         : { *(.dynsym) }
-  . = 0x801000;
+  . = 0x31860;
   .text : { *(.text*) }
-  . = 0x803000;
+  . = 0x41c20;
   .fini_array : { *(.fini_array) }
-  . = 0x805000;
+  . = 0x54e18;
   .data : { *(.data) }
 }

--- a/bolt/test/perf2bolt/perf_test.test
+++ b/bolt/test/perf2bolt/perf_test.test
@@ -2,7 +2,7 @@
 
 REQUIRES: system-linux, perf
 
-RUN: %clang %S/Inputs/perf_test.c -fuse-ld=lld -Wl,--script=%S/Inputs/perf_test.lds -o %t
+RUN: %clang %S/Inputs/perf_test.c -fuse-ld=lld -pie -Wl,--script=%S/Inputs/perf_test.lds -o %t
 RUN: perf record -Fmax -e cycles:u -o %t2 -- %t
 RUN: perf2bolt %t -p=%t2 -o %t3 -nl -ignore-build-id --show-density \
 RUN:   --heatmap %t.hm 2>&1 | FileCheck %s


### PR DESCRIPTION
The original test crashed with segmentation fault:

` perf_test.test.script: line 8: 1470352 Segmentation fault      (core dumped) perf record -Fmax -e cycles:u -o /home/gpastukhov/llvm-build-release/tools/bolt/test/perf2bolt/Output/perf_test.test.tmp2 -- /home/gpastukhov/llvm-build-release/tools/bolt/test/perf2bolt/Output/perf_test.test.tmp
`

The crash happens if the compiler set up not to build PIE by default, however the test expects PIE.