### PR TITLE
[Clang] Only enable builtins on aux triple if supported by language

### DIFF
--- a/clang/lib/Basic/Builtins.cpp
+++ b/clang/lib/Basic/Builtins.cpp
@@ -225,7 +225,8 @@ void Builtin::Context::initializeBuiltins(IdentifierTable &Table,
     // Step #3: Register target-specific builtins for AuxTarget.
     for (const auto &Shard : AuxTargetShards)
       for (const auto &I : Shard.Infos) {
-        Table.get(I.getName(Shard)).setBuiltinID(ID);
+        if (builtinIsSupported(*Shard.Strings, I, LangOpts))
+          Table.get(I.getName(Shard)).setBuiltinID(ID);
         ++ID;
       }
   }

--- a/clang/lib/Headers/cpuid.h
+++ b/clang/lib/Headers/cpuid.h
@@ -345,15 +345,10 @@ static __inline int __get_cpuid_count (unsigned int __leaf,
 // In some configurations, __cpuidex is defined as a builtin (primarily
 // -fms-extensions) which will conflict with the __cpuidex definition below.
 #if !(__has_builtin(__cpuidex))
-// In some cases, offloading will set the host as the aux triple and define the
-// builtin. Given __has_builtin does not detect builtins on aux triples, we need
-// to explicitly check for some offloading cases.
-#ifndef __NVPTX__
 static __inline void __cpuidex(int __cpu_info[4], int __leaf, int __subleaf) {
   __cpuid_count(__leaf, __subleaf, __cpu_info[0], __cpu_info[1], __cpu_info[2],
                 __cpu_info[3]);
 }
-#endif
 #endif
 
 #endif /* __CPUID_H */

--- a/clang/test/Headers/__cpuidex_conflict.c
+++ b/clang/test/Headers/__cpuidex_conflict.c
@@ -5,7 +5,7 @@
 
 // Ensure that we do not run into conflicts when offloading.
 // RUN: %clang_cc1 %s -DIS_STATIC=static -ffreestanding -fopenmp -fopenmp-is-target-device -aux-triple x86_64-unknown-linux-gnu
-// RUN: %clang_cc1 -DIS_STATIC="" -triple nvptx64-nvidia-cuda -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu x86-64 -fcuda-is-device -internal-isystem /home/gha/llvm-project/build/lib/clang/22/include -x cuda %s -o -
+// RUN: %clang_cc1 -DIS_STATIC=static -triple nvptx64-nvidia-cuda -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu x86-64 -fcuda-is-device -x cuda %s -o -
 
 typedef __SIZE_TYPE__ size_t;
 


### PR DESCRIPTION
This patch makes it so that builtins for the aux triple only get enabled if they are marked as supported by the current language options. Otherwise we define them regardless of the language mode. This can cause issues in certain scenarios, like if someone has a definition that conflicts with a builtin gated behind __has_builtin, because __has_builtin will return false given the builtin is only enabled on the aux triple despite the builtin actually being enabled.

This is best exemplified with the __cpuidex conflict test.

Fixes #152558.