### PR TITLE
[Github] Remove redundant 'START_REV', 'END_REV' env variables (NFC)

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -70,8 +70,6 @@ jobs:
       - name: Run code formatter
         env:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
-          START_REV: ${{ github.event.pull_request.base.sha }}
-          END_REV: ${{ github.event.pull_request.head.sha }}
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         # Create an empty comments file so the pr-write job doesn't fail.
         run: |


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/133023, `START_REV` and `END_REV` env variables became redundant.