### PR TITLE
[llvm-c] Guard include of llvm-config in Visibility.h

### DIFF
--- a/llvm/include/llvm-c/Visibility.h
+++ b/llvm/include/llvm-c/Visibility.h
@@ -16,7 +16,11 @@
 #ifndef LLVM_C_VISIBILITY_H
 #define LLVM_C_VISIBILITY_H
 
+#if defined __has_include
+#if __has_include("llvm/Config/llvm-config.h")
 #include "llvm/Config/llvm-config.h"
+#endif
+#endif
 
 /// LLVM_C_ABI is the export/visibility macro used to mark symbols declared in
 /// llvm-c as exported when built as a shared library.


### PR DESCRIPTION
`Visibility.h` defines common macro for being explicit about symbol visibility, instead of relying on defaults that may not be the same on a given platform/toolchain set, and is installed with `llvm-c` API headers.

However, it checks against configuration macros defined by a separate header not installed with `llvm-c`, to support distribution without this dependency, add an include guard. 