### PR TITLE
[clang][timers][modules] Fix a timer being started when it's running

### DIFF
--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -526,6 +526,9 @@ private:
   /// A timer used to track the time spent deserializing.
   std::unique_ptr<llvm::Timer> ReadTimer;
 
+  // A TimeRegion used to start and stop ReadTimer via RAII.
+  std::optional<llvm::TimeRegion> ReadTimeRegion;
+
   /// The location where the module file will be considered as
   /// imported from. For non-module AST types it should be invalid.
   SourceLocation CurrentImportLoc;

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -11003,7 +11003,8 @@ void ASTReader::diagnoseOdrViolations() {
 }
 
 void ASTReader::StartedDeserializing() {
-  if (++NumCurrentElementsDeserializing == 1 && ReadTimer.get())
+  if (Timer *T = ReadTimer.get();
+      ++NumCurrentElementsDeserializing == 1 && T && !T->isRunning())
     ReadTimer->startTimer();
 }
 

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -11003,7 +11003,7 @@ void ASTReader::diagnoseOdrViolations() {
 }
 
 void ASTReader::StartedDeserializing() {
-  if (Timer *T = ReadTimer.get();
+  if (llvm::Timer *T = ReadTimer.get();
       ++NumCurrentElementsDeserializing == 1 && T && !T->isRunning())
     ReadTimer->startTimer();
 }

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -11005,7 +11005,7 @@ void ASTReader::diagnoseOdrViolations() {
 void ASTReader::StartedDeserializing() {
   if (llvm::Timer *T = ReadTimer.get();
       ++NumCurrentElementsDeserializing == 1 && T && !T->isRunning())
-    ReadTimer->startTimer();
+    T->startTimer();
 }
 
 void ASTReader::FinishedDeserializing() {

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -11004,8 +11004,8 @@ void ASTReader::diagnoseOdrViolations() {
 
 void ASTReader::StartedDeserializing() {
   if (llvm::Timer *T = ReadTimer.get();
-      ++NumCurrentElementsDeserializing == 1 && T && !T->isRunning())
-    T->startTimer();
+      ++NumCurrentElementsDeserializing == 1 && T)
+    ReadTimeRegion.emplace(T);
 }
 
 void ASTReader::FinishedDeserializing() {
@@ -11063,8 +11063,7 @@ void ASTReader::FinishedDeserializing() {
           (void)UndeducedFD->getMostRecentDecl();
       }
 
-      if (ReadTimer)
-        ReadTimer->stopTimer();
+      ReadTimeRegion.reset();
 
       diagnoseOdrViolations();
     }


### PR DESCRIPTION
`ASTReader::FinishedDeserializing()` calls
`adjustDeductedFunctionResultType(...)` [0], which in turn calls `FunctionDecl::getMostRecentDecl()`[1]. In modules builds, `getMostRecentDecl()` may reach out to the `ASTReader` and start deserializing again. Starting deserialization starts `ReadTimer`; however, `FinishedDeserializing()` doesn't call `stopTimer()` until after it's call to `adjustDeductedFunctionResultType(...)` [2]. As a result, we hit an assert checking that we don't start an already started timer [3]. To fix this, we simply don't start the timer if it's already running.

Unfortunately I don't have a test case for this yet as modules builds are notoriously difficult to reduce.

[0]: https://github.com/llvm/llvm-project/blob/4d2288d31866013bd361800df4746fbc2fcf742a/clang/lib/Serialization/ASTReader.cpp#L11053
[1]: https://github.com/llvm/llvm-project/blob/4d2288d31866013bd361800df4746fbc2fcf742a/clang/lib/AST/ASTContext.cpp#L3804
[2]: https://github.com/llvm/llvm-project/blob/4d2288d31866013bd361800df4746fbc2fcf742a/clang/lib/Serialization/ASTReader.cpp#L11065-L11066
[3]: https://github.com/llvm/llvm-project/blob/4d2288d31866013bd361800df4746fbc2fcf742a/llvm/lib/Support/Timer.cpp#L150