### PR TITLE
[Sanitizers][Test] narrower constraint for XFAIL

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
@@ -16,7 +16,7 @@
 // UNSUPPORTED: ios
 
 // Symbolizer fails to find test functions on current macOS bot version
-// XFAIL: target=arm{{.*}}
+// XFAIL: system-darwin && target=arm{{.*}}
 
 #include <CoreFoundation/CoreFoundation.h>
 

--- a/compiler-rt/test/asan/TestCases/Posix/fread_fwrite.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/fread_fwrite.cpp
@@ -3,7 +3,7 @@
 // RUN: not %run %t 1 2>&1 | FileCheck %s --check-prefix=CHECK-FREAD
 
 // Symbolizer fails to find test functions on current macOS bot version
-// XFAIL: target=arm{{.*}}
+// XFAIL: system-darwin && target=arm{{.*}}
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
It's a followup to https://github.com/llvm/llvm-project/pull/154189 ,
which broke test on android bot. Making sure XFAIL only happen on darwin
bots

rdar://158543555
