### PR TITLE
InstCombine: fold(select C, (X | A), X) | B into X | select C, (A | B), B. (#154246)

### DIFF
--- a/llvm/test/Transforms/InstCombine/or-select-factor.ll
+++ b/llvm/test/Transforms/InstCombine/or-select-factor.ll
@@ -1,0 +1,33 @@
+; RUN: opt -passes=instcombine -S < %s | FileCheck %s
+
+; Fold: (select C, (x | a), x) | b  ->  x | select C, (a | b), b
+
+define i8 @src(i8 %x, i8 %y) {
+; CHECK-LABEL: @src(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[Y:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = or i8 [[X:%.*]], 4
+; CHECK-NEXT:    [[V2:%.*]] = select i1 [[V0]], i8 [[V1]], i8 [[X]]
+; CHECK-NEXT:    [[V3:%.*]] = or i8 [[V2]], 1
+; CHECK-NEXT:    ret i8 [[V3]]
+;
+  %v0 = icmp eq i8 %y, -1
+  %v1 = or i8 %x, 4
+  %v2 = select i1 %v0, i8 %v1, i8 %x
+  %v3 = or i8 %v2, 1
+  ret i8 %v3
+}
+
+define i8 @tgt(i8 %x, i8 %y) {
+; CHECK-LABEL: @tgt(
+; CHECK-NEXT:    [[V0:%.*]] = icmp eq i8 [[Y:%.*]], -1
+; CHECK-NEXT:    [[V1:%.*]] = select i1 [[V0]], i8 5, i8 1
+; CHECK-NEXT:    [[V2:%.*]] = or i8 [[X:%.*]], [[V1]]
+; CHECK-NEXT:    ret i8 [[V2]]
+;
+  %v0 = icmp eq i8 %y, -1
+  %v1 = select i1 %v0, i8 5, i8 1
+  %v2 = or i8 %x, %v1
+  ret i8 %v2
+}
+
+


### PR DESCRIPTION
Fixes #154246 
Hello, 

I noticed that the InstCombine was missing a simple factoring opportunity when a select feeds a bitwise-or.
For Example in patterns like : 
1. (select C, (X | A), X) | B
2. (select C, X, (X | A)) | B
we can pull the X out and rewrite the canonical and optimized form as follows : 
1. X | select C, (A | B), B
2. X | select C, B, (A | B)

I added a fold in visitOr that recognizes those shapes (including the commuted outer-or) and performs the required rewrite.
and also I placed it before the generic "push constant into select arms" fold so we dont lose the structure we need to factor the X cleanly.

I have also added a test at llvm/test/Transforms/InstCombine/or-select-factor.ll to cover this transformation.

No other files or changes were made.