### PR TITLE
[MLIR][DialectConversion] Export isOpIgnored in ConversionPatternRewriter

### DIFF
--- a/mlir/include/mlir/Transforms/DialectConversion.h
+++ b/mlir/include/mlir/Transforms/DialectConversion.h
@@ -862,6 +862,9 @@ public:
   /// Return a reference to the internal implementation.
   detail::ConversionPatternRewriterImpl &getImpl();
 
+  /// Return "true" if the given operation was replaced or erased.
+  bool isOpIgnored(Operation *op) const;
+
 private:
   // Allow OperationConverter to construct new rewriters.
   friend struct OperationConverter;

--- a/mlir/lib/Transforms/Utils/DialectConversion.cpp
+++ b/mlir/lib/Transforms/Utils/DialectConversion.cpp
@@ -2245,6 +2245,10 @@ detail::ConversionPatternRewriterImpl &ConversionPatternRewriter::getImpl() {
   return *impl;
 }
 
+bool ConversionPatternRewriter::isOpIgnored(Operation *op) const {
+  return getImpl()->isOpIgnored(op);
+}
+
 //===----------------------------------------------------------------------===//
 // ConversionPattern
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This is particularly helpful for more complex dialect conversion patterns which conditionally apply given the subject of an analysis of the non-deleted operations