### PR TITLE
[flang] `do concurrent`: Enable delayed localization by default

### DIFF
--- a/flang/lib/Lower/Bridge.cpp
+++ b/flang/lib/Lower/Bridge.cpp
@@ -2064,8 +2064,7 @@ private:
     // TODO Promote to using `enableDelayedPrivatization` (which is enabled by
     // default unlike the staging flag) once the implementation of this is more
     // complete.
-    bool useDelayedPriv =
-        enableDelayedPrivatizationStaging && doConcurrentLoopOp;
+    bool useDelayedPriv = enableDelayedPrivatization && doConcurrentLoopOp;
     llvm::SetVector<const Fortran::semantics::Symbol *> allPrivatizedSymbols;
     llvm::SmallSet<const Fortran::semantics::Symbol *, 16> mightHaveReadHostSym;
 


### PR DESCRIPTION
Enables delayed localization by default for `do concurrent`. Tested both gfortran and Fujitsu test suites.

All tests pass for gfortran tests. For Fujitsu, enabled delayed localization passes more tests:

Delayed localization disabled:
Testing Time: 7251.76s
  Passed            : 88520
  Failed            :   162
  Executable Missing:   408

Delayed localization enabled:
Testing Time: 7216.73s
  Passed            : 88522
  Failed            :   160
  Executable Missing:   408