### PR TITLE
[Transforms] Allow non-regex Source in SymbolRewriter in case of using ExplicitRewriteDescriptor

### DIFF
--- a/llvm/lib/Transforms/Utils/SymbolRewriter.cpp
+++ b/llvm/lib/Transforms/Utils/SymbolRewriter.cpp
@@ -349,13 +349,7 @@ parseRewriteFunctionDescriptor(yaml::Stream &YS, yaml::ScalarNode *K,
 
     KeyValue = Key->getValue(KeyStorage);
     if (KeyValue == "source") {
-      std::string Error;
-
       Source = std::string(Value->getValue(ValueStorage));
-      if (!Regex(Source).isValid(Error)) {
-        YS.printError(Field.getKey(), "invalid regex: " + Error);
-        return false;
-      }
     } else if (KeyValue == "target") {
       Target = std::string(Value->getValue(ValueStorage));
     } else if (KeyValue == "transform") {
@@ -379,12 +373,22 @@ parseRewriteFunctionDescriptor(yaml::Stream &YS, yaml::ScalarNode *K,
 
   // TODO see if there is a more elegant solution to selecting the rewrite
   // descriptor type
-  if (!Target.empty())
+  if (!Target.empty()) {
     DL->push_back(std::make_unique<ExplicitRewriteFunctionDescriptor>(
         Source, Target, Naked));
-  else
-    DL->push_back(
-        std::make_unique<PatternRewriteFunctionDescriptor>(Source, Transform));
+    return true;
+  }
+
+  {
+    std::string Error;
+    if (!Regex(Source).isValid(Error)) {
+      YS.printError(Descriptor, "invalid Source regex: " + Error);
+      return false;
+    }
+  }
+
+  DL->push_back(
+      std::make_unique<PatternRewriteFunctionDescriptor>(Source, Transform));
 
   return true;
 }
@@ -418,13 +422,7 @@ parseRewriteGlobalVariableDescriptor(yaml::Stream &YS, yaml::ScalarNode *K,
 
     KeyValue = Key->getValue(KeyStorage);
     if (KeyValue == "source") {
-      std::string Error;
-
       Source = std::string(Value->getValue(ValueStorage));
-      if (!Regex(Source).isValid(Error)) {
-        YS.printError(Field.getKey(), "invalid regex: " + Error);
-        return false;
-      }
     } else if (KeyValue == "target") {
       Target = std::string(Value->getValue(ValueStorage));
     } else if (KeyValue == "transform") {
@@ -441,13 +439,23 @@ parseRewriteGlobalVariableDescriptor(yaml::Stream &YS, yaml::ScalarNode *K,
     return false;
   }
 
-  if (!Target.empty())
+  if (!Target.empty()) {
     DL->push_back(std::make_unique<ExplicitRewriteGlobalVariableDescriptor>(
         Source, Target,
         /*Naked*/ false));
-  else
-    DL->push_back(std::make_unique<PatternRewriteGlobalVariableDescriptor>(
-        Source, Transform));
+    return true;
+  }
+
+  {
+    std::string Error;
+    if (!Regex(Source).isValid(Error)) {
+      YS.printError(Descriptor, "invalid Source regex: " + Error);
+      return false;
+    }
+  }
+
+  DL->push_back(std::make_unique<PatternRewriteGlobalVariableDescriptor>(
+      Source, Transform));
 
   return true;
 }
@@ -481,13 +489,7 @@ parseRewriteGlobalAliasDescriptor(yaml::Stream &YS, yaml::ScalarNode *K,
 
     KeyValue = Key->getValue(KeyStorage);
     if (KeyValue == "source") {
-      std::string Error;
-
       Source = std::string(Value->getValue(ValueStorage));
-      if (!Regex(Source).isValid(Error)) {
-        YS.printError(Field.getKey(), "invalid regex: " + Error);
-        return false;
-      }
     } else if (KeyValue == "target") {
       Target = std::string(Value->getValue(ValueStorage));
     } else if (KeyValue == "transform") {
@@ -504,13 +506,23 @@ parseRewriteGlobalAliasDescriptor(yaml::Stream &YS, yaml::ScalarNode *K,
     return false;
   }
 
-  if (!Target.empty())
+  if (!Target.empty()) {
     DL->push_back(std::make_unique<ExplicitRewriteNamedAliasDescriptor>(
         Source, Target,
         /*Naked*/ false));
-  else
-    DL->push_back(std::make_unique<PatternRewriteNamedAliasDescriptor>(
-        Source, Transform));
+    return true;
+  }
+
+  {
+    std::string Error;
+    if (!Regex(Source).isValid(Error)) {
+      YS.printError(Descriptor, "invalid Source regex: " + Error);
+      return false;
+    }
+  }
+
+  DL->push_back(
+      std::make_unique<PatternRewriteNamedAliasDescriptor>(Source, Transform));
 
   return true;
 }

--- a/llvm/test/SymbolRewriter/rewrite.ll
+++ b/llvm/test/SymbolRewriter/rewrite.ll
@@ -46,6 +46,8 @@ $source_comdat_variable = comdat largest
 $source_comdat_variable_1 = comdat nodeduplicate
 @source_comdat_variable_1 = global i32 64, comdat($source_comdat_variable_1)
 
+declare void @"?source_bad.$regex_function"()
+
 ; CHECK: $target_comdat_function = comdat any
 ; CHECK: $target_comdat_function_1 = comdat exactmatch
 ; CHECK: $target_comdat_variable = comdat largest
@@ -90,3 +92,5 @@ $source_comdat_variable_1 = comdat nodeduplicate
 ; CHECK: define dllexport void @target_comdat_function_1() comdat
 ; CHECK-NOT: define dllexport void @source_comdat_function_1() comdat
 
+; CHECK: declare void @target_bad_regex_function()
+; CHECK-NOT: declare void @"?source_bad.$regex_function"()

--- a/llvm/test/SymbolRewriter/rewrite.ll
+++ b/llvm/test/SymbolRewriter/rewrite.ll
@@ -46,7 +46,11 @@ $source_comdat_variable = comdat largest
 $source_comdat_variable_1 = comdat nodeduplicate
 @source_comdat_variable_1 = global i32 64, comdat($source_comdat_variable_1)
 
-declare void @"?source_bad.$regex_function"()
+declare void @"?source_bad_regex_function"()
+
+@"?source_bad_regex_variable" = external global i32
+
+@"?source_bad_regex_alias" = alias void (ptr), ptr @_ZN1SC2Ev
 
 ; CHECK: $target_comdat_function = comdat any
 ; CHECK: $target_comdat_function_1 = comdat exactmatch
@@ -63,6 +67,12 @@ declare void @"?source_bad.$regex_function"()
 ; CHECK-NOT: @source_comdat_variable = global i32 32, comdat
 ; CHECK: @target_comdat_variable_1 = global i32 64, comdat
 ; CHECK-NOT: @source_comdat_variable_1 = global i32 64, comdat
+
+; CHECK: @target_bad_regex_variable = external global i32
+; CHECK-NOT: @"?source_bad_regex_variable" = external global i32
+
+; CHECK: @target_bad_regex_alias = alias void (ptr), ptr @_ZN1SC2Ev
+; CHECK-NOT: @"?source_bad_regex_alias" = alias void (ptr), ptr @_ZN1SC2Ev
 
 ; CHECK: declare void @target_function()
 ; CHECK-NOT: declare void @source_function()
@@ -93,4 +103,4 @@ declare void @"?source_bad.$regex_function"()
 ; CHECK-NOT: define dllexport void @source_comdat_function_1() comdat
 
 ; CHECK: declare void @target_bad_regex_function()
-; CHECK-NOT: declare void @"?source_bad.$regex_function"()
+; CHECK-NOT: declare void @"?source_bad_regex_function"()

--- a/llvm/test/SymbolRewriter/rewrite.map
+++ b/llvm/test/SymbolRewriter/rewrite.map
@@ -64,3 +64,7 @@ global variable: {
   transform: target_comdat_variable_\1,
 }
 
+function: {
+  source: ?source_bad.$regex_function,
+  target: target_bad_regex_function,
+}

--- a/llvm/test/SymbolRewriter/rewrite.map
+++ b/llvm/test/SymbolRewriter/rewrite.map
@@ -65,6 +65,16 @@ global variable: {
 }
 
 function: {
-  source: ?source_bad.$regex_function,
+  source: ?source_bad_regex_function,
   target: target_bad_regex_function,
+}
+
+global variable: {
+  source: ?source_bad_regex_variable,
+  target: target_bad_regex_variable,
+}
+
+global alias: {
+  source: ?source_bad_regex_alias,
+  target: target_bad_regex_alias,
 }


### PR DESCRIPTION
Do not check that Source is a valid regex in case of Target (explicit) transformation. Source may contain special symbols that may cause an incorrect `invalid regex` error.

Note that source and exactly one of [Target, Transform] must be provided.

`Target (explicit transformation)`: In this kind of rule `Source` is treated as a symbol name and is matched in its entirety. `Target` field will denote the symbol name to transform to.

`Transform (pattern transformation)`: This rule treats `Source` as a regex that should match the complete symbol name. `Transform` is a regex specifying the name to transform to.