### PR TITLE
[X86] canCreateUndefOrPoisonForTargetNode - add X86ISD::MOVMSK

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45152,6 +45152,9 @@ bool X86TargetLowering::canCreateUndefOrPoisonForTargetNode(
   case X86ISD::PCMPEQ:
   case X86ISD::PCMPGT:
     return false;
+  // SSE signbit extraction.
+  case X86ISD::MOVMSK:
+    return false;
   case ISD::INTRINSIC_WO_CHAIN:
     switch (Op->getConstantOperandVal(0)) {
     case Intrinsic::x86_sse2_pmadd_wd:

--- a/llvm/test/CodeGen/X86/combine-movmsk.ll
+++ b/llvm/test/CodeGen/X86/combine-movmsk.ll
@@ -489,24 +489,21 @@ define i32 @or_pmovmskb_pmovmskb(<16 x i8> %a0, <8 x i16> %a1) {
   ret i32 %7
 }
 
-; TODO: FREEZE(MOVMSK(X)) -> MOVMSK(FREEZE(X))
+; FREEZE(MOVMSK(X)) -> MOVMSK(FREEZE(X))
 define i32 @movmskps_freeze(<4 x i32> %a0) {
 ; SSE-LABEL: movmskps_freeze:
 ; SSE:       # %bb.0:
 ; SSE-NEXT:    movmskps %xmm0, %eax
-; SSE-NEXT:    andl $15, %eax
 ; SSE-NEXT:    retq
 ;
 ; AVX-LABEL: movmskps_freeze:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    vmovmskps %xmm0, %eax
-; AVX-NEXT:    andl $15, %eax
 ; AVX-NEXT:    retq
 ;
 ; ADL-LABEL: movmskps_freeze:
 ; ADL:       # %bb.0:
 ; ADL-NEXT:    vmovmskps %xmm0, %eax
-; ADL-NEXT:    andl $15, %eax
 ; ADL-NEXT:    retq
   %1 = icmp slt <4 x i32> %a0, zeroinitializer
   %2 = sext <4 x i1> %1 to <4 x i32>


### PR DESCRIPTION
MOVMSK nodes don't create undef/poison when extracting the signbits from the source operand