### PR TITLE
[CIR][NFC] Fix regression by #153819

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenBuiltin.cpp
@@ -129,10 +129,11 @@ RValue CIRGenFunction::emitBuiltinExpr(const GlobalDecl &gd, unsigned builtinID,
   case Builtin::BI__builtin_stdarg_start:
   case Builtin::BI__builtin_va_start:
   case Builtin::BI__va_start: {
-    emitVAStart(builtinID == Builtin::BI__va_start
-                    ? emitScalarExpr(e->getArg(0))
-                    : emitVAListRef(e->getArg(0)).getPointer(),
-                emitScalarExpr(e->getArg(1)));
+    mlir::Value vaList = builtinID == Builtin::BI__va_start
+                             ? emitScalarExpr(e->getArg(0))
+                             : emitVAListRef(e->getArg(0)).getPointer();
+    mlir::Value count = emitScalarExpr(e->getArg(1));
+    emitVAStart(vaList, count);
     return {};
   }
 


### PR DESCRIPTION
This patch fixes a regression introduced by #153819. The evaluation order of the arguments to `emitVAStart` is unspecified, but the test requires the arguments to be evaluated in left-to-right order.

It's a bit strange that the pre-merge checks did not catch this. The tests failed on my local machine, which runs Fedora 42 with gcc 15.2.1 .