### PR TITLE
[flang][OpenMP] Avoid crash with MAP w/o modifiers, version >= 6.0

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -793,7 +793,8 @@ public:
                   if (name->symbol) {
                     name->symbol->set(
                         ompFlag.value_or(Symbol::Flag::OmpMapStorage));
-                    AddToContextObjectWithDSA(*name->symbol, *ompFlag);
+                    AddToContextObjectWithDSA(*name->symbol,
+                        ompFlag.value_or(Symbol::Flag::OmpMapStorage));
                     if (semantics::IsAssumedSizeArray(*name->symbol)) {
                       context_.Say(designator.source,
                           "Assumed-size whole arrays may not appear on the %s "

--- a/flang/test/Lower/OpenMP/map-no-modifier-v60.f90
+++ b/flang/test/Lower/OpenMP/map-no-modifier-v60.f90
@@ -1,0 +1,12 @@
+!RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-version=60 %s -o - | FileCheck %s
+
+!This shouldn't crash. Check for a symptom of a successful compilation
+!CHECK: omp.map.info
+
+subroutine f00
+  implicit none
+  integer :: x
+  !$omp target map(x)
+  !$omp end target
+end
+  


### PR DESCRIPTION
The current code will crash on the MAP clause with OpenMP version >= 6.0 when the clause does not explicitly list any modifiers. The proper fix is to update the handling of assumed-size arrays for OpenMP 6.0+, but in the short term keep the behavior from 5.2, just avoid the crash.