### PR TITLE
[OrcJIT] distinguish normal and abrupt TaskDispatcher shutdown

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/TaskDispatch.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TaskDispatch.cpp
@@ -26,7 +26,7 @@ TaskDispatcher::~TaskDispatcher() = default;
 
 void InPlaceTaskDispatcher::dispatch(std::unique_ptr<Task> T) { T->run(); }
 
-void InPlaceTaskDispatcher::shutdown() {}
+void InPlaceTaskDispatcher::run(bool cancel) {}
 
 #if LLVM_ENABLE_THREADS
 void DynamicThreadPoolTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
@@ -105,9 +105,10 @@ void DynamicThreadPoolTaskDispatcher::dispatch(std::unique_ptr<Task> T) {
   }).detach();
 }
 
-void DynamicThreadPoolTaskDispatcher::shutdown() {
+void DynamicThreadPoolTaskDispatcher::run(bool cancel) {
   std::unique_lock<std::mutex> Lock(DispatchMutex);
-  Shutdown = true;
+  if (cancel)
+    Shutdown = true;
   OutstandingCV.wait(Lock, [this]() { return Outstanding == 0; });
 }
 

--- a/llvm/unittests/ExecutionEngine/JITLink/JITLinkTestUtils.h
+++ b/llvm/unittests/ExecutionEngine/JITLink/JITLinkTestUtils.h
@@ -133,7 +133,7 @@ public:
         HandleFailed(std::move(HandleFailed)) {}
 
   ~MockJITLinkContext() {
-    if (auto Err = MJMM->deallocate(std::move(FinalizedAllocs)))
+    if (auto Err = MJMM->Deallocate(std::move(FinalizedAllocs)))
       notifyFailed(std::move(Err));
   }
 

--- a/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
+++ b/llvm/unittests/ExecutionEngine/Orc/OrcTestCommon.h
@@ -57,6 +57,9 @@ protected:
   public:
     OverridableDispatcher(CoreAPIsBasedStandardTest &Parent) : Parent(Parent) {}
     void dispatch(std::unique_ptr<Task> T) override;
+    void dispatch_super(std::unique_ptr<Task> T) {
+      InPlaceTaskDispatcher::dispatch(std::move(T));
+    }
 
   private:
     CoreAPIsBasedStandardTest &Parent;
@@ -64,6 +67,11 @@ protected:
 
   std::unique_ptr<llvm::orc::ExecutorProcessControl>
   makeEPC(std::shared_ptr<SymbolStringPool> SSP);
+
+  OverridableDispatcher &getDispatcher() {
+    return static_cast<OverridableDispatcher &>(
+        ES.getExecutorProcessControl().getDispatcher());
+  }
 
   std::shared_ptr<SymbolStringPool> SSP = std::make_shared<SymbolStringPool>();
   ExecutionSession ES{makeEPC(SSP)};

--- a/llvm/unittests/ExecutionEngine/Orc/ResourceTrackerTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/ResourceTrackerTest.cpp
@@ -141,6 +141,7 @@ TEST_F(ResourceTrackerStandardTest,
       LookupKind::Static,
       {{&JD, JITDylibLookupFlags::MatchExportedSymbolsOnly}},
       SymbolLookupSet(Foo, SymbolLookupFlags::WeaklyReferencedSymbol)));
+  getDispatcher().run_to_complete();
 
   EXPECT_EQ(SymFlags.size(), 0U)
       << "Symbols should have been removed from the symbol table";
@@ -181,6 +182,7 @@ TEST_F(ResourceTrackerStandardTest, BasicDefineAndRemoveAllAfterMaterializing) {
       LookupKind::Static,
       {{&JD, JITDylibLookupFlags::MatchExportedSymbolsOnly}},
       SymbolLookupSet(Foo, SymbolLookupFlags::WeaklyReferencedSymbol)));
+  getDispatcher().run_to_complete();
 
   EXPECT_EQ(SymFlags.size(), 0U)
       << "Symbols should have been removed from the symbol table";
@@ -218,6 +220,7 @@ TEST_F(ResourceTrackerStandardTest, BasicDefineAndRemoveAllWhileMaterializing) {
             << "Lookup failed unexpectedly";
       },
       NoDependenciesToRegister);
+  getDispatcher().run_to_complete();
 
   cantFail(RT->remove());
   auto SymFlags = cantFail(ES.lookupFlags(
@@ -240,6 +243,7 @@ TEST_F(ResourceTrackerStandardTest, BasicDefineAndRemoveAllWhileMaterializing) {
       << "notifyResolved on MR with removed tracker should have failed";
 
   MR->failMaterialization();
+  getDispatcher().run_to_complete();
 }
 
 TEST_F(ResourceTrackerStandardTest, JITDylibClear) {
@@ -270,6 +274,7 @@ TEST_F(ResourceTrackerStandardTest, JITDylibClear) {
 
   cantFail(
       ES.lookup(makeJITDylibSearchOrder(&JD), SymbolLookupSet({Foo, Bar})));
+  getDispatcher().run_to_complete();
 
   auto JDResourceKey = JD.getDefaultResourceTracker()->getKeyUnsafe();
   EXPECT_EQ(SRM.getRecordedResources().size(), 1U)
@@ -323,6 +328,7 @@ TEST_F(ResourceTrackerStandardTest,
 
   cantFail(
       ES.lookup(makeJITDylibSearchOrder({&JD}), SymbolLookupSet({Foo, Bar})));
+  getDispatcher().run_to_complete();
 
   EXPECT_EQ(SRM.getRecordedResources().size(), 1U)
       << "Expected exactly one entry (for FooRT's Key)";
@@ -370,6 +376,7 @@ TEST_F(ResourceTrackerStandardTest,
 
   cantFail(
       ES.lookup(makeJITDylibSearchOrder({&JD}), SymbolLookupSet({Foo, Bar})));
+  getDispatcher().run_to_complete();
 
   EXPECT_EQ(SRM.getRecordedResources().size(), 2U)
       << "Expected recorded resources for both Foo and Bar";
@@ -415,6 +422,7 @@ TEST_F(ResourceTrackerStandardTest,
       SymbolState::Ready,
       [](Expected<SymbolMap> Result) { cantFail(Result.takeError()); },
       NoDependenciesToRegister);
+  getDispatcher().run_to_complete();
 
   cantFail(FooMR->withResourceKeyDo([&](ResourceKey K) {
     EXPECT_EQ(FooRT->getKeyUnsafe(), K)
@@ -447,6 +455,7 @@ TEST_F(ResourceTrackerStandardTest,
 
   cantFail(FooMR->notifyResolved({{Foo, FooSym}}));
   cantFail(FooMR->notifyEmitted({}));
+  getDispatcher().run_to_complete();
 }
 
 } // namespace

--- a/llvm/unittests/ExecutionEngine/Orc/TaskDispatchTest.cpp
+++ b/llvm/unittests/ExecutionEngine/Orc/TaskDispatchTest.cpp
@@ -19,6 +19,7 @@ TEST(InPlaceTaskDispatchTest, GenericNamedTask) {
   auto D = std::make_unique<InPlaceTaskDispatcher>();
   bool B = false;
   D->dispatch(makeGenericNamedTask([&]() { B = true; }));
+  D->run_to_complete();
   EXPECT_TRUE(B);
   D->shutdown();
 }
@@ -31,6 +32,7 @@ TEST(DynamicThreadPoolDispatchTest, GenericNamedTask) {
   D->dispatch(makeGenericNamedTask(
       [P = std::move(P)]() mutable { P.set_value(true); }));
   EXPECT_TRUE(F.get());
+  D->run_to_complete();
   D->shutdown();
 }
 #endif


### PR DESCRIPTION
Add a `run_to_complete` complement to `shutdown`, which does nearly the same operations, but does not cancel future / pending work. The distinction is often mainly academic, but split for clarity of intent of each caller.

Annotate each and every tests that assumes that any previously scheduled tasks have finished running with a call of `run_to_completion` before reading the variables written by those tasks. This more clearly emphasizes the expectations of each of these tests and makes them robust against data-races or changes to the default scheduler.

These should have no impact currently, but have been tested and shown to pass with a scheduler which defers all work (as if being run on a thread) until an explicit synchronization point "acquires" that state, demonstrating that this is each and every test that would be affected by changes to the default scheduler.