### PR TITLE
[flang][runtime] Fix CUDA build

### DIFF
--- a/flang-rt/lib/runtime/pseudo-unit.cpp
+++ b/flang-rt/lib/runtime/pseudo-unit.cpp
@@ -160,7 +160,7 @@ void PseudoOpenFile::WaitAll(IoErrorHandler &handler) {
   handler.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-Position PseudoOpenFile::InquirePosition() const {
+Position PseudoOpenFile::InquirePosition(FileOffset) const {
   Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -88,7 +88,7 @@ public:
       FileOffset, const char *, std::size_t, IoErrorHandler &);
   RT_API_ATTRS void Wait(int id, IoErrorHandler &);
   RT_API_ATTRS void WaitAll(IoErrorHandler &);
-  RT_API_ATTRS Position InquirePosition() const;
+  RT_API_ATTRS Position InquirePosition(FileOffset) const;
 };
 #endif // defined(RT_USE_PSEUDO_FILE_UNIT)
 
@@ -198,8 +198,8 @@ public:
   RT_API_ATTRS int GetAsynchronousId(IoErrorHandler &);
   RT_API_ATTRS bool Wait(int);
   RT_API_ATTRS Position InquirePosition() const {
-    return OpenFile::InquirePosition(
-        static_cast<FileOffset>(frameOffsetInFile_ + recordOffsetInFrame_));
+    return OpenFileClass::InquirePosition(
+        static_cast<std::int64_t>(frameOffsetInFile_ + recordOffsetInFrame_));
   }
 
 private:


### PR DESCRIPTION
Address problems with CUDA build of flang-new runtime after a recent patch to an external open file API.