### PR TITLE
[libc] Fix missing close at the end of file test

### DIFF
--- a/libc/test/src/__support/File/file_test.cpp
+++ b/libc/test/src/__support/File/file_test.cpp
@@ -510,4 +510,5 @@ TEST(LlvmLibcFileTest, WriteSplit) {
   static constexpr size_t WR_EXPECTED = AVAIL - (sizeof(data) - 1);
   ASSERT_EQ(WR_EXPECTED, f->write(data2, sizeof(data2) - 1).value);
   EXPECT_TRUE(f->error());
+  ASSERT_EQ(f->close(), 0);
 }


### PR DESCRIPTION
The test added by #150802 was missing a close at the end.
