### PR TITLE
[lldb] make lit use the same PYTHONHOME for building and running the API tests

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -353,6 +353,7 @@ if platform.system() == "Windows":
 # Some steps required to initialize the tests dynamically link with python.dll
 # and need to know the location of the Python libraries. This ensures that we
 # use the same version of Python that was used to build lldb to run our tests.
+config.environment["PYTHONHOME"] = config.python_root_dir
 config.environment["PATH"] = os.path.pathsep.join(
     (config.python_root_dir, config.environment.get("PATH", ""))
 )


### PR DESCRIPTION
When testing LLDB, we want to make sure to use the same Python as the one we used to build it.

We already did this in https://github.com/llvm/llvm-project/pull/143183 for the Unit and Shell tests. This patch does the same thing for the API tests as well.