### PR TITLE
[compiler-rt] Fix-forward "[compiler-rt] Fix frame numbering for unparsable frames. #148278"

### DIFF
--- a/compiler-rt/test/asan/TestCases/Posix/asan_symbolize_script/anon_wrong_frame_number.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/asan_symbolize_script/anon_wrong_frame_number.cpp
@@ -5,6 +5,7 @@
 // UNSUPPORTED: aarch64
 // UNSUPPORTED: darwin
 // UNSUPPORTED: ios
+// REQUIRES: x86-64-registered-target
 
 // RUN: %clangxx_asan -O0 -g %s -o %t
 // RUN: %env_asan_opts=symbolize=0 not %run %t DUMMY_ARG > %t.asan_report 2>&1


### PR DESCRIPTION
Reason: buildbot failure (https://lab.llvm.org/buildbot/#/builders/51/builds/21874/steps/9/logs/stdio)

Fix by restricting test to x86-64