### PR TITLE
[MLIR][Linalg] Rename convolution pass

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/Passes.td
+++ b/mlir/include/mlir/Dialect/Linalg/Passes.td
@@ -86,12 +86,6 @@ def LinalgSpecializeGenericOpsPass : Pass<"linalg-specialize-generic-ops">,
   let dependentDialects = ["linalg::LinalgDialect"];
 }
 
-def LinalgNamedOpConversionPass: Pass<"linalg-named-op-conversion">,
-                                 Deprecated<"Use 'simplify-depthwise-conv' instead."> {
-  let summary = "Convert from one named linalg op to another.";
-  let dependentDialects = ["linalg::LinalgDialect", "tensor::TensorDialect"];
-}
-
 // ------------------ End of "form" conversions
 
 def SimplifyDepthwiseConvPass: Pass<"simplify-depthwise-conv"> {

--- a/mlir/include/mlir/Dialect/Linalg/Passes.td
+++ b/mlir/include/mlir/Dialect/Linalg/Passes.td
@@ -86,12 +86,18 @@ def LinalgSpecializeGenericOpsPass : Pass<"linalg-specialize-generic-ops">,
   let dependentDialects = ["linalg::LinalgDialect"];
 }
 
-def LinalgNamedOpConversionPass: Pass<"linalg-named-op-conversion"> {
+def LinalgNamedOpConversionPass: Pass<"linalg-named-op-conversion">,
+                                 Deprecated<"Use 'simplify-depthwise-conv' instead."> {
   let summary = "Convert from one named linalg op to another.";
   let dependentDialects = ["linalg::LinalgDialect", "tensor::TensorDialect"];
 }
 
 // ------------------ End of "form" conversions
+
+def SimplifyDepthwiseConvPass: Pass<"simplify-depthwise-conv"> {
+  let summary = "Simplify depthwise convolution.";
+  let dependentDialects = ["linalg::LinalgDialect", "tensor::TensorDialect"];
+}
 
 def ConvertElementwiseToLinalgPass : Pass<"convert-elementwise-to-linalg", ""> {
   let summary = "Convert ElementwiseMappable ops to linalg";

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -26,7 +26,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
-#include "llvm/Support/Compiler.h"
 
 namespace mlir {
 namespace bufferization {

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -24,9 +24,9 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/TilingInterface.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/Support/Compiler.h"
 
 namespace mlir {
 namespace bufferization {

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -1966,10 +1966,6 @@ void populateFuseTensorPadWithProducerLinalgOpPatterns(
 /// Patterns to simplify depthwise convolutions.
 void populateSimplifyDepthwiseConvPatterns(RewritePatternSet &patterns);
 
-/// Patterns to convert from one named op to another. So far only used on
-/// depthwise convolutions, so deprecated. Use the pattern avove.
-void populateLinalgNamedOpConversionPatterns(RewritePatternSet &patterns);
-
 /// Patterns to fold unit-extent dimensions in operands/results of linalg ops on
 /// tensors via reassociative reshape ops.
 void populateFoldUnitExtentDimsPatterns(RewritePatternSet &patterns,

--- a/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
+++ b/mlir/include/mlir/Dialect/Linalg/Transforms/Transforms.h
@@ -24,6 +24,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/TilingInterface.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/SmallSet.h"
 
@@ -1962,8 +1963,11 @@ void populateFoldAddIntoDestPatterns(RewritePatternSet &patterns);
 void populateFuseTensorPadWithProducerLinalgOpPatterns(
     RewritePatternSet &patterns);
 
-/// Patterns to convert from one named op to another. These can be seen as
-/// canonicalizations of named ops into another named op.
+/// Patterns to simplify depthwise convolutions.
+void populateSimplifyDepthwiseConvPatterns(RewritePatternSet &patterns);
+
+/// Patterns to convert from one named op to another. So far only used on
+/// depthwise convolutions, so deprecated. Use the pattern avove.
 void populateLinalgNamedOpConversionPatterns(RewritePatternSet &patterns);
 
 /// Patterns to fold unit-extent dimensions in operands/results of linalg ops on

--- a/mlir/lib/Dialect/Linalg/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Linalg/Transforms/CMakeLists.txt
@@ -26,7 +26,7 @@ add_mlir_dialect_library(MLIRLinalgTransforms
   MorphOps.cpp
   TransposeMatmul.cpp
   ShardingInterfaceImpl.cpp
-  NamedOpConversions.cpp
+  SimplifyDepthwiseConv.cpp
   NamedToElementwise.cpp
   BlockPackMatmul.cpp
   PackAndUnpackPatterns.cpp

--- a/mlir/lib/Dialect/Linalg/Transforms/SimplifyDepthwiseConv.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/SimplifyDepthwiseConv.cpp
@@ -21,7 +21,6 @@
 #include "llvm/ADT/TypeSwitch.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_LINALGNAMEDOPCONVERSIONPASS
 #define GEN_PASS_DEF_SIMPLIFYDEPTHWISECONVPASS
 #include "mlir/Dialect/Linalg/Passes.h.inc"
 } // namespace mlir
@@ -157,32 +156,9 @@ struct SimplifyDepthwiseConvPass
       return signalPassFailure();
   }
 };
-
-// Deprecated, use the one above
-struct LinalgNamedOpConversionPass
-    : public impl::LinalgNamedOpConversionPassBase<
-          LinalgNamedOpConversionPass> {
-  using impl::LinalgNamedOpConversionPassBase<
-      LinalgNamedOpConversionPass>::LinalgNamedOpConversionPassBase;
-
-  void runOnOperation() override {
-    Operation *op = getOperation();
-    RewritePatternSet patterns(op->getContext());
-    populateLinalgNamedOpConversionPatterns(patterns);
-    if (failed(applyPatternsGreedily(op, std::move(patterns))))
-      return signalPassFailure();
-  }
-};
 } // namespace
 
 void mlir::linalg::populateSimplifyDepthwiseConvPatterns(
-    RewritePatternSet &patterns) {
-  patterns.add<SimplifyDepthwiseConvOp, SimplifyDepthwiseConvQOp>(
-      patterns.getContext());
-}
-
-// Deprecated, use the one above
-void mlir::linalg::populateLinalgNamedOpConversionPatterns(
     RewritePatternSet &patterns) {
   patterns.add<SimplifyDepthwiseConvOp, SimplifyDepthwiseConvQOp>(
       patterns.getContext());

--- a/mlir/lib/Dialect/Linalg/Transforms/SimplifyDepthwiseConv.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/SimplifyDepthwiseConv.cpp
@@ -145,8 +145,7 @@ struct SimplifyDepthwiseConvQOp
 };
 
 struct SimplifyDepthwiseConvPass
-    : public impl::SimplifyDepthwiseConvPassBase<
-          SimplifyDepthwiseConvPass> {
+    : public impl::SimplifyDepthwiseConvPassBase<SimplifyDepthwiseConvPass> {
   using impl::SimplifyDepthwiseConvPassBase<
       SimplifyDepthwiseConvPass>::SimplifyDepthwiseConvPassBase;
 

--- a/mlir/lib/Dialect/Linalg/Transforms/SimplifyDepthwiseConv.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/SimplifyDepthwiseConv.cpp
@@ -22,6 +22,7 @@
 
 namespace mlir {
 #define GEN_PASS_DEF_LINALGNAMEDOPCONVERSIONPASS
+#define GEN_PASS_DEF_SIMPLIFYDEPTHWISECONVPASS
 #include "mlir/Dialect/Linalg/Passes.h.inc"
 } // namespace mlir
 
@@ -143,6 +144,22 @@ struct SimplifyDepthwiseConvQOp
   }
 };
 
+struct SimplifyDepthwiseConvPass
+    : public impl::SimplifyDepthwiseConvPassBase<
+          SimplifyDepthwiseConvPass> {
+  using impl::SimplifyDepthwiseConvPassBase<
+      SimplifyDepthwiseConvPass>::SimplifyDepthwiseConvPassBase;
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    RewritePatternSet patterns(op->getContext());
+    populateSimplifyDepthwiseConvPatterns(patterns);
+    if (failed(applyPatternsGreedily(op, std::move(patterns))))
+      return signalPassFailure();
+  }
+};
+
+// Deprecated, use the one above
 struct LinalgNamedOpConversionPass
     : public impl::LinalgNamedOpConversionPassBase<
           LinalgNamedOpConversionPass> {
@@ -159,6 +176,13 @@ struct LinalgNamedOpConversionPass
 };
 } // namespace
 
+void mlir::linalg::populateSimplifyDepthwiseConvPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<SimplifyDepthwiseConvOp, SimplifyDepthwiseConvQOp>(
+      patterns.getContext());
+}
+
+// Deprecated, use the one above
 void mlir::linalg::populateLinalgNamedOpConversionPatterns(
     RewritePatternSet &patterns) {
   patterns.add<SimplifyDepthwiseConvOp, SimplifyDepthwiseConvQOp>(

--- a/mlir/test/Dialect/Linalg/simplify-depthwise-conv.mlir
+++ b/mlir/test/Dialect/Linalg/simplify-depthwise-conv.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt %s -linalg-named-op-conversion -split-input-file | FileCheck %s
+// RUN: mlir-opt %s --simplify-depthwise-conv -split-input-file | FileCheck %s
 
 // CHECK-LABEL: @depthwise_conv
 func.func @depthwise_conv(%arg0: tensor<?x?x?x?xf32>, %arg1: tensor<?x?x?x1xf32>, %arg2: tensor<?x?x?x?x1xf32>) -> tensor<?x?x?x?x1xf32> {


### PR DESCRIPTION
Rename the pass `LinalgNamedOpConversionPass` to `SimplifyDepthwiseConvPass` to avoid conflating it with the new morphisms we are creating between the norms.