### PR TITLE
[OCaml] Make ocaml_doc installation conditional on LLVM_BUILD_DOCS

### DIFF
--- a/llvm/docs/CMakeLists.txt
+++ b/llvm/docs/CMakeLists.txt
@@ -136,17 +136,23 @@ if( NOT uses_ocaml LESS 0 AND LLVM_ENABLE_OCAMLDOC )
     list(APPEND odoc_files -load ${odoc_file})
   endforeach()
 
-  add_custom_target(ocaml_doc
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html
-    COMMAND ${OCAMLFIND} ocamldoc -d ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html
-                                  -sort -colorize-code -html ${odoc_files}
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/_ocamldoc/style.css
-                                     ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html)
+  set(OCAML_DOC_ADD_TO_ALL "")
+  if(LLVM_BUILD_DOCS)
+    set(OCAML_DOC_ADD_TO_ALL ALL)
+  endif()
+
+  add_custom_target(ocaml_doc ${OCAML_DOC_ADD_TO_ALL}
+      COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html
+      COMMAND ${OCAMLFIND} ocamldoc -d ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html
+                                    -sort -colorize-code -html ${odoc_files}
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/_ocamldoc/style.css
+                                       ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html)
 
   add_dependencies(ocaml_doc ${doc_targets})
 
-  if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+
+  if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY AND LLVM_BUILD_DOCS)
     # ./ suffix is needed to copy the contents of html directory without
     # appending html/ into LLVM_INSTALL_OCAMLDOC_HTML_DIR.
     install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ocamldoc/html/.


### PR DESCRIPTION
### Summary

Fixes #154411, #125437 and #108742.

When building with `-DLLVM_BUILD_DOCS=ON -DLLVM_ENABLE_OCAMLDOC=ON -DLLVM_INSTALL_DOCS=ON`, running

```bash
cmake --build . --target install
```

can fail with:

```
CMake Error at docs/cmake_install.cmake:41 (file):
  file INSTALL cannot find
  "$BUILD/docs/ocamldoc/html/.": No such file or directory.
```

The `install(DIRECTORY …)` rule in `llvm/docs/CMakeLists.txt` unconditionally expects the `ocamldoc/html` directory, but the `ocaml_doc` custom target that generates it is not part of the normal `install` dependency chain. As a result, `install` may run before docs are generated.

### Changes
- This pull request conditionally adds the ocaml_doc target to the default build targets (ALL) only when LLVM_BUILD_DOCS is enabled.

- This ensures that when a user intends to build documentation, the OCaml docs are automatically generated during a normal build (cmake --build .). Consequently, by the time the install target is executed, the ocamldoc/html directory is guaranteed to exist.

### Behavior

- With LLVM_BUILD_DOCS=ON: A standard cmake --build . --target install command will now correctly build the OCaml documentation first and then install it without errors. Users are no longer required to manually build the ocaml_doc target first.
- Without LLVM_BUILD_DOCS=ON (Default): There is no change in behavior. The ocaml_doc target is not added to the ALL build, so documentation is not generated by default, preventing unnecessary work in standard build configurations.

### Rationale
- The change aligns the OCaml documentation build process with the established conventions for other documentation systems in LLVM, such as Doxygen. By making the inclusion in the ALL target dependent on the LLVM_BUILD_DOCS flag, we provide an intuitive and reliable build experience for users who want the documentation, while leaving the default build unaffected.
