### PR TITLE
[clang-tidy] Add new '-hide-progress' option to tidy-scripts for suppressing progress information

### DIFF
--- a/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
+++ b/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py
@@ -258,6 +258,11 @@ def main():
         help="Upgrades clang-tidy warnings to errors. Same format as '-checks'.",
         default="",
     )
+    parser.add_argument(
+        "-hide-progress",
+        action="store_true",
+        help="Hide progress",
+    )
 
     clang_tidy_args = []
     argv = sys.argv[1:]
@@ -312,7 +317,8 @@ def main():
     if max_task_count == 0:
         max_task_count = multiprocessing.cpu_count()
     max_task_count = min(len(lines_by_file), max_task_count)
-    print(f"Running clang-tidy in {max_task_count} threads...")
+    if not args.hide_progress:
+        print(f"Running clang-tidy in {max_task_count} threads...")
 
     combine_fixes = False
     export_fixes_dir = None
@@ -408,7 +414,8 @@ def main():
         return_code = 1
 
     if combine_fixes:
-        print("Writing fixes to " + args.export_fixes + " ...")
+        if not args.hide_progress:
+            print(f"Writing fixes to {args.export_fixes} ...")
         try:
             merge_replacement_files(export_fixes_dir, args.export_fixes)
         except:

--- a/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
+++ b/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py
@@ -576,6 +576,11 @@ async def main() -> None:
         action="store_true",
         help="Enable per-check timing profiles, and print a report",
     )
+    parser.add_argument(
+        "-hide-progress",
+        action="store_true",
+        help="Hide progress",
+    )
     args = parser.parse_args()
 
     db_path = "compile_commands.json"
@@ -681,13 +686,11 @@ async def main() -> None:
     file_name_re = re.compile("|".join(args.files))
     files = {f for f in files if file_name_re.search(f)}
 
-    print(
-        f"Running clang-tidy in {max_task} threads for",
-        len(files),
-        "files out of",
-        number_files_in_database,
-        "in compilation database ...",
-    )
+    if not args.hide_progress:
+        print(
+            f"Running clang-tidy in {max_task} threads for {len(files)} files "
+            f"out of {number_files_in_database} in compilation database ..."
+        )
 
     returncode = 0
     semaphore = asyncio.Semaphore(max_task)
@@ -716,13 +719,15 @@ async def main() -> None:
                     result.stderr += f"{result.filename}: terminated by signal {-result.returncode}\n"
             progress = f"[{i + 1: >{len(f'{len(files)}')}}/{len(files)}]"
             runtime = f"[{result.elapsed:.1f}s]"
-            print(f"{progress}{runtime} {' '.join(result.invocation)}")
+            if not args.hide_progress:
+                print(f"{progress}{runtime} {' '.join(result.invocation)}")
             if result.stdout:
                 print(result.stdout, end=("" if result.stderr else "\n"))
             if result.stderr:
                 print(result.stderr)
     except asyncio.CancelledError:
-        print("\nCtrl-C detected, goodbye.")
+        if not args.hide_progress:
+            print("\nCtrl-C detected, goodbye.")
         for task in tasks:
             task.cancel()
         if delete_fixes_dir:
@@ -742,7 +747,8 @@ async def main() -> None:
             print("No profiling data found.")
 
     if combine_fixes:
-        print(f"Writing fixes to {args.export_fixes} ...")
+        if not args.hide_progress:
+            print(f"Writing fixes to {args.export_fixes} ...")
         try:
             assert export_fixes_dir
             merge_replacement_files(export_fixes_dir, args.export_fixes)
@@ -752,7 +758,8 @@ async def main() -> None:
             returncode = 1
 
     if args.fix:
-        print("Applying fixes ...")
+        if not args.hide_progress:
+            print("Applying fixes ...")
         try:
             assert export_fixes_dir
             apply_fixes(args, clang_apply_replacements_binary, export_fixes_dir)

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -136,7 +136,7 @@ Improvements to clang-tidy
   same name instead.
 
 - Improved :program:`run-clang-tidy.py` and :program:`clang-tidy-diff.py` 
-  scripts by adding the `-hide-progress` option to suppressing progress and
+  scripts by adding the `-hide-progress` option to suppress progress and
   informational messages.
 
 New checks

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -135,6 +135,10 @@ Improvements to clang-tidy
   :program:`clang-tidy-20`. Users should use the check-specific options of the
   same name instead.
 
+- Improved :program:`run-clang-tidy.py` and :program:`clang-tidy-diff.py` 
+  scripts by adding the `-hide-progress` option to suppressing progress and
+  informational messages.
+
 New checks
 ^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/infrastructure/hide-progress-flag-scripts.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/hide-progress-flag-scripts.cpp
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: echo "[{\"directory\":\".\",\"command\":\"clang++ -c %/t/test.cpp\",\"file\":\"%/t/test.cpp\"}]" | sed -e 's/\\/\\\\/g' > %t/compile_commands.json
+// RUN: echo "Checks: '-*,readability-magic-numbers'" > %t/.clang-tidy
+// RUN: cp "%s" "%t/test.cpp"
+// RUN: cd "%t"
+
+// RUN: %run_clang_tidy -quiet -hide-progress "test.cpp" 2>&1 | FileCheck %s --check-prefix=CHECK-RUN-QUIET
+// CHECK-RUN-QUIET-NOT: Running clang-tidy in {{[1-9][0-9]*}} threads for
+// CHECK-RUN-QUIET-NOT: {{[0-9]+}} warning{{s?}} generated
+// CHECK-RUN-QUIET-NOT: [1/1]
+// CHECK-RUN-QUIET: 42 is a magic number;
+
+// REQUIRES: shell
+// RUN: sed 's/42/99/' %s > %t-diff.cpp
+
+// RUN: not diff -U0 %s %t-diff.cpp | %clang_tidy_diff -checks=-*,readability-magic-numbers -quiet -hide-progress -- -std=c++11 2>&1 | FileCheck %s --check-prefix=CHECK-DIFF-QUIET
+// CHECK-DIFF-QUIET-NOT: Running clang-tidy in {{[1-9][0-9]*}} threads...
+// CHECK-DIFF-QUIET-NOT: {{[0-9]+}} warning{{s?}} generated
+// CHECK-DIFF-QUIET: 99 is a magic number;
+
+int main() {
+  int x = 42;
+}


### PR DESCRIPTION
Progress information bloated output, now `run-clang-tidy` emits **only** actual diagnostics, which makes reading its output significantly easier.