### PR TITLE
[clang] fix runtime check for NNS transform

### DIFF
--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -5417,6 +5417,7 @@ QualType TreeTransform<Derived>::TransformTypeInObjectScope(
   case TypeLoc::Typedef:
   case TypeLoc::TemplateSpecialization:
   case TypeLoc::SubstTemplateTypeParm:
+  case TypeLoc::SubstTemplateTypeParmPack:
   case TypeLoc::PackIndexing:
   case TypeLoc::Enum:
   case TypeLoc::Record:

--- a/clang/test/SemaTemplate/nested-name-spec-template.cpp
+++ b/clang/test/SemaTemplate/nested-name-spec-template.cpp
@@ -167,3 +167,18 @@ namespace unresolved_using {
   };
   template struct C<int>;
 } // namespace unresolved_using
+
+#if __cplusplus >= 201703L
+namespace SubstTemplateTypeParmPackType {
+  template <int...> struct A {};
+
+  template <class... Ts> void f() {
+    []<int ... Is>(A<Is...>) { (Ts::g(Is) && ...); }(A<0>{});
+    // expected-warning@-1 {{explicit template parameter list for lambdas is a C++20 extension}}
+  };
+
+  struct B { static void g(int); };
+
+  template void f<B>();
+} // namespace SubstTemplateTypeParmPackType
+#endif


### PR DESCRIPTION
A SubstTemplateTypeParmPackType is one of the types which may appear in a NestedNameSpecifier, so add it to the list of expected types in TreeTransform.

This fixes a regression introduced in #147835, which has never been released, so there are no release notes.

Fixes #154270