### PR TITLE
[ARM] Custom Lowering for SADDO_CARRY and SSUBO_CARRY

### DIFF
--- a/llvm/test/CodeGen/ARM/sadd_sat.ll
+++ b/llvm/test/CodeGen/ARM/sadd_sat.ll
@@ -64,86 +64,81 @@ define i32 @func(i32 %x, i32 %y) nounwind {
 define i64 @func2(i64 %x, i64 %y) nounwind {
 ; CHECK-T16-LABEL: func2:
 ; CHECK-T16:       @ %bb.0:
-; CHECK-T16-NEXT:    .save {r4, lr}
-; CHECK-T16-NEXT:    push {r4, lr}
-; CHECK-T16-NEXT:    mov r4, r1
-; CHECK-T16-NEXT:    eors r1, r3
-; CHECK-T16-NEXT:    adds r2, r0, r2
-; CHECK-T16-NEXT:    adcs r3, r4
-; CHECK-T16-NEXT:    eors r4, r3
-; CHECK-T16-NEXT:    bics r4, r1
-; CHECK-T16-NEXT:    asrs r0, r3, #31
-; CHECK-T16-NEXT:    movs r1, #1
-; CHECK-T16-NEXT:    lsls r1, r1, #31
-; CHECK-T16-NEXT:    eors r1, r0
-; CHECK-T16-NEXT:    cmp r4, #0
-; CHECK-T16-NEXT:    bpl .LBB1_3
+; CHECK-T16-NEXT:    .save {r4, r5, r7, lr}
+; CHECK-T16-NEXT:    push {r4, r5, r7, lr}
+; CHECK-T16-NEXT:    mov r5, r0
+; CHECK-T16-NEXT:    adds r0, r0, r2
+; CHECK-T16-NEXT:    mov r0, r1
+; CHECK-T16-NEXT:    adcs r0, r3
+; CHECK-T16-NEXT:    asrs r0, r0, #31
+; CHECK-T16-NEXT:    movs r4, #1
+; CHECK-T16-NEXT:    lsls r4, r4, #31
+; CHECK-T16-NEXT:    eors r4, r0
+; CHECK-T16-NEXT:    adds r2, r5, r2
+; CHECK-T16-NEXT:    adcs r1, r3
+; CHECK-T16-NEXT:    bvc .LBB1_3
 ; CHECK-T16-NEXT:  @ %bb.1:
-; CHECK-T16-NEXT:    bpl .LBB1_4
+; CHECK-T16-NEXT:    bvc .LBB1_4
 ; CHECK-T16-NEXT:  .LBB1_2:
-; CHECK-T16-NEXT:    pop {r4, pc}
+; CHECK-T16-NEXT:    mov r1, r4
+; CHECK-T16-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-T16-NEXT:  .LBB1_3:
 ; CHECK-T16-NEXT:    mov r0, r2
-; CHECK-T16-NEXT:    bmi .LBB1_2
+; CHECK-T16-NEXT:    bvs .LBB1_2
 ; CHECK-T16-NEXT:  .LBB1_4:
-; CHECK-T16-NEXT:    mov r1, r3
-; CHECK-T16-NEXT:    pop {r4, pc}
+; CHECK-T16-NEXT:    mov r4, r1
+; CHECK-T16-NEXT:    mov r1, r4
+; CHECK-T16-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; CHECK-T2-LABEL: func2:
 ; CHECK-T2:       @ %bb.0:
 ; CHECK-T2-NEXT:    adds r0, r0, r2
-; CHECK-T2-NEXT:    eor.w r12, r1, r3
-; CHECK-T2-NEXT:    adc.w r2, r1, r3
-; CHECK-T2-NEXT:    eors r1, r2
-; CHECK-T2-NEXT:    bics.w r1, r1, r12
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    asrmi r0, r2, #31
-; CHECK-T2-NEXT:    mov.w r1, #-2147483648
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    eormi.w r2, r1, r2, asr #31
-; CHECK-T2-NEXT:    mov r1, r2
+; CHECK-T2-NEXT:    mov.w r2, #-2147483648
+; CHECK-T2-NEXT:    adcs r1, r3
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    asrvs r0, r1, #31
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    eorvs.w r1, r2, r1, asr #31
 ; CHECK-T2-NEXT:    bx lr
 ;
 ; CHECK-ARM-LABEL: func2:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    adds r0, r0, r2
-; CHECK-ARM-NEXT:    eor r12, r1, r3
-; CHECK-ARM-NEXT:    adc r2, r1, r3
-; CHECK-ARM-NEXT:    eor r1, r1, r2
-; CHECK-ARM-NEXT:    bics r1, r1, r12
-; CHECK-ARM-NEXT:    asrmi r0, r2, #31
-; CHECK-ARM-NEXT:    mov r1, #-2147483648
-; CHECK-ARM-NEXT:    eormi r2, r1, r2, asr #31
-; CHECK-ARM-NEXT:    mov r1, r2
+; CHECK-ARM-NEXT:    mov r2, #-2147483648
+; CHECK-ARM-NEXT:    adcs r1, r1, r3
+; CHECK-ARM-NEXT:    asrvs r0, r1, #31
+; CHECK-ARM-NEXT:    eorvs r1, r2, r1, asr #31
 ; CHECK-ARM-NEXT:    bx lr
 ;
 ; CHECK-T15TE-LABEL: func2:
 ; CHECK-T15TE:       @ %bb.0:
-; CHECK-T15TE-NEXT:    .save {r4, lr}
-; CHECK-T15TE-NEXT:    push {r4, lr}
-; CHECK-T15TE-NEXT:    movs r4, r1
-; CHECK-T15TE-NEXT:    eors r1, r3
-; CHECK-T15TE-NEXT:    adds r2, r0, r2
-; CHECK-T15TE-NEXT:    adcs r3, r4
-; CHECK-T15TE-NEXT:    eors r4, r3
-; CHECK-T15TE-NEXT:    bics r4, r1
-; CHECK-T15TE-NEXT:    asrs r0, r3, #31
-; CHECK-T15TE-NEXT:    movs r1, #1
-; CHECK-T15TE-NEXT:    lsls r1, r1, #31
-; CHECK-T15TE-NEXT:    eors r1, r0
-; CHECK-T15TE-NEXT:    cmp r4, #0
-; CHECK-T15TE-NEXT:    bpl .LBB1_3
+; CHECK-T15TE-NEXT:    .save {r4, r5, r7, lr}
+; CHECK-T15TE-NEXT:    push {r4, r5, r7, lr}
+; CHECK-T15TE-NEXT:    movs r5, r0
+; CHECK-T15TE-NEXT:    adds r0, r0, r2
+; CHECK-T15TE-NEXT:    mov r12, r1
+; CHECK-T15TE-NEXT:    mov r0, r12
+; CHECK-T15TE-NEXT:    adcs r0, r3
+; CHECK-T15TE-NEXT:    asrs r0, r0, #31
+; CHECK-T15TE-NEXT:    movs r4, #1
+; CHECK-T15TE-NEXT:    lsls r4, r4, #31
+; CHECK-T15TE-NEXT:    eors r4, r0
+; CHECK-T15TE-NEXT:    adds r2, r5, r2
+; CHECK-T15TE-NEXT:    adcs r1, r3
+; CHECK-T15TE-NEXT:    bvc .LBB1_3
 ; CHECK-T15TE-NEXT:  @ %bb.1:
-; CHECK-T15TE-NEXT:    bpl .LBB1_4
+; CHECK-T15TE-NEXT:    bvc .LBB1_4
 ; CHECK-T15TE-NEXT:  .LBB1_2:
-; CHECK-T15TE-NEXT:    pop {r4, pc}
+; CHECK-T15TE-NEXT:    movs r1, r4
+; CHECK-T15TE-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-T15TE-NEXT:  .LBB1_3:
 ; CHECK-T15TE-NEXT:    mov r12, r2
 ; CHECK-T15TE-NEXT:    mov r0, r12
-; CHECK-T15TE-NEXT:    bmi .LBB1_2
+; CHECK-T15TE-NEXT:    bvs .LBB1_2
 ; CHECK-T15TE-NEXT:  .LBB1_4:
-; CHECK-T15TE-NEXT:    movs r1, r3
-; CHECK-T15TE-NEXT:    pop {r4, pc}
+; CHECK-T15TE-NEXT:    movs r4, r1
+; CHECK-T15TE-NEXT:    movs r1, r4
+; CHECK-T15TE-NEXT:    pop {r4, r5, r7, pc}
   %tmp = call i64 @llvm.sadd.sat.i64(i64 %x, i64 %y)
   ret i64 %tmp
 }

--- a/llvm/test/CodeGen/ARM/sadd_sat_plus.ll
+++ b/llvm/test/CodeGen/ARM/sadd_sat_plus.ll
@@ -53,65 +53,54 @@ define i32 @func32(i32 %x, i32 %y, i32 %z) nounwind {
 define i64 @func64(i64 %x, i64 %y, i64 %z) nounwind {
 ; CHECK-T1-LABEL: func64:
 ; CHECK-T1:       @ %bb.0:
-; CHECK-T1-NEXT:    .save {r4, lr}
-; CHECK-T1-NEXT:    push {r4, lr}
-; CHECK-T1-NEXT:    ldr r3, [sp, #12]
-; CHECK-T1-NEXT:    mov r2, r1
-; CHECK-T1-NEXT:    eors r2, r3
-; CHECK-T1-NEXT:    ldr r4, [sp, #8]
-; CHECK-T1-NEXT:    adds r4, r0, r4
-; CHECK-T1-NEXT:    adcs r3, r1
-; CHECK-T1-NEXT:    eors r1, r3
-; CHECK-T1-NEXT:    bics r1, r2
-; CHECK-T1-NEXT:    asrs r0, r3, #31
+; CHECK-T1-NEXT:    .save {r4, r5, r7, lr}
+; CHECK-T1-NEXT:    push {r4, r5, r7, lr}
+; CHECK-T1-NEXT:    mov r3, r0
+; CHECK-T1-NEXT:    ldr r4, [sp, #20]
+; CHECK-T1-NEXT:    ldr r5, [sp, #16]
+; CHECK-T1-NEXT:    adds r0, r0, r5
+; CHECK-T1-NEXT:    mov r0, r1
+; CHECK-T1-NEXT:    adcs r0, r4
+; CHECK-T1-NEXT:    asrs r0, r0, #31
 ; CHECK-T1-NEXT:    movs r2, #1
 ; CHECK-T1-NEXT:    lsls r2, r2, #31
 ; CHECK-T1-NEXT:    eors r2, r0
-; CHECK-T1-NEXT:    cmp r1, #0
-; CHECK-T1-NEXT:    bpl .LBB1_3
+; CHECK-T1-NEXT:    adds r3, r3, r5
+; CHECK-T1-NEXT:    adcs r1, r4
+; CHECK-T1-NEXT:    bvc .LBB1_3
 ; CHECK-T1-NEXT:  @ %bb.1:
-; CHECK-T1-NEXT:    bpl .LBB1_4
+; CHECK-T1-NEXT:    bvc .LBB1_4
 ; CHECK-T1-NEXT:  .LBB1_2:
 ; CHECK-T1-NEXT:    mov r1, r2
-; CHECK-T1-NEXT:    pop {r4, pc}
+; CHECK-T1-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-T1-NEXT:  .LBB1_3:
-; CHECK-T1-NEXT:    mov r0, r4
-; CHECK-T1-NEXT:    bmi .LBB1_2
+; CHECK-T1-NEXT:    mov r0, r3
+; CHECK-T1-NEXT:    bvs .LBB1_2
 ; CHECK-T1-NEXT:  .LBB1_4:
-; CHECK-T1-NEXT:    mov r2, r3
+; CHECK-T1-NEXT:    mov r2, r1
 ; CHECK-T1-NEXT:    mov r1, r2
-; CHECK-T1-NEXT:    pop {r4, pc}
+; CHECK-T1-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; CHECK-T2-LABEL: func64:
 ; CHECK-T2:       @ %bb.0:
-; CHECK-T2-NEXT:    ldr r2, [sp]
-; CHECK-T2-NEXT:    ldr.w r12, [sp, #4]
-; CHECK-T2-NEXT:    adds r0, r0, r2
-; CHECK-T2-NEXT:    adc.w r2, r1, r12
-; CHECK-T2-NEXT:    eor.w r3, r1, r12
-; CHECK-T2-NEXT:    eors r1, r2
-; CHECK-T2-NEXT:    bics r1, r3
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    asrmi r0, r2, #31
-; CHECK-T2-NEXT:    mov.w r1, #-2147483648
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    eormi.w r2, r1, r2, asr #31
-; CHECK-T2-NEXT:    mov r1, r2
+; CHECK-T2-NEXT:    ldrd r3, r2, [sp]
+; CHECK-T2-NEXT:    adds r0, r0, r3
+; CHECK-T2-NEXT:    adcs r1, r2
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    asrvs r0, r1, #31
+; CHECK-T2-NEXT:    mov.w r2, #-2147483648
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    eorvs.w r1, r2, r1, asr #31
 ; CHECK-T2-NEXT:    bx lr
 ;
 ; CHECK-ARM-LABEL: func64:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    ldr r12, [sp]
-; CHECK-ARM-NEXT:    ldr r2, [sp, #4]
-; CHECK-ARM-NEXT:    adds r0, r0, r12
-; CHECK-ARM-NEXT:    eor r3, r1, r2
-; CHECK-ARM-NEXT:    adc r2, r1, r2
-; CHECK-ARM-NEXT:    eor r1, r1, r2
-; CHECK-ARM-NEXT:    bics r1, r1, r3
-; CHECK-ARM-NEXT:    asrmi r0, r2, #31
-; CHECK-ARM-NEXT:    mov r1, #-2147483648
-; CHECK-ARM-NEXT:    eormi r2, r1, r2, asr #31
-; CHECK-ARM-NEXT:    mov r1, r2
+; CHECK-ARM-NEXT:    ldm sp, {r2, r3}
+; CHECK-ARM-NEXT:    adds r0, r0, r2
+; CHECK-ARM-NEXT:    mov r2, #-2147483648
+; CHECK-ARM-NEXT:    adcs r1, r1, r3
+; CHECK-ARM-NEXT:    asrvs r0, r1, #31
+; CHECK-ARM-NEXT:    eorvs r1, r2, r1, asr #31
 ; CHECK-ARM-NEXT:    bx lr
   %a = mul i64 %y, %z
   %tmp = call i64 @llvm.sadd.sat.i64(i64 %x, i64 %z)

--- a/llvm/test/CodeGen/ARM/ssub_sat.ll
+++ b/llvm/test/CodeGen/ARM/ssub_sat.ll
@@ -64,56 +64,48 @@ define i64 @func2(i64 %x, i64 %y) nounwind {
 ; CHECK-T1:       @ %bb.0:
 ; CHECK-T1-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-T1-NEXT:    push {r4, r5, r7, lr}
-; CHECK-T1-NEXT:    mov r4, r1
-; CHECK-T1-NEXT:    eors r1, r3
-; CHECK-T1-NEXT:    subs r5, r0, r2
-; CHECK-T1-NEXT:    mov r2, r4
-; CHECK-T1-NEXT:    sbcs r2, r3
-; CHECK-T1-NEXT:    eors r4, r2
-; CHECK-T1-NEXT:    ands r4, r1
-; CHECK-T1-NEXT:    asrs r0, r2, #31
-; CHECK-T1-NEXT:    movs r1, #1
-; CHECK-T1-NEXT:    lsls r1, r1, #31
-; CHECK-T1-NEXT:    eors r1, r0
-; CHECK-T1-NEXT:    cmp r4, #0
-; CHECK-T1-NEXT:    bpl .LBB1_3
+; CHECK-T1-NEXT:    mov r5, r0
+; CHECK-T1-NEXT:    subs r0, r0, r2
+; CHECK-T1-NEXT:    mov r0, r1
+; CHECK-T1-NEXT:    sbcs r0, r3
+; CHECK-T1-NEXT:    asrs r0, r0, #31
+; CHECK-T1-NEXT:    movs r4, #1
+; CHECK-T1-NEXT:    lsls r4, r4, #31
+; CHECK-T1-NEXT:    eors r4, r0
+; CHECK-T1-NEXT:    subs r2, r5, r2
+; CHECK-T1-NEXT:    sbcs r1, r3
+; CHECK-T1-NEXT:    bvc .LBB1_3
 ; CHECK-T1-NEXT:  @ %bb.1:
-; CHECK-T1-NEXT:    bpl .LBB1_4
+; CHECK-T1-NEXT:    bvc .LBB1_4
 ; CHECK-T1-NEXT:  .LBB1_2:
+; CHECK-T1-NEXT:    mov r1, r4
 ; CHECK-T1-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-T1-NEXT:  .LBB1_3:
-; CHECK-T1-NEXT:    mov r0, r5
-; CHECK-T1-NEXT:    bmi .LBB1_2
+; CHECK-T1-NEXT:    mov r0, r2
+; CHECK-T1-NEXT:    bvs .LBB1_2
 ; CHECK-T1-NEXT:  .LBB1_4:
-; CHECK-T1-NEXT:    mov r1, r2
+; CHECK-T1-NEXT:    mov r4, r1
+; CHECK-T1-NEXT:    mov r1, r4
 ; CHECK-T1-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; CHECK-T2-LABEL: func2:
 ; CHECK-T2:       @ %bb.0:
 ; CHECK-T2-NEXT:    subs r0, r0, r2
-; CHECK-T2-NEXT:    eor.w r12, r1, r3
-; CHECK-T2-NEXT:    sbc.w r2, r1, r3
-; CHECK-T2-NEXT:    eors r1, r2
-; CHECK-T2-NEXT:    ands.w r1, r1, r12
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    asrmi r0, r2, #31
-; CHECK-T2-NEXT:    mov.w r1, #-2147483648
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    eormi.w r2, r1, r2, asr #31
-; CHECK-T2-NEXT:    mov r1, r2
+; CHECK-T2-NEXT:    mov.w r2, #-2147483648
+; CHECK-T2-NEXT:    sbcs r1, r3
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    asrvs r0, r1, #31
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    eorvs.w r1, r2, r1, asr #31
 ; CHECK-T2-NEXT:    bx lr
 ;
 ; CHECK-ARM-LABEL: func2:
 ; CHECK-ARM:       @ %bb.0:
 ; CHECK-ARM-NEXT:    subs r0, r0, r2
-; CHECK-ARM-NEXT:    eor r12, r1, r3
-; CHECK-ARM-NEXT:    sbc r2, r1, r3
-; CHECK-ARM-NEXT:    eor r1, r1, r2
-; CHECK-ARM-NEXT:    ands r1, r12, r1
-; CHECK-ARM-NEXT:    asrmi r0, r2, #31
-; CHECK-ARM-NEXT:    mov r1, #-2147483648
-; CHECK-ARM-NEXT:    eormi r2, r1, r2, asr #31
-; CHECK-ARM-NEXT:    mov r1, r2
+; CHECK-ARM-NEXT:    mov r2, #-2147483648
+; CHECK-ARM-NEXT:    sbcs r1, r1, r3
+; CHECK-ARM-NEXT:    asrvs r0, r1, #31
+; CHECK-ARM-NEXT:    eorvs r1, r2, r1, asr #31
 ; CHECK-ARM-NEXT:    bx lr
   %tmp = call i64 @llvm.ssub.sat.i64(i64 %x, i64 %y)
   ret i64 %tmp

--- a/llvm/test/CodeGen/ARM/ssub_sat_plus.ll
+++ b/llvm/test/CodeGen/ARM/ssub_sat_plus.ll
@@ -56,64 +56,52 @@ define i64 @func64(i64 %x, i64 %y, i64 %z) nounwind {
 ; CHECK-T1:       @ %bb.0:
 ; CHECK-T1-NEXT:    .save {r4, r5, r7, lr}
 ; CHECK-T1-NEXT:    push {r4, r5, r7, lr}
-; CHECK-T1-NEXT:    ldr r2, [sp, #20]
-; CHECK-T1-NEXT:    mov r5, r1
-; CHECK-T1-NEXT:    eors r5, r2
-; CHECK-T1-NEXT:    ldr r3, [sp, #16]
-; CHECK-T1-NEXT:    subs r4, r0, r3
-; CHECK-T1-NEXT:    mov r3, r1
-; CHECK-T1-NEXT:    sbcs r3, r2
-; CHECK-T1-NEXT:    eors r1, r3
-; CHECK-T1-NEXT:    ands r1, r5
-; CHECK-T1-NEXT:    asrs r0, r3, #31
+; CHECK-T1-NEXT:    mov r3, r0
+; CHECK-T1-NEXT:    ldr r4, [sp, #20]
+; CHECK-T1-NEXT:    ldr r5, [sp, #16]
+; CHECK-T1-NEXT:    subs r0, r0, r5
+; CHECK-T1-NEXT:    mov r0, r1
+; CHECK-T1-NEXT:    sbcs r0, r4
+; CHECK-T1-NEXT:    asrs r0, r0, #31
 ; CHECK-T1-NEXT:    movs r2, #1
 ; CHECK-T1-NEXT:    lsls r2, r2, #31
 ; CHECK-T1-NEXT:    eors r2, r0
-; CHECK-T1-NEXT:    cmp r1, #0
-; CHECK-T1-NEXT:    bpl .LBB1_3
+; CHECK-T1-NEXT:    subs r3, r3, r5
+; CHECK-T1-NEXT:    sbcs r1, r4
+; CHECK-T1-NEXT:    bvc .LBB1_3
 ; CHECK-T1-NEXT:  @ %bb.1:
-; CHECK-T1-NEXT:    bpl .LBB1_4
+; CHECK-T1-NEXT:    bvc .LBB1_4
 ; CHECK-T1-NEXT:  .LBB1_2:
 ; CHECK-T1-NEXT:    mov r1, r2
 ; CHECK-T1-NEXT:    pop {r4, r5, r7, pc}
 ; CHECK-T1-NEXT:  .LBB1_3:
-; CHECK-T1-NEXT:    mov r0, r4
-; CHECK-T1-NEXT:    bmi .LBB1_2
+; CHECK-T1-NEXT:    mov r0, r3
+; CHECK-T1-NEXT:    bvs .LBB1_2
 ; CHECK-T1-NEXT:  .LBB1_4:
-; CHECK-T1-NEXT:    mov r2, r3
+; CHECK-T1-NEXT:    mov r2, r1
 ; CHECK-T1-NEXT:    mov r1, r2
 ; CHECK-T1-NEXT:    pop {r4, r5, r7, pc}
 ;
 ; CHECK-T2-LABEL: func64:
 ; CHECK-T2:       @ %bb.0:
-; CHECK-T2-NEXT:    ldr r2, [sp]
-; CHECK-T2-NEXT:    ldr.w r12, [sp, #4]
-; CHECK-T2-NEXT:    subs r0, r0, r2
-; CHECK-T2-NEXT:    sbc.w r2, r1, r12
-; CHECK-T2-NEXT:    eor.w r3, r1, r12
-; CHECK-T2-NEXT:    eors r1, r2
-; CHECK-T2-NEXT:    ands r1, r3
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    asrmi r0, r2, #31
-; CHECK-T2-NEXT:    mov.w r1, #-2147483648
-; CHECK-T2-NEXT:    it mi
-; CHECK-T2-NEXT:    eormi.w r2, r1, r2, asr #31
-; CHECK-T2-NEXT:    mov r1, r2
+; CHECK-T2-NEXT:    ldrd r3, r2, [sp]
+; CHECK-T2-NEXT:    subs r0, r0, r3
+; CHECK-T2-NEXT:    sbcs r1, r2
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    asrvs r0, r1, #31
+; CHECK-T2-NEXT:    mov.w r2, #-2147483648
+; CHECK-T2-NEXT:    it vs
+; CHECK-T2-NEXT:    eorvs.w r1, r2, r1, asr #31
 ; CHECK-T2-NEXT:    bx lr
 ;
 ; CHECK-ARM-LABEL: func64:
 ; CHECK-ARM:       @ %bb.0:
-; CHECK-ARM-NEXT:    ldr r12, [sp]
-; CHECK-ARM-NEXT:    ldr r2, [sp, #4]
-; CHECK-ARM-NEXT:    subs r0, r0, r12
-; CHECK-ARM-NEXT:    eor r3, r1, r2
-; CHECK-ARM-NEXT:    sbc r2, r1, r2
-; CHECK-ARM-NEXT:    eor r1, r1, r2
-; CHECK-ARM-NEXT:    ands r1, r3, r1
-; CHECK-ARM-NEXT:    asrmi r0, r2, #31
-; CHECK-ARM-NEXT:    mov r1, #-2147483648
-; CHECK-ARM-NEXT:    eormi r2, r1, r2, asr #31
-; CHECK-ARM-NEXT:    mov r1, r2
+; CHECK-ARM-NEXT:    ldm sp, {r2, r3}
+; CHECK-ARM-NEXT:    subs r0, r0, r2
+; CHECK-ARM-NEXT:    mov r2, #-2147483648
+; CHECK-ARM-NEXT:    sbcs r1, r1, r3
+; CHECK-ARM-NEXT:    asrvs r0, r1, #31
+; CHECK-ARM-NEXT:    eorvs r1, r2, r1, asr #31
 ; CHECK-ARM-NEXT:    bx lr
   %a = mul i64 %y, %z
   %tmp = call i64 @llvm.ssub.sat.i64(i64 %x, i64 %z)


### PR DESCRIPTION
To do this, I did refactoring to mirror what goes on with AArch64, including having the carryFlagToValue do the inversion.

While the patterns are not the best, with pattern matching, I hope to at make it as good as AArch64 on Thumb2 where we have CSEL.