### PR TITLE
[lldb][windows] remove duplicate implementation of UTF8ToUTF16

### DIFF
--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -22,6 +22,7 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StructuredData.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/ManagedStatic.h"
@@ -31,6 +32,8 @@
 
 using namespace lldb;
 using namespace lldb_private;
+
+using llvm::sys::windows::UTF8ToUTF16;
 
 static bool GetTripleForProcess(const FileSpec &executable,
                                 llvm::Triple &triple) {
@@ -325,30 +328,17 @@ private:
 
 static llvm::ManagedStatic<WindowsEventLog> event_log;
 
-static std::wstring AnsiToUtf16(const std::string &ansi) {
-  if (ansi.empty())
-    return {};
-
-  const int unicode_length =
-      MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, nullptr, 0);
-  if (unicode_length == 0)
-    return {};
-
-  std::wstring unicode(unicode_length, L'\0');
-  MultiByteToWideChar(CP_ACP, 0, ansi.c_str(), -1, &unicode[0], unicode_length);
-  return unicode;
-}
-
 void Host::SystemLog(Severity severity, llvm::StringRef message) {
   HANDLE h = event_log->GetHandle();
   if (!h)
     return;
 
-  std::wstring wide_message = AnsiToUtf16(message.str());
-  if (wide_message.empty())
+  llvm::SmallVector<wchar_t, 1> argsUTF16;
+  if (UTF8ToUTF16(message.str(), argsUTF16))
     return;
 
-  LPCWSTR msg_ptr = wide_message.c_str();
+  if (argsUTF16.empty())
+    return;
 
   WORD event_type;
   switch (severity) {
@@ -363,5 +353,6 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
     event_type = EVENTLOG_INFORMATION_TYPE;
   }
 
-  ReportEventW(h, event_type, 0, 0, nullptr, 1, 0, &msg_ptr, nullptr);
+  LPCWSTR messages[] = {argsUTF16.data()};
+  ReportEventW(h, event_type, 0, 0, nullptr, 1, 0, messages, nullptr);
 }

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -329,15 +329,15 @@ private:
 static llvm::ManagedStatic<WindowsEventLog> event_log;
 
 void Host::SystemLog(Severity severity, llvm::StringRef message) {
+  if (message.empty())
+    return;
+
   HANDLE h = event_log->GetHandle();
   if (!h)
     return;
 
   llvm::SmallVector<wchar_t, 1> argsUTF16;
   if (UTF8ToUTF16(message.str(), argsUTF16))
-    return;
-
-  if (argsUTF16.empty())
     return;
 
   WORD event_type;
@@ -353,6 +353,7 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
     event_type = EVENTLOG_INFORMATION_TYPE;
   }
 
-  LPCWSTR messages[] = {argsUTF16.data()};
-  ReportEventW(h, event_type, 0, 0, nullptr, 1, 0, messages, nullptr);
+  LPCWSTR messages[1] = {argsUTF16.data()};
+  ReportEventW(h, event_type, 0, 0, nullptr, sizeof(messages), 0, messages,
+               nullptr);
 }

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -354,6 +354,6 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   }
 
   LPCWSTR messages[1] = {argsUTF16.data()};
-  ReportEventW(h, event_type, 0, 0, nullptr, sizeof(messages), 0, messages,
+  ReportEventW(h, event_type, 0, 0, nullptr, std::size(messages), 0, messages,
                nullptr);
 }


### PR DESCRIPTION
`std::wstring AnsiToUtf16(const std::string &ansi)` is a reimplementation of `llvm::sys::windows::UTF8ToUTF16`. This patch removes `AnsiToUtf16` and its usages entirely.