### PR TITLE
[Clang] Fix to diagnose_as_builtin memset

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3285,6 +3285,32 @@ public:
   }
 };
 
+class BuiltInLikeCall {
+  /// If the CallExpr is to a function that has a DiagnoseAsBuiltinAttr
+  /// attribute, then FDecl will be the function declaration in that attribute.
+  /// Otherwise, FDecl will be the function declaration for the CallExpr.
+  const FunctionDecl *FDecl;
+  const CallExpr *TheCall;
+  const DiagnoseAsBuiltinAttr *DABAttr;
+
+public:
+  BuiltInLikeCall(const FunctionDecl *FD, const CallExpr *TheCall)
+      : TheCall(TheCall) {
+    DABAttr = FD->getAttr<DiagnoseAsBuiltinAttr>();
+    if (DABAttr) {
+      FDecl = DABAttr->getFunction();
+      assert(FDecl && "Missing FunctionDecl in DiagnoseAsBuiltin attribute!");
+    } else {
+      FDecl = FD;
+    }
+  }
+  const FunctionDecl *getFDecl() const { return FDecl; }
+  const CallExpr *getCall() const { return TheCall; }
+  const DiagnoseAsBuiltinAttr *getDABAttr() const { return DABAttr; }
+  std::optional<unsigned> TranslateIndex(unsigned Index) const;
+  const Expr *getNonVariadicArg(unsigned Arg) const;
+};
+
 /// MemberExpr - [C99 6.5.2.3] Structure and Union Members.  X->F and X.F.
 ///
 class MemberExpr final

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3039,21 +3039,22 @@ private:
   /// function calls.
   ///
   /// \param Call The call expression to diagnose.
-  void CheckMemaccessArguments(const CallExpr *Call, unsigned BId,
+  void CheckMemaccessArguments(const BuiltInLikeCall &BILC, unsigned BId,
                                IdentifierInfo *FnName);
 
   // Warn if the user has made the 'size' argument to strlcpy or strlcat
   // be the size of the source, instead of the destination.
-  void CheckStrlcpycatArguments(const CallExpr *Call, IdentifierInfo *FnName);
+  void CheckStrlcpycatArguments(const BuiltInLikeCall &BILC,
+                                IdentifierInfo *FnName);
 
   // Warn on anti-patterns as the 'size' argument to strncat.
   // The correct size argument should look like following:
   //   strncat(dst, src, sizeof(dst) - strlen(dest) - 1);
-  void CheckStrncatArguments(const CallExpr *Call,
+  void CheckStrncatArguments(const BuiltInLikeCall &BILC,
                              const IdentifierInfo *FnName);
 
   /// Alerts the user that they are attempting to free a non-malloc'd object.
-  void CheckFreeArguments(const CallExpr *E);
+  void CheckFreeArguments(const BuiltInLikeCall &BILC);
 
   void CheckReturnValExpr(Expr *RetValExp, QualType lhsType,
                           SourceLocation ReturnLoc, bool isObjCMethod = false,

--- a/clang/test/Sema/transpose-memset.c
+++ b/clang/test/Sema/transpose-memset.c
@@ -61,3 +61,12 @@ void macros(void) {
   __builtin_memset(array, 1, 0); // expected-warning{{'size' argument to memset}} // expected-note{{parenthesize}}
   __builtin_bzero(array, 0); // expected-warning{{'size' argument to bzero}} // expected-note{{parenthesize}}
 }
+
+// Custom memset with diagnose_as_builtin attribute
+__attribute((diagnose_as_builtin(__builtin_memset, 2, 3, 1)))
+void custom_memset(unsigned long num, void *ptr, int value);
+
+void dab(void) {
+  char cs[4];
+  custom_memset(0, cs, 8); // expected-warning{{'size' argument to memset is '0'; did you mean to transpose the last two arguments}} expected-note{{parenthesize the third argument to silence}}
+}


### PR DESCRIPTION
The diagnose_as_builtin attribute can be used to request that Clang diagnose the annotated function as though it was a (user-specified) builtin.

This doesn't apply for -Wmemset-transposed-args as seen [here](https://godbolt.org/z/cc36TTGWW). This fix adds the diagnosis for this case.