### PR TITLE
[LLDB][AArch64] Make TPIDR a generic tp register

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -79,7 +79,8 @@ static lldb_private::RegisterInfo g_register_infos_mte[] = {
     DEFINE_EXTENSION_REG(mte_ctrl)};
 
 static lldb_private::RegisterInfo g_register_infos_tls[] = {
-    DEFINE_EXTENSION_REG(tpidr),
+    {"tpidr", nullptr, 8, 0, lldb::eEncodingUint, lldb::eFormatHex,
+     {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, LLDB_REGNUM_GENERIC_TP}, nullptr, nullptr, nullptr},
     // Only present when SME is present
     DEFINE_EXTENSION_REG(tpidr2)};
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -79,8 +79,16 @@ static lldb_private::RegisterInfo g_register_infos_mte[] = {
     DEFINE_EXTENSION_REG(mte_ctrl)};
 
 static lldb_private::RegisterInfo g_register_infos_tls[] = {
-    {"tpidr", nullptr, 8, 0, lldb::eEncodingUint, lldb::eFormatHex,
-     {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, LLDB_REGNUM_GENERIC_TP}, nullptr, nullptr, nullptr},
+    {"tpidr",
+     nullptr,
+     8,
+     0,
+     lldb::eEncodingUint,
+     lldb::eFormatHex,
+     {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, LLDB_REGNUM_GENERIC_TP},
+     nullptr,
+     nullptr,
+     nullptr},
     // Only present when SME is present
     DEFINE_EXTENSION_REG(tpidr2)};
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfoPOSIX_arm64.cpp
@@ -79,16 +79,7 @@ static lldb_private::RegisterInfo g_register_infos_mte[] = {
     DEFINE_EXTENSION_REG(mte_ctrl)};
 
 static lldb_private::RegisterInfo g_register_infos_tls[] = {
-    {"tpidr",
-     nullptr,
-     8,
-     0,
-     lldb::eEncodingUint,
-     lldb::eFormatHex,
-     {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, LLDB_REGNUM_GENERIC_TP},
-     nullptr,
-     nullptr,
-     nullptr},
+    DEFINE_EXTENSION_REG_GENERIC(tpidr, LLDB_REGNUM_GENERIC_TP),
     // Only present when SME is present
     DEFINE_EXTENSION_REG(tpidr2)};
 

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
@@ -545,7 +545,6 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
         KIND_ALL_INVALID, nullptr, nullptr, nullptr,                           \
   }
   
-// Used to define tpidr as a generic tp register
 #define DEFINE_EXTENSION_REG_GENERIC(reg, generic_kind)                        \
   {                                                                            \
     #reg, nullptr, 8, 0, lldb::eEncodingUint, lldb::eFormatHex,                \

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
@@ -471,8 +471,10 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
   }
 
 #define GENERIC_KIND(genenric_kind)                                            \
-  {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, genenric_kind,                    \
-   LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM}
+  {                                                                            \
+   LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, genenric_kind,                    \
+    LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM                                   \
+  }
 // Generates register kinds array for registers with only lldb kind
 #define KIND_ALL_INVALID                                                       \
   {                                                                            \

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
@@ -470,6 +470,9 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
         LLDB_INVALID_REGNUM, lldb_kind                                         \
   }
 
+#define GENERIC_KIND(genenric_kind)                                            \
+  {LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM, genenric_kind,                    \
+   LLDB_INVALID_REGNUM, LLDB_INVALID_REGNUM}
 // Generates register kinds array for registers with only lldb kind
 #define KIND_ALL_INVALID                                                       \
   {                                                                            \
@@ -539,6 +542,13 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
   {                                                                            \
     #reg, nullptr, 8, 0, lldb::eEncodingUint, lldb::eFormatHex,                \
         KIND_ALL_INVALID, nullptr, nullptr, nullptr,                           \
+  }
+  
+// Used to define tpidr as a generic tp register
+#define DEFINE_EXTENSION_REG_GENERIC(reg, generic_kind)                        \
+  {                                                                            \
+    #reg, nullptr, 8, 0, lldb::eEncodingUint, lldb::eFormatHex,                \
+        GENERIC_KIND(generic_kind), nullptr, nullptr, nullptr,                 \
   }
 
 static lldb_private::RegisterInfo g_register_infos_arm64_le[] = {

--- a/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterInfos_arm64.h
@@ -456,6 +456,7 @@ static uint32_t g_d29_invalidates[] = {fpu_v29, fpu_s29, LLDB_INVALID_REGNUM};
 static uint32_t g_d30_invalidates[] = {fpu_v30, fpu_s30, LLDB_INVALID_REGNUM};
 static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
 
+// clang-format off
 // Generates register kinds array with DWARF, EH frame and generic kind
 #define MISC_KIND(reg, type, generic_kind)                                     \
   {                                                                            \
@@ -488,8 +489,6 @@ static uint32_t g_d31_invalidates[] = {fpu_v31, fpu_s31, LLDB_INVALID_REGNUM};
 #define MISC_GPR_KIND(lldb_kind) MISC_KIND(cpsr, gpr, LLDB_REGNUM_GENERIC_FLAGS)
 #define MISC_FPU_KIND(lldb_kind) LLDB_KIND(lldb_kind)
 #define MISC_EXC_KIND(lldb_kind) LLDB_KIND(lldb_kind)
-
-// clang-format off
 
 // Defines a 64-bit general purpose register
 #define DEFINE_GPR64(reg, generic_kind)                                        \

--- a/lldb/test/API/linux/aarch64/tls_registers/TestAArch64LinuxTLSRegisters.py
+++ b/lldb/test/API/linux/aarch64/tls_registers/TestAArch64LinuxTLSRegisters.py
@@ -102,7 +102,6 @@ class AArch64LinuxTLSRegisters(TestBase):
             self.skipTest("SME must not be present.")
 
         self.check_tls_reg(["tpidr"])
-        
 
     @skipUnlessArch("aarch64")
     @skipUnlessPlatform(["linux"])

--- a/lldb/test/API/linux/aarch64/tls_registers/TestAArch64LinuxTLSRegisters.py
+++ b/lldb/test/API/linux/aarch64/tls_registers/TestAArch64LinuxTLSRegisters.py
@@ -93,6 +93,8 @@ class AArch64LinuxTLSRegisters(TestBase):
         for register in registers:
             self.expect("p {}_was_set".format(register), substrs=["true"])
 
+        self.expect("reg read tp", substrs=[hex(set_values["tpidr"])])
+
     @skipUnlessArch("aarch64")
     @skipUnlessPlatform(["linux"])
     def test_tls_no_sme(self):
@@ -100,6 +102,7 @@ class AArch64LinuxTLSRegisters(TestBase):
             self.skipTest("SME must not be present.")
 
         self.check_tls_reg(["tpidr"])
+        
 
     @skipUnlessArch("aarch64")
     @skipUnlessPlatform(["linux"])

--- a/lldb/test/API/linux/aarch64/tls_registers/TestAArch64LinuxTLSRegisters.py
+++ b/lldb/test/API/linux/aarch64/tls_registers/TestAArch64LinuxTLSRegisters.py
@@ -53,6 +53,8 @@ class AArch64LinuxTLSRegisters(TestBase):
                 tls_reg.IsValid(), "{} register not found.".format(register)
             )
             self.assertEqual(tls_reg.GetValueAsUnsigned(), values[register])
+            if register == "tpidr":
+                self.expect("reg read tp", substrs=[hex(values[register])])
 
     def check_tls_reg(self, registers):
         self.setup(registers)
@@ -92,8 +94,6 @@ class AArch64LinuxTLSRegisters(TestBase):
 
         for register in registers:
             self.expect("p {}_was_set".format(register), substrs=["true"])
-
-        self.expect("reg read tp", substrs=[hex(set_values["tpidr"])])
 
     @skipUnlessArch("aarch64")
     @skipUnlessPlatform(["linux"])


### PR DESCRIPTION
Unlike x86, ARM doesn't support a generic thread pointer for TLS data, so things like
```
reg read tp
...
memory read tp
```

Don't work, and you need to specify tpidr. This works, especially because that's the name GDB uses. But for ease of use, and at the request of aperez I've made it so we can reference it via `tp`.

I personally don't have an aarch machine, and all the arm examples in `Shell/Register/Core` are freebsd and don't contain tpidr, so I was unable to add a shell test for this. I added a test to the AARCH register tests, but without an Aarch machine I'm hoping these work.