### PR TITLE
[lldb/API] Add setters to SBStructuredData

### DIFF
--- a/lldb/include/lldb/API/SBStructuredData.h
+++ b/lldb/include/lldb/API/SBStructuredData.h
@@ -109,6 +109,35 @@ public:
   /// Return the generic pointer if this data structure is a generic type.
   lldb::SBScriptObject GetGenericValue() const;
 
+  /// Set the value corresponding to a key. If this data structure
+  /// is not a dictionary type, reset the type to be dictionary and overwrite
+  /// the previous data.
+  void SetValueForKey(const char *key, SBStructuredData &value);
+
+  /// Change the type to unsigned interger and overwrite the previous data with
+  /// the new value.
+  void SetUnsignedIntegerValue(uint64_t value);
+
+  /// Change the type to signed interger and overwrite the previous data with
+  /// the new value.
+  void SetSignedIntegerValue(int64_t value);
+
+  /// Change the type to float and overwrite the previous data with the new
+  /// value.
+  void SetFloatValue(double value);
+
+  /// Change the type to boolean and overwrite the previous data with the new
+  /// value.
+  void SetBooleanValue(bool value);
+
+  /// Change the type to string and overwrite the previous data with the new
+  /// value.
+  void SetStringValue(const char *value);
+
+  /// Change the type to generic and overwrite the previous data with the new
+  /// value.
+  void SetGenericValue(SBScriptObject value);
+
 protected:
   friend class SBAttachInfo;
   friend class SBCommandReturnObject;

--- a/lldb/include/lldb/Core/StructuredDataImpl.h
+++ b/lldb/include/lldb/Core/StructuredDataImpl.h
@@ -81,6 +81,41 @@ public:
 
   void SetObjectSP(const StructuredData::ObjectSP &obj) { m_data_sp = obj; }
 
+  void SetValueForKey(llvm::StringRef key,
+                      const StructuredData::ObjectSP &value) {
+    if (!m_data_sp ||
+        m_data_sp->GetType() != lldb::eStructuredDataTypeDictionary) {
+      m_data_sp = StructuredData::FromKeyValue(key, value);
+    } else if (StructuredData::Dictionary *dict =
+                   m_data_sp->GetAsDictionary()) {
+      dict->AddItem(key, value);
+    }
+  }
+
+  void SetUnsignedIntegerValue(uint64_t value) {
+    m_data_sp = StructuredData::FromInteger(value);
+  }
+
+  void SetSignedIntegerValue(int64_t value) {
+    m_data_sp = StructuredData::FromInteger(value);
+  }
+
+  void SetFloatValue(double value) {
+    m_data_sp = StructuredData::FromFloat(value);
+  }
+
+  void SetBooleanValue(bool value) {
+    m_data_sp = StructuredData::FromBoolean(value);
+  }
+
+  void SetStringValue(std::string value) {
+    m_data_sp = StructuredData::FromString(std::move(value));
+  }
+
+  void SetGenericValue(void *value) {
+    m_data_sp = StructuredData::FromGeneric(value);
+  }
+
   lldb::StructuredDataType GetType() const {
     return (m_data_sp ? m_data_sp->GetType() :
         lldb::eStructuredDataTypeInvalid);

--- a/lldb/include/lldb/Utility/StructuredData.h
+++ b/lldb/include/lldb/Utility/StructuredData.h
@@ -432,7 +432,7 @@ public:
       }
       return success;
     }
-      
+
     template <class IntType>
     bool GetValueForKeyAsInteger(llvm::StringRef key, IntType &result) const {
       ObjectSP value_sp = GetValueForKey(key);
@@ -573,6 +573,30 @@ public:
   private:
     void *m_object;
   };
+
+  template <typename T> static ObjectSP FromInteger(T value) {
+    return std::make_shared<Integer<T>>(value);
+  }
+
+  static StructuredData::ObjectSP FromFloat(double value) {
+    return std::make_shared<StructuredData::Float>(value);
+  }
+  static StructuredData::ObjectSP FromBoolean(bool value) {
+    return std::make_shared<StructuredData::Boolean>(value);
+  }
+  static StructuredData::ObjectSP FromString(std::string value) {
+    return std::make_shared<StructuredData::String>(value);
+  }
+  static StructuredData::ObjectSP FromGeneric(void *value) {
+    return std::make_shared<StructuredData::Generic>(value);
+  }
+
+  static StructuredData::ObjectSP
+  FromKeyValue(llvm::StringRef key, const StructuredData::ObjectSP &value_sp) {
+    auto dict_sp = std::make_shared<StructuredData::Dictionary>();
+    dict_sp->AddItem(key, value_sp);
+    return dict_sp;
+  }
 
   static ObjectSP ParseJSON(llvm::StringRef json_text);
   static ObjectSP ParseJSONFromFile(const FileSpec &file, Status &error);

--- a/lldb/source/API/SBStructuredData.cpp
+++ b/lldb/source/API/SBStructuredData.cpp
@@ -232,3 +232,47 @@ lldb::SBScriptObject SBStructuredData::GetGenericValue() const {
 
   return {m_impl_up->GetGenericValue(), eScriptLanguageDefault};
 }
+
+void SBStructuredData::SetValueForKey(const char *key,
+                                      SBStructuredData &value) {
+  LLDB_INSTRUMENT_VA(this, key, value);
+
+  if (StructuredData::ObjectSP obj_sp = value.m_impl_up->GetObjectSP())
+    m_impl_up->SetValueForKey(key, obj_sp);
+}
+
+void SBStructuredData::SetUnsignedIntegerValue(uint64_t value) {
+  LLDB_INSTRUMENT_VA(this, value);
+
+  m_impl_up->SetUnsignedIntegerValue(value);
+}
+
+void SBStructuredData::SetSignedIntegerValue(int64_t value) {
+  LLDB_INSTRUMENT_VA(this, value);
+
+  m_impl_up->SetSignedIntegerValue(value);
+}
+
+void SBStructuredData::SetFloatValue(double value) {
+  LLDB_INSTRUMENT_VA(this, value);
+
+  m_impl_up->SetFloatValue(value);
+}
+
+void SBStructuredData::SetBooleanValue(bool value) {
+  LLDB_INSTRUMENT_VA(this, value);
+
+  m_impl_up->SetBooleanValue(value);
+}
+
+void SBStructuredData::SetStringValue(const char *value) {
+  LLDB_INSTRUMENT_VA(this, value);
+
+  m_impl_up->SetStringValue(value);
+}
+
+void SBStructuredData::SetGenericValue(SBScriptObject value) {
+  LLDB_INSTRUMENT_VA(this, value);
+
+  m_impl_up->SetGenericValue(value.GetPointer());
+}


### PR DESCRIPTION
This patch adds setters to the SBStruturedData class to be able to initialize said object from the client side directly.