### PR TITLE
Be explicit about what libstdc++ C++11 ABI to use

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -175,6 +175,24 @@ if(LLVM_ENABLE_EXPENSIVE_CHECKS)
   endif()
 endif()
 
+CHECK_CXX_SOURCE_COMPILES("
+#include <iosfwd>
+#if !defined(__GLIBCXX__)
+#error Not libstdc++
+#endif
+int main() { return 0; }
+" LLVM_USES_LIBSTDCXX)
+
+option(GLIBCXX_USE_CXX11_ABI "Use new libstdc++ CXX11 ABI" OFF)
+
+if (LLVM_USES_LIBSTDCXX)
+  if (GLIBCXX_USE_CXX11_ABI)
+    add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=1)
+  else()
+    add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0)
+  endif()
+endif()
+
 if (LLVM_ENABLE_STRICT_FIXED_SIZE_VECTORS)
   add_compile_definitions(STRICT_FIXED_SIZE_VECTORS)
 endif()


### PR DESCRIPTION
libstdc++ can be configured to default to a different C++11 ABI, and when the system that is used to build clang has a different default than the system used to build a clang plugin, that leads to uses of different ABIs, leading to breakage (missing symbols) when using clang APIs that use types like std::string.

We arbitrarily choose to default to the old ABI, but the user can opt-in to the new ABI. The important part is that whichever is picked is reflected in llvm-config's output.