### PR TITLE
[clang] Upstream `clang::CodeGen::getConstantSignedPointer`

### DIFF
--- a/clang/include/clang/CodeGen/CodeGenABITypes.h
+++ b/clang/include/clang/CodeGen/CodeGenABITypes.h
@@ -32,6 +32,7 @@
 namespace llvm {
 class AttrBuilder;
 class Constant;
+class ConstantInt;
 class Function;
 class FunctionType;
 class Type;
@@ -125,6 +126,12 @@ uint16_t getPointerAuthDeclDiscriminator(CodeGenModule &CGM, GlobalDecl GD);
 /// Return a type discriminator for the given function type.
 uint16_t getPointerAuthTypeDiscriminator(CodeGenModule &CGM,
                                          QualType FunctionType);
+
+/// Return a signed constant pointer.
+llvm::Constant *getConstantSignedPointer(CodeGenModule &CGM,
+                                         llvm::Constant *Pointer, unsigned Key,
+                                         llvm::Constant *StorageAddress,
+                                         llvm::ConstantInt *OtherDiscriminator);
 
 /// Given the language and code-generation options that Clang was configured
 /// with, set the default LLVM IR attributes for a function definition.

--- a/clang/lib/CodeGen/CGPointerAuth.cpp
+++ b/clang/lib/CodeGen/CGPointerAuth.cpp
@@ -466,6 +466,14 @@ llvm::Constant *CodeGenModule::getConstantSignedPointer(
                                   OtherDiscriminator);
 }
 
+llvm::Constant *
+CodeGen::getConstantSignedPointer(CodeGenModule &CGM, llvm::Constant *Pointer,
+                                  unsigned Key, llvm::Constant *StorageAddress,
+                                  llvm::ConstantInt *OtherDiscriminator) {
+  return CGM.getConstantSignedPointer(Pointer, Key, StorageAddress,
+                                      OtherDiscriminator);
+}
+
 /// If applicable, sign a given constant function pointer with the ABI rules for
 /// functionType.
 llvm::Constant *CodeGenModule::getFunctionPointer(llvm::Constant *Pointer,


### PR DESCRIPTION
This function was introduced to Swift's fork in
https://github.com/swiftlang/llvm-project/commit/a9dd959e60c32#diff-db27b2738ad84e3f1093f9174710710478f853804d995a6de2816d1caaad30d1.

The Swift compiler cannot use `CodeGenModule::getConstantSignedPointer`, to which it forwards, because that is a private interface.