### PR TITLE
[HLSL][DirectX] Add the Qdx-rootsignature-strip driver option

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -479,6 +479,9 @@ CODEGENOPT(StaticClosure, 1, 0, Benign)
 /// Assume that UAVs/SRVs may alias
 CODEGENOPT(ResMayAlias, 1, 0, Benign)
 
+/// Omit the root signature from produced DXContainer
+CODEGENOPT(HLSLRootSigStrip, 1, 0, Benign)
+
 /// Controls how unwind v2 (epilog) information should be generated for x64
 /// Windows.
 ENUM_CODEGENOPT(WinX64EHUnwindV2, WinX64EHUnwindV2Mode,

--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -479,9 +479,6 @@ CODEGENOPT(StaticClosure, 1, 0, Benign)
 /// Assume that UAVs/SRVs may alias
 CODEGENOPT(ResMayAlias, 1, 0, Benign)
 
-/// Omit the root signature from produced DXContainer
-CODEGENOPT(HLSLRootSigStrip, 1, 0, Benign)
-
 /// Controls how unwind v2 (epilog) information should be generated for x64
 /// Windows.
 ENUM_CODEGENOPT(WinX64EHUnwindV2, WinX64EHUnwindV2Mode,

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -76,9 +76,10 @@ public:
     StaticLibJobClass,
     BinaryAnalyzeJobClass,
     BinaryTranslatorJobClass,
+    BinaryModifyJobClass,
 
     JobClassFirst = PreprocessJobClass,
-    JobClassLast = BinaryTranslatorJobClass
+    JobClassLast = BinaryModifyJobClass
   };
 
   // The offloading kind determines if this action is binded to a particular
@@ -684,6 +685,17 @@ public:
 
   static bool classof(const Action *A) {
     return A->getKind() == BinaryTranslatorJobClass;
+  }
+};
+
+class BinaryModifyJobAction : public JobAction {
+  void anchor() override;
+
+public:
+  BinaryModifyJobAction(Action *Input, types::ID Type);
+
+  static bool classof(const Action *A) {
+    return A->getKind() == BinaryModifyJobClass;
   }
 };
 

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -76,10 +76,10 @@ public:
     StaticLibJobClass,
     BinaryAnalyzeJobClass,
     BinaryTranslatorJobClass,
-    BinaryModifyJobClass,
+    ObjcopyJobClass,
 
     JobClassFirst = PreprocessJobClass,
-    JobClassLast = BinaryModifyJobClass
+    JobClassLast = ObjcopyJobClass
   };
 
   // The offloading kind determines if this action is binded to a particular
@@ -688,14 +688,14 @@ public:
   }
 };
 
-class BinaryModifyJobAction : public JobAction {
+class ObjcopyJobAction : public JobAction {
   void anchor() override;
 
 public:
-  BinaryModifyJobAction(Action *Input, types::ID Type);
+  ObjcopyJobAction(Action *Input, types::ID Type);
 
   static bool classof(const Action *A) {
-    return A->getKind() == BinaryModifyJobClass;
+    return A->getKind() == ObjcopyJobClass;
   }
 };
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9404,6 +9404,12 @@ def res_may_alias : Option<["/", "-"], "res-may-alias", KIND_FLAG>,
   Visibility<[DXCOption, ClangOption, CC1Option]>,
   HelpText<"Assume that UAVs/SRVs may alias">,
   MarshallingInfoFlag<CodeGenOpts<"ResMayAlias">>;
+def dxc_strip_rootsignature :
+  Option<["/", "-"], "Qstrip-rootsignature", KIND_FLAG>,
+  Group<dxc_Group>,
+  Visibility<[DXCOption]>,
+  HelpText<"Omit the root signature from produced DXContainer">,
+  MarshallingInfoFlag<CodeGenOpts<"HLSLRootSigStrip">>;
 def target_profile : DXCJoinedOrSeparate<"T">, MetaVarName<"<profile>">,
   HelpText<"Set target profile">,
   Values<"ps_6_0, ps_6_1, ps_6_2, ps_6_3, ps_6_4, ps_6_5, ps_6_6, ps_6_7,"

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9408,8 +9408,7 @@ def dxc_strip_rootsignature :
   Option<["/", "-"], "Qstrip-rootsignature", KIND_FLAG>,
   Group<dxc_Group>,
   Visibility<[DXCOption]>,
-  HelpText<"Omit the root signature from produced DXContainer">,
-  MarshallingInfoFlag<CodeGenOpts<"HLSLRootSigStrip">>;
+  HelpText<"Omit the root signature from produced DXContainer">;
 def target_profile : DXCJoinedOrSeparate<"T">, MetaVarName<"<profile>">,
   HelpText<"Set target profile">,
   Values<"ps_6_0, ps_6_1, ps_6_2, ps_6_3, ps_6_4, ps_6_5, ps_6_6, ps_6_7,"

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -52,8 +52,8 @@ const char *Action::getClassName(ActionClass AC) {
     return "binary-analyzer";
   case BinaryTranslatorJobClass:
     return "binary-translator";
-  case BinaryModifyJobClass:
-    return "binary-modifier";
+  case ObjcopyJobClass:
+    return "objcopy";
   }
 
   llvm_unreachable("invalid class");
@@ -470,7 +470,7 @@ BinaryTranslatorJobAction::BinaryTranslatorJobAction(Action *Input,
                                                      types::ID Type)
     : JobAction(BinaryTranslatorJobClass, Input, Type) {}
 
-void BinaryModifyJobAction::anchor() {}
+void ObjcopyJobAction::anchor() {}
 
-BinaryModifyJobAction::BinaryModifyJobAction(Action *Input, types::ID Type)
-    : JobAction(BinaryModifyJobClass, Input, Type) {}
+ObjcopyJobAction::ObjcopyJobAction(Action *Input, types::ID Type)
+    : JobAction(ObjcopyJobClass, Input, Type) {}

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -52,6 +52,8 @@ const char *Action::getClassName(ActionClass AC) {
     return "binary-analyzer";
   case BinaryTranslatorJobClass:
     return "binary-translator";
+  case BinaryModifyJobClass:
+    return "binary-modifier";
   }
 
   llvm_unreachable("invalid class");
@@ -467,3 +469,8 @@ void BinaryTranslatorJobAction::anchor() {}
 BinaryTranslatorJobAction::BinaryTranslatorJobAction(Action *Input,
                                                      types::ID Type)
     : JobAction(BinaryTranslatorJobClass, Input, Type) {}
+
+void BinaryModifyJobAction::anchor() {}
+
+BinaryModifyJobAction::BinaryModifyJobAction(Action *Input, types::ID Type)
+    : JobAction(BinaryModifyJobClass, Input, Type) {}

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4646,14 +4646,14 @@ void Driver::BuildDefaultActions(Compilation &C, DerivedArgList &Args,
     const auto &TC =
         static_cast<const toolchains::HLSLToolChain &>(C.getDefaultToolChain());
 
-    // Call objcopy for manipulation of the DXContainer when an option in Args
-    // requires it.
+    // Call objcopy for manipulation of the unvalidated DXContainer when an
+    // option in Args requires it.
     if (TC.requiresObjcopy(Args)) {
       Action *LastAction = Actions.back();
       // llvm-objcopy expects an unvalidated DXIL container (TY_OBJECT).
       if (LastAction->getType() == types::TY_Object)
         Actions.push_back(
-            C.MakeAction<ObjcopyJobAction>(LastAction, types::TY_DX_CONTAINER));
+            C.MakeAction<ObjcopyJobAction>(LastAction, types::TY_Object));
     }
 
     // Call validator for dxil when -Vd not in Args.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4662,6 +4662,16 @@ void Driver::BuildDefaultActions(Compilation &C, DerivedArgList &Args,
         Actions.push_back(C.MakeAction<BinaryTranslatorJobAction>(
             LastAction, types::TY_DX_CONTAINER));
     }
+    if (TC.requiresObjcopy(Args)) {
+      Action *LastAction = Actions.back();
+      // llvm-objcopy expects a DXIL container, which can either be
+      // validated (in which case they are TY_DX_CONTAINER), or unvalidated
+      // (TY_OBJECT).
+      if (LastAction->getType() == types::TY_DX_CONTAINER ||
+          LastAction->getType() == types::TY_Object)
+        Actions.push_back(C.MakeAction<BinaryModifyJobAction>(
+            LastAction, types::TY_DX_CONTAINER));
+    }
   }
 
   // Claim ignored clang-cl options.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4669,8 +4669,8 @@ void Driver::BuildDefaultActions(Compilation &C, DerivedArgList &Args,
       // (TY_OBJECT).
       if (LastAction->getType() == types::TY_DX_CONTAINER ||
           LastAction->getType() == types::TY_Object)
-        Actions.push_back(C.MakeAction<BinaryModifyJobAction>(
-            LastAction, types::TY_DX_CONTAINER));
+        Actions.push_back(
+            C.MakeAction<ObjcopyJobAction>(LastAction, types::TY_DX_CONTAINER));
     }
   }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6266,8 +6266,9 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
        C.getArgs().hasArg(options::OPT_dxc_Fo)) ||
       JA.getType() == types::TY_DX_CONTAINER) {
     StringRef FoValue = C.getArgs().getLastArgValue(options::OPT_dxc_Fo);
-    // If we are targeting DXIL and not validating or translating, we should set
-    // the final result file. Otherwise we should emit to a temporary.
+    // If we are targeting DXIL and not validating/translating/objcopying, we
+    // should set the final result file. Otherwise we should emit to a
+    // temporary.
     if (C.getDefaultToolChain().getTriple().isDXIL()) {
       const auto &TC = static_cast<const toolchains::HLSLToolChain &>(
           C.getDefaultToolChain());

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -652,7 +652,7 @@ Tool *ToolChain::getTool(Action::ActionClass AC) const {
   case Action::VerifyDebugInfoJobClass:
   case Action::BinaryAnalyzeJobClass:
   case Action::BinaryTranslatorJobClass:
-  case Action::BinaryModifyJobClass:
+  case Action::ObjcopyJobClass:
     llvm_unreachable("Invalid tool kind.");
 
   case Action::CompileJobClass:

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -652,6 +652,7 @@ Tool *ToolChain::getTool(Action::ActionClass AC) const {
   case Action::VerifyDebugInfoJobClass:
   case Action::BinaryAnalyzeJobClass:
   case Action::BinaryTranslatorJobClass:
+  case Action::BinaryModifyJobClass:
     llvm_unreachable("Invalid tool kind.");
 
   case Action::CompileJobClass:

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -489,14 +489,11 @@ bool HLSLToolChain::requiresObjcopy(DerivedArgList &Args) const {
 
 bool HLSLToolChain::isLastJob(DerivedArgList &Args,
                               Action::ActionClass AC) const {
-  bool HasObjcopy = requiresObjcopy(Args);
-  if (HasObjcopy)
+  if (requiresObjcopy(Args))
     return AC == Action::Action::ObjcopyJobClass;
-  bool HasTranslation = requiresBinaryTranslation(Args);
-  if (HasTranslation)
+  if (requiresBinaryTranslation(Args))
     return AC == Action::Action::BinaryTranslatorJobClass;
-  bool HasValidation = requiresValidation(Args);
-  if (HasValidation)
+  if (requiresValidation(Args))
     return AC == Action::Action::BinaryAnalyzeJobClass;
 
   // No translation, validation, or objcopy are required, so this action must

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -295,11 +295,11 @@ void tools::hlsl::MetalConverter::ConstructJob(
                                          Exec, CmdArgs, Inputs, Input));
 }
 
-void tools::hlsl::LLVMObjcopy::ConstructJob(Compilation &C, const JobAction &JA,
-                                            const InputInfo &Output,
-                                            const InputInfoList &Inputs,
-                                            const ArgList &Args,
-                                            const char *LinkingOutput) const {
+void tools::LLVMObjcopy::ConstructJob(Compilation &C, const JobAction &JA,
+                                      const InputInfo &Output,
+                                      const InputInfoList &Inputs,
+                                      const ArgList &Args,
+                                      const char *LinkingOutput) const {
 
   std::string ObjcopyPath = getToolChain().GetProgramPath("llvm-objcopy");
   const char *Exec = Args.MakeArgString(ObjcopyPath);
@@ -339,9 +339,9 @@ Tool *clang::driver::toolchains::HLSLToolChain::getTool(
     if (!MetalConverter)
       MetalConverter.reset(new tools::hlsl::MetalConverter(*this));
     return MetalConverter.get();
-  case Action::BinaryModifyJobClass:
+  case Action::ObjcopyJobClass:
     if (!LLVMObjcopy)
-      LLVMObjcopy.reset(new tools::hlsl::LLVMObjcopy(*this));
+      LLVMObjcopy.reset(new tools::LLVMObjcopy(*this));
     return LLVMObjcopy.get();
   default:
     return ToolChain::getTool(AC);
@@ -498,7 +498,7 @@ bool HLSLToolChain::isLastJob(DerivedArgList &Args,
       (!HasTranslation && HasValidation &&
        AC == Action::BinaryAnalyzeJobClass) ||
       (!HasTranslation && !HasValidation && HasObjcopy &&
-       AC == Action::BinaryModifyJobClass))
+       AC == Action::ObjcopyJobClass))
     return true;
   return false;
 }

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -489,12 +489,13 @@ bool HLSLToolChain::requiresObjcopy(DerivedArgList &Args) const {
 
 bool HLSLToolChain::isLastJob(DerivedArgList &Args,
                               Action::ActionClass AC) const {
-  if (requiresObjcopy(Args))
-    return AC == Action::Action::ObjcopyJobClass;
+  // Note: we check in the reverse order of execution
   if (requiresBinaryTranslation(Args))
     return AC == Action::Action::BinaryTranslatorJobClass;
   if (requiresValidation(Args))
     return AC == Action::Action::BinaryAnalyzeJobClass;
+  if (requiresObjcopy(Args))
+    return AC == Action::Action::ObjcopyJobClass;
 
   // No translation, validation, or objcopy are required, so this action must
   // output to the result file.

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -295,11 +295,11 @@ void tools::hlsl::MetalConverter::ConstructJob(
                                          Exec, CmdArgs, Inputs, Input));
 }
 
-void tools::LLVMObjcopy::ConstructJob(Compilation &C, const JobAction &JA,
-                                      const InputInfo &Output,
-                                      const InputInfoList &Inputs,
-                                      const ArgList &Args,
-                                      const char *LinkingOutput) const {
+void tools::hlsl::LLVMObjcopy::ConstructJob(Compilation &C, const JobAction &JA,
+                                            const InputInfo &Output,
+                                            const InputInfoList &Inputs,
+                                            const ArgList &Args,
+                                            const char *LinkingOutput) const {
 
   std::string ObjcopyPath = getToolChain().GetProgramPath("llvm-objcopy");
   const char *Exec = Args.MakeArgString(ObjcopyPath);
@@ -343,7 +343,7 @@ Tool *clang::driver::toolchains::HLSLToolChain::getTool(
     return MetalConverter.get();
   case Action::ObjcopyJobClass:
     if (!LLVMObjcopy)
-      LLVMObjcopy.reset(new tools::LLVMObjcopy(*this));
+      LLVMObjcopy.reset(new tools::hlsl::LLVMObjcopy(*this));
     return LLVMObjcopy.get();
   default:
     return ToolChain::getTool(AC);

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -489,18 +489,17 @@ bool HLSLToolChain::requiresObjcopy(DerivedArgList &Args) const {
 
 bool HLSLToolChain::isLastJob(DerivedArgList &Args,
                               Action::ActionClass AC) const {
-  bool HasTranslation = requiresBinaryTranslation(Args);
-  bool HasValidation = requiresValidation(Args);
   bool HasObjcopy = requiresObjcopy(Args);
-  // If translation and validation are not required, we should only have one
-  // action.
-  if (!HasTranslation && !HasValidation && !HasObjcopy)
-    return true;
-  if ((HasTranslation && AC == Action::BinaryTranslatorJobClass) ||
-      (!HasTranslation && HasValidation &&
-       AC == Action::BinaryAnalyzeJobClass) ||
-      (!HasTranslation && !HasValidation && HasObjcopy &&
-       AC == Action::ObjcopyJobClass))
-    return true;
-  return false;
+  if (HasObjcopy)
+    return AC == Action::Action::ObjcopyJobClass;
+  bool HasTranslation = requiresBinaryTranslation(Args);
+  if (HasTranslation)
+    return AC == Action::Action::BinaryTranslatorJobClass;
+  bool HasValidation = requiresValidation(Args);
+  if (HasValidation)
+    return AC == Action::Action::BinaryAnalyzeJobClass;
+
+  // No translation, validation, or objcopy are required, so this action must
+  // output to the result file.
+  return true;
 }

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -315,6 +315,8 @@ void tools::LLVMObjcopy::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Frs);
   }
 
+  assert(CmdArgs.size() > 2 && "Unnecessary invocation of objcopy.");
+
   C.addCommand(std::make_unique<Command>(JA, *this, ResponseFileSupport::None(),
                                          Exec, CmdArgs, Inputs, Input));
 }

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -42,6 +42,19 @@ public:
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
 };
+
+class LLVM_LIBRARY_VISIBILITY LLVMObjcopy : public Tool {
+public:
+  LLVMObjcopy(const ToolChain &TC)
+      : Tool("hlsl::LLVMObjcopy", "llvm-objcopy", TC) {}
+
+  bool hasIntegratedCPP() const override { return false; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+};
 } // namespace hlsl
 } // namespace tools
 
@@ -65,6 +78,7 @@ public:
   static std::optional<std::string> parseTargetProfile(StringRef TargetProfile);
   bool requiresValidation(llvm::opt::DerivedArgList &Args) const;
   bool requiresBinaryTranslation(llvm::opt::DerivedArgList &Args) const;
+  bool requiresObjcopy(llvm::opt::DerivedArgList &Args) const;
   bool isLastJob(llvm::opt::DerivedArgList &Args, Action::ActionClass AC) const;
 
   // Set default DWARF version to 4 for DXIL uses version 4.
@@ -73,6 +87,7 @@ public:
 private:
   mutable std::unique_ptr<tools::hlsl::Validator> Validator;
   mutable std::unique_ptr<tools::hlsl::MetalConverter> MetalConverter;
+  mutable std::unique_ptr<tools::hlsl::LLVMObjcopy> LLVMObjcopy;
 };
 
 } // end namespace toolchains

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -80,6 +80,12 @@ public:
   bool requiresValidation(llvm::opt::DerivedArgList &Args) const;
   bool requiresBinaryTranslation(llvm::opt::DerivedArgList &Args) const;
   bool requiresObjcopy(llvm::opt::DerivedArgList &Args) const;
+
+  /// If we are targeting DXIL then the last job should output the DXContainer
+  /// to the specified output file with /Fo. Otherwise, we will emit to a
+  /// temporary file for the next job to use.
+  ///
+  /// Returns true if we should output to the final result file.
   bool isLastJob(llvm::opt::DerivedArgList &Args, Action::ActionClass AC) const;
 
   // Set default DWARF version to 4 for DXIL uses version 4.

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -43,11 +43,10 @@ public:
                     const char *LinkingOutput) const override;
 };
 
-} // namespace hlsl
-
 class LLVM_LIBRARY_VISIBILITY LLVMObjcopy : public Tool {
 public:
-  LLVMObjcopy(const ToolChain &TC) : Tool("LLVMObjcopy", "llvm-objcopy", TC) {}
+  LLVMObjcopy(const ToolChain &TC)
+      : Tool("hlsl::LLVMObjcopy", "llvm-objcopy", TC) {}
 
   bool hasIntegratedCPP() const override { return false; }
 
@@ -57,6 +56,7 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+} // namespace hlsl
 } // namespace tools
 
 namespace toolchains {
@@ -88,7 +88,7 @@ public:
 private:
   mutable std::unique_ptr<tools::hlsl::Validator> Validator;
   mutable std::unique_ptr<tools::hlsl::MetalConverter> MetalConverter;
-  mutable std::unique_ptr<tools::LLVMObjcopy> LLVMObjcopy;
+  mutable std::unique_ptr<tools::hlsl::LLVMObjcopy> LLVMObjcopy;
 };
 
 } // end namespace toolchains

--- a/clang/lib/Driver/ToolChains/HLSL.h
+++ b/clang/lib/Driver/ToolChains/HLSL.h
@@ -43,10 +43,11 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+} // namespace hlsl
+
 class LLVM_LIBRARY_VISIBILITY LLVMObjcopy : public Tool {
 public:
-  LLVMObjcopy(const ToolChain &TC)
-      : Tool("hlsl::LLVMObjcopy", "llvm-objcopy", TC) {}
+  LLVMObjcopy(const ToolChain &TC) : Tool("LLVMObjcopy", "llvm-objcopy", TC) {}
 
   bool hasIntegratedCPP() const override { return false; }
 
@@ -55,7 +56,7 @@ public:
                     const llvm::opt::ArgList &TCArgs,
                     const char *LinkingOutput) const override;
 };
-} // namespace hlsl
+
 } // namespace tools
 
 namespace toolchains {
@@ -87,7 +88,7 @@ public:
 private:
   mutable std::unique_ptr<tools::hlsl::Validator> Validator;
   mutable std::unique_ptr<tools::hlsl::MetalConverter> MetalConverter;
-  mutable std::unique_ptr<tools::hlsl::LLVMObjcopy> LLVMObjcopy;
+  mutable std::unique_ptr<tools::LLVMObjcopy> LLVMObjcopy;
 };
 
 } // end namespace toolchains

--- a/clang/test/Driver/dxc_strip_rootsignature.hlsl
+++ b/clang/test/Driver/dxc_strip_rootsignature.hlsl
@@ -1,9 +1,14 @@
-// RUN: %clang_dxc -Qstrip-rootsignature -T cs_6_0 /Fo %t -### %s 2>&1 | FileCheck %s
+// Create a dummy dxv to run
+// RUN: mkdir -p %t.dir
+// RUN: echo "dxv" > %t.dir/dxv && chmod 754 %t.dir/dxv
+
+// RUN: %clang_dxc -Qstrip-rootsignature --dxv-path=%t.dir -T cs_6_0 /Fo %t.dxo -### %s 2>&1 | FileCheck %s
 
 // Test to demonstrate that we specify to the root signature with the
-// -Qstrip-rootsignature option
+// -Qstrip-rootsignature option and that it occurs before DXV
 
-// CHECK: "{{.*}}llvm-objcopy{{.*}}" "{{.*}}" "{{.*}}" "--remove-section=RTS0"
+// CHECK: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.obj" "{{.*}}.obj" "--remove-section=RTS0"
+// CHECK: "{{.*}}dxv{{(.exe)?}}" "{{.*}}.obj" "-o" "{{.*}}.dxo"
 
 [shader("compute"), RootSignature("")]
 [numthreads(1,1,1)]

--- a/clang/test/Driver/dxc_strip_rootsignature.hlsl
+++ b/clang/test/Driver/dxc_strip_rootsignature.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_dxc -Qstrip-rootsignature -T cs_6_0 /Fo %t -### %s 2>&1 | FileCheck %s
+
+// Test to demonstrate that we specify to the root signature with the
+// -Qstrip-rootsignature option
+
+// CHECK: "{{.*}}llvm-objcopy{{.*}}" "{{.*}}" "{{.*}}" "--remove-section=RTS0"
+
+[shader("compute"), RootSignature("")]
+[numthreads(1,1,1)]
+void EmptyEntry() {}


### PR DESCRIPTION
This pr adds the `Qstrip-rootsignature` as a `DXC` driver option.

To do so, this pr introduces the `BinaryModifyJobClass` as an `Action` to modify a produced object file before its final output.

Further, it registers `llvm-objcopy` as the tool to modify a produced `DXContainer` on the `HLSL` toolchain.

This allows us to specify the `Qstrip-rootsignature` option to `clang-dxc` which will invoke `llvm-objcopy` with a `--remove-section=RTS0` argument to implement its functionality.

Resolves: https://github.com/llvm/llvm-project/issues/150275.