### PR TITLE
AMDGPU: Correct inst size for av_mov_b32_imm_pseudo

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -155,7 +155,8 @@ def AV_MOV_B32_IMM_PSEUDO
   let VOP3 = 1;
   let isMoveImm = 1;
   let SchedRW = [Write32Bit];
-  let Size = 4;
+  let Size = 8;
+  let FixedSize = true;
   let UseNamedOperandTable = 1;
 }
 


### PR DESCRIPTION
In the AGPR case this will be an 8 byte instruction,
which is part of why this case is a pain to deal with in the
first place.