### PR TITLE
Update test added in #154418 to work when the default is C++20.

### DIFF
--- a/clang/test/SemaTemplate/nested-name-spec-template.cpp
+++ b/clang/test/SemaTemplate/nested-name-spec-template.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify %s -Wno-c++20-extensions
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++98 %s
 // RUN: %clang_cc1 -fsyntax-only -verify -std=c++11 %s
 
@@ -168,13 +168,12 @@ namespace unresolved_using {
   template struct C<int>;
 } // namespace unresolved_using
 
-#if (__cplusplus >= 201703L && __cplusplus < 202002L)
+#if __cplusplus >= 201703L
 namespace SubstTemplateTypeParmPackType {
   template <int...> struct A {};
 
   template <class... Ts> void f() {
     []<int ... Is>(A<Is...>) { (Ts::g(Is) && ...); }(A<0>{});
-    // expected-warning@-1 {{explicit template parameter list for lambdas is a C++20 extension}}
   };
 
   struct B { static void g(int); };

--- a/clang/test/SemaTemplate/nested-name-spec-template.cpp
+++ b/clang/test/SemaTemplate/nested-name-spec-template.cpp
@@ -168,7 +168,7 @@ namespace unresolved_using {
   template struct C<int>;
 } // namespace unresolved_using
 
-#if __cplusplus >= 201703L
+#if (__cplusplus >= 201703L && __cplusplus < 202002L)
 namespace SubstTemplateTypeParmPackType {
   template <int...> struct A {};
 


### PR DESCRIPTION
The test added for #154418 specifically tests for a warning that the compiler should emit informing the user that a feature is a C++20 extension, but the compiler does not emit that when the default is C++20, so we should skip that test. This change checks whether the C++ default standard is less than C++20, and if so, skips the test.