### PR TITLE
[orc-rt] Fix unit tests.

### DIFF
--- a/orc-rt/test/unit/lit.cfg.py
+++ b/orc-rt/test/unit/lit.cfg.py
@@ -9,16 +9,7 @@ import lit.util
 
 from lit.llvm import llvm_config
 
-# name: The name of this test suite.
 config.name = "ORC-RT-Unit"
-
-# suffixes: A list of file extensions to treat as test files.
-config.suffixes = []
-
-# test_source_root: The root path where tests are located.
-# test_exec_root: The root path where tests should be run.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, "Tests")
 config.test_exec_root = os.path.join(config.orc_rt_obj_root, "unittests")
 config.test_source_root = config.test_exec_root
-
-# testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, "Tests")

--- a/orc-rt/test/unit/lit.site.cfg.py.in
+++ b/orc-rt/test/unit/lit.site.cfg.py.in
@@ -4,6 +4,7 @@ import sys
 
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_build_mode = lit_config.substitute("@LLVM_BUILD_MODE@")
 config.orc_rt_obj_root = "@ORC_RT_BINARY_DIR@"
 config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
@@ -13,4 +14,4 @@ config.llvm_tools_dir = "@ORC_RT_LLVM_TOOLS_DIR@"
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 # Let the main config do the real work.
-lit_config.load_config(config, "@ORC_RT_SOURCE_DIR@/test/lit.cfg.py")
+lit_config.load_config(config, "@ORC_RT_SOURCE_DIR@/test/unit/lit.cfg.py")


### PR DESCRIPTION
We were pointing to the lit.cfg.py file for the regression tests, causing the `check-orc-rt-unit` target to re-run the regression tests rather than running the unit tests.