### PR TITLE
[Scalar] Use SmallPtrSet directly instead of SmallSet (NFC)

### DIFF
--- a/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
+++ b/llvm/lib/Transforms/Scalar/RewriteStatepointsForGC.cpp
@@ -2218,7 +2218,7 @@ static void relocationViaAlloca(
 /// vector.  Doing so has the effect of changing the output of a couple of
 /// tests in ways which make them less useful in testing fused safepoints.
 template <typename T> static void unique_unsorted(SmallVectorImpl<T> &Vec) {
-  SmallSet<T, 8> Seen;
+  SmallPtrSet<T, 8> Seen;
   erase_if(Vec, [&](const T &V) { return !Seen.insert(V).second; });
 }
 


### PR DESCRIPTION
I'm trying to remove the redirection in SmallSet.h:

template <typename PointeeType, unsigned N>
class SmallSet<PointeeType*, N> : public SmallPtrSet<PointeeType*, N> {};

to make it clear that we are using SmallPtrSet.  There are only
handful places that rely on this redirection.

This patch replaces SmallSet to SmallPtrSet where the element type is
a pointer.
