### PR TITLE
[orc-rt] Add orc_rt::span, a pre-c++20 std::span substitute

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(ORC_RT_HEADERS
     orc-rt-c/orc-rt.h
+    orc-rt/span.h
 )
 
 # TODO: Switch to filesets when we move to cmake-3.23.

--- a/orc-rt/include/orc-rt/span.h
+++ b/orc-rt/include/orc-rt/span.h
@@ -1,0 +1,61 @@
+//===---------- span.h - Substitute for C++20 std::span ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// TODO: Replace all uses with std::span once we can use C++20.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_SPAN_H
+#define ORC_RT_SPAN_H
+
+#include <cstddef>
+#include <limits>
+
+namespace orc_rt {
+
+constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
+
+/// A substitute for std::span (and llvm::ArrayRef).
+/// FIXME: Remove in favor of std::span once we can use c++20.
+template <typename T, std::size_t Extent = dynamic_extent> class span {
+public:
+  typedef T element_type;
+  typedef std::remove_cv<T> value_type;
+  typedef std::size_t size_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef T *pointer;
+  typedef const T *const_pointer;
+  typedef T &reference;
+  typedef const T &const_reference;
+
+  typedef pointer iterator;
+
+  static constexpr std::size_t extent = Extent;
+
+  constexpr span() noexcept = default;
+  constexpr span(T *first, size_type count) noexcept
+      : Data(first), Size(count) {}
+
+  template <std::size_t N>
+  constexpr span(T (&arr)[N]) noexcept : Data(&arr[0]), Size(N) {}
+
+  constexpr iterator begin() const noexcept { return Data; }
+  constexpr iterator end() const noexcept { return Data + Size; }
+  constexpr pointer data() const noexcept { return Data; }
+  constexpr reference operator[](size_type idx) const { return Data[idx]; }
+  constexpr size_type size() const noexcept { return Size; }
+  constexpr bool empty() const noexcept { return Size == 0; }
+
+private:
+  T *Data = nullptr;
+  size_type Size = 0;
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_SPAN_H

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -12,6 +12,7 @@ function(add_orc_rt_unittest test_dirname)
 endfunction()
 
 add_orc_rt_unittest(CoreTests
-  init.cpp
+  span-test.cpp
   DISABLE_LLVM_LINK_LLVM_DYLIB
   )
+target_link_libraries(CoreTests PRIVATE orc-rt-executor)

--- a/orc-rt/unittests/init.cpp
+++ b/orc-rt/unittests/init.cpp
@@ -1,6 +1,0 @@
-#include "gtest/gtest.h"
-
-
-TEST(TEST, emptyFuncs) {
-  ASSERT_TRUE(true);
-}

--- a/orc-rt/unittests/span-test.cpp
+++ b/orc-rt/unittests/span-test.cpp
@@ -1,0 +1,50 @@
+//===- span_test.cpp ------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests orc-rt's span implementation.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/span.h"
+#include "gtest/gtest.h"
+
+#include <sstream>
+#include <string>
+
+using namespace orc_rt;
+
+TEST(SpanTest, SpanDefaultConstruction) {
+  span<int> S;
+  EXPECT_TRUE(S.empty()) << "Default constructed span not empty";
+  EXPECT_EQ(S.size(), 0U) << "Default constructed span size not zero";
+  EXPECT_EQ(S.begin(), S.end()) << "Default constructed span begin != end";
+}
+
+TEST(SpanTest, SpanConstructFromFixedArray) {
+  int A[] = {1, 2, 3, 4, 5};
+  span<int> S(A);
+  EXPECT_FALSE(S.empty()) << "Span should be non-empty";
+  EXPECT_EQ(S.size(), 5U) << "Span has unexpected size";
+  EXPECT_EQ(std::distance(S.begin(), S.end()), 5U)
+      << "Unexpected iterator range size";
+  EXPECT_EQ(S.data(), &A[0]) << "Span data has unexpected value";
+  for (unsigned I = 0; I != S.size(); ++I)
+    EXPECT_EQ(S[I], A[I]) << "Unexpected span element value";
+}
+
+TEST(SpanTest, SpanConstructFromIteratorAndSize) {
+  int A[] = {1, 2, 3, 4, 5};
+  span<int> S(&A[0], 5);
+  EXPECT_FALSE(S.empty()) << "Span should be non-empty";
+  EXPECT_EQ(S.size(), 5U) << "Span has unexpected size";
+  EXPECT_EQ(std::distance(S.begin(), S.end()), 5U)
+      << "Unexpected iterator range size";
+  EXPECT_EQ(S.data(), &A[0]) << "Span data has unexpected value";
+  for (unsigned I = 0; I != S.size(); ++I)
+    EXPECT_EQ(S[I], A[I]) << "Unexpected span element value";
+}


### PR DESCRIPTION
This patch introduces an orc_rt::span class template that the ORC runtime can
use until we're able to move to c++20.