### PR TITLE
[AArch64][GlobalISel] Be more precise in RegBankSelect for s/uitofp

### DIFF
--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.cpp
@@ -13,6 +13,7 @@
 
 #include "AArch64RegisterBankInfo.h"
 #include "AArch64RegisterInfo.h"
+#include "AArch64Subtarget.h"
 #include "MCTargetDesc/AArch64MCTargetDesc.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
@@ -492,7 +493,7 @@ static bool isFPIntrinsic(const MachineRegisterInfo &MRI,
 
 bool AArch64RegisterBankInfo::isPHIWithFPConstraints(
     const MachineInstr &MI, const MachineRegisterInfo &MRI,
-    const TargetRegisterInfo &TRI, const unsigned Depth) const {
+    const AArch64RegisterInfo &TRI, const unsigned Depth) const {
   if (!MI.isPHI() || Depth > MaxFPRSearchDepth)
     return false;
 
@@ -506,7 +507,7 @@ bool AArch64RegisterBankInfo::isPHIWithFPConstraints(
 
 bool AArch64RegisterBankInfo::hasFPConstraints(const MachineInstr &MI,
                                                const MachineRegisterInfo &MRI,
-                                               const TargetRegisterInfo &TRI,
+                                               const AArch64RegisterInfo &TRI,
                                                unsigned Depth) const {
   unsigned Op = MI.getOpcode();
   if (Op == TargetOpcode::G_INTRINSIC && isFPIntrinsic(MRI, MI))
@@ -544,7 +545,7 @@ bool AArch64RegisterBankInfo::hasFPConstraints(const MachineInstr &MI,
 
 bool AArch64RegisterBankInfo::onlyUsesFP(const MachineInstr &MI,
                                          const MachineRegisterInfo &MRI,
-                                         const TargetRegisterInfo &TRI,
+                                         const AArch64RegisterInfo &TRI,
                                          unsigned Depth) const {
   switch (MI.getOpcode()) {
   case TargetOpcode::G_FPTOSI:
@@ -582,7 +583,7 @@ bool AArch64RegisterBankInfo::onlyUsesFP(const MachineInstr &MI,
 
 bool AArch64RegisterBankInfo::onlyDefinesFP(const MachineInstr &MI,
                                             const MachineRegisterInfo &MRI,
-                                            const TargetRegisterInfo &TRI,
+                                            const AArch64RegisterInfo &TRI,
                                             unsigned Depth) const {
   switch (MI.getOpcode()) {
   case AArch64::G_DUP:
@@ -620,7 +621,7 @@ bool AArch64RegisterBankInfo::onlyDefinesFP(const MachineInstr &MI,
 
 bool AArch64RegisterBankInfo::prefersFPUse(const MachineInstr &MI,
                                            const MachineRegisterInfo &MRI,
-                                           const TargetRegisterInfo &TRI,
+                                           const AArch64RegisterInfo &TRI,
                                            unsigned Depth) const {
   switch (MI.getOpcode()) {
   case TargetOpcode::G_SITOFP:
@@ -684,8 +685,8 @@ AArch64RegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
 
   const MachineFunction &MF = *MI.getParent()->getParent();
   const MachineRegisterInfo &MRI = MF.getRegInfo();
-  const TargetSubtargetInfo &STI = MF.getSubtarget();
-  const TargetRegisterInfo &TRI = *STI.getRegisterInfo();
+  const AArch64Subtarget &STI = MF.getSubtarget<AArch64Subtarget>();
+  const AArch64RegisterInfo &TRI = *STI.getRegisterInfo();
 
   switch (Opc) {
     // G_{F|S|U}REM are not listed because they are not legal.

--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
@@ -22,6 +22,7 @@
 namespace llvm {
 
 class TargetRegisterInfo;
+class AArch64RegisterInfo;
 
 class AArch64GenRegisterBankInfo : public RegisterBankInfo {
 protected:
@@ -123,25 +124,26 @@ class AArch64RegisterBankInfo final : public AArch64GenRegisterBankInfo {
   /// \returns true if \p MI is a PHI that its def is used by
   /// any instruction that onlyUsesFP.
   bool isPHIWithFPConstraints(const MachineInstr &MI,
-                             const MachineRegisterInfo &MRI,
-                             const TargetRegisterInfo &TRI,
-                             unsigned Depth = 0) const;
+                              const MachineRegisterInfo &MRI,
+                              const AArch64RegisterInfo &TRI,
+                              unsigned Depth = 0) const;
 
   /// \returns true if \p MI only uses and defines FPRs.
   bool hasFPConstraints(const MachineInstr &MI, const MachineRegisterInfo &MRI,
-                     const TargetRegisterInfo &TRI, unsigned Depth = 0) const;
+                        const AArch64RegisterInfo &TRI,
+                        unsigned Depth = 0) const;
 
   /// \returns true if \p MI only uses FPRs.
   bool onlyUsesFP(const MachineInstr &MI, const MachineRegisterInfo &MRI,
-                  const TargetRegisterInfo &TRI, unsigned Depth = 0) const;
+                  const AArch64RegisterInfo &TRI, unsigned Depth = 0) const;
 
   /// \returns true if \p MI only defines FPRs.
   bool onlyDefinesFP(const MachineInstr &MI, const MachineRegisterInfo &MRI,
-                     const TargetRegisterInfo &TRI, unsigned Depth = 0) const;
+                     const AArch64RegisterInfo &TRI, unsigned Depth = 0) const;
 
   /// \returns true if \p MI can take both fpr and gpr uses, but prefers fp.
   bool prefersFPUse(const MachineInstr &MI, const MachineRegisterInfo &MRI,
-                    const TargetRegisterInfo &TRI, unsigned Depth = 0) const;
+                    const AArch64RegisterInfo &TRI, unsigned Depth = 0) const;
 
   /// \returns true if the load \p MI is likely loading from a floating-point
   /// type.

--- a/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
+++ b/llvm/lib/Target/AArch64/GISel/AArch64RegisterBankInfo.h
@@ -139,6 +139,10 @@ class AArch64RegisterBankInfo final : public AArch64GenRegisterBankInfo {
   bool onlyDefinesFP(const MachineInstr &MI, const MachineRegisterInfo &MRI,
                      const TargetRegisterInfo &TRI, unsigned Depth = 0) const;
 
+  /// \returns true if \p MI can take both fpr and gpr uses, but prefers fp.
+  bool prefersFPUse(const MachineInstr &MI, const MachineRegisterInfo &MRI,
+                    const TargetRegisterInfo &TRI, unsigned Depth = 0) const;
+
   /// \returns true if the load \p MI is likely loading from a floating-point
   /// type.
   bool isLoadFromFPType(const MachineInstr &MI) const;

--- a/llvm/test/CodeGen/AArch64/GlobalISel/select-fp-casts.mir
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/select-fp-casts.mir
@@ -358,31 +358,6 @@ body:             |
 ...
 
 ---
-name:            sitofp_s64_s32_fpr_both
-legalized:       true
-regBankSelected: true
-
-registers:
-  - { id: 0, class: fpr }
-  - { id: 1, class: fpr }
-
-body:             |
-  bb.0:
-    liveins: $s0
-
-    ; CHECK-LABEL: name: sitofp_s64_s32_fpr_both
-    ; CHECK: liveins: $s0
-    ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:fpr32 = COPY $s0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:gpr32 = COPY [[COPY]]
-    ; CHECK-NEXT: [[SCVTFUWDri:%[0-9]+]]:fpr64 = nofpexcept SCVTFUWDri [[COPY1]]
-    ; CHECK-NEXT: $d0 = COPY [[SCVTFUWDri]]
-    %0(s32) = COPY $s0
-    %1(s64) = G_SITOFP %0
-    $d0 = COPY %1(s64)
-...
-
----
 name:            sitofp_s64_s64_fpr
 legalized:       true
 regBankSelected: true

--- a/llvm/test/CodeGen/AArch64/itofp.ll
+++ b/llvm/test/CodeGen/AArch64/itofp.ll
@@ -4,11 +4,6 @@
 ; RUN: llc -mtriple=aarch64 -global-isel -global-isel-abort=2 -verify-machineinstrs %s -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NOFP16,CHECK-NOFP16-GI
 ; RUN: llc -mtriple=aarch64 -mattr=+fullfp16 -global-isel -global-isel-abort=2 -verify-machineinstrs %s -o - 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-FP16,CHECK-FP16-GI
 
-; CHECK-FP16-GI:       warning: Instruction selection used fallback path for stofp_load_i64_f16
-; CHECK-FP16-GI-NEXT:  warning: Instruction selection used fallback path for utofp_load_i64_f16
-; CHECK-FP16-GI-NEXT:  warning: Instruction selection used fallback path for stofp_load_i32_f16
-; CHECK-FP16-GI-NEXT:  warning: Instruction selection used fallback path for utofp_load_i32_f16
-
 define double @stofp_i64_f64(i64 %a) {
 ; CHECK-LABEL: stofp_i64_f64:
 ; CHECK:       // %bb.0: // %entry
@@ -844,31 +839,11 @@ entry:
 }
 
 define double @stofp_load_i32_f64(ptr %p) {
-; CHECK-NOFP16-SD-LABEL: stofp_load_i32_f64:
-; CHECK-NOFP16-SD:       // %bb.0: // %entry
-; CHECK-NOFP16-SD-NEXT:    ldr w8, [x0]
-; CHECK-NOFP16-SD-NEXT:    scvtf d0, w8
-; CHECK-NOFP16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: stofp_load_i32_f64:
-; CHECK-FP16-SD:       // %bb.0: // %entry
-; CHECK-FP16-SD-NEXT:    ldr w8, [x0]
-; CHECK-FP16-SD-NEXT:    scvtf d0, w8
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NOFP16-GI-LABEL: stofp_load_i32_f64:
-; CHECK-NOFP16-GI:       // %bb.0: // %entry
-; CHECK-NOFP16-GI-NEXT:    ldr s0, [x0]
-; CHECK-NOFP16-GI-NEXT:    fmov w8, s0
-; CHECK-NOFP16-GI-NEXT:    scvtf d0, w8
-; CHECK-NOFP16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: stofp_load_i32_f64:
-; CHECK-FP16-GI:       // %bb.0: // %entry
-; CHECK-FP16-GI-NEXT:    ldr s0, [x0]
-; CHECK-FP16-GI-NEXT:    fmov w8, s0
-; CHECK-FP16-GI-NEXT:    scvtf d0, w8
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: stofp_load_i32_f64:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr w8, [x0]
+; CHECK-NEXT:    scvtf d0, w8
+; CHECK-NEXT:    ret
 entry:
   %a = load i32, ptr %p
   %c = sitofp i32 %a to double
@@ -936,31 +911,11 @@ entry:
 }
 
 define float @stofp_load_i64_f32(ptr %p) {
-; CHECK-NOFP16-SD-LABEL: stofp_load_i64_f32:
-; CHECK-NOFP16-SD:       // %bb.0: // %entry
-; CHECK-NOFP16-SD-NEXT:    ldr x8, [x0]
-; CHECK-NOFP16-SD-NEXT:    scvtf s0, x8
-; CHECK-NOFP16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: stofp_load_i64_f32:
-; CHECK-FP16-SD:       // %bb.0: // %entry
-; CHECK-FP16-SD-NEXT:    ldr x8, [x0]
-; CHECK-FP16-SD-NEXT:    scvtf s0, x8
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NOFP16-GI-LABEL: stofp_load_i64_f32:
-; CHECK-NOFP16-GI:       // %bb.0: // %entry
-; CHECK-NOFP16-GI-NEXT:    ldr d0, [x0]
-; CHECK-NOFP16-GI-NEXT:    fmov x8, d0
-; CHECK-NOFP16-GI-NEXT:    scvtf s0, x8
-; CHECK-NOFP16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: stofp_load_i64_f32:
-; CHECK-FP16-GI:       // %bb.0: // %entry
-; CHECK-FP16-GI-NEXT:    ldr d0, [x0]
-; CHECK-FP16-GI-NEXT:    fmov x8, d0
-; CHECK-FP16-GI-NEXT:    scvtf s0, x8
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: stofp_load_i64_f32:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr x8, [x0]
+; CHECK-NEXT:    scvtf s0, x8
+; CHECK-NEXT:    ret
 entry:
   %a = load i64, ptr %p
   %c = sitofp i64 %a to float
@@ -968,31 +923,11 @@ entry:
 }
 
 define float @utofp_load_i64_f32(ptr %p) {
-; CHECK-NOFP16-SD-LABEL: utofp_load_i64_f32:
-; CHECK-NOFP16-SD:       // %bb.0: // %entry
-; CHECK-NOFP16-SD-NEXT:    ldr x8, [x0]
-; CHECK-NOFP16-SD-NEXT:    ucvtf s0, x8
-; CHECK-NOFP16-SD-NEXT:    ret
-;
-; CHECK-FP16-SD-LABEL: utofp_load_i64_f32:
-; CHECK-FP16-SD:       // %bb.0: // %entry
-; CHECK-FP16-SD-NEXT:    ldr x8, [x0]
-; CHECK-FP16-SD-NEXT:    ucvtf s0, x8
-; CHECK-FP16-SD-NEXT:    ret
-;
-; CHECK-NOFP16-GI-LABEL: utofp_load_i64_f32:
-; CHECK-NOFP16-GI:       // %bb.0: // %entry
-; CHECK-NOFP16-GI-NEXT:    ldr d0, [x0]
-; CHECK-NOFP16-GI-NEXT:    fmov x8, d0
-; CHECK-NOFP16-GI-NEXT:    ucvtf s0, x8
-; CHECK-NOFP16-GI-NEXT:    ret
-;
-; CHECK-FP16-GI-LABEL: utofp_load_i64_f32:
-; CHECK-FP16-GI:       // %bb.0: // %entry
-; CHECK-FP16-GI-NEXT:    ldr d0, [x0]
-; CHECK-FP16-GI-NEXT:    fmov x8, d0
-; CHECK-FP16-GI-NEXT:    ucvtf s0, x8
-; CHECK-FP16-GI-NEXT:    ret
+; CHECK-LABEL: utofp_load_i64_f32:
+; CHECK:       // %bb.0: // %entry
+; CHECK-NEXT:    ldr x8, [x0]
+; CHECK-NEXT:    ucvtf s0, x8
+; CHECK-NEXT:    ret
 entry:
   %a = load i64, ptr %p
   %c = uitofp i64 %a to float
@@ -1072,26 +1007,18 @@ entry:
 }
 
 define half @stofp_load_i64_f16(ptr %p) {
-; CHECK-NOFP16-SD-LABEL: stofp_load_i64_f16:
-; CHECK-NOFP16-SD:       // %bb.0: // %entry
-; CHECK-NOFP16-SD-NEXT:    ldr x8, [x0]
-; CHECK-NOFP16-SD-NEXT:    scvtf s0, x8
-; CHECK-NOFP16-SD-NEXT:    fcvt h0, s0
-; CHECK-NOFP16-SD-NEXT:    ret
+; CHECK-NOFP16-LABEL: stofp_load_i64_f16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    ldr x8, [x0]
+; CHECK-NOFP16-NEXT:    scvtf s0, x8
+; CHECK-NOFP16-NEXT:    fcvt h0, s0
+; CHECK-NOFP16-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: stofp_load_i64_f16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    ldr x8, [x0]
 ; CHECK-FP16-NEXT:    scvtf h0, x8
 ; CHECK-FP16-NEXT:    ret
-;
-; CHECK-NOFP16-GI-LABEL: stofp_load_i64_f16:
-; CHECK-NOFP16-GI:       // %bb.0: // %entry
-; CHECK-NOFP16-GI-NEXT:    ldr d0, [x0]
-; CHECK-NOFP16-GI-NEXT:    fmov x8, d0
-; CHECK-NOFP16-GI-NEXT:    scvtf s0, x8
-; CHECK-NOFP16-GI-NEXT:    fcvt h0, s0
-; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %a = load i64, ptr %p
   %c = sitofp i64 %a to half
@@ -1099,26 +1026,18 @@ entry:
 }
 
 define half @utofp_load_i64_f16(ptr %p) {
-; CHECK-NOFP16-SD-LABEL: utofp_load_i64_f16:
-; CHECK-NOFP16-SD:       // %bb.0: // %entry
-; CHECK-NOFP16-SD-NEXT:    ldr x8, [x0]
-; CHECK-NOFP16-SD-NEXT:    ucvtf s0, x8
-; CHECK-NOFP16-SD-NEXT:    fcvt h0, s0
-; CHECK-NOFP16-SD-NEXT:    ret
+; CHECK-NOFP16-LABEL: utofp_load_i64_f16:
+; CHECK-NOFP16:       // %bb.0: // %entry
+; CHECK-NOFP16-NEXT:    ldr x8, [x0]
+; CHECK-NOFP16-NEXT:    ucvtf s0, x8
+; CHECK-NOFP16-NEXT:    fcvt h0, s0
+; CHECK-NOFP16-NEXT:    ret
 ;
 ; CHECK-FP16-LABEL: utofp_load_i64_f16:
 ; CHECK-FP16:       // %bb.0: // %entry
 ; CHECK-FP16-NEXT:    ldr x8, [x0]
 ; CHECK-FP16-NEXT:    ucvtf h0, x8
 ; CHECK-FP16-NEXT:    ret
-;
-; CHECK-NOFP16-GI-LABEL: utofp_load_i64_f16:
-; CHECK-NOFP16-GI:       // %bb.0: // %entry
-; CHECK-NOFP16-GI-NEXT:    ldr d0, [x0]
-; CHECK-NOFP16-GI-NEXT:    fmov x8, d0
-; CHECK-NOFP16-GI-NEXT:    ucvtf s0, x8
-; CHECK-NOFP16-GI-NEXT:    fcvt h0, s0
-; CHECK-NOFP16-GI-NEXT:    ret
 entry:
   %a = load i64, ptr %p
   %c = uitofp i64 %a to half


### PR DESCRIPTION
We can generate fpr->fpr instructions for G_SITOFP and G_UITOFP. It was
previously marking the instructions as FPR but then generating GPR instructions
and introducing a copy.