### PR TITLE
Update log_level for LLVM_DEBUG and associated macros

### DIFF
--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -71,7 +71,7 @@ void setCurrentDebugTypes(const char **Types, unsigned Count);
 /// is not specified, or is specified as "bitset".
 #define DEBUG_WITH_TYPE(TYPE, ...)                                             \
   do {                                                                         \
-    if (::llvm::DebugFlag && ::llvm::isCurrentDebugType(TYPE)) {               \
+    if (::llvm::DebugFlag && ::llvm::isCurrentDebugType(TYPE, 1)) {            \
       __VA_ARGS__;                                                             \
     }                                                                          \
   } while (false)

--- a/llvm/unittests/Support/DebugTest.cpp
+++ b/llvm/unittests/Support/DebugTest.cpp
@@ -50,4 +50,46 @@ TEST(DebugTest, CommaInDebugBlock) {
   });
   EXPECT_EQ("ZYX", os1.str());
 }
+
+TEST(DebugTest, DebugWithType) {
+  llvm::DebugFlag = true;
+
+  // Check if the DEBUG_WITH_TYPE macro is enabled for the given type.
+  auto CheckDebugWithType = [](const char *Type) {
+    bool Visited = false;
+    DEBUG_WITH_TYPE(Type, { Visited = true; });
+    return Visited;
+  };
+
+  {
+    static const char *DT[] = {"A", "B"};
+    setCurrentDebugTypes(DT, sizeof(DT) / sizeof(DT[0]));
+    EXPECT_TRUE(CheckDebugWithType("A"));
+    EXPECT_TRUE(CheckDebugWithType("B"));
+    EXPECT_FALSE(CheckDebugWithType("C"));
+  }
+  {
+    static const char *DT[] = {"A:"};
+    setCurrentDebugTypes(DT, sizeof(DT) / sizeof(DT[0]));
+    EXPECT_FALSE(CheckDebugWithType("A"));
+    EXPECT_TRUE(CheckDebugWithType("B"));
+    EXPECT_TRUE(CheckDebugWithType("C"));
+  }
+  {
+    static const char *DT[] = {"A:", "B"};
+    setCurrentDebugTypes(DT, sizeof(DT) / sizeof(DT[0]));
+    EXPECT_FALSE(CheckDebugWithType("A"));
+    EXPECT_TRUE(CheckDebugWithType("B"));
+    EXPECT_FALSE(CheckDebugWithType("C"));
+  }
+  {
+    static const char *DT[] = {"A:3", "B:", "C"};
+    setCurrentDebugTypes(DT, sizeof(DT) / sizeof(DT[0]));
+    EXPECT_TRUE(CheckDebugWithType("A"));
+    EXPECT_FALSE(isCurrentDebugType("A", 4));
+    EXPECT_FALSE(CheckDebugWithType("B"));
+    EXPECT_TRUE(isCurrentDebugType("C", 10));
+    EXPECT_FALSE(CheckDebugWithType("D"));
+  }
+}
 #endif


### PR DESCRIPTION
During the review of #150855 we switched from 0 to 1 for the default log level used, but this macro wasn't updated.