### PR TITLE
[libclc] Use elementwise ctlz/cttz builtins for CLC clz/ctz

### DIFF
--- a/libclc/clc/lib/generic/integer/clc_clz.inc
+++ b/libclc/clc/lib/generic/integer/clc_clz.inc
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clcmacro.h>
-#include <clc/integer/clc_clz.h>
-#include <clc/internal/clc.h>
-
-#define __CLC_BODY <clc_clz.inc>
-#include <clc/integer/gentype.inc>
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_clz(__CLC_GENTYPE x) {
+  return __builtin_elementwise_ctlz(x, (__CLC_GENTYPE)__CLC_GENSIZE);
+}

--- a/libclc/clc/lib/generic/integer/clc_ctz.cl
+++ b/libclc/clc/lib/generic/integer/clc_ctz.cl
@@ -10,34 +10,5 @@
 #include <clc/integer/clc_ctz.h>
 #include <clc/internal/clc.h>
 
-_CLC_OVERLOAD _CLC_DEF char __clc_ctz(char x) {
-  return __clc_ctz(__clc_as_uchar(x));
-}
-
-_CLC_OVERLOAD _CLC_DEF uchar __clc_ctz(uchar x) { return __builtin_ctzg(x, 8); }
-
-_CLC_OVERLOAD _CLC_DEF short __clc_ctz(short x) {
-  return __clc_ctz(__clc_as_ushort(x));
-}
-
-_CLC_OVERLOAD _CLC_DEF ushort __clc_ctz(ushort x) {
-  return __builtin_ctzg(x, 16);
-}
-
-_CLC_OVERLOAD _CLC_DEF int __clc_ctz(int x) {
-  return __clc_ctz(__clc_as_uint(x));
-}
-
-_CLC_OVERLOAD _CLC_DEF uint __clc_ctz(uint x) { return __builtin_ctzg(x, 32); }
-
-_CLC_OVERLOAD _CLC_DEF long __clc_ctz(long x) {
-  return __clc_ctz(__clc_as_ulong(x));
-}
-
-_CLC_OVERLOAD _CLC_DEF ulong __clc_ctz(ulong x) {
-  return __builtin_ctzg(x, 64);
-}
-
-#define __CLC_FUNCTION __clc_ctz
-#define __CLC_BODY <clc/shared/unary_def_scalarize.inc>
+#define __CLC_BODY <clc_ctz.inc>
 #include <clc/integer/gentype.inc>

--- a/libclc/clc/lib/generic/integer/clc_ctz.inc
+++ b/libclc/clc/lib/generic/integer/clc_ctz.inc
@@ -6,9 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <clc/clcmacro.h>
-#include <clc/integer/clc_clz.h>
-#include <clc/internal/clc.h>
-
-#define __CLC_BODY <clc_clz.inc>
-#include <clc/integer/gentype.inc>
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_ctz(__CLC_GENTYPE x) {
+  return __builtin_elementwise_cttz(x, (__CLC_GENTYPE)__CLC_GENSIZE);
+}


### PR DESCRIPTION
Using the elementwise builtin optimizes the vector case; instead of scalarizing we can compile directly to the vector intrinsics.