### PR TITLE
[MLIR] Add missing handling for LLVM_LIT_TOOLS_DIR in mlir lit config (NFC)

### DIFF
--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -29,6 +29,7 @@ lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
 if lit_shell_env:
     use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
 
+# Set the test format based on shell configuration
 config.test_format = lit.formats.ShTest(execute_external=not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
@@ -181,10 +182,10 @@ config.excludes = [
 ]
 
 # Tweak the PATH to include the tools dir.
-llvm_config.with_environment("PATH", config.mlir_tools_dir, append_path=True)
-llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
+tool_dirs = [config.mlir_tools_dir, config.llvm_tools_dir, config.lit_tools_dir]
+for dirs in tool_dirs:
+    llvm_config.with_environment("PATH", dirs, append_path=True)
 
-tool_dirs = [config.mlir_tools_dir, config.llvm_tools_dir]
 tools = [
     "mlir-tblgen",
     "mlir-translate",

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -5,6 +5,7 @@ import sys
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.spirv_tools_tests = @LLVM_INCLUDE_SPIRV_TOOLS_TESTS@
 config.llvm_shlib_ext = "@SHLIBEXT@"
 config.llvm_shlib_dir = lit_config.substitute(path(r"@SHLIBDIR@"))


### PR DESCRIPTION
This is helping some windows users, here is the doc:

**LLVM_LIT_TOOLS_DIR**:PATH
  The path to GnuWin32 tools for tests. Valid on Windows host.  Defaults to
  the empty string, in which case lit will look for tools needed for tests
  (e.g. ``grep``, ``sort``, etc.) in your ``%PATH%``. If GnuWin32 is not in your
  ``%PATH%``, then you can set this variable to the GnuWin32 directory so that
  lit can find tools needed for tests in that directory.