### PR TITLE
[clang][dataflow] Fix uninitialized memory bug.

### DIFF
--- a/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
+++ b/clang/lib/Analysis/FlowSensitive/DataflowAnalysisContext.cpp
@@ -285,10 +285,10 @@ SimpleLogicalContext DataflowAnalysisContext::exportLogicalContext(
     llvm::DenseSet<dataflow::Atom> TargetTokens) const {
   SimpleLogicalContext LC;
 
-  if (Invariant != nullptr) {
-    LC.Invariant = Invariant;
+  // Copy `Invariant` even if it is null, to initialize the field.
+  LC.Invariant = Invariant;
+  if (Invariant != nullptr)
     getReferencedAtoms(*Invariant, TargetTokens);
-  }
 
   llvm::DenseSet<dataflow::Atom> Dependencies =
       collectDependencies(std::move(TargetTokens));


### PR DESCRIPTION
Commit #3ecfc03 introduced a bug involving an uninitialized field in
`exportLogicalContext`. This patch initializes the field properly.
