### PR TITLE
[mlir] Fix missing `mlir-capi-global-constructors-test` on standalone build

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -157,7 +157,10 @@ if(MLIR_ENABLE_CUDA_RUNNER)
 endif()
 
 if(MLIR_ENABLE_EXECUTION_ENGINE)
-  list(APPEND MLIR_TEST_DEPENDS mlir-capi-execution-engine-test)
+  list(APPEND MLIR_TEST_DEPENDS
+    mlir-capi-execution-engine-test
+    mlir-capi-global-constructors-test
+  )
 endif()
 
 if(MLIR_ENABLE_ROCM_RUNNER)


### PR DESCRIPTION
Add `mlir-capi-global-constructors-test` to `MLIR_TEST_DEPENDS` when `MLIR_ENABLE_EXECUTION_ENGINE` is enabled, to ensure that it is also built during standalone builds, and therefore fix test failure due to the executable being missing.

I don't understand the purpose of `LLVM_ENABLE_PIC AND TARGET ${LLVM_NATIVE_ARCH}` block, but the condition is not true in standalone builds.

Fixes 7610b1372955da55e3dc4e2eb1440f0304a56ac8.