### PR TITLE
[clang] build UnresolvedUsingType for constructor initializers

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -4568,6 +4568,7 @@ Sema::BuildMemInitializer(Decl *ConstructorD,
       MarkAnyDeclReferenced(TyD->getLocation(), TyD, /*OdrUse=*/false);
 
       TypeLocBuilder TLB;
+      // FIXME: This is missing building the UsingType for TyD, if any.
       if (const auto *TD = dyn_cast<TagDecl>(TyD)) {
         BaseType = Context.getTagType(ElaboratedTypeKeyword::None,
                                       SS.getScopeRep(), TD, /*OwnsTag=*/false);
@@ -4579,6 +4580,12 @@ Sema::BuildMemInitializer(Decl *ConstructorD,
         BaseType = Context.getTypedefType(ElaboratedTypeKeyword::None,
                                           SS.getScopeRep(), TN);
         TLB.push<TypedefTypeLoc>(BaseType).set(
+            /*ElaboratedKeywordLoc=*/SourceLocation(),
+            SS.getWithLocInContext(Context), IdLoc);
+      } else if (auto *UD = dyn_cast<UnresolvedUsingTypenameDecl>(TyD)) {
+        BaseType = Context.getUnresolvedUsingType(ElaboratedTypeKeyword::None,
+                                                  SS.getScopeRep(), UD);
+        TLB.push<UnresolvedUsingTypeLoc>(BaseType).set(
             /*ElaboratedKeywordLoc=*/SourceLocation(),
             SS.getWithLocInContext(Context), IdLoc);
       } else {

--- a/clang/test/SemaTemplate/class-template-ctor-initializer.cpp
+++ b/clang/test/SemaTemplate/class-template-ctor-initializer.cpp
@@ -4,8 +4,8 @@
 
 template<class X> struct A {};
 
-template<class X> struct B : A<X> { 
-  B() : A<X>() {} 
+template<class X> struct B : A<X> {
+  B() : A<X>() {}
 };
 B<int> x;
 
@@ -76,3 +76,12 @@ namespace NonDependentError {
   Derived1<void> d1;
   Derived2<void> d2;
 }
+
+namespace UnresolvedUsing {
+  template <class T> class A {
+    using typename T::B;
+    struct C : B {
+      C() : B() {}
+    };
+  };
+} // namespace UnresolvedUsing


### PR DESCRIPTION
When building the base type for constructor initializer, the case of an UnresolvedUsingType was not being handled.

For the non-dependent case, we are also skipping adding the UsingType, but this is just missing information in the AST. A FIXME for this is added.

This fixes a regression introduced in #147835, which was never released, so there are no release notes.

Fixes #154436