### PR TITLE
[LV] Add assertion for loop predecessor (and terminator of) existing when checking out of loop inst for poison

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -1527,6 +1527,11 @@ bool LoopVectorizationLegality::canVectorizeWithIfConvert() {
           if (!CurrI || !TheLoop->contains(CurrI)) {
             // If operands from outside the loop may be poison then Ptr may also
             // be poison.
+            assert((TheLoop->getLoopPredecessor() &&
+                    TheLoop->getLoopPredecessor()->getTerminator()) &&
+                   "No loop predecessor/pred terminator found while checking "
+                   "out of loop instruction for poison");
+
             if (!isGuaranteedNotToBePoison(CurrV, AC,
                                            TheLoop->getLoopPredecessor()
                                                ->getTerminator()


### PR DESCRIPTION
In LoopVectorizationLegality, TheLoop->getLoopPredecessor() and [...]Predecessor()->getTerminator() are used without a null check. This patch adds an assert that they are non-null, since they are expected to be defined.