### PR TITLE
[clang] Remove hasValue() check in `RecordExprEvaluator::VisitCXXConstructExpr()`

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -11045,10 +11045,6 @@ bool RecordExprEvaluator::VisitCXXConstructExpr(const CXXConstructExpr *E,
 
   bool ZeroInit = E->requiresZeroInitialization();
   if (CheckTrivialDefaultConstructor(Info, E->getExprLoc(), FD, ZeroInit)) {
-    // If we've already performed zero-initialization, we're already done.
-    if (Result.hasValue())
-      return true;
-
     if (ZeroInit)
       return ZeroInitialization(E, T);
 

--- a/clang/test/SemaCXX/constant-expression-cxx11.cpp
+++ b/clang/test/SemaCXX/constant-expression-cxx11.cpp
@@ -2645,3 +2645,19 @@ namespace GH150709 {
   static_assert((e2[0].*mp)() == 1, ""); // expected-error {{constant expression}}
   static_assert((g.*mp)() == 1, ""); // expected-error {{constant expression}}
 }
+
+namespace GH154567 {
+  struct T {
+    int i;
+  };
+
+  struct S {
+    struct { // expected-warning {{GNU extension}}
+      T val;
+    };
+    constexpr S() : val() {}
+  };
+
+  constexpr S s{};
+  static_assert(s.val.i == 0, "");
+}


### PR DESCRIPTION
When initializing an anonymous struct via an `IndirectFieldDecl`, we create an `APValue` for the struct, but we leave the fields uninitialized. This would later cause the `CXXConstructExpr` that initializes the anonymous struct member to not do anything since its `APValue` already had a value (but the member didn't). Just remove the check for an `APValue` that already has a value from `RecordExprEvaluator::VisitCXXConstructExpr()`.


Fixes #154567