### PR TITLE
[libcxx][test] Silence nodiscard warnings

### DIFF
--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/shared_ptr_array.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.shared/util.smartptr.shared.create/shared_ptr_array.pass.cpp
@@ -20,11 +20,11 @@
 #include <memory>
 
 int main(int, char**) {
-  std::allocate_shared<int[]>(std::allocator<int>{}, 10);
-  std::make_shared<int[]>(10);
+  (void)std::allocate_shared<int[]>(std::allocator<int>{}, 10);
+  (void)std::make_shared<int[]>(10);
 
-  std::allocate_shared<int[10]>(std::allocator<int>{});
-  std::make_shared<int[10]>();
+  (void)std::allocate_shared<int[10]>(std::allocator<int>{});
+  (void)std::make_shared<int[10]>();
 
   return 0;
 }

--- a/libcxx/test/std/utilities/template.bitset/bitset.members/to_ullong.pass.cpp
+++ b/libcxx/test/std/utilities/template.bitset/bitset.members/to_ullong.pass.cpp
@@ -65,7 +65,7 @@ TEST_CONSTEXPR_CXX23 bool test() {
     std::bitset<std::numeric_limits<unsigned long long>::digits + 1> q(0);
     q.flip();
     try {
-      q.to_ullong(); // throws
+      (void)q.to_ullong(); // throws
       assert(false);
     } catch (const std::overflow_error&) {
       // expected

--- a/libcxx/test/std/utilities/template.bitset/bitset.members/to_ulong.pass.cpp
+++ b/libcxx/test/std/utilities/template.bitset/bitset.members/to_ulong.pass.cpp
@@ -64,7 +64,7 @@ TEST_CONSTEXPR_CXX23 bool test() {
     std::bitset<std::numeric_limits<unsigned long>::digits + 1> q(0);
     q.flip();
     try {
-      q.to_ulong(); // throws
+      (void)q.to_ulong(); // throws
       assert(false);
     } catch (const std::overflow_error&) {
       // expected


### PR DESCRIPTION
MSVC's STL marks `std::make_shared`, `std::allocate_shared`, `std::bitset::to_ulong`, and `std::bitset::to_ullong` as `[[nodiscard]]`, which causes these libcxx tests to emit righteous warnings. They should use the traditional `(void)` cast technique to ignore the return values.
