### PR TITLE
[Clang][Codegen][NFC] Add nullptr check in fillOutputFields

### DIFF
--- a/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -1027,8 +1027,11 @@ void CGRecordLowering::fillOutputFields() {
       if (Member.FD)
         Fields[Member.FD->getCanonicalDecl()] = FieldTypes.size() - 1;
       // A field without storage must be a bitfield.
-      if (!Member.Data && Member.FD)
+      if (!Member.Data) {
+        assert(Member.FD &&
+               "Member.Data is a nullptr so Member.FD should not be");
         setBitFieldInfo(Member.FD, Member.Offset, FieldTypes.back());
+      }
     } else if (Member.Kind == MemberInfo::Base)
       NonVirtualBases[Member.RD] = FieldTypes.size() - 1;
     else if (Member.Kind == MemberInfo::VBase)

--- a/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -1027,7 +1027,7 @@ void CGRecordLowering::fillOutputFields() {
       if (Member.FD)
         Fields[Member.FD->getCanonicalDecl()] = FieldTypes.size() - 1;
       // A field without storage must be a bitfield.
-      if (!Member.Data)
+      if (!Member.Data && Member.FD)
         setBitFieldInfo(Member.FD, Member.Offset, FieldTypes.back());
     } else if (Member.Kind == MemberInfo::Base)
       NonVirtualBases[Member.RD] = FieldTypes.size() - 1;


### PR DESCRIPTION
Static analysis flagged that we were checking for nullptr in Member.FD but soon after unconditionally accessing it. It looks like we should be checking, so I added a check.