### PR TITLE
[clang] Fix Variable Length Array `_Countof` Crash

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -253,6 +253,8 @@ Bug Fixes in This Version
 -------------------------
 - Fix a crash when marco name is empty in ``#pragma push_macro("")`` or
   ``#pragma pop_macro("")``. (#GH149762).
+- Fix a crash in variable length array (e.g. int a[*]) function parameter type 
+  being used in `_Countof` expression. (#GH152826)
 - `-Wunreachable-code`` now diagnoses tautological or contradictory
   comparisons such as ``x != 0 || x != 1.0`` and ``x == 0 && x == 1.0`` on
   targets that treat ``_Float16``/``__fp16`` as native scalar types. Previously

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -253,8 +253,8 @@ Bug Fixes in This Version
 -------------------------
 - Fix a crash when marco name is empty in ``#pragma push_macro("")`` or
   ``#pragma pop_macro("")``. (#GH149762).
-- Fix a crash in variable length array (e.g. int a[*]) function parameter type 
-  being used in `_Countof` expression. (#GH152826)
+- Fix a crash in variable length array (e.g. ``int a[*]``) function parameter type 
+  being used in ``_Countof`` expression. (#GH152826)
 - `-Wunreachable-code`` now diagnoses tautological or contradictory
   comparisons such as ``x != 0 || x != 1.0`` and ``x == 0 && x == 1.0`` on
   targets that treat ``_Float16``/``__fp16`` as native scalar types. Previously

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -254,7 +254,7 @@ Bug Fixes in This Version
 - Fix a crash when marco name is empty in ``#pragma push_macro("")`` or
   ``#pragma pop_macro("")``. (#GH149762).
 - Fix a crash in variable length array (e.g. ``int a[*]``) function parameter type 
-  being used in ``_Countof`` expression. (#GH152826)
+  being used in ``_Countof`` expression. (#GH152826).
 - `-Wunreachable-code`` now diagnoses tautological or contradictory
   comparisons such as ``x != 0 || x != 1.0`` and ``x == 0 && x == 1.0`` on
   targets that treat ``_Float16``/``__fp16`` as native scalar types. Previously

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -2248,7 +2248,9 @@ bool Compiler<Emitter>::VisitUnaryExprOrTypeTraitExpr(
     assert(VAT);
     if (VAT->getElementType()->isArrayType()) {
       std::optional<APSInt> Res =
-          VAT->getSizeExpr()->getIntegerConstantExpr(ASTCtx);
+          VAT->getSizeExpr()
+              ? VAT->getSizeExpr()->getIntegerConstantExpr(ASTCtx)
+              : std::nullopt;
       if (Res) {
         if (DiscardResult)
           return true;

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15353,6 +15353,13 @@ bool IntExprEvaluator::VisitUnaryExprOrTypeTraitExpr(
     const auto *VAT = Info.Ctx.getAsVariableArrayType(Ty);
     assert(VAT);
     if (VAT->getElementType()->isArrayType()) {
+      // Variable array size expression could be missing (e.g. int a[*][10]) In
+      // that case, it can't be a constant expression
+      if (!VAT->getSizeExpr()) {
+        Info.FFDiag(E->getBeginLoc());
+        return false;
+      }
+
       std::optional<APSInt> Res =
           VAT->getSizeExpr()->getIntegerConstantExpr(Info.Ctx);
       if (Res) {
@@ -17890,7 +17897,10 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
         // it is an ICE or not.
         const auto *VAT = Ctx.getAsVariableArrayType(ArgTy);
         if (VAT->getElementType()->isArrayType())
-          return CheckICE(VAT->getSizeExpr(), Ctx);
+          // Variable array size expression could be missing (e.g. int a[*][10])
+          // In that case, it can't be a constant expression
+          return VAT->getSizeExpr() ? CheckICE(VAT->getSizeExpr(), Ctx)
+                                    : ICEDiag(IK_NotICE, E->getBeginLoc());
 
         // Otherwise, this is a regular VLA, which is definitely not an ICE.
         return ICEDiag(IK_NotICE, E->getBeginLoc());

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -15354,7 +15354,7 @@ bool IntExprEvaluator::VisitUnaryExprOrTypeTraitExpr(
     assert(VAT);
     if (VAT->getElementType()->isArrayType()) {
       // Variable array size expression could be missing (e.g. int a[*][10]) In
-      // that case, it can't be a constant expression
+      // that case, it can't be a constant expression.
       if (!VAT->getSizeExpr()) {
         Info.FFDiag(E->getBeginLoc());
         return false;
@@ -17898,7 +17898,7 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
         const auto *VAT = Ctx.getAsVariableArrayType(ArgTy);
         if (VAT->getElementType()->isArrayType())
           // Variable array size expression could be missing (e.g. int a[*][10])
-          // In that case, it can't be a constant expression
+          // In that case, it can't be a constant expression.
           return VAT->getSizeExpr() ? CheckICE(VAT->getSizeExpr(), Ctx)
                                     : ICEDiag(IK_NotICE, E->getBeginLoc());
 

--- a/clang/test/Sema/gh152826.c
+++ b/clang/test/Sema/gh152826.c
@@ -2,6 +2,6 @@
 // RUN: %clang_cc1 -std=c2y -verify -fexperimental-new-constant-interpreter %s
 // expected-no-diagnostics
 
-void gh152826(char (*a)[*][5], int (*x)[_Countof (*a)]);
+void gh152826(char (*a)[*][5], int (*x)[_Countof(*a)]);
 void more_likely_in_practice(unsigned long size_one, int (*a)[*][5], int b[_Countof(*a)]);
 void f(int (*x)[*][1][*][2][*][*][3][*], int q[_Countof(*x)]);

--- a/clang/test/Sema/gh152826.c
+++ b/clang/test/Sema/gh152826.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -std=c2y -verify %s
+// RUN: %clang_cc1 -std=c2y -verify -fexperimental-new-constant-interpreter %s
+// expected-no-diagnostics
+
+void gh152826(char (*a)[*][5], int (*x)[_Countof (*a)]);
+void more_likely_in_practice(unsigned long size_one, int (*a)[*][5], int b[_Countof(*a)]);

--- a/clang/test/Sema/gh152826.c
+++ b/clang/test/Sema/gh152826.c
@@ -4,3 +4,4 @@
 
 void gh152826(char (*a)[*][5], int (*x)[_Countof (*a)]);
 void more_likely_in_practice(unsigned long size_one, int (*a)[*][5], int b[_Countof(*a)]);
+void f(int (*x)[*][1][*][2][*][*][3][*], int q[_Countof(*x)]);


### PR DESCRIPTION
Check for missing VLA size expressions (e.g. in int a[*][10]) before evaluation to avoid crashes in _Countof and constant expression checks.

fixes #152826