### PR TITLE
[NFC][Diagnostics] Reformat `DiagnosticIDs.h` and `AllDiagnostics.h`

### DIFF
--- a/clang/include/clang/Basic/AllDiagnostics.h
+++ b/clang/include/clang/Basic/AllDiagnostics.h
@@ -23,20 +23,20 @@
 #include "clang/Basic/DiagnosticInstallAPI.h"
 #include "clang/Basic/DiagnosticLex.h"
 #include "clang/Basic/DiagnosticParse.h"
+#include "clang/Basic/DiagnosticRefactoring.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/DiagnosticSerialization.h"
-#include "clang/Basic/DiagnosticRefactoring.h"
 
 namespace clang {
-template <size_t SizeOfStr, typename FieldType>
-class StringSizerHelper {
+template <size_t SizeOfStr, typename FieldType> class StringSizerHelper {
   static_assert(SizeOfStr <= FieldType(~0U), "Field too small!");
+
 public:
   enum { Size = SizeOfStr };
 };
 } // end namespace clang
 
-#define STR_SIZE(str, fieldTy) clang::StringSizerHelper<sizeof(str)-1, \
-                                                        fieldTy>::Size
+#define STR_SIZE(str, fieldTy)                                                 \
+  clang::StringSizerHelper<sizeof(str) - 1, fieldTy>::Size
 
 #endif

--- a/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/clang/include/clang/Basic/DiagnosticIDs.h
@@ -23,76 +23,78 @@
 #include <vector>
 
 namespace clang {
-  class DiagnosticsEngine;
-  class DiagnosticBuilder;
-  class LangOptions;
-  class SourceLocation;
+class DiagnosticsEngine;
+class DiagnosticBuilder;
+class LangOptions;
+class SourceLocation;
 
-  // Import the diagnostic enums themselves.
-  namespace diag {
-    enum class Group;
+// Import the diagnostic enums themselves.
+namespace diag {
+enum class Group;
 
-    // Size of each of the diagnostic categories.
-    enum {
-      DIAG_SIZE_COMMON        =  300,
-      DIAG_SIZE_DRIVER        =  400,
-      DIAG_SIZE_FRONTEND      =  200,
-      DIAG_SIZE_SERIALIZATION =  120,
-      DIAG_SIZE_LEX           =  500,
-      DIAG_SIZE_PARSE         =  800,
-      DIAG_SIZE_AST           =  300,
-      DIAG_SIZE_COMMENT       =  100,
-      DIAG_SIZE_CROSSTU       =  100,
-      DIAG_SIZE_SEMA          = 5000,
-      DIAG_SIZE_ANALYSIS      =  100,
-      DIAG_SIZE_REFACTORING   = 1000,
-      DIAG_SIZE_INSTALLAPI    =  100,
-    };
-    // Start position for diagnostics.
-    enum {
-      DIAG_START_COMMON        =                          0,
-      DIAG_START_DRIVER        = DIAG_START_COMMON        + static_cast<int>(DIAG_SIZE_COMMON),
-      DIAG_START_FRONTEND      = DIAG_START_DRIVER        + static_cast<int>(DIAG_SIZE_DRIVER),
-      DIAG_START_SERIALIZATION = DIAG_START_FRONTEND      + static_cast<int>(DIAG_SIZE_FRONTEND),
-      DIAG_START_LEX           = DIAG_START_SERIALIZATION + static_cast<int>(DIAG_SIZE_SERIALIZATION),
-      DIAG_START_PARSE         = DIAG_START_LEX           + static_cast<int>(DIAG_SIZE_LEX),
-      DIAG_START_AST           = DIAG_START_PARSE         + static_cast<int>(DIAG_SIZE_PARSE),
-      DIAG_START_COMMENT       = DIAG_START_AST           + static_cast<int>(DIAG_SIZE_AST),
-      DIAG_START_CROSSTU       = DIAG_START_COMMENT       + static_cast<int>(DIAG_SIZE_COMMENT),
-      DIAG_START_SEMA          = DIAG_START_CROSSTU       + static_cast<int>(DIAG_SIZE_CROSSTU),
-      DIAG_START_ANALYSIS      = DIAG_START_SEMA          + static_cast<int>(DIAG_SIZE_SEMA),
-      DIAG_START_REFACTORING   = DIAG_START_ANALYSIS      + static_cast<int>(DIAG_SIZE_ANALYSIS),
-      DIAG_START_INSTALLAPI    = DIAG_START_REFACTORING   + static_cast<int>(DIAG_SIZE_REFACTORING),
-      DIAG_UPPER_LIMIT         = DIAG_START_INSTALLAPI    + static_cast<int>(DIAG_SIZE_INSTALLAPI)
-    };
+// Size of each of the diagnostic categories.
+enum {
+  DIAG_SIZE_COMMON = 300,
+  DIAG_SIZE_DRIVER = 400,
+  DIAG_SIZE_FRONTEND = 200,
+  DIAG_SIZE_SERIALIZATION = 120,
+  DIAG_SIZE_LEX = 500,
+  DIAG_SIZE_PARSE = 800,
+  DIAG_SIZE_AST = 300,
+  DIAG_SIZE_COMMENT = 100,
+  DIAG_SIZE_CROSSTU = 100,
+  DIAG_SIZE_SEMA = 5000,
+  DIAG_SIZE_ANALYSIS = 100,
+  DIAG_SIZE_REFACTORING = 1000,
+  DIAG_SIZE_INSTALLAPI = 100,
+};
+// Start position for diagnostics.
+// clang-format off
+enum {
+  DIAG_START_COMMON        =                          0,
+  DIAG_START_DRIVER        = DIAG_START_COMMON        + static_cast<int>(DIAG_SIZE_COMMON),
+  DIAG_START_FRONTEND      = DIAG_START_DRIVER        + static_cast<int>(DIAG_SIZE_DRIVER),
+  DIAG_START_SERIALIZATION = DIAG_START_FRONTEND      + static_cast<int>(DIAG_SIZE_FRONTEND),
+  DIAG_START_LEX           = DIAG_START_SERIALIZATION + static_cast<int>(DIAG_SIZE_SERIALIZATION),
+  DIAG_START_PARSE         = DIAG_START_LEX           + static_cast<int>(DIAG_SIZE_LEX),
+  DIAG_START_AST           = DIAG_START_PARSE         + static_cast<int>(DIAG_SIZE_PARSE),
+  DIAG_START_COMMENT       = DIAG_START_AST           + static_cast<int>(DIAG_SIZE_AST),
+  DIAG_START_CROSSTU       = DIAG_START_COMMENT       + static_cast<int>(DIAG_SIZE_COMMENT),
+  DIAG_START_SEMA          = DIAG_START_CROSSTU       + static_cast<int>(DIAG_SIZE_CROSSTU),
+  DIAG_START_ANALYSIS      = DIAG_START_SEMA          + static_cast<int>(DIAG_SIZE_SEMA),
+  DIAG_START_REFACTORING   = DIAG_START_ANALYSIS      + static_cast<int>(DIAG_SIZE_ANALYSIS),
+  DIAG_START_INSTALLAPI    = DIAG_START_REFACTORING   + static_cast<int>(DIAG_SIZE_REFACTORING),
+  DIAG_UPPER_LIMIT         = DIAG_START_INSTALLAPI    + static_cast<int>(DIAG_SIZE_INSTALLAPI)
+};
+// clang-format on
 
-    class CustomDiagInfo;
+class CustomDiagInfo;
 
-    /// All of the diagnostics that can be emitted by the frontend.
-    typedef unsigned kind;
+/// All of the diagnostics that can be emitted by the frontend.
+typedef unsigned kind;
 
-    /// Enum values that allow the client to map NOTEs, WARNINGs, and EXTENSIONs
-    /// to either Ignore (nothing), Remark (emit a remark), Warning
-    /// (emit a warning) or Error (emit as an error).  It allows clients to
-    /// map ERRORs to Error or Fatal (stop emitting diagnostics after this one).
-    enum class Severity : uint8_t {
-      // NOTE: 0 means "uncomputed".
-      Ignored = 1, ///< Do not present this diagnostic, ignore it.
-      Remark = 2,  ///< Present this diagnostic as a remark.
-      Warning = 3, ///< Present this diagnostic as a warning.
-      Error = 4,   ///< Present this diagnostic as an error.
-      Fatal = 5    ///< Present this diagnostic as a fatal error.
-    };
+/// Enum values that allow the client to map NOTEs, WARNINGs, and EXTENSIONs
+/// to either Ignore (nothing), Remark (emit a remark), Warning
+/// (emit a warning) or Error (emit as an error).  It allows clients to
+/// map ERRORs to Error or Fatal (stop emitting diagnostics after this one).
+enum class Severity : uint8_t {
+  // NOTE: 0 means "uncomputed".
+  Ignored = 1, ///< Do not present this diagnostic, ignore it.
+  Remark = 2,  ///< Present this diagnostic as a remark.
+  Warning = 3, ///< Present this diagnostic as a warning.
+  Error = 4,   ///< Present this diagnostic as an error.
+  Fatal = 5    ///< Present this diagnostic as a fatal error.
+};
 
-    /// Flavors of diagnostics we can emit. Used to filter for a particular
-    /// kind of diagnostic (for instance, for -W/-R flags).
-    enum class Flavor {
-      WarningOrError, ///< A diagnostic that indicates a problem or potential
-                      ///< problem. Can be made fatal by -Werror.
-      Remark          ///< A diagnostic that indicates normal progress through
-                      ///< compilation.
-    };
-  } // end namespace diag
+/// Flavors of diagnostics we can emit. Used to filter for a particular
+/// kind of diagnostic (for instance, for -W/-R flags).
+enum class Flavor {
+  WarningOrError, ///< A diagnostic that indicates a problem or potential
+                  ///< problem. Can be made fatal by -Werror.
+  Remark          ///< A diagnostic that indicates normal progress through
+                  ///< compilation.
+};
+} // end namespace diag
 } // end namespace clang
 
 // This has to be included *after* the DIAG_START_ enums above are defined.
@@ -173,7 +175,8 @@ public:
 
 /// Used for handling and querying diagnostic IDs.
 ///
-/// Can be used and shared by multiple Diagnostics for multiple translation units.
+/// Can be used and shared by multiple Diagnostics for multiple translation
+/// units.
 class DiagnosticIDs : public RefCountedBase<DiagnosticIDs> {
 public:
   /// The level of the diagnostic, after it has been through mapping.
@@ -498,6 +501,6 @@ private:
   friend class DiagnosticsEngine;
 };
 
-}  // end namespace clang
+} // end namespace clang
 
 #endif


### PR DESCRIPTION
When trying to add a new diagnostic category (e.g. #154618) I discovered
`clang-format` really wanted to reformat these files.

My initial attempt was just to suppress the reformatting with `//
clang-format (on|off)` directives but reviewers preferred just
reformatting the files so these two files have been completely
reformatted.

`clang-format` has been disabled for the enum that declares the
`DIAG_START_*` constants because its much less readable after
formatting.

