### PR TITLE
[AMDGPU] Fix uncaught changes made by AMDGPUPreloadKernelArgumentsPass

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUPreloadKernelArguments.cpp
@@ -341,6 +341,7 @@ static bool markKernelArgsAsInreg(Module &M, const TargetMachine &TM) {
     Changed |= NumPreloadedExplicitArgs > 0;
   }
 
+  Changed |= !FunctionsToErase.empty();
   // Erase cloned functions if we needed to update the kernel signature to
   // support preloading hidden kernel arguments.
   for (auto *F : FunctionsToErase)


### PR DESCRIPTION
#153975 added a new test, `test/CodeGen/AMDGPU/disable-preload-kernargs.ll`, that triggers an assertion under `LLVM_ENABLE_EXPENSIVE_CHECKS` complaining about not invalidating analyses even when the Pass made changes. It was caused by the fact that the Pass only invalidates the analyses when number of explicit arguments is greater than zero, while it is possible that some functions will be removed even when there isn't any explicit argument, hence the missed invalidation.