### PR TITLE
[lldb/crashlog] Avoid StopAtEntry when launch crashlog in interactive mode

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1540,22 +1540,25 @@ def load_crashlog_in_scripted_process(debugger, crashlog_path, options, result):
             }
         )
     )
+
+    crashlog_sd = lldb.SBStructuredData()
+    crashlog_sd.SetGenericValue(
+        lldb.SBScriptObject(crashlog, lldb.eScriptLanguagePython)
+    )
+    structured_data.SetValueForKey("crashlog", crashlog_sd)
+
     launch_info = lldb.SBLaunchInfo(None)
     launch_info.SetProcessPluginName("ScriptedProcess")
     launch_info.SetScriptedProcessClassName(
         "crashlog_scripted_process.CrashLogScriptedProcess"
     )
     launch_info.SetScriptedProcessDictionary(structured_data)
-    launch_info.SetLaunchFlags(lldb.eLaunchFlagStopAtEntry)
 
     error = lldb.SBError()
     process = target.Launch(launch_info, error)
 
     if not process or error.Fail():
         raise InteractiveCrashLogException("couldn't launch Scripted Process", error)
-
-    process.GetScriptedImplementation().set_crashlog(crashlog)
-    process.Continue()
 
     if not options.skip_status:
 


### PR DESCRIPTION
In 88f409194, we changed the way the crashlog scripted process was
launched since the previous approach required to parse the file twice,
by stopping at entry, setting the crashlog object in the middle of the
scripted process launch and resuming it.

Since then, we've introduced SBScriptObject which allows to pass any
arbitrary python object accross the SBAPI boundary to another scripted
affordance.

This patch make sure of that to include the parse crashlog object into
the scripted process launch info dictionary, which eliviates the need to
stop at entry.

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>