### PR TITLE
[memprof] Tidy up #includes (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/IndexedMemProfData.h
+++ b/llvm/include/llvm/ProfileData/IndexedMemProfData.h
@@ -18,10 +18,9 @@
 #include "llvm/ProfileData/DataAccessProf.h"
 #include "llvm/ProfileData/InstrProf.h"
 #include "llvm/ProfileData/MemProf.h"
+#include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/Compiler.h"
-
-#include <functional>
-#include <optional>
+#include "llvm/Support/HashBuilder.h"
 
 namespace llvm {
 namespace memprof {

--- a/llvm/include/llvm/ProfileData/MemProf.h
+++ b/llvm/include/llvm/ProfileData/MemProf.h
@@ -14,24 +14,20 @@
 #ifndef LLVM_PROFILEDATA_MEMPROF_H
 #define LLVM_PROFILEDATA_MEMPROF_H
 
-#include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/ProfileData/MemProfData.inc"
-#include "llvm/Support/BLAKE3.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Endian.h"
 #include "llvm/Support/EndianStream.h"
-#include "llvm/Support/HashBuilder.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <bitset>
 #include <cstdint>
-#include <optional>
 
 namespace llvm {
 namespace yaml {

--- a/llvm/include/llvm/ProfileData/MemProfRadixTree.h
+++ b/llvm/include/llvm/ProfileData/MemProfRadixTree.h
@@ -13,9 +13,12 @@
 #ifndef LLVM_PROFILEDATA_MEMPROFRADIXTREE_H
 #define LLVM_PROFILEDATA_MEMPROFRADIXTREE_H
 
+#include "llvm/ADT/BitVector.h"
 #include "llvm/ProfileData/IndexedMemProfData.h"
 #include "llvm/ProfileData/MemProf.h"
 #include "llvm/Support/Compiler.h"
+
+#include <optional>
 
 namespace llvm {
 namespace memprof {


### PR DESCRIPTION
We've reorganized some code within memprof, but #indludes haven't
quite followed the code that moved.
