### PR TITLE
[clang][bytecode] Fix a crash with typeid pointers

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1788,6 +1788,8 @@ inline bool GetPtrBase(InterpState &S, CodePtr OpPC, uint32_t Off) {
     return false;
 
   if (!Ptr.isBlockPointer()) {
+    if (!Ptr.isIntegralPointer())
+      return false;
     S.Stk.push<Pointer>(Ptr.asIntPointer().baseCast(S.getASTContext(), Off));
     return true;
   }
@@ -1809,6 +1811,8 @@ inline bool GetPtrBasePop(InterpState &S, CodePtr OpPC, uint32_t Off,
     return false;
 
   if (!Ptr.isBlockPointer()) {
+    if (!Ptr.isIntegralPointer())
+      return false;
     S.Stk.push<Pointer>(Ptr.asIntPointer().baseCast(S.getASTContext(), Off));
     return true;
   }

--- a/clang/test/AST/ByteCode/typeid.cpp
+++ b/clang/test/AST/ByteCode/typeid.cpp
@@ -13,7 +13,12 @@ struct __type_info_implementations {
   typedef __unique_impl __impl;
 };
 
-class type_info {
+class __pointer_type_info {
+public:
+  int __flags = 0;
+};
+
+class type_info : public __pointer_type_info {
 protected:
   typedef __type_info_implementations::__impl __impl;
   __impl::__type_name_t __type_name;
@@ -40,3 +45,10 @@ constexpr bool test() {
   return true;
 }
 static_assert(test());
+
+int dontcrash() {
+  auto& pti = static_cast<const std::__pointer_type_info&>(
+      typeid(int)
+  );
+  return pti.__flags == 0 ? 1 : 0;
+}


### PR DESCRIPTION
That code is from a time when typeid pointers didn't exist. We can get there for non-block, non-integral pointers, but we can't meaningfully handle that case. Just return false.

Fixes #153712