### PR TITLE
[asan] Pass -falign-functions=16 when building on Windows

### DIFF
--- a/compiler-rt/lib/asan/CMakeLists.txt
+++ b/compiler-rt/lib/asan/CMakeLists.txt
@@ -106,12 +106,10 @@ if(MSVC)
 endif()
 set(ASAN_CFLAGS ${SANITIZER_COMMON_CFLAGS})
 
-# Win/ASan relies on the runtime having 16-byte aligned functions for
-# hotpatching. See https://github.com/llvm/llvm-project/pull/149444
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  if(CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
-    list(APPEND ASAN_CFLAGS /clang:-falign-functions=16)
-  endif()
+# Win/ASan relies on the runtime functions being hotpatchable. See
+# https://github.com/llvm/llvm-project/pull/149444
+if(MSVC)
+  list(APPEND ASAN_CFLAGS /hotpatch)
 endif()
 
 append_list_if(MSVC /Zl ASAN_CFLAGS)

--- a/compiler-rt/lib/asan/CMakeLists.txt
+++ b/compiler-rt/lib/asan/CMakeLists.txt
@@ -106,6 +106,14 @@ if(MSVC)
 endif()
 set(ASAN_CFLAGS ${SANITIZER_COMMON_CFLAGS})
 
+# Win/ASan relies on the runtime having 16-byte aligned functions for
+# hotpatching. See https://github.com/llvm/llvm-project/pull/149444
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
+    list(APPEND ASAN_CFLAGS /clang:-falign-functions=16)
+  endif()
+endif()
+
 append_list_if(MSVC /Zl ASAN_CFLAGS)
 
 set(ASAN_COMMON_DEFINITIONS "")


### PR DESCRIPTION
Win/ASan relies on the runtime's functions being 16-byte aligned so it can intercept them with hotpatching. This used to be true (but not guaranteed) until #149444.

Pass the flag to explicitly request enough alignment.