### PR TITLE
[tsan][riscv] add Go race detector support for RISC-V sv39 VMA

### DIFF
--- a/compiler-rt/lib/tsan/go/test.c
+++ b/compiler-rt/lib/tsan/go/test.c
@@ -63,6 +63,13 @@ int main(void) {
   __tsan_init(&thr0, &proc0, symbolize_cb);
   current_proc = proc0;
 
+#if defined(__riscv) && (__riscv_xlen == 64) && defined(__linux__)
+  // Use correct go_heap for riscv64 sv39.
+  if (65 - __builtin_clzl((unsigned long)__builtin_frame_address(0)) == 39) {
+    go_heap = (void *)0x511100000;
+  }
+#endif
+
   // Allocate something resembling a heap in Go.
   buf0 = mmap(go_heap, 16384, PROT_READ | PROT_WRITE,
               MAP_PRIVATE | MAP_FIXED | MAP_ANON, -1, 0);

--- a/compiler-rt/lib/tsan/rtl/tsan_platform.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform.h
@@ -681,6 +681,33 @@ struct MappingGoMips64_47 {
   static const uptr kShadowAdd = 0x200000000000ull;
 };
 
+/* Go on linux/riscv64 (39-bit VMA)
+0000 0000 0000 - 000a 0000 0000: executable and heap (40 GiB)
+000a 0000 0000 - 000c 0000 0000: -
+000c 0000 0000 - 0034 0000 0000: shadow - 160 GiB ( ~ 4 * app)
+0034 0000 0000 - 0035 0000 0000: -
+0035 0000 0000 - 0039 0000 0000: metainfo - 40 GiB ( ~ 1 * app)
+0039 0000 0000 - 0040 0000 0000: -
+*/
+struct MappingGoRiscv64_39 {
+  static const uptr kMetaShadowBeg = 0x003500000000ull;
+  static const uptr kMetaShadowEnd = 0x003900000000ull;
+  static const uptr kShadowBeg = 0x000c00000000ull;
+  static const uptr kShadowEnd = 0x003400000000ull;
+  static const uptr kLoAppMemBeg = 0x000000010000ull;
+  static const uptr kLoAppMemEnd = 0x000a00000000ull;
+  static const uptr kMidAppMemBeg = 0;
+  static const uptr kMidAppMemEnd = 0;
+  static const uptr kHiAppMemBeg = 0;
+  static const uptr kHiAppMemEnd = 0;
+  static const uptr kHeapMemBeg = 0;
+  static const uptr kHeapMemEnd = 0;
+  static const uptr kVdsoBeg = 0;
+  static const uptr kShadowMsk = 0;
+  static const uptr kShadowXor = 0;
+  static const uptr kShadowAdd = 0x000c00000000ull;
+};
+
 /* Go on linux/riscv64 (48-bit VMA)
 0000 0001 0000 - 00e0 0000 0000: executable and heap (896 GiB)
 00e0 0000 0000 - 2000 0000 0000: -
@@ -689,7 +716,7 @@ struct MappingGoMips64_47 {
 3000 0000 0000 - 3100 0000 0000: metainfo - 1 TiB ( ~ 1 * app)
 3100 0000 0000 - 8000 0000 0000: -
 */
-struct MappingGoRiscv64 {
+struct MappingGoRiscv64_48 {
   static const uptr kMetaShadowBeg = 0x300000000000ull;
   static const uptr kMetaShadowEnd = 0x310000000000ull;
   static const uptr kShadowBeg = 0x200000000000ull;
@@ -756,7 +783,12 @@ ALWAYS_INLINE auto SelectMapping(Arg arg) {
 #  elif defined(__loongarch_lp64)
   return Func::template Apply<MappingGoLoongArch64_47>(arg);
 #  elif SANITIZER_RISCV64
-  return Func::template Apply<MappingGoRiscv64>(arg);
+  switch (vmaSize) {
+    case 39:
+      return Func::template Apply<MappingGoRiscv64_39>(arg);
+    case 48:
+      return Func::template Apply<MappingGoRiscv64_48>(arg);
+   }
 #  elif SANITIZER_WINDOWS
   return Func::template Apply<MappingGoWindows>(arg);
 #  else
@@ -827,7 +859,8 @@ void ForEachMapping() {
   Func::template Apply<MappingGoAarch64>();
   Func::template Apply<MappingGoLoongArch64_47>();
   Func::template Apply<MappingGoMips64_47>();
-  Func::template Apply<MappingGoRiscv64>();
+  Func::template Apply<MappingGoRiscv64_39>();
+  Func::template Apply<MappingGoRiscv64_48>();
   Func::template Apply<MappingGoS390x>();
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_platform.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform.h
@@ -682,20 +682,19 @@ struct MappingGoMips64_47 {
 };
 
 /* Go on linux/riscv64 (39-bit VMA)
-0000 0000 0000 - 000a 0000 0000: executable and heap (40 GiB)
-000a 0000 0000 - 000c 0000 0000: -
-000c 0000 0000 - 0034 0000 0000: shadow - 160 GiB ( ~ 4 * app)
-0034 0000 0000 - 0035 0000 0000: -
-0035 0000 0000 - 0039 0000 0000: metainfo - 40 GiB ( ~ 1 * app)
-0039 0000 0000 - 0040 0000 0000: -
+0000 0001 0000 - 000f 0000 0000: executable and heap (60 GiB)
+000f 0000 0000 - 0010 0000 0000: -
+0010 0000 0000 - 0030 0000 0000: shadow - 128 GiB ( ~ 2 * app)
+0030 0000 0000 - 0038 0000 0000: metainfo - 32 GiB ( ~ 0.5 * app)
+0038 0000 0000 - 0040 0000 0000: -
 */
 struct MappingGoRiscv64_39 {
-  static const uptr kMetaShadowBeg = 0x003500000000ull;
-  static const uptr kMetaShadowEnd = 0x003900000000ull;
-  static const uptr kShadowBeg = 0x000c00000000ull;
-  static const uptr kShadowEnd = 0x003400000000ull;
+  static const uptr kMetaShadowBeg = 0x003000000000ull;
+  static const uptr kMetaShadowEnd = 0x003800000000ull;
+  static const uptr kShadowBeg = 0x001000000000ull;
+  static const uptr kShadowEnd = 0x003000000000ull;
   static const uptr kLoAppMemBeg = 0x000000010000ull;
-  static const uptr kLoAppMemEnd = 0x000a00000000ull;
+  static const uptr kLoAppMemEnd = 0x000f00000000ull;
   static const uptr kMidAppMemBeg = 0;
   static const uptr kMidAppMemEnd = 0;
   static const uptr kHiAppMemBeg = 0;
@@ -705,7 +704,7 @@ struct MappingGoRiscv64_39 {
   static const uptr kVdsoBeg = 0;
   static const uptr kShadowMsk = 0;
   static const uptr kShadowXor = 0;
-  static const uptr kShadowAdd = 0x000c00000000ull;
+  static const uptr kShadowAdd = 0x001000000000ull;
 };
 
 /* Go on linux/riscv64 (48-bit VMA)

--- a/compiler-rt/lib/tsan/rtl/tsan_platform.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform.h
@@ -787,7 +787,7 @@ ALWAYS_INLINE auto SelectMapping(Arg arg) {
       return Func::template Apply<MappingGoRiscv64_39>(arg);
     case 48:
       return Func::template Apply<MappingGoRiscv64_48>(arg);
-   }
+  }
 #  elif SANITIZER_WINDOWS
   return Func::template Apply<MappingGoWindows>(arg);
 #  else

--- a/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp
@@ -393,9 +393,9 @@ void InitializePlatformEarly() {
     Die();
   }
 #    else
-  if (vmaSize != 48) {
+  if (vmaSize != 39 && vmaSize != 48) {
     Printf("FATAL: ThreadSanitizer: unsupported VMA range\n");
-    Printf("FATAL: Found %zd - Supported 48\n", vmaSize);
+    Printf("FATAL: Found %zd - Supported 39 and 48\n", vmaSize);
     Die();
   }
 #    endif


### PR DESCRIPTION
The majority of readily available RISC-V hardware provides sv39, rather than
sv48. Add a memory mapping for sv39, which will allow the Go race detector
to be used on more hardware.