### PR TITLE
[llvm][Support] Fix missing-field-initializer warnings for crashreporter_annotations_t

### DIFF
--- a/llvm/lib/Support/PrettyStackTrace.cpp
+++ b/llvm/lib/Support/PrettyStackTrace.cpp
@@ -114,15 +114,27 @@ static void PrintCurStackTrace(raw_ostream &OS) {
 //  If any clients of llvm try to link to libCrashReporterClient.a themselves,
 //  only one crash info struct will be used.
 extern "C" {
+#ifdef CRASHREPORTER_ANNOTATIONS_INITIALIZER
+// Available in CRASHREPORTER_ANNOTATIONS_VERSION 5+
+CRASHREPORTER_ANNOTATIONS_INITIALIZER()
+#else
+// Older CrashReporter annotations layouts
 CRASH_REPORTER_CLIENT_HIDDEN
 struct crashreporter_annotations_t gCRAnnotations
-        __attribute__((section("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION)))
-#if CRASHREPORTER_ANNOTATIONS_VERSION < 5
-        = { CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0 };
-#else
-        = { CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0 };
-#endif
-}
+    __attribute__((section("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
+        CRASHREPORTER_ANNOTATIONS_VERSION,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+#if CRASHREPORTER_ANNOTATIONS_VERSION > 4
+        0
+#endif // CRASHREPORTER_ANNOTATIONS_VERSION > 4
+};
+#endif // CRASHREPORTER_ANNOTATIONS_INITIALIZER
+} // extern "C"
 #elif defined(__APPLE__) && HAVE_CRASHREPORTER_INFO
 extern "C" const char *__crashreporter_info__
     __attribute__((visibility("hidden"))) = 0;

--- a/llvm/lib/Support/PrettyStackTrace.cpp
+++ b/llvm/lib/Support/PrettyStackTrace.cpp
@@ -115,7 +115,7 @@ static void PrintCurStackTrace(raw_ostream &OS) {
 //  only one crash info struct will be used.
 extern "C" {
 #ifdef CRASHREPORTER_ANNOTATIONS_INITIALIZER
-// Available in CRASHREPORTER_ANNOTATIONS_VERSION 5+
+// Should be available in CRASHREPORTER_ANNOTATIONS_VERSION > 5
 CRASHREPORTER_ANNOTATIONS_INITIALIZER()
 #else
 // Older CrashReporter annotations layouts


### PR DESCRIPTION
Use `CRASHREPORTER_ANNOTATIONS_INITIALIZER` when possible, which will handle the field initialization for us. That's what we already do in compiler-rt:
https://github.com/llvm/llvm-project/blob/0c480dd4b61e285bfda4de99c77da28922e64b94/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp#L799-L817

This way we won't get these warnings when the layout of crashreporter_annotations_t changes:
```
llvm/lib/Support/PrettyStackTrace.cpp:92:65: warning: missing field 'blah' initializer [-Wmissing-field-initializers]
        = { CRASHREPORTER_ANNOTATIONS_VERSION, 0, 0, 0, 0, 0, 0, 0 };
                                                                  ^
1 warning generated
```