### PR TITLE
[LivePhysRegs] Make use of `MBB.liveouts()` (semi-NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/LivePhysRegs.h
+++ b/llvm/include/llvm/CodeGen/LivePhysRegs.h
@@ -165,9 +165,16 @@ public:
   void dump() const;
 
 private:
+  /// Adds a register, taking the lane mask into consideration.
+  void addRegMaskPair(const MachineBasicBlock::RegisterMaskPair &Pair);
+
   /// Adds live-in registers from basic block \p MBB, taking associated
   /// lane masks into consideration.
   void addBlockLiveIns(const MachineBasicBlock &MBB);
+
+  /// Adds live-out registers from basic block \p MBB, taking associated
+  /// lane masks into consideration.
+  void addBlockLiveOuts(const MachineBasicBlock &MBB);
 
   /// Adds pristine registers. Pristine registers are callee saved registers
   /// that are unused in the function.

--- a/llvm/lib/CodeGen/LiveRegUnits.cpp
+++ b/llvm/lib/CodeGen/LiveRegUnits.cpp
@@ -94,8 +94,8 @@ static void addBlockLiveIns(LiveRegUnits &LiveUnits,
 /// Add live-out registers of basic block \p MBB to \p LiveUnits.
 static void addBlockLiveOuts(LiveRegUnits &LiveUnits,
                              const MachineBasicBlock &MBB) {
-  for (const auto &LI : MBB.liveouts())
-    LiveUnits.addRegMasked(LI.PhysReg, LI.LaneMask);
+  for (const auto &LO : MBB.liveouts())
+    LiveUnits.addRegMasked(LO.PhysReg, LO.LaneMask);
 }
 
 /// Adds all callee saved registers to \p LiveUnits.


### PR DESCRIPTION
This is done for consistency with LiveRegUnits (see #154325). This is technically not an NFC, as `MBB.liveouts()` excludes runtime-defined liveins, but no users currently depend on this.