### PR TITLE
[bolt][aarch64] Skip BB instrumentation with exclusive load/store instructions

### DIFF
--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -579,6 +579,8 @@ void Instrumentation::instrumentFunction(BinaryFunction &Function,
   if (!opts::ConservativeInstrumentation) {
     for (auto BBI = Function.begin(), BBE = Function.end(); BBI != BBE; ++BBI) {
       BinaryBasicBlock &BB = *BBI;
+      if (BBToSkip.find(&BB) != BBToSkip.end())
+        continue;
       if (STOutSet[&BB].size() == 0)
         instrumentLeafNode(BB, BB.begin(), IsLeafFunction, *FuncDesc,
                            BBToID[&BB]);


### PR DESCRIPTION
Basic blocks with exclusive load/store instructions are skipped from instrumentation for aarch64. In case of non-conservative mode the spanning tree leaves BB must be skipped either if contains exclusive instructions.

Related to #153492 