### PR TITLE
[Analyzer] No longer crash with VLA operands to unary type traits

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -916,7 +916,8 @@ VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *Ex,
   QualType T = Ex->getTypeOfArgument();
 
   for (ExplodedNode *N : CheckedSet) {
-    if (Ex->getKind() == UETT_SizeOf) {
+    if (Ex->getKind() == UETT_SizeOf || Ex->getKind() == UETT_DataSizeOf ||
+        Ex->getKind() == UETT_CountOf) {
       if (!T->isIncompleteType() && !T->isConstantSizeType()) {
         assert(T->isVariableArrayType() && "Unknown non-constant-sized type.");
 

--- a/clang/test/Analysis/engine/gh151711.cpp
+++ b/clang/test/Analysis/engine/gh151711.cpp
@@ -1,0 +1,18 @@
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify %s
+// RUN: %clang_analyze_cc1 -analyzer-checker=core,debug.ExprInspection -verify -x c %s
+
+void clang_analyzer_dump(int);
+
+// Ensure that VLA types are correctly handled by unary type traits in the
+// expression engine. Previously, __datasizeof and _Countof both caused failed
+// assertions.
+void gh151711(int i) {
+  clang_analyzer_dump(sizeof(int[i++]));       // expected-warning {{Unknown}}
+#ifdef __cplusplus
+  // __datasizeof is only available in C++.
+  clang_analyzer_dump(__datasizeof(int[i++])); // expected-warning {{Unknown}}
+#else
+  // _Countof is only available in C.
+  clang_analyzer_dump(_Countof(int[i++]));     // expected-warning {{Unknown}}
+#endif
+}


### PR DESCRIPTION
sizeof was handled correctly, but __datasizeof and _Countof were not.

Fixes #151711

(cherry picked from commit 17327482f045b7119e116320db3e9c12fcf250ae with adjustments)
Dropping the ReleaseNotes part of the original patch.

The Static Analyzer release notes section will mention this patch in #154600