### PR TITLE
[Clang][analyzer][NFC] Const-correct CheckerContext API

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
+++ b/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
@@ -623,10 +623,12 @@ public:
   ASTContext &getContext() { return D.getASTContext(); }
 
   const SourceManager &getSourceManager() { return D.getSourceManager(); }
+  const SourceManager &getSourceManager() const { return D.getSourceManager(); }
 
   const AnalyzerOptions &getAnalyzerOptions() { return D.getAnalyzerOptions(); }
 
   Preprocessor &getPreprocessor() { return D.getPreprocessor(); }
+  const Preprocessor &getPreprocessor() const { return D.getPreprocessor(); }
 
   /// Get the top-level entry point for the issue to be reported.
   const Decl *getAnalysisEntryPoint() const { return AnalysisEntryPoint; }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -72,9 +72,7 @@ public:
   StoreManager &getStoreManager() {
     return Eng.getStoreManager();
   }
-  const StoreManager &getStoreManager() const {
-    return Eng.getStoreManager();
-  }
+  const StoreManager &getStoreManager() const { return Eng.getStoreManager(); }
 
   /// Returns the previous node in the exploded graph, which includes
   /// the state of the program before the checker ran. Note, checkers should
@@ -119,9 +117,7 @@ public:
   BugReporter &getBugReporter() {
     return Eng.getBugReporter();
   }
-  const BugReporter &getBugReporter() const {
-    return Eng.getBugReporter();
-  }
+  const BugReporter &getBugReporter() const { return Eng.getBugReporter(); }
 
   const SourceManager &getSourceManager() {
     return getBugReporter().getSourceManager();
@@ -131,14 +127,14 @@ public:
   }
 
   Preprocessor &getPreprocessor() { return getBugReporter().getPreprocessor(); }
-  const Preprocessor &getPreprocessor() const { return getBugReporter().getPreprocessor(); }
+  const Preprocessor &getPreprocessor() const {
+    return getBugReporter().getPreprocessor();
+  }
 
   SValBuilder &getSValBuilder() {
     return Eng.getSValBuilder();
   }
-  const SValBuilder &getSValBuilder() const {
-    return Eng.getSValBuilder();
-  }
+  const SValBuilder &getSValBuilder() const { return Eng.getSValBuilder(); }
 
   SymbolManager &getSymbolManager() {
     return getSValBuilder().getSymbolManager();

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h
@@ -58,12 +58,21 @@ public:
   AnalysisManager &getAnalysisManager() {
     return Eng.getAnalysisManager();
   }
+  const AnalysisManager &getAnalysisManager() const {
+    return Eng.getAnalysisManager();
+  }
 
   ConstraintManager &getConstraintManager() {
     return Eng.getConstraintManager();
   }
+  const ConstraintManager &getConstraintManager() const {
+    return Eng.getConstraintManager();
+  }
 
   StoreManager &getStoreManager() {
+    return Eng.getStoreManager();
+  }
+  const StoreManager &getStoreManager() const {
     return Eng.getStoreManager();
   }
 
@@ -71,12 +80,14 @@ public:
   /// the state of the program before the checker ran. Note, checkers should
   /// not retain the node in their state since the nodes might get invalidated.
   ExplodedNode *getPredecessor() { return Pred; }
+  const ExplodedNode *getPredecessor() const { return Pred; }
   const ProgramPoint getLocation() const { return Location; }
   const ProgramStateRef &getState() const { return Pred->getState(); }
 
   /// Check if the checker changed the state of the execution; ex: added
   /// a new transition or a bug report.
   bool isDifferent() { return Changed; }
+  bool isDifferent() const { return Changed; }
 
   /// Returns the number of times the current block has been visited
   /// along the analyzed path.
@@ -108,22 +119,38 @@ public:
   BugReporter &getBugReporter() {
     return Eng.getBugReporter();
   }
+  const BugReporter &getBugReporter() const {
+    return Eng.getBugReporter();
+  }
 
   const SourceManager &getSourceManager() {
     return getBugReporter().getSourceManager();
   }
+  const SourceManager &getSourceManager() const {
+    return getBugReporter().getSourceManager();
+  }
 
   Preprocessor &getPreprocessor() { return getBugReporter().getPreprocessor(); }
+  const Preprocessor &getPreprocessor() const { return getBugReporter().getPreprocessor(); }
 
   SValBuilder &getSValBuilder() {
+    return Eng.getSValBuilder();
+  }
+  const SValBuilder &getSValBuilder() const {
     return Eng.getSValBuilder();
   }
 
   SymbolManager &getSymbolManager() {
     return getSValBuilder().getSymbolManager();
   }
+  const SymbolManager &getSymbolManager() const {
+    return getSValBuilder().getSymbolManager();
+  }
 
   ProgramStateManager &getStateManager() {
+    return Eng.getStateManager();
+  }
+  const ProgramStateManager &getStateManager() const {
     return Eng.getStateManager();
   }
 

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -422,7 +422,9 @@ public:
   const ProgramStateManager &getStateManager() const { return StateMgr; }
 
   StoreManager &getStoreManager() { return StateMgr.getStoreManager(); }
-  const StoreManager &getStoreManager() const { return StateMgr.getStoreManager(); }
+  const StoreManager &getStoreManager() const {
+    return StateMgr.getStoreManager();
+  }
 
   ConstraintManager &getConstraintManager() {
     return StateMgr.getConstraintManager();

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ExprEngine.h
@@ -196,6 +196,7 @@ public:
   ASTContext &getContext() const { return AMgr.getASTContext(); }
 
   AnalysisManager &getAnalysisManager() { return AMgr; }
+  const AnalysisManager &getAnalysisManager() const { return AMgr; }
 
   AnalysisDeclContextManager &getAnalysisDeclContextManager() {
     return AMgr.getAnalysisDeclContextManager();
@@ -206,8 +207,10 @@ public:
   }
 
   SValBuilder &getSValBuilder() { return svalBuilder; }
+  const SValBuilder &getSValBuilder() const { return svalBuilder; }
 
   BugReporter &getBugReporter() { return BR; }
+  const BugReporter &getBugReporter() const { return BR; }
 
   cross_tu::CrossTranslationUnitContext *
   getCrossTranslationUnitContext() {
@@ -416,10 +419,15 @@ public:
                  unsigned int Space, bool IsDot) const;
 
   ProgramStateManager &getStateManager() { return StateMgr; }
+  const ProgramStateManager &getStateManager() const { return StateMgr; }
 
   StoreManager &getStoreManager() { return StateMgr.getStoreManager(); }
+  const StoreManager &getStoreManager() const { return StateMgr.getStoreManager(); }
 
   ConstraintManager &getConstraintManager() {
+    return StateMgr.getConstraintManager();
+  }
+  const ConstraintManager &getConstraintManager() const {
     return StateMgr.getConstraintManager();
   }
 
@@ -429,6 +437,7 @@ public:
   }
 
   SymbolManager &getSymbolManager() { return SymMgr; }
+  const SymbolManager &getSymbolManager() const { return SymMgr; }
   MemRegionManager &getRegionManager() { return MRMgr; }
 
   DataTag::Factory &getDataTags() { return Engine.getDataTags(); }

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -572,7 +572,9 @@ public:
   CallEventManager &getCallEventManager() { return *CallEventMgr; }
 
   StoreManager &getStoreManager() { return *StoreMgr; }
+  const StoreManager &getStoreManager() const { return *StoreMgr; }
   ConstraintManager &getConstraintManager() { return *ConstraintMgr; }
+  const ConstraintManager &getConstraintManager() const { return *ConstraintMgr; }
   ExprEngine &getOwningEngine() { return *Eng; }
 
   ProgramStateRef

--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/ProgramState.h
@@ -574,7 +574,9 @@ public:
   StoreManager &getStoreManager() { return *StoreMgr; }
   const StoreManager &getStoreManager() const { return *StoreMgr; }
   ConstraintManager &getConstraintManager() { return *ConstraintMgr; }
-  const ConstraintManager &getConstraintManager() const { return *ConstraintMgr; }
+  const ConstraintManager &getConstraintManager() const {
+    return *ConstraintMgr;
+  }
   ExprEngine &getOwningEngine() { return *Eng; }
 
   ProgramStateRef


### PR DESCRIPTION
Improve const-correctness of CheckerContext API by defining the missing `const` overloads to its accessor member functions.

This NFC change is triggered by a work on a downstream checker that operated on a `const CheckerConst& C` most of the time, but needed `C.getPredecessor()` at one point, which forced me to remove `const` from many places.