### PR TITLE
[C99] Update documentation for scope of variables in loops; NFC

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -1763,6 +1763,7 @@ Hexadecimal floating constants (N308)                                          C
 Compound literals (N716)                                                       C99           C89, C++
 ``//`` comments (N644)                                                         C99           C89
 Mixed declarations and code (N740)                                             C99           C89
+init-statement in for (N740)                                                   C99           C89
 Variadic macros (N707)                                                         C99           C89
 Empty macro arguments (N570)                                                   C99           C89
 Trailing comma in enum declaration                                             C99           C89

--- a/clang/www/c_status.html
+++ b/clang/www/c_status.html
@@ -1302,13 +1302,8 @@ conforms by not defining the <code>__STDC_IEC_559_COMPLEX__</code> macro.
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>
-      <td>mixed declarations and code</td>
+      <td>mixed declarations and code<br \>new block scopes for selection and iteration statements</td>
       <td><a href="https://www.open-std.org/jtc1/sc22/wg14/www/docs/n740.htm">N740</a></td>
-      <td class="full" align="center">Yes</td>
-    </tr>
-    <tr>
-      <td>new block scopes for selection and iteration statements</td>
-      <td>Unknown</td>
       <td class="full" align="center">Yes</td>
     </tr>
     <tr>


### PR DESCRIPTION
I tracked down the document which changed the way variables are handled in for loops for C99, it was the same document that allowed mixing code and declarations but the editor's report made it seem like the features came from different papers.

This is an extension we backported to C89 but it's sufficiently distinct in the tracking page so I've added it explicitly to the backported features documentation.