### PR TITLE
Revert "[C++] Expose nullptr_t from stddef.h in C++ mode"

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -229,7 +229,6 @@ Bug Fixes in This Version
   cast chain. (#GH149967).
 - Fixed a crash with incompatible pointer to integer conversions in designated
   initializers involving string literals. (#GH154046)
-- Clang's ``<stddef.h>`` now properly declares ``nullptr_t`` in C++ mode. (#GH154577).
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Headers/__stddef_nullptr_t.h
+++ b/clang/lib/Headers/__stddef_nullptr_t.h
@@ -16,8 +16,7 @@
 #define _NULLPTR_T
 
 #ifdef __cplusplus
-#if __cplusplus >= 201103L ||                                                  \
-    (defined(_MSC_EXTENSIONS) && defined(_NATIVE_NULLPTR_SUPPORTED))
+#if defined(_MSC_EXTENSIONS) && defined(_NATIVE_NULLPTR_SUPPORTED)
 namespace std {
 typedef decltype(nullptr) nullptr_t;
 }

--- a/clang/test/Headers/stddefneeds.cpp
+++ b/clang/test/Headers/stddefneeds.cpp
@@ -1,12 +1,10 @@
 // RUN: %clang_cc1 -fsyntax-only -triple x86_64-apple-macosx10.9.0 -verify -Wsentinel -std=c++11 %s
-// RUN: %clang_cc1 -fsyntax-only -triple x86_64-apple-macosx10.9.0 -verify=old,expected -Wsentinel -std=c++98 %s
 
 ptrdiff_t p0; // expected-error{{unknown}}
 size_t s0; // expected-error{{unknown}}
 void* v0 = NULL; // expected-error{{undeclared}}
 wint_t w0; // expected-error{{unknown}}
 max_align_t m0; // expected-error{{unknown}}
-nullptr_t n0; // expected-error {{unknown}}
 
 #define __need_ptrdiff_t
 #include <stddef.h>
@@ -16,7 +14,6 @@ size_t s1; // expected-error{{unknown}}
 void* v1 = NULL; // expected-error{{undeclared}}
 wint_t w1; // expected-error{{unknown}}
 max_align_t m1; // expected-error{{unknown}}
-nullptr_t n1; // expected-error{{unknown}}
 
 #define __need_size_t
 #include <stddef.h>
@@ -26,16 +23,6 @@ size_t s2;
 void* v2 = NULL; // expected-error{{undeclared}}
 wint_t w2; // expected-error{{unknown}}
 max_align_t m2; // expected-error{{unknown}}
-nullptr_t n2; // expected-error{{unknown}}
-
-#define __need_nullptr_t
-#include <stddef.h>
-ptrdiff_t p6;
-size_t s6;
-void* v6 = NULL; // expected-error{{undeclared}}
-wint_t w6; // expected-error{{unknown}}
-max_align_t m6; // expected-error{{unknown}}
-nullptr_t n6; // old-error{{unknown}}
 
 #define __need_NULL
 #include <stddef.h>
@@ -45,16 +32,6 @@ size_t s3;
 void* v3 = NULL;
 wint_t w3; // expected-error{{unknown}}
 max_align_t m3; // expected-error{{unknown}}
-nullptr_t n3; // old-error{{unknown}}
-
-#define __need_max_align_t
-#include <stddef.h>
-ptrdiff_t p7;
-size_t s7;
-void* v7 = NULL;
-wint_t w7; // expected-error{{unknown}}
-max_align_t m7;
-nullptr_t n7; // old-error{{unknown}}
 
 // Shouldn't bring in wint_t by default:
 #include <stddef.h>
@@ -64,7 +41,6 @@ size_t s4;
 void* v4 = NULL;
 wint_t w4; // expected-error{{unknown}}
 max_align_t m4;
-nullptr_t n4; // old-error{{unknown}}
 
 #define __need_wint_t
 #include <stddef.h>
@@ -74,7 +50,7 @@ size_t s5;
 void* v5 = NULL;
 wint_t w5;
 max_align_t m5;
-nullptr_t n5; // old-error{{unknown}}
+
 
 // linux/stddef.h does something like this for cpp files:
 #undef NULL


### PR DESCRIPTION
Reverts llvm/llvm-project#154599

It seems to be causing staging failures:
    https://lab.llvm.org/staging/#/builders/192/builds/1329
    https://lab.llvm.org/staging/#/builders/192/builds/1330
