### PR TITLE
[SelectionDAG] Remove `UnsafeFPMath` in `visitFP_ROUND`

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18988,7 +18988,7 @@ SDValue DAGCombiner::visitFP_ROUND(SDNode *N) {
     // single-step fp_round we want to fold to.
     // In other words, double rounding isn't the same as rounding.
     // Also, this is a value preserving truncation iff both fp_round's are.
-    if (DAG.getTarget().Options.UnsafeFPMath || N0IsTrunc)
+    if (N->getFlags().hasAllowContract() || N0IsTrunc)
       return DAG.getNode(
           ISD::FP_ROUND, DL, VT, N0.getOperand(0),
           DAG.getIntPtrConstant(NIsTrunc && N0IsTrunc, DL, /*isTarget=*/true));

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -18988,7 +18988,9 @@ SDValue DAGCombiner::visitFP_ROUND(SDNode *N) {
     // single-step fp_round we want to fold to.
     // In other words, double rounding isn't the same as rounding.
     // Also, this is a value preserving truncation iff both fp_round's are.
-    if (N->getFlags().hasAllowContract() || N0IsTrunc)
+    if ((N->getFlags().hasAllowContract() &&
+         N0->getFlags().hasAllowContract()) ||
+        N0IsTrunc)
       return DAG.getNode(
           ISD::FP_ROUND, DL, VT, N0.getOperand(0),
           DAG.getIntPtrConstant(NIsTrunc && N0IsTrunc, DL, /*isTarget=*/true));

--- a/llvm/test/CodeGen/X86/fp-double-rounding.ll
+++ b/llvm/test/CodeGen/X86/fp-double-rounding.ll
@@ -4,16 +4,25 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--"
 
-; CHECK-LABEL: double_rounding:
+; CHECK-LABEL: double_rounding_safe:
 ; SAFE: callq __trunctfdf2
 ; SAFE-NEXT: cvtsd2ss %xmm0
+define void @double_rounding_safe(ptr %x, ptr %f) {
+entry:
+  %0 = load fp128, ptr %x, align 16
+  %1 = fptrunc fp128 %0 to double
+  %2 = fptrunc double %1 to float
+  store float %2, ptr %f, align 4
+  ret void
+}
+; CHECK-LABEL: double_rounding:
 ; UNSAFE: callq __trunctfsf2
 ; UNSAFE-NOT: cvt
 define void @double_rounding(ptr %x, ptr %f) {
 entry:
   %0 = load fp128, ptr %x, align 16
-  %1 = fptrunc fp128 %0 to double
-  %2 = fptrunc double %1 to float
+  %1 = fptrunc contract fp128 %0 to double
+  %2 = fptrunc contract double %1 to float
   store float %2, ptr %f, align 4
   ret void
 }

--- a/llvm/test/CodeGen/X86/fp-double-rounding.ll
+++ b/llvm/test/CodeGen/X86/fp-double-rounding.ll
@@ -1,29 +1,53 @@
-; RUN: llc < %s | FileCheck %s --check-prefix=CHECK --check-prefix=SAFE
-; RUN: llc < %s -enable-unsafe-fp-math | FileCheck %s --check-prefix=CHECK --check-prefix=UNSAFE
+; RUN: llc < %s | FileCheck %s
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64--"
 
 ; CHECK-LABEL: double_rounding_safe:
-; SAFE: callq __trunctfdf2
-; SAFE-NEXT: cvtsd2ss %xmm0
+; CHECK: callq __trunctfdf2
+; CHECK-NEXT: cvtsd2ss %xmm0
 define void @double_rounding_safe(ptr %x, ptr %f) {
 entry:
-  %0 = load fp128, ptr %x, align 16
-  %1 = fptrunc fp128 %0 to double
-  %2 = fptrunc double %1 to float
-  store float %2, ptr %f, align 4
+  %x.fp128 = load fp128, ptr %x, align 16
+  %x.double = fptrunc fp128 %x.fp128 to double
+  %x.float = fptrunc double %x.double to float
+  store float %x.float, ptr %f, align 4
   ret void
 }
+
+; CHECK-LABEL: double_rounding_contract_fst:
+; CHECK: callq __trunctfdf2
+; CHECK-NEXT: cvtsd2ss %xmm0
+define void @double_rounding_contract_fst(ptr %x, ptr %f) {
+entry:
+  %x.fp128 = load fp128, ptr %x, align 16
+  %x.double = fptrunc contract fp128 %x.fp128 to double
+  %x.float = fptrunc double %x.double to float
+  store float %x.float, ptr %f, align 4
+  ret void
+}
+
+; CHECK-LABEL: double_rounding_contract_snd:
+; CHECK: callq __trunctfdf2
+; CHECK-NEXT: cvtsd2ss %xmm0
+define void @double_rounding_contract_snd(ptr %x, ptr %f) {
+entry:
+  %x.fp128 = load fp128, ptr %x, align 16
+  %x.double = fptrunc fp128 %x.fp128 to double
+  %x.float = fptrunc contract double %x.double to float
+  store float %x.float, ptr %f, align 4
+  ret void
+}
+
 ; CHECK-LABEL: double_rounding:
-; UNSAFE: callq __trunctfsf2
-; UNSAFE-NOT: cvt
+; CHECK: callq __trunctfsf2
+; CHECK-NOT: cvt
 define void @double_rounding(ptr %x, ptr %f) {
 entry:
-  %0 = load fp128, ptr %x, align 16
-  %1 = fptrunc contract fp128 %0 to double
-  %2 = fptrunc contract double %1 to float
-  store float %2, ptr %f, align 4
+  %x.fp128 = load fp128, ptr %x, align 16
+  %x.double = fptrunc contract fp128 %x.fp128 to double
+  %x.float = fptrunc contract double %x.double to float
+  store float %x.float, ptr %f, align 4
   ret void
 }
 


### PR DESCRIPTION
Remove `UnsafeFPMath` in `visitFP_ROUND` part, it blocks some bugfixes related to clang and the ultimate goal is to remove `resetTargetOptions` method in `TargetMachine`, see FIXME in `resetTargetOptions`.
See also https://discourse.llvm.org/t/rfc-honor-pragmas-with-ffp-contract-fast
https://discourse.llvm.org/t/allowfpopfusion-vs-sdnodeflags-hasallowcontract 