### PR TITLE
[PowerPC] fix float ABI selection on ppcle

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -188,7 +188,8 @@ createTargetCodeGenInfo(CodeGenModule &CGM) {
     return createPPC32TargetCodeGenInfo(CGM, IsSoftFloat);
   }
   case llvm::Triple::ppcle: {
-    bool IsSoftFloat = CodeGenOpts.FloatABI == "soft";
+    bool IsSoftFloat =
+        CodeGenOpts.FloatABI == "soft" || Target.hasFeature("spe");
     return createPPC32TargetCodeGenInfo(CGM, IsSoftFloat);
   }
   case llvm::Triple::ppc64:

--- a/clang/test/CodeGen/PowerPC/ppc-sfvarargs.c
+++ b/clang/test/CodeGen/PowerPC/ppc-sfvarargs.c
@@ -1,4 +1,7 @@
 // RUN: %clang -O0 --target=powerpc-unknown-linux-gnu -EB -msoft-float -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang -O0 --target=powerpcle-unknown-linux-gnu -EL -msoft-float -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang -O0 --target=powerpcle-unknown-unknown -mcpu=e500 -mhard-float -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang -O0 --target=powerpc-unknown-unknown -mcpu=e500 -mhard-float -S -emit-llvm %s -o - | FileCheck %s
 
 #include <stdarg.h>
 void test(char *fmt, ...) {


### PR DESCRIPTION
soft float ABI selection was not taking effect on little-endian powerPC with embedded vectors (e.g. e500v2) leading to errors.
(embedded vectors use "extended" GPRs to store floating-point values, and this caused issues with variadic arguments assuming dedicated floating-point registers with hard-float ABI)