### PR TITLE
[TableGen] Remove dummy UINT64_C(0) from end of InstBits table. NFC

### DIFF
--- a/llvm/utils/TableGen/CodeEmitterGen.cpp
+++ b/llvm/utils/TableGen/CodeEmitterGen.cpp
@@ -440,7 +440,7 @@ void CodeEmitterGen::emitInstructionBaseValues(
     emitInstBits(O, Value);
     O << "," << '\t' << "// " << R->getName() << "\n";
   }
-  O << "    UINT64_C(0)\n  };\n";
+  O << "  };\n";
 }
 
 void CodeEmitterGen::emitCaseMap(


### PR DESCRIPTION
I suspect this originally existed to avoid a trailing comma from the previous entry. C++ allows trailing commas in arrays so this isn't necessary.