### PR TITLE
[hwasan] Port "[Asan] Skip pre-split coroutine and noop coroutine frame (#99415)"

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1574,6 +1574,9 @@ void HWAddressSanitizer::sanitizeFunction(Function &F,
   if (F.empty())
     return;
 
+  if(F.isPresplitCoroutine())
+    return;
+
   NumTotalFuncs++;
 
   OptimizationRemarkEmitter &ORE =

--- a/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/HWAddressSanitizer.cpp
@@ -1574,7 +1574,7 @@ void HWAddressSanitizer::sanitizeFunction(Function &F,
   if (F.empty())
     return;
 
-  if(F.isPresplitCoroutine())
+  if (F.isPresplitCoroutine())
     return;
 
   NumTotalFuncs++;


### PR DESCRIPTION
Originally suggested by rnk@

(this is the simplified function-level skip version, to unblock builds ASAP)