### PR TITLE
[LLD][COFF] Set isUsedInRegularObj for target symbols in resolveAlternateNames

### DIFF
--- a/lld/COFF/SymbolTable.cpp
+++ b/lld/COFF/SymbolTable.cpp
@@ -1399,6 +1399,7 @@ void SymbolTable::resolveAlternateNames() {
       auto toUndef = dyn_cast<Undefined>(toSym);
       if (toUndef && (!toUndef->weakAlias || toUndef->isAntiDep))
         continue;
+      toSym->isUsedInRegularObj = true;
       if (toSym->isLazy())
         forceLazy(toSym);
       u->setWeakAlias(toSym);

--- a/lld/test/COFF/alternatename-lto.ll
+++ b/lld/test/COFF/alternatename-lto.ll
@@ -1,0 +1,25 @@
+; REQUIRES: x86
+; RUN: mkdir -p %t.dir
+; RUN: llvm-as -o %t.obj %s
+; RUN: lld-link -out:%t.dll -dll -noentry %t.obj -export:test
+
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-windows-msvc19.33.0"
+
+$alt = comdat any
+
+@alt = weak_odr dso_local global i32 0, comdat, align 4
+@ext = external dso_local global i32, align 4
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @test() #0 {
+entry:
+  %0 = load i32, ptr @ext, align 4
+  ret i32 %0
+}
+
+attributes #0 = { noinline nounwind optnone uwtable }
+
+!llvm.linker.options = !{!0}
+
+!0 = !{!"/alternatename:ext=alt"}


### PR DESCRIPTION
Fixes: #154595

Prior to commit bbc8346e6bb543b0a87f52114fed7d766446bee1, this flag was set by `insert()` from `addUndefined()`. Set it explicitly now.