### PR TITLE
Print ProgramPoint instead of pointer for better logging

### DIFF
--- a/mlir/lib/Analysis/DataFlowFramework.cpp
+++ b/mlir/lib/Analysis/DataFlowFramework.cpp
@@ -45,7 +45,7 @@ void AnalysisState::addDependency(ProgramPoint *dependent,
   DATAFLOW_DEBUG({
     if (inserted) {
       LDBG() << "Creating dependency between " << debugName << " of " << anchor
-             << "\nand " << debugName << " on " << dependent;
+             << "\nand " << debugName << " on " << *dependent;
     }
   });
 }
@@ -128,7 +128,7 @@ LogicalResult DataFlowSolver::initializeAndRun(Operation *top) {
     worklist.pop();
 
     DATAFLOW_DEBUG(LDBG() << "Invoking '" << analysis->debugName
-                          << "' on: " << point);
+                          << "' on: " << *point);
     if (failed(analysis->visit(point)))
       return failure();
   }


### PR DESCRIPTION
There're places where a pointer instead of `ProgramPoint` object is passed to stream print `<<`:

https://github.com/pchen7e2/llvm-project/blob/4256d8229602eb08598761f211d54e719007b468/mlir/lib/Analysis/DataFlowFramework.cpp#L132-L133

and they'll be printed as pointer value. This PR converts them to object before passing to stream printers.

I have a random local IR and I call `opt` tool on it with `-debug-only=dataflow`. 

Before:
```
Invoking 'mlir::dataflow::DeadCodeAnalysis' on: 0x51936d8
Invoking 'mlir::triton::(anonymous namespace)::AxisInfoAnalysis' on: 0x51936d8
Creating dependency between mlir::dataflow::PredecessorState of <before operation>:scf.yield %arg3 : i32
and mlir::dataflow::PredecessorState on 0x51936d8
```
After:
```
Invoking 'mlir::dataflow::DeadCodeAnalysis' on: <before operation>:scf.yield %arg3 : i32
Invoking 'mlir::triton::(anonymous namespace)::AxisInfoAnalysis' on: <before operation>:scf.yield %arg3 : i32
Creating dependency between mlir::dataflow::PredecessorState of <before operation>:scf.yield %arg3 : i32
and mlir::dataflow::PredecessorState on <before operation>:scf.yield %arg3 : i32
```

It's now calling `point->print` instead of printing the pointer address value.