### PR TITLE
[NFC][DebugInfo] Allow single instruction sequence in line table to make symbolication of merged functions easier

### DIFF
--- a/lld/test/ELF/undef.s
+++ b/lld/test/ELF/undef.s
@@ -75,7 +75,7 @@
 # Show that a problem in a line table that prevents further parsing of that
 # table means that no line information is displayed in the wardning.
 # CHECK:      error: undefined symbol: zed7
-# CHECK-NEXT: >>> referenced by {{.*}}4.o:(.text+0x10)
+# CHECK-NEXT: >>> referenced by undef-bad-debug.s:21
 
 # Show that a problem with one line table's information doesn't affect getting information from
 # a different one in the same object.

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -582,9 +582,11 @@ void DWARFDebugLine::ParsingState::appendRowToMatrix() {
   if (Row.EndSequence) {
     // Record the end of instruction sequence.
     Sequence.HighPC = Row.Address.Address;
+#if 0
     // Proposed change, without this the added test will fail. With this
-    // GSYMTest/TestDWARFNoLines will fail Sequence.HighPC = Row.Address.Address
-    // + LineTable->Prologue.MinInstLength
+    // GSYMTest/TestDWARFNoLines will fail
+    Sequence.HighPC = Row.Address.Address + LineTable->Prologue.MinInstLength;
+#endif
     Sequence.LastRowIndex = RowNumber + 1;
     Sequence.SectionIndex = Row.Address.SectionIndex;
     if (Sequence.isValid())

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -580,13 +580,9 @@ void DWARFDebugLine::ParsingState::appendRowToMatrix() {
   }
   LineTable->appendRow(Row);
   if (Row.EndSequence) {
-    // Record the end of instruction sequence.
-    Sequence.HighPC = Row.Address.Address;
-#if 1
     // Proposed change, without this the added test will fail. With this
     // GSYMTest/TestDWARFNoLines will fail
     Sequence.HighPC = Row.Address.Address + LineTable->Prologue.MinInstLength;
-#endif
     Sequence.LastRowIndex = RowNumber + 1;
     Sequence.SectionIndex = Row.Address.SectionIndex;
     if (Sequence.isValid())

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -581,7 +581,10 @@ void DWARFDebugLine::ParsingState::appendRowToMatrix() {
   LineTable->appendRow(Row);
   if (Row.EndSequence) {
     // Record the end of instruction sequence.
-    Sequence.HighPC = Row.Address.Address + LineTable->Prologue.MinInstLength;
+    Sequence.HighPC = Row.Address.Address;
+    // Proposed change, without this the added test will fail. With this
+    // GSYMTest/TestDWARFNoLines will fail Sequence.HighPC = Row.Address.Address
+    // + LineTable->Prologue.MinInstLength
     Sequence.LastRowIndex = RowNumber + 1;
     Sequence.SectionIndex = Row.Address.SectionIndex;
     if (Sequence.isValid())

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -1316,7 +1316,7 @@ uint32_t DWARFDebugLine::LineTable::findRowInSeq(
   RowIter FirstRow = Rows.begin() + Seq.FirstRowIndex;
   RowIter LastRow = Rows.begin() + Seq.LastRowIndex;
   assert(FirstRow->Address.Address <= Row.Address.Address &&
-         Row.Address.Address < LastRow[-1].Address.Address);
+         Row.Address.Address <= LastRow[-1].Address.Address);
   RowIter RowPos = std::upper_bound(FirstRow + 1, LastRow - 1, Row,
                                     DWARFDebugLine::Row::orderByAddress) -
                    1;

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -581,7 +581,7 @@ void DWARFDebugLine::ParsingState::appendRowToMatrix() {
   LineTable->appendRow(Row);
   if (Row.EndSequence) {
     // Record the end of instruction sequence.
-    Sequence.HighPC = Row.Address.Address;
+    Sequence.HighPC = Row.Address.Address + LineTable->Prologue.MinInstLength;
     Sequence.LastRowIndex = RowNumber + 1;
     Sequence.SectionIndex = Row.Address.SectionIndex;
     if (Sequence.isValid())

--- a/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp
@@ -582,7 +582,7 @@ void DWARFDebugLine::ParsingState::appendRowToMatrix() {
   if (Row.EndSequence) {
     // Record the end of instruction sequence.
     Sequence.HighPC = Row.Address.Address;
-#if 0
+#if 1
     // Proposed change, without this the added test will fail. With this
     // GSYMTest/TestDWARFNoLines will fail
     Sequence.HighPC = Row.Address.Address + LineTable->Prologue.MinInstLength;

--- a/llvm/test/tools/llvm-dwarfdump/X86/locstats.ll
+++ b/llvm/test/tools/llvm-dwarfdump/X86/locstats.ll
@@ -95,7 +95,7 @@
 ; CHECK-NEXT: "#local vars - entry values with [80%,90%) of parent scope covered by DW_AT_location": 1,
 ; CHECK-NEXT: "#local vars - entry values with [90%,100%) of parent scope covered by DW_AT_location": 0,
 ; CHECK-NEXT: "#local vars - entry values with 100% of parent scope covered by DW_AT_location": 1
-; CHECK-NEXT: "#bytes with line information": 51,
+; CHECK-NEXT: "#bytes with line information": 52,
 ; CHECK-NEXT: "#bytes with line-0 locations": 3,
 ; CHECK-NEXT: "#line entries": 7,
 ; CHECK-NEXT: "#line entries (is_stmt)": 5,

--- a/llvm/test/tools/llvm-symbolizer/symbol-search.test
+++ b/llvm/test/tools/llvm-symbolizer/symbol-search.test
@@ -73,7 +73,7 @@ RUN: llvm-addr2line --obj=%p/Inputs/symbols.so +0x1138 | FileCheck --check-prefi
 RUN: llvm-addr2line --obj=%p/Inputs/symbols.so _ZL14static_func_01i | FileCheck --check-prefix=MULTI-CXX %s
 RUN: llvm-symbolizer --obj=%p/Inputs/symbols.so _ZL14static_func_01i | FileCheck --check-prefix=MULTI-CXX %s
 MULTI-CXX: /tmp/dbginfo{{[/\]+}}symbols.part1.cpp:7
-MULTI-CXX: /tmp/dbginfo{{[/\]+}}symbols.part2.cpp:5
+MULTI-CXX: /tmp/dbginfo/symbols.h:19
 
 # Show that containing function name can be printed in mangled form.
 RUN: llvm-symbolizer --obj=%p/Inputs/symbols.so --no-demangle _Z7func_04i | FileCheck --check-prefix=MANGLED %s

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
@@ -2189,7 +2189,7 @@ TEST_F(DebugLineBasicFixture, LookupLastRow) {
   ASSERT_EQ(Table->Sequences.size(), 1u);
   const auto &Seq = Table->Sequences[0];
   EXPECT_EQ(Seq.LowPC, 0x1000U);
-  EXPECT_EQ(Seq.HighPC, 0x1010U);
+  EXPECT_EQ(Seq.HighPC, 0x1011U);
 
   auto LastRow = Table->Rows.back();
 
@@ -2199,7 +2199,8 @@ TEST_F(DebugLineBasicFixture, LookupLastRow) {
   {
     uint32_t RowIndex = Table->lookupAddress(
         {LastRow.Address.Address, object::SectionedAddress::UndefSection});
-    // Both last and the second to the last row have the same PC, so the second to the last should pop up first.
+    // Both last and the second to the last row have the same PC, so the second
+    // to the second to the last should pop up first.
     EXPECT_EQ(RowIndex, Table->Rows.size() - 2)
         << "Lookup at HighPC should find the second to the last row";
   }
@@ -2235,7 +2236,7 @@ TEST_F(DebugLineBasicFixture, SingleInstSeq) {
   ASSERT_EQ(Table->Sequences.size(), 1u);
   const auto &Seq = Table->Sequences[0];
   EXPECT_EQ(Seq.LowPC, 0x3000U);
-  EXPECT_EQ(Seq.HighPC, 0x3000U);
+  EXPECT_EQ(Seq.HighPC, 0x3001U);
 
   // Verify we have exactly one row (plus the end_sequence row)
   EXPECT_EQ(Table->Rows.size(), 2u);

--- a/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFDebugLineTest.cpp
@@ -2154,7 +2154,7 @@ TEST_F(DebugLineBasicFixture, LookupAddressRangeWithStmtSequenceOffset) {
 /// With the old exclusive HighPC logic, lookups at the last row's address would
 /// fail. With the new inclusive HighPC logic, lookups at the HighPC address
 /// should succeed.
-TEST_F(DebugLineBasicFixture, HighPCInclusiveLookup) {
+TEST_F(DebugLineBasicFixture, LookupLastRow) {
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -2189,7 +2189,7 @@ TEST_F(DebugLineBasicFixture, HighPCInclusiveLookup) {
   ASSERT_EQ(Table->Sequences.size(), 1u);
   const auto &Seq = Table->Sequences[0];
   EXPECT_EQ(Seq.LowPC, 0x1000U);
-  EXPECT_EQ(Seq.HighPC, 0x1011U);
+  EXPECT_EQ(Seq.HighPC, 0x1010U);
 
   auto LastRow = Table->Rows.back();
 
@@ -2199,8 +2199,7 @@ TEST_F(DebugLineBasicFixture, HighPCInclusiveLookup) {
   {
     uint32_t RowIndex = Table->lookupAddress(
         {LastRow.Address.Address, object::SectionedAddress::UndefSection});
-    // EXPECT_NE(RowIndex, Table->UnknownRowIndex) << "Lookup at HighPC found no
-    // row";
+    // Both last and the second to the last row have the same PC, so the second to the last should pop up first.
     EXPECT_EQ(RowIndex, Table->Rows.size() - 2)
         << "Lookup at HighPC should find the second to the last row";
   }
@@ -2209,7 +2208,7 @@ TEST_F(DebugLineBasicFixture, HighPCInclusiveLookup) {
 /// Test that a sequence with only one row works correctly with inclusive
 /// HighPC. This is an important edge case where LowPC == HighPC, and the
 /// inclusive HighPC logic should still allow lookups at that single address.
-TEST_F(DebugLineBasicFixture, SingleInstSequenceInclusiveHighPC) {
+TEST_F(DebugLineBasicFixture, SingleInstSeq) {
   if (!setupGenerator())
     GTEST_SKIP();
 
@@ -2236,7 +2235,7 @@ TEST_F(DebugLineBasicFixture, SingleInstSequenceInclusiveHighPC) {
   ASSERT_EQ(Table->Sequences.size(), 1u);
   const auto &Seq = Table->Sequences[0];
   EXPECT_EQ(Seq.LowPC, 0x3000U);
-  EXPECT_EQ(Seq.HighPC, 0x3001U);
+  EXPECT_EQ(Seq.HighPC, 0x3000U);
 
   // Verify we have exactly one row (plus the end_sequence row)
   EXPECT_EQ(Table->Rows.size(), 2u);
@@ -2251,8 +2250,6 @@ TEST_F(DebugLineBasicFixture, SingleInstSequenceInclusiveHighPC) {
   {
     uint32_t RowIndex = Table->lookupAddress(
         {LastRow.Address.Address, object::SectionedAddress::UndefSection});
-    // EXPECT_NE(RowIndex, Table->UnknownRowIndex) << "Lookup at HighPC found no
-    // row";
     EXPECT_EQ(RowIndex, Table->Rows.size() - 2)
         << "Lookup at HighPC should find the last row";
   }


### PR DESCRIPTION
A "Sequence" in the line table consists of multiple machine instructions [LowPC, HighPC) and rows [FirstRowIndex, LastRowIndex).  

https://github.com/llvm/llvm-project/blob/b3baa4d0635db5c5294d9abd2ea63bb330b069bd/llvm/include/llvm/DebugInfo/DWARF/DWARFDebugLine.h#L223-L225

When adding a Sequence, LastRow is `RowNumbe + 1` while HighPC is `Row.Address`:

https://github.com/llvm/llvm-project/blob/b3baa4d0635db5c5294d9abd2ea63bb330b069bd/llvm/lib/DebugInfo/DWARF/DWARFDebugLine.cpp#L582-L590

This means that if you look up LineTable's last row (`LT->Rows.back()`), you get nothing because its address is not considered to be part of the "Sequence".

Another problem is one-instruction functions can't be its own "Sequence" since LowPC == HighPC, the parser will think this is an invalid Sequence. Normally this is not a problem, but with ICF=safe-thunk, many one-instruction thunks are added. These functions' DebugLine can't be parsed as a stand alone "Sequence", which had made relocation (#149618) and verification (#152807) substantially harder.


I can think of two solutions:

1. Define Sequence's PC to be [LowPC, HighPC + MinInstLength) shown in this diff
     - Unfortunately when I try this one out a bunch of tests in llvm/unittests/DebugInfo/GSYM/GSYMTest.cpp, will fail. 
2. During ICF=safe-thunk, the thunk function can have two instructions (a nop before branch shown below) https://github.com/llvm/llvm-project/pull/154986

https://github.com/llvm/llvm-project/blob/d4b9acad580d85ff95a30056f5a89cc41ef31b55/lld/MachO/Arch/ARM64.cpp#L177-L179