### PR TITLE
[libc++][Android] Fix Dockerfile

### DIFF
--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -40,11 +40,11 @@ jobs:
       env:
         TAG: ${{ github.sha }}
 
-    # - name: Build the Android builder image
-    #   working-directory: libcxx/utils/ci
-    #   run: docker compose build android-buildkite-builder
-    #   env:
-    #     TAG: ${{ github.sha }}
+    - name: Build the Android builder image
+      working-directory: libcxx/utils/ci
+      run: docker compose build android-buildkite-builder
+      env:
+        TAG: ${{ github.sha }}
 
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -32,6 +32,14 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    # The default Docker storage location for GitHub Actions doesn't have
+    # enough disk space, so change it to /mnt, which has more disk space.
+    - name: Change Docker storage location
+      run: |
+        sudo mkdir /mnt/docker
+        echo '{ "data-root": "/mnt/docker" }' | sudo tee /etc/docker/daemon.json
+        sudo systemctl restart docker
+
     - name: Build the Linux builder image
       working-directory: libcxx/utils/ci
       run: |

--- a/.github/workflows/libcxx-build-containers.yml
+++ b/.github/workflows/libcxx-build-containers.yml
@@ -62,10 +62,10 @@ jobs:
       env:
         TAG: ${{ github.sha }}
 
-    # - name: Push the Android builder image
-    #   if: github.event_name == 'push'
-    #   working-directory: libcxx/utils/ci
-    #   run: |
-    #     docker compose push android-buildkite-builder
-    #   env:
-    #     TAG: ${{ github.sha }}
+    - name: Push the Android builder image
+      if: github.event_name == 'push'
+      working-directory: libcxx/utils/ci
+      run: |
+        docker compose push android-buildkite-builder
+      env:
+        TAG: ${{ github.sha }}

--- a/libcxx/utils/ci/docker-compose.yml
+++ b/libcxx/utils/ci/docker-compose.yml
@@ -37,4 +37,4 @@ services:
         ANDROID_CLANG_VERSION: r563880
         ANDROID_CLANG_PREBUILTS_COMMIT: 6ae4184bb8706f9731569b9a0a82be3fcdcb951c
         ANDROID_SYSROOT_COMMIT: f8b85cc5262c6e5cbc9a92c1bab2b18b32a4c63f
-        <<: *compiler_versions
+        <<: [*image_versions, *compiler_versions]

--- a/libcxx/utils/ci/vendor/android/run-buildbot-container
+++ b/libcxx/utils/ci/vendor/android/run-buildbot-container
@@ -27,5 +27,5 @@ if [ -S /var/run/docker.sock ]; then
     DOCKER_OPTIONS+=(--volume /var/run/docker.sock:/var/run/docker.sock)
 fi
 
-docker run "${DOCKER_OPTIONS[@]}" ghcr.io/libcxx/android-buildkite-builder \
+docker run "${DOCKER_OPTIONS[@]}" ghcr.io/llvm/libcxx-android-builder \
     bash -c 'git config --global --add safe.directory /llvm; (/opt/android/container-setup.sh && exec bash)'


### PR DESCRIPTION
In docker-compose.yml, add *image_versions arguments for the android-buildkite-builder service, so that ACTIONS_BASE_IMAGE is set (to builder-base). This will also set the BASE_IMAGE, which we don't really want, because this service uses ubuntu:noble instead of the ubuntu:jammy default, but that's OK because the setting is successfully overridden.

In vendor/android/run-buildbot-container, use the correct ghcr.io Docker path (ghcr.io/llvm/libcxx-android-builder).

Reenable the build-and-push of ghcr.io/llvm/libcxx-android-builder in the libcxx-build-containers.yml workflow.
