### PR TITLE
[docs] Fix debug and strict aliasing typo (#140071)

### DIFF
--- a/clang/docs/UsersManual.rst
+++ b/clang/docs/UsersManual.rst
@@ -2635,7 +2635,7 @@ violates the strict aliasing rules. For example:
 
 Strict aliasing can be explicitly enabled with ``-fstrict-aliasing`` and
 disabled with ``-fno-strict-aliasing``. ``clang-cl`` defaults to
-``-fno-strict-aliasing``; see . Otherwise, Clang defaults to ``-fstrict-aliasing``.
+``-fno-strict-aliasing``. Otherwise, Clang defaults to ``-fstrict-aliasing``.
 
 C and C++ specify slightly different rules for strict aliasing. To improve
 language interoperability, Clang allows two types to alias if either language

--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -15,7 +15,7 @@
 // LLVM_DEBUG() requires the DEBUG_TYPE macro to be defined. Set it to "foo"
 // specify that your debug code belongs to class "foo". Be careful that you only
 // do this after including Debug.h and not around any #include of headers.
-// Headers should define and undef the macro acround the code that needs to use
+// Headers should define and undef the macro around the code that needs to use
 // the LLVM_DEBUG() macro. Then, on the command line, you can specify
 // '-debug-only=foo' to enable JUST the debug information for the foo class.
 //


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/issues/140071, I concluded that removing the typo was the best thing after looking into the commit. Happy to be told if this is incorrect and a different change would be better