### PR TITLE
[libc][math] Refactor dsqrtl implementation to header-only in src/__support/math folder.

### DIFF
--- a/libc/shared/math.h
+++ b/libc/shared/math.h
@@ -39,6 +39,7 @@
 #include "math/coshf16.h"
 #include "math/cospif.h"
 #include "math/cospif16.h"
+#include "math/dsqrtl.h"
 #include "math/erff.h"
 #include "math/exp.h"
 #include "math/exp10.h"

--- a/libc/shared/math/dsqrtl.h
+++ b/libc/shared/math/dsqrtl.h
@@ -1,4 +1,4 @@
-//===-- Implementation of dsqrtl function ---------------------------------===//
+//===-- Shared dsqrtl function ----------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,10 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/math/dsqrtl.h"
+#ifndef LLVM_LIBC_SHARED_MATH_DSQRTL_H
+#define LLVM_LIBC_SHARED_MATH_DSQRTL_H
+
+#include "shared/libc_common.h"
 #include "src/__support/math/dsqrtl.h"
+
 namespace LIBC_NAMESPACE_DECL {
+namespace shared {
 
-LLVM_LIBC_FUNCTION(double, dsqrtl, (long double x)) { return math::dsqrtl(x); }
+using math::dsqrtl;
 
+} // namespace shared
 } // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SHARED_MATH_DSQRTL_H

--- a/libc/src/__support/FPUtil/generic/sqrt.h
+++ b/libc/src/__support/FPUtil/generic/sqrt.h
@@ -69,10 +69,10 @@ LIBC_INLINE void normalize<long double>(int &exponent, UInt128 &mantissa) {
 // Correctly rounded IEEE 754 SQRT for all rounding modes.
 // Shift-and-add algorithm.
 template <typename OutType, typename InType>
-LIBC_INLINE cpp::enable_if_t<cpp::is_floating_point_v<OutType> &&
-                                 cpp::is_floating_point_v<InType> &&
-                                 sizeof(OutType) <= sizeof(InType),
-                             OutType>
+LIBC_INLINE static constexpr cpp::enable_if_t<
+    cpp::is_floating_point_v<OutType> && cpp::is_floating_point_v<InType> &&
+        sizeof(OutType) <= sizeof(InType),
+    OutType>
 sqrt(InType x) {
   if constexpr (internal::SpecialLongDouble<OutType>::VALUE &&
                 internal::SpecialLongDouble<InType>::VALUE) {

--- a/libc/src/__support/math/CMakeLists.txt
+++ b/libc/src/__support/math/CMakeLists.txt
@@ -458,6 +458,14 @@ add_header_library(
 )
 
 add_header_library(
+  dsqrtl
+  HDRS
+    dsqrtl.h
+  DEPENDS
+    libc.src.__support.FPUtil.generic.sqrt
+)
+
+add_header_library(
   erff
   HDRS
     erff.h

--- a/libc/src/__support/math/dsqrtl.h
+++ b/libc/src/__support/math/dsqrtl.h
@@ -1,0 +1,26 @@
+//===-- Implementation header for dsqrtl ------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_MATH_DSQRTL_H
+#define LLVM_LIBC_SRC___SUPPORT_MATH_DSQRTL_H
+
+#include "src/__support/FPUtil/generic/sqrt.h"
+
+namespace LIBC_NAMESPACE_DECL {
+
+namespace math {
+
+LIBC_INLINE static constexpr double dsqrtl(long double x) {
+  return fputil::sqrt<double>(x);
+}
+
+} // namespace math
+
+} // namespace LIBC_NAMESPACE_DECL
+
+#endif // LLVM_LIBC_SRC___SUPPORT_MATH_DSQRTL_H

--- a/libc/src/math/generic/CMakeLists.txt
+++ b/libc/src/math/generic/CMakeLists.txt
@@ -242,7 +242,7 @@ add_entrypoint_object(
   HDRS
     ../dsqrtl.h
   DEPENDS
-    libc.src.__support.FPUtil.generic.sqrt
+    libc.src.__support.math.dsqrtl
 )
 
 add_entrypoint_object(

--- a/libc/test/shared/CMakeLists.txt
+++ b/libc/test/shared/CMakeLists.txt
@@ -35,6 +35,7 @@ add_fp_unittest(
     libc.src.__support.math.coshf16
     libc.src.__support.math.cospif
     libc.src.__support.math.cospif16
+    libc.src.__support.math.dsqrtl
     libc.src.__support.math.erff
     libc.src.__support.math.exp
     libc.src.__support.math.exp10

--- a/libc/test/shared/shared_math_test.cpp
+++ b/libc/test/shared/shared_math_test.cpp
@@ -55,6 +55,7 @@ TEST(LlvmLibcSharedMathTest, AllFloat) {
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::cosf(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::coshf(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::cospif(0.0f));
+  EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::dsqrtl(0.0f));
   EXPECT_FP_EQ(0x0p+0f, LIBC_NAMESPACE::shared::erff(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::exp10f(0.0f));
   EXPECT_FP_EQ(0x1p+0f, LIBC_NAMESPACE::shared::expf(0.0f));

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -2420,6 +2420,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_math_dsqrtl",
+    hdrs = ["src/__support/math/dsqrtl.h"],
+    deps = [
+        ":__support_fputil_sqrt",
+    ],
+)
+
+libc_support_library(
     name = "__support_math_erff",
     hdrs = ["src/__support/math/erff.h"],
     deps = [
@@ -3287,7 +3295,7 @@ libc_math_function(name = "dmulf128")
 libc_math_function(
     name = "dsqrtl",
     additional_deps = [
-        ":__support_fputil_sqrt",
+        ":__support_math_dsqrtl",
     ],
 )
 


### PR DESCRIPTION
Part of #147386

in preparation for: https://discourse.llvm.org/t/rfc-make-clang-builtin-math-functions-constexpr-with-llvm-libc-to-support-c-23-constexpr-math-functions/86450