### PR TITLE
[TableGen] Avoid field lookup in a performance critical place (NFC)

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenTarget.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenTarget.cpp
@@ -270,8 +270,8 @@ void CodeGenTarget::ComputeInstrsByEnum() const {
         const Record &D2 = *Rec2->TheDef;
         // Sort all pseudo instructions before non-pseudo ones, and sort by name
         // within.
-        return std::tuple(!D1.getValueAsBit("isPseudo"), D1.getName()) <
-               std::tuple(!D2.getValueAsBit("isPseudo"), D2.getName());
+        return std::tuple(!Rec1->isPseudo, D1.getName()) <
+               std::tuple(!Rec2->isPseudo, D2.getName());
       });
 
   // Assign an enum value to each instruction according to the sorted order.


### PR DESCRIPTION
`Target.getInstructions()` is called by virtually all TableGen backends. It is slow, and one of the two factors is the use of an expensive predicate in `llvm::sort`. This change speeds up sorting by 10x.
