### PR TITLE
[orc-rt] Use LLVM-style header naming scheme.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(ORC_RT_HEADERS
     orc-rt-c/orc-rt.h
-    orc-rt/bitmask-enum.h
-    orc-rt/error.h
-    orc-rt/compiler.h
-    orc-rt/math.h
-    orc-rt/rtti.h
+    orc-rt/BitmaskEnum.h
+    orc-rt/Compiler.h
+    orc-rt/Error.h
+    orc-rt/Math.h
+    orc-rt/RTTI.h
     orc-rt/span.h
     orc-rt/unique-function.h
 )

--- a/orc-rt/include/orc-rt/BitmaskEnum.h
+++ b/orc-rt/include/orc-rt/BitmaskEnum.h
@@ -1,4 +1,4 @@
-//===---- bitmask-enum.h - Enable bitmask operations on enums ---*- C++ -*-===//
+//===---- BitmaskEnum.h - Enable bitmask operations on enums ----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef ORC_RT_BITMASK_ENUM_H
-#define ORC_RT_BITMASK_ENUM_H
+#ifndef ORC_RT_BITMASKENUM_H
+#define ORC_RT_BITMASKENUM_H
 
-#include "math.h"
+#include "Math.h"
 
 #include <cassert>
 #include <type_traits>
@@ -158,4 +158,4 @@ constexpr E &operator^=(E &LHS, E RHS) noexcept {
 
 } // namespace orc_rt
 
-#endif // ORC_RT_BITMASK_ENUM_H
+#endif // ORC_RT_BITMASKENUM_H

--- a/orc-rt/include/orc-rt/Compiler.h
+++ b/orc-rt/include/orc-rt/Compiler.h
@@ -1,4 +1,4 @@
-//===--------- compiler.h - Compiler abstraction support --------*- C++ -*-===//
+//===--------- Compiler.h - Compiler abstraction support --------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/orc-rt/include/orc-rt/Error.h
+++ b/orc-rt/include/orc-rt/Error.h
@@ -1,4 +1,4 @@
-//===-------- error.h - Enforced error checking for ORC RT ------*- C++ -*-===//
+//===-------- Error.h - Enforced error checking for ORC RT ------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,8 +9,8 @@
 #ifndef ORC_RT_ERROR_H
 #define ORC_RT_ERROR_H
 
-#include "orc-rt/compiler.h"
-#include "orc-rt/rtti.h"
+#include "orc-rt/Compiler.h"
+#include "orc-rt/RTTI.h"
 
 #include <cassert>
 #include <cstdlib>

--- a/orc-rt/include/orc-rt/Math.h
+++ b/orc-rt/include/orc-rt/Math.h
@@ -1,4 +1,4 @@
-//===--------- math.h - Math helpers for the ORC runtime --------*- C++ -*-===//
+//===--------- Math.h - Math helpers for the ORC runtime --------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/orc-rt/include/orc-rt/RTTI.h
+++ b/orc-rt/include/orc-rt/RTTI.h
@@ -1,4 +1,4 @@
-//===------------- rtti.h - RTTI support for ORC RT -------------*- C++ -*-===//
+//===------------- RTTI.h - RTTI support for ORC RT -------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/orc-rt/lib/executor/CMakeLists.txt
+++ b/orc-rt/lib/executor/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(files
   orc-rt-executor.cpp
-  rtti.cpp
+  RTTI.cpp
   )
 
 add_library(orc-rt-executor STATIC ${files})

--- a/orc-rt/lib/executor/RTTI.cpp
+++ b/orc-rt/lib/executor/RTTI.cpp
@@ -1,4 +1,4 @@
-//===- rtti.cpp -----------------------------------------------------------===//
+//===- RTTI.cpp -----------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/rtti.h"
+#include "orc-rt/RTTI.h"
 
 namespace orc_rt {
 

--- a/orc-rt/unittests/BitmaskEnumTest.cpp
+++ b/orc-rt/unittests/BitmaskEnumTest.cpp
@@ -1,4 +1,4 @@
-//===-- bitmask-enum-test.cpp ---------------------------------------------===//
+//===- BitmaskEnumTest.cpp ------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file is a part of the ORC runtime.
+// Test bitmask-enum support APIs.
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/bitmask-enum.h"
+#include "orc-rt/BitmaskEnum.h"
 #include "gtest/gtest.h"
 
 #include <sstream>

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -12,10 +12,10 @@ function(add_orc_rt_unittest test_dirname)
 endfunction()
 
 add_orc_rt_unittest(CoreTests
-  bitmask-enum-test.cpp
-  error-test.cpp
-  math-test.cpp
-  rtti-test.cpp
+  BitmaskEnumTest.cpp
+  ErrorTest.cpp
+  MathTest.cpp
+  RTTITest.cpp
   span-test.cpp
   unique-function-test.cpp
   DISABLE_LLVM_LINK_LLVM_DYLIB

--- a/orc-rt/unittests/ErrorTest.cpp
+++ b/orc-rt/unittests/ErrorTest.cpp
@@ -1,4 +1,4 @@
-//===-- error_test.cpp ----------------------------------------------------===//
+//===- ErrorTest.cpp ------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,7 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/error.h"
+#include "orc-rt/Error.h"
 #include "gtest/gtest.h"
 
 using namespace orc_rt;

--- a/orc-rt/unittests/MathTest.cpp
+++ b/orc-rt/unittests/MathTest.cpp
@@ -1,4 +1,4 @@
-//===- math-test.cpp ------------------------------------------------------===//
+//===- MathTest.cpp -------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Tests for orc-rt's math.h APIs.
+// Tests for orc-rt's Math.h APIs.
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/math.h"
+#include "orc-rt/Math.h"
 #include "gtest/gtest.h"
 
 using namespace orc_rt;

--- a/orc-rt/unittests/RTTITest.cpp
+++ b/orc-rt/unittests/RTTITest.cpp
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "orc-rt/rtti.h"
+#include "orc-rt/RTTI.h"
 #include "gtest/gtest.h"
 
 using namespace orc_rt;


### PR DESCRIPTION
This is more consistent with the rest of the LLVM project, and the resulting names are closer to the types defined in each of the headers.