### PR TITLE
[NFC][SampleFDO] In text sample prof reader, report dreport more concrete parsing errors for different line types

### DIFF
--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -357,7 +357,6 @@ std::error_code SampleProfileReaderText::readImpl() {
       uint64_t NumSamples, NumHeadSamples;
       StringRef FName;
       if (!ParseHead(*LineIt, FName, NumSamples, NumHeadSamples)) {
-
         reportError(LineIt.line_number(),
                     "Expected 'mangled_name:NUM:NUM', found " + *LineIt);
         return sampleprof_error::malformed;


### PR DESCRIPTION
The format `'NUM[.NUM]: NUM[ mangled_name:NUM]*'` applies for most line types except metadata ones.