### PR TITLE
[mlir] Use default RemarkOpts constructor for c++20 compat

### DIFF
--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -61,11 +61,6 @@ struct RemarkOpts {
   StringRef subCategoryName; // Subcategory name
   StringRef functionName;    // Function name if available
 
-  constexpr RemarkOpts(StringRef remarkName, StringRef categoryName,
-                       StringRef subCategoryName, StringRef functionName)
-      : remarkName(remarkName), categoryName(categoryName),
-        subCategoryName(subCategoryName), functionName(functionName) {}
-
   // Construct RemarkOpts from a remark name.
   static constexpr RemarkOpts name(StringRef n) {
     return RemarkOpts{n, {}, {}, {}};

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -60,7 +60,12 @@ struct RemarkOpts {
   StringRef categoryName;    // Category name (subject to regex filtering)
   StringRef subCategoryName; // Subcategory name
   StringRef functionName;    // Function name if available
-  RemarkOpts() = delete;
+
+  constexpr RemarkOpts(StringRef remarkName, StringRef categoryName,
+                       StringRef subCategoryName, StringRef functionName)
+      : remarkName(remarkName), categoryName(categoryName),
+        subCategoryName(functionName), functionName(functionName) {}
+
   // Construct RemarkOpts from a remark name.
   static constexpr RemarkOpts name(StringRef n) {
     return RemarkOpts{n, {}, {}, {}};

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -64,7 +64,7 @@ struct RemarkOpts {
   constexpr RemarkOpts(StringRef remarkName, StringRef categoryName,
                        StringRef subCategoryName, StringRef functionName)
       : remarkName(remarkName), categoryName(categoryName),
-        subCategoryName(functionName), functionName(functionName) {}
+        subCategoryName(subCategoryName), functionName(functionName) {}
 
   // Construct RemarkOpts from a remark name.
   static constexpr RemarkOpts name(StringRef n) {


### PR DESCRIPTION
Using the default constructor makes this header work in both c++17 and c++20 codebases. Without this, a c++20 codebase will break like this:

```c++
external/llvm-project/mlir/include/mlir/IR/Remarks.h:66:12: error: no matching constructor for initialization of 'RemarkOpts'
   66 |     return RemarkOpts{n, {}, {}, {}};
      |            ^         ~~~~~~~~~~~~~~~
external/llvm-project/mlir/include/mlir/IR/Remarks.h:58:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 4 were provided
   58 | struct RemarkOpts {
      |        ^~~~~~~~~~
external/llvm-project/mlir/include/mlir/IR/Remarks.h:58:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 4 were provided
   58 | struct RemarkOpts {
      |        ^~~~~~~~~~
external/llvm-project/mlir/include/mlir/IR/Remarks.h:63:3: note: candidate constructor not viable: requires 0 arguments, but 4 were provided
   63 |   RemarkOpts() = delete;
      |   ^
external/llvm-project/mlir/include/mlir/IR/Remarks.h:65:31: error: constexpr function's return type 'RemarkOpts' is not a literal type
   65 |   static constexpr RemarkOpts name(StringRef n) {
      |                               ^
external/llvm-project/mlir/include/mlir/IR/Remarks.h:58:8: note: 'RemarkOpts' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
   58 | struct RemarkOpts {
      |        ^
```