### PR TITLE
[ADT] Deprecate the redirection from SmallSet to SmallPtrSet

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -276,21 +276,20 @@ public:
   // LLVM_DEPRECATED placed between "template" and "class" above won't work for
   // some reason.  Put a deprecation message on constructors instead.
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet<PointeeType *, N>() = default;
+  SmallSet() = default;
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet<PointeeType *, N>(const SmallSet &) = default;
+  SmallSet(const SmallSet &) = default;
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet<PointeeType *, N>(SmallSet &&) = default;
+  SmallSet(SmallSet &&) = default;
   template <typename IterT>
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet<PointeeType *, N>(IterT Begin, IterT End) : Base(Begin, End) {}
+  SmallSet(IterT Begin, IterT End) : Base(Begin, End) {}
   template <typename Range>
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet<PointeeType *, N>(llvm::from_range_t, Range &&R)
+  SmallSet(llvm::from_range_t, Range &&R)
       : Base(llvm::from_range, std::move(R)) {}
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet<PointeeType *, N>(std::initializer_list<PointeeType *> L)
-      : Base(L) {}
+  SmallSet(std::initializer_list<PointeeType *> L) : Base(L) {}
 };
 
 /// Equality comparison for SmallSet.

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -269,7 +269,13 @@ private:
 /// If this set is of pointer values, transparently switch over to using
 /// SmallPtrSet for performance.
 template <typename PointeeType, unsigned N>
-class SmallSet<PointeeType*, N> : public SmallPtrSet<PointeeType*, N> {};
+class SmallSet<PointeeType *, N> : public SmallPtrSet<PointeeType *, N> {
+public:
+  // LLVM_DEPRECATED placed between "template" and "class" above won't work for
+  // some reason.  Put a deprecation message on the default constructor instead.
+  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
+  SmallSet<PointeeType *, N>() = default;
+};
 
 /// Equality comparison for SmallSet.
 ///

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -272,7 +272,7 @@ template <typename PointeeType, unsigned N>
 class SmallSet<PointeeType *, N> : public SmallPtrSet<PointeeType *, N> {
   using Base = SmallPtrSet<PointeeType *, N>;
 
-  public:
+public:
   // LLVM_DEPRECATED placed between "template" and "class" above won't work for
   // some reason.  Put a deprecation message on constructors instead.
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")

--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -270,11 +270,27 @@ private:
 /// SmallPtrSet for performance.
 template <typename PointeeType, unsigned N>
 class SmallSet<PointeeType *, N> : public SmallPtrSet<PointeeType *, N> {
-public:
+  using Base = SmallPtrSet<PointeeType *, N>;
+
+  public:
   // LLVM_DEPRECATED placed between "template" and "class" above won't work for
-  // some reason.  Put a deprecation message on the default constructor instead.
+  // some reason.  Put a deprecation message on constructors instead.
   LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
   SmallSet<PointeeType *, N>() = default;
+  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
+  SmallSet<PointeeType *, N>(const SmallSet &) = default;
+  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
+  SmallSet<PointeeType *, N>(SmallSet &&) = default;
+  template <typename IterT>
+  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
+  SmallSet<PointeeType *, N>(IterT Begin, IterT End) : Base(Begin, End) {}
+  template <typename Range>
+  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
+  SmallSet<PointeeType *, N>(llvm::from_range_t, Range &&R)
+      : Base(llvm::from_range, std::move(R)) {}
+  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
+  SmallSet<PointeeType *, N>(std::initializer_list<PointeeType *> L)
+      : Base(L) {}
 };
 
 /// Equality comparison for SmallSet.


### PR DESCRIPTION
This patch deprecates the redirection from SmallSet to SmallPtrSet.

I attempted to deprecate in the usual manner:

template <typename PointeeType, unsigned N>
LLVM_DEPRECATED("...", "...")
class SmallSet<PointeeType*, N> : public SmallPtrSet<PointeeType*, N> {};

However, the deprecation warning wouldn't fire.

For this reason, I've attached a deprecation message to the default
constructor.
