### PR TITLE
[libunwind] fix pc range condition check bug

### DIFF
--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -273,7 +273,7 @@ bool CFI_Parser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
           pint_t pcRange = addressSpace.getEncodedP(
               p, nextCFI, cieInfo->pointerEncoding & 0x0F);
           // Test if pc is within the function this FDE covers.
-          if ((pcStart < pc) && (pc <= pcStart + pcRange)) {
+          if ((pcStart <= pc) && (pc < pcStart + pcRange)) {
             // parse rest of info
             fdeInfo->lsda = 0;
             // check for augmentation length

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -273,7 +273,7 @@ bool CFI_Parser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
           pint_t pcRange = addressSpace.getEncodedP(
               p, nextCFI, cieInfo->pointerEncoding & 0x0F);
           // Test if pc is within the function this FDE covers.
-          if ((pcStart <= pc) && (pc < pcStart + pcRange)) {
+          if ((pcStart < pc) && (pc <= pcStart + pcRange)) {
             // parse rest of info
             fdeInfo->lsda = 0;
             // check for augmentation length

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -273,7 +273,7 @@ bool CFI_Parser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
           pint_t pcRange = addressSpace.getEncodedP(
               p, nextCFI, cieInfo->pointerEncoding & 0x0F);
           // Test if pc is within the function this FDE covers.
-          if ((pcStart < pc) && (pc <= pcStart + pcRange)) {
+          if ((pcStart < pc) && (pc <= pcStart + pcRange))  {
             // parse rest of info
             fdeInfo->lsda = 0;
             // check for augmentation length

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -273,7 +273,8 @@ bool CFI_Parser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
           pint_t pcRange = addressSpace.getEncodedP(
               p, nextCFI, cieInfo->pointerEncoding & 0x0F);
           // Test if pc is within the function this FDE covers.
-          if ((pcStart < pc) && (pc <= pcStart + pcRange))  {
+          if ((pcStart < pc) && (pc <= pcStart + pcRange)) {
+            ;
             // parse rest of info
             fdeInfo->lsda = 0;
             // check for augmentation length

--- a/libunwind/src/DwarfParser.hpp
+++ b/libunwind/src/DwarfParser.hpp
@@ -273,8 +273,7 @@ bool CFI_Parser<A>::findFDE(A &addressSpace, pint_t pc, pint_t ehSectionStart,
           pint_t pcRange = addressSpace.getEncodedP(
               p, nextCFI, cieInfo->pointerEncoding & 0x0F);
           // Test if pc is within the function this FDE covers.
-          if ((pcStart < pc) && (pc <= pcStart + pcRange)) {
-            ;
+          if ((pcStart <= pc) && (pc < pcStart + pcRange)) {
             // parse rest of info
             fdeInfo->lsda = 0;
             // check for augmentation length

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -41,10 +41,10 @@ void f() {
   printf("fde_fpc = %p\n", fde_fpc);
   printf("fde_fpc1 = %p\n", fde_fpc1);
   fflush(stdout);
-//  assert(fde_pc != NULL);
-//  assert(fde_fpc != NULL);
-//  assert(fde_fpc1 != NULL);
-//  assert(fde_fpc == fde_fpc1);
+  //  assert(fde_pc != NULL);
+  //  assert(fde_fpc != NULL);
+  //  assert(fde_fpc1 != NULL);
+  //  assert(fde_fpc == fde_fpc1);
 }
 
 int main() {

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -9,6 +9,7 @@
 
 // Manually marking the .eh_frame_hdr as DW_EH_PE_omit to make libunwind to do
 // the linear search.
+// Assuming the begining of the function is at the start of the FDE range.
 
 // clang-format off
 // REQUIRES: target={{x86_64-.+-linux-gnu}}
@@ -35,6 +36,9 @@ void f() {
   const void *fde_pc = _Unwind_Find_FDE(pc, &bases);
   const void *fde_fpc = _Unwind_Find_FDE(fpc, &bases);
   const void *fde_fpc1 = _Unwind_Find_FDE(fpc1, &bases);
+  printf("fde_pc = %p\n", fde_pc);
+  printf("fde_fpc = %p\n", fde_fpc);
+  printf("fde_fpc1 = %p\n", fde_fpc1);
   assert(fde_pc != NULL);
   assert(fde_fpc != NULL);
   assert(fde_fpc1 != NULL);

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -46,10 +46,10 @@ void f() {
   printf("fde_fpc = %p\n", fde_fpc);
   printf("fde_fpc1 = %p\n", fde_fpc1);
   fflush(stdout);
-  //  assert(fde_pc != NULL);
-  //  assert(fde_fpc != NULL);
-  //  assert(fde_fpc1 != NULL);
-  //  assert(fde_fpc == fde_fpc1);
+  assert(fde_pc != NULL);
+  assert(fde_fpc != NULL);
+  assert(fde_fpc1 != NULL);
+  assert(fde_fpc == fde_fpc1);
 }
 
 int main() {

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -12,8 +12,6 @@
 // Assuming the begining of the function is at the start of the FDE range.
 
 // clang-format off
-// REQUIRES: target={{x86_64-.+-linux-gnu}}
-
 
 // RUN: %{build}
 // RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -39,6 +39,7 @@ void f() {
   printf("fde_pc = %p\n", fde_pc);
   printf("fde_fpc = %p\n", fde_fpc);
   printf("fde_fpc1 = %p\n", fde_fpc1);
+  fflush(stdout);
   assert(fde_pc != NULL);
   assert(fde_fpc != NULL);
   assert(fde_fpc1 != NULL);

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -18,6 +18,7 @@
 // RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 
 // RUN: objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: %{exec} %t.exe
+
 // clang-format on
 
 #include <assert.h>
@@ -40,10 +41,10 @@ void f() {
   printf("fde_fpc = %p\n", fde_fpc);
   printf("fde_fpc1 = %p\n", fde_fpc1);
   fflush(stdout);
-  assert(fde_pc != NULL);
-  assert(fde_fpc != NULL);
-  assert(fde_fpc1 != NULL);
-  assert(fde_fpc == fde_fpc1);
+//  assert(fde_pc != NULL);
+//  assert(fde_fpc != NULL);
+//  assert(fde_fpc1 != NULL);
+//  assert(fde_fpc == fde_fpc1);
 }
 
 int main() {

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -13,6 +13,11 @@
 
 // clang-format off
 
+// REQUIRES: linux
+
+// TODO: Figure out why this fails with Memory Sanitizer.
+// XFAIL: msan
+
 // RUN: %{build}
 // RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -1,0 +1,47 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Manually marking the .eh_frame_hdr as DW_EH_PE_omit to make libunwind to do
+// the linear search.
+
+// clang-format off
+// REQUIRES: target={{x86_64-.+-linux-gnu}}
+// RUN: %{build}
+// RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 
+// RUN: objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: %{exec} %t.exe
+// clang-format on
+
+#include <assert.h>
+#include <libunwind.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unwind.h>
+
+void f() {
+  printf("123\n");
+  void *pc = __builtin_return_address(0);
+  void *fpc = (void *)&f;
+  void *fpc1 = (void *)((uintptr_t)fpc + 1);
+
+  struct dwarf_eh_bases bases;
+  const void *fde_pc = _Unwind_Find_FDE(pc, &bases);
+  const void *fde_fpc = _Unwind_Find_FDE(fpc, &bases);
+  const void *fde_fpc1 = _Unwind_Find_FDE(fpc1, &bases);
+  assert(fde_pc != NULL);
+  assert(fde_fpc != NULL);
+  assert(fde_fpc1 != NULL);
+  assert(fde_fpc == fde_fpc1);
+}
+
+int main() {
+  f();
+  return 0;
+}

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -13,6 +13,10 @@
 
 // clang-format off
 // REQUIRES: target={{x86_64-.+-linux-gnu}}
+
+// TODO: Figure out why this fails with Memory Sanitizer.
+// XFAIL: msan
+
 // RUN: %{build}
 // RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -14,8 +14,6 @@
 // clang-format off
 // REQUIRES: target={{x86_64-.+-linux-gnu}}
 
-// TODO: Figure out why this fails with Memory Sanitizer.
-// XFAIL: msan
 
 // RUN: %{build}
 // RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe


### PR DESCRIPTION
There is an off-by-one error with current condition check for PC fallen into the range or not. There is another check within libunwind that use the correct checks in https://github.com/llvm/llvm-project/blob/5050da7ba18fc876f80fbeaaca3564d3b4483bb8/libunwind/src/UnwindCursor.hpp#L2757
```
      if ((fdeInfo.pcStart <= pc) && (pc < fdeInfo.pcEnd))
```