### PR TITLE
[orc-rt] Add inline specifier to orc_rt::make_error.

### DIFF
--- a/orc-rt/include/orc-rt/Error.h
+++ b/orc-rt/include/orc-rt/Error.h
@@ -126,7 +126,7 @@ private:
 };
 
 /// Create an Error from an ErrorInfoBase.
-Error make_error(std::unique_ptr<ErrorInfoBase> Payload) {
+inline Error make_error(std::unique_ptr<ErrorInfoBase> Payload) {
   return Error(std::move(Payload));
 }
 


### PR DESCRIPTION
Prevents linker errors for duplicate definitions when make_error is used from more than one file.