### PR TITLE
[MLIR][NFC] Speed up is valid symbol check

### DIFF
--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -428,8 +428,8 @@ bool mlir::affine::isValidSymbol(Value value) {
 }
 
 /// A utility function to check if a value is defined at the top level of
-/// `region` or is an argument of `region` or dominates the region.
-static bool isTopLevelValueOrDominator(Value value, Region *region) {
+/// `region` or is an argument of `region` or is defined above the region.
+static bool isTopLevelValueOrAbove(Value value, Region *region) {
   Region *parentRegion = value.getParentRegion();
   do {
     if (parentRegion == region)
@@ -460,7 +460,7 @@ bool mlir::affine::isValidSymbol(Value value, Region *region) {
     return false;
 
   // A top-level value is a valid symbol.
-  if (region && isTopLevelValueOrDominator(value, region))
+  if (region && isTopLevelValueOrAbove(value, region))
     return true;
 
   auto *defOp = value.getDefiningOp();

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -464,9 +464,8 @@ bool mlir::affine::isValidSymbol(Value value, Region *region) {
     return true;
 
   auto *defOp = value.getDefiningOp();
-  if (!defOp) {
+  if (!defOp)
     return false;
-  }
 
   // Constant operation is ok.
   Attribute operandCst;

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -473,16 +473,10 @@ bool mlir::affine::isValidSymbol(Value value, Region *region) {
     return true;
 
   // `Pure` operation that whose operands are valid symbolic identifiers.
-  if (isPure(defOp)) {
-    bool allValid = true;
-    for (auto operand : defOp->getOperands()) {
-      if (!affine::isValidSymbol(operand, region)) {
-        allValid = false;
-        break;
-      }
-    }
-    if (allValid)
-      return true;
+  if (isPure(defOp) && llvm::all_of(defOp->getOperands(), [&](Value operand) {
+        return affine::isValidSymbol(operand, region);
+      })) {
+    return true;
   }
 
   // Dim op results could be valid symbols at any level.

--- a/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
+++ b/mlir/lib/Dialect/Affine/IR/AffineOps.cpp
@@ -430,11 +430,7 @@ bool mlir::affine::isValidSymbol(Value value) {
 /// A utility function to check if a value is defined at the top level of
 /// `region` or is an argument of `region` or dominates the region.
 static bool isTopLevelValueOrDominator(Value value, Region *region) {
-  Region *parentRegion;
-  if (auto arg = dyn_cast<BlockArgument>(value))
-    parentRegion = arg.getParentRegion();
-  else
-    parentRegion = value.getDefiningOp()->getParentRegion();
+  Region *parentRegion = value.getParentRegion();
   do {
     if (parentRegion == region)
       return true;


### PR DESCRIPTION
This removes the closure indirection, and removes the recursion on isValidSymbol. The rewriting of the recursion is particularly helpful to avoid redundant checks of isPure and checking the isValidSymbol of the operands for each parent region check