### PR TITLE
Reapply "[compiler-rt]: fix CodeQL format-string warnings via explicit

### DIFF
--- a/compiler-rt/lib/dfsan/dfsan.cpp
+++ b/compiler-rt/lib/dfsan/dfsan.cpp
@@ -792,7 +792,7 @@ static void PrintNoOriginTrackingWarning() {
 
 static void PrintNoTaintWarning(const void *address) {
   Decorator d;
-  Printf("  %sDFSan: no tainted value at %x%s\n", d.Warning(), address,
+  Printf("  %sDFSan: no tainted value at %zx%s\n", d.Warning(), (uptr)address,
          d.Default());
 }
 

--- a/compiler-rt/lib/hwasan/hwasan.cpp
+++ b/compiler-rt/lib/hwasan/hwasan.cpp
@@ -176,7 +176,7 @@ static void HwasanFormatMemoryUsage(InternalScopedString &s) {
       "HWASAN pid: %d rss: %zd threads: %zd stacks: %zd"
       " thr_aux: %zd stack_depot: %zd uniq_stacks: %zd"
       " heap: %zd",
-      internal_getpid(), GetRSS(), thread_stats.n_live_threads,
+      (int)internal_getpid(), GetRSS(), thread_stats.n_live_threads,
       thread_stats.total_stack_size,
       thread_stats.n_live_threads * thread_list.MemoryUsedPerThread(),
       sds.allocated, sds.n_uniq_ids, asc[AllocatorStatMapped]);
@@ -692,7 +692,7 @@ void __hwasan_handle_longjmp(const void *sp_dst) {
         "WARNING: HWASan is ignoring requested __hwasan_handle_longjmp: "
         "stack top: %p; target %p; distance: %p (%zd)\n"
         "False positive error reports may follow\n",
-        (void *)sp, (void *)dst, dst - sp, dst - sp);
+        (void *)sp, (void *)dst, (void *)(dst - sp), dst - sp);
     return;
   }
   TagMemory(sp, dst - sp, 0);

--- a/compiler-rt/lib/hwasan/hwasan_malloc_bisect.h
+++ b/compiler-rt/lib/hwasan/hwasan_malloc_bisect.h
@@ -41,7 +41,7 @@ static inline bool malloc_bisect(StackTrace *stack, uptr orig_size) {
   if (h < left || h > right)
     return false;
   if (flags()->malloc_bisect_dump) {
-    Printf("[alloc] %u %zu\n", h, orig_size);
+    Printf("[alloc] %u %zu\n", (u32)h, orig_size);
     stack->Print();
   }
   return true;

--- a/compiler-rt/lib/hwasan/hwasan_report.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_report.cpp
@@ -306,8 +306,9 @@ static void PrintStackAllocations(const StackAllocationsRingBuffer *sa,
           "%p is located %zd bytes %s a %zd-byte local variable %s "
           "[%p,%p) "
           "in %s %s\n",
-          untagged_addr, offset, whence, local.size, local.name, best_beg,
-          best_beg + local.size, local.function_name, location.data());
+          (void *)untagged_addr, offset, whence, local.size, local.name,
+          (void *)best_beg, (void *)(best_beg + local.size),
+          local.function_name, location.data());
       location.clear();
       Printf("%s\n", d.Default());
     }
@@ -738,8 +739,8 @@ void BaseReport::PrintHeapOrGlobalCandidate() const {
     Printf("%s", d.Location());
     Printf("%p is located %zd bytes %s a %zd-byte region [%p,%p)\n",
            untagged_addr, offset, whence,
-           candidate.heap.end - candidate.heap.begin, candidate.heap.begin,
-           candidate.heap.end);
+           candidate.heap.end - candidate.heap.begin,
+           (void *)candidate.heap.begin, (void *)candidate.heap.end);
     Printf("%s", d.Allocation());
     Printf("allocated by thread T%u here:\n", candidate.heap.thread_id);
     Printf("%s", d.Default());
@@ -762,11 +763,11 @@ void BaseReport::PrintHeapOrGlobalCandidate() const {
       Printf(
           "%p is located %zd bytes %s a %zd-byte global variable "
           "%s [%p,%p) in %s\n",
-          untagged_addr,
+          (void *)untagged_addr,
           candidate.after ? untagged_addr - (info.start + info.size)
                           : info.start - untagged_addr,
           candidate.after ? "after" : "before", info.size, info.name,
-          info.start, info.start + info.size, module_name);
+          (void *)info.start, (void *)(info.start + info.size), module_name);
     } else {
       uptr size = GetGlobalSizeFromDescriptor(candidate.untagged_addr);
       if (size == 0)
@@ -774,14 +775,14 @@ void BaseReport::PrintHeapOrGlobalCandidate() const {
         Printf(
             "%p is located %s a global variable in "
             "\n    #0 0x%x (%s+0x%x)\n",
-            untagged_addr, candidate.after ? "after" : "before",
-            candidate.untagged_addr, module_name, module_address);
+            (void *)untagged_addr, candidate.after ? "after" : "before",
+            (void *)candidate.untagged_addr, module_name, (u32)module_address);
       else
         Printf(
             "%p is located %s a %zd-byte global variable in "
             "\n    #0 0x%x (%s+0x%x)\n",
-            untagged_addr, candidate.after ? "after" : "before", size,
-            candidate.untagged_addr, module_name, module_address);
+            (void *)untagged_addr, candidate.after ? "after" : "before", size,
+            (void *)candidate.untagged_addr, module_name, (u32)module_address);
     }
     Printf("%s", d.Default());
   }
@@ -792,8 +793,8 @@ void BaseReport::PrintAddressDescription() const {
   int num_descriptions_printed = 0;
 
   if (MemIsShadow(untagged_addr)) {
-    Printf("%s%p is HWAsan shadow memory.\n%s", d.Location(), untagged_addr,
-           d.Default());
+    Printf("%s%p is HWAsan shadow memory.\n%s", d.Location(),
+           (void *)untagged_addr, d.Default());
     return;
   }
 
@@ -802,7 +803,7 @@ void BaseReport::PrintAddressDescription() const {
     Printf(
         "%s[%p,%p) is a %s %s heap chunk; "
         "size: %zd offset: %zd\n%s",
-        d.Location(), heap.begin, heap.begin + heap.size,
+        d.Location(), (void *)heap.begin, (void *)(heap.begin + heap.size),
         heap.from_small_heap ? "small" : "large",
         heap.is_allocated ? "allocated" : "unallocated", heap.size,
         untagged_addr - heap.begin, d.Default());
@@ -821,8 +822,8 @@ void BaseReport::PrintAddressDescription() const {
     Printf("%s", d.Error());
     Printf("\nCause: stack tag-mismatch\n");
     Printf("%s", d.Location());
-    Printf("Address %p is located in stack of thread T%zd\n", untagged_addr,
-           sa.thread_id());
+    Printf("Address %p is located in stack of thread T%zd\n",
+           (void *)untagged_addr, (ssize)sa.thread_id());
     Printf("%s", d.Default());
     announce_by_id(sa.thread_id());
     PrintStackAllocations(sa.get(), ptr_tag, untagged_addr);
@@ -842,9 +843,9 @@ void BaseReport::PrintAddressDescription() const {
     Printf("\nCause: use-after-free\n");
     Printf("%s", d.Location());
     Printf("%p is located %zd bytes inside a %zd-byte region [%p,%p)\n",
-           untagged_addr, untagged_addr - UntagAddr(har.tagged_addr),
-           har.requested_size, UntagAddr(har.tagged_addr),
-           UntagAddr(har.tagged_addr) + har.requested_size);
+           (void *)untagged_addr, untagged_addr - UntagAddr(har.tagged_addr),
+           (ssize)har.requested_size, UntagAddr(har.tagged_addr),
+           (void *)(UntagAddr(har.tagged_addr) + har.requested_size));
     Printf("%s", d.Allocation());
     Printf("freed by thread T%u here:\n", ha.free_thread_id);
     Printf("%s", d.Default());
@@ -858,7 +859,7 @@ void BaseReport::PrintAddressDescription() const {
     // Print a developer note: the index of this heap object
     // in the thread's deallocation ring buffer.
     Printf("hwasan_dev_note_heap_rb_distance: %zd %zd\n", ha.ring_index + 1,
-           flags()->heap_history_size);
+           (ssize)flags()->heap_history_size);
     Printf("hwasan_dev_note_num_matching_addrs: %zd\n", ha.num_matching_addrs);
     Printf("hwasan_dev_note_num_matching_addrs_4b: %zd\n",
            ha.num_matching_addrs_4b);
@@ -915,10 +916,11 @@ InvalidFreeReport::~InvalidFreeReport() {
   const Thread *thread = GetCurrentThread();
   if (thread) {
     Report("ERROR: %s: %s on address %p at pc %p on thread T%zd\n",
-           SanitizerToolName, bug_type, untagged_addr, pc, thread->unique_id());
+           SanitizerToolName, bug_type, (void *)untagged_addr, (void *)pc,
+           (ssize)thread->unique_id());
   } else {
     Report("ERROR: %s: %s on address %p at pc %p on unknown thread\n",
-           SanitizerToolName, bug_type, untagged_addr, pc);
+           SanitizerToolName, bug_type, (void *)untagged_addr, (void *)pc);
   }
   Printf("%s", d.Access());
   if (shadow.addr) {
@@ -967,7 +969,8 @@ TailOverwrittenReport::~TailOverwrittenReport() {
   Printf("%s", d.Error());
   const char *bug_type = "allocation-tail-overwritten";
   Report("ERROR: %s: %s; heap object [%p,%p) of size %zd\n", SanitizerToolName,
-         bug_type, untagged_addr, untagged_addr + orig_size, orig_size);
+         bug_type, (void *)untagged_addr, (void *)(untagged_addr + orig_size),
+         orig_size);
   Printf("\n%s", d.Default());
   Printf(
       "Stack of invalid access unknown. Issue detected at deallocation "
@@ -1037,7 +1040,7 @@ TagMismatchReport::~TagMismatchReport() {
   uptr pc = GetTopPc(stack);
   Printf("%s", d.Error());
   Report("ERROR: %s: %s on address %p at pc %p\n", SanitizerToolName, bug_type,
-         untagged_addr, pc);
+         (void *)untagged_addr, (void *)pc);
 
   Thread *t = GetCurrentThread();
 
@@ -1049,12 +1052,12 @@ TagMismatchReport::~TagMismatchReport() {
         GetShortTagCopy(MemToShadow(untagged_addr + mismatch_offset));
     Printf(
         "%s of size %zu at %p tags: %02x/%02x(%02x) (ptr/mem) in thread T%zd\n",
-        is_store ? "WRITE" : "READ", access_size, untagged_addr, ptr_tag,
-        mem_tag, short_tag, t->unique_id());
+        is_store ? "WRITE" : "READ", access_size, (void *)untagged_addr,
+        ptr_tag, mem_tag, short_tag, (ssize)t->unique_id());
   } else {
     Printf("%s of size %zu at %p tags: %02x/%02x (ptr/mem) in thread T%zd\n",
-           is_store ? "WRITE" : "READ", access_size, untagged_addr, ptr_tag,
-           mem_tag, t->unique_id());
+           is_store ? "WRITE" : "READ", access_size, (void *)untagged_addr,
+           ptr_tag, mem_tag, (ssize)t->unique_id());
   }
   if (mismatch_offset)
     Printf("Invalid access starting at offset %zu\n", mismatch_offset);
@@ -1093,7 +1096,7 @@ void ReportTagMismatch(StackTrace *stack, uptr tagged_addr, uptr access_size,
 // See the frame breakdown defined in __hwasan_tag_mismatch (from
 // hwasan_tag_mismatch_{aarch64,riscv64}.S).
 void ReportRegisters(const uptr *frame, uptr pc) {
-  Printf("\nRegisters where the failure occurred (pc %p):\n", pc);
+  Printf("\nRegisters where the failure occurred (pc %p):\n", (void *)pc);
 
   // We explicitly print a single line (4 registers/line) each iteration to
   // reduce the amount of logcat error messages printed. Each Printf() will

--- a/compiler-rt/lib/hwasan/hwasan_thread.cpp
+++ b/compiler-rt/lib/hwasan/hwasan_thread.cpp
@@ -173,9 +173,10 @@ uptr Thread::stack_size() {
 }
 
 void Thread::Print(const char *Prefix) {
-  Printf("%sT%zd %p stack: [%p,%p) sz: %zd tls: [%p,%p)\n", Prefix, unique_id_,
-         (void *)this, stack_bottom(), stack_top(),
-         stack_top() - stack_bottom(), tls_begin(), tls_end());
+  Printf("%sT%zd %p stack: [%p,%p) sz: %zd tls: [%p,%p)\n", Prefix,
+         (ssize)unique_id_, (void *)this, (void *)stack_bottom(),
+         (void *)stack_top(), stack_top() - stack_bottom(), (void *)tls_begin(),
+         (void *)tls_end());
 }
 
 static u32 xorshift(u32 state) {

--- a/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/compiler-rt/lib/lsan/lsan_common.cpp
@@ -806,7 +806,7 @@ static bool ReportUnsuspendedThreads(
       succeded = false;
       Report(
           "Running thread %zu was not suspended. False leaks are possible.\n",
-          os_id);
+          (usize)os_id);
     }
   }
   return succeded;

--- a/compiler-rt/lib/memprof/memprof_shadow_setup.cpp
+++ b/compiler-rt/lib/memprof/memprof_shadow_setup.cpp
@@ -29,7 +29,7 @@ static void ProtectGap(uptr addr, uptr size) {
       Printf("protect_shadow_gap=0:"
              " not protecting shadow gap, allocating gap's shadow\n"
              "|| `[%p, %p]` || ShadowGap's shadow ||\n",
-             GapShadowBeg, GapShadowEnd);
+             (void *)GapShadowBeg, (void *)GapShadowEnd);
     ReserveShadowMemoryRange(GapShadowBeg, GapShadowEnd,
                              "unprotected gap shadow");
     return;

--- a/compiler-rt/lib/xray/xray_init.cpp
+++ b/compiler-rt/lib/xray/xray_init.cpp
@@ -105,7 +105,7 @@ __xray_register_sleds(const XRaySledEntry *SledsBegin,
   }
 
   if (Verbosity())
-    Report("Registering %d new functions!\n", SledMap.Functions);
+    Report("Registering %d new functions!\n", (int)SledMap.Functions);
 
   {
     SpinMutexLock Guard(&XRayInstrMapMutex);

--- a/compiler-rt/lib/xray/xray_interface.cpp
+++ b/compiler-rt/lib/xray/xray_interface.cpp
@@ -308,7 +308,8 @@ XRayPatchingStatus controlPatchingObjectUnchecked(bool Enable, int32_t ObjId) {
     return XRayPatchingStatus::NOT_INITIALIZED;
 
   if (Verbosity())
-    Report("Patching object %d with %d functions.\n", ObjId, InstrMap.Entries);
+    Report("Patching object %d with %d functions.\n", ObjId,
+           (int)InstrMap.Entries);
 
   // Check if the corresponding DSO has been unloaded.
   if (!InstrMap.Loaded) {


### PR DESCRIPTION
casts (#153843)"

Error Fixes.

> Replace ssize_t with sanitizer equivalent ssize.

This reverts commit ee5367bedb97ae8df9930ac1c162b3287c743663.