### PR TITLE
Openmp 6.0 allow default clause on the target directive

### DIFF
--- a/clang/test/OpenMP/target_default_ast.cpp
+++ b/clang/test/OpenMP/target_default_ast.cpp
@@ -43,7 +43,7 @@ void foo() {
 void fun(){
 int a = 0;
     int x = 10;
-    #pragma omp target data default(firstprivate)  map(a)
+    #pragma omp target data default(firstprivate) map(a)
     {
   // DUMP: -OMPTargetDataDirective
   // DUMP-NEXT: -OMPDefaultClause

--- a/clang/test/OpenMP/target_default_ast.cpp
+++ b/clang/test/OpenMP/target_default_ast.cpp
@@ -1,0 +1,81 @@
+// expected-no-diagnostics
+
+//RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+//RUN:   -x c++ -std=c++14 -fexceptions -fcxx-exceptions                   \
+//RUN:   -Wno-source-uses-openmp -Wno-openmp-clauses                       \
+//RUN:   -ast-print %s | FileCheck %s --check-prefix=PRINT
+
+//RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+//RUN:   -x c++ -std=c++14 -fexceptions -fcxx-exceptions                   \
+//RUN:   -Wno-source-uses-openmp -Wno-openmp-clauses                       \
+//RUN:   -ast-dump %s | FileCheck %s --check-prefix=DUMP
+
+//RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+//RUN:   -x c++ -std=c++14 -fexceptions -fcxx-exceptions                   \
+//RUN:   -Wno-source-uses-openmp -Wno-openmp-clauses                       \
+//RUN:   -emit-pch -o %t %s
+
+//RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+//RUN:   -x c++ -std=c++14 -fexceptions -fcxx-exceptions                   \
+//RUN:   -Wno-source-uses-openmp -Wno-openmp-clauses                       \
+//RUN:   -include-pch %t -ast-print %s | FileCheck %s --check-prefix=PRINT
+
+//RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fopenmp -fopenmp-version=60 \
+//RUN:   -x c++ -std=c++14 -fexceptions -fcxx-exceptions                   \
+//RUN:   -Wno-source-uses-openmp -Wno-openmp-clauses                       \
+//RUN:   -include-pch %t -ast-dump-all %s | FileCheck %s --check-prefix=DUMP
+
+#ifndef HEADER
+#define HEADER
+
+void foo() {
+  int a;
+#pragma omp target default(firstprivate)
+  a++;
+  // PRINT: #pragma omp target default(firstprivate)
+  // PRINT-NEXT: a++;
+  // DUMP: -OMPTargetDirective
+  // DUMP-NEXT:  -OMPDefaultClause
+  // DUMP-NEXT:  -OMPFirstprivateClause {{.*}} <implicit>
+  // DUMP-NEXT:   -DeclRefExpr {{.*}} 'a'
+
+}
+void fun(){
+int a = 0;
+    int x = 10;
+    #pragma omp target data default(firstprivate)  map(a)
+    {
+  // DUMP: -OMPTargetDataDirective
+  // DUMP-NEXT: -OMPDefaultClause
+  // DUMP-NEXT: -OMPMapClause
+  // DUMP-NEXT:  -DeclRefExpr {{.*}} 'a'
+  // DUMP-NEXT: -OMPFirstprivateClause {{.*}} <implicit>
+  // DUMP-NEXT:  -DeclRefExpr {{.*}} 'x'
+
+
+        x += 10;
+        a += 1;
+    }
+}
+void bar(){
+int i = 0;
+int j = 0;
+int  nn = 10;
+#pragma omp target default(firstprivate)
+#pragma omp teams 
+#pragma teams distribute parallel for simd 
+        for (j = 0; j < nn; j++ ) {
+          for (i = 0; i < nn; i++ ) {
+                ;
+          }
+        }
+
+  // PRINT: #pragma omp target default(firstprivate)
+  // DUMP: -OMPTargetDirective
+  // DUMP-NEXT: -OMPDefaultClause
+  // DUMP-NEXT: -OMPFirstprivateClause {{.*}} <implicit>
+  // DUMP-NEXT: -DeclRefExpr {{.*}} 'j'
+  // DUMP-NEXT: -DeclRefExpr {{.*}} 'nn'
+  // DUMP-NEXT: -DeclRefExpr {{.*}} 'i'
+}
+#endif

--- a/clang/test/OpenMP/target_default_messages.cpp
+++ b/clang/test/OpenMP/target_default_messages.cpp
@@ -14,20 +14,20 @@ static int x = 0;
 
 int main(int argc, char **argv) {
 #ifdef OMP60
-  #pragma omp target  default // expected-error {{expected '(' after 'default'}}
+  #pragma omp target default // expected-error {{expected '(' after 'default'}}
   for (int i=0; i<200; i++) foo();
 #pragma omp target  default( // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int i=0; i<200; i++) foo();
-#pragma omp target  default() // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}}
+#pragma omp target default() // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}}
   for (int i=0; i<200; i++) foo();
-  #pragma omp target  default (none // expected-error {{expected ')'}} expected-note {{to match this '('}}
+  #pragma omp target default (none // expected-error {{expected ')'}} expected-note {{to match this '('}}
   for (int i=0; i<200; i++) foo();
 #pragma omp target  default(x) // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}}
   for (int i=0; i<200; i++) foo();
 #endif 
 
 #ifdef OMP52
-#pragma omp target  default(firstprivate) // expected-error {{unexpected OpenMP clause 'default' in directive '#pragma omp target'}}
+#pragma omp target default(firstprivate) // expected-error {{unexpected OpenMP clause 'default' in directive '#pragma omp target'}}
   for (int i = 0; i < 200; i++) {
     ++x;
     ++y;

--- a/clang/test/OpenMP/target_default_messages.cpp
+++ b/clang/test/OpenMP/target_default_messages.cpp
@@ -1,0 +1,51 @@
+
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=60 -DOMP60 %s -Wuninitialized
+
+// RUN: %clang_cc1 -verify -fopenmp-simd -fopenmp-version=60 -DOMP60 %s -Wuninitialized
+
+// RUN: %clang_cc1 -verify -fopenmp -fopenmp-version=52 -DOMP52 %s -Wuninitialized
+
+void foo();
+
+namespace {
+static int y = 0;
+}
+static int x = 0;
+
+int main(int argc, char **argv) {
+#ifdef OMP60
+  #pragma omp target  default // expected-error {{expected '(' after 'default'}}
+  for (int i=0; i<200; i++) foo();
+#pragma omp target  default( // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}} expected-error {{expected ')'}} expected-note {{to match this '('}}
+  for (int i=0; i<200; i++) foo();
+#pragma omp target  default() // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}}
+  for (int i=0; i<200; i++) foo();
+  #pragma omp target  default (none // expected-error {{expected ')'}} expected-note {{to match this '('}}
+  for (int i=0; i<200; i++) foo();
+#pragma omp target  default(x) // expected-error {{expected 'none', 'shared', 'private' or 'firstprivate' in OpenMP clause 'default'}}
+  for (int i=0; i<200; i++) foo();
+#endif 
+
+#ifdef OMP52
+#pragma omp target  default(firstprivate) // expected-error {{unexpected OpenMP clause 'default' in directive '#pragma omp target'}}
+  for (int i = 0; i < 200; i++) {
+    ++x;
+    ++y;
+  }
+#pragma omp target default(private) // expected-error {{unexpected OpenMP clause 'default' in directive '#pragma omp target'}}
+  for (int i = 0; i < 200; i++) {
+    ++x;
+    ++y;
+  }
+
+int j = 0, i = 0, nn = 10;
+#pragma omp target teams distribute simd default(shared) // expected-error {{unexpected OpenMP clause 'default' in directive '#pragma omp target teams distribute simd'}}
+	for (j = 0; j < nn; j++ ) {
+	  for (i = 0; i < nn; i++ ) {
+		;
+	  }
+	}
+#endif 
+ 
+  return 0;
+}

--- a/llvm/include/llvm/Frontend/OpenMP/OMP.td
+++ b/llvm/include/llvm/Frontend/OpenMP/OMP.td
@@ -1080,6 +1080,7 @@ def OMP_Target : Directive<[Spelling<"target">]> {
     VersionedClause<OMPC_OMPX_Attribute>,
     VersionedClause<OMPC_Private>,
     VersionedClause<OMPC_UsesAllocators, 50>,
+    VersionedClause<OMPC_Default, 60>,
   ];
   let allowedOnceClauses = [
     VersionedClause<OMPC_DefaultMap>,
@@ -1097,6 +1098,7 @@ def OMP_TargetData : Directive<[Spelling<"target data">]> {
   let allowedOnceClauses = [
     VersionedClause<OMPC_Device>,
     VersionedClause<OMPC_If>,
+    VersionedClause<OMPC_Default, 60>,
   ];
   let requiredClauses = [
     VersionedClause<OMPC_Map>,
@@ -2411,6 +2413,7 @@ def OMP_TargetTeamsDistributeSimd
     VersionedClause<OMPC_Reduction>,
     VersionedClause<OMPC_Shared>,
     VersionedClause<OMPC_UsesAllocators, 50>,
+    VersionedClause<OMPC_Default, 60>,
   ];
   let allowedOnceClauses = [
     VersionedClause<OMPC_Collapse>,


### PR DESCRIPTION
Sections 7.5.1 default Clause in OpenMP 6.0. Allow default clause on the target directive. 