### PR TITLE
[BuiltinsX86] Fix type definitions of built-in functions in BuiltinsX86.td

### DIFF
--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -768,7 +768,7 @@ let Features = "xsave", Attributes = [NoThrow] in {
 }
 
 let Header = "immintrin.h", Languages = "ALL_MS_LANGUAGES", Attributes = [NoThrow, RequireDeclaration] in {
-  def _xgetbv : X86LibBuiltin<"uint64_t(unsigned int)">;
+  def _xgetbv : X86LibBuiltin<"unsigned long long int(unsigned int)">;
 }
 
 let Features = "xsave", Attributes = [NoThrow] in {
@@ -776,7 +776,7 @@ let Features = "xsave", Attributes = [NoThrow] in {
 }
 
 let Header = "immintrin.h", Languages = "ALL_MS_LANGUAGES", Attributes = [NoThrow, RequireDeclaration] in {
-  def _xsetbv : X86LibBuiltin<"void(unsigned int, uint64_t)">;
+  def _xsetbv : X86LibBuiltin<"void(unsigned int, unsigned long long int)">;
 }
 
 let Features = "xsaveopt", Attributes = [NoThrow] in {

--- a/clang/include/clang/Basic/BuiltinsX86.td
+++ b/clang/include/clang/Basic/BuiltinsX86.td
@@ -4769,14 +4769,14 @@ let Features = "sha512", Attributes = [NoThrow, RequiredVectorWidth<256>] in {
 }
 
 let Header = "intrin.h", Languages = "ALL_MS_LANGUAGES", Attributes = [NoThrow, RequireDeclaration] in {
-  def _InterlockedAnd64 : X86LibBuiltin<"int64_t(int64_t volatile *, int64_t)">;
-  def _InterlockedDecrement64 : X86LibBuiltin<"int64_t(int64_t volatile *)">;
-  def _InterlockedExchange64 : X86LibBuiltin<"int64_t(int64_t volatile *, int64_t)">;
-  def _InterlockedExchangeAdd64 : X86LibBuiltin<"int64_t(int64_t volatile *, int64_t)">;
-  def _InterlockedExchangeSub64 : X86LibBuiltin<"int64_t(int64_t volatile *, int64_t)">;
-  def _InterlockedIncrement64 : X86LibBuiltin<"int64_t(int64_t volatile *)">;
-  def _InterlockedOr64 : X86LibBuiltin<"int64_t(int64_t volatile *, int64_t)">;
-  def _InterlockedXor64 : X86LibBuiltin<"int64_t(int64_t volatile *, int64_t)">;
+  def _InterlockedAnd64 : X86LibBuiltin<"long long int(long long int volatile *, long long int)">;
+  def _InterlockedDecrement64 : X86LibBuiltin<"long long int(long long int volatile *)">;
+  def _InterlockedExchange64 : X86LibBuiltin<"long long int(long long int volatile *, long long int)">;
+  def _InterlockedExchangeAdd64 : X86LibBuiltin<"long long int(long long int volatile *, long long int)">;
+  def _InterlockedExchangeSub64 : X86LibBuiltin<"long long int(long long int volatile *, long long int)">;
+  def _InterlockedIncrement64 : X86LibBuiltin<"long long int(long long int volatile *)">;
+  def _InterlockedOr64 : X86LibBuiltin<"long long int(long long int volatile *, long long int)">;
+  def _InterlockedXor64 : X86LibBuiltin<"long long int(long long int volatile *, long long int)">;
 }
 
 let Features = "sm3", Attributes = [NoThrow, RequiredVectorWidth<128>] in {


### PR DESCRIPTION
The `_Interlocked*` and `_x*etbv` intrinsics are defined using the Microsoft-specific type __int64.

__int64 is defined as long long across all platforms.
However, in the builtin function database BuiltinsX86.td the intrinsics are defined using uint64_t.
The type uint64_t can be either long or long long, depending on the target platform.
This leads to incorrect definitions on platforms where uint64_t is not equivalent to long long.

This PR aligns the type definitions in BuiltinsX86.td with the function signatures in xsaveintrin.h and immintrin.h.

Following the precedent of functions like __emul(), we use the microsoft-specific unsigned __int64 definition in the header and use the resolved type 'unsigned long long int' in the builtin function database.