### PR TITLE
[Offload] Fix definition of olMemFill

### DIFF
--- a/offload/liboffload/API/Memory.td
+++ b/offload/liboffload/API/Memory.td
@@ -60,8 +60,7 @@ def olMemcpy : Function {
     let returns = [];
 }
 
-def : Function {
-  let name = "olMemFill";
+def olMemFill : Function {
   let desc = "Fill memory with copies of the given pattern";
   let details = [
     "Filling with patterns larger than 4 bytes may be less performant",


### PR DESCRIPTION
Fix regression introduced by #154102 - the way offload-tblgen handles names has changed