### PR TITLE
[MC] AsmLexer assert buffer is null-terminated at CurBuf.end()

### DIFF
--- a/llvm/include/llvm/MC/MCParser/AsmLexer.h
+++ b/llvm/include/llvm/MC/MCParser/AsmLexer.h
@@ -45,6 +45,7 @@ class AsmLexer {
   SmallVector<AsmToken, 1> CurTok;
 
   const char *CurPtr = nullptr;
+  /// NULL-terminated buffer. NULL terminator must reside at `CurBuf.end()`.
   StringRef CurBuf;
 
   /// The location and description of the current error
@@ -191,6 +192,12 @@ public:
   /// literals.
   void setLexHLASMStrings(bool V) { LexHLASMStrings = V; }
 
+  /// Set buffer to be lexed.
+  /// `Buf` must be NULL-terminated. NULL terminator must reside at `Buf.end()`.
+  /// `ptr` if provided must be in range [`Buf.begin()`, `buf.end()`] or NULL.
+  /// Specifies where lexing of buffer should begin.
+  /// `EndStatementAtEOF` specifies whether `AsmToken::EndOfStatement` should be
+  /// returned upon reaching end of buffer.
   LLVM_ABI void setBuffer(StringRef Buf, const char *ptr = nullptr,
                           bool EndStatementAtEOF = true);
 

--- a/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -119,6 +119,11 @@ AsmLexer::AsmLexer(const MCAsmInfo &MAI) : MAI(MAI) {
 
 void AsmLexer::setBuffer(StringRef Buf, const char *ptr,
                          bool EndStatementAtEOF) {
+  // Buffer must be NULL-terminated. NULL terminator must reside at `Buf.end()`.
+  // It must be safe to dereference `Buf.end()`.
+  assert(*Buf.end() == '\0' &&
+         "Buffer provided to AsmLexer lacks null terminator.");
+
   CurBuf = Buf;
 
   if (ptr)


### PR DESCRIPTION
AsmLexer expects the buffer it's provided for lexing to be
NULL-terminated, where the NULL terminator is pointed to by
`CurBuf.end()`. However, this expectation isn't explicitly stated
anywhere.

This commit adds a couple of comments as well as an assert as means of
documenting this expectation.
