### PR TITLE
[NFC][MC][Sparc] Rearrange decode functions in Sparc disassembler

### DIFF
--- a/llvm/lib/Target/Sparc/Disassembler/SparcDisassembler.cpp
+++ b/llvm/lib/Target/Sparc/Disassembler/SparcDisassembler.cpp
@@ -298,9 +298,8 @@ static DecodeStatus DecodeSIMM13(MCInst &MI, unsigned insn, uint64_t Address,
 }
 
 template <unsigned N>
-constexpr static DecodeStatus DecodeDisp(MCInst &MI, uint32_t ImmVal,
-                                         uint64_t Address,
-                                         const MCDisassembler *Decoder) {
+static DecodeStatus DecodeDisp(MCInst &MI, uint32_t ImmVal, uint64_t Address,
+                               const MCDisassembler *Decoder) {
   int64_t BranchOffset = SignExtend64(ImmVal, N) * 4;
   if (!tryAddingSymbolicOperand(Address + BranchOffset, true, Address, 0, N, MI,
                                 Decoder))

--- a/llvm/lib/Target/Sparc/Disassembler/SparcDisassembler.cpp
+++ b/llvm/lib/Target/Sparc/Disassembler/SparcDisassembler.cpp
@@ -266,16 +266,48 @@ DecodeCoprocPairRegisterClass(MCInst &Inst, unsigned RegNo, uint64_t Address,
   return MCDisassembler::Success;
 }
 
-static DecodeStatus DecodeCall(MCInst &Inst, unsigned insn, uint64_t Address,
-                               const MCDisassembler *Decoder);
-static DecodeStatus DecodeSIMM5(MCInst &Inst, unsigned insn, uint64_t Address,
-                                const MCDisassembler *Decoder);
-static DecodeStatus DecodeSIMM13(MCInst &Inst, unsigned insn, uint64_t Address,
-                                 const MCDisassembler *Decoder);
+static bool tryAddingSymbolicOperand(int64_t Value, bool isBranch,
+                                     uint64_t Address, uint64_t Offset,
+                                     uint64_t Width, MCInst &MI,
+                                     const MCDisassembler *Decoder) {
+  return Decoder->tryAddingSymbolicOperand(MI, Value, Address, isBranch, Offset,
+                                           Width, /*InstSize=*/4);
+}
+
+static DecodeStatus DecodeCall(MCInst &MI, unsigned insn, uint64_t Address,
+                               const MCDisassembler *Decoder) {
+  int64_t CallOffset = SignExtend64(fieldFromInstruction(insn, 0, 30), 30) * 4;
+  if (!tryAddingSymbolicOperand(Address + CallOffset, false, Address, 0, 30, MI,
+                                Decoder))
+    MI.addOperand(MCOperand::createImm(CallOffset));
+  return MCDisassembler::Success;
+}
+
+static DecodeStatus DecodeSIMM5(MCInst &MI, unsigned insn, uint64_t Address,
+                                const MCDisassembler *Decoder) {
+  assert(isUInt<5>(insn));
+  MI.addOperand(MCOperand::createImm(SignExtend64<5>(insn)));
+  return MCDisassembler::Success;
+}
+
+static DecodeStatus DecodeSIMM13(MCInst &MI, unsigned insn, uint64_t Address,
+                                 const MCDisassembler *Decoder) {
+  assert(isUInt<13>(insn));
+  MI.addOperand(MCOperand::createImm(SignExtend64<13>(insn)));
+  return MCDisassembler::Success;
+}
+
 template <unsigned N>
 constexpr static DecodeStatus DecodeDisp(MCInst &MI, uint32_t ImmVal,
                                          uint64_t Address,
-                                         const MCDisassembler *Decoder);
+                                         const MCDisassembler *Decoder) {
+  int64_t BranchOffset = SignExtend64(ImmVal, N) * 4;
+  if (!tryAddingSymbolicOperand(Address + BranchOffset, true, Address, 0, N, MI,
+                                Decoder))
+    MI.addOperand(MCOperand::createImm(BranchOffset));
+  return MCDisassembler::Success;
+}
+
 #include "SparcGenDisassemblerTables.inc"
 
 /// Read four bytes from the ArrayRef and return 32 bit word.
@@ -320,46 +352,4 @@ DecodeStatus SparcDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
       decodeInstruction(DecoderTableSparc32, Instr, Insn, Address, this, STI);
 
   return Result;
-}
-
-static bool tryAddingSymbolicOperand(int64_t Value, bool isBranch,
-                                     uint64_t Address, uint64_t Offset,
-                                     uint64_t Width, MCInst &MI,
-                                     const MCDisassembler *Decoder) {
-  return Decoder->tryAddingSymbolicOperand(MI, Value, Address, isBranch, Offset,
-                                           Width, /*InstSize=*/4);
-}
-
-static DecodeStatus DecodeCall(MCInst &MI, unsigned insn, uint64_t Address,
-                               const MCDisassembler *Decoder) {
-  int64_t CallOffset = SignExtend64(fieldFromInstruction(insn, 0, 30), 30) * 4;
-  if (!tryAddingSymbolicOperand(Address + CallOffset, false, Address, 0, 30, MI,
-                                Decoder))
-    MI.addOperand(MCOperand::createImm(CallOffset));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeSIMM5(MCInst &MI, unsigned insn, uint64_t Address,
-                                const MCDisassembler *Decoder) {
-  assert(isUInt<5>(insn));
-  MI.addOperand(MCOperand::createImm(SignExtend64<5>(insn)));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeSIMM13(MCInst &MI, unsigned insn, uint64_t Address,
-                                 const MCDisassembler *Decoder) {
-  assert(isUInt<13>(insn));
-  MI.addOperand(MCOperand::createImm(SignExtend64<13>(insn)));
-  return MCDisassembler::Success;
-}
-
-template <unsigned N>
-constexpr static DecodeStatus DecodeDisp(MCInst &MI, uint32_t ImmVal,
-                                         uint64_t Address,
-                                         const MCDisassembler *Decoder) {
-  int64_t BranchOffset = SignExtend64(ImmVal, N) * 4;
-  if (!tryAddingSymbolicOperand(Address + BranchOffset, true, Address, 0, N, MI,
-                                Decoder))
-    MI.addOperand(MCOperand::createImm(BranchOffset));
-  return MCDisassembler::Success;
 }


### PR DESCRIPTION
Some of the decode function were previously declared before including `SparcGenDisassemblerTables.inc` and then defined later on because the generated code in `SparcGenDisassemblerTables.inc` references these functions and these functions reference `fieldFromInstruction` which used to be generated.

Now that `fieldFromInstruction` has moved to MCDecoder.h, we can move these definitions to before including the generated code without any circular references.