### PR TITLE
[OpenMP][omptest] Enforce test case order for 'standalone' build

### DIFF
--- a/openmp/tools/omptest/src/OmptTester.cpp
+++ b/openmp/tools/omptest/src/OmptTester.cpp
@@ -42,7 +42,7 @@ static OmptEventReporter *EventReporter;
 #define OMPT_BUFFER_REQUEST_SIZE 256
 
 #ifdef OPENMP_LIBOMPTEST_BUILD_STANDALONE
-std::map<std::string, TestSuite> TestRegistrar::Tests;
+std::vector<std::pair<std::string, TestSuite>> TestRegistrar::Tests;
 #endif
 
 static std::atomic<ompt_id_t> NextOpId{0x8000000000000001};


### PR DESCRIPTION
Note: this only applies to 'standalone' builds, i.e. when:
LIBOMPTEST_BUILD_STANDALONE evaluates to 'ON'.

Use std::vector<std::pair<std::string, TestSuite>> instead of a std::map.

Background:
In some cases it could happen that the test execution order would change vs. the order of appearance.
This can lead to suite failures when e.g. testing for device initialization because it is performed by the first executed test case.
By storing the test suites and cases in order of appearance this issue is avoided. (So far GoogleTest has behaved in the same way.)