### PR TITLE
[mlir][memref] Alias attributes for memref dialect

### DIFF
--- a/mlir/include/mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h
+++ b/mlir/include/mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h
@@ -18,6 +18,9 @@ class LLVMTypeConverter;
 class RewritePatternSet;
 class SymbolTableCollection;
 
+#define GEN_PASS_DECL_CONVERTMEMREFALIASATTRIBUTESTOLLVMPASS
+#include "mlir/Conversion/Passes.h.inc"
+
 #define GEN_PASS_DECL_FINALIZEMEMREFTOLLVMCONVERSIONPASS
 #include "mlir/Conversion/Passes.h.inc"
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -872,7 +872,9 @@ def ConvertMemRefAliasAttributesToLLVMPass :
     Pass<"convert-memref-alias-attributes-to-llvm"> {
   let summary = "Convert MemRef aliasing attributes to LLVM";
   let description = [{
-    TBD
+    Convert MemRef dialect alising attibutes to LLVM dialect ones and erase
+    alias domain ops. This pass must be called before
+    `--finalize-memref-to-llvm`.
   }];
   let dependentDialects = ["LLVM::LLVMDialect"];
 }

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -868,6 +868,15 @@ def ConvertMemRefToEmitC : Pass<"convert-memref-to-emitc", "ModuleOp"> {
 // MemRefToLLVM
 //===----------------------------------------------------------------------===//
 
+def ConvertMemRefAliasAttributesToLLVMPass :
+    Pass<"convert-memref-alias-attributes-to-llvm"> {
+  let summary = "Convert MemRef aliasing attributes to LLVM";
+  let description = [{
+    TBD
+  }];
+  let dependentDialects = ["LLVM::LLVMDialect"];
+}
+
 def FinalizeMemRefToLLVMConversionPass :
     Pass<"finalize-memref-to-llvm", "ModuleOp"> {
   let summary = "Finalize MemRef dialect to LLVM dialect conversion";

--- a/mlir/include/mlir/Dialect/MemRef/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/MemRef/IR/CMakeLists.txt
@@ -6,3 +6,8 @@ mlir_tablegen(MemRefAttrs.h.inc -gen-attrdef-decls -attrdefs-dialect=memref)
 mlir_tablegen(MemRefAttrs.cpp.inc -gen-attrdef-defs -attrdefs-dialect=memref)
 add_public_tablegen_target(MLIRMemRefAttrsIncGen)
 add_dependencies(mlir-headers MLIRMemRefAttrsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS MemRefInterfaces.td)
+mlir_tablegen(MemRefInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(MemRefInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(MLIRMemRefInterfacesIncGen)

--- a/mlir/include/mlir/Dialect/MemRef/IR/CMakeLists.txt
+++ b/mlir/include/mlir/Dialect/MemRef/IR/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_mlir_dialect(MemRefOps memref)
 add_mlir_doc(MemRefOps MemRefOps Dialects/ -gen-op-doc)
+
+set(LLVM_TARGET_DEFINITIONS MemRefOps.td)
+mlir_tablegen(MemRefAttrs.h.inc -gen-attrdef-decls -attrdefs-dialect=memref)
+mlir_tablegen(MemRefAttrs.cpp.inc -gen-attrdef-defs -attrdefs-dialect=memref)
+add_public_tablegen_target(MLIRMemRefAttrsIncGen)
+add_dependencies(mlir-headers MLIRMemRefAttrsIncGen)

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRef.h
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRef.h
@@ -12,6 +12,7 @@
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRefAttrs.h"
+#include "mlir/Dialect/MemRef/IR/MemRefInterfaces.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Interfaces/CallInterfaces.h"

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRef.h
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRef.h
@@ -11,6 +11,7 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRefAttrs.h"
 #include "mlir/Dialect/Utils/ReshapeOpsUtils.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Interfaces/CallInterfaces.h"

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.h
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.h
@@ -1,0 +1,21 @@
+//===- MemRefAttrs.h - MLIR MemRef IR dialect attributes --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the MemRef dialect attributes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_MEMREF_IR_MEMREFATTRS_H_
+#define MLIR_DIALECT_MEMREF_IR_MEMREFATTRS_H_
+
+#include "mlir/IR/OpImplementation.h"
+
+#define GET_ATTRDEF_CLASSES
+#include "mlir/Dialect/MemRef/IR/MemRefAttrs.h.inc"
+
+#endif // MLIR_DIALECT_MEMREF_IR_MEMREFATTRS_H_

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
@@ -20,36 +20,6 @@ class MemRef_Attr<string name, string attrMnemonic,
   let mnemonic = attrMnemonic;
 }
 
-
-//===----------------------------------------------------------------------===//
-// AliasScopeDomainAttr
-//===----------------------------------------------------------------------===//
-
-def MemRef_AliasScopeDomainAttr : MemRef_Attr<"AliasScopeDomain",
-                                              "alias_scope_domain"> {
-  let parameters = (ins
-    "Attribute":$id,
-    OptionalParameter<"StringAttr">:$description
-  );
-
-  let builders = [
-    AttrBuilder<(ins CArg<"StringAttr", "{}">:$description), [{
-      return $_get($_ctxt, DistinctAttr::create(UnitAttr::get($_ctxt)), description);
-    }]>
-  ];
-
-  let summary = "TBD";
-
-  let description = [{
-    TBD
-  }];
-
-  let assemblyFormat = "`<` struct(params) `>`";
-
-  // Generate mnemonic alias for the attribute.
-  let genMnemonicAlias = 1;
-}
-
 //===----------------------------------------------------------------------===//
 // AliasScopeAttr
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
@@ -106,9 +106,6 @@ def MemRef_AliasingAttr : MemRef_Attr<"Aliasing", "aliasing"> {
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";
-
-  // Generate mnemonic alias for the attribute.
-  let genMnemonicAlias = 1;
 }
 
 #endif // MEMREF_ATTRDEFS

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
@@ -105,6 +105,16 @@ def MemRef_AliasingAttr : MemRef_Attr<"Aliasing", "aliasing"> {
     TBD
   }];
 
+  let builders = [
+    AttrBuilderWithInferredContext<(ins
+      "MLIRContext*":$context,
+      CArg<"ArrayRef<Attribute>", "{}">:$alias_scopes,
+      CArg<"ArrayRef<Attribute>", "{}">:$noalias
+    ), [{
+      return $_get(context, ArrayAttr::get(context, alias_scopes), ArrayAttr::get(context, noalias));
+    }]>
+  ];
+
   let assemblyFormat = "`<` struct(params) `>`";
 }
 

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
@@ -1,0 +1,114 @@
+//===-- MemRefAttrs.td - MemRef Attributes definition file -*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MEMREF_ATTRDEFS
+#define MEMREF_ATTRDEFS
+
+include "mlir/Dialect/MemRef/IR/MemRefBase.td"
+include "mlir/IR/AttrTypeBase.td"
+
+// All of the attributes will extend this class.
+class MemRef_Attr<string name, string attrMnemonic,
+                list<Trait> traits = [],
+                string baseCppClass = "::mlir::Attribute">
+    : AttrDef<MemRef_Dialect, name, traits, baseCppClass> {
+  let mnemonic = attrMnemonic;
+}
+
+
+//===----------------------------------------------------------------------===//
+// AliasScopeDomainAttr
+//===----------------------------------------------------------------------===//
+
+def MemRef_AliasScopeDomainAttr : MemRef_Attr<"AliasScopeDomain",
+                                              "alias_scope_domain"> {
+  let parameters = (ins
+    "Attribute":$id,
+    OptionalParameter<"StringAttr">:$description
+  );
+
+  let builders = [
+    AttrBuilder<(ins CArg<"StringAttr", "{}">:$description), [{
+      return $_get($_ctxt, DistinctAttr::create(UnitAttr::get($_ctxt)), description);
+    }]>
+  ];
+
+  let summary = "TBD";
+
+  let description = [{
+    TBD
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  // Generate mnemonic alias for the attribute.
+  let genMnemonicAlias = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// AliasScopeAttr
+//===----------------------------------------------------------------------===//
+
+def MemRef_AliasScopeAttr : MemRef_Attr<"AliasScope", "alias_scope"> {
+  let parameters = (ins
+    "Attribute":$id,
+    OptionalParameter<"StringAttr">:$description
+  );
+
+  let builders = [
+    AttrBuilderWithInferredContext<(ins
+      "MLIRContext*":$context,
+      CArg<"StringAttr", "{}">:$description
+    ), [{
+      return $_get(context, DistinctAttr::create(UnitAttr::get(context)), description);
+    }]>
+  ];
+
+  let summary = "TBD";
+
+  let description = [{
+    TBD
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  let genVerifyDecl = 1;
+
+  // Generate mnemonic alias for the attribute.
+  let genMnemonicAlias = 1;
+}
+
+def MemRef_AliasScopeArrayAttr
+    : TypedArrayAttrBase<MemRef_AliasScopeAttr,
+                         MemRef_AliasScopeAttr.summary # " array"> {
+  let constBuilderCall = ?;
+}
+
+//===----------------------------------------------------------------------===//
+// AliasAttr
+//===----------------------------------------------------------------------===//
+
+def MemRef_AliasingAttr : MemRef_Attr<"Aliasing", "aliasing"> {
+  let parameters = (ins
+    "ArrayAttr":$alias_scopes,
+    "ArrayAttr":$noalias
+  );
+
+  let summary = "TBD";
+
+  let description = [{
+    TBD
+  }];
+
+  let assemblyFormat = "`<` struct(params) `>`";
+
+  // Generate mnemonic alias for the attribute.
+  let genMnemonicAlias = 1;
+}
+
+#endif // MEMREF_ATTRDEFS

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefAttrs.td
@@ -39,10 +39,35 @@ def MemRef_AliasScopeAttr : MemRef_Attr<"AliasScope", "alias_scope"> {
     }]>
   ];
 
-  let summary = "TBD";
+  let summary = "MemRef dialect alias scope";
 
   let description = [{
-    TBD
+    Defines an alias scope that can be attached to a memory-accessing operation.
+    Such scopes can be used in combination with `noalias` metadata to indicate
+    that sets of memory-affecting operations in one scope do not alias with
+    memory-affecting operations in another scope.
+
+    This attribute must be used in conjunctions with
+    `memref.alias_domain_scope`.
+
+    Example:
+    ```
+    #alias_scope1 = #memref.alias_scope<id = distinct[0]<>, description = "scope">
+    #alias_scope2 = #memref.alias_scope<id = distinct[1]<>>
+
+    func.func @memref_alias_scope(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
+      %0 = memref.alias_domain_scope "The Domain" -> f32 {
+        %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope1], noalias=[#alias_scope2]> } : memref<?xf32>
+        memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope2], noalias=[#alias_scope1]> } : memref<?xf32>
+        memref.alias_domain_scope.return %val: f32
+      }
+      return %0 : f32
+    }
+    ```
+
+    This attribute is modeled against LLVM alias scopes, see the following link
+    for more details:
+    https://llvm.org/docs/LangRef.html#noalias-and-alias-scope-metadata
   }];
 
   let assemblyFormat = "`<` struct(params) `>`";
@@ -69,10 +94,11 @@ def MemRef_AliasingAttr : MemRef_Attr<"Aliasing", "aliasing"> {
     "ArrayAttr":$noalias
   );
 
-  let summary = "TBD";
+  let summary = "MemRef dialect aliasing attribute";
 
   let description = [{
-    TBD
+    This attribute combines `alias_scopes` and `noalias` arrays into single
+    attribute.
   }];
 
   let builders = [

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefBase.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefBase.td
@@ -21,6 +21,7 @@ def MemRef_Dialect : Dialect {
   }];
   let dependentDialects = ["arith::ArithDialect"];
   let hasConstantMaterializer = 1;
+  let useDefaultAttributePrinterParser = 1;
 }
 
 #endif // MEMREF_BASE

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefInterfaces.h
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefInterfaces.h
@@ -1,0 +1,18 @@
+//===- MemRefInterfaces.h - MemRef Interfaces -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines op interfaces for the MemRef dialect in MLIR.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_MEMREF_MEMREFINTERFACES_H_
+#define MLIR_DIALECT_MEMREF_MEMREFINTERFACES_H_
+
+#include "mlir/Dialect/MemRef/IR/MemRefInterfaces.h.inc"
+
+#endif // MLIR_DIALECT_MEMREF_MEMREFINTERFACES_H_

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefInterfaces.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefInterfaces.td
@@ -1,0 +1,49 @@
+//===- MemRefInterfaces.td - Memref dialect interfaces -----*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MEMREF_INTERFACES
+#define MEMREF_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def AliasAnalysisOpInterface : OpInterface<"AliasAnalysisOpInterface"> {
+  let description = [{
+    An interface for memory operations that can carry alias analysis metadata.
+    It provides setters and getters for the operation's alias analysis
+    attributes.
+  }];
+
+  let cppNamespace = "::mlir::memref";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/        "Returns the alias attribute or nullptr",
+      /*returnType=*/  "::mlir::memref::AliasingAttr",
+      /*methodName=*/  "getAliasingAttr",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        return op.getAliasAttr();
+      }]
+      >,
+    InterfaceMethod<
+      /*desc=*/        "Sets the alias attribute",
+      /*returnType=*/  "void",
+      /*methodName=*/  "setAliasingAttr",
+      /*args=*/        (ins "::mlir::memref::AliasingAttr":$attr),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        op.setAliasAttr(attr);
+      }]
+      >
+  ];
+}
+
+#endif // MEMREF_INTERFACES

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -465,12 +465,13 @@ def MemRef_AliasDomainScopeOp : MemRef_Op<"alias_domain_scope", [
     TBD
   }];
 
-  let arguments = (ins MemRef_AliasScopeDomainAttr:$domain);
+  let arguments = (ins OptionalAttr<StrAttr>:$description);
   let results = (outs Variadic<AnyType>:$results);
 
   let regions = (region SizedRegion<1>:$region);
 
-  let assemblyFormat = "attr-dict $domain (`->` type($results)^)? $region";
+  let assemblyFormat =
+      "( $description^ )? (`->` type($results)^)? $region attr-dict";
 
   let extraClassDeclaration = [{
     /// Inline op body into parent region and erase the op.

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -497,7 +497,7 @@ def MemRef_AliasDomainScopeOp : MemRef_Op<"alias_domain_scope", [
 
   let extraClassDeclaration = [{
     /// Inline op body into parent region and erase the op.
-    static void inlineIntoParent(PatternRewriter &builder, AliasDomainScopeOp op);
+    static void inlineIntoParent(RewriterBase &builder, AliasDomainScopeOp op);
   }];
 }
 

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -11,6 +11,7 @@
 
 include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "mlir/Dialect/MemRef/IR/MemRefBase.td"
+include "mlir/Dialect/MemRef/IR/MemRefAttrs.td"
 include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/CopyOpInterface.td"
@@ -154,7 +155,7 @@ def AssumeAlignmentOp : MemRef_Op<"assume_alignment", [
       The `assume_alignment` operation takes a memref and an integer alignment
       value. It returns a new SSA value of the same memref type, but associated
       with the assumption that the underlying buffer is aligned to the given
-      alignment. 
+      alignment.
 
       If the buffer isn't aligned to the given alignment, its result is poison.
       This operation doesn't affect the semantics of a program where the
@@ -169,7 +170,7 @@ def AssumeAlignmentOp : MemRef_Op<"assume_alignment", [
   let assemblyFormat = "$memref `,` $alignment attr-dict `:` type($memref)";
   let extraClassDeclaration = [{
     MemRefType getType() { return ::llvm::cast<MemRefType>(getResult().getType()); }
-    
+
     Value getViewSource() { return getMemref(); }
   }];
 
@@ -446,6 +447,57 @@ def MemRef_AllocaScopeReturnOp : MemRef_Op<"alloca_scope.return",
 
   let arguments = (ins Variadic<AnyType>:$results);
   let builders = [OpBuilder<(ins), [{ /*nothing to do */ }]>];
+
+  let assemblyFormat = "attr-dict ($results^ `:` type($results))?";
+}
+
+//===----------------------------------------------------------------------===//
+// AliasDomainScopeOp
+//===----------------------------------------------------------------------===//
+
+def MemRef_AliasDomainScopeOp : MemRef_Op<"alias_domain_scope", [
+    DeclareOpInterfaceMethods<RegionBranchOpInterface>,
+    SingleBlockImplicitTerminator<"AliasDomainScopeReturnOp">,
+    RecursiveMemoryEffects]> {
+  let summary = "TBD";
+  let description = [{
+    TBD
+  }];
+
+  let arguments = (ins MemRef_AliasScopeDomainAttr:$domain);
+  let results = (outs Variadic<AnyType>:$results);
+
+  let regions = (region SizedRegion<1>:$region);
+
+  let assemblyFormat = "attr-dict $domain (`->` type($results)^)? $region";
+
+//  let extraClassDeclaration = [{
+//    /// Inline op body into parent region and erase the op.
+//    static void inlineIntoParent(::mlir::PatternRewriter &builder, EnvironmentRegionOp op);
+//  }];
+//
+//  let builders = [
+//    OpBuilder<(ins "::mlir::Attribute":$environment,
+//      CArg<"::mlir::ValueRange", "std::nullopt">:$args,
+//      CArg<"::mlir::TypeRange", "std::nullopt">:$results,
+//      CArg<"::llvm::function_ref<void(::mlir::OpBuilder &, ::mlir::Location)>", "nullptr">)>
+//  ];
+//
+//  let hasCanonicalizer = 1;
+}
+
+def MemRef_AliasDomainScopeReturnOp : MemRef_Op<"alias_domain_scope.return", [
+  Pure, ReturnLike, Terminator,
+  HasParent<"AliasDomainScopeOp">
+  ]> {
+
+  let summary = "TBD";
+  let description = [{
+    TBD
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$results);
+  let builders = [OpBuilder<(ins), [{ /* nothing to do */ }]>];
 
   let assemblyFormat = "attr-dict ($results^ `:` type($results))?";
 }

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -470,20 +470,6 @@ def MemRef_AliasDomainScopeOp : MemRef_Op<"alias_domain_scope", [
   let regions = (region SizedRegion<1>:$region);
 
   let assemblyFormat = "attr-dict $domain (`->` type($results)^)? $region";
-
-//  let extraClassDeclaration = [{
-//    /// Inline op body into parent region and erase the op.
-//    static void inlineIntoParent(::mlir::PatternRewriter &builder, EnvironmentRegionOp op);
-//  }];
-//
-//  let builders = [
-//    OpBuilder<(ins "::mlir::Attribute":$environment,
-//      CArg<"::mlir::ValueRange", "std::nullopt">:$args,
-//      CArg<"::mlir::TypeRange", "std::nullopt">:$results,
-//      CArg<"::llvm::function_ref<void(::mlir::OpBuilder &, ::mlir::Location)>", "nullptr">)>
-//  ];
-//
-//  let hasCanonicalizer = 1;
 }
 
 def MemRef_AliasDomainScopeReturnOp : MemRef_Op<"alias_domain_scope.return", [
@@ -1285,34 +1271,38 @@ def LoadOp : MemRef_Op<"load",
                        Variadic<Index>:$indices,
                        DefaultValuedOptionalAttr<BoolAttr, "false">:$nontemporal,
                        ConfinedAttr<OptionalAttr<I64Attr>,
-                                    [AllAttrOf<[IntPositive, IntPowerOf2]>]>:$alignment);
+                                    [AllAttrOf<[IntPositive, IntPowerOf2]>]>:$alignment,
+                       OptionalAttr<MemRef_AliasingAttr>:$alias);
 
   let builders = [
     OpBuilder<(ins "Value":$memref,
                    "ValueRange":$indices,
                    CArg<"bool", "false">:$nontemporal,
-                   CArg<"uint64_t", "0">:$alignment), [{
+                   CArg<"uint64_t", "0">:$alignment,
+                   CArg<"AliasingAttr", "nullptr">:$alias), [{
       return build($_builder, $_state, memref, indices, nontemporal,
                    alignment != 0 ? $_builder.getI64IntegerAttr(alignment) :
-                                    nullptr);
+                                    nullptr, alias);
     }]>,
     OpBuilder<(ins "Type":$resultType,
                    "Value":$memref,
                    "ValueRange":$indices,
                    CArg<"bool", "false">:$nontemporal,
-                   CArg<"uint64_t", "0">:$alignment), [{
+                   CArg<"uint64_t", "0">:$alignment,
+                   CArg<"AliasingAttr", "nullptr">:$alias), [{
       return build($_builder, $_state, resultType, memref, indices, nontemporal,
                    alignment != 0 ? $_builder.getI64IntegerAttr(alignment) :
-                                    nullptr);
+                                    nullptr, alias);
     }]>,
     OpBuilder<(ins "TypeRange":$resultTypes,
                    "Value":$memref,
                    "ValueRange":$indices,
                    CArg<"bool", "false">:$nontemporal,
-                   CArg<"uint64_t", "0">:$alignment), [{
+                   CArg<"uint64_t", "0">:$alignment,
+                   CArg<"AliasingAttr", "nullptr">:$alias), [{
       return build($_builder, $_state, resultTypes, memref, indices, nontemporal,
                    alignment != 0 ? $_builder.getI64IntegerAttr(alignment) :
-                                    nullptr);
+                                    nullptr, alias);
     }]>
   ];
 
@@ -2019,17 +2009,19 @@ def MemRef_StoreOp : MemRef_Op<"store",
                        Variadic<Index>:$indices,
                        DefaultValuedOptionalAttr<BoolAttr, "false">:$nontemporal,
                        ConfinedAttr<OptionalAttr<I64Attr>,
-                                    [AllAttrOf<[IntPositive, IntPowerOf2]>]>:$alignment);
+                                    [AllAttrOf<[IntPositive, IntPowerOf2]>]>:$alignment,
+                       OptionalAttr<MemRef_AliasingAttr>:$alias);
 
   let builders = [
     OpBuilder<(ins "Value":$valueToStore,
                    "Value":$memref,
                    "ValueRange":$indices,
                    CArg<"bool", "false">:$nontemporal,
-                   CArg<"uint64_t", "0">:$alignment), [{
+                   CArg<"uint64_t", "0">:$alignment,
+                   CArg<"AliasingAttr", "nullptr">:$alias), [{
       return build($_builder, $_state, valueToStore, memref, indices, nontemporal,
                    alignment != 0 ? $_builder.getI64IntegerAttr(alignment) :
-                                    nullptr);
+                                    nullptr, alias);
     }]>,
     OpBuilder<(ins "Value":$valueToStore, "Value":$memref), [{
       $_state.addOperands(valueToStore);

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -459,10 +459,32 @@ def MemRef_AllocaScopeReturnOp : MemRef_Op<"alloca_scope.return",
 def MemRef_AliasDomainScopeOp : MemRef_Op<"alias_domain_scope", [
     DeclareOpInterfaceMethods<RegionBranchOpInterface>,
     SingleBlockImplicitTerminator<"AliasDomainScopeReturnOp">,
-    RecursiveMemoryEffects]> {
-  let summary = "TBD";
+    RecursiveMemoryEffects,
+    NoRegionArguments]> {
+  let summary = "aliasing domain scope for alias_scope annotations";
   let description = [{
-    TBD
+    Defines a domain that will be associated with an alias scope for the ops
+    inside the region. In case of multiple nested `alias_domain_scope` ops the
+    innermost will take the precence.
+
+    Example:
+    ```
+    #alias_scope1 = #memref.alias_scope<id = distinct[0]<>, description = "scope">
+    #alias_scope2 = #memref.alias_scope<id = distinct[1]<>>
+
+    func.func @memref_alias_scope(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
+      %0 = memref.alias_domain_scope "The Domain" -> f32 {
+        %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope1], noalias=[#alias_scope2]> } : memref<?xf32>
+        memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope2], noalias=[#alias_scope1]> } : memref<?xf32>
+        memref.alias_domain_scope.return %val: f32
+      }
+      return %0 : f32
+    }
+    ```
+
+    The alias scopes are modeled against LLVM alias scopes, see the following
+    link for more details:
+    https://llvm.org/docs/LangRef.html#noalias-and-alias-scope-metadata
   }];
 
   let arguments = (ins OptionalAttr<StrAttr>:$description);
@@ -484,9 +506,16 @@ def MemRef_AliasDomainScopeReturnOp : MemRef_Op<"alias_domain_scope.return", [
   HasParent<"AliasDomainScopeOp">
   ]> {
 
-  let summary = "TBD";
+  let summary = "terminator for alias_domain_scope operation";
   let description = [{
-    TBD
+    `memref.alias_domain_scope.return` operation returns zero or more SSA values
+    from the region within `memref.alias_domain_scope`. If no values are returned,
+    the return operation may be omitted. Otherwise, it has to be present
+    to indicate which values are going to be returned. For example:
+
+    ```mlir
+    memref.alias_domain_scope.return %value
+    ```
   }];
 
   let arguments = (ins Variadic<AnyType>:$results);

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -10,8 +10,11 @@
 #define MEMREF_OPS
 
 include "mlir/Dialect/Arith/IR/ArithBase.td"
-include "mlir/Dialect/MemRef/IR/MemRefBase.td"
 include "mlir/Dialect/MemRef/IR/MemRefAttrs.td"
+include "mlir/Dialect/MemRef/IR/MemRefBase.td"
+include "mlir/Dialect/MemRef/IR/MemRefInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/CopyOpInterface.td"
@@ -21,8 +24,6 @@ include "mlir/Interfaces/MemorySlotInterfaces.td"
 include "mlir/Interfaces/ShapedOpInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
-include "mlir/IR/OpAsmInterface.td"
-include "mlir/IR/SymbolInterfaces.td"
 
 /// A TypeAttr for memref types.
 def MemRefTypeAttr
@@ -1234,7 +1235,8 @@ def LoadOp : MemRef_Op<"load",
                      "::llvm::cast<MemRefType>($_self).getElementType()">,
       MemRefsNormalizable,
       DeclareOpInterfaceMethods<PromotableMemOpInterface>,
-      DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>]> {
+      DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+      DeclareOpInterfaceMethods<AliasAnalysisOpInterface>]> {
   let summary = "load operation";
   let description = [{
     The `load` op reads an element from a memref at the specified indices.
@@ -1974,7 +1976,8 @@ def MemRef_StoreOp : MemRef_Op<"store",
                      "::llvm::cast<MemRefType>($_self).getElementType()">,
       MemRefsNormalizable,
       DeclareOpInterfaceMethods<PromotableMemOpInterface>,
-      DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>]> {
+      DeclareOpInterfaceMethods<DestructurableAccessorOpInterface>,
+      DeclareOpInterfaceMethods<AliasAnalysisOpInterface>]> {
   let summary = "store operation";
   let description = [{
     The `store` op stores an element into a memref at the specified indices.

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -1296,8 +1296,14 @@ def LoadOp : MemRef_Op<"load",
     memory at an address aligned to this boundary. Violations may lead to
     architecture-specific faults or performance penalties.
     A value of 0 indicates no specific alignment requirement.
-    Example:
 
+    An optional `alias` attribute allows to specify the aliasing metadata for
+    the op and works in conjunction with `alias_domain_scope` op. If attribute
+    is missing op is assumed to potentially alias with any other load or store
+    op. Dropping this attribute during the transformations is safe and can only
+    result in missing optimizations.
+
+    Example:
     ```mlir
     %0 = memref.load %A[%a, %b] : memref<8x?xi32, #layout, memspace0>
     ```
@@ -2034,8 +2040,14 @@ def MemRef_StoreOp : MemRef_Op<"store",
     memory at an address aligned to this boundary. Violations may lead to
     architecture-specific faults or performance penalties.
     A value of 0 indicates no specific alignment requirement.
-    Example:
 
+    An optional `alias` attribute allows to specify the aliasing metadata for
+    the op and works in conjunction with `alias_domain_scope` op. If attribute
+    is missing op is assumed to potentially alias with any other load or store
+    op. Dropping this attribute during the transformations is safe and can only
+    result in missing optimizations.
+
+    Example:
     ```mlir
     memref.store %val, %A[%a, %b] : memref<8x?xi32, #layout, memspace0>
     ```

--- a/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
+++ b/mlir/include/mlir/Dialect/MemRef/IR/MemRefOps.td
@@ -471,6 +471,11 @@ def MemRef_AliasDomainScopeOp : MemRef_Op<"alias_domain_scope", [
   let regions = (region SizedRegion<1>:$region);
 
   let assemblyFormat = "attr-dict $domain (`->` type($results)^)? $region";
+
+  let extraClassDeclaration = [{
+    /// Inline op body into parent region and erase the op.
+    static void inlineIntoParent(PatternRewriter &builder, AliasDomainScopeOp op);
+  }];
 }
 
 def MemRef_AliasDomainScopeReturnOp : MemRef_Op<"alias_domain_scope.return", [

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -2109,7 +2109,6 @@ struct ConvertMemRefAliasAttributesToLLVMPass
     MLIRContext *ctx = &getContext();
     llvm::SmallDenseMap<memref::AliasDomainScopeOp, LLVM::AliasScopeDomainAttr>
         aliasScopeMap;
-    SmallVector<memref::AliasDomainScopeOp> aliasScopeOps;
     auto visitor = [&](memref::AliasAnalysisOpInterface aliasOp) -> WalkResult {
       memref::AliasingAttr aliasingAttr = aliasOp.getAliasingAttr();
       if (!aliasingAttr)
@@ -2127,7 +2126,6 @@ struct ConvertMemRefAliasAttributesToLLVMPass
         domain =
             LLVM::AliasScopeDomainAttr::get(ctx, scope.getDescriptionAttr());
         aliasScopeMap[scope] = domain;
-        aliasScopeOps.push_back(scope);
       }
 
       auto convertScope = [&](Attribute scope) -> Attribute {
@@ -2151,8 +2149,9 @@ struct ConvertMemRefAliasAttributesToLLVMPass
       return signalPassFailure();
 
     TrivialPatternRewriter rewriter(ctx);
-    for (memref::AliasDomainScopeOp scope : aliasScopeOps)
+    op->walk([&](memref::AliasDomainScopeOp scope) {
       memref::AliasDomainScopeOp::inlineIntoParent(rewriter, scope);
+    });
   }
 };
 

--- a/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
+++ b/mlir/lib/Conversion/MemRefToLLVM/MemRefToLLVM.cpp
@@ -2093,11 +2093,6 @@ struct FinalizeMemRefToLLVMConversionPass
   }
 };
 
-struct TrivialPatternRewriter : public PatternRewriter {
-  explicit TrivialPatternRewriter(MLIRContext *context)
-      : PatternRewriter(context) {}
-};
-
 struct ConvertMemRefAliasAttributesToLLVMPass
     : public impl::ConvertMemRefAliasAttributesToLLVMPassBase<
           ConvertMemRefAliasAttributesToLLVMPass> {
@@ -2148,7 +2143,7 @@ struct ConvertMemRefAliasAttributesToLLVMPass
     if (op->walk(visitor).wasInterrupted())
       return signalPassFailure();
 
-    TrivialPatternRewriter rewriter(ctx);
+    PatternRewriter rewriter(ctx);
     op->walk([&](memref::AliasDomainScopeOp scope) {
       memref::AliasDomainScopeOp::inlineIntoParent(rewriter, scope);
     });

--- a/mlir/lib/Dialect/MemRef/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/MemRef/IR/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRMemRefDialect
+  MemRefAttrs.cpp
   MemRefDialect.cpp
   MemRefMemorySlot.cpp
   MemRefOps.cpp
@@ -9,6 +10,7 @@ add_mlir_dialect_library(MLIRMemRefDialect
 
   DEPENDS
   MLIRMemRefOpsIncGen
+  MLIRMemRefAttrsIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/MemRef/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/MemRef/IR/CMakeLists.txt
@@ -9,8 +9,9 @@ add_mlir_dialect_library(MLIRMemRefDialect
   ${PROJECT_SOURCE_DIR}/inlude/mlir/Dialect/MemRefDialect
 
   DEPENDS
-  MLIRMemRefOpsIncGen
   MLIRMemRefAttrsIncGen
+  MLIRMemRefInterfacesIncGen
+  MLIRMemRefOpsIncGen
 
   LINK_LIBS PUBLIC
   MLIRArithDialect

--- a/mlir/lib/Dialect/MemRef/IR/MemRefAttrs.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefAttrs.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/MemRef/IR/MemRefAttrs.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+
+using namespace mlir;
+
+LogicalResult mlir::memref::AliasScopeAttr::verify(
+    function_ref<InFlightDiagnostic()> emitError, Attribute id,
+    StringAttr description) {
+  (void)description;
+  if (!isa<StringAttr, DistinctAttr>(id))
+    return emitError()
+           << "id of an alias scope must be a StringAttr or a DistrinctAttr";
+
+  return success();
+}

--- a/mlir/lib/Dialect/MemRef/IR/MemRefDialect.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefDialect.cpp
@@ -25,6 +25,8 @@
 #define GET_ATTRDEF_CLASSES
 #include "mlir/Dialect/MemRef/IR/MemRefAttrs.cpp.inc"
 
+#include "mlir/Dialect/MemRef/IR/MemRefInterfaces.cpp.inc"
+
 using namespace mlir;
 using namespace mlir::memref;
 

--- a/mlir/lib/Dialect/MemRef/IR/MemRefDialect.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefDialect.cpp
@@ -10,13 +10,20 @@
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
 #include "mlir/Dialect/Bufferization/IR/AllocationOpInterface.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/IR/MemRefAttrs.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectImplementation.h"
 #include "mlir/Interfaces/MemorySlotInterfaces.h"
 #include "mlir/Interfaces/RuntimeVerifiableOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Interfaces/ValueBoundsOpInterface.h"
 #include "mlir/Transforms/InliningUtils.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include <optional>
+
+#define GET_ATTRDEF_CLASSES
+#include "mlir/Dialect/MemRef/IR/MemRefAttrs.cpp.inc"
 
 using namespace mlir;
 using namespace mlir::memref;
@@ -45,6 +52,10 @@ void mlir::memref::MemRefDialect::initialize() {
   addOperations<
 #define GET_OP_LIST
 #include "mlir/Dialect/MemRef/IR/MemRefOps.cpp.inc"
+      >();
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "mlir/Dialect/MemRef/IR/MemRefAttrs.cpp.inc"
       >();
   addInterfaces<MemRefInlinerInterface>();
   declarePromisedInterface<ConvertToEmitCPatternInterface, MemRefDialect>();

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -519,6 +519,27 @@ void AllocaScopeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 //===----------------------------------------------------------------------===//
+// AliasDomainScopeOp
+//===----------------------------------------------------------------------===//
+
+/// Given the region at `index`, or the parent operation if `index` is None,
+/// return the successor regions. These are the regions that may be selected
+/// during the flow of control. `operands` is a set of optional attributes that
+/// correspond to a constant value for each operand, or null if that operand is
+/// not a constant.
+void AliasDomainScopeOp::getSuccessorRegions(
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  // If the predecessor is the ExecuteRegionOp, branch into the body.
+  if (point.isParent()) {
+    regions.push_back(RegionSuccessor(&getRegion()));
+    return;
+  }
+
+  // Otherwise, the region branches back to the parent operation.
+  regions.push_back(RegionSuccessor(getResults()));
+}
+
+//===----------------------------------------------------------------------===//
 // AssumeAlignmentOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -539,6 +539,16 @@ void AliasDomainScopeOp::getSuccessorRegions(
   regions.push_back(RegionSuccessor(getResults()));
 }
 
+void AliasDomainScopeOp::inlineIntoParent(mlir::PatternRewriter &builder,
+                                          AliasDomainScopeOp op) {
+  mlir::Block *block = &op.getRegion().front();
+  Operation *term = block->getTerminator();
+  SmallVector<Value> args = llvm::to_vector(term->getOperands());
+  builder.eraseOp(term);
+  builder.inlineBlockBefore(block, op);
+  builder.replaceOp(op, args);
+}
+
 //===----------------------------------------------------------------------===//
 // AssumeAlignmentOp
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
+++ b/mlir/lib/Dialect/MemRef/IR/MemRefOps.cpp
@@ -539,7 +539,7 @@ void AliasDomainScopeOp::getSuccessorRegions(
   regions.push_back(RegionSuccessor(getResults()));
 }
 
-void AliasDomainScopeOp::inlineIntoParent(mlir::PatternRewriter &builder,
+void AliasDomainScopeOp::inlineIntoParent(RewriterBase &builder,
                                           AliasDomainScopeOp op) {
   mlir::Block *block = &op.getRegion().front();
   Operation *term = block->getTerminator();

--- a/mlir/test/Conversion/MemRefToLLVM/memref-alias-attrs-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-alias-attrs-to-llvm.mlir
@@ -1,21 +1,34 @@
 // RUN: mlir-opt --convert-memref-alias-attributes-to-llvm %s | FileCheck %s
 
-#alias_scope_domain = #memref.alias_scope_domain<id = distinct[0]<>, description = "The domain">
 #alias_scope1 = #memref.alias_scope<id = distinct[1]<>, description = "scope">
 #alias_scope2 = #memref.alias_scope<id = distinct[2]<>>
 
-// CHECK: #[[DOMAIN:.*]] = #llvm.alias_scope_domain<id = distinct[0]<>, description = "The domain">
-// CHECK-DAG: #[[SCOPE1:.*]] = #llvm.alias_scope<id = distinct[1]<>, domain = #[[DOMAIN]], description = "scope">
-// CHECK-DAG: #[[SCOPE2:.*]] = #llvm.alias_scope<id = distinct[2]<>, domain = #[[DOMAIN]]>
+// CHECK-DAG: #[[DOMAIN1:.*]] = #llvm.alias_scope_domain<id = {{.*}}, description = "foo">
+// CHECK-DAG: #[[DOMAIN2:.*]] = #llvm.alias_scope_domain<id = {{.*}}>
+// CHECK-DAG: #[[SCOPE1_1:.*]] = #llvm.alias_scope<id = {{.*}}, domain = #[[DOMAIN1]], description = "scope">
+// CHECK-DAG: #[[SCOPE1_2:.*]] = #llvm.alias_scope<id = {{.*}}, domain = #[[DOMAIN1]]>
+// CHECK-DAG: #[[SCOPE2_1:.*]] = #llvm.alias_scope<id = {{.*}}, domain = #[[DOMAIN2]], description = "scope">
+// CHECK-DAG: #[[SCOPE2_2:.*]] = #llvm.alias_scope<id = {{.*}}, domain = #[[DOMAIN2]]>
 
 // CHECK: func @memref_alias_attributes
 func.func @memref_alias_attributes(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
-  %0 = memref.alias_domain_scope #alias_scope_domain -> f32 {
-  // CHECK:  %[[VAL:.*]] = memref.load %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE1]]], noalias = [#[[SCOPE2]]]>} : memref<?xf32>
-  // CHECK:  memref.store %[[VAL]], %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE2]]], noalias = [#[[SCOPE1]]]>} : memref<?xf32>
+  // CHECK-NOT: alias_domain_scope
+  memref.alias_domain_scope "foo" {
+  // CHECK:  %[[VAL:.*]] = memref.load %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE1_1]]], noalias = [#[[SCOPE1_2]]]>} : memref<?xf32>
+  // CHECK:  memref.store %[[VAL]], %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE1_2]]], noalias = [#[[SCOPE1_1]]]>} : memref<?xf32>
+    %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope1], noalias=[#alias_scope2]> } : memref<?xf32>
+    memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope2], noalias=[#alias_scope1]> } : memref<?xf32>
+    memref.alias_domain_scope.return
+  }
+
+  // CHECK-NOT: alias_domain_scope
+  %0 = memref.alias_domain_scope -> f32 {
+  // CHECK:  %[[VAL:.*]] = memref.load %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE2_1]]], noalias = [#[[SCOPE2_2]]]>} : memref<?xf32>
+  // CHECK:  memref.store %[[VAL]], %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE2_2]]], noalias = [#[[SCOPE2_1]]]>} : memref<?xf32>
     %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope1], noalias=[#alias_scope2]> } : memref<?xf32>
     memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope2], noalias=[#alias_scope1]> } : memref<?xf32>
     memref.alias_domain_scope.return %val: f32
   }
+  // CHECK: return %[[VAL]]
   return %0 : f32
 }

--- a/mlir/test/Conversion/MemRefToLLVM/memref-alias-attrs-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-alias-attrs-to-llvm.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-opt --convert-memref-alias-attributes-to-llvm %s | FileCheck %s
+
+#alias_scope_domain = #memref.alias_scope_domain<id = distinct[0]<>, description = "The domain">
+#alias_scope1 = #memref.alias_scope<id = distinct[1]<>, description = "scope">
+#alias_scope2 = #memref.alias_scope<id = distinct[2]<>>
+
+// CHECK: #[[DOMAIN:.*]] = #llvm.alias_scope_domain<id = distinct[0]<>, description = "The domain">
+// CHECK-DAG: #[[SCOPE1:.*]] = #llvm.alias_scope<id = distinct[1]<>, domain = #[[DOMAIN]], description = "scope">
+// CHECK-DAG: #[[SCOPE2:.*]] = #llvm.alias_scope<id = distinct[2]<>, domain = #[[DOMAIN]]>
+
+// CHECK: func @memref_alias_attributes
+func.func @memref_alias_attributes(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
+  %0 = memref.alias_domain_scope #alias_scope_domain -> f32 {
+  // CHECK:  %[[VAL:.*]] = memref.load %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE1]]], noalias = [#[[SCOPE2]]]>} : memref<?xf32>
+  // CHECK:  memref.store %[[VAL]], %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE2]]], noalias = [#[[SCOPE1]]]>} : memref<?xf32>
+    %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope1], noalias=[#alias_scope2]> } : memref<?xf32>
+    memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope2], noalias=[#alias_scope1]> } : memref<?xf32>
+    memref.alias_domain_scope.return %val: f32
+  }
+  return %0 : f32
+}

--- a/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
@@ -803,25 +803,20 @@ func.func @alloca_unconvertable_memory_space() {
 
 // -----
 
-#alias_scope_domain = #memref.alias_scope_domain<id = distinct[0]<>, description = "The domain">
 #llvm_domain = #llvm.alias_scope_domain<id = distinct[1]<>, description = "The domain">
 #scope1 = #llvm.alias_scope<id = distinct[2]<>, domain = #llvm_domain, description = "scope">
 #scope2 = #llvm.alias_scope<id = distinct[3]<>, domain = #llvm_domain>
 
-// CHECK: #[[DOMAIN:.*]] = #llvm.alias_scope_domain<id = distinct[0]<>, description = "The domain">
-// CHECK-DAG: #[[SCOPE1:.*]] = #llvm.alias_scope<id = distinct[1]<>, domain = #[[DOMAIN]], description = "scope">
-// CHECK-DAG: #[[SCOPE2:.*]] = #llvm.alias_scope<id = distinct[2]<>, domain = #[[DOMAIN]]>
+// CHECK: #[[DOMAIN:.*]] = #llvm.alias_scope_domain<id = {{.*}}, description = "The domain">
+// CHECK-DAG: #[[SCOPE1:.*]] = #llvm.alias_scope<id = {{.*}}, domain = #[[DOMAIN]], description = "scope">
+// CHECK-DAG: #[[SCOPE2:.*]] = #llvm.alias_scope<id = {{.*}}, domain = #[[DOMAIN]]>
 
 // CHECK: func @memref_alias_attributes
-func.func @memref_alias_attributes(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
+func.func @memref_alias_attributes(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) {
   // CHECK-NOT:  memref.alias_domain_scope
-  %0 = memref.alias_domain_scope #alias_scope_domain -> f32 {
   // CHECK:  %[[VAL:.*]] = llvm.load {{.*}} {alias_scopes = [#[[SCOPE1]]], noalias_scopes = [#[[SCOPE2]]]}
   // CHECK:  llvm.store %[[VAL]], {{.*}} {alias_scopes = [#[[SCOPE2]]], noalias_scopes = [#[[SCOPE1]]]}
-    %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#scope1], noalias=[#scope2]> } : memref<?xf32>
-    memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#scope2], noalias=[#scope1]> } : memref<?xf32>
-    memref.alias_domain_scope.return %val: f32
-  }
-  // CHECK: return %[[VAL]]
-  return %0 : f32
+  %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#scope1], noalias=[#scope2]> } : memref<?xf32>
+  memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#scope2], noalias=[#scope1]> } : memref<?xf32>
+  return
 }

--- a/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
+++ b/mlir/test/Conversion/MemRefToLLVM/memref-to-llvm.mlir
@@ -804,9 +804,9 @@ func.func @alloca_unconvertable_memory_space() {
 // -----
 
 #alias_scope_domain = #memref.alias_scope_domain<id = distinct[0]<>, description = "The domain">
-#llvm_domain = #llvm.alias_scope_domain<id = distinct[0]<>, description = "The domain">
-#scope1 = #llvm.alias_scope<id = distinct[1]<>, domain = #llvm_domain, description = "scope">
-#scope2 = #llvm.alias_scope<id = distinct[2]<>, domain = #llvm_domain>
+#llvm_domain = #llvm.alias_scope_domain<id = distinct[1]<>, description = "The domain">
+#scope1 = #llvm.alias_scope<id = distinct[2]<>, domain = #llvm_domain, description = "scope">
+#scope2 = #llvm.alias_scope<id = distinct[3]<>, domain = #llvm_domain>
 
 // CHECK: #[[DOMAIN:.*]] = #llvm.alias_scope_domain<id = distinct[0]<>, description = "The domain">
 // CHECK-DAG: #[[SCOPE1:.*]] = #llvm.alias_scope<id = distinct[1]<>, domain = #[[DOMAIN]], description = "scope">
@@ -816,11 +816,12 @@ func.func @alloca_unconvertable_memory_space() {
 func.func @memref_alias_attributes(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
   // CHECK-NOT:  memref.alias_domain_scope
   %0 = memref.alias_domain_scope #alias_scope_domain -> f32 {
-  // CHECK:  llvm.load {{.*}} {alias_scopes = [#[[SCOPE1]]], noalias_scopes = [#[[SCOPE2]]]}
-  // CHECK:  llvm.store {{.*}} {alias_scopes = [#[[SCOPE2]]], noalias_scopes = [#[[SCOPE1]]]}
+  // CHECK:  %[[VAL:.*]] = llvm.load {{.*}} {alias_scopes = [#[[SCOPE1]]], noalias_scopes = [#[[SCOPE2]]]}
+  // CHECK:  llvm.store %[[VAL]], {{.*}} {alias_scopes = [#[[SCOPE2]]], noalias_scopes = [#[[SCOPE1]]]}
     %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#scope1], noalias=[#scope2]> } : memref<?xf32>
     memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#scope2], noalias=[#scope1]> } : memref<?xf32>
     memref.alias_domain_scope.return %val: f32
   }
+  // CHECK: return %[[VAL]]
   return %0 : f32
 }

--- a/mlir/test/Dialect/MemRef/ops.mlir
+++ b/mlir/test/Dialect/MemRef/ops.mlir
@@ -624,3 +624,23 @@ func.func @memref_transpose_map(%src : memref<?x?xf32>) -> memref<?x?xf32, affin
   %dst = memref.transpose %src (i, j) -> (j, i) : memref<?x?xf32> to memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>>
   return %dst : memref<?x?xf32, affine_map<(d0, d1)[s0] -> (d1 * s0 + d0)>>
 }
+
+
+#alias_scope_domain = #memref.alias_scope_domain<id = distinct[0]<>, description = "The domain">
+#alias_scope1 = #memref.alias_scope<id = distinct[1]<>, description = "scope">
+#alias_scope2 = #memref.alias_scope<id = distinct[2]<>>
+
+// CHECK-LABEL: func @memref_alias_scope
+func.func @memref_alias_scope(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
+  // CHECK: %[[RES:.*]] = memref.alias_domain_scope #{{.*}} -> f32
+  %0 = memref.alias_domain_scope #alias_scope_domain -> f32 {
+  // CHECK: %[[VAL:.*]] = memref.load %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE1:.*]]], noalias = [#[[SCOPE2:.*]]]>} : memref<?xf32>
+  // CHECK: memref.store %[[VAL]], %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE2]]], noalias = [#[[SCOPE1]]]>} : memref<?xf32>
+  // CHECK: memref.alias_domain_scope.return %[[VAL]] : f32
+    %val = memref.load %arg1[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope1], noalias=[#alias_scope2]> } : memref<?xf32>
+    memref.store %val, %arg2[%arg3] { alias = #memref.aliasing<alias_scopes=[#alias_scope2], noalias=[#alias_scope1]> } : memref<?xf32>
+    memref.alias_domain_scope.return %val: f32
+  }
+  // CHECK: return %[[RES]]
+  return %0 : f32
+}

--- a/mlir/test/Dialect/MemRef/ops.mlir
+++ b/mlir/test/Dialect/MemRef/ops.mlir
@@ -626,14 +626,16 @@ func.func @memref_transpose_map(%src : memref<?x?xf32>) -> memref<?x?xf32, affin
 }
 
 
-#alias_scope_domain = #memref.alias_scope_domain<id = distinct[0]<>, description = "The domain">
-#alias_scope1 = #memref.alias_scope<id = distinct[1]<>, description = "scope">
-#alias_scope2 = #memref.alias_scope<id = distinct[2]<>>
+#alias_scope1 = #memref.alias_scope<id = distinct[0]<>, description = "scope">
+#alias_scope2 = #memref.alias_scope<id = distinct[1]<>>
 
 // CHECK-LABEL: func @memref_alias_scope
 func.func @memref_alias_scope(%arg1 : memref<?xf32>, %arg2 : memref<?xf32>, %arg3: index) -> f32 {
-  // CHECK: %[[RES:.*]] = memref.alias_domain_scope #{{.*}} -> f32
-  %0 = memref.alias_domain_scope #alias_scope_domain -> f32 {
+  // CHECK: memref.alias_domain_scope "The Domain"
+  memref.alias_domain_scope "The Domain" {}
+
+  // CHECK: %[[RES:.*]] = memref.alias_domain_scope -> f32
+  %0 = memref.alias_domain_scope -> f32 {
   // CHECK: %[[VAL:.*]] = memref.load %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE1:.*]]], noalias = [#[[SCOPE2:.*]]]>} : memref<?xf32>
   // CHECK: memref.store %[[VAL]], %{{.*}}[%{{.*}}] {alias = #memref.aliasing<alias_scopes = [#[[SCOPE2]]], noalias = [#[[SCOPE1]]]>} : memref<?xf32>
   // CHECK: memref.alias_domain_scope.return %[[VAL]] : f32


### PR DESCRIPTION
Add aliasing metadata to the memref ops. 

The API is mostly modeled against LLVM `alias_scope` metadata https://llvm.org/docs/LangRef.html#noalias-and-alias-scope-metadata. The notable difference is that alising domain is modeled using region op instead of attribute. Modeling domain using attributes have issues with inlining, as you have to create new domain each time you inline the function and it doesn't compose well with MLIR inlining infra. Using regions for domain limits the API somewhat as unlike LLVM you can only have a single domain attached to the op.

The translation to LLVM dialect now has to be done in 2 steps:
* `--convert-memref-alias-attributes-to-llvm` to convert alias attributes to the corresponding LLVM dialect attributes and erases `alias_domain_scope` ops. It's no longer safe to inline after this point and until translation to LLVM is fully comleted.
* `--finalize-memref-to-llvm` will convert the ops themselves to LLVM as usual.