### PR TITLE
Fix/clang tidy parameter style

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,11 @@ CheckOptions:
   - key:             readability-identifier-naming.MemberCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterCase
-    value:           CamelCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ConstantParameterCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ConstantPointerParameterCase
+    value:           camelBack
   - key:             readability-identifier-naming.UnionCase
     value:           CamelCase
   - key:             readability-identifier-naming.VariableCase

--- a/mlir/.clang-tidy
+++ b/mlir/.clang-tidy
@@ -56,5 +56,7 @@ CheckOptions:
     value:           camelBack
   - key:             readability-identifier-naming.ParameterCase
     value:           camelBack
+  - key:             readability-identifier-naming.ConstantParameterCase
+    value:           camelBack  
   - key:             readability-identifier-naming.VariableCase
     value:           camelBack


### PR DESCRIPTION
Fix #154957 

For the `.clang-tidy` and `mlir/.clang-tidy` explicitly set the `ParameterCase` and `ConstantParameterCase` to `camelBack`.

This avoids relying on implicit or undocumented defaults between `ParameterCase` and `ConstantParameterCase`.

By explicitly defining the cases, we are standardizing the style across all code and reducing the ambiguity.