### PR TITLE
[llvm][test] remove non-posix grep option from many-instructions.s

### DIFF
--- a/llvm/test/MC/ELF/many-instructions.s
+++ b/llvm/test/MC/ELF/many-instructions.s
@@ -1,6 +1,6 @@
 ## Checks the size of an internal MC structure that is different on 32-bit.
 # REQUIRES: asserts, llvm-64-bits
-# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o /dev/null -debug-only=mc-dump 2>&1 | grep -E -o '[0-9]+ Data Size:[0-9]+' | FileCheck %s
+# RUN: llvm-mc -filetype=obj -triple=x86_64 %s -o /dev/null -debug-only=mc-dump 2>&1 | grep -E '[0-9]+ Data Size:[0-9]+' | FileCheck %s
 
 ## Test that encodeInstruction may cause a new fragment to be created.
 # CHECK: 0 Data Size:16220


### PR DESCRIPTION
Not everything uses the built in shell yet, so this non-posix grep option gets passed to the system grep on AIX and causes failures.

The `-o` option just restricts the amount of output in the matching line to just the pattern, so it seems safe to drop here as we will still get the match we are looking for.