### PR TITLE
[lldb] Add some vector operations to the IRInterpreter

### DIFF
--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -138,6 +138,17 @@ public:
       std::shared_ptr<const UnwindPlan> current_unwindplan) {
     return lldb::UnwindPlanSP();
   }
+
+  /// Get the vector element order for this architecture. This determines how
+  /// vector elements are indexed. This matters in a few places such as reading/
+  /// writing LLVM-IR values to/from target memory. Some architectures use
+  /// little-endian element ordering where element 0 is at the lowest address
+  /// even when the architecture is otherwise big-endian (e.g. MIPS MSA, ARM
+  /// NEON), but some architectures like PowerPC may use big-endian element
+  /// ordering where element 0 is at the highest address.
+  virtual lldb::ByteOrder GetVectorElementOrder() const {
+    return lldb::eByteOrderLittle;
+  }
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -141,11 +141,11 @@ public:
 
   /// Get the vector element order for this architecture. This determines how
   /// vector elements are indexed. This matters in a few places such as reading/
-  /// writing LLVM-IR values to/from target memory. Some architectures use
-  /// little-endian element ordering where element 0 is at the lowest address
+  /// writing LLVM-IR values to/from target registers. Some architectures use
+  /// little-endian element ordering where element 0 is at the lowest bits
   /// even when the architecture is otherwise big-endian (e.g. MIPS MSA, ARM
   /// NEON), but some architectures like PowerPC may use big-endian element
-  /// ordering where element 0 is at the highest address.
+  /// ordering where element 0 is at the highest bits.
   virtual lldb::ByteOrder GetVectorElementOrder() const {
     return lldb::eByteOrderLittle;
   }

--- a/lldb/include/lldb/Expression/IRInterpreter.h
+++ b/lldb/include/lldb/Expression/IRInterpreter.h
@@ -17,8 +17,10 @@
 #include "llvm/Pass.h"
 
 namespace llvm {
+class DataLayout;
 class Function;
 class Module;
+class Instruction;
 }
 
 namespace lldb_private {
@@ -37,7 +39,8 @@ class IRInterpreter {
 public:
   static bool CanInterpret(llvm::Module &module, llvm::Function &function,
                            lldb_private::Status &error,
-                           const bool support_function_calls);
+                           const bool support_function_calls,
+                           lldb_private::ExecutionContext &exe_ctx);
 
   static bool Interpret(llvm::Module &module, llvm::Function &function,
                         llvm::ArrayRef<lldb::addr_t> args,
@@ -51,6 +54,12 @@ public:
 private:
   static bool supportsFunction(llvm::Function &llvm_function,
                                lldb_private::Status &err);
+
+  static bool InterpretExtractElement(
+      const llvm::Instruction *inst, class InterpreterStackFrame &frame,
+      const llvm::DataLayout &data_layout, llvm::Module &module,
+      lldb_private::IRExecutionUnit &execution_unit,
+      lldb_private::Status &error, lldb_private::Log *log);
 };
 
 #endif

--- a/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
+++ b/lldb/packages/Python/lldbsuite/test/gdbclientutils.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import ctypes
 import errno
 import io
@@ -5,6 +6,7 @@ import threading
 import socket
 import traceback
 from lldbsuite.support import seven
+from typing import Optional
 
 
 def checksum(message):
@@ -86,8 +88,8 @@ class MockGDBServerResponder:
     handles any packet not recognized in the common packet handling code.
     """
 
-    registerCount = 40
-    packetLog = None
+    registerCount: int = 40
+    packetLog: Optional[list[str]] = None
 
     class RESPONSE_DISCONNECT:
         pass
@@ -103,6 +105,7 @@ class MockGDBServerResponder:
         Return the unframed packet data that the server should issue in response
         to the given packet received from the client.
         """
+        assert self.packetLog is not None
         self.packetLog.append(packet)
         if packet is MockGDBServer.PACKET_INTERRUPT:
             return self.interrupt()
@@ -242,7 +245,7 @@ class MockGDBServerResponder:
     def qHostInfo(self):
         return "ptrsize:8;endian:little;"
 
-    def qEcho(self):
+    def qEcho(self, _: int):
         return "E04"
 
     def qQueryGDBServer(self):
@@ -263,10 +266,10 @@ class MockGDBServerResponder:
     def D(self, packet):
         return "OK"
 
-    def readRegisters(self):
+    def readRegisters(self) -> str:
         return "00000000" * self.registerCount
 
-    def readRegister(self, register):
+    def readRegister(self, register: int) -> str:
         return "00000000"
 
     def writeRegisters(self, registers_hex):
@@ -306,7 +309,8 @@ class MockGDBServerResponder:
         # SIGINT is 2, return type is 2 digit hex string
         return "S02"
 
-    def qXferRead(self, obj, annex, offset, length):
+    def qXferRead(self, obj: str, annex: str, offset: int,
+                  length: int) -> tuple[str | None, bool]:
         return None, False
 
     def _qXferResponse(self, data, has_more):
@@ -374,15 +378,17 @@ class MockGDBServerResponder:
         pass
 
 
-class ServerChannel:
+class ServerChannel(ABC):
     """
     A wrapper class for TCP or pty-based server.
     """
 
-    def get_connect_address(self):
+    @abstractmethod
+    def get_connect_address(self) -> str:
         """Get address for the client to connect to."""
 
-    def get_connect_url(self):
+    @abstractmethod
+    def get_connect_url(self) -> str:
         """Get URL suitable for process connect command."""
 
     def close_server(self):
@@ -394,10 +400,12 @@ class ServerChannel:
     def close_connection(self):
         """Close all resources used by the accepted connection."""
 
-    def recv(self):
+    @abstractmethod
+    def recv(self) -> bytes:
         """Receive a data packet from the connected client."""
 
-    def sendall(self, data):
+    @abstractmethod
+    def sendall(self, data: bytes) -> None:
         """Send the data to the connected client."""
 
 
@@ -428,11 +436,11 @@ class ServerSocket(ServerChannel):
         self._connection.close()
         self._connection = None
 
-    def recv(self):
+    def recv(self) -> bytes:
         assert self._connection is not None
         return self._connection.recv(4096)
 
-    def sendall(self, data):
+    def sendall(self, data: bytes) -> None:
         assert self._connection is not None
         return self._connection.sendall(data)
 
@@ -444,10 +452,10 @@ class TCPServerSocket(ServerSocket):
         )[0]
         super().__init__(family, type, proto, addr)
 
-    def get_connect_address(self):
+    def get_connect_address(self) -> str:
         return "[{}]:{}".format(*self._server_socket.getsockname())
 
-    def get_connect_url(self):
+    def get_connect_url(self) -> str:
         return "connect://" + self.get_connect_address()
 
 
@@ -455,10 +463,10 @@ class UnixServerSocket(ServerSocket):
     def __init__(self, addr):
         super().__init__(socket.AF_UNIX, socket.SOCK_STREAM, 0, addr)
 
-    def get_connect_address(self):
+    def get_connect_address(self) -> str:
         return self._server_socket.getsockname()
 
-    def get_connect_url(self):
+    def get_connect_url(self) -> str:
         return "unix-connect://" + self.get_connect_address()
 
 
@@ -472,7 +480,7 @@ class PtyServerSocket(ServerChannel):
         self._primary = io.FileIO(primary, "r+b")
         self._secondary = io.FileIO(secondary, "r+b")
 
-    def get_connect_address(self):
+    def get_connect_address(self) -> str:
         libc = ctypes.CDLL(None)
         libc.ptsname.argtypes = (ctypes.c_int,)
         libc.ptsname.restype = ctypes.c_char_p
@@ -485,7 +493,7 @@ class PtyServerSocket(ServerChannel):
         self._secondary.close()
         self._primary.close()
 
-    def recv(self):
+    def recv(self) -> bytes:
         try:
             return self._primary.read(4096)
         except OSError as e:
@@ -494,8 +502,8 @@ class PtyServerSocket(ServerChannel):
                 return b""
             raise
 
-    def sendall(self, data):
-        return self._primary.write(data)
+    def sendall(self, data: bytes) -> None:
+        self._primary.write(data)
 
 
 class MockGDBServer:
@@ -528,18 +536,21 @@ class MockGDBServer:
             self._thread.join()
             self._thread = None
 
-    def get_connect_address(self):
+    def get_connect_address(self) -> str:
+        assert self._socket is not None
         return self._socket.get_connect_address()
 
-    def get_connect_url(self):
+    def get_connect_url(self) -> str:
+        assert self._socket is not None
         return self._socket.get_connect_url()
 
     def run(self):
+        assert self._socket is not None
         # For testing purposes, we only need to worry about one client
         # connecting just one time.
         try:
             self._socket.accept()
-        except:
+        except Exception:
             traceback.print_exc()
             return
         self._shouldSendAck = True
@@ -554,7 +565,7 @@ class MockGDBServer:
                 self._receive(data)
         except self.TerminateConnectionException:
             pass
-        except Exception as e:
+        except Exception:
             print(
                 "An exception happened when receiving the response from the gdb server. Closing the client..."
             )
@@ -587,7 +598,9 @@ class MockGDBServer:
         Once a complete packet is found at the front of self._receivedData,
         its data is removed form self._receivedData.
         """
+        assert self._receivedData is not None
         data = self._receivedData
+        assert self._receivedDataOffset is not None
         i = self._receivedDataOffset
         data_len = len(data)
         if data_len == 0:
@@ -640,10 +653,13 @@ class MockGDBServer:
         self._receivedDataOffset = 0
         return packet
 
-    def _sendPacket(self, packet):
-        self._socket.sendall(seven.bitcast_to_bytes(frame_packet(packet)))
+    def _sendPacket(self, packet: str):
+        assert self._socket is not None
+        framed_packet = seven.bitcast_to_bytes(frame_packet(packet))
+        self._socket.sendall(framed_packet)
 
     def _handlePacket(self, packet):
+        assert self._socket is not None
         if packet is self.PACKET_ACK:
             # Ignore ACKs from the client. For the future, we can consider
             # adding validation code to make sure the client only sends ACKs

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -1369,6 +1369,24 @@ public:
       return;
     }
 
+    // Check for unsupported vector element ordering
+    if (m_register_info.encoding == lldb::eEncodingVector) {
+      ExecutionContext exe_ctx;
+      frame_sp->CalculateExecutionContext(exe_ctx);
+      if (exe_ctx.GetTargetPtr()) {
+        const auto *arch_plugin =
+            exe_ctx.GetTargetRef().GetArchitecturePlugin();
+        if (arch_plugin &&
+            arch_plugin->GetVectorElementOrder() == lldb::eByteOrderBig) {
+          err = Status::FromErrorStringWithFormat(
+              "unable to materialize register %s: vector registers with "
+              "big-endian element ordering are not yet supported",
+              m_register_info.name);
+          return;
+        }
+      }
+    }
+
     lldb::RegisterContextSP reg_context_sp = frame_sp->GetRegisterContext();
 
     if (!reg_context_sp->ReadRegister(&m_register_info, reg_value)) {
@@ -1429,6 +1447,24 @@ public:
           "couldn't dematerialize register %s without a stack frame",
           m_register_info.name);
       return;
+    }
+
+    // Check for unsupported vector element ordering
+    if (m_register_info.encoding == lldb::eEncodingVector) {
+      ExecutionContext exe_ctx;
+      frame_sp->CalculateExecutionContext(exe_ctx);
+      if (exe_ctx.GetTargetPtr()) {
+        const auto *arch_plugin =
+            exe_ctx.GetTargetRef().GetArchitecturePlugin();
+        if (arch_plugin &&
+            arch_plugin->GetVectorElementOrder() == lldb::eByteOrderBig) {
+          err = Status::FromErrorStringWithFormat(
+              "unable to dematerialize register %s: vector registers with "
+              "big-endian element ordering are not yet supported",
+              m_register_info.name);
+          return;
+        }
+      }
     }
 
     lldb::RegisterContextSP reg_context_sp = frame_sp->GetRegisterContext();

--- a/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.cpp
+++ b/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.cpp
@@ -35,7 +35,8 @@ void ArchitecturePPC64::Terminate() {
 std::unique_ptr<Architecture> ArchitecturePPC64::Create(const ArchSpec &arch) {
   if (arch.GetTriple().isPPC64() &&
       arch.GetTriple().getObjectFormat() == llvm::Triple::ObjectFormatType::ELF)
-    return std::unique_ptr<Architecture>(new ArchitecturePPC64());
+    return std::unique_ptr<Architecture>(
+        new ArchitecturePPC64(arch.GetByteOrder()));
   return nullptr;
 }
 
@@ -59,4 +60,8 @@ void ArchitecturePPC64::AdjustBreakpointAddress(const Symbol &func,
     return;
 
   addr.SetOffset(addr.GetOffset() + loffs);
+}
+
+lldb::ByteOrder ArchitecturePPC64::GetVectorElementOrder() const {
+  return m_vector_element_order;
 }

--- a/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.h
+++ b/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.h
@@ -30,9 +30,14 @@ public:
   void AdjustBreakpointAddress(const Symbol &func,
                                Address &addr) const override;
 
+  lldb::ByteOrder GetVectorElementOrder() const override;
+
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);
-  ArchitecturePPC64() = default;
+  ArchitecturePPC64(lldb::ByteOrder vector_element_order)
+      : m_vector_element_order(vector_element_order) {}
+
+  lldb::ByteOrder m_vector_element_order;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1523,7 +1523,7 @@ lldb_private::Status ClangExpressionParser::DoPrepareForExecution(
           !process ? false : process->CanInterpretFunctionCalls();
       can_interpret = IRInterpreter::CanInterpret(
           *execution_unit_sp->GetModule(), *execution_unit_sp->GetFunction(),
-          interpret_error, interpret_function_calls);
+          interpret_error, interpret_function_calls, exe_ctx);
 
       if (!can_interpret && execution_policy == eExecutionPolicyNever) {
         err = Status::FromErrorStringWithFormat(

--- a/lldb/test/API/commands/expression/expr-vec-elt-order/TestExprVectorElementOrder.py
+++ b/lldb/test/API/commands/expression/expr-vec-elt-order/TestExprVectorElementOrder.py
@@ -1,0 +1,313 @@
+""" Check that registers written to memory for expression evaluation are
+    written using the target's endian not the host's.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from textwrap import dedent
+import lldb
+from lldbsuite.test.lldbtest import lldbutil
+from lldbsuite.test.decorators import (
+    skipIfXmlSupportMissing,
+    skipIfRemote,
+    skipIfLLVMTargetMissing,
+)
+from lldbsuite.test.gdbclientutils import MockGDBServerResponder
+from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
+
+
+class Endian(Enum):
+    BIG = 0
+    LITTLE = 1
+
+
+class ElementOrder(Enum):
+    # Memory is laid out as [0, 1, ... N-1]
+    ZEROFIRST = 0
+    # Memory is laid out as [N-1, N-2, ..., 0]
+    LASTFIRST = 1
+
+
+@dataclass
+class Config:
+    architecture: str
+    pc_reg_name: str
+    yaml_file: str
+    data: str
+    machine: str
+    endian: Endian
+    element_order: ElementOrder
+
+
+class Responder(MockGDBServerResponder):
+    def __init__(self, doc: str, endian: Endian, element_order: ElementOrder):
+        super().__init__()
+        self.target_xml = doc
+        self.endian = endian
+        self.element_order = element_order
+
+    def qXferRead(self, obj, annex, offset, length) -> tuple[str | None, bool]:
+        if obj == 'features' and annex == "target.xml":
+            more = offset + length < len(self.target_xml)
+            return self.target_xml[offset:offset+length], more
+        return (None, False)
+
+    def readRegister(self, register: int) -> str:
+        _ = register # Silence unused parameter hint
+        return "E01"
+
+    def readRegisters(self) -> str:
+        # 64 bit pc value.
+        data = ["00", "00", "00", "00", "00", "00", "12", "34"]
+        if self.endian == Endian.LITTLE:
+            data.reverse()
+        return "".join(data)
+
+
+
+class TestXMLRegisterFlags(GDBRemoteTestBase):
+    def do_expr_eval(self, config_name: str):
+        cfg = {
+            # AArch64 stores elements in little-endian, zero-first order.
+            "aarch64-le": Config(
+                architecture="aarch64",
+                pc_reg_name="pc",
+                yaml_file="aarch64.yaml",
+                data="ELFDATA2LSB",
+                machine="EM_AARCH64",
+                endian=Endian.LITTLE,
+                element_order=ElementOrder.ZEROFIRST,
+            ),
+            # AArch64 stores elements in big-endian but the vector remains in
+            # the same zero-first order.
+            "aarch64-be": Config(
+                architecture="aarch64_be",
+                pc_reg_name="pc",
+                yaml_file="aarch64be.yaml",
+                data="ELFDATA2MSB",
+                machine="EM_AARCH64",
+                endian=Endian.BIG,
+                element_order=ElementOrder.ZEROFIRST,
+            ),
+            # PowerPC stores the whole vector as little-endian
+            "ppc-le": Config(
+                architecture="ppc",
+                pc_reg_name="pc",
+                yaml_file="ppc.yaml",
+                data="ELFDATA2LSB",
+                machine="EM_PPC64",
+                endian=Endian.LITTLE,
+                element_order=ElementOrder.ZEROFIRST,
+            ),
+            # PowerPC stores the whole vector as big-endian which reverses
+            # element order
+            "ppc-be": Config(
+                architecture="ppc",
+                pc_reg_name="pc",
+                yaml_file="ppcbe.yaml",
+                data="ELFDATA2MSB",
+                machine="EM_PPC64",
+                endian=Endian.BIG,
+                element_order=ElementOrder.LASTFIRST,
+            ),
+            # Vectors are stored in the same element order as arrays.
+            # Note: WebAssembly loads vectors in reverse order because it
+            #       requires that vectors behave like little-endian first-zero
+            #       even when reinterpreting memory as a vector with different
+            #       element sizes.
+            #       C++ on the other hand effectively shuffles the bytes like
+            #       AArch64 Big Endian does
+            "systemz-be": Config(
+                architecture="s390x",
+                pc_reg_name="pswa",
+                yaml_file="s390x.yaml",
+                data="ELFDATA2MSB",
+                machine="EM_S390",
+                endian=Endian.BIG,
+                element_order=ElementOrder.ZEROFIRST,
+            ),
+        }[config_name]
+
+        assert self.server is not None
+        self.server.responder = Responder(
+            dedent(
+                f"""\
+            <?xml version="1.0"?>
+              <target version="1.0">
+                <architecture>{cfg.architecture}</architecture>
+                <feature>
+                  <reg name="{cfg.pc_reg_name}" bitsize="64"/>
+                </feature>
+            </target>"""
+            ),
+            cfg.endian,
+            cfg.element_order,
+        )
+
+        # We need to have a program file, so that we have a full type system,
+        # so that we can do the casts later.
+        obj_path = self.getBuildArtifact("main.o")
+        yaml_path = self.getBuildArtifact(cfg.yaml_file)
+        with open(yaml_path, "w") as f:
+            f.write(
+                dedent(
+                    f"""\
+                --- !ELF
+                FileHeader:
+                  Class:    ELFCLASS64
+                  Data:     {cfg.data}
+                  Type:     ET_REL
+                  Machine:  {cfg.machine}
+                DWARF:
+                  debug_abbrev:
+                    - Table:
+                        - Code:            1
+                          Tag:             DW_TAG_compile_unit
+                          Children:        DW_CHILDREN_yes
+                          Attributes:
+                            - Attribute:   DW_AT_language
+                              Form:        DW_FORM_data2
+                        - Code:            2
+                          Tag:             DW_TAG_typedef
+                          Children:        DW_CHILDREN_no
+                          Attributes:
+                            - Attribute:   DW_AT_type
+                              Form:        DW_FORM_ref4
+                            - Attribute:   DW_AT_name
+                              Form:        DW_FORM_string
+                        - Code:            3
+                          Tag:             DW_TAG_array_type
+                          Children:        DW_CHILDREN_yes
+                          Attributes:
+                            - Attribute:   DW_AT_GNU_vector
+                              Form:        DW_FORM_flag_present
+                            - Attribute:   DW_AT_type
+                              Form:        DW_FORM_ref4
+                        - Code:            4
+                          Tag:             DW_TAG_subrange_type
+                          Children:        DW_CHILDREN_no
+                          Attributes:
+                            - Attribute:   DW_AT_count
+                              Form:        DW_FORM_data1
+                        - Code:            5
+                          Tag:             DW_TAG_base_type
+                          Children:        DW_CHILDREN_no
+                          Attributes:
+                            - Attribute:   DW_AT_name
+                              Form:        DW_FORM_string
+                            - Attribute:   DW_AT_encoding
+                              Form:        DW_FORM_data1
+                            - Attribute:   DW_AT_byte_size
+                              Form:        DW_FORM_data1
+                  debug_info:
+                    - Version:           4
+                      AbbrevTableID:     0
+                      AbbrOffset:        0x0
+                      AddrSize:          8
+                      Entries:
+                        - AbbrCode:      1
+                          Values:
+                            - Value:     0x0004  # DW_LANG_C_plus_plus
+                        - AbbrCode:      2  # typedef
+                          Values:
+                            - Value:     27  # DW_AT_type: Reference to array type at 0x1b
+                            - CStr:      v4float  # DW_AT_name
+                        - AbbrCode:      3  # array_type
+                          Values:
+                            - Value:     0x01  # DW_AT_GNU_vector (flag_present)
+                            - Value:     35  # DW_AT_type: Reference to float at 0x23
+                        - AbbrCode:      4  # subrange_type
+                          Values:
+                            - Value:     0x04  # DW_AT_count: 4 elements
+                        - AbbrCode:      0  # End of array_type children
+                        - AbbrCode:      5  # base_type (float)
+                          Values:
+                            - CStr:      float  # DW_AT_name
+                            - Value:     0x04  # DW_AT_encoding: DW_ATE_float
+                            - Value:     0x04  # DW_AT_byte_size: 4 bytes
+                        - AbbrCode:      0  # End of compile unit
+                ...
+                """
+                )
+            )
+        self.yaml2obj(yaml_path, obj_path)
+        target = self.dbg.CreateTarget(obj_path)
+
+        process = self.connect(target)
+        lldbutil.expect_state_changes(
+            self, self.dbg.GetListener(), process, [lldb.eStateStopped]
+        )
+
+        # Enable logging to debug type lookup and expression evaluation
+        self.TraceOn()
+        log_file = self.getBuildArtifact("lldb.log")
+        self.runCmd(f"log enable lldb types expr -f {log_file}")
+        self.runCmd("image dump symtab", check=False)
+        self.runCmd("image lookup -t v4float", check=False)
+        self.runCmd("image lookup -t float", check=False)
+
+        # If expressions convert register values into target endian, the
+        # vector should be stored correctly in memory.
+        self.expect("expr --language c++ -- (v4float){0.25, 0.5, 0.75, 1.0}", substrs=["0.25", "0.5", "0.75", "1"])
+
+        # Check the raw bytes to verify endianness
+        result = self.frame().EvaluateExpression("(v4float){0.25, 0.5, 0.75, 1.0}", lldb.eDynamicCanRunTarget)
+        self.assertTrue(result.IsValid())
+        error = lldb.SBError()
+        data = result.GetData()
+        bytes_list = [data.GetUnsignedInt8(error, i) for i in range(16)]
+        # For big-endian: 0x3e800000, 0x3f000000, 0x3f400000, 0x3f800000
+        # For little-endian: bytes are reversed within each float
+        expected_big = [0x3e, 0x80, 0x00, 0x00, 0x3f, 0x00, 0x00, 0x00, 0x3f, 0x40, 0x00, 0x00, 0x3f, 0x80, 0x00, 0x00]
+        expected_little = [0x00, 0x00, 0x80, 0x3e, 0x00, 0x00, 0x00, 0x3f, 0x00, 0x00, 0x40, 0x3f, 0x00, 0x00, 0x80, 0x3f]
+        if cfg.endian == Endian.BIG:
+            self.assertEqual(bytes_list, expected_big)
+        else:
+            self.assertEqual(bytes_list, expected_little)
+
+        pc = (
+            process.thread[0]
+            .frame[0]
+            .GetRegisters()
+            .GetValueAtIndex(0)
+            .GetChildMemberWithName("pc")
+        )
+        ull = target.FindTypes("unsigned long long").GetTypeAtIndex(0)
+        pc_ull = pc.Cast(ull)
+
+        self.assertEqual(pc.GetValue(), pc_ull.GetValue())
+        self.assertEqual(pc.GetValueAsAddress(), pc_ull.GetValueAsAddress())
+        self.assertEqual(pc.GetValueAsSigned(), pc_ull.GetValueAsSigned())
+        self.assertEqual(pc.GetValueAsUnsigned(), pc_ull.GetValueAsUnsigned())
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    @skipIfLLVMTargetMissing("AArch64")
+    def test_aarch64_little_endian_target(self):
+        self.do_expr_eval("aarch64-le")
+
+    # AArch64 doesn't seem to have implemented big-endian in lldb
+    # Both big-endian and little-endian triples select the same ArchSpec.
+    #@skipIfXmlSupportMissing
+    #@skipIfRemote
+    #@skipIfLLVMTargetMissing("AArch64")
+    #def test_aarch64_big_endian(self):
+    #    self.do_expr_eval("aarch64-be")
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    @skipIfLLVMTargetMissing("PowerPC")
+    def test_ppc_little_endian(self):
+        self.do_expr_eval("ppc-le")
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    @skipIfLLVMTargetMissing("PowerPC")
+    def test_ppc_big_endian_target(self):
+        self.do_expr_eval("ppc-be")
+
+    @skipIfXmlSupportMissing
+    @skipIfRemote
+    @skipIfLLVMTargetMissing("SystemZ")
+    def test_systemz_big_endian_target(self):
+        self.do_expr_eval("systemz-be")


### PR DESCRIPTION
This allows the debugger to evaluate expressions without requiring the
expression to be CodeGen'd and executed on the target. This should be more
efficient for many existing targets but is necessary for targets which are
not yet able to evaluate on the target.

As far as I know most targets have a vector memory layout that matches the
IR element order. Most little endian targets choose to use a little endian
element order, and two out of the three big endian targets I know of
(MIPS MSA and ARM NEON) choose to use little endian element order even
when the elements are big endian which matches LLVM-IR's order. The third
is PowerPC Altivec which has the highest indexed element first for
big-endian mode.

I've attempted to implement the correct element ordering on the relevant
operations but I don't really have a means to test the case where the
element order doesn't match LLVM-IR's element order so I've chosen to have
a guard against element order mismatches to ensure that this change can't
break expression evaluation on those targets.