### PR TITLE
[NFC][MC][VE] Rearrange decoder functions for VE disassembler

### DIFF
--- a/llvm/lib/Target/VE/Disassembler/VEDisassembler.cpp
+++ b/llvm/lib/Target/VE/Disassembler/VEDisassembler.cpp
@@ -57,6 +57,7 @@ LLVMInitializeVEDisassembler() {
                                          createVEDisassembler);
 }
 
+// clang-format off
 static const unsigned I32RegDecoderTable[] = {
     VE::SW0,  VE::SW1,  VE::SW2,  VE::SW3,  VE::SW4,  VE::SW5,  VE::SW6,
     VE::SW7,  VE::SW8,  VE::SW9,  VE::SW10, VE::SW11, VE::SW12, VE::SW13,
@@ -127,6 +128,8 @@ static const unsigned MiscRegDecoderTable[] = {
     VE::PMC4,       VE::PMC5,       VE::PMC6,       VE::PMC7,
     VE::PMC8,       VE::PMC9,       VE::PMC10,      VE::PMC11,
     VE::PMC12,      VE::PMC13,      VE::PMC14};
+// clang-format off
+
 
 static DecodeStatus DecodeI32RegisterClass(MCInst &Inst, unsigned RegNo,
                                            uint64_t Address,
@@ -212,106 +215,6 @@ static DecodeStatus DecodeMISCRegisterClass(MCInst &Inst, unsigned RegNo,
     return MCDisassembler::Fail;
   Inst.addOperand(MCOperand::createReg(Reg));
   return MCDisassembler::Success;
-}
-
-static DecodeStatus DecodeASX(MCInst &Inst, uint64_t insn, uint64_t Address,
-                              const MCDisassembler *Decoder);
-static DecodeStatus DecodeLoadI32(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                  const MCDisassembler *Decoder);
-static DecodeStatus DecodeStoreI32(MCInst &Inst, uint64_t insn,
-                                   uint64_t Address,
-                                   const MCDisassembler *Decoder);
-static DecodeStatus DecodeLoadI64(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                  const MCDisassembler *Decoder);
-static DecodeStatus DecodeStoreI64(MCInst &Inst, uint64_t insn,
-                                   uint64_t Address,
-                                   const MCDisassembler *Decoder);
-static DecodeStatus DecodeLoadF32(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                  const MCDisassembler *Decoder);
-static DecodeStatus DecodeStoreF32(MCInst &Inst, uint64_t insn,
-                                   uint64_t Address,
-                                   const MCDisassembler *Decoder);
-static DecodeStatus DecodeLoadASI64(MCInst &Inst, uint64_t insn,
-                                    uint64_t Address,
-                                    const MCDisassembler *Decoder);
-static DecodeStatus DecodeStoreASI64(MCInst &Inst, uint64_t insn,
-                                     uint64_t Address,
-                                     const MCDisassembler *Decoder);
-static DecodeStatus DecodeTS1AMI64(MCInst &Inst, uint64_t insn,
-                                   uint64_t Address,
-                                   const MCDisassembler *Decoder);
-static DecodeStatus DecodeTS1AMI32(MCInst &Inst, uint64_t insn,
-                                   uint64_t Address,
-                                   const MCDisassembler *Decoder);
-static DecodeStatus DecodeCASI64(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                 const MCDisassembler *Decoder);
-static DecodeStatus DecodeCASI32(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                 const MCDisassembler *Decoder);
-static DecodeStatus DecodeCall(MCInst &Inst, uint64_t insn, uint64_t Address,
-                               const MCDisassembler *Decoder);
-static DecodeStatus DecodeSIMM7(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                const MCDisassembler *Decoder);
-static DecodeStatus DecodeSIMM32(MCInst &Inst, uint64_t insn, uint64_t Address,
-                                 const MCDisassembler *Decoder);
-static DecodeStatus DecodeCCOperand(MCInst &Inst, uint64_t insn,
-                                    uint64_t Address,
-                                    const MCDisassembler *Decoder);
-static DecodeStatus DecodeRDOperand(MCInst &Inst, uint64_t insn,
-                                    uint64_t Address,
-                                    const MCDisassembler *Decoder);
-static DecodeStatus DecodeBranchCondition(MCInst &Inst, uint64_t insn,
-                                          uint64_t Address,
-                                          const MCDisassembler *Decoder);
-static DecodeStatus DecodeBranchConditionAlways(MCInst &Inst, uint64_t insn,
-                                                uint64_t Address,
-                                                const MCDisassembler *Decoder);
-
-#include "VEGenDisassemblerTables.inc"
-
-/// Read four bytes from the ArrayRef and return 32 bit word.
-static DecodeStatus readInstruction64(ArrayRef<uint8_t> Bytes, uint64_t Address,
-                                      uint64_t &Size, uint64_t &Insn,
-                                      bool IsLittleEndian) {
-  // We want to read exactly 8 Bytes of data.
-  if (Bytes.size() < 8) {
-    Size = 0;
-    return MCDisassembler::Fail;
-  }
-
-  Insn = IsLittleEndian
-             ? ((uint64_t)Bytes[0] << 0) | ((uint64_t)Bytes[1] << 8) |
-                   ((uint64_t)Bytes[2] << 16) | ((uint64_t)Bytes[3] << 24) |
-                   ((uint64_t)Bytes[4] << 32) | ((uint64_t)Bytes[5] << 40) |
-                   ((uint64_t)Bytes[6] << 48) | ((uint64_t)Bytes[7] << 56)
-             : ((uint64_t)Bytes[7] << 0) | ((uint64_t)Bytes[6] << 8) |
-                   ((uint64_t)Bytes[5] << 16) | ((uint64_t)Bytes[4] << 24) |
-                   ((uint64_t)Bytes[3] << 32) | ((uint64_t)Bytes[2] << 40) |
-                   ((uint64_t)Bytes[1] << 48) | ((uint64_t)Bytes[0] << 56);
-
-  return MCDisassembler::Success;
-}
-
-DecodeStatus VEDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
-                                            ArrayRef<uint8_t> Bytes,
-                                            uint64_t Address,
-                                            raw_ostream &CStream) const {
-  uint64_t Insn;
-  bool isLittleEndian = getContext().getAsmInfo()->isLittleEndian();
-  DecodeStatus Result =
-      readInstruction64(Bytes, Address, Size, Insn, isLittleEndian);
-  if (Result == MCDisassembler::Fail)
-    return MCDisassembler::Fail;
-
-  // Calling the auto-generated decoder function.
-
-  Result = decodeInstruction(DecoderTableVE64, Instr, Insn, Address, this, STI);
-
-  if (Result != MCDisassembler::Fail) {
-    Size = 8;
-    return Result;
-  }
-
-  return MCDisassembler::Fail;
 }
 
 typedef DecodeStatus (*DecodeFunc)(MCInst &MI, unsigned RegNo, uint64_t Address,
@@ -628,4 +531,52 @@ static DecodeStatus DecodeBranchConditionAlways(MCInst &MI, uint64_t insn,
                                                 const MCDisassembler *Decoder) {
   // Decode MEMri.
   return DecodeAS(MI, insn, Address, Decoder);
+}
+
+#include "VEGenDisassemblerTables.inc"
+
+/// Read four bytes from the ArrayRef and return 32 bit word.
+static DecodeStatus readInstruction64(ArrayRef<uint8_t> Bytes, uint64_t Address,
+                                      uint64_t &Size, uint64_t &Insn,
+                                      bool IsLittleEndian) {
+  // We want to read exactly 8 Bytes of data.
+  if (Bytes.size() < 8) {
+    Size = 0;
+    return MCDisassembler::Fail;
+  }
+
+  Insn = IsLittleEndian
+             ? ((uint64_t)Bytes[0] << 0) | ((uint64_t)Bytes[1] << 8) |
+                   ((uint64_t)Bytes[2] << 16) | ((uint64_t)Bytes[3] << 24) |
+                   ((uint64_t)Bytes[4] << 32) | ((uint64_t)Bytes[5] << 40) |
+                   ((uint64_t)Bytes[6] << 48) | ((uint64_t)Bytes[7] << 56)
+             : ((uint64_t)Bytes[7] << 0) | ((uint64_t)Bytes[6] << 8) |
+                   ((uint64_t)Bytes[5] << 16) | ((uint64_t)Bytes[4] << 24) |
+                   ((uint64_t)Bytes[3] << 32) | ((uint64_t)Bytes[2] << 40) |
+                   ((uint64_t)Bytes[1] << 48) | ((uint64_t)Bytes[0] << 56);
+
+  return MCDisassembler::Success;
+}
+
+DecodeStatus VEDisassembler::getInstruction(MCInst &Instr, uint64_t &Size,
+                                            ArrayRef<uint8_t> Bytes,
+                                            uint64_t Address,
+                                            raw_ostream &CStream) const {
+  uint64_t Insn;
+  bool isLittleEndian = getContext().getAsmInfo()->isLittleEndian();
+  DecodeStatus Result =
+      readInstruction64(Bytes, Address, Size, Insn, isLittleEndian);
+  if (Result == MCDisassembler::Fail)
+    return MCDisassembler::Fail;
+
+  // Calling the auto-generated decoder function.
+
+  Result = decodeInstruction(DecoderTableVE64, Instr, Insn, Address, this, STI);
+
+  if (Result != MCDisassembler::Fail) {
+    Size = 8;
+    return Result;
+  }
+
+  return MCDisassembler::Fail;
 }

--- a/llvm/lib/Target/VE/Disassembler/VEDisassembler.cpp
+++ b/llvm/lib/Target/VE/Disassembler/VEDisassembler.cpp
@@ -128,8 +128,7 @@ static const unsigned MiscRegDecoderTable[] = {
     VE::PMC4,       VE::PMC5,       VE::PMC6,       VE::PMC7,
     VE::PMC8,       VE::PMC9,       VE::PMC10,      VE::PMC11,
     VE::PMC12,      VE::PMC13,      VE::PMC14};
-// clang-format off
-
+// clang-format on
 
 static DecodeStatus DecodeI32RegisterClass(MCInst &Inst, unsigned RegNo,
                                            uint64_t Address,


### PR DESCRIPTION
Rearrange decode functions to be before including the generated disassembler code and eliminate forward declarations for most of them. This is possible because `fieldFromInstruction` is now in MCDecoder.h and not in the generated disassembler code.