### PR TITLE
[Asan] Make fuse-lld-globals.cpp require lld

### DIFF
--- a/compiler-rt/test/asan/TestCases/Windows/fuse-lld-globals.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/fuse-lld-globals.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: lld-available
+
 // RUN: %clangxx_asan -fuse-ld=lld -O3 %s -o %t && not %run %t 2>&1 | FileCheck %s
 
 #include <string.h>


### PR DESCRIPTION
Otherwise if we do not build lld, this test will run and fail. Found when experimenting with LLVM_ENABLE_RUNTIMES="compiler-rt" on Windows.