### PR TITLE
[CIR][NFC] Fix build warning in getCIRSourceLanguage

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenModule.h
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.h
@@ -480,7 +480,7 @@ private:
   void setNonAliasAttributes(GlobalDecl gd, mlir::Operation *op);
 
   /// Map source language used to a CIR attribute.
-  cir::SourceLanguage getCIRSourceLanguage() const;
+  std::optional<cir::SourceLanguage> getCIRSourceLanguage() const;
 };
 } // namespace CIRGen
 


### PR DESCRIPTION
The getCIRSourceLanguage wasn't returning a value if the source language was anything other than C or C++. This change updates that function to return a std::optional value and only adds the source language attribute if one was returned.