### PR TITLE
[CIR] Add verifier for vtable initializer

### DIFF
--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -273,7 +273,6 @@ struct MissingFeatures {
   static bool thunks() { return false; }
   static bool tryEmitAsConstant() { return false; }
   static bool typeChecks() { return false; }
-  static bool vtableInitializer() { return false; }
   static bool weakRefReference() { return false; }
   static bool writebacks() { return false; }
   static bool appleKext() { return false; }

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1459,8 +1459,9 @@ cir::VTableAddrPointOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   StringRef name = getName();
 
   // Verify that the result type underlying pointer type matches the type of
-  // the referenced cir.global or cir.func op.
-  auto op = symbolTable.lookupNearestSymbolFrom<cir::GlobalOp>(*this, getNameAttr());
+  // the referenced cir.global.
+  auto op =
+      symbolTable.lookupNearestSymbolFrom<cir::GlobalOp>(*this, getNameAttr());
   if (!op)
     return emitOpError("'")
            << name << "' does not reference a valid cir.global";

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -1460,14 +1460,16 @@ cir::VTableAddrPointOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
 
   // Verify that the result type underlying pointer type matches the type of
   // the referenced cir.global or cir.func op.
-  auto op = symbolTable.lookupNearestSymbolFrom<GlobalOp>(*this, getNameAttr());
+  auto op = symbolTable.lookupNearestSymbolFrom<cir::GlobalOp>(*this, getNameAttr());
   if (!op)
     return emitOpError("'")
            << name << "' does not reference a valid cir.global";
   std::optional<mlir::Attribute> init = op.getInitialValue();
   if (!init)
     return success();
-  assert(!cir::MissingFeatures::vtableInitializer());
+  if (!isa<cir::VTableAttr>(*init))
+    return emitOpError("Expected #cir.vtable in initializer for global '")
+           << name << "'";
   return success();
 }
 

--- a/clang/test/CIR/IR/invalid-vtable.cir
+++ b/clang/test/CIR/IR/invalid-vtable.cir
@@ -10,6 +10,17 @@ cir.func @reference_unknown_vtable() {
 
 // -----
 
+!u8i = !cir.int<u, 8>
+!u32i = !cir.int<u, 32>
+cir.global linkonce_odr @_ZTT1D = #cir.const_array<[#cir.global_view<@_ZTV1D, [0 : i32, 3 : i32]> : !cir.ptr<!u8i>, #cir.global_view<@_ZTC1D0_1B, [0 : i32, 3 : i32]> : !cir.ptr<!u8i>]> : !cir.array<!cir.ptr<!u8i> x 2>
+cir.func @reference_unknown_vtable() {
+  // expected-error @below {{Expected #cir.vtable in initializer for global '_ZTT1D'}}
+  %0 = cir.vtable.address_point(@_ZTT1D, address_point = <index = 0, offset = 2>) : !cir.vptr
+  cir.return
+}
+
+// -----
+
 !rec_S = !cir.record<struct "S" {!cir.vptr}>
 !u8i = !cir.int<u, 8>
 !rec_anon_struct = !cir.record<struct {!cir.array<!cir.ptr<!u8i> x 4>}>


### PR DESCRIPTION
This adds verification for the initializer, if present, of any global passed to the `cir.vtable.address_point` op.