### PR TITLE
[alpha.webkit.UncheckedCallArgsChecker] Don't emit a warning for passing a temporary object as an argument.

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/ASTUtils.cpp
@@ -208,6 +208,8 @@ bool isASafeCallArg(const Expr *E) {
         return true;
     }
   }
+  if (isa<CXXTemporaryObjectExpr>(E))
+    return true; // A temporary lives until the end of this statement.
   if (isConstOwnerPtrMemberExpr(E))
     return true;
 

--- a/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/unchecked-call-arg.cpp
@@ -32,3 +32,8 @@ void foo() {
   provide()->doWork();
   // expected-warning@-1{{Call argument for 'this' parameter is unchecked and unsafe}}
 }
+
+void doWorkWithObject(const CheckedObject&);
+void bar() {
+  doWorkWithObject(CheckedObject());
+}


### PR DESCRIPTION
Since a temporary object lives until the end of the statement, it's safe to pass such an object as a function argument without explicitly creating a CheckedRef/CheckedPtr in stack.