### PR TITLE
[lldb] Adopt JSONTransport in the MCP Server

### DIFF
--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -26,24 +26,10 @@ using namespace llvm;
 
 LLDB_PLUGIN_DEFINE(ProtocolServerMCP)
 
-static constexpr size_t kChunkSize = 1024;
 static constexpr llvm::StringLiteral kName = "lldb-mcp";
 static constexpr llvm::StringLiteral kVersion = "0.1.0";
 
-ProtocolServerMCP::ProtocolServerMCP()
-    : ProtocolServer(),
-      lldb_protocol::mcp::Server(std::string(kName), std::string(kVersion)) {
-  AddNotificationHandler("notifications/initialized",
-                         [](const lldb_protocol::mcp::Notification &) {
-                           LLDB_LOG(GetLog(LLDBLog::Host),
-                                    "MCP initialization complete");
-                         });
-
-  AddTool(
-      std::make_unique<CommandTool>("lldb_command", "Run an lldb command."));
-
-  AddResourceProvider(std::make_unique<DebuggerResourceProvider>());
-}
+ProtocolServerMCP::ProtocolServerMCP() : ProtocolServer() {}
 
 ProtocolServerMCP::~ProtocolServerMCP() { llvm::consumeError(Stop()); }
 
@@ -64,57 +50,37 @@ llvm::StringRef ProtocolServerMCP::GetPluginDescriptionStatic() {
   return "MCP Server.";
 }
 
-void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
-  LLDB_LOG(GetLog(LLDBLog::Host), "New MCP client ({0}) connected",
-           m_clients.size() + 1);
-
-  lldb::IOObjectSP io_sp = std::move(socket);
-  auto client_up = std::make_unique<Client>();
-  client_up->io_sp = io_sp;
-  Client *client = client_up.get();
-
-  Status status;
-  auto read_handle_up = m_loop.RegisterReadObject(
-      io_sp,
-      [this, client](MainLoopBase &loop) {
-        if (llvm::Error error = ReadCallback(*client)) {
-          LLDB_LOG_ERROR(GetLog(LLDBLog::Host), std::move(error), "{0}");
-          client->read_handle_up.reset();
-        }
-      },
-      status);
-  if (status.Fail())
-    return;
-
-  client_up->read_handle_up = std::move(read_handle_up);
-  m_clients.emplace_back(std::move(client_up));
+void ProtocolServerMCP::Extend(lldb_protocol::mcp::Server &server) const {
+  server.AddNotificationHandler("notifications/initialized",
+                                [](const lldb_protocol::mcp::Notification &) {
+                                  LLDB_LOG(GetLog(LLDBLog::Host),
+                                           "MCP initialization complete");
+                                });
+  server.AddTool(
+      std::make_unique<CommandTool>("lldb_command", "Run an lldb command."));
+  server.AddResourceProvider(std::make_unique<DebuggerResourceProvider>());
 }
 
-llvm::Error ProtocolServerMCP::ReadCallback(Client &client) {
-  char chunk[kChunkSize];
-  size_t bytes_read = sizeof(chunk);
-  if (Status status = client.io_sp->Read(chunk, bytes_read); status.Fail())
-    return status.takeError();
-  client.buffer.append(chunk, bytes_read);
+void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
+  Log *log = GetLog(LLDBLog::Host);
+  std::string client_name = llvm::formatv("client_{0}", m_instances.size() + 1);
+  LLDB_LOG(log, "New MCP client connected: {0}", client_name);
 
-  for (std::string::size_type pos;
-       (pos = client.buffer.find('\n')) != std::string::npos;) {
-    llvm::Expected<std::optional<lldb_protocol::mcp::Message>> message =
-        HandleData(StringRef(client.buffer.data(), pos));
-    client.buffer = client.buffer.erase(0, pos + 1);
-    if (!message)
-      return message.takeError();
-
-    if (*message) {
-      std::string Output;
-      llvm::raw_string_ostream OS(Output);
-      OS << llvm::formatv("{0}", toJSON(**message)) << '\n';
-      size_t num_bytes = Output.size();
-      return client.io_sp->Write(Output.data(), num_bytes).takeError();
-    }
+  lldb::IOObjectSP io_sp = std::move(socket);
+  auto transport_up = std::make_unique<lldb_protocol::mcp::MCPTransport>(
+      io_sp, io_sp, std::move(client_name), [&](llvm::StringRef message) {
+        LLDB_LOG(GetLog(LLDBLog::Host), "{0}", message);
+      });
+  auto instance_up = std::make_unique<lldb_protocol::mcp::Server>(
+      std::string(kName), std::string(kVersion), std::move(transport_up),
+      m_loop);
+  Extend(*instance_up);
+  llvm::Error error = instance_up->Run();
+  if (error) {
+    LLDB_LOG_ERROR(log, std::move(error), "Failed to run MCP server: {0}");
+    return;
   }
-
-  return llvm::Error::success();
+  m_instances.push_back(std::move(instance_up));
 }
 
 llvm::Error ProtocolServerMCP::Start(ProtocolServer::Connection connection) {
@@ -158,27 +124,11 @@ llvm::Error ProtocolServerMCP::Stop() {
 
   // Stop the main loop.
   m_loop.AddPendingCallback(
-      [](MainLoopBase &loop) { loop.RequestTermination(); });
+      [](lldb_private::MainLoopBase &loop) { loop.RequestTermination(); });
 
   // Wait for the main loop to exit.
   if (m_loop_thread.joinable())
     m_loop_thread.join();
 
-  {
-    std::lock_guard<std::mutex> guard(m_mutex);
-    m_listener.reset();
-    m_listen_handlers.clear();
-    m_clients.clear();
-  }
-
   return llvm::Error::success();
-}
-
-lldb_protocol::mcp::Capabilities ProtocolServerMCP::GetCapabilities() {
-  lldb_protocol::mcp::Capabilities capabilities;
-  capabilities.tools.listChanged = true;
-  // FIXME: Support sending notifications when a debugger/target are
-  // added/removed.
-  capabilities.resources.listChanged = false;
-  return capabilities;
 }

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
@@ -39,7 +39,8 @@ public:
   Socket *GetSocket() const override { return m_listener.get(); }
 
 protected:
-  // Overridable by the unit tests.
+  // This adds tools and resource providers that
+  // are specific to this server. Overridable by the unit tests.
   virtual void Extend(lldb_protocol::mcp::Server &server) const;
 
 private:

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
@@ -18,8 +18,7 @@
 
 namespace lldb_private::mcp {
 
-class ProtocolServerMCP : public ProtocolServer,
-                          public lldb_protocol::mcp::Server {
+class ProtocolServerMCP : public ProtocolServer {
 public:
   ProtocolServerMCP();
   virtual ~ProtocolServerMCP() override;
@@ -39,26 +38,23 @@ public:
 
   Socket *GetSocket() const override { return m_listener.get(); }
 
+protected:
+  // Overridable by the unit tests.
+  virtual void Extend(lldb_protocol::mcp::Server &server) const;
+
 private:
   void AcceptCallback(std::unique_ptr<Socket> socket);
 
-  lldb_protocol::mcp::Capabilities GetCapabilities() override;
-
   bool m_running = false;
 
-  MainLoop m_loop;
+  lldb_private::MainLoop m_loop;
   std::thread m_loop_thread;
+  std::mutex m_mutex;
 
   std::unique_ptr<Socket> m_listener;
-  std::vector<MainLoopBase::ReadHandleUP> m_listen_handlers;
 
-  struct Client {
-    lldb::IOObjectSP io_sp;
-    MainLoopBase::ReadHandleUP read_handle_up;
-    std::string buffer;
-  };
-  llvm::Error ReadCallback(Client &client);
-  std::vector<std::unique_ptr<Client>> m_clients;
+  std::vector<MainLoopBase::ReadHandleUP> m_listen_handlers;
+  std::vector<std::unique_ptr<lldb_protocol::mcp::Server>> m_instances;
 };
 } // namespace lldb_private::mcp
 

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -12,8 +12,11 @@
 using namespace lldb_protocol::mcp;
 using namespace llvm;
 
-Server::Server(std::string name, std::string version)
-    : m_name(std::move(name)), m_version(std::move(version)) {
+Server::Server(std::string name, std::string version,
+               std::unique_ptr<MCPTransport> transport_up,
+               lldb_private::MainLoop &loop)
+    : m_name(std::move(name)), m_version(std::move(version)),
+      m_transport_up(std::move(transport_up)), m_loop(loop) {
   AddRequestHandlers();
 }
 
@@ -231,4 +234,72 @@ llvm::Expected<Response> Server::ResourcesReadHandler(const Request &request) {
   return make_error<MCPError>(
       llvm::formatv("no resource handler for uri: {0}", uri_str).str(),
       MCPError::kResourceNotFound);
+}
+
+lldb_protocol::mcp::Capabilities Server::GetCapabilities() {
+  lldb_protocol::mcp::Capabilities capabilities;
+  capabilities.tools.listChanged = true;
+  // FIXME: Support sending notifications when a debugger/target are
+  // added/removed.
+  capabilities.resources.listChanged = false;
+  return capabilities;
+}
+
+llvm::Error Server::Run() {
+  auto handle = m_transport_up->RegisterMessageHandler(m_loop, *this);
+  if (!handle)
+    return handle.takeError();
+
+  lldb_private::Status status = m_loop.Run();
+  if (status.Fail())
+    return status.takeError();
+
+  return llvm::Error::success();
+}
+
+void Server::Received(const Request &request) {
+  auto SendResponse = [this](const Response &response) {
+    if (llvm::Error error = m_transport_up->Send(response))
+      m_transport_up->Log(llvm::toString(std::move(error)));
+  };
+
+  llvm::Expected<Response> response = Handle(request);
+  if (response)
+    return SendResponse(*response);
+
+  lldb_protocol::mcp::Error protocol_error;
+  llvm::handleAllErrors(
+      response.takeError(),
+      [&](const MCPError &err) { protocol_error = err.toProtocolError(); },
+      [&](const llvm::ErrorInfoBase &err) {
+        protocol_error.code = MCPError::kInternalError;
+        protocol_error.message = err.message();
+      });
+  Response error_response;
+  error_response.id = request.id;
+  error_response.result = std::move(protocol_error);
+  SendResponse(error_response);
+}
+
+void Server::Received(const Response &response) {
+  m_transport_up->Log("unexpected MCP message: response");
+}
+
+void Server::Received(const Notification &notification) {
+  Handle(notification);
+}
+
+void Server::OnError(llvm::Error error) {
+  m_transport_up->Log(llvm::toString(std::move(error)));
+  TerminateLoop();
+}
+
+void Server::OnClosed() {
+  m_transport_up->Log("EOF");
+  TerminateLoop();
+}
+
+void Server::TerminateLoop() {
+  m_loop.AddPendingCallback(
+      [](lldb_private::MainLoopBase &loop) { loop.RequestTermination(); });
 }

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -236,7 +236,7 @@ llvm::Expected<Response> Server::ResourcesReadHandler(const Request &request) {
       MCPError::kResourceNotFound);
 }
 
-lldb_protocol::mcp::Capabilities Server::GetCapabilities() {
+Capabilities Server::GetCapabilities() {
   lldb_protocol::mcp::Capabilities capabilities;
   capabilities.tools.listChanged = true;
   // FIXME: Support sending notifications when a debugger/target are

--- a/lldb/unittests/ProtocolServer/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/ProtocolServer/ProtocolMCPServerTest.cpp
@@ -39,12 +39,20 @@ using testing::_;
 namespace {
 class TestProtocolServerMCP : public lldb_private::mcp::ProtocolServerMCP {
 public:
-  using ProtocolServerMCP::AddNotificationHandler;
-  using ProtocolServerMCP::AddRequestHandler;
-  using ProtocolServerMCP::AddResourceProvider;
-  using ProtocolServerMCP::AddTool;
   using ProtocolServerMCP::GetSocket;
   using ProtocolServerMCP::ProtocolServerMCP;
+
+  using ExtendCallback =
+      std::function<void(lldb_protocol::mcp::Server &server)>;
+
+  virtual void Extend(lldb_protocol::mcp::Server &server) const override {
+    if (m_extend_callback)
+      m_extend_callback(server);
+  };
+
+  void Extend(ExtendCallback callback) { m_extend_callback = callback; }
+
+  ExtendCallback m_extend_callback;
 };
 
 using Message = typename Transport<Request, Response, Notification>::Message;
@@ -183,8 +191,10 @@ public:
     connection.protocol = Socket::SocketProtocol::ProtocolTcp;
     connection.name = llvm::formatv("{0}:0", k_localhost).str();
     m_server_up = std::make_unique<TestProtocolServerMCP>();
-    m_server_up->AddTool(std::make_unique<TestTool>("test", "test tool"));
-    m_server_up->AddResourceProvider(std::make_unique<TestResourceProvider>());
+    m_server_up->Extend([&](auto &server) {
+      server.AddTool(std::make_unique<TestTool>("test", "test tool"));
+      server.AddResourceProvider(std::make_unique<TestResourceProvider>());
+    });
     ASSERT_THAT_ERROR(m_server_up->Start(connection), llvm::Succeeded());
 
     // Connect to the server over a TCP socket.
@@ -233,20 +243,10 @@ TEST_F(ProtocolServerMCPTest, ToolsList) {
   test_tool.description = "test tool";
   test_tool.inputSchema = json::Object{{"type", "object"}};
 
-  ToolDefinition lldb_command_tool;
-  lldb_command_tool.description = "Run an lldb command.";
-  lldb_command_tool.name = "lldb_command";
-  lldb_command_tool.inputSchema = json::Object{
-      {"type", "object"},
-      {"properties",
-       json::Object{{"arguments", json::Object{{"type", "string"}}},
-                    {"debugger_id", json::Object{{"type", "number"}}}}},
-      {"required", json::Array{"debugger_id"}}};
   Response response;
   response.id = "one";
   response.result = json::Object{
-      {"tools",
-       json::Array{std::move(test_tool), std::move(lldb_command_tool)}},
+      {"tools", json::Array{std::move(test_tool)}},
   };
 
   ASSERT_THAT_ERROR(Write(request), llvm::Succeeded());
@@ -281,7 +281,9 @@ TEST_F(ProtocolServerMCPTest, ToolsCall) {
 }
 
 TEST_F(ProtocolServerMCPTest, ToolsCallError) {
-  m_server_up->AddTool(std::make_unique<ErrorTool>("error", "error tool"));
+  m_server_up->Extend([&](auto &server) {
+    server.AddTool(std::make_unique<ErrorTool>("error", "error tool"));
+  });
 
   llvm::StringLiteral request =
       R"json({"method":"tools/call","params":{"name":"error","arguments":{"arguments":"foo","debugger_id":0}},"jsonrpc":"2.0","id":11})json";
@@ -296,7 +298,9 @@ TEST_F(ProtocolServerMCPTest, ToolsCallError) {
 }
 
 TEST_F(ProtocolServerMCPTest, ToolsCallFail) {
-  m_server_up->AddTool(std::make_unique<FailTool>("fail", "fail tool"));
+  m_server_up->Extend([&](auto &server) {
+    server.AddTool(std::make_unique<FailTool>("fail", "fail tool"));
+  });
 
   llvm::StringLiteral request =
       R"json({"method":"tools/call","params":{"name":"fail","arguments":{"arguments":"foo","debugger_id":0}},"jsonrpc":"2.0","id":11})json";
@@ -315,14 +319,16 @@ TEST_F(ProtocolServerMCPTest, NotificationInitialized) {
   std::condition_variable cv;
   std::mutex mutex;
 
-  m_server_up->AddNotificationHandler(
-      "notifications/initialized", [&](const Notification &notification) {
-        {
-          std::lock_guard<std::mutex> lock(mutex);
-          handler_called = true;
-        }
-        cv.notify_all();
-      });
+  m_server_up->Extend([&](auto &server) {
+    server.AddNotificationHandler("notifications/initialized",
+                                  [&](const Notification &notification) {
+                                    {
+                                      std::lock_guard<std::mutex> lock(mutex);
+                                      handler_called = true;
+                                    }
+                                    cv.notify_all();
+                                  });
+  });
   llvm::StringLiteral request =
       R"json({"method":"notifications/initialized","jsonrpc":"2.0"})json";
 


### PR DESCRIPTION
This PR adopts JSONTransport in the MCP server implementation. It required a slight change in design in the relationship between the two server classes. Previously, these two had an "is-a" connection, while now they have a "has-a" connection.

The "generic" protocol server in Protocol/MCP now operates using a single connection (Transport). This matches the design in DAP where each DAP instance has its own connection. The protocol server in Plugins still supports multiple clients and creates a new server instance for each connection.

I believe the new design makes sense in the long term (as proved by DAP) and allows us to make the server stateful if we choose to do so. There's no reason that multiple client support can't live in the generic protocol library, but for now I kept it in ProtocolServerMCP to avoid creating unnecessary abstractions.