### PR TITLE
[WebKit checkers] Treat asm brk as trivial

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -666,6 +666,13 @@ public:
     return IsFunctionTrivial(Callee);
   }
 
+  bool VisitGCCAsmStmt(const GCCAsmStmt *AS) {
+    auto *Asm = AS->getAsmString();
+    if (!Asm)
+      return false;
+    return Asm->getString() == "brk #0xc471";
+  }
+
   bool
   VisitSubstNonTypeTemplateParmExpr(const SubstNonTypeTemplateParmExpr *E) {
     // Non-type template paramter is compile time constant and trivial.

--- a/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/WebKit/PtrTypesSemantics.cpp
@@ -667,10 +667,7 @@ public:
   }
 
   bool VisitGCCAsmStmt(const GCCAsmStmt *AS) {
-    auto *Asm = AS->getAsmString();
-    if (!Asm)
-      return false;
-    return Asm->getString() == "brk #0xc471";
+    return AS->getAsmString() == "brk #0xc471";
   }
 
   bool

--- a/clang/test/Analysis/Checkers/WebKit/trivial-code-check-asm-brk.cpp
+++ b/clang/test/Analysis/Checkers/WebKit/trivial-code-check-asm-brk.cpp
@@ -1,0 +1,22 @@
+// RUN: %clang_analyze_cc1 -triple arm-darwin -analyzer-checker=alpha.webkit.UncountedCallArgsChecker -verify %s
+// expected-no-diagnostics
+
+void crash()
+{
+  __asm__ volatile ("brk #0xc471");
+  __builtin_unreachable();
+}
+
+class SomeObj {
+public:
+  void ref();
+  void deref();
+
+  void someWork() { crash(); }
+};
+
+SomeObj* provide();
+
+void doSomeWork() {
+  provide()->someWork();
+}


### PR DESCRIPTION
Like other functions which results in abort, treat asm brk instruction as trivial.