### PR TITLE
[clang] NFC: Provide inline definitions for {get,cast}TagDecl and friends

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -23,6 +23,55 @@
 
 namespace clang {
 
+inline CXXRecordDecl *Type::getAsCXXRecordDecl() const {
+  const auto *TT = dyn_cast<TagType>(CanonicalType);
+  if (!isa_and_present<RecordType, InjectedClassNameType>(TT))
+    return nullptr;
+  auto *TD = TT->getOriginalDecl();
+  if (isa<RecordType>(TT) && !isa<CXXRecordDecl>(TD))
+    return nullptr;
+  return cast<CXXRecordDecl>(TD)->getDefinitionOrSelf();
+}
+
+inline CXXRecordDecl *Type::castAsCXXRecordDecl() const {
+  const auto *TT = cast<TagType>(CanonicalType);
+  return cast<CXXRecordDecl>(TT->getOriginalDecl())->getDefinitionOrSelf();
+}
+
+inline RecordDecl *Type::getAsRecordDecl() const {
+  const auto *TT = dyn_cast<TagType>(CanonicalType);
+  if (!isa_and_present<RecordType, InjectedClassNameType>(TT))
+    return nullptr;
+  return cast<RecordDecl>(TT->getOriginalDecl())->getDefinitionOrSelf();
+}
+
+inline RecordDecl *Type::castAsRecordDecl() const {
+  const auto *TT = cast<TagType>(CanonicalType);
+  return cast<RecordDecl>(TT->getOriginalDecl())->getDefinitionOrSelf();
+}
+
+inline EnumDecl *Type::getAsEnumDecl() const {
+  if (const auto *TT = dyn_cast<EnumType>(CanonicalType))
+    return TT->getOriginalDecl()->getDefinitionOrSelf();
+  return nullptr;
+}
+
+inline EnumDecl *Type::castAsEnumDecl() const {
+  return cast<EnumType>(CanonicalType)
+      ->getOriginalDecl()
+      ->getDefinitionOrSelf();
+}
+
+inline TagDecl *Type::getAsTagDecl() const {
+  if (const auto *TT = dyn_cast<TagType>(CanonicalType))
+    return TT->getOriginalDecl()->getDefinitionOrSelf();
+  return nullptr;
+}
+
+inline TagDecl *Type::castAsTagDecl() const {
+  return cast<TagType>(CanonicalType)->getOriginalDecl()->getDefinitionOrSelf();
+}
+
 inline bool QualType::hasNonTrivialToPrimitiveDefaultInitializeCUnion() const {
   if (auto *RD = getTypePtr()->getBaseElementTypeUnsafe()->getAsRecordDecl())
     return hasNonTrivialToPrimitiveDefaultInitializeCUnion(RD);

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -2882,22 +2882,22 @@ public:
   /// Retrieves the CXXRecordDecl that this type refers to, either
   /// because the type is a RecordType or because it is the injected-class-name
   /// type of a class template or class template partial specialization.
-  CXXRecordDecl *getAsCXXRecordDecl() const;
-  CXXRecordDecl *castAsCXXRecordDecl() const;
+  inline CXXRecordDecl *getAsCXXRecordDecl() const;
+  inline CXXRecordDecl *castAsCXXRecordDecl() const;
 
   /// Retrieves the RecordDecl this type refers to.
-  RecordDecl *getAsRecordDecl() const;
-  RecordDecl *castAsRecordDecl() const;
+  inline RecordDecl *getAsRecordDecl() const;
+  inline RecordDecl *castAsRecordDecl() const;
 
   /// Retrieves the EnumDecl this type refers to.
-  EnumDecl *getAsEnumDecl() const;
-  EnumDecl *castAsEnumDecl() const;
+  inline EnumDecl *getAsEnumDecl() const;
+  inline EnumDecl *castAsEnumDecl() const;
 
   /// Retrieves the TagDecl that this type refers to, either
   /// because the type is a TagType or because it is the injected-class-name
   /// type of a class template or class template partial specialization.
-  TagDecl *getAsTagDecl() const;
-  TagDecl *castAsTagDecl() const;
+  inline TagDecl *getAsTagDecl() const;
+  inline TagDecl *castAsTagDecl() const;
 
   /// If this is a pointer or reference to a RecordType, return the
   /// CXXRecordDecl that the type refers to.

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -1917,55 +1917,6 @@ const CXXRecordDecl *Type::getPointeeCXXRecordDecl() const {
   return PointeeType->getAsCXXRecordDecl();
 }
 
-CXXRecordDecl *Type::getAsCXXRecordDecl() const {
-  const auto *TT = dyn_cast<TagType>(CanonicalType);
-  if (!isa_and_present<RecordType, InjectedClassNameType>(TT))
-    return nullptr;
-  auto *TD = TT->getOriginalDecl();
-  if (!isa<InjectedClassNameType>(TT) && !isa<CXXRecordDecl>(TD))
-    return nullptr;
-  return cast<CXXRecordDecl>(TD)->getDefinitionOrSelf();
-}
-
-CXXRecordDecl *Type::castAsCXXRecordDecl() const {
-  const auto *TT = cast<TagType>(CanonicalType);
-  return cast<CXXRecordDecl>(TT->getOriginalDecl())->getDefinitionOrSelf();
-}
-
-RecordDecl *Type::getAsRecordDecl() const {
-  const auto *TT = dyn_cast<TagType>(CanonicalType);
-  if (!isa_and_present<RecordType, InjectedClassNameType>(TT))
-    return nullptr;
-  return cast<RecordDecl>(TT->getOriginalDecl())->getDefinitionOrSelf();
-}
-
-RecordDecl *Type::castAsRecordDecl() const {
-  const auto *TT = cast<TagType>(CanonicalType);
-  return cast<RecordDecl>(TT->getOriginalDecl())->getDefinitionOrSelf();
-}
-
-EnumDecl *Type::getAsEnumDecl() const {
-  if (const auto *TT = dyn_cast<EnumType>(CanonicalType))
-    return TT->getOriginalDecl()->getDefinitionOrSelf();
-  return nullptr;
-}
-
-EnumDecl *Type::castAsEnumDecl() const {
-  return cast<EnumType>(CanonicalType)
-      ->getOriginalDecl()
-      ->getDefinitionOrSelf();
-}
-
-TagDecl *Type::getAsTagDecl() const {
-  if (const auto *TT = dyn_cast<TagType>(CanonicalType))
-    return TT->getOriginalDecl()->getDefinitionOrSelf();
-  return nullptr;
-}
-
-TagDecl *Type::castAsTagDecl() const {
-  return cast<TagType>(CanonicalType)->getOriginalDecl()->getDefinitionOrSelf();
-}
-
 const TemplateSpecializationType *
 Type::getAsNonAliasTemplateSpecializationType() const {
   const auto *TST = getAs<TemplateSpecializationType>();


### PR DESCRIPTION
This is a small performance improvement:

This helps recover the performance lost in #155028, reversing it into a small positive instead.
<img width="1464" height="20" alt="image" src="https://github.com/user-attachments/assets/3378789e-109d-4211-846e-0d38d6cb190a" />