### PR TITLE
[orc-rt] Fix deleted copy operations in move_only_function.

### DIFF
--- a/orc-rt/include/orc-rt/move_only_function.h
+++ b/orc-rt/include/orc-rt/move_only_function.h
@@ -59,9 +59,9 @@ public:
   move_only_function() = default;
   move_only_function(std::nullptr_t) {}
   move_only_function(move_only_function &&) = default;
-  move_only_function(const move_only_function &&) = delete;
+  move_only_function(const move_only_function &) = delete;
   move_only_function &operator=(move_only_function &&) = default;
-  move_only_function &operator=(const move_only_function &&) = delete;
+  move_only_function &operator=(const move_only_function &) = delete;
 
   template <typename CallableT>
   move_only_function(CallableT &&Callable)


### PR DESCRIPTION

These were incorrectly defined with r-value references.