### PR TITLE
[libc] Add half-precision math functions to the math header

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -370,6 +370,13 @@ functions:
     return_type: float
     arguments:
       - type: float
+  - name: exp10f16
+    standards:
+      - stdc
+    return_type: _Float16
+    arguments:
+      - type: _Float16
+    guard: LIBC_TYPES_HAS_FLOAT16
   - name: exp10m1f
     standards:
       - stdc
@@ -395,6 +402,13 @@ functions:
     return_type: float
     arguments:
       - type: float
+  - name: exp2f16
+    standards:
+      - stdc
+    return_type: _Float16
+    arguments:
+      - type: _Float16
+    guard: LIBC_TYPES_HAS_FLOAT16
   - name: exp2m1f
     standards:
       - stdc
@@ -414,6 +428,13 @@ functions:
     return_type: float
     arguments:
       - type: float
+  - name: expf16
+    standards:
+      - stdc
+    return_type: _Float16
+    arguments:
+      - type: _Float16
+    guard: LIBC_TYPES_HAS_FLOAT16
   - name: expm1
     standards:
       - stdc
@@ -426,6 +447,13 @@ functions:
     return_type: float
     arguments:
       - type: float
+  - name: expm1f16
+    standards:
+      - stdc
+    return_type: _Float16
+    arguments:
+      - type: _Float16
+    guard: LIBC_TYPES_HAS_FLOAT16
   - name: f16add
     standards:
       - llvm_libc_ext


### PR DESCRIPTION
This patch adds the `exp10f16`, `exp2f16`, `expf16`, and `expm1f16` math functions to the `math.h` header.