### PR TITLE
[ADT] Simplify SmallDenseMap::swap (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -1038,8 +1038,7 @@ public:
       return;
     }
     if (!Small && !RHS.Small) {
-      std::swap(getLargeRep()->Buckets, RHS.getLargeRep()->Buckets);
-      std::swap(getLargeRep()->NumBuckets, RHS.getLargeRep()->NumBuckets);
+      std::swap(*getLargeRep(), *RHS.getLargeRep());
       return;
     }
 


### PR DESCRIPTION
This patch simplifies the swapping of *getLargeRep().

In other places, we treat the two member variables together like:

  new (getLargeRep()) LargeRep(allocateBuckets(InitBuckets));

This patch makes the code a little more consistent with other places
copying/moving LargeRep.
