### PR TITLE
[ORC-RT] Add IntervalMap and IntervalSet collections.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -6,6 +6,8 @@ set(ORC_RT_HEADERS
     orc-rt/Compiler.h
     orc-rt/Error.h
     orc-rt/ExecutorAddr.h
+    orc-rt/IntervalMap.h
+    orc-rt/IntervalSet.h
     orc-rt/Math.h
     orc-rt/RTTI.h
     orc-rt/WrapperFunctionResult.h

--- a/orc-rt/include/orc-rt/IntervalMap.h
+++ b/orc-rt/include/orc-rt/IntervalMap.h
@@ -1,0 +1,167 @@
+//===---------- IntervalMap.h - A sorted interval map -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements a coalescing interval map.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_INTERVALMAP_H
+#define ORC_RT_INTERVALMAP_H
+
+#include <cassert>
+#include <map>
+
+namespace orc_rt {
+
+enum class IntervalCoalescing { Enabled, Disabled };
+
+/// Maps intervals to keys with optional coalescing.
+///
+/// NOTE: The interface is kept mostly compatible with LLVM's IntervalMap
+///       collection to make it easy to swap over in the future if we choose
+///       to.
+template <typename KeyT, typename ValT> class IntervalMapBase {
+private:
+  using KeyPairT = std::pair<KeyT, KeyT>;
+
+  struct Compare {
+    using is_transparent = std::true_type;
+    bool operator()(const KeyPairT &LHS, const KeyPairT &RHS) const {
+      return LHS < RHS;
+    }
+    bool operator()(const KeyPairT &LHS, const KeyT &RHS) const {
+      return LHS.first < RHS;
+    }
+    bool operator()(const KeyT &LHS, const KeyPairT &RHS) const {
+      return LHS < RHS.first;
+    }
+  };
+
+  using ImplMap = std::map<KeyPairT, ValT, Compare>;
+
+public:
+  using iterator = typename ImplMap::iterator;
+  using const_iterator = typename ImplMap::const_iterator;
+  using size_type = typename ImplMap::size_type;
+
+  bool empty() const { return Impl.empty(); }
+
+  void clear() { Impl.clear(); }
+
+  iterator begin() { return Impl.begin(); }
+  iterator end() { return Impl.end(); }
+
+  const_iterator begin() const { return Impl.begin(); }
+  const_iterator end() const { return Impl.end(); }
+
+  iterator find(KeyT K) {
+    // Early out if the key is clearly outside the range.
+    if (empty() || K < begin()->first.first ||
+        K >= std::prev(end())->first.second)
+      return end();
+
+    auto I = Impl.upper_bound(K);
+    assert(I != begin() && "Should have hit early out above");
+    I = std::prev(I);
+    if (K < I->first.second)
+      return I;
+    return end();
+  }
+
+  const_iterator find(KeyT K) const {
+    return const_cast<IntervalMapBase<KeyT, ValT> *>(this)->find(K);
+  }
+
+  ValT lookup(KeyT K, ValT NotFound = ValT()) const {
+    auto I = find(K);
+    if (I == end())
+      return NotFound;
+    return I->second;
+  }
+
+  // Erase [KS, KE), which must be entirely containing within one existing
+  // range in the map. Removal is allowed to split the range.
+  void erase(KeyT KS, KeyT KE) {
+    if (empty())
+      return;
+
+    auto J = Impl.upper_bound(KS);
+
+    // Check previous range. Bail out if range to remove is entirely after
+    // it.
+    auto I = std::prev(J);
+    if (KS >= I->first.second)
+      return;
+
+    // Assert that range is wholly contained.
+    assert(KE <= I->first.second);
+
+    auto Tmp = std::move(*I);
+    Impl.erase(I);
+
+    // Split-right -- introduce right-split range.
+    if (KE < Tmp.first.second) {
+      Impl.insert(
+          J, std::make_pair(std::make_pair(KE, Tmp.first.second), Tmp.second));
+      J = std::prev(J);
+    }
+
+    // Split-left -- introduce left-split range.
+    if (KS > Tmp.first.first)
+      Impl.insert(
+          J, std::make_pair(std::make_pair(Tmp.first.first, KS), Tmp.second));
+  }
+
+protected:
+  ImplMap Impl;
+};
+
+template <typename KeyT, typename ValT, IntervalCoalescing Coalescing>
+class IntervalMap;
+
+template <typename KeyT, typename ValT>
+class IntervalMap<KeyT, ValT, IntervalCoalescing::Enabled>
+    : public IntervalMapBase<KeyT, ValT> {
+public:
+  // Coalescing insert. Requires that ValTs be equality-comparable.
+  void insert(KeyT KS, KeyT KE, ValT V) {
+    auto J = this->Impl.upper_bound(KS);
+
+    // Coalesce-right if possible. Either way, J points at our insertion
+    // point.
+    if (J != this->end() && KE == J->first.first && J->second == V) {
+      KE = J->first.second;
+      auto Tmp = J++;
+      this->Impl.erase(Tmp);
+    }
+
+    // Coalesce-left if possible.
+    if (J != this->begin()) {
+      auto I = std::prev(J);
+      if (I->first.second == KS && I->second == V) {
+        KS = I->first.first;
+        this->Impl.erase(I);
+      }
+    }
+    this->Impl.insert(J, std::make_pair(std::make_pair(KS, KE), std::move(V)));
+  }
+};
+
+template <typename KeyT, typename ValT>
+class IntervalMap<KeyT, ValT, IntervalCoalescing::Disabled>
+    : public IntervalMapBase<KeyT, ValT> {
+public:
+  // Non-coalescing insert. Does not require ValT to be equality-comparable.
+  void insert(KeyT KS, KeyT KE, ValT V) {
+    this->Impl.insert(std::make_pair(std::make_pair(KS, KE), std::move(V)));
+  }
+};
+
+} // End namespace orc_rt
+
+#endif // ORC_RT_INTERVALMAP_H

--- a/orc-rt/include/orc-rt/IntervalSet.h
+++ b/orc-rt/include/orc-rt/IntervalSet.h
@@ -1,0 +1,91 @@
+//===---------- IntervalSet.h - A sorted interval set -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements a coalescing interval set.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_INTERVALSET_H
+#define ORC_RT_INTERVALSET_H
+
+#include "IntervalMap.h"
+
+namespace orc_rt {
+
+/// Implements a coalescing interval set.
+///
+/// Adjacent intervals are coalesced.
+///
+/// NOTE: The interface is kept mostly compatible with LLVM's IntervalMap
+///       collection to make it easy to swap over in the future if we choose
+///       to.
+template <typename KeyT, IntervalCoalescing Coalescing> class IntervalSet {
+private:
+  using ImplMap = IntervalMap<KeyT, std::monostate, Coalescing>;
+
+public:
+  using value_type = std::pair<KeyT, KeyT>;
+
+  class const_iterator {
+    friend class IntervalSet;
+
+  public:
+    using difference_type = typename ImplMap::iterator::difference_type;
+    using value_type = IntervalSet::value_type;
+    using pointer = const value_type *;
+    using reference = const value_type &;
+    using iterator_category = std::input_iterator_tag;
+
+    const_iterator() = default;
+    const value_type &operator*() const { return I->first; }
+    const value_type *operator->() const { return &I->first; }
+    const_iterator &operator++() {
+      ++I;
+      return *this;
+    }
+    const_iterator operator++(int) {
+      auto Tmp = I;
+      ++I;
+      return Tmp;
+    }
+    friend bool operator==(const const_iterator &LHS,
+                           const const_iterator &RHS) {
+      return LHS.I == RHS.I;
+    }
+    friend bool operator!=(const const_iterator &LHS,
+                           const const_iterator &RHS) {
+      return LHS.I != RHS.I;
+    }
+
+  private:
+    const_iterator(typename ImplMap::const_iterator I) : I(std::move(I)) {}
+    typename ImplMap::const_iterator I;
+  };
+
+  bool empty() const { return Map.empty(); }
+
+  void clear() { Map.clear(); }
+
+  const_iterator begin() const { return const_iterator(Map.begin()); }
+  const_iterator end() const { return const_iterator(Map.end()); }
+
+  const_iterator find(KeyT K) const { return const_iterator(Map.find(K)); }
+
+  void insert(KeyT KS, KeyT KE) {
+    Map.insert(std::move(KS), std::move(KE), std::monostate());
+  }
+
+  void erase(KeyT KS, KeyT KE) { Map.erase(KS, KE); }
+
+private:
+  ImplMap Map;
+};
+
+} // End namespace orc_rt
+
+#endif // ORC_RT_INTERVALSET_H

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -15,6 +15,8 @@ add_orc_rt_unittest(CoreTests
   BitmaskEnumTest.cpp
   ErrorTest.cpp
   ExecutorAddressTest.cpp
+  IntervalMapTest.cpp
+  IntervalSetTest.cpp
   MathTest.cpp
   RTTITest.cpp
   WrapperFunctionResultTest.cpp

--- a/orc-rt/unittests/IntervalMapTest.cpp
+++ b/orc-rt/unittests/IntervalMapTest.cpp
@@ -1,0 +1,204 @@
+//===- IntervalMapTest.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of the ORC runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/IntervalMap.h"
+#include "gtest/gtest.h"
+
+using namespace orc_rt;
+
+TEST(IntervalMapTest, DefaultConstructed) {
+  // Check that a default-constructed IntervalMap behaves as expected.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M;
+
+  EXPECT_TRUE(M.empty());
+  EXPECT_TRUE(M.begin() == M.end());
+  EXPECT_TRUE(M.find(0) == M.end());
+}
+
+TEST(IntervalMapTest, InsertSingleElement) {
+  // Check that a map with a single element inserted behaves as expected.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M;
+
+  M.insert(7, 8, 42);
+
+  EXPECT_FALSE(M.empty());
+  EXPECT_EQ(std::next(M.begin()), M.end());
+  EXPECT_EQ(M.find(7), M.begin());
+  EXPECT_EQ(M.find(8), M.end());
+  EXPECT_EQ(M.lookup(7), 42U);
+  EXPECT_EQ(M.lookup(8), 0U); // 8 not present, so should return unsigned().
+}
+
+TEST(IntervalMapTest, InsertCoalesceWithPrevious) {
+  // Check that insertions coalesce with previous ranges that share the same
+  // value. Also check that they _don't_ coalesce if the values are different.
+
+  // Check that insertion coalesces with previous range when values are equal.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M1;
+
+  M1.insert(7, 8, 42);
+  M1.insert(8, 9, 42);
+
+  EXPECT_FALSE(M1.empty());
+  EXPECT_EQ(std::next(M1.begin()), M1.end()); // Should see just one range.
+  EXPECT_EQ(M1.find(7), M1.find(8)); // 7 and 8 should point to same range.
+  EXPECT_EQ(M1.lookup(7), 42U);      // Value should be preserved.
+
+  // Check that insertion does not coalesce with previous range when values are
+  // not equal.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M2;
+
+  M2.insert(7, 8, 42);
+  M2.insert(8, 9, 7);
+
+  EXPECT_FALSE(M2.empty());
+  EXPECT_EQ(std::next(std::next(M2.begin())), M2.end()); // Expect two ranges.
+  EXPECT_NE(M2.find(7), M2.find(8)); // 7 and 8 should be different ranges.
+  EXPECT_EQ(M2.lookup(7), 42U); // Keys 7 and 8 should map to different values.
+  EXPECT_EQ(M2.lookup(8), 7U);
+}
+
+TEST(IntervalMapTest, InsertCoalesceWithFollowing) {
+  // Check that insertions coalesce with following ranges that share the same
+  // value. Also check that they _don't_ coalesce if the values are different.
+
+  // Check that insertion coalesces with following range when values are equal.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M1;
+
+  M1.insert(8, 9, 42);
+  M1.insert(7, 8, 42);
+
+  EXPECT_FALSE(M1.empty());
+  EXPECT_EQ(std::next(M1.begin()), M1.end()); // Should see just one range.
+  EXPECT_EQ(M1.find(7), M1.find(8)); // 7 and 8 should point to same range.
+  EXPECT_EQ(M1.lookup(7), 42U);      // Value should be preserved.
+
+  // Check that insertion does not coalesce with previous range when values are
+  // not equal.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M2;
+
+  M2.insert(8, 9, 42);
+  M2.insert(7, 8, 7);
+
+  EXPECT_FALSE(M2.empty());
+  EXPECT_EQ(std::next(std::next(M2.begin())), M2.end()); // Expect two ranges.
+  EXPECT_EQ(M2.lookup(7), 7U); // Keys 7 and 8 should map to different values.
+  EXPECT_EQ(M2.lookup(8), 42U);
+}
+
+TEST(IntervalMapTest, InsertCoalesceBoth) {
+  // Check that insertions coalesce with ranges on both sides where posssible.
+  // Also check that they _don't_ coalesce if the values are different.
+
+  // Check that insertion coalesces with both previous and following ranges
+  // when values are equal.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M1;
+
+  M1.insert(7, 8, 42);
+  M1.insert(9, 10, 42);
+
+  // Check no coalescing yet.
+  EXPECT_NE(M1.find(7), M1.find(9));
+
+  // Insert a 3rd range to trigger coalescing on both sides.
+  M1.insert(8, 9, 42);
+
+  EXPECT_FALSE(M1.empty());
+  EXPECT_EQ(std::next(M1.begin()), M1.end()); // Should see just one range.
+  EXPECT_EQ(M1.find(7), M1.find(8)); // 7, 8, and 9 should point to same range.
+  EXPECT_EQ(M1.find(8), M1.find(9));
+  EXPECT_EQ(M1.lookup(7), 42U); // Value should be preserved.
+
+  // Check that insertion does not coalesce with previous range when values are
+  // not equal.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M2;
+
+  M2.insert(7, 8, 42);
+  M2.insert(8, 9, 7);
+  M2.insert(9, 10, 42);
+
+  EXPECT_FALSE(M2.empty());
+  // Expect three ranges.
+  EXPECT_EQ(std::next(std::next(std::next(M2.begin()))), M2.end());
+  EXPECT_NE(M2.find(7), M2.find(8)); // All keys should map to different ranges.
+  EXPECT_NE(M2.find(8), M2.find(9));
+  EXPECT_EQ(M2.lookup(7), 42U); // Key 7, 8, and 9 should map to different vals.
+  EXPECT_EQ(M2.lookup(8), 7U);
+  EXPECT_EQ(M2.lookup(9), 42U);
+}
+
+TEST(IntervalMapTest, EraseSingleElement) {
+  // Check that we can insert and then remove a single range.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M;
+
+  M.insert(7, 10, 42);
+  EXPECT_FALSE(M.empty());
+  M.erase(7, 10);
+  EXPECT_TRUE(M.empty());
+}
+
+TEST(IntervalMapTest, EraseSplittingLeft) {
+  // Check that removal of a trailing subrange succeeds, but leaves the
+  // residual range in-place.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M;
+
+  M.insert(7, 10, 42);
+  EXPECT_FALSE(M.empty());
+  M.erase(9, 10);
+  EXPECT_EQ(std::next(M.begin()), M.end());
+  EXPECT_EQ(M.begin()->first.first, 7U);
+  EXPECT_EQ(M.begin()->first.second, 9U);
+}
+
+TEST(IntervalMapTest, EraseSplittingRight) {
+  // Check that removal of a leading subrange succeeds, but leaves the
+  // residual range in-place.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M;
+
+  M.insert(7, 10, 42);
+  EXPECT_FALSE(M.empty());
+  M.erase(7, 8);
+  EXPECT_EQ(std::next(M.begin()), M.end());
+  EXPECT_EQ(M.begin()->first.first, 8U);
+  EXPECT_EQ(M.begin()->first.second, 10U);
+}
+
+TEST(IntervalMapTest, EraseSplittingBoth) {
+  // Check that removal of an interior subrange leaves both the leading and
+  // trailing residual subranges in-place.
+  IntervalMap<unsigned, unsigned, IntervalCoalescing::Enabled> M;
+
+  M.insert(7, 10, 42);
+  EXPECT_FALSE(M.empty());
+  M.erase(8, 9);
+  EXPECT_EQ(std::next(std::next(M.begin())), M.end());
+  EXPECT_EQ(M.begin()->first.first, 7U);
+  EXPECT_EQ(M.begin()->first.second, 8U);
+  EXPECT_EQ(std::next(M.begin())->first.first, 9U);
+  EXPECT_EQ(std::next(M.begin())->first.second, 10U);
+}
+
+TEST(IntervalMapTest, NonCoalescingMapPermitsNonComparableKeys) {
+  // Test that values that can't be equality-compared are still usable when
+  // coalescing is disabled and behave as expected.
+
+  struct S {}; // Struct with no equality comparison.
+
+  IntervalMap<unsigned, S, IntervalCoalescing::Disabled> M;
+
+  M.insert(7, 8, S());
+
+  EXPECT_FALSE(M.empty());
+  EXPECT_EQ(std::next(M.begin()), M.end());
+  EXPECT_EQ(M.find(7), M.begin());
+  EXPECT_EQ(M.find(8), M.end());
+}

--- a/orc-rt/unittests/IntervalSetTest.cpp
+++ b/orc-rt/unittests/IntervalSetTest.cpp
@@ -1,0 +1,121 @@
+//===- IntervalSetTest.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of the ORC runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/IntervalSet.h"
+#include "gtest/gtest.h"
+
+using namespace orc_rt;
+
+TEST(IntervalSetTest, DefaultConstructed) {
+  // Check that a default-constructed IntervalSet behaves as expected.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  EXPECT_TRUE(S.empty());
+  EXPECT_TRUE(S.begin() == S.end());
+  EXPECT_TRUE(S.find(0) == S.end());
+}
+
+TEST(IntervalSetTest, InsertSingleElement) {
+  // Check that a set with a single element inserted behaves as expected.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(7, 8);
+
+  EXPECT_FALSE(S.empty());
+  EXPECT_EQ(std::next(S.begin()), S.end());
+  EXPECT_EQ(S.find(7), S.begin());
+  EXPECT_EQ(S.find(8), S.end());
+}
+
+TEST(IntervalSetTest, InsertCoalesceWithPrevious) {
+  // Check that insertions coalesce with previous ranges.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(7, 8);
+  S.insert(8, 9);
+
+  EXPECT_FALSE(S.empty());
+  EXPECT_EQ(std::next(S.begin()), S.end()); // Should see just one range.
+  EXPECT_EQ(S.find(7), S.find(8)); // 7 and 8 should point to same range.
+}
+
+TEST(IntervalSetTest, InsertCoalesceWithFollowing) {
+  // Check that insertions coalesce with following ranges.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(8, 9);
+  S.insert(7, 8);
+
+  EXPECT_FALSE(S.empty());
+  EXPECT_EQ(std::next(S.begin()), S.end()); // Should see just one range.
+  EXPECT_EQ(S.find(7), S.find(8)); // 7 and 8 should point to same range.
+}
+
+TEST(IntervalSetTest, InsertCoalesceBoth) {
+  // Check that insertions coalesce with ranges on both sides.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(7, 8);
+  S.insert(9, 10);
+
+  // Check no coalescing yet.
+  EXPECT_NE(S.find(7), S.find(9));
+
+  // Insert a 3rd range to trigger coalescing on both sides.
+  S.insert(8, 9);
+
+  EXPECT_FALSE(S.empty());
+  EXPECT_EQ(std::next(S.begin()), S.end()); // Should see just one range.
+  EXPECT_EQ(S.find(7), S.find(8)); // 7, 8, and 9 should point to same range.
+  EXPECT_EQ(S.find(8), S.find(9));
+}
+
+TEST(IntervalSetTest, EraseSplittingLeft) {
+  // Check that removal of a trailing subrange succeeds, but leaves the
+  // residual range in-place.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(7, 10);
+  EXPECT_FALSE(S.empty());
+  S.erase(9, 10);
+  EXPECT_EQ(std::next(S.begin()), S.end());
+  EXPECT_EQ(S.begin()->first, 7U);
+  EXPECT_EQ(S.begin()->second, 9U);
+}
+
+TEST(IntervalSetTest, EraseSplittingRight) {
+  // Check that removal of a leading subrange succeeds, but leaves the
+  // residual range in-place.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(7, 10);
+  EXPECT_FALSE(S.empty());
+  S.erase(7, 8);
+  EXPECT_EQ(std::next(S.begin()), S.end());
+  EXPECT_EQ(S.begin()->first, 8U);
+  EXPECT_EQ(S.begin()->second, 10U);
+}
+
+TEST(IntervalSetTest, EraseSplittingBoth) {
+  // Check that removal of an interior subrange leaves both the leading and
+  // trailing residual subranges in-place.
+  IntervalSet<unsigned, IntervalCoalescing::Enabled> S;
+
+  S.insert(7, 10);
+  EXPECT_FALSE(S.empty());
+  S.erase(8, 9);
+  EXPECT_EQ(std::next(std::next(S.begin())), S.end());
+  EXPECT_EQ(S.begin()->first, 7U);
+  EXPECT_EQ(S.begin()->second, 8U);
+  EXPECT_EQ(std::next(S.begin())->first, 9U);
+  EXPECT_EQ(std::next(S.begin())->second, 10U);
+}


### PR DESCRIPTION
IntervalMap is an optionally-coalescing map: it uses half-open ranges as keys, allows lookups based on elements of the ranges (returning an iterator to the containing range) and optionally coalesces adjacent ranges that have the same value.

IntervalSet is an optionally-coalescing set based on IntervalMap.

These collections will be used to store address-range information in the ORC runtime.