### PR TITLE
Revert "[ADT] Deprecate the redirection from SmallSet to SmallPtrSet"

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -269,28 +269,7 @@ private:
 /// If this set is of pointer values, transparently switch over to using
 /// SmallPtrSet for performance.
 template <typename PointeeType, unsigned N>
-class SmallSet<PointeeType *, N> : public SmallPtrSet<PointeeType *, N> {
-  using Base = SmallPtrSet<PointeeType *, N>;
-
-public:
-  // LLVM_DEPRECATED placed between "template" and "class" above won't work for
-  // some reason.  Put a deprecation message on constructors instead.
-  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet() = default;
-  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet(const SmallSet &) = default;
-  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet(SmallSet &&) = default;
-  template <typename IterT>
-  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet(IterT Begin, IterT End) : Base(Begin, End) {}
-  template <typename Range>
-  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet(llvm::from_range_t, Range &&R)
-      : Base(llvm::from_range, std::move(R)) {}
-  LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-  SmallSet(std::initializer_list<PointeeType *> L) : Base(L) {}
-};
+class SmallSet<PointeeType*, N> : public SmallPtrSet<PointeeType*, N> {};
 
 /// Equality comparison for SmallSet.
 ///


### PR DESCRIPTION
Reverts llvm/llvm-project#154891

The added constructors changes the semantics of other implicitly defined constructors, which causes downstream breakages.

```
... error: object of type 'X' cannot be assigned because its copy assignment operator is implicitly deleted
... note: explicitly defaulted function was implicitly deleted here
... note: copy assignment operator of 'X' is implicitly deleted because field 'x' has a deleted copy assignment operator
llvm/include/llvm/ADT/SmallSet.h:283:3: note: copy assignment operator is implicitly deleted because 'SmallSet<const XX *, 2>' has a user-declared move constructor
  283 |   SmallSet(SmallSet &&) = default;
```