### PR TITLE
[MLIR] Adopt LDBG() in EliminateBarriers.cpp (NFC)

### DIFF
--- a/llvm/include/llvm/Support/Debug.h
+++ b/llvm/include/llvm/Support/Debug.h
@@ -44,6 +44,11 @@ class raw_ostream;
 /// level, return false.
 LLVM_ABI bool isCurrentDebugType(const char *Type, int Level = 0);
 
+/// Overload allowing to swap the order of the Type and Level arguments.
+LLVM_ABI inline bool isCurrentDebugType(int Level, const char *Type) {
+  return isCurrentDebugType(Type, Level);
+}
+
 /// setCurrentDebugType - Set the current debug type, as if the -debug-only=X
 /// option were specified.  Note that DebugFlag also needs to be set to true for
 /// debug output to be produced.


### PR DESCRIPTION
Also add an extra optional TYPE argument to the LDBG() macro to make it easier to punctually overide DEBUG_TYPE.