### PR TITLE
[MLIR][GPU] Truncate temp filename path size to avoid linux limitations

### DIFF
--- a/mlir/lib/Target/LLVM/NVVM/Target.cpp
+++ b/mlir/lib/Target/LLVM/NVVM/Target.cpp
@@ -267,6 +267,8 @@ NVPTXSerializer::NVPTXSerializer(Operation &module, NVVMTargetAttr target,
 std::optional<NVPTXSerializer::TmpFile>
 NVPTXSerializer::createTemp(StringRef name, StringRef suffix) {
   llvm::SmallString<128> filename;
+  if (name.size() > 80)
+    name = name.substr(0, 80);
   std::error_code ec =
       llvm::sys::fs::createTemporaryFile(name, suffix, filename);
   if (ec) {


### PR DESCRIPTION
Linux has a limitation of 256 characters for a path. Large function names being serialized will cause this to fail. As createTemporaryFile already unique's the file (up to 128 retries for different name variations), truncating should suffice