### PR TITLE
[VectorCombine] Avoid crash when the next node is deleted.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -4260,6 +4260,10 @@ bool VectorCombine::run() {
     if (!DT.isReachableFromEntry(&BB))
       continue;
     // Use early increment range so that we can erase instructions in loop.
+    // make_early_inc_range is not applicable here, as the next iterator may
+    // be invalidated by RecursivelyDeleteTriviallyDeadInstructions.
+    // We manually maintain the next instruction and update it when it is about
+    // to be deleted.
     Instruction *I = &BB.front();
     while (I) {
       NextInst = I->getNextNode();

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -4267,9 +4267,8 @@ bool VectorCombine::run() {
     Instruction *I = &BB.front();
     while (I) {
       NextInst = I->getNextNode();
-      if (!I->isDebugOrPseudoInst()) {
+      if (!I->isDebugOrPseudoInst())
         MadeChange |= FoldInst(*I);
-      }
       I = NextInst;
     }
   }

--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -99,6 +99,10 @@ private:
 
   InstructionWorklist Worklist;
 
+  /// Next instruction to iterate. It will be updated when it is erased by
+  /// RecursivelyDeleteTriviallyDeadInstructions.
+  Instruction *NextInst;
+
   // TODO: Direct calls from the top-level "run" loop use a plain "Instruction"
   //       parameter. That should be updated to specific sub-classes because the
   //       run loop was changed to dispatch on opcode.
@@ -172,9 +176,11 @@ private:
         if (auto *OpI = dyn_cast<Instruction>(Op)) {
           if (RecursivelyDeleteTriviallyDeadInstructions(
                   OpI, nullptr, nullptr, [this](Value *V) {
-                    if (auto I = dyn_cast<Instruction>(V)) {
+                    if (auto *I = dyn_cast<Instruction>(V)) {
                       LLVM_DEBUG(dbgs() << "VC: Erased: " << *I << '\n');
                       Worklist.remove(I);
+                      if (I == NextInst)
+                        NextInst = NextInst->getNextNode();
                     }
                   }))
             continue;
@@ -4254,12 +4260,17 @@ bool VectorCombine::run() {
     if (!DT.isReachableFromEntry(&BB))
       continue;
     // Use early increment range so that we can erase instructions in loop.
-    for (Instruction &I : make_early_inc_range(BB)) {
-      if (I.isDebugOrPseudoInst())
-        continue;
-      MadeChange |= FoldInst(I);
+    Instruction *I = &BB.front();
+    while (I) {
+      NextInst = I->getNextNode();
+      if (!I->isDebugOrPseudoInst()) {
+        MadeChange |= FoldInst(*I);
+      }
+      I = NextInst;
     }
   }
+
+  NextInst = nullptr;
 
   while (!Worklist.isEmpty()) {
     Instruction *I = Worklist.removeOne();

--- a/llvm/test/Transforms/VectorCombine/X86/insert-binop-inseltpoison.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/insert-binop-inseltpoison.ll
@@ -232,3 +232,23 @@ define <4 x float> @ins3_ins3_fdiv(float %x, float %y) {
   %r = fdiv <4 x float> %i0, %i1
   ret <4 x float> %r
 }
+
+; EEnsure we don't crash when erasing dead instructions.
+
+define i32 @pr155110(i32 %x) {
+; CHECK-LABEL: @pr155110(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    br label [[VECTOR_PH:%.*]]
+; CHECK:       vector.ph:
+; CHECK-NEXT:    br label [[VECTOR_PH]]
+;
+entry:
+  br label %vector.ph
+
+vector.ph:                                        ; preds = %vector.ph, %entry
+  %phi = phi i32 [ 0, %entry ], [ %reduce, %vector.ph ]
+  %inselt = insertelement <4 x i32> poison, i32 %phi, i64 0
+  %and = and <4 x i32> %inselt, zeroinitializer
+  %reduce = call i32 @llvm.vector.reduce.and.v4i32(<4 x i32> zeroinitializer)
+  br label %vector.ph
+}

--- a/llvm/test/Transforms/VectorCombine/X86/insert-binop-inseltpoison.ll
+++ b/llvm/test/Transforms/VectorCombine/X86/insert-binop-inseltpoison.ll
@@ -233,7 +233,7 @@ define <4 x float> @ins3_ins3_fdiv(float %x, float %y) {
   ret <4 x float> %r
 }
 
-; EEnsure we don't crash when erasing dead instructions.
+; Ensure we don't crash when erasing dead instructions.
 
 define i32 @pr155110(i32 %x) {
 ; CHECK-LABEL: @pr155110(


### PR DESCRIPTION
`RecursivelyDeleteTriviallyDeadInstructions` is introduced by https://github.com/llvm/llvm-project/pull/149047 to immediately drop dead instructions. However, it may invalidate the next iterator in `make_early_inc_range` in some edge cases, which leads to a crash. This patch manually maintains the next iterator and updates it when the next instruction is about to be deleted.

Closes https://github.com/llvm/llvm-project/issues/155110.
