### PR TITLE
Revert "[NFC][SampleFDO] In text sample prof reader, report dreport more concrete parsing errors for different line types"

### DIFF
--- a/llvm/lib/ProfileData/SampleProfReader.cpp
+++ b/llvm/lib/ProfileData/SampleProfReader.cpp
@@ -382,16 +382,9 @@ std::error_code SampleProfileReaderText::readImpl() {
       if (!ParseLine(*LineIt, LineTy, Depth, NumSamples, LineOffset,
                      Discriminator, FName, TargetCountMap, FunctionHash,
                      Attributes, IsFlat)) {
-        switch (LineTy) {
-        case LineType::Metadata:
-          reportError(LineIt.line_number(),
-                      "Cannot parse metadata: " + *LineIt);
-          break;
-        default:
-          reportError(LineIt.line_number(),
-                      "Expected 'NUM[.NUM]: NUM[ mangled_name:NUM]*', found " +
-                          *LineIt);
-        }
+        reportError(LineIt.line_number(),
+                    "Expected 'NUM[.NUM]: NUM[ mangled_name:NUM]*', found " +
+                        *LineIt);
         return sampleprof_error::malformed;
       }
       if (LineTy != LineType::Metadata && Depth == DepthMetadata) {


### PR DESCRIPTION
Reverts llvm/llvm-project#154885 to fix build bot failure (https://lab.llvm.org/buildbot/#/builders/144/builds/33611)