### PR TITLE
X86: Stop overriding getRegClass

### DIFF
--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -93,21 +93,6 @@ X86InstrInfo::X86InstrInfo(const X86Subtarget &STI)
                       X86::CATCHRET, (STI.is64Bit() ? X86::RET64 : X86::RET32)),
       Subtarget(STI), RI(STI.getTargetTriple()) {}
 
-const TargetRegisterClass *X86InstrInfo::getRegClass(const MCInstrDesc &MCID,
-                                                     unsigned OpNum) const {
-  auto *RC = TargetInstrInfo::getRegClass(MCID, OpNum);
-  // If the target does not have egpr, then r16-r31 will be resereved for all
-  // instructions.
-  if (!RC || !Subtarget.hasEGPR())
-    return RC;
-
-  if (X86II::canUseApxExtendedReg(MCID))
-    return RC;
-
-  const X86RegisterInfo *RI = Subtarget.getRegisterInfo();
-  return RI->constrainRegClassToNonRex2(RC);
-}
-
 bool X86InstrInfo::isCoalescableExtInstr(const MachineInstr &MI,
                                          Register &SrcReg, Register &DstReg,
                                          unsigned &SubIdx) const {

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -240,15 +240,6 @@ class X86InstrInfo final : public X86GenInstrInfo {
 public:
   explicit X86InstrInfo(const X86Subtarget &STI);
 
-  /// Given a machine instruction descriptor, returns the register
-  /// class constraint for OpNum, or NULL. Returned register class
-  /// may be different from the definition in the TD file, e.g.
-  /// GR*RegClass (definition in TD file)
-  /// ->
-  /// GR*_NOREX2RegClass (Returned register class)
-  const TargetRegisterClass *getRegClass(const MCInstrDesc &MCID,
-                                         unsigned OpNum) const override;
-
   /// getRegisterInfo - TargetInstrInfo is a superset of MRegister info.  As
   /// such, whenever a client has an instance of instruction info, it should
   /// always be able to get register info as well (through this method).

--- a/llvm/test/CodeGen/X86/apx/no-rex2-general.ll
+++ b/llvm/test/CodeGen/X86/apx/no-rex2-general.ll
@@ -31,13 +31,11 @@ define i32 @map1_or_vex(<2 x double> noundef %a) nounwind {
 ;
 ; AVX-LABEL: map1_or_vex:
 ; AVX:       # %bb.0: # %entry
-; AVX-NEXT:    pushq %rbx
-; AVX-NEXT:    vcvtsd2si %xmm0, %ebx
+; AVX-NEXT:    vcvtsd2si %xmm0, %r16d
 ; AVX-NEXT:    #APP
 ; AVX-NEXT:    nop
 ; AVX-NEXT:    #NO_APP
-; AVX-NEXT:    movl %ebx, %eax
-; AVX-NEXT:    popq %rbx
+; AVX-NEXT:    movl %r16d, %eax
 ; AVX-NEXT:    retq
 entry:
   %0 = tail call i32 @llvm.x86.sse2.cvtsd2si(<2 x double> %a)
@@ -48,30 +46,22 @@ entry:
 define <2 x i64> @map2_or_vex(ptr nocapture noundef readonly %b, i64 noundef %c) nounwind {
 ; SSE-LABEL: map2_or_vex:
 ; SSE:       # %bb.0: # %entry
-; SSE-NEXT:    pushq %r14
-; SSE-NEXT:    pushq %rbx
-; SSE-NEXT:    movq %rsi, %rbx
-; SSE-NEXT:    movq %rdi, %r14
+; SSE-NEXT:    movq %rsi, %r16
+; SSE-NEXT:    movq %rdi, %r17
 ; SSE-NEXT:    #APP
 ; SSE-NEXT:    nop
 ; SSE-NEXT:    #NO_APP
-; SSE-NEXT:    pabsb (%r14,%rbx,4), %xmm0
-; SSE-NEXT:    popq %rbx
-; SSE-NEXT:    popq %r14
+; SSE-NEXT:    pabsb (%r17,%r16,4), %xmm0
 ; SSE-NEXT:    retq
 ;
 ; AVX-LABEL: map2_or_vex:
 ; AVX:       # %bb.0: # %entry
-; AVX-NEXT:    pushq %r14
-; AVX-NEXT:    pushq %rbx
-; AVX-NEXT:    movq %rsi, %rbx
-; AVX-NEXT:    movq %rdi, %r14
+; AVX-NEXT:    movq %rsi, %r16
+; AVX-NEXT:    movq %rdi, %r17
 ; AVX-NEXT:    #APP
 ; AVX-NEXT:    nop
 ; AVX-NEXT:    #NO_APP
-; AVX-NEXT:    vpabsb (%r14,%rbx,4), %xmm0
-; AVX-NEXT:    popq %rbx
-; AVX-NEXT:    popq %r14
+; AVX-NEXT:    vpabsb (%r17,%r16,4), %xmm0
 ; AVX-NEXT:    retq
 entry:
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{edx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()

--- a/llvm/test/CodeGen/X86/apx/no-rex2-pseudo-amx.ll
+++ b/llvm/test/CodeGen/X86/apx/no-rex2-pseudo-amx.ll
@@ -4,14 +4,12 @@
 define dso_local void @amx(ptr noundef %data) nounwind {
 ; CHECK-LABEL: amx:
 ; CHECK:       # %bb.0: # %entry
-; CHECK-NEXT:    pushq %rbx
-; CHECK-NEXT:    movq %rdi, %rbx
+; CHECK-NEXT:    movq %rdi, %r16
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    movl $8, %eax
-; CHECK-NEXT:    tileloadd (%rbx,%rax), %tmm4
-; CHECK-NEXT:    popq %rbx
+; CHECK-NEXT:    tileloadd (%r16,%rax), %tmm4
 ; CHECK-NEXT:    retq
 entry:
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{edx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()

--- a/llvm/test/CodeGen/X86/apx/no-rex2-pseudo-x87.ll
+++ b/llvm/test/CodeGen/X86/apx/no-rex2-pseudo-x87.ll
@@ -4,17 +4,13 @@
 define void @x87(ptr %0, ptr %1) nounwind {
 ; CHECK-LABEL: x87:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushq %r14
-; CHECK-NEXT:    pushq %rbx
-; CHECK-NEXT:    movq %rsi, %rbx
-; CHECK-NEXT:    movq %rdi, %r14
+; CHECK-NEXT:    movq %rsi, %r16
+; CHECK-NEXT:    movq %rdi, %r17
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    #NO_APP
-; CHECK-NEXT:    flds (%r14)
-; CHECK-NEXT:    fstps (%rbx)
-; CHECK-NEXT:    popq %rbx
-; CHECK-NEXT:    popq %r14
+; CHECK-NEXT:    flds (%r17)
+; CHECK-NEXT:    fstps (%r16)
 ; CHECK-NEXT:    retq
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{edx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()
   %3 = load float, ptr %0

--- a/llvm/test/CodeGen/X86/apx/no-rex2-special.ll
+++ b/llvm/test/CodeGen/X86/apx/no-rex2-special.ll
@@ -4,16 +4,14 @@
 define void @test_xsave(ptr %ptr, i32 %hi, i32 %lo) nounwind {
 ; CHECK-LABEL: test_xsave:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushq %rbx
 ; CHECK-NEXT:    movl %edx, %r16d
 ; CHECK-NEXT:    movl %esi, %edx
-; CHECK-NEXT:    movq %rdi, %rbx
+; CHECK-NEXT:    movq %rdi, %r17
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    movl %r16d, %eax
-; CHECK-NEXT:    xsave (%rbx)
-; CHECK-NEXT:    popq %rbx
+; CHECK-NEXT:    xsave (%r17)
 ; CHECK-NEXT:    retq
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()
   call void @llvm.x86.xsave(ptr %ptr, i32 %hi, i32 %lo)
@@ -24,16 +22,14 @@ declare void @llvm.x86.xsave(ptr, i32, i32)
 define void @test_xsave64(ptr %ptr, i32 %hi, i32 %lo) nounwind {
 ; CHECK-LABEL: test_xsave64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushq %rbx
 ; CHECK-NEXT:    movl %edx, %r16d
 ; CHECK-NEXT:    movl %esi, %edx
-; CHECK-NEXT:    movq %rdi, %rbx
+; CHECK-NEXT:    movq %rdi, %r17
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    movl %r16d, %eax
-; CHECK-NEXT:    xsave64 (%rbx)
-; CHECK-NEXT:    popq %rbx
+; CHECK-NEXT:    xsave64 (%r17)
 ; CHECK-NEXT:    retq
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()
   call void @llvm.x86.xsave64(ptr %ptr, i32 %hi, i32 %lo)
@@ -44,16 +40,14 @@ declare void @llvm.x86.xsave64(ptr, i32, i32)
 define void @test_xrstor(ptr %ptr, i32 %hi, i32 %lo) nounwind {
 ; CHECK-LABEL: test_xrstor:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushq %rbx
 ; CHECK-NEXT:    movl %edx, %r16d
 ; CHECK-NEXT:    movl %esi, %edx
-; CHECK-NEXT:    movq %rdi, %rbx
+; CHECK-NEXT:    movq %rdi, %r17
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    movl %r16d, %eax
-; CHECK-NEXT:    xrstor (%rbx)
-; CHECK-NEXT:    popq %rbx
+; CHECK-NEXT:    xrstor (%r17)
 ; CHECK-NEXT:    retq
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()
   call void @llvm.x86.xrstor(ptr %ptr, i32 %hi, i32 %lo)
@@ -64,16 +58,14 @@ declare void @llvm.x86.xrstor(ptr, i32, i32)
 define void @test_xrstor64(ptr %ptr, i32 %hi, i32 %lo) nounwind {
 ; CHECK-LABEL: test_xrstor64:
 ; CHECK:       # %bb.0:
-; CHECK-NEXT:    pushq %rbx
 ; CHECK-NEXT:    movl %edx, %r16d
 ; CHECK-NEXT:    movl %esi, %edx
-; CHECK-NEXT:    movq %rdi, %rbx
+; CHECK-NEXT:    movq %rdi, %r17
 ; CHECK-NEXT:    #APP
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    #NO_APP
 ; CHECK-NEXT:    movl %r16d, %eax
-; CHECK-NEXT:    xrstor64 (%rbx)
-; CHECK-NEXT:    popq %rbx
+; CHECK-NEXT:    xrstor64 (%r17)
 ; CHECK-NEXT:    retq
   tail call void asm sideeffect "nop", "~{eax},~{ecx},~{esi},~{edi},~{r8},~{r9},~{r10},~{r11}"()
   call void @llvm.x86.xrstor64(ptr %ptr, i32 %hi, i32 %lo)


### PR DESCRIPTION
This function should not be virtual; making this virtual was
an AMDGPU hack that should be removed not spread to other
backends.

This does not need to be overridden to reserve registers. The
register reservation mechanism is orthogonal to to the register
class constraints of the instruction, this should be reporting
the underlying instruction constraint. The registers are separately
reserved, so they will be removed from the allocation order anyway.
If the actual class needs to change based on the subtarget,
it should probably generalize the LookupPtrRegClass mechanism.

This was added by #70958. The new tests there for the class are
probably not useful anymore. These instead should compile to the
end and try to stress the allocation behavior.