### PR TITLE
[SPIRV] Use llvm::is_contained (NFC)

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCommandLine.cpp
@@ -228,7 +228,7 @@ SPIRVExtensionsParser::getValidExtensions(const Triple &TT) {
         SPIRV::OperandCategory::OperandCategory::ExtensionOperand,
         ExtensionEnum);
 
-    if (std::count(AllowedEnv.begin(), AllowedEnv.end(), CurrentEnvironment))
+    if (llvm::is_contained(AllowedEnv, CurrentEnvironment))
       R.insert(ExtensionEnum);
   }
 


### PR DESCRIPTION
We can pass a range to llvm::is_contained.
