### PR TITLE
[clang] Heuristic resolution for explicit object parameter

### DIFF
--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -2488,6 +2488,7 @@ TEST(CrossFileRenameTests, adjustmentCost) {
               T.ExpectedCost);
   }
 }
+
 } // namespace
 } // namespace clangd
 } // namespace clang

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -2483,7 +2483,7 @@ TEST(RenameTest, RenameWithExplicitObjectPararameter) {
         return self.[[memb^er]];
       }
       int normal() {
-        return [[memb^er]];
+        return this->[[mem^ber]] + [[memb^er]];
       }
     };
   )cpp"};

--- a/clang/lib/Sema/HeuristicResolver.cpp
+++ b/clang/lib/Sema/HeuristicResolver.cpp
@@ -321,12 +321,14 @@ std::vector<const NamedDecl *> HeuristicResolverImpl::resolveMemberExpr(
   // Try resolving the member inside the expression's base type.
   Expr *Base = ME->isImplicitAccess() ? nullptr : ME->getBase();
   QualType BaseType = ME->getBaseType();
+  BaseType = simplifyType(BaseType, Base, ME->isArrow());
 
-  if (auto Type = ExplicitMemberHeuristic(Base); !Type.isNull()) {
-    BaseType = Type;
+  if (BaseType->isUndeducedAutoType() || BaseType->isTemplateTypeParmType()) {
+    if (auto Type = ExplicitMemberHeuristic(Base); !Type.isNull()) {
+      BaseType = Type;
+    }
   }
 
-  BaseType = simplifyType(BaseType, Base, ME->isArrow());
   return resolveDependentMember(BaseType, ME->getMember(), NoFilter);
 }
 

--- a/clang/lib/Sema/HeuristicResolver.cpp
+++ b/clang/lib/Sema/HeuristicResolver.cpp
@@ -305,7 +305,7 @@ std::vector<const NamedDecl *> HeuristicResolverImpl::resolveMemberExpr(
   // check if member expr is in the context of an explicit object method
   // If so, it's safe to assume the templated arg is of type of the record
   const auto ExplicitMemberHeuristic =
-      [&](const Expr *Base) -> std::optional<QualType> {
+      [&](const Expr *Base) -> QualType {
     if (auto *DeclRef = dyn_cast_if_present<DeclRefExpr>(Base)) {
       auto *PrDecl = dyn_cast_if_present<ParmVarDecl>(DeclRef->getDecl());
 
@@ -319,15 +319,15 @@ std::vector<const NamedDecl *> HeuristicResolverImpl::resolveMemberExpr(
       }
     }
 
-    return std::nullopt;
+    return {};
   };
 
   // Try resolving the member inside the expression's base type.
   Expr *Base = ME->isImplicitAccess() ? nullptr : ME->getBase();
   QualType BaseType = ME->getBaseType();
 
-  if (auto Type = ExplicitMemberHeuristic(Base)) {
-    BaseType = *Type;
+  if (auto Type = ExplicitMemberHeuristic(Base); !Type.isNull()) {
+    BaseType = Type;
   }
 
   BaseType = simplifyType(BaseType, Base, ME->isArrow());

--- a/clang/lib/Sema/HeuristicResolver.cpp
+++ b/clang/lib/Sema/HeuristicResolver.cpp
@@ -323,7 +323,8 @@ std::vector<const NamedDecl *> HeuristicResolverImpl::resolveMemberExpr(
   QualType BaseType = ME->getBaseType();
   BaseType = simplifyType(BaseType, Base, ME->isArrow());
 
-  if (BaseType->isUndeducedAutoType() || BaseType->isTemplateTypeParmType()) {
+  if (!BaseType.isNull() &&
+      (BaseType->isUndeducedAutoType() || BaseType->isTemplateTypeParmType())) {
     if (auto Type = ExplicitMemberHeuristic(Base); !Type.isNull()) {
       BaseType = Type;
     }

--- a/clang/lib/Sema/HeuristicResolver.cpp
+++ b/clang/lib/Sema/HeuristicResolver.cpp
@@ -304,18 +304,14 @@ std::vector<const NamedDecl *> HeuristicResolverImpl::resolveMemberExpr(
 
   // check if member expr is in the context of an explicit object method
   // If so, it's safe to assume the templated arg is of type of the record
-  const auto ExplicitMemberHeuristic =
-      [&](const Expr *Base) -> QualType {
+  const auto ExplicitMemberHeuristic = [&](const Expr *Base) -> QualType {
     if (auto *DeclRef = dyn_cast_if_present<DeclRefExpr>(Base)) {
       auto *PrDecl = dyn_cast_if_present<ParmVarDecl>(DeclRef->getDecl());
 
       if (PrDecl && PrDecl->isExplicitObjectParameter()) {
-        auto CxxRecord = dyn_cast_if_present<CXXRecordDecl>(
-            PrDecl->getDeclContext()->getParent());
-
-        if (CxxRecord) {
-          return Ctx.getTypeDeclType(dyn_cast<TypeDecl>(CxxRecord));
-        }
+        // get the parent, a cxxrecord
+        return Ctx.getTypeDeclType(
+            dyn_cast<TypeDecl>(PrDecl->getDeclContext()->getParent()));
       }
     }
 

--- a/clang/unittests/Sema/HeuristicResolverTest.cpp
+++ b/clang/unittests/Sema/HeuristicResolverTest.cpp
@@ -41,7 +41,7 @@ template <typename InputNode, typename ParamT, typename InputMatcher,
           typename... OutputMatchers>
 void expectResolution(llvm::StringRef Code, ResolveFnT<ParamT> ResolveFn,
                       const InputMatcher &IM, const OutputMatchers &...OMS) {
-  auto TU = tooling::buildASTFromCodeWithArgs(Code, {"-std=c++23"});
+  auto TU = tooling::buildASTFromCodeWithArgs(Code, {"-std=c++20"});
   auto &Ctx = TU->getASTContext();
   auto InputMatches = match(IM, Ctx);
   ASSERT_EQ(1u, InputMatches.size());

--- a/clang/unittests/Sema/HeuristicResolverTest.cpp
+++ b/clang/unittests/Sema/HeuristicResolverTest.cpp
@@ -41,7 +41,7 @@ template <typename InputNode, typename ParamT, typename InputMatcher,
           typename... OutputMatchers>
 void expectResolution(llvm::StringRef Code, ResolveFnT<ParamT> ResolveFn,
                       const InputMatcher &IM, const OutputMatchers &...OMS) {
-  auto TU = tooling::buildASTFromCodeWithArgs(Code, {"-std=c++20"});
+  auto TU = tooling::buildASTFromCodeWithArgs(Code, {"-std=c++23"});
   auto &Ctx = TU->getASTContext();
   auto InputMatches = match(IM, Ctx);
   ASSERT_EQ(1u, InputMatches.size());


### PR DESCRIPTION
Fixes clangd/clangd#2323. 

Assumes `self` is of the record type in the declaration. 

```cpp
struct Foo {
  int member {};
  auto&& getter1(this auto&& self) { // assume `self` is is `Foo`
    return self.member;
};
```