### PR TITLE
[NFC][SimplifyCFG] Fix a return value in `ConstantComparesGatherer`

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -695,7 +695,7 @@ private:
 
       UsedICmps++;
       Vals.push_back(C);
-      return ICI->getOperand(0);
+      return true;
     }
 
     // If we have "x ult 3", for example, then we can add 0,1,2 to the set.


### PR DESCRIPTION
`ICI->getOperand(0)` is non-null.
