### PR TITLE
[TargetLoweringObjectFile] Handle riscv BE

### DIFF
--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -247,6 +247,8 @@ void TargetLoweringObjectFileELF::Initialize(MCContext &Ctx,
     break;
   case Triple::riscv32:
   case Triple::riscv64:
+  case Triple::riscv32be:
+  case Triple::riscv64be:
     LSDAEncoding = dwarf::DW_EH_PE_pcrel | dwarf::DW_EH_PE_sdata4;
     PersonalityEncoding = dwarf::DW_EH_PE_indirect | dwarf::DW_EH_PE_pcrel |
                           dwarf::DW_EH_PE_sdata4;

--- a/llvm/test/CodeGen/RISCV/dwarf-eh.ll
+++ b/llvm/test/CodeGen/RISCV/dwarf-eh.ll
@@ -14,6 +14,22 @@
 ; RUN:     | FileCheck %s
 ; RUN: llc -mtriple=riscv64 --code-model=medium -relocation-model=pic < %s \
 ; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv32be --code-model=small  < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv32be --code-model=medium < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv32be --code-model=small  -relocation-model=pic < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv32be --code-model=medium -relocation-model=pic < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv64be --code-model=small  < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv64be --code-model=medium < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv64be --code-model=small  -relocation-model=pic < %s \
+; RUN:     | FileCheck %s
+; RUN: llc -mtriple=riscv64be --code-model=medium -relocation-model=pic < %s \
+; RUN:     | FileCheck %s
 
 declare void @throw_exception()
 


### PR DESCRIPTION
Add DWARF exception handling support for riscv big-endian targets.
More CodeGen changes related to riscvbe are coming.
