### PR TITLE
[ADT] Use brace initialization in Set/Map (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseMap.h
+++ b/llvm/include/llvm/ADT/DenseMap.h
@@ -257,13 +257,12 @@ public:
   std::pair<iterator, bool> try_emplace(KeyT &&Key, Ts &&...Args) {
     BucketT *TheBucket;
     if (LookupBucketFor(Key, TheBucket))
-      return std::make_pair(makeInsertIterator(TheBucket),
-                            false); // Already in map.
+      return {makeInsertIterator(TheBucket), false}; // Already in map.
 
     // Otherwise, insert the new element.
     TheBucket =
         InsertIntoBucket(TheBucket, std::move(Key), std::forward<Ts>(Args)...);
-    return std::make_pair(makeInsertIterator(TheBucket), true);
+    return {makeInsertIterator(TheBucket), true};
   }
 
   // Inserts key,value pair into the map if the key isn't already in the map.
@@ -273,12 +272,11 @@ public:
   std::pair<iterator, bool> try_emplace(const KeyT &Key, Ts &&...Args) {
     BucketT *TheBucket;
     if (LookupBucketFor(Key, TheBucket))
-      return std::make_pair(makeInsertIterator(TheBucket),
-                            false); // Already in map.
+      return {makeInsertIterator(TheBucket), false}; // Already in map.
 
     // Otherwise, insert the new element.
     TheBucket = InsertIntoBucket(TheBucket, Key, std::forward<Ts>(Args)...);
-    return std::make_pair(makeInsertIterator(TheBucket), true);
+    return {makeInsertIterator(TheBucket), true};
   }
 
   /// Alternate version of insert() which allows a different, and possibly
@@ -291,13 +289,12 @@ public:
                                       const LookupKeyT &Val) {
     BucketT *TheBucket;
     if (LookupBucketFor(Val, TheBucket))
-      return std::make_pair(makeInsertIterator(TheBucket),
-                            false); // Already in map.
+      return {makeInsertIterator(TheBucket), false}; // Already in map.
 
     // Otherwise, insert the new element.
     TheBucket = InsertIntoBucketWithLookup(TheBucket, std::move(KV.first),
                                            std::move(KV.second), Val);
-    return std::make_pair(makeInsertIterator(TheBucket), true);
+    return {makeInsertIterator(TheBucket), true};
   }
 
   /// insert - Range insertion of pairs.

--- a/llvm/include/llvm/ADT/MapVector.h
+++ b/llvm/include/llvm/ADT/MapVector.h
@@ -123,9 +123,9 @@ public:
       It->second = Vector.size();
       Vector.emplace_back(std::piecewise_construct, std::forward_as_tuple(Key),
                           std::forward_as_tuple(std::forward<Ts>(Args)...));
-      return std::make_pair(std::prev(end()), true);
+      return {std::prev(end()), true};
     }
-    return std::make_pair(begin() + It->second, false);
+    return {begin() + It->second, false};
   }
   template <typename... Ts>
   std::pair<iterator, bool> try_emplace(KeyT &&Key, Ts &&...Args) {
@@ -135,9 +135,9 @@ public:
       Vector.emplace_back(std::piecewise_construct,
                           std::forward_as_tuple(std::move(Key)),
                           std::forward_as_tuple(std::forward<Ts>(Args)...));
-      return std::make_pair(std::prev(end()), true);
+      return {std::prev(end()), true};
     }
-    return std::make_pair(begin() + It->second, false);
+    return {begin() + It->second, false};
   }
 
   std::pair<iterator, bool> insert(const std::pair<KeyT, ValueT> &KV) {

--- a/llvm/include/llvm/ADT/SmallPtrSet.h
+++ b/llvm/include/llvm/ADT/SmallPtrSet.h
@@ -172,14 +172,14 @@ protected:
       // Check to see if it is already in the set.
       for (const void *&Bucket : small_buckets()) {
         if (Bucket == Ptr)
-          return std::make_pair(&Bucket, false);
+          return {&Bucket, false};
       }
 
       // Nope, there isn't.  If we stay small, just 'pushback' now.
       if (NumEntries < CurArraySize) {
         CurArray[NumEntries++] = Ptr;
         incrementEpoch();
-        return std::make_pair(CurArray + (NumEntries - 1), true);
+        return {CurArray + (NumEntries - 1), true};
       }
       // Otherwise, hit the big set case, which will call grow.
     }
@@ -400,7 +400,7 @@ public:
   /// the element equal to Ptr.
   std::pair<iterator, bool> insert(PtrType Ptr) {
     auto p = insert_imp(PtrTraits::getAsVoidPointer(Ptr));
-    return std::make_pair(makeIterator(p.first), p.second);
+    return {makeIterator(p.first), p.second};
   }
 
   /// Insert the given pointer with an iterator hint that is ignored. This is

--- a/llvm/include/llvm/ADT/SparseSet.h
+++ b/llvm/include/llvm/ADT/SparseSet.h
@@ -258,10 +258,10 @@ public:
     unsigned Idx = ValIndexOf(Val);
     iterator I = findIndex(Idx);
     if (I != end())
-      return std::make_pair(I, false);
+      return {I, false};
     Sparse[Idx] = size();
     Dense.push_back(Val);
-    return std::make_pair(end() - 1, true);
+    return {end() - 1, true};
   }
 
   /// array subscript - If an element already exists with this key, return it.

--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -380,8 +380,8 @@ public:
     unsigned BucketNo = LookupBucketFor(Key, FullHashValue);
     StringMapEntryBase *&Bucket = TheTable[BucketNo];
     if (Bucket && Bucket != getTombstoneVal())
-      return std::make_pair(iterator(TheTable + BucketNo, false),
-                            false); // Already exists in map.
+      return {iterator(TheTable + BucketNo, false),
+              false}; // Already exists in map.
 
     if (Bucket == getTombstoneVal())
       --NumTombstones;
@@ -391,7 +391,7 @@ public:
     assert(NumItems + NumTombstones <= NumBuckets);
 
     BucketNo = RehashTable(BucketNo);
-    return std::make_pair(iterator(TheTable + BucketNo, false), true);
+    return {iterator(TheTable + BucketNo, false), true};
   }
 
   // clear - Empties out the StringMap


### PR DESCRIPTION
With brace initialization, we get to avoid type decay and enjoy
guaranteed copy elision as part of C++17.
