### PR TITLE
[orc-rt] Add SimplePackedSerialization.

### DIFF
--- a/orc-rt/include/orc-rt/SimplePackedSerialization.h
+++ b/orc-rt/include/orc-rt/SimplePackedSerialization.h
@@ -1,0 +1,684 @@
+//===---- SimplePackedSerialization.h - simple serialization ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of the ORC runtime support library.
+//
+// The behavior of the utilities in this header must be synchronized with the
+// behavior of the utilities in
+// llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h.
+//
+// The Simple Packed Serialization (SPS) utilities are used to generate
+// argument and return buffers for wrapper functions using the following
+// serialization scheme:
+//
+// Primitives:
+//   bool, char, int8_t, uint8_t -- Two's complement 8-bit (0=false, 1=true)
+//   int16_t, uint16_t           -- Two's complement 16-bit little endian
+//   int32_t, uint32_t           -- Two's complement 32-bit little endian
+//   int64_t, int64_t            -- Two's complement 64-bit little endian
+//
+// Sequence<T>:
+//   Serialized as the sequence length (as a uint64_t) followed by the
+//   serialization of each of the elements without padding.
+//
+// Tuple<T1, ..., TN>:
+//   Serialized as each of the element types from T1 to TN without padding.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_SIMPLEPACKEDSERIALIZATION_H
+#define ORC_RT_SIMPLEPACKEDSERIALIZATION_H
+
+#include "orc-rt/Error.h"
+#include "orc-rt/bit.h"
+#include "orc-rt/span.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace orc_rt {
+
+/// Output char buffer with overflow check.
+class SPSOutputBuffer {
+public:
+  SPSOutputBuffer(char *Buffer, size_t Remaining)
+      : Buffer(Buffer), Remaining(Remaining) {}
+  bool write(const char *Data, size_t Size) {
+    if (Size > Remaining)
+      return false;
+    memcpy(Buffer, Data, Size);
+    Buffer += Size;
+    Remaining -= Size;
+    return true;
+  }
+
+private:
+  char *Buffer = nullptr;
+  size_t Remaining = 0;
+};
+
+/// Input char buffer with underflow check.
+class SPSInputBuffer {
+public:
+  SPSInputBuffer() = default;
+  SPSInputBuffer(const char *Buffer, size_t Remaining)
+      : Buffer(Buffer), Remaining(Remaining) {}
+  bool read(char *Data, size_t Size) {
+    if (Size > Remaining)
+      return false;
+    memcpy(Data, Buffer, Size);
+    Buffer += Size;
+    Remaining -= Size;
+    return true;
+  }
+
+  const char *data() const { return Buffer; }
+  bool skip(size_t Size) {
+    if (Size > Remaining)
+      return false;
+    Buffer += Size;
+    Remaining -= Size;
+    return true;
+  }
+
+private:
+  const char *Buffer = nullptr;
+  size_t Remaining = 0;
+};
+
+/// Specialize to describe how to serialize/deserialize to/from the given
+/// concrete type.
+template <typename SPSTagT, typename ConcreteT, typename _ = void>
+class SPSSerializationTraits;
+
+/// A utility class for serializing to a blob from a variadic list.
+template <typename... ArgTs> class SPSArgList;
+
+// Empty list specialization for SPSArgList.
+template <> class SPSArgList<> {
+public:
+  static size_t size() { return 0; }
+
+  static bool serialize(SPSOutputBuffer &OB) { return true; }
+  static bool deserialize(SPSInputBuffer &IB) { return true; }
+};
+
+// Non-empty list specialization for SPSArgList.
+template <typename SPSTagT, typename... SPSTagTs>
+class SPSArgList<SPSTagT, SPSTagTs...> {
+public:
+  template <typename ArgT, typename... ArgTs>
+  static size_t size(const ArgT &Arg, const ArgTs &...Args) {
+    return SPSSerializationTraits<SPSTagT, ArgT>::size(Arg) +
+           SPSArgList<SPSTagTs...>::size(Args...);
+  }
+
+  template <typename ArgT, typename... ArgTs>
+  static bool serialize(SPSOutputBuffer &OB, const ArgT &Arg,
+                        const ArgTs &...Args) {
+    return SPSSerializationTraits<SPSTagT, ArgT>::serialize(OB, Arg) &&
+           SPSArgList<SPSTagTs...>::serialize(OB, Args...);
+  }
+
+  template <typename ArgT, typename... ArgTs>
+  static bool deserialize(SPSInputBuffer &IB, ArgT &Arg, ArgTs &...Args) {
+    return SPSSerializationTraits<SPSTagT, ArgT>::deserialize(IB, Arg) &&
+           SPSArgList<SPSTagTs...>::deserialize(IB, Args...);
+  }
+};
+
+/// SPS serialization for integral types, bool, and char.
+template <typename SPSTagT>
+class SPSSerializationTraits<
+    SPSTagT, SPSTagT,
+    std::enable_if_t<std::is_same<SPSTagT, bool>::value ||
+                     std::is_same<SPSTagT, char>::value ||
+                     std::is_same<SPSTagT, int8_t>::value ||
+                     std::is_same<SPSTagT, int16_t>::value ||
+                     std::is_same<SPSTagT, int32_t>::value ||
+                     std::is_same<SPSTagT, int64_t>::value ||
+                     std::is_same<SPSTagT, uint8_t>::value ||
+                     std::is_same<SPSTagT, uint16_t>::value ||
+                     std::is_same<SPSTagT, uint32_t>::value ||
+                     std::is_same<SPSTagT, uint64_t>::value>> {
+public:
+  static size_t size(const SPSTagT &Value) { return sizeof(SPSTagT); }
+
+  static bool serialize(SPSOutputBuffer &OB, const SPSTagT &Value) {
+    SPSTagT Tmp = (endian::native == endian::big) ? byteswap(Value) : Value;
+    return OB.write(reinterpret_cast<const char *>(&Tmp), sizeof(Tmp));
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, SPSTagT &Value) {
+    SPSTagT Tmp;
+    if (!IB.read(reinterpret_cast<char *>(&Tmp), sizeof(Tmp)))
+      return false;
+    Value = (endian::native == endian::big) ? byteswap(Tmp) : Tmp;
+    return true;
+  }
+};
+
+/// Any empty placeholder suitable as a substitute for void when deserializing
+class SPSEmpty {};
+
+/// Represents an address in the executor.
+class SPSExecutorAddr {};
+
+/// SPS tag type for tuples.
+///
+/// A blob tuple should be serialized by serializing each of the elements in
+/// sequence.
+template <typename... SPSTagTs> class SPSTuple {
+public:
+  /// Convenience typedef of the corresponding arg list.
+  typedef SPSArgList<SPSTagTs...> AsArgList;
+};
+
+/// SPS tag type for optionals.
+///
+/// SPSOptionals should be serialized as a bool with true indicating that an
+/// SPSTagT value is present, and false indicating that there is no value.
+/// If the boolean is true then the serialized SPSTagT will follow immediately
+/// after it.
+template <typename SPSTagT> class SPSOptional {};
+
+/// SPS tag type for sequences.
+///
+/// SPSSequences should be serialized as a uint64_t sequence length,
+/// followed by the serialization of each of the elements.
+template <typename SPSElementTagT> class SPSSequence;
+
+/// SPS tag type for strings, which are equivalent to sequences of chars.
+using SPSString = SPSSequence<char>;
+
+/// SPS tag type for maps.
+///
+/// SPS maps are just sequences of (Key, Value) tuples.
+template <typename SPSTagT1, typename SPSTagT2>
+using SPSMap = SPSSequence<SPSTuple<SPSTagT1, SPSTagT2>>;
+
+/// Serialization for SPSEmpty type.
+template <> class SPSSerializationTraits<SPSEmpty, SPSEmpty> {
+public:
+  static size_t size(const SPSEmpty &EP) { return 0; }
+  static bool serialize(SPSOutputBuffer &OB, const SPSEmpty &BE) {
+    return true;
+  }
+  static bool deserialize(SPSInputBuffer &IB, SPSEmpty &BE) { return true; }
+};
+
+/// Specialize this to implement 'trivial' sequence serialization for
+/// a concrete sequence type.
+///
+/// Trivial sequence serialization uses the sequence's 'size' member to get the
+/// length of the sequence, and uses a range-based for loop to iterate over the
+/// elements.
+///
+/// Specializing this template class means that you do not need to provide a
+/// specialization of SPSSerializationTraits for your type.
+template <typename SPSElementTagT, typename ConcreteSequenceT>
+class TrivialSPSSequenceSerialization {
+public:
+  static constexpr bool available = false;
+};
+
+/// Specialize this to implement 'trivial' sequence deserialization for
+/// a concrete sequence type.
+///
+/// Trivial deserialization calls a static 'reserve(SequenceT&)' method on your
+/// specialization (you must implement this) to reserve space, and then calls
+/// a static 'append(SequenceT&, ElementT&) method to append each of the
+/// deserialized elements.
+///
+/// Specializing this template class means that you do not need to provide a
+/// specialization of SPSSerializationTraits for your type.
+template <typename SPSElementTagT, typename ConcreteSequenceT>
+class TrivialSPSSequenceDeserialization {
+public:
+  static constexpr bool available = false;
+};
+
+/// Trivial std::string -> SPSSequence<char> serialization.
+template <> class TrivialSPSSequenceSerialization<char, std::string> {
+public:
+  static constexpr bool available = true;
+};
+
+/// Trivial SPSSequence<char> -> std::string deserialization.
+template <> class TrivialSPSSequenceDeserialization<char, std::string> {
+public:
+  static constexpr bool available = true;
+
+  using element_type = char;
+
+  static void reserve(std::string &S, uint64_t Size) { S.reserve(Size); }
+  static bool append(std::string &S, char C) {
+    S.push_back(C);
+    return true;
+  }
+};
+
+/// Trivial std::vector<T> -> SPSSequence<SPSElementTagT> serialization.
+template <typename SPSElementTagT, typename T>
+class TrivialSPSSequenceSerialization<SPSElementTagT, std::vector<T>> {
+public:
+  static constexpr bool available = true;
+};
+
+/// Trivial span<T> -> SPSSequence<SPSElementTagT> serialization.
+template <typename SPSElementTagT, typename T>
+class TrivialSPSSequenceSerialization<SPSElementTagT, span<T>> {
+public:
+  static constexpr bool available = true;
+};
+
+/// Trivial SPSSequence<SPSElementTagT> -> std::vector<T> deserialization.
+template <typename SPSElementTagT, typename T>
+class TrivialSPSSequenceDeserialization<SPSElementTagT, std::vector<T>> {
+public:
+  static constexpr bool available = true;
+
+  using element_type = typename std::vector<T>::value_type;
+
+  static void reserve(std::vector<T> &V, uint64_t Size) { V.reserve(Size); }
+  static bool append(std::vector<T> &V, T E) {
+    V.push_back(std::move(E));
+    return true;
+  }
+};
+
+/// Trivial std::unordered_map<K, V> -> SPSSequence<SPSTuple<SPSKey, SPSValue>>
+/// serialization.
+template <typename SPSKeyTagT, typename SPSValueTagT, typename K, typename V>
+class TrivialSPSSequenceSerialization<SPSTuple<SPSKeyTagT, SPSValueTagT>,
+                                      std::unordered_map<K, V>> {
+public:
+  static constexpr bool available = true;
+};
+
+/// Trivial SPSSequence<SPSTuple<SPSKey, SPSValue>> -> std::unordered_map<K, V>
+/// deserialization.
+template <typename SPSKeyTagT, typename SPSValueTagT, typename K, typename V>
+class TrivialSPSSequenceDeserialization<SPSTuple<SPSKeyTagT, SPSValueTagT>,
+                                        std::unordered_map<K, V>> {
+public:
+  static constexpr bool available = true;
+
+  using element_type = std::pair<K, V>;
+
+  static void reserve(std::unordered_map<K, V> &M, uint64_t Size) {
+    M.reserve(Size);
+  }
+  static bool append(std::unordered_map<K, V> &M, element_type E) {
+    return M.insert(std::move(E)).second;
+  }
+};
+
+/// 'Trivial' sequence serialization: Sequence is serialized as a uint64_t size
+/// followed by a for-earch loop over the elements of the sequence to serialize
+/// each of them.
+template <typename SPSElementTagT, typename SequenceT>
+class SPSSerializationTraits<SPSSequence<SPSElementTagT>, SequenceT,
+                             std::enable_if_t<TrivialSPSSequenceSerialization<
+                                 SPSElementTagT, SequenceT>::available>> {
+public:
+  static size_t size(const SequenceT &S) {
+    size_t Size = SPSArgList<uint64_t>::size(static_cast<uint64_t>(S.size()));
+    for (const auto &E : S)
+      Size += SPSArgList<SPSElementTagT>::size(E);
+    return Size;
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const SequenceT &S) {
+    if (!SPSArgList<uint64_t>::serialize(OB, static_cast<uint64_t>(S.size())))
+      return false;
+    for (const auto &E : S)
+      if (!SPSArgList<SPSElementTagT>::serialize(OB, E))
+        return false;
+    return true;
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, SequenceT &S) {
+    using TBSD = TrivialSPSSequenceDeserialization<SPSElementTagT, SequenceT>;
+    uint64_t Size;
+    if (!SPSArgList<uint64_t>::deserialize(IB, Size))
+      return false;
+    TBSD::reserve(S, Size);
+    for (size_t I = 0; I != Size; ++I) {
+      typename TBSD::element_type E;
+      if (!SPSArgList<SPSElementTagT>::deserialize(IB, E))
+        return false;
+      if (!TBSD::append(S, std::move(E)))
+        return false;
+    }
+    return true;
+  }
+};
+
+/// Trivial serialization / deserialization for span<char>
+template <> class SPSSerializationTraits<SPSSequence<char>, span<const char>> {
+public:
+  static size_t size(const span<const char> &S) {
+    return SPSArgList<uint64_t>::size(static_cast<uint64_t>(S.size())) +
+           S.size();
+  }
+  static bool serialize(SPSOutputBuffer &OB, const span<const char> &S) {
+    if (!SPSArgList<uint64_t>::serialize(OB, static_cast<uint64_t>(S.size())))
+      return false;
+    return OB.write(S.data(), S.size());
+  }
+  static bool deserialize(SPSInputBuffer &IB, span<const char> &S) {
+    uint64_t Size;
+    if (!SPSArgList<uint64_t>::deserialize(IB, Size))
+      return false;
+    S = span<const char>(IB.data(), Size);
+    return IB.skip(Size);
+  }
+};
+
+/// SPSTuple serialization for std::tuple.
+template <typename... SPSTagTs, typename... Ts>
+class SPSSerializationTraits<SPSTuple<SPSTagTs...>, std::tuple<Ts...>> {
+private:
+  using TupleArgList = typename SPSTuple<SPSTagTs...>::AsArgList;
+  using ArgIndices = std::make_index_sequence<sizeof...(Ts)>;
+
+  template <std::size_t... I>
+  static size_t size(const std::tuple<Ts...> &T, std::index_sequence<I...>) {
+    return TupleArgList::size(std::get<I>(T)...);
+  }
+
+  template <std::size_t... I>
+  static bool serialize(SPSOutputBuffer &OB, const std::tuple<Ts...> &T,
+                        std::index_sequence<I...>) {
+    return TupleArgList::serialize(OB, std::get<I>(T)...);
+  }
+
+  template <std::size_t... I>
+  static bool deserialize(SPSInputBuffer &IB, std::tuple<Ts...> &T,
+                          std::index_sequence<I...>) {
+    return TupleArgList::deserialize(IB, std::get<I>(T)...);
+  }
+
+public:
+  static size_t size(const std::tuple<Ts...> &T) {
+    return size(T, ArgIndices{});
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const std::tuple<Ts...> &T) {
+    return serialize(OB, T, ArgIndices{});
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, std::tuple<Ts...> &T) {
+    return deserialize(IB, T, ArgIndices{});
+  }
+};
+
+/// SPSTuple serialization for std::pair.
+template <typename SPSTagT1, typename SPSTagT2, typename T1, typename T2>
+class SPSSerializationTraits<SPSTuple<SPSTagT1, SPSTagT2>, std::pair<T1, T2>> {
+public:
+  static size_t size(const std::pair<T1, T2> &P) {
+    return SPSArgList<SPSTagT1>::size(P.first) +
+           SPSArgList<SPSTagT2>::size(P.second);
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const std::pair<T1, T2> &P) {
+    return SPSArgList<SPSTagT1>::serialize(OB, P.first) &&
+           SPSArgList<SPSTagT2>::serialize(OB, P.second);
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, std::pair<T1, T2> &P) {
+    return SPSArgList<SPSTagT1>::deserialize(IB, P.first) &&
+           SPSArgList<SPSTagT2>::deserialize(IB, P.second);
+  }
+};
+
+/// SPSOptional serialization for std::optional.
+template <typename SPSTagT, typename T>
+class SPSSerializationTraits<SPSOptional<SPSTagT>, std::optional<T>> {
+public:
+  static size_t size(const std::optional<T> &Value) {
+    size_t Size = SPSArgList<bool>::size(!!Value);
+    if (Value)
+      Size += SPSArgList<SPSTagT>::size(*Value);
+    return Size;
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const std::optional<T> &Value) {
+    if (!SPSArgList<bool>::serialize(OB, !!Value))
+      return false;
+    if (Value)
+      return SPSArgList<SPSTagT>::serialize(OB, *Value);
+    return true;
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, std::optional<T> &Value) {
+    bool HasValue;
+    if (!SPSArgList<bool>::deserialize(IB, HasValue))
+      return false;
+    if (HasValue) {
+      Value = T();
+      return SPSArgList<SPSTagT>::deserialize(IB, *Value);
+    } else
+      Value = std::optional<T>();
+    return true;
+  }
+};
+
+/// Serialization for string_views.
+///
+/// Serialization is as for regular strings. Deserialization points directly
+/// into the blob.
+template <> class SPSSerializationTraits<SPSString, std::string_view> {
+public:
+  static size_t size(const std::string_view &S) {
+    return SPSArgList<uint64_t>::size(static_cast<uint64_t>(S.size())) +
+           S.size();
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const std::string_view &S) {
+    if (!SPSArgList<uint64_t>::serialize(OB, static_cast<uint64_t>(S.size())))
+      return false;
+    return OB.write(S.data(), S.size());
+  }
+
+  static bool deserialize(SPSInputBuffer &IB, std::string_view &S) {
+    const char *Data = nullptr;
+    uint64_t Size;
+    if (!SPSArgList<uint64_t>::deserialize(IB, Size))
+      return false;
+    if (Size > std::numeric_limits<size_t>::max())
+      return false;
+    Data = IB.data();
+    if (!IB.skip(Size))
+      return false;
+    S = {Data, static_cast<size_t>(Size)};
+    return true;
+  }
+};
+
+/// SPS tag type for errors.
+class SPSError;
+
+/// SPS tag type for expecteds, which are either a T or a string representing
+/// an error.
+template <typename SPSTagT> class SPSExpected;
+
+namespace detail {
+
+/// Helper type for serializing Errors.
+///
+/// llvm::Errors are move-only, and not inspectable except by consuming them.
+/// This makes them unsuitable for direct serialization via
+/// SPSSerializationTraits, which needs to inspect values twice (once to
+/// determine the amount of space to reserve, and then again to serialize).
+///
+/// The SPSSerializableError type is a helper that can be
+/// constructed from an llvm::Error, but inspected more than once.
+struct SPSSerializableError {
+  bool HasError = false;
+  std::string ErrMsg;
+};
+
+/// Helper type for serializing Expected<T>s.
+///
+/// See SPSSerializableError for more details.
+///
+// FIXME: Use std::variant for storage once we have c++17.
+template <typename T> struct SPSSerializableExpected {
+  bool HasValue = false;
+  T Value{};
+  std::string ErrMsg;
+};
+
+inline SPSSerializableError toSPSSerializable(Error Err) {
+  if (Err)
+    return {true, toString(std::move(Err))};
+  return {false, {}};
+}
+
+inline Error fromSPSSerializable(SPSSerializableError BSE) {
+  if (BSE.HasError)
+    return make_error<StringError>(BSE.ErrMsg);
+  return Error::success();
+}
+
+template <typename T>
+SPSSerializableExpected<T> toSPSSerializable(Expected<T> E) {
+  if (E)
+    return {true, std::move(*E), {}};
+  else
+    return {false, {}, toString(E.takeError())};
+}
+
+template <typename T>
+Expected<T> fromSPSSerializable(SPSSerializableExpected<T> BSE) {
+  if (BSE.HasValue)
+    return std::move(BSE.Value);
+  else
+    return make_error<StringError>(BSE.ErrMsg);
+}
+
+} // namespace detail
+
+/// Serialize to a SPSError from a detail::SPSSerializableError.
+template <>
+class SPSSerializationTraits<SPSError, detail::SPSSerializableError> {
+public:
+  static size_t size(const detail::SPSSerializableError &BSE) {
+    size_t Size = SPSArgList<bool>::size(BSE.HasError);
+    if (BSE.HasError)
+      Size += SPSArgList<SPSString>::size(BSE.ErrMsg);
+    return Size;
+  }
+
+  static bool serialize(SPSOutputBuffer &OB,
+                        const detail::SPSSerializableError &BSE) {
+    if (!SPSArgList<bool>::serialize(OB, BSE.HasError))
+      return false;
+    if (BSE.HasError)
+      if (!SPSArgList<SPSString>::serialize(OB, BSE.ErrMsg))
+        return false;
+    return true;
+  }
+
+  static bool deserialize(SPSInputBuffer &IB,
+                          detail::SPSSerializableError &BSE) {
+    if (!SPSArgList<bool>::deserialize(IB, BSE.HasError))
+      return false;
+
+    if (!BSE.HasError)
+      return true;
+
+    return SPSArgList<SPSString>::deserialize(IB, BSE.ErrMsg);
+  }
+};
+
+/// Serialize to a SPSExpected<SPSTagT> from a
+/// detail::SPSSerializableExpected<T>.
+template <typename SPSTagT, typename T>
+class SPSSerializationTraits<SPSExpected<SPSTagT>,
+                             detail::SPSSerializableExpected<T>> {
+public:
+  static size_t size(const detail::SPSSerializableExpected<T> &BSE) {
+    size_t Size = SPSArgList<bool>::size(BSE.HasValue);
+    if (BSE.HasValue)
+      Size += SPSArgList<SPSTagT>::size(BSE.Value);
+    else
+      Size += SPSArgList<SPSString>::size(BSE.ErrMsg);
+    return Size;
+  }
+
+  static bool serialize(SPSOutputBuffer &OB,
+                        const detail::SPSSerializableExpected<T> &BSE) {
+    if (!SPSArgList<bool>::serialize(OB, BSE.HasValue))
+      return false;
+
+    if (BSE.HasValue)
+      return SPSArgList<SPSTagT>::serialize(OB, BSE.Value);
+
+    return SPSArgList<SPSString>::serialize(OB, BSE.ErrMsg);
+  }
+
+  static bool deserialize(SPSInputBuffer &IB,
+                          detail::SPSSerializableExpected<T> &BSE) {
+    if (!SPSArgList<bool>::deserialize(IB, BSE.HasValue))
+      return false;
+
+    if (BSE.HasValue)
+      return SPSArgList<SPSTagT>::deserialize(IB, BSE.Value);
+
+    return SPSArgList<SPSString>::deserialize(IB, BSE.ErrMsg);
+  }
+};
+
+/// Serialize to a SPSExpected<SPSTagT> from a detail::SPSSerializableError.
+template <typename SPSTagT>
+class SPSSerializationTraits<SPSExpected<SPSTagT>,
+                             detail::SPSSerializableError> {
+public:
+  static size_t size(const detail::SPSSerializableError &BSE) {
+    assert(BSE.HasError && "Cannot serialize expected from a success value");
+    return SPSArgList<bool>::size(false) +
+           SPSArgList<SPSString>::size(BSE.ErrMsg);
+  }
+
+  static bool serialize(SPSOutputBuffer &OB,
+                        const detail::SPSSerializableError &BSE) {
+    assert(BSE.HasError && "Cannot serialize expected from a success value");
+    if (!SPSArgList<bool>::serialize(OB, false))
+      return false;
+    return SPSArgList<SPSString>::serialize(OB, BSE.ErrMsg);
+  }
+};
+
+/// Serialize to a SPSExpected<SPSTagT> from a T.
+template <typename SPSTagT, typename T>
+class SPSSerializationTraits<SPSExpected<SPSTagT>, T> {
+public:
+  static size_t size(const T &Value) {
+    return SPSArgList<bool>::size(true) + SPSArgList<SPSTagT>::size(Value);
+  }
+
+  static bool serialize(SPSOutputBuffer &OB, const T &Value) {
+    if (!SPSArgList<bool>::serialize(OB, true))
+      return false;
+    return SPSArgList<SPSTagT>::serialize(Value);
+  }
+};
+
+} // namespace orc_rt
+
+#endif // ORC_RT_SIMPLEPACKEDSERIALIZATION_H

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_orc_rt_unittest(CoreTests
   IntervalSetTest.cpp
   MathTest.cpp
   RTTITest.cpp
+  SimplePackedSerializationTest.cpp
   WrapperFunctionResultTest.cpp
   bit-test.cpp
   move_only_function-test.cpp

--- a/orc-rt/unittests/SimplePackedSerializationTest.cpp
+++ b/orc-rt/unittests/SimplePackedSerializationTest.cpp
@@ -1,0 +1,184 @@
+//===- SimplePackedSerializationTest.cpp ----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for SimplePackedSerialization infrastructure.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/SimplePackedSerialization.h"
+#include "SimplePackedSerializationTestUtils.h"
+#include "gtest/gtest.h"
+
+using namespace orc_rt;
+
+TEST(SimplePackedSerializationTest, SPSOutputBuffer) {
+  constexpr unsigned NumBytes = 8;
+  char Buffer[NumBytes];
+  char Zero = 0;
+  SPSOutputBuffer OB(Buffer, NumBytes);
+
+  // Expect that we can write NumBytes of content.
+  for (unsigned I = 0; I != NumBytes; ++I) {
+    char C = I;
+    EXPECT_TRUE(OB.write(&C, 1));
+  }
+
+  // Expect an error when we attempt to write an extra byte.
+  EXPECT_FALSE(OB.write(&Zero, 1));
+
+  // Check that the buffer contains the expected content.
+  for (unsigned I = 0; I != NumBytes; ++I)
+    EXPECT_EQ(Buffer[I], (char)I);
+}
+
+TEST(SimplePackedSerializationTest, SPSInputBuffer) {
+  char Buffer[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+  SPSInputBuffer IB(Buffer, sizeof(Buffer));
+
+  char C;
+  for (unsigned I = 0; I != sizeof(Buffer); ++I) {
+    EXPECT_TRUE(IB.read(&C, 1));
+    EXPECT_EQ(C, (char)I);
+  }
+
+  EXPECT_FALSE(IB.read(&C, 1));
+}
+
+template <typename T> static void testFixedIntegralTypeSerialization() {
+  blobSerializationRoundTrip<T, T>(0);
+  blobSerializationRoundTrip<T, T>(static_cast<T>(1));
+  if (std::is_signed<T>::value) {
+    blobSerializationRoundTrip<T, T>(static_cast<T>(-1));
+    blobSerializationRoundTrip<T, T>(std::numeric_limits<T>::min());
+  }
+  blobSerializationRoundTrip<T, T>(std::numeric_limits<T>::max());
+}
+
+TEST(SimplePackedSerializationTest, BoolSerialization) {
+  blobSerializationRoundTrip<bool, bool>(true);
+  blobSerializationRoundTrip<bool, bool>(false);
+}
+
+TEST(SimplePackedSerializationTest, CharSerialization) {
+  blobSerializationRoundTrip<char, char>((char)0x00);
+  blobSerializationRoundTrip<char, char>((char)0xAA);
+  blobSerializationRoundTrip<char, char>((char)0xFF);
+}
+
+TEST(SimplePackedSerializationTest, Int8Serialization) {
+  testFixedIntegralTypeSerialization<int8_t>();
+}
+
+TEST(SimplePackedSerializationTest, UInt8Serialization) {
+  testFixedIntegralTypeSerialization<uint8_t>();
+}
+
+TEST(SimplePackedSerializationTest, Int16Serialization) {
+  testFixedIntegralTypeSerialization<int16_t>();
+}
+
+TEST(SimplePackedSerializationTest, UInt16Serialization) {
+  testFixedIntegralTypeSerialization<uint16_t>();
+}
+
+TEST(SimplePackedSerializationTest, Int32Serialization) {
+  testFixedIntegralTypeSerialization<int32_t>();
+}
+
+TEST(SimplePackedSerializationTest, UInt32Serialization) {
+  testFixedIntegralTypeSerialization<uint32_t>();
+}
+
+TEST(SimplePackedSerializationTest, Int64Serialization) {
+  testFixedIntegralTypeSerialization<int64_t>();
+}
+
+TEST(SimplePackedSerializationTest, UInt64Serialization) {
+  testFixedIntegralTypeSerialization<uint64_t>();
+}
+
+TEST(SimplePackedSerializationTest, SequenceSerialization) {
+  std::vector<int32_t> V({1, 2, -47, 139});
+  blobSerializationRoundTrip<SPSSequence<int32_t>, std::vector<int32_t>>(V);
+}
+
+TEST(SimplePackedSerializationTest, StringViewCharSequenceSerialization) {
+  const char *HW = "Hello, world!";
+  blobSerializationRoundTrip<SPSString, std::string_view>(std::string_view(HW));
+}
+
+TEST(SimplePackedSerializationTest, SpanSerialization) {
+  const char Data[] = {3, 2, 1, 0, 1, 2, 3}; // Span should handle nulls.
+  span<const char> OutS(Data, sizeof(Data));
+
+  size_t Size = SPSArgList<SPSSequence<char>>::size(OutS);
+  auto Buffer = std::make_unique<char[]>(Size);
+  SPSOutputBuffer OB(Buffer.get(), Size);
+
+  EXPECT_TRUE(SPSArgList<SPSSequence<char>>::serialize(OB, OutS));
+
+  SPSInputBuffer IB(Buffer.get(), Size);
+
+  span<const char> InS;
+
+  EXPECT_TRUE(SPSArgList<SPSSequence<char>>::deserialize(IB, InS));
+
+  // Check that the serialized and deserialized values match.
+  EXPECT_EQ(InS.size(), OutS.size());
+  EXPECT_EQ(memcmp(OutS.data(), InS.data(), InS.size()), 0);
+
+  // Check that the span points directly to the input buffer.
+  EXPECT_EQ(InS.data(), Buffer.get() + sizeof(uint64_t));
+}
+
+TEST(SimplePackedSerializationTest, StdTupleSerialization) {
+  std::tuple<int32_t, std::string, bool> P(42, "foo", true);
+  blobSerializationRoundTrip<SPSTuple<int32_t, SPSString, bool>>(P);
+}
+
+TEST(SimplePackedSerializationTest, StdPairSerialization) {
+  std::pair<int32_t, std::string> P(42, "foo");
+  blobSerializationRoundTrip<SPSTuple<int32_t, SPSString>,
+                             std::pair<int32_t, std::string>>(P);
+}
+
+TEST(SimplePackedSerializationTest, StdOptionalNoValueSerialization) {
+  std::optional<int64_t> NoValue;
+  blobSerializationRoundTrip<SPSOptional<int64_t>>(NoValue);
+}
+
+TEST(SimplePackedSerializationTest, StdOptionalValueSerialization) {
+  std::optional<int64_t> Value(42);
+  blobSerializationRoundTrip<SPSOptional<int64_t>>(Value);
+}
+
+TEST(SimplePackedSerializationTest, ArgListSerialization) {
+  using BAL = SPSArgList<bool, int32_t, SPSString>;
+
+  bool Arg1 = true;
+  int32_t Arg2 = 42;
+  std::string Arg3 = "foo";
+
+  size_t Size = BAL::size(Arg1, Arg2, Arg3);
+  auto Buffer = std::make_unique<char[]>(Size);
+  SPSOutputBuffer OB(Buffer.get(), Size);
+
+  EXPECT_TRUE(BAL::serialize(OB, Arg1, Arg2, Arg3));
+
+  SPSInputBuffer IB(Buffer.get(), Size);
+
+  bool ArgOut1;
+  int32_t ArgOut2;
+  std::string ArgOut3;
+
+  EXPECT_TRUE(BAL::deserialize(IB, ArgOut1, ArgOut2, ArgOut3));
+
+  EXPECT_EQ(Arg1, ArgOut1);
+  EXPECT_EQ(Arg2, ArgOut2);
+  EXPECT_EQ(Arg3, ArgOut3);
+}

--- a/orc-rt/unittests/SimplePackedSerializationTestUtils.h
+++ b/orc-rt/unittests/SimplePackedSerializationTestUtils.h
@@ -1,0 +1,34 @@
+//===- SimplePackedSerializationTestUtils.h -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_UNITTEST_SIMPLEPACKEDSERIALIZATIONTESTUTILS_H
+#define ORC_RT_UNITTEST_SIMPLEPACKEDSERIALIZATIONTESTUTILS_H
+
+#include "orc-rt/SimplePackedSerialization.h"
+#include "gtest/gtest.h"
+
+template <typename SPSTagT, typename T>
+static void blobSerializationRoundTrip(const T &Value) {
+  using BST = orc_rt::SPSSerializationTraits<SPSTagT, T>;
+
+  size_t Size = BST::size(Value);
+  auto Buffer = std::make_unique<char[]>(Size);
+  orc_rt::SPSOutputBuffer OB(Buffer.get(), Size);
+
+  EXPECT_TRUE(BST::serialize(OB, Value));
+
+  orc_rt::SPSInputBuffer IB(Buffer.get(), Size);
+
+  T DSValue;
+  EXPECT_TRUE(BST::deserialize(IB, DSValue));
+
+  EXPECT_EQ(Value, DSValue)
+      << "Incorrect value after serialization/deserialization round-trip";
+}
+
+#endif // ORC_RT_UNITTEST_SIMPLEPACKEDSERIALIZATIONTESTUTILS_H


### PR DESCRIPTION
Ports the simple-packed-serialization scheme from the old ORC runtime at compiler-rt/lib/orc/simple_packed_serialization.h.