### PR TITLE
[llvm-lit] Add Windows .cmd wrapper to make llvm-lit directly runnable

### DIFF
--- a/clang/test/utils/update_cc_test_checks/lit.local.cfg
+++ b/clang/test/utils/update_cc_test_checks/lit.local.cfg
@@ -38,10 +38,9 @@ else:
     if config.llvm_external_lit:
         lit = config.llvm_external_lit
     else:
-        if os.name == "nt":
-            lit = shell_quote(os.path.join(config.llvm_tools_dir, "llvm-lit.py"))
-        else:
-            lit = shell_quote(os.path.join(config.llvm_tools_dir, "llvm-lit"))
+        lit = shell_quote(
+            os.path.join(config.llvm_tools_dir, "llvm-lit.py" if os.name == "nt" else "llvm-lit")
+        )
     python = shell_quote(config.python_executable)
     config.substitutions.append(
         (

--- a/clang/test/utils/update_cc_test_checks/lit.local.cfg
+++ b/clang/test/utils/update_cc_test_checks/lit.local.cfg
@@ -38,9 +38,10 @@ else:
     if config.llvm_external_lit:
         lit = config.llvm_external_lit
     else:
-        lit = shell_quote(
-            glob.glob(os.path.join(config.llvm_tools_dir, "llvm-lit*"))[0]
-        )
+        if os.name == "nt":
+            lit = shell_quote(os.path.join(config.llvm_tools_dir, "llvm-lit.py"))
+        else:
+            lit = shell_quote(os.path.join(config.llvm_tools_dir, "llvm-lit"))
     python = shell_quote(config.python_executable)
     config.substitutions.append(
         (

--- a/llvm/utils/llvm-lit/CMakeLists.txt
+++ b/llvm/utils/llvm-lit/CMakeLists.txt
@@ -35,6 +35,14 @@ if(NOT "${CMAKE_CFG_INTDIR}" STREQUAL ".")
       llvm-lit.in
       ${bi}
       )
+    if (WIN32)
+      string(REPLACE ${CMAKE_CFG_INTDIR} ${BUILD_MODE} bi_dir ${LIT_BASE_DIR})
+      configure_file(
+        llvm-lit.cmd.in
+        ${bi_dir}/llvm-lit.cmd
+        @ONLY
+        NEWLINE_STYLE DOS)
+    endif()
   endforeach()
 else()
   set(BUILD_MODE .)
@@ -42,4 +50,11 @@ else()
     llvm-lit.in
     ${LIT_BASE_DIR}/${LIT_FILE_NAME}
     )
+  if (WIN32)
+    configure_file(
+      llvm-lit.cmd.in
+      ${LIT_BASE_DIR}/llvm-lit.cmd
+      @ONLY
+      NEWLINE_STYLE DOS)
+  endif()  
 endif()

--- a/llvm/utils/llvm-lit/llvm-lit.cmd.in
+++ b/llvm/utils/llvm-lit/llvm-lit.cmd.in
@@ -1,0 +1,3 @@
+@echo off
+"@Python3_EXECUTABLE@" "%~dp0@LIT_FILE_NAME@" %*
+exit /b %errorlevel%


### PR DESCRIPTION
On Linux/Mac, `llvm-lit` is configured with a shebang and made executable so tools like LNT and the test-suite can invoke it directly. On Windows the build only produces `llvm-lit.py` which cannot be used as a standalone executable. This caused problems when running the LLVM test-suite via LNT or buildbots.

This change introduces a new template file `llvm-lit.cmd.in` and updates `llvm/utils/llvm-lit/CMakeLists.txt` so that a corresponding `llvm-lit.cmd` is generated in the `build/bin` directory (for both single-config and multi-config generators). The wrapper simply invokes the configured Python interpreter on the adjacent `llvm-lit.py` and propagates the exit code.

This ensures that `llvm-lit` can be used as a direct executable on Windows just like on Linux without requiring external wrappers or modifications in buildbot scripts or LNT.
