### PR TITLE
[AMDGPU] Fix unittest sign-compare

### DIFF
--- a/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
+++ b/llvm/unittests/Target/AMDGPU/AMDGPUUnitTests.cpp
@@ -335,7 +335,7 @@ TEST(AMDGPU, TestGetNamedOperandIdx) {
       if (OpName == AMDGPU::OpName::NUM_OPERAND_NAMES)
         continue;
       int16_t RetrievedIdx = AMDGPU::getNamedOperandIdx(Opcode, OpName);
-      EXPECT_EQ(Idx, RetrievedIdx)
+      EXPECT_EQ(Idx, static_cast<unsigned>(RetrievedIdx))
           << "Opcode " << Opcode << " (" << MCII->getName(Opcode) << ')';
     }
   }


### PR DESCRIPTION
Apparently, some buildbots build unittests with `-Werror,-Wsign-compare`: https://lab.llvm.org/buildbot/#/builders/145/builds/9299