### PR TITLE
[mlir] Fix bug in PDLL Parser

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -147,8 +147,9 @@ private:
     std::string docStr;
     {
       llvm::raw_string_ostream docOS(docStr);
+      std::string tmpDocStr = doc.str();
       raw_indented_ostream(docOS).printReindented(
-          StringRef(docStr).rtrim(" \t"));
+          StringRef(tmpDocStr).rtrim(" \t"));
     }
     return docStr;
   }


### PR DESCRIPTION
This reverts changes made to `mlir/lib/Tools/PDLL/Parser/Parser.cpp` in 095b41c6eedb3acc908dc63ee91ff77944c07d75 .

`raw_indented_ostream::printReindented()` reads from a string to which it also concurrently writes to, causing unintended behavior.

Credits to @jackalcooper for finding the issue.