### PR TITLE
[profcheck] Exclude test introduced in 3054e06

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -1423,6 +1423,7 @@ Transforms/LoopVectorize/single-early-exit-cond-poison.ll
 Transforms/LoopVectorize/single-early-exit-deref-assumptions.ll
 Transforms/LoopVectorize/single-early-exit-interleave-hint.ll
 Transforms/LoopVectorize/single-early-exit-interleave.ll
+Transforms/LoopVectorize/single-early-exit-interleave-only.ll
 Transforms/LoopVectorize/single_early_exit_live_outs.ll
 Transforms/LoopVectorize/single_early_exit.ll
 Transforms/LoopVectorize/single_early_exit_with_outer_loop.ll

--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -121,6 +121,7 @@ Instrumentation/AddressSanitizer/byref-args.ll
 Instrumentation/AddressSanitizer/byval-args.ll
 Instrumentation/AddressSanitizer/calls-only.ll
 Instrumentation/AddressSanitizer/calls-only-smallfn.ll
+Instrumentation/AddressSanitizer/coro-byval-param.ll
 Instrumentation/AddressSanitizer/debug-info-alloca.ll
 Instrumentation/AddressSanitizer/debug-info-global-var.ll
 Instrumentation/AddressSanitizer/debug_info.ll
@@ -255,6 +256,7 @@ Instrumentation/HWAddressSanitizer/alloca-with-calls.ll
 Instrumentation/HWAddressSanitizer/atomic.ll
 Instrumentation/HWAddressSanitizer/basic-compat.ll
 Instrumentation/HWAddressSanitizer/basic.ll
+Instrumentation/HWAddressSanitizer/coro-byval-param.ll
 Instrumentation/HWAddressSanitizer/dbg-assign-tag-offset.ll
 Instrumentation/HWAddressSanitizer/dbg-declare-tag-offset.ll
 Instrumentation/HWAddressSanitizer/dbg-value-tag-offset.ll


### PR DESCRIPTION
LoopVectorize hasn't yet been addressed, new tests will fail.

Issue #147390