### PR TITLE
[libc++] Add a release note about multi{map,set}::find not returning the first element anymore

### DIFF
--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -61,9 +61,7 @@ Deprecations and Removals
 Potentially breaking changes
 ----------------------------
 
-- The algorithm for ``multi{map,set}::find`` has been modified, which doesn't guarantee that the first element is
-  returned. If code relies on the first element being returned from ``find`` it may be broken. To fix it use
-  ``lower_bound`` or ``equal_range`` instead.
+- The algorithm for ``multi{map,set}::find`` has been modified such that it doesn't necessarily return an iterator to the first equal element in the container. This was never guaranteed by the Standard, but libc++ previously happened to always return the first equal element, like other implementations do. Starting with this release, code relying on the first element being returned from ``find`` will be broken, and ``lower_bound`` or ``equal_range`` should be used instead.
 
 Announcements About Future Releases
 -----------------------------------

--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -61,6 +61,10 @@ Deprecations and Removals
 Potentially breaking changes
 ----------------------------
 
+- The algorithm for ``multi{map,set}::find`` has been modified, which doesn't guarantee that the first element is
+  returned. If code relies on the first element being returned from ``find`` it may be broken. To fix it use
+  ``lower_bound`` or ``equal_range`` instead.
+
 Announcements About Future Releases
 -----------------------------------
 


### PR DESCRIPTION
We've modified the algorithm of `__tree::find` in #152370, which can change the return value. Since we're always returned the lower bound before some users started relying on it. This patch adds a release note so users are aware that this might break their code.

