### PR TITLE
[mlir][spirv] Propagate alignment requirements from vector to spirv

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMemoryOps.td
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVMemoryOps.td
@@ -220,7 +220,7 @@ def SPIRV_LoadOp : SPIRV_Op<"Load", []> {
   let arguments = (ins
     SPIRV_AnyPtr:$ptr,
     OptionalAttr<SPIRV_MemoryAccessAttr>:$memory_access,
-    OptionalAttr<I32Attr>:$alignment
+    OptionalAttr<IntValidAlignment<I32Attr>>:$alignment
   );
 
   let results = (outs
@@ -345,7 +345,7 @@ def SPIRV_StoreOp : SPIRV_Op<"Store", []> {
     SPIRV_AnyPtr:$ptr,
     SPIRV_Type:$value,
     OptionalAttr<SPIRV_MemoryAccessAttr>:$memory_access,
-    OptionalAttr<I32Attr>:$alignment
+    OptionalAttr<IntValidAlignment<I32Attr>>:$alignment
   );
 
   let results = (outs);

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -751,7 +751,7 @@ struct VectorLoadOpConverter final
 
     auto memoryAccess = spirv::MemoryAccess::None;
     spirv::MemoryAccessAttr memoryAccessAttr;
-    IntegerAttr alignmentAttr = nullptr;
+    IntegerAttr alignmentAttr;
     if (alignment.has_value()) {
       memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;
       memoryAccessAttr =
@@ -820,7 +820,7 @@ struct VectorStoreOpConverter final
 
     auto memoryAccess = spirv::MemoryAccess::None;
     spirv::MemoryAccessAttr memoryAccessAttr;
-    IntegerAttr alignmentAttr = nullptr;
+    IntegerAttr alignmentAttr;
     if (alignment.has_value()) {
       memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;
       memoryAccessAttr =

--- a/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
+++ b/mlir/lib/Conversion/VectorToSPIRV/VectorToSPIRV.cpp
@@ -743,15 +743,14 @@ struct VectorLoadOpConverter final
 
     auto vectorPtrType = spirv::PointerType::get(spirvVectorType, storageClass);
 
-    auto alignment = loadOp.getAlignment();
-    if (alignment.has_value() &&
-        alignment > std::numeric_limits<uint32_t>::max()) {
+    std::optional<uint64_t> alignment = loadOp.getAlignment();
+    if (alignment > std::numeric_limits<uint32_t>::max()) {
       return rewriter.notifyMatchFailure(loadOp,
                                          "invalid alignment requirement");
     }
 
     auto memoryAccess = spirv::MemoryAccess::None;
-    auto memoryAccessAttr = spirv::MemoryAccessAttr{};
+    spirv::MemoryAccessAttr memoryAccessAttr;
     IntegerAttr alignmentAttr = nullptr;
     if (alignment.has_value()) {
       memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;
@@ -800,8 +799,8 @@ struct VectorStoreOpConverter final
       return rewriter.notifyMatchFailure(
           storeOp, "failed to get memref element pointer");
 
-    auto alignment = storeOp.getAlignment();
-    if (alignment && alignment > std::numeric_limits<uint32_t>::max()) {
+    std::optional<uint64_t> alignment = storeOp.getAlignment();
+    if (alignment > std::numeric_limits<uint32_t>::max()) {
       return rewriter.notifyMatchFailure(storeOp,
                                          "invalid alignment requirement");
     }
@@ -820,7 +819,7 @@ struct VectorStoreOpConverter final
                                        accessChain);
 
     auto memoryAccess = spirv::MemoryAccess::None;
-    auto memoryAccessAttr = spirv::MemoryAccessAttr{};
+    spirv::MemoryAccessAttr memoryAccessAttr;
     IntegerAttr alignmentAttr = nullptr;
     if (alignment.has_value()) {
       memoryAccess = memoryAccess | spirv::MemoryAccess::Aligned;

--- a/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
+++ b/mlir/test/Conversion/VectorToSPIRV/vector-to-spirv.mlir
@@ -953,6 +953,14 @@ func.func @vector_load_single_elem(%arg0 : memref<4xf32, #spirv.storage_class<St
   return %0: vector<1xf32>
 }
 
+// CHECK-LABEL: @vector_load_aligned
+func.func @vector_load_aligned(%arg0 : memref<4xf32, #spirv.storage_class<StorageBuffer>>) -> vector<4xf32> {
+  %idx = arith.constant 0 : index
+  // CHECK: spirv.Load
+  // CHECK-SAME: ["Aligned", 8]
+  %0 = vector.load %arg0[%idx] { alignment = 8 } : memref<4xf32, #spirv.storage_class<StorageBuffer>>, vector<4xf32>
+  return %0: vector<4xf32>
+}
 
 // CHECK-LABEL: @vector_load_2d
 //  CHECK-SAME: (%[[ARG0:.*]]: memref<4x4xf32, #spirv.storage_class<StorageBuffer>>) -> vector<4xf32> {
@@ -993,6 +1001,15 @@ func.func @vector_load_2d(%arg0 : memref<4x4xf32, #spirv.storage_class<StorageBu
 func.func @vector_store(%arg0 : memref<4xf32, #spirv.storage_class<StorageBuffer>>, %arg1 : vector<4xf32>) {
   %idx = arith.constant 0 : index
   vector.store %arg1, %arg0[%idx] : memref<4xf32, #spirv.storage_class<StorageBuffer>>, vector<4xf32>
+  return
+}
+
+// CHECK-LABEL: @vector_store_aligned
+func.func @vector_store_aligned(%arg0 : memref<4xf32, #spirv.storage_class<StorageBuffer>>, %arg1 : vector<4xf32>) {
+  %idx = arith.constant 0 : index
+  // CHECK: spirv.Store
+  // CHECK-SAME: ["Aligned", 8]
+  vector.store %arg1, %arg0[%idx] { alignment = 8 } : memref<4xf32, #spirv.storage_class<StorageBuffer>>, vector<4xf32>
   return
 }
 

--- a/mlir/test/Dialect/SPIRV/IR/invalid.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/invalid.mlir
@@ -29,7 +29,7 @@ func.func @aligned_load_non_power_of_two() -> () {
 func.func @aligned_store_non_positive(%arg0 : f32) -> () {
   %0 = spirv.Variable : !spirv.ptr<f32, Function>
   // expected-error@below {{'spirv.Store' op attribute 'alignment' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-  spirv.Store  "Function" %0, %arg0 ["Aligned", 0] : f32
+  spirv.Store "Function" %0, %arg0 ["Aligned", 0] : f32
   return
 }
 
@@ -38,6 +38,6 @@ func.func @aligned_store_non_positive(%arg0 : f32) -> () {
 func.func @aligned_store_non_power_of_two(%arg0 : f32) -> () {
   %0 = spirv.Variable : !spirv.ptr<f32, Function>
   // expected-error@below {{'spirv.Store' op attribute 'alignment' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
-  spirv.Store  "Function" %0, %arg0 ["Aligned", 3] : f32
+  spirv.Store "Function" %0, %arg0 ["Aligned", 3] : f32
   return
 }

--- a/mlir/test/Dialect/SPIRV/IR/invalid.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/invalid.mlir
@@ -1,0 +1,43 @@
+// RUN: mlir-opt -split-input-file -verify-diagnostics %s 
+
+//===----------------------------------------------------------------------===//
+// spirv.LoadOp
+//===----------------------------------------------------------------------===//
+
+func.func @aligned_load_non_positive() -> () {
+  %0 = spirv.Variable : !spirv.ptr<f32, Function>
+  // expected-error@below {{'spirv.Load' op attribute 'alignment' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
+  %1 = spirv.Load "Function" %0 ["Aligned", 0] : f32
+  return
+}
+
+// -----
+
+func.func @aligned_load_non_power_of_two() -> () {
+  %0 = spirv.Variable : !spirv.ptr<f32, Function>
+  // expected-error@below {{'spirv.Load' op attribute 'alignment' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
+  %1 = spirv.Load "Function" %0 ["Aligned", 3] : f32
+  return
+}
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// spirv.StoreOp
+//===----------------------------------------------------------------------===//
+
+func.func @aligned_store_non_positive(%arg0 : f32) -> () {
+  %0 = spirv.Variable : !spirv.ptr<f32, Function>
+  // expected-error@below {{'spirv.Store' op attribute 'alignment' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
+  spirv.Store  "Function" %0, %arg0 ["Aligned", 0] : f32
+  return
+}
+
+// -----
+
+func.func @aligned_store_non_power_of_two(%arg0 : f32) -> () {
+  %0 = spirv.Variable : !spirv.ptr<f32, Function>
+  // expected-error@below {{'spirv.Store' op attribute 'alignment' failed to satisfy constraint: 32-bit signless integer attribute whose value is positive and whose value is a power of two > 0}}
+  spirv.Store  "Function" %0, %arg0 ["Aligned", 3] : f32
+  return
+}

--- a/mlir/test/Dialect/SPIRV/IR/invalid.mlir
+++ b/mlir/test/Dialect/SPIRV/IR/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -split-input-file -verify-diagnostics %s 
+// RUN: mlir-opt --split-input-file --verify-diagnostics %s
 
 //===----------------------------------------------------------------------===//
 // spirv.LoadOp


### PR DESCRIPTION
Propagates the alignment attribute from `vector.{load,store}` to `spirv.{load,store}`.