### PR TITLE
Enable ctlz is fast on ARM and AArch64 (NFC)

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.h
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.h
@@ -383,6 +383,8 @@ public:
     return true;
   }
 
+  bool isCtlzFast() const override { return true; }
+
   bool isMaskAndCmp0FoldingBeneficial(const Instruction &AndI) const override;
 
   bool hasAndNotCompare(SDValue V) const override {

--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -21387,6 +21387,10 @@ bool ARMTargetLowering::isCheapToSpeculateCtlz(Type *Ty) const {
   return Subtarget->hasV6T2Ops();
 }
 
+bool ARMTargetLowering::isCtlzFast() const {
+  return Subtarget->hasV5TOps() && !Subtarget->isThumb1Only();
+}
+
 bool ARMTargetLowering::isMaskAndCmp0FoldingBeneficial(
     const Instruction &AndI) const {
   if (!Subtarget->hasV7Ops())

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -651,6 +651,8 @@ class VectorType;
       return Opc != ISD::VECREDUCE_ADD;
     }
 
+    bool isCtlzFast() const override;
+
     /// Returns true if an argument of type Ty needs to be passed in a
     /// contiguous block of registers in calling convention CallConv.
     bool functionArgumentNeedsConsecutiveRegisters(


### PR DESCRIPTION
Right now, it doesn't affect any codegen, but I plan on it in the future. But for now, this is still true, ctlz is fast.