### PR TITLE
Make the index dialect inlineable.

### DIFF
--- a/mlir/lib/Dialect/Index/IR/IndexDialect.cpp
+++ b/mlir/lib/Dialect/Index/IR/IndexDialect.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 using namespace mlir;
 using namespace mlir::index;
@@ -16,9 +17,23 @@ using namespace mlir::index;
 // IndexDialect
 //===----------------------------------------------------------------------===//
 
+namespace {
+/// This class defines the interface for handling inlining for index
+/// dialect operations.
+struct IndexInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All arithmetic dialect ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
 void IndexDialect::initialize() {
   registerAttributes();
   registerOperations();
+  addInterfaces<IndexInlinerInterface>();
   declarePromisedInterface<ConvertToLLVMPatternInterface, IndexDialect>();
 }
 

--- a/mlir/test/Dialect/Index/inlining.mlir
+++ b/mlir/test/Dialect/Index/inlining.mlir
@@ -1,0 +1,18 @@
+// RUN: mlir-opt %s -inline -split-input-file | FileCheck %s
+
+// -----
+// Indexes should be inlineable
+func.func @func(%arg0 : index) -> index {
+  %1 = index.constant 2
+  return %1 : index
+}
+
+// CHECK-LABEL: @inline_interface
+func.func @inline_interface(%arg0 : index) -> index {
+  // CHECK: index.constant
+  // CHECK-NOT: call
+  %res = call @func(%arg0) : (index) -> (index)
+  // CHECK: return %[[R]]
+  return %res : index
+}
+


### PR DESCRIPTION
This seems like a simple oversight?