### PR TITLE
[compiler-rt] Remove %T from shared object substitutions

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/coverage-missing.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/coverage-missing.cpp
@@ -1,19 +1,17 @@
 // Test for "sancov.py missing ...".
 
 // First case: coverage from executable. main() is called on every code path.
+// RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s -o %t -DFOOBAR -DMAIN
-// RUN: rm -rf %t-dir
-// RUN: mkdir -p %t-dir
-// RUN: cd %t-dir
-// RUN: %env_asan_opts=coverage=1:coverage_dir=%t-dir %run %t
+// RUN: %env_asan_opts=coverage=1:coverage_dir=%t.dir %run %t
 // RUN: %sancov print *.sancov > main.txt
 // RUN: rm *.sancov
 // RUN: count 1 < main.txt
-// RUN: %env_asan_opts=coverage=1:coverage_dir=%t-dir %run %t x
+// RUN: %env_asan_opts=coverage=1:coverage_dir=%t.dir %run %t x
 // RUN: %sancov print *.sancov > foo.txt
 // RUN: rm *.sancov
 // RUN: count 3 < foo.txt
-// RUN: %env_asan_opts=coverage=1:coverage_dir=%t-dir %run %t x x
+// RUN: %env_asan_opts=coverage=1:coverage_dir=%t.dir %run %t x x
 // RUN: %sancov print *.sancov > bar.txt
 // RUN: rm *.sancov
 // RUN: count 4 < bar.txt
@@ -26,18 +24,15 @@
 // RUN: not grep "^<" %t.log
 
 // Second case: coverage from DSO.
-// cd %t-dir
+// RUN: cd ..
+// RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s -o %dynamiclib -DFOOBAR -shared -fPIC
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %dynamiclib -o %t -DMAIN
-// RUN: cd ..
-// RUN: rm -rf %t-dir
-// RUN: mkdir -p %t-dir
-// RUN: cd %t-dir
-// RUN: %env_asan_opts=coverage=1:coverage_dir=%t-dir %run %t x
+// RUN: %env_asan_opts=coverage=1:coverage_dir=%t.dir %run %t x
 // RUN: %sancov print %xdynamiclib_filename.*.sancov > foo.txt
 // RUN: rm *.sancov
 // RUN: count 2 < foo.txt
-// RUN: %env_asan_opts=coverage=1:coverage_dir=%t-dir %run %t x x
+// RUN: %env_asan_opts=coverage=1:coverage_dir=%t.dir %run %t x x
 // RUN: %sancov print %xdynamiclib_filename.*.sancov > bar.txt
 // RUN: rm *.sancov
 // RUN: count 3 < bar.txt

--- a/compiler-rt/test/asan/TestCases/Linux/local_alias.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/local_alias.cpp
@@ -4,6 +4,7 @@
 // false positive global-buffer-overflow due to sanitized library poisons
 // globals from non-sanitized one.
 //
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -DBUILD_INSTRUMENTED_DSO=1 -fPIC -shared -mllvm -asan-use-private-alias %s -o %dynamiclib1
 // RUN: %clangxx -DBUILD_UNINSTRUMENTED_DSO=1 -fPIC -shared %s -o %dynamiclib2
 // RUN: %clangxx %s -c -mllvm -asan-use-private-alias -o %t.o

--- a/compiler-rt/test/asan/TestCases/Linux/odr-violation.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/odr-violation.cpp
@@ -10,6 +10,7 @@
 // -fno-sanitize-address-use-odr-indicator turns off both.
 //
 // Different size: detect a bug if detect_odr_violation>=1
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -g -DBUILD_SO=1 -fPIC -shared -fno-sanitize-address-use-odr-indicator %s -o %dynamiclib
 // RUN: %clangxx_asan -g -fno-sanitize-address-use-odr-indicator %s %ld_flags_rpath_exe -o %t-ODR-EXE
 // RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=1 not %run %t-ODR-EXE 2>&1 | FileCheck %s

--- a/compiler-rt/test/asan/TestCases/Linux/odr-vtable.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/odr-vtable.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: shared_cxxabi
 
 /// Not using private alias or enabling ODR indicator can detect ODR issues.
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fno-rtti -DBUILD_SO1 -fPIC -shared -mllvm -asan-use-private-alias=0 %s -o %dynamiclib1
 // RUN: %clangxx_asan -fno-rtti -DBUILD_SO2 -fPIC -shared -mllvm -asan-use-private-alias=0 %s -o %dynamiclib2
 // RUN: %clangxx_asan -fno-rtti %s %ld_flags_rpath_exe1 %ld_flags_rpath_exe2 -o %t

--- a/compiler-rt/test/asan/TestCases/Linux/odr_c_test.c
+++ b/compiler-rt/test/asan/TestCases/Linux/odr_c_test.c
@@ -1,6 +1,7 @@
 // Test that we can properly report an ODR violation between an instrumented
 // global and a non-instrumented global if not using private aliases.
 
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clang_asan -fcommon %s -fPIC -shared -mllvm -asan-use-private-alias=0 -o %dynamiclib1  -DFILE1
 // RUN: %clang_asan -fcommon %s -fPIC -shared -mllvm -asan-use-private-alias=0 -o %dynamiclib2  -DFILE2
 // RUN: %clang_asan -fcommon %s -fPIE %ld_flags_rpath_exe1 %ld_flags_rpath_exe2 -o %t

--- a/compiler-rt/test/asan/TestCases/Linux/preinit_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/preinit_test.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -DFUNC=zzzz %s -shared -o %dynamiclib -fPIC
 // RUN: %clangxx_asan -DFUNC=main %s -o %t %ld_flags_rpath_exe
 // RUN: %run %t

--- a/compiler-rt/test/asan/TestCases/Posix/coverage-module-unloaded.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage-module-unloaded.cpp
@@ -1,5 +1,6 @@
 // Check that unloading a module doesn't break coverage dumping for remaining
 // modules.
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib1 -fPIC
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib2 -fPIC
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %libdl -o %t.exe

--- a/compiler-rt/test/asan/TestCases/Posix/coverage-reset.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage-reset.cpp
@@ -1,6 +1,6 @@
+// RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib -fPIC %ld_flags_rpath_so
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %ld_flags_rpath_exe -o %t
-// RUN: rm -rf %t-dir && mkdir -p %t-dir && cd %t-dir
 // RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t 2>&1 | FileCheck %s
 //
 // UNSUPPORTED: ios

--- a/compiler-rt/test/asan/TestCases/Posix/coverage.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage.cpp
@@ -1,6 +1,6 @@
+// RUN:rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib -fPIC %ld_flags_rpath_so
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %ld_flags_rpath_exe -o %t
-// RUN: rm -rf %t-dir && mkdir -p %t-dir && cd %t-dir
 // RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t 2>&1         | FileCheck %s --check-prefix=CHECK-main
 // RUN: %sancov print coverage.*sancov 2>&1 | FileCheck %s --check-prefix=CHECK-SANCOV1
 // RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t foo 2>&1     | FileCheck %s --check-prefix=CHECK-foo
@@ -14,7 +14,6 @@
 // RUN: %sancov print merged-cov 2>&1 | FileCheck %s --check-prefix=CHECK-SANCOV2
 // RUN: %env_asan_opts=coverage=1:verbosity=1 not %run %t foo bar 4    2>&1 | FileCheck %s --check-prefix=CHECK-report
 // RUN: %env_asan_opts=coverage=1:verbosity=1 not %run %t foo bar 4 5  2>&1 | FileCheck %s --check-prefix=CHECK-segv
-// RUN: cd .. && rm -rf %t-dir
 //
 // https://code.google.com/p/address-sanitizer/issues/detail?id=263
 // XFAIL: android

--- a/compiler-rt/test/asan/TestCases/Posix/interception-in-shared-lib-test.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/interception-in-shared-lib-test.cpp
@@ -1,5 +1,6 @@
 // Check that memset() call from a shared library gets intercepted.
 
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -O0 %s -DSHARED_LIB \
 // RUN:     -shared -o %dynamiclib -fPIC %ld_flags_rpath_so
 // RUN: %clangxx_asan -O0 %s -o %t %ld_flags_rpath_exe && \

--- a/compiler-rt/test/asan/TestCases/suppressions-library.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-library.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -O0 -DSHARED_LIB %s %fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_asan -O0 %s -o %t %ld_flags_rpath_exe
 

--- a/compiler-rt/test/cfi/cross-dso-diagnostic.cpp
+++ b/compiler-rt/test/cfi/cross-dso-diagnostic.cpp
@@ -1,5 +1,6 @@
 // Check that cross-DSO diagnostics print the names of both modules
 
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_diag -g -DSHARED_LIB -fPIC -shared -o %dynamiclib %s %ld_flags_rpath_so
 // RUN: %clangxx_cfi_diag -g -o %t_exe_suffix %s %ld_flags_rpath_exe
 // RUN: %t_exe_suffix 2>&1 | FileCheck -DDSONAME=%xdynamiclib_namespec %s

--- a/compiler-rt/test/cfi/cross-dso/icall/diag.cpp
+++ b/compiler-rt/test/cfi/cross-dso/icall/diag.cpp
@@ -6,6 +6,7 @@
 // * otherwise, the callee decides between trap/recover/norecover.
 
 // Full-recover.
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso_diag -g -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_cfi_dso_diag -g %s -o %t %ld_flags_rpath_exe
 

--- a/compiler-rt/test/cfi/cross-dso/icall/icall-from-dso.cpp
+++ b/compiler-rt/test/cfi/cross-dso/icall/icall-from-dso.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_cfi_dso %s -o %t %ld_flags_rpath_exe && %expect_crash %t 2>&1 | FileCheck %s
 

--- a/compiler-rt/test/cfi/cross-dso/icall/icall.cpp
+++ b/compiler-rt/test/cfi/cross-dso/icall/icall.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_cfi_dso %s -o %t %ld_flags_rpath_exe && %expect_crash %t 2>&1 | FileCheck %s
 

--- a/compiler-rt/test/cfi/cross-dso/simple-fail.cpp
+++ b/compiler-rt/test/cfi/cross-dso/simple-fail.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_cfi_dso %s -o %t %ld_flags_rpath_exe
 // RUN: %expect_crash %t 2>&1 | FileCheck --check-prefix=CFI %s

--- a/compiler-rt/test/cfi/cross-dso/simple-pass.cpp
+++ b/compiler-rt/test/cfi/cross-dso/simple-pass.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_cfi_dso -g %s -o %t %ld_flags_rpath_exe
 // RUN: %t 2>&1 | FileCheck --check-prefix=CFI %s

--- a/compiler-rt/test/cfi/target_uninstrumented.cpp
+++ b/compiler-rt/test/cfi/target_uninstrumented.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -g -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_cfi_diag -g %s -o %t %ld_flags_rpath_exe
 // RUN: %run %t 2>&1 | FileCheck %s

--- a/compiler-rt/test/fuzzer/coverage.test
+++ b/compiler-rt/test/fuzzer/coverage.test
@@ -2,6 +2,7 @@
 UNSUPPORTED: target={{.*windows.*}}
 # FIXME: CreatePCArray() emits PLT stub addresses for entry blocks, which are ignored by TracePC::PrintCoverage().
 UNSUPPORTED: target=s390x{{.*}}
+RUN: mkdir -p %t.dir && cd %t.dir
 RUN: %cpp_compiler -mllvm -use-unknown-locations=Disable  %S/NullDerefTest.cpp -o %t-NullDerefTest
 RUN: %cpp_compiler -mllvm -use-unknown-locations=Disable %S/DSO1.cpp -fPIC %ld_flags_rpath_so1 -O0 -shared -o %dynamiclib1
 RUN: %cpp_compiler -mllvm -use-unknown-locations=Disable %S/DSO2.cpp -fPIC %ld_flags_rpath_so2 -O0 -shared -o %dynamiclib2

--- a/compiler-rt/test/fuzzer/dso.test
+++ b/compiler-rt/test/fuzzer/dso.test
@@ -1,5 +1,6 @@
 # FIXME: Disabled on Windows because -fPIC cannot be used to compile for Windows.
 UNSUPPORTED: target={{.*windows.*}}
+RUN: mkdir -p %t.dir && cd %t.dir
 RUN: %cpp_compiler %S/DSO1.cpp -fPIC %ld_flags_rpath_so1 -shared -o %dynamiclib1
 RUN: %cpp_compiler %S/DSO2.cpp -fPIC %ld_flags_rpath_so2 -shared -o %dynamiclib2
 RUN: %cpp_compiler %S/DSOTestMain.cpp %S/DSOTestExtra.cpp %ld_flags_rpath_exe1 %ld_flags_rpath_exe2 -o %t-DSOTest

--- a/compiler-rt/test/fuzzer/full-coverage.test
+++ b/compiler-rt/test/fuzzer/full-coverage.test
@@ -2,6 +2,7 @@
 UNSUPPORTED: target={{.*windows.*}}
 # FIXME: See coverage.test.  Using UNSUPPORTED here due to random failures.
 UNSUPPORTED: target=s390x{{.*}}
+RUN: mkdir -p %t.dir && cd %t.dir
 RUN: %cpp_compiler %S/DSO1.cpp -fPIC %ld_flags_rpath_so1 -O0 -shared -o %dynamiclib1
 RUN: %cpp_compiler %S/DSO2.cpp -fPIC %ld_flags_rpath_so2 -O0 -shared -o %dynamiclib2
 RUN: %cpp_compiler %S/DSOTestMain.cpp %S/DSOTestExtra.cpp %ld_flags_rpath_exe1 %ld_flags_rpath_exe2 -o %t-DSOTest

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -888,7 +888,7 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_exe" + postfix,
-                r"-Wl,-z,origin -Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec"
+                r"-Wl,-z,origin -Wl,-rpath,\$ORIGIN -L%t.dir -l%xdynamiclib_namespec"
                 + postfix,
             )
         )
@@ -897,7 +897,7 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_exe" + postfix,
-                r"-Wl,-rpath,\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
+                r"-Wl,-rpath,\$ORIGIN -L%t.dir -l%xdynamiclib_namespec" + postfix,
             )
         )
         config.substitutions.append(("%ld_flags_rpath_so" + postfix, ""))
@@ -905,14 +905,14 @@ for postfix in ["2", "1", ""]:
         config.substitutions.append(
             (
                 "%ld_flags_rpath_exe" + postfix,
-                r"-Wl,-R\$ORIGIN -L%T -l%xdynamiclib_namespec" + postfix,
+                r"-Wl,-R\$ORIGIN -L%t.dir -l%xdynamiclib_namespec" + postfix,
             )
         )
         config.substitutions.append(("%ld_flags_rpath_so" + postfix, ""))
 
     # Must be defined after the substitutions that use %dynamiclib.
     config.substitutions.append(
-        ("%dynamiclib" + postfix, "%T/%xdynamiclib_filename" + postfix)
+        ("%dynamiclib" + postfix, "%t.dir/%xdynamiclib_filename" + postfix)
     )
     config.substitutions.append(
         (

--- a/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
+++ b/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clang_tsan -O1 %s -DBUILD_LIB=1 -fno-sanitize=thread -shared -fPIC -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clang_tsan -O1 %s -o %t %ld_flags_rpath_exe
 // RUN: %run %t | FileCheck %s

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/function.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/function.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -std=c++17 -fsanitize=function %s -O3 -g -DSHARED_LIB -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx -std=c++17 -fsanitize=function %s -O3 -g -o %t %ld_flags_rpath_exe
 // RUN: %run %t 2>&1 | FileCheck %s --check-prefix=CHECK

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/vptr-non-unique-typeinfo.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/vptr-non-unique-typeinfo.cpp
@@ -1,3 +1,4 @@
+// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -frtti -fsanitize=vptr -fno-sanitize-recover=vptr -I%p/Helpers -g %s -fPIC -shared -o %dynamiclib -DBUILD_SO %ld_flags_rpath_so
 // RUN: %clangxx -frtti -fsanitize=vptr -fno-sanitize-recover=vptr -I%p/Helpers -g %s -O3 -o %t %ld_flags_rpath_exe
 // RUN: %run %t


### PR DESCRIPTION
Given we are trying to deprecate %T and remove it, we also need to remove it from the substitutions within compiler-rt. This is the last remaining upstream user.

This slightly increases the complexity of using these substitutions because now you need to create/cd into a %t.dir (specifically named that) at the beginning of the directory, but I'm not sure that's more knowledge than what was needed before to write a test using this substitution. These tests also definitely were not race safe previously.