### PR TITLE
[lldb] Creating a new Binder helper for JSONRPC transport.

### DIFF
--- a/lldb/include/lldb/Protocol/MCP/Binder.h
+++ b/lldb/include/lldb/Protocol/MCP/Binder.h
@@ -1,0 +1,351 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PROTOCOL_MCP_BINDER_H
+#define LLDB_PROTOCOL_MCP_BINDER_H
+
+#include "lldb/Protocol/MCP/MCPError.h"
+#include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/Protocol/MCP/Transport.h"
+#include "lldb/Utility/Status.h"
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/JSON.h"
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+
+namespace lldb_protocol::mcp {
+
+template <typename T> using Callback = llvm::unique_function<T>;
+
+template <typename T>
+using Reply = llvm::unique_function<void(llvm::Expected<T>)>;
+template <typename Params, typename Result>
+using OutgoingRequest =
+    llvm::unique_function<void(const Params &, Reply<Result>)>;
+template <typename Params>
+using OutgoingNotification = llvm::unique_function<void(const Params &)>;
+
+template <typename Params, typename Result>
+llvm::Expected<Result> AsyncInvoke(lldb_private::MainLoop &loop,
+                                   OutgoingRequest<Params, Result> &fn,
+                                   const Params &params) {
+  std::promise<llvm::Expected<Result>> result_promise;
+  std::future<llvm::Expected<Result>> result_future =
+      result_promise.get_future();
+  std::thread thr([&loop, &fn, params,
+                   result_promise = std::move(result_promise)]() mutable {
+    fn(params, [&loop, &result_promise](llvm::Expected<Result> result) mutable {
+      result_promise.set_value(std::move(result));
+      loop.AddPendingCallback(
+          [](lldb_private::MainLoopBase &loop) { loop.RequestTermination(); });
+    });
+    if (llvm::Error error = loop.Run().takeError())
+      result_promise.set_value(std::move(error));
+  });
+  thr.join();
+  return result_future.get();
+}
+
+/// Binder collects a table of functions that handle calls.
+///
+/// The wrapper takes care of parsing/serializing responses.
+class Binder {
+public:
+  explicit Binder(MCPTransport *transport) : m_handlers(transport) {}
+
+  Binder(const Binder &) = delete;
+  Binder &operator=(const Binder &) = delete;
+
+  /// Bind a handler on transport disconnect.
+  template <typename ThisT, typename... ExtraArgs>
+  void disconnected(void (ThisT::*handler)(MCPTransport *), ThisT *_this,
+                    ExtraArgs... extra_args) {
+    m_handlers.m_disconnect_handler =
+        std::bind(handler, _this, std::placeholders::_1,
+                  std::forward<ExtraArgs>(extra_args)...);
+  }
+
+  /// Bind a handler on error when communicating with the transport.
+  template <typename ThisT, typename... ExtraArgs>
+  void error(void (ThisT::*handler)(MCPTransport *, llvm::Error), ThisT *_this,
+             ExtraArgs... extra_args) {
+    m_handlers.m_error_handler =
+        std::bind(handler, _this, std::placeholders::_1, std::placeholders::_2,
+                  std::forward<ExtraArgs>(extra_args)...);
+  }
+
+  /// Bind a handler for a request.
+  /// e.g. Bind.request("peek", this, &ThisModule::peek);
+  /// Handler should be e.g. Expected<PeekResult> peek(const PeekParams&);
+  /// PeekParams must be JSON parsable and PeekResult must be serializable.
+  template <typename Result, typename Params, typename ThisT,
+            typename... ExtraArgs>
+  void request(llvm::StringLiteral method,
+               llvm::Expected<Result> (ThisT::*fn)(const Params &,
+                                                   ExtraArgs...),
+               ThisT *_this, ExtraArgs... extra_args) {
+    assert(m_handlers.m_request_handlers.find(method) ==
+               m_handlers.m_request_handlers.end() &&
+           "request already bound");
+    std::function<llvm::Expected<Result>(const Params &)> handler =
+        std::bind(fn, _this, std::placeholders::_1,
+                  std::forward<ExtraArgs>(extra_args)...);
+    m_handlers.m_request_handlers[method] =
+        [method, handler](const Request &req,
+                          llvm::unique_function<void(const Response &)> reply) {
+          Params params;
+          llvm::json::Path::Root root(method);
+          if (!fromJSON(req.params, params, root)) {
+            reply(Response{0, Error{eErrorCodeInvalidParams,
+                                    "invalid params for " + method.str() +
+                                        ": " + llvm::toString(root.getError()),
+                                    std::nullopt}});
+            return;
+          }
+          llvm::Expected<Result> result = handler(params);
+          if (llvm::Error error = result.takeError()) {
+            Error protocol_error;
+            llvm::handleAllErrors(
+                std::move(error),
+                [&](const MCPError &err) {
+                  protocol_error = err.toProtocolError();
+                },
+                [&](const llvm::ErrorInfoBase &err) {
+                  protocol_error.code = MCPError::kInternalError;
+                  protocol_error.message = err.message();
+                });
+            reply(Response{0, protocol_error});
+            return;
+          }
+
+          reply(Response{0, *result});
+        };
+  }
+
+  /// Bind a handler for an async request.
+  /// e.g. Bind.asyncRequest("peek", this, &ThisModule::peek);
+  /// Handler should be e.g. `void peek(const PeekParams&,
+  /// Reply<Expected<PeekResult>>);` PeekParams must be JSON parsable and
+  /// PeekResult must be serializable.
+  template <typename Result, typename Params, typename... ExtraArgs>
+  void asyncRequest(
+      llvm::StringLiteral method,
+      std::function<void(const Params &, ExtraArgs..., Reply<Result>)> fn,
+      ExtraArgs... extra_args) {
+    assert(m_handlers.m_request_handlers.find(method) ==
+               m_handlers.m_request_handlers.end() &&
+           "request already bound");
+    std::function<void(const Params &, Reply<Result>)> handler = std::bind(
+        fn, std::placeholders::_1, std::forward<ExtraArgs>(extra_args)...,
+        std::placeholders::_2);
+    m_handlers.m_request_handlers[method] =
+        [method, handler](const Request &req,
+                          Callback<void(const Response &)> reply) {
+          Params params;
+          llvm::json::Path::Root root(method);
+          if (!fromJSON(req.params, params, root)) {
+            reply(Response{0, Error{eErrorCodeInvalidParams,
+                                    "invalid params for " + method.str() +
+                                        ": " + llvm::toString(root.getError()),
+                                    std::nullopt}});
+            return;
+          }
+
+          handler(params, [reply = std::move(reply)](
+                              llvm::Expected<Result> result) mutable {
+            if (llvm::Error error = result.takeError()) {
+              Error protocol_error;
+              llvm::handleAllErrors(
+                  std::move(error),
+                  [&](const MCPError &err) {
+                    protocol_error = err.toProtocolError();
+                  },
+                  [&](const llvm::ErrorInfoBase &err) {
+                    protocol_error.code = MCPError::kInternalError;
+                    protocol_error.message = err.message();
+                  });
+              reply(Response{0, protocol_error});
+              return;
+            }
+
+            reply(Response{0, toJSON(*result)});
+          });
+        };
+  }
+  template <typename Result, typename Params, typename ThisT,
+            typename... ExtraArgs>
+  void asyncRequest(llvm::StringLiteral method,
+                    void (ThisT::*fn)(const Params &, ExtraArgs...,
+                                      Reply<Result>),
+                    ThisT *_this, ExtraArgs... extra_args) {
+    assert(m_handlers.m_request_handlers.find(method) ==
+               m_handlers.m_request_handlers.end() &&
+           "request already bound");
+    std::function<void(const Params &, Reply<Result>)> handler = std::bind(
+        fn, _this, std::placeholders::_1,
+        std::forward<ExtraArgs>(extra_args)..., std::placeholders::_2);
+    m_handlers.m_request_handlers[method] =
+        [method, handler](const Request &req,
+                          Callback<void(const Response &)> reply) {
+          Params params;
+          llvm::json::Path::Root root;
+          if (!fromJSON(req.params, params, root)) {
+            reply(Response{0, Error{eErrorCodeInvalidParams,
+                                    "invalid params for " + method.str(),
+                                    std::nullopt}});
+            return;
+          }
+
+          handler(params, [reply = std::move(reply)](
+                              llvm::Expected<Result> result) mutable {
+            if (llvm::Error error = result.takeError()) {
+              Error protocol_error;
+              llvm::handleAllErrors(
+                  std::move(error),
+                  [&](const MCPError &err) {
+                    protocol_error = err.toProtocolError();
+                  },
+                  [&](const llvm::ErrorInfoBase &err) {
+                    protocol_error.code = MCPError::kInternalError;
+                    protocol_error.message = err.message();
+                  });
+              reply(Response{0, protocol_error});
+              return;
+            }
+
+            reply(Response{0, toJSON(*result)});
+          });
+        };
+  }
+
+  /// Bind a handler for a notification.
+  /// e.g. Bind.notification("peek", this, &ThisModule::peek);
+  /// Handler should be e.g. void peek(const PeekParams&);
+  /// PeekParams must be JSON parsable.
+  template <typename Params, typename ThisT, typename... ExtraArgs>
+  void notification(llvm::StringLiteral method,
+                    void (ThisT::*fn)(const Params &, ExtraArgs...),
+                    ThisT *_this, ExtraArgs... extra_args) {
+    std::function<void(const Params &)> handler =
+        std::bind(fn, _this, std::placeholders::_1,
+                  std::forward<ExtraArgs>(extra_args)...);
+    m_handlers.m_notification_handlers[method] =
+        [handler](const Notification &note) {
+          Params params;
+          llvm::json::Path::Root root;
+          if (!fromJSON(note.params, params, root))
+            return; // FIXME: log error?
+
+          handler(params);
+        };
+  }
+  template <typename Params>
+  void notification(llvm::StringLiteral method,
+                    std::function<void(const Params &)> handler) {
+    assert(m_handlers.m_notification_handlers.find(method) ==
+               m_handlers.m_notification_handlers.end() &&
+           "notification already bound");
+    m_handlers.m_notification_handlers[method] =
+        [handler = std::move(handler)](const Notification &note) {
+          Params params;
+          llvm::json::Path::Root root;
+          if (!fromJSON(note.params, params, root))
+            return; // FIXME: log error?
+
+          handler(params);
+        };
+  }
+
+  /// Bind a function object to be used for outgoing requests.
+  /// e.g. OutgoingRequest<Params, Result> Edit = Bind.outgoingRequest("edit");
+  /// Params must be JSON-serializable, Result must be parsable.
+  template <typename Params, typename Result>
+  OutgoingRequest<Params, Result> outgoingRequest(llvm::StringLiteral method) {
+    return [this, method](const Params &params, Reply<Result> reply) {
+      Request request;
+      request.method = method;
+      request.params = toJSON(params);
+      m_handlers.Send(request, [reply = std::move(reply)](
+                                   const Response &resp) mutable {
+        if (const lldb_protocol::mcp::Error *err =
+                std::get_if<lldb_protocol::mcp::Error>(&resp.result)) {
+          reply(llvm::make_error<MCPError>(err->message, err->code));
+          return;
+        }
+        Result result;
+        llvm::json::Path::Root root;
+        if (!fromJSON(std::get<llvm::json::Value>(resp.result), result, root)) {
+          reply(llvm::make_error<MCPError>("parsing response failed: " +
+                                           llvm::toString(root.getError())));
+          return;
+        }
+        reply(result);
+      });
+    };
+  }
+
+  /// Bind a function object to be used for outgoing notifications.
+  /// e.g. OutgoingNotification<LogParams> Log = Bind.outgoingMethod("log");
+  /// LogParams must be JSON-serializable.
+  template <typename Params>
+  OutgoingNotification<Params>
+  outgoingNotification(llvm::StringLiteral method) {
+    return [this, method](const Params &params) {
+      Notification note;
+      note.method = method;
+      note.params = toJSON(params);
+      m_handlers.Send(note);
+    };
+  }
+
+  operator MCPTransport::MessageHandler &() { return m_handlers; }
+
+private:
+  class RawHandler final : public MCPTransport::MessageHandler {
+  public:
+    explicit RawHandler(MCPTransport *transport);
+
+    void Received(const Notification &note) override;
+    void Received(const Request &req) override;
+    void Received(const Response &resp) override;
+    void OnError(llvm::Error err) override;
+    void OnClosed() override;
+
+    void Send(const Request &req,
+              Callback<void(const Response &)> response_handler);
+    void Send(const Notification &note);
+    void Send(const Response &resp);
+
+    friend class Binder;
+
+  private:
+    std::recursive_mutex m_mutex;
+    MCPTransport *m_transport;
+    int m_seq = 0;
+    std::map<Id, Callback<void(const Response &)>> m_pending_responses;
+    llvm::StringMap<
+        Callback<void(const Request &, Callback<void(const Response &)>)>>
+        m_request_handlers;
+    llvm::StringMap<Callback<void(const Notification &)>>
+        m_notification_handlers;
+    Callback<void(MCPTransport *)> m_disconnect_handler;
+    Callback<void(MCPTransport *, llvm::Error)> m_error_handler;
+  };
+
+  RawHandler m_handlers;
+};
+using BinderUP = std::unique_ptr<Binder>;
+
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/include/lldb/Protocol/MCP/Resource.h
+++ b/lldb/include/lldb/Protocol/MCP/Resource.h
@@ -20,7 +20,7 @@ public:
   virtual ~ResourceProvider() = default;
 
   virtual std::vector<lldb_protocol::mcp::Resource> GetResources() const = 0;
-  virtual llvm::Expected<lldb_protocol::mcp::ResourceResult>
+  virtual llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
   ReadResource(llvm::StringRef uri) const = 0;
 };
 

--- a/lldb/include/lldb/Protocol/MCP/Tool.h
+++ b/lldb/include/lldb/Protocol/MCP/Tool.h
@@ -10,6 +10,8 @@
 #define LLDB_PROTOCOL_MCP_TOOL_H
 
 #include "lldb/Protocol/MCP/Protocol.h"
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
 #include <string>
 
@@ -20,8 +22,11 @@ public:
   Tool(std::string name, std::string description);
   virtual ~Tool() = default;
 
-  virtual llvm::Expected<lldb_protocol::mcp::TextResult>
-  Call(const lldb_protocol::mcp::ToolArguments &args) = 0;
+  using Reply = llvm::unique_function<void(
+      llvm::Expected<lldb_protocol::mcp::ToolsCallResult>)>;
+
+  virtual void Call(const lldb_protocol::mcp::ToolArguments &args,
+                    Reply reply) = 0;
 
   virtual std::optional<llvm::json::Value> GetSchema() const {
     return llvm::json::Object{{"type", "object"}};

--- a/lldb/include/lldb/Protocol/MCP/Transport.h
+++ b/lldb/include/lldb/Protocol/MCP/Transport.h
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PROTOCOL_MCP_TRANSPORT_H
+#define LLDB_PROTOCOL_MCP_TRANSPORT_H
+
+#include "lldb/Host/JSONTransport.h"
+#include "lldb/Host/Socket.h"
+#include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/lldb-forward.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+
+namespace lldb_protocol::mcp {
+
+using MCPTransport = lldb_private::Transport<Request, Response, Notification>;
+using MCPTransportUP = std::unique_ptr<MCPTransport>;
+
+llvm::StringRef CommunicationSocketPath();
+llvm::Expected<lldb::IOObjectSP> Connect();
+
+class Transport final
+    : public lldb_private::JSONRPCTransport<Request, Response, Notification> {
+public:
+  using LogCallback = std::function<void(llvm::StringRef message)>;
+
+  Transport(lldb::IOObjectSP input, lldb::IOObjectSP output,
+            std::string client_name = "", LogCallback log_callback = {});
+
+  void Log(llvm::StringRef message) override;
+
+  static llvm::Expected<MCPTransportUP>
+  Connect(llvm::raw_ostream *logger = nullptr);
+
+private:
+  std::string m_client_name;
+  LogCallback m_log_callback;
+};
+using TransportUP = std::unique_ptr<Transport>;
+
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.h
@@ -41,7 +41,9 @@ public:
 protected:
   // This adds tools and resource providers that
   // are specific to this server. Overridable by the unit tests.
-  virtual void Extend(lldb_protocol::mcp::Server &server) const;
+  virtual void Extend(lldb_protocol::mcp::Server &server);
+
+  void OnInitialized(const lldb_protocol::mcp::Notification &);
 
 private:
   void AcceptCallback(std::unique_ptr<Socket> socket);

--- a/lldb/source/Plugins/Protocol/MCP/Resource.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.cpp
@@ -124,7 +124,7 @@ DebuggerResourceProvider::GetResources() const {
   return resources;
 }
 
-llvm::Expected<lldb_protocol::mcp::ResourceResult>
+llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
 DebuggerResourceProvider::ReadResource(llvm::StringRef uri) const {
 
   auto [protocol, path] = uri.split("://");
@@ -161,7 +161,7 @@ DebuggerResourceProvider::ReadResource(llvm::StringRef uri) const {
   return ReadDebuggerResource(uri, debugger_idx);
 }
 
-llvm::Expected<lldb_protocol::mcp::ResourceResult>
+llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
 DebuggerResourceProvider::ReadDebuggerResource(llvm::StringRef uri,
                                                lldb::user_id_t debugger_id) {
   lldb::DebuggerSP debugger_sp = Debugger::FindDebuggerWithID(debugger_id);
@@ -178,12 +178,12 @@ DebuggerResourceProvider::ReadDebuggerResource(llvm::StringRef uri,
   contents.mimeType = kMimeTypeJSON;
   contents.text = llvm::formatv("{0}", toJSON(debugger_resource));
 
-  lldb_protocol::mcp::ResourceResult result;
+  lldb_protocol::mcp::ResourcesReadResult result;
   result.contents.push_back(contents);
   return result;
 }
 
-llvm::Expected<lldb_protocol::mcp::ResourceResult>
+llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
 DebuggerResourceProvider::ReadTargetResource(llvm::StringRef uri,
                                              lldb::user_id_t debugger_id,
                                              size_t target_idx) {
@@ -214,7 +214,7 @@ DebuggerResourceProvider::ReadTargetResource(llvm::StringRef uri,
   contents.mimeType = kMimeTypeJSON;
   contents.text = llvm::formatv("{0}", toJSON(target_resource));
 
-  lldb_protocol::mcp::ResourceResult result;
+  lldb_protocol::mcp::ResourcesReadResult result;
   result.contents.push_back(contents);
   return result;
 }

--- a/lldb/source/Plugins/Protocol/MCP/Resource.h
+++ b/lldb/source/Plugins/Protocol/MCP/Resource.h
@@ -23,7 +23,7 @@ public:
 
   virtual std::vector<lldb_protocol::mcp::Resource>
   GetResources() const override;
-  virtual llvm::Expected<lldb_protocol::mcp::ResourceResult>
+  virtual llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
   ReadResource(llvm::StringRef uri) const override;
 
 private:
@@ -31,9 +31,9 @@ private:
   static lldb_protocol::mcp::Resource GetTargetResource(size_t target_idx,
                                                         Target &target);
 
-  static llvm::Expected<lldb_protocol::mcp::ResourceResult>
+  static llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
   ReadDebuggerResource(llvm::StringRef uri, lldb::user_id_t debugger_id);
-  static llvm::Expected<lldb_protocol::mcp::ResourceResult>
+  static llvm::Expected<lldb_protocol::mcp::ResourcesReadResult>
   ReadTargetResource(llvm::StringRef uri, lldb::user_id_t debugger_id,
                      size_t target_idx);
 };

--- a/lldb/source/Plugins/Protocol/MCP/Tool.h
+++ b/lldb/source/Plugins/Protocol/MCP/Tool.h
@@ -22,10 +22,11 @@ public:
   using lldb_protocol::mcp::Tool::Tool;
   ~CommandTool() = default;
 
-  virtual llvm::Expected<lldb_protocol::mcp::TextResult>
-  Call(const lldb_protocol::mcp::ToolArguments &args) override;
+  void Call(const lldb_protocol::mcp::ToolArguments &,
+            llvm::unique_function<void(
+                llvm::Expected<lldb_protocol::mcp::ToolsCallResult>)>) override;
 
-  virtual std::optional<llvm::json::Value> GetSchema() const override;
+  std::optional<llvm::json::Value> GetSchema() const override;
 };
 
 } // namespace lldb_private::mcp

--- a/lldb/source/Protocol/MCP/Binder.cpp
+++ b/lldb/source/Protocol/MCP/Binder.cpp
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Protocol/MCP/Binder.h"
+#include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/Protocol/MCP/Transport.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <atomic>
+#include <cassert>
+#include <mutex>
+
+using namespace llvm;
+
+namespace lldb_protocol::mcp {
+
+/// Function object to reply to a call.
+/// Each instance must be called exactly once, otherwise:
+///  - the bug is logged, and (in debug mode) an assert will fire
+///  - if there was no reply, an error reply is sent
+///  - if there were multiple replies, only the first is sent
+class ReplyOnce {
+  std::atomic<bool> replied = {false};
+  const Id id;
+  MCPTransport *transport;               // Null when moved-from.
+  MCPTransport::MessageHandler *handler; // Null when moved-from.
+
+public:
+  ReplyOnce(const Id id, MCPTransport *transport,
+            MCPTransport::MessageHandler *handler)
+      : id(id), transport(transport), handler(handler) {
+    assert(handler);
+  }
+  ReplyOnce(ReplyOnce &&other)
+      : replied(other.replied.load()), id(other.id), transport(other.transport),
+        handler(other.handler) {
+    other.transport = nullptr;
+    other.handler = nullptr;
+  }
+  ReplyOnce &operator=(ReplyOnce &&) = delete;
+  ReplyOnce(const ReplyOnce &) = delete;
+  ReplyOnce &operator=(const ReplyOnce &) = delete;
+
+  ~ReplyOnce() {
+    if (transport && handler && !replied) {
+      assert(false && "must reply to all calls!");
+      (*this)(Response{id, Error{MCPError::kInternalError, "failed to reply",
+                                 std::nullopt}});
+    }
+  }
+
+  void operator()(const Response &resp) {
+    assert(transport && handler && "moved-from!");
+    if (replied.exchange(true)) {
+      assert(false && "must reply to each call only once!");
+      return;
+    }
+
+    if (llvm::Error error = transport->Send(Response{id, resp.result}))
+      handler->OnError(std::move(error));
+  }
+};
+
+Binder::RawHandler::RawHandler(MCPTransport *transport)
+    : m_transport(transport) {}
+
+void Binder::RawHandler::Received(const Notification &note) {
+  std::scoped_lock<std::recursive_mutex> guard(m_mutex);
+  auto it = m_notification_handlers.find(note.method);
+  if (it == m_notification_handlers.end()) {
+    OnError(llvm::createStringError(
+        formatv("no handled for notification {0}", toJSON(note))));
+    return;
+  }
+  it->second(note);
+}
+
+void Binder::RawHandler::Received(const Request &req) {
+  ReplyOnce reply(req.id, m_transport, this);
+
+  std::scoped_lock<std::recursive_mutex> guard(m_mutex);
+  auto it = m_request_handlers.find(req.method);
+  if (it == m_request_handlers.end()) {
+    reply({req.id,
+           Error{eErrorCodeMethodNotFound, "method not found", std::nullopt}});
+    return;
+  }
+
+  it->second(req, std::move(reply));
+}
+
+void Binder::RawHandler::Received(const Response &resp) {
+  std::scoped_lock<std::recursive_mutex> guard(m_mutex);
+  auto it = m_pending_responses.find(resp.id);
+  if (it == m_pending_responses.end()) {
+    OnError(llvm::createStringError(
+        formatv("no pending request for {0}", toJSON(resp))));
+    return;
+  }
+
+  it->second(resp);
+  m_pending_responses.erase(it);
+}
+
+void Binder::RawHandler::OnError(llvm::Error err) {
+  std::scoped_lock<std::recursive_mutex> guard(m_mutex);
+  if (m_error_handler)
+    m_error_handler(m_transport, std::move(err));
+}
+
+void Binder::RawHandler::OnClosed() {
+  std::scoped_lock<std::recursive_mutex> guard(m_mutex);
+  if (m_disconnect_handler)
+    m_disconnect_handler(m_transport);
+}
+
+void Binder::RawHandler::Send(
+    const Request &req,
+    llvm::unique_function<void(const Response &)> response_handler) {
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  Id id = ++m_seq;
+  if (llvm::Error err = m_transport->Send(Request{id, req.method, req.params}))
+    return OnError(std::move(err));
+  m_pending_responses[id] = std::move(response_handler);
+}
+
+void Binder::RawHandler::Send(const Notification &note) {
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  if (llvm::Error err = m_transport->Send(note))
+    return OnError(std::move(err));
+}
+
+} // namespace lldb_protocol::mcp

--- a/lldb/source/Protocol/MCP/CMakeLists.txt
+++ b/lldb/source/Protocol/MCP/CMakeLists.txt
@@ -1,12 +1,15 @@
 add_lldb_library(lldbProtocolMCP NO_PLUGIN_DEPENDENCIES
+  Binder.cpp
   MCPError.cpp
   Protocol.cpp
   Server.cpp
   Tool.cpp
+  Transport.cpp
 
   LINK_COMPONENTS
     Support
   LINK_LIBS
     lldbUtility
+    lldbHost
 )
 

--- a/lldb/source/Protocol/MCP/Transport.cpp
+++ b/lldb/source/Protocol/MCP/Transport.cpp
@@ -1,0 +1,113 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Protocol/MCP/Transport.h"
+#include "lldb/Host/FileSystem.h"
+#include "lldb/Host/HostInfo.h"
+#include "lldb/Host/Socket.h"
+#include "lldb/Utility/FileSpec.h"
+#include "lldb/lldb-forward.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/Threading.h"
+#include "llvm/Support/raw_ostream.h"
+#include <memory>
+#include <thread>
+
+using namespace llvm;
+using namespace lldb;
+using namespace lldb_private;
+
+namespace lldb_protocol::mcp {
+
+static Expected<sys::ProcessInfo> StartServer() {
+  static once_flag f;
+  static FileSpec candidate;
+  llvm::call_once(f, [] {
+    HostInfo::Initialize();
+    candidate = HostInfo::GetSupportExeDir();
+    candidate.AppendPathComponent("lldb-mcp");
+  });
+
+  if (!FileSystem::Instance().Exists(candidate))
+    return createStringError("lldb-mcp executable not found");
+  std::vector<StringRef> args = {candidate.GetPath(), "--server"};
+  sys::ProcessInfo proc =
+      sys::ExecuteNoWait(candidate.GetPath(), args, std::nullopt, {}, 0,
+                         nullptr, nullptr, nullptr, /*DetachProcess=*/true);
+  if (proc.Pid == sys::ProcessInfo::InvalidPid)
+    return createStringError("Failed to start server: " + candidate.GetPath());
+  StringRef socket_path = CommunicationSocketPath();
+  while (!sys::fs::exists(socket_path))
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  return proc;
+}
+
+Transport::Transport(lldb::IOObjectSP input, lldb::IOObjectSP output,
+                     std::string client_name, LogCallback log_callback)
+    : JSONRPCTransport(input, output), m_client_name(client_name),
+      m_log_callback(log_callback) {}
+
+void Transport::Log(llvm::StringRef message) {
+  if (m_log_callback)
+    m_log_callback(llvm::formatv("{0}: {1}", m_client_name, message).str());
+}
+
+llvm::StringRef CommunicationSocketPath() {
+  static std::once_flag f;
+  static SmallString<256> socket_path;
+  llvm::call_once(f, [] {
+    assert(sys::path::home_directory(socket_path) &&
+           "failed to get home directory");
+    sys::path::append(socket_path, ".lldb-mcp-sock");
+  });
+  return socket_path.str();
+}
+
+Expected<IOObjectSP> Connect() {
+  StringRef socket_path = CommunicationSocketPath();
+  if (!sys::fs::exists(socket_path))
+    if (llvm::Error err = StartServer().takeError())
+      return err;
+
+  Socket::SocketProtocol protocol = Socket::ProtocolUnixDomain;
+  Status error;
+  std::unique_ptr<Socket> socket = Socket::Create(protocol, error);
+  if (error.Fail())
+    return error.takeError();
+  std::chrono::steady_clock::time_point deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  while (std::chrono::steady_clock::now() < deadline) {
+    Status error = socket->Connect(socket_path);
+    if (error.Success()) {
+      return socket;
+    }
+    if (error.Fail() && error.GetError() != ECONNREFUSED &&
+        error.GetError() != ENOENT)
+      return error.takeError();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  return createStringError("failed to connect to lldb-mcp multiplexer");
+}
+
+Expected<MCPTransportUP> Transport::Connect(llvm::raw_ostream *logger) {
+  Expected<IOObjectSP> maybe_sock = lldb_protocol::mcp::Connect();
+  if (!maybe_sock)
+    return maybe_sock.takeError();
+
+  return std::make_unique<Transport>(*maybe_sock, *maybe_sock, "client",
+                                     [logger](StringRef msg) {
+                                       if (logger)
+                                         *logger << msg << "\n";
+                                     });
+}
+
+} // namespace lldb_protocol::mcp

--- a/lldb/unittests/Protocol/ProtocolMCPTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPTest.cpp
@@ -277,10 +277,11 @@ TEST(ProtocolMCPTest, ResourceResult) {
   contents2.text = "Second resource content";
   contents2.mimeType = "application/json";
 
-  ResourceResult result;
+  ResourcesReadResult result;
   result.contents = {contents1, contents2};
 
-  llvm::Expected<ResourceResult> deserialized_result = roundtripJSON(result);
+  llvm::Expected<ResourcesReadResult> deserialized_result =
+      roundtripJSON(result);
   ASSERT_THAT_EXPECTED(deserialized_result, llvm::Succeeded());
 
   ASSERT_EQ(result.contents.size(), deserialized_result->contents.size());
@@ -297,9 +298,10 @@ TEST(ProtocolMCPTest, ResourceResult) {
 }
 
 TEST(ProtocolMCPTest, ResourceResultEmpty) {
-  ResourceResult result;
+  ResourcesReadResult result;
 
-  llvm::Expected<ResourceResult> deserialized_result = roundtripJSON(result);
+  llvm::Expected<ResourcesReadResult> deserialized_result =
+      roundtripJSON(result);
   ASSERT_THAT_EXPECTED(deserialized_result, llvm::Succeeded());
 
   EXPECT_TRUE(deserialized_result->contents.empty());


### PR DESCRIPTION
The `lldb_protocol::mcp::Binder` class is used to craft bindings between requests and notifications to specific handlers.

This supports both incoming and outgoing handlers that bind these functions to a MessageHandler and generates encoding/decoding helpers for each call.

For example, see the `lldb_protocol::mcp::Server` class that has been greatly simplified.