### PR TITLE
[clang-tidy][test] Make check_clang_tidy.py work with very long file paths

### DIFF
--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -45,6 +45,7 @@ Notes
 import argparse
 import os
 import pathlib
+import platform
 import re
 import subprocess
 import sys
@@ -145,7 +146,10 @@ class CheckRunner:
             self.clang_extra_args.append("-resource-dir=%s" % self.resource_dir)
 
     def read_input(self) -> None:
-        with open(self.input_file_name, "r", encoding="utf-8") as input_file:
+        file_name = self.input_file_name
+        if platform.system() == "Windows":
+            file_name = "\\\\?\\" + os.path.abspath(file_name)
+        with open(file_name, "r", encoding="utf-8") as input_file:
             self.input_text = input_file.read()
 
     def get_prefixes(self) -> None:

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -146,6 +146,8 @@ class CheckRunner:
             self.clang_extra_args.append("-resource-dir=%s" % self.resource_dir)
 
     def read_input(self) -> None:
+        # Use a "\\?\" prefix on Windows to handle long file paths transparently:
+        # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
         file_name = self.input_file_name
         if platform.system() == "Windows":
             file_name = "\\\\?\\" + os.path.abspath(file_name)


### PR DESCRIPTION
http://github.com/llvm/llvm-project/pull/95220 added a test with a very long file path, which can fail if run on Windows with a long directory path.

On Windows, there are file path length limits, which can be worked around by prefixing the (absolute) path with '\\?\': https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation