### PR TITLE
Revert "[NFC][lldb] Add a null check, actually use new SharedModuleLi…

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -844,8 +844,6 @@ public:
   }
 
   bool RemoveIfOrphaned(const Module *module_ptr) {
-    if (!module_ptr)
-      return false;
     std::lock_guard<std::recursive_mutex> guard(GetMutex());
     RemoveFromMap(*module_ptr, /*if_orphaned=*/true);
     return m_list.RemoveIfOrphaned(module_ptr);
@@ -982,7 +980,7 @@ private:
 };
 
 struct SharedModuleListInfo {
-  SharedModuleList module_list;
+  ModuleList module_list;
   ModuleListProperties module_list_properties;
 };
 }
@@ -1000,7 +998,7 @@ static SharedModuleListInfo &GetSharedModuleListInfo()
   return *g_shared_module_list_info;
 }
 
-static SharedModuleList &GetSharedModuleList() {
+static ModuleList &GetSharedModuleList() {
   return GetSharedModuleListInfo().module_list;
 }
 
@@ -1010,8 +1008,8 @@ ModuleListProperties &ModuleList::GetGlobalModuleListProperties() {
 
 bool ModuleList::ModuleIsInCache(const Module *module_ptr) {
   if (module_ptr) {
-    SharedModuleList &shared_module_list = GetSharedModuleList();
-    return shared_module_list.FindModule(*module_ptr).get() != nullptr;
+    ModuleList &shared_module_list = GetSharedModuleList();
+    return shared_module_list.FindModule(module_ptr).get() != nullptr;
   }
   return false;
 }
@@ -1034,8 +1032,9 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
                             const FileSpecList *module_search_paths_ptr,
                             llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
                             bool *did_create_ptr, bool always_create) {
-  SharedModuleList &shared_module_list = GetSharedModuleList();
-  std::lock_guard<std::recursive_mutex> guard(shared_module_list.GetMutex());
+  ModuleList &shared_module_list = GetSharedModuleList();
+  std::lock_guard<std::recursive_mutex> guard(
+      shared_module_list.m_modules_mutex);
   char path[PATH_MAX];
 
   Status error;


### PR DESCRIPTION
…st class"

This reverts commit 234e075c1dbdaacd2e1b4199ae983f5c4439223c.


I'm reverting this because the ASAN build fails running the TestMiniDumpUUID.py test. This happens because the pointer is already freed before the call to `RemoveIfOrpahaned`. The ModuleList implementation never actually dereferences the pointer, so it worked correctly, but the new map implementation does dereference it, hence the crash.