### PR TITLE
[clang-format] Fix a bug in SkipMacroDefinitionBody

### DIFF
--- a/clang/lib/Format/UnwrappedLineParser.cpp
+++ b/clang/lib/Format/UnwrappedLineParser.cpp
@@ -1207,11 +1207,8 @@ void UnwrappedLineParser::parsePPDefine() {
     return;
   }
 
-  if (auto *Prev = Tokens->getPreviousToken(); Prev->is(tok::comment) &&
-                                               Prev->NewlinesBefore > 0 &&
-                                               !Prev->HasUnescapedNewline) {
-    Prev->Finalized = true;
-  }
+  for (auto *Comment : CommentsBeforeNextToken)
+    Comment->Finalized = true;
 
   do {
     FormatTok->Finalized = true;

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -26023,6 +26023,7 @@ TEST_F(FormatTest, SkipMacroDefinitionBody) {
                  " A  a",
                  Style);
   verifyNoChange("#define MY_MACRO  \\\n"
+                 " /*foo*//*bar*/  \\\n"
                  " /* comment */  \\\n"
                  "   1",
                  Style);


### PR DESCRIPTION
All comments before the macro definition body should be skipped.