### PR TITLE
[C++20][Modules] Use `MultiOnDiskHashTable` to improve the performance of header search algorithm.

### DIFF
--- a/clang/include/clang/Lex/HeaderSearch.h
+++ b/clang/include/clang/Lex/HeaderSearch.h
@@ -138,6 +138,9 @@ struct HeaderFileInfo {
   /// isModuleHeader will potentially be set, but not cleared.
   /// isTextualModuleHeader will be set or cleared based on the role update.
   void mergeModuleMembership(ModuleMap::ModuleHeaderRole Role);
+
+  /// Merge the header file info \p Other into this header file info.
+  void merge(const HeaderFileInfo &Other);
 };
 
 static_assert(sizeof(HeaderFileInfo) <= 16);

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -385,6 +385,9 @@ struct ModuleLocalLookupTable;
 /// The on-disk hash table(s) used for specialization decls.
 struct LazySpecializationInfoLookupTable;
 
+/// The on-disk hash table(s) used for header file infos.
+struct HeaderFileInfoLookupTable;
+
 } // namespace reader
 
 } // namespace serialization
@@ -683,6 +686,9 @@ private:
 
   /// Map from the TU to its lexical contents from each module file.
   std::vector<std::pair<ModuleFile*, LexicalContents>> TULexicalDecls;
+
+  std::unique_ptr<serialization::reader::HeaderFileInfoLookupTable>
+      HeaderFileInfoLookup;
 
   /// Map from a DeclContext to its lookup tables.
   llvm::DenseMap<const DeclContext *,

--- a/clang/include/clang/Serialization/ModuleFile.h
+++ b/clang/include/clang/Serialization/ModuleFile.h
@@ -394,11 +394,7 @@ public:
   ///
   /// This pointer points into a memory buffer, where the on-disk hash
   /// table for header file information actually lives.
-  const char *HeaderFileInfoTableData = nullptr;
-
-  /// The on-disk hash table that contains information about each of
-  /// the header files.
-  void *HeaderFileInfoTable = nullptr;
+  const unsigned char *HeaderFileInfoTableData = nullptr;
 
   // === Submodule information ===
 

--- a/clang/lib/Lex/HeaderSearch.cpp
+++ b/clang/lib/Lex/HeaderSearch.cpp
@@ -1289,23 +1289,20 @@ void HeaderFileInfo::mergeModuleMembership(ModuleMap::ModuleHeaderRole Role) {
                                 (Role & ModuleMap::TextualHeader));
 }
 
-/// Merge the header file info provided by \p OtherHFI into the current
-/// header file info (\p HFI)
-static void mergeHeaderFileInfo(HeaderFileInfo &HFI,
-                                const HeaderFileInfo &OtherHFI) {
-  assert(OtherHFI.External && "expected to merge external HFI");
+void HeaderFileInfo::merge(const HeaderFileInfo &Other) {
+  assert(Other.External && "expected to merge external HFI");
 
-  HFI.isImport |= OtherHFI.isImport;
-  HFI.isPragmaOnce |= OtherHFI.isPragmaOnce;
-  mergeHeaderFileInfoModuleBits(HFI, OtherHFI.isModuleHeader,
-                                OtherHFI.isTextualModuleHeader);
+  isImport |= Other.isImport;
+  isPragmaOnce |= Other.isPragmaOnce;
+  mergeHeaderFileInfoModuleBits(*this, Other.isModuleHeader,
+                                Other.isTextualModuleHeader);
 
-  if (!HFI.LazyControllingMacro.isValid())
-    HFI.LazyControllingMacro = OtherHFI.LazyControllingMacro;
+  if (!LazyControllingMacro.isValid())
+    LazyControllingMacro = Other.LazyControllingMacro;
 
-  HFI.DirInfo = OtherHFI.DirInfo;
-  HFI.External = (!HFI.IsValid || HFI.External);
-  HFI.IsValid = true;
+  DirInfo = Other.DirInfo;
+  External = (!IsValid || External);
+  IsValid = true;
 }
 
 HeaderFileInfo &HeaderSearch::getFileInfo(FileEntryRef FE) {
@@ -1319,7 +1316,7 @@ HeaderFileInfo &HeaderSearch::getFileInfo(FileEntryRef FE) {
     if (ExternalHFI.IsValid) {
       HFI->Resolved = true;
       if (ExternalHFI.External)
-        mergeHeaderFileInfo(*HFI, ExternalHFI);
+        HFI->merge(ExternalHFI);
     }
   }
 
@@ -1343,7 +1340,7 @@ const HeaderFileInfo *HeaderSearch::getExistingFileInfo(FileEntryRef FE) const {
       if (ExternalHFI.IsValid) {
         HFI->Resolved = true;
         if (ExternalHFI.External)
-          mergeHeaderFileInfo(*HFI, ExternalHFI);
+          HFI->merge(ExternalHFI);
       }
     }
   } else if (FE.getUID() < FileInfo.size()) {

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2273,6 +2273,18 @@ ASTReader::getGlobalPreprocessedEntityID(ModuleFile &M,
   return LocalID + I->second;
 }
 
+void HeaderFileInfoTrait::data_type_builder::merge(data_type D) const {
+  Data.merge(D);
+}
+
+ModuleFile *HeaderFileInfoTrait::ReadFileRef(const unsigned char *&d) {
+  using namespace llvm::support;
+
+  uint32_t ModuleFileID =
+      endian::readNext<uint32_t, llvm::endianness::little, unaligned>(d);
+  return Reader.getLocalModuleFile(M, ModuleFileID);
+}
+
 OptionalFileEntryRef
 HeaderFileInfoTrait::getFile(const internal_key_type &Key) {
   FileManager &FileMgr = Reader.getFileManager();
@@ -2297,6 +2309,11 @@ HeaderFileInfoTrait::GetInternalKey(external_key_type ekey) {
                             M.HasTimestamps ? ekey.getModificationTime() : 0,
                             ekey.getName(), /*Imported*/ false};
   return ikey;
+}
+
+OptionalFileEntryRef
+HeaderFileInfoTrait::TryGetExternalKey(internal_key_ref ikey) {
+  return getFile(ikey);
 }
 
 bool HeaderFileInfoTrait::EqualKey(internal_key_ref a, internal_key_ref b) {
@@ -2330,9 +2347,9 @@ HeaderFileInfoTrait::ReadKey(const unsigned char *d, unsigned) {
   return ikey;
 }
 
-HeaderFileInfoTrait::data_type
-HeaderFileInfoTrait::ReadData(internal_key_ref key, const unsigned char *d,
-                              unsigned DataLen) {
+void HeaderFileInfoTrait::ReadDataInto(internal_key_ref key,
+                                       const unsigned char *d, unsigned DataLen,
+                                       data_type_builder &Val) {
   using namespace llvm::support;
 
   const unsigned char *End = d + DataLen;
@@ -2379,7 +2396,12 @@ HeaderFileInfoTrait::ReadData(internal_key_ref key, const unsigned char *d,
   // This HeaderFileInfo was externally loaded.
   HFI.External = true;
   HFI.IsValid = true;
-  return HFI;
+  Val.merge(HFI);
+}
+
+void HeaderFileInfoTrait::MergeDataInto(const data_type &From,
+                                        data_type_builder &To) {
+  To.merge(From);
 }
 
 void ASTReader::addPendingMacro(IdentifierInfo *II, ModuleFile *M,
@@ -4232,13 +4254,16 @@ llvm::Error ASTReader::ReadASTBlock(ModuleFile &F,
       break;
 
     case HEADER_SEARCH_TABLE:
-      F.HeaderFileInfoTableData = Blob.data();
+      F.HeaderFileInfoTableData = (const unsigned char *)Blob.data();
       F.LocalNumHeaderFileInfos = Record[1];
       if (Record[0]) {
-        F.HeaderFileInfoTable = HeaderFileInfoLookupTable::Create(
-            (const unsigned char *)F.HeaderFileInfoTableData + Record[0],
-            (const unsigned char *)F.HeaderFileInfoTableData,
-            HeaderFileInfoTrait(*this, F));
+        if (!HeaderFileInfoLookup) {
+          HeaderFileInfoLookup = std::make_unique<HeaderFileInfoLookupTable>();
+        }
+        HeaderFileInfoLookup->Table.add(
+            &F, F.HeaderFileInfoTableData + Record[0],
+            F.HeaderFileInfoTableData + sizeof(uint32_t),
+            F.HeaderFileInfoTableData, HeaderFileInfoTrait(*this, F));
 
         PP.getHeaderSearchInfo().SetExternalSource(this);
         if (!PP.getHeaderSearchInfo().getExternalLookup())
@@ -6946,43 +6971,8 @@ std::optional<bool> ASTReader::isPreprocessedEntityInFileID(unsigned Index,
     return false;
 }
 
-namespace {
-
-  /// Visitor used to search for information about a header file.
-  class HeaderFileInfoVisitor {
-  FileEntryRef FE;
-    std::optional<HeaderFileInfo> HFI;
-
-  public:
-    explicit HeaderFileInfoVisitor(FileEntryRef FE) : FE(FE) {}
-
-    bool operator()(ModuleFile &M) {
-      HeaderFileInfoLookupTable *Table
-        = static_cast<HeaderFileInfoLookupTable *>(M.HeaderFileInfoTable);
-      if (!Table)
-        return false;
-
-      // Look in the on-disk hash table for an entry for this file name.
-      HeaderFileInfoLookupTable::iterator Pos = Table->find(FE);
-      if (Pos == Table->end())
-        return false;
-
-      HFI = *Pos;
-      return true;
-    }
-
-    std::optional<HeaderFileInfo> getHeaderFileInfo() const { return HFI; }
-  };
-
-} // namespace
-
 HeaderFileInfo ASTReader::GetHeaderFileInfo(FileEntryRef FE) {
-  HeaderFileInfoVisitor Visitor(FE);
-  ModuleMgr.visit(Visitor);
-  if (std::optional<HeaderFileInfo> HFI = Visitor.getHeaderFileInfo())
-      return *HFI;
-
-  return HeaderFileInfo();
+  return HeaderFileInfoLookup->Table.find(FE);
 }
 
 void ASTReader::ReadPragmaDiagnosticMappings(DiagnosticsEngine &Diag) {

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -2347,9 +2347,8 @@ HeaderFileInfoTrait::ReadData(internal_key_ref key, const unsigned char *d,
       // deserialize this header file info again.
       Reader.getPreprocessor().getIncludedFiles().insert(*FE);
 
-  // FIXME: Refactor with mergeHeaderFileInfo in HeaderSearch.cpp.
-  HFI.isImport |= (Flags >> 5) & 0x01;
-  HFI.isPragmaOnce |= (Flags >> 4) & 0x01;
+  HFI.isImport = (Flags >> 5) & 0x01;
+  HFI.isPragmaOnce = (Flags >> 4) & 0x01;
   HFI.DirInfo = (Flags >> 1) & 0x07;
   HFI.LazyControllingMacro = Reader.getGlobalIdentifierID(
       M, endian::readNext<IdentifierID, llvm::endianness::little>(d));

--- a/clang/lib/Serialization/ModuleFile.cpp
+++ b/clang/lib/Serialization/ModuleFile.cpp
@@ -24,7 +24,6 @@ using namespace reader;
 
 ModuleFile::~ModuleFile() {
   delete static_cast<ASTIdentifierLookupTable *>(IdentifierLookupTable);
-  delete static_cast<HeaderFileInfoLookupTable *>(HeaderFileInfoTable);
   delete static_cast<ASTSelectorLookupTable *>(SelectorLookupTable);
 }
 


### PR DESCRIPTION
This is a second attempt to solve https://github.com/llvm/llvm-project/issues/140860, and supersedes the attempt in https://github.com/llvm/llvm-project/pull/140867.

In this approach, we introduce an instance of `MultiOnDiskHashTable` that lazily loads the on-disk hash table for each PCMs, and only condenses it into memory once it surpasses some threshold (64 is used here).

The results are very similar to https://github.com/llvm/llvm-project/pull/140867, where the following test case takes about **14s** before the change, and **0.2s** with the change.

```bash
#/usr/bin/env bash

CLANG=${CLANG:-clang++}
NUM_MODULES=${NUM_MODULES:-1000}
NUM_HEADERS=${NUM_HEADERS:-10000}

mkdir build && cd build

for i in $(seq 1 $NUM_MODULES); do > m${i}.h; done
seq 1 $NUM_MODULES | xargs -I {} -P $(nproc) bash -c "$CLANG -std=c++20 -fmodule-header m{}.h"

for i in $(seq 1 $NUM_HEADERS); do > h${i}.h; done

> a.cpp
for i in $(seq 1 $NUM_MODULES); do echo "import \"m${i}.h\";" >> a.cpp; done
for i in $(seq 1 $NUM_HEADERS); do echo "#include \"h${i}.h\"" >> a.cpp; done
echo "int main() {}" >> a.cpp

time $CLANG -std=c++20 -Wno-experimental-header-units -E a.cpp -o /dev/null \
    $(for i in $(seq 1 $NUM_MODULES); do echo -n "-fmodule-file=m${i}.pcm "; done)
```

I'll be happy to add more comments and such, but I wanted to get some feedback as to whether this approach seems reasonable to folks.