### PR TITLE
[clang] Post-commit review for #150028

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -3265,10 +3265,11 @@ public:
   /// Try to get the alloc_size attribute of the callee. May return null.
   const AllocSizeAttr *getCalleeAllocSizeAttr() const;
 
-  /// Get the total size in bytes allocated by calling a function decorated with
-  /// alloc_size. Returns std::nullopt if the the result cannot be evaluated.
+  /// Evaluates the total size in bytes allocated by calling a function
+  /// decorated with alloc_size. Returns std::nullopt if the the result cannot
+  /// be evaluated.
   std::optional<llvm::APInt>
-  getBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const;
+  evaluateBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const;
 
   bool isCallToStdMove() const;
 

--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -3533,14 +3533,14 @@ const AllocSizeAttr *CallExpr::getCalleeAllocSizeAttr() const {
 }
 
 std::optional<llvm::APInt>
-CallExpr::getBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const {
+CallExpr::evaluateBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const {
   const AllocSizeAttr *AllocSize = getCalleeAllocSizeAttr();
 
   assert(AllocSize && AllocSize->getElemSizeParam().isValid());
   unsigned SizeArgNo = AllocSize->getElemSizeParam().getASTIndex();
   unsigned BitsInSizeT = Ctx.getTypeSize(Ctx.getSizeType());
   if (getNumArgs() <= SizeArgNo)
-    return {};
+    return std::nullopt;
 
   auto EvaluateAsSizeT = [&](const Expr *E, llvm::APSInt &Into) {
     Expr::EvalResult ExprResult;
@@ -3556,7 +3556,7 @@ CallExpr::getBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const {
 
   llvm::APSInt SizeOfElem;
   if (!EvaluateAsSizeT(getArg(SizeArgNo), SizeOfElem))
-    return {};
+    return std::nullopt;
 
   if (!AllocSize->getNumElemsParam().isValid())
     return SizeOfElem;
@@ -3564,12 +3564,12 @@ CallExpr::getBytesReturnedByAllocSizeCall(const ASTContext &Ctx) const {
   llvm::APSInt NumberOfElems;
   unsigned NumArgNo = AllocSize->getNumElemsParam().getASTIndex();
   if (!EvaluateAsSizeT(getArg(NumArgNo), NumberOfElems))
-    return {};
+    return std::nullopt;
 
   bool Overflow;
   llvm::APInt BytesAvailable = SizeOfElem.umul_ov(NumberOfElems, Overflow);
   if (Overflow)
-    return {};
+    return std::nullopt;
 
   return BytesAvailable;
 }

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -9465,7 +9465,8 @@ static bool getBytesReturnedByAllocSizeCall(const ASTContext &Ctx,
          "Can't get the size of a non alloc_size function");
   const auto *Base = LVal.getLValueBase().get<const Expr *>();
   const CallExpr *CE = tryUnwrapAllocSizeCall(Base);
-  std::optional<llvm::APInt> Size = CE->getBytesReturnedByAllocSizeCall(Ctx);
+  std::optional<llvm::APInt> Size =
+      CE->evaluateBytesReturnedByAllocSizeCall(Ctx);
   if (!Size)
     return false;
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -7836,7 +7836,7 @@ static void CheckSufficientAllocSize(Sema &S, QualType DestType,
   if (!CE->getCalleeAllocSizeAttr())
     return;
   std::optional<llvm::APInt> AllocSize =
-      CE->getBytesReturnedByAllocSizeCall(S.Context);
+      CE->evaluateBytesReturnedByAllocSizeCall(S.Context);
   if (!AllocSize)
     return;
   auto Size = CharUnits::fromQuantity(AllocSize->getZExtValue());


### PR DESCRIPTION
 1) Return `std::nullopt` instead of `{}`.
 2) Rename the new function to evaluate*, it's not a simple getter.