### PR TITLE
Fix test added in #155148 work with Windows style path separators.

### DIFF
--- a/llvm/utils/lit/tests/pass-test-update.py
+++ b/llvm/utils/lit/tests/pass-test-update.py
@@ -13,7 +13,7 @@
 # CHECK: Traceback (most recent call last):
 # CHECK:   File {{.*}}, line {{.*}}, in {{.*}}
 # CHECK:     update_output = test_updater(result, test)
-# CHECK:   File "{{.*}}/should_not_run.py", line {{.*}}, in should_not_run
+# CHECK:   File "{{.*}}{{/|\\}}should_not_run.py", line {{.*}}, in should_not_run
 # CHECK:     raise Exception("this test updater should only run on failure")
 # CHECK: Exception: this test updater should only run on failure
 # CHECK: ********************


### PR DESCRIPTION
Should fix Windows build bot failures such as https://lab.llvm.org/buildbot/#/builders/46/builds/22281.

The test (and the followup fix in #155303) did not properly account for Windows style path separators.