### PR TITLE
[libc++][C++03][NFC] Remove XFAILS from libcxx/test/libcxx

### DIFF
--- a/libcxx/test/libcxx/containers/sequences/deque/segmented_iterator.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/sequences/deque/segmented_iterator.compile.pass.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <deque>
 
 using DequeIterator = typename std::deque<int>::iterator;

--- a/libcxx/test/libcxx/localization/locale.categories/__scan_keyword.pass.cpp
+++ b/libcxx/test/libcxx/localization/locale.categories/__scan_keyword.pass.cpp
@@ -35,8 +35,6 @@
 //                const _Ctype& __ct, ios_base::iostate& __err,
 //                bool __case_sensitive = true);
 
-// XFAIL: FROZEN-CXX03-HEADERS-FIXME
-
 #include <__locale_dir/scan_keyword.h>
 #include <cassert>
 #include <locale>


### PR DESCRIPTION
We've split the implementation-specific tests into `libcxx/test/libcxx-03`, so we don't need the annotations in `libcxx/test/libcxx` anymore.
