### PR TITLE
[libc++][C++03] Fix test/libcxx-03/system_reserved_names.gen.py

### DIFF
--- a/libcxx/test/libcxx-03/system_reserved_names.gen.py
+++ b/libcxx/test/libcxx-03/system_reserved_names.gen.py
@@ -29,10 +29,8 @@ for header in public_headers:
 {lit_header_restrictions.get(header, '')}
 {lit_header_undeprecations.get(header, '')}
 
-// UNSUPPORTED: FROZEN-CXX03-HEADERS-FIXME
-
 // This is required to detect the platform we're building for below.
-#include <__config>
+#include <__cxx03/__config>
 
 #define SYSTEM_RESERVED_NAME This name should not be used in libc++
 


### PR DESCRIPTION
This test only fails because it includes `<__config>`. Switch to using
`<__cxx03/__config>` instead to fix the issue.
