### PR TITLE
[clang][bytecode][NFC] Use Pointer::initializeAllElements() in Program

### DIFF
--- a/clang/lib/AST/ByteCode/Program.cpp
+++ b/clang/lib/AST/ByteCode/Program.cpp
@@ -101,7 +101,7 @@ unsigned Program::createGlobalString(const StringLiteral *S, const Expr *Base) {
       }
     }
   }
-  Ptr.initialize();
+  Ptr.initializeAllElements();
 
   return GlobalIndex;
 }


### PR DESCRIPTION
We just initialized the entire string, so use this function instead.