### PR TITLE
[LV][NFC] Rename getNumUsers to getNumUses

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4207,7 +4207,7 @@ VectorizationFactor LoopVectorizationPlanner::selectVectorizationFactor() {
           // divisors.
           case Instruction::Select: {
             VPValue *VPV = VPI->getVPSingleValue();
-            if (VPV->getNumUsers() == 1) {
+            if (VPV->getNumUses() == 1) {
               if (auto *WR = dyn_cast<VPWidenRecipe>(*VPV->user_begin())) {
                 switch (WR->getOpcode()) {
                 case Instruction::UDiv:

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1056,25 +1056,25 @@ const VPRegionBlock *VPlan::getVectorLoopRegion() const {
 void VPlan::printLiveIns(raw_ostream &O) const {
   VPSlotTracker SlotTracker(this);
 
-  if (VF.getNumUsers() > 0) {
+  if (VF.getNumUses() > 0) {
     O << "\nLive-in ";
     VF.printAsOperand(O, SlotTracker);
     O << " = VF";
   }
 
-  if (VFxUF.getNumUsers() > 0) {
+  if (VFxUF.getNumUses() > 0) {
     O << "\nLive-in ";
     VFxUF.printAsOperand(O, SlotTracker);
     O << " = VF * UF";
   }
 
-  if (VectorTripCount.getNumUsers() > 0) {
+  if (VectorTripCount.getNumUses() > 0) {
     O << "\nLive-in ";
     VectorTripCount.printAsOperand(O, SlotTracker);
     O << " = vector-trip-count";
   }
 
-  if (BackedgeTakenCount && BackedgeTakenCount->getNumUsers()) {
+  if (BackedgeTakenCount && BackedgeTakenCount->getNumUses()) {
     O << "\nLive-in ";
     BackedgeTakenCount->printAsOperand(O, SlotTracker);
     O << " = backedge-taken count";
@@ -1416,7 +1416,7 @@ void VPValue::replaceUsesWithIf(
   if (this == New)
     return;
 
-  for (unsigned J = 0; J < getNumUsers();) {
+  for (unsigned J = 0; J < getNumUses();) {
     VPUser *User = Users[J];
     bool RemovedUser = false;
     for (unsigned I = 0, E = User->getNumOperands(); I < E; ++I) {
@@ -1492,9 +1492,9 @@ void VPSlotTracker::assignName(const VPValue *V) {
 }
 
 void VPSlotTracker::assignNames(const VPlan &Plan) {
-  if (Plan.VF.getNumUsers() > 0)
+  if (Plan.VF.getNumUses() > 0)
     assignName(&Plan.VF);
-  if (Plan.VFxUF.getNumUsers() > 0)
+  if (Plan.VFxUF.getNumUses() > 0)
     assignName(&Plan.VFxUF);
   assignName(&Plan.VectorTripCount);
   if (Plan.BackedgeTakenCount)

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -4204,7 +4204,7 @@ public:
   /// Resets the trip count for the VPlan. The caller must make sure all uses of
   /// the original trip count have been replaced.
   void resetTripCount(VPValue *NewTripCount) {
-    assert(TripCount && NewTripCount && TripCount->getNumUsers() == 0 &&
+    assert(TripCount && NewTripCount && TripCount->getNumUses() == 0 &&
            "TripCount must be set when resetting");
     TripCount = NewTripCount;
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -885,7 +885,7 @@ bool VPlanTransforms::handleMaxMinNumReductions(VPlan &Plan) {
     if (VecV == RdxResult)
       continue;
     if (auto *DerivedIV = dyn_cast<VPDerivedIVRecipe>(VecV)) {
-      if (DerivedIV->getNumUsers() == 1 &&
+      if (DerivedIV->getNumUses() == 1 &&
           DerivedIV->getOperand(1) == &Plan.getVectorTripCount()) {
         auto *NewSel = Builder.createSelect(AnyNaN, Plan.getCanonicalIV(),
                                             &Plan.getVectorTripCount());

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2249,7 +2249,7 @@ InstructionCost VPWidenCastRecipe::computeCost(ElementCount VF,
   TTI::CastContextHint CCH = TTI::CastContextHint::None;
   // For Trunc/FPTrunc, get the context from the only user.
   if ((Opcode == Instruction::Trunc || Opcode == Instruction::FPTrunc) &&
-      !hasMoreThanOneUniqueUser() && getNumUsers() > 0) {
+      !hasMoreThanOneUniqueUser() && getNumUses() > 0) {
     if (auto *StoreRecipe = dyn_cast<VPRecipeBase>(*user_begin()))
       CCH = ComputeCCH(StoreRecipe);
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
@@ -535,7 +535,7 @@ void VPlanTransforms::replicateByVF(VPlan &Plan, ElementCount VF) {
         continue;
 
       VPBuilder Builder(RepR);
-      if (RepR->getNumUsers() == 0) {
+      if (RepR->getNumUses() == 0) {
         if (isa<StoreInst>(RepR->getUnderlyingInstr()) &&
             vputils::isSingleScalar(RepR->getOperand(1))) {
           // Stores to invariant addresses need to store the last lane only.

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -198,8 +198,8 @@ bool VPlanVerifier::verifyEVLRecipe(const VPInstruction &EVL) const {
           }
           // EVLIVIncrement is only used by EVLIV & BranchOnCount.
           // Having more than two users is unexpected.
-          if ((I->getNumUsers() != 1) &&
-              (I->getNumUsers() != 2 || none_of(I->users(), [&I](VPUser *U) {
+          if ((I->getNumUses() != 1) &&
+              (I->getNumUses() != 2 || none_of(I->users(), [&I](VPUser *U) {
                  using namespace llvm::VPlanPatternMatch;
                  return match(U, m_BranchOnCount(m_Specific(I), m_VPValue()));
                }))) {

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -137,38 +137,38 @@ TEST_F(VPInstructionTest, setOperand) {
   VPValue *VPV1 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 1));
   VPValue *VPV2 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 2));
   VPInstruction *I1 = new VPInstruction(0, {VPV1, VPV2});
-  EXPECT_EQ(1u, VPV1->getNumUsers());
+  EXPECT_EQ(1u, VPV1->getNumUses());
   EXPECT_EQ(I1, *VPV1->user_begin());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_EQ(1u, VPV2->getNumUses());
   EXPECT_EQ(I1, *VPV2->user_begin());
 
   // Replace operand 0 (VPV1) with VPV3.
   VPValue *VPV3 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 3));
   I1->setOperand(0, VPV3);
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_EQ(0u, VPV1->getNumUses());
+  EXPECT_EQ(1u, VPV2->getNumUses());
   EXPECT_EQ(I1, *VPV2->user_begin());
-  EXPECT_EQ(1u, VPV3->getNumUsers());
+  EXPECT_EQ(1u, VPV3->getNumUses());
   EXPECT_EQ(I1, *VPV3->user_begin());
 
   // Replace operand 1 (VPV2) with VPV3.
   I1->setOperand(1, VPV3);
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
-  EXPECT_EQ(2u, VPV3->getNumUsers());
+  EXPECT_EQ(0u, VPV1->getNumUses());
+  EXPECT_EQ(0u, VPV2->getNumUses());
+  EXPECT_EQ(2u, VPV3->getNumUses());
   EXPECT_EQ(I1, *VPV3->user_begin());
   EXPECT_EQ(I1, *std::next(VPV3->user_begin()));
 
   // Replace operand 0 (VPV3) with VPV4.
   VPValue *VPV4 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 4));
   I1->setOperand(0, VPV4);
-  EXPECT_EQ(1u, VPV3->getNumUsers());
+  EXPECT_EQ(1u, VPV3->getNumUses());
   EXPECT_EQ(I1, *VPV3->user_begin());
   EXPECT_EQ(I1, *VPV4->user_begin());
 
   // Replace operand 1 (VPV3) with VPV4.
   I1->setOperand(1, VPV4);
-  EXPECT_EQ(0u, VPV3->getNumUsers());
+  EXPECT_EQ(0u, VPV3->getNumUses());
   EXPECT_EQ(I1, *VPV4->user_begin());
   EXPECT_EQ(I1, *std::next(VPV4->user_begin()));
 
@@ -186,34 +186,34 @@ TEST_F(VPInstructionTest, replaceAllUsesWith) {
   VPV1->replaceAllUsesWith(VPV3);
   EXPECT_EQ(VPV3, I1->getOperand(0));
   EXPECT_EQ(VPV2, I1->getOperand(1));
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_EQ(0u, VPV1->getNumUses());
+  EXPECT_EQ(1u, VPV2->getNumUses());
   EXPECT_EQ(I1, *VPV2->user_begin());
-  EXPECT_EQ(1u, VPV3->getNumUsers());
+  EXPECT_EQ(1u, VPV3->getNumUses());
   EXPECT_EQ(I1, *VPV3->user_begin());
 
   // Replace all uses of VPV2 with VPV3.
   VPV2->replaceAllUsesWith(VPV3);
   EXPECT_EQ(VPV3, I1->getOperand(0));
   EXPECT_EQ(VPV3, I1->getOperand(1));
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
-  EXPECT_EQ(2u, VPV3->getNumUsers());
+  EXPECT_EQ(0u, VPV1->getNumUses());
+  EXPECT_EQ(0u, VPV2->getNumUses());
+  EXPECT_EQ(2u, VPV3->getNumUses());
   EXPECT_EQ(I1, *VPV3->user_begin());
 
   // Replace all uses of VPV3 with VPV1.
   VPV3->replaceAllUsesWith(VPV1);
   EXPECT_EQ(VPV1, I1->getOperand(0));
   EXPECT_EQ(VPV1, I1->getOperand(1));
-  EXPECT_EQ(2u, VPV1->getNumUsers());
+  EXPECT_EQ(2u, VPV1->getNumUses());
   EXPECT_EQ(I1, *VPV1->user_begin());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
-  EXPECT_EQ(0u, VPV3->getNumUsers());
+  EXPECT_EQ(0u, VPV2->getNumUses());
+  EXPECT_EQ(0u, VPV3->getNumUses());
 
   VPInstruction *I2 = new VPInstruction(0, {VPV1, VPV2});
-  EXPECT_EQ(3u, VPV1->getNumUsers());
+  EXPECT_EQ(3u, VPV1->getNumUses());
   VPV1->replaceAllUsesWith(VPV3);
-  EXPECT_EQ(3u, VPV3->getNumUsers());
+  EXPECT_EQ(3u, VPV3->getNumUses());
 
   delete I1;
   delete I2;
@@ -225,15 +225,15 @@ TEST_F(VPInstructionTest, releaseOperandsAtDeletion) {
   VPValue *VPV2 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 1));
   VPInstruction *I1 = new VPInstruction(0, {VPV1, VPV2});
 
-  EXPECT_EQ(1u, VPV1->getNumUsers());
+  EXPECT_EQ(1u, VPV1->getNumUses());
   EXPECT_EQ(I1, *VPV1->user_begin());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_EQ(1u, VPV2->getNumUses());
   EXPECT_EQ(I1, *VPV2->user_begin());
 
   delete I1;
 
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
+  EXPECT_EQ(0u, VPV1->getNumUses());
+  EXPECT_EQ(0u, VPV2->getNumUses());
 }
 
 using VPBasicBlockTest = VPlanTestBase;


### PR DESCRIPTION
The Users list in VPValue is really just a Use list because the same User can appear several times in the list, reflecting the fact the VPValue can be used for more than one operand of a recipe. In such a scenario there is really just one *user* with multiple *uses* of a given VPValue. See the documentation for the IR routine Value::hasOneUser():

```
  /// Return true if there is exactly one user of this value.
  ///
  /// Note that this is not the same as "has one use". If a value has one use,
  /// then there certainly is a single user. But if value has several uses,
  /// it is possible that all uses are in a single user, or not.
  ///
  /// This check is potentially costly, since it requires traversing,
  /// in the worst case, the whole use list of a value.
  LLVM_ABI bool hasOneUser() const;
```

I've renamed this function, along with addUser and removeUser to mirror the normal IR terminology.