### PR TITLE
[TSan] Fix spurious 'thread finished with ignores enabled' warning on FreeBSD

### DIFF
--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -2890,7 +2890,9 @@ TSAN_INTERCEPTOR(void, _lwp_exit) {
 
 #if SANITIZER_FREEBSD
 TSAN_INTERCEPTOR(void, thr_exit, ThreadID *state) {
-  SCOPED_TSAN_INTERCEPTOR(thr_exit, state);
+  {
+    SCOPED_TSAN_INTERCEPTOR(thr_exit, state);
+  }
   DestroyThreadState();
   REAL(thr_exit(state));
 }


### PR DESCRIPTION
This fixes a false positive error report on FreeBSD under certain circumstances. The error occurs in the thr_exit interceptor as follows:
* `SCOPED_TSAN_INTERCEPTOR` macro calls the `ScopedInterceptor` constructor -> `EnableIgnores` -> `EnableIgnoresImpl`, which increments `thr_->suppress_reports`.
* `DestroyThreadState` -> `ThreadFinish` -> `ReportIgnoresEnabled` then fires off a warning, as `thr_->suppress_reports` is non-zero.

To avoid this spurious error, we follow the example of the `pthread_exit` interceptor, and take an anonymous scope so that the `ScopedInterceptor` destructor gets called before `DestroyThreadState`, decrementing `suppress_reports` back to 0.