### PR TITLE
[clang][bytecode] Cleanup primitive descriptor ctor/dtor handling

### DIFF
--- a/clang/lib/AST/ByteCode/PrimType.h
+++ b/clang/lib/AST/ByteCode/PrimType.h
@@ -272,14 +272,4 @@ static inline bool aligned(const void *P) {
     }                                                                          \
   } while (0)
 
-#define COMPOSITE_TYPE_SWITCH(Expr, B, D)                                      \
-  do {                                                                         \
-    switch (Expr) {                                                            \
-      TYPE_SWITCH_CASE(PT_Ptr, B)                                              \
-    default: {                                                                 \
-      D;                                                                       \
-      break;                                                                   \
-    }                                                                          \
-    }                                                                          \
-  } while (0)
 #endif


### PR DESCRIPTION
Use switches instead of if statements and COMPOSITE_TYPE_SWITCH and remove some leftover move functions.