### PR TITLE
[X86] canCreateUndefOrPoisonForTargetNode - add GF2P8AFFINEINVQB / GF2P8AFFINEQB / GF2P8MULB handling

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45167,6 +45167,11 @@ bool X86TargetLowering::canCreateUndefOrPoisonForTargetNode(
   // SSE signbit extraction.
   case X86ISD::MOVMSK:
     return false;
+  // GFNI instructions.
+  case X86ISD::GF2P8AFFINEINVQB:
+  case X86ISD::GF2P8AFFINEQB:
+  case X86ISD::GF2P8MULB:
+    return false;
   case ISD::INTRINSIC_WO_CHAIN:
     switch (Op->getConstantOperandVal(0)) {
     case Intrinsic::x86_sse2_pmadd_wd:

--- a/llvm/test/CodeGen/X86/combine-gfni.ll
+++ b/llvm/test/CodeGen/X86/combine-gfni.ll
@@ -24,8 +24,7 @@ define <16 x i8> @gf2p8affineqb_freeze(<16 x i8> %a0, <16 x i8> %a1, <16 x i8> %
 ; AVX512-LABEL: gf2p8affineqb_freeze:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpmovb2m %xmm2, %k1
-; AVX512-NEXT:    vgf2p8affineqb $11, %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vmovdqu8 %xmm1, %xmm0 {%k1}
+; AVX512-NEXT:    vgf2p8affineqb $11, %xmm1, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %i = icmp slt <16 x i8> %a2, zeroinitializer
   %g = call <16 x i8> @llvm.x86.vgf2p8affineqb.128(<16 x i8> %a1, <16 x i8> %a1, i8 11)
@@ -55,8 +54,7 @@ define <16 x i8> @gf2p8affineinvqb_freeze(<16 x i8> %a0, <16 x i8> %a1, <16 x i8
 ; AVX512-LABEL: gf2p8affineinvqb_freeze:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpmovb2m %xmm2, %k1
-; AVX512-NEXT:    vgf2p8affineinvqb $11, %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vmovdqu8 %xmm1, %xmm0 {%k1}
+; AVX512-NEXT:    vgf2p8affineinvqb $11, %xmm1, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %i = icmp slt <16 x i8> %a2, zeroinitializer
   %g = call <16 x i8> @llvm.x86.vgf2p8affineinvqb.128(<16 x i8> %a1, <16 x i8> %a1, i8 11)
@@ -86,8 +84,7 @@ define <16 x i8> @gf2p8mulb_freeze(<16 x i8> %a0, <16 x i8> %a1, <16 x i8> %a2) 
 ; AVX512-LABEL: gf2p8mulb_freeze:
 ; AVX512:       # %bb.0:
 ; AVX512-NEXT:    vpmovb2m %xmm2, %k1
-; AVX512-NEXT:    vgf2p8mulb %xmm1, %xmm1, %xmm1
-; AVX512-NEXT:    vmovdqu8 %xmm1, %xmm0 {%k1}
+; AVX512-NEXT:    vgf2p8mulb %xmm1, %xmm1, %xmm0 {%k1}
 ; AVX512-NEXT:    retq
   %i = icmp slt <16 x i8> %a2, zeroinitializer
   %g = call <16 x i8> @llvm.x86.vgf2p8mulb.128(<16 x i8> %a1, <16 x i8> %a1)


### PR DESCRIPTION
All 3 instructions are well defined bit twiddling operations - they do not introduce undef/poison with well defined inputs.

Fixes regressions in #152107