### PR TITLE
[Flang] Fix BUILD_SHARED_LIBS build

### DIFF
--- a/flang/lib/Optimizer/Builder/CMakeLists.txt
+++ b/flang/lib/Optimizer/Builder/CMakeLists.txt
@@ -50,6 +50,7 @@ add_flang_library(FIRBuilder
   FIRDialectSupport
   FIRSupport
   FortranEvaluate
+  FortranSupport
   HLFIRDialect
 
   MLIR_DEPS

--- a/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
+++ b/flang/lib/Optimizer/HLFIR/Transforms/CMakeLists.txt
@@ -27,6 +27,8 @@ add_flang_library(HLFIRTransforms
   FIRSupport
   FIRTransforms
   FlangOpenMPTransforms
+  FortranEvaluate
+  FortranSupport
   HLFIRDialect
 
   LINK_COMPONENTS


### PR DESCRIPTION
In contrast to linking a static library, when linking a shared library all referenced symbols must be available in either the objects files, static libraries, or shared libraries passed to the linker command line and cannot be deferred to when building the executable.

We have buildbots that build with BUILD_SHARED_LIBS=ON such that new link symbol dependencies (e.g. by a new call of a non-inlined function from a header of another component) are detected post-commit, but we don't seem to have any for Flang, which means such build breakages may go unnoticed.

Fixes #150027

Same fix as included in #152223, but with only the changes necessary to fix #150027 (which is unrelated with GCC 15)