### PR TITLE
[openmp][NFC] Fix a warning when built with clang

### DIFF
--- a/openmp/tools/omptest/src/OmptAssertEvent.cpp
+++ b/openmp/tools/omptest/src/OmptAssertEvent.cpp
@@ -24,9 +24,6 @@ const char *omptest::to_string(ObserveState State) {
     return "Always";
   case ObserveState::Never:
     return "Never";
-  default:
-    assert(false && "Requested string representation for unknown ObserveState");
-    return "UNKNOWN";
   }
 }
 


### PR DESCRIPTION
```
/root/llvm-project/openmp/tools/omptest/src/OmptAssertEvent.cpp:27:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
   27 |   default:
      |   ^
1 warning generated.
```