### PR TITLE
[Flang-RT][OpenMP] Define _GLIBCXX_NO_ASSERTIONS

### DIFF
--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -281,6 +281,7 @@ function (add_flangrt_library name)
 
     # Disable libstdc++/libc++ assertions, even in an LLVM_ENABLE_ASSERTIONS
     # build, to avoid an unwanted dependency on libstdc++/libc++.so.
+    target_compile_definitions(${tgtname} PUBLIC _GLIBCXX_NO_ASSERTIONS)
     if (FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
       target_compile_options(${tgtname} PUBLIC -U_GLIBCXX_ASSERTIONS)
       target_compile_options(${tgtname} PUBLIC -U_LIBCPP_ENABLE_ASSERTIONS)

--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -167,6 +167,7 @@ endif()
 
 # Disable libstdc++ assertions, even in an LLVM_ENABLE_ASSERTIONS build, to
 # avoid an unwanted dependency on libstdc++.so.
+add_compile_definitions(_GLIBCXX_NO_ASSERTIONS)
 if(NOT WIN32)
   add_definitions(-U_GLIBCXX_ASSERTIONS)
 endif()


### PR DESCRIPTION
Since GCC 15.1, libstdc++ enabled assertions/hardening by default in non-optimized (-O0) builds [1]. That is, _GLIBCXX_ASSERTIONS is defined in the libstdc++ headers itself so defining/undefining it on the compiler command line no longer has an effect in non-optimized builds. As the commit message[2] suggests, define _GLIBCXX_NO_ASSERTIONS instead.

For libstdc++ headers before 15.1, -U_GLIBCXX_ASSERTIONS still has to be on the command line as well.

Defining _GLIBCXX_NO_ASSERTIONS was previously proposed in #152223

[1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112808
[2] https://github.com/gcc-mirror/gcc/commit/361d230fd7800a7e749aba8ed020f54f5c26d504