### PR TITLE
[NFC][DirectX] Fix build failure

### DIFF
--- a/llvm/lib/Target/DirectX/CMakeLists.txt
+++ b/llvm/lib/Target/DirectX/CMakeLists.txt
@@ -41,6 +41,7 @@ add_llvm_target(DirectXCodeGen
   LINK_COMPONENTS
   Analysis
   AsmPrinter
+  BinaryFormat
   CodeGen
   CodeGenTypes
   Core


### PR DESCRIPTION
Add `BinaryFormat` to `LINK_COMPONENTS` to fix the following linker error:

```
ld.lld: error: undefined symbol: llvm::dxbc::getRootParameterTypes()
>>> referenced by DXILRootSignature.cpp
>>>               lib/Target/DirectX/CMakeFiles/LLVMDirectXCodeGen.dir/DXILRootSignature.cpp.o:(llvm::dxil::RootSignatureAnalysisPrinter::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&))

ld.lld: error: undefined symbol: llvm::dxbc::getShaderVisibility()
>>> referenced by DXILRootSignature.cpp
>>>               lib/Target/DirectX/CMakeFiles/LLVMDirectXCodeGen.dir/DXILRootSignature.cpp.o:(llvm::dxil::RootSignatureAnalysisPrinter::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&))
>>> referenced by DXILRootSignature.cpp
>>>               lib/Target/DirectX/CMakeFiles/LLVMDirectXCodeGen.dir/DXILRootSignature.cpp.o:(llvm::dxil::RootSignatureAnalysisPrinter::run(llvm::Module&, llvm::AnalysisManager<llvm::Module>&))
```

Root cause: https://github.com/llvm/llvm-project/pull/154249 changed a header-only dependency to a real dependency without noticing that the dependency was missing in CMakeLists.txt