### PR TITLE
[CodeGen] Optimize/simplify finalizeBundle. NFC

### DIFF
--- a/llvm/lib/CodeGen/MachineInstrBundle.cpp
+++ b/llvm/lib/CodeGen/MachineInstrBundle.cpp
@@ -173,6 +173,9 @@ void llvm::finalizeBundle(MachineBasicBlock &MBB,
       if (LocalDefs.insert(Reg)) {
         if (MO.isDead())
           DeadDefSet.insert(Reg);
+        else if (Reg.isPhysical())
+          for (MCRegUnit Unit : TRI->regunits(Reg.asMCReg()))
+            LocalDefsP.set(Unit);
       } else {
         // Re-defined inside the bundle, it's no longer killed.
         KilledDefSet.erase(Reg);
@@ -180,11 +183,6 @@ void llvm::finalizeBundle(MachineBasicBlock &MBB,
           // Previously defined but dead.
           DeadDefSet.erase(Reg);
         }
-      }
-
-      if (!MO.isDead() && Reg.isPhysical()) {
-        for (MCRegUnit Unit : TRI->regunits(Reg.asMCReg()))
-          LocalDefsP.set(Unit);
       }
     }
 


### PR DESCRIPTION
When tracking defs in finalizeBundle two sets are used. LocalDefs is used to track defined virtual and physical registers, while LocalDefsP is used to track defined register units for the physical registers.

This patch moves the updates of LocalDefsP to only iterate over regunits when a new physical register is added to LocalDefs. When the physical register already is present in LocalDefs, then the corresponding register units are present in LocalDefsP. So it was a waste of time to add them to the set again.