### PR TITLE
[clang][modules-driver] Move logic to enable -fmodules-driver (NFC)

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -512,9 +512,6 @@ public:
 
   /// BuildActions - Construct the list of actions to perform for the
   /// given arguments, which are only done for a single architecture.
-  /// If the compilation is an explicit module build, delegates to
-  /// BuildDriverManagedModuleBuildActions. Otherwise, BuildDefaultActions is
-  /// used.
   ///
   /// \param C - The compilation that is being built.
   /// \param Args - The input arguments.
@@ -799,27 +796,6 @@ private:
   /// compilation based on which -f(no-)?lto(=.*)? option occurs last.
   void setLTOMode(const llvm::opt::ArgList &Args);
 
-  /// BuildDefaultActions - Constructs the list of actions to perform
-  /// for the provided arguments, which are only done for a single architecture.
-  ///
-  /// \param C - The compilation that is being built.
-  /// \param Args - The input arguments.
-  /// \param Actions - The list to store the resulting actions onto.
-  void BuildDefaultActions(Compilation &C, llvm::opt::DerivedArgList &Args,
-                           const InputList &Inputs, ActionList &Actions) const;
-
-  /// BuildDriverManagedModuleBuildActions - Performs a dependency
-  /// scan and constructs the list of actions to perform for dependency order
-  /// and the provided arguments. This is only done for a single a architecture.
-  ///
-  /// \param C - The compilation that is being built.
-  /// \param Args - The input arguments.
-  /// \param Actions - The list to store the resulting actions onto.
-  void BuildDriverManagedModuleBuildActions(Compilation &C,
-                                            llvm::opt::DerivedArgList &Args,
-                                            const InputList &Inputs,
-                                            ActionList &Actions) const;
-
   /// Scans the leading lines of the C++ source inputs to detect C++20 module
   /// usage.
   ///
@@ -827,7 +803,6 @@ private:
   /// read failure.
   llvm::ErrorOr<bool>
   ScanInputsForCXX20ModulesUsage(const InputList &Inputs) const;
-
   /// Retrieves a ToolChain for a particular \p Target triple.
   ///
   /// Will cache ToolChains for the life of the driver object, and create them

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1856,13 +1856,6 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   // Populate the tool chains for the offloading devices, if any.
   CreateOffloadingDeviceToolChains(*C, Inputs);
 
-  // Construct the list of abstract actions to perform for this compilation. On
-  // MachO targets this uses the driver-driver and universal actions.
-  if (TC.getTriple().isOSBinFormatMachO())
-    BuildUniversalActions(*C, C->getDefaultToolChain(), Inputs);
-  else
-    BuildActions(*C, C->getArgs(), Inputs, C->getActions());
-
   if (C->getArgs().hasFlag(options::OPT_fmodules_driver,
                            options::OPT_fno_modules_driver, false)) {
     // TODO: When -fmodules-driver is no longer experimental, it should be
@@ -1882,6 +1875,13 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
     }
     Diags.Report(diag::remark_performing_driver_managed_module_build);
   }
+
+  // Construct the list of abstract actions to perform for this compilation. On
+  // MachO targets this uses the driver-driver and universal actions.
+  if (TC.getTriple().isOSBinFormatMachO())
+    BuildUniversalActions(*C, C->getDefaultToolChain(), Inputs);
+  else
+    BuildActions(*C, C->getArgs(), Inputs, C->getActions());
 
   if (CCCPrintPhases) {
     PrintActions(*C);


### PR DESCRIPTION
This patch is part of a series to support driver-managed module builds for C++ named modules and Clang modules.

Commit 9403c2d introduced the entry point for the driver-managed module build logic and assumed that it would live in the BuildActions phase of the driver.
That proved unnecessary: the logic can be fully implemented in the BuildJobs phase.

This reverts changes to BuildActions in preparation for the upcoming patches.