### PR TITLE
[llvm-lto2] Added llvm-lto2 -unified-lto descriptions (revised)

### DIFF
--- a/llvm/test/LTO/Resolution/X86/unified-lto-check.ll
+++ b/llvm/test/LTO/Resolution/X86/unified-lto-check.ll
@@ -38,6 +38,16 @@
 ; RUN: llvm-lto2 run --debug-only=lto -o %t3 %t1 %t2 2>&1 | \
 ; RUN: FileCheck --allow-empty %s --check-prefix THIN
 
+; Test invalid unified-lto mode causes an error message return.
+; RUN: not llvm-lto2 run --unified-lto=foo -o %t3 %t1 %t2 2>&1 | \
+; RUN: FileCheck %s --check-prefix INVALIDMODE
+; RUN: not llvm-lto2 run --unified-lto="foo" -o %t3 %t1 %t2 2>&1 | \
+; RUN: FileCheck %s --check-prefix INVALIDMODE
+; RUN: not llvm-lto2 run --unified-lto=1 -o %t3 %t1 %t2 2>&1 | \
+; RUN: FileCheck %s --check-prefix INVALIDMODE
+
+; INVALIDMODE: invalid LTO mode
+
 ; UNIFIEDERR: unified LTO compilation must use compatible bitcode modules
 ; NOUNIFIEDERR-NOT: unified LTO compilation must use compatible bitcode modules
 
@@ -54,3 +64,4 @@
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-unknown-linux-gnu"
+

--- a/llvm/test/LTO/Resolution/X86/unified-lto-check.ll
+++ b/llvm/test/LTO/Resolution/X86/unified-lto-check.ll
@@ -46,7 +46,7 @@
 ; RUN: not llvm-lto2 run --unified-lto=1 -o %t3 %t1 %t2 2>&1 | \
 ; RUN: FileCheck %s --check-prefix INVALIDMODE
 
-; INVALIDMODE: llvm-lto2: for the --unified-lto option: Cannot find option named
+; INVALIDMODE: for the --unified-lto option: Cannot find option named
 
 
 ; UNIFIEDERR: unified LTO compilation must use compatible bitcode modules

--- a/llvm/test/LTO/Resolution/X86/unified-lto-check.ll
+++ b/llvm/test/LTO/Resolution/X86/unified-lto-check.ll
@@ -46,7 +46,8 @@
 ; RUN: not llvm-lto2 run --unified-lto=1 -o %t3 %t1 %t2 2>&1 | \
 ; RUN: FileCheck %s --check-prefix INVALIDMODE
 
-; INVALIDMODE: invalid LTO mode
+; INVALIDMODE: llvm-lto2: for the --unified-lto option: Cannot find option named
+
 
 ; UNIFIEDERR: unified LTO compilation must use compatible bitcode modules
 ; NOUNIFIEDERR-NOT: unified LTO compilation must use compatible bitcode modules

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -198,13 +198,18 @@ static cl::list<std::string>
     PassPlugins("load-pass-plugin",
                 cl::desc("Load passes from plugin library"));
 
-static cl::opt<std::string> UnifiedLTOMode(
+static cl::opt<LTO::LTOKind> UnifiedLTOMode(
     "unified-lto", cl::Optional,
-    cl::desc("Set LTO mode with the following options:\n"
-             " thin      ThinLTO, with Unified LTO enabled.\n"
-             " full      Regular LTO, with Unified LTO enabled.\n"
-             " default   Any LTO mode without Unified LTO. The default mode."),
-    cl::value_desc("mode"));
+    cl::desc("Set LTO mode with the following options:"),
+    cl::values(
+        clEnumValN(LTO::LTOK_UnifiedThin, "thin",
+                   "ThinLTO with Unified LTO enabled"),
+        clEnumValN(LTO::LTOK_UnifiedRegular, "full",
+                   "Regular LTO with Unified LTO enabled"),
+        clEnumValN(LTO::LTOK_Default, "default",
+                   "Any LTO mode without Unified LTO. The default mode")
+    ),
+    cl::value_desc("mode"), cl::init(LTO::LTOK_Default)); 
 
 static cl::opt<bool> EnableFreestanding(
     "lto-freestanding",
@@ -408,18 +413,7 @@ static int run(int argc, char **argv) {
       HasErrors = true;
   };
 
-  LTO::LTOKind LTOMode = LTO::LTOK_Default;
-
-  if (UnifiedLTOMode == "full") {
-    LTOMode = LTO::LTOK_UnifiedRegular;
-  } else if (UnifiedLTOMode == "thin") {
-    LTOMode = LTO::LTOK_UnifiedThin;
-  } else if (UnifiedLTOMode == "default") {
-    LTOMode = LTO::LTOK_Default;
-  } else if (!UnifiedLTOMode.empty()) {
-    llvm::errs() << "invalid LTO mode\n";
-    return 1;
-  }
+  LTO::LTOKind LTOMode = UnifiedLTOMode;
 
   LTO Lto(std::move(Conf), std::move(Backend), 1, LTOMode);
 

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -201,15 +201,13 @@ static cl::list<std::string>
 static cl::opt<LTO::LTOKind> UnifiedLTOMode(
     "unified-lto", cl::Optional,
     cl::desc("Set LTO mode with the following options:"),
-    cl::values(
-        clEnumValN(LTO::LTOK_UnifiedThin, "thin",
-                   "ThinLTO with Unified LTO enabled"),
-        clEnumValN(LTO::LTOK_UnifiedRegular, "full",
-                   "Regular LTO with Unified LTO enabled"),
-        clEnumValN(LTO::LTOK_Default, "default",
-                   "Any LTO mode without Unified LTO. The default mode")
-    ),
-    cl::value_desc("mode"), cl::init(LTO::LTOK_Default)); 
+    cl::values(clEnumValN(LTO::LTOK_UnifiedThin, "thin",
+                          "ThinLTO with Unified LTO enabled"),
+               clEnumValN(LTO::LTOK_UnifiedRegular, "full",
+                          "Regular LTO with Unified LTO enabled"),
+               clEnumValN(LTO::LTOK_Default, "default",
+                          "Any LTO mode without Unified LTO")),
+    cl::value_desc("mode"), cl::init(LTO::LTOK_Default));
 
 static cl::opt<bool> EnableFreestanding(
     "lto-freestanding",
@@ -576,7 +574,8 @@ static int dumpSymtab(int argc, char **argv) {
       }
 
       if (TT.isOSBinFormatCOFF() && Sym.isWeak() && Sym.isIndirect())
-        outs() << "         fallback " << Sym.getCOFFWeakExternalFallback() << '\n';
+        outs() << "         fallback " << Sym.getCOFFWeakExternalFallback()
+               << '\n';
 
       if (!Sym.getSectionName().empty())
         outs() << "         section " << Sym.getSectionName() << "\n";

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -198,9 +198,13 @@ static cl::list<std::string>
     PassPlugins("load-pass-plugin",
                 cl::desc("Load passes from plugin library"));
 
-static cl::opt<std::string> UnifiedLTOMode("unified-lto", cl::Optional,
-                                           cl::desc("Set LTO mode"),
-                                           cl::value_desc("mode"));
+static cl::opt<std::string> UnifiedLTOMode(
+    "unified-lto", cl::Optional,
+    cl::desc("Set LTO mode with the following options:\n"
+             " thin      ThinLTO, with Unified LTO enabled.\n"
+             " full      Regular LTO, with Unified LTO enabled.\n"
+             " default   Any LTO mode without Unified LTO. The default mode."),
+    cl::value_desc("mode"));
 
 static cl::opt<bool> EnableFreestanding(
     "lto-freestanding",


### PR DESCRIPTION
This is a revised PR of #148309 (closed due to some git issues). The changes do the following:

- Adds description for the modes of `-unified-lto=mode` option
- Changes parsing of `unified-lto` descriptions from string to cEnumValN for continuity of description formatting
- Adds testing of error output in `unified-lto-check.ll`

