### PR TITLE
[RISCV] Account for ADDI immediate range in select of two constants w/ zicond

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -9283,7 +9283,7 @@ SDValue RISCVTargetLowering::lowerSELECT(SDValue Op, SelectionDAG &DAG) const {
       auto getCost = [&](const APInt &Delta, const APInt &Addend) {
         const int DeltaCost = RISCVMatInt::getIntMatCost(
             Delta, Subtarget.getXLen(), Subtarget, /*CompressionCost=*/true);
-        // Does the addend folds into an ADDI
+        // Does the addend fold into an ADDI
         if (Addend.isSignedIntN(12))
           return DeltaCost;
         const int AddendCost = RISCVMatInt::getIntMatCost(

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -9280,10 +9280,10 @@ SDValue RISCVTargetLowering::lowerSELECT(SDValue Op, SelectionDAG &DAG) const {
         }
       }
 
-      auto getCost = [&](APInt Delta, APInt Addend) {
+      auto getCost = [&](const APInt &Delta, const APInt &Addend) {
         const int DeltaCost = RISCVMatInt::getIntMatCost(
             Delta, Subtarget.getXLen(), Subtarget, /*CompressionCost=*/true);
-        // Dos the addend folds into an ADDI
+        // Does the addend folds into an ADDI
         if (Addend.isSignedIntN(12))
           return DeltaCost;
         const int AddendCost = RISCVMatInt::getIntMatCost(

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -9288,10 +9288,7 @@ SDValue RISCVTargetLowering::lowerSELECT(SDValue Op, SelectionDAG &DAG) const {
           return DeltaCost;
         const int AddendCost = RISCVMatInt::getIntMatCost(
             Addend, Subtarget.getXLen(), Subtarget, /*CompressionCost=*/true);
-        // Panalize the ADD slightly so that we prefer to end with an ADDI
-        // if costs are otherwise equal.  This helps to expose the immediate
-        // for possible folding into a dependent memory instruction.
-        return AddendCost + DeltaCost + 1;
+        return AddendCost + DeltaCost;
       };
       bool IsCZERO_NEZ = getCost(FalseVal - TrueVal, TrueVal) <=
                          getCost(TrueVal - FalseVal, FalseVal);

--- a/llvm/test/CodeGen/RISCV/select-const.ll
+++ b/llvm/test/CodeGen/RISCV/select-const.ll
@@ -506,11 +506,10 @@ define i32 @select_nonnegative_lui_addi(i32 signext %x) {
 ; RV32ZICOND-LABEL: select_nonnegative_lui_addi:
 ; RV32ZICOND:       # %bb.0:
 ; RV32ZICOND-NEXT:    srli a0, a0, 31
-; RV32ZICOND-NEXT:    lui a1, 1048572
-; RV32ZICOND-NEXT:    addi a1, a1, 25
-; RV32ZICOND-NEXT:    czero.eqz a0, a1, a0
 ; RV32ZICOND-NEXT:    lui a1, 4
-; RV32ZICOND-NEXT:    add a0, a0, a1
+; RV32ZICOND-NEXT:    addi a1, a1, -25
+; RV32ZICOND-NEXT:    czero.nez a0, a1, a0
+; RV32ZICOND-NEXT:    addi a0, a0, 25
 ; RV32ZICOND-NEXT:    ret
 ;
 ; RV64I-LABEL: select_nonnegative_lui_addi:
@@ -536,11 +535,10 @@ define i32 @select_nonnegative_lui_addi(i32 signext %x) {
 ; RV64ZICOND-LABEL: select_nonnegative_lui_addi:
 ; RV64ZICOND:       # %bb.0:
 ; RV64ZICOND-NEXT:    srli a0, a0, 63
-; RV64ZICOND-NEXT:    lui a1, 1048572
-; RV64ZICOND-NEXT:    addi a1, a1, 25
-; RV64ZICOND-NEXT:    czero.eqz a0, a1, a0
 ; RV64ZICOND-NEXT:    lui a1, 4
-; RV64ZICOND-NEXT:    add a0, a0, a1
+; RV64ZICOND-NEXT:    addi a1, a1, -25
+; RV64ZICOND-NEXT:    czero.nez a0, a1, a0
+; RV64ZICOND-NEXT:    addi a0, a0, 25
 ; RV64ZICOND-NEXT:    ret
   %cmp = icmp sgt i32 %x, -1
   %cond = select i1 %cmp, i32 16384, i32 25


### PR DESCRIPTION
When choosing to materialize a select of two constants using zicond, we have a choice of which direction to compute the delta.  The prior cost was looking only at the cost of the values without accounting for the fact it's actually the delta which is the highest cost and that sometimes the addend can fold into an addi.