### PR TITLE
[flang] Extend error checking for implicit interfaces

### DIFF
--- a/flang/test/Semantics/global02.f90
+++ b/flang/test/Semantics/global02.f90
@@ -1,0 +1,37 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1 -Werror
+! Catch discrepancies between implicit result types and a global definition
+
+complex function zbefore()
+zbefore = (0.,0.)
+end
+
+program main
+!ERROR: Implicit declaration of function 'zbefore' has a different result type than in previous declaration
+print *, zbefore()
+print *, zafter()
+print *, zafter2()
+print *, zafter3()
+end
+
+subroutine another
+implicit integer(z)
+!ERROR: Implicit declaration of function 'zafter' has a different result type than in previous declaration
+print *, zafter()
+end
+
+!ERROR: Function 'zafter' has a result type that differs from the implicit type it obtained in a previous reference
+complex function zafter()
+zafter = (0.,0.)
+end
+
+function zafter2()
+!ERROR: Function 'zafter2' has a result type that differs from the implicit type it obtained in a previous reference
+complex zafter2
+zafter2 = (0.,0.)
+end
+
+function zafter3() result(res)
+!ERROR: Function 'zafter3' has a result type that differs from the implicit type it obtained in a previous reference
+complex res
+res = (0.,0.)
+end


### PR DESCRIPTION
When an external procedure is called by means of an implicit interface that turns out to be different in a significant way from the actual interface in its definition elsewhere in the source file, we emit an error message.  This works for differences in actual vs dummy arguments, and for the result types of previously declared functions. This patch adds checking for differences between implicitly typed external function references and their actual declared types when the function's definition appears later.