### PR TITLE
[libc][NFC] Clean up utimes and setsid

### DIFF
--- a/libc/src/unistd/linux/setsid.cpp
+++ b/libc/src/unistd/linux/setsid.cpp
@@ -11,6 +11,7 @@
 #include "hdr/types/pid_t.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
 #include "src/__support/common.h"
+#include "src/__support/libc_errno.h"
 #include "src/__support/macros/config.h"
 
 #include <sys/syscall.h> // For syscall numbers.
@@ -18,7 +19,12 @@
 namespace LIBC_NAMESPACE_DECL {
 
 LLVM_LIBC_FUNCTION(pid_t, setsid, ()) {
-  return LIBC_NAMESPACE::syscall_impl<pid_t>(SYS_setsid);
+  pid_t ret = LIBC_NAMESPACE::syscall_impl<pid_t>(SYS_setsid);
+  if (ret < 0) {
+    libc_errno = static_cast<int>(-ret);
+    return -1;
+  }
+  return ret;
 }
 
 } // namespace LIBC_NAMESPACE_DECL


### PR DESCRIPTION
Simplify utims a bit and add proper error handling to setsid as
described in the standard
