### PR TITLE
[ASAN][AArch64] Asan crash fix for scalable types.

### DIFF
--- a/clang/test/CodeGen/asan-scalabe-vector.cpp
+++ b/clang/test/CodeGen/asan-scalabe-vector.cpp
@@ -1,0 +1,12 @@
+// Regression test for compiler crash
+// RUN: %clang_cc1 -triple aarch64-unknown-linux-gnu -target-feature +sve -target-feature +sve2 -emit-obj -fsanitize=address -fsanitize-address-use-after-scope %s -o - | llvm-objdump -d - | FileCheck %s
+// REQUIRES: aarch64-registered-target
+
+#include <arm_sve.h>
+int biz(svfloat64_t*);
+int foo(){
+    svfloat64_t a,b,c;
+    return biz(&a)+biz(&b)+biz(&c);
+}
+
+//CHECK: 0000000000000000 <_Z3foov>:

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1406,6 +1406,8 @@ bool AddressSanitizer::isInterestingAlloca(const AllocaInst &AI) {
       (AI.getAllocatedType()->isSized() &&
        // alloca() may be called with 0 size, ignore it.
        ((!AI.isStaticAlloca()) || !getAllocaSizeInBytes(AI).isZero()) &&
+       // alloca() may be called with a scalable parameter, we can't handle it.
+       !AI.getAllocationSize(AI.getDataLayout())->isScalable() &&
        // We are only interested in allocas not promotable to registers.
        // Promotable allocas are common under -O0.
        (!ClSkipPromotableAllocas || !isAllocaPromotable(&AI)) &&


### PR DESCRIPTION
Asan doesn't support scalable types yet. Compiler crashes when alloca's size comes from a scalable type.