### PR TITLE
[clang] Fix crash when `__builtin_function_start` is given an invalid first parameter

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -258,6 +258,8 @@ Bug Fixes in This Version
   targets that treat ``_Float16``/``__fp16`` as native scalar types. Previously
   the warning was silently lost because the operands differed only by an implicit
   cast chain. (#GH149967).
+- Fix crash in ``__builtin_function_start`` by checking for invalid
+  first parameter. (#GH113323).
 - Fixed a crash with incompatible pointer to integer conversions in designated
   initializers involving string literals. (#GH154046)
 - Clang now emits a frontend error when a function marked with the `flatten` attribute

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -286,6 +286,9 @@ static bool BuiltinFunctionStart(Sema &S, CallExpr *TheCall) {
   if (S.checkArgCount(TheCall, 1))
     return true;
 
+  if (TheCall->getArg(0)->containsErrors())
+    return true;
+
   ExprResult Arg = S.DefaultFunctionArrayLvalueConversion(TheCall->getArg(0));
   if (Arg.isInvalid())
     return true;

--- a/clang/test/SemaCXX/gh113323.cpp
+++ b/clang/test/SemaCXX/gh113323.cpp
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+int a() {} // expected-warning {{non-void function does not return a value}}
+constexpr void (*d)() = a; // expected-error {{cannot initialize a variable of type}}
+const void *f = __builtin_function_start(d);

--- a/clang/test/SemaCXX/gh113323.cpp
+++ b/clang/test/SemaCXX/gh113323.cpp
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,no-recovery -fno-recovery-ast %s
 
 int a() {} // expected-warning {{non-void function does not return a value}}
 constexpr void (*d)() = a; // expected-error {{cannot initialize a variable of type}}
-const void *f = __builtin_function_start(d);
+const void *f = __builtin_function_start(d);  // no-recovery-error {{argument must be a function}}


### PR DESCRIPTION
Prevent a crash in `__builtin_function_start` by adding a check for an invalid first parameter.

fixes #113323