### PR TITLE
[Flang] Fix symbol name clash when dummy procedure name is the same as common-block-name

### DIFF
--- a/flang/test/Transforms/dummy-procedure-common-block-name.f
+++ b/flang/test/Transforms/dummy-procedure-common-block-name.f
@@ -1,0 +1,12 @@
+! RUN: bbc -emit-fir %s -o - | FileCheck %s
+
+subroutine ss5()
+common /com_dummy1/ x
+! CHECK: fir.global common @com_dummy1_
+interface
+    subroutine com_dummy1()
+    end subroutine
+end interface
+! CHECK: func.func private @_QPcom_dummy1()
+print *,fun_sub(com_dummy1)
+end


### PR DESCRIPTION
Dummy procedures in interface blocks are not external procedures that need to be linked. Do not externalize those.

Fixes #122822