### PR TITLE
[clang] Fix clang module build by declaring new textual header

### DIFF
--- a/clang/include/module.modulemap
+++ b/clang/include/module.modulemap
@@ -37,6 +37,7 @@ module Clang_Basic {
   umbrella "clang/Basic"
 
   textual header "clang/Basic/AArch64ACLETypes.def"
+  textual header "clang/Basic/ABIVersions.def"
   textual header "clang/Basic/AMDGPUTypes.def"
   textual header "clang/Basic/BuiltinHeaders.def"
   textual header "clang/Basic/BuiltinsAArch64.def"


### PR DESCRIPTION
Add `clang/Basic/ABIVersions.def` introduced in #151995 to textual header
to fix clang module build.
