### PR TITLE
[clang-doc] lower filename length limit by 5

### DIFF
--- a/clang-tools-extra/clang-doc/Serialize.cpp
+++ b/clang-tools-extra/clang-doc/Serialize.cpp
@@ -778,7 +778,9 @@ static void populateSymbolInfo(SymbolInfo &I, const T *D, const FullComment *C,
     Mangler->mangleCXXVTable(CXXD, MangledStream);
   else
     MangledStream << D->getNameAsString();
-  if (MangledName.size() > 255)
+  // A 250 length limit was chosen since 255 is a common limit across
+  // different filesystems, with a 5 character buffer for file extensions.
+  if (MangledName.size() > 250)
     // File creation fails if the mangled name is too long, so default to the
     // USR. We should look for a better check since filesystems differ in
     // maximum filename length

--- a/clang-tools-extra/test/clang-doc/long-name.cpp
+++ b/clang-tools-extra/test/clang-doc/long-name.cpp
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: clang-doc --output=%t --format=mustache --executor=standalone %s
+// RUN: ls %t/json | FileCheck %s -check-prefix=CHECK-JSON
+// RUN: ls %t/html | FileCheck %s -check-prefix=CHECK-HTML
+
+struct ThisStructHasANameThatResultsInAMangledNameThatIsExactly250CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheLengthIsTooLongThenClangDocWillCrashAnd12 {};
+
+// This name is 1 character over the limit, so it will be serialized as a USR.
+struct ThisStructHasANameThatResultsInAMangledNameThatIsExactly251CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheLengthIsTooLongThenClangDocWillCrashAnd123 {};
+
+// CHECK-JSON: ThisStructHasANameThatResultsInAMangledNameThatIsExactly250CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheLengthIsTooLongThenClangDocWillCrashAnd12.json
+// CHECK-JSON: {{[0-9A-F]*}}.json
+// CHECK-HTML: ThisStructHasANameThatResultsInAMangledNameThatIsExactly250CharactersLongThatIsSupposedToTestTheFilenameLengthLimitsWithinClangDocInOrdertoSeeifclangdocwillcrashornotdependingonthelengthofthestructIfTheLengthIsTooLongThenClangDocWillCrashAnd12.html
+// CHECK-HTML: {{[0-9A-F]*}}.html


### PR DESCRIPTION
The previous limit did not take into account filename extensions. Since
the extensions we use (.yaml, .json, .html, .md) are at most 5
characters, we can lower the limit by 5.

Also add some tests to make sure the rules are observed and don't
explicitly crash clang-doc.