### PR TITLE
Reapply "[AMDGPU] gfx1250 trans instructions bf16 codegen tests update. NFC (#155310)"

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.rcp.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.rcp.bf16.ll
@@ -31,5 +31,71 @@ define amdgpu_kernel void @rcp_bf16(ptr addrspace(1) %out, bfloat %src) #1 {
   ret void
 }
 
+define amdgpu_kernel void @rcp_bf16_constant_4(ptr addrspace(1) %out) #1 {
+; SDAG-TRUE16-LABEL: rcp_bf16_constant_4:
+; SDAG-TRUE16:       ; %bb.0:
+; SDAG-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0x3e80
+; SDAG-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; SDAG-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; SDAG-TRUE16-NEXT:    flat_store_b16 v1, v0, s[0:1]
+; SDAG-TRUE16-NEXT:    s_endpgm
+;
+; SDAG-FAKE16-LABEL: rcp_bf16_constant_4:
+; SDAG-FAKE16:       ; %bb.0:
+; SDAG-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; SDAG-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0x3e80
+; SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; SDAG-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; SDAG-FAKE16-NEXT:    s_endpgm
+  %rcp = call bfloat @llvm.amdgcn.rcp.bf16(bfloat 4.0) #0
+  store bfloat %rcp, ptr addrspace(1) %out, align 2
+  ret void
+}
+
+define amdgpu_kernel void @rcp_bf16_constant_100(ptr addrspace(1) %out) #1 {
+; SDAG-TRUE16-LABEL: rcp_bf16_constant_100:
+; SDAG-TRUE16:       ; %bb.0:
+; SDAG-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0x3c24
+; SDAG-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; SDAG-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; SDAG-TRUE16-NEXT:    flat_store_b16 v1, v0, s[0:1]
+; SDAG-TRUE16-NEXT:    s_endpgm
+;
+; SDAG-FAKE16-LABEL: rcp_bf16_constant_100:
+; SDAG-FAKE16:       ; %bb.0:
+; SDAG-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; SDAG-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0x3c24
+; SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; SDAG-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; SDAG-FAKE16-NEXT:    s_endpgm
+  %rcp = call bfloat @llvm.amdgcn.rcp.bf16(bfloat 100.0) #0
+  store bfloat %rcp, ptr addrspace(1) %out, align 2
+  ret void
+}
+
+define amdgpu_kernel void @rcp_undef_bf16(ptr addrspace(1) %out) #1 {
+; SDAG-TRUE16-LABEL: rcp_undef_bf16:
+; SDAG-TRUE16:       ; %bb.0:
+; SDAG-TRUE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; SDAG-TRUE16-NEXT:    v_mov_b16_e32 v0.l, 0x7fc0
+; SDAG-TRUE16-NEXT:    v_mov_b32_e32 v1, 0
+; SDAG-TRUE16-NEXT:    s_wait_kmcnt 0x0
+; SDAG-TRUE16-NEXT:    flat_store_b16 v1, v0, s[0:1]
+; SDAG-TRUE16-NEXT:    s_endpgm
+;
+; SDAG-FAKE16-LABEL: rcp_undef_bf16:
+; SDAG-FAKE16:       ; %bb.0:
+; SDAG-FAKE16-NEXT:    s_load_b64 s[0:1], s[4:5], 0x0
+; SDAG-FAKE16-NEXT:    v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0x7fc0
+; SDAG-FAKE16-NEXT:    s_wait_kmcnt 0x0
+; SDAG-FAKE16-NEXT:    global_store_b16 v0, v1, s[0:1]
+; SDAG-FAKE16-NEXT:    s_endpgm
+  %rcp = call bfloat @llvm.amdgcn.rcp.bf16(bfloat undef)
+  store bfloat %rcp, ptr addrspace(1) %out, align 2
+  ret void
+}
+
 attributes #0 = { nounwind readnone }
 attributes #1 = { nounwind }

--- a/llvm/test/CodeGen/AMDGPU/llvm.cos.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.cos.bf16.ll
@@ -6,6 +6,23 @@
 
 declare bfloat @llvm.cos.bf16(bfloat) #0
 
+define amdgpu_kernel void @cos_bf16(ptr addrspace(1) %out, bfloat %src) #1 {
+; GCN-LABEL: cos_bf16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_load_b96 s[0:2], s[4:5], 0x0
+; GCN-NEXT:    s_mov_b32 s3, 0x3e230000
+; GCN-NEXT:    v_mov_b32_e32 v1, 0
+; GCN-NEXT:    s_wait_kmcnt 0x0
+; GCN-NEXT:    v_fma_mixlo_bf16 v0, s2, s3, 0 op_sel_hi:[1,0,0]
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_cos_bf16_e32 v0, v0
+; GCN-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GCN-NEXT:    s_endpgm
+  %cos = call bfloat @llvm.cos.bf16(bfloat %src) #0
+  store bfloat %cos, ptr addrspace(1) %out, align 2
+  ret void
+}
+
 define amdgpu_kernel void @cos_bf16_constant_4(ptr addrspace(1) %out) #1 {
 ; GCN-LABEL: cos_bf16_constant_4:
 ; GCN:       ; %bb.0:

--- a/llvm/test/CodeGen/AMDGPU/llvm.sin.bf16.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.sin.bf16.ll
@@ -6,6 +6,23 @@
 
 declare bfloat @llvm.sin.bf16(bfloat) #0
 
+define amdgpu_kernel void @sin_bf16(ptr addrspace(1) %out, bfloat %src) #1 {
+; GCN-LABEL: sin_bf16:
+; GCN:       ; %bb.0:
+; GCN-NEXT:    s_load_b96 s[0:2], s[4:5], 0x0
+; GCN-NEXT:    s_mov_b32 s3, 0x3e230000
+; GCN-NEXT:    v_mov_b32_e32 v1, 0
+; GCN-NEXT:    s_wait_kmcnt 0x0
+; GCN-NEXT:    v_fma_mixlo_bf16 v0, s2, s3, 0 op_sel_hi:[1,0,0]
+; GCN-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GCN-NEXT:    v_sin_bf16_e32 v0, v0
+; GCN-NEXT:    global_store_b16 v1, v0, s[0:1]
+; GCN-NEXT:    s_endpgm
+  %sin = call bfloat @llvm.sin.bf16(bfloat %src) #0
+  store bfloat %sin, ptr addrspace(1) %out, align 2
+  ret void
+}
+
 define amdgpu_kernel void @sin_bf16_constant_4(ptr addrspace(1) %out) #1 {
 ; GCN-LABEL: sin_bf16_constant_4:
 ; GCN:       ; %bb.0:


### PR DESCRIPTION
This reverts commit 665da0a1649814471739c41a702e0e9447316b20.

Regenerate checks after 445415219708f9539801018e03282049ca33e0e2 landed
after adding these tests.