### PR TITLE
[CI] Strip strings from filenames in compute_projects.py

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -333,6 +333,7 @@ if __name__ == "__main__":
     current_platform = platform.system()
     if len(sys.argv) == 2:
         current_platform = sys.argv[1]
-    env_variables = get_env_variables(sys.stdin.readlines(), current_platform)
+    changed_files = [line.strip() for line in sys.stdin.readlines()]
+    env_variables = get_env_variables(changed_files, current_platform)
     for env_variable in env_variables:
         print(f"{env_variable}='{env_variables[env_variable]}'")


### PR DESCRIPTION
This can otherwise mess up some of the path detection logic, particularly around ensuring the premerge checks are run when the workflow YAML file is changed.