### PR TITLE
[clang-scan-deps] Remove unused OutputsPaths from FullDependencyConsumer (NFC)

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -220,7 +220,6 @@ private:
   std::vector<std::string> VisibleModules;
   std::vector<Command> Commands;
   std::string ContextHash;
-  std::vector<std::string> OutputPaths;
   const llvm::DenseSet<ModuleID> &AlreadySeen;
 };
 


### PR DESCRIPTION
The OutputPaths field of FullDependencyConsumer is not used, and the resulting TranslationUnitDeps has no corresponding field. This change removes the unused member.

It was added in commit f978ea4, and this comment in the Differential Revision suggests it was intended to be removed before landing: https://reviews.llvm.org/D70268#1772032