### PR TITLE
[BOLT][test] Fix 'veneer-lld-abs' test execution on Windows host

### DIFF
--- a/bolt/test/AArch64/veneer-lld-abs.s
+++ b/bolt/test/AArch64/veneer-lld-abs.s
@@ -12,7 +12,7 @@
 
 ## Occasionally, we see the linker not generating $d symbols for long veneers
 ## causing BOLT to fail veneer elimination.
-# RUN: llvm-objcopy --remove-symbol-prefix=\$d %t.exe %t.no-marker.exe
+# RUN: llvm-objcopy --remove-symbol-prefix='$d' %t.exe %t.no-marker.exe
 # RUN: llvm-bolt %t.no-marker.exe -o %t.no-marker.bolt \
 # RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-BOLT
 # RUN: llvm-objdump -d -j .text  %t.no-marker.bolt | \


### PR DESCRIPTION
The `\$d` escaping sequence is not working properly on the Windows host. Replacing it with `'$d'` fixes the problem and works fine on both Windows and Linux hosts.