### PR TITLE
[MLIR][diag] Add PassManager option to emit failed pass name

### DIFF
--- a/mlir/include/mlir/Pass/PassManager.h
+++ b/mlir/include/mlir/Pass/PassManager.h
@@ -275,6 +275,10 @@ public:
   /// Runs the verifier after each individual pass.
   void enableVerifier(bool enabled = true);
 
+  /// Sets whether an error containing the failing pass name should be emitted
+  /// upon failure.
+  void enableErrorOnFailure(bool enabled = true);
+
   //===--------------------------------------------------------------------===//
   // Instrumentations
   //===--------------------------------------------------------------------===//
@@ -497,6 +501,10 @@ private:
 
   /// A flag that indicates if the IR should be verified in between passes.
   bool verifyPasses : 1;
+
+  /// A flag that indicates if an error containing the pass name should be
+  /// emitted upon failure.
+  bool emitErrorOnFailure : 1;
 };
 
 /// Register a set of useful command-line options that can be used to configure

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -207,6 +207,15 @@ public:
   }
   bool shouldVerifyPasses() const { return verifyPassesFlag; }
 
+  /// Set whether to emit and error upon pass failure.
+  MlirOptMainConfig &emitErrorOnPassFailure(bool emit) {
+    emitErrorOnPassFailureFlag = emit;
+    return *this;
+  }
+  bool shouldEmitErrorOnPassFailure() const {
+    return emitErrorOnPassFailureFlag;
+  }
+
   /// Set whether to run the verifier on parsing.
   MlirOptMainConfig &verifyOnParsing(bool verify) {
     disableVerifierOnParsingFlag = !verify;
@@ -290,6 +299,9 @@ protected:
 
   /// Run the verifier after each transformation pass.
   bool verifyPassesFlag = true;
+
+  /// Emit an error upon a pass failure.
+  bool emitErrorOnPassFailureFlag = false;
 
   /// Disable the verifier on parsing.
   bool disableVerifierOnParsingFlag = false;

--- a/mlir/lib/Pass/PassDetail.h
+++ b/mlir/lib/Pass/PassDetail.h
@@ -29,7 +29,7 @@ public:
   OpToOpPassAdaptor(const OpToOpPassAdaptor &rhs) = default;
 
   /// Run the held pipeline over all operations.
-  void runOnOperation(bool verifyPasses);
+  void runOnOperation(bool verifyPasses, bool emitErrorOnFailure);
   void runOnOperation() override;
 
   /// Try to merge the current pass adaptor into 'rhs'. This will try to append
@@ -60,25 +60,29 @@ public:
 
 private:
   /// Run this pass adaptor synchronously.
-  void runOnOperationImpl(bool verifyPasses);
+  void runOnOperationImpl(bool verifyPasses, bool emitErrorOnFailure);
 
   /// Run this pass adaptor asynchronously.
-  void runOnOperationAsyncImpl(bool verifyPasses);
+  void runOnOperationAsyncImpl(bool verifyPasses, bool emitErrorOnFailure);
 
   /// Run the given operation and analysis manager on a single pass.
   /// `parentInitGeneration` is the initialization generation of the parent pass
   /// manager, and is used to initialize any dynamic pass pipelines run by the
-  /// given pass.
+  /// given pass. If `emitErrorOnFailure` is set, when a pass in
+  /// the pipeline fails its name will be emitted in an error.
   static LogicalResult run(Pass *pass, Operation *op, AnalysisManager am,
-                           bool verifyPasses, unsigned parentInitGeneration);
+                           bool verifyPasses, bool emitErrorOnFailure,
+                           unsigned parentInitGeneration);
 
   /// Run the given operation and analysis manager on a provided op pass
   /// manager. `parentInitGeneration` is the initialization generation of the
   /// parent pass manager, and is used to initialize any dynamic pass pipelines
-  /// run by the given passes.
+  /// run by the given passes. If `emitErrorOnFailure` is set, when a pass in
+  /// the pipeline fails its name will be emitted in an error.
   static LogicalResult runPipeline(
       OpPassManager &pm, Operation *op, AnalysisManager am, bool verifyPasses,
-      unsigned parentInitGeneration, PassInstrumentor *instrumentor = nullptr,
+      bool emitErrorOnFailure, unsigned parentInitGeneration,
+      PassInstrumentor *instrumentor = nullptr,
       const PassInstrumentation::PipelineParentInfo *parentInfo = nullptr);
 
   /// A set of adaptors to run.

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -182,6 +182,11 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
         cl::desc("Run the verifier after each transformation pass"),
         cl::location(verifyPassesFlag), cl::init(true));
 
+    static cl::opt<bool, /*ExternalStorage=*/true> emitPassErrorOnFailure(
+        "emit-pass-error-on-failure",
+        cl::desc("Emit an error with the pass name when a pass fails"),
+        cl::location(emitErrorOnPassFailureFlag), cl::init(false));
+
     static cl::opt<bool, /*ExternalStorage=*/true> disableVerifyOnParsing(
         "mlir-very-unsafe-disable-verifier-on-parsing",
         cl::desc("Disable the verifier on parsing (very unsafe)"),
@@ -465,6 +470,7 @@ performActions(raw_ostream &os,
   // Prepare the pass manager, applying command-line and reproducer options.
   PassManager pm(op.get()->getName(), PassManager::Nesting::Implicit);
   pm.enableVerifier(config.shouldVerifyPasses());
+  pm.enableErrorOnFailure(config.shouldEmitErrorOnPassFailure());
   if (failed(applyPassManagerCLOptions(pm)))
     return failure();
   pm.enableTiming(timing);

--- a/mlir/test/Pass/pass-name-diagnostics.mlir
+++ b/mlir/test/Pass/pass-name-diagnostics.mlir
@@ -1,0 +1,7 @@
+// RUN: mlir-opt %s -pass-pipeline='builtin.module(func.func(test-pass-failure{gen-diagnostics}))' -emit-pass-error-on-failure -verify-diagnostics=only-expected
+
+// expected-error@+2 {{failed to run pass}}
+// expected-error@+1 {{illegal operation}}
+func.func @TestAlwaysIllegalOperationPass1() {
+  return
+}


### PR DESCRIPTION
This patch adds an option to `PassManager` which simply controls whether an error will be emitted when a pass in the pipeline fails. This error includes the name of the pass that failed which could be very helpful for debugging.