### PR TITLE
Emit DW_OP_lit0/1 for constant boolean values

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -3111,8 +3111,10 @@ void DwarfDebug::emitDebugLocValue(const AsmPrinter &AP, const DIBasicType *BT,
                             &AP](const DbgValueLocEntry &Entry,
                                  DIExpressionCursor &Cursor) -> bool {
     if (Entry.isInt()) {
-      if (BT && (BT->getEncoding() == dwarf::DW_ATE_signed ||
-                 BT->getEncoding() == dwarf::DW_ATE_signed_char))
+      if (BT && (BT->getEncoding() == dwarf::DW_ATE_boolean))
+        DwarfExpr.addBooleanConstant(Entry.getInt());
+      else if (BT && (BT->getEncoding() == dwarf::DW_ATE_signed ||
+                      BT->getEncoding() == dwarf::DW_ATE_signed_char))
         DwarfExpr.addSignedConstant(Entry.getInt());
       else
         DwarfExpr.addUnsignedConstant(Entry.getInt());

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.cpp
@@ -194,6 +194,15 @@ void DwarfExpression::addStackValue() {
     emitOp(dwarf::DW_OP_stack_value);
 }
 
+void DwarfExpression::addBooleanConstant(int64_t Value) {
+  assert(isImplicitLocation() || isUnknownLocation());
+  LocationKind = Implicit;
+  if (Value == 0)
+    emitOp(dwarf::DW_OP_lit0);
+  else
+    emitOp(dwarf::DW_OP_lit1);
+}
+
 void DwarfExpression::addSignedConstant(int64_t Value) {
   assert(isImplicitLocation() || isUnknownLocation());
   LocationKind = Implicit;

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfExpression.h
@@ -229,6 +229,9 @@ public:
   /// This needs to be called last to commit any pending changes.
   void finalize();
 
+  /// Emit a boolean constant.
+  void addBooleanConstant(int64_t Value);
+
   /// Emit a signed constant.
   void addSignedConstant(int64_t Value);
 

--- a/llvm/test/DebugInfo/debug-bool-const-location.ll
+++ b/llvm/test/DebugInfo/debug-bool-const-location.ll
@@ -1,0 +1,48 @@
+; REQUIRES: object-emission
+; RUN: %llc_dwarf %s -O3 -filetype=obj -o - | llvm-dwarfdump - | FileCheck %s
+
+; CHECK: {{.*}}DW_TAG_variable
+; CHECK: {{.*}} DW_OP_lit1
+; CHECK-NOT: {{.*}} DW_OP_lit0, DW_OP_not
+; CHECK: {{.*}} DW_OP_lit0
+; CHECK: {{.*}} DW_AT_name    ("arg")
+
+define void @foo(i8 %"arg.arg") !dbg !5
+{
+entry:
+  %".4" = alloca i1
+  %".5" = icmp eq i8 %"arg.arg", 0
+  %arg = alloca i1
+  br i1 %".5", label %"entry.if", label %"entry.else"
+entry.if:
+  store i1 false, i1* %arg
+  call void @"llvm.dbg.value"(metadata i1 false , metadata !9, metadata !10), !dbg !6
+  br label %"entry.endif"
+entry.else:
+  store i1 true, i1* %arg
+  call void @"llvm.dbg.value"(metadata i1 true , metadata !9, metadata !10), !dbg !7
+  br label %"entry.endif"
+entry.endif:
+  %".11" = load i1, i1* %arg
+  store i1 %".11", i1* %".4", !dbg !8
+  call void @"llvm.dbg.value"(metadata i1 %".11" , metadata !9, metadata !10), !dbg !8
+  ret void, !dbg !8
+}
+
+declare void @"llvm.dbg.value"(metadata %".1", metadata %".2", metadata %".3")
+
+!llvm.dbg.cu = !{ !2 }
+!llvm.module.flags = !{ !11, !12 }
+
+!1 = !DIFile(directory: "", filename: "test")
+!2 = distinct !DICompileUnit(emissionKind: FullDebug, file: !1, isOptimized: false, language: DW_LANG_C_plus_plus, runtimeVersion: 0)
+!3 = !DIBasicType(encoding: DW_ATE_boolean, name: "bool", size: 8)
+!4 = !DISubroutineType(types: !{null})
+!5 = distinct !DISubprogram(file: !1, isDefinition: true, isLocal: false, isOptimized: false, line: 5, linkageName: "foo", name: "foo", scope: !1, scopeLine: 5, type: !4, unit: !2)
+!6 = !DILocation(column: 1, line: 5, scope: !5)
+!7 = !DILocation(column: 1, line: 7, scope: !5)
+!8 = !DILocation(column: 1, line: 8, scope: !5)
+!9 = !DILocalVariable(arg: 0, file: !1, line: 5, name: "arg", scope: !5, type: !3)
+!10 = !DIExpression()
+!11 = !{ i32 2, !"Dwarf Version", i32 4 }
+!12 = !{ i32 2, !"Debug Info Version", i32 3 }


### PR DESCRIPTION
Backends like NVPTX use -1 to indicate `true` and 0 to indicate `false` for boolean values. Machine instruction `#DBG_VALUE` also uses -1 to indicate a `true` boolean constant.

However, during the DWARF generation, booleans are treated as unsigned variables, and the debug_loc expression, like `DW_OP_lit0; DW_OP_not` is emitted for the `true` value.

This leads to the debugger printing `255` instead of `true` for constant boolean variables.

This change emits `DW_OP_lit1` instead of `DW_OP_lot0; DW_OP_not`.