### PR TITLE
[mlir][emitc] Mark emitc.literal with CExpression

### DIFF
--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -873,7 +873,7 @@ def EmitC_IncludeOp
   let hasCustomAssemblyFormat = 1;
 }
 
-def EmitC_LiteralOp : EmitC_Op<"literal", [Pure]> {
+def EmitC_LiteralOp : EmitC_Op<"literal", [Pure, CExpressionInterface]> {
   let summary = "Literal operation";
   let description = [{
     The `emitc.literal` operation produces an SSA value equal to some constant

--- a/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
+++ b/mlir/include/mlir/Dialect/EmitC/IR/EmitC.td
@@ -896,6 +896,12 @@ def EmitC_LiteralOp : EmitC_Op<"literal", [Pure, CExpressionInterface]> {
 
   let hasVerifier = 1;
   let assemblyFormat = "$value attr-dict `:` type($result)";
+
+  let extraClassDeclaration = [{
+    bool hasSideEffects() {
+      return false;
+    }
+  }];
 }
 
 def EmitC_LogicalAndOp : EmitC_BinaryOp<"logical_and", []> {

--- a/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
@@ -38,7 +38,7 @@ struct FormExpressionsPass
     auto matchFun = [&](Operation *op) {
       if (isa<emitc::CExpressionInterface>(*op) &&
           !op->getParentOfType<emitc::ExpressionOp>() &&
-          op->getNumResults() == 1)
+          !isa<emitc::LiteralOp>(op) && op->getNumResults() == 1)
         createExpression(op, builder);
     };
     rootOp->walk(matchFun);

--- a/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
+++ b/mlir/lib/Dialect/EmitC/Transforms/FormExpressions.cpp
@@ -36,9 +36,9 @@ struct FormExpressionsPass
     // Wrap each C operator op with an expression op.
     OpBuilder builder(context);
     auto matchFun = [&](Operation *op) {
-      if (isa<emitc::CExpressionInterface>(*op) &&
-          !op->getParentOfType<emitc::ExpressionOp>() &&
-          !isa<emitc::LiteralOp>(op) && op->getNumResults() == 1)
+      if (op->getNumResults() == 1 && !isa<emitc::LiteralOp>(op) &&
+          isa<emitc::CExpressionInterface>(*op) &&
+          !op->getParentOfType<emitc::ExpressionOp>())
         createExpression(op, builder);
     };
     rootOp->walk(matchFun);

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -100,6 +100,7 @@ static FailureOr<int> getOperatorPrecedence(Operation *operation) {
       .Case<emitc::ConstantOp>([&](auto op) { return 17; })
       .Case<emitc::DivOp>([&](auto op) { return 13; })
       .Case<emitc::LoadOp>([&](auto op) { return 16; })
+      .Case<emitc::LiteralOp>([&](auto op) { return 16; })
       .Case<emitc::LogicalAndOp>([&](auto op) { return 4; })
       .Case<emitc::LogicalNotOp>([&](auto op) { return 15; })
       .Case<emitc::LogicalOrOp>([&](auto op) { return 3; })
@@ -450,6 +451,16 @@ static LogicalResult printOperation(CppEmitter &emitter, emitc::LoadOp loadOp) {
     return failure();
 
   return emitter.emitOperand(loadOp.getOperand());
+}
+
+static LogicalResult printOperation(CppEmitter &emitter,
+                                    emitc::LiteralOp literalOp) {
+  // If literalOp is used inside an expression, we treat it as an embedded one.
+  if (emitter.isPartOfCurrentExpression(literalOp.getResult()))
+    return emitter.ostream() << literalOp.getValue(), success();
+
+  emitter.cacheDeferredOpResult(literalOp.getResult(), literalOp.getValue());
+  return success();
 }
 
 static LogicalResult printBinaryOperation(CppEmitter &emitter,
@@ -1714,10 +1725,10 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
                 emitc::DeclareFuncOp, emitc::DivOp, emitc::ExpressionOp,
                 emitc::FieldOp, emitc::FileOp, emitc::ForOp, emitc::FuncOp,
                 emitc::GlobalOp, emitc::IfOp, emitc::IncludeOp, emitc::LoadOp,
-                emitc::LogicalAndOp, emitc::LogicalNotOp, emitc::LogicalOrOp,
-                emitc::MulOp, emitc::RemOp, emitc::ReturnOp, emitc::SubOp,
-                emitc::SwitchOp, emitc::UnaryMinusOp, emitc::UnaryPlusOp,
-                emitc::VariableOp, emitc::VerbatimOp>(
+                emitc::LiteralOp, emitc::LogicalAndOp, emitc::LogicalNotOp,
+                emitc::LogicalOrOp, emitc::MulOp, emitc::RemOp, emitc::ReturnOp,
+                emitc::SubOp, emitc::SwitchOp, emitc::UnaryMinusOp,
+                emitc::UnaryPlusOp, emitc::VariableOp, emitc::VerbatimOp>(
 
               [&](auto op) { return printOperation(*this, op); })
           // Func ops.
@@ -1729,10 +1740,6 @@ LogicalResult CppEmitter::emitOperation(Operation &op, bool trailingSemicolon) {
           })
           .Case<emitc::GetFieldOp>([&](auto op) {
             cacheDeferredOpResult(op.getResult(), op.getFieldName());
-            return success();
-          })
-          .Case<emitc::LiteralOp>([&](auto op) {
-            cacheDeferredOpResult(op.getResult(), op.getValue());
             return success();
           })
           .Case<emitc::MemberOp>([&](auto op) {

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -455,7 +455,7 @@ static LogicalResult printOperation(CppEmitter &emitter, emitc::LoadOp loadOp) {
 
 static LogicalResult printOperation(CppEmitter &emitter,
                                     emitc::LiteralOp literalOp) {
-  // If literalOp is used inside an expression, we treat it as an embedded one.
+  // If literalOp is used inside an expression, we treat it as an inlined one.
   if (emitter.isPartOfCurrentExpression(literalOp.getResult()))
     return emitter.ostream() << literalOp.getValue(), success();
 

--- a/mlir/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/mlir/lib/Target/Cpp/TranslateToCpp.cpp
@@ -100,7 +100,7 @@ static FailureOr<int> getOperatorPrecedence(Operation *operation) {
       .Case<emitc::ConstantOp>([&](auto op) { return 17; })
       .Case<emitc::DivOp>([&](auto op) { return 13; })
       .Case<emitc::LoadOp>([&](auto op) { return 16; })
-      .Case<emitc::LiteralOp>([&](auto op) { return 16; })
+      .Case<emitc::LiteralOp>([&](auto op) { return 17; })
       .Case<emitc::LogicalAndOp>([&](auto op) { return 4; })
       .Case<emitc::LogicalNotOp>([&](auto op) { return 15; })
       .Case<emitc::LogicalOrOp>([&](auto op) { return 3; })

--- a/mlir/test/Dialect/EmitC/form-expressions.mlir
+++ b/mlir/test/Dialect/EmitC/form-expressions.mlir
@@ -192,6 +192,7 @@ func.func @opaque_type_expression(%arg0: i32,  %arg1: !emitc.opaque<"T0">, %arg2
   %c = emitc.cmp lt, %b, %arg2 :(i32, i32) -> i1
   return %c : i1
 }
+<<<<<<< HEAD
 
 // CHECK-LABEL:   func.func @expression_with_constant(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> i32 {
@@ -228,3 +229,5 @@ func.func @expression_with_literal(%arg0: i32) -> i1 {
   %c = emitc.cmp lt, %b, %arg0 :(i32, i32) -> i1
   return %c : i1
 }
+=======
+>>>>>>> 6a27d24c62dd ([mlir][emitc] Ignore literal in form-expression)

--- a/mlir/test/Dialect/EmitC/form-expressions.mlir
+++ b/mlir/test/Dialect/EmitC/form-expressions.mlir
@@ -211,20 +211,14 @@ func.func @expression_with_constant(%arg0: i32) -> i32 {
 
 // CHECK-LABEL:   func.func @expression_with_literal(
 // CHECK-SAME:      %[[ARG0:.*]]: i32) -> i1 {
-// CHECK:           %[[VAL_0:.*]] = emitc.expression : i32 {
+// CHECK:           %[[VAL_0:.*]] = emitc.expression : i1 {
 // CHECK:             %[[VAL_1:.*]] = literal "1" : i32
-// CHECK:             yield %[[VAL_1]] : i32
+// CHECK:             %[[VAL_2:.*]] = literal "2" : i32
+// CHECK:             %[[VAL_3:.*]] = add %[[VAL_1]], %[[VAL_2]] : (i32, i32) -> i32
+// CHECK:             %[[VAL_4:.*]] = cmp lt, %[[VAL_3]], %[[ARG0]] : (i32, i32) -> i1
+// CHECK:             yield %[[VAL_4]] : i1
 // CHECK:           }
-// CHECK:           %[[VAL_2:.*]] = emitc.expression : i32 {
-// CHECK:             %[[VAL_3:.*]] = literal "2" : i32
-// CHECK:             yield %[[VAL_3]] : i32
-// CHECK:           }
-// CHECK:           %[[VAL_4:.*]] = emitc.expression : i1 {
-// CHECK:             %[[VAL_5:.*]] = add %[[VAL_0]], %[[VAL_2]] : (i32, i32) -> i32
-// CHECK:             %[[VAL_6:.*]] = cmp lt, %[[VAL_5]], %[[ARG0]] : (i32, i32) -> i1
-// CHECK:             yield %[[VAL_6]] : i1
-// CHECK:           }
-// CHECK:           return %[[VAL_4]] : i1
+// CHECK:           return %[[VAL_0]] : i1
 // CHECK:         }
 
 func.func @expression_with_literal(%arg0: i32) -> i1 {

--- a/mlir/test/Dialect/EmitC/form-expressions.mlir
+++ b/mlir/test/Dialect/EmitC/form-expressions.mlir
@@ -192,7 +192,6 @@ func.func @opaque_type_expression(%arg0: i32,  %arg1: !emitc.opaque<"T0">, %arg2
   %c = emitc.cmp lt, %b, %arg2 :(i32, i32) -> i1
   return %c : i1
 }
-<<<<<<< HEAD
 
 // CHECK-LABEL:   func.func @expression_with_constant(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> i32 {
@@ -209,25 +208,3 @@ func.func @expression_with_constant(%arg0: i32) -> i32 {
   %a = emitc.mul %arg0, %c42 : (i32, i32) -> i32
   return %a : i32
 }
-
-// CHECK-LABEL:   func.func @expression_with_literal(
-// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i1 {
-// CHECK:           %[[VAL_0:.*]] = emitc.expression : i1 {
-// CHECK:             %[[VAL_1:.*]] = literal "1" : i32
-// CHECK:             %[[VAL_2:.*]] = literal "2" : i32
-// CHECK:             %[[VAL_3:.*]] = add %[[VAL_1]], %[[VAL_2]] : (i32, i32) -> i32
-// CHECK:             %[[VAL_4:.*]] = cmp lt, %[[VAL_3]], %[[ARG0]] : (i32, i32) -> i1
-// CHECK:             yield %[[VAL_4]] : i1
-// CHECK:           }
-// CHECK:           return %[[VAL_0]] : i1
-// CHECK:         }
-
-func.func @expression_with_literal(%arg0: i32) -> i1 {
-  %literal1 = emitc.literal "1" : i32
-  %literal2 = emitc.literal "2" : i32
-  %b = emitc.add %literal1, %literal2 : (i32, i32) -> i32
-  %c = emitc.cmp lt, %b, %arg0 :(i32, i32) -> i1
-  return %c : i1
-}
-=======
->>>>>>> 6a27d24c62dd ([mlir][emitc] Ignore literal in form-expression)

--- a/mlir/test/Dialect/EmitC/form-expressions.mlir
+++ b/mlir/test/Dialect/EmitC/form-expressions.mlir
@@ -208,3 +208,29 @@ func.func @expression_with_constant(%arg0: i32) -> i32 {
   %a = emitc.mul %arg0, %c42 : (i32, i32) -> i32
   return %a : i32
 }
+
+// CHECK-LABEL:   func.func @expression_with_literal(
+// CHECK-SAME:      %[[ARG0:.*]]: i32) -> i1 {
+// CHECK:           %[[VAL_0:.*]] = emitc.expression : i32 {
+// CHECK:             %[[VAL_1:.*]] = literal "1" : i32
+// CHECK:             yield %[[VAL_1]] : i32
+// CHECK:           }
+// CHECK:           %[[VAL_2:.*]] = emitc.expression : i32 {
+// CHECK:             %[[VAL_3:.*]] = literal "2" : i32
+// CHECK:             yield %[[VAL_3]] : i32
+// CHECK:           }
+// CHECK:           %[[VAL_4:.*]] = emitc.expression : i1 {
+// CHECK:             %[[VAL_5:.*]] = add %[[VAL_0]], %[[VAL_2]] : (i32, i32) -> i32
+// CHECK:             %[[VAL_6:.*]] = cmp lt, %[[VAL_5]], %[[ARG0]] : (i32, i32) -> i1
+// CHECK:             yield %[[VAL_6]] : i1
+// CHECK:           }
+// CHECK:           return %[[VAL_4]] : i1
+// CHECK:         }
+
+func.func @expression_with_literal(%arg0: i32) -> i1 {
+  %literal1 = emitc.literal "1" : i32
+  %literal2 = emitc.literal "2" : i32
+  %b = emitc.add %literal1, %literal2 : (i32, i32) -> i32
+  %c = emitc.cmp lt, %b, %arg0 :(i32, i32) -> i1
+  return %c : i1
+}

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -478,10 +478,9 @@ func.func @expression_with_literal(%arg0 : i32) -> i1 {
     %add = add %literal1, %arg0 : (i32, i32) -> i32
     %div = div %add, %literal2 : (i32, i32) -> i32
     %literal3 = emitc.literal "3" : i32
-    %f = emitc.cmp lt, %div, %literal3 :(i32, i32) -> i1
-    emitc.yield %f : i1
+    %cmp = emitc.cmp lt, %div, %literal3 : (i32, i32) -> i1
+    emitc.yield %cmp : i1
   }
-
   return %ret : i1
 }
 

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -472,7 +472,7 @@ emitc.func @expression_with_call_opaque_with_args_array(%0 : i32, %1 : i32) {
 // CPP-DECLTOP-NEXT: }
 
 func.func @expression_with_literal(%arg0 : i32) -> i1 {
-  %ret = emitc.expression noinline : i1 {
+  %ret = emitc.expression %arg0 noinline : (i32) -> i1 {
     %literal1 = emitc.literal "1" : i32
     %literal2 = emitc.literal "2" : i32
     %add = add %literal1, %arg0 : (i32, i32) -> i32
@@ -495,9 +495,9 @@ func.func @expression_with_literal(%arg0 : i32) -> i1 {
 // CPP-DECLTOP-NEXT: }
 
 func.func @single_literal_in_expression() -> i32 {
-  %result = emitc.expression : i32 {
-    %lit = emitc.literal "42" : i32
-    emitc.yield %lit : i32
+  %ret = emitc.expression : () -> i32 {
+    %literal = emitc.literal "42" : i32
+    emitc.yield %literal : i32
   }
-  return %result : i32
+  return %ret : i32
 }

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -484,3 +484,20 @@ func.func @expression_with_literal(%arg0 : i32) -> i1 {
 
   return %ret : i1
 }
+
+
+// CPP-DEFAULT:      int32_t single_literal_in_expression() {
+// CPP-DEFAULT-NEXT:   return 42;
+// CPP-DEFAULT-NEXT: }
+
+// CPP-DECLTOP:      int32_t single_literal_in_expression() {
+// CPP-DECLTOP-NEXT:   return 42;
+// CPP-DECLTOP-NEXT: }
+
+func.func @single_literal_in_expression() -> i32 {
+  %result = emitc.expression : i32 {
+    %lit = emitc.literal "42" : i32
+    emitc.yield %lit : i32
+  }
+  return %result : i32
+}

--- a/mlir/test/Target/Cpp/expressions.mlir
+++ b/mlir/test/Target/Cpp/expressions.mlir
@@ -458,3 +458,29 @@ emitc.func @expression_with_call_opaque_with_args_array(%0 : i32, %1 : i32) {
   }
   return
 }
+
+
+// CPP-DEFAULT:      bool expression_with_literal(int32_t [[VAL_1:v[0-9]+]]) {
+// CPP-DEFAULT-NEXT:   bool [[VAL_2:v[0-9]+]] = (1 + [[VAL_1]]) / 2 < 3;
+// CPP-DEFAULT-NEXT:   return [[VAL_2]];
+// CPP-DEFAULT-NEXT: }
+
+// CPP-DECLTOP:      bool expression_with_literal(int32_t [[VAL_1:v[0-9]+]]) {
+// CPP-DECLTOP-NEXT:   bool [[VAL_2:v[0-9]+]];
+// CPP-DECLTOP-NEXT:   [[VAL_2]] = (1 + [[VAL_1]]) / 2 < 3;
+// CPP-DECLTOP-NEXT:   return [[VAL_2]];
+// CPP-DECLTOP-NEXT: }
+
+func.func @expression_with_literal(%arg0 : i32) -> i1 {
+  %ret = emitc.expression noinline : i1 {
+    %literal1 = emitc.literal "1" : i32
+    %literal2 = emitc.literal "2" : i32
+    %add = add %literal1, %arg0 : (i32, i32) -> i32
+    %div = div %add, %literal2 : (i32, i32) -> i32
+    %literal3 = emitc.literal "3" : i32
+    %f = emitc.cmp lt, %div, %literal3 :(i32, i32) -> i1
+    emitc.yield %f : i1
+  }
+
+  return %ret : i1
+}


### PR DESCRIPTION
This PR marks `emitc.literal` as a valid operation within `emitc.expression`, removing an artificial restriction since literals are inherently inlined into expressions during emission.

Example:
```mlir
%0 = emitc.expression : i32 {
  %literal = emitc.literal "42" : i32
  emitc.yield %literal : i32
}
```