### PR TITLE
[clang][bytecode] Reject vectors with non-primitive element types

### DIFF
--- a/clang/test/CodeGenCXX/int64_uint64.cpp
+++ b/clang/test/CodeGenCXX/int64_uint64.cpp
@@ -6,6 +6,14 @@
 // RUN:   -target-feature +neon \
 // RUN:   -emit-llvm -w -O1 -o - %s | FileCheck --check-prefix=CHECK-AARCH64 %s
 
+// RUN: %clang_cc1 -triple arm-linux-guneabi \
+// RUN:   -target-cpu cortex-a8 -fexperimental-new-constant-interpreter \
+// RUN:   -emit-llvm -w -O1 -o - %s | FileCheck --check-prefix=CHECK-ARM %s
+
+// RUN: %clang_cc1 -triple arm64-linux-gnueabi \
+// RUN:   -target-feature +neon -fexperimental-new-constant-interpreter \
+// RUN:   -emit-llvm -w -O1 -o - %s | FileCheck --check-prefix=CHECK-AARCH64 %s
+
 // REQUIRES: aarch64-registered-target || arm-registered-target
 
 // Test if int64_t and uint64_t can be correctly mangled.


### PR DESCRIPTION
This happens for e.g. arm's float8 types.