### PR TITLE
[Clang][LoongArch] Add support for UEFI target

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -767,6 +767,9 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     case llvm::Triple::OpenBSD:
       return std::make_unique<OpenBSDTargetInfo<LoongArch64TargetInfo>>(Triple,
                                                                         Opts);
+    case llvm::Triple::UEFI:
+      return std::make_unique<UEFITargetInfo<LoongArch64TargetInfo>>(Triple,
+                                                                     Opts);
     default:
       return std::make_unique<LoongArch64TargetInfo>(Triple, Opts);
     }

--- a/clang/lib/Basic/Targets/LoongArch.h
+++ b/clang/lib/Basic/Targets/LoongArch.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_CLANG_LIB_BASIC_TARGETS_LOONGARCH_H
 #define LLVM_CLANG_LIB_BASIC_TARGETS_LOONGARCH_H
 
+#include "OSTargets.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
 #include "llvm/Support/Compiler.h"
@@ -159,6 +160,8 @@ public:
     IntMaxType = Int64Type = SignedLong;
     HasUnalignedAccess = true;
     resetDataLayout("e-m:e-p:64:64-i64:64-i128:128-n32:64-S128");
+    if (Triple.isUEFI())
+      resetDataLayout("e-m:w-p:64:64-i64:64-i128:128-n32:64-S128");
     // TODO: select appropriate ABI.
     setABI("lp64d");
   }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -698,8 +698,10 @@ static llvm::Triple computeTargetTriple(const Driver &D,
     }
   }
 
-  // Currently the only architecture supported by *-uefi triples are x86_64.
-  if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64)
+  // Currently the only architectures supported by *-uefi triples are
+  // x86_64 and loongarch64.
+  if (Target.isUEFI() && Target.getArch() != llvm::Triple::x86_64 &&
+      Target.getArch() != llvm::Triple::loongarch64)
     D.Diag(diag::err_target_unknown_triple) << Target.str();
 
   // The `-maix[32|64]` flags are only valid for AIX targets.

--- a/clang/test/CodeGen/LoongArch/uefi-data-layout.c
+++ b/clang/test/CodeGen/LoongArch/uefi-data-layout.c
@@ -1,0 +1,3 @@
+// RUN: %clang -target loongarch64-unknown-uefi -S -emit-llvm -o - %s | \
+// RUN:     FileCheck --check-prefix=LA64_UEFI %s
+// LA64_UEFI: target datalayout = "e-m:w-p:64:64-i64:64-i128:128-n32:64-S128"

--- a/clang/test/Driver/uefi-constructed-args.c
+++ b/clang/test/Driver/uefi-constructed-args.c
@@ -12,3 +12,18 @@
 // CHECK-SAME: "/entry:EfiMain"
 // CHECK-SAME: "/tsaware:no"
 // CHECK-SAME: "/debug"
+
+// RUN: %clang -### --target=loongarch64-unknown-uefi -g -- %s 2>&1 \
+// RUN:     | FileCheck -check-prefixes=LA64 %s
+// RUN: %clang_cl -### --target=loongarch64-unknown-uefi -g -- %s 2>&1 \
+// RUN:     | FileCheck -check-prefixes=LA64 %s
+// LA64: "-cc1"
+// LA64-SAME: "-triple" "loongarch64-unknown-uefi"
+// LA64-SAME: "-mrelocation-model" "pic" "-pic-level" "2"
+// LA64-SAME: "-mframe-pointer=all"
+// LA64-SAME: "-fms-extensions"
+// LA64-NEXT: "/nologo"
+// LA64-SAME: "/subsystem:efi_application"
+// LA64-SAME: "/entry:EfiMain"
+// LA64-SAME: "/tsaware:no"
+// LA64-SAME: "/debug"


### PR DESCRIPTION
This patch adds basic UEFI target support for loongarch64, enabling Clang to recognize and handle the loongarch64-unknown-uefi target triple.

Depends on #154883