### PR TITLE
[X86] canCreateUndefOrPoisonForTargetNode - add SSE bit logic + VPTERNLOG handling

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -45150,6 +45150,14 @@ bool X86TargetLowering::canCreateUndefOrPoisonForTargetNode(
     bool PoisonOnly, bool ConsiderFlags, unsigned Depth) const {
 
   switch (Op.getOpcode()) {
+  // SSE bit logic.
+  case X86ISD::FAND:
+  case X86ISD::FOR:
+  case X86ISD::FXOR:
+  case X86ISD::FANDN:
+  case X86ISD::ANDNP:
+  case X86ISD::VPTERNLOG:
+    return false;
   // SSE vector insert/extracts use modulo indices.
   case X86ISD::PINSRB:
   case X86ISD::PINSRW:


### PR DESCRIPTION
Basic bitlogic operations don't create undef/poison.

Its proving really annoying to create proper test coverage for these specific opcodes as they tend to appear in later stages - their presence does help in some upcoming patches (e.g. #152107) and I'd prefer to get them committed early.