### PR TITLE
[NFC] SimplifyCFG: Detect switch replacement earlier in `switchToLookup`

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -6961,7 +6961,7 @@ static bool simplifySwitchLookup(SwitchInst *SI, IRBuilder<> &Builder,
                         Results, DL, TTI))
       return false;
 
-    // Append the result  and result types from this case to the list for each
+    // Append the result and result types from this case to the list for each
     // phi.
     for (const auto &I : Results) {
       PHINode *PHI = I.first;

--- a/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -7034,6 +7034,9 @@ static bool simplifySwitchLookup(SwitchInst *SI, IRBuilder<> &Builder,
       return false;
   }
 
+  if (!shouldBuildLookupTable(SI, TableSize, TTI, DL, ResultTypes))
+    return false;
+
   // Compute the table index value.
   Value *TableIndex;
   if (UseSwitchConditionAsTableIndex) {
@@ -7063,9 +7066,6 @@ static bool simplifySwitchLookup(SwitchInst *SI, IRBuilder<> &Builder,
       }
     }
   }
-
-  if (!shouldBuildLookupTable(SI, TableSize, TTI, DL, ResultTypes))
-    return false;
 
   // Keep track of the switch replacement for each phi
   SmallDenseMap<PHINode *, SwitchReplacement> PhiToReplacementMap;


### PR DESCRIPTION
This PR is the first part to solve the issue in #149937.

The end goal is enabling more switch optimizations on targets that do not support lookup tables.

SimplifyCFG has the ability to replace switches with either a few simple calculations, a single value, or a lookup table.
However, it only considers these options if the target supports lookup tables, even if the final result is not a LUT, but a few simple instructions like muls, adds and shifts.

To enable more targets to use these other kinds of optimization, this PR restructures the code in `switchToLookup`.
Previously, code was generated even before choosing what kind of replacement to do. However, we need to know if we actually want to create a true LUT or not before generating anything. Then we can check for target support only if any LUT would be created.

This PR moves the code so it first determines the replacement kind and then generates the instructions.

A later PR will insert the target support check after determining the kind of replacement. If the result is not a LUT, then even targets without LUT support can replace the switch with something else.