### PR TITLE
[LLDB] Add unary plus and minus to DIL

### DIFF
--- a/lldb/docs/dil-expr-lang.ebnf
+++ b/lldb/docs/dil-expr-lang.ebnf
@@ -8,7 +8,7 @@ expression = unary_expression ;
 unary_expression = postfix_expression
                  | unary_operator expression ;
 
-unary_operator = "*" | "&" ;
+unary_operator = "*" | "&" | "+" | "-";
 
 postfix_expression = primary_expression
                    | postfix_expression "[" integer_literal "]"

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -413,8 +413,13 @@ public:
 
   // DIL
 
+  /// Checks if the type is eligible for integral promotion.
   virtual bool IsPromotableIntegerType(lldb::opaque_compiler_type_t type);
 
+  /// Perform integral promotion on a given type.
+  /// This promotes eligible types (boolean, integers, unscoped enumerations)
+  /// to a larger integer type according to type system rules.
+  /// \returns Promoted type.
   virtual llvm::Expected<CompilerType>
   DoIntegralPromotion(CompilerType from, ExecutionContextScope *exe_scope);
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -411,6 +411,13 @@ public:
   GetIntegralTemplateArgument(lldb::opaque_compiler_type_t type, size_t idx,
                               bool expand_pack);
 
+  // DIL
+
+  virtual bool IsPromotableIntegerType(lldb::opaque_compiler_type_t type);
+
+  virtual llvm::Expected<CompilerType>
+  DoIntegralPromotion(CompilerType from, ExecutionContextScope *exe_scope);
+
   // Dumping types
 
 #ifndef NDEBUG

--- a/lldb/include/lldb/ValueObject/DILAST.h
+++ b/lldb/include/lldb/ValueObject/DILAST.h
@@ -33,6 +33,8 @@ enum class NodeKind {
 enum class UnaryOpKind {
   AddrOf, // "&"
   Deref,  // "*"
+  Minus,  // "-"
+  Plus,   // "+"
 };
 
 /// Forward declaration, for use in DIL AST nodes. Definition is at the very

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -61,6 +61,8 @@ private:
   llvm::Expected<lldb::ValueObjectSP>
   Visit(const BooleanLiteralNode *node) override;
 
+  llvm::Expected<lldb::ValueObjectSP>
+  UnaryConversion(lldb::ValueObjectSP valobj);
   llvm::Expected<CompilerType>
   PickIntegerType(lldb::TypeSystemSP type_system,
                   std::shared_ptr<ExecutionContextScope> ctx,

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -61,6 +61,8 @@ private:
   llvm::Expected<lldb::ValueObjectSP>
   Visit(const BooleanLiteralNode *node) override;
 
+  /// Perform usual unary conversions on a value. At the moment this
+  /// includes array-to-pointer and integral promotion for eligible types.
   llvm::Expected<lldb::ValueObjectSP>
   UnaryConversion(lldb::ValueObjectSP valobj);
   llvm::Expected<CompilerType>

--- a/lldb/include/lldb/ValueObject/DILEval.h
+++ b/lldb/include/lldb/ValueObject/DILEval.h
@@ -64,7 +64,7 @@ private:
   /// Perform usual unary conversions on a value. At the moment this
   /// includes array-to-pointer and integral promotion for eligible types.
   llvm::Expected<lldb::ValueObjectSP>
-  UnaryConversion(lldb::ValueObjectSP valobj);
+  UnaryConversion(lldb::ValueObjectSP valobj, uint32_t location);
   llvm::Expected<CompilerType>
   PickIntegerType(lldb::TypeSystemSP type_system,
                   std::shared_ptr<ExecutionContextScope> ctx,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -938,6 +938,14 @@ public:
 
   CompilerType GetTypeForFormatters(void *type) override;
 
+  // DIL
+
+  bool IsPromotableIntegerType(lldb::opaque_compiler_type_t type) override;
+
+  llvm::Expected<CompilerType>
+  DoIntegralPromotion(CompilerType from,
+                      ExecutionContextScope *exe_scope) override;
+
 #define LLDB_INVALID_DECL_LEVEL UINT32_MAX
   // LLDB_INVALID_DECL_LEVEL is returned by CountDeclLevels if child_decl_ctx
   // could not be found in decl_ctx.

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -370,30 +370,10 @@ bool CompilerType::IsScalarOrUnscopedEnumerationType() const {
 }
 
 bool CompilerType::IsPromotableIntegerType() const {
-  // Unscoped enums are always considered as promotable, even if their
-  // underlying type does not need to be promoted (e.g. "int").
-  if (IsUnscopedEnumerationType())
-    return true;
-
-  switch (GetBasicTypeEnumeration()) {
-  case lldb::eBasicTypeBool:
-  case lldb::eBasicTypeChar:
-  case lldb::eBasicTypeSignedChar:
-  case lldb::eBasicTypeUnsignedChar:
-  case lldb::eBasicTypeShort:
-  case lldb::eBasicTypeUnsignedShort:
-  case lldb::eBasicTypeWChar:
-  case lldb::eBasicTypeSignedWChar:
-  case lldb::eBasicTypeUnsignedWChar:
-  case lldb::eBasicTypeChar16:
-  case lldb::eBasicTypeChar32:
-    return true;
-
-  default:
-    return false;
-  }
-
-  llvm_unreachable("All cases handled above.");
+  if (IsValid())
+    if (auto type_system_sp = GetTypeSystem())
+      return type_system_sp->IsPromotableIntegerType(m_type);
+  return false;
 }
 
 bool CompilerType::IsPointerToVoid() const {

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -123,6 +123,16 @@ CompilerType TypeSystem::GetTypeForFormatters(void *type) {
   return CompilerType(weak_from_this(), type);
 }
 
+bool TypeSystem::IsPromotableIntegerType(lldb::opaque_compiler_type_t type) {
+  return false;
+}
+
+llvm::Expected<CompilerType>
+TypeSystem::DoIntegralPromotion(CompilerType from,
+                                ExecutionContextScope *exe_scope) {
+  return CompilerType();
+}
+
 bool TypeSystem::IsTemplateType(lldb::opaque_compiler_type_t type) {
   return false;
 }

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -130,7 +130,8 @@ bool TypeSystem::IsPromotableIntegerType(lldb::opaque_compiler_type_t type) {
 llvm::Expected<CompilerType>
 TypeSystem::DoIntegralPromotion(CompilerType from,
                                 ExecutionContextScope *exe_scope) {
-  return CompilerType();
+  return llvm::createStringError(
+      "Integral promotion is not implemented for this TypeSystem");
 }
 
 bool TypeSystem::IsTemplateType(lldb::opaque_compiler_type_t type) {

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -308,6 +308,11 @@ Interpreter::Visit(const UnaryOpNode *node) {
     return value;
   }
   case UnaryOpKind::Minus: {
+    if (operand->GetCompilerType().IsReferenceType()) {
+      operand = operand->Dereference(error);
+      if (error.Fail())
+        return error.ToError();
+    }
     llvm::Expected<lldb::ValueObjectSP> conv_op = UnaryConversion(operand);
     if (!conv_op)
       return conv_op;
@@ -332,6 +337,11 @@ Interpreter::Visit(const UnaryOpNode *node) {
     break;
   }
   case UnaryOpKind::Plus: {
+    if (operand->GetCompilerType().IsReferenceType()) {
+      operand = operand->Dereference(error);
+      if (error.Fail())
+        return error.ToError();
+    }
     llvm::Expected<lldb::ValueObjectSP> conv_op = UnaryConversion(operand);
     if (!conv_op)
       return conv_op;

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -45,9 +45,6 @@ static CompilerType GetBasicType(lldb::TypeSystemSP type_system,
 static lldb::ValueObjectSP
 ArrayToPointerConversion(lldb::ValueObjectSP valobj,
                          std::shared_ptr<ExecutionContextScope> ctx) {
-  assert(valobj->IsArrayType() &&
-         "an argument to array-to-pointer conversion must be an array");
-
   uint64_t addr = valobj->GetLoadAddress();
   ExecutionContext exe_ctx;
   ctx->CalculateExecutionContext(exe_ctx);

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -242,6 +242,10 @@ Interpreter::Interpreter(lldb::TargetSP target, llvm::StringRef expr,
 llvm::Expected<lldb::ValueObjectSP> Interpreter::Evaluate(const ASTNode *node) {
   // Evaluate an AST.
   auto value_or_error = node->Accept(this);
+  // Convert SP with a nullptr to an error.
+  if (value_or_error && !*value_or_error)
+    return llvm::make_error<DILDiagnosticError>(m_expr, "invalid value object",
+                                                node->GetLocation());
   // Return the computed value-or-error. The caller is responsible for
   // checking if an error occured during the evaluation.
   return value_or_error;

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -55,8 +55,6 @@ ArrayToPointerConversion(ValueObject &valobj, ExecutionContextScope &ctx) {
 
 llvm::Expected<lldb::ValueObjectSP>
 Interpreter::UnaryConversion(lldb::ValueObjectSP valobj) {
-  // Perform usual conversions for unary operators. At the moment this includes
-  // array-to-pointer and the integral promotion for eligible types.
   llvm::Expected<lldb::TypeSystemSP> type_system =
       GetTypeSystemFromCU(m_exe_ctx_scope);
   if (!type_system)

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -43,14 +43,14 @@ static CompilerType GetBasicType(lldb::TypeSystemSP type_system,
 }
 
 static lldb::ValueObjectSP
-ArrayToPointerConversion(lldb::ValueObjectSP valobj,
+ArrayToPointerConversion(ValueObject &valobj,
                          std::shared_ptr<ExecutionContextScope> ctx) {
-  uint64_t addr = valobj->GetLoadAddress();
+  uint64_t addr = valobj.GetLoadAddress();
   ExecutionContext exe_ctx;
   ctx->CalculateExecutionContext(exe_ctx);
   return ValueObject::CreateValueObjectFromAddress(
       "result", addr, exe_ctx,
-      valobj->GetCompilerType().GetArrayElementType(ctx.get()).GetPointerType(),
+      valobj.GetCompilerType().GetArrayElementType(ctx.get()).GetPointerType(),
       /* do_deref */ false);
 }
 
@@ -62,8 +62,8 @@ Interpreter::UnaryConversion(lldb::ValueObjectSP valobj) {
       GetTypeSystemFromCU(m_exe_ctx_scope);
   if (!type_system)
     return type_system.takeError();
+
   CompilerType in_type = valobj->GetCompilerType();
-  CompilerType result_type;
   if (valobj->IsBitfield()) {
     // Promote bitfields. If `int` can represent the bitfield value, it is
     // converted to `int`. Otherwise, if `unsigned int` can represent it, it
@@ -100,7 +100,7 @@ Interpreter::UnaryConversion(lldb::ValueObjectSP valobj) {
   }
 
   if (in_type.IsArrayType())
-    valobj = ArrayToPointerConversion(valobj, m_exe_ctx_scope);
+    valobj = ArrayToPointerConversion(*valobj, m_exe_ctx_scope);
 
   if (valobj->GetCompilerType().IsInteger() ||
       valobj->GetCompilerType().IsUnscopedEnumerationType()) {

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -54,7 +54,10 @@ ArrayToPointerConversion(ValueObject &valobj, ExecutionContextScope &ctx) {
 }
 
 llvm::Expected<lldb::ValueObjectSP>
-Interpreter::UnaryConversion(lldb::ValueObjectSP valobj) {
+Interpreter::UnaryConversion(lldb::ValueObjectSP valobj, uint32_t location) {
+  if (!valobj)
+    return llvm::make_error<DILDiagnosticError>(m_expr, "invalid value object",
+                                                location);
   llvm::Expected<lldb::TypeSystemSP> type_system =
       GetTypeSystemFromCU(m_exe_ctx_scope);
   if (!type_system)
@@ -311,7 +314,8 @@ Interpreter::Visit(const UnaryOpNode *node) {
       if (error.Fail())
         return error.ToError();
     }
-    llvm::Expected<lldb::ValueObjectSP> conv_op = UnaryConversion(operand);
+    llvm::Expected<lldb::ValueObjectSP> conv_op =
+        UnaryConversion(operand, node->GetOperand()->GetLocation());
     if (!conv_op)
       return conv_op;
     operand = *conv_op;
@@ -340,7 +344,8 @@ Interpreter::Visit(const UnaryOpNode *node) {
       if (error.Fail())
         return error.ToError();
     }
-    llvm::Expected<lldb::ValueObjectSP> conv_op = UnaryConversion(operand);
+    llvm::Expected<lldb::ValueObjectSP> conv_op =
+        UnaryConversion(operand, node->GetOperand()->GetLocation());
     if (!conv_op)
       return conv_op;
     operand = *conv_op;

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -43,14 +43,13 @@ static CompilerType GetBasicType(lldb::TypeSystemSP type_system,
 }
 
 static lldb::ValueObjectSP
-ArrayToPointerConversion(ValueObject &valobj,
-                         std::shared_ptr<ExecutionContextScope> ctx) {
+ArrayToPointerConversion(ValueObject &valobj, ExecutionContextScope &ctx) {
   uint64_t addr = valobj.GetLoadAddress();
   ExecutionContext exe_ctx;
-  ctx->CalculateExecutionContext(exe_ctx);
+  ctx.CalculateExecutionContext(exe_ctx);
   return ValueObject::CreateValueObjectFromAddress(
       "result", addr, exe_ctx,
-      valobj.GetCompilerType().GetArrayElementType(ctx.get()).GetPointerType(),
+      valobj.GetCompilerType().GetArrayElementType(&ctx).GetPointerType(),
       /* do_deref */ false);
 }
 
@@ -100,7 +99,7 @@ Interpreter::UnaryConversion(lldb::ValueObjectSP valobj) {
   }
 
   if (in_type.IsArrayType())
-    valobj = ArrayToPointerConversion(*valobj, m_exe_ctx_scope);
+    valobj = ArrayToPointerConversion(*valobj, *m_exe_ctx_scope);
 
   if (valobj->GetCompilerType().IsInteger() ||
       valobj->GetCompilerType().IsUnscopedEnumerationType()) {

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -95,7 +95,8 @@ ASTNodeUP DILParser::ParseExpression() { return ParseUnaryExpression(); }
 //    "*"
 //
 ASTNodeUP DILParser::ParseUnaryExpression() {
-  if (CurToken().IsOneOf({Token::amp, Token::star})) {
+  if (CurToken().IsOneOf(
+          {Token::amp, Token::star, Token::minus, Token::plus})) {
     Token token = CurToken();
     uint32_t loc = token.GetLocation();
     m_dil_lexer.Advance();
@@ -107,7 +108,12 @@ ASTNodeUP DILParser::ParseUnaryExpression() {
     case Token::amp:
       return std::make_unique<UnaryOpNode>(loc, UnaryOpKind::AddrOf,
                                            std::move(rhs));
-
+    case Token::minus:
+      return std::make_unique<UnaryOpNode>(loc, UnaryOpKind::Minus,
+                                           std::move(rhs));
+    case Token::plus:
+      return std::make_unique<UnaryOpNode>(loc, UnaryOpKind::Plus,
+                                           std::move(rhs));
     default:
       llvm_unreachable("invalid token kind");
     }

--- a/lldb/source/ValueObject/DILParser.cpp
+++ b/lldb/source/ValueObject/DILParser.cpp
@@ -93,6 +93,8 @@ ASTNodeUP DILParser::ParseExpression() { return ParseUnaryExpression(); }
 //  unary_operator:
 //    "&"
 //    "*"
+//    "+"
+//    "-"
 //
 ASTNodeUP DILParser::ParseUnaryExpression() {
   if (CurToken().IsOneOf(

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/Makefile
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -19,27 +19,30 @@ class TestFrameVarDILArithmetic(TestBase):
 
         self.runCmd("settings set target.experimental.use-DIL true")
 
-        # Check unary
+        # Check unary results and integral promotion
         self.expect_var_path("+0", value="0")
         self.expect_var_path("-0", value="0")
         self.expect_var_path("+1", value="1")
         self.expect_var_path("-1", value="-1")
-        self.expect_var_path("s", value="10")
-        self.expect_var_path("+s", value="10")
-        self.expect_var_path("-s", value="-10")
-        self.expect_var_path("us", value="1")
-        self.expect_var_path("-us", value="-1")
+        self.expect_var_path("-9223372036854775808", value="9223372036854775808")
+        self.expect_var_path("s", value="10", type="short")
+        self.expect_var_path("+s", value="10", type="int")
+        self.expect_var_path("-s", value="-10", type="int")
+        self.expect_var_path("+us", value="1", type="int")
+        self.expect_var_path("-us", value="-1", type="int")
         self.expect_var_path("+0.0", value="0")
         self.expect_var_path("-0.0", value="-0")
-        self.expect_var_path("-9223372036854775808", value="9223372036854775808")
-        self.expect_var_path("+array", type="int *")
         self.expect_var_path("+enum_one", value="1")
         self.expect_var_path("-enum_one", value="-1")
+        self.expect_var_path("+wchar", value="1")
+        self.expect_var_path("+char16", value="2")
+        self.expect_var_path("+char32", value="3")
         self.expect_var_path("-bitfield.a", value="-1", type="int")
         self.expect_var_path("+bitfield.a", value="1", type="int")
         self.expect_var_path("+bitfield.b", value="2", type="int")
         self.expect_var_path("+bitfield.c", value="3", type="unsigned int")
         self.expect_var_path("+bitfield.d", value="4", type="uint64_t")
+        self.expect_var_path("+array", type="int *")
         self.expect_var_path("+p", type="int *")
         self.expect(
             "frame var -- '-p'",

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -32,6 +32,10 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect_var_path("+0.0", value="0")
         self.expect_var_path("-0.0", value="-0")
         self.expect_var_path("-9223372036854775808", value="9223372036854775808")
+        self.expect_var_path("+array", type="int *")
+        self.expect_var_path("+enum_one", value="1")
+        self.expect_var_path("-enum_one", value="4294967295") # TODO: fix
+        self.expect_var_path("+bf.a", value="7")
         self.expect_var_path("+p", type="int *")
         self.expect(
             "frame var -- '-p'",

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -34,7 +34,7 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect_var_path("-9223372036854775808", value="9223372036854775808")
         self.expect_var_path("+array", type="int *")
         self.expect_var_path("+enum_one", value="1")
-        self.expect_var_path("-enum_one", value="4294967295") # TODO: fix
+        self.expect_var_path("-enum_one", value="-1")
         self.expect_var_path("+bf.a", value="7")
         self.expect_var_path("+p", type="int *")
         self.expect(

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -1,0 +1,40 @@
+"""
+Test DIL arithmetic.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestFrameVarDILArithmetic(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_arithmetic(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.runCmd("settings set target.experimental.use-DIL true")
+
+        # Check unary
+        self.expect_var_path("+0", value="0")
+        self.expect_var_path("-0", value="0")
+        self.expect_var_path("+1", value="1")
+        self.expect_var_path("-1", value="-1")
+        self.expect_var_path("s", value="10")
+        self.expect_var_path("+s", value="10")
+        self.expect_var_path("-s", value="-10")
+        self.expect_var_path("us", value="1")
+        self.expect_var_path("-us", value="-1")
+        self.expect_var_path("+0.0", value="0")
+        self.expect_var_path("-0.0", value="-0")
+        self.expect_var_path("-9223372036854775808", value="9223372036854775808")
+        self.expect_var_path("+p", type="int *")
+        self.expect(
+            "frame var -- '-p'",
+            error=True,
+            substrs=["invalid argument type 'int *' to unary expression"],
+        )

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -35,7 +35,11 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect_var_path("+array", type="int *")
         self.expect_var_path("+enum_one", value="1")
         self.expect_var_path("-enum_one", value="-1")
-        self.expect_var_path("+bf.a", value="7")
+        self.expect_var_path("-bitfield.a", value="-1", type="int")
+        self.expect_var_path("+bitfield.a", value="1", type="int")
+        self.expect_var_path("+bitfield.b", value="2", type="int")
+        self.expect_var_path("+bitfield.c", value="3", type="unsigned int")
+        self.expect_var_path("+bitfield.d", value="4", type="uint64_t")
         self.expect_var_path("+p", type="int *")
         self.expect(
             "frame var -- '-p'",

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -44,11 +44,3 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect_var_path("+bitfield.b", value="2", type="int")
         self.expect_var_path("+bitfield.c", value="3", type="unsigned int")
         self.expect_var_path("+bitfield.d", value="4", type="uint64_t")
-        self.expect_var_path("+array", type="int *")
-        self.expect_var_path("+array_ref", type="int *")
-        self.expect_var_path("+ptr", type="int *")
-        self.expect(
-            "frame var -- '-ptr'",
-            error=True,
-            substrs=["invalid argument type 'int *' to unary expression"],
-        )

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/TestFrameVarDILArithmetic.py
@@ -30,6 +30,8 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect_var_path("-s", value="-10", type="int")
         self.expect_var_path("+us", value="1", type="int")
         self.expect_var_path("-us", value="-1", type="int")
+        self.expect_var_path("+ref", value="2", type="int")
+        self.expect_var_path("-ref", value="-2", type="int")
         self.expect_var_path("+0.0", value="0")
         self.expect_var_path("-0.0", value="-0")
         self.expect_var_path("+enum_one", value="1")
@@ -43,9 +45,10 @@ class TestFrameVarDILArithmetic(TestBase):
         self.expect_var_path("+bitfield.c", value="3", type="unsigned int")
         self.expect_var_path("+bitfield.d", value="4", type="uint64_t")
         self.expect_var_path("+array", type="int *")
-        self.expect_var_path("+p", type="int *")
+        self.expect_var_path("+array_ref", type="int *")
+        self.expect_var_path("+ptr", type="int *")
         self.expect(
-            "frame var -- '-p'",
+            "frame var -- '-ptr'",
             error=True,
             substrs=["invalid argument type 'int *' to unary expression"],
         )

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
@@ -1,3 +1,5 @@
+#include <cstdint>
+
 int main(int argc, char **argv) {
   short s = 10;
   unsigned short us = 1;
@@ -5,5 +7,13 @@ int main(int argc, char **argv) {
   int x = 2;
   int &r = x;
   int *p = &x;
+  int array[] = {1};
+  enum Enum { kZero, kOne } enum_one = kOne;
+
+  struct BitFieldStruct {
+    uint16_t a : 10;
+  };
+  BitFieldStruct bf = {7};
+
   return 0; // Set a breakpoint here
 }

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
@@ -11,9 +11,12 @@ int main(int argc, char **argv) {
   enum Enum { kZero, kOne } enum_one = kOne;
 
   struct BitFieldStruct {
-    uint16_t a : 10;
+    char a : 4;
+    int b : 32;
+    unsigned int c : 32;
+    uint64_t d : 48;
   };
-  BitFieldStruct bf = {7};
+  BitFieldStruct bitfield = {1, 2, 3, 4};
 
   return 0; // Set a breakpoint here
 }

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
@@ -1,0 +1,9 @@
+int main(int argc, char **argv) {
+  short s = 10;
+  unsigned short us = 1;
+
+  int x = 2;
+  int &r = x;
+  int *p = &x;
+  return 0; // Set a breakpoint here
+}

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
@@ -9,6 +9,9 @@ int main(int argc, char **argv) {
   int *p = &x;
   int array[] = {1};
   enum Enum { kZero, kOne } enum_one = kOne;
+  wchar_t wchar = 1;
+  char16_t char16 = 2;
+  char32_t char32 = 3;
 
   struct BitFieldStruct {
     char a : 4;

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
@@ -6,9 +6,6 @@ int main(int argc, char **argv) {
 
   int x = 2;
   int &ref = x;
-  int *ptr = &x;
-  int array[] = {1};
-  int(&array_ref)[1] = array;
   enum Enum { kZero, kOne } enum_one = kOne;
   wchar_t wchar = 1;
   char16_t char16 = 2;

--- a/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/Arithmetic/main.cpp
@@ -5,9 +5,10 @@ int main(int argc, char **argv) {
   unsigned short us = 1;
 
   int x = 2;
-  int &r = x;
-  int *p = &x;
+  int &ref = x;
+  int *ptr = &x;
   int array[] = {1};
+  int(&array_ref)[1] = array;
   enum Enum { kZero, kOne } enum_one = kOne;
   wchar_t wchar = 1;
   char16_t char16 = 2;

--- a/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/Makefile
+++ b/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/TestFrameVarDILPointerArithmetic.py
+++ b/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/TestFrameVarDILPointerArithmetic.py
@@ -1,0 +1,29 @@
+"""
+Test DIL pointer arithmetic.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestFrameVarDILPointerArithmetic(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_pointer_arithmetic(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", lldb.SBFileSpec("main.cpp")
+        )
+
+        self.runCmd("settings set target.experimental.use-DIL true")
+
+        self.expect_var_path("+array", type="int *")
+        self.expect_var_path("+array_ref", type="int *")
+        self.expect_var_path("+p_int0", type="int *")
+        self.expect(
+            "frame var -- '-p_int0'",
+            error=True,
+            substrs=["invalid argument type 'int *' to unary expression"],
+        )

--- a/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/main.cpp
@@ -1,8 +1,11 @@
+void stop() {}
+
 int main(int argc, char **argv) {
   int array[10];
   array[0] = 0;
   int (&array_ref)[10] = array;
   int *p_int0 = &array[0];
 
-  return 0; // Set a breakpoint here
+  stop(); // Set a breakpoint here
+  return 0;
 }

--- a/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/main.cpp
@@ -1,7 +1,7 @@
 int main(int argc, char **argv) {
   int array[10];
   array[0] = 0;
-  int(&array_ref)[10] = array;
+  int (&array_ref)[10] = array;
   int *p_int0 = &array[0];
 
   return 0; // Set a breakpoint here

--- a/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/main.cpp
+++ b/lldb/test/API/commands/frame/var-dil/expr/PointerArithmetic/main.cpp
@@ -1,0 +1,8 @@
+int main(int argc, char **argv) {
+  int array[10];
+  array[0] = 0;
+  int(&array_ref)[10] = array;
+  int *p_int0 = &array[0];
+
+  return 0; // Set a breakpoint here
+}


### PR DESCRIPTION
This patch adds unary nodes plus and minus, and introduces unary type conversions and integral promotion.