### PR TITLE
[clang] Update typechecking of builtin elementwise ternary math operators

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -179,10 +179,6 @@ Non-comprehensive list of changes in this release
   Currently, the use of ``__builtin_dedup_pack`` is limited to template arguments and base
   specifiers, it also must be used within a template context.
 
-- Builtin elementwise operators now accept vector arguments that have different
-  qualifiers on their elements. For example, vector of 4 ``const float`` values
-  and vector of 4 ``float`` values.
-
 
 New Compiler Flags
 ------------------
@@ -270,6 +266,9 @@ Bug Fixes in This Version
   calls another function that requires target features not enabled in the caller. This
   prevents a fatal error in the backend.
 - Fixed scope of typedefs present inside a template class. (#GH91451)
+- Builtin elementwise operators now accept vector arguments that have different
+  qualifiers on their elements. For example, vector of 4 ``const float`` values
+  and vector of 4 ``float`` values. (#GH155620)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -268,7 +268,7 @@ Bug Fixes in This Version
 - Fixed scope of typedefs present inside a template class. (#GH91451)
 - Builtin elementwise operators now accept vector arguments that have different
   qualifiers on their elements. For example, vector of 4 ``const float`` values
-  and vector of 4 ``float`` values. (#GH155620)
+  and vector of 4 ``float`` values. (#GH155405)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -179,6 +179,10 @@ Non-comprehensive list of changes in this release
   Currently, the use of ``__builtin_dedup_pack`` is limited to template arguments and base
   specifiers, it also must be used within a template context.
 
+- Builtin elementwise operators now accept vector arguments that have different
+  qualifiers on their elements. For example, vector of 4 ``const float`` values
+  and vector of 4 ``float`` values.
+
 
 New Compiler Flags
 ------------------

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -15892,7 +15892,6 @@ static bool checkBuiltinVectorMathMixedEnums(Sema &S, Expr *LHS, Expr *RHS,
 /// types can make the vector types be considered not equal. For example,
 /// vector of 4 'const float' values vs vector of 4 'float' values.
 /// So we compare unqualified types of their elements and number of elements.
-/// See GitHub issue #155405.
 static bool checkBuiltinVectorMathArgTypes(Sema &SemaRef,
                                            ArrayRef<Expr *> Args) {
   assert(!Args.empty() && "Should have at least one argument.");

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -15895,7 +15895,7 @@ static bool checkBuiltinVectorMathMixedEnums(Sema &S, Expr *LHS, Expr *RHS,
 /// See GitHub issue #155405.
 static bool checkBuiltinVectorMathArgTypes(Sema &SemaRef,
                                            ArrayRef<Expr *> Args) {
-  assert(Args.size() > 0 && "Should have at least one argument.");
+  assert(!Args.empty() && "Should have at least one argument.");
 
   Expr *Arg0 = Args.front();
   QualType Ty0 = Arg0->getType();

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -15894,10 +15894,10 @@ static bool checkBuiltinVectorMathMixedEnums(Sema &S, Expr *LHS, Expr *RHS,
 /// So we compare unqualified types of their elements and number of elements.
 /// See GitHub issue #155405.
 static bool checkBuiltinVectorMathArgTypes(Sema &SemaRef, unsigned NumArgs,
-                                           Expr *Args[]) {
+                                           ArrayRef<Expr *> Args) {
   assert(NumArgs > 0 && "Should have at least one argument.");
 
-  auto EmitError = [&](int I) {
+  auto EmitError = [&](unsigned I) {
     SemaRef.Diag(Args[0]->getBeginLoc(),
                  diag::err_typecheck_call_different_arg_types)
         << Args[0]->getType() << Args[I]->getType();
@@ -15907,7 +15907,7 @@ static bool checkBuiltinVectorMathArgTypes(Sema &SemaRef, unsigned NumArgs,
 
   // Compare scalar types.
   if (!Ty0->isVectorType()) {
-    for (unsigned I = 1; I < NumArgs; ++I)
+    for (unsigned I = 1; I != NumArgs; ++I)
       if (!SemaRef.Context.hasSameUnqualifiedType(Ty0, Args[I]->getType())) {
         EmitError(I);
         return true;
@@ -15918,7 +15918,7 @@ static bool checkBuiltinVectorMathArgTypes(Sema &SemaRef, unsigned NumArgs,
 
   // Compare vector types.
   const auto *Vec0 = Ty0->castAs<VectorType>();
-  for (unsigned I = 1; I < NumArgs; ++I) {
+  for (unsigned I = 1; I != NumArgs; ++I) {
     QualType TyI = Args[I]->getType();
     if (!TyI->isVectorType()) {
       EmitError(I);

--- a/clang/test/Sema/builtins-elementwise-math.c
+++ b/clang/test/Sema/builtins-elementwise-math.c
@@ -5,6 +5,7 @@ typedef double double4 __attribute__((ext_vector_type(4)));
 typedef float float2 __attribute__((ext_vector_type(2)));
 typedef float float3 __attribute__((ext_vector_type(3)));
 typedef float float4 __attribute__((ext_vector_type(4)));
+typedef const float cfloat4 __attribute__((ext_vector_type(4)));
 
 typedef int int2 __attribute__((ext_vector_type(2)));
 typedef int int3 __attribute__((ext_vector_type(3)));
@@ -1330,14 +1331,30 @@ void test_builtin_elementwise_fsh(int i32, int2 v2i32, short i16, int3 v3i32,
     // expected-error@-1 {{arguments are of different types ('int3' (vector of 3 'int' values) vs 'int2' (vector of 2 'int' values))}}
 }
 
+// Tests corresponding to GitHub issues #141397 and #155405.
+// Type mismatch error when 'builtin-elementwise-math' arguments have
+// different qualifiers, this should be well-formed.
 typedef struct {
   float3 b;
 } struct_float3;
-// This example uncovered a bug #141397 :
-// Type mismatch error when 'builtin-elementwise-math' arguments have different qualifiers, this should be well-formed
+
 float3 foo(float3 a,const struct_float3* hi) {
   float3 b = __builtin_elementwise_max((float3)(0.0f), a);
   return __builtin_elementwise_pow(b, hi->b.yyy);
+}
+
+float3 baz(float3 a, const struct_float3* hi) {
+  return __builtin_elementwise_fma(a, a, hi->b);
+}
+
+cfloat4 qux(cfloat4 x, float4 y, float4 z) {
+  float a = __builtin_elementwise_fma(x[0],y[0],z[0]);
+  return __builtin_elementwise_fma(x,y,z);
+}
+
+cfloat4 quux(cfloat4 x, float4 y) {
+  float a = __builtin_elementwise_pow(x[0],y[0]);
+  return __builtin_elementwise_pow(x,y);
 }
 
 void test_builtin_elementwise_ctlz(int i32, int2 v2i32, short i16,


### PR DESCRIPTION
Fixes #155405

For scalars we directly compare their unqualified types. But even if we compare unqualified vector types, a difference in qualifiers in the element types can make the vector types be considered not equal. For example, vector of 4 'const float' values vs vector of 4 'float' values. So we compare unqualified types of their elements and number of elements.

/cc @tbaederr 