### PR TITLE
Revert "[ADT] Deprecate the redirection from SmallSet to SmallPtrSet (Take 2) (#155078)

### DIFF
--- a/llvm/include/llvm/ADT/SmallSet.h
+++ b/llvm/include/llvm/ADT/SmallSet.h
@@ -268,17 +268,8 @@ private:
 
 /// If this set is of pointer values, transparently switch over to using
 /// SmallPtrSet for performance.
-///
-/// We use this middleman class DeprecatedSmallSet so that the deprecation
-/// warning works.  Placing LLVM_DEPRECATED just before SmallSet below won't
-/// work.
-template <typename PointerType, unsigned N>
-class LLVM_DEPRECATED("Use SmallPtrSet instead", "SmallPtrSet")
-    DeprecatedSmallSet : public SmallPtrSet<PointerType, N> {};
-
 template <typename PointeeType, unsigned N>
-class SmallSet<PointeeType *, N> : public DeprecatedSmallSet<PointeeType *, N> {
-};
+class SmallSet<PointeeType *, N> : public SmallPtrSet<PointeeType *, N> {};
 
 /// Equality comparison for SmallSet.
 ///


### PR DESCRIPTION
This reverts commit 9b493dcad25941911af94bd6a63fea5fb187b870.

There are hundreds of warnings when building LLVM/Clang because of this right now. See the original PR for the detailed issues.

Also revert the follow-up fix "[ADT] Fix redirection of SmallSet to SmallPtrSet (#155117)" This reverts commit 3ca1ca4301703ceadd0ab9c0b156bd6c0a3af7ec.