### PR TITLE
[BOLT] Remove shell requirements from several tests

### DIFF
--- a/bolt/test/X86/double-jump.test
+++ b/bolt/test/X86/double-jump.test
@@ -1,15 +1,11 @@
 ## Test the double jump removal peephole.
 
-## This test has commands that rely on shell capabilities that won't execute
-## correctly on Windows e.g. subshell execution
-REQUIRES: shell
-
 RUN: %clangxx %cxxflags %p/Inputs/double_jump.cpp -o %t.exe
-RUN: (llvm-bolt %t.exe --peepholes=double-jumps \
-RUN:   --eliminate-unreachable -o %t 2>&1 \
-RUN:   && llvm-objdump -d %t --print-imm-hex --no-show-raw-insn) | FileCheck %s
+RUN: llvm-bolt %t.exe --peepholes=double-jumps \
+RUN:   --eliminate-unreachable -o %t | FileCheck --check-prefix CHECK-BOLT %s
+RUN: llvm-objdump -d %t --print-imm-hex --no-show-raw-insn | FileCheck %s
 
-CHECK: BOLT-INFO: Peephole: 1 double jumps patched.
+CHECK-BOLT: BOLT-INFO: Peephole: 1 double jumps patched.
 
 CHECK: <_Z3foom>:
 CHECK-NEXT: pushq %rbp

--- a/bolt/test/X86/jmp-optimization.test
+++ b/bolt/test/X86/jmp-optimization.test
@@ -1,10 +1,7 @@
 ## Tests the optimization of functions that just do a tail call in the beginning.
 
-## This test has commands that rely on shell capabilities that won't execute
-## correctly on Windows e.g. unsupported parameter expansion
-REQUIRES: shell
-
-RUN: %clangxx %cxxflags -O2 %S/Inputs/jmp_opt{,2,3}.cpp -o %t
+RUN: %clangxx %cxxflags -O2 %S/Inputs/jmp_opt.cpp %S/Inputs/jmp_opt2.cpp \
+RUN:   %S/Inputs/jmp_opt3.cpp -o %t
 RUN: llvm-bolt -inline-small-functions %t -o %t.bolt
 RUN: llvm-objdump -d %t.bolt --print-imm-hex | FileCheck %s
 

--- a/bolt/test/X86/jump-table-icp.test
+++ b/bolt/test/X86/jump-table-icp.test
@@ -4,11 +4,7 @@ RUN: link_fdata %p/Inputs/jump_table_icp.s %t.o %t.fdata --nmtool llvm-nm
 RUN: llvm-strip --strip-unneeded %t.o
 RUN: %clang %cflags -no-pie %t.o -o %t.exe -Wl,-q
 
-## This test has commands that rely on shell capabilities that won't execute
-## correctly on Windows e.g. subshell execution
-REQUIRES: shell
-
-RUN: (llvm-bolt %t.exe --data %t.fdata -o %t --relocs \
+RUN: llvm-bolt %t.exe --data %t.fdata -o %t --relocs \
 RUN:   --reorder-blocks=cache --split-functions --split-all-cold \
 RUN:   --use-gnu-stack --dyno-stats --indirect-call-promotion=jump-tables \
 RUN:   --print-icp -v=0 \
@@ -16,8 +12,8 @@ RUN:   --enable-bat --print-cache-metrics \
 RUN:   --icp-jt-remaining-percent-threshold=10 \
 RUN:   --icp-jt-total-percent-threshold=2 \
 RUN:   --indirect-call-promotion-topn=1 \
-RUN:   --icp-jump-tables-targets --align-functions-max-bytes=7 2>&1 && \
-RUN:   llvm-objdump -d %t --print-imm-hex) | FileCheck %s
+RUN:   --icp-jump-tables-targets --align-functions-max-bytes=7 | FileCheck %s
+RUN: llvm-objdump -d %t --print-imm-hex | FileCheck --check-prefix CHECK-ASM %s
 
 BOLT-INFO: ICP total indirect callsites = 0
 BOLT-INFO: ICP total jump table callsites = 2
@@ -107,14 +103,14 @@ CHECK-NEXT:   Exec Count : 140
 CHECK:   Predecessors: .Ltmp{{.*}}, .LFT{{.*}}
 CHECK:   Successors: .Ltmp{{.*}} (mispreds: 0, count: 98)
 
-CHECK:     <_Z3inci>:
-CHECK:        	movq    0x{{.*}}(,%rax,8), %rax
-CHECK-NEXT:    cmpq    $0x{{.*}}, %rax
-CHECK-NEXT:    je {{.*}} <_Z3inci+0x{{.*}}>
-CHECK-NEXT:   	jmpq   *%rax
+CHECK-ASM:     <_Z3inci>:
+CHECK-ASM:        	movq    0x{{.*}}(,%rax,8), %rax
+CHECK-ASM-NEXT:    cmpq    $0x{{.*}}, %rax
+CHECK-ASM-NEXT:    je {{.*}} <_Z3inci+0x{{.*}}>
+CHECK-ASM-NEXT:   	jmpq   *%rax
 
-CHECK:     <_Z7inc_dupi>:
-CHECK:        	movq    0x{{.*}}(,%rax,8), %rax
-CHECK-NEXT:    cmpq $0x{{.*}}, %rax
-CHECK-NEXT:    je {{.*}} <_Z7inc_dupi+0x{{.*}}>
-CHECK-NEXT:   	jmpq   *%rax
+CHECK-ASM:     <_Z7inc_dupi>:
+CHECK-ASM:        	movq    0x{{.*}}(,%rax,8), %rax
+CHECK-ASM-NEXT:    cmpq $0x{{.*}}, %rax
+CHECK-ASM-NEXT:    je {{.*}} <_Z7inc_dupi+0x{{.*}}>
+CHECK-ASM-NEXT:   	jmpq   *%rax

--- a/bolt/test/X86/shrinkwrapping.test
+++ b/bolt/test/X86/shrinkwrapping.test
@@ -2,23 +2,21 @@
 ## shrink-wrapping when optimizing a function without
 ## frame pointers.
 
-## This test has commands that rely on shell capabilities that won't execute
-## correctly on Windows e.g. subshell execution to capture command output.
-REQUIRES: shell
-
 RUN: %clangxx %cxxflags -no-pie %S/Inputs/exc4sw.S -o %t.exe -Wl,-q
 RUN: llvm-bolt %t.exe -o %t --relocs --frame-opt=all \
 RUN:   --print-only=main --print-cfg \
 RUN:   --data=%p/Inputs/exc4sw.fdata --reorder-blocks=cache 2>&1 | \
 RUN:   FileCheck %s --check-prefix=CHECK-BOLT
 
-RUN: llvm-objdump --dwarf=frames %t.exe | grep -A20 -e \
-RUN:   `llvm-nm --numeric-sort %t.exe | grep main | tail -n 1 | \
-RUN:    cut -f1 -d' ' | tail -c9` 2>&1 | FileCheck %s --check-prefix=CHECK-INPUT
+RUN: llvm-nm --numeric-sort %t.exe | grep main | tail -n 1 | \
+RUN:    cut -f1 -d' ' | tail -c9 > %t.input_address
+RUN: llvm-objdump --dwarf=frames %t.exe | grep -A20 -f %t.input_address \
+RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-INPUT
 
-RUN: llvm-objdump --dwarf=frames %t | grep -A20 -e \
-RUN:   `llvm-nm --numeric-sort %t | grep main | tail -n 1 | cut -f1 -d' ' | \
-RUN:    tail -c9` 2>&1 | FileCheck %s --check-prefix=CHECK-OUTPUT
+RUN: llvm-nm --numeric-sort %t | grep main | tail -n 1 | \
+RUN:   cut -f1 -d' ' | tail -c9 > %t.output_address
+RUN: llvm-objdump --dwarf=frames %t | grep -A20 -f %t.output_address \
+RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-OUTPUT
 
 CHECK-BOLT: Extern Entry Count: 100
 CHECK-BOLT: Shrink wrapping moved 2 spills inserting load/stores and 0 spills inserting push/pops


### PR DESCRIPTION
This patch removes the shell requirement from four tests. This patched is aimed at enabling lit's internal shell for BOLT, which results in a ~15% test time improvement.

After this patch there are still two more unresolved tests that need to be fixed. That is tracked by #102693.

This is towards #102701.