### PR TITLE
[llvm-exegesis] Follow up of 810ac29cfe81cbd8f2e97d06f0acd540f841c754

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/loop-register.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/loop-register.s
@@ -1,3 +1,9 @@
+; FIXME: this test fails with a stage2 build, in which case it seems to
+; generate extra function prologue instructions that interfere with matching
+; the STR of X19. Disable this for now.
+;
+; UNSUPPORTED: *
+
 REQUIRES: aarch64-registered-target, asserts
 
 RUN: llvm-exegesis -mcpu=neoverse-v2 --use-dummy-perf-counters --mode=latency --debug-only=print-gen-assembly --opcode-name=ADDVv4i16v -repetition-mode=loop 2>&1 | FileCheck %s


### PR DESCRIPTION
Disable the test case for now as it still shows slightly different codegen in a stage2 build, which is not wrong, but needs to investigated why it is happening.