### PR TITLE
[libc++][AIX] Fixup problems with ABI list checking

### DIFF
--- a/libcxx/lib/abi/CMakeLists.txt
+++ b/libcxx/lib/abi/CMakeLists.txt
@@ -16,6 +16,9 @@ function(cxx_abi_list_identifier result triple abi_library abi_version unstable 
   elseif("${triple}" MATCHES "freebsd")
     # Ignore the major and minor versions of freebsd targets.
     string(REGEX REPLACE "freebsd[0-9]+\\.[0-9]+" "freebsd" triple "${triple}")
+  elseif("${triple}" MATCHES "aix")
+    # Ignore the V.R.M.F version string of aix targets.
+    string(REGEX REPLACE "aix[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+" "aix" triple  "${triple}")
   endif()
   list(APPEND abi_properties "${triple}")
   list(APPEND abi_properties "${abi_library}")
@@ -45,6 +48,7 @@ if (CMAKE_CXX_COMPILER_TARGET)
 else()
   set(triple "${LLVM_DEFAULT_TARGET_TRIPLE}")
 endif()
+
 cxx_abi_list_identifier(abi_list_identifier
   "${triple}"
   "${LIBCXX_CXX_ABI}"

--- a/libcxx/lib/abi/CMakeLists.txt
+++ b/libcxx/lib/abi/CMakeLists.txt
@@ -18,7 +18,7 @@ function(cxx_abi_list_identifier result triple abi_library abi_version unstable 
     string(REGEX REPLACE "freebsd[0-9]+\\.[0-9]+" "freebsd" triple "${triple}")
   elseif("${triple}" MATCHES "aix")
     # Ignore the V.R.M.F version string of aix targets.
-    string(REGEX REPLACE "aix[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+" "aix" triple  "${triple}")
+    string(REGEX REPLACE "aix[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+" "aix" triple "${triple}")
   endif()
   list(APPEND abi_properties "${triple}")
   list(APPEND abi_properties "${abi_library}")

--- a/libcxx/lib/abi/CMakeLists.txt
+++ b/libcxx/lib/abi/CMakeLists.txt
@@ -48,7 +48,6 @@ if (CMAKE_CXX_COMPILER_TARGET)
 else()
   set(triple "${LLVM_DEFAULT_TARGET_TRIPLE}")
 endif()
-
 cxx_abi_list_identifier(abi_list_identifier
   "${triple}"
   "${LIBCXX_CXX_ABI}"

--- a/libcxx/utils/libcxx/sym_check/util.py
+++ b/libcxx/utils/libcxx/sym_check/util.py
@@ -95,7 +95,7 @@ def is_xcoff_or_big_ar(filename):
     with open(filename, "rb") as f:
         magic_bytes = f.read(7)
     return (
-        magic_bytes[:4] in [b"\x01DF", b"\x01F7"]  # XCOFF32  # XCOFF64
+        magic_bytes[:2] in [b"\x01\xDF", b"\x01\xF7"]  # XCOFF32  # XCOFF64
         or magic_bytes == b"<bigaf>"
     )
 


### PR DESCRIPTION
There are some problems with our ABI list checking exposed by recent compiler/cmake upgrades.

- For symcheck, there are typos in how XCOFF magic are defined, we intended the second two digits to be a hex value, but our syntax doesn't say that. Thus this will never match a valid XCOFF file.
- AIX triples can have version numbers. Those need to be discarded when looking for an libc++ ABI list, like we do for other targets.