### PR TITLE
[flang-rt] Add the ability to have user supplied callback functions to further customize the runtime environment.

### DIFF
--- a/flang-rt/include/flang-rt/runtime/environment.h
+++ b/flang-rt/include/flang-rt/runtime/environment.h
@@ -48,20 +48,9 @@ struct ExecutionEnvironment {
   void Configure(int argc, const char *argv[], const char *envp[],
       const EnvironmentDefaultList *envDefaults);
 
-  // Optional callback routines to be invoked pre and post
-  // execution environment setup.
-  // RTNAME(RegisterConfigureEnv) will return true if callback
-  // function(s) is(are) successfully added to small array of
-  // pointers.  False if more than nConfigEnvCallback registrations
-  // for either pre or post functions.
-
+  // Maximum number of registered pre and post ExecutionEnvironment::Configure()
+  // callback functions.
   static constexpr int nConfigEnvCallback{8};
-  int nPreConfigEnvCallback{0};
-  void (*PreConfigEnvCallback[nConfigEnvCallback])(int, const char *[],
-      const char *[], const EnvironmentDefaultList *){nullptr};
-  int nPostConfigEnvCallback{0};
-  void (*PostConfigEnvCallback[nConfigEnvCallback])(int, const char *[],
-      const char *[], const EnvironmentDefaultList *){nullptr};
 
   const char *GetEnv(
       const char *name, std::size_t name_length, const Terminator &terminator);

--- a/flang-rt/include/flang-rt/runtime/environment.h
+++ b/flang-rt/include/flang-rt/runtime/environment.h
@@ -11,8 +11,21 @@
 
 #include "flang/Common/optional.h"
 #include "flang/Decimal/decimal.h"
+#include "flang/Runtime/entry-names.h"
 
 struct EnvironmentDefaultList;
+
+// ExecutionEnvironment::Configure() allows for optional callback functions
+// to be run pre and post the core logic.
+// Most likely scenario is when a user supplied constructor function is
+// run prior to _QQmain calling RTNAME(ProgramStart)().
+
+extern "C" {
+void RTNAME(RegisterConfigureEnv)(void (*)(int, const char *[], const char *[],
+                                      const EnvironmentDefaultList *),
+    void (*)(
+        int, const char *[], const char *[], const EnvironmentDefaultList *));
+}
 
 namespace Fortran::runtime {
 
@@ -42,6 +55,14 @@ struct ExecutionEnvironment {
       ExecutionEnvironment(){};
   void Configure(int argc, const char *argv[], const char *envp[],
       const EnvironmentDefaultList *envDefaults);
+
+  // Optional callback routines to be invoked pre and post
+  // execution environment setup.
+  void (*PreConfigureEnv)(int, const char *[], const char *[],
+      const EnvironmentDefaultList *){nullptr};
+  void (*PostConfigureEnv)(int, const char *[], const char *[],
+      const EnvironmentDefaultList *){nullptr};
+
   const char *GetEnv(
       const char *name, std::size_t name_length, const Terminator &terminator);
 

--- a/flang-rt/include/flang-rt/runtime/environment.h
+++ b/flang-rt/include/flang-rt/runtime/environment.h
@@ -15,20 +15,6 @@
 
 struct EnvironmentDefaultList;
 
-#if 0
-// ExecutionEnvironment::Configure() allows for optional callback functions
-// to be run pre and post the core logic.
-// Most likely scenario is when a user supplied constructor function is
-// run prior to _QQmain calling RTNAME(ProgramStart)().
-
-extern "C" {
-bool RTNAME(RegisterConfigureEnv)(void (*)(int, const char *[], const char *[],
-                                      const EnvironmentDefaultList *),
-    void (*)(
-        int, const char *[], const char *[], const EnvironmentDefaultList *));
-}
-#endif
-
 namespace Fortran::runtime {
 
 class Terminator;

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -29,6 +29,22 @@ RT_VAR_ATTRS ExecutionEnvironment executionEnvironment;
 RT_OFFLOAD_VAR_GROUP_END
 #endif // FLANG_RUNTIME_NO_GLOBAL_VAR_DEFS
 
+// Optional callback routines to be invoked pre and post execution
+// environment setup.
+// RTNAME(RegisterConfigureEnv) will return true if callback function(s)
+// is(are) successfully added to small array of pointers.  False if more
+// than nConfigEnvCallback registrations for either pre or post functions.
+
+static int nPreConfigEnvCallback{0};
+static void (*PreConfigEnvCallback[ExecutionEnvironment::nConfigEnvCallback])(
+    int, const char *[], const char *[], const EnvironmentDefaultList *){
+    nullptr};
+
+static int nPostConfigEnvCallback{0};
+static void (*PostConfigEnvCallback[ExecutionEnvironment::nConfigEnvCallback])(
+    int, const char *[], const char *[], const EnvironmentDefaultList *){
+    nullptr};
+
 static void SetEnvironmentDefaults(const EnvironmentDefaultList *envDefaults) {
   if (!envDefaults) {
     return;
@@ -82,7 +98,7 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
   if (0 != nPreConfigEnvCallback) {
     // Run an optional callback function after the core of the
     // ExecutionEnvironment() logic.
-    for (auto i = 0; i != nPreConfigEnvCallback; ++i) {
+    for (int i{0}; i != nPostConfigEnvCallback; ++i) {
       PreConfigEnvCallback[i](ac, av, env, envDefaults);
     }
   }
@@ -186,7 +202,7 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
   if (0 != nPostConfigEnvCallback) {
     // Run an optional callback function in reverse order of registration
     // after the core of the ExecutionEnvironment() logic.
-    for (auto i = 0; i != nPostConfigEnvCallback; ++i) {
+    for (int i{0}; i != nPostConfigEnvCallback; ++i) {
       PostConfigEnvCallback[i](ac, av, env, envDefaults);
     }
   }
@@ -279,21 +295,16 @@ bool RTNAME(RegisterConfigureEnv)(
   bool ret{true};
 
   if (nullptr != pre) {
-    if (executionEnvironment.nPreConfigEnvCallback <
-        executionEnvironment.nConfigEnvCallback) {
-      executionEnvironment
-          .PreConfigEnvCallback[executionEnvironment.nPreConfigEnvCallback++] =
-          pre;
+    if (nPreConfigEnvCallback < ExecutionEnvironment::nConfigEnvCallback) {
+      PreConfigEnvCallback[nPreConfigEnvCallback++] = pre;
     } else {
       ret = false;
     }
   }
 
   if (ret && nullptr != post) {
-    if (executionEnvironment.nPostConfigEnvCallback <
-        executionEnvironment.nConfigEnvCallback) {
-      executionEnvironment.PostConfigEnvCallback[executionEnvironment
-              .nPostConfigEnvCallback++] = post;
+    if (nPostConfigEnvCallback < ExecutionEnvironment::nConfigEnvCallback) {
+      PostConfigEnvCallback[nPostConfigEnvCallback++] = post;
     } else {
       ret = false;
     }

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -186,7 +186,7 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
   if (0 != nPostConfigEnvCallback) {
     // Run an optional callback function in reverse order of registration
     // after the core of the ExecutionEnvironment() logic.
-    for (auto i = nPostConfigEnvCallback - 1; i >= 0; --i) {
+    for (auto i = 0; i != nPostConfigEnvCallback; ++i) {
       PostConfigEnvCallback[i](ac, av, env, envDefaults);
     }
   }

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -98,7 +98,7 @@ void ExecutionEnvironment::Configure(int ac, const char *av[],
   if (0 != nPreConfigEnvCallback) {
     // Run an optional callback function after the core of the
     // ExecutionEnvironment() logic.
-    for (int i{0}; i != nPostConfigEnvCallback; ++i) {
+    for (int i{0}; i != nPreConfigEnvCallback; ++i) {
       PreConfigEnvCallback[i](ac, av, env, envDefaults);
     }
   }


### PR DESCRIPTION
Add the ability to have pre and post call back functions to ExecutionEnvironment::Configure() to allow further customization of the flang runtime environment (called from _FortranAStartProgam) in situations where either the desired features/functionality are proprietary or are too specific to be accepted by the flang community.

Example:
Custom constructor object linked with flang objects:
```
#include "flang-rt/runtime/environment.h"
#include "flang/Runtime/entry-names.h"
#include "flang/Runtime/extensions.h"

namespace Fortran::runtime {

// Do something specific to the flang runtime environment prior to the
// core logic of ExecutionEnvironment::Configure().
static void
CustomPreConfigureEnv(int argc, const char *argv[], const char *envp[],
                      const EnvironmentDefaultList *envDefaultList) {
  puts(__func__);
}

// Do something specific to the flang runtime environment after running the
// core logic of ExecutionEnvironment::Configure().
static void
CustomPostConfigureEnv(int argc, const char *argv[], const char *envp[],
                       const EnvironmentDefaultList *envDefaultList) {
  puts(__func__);
}

void __attribute__((constructor)) CustomInitCstor(void) {
  // Possibilities:
  // RTNAME(RegisterConfigureEnv)(&CustomPreConfigureEnv,
  // &CustomPostConfigureEnv); RTNAME(RegisterConfigureEnv)(nullptr,
  // &CustomPostConfigureEnv);
  RTNAME(RegisterConfigureEnv)(&CustomPreConfigureEnv, nullptr);
}
} // namespace Fortran::runtime
```


