### PR TITLE
[llvm][InstSimplify]: Increase the MaxRecurse limit to support deeper fold (icmp eq a, c1) | (icmp ult f(a), c2) to icmp ult f(a), c2.

### DIFF
--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -1933,13 +1933,16 @@ static Value *simplifyAndOrWithICmpEq(unsigned Opcode, Value *Op0, Value *Op1,
   // In the final case (Res == Absorber with inverted predicate), it is safe to
   // refine poison during simplification, but not undef. For simplicity always
   // disable undef-based folds here.
+  // Allow one extra recursion level for this speculative replace+simplify;
+  // because some folds require > MaxRecurse replacements to appear.
+  unsigned LocalMaxRecurse = MaxRecurse ? MaxRecurse + 1 : 1;
   if (Value *Res = simplifyWithOpReplaced(Op1, A, B, Q.getWithoutUndef(),
                                           /* AllowRefinement */ true,
-                                          /* DropFlags */ nullptr, MaxRecurse))
+                                          /* DropFlags */ nullptr, LocalMaxRecurse))
     return Simplify(Res);
   if (Value *Res = simplifyWithOpReplaced(Op1, B, A, Q.getWithoutUndef(),
                                           /* AllowRefinement */ true,
-                                          /* DropFlags */ nullptr, MaxRecurse))
+                                          /* DropFlags */ nullptr, LocalMaxRecurse))
     return Simplify(Res);
 
   return nullptr;

--- a/llvm/lib/Analysis/InstructionSimplify.cpp
+++ b/llvm/lib/Analysis/InstructionSimplify.cpp
@@ -1936,13 +1936,15 @@ static Value *simplifyAndOrWithICmpEq(unsigned Opcode, Value *Op0, Value *Op1,
   // Allow one extra recursion level for this speculative replace+simplify;
   // because some folds require > MaxRecurse replacements to appear.
   unsigned LocalMaxRecurse = MaxRecurse ? MaxRecurse + 1 : 1;
-  if (Value *Res = simplifyWithOpReplaced(Op1, A, B, Q.getWithoutUndef(),
-                                          /* AllowRefinement */ true,
-                                          /* DropFlags */ nullptr, LocalMaxRecurse))
+  if (Value *Res =
+          simplifyWithOpReplaced(Op1, A, B, Q.getWithoutUndef(),
+                                 /* AllowRefinement */ true,
+                                 /* DropFlags */ nullptr, LocalMaxRecurse))
     return Simplify(Res);
-  if (Value *Res = simplifyWithOpReplaced(Op1, B, A, Q.getWithoutUndef(),
-                                          /* AllowRefinement */ true,
-                                          /* DropFlags */ nullptr, LocalMaxRecurse))
+  if (Value *Res =
+          simplifyWithOpReplaced(Op1, B, A, Q.getWithoutUndef(),
+                                 /* AllowRefinement */ true,
+                                 /* DropFlags */ nullptr, LocalMaxRecurse))
     return Simplify(Res);
 
   return nullptr;

--- a/llvm/test/CodeGen/AMDGPU/select-constant-cttz.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-constant-cttz.ll
@@ -6,26 +6,11 @@ declare i32 @llvm.amdgcn.sffbh.i32(i32) nounwind readnone speculatable
 define amdgpu_kernel void @select_constant_cttz(ptr addrspace(1) noalias %out, ptr addrspace(1) nocapture readonly %arrayidx) nounwind {
 ; GCN-LABEL: select_constant_cttz:
 ; GCN:       ; %bb.0:
-; GCN-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
-; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_load_dword s2, s[2:3], 0x0
+; GCN-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; GCN-NEXT:    s_mov_b32 s3, 0xf000
-; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_lshr_b32 s4, 1, s2
-; GCN-NEXT:    s_cmp_lg_u32 s2, 0
-; GCN-NEXT:    s_ff1_i32_b32 s2, s4
-; GCN-NEXT:    s_cselect_b64 s[4:5], -1, 0
-; GCN-NEXT:    s_and_b64 s[6:7], s[4:5], exec
-; GCN-NEXT:    s_cselect_b32 s2, -1, s2
-; GCN-NEXT:    s_flbit_i32 s6, s2
-; GCN-NEXT:    s_sub_i32 s8, 31, s6
-; GCN-NEXT:    s_cmp_eq_u32 s2, 0
-; GCN-NEXT:    s_cselect_b64 s[6:7], -1, 0
-; GCN-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GCN-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-NEXT:    s_cselect_b32 s4, -1, s8
 ; GCN-NEXT:    s_mov_b32 s2, -1
-; GCN-NEXT:    v_mov_b32_e32 v0, s4
+; GCN-NEXT:    v_mov_b32_e32 v0, -1
+; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], 0
 ; GCN-NEXT:    s_endpgm
   %v    = load i32, ptr addrspace(1) %arrayidx, align 4
@@ -43,3 +28,4 @@ define amdgpu_kernel void @select_constant_cttz(ptr addrspace(1) noalias %out, p
 }
 
 !0 = !{i32 0, i32 33}
+


### PR DESCRIPTION
Close #143957.
alive2: https://alive2.llvm.org/ce/z/wc2PXT
godbolt: https://godbolt.org/z/o8nqYz577