### PR TITLE
[CI] Bump Linux Contaienr LLVM to 21.1.0

### DIFF
--- a/.github/workflows/containers/github-action-ci/Dockerfile
+++ b/.github/workflows/containers/github-action-ci/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/ubuntu:24.04 as base
 ENV LLVM_SYSROOT=/opt/llvm
 
 FROM base as stage1-toolchain
-ENV LLVM_VERSION=20.1.8
+ENV LLVM_VERSION=21.1.0
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Now that a new release has come out, we should bump the version of the toolchain in the container to keep up to date.