### PR TITLE
[clang] MicrosoftMangle: pick correct tagdecl for mangling tagkind

### DIFF
--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -3246,13 +3246,17 @@ void MicrosoftCXXNameMangler::mangleTagTypeKind(TagTypeKind TTK) {
 }
 void MicrosoftCXXNameMangler::mangleType(const EnumType *T, Qualifiers,
                                          SourceRange) {
-  mangleType(cast<TagType>(T)->getOriginalDecl()->getDefinitionOrSelf());
+  mangleType(cast<TagType>(T)->getOriginalDecl());
 }
 void MicrosoftCXXNameMangler::mangleType(const RecordType *T, Qualifiers,
                                          SourceRange) {
-  mangleType(cast<TagType>(T)->getOriginalDecl()->getDefinitionOrSelf());
+  mangleType(cast<TagType>(T)->getOriginalDecl());
 }
 void MicrosoftCXXNameMangler::mangleType(const TagDecl *TD) {
+  // MSVC chooses the tag kind of the definition if it exists, otherwise it
+  // always picks the first declaration.
+  const auto *Def = TD->getDefinition();
+  TD = Def ? Def : TD->getFirstDecl();
   mangleTagTypeKind(TD->getTagKind());
   mangleName(TD);
 }

--- a/clang/test/CodeGenCXX/mangle-ms-cxx11.cpp
+++ b/clang/test/CodeGenCXX/mangle-ms-cxx11.cpp
@@ -358,3 +358,42 @@ struct s { enum {}; enum {}; };
 // DBG-DAG: DW_TAG_enumeration_type{{.*}}identifier: ".?AW4<unnamed-type-$S3>@s@pr37723@@"
 s x;
 }
+
+namespace InconsistentTagKinds {
+  namespace t1 {
+    class A;
+    struct A;
+    void f(A*) {}
+    // CHECK-DAG: @"?f@t1@InconsistentTagKinds@@YAXPAVA@12@@Z"
+  } // namespace t1
+  namespace t2 {
+    struct A;
+    class A;
+    void f(A*) {}
+    // CHECK-DAG: @"?f@t2@InconsistentTagKinds@@YAXPAUA@12@@Z"
+  } // namespace t2
+  namespace t3 {
+    class A {};
+    struct A;
+    void f(A*) {}
+    // CHECK-DAG: @"?f@t3@InconsistentTagKinds@@YAXPAVA@12@@Z"
+  } // namespace t3
+  namespace t4 {
+    struct A {};
+    class A;
+    void f(A*) {}
+    // CHECK-DAG: @"?f@t4@InconsistentTagKinds@@YAXPAUA@12@@Z"
+  } // namespace t4
+  namespace t5 {
+    class A;
+    struct A {};
+    void f(A*) {}
+    // CHECK-DAG: @"?f@t5@InconsistentTagKinds@@YAXPAUA@12@@Z"
+  } // namespace t5
+  namespace t6 {
+    struct A;
+    class A {};
+    void f(A*) {}
+    // CHECK-DAG: @"?f@t6@InconsistentTagKinds@@YAXPAVA@12@@Z"
+  } // namespace t6
+} // namespace InconsistentTagKinds


### PR DESCRIPTION
This fixes a regression reported here: https://github.com/llvm/llvm-project/pull/147835#issuecomment-3225550458

Since this regression was never released, there are no release notes.