### PR TITLE
[flang] Downgrade an error to a warning for specific circumstances

### DIFF
--- a/flang/include/flang/Semantics/tools.h
+++ b/flang/include/flang/Semantics/tools.h
@@ -261,7 +261,7 @@ bool IsAccessible(const Symbol &, const Scope &);
 
 // Return an error if a symbol is not accessible from a scope
 std::optional<parser::MessageFormattedText> CheckAccessibleSymbol(
-    const Scope &, const Symbol &);
+    const Scope &, const Symbol &, bool inStructureConstructor = false);
 
 // Analysis of image control statements
 bool IsImageControlStmt(const parser::ExecutableConstruct &);

--- a/flang/lib/Semantics/expression.cpp
+++ b/flang/lib/Semantics/expression.cpp
@@ -2198,7 +2198,8 @@ MaybeExpr ExpressionAnalyzer::CheckStructureConstructor(
     }
     if (symbol) {
       const semantics::Scope &innermost{context_.FindScope(exprSource)};
-      if (auto msg{CheckAccessibleSymbol(innermost, *symbol)}) {
+      if (auto msg{CheckAccessibleSymbol(
+              innermost, *symbol, /*inStructureConstructor=*/true)}) {
         Say(exprSource, std::move(*msg));
       }
       if (checkConflicts) {

--- a/flang/test/Semantics/c_loc01.f90
+++ b/flang/test/Semantics/c_loc01.f90
@@ -66,3 +66,12 @@ module m
     purefun2 = 1
   end
 end module
+
+module m2
+  use iso_c_binding
+  ! In this context (structure constructor from intrinsic module being used directly
+  ! in another module), emit only a warning, since this module might have originally
+  ! been a module file that was converted back into Fortran.
+  !WARNING: PRIVATE name '__address' is accessible only within module '__fortran_builtins'
+  type(c_ptr) :: p = c_ptr(0)
+end


### PR DESCRIPTION
We emit an error on the component name in the structure constructor "__builtin_c_ptr(__address=0)", which is the value of "c_ptr_null()", because the component name "__address" is PRIVATE to an intrinsic module.  The error is specifically omitted, however, when the name appears in a module file, since it's what we emit for "c_ptr_null()" in initializers.

This patch carves out another exception -- downgrading the error to a warning -- for the case of a PRIVATE component name in a structure constructor from an intrinsic module when the structure constructor appears in a module.  This case arises when module files are being reprocessed as Fortran source in order to convert them to hermetic module files.