### PR TITLE
[llvm-debuginfo-analyzer][lit] Fix tests failing when X86 isn't available

### DIFF
--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_ranges.s
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/DW_AT_ranges.s
@@ -16,6 +16,8 @@
 # 12   return (int)my_var;
 # 13 }
 
+# REQUIRES: x86-registered-target        
+
 # RUN: llvm-mc %s -triple=i686-pc-linux -filetype=obj -o - | \
 # RUN: llvm-debuginfo-analyzer --attribute=all \
 # RUN:                         --print=all \

--- a/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/high_pc_exclusive.s
+++ b/llvm/test/tools/llvm-debuginfo-analyzer/DWARF/high_pc_exclusive.s
@@ -12,6 +12,8 @@
 # 8 }
 # 9
 
+# REQUIRES: x86-registered-target
+
 # RUN: llvm-mc %s -triple=i686-pc-linux -filetype=obj -o - | \
 # RUN: llvm-debuginfo-analyzer --attribute=all \
 # RUN:                         --print=all \


### PR DESCRIPTION
Need to require the target.

Fixes: https://github.com/llvm/llvm-project/pull/153318