### PR TITLE
[mlir] Fix node numbering order in SliceMatchers example

### DIFF
--- a/mlir/include/mlir/Query/Matcher/SliceMatchers.h
+++ b/mlir/include/mlir/Query/Matcher/SliceMatchers.h
@@ -36,7 +36,7 @@
 ///              9
 ///
 /// Assuming all local orders match the numbering order:
-///     {5, 7, 6, 8, 9}
+///     {1, 5, 6, 7, 8, 9}
 namespace mlir::query::matcher {
 
 template <typename Matcher>


### PR DESCRIPTION
After reviewing this again, it looks like I missed some nodes. Node 7 uses node 1 and 5 as well.