### PR TITLE
[CMake][AIX] Enable CMP0182: Create shared library archives by default

### DIFF
--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -45,5 +45,5 @@ endif()
 # CMP0182: Create shared library archives by default on AIX.
 # New in CMake 4.0: https://cmake.org/cmake/help/latest/policy/CMP0182.html
 if(POLICY CMP0182)
-    cmake_policy(SET CMP0182 NEW)
+  cmake_policy(SET CMP0182 NEW)
 endif()

--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -41,3 +41,9 @@ if(POLICY CMP0156)
     cmake_policy(SET CMP0179 NEW)
   endif()
 endif()
+
+# CMP0182: Create shared library archives by default on AIX.
+# New in CMake 4.0: https://cmake.org/cmake/help/latest/policy/CMP0182.html
+if(POLICY CMP0182)
+    cmake_policy(SET CMP0182 NEW)
+endif()


### PR DESCRIPTION
On AIX we prefer to create shared libraries as shared library archives (i.e. we archive the shared object in a big AR archive) as this is the standard format on the platform.

There is now a CMake policy that allows us to do this by default, so opt-in to that behaviour.