### PR TITLE
[Clang] Update ReleaseNotes with ThreadSafetyAnalysis changes

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -246,6 +246,10 @@ Improvements to Clang's diagnostics
   decorated with the ``alloc_size`` attribute don't allocate enough space for
   the target pointer type.
 
+- The :doc:`ThreadSafetyAnalysis` attributes ``ACQUIRED_BEFORE(...)`` and
+  ``ACQUIRED_AFTER(...)`` have been moved to the stable feature set and no
+  longer require ``-Wthread-safety-beta`` to be used.
+
 Improvements to Clang's time-trace
 ----------------------------------
 


### PR DESCRIPTION
Note that ACQUIRED_BEFORE(...) and ACQUIRED_AFTER(...) no longer require -Wthread-safety-beta.

Follow-up from https://github.com/llvm/llvm-project/pull/152853.