### PR TITLE
[lldb] Add a simplified syntax for underlying command options (NFC)

### DIFF
--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -741,35 +741,32 @@ let Command = "process launch" in {
 }
 
 let Command = "process attach" in {
-  def process_attach_continue
-      : Option<"continue", "c">,
-        Desc<"Immediately ${ansi.underline}c${ansi.normal}ontinue the process "
-             "once attached.">;
-  def process_attach_plugin
-      : Option<"plugin", "P">,
-        Arg<"Plugin">,
-        Desc<"Name of the process ${ansi.underline}p${ansi.normal}lugin you "
-             "want to use.">;
+  def process_attach_continue : Option<"continue", "c">,
+                                Desc<"Immediately ${c}ontinue the process "
+                                     "once attached.">;
+  def process_attach_plugin : Option<"plugin", "P">,
+                              Arg<"Plugin">,
+                              Desc<"Name of the process ${p}lugin you "
+                                   "want to use.">;
   def process_attach_pid : Option<"pid", "p">,
                            Group<1>,
                            Arg<"Pid">,
-                           Desc<"The ${ansi.underline}p${ansi.normal}rocess ID "
+                           Desc<"The ${p}rocess ID "
                                 "of an existing process to attach to.">;
   def process_attach_name : Option<"name", "n">,
                             Group<2>,
                             Arg<"ProcessName">,
-                            Desc<"The ${ansi.underline}n${ansi.normal}ame of "
+                            Desc<"The ${n}ame of "
                                  "the process to attach to.">;
   def process_attach_include_existing
       : Option<"include-existing", "i">,
         Group<2>,
-        Desc<"${ansi.underline}I${ansi.normal}nclude existing processes when "
+        Desc<"${I}nclude existing processes when "
              "doing attach -w.">;
-  def process_attach_waitfor
-      : Option<"waitfor", "w">,
-        Group<2>,
-        Desc<"${ansi.underline}W${ansi.normal}ait for the process with "
-             "<process-name> to launch.">;
+  def process_attach_waitfor : Option<"waitfor", "w">,
+                               Group<2>,
+                               Desc<"${W}ait for the process with "
+                                    "<process-name> to launch.">;
 }
 
 let Command = "process continue" in {

--- a/lldb/utils/TableGen/LLDBOptionDefEmitter.cpp
+++ b/lldb/utils/TableGen/LLDBOptionDefEmitter.cpp
@@ -34,8 +34,10 @@ inline std::string underline(llvm::StringRef Str) {
     Stream << OpeningHead;
 
     // No opening brace: we're done.
-    if (OpeningHead == Str && OpeningTail.empty())
+    if (OpeningHead == Str)
       break;
+
+    assert(!OpeningTail.empty());
 
     // Find the closing brace.
     std::tie(ClosingHead, ClosingTail) = OpeningTail.split('}');

--- a/lldb/utils/TableGen/LLDBOptionDefEmitter.cpp
+++ b/lldb/utils/TableGen/LLDBOptionDefEmitter.cpp
@@ -23,6 +23,31 @@ using namespace llvm;
 using namespace lldb_private;
 
 namespace {
+/// Parses curly braces and replaces them with ANSI underline formatting.
+inline std::string underline(llvm::StringRef Str) {
+  llvm::StringRef OpeningHead, OpeningTail, ClosingHead, ClosingTail;
+  std::string Result;
+  llvm::raw_string_ostream Stream(Result);
+  while (!Str.empty()) {
+    // Find the opening brace.
+    std::tie(OpeningHead, OpeningTail) = Str.split("${");
+    Stream << OpeningHead;
+
+    // No opening brace: we're done.
+    if (OpeningHead == Str && OpeningTail.empty())
+      break;
+
+    // Find the closing brace.
+    std::tie(ClosingHead, ClosingTail) = OpeningTail.split('}');
+    assert(!ClosingTail.empty() &&
+           "unmatched curly braces in command option description");
+
+    Stream << "${ansi.underline}" << ClosingHead << "${ansi.normal}";
+    Str = ClosingTail;
+  }
+  return Result;
+}
+
 struct CommandOption {
   std::vector<std::string> GroupsArg;
   bool Required = false;
@@ -68,7 +93,7 @@ struct CommandOption {
       Completions = Option->getValueAsListOfStrings("Completions");
 
     if (auto D = Option->getValue("Description"))
-      Description = D->getValue()->getAsUnquotedString();
+      Description = underline(D->getValue()->getAsUnquotedString());
   }
 };
 } // namespace

--- a/lldb/utils/TableGen/LLDBOptionDefEmitter.cpp
+++ b/lldb/utils/TableGen/LLDBOptionDefEmitter.cpp
@@ -24,7 +24,7 @@ using namespace lldb_private;
 
 namespace {
 /// Parses curly braces and replaces them with ANSI underline formatting.
-inline std::string underline(llvm::StringRef Str) {
+std::string underline(llvm::StringRef Str) {
   llvm::StringRef OpeningHead, OpeningTail, ClosingHead, ClosingTail;
   std::string Result;
   llvm::raw_string_ostream Stream(Result);


### PR DESCRIPTION
This PR updates the tablegen emitter for command options to support a simplified syntax to underline the mnemonic. Previously, you had to write `${ansi.underline}<L>${ansi.normal}`, where `<L>` is the mnemonic. This really hurt the readability of the description. With this PR, you can write `${<L>}` instead.