### PR TITLE
[memprof] Modernize DataAccessProfRecord (NFC)

### DIFF
--- a/llvm/include/llvm/ProfileData/DataAccessProf.h
+++ b/llvm/include/llvm/ProfileData/DataAccessProf.h
@@ -116,9 +116,9 @@ public:
       Locations.emplace_back(Loc.FileName, Loc.Line);
   }
   // Empty constructor is used in yaml conversion.
-  DataAccessProfRecord() : AccessCount(0) {}
+  DataAccessProfRecord() = default;
   SymbolHandle SymHandle;
-  uint64_t AccessCount;
+  uint64_t AccessCount = 0;
   // The locations of data in the source code. Optional.
   SmallVector<SourceLocation> Locations;
 };


### PR DESCRIPTION
It's a bit safer to keep the initialization attached to the member
variable.
