### PR TITLE
Fix the lit failure on "loop-register.s" test.

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/loop-register.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/loop-register.s
@@ -2,7 +2,7 @@
 ; generate extra function prologue instructions that interfere with matching
 ; the STR of X19. Disable this for now.
 ;
-; UNSUPPORTED: *
+; UNSUPPORTED: target={{.*}}
 
 REQUIRES: aarch64-registered-target, asserts
 


### PR DESCRIPTION
This is a follow up of f3a5c16b9810fc12e7be35ff719be10427338256, which broke the test on arm64 due to incorrect use of the UNSUPPORTED tag.