### PR TITLE
[flang][runtime] Handle null list-directed fields in child input

### DIFF
--- a/flang-rt/lib/runtime/descriptor-io.cpp
+++ b/flang-rt/lib/runtime/descriptor-io.cpp
@@ -170,6 +170,8 @@ static RT_API_ATTRS Fortran::common::optional<bool> DefinedFormattedIo(
       io.GotChar(io.InquirePos() - *startPos);
     }
     return handler.GetIoStat() == IostatOk;
+  } else if (peek && peek->descriptor == DataEdit::ListDirectedNullValue) {
+    return false;
   } else {
     // There's a defined I/O subroutine, but there's a FORMAT present and
     // it does not have a DT data edit descriptor, so apply default formatting

--- a/flang/docs/Extensions.md
+++ b/flang/docs/Extensions.md
@@ -910,6 +910,13 @@ print *, [(j,j=1,10)]
   `ALLOCATE` and `DEALLOCATE` statements with error recovery for
   multiple variables.
 
+* When a "null" value is encountered in list-directed input, the
+  corresponding effective item in the data list is left unchanged,
+  even when it has a derived type with a defined `READ(FORMATTED)`
+  subroutine.  This is the most literal reading of F'2023 13.10.3.2p2
+  and the portable interpretation across the most common Fortran
+  compilers.
+
 ## De Facto Standard Features
 
 * `EXTENDS_TYPE_OF()` returns `.TRUE.` if both of its arguments have the


### PR DESCRIPTION
List-directed input statements maintain two flags ("eatComma_" and "hitSlash_") in their state that allow GetNextDataEdit() to detect and handle field separators (usually ',') and slashes in the input stream.  For list-directed input in a defined input subroutine, it's necessary to copy those flags from the parent list-directed input statement (if any) and update them afterwards.

Fixes https://github.com/llvm/llvm-project/issues/154791.