### PR TITLE
[lldb] NFC Moving mcp::Transport into its own file.

### DIFF
--- a/lldb/include/lldb/Protocol/MCP/MCPError.h
+++ b/lldb/include/lldb/Protocol/MCP/MCPError.h
@@ -19,7 +19,7 @@ class MCPError : public llvm::ErrorInfo<MCPError> {
 public:
   static char ID;
 
-  MCPError(std::string message, int64_t error_code = kInternalError);
+  MCPError(std::string message, int64_t error_code = eErrorCodeInternalError);
 
   void log(llvm::raw_ostream &OS) const override;
   std::error_code convertToErrorCode() const override;
@@ -27,9 +27,6 @@ public:
   const std::string &getMessage() const { return m_message; }
 
   lldb_protocol::mcp::Error toProtocolError() const;
-
-  static constexpr int64_t kResourceNotFound = -32002;
-  static constexpr int64_t kInternalError = -32603;
 
 private:
   std::string m_message;

--- a/lldb/include/lldb/Protocol/MCP/Protocol.h
+++ b/lldb/include/lldb/Protocol/MCP/Protocol.h
@@ -55,6 +55,11 @@ enum ErrorCode : signed {
   eErrorCodeInvalidParams = -32602,
   /// Internal JSON-RPC error.
   eErrorCodeInternalError = -32603,
+
+  /// Additional MCP error codes.
+
+  /// Resource related uri not found.
+  eErrorCodeResourceNotFound = -32002,
 };
 
 struct Error {

--- a/lldb/include/lldb/Protocol/MCP/Transport.h
+++ b/lldb/include/lldb/Protocol/MCP/Transport.h
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PROTOCOL_MCP_TRANSPORT_H
+#define LLDB_PROTOCOL_MCP_TRANSPORT_H
+
+#include "lldb/Host/JSONTransport.h"
+#include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/lldb-forward.h"
+#include "llvm/ADT/StringRef.h"
+#include <functional>
+#include <string>
+
+namespace lldb_protocol::mcp {
+
+class Transport
+    : public lldb_private::JSONRPCTransport<Request, Response, Notification> {
+public:
+  using LogCallback = std::function<void(llvm::StringRef message)>;
+
+  Transport(lldb::IOObjectSP in, lldb::IOObjectSP out, std::string client_name,
+            LogCallback log_callback = {});
+  virtual ~Transport() = default;
+
+  void Log(llvm::StringRef message) override;
+
+private:
+  std::string m_client_name;
+  LogCallback m_log_callback;
+};
+
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -67,7 +67,7 @@ void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
   LLDB_LOG(log, "New MCP client connected: {0}", client_name);
 
   lldb::IOObjectSP io_sp = std::move(socket);
-  auto transport_up = std::make_unique<lldb_protocol::mcp::MCPTransport>(
+  auto transport_up = std::make_unique<lldb_protocol::mcp::Transport>(
       io_sp, io_sp, std::move(client_name), [&](llvm::StringRef message) {
         LLDB_LOG(GetLog(LLDBLog::Host), "{0}", message);
       });

--- a/lldb/source/Protocol/MCP/CMakeLists.txt
+++ b/lldb/source/Protocol/MCP/CMakeLists.txt
@@ -3,6 +3,7 @@ add_lldb_library(lldbProtocolMCP NO_PLUGIN_DEPENDENCIES
   Protocol.cpp
   Server.cpp
   Tool.cpp
+  Transport.cpp
 
   LINK_COMPONENTS
     Support

--- a/lldb/source/Protocol/MCP/Server.cpp
+++ b/lldb/source/Protocol/MCP/Server.cpp
@@ -15,7 +15,7 @@ using namespace lldb_protocol::mcp;
 using namespace llvm;
 
 Server::Server(std::string name, std::string version,
-               std::unique_ptr<MCPTransport> transport_up,
+               std::unique_ptr<Transport> transport_up,
                lldb_private::MainLoop &loop)
     : m_name(std::move(name)), m_version(std::move(version)),
       m_transport_up(std::move(transport_up)), m_loop(loop) {
@@ -180,7 +180,7 @@ llvm::Expected<Response> Server::ResourcesReadHandler(const Request &request) {
 
   return make_error<MCPError>(
       llvm::formatv("no resource handler for uri: {0}", uri_str).str(),
-      MCPError::kResourceNotFound);
+      eErrorCodeResourceNotFound);
 }
 
 ServerCapabilities Server::GetCapabilities() {
@@ -219,7 +219,7 @@ void Server::Received(const Request &request) {
       response.takeError(),
       [&](const MCPError &err) { protocol_error = err.toProtocolError(); },
       [&](const llvm::ErrorInfoBase &err) {
-        protocol_error.code = MCPError::kInternalError;
+        protocol_error.code = eErrorCodeInternalError;
         protocol_error.message = err.message();
       });
   Response error_response;

--- a/lldb/source/Protocol/MCP/Transport.cpp
+++ b/lldb/source/Protocol/MCP/Transport.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Protocol/MCP/Transport.h"
+#include "lldb/Host/JSONTransport.h"
+#include "lldb/lldb-forward.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <string>
+#include <utility>
+
+using namespace llvm;
+using namespace lldb;
+
+namespace lldb_protocol::mcp {
+
+Transport::Transport(IOObjectSP in, IOObjectSP out, std::string client_name,
+                     LogCallback log_callback)
+    : JSONRPCTransport(in, out), m_client_name(std::move(client_name)),
+      m_log_callback(log_callback) {}
+
+void Transport::Log(StringRef message) {
+  if (m_log_callback)
+    m_log_callback(formatv("{0}: {1}", m_client_name, message).str());
+}
+
+} // namespace lldb_protocol::mcp

--- a/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Protocol/MCP/Resource.h"
 #include "lldb/Protocol/MCP/Server.h"
 #include "lldb/Protocol/MCP/Tool.h"
+#include "lldb/Protocol/MCP/Transport.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/JSON.h"
@@ -36,12 +37,12 @@ using namespace lldb_private;
 using namespace lldb_protocol::mcp;
 
 namespace {
-class TestMCPTransport final : public MCPTransport {
+class TestMCPTransport final : public lldb_protocol::mcp::Transport {
 public:
   TestMCPTransport(lldb::IOObjectSP in, lldb::IOObjectSP out)
-      : lldb_protocol::mcp::MCPTransport(in, out, "unittest") {}
+      : lldb_protocol::mcp::Transport(in, out, "unittest") {}
 
-  using MCPTransport::Write;
+  using Transport::Write;
 
   void Log(llvm::StringRef message) override {
     log_messages.emplace_back(message);


### PR DESCRIPTION
Moving `lldb_protocol::mcp::MCPTransport` out of Server.h and into its own file and simplifying the name to `Transport`.