### PR TITLE
[flang][runtime] Handle ALLOCATE(..., short SOURCE=)

### DIFF
--- a/flang/include/flang/Runtime/assign.h
+++ b/flang/include/flang/Runtime/assign.h
@@ -44,11 +44,10 @@ enum AssignFlags {
 
 #ifdef RT_DEVICE_COMPILATION
 RT_API_ATTRS void Assign(Descriptor &to, const Descriptor &from,
-    Terminator &terminator, int flags, MemmoveFct memmoveFct = &MemmoveWrapper);
+    Terminator &terminator, int flags, MemmoveFct = &MemmoveWrapper);
 #else
 RT_API_ATTRS void Assign(Descriptor &to, const Descriptor &from,
-    Terminator &terminator, int flags,
-    MemmoveFct memmoveFct = &Fortran::runtime::memmove);
+    Terminator &terminator, int flags, MemmoveFct = &runtime::memmove);
 #endif
 
 extern "C" {


### PR DESCRIPTION
Ensure that blank padding takes place when a fixed-length character allocatable is allocated with a short SOURCE= specifier.  While here, clean up DoFromSourceAssign() so that it uses a temporary descriptor on the stack rather than allocating one from the heap.

Fixes https://github.com/llvm/llvm-project/issues/155703.