### PR TITLE
[orc-rt] Allow move_only_function to capture by lvalue-reference.

### DIFF
--- a/orc-rt/include/orc-rt/move_only_function.h
+++ b/orc-rt/include/orc-rt/move_only_function.h
@@ -26,6 +26,7 @@
 #define ORC_RT_MOVE_ONLY_FUNCTION_H
 
 #include <memory>
+#include <type_traits>
 
 namespace orc_rt {
 
@@ -46,7 +47,7 @@ public:
   }
 
 private:
-  CallableT Callable;
+  std::decay_t<CallableT> Callable;
 };
 
 } // namespace move_only_function_detail

--- a/orc-rt/unittests/move_only_function-test.cpp
+++ b/orc-rt/unittests/move_only_function-test.cpp
@@ -98,6 +98,11 @@ TEST(MoveOnlyFunctionTest, Captures) {
   EXPECT_EQ(C5(), 15);
   Tmp = std::move(C5);
   EXPECT_EQ(Tmp(), 15);
+
+  // Test capture via lvalue.
+  auto Inc = [](int N) { return N + 1; };
+  move_only_function<int(int)> C6(Inc);
+  EXPECT_EQ(C6(1), 2);
 }
 
 TEST(MoveOnlyFunctionTest, MoveOnly) {


### PR DESCRIPTION
Store std::decay_t<Callable> to ensure that we can initialize via lvalue references:

  auto NamedNoop = [](){};
   move_only_function<void()> Noop(NamedNoop); // <- no longer an error!