### PR TITLE
[lldb] Correct a usage after a rename was merged.

### DIFF
--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
         [](MainLoopBase &loop) { loop.RequestTermination(); });
   });
 
-  auto transport_up = std::make_unique<lldb_protocol::mcp::MCPTransport>(
+  auto transport_up = std::make_unique<lldb_protocol::mcp::Transport>(
       input, output, std::string(client_name),
       [&](llvm::StringRef message) { llvm::errs() << message << '\n'; });
 


### PR DESCRIPTION
Fixes lldb-mcp, aa71d95 was merged after 71a065e.