### PR TITLE
[flang][runtime][NFC] Clean up Fortran::common::optional<> usage

### DIFF
--- a/flang-rt/include/flang-rt/runtime/connection.h
+++ b/flang-rt/include/flang-rt/runtime/connection.h
@@ -26,10 +26,10 @@ enum class Access { Sequential, Direct, Stream };
 // established in an OPEN statement.
 struct ConnectionAttributes {
   Access access{Access::Sequential}; // ACCESS='SEQUENTIAL', 'DIRECT', 'STREAM'
-  Fortran::common::optional<bool> isUnformatted; // FORM='UNFORMATTED' if true
+  common::optional<bool> isUnformatted; // FORM='UNFORMATTED' if true
   bool isUTF8{false}; // ENCODING='UTF-8'
   unsigned char internalIoCharKind{0}; // 0->external, 1/2/4->internal
-  Fortran::common::optional<std::int64_t> openRecl; // RECL= on OPEN
+  common::optional<std::int64_t> openRecl; // RECL= on OPEN
 
   RT_API_ATTRS bool IsRecordFile() const {
     // Formatted stream files are viewed as having records, at least on input
@@ -82,15 +82,14 @@ struct ConnectionState : public ConnectionAttributes {
     unterminatedRecord = false;
   }
 
-  RT_API_ATTRS Fortran::common::optional<std::int64_t>
-  EffectiveRecordLength() const {
+  RT_API_ATTRS common::optional<std::int64_t> EffectiveRecordLength() const {
     // When an input record is longer than an explicit RECL= from OPEN
     // it is effectively truncated on input.
     return openRecl && recordLength && *openRecl < *recordLength ? openRecl
                                                                  : recordLength;
   }
 
-  Fortran::common::optional<std::int64_t> recordLength;
+  common::optional<std::int64_t> recordLength;
 
   std::int64_t currentRecordNumber{1}; // 1 is first
 
@@ -106,12 +105,11 @@ struct ConnectionState : public ConnectionAttributes {
   std::int64_t furthestPositionInRecord{0}; // max(position+bytes)
 
   // Set at end of non-advancing I/O data transfer
-  Fortran::common::optional<std::int64_t>
-      leftTabLimit; // offset in current record
+  common::optional<std::int64_t> leftTabLimit; // offset in current record
 
   // currentRecordNumber value captured after ENDFILE/REWIND/BACKSPACE statement
   // or an end-of-file READ condition on a sequential access file
-  Fortran::common::optional<std::int64_t> endfileRecordNumber;
+  common::optional<std::int64_t> endfileRecordNumber;
 
   // Mutable modes set at OPEN() that can be overridden in READ/WRITE & FORMAT
   MutableModes modes; // BLANK=, DECIMAL=, SIGN=, ROUND=, PAD=, DELIM=, kP

--- a/flang-rt/include/flang-rt/runtime/environment.h
+++ b/flang-rt/include/flang-rt/runtime/environment.h
@@ -31,7 +31,7 @@ RT_OFFLOAD_VAR_GROUP_END
 // External unformatted I/O data conversions
 enum class Convert { Unknown, Native, LittleEndian, BigEndian, Swap };
 
-RT_API_ATTRS Fortran::common::optional<Convert> GetConvertFromString(
+RT_API_ATTRS common::optional<Convert> GetConvertFromString(
     const char *, std::size_t);
 
 struct ExecutionEnvironment {

--- a/flang-rt/include/flang-rt/runtime/file.h
+++ b/flang-rt/include/flang-rt/runtime/file.h
@@ -37,11 +37,10 @@ public:
   void set_mayAsynchronous(bool yes) { mayAsynchronous_ = yes; }
   bool isTerminal() const { return isTerminal_; }
   bool isWindowsTextFile() const { return isWindowsTextFile_; }
-  Fortran::common::optional<FileOffset> knownSize() const { return knownSize_; }
+  common::optional<FileOffset> knownSize() const { return knownSize_; }
 
   bool IsConnected() const { return fd_ >= 0; }
-  void Open(OpenStatus, Fortran::common::optional<Action>, Position,
-      IoErrorHandler &);
+  void Open(OpenStatus, common::optional<Action>, Position, IoErrorHandler &);
   void Predefine(int fd);
   void Close(CloseStatus, IoErrorHandler &);
 
@@ -95,10 +94,10 @@ private:
   bool mayWrite_{false};
   bool mayPosition_{false};
   bool mayAsynchronous_{false};
-  Fortran::common::optional<Position>
+  common::optional<Position>
       openPosition_; // from Open(); reset after positioning
   FileOffset position_{0};
-  Fortran::common::optional<FileOffset> knownSize_;
+  common::optional<FileOffset> knownSize_;
   bool isTerminal_{false};
   bool isWindowsTextFile_{false}; // expands LF to CR+LF on write
 

--- a/flang-rt/include/flang-rt/runtime/format-implementation.h
+++ b/flang-rt/include/flang-rt/runtime/format-implementation.h
@@ -302,7 +302,7 @@ RT_API_ATTRS int FormatControl<CONTEXT>::CueUpNextDataEdit(
     }
   }
   while (true) {
-    Fortran::common::optional<int> repeat;
+    common::optional<int> repeat;
     bool unlimited{false};
     auto maybeReversionPoint{offset_};
     CharType ch{GetNextChar(context)};
@@ -498,8 +498,8 @@ RT_API_ATTRS int FormatControl<CONTEXT>::CueUpNextDataEdit(
 
 // Returns the next data edit descriptor
 template <typename CONTEXT>
-RT_API_ATTRS Fortran::common::optional<DataEdit>
-FormatControl<CONTEXT>::GetNextDataEdit(Context &context, int maxRepeat) {
+RT_API_ATTRS common::optional<DataEdit> FormatControl<CONTEXT>::GetNextDataEdit(
+    Context &context, int maxRepeat) {
   int repeat{CueUpNextDataEdit(context)};
   auto start{offset_};
   DataEdit edit;
@@ -530,7 +530,7 @@ FormatControl<CONTEXT>::GetNextDataEdit(Context &context, int maxRepeat) {
         }
         if (edit.ioTypeChars >= edit.maxIoTypeChars) {
           ReportBadFormat(context, "Excessive DT'iotype' in FORMAT", start);
-          return Fortran::common::nullopt;
+          return common::nullopt;
         }
         edit.ioType[edit.ioTypeChars++] = ch;
         if (ch == quote) {
@@ -539,7 +539,7 @@ FormatControl<CONTEXT>::GetNextDataEdit(Context &context, int maxRepeat) {
       }
       if (!ok) {
         ReportBadFormat(context, "Unclosed DT'iotype' in FORMAT", start);
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
     }
     if (PeekNext() == '(') {
@@ -554,7 +554,7 @@ FormatControl<CONTEXT>::GetNextDataEdit(Context &context, int maxRepeat) {
         }
         if (edit.vListEntries >= edit.maxVListEntries) {
           ReportBadFormat(context, "Excessive DT(v_list) in FORMAT", start);
-          return Fortran::common::nullopt;
+          return common::nullopt;
         }
         edit.vList[edit.vListEntries++] = n;
         auto ch{static_cast<char>(GetNextChar(context))};
@@ -565,7 +565,7 @@ FormatControl<CONTEXT>::GetNextDataEdit(Context &context, int maxRepeat) {
       }
       if (!ok) {
         ReportBadFormat(context, "Unclosed DT(v_list) in FORMAT", start);
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
     }
   } else { // not DT'iotype'

--- a/flang-rt/include/flang-rt/runtime/format.h
+++ b/flang-rt/include/flang-rt/runtime/format.h
@@ -76,9 +76,9 @@ struct DataEdit {
   }
 
   char variation{'\0'}; // N, S, or X for EN, ES, EX; G/l for original G/list
-  Fortran::common::optional<int> width; // the 'w' field; optional for A
-  Fortran::common::optional<int> digits; // the 'm' or 'd' field
-  Fortran::common::optional<int> expoDigits; // 'Ee' field
+  common::optional<int> width; // the 'w' field; optional for A
+  common::optional<int> digits; // the 'm' or 'd' field
+  common::optional<int> expoDigits; // 'Ee' field
   MutableModes modes;
   int repeat{1};
 
@@ -116,7 +116,7 @@ public:
   // Extracts the next data edit descriptor, handling control edit descriptors
   // along the way.  If maxRepeat==0, this is a peek at the next data edit
   // descriptor.
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       Context &, int maxRepeat = 1);
 
   // Emit any remaining character literals after the last data item (on output)

--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -105,8 +105,7 @@ public:
   RT_API_ATTRS void HandleRelativePosition(std::int64_t byteOffset);
   RT_API_ATTRS void HandleAbsolutePosition(
       std::int64_t byteOffset); // for r* in list I/O
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
-      int maxRepeat = 1);
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(int maxRepeat = 1);
   RT_API_ATTRS ExternalFileUnit *
   GetExternalFileUnit() const; // null if internal unit
   RT_API_ATTRS bool BeginReadingRecord();
@@ -136,7 +135,7 @@ public:
   }
 
   // Vacant after the end of the current record
-  RT_API_ATTRS Fortran::common::optional<char32_t> GetCurrentCharSlow(
+  RT_API_ATTRS common::optional<char32_t> GetCurrentCharSlow(
       std::size_t &byteCount);
 
   // For faster formatted input editing, this structure can be built by
@@ -158,11 +157,11 @@ public:
 
     RT_API_ATTRS bool MustUseSlowPath() const { return at_ == nullptr; }
 
-    RT_API_ATTRS Fortran::common::optional<char32_t> Next() const {
+    RT_API_ATTRS common::optional<char32_t> Next() const {
       if (at_ && at_ < limit_) {
         return *at_;
       } else {
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
     }
     RT_API_ATTRS void NextRecord(IoStatementState &io) {
@@ -199,14 +198,14 @@ public:
 
   RT_API_ATTRS FastAsciiField GetUpcomingFastAsciiField();
 
-  RT_API_ATTRS Fortran::common::optional<char32_t> GetCurrentChar(
+  RT_API_ATTRS common::optional<char32_t> GetCurrentChar(
       std::size_t &byteCount, FastAsciiField *field = nullptr) {
     if (field) {
       if (auto ch{field->Next()}) {
         byteCount = ch ? 1 : 0;
         return ch;
       } else if (!field->MustUseSlowPath()) {
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
     }
     return GetCurrentCharSlow(byteCount);
@@ -218,9 +217,9 @@ public:
 
   // For fixed-width fields, return the number of remaining bytes.
   // Skip over leading blanks.
-  RT_API_ATTRS Fortran::common::optional<int> CueUpInput(
+  RT_API_ATTRS common::optional<int> CueUpInput(
       const DataEdit &edit, FastAsciiField *fastField = nullptr) {
-    Fortran::common::optional<int> remaining;
+    common::optional<int> remaining;
     if (edit.IsListDirected()) {
       std::size_t byteCount{0};
       GetNextNonBlank(byteCount, fastField);
@@ -237,9 +236,8 @@ public:
     return remaining;
   }
 
-  RT_API_ATTRS Fortran::common::optional<char32_t> SkipSpaces(
-      Fortran::common::optional<int> &remaining,
-      FastAsciiField *fastField = nullptr) {
+  RT_API_ATTRS common::optional<char32_t> SkipSpaces(
+      common::optional<int> &remaining, FastAsciiField *fastField = nullptr) {
     while (!remaining || *remaining > 0) {
       std::size_t byteCount{0};
       if (auto ch{GetCurrentChar(byteCount, fastField)}) {
@@ -262,13 +260,13 @@ public:
         break;
       }
     }
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
 
   // Acquires the next input character, respecting any applicable field width
   // or separator character.
-  RT_API_ATTRS Fortran::common::optional<char32_t> NextInField(
-      Fortran::common::optional<int> &remaining, const DataEdit &,
+  RT_API_ATTRS common::optional<char32_t> NextInField(
+      common::optional<int> &remaining, const DataEdit &,
       FastAsciiField *field = nullptr);
 
   // Detect and signal any end-of-record condition after input.
@@ -277,7 +275,7 @@ public:
       std::size_t afterReading, const ConnectionState &);
 
   // Skips spaces, advances records, and ignores NAMELIST comments
-  RT_API_ATTRS Fortran::common::optional<char32_t> GetNextNonBlank(
+  RT_API_ATTRS common::optional<char32_t> GetNextNonBlank(
       std::size_t &byteCount, FastAsciiField *fastField = nullptr) {
     auto ch{GetCurrentChar(byteCount, fastField)};
     bool inNamelist{mutableModes().inNamelist};
@@ -294,7 +292,7 @@ public:
           fastField->NextRecord(*this);
         }
       } else {
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
       ch = GetCurrentChar(byteCount, fastField);
     }
@@ -316,47 +314,43 @@ public:
   }
 
 private:
-  std::variant<Fortran::common::reference_wrapper<OpenStatementState>,
-      Fortran::common::reference_wrapper<CloseStatementState>,
-      Fortran::common::reference_wrapper<NoopStatementState>,
-      Fortran::common::reference_wrapper<
+  std::variant<common::reference_wrapper<OpenStatementState>,
+      common::reference_wrapper<CloseStatementState>,
+      common::reference_wrapper<NoopStatementState>,
+      common::reference_wrapper<
           InternalFormattedIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           InternalFormattedIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           InternalListIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
-          InternalListIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<InternalListIoStatementState<Direction::Input>>,
+      common::reference_wrapper<
           ExternalFormattedIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           ExternalFormattedIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           ExternalListIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
-          ExternalListIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<ExternalListIoStatementState<Direction::Input>>,
+      common::reference_wrapper<
           ExternalUnformattedIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           ExternalUnformattedIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           ChildFormattedIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           ChildFormattedIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
-          ChildListIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
-          ChildListIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<ChildListIoStatementState<Direction::Output>>,
+      common::reference_wrapper<ChildListIoStatementState<Direction::Input>>,
+      common::reference_wrapper<
           ChildUnformattedIoStatementState<Direction::Output>>,
-      Fortran::common::reference_wrapper<
+      common::reference_wrapper<
           ChildUnformattedIoStatementState<Direction::Input>>,
-      Fortran::common::reference_wrapper<InquireUnitState>,
-      Fortran::common::reference_wrapper<InquireNoUnitState>,
-      Fortran::common::reference_wrapper<InquireUnconnectedFileState>,
-      Fortran::common::reference_wrapper<InquireIOLengthState>,
-      Fortran::common::reference_wrapper<ExternalMiscIoStatementState>,
-      Fortran::common::reference_wrapper<ErroneousIoStatementState>>
+      common::reference_wrapper<InquireUnitState>,
+      common::reference_wrapper<InquireNoUnitState>,
+      common::reference_wrapper<InquireUnconnectedFileState>,
+      common::reference_wrapper<InquireIOLengthState>,
+      common::reference_wrapper<ExternalMiscIoStatementState>,
+      common::reference_wrapper<ErroneousIoStatementState>>
       u_;
 };
 
@@ -388,7 +382,7 @@ public:
   RT_API_ATTRS void BackspaceRecord();
   RT_API_ATTRS void HandleRelativePosition(std::int64_t);
   RT_API_ATTRS void HandleAbsolutePosition(std::int64_t);
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       IoStatementState &, int maxRepeat = 1);
   RT_API_ATTRS ExternalFileUnit *GetExternalFileUnit() const;
   RT_API_ATTRS bool BeginReadingRecord();
@@ -422,7 +416,7 @@ class ListDirectedStatementState<Direction::Output>
 public:
   RT_API_ATTRS bool EmitLeadingSpaceOrAdvance(
       IoStatementState &, std::size_t = 1, bool isCharacter = false);
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       IoStatementState &, int maxRepeat = 1);
   RT_API_ATTRS bool lastWasUndelimitedCharacter() const {
     return lastWasUndelimitedCharacter_;
@@ -446,7 +440,7 @@ public:
   // Skips value separators, handles repetition and null values.
   // Vacant when '/' appears; present with descriptor == ListDirectedNullValue
   // when a null value appears.
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       IoStatementState &, int maxRepeat = 1);
 
   // Each NAMELIST input item is treated like a distinct list-directed
@@ -469,7 +463,7 @@ protected:
 
 private:
   int remaining_{0}; // for "r*" repetition
-  Fortran::common::optional<SavedPosition> repeatPosition_;
+  common::optional<SavedPosition> repeatPosition_;
   bool eatComma_{false}; // consume comma after previously read item
   bool hitSlash_{false}; // once '/' is seen, nullify further items
   bool realPart_{false};
@@ -524,7 +518,7 @@ public:
   }
   RT_API_ATTRS void CompleteOperation();
   RT_API_ATTRS int EndIoStatement();
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       IoStatementState &, int maxRepeat = 1) {
     return format_.GetNextDataEdit(*this, maxRepeat);
   }
@@ -618,7 +612,7 @@ public:
       const char *sourceFile = nullptr, int sourceLine = 0);
   RT_API_ATTRS void CompleteOperation();
   RT_API_ATTRS int EndIoStatement();
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       IoStatementState &, int maxRepeat = 1) {
     return format_.GetNextDataEdit(*this, maxRepeat);
   }
@@ -680,7 +674,7 @@ public:
   RT_API_ATTRS void CompleteOperation();
   RT_API_ATTRS int EndIoStatement();
   RT_API_ATTRS bool AdvanceRecord(int = 1);
-  RT_API_ATTRS Fortran::common::optional<DataEdit> GetNextDataEdit(
+  RT_API_ATTRS common::optional<DataEdit> GetNextDataEdit(
       IoStatementState &, int maxRepeat = 1) {
     return format_.GetNextDataEdit(*this, maxRepeat);
   }
@@ -740,15 +734,15 @@ public:
 private:
   bool wasExtant_;
   bool isNewUnit_;
-  Fortran::common::optional<OpenStatus> status_;
-  Fortran::common::optional<Position> position_;
-  Fortran::common::optional<Action> action_;
+  common::optional<OpenStatus> status_;
+  common::optional<Position> position_;
+  common::optional<Action> action_;
   Convert convert_{Convert::Unknown};
   OwningPtr<char> path_;
   std::size_t pathLength_{};
-  Fortran::common::optional<bool> isUnformatted_;
-  Fortran::common::optional<bool> mustBeFormatted_;
-  Fortran::common::optional<Access> access_;
+  common::optional<bool> isUnformatted_;
+  common::optional<bool> mustBeFormatted_;
+  common::optional<Access> access_;
 };
 
 class CloseStatementState : public ExternalIoStatementBase {

--- a/flang-rt/include/flang-rt/runtime/random-templates.h
+++ b/flang-rt/include/flang-rt/runtime/random-templates.h
@@ -33,7 +33,7 @@ static constexpr int rangeBits{
 
 extern Lock lock;
 extern Generator generator;
-extern Fortran::common::optional<GeneratedWord> nextValue;
+extern common::optional<GeneratedWord> nextValue;
 
 // Call only with lock held
 static GeneratedWord GetNextValue() {

--- a/flang-rt/include/flang-rt/runtime/tools.h
+++ b/flang-rt/include/flang-rt/runtime/tools.h
@@ -94,8 +94,9 @@ RT_API_ATTRS void CheckConformability(const Descriptor &to, const Descriptor &x,
 template <int KIND> struct StoreIntegerAt {
   RT_API_ATTRS void operator()(const Fortran::runtime::Descriptor &result,
       std::size_t at, std::int64_t value) const {
-    *result.ZeroBasedIndexedElement<Fortran::runtime::CppTypeFor<
-        Fortran::common::TypeCategory::Integer, KIND>>(at) = value;
+    *result.ZeroBasedIndexedElement<
+        Fortran::runtime::CppTypeFor<common::TypeCategory::Integer, KIND>>(at) =
+        value;
   }
 };
 
@@ -103,8 +104,9 @@ template <int KIND> struct StoreIntegerAt {
 template <int KIND> struct StoreFloatingPointAt {
   RT_API_ATTRS void operator()(const Fortran::runtime::Descriptor &result,
       std::size_t at, std::double_t value) const {
-    *result.ZeroBasedIndexedElement<Fortran::runtime::CppTypeFor<
-        Fortran::common::TypeCategory::Real, KIND>>(at) = value;
+    *result.ZeroBasedIndexedElement<
+        Fortran::runtime::CppTypeFor<common::TypeCategory::Real, KIND>>(at) =
+        value;
   }
 };
 
@@ -136,7 +138,7 @@ static inline RT_API_ATTRS std::int64_t GetInt64(
   }
 }
 
-static inline RT_API_ATTRS Fortran::common::optional<std::int64_t> GetInt64Safe(
+static inline RT_API_ATTRS common::optional<std::int64_t> GetInt64Safe(
     const char *p, std::size_t bytes, Terminator &terminator) {
   switch (bytes) {
   case 1:
@@ -154,7 +156,7 @@ static inline RT_API_ATTRS Fortran::common::optional<std::int64_t> GetInt64Safe(
     if (static_cast<Int128>(result) == n) {
       return result;
     }
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
   default:
     terminator.Crash("GetInt64Safe: no case for %zd bytes", bytes);
@@ -392,8 +394,7 @@ inline RT_API_ATTRS RESULT ApplyLogicalKind(
 }
 
 // Calculate result type of (X op Y) for *, //, DOT_PRODUCT, &c.
-Fortran::common::optional<
-    std::pair<TypeCategory, int>> inline constexpr RT_API_ATTRS
+common::optional<std::pair<TypeCategory, int>> inline constexpr RT_API_ATTRS
 GetResultType(TypeCategory xCat, int xKind, TypeCategory yCat, int yKind) {
   int maxKind{std::max(xKind, yKind)};
   switch (xCat) {
@@ -467,18 +468,18 @@ GetResultType(TypeCategory xCat, int xKind, TypeCategory yCat, int yKind) {
     if (yCat == TypeCategory::Character) {
       return std::make_pair(TypeCategory::Character, maxKind);
     } else {
-      return Fortran::common::nullopt;
+      return common::nullopt;
     }
   case TypeCategory::Logical:
     if (yCat == TypeCategory::Logical) {
       return std::make_pair(TypeCategory::Logical, maxKind);
     } else {
-      return Fortran::common::nullopt;
+      return common::nullopt;
     }
   default:
     break;
   }
-  return Fortran::common::nullopt;
+  return common::nullopt;
 }
 
 // Accumulate floating-point results in (at least) double precision

--- a/flang-rt/include/flang-rt/runtime/type-code.h
+++ b/flang-rt/include/flang-rt/runtime/type-code.h
@@ -54,7 +54,7 @@ public:
     return IsValid() && !IsDerived();
   }
 
-  RT_API_ATTRS Fortran::common::optional<std::pair<TypeCategory, int>>
+  RT_API_ATTRS common::optional<std::pair<TypeCategory, int>>
   GetCategoryAndKind() const;
 
   RT_API_ATTRS bool operator==(TypeCode that) const {

--- a/flang-rt/include/flang-rt/runtime/type-info.h
+++ b/flang-rt/include/flang-rt/runtime/type-info.h
@@ -39,7 +39,7 @@ public:
     LenParameter = 3
   };
   RT_API_ATTRS Genre genre() const { return genre_; }
-  RT_API_ATTRS Fortran::common::optional<TypeParameterValue> GetValue(
+  RT_API_ATTRS common::optional<TypeParameterValue> GetValue(
       const Descriptor *) const;
 
 private:

--- a/flang-rt/include/flang-rt/runtime/utf.h
+++ b/flang-rt/include/flang-rt/runtime/utf.h
@@ -63,7 +63,7 @@ RT_API_ATTRS std::size_t MeasurePreviousUTF8Bytes(
 
 // Ensure that all bytes are present in sequence in the input buffer
 // before calling; use MeasureUTF8Bytes(first byte) to count them.
-RT_API_ATTRS Fortran::common::optional<char32_t> DecodeUTF8(const char *);
+RT_API_ATTRS common::optional<char32_t> DecodeUTF8(const char *);
 
 // Ensure that at least maxUTF8Bytes remain in the output
 // buffer before calling.

--- a/flang-rt/lib/runtime/descriptor-io.cpp
+++ b/flang-rt/lib/runtime/descriptor-io.cpp
@@ -42,7 +42,7 @@ inline RT_API_ATTRS A &ExtractElement(IoStatementState &io,
 }
 
 // Defined formatted I/O (maybe)
-static RT_API_ATTRS Fortran::common::optional<bool> DefinedFormattedIo(
+static RT_API_ATTRS common::optional<bool> DefinedFormattedIo(
     IoStatementState &io, const Descriptor &descriptor,
     const typeInfo::DerivedType &derived,
     const typeInfo::SpecialBinding &special,
@@ -50,7 +50,7 @@ static RT_API_ATTRS Fortran::common::optional<bool> DefinedFormattedIo(
   // Look at the next data edit descriptor.  If this is list-directed I/O, the
   // "maxRepeat=0" argument will prevent the input from advancing over an
   // initial '(' that shouldn't be consumed now as the start of a real part.
-  Fortran::common::optional<DataEdit> peek{io.GetNextDataEdit(/*maxRepeat=*/0)};
+  common::optional<DataEdit> peek{io.GetNextDataEdit(/*maxRepeat=*/0)};
   if (peek &&
       (peek->descriptor == DataEdit::DefinedDerivedType ||
           peek->descriptor == DataEdit::ListDirected ||
@@ -107,7 +107,7 @@ static RT_API_ATTRS Fortran::common::optional<bool> DefinedFormattedIo(
     std::int32_t unit{external->unitNumber()};
     std::int32_t ioStat{IostatOk};
     char ioMsg[100];
-    Fortran::common::optional<std::int64_t> startPos;
+    common::optional<std::int64_t> startPos;
     if (edit.descriptor == DataEdit::DefinedDerivedType &&
         special.which() == typeInfo::SpecialBinding::Which::ReadFormatted) {
       // DT is an edit descriptor, so everything that the child
@@ -174,7 +174,7 @@ static RT_API_ATTRS Fortran::common::optional<bool> DefinedFormattedIo(
     // There's a defined I/O subroutine, but there's a FORMAT present and
     // it does not have a DT data edit descriptor, so apply default formatting
     // to the components of the derived type as usual.
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
 }
 

--- a/flang-rt/lib/runtime/edit-input.cpp
+++ b/flang-rt/lib/runtime/edit-input.cpp
@@ -52,9 +52,9 @@ template <int LOG2_BASE>
 static RT_API_ATTRS bool EditBOZInput(
     IoStatementState &io, const DataEdit &edit, void *n, std::size_t bytes) {
   // Skip leading white space & zeroes
-  Fortran::common::optional<int> remaining{io.CueUpInput(edit)};
+  common::optional<int> remaining{io.CueUpInput(edit)};
   auto start{io.GetConnectionState().positionInRecord};
-  Fortran::common::optional<char32_t> next{io.NextInField(remaining, edit)};
+  common::optional<char32_t> next{io.NextInField(remaining, edit)};
   if (next.value_or('?') == '0') {
     do {
       start = io.GetConnectionState().positionInRecord;
@@ -154,8 +154,8 @@ static RT_API_ATTRS bool EditBOZInput(
 
 // Prepares input from a field, and returns the sign, if any, else '\0'.
 static RT_API_ATTRS char ScanNumericPrefix(IoStatementState &io,
-    const DataEdit &edit, Fortran::common::optional<char32_t> &next,
-    Fortran::common::optional<int> &remaining,
+    const DataEdit &edit, common::optional<char32_t> &next,
+    common::optional<int> &remaining,
     IoStatementState::FastAsciiField *fastField = nullptr) {
   remaining = io.CueUpInput(edit, fastField);
   next = io.NextInField(remaining, edit, fastField);
@@ -202,8 +202,8 @@ RT_API_ATTRS bool EditIntegerInput(IoStatementState &io, const DataEdit &edit,
         edit.descriptor);
     return false;
   }
-  Fortran::common::optional<int> remaining;
-  Fortran::common::optional<char32_t> next;
+  common::optional<int> remaining;
+  common::optional<char32_t> next;
   auto fastField{io.GetUpcomingFastAsciiField()};
   char sign{ScanNumericPrefix(io, edit, next, remaining, &fastField)};
   if (sign == '-' && !isSigned) {
@@ -318,10 +318,10 @@ struct ScannedRealInput {
 };
 static RT_API_ATTRS ScannedRealInput ScanRealInput(
     char *buffer, int bufferSize, IoStatementState &io, const DataEdit &edit) {
-  Fortran::common::optional<int> remaining;
-  Fortran::common::optional<char32_t> next;
+  common::optional<int> remaining;
+  common::optional<char32_t> next;
   int got{0};
-  Fortran::common::optional<int> radixPointOffset;
+  common::optional<int> radixPointOffset;
   // The following lambda definition violates the conding style,
   // but cuda-11.8 nvcc hits an internal error with the brace initialization.
   auto Put = [&](char ch) -> void {
@@ -938,8 +938,8 @@ RT_API_ATTRS bool EditLogicalInput(
         edit.descriptor);
     return false;
   }
-  Fortran::common::optional<int> remaining{io.CueUpInput(edit)};
-  Fortran::common::optional<char32_t> next{io.NextInField(remaining, edit)};
+  common::optional<int> remaining{io.CueUpInput(edit)};
+  common::optional<char32_t> next{io.NextInField(remaining, edit)};
   if (next && *next == '.') { // skip optional period
     next = io.NextInField(remaining, edit);
   }

--- a/flang-rt/lib/runtime/environment.cpp
+++ b/flang-rt/lib/runtime/environment.cpp
@@ -52,8 +52,7 @@ static void SetEnvironmentDefaults(const EnvironmentDefaultList *envDefaults) {
 }
 
 RT_OFFLOAD_API_GROUP_BEGIN
-Fortran::common::optional<Convert> GetConvertFromString(
-    const char *x, std::size_t n) {
+common::optional<Convert> GetConvertFromString(const char *x, std::size_t n) {
   static const char *keywords[]{
       "UNKNOWN", "NATIVE", "LITTLE_ENDIAN", "BIG_ENDIAN", "SWAP", nullptr};
   switch (IdentifyValue(x, n, keywords)) {
@@ -68,7 +67,7 @@ Fortran::common::optional<Convert> GetConvertFromString(
   case 4:
     return Convert::Swap;
   default:
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
 }
 RT_OFFLOAD_API_GROUP_END

--- a/flang-rt/lib/runtime/io-api-common.h
+++ b/flang-rt/lib/runtime/io-api-common.h
@@ -31,7 +31,7 @@ static inline RT_API_ATTRS Cookie NoopUnit(const Terminator &terminator,
 }
 
 static inline RT_API_ATTRS ExternalFileUnit *GetOrCreateUnit(int unitNumber,
-    Direction direction, Fortran::common::optional<bool> isUnformatted,
+    Direction direction, common::optional<bool> isUnformatted,
     const Terminator &terminator, Cookie &errorCookie) {
   IoErrorHandler handler{terminator};
   handler.HasIoStat();

--- a/flang-rt/lib/runtime/io-api.cpp
+++ b/flang-rt/lib/runtime/io-api.cpp
@@ -386,8 +386,8 @@ Cookie IODEF(BeginEndfile)(
   Terminator terminator{sourceFile, sourceLine};
   Cookie errorCookie{nullptr};
   if (ExternalFileUnit *
-      unit{GetOrCreateUnit(unitNumber, Direction::Output,
-          Fortran::common::nullopt, terminator, errorCookie)}) {
+      unit{GetOrCreateUnit(unitNumber, Direction::Output, common::nullopt,
+          terminator, errorCookie)}) {
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<ErroneousIoStatementState>(
           IostatBadOpOnChildUnit, nullptr /* no unit */, sourceFile,
@@ -406,8 +406,8 @@ Cookie IODEF(BeginRewind)(
   Terminator terminator{sourceFile, sourceLine};
   Cookie errorCookie{nullptr};
   if (ExternalFileUnit *
-      unit{GetOrCreateUnit(unitNumber, Direction::Input,
-          Fortran::common::nullopt, terminator, errorCookie)}) {
+      unit{GetOrCreateUnit(unitNumber, Direction::Input, common::nullopt,
+          terminator, errorCookie)}) {
     if (ChildIo * child{unit->GetChildIo()}) {
       return &child->BeginIoStatement<ErroneousIoStatementState>(
           IostatBadOpOnChildUnit, nullptr /* no unit */, sourceFile,
@@ -732,7 +732,7 @@ bool IODEF(SetAction)(Cookie cookie, const char *keyword, std::size_t length) {
     io.GetIoErrorHandler().Crash(
         "SetAction() called after GetNewUnit() for an OPEN statement");
   }
-  Fortran::common::optional<Action> action;
+  common::optional<Action> action;
   static const char *keywords[]{"READ", "WRITE", "READWRITE", nullptr};
   switch (IdentifyValue(keyword, length, keywords)) {
   case 0:

--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -46,9 +46,9 @@ bool IoStatementBase::Receive(char *, std::size_t, std::size_t) {
   return false;
 }
 
-Fortran::common::optional<DataEdit> IoStatementBase::GetNextDataEdit(
+common::optional<DataEdit> IoStatementBase::GetNextDataEdit(
     IoStatementState &, int) {
-  return Fortran::common::nullopt;
+  return common::nullopt;
 }
 
 bool IoStatementBase::BeginReadingRecord() { return true; }
@@ -532,7 +532,7 @@ int ExternalFormattedIoStatementState<DIR, CHAR>::EndIoStatement() {
   return ExternalIoStatementState<DIR>::EndIoStatement();
 }
 
-Fortran::common::optional<DataEdit> IoStatementState::GetNextDataEdit(int n) {
+common::optional<DataEdit> IoStatementState::GetNextDataEdit(int n) {
   return common::visit(
       [&](auto &x) { return x.get().GetNextDataEdit(*this, n); }, u_);
 }
@@ -618,13 +618,13 @@ ExternalFileUnit *IoStatementState::GetExternalFileUnit() const {
       [](auto &x) { return x.get().GetExternalFileUnit(); }, u_);
 }
 
-Fortran::common::optional<char32_t> IoStatementState::GetCurrentCharSlow(
+common::optional<char32_t> IoStatementState::GetCurrentCharSlow(
     std::size_t &byteCount) {
   const char *p{nullptr};
   std::size_t bytes{GetNextInputBytes(p)};
   if (bytes == 0) {
     byteCount = 0;
-    return Fortran::common::nullopt;
+    return common::nullopt;
   } else {
     const ConnectionState &connection{GetConnectionState()};
     if (connection.isUTF8) {
@@ -661,8 +661,8 @@ IoStatementState::FastAsciiField IoStatementState::GetUpcomingFastAsciiField() {
   return FastAsciiField{connection};
 }
 
-Fortran::common::optional<char32_t> IoStatementState::NextInField(
-    Fortran::common::optional<int> &remaining, const DataEdit &edit,
+common::optional<char32_t> IoStatementState::NextInField(
+    common::optional<int> &remaining, const DataEdit &edit,
     FastAsciiField *field) {
   std::size_t byteCount{0};
   if (!remaining) { // Stream, list-directed, NAMELIST, &c.
@@ -680,21 +680,21 @@ Fortran::common::optional<char32_t> IoStatementState::NextInField(
         case '"':
         case '*':
         case '\n': // for stream access
-          return Fortran::common::nullopt;
+          return common::nullopt;
         case '&':
         case '$':
           if (edit.IsNamelist()) {
-            return Fortran::common::nullopt;
+            return common::nullopt;
           }
           break;
         case ',':
           if (!(edit.modes.editingFlags & decimalComma)) {
-            return Fortran::common::nullopt;
+            return common::nullopt;
           }
           break;
         case ';':
           if (edit.modes.editingFlags & decimalComma) {
-            return Fortran::common::nullopt;
+            return common::nullopt;
           }
           break;
         default:
@@ -712,7 +712,7 @@ Fortran::common::optional<char32_t> IoStatementState::NextInField(
   } else if (*remaining > 0) {
     if (auto next{GetCurrentChar(byteCount, field)}) {
       if (byteCount > static_cast<std::size_t>(*remaining)) {
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
       *remaining -= byteCount;
       if (field) {
@@ -726,10 +726,10 @@ Fortran::common::optional<char32_t> IoStatementState::NextInField(
     if (CheckForEndOfRecord(0,
             field ? field->connection() : GetConnectionState())) { // do padding
       --*remaining;
-      return Fortran::common::optional<char32_t>{' '};
+      return common::optional<char32_t>{' '};
     }
   }
-  return Fortran::common::nullopt;
+  return common::nullopt;
 }
 
 bool IoStatementState::CheckForEndOfRecord(
@@ -821,7 +821,7 @@ bool ListDirectedStatementState<Direction::Output>::EmitLeadingSpaceOrAdvance(
   return true;
 }
 
-Fortran::common::optional<DataEdit>
+common::optional<DataEdit>
 ListDirectedStatementState<Direction::Output>::GetNextDataEdit(
     IoStatementState &io, int maxRepeat) {
   DataEdit edit;
@@ -838,7 +838,7 @@ int ListDirectedStatementState<Direction::Input>::EndIoStatement() {
   return IostatOk;
 }
 
-Fortran::common::optional<DataEdit>
+common::optional<DataEdit>
 ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
     IoStatementState &io, int maxRepeat) {
   // N.B. list-directed transfers cannot be nonadvancing (C1221)
@@ -891,7 +891,7 @@ ListDirectedStatementState<Direction::Input>::GetNextDataEdit(
   }
   eatComma_ = true;
   if (!ch) {
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
   if (*ch == '/') {
     hitSlash_ = true;

--- a/flang-rt/lib/runtime/misc-intrinsic.cpp
+++ b/flang-rt/lib/runtime/misc-intrinsic.cpp
@@ -19,7 +19,7 @@ namespace Fortran::runtime {
 
 static RT_API_ATTRS void TransferImpl(Descriptor &result,
     const Descriptor &source, const Descriptor &mold, const char *sourceFile,
-    int line, Fortran::common::optional<std::int64_t> resultExtent) {
+    int line, common::optional<std::int64_t> resultExtent) {
   int rank{resultExtent.has_value() ? 1 : 0};
   std::size_t elementBytes{mold.ElementBytes()};
   result.Establish(mold.type(), elementBytes, nullptr, rank, nullptr,
@@ -91,7 +91,7 @@ void RTDEF(Rename)(const Descriptor &path1, const Descriptor &path2,
 
 void RTDEF(Transfer)(Descriptor &result, const Descriptor &source,
     const Descriptor &mold, const char *sourceFile, int line) {
-  Fortran::common::optional<std::int64_t> elements;
+  common::optional<std::int64_t> elements;
   if (mold.rank() > 0) {
     if (std::size_t sourceElementBytes{
             source.Elements() * source.ElementBytes()}) {

--- a/flang-rt/lib/runtime/namelist.cpp
+++ b/flang-rt/lib/runtime/namelist.cpp
@@ -125,11 +125,11 @@ static RT_API_ATTRS bool GetLowerCaseName(IoStatementState &io, char buffer[],
   return false;
 }
 
-static RT_API_ATTRS Fortran::common::optional<SubscriptValue> GetSubscriptValue(
+static RT_API_ATTRS common::optional<SubscriptValue> GetSubscriptValue(
     IoStatementState &io) {
-  Fortran::common::optional<SubscriptValue> value;
+  common::optional<SubscriptValue> value;
   std::size_t byteCount{0};
-  Fortran::common::optional<char32_t> ch{io.GetCurrentChar(byteCount)};
+  common::optional<char32_t> ch{io.GetCurrentChar(byteCount)};
   bool negate{ch && *ch == '-'};
   if ((ch && *ch == '+') || negate) {
     io.HandleRelativePosition(byteCount);
@@ -146,7 +146,7 @@ static RT_API_ATTRS Fortran::common::optional<SubscriptValue> GetSubscriptValue(
   if (overflow) {
     io.GetIoErrorHandler().SignalError(
         "NAMELIST input subscript value overflow");
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
   if (negate) {
     if (value) {
@@ -168,7 +168,7 @@ static RT_API_ATTRS bool HandleSubscripts(IoStatementState &io,
   std::size_t contiguousStride{source.ElementBytes()};
   bool ok{true};
   std::size_t byteCount{0};
-  Fortran::common::optional<char32_t> ch{io.GetNextNonBlank(byteCount)};
+  common::optional<char32_t> ch{io.GetNextNonBlank(byteCount)};
   char32_t comma{GetComma(io)};
   for (; ch && *ch != ')'; ++j) {
     SubscriptValue dimLower{0}, dimUpper{0}, dimStride{0};
@@ -300,9 +300,9 @@ static RT_API_ATTRS bool HandleSubstring(
   SubscriptValue chars{static_cast<SubscriptValue>(desc.ElementBytes()) / kind};
   // Allow for blanks in substring bounds; they're nonstandard, but not
   // ambiguous within the parentheses.
-  Fortran::common::optional<SubscriptValue> lower, upper;
+  common::optional<SubscriptValue> lower, upper;
   std::size_t byteCount{0};
-  Fortran::common::optional<char32_t> ch{io.GetNextNonBlank(byteCount)};
+  common::optional<char32_t> ch{io.GetNextNonBlank(byteCount)};
   if (ch) {
     if (*ch == ':') {
       lower = 1;
@@ -364,8 +364,7 @@ static RT_API_ATTRS bool HandleComponent(IoStatementState &io, Descriptor &desc,
           // If base and component are both arrays, the component name
           // must be followed by subscripts; process them now.
           std::size_t byteCount{0};
-          if (Fortran::common::optional<char32_t> next{
-                  io.GetNextNonBlank(byteCount)};
+          if (common::optional<char32_t> next{io.GetNextNonBlank(byteCount)};
               next && *next == '(') {
             io.HandleRelativePosition(byteCount); // skip over '('
             StaticDescriptor<maxRank, true, 16> staticDesc;
@@ -454,7 +453,7 @@ bool IODEF(InputNamelist)(Cookie cookie, const NamelistGroup &group) {
   RUNTIME_CHECK(handler, listInput != nullptr);
   // Find this namelist group's header in the input
   io.BeginReadingRecord();
-  Fortran::common::optional<char32_t> next;
+  common::optional<char32_t> next;
   char name[nameBufferSize];
   RUNTIME_CHECK(handler, group.groupName != nullptr);
   char32_t comma{GetComma(io)};

--- a/flang-rt/lib/runtime/pseudo-unit.cpp
+++ b/flang-rt/lib/runtime/pseudo-unit.cpp
@@ -35,8 +35,7 @@ ExternalFileUnit *ExternalFileUnit::LookUpOrCreate(
 }
 
 ExternalFileUnit *ExternalFileUnit::LookUpOrCreateAnonymous(int unit,
-    Direction direction, Fortran::common::optional<bool>,
-    IoErrorHandler &handler) {
+    Direction direction, common::optional<bool>, IoErrorHandler &handler) {
   if (direction != Direction::Output) {
     handler.Crash("ExternalFileUnit only supports output IO");
   }
@@ -59,14 +58,14 @@ ExternalFileUnit &ExternalFileUnit::NewUnit(const Terminator &, bool) {
   Terminator{__FILE__, __LINE__}.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-bool ExternalFileUnit::OpenUnit(Fortran::common::optional<OpenStatus> status,
-    Fortran::common::optional<Action>, Position, OwningPtr<char> &&,
-    std::size_t, Convert, IoErrorHandler &handler) {
+bool ExternalFileUnit::OpenUnit(common::optional<OpenStatus> status,
+    common::optional<Action>, Position, OwningPtr<char> &&, std::size_t,
+    Convert, IoErrorHandler &handler) {
   handler.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 
-bool ExternalFileUnit::OpenAnonymousUnit(Fortran::common::optional<OpenStatus>,
-    Fortran::common::optional<Action>, Position, Convert convert,
+bool ExternalFileUnit::OpenAnonymousUnit(common::optional<OpenStatus>,
+    common::optional<Action>, Position, Convert convert,
     IoErrorHandler &handler) {
   handler.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
@@ -105,13 +104,12 @@ void PseudoOpenFile::set_mayAsynchronous(bool yes) {
   }
 }
 
-Fortran::common::optional<PseudoOpenFile::FileOffset>
-PseudoOpenFile::knownSize() const {
+common::optional<PseudoOpenFile::FileOffset> PseudoOpenFile::knownSize() const {
   Terminator{__FILE__, __LINE__}.Crash("unsupported");
 }
 
-void PseudoOpenFile::Open(OpenStatus, Fortran::common::optional<Action>,
-    Position, IoErrorHandler &handler) {
+void PseudoOpenFile::Open(
+    OpenStatus, common::optional<Action>, Position, IoErrorHandler &handler) {
   handler.Crash("%s: unsupported", RT_PRETTY_FUNCTION);
 }
 

--- a/flang-rt/lib/runtime/random.cpp
+++ b/flang-rt/lib/runtime/random.cpp
@@ -28,7 +28,7 @@ namespace Fortran::runtime::random {
 
 Lock lock;
 Generator generator;
-Fortran::common::optional<GeneratedWord> nextValue;
+common::optional<GeneratedWord> nextValue;
 
 extern "C" {
 

--- a/flang-rt/lib/runtime/type-code.cpp
+++ b/flang-rt/lib/runtime/type-code.cpp
@@ -131,7 +131,7 @@ RT_API_ATTRS TypeCode::TypeCode(TypeCategory f, int kind) {
   }
 }
 
-RT_API_ATTRS Fortran::common::optional<std::pair<TypeCategory, int>>
+RT_API_ATTRS common::optional<std::pair<TypeCategory, int>>
 TypeCode::GetCategoryAndKind() const {
   switch (raw_) {
   case CFI_type_signed_char:
@@ -233,7 +233,7 @@ TypeCode::GetCategoryAndKind() const {
   case CFI_type_uint128_t:
     return std::make_pair(TypeCategory::Unsigned, 16);
   default:
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
 }
 

--- a/flang-rt/lib/runtime/type-info.cpp
+++ b/flang-rt/lib/runtime/type-info.cpp
@@ -15,7 +15,7 @@ namespace Fortran::runtime::typeInfo {
 
 RT_OFFLOAD_API_GROUP_BEGIN
 
-RT_API_ATTRS Fortran::common::optional<TypeParameterValue> Value::GetValue(
+RT_API_ATTRS common::optional<TypeParameterValue> Value::GetValue(
     const Descriptor *descriptor) const {
   switch (genre_) {
   case Genre::Explicit:
@@ -26,9 +26,9 @@ RT_API_ATTRS Fortran::common::optional<TypeParameterValue> Value::GetValue(
         return addendum->LenParameterValue(value_);
       }
     }
-    return Fortran::common::nullopt;
+    return common::nullopt;
   default:
-    return Fortran::common::nullopt;
+    return common::nullopt;
   }
 }
 

--- a/flang-rt/lib/runtime/unit-map.cpp
+++ b/flang-rt/lib/runtime/unit-map.cpp
@@ -30,7 +30,7 @@ void UnitMap::Initialize() {
 ExternalFileUnit &UnitMap::NewUnit(const Terminator &terminator) {
   CriticalSection critical{lock_};
   Initialize();
-  Fortran::common::optional<int> n{freeNewUnits_.PopValue()};
+  common::optional<int> n{freeNewUnits_.PopValue()};
   if (!n) {
     n = emergencyNewUnit_++;
   }

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -71,10 +71,10 @@ public:
   // at the end of IO statement.
   RT_API_ATTRS bool isTerminal() const { return true; }
   RT_API_ATTRS bool isWindowsTextFile() const { return false; }
-  RT_API_ATTRS Fortran::common::optional<FileOffset> knownSize() const;
+  RT_API_ATTRS common::optional<FileOffset> knownSize() const;
   RT_API_ATTRS bool IsConnected() const { return false; }
-  RT_API_ATTRS void Open(OpenStatus, Fortran::common::optional<Action>,
-      Position, IoErrorHandler &);
+  RT_API_ATTRS void Open(
+      OpenStatus, common::optional<Action>, Position, IoErrorHandler &);
   RT_API_ATTRS void Predefine(int fd) {}
   RT_API_ATTRS void Close(CloseStatus, IoErrorHandler &);
   RT_API_ATTRS std::size_t Read(FileOffset, char *, std::size_t minBytes,
@@ -127,8 +127,7 @@ public:
   static RT_API_ATTRS ExternalFileUnit *LookUpOrCreate(
       int unit, const Terminator &, bool &wasExtant);
   static RT_API_ATTRS ExternalFileUnit *LookUpOrCreateAnonymous(int unit,
-      Direction, Fortran::common::optional<bool> isUnformatted,
-      IoErrorHandler &);
+      Direction, common::optional<bool> isUnformatted, IoErrorHandler &);
   static RT_API_ATTRS ExternalFileUnit *LookUp(
       const char *path, std::size_t pathLen);
   static RT_API_ATTRS ExternalFileUnit &CreateNew(int unit, const Terminator &);
@@ -139,11 +138,11 @@ public:
   static RT_API_ATTRS void FlushAll(IoErrorHandler &);
 
   // Returns true if an existing unit was closed
-  RT_API_ATTRS bool OpenUnit(Fortran::common::optional<OpenStatus>,
-      Fortran::common::optional<Action>, Position, OwningPtr<char> &&path,
+  RT_API_ATTRS bool OpenUnit(common::optional<OpenStatus>,
+      common::optional<Action>, Position, OwningPtr<char> &&path,
       std::size_t pathLength, Convert, IoErrorHandler &);
-  RT_API_ATTRS bool OpenAnonymousUnit(Fortran::common::optional<OpenStatus>,
-      Fortran::common::optional<Action>, Position, Convert, IoErrorHandler &);
+  RT_API_ATTRS bool OpenAnonymousUnit(common::optional<OpenStatus>,
+      common::optional<Action>, Position, Convert, IoErrorHandler &);
   RT_API_ATTRS void CloseUnit(CloseStatus, IoErrorHandler &);
   RT_API_ATTRS void DestroyClosed();
 
@@ -254,7 +253,7 @@ private:
       u_;
 
   // Points to the active alternative (if any) in u_ for use as a Cookie
-  Fortran::common::optional<IoStatementState> io_;
+  common::optional<IoStatementState> io_;
 
   // A stack of child I/O pseudo-units for defined I/O that have this
   // unit number.
@@ -298,7 +297,7 @@ private:
       ChildUnformattedIoStatementState<Direction::Input>, InquireUnitState,
       ErroneousIoStatementState, ExternalMiscIoStatementState>
       u_;
-  Fortran::common::optional<IoStatementState> io_;
+  common::optional<IoStatementState> io_;
 };
 
 RT_OFFLOAD_API_GROUP_END

--- a/flang-rt/lib/runtime/utf.cpp
+++ b/flang-rt/lib/runtime/utf.cpp
@@ -56,7 +56,7 @@ std::size_t MeasurePreviousUTF8Bytes(const char *end, std::size_t limit) {
 }
 
 // Non-minimal encodings are accepted.
-Fortran::common::optional<char32_t> DecodeUTF8(const char *p0) {
+common::optional<char32_t> DecodeUTF8(const char *p0) {
   const std::uint8_t *p{reinterpret_cast<const std::uint8_t *>(p0)};
   std::size_t bytes{MeasureUTF8Bytes(*p0)};
   if (bytes == 1) {
@@ -66,7 +66,7 @@ Fortran::common::optional<char32_t> DecodeUTF8(const char *p0) {
     for (std::size_t j{1}; j < bytes; ++j) {
       std::uint8_t next{p[j]};
       if (next < 0x80 || next > 0xbf) {
-        return Fortran::common::nullopt;
+        return common::nullopt;
       }
       result = (result << 6) | (next & 0x3f);
     }
@@ -74,7 +74,7 @@ Fortran::common::optional<char32_t> DecodeUTF8(const char *p0) {
       return static_cast<char32_t>(result);
     }
   }
-  return Fortran::common::nullopt;
+  return common::nullopt;
 }
 
 std::size_t EncodeUTF8(char *p0, char32_t ucs) {


### PR DESCRIPTION
When somebody replaced uses of std::optional<> in the runtime with a new optional<> defined locally, many needless top-level Fortran:: namespace qualifiers were added, which are inconsistent with namespace usage in the runtime.  Clean them up.