### PR TITLE
[CI] Handle Runtime Build Failures Correctly in generate_test_report

### DIFF
--- a/.ci/generate_test_report_lib.py
+++ b/.ci/generate_test_report_lib.py
@@ -27,6 +27,13 @@ def _parse_ninja_log(ninja_log: list[str]) -> list[tuple[str, str]]:
             # We hit the end of the log without finding a build failure, go to
             # the next log.
             return failures
+        # If we are doing a build with LLVM_ENABLE_RUNTIMES, we can have nested
+        # ninja invocations. The sub-ninja will print that a subcommand failed,
+        # and then the outer ninja will list the command that failed. We should
+        # ignore the outer failure.
+        if ninja_log[index - 1].startswith("ninja: build stopped:"):
+            index += 1
+            continue
         # We are trying to parse cases like the following:
         #
         # [4/5] test/4.stamp

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -126,6 +126,11 @@ class TestReports(unittest.TestCase):
             ),
         )
 
+    # Test that we can correctly handle the runtimes build. the LLVM runtimes
+    # build will involve ninja invoking more ninja processes within the
+    # runtimes directory. This means that we see two failures for a failure in
+    # the runtimes build: one from the inner ninja containing the actual action
+    # that failed, and one for the sub ninja invocation that failed.
     def test_ninja_log_runtimes_failure(self):
         failures = generate_test_report_lib.find_failure_in_ninja_logs(
             [

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -125,7 +125,7 @@ class TestReports(unittest.TestCase):
                 ),
             ),
         )
-    
+
     def test_ninja_log_runtimes_failure(self):
         failures = generate_test_report_lib.find_failure_in_ninja_logs(
             [

--- a/.ci/generate_test_report_lib_test.py
+++ b/.ci/generate_test_report_lib_test.py
@@ -125,6 +125,34 @@ class TestReports(unittest.TestCase):
                 ),
             ),
         )
+    
+    def test_ninja_log_runtimes_failure(self):
+        failures = generate_test_report_lib.find_failure_in_ninja_logs(
+            [
+                [
+                    "[1/5] test/1.stamp",
+                    "[2/5] test/2.stamp",
+                    "FAILED: touch test/2.stamp",
+                    "Wow! This system is really broken!",
+                    "ninja: build stopped: subcommand failed.",
+                    "FAILED: running check-runtime failed.",
+                    "<some random command>",
+                    "ninja: build stopped: subcommand failed.",
+                ]
+            ]
+        )
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(
+            failures[0],
+            (
+                "test/2.stamp",
+                dedent(
+                    """\
+                    FAILED: touch test/2.stamp
+                    Wow! This system is really broken!"""
+                ),
+            ),
+        )
 
     def test_title_only(self):
         self.assertEqual(


### PR DESCRIPTION
The nested ninja invocations currently confuse the script. Update  the script to handle this correctly and a test to ensure we do not regress this behavior in the future.