### PR TITLE
[libc][NFC] Fix Implicit Conversion Warning in getrandom Test

### DIFF
--- a/libc/test/src/sys/random/linux/getrandom_test.cpp
+++ b/libc/test/src/sys/random/linux/getrandom_test.cpp
@@ -19,11 +19,12 @@ using LlvmLibcGetRandomTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 TEST_F(LlvmLibcGetRandomTest, InvalidFlag) {
   LIBC_NAMESPACE::cpp::array<char, 10> buffer;
   ASSERT_THAT(LIBC_NAMESPACE::getrandom(buffer.data(), buffer.size(), -1),
-              Fails(EINVAL));
+              Fails<ssize_t>(EINVAL));
 }
 
 TEST_F(LlvmLibcGetRandomTest, InvalidBuffer) {
-  ASSERT_THAT(LIBC_NAMESPACE::getrandom(nullptr, 65536, 0), Fails(EFAULT));
+  ASSERT_THAT(LIBC_NAMESPACE::getrandom(nullptr, 65536, 0),
+              Fails<ssize_t>(EFAULT));
 }
 
 TEST_F(LlvmLibcGetRandomTest, ReturnsSize) {


### PR DESCRIPTION
getrandom returns a ssize_t, but the error codes are defined as integers. We need to use the builtin cast in the Fails matcher to ensure that everything is the same type.

clang will warn about this in a bootstrapping build. Originally found in \#155627.