### PR TITLE
AMDGPU: Move some code out of macro for defining regclass decoder

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -157,11 +157,11 @@ static DecodeStatus decodeRegisterClassImpl(MCInst &Inst, unsigned Imm,
   return addOperand(Inst, DAsm->createRegOperand(RegClassID, Imm));
 }
 
+using RegClassDecoder = decltype(&decodeRegisterClassImpl<0>);
+
 #define DECODE_OPERAND_REG_8(RegClass)                                         \
-  static const constexpr auto Decode##RegClass##RegisterClass =                \
-      [](auto... args) {                                                       \
-        return decodeRegisterClassImpl<AMDGPU::RegClass##RegClassID>(args...); \
-      };
+  static const constexpr RegClassDecoder Decode##RegClass##RegisterClass =     \
+      decodeRegisterClassImpl<AMDGPU::RegClass##RegClassID>;
 
 #define DECODE_SrcOp(Name, EncSize, OpWidth, EncImm)                           \
   static DecodeStatus Name(MCInst &Inst, unsigned Imm, uint64_t /*Addr*/,      \

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -157,11 +157,11 @@ static DecodeStatus decodeRegisterClassImpl(MCInst &Inst, unsigned Imm,
   return addOperand(Inst, DAsm->createRegOperand(RegClassID, Imm));
 }
 
-using RegClassDecoder = decltype(&decodeRegisterClassImpl<0>);
-
 #define DECODE_OPERAND_REG_8(RegClass)                                         \
-  static const constexpr RegClassDecoder Decode##RegClass##RegisterClass =     \
-      decodeRegisterClassImpl<AMDGPU::RegClass##RegClassID>;
+  static const constexpr auto Decode##RegClass##RegisterClass =                \
+      [](auto... args) {                                                       \
+        return decodeRegisterClassImpl<AMDGPU::RegClass##RegClassID>(args...); \
+      };
 
 #define DECODE_SrcOp(Name, EncSize, OpWidth, EncImm)                           \
   static DecodeStatus Name(MCInst &Inst, unsigned Imm, uint64_t /*Addr*/,      \


### PR DESCRIPTION
Use a template function for the implementation, and use the macro
to define a constant function pointer with the expected name. Not
sure if there's a cleaner way to do this. This worked out to less
code using variadic templates to forward the arguments, but it added
a noticable ~10 seconds to compilation time on this file.

This will help avoid another copy-paste version of this function
in a future change.