### PR TITLE
[clang][bytecode] Avoid copying APValue into EvaluationResult

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.h
+++ b/clang/lib/AST/ByteCode/EvaluationResult.h
@@ -55,7 +55,7 @@ private:
 
   void setSource(DeclTy D) { Source = D; }
 
-  void setValue(const APValue &V) {
+  void takeValue(APValue &&V) {
     // V could still be an LValue.
     assert(empty());
     Value = std::move(V);


### PR DESCRIPTION
Move the `APValue` into `EvaluationResult` instead.

For a large primitive array (`#embed` of the sqlite3 amalgamation), this improves compile times by around 25%.