### PR TITLE
[clang][bytecode][NFC] Remove FunctionPointer leftovers

### DIFF
--- a/clang/lib/AST/ByteCode/Disasm.cpp
+++ b/clang/lib/AST/ByteCode/Disasm.cpp
@@ -574,8 +574,6 @@ LLVM_DUMP_METHOD void EvaluationResult::dump() const {
     OS << "LValue: ";
     if (const auto *P = std::get_if<Pointer>(&Value))
       P->toAPValue(ASTCtx).printPretty(OS, ASTCtx, SourceType);
-    else if (const auto *FP = std::get_if<FunctionPointer>(&Value)) // Nope
-      FP->toAPValue(ASTCtx).printPretty(OS, ASTCtx, SourceType);
     OS << "\n";
     break;
   }

--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -23,8 +23,6 @@ APValue EvaluationResult::toAPValue() const {
     // Either a pointer or a function pointer.
     if (const auto *P = std::get_if<Pointer>(&Value))
       return P->toAPValue(Ctx->getASTContext());
-    else if (const auto *FP = std::get_if<FunctionPointer>(&Value))
-      return FP->toAPValue(Ctx->getASTContext());
     else
       llvm_unreachable("Unhandled LValue type");
     break;
@@ -46,8 +44,6 @@ std::optional<APValue> EvaluationResult::toRValue() const {
   // We have a pointer and want an RValue.
   if (const auto *P = std::get_if<Pointer>(&Value))
     return P->toRValue(*Ctx, getSourceType());
-  else if (const auto *FP = std::get_if<FunctionPointer>(&Value)) // Nope
-    return FP->toAPValue(Ctx->getASTContext());
   llvm_unreachable("Unhandled lvalue kind");
 }
 

--- a/clang/lib/AST/ByteCode/EvaluationResult.h
+++ b/clang/lib/AST/ByteCode/EvaluationResult.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_CLANG_AST_INTERP_EVALUATION_RESULT_H
 #define LLVM_CLANG_AST_INTERP_EVALUATION_RESULT_H
 
-#include "FunctionPointer.h"
 #include "Pointer.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/Decl.h"
@@ -43,7 +42,7 @@ public:
 
 private:
   const Context *Ctx = nullptr;
-  std::variant<std::monostate, Pointer, FunctionPointer, APValue> Value;
+  std::variant<std::monostate, Pointer, APValue> Value;
   ResultKind Kind = Empty;
   DeclTy Source = nullptr; // Currently only needed for dump().
 
@@ -60,11 +59,6 @@ private:
     assert(empty());
     Value = std::move(V);
     Kind = RValue;
-  }
-  void setFunctionPointer(const FunctionPointer &P) {
-    assert(empty());
-    Value = P;
-    Kind = LValue;
   }
   void setInvalid() {
     // We are NOT asserting empty() here, since setting it to invalid


### PR DESCRIPTION
from EvaluationResult. `setFunctionPointer()` is unused.