### PR TITLE
Revert "[X86] Fix incorrect NOP insertion between fused instructions that breaks macro fusion"

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86AsmBackend.cpp
@@ -485,16 +485,7 @@ void X86AsmBackend::emitInstructionBegin(MCObjectStreamer &OS,
   if (!CanPadInst)
     return;
 
-  if (PendingBA) {
-    auto *NextFragment = PendingBA->getNext();
-    assert(NextFragment && "NextFragment should not be null");
-    if (NextFragment == OS.getCurrentFragment())
-      return;
-    // We eagerly create an empty fragment when inserting a fragment
-    // with a variable-size tail.
-    if (NextFragment->getKind() == MCFragment::FT_Relaxable)
-      return;
-
+  if (PendingBA && PendingBA->getNext() == OS.getCurrentFragment()) {
     // Macro fusion actually happens and there is no other fragment inserted
     // after the previous instruction.
     //

--- a/llvm/test/MC/X86/align-branch-fused.s
+++ b/llvm/test/MC/X86/align-branch-fused.s
@@ -1,10 +1,7 @@
-# RUN: rm -rf %t && split-file %s %t && cd %t
-# RUN: llvm-mc -filetype=obj -triple x86_64 --x86-align-branch-boundary=32 --x86-align-branch=fused+jcc foo.s | llvm-objdump -d --no-show-raw-insn - | FileCheck foo.s
-# RUN: llvm-mc -filetype=obj -triple x86_64 --x86-align-branch-boundary=32 --x86-align-branch=fused+jcc -x86-pad-max-prefix-size=1 bar.s | llvm-objdump -d --no-show-raw-insn - | FileCheck bar.s
+# RUN: llvm-mc -filetype=obj -triple x86_64 --x86-align-branch-boundary=32 --x86-align-branch=fused+jcc %s | llvm-objdump -d --no-show-raw-insn - | FileCheck %s
 
   # Exercise cases where fused instructions need to be aligned.
 
-#--- foo.s
   .text
   .globl  foo
 foo:
@@ -43,18 +40,3 @@ foo:
   cmp  %rax, %rbp
   jne foo
   int3
-
-# Exercise the case where fused instructions need to be aligned,
-# ensuring fusion is not broken by a NOP
-
-#--- bar.s
-  .text
-	.globl	bar
-bar:
-  .nops 27
-# CHECK:      20:       testq   %rcx, %rcx
-# CHECK:      23:       je
-	testq	%rcx, %rcx
-	je	.EXIT
-.EXIT:
-	ret


### PR DESCRIPTION
Reverts llvm/llvm-project#155316