### PR TITLE
Be smarter about the GLIBCXX_USE_CXX11_ABI default

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -183,7 +183,15 @@ CHECK_CXX_SOURCE_COMPILES("
 int main() { return 0; }
 " LLVM_USES_LIBSTDCXX)
 
-option(GLIBCXX_USE_CXX11_ABI "Use new libstdc++ CXX11 ABI" ON)
+CHECK_CXX_SOURCE_COMPILES("
+#include <string>
+#if _GLIBCXX_USE_CXX11_ABI == 0
+#error _GLIBCXX_USE_CXX11_ABI not active
+#endif
+int main() { return 0; }
+" LLVM_DEFAULT_TO_GLIBCXX_USE_CXX11_ABI)
+
+option(GLIBCXX_USE_CXX11_ABI "Use new libstdc++ CXX11 ABI" ${LLVM_DEFAULT_TO_GLIBCXX_USE_CXX11_ABI})
 
 if (LLVM_USES_LIBSTDCXX)
   if (GLIBCXX_USE_CXX11_ABI)


### PR DESCRIPTION
It appears that unconditionally using GLIBCXX_USE_CXX11_ABI=0 is slow on modern libstdc++, while using GLIBCXX_USE_CXX11_ABI=1 breaks old buildbots, so use the compiler default unless asked to do differently.