### PR TITLE
[Offload][OpenMP] Tests require libc on GPU for printf

### DIFF
--- a/offload/test/mapping/map_ptr_and_star_global.c
+++ b/offload/test/mapping/map_ptr_and_star_global.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+
 // REQUIRES: libc
 
 #include <omp.h>

--- a/offload/test/mapping/map_ptr_and_star_global.c
+++ b/offload/test/mapping/map_ptr_and_star_global.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_ptr_and_star_local.c
+++ b/offload/test/mapping/map_ptr_and_star_local.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+
 // REQUIRES: libc
 
 #include <omp.h>

--- a/offload/test/mapping/map_ptr_and_star_local.c
+++ b/offload/test/mapping/map_ptr_and_star_local.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_ptr_and_subscript_global.c
+++ b/offload/test/mapping/map_ptr_and_subscript_global.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+
 // REQUIRES: libc
 
 #include <omp.h>

--- a/offload/test/mapping/map_ptr_and_subscript_global.c
+++ b/offload/test/mapping/map_ptr_and_subscript_global.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_ptr_and_subscript_local.c
+++ b/offload/test/mapping/map_ptr_and_subscript_local.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+
 // REQUIRES: libc
 
 #include <omp.h>

--- a/offload/test/mapping/map_ptr_and_subscript_local.c
+++ b/offload/test/mapping/map_ptr_and_subscript_local.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_global.c
+++ b/offload/test/mapping/map_structptr_and_member_global.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+
 // REQUIRES: libc
 
 #include <omp.h>

--- a/offload/test/mapping/map_structptr_and_member_global.c
+++ b/offload/test/mapping/map_structptr_and_member_global.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>

--- a/offload/test/mapping/map_structptr_and_member_local.c
+++ b/offload/test/mapping/map_structptr_and_member_local.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+
 // REQUIRES: libc
 
 #include <omp.h>

--- a/offload/test/mapping/map_structptr_and_member_local.c
+++ b/offload/test/mapping/map_structptr_and_member_local.c
@@ -1,4 +1,5 @@
 // RUN: %libomptarget-compilexx-run-and-check-generic
+// REQUIRES: libc
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
These tests currently fail when libc is not configured to be built as they require printf to be available in target regions.