### PR TITLE
[lldb] Add lldbHost dependency to lldbProtocolMCP

### DIFF
--- a/lldb/source/Protocol/MCP/CMakeLists.txt
+++ b/lldb/source/Protocol/MCP/CMakeLists.txt
@@ -8,6 +8,7 @@ add_lldb_library(lldbProtocolMCP NO_PLUGIN_DEPENDENCIES
   LINK_COMPONENTS
     Support
   LINK_LIBS
+    lldbHost
     lldbUtility
 )
 


### PR DESCRIPTION
Fixes linker error:

```
/usr/bin/ld: /tmp/lto-llvm-013f16.o: in function `lldb_private::JSONTransport<lldb_protocol::mcp::Request, lldb_protocol::mcp::Response, lldb_protocol::mcp::Notification>::OnRead(lldb_private::MainLoopBase&, lldb_private::Transport<lldb_protocol::mcp::Request, lldb_protocol::mcp::Response, lldb_protocol::mcp::Notification>::MessageHandler&)':
/usr/bin/../lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/bits/unique_ptr.h:1085:(.text._ZN12lldb_private13JSONTransportIN13lldb_protocol3mcp7RequestENS2_8ResponseENS2_12NotificationEE6OnReadERNS_12MainLoopBaseERNS_9TransportIS3_S4_S5_E14MessageHandlerE+0x7fc): undefined reference to `lldb_private::TransportUnhandledContentsError::TransportUnhandledContentsError(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)'
```