### PR TITLE
[lldb][test] Run ranges::ref_vew test only for libc++

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ranges/ref_view/TestDataFormatterStdRangesRefView.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ranges/ref_view/TestDataFormatterStdRangesRefView.py
@@ -29,7 +29,6 @@ class StdRangesRefViewDataFormatterTestCase(TestBase):
 
     def do_test(self):
         """Test that std::ranges::ref_view is formatted correctly when printed."""
-        self.build()
         (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "Break here", lldb.SBFileSpec("main.cpp", False)
         )


### PR DESCRIPTION
Remove redundant build step in std::ranges::ref_view test, this causes it use `libstdc++` on linux instead of `libc++` .