### PR TITLE
[ADT] Fix signed integer overflow

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -124,7 +124,8 @@ struct DenseMapInfo<
     if constexpr (std::is_unsigned_v<T> && sizeof(T) > sizeof(unsigned))
       return densemap::detail::mix(Val);
     else
-      return static_cast<unsigned>(Val * 37U);
+      return static_cast<unsigned>(Val *
+                                   static_cast<std::make_unsigned_t<T>>(37U));
   }
 
   static bool isEqual(const T &LHS, const T &RHS) { return LHS == RHS; }


### PR DESCRIPTION
Fixes the signed overflow for signed types > int after #155549, as integer promotion would result in `Val * 37U` being signed which would result in UB signed overflow for large values 