### PR TITLE
[FuncSpec] Invalidate analysis by setting MadeChanges explicitly

### DIFF
--- a/llvm/lib/Transforms/IPO/SCCP.cpp
+++ b/llvm/lib/Transforms/IPO/SCCP.cpp
@@ -170,9 +170,12 @@ static bool runIPSCCP(
     if (F.isDeclaration())
       continue;
     // Skip the dead functions marked by FunctionSpecializer, avoiding removing
-    // blocks in dead functions.
-    if (IsFuncSpecEnabled && Specializer.isDeadFunction(&F))
+    // blocks in dead functions. Set MadeChanges if there is any dead function
+    // that will be removed later.
+    if (IsFuncSpecEnabled && Specializer.isDeadFunction(&F)) {
+      MadeChanges = true;
       continue;
+    }
 
     SmallVector<BasicBlock *, 512> BlocksToErase;
 


### PR DESCRIPTION
As reported in https://github.com/llvm/llvm-project/issues/154668#issuecomment-3233294078, we missed invalidating analysis as we don't set the MadeChanges to true after removing dead functions.

This patch makes it explicit to remove the dead functions marked by FuncSpec in SCCP and set MadeChanges correctly.