### PR TITLE
libclc: CMake: include GetClangResourceDir

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -99,6 +99,7 @@ else()
 
   # Setup the paths where libclc runtimes should be stored. By default, in an
   # in-tree build we place the libraries in clang's resource driectory.
+  include(GetClangResourceDir)
   get_clang_resource_dir( LIBCLC_OUTPUT_DIR PREFIX ${LLVM_LIBRARY_OUTPUT_INTDIR}/.. )
 
   # Note we do not adhere to LLVM_ENABLE_PER_TARGET_RUNTIME_DIR.


### PR DESCRIPTION
`get_clang_resource_dir` is not guarantee to be there. Make sure of it by including `GetClangResourceDir`.