### PR TITLE
[clang-format] Fix TableGen nested DAGArg format

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1045,6 +1045,14 @@ private:
       }
     }
     // Parse the [DagArgList] part
+    return parseTableGenDAGArgList(Opener, BreakInside);
+  }
+
+  // DagArgList   ::=  "," DagArg [DagArgList]
+  // This parses SimpleValue 6's [DagArgList] part.
+  bool parseTableGenDAGArgList(FormatToken *Opener, bool BreakInside) {
+    ScopedContextCreator ContextCreator(*this, tok::l_paren, 1);
+    Contexts.back().IsTableGenDAGArgList = true;
     bool FirstDAGArgListElm = true;
     while (CurrentToken) {
       if (!FirstDAGArgListElm && CurrentToken->is(tok::comma)) {
@@ -1101,6 +1109,9 @@ private:
     // SimpleValue6 ::=  "(" DagArg [DagArgList] ")"
     if (Tok->is(tok::l_paren)) {
       Tok->setType(TT_TableGenDAGArgOpener);
+      // Nested DAGArg requires space before '(' as separator.
+      if (Contexts.back().IsTableGenDAGArgList)
+        Tok->SpacesRequiredBefore = 1;
       return parseTableGenDAGArgAndList(Tok);
     }
     // SimpleValue 9: Bang operator
@@ -2138,7 +2149,7 @@ private:
     // Whether the braces may mean concatenation instead of structure or array
     // literal.
     bool VerilogMayBeConcatenation = false;
-    bool IsTableGenDAGArg = false;
+    bool IsTableGenDAGArgList = false;
     bool IsTableGenBangOpe = false;
     bool IsTableGenCondOpe = false;
     enum {

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1051,7 +1051,7 @@ private:
   // DagArgList   ::=  "," DagArg [DagArgList]
   // This parses SimpleValue 6's [DagArgList] part.
   bool parseTableGenDAGArgList(FormatToken *Opener, bool BreakInside) {
-    ScopedContextCreator ContextCreator(*this, tok::l_paren, 1);
+    ScopedContextCreator ContextCreator(*this, tok::l_paren, 0);
     Contexts.back().IsTableGenDAGArgList = true;
     bool FirstDAGArgListElm = true;
     while (CurrentToken) {

--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -185,8 +185,8 @@ TEST_F(FormatTestTableGen, SimpleValue6) {
                "      i32:$dst6,                                // dst6\n"
                "      i32:$dst7                                 // dst7\n"
                "  );\n"
-               "  let DAGArgBang =\n"
-               "      (!cast<SomeType>(\"Some\") i32:$src1, i32:$src2);\n"
+               "  let DAGArgBang = (!cast<SomeType>(\"Some\") i32:$src1,\n"
+               "      i32:$src2);\n"
                "  let NestedDAGArg = ((DAGArg1 (v111 v112, v113), v12) v2,\n"
                "      (DAGArg3 (v31 v32)));\n"
                "}");

--- a/clang/unittests/Format/FormatTestTableGen.cpp
+++ b/clang/unittests/Format/FormatTestTableGen.cpp
@@ -185,9 +185,16 @@ TEST_F(FormatTestTableGen, SimpleValue6) {
                "      i32:$dst6,                                // dst6\n"
                "      i32:$dst7                                 // dst7\n"
                "  );\n"
-               "  let DAGArgBang = (!cast<SomeType>(\"Some\") i32:$src1,\n"
-               "      i32:$src2);\n"
+               "  let DAGArgBang =\n"
+               "      (!cast<SomeType>(\"Some\") i32:$src1, i32:$src2);\n"
+               "  let NestedDAGArg = ((DAGArg1 (v111 v112, v113), v12) v2,\n"
+               "      (DAGArg3 (v31 v32)));\n"
                "}");
+}
+
+TEST_F(FormatTestTableGen, SimpleValue6_NestedInPat) {
+  verifyFormat("def : Pat<(vec.vt (avg (vec.vt V128:$l), (vec.vt V128:$r))),\n"
+               "          (inst $l, $r)>;");
 }
 
 TEST_F(FormatTestTableGen, SimpleValue7) {


### PR DESCRIPTION
Fixes https://github.com/llvm/llvm-project/issues/154634. 
Allow inserting space before DAGArg's opener paren when nested.