### PR TITLE
[Dexter] Update Dexter lit substitutions, making lldb-dap the default

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/aggregate-indirect-arg.cpp
@@ -3,7 +3,7 @@
 //
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 // Radar 8945514
 
 class SVal {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/asan-deque.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/asan-deque.cpp
@@ -10,7 +10,7 @@
 
 // RUN: %clang++ -std=gnu++11 -O1 -glldb -fsanitize=address -arch x86_64 %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 #include <deque>
 
 struct A {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/asan.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/asan.c
@@ -6,7 +6,7 @@
 // RUN: %clang -std=gnu11 --driver-mode=gcc -O0 -glldb -fblocks -arch x86_64 \
 // RUN:     -fsanitize=address %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 struct S {
   int a[8];

--- a/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/ctor.cpp
@@ -3,7 +3,7 @@
 //
 // RUN: %clang++ -std=gnu++11 -O0 -glldb %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 class A {
 public:

--- a/cross-project-tests/debuginfo-tests/dexter-tests/dbg-arg.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/dbg-arg.c
@@ -4,7 +4,7 @@
 // This test case checks debug info during register moves for an argument.
 // RUN: %clang -std=gnu11 -m64 -mllvm -fast-isel=false -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 //
 // Radar 8412415
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/deferred_globals.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-windows
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary  %t --debugger 'lldb' -v -- %s
+// RUN:     --binary  %t %dexter_lldb_args -v -- %s
 
 const int d = 100;
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/bitcast.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/bitcast.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 //// Adapted from https://bugs.llvm.org/show_bug.cgi?id=34136#c1
 //// LowerDbgDeclare has since been updated to look through bitcasts. We still

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/const-branch.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/const-branch.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 //// Adapted from https://bugs.llvm.org/show_bug.cgi?id=34136#c4
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ctrl-flow.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ctrl-flow.c
@@ -1,7 +1,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 //// Check that we give good locations to a variable ('local') which is escaped
 //// down some control paths and not others. This example is handled well currently.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/implicit-ptr.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/implicit-ptr.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 //// Check that 'param' in 'fun' can be read throughout, and that 'pa' and 'pb'
 //// can be dereferenced in the debugger even if we can't provide the pointer

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inline-escaping-function.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inline-escaping-function.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 // 1. param is escaped by inlineme(&param) so it is not promoted by
 //    SROA/mem2reg.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining-dse.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining-dse.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 //
 //// Check that once-escaped variable 'param' can still be read after we
 //// perform inlining + mem2reg, and that we see the DSE'd value 255.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/inlining.c
@@ -1,7 +1,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 //
 //// Check that the once-escaped variable 'param' can still be read after
 //// we perform inlining + mem2reg. See D89810 and D85555.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/loop.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/loop.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 //// Check that escaped local 'param' in function 'fun' has sensible debug info
 //// after the escaping function 'use' gets arg promotion (int* -> int). Currently

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/merged-store.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/merged-store.c
@@ -4,7 +4,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 
 // 1. parama is escaped by esc(&parama) so it is not promoted by
 //    SROA/mem2reg.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ptr-to.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/ptr-to.c
@@ -5,7 +5,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 //
 //// Check that a pointer to a variable living on the stack dereferences to the
 //// variable value.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/struct-dse.c
@@ -5,7 +5,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O2 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 1.0 -w %dexter_lldb_args --binary %t -- %s
 //
 //// Check debug-info for the escaped struct variable num is reasonable.
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/memvars/unused-merged-value.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/memvars/unused-merged-value.c
@@ -6,7 +6,7 @@
 // REQUIRES: lldb
 // UNSUPPORTED: system-windows
 // RUN: %clang -std=gnu11 -O3 -glldb %s -o %t
-// RUN: %dexter --fail-lt 0.1 -w --debugger lldb --binary %t -- %s
+// RUN: %dexter --fail-lt 0.1 -w %dexter_lldb_args --binary %t -- %s
 // See NOTE at end for more info about the RUN command.
 
 // 1. SROA/mem2reg fully promotes parama.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/namespace.cpp
@@ -7,7 +7,7 @@
 
 // RUN: %clang++ -g -O0 %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -v -- %s
+// RUN:     --binary %t %dexter_lldb_args -v -- %s
 
 #include <stdio.h>
 

--- a/cross-project-tests/debuginfo-tests/dexter-tests/nrvo-string.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/nrvo-string.cpp
@@ -9,11 +9,11 @@
 //
 // RUN: %clang++ -std=gnu++11 -O0 -glldb -fno-exceptions %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 //
 // RUN: %clang++ -std=gnu++11 -O1 -glldb -fno-exceptions %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 //
 // PR34513
 volatile int sideeffect = 0;

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-fastmath.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-fastmath.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang++ -std=gnu++11 -O2 -ffast-math -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 // RUN: %clang++ -std=gnu++11 -O0 -ffast-math -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 // REQUIRES: lldb
 // Currently getting intermittent failures on darwin.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-loops.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-loops.cpp
@@ -7,7 +7,7 @@
 
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 // A simple loop of assignments.
 // With optimization level > 0 the compiler reorders basic blocks

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-simple-functions.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-simple-functions.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 // REQUIRES: lldb, D136396
 // Currently getting intermittent failures on darwin.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-struct-and-methods.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-struct-and-methods.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -v -- %s
+// RUN:     --binary %t %dexter_lldb_args -v -- %s
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 // REQUIRES: lldb
 // Currently getting intermittent failures on darwin.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/optnone-vectors-and-functions.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/optnone-vectors-and-functions.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang++ -std=gnu++11 -O2 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -v -- %s
+// RUN:     --binary %t %dexter_lldb_args -v -- %s
 // RUN: %clang++ -std=gnu++11 -O0 -g %s -o %t
 // RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t --debugger 'lldb' -- %s
+// RUN:     --binary %t %dexter_lldb_args -- %s
 
 // REQUIRES: lldb
 // Currently getting intermittent failures on darwin.

--- a/cross-project-tests/debuginfo-tests/dexter-tests/stack-var.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/stack-var.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %clang -std=gnu11 -O -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'lldb' -- %s
+// RUN: %dexter --fail-lt 1.0 -w --binary %t %dexter_lldb_args -- %s
 
 void __attribute__((noinline, optnone)) bar(int *test) {}
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter-tests/vla.c
+++ b/cross-project-tests/debuginfo-tests/dexter-tests/vla.c
@@ -3,7 +3,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %clang -std=gnu11 -O0 -glldb %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w --binary %t --debugger 'lldb' -- %s
+// RUN: %dexter --fail-lt 1.0 -w --binary %t %dexter_lldb_args -- %s
 
 void init_vla(int size) {
   int i;

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
@@ -2,6 +2,9 @@
 //      Test that a \DexDeclareAddress value can be used to compare the
 //      addresses of two local variables that refer to the same address.
 //
+// NB: This test passes with `--debugger lldb-dap` but fails with --debugger lldb
+// XFAIL: !system-windows && !lldb-dap
+//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expression_address.cpp
@@ -14,4 +17,4 @@ int main() {
 
 // DexDeclareAddress('x_addr', '&x', on_line=ref('test_line'))
 // DexExpectWatchValue('&x', address('x_addr'), on_line=ref('test_line'))
-// DexExpectWatchValue('&y', address('x_addr'), on_line=ref('test_line'))
+// DexExpectWatchValue('y', address('x_addr'), on_line=ref('test_line'))

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
@@ -2,9 +2,6 @@
 //      Test that a \DexDeclareAddress value can be used to compare the
 //      addresses of two local variables that refer to the same address.
 //
-// NB: This test passes with `--debugger lldb-dap` but fails with --debugger lldb
-// XFAIL: !system-windows && !lldb-dap
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
 // CHECK: expression_address.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
@@ -12,10 +12,11 @@
 // CHECK: limit_steps_simple.cpp
 
 int main() {
-    int x = 0; // DexLabel('start')
-    x = 1;
+    int x = 0;
+    x = 1; // DexLabel('start')
     x = 2; // DexLabel('finish_line')
-} // DexLabel('finish')
+    return 0; // DexLabel('finish')
+}
 
 // DexLimitSteps(from_line=ref('start'), to_line=ref('finish'))
 // DexFinishTest(on_line=ref('finish_line'))

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_label_kwarg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_label_kwarg.cpp
@@ -2,7 +2,7 @@
 //    Check that bad keyword args in \DexLabel are reported.
 //    Use --binary switch to trick dexter into skipping the build step.
 //
-// RUN: not %dexter_base test --binary %s --debugger 'lldb' -- %s | FileCheck %s
+// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
 // CHECK: parser error:{{.*}}err_label_kwarg.cpp(8): unexpected named args: bad_arg
 
 // DexLabel('test', bad_arg=0)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_limit_steps_no_values.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_limit_steps_no_values.cpp
@@ -3,7 +3,7 @@
 //    in a \DexLimitSteps command results in a useful error message.
 //    Use --binary switch to trick dexter into skipping the build step.
 //
-// RUN: not %dexter_base test --binary %s --debugger 'lldb' -- %s | FileCheck %s
+// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
 // CHECK: parser error:{{.*}}err_limit_steps_no_values.cpp(9): expected 0 or at least 2 positional arguments
 
 // DexLimitSteps('test')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
@@ -8,7 +8,7 @@
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
-// CHECK:parser error:{{.*}}err_paren.cpp(22): Unbalanced parenthesis starting here
+// CHECK:parser error:{{.*}}err_paren.cpp(19): Unbalanced parenthesis starting here
 // CHECK:// {{Dex}}ExpectWatchValue(
 // CHECK:                      ^
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
@@ -8,7 +8,7 @@
 //       as the test should finish before lldb would be invoked.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger 'lldb' \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_paren.cpp(22): Unbalanced parenthesis starting here

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
@@ -4,9 +4,6 @@
 //      Check directives are in check.txt to prevent dexter reading any embedded
 //      commands.
 //
-// Note: Despite using 'lldb' as the debugger, lldb is not actually required
-//       as the test should finish before lldb would be invoked.
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
@@ -8,7 +8,7 @@
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
-// CHECK:parser error:{{.*}}err_paren_mline.cpp(23): Unbalanced parenthesis starting here
+// CHECK:parser error:{{.*}}err_paren_mline.cpp(20): Unbalanced parenthesis starting here
 // CHECK:{{Dex}}ExpectWatchValue(
 // CHECK:                   ^
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
@@ -8,7 +8,7 @@
 //       as the test should finish before lldb would be invoked.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger "lldb" \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_paren_mline.cpp(23): Unbalanced parenthesis starting here

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
@@ -4,9 +4,6 @@
 //      Check directives are in check.txt to prevent dexter reading any embedded
 //      commands.
 //
-// Note: Despite using 'lldb' as the debugger, lldb is not actually required
-//       as the test should finish before lldb would be invoked.
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
@@ -8,7 +8,7 @@
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
-// CHECK:parser error:{{.*}}err_syntax.cpp(21): invalid syntax
+// CHECK:parser error:{{.*}}err_syntax.cpp(18): invalid syntax
 // CHECK:// {{Dex}}ExpectWatchValue(,'a', 3, 3, 3, 3, on_line=0)
 // CHECK:                       ^
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
@@ -4,9 +4,6 @@
 //      Check directives are in check.txt to prevent dexter reading any embedded
 //      commands.
 //
-// Note: Despite using 'lldb' as the debugger, lldb is not actually required
-//       as the test should finish before lldb would be invoked.
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
@@ -8,7 +8,7 @@
 //       as the test should finish before lldb would be invoked.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger "lldb" \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_syntax.cpp(21): invalid syntax

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
@@ -3,7 +3,7 @@
 //      they appeared in rather than the current declared file.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger 'lldb' -v -- %s \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args -v -- %s \
 // RUN:     | FileCheck %s --implicit-check-not=FAIL-FILENAME-MATCH
 
 // CHECK: err_syntax_dexdeclarefile.cpp(14): Undeclared address: 'not_been_declared'

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
@@ -8,7 +8,7 @@
 //       as the test should finish before lldb would be invoked.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger "lldb" \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_syntax_mline.cpp(24): invalid syntax

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
@@ -8,7 +8,7 @@
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
-// CHECK:parser error:{{.*}}err_syntax_mline.cpp(24): invalid syntax
+// CHECK:parser error:{{.*}}err_syntax_mline.cpp(21): invalid syntax
 // CHECK:    ,'a', 3, 3, 3, 3, on_line=0)
 // CHECK:    ^
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
@@ -4,9 +4,6 @@
 //      Check directives are in check.txt to prevent dexter reading any embedded
 //      commands.
 //
-// Note: Despite using 'lldb' as the debugger, lldb is not actually required
-//       as the test should finish before lldb would be invoked.
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
@@ -8,7 +8,7 @@
 //       as the test should finish before lldb would be invoked.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger "lldb" \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_type.cpp(21): expected at least two args

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
@@ -8,7 +8,7 @@
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
-// CHECK:parser error:{{.*}}err_type.cpp(21): expected at least two args
+// CHECK:parser error:{{.*}}err_type.cpp(18): expected at least two args
 // CHECK:// {{Dex}}ExpectWatchValue()
 // CHECK:                      ^
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
@@ -4,9 +4,6 @@
 //      Check directives are in check.txt to prevent dexter reading any embedded
 //      commands.
 //
-// Note: Despite using 'lldb' as the debugger, lldb is not actually required
-//       as the test should finish before lldb would be invoked.
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
@@ -8,7 +8,7 @@
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
-// CHECK:parser error:{{.*}}err_type_mline.cpp(22): expected at least two args
+// CHECK:parser error:{{.*}}err_type_mline.cpp(19): expected at least two args
 // CHECK:{{Dex}}ExpectWatchValue(
 // CHECK:                   ^
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
@@ -8,7 +8,7 @@
 //       as the test should finish before lldb would be invoked.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_base test --binary %t --debugger "lldb" \
+// RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_type_mline.cpp(22): expected at least two args

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
@@ -4,9 +4,6 @@
 //      Check directives are in check.txt to prevent dexter reading any embedded
 //      commands.
 //
-// Note: Despite using 'lldb' as the debugger, lldb is not actually required
-//       as the test should finish before lldb would be invoked.
-//
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
 // RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/source-root-dir.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/source-root-dir.cpp
@@ -2,10 +2,8 @@
 // XFAIL:*
 // RUN: %dexter_regression_test_cxx_build \
 // RUN:     -fdebug-prefix-map=%S=/changed %s -o %t
-// RUN: %dexter --fail-lt 1.0 -w \
-// RUN:     --binary %t \
-// RUN:     --debugger %dexter_regression_test_debugger \
-// RUN:     --source-root-dir=%S --debugger-use-relative-paths -- %s
+// RUN: %dexter_regression_test_run \
+// RUN:     --binary %t --source-root-dir=%S --debugger-use-relative-paths -- %s
 
 #include <stdio.h>
 int main() {

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -102,17 +102,9 @@ if "compiler-rt" in config.llvm_enabled_projects:
     config.available_features.add("compiler-rt")
 
 # Check which debuggers are available:
-lldb_path = llvm_config.use_llvm_tool("lldb", search_env="LLDB")
 lldb_dap_path = llvm_config.use_llvm_tool("lldb-dap")
-
-# We prefer to use lldb-dap if possible, but we assume that there will never be a case where lldb-dap is available and
-# lldb isn't, so use the existence of lldb as the lowest common denominator.
-if lldb_path is not None:
-    config.available_features.add("lldb")
-# There are some small niche differences in the output between lldb and lldb-dap, so we add this feature as a way to
-# disable the tests that will fail if we fall back to lldb.
 if lldb_dap_path is not None:
-    config.available_features.add("lldb-dap")
+    config.available_features.add("lldb")
 
 if llvm_config.use_llvm_tool("llvm-ar"):
     config.available_features.add("llvm-ar")
@@ -127,8 +119,6 @@ def configure_dexter_substitutions():
     tools.append(ToolSubst("%dexter", f'"{sys.executable}" "{dexter_path}" test'))
     if lldb_dap_path is not None:
         tools.append(ToolSubst("%dexter_lldb_args", f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap'))
-    elif lldb_path is not None:
-        tools.append(ToolSubst("%dexter_lldb_args", f'--lldb-executable "{lldb_path}" --debugger lldb'))
 
     # For testing other bits of dexter that aren't under the "test" subcommand,
     # have a %dexter_base substitution.
@@ -152,12 +142,8 @@ def configure_dexter_substitutions():
         dependencies = ["clang", "lldb"]
         dexter_regression_test_c_builder = "clang"
         dexter_regression_test_cxx_builder = "clang++"
-        if lldb_dap_path is not None:
-            dexter_regression_test_debugger = "lldb-dap"
-            dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_dap_path}"'
-        else:
-            dexter_regression_test_debugger = "lldb"
-            dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_path}"'
+        dexter_regression_test_debugger = "lldb-dap"
+        dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_dap_path}"'
         dexter_regression_test_c_flags = "-O0 -glldb -std=gnu11"
         dexter_regression_test_cxx_flags = "-O0 -glldb -std=gnu++11"
 

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -118,7 +118,12 @@ def configure_dexter_substitutions():
     )
     tools.append(ToolSubst("%dexter", f'"{sys.executable}" "{dexter_path}" test'))
     if lldb_dap_path is not None:
-        tools.append(ToolSubst("%dexter_lldb_args", f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap'))
+        tools.append(
+            ToolSubst(
+                "%dexter_lldb_args",
+                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap',
+            )
+        )
 
     # For testing other bits of dexter that aren't under the "test" subcommand,
     # have a %dexter_base substitution.
@@ -148,7 +153,10 @@ def configure_dexter_substitutions():
         dexter_regression_test_cxx_flags = "-O0 -glldb -std=gnu++11"
 
     tools.append(
-        ToolSubst("%dexter_regression_test_debugger_args", f"--debugger {dexter_regression_test_debugger} {dexter_regression_test_additional_flags}")
+        ToolSubst(
+            "%dexter_regression_test_debugger_args",
+            f"--debugger {dexter_regression_test_debugger} {dexter_regression_test_additional_flags}",
+        )
     )
 
     # Typical command would take the form:


### PR DESCRIPTION
This patch updates Dexter's lit test setup, making lldb-dap the default debugger where available; as part of this, I've replaced references to `--debugger lldb` with new substitutions that provide the debugger and executable path: one substitution returns just lldb for the tests that require it (all the LLDB-using tests in `dexter-tests`), and the other which provides the system-preferred debugger for the tests that should be able to run with any debugger (all the tests in `feature_tests`).

As a small note, one test generates output that differs between lldb and lldb-dap - for this test specifically, we add an lldb-dap feature so that it can be marked XFAIL if we fall back to using LLDB.