### PR TITLE
Reapply "[lit] Implement builtin umask (#94621)"

### DIFF
--- a/llvm/test/tools/llvm-dwarfutil/ELF/X86/mirror-permissions-unix.test
+++ b/llvm/test/tools/llvm-dwarfutil/ELF/X86/mirror-permissions-unix.test
@@ -3,7 +3,6 @@
 ## Setting the umask to 0 ensures deterministic permissions across
 ## test environments.
 # UNSUPPORTED: system-windows
-# REQUIRES: shell
 
 # RUN: touch %t
 # RUN: chmod 0777 %t

--- a/llvm/test/tools/llvm-objcopy/ELF/mirror-permissions-unix.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/mirror-permissions-unix.test
@@ -6,7 +6,6 @@
 ## Setting the umask to 0 ensures deterministic permissions across
 ## test environments.
 # UNSUPPORTED: system-windows
-# REQUIRES: shell
 
 # RUN: touch %t
 # RUN: chmod 0777 %t

--- a/llvm/test/tools/llvm-objcopy/ELF/respect-umask.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/respect-umask.test
@@ -1,10 +1,8 @@
 ## This tests that the umask is respected when
 ## assigning permissions of output files.
 
-## Windows has no umask so this test makes no sense, nor would
-## it work because there is no umask(1) in a Windows environment
+## Windows has no umask so this test makes no sense.
 # UNSUPPORTED: system-windows
-# REQUIRES: shell
 
 # RUN: rm -f %t
 # RUN: touch %t

--- a/llvm/utils/lit/tests/Inputs/shtest-umask/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-umask/lit.cfg
@@ -1,0 +1,7 @@
+import lit.formats
+
+config.name = "shtest-umask"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest(execute_external=False)
+if sys.platform.startswith("win") or sys.platform.startswith("cygwin"):
+    config.available_features.add("system-windows")

--- a/llvm/utils/lit/tests/Inputs/shtest-umask/umask-bad-arg.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-umask/umask-bad-arg.txt
@@ -1,0 +1,1 @@
+# RUN: umask bad

--- a/llvm/utils/lit/tests/Inputs/shtest-umask/umask-ok.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-umask/umask-ok.txt
@@ -1,0 +1,11 @@
+## Windows has no umask so this test makes no sense.
+# UNSUPPORTED: system-windows
+
+# RUN: touch %t
+# RUN: chmod 644 %t && ls -l %t | cut -f 1 -d ' ' > %t.644
+# RUN: chmod 600 %t && ls -l %t | cut -f 1 -d ' ' > %t.600
+# RUN: chmod 666 %t && ls -l %t | cut -f 1 -d ' ' > %t.666
+
+# RUN: umask 022 && rm %t && touch %t && ls -l %t | cut -f 1 -d ' ' | cmp - %t.644
+# RUN: umask 177 && rm %t && touch %t && ls -l %t | cut -f 1 -d ' ' | cmp - %t.600
+# RUN: umask 000 && rm %t && touch %t && ls -l %t | cut -f 1 -d ' ' | cmp - %t.666

--- a/llvm/utils/lit/tests/Inputs/shtest-umask/umask-too-many-args.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-umask/umask-too-many-args.txt
@@ -1,0 +1,1 @@
+# RUN: umask 0 0

--- a/llvm/utils/lit/tests/shtest-umask.py
+++ b/llvm/utils/lit/tests/shtest-umask.py
@@ -1,0 +1,18 @@
+# Check the umask command
+
+# RUN: not %{lit} -a -v %{inputs}/shtest-umask | FileCheck -match-full-lines %s
+
+# CHECK: -- Testing: 3 tests{{.*}}
+
+# CHECK-LABEL: FAIL: shtest-umask :: umask-bad-arg.txt ({{[^)]*}})
+# CHECK: umask bad
+# CHECK: # | Error: 'umask': invalid literal {{.*}}
+
+# CHECK-LABEL: FAIL: shtest-umask :: umask-too-many-args.txt ({{[^)]*}})
+# CHECK: umask 0 0
+# CHECK: # | 'umask' supports only one argument
+
+# CHECK: Total Discovered Tests: 3
+# CHECK: {{Passed|Unsupported}}: 1 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Failed{{ *}}: 2 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK-NOT: {{.}}


### PR DESCRIPTION
This reverts commit faa4e35c622c13c7a565b979a6676d6cf3040cd4.

This was originally reverted because it was using a Python 3.9 feature (umask in subprocess.Popen) when LLVM only requires Python 3.8. This patch uses os.umask instead, which has been around for longer.