### PR TITLE
[clang-tidy][NFC] Add custom .clang-format with 'QualifierAlignment: Left'

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-format
+++ b/clang-tools-extra/clang-tidy/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+QualifierAlignment: Left

--- a/clang-tools-extra/clang-tidy/bugprone/CapturingThisInMemberVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/CapturingThisInMemberVariableCheck.cpp
@@ -44,11 +44,11 @@ AST_MATCHER(CXXRecordDecl, correctHandleCaptureThisLambda) {
   if (Node.hasSimpleMoveAssignment())
     return false;
 
-  for (CXXConstructorDecl const *C : Node.ctors()) {
+  for (const CXXConstructorDecl *C : Node.ctors()) {
     if (C->isCopyOrMoveConstructor() && C->isDefaulted() && !C->isDeleted())
       return false;
   }
-  for (CXXMethodDecl const *M : Node.methods()) {
+  for (const CXXMethodDecl *M : Node.methods()) {
     if (M->isCopyAssignmentOperator())
       llvm::errs() << M->isDeleted() << "\n";
     if (M->isCopyAssignmentOperator() && M->isDefaulted() && !M->isDeleted())

--- a/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/MultiLevelImplicitPointerConversionCheck.h
@@ -31,7 +31,7 @@ public:
   }
 
 private:
-  bool const EnableInC;
+  const bool EnableInC;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/SmartPtrArrayMismatchCheck.h
+++ b/clang-tools-extra/clang-tidy/bugprone/SmartPtrArrayMismatchCheck.h
@@ -40,7 +40,7 @@ protected:
   static const char PointerTypeN[];
 
 private:
-  StringRef const SmartPointerName;
+  const StringRef SmartPointerName;
 };
 
 } // namespace clang::tidy::bugprone

--- a/clang-tools-extra/clang-tidy/bugprone/UnusedLocalNonTrivialVariableCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/UnusedLocalNonTrivialVariableCheck.cpp
@@ -33,7 +33,7 @@ AST_MATCHER(VarDecl, isReferenced) { return Node.isReferenced(); }
 AST_MATCHER(VarDecl, explicitMarkUnused) {
   // Implementations should not emit a warning that a name-independent
   // declaration is used or unused.
-  LangOptions const &LangOpts = Finder->getASTContext().getLangOpts();
+  const LangOptions &LangOpts = Finder->getASTContext().getLangOpts();
   return Node.hasAttr<UnusedAttr>() ||
          (LangOpts.CPlusPlus26 && Node.isPlaceholderVar(LangOpts));
 }

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/AvoidConstOrRefDataMembersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/AvoidConstOrRefDataMembersCheck.cpp
@@ -14,73 +14,73 @@ using namespace clang::ast_matchers;
 
 namespace clang::tidy::cppcoreguidelines {
 
-static bool isCopyConstructible(CXXRecordDecl const &Node) {
+static bool isCopyConstructible(const CXXRecordDecl &Node) {
   if (Node.needsOverloadResolutionForCopyConstructor() &&
       Node.needsImplicitCopyConstructor()) {
     // unresolved
-    for (CXXBaseSpecifier const &BS : Node.bases()) {
-      CXXRecordDecl const *BRD = BS.getType()->getAsCXXRecordDecl();
+    for (const CXXBaseSpecifier &BS : Node.bases()) {
+      const CXXRecordDecl *BRD = BS.getType()->getAsCXXRecordDecl();
       if (BRD != nullptr && !isCopyConstructible(*BRD))
         return false;
     }
   }
   if (Node.hasSimpleCopyConstructor())
     return true;
-  for (CXXConstructorDecl const *Ctor : Node.ctors())
+  for (const CXXConstructorDecl *Ctor : Node.ctors())
     if (Ctor->isCopyConstructor())
       return !Ctor->isDeleted();
   return false;
 }
 
-static bool isMoveConstructible(CXXRecordDecl const &Node) {
+static bool isMoveConstructible(const CXXRecordDecl &Node) {
   if (Node.needsOverloadResolutionForMoveConstructor() &&
       Node.needsImplicitMoveConstructor()) {
     // unresolved
-    for (CXXBaseSpecifier const &BS : Node.bases()) {
-      CXXRecordDecl const *BRD = BS.getType()->getAsCXXRecordDecl();
+    for (const CXXBaseSpecifier &BS : Node.bases()) {
+      const CXXRecordDecl *BRD = BS.getType()->getAsCXXRecordDecl();
       if (BRD != nullptr && !isMoveConstructible(*BRD))
         return false;
     }
   }
   if (Node.hasSimpleMoveConstructor())
     return true;
-  for (CXXConstructorDecl const *Ctor : Node.ctors())
+  for (const CXXConstructorDecl *Ctor : Node.ctors())
     if (Ctor->isMoveConstructor())
       return !Ctor->isDeleted();
   return false;
 }
 
-static bool isCopyAssignable(CXXRecordDecl const &Node) {
+static bool isCopyAssignable(const CXXRecordDecl &Node) {
   if (Node.needsOverloadResolutionForCopyAssignment() &&
       Node.needsImplicitCopyAssignment()) {
     // unresolved
-    for (CXXBaseSpecifier const &BS : Node.bases()) {
-      CXXRecordDecl const *BRD = BS.getType()->getAsCXXRecordDecl();
+    for (const CXXBaseSpecifier &BS : Node.bases()) {
+      const CXXRecordDecl *BRD = BS.getType()->getAsCXXRecordDecl();
       if (BRD != nullptr && !isCopyAssignable(*BRD))
         return false;
     }
   }
   if (Node.hasSimpleCopyAssignment())
     return true;
-  for (CXXMethodDecl const *Method : Node.methods())
+  for (const CXXMethodDecl *Method : Node.methods())
     if (Method->isCopyAssignmentOperator())
       return !Method->isDeleted();
   return false;
 }
 
-static bool isMoveAssignable(CXXRecordDecl const &Node) {
+static bool isMoveAssignable(const CXXRecordDecl &Node) {
   if (Node.needsOverloadResolutionForMoveAssignment() &&
       Node.needsImplicitMoveAssignment()) {
     // unresolved
-    for (CXXBaseSpecifier const &BS : Node.bases()) {
-      CXXRecordDecl const *BRD = BS.getType()->getAsCXXRecordDecl();
+    for (const CXXBaseSpecifier &BS : Node.bases()) {
+      const CXXRecordDecl *BRD = BS.getType()->getAsCXXRecordDecl();
       if (BRD != nullptr && !isMoveAssignable(*BRD))
         return false;
     }
   }
   if (Node.hasSimpleMoveAssignment())
     return true;
-  for (CXXMethodDecl const *Method : Node.methods())
+  for (const CXXMethodDecl *Method : Node.methods())
     if (Method->isMoveAssignmentOperator())
       return !Method->isDeleted();
   return false;

--- a/clang-tools-extra/clang-tidy/misc/OverrideWithDifferentVisibilityCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/OverrideWithDifferentVisibilityCheck.cpp
@@ -17,7 +17,7 @@ using namespace clang;
 namespace {
 
 AST_MATCHER(NamedDecl, isOperatorDecl) {
-  DeclarationName::NameKind const NK = Node.getDeclName().getNameKind();
+  const DeclarationName::NameKind NK = Node.getDeclName().getNameKind();
   return NK != DeclarationName::Identifier &&
          NK != DeclarationName::CXXConstructorName &&
          NK != DeclarationName::CXXDestructorName;
@@ -104,7 +104,7 @@ void OverrideWithDifferentVisibilityCheck::check(
 
   const auto *const OverriddenFunction =
       Result.Nodes.getNodeAs<FunctionDecl>("base_func");
-  AccessSpecifier const ActualAccess = MatchedFunction->getAccess();
+  const AccessSpecifier ActualAccess = MatchedFunction->getAccess();
   AccessSpecifier OverriddenAccess = OverriddenFunction->getAccess();
 
   const CXXBaseSpecifier *InheritanceWithStrictVisibility = nullptr;

--- a/clang-tools-extra/clang-tidy/modernize/ConcatNestedNamespacesCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ConcatNestedNamespacesCheck.cpp
@@ -152,14 +152,14 @@ void ConcatNestedNamespacesCheck::reportDiagnostic(
       ConcatNameSpace.append("::");
   }
 
-  for (SourceRange const &Front : Fronts)
+  for (const SourceRange &Front : Fronts)
     DB << FixItHint::CreateRemoval(Front);
   DB << FixItHint::CreateReplacement(
       Namespaces.back().getReplacedNamespaceFrontRange(), ConcatNameSpace);
   if (LastRBrace != Namespaces.back().getDefaultNamespaceBackRange())
     DB << FixItHint::CreateReplacement(LastRBrace,
                                        ("} // " + ConcatNameSpace).str());
-  for (SourceRange const &Back : llvm::reverse(Backs))
+  for (const SourceRange &Back : llvm::reverse(Backs))
     DB << FixItHint::CreateRemoval(Back);
 }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseAutoCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseAutoCheck.cpp
@@ -334,14 +334,14 @@ void UseAutoCheck::replaceIterators(const DeclStmt *D, ASTContext *Context) {
 
 static void ignoreTypeLocClasses(
     TypeLoc &Loc,
-    std::initializer_list<TypeLoc::TypeLocClass> const &LocClasses) {
+    const std::initializer_list<TypeLoc::TypeLocClass> &LocClasses) {
   while (llvm::is_contained(LocClasses, Loc.getTypeLocClass()))
     Loc = Loc.getNextTypeLoc();
 }
 
 static bool isMultiLevelPointerToTypeLocClasses(
     TypeLoc Loc,
-    std::initializer_list<TypeLoc::TypeLocClass> const &LocClasses) {
+    const std::initializer_list<TypeLoc::TypeLocClass> &LocClasses) {
   ignoreTypeLocClasses(Loc, {TypeLoc::Paren, TypeLoc::Qualified});
   TypeLoc::TypeLocClass TLC = Loc.getTypeLocClass();
   if (TLC != TypeLoc::Pointer && TLC != TypeLoc::MemberPointer)

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -953,7 +953,7 @@ std::string IdentifierNamingCheck::fixupWithCase(
     break;
 
   case IdentifierNamingCheck::CT_LowerCase:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       if (&Word != &Words.front())
         Fixup += "_";
       Fixup += Word.lower();
@@ -961,7 +961,7 @@ std::string IdentifierNamingCheck::fixupWithCase(
     break;
 
   case IdentifierNamingCheck::CT_UpperCase:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       if (&Word != &Words.front())
         Fixup += "_";
       Fixup += Word.upper();
@@ -969,14 +969,14 @@ std::string IdentifierNamingCheck::fixupWithCase(
     break;
 
   case IdentifierNamingCheck::CT_CamelCase:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       Fixup += toupper(Word.front());
       Fixup += Word.substr(1).lower();
     }
     break;
 
   case IdentifierNamingCheck::CT_CamelBack:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       if (&Word == &Words.front()) {
         Fixup += Word.lower();
       } else {
@@ -987,7 +987,7 @@ std::string IdentifierNamingCheck::fixupWithCase(
     break;
 
   case IdentifierNamingCheck::CT_CamelSnakeCase:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       if (&Word != &Words.front())
         Fixup += "_";
       Fixup += toupper(Word.front());
@@ -996,7 +996,7 @@ std::string IdentifierNamingCheck::fixupWithCase(
     break;
 
   case IdentifierNamingCheck::CT_CamelSnakeBack:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       if (&Word != &Words.front()) {
         Fixup += "_";
         Fixup += toupper(Word.front());
@@ -1008,7 +1008,7 @@ std::string IdentifierNamingCheck::fixupWithCase(
     break;
 
   case IdentifierNamingCheck::CT_LeadingUpperSnakeCase:
-    for (auto const &Word : Words) {
+    for (const auto &Word : Words) {
       if (&Word != &Words.front()) {
         Fixup += "_";
         Fixup += Word.lower();


### PR DESCRIPTION
["QualifierAlignment: Left"](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifieralignment) is  an established way of writing code in `clang-tools-extra/clang-tidy`. We should enforce it in CI.

This patch fixes all findings in current files that doesn't align with left-alignment style.