### PR TITLE
[DirectX] Don't byte-swap returned byte-offset

### DIFF
--- a/llvm/lib/MC/DXContainerRootSignature.cpp
+++ b/llvm/lib/MC/DXContainerRootSignature.cpp
@@ -22,11 +22,12 @@ static uint32_t writePlaceholder(raw_svector_ostream &Stream) {
 
 static uint32_t rewriteOffsetToCurrentByte(raw_svector_ostream &Stream,
                                            uint32_t Offset) {
+  uint32_t ByteOffset = Stream.tell();
   uint32_t Value =
       support::endian::byte_swap<uint32_t, llvm::endianness::little>(
-          Stream.tell());
+          ByteOffset);
   Stream.pwrite(reinterpret_cast<const char *>(&Value), sizeof(Value), Offset);
-  return Value;
+  return ByteOffset;
 }
 
 size_t RootSignatureDesc::getSize() const {


### PR DESCRIPTION
- The returned byte offset from `rewriteOffsetToCurrentByte` should not be byte-swapped as it will be compared and interpreted as a uint32_t in its uses

This commit corrects build failures that hit an assert on big-endian builds