### PR TITLE
[X86] Enable EliminateSpillageCopies by default on X86

### DIFF
--- a/llvm/lib/Target/X86/X86Subtarget.h
+++ b/llvm/lib/Target/X86/X86Subtarget.h
@@ -422,6 +422,8 @@ public:
 
   bool enableEarlyIfConversion() const override;
 
+  bool enableSpillageCopyElimination() const override { return true; }
+
   void getPostRAMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
                               &Mutations) const override;
 


### PR DESCRIPTION
RAGreedy sometimes generates spill-reload chains such as in #136574; there is machinery in MachineCopyPropagation::EliminateSpillageCopies that eliminates these meaningless movs. Here we just enable it by default on X86.

Old code in RAGreedy that removed tried to prevent these chains are [here](https://github.com/llvm/llvm-project/commit/294eca35a00f89dff474044ebd478a7f83ccc310).

Running EliminateSpillageCopies is a little cheaper than the other functions in MachineCopyPropagation in the little perf profiling I've done.