### PR TITLE
[AMDGPU] Common up code from AMDGPUInstPrinter::printImmediate64. NFC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUInstPrinter.h
@@ -89,6 +89,8 @@ private:
                         raw_ostream &O);
   void printImmediate64(uint64_t Imm, const MCSubtargetInfo &STI,
                         raw_ostream &O, bool IsFP);
+  void printLiteral64(uint64_t Imm, const MCSubtargetInfo &STI, raw_ostream &O,
+                      bool IsFP);
   void printOperand(const MCInst *MI, unsigned OpNo, const MCSubtargetInfo &STI,
                     raw_ostream &O);
   void printRegularOperand(const MCInst *MI, unsigned OpNo,


### PR DESCRIPTION
Introduce a new helper function printLiteral64.
