### PR TITLE
[clang-doc] Add a Markdown parser

### DIFF
--- a/clang-tools-extra/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/clang-doc/CMakeLists.txt
@@ -18,6 +18,7 @@ add_clang_library(clangDoc STATIC
   YAMLGenerator.cpp
   JSONGenerator.cpp
   MDMustacheGenerator.cpp
+  MDParser.cpp
 
   DEPENDS
   omp_gen

--- a/clang-tools-extra/clang-doc/MDParser.cpp
+++ b/clang-tools-extra/clang-doc/MDParser.cpp
@@ -1,0 +1,255 @@
+#include "MDParser.h"
+#include "clang/Basic/CharInfo.h"
+#include "llvm/ADT/AllocatorList.h"
+#include <cassert>
+#include <iterator>
+#include <stack>
+
+namespace clang {
+namespace doc {
+namespace md {
+
+using namespace llvm;
+// FIXME: These functions need to account for special characters, ASCII codes,
+// etc.
+static bool isEmphasisDelimiter(char Token) {
+  if (Token == '*' || Token == '_')
+    return true;
+  return false;
+}
+
+static bool isEmpty(StringRef Line) {
+  if (Line.size() == 0)
+    return true;
+  if (Line.size() == 1 && Line[0] == ' ')
+    return true;
+  for (auto &Char : Line) {
+    if (Char != ' ')
+      return false;
+  }
+  return true;
+}
+
+static MDType determineBlockType(StringRef Line) {
+  StringRef TrimmedLine = Line.ltrim(' ');
+  if (TrimmedLine.empty())
+    return MDType::None;
+
+  switch (TrimmedLine[0]) {
+  case '*':
+  case '-':
+    return MDType::Paragraph;
+  case '>':
+    return MDType::Paragraph;
+  default:
+    return MDType::Paragraph;
+  }
+}
+
+ContainerBlock *ASTContext::getRoot() { return Root; }
+
+Block *ASTContext::allocate() {
+  if (!Root) {
+    Root = new (Arena) ContainerBlock();
+    return Root;
+  }
+
+  return new (Arena) Block();
+}
+
+Block *ASTContext::allocate(MDType Type) {
+  auto *NewNode = allocate();
+  NewNode->Type = Type;
+  return NewNode;
+}
+
+StringRef ASTContext::intern(Twine String) { return SSaver.save(String); }
+StringRef ASTContext::intern(std::string &String) {
+  return SSaver.save(String);
+}
+StringRef ASTContext::intern(StringRef String) { return SSaver.save(String); }
+
+std::optional<std::pair<DelimiterContext, size_t>>
+MarkdownParser::processDelimiters(StringRef Line, const size_t &Start) {
+  size_t Idx = Start;
+  while (Idx < Line.size() && Line[Idx] == Line[Start]) {
+    ++Idx;
+  }
+  size_t DelimiterRunLength = Idx - Start;
+
+  char Preceeding = (Start == 0) ? ' ' : Line[Start - 1];
+  char Proceeding = (Idx >= Line.size()) ? ' ' : Line[Idx];
+
+  bool LeftFlanking = !isWhitespace(Proceeding) &&
+                      (!isPunctuation(Proceeding) || isWhitespace(Preceeding) ||
+                       isPunctuation(Preceeding));
+  bool RightFlanking = !isWhitespace(Preceeding) &&
+                       (!isPunctuation(Preceeding) ||
+                        isWhitespace(Proceeding) || isPunctuation(Proceeding));
+
+  DelimiterContext Ctx;
+  Ctx.Length = DelimiterRunLength;
+  Ctx.DelimChar = Line[Start];
+  Ctx.LeftFlanking = LeftFlanking;
+  Ctx.RightFlanking = RightFlanking;
+  Ctx.CanOpen = LeftFlanking;
+  Ctx.CanClose = RightFlanking;
+
+  if (LeftFlanking || RightFlanking)
+    return std::make_pair(Ctx, Idx);
+  return std::nullopt;
+}
+
+InlineContainer *
+MarkdownParser::determineEmphasisNode(DelimiterContext &Opener,
+                                      DelimiterContext &Closer) {
+  auto &OpenerLength = Opener.Length;
+  auto &CloserLength = Closer.Length;
+
+  InlineContainer *PossibleNode;
+  if (OpenerLength >= 2 && CloserLength >= 2) {
+    PossibleNode = new (Ctx.Arena) StrongInline();
+    OpenerLength -= 2;
+    CloserLength -= 2;
+    return PossibleNode;
+  }
+
+  if (OpenerLength == 1 && CloserLength == 1) {
+    PossibleNode = new (Ctx.Arena) EmphasisInline();
+    OpenerLength -= 1;
+    CloserLength -= 1;
+    return PossibleNode;
+  }
+
+  return nullptr;
+}
+
+void MarkdownParser::processEmphasis(LineNodeList &Stack, List<Inline> &Out) {
+  auto It = Stack.begin();
+  while (It != Stack.end()) {
+    if (It->DelimiterCtx && It->DelimiterCtx->CanOpen) {
+      auto CloseIt = std::next(It);
+      while (CloseIt != Stack.end()) {
+        if (CloseIt->DelimiterCtx && CloseIt->DelimiterCtx->CanClose &&
+            CloseIt->DelimiterCtx->DelimChar == It->DelimiterCtx->DelimChar) {
+          break;
+        }
+        ++CloseIt;
+      }
+
+      if (CloseIt != Stack.end() && It->DelimiterCtx && CloseIt->DelimiterCtx) {
+        auto *Node =
+            determineEmphasisNode(*It->DelimiterCtx, *CloseIt->DelimiterCtx);
+        if (Node) {
+          std::string InnerText;
+          for (auto InnerIt = std::next(It); InnerIt != CloseIt; ++InnerIt)
+            InnerText += InnerIt->Content.str();
+
+          if (Node->Type == InlineType::Strong) {
+            parse(StringRef(InnerText), Node->Children);
+            Out.push_back(*Node);
+          } else if (Node->Type == InlineType::Emphasis) {
+            parse(StringRef(InnerText), Node->Children);
+            Out.push_back(*Node);
+          }
+          It = std::next(CloseIt);
+          continue;
+        }
+      }
+    }
+
+    appendText(Out, It->Content.str());
+    ++It;
+  }
+}
+
+void MarkdownParser::appendText(List<Inline> &Out, StringRef Text) {
+  if (Text.empty())
+    return;
+  auto *Node = new (Ctx.Arena) TextInline(Ctx.intern(Text));
+  Out.push_back(*Node);
+}
+
+void MarkdownParser::parse(InlineContainerBlock *Inline) {
+  if (!Inline)
+    return;
+  if (!Inline->UnresolvedInlineText)
+    return;
+  parse(Inline->UnresolvedInlineText.value(), Inline->Children);
+  Inline->UnresolvedInlineText.reset();
+}
+
+void MarkdownParser::parse(llvm::StringRef Line, List<Inline> &Out) {
+  LineNodeList Nodes;
+  size_t Idx = 0;
+  while (Idx < Line.size()) {
+    if (isEmphasisDelimiter(Line[Idx])) {
+      if (auto Run = processDelimiters(Line, Idx)) {
+        size_t End = Run->second;
+        Nodes.emplace_back(Line.substr(Idx, End - Idx), Run->first);
+        Idx = End;
+        continue;
+      }
+    }
+
+    // FIXME: support '_'
+    size_t Next = Line.find_first_of("*", Idx);
+    if (Next == StringRef::npos)
+      Next = Line.size();
+    Nodes.emplace_back(Line.substr(Idx, Next - Idx));
+    Idx = Next;
+  }
+
+  processEmphasis(Nodes, Out);
+}
+
+void MarkdownParser::parse(std::vector<StringRef> &Lines) {
+  assert(!Ctx.getRoot() && "ASTContext is single-use; create a new context");
+  if (Ctx.getRoot())
+    return;
+
+  auto *Current = new (Ctx.Arena) ContainerBlock();
+  Ctx.Root = Current;
+  Current->Type = MDType::Document;
+  std::stack<ContainerBlock *> OpenContainers;
+  OpenContainers.push(Current);
+
+  std::vector<InlineContainerBlock *> Inlines;
+  for (auto &Line : Lines) {
+    if (isEmpty(Line)) {
+      State = MDType::None;
+      continue;
+    }
+
+    auto CurrentBlockType = determineBlockType(Line);
+    auto &Children = OpenContainers.top()->Children;
+
+    if (State != CurrentBlockType) {
+      State = CurrentBlockType;
+      switch (CurrentBlockType) {
+      case MDType::Paragraph: {
+        auto *NewParagraph = new (Ctx.Arena) ParagraphBlock(Line);
+        Children.push_back(*NewParagraph);
+        Inlines.push_back(NewParagraph);
+        break;
+      }
+      case MDType::None:
+        break;
+      }
+      continue;
+    }
+  }
+  // The only container left should be the root document node
+  if (!(OpenContainers.size() == 1))
+    return;
+  OpenContainers.pop();
+
+  for (auto &CurrentInline : Inlines) {
+    if (!CurrentInline->UnresolvedInlineText.has_value())
+      continue;
+    parse(CurrentInline);
+  }
+}
+} // namespace md
+} // namespace doc
+} // namespace clang

--- a/clang-tools-extra/clang-doc/MDParser.h
+++ b/clang-tools-extra/clang-doc/MDParser.h
@@ -1,0 +1,191 @@
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MD_PARSER_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_DOC_MD_PARSER_H
+#include "llvm/ADT/AllocatorList.h"
+#include "llvm/ADT/simple_ilist.h"
+#include "llvm/Support/Allocator.h"
+#include "llvm/Support/StringSaver.h"
+
+namespace clang {
+namespace doc {
+namespace md {
+
+enum class MDType { Paragraph, Document, None };
+
+enum class InlineType { Emphasis, Strong, Text };
+
+enum class MDTokenType { LeftDelimiterRun, RightDelimiterRun, Text };
+
+template <class T>
+using List = llvm::simple_ilist<T, llvm::ilist_sentinel_tracking<true>>;
+
+struct Block : llvm::ilist_node<Block, llvm::ilist_sentinel_tracking<true>> {
+  Block() = default;
+  Block(MDType Ty) : Type(Ty) {}
+  Block(MDType Ty, Block *Parent) : Parent(Parent), Type(Ty) {}
+
+  Block *Parent;
+  MDType Type;
+};
+
+struct ContainerBlock : Block {
+  List<Block> Children;
+};
+
+struct Inline;
+
+/// A block that can contain inline elements.
+struct InlineContainerBlock : Block {
+  InlineContainerBlock() = default;
+  InlineContainerBlock(MDType Type) : Block(Type) {}
+  InlineContainerBlock(MDType Type, llvm::StringRef Line)
+      : Block(Type), UnresolvedInlineText(Line) {}
+  List<Inline> Children;
+
+  std::optional<llvm::StringRef> UnresolvedInlineText;
+};
+
+struct ParagraphBlock : InlineContainerBlock {
+  ParagraphBlock() : InlineContainerBlock(MDType::Paragraph) {}
+  ParagraphBlock(llvm::StringRef Line)
+      : InlineContainerBlock(MDType::Paragraph, Line) {}
+};
+
+struct Inline : llvm::ilist_node<Inline, llvm::ilist_sentinel_tracking<true>> {
+  Inline() = default;
+  Inline(InlineType Type) : Type(Type) {}
+  InlineType Type;
+};
+
+/// An inline element that can contain other inline elements.
+struct InlineContainer : Inline {
+  InlineContainer() = default;
+  InlineContainer(InlineType Type) : Inline(Type) {}
+  List<Inline> Children;
+};
+
+struct TextInline : Inline {
+  TextInline(llvm::StringRef Text) : Inline(InlineType::Text), Text(Text) {}
+  llvm::StringRef Text;
+};
+
+struct EmphasisInline : InlineContainer {
+  EmphasisInline() : InlineContainer(InlineType::Emphasis) {}
+};
+
+struct StrongInline : InlineContainer {
+  StrongInline() : InlineContainer(InlineType::Strong) {}
+};
+
+class MarkdownParser;
+
+class ASTContext {
+  llvm::BumpPtrAllocator Arena;
+  llvm::StringSaver SSaver;
+  ContainerBlock *Root;
+
+  friend MarkdownParser;
+
+public:
+  ASTContext()
+      : Arena(llvm::BumpPtrAllocator()), SSaver(Arena), Root(nullptr) {}
+  ContainerBlock *getRoot();
+  Block *allocate();
+  Block *allocate(MDType Type);
+  llvm::StringRef intern(llvm::Twine String);
+  llvm::StringRef intern(std::string &String);
+  llvm::StringRef intern(llvm::StringRef String);
+};
+
+struct DelimiterContext {
+  // Since Content is a StringRef, we separately track the length so that we can
+  // decrement when necessary without modifying the string.
+  size_t Length;
+  char DelimChar;
+  bool RightFlanking;
+  bool LeftFlanking;
+  bool CanOpen = false;
+  bool CanClose = false;
+};
+
+/// \brief A temporary structure for tracking text in a line.
+///
+/// A LineNode might be a valid delimiter run, text, or a delimiter run that
+/// will later be merged with a text if there is no matching run e.g. ***foo.
+///
+/// Line nodes live in a BumpPtrList, so they will be destroyed once a line is
+/// parsed.
+struct LineNode
+    : llvm::ilist_node<LineNode, llvm::ilist_sentinel_tracking<true>> {
+  llvm::Twine Content;
+  // Instantiated if the line is a delimiter run.
+  std::optional<DelimiterContext> DelimiterCtx;
+
+  LineNode() : DelimiterCtx(std::nullopt) {}
+  LineNode(llvm::StringRef Content)
+      : Content(Content), DelimiterCtx(std::nullopt) {}
+  LineNode(llvm::StringRef Content, DelimiterContext Ctx)
+      : Content(Content), DelimiterCtx(Ctx) {
+    if (DelimiterCtx)
+      DelimiterCtx->Length = Content.size();
+  }
+  LineNode(llvm::StringRef Content, std::optional<DelimiterContext> Ctx)
+      : Content(Content), DelimiterCtx(Ctx) {
+    if (DelimiterCtx)
+      DelimiterCtx->Length = Content.size();
+  }
+};
+
+/// \brief A Markdown parser based on the CommonMark specification
+///
+/// The parser constructs an AST from a collection of strings.
+class MarkdownParser {
+  ASTContext &Ctx;
+  MDType State = MDType::None;
+
+  using LineNodeList = llvm::BumpPtrList<LineNode>;
+
+  /// \brief Determine whether a substring is a delimiter run, what type of
+  /// run it is, and if it can be an opener or closer.
+  ///
+  /// The CommonMark specification defines delimiter runs as:
+  /// A delimiter run is either a sequence of one or more * or _ characters that
+  /// is not preceded or followed by a non-backslash-escaped * or _ character
+  ///
+  /// A left-flanking delimiter run is a delimiter run that is (1) not followed
+  /// by Unicode whitespace, and either (2a) not followed by a Unicode
+  /// punctuation character, or (2b) followed by a Unicode punctuation character
+  /// and preceded by Unicode whitespace or a Unicode punctuation character.
+  ///
+  /// A right-flanking delimiter run is a delimiter run that is (1) not preceded
+  /// by Unicode whitespace, and either (2a) not preceded by a Unicode
+  /// punctuation character, or (2b) preceded by a Unicode punctuation character
+  /// and followed by Unicode whitespace or a Unicode punctuation character.
+  ///
+  /// @param IdxOrigin the index of * or _ that might start a delimiter run.
+  /// @return A pair denoting the type of run and the index where the run stops
+  std::optional<std::pair<DelimiterContext, size_t>>
+  processDelimiters(llvm::StringRef Line, const size_t &Origin = 0);
+
+  void appendText(List<Inline> &Out, llvm::StringRef Text);
+
+  void processEmphasis(LineNodeList &Stack, List<Inline> &Out);
+
+  /// \brief Combine text within a range of nodes
+  template <class Iterator, class ReverseIterator>
+  void gatherTextNodes(Block *Parent, Iterator Start, ReverseIterator End);
+  InlineContainer *determineEmphasisNode(DelimiterContext &Opener,
+                                         DelimiterContext &Closer);
+
+  void parse(InlineContainerBlock *Inline);
+  void parse(llvm::StringRef Line, List<Inline> &Out);
+
+public:
+  MarkdownParser(ASTContext &Ctx) : Ctx(Ctx) {}
+
+  /// \brief Parses a collection of strings to construct a Document.
+  void parse(std::vector<llvm::StringRef> &Lines);
+};
+} // namespace md
+} // namespace doc
+} // namespace clang
+#endif

--- a/clang-tools-extra/clang-doc/Representation.h
+++ b/clang-tools-extra/clang-doc/Representation.h
@@ -112,6 +112,7 @@ struct CommentInfo {
   bool SelfClosing = false; // Indicates if tag is self-closing (for HTML).
   bool Explicit = false;    // Indicates if the direction of a param is explicit
                             // (for (T)ParamCommand).
+  bool Markdown = false;    // Comment contains Markdown tokens.
 };
 
 struct Reference {

--- a/clang-tools-extra/unittests/clang-doc/CMakeLists.txt
+++ b/clang-tools-extra/unittests/clang-doc/CMakeLists.txt
@@ -31,6 +31,7 @@ add_extra_unittest(ClangDocTests
   SerializeTest.cpp
   YAMLGeneratorTest.cpp
   JSONGeneratorTest.cpp
+  MDParserTest.cpp
   )
 
 clang_target_link_libraries(ClangDocTests

--- a/clang-tools-extra/unittests/clang-doc/MDParserTest.cpp
+++ b/clang-tools-extra/unittests/clang-doc/MDParserTest.cpp
@@ -1,0 +1,224 @@
+#include "MDParser.h"
+#include "llvm/ADT/StringRef.h"
+#include "gtest/gtest.h"
+
+using llvm::StringRef;
+
+namespace clang {
+namespace doc {
+using namespace clang::doc::md;
+
+TEST(MDParserTest, Strong) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"**Strong**"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  ASSERT_EQ(Paragraph.Children.front().Type, md::InlineType::Strong);
+  auto &Strong = static_cast<InlineContainer &>(Paragraph.Children.front());
+  ASSERT_EQ(Strong.Children.front().Type, InlineType::Text);
+  auto &Text = static_cast<TextInline &>(Strong.Children.front());
+  ASSERT_EQ(Text.Text, "Strong");
+}
+
+TEST(MDParserTest, Emphasis) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"*Emphasis*"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  ASSERT_EQ(Paragraph.Children.front().Type, InlineType::Emphasis);
+  auto &Emphasis = static_cast<InlineContainer &>(Paragraph.Children.front());
+  ASSERT_EQ(Emphasis.Children.front().Type, InlineType::Text);
+  auto &Text = static_cast<TextInline &>(Emphasis.Children.front());
+  ASSERT_EQ(Text.Text, "Emphasis");
+}
+
+TEST(MDParserTest, Text) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"Text"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  ASSERT_EQ(Paragraph.Children.front().Type, InlineType::Text);
+  auto &Text = static_cast<TextInline &>(Paragraph.Children.front());
+  ASSERT_EQ(Text.Text, "Text");
+}
+
+// TEST(MDParserTest, StrongEmphasis) {
+//   ASTContext AST;
+//   MarkdownParser Parser(AST);
+//   std::vector<StringRef> Line = {{"***StrongEmphasis***"}};
+//   Parser.parse(Line);
+//   ContainerBlock *Root = AST.getRoot();
+//   ASSERT_NE(Root, nullptr);
+//   ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+//   auto &Paragraph = static_cast<InlineContainerBlock
+//   &>(Root->Children.front()); auto &Emphasis = static_cast<Inline
+//   &>(Paragraph.Children.front()); ASSERT_EQ(Emphasis.Type,
+//   InlineType::Emphasis); auto &Strong = static_cast<InlineContainer
+//   &>(Emphasis).Children.front(); ASSERT_EQ(Strong.Type, InlineType::Strong);
+//   auto &Text = static_cast<TextInline &>(
+//       static_cast<InlineContainer &>(Strong).Children.front());
+//   ASSERT_EQ(Text.Text, "StrongEmphasis");
+// }
+
+TEST(MDParserTest, LiteralTextBeforeEmphasis) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"Literal*Emphasis*"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  auto &Text = static_cast<TextInline &>(Paragraph.Children.front());
+  ASSERT_EQ(Text.Type, InlineType::Text);
+  ASSERT_EQ(Text.Text, "Literal");
+  auto &Emphasis = static_cast<InlineContainer &>(Paragraph.Children.back());
+  ASSERT_EQ(Emphasis.Type, InlineType::Emphasis);
+  auto EmphasisText = static_cast<TextInline &>(Emphasis.Children.front());
+  ASSERT_EQ(EmphasisText.Text, "Emphasis");
+}
+
+TEST(MDParserTest, LiteralTextBeforeEmphasisWithSpace) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"Literal *Emphasis*"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  auto &Text = static_cast<TextInline &>(Paragraph.Children.front());
+  ASSERT_EQ(Text.Type, InlineType::Text);
+  ASSERT_EQ(Text.Text, "Literal ");
+  auto &Emphasis = static_cast<InlineContainer &>(Paragraph.Children.back());
+  ASSERT_EQ(Emphasis.Type, InlineType::Emphasis);
+  auto EmphasisText = static_cast<TextInline &>(Emphasis.Children.front());
+  ASSERT_EQ(EmphasisText.Text, "Emphasis");
+}
+
+TEST(MDParserTest, LiteralTextAfterEmphasis) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"*Emphasis*Literal"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  auto &Emphasis = static_cast<InlineContainer &>(Paragraph.Children.front());
+  ASSERT_EQ(Emphasis.Type, InlineType::Emphasis);
+  auto EmphasisText = static_cast<TextInline &>(Emphasis.Children.front());
+  ASSERT_EQ(EmphasisText.Text, "Emphasis");
+  auto &Text = static_cast<TextInline &>(Paragraph.Children.back());
+  ASSERT_EQ(Text.Type, InlineType::Text);
+  ASSERT_EQ(Text.Text, "Literal");
+}
+
+TEST(MDParserTest, LiteralTextAfterEmphasisWithSpace) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"*Emphasis* Literal"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  auto &Emphasis = static_cast<InlineContainer &>(Paragraph.Children.front());
+  ASSERT_EQ(Emphasis.Type, InlineType::Emphasis);
+  auto EmphasisText = static_cast<TextInline &>(Emphasis.Children.front());
+  ASSERT_EQ(EmphasisText.Text, "Emphasis");
+  auto &Text = static_cast<TextInline &>(Paragraph.Children.back());
+  ASSERT_EQ(Text.Type, InlineType::Text);
+  ASSERT_EQ(Text.Text, " Literal");
+}
+
+TEST(MDParserTest, LiteralTextBeforeAndAfterEmphasis) {
+  ASTContext AST;
+  MarkdownParser Parser(AST);
+  std::vector<StringRef> Line = {{"Literal*Emphasis*Literal"}};
+  Parser.parse(Line);
+  ContainerBlock *Root = AST.getRoot();
+
+  ASSERT_NE(Root, nullptr);
+  ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+  auto &Paragraph = static_cast<InlineContainerBlock &>(Root->Children.front());
+  auto &FrontText = static_cast<TextInline &>(Paragraph.Children.front());
+  ASSERT_EQ(FrontText.Type, InlineType::Text);
+  ASSERT_EQ(FrontText.Text, "Literal");
+
+  auto &Emphasis = static_cast<InlineContainer &>(
+      *(++(Paragraph.Children.front().getIterator())));
+  ASSERT_EQ(Emphasis.Type, InlineType::Emphasis);
+  auto EmphasisText = static_cast<TextInline &>(Emphasis.Children.front());
+  ASSERT_EQ(EmphasisText.Text, "Emphasis");
+
+  auto &BackText = static_cast<TextInline &>(Paragraph.Children.back());
+  ASSERT_EQ(BackText.Type, InlineType::Text);
+  ASSERT_EQ(BackText.Text, "Literal");
+}
+
+// TEST(MDParserTest, LeftoverBeforeStrong) {
+//   ASTContext AST;
+//   MarkdownParser Parser(AST);
+//   std::vector<StringRef> Line = {{"***Leftover**"}};
+//   Parser.parse(Line);
+//   ContainerBlock *Root = AST.getRoot();
+//
+//   ASSERT_NE(Root, nullptr);
+//   ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+//   auto &Paragraph = static_cast<InlineContainerBlock
+//   &>(Root->Children.front());
+//
+//   auto &Leftover = static_cast<TextInline &>(Paragraph.Children.front());
+//   ASSERT_EQ(Leftover.Type, InlineType::Text);
+//   ASSERT_EQ(Leftover.Text, "*");
+//
+//   auto &Strong = static_cast<InlineContainer &>(
+//       *(++(Paragraph.Children.front().getIterator())));
+//   ASSERT_EQ(Strong.Type, InlineType::Strong);
+//   auto &StrongText = static_cast<TextInline &>(Strong.Children.front());
+//   ASSERT_EQ(StrongText.Text, "Leftover");
+// }
+//
+// TEST(MDParserTest, LeftoverAfterStrong) {
+//   ASTContext AST;
+//   MarkdownParser Parser(AST);
+//   std::vector<StringRef> Line = {{"**Leftover***"}};
+//   Parser.parse(Line);
+//   ContainerBlock *Root = AST.getRoot();
+//
+//   ASSERT_NE(Root, nullptr);
+//   ASSERT_EQ(Root->Children.front().Type, MDType::Paragraph);
+//   auto &Paragraph = static_cast<InlineContainerBlock
+//   &>(Root->Children.front());
+//
+//   auto &Strong = static_cast<InlineContainer &>(Paragraph.Children.front());
+//   ASSERT_EQ(Strong.Type, InlineType::Strong);
+//   auto &StrongText = static_cast<TextInline &>(Strong.Children.front());
+//   ASSERT_EQ(StrongText.Text, "Leftover");
+//
+//   auto &Leftover = static_cast<TextInline &>(Paragraph.Children.back());
+//   ASSERT_EQ(Leftover.Type, InlineType::Text);
+//   ASSERT_EQ(Leftover.Text, "*");
+// }
+} // namespace doc
+} // namespace clang


### PR DESCRIPTION
Initial implementation of a Markdown parser and Markdown AST. Currently, the parser only recognizes emphasis and strong syntax. It also only creates paragraph blocks. The AST is allocated via a BumpPtrAllocator. It attempts to conform to the CommonMark standard

The parser ingests lines and creates preprocessing LineNodes that later are converted to Nodes that form the AST.