### PR TITLE
[ValueTracking] Use unionWith when calculating known bits for abs.

### DIFF
--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -1829,7 +1829,7 @@ static void computeKnownBitsFromOperator(const Operator *I,
       case Intrinsic::abs: {
         computeKnownBits(I->getOperand(0), DemandedElts, Known2, Q, Depth + 1);
         bool IntMinIsPoison = match(II->getArgOperand(1), m_One());
-        Known = Known2.abs(IntMinIsPoison);
+        Known = Known.unionWith(Known2.abs(IntMinIsPoison));
         break;
       }
       case Intrinsic::bitreverse:

--- a/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
+++ b/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
@@ -847,3 +847,17 @@ cond.end:
   %r = phi i32 [ %0, %cond.true ], [ 0, %entry ]
   ret i32 %r
 }
+
+; The AND should be removable based on range metadata. Make sure
+; computeKnownBits doesn't lose this.
+define i32 @abs_range_metadata(i32 %x) {
+; CHECK-LABEL: @abs_range_metadata(
+; CHECK-NEXT:    [[A:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false), !range [[RNG0:![0-9]+]]
+; CHECK-NEXT:    [[B:%.*]] = and i32 [[A]], 15
+; CHECK-NEXT:    ret i32 [[B]]
+;
+  %a = call i32 @llvm.abs.i32(i32 %x, i1 false), !range !1
+  %b = and i32 %a, 15
+  ret i32 %b
+}
+!1 = !{i32 0, i32 16}

--- a/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
+++ b/llvm/test/Transforms/InstCombine/abs-intrinsic.ll
@@ -852,8 +852,7 @@ cond.end:
 ; computeKnownBits doesn't lose this.
 define i32 @abs_range_metadata(i32 %x) {
 ; CHECK-LABEL: @abs_range_metadata(
-; CHECK-NEXT:    [[A:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false), !range [[RNG0:![0-9]+]]
-; CHECK-NEXT:    [[B:%.*]] = and i32 [[A]], 15
+; CHECK-NEXT:    [[B:%.*]] = call i32 @llvm.abs.i32(i32 [[X:%.*]], i1 false), !range [[RNG0:![0-9]+]]
 ; CHECK-NEXT:    ret i32 [[B]]
 ;
   %a = call i32 @llvm.abs.i32(i32 %x, i1 false), !range !1


### PR DESCRIPTION
We may have already gotten information from range metadata, don't
overwrite it.