### PR TITLE
[clang] fix regression parsing C enum which doesn't declare anything

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -5291,10 +5291,8 @@ Decl *Sema::ParsedFreeStandingDeclSpec(Scope *S, AccessSpecifier AS,
     //   UNION_TYPE;   <- where UNION_TYPE is a typedef union.
     if ((Tag && Tag->getDeclName()) ||
         DS.getTypeSpecType() == DeclSpec::TST_typename) {
-      RecordDecl *Record = dyn_cast_or_null<RecordDecl>(Tag);
-      if (!Record)
-        Record = DS.getRepAsType().get()->getAsRecordDecl();
-
+      RecordDecl *Record = Tag ? dyn_cast<RecordDecl>(Tag)
+                               : DS.getRepAsType().get()->getAsRecordDecl();
       if (Record && getLangOpts().MicrosoftExt) {
         Diag(DS.getBeginLoc(), diag::ext_ms_anonymous_record)
             << Record->isUnion() << DS.getSourceRange();

--- a/clang/test/Sema/GH155794.c
+++ b/clang/test/Sema/GH155794.c
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wno-everything %s
+
+struct S {
+  enum e1 {} // expected-error {{use of empty enum}} expected-error {{expected ';' after enum}}
+  enum e2 {} // expected-error {{use of empty enum}}
+}; // expected-error {{expected member name or ';' after declaration specifiers}}


### PR DESCRIPTION
The regression was introduced in #155313

Since this regression was never released, there are no release notes.

Fixes #155794