### PR TITLE
[MemoryBuiltins] Add getBaseObjectSize() (NFCI)

### DIFF
--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -181,6 +181,13 @@ LLVM_ABI bool getObjectSize(const Value *Ptr, uint64_t &Size,
                             const DataLayout &DL, const TargetLibraryInfo *TLI,
                             ObjectSizeOpts Opts = {});
 
+/// Like getObjectSize(), but only supports base objects (like allocas,
+/// global variables and allocator calls). Requires ExactSizeFromOffset mode.
+LLVM_ABI std::optional<TypeSize> getBaseObjectSize(const Value *Ptr,
+                                                   const DataLayout &DL,
+                                                   const TargetLibraryInfo *TLI,
+                                                   ObjectSizeOpts Opts = {});
+
 /// Try to turn a call to \@llvm.objectsize into an integer value of the given
 /// Type. Returns null on failure. If MustSucceed is true, this function will
 /// not return null, and may return conservative values governed by the second

--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -181,8 +181,9 @@ LLVM_ABI bool getObjectSize(const Value *Ptr, uint64_t &Size,
                             const DataLayout &DL, const TargetLibraryInfo *TLI,
                             ObjectSizeOpts Opts = {});
 
-/// Like getObjectSize(), but only supports base objects (like allocas,
-/// global variables and allocator calls). Requires ExactSizeFromOffset mode.
+/// Like getObjectSize(), but only returns the size of base objects (like
+/// allocas, global variables and allocator calls) and std::nullopt otherwise.
+/// Requires ExactSizeFromOffset mode.
 LLVM_ABI std::optional<TypeSize> getBaseObjectSize(const Value *Ptr,
                                                    const DataLayout &DL,
                                                    const TargetLibraryInfo *TLI,

--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -103,12 +103,15 @@ static std::optional<TypeSize> getObjectSize(const Value *V,
                                              const TargetLibraryInfo &TLI,
                                              bool NullIsValidLoc,
                                              bool RoundToAlign = false) {
-  uint64_t Size;
   ObjectSizeOpts Opts;
   Opts.RoundToAlign = RoundToAlign;
   Opts.NullIsUnknownSize = NullIsValidLoc;
-  if (getObjectSize(V, Size, DL, &TLI, Opts))
-    return TypeSize::getFixed(Size);
+  if (std::optional<TypeSize> Size = getBaseObjectSize(V, DL, &TLI, Opts)) {
+    // FIXME: Remove this check, only exists to preserve previous behavior.
+    if (Size->isScalable())
+      return std::nullopt;
+    return Size;
+  }
   return std::nullopt;
 }
 


### PR DESCRIPTION
getObjectSize() is based on ObjectSizeOffsetVisitor, which has become very expensive over time. The implementation is geared towards computing as-good-as-possible results for the objectsize intrinsics and similar. However, we also use it in BasicAA, which is very hot, and really only cares about the base cases like alloca/malloc/global, not any of the analysis for GEPs, phis, or loads.

Add a new getBaseObjectSize() API for this use case, which only handles the non-recursive cases. As a bonus, this API can easily return a TypeSize and thus support scalable vectors. For now, I'm explicitly discarding the scalable sizes in BasicAA just to avoid unnecessary behavior changes during this refactor.

Compile-time: https://llvm-compile-time-tracker.com/compare.php?from=24924a8be1bb7c6083303330ecc0e7dc647247d3&to=061852858448ad2b549fc2b5a0dcd2d38581a859&stat=instructions:u

No changes on llvm-opt-benchmark.