### PR TITLE
[libc][test] Remove more unused nan variables

### DIFF
--- a/libc/test/src/math/smoke/TotalOrderMagTest.h
+++ b/libc/test/src/math/smoke/TotalOrderMagTest.h
@@ -106,12 +106,6 @@ public:
   }
 
   void testNaNPayloads(TotalOrderMagFunc func) {
-
-    T qnan_0x15 = FPBits::quiet_nan(Sign::POS, 0x15).get_val();
-    T neg_qnan_0x15 = FPBits::quiet_nan(Sign::NEG, 0x15).get_val();
-    T snan_0x15 = FPBits::signaling_nan(Sign::POS, 0x15).get_val();
-    T neg_snan_0x15 = FPBits::signaling_nan(Sign::NEG, 0x15).get_val();
-
     EXPECT_TRUE(funcWrapper(func, aNaN, aNaN));
     EXPECT_TRUE(funcWrapper(func, sNaN, sNaN));
 


### PR DESCRIPTION
These are redefined/shadowed by the if constexpr (FPBits::FRACTION_LEN - 1 >= 5) case below.

Added by https://github.com/llvm/llvm-project/pull/155569. I missed these ones in #155894.