### PR TITLE
[LLVM] Specialize test suites for `TableGen` and `FileCheck` to use smaller set of dependencies

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -65,9 +65,11 @@ set(LLVM_TEST_DEPENDS_COMMON
   count
   llvm-config
   not
+  prepare-check-lit
   )
 
 set(LLVM_TEST_DEPENDS
+  ${LLVM_TEST_DEPENDS_COMMON}
   BugpointPasses
   LLVMWindowsDriver
   UnitTests
@@ -267,7 +269,6 @@ set_target_properties(check-llvm PROPERTIES FOLDER "LLVM/Tests")
 # reduced set of dependencies in their individual CMakeLists.txt
 add_lit_testsuites(LLVM ${CMAKE_CURRENT_SOURCE_DIR}
   ${exclude_from_check_all}
-  DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
   DEPENDS ${LLVM_TEST_DEPENDS}
   FOLDER "Tests/Subdirectories"
   SKIP "^FileCheck" "^TableGen"

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -59,100 +59,104 @@ configure_lit_site_cfg(
 
 # Set the depends list as a variable so that it can grow conditionally.
 # NOTE: Sync the substitutions in test/lit.cfg when adding to this list.
+
+set(LLVM_TEST_DEPENDS_COMMON
+  FileCheck
+  count
+  llvm-config
+  not
+  )
+
 set(LLVM_TEST_DEPENDS
-          BugpointPasses
-          FileCheck
-          LLVMWindowsDriver
-          UnitTests
-          bugpoint
-          count
-          llc
-          lli
-          lli-child-target
-          llvm-addr2line
-          llvm-ar
-          llvm-as
-          llvm-bcanalyzer
-          llvm-bitcode-strip
-          llvm-c-test
-          llvm-cat
-          llvm-cfi-verify
-          llvm-cgdata
-          llvm-config
-          llvm-cov
-          llvm-ctxprof-util
-          llvm-cvtres
-          llvm-cxxdump
-          llvm-cxxfilt
-          llvm-cxxmap
-          llvm-debuginfo-analyzer
-          llvm-debuginfod-find
-          llvm-diff
-          llvm-dis
-          llvm-dlltool
-          dsymutil
-          llvm-dwarfdump
-          llvm-dwarfutil
-          llvm-dwp
-          llvm-exegesis
-          llvm-extract
-          llvm-gsymutil
-          llvm-ir2vec
-          llvm-isel-fuzzer
-          llvm-ifs
-          llvm-install-name-tool
-          llvm-jitlink
-          llvm-lib
-          llvm-libtool-darwin
-          llvm-link
-          llvm-lipo
-          llvm-locstats
-          llvm-lto2
-          llvm-mc
-          llvm-mca
-          llvm-ml
-          llvm-ml64
-          llvm-modextract
-          llvm-nm
-          llvm-objcopy
-          llvm-objdump
-          llvm-opt-fuzzer
-          llvm-opt-report
-          llvm-offload-wrapper
-          llvm-otool
-          llvm-pdbutil
-          llvm-profdata
-          llvm-profgen
-          llvm-ranlib
-          llvm-rc
-          llvm-readobj
-          llvm-readelf
-          llvm-reduce
-          llvm-remarkutil
-          llvm-rtdyld
-          llvm-sim
-          llvm-size
-          llvm-split
-          llvm-stress
-          llvm-strings
-          llvm-strip
-          llvm-symbolizer
-          llvm-tblgen
-          llvm-readtapi
-          llvm-tli-checker
-          llvm-undname
-          llvm-windres
-          llvm-xray
-          not
-          obj2yaml
-          opt
-          sancov
-          sanstats
-          split-file
-          verify-uselistorder
-          yaml-bench
-          yaml2obj
-        )
+  BugpointPasses
+  LLVMWindowsDriver
+  UnitTests
+  bugpoint
+  llc
+  lli
+  lli-child-target
+  llvm-addr2line
+  llvm-ar
+  llvm-as
+  llvm-bcanalyzer
+  llvm-bitcode-strip
+  llvm-c-test
+  llvm-cat
+  llvm-cfi-verify
+  llvm-cgdata
+  llvm-cov
+  llvm-ctxprof-util
+  llvm-cvtres
+  llvm-cxxdump
+  llvm-cxxfilt
+  llvm-cxxmap
+  llvm-debuginfo-analyzer
+  llvm-debuginfod-find
+  llvm-diff
+  llvm-dis
+  llvm-dlltool
+  dsymutil
+  llvm-dwarfdump
+  llvm-dwarfutil
+  llvm-dwp
+  llvm-exegesis
+  llvm-extract
+  llvm-gsymutil
+  llvm-ir2vec
+  llvm-isel-fuzzer
+  llvm-ifs
+  llvm-install-name-tool
+  llvm-jitlink
+  llvm-lib
+  llvm-libtool-darwin
+  llvm-link
+  llvm-lipo
+  llvm-locstats
+  llvm-lto2
+  llvm-mc
+  llvm-mca
+  llvm-ml
+  llvm-ml64
+  llvm-modextract
+  llvm-nm
+  llvm-objcopy
+  llvm-objdump
+  llvm-opt-fuzzer
+  llvm-opt-report
+  llvm-offload-wrapper
+  llvm-otool
+  llvm-pdbutil
+  llvm-profdata
+  llvm-profgen
+  llvm-ranlib
+  llvm-rc
+  llvm-readobj
+  llvm-readelf
+  llvm-reduce
+  llvm-remarkutil
+  llvm-rtdyld
+  llvm-sim
+  llvm-size
+  llvm-split
+  llvm-stress
+  llvm-strings
+  llvm-strip
+  llvm-symbolizer
+  llvm-tblgen
+  llvm-readtapi
+  llvm-tli-checker
+  llvm-undname
+  llvm-windres
+  llvm-xray
+  obj2yaml
+  opt
+  sancov
+  sanstats
+  split-file
+  verify-uselistorder
+  yaml-bench
+  yaml2obj
+  )
 
 if(TARGET llvm-lto)
   set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} llvm-lto)
@@ -259,11 +263,18 @@ add_lit_testsuite(check-llvm "Running the LLVM regression tests"
   )
 set_target_properties(check-llvm PROPERTIES FOLDER "LLVM/Tests")
 
+# Note, exclude TableGen and FileCheck directories as we define them with a
+# reduced set of dependencies in their individual CMakeLists.txt
 add_lit_testsuites(LLVM ${CMAKE_CURRENT_SOURCE_DIR}
   ${exclude_from_check_all}
+  DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
   DEPENDS ${LLVM_TEST_DEPENDS}
   FOLDER "Tests/Subdirectories"
+  SKIP "^FileCheck"
+  SKIP "^TableGen"
   )
+add_subdirectory(FileCheck)
+add_subdirectory(TableGen)
 
 # Setup an alias for 'check-all'.
 add_custom_target(check)

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -270,8 +270,7 @@ add_lit_testsuites(LLVM ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
   DEPENDS ${LLVM_TEST_DEPENDS}
   FOLDER "Tests/Subdirectories"
-  SKIP "^FileCheck"
-  SKIP "^TableGen"
+  SKIP "^FileCheck" "^TableGen"
   )
 add_subdirectory(FileCheck)
 add_subdirectory(TableGen)

--- a/llvm/test/FileCheck/CMakeLists.txt
+++ b/llvm/test/FileCheck/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_lit_testsuite(check-llvm-filecheck "Running lit suite for FileCheck"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
+  )

--- a/llvm/test/TableGen/CMakeLists.txt
+++ b/llvm/test/TableGen/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Subset of dependencies for TableGen lit test.
+set(LLVM_TEST_TABLEGEN_DEPENDS
+  llvm-tblgen
+  )
+
+add_lit_testsuite(check-llvm-tablegen "Running lit suite for TableGen"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
+  DEPENDS ${LLVM_TEST_TABLEGEN_DEPENDS}
+  )

--- a/llvm/test/TableGen/CMakeLists.txt
+++ b/llvm/test/TableGen/CMakeLists.txt
@@ -1,10 +1,5 @@
-# Subset of dependencies for TableGen lit test.
-set(LLVM_TEST_TABLEGEN_DEPENDS
-  llvm-tblgen
-  )
-
 add_lit_testsuite(check-llvm-tablegen "Running lit suite for TableGen"
   ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
-  DEPENDS ${LLVM_TEST_TABLEGEN_DEPENDS}
+  DEPENDS llvm-tblgen
   )


### PR DESCRIPTION
Define lit testsuite for FileCheck and TableGen with smaller set of dependencies. This uses the new `SKIP` argument to `add_lit_testsuites` that was added in https://github.com/llvm/llvm-project/pull/157176/.