### PR TITLE
ThinLTOBitcodeWriter: Split modules with __cfi_check and no type metadata.

### DIFF
--- a/llvm/test/Transforms/ThinLTOBitcodeWriter/cfi-check-no-metadata.ll
+++ b/llvm/test/Transforms/ThinLTOBitcodeWriter/cfi-check-no-metadata.ll
@@ -1,0 +1,18 @@
+; RUN: opt -thinlto-bc -thinlto-split-lto-unit -o %t %s
+; RUN: llvm-modextract -b -n 0 -o - %t | llvm-dis | FileCheck --check-prefix=M0 %s
+; RUN: llvm-modextract -b -n 1 -o - %t | llvm-dis | FileCheck --check-prefix=M1 %s
+
+; Check that __cfi_check is emitted on the full LTO side with
+; attributes preserved, even if nothing has !type metadata
+; on the ThinLTO side.
+
+; M0: @g = global i32 0
+@g = global i32 0
+
+; M1: define void @__cfi_check() #0
+define void @__cfi_check() #0 {
+  ret void
+}
+
+; M1: attributes #0 = { "branch-target-enforcement" }
+attributes #0 = { "branch-target-enforcement" }


### PR DESCRIPTION
Eli Friedman found a case that was not handled correctly by #154833 where
we failed to split the module if it contained a __cfi_check function but
no type metadata. Handle this case correctly by checking for __cfi_check
when deciding whether to split.
