### PR TITLE
[lldb] Skip TestVariableAnnotationsDisassembler.py on non-x86 architectures

### DIFF
--- a/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
+++ b/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
@@ -22,6 +22,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.runCmd(f"disassemble -n {symname} -v", check=True)
         return self.res.GetOutput()
 
+    @skipIf(archs=no_match(["x86_64"]))
     def test_d_original_example_O1(self):
         obj = self._build_obj("d_original_example.o")
         target = self._create_target(obj)
@@ -33,6 +34,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64"]))
     def test_regs_int_params(self):
         obj = self._build_obj("regs_int_params.o")
         target = self._create_target(obj)
@@ -47,6 +49,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64"]))
     def test_regs_fp_params(self):
         obj = self._build_obj("regs_fp_params.o")
         target = self._create_target(obj)
@@ -61,6 +64,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64"]))
     def test_regs_mixed_params(self):
         obj = self._build_obj("regs_mixed_params.o")
         target = self._create_target(obj)
@@ -75,6 +79,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64"]))
     def test_live_across_call(self):
         obj = self._build_obj("live_across_call.o")
         target = self._create_target(obj)
@@ -86,6 +91,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64"]))
     def test_loop_reg_rotate(self):
         obj = self._build_obj("loop_reg_rotate.o")
         target = self._create_target(obj)
@@ -99,6 +105,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIf(archs=no_match(["x86_64"]))
     def test_seed_reg_const_undef(self):
         obj = self._build_obj("seed_reg_const_undef.o")
         target = self._create_target(obj)


### PR DESCRIPTION
The test lldb-api::TestVariableAnnotationsDisassembler.py was failing on the lldb-remote-linux-ubuntu and lldb-remote-linux-win builders due to assembler incompatibilities in d_original_example.s. These failures are not related to the disassembler changes themselves but to the test setup.

This patch updates the test to be skipped when running on unsupported architectures to avoid failures. The test will still run and validate correctly where the assembler input is supported.