### PR TITLE
[msan] Detect dereferencing zero-alloc as use-of-uninitialized-value

### DIFF
--- a/compiler-rt/lib/msan/msan_allocator.cpp
+++ b/compiler-rt/lib/msan/msan_allocator.cpp
@@ -230,6 +230,12 @@ static void *MsanAllocate(BufferedStackTrace *stack, uptr size, uptr alignment,
       __msan_set_origin(allocated, size, o.raw_id());
     }
   }
+
+  uptr actually_allocated_size = allocator.GetActuallyAllocatedSize(allocated);
+  // For compatibility, the allocator converted 0-sized allocations into 1 byte
+  if (size == 0 && actually_allocated_size > 0 && flags()->poison_in_malloc)
+    __msan_poison(allocated, 1);
+
   UnpoisonParam(2);
   RunMallocHooks(allocated, size);
   return allocated;

--- a/compiler-rt/test/msan/zero_alloc.cpp
+++ b/compiler-rt/test/msan/zero_alloc.cpp
@@ -1,9 +1,5 @@
 // RUN: %clang_msan -Wno-alloc-size -fsanitize-recover=memory %s -o %t && not %run %t 2>&1 | FileCheck %s
 
-// MSan doesn't catch this because internally it translates 0-byte allocations
-// into 1-byte
-// XFAIL: *
-
 #include <malloc.h>
 #include <stdio.h>
 


### PR DESCRIPTION
When a zero-byte allocation is requested, MSan actually allocates 1-byte for compatibility. This change poisons that byte, to detect dereferences.

Also updates the test from #155934