### PR TITLE
[C++20][Modules] Fix merging of anonymous members of class templates.

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -4521,6 +4521,23 @@ public:
     return field_begin() == field_end();
   }
 
+  /// noload_fields - Iterate over the fields stored in this record
+  /// that are currently loaded; don't attempt to retrieve anything
+  /// from an external source.
+  field_range noload_fields() const {
+    return field_range(noload_field_begin(), noload_field_end());
+  }
+
+  field_iterator noload_field_begin() const;
+  field_iterator noload_field_end() const {
+    return field_iterator(decl_iterator());
+  }
+
+  // Whether there are any fields (non-static data members) in this record.
+  bool noload_field_empty() const {
+    return noload_field_begin() == noload_field_end();
+  }
+
   /// Note that the definition of this type is now complete.
   virtual void completeDefinition();
 

--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5161,6 +5161,10 @@ RecordDecl::field_iterator RecordDecl::field_begin() const {
   return field_iterator(decl_iterator(FirstDecl));
 }
 
+RecordDecl::field_iterator RecordDecl::noload_field_begin() const {
+  return field_iterator(decl_iterator(getDefinitionOrSelf()->FirstDecl));
+}
+
 /// completeDefinition - Notes that the definition of this type is now
 /// complete.
 void RecordDecl::completeDefinition() {

--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3432,7 +3432,19 @@ NamedDecl *ASTDeclReader::getAnonymousDeclForMerging(ASTReader &Reader,
   // If this is the first time, but we have parsed a declaration of the context,
   // build the anonymous declaration list from the parsed declaration.
   auto *PrimaryDC = getPrimaryDCForAnonymousDecl(DC);
-  if (PrimaryDC && !cast<Decl>(PrimaryDC)->isFromASTFile()) {
+  auto needToNumberAnonymousDeclsWithin = [](Decl *D) {
+    if (!D->isFromASTFile())
+      return true;
+    // If this is a class template specialization from an AST file, has at least
+    // one field, but none of the fields have been loaded from external storage,
+    // this is a situation where the class template specialization decl
+    // was imported but the definition was instantiated within the source.
+    // In such a case, we still need to number the anonymous decls.
+    auto *CTSD = dyn_cast<ClassTemplateSpecializationDecl>(D);
+    return CTSD && !CTSD->noload_field_empty() &&
+           !CTSD->hasLoadedFieldsFromExternalStorage();
+  };
+  if (PrimaryDC && needToNumberAnonymousDeclsWithin(cast<Decl>(PrimaryDC))) {
     numberAnonymousDeclsWithin(PrimaryDC, [&](NamedDecl *ND, unsigned Number) {
       if (Previous.size() == Number)
         Previous.push_back(cast<NamedDecl>(ND->getCanonicalDecl()));

--- a/clang/test/Modules/merge-anon-in-template-2.cpp
+++ b/clang/test/Modules/merge-anon-in-template-2.cpp
@@ -1,0 +1,47 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 -fmodule-name=hu-01 -emit-header-unit -xc++-user-header %t/hu-01.h \
+// RUN:  -o %t/hu-01.pcm
+
+// RUN: %clang_cc1 -std=c++20 -fmodule-name=hu-02 -emit-header-unit -xc++-user-header %t/hu-02.h \
+// RUN:  -Wno-experimental-header-units \
+// RUN:  -fmodule-map-file=%t/hu-01.map -fmodule-file=hu-01=%t/hu-01.pcm \
+// RUN:  -o %t/hu-02.pcm
+
+// RUN: %clang_cc1 -std=c++20 -emit-obj %t/main.cpp \
+// RUN:  -Wno-experimental-header-units \
+// RUN:  -fmodule-map-file=%t/hu-01.map -fmodule-file=hu-01=%t/hu-01.pcm \
+// RUN:  -fmodule-map-file=%t/hu-02.map -fmodule-file=hu-02=%t/hu-02.pcm
+
+//--- hu-01.map
+module "hu-01" {
+  header "hu-01.h"
+  export *
+}
+
+//--- hu-02.map
+module "hu-02" {
+  header "hu-02.h"
+  export *
+}
+
+//--- hu-01.h
+template <typename T>
+struct S { union { T x; }; };
+
+using SI = S<int>;
+
+//--- hu-02.h
+template <typename T>
+struct S { union { T x; }; };
+
+inline void f(S<int> s = {}) { s.x; }
+
+//--- main.cpp
+import "hu-01.h";
+void g(S<int>) {}
+
+import "hu-02.h";
+void h() { f(); }

--- a/clang/test/Modules/merge-anon-in-template-3.cpp
+++ b/clang/test/Modules/merge-anon-in-template-3.cpp
@@ -1,0 +1,45 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -std=c++20 -fmodule-name=hu-01 -emit-header-unit -xc++-user-header %t/hu-01.h \
+// RUN:  -o %t/hu-01.pcm
+
+// RUN: %clang_cc1 -std=c++20 -fmodule-name=hu-02 -emit-header-unit -xc++-user-header %t/hu-02.h \
+// RUN:  -Wno-experimental-header-units \
+// RUN:  -fmodule-map-file=%t/hu-01.map -fmodule-file=hu-01=%t/hu-01.pcm \
+// RUN:  -o %t/hu-02.pcm
+
+// RUN: %clang_cc1 -std=c++20 -emit-obj %t/main.cpp \
+// RUN:  -Wno-experimental-header-units \
+// RUN:  -fmodule-map-file=%t/hu-01.map -fmodule-file=hu-01=%t/hu-01.pcm \
+// RUN:  -fmodule-map-file=%t/hu-02.map -fmodule-file=hu-02=%t/hu-02.pcm
+
+//--- hu-01.map
+module "hu-01" {
+  header "hu-01.h"
+  export *
+}
+
+//--- hu-02.map
+module "hu-02" {
+  header "hu-02.h"
+  export *
+}
+
+//--- hu-01.h
+template <typename T>
+struct S { union { T x; }; };
+
+using SI = S<int>;
+
+//--- hu-02.h
+import "hu-01.h";
+inline void f(S<int> s = {}) { s.x; }
+
+//--- main.cpp
+import "hu-01.h";
+void g(S<int>) {}
+
+import "hu-02.h";
+void h() { f(); }


### PR DESCRIPTION
# Problem Description

Consider the following example involving an anonymous `union` in a class template:
```cpp
// a.h
template <typename T>
struct S { union { T x; }; };

using SI = S<int>;

// b.h
import "a.h";
inline void f(S<int> s = {}) { s.x; }

// main.cpp
import "a.h";
void g(S<int>) {}

import "b.h";
void h() { f(); }
```
This example currently triggers an assertion failure that looks like this:
```
clang: llvm-project/clang/lib/CodeGen/CGRecordLayout.h:204: unsigned int clang::CodeGen::CGRecordLayout::getLLVMFieldNo(const FieldDecl *) const: Assertion `FieldInfo.count(FD) && "Invalid field for record!"' failed.
```

We try to look-up a `FieldDecl` instance in the `FieldInfo` of a `CGRecordLayout`, which is missing.

- `a.h` has a `ClassTemplateDecl` (from the `S` primary template), and a `ClassTemplateSpecializationDecl` (from the `using SI = S<int>;`). Note however, that the `ClassTemplateSpecializationDecl` is not an instantiation at this point.
- `b.h` imports `a.h`, and requires a full instantiation of `S<int>` (from `f(S<int> s)`). It performs the instantiation, creates the `FieldDecl` instances for the anonymous `union` and `int x;`, forms the reference to them, and write all of that to `b.pcm`.
- `main.cpp` imports `a.h`, and it also requires a full instantiation of `S<int>` (from `g(S<int>)`). Since we don't have an instantiated version (we haven't imported `b.h` yet), we perform the instantiation again here.
- `main.cpp` imports `b.h`, and that updates `S<int>` instantiated in `main.cpp` with the information from `b.h`. The invocation of `f()` pulls in the `s.x` expression which requires the `FieldDecl`s (both the anonymous `union` and the `int x;`) in `b.pcm`. The anonymous `union` `FieldDecl` first tries to merge with the existing one, but this process is unsuccessful, and the merging does not occur.
- We flow into CodeGen layer in this state, which produces a `CGRecordLayout` with the `ClassTemplateSpecializationDecl` with a `FieldDecl` for the anonymous `union` from `main.cpp`. We later try to do a look-up of the `FieldDecl` for the anonymous `union` from `b.h`. At this point, the expected behavior is for the `FieldDecl`s to have been merged such that `getCanonicalDecl` returns the canonical version, which *is* present in the `CGRecordLayout`. However, since the merging failed, we end up doing the look-up of the `FieldDecl` for the anonymous `union` from `b.h` in a hashmap that contains the `FieldDecl` for the anonymous `union` from `main.cpp`.

# Why Merging Fails

The following piece of code is within `ASTDeclReader::getAnonymousDeclForMerging`:

```
  // If this is the first time, but we have parsed a declaration of the context,
  // build the anonymous declaration list from the parsed declaration.
  auto *PrimaryDC = getPrimaryDCForAnonymousDecl(DC);
  if (PrimaryDC && !cast<Decl>(PrimaryDC)->isFromASTFile()) {
    numberAnonymousDeclsWithin(PrimaryDC, [&](NamedDecl *ND, unsigned Number) {
      if (Previous.size() == Number)
        Previous.push_back(cast<NamedDecl>(ND->getCanonicalDecl()));
      else
        Previous[Number] = cast<NamedDecl>(ND->getCanonicalDecl());
    });
  }
```

https://github.com/llvm/llvm-project/blob/main/clang/lib/Serialization/ASTReaderDecl.cpp#L3430

Typically, an AST import action will insert a `DeclContext` into the `AnonymousDeclarationsForMerging` hashmap if no existing entry has been found. However, if the `DeclContext` was parsed within this source file, it doesn't go through the same codepath to insert itself into the hashmap. As such, this piece of code is trying to fill that gap by performing the insertion if the `DeclContext` is not from an AST file. It's meant to handle an example like this:

```cpp
// b.h
struct S { union { int x; }; };

// main.cpp
struct S { union { int x; }; };  // parsed within the source!
import "b.h";  // merge with above
```

The problem is that this condition is not accurate enough in the face of template instantiations.

Consider this slightly modified version of the above example:

```cpp
// a.h
template <typename T>
struct S { union { T x; }; };

using SI = S<int>;  // creates a `ClassTemplateSpecializationDecl` but doesn't instantiate.

// b.h
import "a.h";
void f(S<int>) {}  // full instantiation.

// main.cpp
import "a.h";
void g(S<int>) {}  // fully instantiate `S<int>` here, but it fills in
                   // the `ClassTemplateSpecializationDecl` skeleton imported from `a.h`.

import "b.h"; // <-- problem
```

Here, in `main.cpp` during the import of `a.h`, we do an import of the skeleton (uninstantiated) instance of `ClassTemplateSpecializationDecl`. As such, the numbering of anonymous members does not take place. Then, it gets fully instantiated from `void g(S<int>);` but still, no numbering occurs. So semantically we're in the same situation as the previous example of having parsed the decl in the source (it just happens to be **instantiated** in the source rather than parsed), but the `isFromASTFile` of the `ClassTemplateSpecializationDecl` reports `true` (since the instance **was** imported from `a.h`!). The numbering never happens, which in turn makes it such that merging doesn't happen.

# Proposed Solution

The solution proposed here is to check whether the point of instantiation is local, even if the decl is from an AST file. Additionally, we make an `UpdateRecord` only update the point of instantiation if it's not already set. This way, the point of instantiation always remains the **first** point of instantiation.

# Alternative Considered

An approach where we inject the numbering logic before an `UpdateDecl` call was considered. The idea was that since for `UpdateDecl` we already know we're not the first one, we know we should prepare to do some merging. This approach does actually work to address `merge-anon-in-template-3.cpp` where an `UpdateDecl` occurs. However, it does not fix the case where an `UpdateDecl` does not occur, e.g. in `merge-anon-in-template-2.cpp`. As such, I believe that the solution proposed in this PR is simpler and more robust.