### PR TITLE
[compiler-rt] Make __EH_FRAME_LIST__ const to avoid RW .eh_frame mapping (#155764)

### DIFF
--- a/compiler-rt/lib/builtins/crtbegin.c
+++ b/compiler-rt/lib/builtins/crtbegin.c
@@ -19,7 +19,7 @@
 __attribute__((visibility("hidden"))) void *__dso_handle = &__dso_handle;
 
 #ifdef EH_USE_FRAME_REGISTRY
-__extension__ static void * const __EH_FRAME_LIST__[]
+__extension__ static void *const __EH_FRAME_LIST__[]
     __attribute__((section(".eh_frame"), aligned(sizeof(void *)))) = {};
 
 extern void __register_frame_info(const void *, void *) __attribute__((weak));

--- a/compiler-rt/lib/builtins/crtbegin.c
+++ b/compiler-rt/lib/builtins/crtbegin.c
@@ -19,7 +19,7 @@
 __attribute__((visibility("hidden"))) void *__dso_handle = &__dso_handle;
 
 #ifdef EH_USE_FRAME_REGISTRY
-__extension__ static void *__EH_FRAME_LIST__[]
+__extension__ static void * const __EH_FRAME_LIST__[]
     __attribute__((section(".eh_frame"), aligned(sizeof(void *)))) = {};
 
 extern void __register_frame_info(const void *, void *) __attribute__((weak));


### PR DESCRIPTION
In crtbegin.c, `__EH_FRAME_LIST__` was previously declared as a writable array of pointers. This caused the linker to place .eh_frame into a segment with read-write permissions, leading to larger virtual memory footprint at runtime (e.g. .eh_frame mapped into both LOAD and RELRO).

Changing it to `static void * const __EH_FRAME_LIST__[]` ensures that the section is treated as read-only, matching GCC’s behavior with `__EH_FRAME_BEGIN__`. This prevents unnecessary RW mappings of .eh_frame while preserving the intended semantics.

Fixes: #155764