### PR TITLE
[KeyInstr] Add release note following #149509

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -211,6 +211,7 @@ Deprecated Compiler Flags
 
 Modified Compiler Flags
 -----------------------
+- The `-gkey-instructions` compiler flag is now enabled by default when DWARF is emitted for plain C/C++ and optimizations are enabled. (#GH149509)
 
 Removed Compiler Flags
 -------------------------


### PR DESCRIPTION
Key Instructions (-gkey-instructions) is now enabled by default when DWARF is
being emitted, the input is plain C/C++, and optimisations are enabled.

Add release note for the change in default behaviour.