### PR TITLE
[libc++][NFC] Replace typedefs with using declarations

### DIFF
--- a/libcxx/include/__tree
+++ b/libcxx/include/__tree
@@ -551,7 +551,7 @@ private:
 template <class _Pointer>
 class __tree_end_node {
 public:
-  typedef _Pointer pointer;
+  using pointer = _Pointer;
   pointer __left_;
 
   _LIBCPP_HIDE_FROM_ABI __tree_end_node() _NOEXCEPT : __left_() {}
@@ -595,11 +595,11 @@ public:
 
 template <class _Allocator>
 class __tree_node_destructor {
-  typedef _Allocator allocator_type;
-  typedef allocator_traits<allocator_type> __alloc_traits;
+  using allocator_type                 = _Allocator;
+  using __alloc_traits _LIBCPP_NODEBUG = allocator_traits<allocator_type>;
 
 public:
-  typedef typename __alloc_traits::pointer pointer;
+  using pointer = typename __alloc_traits::pointer;
 
 private:
   allocator_type& __na_;
@@ -636,10 +636,11 @@ struct __generic_container_node_destructor<__tree_node<_Tp, _VoidPtr>, _Alloc> :
 
 template <class _Tp, class _NodePtr, class _DiffType>
 class __tree_iterator {
-  typedef __tree_node_types<_NodePtr> _NodeTypes;
-  typedef _NodePtr __node_pointer;
-  typedef typename _NodeTypes::__node_base_pointer __node_base_pointer;
-  typedef typename _NodeTypes::__end_node_pointer __end_node_pointer;
+  using _NodeTypes _LIBCPP_NODEBUG = __tree_node_types<_NodePtr>;
+  // NOLINTNEXTLINE(libcpp-nodebug-on-aliases) lldb relies on this alias for pretty printing
+  using __node_pointer                      = _NodePtr;
+  using __node_base_pointer _LIBCPP_NODEBUG = typename _NodeTypes::__node_base_pointer;
+  using __end_node_pointer _LIBCPP_NODEBUG  = typename _NodeTypes::__end_node_pointer;
 
   __end_node_pointer __ptr_;
 
@@ -696,11 +697,11 @@ private:
 
 template <class _Tp, class _NodePtr, class _DiffType>
 class __tree_const_iterator {
-  typedef __tree_node_types<_NodePtr> _NodeTypes;
+  using _NodeTypes _LIBCPP_NODEBUG = __tree_node_types<_NodePtr>;
   // NOLINTNEXTLINE(libcpp-nodebug-on-aliases) lldb relies on this alias for pretty printing
-  using __node_pointer = _NodePtr;
-  typedef typename _NodeTypes::__node_base_pointer __node_base_pointer;
-  typedef typename _NodeTypes::__end_node_pointer __end_node_pointer;
+  using __node_pointer                      = _NodePtr;
+  using __node_base_pointer _LIBCPP_NODEBUG = typename _NodeTypes::__node_base_pointer;
+  using __end_node_pointer _LIBCPP_NODEBUG  = typename _NodeTypes::__end_node_pointer;
 
   __end_node_pointer __ptr_;
 
@@ -769,21 +770,20 @@ int __diagnose_non_const_comparator();
 template <class _Tp, class _Compare, class _Allocator>
 class __tree {
 public:
-  using value_type = __get_node_value_type_t<_Tp>;
-  typedef _Compare value_compare;
-  typedef _Allocator allocator_type;
+  using value_type     = __get_node_value_type_t<_Tp>;
+  using value_compare  = _Compare;
+  using allocator_type = _Allocator;
 
 private:
-  typedef allocator_traits<allocator_type> __alloc_traits;
-  using key_type = __get_tree_key_type_t<_Tp>;
+  using __alloc_traits _LIBCPP_NODEBUG = allocator_traits<allocator_type>;
+  using key_type                       = __get_tree_key_type_t<_Tp>;
 
 public:
-  typedef typename __alloc_traits::pointer pointer;
-  typedef typename __alloc_traits::const_pointer const_pointer;
-  typedef typename __alloc_traits::size_type size_type;
-  typedef typename __alloc_traits::difference_type difference_type;
+  using pointer         = typename __alloc_traits::pointer;
+  using const_pointer   = typename __alloc_traits::const_pointer;
+  using size_type       = typename __alloc_traits::size_type;
+  using difference_type = typename __alloc_traits::difference_type;
 
-public:
   using __void_pointer _LIBCPP_NODEBUG = typename __alloc_traits::void_pointer;
 
   using __node _LIBCPP_NODEBUG = __tree_node<_Tp, __void_pointer>;
@@ -798,8 +798,8 @@ public:
 
   using __parent_pointer _LIBCPP_NODEBUG = __end_node_pointer; // TODO: Remove this once the uses in <map> are removed
 
-  typedef __rebind_alloc<__alloc_traits, __node> __node_allocator;
-  typedef allocator_traits<__node_allocator> __node_traits;
+  using __node_allocator _LIBCPP_NODEBUG = __rebind_alloc<__alloc_traits, __node>;
+  using __node_traits _LIBCPP_NODEBUG    = allocator_traits<__node_allocator>;
 
 // TODO(LLVM 22): Remove this check
 #ifndef _LIBCPP_ABI_TREE_REMOVE_NODE_POINTER_UB
@@ -819,8 +819,8 @@ private:
   // the pointer using 'pointer_traits'.
   static_assert(is_same<__node_pointer, typename __node_traits::pointer>::value,
                 "Allocator does not rebind pointers in a sane manner.");
-  typedef __rebind_alloc<__node_traits, __node_base> __node_base_allocator;
-  typedef allocator_traits<__node_base_allocator> __node_base_traits;
+  using __node_base_allocator _LIBCPP_NODEBUG = __rebind_alloc<__node_traits, __node_base>;
+  using __node_base_traits _LIBCPP_NODEBUG    = allocator_traits<__node_base_allocator>;
   static_assert(is_same<__node_base_pointer, typename __node_base_traits::pointer>::value,
                 "Allocator does not rebind pointers in a sane manner.");
 
@@ -857,8 +857,8 @@ public:
     return std::addressof(__end_node()->__left_);
   }
 
-  typedef __tree_iterator<_Tp, __node_pointer, difference_type> iterator;
-  typedef __tree_const_iterator<_Tp, __node_pointer, difference_type> const_iterator;
+  using iterator       = __tree_iterator<_Tp, __node_pointer, difference_type>;
+  using const_iterator = __tree_const_iterator<_Tp, __node_pointer, difference_type>;
 
   _LIBCPP_HIDE_FROM_ABI explicit __tree(const value_compare& __comp) _NOEXCEPT_(
       is_nothrow_default_constructible<__node_allocator>::value&& is_nothrow_copy_constructible<value_compare>::value);
@@ -1117,8 +1117,8 @@ public:
   template <class _Key>
   _LIBCPP_HIDE_FROM_ABI pair<const_iterator, const_iterator> __equal_range_multi(const _Key& __k) const;
 
-  typedef __tree_node_destructor<__node_allocator> _Dp;
-  typedef unique_ptr<__node, _Dp> __node_holder;
+  using _Dp _LIBCPP_NODEBUG           = __tree_node_destructor<__node_allocator>;
+  using __node_holder _LIBCPP_NODEBUG = unique_ptr<__node, _Dp>;
 
   _LIBCPP_HIDE_FROM_ABI __node_holder remove(const_iterator __p) _NOEXCEPT;
 
@@ -1411,8 +1411,8 @@ __tree<_Tp, _Compare, _Allocator>& __tree<_Tp, _Compare, _Allocator>::operator=(
 template <class _Tp, class _Compare, class _Allocator>
 template <class _ForwardIterator>
 void __tree<_Tp, _Compare, _Allocator>::__assign_unique(_ForwardIterator __first, _ForwardIterator __last) {
-  typedef iterator_traits<_ForwardIterator> _ITraits;
-  typedef typename _ITraits::value_type _ItValueType;
+  using _ITraits     = iterator_traits<_ForwardIterator>;
+  using _ItValueType = typename _ITraits::value_type;
   static_assert(
       is_same<_ItValueType, value_type>::value, "__assign_unique may only be called with the containers value type");
   static_assert(
@@ -1431,8 +1431,8 @@ void __tree<_Tp, _Compare, _Allocator>::__assign_unique(_ForwardIterator __first
 template <class _Tp, class _Compare, class _Allocator>
 template <class _InputIterator>
 void __tree<_Tp, _Compare, _Allocator>::__assign_multi(_InputIterator __first, _InputIterator __last) {
-  typedef iterator_traits<_InputIterator> _ITraits;
-  typedef typename _ITraits::value_type _ItValueType;
+  using _ITraits     = iterator_traits<_InputIterator>;
+  using _ItValueType = typename _ITraits::value_type;
   static_assert(
       is_same<_ItValueType, value_type>::value, "__assign_multi may only be called with the containers value_type");
   if (__size_ != 0) {
@@ -2121,7 +2121,7 @@ template <class _Tp, class _Compare, class _Allocator>
 template <class _Key>
 pair<typename __tree<_Tp, _Compare, _Allocator>::iterator, typename __tree<_Tp, _Compare, _Allocator>::iterator>
 __tree<_Tp, _Compare, _Allocator>::__equal_range_unique(const _Key& __k) {
-  typedef pair<iterator, iterator> _Pp;
+  using _Pp                   = pair<iterator, iterator>;
   __end_node_pointer __result = __end_node();
   __node_pointer __rt         = __root();
   while (__rt != nullptr) {
@@ -2143,7 +2143,7 @@ template <class _Key>
 pair<typename __tree<_Tp, _Compare, _Allocator>::const_iterator,
      typename __tree<_Tp, _Compare, _Allocator>::const_iterator>
 __tree<_Tp, _Compare, _Allocator>::__equal_range_unique(const _Key& __k) const {
-  typedef pair<const_iterator, const_iterator> _Pp;
+  using _Pp                   = pair<const_iterator, const_iterator>;
   __end_node_pointer __result = __end_node();
   __node_pointer __rt         = __root();
   while (__rt != nullptr) {
@@ -2165,7 +2165,7 @@ template <class _Tp, class _Compare, class _Allocator>
 template <class _Key>
 pair<typename __tree<_Tp, _Compare, _Allocator>::iterator, typename __tree<_Tp, _Compare, _Allocator>::iterator>
 __tree<_Tp, _Compare, _Allocator>::__equal_range_multi(const _Key& __k) {
-  typedef pair<iterator, iterator> _Pp;
+  using _Pp                   = pair<iterator, iterator>;
   __end_node_pointer __result = __end_node();
   __node_pointer __rt     = __root();
   while (__rt != nullptr) {
@@ -2186,7 +2186,7 @@ template <class _Key>
 pair<typename __tree<_Tp, _Compare, _Allocator>::const_iterator,
      typename __tree<_Tp, _Compare, _Allocator>::const_iterator>
 __tree<_Tp, _Compare, _Allocator>::__equal_range_multi(const _Key& __k) const {
-  typedef pair<const_iterator, const_iterator> _Pp;
+  using _Pp                   = pair<const_iterator, const_iterator>;
   __end_node_pointer __result = __end_node();
   __node_pointer __rt     = __root();
   while (__rt != nullptr) {


### PR DESCRIPTION
We've done quite a bit of refactoring recently in `<__tree>`. This patch finishes up replacing typedefs with using declarations. As a side-effect, this also adds some `_LIBCPP_NODEBUG` annotations, since the clang-tidy check catches these now.
