### PR TITLE
[OpenMP] Use Clang resource dir only in bootstrapping build

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -12,10 +12,10 @@ include(ExtendPath)
 
 # The generated headers will be placed in clang's resource if using it to
 # compile openmp in a runtimes-bootstrapping build.
-if(NOT LLVM_RUNTIMES_BUILD)
-  set(LIBOMP_HEADERS_INTDIR ${CMAKE_CURRENT_BINARY_DIR})
-else()
+if(LLVM_TREE_AVAILABLE AND LLVM_RUNTIMES_BUILD)
   set(LIBOMP_HEADERS_INTDIR ${LLVM_BINARY_DIR}/${LIBOMP_HEADERS_INSTALL_PATH})
+else()
+  set(LIBOMP_HEADERS_INTDIR ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 # Configure omp.h, kmp_config.h and omp-tools.h if necessary

--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -10,8 +10,9 @@
 
 include(ExtendPath)
 
-# The generated headers will be placed in clang's resource directory if present.
-if(NOT LLVM_TREE_AVAILABLE)
+# The generated headers will be placed in clang's resource if using it to
+# compile openmp in a runtimes-bootstrapping build.
+if(NOT LLVM_RUNTIMES_BUILD)
   set(LIBOMP_HEADERS_INTDIR ${CMAKE_CURRENT_BINARY_DIR})
 else()
   set(LIBOMP_HEADERS_INTDIR ${LLVM_BINARY_DIR}/${LIBOMP_HEADERS_INSTALL_PATH})


### PR DESCRIPTION
In an LLVM_ENABLE_PROJECTS=openmp build, the LLVM build tree in which just-built Clang is available, but in contrast to an LLVM_ENABLE_RUNTIMES=openmp build, is not the compiler that openmp is built with (CMAKE_CXX_COMPILER). The latter compiler (which might also be gcc) will not look into the resource directory of just-built Clang, where the OpenMP headers are installed. There may not even be a just-built Clang without LLVM_ENABLE_PROJECTS=clang.

We cannot add the  OpenMP header output directory to the search path which also include's Clang's internal headers that will conflict with CMAKE_CXX_COMPILER's internal headers. The only choice left is to use what the OpenMP standalone build does: Use CMAKE_CURRENT_BINARY_DIR which is added unconditionally to the header search path to compile openmp itself.

Note that LLVM_ENABLE_PROJECTS=openmp is [deprecated](https://github.com/llvm/llvm-project/pull/136314). Consider switching to a LLVM_ENABLE_RUNTIMES=openmp build and supporting removing the [LLVM_ENABLE_PROJECTS=openmp build mode](https://github.com/llvm/llvm-project/pull/152189).