### PR TITLE
[lldb] Restrict TestVariableAnnotationsDisassembler.py to ELF x86_64 (skip on Windows/COFF)

### DIFF
--- a/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
+++ b/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
@@ -22,6 +22,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.runCmd(f"disassemble -n {symname} -v", check=True)
         return self.res.GetOutput()
 
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_d_original_example_O1(self):
         obj = self._build_obj("d_original_example.o")
@@ -34,6 +36,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_int_params(self):
         obj = self._build_obj("regs_int_params.o")
@@ -49,6 +53,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_fp_params(self):
         obj = self._build_obj("regs_fp_params.o")
@@ -64,6 +70,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_mixed_params(self):
         obj = self._build_obj("regs_mixed_params.o")
@@ -79,6 +87,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_live_across_call(self):
         obj = self._build_obj("live_across_call.o")
@@ -91,6 +101,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_loop_reg_rotate(self):
         obj = self._build_obj("loop_reg_rotate.o")
@@ -105,6 +117,8 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
+    @skipIfWindows
+    @skipUnlessPlatform(["linux","freebsd","netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_seed_reg_const_undef(self):
         obj = self._build_obj("seed_reg_const_undef.o")

--- a/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
+++ b/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
@@ -5,6 +5,9 @@ import os
 import re
 
 
+# Requires ELF assembler directives (.section … @progbits, .ident, etc.);
+# not compatible with COFF/Mach-O toolchains.
+@skipUnlessPlatform(["linux", "android", "freebsd", "netbsd"])
 class TestVariableAnnotationsDisassembler(TestBase):
     def _build_obj(self, obj_name: str) -> str:
         # Let the Makefile build all .o’s (pattern rule). Then grab the one we need.
@@ -22,8 +25,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.runCmd(f"disassemble -n {symname} -v", check=True)
         return self.res.GetOutput()
 
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_d_original_example_O1(self):
         obj = self._build_obj("d_original_example.o")
@@ -36,8 +37,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_int_params(self):
         obj = self._build_obj("regs_int_params.o")
@@ -53,8 +52,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_fp_params(self):
         obj = self._build_obj("regs_fp_params.o")
@@ -70,8 +67,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_mixed_params(self):
         obj = self._build_obj("regs_mixed_params.o")
@@ -87,8 +82,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_live_across_call(self):
         obj = self._build_obj("live_across_call.o")
@@ -101,8 +94,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_loop_reg_rotate(self):
         obj = self._build_obj("loop_reg_rotate.o")
@@ -117,8 +108,6 @@ class TestVariableAnnotationsDisassembler(TestBase):
         self.assertNotIn("<decoding error>", out)
 
     @no_debug_info_test
-    @skipIfWindows
-    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_seed_reg_const_undef(self):
         obj = self._build_obj("seed_reg_const_undef.o")

--- a/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
+++ b/lldb/test/API/functionalities/disassembler-variables/TestVariableAnnotationsDisassembler.py
@@ -23,7 +23,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
         return self.res.GetOutput()
 
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_d_original_example_O1(self):
         obj = self._build_obj("d_original_example.o")
@@ -37,7 +37,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
 
     @no_debug_info_test
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_int_params(self):
         obj = self._build_obj("regs_int_params.o")
@@ -54,7 +54,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
 
     @no_debug_info_test
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_fp_params(self):
         obj = self._build_obj("regs_fp_params.o")
@@ -71,7 +71,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
 
     @no_debug_info_test
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_regs_mixed_params(self):
         obj = self._build_obj("regs_mixed_params.o")
@@ -88,7 +88,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
 
     @no_debug_info_test
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_live_across_call(self):
         obj = self._build_obj("live_across_call.o")
@@ -102,7 +102,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
 
     @no_debug_info_test
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_loop_reg_rotate(self):
         obj = self._build_obj("loop_reg_rotate.o")
@@ -118,7 +118,7 @@ class TestVariableAnnotationsDisassembler(TestBase):
 
     @no_debug_info_test
     @skipIfWindows
-    @skipUnlessPlatform(["linux","freebsd","netbsd"])
+    @skipUnlessPlatform(["linux", "freebsd", "netbsd"])
     @skipIf(archs=no_match(["x86_64"]))
     def test_seed_reg_const_undef(self):
         obj = self._build_obj("seed_reg_const_undef.o")


### PR DESCRIPTION
The `TestVariableAnnotationsDisassembler.py` test assembles `d_original_example.s`, 
which contains ELF-specific directives such as:

- `.ident`
- `.section ".note.GNU-stack", "", @progbits`
- `.section .debug_line, "", @progbits`

These directives are not understood by COFF on Windows, so the test fails 
on the lldb-remote-linux-win builder even when running on x86_64.

This patch adds a decorator to gate the test,
- `@skipUnlessPlatform(["linux", "freebsd", "netbsd", "android"])` — 
  runs only on ELF platforms

Follow-up to #155942.