### PR TITLE
[mlir][spirv] Add pattern matching for arith.index_cast index to i1 for ArithToSPIRV

### DIFF
--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -612,7 +612,8 @@ struct UIToFPI1Pattern final : public OpConversionPattern<arith::UIToFPOp> {
 //===----------------------------------------------------------------------===//
 
 /// Converts arith.index_cast to spirv.Select if the type of source is index.
-struct IndexCastIndexI1Pattern final : public OpConversionPattern<arith::IndexCastOp> {
+struct IndexCastIndexI1Pattern final
+    : public OpConversionPattern<arith::IndexCastOp> {
   using OpConversionPattern::OpConversionPattern;
 
   LogicalResult
@@ -629,10 +630,11 @@ struct IndexCastIndexI1Pattern final : public OpConversionPattern<arith::IndexCa
     Value zero = spirv::ConstantOp::getZero(dstType, loc, rewriter);
     Value one = spirv::ConstantOp::getOne(dstType, loc, rewriter);
     Value zeroIdx = spirv::ConstantOp::getZero(srcType, loc, rewriter);
-    auto isZero = spirv::IEqualOp::create(
-        rewriter, loc, dstType, zeroIdx, adaptor.getOperands().front());
+    auto isZero = spirv::IEqualOp::create(rewriter, loc, dstType, zeroIdx,
+                                          adaptor.getOperands().front());
     // spriv.IEqual outputs i32, spirv.Select is used to truncate to i1:
-    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, dstType, isZero, zero, one);
+    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, dstType, isZero, zero,
+                                                 one);
     return success();
   }
 };

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -625,16 +625,9 @@ struct IndexCastIndexI1Pattern final
     if (srcType != indexType || !op.getType().isInteger(1))
       return failure();
 
-    Type dstType = rewriter.getI1Type();
     Location loc = op.getLoc();
-    Value zero = spirv::ConstantOp::getZero(dstType, loc, rewriter);
-    Value one = spirv::ConstantOp::getOne(dstType, loc, rewriter);
     Value zeroIdx = spirv::ConstantOp::getZero(srcType, loc, rewriter);
-    auto isZero = spirv::IEqualOp::create(rewriter, loc, dstType, zeroIdx,
-                                          adaptor.getOperands().front());
-    // spriv.IEqual outputs i32, spirv.Select is used to truncate to i1:
-    rewriter.replaceOpWithNewOp<spirv::SelectOp>(op, dstType, isZero, zero,
-                                                 one);
+    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, rewriter.getI1Type(), zeroIdx, adaptor.getOperands().front());
     return success();
   }
 };

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -622,10 +622,14 @@ struct IndexCastIndexI1Pattern final
     if (!isBoolScalarOrVector(op.getType()))
       return failure();
 
+    Type dstType = getTypeConverter()->convertType(op.getType());
+    if (!dstType)
+      return getTypeConversionFailure(rewriter, op);
+
     Location loc = op.getLoc();
     Value zeroIdx =
-        spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
-    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, op.getType(), zeroIdx,
+       spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
+    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, dstType, zeroIdx,
                                                     adaptor.getIn());
     return success();
   }

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -623,7 +623,8 @@ struct IndexCastIndexI1Pattern final
       return failure();
 
     Location loc = op.getLoc();
-    Value zeroIdx = spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
+    Value zeroIdx =
+        spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
     rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, op.getType(), zeroIdx,
                                                     adaptor.getIn());
     return success();

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -611,7 +611,7 @@ struct UIToFPI1Pattern final : public OpConversionPattern<arith::UIToFPOp> {
 // IndexCastOp
 //===----------------------------------------------------------------------===//
 
-// Converts arith.index_cast to spirv.Select if the target type is i1.
+// Converts arith.index_cast to spirv.INotEqual if the target type is i1.
 struct IndexCastIndexI1Pattern final
     : public OpConversionPattern<arith::IndexCastOp> {
   using OpConversionPattern::OpConversionPattern;

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -625,8 +625,8 @@ struct IndexCastIndexI1Pattern final
 
     Location loc = op.getLoc();
     Value zeroIdx = spirv::ConstantOp::getZero(srcType, loc, rewriter);
-    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(
-        op, op.getType(), zeroIdx, adaptor.getIn());
+    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, op.getType(), zeroIdx,
+                                                    adaptor.getIn());
     return success();
   }
 };

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -619,12 +619,11 @@ struct IndexCastIndexI1Pattern final
   LogicalResult
   matchAndRewrite(arith::IndexCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type srcType = adaptor.getIn().getType();
-    if (!op.getType().isInteger(1))
+    if (!isBoolScalarOrVector(op.getType()))
       return failure();
 
     Location loc = op.getLoc();
-    Value zeroIdx = spirv::ConstantOp::getZero(srcType, loc, rewriter);
+    Value zeroIdx = spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
     rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, op.getType(), zeroIdx,
                                                     adaptor.getIn());
     return success();

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -627,7 +627,8 @@ struct IndexCastIndexI1Pattern final
 
     Location loc = op.getLoc();
     Value zeroIdx = spirv::ConstantOp::getZero(srcType, loc, rewriter);
-    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, rewriter.getI1Type(), zeroIdx, adaptor.getOperands().front());
+    rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(
+        op, rewriter.getI1Type(), zeroIdx, adaptor.getOperands().front());
     return success();
   }
 };

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -628,7 +628,7 @@ struct IndexCastIndexI1Pattern final
 
     Location loc = op.getLoc();
     Value zeroIdx =
-       spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
+        spirv::ConstantOp::getZero(adaptor.getIn().getType(), loc, rewriter);
     rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(op, dstType, zeroIdx,
                                                     adaptor.getIn());
     return success();

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -611,7 +611,7 @@ struct UIToFPI1Pattern final : public OpConversionPattern<arith::UIToFPOp> {
 // IndexCastOp
 //===----------------------------------------------------------------------===//
 
-/// Converts arith.index_cast to spirv.Select if the type of source is index.
+// Converts arith.index_cast to spirv.Select if the target type is i1.
 struct IndexCastIndexI1Pattern final
     : public OpConversionPattern<arith::IndexCastOp> {
   using OpConversionPattern::OpConversionPattern;

--- a/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
+++ b/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp
@@ -619,16 +619,14 @@ struct IndexCastIndexI1Pattern final
   LogicalResult
   matchAndRewrite(arith::IndexCastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Type srcType = adaptor.getOperands().front().getType();
-    // Indexes have already been converted to its respective spirv type:
-    Type indexType = getTypeConverter<SPIRVTypeConverter>()->getIndexType();
-    if (srcType != indexType || !op.getType().isInteger(1))
+    Type srcType = adaptor.getIn().getType();
+    if (!op.getType().isInteger(1))
       return failure();
 
     Location loc = op.getLoc();
     Value zeroIdx = spirv::ConstantOp::getZero(srcType, loc, rewriter);
     rewriter.replaceOpWithNewOp<spirv::INotEqualOp>(
-        op, rewriter.getI1Type(), zeroIdx, adaptor.getOperands().front());
+        op, op.getType(), zeroIdx, adaptor.getIn());
     return success();
   }
 };

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -736,11 +736,8 @@ func.func @index_castui4(%arg0: index) {
 
 // CHECK-LABEL: index_castindexi1
 func.func @index_castindexi1(%arg0 : index) {
-  // CHECK: %[[FALSE:.+]] = spirv.Constant false
-  // CHECK: %[[TRUE:.+]] = spirv.Constant true
   // CHECK: %[[ZERO:.+]] = spirv.Constant 0 : i32
-  // CHECK: %[[IS_ZERO:.+]] = spirv.IEqual %[[ZERO]], %{{.+}} : i32
-  // CHECK: spirv.Select %[[IS_ZERO]], %[[FALSE]], %[[TRUE]] : i1, i1
+  // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : i32
   %0 = arith.index_cast %arg0 : index to i1
   return
 }

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -734,11 +734,19 @@ func.func @index_castui4(%arg0: index) {
   return
 }
 
-// CHECK-LABEL: index_castindexi1
-func.func @index_castindexi1(%arg0 : index) {
+// CHECK-LABEL: index_castindexi1_1
+func.func @index_castindexi1_1(%arg0 : index) {
   // CHECK: %[[ZERO:.+]] = spirv.Constant 0 : i32
   // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : i32
   %0 = arith.index_cast %arg0 : index to i1
+  return
+}
+
+// CHECK-LABEL: index_castindexi1_2
+func.func @index_castindexi1_2(%arg0 : vector<3xindex>) {
+  // CHECK: %[[ZERO:.+]] = spirv.Constant dense<0> : vector<3xi32>
+  // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : vector<3xi32>
+  %0 = arith.index_cast %arg0 : vector<3xindex> to vector<3xi1>
   return
 }
 

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -734,6 +734,17 @@ func.func @index_castui4(%arg0: index) {
   return
 }
 
+// CHECK-LABEL: index_castindexi1
+func.func @index_castindexi1(%arg0 : index) {
+  // CHECK: %[[FALSE:.+]] = spirv.Constant false
+  // CHECK: %[[TRUE:.+]] = spirv.Constant true
+  // CHECK: %[[ZERO:.+]] = spirv.Constant 0 : i32
+  // CHECK: %[[IS_ZERO:.+]] = spirv.IEqual %[[ZERO]], %{{.+}} : i32
+  // CHECK: spirv.Select %[[IS_ZERO]], %[[FALSE]], %[[TRUE]] : i1, i1
+  %0 = arith.index_cast %arg0 : index to i1
+  return
+}
+
 // CHECK-LABEL: @bit_cast
 func.func @bit_cast(%arg0: vector<2xf32>, %arg1: i64) {
   // CHECK: spirv.Bitcast %{{.+}} : vector<2xf32> to vector<2xi32>

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -743,7 +743,16 @@ func.func @index_castindexi1_1(%arg0 : index) {
 }
 
 // CHECK-LABEL: index_castindexi1_2
-func.func @index_castindexi1_2(%arg0 : vector<3xindex>) {
+func.func @index_castindexi1_2(%arg0 : vector<1xindex>) -> vector<1xi1> {
+  // Single-element vectors do not exist in SPIRV.
+  // CHECK: %[[ZERO:.+]] = spirv.Constant 0 : i32
+  // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : i32
+  %0 = arith.index_cast %arg0 : vector<1xindex> to vector<1xi1>
+  return %0 : vector<1xi1>
+}
+
+// CHECK-LABEL: index_castindexi1_3
+func.func @index_castindexi1_3(%arg0 : vector<3xindex>) {
   // CHECK: %[[ZERO:.+]] = spirv.Constant dense<0> : vector<3xi32>
   // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : vector<3xi32>
   %0 = arith.index_cast %arg0 : vector<3xindex> to vector<3xi1>

--- a/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
+++ b/mlir/test/Conversion/ArithToSPIRV/arith-to-spirv.mlir
@@ -735,7 +735,7 @@ func.func @index_castui4(%arg0: index) {
 }
 
 // CHECK-LABEL: index_castindexi1_1
-func.func @index_castindexi1_1(%arg0 : index) {
+func.func @index_castindexi1_1(%arg0: index) {
   // CHECK: %[[ZERO:.+]] = spirv.Constant 0 : i32
   // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : i32
   %0 = arith.index_cast %arg0 : index to i1
@@ -743,7 +743,7 @@ func.func @index_castindexi1_1(%arg0 : index) {
 }
 
 // CHECK-LABEL: index_castindexi1_2
-func.func @index_castindexi1_2(%arg0 : vector<1xindex>) -> vector<1xi1> {
+func.func @index_castindexi1_2(%arg0: vector<1xindex>) -> vector<1xi1> {
   // Single-element vectors do not exist in SPIRV.
   // CHECK: %[[ZERO:.+]] = spirv.Constant 0 : i32
   // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : i32
@@ -752,7 +752,7 @@ func.func @index_castindexi1_2(%arg0 : vector<1xindex>) -> vector<1xi1> {
 }
 
 // CHECK-LABEL: index_castindexi1_3
-func.func @index_castindexi1_3(%arg0 : vector<3xindex>) {
+func.func @index_castindexi1_3(%arg0: vector<3xindex>) {
   // CHECK: %[[ZERO:.+]] = spirv.Constant dense<0> : vector<3xi32>
   // CHECK: spirv.INotEqual %[[ZERO]], %{{.+}} : vector<3xi32>
   %0 = arith.index_cast %arg0 : vector<3xindex> to vector<3xi1>


### PR DESCRIPTION
Currently, `arith.index_cast` gets converted to `OpSConvert`: https://github.com/llvm/llvm-project/blob/9bf5bf3baf3c7aec82cdd235c6a2fd57b4dd55ab/mlir/lib/Conversion/ArithToSPIRV/ArithToSPIRV.cpp#L1331 [OpSConvert requires its operands to be of integer type](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpSConvert), which poses an issue for `i1` since SPIRV distinguishes between booleans and integers. As a result, the following example doesn't get converted, leaving behind illegal ops:
```
%0 = arith.index_cast %arg0 : index to i1
```
This PR adds additional logic to convert `arith.index_casts` to SPIRV dialect when casting from `index` to `i1`. Converting `index_cast`s from `i1` to `index` is submitted as https://github.com/llvm/llvm-project/pull/155729. 