### PR TITLE
[flang-rt] Use -Wp to undefine macros

### DIFF
--- a/flang-rt/CMakeLists.txt
+++ b/flang-rt/CMakeLists.txt
@@ -255,11 +255,11 @@ if (UNIX AND CMAKE_SYSTEM_NAME MATCHES "AIX")
   add_compile_definitions(_LARGE_FILE_API)
 endif ()
 
-# Check whether the compiler can undefine a macro using the "-U" flag.
+# Check whether the compiler can undefine a macro using the "-Wp,-U" flag.
 # Aternatively, we could use
 #   CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "GNU"
 # but some older versions of CMake don't define it for GCC itself.
-check_cxx_compiler_flag("-UTESTFLAG" FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
+check_cxx_compiler_flag("-Wp,-UTESTFLAG" FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
 
 # Check whether -fno-lto is supported.
 check_cxx_compiler_flag(-fno-lto FLANG_RT_HAS_FNO_LTO_FLAG)

--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -283,8 +283,10 @@ function (add_flangrt_library name)
     # build, to avoid an unwanted dependency on libstdc++/libc++.so.
     target_compile_definitions(${tgtname} PUBLIC _GLIBCXX_NO_ASSERTIONS)
     if (FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
-      target_compile_options(${tgtname} PUBLIC -Wp,-U_GLIBCXX_ASSERTIONS)
-      target_compile_options(${tgtname} PUBLIC -Wp,-U_LIBCPP_ENABLE_ASSERTIONS)
+      target_compile_options(${tgtname} PUBLIC
+          "$<$<COMPILE_LANGUAGE:CXX>:-Wp,-U_GLIBCXX_ASSERTIONS>")
+      target_compile_options(${tgtname} PUBLIC
+          "$<$<COMPILE_LANGUAGE:CXX>:-Wp,-U_LIBCPP_ENABLE_ASSERTIONS>")
     endif ()
 
     # Non-GTest unittests depend on LLVMSupport

--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -283,8 +283,8 @@ function (add_flangrt_library name)
     # build, to avoid an unwanted dependency on libstdc++/libc++.so.
     target_compile_definitions(${tgtname} PUBLIC _GLIBCXX_NO_ASSERTIONS)
     if (FLANG_RT_SUPPORTS_UNDEFINE_FLAG)
-      target_compile_options(${tgtname} PUBLIC -U_GLIBCXX_ASSERTIONS)
-      target_compile_options(${tgtname} PUBLIC -U_LIBCPP_ENABLE_ASSERTIONS)
+      target_compile_options(${tgtname} PUBLIC -Wp,-U_GLIBCXX_ASSERTIONS)
+      target_compile_options(${tgtname} PUBLIC -Wp,-U_LIBCPP_ENABLE_ASSERTIONS)
     endif ()
 
     # Non-GTest unittests depend on LLVMSupport


### PR DESCRIPTION
If the macro was previously defined with `-Wp,-D` then a later `-U` is *not* going to take effect, the `-Wp` flag takes precedence.

Instead use `-Wp,-U`. This works regardless of whether the original definition was provided via `-D` or `-Wp,-D`.

Also make sure these flags only get passed to the C++ compiler -- they are only relevant there, and flang does not support `-Wp`.