### PR TITLE
[X86] Add -fexperimental-new-constant-interpreter test coverage to the LZCNT/POPCNT constexpr test files

### DIFF
--- a/clang/test/CodeGen/X86/lzcnt-builtins.c
+++ b/clang/test/CodeGen/X86/lzcnt-builtins.c
@@ -1,59 +1,54 @@
 // RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -emit-llvm -o - | FileCheck %s
 // RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -emit-llvm -o - | FileCheck %s
 
+// RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s
+
 
 #include <immintrin.h>
+#include "builtin_test_helpers.h"
 
 unsigned short test__lzcnt16(unsigned short __X)
 {
   // CHECK: @llvm.ctlz.i16(i16 %{{.*}}, i1 false)
   return __lzcnt16(__X);
 }
+TEST_CONSTEXPR(__lzcnt16(0x0000) == 16);
+TEST_CONSTEXPR(__lzcnt16(0x8000) ==  0);
+TEST_CONSTEXPR(__lzcnt16(0x0010) == 11);
 
 unsigned int test_lzcnt32(unsigned int __X)
 {
   // CHECK: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
   return __lzcnt32(__X);
 }
+TEST_CONSTEXPR(__lzcnt32(0x00000000) == 32);
+TEST_CONSTEXPR(__lzcnt32(0x80000000) ==  0);
+TEST_CONSTEXPR(__lzcnt32(0x00000010) == 27);
 
 unsigned long long test__lzcnt64(unsigned long long __X)
 {
   // CHECK: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
   return __lzcnt64(__X);
 }
+TEST_CONSTEXPR(__lzcnt64(0x0000000000000000ULL) == 64);
+TEST_CONSTEXPR(__lzcnt64(0x8000000000000000ULL) ==  0);
+TEST_CONSTEXPR(__lzcnt64(0x0000000100000000ULL) == 31);
 
 unsigned int test_lzcnt_u32(unsigned int __X)
 {
   // CHECK: @llvm.ctlz.i32(i32 %{{.*}}, i1 false)
   return _lzcnt_u32(__X);
 }
+TEST_CONSTEXPR(_lzcnt_u32(0x00000000) == 32);
+TEST_CONSTEXPR(_lzcnt_u32(0x80000000) ==  0);
+TEST_CONSTEXPR(_lzcnt_u32(0x00000010) == 27);
 
 unsigned long long test__lzcnt_u64(unsigned long long __X)
 {
   // CHECK: @llvm.ctlz.i64(i64 %{{.*}}, i1 false)
   return _lzcnt_u64(__X);
 }
-
-
-// Test constexpr handling.
-#if defined(__cplusplus) && (__cplusplus >= 201103L)
-char lzcnt16_0[__lzcnt16(0x0000) == 16 ? 1 : -1];
-char lzcnt16_1[__lzcnt16(0x8000) ==  0 ? 1 : -1];
-char lzcnt16_2[__lzcnt16(0x0010) == 11 ? 1 : -1];
-
-char lzcnt32_0[__lzcnt32(0x00000000) == 32 ? 1 : -1];
-char lzcnt32_1[__lzcnt32(0x80000000) ==  0 ? 1 : -1];
-char lzcnt32_2[__lzcnt32(0x00000010) == 27 ? 1 : -1];
-
-char lzcnt64_0[__lzcnt64(0x0000000000000000ULL) == 64 ? 1 : -1];
-char lzcnt64_1[__lzcnt64(0x8000000000000000ULL) ==  0 ? 1 : -1];
-char lzcnt64_2[__lzcnt64(0x0000000100000000ULL) == 31 ? 1 : -1];
-
-char lzcntu32_0[_lzcnt_u32(0x00000000) == 32 ? 1 : -1];
-char lzcntu32_1[_lzcnt_u32(0x80000000) ==  0 ? 1 : -1];
-char lzcntu32_2[_lzcnt_u32(0x00000010) == 27 ? 1 : -1];
-
-char lzcntu64_0[_lzcnt_u64(0x0000000000000000ULL) == 64 ? 1 : -1];
-char lzcntu64_1[_lzcnt_u64(0x8000000000000000ULL) ==  0 ? 1 : -1];
-char lzcntu64_2[_lzcnt_u64(0x0000000100000000ULL) == 31 ? 1 : -1];
-#endif
+TEST_CONSTEXPR(_lzcnt_u64(0x0000000000000000ULL) == 64);
+TEST_CONSTEXPR(_lzcnt_u64(0x8000000000000000ULL) ==  0);
+TEST_CONSTEXPR(_lzcnt_u64(0x0000000100000000ULL) == 31);

--- a/clang/test/CodeGen/X86/popcnt-builtins.c
+++ b/clang/test/CodeGen/X86/popcnt-builtins.c
@@ -3,24 +3,37 @@
 // RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -no-enable-noundef-analysis -emit-llvm -o - | FileCheck %s
 // RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -no-enable-noundef-analysis -emit-llvm -o - | FileCheck %s
 
+// RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -target-feature +popcnt -no-enable-noundef-analysis -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes=CHECK,CHECK-POPCNT
+// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -target-feature +popcnt -no-enable-noundef-analysis -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes=CHECK,CHECK-POPCNT
+// RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-apple-darwin -no-enable-noundef-analysis -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-apple-darwin -no-enable-noundef-analysis -emit-llvm -o - -fexperimental-new-constant-interpreter | FileCheck %s
+
+
 #include <x86intrin.h>
+#include "builtin_test_helpers.h"
 
 #ifdef __POPCNT__
 int test_mm_popcnt_u32(unsigned int __X) {
   //CHECK-POPCNT: call i32 @llvm.ctpop.i32
   return _mm_popcnt_u32(__X);
 }
+TEST_CONSTEXPR(_mm_popcnt_u32(0x00000000) == 0);
+TEST_CONSTEXPR(_mm_popcnt_u32(0x000000F0) == 4);
 #endif
 
 int test_popcnt32(unsigned int __X) {
   //CHECK: call i32 @llvm.ctpop.i32
   return _popcnt32(__X);
 }
+TEST_CONSTEXPR(_popcnt32(0x00000000) == 0);
+TEST_CONSTEXPR(_popcnt32(0x100000F0) == 5);
 
 int test__popcntd(unsigned int __X) {
   //CHECK: call i32 @llvm.ctpop.i32
   return __popcntd(__X);
 }
+TEST_CONSTEXPR(__popcntd(0x00000000) == 0);
+TEST_CONSTEXPR(__popcntd(0x00F000F0) == 8);
 
 #ifdef __x86_64__
 #ifdef __POPCNT__
@@ -28,42 +41,21 @@ long long test_mm_popcnt_u64(unsigned long long __X) {
   //CHECK-POPCNT: call i64 @llvm.ctpop.i64
   return _mm_popcnt_u64(__X);
 }
+TEST_CONSTEXPR(_mm_popcnt_u64(0x0000000000000000ULL) == 0);
+TEST_CONSTEXPR(_mm_popcnt_u64(0xF000000000000001ULL) == 5);
 #endif
 
 long long test_popcnt64(unsigned long long __X) {
   //CHECK: call i64 @llvm.ctpop.i64
   return _popcnt64(__X);
 }
+TEST_CONSTEXPR(_popcnt64(0x0000000000000000ULL) == 0);
+TEST_CONSTEXPR(_popcnt64(0xF00000F000000001ULL) == 9);
 
 long long test__popcntq(unsigned long long __X) {
   //CHECK: call i64 @llvm.ctpop.i64
   return __popcntq(__X);
 }
-#endif
-
-// Test constexpr handling.
-#if defined(__cplusplus) && (__cplusplus >= 201103L)
-#if defined(__POPCNT__)
-char ctpop32_0[_mm_popcnt_u32(0x00000000) == 0 ? 1 : -1];
-char ctpop32_1[_mm_popcnt_u32(0x000000F0) == 4 ? 1 : -1];
-#endif
-
-char popcnt32_0[_popcnt32(0x00000000) == 0 ? 1 : -1];
-char popcnt32_1[_popcnt32(0x100000F0) == 5 ? 1 : -1];
-
-char popcntd_0[__popcntd(0x00000000) == 0 ? 1 : -1];
-char popcntd_1[__popcntd(0x00F000F0) == 8 ? 1 : -1];
-
-#ifdef __x86_64__
-#if defined(__POPCNT__)
-char ctpop64_0[_mm_popcnt_u64(0x0000000000000000ULL) == 0 ? 1 : -1];
-char ctpop64_1[_mm_popcnt_u64(0xF000000000000001ULL) == 5 ? 1 : -1];
-#endif
-
-char popcnt64_0[_popcnt64(0x0000000000000000ULL) == 0 ? 1 : -1];
-char popcnt64_1[_popcnt64(0xF00000F000000001ULL) == 9 ? 1 : -1];
-
-char popcntq_0[__popcntq(0x0000000000000000ULL) == 0 ? 1 : -1];
-char popcntq_1[__popcntq(0xF000010000300001ULL) == 8 ? 1 : -1];
-#endif
+TEST_CONSTEXPR(__popcntq(0x0000000000000000ULL) == 0);
+TEST_CONSTEXPR(__popcntq(0xF000010000300001ULL) == 8);
 #endif


### PR DESCRIPTION
Update tests to use builtin_test_helpers.h and the TEST_CONSTEXPR helper macro

Partial fix for #155814