### PR TITLE
[RISCV] Eagerly optimize scalar packing for buildvector lowering

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4257,6 +4257,7 @@ static SDValue lowerBuildVectorViaPacking(SDValue Op, SelectionDAG &DAG,
   MVT XLenVT = Subtarget.getXLenVT();
   SDValue Mask = DAG.getConstant(
       APInt::getLowBitsSet(XLenVT.getSizeInBits(), ElemSizeInBits), DL, XLenVT);
+  unsigned ZeroPrefix = XLenVT.getSizeInBits() - ElemSizeInBits;
   auto pack = [&](SDValue A, SDValue B) {
     // Bias the scheduling of the inserted operations to near the
     // definition of the element - this tends to reduce register
@@ -4270,8 +4271,10 @@ static SDValue lowerBuildVectorViaPacking(SDValue Op, SelectionDAG &DAG,
                              ElemDL, XLenVT, A, B),
           0);
 
-    A = DAG.getNode(ISD::AND, SDLoc(A), XLenVT, A, Mask);
-    B = DAG.getNode(ISD::AND, SDLoc(B), XLenVT, B, Mask);
+    if (DAG.computeKnownBits(A).countMinLeadingZeros() < ZeroPrefix)
+      A = DAG.getNode(ISD::AND, SDLoc(A), XLenVT, A, Mask);
+    if (DAG.computeKnownBits(B).countMinLeadingZeros() < ZeroPrefix)
+      B = DAG.getNode(ISD::AND, SDLoc(B), XLenVT, B, Mask);
     SDValue ShtAmt = DAG.getConstant(ElemSizeInBits, ElemDL, XLenVT);
     return DAG.getNode(ISD::OR, ElemDL, XLenVT, A,
                        DAG.getNode(ISD::SHL, ElemDL, XLenVT, B, ShtAmt),

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4272,7 +4272,7 @@ static SDValue lowerBuildVectorViaPacking(SDValue Op, SelectionDAG &DAG,
           0);
 
     // Manually optimize away the ANDs if we can, DAGCombiner will
-    // sometimes end of perturbing codegen if we don't.
+    // sometimes end up perturbing codegen if we don't.
     if (DAG.computeKnownBits(A).countMinLeadingZeros() < ZeroPrefix)
       A = DAG.getNode(ISD::AND, SDLoc(A), XLenVT, A, Mask);
     if (DAG.computeKnownBits(B).countMinLeadingZeros() < ZeroPrefix)

--- a/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/llvm/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -4271,6 +4271,8 @@ static SDValue lowerBuildVectorViaPacking(SDValue Op, SelectionDAG &DAG,
                              ElemDL, XLenVT, A, B),
           0);
 
+    // Manually optimize away the ANDs if we can, DAGCombiner will
+    // sometimes end of perturbing codegen if we don't.
     if (DAG.computeKnownBits(A).countMinLeadingZeros() < ZeroPrefix)
       A = DAG.getNode(ISD::AND, SDLoc(A), XLenVT, A, Mask);
     if (DAG.computeKnownBits(B).countMinLeadingZeros() < ZeroPrefix)

--- a/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-int-buildvec.ll
+++ b/llvm/test/CodeGen/RISCV/rvv/fixed-vectors-int-buildvec.ll
@@ -2629,7 +2629,7 @@ define <16 x i8> @buildvec_v16i8_undef_edges(ptr %p) {
 ; RVA22U64-NEXT:    or a0, a0, a4
 ; RVA22U64-NEXT:    slli a6, a6, 24
 ; RVA22U64-NEXT:    or a1, a1, a2
-; RVA22U64-NEXT:    add.uw a1, a6, a1
+; RVA22U64-NEXT:    or a1, a6, a1
 ; RVA22U64-NEXT:    or a0, a0, a3
 ; RVA22U64-NEXT:    vsetivli zero, 2, e64, m1, ta, ma
 ; RVA22U64-NEXT:    vmv.v.x v8, a1


### PR DESCRIPTION
Instead of relying on DAG to cleanup the redundant ANDs, go ahead actively try to prove them redundant at construction.

I noticed this because SimplifyDemandedBits was dropping the disjoint on the OR, but there's at least one other codegen diff in the tests as well.