### PR TITLE
[analyzer] Clean up bug types in CallAndMessageChecker

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -143,68 +143,49 @@ def BitwiseShiftChecker : Checker<"BitwiseShift">,
   ]>,
   Documentation<HasDocumentation>;
 
-def CallAndMessageModeling : Checker<"CallAndMessageModeling">,
-  HelpText<"Responsible for essential modeling and assumptions after a "
-           "function/method call. For instance, if we can't reason about the "
-           "nullability of the implicit this parameter after a method call, "
-           "this checker conservatively assumes it to be non-null">,
-  Documentation<HasDocumentation>,
-  Hidden;
-
-def CallAndMessageChecker : Checker<"CallAndMessage">,
-  HelpText<"Check for logical errors for function calls and Objective-C "
-           "message expressions (e.g., uninitialized arguments, null function "
-           "pointers)">,
-  CheckerOptions<[
-    CmdLineOption<Boolean,
-                  "FunctionPointer",
-                  "Check whether a called function pointer is null or "
-                  "undefined",
-                  "true",
-                  Released>,
-    CmdLineOption<Boolean,
-                  "ParameterCount",
-                  "Check whether a function was called with the appropriate "
-                  "number of arguments",
-                  "true",
-                  Released>,
-    CmdLineOption<Boolean,
-                  "CXXThisMethodCall",
-                  "Check whether the implicit this parameter is null or "
-                  "undefined upon a method call",
-                  "true",
-                  Released>,
-    CmdLineOption<Boolean,
-                  "CXXDeallocationArg",
-                  "Check whether the argument of operator delete is undefined",
-                  "true",
-                  Released>,
-    CmdLineOption<Boolean,
-                  "ArgInitializedness",
-                  "Check whether any of the pass-by-value parameters is "
-                  "undefined",
-                  "true",
-                  Released>,
-    CmdLineOption<Boolean,
-                  "ArgPointeeInitializedness",
-                  "Check whether the pointee of a pass-by-reference or "
-                  "pass-by-pointer is undefined",
-                  "false",
-                  InAlpha>,
-    CmdLineOption<Boolean,
-                  "NilReceiver",
-                  "Check whether the reciever in the message expression is nil",
-                  "true",
-                  Released>,
-    CmdLineOption<Boolean,
-                  "UndefReceiver",
-                  "Check whether the reciever in the message expression is "
-                  "undefined",
-                  "true",
-                  Released>,
-  ]>,
-  Documentation<HasDocumentation>,
-  Dependencies<[CallAndMessageModeling]>;
+def CallAndMessageChecker
+    : Checker<"CallAndMessage">,
+      HelpText<
+          "Check for logical errors for function calls and Objective-C "
+          "message expressions (e.g., uninitialized arguments, null function "
+          "pointers)">,
+      CheckerOptions<
+          [CmdLineOption<Boolean, "FunctionPointer",
+                         "Check whether a called function pointer is null or "
+                         "undefined",
+                         "true", Released>,
+           CmdLineOption<
+               Boolean, "ParameterCount",
+               "Check whether a function was called with the appropriate "
+               "number of arguments",
+               "true", Released>,
+           CmdLineOption<Boolean, "CXXThisMethodCall",
+                         "Check whether the implicit this parameter is null or "
+                         "undefined upon a method call",
+                         "true", Released>,
+           CmdLineOption<
+               Boolean, "CXXDeallocationArg",
+               "Check whether the argument of operator delete is undefined",
+               "true", Released>,
+           CmdLineOption<Boolean, "ArgInitializedness",
+                         "Check whether any of the pass-by-value parameters is "
+                         "undefined",
+                         "true", Released>,
+           CmdLineOption<Boolean, "ArgPointeeInitializedness",
+                         "Check whether the pointee of a pass-by-reference or "
+                         "pass-by-pointer is undefined",
+                         "false", InAlpha>,
+           CmdLineOption<
+               Boolean, "NilReceiver",
+               "Check whether the reciever in the message expression is nil",
+               "true", Released>,
+           CmdLineOption<
+               Boolean, "UndefReceiver",
+               "Check whether the reciever in the message expression is "
+               "undefined",
+               "true", Released>,
+]>,
+      Documentation<HasDocumentation>;
 
 def FixedAddressDereferenceChecker
     : Checker<"FixedAddressDereference">,

--- a/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
@@ -76,9 +76,6 @@ public:
   };
 
   bool ChecksEnabled[CK_NumCheckKinds] = {false};
-  // The original core.CallAndMessage checker name. This should rather be an
-  // array, as seen in MallocChecker and CStringChecker.
-  CheckerNameRef OriginalName;
 
   void checkPreObjCMessage(const ObjCMethodCall &msg, CheckerContext &C) const;
 
@@ -680,8 +677,6 @@ void CallAndMessageChecker::HandleNilReceiver(CheckerContext &C,
 
 void ento::registerCallAndMessageChecker(CheckerManager &Mgr) {
   CallAndMessageChecker *Chk = Mgr.registerChecker<CallAndMessageChecker>();
-
-  Chk->OriginalName = Mgr.getCurrentCheckerName();
 
 #define QUERY_CHECKER_OPTION(OPTION)                                           \
   Chk->ChecksEnabled[CallAndMessageChecker::CK_##OPTION] =                     \

--- a/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
@@ -112,7 +112,7 @@ private:
                           const BugType &BT,
                           const ParmVarDecl *ParamDecl) const;
 
-  static void emitBadCall(const BugType *BT, CheckerContext &C,
+  static void emitBadCall(const BugType &BT, CheckerContext &C,
                           const Expr *BadE);
   void emitNilReceiverBug(CheckerContext &C, const ObjCMethodCall &msg,
                           ExplodedNode *N) const;
@@ -128,13 +128,13 @@ private:
 };
 } // end anonymous namespace
 
-void CallAndMessageChecker::emitBadCall(const BugType *BT, CheckerContext &C,
+void CallAndMessageChecker::emitBadCall(const BugType &BT, CheckerContext &C,
                                         const Expr *BadE) {
   ExplodedNode *N = C.generateErrorNode();
   if (!N)
     return;
 
-  auto R = std::make_unique<PathSensitiveBugReport>(*BT, BT->getDescription(), N);
+  auto R = std::make_unique<PathSensitiveBugReport>(BT, BT.getDescription(), N);
   if (BadE) {
     R->addRange(BadE->getSourceRange());
     if (BadE->isGLValue())
@@ -362,7 +362,7 @@ ProgramStateRef CallAndMessageChecker::checkFunctionPointerCall(
       C.addSink(State);
       return nullptr;
     }
-    emitBadCall(&CallUndefBug, C, Callee);
+    emitBadCall(CallUndefBug, C, Callee);
     return nullptr;
   }
 
@@ -374,7 +374,7 @@ ProgramStateRef CallAndMessageChecker::checkFunctionPointerCall(
       C.addSink(StNull);
       return nullptr;
     }
-    emitBadCall(&CallNullBug, C, Callee);
+    emitBadCall(CallNullBug, C, Callee);
     return nullptr;
   }
 
@@ -424,7 +424,7 @@ ProgramStateRef CallAndMessageChecker::checkCXXMethodCall(
       C.addSink(State);
       return nullptr;
     }
-    emitBadCall(&CXXCallUndefBug, C, CC->getCXXThisExpr());
+    emitBadCall(CXXCallUndefBug, C, CC->getCXXThisExpr());
     return nullptr;
   }
 
@@ -436,7 +436,7 @@ ProgramStateRef CallAndMessageChecker::checkCXXMethodCall(
       C.addSink(StNull);
       return nullptr;
     }
-    emitBadCall(&CXXCallNullBug, C, CC->getCXXThisExpr());
+    emitBadCall(CXXCallNullBug, C, CC->getCXXThisExpr());
     return nullptr;
   }
 

--- a/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/CallAndMessageChecker.cpp
@@ -54,7 +54,7 @@ public:
   // Like a checker family, CallAndMessageChecker can produce many kinds of
   // warnings which can be separately enabled or disabled. However, for
   // historical reasons these warning kinds are represented by checker options
-  // (and not separate checkcer frontends with their own names) because
+  // (and not separate checker frontends with their own names) because
   // CallAndMessage is among the oldest checkers out there, and can
   // be responsible for the majority of the reports on any given project. This
   // is obviously not ideal, but changing checker name has the consequence of

--- a/clang/test/Analysis/analyzer-enabled-checkers.c
+++ b/clang/test/Analysis/analyzer-enabled-checkers.c
@@ -12,7 +12,6 @@
 // CHECK-NEXT: apiModeling.llvm.CastValue
 // CHECK-NEXT: apiModeling.llvm.ReturnValue
 // CHECK-NEXT: core.BitwiseShift
-// CHECK-NEXT: core.CallAndMessageModeling
 // CHECK-NEXT: core.CallAndMessage
 // CHECK-NEXT: core.DivideZero
 // CHECK-NEXT: core.DynamicTypePropagation

--- a/clang/test/Analysis/std-c-library-functions-arg-enabled-checkers.c
+++ b/clang/test/Analysis/std-c-library-functions-arg-enabled-checkers.c
@@ -20,7 +20,6 @@
 // CHECK-NEXT: apiModeling.llvm.CastValue
 // CHECK-NEXT: apiModeling.llvm.ReturnValue
 // CHECK-NEXT: core.BitwiseShift
-// CHECK-NEXT: core.CallAndMessageModeling
 // CHECK-NEXT: core.CallAndMessage
 // CHECK-NEXT: core.DivideZero
 // CHECK-NEXT: core.DynamicTypePropagation


### PR DESCRIPTION
In CallAndMessageChecker the initialization of bug types was highly obfuscated (even compared to other `mutable std::unique_ptr` hacks). This commit cleans up this situation and removes a totally superfluous hidded 'modeling' sub-checker that did not have any role apart from obstructing the normal initialization of bug types.

(Note that if we need to reintroduce CallAndMessageModeling in the future, we can do it cleanly within the CheckerFamily framework, so we wouldn't need to re-obfuscate the bug type initialization.)

This change is mostly non-functional, the only visible change is the removal of the hidden modeling checker.