### PR TITLE
Mark ExecutionEngine/JITLink and ExecutionEngine/Orc as unsupported on AIX

### DIFF
--- a/llvm/test/ExecutionEngine/JITLink/lit.local.cfg
+++ b/llvm/test/ExecutionEngine/JITLink/lit.local.cfg
@@ -1,0 +1,2 @@
+if "aix" in config.target_triple:
+    config.unsupported = True

--- a/llvm/test/ExecutionEngine/Orc/lit.local.cfg
+++ b/llvm/test/ExecutionEngine/Orc/lit.local.cfg
@@ -1,0 +1,2 @@
+if "aix" in config.target_triple:
+    config.unsupported = True


### PR DESCRIPTION
Create ExecutionEngine/JitLink/lit.local.cfg and
ExecutionEngine/Orc/lit.local.cfg and use them to mark tests as unsupported on AIX.