### PR TITLE
[flang] Support #if defined when no definitions

### DIFF
--- a/flang/lib/Parser/preprocessor.cpp
+++ b/flang/lib/Parser/preprocessor.cpp
@@ -414,7 +414,7 @@ std::optional<TokenSequence> Preprocessor::MacroReplacement(
     const TokenSequence &input, Prescanner &prescanner,
     std::optional<std::size_t> *partialFunctionLikeMacro, bool inIfExpression) {
   // Do quick scan for any use of a defined name.
-  if (definitions_.empty()) {
+  if (!inIfExpression && definitions_.empty()) {
     return std::nullopt;
   }
   std::size_t tokens{input.SizeInTokens()};

--- a/flang/test/Preprocessing/no-pp-if.f90
+++ b/flang/test/Preprocessing/no-pp-if.f90
@@ -1,0 +1,10 @@
+!RUN: %flang -fc1 -fdebug-unparse %s 2>&1 | FileCheck %s
+!CHECK-NOT: ERROR STOP
+!CHECK: CONTINUE
+#if defined UNDEFINED
+error stop
+#endif
+#if !defined UNDEFINED
+continue
+#endif
+end


### PR DESCRIPTION
The "defined" operator isn't working in #if/#elif expressions when there are no defined macros.  Fix.