### PR TITLE
[NVPTX] Remove unsupported 'seq_cst' test

### DIFF
--- a/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.cpp
+++ b/llvm/lib/Target/NVPTX/MCTargetDesc/NVPTXInstPrinter.cpp
@@ -290,7 +290,8 @@ void NVPTXInstPrinter::printAtomicCode(const MCInst *MI, int OpNum,
       O << ".acq_rel";
       return;
     case NVPTX::Ordering::SequentiallyConsistent:
-      O << ".seq_cst";
+      report_fatal_error(
+          "NVPTX AtomicCode Printer does not support \"seq_cst\" ordering.");
       return;
     case NVPTX::Ordering::Volatile:
       O << ".volatile";

--- a/llvm/test/CodeGen/NVPTX/atomics-b128.ll
+++ b/llvm/test/CodeGen/NVPTX/atomics-b128.ll
@@ -1024,10 +1024,10 @@ define void @test_atomicrmw_xchg_const() {
 ; CHECK-NEXT:    {
 ; CHECK-NEXT:    .reg .b128 amt, dst;
 ; CHECK-NEXT:    mov.b128 amt, {%rd2, %rd1};
-; CHECK-NEXT:    atom.seq_cst.sys.shared.exch.b128 dst, [si128], amt;
+; CHECK-NEXT:    atom.relaxed.sys.shared.exch.b128 dst, [si128], amt;
 ; CHECK-NEXT:    mov.b128 {%rd3, %rd4}, dst;
 ; CHECK-NEXT:    }
 ; CHECK-NEXT:    ret;
-	%res = atomicrmw xchg ptr addrspace(3) @si128, i128 23 seq_cst
+  %res = atomicrmw xchg ptr addrspace(3) @si128, i128 23 monotonic
   ret void
 }


### PR DESCRIPTION
The NVPTX backend does not currently support correctly lowering `atomicrmw` with `seq_cst` of any size. Remove a test which erroneously hit this case and add logic to appropriately error out when this ordering is encountered, instead of emitting invalid PTX.  

In the long term, we should use `fence.sc`, similar to other atomic operations, to support this ordering.