### PR TITLE
[HLSL][NFC] Add assert to verify implicit binding resource attribute exists

### DIFF
--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -180,6 +180,7 @@ static void createResourceCtorArgs(CodeGenModule &CGM, CXXConstructorDecl *CD,
 
   } else {
     // implicit binding
+    assert(RBA && "missing implicit binding attribute");
     auto *OrderID =
         llvm::ConstantInt::get(CGM.IntTy, RBA->getImplicitBindingOrderID());
     Args.add(RValue::get(Space), AST.UnsignedIntTy);


### PR DESCRIPTION
Adds assert as requested in https://github.com/llvm/llvm-project/pull/152454#discussion_r2304509802.