### PR TITLE
[flang-rt] Enable lit internal shell by default

### DIFF
--- a/flang-rt/test/lit.cfg.py
+++ b/flang-rt/test/lit.cfg.py
@@ -16,11 +16,21 @@ def shjoin(args, sep=" "):
 # name: The name of this test suite.
 config.name = "flang-rt"
 
+# TODO: Consolidate the logic for turning on the internal shell by default for all LLVM test suites.
+# See https://github.com/llvm/llvm-project/issues/106636 for more details.
+#
+# We prefer the lit internal shell which provides a better user experience on failures
+# unless the user explicitly disables it with LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
 # testFormat: The test format to use to interpret tests.
 #
 # For now we require '&&' between commands, until they get globally killed and
 # the test runner updated.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [


### PR DESCRIPTION
This patch enables the lit internal shell by default for testing flang-rt. The lit internal shell is able to run tests a bit faster as it avoids having to fork bash for every run line and also produces nicer debug information on failures.

This is part of #102704.