### PR TITLE
[lldb] Stop the protocol servers when terminating the plugin

### DIFF
--- a/lldb/include/lldb/Core/ProtocolServer.h
+++ b/lldb/include/lldb/Core/ProtocolServer.h
@@ -22,6 +22,8 @@ public:
 
   static ProtocolServer *GetOrCreate(llvm::StringRef name);
 
+  static llvm::Error Terminate();
+
   static std::vector<llvm::StringRef> GetSupportedProtocols();
 
   struct Connection {

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -39,6 +39,8 @@ void ProtocolServerMCP::Initialize() {
 }
 
 void ProtocolServerMCP::Terminate() {
+  if (llvm::Error error = ProtocolServer::Terminate())
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Host), std::move(error), "{0}");
   PluginManager::UnregisterPlugin(CreateInstance);
 }
 


### PR DESCRIPTION
Currently, the server keeps running until we call Stop from its dtor in the static destruction chain. This is too late: the server should stop when the plugin gets terminated.