### PR TITLE
Fix debuginfod build failure when httplib is used.

### DIFF
--- a/llvm/include/llvm/Debuginfod/HTTPServer.h
+++ b/llvm/include/llvm/Debuginfod/HTTPServer.h
@@ -104,6 +104,7 @@ class HTTPServer {
 public:
   HTTPServer();
   ~HTTPServer();
+  HTTPServer(HTTPServer &&);
 
   /// Returns true only if LLVM has been compiled with a working HTTPServer.
   static bool isAvailable();

--- a/llvm/lib/Debuginfod/HTTPServer.cpp
+++ b/llvm/lib/Debuginfod/HTTPServer.cpp
@@ -62,6 +62,8 @@ bool llvm::streamFile(HTTPServerRequest &Request, StringRef FilePath) {
   return true;
 }
 
+HTTPServer::HTTPServer(HTTPServer &&) = default;
+
 #ifdef LLVM_ENABLE_HTTPLIB
 
 bool HTTPServer::isAvailable() { return true; }


### PR DESCRIPTION
This is a follow up of adbd43250ade1d5357542d8bd7c3dfed212ddec0. The problem is HTTPServer class will lost its implicit move ctor if httplib is used. This patch adds the move ctor explicitly to solve this issue. The default move ctor is not added in the header due to a limitation that "httplib::Server" is a forward declaration and it is incomplete.