### PR TITLE
[clang] `__builtin_expect_with_probability` accepts value depenent parameter

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -260,6 +260,7 @@ Bug Fixes in This Version
   cast chain. (#GH149967).
 - Fixed a crash with incompatible pointer to integer conversions in designated
   initializers involving string literals. (#GH154046)
+- ``__builtin_expect_with_probability`` now works with a value dependent parameter. (GH153082).
 - Clang now emits a frontend error when a function marked with the `flatten` attribute
   calls another function that requires target features not enabled in the caller. This
   prevents a fatal error in the backend.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2855,6 +2855,9 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     SmallVector<PartialDiagnosticAt, 8> Notes;
     Expr::EvalResult Eval;
     Eval.Diag = &Notes;
+    if (ProbArg->isValueDependent() || ProbArg->isTypeDependent())
+      break;
+
     if ((!ProbArg->EvaluateAsConstantExpr(Eval, Context)) ||
         !Eval.Val.isFloat()) {
       Diag(ProbArg->getBeginLoc(), diag::err_probability_not_constant_float)

--- a/clang/test/Sema/builtin-expect-with-probability.cpp
+++ b/clang/test/Sema/builtin-expect-with-probability.cpp
@@ -57,3 +57,19 @@ void test(int x, double p) { // expected-note {{declared here}}
   dummy = __builtin_expect_with_probability(x > 0, 1, pi);
   expect_taken<S>(x);
 }
+
+namespace gh153082{
+    template <typename T> void f() {
+        (void) __builtin_expect_with_probability(0, 0, ({ 0; }));
+    }
+
+    template <typename T> void more_test_case(long a) {
+        (void)__builtin_expect_with_probability(a, 0, sizeof(T)/3.9);   // expected-error {{probability argument to __builtin_expect_with_probability is outside the range [0.0, 1.0]}} \
+                                                                        // expected-error {{probability argument}}
+    }
+
+    template void more_test_case<short>(long);
+    template void more_test_case<char>(long);
+    template void more_test_case<int>(long); // expected-note {{in instantiation of function template specialization 'gh153082::more_test_case<int>' requested here}}
+    template void more_test_case<long long>(long); // expected-note {{instantiation of function template specialization 'gh153082::more_test_case<long long>' requested here}}
+};


### PR DESCRIPTION
Defer the `CheckBuiltinFunctionCall` to template instantiation.

fixes #153082