### PR TITLE
[Flang] Make all tests work with lit's internal shell

### DIFF
--- a/flang/docs/FlangDriver.md
+++ b/flang/docs/FlangDriver.md
@@ -360,10 +360,8 @@ be exactly what you want to test.  In fact, you can check these additional
 flags by using the `-###` compiler driver command line option.
 
 Lastly, you can use `! REQUIRES: <feature>` for tests that will only work when
-`<feature>` is available. For example, you can use`! REQUIRES: shell` to mark a
-test as only available on Unix-like systems (i.e. systems that contain a Unix
-shell). In practice this means that the corresponding test is skipped on
-Windows.
+`<feature>` is available. For example, you can use`! REQUIRES: system-linux` to
+mark a test as only available on Linux systems.
 
 ## Frontend Driver Plugins
 Plugins are an extension to the frontend driver that make it possible to run

--- a/flang/test/Driver/color-diagnostics-parse.f90
+++ b/flang/test/Driver/color-diagnostics-parse.f90
@@ -1,7 +1,7 @@
 ! Test the behaviors of -f{no-}color-diagnostics and -f{no-}diagnostics-color
 ! when emitting parsing diagnostics.
 ! Windows command prompt doesn't support ANSI escape sequences.
-! REQUIRES: shell
+! REQUIRES: system-linux
 
 ! RUN: not %flang %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD

--- a/flang/test/Driver/color-diagnostics-scan.f
+++ b/flang/test/Driver/color-diagnostics-scan.f
@@ -1,7 +1,7 @@
 ! Test the behaviors of -f{no-}color-diagnostics and -f{no}-diagnostic-colors
 ! when emitting scanning diagnostics.
 ! Windows command prompt doesn't support ANSI escape sequences.
-! REQUIRES: shell
+! REQUIRES: system-linux
 
 ! RUN: not %flang %s -E -Werror -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD

--- a/flang/test/Driver/color-diagnostics-sema.f90
+++ b/flang/test/Driver/color-diagnostics-sema.f90
@@ -1,7 +1,7 @@
 ! Test the behaviors of -f{no-}color-diagnostics and -f{no}diagnostics-color
 ! when emitting semantic diagnostics.
 ! Windows command prompt doesn't support ANSI escape sequences.
-! REQUIRES: shell
+! REQUIRES: system-linux
 
 ! RUN: not %flang %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD

--- a/flang/test/Driver/color-diagnostics.f90
+++ b/flang/test/Driver/color-diagnostics.f90
@@ -1,6 +1,6 @@
 ! Test the behaviors of -f{no-}color-diagnostics and -f{no}-diagnostics-color.
 ! Windows command prompt doesn't support ANSI escape sequences.
-! REQUIRES: shell
+! REQUIRES: system-linux
 
 ! RUN: not %flang %s -fcolor-diagnostics 2>&1 \
 ! RUN:     | FileCheck %s --check-prefix=CHECK_CD

--- a/flang/test/Lower/Intrinsics/selected_int_kind.f90
+++ b/flang/test/Lower/Intrinsics/selected_int_kind.f90
@@ -1,4 +1,3 @@
-! REQUIRES: shell
 ! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPselected_int_kind_test1(

--- a/flang/test/Lower/Intrinsics/selected_real_kind.f90
+++ b/flang/test/Lower/Intrinsics/selected_real_kind.f90
@@ -1,4 +1,3 @@
-! REQUIRES: shell
 ! RUN: bbc -emit-fir -hlfir=false %s -o - | FileCheck %s
 
 ! CHECK-LABEL: func.func @_QPselected_real_kind_test1(

--- a/flang/test/Lower/OpenMP/parallel-firstprivate-clause-scalar.f90
+++ b/flang/test/Lower/OpenMP/parallel-firstprivate-clause-scalar.f90
@@ -1,7 +1,6 @@
 ! This test checks lowering of `FIRSTPRIVATE` clause for scalar types.
 
 ! REQUIRES: x86-registered-target
-! REQUIRES: shell
 ! RUN: bbc -target x86_64-unknown-linux-gnu -fopenmp -emit-hlfir %s -o - \
 ! RUN: | FileCheck %s --check-prefixes=CHECK%if target=x86_64{{.*}} %{,CHECK-KIND10%}%if flang-supports-f128-math %{,CHECK-KIND16%}
 

--- a/flang/test/Lower/OpenMP/parallel-private-clause-str.f90
+++ b/flang/test/Lower/OpenMP/parallel-private-clause-str.f90
@@ -1,7 +1,6 @@
 ! This test checks lowering of OpenMP parallel Directive with
 ! `PRIVATE` clause present for strings
 
-! REQUIRES: shell
 ! RUN: bbc -fopenmp -emit-hlfir %s -o - \
 ! RUN: | FileCheck %s
 

--- a/flang/test/Lower/OpenMP/parallel-private-clause.f90
+++ b/flang/test/Lower/OpenMP/parallel-private-clause.f90
@@ -1,7 +1,6 @@
 ! This test checks lowering of OpenMP parallel Directive with
 ! `PRIVATE` clause present.
 
-! REQUIRES: shell
 ! RUN: bbc --use-desc-for-alloc=false -fopenmp -emit-hlfir %s -o - \
 ! RUN: | FileCheck %s --check-prefix=FIRDialect
 

--- a/flang/test/Lower/OpenMP/threadprivate-integer-different-kinds.f90
+++ b/flang/test/Lower/OpenMP/threadprivate-integer-different-kinds.f90
@@ -1,7 +1,6 @@
 ! This test checks lowering of OpenMP Threadprivate Directive.
 ! Test for variables with different kind.
 
-!REQUIRES: shell
 !RUN: %flang_fc1 -emit-hlfir -fopenmp %s -o - | FileCheck %s
 
 program test

--- a/flang/test/Lower/OpenMP/wsloop-variable.f90
+++ b/flang/test/Lower/OpenMP/wsloop-variable.f90
@@ -1,7 +1,6 @@
 ! This test checks lowering of OpenMP DO Directive(Worksharing) for different
 ! types of loop iteration variable, lower bound, upper bound, and step.
 
-!REQUIRES: shell
 !RUN: bbc -fopenmp -emit-hlfir %s -o - 2>&1 | FileCheck %s
 
 !CHECK:  OpenMP loop iteration variable cannot have more than 64 bits size and will be narrowed into 64 bits.

--- a/flang/test/Semantics/OpenMP/do07.f90
+++ b/flang/test/Semantics/OpenMP/do07.f90
@@ -1,5 +1,4 @@
 ! RUN: not %flang -fsyntax-only -fopenmp %s 2>&1 | FileCheck %s
-! REQUIRES: shell
 ! OpenMP Version 4.5
 ! 2.7.1 Loop Construct
 ! No statement in the associated loops other than the DO statements

--- a/flang/test/Semantics/OpenMP/invalid-branch.f90
+++ b/flang/test/Semantics/OpenMP/invalid-branch.f90
@@ -1,5 +1,4 @@
 ! RUN: not %flang -fsyntax-only -fopenmp %s 2>&1 | FileCheck %s
-! REQUIRES: shell
 ! OpenMP Version 4.5
 ! Check invalid branches into or out of OpenMP structured blocks.
 

--- a/flang/test/Semantics/OpenMP/nontemporal.f90
+++ b/flang/test/Semantics/OpenMP/nontemporal.f90
@@ -1,5 +1,4 @@
 ! RUN: %python %S/../test_errors.py %s  %flang -fopenmp -fopenmp-version=50
-! REQUIRES: shell
 ! Check OpenMP clause validity for NONTEMPORAL clause
 
 program omp_simd

--- a/flang/test/Semantics/missing_newline.f90
+++ b/flang/test/Semantics/missing_newline.f90
@@ -1,5 +1,4 @@
 ! RUN: echo -n "end program" > %t.f90
 ! RUN: %flang_fc1 -fsyntax-only %t.f90
-! RUN: echo -ne "\rend program" > %t.f90
+! RUN: echo -n -e "\rend program" > %t.f90
 ! RUN: %flang_fc1 -fsyntax-only %t.f90
-! REQUIRES: shell


### PR DESCRIPTION
This patch removes REQUIRES: shell lines and updates the tests to not
need a shell, or adds REQUIRES lines for Linux where relevant. A lot of
these seem to have gotten introduced in
58c3f20bbf51f454ffb38ddb700a1d5ad374dc7b, but many are no longer
relevant as these tests no longer use shell scripts.

There was one test (missing_newline.f90) that needed to be modified to
work. Lit doesn't recognize -ne correctly for echo and the options need
to be split into separate flags.
