### PR TITLE
[lldb] Refactor variable annotation logic in Disassembler::PrintInstructions

### DIFF
--- a/lldb/include/lldb/Core/Disassembler.h
+++ b/lldb/include/lldb/Core/Disassembler.h
@@ -566,6 +566,26 @@ private:
   const Disassembler &operator=(const Disassembler &) = delete;
 };
 
+/// Tracks live variable annotations across instructions and produces
+/// per-instruction "events" like `name = RDI` or `name = <undef>`.
+class VariableAnnotator {
+  struct VarState {
+    /// Display name.
+    std::string name;
+    /// Last printed location (empty means <undef>).
+    std::string last_loc;
+  };
+
+  // Live state from the previous instruction, keyed by Variable::GetID().
+  llvm::DenseMap<lldb::user_id_t, VarState> Live_;
+
+public:
+  /// Compute annotation strings for a single instruction and update `Live_`.
+  /// Returns only the events that should be printed *at this instruction*.
+  std::vector<std::string> annotate(Instruction &inst, Target &target,
+                                    const lldb::ModuleSP &module_sp);
+};
+
 } // namespace lldb_private
 
 #endif // LLDB_CORE_DISASSEMBLER_H


### PR DESCRIPTION
This patch is a follow-up to [#152887](https://github.com/llvm/llvm-project/pull/152887), addressing review comments that came in after the original change was merged.

- Move `VarState` definition out of `PrintInstructions` into a private helper, with member comments placed before fields.
- Introduce a `VariableAnnotator` helper class to encapsulate state and logic for live variable tracking across instructions.
- Replace `seen_this_inst` flag with a map-diff approach: recompute the current variable set per instruction and diff against the previous set.
- Use `nullptr` instead of an empty `ProcessSP` when calling `ABI::FindPlugin`.
- Narrow `Block*` scope with `if (Block *B = ...)`.
- Set `DIDumpOptions::PrintRegisterOnly` directly from `static_cast<bool>(abi_sp)`.
- Prefer `emplace_back` over `push_back` for event strings.
- General cleanup to match LLVM coding style and reviewer feedback.

This makes the annotation code easier to read and consistent with LLVM/LLDB conventions while preserving functionality.