### PR TITLE
[clang] fix obtaining EnumDecl for UsingEnumDecl

### DIFF
--- a/clang/include/clang/AST/DeclCXX.h
+++ b/clang/include/clang/AST/DeclCXX.h
@@ -3826,7 +3826,7 @@ public:
 
 public:
   EnumDecl *getEnumDecl() const {
-    return cast<clang::EnumType>(EnumType->getType())->getOriginalDecl();
+    return EnumType->getType()->castAs<clang::EnumType>()->getOriginalDecl();
   }
 
   static UsingEnumDecl *Create(ASTContext &C, DeclContext *DC,

--- a/clang/test/SemaTemplate/using-decl.cpp
+++ b/clang/test/SemaTemplate/using-decl.cpp
@@ -14,3 +14,15 @@ namespace UsingInGenericLambda {
   }
   void e() { c<int>(); }
 }
+
+namespace UsingUsingEnum {
+  namespace foo {
+    enum class EnumOne {};
+  }
+  using foo::EnumOne;
+
+  template <class> void t() {
+    using enum EnumOne;
+  }
+  template void t<void>();
+} // namespace UsingUsingEnum


### PR DESCRIPTION
Use the castAs acessor for the type for a UsingEnumDecl, as it can be sugar for an EnumType.

Fixes a regression reported here: https://github.com/llvm/llvm-project/pull/155313#issuecomment-3238482327

Since this regression was never released, there are no release notes.