### PR TITLE
[mlir] EnumAttr.td: Fix the width of I64Enum

### DIFF
--- a/mlir/include/mlir/IR/EnumAttr.td
+++ b/mlir/include/mlir/IR/EnumAttr.td
@@ -289,7 +289,7 @@ class IntEnum<string name, string summary, list<EnumCase> cases, int width>
 class I32Enum<string name, string summary, list<EnumCase> cases>
     : IntEnum<name, summary, cases, 32>;
 class I64Enum<string name, string summary, list<EnumCase> cases>
-    : IntEnum<name, summary, cases, 32>;
+    : IntEnum<name, summary, cases, 64>;
 
 // An enum attribute backed by IntegerAttr.
 //

--- a/mlir/test/lib/Dialect/Test/TestEnumDefs.td
+++ b/mlir/test/lib/Dialect/Test/TestEnumDefs.td
@@ -27,9 +27,10 @@ def SomeI32Enum : I32EnumAttr<"SomeI32Enum", "",
 
 def I64Case5:  I64EnumAttrCase<"case5", 5>;
 def I64Case10: I64EnumAttrCase<"case10", 10>;
+def I64Case1p32 : I64EnumAttrCase<"caseLarse", 4294967296>;
 
 def SomeI64Enum: I64EnumAttr<
-  "SomeI64Enum", "", [I64Case5, I64Case10]>;
+  "SomeI64Enum", "", [I64Case5, I64Case10, I64Case1p32]>;
 
 //===----------------------------------------------------------------------===//
 // Test Enum
@@ -49,6 +50,13 @@ def TestEnum
 def TestSimpleEnum : I32Enum<"SimpleEnum", "", [
     I32EnumCase<"a", 0>,
     I32EnumCase<"b", 1>
+  ]> {
+  let cppNamespace = "::test";
+}
+
+def TestSimpleEnum64 : I64Enum<"SimpleEnum64", "", [
+    I64EnumCase<"a", 4294967296>,
+    I64EnumCase<"b", 4294967297>
   ]> {
   let cppNamespace = "::test";
 }


### PR DESCRIPTION
Follow-up to #132148
