### PR TITLE
[PowerPC][llvm][test] fix llvm-64-bits for powerpc64

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -385,7 +385,7 @@ for arch in config.targets_to_build.split():
     config.available_features.add(arch.lower() + "-registered-target")
 
 # Features
-known_arches = ["x86_64", "mips64", "ppc64", "aarch64"]
+known_arches = ["x86_64", "mips64", "powerpc64", "aarch64"]
 if config.host_ldflags.find("-m32") < 0 and any(
     config.llvm_host_triple.startswith(x) for x in known_arches
 ):


### PR DESCRIPTION
This feature flag checks a list of known 64-bit arches, but erroneously names `ppc64` instead of `powerpc64`. This means that targets like `powerpc64le-unknown-linux-gnu` were not running the intended tests.