### PR TITLE
[ADT] Remove a meaningless std::move (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/StringMap.h
+++ b/llvm/include/llvm/ADT/StringMap.h
@@ -264,7 +264,7 @@ public:
   /// at - Return the entry for the specified key, or abort if no such
   /// entry exists.
   const ValueTy &at(StringRef Val) const {
-    auto Iter = this->find(std::move(Val));
+    auto Iter = this->find(Val);
     assert(Iter != this->end() && "StringMap::at failed due to a missing key");
     return Iter->second;
   }


### PR DESCRIPTION
std::move on StringRef is not useful because it's copied anyway.
