### PR TITLE
Revert "[msan] Detect dereferencing zero-alloc as use-of-uninitialized-value"

### DIFF
--- a/compiler-rt/lib/msan/msan_allocator.cpp
+++ b/compiler-rt/lib/msan/msan_allocator.cpp
@@ -230,12 +230,6 @@ static void *MsanAllocate(BufferedStackTrace *stack, uptr size, uptr alignment,
       __msan_set_origin(allocated, size, o.raw_id());
     }
   }
-
-  uptr actually_allocated_size = allocator.GetActuallyAllocatedSize(allocated);
-  // For compatibility, the allocator converted 0-sized allocations into 1 byte
-  if (size == 0 && actually_allocated_size > 0 && flags()->poison_in_malloc)
-    __msan_poison(allocated, 1);
-
   UnpoisonParam(2);
   RunMallocHooks(allocated, size);
   return allocated;

--- a/compiler-rt/test/msan/zero_alloc.cpp
+++ b/compiler-rt/test/msan/zero_alloc.cpp
@@ -1,5 +1,9 @@
 // RUN: %clang_msan -Wno-alloc-size -fsanitize-recover=memory %s -o %t && not %run %t 2>&1 | FileCheck %s
 
+// MSan doesn't catch this because internally it translates 0-byte allocations
+// into 1-byte
+// XFAIL: *
+
 #include <malloc.h>
 #include <stdio.h>
 


### PR DESCRIPTION
Reverts llvm/llvm-project#155944

Per post-commit discussion in https://github.com/llvm/llvm-project/pull/155944#discussion_r2311822441, this is detecting OOB access, which is not in scope for MSan. To be logically consistent with how MSan does not try to handle OOB in other cases, this patch reverts the MSan change. Dereferencing zero-alloc can be detected with ASan instead (as of https://github.com/llvm/llvm-project/pull/155943).
