### PR TITLE
[clang-tidy][NFC] Enable 'readability-redundant-declaration' check in clang-tidy config

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -32,7 +32,6 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
-  -readability-redundant-declaration,
   -readability-simplify-boolean-expr,
   -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument,

--- a/clang-tools-extra/clang-tidy/readability/UppercaseLiteralSuffixCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UppercaseLiteralSuffixCheck.cpp
@@ -30,9 +30,6 @@ struct IntegerLiteralCheck {
   static constexpr llvm::StringLiteral Suffixes =
       llvm::StringLiteral("uUlLiIjJ");
 };
-constexpr llvm::StringLiteral IntegerLiteralCheck::Name;
-constexpr llvm::StringLiteral IntegerLiteralCheck::SkipFirst;
-constexpr llvm::StringLiteral IntegerLiteralCheck::Suffixes;
 
 struct FloatingLiteralCheck {
   using type = clang::FloatingLiteral;
@@ -50,9 +47,6 @@ struct FloatingLiteralCheck {
   static constexpr llvm::StringLiteral Suffixes =
       llvm::StringLiteral("fFlLhHqQiIjJ");
 };
-constexpr llvm::StringLiteral FloatingLiteralCheck::Name;
-constexpr llvm::StringLiteral FloatingLiteralCheck::SkipFirst;
-constexpr llvm::StringLiteral FloatingLiteralCheck::Suffixes;
 
 struct NewSuffix {
   SourceRange LiteralLocation;


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/156163