### PR TITLE
[clang][bytecode] Fix ignoring comparisons in C

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -942,7 +942,7 @@ bool Compiler<Emitter>::VisitBinaryOperator(const BinaryOperator *BO) {
     if (!Result)
       return false;
     if (DiscardResult)
-      return this->emitPop(*T, BO);
+      return this->emitPopBool(BO);
     if (T != PT_Bool)
       return this->emitCast(PT_Bool, *T, BO);
     return true;

--- a/clang/test/AST/ByteCode/c.c
+++ b/clang/test/AST/ByteCode/c.c
@@ -362,3 +362,9 @@ void bar() { // pedantic-warning {{a function declaration without a prototype}}
   int x;
   x = foo(); // all-warning {{too few arguments}}
 }
+
+int *_b = &a;
+void discardedCmp(void)
+{
+    (*_b) = ((&a == &a) , a); // all-warning {{left operand of comma operator has no effect}}
+}


### PR DESCRIPTION
Our comparison ops always return bool, and we do the pop before the conversion to in in C.

Fixes #156178