### PR TITLE
[MLIR][BUG] fix {$VARIABLE} usage in CMakeLists.txt

### DIFF
--- a/mlir/lib/Dialect/AMDGPU/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/AMDGPU/Transforms/CMakeLists.txt
@@ -5,7 +5,7 @@ add_mlir_dialect_library(MLIRAMDGPUTransforms
   ResolveStridedMetadata.cpp
 
   ADDITIONAL_HEADER_DIRS
-  {$MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/AMDGPU/Transforms
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/AMDGPU/Transforms
 
   DEPENDS
   MLIRAMDGPUTransformsIncGen

--- a/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Arith/Transforms/CMakeLists.txt
@@ -12,7 +12,7 @@ add_mlir_dialect_library(MLIRArithTransforms
   UnsignedWhenEquivalent.cpp
 
   ADDITIONAL_HEADER_DIRS
-  {$MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Arith/Transforms
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Arith/Transforms
 
   DEPENDS
   MLIRArithTransformsIncGen

--- a/mlir/lib/Dialect/ControlFlow/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/ControlFlow/Transforms/CMakeLists.txt
@@ -3,7 +3,7 @@ add_mlir_dialect_library(MLIRControlFlowTransforms
   BufferizableOpInterfaceImpl.cpp
 
   ADDITIONAL_HEADER_DIRS
-  {$MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/ControlFlow/Transforms
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/ControlFlow/Transforms
 
   LINK_LIBS PUBLIC
   MLIRBufferizationDialect

--- a/mlir/lib/Dialect/Quant/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Quant/Transforms/CMakeLists.txt
@@ -4,7 +4,7 @@ add_mlir_dialect_library(MLIRQuantTransforms
   StripFuncQuantTypes.cpp
 
   ADDITIONAL_HEADER_DIRS
-  {$MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Quant/Transforms
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Quant/Transforms
 
   DEPENDS
   MLIRQuantTransformsIncGen


### PR DESCRIPTION
This pr fixed #156182 