### PR TITLE
[openmp] Fix missing include directory in omptest tool

### DIFF
--- a/openmp/tools/omptest/CMakeLists.txt
+++ b/openmp/tools/omptest/CMakeLists.txt
@@ -22,6 +22,8 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
+include_directories(${LIBOMP_INCLUDE_DIR})
+
 set(OMPTEST_HEADERS
   ./include/AssertMacros.h
   ./include/InternalEvent.h


### PR DESCRIPTION
Add missing `LIBOMP_INCLUDE_DIR` include directory to fix build failures in omptest, as reported
in https://github.com/llvm/llvm-project/pull/154786#issuecomment-3223481804. Thanks fo @jprotze for the suggested fix.