### PR TITLE
[ADT] Remove Mask in PointerEmbedded

### DIFF
--- a/llvm/include/llvm/ADT/PointerEmbeddedInt.h
+++ b/llvm/include/llvm/ADT/PointerEmbeddedInt.h
@@ -42,9 +42,6 @@ class PointerEmbeddedInt {
     // We shift as many zeros into the value as we can while preserving the
     // number of bits desired for the integer.
     Shift = sizeof(uintptr_t) * CHAR_BIT - Bits,
-
-    // We also want to be able to mask out the preserved bits for asserts.
-    Mask = static_cast<uintptr_t>(-1) << Bits
   };
 
   struct RawValueTag {


### PR DESCRIPTION
Mask, a private enum, isn't used anywhere in the class.
