### PR TITLE
[asan] Rewrite Windows/heaprealloc_alloc_zero check to avoid dereference

### DIFF
--- a/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
@@ -3,13 +3,19 @@
 // UNSUPPORTED: asan-64-bits
 #include <cassert>
 #include <iostream>
+#include <sanitizer/allocator_interface.h>
 #include <windows.h>
 
 int main() {
   void *ptr = malloc(0);
   if (ptr)
     std::cerr << "allocated!\n";
-  ((char *)ptr)[0] = '\xff'; //check this 'allocate 1 instead of 0' hack hasn't changed
+
+  // Check the 'allocate 1 instead of 0' hack hasn't changed
+  // Note that as of b3452d90b043a398639e62b0ab01aa339cc649de, dereferencing
+  // the pointer will be detected as a heap-buffer-overflow.
+  if (__sanitizer_get_allocated_size(ptr) != 1)
+    return 1;
 
   free(ptr);
 

--- a/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
+++ b/compiler-rt/test/asan/TestCases/Windows/heaprealloc_alloc_zero.cpp
@@ -1,6 +1,5 @@
 // RUN: %clang_cl_asan %Od %MT -o %t %s
 // RUN: %env_asan_opts=windows_hook_rtl_allocators=true %run %t 2>&1 | FileCheck %s
-// UNSUPPORTED: asan-64-bits
 #include <cassert>
 #include <iostream>
 #include <sanitizer/allocator_interface.h>


### PR DESCRIPTION
The test currently checks that 1-byte is allocated when malloc(0) is called, by dereferencing the pointer.
https://github.com/llvm/llvm-project/pull/155943 changed ASan to consider the dereference to be a heap buffer overflow. This patch changes the test to check the allocated size is still 1-byte, but not dereference the pointer.

This aims to fix the breakage reported in https://github.com/llvm/llvm-project/pull/155943#issuecomment-3239543505

It also enables the test for 64-bit Windows.