### PR TITLE
[CodeGen] Drop disjoint flag when reassociating

### DIFF
--- a/llvm/lib/CodeGen/TargetInstrInfo.cpp
+++ b/llvm/lib/CodeGen/TargetInstrInfo.cpp
@@ -1456,11 +1456,13 @@ void TargetInstrInfo::reassociateOps(
   MIB1->clearFlag(MachineInstr::MIFlag::NoSWrap);
   MIB1->clearFlag(MachineInstr::MIFlag::NoUWrap);
   MIB1->clearFlag(MachineInstr::MIFlag::IsExact);
+  MIB1->clearFlag(MachineInstr::MIFlag::Disjoint);
 
   MIB2->setFlags(IntersectedFlags);
   MIB2->clearFlag(MachineInstr::MIFlag::NoSWrap);
   MIB2->clearFlag(MachineInstr::MIFlag::NoUWrap);
   MIB2->clearFlag(MachineInstr::MIFlag::IsExact);
+  MIB2->clearFlag(MachineInstr::MIFlag::Disjoint);
 
   setSpecialOperandAttr(Root, Prev, *MIB1, *MIB2);
 

--- a/llvm/test/CodeGen/RISCV/machine-combiner-mir.ll
+++ b/llvm/test/CodeGen/RISCV/machine-combiner-mir.ll
@@ -116,8 +116,8 @@ define i64 @test_or_flags(i64 %a0, i64 %a1, i64 %a2, i64 %a3) {
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:gpr = COPY $x11
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:gpr = COPY $x10
   ; CHECK-NEXT:   [[OR:%[0-9]+]]:gpr = OR [[COPY3]], [[COPY2]]
-  ; CHECK-NEXT:   [[OR1:%[0-9]+]]:gpr = disjoint OR [[COPY1]], [[COPY]]
-  ; CHECK-NEXT:   [[OR2:%[0-9]+]]:gpr = disjoint OR killed [[OR]], killed [[OR1]]
+  ; CHECK-NEXT:   [[OR1:%[0-9]+]]:gpr = OR [[COPY1]], [[COPY]]
+  ; CHECK-NEXT:   [[OR2:%[0-9]+]]:gpr = OR killed [[OR]], killed [[OR1]]
   ; CHECK-NEXT:   $x10 = COPY [[OR2]]
   ; CHECK-NEXT:   PseudoRET implicit $x10
   %t0 = or i64 %a0, %a1


### PR DESCRIPTION
This fixes a latent miscompile.  To understand why the flag can't be preserved, consider the case where a0=0, a1=0, a2=-1, and s3=-1.