### PR TITLE
[mlir][emitc] Do not convert illegal types to emitc

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitCPass.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitCPass.cpp
@@ -42,7 +42,12 @@ void ConvertArithToEmitC::runOnOperation() {
   RewritePatternSet patterns(&getContext());
 
   TypeConverter typeConverter;
-  typeConverter.addConversion([](Type type) { return type; });
+  // Fallback for other types.
+  typeConverter.addConversion([](Type type) -> std::optional<Type> {
+    if (!emitc::isSupportedEmitCType(type))
+      return {};
+    return type;
+  });
 
   populateArithToEmitCPatterns(typeConverter, patterns);
 

--- a/mlir/lib/Conversion/FuncToEmitC/FuncToEmitCPass.cpp
+++ b/mlir/lib/Conversion/FuncToEmitC/FuncToEmitCPass.cpp
@@ -41,7 +41,12 @@ void ConvertFuncToEmitC::runOnOperation() {
   RewritePatternSet patterns(&getContext());
 
   TypeConverter typeConverter;
-  typeConverter.addConversion([](Type type) { return type; });
+  // Fallback for other types.
+  typeConverter.addConversion([](Type type) -> std::optional<Type> {
+    if (!emitc::isSupportedEmitCType(type))
+      return {};
+    return type;
+  });
 
   populateFuncToEmitCPatterns(typeConverter, patterns);
 

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc-failed.mlir
@@ -13,3 +13,11 @@ func.func @vector(%arg0: vector<4xi32>, %arg1: vector<4xi32>) {
   %0 = arith.addi %arg0, %arg1 : vector<4xi32>
   return
 }
+
+// -----
+
+func.func @unsuppoted_emitc_type(%arg0: i4, %arg1: i4) {
+  // expected-error@+1 {{failed to legalize operation 'arith.addi'}}
+  %0 = arith.addi %arg0, %arg1 : i4
+  return
+}

--- a/mlir/test/Conversion/FuncToEmitC/func-to-emitc-failed.mlir
+++ b/mlir/test/Conversion/FuncToEmitC/func-to-emitc-failed.mlir
@@ -1,0 +1,6 @@
+// RUN: mlir-opt -convert-func-to-emitc %s -split-input-file -verify-diagnostics
+
+// expected-error@+1 {{failed to legalize operation 'func.func'}}
+func.func @unsuppoted_emitc_type(%arg0: i4) -> i4 {
+  return %arg0 : i4
+}


### PR DESCRIPTION
This PR adds fallbacks for other types instead of converting unsupported types to emitc.