### PR TITLE
[lldb-dap] Destroy debugger when debug session terminates

### DIFF
--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -898,6 +898,26 @@ bool DAP::HandleObject(const Message &M) {
 }
 
 void DAP::SendTerminatedEvent() {
+  // The folloiwng is to prevent races between the request handler thread and
+  // the event thread, where we are being asked to disconnect while the debugee
+  // process exits.
+  //
+  // The request handler thread, when entering this method, would have already
+  // acquired the API mutex (in BaseRequestHandler::Run). The next thing it
+  // tries to do is to acquire the call_once() mutex below.
+  //
+  // A deadlock will happen if the event thread happens to acquire the
+  // call_once() mutex first, then go into SBDebugger::Destroy() and eventually
+  // Target::Destroy(), where it tries to acquire the API mutex.
+  //
+  // To avoid this deadlock, we require that both threads acquire the API mutex
+  // first. Whoever gets it can go through the call_once() without issue.
+  //
+  // This is during the termination of a debug session, so performance loss
+  // introduced by this additional lock are hopefully not too critical.
+  lldb::SBMutex lock = GetAPIMutex();
+  std::lock_guard<lldb::SBMutex> guard(lock);
+
   // Prevent races if the process exits while we're being asked to disconnect.
   llvm::call_once(terminated_event_flag, [&] {
     RunTerminateCommands();

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -901,9 +901,15 @@ void DAP::SendTerminatedEvent() {
   // Prevent races if the process exits while we're being asked to disconnect.
   llvm::call_once(terminated_event_flag, [&] {
     RunTerminateCommands();
+
     // Send a "terminated" event
     llvm::json::Object event(CreateTerminatedEventObject(target));
     SendJSON(llvm::json::Value(std::move(event)));
+
+    // Destroy the debugger when the session ends. This will trigger the
+    // debugger's destroy callbacks for earlier logging and clean-ups, rather
+    // than waiting for the termination of the lldb-dap process.
+    lldb::SBDebugger::Destroy(debugger);
   });
 }
 

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -231,13 +231,7 @@ llvm::Error SendThreadStoppedEvent(DAP &dap, bool on_entry) {
 // Send a "terminated" event to indicate the process is done being
 // debugged.
 void SendTerminatedEvent(DAP &dap) {
-  // Prevent races if the process exits while we're being asked to disconnect.
-  llvm::call_once(dap.terminated_event_flag, [&] {
-    dap.RunTerminateCommands();
-    // Send a "terminated" event
-    llvm::json::Object event(CreateTerminatedEventObject(dap.target));
-    dap.SendJSON(llvm::json::Value(std::move(event)));
-  });
+  dap.SendTerminatedEvent();
 }
 
 // Grab any STDOUT and STDERR from the process and send it up to VS Code

--- a/lldb/tools/lldb-dap/EventHelper.cpp
+++ b/lldb/tools/lldb-dap/EventHelper.cpp
@@ -230,9 +230,7 @@ llvm::Error SendThreadStoppedEvent(DAP &dap, bool on_entry) {
 
 // Send a "terminated" event to indicate the process is done being
 // debugged.
-void SendTerminatedEvent(DAP &dap) {
-  dap.SendTerminatedEvent();
-}
+void SendTerminatedEvent(DAP &dap) { dap.SendTerminatedEvent(); }
 
 // Grab any STDOUT and STDERR from the process and send it up to VS Code
 // via an "output" event to the "stdout" and "stderr" categories.


### PR DESCRIPTION
# Patch

Currently, in Server Mode (i.e. `--connection`), all debuggers are destroyed when the **lldb-dap process** terminates. This causes logging and release of resources to be delayed. This can also cause congestion if multiple debuggers have the same destroy callbacks, which will fight for the same resources (e.g. web requests) at the same time.

Instead, the debuggers can be destroyed as early as when the **debug session** terminates. This way, logging and release of release of resources can happen as soon as possible. Congestion can also be naturally reduced, because it's unlikely that all debug sessions will terminate at the same time.

# Tests

```
$ cd build
$ ninja lldb-dap

#################### Run unit tests ####################
$ ninja lldb-unit-test-deps
$ tools/lldb/unittests/DAP/DAPTests
...
[==========] 74 tests from 11 test suites ran. (1414 ms total)
[  PASSED  ] 74 tests.

#################### Run api tests ####################
$ ninja lldb-api-test-deps
$ bin/llvm-lit -a --show-unsupported \
    ../llvm-project/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/evaluate/TestDAP_evaluate.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/output/TestDAP_output.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/restart/TestDAP_restart_console.py \
    ../llvm-project/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
...
UNSUPPORTED: LLDB (/Users/royshi/public_llvm/build/bin/clang-arm64) :: test_basic_functionality (TestDAP_restart_console.TestDAP_restart_console) (skip on debug build type(s))
UNSUPPORTED: LLDB (/Users/royshi/public_llvm/build/bin/clang-arm64) :: test_stopOnEntry (TestDAP_restart_console.TestDAP_restart_console) (skip on debug build type(s))
...
********************
********************
Unsupported Tests (1):
  lldb-api :: tools/lldb-dap/restart/TestDAP_restart_console.py


Testing Time: 71.53s

Total Discovered Tests: 9
  Unsupported: 1 (11.11%)
  Passed     : 8 (88.89%)
```
