### PR TITLE
[clang-tidy][NFC] Enable `readability-convert-member-functions-to-static` in the codebase

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -23,7 +23,6 @@ Checks: >
   -readability-avoid-nested-conditional-operator,
   -readability-braces-around-statements,
   -readability-container-contains,
-  -readability-convert-member-functions-to-static,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
   -readability-identifier-length,

--- a/clang-tools-extra/clang-tidy/ClangTidyProfiling.h
+++ b/clang-tools-extra/clang-tidy/ClangTidyProfiling.h
@@ -36,7 +36,8 @@ public:
 private:
   std::optional<StorageParams> Storage;
 
-  void printUserFriendlyTable(llvm::raw_ostream &OS, llvm::TimerGroup &TG);
+  static void printUserFriendlyTable(llvm::raw_ostream &OS,
+                                     llvm::TimerGroup &TG);
   void printAsJSON(llvm::raw_ostream &OS, llvm::TimerGroup &TG);
   void storeProfileData(llvm::TimerGroup &TG);
 

--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
@@ -51,7 +51,7 @@ public:
 
   /// Makes sure we have contents for all the files we were interested in.
   /// Ideally `FilesToRecord` should be empty.
-  void checkAllFilesRecorded() {
+  static void checkAllFilesRecorded() {
     LLVM_DEBUG({
       for (auto FileEntry : FilesToRecord)
         llvm::dbgs() << "Did not record contents for input file: "

--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
@@ -51,7 +51,7 @@ public:
 
   /// Makes sure we have contents for all the files we were interested in.
   /// Ideally `FilesToRecord` should be empty.
-  static void checkAllFilesRecorded() {
+  void checkAllFilesRecorded() {
     LLVM_DEBUG({
       for (auto FileEntry : FilesToRecord)
         llvm::dbgs() << "Did not record contents for input file: "

--- a/clang-tools-extra/clang-tidy/altera/IdDependentBackwardBranchCheck.h
+++ b/clang-tools-extra/clang-tidy/altera/IdDependentBackwardBranchCheck.h
@@ -65,7 +65,7 @@ private:
                                    const MemberExpr *MemExpr,
                                    const FieldDecl *PotentialField);
   /// Returns the loop type.
-  LoopType getLoopType(const Stmt *Loop);
+  static LoopType getLoopType(const Stmt *Loop);
 
 public:
   IdDependentBackwardBranchCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/clang-tidy/altera/KernelNameRestrictionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/KernelNameRestrictionCheck.cpp
@@ -37,7 +37,7 @@ public:
 private:
   /// Returns true if the name of the file with path FileName is 'kernel.cl',
   /// 'verilog.cl', or 'vhdl.cl'. The file name check is case insensitive.
-  bool fileNameIsRestricted(StringRef FileName);
+  static bool fileNameIsRestricted(StringRef FileName);
 
   struct IncludeDirective {
     SourceLocation Loc; // Location in the include directive.

--- a/clang-tools-extra/clang-tidy/altera/UnrollLoopsCheck.h
+++ b/clang-tools-extra/clang-tidy/altera/UnrollLoopsCheck.h
@@ -44,8 +44,8 @@ private:
   /// Attempts to extract an integer value from either side of the
   /// BinaryOperator. Returns true and saves the result to &value if successful,
   /// returns false otherwise.
-  bool extractValue(int &Value, const BinaryOperator *Op,
-                    const ASTContext *Context);
+  static bool extractValue(int &Value, const BinaryOperator *Op,
+                           const ASTContext *Context);
   /// Returns true if the given loop statement has a large number of iterations,
   /// as determined by the integer value in the loop's condition expression,
   /// if one exists.
@@ -59,13 +59,14 @@ private:
                                  const ASTContext *Context) const;
   /// Returns the type of unrolling, if any, associated with the given
   /// statement.
-  enum UnrollType unrollType(const Stmt *Statement, ASTContext *Context);
+  static enum UnrollType unrollType(const Stmt *Statement, ASTContext *Context);
   /// Returns the condition expression within a given for statement. If there is
   /// none, or if the Statement is not a loop, then returns a NULL pointer.
-  const Expr *getCondExpr(const Stmt *Statement);
+  static const Expr *getCondExpr(const Stmt *Statement);
   /// Returns True if the loop statement has known bounds.
-  bool hasKnownBounds(const Stmt *Statement, const IntegerLiteral *CXXLoopBound,
-                      const ASTContext *Context);
+  static bool hasKnownBounds(const Stmt *Statement,
+                             const IntegerLiteral *CXXLoopBound,
+                             const ASTContext *Context);
   void storeOptions(ClangTidyOptions::OptionMap &Opts) override;
 };
 

--- a/clang-tools-extra/clang-tidy/android/CloexecCheck.cpp
+++ b/clang-tools-extra/clang-tidy/android/CloexecCheck.cpp
@@ -98,7 +98,7 @@ void CloexecCheck::insertStringFlag(
 }
 
 StringRef CloexecCheck::getSpellingArg(const MatchFinder::MatchResult &Result,
-                                       int N) const {
+                                       int N) {
   const auto *MatchedCall = Result.Nodes.getNodeAs<CallExpr>(FuncBindingStr);
   const SourceManager &SM = *Result.SourceManager;
   return Lexer::getSourceText(

--- a/clang-tools-extra/clang-tidy/android/CloexecCheck.h
+++ b/clang-tools-extra/clang-tidy/android/CloexecCheck.h
@@ -85,8 +85,8 @@ protected:
                         const char Mode, const int ArgPos);
 
   /// Helper function to get the spelling of a particular argument.
-  StringRef getSpellingArg(const ast_matchers::MatchFinder::MatchResult &Result,
-                           int N) const;
+  static StringRef
+  getSpellingArg(const ast_matchers::MatchFinder::MatchResult &Result, int N);
 
   /// Binding name of the FuncDecl of a function call.
   static const char *FuncDeclBindingStr;

--- a/clang-tools-extra/clang-tidy/bugprone/AssignmentInIfConditionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/AssignmentInIfConditionCheck.cpp
@@ -35,13 +35,14 @@ void AssignmentInIfConditionCheck::check(
             : Check(Check) {}
 
         // Dont traverse into any lambda expressions.
-        bool TraverseLambdaExpr(LambdaExpr *, DataRecursionQueue * = nullptr) {
+        static bool TraverseLambdaExpr(LambdaExpr *,
+                                       DataRecursionQueue * = nullptr) {
           return true;
         }
 
         // Dont traverse into any requires expressions.
-        bool TraverseRequiresExpr(RequiresExpr *,
-                                  DataRecursionQueue * = nullptr) {
+        static bool TraverseRequiresExpr(RequiresExpr *,
+                                         DataRecursionQueue * = nullptr) {
           return true;
         }
 

--- a/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/BranchCloneCheck.cpp
@@ -50,28 +50,32 @@ static bool isFallthroughSwitchBranch(const SwitchBranch &Branch) {
   struct SwitchCaseVisitor : RecursiveASTVisitor<SwitchCaseVisitor> {
     using RecursiveASTVisitor<SwitchCaseVisitor>::DataRecursionQueue;
 
-    bool TraverseLambdaExpr(LambdaExpr *, DataRecursionQueue * = nullptr) {
+    static bool TraverseLambdaExpr(LambdaExpr *,
+                                   DataRecursionQueue * = nullptr) {
       return true; // Ignore lambdas
     }
 
-    bool TraverseDecl(Decl *) {
+    static bool TraverseDecl(Decl *) {
       return true; // No need to check declarations
     }
 
-    bool TraverseSwitchStmt(SwitchStmt *, DataRecursionQueue * = nullptr) {
+    static bool TraverseSwitchStmt(SwitchStmt *,
+                                   DataRecursionQueue * = nullptr) {
       return true; // Ignore sub-switches
     }
 
     // NOLINTNEXTLINE(readability-identifier-naming) - FIXME
-    bool TraverseSwitchCase(SwitchCase *, DataRecursionQueue * = nullptr) {
+    static bool TraverseSwitchCase(SwitchCase *,
+                                   DataRecursionQueue * = nullptr) {
       return true; // Ignore cases
     }
 
-    bool TraverseDefaultStmt(DefaultStmt *, DataRecursionQueue * = nullptr) {
+    static bool TraverseDefaultStmt(DefaultStmt *,
+                                    DataRecursionQueue * = nullptr) {
       return true; // Ignore defaults
     }
 
-    bool TraverseAttributedStmt(AttributedStmt *S) {
+    static bool TraverseAttributedStmt(AttributedStmt *S) {
       if (!S)
         return true;
 

--- a/clang-tools-extra/clang-tidy/bugprone/MacroRepeatedSideEffectsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/MacroRepeatedSideEffectsCheck.cpp
@@ -32,7 +32,7 @@ private:
   unsigned countArgumentExpansions(const MacroInfo *MI,
                                    const IdentifierInfo *Arg) const;
 
-  bool hasSideEffects(const Token *ResultArgToks) const;
+  static bool hasSideEffects(const Token *ResultArgToks);
 };
 } // End of anonymous namespace.
 
@@ -159,8 +159,7 @@ unsigned MacroRepeatedPPCallbacks::countArgumentExpansions(
   return Max;
 }
 
-bool MacroRepeatedPPCallbacks::hasSideEffects(
-    const Token *ResultArgToks) const {
+bool MacroRepeatedPPCallbacks::hasSideEffects(const Token *ResultArgToks) {
   for (; ResultArgToks->isNot(tok::eof); ++ResultArgToks) {
     if (ResultArgToks->isOneOf(tok::plusplus, tok::minusminus))
       return true;

--- a/clang-tools-extra/clang-tidy/fuchsia/MultipleInheritanceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/fuchsia/MultipleInheritanceCheck.cpp
@@ -47,7 +47,7 @@ bool MultipleInheritanceCheck::getInterfaceStatus(const CXXRecordDecl *Node,
 }
 
 bool MultipleInheritanceCheck::isCurrentClassInterface(
-    const CXXRecordDecl *Node) const {
+    const CXXRecordDecl *Node) {
   // Interfaces should have no fields.
   if (!Node->field_empty())
     return false;

--- a/clang-tools-extra/clang-tidy/fuchsia/MultipleInheritanceCheck.h
+++ b/clang-tools-extra/clang-tidy/fuchsia/MultipleInheritanceCheck.h
@@ -32,7 +32,7 @@ public:
 private:
   void addNodeToInterfaceMap(const CXXRecordDecl *Node, bool IsInterface);
   bool getInterfaceStatus(const CXXRecordDecl *Node, bool &IsInterface) const;
-  bool isCurrentClassInterface(const CXXRecordDecl *Node) const;
+  static bool isCurrentClassInterface(const CXXRecordDecl *Node);
   bool isInterface(const CXXRecordDecl *Node);
 
   // Contains the identity of each named CXXRecord as an interface.  This is

--- a/clang-tools-extra/clang-tidy/misc/StaticAssertCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/StaticAssertCheck.h
@@ -30,8 +30,8 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 
 private:
-  SourceLocation getLastParenLoc(const ASTContext *ASTCtx,
-                                 SourceLocation AssertLoc);
+  static SourceLocation getLastParenLoc(const ASTContext *ASTCtx,
+                                        SourceLocation AssertLoc);
 };
 
 } // namespace clang::tidy::misc

--- a/clang-tools-extra/clang-tidy/misc/ThrowByValueCatchByReferenceCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/ThrowByValueCatchByReferenceCheck.h
@@ -38,8 +38,8 @@ private:
   void diagnoseThrowLocations(const CXXThrowExpr *ThrowExpr);
   void diagnoseCatchLocations(const CXXCatchStmt *CatchStmt,
                               ASTContext &Context);
-  bool isFunctionParameter(const DeclRefExpr *DeclRefExpr);
-  bool isCatchVariable(const DeclRefExpr *DeclRefExpr);
+  static bool isFunctionParameter(const DeclRefExpr *DeclRefExpr);
+  static bool isCatchVariable(const DeclRefExpr *DeclRefExpr);
   bool isFunctionOrCatchVar(const DeclRefExpr *DeclRefExpr);
   const bool CheckAnonymousTemporaries;
   const bool WarnOnLargeObject;

--- a/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/UnusedParametersCheck.cpp
@@ -99,7 +99,7 @@ public:
     return Index[Fn->getCanonicalDecl()].OtherRefs;
   }
 
-  bool shouldTraversePostOrder() const { return true; }
+  static bool shouldTraversePostOrder() { return true; }
 
   bool WalkUpFromDeclRefExpr(DeclRefExpr *DeclRef) {
     if (const auto *Fn = dyn_cast<FunctionDecl>(DeclRef->getDecl())) {

--- a/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/DeprecatedHeadersCheck.cpp
@@ -53,8 +53,8 @@ public:
   ExternCRefutationVisitor(std::vector<IncludeMarker> &IncludesToBeProcessed,
                            SourceManager &SM)
       : IncludesToBeProcessed(IncludesToBeProcessed), SM(SM) {}
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
-  bool shouldVisitLambdaBody() const { return false; }
+  static bool shouldWalkTypesOfTypeLocs() { return false; }
+  static bool shouldVisitLambdaBody() { return false; }
 
   bool VisitLinkageSpecDecl(LinkageSpecDecl *LinkSpecDecl) const {
     if (LinkSpecDecl->getLanguage() != LinkageSpecLanguageIDs::C ||

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertCheck.h
@@ -38,7 +38,7 @@ private:
     bool NeedsReverseCall = false;
   };
 
-  void getAliasRange(SourceManager &SM, SourceRange &DeclRange);
+  static void getAliasRange(SourceManager &SM, SourceRange &DeclRange);
 
   void doConversion(ASTContext *Context, const VarDecl *IndexVar,
                     const ValueDecl *MaybeContainer, const UsageResult &Usages,
@@ -46,18 +46,18 @@ private:
                     bool AliasFromForInit, const ForStmt *Loop,
                     RangeDescriptor Descriptor);
 
-  StringRef getContainerString(ASTContext *Context, const ForStmt *Loop,
-                               const Expr *ContainerExpr);
+  static StringRef getContainerString(ASTContext *Context, const ForStmt *Loop,
+                                      const Expr *ContainerExpr);
 
-  void getArrayLoopQualifiers(ASTContext *Context,
-                              const ast_matchers::BoundNodes &Nodes,
-                              const Expr *ContainerExpr,
-                              const UsageResult &Usages,
-                              RangeDescriptor &Descriptor);
+  static void getArrayLoopQualifiers(ASTContext *Context,
+                                     const ast_matchers::BoundNodes &Nodes,
+                                     const Expr *ContainerExpr,
+                                     const UsageResult &Usages,
+                                     RangeDescriptor &Descriptor);
 
-  void getIteratorLoopQualifiers(ASTContext *Context,
-                                 const ast_matchers::BoundNodes &Nodes,
-                                 RangeDescriptor &Descriptor);
+  static void getIteratorLoopQualifiers(ASTContext *Context,
+                                        const ast_matchers::BoundNodes &Nodes,
+                                        RangeDescriptor &Descriptor);
 
   void determineRangeDescriptor(ASTContext *Context,
                                 const ast_matchers::BoundNodes &Nodes,

--- a/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseStdNumbersCheck.cpp
@@ -80,12 +80,13 @@ AST_MATCHER_P(clang::Expr, anyOfExhaustive, std::vector<Matcher<clang::Stmt>>,
 // the literal of every constant and for formulas' subexpressions that look at
 // literals.
 struct MatchBuilder {
-  auto
-  ignoreParenAndArithmeticCasting(const Matcher<clang::Expr> Matcher) const {
+  static auto
+  ignoreParenAndArithmeticCasting(const Matcher<clang::Expr> Matcher) {
     return expr(hasType(qualType(isArithmetic())), ignoringParenCasts(Matcher));
   }
 
-  auto ignoreParenAndFloatingCasting(const Matcher<clang::Expr> Matcher) const {
+  static auto
+  ignoreParenAndFloatingCasting(const Matcher<clang::Expr> Matcher) {
     return expr(hasType(qualType(isFloating())), ignoringParenCasts(Matcher));
   }
 

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -51,7 +51,7 @@ public:
 
   bool Collision = false;
 
-  bool shouldWalkTypesOfTypeLocs() const { return false; }
+  static bool shouldWalkTypesOfTypeLocs() { return false; }
 
   bool visitUnqualName(StringRef UnqualName) {
     // Check for collisions with function arguments.

--- a/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
+++ b/clang-tools-extra/clang-tidy/performance/UnnecessaryCopyInitialization.h
@@ -56,7 +56,8 @@ private:
                                   const VarDecl *ObjectArg);
   void handleCopyFromLocalVar(const CheckContext &Ctx, const VarDecl &OldVar);
 
-  void maybeIssueFixes(const CheckContext &Ctx, DiagnosticBuilder &Diagnostic);
+  static void maybeIssueFixes(const CheckContext &Ctx,
+                              DiagnosticBuilder &Diagnostic);
 
   const std::vector<StringRef> AllowedTypes;
   const std::vector<StringRef> ExcludedContainerTypes;

--- a/clang-tools-extra/clang-tidy/readability/AvoidUnconditionalPreprocessorIfCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/AvoidUnconditionalPreprocessorIfCheck.cpp
@@ -66,7 +66,7 @@ struct AvoidUnconditionalPreprocessorIfPPCallbacks : public PPCallbacks {
     return true;
   }
 
-  bool isImmutableToken(const Token &Tok) {
+  static bool isImmutableToken(const Token &Tok) {
     switch (Tok.getKind()) {
     case tok::eod:
     case tok::eof:

--- a/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ConvertMemberFunctionsToStatic.cpp
@@ -66,7 +66,7 @@ AST_MATCHER(CXXMethodDecl, usesThis) {
 
     // If we enter a class declaration, don't traverse into it as any usages of
     // `this` will correspond to the nested class.
-    bool TraverseCXXRecordDecl(CXXRecordDecl *RD) { return true; }
+    static bool TraverseCXXRecordDecl(CXXRecordDecl *RD) { return true; }
 
   } UsageOfThis;
 

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.cpp
@@ -417,7 +417,7 @@ IdentifierNamingCheck::IdentifierNamingCheck(StringRef Name,
 IdentifierNamingCheck::~IdentifierNamingCheck() = default;
 
 bool IdentifierNamingCheck::HungarianNotation::checkOptionValid(
-    int StyleKindIndex) const {
+    int StyleKindIndex) {
   if ((StyleKindIndex >= SK_EnumConstant) &&
       (StyleKindIndex <= SK_ConstantParameter))
     return true;
@@ -429,7 +429,7 @@ bool IdentifierNamingCheck::HungarianNotation::checkOptionValid(
 }
 
 bool IdentifierNamingCheck::HungarianNotation::isOptionEnabled(
-    StringRef OptionKey, const llvm::StringMap<std::string> &StrMap) const {
+    StringRef OptionKey, const llvm::StringMap<std::string> &StrMap) {
   if (OptionKey.empty())
     return false;
 
@@ -442,7 +442,7 @@ bool IdentifierNamingCheck::HungarianNotation::isOptionEnabled(
 
 void IdentifierNamingCheck::HungarianNotation::loadFileConfig(
     const ClangTidyCheck::OptionsView &Options,
-    IdentifierNamingCheck::HungarianNotationOption &HNOption) const {
+    IdentifierNamingCheck::HungarianNotationOption &HNOption) {
 
   static constexpr StringRef HNOpts[] = {"TreatStructAsClass"};
   static constexpr StringRef HNDerivedTypes[] = {"Array", "Pointer",
@@ -535,7 +535,7 @@ std::string IdentifierNamingCheck::HungarianNotation::getPrefix(
 
 bool IdentifierNamingCheck::HungarianNotation::removeDuplicatedPrefix(
     SmallVector<StringRef, 8> &Words,
-    const IdentifierNamingCheck::HungarianNotationOption &HNOption) const {
+    const IdentifierNamingCheck::HungarianNotationOption &HNOption) {
   if (Words.size() <= 1)
     return true;
 
@@ -652,7 +652,7 @@ std::string IdentifierNamingCheck::HungarianNotation::getClassPrefix(
 }
 
 std::string IdentifierNamingCheck::HungarianNotation::getEnumPrefix(
-    const EnumConstantDecl *ECD) const {
+    const EnumConstantDecl *ECD) {
   const auto *ED = cast<EnumDecl>(ECD->getDeclContext());
 
   std::string Name = ED->getName().str();
@@ -697,7 +697,7 @@ std::string IdentifierNamingCheck::HungarianNotation::getEnumPrefix(
 }
 
 size_t IdentifierNamingCheck::HungarianNotation::getAsteriskCount(
-    const std::string &TypeName) const {
+    const std::string &TypeName) {
   size_t Pos = TypeName.find('*');
   size_t Count = 0;
   for (; Pos < TypeName.length(); Pos++, Count++) {
@@ -719,7 +719,7 @@ size_t IdentifierNamingCheck::HungarianNotation::getAsteriskCount(
 }
 
 void IdentifierNamingCheck::HungarianNotation::loadDefaultConfig(
-    IdentifierNamingCheck::HungarianNotationOption &HNOption) const {
+    IdentifierNamingCheck::HungarianNotationOption &HNOption) {
 
   // Options
   static constexpr std::pair<StringRef, StringRef> General[] = {
@@ -1024,7 +1024,7 @@ std::string IdentifierNamingCheck::fixupWithCase(
 }
 
 bool IdentifierNamingCheck::isParamInMainLikeFunction(
-    const ParmVarDecl &ParmDecl, bool IncludeMainLike) const {
+    const ParmVarDecl &ParmDecl, bool IncludeMainLike) {
   const auto *FDecl =
       dyn_cast_or_null<FunctionDecl>(ParmDecl.getParentFunctionOrMethod());
   if (!FDecl)
@@ -1472,7 +1472,7 @@ StyleKind IdentifierNamingCheck::findStyleKindForAnonField(
 
 StyleKind IdentifierNamingCheck::findStyleKindForField(
     const FieldDecl *Field, QualType Type,
-    ArrayRef<std::optional<NamingStyle>> NamingStyles) const {
+    ArrayRef<std::optional<NamingStyle>> NamingStyles) {
   if (!Type.isNull() && Type.isConstQualified()) {
     if (NamingStyles[SK_ConstantMember])
       return SK_ConstantMember;
@@ -1498,7 +1498,7 @@ StyleKind IdentifierNamingCheck::findStyleKindForField(
 
 StyleKind IdentifierNamingCheck::findStyleKindForVar(
     const VarDecl *Var, QualType Type,
-    ArrayRef<std::optional<NamingStyle>> NamingStyles) const {
+    ArrayRef<std::optional<NamingStyle>> NamingStyles) {
   if (Var->isConstexpr() && NamingStyles[SK_ConstexprVariable])
     return SK_ConstexprVariable;
 

--- a/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/IdentifierNamingCheck.h
@@ -90,23 +90,23 @@ public:
 
   struct HungarianNotation {
   public:
-    bool checkOptionValid(int StyleKindIndex) const;
-    bool isOptionEnabled(StringRef OptionKey,
-                         const llvm::StringMap<std::string> &StrMap) const;
+    static bool checkOptionValid(int StyleKindIndex);
+    static bool isOptionEnabled(StringRef OptionKey,
+                                const llvm::StringMap<std::string> &StrMap);
 
-    size_t getAsteriskCount(const std::string &TypeName) const;
+    static size_t getAsteriskCount(const std::string &TypeName);
     size_t getAsteriskCount(const std::string &TypeName,
                             const NamedDecl *ND) const;
 
-    void loadDefaultConfig(
-        IdentifierNamingCheck::HungarianNotationOption &HNOption) const;
-    void loadFileConfig(
-        const ClangTidyCheck::OptionsView &Options,
-        IdentifierNamingCheck::HungarianNotationOption &HNOption) const;
+    static void
+    loadDefaultConfig(IdentifierNamingCheck::HungarianNotationOption &HNOption);
+    static void
+    loadFileConfig(const ClangTidyCheck::OptionsView &Options,
+                   IdentifierNamingCheck::HungarianNotationOption &HNOption);
 
-    bool removeDuplicatedPrefix(
+    static bool removeDuplicatedPrefix(
         SmallVector<StringRef, 8> &Words,
-        const IdentifierNamingCheck::HungarianNotationOption &HNOption) const;
+        const IdentifierNamingCheck::HungarianNotationOption &HNOption);
 
     std::string getPrefix(
         const Decl *D,
@@ -120,7 +120,7 @@ public:
         const CXXRecordDecl *CRD,
         const IdentifierNamingCheck::HungarianNotationOption &HNOption) const;
 
-    std::string getEnumPrefix(const EnumConstantDecl *ECD) const;
+    static std::string getEnumPrefix(const EnumConstantDecl *ECD);
     std::string getDeclTypeName(const NamedDecl *ND) const;
   };
 
@@ -191,8 +191,8 @@ public:
       const IdentifierNamingCheck::HungarianNotationOption &HNOption,
       StyleKind SK, const SourceManager &SM, bool IgnoreFailedSplit) const;
 
-  bool isParamInMainLikeFunction(const ParmVarDecl &ParmDecl,
-                                 bool IncludeMainLike) const;
+  static bool isParamInMainLikeFunction(const ParmVarDecl &ParmDecl,
+                                        bool IncludeMainLike);
 
 private:
   std::optional<FailureInfo>
@@ -212,13 +212,13 @@ private:
       const FieldDecl *AnonField,
       ArrayRef<std::optional<NamingStyle>> NamingStyles) const;
 
-  StyleKind findStyleKindForField(
-      const FieldDecl *Field, QualType Type,
-      ArrayRef<std::optional<NamingStyle>> NamingStyles) const;
+  static StyleKind
+  findStyleKindForField(const FieldDecl *Field, QualType Type,
+                        ArrayRef<std::optional<NamingStyle>> NamingStyles);
 
-  StyleKind
+  static StyleKind
   findStyleKindForVar(const VarDecl *Var, QualType Type,
-                      ArrayRef<std::optional<NamingStyle>> NamingStyles) const;
+                      ArrayRef<std::optional<NamingStyle>> NamingStyles);
 
   /// Stores the style options as a vector, indexed by the specified \ref
   /// StyleKind, for a given directory.

--- a/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.cpp
@@ -223,7 +223,7 @@ bool MagicNumbersCheck::isIgnoredValue(const FloatingLiteral *Literal) const {
 }
 
 bool MagicNumbersCheck::isSyntheticValue(const SourceManager *SourceManager,
-                                         const IntegerLiteral *Literal) const {
+                                         const IntegerLiteral *Literal) {
   const std::pair<FileID, unsigned> FileOffset =
       SourceManager->getDecomposedLoc(Literal->getLocation());
   if (FileOffset.first.isInvalid())
@@ -247,7 +247,7 @@ bool MagicNumbersCheck::isBitFieldWidth(
 
 bool MagicNumbersCheck::isUserDefinedLiteral(
     const clang::ast_matchers::MatchFinder::MatchResult &Result,
-    const clang::Expr &Literal) const {
+    const clang::Expr &Literal) {
   DynTypedNodeList Parents = Result.Context->getParents(Literal);
   if (Parents.empty())
     return false;

--- a/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.h
+++ b/clang-tools-extra/clang-tidy/readability/MagicNumbersCheck.h
@@ -38,8 +38,8 @@ private:
                         const FloatingLiteral *) const {
     return false;
   }
-  bool isSyntheticValue(const clang::SourceManager *SourceManager,
-                        const IntegerLiteral *Literal) const;
+  static bool isSyntheticValue(const clang::SourceManager *SourceManager,
+                               const IntegerLiteral *Literal);
 
   bool isBitFieldWidth(const clang::ast_matchers::MatchFinder::MatchResult &,
                        const FloatingLiteral &) const {
@@ -50,9 +50,9 @@ private:
   isBitFieldWidth(const clang::ast_matchers::MatchFinder::MatchResult &Result,
                   const IntegerLiteral &Literal) const;
 
-  bool isUserDefinedLiteral(
+  static bool isUserDefinedLiteral(
       const clang::ast_matchers::MatchFinder::MatchResult &Result,
-      const clang::Expr &Literal) const;
+      const clang::Expr &Literal);
 
   template <typename L>
   void checkBoundMatch(const ast_matchers::MatchFinder::MatchResult &Result,

--- a/clang-tools-extra/clang-tidy/utils/FormatStringConverter.h
+++ b/clang-tools-extra/clang-tidy/utils/FormatStringConverter.h
@@ -89,11 +89,13 @@ private:
   // puts the width and preicision first.
   std::vector<std::tuple<unsigned, unsigned>> ArgRotates;
 
-  void emitAlignment(const PrintfSpecifier &FS, std::string &FormatSpec);
-  void emitSign(const PrintfSpecifier &FS, std::string &FormatSpec);
-  void emitAlternativeForm(const PrintfSpecifier &FS, std::string &FormatSpec);
-  void emitFieldWidth(const PrintfSpecifier &FS, std::string &FormatSpec);
-  void emitPrecision(const PrintfSpecifier &FS, std::string &FormatSpec);
+  static void emitAlignment(const PrintfSpecifier &FS, std::string &FormatSpec);
+  static void emitSign(const PrintfSpecifier &FS, std::string &FormatSpec);
+  static void emitAlternativeForm(const PrintfSpecifier &FS,
+                                  std::string &FormatSpec);
+  static void emitFieldWidth(const PrintfSpecifier &FS,
+                             std::string &FormatSpec);
+  static void emitPrecision(const PrintfSpecifier &FS, std::string &FormatSpec);
   void emitStringArgument(unsigned ArgIndex, const Expr *Arg);
   bool emitIntegerArgument(ConversionSpecifier::Kind ArgKind, const Expr *Arg,
                            unsigned ArgIndex, std::string &FormatSpec);

--- a/clang-tools-extra/clang-tidy/utils/HeaderGuard.h
+++ b/clang-tools-extra/clang-tidy/utils/HeaderGuard.h
@@ -25,7 +25,7 @@ public:
                            Preprocessor *ModuleExpanderPP) override;
 
   /// Ensure that the provided header guard is a non-reserved identifier.
-  std::string sanitizeHeaderGuard(StringRef Guard);
+  static std::string sanitizeHeaderGuard(StringRef Guard);
 
   /// Returns ``true`` if the check should suggest inserting a trailing comment
   /// on the ``#endif`` of the header guard. It will use the same name as

--- a/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
+++ b/clang-tools-extra/clang-tidy/utils/RenamerClangTidyCheck.cpp
@@ -219,9 +219,9 @@ public:
       : Check(Check), SM(SM),
         AggressiveDependentMemberLookup(AggressiveDependentMemberLookup) {}
 
-  bool shouldVisitTemplateInstantiations() const { return true; }
+  static bool shouldVisitTemplateInstantiations() { return true; }
 
-  bool shouldVisitImplicitCode() const { return false; }
+  static bool shouldVisitImplicitCode() { return false; }
 
   bool VisitCXXConstructorDecl(CXXConstructorDecl *Decl) {
     if (Decl->isImplicit())


### PR DESCRIPTION
Closes #156158.

Ironically, one warning found in `ConvertMemberFunctionsToStatic.cpp`