### PR TITLE
[ADT] Mark BitVector::find_prev_unset const (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/BitVector.h
+++ b/llvm/include/llvm/ADT/BitVector.h
@@ -327,7 +327,7 @@ public:
 
   /// find_prev_unset - Returns the index of the first unset bit that precedes
   /// the bit at \p PriorTo.  Returns -1 if all previous bits are set.
-  int find_prev_unset(unsigned PriorTo) {
+  int find_prev_unset(unsigned PriorTo) const {
     return find_last_unset_in(0, PriorTo);
   }
 


### PR DESCRIPTION
find_prev_unset calls find_last_unset_in, a const method, but
find_prev_unset itself isn't marked const.
