### PR TITLE
[libc++][NFC] Use llvm.org/PR to link to bug reports

### DIFF
--- a/libcxx/CMakeLists.txt
+++ b/libcxx/CMakeLists.txt
@@ -361,8 +361,7 @@ endif()
 if (NOT LIBCXX_ENABLE_RTTI AND LIBCXX_ENABLE_EXCEPTIONS)
   message(FATAL_ERROR "Libc++ cannot be built with exceptions enabled but RTTI"
                       " disabled, since that configuration is broken. See"
-                      " https://github.com/llvm/llvm-project/issues/66117"
-                      " for details.")
+                      " https://llvm.org/PR66117 for details.")
 endif()
 
 if (LIBCXX_ENABLE_ABI_LINKER_SCRIPT)

--- a/libcxx/docs/Modules.rst
+++ b/libcxx/docs/Modules.rst
@@ -72,7 +72,7 @@ Some of the current limitations
  * Clang:
     * Including headers after importing the ``std`` module may fail. This is
       hard to solve and there is a work-around by first including all headers
-      `bug report <https://github.com/llvm/llvm-project/issues/61465>`__.
+      `bug report <https://llvm.org/PR61465>`__.
 
 Blockers
 ~~~~~~~~
@@ -88,8 +88,7 @@ Blockers
 
   * Clang
 
-    * Some concepts do not work properly
-      `bug report <https://github.com/llvm/llvm-project/issues/62943>`__.
+    * Some concepts do not work properly `bug report <https://llvm.org/PR61465>`__.
 
 
 Using in external projects

--- a/libcxx/docs/ReleaseNotes/22.rst
+++ b/libcxx/docs/ReleaseNotes/22.rst
@@ -38,9 +38,9 @@ What's New in Libc++ 22.0.0?
 Implemented Papers
 ------------------
 
-- P2321R2: ``zip`` (`Github <https://github.com/llvm/llvm-project/issues/105169>`__) (The paper is partially
-  implemented. ``zip_transform_view`` is implemented in this release)
-- P3168R2: Give ``std::optional`` Range Support (`Github <https://github.com/llvm/llvm-project/issues/105430>`__)
+- P2321R2: ``zip`` (`Github <https://llvm.org/PR105169>`__) (The paper is partially implemented. ``zip_transform_view``
+  is implemented in this release)
+- P3168R2: Give ``std::optional`` Range Support (`Github <https://llvm.org/PR105430>`__)
 
 Improvements and New Features
 -----------------------------

--- a/libcxx/docs/Status/Cxx17Papers.csv
+++ b/libcxx/docs/Status/Cxx17Papers.csv
@@ -26,7 +26,7 @@
 "`P0013R1 <https://wg21.link/P0013R1>`__","Logical type traits rev 2","2015-10 (Kona)","|Complete|","3.8",""
 "","","","","",""
 "`P0024R2 <https://wg21.link/P0024R2>`__","The Parallelism TS Should be Standardized","2016-02 (Jacksonville)","|Partial|","",""
-"`P0226R1 <https://wg21.link/P0226R1>`__","Mathematical Special Functions for C++17","2016-02 (Jacksonville)","|In Progress|","","Progress is tracked `here <https://github.com/llvm/llvm-project/issues/99939>`__"
+"`P0226R1 <https://wg21.link/P0226R1>`__","Mathematical Special Functions for C++17","2016-02 (Jacksonville)","|In Progress|","","Progress is tracked `here <https://llvm.org/PR99939>`__"
 "`P0220R1 <https://wg21.link/P0220R1>`__","Adopt Library Fundamentals V1 TS Components for C++17","2016-02 (Jacksonville)","|Complete|","16",""
 "`P0218R1 <https://wg21.link/P0218R1>`__","Adopt the File System TS for C++17","2016-02 (Jacksonville)","|Complete|","7",""
 "`P0033R1 <https://wg21.link/P0033R1>`__","Re-enabling shared_from_this","2016-02 (Jacksonville)","|Complete|","3.9",""

--- a/libcxx/docs/Status/Cxx20Papers.csv
+++ b/libcxx/docs/Status/Cxx20Papers.csv
@@ -18,7 +18,7 @@
 "`P0777R1 <https://wg21.link/P0777R1>`__","Treating Unnecessary ``decay``\ ","2017-11 (Albuquerque)","|Complete|","7",""
 "","","","","",""
 "`P0122R7 <https://wg21.link/P0122R7>`__","<span>","2018-03 (Jacksonville)","|Complete|","7",""
-"`P0355R7 <https://wg21.link/P0355R7>`__","Extending chrono to Calendars and Time Zones","2018-03 (Jacksonville)","|Partial|","","See the `Github issue <https://github.com/llvm/llvm-project/issues/99982>`__ for detailed status"
+"`P0355R7 <https://wg21.link/P0355R7>`__","Extending chrono to Calendars and Time Zones","2018-03 (Jacksonville)","|Partial|","","See the `Github issue <https://llvm.org/PR99982>`__ for detailed status"
 "`P0551R3 <https://wg21.link/P0551R3>`__","Thou Shalt Not Specialize ``std``\  Function Templates!","2018-03 (Jacksonville)","|Complete|","11",""
 "`P0753R2 <https://wg21.link/P0753R2>`__","Manipulators for C++ Synchronized Buffered Ostream","2018-03 (Jacksonville)","","",""
 "`P0754R2 <https://wg21.link/P0754R2>`__","<version>","2018-03 (Jacksonville)","|Complete|","7",""

--- a/libcxx/include/__algorithm/simd_utils.h
+++ b/libcxx/include/__algorithm/simd_utils.h
@@ -123,7 +123,7 @@ template <class _Tp, size_t _Np>
 [[__nodiscard__]] _LIBCPP_HIDE_FROM_ABI size_t __find_first_set(__simd_vector<_Tp, _Np> __vec) noexcept {
   using __mask_vec = __simd_vector<bool, _Np>;
 
-  // This has MSan disabled du to https://github.com/llvm/llvm-project/issues/85876
+  // This has MSan disabled du to https://llvm.org/PR85876
   auto __impl = [&]<class _MaskT>(_MaskT) _LIBCPP_NO_SANITIZE("memory") noexcept {
 #  if defined(_LIBCPP_BIG_ENDIAN)
     return std::min<size_t>(

--- a/libcxx/include/__atomic/atomic.h
+++ b/libcxx/include/__atomic/atomic.h
@@ -350,7 +350,7 @@ private:
     //    &Context.getTargetInfo().getLongDoubleFormat() ==
     //        &llvm::APFloat::x87DoubleExtended())
     // For more info
-    // https://github.com/llvm/llvm-project/issues/68602
+    // https://llvm.org/PR68602
     // https://reviews.llvm.org/D53965
     return !__is_fp80_long_double();
 #  endif
@@ -367,7 +367,7 @@ private:
       while (!__self.compare_exchange_weak(__old, __new, __m, memory_order_relaxed)) {
 #  ifdef _LIBCPP_COMPILER_CLANG_BASED
         if constexpr (__is_fp80_long_double()) {
-          // https://github.com/llvm/llvm-project/issues/47978
+          // https://llvm.org/PR47978
           // clang bug: __old is not updated on failure for atomic<long double>::compare_exchange_weak
           // Note __old = __self.load(memory_order_relaxed) will not work
           std::__cxx_atomic_load_inplace(std::addressof(__self.__a_), std::addressof(__old), memory_order_relaxed);

--- a/libcxx/include/__configuration/abi.h
+++ b/libcxx/include/__configuration/abi.h
@@ -101,8 +101,8 @@
 // We had some bugs where we use [[no_unique_address]] together with construct_at,
 // which causes UB as the call on construct_at could write to overlapping subobjects
 //
-// https://github.com/llvm/llvm-project/issues/70506
-// https://github.com/llvm/llvm-project/issues/70494
+// https://llvm.org/PR70506
+// https://llvm.org/PR70494
 //
 // To fix the bug we had to change the ABI of some classes to remove [[no_unique_address]] under certain conditions.
 // The macro below is used for all classes whose ABI have changed as part of fixing these bugs.

--- a/libcxx/include/__configuration/availability.h
+++ b/libcxx/include/__configuration/availability.h
@@ -72,7 +72,7 @@
 //
 // We also allow users to force-disable availability markup via the `_LIBCPP_DISABLE_AVAILABILITY`
 // macro because that is the only way to work around a Clang bug related to availability
-// attributes: https://github.com/llvm/llvm-project/issues/134151.
+// attributes: https://llvm.org/PR134151.
 // Once that bug has been fixed, we should remove the macro.
 #if defined(_LIBCPP_BUILDING_LIBRARY) || defined(_LIBCXXABI_BUILDING_LIBRARY) ||                                       \
     !defined(_LIBCPP_COMPILER_CLANG_BASED) || defined(_LIBCPP_DISABLE_AVAILABILITY)
@@ -307,7 +307,7 @@
 // This controls the availability of the C++17 std::pmr library,
 // which is implemented in large part in the built library.
 //
-// TODO: Enable std::pmr markup once https://github.com/llvm/llvm-project/issues/40340 has been fixed
+// TODO: Enable std::pmr markup once https://llvm.org/PR40340 has been fixed
 //       Until then, it is possible for folks to try to use `std::pmr` when back-deploying to targets that don't support
 //       it and it'll be a load-time error, but we don't have a good alternative because the library won't compile if we
 //       use availability annotations until that bug has been fixed.

--- a/libcxx/include/__iterator/bounded_iter.h
+++ b/libcxx/include/__iterator/bounded_iter.h
@@ -116,8 +116,7 @@ public:
   // These operations check that the iterator is dereferenceable. Since the class invariant is
   // that the iterator is always within `[begin, end]`, we only need to check it's not pointing to
   // `end`. This is easier for the optimizer because it aligns with the `iter != container.end()`
-  // checks that typical callers already use (see
-  // https://github.com/llvm/llvm-project/issues/78829).
+  // checks that typical callers already use (see https://llvm.org/PR78829).
   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 reference operator*() const _NOEXCEPT {
     _LIBCPP_ASSERT_VALID_ELEMENT_ACCESS(
         __current_ != __end_, "__bounded_iter::operator*: Attempt to dereference an iterator at the end");

--- a/libcxx/include/__iterator/concepts.h
+++ b/libcxx/include/__iterator/concepts.h
@@ -118,7 +118,7 @@ concept __signed_integer_like = signed_integral<_Tp>;
 
 template <class _Ip>
 concept weakly_incrementable =
-    // TODO: remove this once the clang bug is fixed (bugs.llvm.org/PR48173).
+    // TODO: remove this once the clang bug is fixed (https://llvm.org/PR48173).
     !same_as<_Ip, bool> && // Currently, clang does not handle bool correctly.
     movable<_Ip> && requires(_Ip __i) {
       typename iter_difference_t<_Ip>;

--- a/libcxx/include/__math/hypot.h
+++ b/libcxx/include/__math/hypot.h
@@ -53,7 +53,7 @@ inline _LIBCPP_HIDE_FROM_ABI __promote_t<_A1, _A2> hypot(_A1 __x, _A2 __y) _NOEX
 // Computes the three-dimensional hypotenuse: `std::hypot(x,y,z)`.
 // The naive implementation might over-/underflow which is why this implementation is more involved:
 //    If the square of an argument might run into issues, we scale the arguments appropriately.
-// See https://github.com/llvm/llvm-project/issues/92782 for a detailed discussion and summary.
+// See https://llvm.org/PR92782 for a detailed discussion and summary.
 template <class _Real>
 _LIBCPP_HIDE_FROM_ABI _Real __hypot(_Real __x, _Real __y, _Real __z) {
   // Factors needed to determine if over-/underflow might happen

--- a/libcxx/include/__memory/compressed_pair.h
+++ b/libcxx/include/__memory/compressed_pair.h
@@ -52,7 +52,7 @@ _LIBCPP_BEGIN_NAMESPACE_STD
 //
 // Furthermore, that alignment must be the same as what was used in the old __compressed_pair layout, so we must
 // handle reference types specially since alignof(T&) == alignof(T).
-// See https://github.com/llvm/llvm-project/issues/118559.
+// See https://llvm.org/PR118559.
 
 #ifndef _LIBCPP_ABI_NO_COMPRESSED_PAIR_PADDING
 

--- a/libcxx/include/__vector/vector_bool.h
+++ b/libcxx/include/__vector/vector_bool.h
@@ -19,7 +19,7 @@
 #include <__bit_reference>
 #include <__config>
 #include <__functional/unary_function.h>
-#include <__fwd/bit_reference.h> // TODO: This is a workaround for https://github.com/llvm/llvm-project/issues/131814
+#include <__fwd/bit_reference.h> // TODO: This is a workaround for https://llvm.org/PR131814
 #include <__fwd/functional.h>
 #include <__fwd/vector.h>
 #include <__iterator/distance.h>

--- a/libcxx/include/module.modulemap.in
+++ b/libcxx/include/module.modulemap.in
@@ -842,7 +842,7 @@ module std [system] {
     module stable_partition                       { header "__algorithm/stable_partition.h" }
     module stable_sort {
       header "__algorithm/stable_sort.h"
-      export std.memory.unique_temporary_buffer // TODO: Workaround for https://github.com/llvm/llvm-project/issues/120108
+      export std.memory.unique_temporary_buffer // TODO: Workaround for https://llvm.org/PR120108
     }
     module swap_ranges                            { header "__algorithm/swap_ranges.h" }
     module three_way_comp_ref_type                { header "__algorithm/three_way_comp_ref_type.h" }
@@ -1260,7 +1260,7 @@ module std [system] {
     module directory_entry                { header "__filesystem/directory_entry.h" }
     module directory_iterator             {
       header "__filesystem/directory_iterator.h"
-      // This is a workaround for https://github.com/llvm/llvm-project/issues/120108.
+      // This is a workaround for https://llvm.org/PR120108.
       export *
     }
     module directory_options              { header "__filesystem/directory_options.h" }
@@ -1637,7 +1637,7 @@ module std [system] {
     module allocation_guard                   { header "__memory/allocation_guard.h" }
     module allocator {
       header "__memory/allocator.h"
-      export * // TODO: Workaround for https://github.com/llvm/llvm-project/issues/120108
+      export * // TODO: Workaround for https://llvm.org/PR120108
     }
     module allocator_arg_t                    { header "__memory/allocator_arg_t.h" }
     module allocator_destructor               { header "__memory/allocator_destructor.h" }
@@ -1682,7 +1682,7 @@ module std [system] {
       header "__memory/unique_temporary_buffer.h"
       export std.memory.unique_ptr
       export std_core.type_traits.is_constant_evaluated
-      export * // TODO: Workaround for https://github.com/llvm/llvm-project/issues/120108
+      export * // TODO: Workaround for https://llvm.org/PR120108
     }
     module uses_allocator                     { header "__memory/uses_allocator.h" }
     module uses_allocator_construction        { header "__memory/uses_allocator_construction.h" }
@@ -1721,7 +1721,7 @@ module std [system] {
     module allocate {
       header "__new/allocate.h"
       export std.utility.element_count // used as part of the API
-      export * // TODO: Workaround for https://github.com/llvm/llvm-project/issues/120108
+      export * // TODO: Workaround for https://llvm.org/PR120108
     }
     module destroying_delete_t  { header "__new/destroying_delete_t.h" }
     module exceptions           { header "__new/exceptions.h" }

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2258,7 +2258,7 @@ private:
     (void)__new_mid;
 #  if _LIBCPP_INSTRUMENTED_WITH_ASAN
 #    if defined(__APPLE__)
-    // TODO: remove after addressing issue #96099 (https://github.com/llvm/llvm-project/issues/96099)
+    // TODO: remove after addressing issue #96099 (https://llvm.org/PR96099)
     if (!__is_long())
       return;
 #    endif

--- a/libcxx/include/string_view
+++ b/libcxx/include/string_view
@@ -460,7 +460,7 @@ public:
   _LIBCPP_CONSTEXPR _LIBCPP_HIDE_FROM_ABI basic_string_view substr(size_type __pos = 0, size_type __n = npos) const {
     // Use the `__assume_valid` form of the constructor to avoid an unnecessary check. Any substring of a view is a
     // valid view. In particular, `size()` is known to be smaller than `numeric_limits<difference_type>::max()`, so the
-    // new size is also smaller. See also https://github.com/llvm/llvm-project/issues/91634.
+    // new size is also smaller. See also https://llvm.org/PR91634.
     return __pos > size() ? (__throw_out_of_range("string_view::substr"), basic_string_view())
                           : basic_string_view(__assume_valid(), data() + __pos, std::min(__n, size() - __pos));
   }

--- a/libcxx/src/atomic.cpp
+++ b/libcxx/src/atomic.cpp
@@ -152,7 +152,7 @@ static void __libcpp_contention_wait(__cxx_atomic_contention_t volatile* __conte
                                      __cxx_atomic_contention_t const volatile* __platform_state,
                                      __cxx_contention_t __old_value) {
   __cxx_atomic_fetch_add(__contention_state, __cxx_contention_t(1), memory_order_relaxed);
-  // https://github.com/llvm/llvm-project/issues/109290
+  // https://llvm.org/PR109290
   // There are no platform guarantees of a memory barrier in the platform wait implementation
   __cxx_atomic_thread_fence(memory_order_seq_cst);
   // We sleep as long as the monitored value hasn't changed.

--- a/libcxx/src/experimental/tzdb.cpp
+++ b/libcxx/src/experimental/tzdb.cpp
@@ -766,7 +766,7 @@ void __init_tzdb(tzdb& __tzdb, __tz::__rules_storage_type& __rules) {
   // On Linux systems it seems /etc/timezone is deprecated and being phased out.
   // This file is used when /etc/localtime does not exist, or when it exists but
   // is not a symlink. For more information and links see
-  // https://github.com/llvm/llvm-project/issues/105634
+  // https://llvm.org/PR105634
 
   string __name = chrono::__current_zone_environment();
 

--- a/libcxx/test/extensions/posix/xopen_source.gen.py
+++ b/libcxx/test/extensions/posix/xopen_source.gen.py
@@ -10,7 +10,7 @@
 # We may not want to guarantee this forever, but since this works today and
 # it's something that users rely on, it makes sense to put a test on it.
 #
-# https://github.com/llvm/llvm-project/issues/117630
+# https://llvm.org/PR117630
 
 # RUN: %{python} %s %{libcxx-dir}/utils
 # END.

--- a/libcxx/test/libcxx-03/containers/associative/reference_comparator_abi.compile.pass.cpp
+++ b/libcxx/test/libcxx-03/containers/associative/reference_comparator_abi.compile.pass.cpp
@@ -15,7 +15,7 @@
 // If we decide to make reference comparators ill-formed, this test would become
 // unnecessary.
 //
-// See https://github.com/llvm/llvm-project/issues/118559 for more details.
+// See https://llvm.org/PR118559 for more details.
 
 #include <set>
 #include <map>

--- a/libcxx/test/libcxx-03/iterators/contiguous_iterators.verify.cpp
+++ b/libcxx/test/libcxx-03/iterators/contiguous_iterators.verify.cpp
@@ -14,7 +14,7 @@
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
 
 // Verify that __bounded_iter does not accept non-contiguous iterators as determined by __libcpp_is_contiguous_iterator.
-// static_assert should be used, see https://github.com/llvm/llvm-project/issues/115002.
+// static_assert should be used, see https://llvm.org/PR115002.
 // __wrap_iter cannot be so handled because it may directly wrap user-defined fancy pointers in libc++'s vector.
 
 #include <deque>

--- a/libcxx/test/libcxx-03/numerics/complex.number/cmplx.over.pow.pass.cpp
+++ b/libcxx/test/libcxx-03/numerics/complex.number/cmplx.over.pow.pass.cpp
@@ -15,7 +15,7 @@
 //  template<class T, class U> complex<__promote_t<T, U>> pow(const T&, const complex<U>&);
 
 // Test that these additional overloads are free from catching std::complex<non-floating-point>,
-// which is expected by several 3rd party libraries, see https://github.com/llvm/llvm-project/issues/109858.
+// which is expected by several 3rd party libraries, see https://llvm.org/PR109858.
 //
 // Note that we reserve the right to break this in the future if we have a reason to, but for the time being,
 // make sure we don't break this property unintentionally.

--- a/libcxx/test/libcxx-03/vendor/apple/disable-availability.sh.cpp
+++ b/libcxx/test/libcxx-03/vendor/apple/disable-availability.sh.cpp
@@ -13,7 +13,7 @@
 // UNSUPPORTED: apple-clang-15
 
 // This test ensures that we retain a way to disable availability markup on Apple platforms
-// in order to work around Clang bug https://github.com/llvm/llvm-project/issues/134151.
+// in order to work around Clang bug https://llvm.org/PR134151.
 //
 // Once that bug has been fixed or once we've made changes to libc++'s use of availability
 // that render that workaround unnecessary, the macro and this test can be removed.

--- a/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_nontrivial.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/alg.modifying.operations/copy_move_nontrivial.pass.cpp
@@ -314,7 +314,7 @@ constexpr bool test() {
   test_copy_and_move<int*, const int*>();
 
   // `memmove` does not support volatile pointers.
-  // (See also https://github.com/llvm/llvm-project/issues/28901).
+  // (See also https://llvm.org/PR28527).
   if (!std::is_constant_evaluated()) {
     test_both_directions<volatile int, int>();
     test_both_directions<volatile int, volatile int>();

--- a/libcxx/test/libcxx/algorithms/callable-requirements-rvalue.compile.pass.cpp
+++ b/libcxx/test/libcxx/algorithms/callable-requirements-rvalue.compile.pass.cpp
@@ -14,8 +14,7 @@
 // but not rvalue callable to algorithms. While it is technically ill-formed for users
 // to provide us such predicates, this test is useful for libc++ to ensure that we check
 // predicate requirements correctly (i.e. that we check them on lvalues and not on
-// rvalues). See https://github.com/llvm/llvm-project/issues/69554 for additional
-// context.
+// rvalues). See https://llvm.org/PR69554 for additional context.
 
 #include <algorithm>
 

--- a/libcxx/test/libcxx/atomics/atomics.syn/wait.issue_85107.pass.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.syn/wait.issue_85107.pass.cpp
@@ -15,9 +15,8 @@
 
 // XFAIL: availability-synchronization_library-missing
 
-// This is a regression test for https://github.com/llvm/llvm-project/issues/85107, which describes
-// how we were using UL_COMPARE_AND_WAIT instead of UL_COMPARE_AND_WAIT64 in the implementation of
-// atomic::wait, leading to potential infinite hangs.
+// This is a regression test for https://llvm.org/PR85107, which describes how we were using UL_COMPARE_AND_WAIT instead
+// of UL_COMPARE_AND_WAIT64 in the implementation of atomic::wait, leading to potential infinite hangs.
 
 #include <atomic>
 #include <cassert>
@@ -36,7 +35,7 @@ int main(int, char**) {
       }
     });
 
-    // https://github.com/llvm/llvm-project/issues/85107
+    // https://llvm.org/PR85107
     // [libc++] atomic_wait uses UL_COMPARE_AND_WAIT when it should use UL_COMPARE_AND_WAIT64 on Darwin
     constexpr std::__cxx_contention_t old_val = 0;
     constexpr std::__cxx_contention_t new_val = old_val + (1ll << 32);

--- a/libcxx/test/libcxx/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
+++ b/libcxx/test/libcxx/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
@@ -44,7 +44,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/libcxx/containers/associative/reference_comparator_abi.compile.pass.cpp
+++ b/libcxx/test/libcxx/containers/associative/reference_comparator_abi.compile.pass.cpp
@@ -15,7 +15,7 @@
 // If we decide to make reference comparators ill-formed, this test would become
 // unnecessary.
 //
-// See https://github.com/llvm/llvm-project/issues/118559 for more details.
+// See https://https://llvm.org/PR118559 for more details.
 
 #include <set>
 #include <map>

--- a/libcxx/test/libcxx/containers/container.adaptors/flat.multiset/insert.temporary.pass.cpp
+++ b/libcxx/test/libcxx/containers/container.adaptors/flat.multiset/insert.temporary.pass.cpp
@@ -10,7 +10,7 @@
 
 // <flat_set>
 
-// https://github.com/llvm/llvm-project/issues/119016
+// https://https://llvm.org/PR119016
 
 #include <flat_set>
 

--- a/libcxx/test/libcxx/containers/container.adaptors/flat.multiset/insert_range.pass.cpp
+++ b/libcxx/test/libcxx/containers/container.adaptors/flat.multiset/insert_range.pass.cpp
@@ -14,7 +14,7 @@
 // As an extension, libc++ flat containers support inserting a non forward range into
 // a pre-C++23 container that doesn't provide insert_range(...), since many containers
 // out there are in that situation.
-// https://github.com/llvm/llvm-project/issues/136656
+// https://https://llvm.org/PR136656
 
 #include <algorithm>
 #include <cassert>

--- a/libcxx/test/libcxx/containers/container.adaptors/flat.set/insert.temporary.pass.cpp
+++ b/libcxx/test/libcxx/containers/container.adaptors/flat.set/insert.temporary.pass.cpp
@@ -10,7 +10,7 @@
 
 // <flat_set>
 
-// https://github.com/llvm/llvm-project/issues/119016
+// https://llvm.org/PR119016
 
 #include <flat_set>
 

--- a/libcxx/test/libcxx/containers/container.adaptors/flat.set/insert_range.pass.cpp
+++ b/libcxx/test/libcxx/containers/container.adaptors/flat.set/insert_range.pass.cpp
@@ -13,8 +13,7 @@
 
 // As an extension, libc++ flat containers support inserting a non forward range into
 // a pre-C++23 container that doesn't provide insert_range(...), since many containers
-// out there are in that situation.
-// https://github.com/llvm/llvm-project/issues/136656
+// out there are in that situation. See https://llvm.org/PR136656
 
 #include <algorithm>
 #include <cassert>

--- a/libcxx/test/libcxx/containers/strings/basic.string/asan_turning_off.pass.cpp
+++ b/libcxx/test/libcxx/containers/strings/basic.string/asan_turning_off.pass.cpp
@@ -16,7 +16,7 @@
 // This test confirms that those allocators work after turning off annotations.
 //
 // A context to this test is a situations when memory is repurposed and destructors are not called.
-//   Related issue: https://github.com/llvm/llvm-project/issues/60384
+//   Related issue: https://llvm.org/PR60384
 //
 // That issue appeared in the past and was addressed here: https://reviews.llvm.org/D145628
 //

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.ctor.layout_stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_left/assert.ctor.layout_stride.pass.cpp
@@ -12,7 +12,7 @@
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // ADDITIONAL_COMPILE_FLAGS: -Wno-ctad-maybe-unsupported
 
-// FIXME: https://github.com/llvm/llvm-project/issues/64719
+// FIXME: https://llvm.org/PR64719
 // There appear to be some issues around ctad which make it
 // currently impossible to get this code warning free.
 // Thus added the additional compile flag above

--- a/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.ctor.layout_stride.pass.cpp
+++ b/libcxx/test/libcxx/containers/views/mdspan/layout_right/assert.ctor.layout_stride.pass.cpp
@@ -12,7 +12,7 @@
 // XFAIL: libcpp-hardening-mode=debug && availability-verbose_abort-missing
 // ADDITIONAL_COMPILE_FLAGS: -Wno-ctad-maybe-unsupported
 
-// FIXME: https://github.com/llvm/llvm-project/issues/64719
+// FIXME: https://llvm.org/PR64719
 // There appear to be some issues around ctad which make it
 // currently impossible to get this code warning free.
 // Thus added the additional compile flag above

--- a/libcxx/test/libcxx/input.output/iostream.format/output.streams/ostream.syn/includes.compile.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/output.streams/ostream.syn/includes.compile.pass.cpp
@@ -18,7 +18,7 @@
 // However using the granularized headers so it's possible to implement
 // <ostream> without <format>. This would be a non-conforming implementation.
 //
-// See https://github.com/llvm/llvm-project/issues/71925
+// See https://llvm.org/PR71925
 
 #include <ostream>
 #include <vector>

--- a/libcxx/test/libcxx/iterators/contiguous_iterators.verify.cpp
+++ b/libcxx/test/libcxx/iterators/contiguous_iterators.verify.cpp
@@ -12,7 +12,7 @@
 // __bounded_iter<_Iter>
 
 // Verify that __bounded_iter does not accept non-contiguous iterators as determined by __libcpp_is_contiguous_iterator.
-// static_assert should be used, see https://github.com/llvm/llvm-project/issues/115002.
+// static_assert should be used, see https://llvm.org/PR115002.
 // __wrap_iter cannot be so handled because it may directly wrap user-defined fancy pointers in libc++'s vector.
 
 #include <deque>

--- a/libcxx/test/libcxx/numerics/complex.number/cmplx.over.pow.pass.cpp
+++ b/libcxx/test/libcxx/numerics/complex.number/cmplx.over.pow.pass.cpp
@@ -13,7 +13,7 @@
 //  template<class T, class U> complex<__promote_t<T, U>> pow(const T&, const complex<U>&);
 
 // Test that these additional overloads are free from catching std::complex<non-floating-point>,
-// which is expected by several 3rd party libraries, see https://github.com/llvm/llvm-project/issues/109858.
+// which is expected by several 3rd party libraries, see https://llvm.org/PR109858.
 //
 // Note that we reserve the right to break this in the future if we have a reason to, but for the time being,
 // make sure we don't break this property unintentionally.

--- a/libcxx/test/libcxx/utilities/expected/expected.expected/transform_error.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.expected/transform_error.mandates.verify.cpp
@@ -15,7 +15,7 @@
 //
 // TODO(LLVM 22): Remove '0-1' from 'expected-error-re@*:* 0-1 {{union member {{.*}} has reference type {{.*}}}}'
 // and remove 'expected-warning-re@*:* 0-1 {{union member {{.*}} has reference type {{.*}}, which is a Microsoft extension}}'
-// once LLVM 22 releases. See https://github.com/llvm/llvm-project/issues/104885.
+// once LLVM 22 releases. See https://llvm.org/PR104885.
 
 // Test the mandates
 

--- a/libcxx/test/libcxx/utilities/expected/expected.void/transform_error.mandates.verify.cpp
+++ b/libcxx/test/libcxx/utilities/expected/expected.void/transform_error.mandates.verify.cpp
@@ -16,7 +16,7 @@
 // TODO(LLVM 22): Remove '0-1' from 'expected-error-re@*:* 0-1 {{union member {{.*}} has reference type {{.*}}}}'
 // and remove 'expected-warning-re@*:* 0-1 {{union member {{.*}} has reference type {{.*}}, which is a Microsoft extension}}'
 // and remove 'expected-error-re@*:* 0-1 {{call to deleted constructor of {{.*}}}}'
-// once LLVM 22 releases. See See https://github.com/llvm/llvm-project/issues/104885.
+// once LLVM 22 releases. See See https://llvm.org/PR104885.
 
 // Test the mandates
 

--- a/libcxx/test/libcxx/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/libcxx/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_underaligned_buffer.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_underaligned_buffer.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/libcxx/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/libcxx/utilities/utility/mem.res/mem.res.pool/unsynchronized_buffer.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/mem.res/mem.res.pool/unsynchronized_buffer.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/libcxx/utilities/utility/mem.res/pmr.availability.verify.cpp
+++ b/libcxx/test/libcxx/utilities/utility/mem.res/pmr.availability.verify.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14
 // REQUIRES: availability-pmr-missing
 
-// TODO: This test doesn't work until https://github.com/llvm/llvm-project/issues/40340
+// TODO: This test doesn't work until https://llvm.org/PR40995
 //       has been fixed, because we actually disable availability markup.
 // XFAIL: *
 

--- a/libcxx/test/libcxx/vendor/apple/disable-availability.sh.cpp
+++ b/libcxx/test/libcxx/vendor/apple/disable-availability.sh.cpp
@@ -9,7 +9,7 @@
 // REQUIRES: stdlib=apple-libc++
 
 // This test ensures that we retain a way to disable availability markup on Apple platforms
-// in order to work around Clang bug https://github.com/llvm/llvm-project/issues/134151.
+// in order to work around Clang bug https://llvm.org/PR134151.
 //
 // Once that bug has been fixed or once we've made changes to libc++'s use of availability
 // that render that workaround unnecessary, the macro and this test can be removed.

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/copy.pass.cpp
@@ -114,7 +114,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
   // Validate std::copy with std::vector<bool> iterators and custom storage types.
   // Ensure that assigned bits hold the intended values, while unassigned bits stay unchanged.
-  // Related issue: https://github.com/llvm/llvm-project/issues/131692.
+  // Related issue: https://llvm.org/PR131692.
   {
     //// Tests for std::copy with aligned bits
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/copy_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/copy_backward.pass.cpp
@@ -116,7 +116,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
   // Validate std::copy_backward with std::vector<bool> iterators and custom storage types.
   // Ensure that assigned bits hold the intended values, while unassigned bits stay unchanged.
-  // Related issue: https://github.com/llvm/llvm-project/issues/131718.
+  // Related issue: https://llvm.org/PR131718.
   {
     //// Tests for std::copy_backward with aligned bits
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy.pass.cpp
@@ -241,7 +241,7 @@ constexpr bool test() {
 
   // Validate std::ranges::copy with std::vector<bool> iterators and custom storage types.
   // Ensure that assigned bits hold the intended values, while unassigned bits stay unchanged.
-  // Related issue: https://github.com/llvm/llvm-project/issues/131692.
+  // Related issue: https://llvm.org/PR131692.
   {
     //// Tests for std::ranges::copy with aligned bits
 

--- a/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.modifying.operations/alg.copy/ranges.copy_backward.pass.cpp
@@ -359,7 +359,7 @@ constexpr bool test() {
 
   // Validate std::ranges::copy_backward with std::vector<bool> iterators and custom storage types.
   // Ensure that assigned bits hold the intended values, while unassigned bits stay unchanged.
-  // Related issue: https://github.com/llvm/llvm-project/issues/131718.
+  // Related issue: https://llvm.org/PR131718.
   {
     //// Tests for std::ranges::copy_backward with aligned bits
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/count.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/count.pass.cpp
@@ -56,7 +56,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
     }
 
     // Fix std::count for std::vector<bool> with small storage types, e.g., std::uint16_t, unsigned short.
-    // See https://github.com/llvm/llvm-project/issues/122528
+    // See https://llvm.org/PR122528
     {
       using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
       std::vector<bool, Alloc> in(100, true, Alloc(1));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/ranges.count.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.count/ranges.count.pass.cpp
@@ -285,7 +285,7 @@ constexpr bool test() {
     }
 
     // Fix std::ranges::count for std::vector<bool> with small storage types, e.g., std::uint16_t, unsigned short.
-    // See https://github.com/llvm/llvm-project/issues/122528
+    // See https://llvm.org/PR122528
     {
       using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
       std::vector<bool, Alloc> in(100, true, Alloc(1));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/equal.pass.cpp
@@ -178,7 +178,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
   }
 
   // Make sure std::equal behaves properly with std::vector<bool> iterators with custom size types.
-  // See issue: https://github.com/llvm/llvm-project/issues/126369.
+  // See issue: https://llvm.org/PR126369.
   {
     //// Tests for std::equal with aligned bits
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.equal/ranges.equal.pass.cpp
@@ -446,7 +446,7 @@ constexpr bool test() {
   }
 
   // Make sure std::equal behaves properly with std::vector<bool> iterators with custom size types.
-  // See issue: https://github.com/llvm/llvm-project/issues/126369.
+  // See issue: https://llvm.org/PR126369.
   {
     //// Tests for std::equal with aligned bits
 

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/find.pass.cpp
@@ -244,7 +244,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
     }
 
     // Verify that the std::vector<bool>::iterator optimization works properly for allocators with custom size types
-    // Fix https://github.com/llvm/llvm-project/issues/122528
+    // Fix https://llvm.org/PR122528
     {
       using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
       std::vector<bool, Alloc> in(100, false, Alloc(1));

--- a/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
+++ b/libcxx/test/std/algorithms/alg.nonmodifying/alg.find/ranges.find.pass.cpp
@@ -219,7 +219,7 @@ constexpr bool test() {
     }
 
     // Verify that the std::vector<bool>::iterator optimization works properly for allocators with custom size types
-    // See https://github.com/llvm/llvm-project/issues/122528
+    // See https://llvm.org/PR122528
     {
       using Alloc = sized_allocator<bool, std::uint8_t, std::int8_t>;
       std::vector<bool, Alloc> in(100, false, Alloc(1));

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/assign.pass.cpp
@@ -56,7 +56,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_strong.pass.cpp
@@ -219,7 +219,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/compare_exchange_weak.pass.cpp
@@ -67,7 +67,7 @@ void testBasic(MemoryOrder... memory_order) {
     assert(a.load() == T(1.2));
 
     // bug
-    // TODO https://github.com/llvm/llvm-project/issues/47978
+    // TODO https://llvm.org/PR48634
     if constexpr (!std::same_as<T, long double>) {
       assert(expected == T(1.2));
     }
@@ -235,7 +235,7 @@ int main(int, char**) {
   test<float>();
   test<double>();
 
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/ctor.pass.cpp
@@ -55,7 +55,7 @@ constexpr void testOne() {
 constexpr bool test() {
   testOne<float>();
   testOne<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // testOne<long double>();
   return true;
 }

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/exchange.pass.cpp
@@ -69,7 +69,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_add.pass.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: !has-64-bit-atomics
 
-// https://github.com/llvm/llvm-project/issues/72893
+// https://llvm.org/PR72893
 // XFAIL: target={{x86_64-.*}} && tsan
 
 // floating-point-type fetch_add(floating-point-type,
@@ -112,7 +112,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/fetch_sub.pass.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 // XFAIL: !has-64-bit-atomics
 
-// https://github.com/llvm/llvm-project/issues/72893
+// https://llvm.org/PR72893
 // XFAIL: target={{x86_64-.*}} && tsan
 
 // floating-point-type fetch_sub(floating-point-type,
@@ -113,7 +113,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/load.pass.cpp
@@ -132,7 +132,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/lockfree.pass.cpp
@@ -54,7 +54,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_all.pass.cpp
@@ -92,7 +92,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/notify_one.pass.cpp
@@ -76,7 +76,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.float.pass.cpp
@@ -52,7 +52,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.minus_equals.pass.cpp
@@ -95,7 +95,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/operator.plus_equals.pass.cpp
@@ -95,7 +95,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/store.pass.cpp
@@ -106,7 +106,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
+++ b/libcxx/test/std/atomics/atomics.types.generic/atomics.types.float/wait.pass.cpp
@@ -117,7 +117,7 @@ void test() {
 int main(int, char**) {
   test<float>();
   test<double>();
-  // TODO https://github.com/llvm/llvm-project/issues/47978
+  // TODO https://llvm.org/PR48634
   // test<long double>();
 
   return 0;

--- a/libcxx/test/std/containers/sequences/deque/deque.cons/from_range.pass.cpp
+++ b/libcxx/test/std/containers/sequences/deque/deque.cons/from_range.pass.cpp
@@ -28,7 +28,7 @@ int main(int, char**) {
   static_assert(test_constraints<std::deque, int, double>());
 
   // TODO(varconst): `deque`'s constructors currently aren't exception-safe.
-  // See https://github.com/llvm/llvm-project/issues/62056.
+  // See https://llvm.org/PR62056.
   //test_exception_safety_throwing_copy<std::deque>();
   //test_exception_safety_throwing_allocator<std::deque, int>();
 

--- a/libcxx/test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/shrink_to_fit.pass.cpp
@@ -80,7 +80,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
 }
 
 #if TEST_STD_VER >= 23
-// https://github.com/llvm/llvm-project/issues/95161
+// https://llvm.org/PR95161
 constexpr bool test_increasing_allocator() {
   std::vector<bool, increasing_allocator<bool>> v;
   v.push_back(1);

--- a/libcxx/test/std/containers/sequences/vector.bool/small_allocator_size.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector.bool/small_allocator_size.pass.cpp
@@ -12,7 +12,7 @@
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
 
 // This test ensures that std::vector<bool> handles allocator types with small size types
-// properly. Related issue: https://github.com/llvm/llvm-project/issues/121713.
+// properly. Related issue: https://llvm.org/PR121713.
 
 #include <cassert>
 #include <cstddef>

--- a/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.capacity/shrink_to_fit.pass.cpp
@@ -74,7 +74,7 @@ TEST_CONSTEXPR_CXX20 bool tests() {
 }
 
 #if TEST_STD_VER >= 23
-// https://github.com/llvm/llvm-project/issues/95161
+// https://llvm.org/PR95161
 constexpr bool test_increasing_allocator() {
   std::vector<int, increasing_allocator<int>> v;
   v.push_back(1);

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter.pass.cpp
@@ -79,7 +79,7 @@ TEST_CONSTEXPR_CXX20 void basic_test_cases() {
   test<std::vector<int, safe_allocator<int> > >(
       random_access_iterator<const int*>(a), random_access_iterator<const int*>(an));
 
-  // Regression test for https://github.com/llvm/llvm-project/issues/46841
+  // Regression test for https://llvm.org/PR47497
   {
     std::vector<int> v1({}, forward_iterator<const int*>{});
     std::vector<int> v2(forward_iterator<const int*>{}, {});

--- a/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp
+++ b/libcxx/test/std/containers/sequences/vector/vector.cons/construct_iter_iter_alloc.pass.cpp
@@ -90,7 +90,7 @@ TEST_CONSTEXPR_CXX20 void basic_tests() {
     test<std::vector<int, safe_allocator<int> > >(a, an, alloc);
   }
 
-  // Regression test for https://github.com/llvm/llvm-project/issues/46841
+  // Regression test for https://llvm.org/PR47497
   {
     min_allocator<int> alloc;
     std::vector<int, min_allocator<int> > v1({}, forward_iterator<const int*>{}, alloc);

--- a/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
+++ b/libcxx/test/std/containers/views/mdspan/mdspan/conversion.pass.cpp
@@ -232,7 +232,7 @@ int main(int, char**) {
   test<t, o, t, t, t, t, t, t, conv_test_accessor_c<int, t, t, o, o>>(conv_test_accessor_nc<int, t, o>());
 // FIXME: these tests trigger what appears to be a compiler bug on MINGW32 with --target=x86_64-w64-windows-gnu
 // https://godbolt.org/z/KK8aj5bs7
-// Bug report: https://github.com/llvm/llvm-project/issues/64077
+// Bug report: https://llvm.org/PR64077
 #ifndef __MINGW32__
   test<t, t, t, o, t, t, t, t, conv_test_accessor_c<int, o, t, t, t>>(conv_test_accessor_nc<int, t, t>());
   test<t, t, t, t, t, t, t, t, conv_test_accessor_c<int, o, o, o, o>>(conv_test_accessor_nc<int, t, o>());

--- a/libcxx/test/std/containers/views/views.span/span.cons/copy.pass.cpp
+++ b/libcxx/test/std/containers/views/views.span/span.cons/copy.pass.cpp
@@ -95,7 +95,7 @@ constexpr bool test_all() {
   test<std::string>();
   test<const std::string>();
 
-  // Regression test for https://github.com/llvm/llvm-project/issues/104496
+  // Regression test for https://llvm.org/PR104496
   {
     struct Incomplete;
     std::span<Incomplete> x;

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcode/syserr.errcode.constructors/lwg3629.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcode/syserr.errcode.constructors/lwg3629.pass.cpp
@@ -12,7 +12,7 @@
 
 // template <ErrorCodeEnum E> error_code(E e);
 
-// Regression test for https://github.com/llvm/llvm-project/issues/57614
+// Regression test for https://llvm.org/PR57614
 
 int make_error_code; // It's important that this comes before <system_error>
 

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcode/syserr.errcode.modifiers/lwg3629.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcode/syserr.errcode.modifiers/lwg3629.pass.cpp
@@ -12,7 +12,7 @@
 
 // template <ErrorCodeEnum E> error_code& operator=(E e);
 
-// Regression test for https://github.com/llvm/llvm-project/issues/57614
+// Regression test for https://llvm.org/PR57614
 
 int make_error_code; // It's important that this comes before <system_error>
 

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcondition/syserr.errcondition.constructors/lwg3629.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcondition/syserr.errcondition.constructors/lwg3629.pass.cpp
@@ -12,7 +12,7 @@
 
 // template <ErrorCodeEnum E> error_condition(E e);
 
-// Regression test for https://github.com/llvm/llvm-project/issues/57614
+// Regression test for https://llvm.org/PR57614
 
 int make_error_condition; // It's important that this comes before <system_error>
 

--- a/libcxx/test/std/diagnostics/syserr/syserr.errcondition/syserr.errcondition.modifiers/lwg3629.pass.cpp
+++ b/libcxx/test/std/diagnostics/syserr/syserr.errcondition/syserr.errcondition.modifiers/lwg3629.pass.cpp
@@ -12,7 +12,7 @@
 
 // template <ErrorCodeEnum E> error_condition& operator=(E e);
 
-// Regression test for https://github.com/llvm/llvm-project/issues/57614
+// Regression test for https://llvm.org/PR57614
 
 int make_error_condition; // It's important that this comes before <system_error>
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.assign/nonmember_swap_min.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.assign/nonmember_swap_min.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // This tests that swapping filebufs works correctly even when the small buffer
-// optimization is in use (https://github.com/llvm/llvm-project/issues/49282).
+// optimization is in use (https://llvm.org/PR49938).
 
 // <fstream>
 

--- a/libcxx/test/std/input.output/file.streams/fstreams/filebuf.virtuals/setbuf.pass.cpp
+++ b/libcxx/test/std/input.output/file.streams/fstreams/filebuf.virtuals/setbuf.pass.cpp
@@ -13,7 +13,7 @@
 
 // basic_streambuf<charT, traits>* setbuf(char_type* s, streamsize n) override;
 
-// This test requires the fix to https://github.com/llvm/llvm-project/issues/60509 in the dylib,
+// This test requires the fix to https://llvm.org/PR60509 in the dylib,
 // which landed in 5afb937d8a30445642ccaf33866ee4cdd0713222.
 // XFAIL: using-built-library-before-llvm-19
 

--- a/libcxx/test/std/input.output/iostream.format/print.fun/includes.compile.pass.cpp
+++ b/libcxx/test/std/input.output/iostream.format/print.fun/includes.compile.pass.cpp
@@ -18,7 +18,7 @@
 // using the granularized headers so it's possible to implement <print> without
 // <format>. This would be a non-conforming implementation.
 //
-// See https://github.com/llvm/llvm-project/issues/71925
+// See https://llvm.org/PR71925
 
 #include <print>
 #include <vector>

--- a/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
+++ b/libcxx/test/std/input.output/iostreams.base/ios.base/ios.types/ios_Init/ios_Init.global.pass.cpp
@@ -8,7 +8,7 @@
 
 #include <iostream>
 
-// FIXME: Remove after issue https://github.com/llvm/llvm-project/issues/127348 resolved.
+// FIXME: Remove after issue https://llvm.org/PR127348 resolved.
 extern "C" const char* __asan_default_options() { return "check_initialization_order=true:strict_init_order=true"; }
 
 // Test that ios used from globals constructors doesn't trigger Asan initialization-order-fiasco.

--- a/libcxx/test/std/input.output/string.streams/istringstream/istringstream.members/str.allocator_propagation.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/istringstream/istringstream.members/str.allocator_propagation.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // This test ensures that we properly propagate allocators from istringstream's

--- a/libcxx/test/std/input.output/string.streams/ostringstream/ostringstream.members/str.allocator_propagation.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/ostringstream/ostringstream.members/str.allocator_propagation.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // This test ensures that we properly propagate allocators from ostringstream's

--- a/libcxx/test/std/input.output/string.streams/stringstream/stringstream.members/str.allocator_propagation.pass.cpp
+++ b/libcxx/test/std/input.output/string.streams/stringstream/stringstream.members/str.allocator_propagation.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // This test ensures that we properly propagate allocators from stringstream's

--- a/libcxx/test/std/numerics/c.math/cmath.pass.cpp
+++ b/libcxx/test/std/numerics/c.math/cmath.pass.cpp
@@ -1210,7 +1210,7 @@ void test_hypot()
     assert(std::hypot(1,4,8) == 9);
 
     // Check for undue over-/underflows of intermediate results.
-    // See discussion at https://github.com/llvm/llvm-project/issues/92782.
+    // See discussion at https://llvm.org/PR92782.
     types::for_each(types::floating_point_types(), TestHypot3());
 #endif
 }

--- a/libcxx/test/std/numerics/complex.number/complex.special/gh_101960_ambiguous_ctor.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex.special/gh_101960_ambiguous_ctor.pass.cpp
@@ -8,8 +8,7 @@
 
 // <complex>
 
-// Regression test for https://github.com/llvm/llvm-project/issues/101960 where we used to
-// trigger an ambiguous constructor.
+// Regression test for https://llvm.org/PR101960 where we used to trigger an ambiguous constructor.
 
 #include <complex>
 #include <cassert>

--- a/libcxx/test/std/numerics/complex.number/complex/bit_cast.pass.cpp
+++ b/libcxx/test/std/numerics/complex.number/complex/bit_cast.pass.cpp
@@ -8,8 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
-// Make sure that std::bit_cast works with std::complex. Test case extracted from
-// https://github.com/llvm/llvm-project/issues/94620.
+// Make sure that std::bit_cast works with std::complex. Test case extracted from https://llvm.org/PR94620.
 
 #include <bit>
 #include <complex>

--- a/libcxx/test/std/numerics/numeric.ops/numeric.ops.lcm/lcm.pass.cpp
+++ b/libcxx/test/std/numerics/numeric.ops/numeric.ops.lcm/lcm.pass.cpp
@@ -149,7 +149,7 @@ int main(int argc, char**)
     assert(res1 == 1324997410816LL);
     }
 
-    // https://github.com/llvm/llvm-project/issues/96196
+    // https://llvm.org/PR96196
     {
         assert(test_limits<unsigned int>());
         assert(test_limits<std::uint32_t>());

--- a/libcxx/test/std/ranges/range.adaptors/range.lazy.split/types.h
+++ b/libcxx/test/std/ranges/range.adaptors/range.lazy.split/types.h
@@ -60,7 +60,7 @@ struct ForwardDiffView : std::ranges::view_base {
   constexpr explicit ForwardDiffView() = default;
   constexpr ForwardDiffView(const char* ptr) : ForwardDiffView(std::string_view(ptr)) {}
   constexpr ForwardDiffView(std::string_view v) {
-    // Workaround https://github.com/llvm/llvm-project/issues/55867
+    // Workaround https://llvm.org/PR55867
     buffer_ = v;
   }
   constexpr ForwardDiffView(ForwardDiffView&&) = default;
@@ -144,7 +144,7 @@ struct InputView : std::ranges::view_base {
   constexpr InputView() = default;
   constexpr InputView(const char* s) : InputView(std::string_view(s)) {}
   constexpr InputView(std::string_view v) {
-    // Workaround https://github.com/llvm/llvm-project/issues/55867
+    // Workaround https://llvm.org/PR55867
     buffer_ = v;
   }
 

--- a/libcxx/test/std/ranges/range.factories/range.iota.view/size.pass.cpp
+++ b/libcxx/test/std/ranges/range.factories/range.iota.view/size.pass.cpp
@@ -91,7 +91,7 @@ constexpr bool test() {
   }
 
   // Make sure iota_view<short, short> works properly. For details,
-  // see https://github.com/llvm/llvm-project/issues/67551.
+  // see https://llvm.org/PR67551.
   {
     static_assert(std::ranges::sized_range<std::ranges::iota_view<short, short>>);
     std::ranges::iota_view<short, short> io(10, 20);

--- a/libcxx/test/std/ranges/range.req/range.view/enable_view.compile.pass.cpp
+++ b/libcxx/test/std/ranges/range.req/range.view/enable_view.compile.pass.cpp
@@ -146,7 +146,7 @@ static_assert(!std::ranges::enable_view<const PrivateInherit>);
 static_assert(!std::ranges::enable_view<volatile PrivateInherit>);
 static_assert(!std::ranges::enable_view<const volatile PrivateInherit>);
 
-// https://github.com/llvm/llvm-project/issues/132577
+// https://llvm.org/PR132577
 // enable_view<view_interface<T>> should be false.
 static_assert(!std::ranges::enable_view<std::ranges::view_interface<V1>>);
 static_assert(!std::ranges::enable_view<const std::ranges::view_interface<V1>>);

--- a/libcxx/test/std/ranges/ranges_robust_against_no_unique_address.pass.cpp
+++ b/libcxx/test/std/ranges/ranges_robust_against_no_unique_address.pass.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
 // Test that views that use __movable_box do not overwrite overlapping subobjects.
-// https://github.com/llvm/llvm-project/issues/70506
+// https://llvm.org/PR70506
 
 #include <cassert>
 #include <ranges>

--- a/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.capacity/shrink_to_fit.pass.cpp
@@ -63,7 +63,7 @@ TEST_CONSTEXPR_CXX20 bool test() {
 
 #if TEST_STD_VER >= 23
   { // Make sure shrink_to_fit never increases capacity
-    // See: https://github.com/llvm/llvm-project/issues/95161
+    // See: https://llvm.org/PR95161
     std::basic_string<char, std::char_traits<char>, increasing_allocator<char>> s{
         "String does not fit in the internal buffer"};
     std::size_t capacity = s.capacity();

--- a/libcxx/test/std/strings/basic.string/string.nonmembers/string_op+/string.string_view.pass.cpp
+++ b/libcxx/test/std/strings/basic.string/string.nonmembers/string_op+/string.string_view.pass.cpp
@@ -120,9 +120,9 @@ constexpr void test(const CharT* x, const CharT* y, const CharT* expected) {
   }
   // string_view + string&&
   {
-    // TODO: Remove workaround once https://github.com/llvm/llvm-project/issues/92382 is fixed.
+    // TODO: Remove workaround once https://llvm.org/PR92382 is fixed.
     // Create a `basic_string` to workaround clang bug:
-    // https://github.com/llvm/llvm-project/issues/92382
+    // https://llvm.org/PR92382
     // Comparison between pointers to a string literal and some other object results in constant evaluation failure.
     if constexpr (std::same_as<StringViewT<CharT, TraitsT>, std::basic_string_view<CharT, TraitsT>>) {
       std::basic_string<CharT, TraitsT, AllocT> st_{x, allocator};

--- a/libcxx/test/std/thread/futures/futures.task/futures.task.members/type.verify.cpp
+++ b/libcxx/test/std/thread/futures/futures.task/futures.task.members/type.verify.cpp
@@ -12,7 +12,7 @@
 // <future>
 
 // Verify that the non-conforming extension packaged_task::result_type is removed.
-// See https://github.com/llvm/llvm-project/issues/112856.
+// See https://llvm.org/PR112856.
 
 #include <future>
 

--- a/libcxx/test/std/thread/thread.jthread/join.deadlock.pass.cpp
+++ b/libcxx/test/std/thread/thread.jthread/join.deadlock.pass.cpp
@@ -10,7 +10,7 @@
 // it would dead lock the test
 // UNSUPPORTED: windows
 
-// TSAN bug: https://github.com/llvm/llvm-project/issues/66537
+// TSAN bug: https://llvm.org/PR66537
 // UNSUPPORTED: tsan
 
 // UNSUPPORTED: no-threads

--- a/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/cmp.pass.cpp
+++ b/libcxx/test/std/thread/thread.threads/thread.thread.class/thread.thread.id/cmp.pass.cpp
@@ -51,7 +51,7 @@ int main(int, char**) {
   assert(testOrder(id1, id3, isLess ? std::strong_ordering::less : std::strong_ordering::greater));
 #endif
 
-  // Regression tests for https://github.com/llvm/llvm-project/issues/56187
+  // Regression tests for https://llvm.org/PR56187
   // libc++ previously declared the comparison operators as hidden friends
   // which was non-conforming.
   assert(std::operator==(id1, id2));

--- a/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
+++ b/libcxx/test/std/time/time.duration/time.duration.nonmember/ostream.pass.cpp
@@ -215,7 +215,7 @@ static void test_units() {
 
 template <class CharT>
 static void test_unsigned_types() {
-  // Reported in https://github.com/llvm/llvm-project/issues/96820
+  // Reported in https://llvm.org/PR96820
   using namespace std::literals::chrono_literals;
 
   // C locale

--- a/libcxx/test/std/time/time.syn/formatter.duration.pass.cpp
+++ b/libcxx/test/std/time/time.syn/formatter.duration.pass.cpp
@@ -1163,7 +1163,7 @@ static void test_pr62082() {
 
 template <class CharT>
 static void test_unsigned_duration() {
-  // Reported in https://github.com/llvm/llvm-project/issues/96820
+  // Reported in https://llvm.org/PR96820
   using namespace std::literals::chrono_literals;
 
   check(SV("1as"), SV("{}"), std::chrono::duration<unsigned short, std::atto>(1));

--- a/libcxx/test/std/utilities/allocator.adaptor/allocator.adaptor.cnstr/allocs.pass.cpp
+++ b/libcxx/test/std/utilities/allocator.adaptor/allocator.adaptor.cnstr/allocs.pass.cpp
@@ -112,7 +112,7 @@ int main(int, char**) {
         "");
   }
   {
-    // Test construction from convertible-to-allocator types (https://github.com/llvm/llvm-project/issues/78754)
+    // Test construction from convertible-to-allocator types (https://llvm.org/PR78754)
     typedef std::scoped_allocator_adaptor<A1<int>, A1<int>> A;
     A a(A1<char>(4), A1<char>(5));
     assert(a.outer_allocator() == A1<int>(4));

--- a/libcxx/test/std/utilities/allocator.adaptor/base-is-uglified.compile.pass.cpp
+++ b/libcxx/test/std/utilities/allocator.adaptor/base-is-uglified.compile.pass.cpp
@@ -13,7 +13,7 @@
 // This test ensures that we don't use a non-uglified name 'base' in the
 // implementation of scoped_allocator_adaptor.
 //
-// See https://github.com/llvm/llvm-project/issues/78754.
+// See https://llvm.org/PR78754.
 
 #include <memory>
 #include <scoped_allocator>

--- a/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.copy.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/ctor/ctor.copy.pass.cpp
@@ -123,7 +123,7 @@ constexpr bool test() {
   {
     // TODO: Drop this once AppleClang is upgraded
 #ifndef TEST_COMPILER_APPLE_CLANG
-    // https://github.com/llvm/llvm-project/issues/92676
+    // https://llvm.org/PR92676
     std::expected<Any, int> e1;
     auto e2 = e1;
     assert(e2.has_value());

--- a/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
+++ b/libcxx/test/std/utilities/expected/expected.expected/observers/has_value.pass.cpp
@@ -56,7 +56,7 @@ constexpr bool test() {
   // The other tests use a synthetic struct that clobbers its tail padding
   // on construction, making the issue easier to reproduce.
   //
-  // See https://github.com/llvm/llvm-project/issues/68552 and the linked PR.
+  // See https://llvm.org/PR68552 and the linked PR.
   {
     auto f1 = []() -> std::expected<std::optional<int>, long> { return 0; };
 

--- a/libcxx/test/std/utilities/expected/types.h
+++ b/libcxx/test/std/utilities/expected/types.h
@@ -157,7 +157,7 @@ struct MoveOnlyErrorType {
 // tail padding. With this type we can check that `std::expected` handles
 // the case where the "has value" flag is an overlapping subobject correctly.
 //
-// See https://github.com/llvm/llvm-project/issues/68552 for details.
+// See https://llvm.org/PR68552 for details.
 template <int Constant>
 struct TailClobberer {
   constexpr TailClobberer() noexcept {
@@ -200,9 +200,8 @@ static_assert(std::is_nothrow_move_constructible_v<TailClobbererNonTrivialMove<0
 static_assert(!std::is_nothrow_move_constructible_v<TailClobbererNonTrivialMove<0, false>>);
 
 // The `CheckForInvalidWrites` class recreates situations where other objects
-// may be placed into a `std::expected`'s tail padding (see
-// https://github.com/llvm/llvm-project/issues/70494). With a template
-// parameter `WithPaddedExpected` two cases can be tested:
+// may be placed into a `std::expected`'s tail padding (see https://llvm.org/PR70494).
+// With a template parameter `WithPaddedExpected` two cases can be tested:
 //
 // 1. The `std::expected<T, E>` itself has padding, because `T`/`E` _don't_
 //    have tail padding. This is modelled by `CheckForInvalidWrites<true>`

--- a/libcxx/test/std/utilities/format/format.functions/bug_81590.compile.pass.cpp
+++ b/libcxx/test/std/utilities/format/format.functions/bug_81590.compile.pass.cpp
@@ -11,7 +11,7 @@
 // XFAIL: availability-fp_to_chars-missing
 
 // The sample code is based on the bug report
-// https://github.com/llvm/llvm-project/issues/81590
+// https://llvm.org/PR81590
 //
 // Tests whether this formatter does not fail to compile due to nested concept
 // evaluation.

--- a/libcxx/test/std/utilities/format/format.functions/format_tests.h
+++ b/libcxx/test/std/utilities/format/format.functions/format_tests.h
@@ -3190,7 +3190,7 @@ void format_tests(TestFunction check, ExceptionTest check_exception) {
     check(SV("hello 09azAZ!"), SV("hello {}"), data);
   }
   {
-    // https://github.com/llvm/llvm-project/issues/115935
+    // https://llvm.org/PR115935
     // Contents after the embedded null character are discarded.
     CharT buffer[] = {CharT('a'), CharT('b'), CharT('c'), 0, CharT('d'), CharT('e'), CharT('f'), 0};
     check(SV("hello abc"), SV("hello {}"), buffer);

--- a/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uses_allocator_construction_args.pass.cpp
+++ b/libcxx/test/std/utilities/memory/allocator.uses/allocator.uses.construction/uses_allocator_construction_args.pass.cpp
@@ -123,7 +123,7 @@ constexpr void testOne() {
   }
   {
     // Tests for ensuring forward declarations of uses_allocator_construction_args
-    // See https://github.com/llvm/llvm-project/issues/66714.
+    // See https://llvm.org/PR66714.
     {
       using NestedPairType = std::pair<int, std::pair<int, UsesAllocArgT>>;
       std::same_as<std::tuple<

--- a/libcxx/test/std/utilities/memory/pointer.conversion/to_address.pass.cpp
+++ b/libcxx/test/std/utilities/memory/pointer.conversion/to_address.pass.cpp
@@ -153,7 +153,7 @@ constexpr bool test() {
     assert(std::to_address(&p11) == &p11);
     ASSERT_SAME_TYPE(decltype(std::to_address(&p11)), int(**)());
 
-    // See https://github.com/llvm/llvm-project/issues/67449
+    // See https://llvm.org/PR67449
     {
         struct S { };
         S* p = nullptr;

--- a/libcxx/test/std/utilities/memory/specialized.algorithms/overload_compare_iterator.h
+++ b/libcxx/test/std/utilities/memory/specialized.algorithms/overload_compare_iterator.h
@@ -19,7 +19,7 @@
 // An iterator type that overloads operator== and operator!= without any constraints, which
 // can trip up some algorithms if we compare iterators against types that we're not allowed to.
 //
-// See https://github.com/llvm/llvm-project/issues/69334 for details.
+// See https://llvm.org/PR69334 for details.
 template <class Iterator>
 struct overload_compare_iterator {
   static_assert(

--- a/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.const/pr40459.pass.cpp
+++ b/libcxx/test/std/utilities/memory/util.smartptr/util.smartptr.weak/util.smartptr.weak.const/pr40459.pass.cpp
@@ -13,7 +13,7 @@
 // template<class Y> weak_ptr(const weak_ptr<Y>& r);
 // template<class Y> weak_ptr(weak_ptr<Y>&& r);
 //
-// Regression test for https://github.com/llvm/llvm-project/issues/40459
+// Regression test for https://llvm.org/PR41114
 // Verify that these constructors never attempt a derived-to-virtual-base
 // conversion on a dangling weak_ptr.
 

--- a/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
+++ b/libcxx/test/std/utilities/meta/meta.unary/meta.unary.prop/has_unique_object_representations.compile.pass.cpp
@@ -95,7 +95,7 @@ void test() {
   test<true, char[][2]>();
   test<true, char[][2][3]>();
 
-  // Important test case for https://github.com/llvm/llvm-project/issues/95311.
+  // Important test case for https://llvm.org/PR95311.
   // Note that the order is important here, we want to instantiate the array
   // variants before the non-array ones, otherwise we don't trigger the bug.
   {

--- a/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/gh_101960_internal_ctor.compile.pass.cpp
+++ b/libcxx/test/std/utilities/optional/optional.object/optional.object.ctor/gh_101960_internal_ctor.compile.pass.cpp
@@ -10,7 +10,7 @@
 
 // <optional>
 
-// Regression test for https://github.com/llvm/llvm-project/issues/101960 where a constructor
+// Regression test for https://llvm.org/PR101960 where a constructor
 // of std::optional that should have been private was instead publicly available.
 
 #include <optional>

--- a/libcxx/test/std/utilities/template.bitset/bitset.cons/char_ptr_ctor.pass.cpp
+++ b/libcxx/test/std/utilities/template.bitset/bitset.cons/char_ptr_ctor.pass.cpp
@@ -73,7 +73,7 @@ TEST_CONSTEXPR_CXX23 void test_char_pointer_ctor()
         assert(v[i] == false);
   }
   // Verify that this constructor doesn't read over the given bound.
-  // See https://github.com/llvm/llvm-project/issues/143684
+  // See https://llvm.org/PR143684
   {
     const char not_null_terminated[] = {'1', '0', '1', '0', '1', '0', '1', '0', '1', '0'};
     std::bitset<N> v(not_null_terminated, 10);

--- a/libcxx/test/std/utilities/template.bitset/bitset.members/nonstdmem.uglified.compile.pass.cpp
+++ b/libcxx/test/std/utilities/template.bitset/bitset.members/nonstdmem.uglified.compile.pass.cpp
@@ -11,8 +11,8 @@
 // This test ensures that we don't use a non-uglified name 'base', 'iterator',
 // 'const_iterator', and `const_reference` in the implementation of bitset.
 //
-// See https://github.com/llvm/llvm-project/issues/111125.
-// See https://github.com/llvm/llvm-project/issues/121618.
+// See https://llvm.org/PR111125.
+// See https://llvm.org/PR121618.
 
 // XFAIL: FROZEN-CXX03-HEADERS-FIXME
 

--- a/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
+++ b/libcxx/test/std/utilities/tuple/tuple.tuple/tuple.creation/tuple_cat.pass.cpp
@@ -31,7 +31,7 @@ template<typename ...Ts>
 void forward_as_tuple(Ts...) = delete;
 }
 
-// https://github.com/llvm/llvm-project/issues/41034
+// https://llvm.org/PR41689
 struct Unconstrained {
   int data;
   template <typename Arg>
@@ -312,7 +312,7 @@ int main(int, char**)
         assert(std::get<0>(t).i == 1);
         assert(std::get<0>(t2).i == 1);
     }
-    // See https://github.com/llvm/llvm-project/issues/41034
+    // See https://llvm.org/PR41689
     {
       test_tuple_cat_with_unconstrained_constructor();
 #if TEST_STD_VER >= 14

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.class.general/equality.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.class.general/equality.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/assign.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/assign.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/copy.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/copy.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/default.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/default.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/memory_resource_convert.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/memory_resource_convert.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/other_alloc.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.ctor/other_alloc.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/equal.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/not_equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.eq/not_equal.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_bytes.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_bytes.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_object.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/allocate_deallocate_object.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_const_lvalue_pair.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_rvalue.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_rvalue.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_pair_values.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_piecewise_pair_evil.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_types.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/construct_types.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/deallocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/deallocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/destroy.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/destroy.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/new_delete_object.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/new_delete_object.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/select_on_container_copy_construction.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.poly.allocator.class/mem.poly.allocator.mem/select_on_container_copy_construction.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <deque>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_deque_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <deque>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_forward_list_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_forward_list_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <forward_list>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <list>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_list_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <list>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_map_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_regex_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_regex_synop.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: no-localization
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <regex>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_set_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <string>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_string_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <string>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_map_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_map>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_unordered_set_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <unordered_set>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <vector>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop2.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.aliases/header_vector_synop2.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <vector>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/default_resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/new_delete_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/new_delete_resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.global/null_memory_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.global/null_memory_resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/copy_move.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/copy_move.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/with_default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/with_default_resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/without_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.ctor/without_buffer.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_deallocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_deallocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_exception_safety.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_exception_safety.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: c++03, c++11, c++14
 // UNSUPPORTED: no-exceptions
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_initial_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_initial_buffer.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_zero_sized_buffer.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_from_zero_sized_buffer.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_in_geometric_progression.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_overaligned_request.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_overaligned_request.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_with_initial_size.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/allocate_with_initial_size.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/equality.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.monotonic.buffer/mem.res.monotonic.buffer.mem/equality.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/ctor_does_not_allocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/sync_with_default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/sync_with_default_resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/unsync_with_default_resource.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.ctor/unsync_with_default_resource.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/equality.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/equality.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_overaligned_request.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_overaligned_request.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_reuse_blocks.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_allocate_reuse_blocks.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_deallocate_matches_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/sync_deallocate_matches_allocate.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_overaligned_request.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_overaligned_request.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_reuse_blocks.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_allocate_reuse_blocks.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_deallocate_matches_allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res.pool/mem.res.pool.mem/unsync_deallocate_matches_allocate.pass.cpp
@@ -8,7 +8,7 @@
 
 // UNSUPPORTED: no-exceptions
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/construct.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/construct.verify.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/equal.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/not_equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.eq/not_equal.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/private_members.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/private_members.verify.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/protected_members.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.private/protected_members.verify.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // <memory_resource>

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/allocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/allocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/deallocate.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/deallocate.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/dtor.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/dtor.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/is_equal.pass.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/mem.res/mem.res.public/is_equal.pass.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // test_memory_resource requires RTTI for dynamic_cast

--- a/libcxx/test/std/utilities/utility/mem.res/nodiscard.verify.cpp
+++ b/libcxx/test/std/utilities/utility/mem.res/nodiscard.verify.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
-// TODO: Change to XFAIL once https://github.com/llvm/llvm-project/issues/40340 is fixed
+// TODO: Change to XFAIL once https://llvm.org/PR40995 is fixed
 // UNSUPPORTED: availability-pmr-missing
 
 // check that functions are marked [[nodiscard]]

--- a/libcxx/test/std/utilities/utility/pairs/pairs.pair/ctor.pair_like.pass.cpp
+++ b/libcxx/test/std/utilities/utility/pairs/pairs.pair/ctor.pair_like.pass.cpp
@@ -45,7 +45,7 @@ struct std::tuple_element<N, my_ns::MyPairLike> {
   using type = int;
 };
 
-// https://github.com/llvm/llvm-project/issues/65620
+// https://llvm.org/PR65620
 // This used to be a hard error
 static_assert(!std::is_constructible_v<std::pair<int,int>, my_ns::MyPairLike const&>);
 

--- a/libcxx/test/std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.variant/variant.ctor/T.pass.cpp
@@ -186,7 +186,7 @@ int main(int, char**) {
   test_construction_with_repeated_types();
   test_vector_bool();
 
-  { // Check that the constraints are evaluated lazily (see https://github.com/llvm/llvm-project/issues/151328)
+  { // Check that the constraints are evaluated lazily (see llvm.org/PR151328)
     struct Matcher {
       Matcher() {}
       Matcher(std::variant<ConvertibleFromAny>) {}

--- a/libcxx/test/std/utilities/variant/variant.visit.member/visit_return_type.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.visit.member/visit_return_type.pass.cpp
@@ -208,7 +208,7 @@ void test_exceptions() {
 #endif
 }
 
-// See https://bugs.llvm.org/show_bug.cgi?id=31916
+// See https://llvm.org/PR31916
 template <typename ReturnType>
 void test_caller_accepts_nonconst() {
   struct A {};

--- a/libcxx/test/std/utilities/variant/variant.visit/visit_return_type.pass.cpp
+++ b/libcxx/test/std/utilities/variant/variant.visit/visit_return_type.pass.cpp
@@ -349,7 +349,7 @@ void test_exceptions() {
 #endif
 }
 
-// See https://bugs.llvm.org/show_bug.cgi?id=31916
+// See https://llvm.org/PR31916
 template <typename ReturnType>
 void test_caller_accepts_nonconst() {
   struct A {};

--- a/libcxx/test/support/is_transparent.h
+++ b/libcxx/test/support/is_transparent.h
@@ -37,7 +37,7 @@ struct transparent_less_not_referenceable
 };
 
 // Prevent regression when empty base class optimization is not suitable.
-// See https://github.com/llvm/llvm-project/issues/152543.
+// See llvm.org/PR152543.
 struct transparent_less_nonempty {
   template <class T, class U>
   constexpr bool operator()(T&& t, U&& u) const {

--- a/libcxx/utils/generate_feature_test_macro_components.py
+++ b/libcxx/utils/generate_feature_test_macro_components.py
@@ -569,7 +569,7 @@ feature_test_macros = [
             "headers": ["format"],
             # Trying to use `std::format` where to_chars floating-point is not
             # available causes compilation errors, even with non floating-point types.
-            # https://github.com/llvm/llvm-project/issues/125353
+            # https://llvm.org/PR125353
             "test_suite_guard": "!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
             "libcxx_guard": "_LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
         },
@@ -1053,7 +1053,7 @@ feature_test_macros = [
             "headers": ["ostream", "print"],
             # Trying to use `std::print` where to_chars floating-point is not
             # available causes compilation errors, even with non floating-point types.
-            # https://github.com/llvm/llvm-project/issues/125353
+            # https://llvm.org/PR125353
             "test_suite_guard": "!defined(_LIBCPP_VERSION) || _LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
             "libcxx_guard": "_LIBCPP_AVAILABILITY_HAS_TO_CHARS_FLOATING_POINT",
         },

--- a/libcxx/utils/libcxx/test/features.py
+++ b/libcxx/utils/libcxx/test/features.py
@@ -176,7 +176,7 @@ DEFAULT_FEATURES = [
         when=lambda cfg: hasCompileFlag(cfg, "-Xclang -verify-ignore-unexpected"),
     ),
     Feature(
-        name="add-latomic-workaround",  # https://github.com/llvm/llvm-project/issues/73361
+        name="add-latomic-workaround",  # https://llvm.org/PR73361
         when=lambda cfg: sourceBuilds(
             cfg, "int main(int, char**) { return 0; }", ["-latomic"]
         ),


### PR DESCRIPTION
We've built up quite a few links directly to github within the code base. We should instead use `llvm.org/PR<issue-number>` to link to bugs, since that is resilient to the bug tracker changing in the future. This is especially relevant for tests linking to bugs, since they will probably be there for decades to come. A nice side effect is that these links are significantly shorter than the GH links, making them much less of an eyesore.

This patch also replaces a few links that linked to the old bugzilla instance on llvm.org.
