### PR TITLE
[llvm-exegesis] Exclude loads/stores from aliasing instruction set

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/no-aliasing-ld-str.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/no-aliasing-ld-str.s
@@ -1,0 +1,8 @@
+REQUIRES: aarch64-registered-target
+
+RUN: llvm-exegesis -mtriple=aarch64 -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=FMOVWSr --benchmark-phase=assemble-measured-code 2>&1
+RUN: llvm-objdump -d %d > %t.s
+RUN: FileCheck %s < %t.s
+
+CHECK-NOT: ld{{[1-4]}}
+CHECK-NOT: st{{[1-4]}}

--- a/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
+++ b/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
@@ -206,6 +206,8 @@ const Operand &Instruction::getPrimaryOperand(const Variable &Var) const {
 }
 
 bool Instruction::hasMemoryOperands() const {
+  if (Description.mayLoad() || Description.mayStore())
+    return true;
   return any_of(Operands, [](const Operand &Op) {
     return Op.isReg() && Op.isExplicit() && Op.isMemory();
   });

--- a/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
@@ -57,6 +57,8 @@ computeAliasingInstructions(const LLVMState &State, const Instruction *Instr,
       continue;
     if (OtherInstr.hasMemoryOperands())
       continue;
+    if (OtherInstr.Description.mayLoad() || OtherInstr.Description.mayStore())
+      continue;
     if (!ET.allowAsBackToBack(OtherInstr))
       continue;
     if (Instr->hasAliasingRegistersThrough(OtherInstr, ForbiddenRegisters))

--- a/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
@@ -57,8 +57,6 @@ computeAliasingInstructions(const LLVMState &State, const Instruction *Instr,
       continue;
     if (OtherInstr.hasMemoryOperands())
       continue;
-    if (OtherInstr.Description.mayLoad() || OtherInstr.Description.mayStore())
-      continue;
     if (!ET.allowAsBackToBack(OtherInstr))
       continue;
     if (Instr->hasAliasingRegistersThrough(OtherInstr, ForbiddenRegisters))


### PR DESCRIPTION
In the serial snippet generator and function that computes the aliasing instructions, I don't think we want to include load/store instructions to create a chain as that could make the results more unreliable.

There is a hasMemoryOperands() check, but I think that's an X86 way for checking for loads/stores. For AArch64, we should check mayLoad() and mayStore(), and probably for other architectures too.