### PR TITLE
[llldb][test] Mark a DWO test unsupported on Darwin and Windows

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/dwo-static-data-member-access.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwo-static-data-member-access.test
@@ -4,6 +4,9 @@
 # a DW_TAG_variable DIE, whose parent DIE is only
 # a forward declaration.
 
+# UNSUPPORTED: system-darwin
+# UNSUPPORTED: system-windows
+
 # RUN: %clangxx_host %S/Inputs/dwo-static-data-member.cpp \
 # RUN:   -g -gdwarf-5 -gsplit-dwarf -flimit-debug-info -o %t
 # RUN: %lldb %t -s %s -o exit 2>&1 | FileCheck %s


### PR DESCRIPTION
This uses split DWARF and from looking at other tests, it should not be running on Darwin or Windows.

It does pass using the DIA PDB plugin but I think this is misleading because it's not actually testing the intended feature.

When the native PDB plugin is used it fails because it cannot set a breakpoint. I don't see a point to running this test on Windows at all.

Native PDB plugin test failures are being tracked in #114906.