### PR TITLE
[X86][GlobalIsel] Support G_INTRINSIC_TRUNC/G_FCEIL/G_FFLOOR

### DIFF
--- a/llvm/lib/Target/X86/GISel/X86LegalizerInfo.cpp
+++ b/llvm/lib/Target/X86/GISel/X86LegalizerInfo.cpp
@@ -580,7 +580,8 @@ X86LegalizerInfo::X86LegalizerInfo(const X86Subtarget &STI,
       .lower();
 
   // fp intrinsics
-  getActionDefinitionsBuilder(G_INTRINSIC_ROUNDEVEN)
+  getActionDefinitionsBuilder(
+      {G_INTRINSIC_ROUNDEVEN, G_INTRINSIC_TRUNC, G_FCEIL, G_FFLOOR})
       .scalarize(0)
       .minScalar(0, LLT::scalar(32))
       .libcall();


### PR DESCRIPTION
This PR adds support for C/CPP Lib Intrinsic from LangRef in GlobalIsel.
Test is added https://github.com/llvm/llvm-project/pull/156281
