### PR TITLE
[lldb][test] Don't specify DWARF debug info in frame format test

### DIFF
--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionReturnObjC.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionReturnObjC.test
@@ -3,7 +3,7 @@
 # format variable (in this case Objective-C).
 #
 # RUN: split-file %s %t
-# RUN: %clang_host -g -gdwarf %t/main.m -o %t.objc.out
+# RUN: %clang_host -g %t/main.m -o %t.objc.out
 # RUN: %lldb -x -b -s %t/commands.input %t.objc.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
 


### PR DESCRIPTION
This test fails on Windows when using the native PDB plugin, but I'm surprised that it did not fail using the DIA plugin too. As it requests DWARF debug information that is likely discarded by link.exe.

By making it generate the default debug info, DWARF most places and PDB on Windows, this test passes with both PDB plugins on Windows.

(native PDB tracking issue is #114906)