### PR TITLE
[lldb][test] Use lld on Windows in frame format test

### DIFF
--- a/lldb/test/Shell/Settings/TestFrameFormatFunctionReturnObjC.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatFunctionReturnObjC.test
@@ -2,8 +2,11 @@
 # ${function.return-right} in languages that don't implement this frame
 # format variable (in this case Objective-C).
 #
+# link.exe will discard DWARF information.
+# REQUIRES: (system-windows && lld) || !system-windows
+#
 # RUN: split-file %s %t
-# RUN: %clang_host -g -gdwarf %t/main.m -o %t.objc.out
+# RUN: %clang_host -g -gdwarf %t/main.m -o %t.objc.out %if system-windows %{-fuse-ld=lld%}
 # RUN: %lldb -x -b -s %t/commands.input %t.objc.out -o exit 2>&1 \
 # RUN:       | FileCheck %s
 


### PR DESCRIPTION
link.exe discards DWARF information. Other linkers on non-Windows do not.

Uses the same solution as TestFrameFunctionInlined.test.

This test was failing with the native PDB plugin but shouldn't have been using PDB anyway (see #114906). Passes with DWARF and lld.