### PR TITLE
[X86] Add -fexperimental-new-constant-interpreter test coverage to the u32/f32 u64/f64 cast constexpr test files

### DIFF
--- a/clang/test/CodeGen/X86/x86-builtins.c
+++ b/clang/test/CodeGen/X86/x86-builtins.c
@@ -1,39 +1,40 @@
 // RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-unknown-unknown -emit-llvm -o - -Wall -Werror | FileCheck %s
 // RUN: %clang_cc1 -x c -ffreestanding %s -triple=i386-unknown-unknown -emit-llvm -o - -Wall -Werror | FileCheck %s
-// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=x86_64-unknown-unknown -emit-llvm -o - -Wall -Werror | FileCheck %s
-// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding %s -triple=i386-unknown-unknown -emit-llvm -o - -Wall -Werror | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ffreestanding %s -triple=x86_64-unknown-unknown -emit-llvm -o - -Wall -Werror | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ffreestanding %s -triple=i386-unknown-unknown -emit-llvm -o - -Wall -Werror | FileCheck %s
+
+// RUN: %clang_cc1 -x c -ffreestanding %s -triple=x86_64-unknown-unknown -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -x c -ffreestanding %s -triple=i386-unknown-unknown -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ffreestanding %s -triple=x86_64-unknown-unknown -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s
+// RUN: %clang_cc1 -x c++ -ffreestanding %s -triple=i386-unknown-unknown -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s
 
 #include <x86intrin.h>
+#include "builtin_test_helpers.h"
 
 unsigned int test_castf32_u32 (float __A){
   // CHECK-LABEL: test_castf32_u32
   // CHECK: %{{.*}} = load i32, ptr %{{.*}}, align 4
   return _castf32_u32(__A);
 }
+TEST_CONSTEXPR(_castf32_u32(-0.0f) == 0x80000000);
 
 unsigned long long test_castf64_u64 (double __A){
   // CHECK-LABEL: test_castf64_u64
   // CHECK: %{{.*}} = load i64, ptr %{{.*}}, align 8
   return _castf64_u64(__A);
 }
+TEST_CONSTEXPR(_castf64_u64(-0.0) == 0x8000000000000000);
 
 float test_castu32_f32 (unsigned int __A){
   // CHECK-LABEL: test_castu32_f32
   // CHECK: %{{.*}} = load float, ptr %{{.*}}, align 4
   return _castu32_f32(__A);
 }
+TEST_CONSTEXPR(_castu32_f32(0x3F800000) == +1.0f);
 
 double test_castu64_f64 (unsigned long long __A){
   // CHECK-LABEL: test_castu64_f64
   // CHECK: %{{.*}} = load double, ptr %{{.*}}, align 8
   return _castu64_f64(__A);
 }
-
-// Test constexpr handling.
-#if defined(__cplusplus) && (__cplusplus >= 201103L)
-char cast_f32_u32_0[_castf32_u32(-0.0f) == 0x80000000 ? 1 : -1];
-char cast_u32_f32_0[_castu32_f32(0x3F800000) == +1.0f ? 1 : -1];
-
-char castf64_u64_0[_castf64_u64(-0.0) == 0x8000000000000000 ? 1 : -1];
-char castu64_f64_0[_castu64_f64(0xBFF0000000000000ULL) == -1.0 ? 1 : -1];
-#endif
+TEST_CONSTEXPR(_castu64_f64(0xBFF0000000000000ULL) == -1.0);


### PR DESCRIPTION
Update tests to use builtin_test_helpers.h and the TEST_CONSTEXPR helper macro

Partial fix for #155814