### PR TITLE
[CHERI] Add enum values and LL parse/print support for CHERIoT calling conventions.

### DIFF
--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -187,9 +187,9 @@ enum Kind {
   kw_graalcc,
   kw_riscv_vector_cc,
   kw_riscv_vls_cc,
-  kw_chericcallcc,
-  kw_chericcallee,
-  kw_cherilibcallcc,
+  kw_cheriot_compartmentcallcc,
+  kw_cheriot_compartmentcalleecc,
+  kw_cheriot_librarycallcc,
 
   // Attributes:
   kw_attributes,

--- a/llvm/include/llvm/AsmParser/LLToken.h
+++ b/llvm/include/llvm/AsmParser/LLToken.h
@@ -187,6 +187,9 @@ enum Kind {
   kw_graalcc,
   kw_riscv_vector_cc,
   kw_riscv_vls_cc,
+  kw_chericcallcc,
+  kw_chericcallee,
+  kw_cherilibcallcc,
 
   // Attributes:
   kw_attributes,

--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -287,16 +287,14 @@ namespace CallingConv {
     // Calling convention for AMDGPU whole wave functions.
     AMDGPU_Gfx_WholeWave = 124,
 
-    /// CHERIoT_CompartmentCall - Calling convention used for CHERI when
-    /// crossing a protection boundary.
+    /// Calling convention used for CHERIoT when crossing a protection boundary.
     CHERIoT_CompartmentCall = 125,
-    /// CHERIoT_CompartmentCallee - Calling convention used for the callee of
-    /// CHERIoT_CompartmentCall.
+    /// Calling convention used for the callee of CHERIoT_CompartmentCall.
     /// Ignores the first two capability arguments and the first integer
     /// argument, zeroes all unused return registers on return.
     CHERIoT_CompartmentCallee = 126,
-    /// CHERIoT_LibraryCall - Calling convention used for cross-library calls to
-    /// a stateless compartment.
+    /// Calling convention used for CHERIoT for cross-library calls to a
+    /// stateless compartment.
     CHERIoT_LibraryCall = 127,
 
     /// The highest possible ID. Must be some 2^k - 1.

--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -287,16 +287,17 @@ namespace CallingConv {
     // Calling convention for AMDGPU whole wave functions.
     AMDGPU_Gfx_WholeWave = 124,
 
-    /// CHERI_CCall - Calling convention used for CHERI when crossing a
+    /// CHERIoT_CompartmentCall - Calling convention used for CHERI when
+    /// crossing a
     /// protection boundary.
-    CHERI_CCall = 125,
+    CHERIoT_CompartmentCall = 125,
     /// CHERI_CCallee - Calling convention used for the callee of CHERI_CCall.
     /// Ignores the first two capability arguments and the first integer
     /// argument, zeroes all unused return registers on return.
-    CHERI_CCallee = 126,
+    CHERIoT_CompartmentCallee = 126,
     /// CHERI_LibCall - Calling convention used for cross-library calls to a
     /// stateless compartment.
-    CHERI_LibCall = 127,
+    CHERIoT_LibraryCall = 127,
 
     /// The highest possible ID. Must be some 2^k - 1.
     MaxID = 1023

--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -287,6 +287,17 @@ namespace CallingConv {
     // Calling convention for AMDGPU whole wave functions.
     AMDGPU_Gfx_WholeWave = 124,
 
+    /// CHERI_CCall - Calling convention used for CHERI when crossing a
+    /// protection boundary.
+    CHERI_CCall = 125,
+    /// CHERI_CCallee - Calling convention used for the callee of CHERI_CCall.
+    /// Ignores the first two capability arguments and the first integer
+    /// argument, zeroes all unused return registers on return.
+    CHERI_CCallee = 126,
+    /// CHERI_LibCall - Calling convention used for cross-library calls to a
+    /// stateless compartment.
+    CHERI_LibCall = 127,
+
     /// The highest possible ID. Must be some 2^k - 1.
     MaxID = 1023
   };

--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -291,11 +291,13 @@ namespace CallingConv {
     /// crossing a
     /// protection boundary.
     CHERIoT_CompartmentCall = 125,
-    /// CHERI_CCallee - Calling convention used for the callee of CHERI_CCall.
+    /// CHERIoT_CompartmentCallee - Calling convention used for the callee of
+    /// CHERI_CCall.
     /// Ignores the first two capability arguments and the first integer
     /// argument, zeroes all unused return registers on return.
     CHERIoT_CompartmentCallee = 126,
-    /// CHERI_LibCall - Calling convention used for cross-library calls to a
+    /// CHERIoT_LibraryCall - Calling convention used for cross-library calls to
+    /// a
     /// stateless compartment.
     CHERIoT_LibraryCall = 127,
 

--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -288,17 +288,15 @@ namespace CallingConv {
     AMDGPU_Gfx_WholeWave = 124,
 
     /// CHERIoT_CompartmentCall - Calling convention used for CHERI when
-    /// crossing a
-    /// protection boundary.
+    /// crossing a protection boundary.
     CHERIoT_CompartmentCall = 125,
     /// CHERIoT_CompartmentCallee - Calling convention used for the callee of
-    /// CHERI_CCall.
+    /// CHERIoT_CompartmentCall.
     /// Ignores the first two capability arguments and the first integer
     /// argument, zeroes all unused return registers on return.
     CHERIoT_CompartmentCallee = 126,
     /// CHERIoT_LibraryCall - Calling convention used for cross-library calls to
-    /// a
-    /// stateless compartment.
+    /// a stateless compartment.
     CHERIoT_LibraryCall = 127,
 
     /// The highest possible ID. Must be some 2^k - 1.

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -685,9 +685,9 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(graalcc);
   KEYWORD(riscv_vector_cc);
   KEYWORD(riscv_vls_cc);
-  KEYWORD(chericcallcc);
-  KEYWORD(chericcallee);
-  KEYWORD(cherilibcallcc);
+  KEYWORD(cheriot_compartmentcallcc);
+  KEYWORD(cheriot_compartmentcalleecc);
+  KEYWORD(cheriot_librarycallcc);
 
   KEYWORD(cc);
   KEYWORD(c);

--- a/llvm/lib/AsmParser/LLLexer.cpp
+++ b/llvm/lib/AsmParser/LLLexer.cpp
@@ -685,6 +685,9 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(graalcc);
   KEYWORD(riscv_vector_cc);
   KEYWORD(riscv_vls_cc);
+  KEYWORD(chericcallcc);
+  KEYWORD(chericcallee);
+  KEYWORD(cherilibcallcc);
 
   KEYWORD(cc);
   KEYWORD(c);

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -2312,14 +2312,14 @@ bool LLParser::parseOptionalCallingConv(unsigned &CC) {
 #undef CC_VLS_CASE
     }
     return false;
-  case lltok::kw_chericcallcc:
-    CC = CallingConv::CHERI_CCall;
+  case lltok::kw_cheriot_compartmentcallcc:
+    CC = CallingConv::CHERIoT_CompartmentCall;
     break;
-  case lltok::kw_chericcallee:
-    CC = CallingConv::CHERI_CCallee;
+  case lltok::kw_cheriot_compartmentcalleecc:
+    CC = CallingConv::CHERIoT_CompartmentCallee;
     break;
-  case lltok::kw_cherilibcallcc:
-    CC = CallingConv::CHERI_LibCall;
+  case lltok::kw_cheriot_librarycallcc:
+    CC = CallingConv::CHERIoT_LibraryCall;
     break;
   case lltok::kw_cc: {
       Lex.Lex();

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -2312,6 +2312,15 @@ bool LLParser::parseOptionalCallingConv(unsigned &CC) {
 #undef CC_VLS_CASE
     }
     return false;
+  case lltok::kw_chericcallcc:
+    CC = CallingConv::CHERI_CCall;
+    break;
+  case lltok::kw_chericcallee:
+    CC = CallingConv::CHERI_CCallee;
+    break;
+  case lltok::kw_cherilibcallcc:
+    CC = CallingConv::CHERI_LibCall;
+    break;
   case lltok::kw_cc: {
       Lex.Lex();
       return parseUInt32(CC);

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -430,6 +430,15 @@ static void PrintCallingConv(unsigned cc, raw_ostream &Out) {
     CC_VLS_CASE(32768)
     CC_VLS_CASE(65536)
 #undef CC_VLS_CASE
+  case CallingConv::CHERI_CCall:
+    Out << "chericcallcc";
+    break;
+  case CallingConv::CHERI_CCallee:
+    Out << "chericcallee";
+    break;
+  case CallingConv::CHERI_LibCall:
+    Out << "cherilibcallcc";
+    break;
   }
 }
 

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -430,14 +430,14 @@ static void PrintCallingConv(unsigned cc, raw_ostream &Out) {
     CC_VLS_CASE(32768)
     CC_VLS_CASE(65536)
 #undef CC_VLS_CASE
-  case CallingConv::CHERI_CCall:
-    Out << "chericcallcc";
+  case CallingConv::CHERIoT_CompartmentCall:
+    Out << "cheriot_compartmentcallcc";
     break;
-  case CallingConv::CHERI_CCallee:
-    Out << "chericcallee";
+  case CallingConv::CHERIoT_CompartmentCallee:
+    Out << "cheriot_compartmentcalleecc";
     break;
-  case CallingConv::CHERI_LibCall:
-    Out << "cherilibcallcc";
+  case CallingConv::CHERIoT_LibraryCall:
+    Out << "cheriot_librarycallcc";
     break;
   }
 }


### PR DESCRIPTION
This is the set of the calling conventions supported by the CHERIoT CHERI downstream of LLVM.
