### PR TITLE
[libc] Add support for std::cout on embedded

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -124,8 +124,11 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # stdio.h entrypoints
     libc.src.stdio.asprintf
+    libc.src.stdio.fflush
     libc.src.stdio.fopencookie
     libc.src.stdio.fprintf
+    libc.src.stdio.fwrite
+    libc.src.stdio.getc
     libc.src.stdio.getchar
     libc.src.stdio.printf
     libc.src.stdio.putchar
@@ -135,7 +138,12 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.snprintf
     libc.src.stdio.sprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
+    libc.src.stdio.ungetc
     libc.src.stdio.vasprintf
+    libc.src.stdio.vfprintf
     libc.src.stdio.vprintf
     libc.src.stdio.vscanf
     libc.src.stdio.vsnprintf

--- a/libc/config/baremetal/arm/entrypoints.txt
+++ b/libc/config/baremetal/arm/entrypoints.txt
@@ -124,8 +124,11 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # stdio.h entrypoints
     libc.src.stdio.asprintf
+    libc.src.stdio.fflush
     libc.src.stdio.fopencookie
     libc.src.stdio.fprintf
+    libc.src.stdio.fwrite
+    libc.src.stdio.getc
     libc.src.stdio.getchar
     libc.src.stdio.printf
     libc.src.stdio.putchar
@@ -135,7 +138,12 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.snprintf
     libc.src.stdio.sprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
+    libc.src.stdio.ungetc
     libc.src.stdio.vasprintf
+    libc.src.stdio.vfprintf
     libc.src.stdio.vprintf
     libc.src.stdio.vscanf
     libc.src.stdio.vsnprintf

--- a/libc/config/baremetal/riscv/entrypoints.txt
+++ b/libc/config/baremetal/riscv/entrypoints.txt
@@ -124,8 +124,11 @@ set(TARGET_LIBC_ENTRYPOINTS
 
     # stdio.h entrypoints
     libc.src.stdio.asprintf
+    libc.src.stdio.fflush
     libc.src.stdio.fopencookie
     libc.src.stdio.fprintf
+    libc.src.stdio.fwrite
+    libc.src.stdio.getc
     libc.src.stdio.getchar
     libc.src.stdio.printf
     libc.src.stdio.putchar
@@ -135,7 +138,12 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.stdio.snprintf
     libc.src.stdio.sprintf
     libc.src.stdio.sscanf
+    libc.src.stdio.stderr
+    libc.src.stdio.stdin
+    libc.src.stdio.stdout
+    libc.src.stdio.ungetc
     libc.src.stdio.vasprintf
+    libc.src.stdio.vfprintf
     libc.src.stdio.vprintf
     libc.src.stdio.vscanf
     libc.src.stdio.vsnprintf

--- a/libc/src/__support/File/baremetal/stderr.cpp
+++ b/libc/src/__support/File/baremetal/stderr.cpp
@@ -14,10 +14,10 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-cookie_io_functions_t io_func = {.read = nullptr,
-                                 .write = __llvm_libc_stdio_write,
-                                 .seek = nullptr,
-                                 .close = nullptr};
+static cookie_io_functions_t io_func = {.read = nullptr,
+                                        .write = __llvm_libc_stdio_write,
+                                        .seek = nullptr,
+                                        .close = nullptr};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 // Buffering is implementation defined. Therefore to save RAM, we use no

--- a/libc/src/__support/File/baremetal/stdin.cpp
+++ b/libc/src/__support/File/baremetal/stdin.cpp
@@ -14,10 +14,10 @@
 
 namespace LIBC_NAMESPACE_DECL {
 
-cookie_io_functions_t io_func = {.read = __llvm_libc_stdio_read,
-                                 .write = nullptr,
-                                 .seek = nullptr,
-                                 .close = nullptr};
+static cookie_io_functions_t io_func = {.read = __llvm_libc_stdio_read,
+                                        .write = nullptr,
+                                        .seek = nullptr,
+                                        .close = nullptr};
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wglobal-constructors"
 // Buffering is implementation defined. Therefore to save RAM, we use no


### PR DESCRIPTION
Fixes an bug with external linkage in stdout/stderr. Adds the required entrypoints for std::cout.
Full support requires #156331.