### PR TITLE
[libc++] Include __llvm-libc-common.h if applicable

### DIFF
--- a/libcxx/include/__configuration/platform.h
+++ b/libcxx/include/__configuration/platform.h
@@ -49,6 +49,11 @@
 #  include <picolibc.h>
 #endif
 
+// TODO: we should remove this once (#147956) is merged, for the same reason as listed above.
+#if __has_include(<__llvm-libc-common.h>)
+#  include <__llvm-libc-common.h>
+#endif
+
 #ifndef __BYTE_ORDER__
 #  error                                                                                                               \
       "Your compiler doesn't seem to define __BYTE_ORDER__, which is required by libc++ to know the endianness of your target platform"


### PR DESCRIPTION
Currently on embedded platforms, `<features.h>` is not being included. We need at least one of the LLVM-libc headers to be included, to have access to the define `__LLVM_LIBC__`. Therefore, as a temporary solution until #147956 is merged, we include a check for the LLVM-libc common header library.

Corresponding PR in LLVM-libc is here: #156330.