### PR TITLE
[X86] Add -fexperimental-new-constant-interpreter test coverage to the x86 scalar rotate constexpr test files

### DIFF
--- a/clang/test/CodeGen/X86/rot-intrinsics.c
+++ b/clang/test/CodeGen/X86/rot-intrinsics.c
@@ -5,14 +5,22 @@
 // RUN: %clang_cc1 -x c -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
 // RUN: %clang_cc1 -x c -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
 
-// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding -triple i686--linux -no-enable-noundef-analysis -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
-// RUN: %clang_cc1 -x c++ -std=c++11 -ffreestanding -triple x86_64--linux -no-enable-noundef-analysis -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-64BIT-LONG
-// RUN: %clang_cc1 -x c++ -std=c++11 -fms-extensions -fms-compatibility -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
-// RUN: %clang_cc1 -x c++ -std=c++11 -fms-extensions -fms-compatibility -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
-// RUN: %clang_cc1 -x c++ -std=c++11 -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
-// RUN: %clang_cc1 -x c++ -std=c++11 -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple i686--linux -no-enable-noundef-analysis -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple x86_64--linux -no-enable-noundef-analysis -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-64BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple i686--linux -no-enable-noundef-analysis -emit-llvm %s -o - -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -ffreestanding -triple x86_64--linux -no-enable-noundef-analysis -emit-llvm %s -o - -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes CHECK,CHECK-64BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=i686-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
+// RUN: %clang_cc1 -x c++ -fms-extensions -fms-compatibility -fms-compatibility-version=17.00 -ffreestanding %s -triple=x86_64-windows-msvc -target-feature +sse2 -no-enable-noundef-analysis -emit-llvm -o - -Wall -Werror -fexperimental-new-constant-interpreter | FileCheck %s --check-prefixes CHECK,CHECK-32BIT-LONG
 
 #include <x86intrin.h>
+#include "builtin_test_helpers.h"
 
 unsigned char test__rolb(unsigned char value, int shift) {
 // CHECK-LABEL: test__rolb
@@ -20,6 +28,7 @@ unsigned char test__rolb(unsigned char value, int shift) {
 // CHECK:   ret i8 [[R]]
   return __rolb(value, shift);
 }
+TEST_CONSTEXPR(__rolb(0x01, 5) == 0x20);
 
 unsigned short test__rolw(unsigned short value, int shift) {
 // CHECK-LABEL: test__rolw
@@ -27,6 +36,7 @@ unsigned short test__rolw(unsigned short value, int shift) {
 // CHECK:   ret i16 [[R]]
   return __rolw(value, shift);
 }
+TEST_CONSTEXPR(__rolw(0x3210, 11) == 0x8190);
 
 unsigned int test__rold(unsigned int value, int shift) {
 // CHECK-LABEL: test__rold
@@ -34,6 +44,7 @@ unsigned int test__rold(unsigned int value, int shift) {
 // CHECK:   ret i32 [[R]]
   return __rold(value, shift);
 }
+TEST_CONSTEXPR(__rold(0x76543210, 22) == 0x841D950C);
 
 #if defined(__x86_64__)
 unsigned long test__rolq(unsigned long value, int shift) {
@@ -42,6 +53,7 @@ unsigned long test__rolq(unsigned long value, int shift) {
 // CHECK-LONG:   ret i64 [[R]]
   return __rolq(value, shift);
 }
+TEST_CONSTEXPR(__rolq(0xFEDCBA9876543210ULL, 55) == 0x087F6E5D4C3B2A19ULL);
 #endif
 
 unsigned char test__rorb(unsigned char value, int shift) {
@@ -50,6 +62,7 @@ unsigned char test__rorb(unsigned char value, int shift) {
 // CHECK:   ret i8 [[R]]
   return __rorb(value, shift);
 }
+TEST_CONSTEXPR(__rorb(0x01, 5) == 0x08);
 
 unsigned short test__rorw(unsigned short value, int shift) {
 // CHECK-LABEL: test__rorw
@@ -57,6 +70,7 @@ unsigned short test__rorw(unsigned short value, int shift) {
 // CHECK:   ret i16 [[R]]
   return __rorw(value, shift);
 }
+TEST_CONSTEXPR(__rorw(0x3210, 11) == 0x4206);
 
 unsigned int test__rord(unsigned int value, int shift) {
 // CHECK-LABEL: test__rord
@@ -64,6 +78,7 @@ unsigned int test__rord(unsigned int value, int shift) {
 // CHECK:   ret i32 [[R]]
   return __rord(value, shift);
 }
+TEST_CONSTEXPR(__rord(0x76543210, 22) == 0x50C841D9);
 
 #if defined(__x86_64__)
 unsigned long test__rorq(unsigned long value, int shift) {
@@ -72,6 +87,7 @@ unsigned long test__rorq(unsigned long value, int shift) {
 // CHECK-LONG:   ret i64 [[R]]
   return __rorq(value, shift);
 }
+TEST_CONSTEXPR(__rorq(0xFEDCBA9876543210ULL, 55) == 0xB97530ECA86421FDULL);
 #endif
 
 unsigned short test_rotwl(unsigned short value, int shift) {
@@ -80,6 +96,7 @@ unsigned short test_rotwl(unsigned short value, int shift) {
 // CHECK:   ret i16 [[R]]
   return _rotwl(value, shift);
 }
+TEST_CONSTEXPR(_rotwl(0x3210, 4) == 0x2103);
 
 unsigned int test_rotl(unsigned int value, int shift) {
 // CHECK-LABEL: test_rotl
@@ -87,6 +104,7 @@ unsigned int test_rotl(unsigned int value, int shift) {
 // CHECK:   ret i32 [[R]]
   return _rotl(value, shift);
 }
+TEST_CONSTEXPR(_rotl(0x76543210, 8) == 0x54321076);
 
 unsigned long test_lrotl(unsigned long value, int shift) {
 // CHECK-32BIT-LONG-LABEL: test_lrotl
@@ -98,6 +116,11 @@ unsigned long test_lrotl(unsigned long value, int shift) {
 // CHECK-64BIT-LONG:   ret i64 [[R]]
   return _lrotl(value, shift);
 }
+#if defined(__LP64__) && !defined(_MSC_VER)
+TEST_CONSTEXPR(_lrotl(0xFEDCBA9876543210ULL, 55) == 0x087F6E5D4C3B2A19ULL);
+#else
+TEST_CONSTEXPR(_lrotl(0x76543210, 22) == 0x841D950C);
+#endif
 
 
 unsigned short test_rotwr(unsigned short value, int shift) {
@@ -106,6 +129,7 @@ unsigned short test_rotwr(unsigned short value, int shift) {
 // CHECK:   ret i16 [[R]]
   return _rotwr(value, shift);
 }
+TEST_CONSTEXPR(_rotwr(0x3210, 4) == 0x0321);
 
 unsigned int test_rotr(unsigned int value, int shift) {
 // CHECK-LABEL: test_rotr
@@ -113,6 +137,7 @@ unsigned int test_rotr(unsigned int value, int shift) {
 // CHECK:   ret i32 [[R]]
   return _rotr(value, shift);
 }
+TEST_CONSTEXPR(_rotr(0x76543210, 8) == 0x10765432);
 
 unsigned long test_lrotr(unsigned long value, int shift) {
 // CHECK-32BIT-LONG-LABEL: test_lrotr
@@ -124,34 +149,9 @@ unsigned long test_lrotr(unsigned long value, int shift) {
 // CHECK-64BIT-LONG:   ret i64 [[R]]
   return _lrotr(value, shift);
 }
-
-// Test constexpr handling.
-#if defined(__cplusplus) && (__cplusplus >= 201103L)
-
-char rolb_0[__rolb(0x01, 5) == 0x20 ? 1 : -1];
-char rolw_0[__rolw(0x3210, 11) == 0x8190 ? 1 : -1];
-char rold_0[__rold(0x76543210, 22) == 0x841D950C ? 1 : -1];
-
-char rorb_0[__rorb(0x01, 5) == 0x08 ? 1 : -1];
-char rorw_0[__rorw(0x3210, 11) == 0x4206 ? 1 : -1];
-char rord_0[__rord(0x76543210, 22) == 0x50C841D9 ? 1 : -1];
-
-#if defined(__x86_64__)
-char rolq_0[__rolq(0xFEDCBA9876543210ULL, 55) == 0x087F6E5D4C3B2A19ULL ? 1 : -1];
-char rorq_0[__rorq(0xFEDCBA9876543210ULL, 55) == 0xB97530ECA86421FDULL ? 1 : -1];
-#endif
-
-char rotwl_0[_rotwl(0x3210, 4) == 0x2103 ? 1 : -1];
-char rotwr_0[_rotwr(0x3210, 4) == 0x0321 ? 1 : -1];
-char rotl_0[_rotl(0x76543210, 8) == 0x54321076 ? 1 : -1];
-char rotr_0[_rotr(0x76543210, 8) == 0x10765432 ? 1 : -1];
-
 #if defined(__LP64__) && !defined(_MSC_VER)
-char lrotl_0[_lrotl(0xFEDCBA9876543210ULL, 55) == 0x087F6E5D4C3B2A19ULL ? 1 : -1];
-char lrotr_0[_lrotr(0xFEDCBA9876543210ULL, 55) == 0xB97530ECA86421FDULL ? 1 : -1];
+TEST_CONSTEXPR(_lrotr(0xFEDCBA9876543210ULL, 55) == 0xB97530ECA86421FDULL);
 #else
-char lrotl_0[_lrotl(0x76543210, 22) == 0x841D950C ? 1 : -1];
-char lrotr_0[_lrotr(0x76543210, 22) == 0x50C841D9 ? 1 : -1];
+TEST_CONSTEXPR(_lrotr(0x76543210, 22) == 0x50C841D9);
 #endif
 
-#endif


### PR DESCRIPTION
Update tests to use builtin_test_helpers.h and the TEST_CONSTEXPR helper macro

Partial fix for #155814