### PR TITLE
[AArch64] Provide a custom decoder for LDR_ZA/STR_ZA

### DIFF
--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -1108,6 +1108,10 @@ class sme_spill_fill_base<bit isStore, dag outs, dag ins, string opcodestr>
     : I<outs, ins, opcodestr, "\t$ZAt[$Rv, $imm4], [$Rn, $offset, mul vl]", "",
         []>,
       Sched<[]> {
+  // 'offset' operand is encoded in the same bits as 'imm4'. There is currently
+  // no way to tell TableGen about this.
+  let DecoderMethod = "DecodeSMESpillFillInstruction";
+  bits<0> ZAt;
   bits<2> Rv;
   bits<5> Rn;
   bits<4> imm4;

--- a/llvm/test/MC/Disassembler/AArch64/armv9.2a-sme.txt
+++ b/llvm/test/MC/Disassembler/AArch64/armv9.2a-sme.txt
@@ -1,0 +1,4 @@
+# RUN: llvm-mc -triple=aarch64 -mattr=+sme -disassemble %s | FileCheck %s
+
+[0x45,0x41,0x00,0xe1] # CHECK: ldr za[w14, 5], [x10, #5, mul vl]
+[0x45,0x41,0x20,0xe1] # CHECK: str za[w14, 5], [x10, #5, mul vl]


### PR DESCRIPTION
These instructions encode two operands in the same field. Instead of fixing them after they have been incorrectly decoded, provide a custom decoder.

This will allow to remove `-ignore-non-decodable-operands` option from AArch64/CMakeLists.txt, see #156358 for the context.
