### PR TITLE
[AArch64] Remove post-decoding instruction mutations

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1561,13 +1561,12 @@ def VectorIndexHOperand : AsmVectorIndex<0, 7>;
 def VectorIndexSOperand : AsmVectorIndex<0, 3>;
 def VectorIndexDOperand : AsmVectorIndex<0, 1>;
 
-let OperandNamespace = "AArch64" in {
-  let OperandType = "OPERAND_IMPLICIT_IMM_0" in {
-    defm VectorIndex0 : VectorIndex<i64, VectorIndex0Operand,
-                                [{ return ((uint64_t)Imm) == 0; }]>;
-    defm VectorIndex032b : VectorIndex<i32, VectorIndex0Operand,
-                                [{ return ((uint32_t)Imm) == 0; }]>;
-  }
+let OperandNamespace = "AArch64", OperandType = "OPERAND_IMPLICIT_IMM_0",
+    DecoderMethod = "DecodeZeroImm" in {
+  defm VectorIndex0 : VectorIndex<i64, VectorIndex0Operand,
+                                  [{ return ((uint64_t)Imm) == 0; }]>;
+  defm VectorIndex032b : VectorIndex<i32, VectorIndex0Operand,
+                                     [{ return ((uint32_t)Imm) == 0; }]>;
 }
 defm VectorIndex1 : VectorIndex<i64, VectorIndex1Operand,
                                 [{ return ((uint64_t)Imm) == 1; }]>;
@@ -1620,6 +1619,7 @@ def sme_elm_idx0_0 : Operand<i32>, TImmLeaf<i32, [{
   let PrintMethod = "printMatrixIndex";
   let OperandNamespace = "AArch64";
   let OperandType = "OPERAND_IMPLICIT_IMM_0";
+  let DecoderMethod = "DecodeZeroImm";
 }
 def sme_elm_idx0_1 : Operand<i32>, TImmLeaf<i32, [{
   return ((uint32_t)Imm) <= 1;
@@ -1683,6 +1683,7 @@ def uimm0s2range : Operand<i64>, ImmLeaf<i64,
   let ParserMatchClass = UImm0s2RangeOperand;
   let OperandNamespace = "AArch64";
   let OperandType = "OPERAND_IMPLICIT_IMM_0";
+  let DecoderMethod = "DecodeZeroImm";
 }
 
 def uimm0s4range : Operand<i64>, ImmLeaf<i64,
@@ -1691,6 +1692,7 @@ def uimm0s4range : Operand<i64>, ImmLeaf<i64,
   let ParserMatchClass = UImm0s4RangeOperand;
   let OperandNamespace = "AArch64";
   let OperandType = "OPERAND_IMPLICIT_IMM_0";
+  let DecoderMethod = "DecodeZeroImm";
 }
 
 def uimm1s2range : Operand<i64>, ImmLeaf<i64,
@@ -8220,18 +8222,23 @@ multiclass SMov {
   // streaming mode.
   let Predicates = [HasNEONandIsStreamingSafe] in {
     def vi8to32_idx0 : SIMDSMov<0, ".b", GPR32, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00001;
     }
     def vi8to64_idx0 : SIMDSMov<1, ".b", GPR64, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00001;
     }
     def vi16to32_idx0 : SIMDSMov<0, ".h", GPR32, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00010;
     }
     def vi16to64_idx0 : SIMDSMov<1, ".h", GPR64, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00010;
     }
     def vi32to64_idx0 : SIMDSMov<1, ".s", GPR64, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00100;
     }
   }
@@ -8267,15 +8274,19 @@ multiclass UMov {
   // streaming mode.
   let Predicates = [HasNEONandIsStreamingSafe] in {
     def vi8_idx0 : SIMDUMov<0, ".b", v16i8, GPR32, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00001;
     }
     def vi16_idx0 : SIMDUMov<0, ".h", v8i16, GPR32, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00010;
     }
     def vi32_idx0 : SIMDUMov<0, ".s", v4i32, GPR32, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b00100;
     }
     def vi64_idx0 : SIMDUMov<1, ".d", v2i64, GPR64, VectorIndex0> {
+      bits<0> idx;
       let Inst{20-16} = 0b01000;
     }
     def : SIMDMovAlias<"mov", ".s",

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -1875,16 +1875,15 @@ class MatrixTileAsmOperand<string RC, int EltSize> : AsmOperandClass {
                           # EltSize # ", AArch64::" # RC # "RegClassID>";
 }
 
-class MatrixTileOperand<int EltSize, int NumBitsForTile, RegisterClass RC>
+class MatrixTileOperand<int EltSize, RegisterClass RC>
     : RegisterOperand<RC> {
   let ParserMatchClass = MatrixTileAsmOperand<!cast<string>(RC), EltSize>;
-  let DecoderMethod = "DecodeMatrixTile<" # NumBitsForTile # ">";
   let PrintMethod = "printMatrixTile";
 }
 
-def TileOp16  : MatrixTileOperand<16, 1, MPR16>;
-def TileOp32  : MatrixTileOperand<32, 2, MPR32>;
-def TileOp64  : MatrixTileOperand<64, 3, MPR64>;
+def TileOp16  : MatrixTileOperand<16, MPR16>;
+def TileOp32  : MatrixTileOperand<32, MPR32>;
+def TileOp64  : MatrixTileOperand<64, MPR64>;
 
 //
 // Tile vectors (horizontal and vertical)
@@ -1902,26 +1901,24 @@ class MatrixTileVectorAsmOperand<string RC, int EltSize, int IsVertical>
                           # EltSize # ", AArch64::" # RC # "RegClassID>";
 }
 
-class MatrixTileVectorOperand<int EltSize, int NumBitsForTile,
-                              RegisterClass RC, int IsVertical>
+class MatrixTileVectorOperand<int EltSize, RegisterClass RC, int IsVertical>
     : RegisterOperand<RC> {
   let ParserMatchClass = MatrixTileVectorAsmOperand<!cast<string>(RC), EltSize,
                                                     IsVertical>;
-  let DecoderMethod = "DecodeMatrixTile<" # NumBitsForTile # ">";
   let PrintMethod = "printMatrixTileVector<" # IsVertical # ">";
 }
 
-def TileVectorOpH8   : MatrixTileVectorOperand<  8, 0, MPR8,   0>;
-def TileVectorOpH16  : MatrixTileVectorOperand< 16, 1, MPR16,  0>;
-def TileVectorOpH32  : MatrixTileVectorOperand< 32, 2, MPR32,  0>;
-def TileVectorOpH64  : MatrixTileVectorOperand< 64, 3, MPR64,  0>;
-def TileVectorOpH128 : MatrixTileVectorOperand<128, 4, MPR128, 0>;
+def TileVectorOpH8   : MatrixTileVectorOperand<  8, MPR8,   0>;
+def TileVectorOpH16  : MatrixTileVectorOperand< 16, MPR16,  0>;
+def TileVectorOpH32  : MatrixTileVectorOperand< 32, MPR32,  0>;
+def TileVectorOpH64  : MatrixTileVectorOperand< 64, MPR64,  0>;
+def TileVectorOpH128 : MatrixTileVectorOperand<128, MPR128, 0>;
 
-def TileVectorOpV8   : MatrixTileVectorOperand<  8, 0, MPR8,   1>;
-def TileVectorOpV16  : MatrixTileVectorOperand< 16, 1, MPR16,  1>;
-def TileVectorOpV32  : MatrixTileVectorOperand< 32, 2, MPR32,  1>;
-def TileVectorOpV64  : MatrixTileVectorOperand< 64, 3, MPR64,  1>;
-def TileVectorOpV128 : MatrixTileVectorOperand<128, 4, MPR128, 1>;
+def TileVectorOpV8   : MatrixTileVectorOperand<  8, MPR8,   1>;
+def TileVectorOpV16  : MatrixTileVectorOperand< 16, MPR16,  1>;
+def TileVectorOpV32  : MatrixTileVectorOperand< 32, MPR32,  1>;
+def TileVectorOpV64  : MatrixTileVectorOperand< 64, MPR64,  1>;
+def TileVectorOpV128 : MatrixTileVectorOperand<128, MPR128, 1>;
 
 //
 // Accumulator matrix

--- a/llvm/lib/Target/AArch64/CMakeLists.txt
+++ b/llvm/lib/Target/AArch64/CMakeLists.txt
@@ -7,8 +7,7 @@ tablegen(LLVM AArch64GenAsmWriter.inc -gen-asm-writer)
 tablegen(LLVM AArch64GenAsmWriter1.inc -gen-asm-writer -asmwriternum=1)
 tablegen(LLVM AArch64GenCallingConv.inc -gen-callingconv)
 tablegen(LLVM AArch64GenDAGISel.inc -gen-dag-isel)
-tablegen(LLVM AArch64GenDisassemblerTables.inc -gen-disassembler
-              -ignore-non-decodable-operands)
+tablegen(LLVM AArch64GenDisassemblerTables.inc -gen-disassembler)
 tablegen(LLVM AArch64GenFastISel.inc -gen-fast-isel)
 tablegen(LLVM AArch64GenGlobalISel.inc -gen-global-isel)
 tablegen(LLVM AArch64GenO0PreLegalizeGICombiner.inc -gen-global-isel-combiner

--- a/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
+++ b/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
@@ -130,47 +130,57 @@ DecodeMatrixTileListRegisterClass(MCInst &Inst, unsigned RegMask,
   return Success;
 }
 
-static DecodeStatus DecodeMPRRegisterClass(MCInst &Inst,
-                                           const MCDisassembler *Decoder) {
-  Inst.addOperand(MCOperand::createReg(AArch64::ZA));
-  return Success;
-}
-
 static DecodeStatus DecodeZTRRegisterClass(MCInst &Inst,
                                            const MCDisassembler *Decoder) {
   Inst.addOperand(MCOperand::createReg(AArch64::ZT0));
   return Success;
 }
 
-static const MCPhysReg MatrixZATileDecoderTable[5][16] = {
-    {AArch64::ZAB0},
-    {AArch64::ZAH0, AArch64::ZAH1},
-    {AArch64::ZAS0, AArch64::ZAS1, AArch64::ZAS2, AArch64::ZAS3},
-    {AArch64::ZAD0, AArch64::ZAD1, AArch64::ZAD2, AArch64::ZAD3, AArch64::ZAD4,
-     AArch64::ZAD5, AArch64::ZAD6, AArch64::ZAD7},
-    {AArch64::ZAQ0, AArch64::ZAQ1, AArch64::ZAQ2, AArch64::ZAQ3, AArch64::ZAQ4,
-     AArch64::ZAQ5, AArch64::ZAQ6, AArch64::ZAQ7, AArch64::ZAQ8, AArch64::ZAQ9,
-     AArch64::ZAQ10, AArch64::ZAQ11, AArch64::ZAQ12, AArch64::ZAQ13,
-     AArch64::ZAQ14, AArch64::ZAQ15}};
+static DecodeStatus DecodeMPRRegisterClass(MCInst &Inst,
+                                           const MCDisassembler *Decoder) {
+  Inst.addOperand(MCOperand::createReg(AArch64::ZA));
+  return Success;
+}
 
-template <unsigned NumBitsForTile>
-static DecodeStatus DecodeMatrixTile(MCInst &Inst,
-                                     const MCDisassembler *Decoder) {
-  static_assert(NumBitsForTile == 0);
+static DecodeStatus DecodeMPR8RegisterClass(MCInst &Inst,
+                                            const MCDisassembler *Decoder) {
   Inst.addOperand(MCOperand::createReg(AArch64::ZAB0));
   return Success;
 }
 
-template <unsigned NumBitsForTile>
-static DecodeStatus DecodeMatrixTile(MCInst &Inst, unsigned RegNo,
-                                     uint64_t Address,
-                                     const MCDisassembler *Decoder) {
-  static_assert(NumBitsForTile != 0);
-  unsigned LastReg = (1 << NumBitsForTile) - 1;
-  if (RegNo > LastReg)
-    return Fail;
-  Inst.addOperand(
-      MCOperand::createReg(MatrixZATileDecoderTable[NumBitsForTile][RegNo]));
+static DecodeStatus DecodeMPR16RegisterClass(MCInst &Inst, unsigned RegNo,
+                                             uint64_t Address,
+                                             const MCDisassembler *Decoder) {
+  MCRegister Reg =
+      AArch64MCRegisterClasses[AArch64::MPR16RegClassID].getRegister(RegNo);
+  Inst.addOperand(MCOperand::createReg(Reg));
+  return Success;
+}
+
+static DecodeStatus DecodeMPR32RegisterClass(MCInst &Inst, unsigned RegNo,
+                                             uint64_t Address,
+                                             const MCDisassembler *Decoder) {
+  MCRegister Reg =
+      AArch64MCRegisterClasses[AArch64::MPR32RegClassID].getRegister(RegNo);
+  Inst.addOperand(MCOperand::createReg(Reg));
+  return Success;
+}
+
+static DecodeStatus DecodeMPR64RegisterClass(MCInst &Inst, unsigned RegNo,
+                                             uint64_t Address,
+                                             const MCDisassembler *Decoder) {
+  MCRegister Reg =
+      AArch64MCRegisterClasses[AArch64::MPR64RegClassID].getRegister(RegNo);
+  Inst.addOperand(MCOperand::createReg(Reg));
+  return Success;
+}
+
+static DecodeStatus DecodeMPR128RegisterClass(MCInst &Inst, unsigned RegNo,
+                                              uint64_t Address,
+                                              const MCDisassembler *Decoder) {
+  MCRegister Reg =
+      AArch64MCRegisterClasses[AArch64::MPR128RegClassID].getRegister(RegNo);
+  Inst.addOperand(MCOperand::createReg(Reg));
   return Success;
 }
 

--- a/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
+++ b/llvm/lib/Target/AArch64/Disassembler/AArch64Disassembler.cpp
@@ -130,6 +130,18 @@ DecodeMatrixTileListRegisterClass(MCInst &Inst, unsigned RegMask,
   return Success;
 }
 
+static DecodeStatus DecodeMPRRegisterClass(MCInst &Inst,
+                                           const MCDisassembler *Decoder) {
+  Inst.addOperand(MCOperand::createReg(AArch64::ZA));
+  return Success;
+}
+
+static DecodeStatus DecodeZTRRegisterClass(MCInst &Inst,
+                                           const MCDisassembler *Decoder) {
+  Inst.addOperand(MCOperand::createReg(AArch64::ZT0));
+  return Success;
+}
+
 static const MCPhysReg MatrixZATileDecoderTable[5][16] = {
     {AArch64::ZAB0},
     {AArch64::ZAH0, AArch64::ZAH1},
@@ -142,9 +154,18 @@ static const MCPhysReg MatrixZATileDecoderTable[5][16] = {
      AArch64::ZAQ14, AArch64::ZAQ15}};
 
 template <unsigned NumBitsForTile>
+static DecodeStatus DecodeMatrixTile(MCInst &Inst,
+                                     const MCDisassembler *Decoder) {
+  static_assert(NumBitsForTile == 0);
+  Inst.addOperand(MCOperand::createReg(AArch64::ZAB0));
+  return Success;
+}
+
+template <unsigned NumBitsForTile>
 static DecodeStatus DecodeMatrixTile(MCInst &Inst, unsigned RegNo,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
+  static_assert(NumBitsForTile != 0);
   unsigned LastReg = (1 << NumBitsForTile) - 1;
   if (RegNo > LastReg)
     return Fail;
@@ -1392,6 +1413,11 @@ DecodeSVELogicalImmInstruction(MCInst &Inst, uint32_t insn, uint64_t Addr,
   return Success;
 }
 
+static DecodeStatus DecodeZeroImm(MCInst &Inst, const MCDisassembler *Decoder) {
+  Inst.addOperand(MCOperand::createImm(0));
+  return Success;
+}
+
 template <int Bits>
 static DecodeStatus DecodeSImm(MCInst &Inst, uint64_t Imm, uint64_t Address,
                                const MCDisassembler *Decoder) {
@@ -1540,6 +1566,7 @@ DecodeSMESpillFillInstruction(MCInst &Inst, uint32_t Bits, uint64_t Addr,
   unsigned RnBits = fieldFromInstruction(Bits, 5, 5);
   unsigned Imm4Bits = fieldFromInstruction(Bits, 0, 4);
 
+  DecodeMPRRegisterClass(Inst, Decoder);
   DecodeSimpleRegisterClass<AArch64::MatrixIndexGPR32_12_15RegClassID, 0, 4>(
       Inst, RvBits, Addr, Decoder);
   Inst.addOperand(MCOperand::createImm(Imm4Bits));
@@ -1583,33 +1610,6 @@ DecodeStatus AArch64Disassembler::getInstruction(MCInst &MI, uint64_t &Size,
   for (const auto *Table : Tables) {
     DecodeStatus Result =
         decodeInstruction(Table, MI, Insn, Address, this, STI);
-
-    const MCInstrDesc &Desc = MCII->get(MI.getOpcode());
-
-    // For Scalable Matrix Extension (SME) instructions that have an implicit
-    // operand for the accumulator (ZA) or implicit immediate zero which isn't
-    // encoded, manually insert operand.
-    for (unsigned i = 0; i < Desc.getNumOperands(); i++) {
-      if (Desc.operands()[i].OperandType == MCOI::OPERAND_REGISTER) {
-        switch (Desc.operands()[i].RegClass) {
-        default:
-          break;
-        case AArch64::MPRRegClassID:
-          MI.insert(MI.begin() + i, MCOperand::createReg(AArch64::ZA));
-          break;
-        case AArch64::MPR8RegClassID:
-          MI.insert(MI.begin() + i, MCOperand::createReg(AArch64::ZAB0));
-          break;
-        case AArch64::ZTRRegClassID:
-          MI.insert(MI.begin() + i, MCOperand::createReg(AArch64::ZT0));
-          break;
-        }
-      } else if (Desc.operands()[i].OperandType ==
-                 AArch64::OPERAND_IMPLICIT_IMM_0) {
-        MI.insert(MI.begin() + i, MCOperand::createImm(0));
-      }
-    }
-
     if (Result != MCDisassembler::Fail)
       return Result;
   }

--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -894,6 +894,7 @@ multiclass sme_mem_ld_v_ss<string mnemonic, bit is_col> {
   def _B : sme_mem_ld_ss_inst<0b0, 0b00, mnemonic # "b",
                               !if(is_col, TileVectorOpV8, TileVectorOpH8),
                               is_col, sme_elm_idx0_15, GPR64shifted8> {
+    bits<0> ZAt;
     bits<4> imm;
     let Inst{3-0} = imm;
   }
@@ -925,6 +926,7 @@ multiclass sme_mem_ld_v_ss<string mnemonic, bit is_col> {
                               !if(is_col, TileVectorOpV128, TileVectorOpH128),
                               is_col, sme_elm_idx0_0, GPR64shifted128> {
     bits<4> ZAt;
+    bits<0> imm;
     let Inst{3-0} = ZAt;
   }
 
@@ -1032,6 +1034,7 @@ multiclass sme_mem_st_v_ss<string mnemonic, bit is_col> {
   def _B : sme_mem_st_ss_inst<0b0, 0b00, mnemonic # "b",
                               !if(is_col, TileVectorOpV8, TileVectorOpH8),
                               is_col, sme_elm_idx0_15, GPR64shifted8> {
+    bits<0> ZAt;
     bits<4> imm;
     let Inst{3-0} = imm;
   }
@@ -1063,6 +1066,7 @@ multiclass sme_mem_st_v_ss<string mnemonic, bit is_col> {
                               !if(is_col, TileVectorOpV128, TileVectorOpH128),
                               is_col, sme_elm_idx0_0, GPR64shifted128> {
     bits<4> ZAt;
+    bits<0> imm;
     let Inst{3-0} = ZAt;
   }
 
@@ -1232,6 +1236,7 @@ multiclass sme_vector_v_to_tile<string mnemonic, bit is_col> {
                                                           TileVectorOpH8),
                                    is_col, sme_elm_idx0_15, ZPR8, mnemonic>,
                                    SMEPseudo2Instr<NAME # _B, 1> {
+    bits<0> ZAd;
     bits<4> imm;
     let Inst{3-0} = imm;
   }
@@ -1417,6 +1422,7 @@ multiclass sme_tile_to_vector_v<string mnemonic, bit is_col> {
   def _B : sme_tile_to_vector_inst<0b0, 0b00, ZPR8, !if(is_col, TileVectorOpV8,
                                                                 TileVectorOpH8),
                                    is_col, sme_elm_idx0_15, mnemonic> {
+    bits<0> ZAn;
     bits<4> imm;
     let Inst{8-5} = imm;
     let mayLoad = 1;
@@ -1452,6 +1458,7 @@ multiclass sme_tile_to_vector_v<string mnemonic, bit is_col> {
                                                                   TileVectorOpH128),
                                    is_col, sme_elm_idx0_0, mnemonic> {
     bits<4> ZAn;
+    bits<0> imm;
     let Inst{8-5} = ZAn;
     let mayLoad = 1;
   }
@@ -1738,6 +1745,7 @@ class sme2_dot_mla_add_sub_array_vg24_single<bits<7> op,
        sme_elm_idx0_7:$imm3, multi_vector_ty:$Zn, zpr_ty:$Zm),
        mnemonic,"\t$ZAd[$Rv, $imm3, " # !if(op{5}, "vgx4", "vgx2") # "], $Zn, $Zm",
        "", []> , Sched<[]> {
+  bits<0> ZAd;
   bits<4> Zm;
   bits<5> Zn;
   bits<2> Rv;
@@ -1805,6 +1813,7 @@ class sme2_dot_mla_add_sub_array_vg2_multi<bits<7> op,
        sme_elm_idx0_7:$imm3, multi_vector_ty:$Zn, multi_vector_ty:$Zm),
        mnemonic, "\t$ZAd[$Rv, $imm3, vgx2], $Zn, $Zm",
        "", []>, Sched<[]>{
+  bits<0> ZAd;
   bits<4> Zm;
   bits<4> Zn;
   bits<2> Rv;
@@ -1845,6 +1854,7 @@ class sme2_dot_mla_add_sub_array_vg4_multi<bits<7> op,
         sme_elm_idx0_7:$imm3, multi_vector_ty:$Zn, multi_vector_ty:$Zm),
         mnemonic, "\t$ZAd[$Rv, $imm3, vgx4], $Zn, $Zm",
         "", []>, Sched<[]>{
+  bits<0> ZAd;
   bits<3> Zm;
   bits<3> Zn;
   bits<2> Rv;
@@ -1887,6 +1897,7 @@ class sme2_multivec_accum_add_sub<string mnemonic, bit sz, bit vg4, bits<3> op,
         (ins matrix_ty:$_ZAdn, MatrixIndexGPR32Op8_11:$Rv, sme_elm_idx0_7:$imm3, vector_ty:$Zm),
         mnemonic, "\t$ZAdn[$Rv, $imm3, " # !if(vg4, "vgx4", "vgx2") # "], $Zm",
         "", []>, Sched<[]> {
+  bits<0> ZAdn;
   bits<2> Rv;
   bits<3> imm3;
   let Inst{31-23} = 0b110000011;
@@ -2129,6 +2140,7 @@ class sme2_mla_long_array_index_base<bits<2> op0, bits<2> op, Operand index_ty,
         (ins MatrixOp32:$_ZAda, MatrixIndexGPR32Op8_11:$Rv, index_ty:$imm, multi_vector_ty:$Zn, ZPR4b16:$Zm, VectorIndexH32b_timm:$i3),
         mnemonic, "\t$ZAda[$Rv, $imm" # !if(!eq(vg_acronym, ""), "", ", " # vg_acronym) # "], $Zn, $Zm$i3",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   let Inst{31-24} = 0b11000001;
@@ -2243,6 +2255,7 @@ class sme2_mla_long_array<bits<2>op0, bits<2> op,
        index_ty:$imm, first_vector_ty:$Zn, second_vector_ty:$Zm),
        mnemonic,"\t$ZAda[$Rv, $imm" # !if(!eq(vg_acronym, ""), "", ", " # vg_acronym) # "], $Zn, $Zm",
        "", []> , Sched<[]> {
+  bits<0> ZAda;
   bits<2> Rv;
   let Inst{31-24} = 0b11000001;
   let Inst{23-22} = op0;
@@ -2789,6 +2802,7 @@ class sme2_multi_vec_array_vg2_index<bits<2> sz, bits<6> op, MatrixOperand matri
          multi_vector_ty:$Zn, vector_ty:$Zm, index_ty:$i),
          mnemonic, "\t$ZAda[$Rv, $imm3, vgx2], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<4> Zn;
@@ -2887,6 +2901,7 @@ class sme2_multi_vec_array_vg2_index_64b<bits<2> op,
          multi_vector_ty:$Zn, vector_ty:$Zm, VectorIndexD32b_timm:$i1),
         mnemonic, "\t$ZAda[$Rv, $imm3, vgx2], $Zn, $Zm$i1",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<1> i1;
@@ -2931,6 +2946,7 @@ class sme2_multi_vec_array_vg4_index<bit sz, bits<7> op, MatrixOperand matrix_ty
          multi_vector_ty:$Zn, vector_ty:$Zm, index_ty:$i),
          mnemonic, "\t$ZAda[$Rv, $imm3, vgx4], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<3> Zn;
@@ -3018,6 +3034,7 @@ class sme2_multi_vec_array_vg4_index_64b<bits<3> op,
          multi_vector_ty:$Zn, vector_ty:$Zm, VectorIndexD32b_timm:$i1),
         mnemonic, "\t$ZAda[$Rv, $imm3, vgx4], $Zn, $Zm$i1",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<1> i1;
@@ -3062,6 +3079,7 @@ class sme2_fp8_fmlal_vg24_index_za16<bits<2> sz, bit vg4, bits<3> op,
          multi_vector_ty:$Zn, ZPR4b8:$Zm, VectorIndexB32b_timm:$i),
          mnemonic, "\t$ZAda[$Rv, $imm2, " # !if(vg4, "vgx4", "vgx2") # "], $Zn, $Zm$i",
          "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<4> i;
@@ -3119,6 +3137,7 @@ class sme2_fp8_fmlal_index_za16<string mnemonic, bits<2> sz,bits<2> op>
         (ins MatrixOp16:$_ZAda, MatrixIndexGPR32Op8_11:$Rv, uimm3s2range:$imm3, ZPR8:$Zn, ZPR4b8:$Zm, VectorIndexB32b_timm:$i),
         mnemonic, "\t$ZAda[$Rv, $imm3], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<4> i;
@@ -3155,6 +3174,7 @@ class sme2_mla_ll_array_index_32b<string mnemonic, bits<2> sz, bits<3> op>
         (ins MatrixOp32:$_ZAda, MatrixIndexGPR32Op8_11:$Rv, uimm2s4range:$imm2, ZPR8:$Zn, ZPR4b8:$Zm, VectorIndexB32b_timm:$i),
         mnemonic, "\t$ZAda[$Rv, $imm2], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<4> i;
@@ -3191,6 +3211,7 @@ class sme2_mla_ll_array_index_64b<string mnemonic, bits<2> op>
         (ins MatrixOp64:$_ZAda, MatrixIndexGPR32Op8_11:$Rv, uimm2s4range:$imm2, ZPR16:$Zn, ZPR4b16:$Zm, VectorIndexH32b_timm:$i),
         mnemonic, "\t$ZAda[$Rv, $imm2], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<3> i;
@@ -3226,6 +3247,7 @@ class sme2_mla_ll_array_vg24_index_32b<bits<2> sz, bit vg4, bits<3> op,
              vector_ty:$Zn, ZPR4b8:$Zm, VectorIndexB32b_timm:$i),
         mnemonic, "\t$ZAda[$Rv, $imm, " # !if(vg4, "vgx4", "vgx2") # "], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<4> i;
@@ -3287,6 +3309,7 @@ class sme2_mla_ll_array_vg24_index_64b<bit vg4,  bits<2> op,
              vector_ty:$Zn, ZPR4b16:$Zm, VectorIndexH32b_timm:$i),
         mnemonic, "\t$ZAda[$Rv, $imm, " # !if(vg4, "vgx4", "vgx2") # "], $Zn, $Zm$i",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<3> i;
@@ -3349,6 +3372,7 @@ class sme2_mla_ll_array_single<string mnemonic, bits<5> op,
              vector_ty:$Zn, zpr_ty:$Zm),
         mnemonic, "\t$ZAda[$Rv, $imm], $Zn, $Zm",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<5> Zn;
@@ -3387,6 +3411,7 @@ class sme2_mla_ll_array_vg24_single<bits<6> op, MatrixOperand matrix_ty,
              vector_ty:$Zn, zpr_ty:$Zm),
         mnemonic, "\t$ZAda[$Rv, $imm,  " # !if(op{4}, "vgx4", "vgx2") # "], $Zn, $Zm",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<5> Zn;
@@ -3447,6 +3472,7 @@ class sme2_mla_ll_array_vg2_multi<bits<5> op, MatrixOperand matrix_ty,
              vector_ty:$Zn, vector_ty:$Zm),
         mnemonic, "\t$ZAda[$Rv, $imm, vgx2], $Zn, $Zm",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<4> Zm;
   bits<2> Rv;
   bits<4> Zn;
@@ -3492,6 +3518,7 @@ class sme2_mla_ll_array_vg4_multi<bits<5> op,MatrixOperand matrix_ty,
              vector_ty:$Zn, vector_ty:$Zm),
         mnemonic, "\t$ZAda[$Rv, $imm, vgx4], $Zn, $Zm",
         "", []>, Sched<[]> {
+  bits<0> ZAda;
   bits<3> Zm;
   bits<2> Rv;
   bits<3> Zn;
@@ -3638,6 +3665,7 @@ class sme2_zero_zt<string mnemonic, bits<4> opc>
     : I<(outs ZTR:$ZT), (ins ),
          mnemonic, "\t\\{ $ZT \\}",
          "", []>, Sched<[]> {
+  bits<0> ZT;
   let Inst{31-4} = 0b1100000001001000000000000000;
   let Inst{3-0}  = opc;
 }
@@ -3660,6 +3688,7 @@ class sme2_spill_fill_vector<string mnemonic, bits<8> opc>
         !if(opc{7}, (ins ZTR:$ZTt, GPR64sp:$Rn), (ins GPR64sp:$Rn)),
         mnemonic, "\t$ZTt, [$Rn]",
         "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Rn;
   let Inst{31-22} = 0b1110000100;
   let Inst{21-16} = opc{7-2};
@@ -3690,6 +3719,7 @@ class sme2_movt_zt_to_scalar<string mnemonic, bits<7> opc>
     : I<(outs GPR64:$Rt), (ins ZTR:$ZTt, uimm3s8:$imm3),
          mnemonic, "\t$Rt, $ZTt[$imm3]",
          "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<3> imm3;
   bits<5> Rt;
   let Inst{31-15} = 0b11000000010011000;
@@ -3702,6 +3732,7 @@ class sme2_movt_scalar_to_zt<string mnemonic, bits<7> opc>
     : I<(outs ZTR:$ZTt), (ins uimm3s8:$imm3, GPR64:$Rt),
          mnemonic, "\t$ZTt[$imm3], $Rt",
          "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<3> imm3;
   bits<5> Rt;
   let Inst{31-15} = 0b11000000010011100;
@@ -3715,6 +3746,7 @@ class sme2_movt_zt_to_zt<string mnemonic, bits<7> opc>
    : I<(outs ZTR:$ZTt), (ins sme_elm_idx0_3:$off2, ZPRAny:$Zt),
         mnemonic, "\t$ZTt[$off2, mul vl], $Zt",
         "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Zt;
   bits<2> off2;
   let Inst{31-14} = 0b110000000100111100;
@@ -3748,6 +3780,7 @@ class sme2_luti_vector_index<bits<2> sz, bits<7> opc, RegisterOperand vector_ty,
         (ins ZTR:$ZTt, ZPRAny:$Zn, index_ty:$i),
         mnemonic, "\t$Zd, $ZTt, $Zn$i",
         "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Zn;
   bits<5> Zd;
   let Inst{31-19} = 0b1100000011001;
@@ -3817,6 +3850,7 @@ class sme2_luti_vector_vg2_index<bits<2> sz, bits<6> opc, RegisterOperand vector
         (ins ZTR:$ZTt, ZPRAny:$Zn, index_ty:$i),
         mnemonic, "\t$Zd, $ZTt, $Zn$i",
         "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Zn;
   bits<4> Zd;
   let Inst{31-19} = 0b1100000010001;
@@ -3862,6 +3896,7 @@ class sme2_luti_vector_vg4_index<bits<2> sz, bits<5>opc, RegisterOperand vector_
         (ins ZTR:$ZTt, ZPRAny:$Zn, index_ty:$i),
         mnemonic, "\t$Zd, $ZTt, $Zn$i",
         "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Zn;
   bits<3> Zd;
   let Inst{31-19} = 0b1100000010001;
@@ -3944,6 +3979,7 @@ multiclass sme2_mova_vec_to_tile_vg2_multi_base<bit v, string mnemonic, SDPatter
                                                        TileVectorOpH8),
                                                 uimm3s2range,  ZZ_b_mul_r,
                                                 mnemonic>, SMEPseudo2Instr<NAME # _B, 1> {
+    bits<0> ZAd;
     bits<3> imm;
     let Inst{2-0} = imm;
   }
@@ -3976,6 +4012,7 @@ multiclass sme2_mova_vec_to_tile_vg2_multi_base<bit v, string mnemonic, SDPatter
                                                 uimm0s2range, ZZ_d_mul_r,
                                                 mnemonic>, SMEPseudo2Instr<NAME # _D, 1> {
     bits<3> ZAd;
+    bits<0> imm;
     let Inst{2-0} = ZAd;
    }
 
@@ -4108,6 +4145,7 @@ multiclass sme2_mova_vec_to_tile_vg4_multi_base<bit v, string mnemonic, SDPatter
                                                        TileVectorOpH8),
                                                 uimm2s4range, ZZZZ_b_mul_r,
                                                 mnemonic>, SMEPseudo2Instr<NAME # _B, 1> {
+    bits<0> ZAd;
     bits<2> imm;
     let Inst{1-0} = imm;
   }
@@ -4129,6 +4167,7 @@ multiclass sme2_mova_vec_to_tile_vg4_multi_base<bit v, string mnemonic, SDPatter
                                                  uimm0s4range, ZZZZ_s_mul_r,
                                                  mnemonic>, SMEPseudo2Instr<NAME # _S, 1> {
     bits<2> ZAd;
+    bits<0> imm;
     let Inst{1-0} = ZAd;
   }
 
@@ -4138,6 +4177,7 @@ multiclass sme2_mova_vec_to_tile_vg4_multi_base<bit v, string mnemonic, SDPatter
                                                 uimm0s4range, ZZZZ_d_mul_r,
                                                 mnemonic>, SMEPseudo2Instr<NAME # _D, 1> {
     bits<3> ZAd;
+    bits<0> imm;
     let Inst{2-0} = ZAd;
   }
 
@@ -4223,6 +4263,7 @@ class sme2_mova_vec_to_array_vg24_multi< bits<5> op, RegisterOperand array_ty,
             vector_ty:$Zn),
        mnemonic, "\t$ZAd[$Rs, $imm, " # vg_acronym # "], $Zn",
        "", []>, Sched<[]> {
+  bits<0> ZAd;
   bits<2> Rs;
   bits<3> imm;
   let Inst{31-15} = 0b11000000000001000;
@@ -4477,6 +4518,7 @@ multiclass sme2_mova_tile_to_vec_vg2_multi_inst<bit v, bits<3> opc, string mnemo
                                                 !if(v, TileVectorOpV8,
                                                        TileVectorOpH8),
                                                  uimm3s2range, mnemonic>, SMEPseudo2Instr<NAME # _B, 1> {
+    bits<0> ZAn;
     bits<3> imm;
     let Inst{7-5} = imm;
     let mayLoad = 1;
@@ -4509,6 +4551,7 @@ multiclass sme2_mova_tile_to_vec_vg2_multi_inst<bit v, bits<3> opc, string mnemo
                                                        TileVectorOpH64),
                                                 uimm0s2range, mnemonic>, SMEPseudo2Instr<NAME # _D, 1> {
     bits<3> ZAn;
+    bits<0> imm;
     let Inst{7-5} = ZAn;
     let mayLoad = 1;
   }
@@ -4623,6 +4666,7 @@ multiclass sme2_mova_tile_to_vec_vg4_multi_base<bit v, bits<3> opc, string mnemo
                                                 !if(v, TileVectorOpV8,
                                                        TileVectorOpH8),
                                                 uimm2s4range, mnemonic>, SMEPseudo2Instr<NAME # _B, 1> {
+    bits<0> ZAn;
     bits<2> imm;
     let Inst{6-5} = imm;
     let mayLoad = 1;
@@ -4646,6 +4690,7 @@ multiclass sme2_mova_tile_to_vec_vg4_multi_base<bit v, bits<3> opc, string mnemo
                                                        TileVectorOpH32),
                                                  uimm0s4range, mnemonic>, SMEPseudo2Instr<NAME # _S, 1> {
     bits<2> ZAn;
+    bits<0> imm;
     let Inst{6-5} = ZAn;
     let mayLoad = 1;
   }
@@ -4656,6 +4701,7 @@ multiclass sme2_mova_tile_to_vec_vg4_multi_base<bit v, bits<3> opc, string mnemo
                                                        TileVectorOpH64),
                                                 uimm0s4range, mnemonic>, SMEPseudo2Instr<NAME # _D, 1> {
     bits<3> ZAn;
+    bits<0> imm;
     let Inst{7-5} = ZAn;
     let mayLoad = 1;
   }
@@ -4745,6 +4791,7 @@ class sme2_mova_array_to_vec_vg24_multi<bits<4>op, RegisterOperand vector_ty,
        mnemonic,
        "\t$Zd, $ZAn[$Rs, $imm, " # vg_acronym # "]",
        "", []>, Sched<[]> {
+  bits<0> ZAn;
   bits<2> Rs;
   bits<3> imm;
   let Inst{31-15} = 0b11000000000001100;
@@ -5278,6 +5325,7 @@ multiclass sme2p1_movaz_tile_to_vec_base<bit v, string mnemonic> {
   def _B : sme2p1_movaz_tile_to_vec_base<0b00, 0b0, v, ZPR8,
                                     !if(v, TileVectorOpV8, TileVectorOpH8),
                                     sme_elm_idx0_15, mnemonic>, SMEPseudo2Instr<NAME # _B, 1> {
+    bits<0> ZAn;
     bits<4> imm;
     let Inst{8-5} = imm;
   }
@@ -5313,6 +5361,7 @@ multiclass sme2p1_movaz_tile_to_vec_base<bit v, string mnemonic> {
                                     !if(v, TileVectorOpV128, TileVectorOpH128),
                                     sme_elm_idx0_0, mnemonic>, SMEPseudo2Instr<NAME # _Q, 1> {
     bits<4> ZAn;
+    bits<0> imm;
     let Inst{8-5} = ZAn;
   }
 }
@@ -5382,7 +5431,8 @@ class sme2p1_zero_matrix<bits<6> opc, Operand index_ty, string mnemonic,
         (ins MatrixOp64:$_ZAd, MatrixIndexGPR32Op8_11:$Rv, index_ty:$imm),
         mnemonic, "\t$ZAd[$Rv, $imm" # !if(!eq(vg_acronym, ""), "", ", " # vg_acronym) # "]",
         "", []>, Sched<[]> {
-  bits <2> Rv;
+  bits<0> ZAd;
+  bits<2> Rv;
   let Inst{31-18} = 0b11000000000011;
   let Inst{17-15} = opc{5-3};
   let Inst{14-13} = Rv;
@@ -5453,6 +5503,7 @@ class sme2p1_luti_vector_vg2_index<bits<4> op, bits<2> sz, RegisterOperand vecto
     :  I<(outs vector_ty:$Zd), (ins ZTR:$ZTt, ZPRAny:$Zn, index_ty:$i),
           mnemonic, "\t$Zd, $ZTt, $Zn$i",
           "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Zn;
   bits<4> Zd;
   let Inst{31-19} = 0b1100000010011;
@@ -5502,6 +5553,7 @@ class sme2p1_luti_vector_vg4_index<bits<3> op, bits<2> sz, RegisterOperand vecto
     :  I<(outs vector_ty:$Zd), (ins ZTR:$ZTt, ZPRAny:$Zn, index_ty:$i),
           mnemonic, "\t$Zd, $ZTt, $Zn$i",
           "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<5> Zn;
   bits<3> Zd;
   let Inst{31-19} = 0b1100000010011;
@@ -5547,6 +5599,7 @@ class sme2_luti4_vector_vg4<bits<2> sz, bits<2> op, string mnemonic>
   : I<(outs ZZZZ_b_mul_r:$Zd), (ins ZTR:$ZTt, ZZ_mul_r:$Zn),
        mnemonic, "\t$Zd, $ZTt, $Zn",
        "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<4> Zn;
   bits<3> Zd;
   let Inst{31-14} = 0b110000001000101100;
@@ -5563,6 +5616,7 @@ class sme2_luti4_vector_vg4_strided<bits<2> sz, bits<2> op, string mnemonic>
    : I<(outs ZZZZ_b_strided:$Zd), (ins ZTR:$ZTt, ZZ_mul_r:$Zn),
         mnemonic, "\t$Zd, $ZTt, $Zn",
         "", []>, Sched<[]> {
+  bits<0> ZTt;
   bits<4> Zn;
   bits<3> Zd;
   let Inst{31-14} = 0b110000001001101100;

--- a/llvm/lib/Target/AArch64/SMEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SMEInstrFormats.td
@@ -1272,7 +1272,7 @@ multiclass sme_vector_v_to_tile<string mnemonic, bit is_col> {
                                    is_col, sme_elm_idx0_0, ZPR128, mnemonic>,
                                    SMEPseudo2Instr<NAME # _Q, 1> {
     bits<4> ZAd;
-    bits<1> imm;
+    bits<0> imm;
     let Inst{3-0} = ZAd;
   }
 

--- a/llvm/lib/Target/AArch64/SVEInstrFormats.td
+++ b/llvm/lib/Target/AArch64/SVEInstrFormats.td
@@ -10727,7 +10727,9 @@ class sve2p1_vector_to_pred<bits<4> opc, string mnemonic,
 }
 
 multiclass sve2p1_vector_to_pred<string mnemonic, SDPatternOperator Op_lane, SDPatternOperator Op> {
-  def _B : sve2p1_vector_to_pred<{0, 0, 0, 1}, mnemonic, PPR8,  VectorIndex032b>;
+  def _B : sve2p1_vector_to_pred<{0, 0, 0, 1}, mnemonic, PPR8,  VectorIndex032b> {
+    bits<0> index;
+  }
   def _H : sve2p1_vector_to_pred<{0, 0, 1, ?}, mnemonic, PPR16, VectorIndexD32b> {
     bits<1> index;
     let Inst{17} = index;
@@ -10794,7 +10796,9 @@ class sve2p1_pred_to_vector<bits<4> opc, string mnemonic,
 
 multiclass sve2p1_pred_to_vector<string mnemonic, SDPatternOperator MergeOp,
                                  SDPatternOperator ZeroOp> {
-  def _B : sve2p1_pred_to_vector<{0, 0, 0, 1}, mnemonic, PPR8,  VectorIndex0>;
+  def _B : sve2p1_pred_to_vector<{0, 0, 0, 1}, mnemonic, PPR8,  VectorIndex0> {
+    bits<0> index;
+  }
   def _H : sve2p1_pred_to_vector<{0, 0, 1, ?}, mnemonic, PPR16, VectorIndexD32b> {
     bits<1> index;
     let Inst{17} = index;

--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2249,7 +2249,6 @@ llvm_target_lib_list = [lib for lib in [
             "lib/Target/ARM/ARMGenSubtargetInfo.inc": ["-gen-subtarget"],
             "lib/Target/ARM/ARMGenDisassemblerTables.inc": [
                 "-gen-disassembler",
-                "-ignore-non-decodable-operands",
             ],
         },
     },


### PR DESCRIPTION
Add `bits<0>` fields to instructions using the ZTR/MPR/MPR8 register classes.
These register classes contain only one register, and it is not encoded in the instruction.
This way, the generated decoder can completely decode instructions without having to perform a post-decoding pass to insert missing operands.

Some immediate operands are also not encoded and have only one possible value "zero". Use this trick for them, too.

Finally, remove `-ignore-non-decodable-operands` option from `llvm-tblgen` invocation to ensure that non-decodable operands do not appear in the future.
