### PR TITLE
[llvm-reduce] Treat CallBrInst as Branch

### DIFF
--- a/llvm/test/tools/llvm-reduce/reduce-bb-callbr.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-bb-callbr.ll
@@ -1,22 +1,44 @@
-; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=basic-blocks --test FileCheck --test-arg %s --test-arg --match-full-lines --test-arg --check-prefix=INTERESTING --test-arg --input-file
-; RUN: FileCheck %s --input-file %t --check-prefixes=INTERESTING
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=basic-blocks --test FileCheck --test-arg %s --test-arg --check-prefix=INTERESTING --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefixes=CHECK,INTERESTING
 
-; CHECK-INTERESTINGNESS: store i32 0,
-; CHECK-INTERESTINGNESS: store i32 1,
 
-define i32 @e(ptr %p, i1 %cond) {
-entry:
+; CHECK-LABEL: define i32 @keep_callbr(ptr %p, i1 %cond) {
+; CHECK: entry1:
+; CHECK-NEXT: callbr void asm
+; INTERESTING: store i32 0,
+; INTERESTING: store i32 1,
+
+define i32 @keep_callbr(ptr %p, i1 %cond) {
+entry1:
   callbr void asm sideeffect "", "!i,~{dirflag},~{fpsr},~{flags}"()
   to label %for.cond [label %preheader]
 
 for.cond:
   store i32 0, ptr %p
-  br label %preheader
+  ret i32 0
 
 preheader:
-  store i32 1, %p
-  br i1 %%cond, label %for.cond, label %g
+  store i32 1, ptr %p
+  ret i32 1
+}
 
-returnbb:
+
+; CHECK-LABEL: define i32 @drop_callbr(ptr %p, i1 %cond) {
+; CHECK: entry1:
+; CHECK-NEXT: br
+; INTERESTING: store i32 0,
+
+define i32 @drop_callbr(ptr %p, i1 %cond) {
+entry1:
+  callbr void asm sideeffect "", "!i,~{dirflag},~{fpsr},~{flags}"()
+  to label %for.cond [label %preheader]
+
+for.cond:
+  store i32 0, ptr %p
   ret i32 0
+
+preheader:
+  store i32 1, ptr %p
+  ret i32 1
+
 }

--- a/llvm/test/tools/llvm-reduce/reduce-bb-callbr.ll
+++ b/llvm/test/tools/llvm-reduce/reduce-bb-callbr.ll
@@ -1,0 +1,22 @@
+; RUN: llvm-reduce %s -o %t --abort-on-invalid-reduction --delta-passes=basic-blocks --test FileCheck --test-arg %s --test-arg --match-full-lines --test-arg --check-prefix=INTERESTING --test-arg --input-file
+; RUN: FileCheck %s --input-file %t --check-prefixes=INTERESTING
+
+; CHECK-INTERESTINGNESS: store i32 0,
+; CHECK-INTERESTINGNESS: store i32 1,
+
+define i32 @e(ptr %p, i1 %cond) {
+entry:
+  callbr void asm sideeffect "", "!i,~{dirflag},~{fpsr},~{flags}"()
+  to label %for.cond [label %preheader]
+
+for.cond:
+  store i32 0, ptr %p
+  br label %preheader
+
+preheader:
+  store i32 1, %p
+  br i1 %%cond, label %for.cond, label %g
+
+returnbb:
+  ret i32 0
+}

--- a/llvm/tools/llvm-reduce/deltas/ReduceBasicBlocks.cpp
+++ b/llvm/tools/llvm-reduce/deltas/ReduceBasicBlocks.cpp
@@ -49,7 +49,7 @@ static void replaceBranchTerminator(BasicBlock &BB,
   if (isa<CatchSwitchInst>(Term))
     return;
 
-  bool IsBranch = isa<BranchInst>(Term);
+  bool IsBranch = isa<BranchInst>(Term) || isa<CallBrInst>(Term);
   if (InvokeInst *Invoke = dyn_cast<InvokeInst>(Term)) {
     BasicBlock *UnwindDest = Invoke->getUnwindDest();
     BasicBlock::iterator LP = UnwindDest->getFirstNonPHIIt();


### PR DESCRIPTION
Fixes the bug of the missing terminator for CallBrInst. Crash when I reduce https://github.com/llvm/llvm-project/issues/155807.