### PR TITLE
[HLSL][DirectX] Add support for `rootsig` as a target environment

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1185,6 +1185,7 @@ static llvm::Triple::EnvironmentType getEnvironmentType(llvm::StringRef Environm
              .Case("callable", llvm::Triple::Callable)
              .Case("mesh", llvm::Triple::Mesh)
              .Case("amplification", llvm::Triple::Amplification)
+             .Case("rootsignature", llvm::Triple::RootSignature)
              .Case("library", llvm::Triple::Library)
              .Default(llvm::Triple::UnknownEnvironment);
 }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13147,6 +13147,8 @@ def err_hlsl_attribute_needs_intangible_type: Error<"attribute %0 can be used on
 def err_hlsl_incorrect_num_initializers: Error<
   "too %select{few|many}0 initializers in list for type %1 "
   "(expected %2 but found %3)">;
+def err_hlsl_rootsignature_entry: Error<
+   "rootsignature specified as target environment but entry, %0, was not defined">;
 
 def err_hlsl_operator_unsupported : Error<
   "the '%select{&|*|->}0' operator is unsupported in HLSL">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -9432,7 +9432,8 @@ def target_profile : DXCJoinedOrSeparate<"T">, MetaVarName<"<profile>">,
          "cs_6_0, cs_6_1, cs_6_2, cs_6_3, cs_6_4, cs_6_5, cs_6_6, cs_6_7,"
          "lib_6_3, lib_6_4, lib_6_5, lib_6_6, lib_6_7, lib_6_x,"
          "ms_6_5, ms_6_6, ms_6_7,"
-         "as_6_5, as_6_6, as_6_7">;
+         "as_6_5, as_6_6, as_6_7,"
+         "rootsig_1_0, rootsig_1_1">;
 def emit_pristine_llvm : DXCFlag<"emit-pristine-llvm">,
   HelpText<"Emit pristine LLVM IR from the frontend by not running any LLVM passes at all."
            "Same as -S + -emit-llvm + -disable-llvm-passes.">;

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -240,7 +240,7 @@ IdentifierInfo *ParseHLSLRootSignature(Sema &Actions,
                                        llvm::dxbc::RootSignatureVersion Version,
                                        StringLiteral *Signature);
 
-void HandleRootSignatureTarget(Sema &S);
+void HandleRootSignatureTarget(Sema &S, StringRef EntryRootSig);
 
 } // namespace hlsl
 } // namespace clang

--- a/clang/include/clang/Parse/ParseHLSLRootSignature.h
+++ b/clang/include/clang/Parse/ParseHLSLRootSignature.h
@@ -240,6 +240,8 @@ IdentifierInfo *ParseHLSLRootSignature(Sema &Actions,
                                        llvm::dxbc::RootSignatureVersion Version,
                                        StringLiteral *Signature);
 
+void HandleRootSignatureTarget(Sema &S);
+
 } // namespace hlsl
 } // namespace clang
 

--- a/clang/include/clang/Sema/SemaHLSL.h
+++ b/clang/include/clang/Sema/SemaHLSL.h
@@ -157,6 +157,8 @@ public:
     RootSigOverrideIdent = DeclIdent;
   }
 
+  HLSLRootSignatureDecl *lookupRootSignatureOverrideDecl(DeclContext *DC) const;
+
   // Returns true if any RootSignatureElement is invalid and a diagnostic was
   // produced
   bool

--- a/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -453,8 +453,7 @@ void CGHLSLRuntime::addRootSignature(
   llvm::Module &M = CGM.getModule();
   Triple T(M.getTargetTriple());
 
-  // If we are not targeting a root signature enviornment then this decl will
-  // be generated when the function decl it is attached is handled
+  // Generated later with the function decl if not targeting root signature
   if (T.getEnvironment() != Triple::EnvironmentType::RootSignature)
     return;
 

--- a/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -62,6 +62,7 @@ class VarDecl;
 class ParmVarDecl;
 class InitListExpr;
 class HLSLBufferDecl;
+class HLSLRootSignatureDecl;
 class HLSLVkBindingAttr;
 class HLSLResourceBindingAttr;
 class Type;
@@ -151,6 +152,7 @@ public:
   void generateGlobalCtorDtorCalls();
 
   void addBuffer(const HLSLBufferDecl *D);
+  void addRootSignature(const HLSLRootSignatureDecl *D);
   void finishCodeGen();
 
   void setHLSLEntryAttributes(const FunctionDecl *FD, llvm::Function *Fn);

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -7537,7 +7537,7 @@ void CodeGenModule::EmitTopLevelDecl(Decl *D) {
     break;
 
   case Decl::HLSLRootSignature:
-    // Will be handled by attached function
+    getHLSLRuntime().addRootSignature(cast<HLSLRootSignatureDecl>(D));
     break;
   case Decl::HLSLBuffer:
     getHLSLRuntime().addBuffer(cast<HLSLBufferDecl>(D));

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -70,7 +70,7 @@ bool isLegalShaderModel(Triple &T) {
   return false;
 }
 
-std::optional<std::string> tryParseProfile(StringRef Profile) {
+std::optional<llvm::Triple> tryParseTriple(StringRef Profile) {
   // [ps|vs|gs|hs|ds|cs|ms|as]_[major]_[minor]
   SmallVector<StringRef, 3> Parts;
   Profile.split(Parts, "_");
@@ -152,8 +152,14 @@ std::optional<std::string> tryParseProfile(StringRef Profile) {
   T.setOSName(Triple::getOSTypeName(Triple::OSType::ShaderModel).str() +
               VersionTuple(Major, Minor).getAsString());
   T.setEnvironment(Kind);
-  if (isLegalShaderModel(T))
-    return T.getTriple();
+
+  return T;
+}
+
+std::optional<std::string> tryParseProfile(StringRef Profile) {
+  std::optional<llvm::Triple> MaybeT = tryParseTriple(Profile);
+  if (MaybeT && isLegalShaderModel(*MaybeT))
+    return MaybeT->getTriple();
   else
     return std::nullopt;
 }

--- a/clang/lib/Driver/ToolChains/HLSL.cpp
+++ b/clang/lib/Driver/ToolChains/HLSL.cpp
@@ -62,6 +62,10 @@ bool isLegalShaderModel(Triple &T) {
     VersionTuple MinVer(6, 5);
     return MinVer <= Version;
   } break;
+  case Triple::EnvironmentType::RootSignature:
+    VersionTuple MinVer(1, 0);
+    VersionTuple MaxVer(1, 1);
+    return MinVer <= Version && Version <= MaxVer;
   }
   return false;
 }
@@ -84,6 +88,7 @@ std::optional<std::string> tryParseProfile(StringRef Profile) {
           .Case("lib", Triple::EnvironmentType::Library)
           .Case("ms", Triple::EnvironmentType::Mesh)
           .Case("as", Triple::EnvironmentType::Amplification)
+          .Case("rootsig", Triple::EnvironmentType::RootSignature)
           .Default(Triple::EnvironmentType::UnknownEnvironment);
   if (Kind == Triple::EnvironmentType::UnknownEnvironment)
     return std::nullopt;

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -1315,18 +1315,22 @@ void HLSLFrontendAction::ExecuteAction() {
   auto &TargetInfo = CI.getASTContext().getTargetInfo();
   bool IsRootSignatureTarget =
       TargetInfo.getTriple().getEnvironment() == llvm::Triple::RootSignature;
+  StringRef HLSLEntry = TargetInfo.getTargetOpts().HLSLEntry;
 
   // Register HLSL specific callbacks
   auto LangOpts = CI.getLangOpts();
+  StringRef RootSigName =
+      IsRootSignatureTarget ? HLSLEntry : LangOpts.HLSLRootSigOverride;
+
   auto MacroCallback = std::make_unique<InjectRootSignatureCallback>(
-      S, LangOpts.HLSLRootSigOverride, LangOpts.HLSLRootSigVer);
+      S, RootSigName, LangOpts.HLSLRootSigVer);
 
   Preprocessor &PP = CI.getPreprocessor();
   PP.addPPCallbacks(std::move(MacroCallback));
 
   // If we are targeting a root signature, invoke custom handling
   if (IsRootSignatureTarget)
-    return hlsl::HandleRootSignatureTarget(S);
+    return hlsl::HandleRootSignatureTarget(S, HLSLEntry);
   else // otherwise, invoke as normal
     return WrapperFrontendAction::ExecuteAction();
 }

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -1296,9 +1296,6 @@ public:
 
 void HLSLFrontendAction::ExecuteAction() {
   // Pre-requisites to invoke
-  if (getCurrentFileKind().getLanguage() != Language::HLSL)
-    return WrapperFrontendAction::ExecuteAction();
-
   CompilerInstance &CI = getCompilerInstance();
   if (!CI.hasASTContext() || !CI.hasPreprocessor())
     return WrapperFrontendAction::ExecuteAction();

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -1488,10 +1488,6 @@ void HandleRootSignatureTarget(Sema &S, StringRef EntryRootSig) {
     P->Initialize();
     S.ActOnStartOfTranslationUnit();
 
-    // Skim through the file to parse to find the define
-    while (P->getCurToken().getKind() != tok::eof)
-      P->ConsumeAnyToken();
-
     HLSLRootSignatureDecl *SignatureDecl =
         S.HLSL().lookupRootSignatureOverrideDecl(
             S.getASTContext().getTranslationUnitDecl());

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -1488,6 +1488,10 @@ void HandleRootSignatureTarget(Sema &S, StringRef EntryRootSig) {
     P->Initialize();
     S.ActOnStartOfTranslationUnit();
 
+    // Skim through the file to parse to find the define
+    while (P->getCurToken().getKind() != tok::eof)
+      P->ConsumeAnyToken();
+
     HLSLRootSignatureDecl *SignatureDecl =
         S.HLSL().lookupRootSignatureOverrideDecl(
             S.getASTContext().getTranslationUnitDecl());

--- a/clang/lib/Parse/ParseHLSLRootSignature.cpp
+++ b/clang/lib/Parse/ParseHLSLRootSignature.cpp
@@ -1473,7 +1473,7 @@ IdentifierInfo *ParseHLSLRootSignature(Sema &Actions,
   return DeclIdent;
 }
 
-void HandleRootSignatureTarget(Sema &S) {
+void HandleRootSignatureTarget(Sema &S, StringRef EntryRootSig) {
   ASTConsumer *Consumer = &S.getASTConsumer();
 
   // Minimally initalize the parser. This does a couple things:
@@ -1487,6 +1487,16 @@ void HandleRootSignatureTarget(Sema &S) {
   if (HaveLexer) {
     P->Initialize();
     S.ActOnStartOfTranslationUnit();
+
+    HLSLRootSignatureDecl *SignatureDecl =
+        S.HLSL().lookupRootSignatureOverrideDecl(
+            S.getASTContext().getTranslationUnitDecl());
+
+    if (SignatureDecl)
+      Consumer->HandleTopLevelDecl(DeclGroupRef(SignatureDecl));
+    else
+      S.getDiagnostics().Report(diag::err_hlsl_rootsignature_entry)
+          << EntryRootSig;
   }
 
   Consumer->HandleTranslationUnit(S.getASTContext());

--- a/clang/lib/Sema/SemaHLSL.cpp
+++ b/clang/lib/Sema/SemaHLSL.cpp
@@ -765,6 +765,8 @@ void SemaHLSL::ActOnTopLevelFunction(FunctionDecl *FD) {
     case llvm::Triple::UnknownEnvironment:
     case llvm::Triple::Library:
       break;
+    case llvm::Triple::RootSignature:
+      llvm_unreachable("rootsig environment has no functions");
     default:
       llvm_unreachable("Unhandled environment in triple");
     }
@@ -827,6 +829,8 @@ void SemaHLSL::CheckEntryPoint(FunctionDecl *FD) {
       }
     }
     break;
+  case llvm::Triple::RootSignature:
+    llvm_unreachable("rootsig environment has no function entry point");
   default:
     llvm_unreachable("Unhandled environment in triple");
   }

--- a/clang/test/AST/HLSL/RootSignature-Target-AST.hlsl
+++ b/clang/test/AST/HLSL/RootSignature-Target-AST.hlsl
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-rootsignature -ast-dump \
+// RUN:  -hlsl-entry EntryRootSig -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,CHECK-V1_1
+
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-rootsignature -ast-dump \
+// RUN:  -fdx-rootsignature-version=rootsig_1_0 \
+// RUN:  -hlsl-entry EntryRootSig -disable-llvm-passes -o - %s | FileCheck %s --check-prefixes=CHECK,CHECK-V1_0
+
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-rootsignature -ast-dump \
+// RUN:  -D CmdRS='"UAV(u0)"'\
+// RUN:  -hlsl-entry CmdRS -disable-llvm-passes -o - %s | FileCheck %s --check-prefix=CMD
+
+// CHECK: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[ENTRY_RS_DECL:__hlsl_rootsig_decl_\d*]]
+// CHECK-V1_0-SAME: version: 1.0,
+// CHECK-V1_1-SAME: version: 1.1,
+// CHECK-SAME: RootElements{
+// CHECK-SAME: RootCBV(b0,
+// CHECK-SAME:   space = 0, visibility = All,
+// CHECK-V1_0-SAME: flags = DataVolatile
+// CHECK-V1_1-SAME: flags = DataStaticWhileSetAtExecute
+// CHECK-SAME: )
+// CHECK-SAME: }
+#define EntryRootSig "CBV(b0)"
+
+// CMD: -HLSLRootSignatureDecl 0x{{.*}} {{.*}} implicit [[CMD_RS_DECL:__hlsl_rootsig_decl_\d*]]
+// CMD-SAME: version: 1.1,
+// CMD-SAME: RootElements{
+// CMD-SAME: RootUAV(u0, space = 0, visibility = All, flags = DataVolatile)
+// CMD-SAME: }

--- a/clang/test/CodeGenHLSL/RootSignature-Target.hlsl
+++ b/clang/test/CodeGenHLSL/RootSignature-Target.hlsl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-rootsignature \
+// RUN: -hlsl-entry EntryRS -emit-llvm -o - %s | FileCheck %s
+
+// CHECK: !dx.rootsignatures = !{![[#ENTRY:]]}
+// CHECK: ![[#ENTRY]] = !{null, ![[#ENTRY_RS:]], i32 2}
+// CHECK: ![[#ENTRY_RS]] = !{![[#ROOT_CBV:]]}
+// CHECK: ![[#ROOT_CBV]] = !{!"RootCBV", i32 0, i32 0, i32 0, i32 4}
+
+#define EntryRS "CBV(b0)"

--- a/clang/test/Driver/dxc_rootsignature_target.hlsl
+++ b/clang/test/Driver/dxc_rootsignature_target.hlsl
@@ -1,0 +1,8 @@
+// RUN: %clang_dxc -E EntryRS -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
+
+// CMDS: "{{.*}}clang{{.*}}" "-cc1"
+// CMDS-SAME: "-triple" "dxilv1.1-unknown-shadermodel1.1-rootsignature"
+// CMDS-SAME: "-hlsl-entry" "EntryRS"
+// CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.dxo" "--only-section=RTS0"
+
+#define EntryRS "CBV(b0)"

--- a/clang/test/Driver/dxc_rootsignature_target.hlsl
+++ b/clang/test/Driver/dxc_rootsignature_target.hlsl
@@ -1,40 +1,8 @@
 // RUN: %clang_dxc -E EntryRS -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
 
-// RUN: %clang_dxc -E EntryRS -T rootsig_1_1 /Fo %t.dxo %s
-// RUN: obj2yaml %t.dxo | FileCheck %s --check-prefix=OBJ
-
 // CMDS: "{{.*}}clang{{.*}}" "-cc1"
 // CMDS-SAME: "-triple" "dxilv1.1-unknown-shadermodel1.1-rootsignature"
 // CMDS-SAME: "-hlsl-entry" "EntryRS"
 // CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.dxo" "--only-section=RTS0"
 
 #define EntryRS "UAV(u0)"
-
-// OBJ: --- !dxcontainer
-// FileSize = 32 (header) + 48 (RTS0 content) + 4 (1 part offset) + 8 (1 part header)
-// OBJ:       FileSize: 92
-// OBJ-NEXT:  PartCount:        1
-// OBJ-NEXT:  PartOffsets:      [ 36 ]
-// OBJ-NEXT:  Parts:
-// OBJ-NOT:   DXIL
-// OBJ-NOT:   SFI0
-// OBJ-NOT:   HASH
-// OBJ-NOT:   ISG0
-// OBJ-NOT:   OSG0
-
-// OBJ:       - Name: RTS0
-// OBJ-NEXT:    Size:         48
-// OBJ-NEXT:    RootSignature:
-// OBJ-NEXT:      Version:         2
-// OBJ-NEXT:      NumRootParameters: 1
-// OBJ-NEXT:      RootParametersOffset: 24
-
-// OBJ:         Parameters:
-// UAV(u0)
-// OBJ:          - ParameterType:   4
-// OBJ-NEXT:       ShaderVisibility: 0
-// OBJ-NEXT:       Descriptor:
-// OBJ-NEXT:         RegisterSpace:   0
-// OBJ-NEXT:         ShaderRegister:  0
-
-// OBJ-NOT: PSV0

--- a/clang/test/Driver/dxc_rootsignature_target.hlsl
+++ b/clang/test/Driver/dxc_rootsignature_target.hlsl
@@ -1,8 +1,40 @@
 // RUN: %clang_dxc -E EntryRS -T rootsig_1_1 /Fo %t.dxo -### %s 2>&1 | FileCheck %s --check-prefix=CMDS
 
+// RUN: %clang_dxc -E EntryRS -T rootsig_1_1 /Fo %t.dxo %s
+// RUN: obj2yaml %t.dxo | FileCheck %s --check-prefix=OBJ
+
 // CMDS: "{{.*}}clang{{.*}}" "-cc1"
 // CMDS-SAME: "-triple" "dxilv1.1-unknown-shadermodel1.1-rootsignature"
 // CMDS-SAME: "-hlsl-entry" "EntryRS"
 // CMDS: "{{.*}}llvm-objcopy{{(.exe)?}}" "{{.*}}.dxo" "--only-section=RTS0"
 
-#define EntryRS "CBV(b0)"
+#define EntryRS "UAV(u0)"
+
+// OBJ: --- !dxcontainer
+// FileSize = 32 (header) + 48 (RTS0 content) + 4 (1 part offset) + 8 (1 part header)
+// OBJ:       FileSize: 92
+// OBJ-NEXT:  PartCount:        1
+// OBJ-NEXT:  PartOffsets:      [ 36 ]
+// OBJ-NEXT:  Parts:
+// OBJ-NOT:   DXIL
+// OBJ-NOT:   SFI0
+// OBJ-NOT:   HASH
+// OBJ-NOT:   ISG0
+// OBJ-NOT:   OSG0
+
+// OBJ:       - Name: RTS0
+// OBJ-NEXT:    Size:         48
+// OBJ-NEXT:    RootSignature:
+// OBJ-NEXT:      Version:         2
+// OBJ-NEXT:      NumRootParameters: 1
+// OBJ-NEXT:      RootParametersOffset: 24
+
+// OBJ:         Parameters:
+// UAV(u0)
+// OBJ:          - ParameterType:   4
+// OBJ-NEXT:       ShaderVisibility: 0
+// OBJ-NEXT:       Descriptor:
+// OBJ-NEXT:         RegisterSpace:   0
+// OBJ-NEXT:         ShaderRegister:  0
+
+// OBJ-NOT: PSV0

--- a/clang/test/SemaHLSL/RootSignature-target-err.hlsl
+++ b/clang/test/SemaHLSL/RootSignature-target-err.hlsl
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.0-rootsignature -hlsl-entry NotFoundRS -fsyntax-only %s -verify
+
+// expected-error@* {{rootsignature specified as target environment but entry, NotFoundRS, was not defined}}
+
+#define EntryRootSig "CBV(b0)"

--- a/llvm/include/llvm/BinaryFormat/DXContainer.h
+++ b/llvm/include/llvm/BinaryFormat/DXContainer.h
@@ -45,7 +45,7 @@ namespace dxbc {
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();
 
 inline Triple::EnvironmentType getShaderStage(uint32_t Kind) {
-  assert(Kind <= Triple::Amplification - Triple::Pixel &&
+  assert(Kind <= Triple::RootSignature - Triple::Pixel &&
          "Shader kind out of expected range.");
   return static_cast<Triple::EnvironmentType>(Triple::Pixel + Kind);
 }

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -305,6 +305,7 @@ public:
     Callable,
     Mesh,
     Amplification,
+    RootSignature,
     OpenCL,
     OpenHOS,
     Mlibc,
@@ -872,7 +873,7 @@ public:
            Env == Triple::Intersection || Env == Triple::AnyHit ||
            Env == Triple::ClosestHit || Env == Triple::Miss ||
            Env == Triple::Callable || Env == Triple::Mesh ||
-           Env == Triple::Amplification;
+           Env == Triple::Amplification || Env == Triple::RootSignature;
   }
 
   /// Tests whether the target is SPIR (32- or 64-bit).

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -167,7 +167,6 @@ void DXContainerGlobals::addRootSignature(Module &M,
   }
 
   const mcdxbc::RootSignatureDesc *RS = RSA.getDescForFunction(EntryFunction);
-
   if (!RS)
     return;
 

--- a/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
+++ b/llvm/lib/Target/DirectX/DXContainerGlobals.cpp
@@ -158,10 +158,14 @@ void DXContainerGlobals::addRootSignature(Module &M,
   if (MMI.ShaderProfile == llvm::Triple::Library)
     return;
 
-  assert(MMI.EntryPropertyVec.size() == 1);
-
   auto &RSA = getAnalysis<RootSignatureAnalysisWrapper>().getRSInfo();
-  const Function *EntryFunction = MMI.EntryPropertyVec[0].Entry;
+  const Function *EntryFunction = nullptr;
+
+  if (MMI.ShaderProfile != llvm::Triple::RootSignature) {
+    assert(MMI.EntryPropertyVec.size() == 1);
+    EntryFunction = MMI.EntryPropertyVec[0].Entry;
+  }
+
   const mcdxbc::RootSignatureDesc *RS = RSA.getDescForFunction(EntryFunction);
 
   if (!RS)
@@ -258,7 +262,8 @@ void DXContainerGlobals::addPipelineStateValidationInfo(
   dxil::ModuleMetadataInfo &MMI =
       getAnalysis<DXILMetadataAnalysisWrapperPass>().getModuleMetadata();
   assert(MMI.EntryPropertyVec.size() == 1 ||
-         MMI.ShaderProfile == Triple::Library);
+         MMI.ShaderProfile == Triple::Library ||
+         MMI.ShaderProfile == Triple::RootSignature);
   PSV.BaseData.ShaderStage =
       static_cast<uint8_t>(MMI.ShaderProfile - Triple::Pixel);
 
@@ -279,7 +284,8 @@ void DXContainerGlobals::addPipelineStateValidationInfo(
     break;
   }
 
-  if (MMI.ShaderProfile != Triple::Library)
+  if (MMI.ShaderProfile != Triple::Library &&
+      MMI.ShaderProfile != Triple::RootSignature)
     PSV.EntryName = MMI.EntryPropertyVec[0].Entry->getName();
 
   PSV.finalize(MMI.ShaderProfile);

--- a/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
+++ b/llvm/lib/Target/DirectX/DXILTranslateMetadata.cpp
@@ -127,6 +127,8 @@ static StringRef getShortShaderStage(Triple::EnvironmentType Env) {
     return "ms";
   case Triple::Amplification:
     return "as";
+  case Triple::RootSignature:
+    return "rootsig";
   default:
     break;
   }

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -391,6 +391,8 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   case Callable: return "callable";
   case Mesh: return "mesh";
   case Amplification: return "amplification";
+  case RootSignature:
+    return "rootsignature";
   case OpenCL:
     return "opencl";
   case OpenHOS: return "ohos";
@@ -787,6 +789,7 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
       .StartsWith("callable", Triple::Callable)
       .StartsWith("mesh", Triple::Mesh)
       .StartsWith("amplification", Triple::Amplification)
+      .StartsWith("rootsignature", Triple::RootSignature)
       .StartsWith("opencl", Triple::OpenCL)
       .StartsWith("ohos", Triple::OpenHOS)
       .StartsWith("pauthtest", Triple::PAuthTest)

--- a/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Target.ll
+++ b/llvm/test/CodeGen/DirectX/ContainerData/RootSignature-Target.ll
@@ -1,0 +1,23 @@
+; RUN: opt %s -dxil-embed -dxil-globals -S -o - | FileCheck %s
+; RUN: llc %s --filetype=obj -o - | obj2yaml | FileCheck %s --check-prefix=DXC
+
+target triple = "dxil-unknown-shadermodel1.1-rootsignature"
+
+; CHECK: @dx.rts0 = private constant [24 x i8]  c"{{.*}}", section "RTS0", align 4
+
+!dx.rootsignatures = !{!2} ; list of function/root signature pairs
+!2 = !{ null, !3, i32 2 } ; function, root signature, version
+!3 = !{ !4 } ; list of root signature elements
+!4 = !{ !"RootFlags", i32 1 } ; 1 = allow_input_assembler_input_layout
+
+; DXC:       - Name:            RTS0
+; DXC-NEXT:    Size:            24
+; DXC-NEXT:    RootSignature:
+; DXC-NEXT:      Version:         2
+; DXC-NEXT:      NumRootParameters: 0
+; DXC-NEXT:      RootParametersOffset: 24
+; DXC-NEXT:      NumStaticSamplers: 0
+; DXC-NEXT:      StaticSamplersOffset: 24
+; DXC-NEXT:      Parameters: []
+; DXC-NEXT:      AllowInputAssemblerInputLayout: true
+

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -546,6 +546,22 @@ TEST(TripleTest, ParsedIDs) {
   EXPECT_EQ(VersionTuple(1, 8), T.getDXILVersion());
   EXPECT_EQ(Triple::Amplification, T.getEnvironment());
 
+  T = Triple("dxilv1.0-unknown-shadermodel1.0-rootsignature");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_0, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::ShaderModel, T.getOS());
+  EXPECT_EQ(VersionTuple(1, 0), T.getDXILVersion());
+  EXPECT_EQ(Triple::RootSignature, T.getEnvironment());
+
+  T = Triple("dxilv1.1-unknown-shadermodel1.1-rootsignature");
+  EXPECT_EQ(Triple::dxil, T.getArch());
+  EXPECT_EQ(Triple::DXILSubArch_v1_1, T.getSubArch());
+  EXPECT_EQ(Triple::UnknownVendor, T.getVendor());
+  EXPECT_EQ(Triple::ShaderModel, T.getOS());
+  EXPECT_EQ(VersionTuple(1, 1), T.getDXILVersion());
+  EXPECT_EQ(Triple::RootSignature, T.getEnvironment());
+
   T = Triple("dxilv1.8-unknown-shadermodel6.15-library");
   EXPECT_EQ(Triple::dxil, T.getArch());
   EXPECT_EQ(Triple::DXILSubArch_v1_8, T.getSubArch());


### PR DESCRIPTION
This pr implements support for a root signature as a target, as specified [here](https://github.com/llvm/wg-hlsl/blob/main/proposals/0029-root-signature-driver-options.md#target-root-signature-version).

This is implemented in the following steps:
1. Add `rootsignature` as a shader model environment type and define `rootsig` as a `target_profile`. Only valid as versions 1.0 and 1.1
2. Updates `HLSLFrontendAction` to invoke a special handling of constructing the `ASTContext` if we are considering an `hlsl` file and with a `rootsignature` target
3. Defines the special handling to minimally instantiate the `Parser` and `Sema` to insert the `RootSignatureDecl`
4. Updates `CGHLSLRuntime` to emit the constructed root signature decl as part of `dx.rootsignatures` with a `null` entry function
5. Updates `DXILRootSignature` to handle emitting a root signature without an entry function
6. Updates `ToolChains/HLSL` to invoke `only-section=RTS0` to strip any other generated information

Resolves: https://github.com/llvm/llvm-project/issues/150286.

##### Implementation Considerations
Ideally we could invoke this as part of `clang-dxc` without the need of a source file. However, the initialization of the `Parser` and `Lexer` becomes quite complicated to handle this.

Technically, we could avoid generating any of the extra information that is removed in step 6. However, it seems better to re-use the logic in `llvm-objcopy` without any need for additional custom logic in `DXILRootSignature`.