### PR TITLE
[NFC][libclc] Define _CLC_DEF_WEAK and replace _CLC_DEF_ldexp with it

### DIFF
--- a/libclc/clc/include/clc/clcfunc.h
+++ b/libclc/clc/include/clc/clcfunc.h
@@ -24,6 +24,8 @@
 #define _CLC_DEF __attribute__((always_inline))
 #endif
 
+#define _CLC_DEF_WEAK _CLC_DEF __attribute__((weak))
+
 #if __OPENCL_C_VERSION__ == CL_VERSION_2_0 ||                                  \
     (__OPENCL_C_VERSION__ >= CL_VERSION_3_0 &&                                 \
      defined(__opencl_c_generic_address_space))

--- a/libclc/clc/lib/generic/math/clc_ldexp.cl
+++ b/libclc/clc/lib/generic/math/clc_ldexp.cl
@@ -15,9 +15,7 @@
 #include <clc/relational/clc_isnan.h>
 #include <clc/shared/clc_clamp.h>
 
-#define _CLC_DEF_ldexp _CLC_DEF __attribute__((weak))
-
-_CLC_DEF_ldexp _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
+_CLC_DEF_WEAK _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
 
   if (!__clc_fp32_subnormals_supported()) {
     // This treats subnormals as zeros
@@ -90,7 +88,7 @@ _CLC_DEF_ldexp _CLC_OVERLOAD float __clc_ldexp(float x, int n) {
 
 #pragma OPENCL EXTENSION cl_khr_fp64 : enable
 
-_CLC_DEF_ldexp _CLC_OVERLOAD double __clc_ldexp(double x, int n) {
+_CLC_DEF_WEAK _CLC_OVERLOAD double __clc_ldexp(double x, int n) {
   long l = __clc_as_ulong(x);
   int e = (l >> 52) & 0x7ff;
   long s = l & 0x8000000000000000;
@@ -125,14 +123,14 @@ _CLC_DEF_ldexp _CLC_OVERLOAD double __clc_ldexp(double x, int n) {
 
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
-_CLC_OVERLOAD _CLC_DEF_ldexp half __clc_ldexp(half x, int n) {
+_CLC_OVERLOAD _CLC_DEF_WEAK half __clc_ldexp(half x, int n) {
   return (half)__clc_ldexp((float)x, n);
 }
 
 #endif
 
 #define __CLC_FUNCTION __clc_ldexp
-#define __CLC_DEF_SPEC _CLC_DEF_ldexp
+#define __CLC_DEF_SPEC _CLC_DEF_WEAK
 #define __CLC_ARG2_TYPE int
 #define __CLC_BODY <clc/shared/binary_def_scalarize.inc>
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
_CLC_DEF_WEAK can be used in our downstream libclc to allow overriding generic __clc_tgamma implementation.