### PR TITLE
[libunwind][test] set fed test to require x86 as others arch may have cross toolchain build

### DIFF
--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -15,7 +15,7 @@
 
 // REQUIRES: linux
 
-// UNSUPPORTED: target={{aarch64-.+linux.*}}
+// UNSUPPORTED: target={{(aarch64|arm.*)-.+linux.*}}
 // aarch64-unknown-linux-gnu has a cross toolchain build(llvm-clang-win-x-aarch64)
 // where objdump is not available.
 

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -19,9 +19,9 @@
 // XFAIL: msan
 
 // RUN: %{build}
-// RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: llvm-objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 
-// RUN: objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: llvm-objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: %{exec} %t.exe
 
 // clang-format on

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -15,13 +15,17 @@
 
 // REQUIRES: linux
 
+// UNSUPPORTED: target={{aarch64-.+linux.*}}
+// aarch64-unknown-linux-gnu has a cross toolchain build(llvm-clang-win-x-aarch64)
+// where objdump is not available.
+
 // TODO: Figure out why this fails with Memory Sanitizer.
 // XFAIL: msan
 
 // RUN: %{build}
-// RUN: llvm-objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: objcopy --dump-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: echo -ne '\xFF' | dd of=%t_ehf_hdr.bin bs=1 seek=2 count=2 conv=notrunc status=none 
-// RUN: llvm-objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
+// RUN: objcopy --update-section .eh_frame_hdr=%t_ehf_hdr.bin %t.exe
 // RUN: %{exec} %t.exe
 
 // clang-format on

--- a/libunwind/test/eh_frame_fde_pc_range.pass.cpp
+++ b/libunwind/test/eh_frame_fde_pc_range.pass.cpp
@@ -13,10 +13,8 @@
 
 // clang-format off
 
-// REQUIRES: linux
-
-// UNSUPPORTED: target={{(aarch64|arm.*)-.+linux.*}}
-// aarch64-unknown-linux-gnu has a cross toolchain build(llvm-clang-win-x-aarch64)
+// REQUIRES: target={{x86_64-.+-linux-gnu}}
+// aarch64,arm have a cross toolchain build(llvm-clang-win-x-aarch64, etc)
 // where objdump is not available.
 
 // TODO: Figure out why this fails with Memory Sanitizer.


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/154902, the test failed with llvm-clang-win-x-aarch64(it is a cross-build, which builds on Windows and run on Linux, "Win to Aarch64 Linux Ubuntu Cross Toolchain"), and objdump is not available on Windows(the build env). 
Set to require x86 Linux instead.