### PR TITLE
[ADT] Remove an obsolete forward declaration (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -88,9 +88,6 @@ namespace pointer_union_detail {
   };
 }
 
-// This is a forward declaration of CastInfoPointerUnionImpl
-// Refer to its definition below for further details
-template <typename... PTs> struct CastInfoPointerUnionImpl;
 /// A discriminated union of two or more pointer types, with the discriminator
 /// in the low bit of the pointer.
 ///


### PR DESCRIPTION
We just removed CastInfoPointerUnionImpl in:

  commit 2d216a94f3c84037cdfb3fa5def9efb020a88537
  Author: Kazu Hirata <kazu@google.com>
  Date:   Mon Sep 1 08:04:49 2025 -0700

This patch removes the obsolete forward declaration.
