### PR TITLE
[RISCV] Simplify code gen for riscv_vector_builtin_cg.inc [NFC]

### DIFF
--- a/clang/utils/TableGen/RISCVVEmitter.cpp
+++ b/clang/utils/TableGen/RISCVVEmitter.cpp
@@ -166,6 +166,8 @@ static VectorTypeModifier getTupleVTM(unsigned NF) {
       static_cast<uint8_t>(VectorTypeModifier::Tuple2) + (NF - 2));
 }
 
+static const unsigned UnknownIndex = (unsigned)-1;
+
 static unsigned getIndexedLoadStorePtrIdx(const RVVIntrinsic *RVVI) {
   // We need a special rule for segment load/store since the data width is not
   // encoded in the intrinsic name itself.
@@ -183,7 +185,7 @@ static unsigned getIndexedLoadStorePtrIdx(const RVVIntrinsic *RVVI) {
   if (IRName.starts_with("vsoxseg") || IRName.starts_with("vsuxseg"))
     return RVVI->isMasked() ? 1 : 0;
 
-  return (unsigned)-1;
+  return UnknownIndex;
 }
 
 // This function is used to get the log2SEW of each segment load/store, this
@@ -249,19 +251,21 @@ void emitCodeGenSwitchBody(const RVVIntrinsic *RVVI, raw_ostream &OS) {
     OS << "  ID = Intrinsic::riscv_" + RVVI->getIRName() + ";\n";
 
   OS << "  PolicyAttrs = " << RVVI->getPolicyAttrsBits() << ";\n";
-  OS << "  SegInstSEW = " << getSegInstLog2SEW(RVVI->getOverloadedName())
-     << ";\n";
+  unsigned IndexedLoadStorePtrIdx = getIndexedLoadStorePtrIdx(RVVI);
+  if (IndexedLoadStorePtrIdx != UnknownIndex) {
+    OS << "  {\n";
+    OS << "    auto PointeeType = E->getArg(" << IndexedLoadStorePtrIdx
+       << ")->getType()->getPointeeType();\n";
+    OS << "    SegInstSEW = "
+          "llvm::Log2_64(getContext().getTypeSize(PointeeType));\n";
+    OS << "  }\n";
+  } else {
+    OS << "  SegInstSEW = " << getSegInstLog2SEW(RVVI->getOverloadedName())
+       << ";\n";
+  }
 
   if (RVVI->hasManualCodegen()) {
     OS << "IsMasked = " << (RVVI->isMasked() ? "true" : "false") << ";\n";
-
-    // Skip the non-indexed load/store and compatible header load/store.
-    OS << "if (SegInstSEW == (unsigned)-1) {\n";
-    OS << "  auto PointeeType = E->getArg(" << getIndexedLoadStorePtrIdx(RVVI)
-       << "      )->getType()->getPointeeType();\n";
-    OS << "  SegInstSEW = "
-          "      llvm::Log2_64(getContext().getTypeSize(PointeeType));\n}\n";
-
     OS << RVVI->getManualCodegen();
     OS << "break;\n";
     return;


### PR DESCRIPTION
For each intrinsic with ManualCodegen block will generate something like below:

```cpp
  SegInstSEW = 0;
  ...
  if (SegInstSEW == (unsigned)-1) {
    auto PointeeType = E->getArg(4294967295)->getType()->getPointeeType();
    SegInstSEW = llvm::Log2_64(getContext().getTypeSize(PointeeType));
  }

```

But actually SegInstSEW is table-gen-time constant, so can remove that if-check and directly use the constant.

This change reduce riscv_vector_builtin_cg.inc around 6600 lines (30913 to 24305) which is around 20% reduction, however seems this isn't impact the build time much since the redundant dead branch is almost will optimized away by compiler in early stage.