### PR TITLE
[RISCV][TTI] Fix shift VV opcode mapping in getArithmeticInstrCost

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVTargetTransformInfo.cpp
@@ -2522,9 +2522,13 @@ InstructionCost RISCVTTIImpl::getArithmeticInstrCost(
     Op = RISCV::VADD_VV;
     break;
   case ISD::SHL:
-  case ISD::SRL:
-  case ISD::SRA:
     Op = RISCV::VSLL_VV;
+    break;
+  case ISD::SRL:
+    Op = RISCV::VSRL_VV;
+    break;
+  case ISD::SRA:
+    Op = RISCV::VSRA_VV;
     break;
   case ISD::AND:
   case ISD::OR:

--- a/llvm/test/Analysis/CostModel/RISCV/rvv-shift-cost.ll
+++ b/llvm/test/Analysis/CostModel/RISCV/rvv-shift-cost.ll
@@ -1,0 +1,26 @@
+; REQUIRES: riscv-registered-target
+; RUN: opt -mtriple=riscv64 -mattr=+v -passes='print<cost-model>' -disable-output < %s 2>&1 | FileCheck %s
+
+define <8 x i32> @shl_cost(<8 x i32> %a, <8 x i32> %b) {
+; CHECK-LABEL: 'shl_cost'
+; CHECK: Cost Model: Found an estimated cost of
+; CHECK: shl <8 x i32>
+  %r = shl <8 x i32> %a, %b
+  ret <8 x i32> %r
+}
+
+define <8 x i32> @srl_cost(<8 x i32> %a, <8 x i32> %b) {
+; CHECK-LABEL: 'srl_cost'
+; CHECK: Cost Model: Found an estimated cost of
+; CHECK: lshr <8 x i32>
+  %r = lshr <8 x i32> %a, %b
+  ret <8 x i32> %r
+}
+
+define <8 x i32> @sra_cost(<8 x i32> %a, <8 x i32> %b) {
+; CHECK-LABEL: 'sra_cost'
+; CHECK: Cost Model: Found an estimated cost of
+; CHECK: ashr <8 x i32>
+  %r = ashr <8 x i32> %a, %b
+  ret <8 x i32> %r
+}

--- a/llvm/test/CodeGen/RISCV/rvv-shift-vv.ll
+++ b/llvm/test/CodeGen/RISCV/rvv-shift-vv.ll
@@ -1,0 +1,27 @@
+; REQUIRES: riscv-registered-target
+
+; RUN: llc -mtriple=riscv64 -mattr=+v -O2 -verify-machineinstrs < %s | FileCheck %s
+
+; 我們用 <8 x i32> 並讓位移量來自第二個向量參數，確保走 VV 形式
+;（不是 vx/vi）。每個函式只做一次對應的 shift。
+
+; CHECK-LABEL: shl_vv
+; CHECK:       vsll.vv
+define <8 x i32> @shl_vv(<8 x i32> %a, <8 x i32> %b) {
+  %r = shl <8 x i32> %a, %b
+  ret <8 x i32> %r
+}
+
+; CHECK-LABEL: srl_vv
+; CHECK:       vsrl.vv
+define <8 x i32> @srl_vv(<8 x i32> %a, <8 x i32> %b) {
+  %r = lshr <8 x i32> %a, %b
+  ret <8 x i32> %r
+}
+
+; CHECK-LABEL: sra_vv
+; CHECK:       vsra.vv
+define <8 x i32> @sra_vv(<8 x i32> %a, <8 x i32> %b) {
+  %r = ashr <8 x i32> %a, %b
+  ret <8 x i32> %r
+}


### PR DESCRIPTION
### Summary
Fix incorrect opcode mapping in `RISCVTTIImpl::getArithmeticInstrCost` for vector shift operations:

- SHL → VSLL_VV
- SRL → VSRL_VV
- SRA → VSRA_VV

Previously, all three were mapped to `VSLL_VV`.

### Motivation
Correct mapping ensures the cost model reflects the real instructions,
preventing vectorization and scheduling decisions from being based on wrong costs.

### Changes
- Updated `RISCVTargetTransformInfo.cpp` to use proper opcodes.
- Added tests:
  - **CodeGen/RISCV/rvv-shift-vv.ll**  
    Verifies `shl/lshr/ashr` generate `vsll.vv / vsrl.vv / vsra.vv`.
  - **Analysis/CostModel/RISCV/rvv-shift-cost.ll**  
    Ensures cost model reports costs for `shl/lshr/ashr`.

### Scope
- No functional changes outside TTI.
- Only touches one source file and adds two test files.

### Follow-up
A separate PR will address the incorrect mapping of `ssub_sat` to use `VSSUB_VV` instead of `VSSUBU_VV`.

---