### PR TITLE
AMDGPU: Fix true16 d16 entry table for DS pseudos

### DIFF
--- a/llvm/lib/Target/AMDGPU/DSInstructions.td
+++ b/llvm/lib/Target/AMDGPU/DSInstructions.td
@@ -127,11 +127,12 @@ multiclass DS_1A1D_NORET_mc<string opName, RegisterClass rc = VGPR_32> {
   }
 }
 
-multiclass DS_1A1D_NORET_t16<string opName, RegisterClass rc = VGPR_32> 
+multiclass DS_1A1D_NORET_t16<string opName, RegisterClass rc = VGPR_32>
 : DS_1A1D_NORET_mc<opName, rc> {
   let has_m0_read = 0 in {
     let True16Predicate = UseRealTrue16Insts in {
-      def "_t16" : DS_1A1D_NORET<opName#"_t16", VGPR_16>, True16D16Table<NAME#"_D16_HI", NAME>;
+      def "_t16" : DS_1A1D_NORET<opName#"_t16", VGPR_16>,
+        True16D16Table<NAME#"_D16_HI", NAME#"_gfx9">;
     }
   }
 }


### PR DESCRIPTION
This should be trying to use the _gfx9 variants of DS pseudos,
not the base form with m0 uses.