### PR TITLE
Import and Export `getXXXPluginInfo` from embedded plugin such as Polly

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -94,7 +94,7 @@ using namespace clang;
 using namespace llvm;
 
 #define HANDLE_EXTENSION(Ext)                                                  \
-  llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+  LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
 
 namespace llvm {

--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -87,7 +87,7 @@ constexpr llvm::StringLiteral timingIdBackend =
 
 // Declare plugin extension function declarations.
 #define HANDLE_EXTENSION(Ext)                                                  \
-  llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+  LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
 
 /// Save the given \c mlirModule to a temporary .mlir file, in a location

--- a/llvm/docs/WritingAnLLVMNewPMPass.rst
+++ b/llvm/docs/WritingAnLLVMNewPMPass.rst
@@ -254,7 +254,7 @@ See the definition of ``add_llvm_pass_plugin`` for more CMake details.
 The pass must provide at least one of two entry points for the new pass manager,
 one for static registration and one for dynamically loaded plugins:
 
-- ``llvm::PassPluginLibraryInfo get##Name##PluginInfo();``
+- ``LLVM_ABI llvm::PassPluginLibraryInfo get##Name##PluginInfo();``
 - ``extern "C" ::llvm::PassPluginLibraryInfo llvmGetPassPluginInfo() LLVM_ATTRIBUTE_WEAK;``
 
 Pass plugins are compiled and linked dynamically by default. Setting
@@ -268,7 +268,7 @@ To make ``PassBuilder`` aware of statically linked pass plugins:
 .. code-block:: c++
 
     // Declare plugin extension function declarations.
-    #define HANDLE_EXTENSION(Ext) llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+    #define HANDLE_EXTENSION(Ext) LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
     #include "llvm/Support/Extension.def"
 
     ...

--- a/llvm/lib/Extensions/Extensions.cpp
+++ b/llvm/lib/Extensions/Extensions.cpp
@@ -1,6 +1,6 @@
 #include "llvm/Passes/PassPlugin.h"
 #define HANDLE_EXTENSION(Ext)                                                  \
-		llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+  LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
 
 

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -178,7 +178,7 @@ Error Config::addSaveTemps(std::string OutputFileName, bool UseInputModulePath,
 }
 
 #define HANDLE_EXTENSION(Ext)                                                  \
-  llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+  LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
 #undef HANDLE_EXTENSION
 

--- a/llvm/tools/bugpoint/bugpoint.cpp
+++ b/llvm/tools/bugpoint/bugpoint.cpp
@@ -93,7 +93,7 @@ public:
 }
 
 #define HANDLE_EXTENSION(Ext)                                                  \
-  llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+  LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
 
 int main(int argc, char **argv) {

--- a/llvm/tools/opt/NewPMDriver.cpp
+++ b/llvm/tools/opt/NewPMDriver.cpp
@@ -344,7 +344,7 @@ static void registerEPCallbacks(PassBuilder &PB) {
 }
 
 #define HANDLE_EXTENSION(Ext)                                                  \
-  llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
+  LLVM_ABI llvm::PassPluginLibraryInfo get##Ext##PluginInfo();
 #include "llvm/Support/Extension.def"
 #undef HANDLE_EXTENSION
 

--- a/polly/include/polly/RegisterPasses.h
+++ b/polly/include/polly/RegisterPasses.h
@@ -13,6 +13,8 @@
 #ifndef POLLY_REGISTER_PASSES_H
 #define POLLY_REGISTER_PASSES_H
 
+#include "llvm/Support/Compiler.h"
+
 namespace llvm {
 class PassRegistry;
 class PassBuilder;
@@ -27,6 +29,6 @@ void initializePollyPasses(llvm::PassRegistry &Registry);
 void registerPollyPasses(llvm::PassBuilder &PB);
 } // namespace polly
 
-llvm::PassPluginLibraryInfo getPollyPluginInfo();
+LLVM_ALWAYS_EXPORT llvm::PassPluginLibraryInfo getPollyPluginInfo();
 
 #endif

--- a/polly/include/polly/RegisterPasses.h
+++ b/polly/include/polly/RegisterPasses.h
@@ -29,6 +29,6 @@ void initializePollyPasses(llvm::PassRegistry &Registry);
 void registerPollyPasses(llvm::PassBuilder &PB);
 } // namespace polly
 
-LLVM_ALWAYS_EXPORT llvm::PassPluginLibraryInfo getPollyPluginInfo();
+LLVM_ABI llvm::PassPluginLibraryInfo getPollyPluginInfo();
 
 #endif


### PR DESCRIPTION
Fixes #152328

For exporting:
<s>Since the declaration/definition of `getPollyPluginInfo` is embedded into the LLVM DLL using `add_llvm_pass_plugin`, which defines `LLVM_BUILD_STATIC` by the effect of `DISABLE_LLVM_LINK_LLVM_DYLIB`, it must be declared with `LLVM_ALWAYS_EXPORT`.</s>
Just a `LLVM_ABI` is required after https://github.com/llvm/llvm-project/pull/158023 gets merged.

For importing:
The annotation `LLVM_ABI` is required in the body of the macro `HANDLE_EXTENTION`, which generates the declaration of  `getPollyPluginInfo` from the CMake-generated file `"llvm/Support/Extension.def"`.