### PR TITLE
[Utils] Fix AArch64 ASM regex after #148287

### DIFF
--- a/llvm/utils/UpdateTestChecks/asm.py
+++ b/llvm/utils/UpdateTestChecks/asm.py
@@ -46,7 +46,7 @@ ASM_FUNCTION_AARCH64_RE = re.compile(
     r"(?:[ \t]+.cfi_startproc\n)?"  # drop optional cfi noise
     r"(?P<body>.*?)"
     # This list is incomplete
-    r"^(\.Lfunc_end[0-9]+:|// -- End function)",
+    r"^\s*(\.Lfunc_end[0-9]+:|// -- End function)",
     flags=(re.M | re.S),
 )
 


### PR DESCRIPTION
PR #148287 removed the "\s*" before ".Lfunc_end" for AArch64, which broke `update_llc_test_checks.py` for a number of tests including:

- `llvm/test/CodeGen/AArch64/sme-za-exceptions.ll`
- `llvm/test/CodeGen/AArch64/win-sve.ll`

This patch adds the "\s*" back.