### PR TITLE
[lldb][windows] use OutputDebugStringA instead of c to log events

### DIFF
--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -310,20 +310,24 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   if (message.empty())
     return;
 
-  std::string log_prefix;
+  std::string log_msg;
+  llvm::raw_string_ostream stream(log_msg);
+
   switch (severity) {
   case lldb::eSeverityWarning:
-    log_prefix = "[Warning] ";
+    stream << "[Warning] ";
     break;
   case lldb::eSeverityError:
-    log_prefix = "[Error] ";
+    stream << "[Error] ";
     break;
   case lldb::eSeverityInfo:
   default:
-    log_prefix = "[Info] ";
+    stream << "[Info] ";
     break;
   }
 
-  std::string final_message = log_prefix + message.str();
-  OutputDebugStringA(final_message.c_str());
+  stream << message;
+  stream.flush();
+
+  OutputDebugStringA(log_msg.c_str());
 }

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -22,10 +22,8 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StructuredData.h"
 
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ConvertUTF.h"
-#include "llvm/Support/ManagedStatic.h"
 
 // Windows includes
 #include <tlhelp32.h>
@@ -308,52 +306,24 @@ Environment Host::GetEnvironment() {
   return env;
 }
 
-/// Manages the lifecycle of a Windows Event's Source.
-/// The destructor will call DeregisterEventSource.
-/// This class is meant to be used with \ref llvm::ManagedStatic.
-class WindowsEventLog {
-public:
-  WindowsEventLog() : handle(RegisterEventSource(nullptr, L"lldb")) {}
-
-  ~WindowsEventLog() {
-    if (handle)
-      DeregisterEventSource(handle);
-  }
-
-  HANDLE GetHandle() const { return handle; }
-
-private:
-  HANDLE handle;
-};
-
-static llvm::ManagedStatic<WindowsEventLog> event_log;
-
 void Host::SystemLog(Severity severity, llvm::StringRef message) {
   if (message.empty())
     return;
 
-  HANDLE h = event_log->GetHandle();
-  if (!h)
-    return;
-
-  llvm::SmallVector<wchar_t, 1> argsUTF16;
-  if (UTF8ToUTF16(message.str(), argsUTF16))
-    return;
-
-  WORD event_type;
+  std::string log_prefix;
   switch (severity) {
   case lldb::eSeverityWarning:
-    event_type = EVENTLOG_WARNING_TYPE;
+    log_prefix = "[Warning] ";
     break;
   case lldb::eSeverityError:
-    event_type = EVENTLOG_ERROR_TYPE;
+    log_prefix = "[Error] ";
     break;
   case lldb::eSeverityInfo:
   default:
-    event_type = EVENTLOG_INFORMATION_TYPE;
+    log_prefix = "[Info] ";
+    break;
   }
 
-  LPCWSTR messages[1] = {argsUTF16.data()};
-  ReportEventW(h, event_type, 0, 0, nullptr, std::size(messages), 0, messages,
-               nullptr);
+  std::string final_message = log_prefix + message.str();
+  OutputDebugStringA(final_message.c_str());
 }


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/150213 we made use of the Event Viewer on Windows (equivalent of system logging on Darwin) rather than piping to the standard output. This turned out to be too verbose in practice, as the Event Viewer is developer oriented and not user oriented.

This patch swaps the use of `ReportEventW` for `OutputDebugStringA`, allowing to use tools such as `DebugView` to record logs when we are interested in receiving them, rather than continuously writing to the buffer. Please see an example below:
<img width="1253" height="215" alt="Screenshot 2025-09-02 at 16 07 03" src="https://github.com/user-attachments/assets/4a326e46-d8a4-4c99-8c96-1bee62da8d55" />


