### PR TITLE
[Dexter] Use continue when resuming lldb execution to reach breakpoint

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -232,7 +232,7 @@ class LLDB(DebuggerBase):
                     ):
                         stepped_to_breakpoint = True
             if stepped_to_breakpoint:
-                self._thread.StepInto()
+                self._thread.Continue()
 
     def go(self) -> ReturnCode:
         self._process.Continue()
@@ -441,7 +441,7 @@ class LLDBDAP(DAP):
                 # Step again now to get to the breakpoint.
                 step_req_id = self.send_message(
                     self.make_request(
-                        "stepIn", {"threadId": self._debugger_state.thread}
+                        "continue", {"threadId": self._debugger_state.thread}
                     )
                 )
                 response = self._await_response(step_req_id)

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -232,7 +232,7 @@ class LLDB(DebuggerBase):
                     ):
                         stepped_to_breakpoint = True
             if stepped_to_breakpoint:
-                self._thread.Continue()
+                self._process.Continue()
 
     def go(self) -> ReturnCode:
         self._process.Continue()


### PR DESCRIPTION
Currently, Dexter's interface for lldb and lldb-dap has a post-step hook that checks to see whether lldb reports that we stopped because we completed a step, and if so checks to see whether the current $pc address also matches a known breakpoint whose conditions (if any) are met, and if so it requests to "step in", so that we "resume" execution, stopping again at the current address, such that lldb now reports that we have hit a breakpoint and provides the list of breakpoints that were hit.

This logic has a flaw however: the call to "step in" sets an implicit breakpoint on the next line. In Dexter's default stepping mode this is not an issue, as we intend to step there eventually. When we use DexContinue, however, we set a breakpoint from which we wish to continue to the next user-specified breakpoint, rather than stepping. Currently, there is a bug where Dexter sets a DexContinue breakpoint, arrives at that bp from a step, requests "step in" so that LLDB gives us the hit breakpoint ID, requests "continue" to hit the next user breakpoint, and then arrives at the next line after the continue due to the earlier "step in" request. This effectively negates the DexContinue command.

This patch fixes this behaviour by using "continue" instead of "step in" in the post-step hook, ensuring that no implicit breakpoint is set so that we do not incorrectly stop at the next line.

Likely fixes the issue reported at: https://github.com/llvm/llvm-project/pull/152721#issuecomment-3242907059