### PR TITLE
[BOLT] Port additional test to internal shell

### DIFF
--- a/bolt/test/runtime/copy_file.py
+++ b/bolt/test/runtime/copy_file.py
@@ -1,0 +1,15 @@
+import sys
+import shutil
+
+with open(sys.argv[1] + ".output") as log_file:
+    lines = log_file.readlines()
+    for line in lines:
+        if line.startswith(sys.argv[2]):
+            pid = line.split(" ")[1].strip()
+            shutil.copy(
+                sys.argv[1] + "." + pid + ".fdata",
+                sys.argv[1] + "." + sys.argv[3] + ".fdata",
+            )
+            sys.exit(0)
+
+sys.exit(1)


### PR DESCRIPTION
This test was broken by #156083 because it was never ported to the internal shell. It requires fuser which is not installed by default on premerge and none of the BOLT buildbots have been online in a while.

This was actually causing a timeout because of #156484, worked around using a manual bash invocation with a wait call to ensure all of the subprocesses have exited.