### PR TITLE
[BOLT] close map_files FD

### DIFF
--- a/bolt/runtime/instr.cpp
+++ b/bolt/runtime/instr.cpp
@@ -714,9 +714,11 @@ static char *getBinaryPath() {
       uint32_t Ret = __readlink(FindBuf, TargetPath, sizeof(TargetPath));
       assert(Ret != -1 && Ret != BufSize, "readlink error");
       TargetPath[Ret] = '\0';
+      __close(FDdir);
       return TargetPath;
     }
   }
+  __close(FDdir);
   return nullptr;
 }
 


### PR DESCRIPTION
The BOLT runtime currently does not close the FD pointing to /proc/self/map_files. This does not actually hurt anything but was at least a bit of a red herring for me when looking through strace on a BOLT instrumented binary.