### PR TITLE
[asan] Change zero_alloc.cpp testcase to use stdlib.h, re-enable on Mac

### DIFF
--- a/compiler-rt/test/asan/TestCases/zero_alloc.cpp
+++ b/compiler-rt/test/asan/TestCases/zero_alloc.cpp
@@ -1,10 +1,7 @@
 // RUN: %clang_asan -Wno-alloc-size -fsanitize-recover=address %s -o %t && %env_asan_opts=halt_on_error=0 %run %t 2>&1 | FileCheck %s
 
-// UNSUPPORTED: darwin
-// UNSUPPORTED: ios
-
-#include <malloc.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char **argv) {
   {


### PR DESCRIPTION
Avoid build breakage on Mac (reported at https://github.com/llvm/llvm-project/pull/155943#issuecomment-3244593484)