### PR TITLE
[flang][OpenMP] Fix offsets for EQUIVALENCE in firstprivate(/block/)

### DIFF
--- a/flang/lib/Semantics/compute-offsets.cpp
+++ b/flang/lib/Semantics/compute-offsets.cpp
@@ -239,7 +239,9 @@ void ComputeOffsetsHelper::DoCommonBlock(Symbol &commonBlock) {
   std::size_t minAlignment{0};
   UnorderedSymbolSet previous;
   for (auto object : details.objects()) {
-    Symbol &symbol{*object};
+    // Allow for host association when the common block is
+    // OpenMP firstprivate.
+    Symbol &symbol{object->GetUltimate()};
     auto errorSite{
         commonBlock.name().empty() ? symbol.name() : commonBlock.name()};
     if (std::size_t padding{DoSymbol(symbol.GetUltimate())}) {

--- a/flang/lib/Semantics/symbol.cpp
+++ b/flang/lib/Semantics/symbol.cpp
@@ -611,7 +611,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Details &details) {
               sep = ',';
             }
           },
-          [](const HostAssocDetails &) {},
+          [&os](const HostAssocDetails &x) { os << " => " << x.symbol(); },
           [&](const ProcBindingDetails &x) {
             os << " => " << x.symbol().name();
             DumpOptional(os, "passName", x.passName());

--- a/flang/test/Semantics/cuf-device-procedures01.cuf
+++ b/flang/test/Semantics/cuf-device-procedures01.cuf
@@ -40,5 +40,5 @@ subroutine host()
 end subroutine
 
 ! CHECK-LABEL: Subprogram scope: host
-! CHECK: atomicadd, EXTERNAL: HostAssoc{{$}}
-! CHECK: syncthreads, EXTERNAL: HostAssoc{{$}}
+! CHECK: atomicadd, EXTERNAL: HostAssoc => atomicadd, EXTERNAL (Function, Implicit): ProcEntity REAL(4){{$}}
+! CHECK: syncthreads, EXTERNAL: HostAssoc => syncthreads, EXTERNAL (Subroutine): ProcEntity{{$}}

--- a/flang/test/Semantics/offsets05.f90
+++ b/flang/test/Semantics/offsets05.f90
@@ -1,0 +1,20 @@
+!RUN: %flang_fc1 -fdebug-dump-symbols -fopenmp %s | FileCheck %s
+
+subroutine sub
+  common /block/ a
+  equivalence (b,c), (d,e), (a,f)
+!$omp parallel firstprivate(/block/)
+!$omp end parallel
+end subroutine
+
+!CHECK: a (Implicit, InCommonBlock) size=4 offset=0: ObjectEntity type: REAL(4)
+!CHECK: b (Implicit) size=4 offset=0: ObjectEntity type: REAL(4)
+!CHECK: c (Implicit) size=4 offset=0: ObjectEntity type: REAL(4)
+!CHECK: d (Implicit) size=4 offset=4: ObjectEntity type: REAL(4)
+!CHECK: e (Implicit) size=4 offset=4: ObjectEntity type: REAL(4)
+!CHECK: f (Implicit) size=4 offset=0: ObjectEntity type: REAL(4)
+!CHECK: sub (Subroutine): HostAssoc => sub (Subroutine): Subprogram ()
+!CHECK: Equivalence Sets: (b,c) (d,e) (a,f)
+!CHECK: block size=4 offset=0: CommonBlockDetails alignment=4: a
+!CHECK: OtherConstruct scope:
+!CHECK:   a (OmpFirstPrivate, OmpExplicit): HostAssoc => a (Implicit, InCommonBlock) size=4 offset=0: ObjectEntity type: REAL(4)


### PR DESCRIPTION
When a common block appears in firstprivate, its contents become host associations, which the symbol offset computation code for equivalences wasn't expecting.  Add a GetUltimate() call, and extend symbol dumping for HostAssocDetails.