### PR TITLE
[libc] Install dladdr on X86

### DIFF
--- a/libc/config/linux/x86_64/entrypoints.txt
+++ b/libc/config/linux/x86_64/entrypoints.txt
@@ -18,6 +18,7 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.ctype.toupper
 
     # dlfcn.h entrypoints
+    libc.src.dlfcn.dladdr
     libc.src.dlfcn.dlclose
     libc.src.dlfcn.dlerror
     libc.src.dlfcn.dlopen

--- a/libc/hdr/types/CMakeLists.txt
+++ b/libc/hdr/types/CMakeLists.txt
@@ -461,3 +461,12 @@ add_proxy_header_library(
     libc.include.llvm-libc-types.struct_sched_param
     libc.include.sched
 )
+
+add_proxy_header_library(
+  dl_info
+  HDRS
+    dl_info.h
+  FULL_BUILD_DEPENDS
+    libc.include.llvm-libc-types.dl_info
+    libc.include.dlfcn
+)

--- a/libc/hdr/types/dl_info.h
+++ b/libc/hdr/types/dl_info.h
@@ -1,0 +1,21 @@
+//===-- Proxy for struct timespec  ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_LIBC_HDR_TYPES_DLINFO_H
+#define LLVM_LIBC_HDR_TYPES_DLINFO_H
+
+#ifdef LIBC_FULL_BUILD
+
+#include "include/llvm-libc-types/Dl_info.h"
+
+#else
+
+#include <dlfcn.h>
+
+#endif // LIBC_FULL_BUILD
+
+#endif // LLVM_LIBC_HDR_TYPES_STRUCT_TIMESPEC_H

--- a/libc/src/dlfcn/CMakeLists.txt
+++ b/libc/src/dlfcn/CMakeLists.txt
@@ -54,4 +54,5 @@ add_entrypoint_object(
     dladdr.h
   DEPENDS
     libc.include.dlfcn
+    libc.hdr.types.dl_info
 )

--- a/libc/src/dlfcn/dladdr.cpp
+++ b/libc/src/dlfcn/dladdr.cpp
@@ -15,7 +15,8 @@ namespace LIBC_NAMESPACE_DECL {
 
 // TODO: https:// github.com/llvm/llvm-project/issues/97929
 LLVM_LIBC_FUNCTION(int, dladdr,
-                   (const void *__restrict addr, Dl_info *__restrict info)) {
+                   ([[maybe_unused]] const void *__restrict addr,
+                    [[maybe_unused]] Dl_info *__restrict info)) {
   return -1;
 }
 

--- a/libc/src/dlfcn/dladdr.h
+++ b/libc/src/dlfcn/dladdr.h
@@ -11,6 +11,8 @@
 
 #include "src/__support/macros/config.h"
 
+#include "hdr/types/dl_info.h"
+
 namespace LIBC_NAMESPACE_DECL {
 
 int dladdr(const void *__restrict, Dl_info *__restrict);


### PR DESCRIPTION
This patch adds dladdr to the X86 entrypoints and also does the necessary plumbing so that dladdr.cpp will actually compile.

This depends on #156195.