### PR TITLE
[lld] Remove shell requirements from tests

### DIFF
--- a/lld/test/COFF/color-diagnostics.test
+++ b/lld/test/COFF/color-diagnostics.test
@@ -1,5 +1,5 @@
 # Windows command prompt doesn't support ANSI escape sequences.
-# REQUIRES: shell
+# UNSUPPORTED: system-windows
 
 # RUN: not lld-link -xyz --color-diagnostics /nosuchfile 2>&1 \
 # RUN:   | FileCheck -check-prefix=COLOR %s

--- a/lld/test/COFF/linkrepro-res.test
+++ b/lld/test/COFF/linkrepro-res.test
@@ -1,4 +1,6 @@
-# REQUIRES: x86, shell
+# REQUIRES: x86
+# Unsupported on Windows due to maximum path length limitations.
+# UNSUPPORTED: system-windows
 
 # RUN: rm -rf %t.dir
 # RUN: mkdir -p %t.dir/build

--- a/lld/test/COFF/linkrepro.test
+++ b/lld/test/COFF/linkrepro.test
@@ -1,4 +1,6 @@
-# REQUIRES: x86, shell
+# REQUIRES: x86
+# Unsupported on Windows due to maximum path length limitations.
+# UNSUPPORTED: system-windows
 
 # RUN: rm -rf %t.dir
 # RUN: split-file %s %t.dir

--- a/lld/test/ELF/arm-exidx-range.s
+++ b/lld/test/ELF/arm-exidx-range.s
@@ -1,4 +1,6 @@
-// REQUIRES: arm, shell
+// REQUIRES: arm
+// Fails for unclear reasons on 32-bit windows
+// UNSUPPORTED: system-windows
 // RUN: llvm-mc --arm-add-build-attributes --triple=armv7a-linux-gnueabihf -filetype=obj %s -o %t.o
 // RUN: echo "SECTIONS { \
 // RUN:         . = 0x80000000; \

--- a/lld/test/ELF/color-diagnostics.test
+++ b/lld/test/ELF/color-diagnostics.test
@@ -1,5 +1,5 @@
 # Windows command prompt doesn't support ANSI escape sequences.
-# REQUIRES: shell
+# UNSUPPORTED: system-windows
 
 # RUN: not ld.lld -xyz --color-diagnostics /nosuchfile 2>&1 \
 # RUN:   | FileCheck -check-prefix=COLOR %s

--- a/lld/test/ELF/file-access.s
+++ b/lld/test/ELF/file-access.s
@@ -1,4 +1,5 @@
 # REQUIRES: x86
+# UNSUPPORTED: system-windows
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t.o
 # RUN: ld.lld -r %t.o -o %t1.o

--- a/lld/test/ELF/file-access.s
+++ b/lld/test/ELF/file-access.s
@@ -1,4 +1,4 @@
-# REQUIRES: x86, shell
+# REQUIRES: x86
 
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t.o
 # RUN: ld.lld -r %t.o -o %t1.o

--- a/lld/test/ELF/linkerscript/invalid.test
+++ b/lld/test/ELF/linkerscript/invalid.test
@@ -5,7 +5,7 @@
 ## We can't write quoted strings that are interpreted the same way
 ## by all echo commands. So, we don't want to run this on Windows.
 
-# REQUIRES: shell
+# UNSUPPORTED: system-windows
 
 # RUN: mkdir -p %t.dir
 

--- a/lld/test/ELF/lto/resolution-err.ll
+++ b/lld/test/ELF/lto/resolution-err.ll
@@ -1,5 +1,5 @@
 ; UNSUPPORTED: system-windows
-; REQUIRES: shell, non-root-user
+; REQUIRES: non-root-user
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: touch %t.resolution.txt
 ; RUN: chmod u-w %t.resolution.txt

--- a/lld/test/MachO/color-diagnostics.test
+++ b/lld/test/MachO/color-diagnostics.test
@@ -1,5 +1,5 @@
 # Windows command prompt doesn't support ANSI escape sequences.
-# REQUIRES: shell
+# UNSUPPORTED: system-windows
 
 # RUN: not %lld --color-diagnostics /nosuchfile 2>&1 \
 # RUN:   | FileCheck -check-prefix=COLOR %s

--- a/lld/test/MachO/framework.s
+++ b/lld/test/MachO/framework.s
@@ -1,4 +1,5 @@
 # REQUIRES: x86
+# UNSUPPORTED: system-windows
 # RUN: rm -rf %t; split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %t/foo.s -o %t/foo.o
 # RUN: mkdir -p %t/Foo.framework/Versions/A

--- a/lld/test/MachO/framework.s
+++ b/lld/test/MachO/framework.s
@@ -1,4 +1,4 @@
-# REQUIRES: x86, shell
+# REQUIRES: x86
 # RUN: rm -rf %t; split-file %s %t
 # RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %t/foo.s -o %t/foo.o
 # RUN: mkdir -p %t/Foo.framework/Versions/A

--- a/lld/test/MachO/implicit-and-allowable-clients.test
+++ b/lld/test/MachO/implicit-and-allowable-clients.test
@@ -1,4 +1,7 @@
-# REQUIRES: aarch64, shell
+# ln -s is not guaranteed to work on Windows
+# UNSUPPORTED: system-windows
+
+# REQUIRES: aarch64
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/FrameworkPublic.tbd %t/System/Library/Frameworks/FrameworkPublic.framework/
 # RUN: ln -s Versions/A/FrameworkPrivate.tbd %t/System/Library/Frameworks/FrameworkPrivate.framework/

--- a/lld/test/MachO/link-search-at-loader-path-symlink.s
+++ b/lld/test/MachO/link-search-at-loader-path-symlink.s
@@ -1,4 +1,6 @@
 # REQUIRES: x86
+# Windows does not support rpath
+# UNSUPPORTED: system-windows
 
 # RUN: rm -rf %t; split-file %s %t
 

--- a/lld/test/MachO/link-search-at-loader-path-symlink.s
+++ b/lld/test/MachO/link-search-at-loader-path-symlink.s
@@ -1,4 +1,4 @@
-# REQUIRES: x86, shell
+# REQUIRES: x86
 
 # RUN: rm -rf %t; split-file %s %t
 

--- a/lld/test/MachO/reexport-with-symlink.s
+++ b/lld/test/MachO/reexport-with-symlink.s
@@ -1,4 +1,4 @@
-# REQUIRES: aarch64, shell
+# REQUIRES: aarch64
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/Developer %t/Developer/Library/Frameworks/Developer.framework/
 # RUN: llvm-mc -filetype obj -triple arm64-apple-macos11.0 %t/test.s -o %t/test.o

--- a/lld/test/MachO/reexport-with-symlink.s
+++ b/lld/test/MachO/reexport-with-symlink.s
@@ -1,4 +1,5 @@
 # REQUIRES: aarch64
+# UNSUPPORTED: system-windows
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/Developer %t/Developer/Library/Frameworks/Developer.framework/
 # RUN: llvm-mc -filetype obj -triple arm64-apple-macos11.0 %t/test.s -o %t/test.o

--- a/lld/test/MachO/reexport-without-rpath.s
+++ b/lld/test/MachO/reexport-without-rpath.s
@@ -1,4 +1,4 @@
-# REQUIRES: aarch64, shell
+# REQUIRES: aarch64
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/Developer %t/Developer/Library/Frameworks/Developer.framework/
 # RUN: ln -s Versions/A/DeveloperCore %t/Developer/Library/PrivateFrameworks/DeveloperCore.framework/

--- a/lld/test/MachO/reexport-without-rpath.s
+++ b/lld/test/MachO/reexport-without-rpath.s
@@ -1,4 +1,6 @@
 # REQUIRES: aarch64
+# Windows does not support rpath
+# UNSUPPORTED: system-windows
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/Developer %t/Developer/Library/Frameworks/Developer.framework/
 # RUN: ln -s Versions/A/DeveloperCore %t/Developer/Library/PrivateFrameworks/DeveloperCore.framework/

--- a/lld/test/MachO/reproduce.s
+++ b/lld/test/MachO/reproduce.s
@@ -1,4 +1,6 @@
-# REQUIRES: x86, shell
+# REQUIRES: x86_64
+# Unsupported on Windows due to maximum path length limitations.
+# UNSUPPORTED: system-windows
 
 # RUN: rm -rf %t.dir
 # RUN: mkdir -p %t.dir/build1

--- a/lld/test/MachO/reproduce.s
+++ b/lld/test/MachO/reproduce.s
@@ -1,4 +1,4 @@
-# REQUIRES: x86_64
+# REQUIRES: x86
 # Unsupported on Windows due to maximum path length limitations.
 # UNSUPPORTED: system-windows
 

--- a/lld/test/MachO/tapi-rpath.s
+++ b/lld/test/MachO/tapi-rpath.s
@@ -1,4 +1,4 @@
-# REQUIRES: aarch64, shell
+# REQUIRES: aarch64
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/Developer %t/Developer/Library/Frameworks/Developer.framework/
 # RUN: ln -s Versions/A/DeveloperCore %t/Developer/Library/PrivateFrameworks/DeveloperCore.framework/

--- a/lld/test/MachO/tapi-rpath.s
+++ b/lld/test/MachO/tapi-rpath.s
@@ -1,4 +1,6 @@
 # REQUIRES: aarch64
+# Windows does not support rpath
+# UNSUPPORTED: system-windows
 # RUN: rm -rf %t; split-file %s %t
 # RUN: ln -s Versions/A/Developer %t/Developer/Library/Frameworks/Developer.framework/
 # RUN: ln -s Versions/A/DeveloperCore %t/Developer/Library/PrivateFrameworks/DeveloperCore.framework/

--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -19,7 +19,7 @@ config.name = "lld"
 # testFormat: The test format to use to interpret tests.
 #
 # For now we require '&&' between commands, until they get globally killed and the test runner updated.
-config.test_format = lit.formats.ShTest(False)
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".ll", ".s", ".test", ".yaml", ".objtxt"]

--- a/lld/test/lit.cfg.py
+++ b/lld/test/lit.cfg.py
@@ -19,7 +19,7 @@ config.name = "lld"
 # testFormat: The test format to use to interpret tests.
 #
 # For now we require '&&' between commands, until they get globally killed and the test runner updated.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+config.test_format = lit.formats.ShTest(False)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [".ll", ".s", ".test", ".yaml", ".objtxt"]

--- a/lld/test/wasm/reproduce.s
+++ b/lld/test/wasm/reproduce.s
@@ -1,4 +1,5 @@
-# REQUIRES: shell
+# Unsupported on Windows due to maximum path length limitations.
+# UNSUPPORTED: system-windows
 # RUN: rm -rf %t.dir
 # RUN: mkdir -p %t.dir
 # RUN: llvm-mc -filetype=obj -triple=wasm32-unknown-unknown -o %t.dir/foo.o %s


### PR DESCRIPTION
These tests all pass inside the lit internal shell. A couple were marked
as requiring a shell to exclude them on Windows. Update those tests to
explicitly carve out Windows rather than any configuration that does not
provide the shell feature.

Towards #102700.
