### PR TITLE
[libc] Add missing and correct some existing C23 functions to math.h

### DIFF
--- a/libc/include/math.yaml
+++ b/libc/include/math.yaml
@@ -310,10 +310,33 @@ functions:
     arguments:
       - type: _Float16
     guard: LIBC_TYPES_HAS_FLOAT16
+  - name: daddf128
+    standards:
+      - llvm_libc_ext
+    return_type: double
+    arguments:
+      - type: float128
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
+  - name: daddl
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: long double
+      - type: long double
+  - name: ddivf128
+    standards:
+      - llvm_libc_ext
+    return_type: double
+    arguments:
+      - type: float128
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
   - name: ddivl
     standards:
       - stdc
-    return_type: long double
+    return_type: double
     arguments:
       - type: long double
       - type: long double
@@ -332,13 +355,20 @@ functions:
     arguments:
       - type: long double
       - type: long double
+  - name: dsqrtf128
+    standards:
+      - llvm_libc_ext
+    return_type: double
+    arguments:
+      - type: float128
+    guard: LIBC_TYPES_HAS_FLOAT128
   - name: dsqrtl
     standards:
       - stdc
     return_type: double
     arguments:
       - type: long double
-  - name: dsqrtf128
+  - name: dsubf128
     standards:
       - llvm_libc_ext
     return_type: double
@@ -346,6 +376,13 @@ functions:
       - type: float128
       - type: float128
     guard: LIBC_TYPES_HAS_FLOAT128
+  - name: dsubl
+    standards:
+      - stdc
+    return_type: double
+    arguments:
+      - type: long double
+      - type: long double
   - name: erff
     standards:
       - stdc
@@ -1167,6 +1204,13 @@ functions:
       - type: _Float16
       - type: _Float16
     guard: LIBC_TYPES_HAS_FLOAT16
+  - name: fminimum_numl
+    standards:
+      - stdc
+    return_type: long double
+    arguments:
+      - type: long double
+      - type: long double
   - name: fminimumf
     standards:
       - stdc


### PR DESCRIPTION
This change fixes and closes some gaps in the YAML template for producing the math.h header.

It adds some missing declarations (dadd/dsub function variants), correct arguments and/or return type for other functions from this family (dsqrt and ddiv), and add a missing fminimum_numl variant.