### PR TITLE
[CodeGen][test][NFC] Refactor ObjC attribute tests

### DIFF
--- a/clang/test/CodeGen/instrument-objc-method.m
+++ b/clang/test/CodeGen/instrument-objc-method.m
@@ -1,29 +1,24 @@
-// RUN: %clang_cc1 -disable-llvm-passes -triple x86_64-apple-darwin10 -debug-info-kind=standalone -emit-llvm -o - %s -finstrument-functions | FileCheck -check-prefix=PREINLINE %s
-// RUN: %clang_cc1 -disable-llvm-passes -triple x86_64-apple-darwin10 -debug-info-kind=standalone -emit-llvm -o - %s -finstrument-function-entry-bare | FileCheck -check-prefix=BARE %s
+// RUN: %clang_cc1 -disable-llvm-passes -triple x86_64-apple-darwin10 -debug-info-kind=standalone -emit-llvm -o - %s -finstrument-functions | FileCheck --check-prefix=PREINLINE --implicit-check-not="__cyg_profile_func_enter" %s
+// RUN: %clang_cc1 -disable-llvm-passes -triple x86_64-apple-darwin10 -debug-info-kind=standalone -emit-llvm -o - %s -finstrument-function-entry-bare | FileCheck --check-prefix=BARE --implicit-check-not="__cyg_profile_func_enter" %s
 
 @interface ObjCClass
 @end
 
 @implementation ObjCClass
 
-// PREINLINE: @"\01+[ObjCClass initialize]"{{\(.*\)}} #0
-// BARE: @"\01+[ObjCClass initialize]"{{\(.*\)}} #0
+// PREINLINE: define {{.*}}@"\01+[ObjCClass initialize]"{{\(.*\)}} #[[#ATTR:]]
+// BARE: define {{.*}}@"\01+[ObjCClass initialize]"{{\(.*\)}} #[[#ATTR:]]
 + (void)initialize {
 }
 
-// BARE: @"\01+[ObjCClass load]"{{\(.*\)}} #1
 + (void)load __attribute__((no_instrument_function)) {
 }
 
-// PREINLINE: @"\01-[ObjCClass dealloc]"{{\(.*\)}} #1
-// BARE: @"\01-[ObjCClass dealloc]"{{\(.*\)}} #1
 - (void)dealloc __attribute__((no_instrument_function)) {
 }
 
-// PREINLINE: attributes #0 = { {{.*}}"instrument-function-entry"="__cyg_profile_func_enter"
-// PREINLINE-NOT: attributes #0 = { {{.*}}"instrument-function-entry"="__cyg_profile_func_enter_bare"
-// PREINLINE-NOT: attributes #2 = { {{.*}}"__cyg_profile_func_enter"
-// BARE: attributes #0 = { {{.*}}"instrument-function-entry-inlined"="__cyg_profile_func_enter_bare"
-// BARE-NOT: attributes #0 = { {{.*}}"__cyg_profile_func_enter"
-// BARE-NOT: attributes #2 = { {{.*}}"__cyg_profile_func_enter_bare"
+// PREINLINE: attributes #[[#ATTR]] =
+// PREINLINE-SAME: "instrument-function-entry"="__cyg_profile_func_enter"
+// BARE: attributes #[[#ATTR]] =
+// BARE-SAME: "instrument-function-entry-inlined"="__cyg_profile_func_enter_bare"
 @end

--- a/clang/test/CodeGenObjCXX/address-safety-attr.mm
+++ b/clang/test/CodeGenObjCXX/address-safety-attr.mm
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -emit-llvm -o - %s | FileCheck -check-prefix=WITHOUT %s
-// RUN: %clang_cc1 -emit-llvm -o - %s -fsanitize=address | FileCheck -check-prefix=ASAN %s
+// RUN: %clang_cc1 -emit-llvm -o - %s | FileCheck %s --implicit-check-not=sanitize_address
+// RUN: %clang_cc1 -emit-llvm -o - %s -fsanitize=address | FileCheck %s --check-prefixes=CHECK,ASAN
 
 @interface MyClass
 + (int) addressSafety:(int*)a;
@@ -7,15 +7,14 @@
 
 @implementation MyClass
 
-// WITHOUT:  +[MyClass load]{{.*}}#0
-// ASAN: +[MyClass load]{{.*}}#0
+// ASAN: ; Function Attrs:
+// ASAN-SAME: sanitize_address
+// CHECK-LABEL: define {{.*}}+[MyClass load]
 +(void) load { }
 
-// WITHOUT:  +[MyClass addressSafety:]{{.*}}#0
-// ASAN:  +[MyClass addressSafety:]{{.*}}#0
+// ASAN: ; Function Attrs:
+// ASAN-SAME: sanitize_address
+// CHECK-LABEL: define {{.*}}+[MyClass addressSafety:]
 + (int) addressSafety:(int*)a { return *a; }
 
 @end
-
-// ASAN: attributes #0 = {{.*}}sanitize_address
-// WITHOUT-NOT: attributes #0 = {{.*}}sanitize_address


### PR DESCRIPTION
Some downstream work broke these tests because the attribute number changed. Refactor these tests to be more resilient in the face of changes like this

* `instrument-objc-method.m`
  * `#1` was never checked, I think it was trying to check that `__cyg_profile_func_enter` was not used, so I added `--implicit-check-not="__cyg_profile_func_enter"`
  * Use `[[#ATTR:]]` so the test doesn't fail if the number changes
* `address-safety-attr.mm`
  * Check attributes in `Function Attrs:` so it's independent of the attribute number