### PR TITLE
[clang-tidy] Fix file extension inconsistency

### DIFF
--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -391,9 +391,7 @@ def parse_arguments() -> Tuple[argparse.Namespace, List[str]]:
     args, extra_args = parser.parse_known_args()
     if args.std is None:
         _, extension = os.path.splitext(args.assume_filename or args.input_file_name)
-        args.std = [
-            "c99-or-later" if extension in [".c", ".m"] else "c++11-or-later"
-        ]
+        args.std = ["c99-or-later" if extension in [".c", ".m"] else "c++11-or-later"]
 
     return (args, extra_args)
 

--- a/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
+++ b/clang-tools-extra/test/clang-tidy/check_clang_tidy.py
@@ -392,7 +392,7 @@ def parse_arguments() -> Tuple[argparse.Namespace, List[str]]:
     if args.std is None:
         _, extension = os.path.splitext(args.assume_filename or args.input_file_name)
         args.std = [
-            "c++11-or-later" if extension in [".cpp", ".hpp", ".mm"] else "c99-or-later"
+            "c99-or-later" if extension in [".c", ".m"] else "c++11-or-later"
         ]
 
     return (args, extra_args)


### PR DESCRIPTION
This fixes an issue with #150791. In CheckRunner, we treat files with unrecognized extensions as ".cpp", by forcefully assigning `extension = ".cpp"` if it's not already one of `".c", ".hpp", ".m", or ".mm"`. Make the new code which chooses the default `-std` argument be consistent with that, so that using other file extensions doesn't trigger an error message like `error: invalid argument '-std=c99' not allowed with 'C++'`