### PR TITLE
Reverts recent debuginfod patches

### DIFF
--- a/llvm/include/llvm/Debuginfod/Debuginfod.h
+++ b/llvm/include/llvm/Debuginfod/Debuginfod.h
@@ -152,16 +152,11 @@ public:
   Expected<std::string> findBinaryPath(object::BuildIDRef);
 };
 
-class DebuginfodServer {
-public:
+struct DebuginfodServer {
   HTTPServer Server;
+  DebuginfodLog &Log;
+  DebuginfodCollection &Collection;
   DebuginfodServer(DebuginfodLog &Log, DebuginfodCollection &Collection);
-  static Expected<DebuginfodServer> create(DebuginfodLog &Log,
-                                           DebuginfodCollection &Collection);
-
-private:
-  DebuginfodServer() = default;
-  Error init(DebuginfodLog &Log, DebuginfodCollection &Collection);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Debuginfod/HTTPServer.h
+++ b/llvm/include/llvm/Debuginfod/HTTPServer.h
@@ -104,7 +104,6 @@ class HTTPServer {
 public:
   HTTPServer();
   ~HTTPServer();
-  HTTPServer(HTTPServer &&);
 
   /// Returns true only if LLVM has been compiled with a working HTTPServer.
   static bool isAvailable();

--- a/llvm/lib/Debuginfod/HTTPServer.cpp
+++ b/llvm/lib/Debuginfod/HTTPServer.cpp
@@ -62,8 +62,6 @@ bool llvm::streamFile(HTTPServerRequest &Request, StringRef FilePath) {
   return true;
 }
 
-HTTPServer::HTTPServer(HTTPServer &&) = default;
-
 #ifdef LLVM_ENABLE_HTTPLIB
 
 bool HTTPServer::isAvailable() { return true; }

--- a/llvm/tools/llvm-debuginfod/llvm-debuginfod.cpp
+++ b/llvm/tools/llvm-debuginfod/llvm-debuginfod.cpp
@@ -131,8 +131,8 @@ int llvm_debuginfod_main(int argc, char **argv, const llvm::ToolContext &) {
   DefaultThreadPool Pool(hardware_concurrency(MaxConcurrency));
   DebuginfodLog Log;
   DebuginfodCollection Collection(Paths, Log, Pool, MinInterval);
-  DebuginfodServer Server =
-      ExitOnErr(DebuginfodServer::create(Log, Collection));
+  DebuginfodServer Server(Log, Collection);
+
   if (!Port)
     Port = ExitOnErr(Server.Server.bind(HostInterface.c_str()));
   else


### PR DESCRIPTION
This patch reverts 44e791c6ff1a982de9651aad7d1c83d1ad96da8a, 3cc1031a827d319c6cb48df1c3aafc9ba7e96d72 and
adbd43250ade1d5357542d8bd7c3dfed212ddec0. Which breaks debuginfod build and tests when httplib is used.