### PR TITLE
[utils] Process attribute references in lines defining attrs.

### DIFF
--- a/mlir/utils/generate-test-checks.py
+++ b/mlir/utils/generate-test-checks.py
@@ -229,7 +229,9 @@ def process_attribute_definition(line, attribute_namer):
             "// CHECK: #[["
             + attribute_name
             + ":.+]] ="
-            + line[len(m.group(0)) :]
+            # The rest of the line may contain attribute references,
+            # so we have to process them.
+            + process_attribute_references(line[len(m.group(0)) :], attribute_namer)
             + "\n"
         )
     return None


### PR DESCRIPTION
Here is an example of TBAA attributes generated by Flang:
```
#tbaa_root = #llvm.tbaa_root<id = "Flang function root _QPtest6">
#tbaa_type_desc = #llvm.tbaa_type_desc<id = "any access", members = {<#tbaa_root, 0>}>
```

We have to process the text after `=` to replace the attribute
references with proper check variables.
