### PR TITLE
[flang][rt] Remove findloc.cpp from supported_sources fro CUDA build

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -178,6 +178,9 @@ endif ()
 if ("${LLVM_RUNTIMES_TARGET}" MATCHES "^amdgcn|^nvptx")
   set(sources ${gpu_sources})
 elseif(FLANG_RT_EXPERIMENTAL_OFFLOAD_SUPPORT STREQUAL "CUDA")
+  # findloc.cpp has some issues with higher compute capability. Remove it
+  # from CUDA build until we can lower its memory footprint.
+  list(REMOVE_ITEM supported_sources findloc.cpp)
   set(sources ${supported_sources})
 else ()
   set(sources ${supported_sources} ${host_sources} ${f128_sources})


### PR DESCRIPTION
findloc.cpp is causing memory exhaustion with higher compute capabilities. Also it is a very expensive file to build. Remove it from the supported_sources for CUDA build until we can lower its memory footprint. 