### PR TITLE
[Frontend] Define __SANITIZE__ macros for kernel address variants

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1519,11 +1519,11 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   if (TI.getTriple().isOSBinFormatELF())
     Builder.defineMacro("__ELF__");
 
-  if (LangOpts.Sanitize.has(SanitizerKind::Address) ||
-      LangOpts.Sanitize.has(SanitizerKind::KernelAddress))
+  if (LangOpts.Sanitize.hasOneOf(SanitizerKind::Address |
+                                 SanitizerKind::KernelAddress))
     Builder.defineMacro("__SANITIZE_ADDRESS__");
-  if (LangOpts.Sanitize.has(SanitizerKind::HWAddress) ||
-      LangOpts.Sanitize.has(SanitizerKind::KernelHWAddress))
+  if (LangOpts.Sanitize.hasOneOf(SanitizerKind::HWAddress |
+                                 SanitizerKind::KernelHWAddress))
     Builder.defineMacro("__SANITIZE_HWADDRESS__");
   if (LangOpts.Sanitize.has(SanitizerKind::Thread))
     Builder.defineMacro("__SANITIZE_THREAD__");

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1519,9 +1519,11 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   if (TI.getTriple().isOSBinFormatELF())
     Builder.defineMacro("__ELF__");
 
-  if (LangOpts.Sanitize.has(SanitizerKind::Address))
+  if (LangOpts.Sanitize.has(SanitizerKind::Address) ||
+      LangOpts.Sanitize.has(SanitizerKind::KernelAddress))
     Builder.defineMacro("__SANITIZE_ADDRESS__");
-  if (LangOpts.Sanitize.has(SanitizerKind::HWAddress))
+  if (LangOpts.Sanitize.has(SanitizerKind::HWAddress) ||
+      LangOpts.Sanitize.has(SanitizerKind::KernelHWAddress))
     Builder.defineMacro("__SANITIZE_HWADDRESS__");
   if (LangOpts.Sanitize.has(SanitizerKind::Thread))
     Builder.defineMacro("__SANITIZE_THREAD__");

--- a/clang/test/Preprocessor/sanitizer-predefines.c
+++ b/clang/test/Preprocessor/sanitizer-predefines.c
@@ -1,7 +1,9 @@
 // RUN: %clang_cc1 -E -dM -triple aarch64-unknown-linux -fsanitize=address %s | FileCheck %s --check-prefix=ASAN
+// RUN: %clang_cc1 -E -dM -triple aarch64-unknown-linux -fsanitize=kernel-address %s | FileCheck %s --check-prefix=ASAN
 // ASAN: #define __SANITIZE_ADDRESS__ 1
 
 // RUN: %clang_cc1 -E -dM -triple aarch64-unknown-linux -fsanitize=hwaddress %s | FileCheck %s --check-prefix=HWASAN
+// RUN: %clang_cc1 -E -dM -triple aarch64-unknown-linux -fsanitize=kernel-hwaddress %s | FileCheck %s --check-prefix=HWASAN
 // HWASAN: #define __SANITIZE_HWADDRESS__ 1
 
 // RUN: %clang_cc1 -E -dM -triple aarch64-unknown-linux -fsanitize=thread %s | FileCheck %s --check-prefix=TSAN


### PR DESCRIPTION
GCC defines these macros for both userspace and kernel address sanitizers:

    $ gcc -E -dM -fsanitize=address -x c /dev/null &| string match -er SANITIZE
    #define __SANITIZE_ADDRESS__ 1
    $ gcc -E -dM -fsanitize=kernel-address -x c /dev/null &| string match -er SANITIZE
    #define __SANITIZE_ADDRESS__ 1
    $ gcc -E -dM -fsanitize=hwaddress -x c /dev/null &| string match -er SANITIZE
    #define __SANITIZE_HWADDRESS__ 1
    $ gcc -E -dM -fsanitize=kernel-hwaddress -x c /dev/null &| string match -er SANITIZE
    #define __SANITIZE_HWADDRESS__ 1

PR #153888 added these same defines for clang but only for the userspace address sanitizers:

    $ clang -E -dM -fsanitize=address -x c /dev/null &| string match -er SANITIZE
    #define __SANITIZE_ADDRESS__ 1
    $ clang -E -dM -fsanitize=kernel-address -x c /dev/null &| string match -er SANITIZE
    $ clang -E -dM -fsanitize=hwaddress -x c /dev/null &| string match -er SANITIZE
    #define __SANITIZE_HWADDRESS__ 1
    $ clang -E -dM -fsanitize=kernel-hwaddress -x c /dev/null &| string match -er SANITIZE

Match GCC's behavior so that the Linux kernel can eventually drop its own internal defines.
