### PR TITLE
[libc++] Conditionally declare `lgamma_r` as noexcept

### DIFF
--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -97,13 +97,23 @@ public:
   }
 };
 
-// The LLVM C library provides this with conflicting `noexcept` attributes.
-#if !defined(_LIBCPP_MSVCRT_LIKE) && !defined(__LLVM_LIBC__)
-extern "C" double lgamma_r(double, int*);
+// Some libc declares the math functions to be `noexcept`.
+#if defined(_LIBCPP_GLIBC_PREREQ)
+#  if _LIBCPP_GLIBC_PREREQ(2, 8)
+#    define _LIBCPP_LGAMMA_R_NOEXCEPT _NOEXCEPT
+#  endif
+#elif defined(__LLVM_LIBC__)
+#  define _LIBCPP_LGAMMA_R_NOEXCEPT _NOEXCEPT
+#else
+#  define _LIBCPP_LGAMMA_R_NOEXCEPT
+#endif
+
+#if !defined(_LIBCPP_MSVCRT_LIKE)
+extern "C" double lgamma_r(double, int*) _LIBCPP_LGAMMA_R_NOEXCEPT;
 #endif
 
 inline _LIBCPP_HIDE_FROM_ABI double __libcpp_lgamma(double __d) {
-#if defined(_LIBCPP_MSVCRT_LIKE) || defined(__LLVM_LIBC__)
+#if defined(_LIBCPP_MSVCRT_LIKE)
   return lgamma(__d);
 #else
   int __sign;


### PR DESCRIPTION
An older PR https://github.com/llvm/llvm-project/pull/102036 suggested that LLVM libc declares `lgamma_r` as noexcept and is incompatible with this redeclaration. However, I recently discovered that glibc also declares the math functions to be noexcept under C++ mode. 

This line usually don't cause issues because both the glibc and this file are included as "system headers". According to [this godbolt](https://godbolt.org/z/o7Wd9PP58), both GCC and clang ignore the different exception specification between multiple declarations if they are in system headers. 

However, this seems not the case for NVCC/EDG, so a fix for this redeclaration is still desirable. This patch proposes that we should declare the function as noexcept under known libc integrations to keep the declared function consistent. 