### PR TITLE
[mlir][ToLLVM] Fix the index bitwidth handling for the dynamic case of `convert-to-llvm`

### DIFF
--- a/mlir/lib/Conversion/ConvertToLLVM/ConvertToLLVMPass.cpp
+++ b/mlir/lib/Conversion/ConvertToLLVM/ConvertToLLVMPass.cpp
@@ -174,7 +174,9 @@ struct DynamicConvertToLLVM : public ConvertToLLVMPassInterface {
     target.addLegalDialect<LLVM::LLVMDialect>();
     // Get the data layout analysis.
     const auto &dlAnalysis = manager.getAnalysis<DataLayoutAnalysis>();
-    LLVMTypeConverter typeConverter(context, &dlAnalysis);
+    const DataLayout &dl = dlAnalysis.getAtOrAbove(op);
+    LowerToLLVMOptions options(context, dl);
+    LLVMTypeConverter typeConverter(context, options, &dlAnalysis);
 
     // Configure the conversion with dialect level interfaces.
     for (ConvertToLLVMPatternInterface *iface : *interfaces)

--- a/mlir/test/Conversion/FuncToLLVM/func-to-llvm-datalayout.mlir
+++ b/mlir/test/Conversion/FuncToLLVM/func-to-llvm-datalayout.mlir
@@ -1,0 +1,39 @@
+// RUN: mlir-opt --convert-to-llvm="filter-dialects=func dynamic=true" --split-input-file %s
+
+
+// CHECK-LABEL: llvm.func @test_default_index
+// CHECK-SAME: (%{{.*}}: i64) -> i64
+func.func private @test_default_index(%arg0: index) -> index
+
+// -----
+
+// CHECK-LABEL: module attributes {dlti.dl_spec = #dlti.dl_spec<
+// CHECK-SAME: #dlti.dl_entry<index, 32>
+// CHECK-SAME: >}
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 32>>} {
+  // CHECK-LABEL: llvm.func @test_32bit_index
+  // CHECK-SAME: (%{{.*}}: i32) -> i32
+  func.func private @test_32bit_index(%arg0: index) -> index
+}
+
+// -----
+
+// CHECK-LABEL: module attributes {dlti.dl_spec = #dlti.dl_spec<
+// CHECK-SAME: #dlti.dl_entry<index, 64>
+// CHECK-SAME: >}
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 64>>} {
+  // CHECK-LABEL: llvm.func @test_64bit_index
+  // CHECK-SAME: (%{{.*}}: i64) -> i64
+  func.func private @test_64bit_index(%arg0: index) -> index
+}
+
+// -----
+
+// CHECK-LABEL: module attributes {dlti.dl_spec = #dlti.dl_spec<
+// CHECK-SAME: #dlti.dl_entry<index, 16>
+// CHECK-SAME: >}
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 16>>} {
+  // CHECK-LABEL: llvm.func @test_16bit_index
+  // CHECK-SAME: (%{{.*}}: i16) -> i16
+  func.func private @test_16bit_index(%arg0: index) -> index
+}


### PR DESCRIPTION
This patch changes the behavior of `convert-to-llvm{dynamic=true}` so that the nearest `DataLayout` is used to configure LowerToLLVMOptions and LLVMTypeConverter.

Example:

```mlir
module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<index, 16>>} {
  func.func private @test_16bit_index(%arg0: index) -> index
}
// mlir-opt --convert-to-llvm="dynamic=true"
module attributes {dlti.dl_spec = #dlti.dl_spec<index = 16 : i64>} {
  llvm.func @test_16bit_index(i16) -> i16 attributes {sym_visibility = "private"}
}
```