### PR TITLE
fix(LLDB): Repair OC_Bridge variable display issue when load-on-demand is true

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFileOnDemand.h
+++ b/lldb/include/lldb/Symbol/SymbolFileOnDemand.h
@@ -178,6 +178,8 @@ public:
 
   void PreloadSymbols() override;
 
+  std::vector<lldb::DataBufferSP> GetASTData(lldb::LanguageType language) override;
+
   uint64_t GetDebugInfoSize(bool load_all_debug_info = false) override;
   lldb_private::StatsDuration::Duration GetDebugInfoParseTime() override;
   lldb_private::StatsDuration::Duration GetDebugInfoIndexTime() override;

--- a/lldb/source/Symbol/SymbolFileOnDemand.cpp
+++ b/lldb/source/Symbol/SymbolFileOnDemand.cpp
@@ -535,6 +535,15 @@ void SymbolFileOnDemand::PreloadSymbols() {
   return m_sym_file_impl->PreloadSymbols();
 }
 
+std::vector<lldb::DataBufferSP> SymbolFileOnDemand::GetASTData(lldb::LanguageType language) {
+  if (!m_debug_info_enabled) {
+    LLDB_LOG(GetLog(), "[{0}] {1} is skipped", GetSymbolFileName(),
+             __FUNCTION__);
+    return {};
+  }
+  return m_sym_file_impl->GetASTData(language);
+}
+
 uint64_t SymbolFileOnDemand::GetDebugInfoSize(bool load_all_debug_info) {
   // Always return the real debug info size.
   LLDB_LOG(GetLog(), "[{0}] {1} is not skipped", GetSymbolFileName(),


### PR DESCRIPTION
fix(LLDB): Repair OC_Bridge variable display issue when load-on-demand is true
When symbols.load-on-demand is enabled in LLDB, variables from OC-bridged Swift objects were not being displayed. This was due to SymbolFileOndemand not correctly overriding the GetAstData method, causing it to return an empty implementation from the base SymbolFile class.
This commit fixes the issue by providing the correct implementation of GetAstData in SymbolFileOndemand, ensuring that the necessary AST data is loaded and OC-bridged variables can be correctly resolved and displayed during debugging.

Problem
When the symbols.load-on-demand setting in LLDB is set to True, member variables of Objective-C bridged Swift objects (OC Bridge variables) fail to display during debugging sessions.
Root Cause
The underlying issue is related to how LLDB handles symbol loading with the on-demand setting enabled.
Class Inheritance and Method Overriding: The SymbolFileOndemand class, which is active when on-demand symbol loading is enabled, inherits from the SymbolFile base class.
Missing Implementation: The SymbolFile base class provides a virtual method called GetAstData, but its default implementation returns an empty object. While other, direct subclasses of SymbolFile provide a proper override for this method, SymbolFileOndemand does not.
Incorrect Method Resolution: Consequently, when LLDB attempts to resolve symbols for OC Bridge variables in on-demand mode, it calls the empty base class implementation of GetAstData through the SymbolFileOndemand object. This fails to retrieve the necessary Abstract Syntax Tree (AST) data required to parse and display these variables.
In contrast, when symbols.load-on-demand is False, LLDB uses a different SymbolFile subclass that correctly implements GetAstData, and the variables are displayed as expected.
Solution
The solution is to provide the missing override for the GetAstData method in the SymbolFileOndemand class.
The implementation now delegates the call to the original SymbolFile object that SymbolFileOndemand wraps. This ensures that even when operating in on-demand mode, LLDB can correctly fetch the AST data, allowing it to resolve and display the OC Bridge variables correctly.