### PR TITLE
[clang-tidy] Fix `readability-uppercase-literal-suffix` warning with hex literals

### DIFF
--- a/clang-tools-extra/clang-tidy/readability/UppercaseLiteralSuffixCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UppercaseLiteralSuffixCheck.cpp
@@ -29,7 +29,7 @@ struct IntegerLiteralCheck {
   // integer (wb), and can be a complex number ('i', 'j'). In MS compatibility
   // mode, suffixes like i32 are supported.
   static constexpr llvm::StringLiteral Suffixes =
-      llvm::StringLiteral("uUlLzZwWbBiIjJ");
+      llvm::StringLiteral("uUlLzZwWiIjJ");
 };
 
 struct FloatingLiteralCheck {

--- a/clang-tools-extra/test/clang-tidy/checkers/cert/uppercase-literal-suffix-integer.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/cert/uppercase-literal-suffix-integer.cpp
@@ -128,3 +128,12 @@ void integer_suffix() {
   static_assert(is_same<decltype(v24), const unsigned long long>::value, "");
   static_assert(v24 == 1, "");
 }
+
+void no_warning_on_hex_literals() {
+  int a = 0xa;
+  int b = 0xb;
+  int c = 0xc;
+  int d = 0xd;
+  int e = 0xe;
+  int f = 0xf;
+}


### PR DESCRIPTION
This is a regression I introduced in #148275 and was [noticed by](https://github.com/llvm/llvm-project/pull/148275#issuecomment-3246670841) nettle. The check incorrectly fires on hex literals containing the letter `b` ([godbolt](https://godbolt.org/z/rcb77h6ef)).

(I felt a revert was unnecessary in this case. Maybe others disagree?)