### PR TITLE
[MLIR][NVVM] Add clusterlaunchcontrol Ops

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -4062,8 +4062,8 @@ def NVVM_ClusterLaunchControlTryCancelOp
   }];
 
   let arguments = (ins UnitAttr:$multicast, 
-                       LLVM_PointerShared: $addr,
-                       LLVM_PointerShared: $mbar);
+                       LLVM_PointerShared: $smemAddress,
+                       LLVM_PointerShared: $mbarrier);
 
   let assemblyFormat = "(`multicast` $multicast^ `,`)? $addr `,` $mbar attr-dict";
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -4048,11 +4048,11 @@ def NVVM_ClusterLaunchControlTryCancelOp
     opaque response to shared memory indicating whether the operation succeeded 
     or failed.
 
-    Operand `addr` specifies the naturally aligned address of the 16-byte wide 
-    shared memory location where the request's response is written.
+    Operand `smemAddress` specifies the naturally aligned address of the 
+    16-byte wide shared memory location where the request's response is written.
 
-    Operand `mbar` specifies the mbarrier object used to track the completion 
-    of the asynchronous operation.
+    Operand `mbarrier` specifies the mbarrier object used to track the 
+    completion of the asynchronous operation.
 
     If `multicast` is specified, the response is asynchronously written to the 
     corresponding local shared memory location (specifed by `addr`) of each CTA 
@@ -4109,28 +4109,25 @@ def NVVM_ClusterLaunchControlQueryCancelOp
   let summary = "Query the response of a clusterlaunchcontrol.try.cancel operation";
   let description = [{
     `clusterlaunchcontrol.query.cancel` queries the response of a 
-    `clusterlaunchcontrol.try.cancel` operation.
-
-    Operand `try_cancel_response` specifies the response of the 
-    `clusterlaunchcontrol.try.cancel` operation to be queried.
+    `clusterlaunchcontrol.try.cancel` operation specified by operand 
+    `try_cancel_response`.
 
     Operand `query_type` specifies the type of query to perform and can be one 
     of the following:
     - `is_canceled` : Returns true if the try cancel request succeeded, 
-    otherwise returns false.
-    - `get_first_cta_id_{x/y/z}` : Behaviour is defined only if the try cancel 
-    request succeeded. Returns the x, y, or z coordinate of the first CTA in 
-    the canceled cluster.
+    and false otherwise.
+    - `get_first_cta_id_{x/y/z}` : Returns the x, y, or z coordinate of the 
+    first CTA in the canceled cluster. Behaviour is defined only if the try 
+    cancel request succeeded. 
 
     [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-query-cancel)
   }];
 
-  let arguments = (ins DefaultValuedAttr<ClusterLaunchControlQueryTypeAttr, 
-                     "ClusterLaunchControlQueryType::IS_CANCELED">:$query_type,
+  let arguments = (ins ClusterLaunchControlQueryTypeAttr:$query_type, 
                        I128:$try_cancel_response);
   let results = (outs AnyTypeOf<[I1, I32]>:$res);
                                  
-  let assemblyFormat = "(`query` `=` $query_type^ `,`)? $try_cancel_response attr-dict `:` type($res)";
+  let assemblyFormat = "`query` `=` $query_type `,` $try_cancel_response attr-dict `:` type($res)";
   
   let hasVerifier = 1;
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -4036,6 +4036,119 @@ def NVVM_DotAccumulate2WayOp : NVVM_Op<"dot.accumulate.2way"> {
 }
 
 //===----------------------------------------------------------------------===//
+// NVVM clusterlaunchcontrol Ops.
+//===----------------------------------------------------------------------===//
+
+def NVVM_ClusterLaunchControlTryCancelOp
+    : NVVM_Op<"clusterlaunchcontrol.try.cancel", [NVVMRequiresSM<100>]> {
+  let summary = "Request atomically canceling the launch of a cluster that has not started running yet";
+  let description = [{
+    `clusterlaunchcontrol.try.cancel` requests atomically canceling the launch 
+    of a cluster that has not started running yet. It asynchronously writes an 
+    opaque response to shared memory indicating whether the operation succeeded 
+    or failed.
+
+    Operand `addr` specifies the naturally aligned address of the 16-byte wide 
+    shared memory location where the request's response is written.
+
+    Operand `mbar` specifies the mbarrier object used to track the completion 
+    of the asynchronous operation.
+
+    If `multicast` is specified, the response is asynchronously written to the 
+    corresponding local shared memory location (specifed by `addr`) of each CTA 
+    in the requesting cluster.
+
+    [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-try-cancel)
+  }];
+
+  let arguments = (ins UnitAttr:$multicast, 
+                       LLVM_PointerShared: $addr,
+                       LLVM_PointerShared: $mbar);
+
+  let assemblyFormat = "(`multicast` $multicast^ `,`)? $addr `,` $mbar attr-dict";
+
+  let extraClassDeclaration = [{
+    static mlir::NVVM::IDArgPair
+    getIntrinsicIDAndArgs(Operation &op, LLVM::ModuleTranslation &mt,
+                          llvm::IRBuilderBase &builder);
+  }];
+  
+  string llvmBuilder = [{
+    auto [id, args] = 
+    NVVM::ClusterLaunchControlTryCancelOp::getIntrinsicIDAndArgs(
+                        *op, moduleTranslation, builder);
+    createIntrinsicCall(builder, id, args);
+  }];
+}
+
+def ClusterLaunchControlIsCanceled
+  : I32EnumCase<"IS_CANCELED", 0, "is_canceled">;
+def ClusterLaunchControlGetFirstCTAIDX
+  : I32EnumCase<"GET_FIRST_CTA_ID_X", 1, "get_first_cta_id_x">;
+def ClusterLaunchControlGetFirstCTAIDY
+  : I32EnumCase<"GET_FIRST_CTA_ID_Y", 2, "get_first_cta_id_y">;
+def ClusterLaunchControlGetFirstCTAIDZ
+  : I32EnumCase<"GET_FIRST_CTA_ID_Z", 3, "get_first_cta_id_z">;
+
+def ClusterLaunchControlQueryType
+  : I32Enum<"ClusterLaunchControlQueryType",
+      "NVVM ClusterLaunchControlQueryType", 
+      [ClusterLaunchControlIsCanceled, ClusterLaunchControlGetFirstCTAIDX,
+      ClusterLaunchControlGetFirstCTAIDY, ClusterLaunchControlGetFirstCTAIDZ]> {
+  let cppNamespace = "::mlir::NVVM";
+}
+
+def ClusterLaunchControlQueryTypeAttr
+  : EnumAttr<NVVM_Dialect,
+      ClusterLaunchControlQueryType, "cluster_launch_control_query_type"> {
+  let assemblyFormat = "$value";
+}
+
+def NVVM_ClusterLaunchControlQueryCancelOp
+    : NVVM_Op<"clusterlaunchcontrol.query.cancel", [NVVMRequiresSM<100>]> {
+  let summary = "Query the response of a clusterlaunchcontrol.try.cancel operation";
+  let description = [{
+    `clusterlaunchcontrol.query.cancel` queries the response of a 
+    `clusterlaunchcontrol.try.cancel` operation.
+
+    Operand `try_cancel_response` specifies the response of the 
+    `clusterlaunchcontrol.try.cancel` operation to be queried.
+
+    Operand `query_type` specifies the type of query to perform and can be one 
+    of the following:
+    - `is_canceled` : Returns true if the try cancel request succeeded, 
+    otherwise returns false.
+    - `get_first_cta_id_{x/y/z}` : Behaviour is defined only if the try cancel 
+    request succeeded. Returns the x, y, or z coordinate of the first CTA in 
+    the canceled cluster.
+
+    [For more information, see PTX ISA](https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-query-cancel)
+  }];
+
+  let arguments = (ins DefaultValuedAttr<ClusterLaunchControlQueryTypeAttr, 
+                     "ClusterLaunchControlQueryType::IS_CANCELED">:$query_type,
+                       I128:$try_cancel_response);
+  let results = (outs AnyTypeOf<[I1, I32]>:$res);
+                                 
+  let assemblyFormat = "(`query` `=` $query_type^ `,`)? $try_cancel_response attr-dict `:` type($res)";
+  
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    static mlir::NVVM::IDArgPair
+    getIntrinsicIDAndArgs(Operation &op, LLVM::ModuleTranslation &mt,
+                          llvm::IRBuilderBase &builder);
+  }];
+  
+  string llvmBuilder = [{
+    auto [id, args] = 
+    NVVM::ClusterLaunchControlQueryCancelOp::getIntrinsicIDAndArgs(
+                        *op, moduleTranslation, builder);
+    $res = createIntrinsicCall(builder, id, args);
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // NVVM target attribute.
 //===----------------------------------------------------------------------===//
 

--- a/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/NVVMOps.td
@@ -4065,7 +4065,7 @@ def NVVM_ClusterLaunchControlTryCancelOp
                        LLVM_PointerShared: $smemAddress,
                        LLVM_PointerShared: $mbarrier);
 
-  let assemblyFormat = "(`multicast` $multicast^ `,`)? $addr `,` $mbar attr-dict";
+  let assemblyFormat = "(`multicast` $multicast^ `,`)? $smemAddress `,` $mbarrier attr-dict";
 
   let extraClassDeclaration = [{
     static mlir::NVVM::IDArgPair

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -2146,8 +2146,6 @@ NVVM::IDArgPair ClusterLaunchControlQueryCancelOp::getIntrinsicIDAndArgs(
     return {llvm::Intrinsic::
                 nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_z,
             args};
-  default:
-    llvm_unreachable("Invalid query type");
   }
 }
 

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -2110,8 +2110,8 @@ NVVM::IDArgPair ClusterLaunchControlTryCancelOp::getIntrinsicIDAndArgs(
     Operation &op, LLVM::ModuleTranslation &mt, llvm::IRBuilderBase &builder) {
   auto curOp = cast<NVVM::ClusterLaunchControlTryCancelOp>(op);
   llvm::SmallVector<llvm::Value *> args;
-  args.push_back(mt.lookupValue(curOp.getAddr()));
-  args.push_back(mt.lookupValue(curOp.getMbar()));
+  args.push_back(mt.lookupValue(curOp.getSmemAddress()));
+  args.push_back(mt.lookupValue(curOp.getMbarrrier()));
 
   return curOp.getMulticast()
              ? NVVM::IDArgPair(

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -2113,15 +2113,13 @@ NVVM::IDArgPair ClusterLaunchControlTryCancelOp::getIntrinsicIDAndArgs(
   args.push_back(mt.lookupValue(curOp.getSmemAddress()));
   args.push_back(mt.lookupValue(curOp.getMbarrier()));
 
-  return curOp.getMulticast()
-             ? NVVM::IDArgPair(
-                   {llvm::Intrinsic::
-                        nvvm_clusterlaunchcontrol_try_cancel_async_multicast_shared,
-                    args})
-             : NVVM::IDArgPair(
-                   {llvm::Intrinsic::
-                        nvvm_clusterlaunchcontrol_try_cancel_async_shared,
-                    args});
+  llvm::Intrinsic::ID intrinsicID =
+      curOp.getMulticast()
+          ? llvm::Intrinsic::
+                nvvm_clusterlaunchcontrol_try_cancel_async_multicast_shared
+          : llvm::Intrinsic::nvvm_clusterlaunchcontrol_try_cancel_async_shared;
+
+  return {intrinsicID, args};
 }
 
 NVVM::IDArgPair ClusterLaunchControlQueryCancelOp::getIntrinsicIDAndArgs(
@@ -2130,23 +2128,27 @@ NVVM::IDArgPair ClusterLaunchControlQueryCancelOp::getIntrinsicIDAndArgs(
   llvm::SmallVector<llvm::Value *> args;
   args.push_back(mt.lookupValue(curOp.getTryCancelResponse()));
 
+  llvm::Intrinsic::ID intrinsicID;
+
   switch (curOp.getQueryType()) {
   case NVVM::ClusterLaunchControlQueryType::IS_CANCELED:
-    return {llvm::Intrinsic::nvvm_clusterlaunchcontrol_query_cancel_is_canceled,
-            args};
+    intrinsicID =
+        llvm::Intrinsic::nvvm_clusterlaunchcontrol_query_cancel_is_canceled;
+    break;
   case NVVM::ClusterLaunchControlQueryType::GET_FIRST_CTA_ID_X:
-    return {llvm::Intrinsic::
-                nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_x,
-            args};
+    intrinsicID = llvm::Intrinsic::
+        nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_x;
+    break;
   case NVVM::ClusterLaunchControlQueryType::GET_FIRST_CTA_ID_Y:
-    return {llvm::Intrinsic::
-                nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_y,
-            args};
+    intrinsicID = llvm::Intrinsic::
+        nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_y;
+    break;
   case NVVM::ClusterLaunchControlQueryType::GET_FIRST_CTA_ID_Z:
-    return {llvm::Intrinsic::
-                nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_z,
-            args};
+    intrinsicID = llvm::Intrinsic::
+        nvvm_clusterlaunchcontrol_query_cancel_get_first_ctaid_z;
+    break;
   }
+  return {intrinsicID, args};
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/NVVMDialect.cpp
@@ -2111,7 +2111,7 @@ NVVM::IDArgPair ClusterLaunchControlTryCancelOp::getIntrinsicIDAndArgs(
   auto curOp = cast<NVVM::ClusterLaunchControlTryCancelOp>(op);
   llvm::SmallVector<llvm::Value *> args;
   args.push_back(mt.lookupValue(curOp.getSmemAddress()));
-  args.push_back(mt.lookupValue(curOp.getMbarrrier()));
+  args.push_back(mt.lookupValue(curOp.getMbarrier()));
 
   return curOp.getMulticast()
              ? NVVM::IDArgPair(

--- a/mlir/test/Target/LLVMIR/nvvm/clusterlaunchcontrol.mlir
+++ b/mlir/test/Target/LLVMIR/nvvm/clusterlaunchcontrol.mlir
@@ -1,0 +1,64 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+llvm.func @clusterlaunchcontrol_try_cancel(%addr: !llvm.ptr<3>, %mbar: !llvm.ptr<3>) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_try_cancel(ptr addrspace(3) %0, ptr addrspace(3) %1) {
+  // CHECK-NEXT: call void @llvm.nvvm.clusterlaunchcontrol.try_cancel.async.shared(ptr addrspace(3) %0, ptr addrspace(3) %1)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  nvvm.clusterlaunchcontrol.try.cancel %addr, %mbar
+  llvm.return
+}
+
+llvm.func @clusterlaunchcontrol_try_cancel_multicast(%addr: !llvm.ptr<3>, %mbar: !llvm.ptr<3>) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_try_cancel_multicast(ptr addrspace(3) %0, ptr addrspace(3) %1) {
+  // CHECK-NEXT: call void @llvm.nvvm.clusterlaunchcontrol.try_cancel.async.multicast.shared(ptr addrspace(3) %0, ptr addrspace(3) %1)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  nvvm.clusterlaunchcontrol.try.cancel multicast, %addr, %mbar
+  llvm.return
+}
+
+llvm.func @clusterlaunchcontrol_query_cancel(%try_cancel_response: i128) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel(i128 %0) {
+  // CHECK-NEXT: %2 = call i1 @llvm.nvvm.clusterlaunchcontrol.query_cancel.is_canceled(i128 %0)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  nvvm.clusterlaunchcontrol.query.cancel %try_cancel_response : i1
+  llvm.return
+}
+
+llvm.func @clusterlaunchcontrol_query_cancel_is_canceled(%try_cancel_response: i128) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel_is_canceled(i128 %0) {
+  // CHECK-NEXT: %2 = call i1 @llvm.nvvm.clusterlaunchcontrol.query_cancel.is_canceled(i128 %0)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  %res = nvvm.clusterlaunchcontrol.query.cancel query = is_canceled, %try_cancel_response : i1
+  llvm.return
+}
+
+llvm.func @clusterlaunchcontrol_query_cancel_get_first_cta_id_x(%try_cancel_response: i128) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel_get_first_cta_id_x(i128 %0) {
+  // CHECK-NEXT: %2 = call i32 @llvm.nvvm.clusterlaunchcontrol.query_cancel.get_first_ctaid.x(i128 %0)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  %res = nvvm.clusterlaunchcontrol.query.cancel query = get_first_cta_id_x, %try_cancel_response : i32
+  llvm.return
+}
+
+llvm.func @clusterlaunchcontrol_query_cancel_get_first_cta_id_y(%try_cancel_response: i128) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel_get_first_cta_id_y(i128 %0) {
+  // CHECK-NEXT: %2 = call i32 @llvm.nvvm.clusterlaunchcontrol.query_cancel.get_first_ctaid.y(i128 %0)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  %res = nvvm.clusterlaunchcontrol.query.cancel query = get_first_cta_id_y, %try_cancel_response : i32
+  llvm.return
+}
+
+llvm.func @clusterlaunchcontrol_query_cancel_get_first_cta_id_z(%try_cancel_response: i128) {
+  // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel_get_first_cta_id_z(i128 %0) {
+  // CHECK-NEXT: %2 = call i32 @llvm.nvvm.clusterlaunchcontrol.query_cancel.get_first_ctaid.z(i128 %0)
+  // CHECK-NEXT: ret void
+  // CHECK-NEXT: }
+  %res = nvvm.clusterlaunchcontrol.query.cancel query = get_first_cta_id_z, %try_cancel_response : i32
+  llvm.return
+}

--- a/mlir/test/Target/LLVMIR/nvvm/clusterlaunchcontrol.mlir
+++ b/mlir/test/Target/LLVMIR/nvvm/clusterlaunchcontrol.mlir
@@ -18,15 +18,6 @@ llvm.func @clusterlaunchcontrol_try_cancel_multicast(%addr: !llvm.ptr<3>, %mbar:
   llvm.return
 }
 
-llvm.func @clusterlaunchcontrol_query_cancel(%try_cancel_response: i128) {
-  // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel(i128 %0) {
-  // CHECK-NEXT: %2 = call i1 @llvm.nvvm.clusterlaunchcontrol.query_cancel.is_canceled(i128 %0)
-  // CHECK-NEXT: ret void
-  // CHECK-NEXT: }
-  nvvm.clusterlaunchcontrol.query.cancel %try_cancel_response : i1
-  llvm.return
-}
-
 llvm.func @clusterlaunchcontrol_query_cancel_is_canceled(%try_cancel_response: i128) {
   // CHECK-LABEL: define void @clusterlaunchcontrol_query_cancel_is_canceled(i128 %0) {
   // CHECK-NEXT: %2 = call i1 @llvm.nvvm.clusterlaunchcontrol.query_cancel.is_canceled(i128 %0)

--- a/mlir/test/Target/LLVMIR/nvvmir-invalid.mlir
+++ b/mlir/test/Target/LLVMIR/nvvmir-invalid.mlir
@@ -535,3 +535,19 @@ llvm.func @nanosleep() {
   nvvm.nanosleep 100000000000000
   llvm.return
 }
+
+// -----
+
+llvm.func @clusterlaunchcontrol_query_cancel_is_canceled_invalid_return_type(%try_cancel_response: i128) {
+  // expected-error@+1 {{'nvvm.clusterlaunchcontrol.query.cancel' op is_canceled query type returns an i1}}
+  %res = nvvm.clusterlaunchcontrol.query.cancel query = is_canceled, %try_cancel_response : i32
+  llvm.return
+}
+
+// -----
+
+llvm.func @clusterlaunchcontrol_query_cancel_get_first_cta_id_invalid_return_type(%try_cancel_response: i128) {
+  // expected-error@+1 {{'nvvm.clusterlaunchcontrol.query.cancel' op get_first_cta_id_x, get_first_cta_id_y, get_first_cta_id_z query types return an i32}}
+  %res = nvvm.clusterlaunchcontrol.query.cancel query = get_first_cta_id_x, %try_cancel_response : i1
+  llvm.return
+}


### PR DESCRIPTION
This change adds the `clusterlaunchcontrol.try.cancel` and `clusterlaunchcontrol.query.cancel` Ops to the NVVM dialect.

Tests are added in `clusterlaunchcontrol.mlir`.

PTX Reference: https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-clusterlaunchcontrol-try-cancel