### PR TITLE
[clang] Polymorphic Cleanup type is moved despite not being POD types

### DIFF
--- a/clang/lib/CIR/CodeGen/EHScopeStack.h
+++ b/clang/lib/CIR/CodeGen/EHScopeStack.h
@@ -90,7 +90,7 @@ public:
   ///
   /// Cleanup implementations should generally be declared in an
   /// anonymous namespace.
-  class Cleanup {
+  class LLVM_MOVABLE_POLYMORPHIC_TYPE Cleanup {
     // Anchor the construction vtable.
     virtual void anchor();
 

--- a/clang/lib/CodeGen/EHScopeStack.h
+++ b/clang/lib/CodeGen/EHScopeStack.h
@@ -143,7 +143,7 @@ public:
   ///
   /// Cleanup implementations should generally be declared in an
   /// anonymous namespace.
-  class alignas(uint64_t) Cleanup {
+  class LLVM_MOVABLE_POLYMORPHIC_TYPE alignas(uint64_t) Cleanup {
     // Anchor the construction vtable.
     virtual void anchor();
 

--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -706,6 +706,15 @@ void AnnotateIgnoreWritesEnd(const char *file, int line);
 #define LLVM_PREFERRED_TYPE(T)
 #endif
 
+#if LLVM_HAS_CPP_ATTRIBUTE(clang::ptrauth_vtable_pointer) &&                   \
+    (defined(__PTRAUTH__) || __has_feature(ptrauth_calls))
+#define LLVM_MOVABLE_POLYMORPHIC_TYPE                                          \
+  [[clang::ptrauth_vtable_pointer(default_key, no_address_discrimination,      \
+                                  default_extra_discrimination)]]
+#else
+#define LLVM_MOVABLE_POLYMORPHIC_TYPE
+#endif
+
 /// \macro LLVM_VIRTUAL_ANCHOR_FUNCTION
 /// This macro is used to adhere to LLVM's policy that each class with a vtable
 /// must have at least one out-of-line virtual function. This macro allows us


### PR DESCRIPTION
Clang as a number of Cleanup types used in exception handling, these are presumed to be POD types that can be memmoved as needed, however this is not correct by default on platforms with pointer authentication that make vtable pointers address discriminated.

This PR mitigates this problem by introducing a LLVM_MOVABLE_POLYMORPHIC_TYPE macro that can be used to annotate polymorphic types that are required to be movable, to override the use of address discrimination of the vtable pointer.