### PR TITLE
[lld][MachO] Silence warnings about --read-workers parsing

### DIFF
--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1834,9 +1834,10 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
   if (auto *arg = args.getLastArg(OPT_read_workers)) {
     StringRef v(arg->getValue());
     unsigned threads = 0;
-    if (!llvm::to_integer(v, threads, 0) || threads < 0)
-      error(arg->getSpelling() + ": expected a positive integer, but got '" +
-            arg->getValue() + "'");
+    if (!llvm::to_integer(v, threads, 0))
+      error(arg->getSpelling() +
+            ": expected a non-negative integer, but got '" + arg->getValue() +
+            "'");
     config->readWorkers = threads;
   }
   if (auto *arg = args.getLastArg(OPT_threads_eq)) {

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -1833,12 +1833,12 @@ bool link(ArrayRef<const char *> argsArr, llvm::raw_ostream &stdoutOS,
 
   if (auto *arg = args.getLastArg(OPT_read_workers)) {
     StringRef v(arg->getValue());
-    unsigned threads = 0;
-    if (!llvm::to_integer(v, threads, 0))
+    unsigned workers = 0;
+    if (!llvm::to_integer(v, workers, 0))
       error(arg->getSpelling() +
             ": expected a non-negative integer, but got '" + arg->getValue() +
             "'");
-    config->readWorkers = threads;
+    config->readWorkers = workers;
   }
   if (auto *arg = args.getLastArg(OPT_threads_eq)) {
     StringRef v(arg->getValue());

--- a/lld/test/MachO/read-workers.s
+++ b/lld/test/MachO/read-workers.s
@@ -1,0 +1,16 @@
+# REQUIRES: x86
+# RUN: llvm-mc -filetype=obj -triple=x86_64-apple-darwin %s -o %t.o
+
+## A non-negative integer is allowed.
+# RUN: %lld --read-workers=0 %t.o -o /dev/null
+# RUN: %lld --read-workers=1 %t.o -o /dev/null
+# RUN: %lld --read-workers=2 %t.o -o /dev/null
+
+# RUN: not %lld --read-workers=all %t.o -o /dev/null 2>&1 | FileCheck %s -DN=all
+# RUN: not %lld --read-workers=-1 %t.o -o /dev/null 2>&1 | FileCheck %s -DN=-1
+
+# CHECK: error: --read-workers=: expected a non-negative integer, but got '[[N]]'
+
+.globl _main
+_main:
+  ret


### PR DESCRIPTION
The parsing of the --read-workers argument v is implemented like this:

  unsigned threads = 0
  if (!llvm::to_integer(v, threads, 0) || threads < 0) {
  ...

As reported by a compiler warning, the value of the "threads < 0" expession is never going to be true. It could only evaluate to true if v represents a negative number, but in this case llvm::to_integer returns false since threads is unsigned and hence the second operand of the || operator will not be evaluated.

This patch removes the useless || operand to silence compiler warnings. Since I had to first find out if --read-workers=0 is valid or not (it seems to be), I also added a test to document the valid values for the option and I adjusted the error message on invalid values to clearly state that 0 is valid.