### PR TITLE
[CodeGen, CHERI] Add capability types to MVT.

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.h
+++ b/llvm/include/llvm/CodeGen/ValueTypes.h
@@ -229,7 +229,9 @@ namespace llvm {
     }
 
     /// Return true if this is a capability type.
-    bool isCapability() const { return isSimple() ? V.isCapability() : false; }
+    bool isCheriCapability() const {
+      return isSimple() ? V.isCheriCapability() : false;
+    }
 
     /// Return true if this is an overloaded type for TableGen.
     bool isOverloaded() const {

--- a/llvm/include/llvm/CodeGen/ValueTypes.h
+++ b/llvm/include/llvm/CodeGen/ValueTypes.h
@@ -228,6 +228,9 @@ namespace llvm {
       return isSimple() ? V.is2048BitVector() : isExtended2048BitVector();
     }
 
+    /// Return true if this is a capability type.
+    bool isCapability() const { return isSimple() ? V.isCapability() : false; }
+
     /// Return true if this is an overloaded type for TableGen.
     bool isOverloaded() const {
       return (V == MVT::iAny || V == MVT::fAny || V == MVT::vAny ||

--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -362,8 +362,10 @@ def amdgpuBufferStridedPointer : ValueType<192, 252>;
 
 def aarch64mfp8 : ValueType<8,  253>;  // 8-bit value in FPR (AArch64)
 
-def c64 : VTCapability<64, 254>;   // 64-bit capability value
-def c128 : VTCapability<128, 255>; // 128-bit capability value
+// CHERI capabilities. Pointer-like values that carry additional metadata
+// for enforcing safety guarantees on CHERI-enabled targets.
+def c64 : VTCapability<64, 254>;   // 64-bit CHERI capability value
+def c128 : VTCapability<128, 255>; // 128-bit CHERI capability value
 
 let isNormalValueType = false in {
 def token      : ValueType<0, 504>;  // TokenTy

--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -364,7 +364,6 @@ def aarch64mfp8 : ValueType<8,  253>;  // 8-bit value in FPR (AArch64)
 
 def c64 : VTCapability<64, 254>;   // 64-bit capability value
 def c128 : VTCapability<128, 255>; // 128-bit capability value
-def c256 : VTCapability<256, 256>; // 256-bit capability value
 
 let isNormalValueType = false in {
 def token      : ValueType<0, 504>;  // TokenTy

--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -28,6 +28,7 @@ class ValueType<int size, int value> {
   // Indicates this VT should be included in the
   // [FIRST_VALUETYPE,LAST_VALUETYPE] range.
   bit isNormalValueType = true;
+  bit isCapability = false;
 }
 
 class VTAny<int value> : ValueType<0, value> {
@@ -63,6 +64,10 @@ class VTVecTup<int size, int nf, ValueType dummy_elt, int value>
   let NF = nf;
   let ElementType = dummy_elt;
   let isRISCVVecTuple = true;
+}
+
+class VTCapability<int size, int value> : ValueType<size, value> {
+  let isCapability = true;
 }
 
 defset list<ValueType> ValueTypes = {
@@ -356,6 +361,10 @@ def amdgpuBufferFatPointer : ValueType<160, 251>;
 def amdgpuBufferStridedPointer : ValueType<192, 252>;
 
 def aarch64mfp8 : ValueType<8,  253>;  // 8-bit value in FPR (AArch64)
+
+def c64 : VTCapability<64, 254>;   // 64-bit capability value
+def c128 : VTCapability<128, 255>; // 128-bit capability value
+def c256 : VTCapability<256, 256>; // 256-bit capability value
 
 let isNormalValueType = false in {
 def token      : ValueType<0, 504>;  // TokenTy

--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -28,7 +28,7 @@ class ValueType<int size, int value> {
   // Indicates this VT should be included in the
   // [FIRST_VALUETYPE,LAST_VALUETYPE] range.
   bit isNormalValueType = true;
-  bit isCapability = false;
+  bit isCheriCapability = false;
 }
 
 class VTAny<int value> : ValueType<0, value> {
@@ -66,8 +66,8 @@ class VTVecTup<int size, int nf, ValueType dummy_elt, int value>
   let isRISCVVecTuple = true;
 }
 
-class VTCapability<int size, int value> : ValueType<size, value> {
-  let isCapability = true;
+class VTCheriCapability<int size, int value> : ValueType<size, value> {
+  let isCheriCapability = true;
 }
 
 defset list<ValueType> ValueTypes = {
@@ -364,8 +364,8 @@ def aarch64mfp8 : ValueType<8,  253>;  // 8-bit value in FPR (AArch64)
 
 // CHERI capabilities. Pointer-like values that carry additional metadata
 // for enforcing safety guarantees on CHERI-enabled targets.
-def c64 : VTCapability<64, 254>;   // 64-bit CHERI capability value
-def c128 : VTCapability<128, 255>; // 128-bit CHERI capability value
+def c64 : VTCheriCapability<64, 254>;   // 64-bit CHERI capability value
+def c128 : VTCheriCapability<128, 255>; // 128-bit CHERI capability value
 
 let isNormalValueType = false in {
 def token      : ValueType<0, 504>;  // TokenTy

--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -178,10 +178,10 @@ namespace llvm {
       return (isFixedLengthVector() && getFixedSizeInBits() == 2048);
     }
 
-    /// Return true if this is a capability type.
-    bool isCapability() const {
-      return (SimpleTy >= MVT::FIRST_CAPABILITY_VALUETYPE) &&
-             (SimpleTy <= MVT::LAST_CAPABILITY_VALUETYPE);
+    /// Return true if this is a CHERI capability type.
+    bool isCheriCapability() const {
+      return (SimpleTy >= MVT::FIRST_CHERI_CAPABILITY_VALUETYPE) &&
+             (SimpleTy <= MVT::LAST_CHERI_CAPABILITY_VALUETYPE);
     }
 
     /// Return true if this is an overloaded type for TableGen.

--- a/llvm/include/llvm/CodeGenTypes/MachineValueType.h
+++ b/llvm/include/llvm/CodeGenTypes/MachineValueType.h
@@ -178,6 +178,12 @@ namespace llvm {
       return (isFixedLengthVector() && getFixedSizeInBits() == 2048);
     }
 
+    /// Return true if this is a capability type.
+    bool isCapability() const {
+      return (SimpleTy >= MVT::FIRST_CAPABILITY_VALUETYPE) &&
+             (SimpleTy <= MVT::LAST_CAPABILITY_VALUETYPE);
+    }
+
     /// Return true if this is an overloaded type for TableGen.
     bool isOverloaded() const {
       switch (SimpleTy) {

--- a/llvm/lib/CodeGen/ValueTypes.cpp
+++ b/llvm/lib/CodeGen/ValueTypes.cpp
@@ -176,7 +176,7 @@ std::string EVT::getEVTString() const {
       return "i" + utostr(getSizeInBits());
     if (isFloatingPoint())
       return "f" + utostr(getSizeInBits());
-    if (isCapability())
+    if (isCheriCapability())
       return "c" + utostr(getSizeInBits());
     llvm_unreachable("Invalid EVT!");
   case MVT::bf16:      return "bf16";

--- a/llvm/lib/CodeGen/ValueTypes.cpp
+++ b/llvm/lib/CodeGen/ValueTypes.cpp
@@ -176,6 +176,8 @@ std::string EVT::getEVTString() const {
       return "i" + utostr(getSizeInBits());
     if (isFloatingPoint())
       return "f" + utostr(getSizeInBits());
+    if (isCapability())
+      return "c" + utostr(getSizeInBits());
     llvm_unreachable("Invalid EVT!");
   case MVT::bf16:      return "bf16";
   case MVT::ppcf128:   return "ppcf128";

--- a/llvm/utils/TableGen/Basic/VTEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/VTEmitter.cpp
@@ -132,6 +132,7 @@ void VTEmitter::run(raw_ostream &OS) {
     bool IsVector = VT->getValueAsBit("isVector");
     bool IsScalable = VT->getValueAsBit("isScalable");
     bool IsRISCVVecTuple = VT->getValueAsBit("isRISCVVecTuple");
+    bool IsCapability = VT->getValueAsBit("isCapability");
     int64_t NF = VT->getValueAsInt("NF");
     bool IsNormalValueType =  VT->getValueAsBit("isNormalValueType");
     int64_t NElem = IsVector ? VT->getValueAsInt("nElem") : 0;
@@ -152,6 +153,7 @@ void VTEmitter::run(raw_ostream &OS) {
     UpdateVTRange("INTEGER_VALUETYPE", Name, IsInteger && !IsVector);
     UpdateVTRange("FP_VALUETYPE", Name, IsFP && !IsVector);
     UpdateVTRange("VALUETYPE", Name, IsNormalValueType);
+    UpdateVTRange("CAPABILITY_VALUETYPE", Name, IsCapability);
 
     // clang-format off
     OS << "  GET_VT_ATTR("

--- a/llvm/utils/TableGen/Basic/VTEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/VTEmitter.cpp
@@ -132,7 +132,7 @@ void VTEmitter::run(raw_ostream &OS) {
     bool IsVector = VT->getValueAsBit("isVector");
     bool IsScalable = VT->getValueAsBit("isScalable");
     bool IsRISCVVecTuple = VT->getValueAsBit("isRISCVVecTuple");
-    bool IsCapability = VT->getValueAsBit("isCapability");
+    bool IsCheriCapability = VT->getValueAsBit("isCheriCapability");
     int64_t NF = VT->getValueAsInt("NF");
     bool IsNormalValueType =  VT->getValueAsBit("isNormalValueType");
     int64_t NElem = IsVector ? VT->getValueAsInt("nElem") : 0;
@@ -153,7 +153,7 @@ void VTEmitter::run(raw_ostream &OS) {
     UpdateVTRange("INTEGER_VALUETYPE", Name, IsInteger && !IsVector);
     UpdateVTRange("FP_VALUETYPE", Name, IsFP && !IsVector);
     UpdateVTRange("VALUETYPE", Name, IsNormalValueType);
-    UpdateVTRange("CAPABILITY_VALUETYPE", Name, IsCapability);
+    UpdateVTRange("CHERI_CAPABILITY_VALUETYPE", Name, IsCheriCapability);
 
     // clang-format off
     OS << "  GET_VT_ATTR("


### PR DESCRIPTION
This adds value types for representing capability types, enabling their use in instruction selection and other parts of the backend.

These types are distinguished from each other only by size. This is sufficient, at least today, because no existing CHERI configuration supports multiple capability sizes simultaneously. Hybrid configurations supporting intermixed integral pointers and capabilities do exist, and are one of the reasons why these value types are needed beyond existing integral types.

Co-authored-by: David Chisnall <theraven@theravensnest.org>
Co-authored-by: Jessica Clarke <jrtc27@jrtc27.com>