### PR TITLE
AMDGPU: Avoid directly using MCOperandInfo RegClass field

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNDPPCombine.cpp
@@ -193,16 +193,6 @@ MachineOperand *GCNDPPCombine::getOldOpndValue(MachineOperand &OldOpnd) const {
   return &OldOpnd;
 }
 
-[[maybe_unused]] static unsigned getOperandSize(MachineInstr &MI, unsigned Idx,
-                               MachineRegisterInfo &MRI) {
-  int16_t RegClass = MI.getDesc().operands()[Idx].RegClass;
-  if (RegClass == -1)
-    return 0;
-
-  const TargetRegisterInfo *TRI = MRI.getTargetRegisterInfo();
-  return TRI->getRegSizeInBits(*TRI->getRegClass(RegClass));
-}
-
 MachineInstr *GCNDPPCombine::createDPPInst(MachineInstr &OrigMI,
                                            MachineInstr &MovMI,
                                            RegSubRegPair CombOldVGPR,
@@ -321,8 +311,8 @@ MachineInstr *GCNDPPCombine::createDPPInst(MachineInstr &OrigMI,
       // requirements are the same as for src0. We check src0 instead because
       // pseudos are shared between subtargets and allow SGPR for src1 on all.
       if (!ST->hasDPPSrc1SGPR()) {
-        assert(getOperandSize(*DPPInst, Src0Idx, *MRI) ==
-                   getOperandSize(*DPPInst, NumOperands, *MRI) &&
+        assert(TII->getOpSize(*DPPInst, Src0Idx) ==
+                   TII->getOpSize(*DPPInst, NumOperands) &&
                "Src0 and Src1 operands should have the same size");
       }
 


### PR DESCRIPTION
This value should not be directly interpreted. Also avoids
a function only used for an assert.