### PR TITLE
[lldb][Expression] Reject languages not supported by TypeSystems for expression evaluation

### DIFF
--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -44,18 +44,21 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
   const int short_option = GetDefinitions()[option_idx].short_option;
 
   switch (short_option) {
-  case 'l':
+  case 'l': {
     language = Language::GetLanguageTypeFromString(option_arg);
-    if (language == eLanguageTypeUnknown) {
+
+    if (const LanguageSet supported_languages =
+            Language::GetLanguagesSupportingTypeSystemsForExpressions();
+        !supported_languages[language]) {
       StreamString sstr;
-      sstr.Printf("unknown language type: '%s' for expression. "
+      sstr.Printf("invalid language '%s' for expression. "
                   "List of supported languages:\n",
                   option_arg.str().c_str());
 
       Language::PrintSupportedLanguagesForExpressions(sstr, "  ", "\n");
       error = Status(sstr.GetString().str());
     }
-    break;
+  } break;
 
   case 'a': {
     bool success;

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -46,18 +46,23 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
   switch (short_option) {
   case 'l': {
     language = Language::GetLanguageTypeFromString(option_arg);
-
     if (const LanguageSet supported_languages =
             Language::GetLanguagesSupportingTypeSystemsForExpressions();
-        !supported_languages[language]) {
-      StreamString sstr;
-      sstr.Printf("invalid language '%s' for expression. "
-                  "List of supported languages:\n",
+        supported_languages[language])
+      break;
+
+    StreamString sstr;
+    if (language == eLanguageTypeUnknown)
+      sstr.Printf("unknown language '%s' for expression. ",
+                  option_arg.str().c_str());
+    else
+      sstr.Printf("language '%s' is currently not supported for expression "
+                  "evaluation. ",
                   option_arg.str().c_str());
 
-      Language::PrintSupportedLanguagesForExpressions(sstr, "  ", "\n");
-      error = Status(sstr.GetString().str());
-    }
+    sstr.PutCString("List of supported languages for expressions:\n");
+    Language::PrintSupportedLanguagesForExpressions(sstr, "  ", "\n");
+    error = Status(sstr.GetString().str());
   } break;
 
   case 'a': {

--- a/lldb/test/API/commands/expression/calculator_mode/TestCalculatorMode.py
+++ b/lldb/test/API/commands/expression/calculator_mode/TestCalculatorMode.py
@@ -21,7 +21,7 @@ class TestCalculatorMode(TestBase):
         )
         # Now try it with a specific language:
         self.expect(
-            "expression -l c -- 11 + 22",
+            "expression -l c++ -- 11 + 22",
             "11 + 22 didn't get the expected result",
             substrs=["33"],
         )

--- a/lldb/test/API/commands/expression/invalid-args/TestInvalidArgsExpression.py
+++ b/lldb/test/API/commands/expression/invalid-args/TestInvalidArgsExpression.py
@@ -10,7 +10,19 @@ class InvalidArgsExpressionTestCase(TestBase):
             "expression -l foo --",
             error=True,
             substrs=[
-                "error: unknown language type: 'foo' for expression",
+                "error: invalid language 'foo' for expression.",
+                "List of supported languages:",
+                "c++",
+                "c++11",
+                "c++14",
+            ],
+        )
+
+        self.expect(
+            "expression -l c --",
+            error=True,
+            substrs=[
+                "error: invalid language 'c' for expression.",
                 "List of supported languages:",
                 "c++",
                 "c++11",

--- a/lldb/test/API/commands/expression/invalid-args/TestInvalidArgsExpression.py
+++ b/lldb/test/API/commands/expression/invalid-args/TestInvalidArgsExpression.py
@@ -10,8 +10,8 @@ class InvalidArgsExpressionTestCase(TestBase):
             "expression -l foo --",
             error=True,
             substrs=[
-                "error: invalid language 'foo' for expression.",
-                "List of supported languages:",
+                "error: unknown language 'foo' for expression.",
+                "List of supported languages for expressions:",
                 "c++",
                 "c++11",
                 "c++14",
@@ -22,8 +22,8 @@ class InvalidArgsExpressionTestCase(TestBase):
             "expression -l c --",
             error=True,
             substrs=[
-                "error: invalid language 'c' for expression.",
-                "List of supported languages:",
+                "error: language 'c' is currently not supported for expression evaluation.",
+                "List of supported languages for expressions:",
                 "c++",
                 "c++11",
                 "c++14",


### PR DESCRIPTION
There are some languages for which the `ClangExpressionParser` currently switches the language type behind a user's back. Specifically, `C` gets turned into `C++` and `ObjC` into `ObjC++`. That's because the Clang expression evaluator depends on C++ features. These languages have different semantics, so if, e.g., a user forcefully wants to evaluate an expression in `C`, but we switch it to `C++`, they will most likely wonder why the expression failed (we get reports like this every once in a while...https://github.com/llvm/llvm-project/issues/152113 is a variation of this).

This patch rejects languages specified with `expression --language` that we won't be able to explicitly evaluate.

rdar://159669244