### PR TITLE
[ConstantFolding] Fold scalable get_active_lane_masks

### DIFF
--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4238,6 +4238,13 @@ static Constant *ConstantFoldScalableVectorCall(
 
     return ConstantInt::getFalse(SVTy);
   }
+  case Intrinsic::get_active_lane_mask: {
+    auto Op0 = cast<ConstantInt>(Operands[0])->getValue();
+    auto Op1 = cast<ConstantInt>(Operands[1])->getValue();
+    if ((Op0.uge(Op1) && (!Op1.isZero())))
+      return ConstantVector::getNullValue(SVTy);
+    break;
+  }
   default:
     break;
   }

--- a/llvm/lib/Analysis/ConstantFolding.cpp
+++ b/llvm/lib/Analysis/ConstantFolding.cpp
@@ -4241,7 +4241,7 @@ static Constant *ConstantFoldScalableVectorCall(
   case Intrinsic::get_active_lane_mask: {
     auto Op0 = cast<ConstantInt>(Operands[0])->getValue();
     auto Op1 = cast<ConstantInt>(Operands[1])->getValue();
-    if ((Op0.uge(Op1) && (!Op1.isZero())))
+    if (Op0.uge(Op1))
       return ConstantVector::getNullValue(SVTy);
     break;
   }

--- a/llvm/test/Transforms/InstSimplify/ConstProp/active-lane-mask.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/active-lane-mask.ll
@@ -307,6 +307,40 @@ entry:
   ret <4 x float> %var33
 }
 
+define <vscale x 4 x i1> @nxv4i1_12_12() {
+; CHECK-LABEL: @nxv4i1_12_12(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret <vscale x 4 x i1> zeroinitializer
+;
+entry:
+  %mask = call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i32(i32 12, i32 12)
+  ret <vscale x 4 x i1> %mask
+}
+
+define <vscale x 4 x i1> @nxv4i1_8_4() {
+; CHECK-LABEL: @nxv4i1_8_4(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    ret <vscale x 4 x i1> zeroinitializer
+;
+entry:
+  %mask = call <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i32(i32 8, i32 4)
+  ret <vscale x 4 x i1> %mask
+}
+
+define <vscale x 16 x i1> @nxv16i1_0_0() {
+; CHECK-LABEL: @nxv16i1_0_0(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[MASK:%.*]] = call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 0)
+; CHECK-NEXT:    ret <vscale x 16 x i1> [[MASK]]
+;
+entry:
+  %mask = call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 0)
+  ret <vscale x 16 x i1> %mask
+}
+
 declare <4 x i1> @llvm.get.active.lane.mask.v4i1.i32(i32, i32)
 declare <8 x i1> @llvm.get.active.lane.mask.v8i1.i32(i32, i32)
 declare <16 x i1> @llvm.get.active.lane.mask.v16i1.i32(i32, i32)
+
+declare <vscale x 4 x i1> @llvm.get.active.lane.mask.nxv4i1.i32(i32, i32)
+declare <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv4i1.i64(i64, i64)

--- a/llvm/test/Transforms/InstSimplify/ConstProp/active-lane-mask.ll
+++ b/llvm/test/Transforms/InstSimplify/ConstProp/active-lane-mask.ll
@@ -330,8 +330,7 @@ entry:
 define <vscale x 16 x i1> @nxv16i1_0_0() {
 ; CHECK-LABEL: @nxv16i1_0_0(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[MASK:%.*]] = call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 0)
-; CHECK-NEXT:    ret <vscale x 16 x i1> [[MASK]]
+; CHECK-NEXT:    ret <vscale x 16 x i1> zeroinitializer
 ;
 entry:
   %mask = call <vscale x 16 x i1> @llvm.get.active.lane.mask.nxv16i1.i64(i64 0, i64 0)


### PR DESCRIPTION
Scalable get_active_lane_mask intrinsics with a range of 0 can be lowered to zeroinitializer. This helps remove no-op scalable masked stores and loads.