### PR TITLE
[clang][bytecode] Remove superfluous check for complex types

### DIFF
--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -4199,8 +4199,7 @@ template <class Emitter> bool Compiler<Emitter>::visit(const Expr *E) {
     return this->discard(E);
 
   // Create local variable to hold the return value.
-  if (!E->isGLValue() && !E->getType()->isAnyComplexType() &&
-      !canClassify(E->getType())) {
+  if (!E->isGLValue() && !canClassify(E->getType())) {
     UnsignedOrNone LocalIndex = allocateLocal(E);
     if (!LocalIndex)
       return false;


### PR DESCRIPTION
`!E->getType()->isAnyComplexType()` is implied by `!canClassify()`.