### PR TITLE
[analyzer] Canonicalize the Decls of FieldRegions

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
+++ b/clang/include/clang/StaticAnalyzer/Core/PathSensitive/MemRegion.h
@@ -1548,8 +1548,8 @@ public:
   ///  a specified FieldDecl.  'superRegion' corresponds to the containing
   ///  memory region (which typically represents the memory representing
   ///  a structure or class).
-  const FieldRegion *getFieldRegion(const FieldDecl *fd,
-                                    const SubRegion* superRegion);
+  const FieldRegion *getFieldRegion(const FieldDecl *FD,
+                                    const SubRegion *SuperRegion);
 
   const FieldRegion *getFieldRegionWithSuper(const FieldRegion *FR,
                                              const SubRegion *superRegion) {

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1268,10 +1268,10 @@ const SymbolicRegion *MemRegionManager::getSymbolicHeapRegion(SymbolRef Sym) {
   return getSubRegion<SymbolicRegion>(Sym, getHeapRegion());
 }
 
-const FieldRegion*
-MemRegionManager::getFieldRegion(const FieldDecl *d,
-                                 const SubRegion* superRegion){
-  return getSubRegion<FieldRegion>(d->getCanonicalDecl(), superRegion);
+const FieldRegion *
+MemRegionManager::getFieldRegion(const FieldDecl *FD,
+                                 const SubRegion *SuperRegion) {
+  return getSubRegion<FieldRegion>(FD->getCanonicalDecl(), SuperRegion);
 }
 
 const ObjCIvarRegion*

--- a/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
+++ b/clang/lib/StaticAnalyzer/Core/MemRegion.cpp
@@ -1704,8 +1704,8 @@ static RegionOffset calculateOffset(const MemRegion *R) {
       if (SymbolicOffsetBase)
         continue;
 
+      assert(FR->getDecl()->getCanonicalDecl() == FR->getDecl());
       auto MaybeFieldIdx = [FR, RD]() -> std::optional<unsigned> {
-        assert(FR->getDecl()->getCanonicalDecl() == FR->getDecl());
         for (auto [Idx, Field] : llvm::enumerate(RD->fields())) {
           if (FR->getDecl() == Field->getCanonicalDecl())
             return Idx;

--- a/clang/test/Analysis/modules/explicit-templ-inst-crash-in-modules.cppm
+++ b/clang/test/Analysis/modules/explicit-templ-inst-crash-in-modules.cppm
@@ -1,0 +1,35 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// DEFINE: %{common-flags}= -std=c++20 -I %t -fprebuilt-module-path=%t
+//
+// RUN: %clang_cc1 %{common-flags} %t/other.cppm -emit-module-interface -o %t/other.pcm
+// RUN: %clang_analyze_cc1 -analyzer-checker=core %{common-flags} %t/entry.cppm -verify
+
+
+//--- MyStruct.h
+template <typename T> struct MyStruct {
+  T data = 0;
+};
+template struct MyStruct<int>; // Explicit template instantiation.
+
+//--- other.cppm
+module;
+#include "MyStruct.h"
+export module other;
+static void implicit_instantiate_MyStruct() {
+  MyStruct<int> var;
+  (void)var;
+}
+
+//--- entry.cppm
+// expected-no-diagnostics
+module;
+#include "MyStruct.h"
+module other;
+
+void entry_point() {
+  MyStruct<int> var; // no-crash
+  (void)var;
+}


### PR DESCRIPTION
When calculating the offset of a FieldRegion, we need to find out which field index the given field refers to.
Previously, if for some reason the field was not found, then the `Idx` passed to `Layout.getFieldOffset` was out of bounds and caused undefined behavior when dereferenced an out of bounds element in `ASTVector::FieldOffsets::operator[]`, which asserts this in debug builds, but exposes the undefined behavior in release builds.

In this patch, I refactored how we enumerate the fields, and gracefully handle the scenario where the field is not found.
That case is still bad, but at least it should not expose the undefined behavior in release builds, and should assert earlier in debug builds than before.

The motivational case was transformed into a regression test, that would fail if no canonicalization would happen when creating a FieldRegion. This was reduced from a production crash.
In the test case, due to how modules work, there would be multiple copies of the same template specialization in the AST. This could lead into inconsistent state when the FieldRegion's Decl was different to the RecordDecl's field - because one referred to the first and the other to the second. This made `calculateOffset` fail to compute the field index, triggering the undefined behavior in production.

While this inconsistency gets fixed now, I think the assertion is still warranted to avoid potential undefined behavior in release builds.

CPP-6691,CPP-6849