### PR TITLE
[llvm-readobj][ELF] Prints hex format values in lower-case mode

### DIFF
--- a/lld/test/ELF/emulation-hexagon.s
+++ b/lld/test/ELF/emulation-hexagon.s
@@ -23,7 +23,7 @@
 # CHECK-NEXT:    Type:                              EXEC (Executable file)
 # CHECK-NEXT:    Machine:                           Qualcomm Hexagon
 # CHECK-NEXT:    Version:                           0x1
-# CHECK-NEXT:    Entry point address:               0x200B4
+# CHECK-NEXT:    Entry point address:               0x200b4
 # CHECK-NEXT:    Start of program headers:          52 (bytes into file)
 # CHECK-NEXT:    Start of section headers:
 # CHECK-NEXT:    Flags:                             0x73

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -151,7 +151,7 @@ Changes to the Debug Info
 Changes to the LLVM tools
 ---------------------------------
 
-* `llvm-readelf` now dumps all hex format values in lower-case mode generally.
+* `llvm-readelf` now dumps all hex format values in lower-case mode.
 
 Changes to LLDB
 ---------------------------------

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -151,6 +151,9 @@ Changes to the Debug Info
 Changes to the LLVM tools
 ---------------------------------
 
+* `llvm-readelf` now dumps all hex format addresses in lower-case mode generally.
+  Therefore the corresponding tests have been udpated as well.
+
 Changes to LLDB
 ---------------------------------
 

--- a/llvm/docs/ReleaseNotes.md
+++ b/llvm/docs/ReleaseNotes.md
@@ -151,8 +151,7 @@ Changes to the Debug Info
 Changes to the LLVM tools
 ---------------------------------
 
-* `llvm-readelf` now dumps all hex format addresses in lower-case mode generally.
-  Therefore the corresponding tests have been udpated as well.
+* `llvm-readelf` now dumps all hex format values in lower-case mode generally.
 
 Changes to LLDB
 ---------------------------------

--- a/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
+++ b/llvm/test/tools/llvm-readobj/ELF/AArch64/memtag.test
@@ -195,13 +195,13 @@
 ##      - ULEB-encoded value: 0x01
 
 # LLVM-OK:      Memtag Global Descriptors: [
-# LLVM-OK-NEXT:    0xDEAD0000: 0x10
-# LLVM-OK-NEXT:    0xDEAD0010: 0x20
-# LLVM-OK-NEXT:    0xDEAD0100: 0x40
-# LLVM-OK-NEXT:    0xDEADF000: 0x1000
-# LLVM-OK-NEXT:    0xDEAE0000: 0x10
-# LLVM-OK-NEXT:    0xDEAE0010: 0x10
-# LLVM-OK-NEXT:    0xDEAE0020: 0x10
+# LLVM-OK-NEXT:    0xdead0000: 0x10
+# LLVM-OK-NEXT:    0xdead0010: 0x20
+# LLVM-OK-NEXT:    0xdead0100: 0x40
+# LLVM-OK-NEXT:    0xdeadf000: 0x1000
+# LLVM-OK-NEXT:    0xdeae0000: 0x10
+# LLVM-OK-NEXT:    0xdeae0010: 0x10
+# LLVM-OK-NEXT:    0xdeae0020: 0x10
 # LLVM-OK-NEXT: ]
 # GNU-OK:       Memtag Global Descriptors:
 # GNU-OK-NEXT:     0xdead0000: 0x10

--- a/llvm/test/tools/llvm-readobj/ELF/Sparc/elf-headers.test
+++ b/llvm/test/tools/llvm-readobj/ELF/Sparc/elf-headers.test
@@ -27,7 +27,7 @@
 # RUN:   -DFLAG0_NAME=EF_SPARC_32PLUS -DFLAG1_NAME=EF_SPARC_HAL_R1 \
 # RUN:   -DFLAG2_NAME=EF_SPARC_SUN_US1 -DFLAG3_NAME=EF_SPARC_SUN_US3
 # RUN: llvm-readelf -h %t | FileCheck %s --match-full-lines --check-prefix=GNU \
-# RUN:   -DFLAG_VALUE=0xF00 \
+# RUN:   -DFLAG_VALUE=0xf00 \
 # RUN:   -DGNU_FLAG_NAME=", V8+ ABI, Sun UltraSPARC I extensions, HAL/Fujitsu R1 extensions, Sun UltraSPARC III extensions"
 
 # RUN: yaml2obj %s -o %t -DCLASS_NAME="ELFCLASS64" -DMACHINE_NAME="EM_SPARCV9" -DFLAG_NAME=""
@@ -57,7 +57,7 @@
 # RUN:   -DFLAG0_NAME=EF_SPARCV9_PSO -DFLAG1_NAME=EF_SPARC_HAL_R1 \
 # RUN:   -DFLAG2_NAME=EF_SPARC_SUN_US1 -DFLAG3_NAME=EF_SPARC_SUN_US3
 # RUN: llvm-readelf -h %t | FileCheck %s --match-full-lines --check-prefix=GNU \
-# RUN:   -DFLAG_VALUE=0xE01\
+# RUN:   -DFLAG_VALUE=0xe01\
 # RUN:   -DGNU_FLAG_NAME=", Sun UltraSPARC I extensions, HAL/Fujitsu R1 extensions, Sun UltraSPARC III extensions, Partial Store Ordering"
 
 --- !ELF

--- a/llvm/test/tools/llvm-readobj/ELF/file-types.test
+++ b/llvm/test/tools/llvm-readobj/ELF/file-types.test
@@ -62,7 +62,7 @@ FileHeader:
 # RUN: llvm-readelf -h %t.unknown | FileCheck %s --match-full-lines --check-prefix GNU-UNNKNOWN
 
 # LLVM-UNNKNOWN: ElfHeader {
-# LLVM-UNNKNOWN:   Type: Unknown (0xFDFF)
+# LLVM-UNNKNOWN:   Type: Unknown (0xfdff)
 
 # GNU-UNNKNOWN: ELF Header:
 # GNU-UNNKNOWN:   Type: <unknown>: fdff
@@ -72,7 +72,7 @@ FileHeader:
 # RUN: llvm-readelf -h %t6 | FileCheck %s --match-full-lines --check-prefix GNU-LOOS
 
 # LLVM-LOOS: ElfHeader {
-# LLVM-LOOS:   Type: OS Specific (0xFE00)
+# LLVM-LOOS:   Type: OS Specific (0xfe00)
 
 # GNU-LOOS: ELF Header:
 # GNU-LOOS:   Type: OS Specific: (fe00)
@@ -82,7 +82,7 @@ FileHeader:
 # RUN: llvm-readelf -h %t7 | FileCheck %s --match-full-lines --check-prefix GNU-HIOS
 
 # LLVM-HIOS: ElfHeader {
-# LLVM-HIOS:   Type: OS Specific (0xFEFF)
+# LLVM-HIOS:   Type: OS Specific (0xfeff)
 
 # GNU-HIOS: ELF Header:
 # GNU-HIOS:   Type: OS Specific: (feff)
@@ -92,7 +92,7 @@ FileHeader:
 # RUN: llvm-readelf -h %t8 | FileCheck %s --match-full-lines --check-prefix GNU-LOPROC
 
 # LLVM-LOPROC: ElfHeader {
-# LLVM-LOPROC:   Type: Processor Specific (0xFF00)
+# LLVM-LOPROC:   Type: Processor Specific (0xff00)
 
 # GNU-LOPROC: ELF Header:
 # GNU-LOPROC:   Type: Processor Specific: (ff00)
@@ -102,7 +102,7 @@ FileHeader:
 # RUN: llvm-readelf -h %t9 | FileCheck %s --match-full-lines --check-prefix GNU-HIPROC
 
 # LLVM-HIPROC: ElfHeader {
-# LLVM-HIPROC:   Type: Processor Specific (0xFFFF)
+# LLVM-HIPROC:   Type: Processor Specific (0xffff)
 
 # GNU-HIPROC: ELF Header:
 # GNU-HIPROC:   Type: Processor Specific: (ffff)

--- a/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
+++ b/llvm/test/tools/llvm-readobj/ELF/note-freebsd.test
@@ -48,7 +48,7 @@ Sections:
 # GNU-NEXT: FreeBSD              0x00000007	NT_FREEBSD_ARCH_TAG (architecture tag)
 # GNU-NEXT:   Arch tag: aarch64
 # GNU-NEXT: FreeBSD              0x00000004	NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
-# GNU-NEXT:   Feature flags: ASLR_DISABLE PROTMAX_DISABLE STKGAP_DISABLE WXNEEDED LA48 ASG_DISABLE (0xFFFFFFFF)
+# GNU-NEXT:   Feature flags: ASLR_DISABLE PROTMAX_DISABLE STKGAP_DISABLE WXNEEDED LA48 ASG_DISABLE (0xffffffff)
 # GNU-NEXT: FreeBSD              0x00000001	NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
 # GNU-NEXT:   description data: 00
 # GNU-NEXT: FreeBSD              0x00000004	NT_FREEBSD_NOINIT_TAG (no .init tag)
@@ -91,7 +91,7 @@ Sections:
 # LLVM-NEXT:            Owner: FreeBSD
 # LLVM-NEXT:            Data size: 0x4
 # LLVM-NEXT:            Type: NT_FREEBSD_FEATURE_CTL (FreeBSD feature control)
-# LLVM-NEXT:            Feature flags: ASLR_DISABLE PROTMAX_DISABLE STKGAP_DISABLE WXNEEDED LA48 ASG_DISABLE (0xFFFFFFFF)
+# LLVM-NEXT:            Feature flags: ASLR_DISABLE PROTMAX_DISABLE STKGAP_DISABLE WXNEEDED LA48 ASG_DISABLE (0xffffffff)
 # LLVM-NEXT:        }
 # LLVM-NEXT:        {
 # LLVM-NEXT:            Owner: FreeBSD

--- a/llvm/test/tools/llvm-readobj/ELF/section-types.test
+++ b/llvm/test/tools/llvm-readobj/ELF/section-types.test
@@ -134,14 +134,14 @@
 # GNU-NEXT: gnu_verneed             VERNEED
 # GNU-NEXT: unknown                 0x1000: <unknown>
 # GNU-NEXT: loos                    LOOS+0x0
-# GNU-NEXT: fooos                   LOOS+0xF00
+# GNU-NEXT: fooos                   LOOS+0xf00
 # GNU-NEXT: hios                    VERSYM
 # GNU-NEXT: loproc                  LOPROC+0x0
-# GNU-NEXT: fooproc                 LOPROC+0xF00
-# GNU-NEXT: hiproc                  LOPROC+0xFFFFFFF
+# GNU-NEXT: fooproc                 LOPROC+0xf00
+# GNU-NEXT: hiproc                  LOPROC+0xfffffff
 # GNU-NEXT: louser                  LOUSER+0x0
-# GNU-NEXT: foouser                 LOUSER+0xF00
-# GNU-NEXT: hiuser                  LOUSER+0x7FFFFFFF
+# GNU-NEXT: foouser                 LOUSER+0xf00
+# GNU-NEXT: hiuser                  LOUSER+0x7fffffff
 # GNU-NEXT: .symtab                 SYMTAB
 # GNU-NEXT: .strtab                 STRTAB
 

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -3601,7 +3601,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
   OS.PadToColumn(2u);
   OS << "Version:";
   OS.PadToColumn(37u);
-  OS << utohexstr(e.e_ident[ELF::EI_VERSION]);
+  OS << utohexstr(e.e_ident[ELF::EI_VERSION], /*LowerCase=*/true);
   if (e.e_version == ELF::EV_CURRENT)
     OS << " (current)";
   OS << "\n";
@@ -3638,7 +3638,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
 
   Str = enumToString(e.e_machine, ArrayRef(ElfMachineType));
   printFields(OS, "Machine:", Str);
-  Str = "0x" + utohexstr(e.e_version);
+  Str = "0x" + utohexstr(e.e_version, /*LowerCase=*/true);
   printFields(OS, "Version:", Str);
   Str = "0x" + utohexstr(e.e_entry, /*LowerCase=*/true);
   printFields(OS, "Entry point address:", Str);
@@ -3711,7 +3711,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
     } break;
     }
   }
-  Str = "0x" + utohexstr(e.e_flags);
+  Str = "0x" + utohexstr(e.e_flags, /*LowerCase=*/true);
   if (!ElfFlags.empty())
     Str = Str + ", " + ElfFlags;
   printFields(OS, "Flags:", Str);
@@ -4088,12 +4088,12 @@ template <class ELFT> void GNUELFDumper<ELFT>::printRelr(const Elf_Shdr &Sec) {
 // returned as '<unknown>' followed by the type value.
 static std::string getSectionTypeOffsetString(unsigned Type) {
   if (Type >= SHT_LOOS && Type <= SHT_HIOS)
-    return "LOOS+0x" + utohexstr(Type - SHT_LOOS);
+    return "LOOS+0x" + utohexstr(Type - SHT_LOOS, /*LowerCase=*/true);
   else if (Type >= SHT_LOPROC && Type <= SHT_HIPROC)
-    return "LOPROC+0x" + utohexstr(Type - SHT_LOPROC);
+    return "LOPROC+0x" + utohexstr(Type - SHT_LOPROC, /*LowerCase=*/true);
   else if (Type >= SHT_LOUSER && Type <= SHT_HIUSER)
-    return "LOUSER+0x" + utohexstr(Type - SHT_LOUSER);
-  return "0x" + utohexstr(Type) + ": <unknown>";
+    return "LOUSER+0x" + utohexstr(Type - SHT_LOUSER, /*LowerCase=*/true);
+  return "0x" + utohexstr(Type, /*LowerCase=*/true) + ": <unknown>";
 }
 
 static std::string getSectionTypeString(unsigned Machine, unsigned Type) {
@@ -5722,9 +5722,9 @@ getFreeBSDNote(uint32_t NoteType, ArrayRef<uint8_t> Desc, bool IsCore) {
     raw_string_ostream OS(FlagsStr);
     printFlags(Value, ArrayRef(FreeBSDFeatureCtlFlags), OS);
     if (FlagsStr.empty())
-      OS << "0x" << utohexstr(Value);
+      OS << "0x" << utohexstr(Value, /*LowerCase=*/true);
     else
-      OS << "(0x" << utohexstr(Value) << ")";
+      OS << "(0x" << utohexstr(Value, /*LowerCase=*/true) << ")";
     return FreeBSDNote{"Feature flags", FlagsStr};
   }
   default:
@@ -7349,7 +7349,8 @@ template <class ELFT> void LLVMELFDumper<ELFT>::printFileHeaders() {
       else
         TypeStr = "Unknown";
     }
-    W.printString("Type", TypeStr + " (0x" + utohexstr(E.e_type) + ")");
+    W.printString("Type", TypeStr + " (0x" +
+                              utohexstr(E.e_type, /*LowerCase=*/true) + ")");
 
     W.printEnum("Machine", E.e_machine, ArrayRef(ElfMachineType));
     W.printNumber("Version", E.e_version);
@@ -8246,7 +8247,7 @@ void LLVMELFDumper<ELFT>::printMemtag(
   {
     ListScope L(W, "Memtag Global Descriptors:");
     for (const auto &[Addr, BytesToTag] : Descriptors) {
-      W.printHex("0x" + utohexstr(Addr), BytesToTag);
+      W.printHex("0x" + utohexstr(Addr, /*LowerCase=*/true), BytesToTag);
     }
   }
 }

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -3640,7 +3640,7 @@ template <class ELFT> void GNUELFDumper<ELFT>::printFileHeaders() {
   printFields(OS, "Machine:", Str);
   Str = "0x" + utohexstr(e.e_version);
   printFields(OS, "Version:", Str);
-  Str = "0x" + utohexstr(e.e_entry);
+  Str = "0x" + utohexstr(e.e_entry, /*LowerCase=*/true);
   printFields(OS, "Entry point address:", Str);
   Str = to_string(e.e_phoff) + " (bytes into file)";
   printFields(OS, "Start of program headers:", Str);


### PR DESCRIPTION
Previously, llvm-readelf dumped hex format values in different ways. Some of them were printed in upper-case, while the others were in lower-case format. This change switches the format to lower-case in all cases.

Why is this useful? As an example, FileCheck comparisons are case-sensitive by default. This change means it's easier to compare those values, because they have the same format.