### PR TITLE
[bazel][libc] Update MPFR to v4.2.2

### DIFF
--- a/utils/bazel/WORKSPACE
+++ b/utils/bazel/WORKSPACE
@@ -121,9 +121,9 @@ maybe(
     http_archive,
     name = "mpfr",
     build_file = "@llvm-raw//utils/bazel/third_party_build:mpfr.BUILD",
-    sha256 = "9cbed5d0af0d9ed5e9f8dd013e17838eb15e1db9a6ae0d371d55d35f93a782a7",
-    strip_prefix = "mpfr-4.1.1",
-    urls = ["https://www.mpfr.org/mpfr-4.1.1/mpfr-4.1.1.tar.gz"],
+    sha256 = "826cbb24610bd193f36fde172233fb8c009f3f5c2ad99f644d0dea2e16a20e42",
+    strip_prefix = "mpfr-4.2.2",
+    urls = ["https://www.mpfr.org/mpfr-current/mpfr-4.2.2.tar.gz"],
 )
 
 maybe(


### PR DESCRIPTION
Use MPFR v4.2.2 rather than MPFR v4.1.1 for Bazel/Clang builds to avoid conflicts with glibc’s `__float128` fallback typedef. See https://gitlab.inria.fr/mpfr/mpfr/-/commit/c37c9d599b9aced92e182507bf223440bbc9a9f1 for further details.

Fixes https://github.com/llvm/llvm-project/issues/147879