### PR TITLE
[lldb] Moving MCPTransport into its own file.

### DIFF
--- a/lldb/include/lldb/Host/JSONTransport.h
+++ b/lldb/include/lldb/Host/JSONTransport.h
@@ -100,7 +100,8 @@ public:
   virtual llvm::Expected<MainLoop::ReadHandleUP>
   RegisterMessageHandler(MainLoop &loop, MessageHandler &handler) = 0;
 
-protected:
+  // FIXME: Refactor mcp::Server to not directly access log on the transport.
+  // protected:
   template <typename... Ts> inline auto Logv(const char *Fmt, Ts &&...Vals) {
     Log(llvm::formatv(Fmt, std::forward<Ts>(Vals)...).str());
   }
@@ -139,15 +140,17 @@ public:
   /// detail.
   static constexpr size_t kReadBufferSize = 1024;
 
-protected:
-  virtual llvm::Expected<std::vector<std::string>> Parse() = 0;
-  virtual std::string Encode(const llvm::json::Value &message) = 0;
+  // FIXME: Write should be protected.
   llvm::Error Write(const llvm::json::Value &message) {
     this->Logv("<-- {0}", message);
     std::string output = Encode(message);
     size_t bytes_written = output.size();
     return m_out->Write(output.data(), bytes_written).takeError();
   }
+
+protected:
+  virtual llvm::Expected<std::vector<std::string>> Parse() = 0;
+  virtual std::string Encode(const llvm::json::Value &message) = 0;
 
   llvm::SmallString<kReadBufferSize> m_buffer;
 

--- a/lldb/include/lldb/Protocol/MCP/Server.h
+++ b/lldb/include/lldb/Protocol/MCP/Server.h
@@ -14,32 +14,16 @@
 #include "lldb/Protocol/MCP/Protocol.h"
 #include "lldb/Protocol/MCP/Resource.h"
 #include "lldb/Protocol/MCP/Tool.h"
+#include "lldb/Protocol/MCP/Transport.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Error.h"
-#include <mutex>
+#include "llvm/Support/JSON.h"
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace lldb_protocol::mcp {
-
-class MCPTransport
-    : public lldb_private::JSONRPCTransport<Request, Response, Notification> {
-public:
-  using LogCallback = std::function<void(llvm::StringRef message)>;
-
-  MCPTransport(lldb::IOObjectSP in, lldb::IOObjectSP out,
-               std::string client_name, LogCallback log_callback = {})
-      : JSONRPCTransport(in, out), m_client_name(std::move(client_name)),
-        m_log_callback(log_callback) {}
-  virtual ~MCPTransport() = default;
-
-  void Log(llvm::StringRef message) override {
-    if (m_log_callback)
-      m_log_callback(llvm::formatv("{0}: {1}", m_client_name, message).str());
-  }
-
-private:
-  std::string m_client_name;
-  LogCallback m_log_callback;
-};
 
 /// Information about this instance of lldb's MCP server for lldb-mcp to use to
 /// coordinate connecting an lldb-mcp client.

--- a/lldb/include/lldb/Protocol/MCP/Transport.h
+++ b/lldb/include/lldb/Protocol/MCP/Transport.h
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_PROTOCOL_MCP_TRANSPORT_H
+#define LLDB_PROTOCOL_MCP_TRANSPORT_H
+
+#include "lldb/Host/JSONTransport.h"
+#include "lldb/Protocol/MCP/Protocol.h"
+#include "lldb/lldb-forward.h"
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace lldb_protocol::mcp {
+
+/// Generic transport that uses the MCP protocol.
+using MCPTransport = lldb_private::Transport<Request, Response, Notification>;
+
+/// Generic logging callback, to allow the MCP server / client / transport layer
+/// to be independent of the lldb log implementation.
+using LogCallback = llvm::unique_function<void(llvm::StringRef message)>;
+
+class Transport final
+    : public lldb_private::JSONRPCTransport<Request, Response, Notification> {
+public:
+  Transport(lldb::IOObjectSP in, lldb::IOObjectSP out,
+            LogCallback log_callback = {});
+  virtual ~Transport() = default;
+
+  /// Transport is not copyable.
+  /// @{
+  Transport(const Transport &) = delete;
+  void operator=(const Transport &) = delete;
+  /// @}
+
+  void Log(llvm::StringRef message) override;
+
+private:
+  LogCallback m_log_callback;
+};
+
+} // namespace lldb_protocol::mcp
+
+#endif

--- a/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
+++ b/lldb/source/Plugins/Protocol/MCP/ProtocolServerMCP.cpp
@@ -70,9 +70,9 @@ void ProtocolServerMCP::AcceptCallback(std::unique_ptr<Socket> socket) {
   LLDB_LOG(log, "New MCP client connected: {0}", client_name);
 
   lldb::IOObjectSP io_sp = std::move(socket);
-  auto transport_up = std::make_unique<lldb_protocol::mcp::MCPTransport>(
-      io_sp, io_sp, std::move(client_name), [&](llvm::StringRef message) {
-        LLDB_LOG(GetLog(LLDBLog::Host), "{0}", message);
+  auto transport_up = std::make_unique<lldb_protocol::mcp::Transport>(
+      io_sp, io_sp, [client_name](llvm::StringRef message) {
+        LLDB_LOG(GetLog(LLDBLog::Host), "{0}: {1}", client_name, message);
       });
   auto instance_up = std::make_unique<lldb_protocol::mcp::Server>(
       std::string(kName), std::string(kVersion), std::move(transport_up),

--- a/lldb/source/Protocol/MCP/CMakeLists.txt
+++ b/lldb/source/Protocol/MCP/CMakeLists.txt
@@ -3,6 +3,7 @@ add_lldb_library(lldbProtocolMCP NO_PLUGIN_DEPENDENCIES
   Protocol.cpp
   Server.cpp
   Tool.cpp
+  Transport.cpp
 
   LINK_COMPONENTS
     Support

--- a/lldb/source/Protocol/MCP/Transport.cpp
+++ b/lldb/source/Protocol/MCP/Transport.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Protocol/MCP/Transport.h"
+#include "llvm/ADT/StringRef.h"
+#include <utility>
+
+using namespace lldb_protocol::mcp;
+using namespace llvm;
+
+Transport::Transport(lldb::IOObjectSP in, lldb::IOObjectSP out,
+                     LogCallback log_callback)
+    : JSONRPCTransport(in, out), m_log_callback(std::move(log_callback)) {}
+
+void Transport::Log(StringRef message) {
+  if (m_log_callback)
+    m_log_callback(message);
+}

--- a/lldb/tools/lldb-mcp/lldb-mcp.cpp
+++ b/lldb/tools/lldb-mcp/lldb-mcp.cpp
@@ -67,9 +67,10 @@ int main(int argc, char *argv[]) {
         [](MainLoopBase &loop) { loop.RequestTermination(); });
   });
 
-  auto transport_up = std::make_unique<lldb_protocol::mcp::MCPTransport>(
-      input, output, std::string(client_name),
-      [&](llvm::StringRef message) { llvm::errs() << message << '\n'; });
+  auto transport_up = std::make_unique<lldb_protocol::mcp::Transport>(
+      input, output, [&](llvm::StringRef message) {
+        llvm::errs() << formatv("{0}: {1}", client_name, message) << '\n';
+      });
 
   auto instance_up = std::make_unique<lldb_protocol::mcp::Server>(
       std::string(kName), std::string(kVersion), std::move(transport_up), loop);


### PR DESCRIPTION
Moving `lldb_protocol::mcp::MCPTransport` into its own file and renaming to `lldb_protocol::mcp::Transport`.