### PR TITLE
[lldb] Revert custom __str__ in SBStructuredDataExtensions.i

### DIFF
--- a/lldb/bindings/interface/SBStructuredDataExtensions.i
+++ b/lldb/bindings/interface/SBStructuredDataExtensions.i
@@ -52,18 +52,6 @@ STRING_EXTENSION_OUTSIDE(SBStructuredData)
         else:
             raise TypeError("cannot convert generic to bool")
 
-    def __str__(self):
-        data_type = self.GetType()
-        if data_type in (
-            eStructuredDataTypeString,
-            eStructuredDataTypeInteger,
-            eStructuredDataTypeSignedInteger,
-            eStructuredDataTypeFloat,
-        ):
-            return str(self.dynamic)
-        else:
-            raise TypeError(f"cannot convert {self.type_name(data_type)} to string")
-
     def __int__(self):
         data_type = self.GetType()
         if data_type in (

--- a/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
+++ b/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
@@ -48,6 +48,8 @@ class TestStructuredDataAPI(TestBase):
         s.Clear()
         error = example.GetDescription(s)
         self.assertSuccess(error, "GetDescription works")
+        # Ensure str() doesn't raise an exception.
+        self.assertTrue(str(example))
         if not "key_float" in s.GetData():
             self.fail("FAILED: could not find key_float in description output")
 
@@ -344,7 +346,7 @@ class TestStructuredDataAPI(TestBase):
             self.fail("wrong output: " + str(output))
 
     def test_round_trip_scalars(self):
-        for original in (0, 11, -1, 0.0, 4.5, -0.25, "", "dirk", True, False):
+        for original in (0, 11, -1, 0.0, 4.5, -0.25, True, False):
             constructor = type(original)
             data = lldb.SBStructuredData()
             data.SetFromJSON(json.dumps(original))
@@ -356,13 +358,6 @@ class TestStructuredDataAPI(TestBase):
             data = lldb.SBStructuredData()
             data.SetFromJSON(json.dumps(original))
             self.assertEqual(data.dynamic, original)
-
-    def test_round_trip_string(self):
-        # No 0.0, it inherently does not round trip.
-        for original in (0, 11, -1, 4.5, -0.25, "", "dirk"):
-            data = lldb.SBStructuredData()
-            data.SetFromJSON(json.dumps(original))
-            self.assertEqual(str(data), str(original))
 
     def test_round_trip_int(self):
         for original in (0, 11, -1):


### PR DESCRIPTION
`__str__` was implemented in #155061, however its behavior was limited to only a some kinds of `SBStructuredData`. That was a breaking change, and this change removes that implementation of `__str__`, relying on the existing behavior which calls `GetDescription`.