### PR TITLE
[lldb] Reimplement __str__ in SBStructuredDataExtensions.i

### DIFF
--- a/lldb/bindings/interface/SBStructuredDataExtensions.i
+++ b/lldb/bindings/interface/SBStructuredDataExtensions.i
@@ -38,6 +38,18 @@ STRING_EXTENSION_OUTSIDE(SBStructuredData)
         else:
             raise TypeError(f"cannot subscript {self.type_name(data_type)} type")
 
+    def __str__(self):
+        data_type = self.GetType()
+        if data_type in (
+            eStructuredDataTypeString,
+            eStructuredDataTypeInteger,
+            eStructuredDataTypeSignedInteger,
+            eStructuredDataTypeFloat,
+        ):
+             return str(self.dynamic)
+        else:
+            return repr(self)
+
     def __bool__(self):
         data_type = self.GetType()
         if data_type == eStructuredDataTypeInvalid:

--- a/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
+++ b/lldb/test/API/python_api/sbstructureddata/TestStructuredDataAPI.py
@@ -2,13 +2,13 @@
 Test some SBStructuredData API.
 """
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 import json
+
 
 class TestStructuredDataAPI(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
@@ -346,7 +346,7 @@ class TestStructuredDataAPI(TestBase):
             self.fail("wrong output: " + str(output))
 
     def test_round_trip_scalars(self):
-        for original in (0, 11, -1, 0.0, 4.5, -0.25, True, False):
+        for original in (0, 11, -1, 0.0, 4.5, -0.25, "", "dirk", True, False):
             constructor = type(original)
             data = lldb.SBStructuredData()
             data.SetFromJSON(json.dumps(original))
@@ -358,6 +358,19 @@ class TestStructuredDataAPI(TestBase):
             data = lldb.SBStructuredData()
             data.SetFromJSON(json.dumps(original))
             self.assertEqual(data.dynamic, original)
+
+    def test_round_trip_string(self):
+        # No 0.0, it inherently does not round trip.
+        for original in (0, 11, -1, 4.5, -0.25, "", "dirk", True, False):
+            data = lldb.SBStructuredData()
+            data.SetFromJSON(json.dumps(original))
+            self.assertEqual(str(data), str(original))
+
+    def test_str(self):
+        for original in ([15], {"id": 23}, None):
+            data = lldb.SBStructuredData()
+            data.SetFromJSON(json.dumps(original))
+            self.assertTrue(str(data))
 
     def test_round_trip_int(self):
         for original in (0, 11, -1):


### PR DESCRIPTION
Follow up to #155061 and #156721.

After discussing with @medismailben, the ideal course of to have a `__str__`, however, instead of throwing an exception, the fallback behavior calls `__repr__` (`GetDescription`).

The main value of this is that `str(string_data)` will produce the string itself, not a quoted string as returned by `__repr__`/`GetDescription`.
