### PR TITLE
[LLDB] Make internal shell the default for running LLDB lit tests.

### DIFF
--- a/lldb/test/Shell/Process/Optimization.test
+++ b/lldb/test/Shell/Process/Optimization.test
@@ -1,5 +1,5 @@
 Test warnings.
-REQUIRES: shell, system-darwin
+REQUIRES: system-darwin
 RUN: %clang_host -O3 %S/Inputs/true.c -std=c99 -g -o %t.exe
 RUN: %lldb -o "b main" -o r -o q -b %t.exe 2>&1 | FileCheck %s
 

--- a/lldb/test/Shell/Process/UnsupportedLanguage.test
+++ b/lldb/test/Shell/Process/UnsupportedLanguage.test
@@ -1,7 +1,5 @@
 Test unsupported language warning
 
-REQUIRES: shell
-
 RUN: %clang_host %S/Inputs/true.c -std=c99 -g -c -S -emit-llvm -o - \
 RUN:   | sed -e 's/DW_LANG_C99/DW_LANG_Mips_Assembler/g' >%t.ll
 RUN: %clang_host %t.ll -g -o %t.exe

--- a/lldb/test/Shell/SymbolFile/DWARF/dwo-missing-error.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwo-missing-error.test
@@ -11,12 +11,12 @@
 # "a.out-dwo-missing-error.dwo".
 # RUN: rm -rf %t.compdir/
 # RUN: mkdir -p %t.compdir/a/b/
-# RUN: cd %t.compdir/a/b/
+# RUN: pushd %t.compdir/a/b/
 # RUN: %clang_host %S/Inputs/dwo-missing-error.c -glldb -gdwarf-5 \
 # RUN:     -gsplit-dwarf -fdebug-prefix-map=%t.compdir=. -o a.out
 # RUN: rm *.dwo
 # RUN: %lldb a.out -s %s -o exit 2>&1 | FileCheck %s 
-# RUN: cd -
+# RUN: popd
 
 # Test the error message with an absolute DW_AT_comp_dir and DW_AT_dwo_name.
 # RUN: rm -rf %t.compdir/

--- a/lldb/test/Shell/lit.cfg.py
+++ b/lldb/test/Shell/lit.cfg.py
@@ -21,7 +21,15 @@ from helper import toolchain
 config.name = "lldb-shell"
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = toolchain.ShTestLldb(not llvm_config.use_lit_shell)
+# We prefer the lit internal shell which provides a better user experience on
+# failures and is faster unless the user explicitly disables it with
+# LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
+config.test_format = toolchain.ShTestLldb(not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.

--- a/lldb/test/lit.cfg.py
+++ b/lldb/test/lit.cfg.py
@@ -13,3 +13,15 @@ from lit.llvm import llvm_config
 config.name = "lldb"
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.lldb_obj_root, "test")
+
+# We prefer the lit internal shell which provides a better user experience on
+# failures and is faster unless the user explicitly disables it with
+# LIT_USE_INTERNAL_SHELL=0 env var.
+
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
+if use_lit_shell:
+    os.environ["LIT_USE_INTERNAL_SHELL"] = "1"

--- a/lldb/test/lit.cfg.py
+++ b/lldb/test/lit.cfg.py
@@ -13,15 +13,3 @@ from lit.llvm import llvm_config
 config.name = "lldb"
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = os.path.join(config.lldb_obj_root, "test")
-
-# We prefer the lit internal shell which provides a better user experience on
-# failures and is faster unless the user explicitly disables it with
-# LIT_USE_INTERNAL_SHELL=0 env var.
-
-use_lit_shell = True
-lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
-if lit_shell_env:
-    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
-
-if use_lit_shell:
-    os.environ["LIT_USE_INTERNAL_SHELL"] = "1"


### PR DESCRIPTION
This patch updates the lld lit test config to use the internal shell by default. This has some performance advantages (~10-15%) and also produces nicer failure output. It also updates the two LLDB tests to not require shell (so that they run under the internal shell), after first verifying that they run and pass using the internal shell; and it fixes one test that was not passing under the internal shell.