### PR TITLE
[LLVM][MC][DecoderEmitter] Fail fatally if `Insn` and decoder table bitwidths mismatch

### DIFF
--- a/llvm/test/TableGen/DecoderEmitterBitwidthSpecialization.td
+++ b/llvm/test/TableGen/DecoderEmitterBitwidthSpecialization.td
@@ -132,7 +132,7 @@ def Inst3 : Instruction16Bit<3> {
 // CHECK-SPECIALIZE-NO-TABLE-LABEL:   template <typename InsnType>
 // CHECK-SPECIALIZE-NO-TABLE-NEXT:    decodeInstruction
 // CHECK-SPECIALIZE-NO-TABLE:         uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
-// CHECK-SPECIALIZE-NO-TABLE-NEXT:    if (InsnBitWidth<InsnType> != BitWidth)
+// CHECK-SPECIALIZE-NO-TABLE-NEXT:    assert(InsnBitWidth<InsnType> == BitWidth &&
 
 // -----------------------------------------------------------------------------
 // Per bitwidth specialization with function table.
@@ -186,4 +186,4 @@ def Inst3 : Instruction16Bit<3> {
 // CHECK-SPECIALIZE-TABLE-LABEL:    template <typename InsnType>
 // CHECK-SPECIALIZE-TABLE-NEXT:     decodeInstruction
 // CHECK-SPECIALIZE-TABLE:          uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
-// CHECK-SPECIALIZE-TABLE-NEXT:     if (InsnBitWidth<InsnType> != BitWidth)
+// CHECK-SPECIALIZE-TABLE-NEXT:     assert(InsnBitWidth<InsnType> == BitWidth &&

--- a/llvm/test/TableGen/DecoderEmitterBitwidthSpecialization.td
+++ b/llvm/test/TableGen/DecoderEmitterBitwidthSpecialization.td
@@ -105,7 +105,8 @@ def Inst3 : Instruction16Bit<3> {
 // When we specialize per bitwidth, we emit 2 decodeToMCInst functions and
 // DecodeIdx is assigned per bit width.
 
-// CHECK-SPECIALIZE-NO-TABLE-LABEL:   DecoderTable8[25]
+// CHECK-SPECIALIZE-NO-TABLE-LABEL:   DecoderTable8[26]
+// CHECK-SPECIALIZE-NO-TABLE:           /* 0 */ 8, // Bitwidth 8
 // CHECK-SPECIALIZE-NO-TABLE:           DecodeIdx: 0
 // CHECK-SPECIALIZE-NO-TABLE:           DecodeIdx: 1
 // CHECK-SPECIALIZE-NO-TABLE:         };
@@ -116,7 +117,8 @@ def Inst3 : Instruction16Bit<3> {
 // CHECK-SPECIALIZE-NO-TABLE:           case 0
 // CHECK-SPECIALIZE-NO-TABLE:           case 1
 
-// CHECK-SPECIALIZE-NO-TABLE-LABEL:   DecoderTable16[25]
+// CHECK-SPECIALIZE-NO-TABLE-LABEL:   DecoderTable16[26]
+// CHECK-SPECIALIZE-NO-TABLE:           /* 0 */ 16, // Bitwidth 16
 // CHECK-SPECIALIZE-NO-TABLE:           DecodeIdx: 0
 // CHECK-SPECIALIZE-NO-TABLE:           DecodeIdx: 1
 // CHECK-SPECIALIZE-NO-TABLE:         };
@@ -127,11 +129,17 @@ def Inst3 : Instruction16Bit<3> {
 // CHECK-SPECIALIZE-NO-TABLE:           case 0
 // CHECK-SPECIALIZE-NO-TABLE:           case 1
 
+// CHECK-SPECIALIZE-NO-TABLE-LABEL:   template <typename InsnType>
+// CHECK-SPECIALIZE-NO-TABLE-NEXT:    decodeInstruction
+// CHECK-SPECIALIZE-NO-TABLE:         uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
+// CHECK-SPECIALIZE-NO-TABLE-NEXT:    if (InsnBitWidth<InsnType> != BitWidth)
+
 // -----------------------------------------------------------------------------
 // Per bitwidth specialization with function table.
 
 // 8 bit deccoder table, functions, and function table.
-// CHECK-SPECIALIZE-TABLE-LABEL:    DecoderTable8[25]
+// CHECK-SPECIALIZE-TABLE-LABEL:    DecoderTable8[26]
+// CHECK-SPECIALIZE-TABLE:           /* 0 */ 8, // Bitwidth 8
 // CHECK-SPECIALIZE-TABLE:            DecodeIdx: 0
 // CHECK-SPECIALIZE-TABLE:            DecodeIdx: 1
 // CHECK-SPECIALIZE-TABLE:          };
@@ -153,7 +161,8 @@ def Inst3 : Instruction16Bit<3> {
 // CHECK-SPECIALIZE-TABLE-NEXT:     };
 
 // 16 bit deccoder table, functions, and function table.
-// CHECK-SPECIALIZE-TABLE-LABEL:    DecoderTable16[25]
+// CHECK-SPECIALIZE-TABLE-LABEL:    DecoderTable16[26]
+// CHECK-SPECIALIZE-TABLE:            /* 0 */ 16, // Bitwidth 16
 // CHECK-SPECIALIZE-TABLE:            DecodeIdx: 0
 // CHECK-SPECIALIZE-TABLE:            DecodeIdx: 1
 // CHECK-SPECIALIZE-TABLE:          };
@@ -173,3 +182,8 @@ def Inst3 : Instruction16Bit<3> {
 // CHECK-SPECIALIZE-TABLE-NEXT:       decodeFn_16bit_0,
 // CHECK-SPECIALIZE-TABLE-NEXT:       decodeFn_16bit_1,
 // CHECK-SPECIALIZE-TABLE-NEXT:     };
+
+// CHECK-SPECIALIZE-TABLE-LABEL:    template <typename InsnType>
+// CHECK-SPECIALIZE-TABLE-NEXT:     decodeInstruction
+// CHECK-SPECIALIZE-TABLE:          uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
+// CHECK-SPECIALIZE-TABLE-NEXT:     if (InsnBitWidth<InsnType> != BitWidth)

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -2127,9 +2127,9 @@ static DecodeStatus decodeInstruction(const uint8_t DecodeTable[], MCInst &MI,
     // Fail with a fatal error if decoder table's bitwidth does not match
     // `InsnType` bitwidth.
     OS << R"(
-  uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
-  if (InsnBitWidth<InsnType> != BitWidth)
-    llvm_unreachable("Table and instruction bitwidth mismatch");
+  [[maybe_unused]] uint32_t BitWidth = decodeULEB128AndIncUnsafe(Ptr);
+  assert(InsnBitWidth<InsnType> == BitWidth &&
+         "Table and instruction bitwidth mismatch");
 )";
   }
 


### PR DESCRIPTION
When decoders are specialized per-bitwidth:
- Encode the bit width of a decoder table as a ULEB128 encoded entry at the start of each decoder table.
- Add a fatal error in `decodeInstruction` if the bit width for `InsnType` does not match the bit width encoded in the decoder table.
