### PR TITLE
Revert "[llvm-exegesis] Exclude loads/stores from aliasing instruction set"

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/no-aliasing-ld-str.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/no-aliasing-ld-str.s
@@ -1,8 +1,0 @@
-REQUIRES: aarch64-registered-target
-
-RUN: llvm-exegesis -mtriple=aarch64 -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=FMOVWSr --benchmark-phase=assemble-measured-code 2>&1
-RUN: llvm-objdump -d %d > %t.s
-RUN: FileCheck %s < %t.s
-
-CHECK-NOT: ld{{[1-4]}}
-CHECK-NOT: st{{[1-4]}}

--- a/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
+++ b/llvm/tools/llvm-exegesis/lib/MCInstrDescView.cpp
@@ -206,8 +206,6 @@ const Operand &Instruction::getPrimaryOperand(const Variable &Var) const {
 }
 
 bool Instruction::hasMemoryOperands() const {
-  if (Description.mayLoad() || Description.mayStore())
-    return true;
   return any_of(Operands, [](const Operand &Op) {
     return Op.isReg() && Op.isExplicit() && Op.isMemory();
   });


### PR DESCRIPTION
Reverts llvm/llvm-project#156300

Need to look at the X86 test failures. 