### PR TITLE
lit] Update internal shell lexer to remove escape on '$' only for double-quoted strings.

### DIFF
--- a/llvm/utils/lit/lit/ShUtil.py
+++ b/llvm/utils/lit/lit/ShUtil.py
@@ -117,7 +117,7 @@ class ShLexer:
                 return str
             # LLDB uses "$" at the start of global variable names; it should
             # not be escaped nor dropped.
-            elif c == "\\" and self.look() == "$":
+            elif c == "\\" and self.look() == "$" and delim == '"':
                 c = self.eat()
                 str += c
             elif c == "\\" and delim == '"':

--- a/llvm/utils/lit/tests/unit/ShUtil.py
+++ b/llvm/utils/lit/tests/unit/ShUtil.py
@@ -30,6 +30,8 @@ class TestShLexer(unittest.TestCase):
         self.assertEqual(self.lex(""" a\\ b """, win32Escapes=True), ["a\\", "b"])
         self.assertEqual(self.lex('"\\$y = 11"'), ["$y = 11"])
         self.assertEqual(self.lex('"expr \\$y = 11"'), ["expr $y = 11"])
+        self.assertEqual(self.lex("'\\$y = 11'"), ["\\$y = 11"])
+        self.assertEqual(self.lex("'expr \\$y = 11'"), ["expr \\$y = 11"])
 
 class TestShParse(unittest.TestCase):
     def parse(self, str):


### PR DESCRIPTION
PR 156125 removed the escape (backslash) in front of '$' for all quoted strings. It has since been pointed out this should only happen for double-quoted strings. This PR fixes that.