### PR TITLE
[flang][runtime] tweak advancing for child list directed io

### DIFF
--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -1109,7 +1109,7 @@ template <Direction DIR>
 bool ChildListIoStatementState<DIR>::AdvanceRecord(int n) {
 #if !defined(RT_DEVICE_AVOID_RECURSION)
   // Allow child NAMELIST input to advance
-  if (DIR == Direction::Input && this->mutableModes().inNamelist) {
+  if constexpr (DIR == Direction::Input) {
     return this->child().parent().AdvanceRecord(n);
   } else {
     return false;

--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -1108,7 +1108,7 @@ ChildListIoStatementState<DIR>::ChildListIoStatementState(
 template <Direction DIR>
 bool ChildListIoStatementState<DIR>::AdvanceRecord(int n) {
 #if !defined(RT_DEVICE_AVOID_RECURSION)
-  // Allow child NAMELIST input to advance
+  // Allow child list directed input to advance
   if constexpr (DIR == Direction::Input) {
     return this->child().parent().AdvanceRecord(n);
   } else {


### PR DESCRIPTION
Updates the runtime to allow record to advance whenever a child IO statement is trying to read past the end of a record.

Fixes: https://github.com/llvm/llvm-project/issues/154979

Doesn't help with: https://github.com/llvm/llvm-project/issues/154971 which is actually an issue with inferring child list IO edit descriptors when the source contains a "\\".

Added test in llvm-test-suite: https://github.com/llvm/llvm-test-suite/pull/281

