### PR TITLE
[LAA] Support assumptions with non-constant deref sizes.

### DIFF
--- a/llvm/lib/Analysis/Loads.cpp
+++ b/llvm/lib/Analysis/Loads.cpp
@@ -394,7 +394,8 @@ bool llvm::isDereferenceableAndAlignedInLoop(
              Base, Alignment,
              [&SE, AccessSizeSCEV, &LoopGuards](const RetainedKnowledge &RK) {
                return SE.isKnownPredicate(
-                   CmpInst::ICMP_ULE, AccessSizeSCEV,
+                   CmpInst::ICMP_ULE,
+                   SE.applyLoopGuards(AccessSizeSCEV, *LoopGuards),
                    SE.applyLoopGuards(SE.getSCEV(RK.IRArgValue), *LoopGuards));
              },
              DL, HeaderFirstNonPHI, AC, &DT) ||


### PR DESCRIPTION
Update evaluatePtrAddrecAtMaxBTCWillNotWrap to support non-constant sizes in dereferenceable assumptions.

Apply loop-guards in a few places needed to reason about expressions involving trip counts of the from (BTC - 1).