### PR TITLE
[lldb] Correct style of error messages

### DIFF
--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -208,7 +208,7 @@ void SBCommandInterpreter::HandleCommandsFromFile(
   LLDB_INSTRUMENT_VA(this, file, override_context, options, result);
 
   if (!IsValid()) {
-    result->AppendError("SBCommandInterpreter is not valid.");
+    result->AppendError("SBCommandInterpreter is not valid");
     return;
   }
 

--- a/lldb/source/Commands/CommandObjectBreakpoint.cpp
+++ b/lldb/source/Commands/CommandObjectBreakpoint.cpp
@@ -609,12 +609,12 @@ protected:
       const size_t num_files = m_options.m_filenames.GetSize();
       if (num_files == 0) {
         if (!GetDefaultFile(target, file, result)) {
-          result.AppendError("No file supplied and no default file available.");
+          result.AppendError("no file supplied and no default file available");
           return;
         }
       } else if (num_files > 1) {
-        result.AppendError("Only one file at a time is allowed for file and "
-                           "line breakpoints.");
+        result.AppendError("only one file at a time is allowed for file and "
+                           "line breakpoints");
         return;
       } else
         file = m_options.m_filenames.GetFileSpecAtIndex(0);
@@ -784,7 +784,7 @@ protected:
       }
       result.SetStatus(eReturnStatusSuccessFinishResult);
     } else if (!bp_sp) {
-      result.AppendError("Breakpoint creation failed: No breakpoint created.");
+      result.AppendError("breakpoint creation failed: no breakpoint created");
     }
   }
 
@@ -940,7 +940,7 @@ protected:
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
-      result.AppendError("No breakpoints exist to be enabled.");
+      result.AppendError("no breakpoints exist to be enabled");
       return;
     }
 
@@ -1048,7 +1048,7 @@ protected:
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
-      result.AppendError("No breakpoints exist to be disabled.");
+      result.AppendError("no breakpoints exist to be disabled");
       return;
     }
 
@@ -1224,7 +1224,7 @@ protected:
         }
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       } else {
-        result.AppendError("Invalid breakpoint ID.");
+        result.AppendError("invalid breakpoint ID");
       }
     }
   }
@@ -1318,7 +1318,7 @@ protected:
 
     // Early return if there's no breakpoint at all.
     if (num_breakpoints == 0) {
-      result.AppendError("Breakpoint clear: No breakpoint cleared.");
+      result.AppendError("breakpoint clear: no breakpoint cleared");
       return;
     }
 
@@ -1364,7 +1364,7 @@ protected:
       output_stream.EOL();
       result.SetStatus(eReturnStatusSuccessFinishNoResult);
     } else {
-      result.AppendError("Breakpoint clear: No breakpoint cleared.");
+      result.AppendError("breakpoint clear: no breakpoint cleared");
     }
   }
 
@@ -1459,7 +1459,7 @@ protected:
     size_t num_breakpoints = breakpoints.GetSize();
 
     if (num_breakpoints == 0) {
-      result.AppendError("No breakpoints exist to be deleted.");
+      result.AppendError("no breakpoints exist to be deleted");
       return;
     }
 
@@ -1504,7 +1504,7 @@ protected:
         }
       }
       if (valid_bp_ids.GetSize() == 0) {
-        result.AppendError("No disabled breakpoints.");
+        result.AppendError("no disabled breakpoints");
         return;
       }
     } else {
@@ -1712,7 +1712,7 @@ protected:
 
     const size_t argc = command.GetArgumentCount();
     if (argc == 0) {
-      result.AppendError("No names provided.");
+      result.AppendError("no names provided");
       return;
     }
 
@@ -1799,7 +1799,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (!m_name_options.m_name.OptionWasSet()) {
-      result.AppendError("No name option provided.");
+      result.AppendError("no name option provided");
       return;
     }
 
@@ -1813,7 +1813,7 @@ protected:
 
     size_t num_breakpoints = breakpoints.GetSize();
     if (num_breakpoints == 0) {
-      result.AppendError("No breakpoints, cannot add names.");
+      result.AppendError("no breakpoints, cannot add names");
       return;
     }
 
@@ -1825,7 +1825,7 @@ protected:
 
     if (result.Succeeded()) {
       if (valid_bp_ids.GetSize() == 0) {
-        result.AppendError("No breakpoints specified, cannot add names.");
+        result.AppendError("no breakpoints specified, cannot add names");
         return;
       }
       size_t num_valid_ids = valid_bp_ids.GetSize();
@@ -1873,7 +1873,7 @@ public:
 protected:
   void DoExecute(Args &command, CommandReturnObject &result) override {
     if (!m_name_options.m_name.OptionWasSet()) {
-      result.AppendError("No name option provided.");
+      result.AppendError("no name option provided");
       return;
     }
 
@@ -1887,7 +1887,7 @@ protected:
 
     size_t num_breakpoints = breakpoints.GetSize();
     if (num_breakpoints == 0) {
-      result.AppendError("No breakpoints, cannot delete names.");
+      result.AppendError("no breakpoints, cannot delete names");
       return;
     }
 
@@ -1899,7 +1899,7 @@ protected:
 
     if (result.Succeeded()) {
       if (valid_bp_ids.GetSize() == 0) {
-        result.AppendError("No breakpoints specified, cannot delete names.");
+        result.AppendError("no breakpoints specified, cannot delete names");
         return;
       }
       ConstString bp_name(m_name_options.m_name.GetCurrentValue());

--- a/lldb/source/Commands/CommandObjectCommands.cpp
+++ b/lldb/source/Commands/CommandObjectCommands.cpp
@@ -418,7 +418,7 @@ protected:
       if ((pos != std::string::npos) && (pos > 0))
         raw_command_string = raw_command_string.substr(pos);
     } else {
-      result.AppendError("Error parsing command string.  No alias created.");
+      result.AppendError("error parsing command string.  No alias created");
       return;
     }
 
@@ -2888,7 +2888,7 @@ protected:
     size_t num_args = command.GetArgumentCount();
 
     if (num_args == 0) {
-      result.AppendError("No command was specified.");
+      result.AppendError("no command was specified");
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -140,7 +140,7 @@ protected:
     } else {
       StopInfoSP stop_info_sp = thread->GetStopInfo();
       if (!stop_info_sp) {
-        result.AppendError("No arguments provided, and no stop info.");
+        result.AppendError("no arguments provided, and no stop info");
         return;
       }
 
@@ -148,7 +148,7 @@ protected:
     }
 
     if (!valobj_sp) {
-      result.AppendError("No diagnosis available.");
+      result.AppendError("no diagnosis available");
       return;
     }
 
@@ -310,7 +310,7 @@ protected:
           if (frame_idx == 0) {
             // If you are already at the bottom of the stack, then just warn
             // and don't reset the frame.
-            result.AppendError("Already at the bottom of the stack.");
+            result.AppendError("already at the bottom of the stack");
             return;
           } else
             frame_idx = 0;
@@ -335,7 +335,7 @@ protected:
             if (frame_idx == num_frames - 1) {
               // If we are already at the top of the stack, just warn and don't
               // reset the frame.
-              result.AppendError("Already at the top of the stack.");
+              result.AppendError("already at the top of the stack");
               return;
             } else
               frame_idx = num_frames - 1;

--- a/lldb/source/Commands/CommandObjectLog.cpp
+++ b/lldb/source/Commands/CommandObjectLog.cpp
@@ -547,7 +547,7 @@ protected:
         Timer::SetQuiet(!increment);
         result.SetStatus(eReturnStatusSuccessFinishNoResult);
       } else
-        result.AppendError("Could not convert increment value to boolean.");
+        result.AppendError("could not convert increment value to boolean");
     }
 
     if (!result.Succeeded()) {

--- a/lldb/source/Commands/CommandObjectMultiword.cpp
+++ b/lldb/source/Commands/CommandObjectMultiword.cpp
@@ -159,7 +159,7 @@ void CommandObjectMultiword::Execute(const char *args_string,
 
   auto sub_command = args[0].ref();
   if (sub_command.empty()) {
-    result.AppendError("Need to specify a non-empty subcommand.");
+    result.AppendError("need to specify a non-empty subcommand");
     return;
   }
 

--- a/lldb/source/Commands/CommandObjectProcess.cpp
+++ b/lldb/source/Commands/CommandObjectProcess.cpp
@@ -259,7 +259,7 @@ protected:
         if (!exe_module_sp)
           exe_module_sp = target->GetExecutableModule();
         if (!exe_module_sp) {
-          result.AppendWarning("Could not get executable module after launch.");
+          result.AppendWarning("could not get executable module after launch");
         } else {
 
           const char *archname =

--- a/lldb/source/Commands/CommandObjectSource.cpp
+++ b/lldb/source/Commands/CommandObjectSource.cpp
@@ -513,7 +513,7 @@ protected:
           "No selected frame to use to find the default source.");
       return false;
     } else if (!cur_frame->HasDebugInformation()) {
-      result.AppendError("No debug info for the selected frame.");
+      result.AppendError("no debug info for the selected frame");
       return false;
     } else {
       const SymbolContext &sc =
@@ -553,11 +553,11 @@ protected:
         }
       }
       if (!m_module_list.GetSize()) {
-        result.AppendError("No modules match the input.");
+        result.AppendError("no modules match the input");
         return;
       }
     } else if (target.GetImages().GetSize() == 0) {
-      result.AppendError("The target has no associated executable images.");
+      result.AppendError("the target has no associated executable images");
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -2420,7 +2420,7 @@ protected:
     result.GetErrorStream().SetAddressByteSize(addr_byte_size);
 
     if (command.GetArgumentCount() == 0) {
-      result.AppendError("file option must be specified.");
+      result.AppendError("file option must be specified");
       return;
     } else {
       // Dump specified images (by basename or fullpath)
@@ -3565,13 +3565,13 @@ protected:
 
     ThreadList threads(process->GetThreadList());
     if (threads.GetSize() == 0) {
-      result.AppendError("The process must be paused to use this command.");
+      result.AppendError("the process must be paused to use this command");
       return;
     }
 
     ThreadSP thread(threads.GetThreadAtIndex(0));
     if (!thread) {
-      result.AppendError("The process must be paused to use this command.");
+      result.AppendError("the process must be paused to use this command");
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectThread.cpp
+++ b/lldb/source/Commands/CommandObjectThread.cpp
@@ -1570,7 +1570,7 @@ protected:
     uint32_t frame_idx = frame_sp->GetFrameIndex();
 
     if (frame_sp->IsInlined()) {
-      result.AppendError("Don't know how to return from inlined frames.");
+      result.AppendError("don't know how to return from inlined frames");
       return;
     }
 

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -44,7 +44,7 @@ static bool CheckTargetForWatchpointOperations(Target &target,
   bool process_is_valid =
       target.GetProcessSP() && target.GetProcessSP()->IsAlive();
   if (!process_is_valid) {
-    result.AppendError("There's no process or it is not alive.");
+    result.AppendError("there's no process or it is not alive");
     return false;
   }
   // Target passes our checks, return true.
@@ -243,7 +243,7 @@ protected:
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
-        result.AppendError("Invalid watchpoints specification.");
+        result.AppendError("invalid watchpoints specification");
         return;
       }
 
@@ -298,7 +298,7 @@ protected:
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
-      result.AppendError("No watchpoints exist to be enabled.");
+      result.AppendError("no watchpoints exist to be enabled");
       return;
     }
 
@@ -314,7 +314,7 @@ protected:
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
-        result.AppendError("Invalid watchpoints specification.");
+        result.AppendError("invalid watchpoints specification");
         return;
       }
 
@@ -366,7 +366,7 @@ protected:
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
-      result.AppendError("No watchpoints exist to be disabled.");
+      result.AppendError("no watchpoints exist to be disabled");
       return;
     }
 
@@ -385,7 +385,7 @@ protected:
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
-        result.AppendError("Invalid watchpoints specification.");
+        result.AppendError("invalid watchpoints specification");
         return;
       }
 
@@ -476,7 +476,7 @@ protected:
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
-      result.AppendError("No watchpoints exist to be deleted.");
+      result.AppendError("no watchpoints exist to be deleted");
       return;
     }
 
@@ -500,7 +500,7 @@ protected:
     std::vector<uint32_t> wp_ids;
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                wp_ids)) {
-      result.AppendError("Invalid watchpoints specification.");
+      result.AppendError("invalid watchpoints specification");
       return;
     }
 
@@ -596,7 +596,7 @@ protected:
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
-      result.AppendError("No watchpoints exist to be ignored.");
+      result.AppendError("no watchpoints exist to be ignored");
       return;
     }
 
@@ -611,7 +611,7 @@ protected:
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
-        result.AppendError("Invalid watchpoints specification.");
+        result.AppendError("invalid watchpoints specification");
         return;
       }
 
@@ -715,7 +715,7 @@ protected:
     size_t num_watchpoints = watchpoints.GetSize();
 
     if (num_watchpoints == 0) {
-      result.AppendError("No watchpoints exist to be modified.");
+      result.AppendError("no watchpoints exist to be modified");
       return;
     }
 
@@ -728,7 +728,7 @@ protected:
       std::vector<uint32_t> wp_ids;
       if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(
               target, command, wp_ids)) {
-        result.AppendError("Invalid watchpoints specification.");
+        result.AppendError("invalid watchpoints specification");
         return;
       }
 

--- a/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpointCommand.cpp
@@ -376,7 +376,7 @@ protected:
     std::vector<uint32_t> valid_wp_ids;
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                valid_wp_ids)) {
-      result.AppendError("Invalid watchpoints specification.");
+      result.AppendError("invalid watchpoints specification");
       return;
     }
 
@@ -470,7 +470,7 @@ protected:
     std::vector<uint32_t> valid_wp_ids;
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                valid_wp_ids)) {
-      result.AppendError("Invalid watchpoints specification.");
+      result.AppendError("invalid watchpoints specification");
       return;
     }
 
@@ -525,7 +525,7 @@ protected:
     std::vector<uint32_t> valid_wp_ids;
     if (!CommandObjectMultiwordWatchpoint::VerifyWatchpointIDs(target, command,
                                                                valid_wp_ids)) {
-      result.AppendError("Invalid watchpoints specification.");
+      result.AppendError("invalid watchpoints specification");
       return;
     }
 

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -2078,7 +2078,7 @@ llvm::Expected<Value> DWARFExpression::Evaluate(
 
     case DW_OP_implicit_pointer: {
       dwarf4_location_description_kind = Implicit;
-      return llvm::createStringError("Could not evaluate %s.",
+      return llvm::createStringError("could not evaluate %s",
                                      DW_OP_value_to_name(op));
     }
 

--- a/lldb/source/Expression/DWARFExpressionList.cpp
+++ b/lldb/source/Expression/DWARFExpressionList.cpp
@@ -254,7 +254,7 @@ llvm::Expected<Value> DWARFExpressionList::Evaluate(
     }
 
     if (!pc.IsValid()) {
-      return llvm::createStringError("Invalid PC in frame.");
+      return llvm::createStringError("invalid PC in frame");
     }
     addr_t pc_load_addr = pc.GetLoadAddress(exe_ctx->GetTargetPtr());
     const DWARFExpression *entry =

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1802,13 +1802,13 @@ CommandObject *CommandInterpreter::BuildAliasResult(
 
         // Make sure we aren't going outside the bounds of the cmd string:
         if (strpos < start_fudge) {
-          result.AppendError("Unmatched quote at command beginning.");
+          result.AppendError("unmatched quote at command beginning");
           return nullptr;
         }
         llvm::StringRef arg_text = entry.ref();
         if (strpos - start_fudge + arg_text.size() + len_fudge >
             raw_input_string.size()) {
-          result.AppendError("Unmatched quote at command end.");
+          result.AppendError("unmatched quote at command end");
           return nullptr;
         }
         raw_input_string = raw_input_string.erase(
@@ -2091,7 +2091,7 @@ bool CommandInterpreter::HandleCommand(const char *command_line,
     command_string = command_line;
     original_command_string = command_line;
     if (m_repeat_command.empty()) {
-      result.AppendError("No auto repeat.");
+      result.AppendError("no auto repeat");
       return false;
     }
 

--- a/lldb/source/Interpreter/CommandObject.cpp
+++ b/lldb/source/Interpreter/CommandObject.cpp
@@ -217,7 +217,7 @@ bool CommandObject::CheckRequirements(CommandReturnObject &result) {
     if (process == nullptr) {
       // A process that is not running is considered paused.
       if (GetFlags().Test(eCommandProcessMustBeLaunched)) {
-        result.AppendError("Process must exist.");
+        result.AppendError("process must exist");
         return false;
       }
     } else {
@@ -236,7 +236,7 @@ bool CommandObject::CheckRequirements(CommandReturnObject &result) {
       case eStateExited:
       case eStateUnloaded:
         if (GetFlags().Test(eCommandProcessMustBeLaunched)) {
-          result.AppendError("Process must be launched.");
+          result.AppendError("process must be launched");
           return false;
         }
         break;
@@ -255,7 +255,7 @@ bool CommandObject::CheckRequirements(CommandReturnObject &result) {
   if (GetFlags().Test(eCommandProcessMustBeTraced)) {
     Target *target = m_exe_ctx.GetTargetPtr();
     if (target && !target->GetTrace()) {
-      result.AppendError("Process is not being traced.");
+      result.AppendError("process is not being traced");
       return false;
     }
   }

--- a/lldb/source/Interpreter/Options.cpp
+++ b/lldb/source/Interpreter/Options.cpp
@@ -1285,7 +1285,7 @@ llvm::Expected<Args> Options::Parse(const Args &args,
   Status error;
   Option *long_options = GetLongOptions();
   if (long_options == nullptr) {
-    return llvm::createStringError("Invalid long options.");
+    return llvm::createStringError("invalid long options");
   }
 
   std::string short_options = BuildShortOptions(long_options);

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -84,7 +84,7 @@ llvm::Expected<uint32_t> lldb_private::formatters::
     LibcxxStdVectorSyntheticFrontEnd::CalculateNumChildren() {
   if (!m_start || !m_finish)
     return llvm::createStringError(
-        "Failed to determine start/end of vector data.");
+        "failed to determine start/end of vector data");
 
   uint64_t start_val = m_start->GetValueAsUnsigned(0);
   uint64_t finish_val = m_finish->GetValueAsUnsigned(0);
@@ -94,18 +94,18 @@ llvm::Expected<uint32_t> lldb_private::formatters::
     return 0;
 
   if (start_val == 0)
-    return llvm::createStringError("Invalid value for start of vector.");
+    return llvm::createStringError("invalid value for start of vector");
 
   if (finish_val == 0)
-    return llvm::createStringError("Invalid value for end of vector.");
+    return llvm::createStringError("invalid value for end of vector");
 
   if (start_val > finish_val)
     return llvm::createStringError(
-        "Start of vector data begins after end pointer.");
+        "start of vector data begins after end pointer");
 
   size_t num_children = (finish_val - start_val);
   if (num_children % m_element_size)
-    return llvm::createStringError("Size not multiple of element size.");
+    return llvm::createStringError("size not multiple of element size");
 
   return num_children / m_element_size;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/MsvcStlVector.cpp
@@ -70,7 +70,7 @@ llvm::Expected<uint32_t> lldb_private::formatters::
     MsvcStlVectorSyntheticFrontEnd::CalculateNumChildren() {
   if (!m_start || !m_finish)
     return llvm::createStringError(
-        "Failed to determine start/end of vector data.");
+        "failed to determine start/end of vector data");
 
   uint64_t start_val = m_start->GetValueAsUnsigned(0);
   uint64_t finish_val = m_finish->GetValueAsUnsigned(0);
@@ -80,18 +80,18 @@ llvm::Expected<uint32_t> lldb_private::formatters::
     return 0;
 
   if (start_val == 0)
-    return llvm::createStringError("Invalid value for start of vector.");
+    return llvm::createStringError("invalid value for start of vector");
 
   if (finish_val == 0)
-    return llvm::createStringError("Invalid value for end of vector.");
+    return llvm::createStringError("invalid value for end of vector");
 
   if (start_val > finish_val)
     return llvm::createStringError(
-        "Start of vector data begins after end pointer.");
+        "start of vector data begins after end pointer");
 
   size_t num_children = (finish_val - start_val);
   if (num_children % m_element_size)
-    return llvm::createStringError("Size not multiple of element size.");
+    return llvm::createStringError("size not multiple of element size");
 
   return num_children / m_element_size;
 }

--- a/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
+++ b/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
@@ -295,7 +295,7 @@ class ParsedCommandTestCase(TestBase):
 
         # no-args turns off auto-repeat
         results = self.run_one_repeat("no-args\n\n", 1)
-        self.assertIn("No auto repeat", results, "Got auto-repeat error")
+        self.assertIn("no auto repeat", results, "Got auto-repeat error")
 
         # one-args does the normal repeat
         results = self.run_one_repeat("one-arg-no-opt ONE_ARG\n\n", 0)

--- a/lldb/test/API/commands/frame/select/TestFrameSelect.py
+++ b/lldb/test/API/commands/frame/select/TestFrameSelect.py
@@ -23,12 +23,12 @@ class TestFrameSelect(TestBase):
         self.expect(
             "frame select -r -1",
             error=True,
-            substrs=["Already at the bottom of the stack."],
+            substrs=["already at the bottom of the stack"],
         )
         self.expect(
             "frame select -r -2147483647",
             error=True,
-            substrs=["Already at the bottom of the stack."],
+            substrs=["already at the bottom of the stack"],
         )
         self.expect(
             "frame select -r -2147483648",
@@ -61,7 +61,7 @@ class TestFrameSelect(TestBase):
         self.expect(
             "frame select -r 1",
             error=True,
-            substrs=["Already at the top of the stack."],
+            substrs=["already at the top of the stack"],
         )
 
     @no_debug_info_test

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/TestDataFormatterLibcxxInvalidVectorSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/TestDataFormatterLibcxxInvalidVectorSimulator.py
@@ -21,21 +21,21 @@ class LibcxxInvalidVectorDataFormatterSimulatorTestCase(TestBase):
 
         self.expect(
             "frame variable v1",
-            substrs=["size=error: Invalid value for end of vector."],
+            substrs=["size=error: invalid value for end of vector"],
         )
         self.expect(
             "frame variable v2",
-            substrs=["size=error: Invalid value for start of vector."],
+            substrs=["size=error: invalid value for start of vector"],
         )
         self.expect(
             "frame variable v3",
-            substrs=["size=error: Start of vector data begins after end pointer."],
+            substrs=["size=error: start of vector data begins after end pointer"],
         )
         self.expect(
             "frame variable v4",
-            substrs=["size=error: Failed to determine start/end of vector data."],
+            substrs=["size=error: failed to determine start/end of vector data"],
         )
         self.expect(
             "frame variable v5",
-            substrs=["size=error: Size not multiple of element size."],
+            substrs=["size=error: size not multiple of element size"],
         )

--- a/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashingStep.py
+++ b/lldb/test/API/functionalities/inferior-crashing/TestInferiorCrashingStep.py
@@ -201,7 +201,7 @@ class CrashingInferiorStepTestCase(TestBase):
         self.expect("next", substrs=["Process", expected_state])
 
         if expected_state == "exited":
-            self.expect("thread list", error=True, substrs=["Process must be launched"])
+            self.expect("thread list", error=True, substrs=["process must be launched"])
         else:
             self.check_stop_reason()
 

--- a/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
+++ b/lldb/test/API/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferiorStep.py
@@ -98,7 +98,7 @@ class CrashingRecursiveInferiorStepTestCase(TestBase):
         self.expect("next", substrs=["Process", expected_state])
 
         if expected_state == "exited":
-            self.expect("thread list", error=True, substrs=["Process must be launched"])
+            self.expect("thread list", error=True, substrs=["process must be launched"])
         else:
             self.check_stop_reason()
 

--- a/lldb/test/API/functionalities/multiword-commands/TestMultiWordCommands.py
+++ b/lldb/test/API/functionalities/multiword-commands/TestMultiWordCommands.py
@@ -26,5 +26,5 @@ class MultiwordCommandsTestCase(TestBase):
         self.expect(
             'platform ""',
             error=True,
-            substrs=["Need to specify a non-empty subcommand."],
+            substrs=["need to specify a non-empty subcommand"],
         )

--- a/lldb/test/API/python_api/interpreter/TestRunCommandInterpreterAPI.py
+++ b/lldb/test/API/python_api/interpreter/TestRunCommandInterpreterAPI.py
@@ -105,7 +105,7 @@ class CommandRunInterpreterAPICase(TestBase):
         self.assertFalse(has_crashed)
 
         self.assertIn("invalid target", result_str)
-        self.assertIn("No auto repeat", result_str)
+        self.assertIn("no auto repeat", result_str)
 
 
 class SBCommandInterpreterRunOptionsCase(TestBase):

--- a/lldb/unittests/API/SBCommandInterpreterTest.cpp
+++ b/lldb/unittests/API/SBCommandInterpreterTest.cpp
@@ -60,7 +60,7 @@ TEST_F(SBCommandInterpreterTest, SingleWordCommand) {
     SBCommandReturnObject result;
     interp.HandleCommand("", result);
     EXPECT_FALSE(result.Succeeded());
-    EXPECT_STREQ(result.GetError(), "error: No auto repeat.\n");
+    EXPECT_STREQ(result.GetError(), "error: no auto repeat\n");
   }
 
   // Now we test a command with autorepeat
@@ -98,7 +98,7 @@ TEST_F(SBCommandInterpreterTest, MultiWordCommand) {
     SBCommandReturnObject result;
     interp.HandleCommand("", result);
     EXPECT_FALSE(result.Succeeded());
-    EXPECT_STREQ(result.GetError(), "error: No auto repeat.\n");
+    EXPECT_STREQ(result.GetError(), "error: no auto repeat\n");
   }
 
   // We first test a subcommand with autorepeat


### PR DESCRIPTION
The LLVM Style Guide says the following about error and warning messages [1]:

> [T]o match error message styles commonly produced by other tools,
> start the first sentence with a lowercase letter, and finish the last
> sentence without a period, if it would end in one otherwise.

I often provide this feedback during code review, but we still have a bunch of places where we have inconsistent error message, which bothers me as a user. This PR identifies a handful of those places and updates the messages to be consistent.

[1] https://llvm.org/docs/CodingStandards.html#error-and-warning-messages