### PR TITLE
[libc][NFC] disable localtime on aarch64/baremetal

### DIFF
--- a/libc/config/baremetal/aarch64/entrypoints.txt
+++ b/libc/config/baremetal/aarch64/entrypoints.txt
@@ -269,8 +269,9 @@ set(TARGET_LIBC_ENTRYPOINTS
     libc.src.time.difftime
     libc.src.time.gmtime
     libc.src.time.gmtime_r
-    libc.src.time.localtime
-    libc.src.time.localtime_r
+    # TODO: Re-enable these when tests aren't broken.
+    # libc.src.time.localtime
+    # libc.src.time.localtime_r
     libc.src.time.mktime
     libc.src.time.strftime
     libc.src.time.strftime_l


### PR DESCRIPTION
The fuchsia builder was broken by https://github.com/llvm/llvm-project/pull/110363
This patch disables localtime for aarch64 baremetal, which is the
failing target.

Context: https://lab.llvm.org/buildbot/#/builders/11/builds/23186
