### PR TITLE
[libc++][test] Get rid of warning on macOS about undefined macro

### DIFF
--- a/libcxx/test/extensions/clang/thread/thread.mutex/lock.verify.cpp
+++ b/libcxx/test/extensions/clang/thread/thread.mutex/lock.verify.cpp
@@ -31,7 +31,7 @@ void f1() {
 } // expected-warning {{mutex 'm0' is still held at the end of function}} \
      expected-warning {{mutex 'm1' is still held at the end of function}}
 
-#if TEST_STD_VER >= 11 && TEST_CLANG_VER >= 2101
+#if TEST_STD_VER >= 11 && defined(TEST_CLANG_VER) && TEST_CLANG_VER >= 2101
 void f2() {
   std::lock(m0, m1, m2);
 } // expected-warning {{mutex 'm0' is still held at the end of function}} \


### PR DESCRIPTION
`TEST_CLANG_VER` is not defined for Apple Clang, so it's better to detect whether the macro is defined to get rid of warnings due to `-Wundef`. This also corresponds to the guard in `<mutex>`.