### PR TITLE
[NFC][libclc] Set MACRO_ARCH to ${ARCH} uncondionally before customizing

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -394,6 +394,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 
     message( STATUS "  device: ${d} ( ${${d}_aliases} )" )
 
+    set( MACRO_ARCH ${ARCH} )
     if ( ARCH STREQUAL spirv OR ARCH STREQUAL spirv64 )
       set( build_flags -O0 -finline-hint-functions -DCLC_SPIRV )
       set( opt_flags )
@@ -412,7 +413,6 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     else()
       set( build_flags )
       set( opt_flags -O3 )
-      set( MACRO_ARCH ${ARCH} )
     endif()
 
     set( LIBCLC_ARCH_OBJFILE_DIR "${LIBCLC_OBJFILE_DIR}/${arch_suffix}" )


### PR DESCRIPTION
Our downstream libclc add a few more targets that customizes build_flags and opt_flags. Then in each customization block, MACRO_ARCH is defined to be ${ARCH}.
Hoisting MACRO_ARCH definition out of if-else-end block avoids code duplication. This also avoids potential error when MACRO_ARCH definition is forgotten, e.g. in https://github.com/intel/llvm/pull/19971.