### PR TITLE
[orc-rt] Fix memory leak in WrapperFunctionResult.

### DIFF
--- a/orc-rt/include/orc-rt/WrapperFunctionResult.h
+++ b/orc-rt/include/orc-rt/WrapperFunctionResult.h
@@ -40,10 +40,9 @@ public:
   }
 
   WrapperFunctionResult &operator=(WrapperFunctionResult &&Other) {
-    orc_rt_WrapperFunctionResult Tmp;
-    orc_rt_WrapperFunctionResultInit(&Tmp);
-    std::swap(Tmp, Other.R);
-    std::swap(R, Tmp);
+    orc_rt_DisposeWrapperFunctionResult(&R);
+    orc_rt_WrapperFunctionResultInit(&R);
+    std::swap(R, Other.R);
     return *this;
   }
 


### PR DESCRIPTION
Previously `Tmp` could have been left owning a heap-allocated buffer and would not have freed it on destruction (since Tmp was a C orc_rt_WrapperFunctionResult).

This patch removes Tmp and simply resets R before swapping it with Other.R.