### PR TITLE
[ADT] Simplify EnumeratedArray::operator[] (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/EnumeratedArray.h
+++ b/llvm/include/llvm/ADT/EnumeratedArray.h
@@ -57,8 +57,7 @@ public:
   }
   ValueType &operator[](Enumeration Index) {
     return const_cast<ValueType &>(
-        static_cast<const EnumeratedArray<ValueType, Enumeration, LargestEnum,
-                                          IndexType, Size> &>(*this)[Index]);
+        static_cast<const EnumeratedArray &>(*this)[Index]);
   }
   IndexType size() const { return Size; }
   bool empty() const { return size() == 0; }


### PR DESCRIPTION
This patch simplifies EnumeratedArray::operator[] with the
injected-class-name.
