### PR TITLE
[Support] Make shouldReverseIterate constexpr

### DIFF
--- a/llvm/include/llvm/Support/ReverseIteration.h
+++ b/llvm/include/llvm/Support/ReverseIteration.h
@@ -6,13 +6,11 @@
 
 namespace llvm {
 
-template<class T = void *>
-bool shouldReverseIterate() {
-#if LLVM_ENABLE_REVERSE_ITERATION
-  return detail::IsPointerLike<T>::value;
-#else
-  return false;
-#endif
+template <class T = void *> constexpr bool shouldReverseIterate() {
+  if constexpr (LLVM_ENABLE_REVERSE_ITERATION)
+    return detail::IsPointerLike<T>::value;
+  else
+    return false;
 }
 
 } // namespace llvm

--- a/llvm/include/llvm/Support/ReverseIteration.h
+++ b/llvm/include/llvm/Support/ReverseIteration.h
@@ -7,10 +7,11 @@
 namespace llvm {
 
 template <class T = void *> constexpr bool shouldReverseIterate() {
-  if constexpr (LLVM_ENABLE_REVERSE_ITERATION)
-    return detail::IsPointerLike<T>::value;
-  else
-    return false;
+#if LLVM_ENABLE_REVERSE_ITERATION
+  return detail::IsPointerLike<T>::value;
+#else
+  return false;
+#endif
 }
 
 } // namespace llvm


### PR DESCRIPTION
This patch makes shouldReverseIterate constexpr, allowing compile-time
evaluation at call sites.
