### PR TITLE
release/21.x: [clang][docs] Fix implicit-int-conversion-on-negation typos

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -677,8 +677,8 @@ Improvements to Clang's diagnostics
   trigger a ``'Blue' is deprecated`` warning, which can be turned off with
   ``-Wno-deprecated-declarations-switch-case``.
 
-- Split diagnosis of implicit integer comparison on negation to a new
-  diagnostic group ``-Wimplicit-int-comparison-on-negation``, grouped under
+- Split diagnosis of implicit integer conversion on negation to a new
+  diagnostic group ``-Wimplicit-int-conversion-on-negation``, grouped under
   ``-Wimplicit-int-conversion``, so user can turn it off independently.
 
 - Improved the FixIts for unused lambda captures.


### PR DESCRIPTION
References to `-Wimplicit-int-comparison-on-negation` should be `-Wimplicit-int-conversion-on-negation` instead.

See: https://github.com/llvm/llvm-project/pull/139429/files#r2124372667