### PR TITLE
Document Policy on supporting newer C++ standard in LLVM codebase

### DIFF
--- a/llvm/docs/CMake.rst
+++ b/llvm/docs/CMake.rst
@@ -280,8 +280,8 @@ explanation and LLVM-related notes.  For full documentation, consult the CMake
 manual, or execute ``cmake --help-variable VARIABLE_NAME``.
 
 **CMAKE_CXX_STANDARD**:STRING
-  Sets the C++ standard to conform to when building LLVM.  Possible values are
-  17 and 20.  LLVM requires C++17 or higher.  This defaults to 17.
+  Sets the C++ standard to conform to when building LLVM.
+  LLVM requires C++17 or higher.  This defaults to 17.
 
 **CMAKE_INSTALL_BINDIR**:PATH
   The path to install executables, relative to the *CMAKE_INSTALL_PREFIX*.

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -78,7 +78,7 @@ Each toolchain provides a good reference for what it accepts:
 Additionally, there are compiler comparison tables of supported C++ features on
 `cppreference.com <https://en.cppreference.com/w/cpp/compiler_support/17>`_.
 
-To keep track with the evolution of the standard, newer C++ version can be used
+To keep track with the evolution of the standard, newer C++ versions can be used
 to build LLVM. However, our support focuses on the minimum supported C++
 version and a very recent standard may not yet be supported, or only using the
 latest version of the supported toolchains and possibly not across all the

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -78,6 +78,12 @@ Each toolchain provides a good reference for what it accepts:
 Additionally, there are compiler comparison tables of supported C++ features on
 `cppreference.com <https://en.cppreference.com/w/cpp/compiler_support/17>`_.
 
+To keep track with the evolution of the standard, newer C++ version can be used
+to build LLVM. However, our support focuses on the minimum supported C++
+version and a very recent standard may not be yet supported, or only using the
+latest version of the supported toolchains and possibly not across all the
+subprojects.
+
 
 C++ Standard Library
 --------------------

--- a/llvm/docs/CodingStandards.rst
+++ b/llvm/docs/CodingStandards.rst
@@ -80,7 +80,7 @@ Additionally, there are compiler comparison tables of supported C++ features on
 
 To keep track with the evolution of the standard, newer C++ version can be used
 to build LLVM. However, our support focuses on the minimum supported C++
-version and a very recent standard may not be yet supported, or only using the
+version and a very recent standard may not yet be supported, or only using the
 latest version of the supported toolchains and possibly not across all the
 subprojects.
 


### PR DESCRIPTION
See RFC: https://discourse.llvm.org/t/policy-on-supporting-newer-c-standard-in-llvm-codebase/88114