### PR TITLE
[DAG][ARM] canCreateUndefOrPoisonForTargetNode - ARMISD VORRIMM\VBICIMM nodes can't create poison/undef

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelLowering.cpp
+++ b/llvm/lib/Target/ARM/ARMISelLowering.cpp
@@ -21363,6 +21363,19 @@ bool ARMTargetLowering::canCombineStoreAndExtract(Type *VectorTy, Value *Idx,
   return false;
 }
 
+bool ARMTargetLowering::canCreateUndefOrPoisonForTargetNode(
+    SDValue Op, const APInt &DemandedElts, const SelectionDAG &DAG,
+    bool PoisonOnly, bool ConsiderFlags, unsigned Depth) const {
+  unsigned Opcode = Op.getOpcode();
+  switch (Opcode) {
+  case ARMISD::VORRIMM:
+  case ARMISD::VBICIMM:
+    return false;
+  }
+  return TargetLowering::canCreateUndefOrPoisonForTargetNode(
+      Op, DemandedElts, DAG, PoisonOnly, ConsiderFlags, Depth);
+}
+
 bool ARMTargetLowering::isCheapToSpeculateCttz(Type *Ty) const {
   return Subtarget->hasV5TOps() && !Subtarget->isThumb1Only();
 }

--- a/llvm/lib/Target/ARM/ARMISelLowering.h
+++ b/llvm/lib/Target/ARM/ARMISelLowering.h
@@ -707,6 +707,10 @@ class VectorType;
     bool canCombineStoreAndExtract(Type *VectorTy, Value *Idx,
                                    unsigned &Cost) const override;
 
+    bool canCreateUndefOrPoisonForTargetNode(
+        SDValue Op, const APInt &DemandedElts, const SelectionDAG &DAG,
+        bool PoisonOnly, bool ConsiderFlags, unsigned Depth) const override;
+
     bool canMergeStoresTo(unsigned AddressSpace, EVT MemVT,
                           const MachineFunction &MF) const override {
       // Do not merge to larger than i32.

--- a/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
@@ -106,6 +106,19 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VORRIMM) {
   KnownBits Known = DAG->computeKnownBits(Op, DemandedElts);
   EXPECT_EQ(Known.One, APInt(32, 0xAA));
   EXPECT_EQ(Known.Zero, APInt(32, 0x0));
+
+  // LHS(per-lane)     = 00000000 00000000 00000000 00000000  (0x00000000)
+  // Encoded(per-lane) = 00000000 00000000 00000000 10101010  (0x000000AA)
+  //  =>
+  // Known.One  = 00000000 00000000 00000000 10101010  (0x000000AA)
+  // Known.Zero = 11111111 11111111 11111111 01010101  (0x00000000)
+  SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
+  SDValue ZeroVec = DAG->getSplatBuildVector(VT, DL, Zero);
+  Op = DAG->getNode(ARMISD::VORRIMM, DL, VT, ZeroVec, EncSD);
+  auto FrVORRIMM = DAG->getFreeze(Op);
+  Known = DAG->computeKnownBits(FrVORRIMM);
+  EXPECT_EQ(Known.One, APInt(32, 0xAA));
+  EXPECT_EQ(Known.Zero, APInt(32, 0xFFFFFF55));
 }
 
 /// VBIC (immediate): x & ~imm with 32-bit elements.
@@ -127,6 +140,11 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VBICIMM) {
   // Known.Zero = 00000000 00000000 00000000 10101010  (0x000000AA)
   APInt DemandedElts = APInt::getAllOnes(4);
   KnownBits Known = DAG->computeKnownBits(Op, DemandedElts);
+  EXPECT_EQ(Known.One, APInt(32, 0xFFFFFF55));
+  EXPECT_EQ(Known.Zero, APInt(32, 0x000000AA));
+
+  auto FrVBICIMM = DAG->getFreeze(Op);
+  Known = DAG->computeKnownBits(FrVBICIMM);
   EXPECT_EQ(Known.One, APInt(32, 0xFFFFFF55));
   EXPECT_EQ(Known.Zero, APInt(32, 0x000000AA));
 }

--- a/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
+++ b/llvm/unittests/Target/ARM/ARMSelectionDAGTest.cpp
@@ -115,7 +115,7 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VORRIMM) {
   SDValue Zero = DAG->getConstant(0, DL, MVT::i32);
   SDValue ZeroVec = DAG->getSplatBuildVector(VT, DL, Zero);
   Op = DAG->getNode(ARMISD::VORRIMM, DL, VT, ZeroVec, EncSD);
-  auto FrVORRIMM = DAG->getFreeze(Op);
+  SDValue FrVORRIMM = DAG->getFreeze(Op);
   Known = DAG->computeKnownBits(FrVORRIMM);
   EXPECT_EQ(Known.One, APInt(32, 0xAA));
   EXPECT_EQ(Known.Zero, APInt(32, 0xFFFFFF55));
@@ -143,7 +143,7 @@ TEST_F(ARMSelectionDAGTest, computeKnownBits_VBICIMM) {
   EXPECT_EQ(Known.One, APInt(32, 0xFFFFFF55));
   EXPECT_EQ(Known.Zero, APInt(32, 0x000000AA));
 
-  auto FrVBICIMM = DAG->getFreeze(Op);
+  SDValue FrVBICIMM = DAG->getFreeze(Op);
   Known = DAG->computeKnownBits(FrVBICIMM);
   EXPECT_EQ(Known.One, APInt(32, 0xFFFFFF55));
   EXPECT_EQ(Known.Zero, APInt(32, 0x000000AA));


### PR DESCRIPTION
### Summary
This PR resolves https://github.com/llvm/llvm-project/issues/156640