### PR TITLE
[Dexter] Only increment step index if we record the step

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ConditionalController.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DebuggerControllers/ConditionalController.py
@@ -268,7 +268,6 @@ class ConditionalController(DebuggerControllerBase):
             step_info = self.debugger.get_step_info(self._watches, self._step_index)
             backtrace = None
             if step_info.current_frame:
-                self._step_index += 1
                 backtrace = [f.function for f in step_info.frames]
 
             record_step = False
@@ -369,6 +368,7 @@ class ConditionalController(DebuggerControllerBase):
                         step_function_backtraces.pop()
 
             if record_step and step_info.current_frame:
+                self._step_index += 1
                 # Record the step.
                 update_step_watches(
                     step_info, self._watches, self.step_collection.commands

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex-continue.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex-continue.cpp
@@ -59,6 +59,6 @@ int main() {
 // CHECK-NEXT: .   .   .   [4, "c(int)", "{{.*}}dex-continue.cpp", 19, 3, "StopReason.BREAKPOINT", "StepKind.VERTICAL_FORWARD", []]
 // CHECK-NEXT: .   .   .   [5, "c(int)", "{{.*}}dex-continue.cpp", 20, 3, "StopReason.BREAKPOINT", "StepKind.VERTICAL_FORWARD", []]
 // CHECK-NEXT: .   [6, "a(int)", "{{.*}}dex-continue.cpp", 33, 3, "StopReason.BREAKPOINT", "StepKind.VERTICAL_FORWARD", []]
-// CHECK-NEXT: .   [8, "f()", "{{.*}}dex-continue.cpp", 38, 3, "StopReason.BREAKPOINT", "StepKind.VERTICAL_FORWARD", []]
-// CHECK-NEXT: .   [9, "f()", "{{.*}}dex-continue.cpp", 39, 1, "StopReason.STEP", "StepKind.VERTICAL_FORWARD", []]
+// CHECK-NEXT: .   [7, "f()", "{{.*}}dex-continue.cpp", 38, 3, "StopReason.BREAKPOINT", "StepKind.VERTICAL_FORWARD", []]
+// CHECK-NEXT: .   [8, "f()", "{{.*}}dex-continue.cpp", 39, 1, "StopReason.STEP", "StepKind.VERTICAL_FORWARD", []]
 // CHECK-NEXT: ## END (9 steps) ##

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex_step_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex_step_function.cpp
@@ -35,5 +35,5 @@ int main() {
 // CHECK-NEXT:.   [1, "a(int)", "{{.*}}dex_step_function.cpp", 23, 12, "StopReason.STEP", "StepKind.VERTICAL_FORWARD", []]
 // CHECK-NEXT:.   .   .   [2, "c(int)", "{{.*}}dex_step_function.cpp", 12, 3, "StopReason.BREAKPOINT", "StepKind.FUNC", []]
 // CHECK-NEXT:.   .   .   [3, "c(int)", "{{.*}}dex_step_function.cpp", 13, 3, "StopReason.STEP", "StepKind.VERTICAL_FORWARD", []]
-// CHECK-NEXT:.   [6, "a(int)", "{{.*}}dex_step_function.cpp", 23, 3, "StopReason.STEP", "StepKind.HORIZONTAL_BACKWARD", []]
+// CHECK-NEXT:.   [4, "a(int)", "{{.*}}dex_step_function.cpp", 23, 3, "StopReason.STEP", "StepKind.HORIZONTAL_BACKWARD", []]
 // CHECK-NEXT: ## END (5 steps) ##


### PR DESCRIPTION
Should fix the issue raised here - https://github.com/llvm/llvm-project/pull/156481#issuecomment-3251158052 

Prior to this patch we incremented step_index every time the debugger stopped. Now that some stops are not recorded, we should only increment the step_index for those that are.

This should make the `-v` output more consistent between platforms and debuggers.