### PR TITLE
Fix incorrect array initialization with string literal (fixes #112189)

### DIFF
--- a/clang/test/SemaCXX/GH112189.cpp
+++ b/clang/test/SemaCXX/GH112189.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -verify %s
+// expected-no-diagnostics
+
+template<unsigned int SPACE>
+char foo_choose() {
+  char buffer[SPACE] {__builtin_choose_expr(6, "foo", "boo")};
+  return buffer[0];
+}
+
+int boro_choose()
+{
+  int r = foo_choose<10>();
+  r += foo_choose<100>();
+  return r + foo_choose<4>();
+}
+
+template<unsigned int SPACE>
+char foo_gen_ext() {
+  char buffer[SPACE] {__extension__ (_Generic(0, int: (__extension__ "foo" )))};
+  return buffer[0];
+}
+
+int boro_gen_ext()
+{
+  int r = foo_gen_ext<10>();
+  r += foo_gen_ext<100>();
+  return r + foo_gen_ext<4>();
+}
+
+template<unsigned int SPACE>
+char foo_paren_predef() {
+  char buffer[SPACE] {(((__FILE__)))};
+  return buffer[0];
+}
+
+int boro_paren_predef()
+{
+  int r = foo_paren_predef<200000>();
+  r += foo_paren_predef<300000>();
+  return r + foo_paren_predef<100000>();
+}


### PR DESCRIPTION
Following [the suggestion of @zygoloid](https://github.com/llvm/llvm-project/issues/112189#issuecomment-3172788105) `updateStringLiteralType` now recursively clones subexpressions which types it modifies.

Done as a separate static function and not inlined directly into the `updateStringLiteralType` function for maintainability.

I probably should have done this for the dependent case only, but the function is buried deep in the call stack and I didn't bother.

Fixes #112189