### PR TITLE
[AVR] Remove some custom decoder functions (NFCI)

### DIFF
--- a/llvm/lib/Target/AVR/AVRInstrFormats.td
+++ b/llvm/lib/Target/AVR/AVRInstrFormats.td
@@ -128,8 +128,6 @@ class FRd<bits<4> opcode, bits<7> f, dag outs, dag ins, string asmstr,
   let Inst{11 - 9} = f{6 - 4};
   let Inst{8 - 4} = rd;
   let Inst{3 - 0} = f{3 - 0};
-
-  let DecoderMethod = "decodeFRd";
 }
 
 //===----------------------------------------------------------------------===//
@@ -308,8 +306,6 @@ class FIORdA<dag outs, dag ins, string asmstr, list<dag> pattern>
   let Inst{10 - 9} = A{5 - 4};
   let Inst{8 - 4} = rd;
   let Inst{3 - 0} = A{3 - 0};
-
-  let DecoderMethod = "decodeFIORdA";
 }
 
 //===----------------------------------------------------------------------===//
@@ -327,8 +323,6 @@ class FIOARr<dag outs, dag ins, string asmstr, list<dag> pattern>
   let Inst{10 - 9} = A{5 - 4};
   let Inst{8 - 4} = rr;
   let Inst{3 - 0} = A{3 - 0};
-
-  let DecoderMethod = "decodeFIOARr";
 }
 
 //===----------------------------------------------------------------------===//
@@ -343,17 +337,10 @@ class FIOBIT<bits<2> t, dag outs, dag ins, string asmstr, list<dag> pattern>
   bits<5> addr;
   bits<3> b;
 
-  let Inst{15 - 12} = 0b1001;
-
-  let Inst{11 - 10} = 0b10;
+  let Inst{15 - 10} = 0b100110;
   let Inst{9 - 8} = t;
-
-  let Inst{7 - 4} = addr{4 - 1};
-
-  let Inst{3} = addr{0};
+  let Inst{7 - 3} = addr;
   let Inst{2 - 0} = b{2 - 0};
-
-  let DecoderMethod = "decodeFIOBIT";
 }
 
 //===----------------------------------------------------------------------===//
@@ -412,8 +399,6 @@ class FBRsk<bit f, bits<3> s, dag outs, dag ins, string asmstr,
   let Inst{10} = f;
   let Inst{9 - 3} = k;
   let Inst{2 - 0} = s;
-
-  let DecoderMethod = "decodeCondBranch";
 }
 
 //===----------------------------------------------------------------------===//
@@ -437,8 +422,6 @@ class FBRk<bit f, dag outs, dag ins, string asmstr, list<dag> pattern>
   let Inst{15 - 13} = 0b110;
   let Inst{12} = f;
   let Inst{11 - 0} = k;
-
-  let DecoderMethod = "decodeFBRk";
 }
 
 //===----------------------------------------------------------------------===//
@@ -532,14 +515,8 @@ class FSK<bit f, dag outs, dag ins, string asmstr, list<dag> pattern>
 
   let Inst{11} = 0;
   let Inst{10} = f;
-  let Inst{9 - 8} = k{6 - 5};
-
-  let Inst{7 - 4} = k{4 - 1};
-
-  let Inst{3} = k{0};
+  let Inst{9 - 3} = k;
   let Inst{2 - 0} = s;
-
-  let DecoderMethod = "decodeCondBranch";
 }
 
 class ExtensionPseudo<dag outs, dag ins, string asmstr, list<dag> pattern>

--- a/llvm/lib/Target/AVR/AVRInstrInfo.td
+++ b/llvm/lib/Target/AVR/AVRInstrInfo.td
@@ -204,16 +204,19 @@ def memspi : Operand<iPTR> {
 def relbrtarget_7 : Operand<OtherVT> {
   let PrintMethod = "printPCRelImm";
   let EncoderMethod = "encodeRelCondBrTarget<AVR::fixup_7_pcrel>";
+  let DecoderMethod = "decodeRelCondBrTarget7";
 }
 
 def brtarget_13 : Operand<OtherVT> {
   let PrintMethod = "printPCRelImm";
   let EncoderMethod = "encodeRelCondBrTarget<AVR::fixup_13_pcrel>";
+  let DecoderMethod = "decodeRelCondBrTarget13";
 }
 
 def rcalltarget_13 : Operand<i16> {
   let PrintMethod = "printPCRelImm";
   let EncoderMethod = "encodeRelCondBrTarget<AVR::fixup_13_pcrel>";
+  let DecoderMethod = "decodeRelCondBrTarget13";
 }
 
 // The target of a 22 or 16-bit call/jmp instruction.

--- a/llvm/lib/Target/AVR/Disassembler/AVRDisassembler.cpp
+++ b/llvm/lib/Target/AVR/Disassembler/AVRDisassembler.cpp
@@ -97,41 +97,6 @@ static DecodeStatus DecodeZREGRegisterClass(MCInst &Inst,
   return MCDisassembler::Success;
 }
 
-static DecodeStatus decodeFIOARr(MCInst &Inst, unsigned Insn, uint64_t Address,
-                                 const MCDisassembler *Decoder) {
-  unsigned addr = 0;
-  addr |= fieldFromInstruction(Insn, 0, 4);
-  addr |= fieldFromInstruction(Insn, 9, 2) << 4;
-  unsigned reg = fieldFromInstruction(Insn, 4, 5);
-  Inst.addOperand(MCOperand::createImm(addr));
-  if (DecodeGPR8RegisterClass(Inst, reg, Address, Decoder) ==
-      MCDisassembler::Fail)
-    return MCDisassembler::Fail;
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus decodeFIORdA(MCInst &Inst, unsigned Insn, uint64_t Address,
-                                 const MCDisassembler *Decoder) {
-  unsigned addr = 0;
-  addr |= fieldFromInstruction(Insn, 0, 4);
-  addr |= fieldFromInstruction(Insn, 9, 2) << 4;
-  unsigned reg = fieldFromInstruction(Insn, 4, 5);
-  if (DecodeGPR8RegisterClass(Inst, reg, Address, Decoder) ==
-      MCDisassembler::Fail)
-    return MCDisassembler::Fail;
-  Inst.addOperand(MCOperand::createImm(addr));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus decodeFIOBIT(MCInst &Inst, unsigned Insn, uint64_t Address,
-                                 const MCDisassembler *Decoder) {
-  unsigned addr = fieldFromInstruction(Insn, 3, 5);
-  unsigned b = fieldFromInstruction(Insn, 0, 3);
-  Inst.addOperand(MCOperand::createImm(addr));
-  Inst.addOperand(MCOperand::createImm(b));
-  return MCDisassembler::Success;
-}
-
 static DecodeStatus decodeCallTarget(MCInst &Inst, unsigned Field,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
@@ -141,12 +106,17 @@ static DecodeStatus decodeCallTarget(MCInst &Inst, unsigned Field,
   return MCDisassembler::Success;
 }
 
-static DecodeStatus decodeFRd(MCInst &Inst, unsigned Insn, uint64_t Address,
-                              const MCDisassembler *Decoder) {
-  unsigned d = fieldFromInstruction(Insn, 4, 5);
-  if (DecodeGPR8RegisterClass(Inst, d, Address, Decoder) ==
-      MCDisassembler::Fail)
-    return MCDisassembler::Fail;
+static DecodeStatus decodeRelCondBrTarget7(MCInst &Inst, unsigned Field,
+                                           uint64_t Address,
+                                           const MCDisassembler *Decoder) {
+  Inst.addOperand(MCOperand::createImm(SignExtend32(Field, 7) << 1));
+  return MCDisassembler::Success;
+}
+
+static DecodeStatus decodeRelCondBrTarget13(MCInst &Inst, unsigned Field,
+                                            uint64_t Address,
+                                            const MCDisassembler *Decoder) {
+  Inst.addOperand(MCOperand::createImm(SignExtend32(Field, 12) << 1));
   return MCDisassembler::Success;
 }
 
@@ -221,59 +191,6 @@ static DecodeStatus decodeMemri(MCInst &Inst, unsigned Insn, uint64_t Address,
       MCOperand::createReg((Insn & 0x40) ? AVR::R29R28 : AVR::R31R30));
   // Append the immediate offset operand.
   Inst.addOperand(MCOperand::createImm(Insn & 0x3f));
-
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus decodeFBRk(MCInst &Inst, unsigned Insn, uint64_t Address,
-                               const MCDisassembler *Decoder) {
-  // Decode the opcode.
-  switch (Insn & 0xf000) {
-  case 0xc000:
-    Inst.setOpcode(AVR::RJMPk);
-    break;
-  case 0xd000:
-    Inst.setOpcode(AVR::RCALLk);
-    break;
-  default: // Unknown relative branch instruction.
-    return MCDisassembler::Fail;
-  }
-  // Decode the relative offset.
-  int16_t Offset = ((int16_t)((Insn & 0xfff) << 4)) >> 3;
-  Inst.addOperand(MCOperand::createImm(Offset));
-  return MCDisassembler::Success;
-}
-
-static DecodeStatus decodeCondBranch(MCInst &Inst, unsigned Insn,
-                                     uint64_t Address,
-                                     const MCDisassembler *Decoder) {
-  // These 8 instructions are not defined as aliases of BRBS/BRBC.
-  DenseMap<unsigned, unsigned> brInsts = {
-      {0x000, AVR::BRLOk}, {0x400, AVR::BRSHk}, {0x001, AVR::BREQk},
-      {0x401, AVR::BRNEk}, {0x002, AVR::BRMIk}, {0x402, AVR::BRPLk},
-      {0x004, AVR::BRLTk}, {0x404, AVR::BRGEk}};
-
-  // Get the relative offset.
-  int16_t Offset = ((int16_t)((Insn & 0x3f8) << 6)) >> 8;
-
-  // Search the instruction pattern.
-  auto NotAlias = [&Insn](const std::pair<unsigned, unsigned> &I) {
-    return (Insn & 0x407) != I.first;
-  };
-  llvm::partition(brInsts, NotAlias);
-  auto It = llvm::partition_point(brInsts, NotAlias);
-
-  // Decode the instruction.
-  if (It != brInsts.end()) {
-    // This instruction is not an alias of BRBC/BRBS.
-    Inst.setOpcode(It->second);
-    Inst.addOperand(MCOperand::createImm(Offset));
-  } else {
-    // Fall back to an ordinary BRBS/BRBC.
-    Inst.setOpcode(Insn & 0x400 ? AVR::BRBCsk : AVR::BRBSsk);
-    Inst.addOperand(MCOperand::createImm(Insn & 7));
-    Inst.addOperand(MCOperand::createImm(Offset));
-  }
 
   return MCDisassembler::Success;
 }

--- a/llvm/lib/Target/AVR/Disassembler/AVRDisassembler.cpp
+++ b/llvm/lib/Target/AVR/Disassembler/AVRDisassembler.cpp
@@ -109,6 +109,7 @@ static DecodeStatus decodeCallTarget(MCInst &Inst, unsigned Field,
 static DecodeStatus decodeRelCondBrTarget7(MCInst &Inst, unsigned Field,
                                            uint64_t Address,
                                            const MCDisassembler *Decoder) {
+  // The legal range is [-128, 126] (in bytes).
   Inst.addOperand(MCOperand::createImm(SignExtend32(Field, 7) << 1));
   return MCDisassembler::Success;
 }
@@ -116,6 +117,7 @@ static DecodeStatus decodeRelCondBrTarget7(MCInst &Inst, unsigned Field,
 static DecodeStatus decodeRelCondBrTarget13(MCInst &Inst, unsigned Field,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
+  // The legal range is [-4096, 4094] (in bytes).
   Inst.addOperand(MCOperand::createImm(SignExtend32(Field, 12) << 1));
   return MCDisassembler::Success;
 }


### PR DESCRIPTION
The generated decoding functions look identical to the custom ones,
we only need to provide custom decoders for some operands.
