### PR TITLE
[NVPTX] Add sm_88 and sm_110* arch supports

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTX.td
+++ b/llvm/lib/Target/NVPTX/NVPTX.td
@@ -80,9 +80,9 @@ class FeaturePTX<int version>:
 //  + Compare within the family by comparing FullSMVersion, given both belongs to
 //    the same family.
 //  + Detect 'a' variants by checking FullSMVersion & 1.
-foreach sm = [20, 21, 30, 32, 35, 37, 50, 52, 53,
-              60, 61, 62, 70, 72, 75, 80, 86, 87,
-              89, 90, 100, 101, 103, 120, 121] in {
+foreach sm = [20, 21, 30, 32, 35, 37, 50, 52, 53, 60,
+              61, 62, 70, 72, 75, 80, 86, 87, 88, 89,
+              90, 100, 101, 103, 110, 120, 121] in {
   // Base SM version (e.g. FullSMVersion for sm_100 is 1000)
   def SM#sm : FeatureSM<""#sm, !mul(sm, 10)>;
 
@@ -127,6 +127,7 @@ def : Proc<"sm_75",   [SM75, PTX63]>;
 def : Proc<"sm_80",   [SM80, PTX70]>;
 def : Proc<"sm_86",   [SM86, PTX71]>;
 def : Proc<"sm_87",   [SM87, PTX74]>;
+def : Proc<"sm_88",   [SM88, PTX90]>;
 def : Proc<"sm_89",   [SM89, PTX78]>;
 def : Proc<"sm_90",   [SM90, PTX78]>;
 def : Proc<"sm_90a",  [SM90a, PTX80]>;
@@ -139,6 +140,9 @@ def : Proc<"sm_101f", [SM101f, PTX88]>;
 def : Proc<"sm_103",  [SM103, PTX88]>;
 def : Proc<"sm_103a", [SM103a, PTX88]>;
 def : Proc<"sm_103f", [SM103f, PTX88]>;
+def : Proc<"sm_110",  [SM110, PTX90]>;
+def : Proc<"sm_110a", [SM110a, PTX90]>;
+def : Proc<"sm_110f", [SM110f, PTX90]>;
 def : Proc<"sm_120",  [SM120, PTX87]>;
 def : Proc<"sm_120a", [SM120a, PTX87]>;
 def : Proc<"sm_120f", [SM120f, PTX88]>;

--- a/llvm/test/CodeGen/NVPTX/sm-version.ll
+++ b/llvm/test/CodeGen/NVPTX/sm-version.ll
@@ -14,6 +14,7 @@
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_75 | FileCheck %s --check-prefix=SM75
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_80 | FileCheck %s --check-prefix=SM80
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_86 | FileCheck %s --check-prefix=SM86
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_88 | FileCheck %s --check-prefix=SM88
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_90 | FileCheck %s --check-prefix=SM90
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_90a | FileCheck %s --check-prefix=SM90a
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_100 | FileCheck %s --check-prefix=SM100
@@ -25,6 +26,9 @@
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_103 | FileCheck %s --check-prefix=SM103
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_103a | FileCheck %s --check-prefix=SM103a
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_103f | FileCheck %s --check-prefix=SM103f
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_110 | FileCheck %s --check-prefix=SM110
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_110a | FileCheck %s --check-prefix=SM110a
+; RUN: llc < %s -mtriple=nvptx -mcpu=sm_110f | FileCheck %s --check-prefix=SM110f
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_120 | FileCheck %s --check-prefix=SM120
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_120a | FileCheck %s --check-prefix=SM120a
 ; RUN: llc < %s -mtriple=nvptx -mcpu=sm_120f | FileCheck %s --check-prefix=SM120f
@@ -48,6 +52,7 @@
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_75 | FileCheck %s --check-prefix=SM75
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_80 | FileCheck %s --check-prefix=SM80
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_86 | FileCheck %s --check-prefix=SM86
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_88 | FileCheck %s --check-prefix=SM88
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_90 | FileCheck %s --check-prefix=SM90
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_90a | FileCheck %s --check-prefix=SM90a
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_100 | FileCheck %s --check-prefix=SM100
@@ -59,6 +64,9 @@
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_103 | FileCheck %s --check-prefix=SM103
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_103a | FileCheck %s --check-prefix=SM103a
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_103f | FileCheck %s --check-prefix=SM103f
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_110 | FileCheck %s --check-prefix=SM110
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_110a | FileCheck %s --check-prefix=SM110a
+; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_110f | FileCheck %s --check-prefix=SM110f
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_120 | FileCheck %s --check-prefix=SM120
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_120a | FileCheck %s --check-prefix=SM120a
 ; RUN: llc < %s -mtriple=nvptx64 -mcpu=sm_120f | FileCheck %s --check-prefix=SM120f
@@ -82,6 +90,7 @@
 ; SM75: .version 6.3
 ; SM80: .version 7.0
 ; SM86: .version 7.1
+; SM88: .version 9.0
 ; SM90: .version 7.8
 ; SM90a: .version 8.0
 ; SM100: .version 8.6
@@ -93,6 +102,9 @@
 ; SM103: .version 8.8
 ; SM103a: .version 8.8
 ; SM103f: .version 8.8
+; SM110: .version 9.0
+; SM110a: .version 9.0
+; SM110f: .version 9.0
 ; SM120: .version 8.7
 ; SM120a: .version 8.7
 ; SM120f: .version 8.8
@@ -116,6 +128,7 @@
 ; SM75: .target sm_75
 ; SM80: .target sm_80
 ; SM86: .target sm_86
+; SM88: .target sm_88
 ; SM90: .target sm_90
 ; SM90a: .target sm_90a
 ; SM100: .target sm_100
@@ -127,6 +140,9 @@
 ; SM103: .target sm_103
 ; SM103a: .target sm_103a
 ; SM103f: .target sm_103f
+; SM110: .target sm_110
+; SM110a: .target sm_110a
+; SM110f: .target sm_110f
 ; SM120: .target sm_120
 ; SM120a: .target sm_120a
 ; SM120f: .target sm_120f


### PR DESCRIPTION
This change adds support of sm_88, sm_110, sm_110a, and sm_110f. These are added with PTX ISA version 9.0.