### PR TITLE
[libc++] Use pack subscripting for std::get

### DIFF
--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -568,10 +568,12 @@ typedef __char32_t char32_t;
       _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                           \
       _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                           \
       _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++23-extensions")                                                           \
+      _LIBCPP_CLANG_DIAGNOSTIC_IGNORED("-Wc++26-extensions")                                                           \
       _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++14-extensions")                                                             \
       _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++17-extensions")                                                             \
       _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++20-extensions")                                                             \
       _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++23-extensions")
+      _LIBCPP_GCC_DIAGNOSTIC_IGNORED("-Wc++26-extensions")
 #    define _LIBCPP_POP_EXTENSION_DIAGNOSTICS _LIBCPP_DIAGNOSTIC_POP
 #  else
 #    define _LIBCPP_PUSH_EXTENSION_DIAGNOSTICS

--- a/libcxx/include/__fwd/pair.h
+++ b/libcxx/include/__fwd/pair.h
@@ -28,23 +28,22 @@ inline const bool __is_pair_v = false;
 template <class _Type1, class _Type2>
 inline const bool __is_pair_v<pair<_Type1, _Type2> > = true;
 
-template <size_t _Ip, class _T1, class _T2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(pair<_T1, _T2>&) _NOEXCEPT;
+// clang-format fails miserably with pack subscripting currently
+// clang-format off
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Ts...[_Ip]& get(pair<_Ts...>&) _NOEXCEPT;
 
-template <size_t _Ip, class _T1, class _T2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(const pair<_T1, _T2>&) _NOEXCEPT;
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ts...[_Ip]& get(const pair<_Ts...>&) _NOEXCEPT;
 
 #ifndef _LIBCPP_CXX03_LANG
-template <size_t _Ip, class _T1, class _T2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(pair<_T1, _T2>&&) _NOEXCEPT;
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Ts...[_Ip]&& get(pair<_Ts...>&&) _NOEXCEPT;
 
-template <size_t _Ip, class _T1, class _T2>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(const pair<_T1, _T2>&&) _NOEXCEPT;
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ts...[_Ip]&& get(const pair<_Ts...>&&) _NOEXCEPT;
 #endif
+// clang-format on
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__fwd/tuple.h
+++ b/libcxx/include/__fwd/tuple.h
@@ -43,21 +43,20 @@ struct tuple_element<_Ip, tuple<_Tp...> > {
 template <class>
 struct tuple_size;
 
+// clang-format fails miserably with pack subscripting currently
+// clang-format off
 template <size_t _Ip, class... _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(tuple<_Tp...>&) _NOEXCEPT;
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp...[_Ip]& get(tuple<_Tp...>&) _NOEXCEPT;
 
 template <size_t _Ip, class... _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(const tuple<_Tp...>&) _NOEXCEPT;
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp...[_Ip]& get(const tuple<_Tp...>&) _NOEXCEPT;
 
 template <size_t _Ip, class... _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(tuple<_Tp...>&&) _NOEXCEPT;
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp...[_Ip]&& get(tuple<_Tp...>&&) _NOEXCEPT;
 
 template <size_t _Ip, class... _Tp>
-_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(const tuple<_Tp...>&&) _NOEXCEPT;
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp...[_Ip]&& get(const tuple<_Tp...>&&) _NOEXCEPT;
+// clang-format on
 
 #endif // _LIBCPP_CXX03_LANG
 

--- a/libcxx/include/__utility/pair.h
+++ b/libcxx/include/__utility/pair.h
@@ -618,29 +618,28 @@ struct __get_pair<1> {
   }
 };
 
-template <size_t _Ip, class _T1, class _T2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(pair<_T1, _T2>& __p) _NOEXCEPT {
+// clang-format fails miserably with pack subscripting currently
+// clang-format off
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Ts...[_Ip]& get(pair<_Ts...>& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(__p);
 }
 
-template <size_t _Ip, class _T1, class _T2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&
-get(const pair<_T1, _T2>& __p) _NOEXCEPT {
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ts...[_Ip]& get(const pair<_Ts...>& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(__p);
 }
 
-template <size_t _Ip, class _T1, class _T2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(pair<_T1, _T2>&& __p) _NOEXCEPT {
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Ts...[_Ip]&& get(pair<_Ts...>&& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(std::move(__p));
 }
 
-template <size_t _Ip, class _T1, class _T2>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, pair<_T1, _T2> >::type&&
-get(const pair<_T1, _T2>&& __p) _NOEXCEPT {
+template <size_t _Ip, class... _Ts>
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Ts...[_Ip]&& get(const pair<_Ts...>&& __p) _NOEXCEPT {
   return __get_pair<_Ip>::get(std::move(__p));
 }
+// clang-format on
 
 #if _LIBCPP_STD_VER >= 14
 template <class _T1, class _T2>

--- a/libcxx/include/tuple
+++ b/libcxx/include/tuple
@@ -582,17 +582,17 @@ class _LIBCPP_NO_SPECIALIZATIONS tuple {
 
   _BaseT __base_;
 
+  // clang-format fails miserably with pack subscripting currently
+  // clang-format off
   template <size_t _Jp, class... _Up>
-  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Jp, tuple<_Up...> >::type& get(tuple<_Up...>&) _NOEXCEPT;
+  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 _Up...[_Jp]& get(tuple<_Up...>&) _NOEXCEPT;
   template <size_t _Jp, class... _Up>
-  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Jp, tuple<_Up...> >::type&
-  get(const tuple<_Up...>&) _NOEXCEPT;
+  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Up...[_Jp]& get(const tuple<_Up...>&) _NOEXCEPT;
   template <size_t _Jp, class... _Up>
-  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Jp, tuple<_Up...> >::type&&
-  get(tuple<_Up...>&&) _NOEXCEPT;
+  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 _Up...[_Jp]&& get(tuple<_Up...>&&) _NOEXCEPT;
   template <size_t _Jp, class... _Up>
-  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Jp, tuple<_Up...> >::type&&
-  get(const tuple<_Up...>&&) _NOEXCEPT;
+  friend _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Up...[_Jp]&& get(const tuple<_Up...>&&) _NOEXCEPT;
+  // clang-format on
 
 public:
   using __trivially_relocatable _LIBCPP_NODEBUG =
@@ -1119,30 +1119,24 @@ swap(const tuple<_Tp...>& __lhs,
 // get
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(tuple<_Tp...>& __t) _NOEXCEPT {
-  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
-  return static_cast<__tuple_leaf<_Ip, type>&>(__t.__base_).get();
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp...[_Ip]& get(tuple<_Tp...>& __t) _NOEXCEPT {
+  return static_cast<__tuple_leaf<_Ip, _Tp...[_Ip]>&>(__t.__base_).get();
 }
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, tuple<_Tp...> >::type&
-get(const tuple<_Tp...>& __t) _NOEXCEPT {
-  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
-  return static_cast<const __tuple_leaf<_Ip, type>&>(__t.__base_).get();
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp...[_Ip]& get(const tuple<_Tp...>& __t) _NOEXCEPT {
+  return static_cast<const __tuple_leaf<_Ip, _Tp...[_Ip]>&>(__t.__base_).get();
 }
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(tuple<_Tp...>&& __t) _NOEXCEPT {
-  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 _Tp...[_Ip]&& get(tuple<_Tp...>&& __t) _NOEXCEPT {
+  using type _LIBCPP_NODEBUG = _Tp...[_Ip];
   return static_cast<type&&>(static_cast<__tuple_leaf<_Ip, type>&&>(__t.__base_).get());
 }
 
 template <size_t _Ip, class... _Tp>
-inline _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const typename tuple_element<_Ip, tuple<_Tp...> >::type&&
-get(const tuple<_Tp...>&& __t) _NOEXCEPT {
-  using type _LIBCPP_NODEBUG = typename tuple_element<_Ip, tuple<_Tp...> >::type;
+_LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX14 const _Tp...[_Ip]&& get(const tuple<_Tp...>&& __t) _NOEXCEPT {
+  using type _LIBCPP_NODEBUG = _Tp...[_Ip];
   return static_cast<const type&&>(static_cast<const __tuple_leaf<_Ip, type>&&>(__t.__base_).get());
 }
 


### PR DESCRIPTION
This reduces the compile time quite a bit, since calls to `std::get` don't instantiate `tuple_element` anymore.
