### PR TITLE
[lldb] fix Python 3.9+ specific typing annotations

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1,4 +1,8 @@
 # System modules
+
+# allow the use of the `list[str]` type hint in Python 3.8
+from __future__ import annotations
+
 from functools import wraps
 from packaging import version
 import ctypes


### PR DESCRIPTION
This patch replaces `list` with its `typing` implementation, i.e `list[str]` becomes `List[str]`.

[Type hinting generic in the standard collection were introduced in Python 3.9](https://peps.python.org/pep-0585/), however the minimum supported Python version for lldb is 3.8. This patch will unblock the [bots for Ubuntu 20.04](https://ci.swift.org/view/Swift%20rebranch/job/oss-swift-rebranch-package-ubuntu-20_04/2847/consoleText), which run on Python 3.8.