### PR TITLE
[clang-tidy] Do not crash when an empty directory is used in the comp…

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -126,6 +126,10 @@ Improvements to clang-tidy
 - Improved :program:`clang-tidy` option `-quiet` by suppressing diagnostic
   count messages.
 
+- Improved :program:`clang-tidy` by not crashing when an empty `directory`
+  field is used in a compilation database; the current working directory
+  will be used instead, and an error message will be printed.
+
 New checks
 ^^^^^^^^^^
 

--- a/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/invalid-database/compile_commands.json
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/Inputs/invalid-database/compile_commands.json
@@ -1,0 +1,5 @@
+[{
+    "directory":"/invalid/",
+    "file":"/tmp/",
+    "arguments": []
+}]

--- a/clang-tools-extra/test/clang-tidy/infrastructure/empty-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/empty-database.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: system-windows
 
-// RUN: not --crash clang-tidy -p %S/Inputs/empty-database %s 2>&1 | FileCheck %s
+// RUN: clang-tidy -p %S/Inputs/empty-database %s 2>&1 | FileCheck %s
 
-// CHECK: LLVM ERROR: Cannot chdir into ""!
+// CHECK: 'directory' field of compilation database is empty; using the current working directory instead.

--- a/clang-tools-extra/test/clang-tidy/infrastructure/invalid-database.cpp
+++ b/clang-tools-extra/test/clang-tidy/infrastructure/invalid-database.cpp
@@ -1,0 +1,5 @@
+// UNSUPPORTED: system-windows
+
+// RUN: not --crash clang-tidy -p %S/Inputs/invalid-database %s 2>&1 | FileCheck %s
+
+// CHECK: LLVM ERROR: Cannot chdir into "/invalid/"!


### PR DESCRIPTION
…ilation database

Currently a hard crash encourages people to report a bug upstream, but this is not really a bug. Instead, print an error and use a reasonable default (the current working directory).

Fixes #57264