### PR TITLE
[compiler-rt][ASan] Work around msvc cl x64 build warnings

### DIFF
--- a/compiler-rt/lib/asan/CMakeLists.txt
+++ b/compiler-rt/lib/asan/CMakeLists.txt
@@ -108,7 +108,8 @@ set(ASAN_CFLAGS ${SANITIZER_COMMON_CFLAGS})
 
 # Win/ASan relies on the runtime functions being hotpatchable. See
 # https://github.com/llvm/llvm-project/pull/149444
-if(MSVC)
+# MSVC cl 64 bit architectures treat /hotpatch as an unknown option
+if(CLANG_CL OR (MSVC AND "i386" IN_LIST ASAN_SUPPORTED_ARCH))
   list(APPEND ASAN_CFLAGS /hotpatch)
 endif()
 


### PR DESCRIPTION
After #154694, MSVC cl started emitting build warnings for 64 bit architectures

`cl : Command line warning D9002 : ignoring unknown option '/hotpatch'`

[This documentation](https://learn.microsoft.com/en-us/cpp/build/reference/hotpatch-create-hotpatchable-image?view=msvc-170) is being updated for clarity, but the `/hotpatch` compiler option only affects x86 compilation.