### PR TITLE
[PowerPC][NFC] Update TableGen range punctuator with '...'

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCInstrFormats.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFormats.td
@@ -18,7 +18,7 @@ class I<bits<6> opcode, dag OOL, dag IOL, string asmstr, InstrItinClass itin>
   bit PPC64 = 0;  // Default value, override with isPPC64
 
   let Namespace = "PPC";
-  let Inst{0-5} = opcode;
+  let Inst{0...5} = opcode;
   let OutOperandList = OOL;
   let InOperandList = IOL;
   let AsmString = asmstr;
@@ -34,7 +34,7 @@ class I<bits<6> opcode, dag OOL, dag IOL, string asmstr, InstrItinClass itin>
   let TSFlags{0}   = PPC970_First;
   let TSFlags{1}   = PPC970_Single;
   let TSFlags{2}   = PPC970_Cracked;
-  let TSFlags{5-3} = PPC970_Unit;
+  let TSFlags{5...3} = PPC970_Unit;
 
   // Indicate that this instruction is of type X-Form Load or Store
   bits<1> XFormMemOp = 0;
@@ -99,8 +99,8 @@ class I2<bits<6> opcode1, bits<6> opcode2, dag OOL, dag IOL, string asmstr,
   bit PPC64 = 0;  // Default value, override with isPPC64
 
   let Namespace = "PPC";
-  let Inst{0-5} = opcode1;
-  let Inst{32-37} = opcode2;
+  let Inst{0...5} = opcode1;
+  let Inst{32...37} = opcode2;
   let OutOperandList = OOL;
   let InOperandList = IOL;
   let AsmString = asmstr;
@@ -116,7 +116,7 @@ class I2<bits<6> opcode1, bits<6> opcode2, dag OOL, dag IOL, string asmstr,
   let TSFlags{0}   = PPC970_First;
   let TSFlags{1}   = PPC970_Single;
   let TSFlags{2}   = PPC970_Cracked;
-  let TSFlags{5-3} = PPC970_Unit;
+  let TSFlags{5...3} = PPC970_Unit;
 
   // Fields used for relation models.
   string BaseName = "";
@@ -135,7 +135,7 @@ class IForm<bits<6> opcode, bit aa, bit lk, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
   bits<24> LI;
 
-  let Inst{6-29}  = LI;
+  let Inst{6...29}  = LI;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 }
@@ -148,12 +148,12 @@ class BForm<bits<6> opcode, bit aa, bit lk, dag OOL, dag IOL, string asmstr>
   bits<14> BD;
 
   bits<5> BI;
-  let BI{0-1} = BIBO{5-6};
-  let BI{2-4} = CR{0-2};
+  let BI{0...1} = BIBO{5...6};
+  let BI{2...4} = CR{0...2};
 
-  let Inst{6-10}  = BIBO{4-0};
-  let Inst{11-15} = BI;
-  let Inst{16-29} = BD;
+  let Inst{6...10}  = BIBO{4...0};
+  let Inst{11...15} = BI;
+  let Inst{16...29} = BD;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 }
@@ -161,8 +161,8 @@ class BForm<bits<6> opcode, bit aa, bit lk, dag OOL, dag IOL, string asmstr>
 class BForm_1<bits<6> opcode, bits<5> bo, bit aa, bit lk, dag OOL, dag IOL,
              string asmstr>
   : BForm<opcode, aa, lk, OOL, IOL, asmstr> {
-  let BIBO{4-0} = bo;
-  let BIBO{6-5} = 0;
+  let BIBO{4...0} = bo;
+  let BIBO{6...5} = 0;
   let CR = 0;
 }
 
@@ -171,9 +171,9 @@ class BForm_2<bits<6> opcode, bits<5> bo, bits<5> bi, bit aa, bit lk,
   : I<opcode, OOL, IOL, asmstr, IIC_BrB> {
   bits<14> BD;
 
-  let Inst{6-10}  = bo;
-  let Inst{11-15} = bi;
-  let Inst{16-29} = BD;
+  let Inst{6...10}  = bo;
+  let Inst{11...15} = bi;
+  let Inst{16...29} = BD;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 }
@@ -185,9 +185,9 @@ class BForm_3<bits<6> opcode, bit aa, bit lk,
   bits<5> BI;
   bits<14> BD;
 
-  let Inst{6-10}  = BO;
-  let Inst{11-15} = BI;
-  let Inst{16-29} = BD;
+  let Inst{6...10}  = BO;
+  let Inst{11...15} = BI;
+  let Inst{16...29} = BD;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 }
@@ -200,10 +200,10 @@ class BForm_3_at<bits<6> opcode, bit aa, bit lk,
   bits<5> BI;
   bits<14> BD;
 
-  let Inst{6-8}   = BO{4-2};
-  let Inst{9-10}  = at;
-  let Inst{11-15} = BI;
-  let Inst{16-29} = BD;
+  let Inst{6...8}   = BO{4...2};
+  let Inst{9...10}  = at;
+  let Inst{11...15} = BI;
+  let Inst{16...29} = BD;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 }
@@ -215,9 +215,9 @@ BForm_4<bits<6> opcode, bits<5> bo, bit aa, bit lk,
   bits<5> BI;
   bits<14> BD;
 
-  let Inst{6-10}  = bo;
-  let Inst{11-15} = BI;
-  let Inst{16-29} = BD;
+  let Inst{6...10}  = bo;
+  let Inst{11...15} = BI;
+  let Inst{16...29} = BD;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 }
@@ -231,7 +231,7 @@ class SCForm<bits<6> opcode, bits<1> xo1, bits<1> xo2,
 
   let Pattern = pattern;
 
-  let Inst{20-26} = LEV;
+  let Inst{20...26} = LEV;
   let Inst{30}    = xo1;
   let Inst{31}    = xo2;
 }
@@ -246,9 +246,9 @@ class DForm_base<bits<6> opcode, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = RA;
-  let Inst{16-31} = D;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = RA;
+  let Inst{16...31} = D;
 }
 
 class DForm_1<bits<6> opcode, dag OOL, dag IOL, string asmstr,
@@ -273,9 +273,9 @@ class DForm_2_r0<bits<6> opcode, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = 0;
-  let Inst{16-31} = D;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = 0;
+  let Inst{16...31} = D;
 }
 
 class DForm_4<bits<6> opcode, dag OOL, dag IOL, string asmstr,
@@ -287,9 +287,9 @@ class DForm_4<bits<6> opcode, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = RA;
-  let Inst{16-31} = D;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = RA;
+  let Inst{16...31} = D;
 }
 
 class DForm_4_zero<bits<6> opcode, dag OOL, dag IOL, string asmstr,
@@ -321,13 +321,13 @@ class IForm_and_DForm_1<bits<6> opcode1, bit aa, bit lk, bits<6> opcode2,
   let Pattern = pattern;
   bits<24> LI;
 
-  let Inst{6-29}  = LI;
+  let Inst{6...29}  = LI;
   let Inst{30}    = aa;
   let Inst{31}    = lk;
 
-  let Inst{38-42}  = RST;
-  let Inst{43-47} = RA;
-  let Inst{48-63} = D;
+  let Inst{38...42}  = RST;
+  let Inst{43...47} = RA;
+  let Inst{48...63} = D;
 }
 
 // This is used to emit BL8+NOP.
@@ -349,11 +349,11 @@ class DForm_5<bits<6> opcode, dag OOL, dag IOL, string asmstr,
   bits<5>  RA;
   bits<16> D;
 
-  let Inst{6-8}   = BF;
+  let Inst{6...8}   = BF;
   let Inst{9}     = 0;
   let Inst{10}    = L;
-  let Inst{11-15} = RA;
-  let Inst{16-31} = D;
+  let Inst{11...15} = RA;
+  let Inst{16...31} = D;
 }
 
 class DForm_5_ext<bits<6> opcode, dag OOL, dag IOL, string asmstr,
@@ -383,10 +383,10 @@ class DSForm_1<bits<6> opcode, bits<2> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = RA;
-  let Inst{16-29} = D;
-  let Inst{30-31} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = RA;
+  let Inst{16...29} = D;
+  let Inst{30...31} = xo;
 }
 
 // ISA V3.0B 1.6.6 DX-Form
@@ -398,10 +398,10 @@ class DXForm<bits<6> opcode, bits<5> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = D{5-1};  // d1
-  let Inst{16-25} = D{15-6}; // d0
-  let Inst{26-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = D{5...1};  // d1
+  let Inst{16...25} = D{15...6}; // d0
+  let Inst{26...30} = xo;
   let Inst{31}    = D{0};    // d2
 }
 
@@ -415,11 +415,11 @@ class DQ_RD6_RS5_DQ12<bits<6> opcode, bits<3> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = RA;
-  let Inst{16-27} = DQ;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = RA;
+  let Inst{16...27} = DQ;
   let Inst{28}    = XT{5};
-  let Inst{29-31} = xo;
+  let Inst{29...31} = xo;
 }
 
 class DQForm_RTp5_RA17_MEM<bits<6> opcode, bits<4> xo, dag OOL, dag IOL,
@@ -431,10 +431,10 @@ class DQForm_RTp5_RA17_MEM<bits<6> opcode, bits<4> xo, dag OOL, dag IOL,
   bits<12> DQ;
   let Pattern = pattern;
 
-  let Inst{6-10} =  RTp{4-0};
-  let Inst{11-15} = RA;
-  let Inst{16-27} = DQ;
-  let Inst{28-31} = xo;
+  let Inst{6...10} =  RTp{4...0};
+  let Inst{11...15} = RA;
+  let Inst{16...27} = DQ;
+  let Inst{28...31} = xo;
 }
 
 // 1.7.6 X-Form
@@ -449,10 +449,10 @@ class XForm_base_r3xo<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asms
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -475,7 +475,7 @@ class XForm_tlbilx<bits<10> xo, dag OOL, dag IOL, string asmstr,
 class XForm_attn<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
                  InstrItinClass itin>
   : I<opcode, OOL, IOL, asmstr, itin> {
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
 }
 
 // This is the same as XForm_base_r3xo, but the first two operands are swapped
@@ -490,10 +490,10 @@ class XForm_base_r3xo_swapped
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -528,10 +528,10 @@ class XForm_tlbws<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-15} = RA;
+  let Inst{6...10}  = RST;
+  let Inst{11...15} = RA;
   let Inst{20}    = WS;
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -570,12 +570,12 @@ class XForm_16<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RA;
   bits<5> RB;
 
-  let Inst{6-8}   = BF;
+  let Inst{6...8}   = BF;
   let Inst{9}     = 0;
   let Inst{10}    = L;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -587,10 +587,10 @@ class XForm_icbt<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RB;
 
   let Inst{6} = 0;
-  let Inst{7-10} = CT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{7...10} = CT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -600,9 +600,9 @@ class XForm_sr<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RS;
   bits<4> SR;
 
-  let Inst{6-10} = RS;
-  let Inst{12-15} = SR;
-  let Inst{21-30} = xo;
+  let Inst{6...10} = RS;
+  let Inst{12...15} = SR;
+  let Inst{21...30} = xo;
 }
 
 class XForm_mbar<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
@@ -610,8 +610,8 @@ class XForm_mbar<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
          : I<opcode, OOL, IOL, asmstr, itin> {
   bits<5> MO;
 
-  let Inst{6-10} = MO;
-  let Inst{21-30} = xo;
+  let Inst{6...10} = MO;
+  let Inst{21...30} = xo;
 }
 
 class XForm_srin<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
@@ -620,9 +620,9 @@ class XForm_srin<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RS;
   bits<5> RB;
 
-  let Inst{6-10} = RS;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10} = RS;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
 }
 
 class XForm_mtmsr<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
@@ -631,9 +631,9 @@ class XForm_mtmsr<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RS;
   bits<1> L;
 
-  let Inst{6-10} = RS;
+  let Inst{6...10} = RS;
   let Inst{15} = L;
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
 }
 
 class XForm_16_ext<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
@@ -649,11 +649,11 @@ class XForm_17<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RA;
   bits<5> RB;
 
-  let Inst{6-8}   = BF;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...8}   = BF;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -673,10 +673,10 @@ class XForm_18<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
   
-  let Inst{6-10}  = FRT;
-  let Inst{11-15} = FRA;
-  let Inst{16-20} = FRB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = FRT;
+  let Inst{11...15} = FRA;
+  let Inst{16...20} = FRB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -696,11 +696,11 @@ class XForm_20<bits<6> opcode, bits<6> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
   
-  let Inst{6-10}  = FRT;
-  let Inst{11-15} = FRA;
-  let Inst{16-20} = FRB;
-  let Inst{21-24} = tttt;
-  let Inst{25-30} = xo;
+  let Inst{6...10}  = FRT;
+  let Inst{11...15} = FRA;
+  let Inst{16...20} = FRB;
+  let Inst{21...24} = tttt;
+  let Inst{25...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -708,10 +708,10 @@ class XForm_24<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
                InstrItinClass itin, list<dag> pattern> 
   : I<opcode, OOL, IOL, asmstr, itin> {
   let Pattern = pattern;
-  let Inst{6-10}  = 31;
-  let Inst{11-15} = 0;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = 31;
+  let Inst{11...15} = 0;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -721,11 +721,11 @@ class XForm_24_sync<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
   bits<2> L;
 
   let Pattern = pattern;
-  let Inst{6-8}   = 0;
-  let Inst{9-10}  = L;
-  let Inst{11-15} = 0;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...8}   = 0;
+  let Inst{9...10}  = L;
+  let Inst{11...15} = 0;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -736,12 +736,12 @@ class XForm_IMM2_IMM2<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
   bits<2> PL;
 
   let Pattern = pattern;
-  let Inst{6-8}   = 0;
-  let Inst{9-10}  = L;
-  let Inst{11-13} = 0;
-  let Inst{14-15} = PL;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...8}   = 0;
+  let Inst{9...10}  = L;
+  let Inst{11...13} = 0;
+  let Inst{14...15} = PL;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -752,12 +752,12 @@ class XForm_IMM3_IMM2<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
   bits<2> SC;
 
   let Pattern = pattern;
-  let Inst{6-7}   = 0;
-  let Inst{8-10}  = L;
-  let Inst{11-13} = 0;
-  let Inst{14-15} = SC;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...7}   = 0;
+  let Inst{8...10}  = L;
+  let Inst{11...13} = 0;
+  let Inst{14...15} = SC;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -803,9 +803,9 @@ class XForm_42<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RST;
-  let Inst{11-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 class XForm_43<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
@@ -816,9 +816,9 @@ class XForm_43<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = FM;
-  let Inst{11-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = FM;
+  let Inst{11...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -828,11 +828,11 @@ class XForm_44<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RT;
   bits<3> BFA;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-13} = BFA;
-  let Inst{14-15} = 0;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...13} = BFA;
+  let Inst{14...15} = 0;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -842,11 +842,11 @@ class XForm_45<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RT;
   bits<2> L;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-13} = 0;
-  let Inst{14-15} = L;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...13} = 0;
+  let Inst{14...15} = L;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -856,11 +856,11 @@ class X_FRT5_XO2_XO3_XO10<bits<6> opcode, bits<2> xo1, bits<3> xo2, bits<10> xo,
   : XForm_base_r3xo<opcode, xo, OOL, IOL, asmstr, itin, pattern> {
   let Pattern = pattern;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-12} = xo1;
-  let Inst{13-15} = xo2;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...12} = xo1;
+  let Inst{13...15} = xo2;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -871,11 +871,11 @@ class X_FRT5_XO2_XO3_FRB5_XO10<bits<6> opcode, bits<2> xo1, bits<3> xo2,
   let Pattern = pattern;
   bits<5> FRB;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-12} = xo1;
-  let Inst{13-15} = xo2;
-  let Inst{16-20} = FRB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...12} = xo1;
+  let Inst{13...15} = xo2;
+  let Inst{16...20} = FRB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -886,12 +886,12 @@ class X_FRT5_XO2_XO3_DRM3_XO10<bits<6> opcode, bits<2> xo1, bits<3> xo2,
   let Pattern = pattern;
   bits<3> DRM;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-12} = xo1;
-  let Inst{13-15} = xo2;
-  let Inst{16-17} = 0;
-  let Inst{18-20} = DRM;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...12} = xo1;
+  let Inst{13...15} = xo2;
+  let Inst{16...17} = 0;
+  let Inst{18...20} = DRM;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -902,12 +902,12 @@ class X_FRT5_XO2_XO3_RM2_X10<bits<6> opcode, bits<2> xo1, bits<3> xo2,
   let Pattern = pattern;
   bits<2> RM;
 
-  let Inst{6-10}  = RST;
-  let Inst{11-12} = xo1;
-  let Inst{13-15} = xo2;
-  let Inst{16-18} = 0;
-  let Inst{19-20} = RM;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RST;
+  let Inst{11...12} = xo1;
+  let Inst{13...15} = xo2;
+  let Inst{16...18} = 0;
+  let Inst{19...20} = RM;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -934,10 +934,10 @@ class XForm_htm0<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   bit RC = 1;
 
-  let Inst{6-9}   = 0;
+  let Inst{6...9}   = 0;
   let Inst{10}    = R;
-  let Inst{11-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{11...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -949,8 +949,8 @@ class XForm_htm1<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
   bit RC = 1;
 
   let Inst{6}     = A;
-  let Inst{7-20}  = 0;
-  let Inst{21-30} = xo;
+  let Inst{7...20}  = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -961,10 +961,10 @@ class XForm_htm2<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{7-9}   = 0;
+  let Inst{7...9}   = 0;
   let Inst{10}    = L;
-  let Inst{11-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{11...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -975,9 +975,9 @@ class XForm_htm3<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;
 
-  let Inst{6-8}   = BF;
-  let Inst{9-20}  = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...8}   = BF;
+  let Inst{9...20}  = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -992,12 +992,12 @@ class X_BF3_L1_RS5_RS5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = BF;
+  let Inst{6...8}   = BF;
   let Inst{9}     = 0;
   let Inst{10}    = L;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1011,11 +1011,11 @@ class X_BF3_RS5_RS5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = BF;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...8}   = BF;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1035,10 +1035,10 @@ class X_BF3_DCMX7_RS5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}  = BF;
-  let Inst{9-15} = DCMX;
-  let Inst{16-20} = VB;
-  let Inst{21-30} = xo;
+  let Inst{6...8}  = BF;
+  let Inst{9...15} = DCMX;
+  let Inst{16...20} = VB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1050,10 +1050,10 @@ class X_RD6_IMM8<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-12} = 0;
-  let Inst{13-20} = IMM8;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...12} = 0;
+  let Inst{13...20} = IMM8;
+  let Inst{21...30} = xo;
   let Inst{31}    = XT{5};
 }
 
@@ -1092,10 +1092,10 @@ class XX1Form<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = XT{5};
 }
 
@@ -1117,10 +1117,10 @@ class XX2Form<bits<6> opcode, bits<9> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = 0;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = 0;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
 }
@@ -1133,10 +1133,10 @@ class XX2Form_1<bits<6> opcode, bits<9> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = CR;
-  let Inst{9-15}  = 0;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...8}   = CR;
+  let Inst{9...15}  = 0;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = 0;
 }
@@ -1150,11 +1150,11 @@ class XX2Form_2<bits<6> opcode, bits<9> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-13} = 0;
-  let Inst{14-15} = D;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...13} = 0;
+  let Inst{14...15} = D;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
 }
@@ -1168,10 +1168,10 @@ class XX2_RD6_UIM5_RS6<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = UIM5;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = UIM5;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
 }
@@ -1185,10 +1185,10 @@ class XX2_RD5_XO5_RS6<bits<6> opcode, bits<5> xo2, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = xo2;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = xo2;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = 0;
 }
@@ -1202,10 +1202,10 @@ class XX2_RD6_XO5_RS6<bits<6> opcode, bits<5> xo2, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = xo2;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = xo2;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
 }
@@ -1219,10 +1219,10 @@ class XX2_BF3_DCMX7_RS6<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}  = BF;
-  let Inst{9-15} = DCMX;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...8}  = BF;
+  let Inst{9...15} = DCMX;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = 0;
 }
@@ -1237,12 +1237,12 @@ class XX2_RD6_DCMX7_RS6<bits<6> opcode, bits<4> xo1, bits<3> xo2,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = DCMX{4-0};
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-24} = xo1;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = DCMX{4...0};
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...24} = xo1;
   let Inst{25}    = DCMX{6};
-  let Inst{26-28} = xo2;
+  let Inst{26...28} = xo2;
   let Inst{29}    = DCMX{5};
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
@@ -1257,10 +1257,10 @@ class XForm_XD6_RA5_RB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = D{4-0};  // D
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = D{4...0};  // D
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = D{5};    // DX
 }
 
@@ -1273,11 +1273,11 @@ class XForm_BF3_UIM6_FRB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = BF;
+  let Inst{6...8}   = BF;
   let Inst{9}     = 0;
-  let Inst{10-15} = UIM;
-  let Inst{16-20} = FRB;
-  let Inst{21-30} = xo;
+  let Inst{10...15} = UIM;
+  let Inst{16...20} = FRB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1292,11 +1292,11 @@ class XForm_SP2_FRTB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asms
 
   bit RC = 0; // set by isRecordForm
 
-  let Inst{6 - 10} = FRT;
-  let Inst{11 - 12} = SP;
-  let Inst{13 - 15} = 0;
-  let Inst{16 - 20} = FRB;
-  let Inst{21 - 30} = xo;
+  let Inst{6...10} = FRT;
+  let Inst{11...12} = SP;
+  let Inst{13...15} = 0;
+  let Inst{16...20} = FRB;
+  let Inst{21...30} = xo;
   let Inst{31} = RC;
 }
 
@@ -1311,11 +1311,11 @@ class XForm_S1_FRTB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
 
   bit RC = 0; // set by isRecordForm
 
-  let Inst{6 - 10} = FRT;
+  let Inst{6...10} = FRT;
   let Inst{11} = S;
-  let Inst{12 - 15} = 0;
-  let Inst{16 - 20} = FRB;
-  let Inst{21 - 30} = xo;
+  let Inst{12...15} = 0;
+  let Inst{16...20} = FRB;
+  let Inst{21...30} = xo;
   let Inst{31} = RC;
 }
 
@@ -1328,10 +1328,10 @@ class XX3Form<bits<6> opcode, bits<8> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = XA{4-0};
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-28} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = XA{4...0};
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...28} = xo;
   let Inst{29}    = XA{5};
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
@@ -1353,11 +1353,11 @@ class XX3Form_1<bits<6> opcode, bits<8> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = CR;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = XA{4-0};
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-28} = xo;
+  let Inst{6...8}   = CR;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = XA{4...0};
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...28} = xo;
   let Inst{29}    = XA{5};
   let Inst{30}    = XB{5};
   let Inst{31}    = 0;
@@ -1373,12 +1373,12 @@ class XX3Form_2<bits<6> opcode, bits<5> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = XA{4-0};
-  let Inst{16-20} = XB{4-0};
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = XA{4...0};
+  let Inst{16...20} = XB{4...0};
   let Inst{21}    = 0;
-  let Inst{22-23} = D;
-  let Inst{24-28} = xo;
+  let Inst{22...23} = D;
+  let Inst{24...28} = xo;
   let Inst{29}    = XA{5};
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
@@ -1395,11 +1395,11 @@ class XX3Form_Rc<bits<6> opcode, bits<7> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = XA{4-0};
-  let Inst{16-20} = XB{4-0};
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = XA{4...0};
+  let Inst{16...20} = XB{4...0};
   let Inst{21}    = RC;
-  let Inst{22-28} = xo;
+  let Inst{22...28} = xo;
   let Inst{29}    = XA{5};
   let Inst{30}    = XB{5};
   let Inst{31}    = XT{5};
@@ -1415,11 +1415,11 @@ class XX4Form<bits<6> opcode, bits<2> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = XT{4-0};
-  let Inst{11-15} = XA{4-0};
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-25} = XC{4-0};
-  let Inst{26-27} = xo;
+  let Inst{6...10}  = XT{4...0};
+  let Inst{11...15} = XA{4...0};
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...25} = XC{4...0};
+  let Inst{26...27} = xo;
   let Inst{28}    = XC{5};
   let Inst{29}    = XA{5};
   let Inst{30}    = XB{5};
@@ -1435,10 +1435,10 @@ class DCB_Form<bits<10> xo, bits<5> immfield, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = immfield;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = immfield;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1451,10 +1451,10 @@ class DCB_Form_hint<bits<10> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = TH;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = TH;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1469,11 +1469,11 @@ class DSS_Form<bits<1> T, bits<10> xo, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   let Inst{6}     = T;
-  let Inst{7-8}   = 0;
-  let Inst{9-10}  = STRM;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{7...8}   = 0;
+  let Inst{9...10}  = STRM;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1487,10 +1487,10 @@ class XLForm_1<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = CRD;
-  let Inst{11-15} = CRA;
-  let Inst{16-20} = CRB;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = CRD;
+  let Inst{11...15} = CRA;
+  let Inst{16...20} = CRB;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1527,10 +1527,10 @@ class XLForm_1_ext<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = CRD;
-  let Inst{11-15} = CRD;
-  let Inst{16-20} = CRD;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = CRD;
+  let Inst{11...15} = CRD;
+  let Inst{16...20} = CRD;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1543,11 +1543,11 @@ class XLForm_2<bits<6> opcode, bits<10> xo, bit lk, dag OOL, dag IOL, string asm
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = BO;
-  let Inst{11-15} = BI;
-  let Inst{16-18} = 0;
-  let Inst{19-20} = BH;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = BO;
+  let Inst{11...15} = BI;
+  let Inst{16...18} = 0;
+  let Inst{19...20} = BH;
+  let Inst{21...30} = xo;
   let Inst{31}    = lk;
 }
 
@@ -1557,9 +1557,9 @@ class XLForm_2_br<bits<6> opcode, bits<10> xo, bit lk,
   bits<7> BIBO;  // 2 bits of BI and 5 bits of BO.
   bits<3>  CR;
   
-  let BO = BIBO{4-0};
-  let BI{0-1} = BIBO{5-6};
-  let BI{2-4} = CR{0-2};
+  let BO = BIBO{4...0};
+  let BI{0...1} = BIBO{5...6};
+  let BI{2...4} = CR{0...2};
   let BH = 0;
 }
 
@@ -1584,12 +1584,12 @@ class XLForm_3<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<3> BF;
   bits<3> BFA;
   
-  let Inst{6-8}   = BF;
-  let Inst{9-10}  = 0;
-  let Inst{11-13} = BFA;
-  let Inst{14-15} = 0;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...8}   = BF;
+  let Inst{9...10}  = 0;
+  let Inst{11...13} = BFA;
+  let Inst{14...15} = 0;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1602,13 +1602,13 @@ class XLForm_4<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   
   bit RC = 0;
   
-  let Inst{6-8}   = BF;
-  let Inst{9-10}  = 0;
-  let Inst{11-14} = 0;
+  let Inst{6...8}   = BF;
+  let Inst{9...10}  = 0;
+  let Inst{11...14} = 0;
   let Inst{15}    = W;
-  let Inst{16-19} = U;
+  let Inst{16...19} = U;
   let Inst{20}    = 0;
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -1619,9 +1619,9 @@ class XLForm_S<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-19}  = 0;
+  let Inst{6...19}  = 0;
   let Inst{20}    = S;
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1640,17 +1640,17 @@ class XLForm_2_and_DSForm_1<bits<6> opcode1, bits<10> xo1, bit lk,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = BO;
-  let Inst{11-15} = BI;
-  let Inst{16-18} = 0;
-  let Inst{19-20} = BH;
-  let Inst{21-30} = xo1;
+  let Inst{6...10}  = BO;
+  let Inst{11...15} = BI;
+  let Inst{16...18} = 0;
+  let Inst{19...20} = BH;
+  let Inst{21...30} = xo1;
   let Inst{31}    = lk;
 
-  let Inst{38-42} = RST;
-  let Inst{43-47} = RA;
-  let Inst{48-61} = D;
-  let Inst{62-63} = xo2;
+  let Inst{38...42} = RST;
+  let Inst{43...47} = RA;
+  let Inst{48...61} = D;
+  let Inst{62...63} = xo2;
 }
 
 class XLForm_2_ext_and_DSForm_1<bits<6> opcode1, bits<10> xo1,
@@ -1677,16 +1677,16 @@ class XLForm_2_ext_and_DForm_1<bits<6> opcode1, bits<10> xo1, bits<5> bo,
 
   let Pattern = pattern;
 
-  let Inst{6-10} = bo;
-  let Inst{11-15} = bi;
-  let Inst{16-18} = 0;
-  let Inst{19-20} = 0;  // Unused (BH)
-  let Inst{21-30} = xo1;
+  let Inst{6...10} = bo;
+  let Inst{11...15} = bi;
+  let Inst{16...18} = 0;
+  let Inst{19...20} = 0;  // Unused (BH)
+  let Inst{21...30} = xo1;
   let Inst{31} = lk;
 
-  let Inst{38-42} = RST;
-  let Inst{43-47} = RA;
-  let Inst{48-63} = D;
+  let Inst{38...42} = RST;
+  let Inst{43...47} = RA;
+  let Inst{48...63} = D;
 }
 
 // 1.7.8 XFX-Form
@@ -1696,7 +1696,7 @@ class XFXForm_1<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5>  RST;
   bits<10> SPR;
 
-  let Inst{6-10}  = RST;
+  let Inst{6...10}  = RST;
   let Inst{11}    = SPR{4};
   let Inst{12}    = SPR{3};
   let Inst{13}    = SPR{2};
@@ -1707,7 +1707,7 @@ class XFXForm_1<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   let Inst{18}    = SPR{7};
   let Inst{19}    = SPR{6};
   let Inst{20}    = SPR{5};
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1722,9 +1722,9 @@ class XFXForm_3<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
          : I<opcode, OOL, IOL, asmstr, itin> {
   bits<5>  RT;
    
-  let Inst{6-10}  = RT;
-  let Inst{11-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1735,9 +1735,9 @@ class XFXForm_3p<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<10> imm;
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-20} = imm;
-  let Inst{21-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...20} = imm;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1747,11 +1747,11 @@ class XFXForm_5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<8>  FXM;
   bits<5>  RST;
 
-  let Inst{6-10}  = RST;
+  let Inst{6...10}  = RST;
   let Inst{11}    = 0;
-  let Inst{12-19} = FXM;
+  let Inst{12...19} = FXM;
   let Inst{20}    = 0;
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1761,11 +1761,11 @@ class XFXForm_5a<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   bits<5>  RST;
   bits<8>  FXM;
 
-  let Inst{6-10}  = RST;
+  let Inst{6...10}  = RST;
   let Inst{11}    = 1;
-  let Inst{12-19} = FXM;
+  let Inst{12...19} = FXM;
   let Inst{20}    = 0;
-  let Inst{21-30} = xo;
+  let Inst{21...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1782,10 +1782,10 @@ class XFLForm<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   let Inst{6} = 0;
-  let Inst{7-14}  = FM;
+  let Inst{7...14}  = FM;
   let Inst{15} = 0;
-  let Inst{16-20} = RT;
-  let Inst{21-30} = xo;
+  let Inst{16...20} = RT;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -1801,10 +1801,10 @@ class XFLForm_1<bits<6> opcode, bits<10> xo, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   let Inst{6}     = L;
-  let Inst{7-14}  = FLM;
+  let Inst{7...14}  = FLM;
   let Inst{15}    = W;
-  let Inst{16-20} = FRB;
-  let Inst{21-30} = xo;
+  let Inst{16...20} = FRB;
+  let Inst{21...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -1819,10 +1819,10 @@ class XSForm_1<bits<6> opcode, bits<9> xo, dag OOL, dag IOL, string asmstr,
   bit RC = 0;    // set by isRecordForm
   let Pattern = pattern;
 
-  let Inst{6-10}  = RS;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = SH{4,3,2,1,0};
-  let Inst{21-29} = xo;
+  let Inst{6...10}  = RS;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = SH{4,3,2,1,0};
+  let Inst{21...29} = xo;
   let Inst{30}    = SH{5};
   let Inst{31}    = RC;
 }
@@ -1839,11 +1839,11 @@ class XOForm_1<bits<6> opcode, bits<9> xo, bit oe, dag OOL, dag IOL, string asms
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
   let Inst{21}    = oe;
-  let Inst{22-30} = xo;
+  let Inst{22...30} = xo;
   let Inst{31}    = RC;  
 }
 
@@ -1866,11 +1866,11 @@ class AForm_1<bits<6> opcode, bits<5> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = FRT;
-  let Inst{11-15} = FRA;
-  let Inst{16-20} = FRB;
-  let Inst{21-25} = FRC;
-  let Inst{26-30} = xo;
+  let Inst{6...10}  = FRT;
+  let Inst{11...15} = FRA;
+  let Inst{16...20} = FRB;
+  let Inst{21...25} = FRC;
+  let Inst{26...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -1896,11 +1896,11 @@ class AForm_4<bits<6> opcode, bits<5> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-25} = COND;
-  let Inst{26-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...25} = COND;
+  let Inst{26...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -1918,11 +1918,11 @@ class MForm_1<bits<6> opcode, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RS;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-25} = MB;
-  let Inst{26-30} = ME;
+  let Inst{6...10}  = RS;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...25} = MB;
+  let Inst{26...30} = ME;
   let Inst{31}    = RC;
 }
 
@@ -1939,11 +1939,11 @@ class MForm_2<bits<6> opcode, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RS;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = SH;
-  let Inst{21-25} = MB;
-  let Inst{26-30} = ME;
+  let Inst{6...10}  = RS;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = SH;
+  let Inst{21...25} = MB;
+  let Inst{26...30} = ME;
   let Inst{31}    = RC;
 }
 
@@ -1960,11 +1960,11 @@ class MDForm_1<bits<6> opcode, bits<3> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RS;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = SH{4,3,2,1,0};
-  let Inst{21-26} = MBE{4,3,2,1,0,5};
-  let Inst{27-29} = xo;
+  let Inst{6...10}  = RS;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = SH{4,3,2,1,0};
+  let Inst{21...26} = MBE{4,3,2,1,0,5};
+  let Inst{27...29} = xo;
   let Inst{30}    = SH{5};
   let Inst{31}    = RC;
 }
@@ -1981,11 +1981,11 @@ class MDSForm_1<bits<6> opcode, bits<4> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RS;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-26} = MBE{4,3,2,1,0,5};
-  let Inst{27-30} = xo;
+  let Inst{6...10}  = RS;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...26} = MBE{4,3,2,1,0,5};
+  let Inst{27...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -2003,11 +2003,11 @@ class VAForm_1<bits<6> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
   
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-25} = RC;
-  let Inst{26-31} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...25} = RC;
+  let Inst{26...31} = xo;
 }
 
 // VAForm_1a - DABC ordering.
@@ -2021,11 +2021,11 @@ class VAForm_1a<bits<6> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
   
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-25} = RC;
-  let Inst{26-31} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...25} = RC;
+  let Inst{26...31} = xo;
 }
 
 class VAForm_2<bits<6> xo, dag OOL, dag IOL, string asmstr,
@@ -2038,12 +2038,12 @@ class VAForm_2<bits<6> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
   
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
   let Inst{21}    = 0;
-  let Inst{22-25} = SH;
-  let Inst{26-31} = xo;
+  let Inst{22...25} = SH;
+  let Inst{26...31} = xo;
 }
 
 // E-2 VX-Form
@@ -2056,10 +2056,10 @@ class VXForm_1<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = VA;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = VA;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 class VXForm_setzero<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -2078,10 +2078,10 @@ class VXForm_2<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = 0;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = 0;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 class VXForm_3<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -2092,10 +2092,10 @@ class VXForm_3<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = IMM;
-  let Inst{16-20} = 0;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = IMM;
+  let Inst{16...20} = 0;
+  let Inst{21...31} = xo;
 }
 
 /// VXForm_4 - VX instructions with "VD,0,0" register fields, like mfvscr.
@@ -2106,10 +2106,10 @@ class VXForm_4<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = 0;
-  let Inst{16-20} = 0;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = 0;
+  let Inst{16...20} = 0;
+  let Inst{21...31} = xo;
 }
 
 /// VXForm_5 - VX instructions with "0,0,VB" register fields, like mtvscr.
@@ -2120,10 +2120,10 @@ class VXForm_5<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = 0;
-  let Inst{11-15} = 0;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = 0;
+  let Inst{11...15} = 0;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 // e.g. [PO VRT EO VRB XO]
@@ -2135,10 +2135,10 @@ class VXForm_RD5_XO5_RS5<bits<11> xo, bits<5> eo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = eo;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = eo;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 /// VXForm_CR - VX crypto instructions with "VRT, VRA, ST, SIX"
@@ -2152,11 +2152,11 @@ class VXForm_CR<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = VA;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = VA;
   let Inst{16} =  ST;
-  let Inst{17-20} = SIX;
-  let Inst{21-31} = xo;
+  let Inst{17...20} = SIX;
+  let Inst{21...31} = xo;
 }
 
 /// VXForm_BX - VX crypto instructions with "VRT, VRA, 0 - like vsbox"
@@ -2168,10 +2168,10 @@ class VXForm_BX<bits<11> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = VA;
-  let Inst{16-20} = 0;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = VA;
+  let Inst{16...20} = 0;
+  let Inst{21...31} = xo;
 }
 
 // E-4 VXR-Form
@@ -2185,11 +2185,11 @@ class VXRForm_1<bits<10> xo, dag OOL, dag IOL, string asmstr,
   
   let Pattern = pattern;
   
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = VA;
-  let Inst{16-20} = VB;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = VA;
+  let Inst{16...20} = VB;
   let Inst{21}    = RC;
-  let Inst{22-31} = xo;
+  let Inst{22...31} = xo;
 }
 
 // VX-Form: [PO VRT EO VRB 1 PS XO]
@@ -2203,12 +2203,12 @@ class VX_RD5_EO5_RS5_PS1_XO9<bits<5> eo, bits<9> xo,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = eo;
-  let Inst{16-20} = VB;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = eo;
+  let Inst{16...20} = VB;
   let Inst{21}    = 1;
   let Inst{22}    = PS;
-  let Inst{23-31} = xo;
+  let Inst{23...31} = xo;
 }
 
 // VX-Form: [PO VRT VRA VRB 1 PS XO] or [PO VRT VRA VRB 1 / XO]
@@ -2222,12 +2222,12 @@ class VX_RD5_RSp5_PS1_XO9<bits<9> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = VD;
-  let Inst{11-15} = VA;
-  let Inst{16-20} = VB;
+  let Inst{6...10}  = VD;
+  let Inst{11...15} = VA;
+  let Inst{16...20} = VB;
   let Inst{21}    = 1;
   let Inst{22}    = PS;
-  let Inst{23-31} = xo;
+  let Inst{23...31} = xo;
 }
 
 class Z22Form_BF3_FRA5_DCM6<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
@@ -2240,11 +2240,11 @@ class Z22Form_BF3_FRA5_DCM6<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = BF;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = FRA;
-  let Inst{16-21} = DCM;
-  let Inst{22-30} = xo;
+  let Inst{6...8}   = BF;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = FRA;
+  let Inst{16...21} = DCM;
+  let Inst{22...30} = xo;
   let Inst{31}    = 0;
 }
 
@@ -2260,10 +2260,10 @@ class Z22Form_FRTA5_SH6<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   bit RC = 0; // set by isRecordForm
 
-  let Inst{6 - 10} = FRT;
-  let Inst{11 - 15} = FRA;
-  let Inst{16 - 21} = SH;
-  let Inst{22 - 30} = xo;
+  let Inst{6...10} = FRT;
+  let Inst{11...15} = FRA;
+  let Inst{16...21} = SH;
+  let Inst{22...30} = xo;
   let Inst{31} = RC;
 }
 
@@ -2279,12 +2279,12 @@ class Z23Form_8<bits<6> opcode, bits<8> xo, dag OOL, dag IOL, string asmstr,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = VRT;
-  let Inst{11-14} = 0;
+  let Inst{6...10}  = VRT;
+  let Inst{11...14} = 0;
   let Inst{15} = R;
-  let Inst{16-20} = VRB;
-  let Inst{21-22} = idx;
-  let Inst{23-30} = xo;
+  let Inst{16...20} = VRB;
+  let Inst{21...22} = idx;
+  let Inst{23...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -2298,11 +2298,11 @@ class Z23Form_RTAB5_CY2<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-22} = CY;
-  let Inst{23-30} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...22} = CY;
+  let Inst{23...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -2318,11 +2318,11 @@ class Z23Form_FRTAB5_RMC2<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 
   bit RC = 0; // set by isRecordForm
 
-  let Inst{6 - 10} = FRT;
-  let Inst{11 - 15} = FRA;
-  let Inst{16 - 20} = FRB;
-  let Inst{21 - 22} = RMC;
-  let Inst{23 - 30} = xo;
+  let Inst{6...10} = FRT;
+  let Inst{11...15} = FRA;
+  let Inst{16...20} = FRB;
+  let Inst{21...22} = RMC;
+  let Inst{23...30} = xo;
   let Inst{31} = RC;
 }
 
@@ -2345,12 +2345,12 @@ class Z23Form_FRTB5_R1_RMC2<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 
   bit RC = 0; // set by isRecordForm
 
-  let Inst{6 - 10} = FRT;
-  let Inst{11 - 14} = 0;
+  let Inst{6...10} = FRT;
+  let Inst{11...14} = 0;
   let Inst{15} = R;
-  let Inst{16 - 20} = FRB;
-  let Inst{21 - 22} = RMC;
-  let Inst{23 - 30} = xo;
+  let Inst{16...20} = FRB;
+  let Inst{21...22} = RMC;
+  let Inst{23...30} = xo;
   let Inst{31} = RC;
 }
 
@@ -2362,7 +2362,7 @@ class PPCEmitTimePseudo<dag OOL, dag IOL, string asmstr, list<dag> pattern>
   let isCodeGenOnly = 1;
   let PPC64 = 0;
   let Pattern = pattern;
-  let Inst{31-0} = 0;
+  let Inst{31...0} = 0;
   let hasNoSchedulingInfo = 1;
 }
 

--- a/llvm/lib/Target/PowerPC/PPCInstrFuture.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFuture.td
@@ -23,11 +23,11 @@ class XOForm_RTAB5_L1<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   bit RC = 0;    // set by isRecordForm
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
   let Inst{21}    = L;
-  let Inst{22-30} = xo;
+  let Inst{22...30} = xo;
   let Inst{31}    = RC;
 }
 
@@ -52,10 +52,10 @@ class VXForm_VRTB5<bits<11> xo, bits<5> R, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6 -10} = VRT;
-  let Inst{11 -15} = R;
-  let Inst{16 -20} = VRB;
-  let Inst{21 -31} = xo;
+  let Inst{6...10} = VRT;
+  let Inst{11...15} = R;
+  let Inst{16...20} = VRB;
+  let Inst{21...31} = xo;
 }
 
 class VXForm_VRTB5_UIM2<bits<11> xo, bits<3> R, dag OOL, dag IOL, string asmstr,
@@ -67,11 +67,11 @@ class VXForm_VRTB5_UIM2<bits<11> xo, bits<3> R, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6 -10} = VRT;
-  let Inst{11 -13} = R;
-  let Inst{14 -15} = UIM;
-  let Inst{16 -20} = VRB;
-  let Inst{21 -31} = xo;
+  let Inst{6...10} = VRT;
+  let Inst{11...13} = R;
+  let Inst{14...15} = UIM;
+  let Inst{16...20} = VRB;
+  let Inst{21...31} = xo;
 }
 
 class VXForm_VRTB5_UIM1<bits<11> xo, bits<4> R, dag OOL, dag IOL, string asmstr,
@@ -83,11 +83,11 @@ class VXForm_VRTB5_UIM1<bits<11> xo, bits<4> R, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6 -10} = VRT;
-  let Inst{11 -14} = R;
+  let Inst{6...10} = VRT;
+  let Inst{11...14} = R;
   let Inst{15} = UIM;
-  let Inst{16 -20} = VRB;
-  let Inst{21 -31} = xo;
+  let Inst{16...20} = VRB;
+  let Inst{21...31} = xo;
 }
 
 class VXForm_VRTB5_UIM3<bits<11> xo, bits<2> R, dag OOL, dag IOL, string asmstr,
@@ -99,11 +99,11 @@ class VXForm_VRTB5_UIM3<bits<11> xo, bits<2> R, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6 -10} = VRT;
-  let Inst{11 -12} = R;
-  let Inst{13 -15} = UIM;
-  let Inst{16 -20} = VRB;
-  let Inst{21 -31} = xo;
+  let Inst{6...10} = VRT;
+  let Inst{11...12} = R;
+  let Inst{13...15} = UIM;
+  let Inst{16...20} = VRB;
+  let Inst{21...31} = xo;
 }
 
 class VXForm_VRTAB5<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -114,10 +114,10 @@ class VXForm_VRTAB5<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6 -10} = VRT;
-  let Inst{11 -15} = VRA;
-  let Inst{16 -20} = VRB;
-  let Inst{21 -31} = xo;
+  let Inst{6...10} = VRT;
+  let Inst{11...15} = VRA;
+  let Inst{16...20} = VRB;
+  let Inst{21...31} = xo;
 }
 
 let Predicates = [IsISAFuture] in {

--- a/llvm/lib/Target/PowerPC/PPCInstrFutureMMA.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrFutureMMA.td
@@ -22,13 +22,13 @@ class XX3Form_AT3_XABp5_P1<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -8} = AT{2 -0};
-  let Inst{9 -10} = 0;
-  let Inst{11 -14} = XAp{3 -0};
+  let Inst{6...8} = AT{2...0};
+  let Inst{9...10} = 0;
+  let Inst{11...14} = XAp{3...0};
   let Inst{15} = P;
-  let Inst{16 -19} = XBp{3 -0};
+  let Inst{16...19} = XBp{3...0};
   let Inst{20} = 0;
-  let Inst{21 -28} = xo;
+  let Inst{21...28} = xo;
   let Inst{29} = XAp{4};
   let Inst{30} = XBp{4};
   let Inst{31} = 0;
@@ -43,12 +43,12 @@ class XX2Form_AT3_XBp5_P2<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -8} = AT{2 -0};
-  let Inst{9 -14} = 0;
+  let Inst{6...8} = AT{2...0};
+  let Inst{9...14} = 0;
   let Inst{15} = P{0};
-  let Inst{16 -19} = XBp{3 -0};
+  let Inst{16...19} = XBp{3...0};
   let Inst{20} = P{1};
-  let Inst{21 -29} = xo;
+  let Inst{21...29} = xo;
   let Inst{30} = XBp{4};
   let Inst{31} = 0;
 }
@@ -61,12 +61,12 @@ class XForm_ATB3<bits<6> opcode, bits<5> o, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -8} = AT{2 -0};
-  let Inst{9 -10} = 0;
-  let Inst{11 -15} = o;
-  let Inst{16 -18} = AB{2 -0};
-  let Inst{19 -20} = 0;
-  let Inst{21 -30} = xo;
+  let Inst{6...8} = AT{2...0};
+  let Inst{9...10} = 0;
+  let Inst{11...15} = o;
+  let Inst{16...18} = AB{2...0};
+  let Inst{19...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -79,12 +79,12 @@ class XX3Form_AT3_XAp5B6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -8} = AT;
-  let Inst{9 -10} = 0;
-  let Inst{11 -14} = XAp{3 -0};
+  let Inst{6...8} = AT;
+  let Inst{9...10} = 0;
+  let Inst{11...14} = XAp{3...0};
   let Inst{15} = 0;
-  let Inst{16 -20} = XB{4 -0};
-  let Inst{21 -28} = xo;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...28} = xo;
   let Inst{29} = XAp{4};
   let Inst{30} = XB{5};
   let Inst{31} = 0;
@@ -104,20 +104,20 @@ class MMIRR_XX3Form_X8YP4_XAp5B6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6 -7} = 3;
-  let Inst{8 -11} = 9;
-  let Inst{12 -15} = 0;
-  let Inst{16 -19} = PMSK;
-  let Inst{20 -27} = XMSK;
-  let Inst{28 -31} = YMSK;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...15} = 0;
+  let Inst{16...19} = PMSK;
+  let Inst{20...27} = XMSK;
+  let Inst{28...31} = YMSK;
 
   // The instruction.
-  let Inst{38 -40} = AT;
-  let Inst{41 -42} = 0;
-  let Inst{43 -46} = XAp{3 -0};
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...46} = XAp{3...0};
   let Inst{47} = 0;
-  let Inst{48 -52} = XB{4 -0};
-  let Inst{53 -60} = xo;
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XAp{4};
   let Inst{62} = XB{5};
   let Inst{63} = 0;
@@ -137,21 +137,21 @@ class MMIRR_XX3Form_X8Y4P2_XAp5B6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6 -7} = 3;
-  let Inst{8 -11} = 9;
-  let Inst{12 -15} = 0;
-  let Inst{16 -17} = PMSK;
-  let Inst{18 -19} = 0;
-  let Inst{20 -27} = XMSK;
-  let Inst{28 -31} = YMSK;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...15} = 0;
+  let Inst{16...17} = PMSK;
+  let Inst{18...19} = 0;
+  let Inst{20...27} = XMSK;
+  let Inst{28...31} = YMSK;
 
   // The instruction.
-  let Inst{38 -40} = AT;
-  let Inst{41 -42} = 0;
-  let Inst{43 -46} = XAp{3 -0};
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...46} = XAp{3...0};
   let Inst{47} = 0;
-  let Inst{48 -52} = XB{4 -0};
-  let Inst{53 -60} = xo;
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XAp{4};
   let Inst{62} = XB{5};
   let Inst{63} = 0;
@@ -358,13 +358,13 @@ class XForm_AT3_T1_AB3<bits<6> opcode, bits<5> o, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -8} = AT{2 -0};
+  let Inst{6...8} = AT{2...0};
   let Inst{9} = 0;
   let Inst{10} = T;
-  let Inst{11 -15} = o;
-  let Inst{16 -18} = AB{2 -0};
-  let Inst{19 -20} = 0;
-  let Inst{21 -30} = xo;
+  let Inst{11...15} = o;
+  let Inst{16...18} = AB{2...0};
+  let Inst{19...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -376,11 +376,11 @@ class XForm_ATp2_SR5<bits<6> opcode, bits<5> o, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -7} = ATp{1 -0};
-  let Inst{8 -10} = 0;
-  let Inst{11 -15} = o;
-  let Inst{16 -20} = SR{4 -0};
-  let Inst{21 -30} = xo;
+  let Inst{6...7} = ATp{1...0};
+  let Inst{8...10} = 0;
+  let Inst{11...15} = o;
+  let Inst{16...20} = SR{4...0};
+  let Inst{21...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -395,13 +395,13 @@ class XX2Form_AT3_XB6_ID2_E1_BL2<bits<6> opcode, bits<9> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6 -8} = AT{2 -0};
-  let Inst{9 -10} = 0;
-  let Inst{11 -12} = ID{1 -0};
+  let Inst{6...8} = AT{2...0};
+  let Inst{9...10} = 0;
+  let Inst{11...12} = ID{1...0};
   let Inst{13} = E;
-  let Inst{14 -15} = BL{1 -0};
-  let Inst{16 -20} = XB{4 -0};
-  let Inst{21 -29} = xo;
+  let Inst{14...15} = BL{1...0};
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30} = XB{5};
   let Inst{31} = 0;
 }

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.td
@@ -4275,7 +4275,7 @@ def WRTEEI: I<31, (outs), (ins i1imm:$E), "wrteei $E", IIC_SprMTMSR>,
   bits<1> E;
 
   let Inst{16} = E;
-  let Inst{21-30} = 163;
+  let Inst{21...30} = 163;
 }
 
 def DCCCI : XForm_tlb<454, (outs), (ins gprc:$RA, gprc:$RB),

--- a/llvm/lib/Target/PowerPC/PPCInstrP10.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrP10.td
@@ -125,8 +125,8 @@ class PI<bits<6> pref, bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let InOperandList = IOL;
   let AsmString = asmstr;
   let Itinerary = itin;
-  let Inst{0-5} = pref;
-  let Inst{32-37} = opcode;
+  let Inst{0...5} = pref;
+  let Inst{32...37} = opcode;
 
   bits<1> PPC970_First = 0;
   bits<1> PPC970_Single = 0;
@@ -138,7 +138,7 @@ class PI<bits<6> pref, bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let TSFlags{0}   = PPC970_First;
   let TSFlags{1}   = PPC970_Single;
   let TSFlags{2}   = PPC970_Cracked;
-  let TSFlags{5-3} = PPC970_Unit;
+  let TSFlags{5...3} = PPC970_Unit;
 
   bits<1> Prefixed = 1;  // This is a prefixed instruction.
   let TSFlags{7}  = Prefixed;
@@ -167,11 +167,11 @@ class VXForm_VTB5_RC<bits<10> xo, bits<5> R, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10} = VT;
-  let Inst{11-15} = R;
-  let Inst{16-20} = VB;
+  let Inst{6...10} = VT;
+  let Inst{11...15} = R;
+  let Inst{16...20} = VB;
   let Inst{21} = RC;
-  let Inst{22-31} = xo;
+  let Inst{22...31} = xo;
 }
 
 // Multiclass definition to account for record and non-record form
@@ -200,16 +200,16 @@ class MLS_DForm_R_SI34_RTA5_MEM<bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 2;
-  let Inst{8-10} = 0;
+  let Inst{6...7} = 2;
+  let Inst{8...10} = 0;
   let Inst{11} = PCRel;
-  let Inst{12-13} = 0;
-  let Inst{14-31} = D{33-16}; // d0
+  let Inst{12...13} = 0;
+  let Inst{14...31} = D{33...16}; // d0
 
   // The instruction.
-  let Inst{38-42} = RST{4-0};
-  let Inst{43-47} = RA;
-  let Inst{48-63} = D{15-0}; // d1
+  let Inst{38...42} = RST{4...0};
+  let Inst{43...47} = RA;
+  let Inst{48...63} = D{15...0}; // d1
 }
 
 class MLS_DForm_R_SI34_RTA5<bits<6> opcode, dag OOL, dag IOL, string asmstr,
@@ -222,16 +222,16 @@ class MLS_DForm_R_SI34_RTA5<bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 2;
-  let Inst{8-10} = 0;
+  let Inst{6...7} = 2;
+  let Inst{8...10} = 0;
   let Inst{11} = PCRel;
-  let Inst{12-13} = 0;
-  let Inst{14-31} = SI{33-16};
+  let Inst{12...13} = 0;
+  let Inst{14...31} = SI{33...16};
 
   // The instruction.
-  let Inst{38-42} = RT;
-  let Inst{43-47} = RA;
-  let Inst{48-63} = SI{15-0};
+  let Inst{38...42} = RT;
+  let Inst{43...47} = RA;
+  let Inst{48...63} = SI{15...0};
 }
 
 class MLS_DForm_SI34_RT5<bits<6> opcode, dag OOL, dag IOL, string asmstr,
@@ -243,16 +243,16 @@ class MLS_DForm_SI34_RT5<bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 2;
-  let Inst{8-10} = 0;
+  let Inst{6...7} = 2;
+  let Inst{8...10} = 0;
   let Inst{11} = 0;
-  let Inst{12-13} = 0;
-  let Inst{14-31} = SI{33-16};
+  let Inst{12...13} = 0;
+  let Inst{14...31} = SI{33...16};
 
   // The instruction.
-  let Inst{38-42} = RT;
-  let Inst{43-47} = 0;
-  let Inst{48-63} = SI{15-0};
+  let Inst{38...42} = RT;
+  let Inst{43...47} = 0;
+  let Inst{48...63} = SI{15...0};
 }
 
 multiclass MLS_DForm_R_SI34_RTA5_p<bits<6> opcode, dag OOL, dag IOL,
@@ -274,15 +274,15 @@ class 8LS_DForm_R_SI34_RTA5_MEM<bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-10} = 0;
+  let Inst{6...10} = 0;
   let Inst{11} = PCRel;
-  let Inst{12-13} = 0;
-  let Inst{14-31} = D{33-16}; // d0
+  let Inst{12...13} = 0;
+  let Inst{14...31} = D{33...16}; // d0
 
   // The instruction.
-  let Inst{38-42} = RST{4-0};
-  let Inst{43-47} = RA;
-  let Inst{48-63} = D{15-0}; // d1
+  let Inst{38...42} = RST{4...0};
+  let Inst{43...47} = RA;
+  let Inst{48...63} = D{15...0}; // d1
 }
 
 // 8LS:D-Form: [ 1 0 0 // R // d0
@@ -298,18 +298,18 @@ class 8LS_DForm_R_SI34_XT6_RA5_MEM<bits<5> opcode, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 0;
+  let Inst{6...7} = 0;
   let Inst{8} = 0;
-  let Inst{9-10} = 0; // reserved
+  let Inst{9...10} = 0; // reserved
   let Inst{11} = PCRel;
-  let Inst{12-13} = 0; // reserved
-  let Inst{14-31} = D{33-16}; // d0
+  let Inst{12...13} = 0; // reserved
+  let Inst{14...31} = D{33...16}; // d0
 
   // The instruction.
   let Inst{37} = XST{5};
-  let Inst{38-42} = XST{4-0};
-  let Inst{43-47} = RA;
-  let Inst{48-63} = D{15-0}; // d1
+  let Inst{38...42} = XST{4...0};
+  let Inst{43...47} = RA;
+  let Inst{48...63} = D{15...0}; // d1
 }
 
 // X-Form: [PO T IMM VRB XO TX]
@@ -321,10 +321,10 @@ class XForm_XT6_IMM5_VB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
   bits<5> IMM;
 
   let Pattern = pattern;
-  let Inst{6-10} = XT{4-0};
-  let Inst{11-15} = IMM;
-  let Inst{16-20} = VRB;
-  let Inst{21-30} = xo;
+  let Inst{6...10} = XT{4...0};
+  let Inst{11...15} = IMM;
+  let Inst{16...20} = VRB;
+  let Inst{21...30} = xo;
   let Inst{31} = XT{5};
 }
 
@@ -341,19 +341,19 @@ class 8RR_XX4Form_IMM8_XTAB6<bits<6> opcode, bits<2> xo,
     let Pattern = pattern;
 
     // The prefix.
-    let Inst{6-7} = 1;
+    let Inst{6...7} = 1;
     let Inst{8} = 0;
-    let Inst{9-11} = 0;
-    let Inst{12-13} = 0;
-    let Inst{14-23} = 0;
-    let Inst{24-31} = IMM;
+    let Inst{9...11} = 0;
+    let Inst{12...13} = 0;
+    let Inst{14...23} = 0;
+    let Inst{24...31} = IMM;
 
     // The instruction.
-    let Inst{38-42} = XT{4-0};
-    let Inst{43-47} = XA{4-0};
-    let Inst{48-52} = XB{4-0};
-    let Inst{53-57} = XC{4-0};
-    let Inst{58-59} = xo;
+    let Inst{38...42} = XT{4...0};
+    let Inst{43...47} = XA{4...0};
+    let Inst{48...52} = XB{4...0};
+    let Inst{53...57} = XC{4...0};
+    let Inst{58...59} = xo;
     let Inst{60} = XC{5};
     let Inst{61} = XA{5};
     let Inst{62} = XB{5};
@@ -369,11 +369,11 @@ class VXForm_RD5_N3_VB5<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RD;
-  let Inst{11-12} = 0;
-  let Inst{13-15} = N;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = RD;
+  let Inst{11...12} = 0;
+  let Inst{13...15} = N;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 
@@ -401,11 +401,11 @@ class VXForm_BF3_VAB5<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-8} = BF;
-  let Inst{9-10} = 0;
-  let Inst{11-15} = VA;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{6...8} = BF;
+  let Inst{9...10} = 0;
+  let Inst{11...15} = VA;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 // VN-Form: [PO VRT VRA VRB PS SD XO]
@@ -420,12 +420,12 @@ class VNForm_VTAB5_SD3<bits<6> xo, bits<2> ps, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = VRT;
-  let Inst{11-15} = VRA;
-  let Inst{16-20} = VRB;
-  let Inst{21-22} = ps;
-  let Inst{23-25} = SD;
-  let Inst{26-31} = xo;
+  let Inst{6...10}  = VRT;
+  let Inst{11...15} = VRA;
+  let Inst{16...20} = VRB;
+  let Inst{21...22} = ps;
+  let Inst{23...25} = SD;
+  let Inst{26...31} = xo;
 }
 
 class VXForm_RD5_MP_VB5<bits<11> xo, bits<4> eo, dag OOL, dag IOL,
@@ -437,11 +437,11 @@ class VXForm_RD5_MP_VB5<bits<11> xo, bits<4> eo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RD;
-  let Inst{11-14} = eo;
+  let Inst{6...10}  = RD;
+  let Inst{11...14} = eo;
   let Inst{15} = MP;
-  let Inst{16-20} = VB;
-  let Inst{21-31} = xo;
+  let Inst{16...20} = VB;
+  let Inst{21...31} = xo;
 }
 
 // 8RR:D-Form: [ 1 1 0 // // imm0
@@ -456,17 +456,17 @@ class 8RR_DForm_IMM32_XT6<bits<6> opcode, bits<4> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 1;
-  let Inst{8-11} = 0;
-  let Inst{12-13} = 0; // reserved
-  let Inst{14-15} = 0; // reserved
-  let Inst{16-31} = IMM32{31-16};
+  let Inst{6...7} = 1;
+  let Inst{8...11} = 0;
+  let Inst{12...13} = 0; // reserved
+  let Inst{14...15} = 0; // reserved
+  let Inst{16...31} = IMM32{31...16};
 
   // The instruction.
-  let Inst{38-42} = XT{4-0};
-  let Inst{43-46} = xo;
+  let Inst{38...42} = XT{4...0};
+  let Inst{43...46} = xo;
   let Inst{47} = XT{5};
-  let Inst{48-63} = IMM32{15-0};
+  let Inst{48...63} = IMM32{15...0};
 }
 
 // 8RR:D-Form: [ 1 1 0 // // imm0
@@ -482,18 +482,18 @@ class 8RR_DForm_IMM32_XT6_IX<bits<6> opcode, bits<3> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 1;
-  let Inst{8-11} = 0;
-  let Inst{12-13} = 0; // reserved
-  let Inst{14-15} = 0; // reserved
-  let Inst{16-31} = IMM32{31-16};
+  let Inst{6...7} = 1;
+  let Inst{8...11} = 0;
+  let Inst{12...13} = 0; // reserved
+  let Inst{14...15} = 0; // reserved
+  let Inst{16...31} = IMM32{31...16};
 
   // The instruction.
-  let Inst{38-42} = XT{4-0};
-  let Inst{43-45} = xo;
+  let Inst{38...42} = XT{4...0};
+  let Inst{43...45} = xo;
   let Inst{46} = IX;
   let Inst{47} = XT{5};
-  let Inst{48-63} = IMM32{15-0};
+  let Inst{48...63} = IMM32{15...0};
 }
 
 class 8RR_XX4Form_XTABC6<bits<6> opcode, bits<2> xo, dag OOL, dag IOL,
@@ -507,17 +507,17 @@ class 8RR_XX4Form_XTABC6<bits<6> opcode, bits<2> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 1;
-  let Inst{8-11} = 0;
-  let Inst{12-13} = 0;
-  let Inst{14-31} = 0;
+  let Inst{6...7} = 1;
+  let Inst{8...11} = 0;
+  let Inst{12...13} = 0;
+  let Inst{14...31} = 0;
 
   // The instruction.
-  let Inst{38-42} = XT{4-0};
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-57} = XC{4-0};
-  let Inst{58-59} = xo;
+  let Inst{38...42} = XT{4...0};
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...57} = XC{4...0};
+  let Inst{58...59} = xo;
   let Inst{60} = XC{5};
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
@@ -537,18 +537,18 @@ class 8RR_XX4Form_IMM3_XTABC6<bits<6> opcode, bits<2> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 1;
-  let Inst{8-11} = 0;
-  let Inst{12-13} = 0;
-  let Inst{14-28} = 0;
-  let Inst{29-31} = IMM;
+  let Inst{6...7} = 1;
+  let Inst{8...11} = 0;
+  let Inst{12...13} = 0;
+  let Inst{14...28} = 0;
+  let Inst{29...31} = IMM;
 
   // The instruction.
-  let Inst{38-42} = XT{4-0};
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-57} = XC{4-0};
-  let Inst{58-59} = xo;
+  let Inst{38...42} = XT{4...0};
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...57} = XC{4...0};
+  let Inst{58...59} = xo;
   let Inst{60} = XC{5};
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
@@ -565,11 +565,11 @@ class XX2_BF3_XO5_XB6_XO9<bits<6> opcode, bits<5> xo2, bits<9> xo, dag OOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}   = BF;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = xo2;
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-29} = xo;
+  let Inst{6...8}   = BF;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = xo2;
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...29} = xo;
   let Inst{30}    = XB{5};
   let Inst{31}    = 0;
 }
@@ -863,11 +863,11 @@ class DQForm_XTp5_RA17_MEM<bits<6> opcode, bits<4> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-9} = XTp{3-0};
+  let Inst{6...9} = XTp{3...0};
   let Inst{10} = XTp{4};
-  let Inst{11-15} = RA;
-  let Inst{16-27} = DQ;
-  let Inst{28-31} = xo;
+  let Inst{11...15} = RA;
+  let Inst{16...27} = DQ;
+  let Inst{28...31} = xo;
 }
 
 class XForm_XTp5_XAB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
@@ -878,11 +878,11 @@ class XForm_XTp5_XAB5<bits<6> opcode, bits<10> xo, dag OOL, dag IOL,
   bits<5> RB;
 
   let Pattern = pattern;
-  let Inst{6-9} = XTp{3-0};
+  let Inst{6...9} = XTp{3...0};
   let Inst{10} = XTp{4};
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-30} = xo;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -896,16 +896,16 @@ class 8LS_DForm_R_XTp5_SI34_MEM<bits<6> opcode, dag OOL, dag IOL, string asmstr,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-10} = 0;
+  let Inst{6...10} = 0;
   let Inst{11} = PCRel;
-  let Inst{12-13} = 0;
-  let Inst{14-31} = D{33-16}; // Imm18
+  let Inst{12...13} = 0;
+  let Inst{14...31} = D{33...16}; // Imm18
 
   // The instruction.
-  let Inst{38-41} = XTp{3-0};
+  let Inst{38...41} = XTp{3...0};
   let Inst{42}    = XTp{4};
-  let Inst{43-47} = RA;
-  let Inst{48-63} = D{15-0};
+  let Inst{43...47} = RA;
+  let Inst{48...63} = D{15...0};
 }
 
 multiclass 8LS_DForm_R_XTp5_SI34_MEM_p<bits<6> opcode, dag OOL,
@@ -935,11 +935,11 @@ class XForm_AT3<bits<6> opcode, bits<5> xo2, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8}  = AT;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = xo2;
-  let Inst{16-20} = 0;
-  let Inst{21-30} = xo;
+  let Inst{6...8}  = AT;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = xo2;
+  let Inst{16...20} = 0;
+  let Inst{21...30} = xo;
   let Inst{31} = 0;
 }
 
@@ -952,10 +952,10 @@ class XForm_XT6_IMM5<bits<6> opcode, bits<5> eo, bits<10> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-10} = XT{4-0};
-  let Inst{11-15} = eo;
-  let Inst{16-20} = UIM;
-  let Inst{21-30} = xo;
+  let Inst{6...10} = XT{4...0};
+  let Inst{11...15} = eo;
+  let Inst{16...20} = UIM;
+  let Inst{21...30} = xo;
   let Inst{31} = XT{5};
 }
 
@@ -969,11 +969,11 @@ class XX3Form_AT3_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
 
   let Pattern = pattern;
 
-  let Inst{6-8} = AT;
-  let Inst{9-10} = 0;
-  let Inst{11-15} = XA{4-0};
-  let Inst{16-20} = XB{4-0};
-  let Inst{21-28} = xo;
+  let Inst{6...8} = AT;
+  let Inst{9...10} = 0;
+  let Inst{11...15} = XA{4...0};
+  let Inst{16...20} = XB{4...0};
+  let Inst{21...28} = xo;
   let Inst{29}    = XA{5};
   let Inst{30}    = XB{5};
   let Inst{31} = 0;
@@ -993,20 +993,20 @@ class MMIRR_XX3Form_XY4P2_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 3;
-  let Inst{8-11} = 9;
-  let Inst{12-15} = 0;
-  let Inst{16-17} = PMSK;
-  let Inst{18-23} = 0;
-  let Inst{24-27} = XMSK;
-  let Inst{28-31} = YMSK;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...15} = 0;
+  let Inst{16...17} = PMSK;
+  let Inst{18...23} = 0;
+  let Inst{24...27} = XMSK;
+  let Inst{28...31} = YMSK;
 
   // The instruction.
-  let Inst{38-40} = AT;
-  let Inst{41-42} = 0;
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-60} = xo;
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
   let Inst{63} = 0;
@@ -1025,18 +1025,18 @@ class MMIRR_XX3Form_XY4_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 3;
-  let Inst{8-11} = 9;
-  let Inst{12-23} = 0;
-  let Inst{24-27} = XMSK;
-  let Inst{28-31} = YMSK;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...23} = 0;
+  let Inst{24...27} = XMSK;
+  let Inst{28...31} = YMSK;
 
   // The instruction.
-  let Inst{38-40} = AT;
-  let Inst{41-42} = 0;
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-60} = xo;
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
   let Inst{63} = 0;
@@ -1055,19 +1055,19 @@ class MMIRR_XX3Form_X4Y2_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 3;
-  let Inst{8-11} = 9;
-  let Inst{12-23} = 0;
-  let Inst{24-27} = XMSK;
-  let Inst{28-29} = YMSK;
-  let Inst{30-31} = 0;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...23} = 0;
+  let Inst{24...27} = XMSK;
+  let Inst{28...29} = YMSK;
+  let Inst{30...31} = 0;
 
   // The instruction.
-  let Inst{38-40} = AT;
-  let Inst{41-42} = 0;
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-60} = xo;
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
   let Inst{63} = 0;
@@ -1087,19 +1087,19 @@ class MMIRR_XX3Form_XY4P8_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 3;
-  let Inst{8-11} = 9;
-  let Inst{12-15} = 0;
-  let Inst{16-23} = PMSK;
-  let Inst{24-27} = XMSK;
-  let Inst{28-31} = YMSK;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...15} = 0;
+  let Inst{16...23} = PMSK;
+  let Inst{24...27} = XMSK;
+  let Inst{28...31} = YMSK;
 
   // The instruction.
-  let Inst{38-40} = AT;
-  let Inst{41-42} = 0;
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-60} = xo;
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
   let Inst{63} = 0;
@@ -1119,20 +1119,20 @@ class MMIRR_XX3Form_XYP4_XAB6<bits<6> opcode, bits<8> xo, dag OOL, dag IOL,
   let Pattern = pattern;
 
   // The prefix.
-  let Inst{6-7} = 3;
-  let Inst{8-11} = 9;
-  let Inst{12-15} = 0;
-  let Inst{16-19} = PMSK;
-  let Inst{20-23} = 0;
-  let Inst{24-27} = XMSK;
-  let Inst{28-31} = YMSK;
+  let Inst{6...7} = 3;
+  let Inst{8...11} = 9;
+  let Inst{12...15} = 0;
+  let Inst{16...19} = PMSK;
+  let Inst{20...23} = 0;
+  let Inst{24...27} = XMSK;
+  let Inst{28...31} = YMSK;
 
   // The instruction.
-  let Inst{38-40} = AT;
-  let Inst{41-42} = 0;
-  let Inst{43-47} = XA{4-0};
-  let Inst{48-52} = XB{4-0};
-  let Inst{53-60} = xo;
+  let Inst{38...40} = AT;
+  let Inst{41...42} = 0;
+  let Inst{43...47} = XA{4...0};
+  let Inst{48...52} = XB{4...0};
+  let Inst{53...60} = xo;
   let Inst{61} = XA{5};
   let Inst{62} = XB{5};
   let Inst{63} = 0;

--- a/llvm/lib/Target/PowerPC/PPCInstrSPE.td
+++ b/llvm/lib/Target/PowerPC/PPCInstrSPE.td
@@ -20,10 +20,10 @@ class EFXForm_1<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...31} = xo;
 }
 
 class EFXForm_2<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -45,11 +45,11 @@ class EFXForm_3<bits<11> xo, dag OOL, dag IOL, string asmstr,
   bits<5> RA;
   bits<5> RB;
 
-  let Inst{6-8}  = crD;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-31} = xo;
+  let Inst{6...8}  = crD;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...31} = xo;
 }
 
 class EVXForm_1<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -61,10 +61,10 @@ class EVXForm_1<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...31} = xo;
 }
 
 class EVXForm_2<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -88,11 +88,11 @@ class EVXForm_3<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-8}  = crD;
-  let Inst{9-10}  = 0;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-31} = xo;
+  let Inst{6...8}  = crD;
+  let Inst{9...10}  = 0;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...31} = xo;
 }
 
 class EVXForm_4<bits<8> xo, dag OOL, dag IOL, string asmstr,
@@ -105,11 +105,11 @@ class EVXForm_4<bits<8> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = RB;
-  let Inst{21-28} = xo;
-  let Inst{29-31} = crD;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = RB;
+  let Inst{21...28} = xo;
+  let Inst{29...31} = crD;
 }
 
 class EVXForm_D<bits<11> xo, dag OOL, dag IOL, string asmstr,
@@ -121,10 +121,10 @@ class EVXForm_D<bits<11> xo, dag OOL, dag IOL, string asmstr,
 
   let Pattern = pattern;
 
-  let Inst{6-10}  = RT;
-  let Inst{11-15} = RA;
-  let Inst{16-20} = D;
-  let Inst{21-31} = xo;
+  let Inst{6...10}  = RT;
+  let Inst{11...15} = RA;
+  let Inst{16...20} = D;
+  let Inst{21...31} = xo;
 }
 
 let DecoderNamespace = "SPE", Predicates = [HasSPE] in {


### PR DESCRIPTION
The '-' punctuator was deprecated via: https://github.com/llvm/llvm-project/commit/196e6f9f18933ed33eee39a1c9350ccce6b18e2c