### PR TITLE
[clang] Rewrite tests relying on shell environment variable features

### DIFF
--- a/clang/test/Driver/config-file3.c
+++ b/clang/test/Driver/config-file3.c
@@ -1,3 +1,5 @@
+// Needs symlinks
+// UNSUPPORTED: system-windows
 // REQUIRES: x86-registered-target
 
 // RUN: rm -rf %t && mkdir %t

--- a/clang/test/Driver/config-file3.c
+++ b/clang/test/Driver/config-file3.c
@@ -1,7 +1,5 @@
-// REQUIRES: shell
 // REQUIRES: x86-registered-target
 
-// RUN: unset CLANG_NO_DEFAULT_CONFIG
 // RUN: rm -rf %t && mkdir %t
 
 //--- If config file is specified by relative path (workdir/cfg-s2), it is searched for by that path.
@@ -10,7 +8,9 @@
 // RUN: echo "@subdir/cfg-s2" > %t/workdir/cfg-1
 // RUN: echo "-Wundefined-var-template" > %t/workdir/subdir/cfg-s2
 //
-// RUN: ( cd %t && %clang --config=workdir/cfg-1 -c -### %s 2>&1 | FileCheck %s -check-prefix CHECK-REL )
+// RUN: pushd %t
+// RUN: %clang --config=workdir/cfg-1 -c -### %s 2>&1 | FileCheck %s -check-prefix CHECK-REL
+// RUN: popd
 //
 // CHECK-REL: Configuration file: {{.*}}/workdir/cfg-1
 // CHECK-REL: -Wundefined-var-template
@@ -51,84 +51,84 @@
 // RUN: touch %t/testdmode/clang++.cfg
 // RUN: touch %t/testdmode/clang-g++.cfg
 // RUN: touch %t/testdmode/clang.cfg
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
 //
 // FULL1: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu-clang++.cfg
 
 //--- -m32 overrides triple.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-I386 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-I386 --implicit-check-not 'Configuration file:'
 //
 // FULL1-I386: Configuration file: {{.*}}/testdmode/i386-unknown-linux-gnu-clang++.cfg
 
 //--- --target= also works for overriding triple.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --target=i386-unknown-linux-gnu --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-I386 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --target=i386-unknown-linux-gnu --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-I386 --implicit-check-not 'Configuration file:'
 
 //--- With --target= + -m64, -m64 takes precedence.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --target=i386-unknown-linux-gnu -m64 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --target=i386-unknown-linux-gnu -m64 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
 
 //--- i386 prefix also works for 32-bit.
 //
-// RUN: %t/testdmode/i386-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-I386 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/i386-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-I386 --implicit-check-not 'Configuration file:'
 
 //--- i386 prefix + -m64 also works for 64-bit.
 //
-// RUN: %t/testdmode/i386-unknown-linux-gnu-clang-g++ -m64 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/i386-unknown-linux-gnu-clang-g++ -m64 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
 
 //--- File specified by --config= is loaded after the one inferred from the executable.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir=%S/Inputs/config --config-user-dir= --config=i386-qqq.cfg -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix EXPLICIT --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir=%S/Inputs/config --config-user-dir= --config=i386-qqq.cfg -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix EXPLICIT --implicit-check-not 'Configuration file:'
 //
 // EXPLICIT: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu-clang++.cfg
 // EXPLICIT-NEXT: Configuration file: {{.*}}/Inputs/config/i386-qqq.cfg
 
 //--- --no-default-config --config= loads only specified file.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir=%S/Inputs/config --config-user-dir= --no-default-config --config=i386-qqq.cfg -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix EXPLICIT-ONLY --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir=%S/Inputs/config --config-user-dir= --no-default-config --config=i386-qqq.cfg -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix EXPLICIT-ONLY --implicit-check-not 'Configuration file:'
 //
 // EXPLICIT-ONLY: Configuration file: {{.*}}/Inputs/config/i386-qqq.cfg
 
 //--- --no-default-config disables default filenames.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir=%S/Inputs/config --config-user-dir= --no-default-config -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix NO-CONFIG
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir=%S/Inputs/config --config-user-dir= --no-default-config -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix NO-CONFIG
 //
 // NO-CONFIG-NOT: Configuration file:
 
 //--- --driver-mode= is respected.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --driver-mode=gcc --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-GCC --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --driver-mode=gcc --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-GCC --implicit-check-not 'Configuration file:'
 //
 // FULL1-GCC: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu-clang.cfg
 
 //--- "clang" driver symlink should yield the "*-clang" configuration file.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-GCC --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1-GCC --implicit-check-not 'Configuration file:'
 
 //--- "clang" + --driver-mode= should yield "*-clang++".
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang --driver-mode=g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang --driver-mode=g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
 
 //--- Clang started via name prefix that is not valid is forcing that prefix instead of target triple.
 //
-// RUN: %t/testdmode/qqq-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix QQQ --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/qqq-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix QQQ --implicit-check-not 'Configuration file:'
 //
 // QQQ: Configuration file: {{.*}}/testdmode/qqq-clang-g++.cfg
 
 //--- Explicit --target= overrides the triple even with non-standard name prefix.
 //
-// RUN: %t/testdmode/qqq-clang-g++ --target=x86_64-unknown-linux-gnu --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/qqq-clang-g++ --target=x86_64-unknown-linux-gnu --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL1 --implicit-check-not 'Configuration file:'
 
 //--- "x86_64" prefix does not form a valid triple either.
 //
-// RUN: %t/testdmode/x86_64-clang --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix X86_64 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-clang --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix X86_64 --implicit-check-not 'Configuration file:'
 //
 // X86_64: Configuration file: {{.*}}/testdmode/x86_64-clang.cfg
 
 //--- Try cheribsd prefix using misordered triple components.
 //
-// RUN: %t/testdmode/cheribsd-riscv64-hybrid-clang++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix CHERIBSD --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/cheribsd-riscv64-hybrid-clang++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix CHERIBSD --implicit-check-not 'Configuration file:'
 //
 // CHERIBSD: Configuration file: {{.*}}/testdmode/cheribsd-riscv64-hybrid-clang++.cfg
 
@@ -136,13 +136,13 @@
 //
 // RUN: rm %t/testdmode/x86_64-unknown-linux-gnu-clang++.cfg
 // RUN: rm %t/testdmode/i386-unknown-linux-gnu-clang++.cfg
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL2 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL2 --implicit-check-not 'Configuration file:'
 //
 // FULL2: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu-clang-g++.cfg
 
 //--- FULL2 + -m32.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL2-I386 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL2-I386 --implicit-check-not 'Configuration file:'
 //
 // FULL2-I386: Configuration file: {{.*}}/testdmode/i386-unknown-linux-gnu-clang-g++.cfg
 
@@ -155,42 +155,42 @@
 // RUN: rm %t/testdmode/i386-unknown-linux-gnu-clang-g++.cfg
 // RUN: rm %t/testdmode/x86_64-unknown-linux-gnu-clang.cfg
 // RUN: rm %t/testdmode/i386-unknown-linux-gnu-clang.cfg
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL3 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL3 --implicit-check-not 'Configuration file:'
 //
 // FULL3: Configuration file: {{.*}}/testdmode/clang++.cfg
 // FULL3: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu.cfg
 
 //--- FULL3 + -m32.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL3-I386 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL3-I386 --implicit-check-not 'Configuration file:'
 //
 // FULL3-I386: Configuration file: {{.*}}/testdmode/clang++.cfg
 // FULL3-I386: Configuration file: {{.*}}/testdmode/i386-unknown-linux-gnu.cfg
 
 //--- FULL3 + --driver-mode=.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --driver-mode=gcc --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL3-GCC --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --driver-mode=gcc --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL3-GCC --implicit-check-not 'Configuration file:'
 //
 // FULL3-GCC: Configuration file: {{.*}}/testdmode/clang.cfg
 // FULL3-GCC: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu.cfg
 
 //--- QQQ fallback.
 //
-// RUN: %t/testdmode/qqq-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix QQQ-FALLBACK --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/qqq-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix QQQ-FALLBACK --implicit-check-not 'Configuration file:'
 //
 // QQQ-FALLBACK: Configuration file: {{.*}}/testdmode/clang++.cfg
 // QQQ-FALLBACK: Configuration file: {{.*}}/testdmode/qqq.cfg
 
 //--- "x86_64" falback.
 //
-// RUN: %t/testdmode/x86_64-clang --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix X86_64-FALLBACK --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-clang --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix X86_64-FALLBACK --implicit-check-not 'Configuration file:'
 //
 // X86_64-FALLBACK: Configuration file: {{.*}}/testdmode/clang.cfg
 // X86_64-FALLBACK: Configuration file: {{.*}}/testdmode/x86_64.cfg
 
 //--- cheribsd fallback.
 //
-// RUN: %t/testdmode/cheribsd-riscv64-hybrid-clang++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix CHERIBSD-FALLBACK --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/cheribsd-riscv64-hybrid-clang++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix CHERIBSD-FALLBACK --implicit-check-not 'Configuration file:'
 //
 // CHERIBSD-FALLBACK: Configuration file: {{.*}}/testdmode/clang++.cfg
 // CHERIBSD-FALLBACK: Configuration file: {{.*}}/testdmode/cheribsd-riscv64-hybrid.cfg
@@ -198,7 +198,7 @@
 //--- Test fallback to x86_64-unknown-linux-gnu.cfg + clang-g++.cfg.
 //
 // RUN: rm %t/testdmode/clang++.cfg
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL4 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL4 --implicit-check-not 'Configuration file:'
 //
 // FULL4: Configuration file: {{.*}}/testdmode/clang-g++.cfg
 // FULL4: Configuration file: {{.*}}/testdmode/x86_64-unknown-linux-gnu.cfg
@@ -207,20 +207,20 @@
 //
 // RUN: rm %t/testdmode/x86_64-unknown-linux-gnu.cfg
 // RUN: rm %t/testdmode/i386-unknown-linux-gnu.cfg
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL5 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL5 --implicit-check-not 'Configuration file:'
 //
 // FULL5: Configuration file: {{.*}}/testdmode/clang-g++.cfg
 
 //--- FULL5 + -m32.
 //
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL5-I386 --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ -m32 --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix FULL5-I386 --implicit-check-not 'Configuration file:'
 //
 // FULL5-I386: Configuration file: {{.*}}/testdmode/clang-g++.cfg
 
 //--- Test that incorrect driver mode config file is not used.
 //
 // RUN: rm %t/testdmode/clang-g++.cfg
-// RUN: %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix NO-CONFIG
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testdmode/x86_64-unknown-linux-gnu-clang-g++ --config-system-dir= --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix NO-CONFIG
 
 //--- Tilde expansion in user configuration file directory
 //
@@ -232,20 +232,20 @@
 // RUN: touch %t/testdmode/x86_64-apple-darwin23.6.0-clang.cfg
 // RUN: touch %t/testdmode/x86_64-apple-darwin23-clang.cfg
 // RUN: touch %t/testdmode/x86_64-apple-darwin-clang.cfg
-// RUN: %clang -target x86_64-apple-darwin23.6.0 --config-system-dir=%t/testdmode --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix DARWIN --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %clang -target x86_64-apple-darwin23.6.0 --config-system-dir=%t/testdmode --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix DARWIN --implicit-check-not 'Configuration file:'
 //
 // DARWIN: Configuration file: {{.*}}/testdmode/x86_64-apple-darwin23.6.0-clang.cfg
 
 //--- DARWIN + no full version
 //
 // RUN: rm %t/testdmode/x86_64-apple-darwin23.6.0-clang.cfg
-// RUN: %clang -target x86_64-apple-darwin23.6.0 --config-system-dir=%t/testdmode --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix DARWIN-MAJOR --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %clang -target x86_64-apple-darwin23.6.0 --config-system-dir=%t/testdmode --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix DARWIN-MAJOR --implicit-check-not 'Configuration file:'
 //
 // DARWIN-MAJOR: Configuration file: {{.*}}/testdmode/x86_64-apple-darwin23-clang.cfg
 
 //--- DARWIN + no version
 //
 // RUN: rm %t/testdmode/x86_64-apple-darwin23-clang.cfg
-// RUN: %clang -target x86_64-apple-darwin23.6.0 --config-system-dir=%t/testdmode --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix DARWIN-VERSIONLESS --implicit-check-not 'Configuration file:'
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %clang -target x86_64-apple-darwin23.6.0 --config-system-dir=%t/testdmode --config-user-dir= -no-canonical-prefixes --version 2>&1 | FileCheck %s -check-prefix DARWIN-VERSIONLESS --implicit-check-not 'Configuration file:'
 //
 // DARWIN-VERSIONLESS: Configuration file: {{.*}}/testdmode/x86_64-apple-darwin-clang.cfg

--- a/clang/test/Driver/config-zos.c
+++ b/clang/test/Driver/config-zos.c
@@ -1,3 +1,5 @@
+// Needs symlinks
+// UNSUPPORTED: system-windows
 // REQUIRES: systemz-registered-target
 
 // RUN: rm -rf %t && mkdir %t

--- a/clang/test/Driver/config-zos.c
+++ b/clang/test/Driver/config-zos.c
@@ -1,15 +1,13 @@
-// REQUIRES: shell
 // REQUIRES: systemz-registered-target
 
-// RUN: unset CLANG_NO_DEFAULT_CONFIG
 // RUN: rm -rf %t && mkdir %t
 
 // RUN: mkdir -p %t/testbin
 // RUN: mkdir -p %t/etc
 // RUN: ln -s %clang %t/testbin/clang
 // RUN: echo "-DXYZ=789" >%t/etc/clang.cfg
-// RUN: %t/testbin/clang --target=s390x-ibm-zos -c -### -no-canonical-prefixes %s 2>&1 | FileCheck -DDIR=%t %s 
-// RUN: %t/testbin/clang --target=s390x-ibm-zos -c -### -no-canonical-prefixes --no-default-config %s 2>&1 | FileCheck -check-prefix=NOCONFIG %s 
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testbin/clang --target=s390x-ibm-zos -c -### -no-canonical-prefixes %s 2>&1 | FileCheck -DDIR=%t %s 
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %t/testbin/clang --target=s390x-ibm-zos -c -### -no-canonical-prefixes --no-default-config %s 2>&1 | FileCheck -check-prefix=NOCONFIG %s 
 //
 // CHECK: Configuration file: [[DIR]]/etc/clang.cfg
 // CHECK: "-D" "XYZ=789"

--- a/clang/test/Driver/config-zos1.c
+++ b/clang/test/Driver/config-zos1.c
@@ -1,23 +1,20 @@
-// REQUIRES: shell
 // REQUIRES: systemz-registered-target
 
-// RUN: unset CLANG_NO_DEFAULT_CONFIG
-
 // RUN: export CLANG_CONFIG_PATH=%S/Inputs/config-zos
-// RUN: %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s 
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s 
 // CHECK: Configuration file: {{.*}}/Inputs/config-zos/clang.cfg
 // CHECK: "-D" "ABC=123"
 
 // RUN: export CLANG_CONFIG_PATH=%S/Inputs/config-zos/def.cfg
-// RUN: %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s -check-prefix=CHECK-DEF
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s -check-prefix=CHECK-DEF
 // CHECK-DEF: Configuration file: {{.*}}/Inputs/config-zos/def.cfg
 // CHECK-DEF: "-D" "DEF=456"
 
 // RUN: export CLANG_CONFIG_PATH=%S/Inputs/config-zos/Garbage
-// RUN: not %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s  -check-prefix=CHECK-ERR
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG not %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s  -check-prefix=CHECK-ERR
 // CHECK-ERR:  error: configuration file '{{.*}}/Inputs/config-zos/Garbage' cannot be found
 
 // The directory exists but no clang.cfg in it
 // RUN: export CLANG_CONFIG_PATH=%S/Inputs/config-zos/tst
-// RUN: not %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s  -check-prefix=CHECK-ERRDIR
+// RUN: env -u CLANG_NO_DEFAULT_CONFIG not %clang --target=s390x-ibm-zos -c -### %s 2>&1 | FileCheck %s  -check-prefix=CHECK-ERRDIR
 // CHECK-ERRDIR:  error: configuration file '{{.*}}/Inputs/config-zos/tst/clang.cfg' cannot be found

--- a/clang/test/Driver/config-zos1.c
+++ b/clang/test/Driver/config-zos1.c
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // REQUIRES: systemz-registered-target
 
 // RUN: export CLANG_CONFIG_PATH=%S/Inputs/config-zos

--- a/clang/test/Driver/coverage.c
+++ b/clang/test/Driver/coverage.c
@@ -18,7 +18,7 @@
 // GCNO-LOCATION-REL: "-coverage-notes-file={{.*}}{{/|\\\\}}foo/bar.gcno"
 
 /// GCC allows PWD to change the paths.
-// RUN: %if system-linux %{ PWD=/proc/self/cwd %clang -### -c --coverage %s -o foo/bar.o 2>&1 | FileCheck --check-prefix=PWD %s %}
+// RUN: %if system-linux %{ env PWD=/proc/self/cwd %clang -### -c --coverage %s -o foo/bar.o 2>&1 | FileCheck --check-prefix=PWD %s %}
 // PWD: "-coverage-notes-file=/proc/self/cwd/foo/bar.gcno" "-coverage-data-file=/proc/self/cwd/foo/bar.gcda"
 
 /// Don't warn -Wunused-command-line-argument.
@@ -50,6 +50,6 @@
 // LINK2: -cc1{{.*}} "-coverage-notes-file={{.*}}{{/|\\\\}}f/gb.gcno" "-coverage-data-file={{.*}}{{/|\\\\}}f/gb.gcda"
 
 /// GCC allows PWD to change the paths.
-// RUN: %if system-linux %{ PWD=/proc/self/cwd %clang -### --coverage d/a.c d/b.c -o e/x -fprofile-dir=f 2>&1 | FileCheck %s --check-prefix=LINK3 %}
+// RUN: %if system-linux %{ env PWD=/proc/self/cwd %clang -### --coverage d/a.c d/b.c -o e/x -fprofile-dir=f 2>&1 | FileCheck %s --check-prefix=LINK3 %}
 // LINK3: -cc1{{.*}} "-coverage-notes-file=/proc/self/cwd/e/x-a.gcno" "-coverage-data-file=f/proc/self/cwd/e/x-a.gcda"
 // LINK3: -cc1{{.*}} "-coverage-notes-file=/proc/self/cwd/e/x-b.gcno" "-coverage-data-file=f/proc/self/cwd/e/x-b.gcda"

--- a/clang/test/Modules/crash-vfs-path-symlink-component.m
+++ b/clang/test/Modules/crash-vfs-path-symlink-component.m
@@ -1,3 +1,5 @@
+// Needs symlinks
+// UNSUPPORTED: system-windows
 // REQUIRES: crash-recovery
 
 // FIXME: This XFAIL is cargo-culted from crash-report.c. Do we need it?

--- a/clang/test/Modules/crash-vfs-path-symlink-component.m
+++ b/clang/test/Modules/crash-vfs-path-symlink-component.m
@@ -1,4 +1,4 @@
-// REQUIRES: crash-recovery, shell
+// REQUIRES: crash-recovery
 
 // FIXME: This XFAIL is cargo-culted from crash-report.c. Do we need it?
 // XFAIL: target={{.*-windows-gnu}}
@@ -59,7 +59,7 @@
 // %/t/i directory containing the symlink component.
 
 // RUN: rm -rf %/t/i
-// RUN: unset FORCE_CLANG_DIAGNOSTICS_CRASH
+// RUN: env -u FORCE_CLANG_DIAGNOSTICS_CRASH \
 // RUN: %clang -E %s -I %/t/i -isysroot %/t/sysroot/ \
 // RUN:     -ivfsoverlay %t/crash-vfs-*.cache/vfs/vfs.yaml -fmodules \
 // RUN:     -fmodules-cache-path=%t/m/ 2>&1 \

--- a/clang/test/Modules/crash-vfs-path-traversal.m
+++ b/clang/test/Modules/crash-vfs-path-traversal.m
@@ -1,4 +1,4 @@
-// REQUIRES: crash-recovery, shell
+// REQUIRES: crash-recovery
 // UNSUPPORTED: ms-sdk, target={{.*-(ps4|ps5)}}
 
 // FIXME: Canonicalizing paths to remove relative traversal components
@@ -57,7 +57,7 @@
 // RUN: sed -e "s@usr/include@usr/include/../include@g" \
 // RUN:     %t/crash-vfs-*.cache/vfs/vfs.yaml > %t/vfs.yaml
 // RUN: cp %t/vfs.yaml %t/crash-vfs-*.cache/vfs/vfs.yaml
-// RUN: unset FORCE_CLANG_DIAGNOSTICS_CRASH
+// RUN: env -u FORCE_CLANG_DIAGNOSTICS_CRASH \
 // RUN: %clang -E %s -I %S/Inputs/crash-recovery -isysroot %/t/i/ \
 // RUN:     -ivfsoverlay %t/crash-vfs-*.cache/vfs/vfs.yaml -fmodules \
 // RUN:     -fmodules-cache-path=%t/m/ 2>&1 \

--- a/clang/test/Modules/crash-vfs-relative-overlay.m
+++ b/clang/test/Modules/crash-vfs-relative-overlay.m
@@ -1,4 +1,4 @@
-// REQUIRES: crash-recovery, shell
+// REQUIRES: crash-recovery
 
 // FIXME: This XFAIL is cargo-culted from crash-report.c. Do we need it?
 // XFAIL: target={{.*-windows-gnu}}
@@ -52,7 +52,7 @@
 // Test that reading the YAML file will yield the correct path after
 // the overlay dir is prefixed to access headers in .cache/vfs directory.
 
-// RUN: unset FORCE_CLANG_DIAGNOSTICS_CRASH
+// RUN: env -u FORCE_CLANG_DIAGNOSTICS_CRASH \
 // RUN: %clang -E %s -I %S/Inputs/crash-recovery/usr/include -isysroot %/t/i/ \
 // RUN:     -ivfsoverlay %t/crash-vfs-*.cache/vfs/vfs.yaml -fmodules \
 // RUN:     -fmodules-cache-path=%t/m/ 2>&1 \

--- a/clang/test/Modules/crash-vfs-relative-overlay.m
+++ b/clang/test/Modules/crash-vfs-relative-overlay.m
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // REQUIRES: crash-recovery
 
 // FIXME: This XFAIL is cargo-culted from crash-report.c. Do we need it?


### PR DESCRIPTION
This patch rewrites a couple tsts that fail when running with lit's
internal shell enabled due to assumptions about setting environment
variables. There were a couple cases where there was an implict env.
Most of the cases needed unset swapped for env -u.

Toeards #102699.
