### PR TITLE
TSAN: Report when thread is not live and referenced in pthread

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_thread_registry.h
@@ -135,7 +135,7 @@ class SANITIZER_MUTEX ThreadRegistry {
   // Finishes thread and returns previous status.
   ThreadStatus FinishThread(u32 tid);
   void StartThread(u32 tid, ThreadID os_id, ThreadType thread_type, void *arg);
-  u32 ConsumeThreadUserId(uptr user_id);
+  bool ConsumeThreadUserId(uptr user_id, u32 *tid_out);
   void SetThreadUserId(u32 tid, uptr user_id);
 
   // OnFork must be called in the child process after fork to purge old

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -1132,6 +1132,10 @@ TSAN_INTERCEPTOR(int, pthread_join, void *th, void **ret) {
   SCOPED_INTERCEPTOR_RAW(pthread_join, th, ret);
   Tid tid;
   if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    Report(
+        "ThreadSanitizer: pthread_join was called on thread %d but it is "
+        "dead.\n",
+        thr->tid);
     return -errno_EINVAL;
   }
   ThreadIgnoreBegin(thr, pc);
@@ -1160,6 +1164,10 @@ TSAN_INTERCEPTOR(int, pthread_detach, void *th) {
   SCOPED_INTERCEPTOR_RAW(pthread_detach, th);
   Tid tid;
   if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    Report(
+        "ThreadSanitizer: pthread_detach was called on thread %d but it is "
+        "dead.\n",
+        thr->tid);
     return -errno_EINVAL;
   }
   int res = REAL(pthread_detach)(th);
@@ -1184,6 +1192,10 @@ TSAN_INTERCEPTOR(int, pthread_tryjoin_np, void *th, void **ret) {
   SCOPED_INTERCEPTOR_RAW(pthread_tryjoin_np, th, ret);
   Tid tid;
   if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    Report(
+        "ThreadSanitizer: pthread_tryjoin_np was called on thread %d but it is "
+        "dead.\n",
+        thr->tid);
     return -errno_EINVAL;
   }
   ThreadIgnoreBegin(thr, pc);
@@ -1201,6 +1213,10 @@ TSAN_INTERCEPTOR(int, pthread_timedjoin_np, void *th, void **ret,
   SCOPED_INTERCEPTOR_RAW(pthread_timedjoin_np, th, ret, abstime);
   Tid tid;
   if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    Report(
+        "ThreadSanitizer: pthread_timedjoin_np was called on thread %d but it "
+        "is dead.\n",
+        thr->tid);
     return -errno_EINVAL;
   }
   ThreadIgnoreBegin(thr, pc);

--- a/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp
@@ -1130,7 +1130,10 @@ TSAN_INTERCEPTOR(int, pthread_create,
 
 TSAN_INTERCEPTOR(int, pthread_join, void *th, void **ret) {
   SCOPED_INTERCEPTOR_RAW(pthread_join, th, ret);
-  Tid tid = ThreadConsumeTid(thr, pc, (uptr)th);
+  Tid tid;
+  if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    return -errno_EINVAL;
+  }
   ThreadIgnoreBegin(thr, pc);
   int res = BLOCK_REAL(pthread_join)(th, ret);
   ThreadIgnoreEnd(thr);
@@ -1155,7 +1158,10 @@ int internal_pthread_join(void *th, void **ret) {
 
 TSAN_INTERCEPTOR(int, pthread_detach, void *th) {
   SCOPED_INTERCEPTOR_RAW(pthread_detach, th);
-  Tid tid = ThreadConsumeTid(thr, pc, (uptr)th);
+  Tid tid;
+  if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    return -errno_EINVAL;
+  }
   int res = REAL(pthread_detach)(th);
   if (res == 0) {
     ThreadDetach(thr, pc, tid);
@@ -1176,7 +1182,10 @@ TSAN_INTERCEPTOR(void, pthread_exit, void *retval) {
 #if SANITIZER_LINUX
 TSAN_INTERCEPTOR(int, pthread_tryjoin_np, void *th, void **ret) {
   SCOPED_INTERCEPTOR_RAW(pthread_tryjoin_np, th, ret);
-  Tid tid = ThreadConsumeTid(thr, pc, (uptr)th);
+  Tid tid;
+  if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    return -errno_EINVAL;
+  }
   ThreadIgnoreBegin(thr, pc);
   int res = REAL(pthread_tryjoin_np)(th, ret);
   ThreadIgnoreEnd(thr);
@@ -1190,7 +1199,10 @@ TSAN_INTERCEPTOR(int, pthread_tryjoin_np, void *th, void **ret) {
 TSAN_INTERCEPTOR(int, pthread_timedjoin_np, void *th, void **ret,
                  const struct timespec *abstime) {
   SCOPED_INTERCEPTOR_RAW(pthread_timedjoin_np, th, ret, abstime);
-  Tid tid = ThreadConsumeTid(thr, pc, (uptr)th);
+  Tid tid;
+  if (!ThreadConsumeTid(thr, pc, (uptr)th, &tid)) {
+    return -errno_EINVAL;
+  }
   ThreadIgnoreBegin(thr, pc);
   int res = BLOCK_REAL(pthread_timedjoin_np)(th, ret, abstime);
   ThreadIgnoreEnd(thr);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -563,7 +563,7 @@ Tid ThreadCreate(ThreadState *thr, uptr pc, uptr uid, bool detached);
 void ThreadStart(ThreadState *thr, Tid tid, ThreadID os_id,
                  ThreadType thread_type);
 void ThreadFinish(ThreadState *thr);
-Tid ThreadConsumeTid(ThreadState *thr, uptr pc, uptr uid);
+bool ThreadConsumeTid(ThreadState *thr, uptr pc, uptr uid, Tid *tid_out);
 void ThreadJoin(ThreadState *thr, uptr pc, Tid tid);
 void ThreadDetach(ThreadState *thr, uptr pc, Tid tid);
 void ThreadFinalize(ThreadState *thr);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl_thread.cpp
@@ -301,8 +301,8 @@ struct ConsumeThreadContext {
   ThreadContextBase *tctx;
 };
 
-Tid ThreadConsumeTid(ThreadState *thr, uptr pc, uptr uid) {
-  return ctx->thread_registry.ConsumeThreadUserId(uid);
+bool ThreadConsumeTid(ThreadState *thr, uptr pc, uptr uid, Tid *tid_out) {
+  return ctx->thread_registry.ConsumeThreadUserId(uid, tid_out);
 }
 
 struct JoinArg {

--- a/compiler-rt/test/tsan/double_detach.c
+++ b/compiler-rt/test/tsan/double_detach.c
@@ -1,0 +1,18 @@
+// RUN: %clang_tsan -O1 %s -o %t && %run %t 2>&1 | FileCheck %s
+
+#include <pthread.h>
+#include <stdio.h>
+
+void *fn(void *) { return NULL; }
+
+int main() {
+  pthread_t th;
+  int rc = pthread_create(&th, 0, fn, 0);
+  if (rc)
+    return rc;
+  pthread_detach(th);
+  pthread_detach(th);
+  return 0;
+}
+
+// CHECK: ThreadSanitizer: pthread_detach was called on thread 0 but it is dead.

--- a/compiler-rt/test/tsan/join_detach.c
+++ b/compiler-rt/test/tsan/join_detach.c
@@ -1,0 +1,18 @@
+// RUN: %clang_tsan -O1 %s -o %t && %run %t 2>&1 | FileCheck %s
+
+#include <pthread.h>
+#include <stdio.h>
+
+void *fn(void *) { return NULL; }
+
+int main() {
+  pthread_t th;
+  int rc = pthread_create(&th, 0, fn, 0);
+  if (rc)
+    return rc;
+  pthread_join(th, NULL);
+  pthread_detach(th);
+  return 0;
+}
+
+// CHECK: ThreadSanitizer: pthread_detach was called on thread 0 but it is dead.


### PR DESCRIPTION
fixes #146683 #156829

When a process calls pthread_{join,detach} twice, TSAN crashes when it doesn't find the current thread to remove from the live threads map.

This patch makes it output something like:
==29712==ThreadSanitizer: pthread_detach was called on thread 0 but it is dead.