### PR TITLE
[NFC][InstrInfoEmitter] Include location of inst definition in comment

### DIFF
--- a/llvm/utils/TableGen/Common/CodeGenInstruction.h
+++ b/llvm/utils/TableGen/Common/CodeGenInstruction.h
@@ -320,6 +320,8 @@ public:
     return RV && isa<DagInit>(RV->getValue());
   }
 
+  StringRef getName() const { return TheDef->getName(); }
+
 private:
   bool isOperandImpl(StringRef OpListName, unsigned i,
                      StringRef PropertyName) const;

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -1316,9 +1316,9 @@ void InstrInfoEmitter::emitEnums(
   for (const CodeGenInstruction *Inst : NumberedInstructions) {
     OS << "    " << Inst->TheDef->getName();
     OS.PadToColumn(MaxNameSize + 5);
-    OS << " = " << Target.getInstrIntValue(Inst->TheDef) << ", // (";
-    OS << SrcMgr.getFormattedLocationNoOffset(Inst->TheDef->getLoc().front())
-       << ")\n";
+    OS << " = " << Target.getInstrIntValue(Inst->TheDef) << ", // ";
+    OS << SrcMgr.getFormattedLocationNoOffset(Inst->TheDef->getLoc().front());
+    OS << '\n';
   }
   OS << "    INSTRUCTION_LIST_END = " << NumberedInstructions.size() << '\n';
   OS << "  };\n";

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -25,7 +25,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/FormattedStream.h"
+#include "llvm/Support/Format.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TableGen/Error.h"
@@ -1291,9 +1291,8 @@ void InstrInfoEmitter::emitRecord(
 
 // emitEnums - Print out enum values for all of the instructions.
 void InstrInfoEmitter::emitEnums(
-    raw_ostream &RawOS,
+    raw_ostream &OS,
     ArrayRef<const CodeGenInstruction *> NumberedInstructions) {
-  formatted_raw_ostream OS(RawOS);
   OS << "#ifdef GET_INSTRINFO_ENUM\n";
   OS << "#undef GET_INSTRINFO_ENUM\n";
 
@@ -1314,11 +1313,10 @@ void InstrInfoEmitter::emitEnums(
 
   OS << "  enum {\n";
   for (const CodeGenInstruction *Inst : NumberedInstructions) {
-    OS << "    " << Inst->TheDef->getName();
-    OS.PadToColumn(MaxNameSize + 5);
-    OS << " = " << Target.getInstrIntValue(Inst->TheDef) << ", // ";
-    OS << SrcMgr.getFormattedLocationNoOffset(Inst->TheDef->getLoc().front());
-    OS << '\n';
+    OS << "    " << left_justify(Inst->TheDef->getName(), MaxNameSize) << " = "
+       << Target.getInstrIntValue(Inst->TheDef) << ", // "
+       << SrcMgr.getFormattedLocationNoOffset(Inst->TheDef->getLoc().front())
+       << '\n';
   }
   OS << "    INSTRUCTION_LIST_END = " << NumberedInstructions.size() << '\n';
   OS << "  };\n";


### PR DESCRIPTION
Print the source location of the instruction definition in comment next to the enum value for each instruction. To make this more readable, change formatting of the instruction enums to be better aligned.

Example output:

```
    VLD4qWB_register_Asm_8                 = 573, // (ARMInstrNEON.td:8849)
    VMOVD0                                 = 574, // (ARMInstrNEON.td:6337)
    VMOVDcc                                = 575, // (ARMInstrVFP.td:2466)
    VMOVHcc                                = 576, // (ARMInstrVFP.td:2474)
    VMOVQ0                                 = 577, // (ARMInstrNEON.td:6341)
```