### PR TITLE
[LLDB] Fix tests that fail when using internal shell.

### DIFF
--- a/lldb/test/Shell/Host/TestCustomShell.test
+++ b/lldb/test/Shell/Host/TestCustomShell.test
@@ -6,7 +6,7 @@
 # XFAIL: system-openbsd
 
 # RUN: %clang_host %S/Inputs/simple.c -g -o %t.out
-# RUN: SHELL=bogus not %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s --check-prefix ERROR
+# RUN: env SHELL=bogus not %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s --check-prefix ERROR
 # RUN: env -i ASAN_OPTIONS='detect_container_overflow=0' %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s
 
 # ERROR: error: shell expansion failed

--- a/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
@@ -7,5 +7,4 @@
 // RUN: %lldb %t -o "breakpoint set -f %s -l 11" -o run -o exit | FileCheck %s
 // CHECK: stop reason = breakpoint
 
-
 int main() { return 0; }

--- a/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
@@ -3,7 +3,7 @@
 // requires the ld64 linker, which clang invokes by default.
 // REQUIRES: system-darwin
 // RUN: %clang_host %s -g -c -o %t.o
-// RUN: ZERO_AR_DATE=1 %clang_host %t.o -g -o %t
+// RUN: env ZERO_AR_DATE=1 %clang_host %t.o -g -o %t
 // RUN: %lldb %t -o "breakpoint set -f %s -l 11" -o run -o exit | FileCheck %s
 // CHECK: stop reason = breakpoint
 

--- a/lldb/test/Shell/SymbolFile/add-dsym.test
+++ b/lldb/test/Shell/SymbolFile/add-dsym.test
@@ -4,5 +4,5 @@
 # HELP: Syntax: add-dsym <cmd-options> <filename>
 
 # RUN: yaml2obj %S/Inputs/a.yaml -o %t.out
-# RUN: LLDB_APPLE_DSYMFORUUID_EXECUTABLE=%S/Inputs/dsymforuuid.sh %lldb %t.out -o 'add-dsym -u 41945CA4-5D9D-3CDE-82B4-37E4C09750B5' 2>&1 | FileCheck %s
+# RUN: env LLDB_APPLE_DSYMFORUUID_EXECUTABLE=%S/Inputs/dsymforuuid.sh %lldb %t.out -o 'add-dsym -u 41945CA4-5D9D-3CDE-82B4-37E4C09750B5' 2>&1 | FileCheck %s
 # CHECK: UUID information was not found


### PR DESCRIPTION
These tests were failing on darwin, because the internal shell needs environment var definitions to start with 'env'.  This PR (hopefully) fixes that problem.