### PR TITLE
[clang] Add [system] label to modules from resource headers

### DIFF
--- a/clang/lib/Headers/module.modulemap
+++ b/clang/lib/Headers/module.modulemap
@@ -329,13 +329,13 @@ module _Builtin_unwind [system] {
 }
 // End -fbuiltin-headers-in-system-modules affected modules
 
-module opencl_c {
+module opencl_c [system] {
   requires opencl
   header "opencl-c.h"
   header "opencl-c-base.h"
 }
 
-module ptrauth {
+module ptrauth [system] {
   header "ptrauth.h"
   export *
 }


### PR DESCRIPTION
Since resource headers are installed, commonly as system dependencies, they should have `[system]` on them. Fix up the ones missing. 