### PR TITLE
LICM.cpp - Changed std::vector reference to SmallVector

### DIFF
--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2176,7 +2176,9 @@ bool llvm::promoteLoopAccessesToScalars(
   });
 
   // Look at all the loop uses, and try to merge their locations.
+  // std::vector<DebugLoc> LoopUsesLocs;
   std::vector<DebugLoc> LoopUsesLocs;
+
   for (auto U : LoopUses)
     LoopUsesLocs.push_back(U->getDebugLoc());
   auto DL = DebugLoc::getMergedLocations(LoopUsesLocs);

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2177,7 +2177,7 @@ bool llvm::promoteLoopAccessesToScalars(
 
   // Look at all the loop uses, and try to merge their locations.
   // std::vector<DebugLoc> LoopUsesLocs;
-  std::vector<DebugLoc> LoopUsesLocs;
+  SmallVector<DebugLoc, 4> LoopUsesLocs;
 
   for (auto U : LoopUses)
     LoopUsesLocs.push_back(U->getDebugLoc());

--- a/llvm/lib/Transforms/Scalar/LICM.cpp
+++ b/llvm/lib/Transforms/Scalar/LICM.cpp
@@ -2176,7 +2176,6 @@ bool llvm::promoteLoopAccessesToScalars(
   });
 
   // Look at all the loop uses, and try to merge their locations.
-  // std::vector<DebugLoc> LoopUsesLocs;
   SmallVector<DebugLoc, 4> LoopUsesLocs;
 
   for (auto U : LoopUses)


### PR DESCRIPTION
This change was done due to the precedence of SmallVector use in LLVM:

After checking runtime improvements using the [LLVM Compile Time tracker tool](https://llvm-compile-time-tracker.com/index.php), there weren't any significant improvements (improvements are likely hidden in the noise). However, as quoted in the [LLVM Programmer's manual:](https://llvm.org/docs/ProgrammersManual.html#id49)

> std::vector is well loved and respected. However, SmallVector<T, 0> is often a better option due to the advantages listed above.