### PR TITLE
[OpenACC][NFCI] Split up the init and decl from OpenACC recipes

### DIFF
--- a/clang/include/clang/Sema/SemaOpenACC.h
+++ b/clang/include/clang/Sema/SemaOpenACC.h
@@ -15,6 +15,7 @@
 #define LLVM_CLANG_SEMA_SEMAOPENACC_H
 
 #include "clang/AST/DeclGroup.h"
+#include "clang/AST/OpenACCClause.h"
 #include "clang/AST/StmtOpenACC.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/OpenACCKinds.h"
@@ -237,21 +238,11 @@ public:
                                 SourceLocation ClauseLoc,
                                 ArrayRef<const OpenACCClause *> Clauses);
 
-  // Creates a VarDecl with a proper default init for the purposes of a
-  // `private`/'firstprivate'/'reduction' clause, so it can be used to generate
-  // a recipe later.
-  //  The first entry is the recipe itself, the second is any required
-  //  'temporary' created for the init (in the case of a copy), such as with
-  //  firstprivate.
-  std::pair<VarDecl *, VarDecl *> CreateInitRecipe(OpenACCClauseKind CK,
-                                                   const Expr *VarExpr) {
-    assert(CK != OpenACCClauseKind::Reduction);
-    return CreateInitRecipe(CK, OpenACCReductionOperator::Invalid, VarExpr);
-  }
-  std::pair<VarDecl *, VarDecl *>
-  CreateInitRecipe(OpenACCClauseKind CK,
-                   OpenACCReductionOperator ReductionOperator,
-                   const Expr *VarExpr);
+  OpenACCPrivateRecipe CreatePrivateInitRecipe(const Expr *VarExpr);
+  OpenACCFirstPrivateRecipe CreateFirstPrivateInitRecipe(const Expr *VarExpr);
+  OpenACCReductionRecipe
+  CreateReductionInitRecipe(OpenACCReductionOperator ReductionOperator,
+                            const Expr *VarExpr);
 
 public:
   ComputeConstructInfo &getActiveComputeConstructInfo() {

--- a/clang/lib/AST/OpenACCClause.cpp
+++ b/clang/lib/AST/OpenACCClause.cpp
@@ -317,11 +317,11 @@ OpenACCTileClause *OpenACCTileClause::Create(const ASTContext &C,
 OpenACCPrivateClause *
 OpenACCPrivateClause::Create(const ASTContext &C, SourceLocation BeginLoc,
                              SourceLocation LParenLoc, ArrayRef<Expr *> VarList,
-                             ArrayRef<VarDecl *> InitRecipes,
+                             ArrayRef<OpenACCPrivateRecipe> InitRecipes,
                              SourceLocation EndLoc) {
   assert(VarList.size() == InitRecipes.size());
-  void *Mem =
-      C.Allocate(OpenACCPrivateClause::totalSizeToAlloc<Expr *, VarDecl *>(
+  void *Mem = C.Allocate(
+      OpenACCPrivateClause::totalSizeToAlloc<Expr *, OpenACCPrivateRecipe>(
           VarList.size(), InitRecipes.size()));
   return new (Mem)
       OpenACCPrivateClause(BeginLoc, LParenLoc, VarList, InitRecipes, EndLoc);

--- a/clang/lib/AST/StmtProfile.cpp
+++ b/clang/lib/AST/StmtProfile.cpp
@@ -2636,8 +2636,11 @@ void OpenACCClauseProfiler::VisitPrivateClause(
     const OpenACCPrivateClause &Clause) {
   VisitClauseWithVarList(Clause);
 
-  for (auto *VD : Clause.getInitRecipes())
-    Profiler.VisitDecl(VD);
+  for (auto &Recipe : Clause.getInitRecipes()) {
+    Profiler.VisitDecl(Recipe.AllocaDecl);
+    if (Recipe.InitExpr)
+      Profiler.VisitExpr(Recipe.InitExpr);
+  }
 }
 
 void OpenACCClauseProfiler::VisitFirstPrivateClause(
@@ -2645,7 +2648,9 @@ void OpenACCClauseProfiler::VisitFirstPrivateClause(
   VisitClauseWithVarList(Clause);
 
   for (auto &Recipe : Clause.getInitRecipes()) {
-    Profiler.VisitDecl(Recipe.RecipeDecl);
+    Profiler.VisitDecl(Recipe.AllocaDecl);
+    if (Recipe.InitExpr)
+      Profiler.VisitExpr(Recipe.InitExpr);
     Profiler.VisitDecl(Recipe.InitFromTemporary);
   }
 }
@@ -2750,11 +2755,13 @@ void OpenACCClauseProfiler::VisitReductionClause(
   VisitClauseWithVarList(Clause);
 
   for (auto &Recipe : Clause.getRecipes()) {
-    Profiler.VisitDecl(Recipe.RecipeDecl);
+    Profiler.VisitDecl(Recipe.AllocaDecl);
+    if (Recipe.InitExpr)
+      Profiler.VisitExpr(Recipe.InitExpr);
     // TODO: OpenACC: Make sure we remember to update this when we figure out
     // what we're adding for the operation recipe, in the meantime, a static
     // assert will make sure we don't add something.
-    static_assert(sizeof(OpenACCReductionRecipe) == sizeof(int *));
+    static_assert(sizeof(OpenACCReductionRecipe) == 2 * sizeof(int *));
   }
 }
 

--- a/clang/lib/CIR/CodeGen/CIRGenOpenACCClause.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenOpenACCClause.cpp
@@ -1280,10 +1280,16 @@ public:
 
         {
           mlir::OpBuilder::InsertionGuard guardCase(builder);
-          auto recipe = getOrCreateRecipe<mlir::acc::PrivateRecipeOp>(
-              cgf.getContext(), varExpr, varRecipe, /*temporary=*/nullptr,
-              OpenACCReductionOperator::Invalid,
+          // TODO: OpenACC: At the moment this is a bit of a hacky way of doing
+          // this, and won't work when we get to bounds/etc. Do this for now to
+          // limit the scope of this refactor.
+          VarDecl *allocaDecl = varRecipe.AllocaDecl;
+          allocaDecl->setInit(varRecipe.InitExpr);
+          allocaDecl->setInitStyle(VarDecl::CallInit);
 
+          auto recipe = getOrCreateRecipe<mlir::acc::PrivateRecipeOp>(
+              cgf.getContext(), varExpr, allocaDecl, /*temporary=*/nullptr,
+              OpenACCReductionOperator::Invalid,
               Decl::castToDeclContext(cgf.curFuncDecl), opInfo.baseType,
               privateOp.getResult());
           // TODO: OpenACC: The dialect is going to change in the near future to
@@ -1316,8 +1322,15 @@ public:
 
         {
           mlir::OpBuilder::InsertionGuard guardCase(builder);
+          // TODO: OpenACC: At the moment this is a bit of a hacky way of doing
+          // this, and won't work when we get to bounds/etc. Do this for now to
+          // limit the scope of this refactor.
+          VarDecl *allocaDecl = varRecipe.AllocaDecl;
+          allocaDecl->setInit(varRecipe.InitExpr);
+          allocaDecl->setInitStyle(VarDecl::CallInit);
+
           auto recipe = getOrCreateRecipe<mlir::acc::FirstprivateRecipeOp>(
-              cgf.getContext(), varExpr, varRecipe.RecipeDecl,
+              cgf.getContext(), varExpr, allocaDecl,
               varRecipe.InitFromTemporary, OpenACCReductionOperator::Invalid,
               Decl::castToDeclContext(cgf.curFuncDecl), opInfo.baseType,
               firstPrivateOp.getResult());
@@ -1353,9 +1366,15 @@ public:
 
         {
           mlir::OpBuilder::InsertionGuard guardCase(builder);
+          // TODO: OpenACC: At the moment this is a bit of a hacky way of doing
+          // this, and won't work when we get to bounds/etc. Do this for now to
+          // limit the scope of this refactor.
+          VarDecl *allocaDecl = varRecipe.AllocaDecl;
+          allocaDecl->setInit(varRecipe.InitExpr);
+          allocaDecl->setInitStyle(VarDecl::CallInit);
 
           auto recipe = getOrCreateRecipe<mlir::acc::ReductionRecipeOp>(
-              cgf.getContext(), varExpr, varRecipe.RecipeDecl,
+              cgf.getContext(), varExpr, allocaDecl,
               /*temporary=*/nullptr, clause.getReductionOp(),
               Decl::castToDeclContext(cgf.curFuncDecl), opInfo.baseType,
               reductionOp.getResult());

--- a/clang/lib/Sema/SemaOpenACCClause.cpp
+++ b/clang/lib/Sema/SemaOpenACCClause.cpp
@@ -795,12 +795,11 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitPrivateClause(
   // really isn't anything to do here. GCC does some duplicate-finding, though
   // it isn't apparent in the standard where this is justified.
 
-  llvm::SmallVector<VarDecl *> InitRecipes;
+  llvm::SmallVector<OpenACCPrivateRecipe> InitRecipes;
 
   // Assemble the recipes list.
   for (const Expr *VarExpr : Clause.getVarList())
-    InitRecipes.push_back(
-        SemaRef.CreateInitRecipe(OpenACCClauseKind::Private, VarExpr).first);
+    InitRecipes.push_back(SemaRef.CreatePrivateInitRecipe(VarExpr));
 
   return OpenACCPrivateClause::Create(
       Ctx, Clause.getBeginLoc(), Clause.getLParenLoc(), Clause.getVarList(),
@@ -817,8 +816,7 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitFirstPrivateClause(
 
   // Assemble the recipes list.
   for (const Expr *VarExpr : Clause.getVarList())
-    InitRecipes.push_back(
-        SemaRef.CreateInitRecipe(OpenACCClauseKind::FirstPrivate, VarExpr));
+    InitRecipes.push_back(SemaRef.CreateFirstPrivateInitRecipe(VarExpr));
 
   return OpenACCFirstPrivateClause::Create(
       Ctx, Clause.getBeginLoc(), Clause.getLParenLoc(), Clause.getVarList(),
@@ -1783,12 +1781,8 @@ OpenACCClause *SemaOpenACCClauseVisitor::VisitReductionClause(
     if (Res.isUsable()) {
       ValidVars.push_back(Res.get());
 
-      VarDecl *InitRecipe =
-          SemaRef
-              .CreateInitRecipe(OpenACCClauseKind::Reduction,
-                                Clause.getReductionOp(), Res.get())
-              .first;
-      Recipes.push_back({InitRecipe});
+      Recipes.push_back(SemaRef.CreateReductionInitRecipe(
+          Clause.getReductionOp(), Res.get()));
     }
   }
 

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -8751,8 +8751,11 @@ void ASTRecordWriter::writeOpenACCClause(const OpenACCClause *C) {
     writeSourceLocation(PC->getLParenLoc());
     writeOpenACCVarList(PC);
 
-    for (VarDecl *VD : PC->getInitRecipes())
-      AddDeclRef(VD);
+    for (const OpenACCPrivateRecipe &R : PC->getInitRecipes()) {
+      static_assert(sizeof(R) == 2 * sizeof(int *));
+      AddDeclRef(R.AllocaDecl);
+      AddStmt(const_cast<Expr *>(R.InitExpr));
+    }
     return;
   }
   case OpenACCClauseKind::Host: {
@@ -8773,7 +8776,9 @@ void ASTRecordWriter::writeOpenACCClause(const OpenACCClause *C) {
     writeOpenACCVarList(FPC);
 
     for (const OpenACCFirstPrivateRecipe &R : FPC->getInitRecipes()) {
-      AddDeclRef(R.RecipeDecl);
+      static_assert(sizeof(R) == 3 * sizeof(int *));
+      AddDeclRef(R.AllocaDecl);
+      AddStmt(const_cast<Expr *>(R.InitExpr));
       AddDeclRef(R.InitFromTemporary);
     }
     return;
@@ -8895,8 +8900,9 @@ void ASTRecordWriter::writeOpenACCClause(const OpenACCClause *C) {
     writeOpenACCVarList(RC);
 
     for (const OpenACCReductionRecipe &R : RC->getRecipes()) {
-      static_assert(sizeof(OpenACCReductionRecipe) == sizeof(int *));
-      AddDeclRef(R.RecipeDecl);
+      static_assert(sizeof(OpenACCReductionRecipe) == 2 * sizeof(int *));
+      AddDeclRef(R.AllocaDecl);
+      AddStmt(const_cast<Expr *>(R.InitExpr));
     }
     return;
   }

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -2837,8 +2837,10 @@ void OpenACCClauseEnqueue::VisitTileClause(const OpenACCTileClause &C) {
 
 void OpenACCClauseEnqueue::VisitPrivateClause(const OpenACCPrivateClause &C) {
   VisitVarList(C);
-  for (VarDecl *V : C.getInitRecipes())
-    Visitor.AddDecl(V);
+  for (const OpenACCPrivateRecipe &R : C.getInitRecipes()) {
+    Visitor.AddDecl(R.AllocaDecl);
+    Visitor.AddStmt(R.InitExpr);
+  }
 }
 
 void OpenACCClauseEnqueue::VisitHostClause(const OpenACCHostClause &C) {
@@ -2853,7 +2855,8 @@ void OpenACCClauseEnqueue::VisitFirstPrivateClause(
     const OpenACCFirstPrivateClause &C) {
   VisitVarList(C);
   for (const OpenACCFirstPrivateRecipe &R : C.getInitRecipes()) {
-    Visitor.AddDecl(R.RecipeDecl);
+    Visitor.AddDecl(R.AllocaDecl);
+    Visitor.AddStmt(R.InitExpr);
     Visitor.AddDecl(R.InitFromTemporary);
   }
 }
@@ -2930,8 +2933,8 @@ void OpenACCClauseEnqueue::VisitReductionClause(
     const OpenACCReductionClause &C) {
   VisitVarList(C);
   for (const OpenACCReductionRecipe &R : C.getRecipes()) {
-    static_assert(sizeof(OpenACCReductionRecipe) == sizeof(int *));
-    Visitor.AddDecl(R.RecipeDecl);
+    Visitor.AddDecl(R.AllocaDecl);
+    Visitor.AddStmt(R.InitExpr);
   }
 }
 void OpenACCClauseEnqueue::VisitAutoClause(const OpenACCAutoClause &C) {}


### PR DESCRIPTION
Expressions/references with 'bounds' are going to need to do initialization significantly differently, so we need to have the initializer and the declaration 'separate' in the future.  This patch splits the AST node into two, and normalizes them a bit.

Additionally, since this required significant work on the recipe generation, this patch also does a bit of a refactor to improve readability and future expansion, now that we have a good understanding of how these are going to look.