### PR TITLE
[lit] Add support for env -i

### DIFF
--- a/clang/test/Driver/env.c
+++ b/clang/test/Driver/env.c
@@ -1,8 +1,3 @@
-// These tests try to ensure that the driver operates reasonably when run with
-// a strange environment. Unfortunately, it requires a normal shell and the
-// 'env' command that understands arguments, unlike the LIT built-in env.
-//
-// REQUIRES: shell
 // The PATH variable is heavily used when trying to find a linker.
 // RUN: env -i LC_ALL=C LD_LIBRARY_PATH="$LD_LIBRARY_PATH" CLANG_NO_DEFAULT_CONFIG=1 \
 // RUN:   %clang %s -### -o %t.o --target=i386-unknown-linux \

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -326,6 +326,10 @@ def updateEnv(env, args):
         if arg == "-u":
             unset_next_env_var = True
             continue
+        # Support for the -i flag which clears the environment
+        if arg == "-i":
+            env.env = {}
+            continue
         if unset_next_env_var:
             unset_next_env_var = False
             if arg in env.env:
@@ -890,7 +894,12 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
             if os.path.isfile(exe_in_cwd):
                 executable = exe_in_cwd
         if not executable:
-            executable = lit.util.which(args[0], cmd_shenv.env["PATH"])
+            # Use the path from cmd_shenv by default, but if the environment variable
+            # is unset (like if the user is using env -i), use the standard path.
+            path = (
+                cmd_shenv.env["PATH"] if "PATH" in cmd_shenv.env else shenv.env["PATH"]
+            )
+            executable = lit.util.which(args[0], shenv.env["PATH"])
         if not executable:
             raise InternalShellError(j, "%r: command not found" % args[0])
 

--- a/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-i.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-i.txt
@@ -1,0 +1,23 @@
+## Tests env command for clearing the environment
+
+## Check and make sure preset environment variable were set in lit.cfg.
+#
+# RUN: env | FileCheck --check-prefix=CHECK-ENV-PRESET %s
+## Check clearing the entire environment.
+#
+# RUN: env -i | FileCheck --check-prefix=CHECK-ENV-CLEAR-1 %s
+#
+## Check setting a variable in a clear environment.
+#
+# RUN: env -i BAZ=3 | FileCheck --check-prefix=CHECK-ENV-ONE-1 %s
+#
+
+# CHECK-ENV-PRESET: BAR = 2
+# CHECK-ENV-PRESET: FOO = 1
+
+# CHECK-ENV-CLEAR-NOT: BAR
+# CHECK-ENV-CLEAR-NOT: FOO
+
+# CHECK-ENV-ONE-NOT: BAR
+# CHECK-ENV-ONE: BAZ = 3
+# CHECK-ENV-ONE-NOT: FOO

--- a/llvm/utils/lit/tests/shtest-env-positive.py
+++ b/llvm/utils/lit/tests/shtest-env-positive.py
@@ -1,13 +1,13 @@
 ## Test the env command (passing tests).
 
 # RUN: %{lit} -a -v %{inputs}/shtest-env-positive \
-# RUN: | FileCheck -match-full-lines %s
+# RUN:   | FileCheck -match-full-lines %s
 #
 # END.
 
 ## Test the env command's successful executions.
 
-# CHECK: -- Testing: 9 tests{{.*}}
+# CHECK: -- Testing: 10 tests{{.*}}
 
 # CHECK: PASS: shtest-env :: env-args-last-is-assign.txt ({{[^)]*}})
 # CHECK: env FOO=1
@@ -39,6 +39,12 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
+# CHECK: PASS: shtest-env :: env-i.txt ({{[^)]*}})
+# CHECK: env -i | {{.*}}
+# CHECK: # executed command: env -i
+# CHECK-NOT: # error:
+# CHECK: --
+
 # CHECK: PASS: shtest-env :: env-no-subcommand.txt ({{[^)]*}})
 # CHECK: env | {{.*}}
 # CHECK: # executed command: env
@@ -65,6 +71,6 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
-# CHECK: Total Discovered Tests: 9
-# CHECK: Passed: 9 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Total Discovered Tests: 10
+# CHECK: Passed: 10 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}


### PR DESCRIPTION
env -i is needed for some lit tests. The feature requires a minimal amount of work to support and there is no easy way to rewrite the tests that require it.

At least two tests that need this:
1. clang/test/Driver/env.c
2. lldb/test/Shell/Host/TestCustomShell.test