### PR TITLE
[nfc] Make function-specialization3.ll test compatible with profile propagation unittests

### DIFF
--- a/llvm/test/Transforms/FunctionSpecialization/function-specialization3.ll
+++ b/llvm/test/Transforms/FunctionSpecialization/function-specialization3.ll
@@ -34,14 +34,14 @@ return:
 
 ; FORCE-NOT: define internal i32 @foo(
 ;
-; FORCE:      define internal i32 @foo.specialized.1(i32 %x, ptr %b) {
+; FORCE:      define internal i32 @foo.specialized.1(i32 %x, ptr %b) {{(!prof !0 )?}}{
 ; FORCE-NEXT: entry:
 ; FORCE-NEXT:   %0 = load i32, ptr @A, align 4
 ; FORCE-NEXT:   %add = add nsw i32 %x, %0
 ; FORCE-NEXT:   ret i32 %add
 ; FORCE-NEXT: }
 ;
-; FORCE:      define internal i32 @foo.specialized.2(i32 %x, ptr %b) {
+; FORCE:      define internal i32 @foo.specialized.2(i32 %x, ptr %b) {{(!prof !0 )?}}{
 ; FORCE-NEXT: entry:
 ; FORCE-NEXT:   %0 = load i32, ptr @B, align 4
 ; FORCE-NEXT:   %add = add nsw i32 %x, %0


### PR DESCRIPTION
The build configuration described in
https://discourse.llvm.org/t/rfc-profile-information-propagation-unittesting/73595/11 causes this test to fail because that build configuration injects profile metadata which show up in the output. To fix this we just change the assertion to tolerate the presence of profile metadata.

Tracking issue: #147390