### PR TITLE
[bazel] Add -lbsd for lldb on Linux

### DIFF
--- a/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/lldb/BUILD.bazel
@@ -62,6 +62,14 @@ selects.config_setting_group(
     ],
 )
 
+selects.config_setting_group(
+    name = "needs_libbsd",
+    match_all = [
+        ":libedit_enabled_setting",
+        "@platforms//os:linux",
+    ],
+)
+
 _VERSION_SUBSTITUTIONS = {
     "@LLDB_VERSION@": PACKAGE_VERSION,
     "@LLDB_VERSION_MAJOR@": LLVM_VERSION_MAJOR,
@@ -560,6 +568,11 @@ cc_library(
     }) + select({
         ":libedit_enabled": [
             "-ledit",
+        ],
+        "//conditions:default": [],
+    }) + select({
+        ":needs_libbsd": [
+            "-lbsd",
         ],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
In the case you link libedit statically with a vendored sysroot, this
flag is also required. It should be harmless in the case you link it
dynamically since libedit already links libbsd otherwise.
