### PR TITLE
[TableGen] Don't print the instruction enum value in multiple comments in GenInstrInfo.inc.

### DIFF
--- a/llvm/test/TableGen/def-multiple-operands.td
+++ b/llvm/test/TableGen/def-multiple-operands.td
@@ -24,7 +24,7 @@ def Reg3Opnd : Operand<OtherVT> {
 // CHECK: archInstrTable {{.* = \{}}
 // CHECK: {{\{}}
 // CHECK: {{\{}} [[ID:[0-9]+]], 4, 3, 13, {{.+\}, \/\/}}
-// CHECK-SAME: Inst #[[ID]] = InstA
+// CHECK-SAME: InstA
 def InstA : Instruction {
   let Namespace = "MyNS";
   let Size = 13;

--- a/llvm/utils/TableGen/InstrInfoEmitter.cpp
+++ b/llvm/utils/TableGen/InstrInfoEmitter.cpp
@@ -760,8 +760,9 @@ void InstrInfoEmitter::emitFeatureVerifier(raw_ostream &OS,
   OS << "  };\n"
      << "  static constexpr " << getMinimalTypeForRange(FeatureBitsets.size())
      << " RequiredFeaturesRefs[] = {\n";
-  unsigned InstIdx = 0;
-  for (const CodeGenInstruction *Inst : Target.getInstructions()) {
+  ArrayRef<const CodeGenInstruction *> NumberedInstructions =
+      Target.getInstructions();
+  for (const CodeGenInstruction *Inst : NumberedInstructions) {
     OS << "    CEFBS";
     unsigned NumPredicates = 0;
     for (const Record *Predicate :
@@ -774,11 +775,10 @@ void InstrInfoEmitter::emitFeatureVerifier(raw_ostream &OS,
     }
     if (!NumPredicates)
       OS << "_None";
-    OS << ", // " << Inst->TheDef->getName() << " = " << InstIdx << '\n';
-    InstIdx++;
+    OS << ", // " << Inst->TheDef->getName() << '\n';
   }
   OS << "  };\n\n"
-     << "  assert(Opcode < " << InstIdx << ");\n"
+     << "  assert(Opcode < " << NumberedInstructions.size() << ");\n"
      << "  return FeatureBitsets[RequiredFeaturesRefs[Opcode]];\n"
      << "}\n\n";
 
@@ -1284,7 +1284,7 @@ void InstrInfoEmitter::emitRecord(
   OS.write_hex(Value);
   OS << "ULL";
 
-  OS << " },  // Inst #" << Num << " = " << Inst.TheDef->getName() << '\n';
+  OS << " },  // " << Inst.TheDef->getName() << '\n';
 }
 
 // emitEnums - Print out enum values for all of the instructions.


### PR DESCRIPTION
The name is most interesting and if you really need the number you can use the name to find the entry in the enum or use the first field of the table row.