### PR TITLE
[AMDGPU] Print high vgpr operand comments from objdump

### DIFF
--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
 #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
 
+#include "llvm/MC/MCInstrAnalysis.h"
 #include <cstdint>
 #include <memory>
 
@@ -44,6 +45,28 @@ MCAsmBackend *createAMDGPUAsmBackend(const Target &T,
 std::unique_ptr<MCObjectTargetWriter>
 createAMDGPUELFObjectWriter(bool Is64Bit, uint8_t OSABI,
                             bool HasRelocationAddend);
+
+namespace AMDGPU {
+class AMDGPUMCInstrAnalysis : public MCInstrAnalysis {
+private:
+  unsigned VgprMSBs = 0;
+
+public:
+  explicit AMDGPUMCInstrAnalysis(const MCInstrInfo *Info)
+      : MCInstrAnalysis(Info) {}
+
+  bool evaluateBranch(const MCInst &Inst, uint64_t Addr, uint64_t Size,
+                      uint64_t &Target) const override;
+
+  void resetState() override { VgprMSBs = 0; }
+
+  void updateState(const MCInst &Inst, uint64_t Addr) override;
+
+  unsigned getVgprMSBs() const { return VgprMSBs; }
+};
+
+} // namespace AMDGPU
+
 } // namespace llvm
 
 #define GET_REGINFO_ENUM

--- a/llvm/test/CodeGen/AMDGPU/vgpr-lowering-gfx1250.mir
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-lowering-gfx1250.mir
@@ -1,4 +1,5 @@
 # RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -start-before=amdgpu-lower-vgpr-encoding -o - %s | FileCheck -check-prefixes=GCN,ASM %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -start-before=amdgpu-lower-vgpr-encoding -o - %s | llvm-mc -triple=amdgcn -mcpu=gfx1250 -filetype=obj -o - | llvm-objdump -d --mcpu=gfx1250 - | FileCheck -check-prefixes=GCN,DIS %s
 
 # ASM-LABEL: {{^}}high_vgprs:
 # DIS-LABEL: <high_vgprs>:


### PR DESCRIPTION
This followed the agreed convention: every basic block shall
start with all MSBs zero. Codegen does the same lowering.