### PR TITLE
[libc] Remove unused _Thread_local define from headers.

### DIFF
--- a/libc/include/__llvm-libc-common.h
+++ b/libc/include/__llvm-libc-common.h
@@ -37,9 +37,6 @@
 #undef _Alignof
 #define _Alignof alignof
 
-#undef _Thread_local
-#define _Thread_local thread_local
-
 #undef __NOEXCEPT
 #if __cplusplus >= 201103L
 #define __NOEXCEPT noexcept


### PR DESCRIPTION
It was added in dd33f9cdef9f6209aa34713e1417f4a2e24e5ca6 to describe thread-local errno, but is no longer used in the codebase (with the exception of a single integration test, but the llvm-libc-provided `#define _Thread_local thread_local` is not needed there anyway, since `_Thread_local` is a keyword from C11 onwards.