### PR TITLE
[CI] Only invoke ninja for runtimes build if runtimes are specified

### DIFF
--- a/.ci/monolithic-windows.sh
+++ b/.ci/monolithic-windows.sh
@@ -56,6 +56,8 @@ start-group "ninja"
 # Targets are not escaped as they are passed as separate arguments.
 ninja -C "${BUILD_DIR}" -k 0 ${targets} |& tee ninja.log
 
-start-group "ninja runtimes"
-
-ninja -C "${BUILD_DIR}" -k 0 ${runtimes_targets} |& tee ninja_runtimes.log
+if [[ "${runtime_targets}" != "" ]]; then
+  start-group "ninja runtimes"
+  
+  ninja -C "${BUILD_DIR}" -k 0 ${runtimes_targets} |& tee ninja_runtimes.log
+fi


### PR DESCRIPTION
Otherwise we end up running ninja without any targets specified which just builds the rest of the default enabled targets. This shouldn't have too much impact, but can involve building extra things that we don't need.

This also makes the monolithic-windows.sh script consistent with the monolithic-windows.sh script.