### PR TITLE
[compiler-rt] Fix a bug introduced into DEFINE_COMPILERRT_FUNCTION_ALIAS

### DIFF
--- a/compiler-rt/lib/builtins/assembly.h
+++ b/compiler-rt/lib/builtins/assembly.h
@@ -304,7 +304,7 @@
   .globl FUNC_SYMBOL(SYMBOL_NAME(name)) SEPARATOR                              \
   SYMBOL_IS_FUNC(SYMBOL_NAME(name)) SEPARATOR                                  \
   DECLARE_SYMBOL_VISIBILITY(name) SEPARATOR                                    \
-  .set FUNC_SYMBOL(SYMBOL_NAME(name)), FUNC_SYMBOL(target) SEPARATOR
+  .set FUNC_SYMBOL(SYMBOL_NAME(name)), FUNC_SYMBOL(SYMBOL_NAME(target)) SEPARATOR
 
 #if defined(__ARM_EABI__)
 #define DEFINE_AEABI_FUNCTION_ALIAS(aeabi_name, name)                          \


### PR DESCRIPTION
... during a refactoring for arm64ec in #137960 6ade80ce18087b1e27505985a254c487679e16b8. The subtle change here results in a change in symbols in the library from:

```
  00000038 T ___gesf2
  00000038 T ___gtsf2
```

to:

```
           I ___gesf2 (indirect for __gtsf2)
  00000038 T ___gtsf2
```

... which is a breaking change on Mach-O platforms.

rdar://157846316