### PR TITLE
[flang][acc] honor reduction clause's implied copy attribute

### DIFF
--- a/flang/lib/Semantics/resolve-directives.cpp
+++ b/flang/lib/Semantics/resolve-directives.cpp
@@ -304,6 +304,12 @@ public:
     return false;
   }
 
+  bool Pre(const parser::AccClause::Reduction &x) {
+    const auto &objectList{std::get<parser::AccObjectList>(x.v.t)};
+    ResolveAccObjectList(objectList, Symbol::Flag::AccReduction);
+    return false;
+  }
+
   void Post(const parser::Name &);
 
 private:

--- a/flang/test/Semantics/OpenACC/acc-reduction-validity.f90
+++ b/flang/test/Semantics/OpenACC/acc-reduction-validity.f90
@@ -177,13 +177,23 @@ program openacc_reduction_validity
 end program
 
 subroutine sum()
-  ! ERROR: 'sum' is already declared in this scoping unit
+  !ERROR: 'sum' is already declared in this scoping unit
   integer :: i,sum 
   sum = 0
-  !$acc parallel 
+  !$acc parallel
+  !ERROR: Only variables are allowed in data clauses on the LOOP directive
   !$acc loop independent gang reduction(+:sum)
   do i=1,10
      sum = sum + i
   enddo
+  !$acc end parallel
+end subroutine
+
+subroutine reduce()
+  integer :: red = 0, ii
+  !$acc parallel loop default(none) reduction(+:red)
+  do ii = 1, 10
+    red = red + ii
+  end do
   !$acc end parallel
 end subroutine


### PR DESCRIPTION
The Open ACC spec states that the reduction clause implies the copy clause. Account for this in the check for `default(none)` variables. Add a test that shouldn't error, but did before this PR.