### PR TITLE
[LLDB] Fix deterministic-build.cpp post #156931

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
@@ -7,4 +7,5 @@
 // RUN: %lldb %t -o "breakpoint set -f %s -l 11" -o run -o exit | FileCheck %s
 // CHECK: stop reason = breakpoint
 
+
 int main() { return 0; }

--- a/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/deterministic-build.cpp
@@ -4,8 +4,7 @@
 // REQUIRES: system-darwin
 // RUN: %clang_host %s -g -c -o %t.o
 // RUN: env ZERO_AR_DATE=1 %clang_host %t.o -g -o %t
-// RUN: %lldb %t -o "breakpoint set -f %s -l 11" -o run -o exit | FileCheck %s
+// RUN: %lldb %t -o "breakpoint set -f %s -l 10" -o run -o exit | FileCheck %s
 // CHECK: stop reason = breakpoint
-
 
 int main() { return 0; }


### PR DESCRIPTION
This test was brokem by migrating to the lit internal shell due to a lack of env prefix for setting environment variables. This was fixed in prevented the breakpoint in the test from mapping to anything, causing the test to file. This patch restores the original line numbering.