### PR TITLE
[profcheck] Change the FileCheck substitute command

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -20,8 +20,8 @@ config.name = "LLVM"
 # testFormat: The test format to use to interpret tests.
 extra_substitutions = extra_substitutions = (
     [
-        (r"\| not FileCheck .*", "> /dev/null"),
-        (r"\| FileCheck .*", "> /dev/null"),
+        (r"FileCheck .*", "cat > /dev/null"),
+        (r"not FileCheck .*", "cat > /dev/null"),
     ]
     if config.enable_profcheck
     else []
@@ -38,6 +38,16 @@ config.suffixes = [".ll", ".c", ".test", ".txt", ".s", ".mir", ".yaml", ".spv"]
 # subdirectories contain auxiliary inputs for various tests in their parent
 # directories.
 config.excludes = ["Inputs", "CMakeLists.txt", "README.txt", "LICENSE.txt"]
+
+# Exclude llvm-reduce tests for profcheck because we substitute the FileCheck
+# binary with a no-op command for profcheck, but llvm-reduce tests have RUN
+# commands of the form llvm-reduce --test FileCheck, which explode if we
+# substitute FileCheck because llvm-reduce expects FileCheck in these tests.
+# It's not really possible to exclude these tests from the command substitution,
+# so we just exclude llvm-reduce tests from this config altogether. This should
+# be fine though as profcheck config tests are mostly concerned with opt.
+if config.enable_profcheck:
+  config.excludes = config.excludes + ["llvm-reduce"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)

--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -47,7 +47,7 @@ config.excludes = ["Inputs", "CMakeLists.txt", "README.txt", "LICENSE.txt"]
 # so we just exclude llvm-reduce tests from this config altogether. This should
 # be fine though as profcheck config tests are mostly concerned with opt.
 if config.enable_profcheck:
-  config.excludes = config.excludes + ["llvm-reduce"]
+    config.excludes = config.excludes + ["llvm-reduce"]
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)


### PR DESCRIPTION
The intent of the original regex doesn't work if, for example, the last RUN line was a pipe and FileCheck is in the next RUN line. See for example
[`function-specialization3.ll`](https://github.com/llvm/llvm-project/blob/a7c2ce6009a8034ebbf718c12a6e56c085036b57/llvm/test/Transforms/FunctionSpecialization/function-specialization3.ll). To fix this we just replace the redirerect stdout to `/dev/null` with `cat > /dev/null`, which works because it's effectively a no-op command that can be piped to or run standalone.

Tracking issue: #147390