### PR TITLE
[NFC][TableGen] Fix GlobalISel TableGen backend namespace usage

### DIFF
--- a/llvm/utils/TableGen/Common/GlobalISel/CXXPredicates.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/CXXPredicates.cpp
@@ -12,8 +12,8 @@
 #include "CXXPredicates.h"
 #include "llvm/ADT/STLExtras.h"
 
-namespace llvm {
-namespace gi {
+using namespace llvm;
+using namespace gi;
 
 std::vector<const CXXPredicateCode *>
 CXXPredicateCode::getSorted(const CXXPredicateCodePool &Pool) {
@@ -46,6 +46,3 @@ CXXPredicateCode::CXXPredicateCode(std::string Code, unsigned ID)
 
 CXXPredicateCode::CXXPredicateCodePool CXXPredicateCode::AllCXXMatchCode;
 CXXPredicateCode::CXXPredicateCodePool CXXPredicateCode::AllCXXCustomActionCode;
-
-} // namespace gi
-} // namespace llvm

--- a/llvm/utils/TableGen/Common/GlobalISel/CXXPredicates.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/CXXPredicates.h
@@ -22,8 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace llvm {
-namespace gi {
+namespace llvm::gi {
 
 /// Entry into the static pool of all CXX Predicate code. This contains
 /// fully expanded C++ code.
@@ -80,7 +79,6 @@ public:
   }
 };
 
-} // namespace gi
-} // end namespace llvm
+} // namespace llvm::gi
 
 #endif // LLVM_UTILS_TABLEGEN_COMMON_GLOBALISEL_CXXPREDICATES_H

--- a/llvm/utils/TableGen/Common/GlobalISel/CombinerUtils.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/CombinerUtils.cpp
@@ -9,9 +9,9 @@
 #include "CombinerUtils.h"
 #include "llvm/ADT/StringSet.h"
 
-namespace llvm {
+using namespace llvm;
 
-StringRef insertStrRef(StringRef S) {
+StringRef llvm::insertStrRef(StringRef S) {
   if (S.empty())
     return {};
 
@@ -19,5 +19,3 @@ StringRef insertStrRef(StringRef S) {
   auto [It, Inserted] = Pool.insert(S);
   return It->getKey();
 }
-
-} // namespace llvm

--- a/llvm/utils/TableGen/Common/GlobalISel/CombinerUtils.h
+++ b/llvm/utils/TableGen/Common/GlobalISel/CombinerUtils.h
@@ -67,6 +67,7 @@ inline const DagInit *getDagWithOperatorOfSubClass(const Init &N,
 }
 
 /// Copies a StringRef into a static pool to preserve it.
+// FIXME: Use UniqueStringSaver instead.
 StringRef insertStrRef(StringRef S);
 
 } // namespace llvm

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -23,6 +23,7 @@ STATISTIC(NumPatternEmitted, "Number of patterns emitted");
 using namespace llvm;
 using namespace gi;
 
+// FIXME: Use createStringError instead.
 static Error failUnsupported(const Twine &Reason) {
   return make_error<StringError>(Reason, inconvertibleErrorCode());
 }

--- a/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/GlobalISelMatchTable.cpp
@@ -20,17 +20,15 @@
 
 STATISTIC(NumPatternEmitted, "Number of patterns emitted");
 
-namespace llvm {
-namespace gi {
+using namespace llvm;
+using namespace gi;
 
-namespace {
-
-Error failUnsupported(const Twine &Reason) {
+static Error failUnsupported(const Twine &Reason) {
   return make_error<StringError>(Reason, inconvertibleErrorCode());
 }
 
 /// Get the name of the enum value used to number the predicate function.
-std::string getEnumNameForPredicate(const TreePredicateFn &Predicate) {
+static std::string getEnumNameForPredicate(const TreePredicateFn &Predicate) {
   if (Predicate.hasGISelPredicateCode())
     return "GICXXPred_MI_" + Predicate.getFnName();
   if (Predicate.hasGISelLeafPredicateCode())
@@ -39,18 +37,17 @@ std::string getEnumNameForPredicate(const TreePredicateFn &Predicate) {
          Predicate.getFnName();
 }
 
-std::string getMatchOpcodeForImmPredicate(const TreePredicateFn &Predicate) {
+static std::string
+getMatchOpcodeForImmPredicate(const TreePredicateFn &Predicate) {
   return "GIM_Check" + Predicate.getImmTypeIdentifier().str() + "ImmPredicate";
 }
 
 // GIMT_Encode2/4/8
 constexpr StringLiteral EncodeMacroName = "GIMT_Encode";
 
-} // namespace
-
 //===- Helpers ------------------------------------------------------------===//
 
-void emitEncodingMacrosDef(raw_ostream &OS) {
+void llvm::gi::emitEncodingMacrosDef(raw_ostream &OS) {
   OS << "#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__\n"
      << "#define " << EncodeMacroName << "2(Val)"
      << " uint8_t(Val), uint8_t((Val) >> 8)\n"
@@ -76,14 +73,15 @@ void emitEncodingMacrosDef(raw_ostream &OS) {
      << "#endif\n";
 }
 
-void emitEncodingMacrosUndef(raw_ostream &OS) {
+void llvm::gi::emitEncodingMacrosUndef(raw_ostream &OS) {
   OS << "#undef " << EncodeMacroName << "2\n"
      << "#undef " << EncodeMacroName << "4\n"
      << "#undef " << EncodeMacroName << "8\n";
 }
 
-std::string getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset,
-                                    int HwModeIdx) {
+std::string
+llvm::gi::getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset,
+                                  int HwModeIdx) {
   std::string Name = "GIFBS";
   for (const Record *Feature : FeatureBitset)
     Name += ("_" + Feature->getName()).str();
@@ -94,8 +92,8 @@ std::string getNameForFeatureBitset(ArrayRef<const Record *> FeatureBitset,
 
 template <class GroupT>
 std::vector<Matcher *>
-optimizeRules(ArrayRef<Matcher *> Rules,
-              std::vector<std::unique_ptr<Matcher>> &MatcherStorage) {
+llvm::gi::optimizeRules(ArrayRef<Matcher *> Rules,
+                        std::vector<std::unique_ptr<Matcher>> &MatcherStorage) {
 
   std::vector<Matcher *> OptRules;
   std::unique_ptr<GroupT> CurrentGroup = std::make_unique<GroupT>();
@@ -142,11 +140,11 @@ optimizeRules(ArrayRef<Matcher *> Rules,
   return OptRules;
 }
 
-template std::vector<Matcher *> optimizeRules<GroupMatcher>(
+template std::vector<Matcher *> llvm::gi::optimizeRules<GroupMatcher>(
     ArrayRef<Matcher *> Rules,
     std::vector<std::unique_ptr<Matcher>> &MatcherStorage);
 
-template std::vector<Matcher *> optimizeRules<SwitchMatcher>(
+template std::vector<Matcher *> llvm::gi::optimizeRules<SwitchMatcher>(
     ArrayRef<Matcher *> Rules,
     std::vector<std::unique_ptr<Matcher>> &MatcherStorage);
 
@@ -158,7 +156,7 @@ static std::string getEncodedEmitStr(StringRef NamedValue, unsigned NumBytes) {
 
 //===- Global Data --------------------------------------------------------===//
 
-std::set<LLTCodeGen> KnownTypes;
+std::set<LLTCodeGen> llvm::gi::KnownTypes;
 
 //===- MatchTableRecord ---------------------------------------------------===//
 
@@ -437,7 +435,7 @@ bool LLTCodeGen::operator<(const LLTCodeGen &Other) const {
 
 //===- LLTCodeGen Helpers -------------------------------------------------===//
 
-std::optional<LLTCodeGen> MVTToLLT(MVT::SimpleValueType SVT) {
+std::optional<LLTCodeGen> llvm::gi::MVTToLLT(MVT::SimpleValueType SVT) {
   MVT VT(SVT);
 
   if (VT.isVector() && !VT.getVectorElementCount().isScalar())
@@ -2434,6 +2432,3 @@ void MakeTempRegisterAction::emitActionOpcodes(MatchTable &Table,
         << MatchTable::ULEB128Value(TempRegID) << MatchTable::Comment("TypeID")
         << Ty << MatchTable::LineBreak;
 }
-
-} // namespace gi
-} // namespace llvm

--- a/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/PatternParser.cpp
@@ -17,8 +17,9 @@
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
 
-namespace llvm {
-namespace gi {
+using namespace llvm;
+using namespace gi;
+
 static constexpr StringLiteral MIFlagsEnumClassName = "MIFlagEnum";
 
 namespace {
@@ -445,6 +446,3 @@ const PatFrag *PatternParser::parsePatFrag(const Record *Def) {
   SeenPatFrags.insert(Res);
   return Res;
 }
-
-} // namespace gi
-} // namespace llvm

--- a/llvm/utils/TableGen/Common/GlobalISel/Patterns.cpp
+++ b/llvm/utils/TableGen/Common/GlobalISel/Patterns.cpp
@@ -18,8 +18,8 @@
 #include "llvm/TableGen/Error.h"
 #include "llvm/TableGen/Record.h"
 
-namespace llvm {
-namespace gi {
+using namespace llvm;
+using namespace gi;
 
 //===- PatternType --------------------------------------------------------===//
 
@@ -884,6 +884,3 @@ bool BuiltinPattern::checkSemantics(ArrayRef<SMLoc> Loc) {
 
   return true;
 }
-
-} // namespace gi
-} // namespace llvm

--- a/llvm/utils/TableGen/GlobalISelEmitter.cpp
+++ b/llvm/utils/TableGen/GlobalISelEmitter.cpp
@@ -86,8 +86,6 @@ static cl::opt<bool> OptimizeMatchTable(
     cl::desc("Generate an optimized version of the match table"),
     cl::init(true), cl::cat(GlobalISelEmitterCat));
 
-namespace {
-
 static std::string explainPredicates(const TreePatternNode &N) {
   std::string Explanation;
   StringRef Separator = "";
@@ -167,7 +165,7 @@ static std::string explainPredicates(const TreePatternNode &N) {
   return Explanation;
 }
 
-std::string explainOperator(const Record *Operator) {
+static std::string explainOperator(const Record *Operator) {
   if (Operator->isSubClassOf("SDNode"))
     return (" (" + Operator->getValueAsString("Opcode") + ")").str();
 
@@ -314,6 +312,7 @@ static Expected<LLTCodeGen> getInstResultType(const TreePatternNode &Dst,
   return *MaybeOpTy;
 }
 
+namespace {
 class GlobalISelEmitter final : public GlobalISelMatchTableExecutorEmitter {
 public:
   explicit GlobalISelEmitter(const RecordKeeper &RK);
@@ -493,8 +492,11 @@ private:
                        const TreePredicateFn &Predicate,
                        InstructionMatcher &InsnMatcher, bool &HasAddedMatcher);
 };
+} // namespace
 
-StringRef getPatFragPredicateEnumName(const Record *R) { return R->getName(); }
+static StringRef getPatFragPredicateEnumName(const Record *R) {
+  return R->getName();
+}
 
 void GlobalISelEmitter::gatherOpcodeValues() {
   InstructionOpcodeMatcher::initOpcodeValuesMap(Target);
@@ -2533,8 +2535,6 @@ void GlobalISelEmitter::declareSubtargetFeature(const Record *Predicate) {
 unsigned GlobalISelEmitter::declareHwModeCheck(StringRef HwModeFeatures) {
   return HwModes.emplace(HwModeFeatures.str(), HwModes.size()).first->second;
 }
-
-} // end anonymous namespace
 
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
- Move standalone functions and variables out of anonymous namespace and make them static.
- Restrict the scope of anonymous namespace to just class declarations.
- Remove llvm/gi namespace enclosing the entire .cpp files and instead use `using namespace`.
- Use nested namespaces when possible.