### PR TITLE
[BOLT][AArch64][instr] Remove instructions on saving and restoring NZCV

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -2517,21 +2517,17 @@ public:
   createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
                        unsigned CodePointerSize) const override {
     unsigned int I = 0;
-    InstructionListType Instrs(10);
+    InstructionListType Instrs(6);
 
     createPushRegisters(Instrs[I++], AArch64::X0, AArch64::X1);
-    getSystemFlag(Instrs[I++], AArch64::X1);
     InstructionListType Addr = materializeAddress(Target, Ctx, AArch64::X0);
     assert(Addr.size() == 2 && "Invalid Addr size");
     std::copy(Addr.begin(), Addr.end(), Instrs.begin() + I);
     I += Addr.size();
-    storeReg(Instrs[I++], AArch64::X2, AArch64::SP);
-    InstructionListType Insts = createIncMemory(AArch64::X0, AArch64::X2);
+    InstructionListType Insts = createIncMemory(AArch64::X0, AArch64::X1);
     assert(Insts.size() == 2 && "Invalid Insts size");
     std::copy(Insts.begin(), Insts.end(), Instrs.begin() + I);
     I += Insts.size();
-    loadReg(Instrs[I++], AArch64::X2, AArch64::SP);
-    setSystemFlag(Instrs[I++], AArch64::X1);
     createPopRegisters(Instrs[I++], AArch64::X0, AArch64::X1);
     return Instrs;
   }


### PR DESCRIPTION
Remove the `NZCV` save and restore instructions from instrumentation
sequence because the instructions used for getting counter address,
counter increment and stack push/pop won't impact `NZCV`. And with
this we can use `X1` to do counter increment and then the push and
pop of `X2` can be removed.