### PR TITLE
[libc] Workaround for GCC on `typedef` for `_Complex __float128`

### DIFF
--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -13,7 +13,12 @@
 
 #ifdef LIBC_TYPES_HAS_CFLOAT128
 #ifndef LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
+#if defined(__GNUC__) && !defined(__clang__)
+// Remove the workaround when https://gcc.gnu.org/PR121799 gets fixed.
+typedef __typeof__(_Complex __float128) cfloat128;
+#else  // ^^^ workaround / no workaround vvv
 typedef _Complex __float128 cfloat128;
+#endif // ^^^ workaround ^^^
 #else
 typedef _Complex long double cfloat128;
 #endif // LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE

--- a/libc/include/llvm-libc-types/cfloat128.h
+++ b/libc/include/llvm-libc-types/cfloat128.h
@@ -14,7 +14,7 @@
 #ifdef LIBC_TYPES_HAS_CFLOAT128
 #ifndef LIBC_TYPES_CFLOAT128_IS_COMPLEX_LONG_DOUBLE
 #if defined(__GNUC__) && !defined(__clang__)
-// Remove the workaround when https://gcc.gnu.org/PR121799 gets fixed.
+// Remove the workaround when https://gcc.gnu.org/PR32187 gets fixed.
 typedef __typeof__(_Complex __float128) cfloat128;
 #else  // ^^^ workaround / no workaround vvv
 typedef _Complex __float128 cfloat128;

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1265,3 +1265,5 @@ typedef __char32_t char32_t;
 #endif // __cplusplus
 
 #endif // _LIBCPP___CONFIG
+
+// triggering CI, will be reverted

--- a/libcxx/include/__config
+++ b/libcxx/include/__config
@@ -1265,5 +1265,3 @@ typedef __char32_t char32_t;
 #endif // __cplusplus
 
 #endif // _LIBCPP___CONFIG
-
-// triggering CI, will be reverted


### PR DESCRIPTION
Currently, GCC can't parse `typedef _Complex __float128 cfloat128;`, although `__typeof__` can be used as a workaround. Reported https://gcc.gnu.org/PR121799 which was later considered as duplicate of https://gcc.gnu.org/PR32187.

Some recent changes exposed it to GCC and then caused CI failure for libc++. This patch adds a workaround for GCC.