### PR TITLE
[Support] Modernize PointerLikeTypeTraits with llvm::is_detected (NFC)

### DIFF
--- a/llvm/include/llvm/Support/PointerLikeTypeTraits.h
+++ b/llvm/include/llvm/Support/PointerLikeTypeTraits.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_POINTERLIKETYPETRAITS_H
 #define LLVM_SUPPORT_POINTERLIKETYPETRAITS_H
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/DataTypes.h"
 #include <cassert>
 #include <type_traits>
@@ -31,25 +32,15 @@ struct ConstantLog2
     : std::integral_constant<size_t, ConstantLog2<N / 2>::value + 1> {};
 template <> struct ConstantLog2<1> : std::integral_constant<size_t, 0> {};
 
-// Provide a trait to check if T is pointer-like.
-template <typename T, typename U = void> struct HasPointerLikeTypeTraits {
-  static const bool value = false;
-};
-
 // sizeof(T) is valid only for a complete T.
 template <typename T>
-struct HasPointerLikeTypeTraits<
-    T, decltype((sizeof(PointerLikeTypeTraits<T>) + sizeof(T)), void())> {
-  static const bool value = true;
-};
+using check_IsPointerLike =
+    std::void_t<decltype(sizeof(PointerLikeTypeTraits<T>)),
+                decltype(sizeof(T))>;
 
-template <typename T> struct IsPointerLike {
-  static const bool value = HasPointerLikeTypeTraits<T>::value;
-};
-
-template <typename T> struct IsPointerLike<T *> {
-  static const bool value = true;
-};
+// Provide a trait to check if T is pointer-like.
+template <typename T>
+struct IsPointerLike : is_detected<check_IsPointerLike, T> {};
 } // namespace detail
 
 // Provide PointerLikeTypeTraits for non-cvr pointers.


### PR DESCRIPTION
This patch consolidates four separate template structs into a single
IsPointerLike struct.  A helper alias:

  using check_IsPointerLike = ...;

encapsulates the logic to determine a type has pointer-like traits.
