### PR TITLE
[libc++][test] Move the SFINAE test for return types of `quoted` to `libcxx/test/libcxx/`

### DIFF
--- a/libcxx/test/libcxx/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp
@@ -16,6 +16,8 @@
 //   with the wrong CharTraits. To avoid our having to create working
 //   ostreams with weird CharTraits, this is a compile-only test.
 
+//   It is unspecified whether these operators are SFINAE-friendly. We choose to make them so.
+
 #include <iomanip>
 #include <istream>
 #include <ostream>
@@ -26,44 +28,47 @@
 #include "test_allocator.h"
 #include "test_macros.h"
 
-template<class IS, class Q>
-decltype(std::declval<IS>() >> std::declval<Q>(), std::true_type())
-has_rightshift_impl(int) { return std::true_type(); }
+template <class IS, class Q>
+decltype(std::declval<IS>() >> std::declval<Q>(), std::true_type()) has_rightshift_impl(int) {
+  return std::true_type();
+}
 
-template<class IS, class Q>
-std::false_type
-has_rightshift_impl(long) { return std::false_type(); }
+template <class IS, class Q>
+std::false_type has_rightshift_impl(long) {
+  return std::false_type();
+}
 
-template<class IS, class Q>
+template <class IS, class Q>
 struct HasRightShift : decltype(has_rightshift_impl<IS, Q>(0)) {};
 
-template<class OS, class Q>
-decltype(std::declval<OS>() << std::declval<Q>(), std::true_type())
-has_leftshift_impl(int) { return std::true_type(); }
+template <class OS, class Q>
+decltype(std::declval<OS>() << std::declval<Q>(), std::true_type()) has_leftshift_impl(int) {
+  return std::true_type();
+}
 
-template<class OS, class Q>
-std::false_type
-has_leftshift_impl(long) { return std::false_type(); }
+template <class OS, class Q>
+std::false_type has_leftshift_impl(long) {
+  return std::false_type();
+}
 
-template<class OS, class Q>
+template <class OS, class Q>
 struct HasLeftShift : decltype(has_leftshift_impl<OS, Q>(0)) {};
 
-template<class CharT>
+template <class CharT>
 struct FakeCharTraits : std::char_traits<CharT> {};
 
-void test_string_literal()
-{
+void test_string_literal() {
   using Q = decltype(std::quoted("hello"));
-  static_assert( HasLeftShift<std::ostream&, Q>::value, "");
+  static_assert(HasLeftShift<std::ostream&, Q>::value, "");
   static_assert(!HasRightShift<std::istream&, Q>::value, "");
-  static_assert( HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, Q>::value, "");
+  static_assert(HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, Q>::value, "");
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, Q>::value, "");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
   using WQ = decltype(std::quoted(L"hello"));
-  static_assert( HasLeftShift<std::wostream&, WQ>::value, "");
+  static_assert(HasLeftShift<std::wostream&, WQ>::value, "");
   static_assert(!HasRightShift<std::wistream&, WQ>::value, "");
-  static_assert( HasLeftShift<std::basic_ostream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");
+  static_assert(HasLeftShift<std::basic_ostream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");
   static_assert(!HasRightShift<std::basic_istream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");
 
   static_assert(!HasLeftShift<std::ostream&, WQ>::value, "");
@@ -71,15 +76,14 @@ void test_string_literal()
 #endif // TEST_HAS_NO_WIDE_CHARACTERS
 }
 
-void test_std_string()
-{
-  std::string s = "hello";
+void test_std_string() {
+  std::string s  = "hello";
   const auto& cs = s;
-  using Q = decltype(std::quoted(s));
-  using CQ = decltype(std::quoted(cs));
-  static_assert( HasLeftShift<std::ostream&, Q>::value, "");
-  static_assert( HasRightShift<std::istream&, Q>::value, "");
-  static_assert( HasLeftShift<std::ostream&, CQ>::value, "");
+  using Q        = decltype(std::quoted(s));
+  using CQ       = decltype(std::quoted(cs));
+  static_assert(HasLeftShift<std::ostream&, Q>::value, "");
+  static_assert(HasRightShift<std::istream&, Q>::value, "");
+  static_assert(HasLeftShift<std::ostream&, CQ>::value, "");
   static_assert(!HasRightShift<std::istream&, CQ>::value, "");
   static_assert(!HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, Q>::value, "");
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, Q>::value, "");
@@ -87,26 +91,26 @@ void test_std_string()
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, CQ>::value, "");
 
   std::basic_string<char, FakeCharTraits<char>, test_allocator<char>> st = "hello";
-  const auto& cst = st;
-  using QT = decltype(std::quoted(st));
-  using CQT = decltype(std::quoted(cst));
+  const auto& cst                                                        = st;
+  using QT                                                               = decltype(std::quoted(st));
+  using CQT                                                              = decltype(std::quoted(cst));
   static_assert(!HasLeftShift<std::ostream&, QT>::value, "");
   static_assert(!HasRightShift<std::istream&, QT>::value, "");
   static_assert(!HasLeftShift<std::ostream&, CQT>::value, "");
   static_assert(!HasRightShift<std::istream&, CQT>::value, "");
-  static_assert( HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, QT>::value, "");
-  static_assert( HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, QT>::value, "");
-  static_assert( HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, CQT>::value, "");
+  static_assert(HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, QT>::value, "");
+  static_assert(HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, QT>::value, "");
+  static_assert(HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, CQT>::value, "");
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, CQT>::value, "");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
   std::wstring ws = L"hello";
   const auto& cws = ws;
-  using WQ = decltype(std::quoted(ws));
-  using CWQ = decltype(std::quoted(cws));
-  static_assert( HasLeftShift<std::wostream&, WQ>::value, "");
-  static_assert( HasRightShift<std::wistream&, WQ>::value, "");
-  static_assert( HasLeftShift<std::wostream&, CWQ>::value, "");
+  using WQ        = decltype(std::quoted(ws));
+  using CWQ       = decltype(std::quoted(cws));
+  static_assert(HasLeftShift<std::wostream&, WQ>::value, "");
+  static_assert(HasRightShift<std::wistream&, WQ>::value, "");
+  static_assert(HasLeftShift<std::wostream&, CWQ>::value, "");
   static_assert(!HasRightShift<std::wistream&, CWQ>::value, "");
   static_assert(!HasLeftShift<std::basic_ostream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");
   static_assert(!HasRightShift<std::basic_istream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");
@@ -118,15 +122,14 @@ void test_std_string()
 #endif // TEST_HAS_NO_WIDE_CHARACTERS
 }
 
-void test_std_string_view()
-{
+void test_std_string_view() {
   std::string_view s = "hello";
-  const auto& cs = s;
-  using Q = decltype(std::quoted(s));
-  using CQ = decltype(std::quoted(cs));
-  static_assert( HasLeftShift<std::ostream&, Q>::value, "");
+  const auto& cs     = s;
+  using Q            = decltype(std::quoted(s));
+  using CQ           = decltype(std::quoted(cs));
+  static_assert(HasLeftShift<std::ostream&, Q>::value, "");
   static_assert(!HasRightShift<std::istream&, Q>::value, "");
-  static_assert( HasLeftShift<std::ostream&, CQ>::value, "");
+  static_assert(HasLeftShift<std::ostream&, CQ>::value, "");
   static_assert(!HasRightShift<std::istream&, CQ>::value, "");
   static_assert(!HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, Q>::value, "");
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, Q>::value, "");
@@ -134,26 +137,26 @@ void test_std_string_view()
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, CQ>::value, "");
 
   std::basic_string_view<char, FakeCharTraits<char>> st = "hello";
-  const auto& cst = st;
-  using QT = decltype(std::quoted(st));
-  using CQT = decltype(std::quoted(cst));
+  const auto& cst                                       = st;
+  using QT                                              = decltype(std::quoted(st));
+  using CQT                                             = decltype(std::quoted(cst));
   static_assert(!HasLeftShift<std::ostream&, QT>::value, "");
   static_assert(!HasRightShift<std::istream&, QT>::value, "");
   static_assert(!HasLeftShift<std::ostream&, CQT>::value, "");
   static_assert(!HasRightShift<std::istream&, CQT>::value, "");
-  static_assert( HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, QT>::value, "");
+  static_assert(HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, QT>::value, "");
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, QT>::value, "");
-  static_assert( HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, CQT>::value, "");
+  static_assert(HasLeftShift<std::basic_ostream<char, FakeCharTraits<char>>&, CQT>::value, "");
   static_assert(!HasRightShift<std::basic_istream<char, FakeCharTraits<char>>&, CQT>::value, "");
 
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
   std::wstring_view ws = L"hello";
-  const auto& cws = ws;
-  using WQ = decltype(std::quoted(ws));
-  using CWQ = decltype(std::quoted(cws));
-  static_assert( HasLeftShift<std::wostream&, WQ>::value, "");
+  const auto& cws      = ws;
+  using WQ             = decltype(std::quoted(ws));
+  using CWQ            = decltype(std::quoted(cws));
+  static_assert(HasLeftShift<std::wostream&, WQ>::value, "");
   static_assert(!HasRightShift<std::wistream&, WQ>::value, "");
-  static_assert( HasLeftShift<std::wostream&, CWQ>::value, "");
+  static_assert(HasLeftShift<std::wostream&, CWQ>::value, "");
   static_assert(!HasRightShift<std::wistream&, CWQ>::value, "");
   static_assert(!HasLeftShift<std::basic_ostream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");
   static_assert(!HasRightShift<std::basic_istream<wchar_t, FakeCharTraits<wchar_t>>&, WQ>::value, "");

--- a/libcxx/test/libcxx/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp
+++ b/libcxx/test/libcxx/input.output/iostream.format/quoted.manip/quoted_traits.compile.pass.cpp
@@ -17,6 +17,7 @@
 //   ostreams with weird CharTraits, this is a compile-only test.
 
 //   It is unspecified whether these operators are SFINAE-friendly. We choose to make them so.
+//   See https://wg21.link/LWG4364 for whether this should be considered an extension or not.
 
 #include <iomanip>
 #include <istream>


### PR DESCRIPTION
[quoted.manip] only specifies that `operator<<`/`operator>>` is well-formed for operands with suitable types, and leaves it undefined whether they are SFINAE-friendly.

Although it's worthwhile making them SFINAE-friendly, perhaps the SFINAE-friendliness should be considered as a libc++-specific choice at this moment.

Also clang-format the file to make CI happy.