### PR TITLE
[SelectionDAG] Clean up SCALAR_TO_VECTOR handling in SimplifyDemanded…

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp
@@ -3227,27 +3227,6 @@ bool TargetLowering::SimplifyDemandedVectorElts(
       KnownUndef.setAllBits();
       return TLO.CombineTo(Op, TLO.DAG.getUNDEF(VT));
     }
-    SDValue ScalarSrc = Op.getOperand(0);
-    if (ScalarSrc.getOpcode() == ISD::EXTRACT_VECTOR_ELT) {
-      SDValue Src = ScalarSrc.getOperand(0);
-      SDValue Idx = ScalarSrc.getOperand(1);
-      EVT SrcVT = Src.getValueType();
-
-      ElementCount SrcEltCnt = SrcVT.getVectorElementCount();
-
-      if (SrcEltCnt.isScalable())
-        return false;
-
-      unsigned NumSrcElts = SrcEltCnt.getFixedValue();
-      if (isNullConstant(Idx)) {
-        APInt SrcDemandedElts = APInt::getOneBitSet(NumSrcElts, 0);
-        APInt SrcUndef = KnownUndef.zextOrTrunc(NumSrcElts);
-        APInt SrcZero = KnownZero.zextOrTrunc(NumSrcElts);
-        if (SimplifyDemandedVectorElts(Src, SrcDemandedElts, SrcUndef, SrcZero,
-                                       TLO, Depth + 1))
-          return true;
-      }
-    }
     KnownUndef.setHighBits(NumElts - 1);
     break;
   }


### PR DESCRIPTION
…VectorElts

This patch reverts changes from commit 585e65d3307f5f0 (https://reviews.llvm.org/D104250), as it doesn't seem to be needed nowadays.

The removed code was doing a recursive call to
SimplifyDemandedVectorElts trying to simplify the vector %vec when finding things like
  (SCALAR_TO_VECTOR (EXTRACT_VECTOR_ELT %vec, 0))

I figure that (EXTRACT_VECTOR_ELT %vec, 0) would be simplified based on only demanding element zero regardless of being used in a SCALAR_TO_VECTOR operation or not.

It had been different if the code tried to simplify the whole expression as %vec. That could also have motivate why to make element zero a special case. But it only simplified %vec without folding away the SCALAR_TO_VECTOR.