### PR TITLE
[AArch64] Verify OPERAND_SHIFT_MSL and OPERAND_IMPLICIT_IMM_0

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -11256,7 +11256,6 @@ AArch64InstrInfo::analyzeLoopForPipelining(MachineBasicBlock *LoopBB) const {
 /// verifyInstruction - Perform target specific instruction verification.
 bool AArch64InstrInfo::verifyInstruction(const MachineInstr &MI,
                                          StringRef &ErrInfo) const {
-
   // Verify that immediate offsets on load/store instructions are within range.
   // Stack objects with an FI operand are excluded as they can be fixed up
   // during PEI.
@@ -11270,6 +11269,30 @@ bool AArch64InstrInfo::verifyInstruction(const MachineInstr &MI,
         ErrInfo = "Unexpected immediate on load/store instruction";
         return false;
       }
+    }
+  }
+
+  const MCInstrDesc &MCID = MI.getDesc();
+  for (unsigned Op = 0; Op < MCID.getNumOperands(); Op++) {
+    const MachineOperand &MO = MI.getOperand(Op);
+    switch (MCID.operands()[Op].OperandType) {
+    case AArch64::OPERAND_IMPLICIT_IMM_0:
+      if (!MO.isImm() || MO.getImm() != 0) {
+        ErrInfo = "OPERAND_IMPLICIT_IMM_0 should be 0";
+        return false;
+      }
+      break;
+    case AArch64::OPERAND_SHIFT_MSL:
+      if (!MO.isImm() ||
+          AArch64_AM::getShiftType(MO.getImm()) != AArch64_AM::MSL ||
+          (AArch64_AM::getShiftValue(MO.getImm()) != 8 &&
+           AArch64_AM::getShiftValue(MO.getImm()) != 16)) {
+        ErrInfo = "OPERAND_SHIFT_MSL should be msl shift of 8 or 16";
+        return false;
+      }
+      break;
+    default:
+      break;
     }
   }
   return true;

--- a/llvm/test/CodeGen/AArch64/verify-imm.mir
+++ b/llvm/test/CodeGen/AArch64/verify-imm.mir
@@ -1,0 +1,22 @@
+# RUN: not --crash llc -mtriple=aarch64 -run-pass machineverifier -o /dev/null %s 2>&1 | FileCheck -implicit-check-not="Bad machine code"  %s
+
+# CHECK: *** Bad machine code: OPERAND_SHIFT_MSL should be msl shift of 8 or 16 ***
+# CHECK: - instruction: $d0 = MOVIv2s_msl 55, 262
+# CHECK: *** Bad machine code: OPERAND_SHIFT_MSL should be msl shift of 8 or 16 ***
+# CHECK: - instruction: $q0 = MOVIv4s_msl 55, 8
+# CHECK: *** Bad machine code: OPERAND_IMPLICIT_IMM_0 should be 0 ***
+# CHECK: - instruction: $zad0 = MOVA_MXI2Z_V_D $zad0(tied-def 0), $w12, 1, $z0_z1
+
+---
+name:            verifyImm
+alignment:       4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $z0_z1, $zad0, $x0, $w12
+
+    $d0 = MOVIv2s_msl 55, 262
+    $q0 = MOVIv4s_msl 55, 8
+    $zad0 = MOVA_MXI2Z_V_D $zad0, $w12, 1, $z0_z1
+    RET undef $lr, implicit $x0
+...


### PR DESCRIPTION
This adds some basic verification for the new OPERAND_SHIFT_MSL and the existing OPERAND_IMPLICIT_IMM_0 immediate operand types, that should be 264/272 or 0 respectively.