### PR TITLE
[clang] Fix of test 'ctu-import-type-decl-definition.c' (NFC)

### DIFF
--- a/clang/test/Analysis/ctu-import-type-decl-definition.c
+++ b/clang/test/Analysis/ctu-import-type-decl-definition.c
@@ -4,8 +4,8 @@
 
 // RUN: %clang_cc1 -emit-pch -o %t/import.c.ast %t/import.c
 
-// RUN: %clang_extdef_map -- -x c %t/import.c >> %t/externalDefMap.txt
-// RUN: sed -i='' 's/$/.ast/' %t/externalDefMap.txt
+// RUN: %clang_extdef_map -- -x c %t/import.c >> %t/externalDefMap_.txt
+// RUN: sed 's/$/.ast/' %t/externalDefMap_.txt >> %t/externalDefMap.txt
 
 // RUN: %clang_cc1 -analyze \
 // RUN:   -analyzer-checker=core \

--- a/clang/test/Analysis/ctu-import-type-decl-definition.c
+++ b/clang/test/Analysis/ctu-import-type-decl-definition.c
@@ -4,8 +4,8 @@
 
 // RUN: %clang_cc1 -emit-pch -o %t/import.c.ast %t/import.c
 
-// RUN: %clang_extdef_map -- -x c %t/import.c >> %t/externalDefMap_.txt
-// RUN: sed 's/$/.ast/' %t/externalDefMap_.txt >> %t/externalDefMap.txt
+// RUN: %clang_extdef_map -- -x c %t/import.c >> %t/externalDefMap.tmp.txt
+// RUN: sed 's/$/.ast/' %t/externalDefMap.tmp.txt >> %t/externalDefMap.txt
 
 // RUN: %clang_cc1 -analyze \
 // RUN:   -analyzer-checker=core \


### PR DESCRIPTION
It looks not possible to have a `sed` command with -i option that works on all platforms. The -i option is not necessary so it is removed.