### PR TITLE
IRLinker: avoid quadratic behavior

### DIFF
--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Linker/IRMover.h"
 #include "LinkDiagnosticInfo.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/IR/AutoUpgrade.h"
@@ -289,6 +290,9 @@ typedef DenseMap<const Metadata *, TrackingMDRef> MDMapT;
 class IRLinker {
   Module &DstM;
   std::unique_ptr<Module> SrcM;
+
+  // Lookup table to optimize IRMover::linkNamedMDNodes().
+  DenseMap<StringRef, DenseSet<MDNode *>> NamedMDNodes;
 
   /// See IRMover::move().
   IRMover::LazyCallback AddLazyFor;
@@ -1132,12 +1136,20 @@ void IRLinker::linkNamedMDNodes() {
       continue;
 
     NamedMDNode *DestNMD = DstM.getOrInsertNamedMetadata(NMD.getName());
+
+    auto &Inserted = NamedMDNodes[DestNMD->getName()];
+    if (Inserted.size() < DestNMD->getNumOperands()) {
+      // Must be the first module, copy everything from DestNMD.
+      Inserted.insert(DestNMD->operands().begin(), DestNMD->operands().end());
+    }
+
     // Add Src elements into Dest node.
     for (const MDNode *Op : NMD.operands()) {
       MDNode *MD = Mapper.mapMDNode(*Op);
-      if (!is_contained(DestNMD->operands(), MD))
+      if (Inserted.insert(MD).second)
         DestNMD->addOperand(MD);
     }
+    assert(Inserted.size() == DestNMD->getNumOperands());
   }
 }
 

--- a/llvm/lib/Linker/IRMover.cpp
+++ b/llvm/lib/Linker/IRMover.cpp
@@ -8,6 +8,7 @@
 
 #include "llvm/Linker/IRMover.h"
 #include "LinkDiagnosticInfo.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallString.h"
@@ -1138,7 +1139,7 @@ void IRLinker::linkNamedMDNodes() {
     NamedMDNode *DestNMD = DstM.getOrInsertNamedMetadata(NMD.getName());
 
     auto &Inserted = NamedMDNodes[DestNMD->getName()];
-    if (Inserted.size() < DestNMD->getNumOperands()) {
+    if (Inserted.empty()) {
       // Must be the first module, copy everything from DestNMD.
       Inserted.insert(DestNMD->operands().begin(), DestNMD->operands().end());
     }


### PR DESCRIPTION
After #146020  `is_contained` does linear search trough
all previously inserted operands.

On large binaries it can take up to 30% for ThinLTO linking with CFI, which
uses long lists of `cfi.functions` metadata.
