### PR TITLE
[clang] Move two flags from EvalInfo to State

### DIFF
--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -20,13 +20,21 @@ using namespace clang::interp;
 InterpState::InterpState(State &Parent, Program &P, InterpStack &Stk,
                          Context &Ctx, SourceMapper *M)
     : Parent(Parent), M(M), P(P), Stk(Stk), Ctx(Ctx), BottomFrame(*this),
-      Current(&BottomFrame) {}
+      Current(&BottomFrame) {
+  CheckingPotentialConstantExpression =
+      Parent.CheckingPotentialConstantExpression;
+  CheckingForUndefinedBehavior = Parent.CheckingForUndefinedBehavior;
+}
 
 InterpState::InterpState(State &Parent, Program &P, InterpStack &Stk,
                          Context &Ctx, const Function *Func)
     : Parent(Parent), M(nullptr), P(P), Stk(Stk), Ctx(Ctx),
       BottomFrame(*this, Func, nullptr, CodePtr(), Func->getArgSize()),
-      Current(&BottomFrame) {}
+      Current(&BottomFrame) {
+  CheckingPotentialConstantExpression =
+      Parent.CheckingPotentialConstantExpression;
+  CheckingForUndefinedBehavior = Parent.CheckingForUndefinedBehavior;
+}
 
 bool InterpState::inConstantContext() const {
   if (ConstantContextOverride)

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -70,17 +70,11 @@ public:
   ASTContext &getASTContext() const override { return Parent.getASTContext(); }
 
   // Forward status checks and updates to the walker.
-  bool checkingForUndefinedBehavior() const override {
-    return Parent.checkingForUndefinedBehavior();
-  }
   bool keepEvaluatingAfterFailure() const override {
     return Parent.keepEvaluatingAfterFailure();
   }
   bool keepEvaluatingAfterSideEffect() const override {
     return Parent.keepEvaluatingAfterSideEffect();
-  }
-  bool checkingPotentialConstantExpression() const override {
-    return Parent.checkingPotentialConstantExpression();
   }
   bool noteUndefinedBehavior() override {
     return Parent.noteUndefinedBehavior();

--- a/clang/lib/AST/ByteCode/State.h
+++ b/clang/lib/AST/ByteCode/State.h
@@ -59,8 +59,6 @@ class State {
 public:
   virtual ~State();
 
-  virtual bool checkingForUndefinedBehavior() const = 0;
-  virtual bool checkingPotentialConstantExpression() const = 0;
   virtual bool noteUndefinedBehavior() = 0;
   virtual bool keepEvaluatingAfterFailure() const = 0;
   virtual bool keepEvaluatingAfterSideEffect() const = 0;
@@ -74,6 +72,16 @@ public:
   virtual bool hasPriorDiagnostic() = 0;
   virtual unsigned getCallStackDepth() = 0;
   virtual bool noteSideEffect() = 0;
+
+  /// Are we checking whether the expression is a potential constant
+  /// expression?
+  bool checkingPotentialConstantExpression() const {
+    return CheckingPotentialConstantExpression;
+  }
+  /// Are we checking an expression for overflow?
+  bool checkingForUndefinedBehavior() const {
+    return CheckingForUndefinedBehavior;
+  }
 
 public:
   State() = default;
@@ -127,6 +135,19 @@ public:
   /// Whether or not we're in a context where the front end requires a
   /// constant value.
   bool InConstantContext = false;
+
+  /// Whether we're checking that an expression is a potential constant
+  /// expression. If so, do not fail on constructs that could become constant
+  /// later on (such as a use of an undefined global).
+  bool CheckingPotentialConstantExpression = false;
+
+  /// Whether we're checking for an expression that has undefined behavior.
+  /// If so, we will produce warnings if we encounter an operation that is
+  /// always undefined.
+  ///
+  /// Note that we still need to evaluate the expression normally when this
+  /// is set; this is used when evaluating ICEs in C.
+  bool CheckingForUndefinedBehavior = false;
 
 private:
   void addCallStack(unsigned Limit);

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -926,19 +926,6 @@ namespace {
     /// fold (not just why it's not strictly a constant expression)?
     bool HasFoldFailureDiagnostic;
 
-    /// Whether we're checking that an expression is a potential constant
-    /// expression. If so, do not fail on constructs that could become constant
-    /// later on (such as a use of an undefined global).
-    bool CheckingPotentialConstantExpression = false;
-
-    /// Whether we're checking for an expression that has undefined behavior.
-    /// If so, we will produce warnings if we encounter an operation that is
-    /// always undefined.
-    ///
-    /// Note that we still need to evaluate the expression normally when this
-    /// is set; this is used when evaluating ICEs in C.
-    bool CheckingForUndefinedBehavior = false;
-
     enum EvaluationMode {
       /// Evaluate as a constant expression. Stop if we find that the expression
       /// is not a constant expression.
@@ -959,19 +946,6 @@ namespace {
       /// can't be modeled.
       EM_IgnoreSideEffects,
     } EvalMode;
-
-    /// Are we checking whether the expression is a potential constant
-    /// expression?
-    bool checkingPotentialConstantExpression() const override  {
-      return CheckingPotentialConstantExpression;
-    }
-
-    /// Are we checking an expression for overflow?
-    // FIXME: We should check for any kind of undefined or suspicious behavior
-    // in such constructs, not just overflow.
-    bool checkingForUndefinedBehavior() const override {
-      return CheckingForUndefinedBehavior;
-    }
 
     EvalInfo(const ASTContext &C, Expr::EvalStatus &S, EvaluationMode Mode)
         : Ctx(const_cast<ASTContext &>(C)), EvalStatus(S), CurrentCall(nullptr),


### PR DESCRIPTION
Instead of relaying from InterpState to the parent state (which is an EvalInfo), just save the variables in State instead, so both subclasses have access to it.