### PR TITLE
[libclc] Implement erf/erfc vector function with loop since scalar function is large

### DIFF
--- a/libclc/clc/include/clc/shared/unary_def_scalarize_loop.inc
+++ b/libclc/clc/include/clc/shared/unary_def_scalarize_loop.inc
@@ -15,12 +15,14 @@
 #endif
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_FUNCTION(__CLC_GENTYPE x) {
-  __CLC_GENTYPE result;
-  __CLC_SCALAR_GENTYPE *a = (__CLC_SCALAR_GENTYPE *)&x;
-  __CLC_SCALAR_GENTYPE *b = (__CLC_SCALAR_GENTYPE *)&result;
+  union {
+    __CLC_GENTYPE vec;
+    __CLC_SCALAR_GENTYPE arr[__CLC_VECSIZE_OR_1];
+  } u_x, u_result;
+  u_x.vec = x;
   for (int i = 0; i < __CLC_VECSIZE_OR_1; ++i)
-    b[i] = __CLC_IMPL_FUNCTION(a[i]);
-  return result;
+    u_result.arr[i] = __CLC_IMPL_FUNCTION(u_x.arr[i]);
+  return u_result.vec;
 }
 
 #endif // __CLC_VECSIZE_OR_1 >= 2

--- a/libclc/clc/include/clc/shared/unary_def_scalarize_loop.inc
+++ b/libclc/clc/include/clc/shared/unary_def_scalarize_loop.inc
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if __CLC_VECSIZE_OR_1 >= 2
-
 #include <clc/utils.h>
+
+#if __CLC_VECSIZE_OR_1 >= 2
 
 #ifndef __CLC_IMPL_FUNCTION
 #define __CLC_IMPL_FUNCTION __CLC_FUNCTION

--- a/libclc/clc/include/clc/shared/unary_def_scalarize_loop.inc
+++ b/libclc/clc/include/clc/shared/unary_def_scalarize_loop.inc
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#if __CLC_VECSIZE_OR_1 >= 2
+
+#include <clc/utils.h>
+
+#ifndef __CLC_IMPL_FUNCTION
+#define __CLC_IMPL_FUNCTION __CLC_FUNCTION
+#endif
+
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __CLC_FUNCTION(__CLC_GENTYPE x) {
+  __CLC_GENTYPE result;
+  __CLC_SCALAR_GENTYPE *a = (__CLC_SCALAR_GENTYPE *)&x;
+  __CLC_SCALAR_GENTYPE *b = (__CLC_SCALAR_GENTYPE *)&result;
+  for (int i = 0; i < __CLC_VECSIZE_OR_1; ++i)
+    b[i] = __CLC_IMPL_FUNCTION(a[i]);
+  return result;
+}
+
+#endif // __CLC_VECSIZE_OR_1 >= 2

--- a/libclc/clc/lib/generic/math/clc_erf.cl
+++ b/libclc/clc/lib/generic/math/clc_erf.cl
@@ -507,5 +507,5 @@ _CLC_OVERLOAD _CLC_DEF half __clc_erf(half x) {
 #endif
 
 #define __CLC_FUNCTION __clc_erf
-#define __CLC_BODY <clc/shared/unary_def_scalarize.inc>
+#define __CLC_BODY <clc/shared/unary_def_scalarize_loop.inc>
 #include <clc/math/gentype.inc>

--- a/libclc/clc/lib/generic/math/clc_erfc.cl
+++ b/libclc/clc/lib/generic/math/clc_erfc.cl
@@ -518,5 +518,5 @@ _CLC_OVERLOAD _CLC_DEF half __clc_erfc(half x) {
 #endif
 
 #define __CLC_FUNCTION __clc_erfc
-#define __CLC_BODY <clc/shared/unary_def_scalarize.inc>
+#define __CLC_BODY <clc/shared/unary_def_scalarize_loop.inc>
 #include <clc/math/gentype.inc>


### PR DESCRIPTION
This PR reduces amdgcn--amdhsa.bc size by 1.8% and nvptx64--nvidiacl.bc size by 4%.
Loop trip count is constant and backend can decide whether to unroll.