### PR TITLE
[clang] Restrict -Wnrvo to C++ code only.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -223,7 +223,6 @@ Deprecated Compiler Flags
 Modified Compiler Flags
 -----------------------
 - The `-gkey-instructions` compiler flag is now enabled by default when DWARF is emitted for plain C/C++ and optimizations are enabled. (#GH149509)
-- The `-Wnrvo` compiler flag will not apply for C language.
 
 Removed Compiler Flags
 -------------------------
@@ -279,6 +278,8 @@ Improvements to Clang's diagnostics
 - The :doc:`ThreadSafetyAnalysis` attributes ``ACQUIRED_BEFORE(...)`` and
   ``ACQUIRED_AFTER(...)`` have been moved to the stable feature set and no
   longer require ``-Wthread-safety-beta`` to be used.
+
+- The `-Wnrvo` compiler flag is now ignored in C mode.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -223,6 +223,7 @@ Deprecated Compiler Flags
 Modified Compiler Flags
 -----------------------
 - The `-gkey-instructions` compiler flag is now enabled by default when DWARF is emitted for plain C/C++ and optimizations are enabled. (#GH149509)
+- The `-Wnrvo` compiler flag will not apply for C language.
 
 Removed Compiler Flags
 -------------------------

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16169,6 +16169,8 @@ void Sema::applyFunctionAttributesBeforeParsingBody(Decl *FD) {
 }
 
 void Sema::computeNRVO(Stmt *Body, FunctionScopeInfo *Scope) {
+  if (!getLangOpts().CPlusPlus)
+    return;
   ReturnStmt **Returns = Scope->Returns.data();
 
   for (unsigned I = 0, E = Scope->Returns.size(); I != E; ++I) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16169,15 +16169,15 @@ void Sema::applyFunctionAttributesBeforeParsingBody(Decl *FD) {
 }
 
 void Sema::computeNRVO(Stmt *Body, FunctionScopeInfo *Scope) {
-  if (!getLangOpts().CPlusPlus)
-    return;
   ReturnStmt **Returns = Scope->Returns.data();
 
   for (unsigned I = 0, E = Scope->Returns.size(); I != E; ++I) {
     if (const VarDecl *NRVOCandidate = Returns[I]->getNRVOCandidate()) {
       if (!NRVOCandidate->isNRVOVariable()) {
-        Diag(Returns[I]->getRetValue()->getExprLoc(),
-             diag::warn_not_eliding_copy_on_return);
+        if (getLangOpts().CPlusPlus) {
+          Diag(Returns[I]->getRetValue()->getExprLoc(),
+               diag::warn_not_eliding_copy_on_return);
+        }
         Returns[I]->setNRVOCandidate(nullptr);
       }
     }

--- a/clang/test/SemaCXX/no-warn-nrvo-on-c.c
+++ b/clang/test/SemaCXX/no-warn-nrvo-on-c.c
@@ -1,0 +1,41 @@
+// RUN: %clang -std=c23 -Wnrvo -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <stdlib.h>
+
+#define SIZE 20
+
+typedef struct String_s {
+    char*  buf;
+    size_t len;
+} String;
+
+
+void clean(String* s) {
+    free(s->buf);
+}
+
+String randomString() {
+    String s = {};
+
+    s.buf = malloc(SIZE);
+    s.len = SIZE;
+
+    if (!s.buf) {
+        goto fail;
+    }
+
+    return s;
+
+fail:
+    clean(&s);
+    return (String){};
+}
+
+int main(int argc, char** argv)
+{
+    String s= randomString();
+    clean(&s);
+
+    return 0;
+}


### PR DESCRIPTION
Pull request #139973 created a very useful warning for detecting not return value optimizations. This can be seen as useful for two different audiences: _compiler developers_, who may see cases where no optimization is done, and _compiler users_ who can detect when there is no copy elision. In C++ this makes a lot of sense - the effect of not having copy elision is not only performance impact, but it can be seen in the execution of code (like the copy constructor or the assignment operator) that may not be executed otherwise. 

However, the value for compiler users with regards to plain C code is more difficult for me to assert. Specifically, in C it's only about a missing optimization - and can pollute your code with this new warning. GCC, for instance, restrict -Wnrvo to C++.

The following pull request will restrict Wnrvo so it does not warn on plain C-code.

Change-Id: Iaadd60f072c176972a5210c1fd1a6f0499d3ff39