### PR TITLE
[orc-rt] Fix byteswap implementation for 64-bit types, rename tests.

### DIFF
--- a/orc-rt/include/orc-rt/bit.h
+++ b/orc-rt/include/orc-rt/bit.h
@@ -95,8 +95,8 @@ template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
 #elif defined(_MSC_VER) && !defined(_DEBUG)
     return _byteswap_uint64(UV);
 #else
-    uint64_t Hi = llvm::byteswap<uint32_t>(UV);
-    uint32_t Lo = llvm::byteswap<uint32_t>(UV >> 32);
+    uint64_t Hi = byteswap<uint32_t>(UV);
+    uint32_t Lo = byteswap<uint32_t>(UV >> 32);
     return (Hi << 32) | Lo;
 #endif
   } else {

--- a/orc-rt/unittests/bit-test.cpp
+++ b/orc-rt/unittests/bit-test.cpp
@@ -34,7 +34,7 @@ TEST(BitTest, endian) {
 #endif
 }
 
-TEST(MathTest, byte_swap_32) {
+TEST(BitTest, byte_swap_32) {
   unsigned char Seq[] = {0x01, 0x23, 0x45, 0x67};
   uint32_t X = 0;
   memcpy(&X, Seq, sizeof(X));
@@ -56,7 +56,7 @@ TEST(MathTest, byte_swap_32) {
 #endif
 }
 
-TEST(MathTest, byte_swap_64) {
+TEST(BitTest, byte_swap_64) {
   unsigned char Seq[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
   uint64_t X = 0;
   memcpy(&X, Seq, sizeof(X));


### PR DESCRIPTION
The 64-bit path included references to the llvm:: namespace that would have caused compile failures but for the fact that they were compiled out on all machines where the ORC runtime is currently tested.