### PR TITLE
[LangRef] inline asm: the instructions are treated opaquely

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -5227,7 +5227,10 @@ represents the inline assembler as a template string (containing the
 instructions to emit), a list of operand constraints (stored as a string), a
 flag that indicates whether or not the inline asm expression has side effects,
 and a flag indicating whether the function containing the asm needs to align its
-stack conservatively.
+stack conservatively. The compiler's understanding of the semantics of the
+expression comes only from the list of operand constraints and the flags -- not
+the contents of the template string. In particular, no optimizations or analyses
+will be performed based on the contents of that string.
 
 The template string supports argument substitution of the operands using "``$``"
 followed by a number, to indicate substitution of the given register/memory

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -5227,10 +5227,15 @@ represents the inline assembler as a template string (containing the
 instructions to emit), a list of operand constraints (stored as a string), a
 flag that indicates whether or not the inline asm expression has side effects,
 and a flag indicating whether the function containing the asm needs to align its
-stack conservatively. The compiler's understanding of the semantics of the
-expression comes only from the list of operand constraints and the flags -- not
-the contents of the template string. In particular, no optimizations or analyses
-will be performed based on the contents of that string.
+stack conservatively.
+
+The compiler's understanding of the semantics of the expression comes only from
+the list of operand constraints and the flags -- not the contents of the
+template string. In particular, no optimizations or analyses will be performed
+based on the contents of that string. This ensures correct behavior if the
+assembly code emitted by this expression is altered later, e.g. via
+self-modifying code, as long as the code keeps upholding the requirements of the
+operand constraints and the flags.
 
 The template string supports argument substitution of the operands using "``$``"
 followed by a number, to indicate substitution of the given register/memory

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -5229,13 +5229,13 @@ flag that indicates whether or not the inline asm expression has side effects,
 and a flag indicating whether the function containing the asm needs to align its
 stack conservatively.
 
-The compiler's understanding of the semantics of the expression comes only from
-the list of operand constraints and the flags -- not the contents of the
-template string. In particular, no optimizations or analyses will be performed
-based on the contents of that string. This ensures correct behavior if the
-assembly code emitted by this expression is altered later, e.g. via
-self-modifying code, as long as the code keeps upholding the requirements of the
-operand constraints and the flags.
+The compiler may not assume that the actual code executed at runtime matches the
+contents of the template string. Correctness-critical analyses must base their
+results only on the list of operand constraints and the flags -- not the
+contents of the template string. This ensures correct behavior if the assembly
+code emitted by this expression is altered later, e.g. via self-modifying code,
+as long as the code keeps upholding the requirements of the operand constraints
+and the flags.
 
 The template string supports argument substitution of the operands using "``$``"
 followed by a number, to indicate substitution of the given register/memory


### PR DESCRIPTION
This wasn't true until recently, but https://github.com/llvm/llvm-project/issues/156571 got fixed to make it true.

I was not entirely sure where to put this; for now I made it a new paragraph fairly early on in the inline asm docs.

Cc @nikic  @jyknight @efriedma-quic 