### PR TITLE
[DA] Add overflow check in ExactSIV

### DIFF
--- a/llvm/test/Analysis/DependenceAnalysis/ExactSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/ExactSIV.ll
@@ -841,7 +841,7 @@ define void @exact14(ptr %A) {
 ; CHECK-SIV-ONLY-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 0, ptr %idx.0, align 1
 ; CHECK-SIV-ONLY-NEXT:    da analyze - none!
 ; CHECK-SIV-ONLY-NEXT:  Src: store i8 0, ptr %idx.0, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
-; CHECK-SIV-ONLY-NEXT:    da analyze - none!
+; CHECK-SIV-ONLY-NEXT:    da analyze - output [*|<]!
 ; CHECK-SIV-ONLY-NEXT:  Src: store i8 1, ptr %idx.1, align 1 --> Dst: store i8 1, ptr %idx.1, align 1
 ; CHECK-SIV-ONLY-NEXT:    da analyze - none!
 ;

--- a/llvm/test/Analysis/DependenceAnalysis/ExactSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/ExactSIV.ll
@@ -815,8 +815,8 @@ for.end:                                          ; preds = %for.body
 ;;     A[3*i - 2] = 1;
 ;; }
 ;;
-;; FIXME: DependencyAnalsysis currently detects no dependency between
-;; `A[-6*i + INT64_MAX]` and `A[3*i - 2]`, but it does exist. For example,
+;; There exists dependency between `A[-6*i + INT64_MAX]` and `A[3*i - 2]`.
+;; For example,
 ;;
 ;; | memory location        | -6*i + INT64_MAX       | 3*i - 2
 ;; |------------------------|------------------------|-----------

--- a/llvm/test/Analysis/DependenceAnalysis/ExactSIV.ll
+++ b/llvm/test/Analysis/DependenceAnalysis/ExactSIV.ll
@@ -815,8 +815,8 @@ for.end:                                          ; preds = %for.body
 ;;     A[3*i - 2] = 1;
 ;; }
 ;;
-;; There exists dependency between `A[-6*i + INT64_MAX]` and `A[3*i - 2]`.
-;; For example,
+;; FIXME: DependencyAnalsysis currently detects no dependency between
+;; `A[-6*i + INT64_MAX]` and `A[3*i - 2]`, but it does exist. For example,
 ;;
 ;; | memory location        | -6*i + INT64_MAX       | 3*i - 2
 ;; |------------------------|------------------------|-----------


### PR DESCRIPTION
This patch adds an overflow check to the `exactSIVtest` function to fix the issue demonstrated in the test case added in #157085. This patch only fixes one of the routines. To fully resolve the test case, the other functions need to be addressed as well.