### PR TITLE
[LangRef] Clarify  to exclude norecurse attribute when a function could occur in a cycle in dynamic call-graph

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2256,9 +2256,12 @@ For example:
     behavior at runtime if the function ever does dynamically return. Annotated
     functions may still raise an exception, i.a., ``nounwind`` is not implied.
 ``norecurse``
-    This function attribute indicates that the function does not call itself
-    either directly or indirectly down any possible call path. This produces
-    undefined behavior at runtime if the function ever does recurse.
+    This function attribute indicates that the function does not participate in
+    recursion, either directly or through mutual recursion. At runtime it is
+    undefined behavior if any dynamic call stack contains this function more
+    than once at the same time. A function must not be marked ``norecurse`` if,
+    along any call path starting from its body, control may reach an external
+    function whose definition is not available.
 
 .. _langref_willreturn:
 

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2256,12 +2256,16 @@ For example:
     behavior at runtime if the function ever does dynamically return. Annotated
     functions may still raise an exception, i.a., ``nounwind`` is not implied.
 ``norecurse``
-    This function attribute indicates that the function does not participate in
-    recursion, either directly or through mutual recursion. At runtime it is
-    undefined behavior if any dynamic call stack contains this function more
-    than once at the same time. A function must not be marked ``norecurse`` if,
-    along any call path starting from its body, control may reach an external
-    function whose definition is not available.
+    This function attribute indicates that the function is not recursive and
+    does not participate in recursion. This means that the function never
+    occurs inside a cycle in the dynamic call graph.
+    For example:
+
+.. code-block:: llvm
+
+    fn -> other_fn -> fn       ; fn is not norecurse
+    other_fn -> fn -> other_fn ; fn is not norecurse
+    fn -> other_fn -> other_fn ; fn is norecurse
 
 .. _langref_willreturn:
 


### PR DESCRIPTION
Update the definition of the `norecurse` attribute to forbid marking a function as `norecurse` if any call path from its body may reach it (possibly through an external function without a visible definition). This makes it clear that `norecurse` excludes both direct and mutual recursion, even when recursion could arise through callees in separate modules.

As per my understanding, this scenario only arises when norecurse is forced through a llvm user option 
`-mllvm -force-attribute=<fname>:norecurse`.

There are a few examples in https://github.com/llvm/llvm-project/issues/157081 which shows that the function attribute inference incorrectly infers norecurse when the behavior (as per new definition) is not enforced.