### PR TITLE
[InstCombine] Make foldCmpLoadFromIndexedGlobal() GEP-type independent

### DIFF
--- a/llvm/test/Transforms/InstCombine/load-cmp.ll
+++ b/llvm/test/Transforms/InstCombine/load-cmp.ll
@@ -377,9 +377,9 @@ define i1 @pr93017(i64 %idx) {
 ; Mask is 0b10101010
 define i1 @load_vs_array_type_mismatch1(i32 %idx) {
 ; CHECK-LABEL: @load_vs_array_type_mismatch1(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds i16, ptr @g_i32_lo, i32 [[IDX:%.*]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[GEP]], align 2
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[LOAD]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = shl nuw i32 1, [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 170
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[TMP3]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %gep = getelementptr inbounds i16, ptr @g_i32_lo, i32 %idx
@@ -393,9 +393,9 @@ define i1 @load_vs_array_type_mismatch1(i32 %idx) {
 ; Mask is 0b01010101
 define i1 @load_vs_array_type_mismatch2(i32 %idx) {
 ; CHECK-LABEL: @load_vs_array_type_mismatch2(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds i16, ptr @g_i32_hi, i32 [[IDX:%.*]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[GEP]], align 2
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[LOAD]], 0
+; CHECK-NEXT:    [[TMP2:%.*]] = shl nuw i32 1, [[TMP1:%.*]]
+; CHECK-NEXT:    [[TMP3:%.*]] = and i32 [[TMP2]], 85
+; CHECK-NEXT:    [[CMP:%.*]] = icmp ne i32 [[TMP3]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %gep = getelementptr inbounds i16, ptr @g_i32_hi, i32 %idx
@@ -409,9 +409,8 @@ define i1 @load_vs_array_type_mismatch2(i32 %idx) {
 ; idx == 1 || idx == 3
 define i1 @load_vs_array_type_mismatch_offset1(i32 %idx) {
 ; CHECK-LABEL: @load_vs_array_type_mismatch_offset1(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds { i16, i16 }, ptr @g_i16_1, i32 [[IDX:%.*]], i32 1
-; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[GEP]], align 2
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[LOAD]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[IDX:%.*]], -3
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[TMP1]], 1
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %gep = getelementptr inbounds {i16, i16}, ptr @g_i16_1, i32 %idx, i32 1
@@ -425,9 +424,8 @@ define i1 @load_vs_array_type_mismatch_offset1(i32 %idx) {
 ; idx == 0 || idx == 2
 define i1 @load_vs_array_type_mismatch_offset2(i32 %idx) {
 ; CHECK-LABEL: @load_vs_array_type_mismatch_offset2(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr inbounds { i16, i16 }, ptr @g_i16_2, i32 [[IDX:%.*]], i32 1
-; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[GEP]], align 2
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[LOAD]], 0
+; CHECK-NEXT:    [[TMP1:%.*]] = and i32 [[IDX:%.*]], -3
+; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i32 [[TMP1]], 0
 ; CHECK-NEXT:    ret i1 [[CMP]]
 ;
   %gep = getelementptr inbounds {i16, i16}, ptr @g_i16_2, i32 %idx, i32 1

--- a/llvm/test/Transforms/InstCombine/opaque-ptr.ll
+++ b/llvm/test/Transforms/InstCombine/opaque-ptr.ll
@@ -543,10 +543,7 @@ define i1 @cmp_load_gep_global_different_load_type(i64 %idx) {
 
 define i1 @cmp_load_gep_global_different_gep_type(i64 %idx) {
 ; CHECK-LABEL: @cmp_load_gep_global_different_gep_type(
-; CHECK-NEXT:    [[GEP:%.*]] = getelementptr i16, ptr @ary, i64 [[IDX:%.*]]
-; CHECK-NEXT:    [[LOAD:%.*]] = load i16, ptr [[GEP]], align 2
-; CHECK-NEXT:    [[CMP:%.*]] = icmp eq i16 [[LOAD]], 3
-; CHECK-NEXT:    ret i1 [[CMP]]
+; CHECK-NEXT:    ret i1 false
 ;
   %gep = getelementptr [4 x i16], ptr @ary, i64 0, i64 %idx
   %load = load i16, ptr %gep


### PR DESCRIPTION
foldCmpLoadFromIndexedGlobal() currently checks that the global type, the GEP type and the load type match in certain ways. Replace this with generic logic based on offsets.

This is a reboot of https://github.com/llvm/llvm-project/pull/67093. This PR is less ambitious by requiring that the constant offset is smaller than the stride, which avoids the additional complexity of that PR.