### PR TITLE
[orc-rt] Add a make_scope_exit utility.

### DIFF
--- a/orc-rt/include/CMakeLists.txt
+++ b/orc-rt/include/CMakeLists.txt
@@ -13,6 +13,7 @@ set(ORC_RT_HEADERS
     orc-rt/MemoryFlags.h
     orc-rt/RTTI.h
     orc-rt/WrapperFunction.h
+    orc-rt/ScopeExit.h
     orc-rt/SimplePackedSerialization.h
     orc-rt/SPSWrapperFunction.h
     orc-rt/bind.h

--- a/orc-rt/include/orc-rt/ScopeExit.h
+++ b/orc-rt/include/orc-rt/ScopeExit.h
@@ -1,0 +1,53 @@
+//===---------- ScopeExit.h - Execute code at scope exit --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// make_scope_exit and related APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ORC_RT_SCOPEEXIT_H
+#define ORC_RT_SCOPEEXIT_H
+
+#include <type_traits>
+#include <utility>
+
+namespace orc_rt {
+namespace detail {
+
+template <typename Fn> class ScopeExitRunner {
+public:
+  ScopeExitRunner(Fn &&F) : F(F) {}
+  ScopeExitRunner(const ScopeExitRunner &) = delete;
+  ScopeExitRunner &operator=(const ScopeExitRunner &) = delete;
+  ScopeExitRunner(ScopeExitRunner &&) = delete;
+  ScopeExitRunner &operator=(ScopeExitRunner &&) = delete;
+  ~ScopeExitRunner() {
+    if (Engaged)
+      F();
+  }
+  void release() { Engaged = false; }
+
+private:
+  Fn F;
+  bool Engaged = true;
+};
+
+} // namespace detail
+
+/// Creates an object that runs the given function object upon destruction.
+/// Calling the object's release method prior to destruction will prevent the
+/// function object from running.
+template <typename Fn>
+[[nodiscard]] detail::ScopeExitRunner<std::decay_t<Fn>>
+make_scope_exit(Fn &&F) {
+  return detail::ScopeExitRunner<std::decay_t<Fn>>(std::forward<Fn>(F));
+}
+
+} // namespace orc_rt
+
+#endif // ORC_RT_SCOPEEXIT_H

--- a/orc-rt/unittests/CMakeLists.txt
+++ b/orc-rt/unittests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_orc_rt_unittest(CoreTests
   MathTest.cpp
   MemoryFlagsTest.cpp
   RTTITest.cpp
+  ScopeExitTest.cpp
   SimplePackedSerializationTest.cpp
   SPSWrapperFunctionTest.cpp
   WrapperFunctionBufferTest.cpp

--- a/orc-rt/unittests/ScopeExitTest.cpp
+++ b/orc-rt/unittests/ScopeExitTest.cpp
@@ -1,0 +1,39 @@
+//===- ScopeExitTest.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Tests for orc-rt's ScopeExit.h APIs.
+//
+//===----------------------------------------------------------------------===//
+
+#include "orc-rt/ScopeExit.h"
+#include "gtest/gtest.h"
+
+using namespace orc_rt;
+
+TEST(ScopeExitTest, Noop) {
+  auto _ = make_scope_exit([]() {});
+}
+
+TEST(ScopeExitTest, OnScopeExit) {
+  bool ScopeExitRun = false;
+  {
+    auto _ = make_scope_exit([&]() { ScopeExitRun = true; });
+    EXPECT_FALSE(ScopeExitRun);
+  }
+  EXPECT_TRUE(ScopeExitRun);
+}
+
+TEST(ScopeExitTest, Release) {
+  bool ScopeExitRun = false;
+  {
+    auto OnExit = make_scope_exit([&]() { ScopeExitRun = true; });
+    EXPECT_FALSE(ScopeExitRun);
+    OnExit.release();
+  }
+  EXPECT_FALSE(ScopeExitRun);
+}


### PR DESCRIPTION
make_scoped_exit takes a function object and returns an object that will run the given function object at destruction time (unless the scope-exit object's `release` method is called to disable it).

This can be useful when a function needs to conditionally perform some cleanup, but may exit along multiple pathways. E.g.

```
  // Allocate resource here.
  auto DoCleanup = make_scope_exit([]() {
    // release resource here.
  });

  // various conditional error return paths.
  if (...)
    return make_error<...>(...);

  // successful return: cancel cleanup.
  DoCleanup.release();
  return Error::success();
```