### PR TITLE
[flang][FIR] enable fir.box_addr codegen inside fir.global

### DIFF
--- a/flang/test/Fir/box_addr-codegen-in-global.fir
+++ b/flang/test/Fir/box_addr-codegen-in-global.fir
@@ -1,0 +1,24 @@
+// Test codegen of fir.box_addr inside fir.global
+// RUN: tco %s | FileCheck %s
+
+fir.global @x_addr constant : !fir.type<sometype{p:i64}> {
+  %c-1 = arith.constant -1 : index
+  %c5 = arith.constant 5 : index
+  %c3 = arith.constant 3 : index
+  %c-3 = arith.constant -3 : index
+  %c2 = arith.constant 2 : index
+  %c1 = arith.constant 1 : index
+  %0 = fir.undefined !fir.type<sometype{p:i64}>
+  %1 = fir.address_of(@_QFEx) : !fir.ref<!fir.array<2x3x5x!fir.type<_QFTt1{c:i32}>>>
+  %2 = fir.shape_shift %c1, %c2, %c-3, %c3, %c1, %c5 : (index, index, index, index, index, index) -> !fir.shapeshift<3>
+  %3 = fir.field_index c, !fir.type<_QFTt1{c:i32}>
+  %4 = fir.slice %c1, %c2, %c1, %c-3, %c-1, %c1, %c1, %c5, %c1 path %3 : (index, index, index, index, index, index, index, index, index, !fir.field) -> !fir.slice<3>
+  %5 = fir.embox %1(%2) [%4] : (!fir.ref<!fir.array<2x3x5x!fir.type<_QFTt1{c:i32}>>>, !fir.shapeshift<3>, !fir.slice<3>) -> !fir.box<!fir.ref<!fir.array<2x3x5xi32>>>
+  %6 = fir.box_addr %5 : (!fir.box<!fir.ref<!fir.array<2x3x5xi32>>>) -> !fir.ref<!fir.array<2x3x5xi32>>
+  %7 = fir.convert %6 : (!fir.ref<!fir.array<2x3x5xi32>>) -> i64
+  %8 = fir.insert_value %0, %7, ["p", !fir.type<sometype{p:i64}>] : (!fir.type<sometype{p:i64}>, i64) -> !fir.type<sometype{p:i64}>
+  fir.has_value %8 : !fir.type<sometype{p:i64}>
+}
+fir.global @_QFEx target : !fir.array<2x3x5x!fir.type<_QFTt1{c:i32}>>
+
+// CHECK: @x_addr = constant %sometype { i64 ptrtoint (ptr @_QFEx to i64) }


### PR DESCRIPTION
This is needed for https://github.com/llvm/llvm-project/pull/153222.

The semantics patch will allow lowering to represent contiguous designator as such in FIR in some cases of array component reference, but this creates a new hlfir.designate pattern that had no code generation support.

@vzakhari implemented the hlfir.designate to fir lowering for this pattern in https://github.com/llvm/llvm-project/pull/154232. This introduced a usage of fir.box_addr in fir.global that had no support for llvm code generation because it was never used.

FIR lowering of the fir.box type inside fir.global is special (it is an actual descriptor struct value instead of being a descriptor in memory) and causes builtin.unrealized_conversion_cast to be inserted under the hood by MLIR dialect conversion framework after each operation producing a fir.box is translated. These builtin.unrealized_conversion_cast must be removed before the code generation of operation of using the fir.box in order to get the right "by value" code generation required in global initial value definitions.
