### PR TITLE
[Dexter] Temporarily print DAP logs on specific exception

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -10,6 +10,7 @@
 import abc
 from collections import defaultdict
 import copy
+import io
 import json
 import os
 import shlex
@@ -50,6 +51,7 @@ class DAPMessageLogger:
         self.prefix_recv: str = "<-"
         self.out_handle = None
         self.open = False
+        self.text = io.StringIO() # In-process copy of the message log.
         self.lock = threading.Lock()
 
     def _custom_enter(self):
@@ -91,6 +93,8 @@ class DAPMessageLogger:
         message_str = json.dumps(
             self._colorize_dap_message(message), indent=self.indent
         ).replace("\\u001b", "\033")
+
+        self.text.write(f"{prefix} {message_str}\n")
         if self.out_handle is not None and self.open:
             with self.lock:
                 self.out_handle.write(f"{prefix} {message_str}\n")

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -430,9 +430,16 @@ class LLDBDAP(DAP):
             trace_response = self._await_response(trace_req_id)
             if not trace_response["success"]:
                 raise DebuggerException("failed to get stack frames")
-            stackframes = trace_response["body"]["stackFrames"]
-            path = stackframes[0]["source"]["path"]
-            addr = stackframes[0]["instructionPointerReference"]
+            try:
+                stackframes = trace_response["body"]["stackFrames"]
+                path = stackframes[0]["source"]["path"]
+                addr = stackframes[0]["instructionPointerReference"]
+            except KeyError as e:
+                # Temporarily print the DAP log if this fails to aid debugging
+                # a buildbot failure that doesn't reproduce easily.
+                print(self.message_logger.text.getvalue())
+                raise e
+
             if any(
                 self._debugger_state.bp_addr_map.get(self.dex_id_to_dap_id[dex_bp_id])
                 == addr

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -437,7 +437,7 @@ class LLDBDAP(DAP):
             except KeyError as e:
                 # Temporarily print the DAP log if this fails to aid debugging
                 # a buildbot failure that doesn't reproduce easily.
-                print(self.message_logger.text.getvalue())
+                print(self.message_logger.text.getvalue(), file=sys.stderr)
                 raise e
 
             if any(

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex-continue.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex-continue.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run -v --binary %t -- %s 2>&1 | FileCheck %s
+// RUN: %dexter_regression_test_run -v --binary %t -- %s 2>&1 | FileCheck --dump-input-context=999999999 %s
 
 int g = 0;
 int c(int) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex_step_function.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/control/dex_step_function.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run -v --binary %t -- %s 2>&1 | FileCheck %s
+// RUN: %dexter_regression_test_run -v --binary %t -- %s 2>&1 | FileCheck --dump-input-context=999999999 %s
 
 int g = 0;
 int c(int) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/dex_declare_file.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/dex_declare_file.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: dex_declare_file.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_program_state.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_program_state.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_program_state.cpp:
 
 int GCD(int lhs, int rhs)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_kinds.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_kinds.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_step_kinds.cpp:
 
 int abs(int i){

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_order.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_step_order.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_step_order.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_type.cpp
@@ -10,7 +10,7 @@
 // expected behaviour.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_watch_type.cpp:
 
 template<class T>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/expect_watch_value.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_watch_value.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_out_range.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_out_range.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: float_range_out_range.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_zero_nonmatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/float_range_zero_nonmatch.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: float_range_zero_nonmatch.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/missing_dex_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/missing_dex_address.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: missing_dex_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unreachable.cpp:
 
 int

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_line_range.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_line_range.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unreachable_line_range.cpp:
 
 int

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_on_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/penalty/unreachable_on_line.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unreachable_on_line.cpp:
 
 int

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/command_line.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_c_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: command_line.c:
 
 int main(int argc, const char **argv) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_after_ref.cpp
@@ -3,7 +3,7 @@
 //      the first reference to that value.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: address_after_ref.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/address_hit_count.cpp
@@ -5,7 +5,7 @@
 //      times.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: address_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/expression_address.cpp
@@ -3,7 +3,7 @@
 //      addresses of two local variables that refer to the same address.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expression_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/identical_address.cpp
@@ -3,7 +3,7 @@
 //      pointer variables.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: identical_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/multiple_address.cpp
@@ -3,7 +3,7 @@
 //      addresses can be used within a single \DexExpectWatchValue.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: multiple_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/offset_address.cpp
@@ -3,7 +3,7 @@
 //      variables that have a fixed offset between them.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: offset_address.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_address/self_comparison.cpp
@@ -3,7 +3,7 @@
 //      value of a variable over time, relative to its initial value.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: self_comparison.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/dex_and_source/test.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/dex_and_source/test.cpp
@@ -7,7 +7,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: dex_and_source
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/precompiled_binary/commands.dex
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/precompiled_binary/commands.dex
@@ -5,7 +5,7 @@
 # UNSUPPORTED: system-darwin
 #
 # RUN: %dexter_regression_test_cxx_build %S/test.cpp -o %t
-# RUN: %dexter_regression_base --binary %t %s | FileCheck %s
+# RUN: %dexter_regression_base --binary %t %s | FileCheck --dump-input-context=999999999 %s
 # CHECK: commands.dex
 #
 # test.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/precompiled_binary_different_dir/dex_commands/commands.dex
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/precompiled_binary_different_dir/dex_commands/commands.dex
@@ -5,7 +5,7 @@
 # UNSUPPORTED: system-darwin
 #
 # RUN: %clang %S/../source/test.cpp -O0 -g -o %t
-# RUN: %dexter_regression_base --binary %t %s | FileCheck %s
+# RUN: %dexter_regression_base --binary %t %s | FileCheck --dump-input-context=999999999 %s
 # RUN: rm %t
 # CHECK: commands.dex
 #

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/precompiled_binary_different_dir/dex_commands/source_root_dir.dex
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/precompiled_binary_different_dir/dex_commands/source_root_dir.dex
@@ -6,7 +6,7 @@
 
 # RUN: %clang %S/../source/test.cpp -O0 -g -o %t
 # RUN: %dexter_regression_base --binary %t \
-# RUN:   --source-root-dir="%S/../source" -- %s | FileCheck %s
+# RUN:   --source-root-dir="%S/../source" -- %s | FileCheck --dump-input-context=999999999 %s
 # RUN: rm %t
 
 # CHECK: source_root_dir.dex: (1.0000)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/windows_noncanonical_path/test.dex
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_declare_file/windows_noncanonical_path/test.dex
@@ -4,7 +4,7 @@
 # REQUIRES: system-windows
 #
 # RUN: %dexter_regression_test_cxx_build "%S/source/test file.cpp" -o %t
-# RUN: %dexter_regression_base --binary %t %s | FileCheck %s
+# RUN: %dexter_regression_base --binary %t %s | FileCheck --dump-input-context=999999999 %s
 # CHECK: test.dex
 #
 # ./source/test file.cpp

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional.cpp
@@ -7,7 +7,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: default_conditional.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_conditional_hit_count.cpp
@@ -8,7 +8,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: default_conditional_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_hit_count.cpp
@@ -5,7 +5,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: default_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/default_simple.cpp
@@ -5,7 +5,7 @@
 //      Tests using the default controller (no \DexLimitSteps).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: default_simple.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_conditional.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_conditional_hit_count.cpp
@@ -9,7 +9,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_conditional_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_hit_count.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_hit_count.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/dex_finish_test/limit_steps_simple.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-windows, system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_simple.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_program_state.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_program_state.cpp
@@ -6,7 +6,7 @@
 //
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_program_state.cpp:
 
 int GCD(int lhs, int rhs)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/direction.cpp
@@ -11,7 +11,7 @@
 // XFAIL: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: direction.cpp:
 
 int func(int i) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: func.cpp:
 
 int func(int i) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func_external.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/func_external.cpp
@@ -9,7 +9,7 @@
 // why.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: func_external.cpp:
 
 #include <cstdlib>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/recursive.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/recursive.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: recursive.cpp:
 
 int func(int i) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/small_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_kind/small_loop.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: small_loop.cpp:
 
 int func(int i){

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_order.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_step_order.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_step_order.cpp:
 
 int main() // DexLabel('main')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_type.cpp
@@ -9,7 +9,7 @@
 // XFAIL: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_watch_type.cpp:
 
 template<class T>

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/expect_watch_value.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: expect_watch_value.cpp:
 
 unsigned long Factorial(int n) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_multiple.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_multiple.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: float_range_multiple.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_no_arg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_no_arg.cpp
@@ -8,7 +8,7 @@
 // UNSUPPORTED: system-darwin, system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: float_range_no_arg.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_small.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_small.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: float_range_small.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_zero_match.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/float_range_watch/float_range_zero_match.cpp
@@ -4,7 +4,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: float_range_zero_match.cpp:
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/hit_count.cpp
@@ -3,7 +3,7 @@
 //      the number of times the command can trigger.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: hit_count.cpp
 
 int a;

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_check_json_step_count.cpp
@@ -2,7 +2,7 @@
 //      Check number of step lines are correctly reported in json output.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --verbose -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t --verbose -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_check_json_step_count.cpp
 // CHECK: ## BEGIN ##
 // CHECK-COUNT-3: json_step_count.cpp",

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_loop.cpp
@@ -3,7 +3,7 @@
 //      for loop.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_expect_loop.cpp:
 
 int main(const int argc, const char * argv[]) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_expect_value.cpp
@@ -2,7 +2,7 @@
 //      Ensure that limited stepping breaks for all expected values.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_expect_value.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_line_mismatch.cpp
@@ -4,7 +4,7 @@
 //      empty line.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_line_mismatch.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_overlapping_ranges.cpp
@@ -2,7 +2,7 @@
 //      Ensure that multiple overlapping \DexLimitSteps ranges do not interfere.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_overlapping_ranges.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/limit_steps_same_line_conditional.cpp
@@ -2,7 +2,7 @@
 //      Test that LimitStep commands can exist on the same from line.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: limit_steps_same_line_conditional.cpp
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/limit_steps/unconditional.cpp
@@ -3,7 +3,7 @@
 //      breakpoint range is set any time from_line is stepped on).
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unconditional.cpp
 
 int glob;

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unreachable.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_not_cmd_lineno.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_not_cmd_lineno.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unreachable_not_cmd_lineno.cpp:
 
 int main(int argc, char **argv)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_on_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/commands/perfect/unreachable_on_line.cpp
@@ -5,7 +5,7 @@
 // UNSUPPORTED: system-darwin
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: unreachable_on_line.cpp:
 
 int main()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/help/help.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/help/help.test
@@ -1,7 +1,7 @@
 Purpose:
     Check the `help` subtool runs.
 
-RUN: %dexter_base help | FileCheck %s
+RUN: %dexter_base help | FileCheck --dump-input-context=999999999 %s
 CHECK: The following subtools are available:
 CHECK: help
 CHECK: list-debuggers

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/list-debuggers/list-debuggers.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/list-debuggers/list-debuggers.test
@@ -1,7 +1,7 @@
 Purpose:
     Check the `list-debuggers` subtool runs.
 
-RUN: %dexter_base list-debuggers | FileCheck %s
+RUN: %dexter_base list-debuggers | FileCheck --dump-input-context=999999999 %s
 CHECK: lldb
 CHECK: vs2015
 CHECK: vs2017

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/address_printing.cpp
@@ -12,7 +12,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
+// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck --dump-input-context=999999999 %s
 
 // CHECK: Resolved Addresses:
 // CHECK-NEXT: 'x_2': 0x[[X2_VAL:[0-9a-f]+]]

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_bad_label_ref.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_bad_label_ref.cpp
@@ -2,7 +2,7 @@
 //      Check that referencing an undefined label gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines
 //
 // CHECK: parser error:{{.*}}err_bad_label_ref.cpp(15): Unresolved label: 'label_does_not_exist'
 // CHECK-NEXT: {{Dex}}ExpectWatchValue('result', '0', on_line=ref('label_does_not_exist'))

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_address.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_address.cpp
@@ -2,7 +2,7 @@
 //      Check that declaring duplicate addresses gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines
 
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_label.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_duplicate_label.cpp
@@ -2,7 +2,7 @@
 //      Check that defining duplicate labels gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines
 //
 // CHECK: parser error:{{.*}}err_duplicate_label.cpp(12): Found duplicate line label: 'oops'
 // CHECK-NEXT: {{Dex}}Label('oops')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_label_kwarg.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_label_kwarg.cpp
@@ -2,7 +2,7 @@
 //    Check that bad keyword args in \DexLabel are reported.
 //    Use --binary switch to trick dexter into skipping the build step.
 //
-// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
+// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: parser error:{{.*}}err_label_kwarg.cpp(8): unexpected named args: bad_arg
 
 // DexLabel('test', bad_arg=0)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_limit_steps_no_values.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_limit_steps_no_values.cpp
@@ -3,7 +3,7 @@
 //    in a \DexLimitSteps command results in a useful error message.
 //    Use --binary switch to trick dexter into skipping the build step.
 //
-// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck %s
+// RUN: not %dexter_base test --binary %s %dexter_regression_test_debugger_args -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: parser error:{{.*}}err_limit_steps_no_values.cpp(9): expected 0 or at least 2 positional arguments
 
 // DexLimitSteps('test')

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren.cpp
@@ -6,7 +6,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
-// RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
+// RUN:     -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_paren.cpp(19): Unbalanced parenthesis starting here
 // CHECK:// {{Dex}}ExpectWatchValue(

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_paren_mline.cpp
@@ -6,7 +6,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
-// RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
+// RUN:     -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_paren_mline.cpp(20): Unbalanced parenthesis starting here
 // CHECK:{{Dex}}ExpectWatchValue(

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax.cpp
@@ -6,7 +6,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
-// RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
+// RUN:     -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_syntax.cpp(18): invalid syntax
 // CHECK:// {{Dex}}ExpectWatchValue(,'a', 3, 3, 3, 3, on_line=0)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_dexdeclarefile.cpp
@@ -4,7 +4,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args -v -- %s \
-// RUN:     | FileCheck %s --implicit-check-not=FAIL-FILENAME-MATCH
+// RUN:     | FileCheck --dump-input-context=999999999 %s --implicit-check-not=FAIL-FILENAME-MATCH
 
 // CHECK: err_syntax_dexdeclarefile.cpp(14): Undeclared address: 'not_been_declared'
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_syntax_mline.cpp
@@ -6,7 +6,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
-// RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
+// RUN:     -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_syntax_mline.cpp(21): invalid syntax
 // CHECK:    ,'a', 3, 3, 3, 3, on_line=0)

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type.cpp
@@ -6,7 +6,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
-// RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
+// RUN:     -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_type.cpp(18): expected at least two args
 // CHECK:// {{Dex}}ExpectWatchValue()

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_type_mline.cpp
@@ -6,7 +6,7 @@
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: not %dexter_base test --binary %t %dexter_regression_test_debugger_args \
-// RUN:     -v -- %s | FileCheck %s --match-full-lines --strict-whitespace
+// RUN:     -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines --strict-whitespace
 //
 // CHECK:parser error:{{.*}}err_type_mline.cpp(19): expected at least two args
 // CHECK:{{Dex}}ExpectWatchValue(

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_undeclared_addr.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/err_undeclared_addr.cpp
@@ -2,7 +2,7 @@
 //      Check that using an undeclared address gives a useful error message.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s --match-full-lines
+// RUN: not %dexter_regression_test_run --binary %t -v -- %s | FileCheck --dump-input-context=999999999 %s --match-full-lines
 
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_another_line.cpp
@@ -3,7 +3,7 @@
 //    that line instead of the line the command is found on.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: label_another_line.cpp: (1.0000)
 
 int main() {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/label_offset.cpp
@@ -2,7 +2,7 @@
 //      Check that we can use label-relative line numbers.
 //
 // RUN: %dexter_regression_test_cxx_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t -v -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t -v -- %s | FileCheck --dump-input-context=999999999 %s
 //
 // CHECK: label_offset.cpp: (1.0000)
 

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_c_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: target_run_args.c:
 
 int main(int argc, const char **argv) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/test/target_run_args_with_command.c
@@ -2,7 +2,7 @@
 // UNSUPPORTED: system-windows
 //
 // RUN: %dexter_regression_test_c_build %s -o %t
-// RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck %s
+// RUN: %dexter_regression_test_run --binary %t --target-run-args "a b 'c d'" -- %s | FileCheck --dump-input-context=999999999 %s
 // CHECK: target_run_args_with_command.c:
 
 int main(int argc, const char **argv) {

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/subtools/view.cpp
@@ -4,7 +4,7 @@
 // RUN: %dexter_regression_test_cxx_build %s -o %t
 // RUN: %dexter_regression_test_run --binary %t --results %t.results -- %s
 //
-// RUN: %dexter_base view %t.results/view.cpp.dextIR | FileCheck %s
+// RUN: %dexter_base view %t.results/view.cpp.dextIR | FileCheck --dump-input-context=999999999 %s
 // CHECK: ## BEGIN
 // CHECK: ## END
 //

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/unittests/run.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/unittests/run.test
@@ -2,7 +2,7 @@ Purpose:
     Run DExTer unit tests.
 
 # Dexter returns 1 when no subtools are specified.
-RUN: not %dexter_base --unittest=show-all 2>&1 | FileCheck %s
+RUN: not %dexter_base --unittest=show-all 2>&1 | FileCheck --dump-input-context=999999999 %s
 
 CHECK: Ran {{[0-9]+}} tests
 CHECK-EMPTY:

--- a/cross-project-tests/debuginfo-tests/dexter/feature_tests/unittests/run.test
+++ b/cross-project-tests/debuginfo-tests/dexter/feature_tests/unittests/run.test
@@ -2,7 +2,7 @@ Purpose:
     Run DExTer unit tests.
 
 # Dexter returns 1 when no subtools are specified.
-RUN: not %dexter_base --unittest=show-all 2>&1 | FileCheck --dump-input-context=999999999 %s
+RUN: not %dexter_base --unittest=show-all 2>&1 | FileCheck %s
 
 CHECK: Ran {{[0-9]+}} tests
 CHECK-EMPTY:


### PR DESCRIPTION
Temporarily print the DAP log if this fails to aid debugging a buildbot failure that doesn't reproduce easily.

See #157090 description for motivation

I think dumping the DAP log on unhandled exception could be a nice general feature, but for now I'd just like to be able to understand this specific failure mode better