### PR TITLE
[Support] Fix the style of type aliases (NFC)

### DIFF
--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -305,62 +305,62 @@ template <typename T> struct MissingTrait;
 
 // Test if ScalarEnumerationTraits<T> is defined on type T.
 template <class T> struct has_ScalarEnumerationTraits {
-  using Signature_enumeration = void (*)(class IO &, T &);
+  using SignatureEnumeration = void (*)(class IO &, T &);
 
   template <class U>
   using check =
-      SameType<Signature_enumeration, &ScalarEnumerationTraits<U>::enumeration>;
+      SameType<SignatureEnumeration, &ScalarEnumerationTraits<U>::enumeration>;
 
   static constexpr bool value = is_detected<check, T>::value;
 };
 
 // Test if ScalarBitSetTraits<T> is defined on type T.
 template <class T> struct has_ScalarBitSetTraits {
-  using Signature_bitset = void (*)(class IO &, T &);
+  using SignatureBitset = void (*)(class IO &, T &);
 
   template <class U>
-  using check = SameType<Signature_bitset, &ScalarBitSetTraits<U>::bitset>;
+  using check = SameType<SignatureBitset, &ScalarBitSetTraits<U>::bitset>;
 
   static constexpr bool value = is_detected<check, T>::value;
 };
 
 // Test if ScalarTraits<T> is defined on type T.
 template <class T> struct has_ScalarTraits {
-  using Signature_input = StringRef (*)(StringRef, void *, T &);
-  using Signature_output = void (*)(const T &, void *, raw_ostream &);
-  using Signature_mustQuote = QuotingType (*)(StringRef);
+  using SignatureInput = StringRef (*)(StringRef, void *, T &);
+  using SignatureOutput = void (*)(const T &, void *, raw_ostream &);
+  using SignatureMustQuote = QuotingType (*)(StringRef);
 
   template <class U>
-  using check = std::tuple<SameType<Signature_input, &U::input>,
-                           SameType<Signature_output, &U::output>,
-                           SameType<Signature_mustQuote, &U::mustQuote>>;
+  using check = std::tuple<SameType<SignatureInput, &U::input>,
+                           SameType<SignatureOutput, &U::output>,
+                           SameType<SignatureMustQuote, &U::mustQuote>>;
 
   static constexpr bool value = is_detected<check, ScalarTraits<T>>::value;
 };
 
 // Test if BlockScalarTraits<T> is defined on type T.
 template <class T> struct has_BlockScalarTraits {
-  using Signature_input = StringRef (*)(StringRef, void *, T &);
-  using Signature_output = void (*)(const T &, void *, raw_ostream &);
+  using SignatureInput = StringRef (*)(StringRef, void *, T &);
+  using SignatureOutput = void (*)(const T &, void *, raw_ostream &);
 
   template <class U>
-  using check = std::tuple<SameType<Signature_input, &U::input>,
-                           SameType<Signature_output, &U::output>>;
+  using check = std::tuple<SameType<SignatureInput, &U::input>,
+                           SameType<SignatureOutput, &U::output>>;
 
   static constexpr bool value = is_detected<check, BlockScalarTraits<T>>::value;
 };
 
 // Test if TaggedScalarTraits<T> is defined on type T.
 template <class T> struct has_TaggedScalarTraits {
-  using Signature_input = StringRef (*)(StringRef, StringRef, void *, T &);
-  using Signature_output = void (*)(const T &, void *, raw_ostream &,
-                                    raw_ostream &);
-  using Signature_mustQuote = QuotingType (*)(const T &, StringRef);
+  using SignatureInput = StringRef (*)(StringRef, StringRef, void *, T &);
+  using SignatureOutput = void (*)(const T &, void *, raw_ostream &,
+                                   raw_ostream &);
+  using SignatureMustQuote = QuotingType (*)(const T &, StringRef);
 
   template <class U>
-  using check = std::tuple<SameType<Signature_input, &U::input>,
-                           SameType<Signature_output, &U::output>,
-                           SameType<Signature_mustQuote, &U::mustQuote>>;
+  using check = std::tuple<SameType<SignatureInput, &U::input>,
+                           SameType<SignatureOutput, &U::output>,
+                           SameType<SignatureMustQuote, &U::mustQuote>>;
 
   static constexpr bool value =
       is_detected<check, TaggedScalarTraits<T>>::value;
@@ -368,9 +368,9 @@ template <class T> struct has_TaggedScalarTraits {
 
 // Test if MappingContextTraits<T> is defined on type T.
 template <class T, class Context> struct has_MappingTraits {
-  using Signature_mapping = void (*)(class IO &, T &, Context &);
+  using SignatureMapping = void (*)(class IO &, T &, Context &);
 
-  template <class U> using check = SameType<Signature_mapping, &U::mapping>;
+  template <class U> using check = SameType<SignatureMapping, &U::mapping>;
 
   static constexpr bool value =
       is_detected<check, MappingContextTraits<T, Context>>::value;
@@ -378,18 +378,18 @@ template <class T, class Context> struct has_MappingTraits {
 
 // Test if MappingTraits<T> is defined on type T.
 template <class T> struct has_MappingTraits<T, EmptyContext> {
-  using Signature_mapping = void (*)(class IO &, T &);
+  using SignatureMapping = void (*)(class IO &, T &);
 
-  template <class U> using check = SameType<Signature_mapping, &U::mapping>;
+  template <class U> using check = SameType<SignatureMapping, &U::mapping>;
 
   static constexpr bool value = is_detected<check, MappingTraits<T>>::value;
 };
 
 // Test if MappingContextTraits<T>::validate() is defined on type T.
 template <class T, class Context> struct has_MappingValidateTraits {
-  using Signature_validate = std::string (*)(class IO &, T &, Context &);
+  using SignatureValidate = std::string (*)(class IO &, T &, Context &);
 
-  template <class U> using check = SameType<Signature_validate, &U::validate>;
+  template <class U> using check = SameType<SignatureValidate, &U::validate>;
 
   static constexpr bool value =
       is_detected<check, MappingContextTraits<T, Context>>::value;
@@ -397,18 +397,18 @@ template <class T, class Context> struct has_MappingValidateTraits {
 
 // Test if MappingTraits<T>::validate() is defined on type T.
 template <class T> struct has_MappingValidateTraits<T, EmptyContext> {
-  using Signature_validate = std::string (*)(class IO &, T &);
+  using SignatureValidate = std::string (*)(class IO &, T &);
 
-  template <class U> using check = SameType<Signature_validate, &U::validate>;
+  template <class U> using check = SameType<SignatureValidate, &U::validate>;
 
   static constexpr bool value = is_detected<check, MappingTraits<T>>::value;
 };
 
 // Test if MappingContextTraits<T>::enumInput() is defined on type T.
 template <class T, class Context> struct has_MappingEnumInputTraits {
-  using Signature_enumInput = void (*)(class IO &, T &);
+  using SignatureEnumInput = void (*)(class IO &, T &);
 
-  template <class U> using check = SameType<Signature_enumInput, &U::enumInput>;
+  template <class U> using check = SameType<SignatureEnumInput, &U::enumInput>;
 
   static constexpr bool value =
       is_detected<check, MappingContextTraits<T, Context>>::value;
@@ -416,27 +416,27 @@ template <class T, class Context> struct has_MappingEnumInputTraits {
 
 // Test if MappingTraits<T>::enumInput() is defined on type T.
 template <class T> struct has_MappingEnumInputTraits<T, EmptyContext> {
-  using Signature_enumInput = void (*)(class IO &, T &);
+  using SignatureEnumInput = void (*)(class IO &, T &);
 
-  template <class U> using check = SameType<Signature_enumInput, &U::enumInput>;
+  template <class U> using check = SameType<SignatureEnumInput, &U::enumInput>;
 
   static constexpr bool value = is_detected<check, MappingTraits<T>>::value;
 };
 
 // Test if SequenceTraits<T> is defined on type T.
 template <class T> struct has_SequenceMethodTraits {
-  using Signature_size = size_t (*)(class IO &, T &);
+  using SignatureSize = size_t (*)(class IO &, T &);
 
-  template <class U> using check = SameType<Signature_size, &U::size>;
+  template <class U> using check = SameType<SignatureSize, &U::size>;
 
   static constexpr bool value = is_detected<check, SequenceTraits<T>>::value;
 };
 
 // Test if CustomMappingTraits<T> is defined on type T.
 template <class T> struct has_CustomMappingTraits {
-  using Signature_input = void (*)(IO &io, StringRef key, T &v);
+  using SignatureInput = void (*)(IO &io, StringRef key, T &v);
 
-  template <class U> using check = SameType<Signature_input, &U::inputOne>;
+  template <class U> using check = SameType<SignatureInput, &U::inputOne>;
 
   static constexpr bool value =
       is_detected<check, CustomMappingTraits<T>>::value;
@@ -464,18 +464,18 @@ struct has_SequenceTraits
 
 // Test if DocumentListTraits<T> is defined on type T
 template <class T> struct has_DocumentListTraits {
-  using Signature_size = size_t (*)(class IO &, T &);
+  using SignatureSize = size_t (*)(class IO &, T &);
 
-  template <class U> using check = SameType<Signature_size, &U::size>;
+  template <class U> using check = SameType<SignatureSize, &U::size>;
 
   static constexpr bool value =
       is_detected<check, DocumentListTraits<T>>::value;
 };
 
 template <class T> struct has_PolymorphicTraits {
-  using Signature_getKind = NodeKind (*)(const T &);
+  using SignatureGetKind = NodeKind (*)(const T &);
 
-  template <class U> using check = SameType<Signature_getKind, &U::getKind>;
+  template <class U> using check = SameType<SignatureGetKind, &U::getKind>;
 
   static constexpr bool value = is_detected<check, PolymorphicTraits<T>>::value;
 };


### PR DESCRIPTION
This patch renames several type aliases to stick to the LLVM
coding standards.
