### PR TITLE
[Dexter] llvm-lit: always log DAP messages

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -121,7 +121,7 @@ def configure_dexter_substitutions():
         tools.append(
             ToolSubst(
                 "%dexter_lldb_args",
-                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap --dap-message-log=%t.dap.log'
+                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap --dap-message-log=%t.dap.log',
             )
         )
 
@@ -148,7 +148,9 @@ def configure_dexter_substitutions():
         dexter_regression_test_c_builder = "clang"
         dexter_regression_test_cxx_builder = "clang++"
         dexter_regression_test_debugger = "lldb-dap"
-        dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_dap_path}"  --dap-message-log=%t.dap.log'
+        dexter_regression_test_additional_flags = (
+            f'--lldb-executable "{lldb_dap_path}"  --dap-message-log=%t.dap.log'
+        )
         dexter_regression_test_c_flags = "-O0 -glldb -std=gnu11"
         dexter_regression_test_cxx_flags = "-O0 -glldb -std=gnu++11"
 

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -121,7 +121,7 @@ def configure_dexter_substitutions():
         tools.append(
             ToolSubst(
                 "%dexter_lldb_args",
-                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap',
+                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap --dap-message-log=%t.dap.log'
             )
         )
 
@@ -148,7 +148,7 @@ def configure_dexter_substitutions():
         dexter_regression_test_c_builder = "clang"
         dexter_regression_test_cxx_builder = "clang++"
         dexter_regression_test_debugger = "lldb-dap"
-        dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_dap_path}"'
+        dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_dap_path}"  --dap-message-log=%t.dap.log'
         dexter_regression_test_c_flags = "-O0 -glldb -std=gnu11"
         dexter_regression_test_cxx_flags = "-O0 -glldb -std=gnu++11"
 


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/157090 description for motivation.


Printing the dap logs to stdout/err on failure sadly isn't enough (see #157130).

With this patch, we might be able to get clues about the flaky tests with well timed log inspection.