### PR TITLE
[scudo] Move getPageSize() decl to common.h header

### DIFF
--- a/compiler-rt/lib/scudo/standalone/common.cpp
+++ b/compiler-rt/lib/scudo/standalone/common.cpp
@@ -16,9 +16,6 @@ namespace scudo {
 uptr PageSizeCached = 0;
 uptr PageSizeLogCached = 0;
 
-// Must be defined in platform specific code.
-uptr getPageSize();
-
 // This must be called in the init path or there could be a race if multiple
 // threads try to set the cached values.
 uptr getPageSizeSlow() {

--- a/compiler-rt/lib/scudo/standalone/common.h
+++ b/compiler-rt/lib/scudo/standalone/common.h
@@ -148,6 +148,10 @@ inline constexpr uptr getPageSizeLogCached() {
 extern uptr PageSizeCached;
 extern uptr PageSizeLogCached;
 
+// Must be defined in platform specific code.
+uptr getPageSize();
+
+// Always calls getPageSize(), but caches the results for get*Cached(), below.
 uptr getPageSizeSlow();
 
 inline uptr getPageSizeCached() {


### PR DESCRIPTION
The getPageSize() function is defined in the platform-specific
source files but used in common.cpp.  Every function used across
files should be declared in a header so the same declaration is
in scope for the callers and the definition.
