### PR TITLE
[libc][bazel] Fix missing fmodbf16 dependency

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3751,6 +3751,7 @@ libc_math_function(
 libc_math_function(
     name = "fmodbf16",
     additional_deps = [
+        ":__support_fputil_bfloat16",
         ":__support_fputil_generic_fmod",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -740,7 +740,12 @@ math_test(
 
 math_test(
     name = "fmodbf16",
-    hdrs = ["FModTest.h"],
+    hdrs = [
+        "FModTest.h",
+    ],
+    deps = [
+        "//libc:__support_fputil_bfloat16",
+    ],
 )
 
 math_test(


### PR DESCRIPTION
Tests were failing due to a missing dependency on fputil/bfloat16.
