### PR TITLE
[Clang][PowerPC] Add __dmr2048 type and DMF crypto builtins

### DIFF
--- a/clang/include/clang/Basic/BuiltinsPPC.def
+++ b/clang/include/clang/Basic/BuiltinsPPC.def
@@ -1131,6 +1131,13 @@ UNALIASED_CUSTOM_MMA_BUILTIN(mma_dmxvf16gerx2, "vW1024*W256V",
 UNALIASED_CUSTOM_MMA_BUILTIN(mma_pmdmxvf16gerx2, "vW1024*W256Vi255i15i3",
                              "mma,isa-future-instructions")
 
+UNALIASED_CUSTOM_BUILTIN(mma_dmsha2hash, "vW1024*W1024*Ii", true,
+                         "mma,isa-future-instructions")
+UNALIASED_CUSTOM_BUILTIN(mma_dmsha3hash, "vW2048*Ii", true,
+                         "mma,isa-future-instructions")
+UNALIASED_CUSTOM_BUILTIN(mma_dmxxshapad, "vW1024*VIiIiIi", true,
+                         "mma,isa-future-instructions")
+
 // FIXME: Obviously incomplete.
 
 #undef BUILTIN

--- a/clang/include/clang/Basic/BuiltinsPPC.def
+++ b/clang/include/clang/Basic/BuiltinsPPC.def
@@ -1105,6 +1105,13 @@ UNALIASED_CUSTOM_BUILTIN(mma_disassemble_dmr, "vv*W1024*", false,
 UNALIASED_CUSTOM_BUILTIN(mma_build_dmr, "vW1024*VVVVVVVV", false,
                          "mma,isa-future-instructions")
 
+UNALIASED_CUSTOM_BUILTIN(mma_dmsha2hash, "vW1024*W1024*Ii", true,
+                         "mma,isa-future-instructions")
+UNALIASED_CUSTOM_BUILTIN(mma_dmsha3hash, "vW2048*Ii", true,
+                         "mma,isa-future-instructions")
+UNALIASED_CUSTOM_BUILTIN(mma_dmxxshapad, "vW1024*VIiIiIi", true,
+                         "mma,isa-future-instructions")
+
 // MMA builtins with positive/negative multiply/accumulate.
 UNALIASED_CUSTOM_MMA_BUILTIN(mma_xvf16ger2, "vW512*VV",
                              "mma,paired-vector-memops")
@@ -1130,13 +1137,6 @@ UNALIASED_CUSTOM_MMA_BUILTIN(mma_dmxvf16gerx2, "vW1024*W256V",
                              "mma,isa-future-instructions")
 UNALIASED_CUSTOM_MMA_BUILTIN(mma_pmdmxvf16gerx2, "vW1024*W256Vi255i15i3",
                              "mma,isa-future-instructions")
-
-UNALIASED_CUSTOM_BUILTIN(mma_dmsha2hash, "vW1024*W1024*Ii", true,
-                         "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_dmsha3hash, "vW2048*Ii", true,
-                         "mma,isa-future-instructions")
-UNALIASED_CUSTOM_BUILTIN(mma_dmxxshapad, "vW1024*VIiIiIi", true,
-                         "mma,isa-future-instructions")
 
 // FIXME: Obviously incomplete.
 

--- a/clang/include/clang/Basic/PPCTypes.def
+++ b/clang/include/clang/Basic/PPCTypes.def
@@ -30,6 +30,7 @@
 #endif
 
 
+PPC_VECTOR_MMA_TYPE(__dmr2048, DMR2048, 2048)
 PPC_VECTOR_MMA_TYPE(__dmr1024, DMR1024, 1024)
 PPC_VECTOR_MMA_TYPE(__vector_quad, VectorQuad, 512)
 PPC_VECTOR_VSX_TYPE(__vector_pair, VectorPair, 256)

--- a/clang/include/clang/Serialization/ASTBitCodes.h
+++ b/clang/include/clang/Serialization/ASTBitCodes.h
@@ -1160,7 +1160,7 @@ enum PredefinedTypeIDs {
 ///
 /// Type IDs for non-predefined types will start at
 /// NUM_PREDEF_TYPE_IDs.
-const unsigned NUM_PREDEF_TYPE_IDS = 513;
+const unsigned NUM_PREDEF_TYPE_IDS = 514;
 
 // Ensure we do not overrun the predefined types we reserved
 // in the enum PredefinedTypeIDs above.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -3501,6 +3501,7 @@ static void encodeTypeForFunctionPointerAuth(const ASTContext &Ctx,
     case BuiltinType::VectorQuad:
     case BuiltinType::VectorPair:
     case BuiltinType::DMR1024:
+    case BuiltinType::DMR2048:
       OS << "?";
       return;
 

--- a/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
+++ b/clang/lib/CodeGen/TargetBuiltins/PPC.cpp
@@ -1153,7 +1153,8 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
     }
     if (BuiltinID == PPC::BI__builtin_mma_dmmr ||
         BuiltinID == PPC::BI__builtin_mma_dmxor ||
-        BuiltinID == PPC::BI__builtin_mma_disassemble_dmr) {
+        BuiltinID == PPC::BI__builtin_mma_disassemble_dmr ||
+        BuiltinID == PPC::BI__builtin_mma_dmsha2hash) {
       Address Addr = EmitPointerWithAlignment(E->getArg(1));
       Ops[1] = Builder.CreateLoad(Addr);
     }

--- a/clang/test/AST/ast-dump-ppc-types.c
+++ b/clang/test/AST/ast-dump-ppc-types.c
@@ -17,6 +17,8 @@
 // are correctly defined. We also added checks on a couple of other targets to
 // ensure the types are target-dependent.
 
+// CHECK: TypedefDecl {{.*}} implicit __dmr2048 '__dmr2048'
+//  CHECK: `-BuiltinType {{.*}} '__dmr2048'
 // CHECK: TypedefDecl {{.*}} implicit __dmr1024 '__dmr1024'
 // CHECK: `-BuiltinType {{.*}} '__dmr1024'
 // CHECK: TypedefDecl {{.*}} implicit __vector_quad '__vector_quad'

--- a/clang/test/AST/ast-dump-ppc-types.c
+++ b/clang/test/AST/ast-dump-ppc-types.c
@@ -18,7 +18,7 @@
 // ensure the types are target-dependent.
 
 // CHECK: TypedefDecl {{.*}} implicit __dmr2048 '__dmr2048'
-//  CHECK: `-BuiltinType {{.*}} '__dmr2048'
+// CHECK: `-BuiltinType {{.*}} '__dmr2048'
 // CHECK: TypedefDecl {{.*}} implicit __dmr1024 '__dmr1024'
 // CHECK: `-BuiltinType {{.*}} '__dmr1024'
 // CHECK: TypedefDecl {{.*}} implicit __vector_quad '__vector_quad'

--- a/clang/test/CodeGen/PowerPC/builtins-ppc-dmf.c
+++ b/clang/test/CodeGen/PowerPC/builtins-ppc-dmf.c
@@ -208,6 +208,75 @@ void test_dmf_basic2(char *p1, char *res1, char *res2,
   __builtin_mma_build_dmr((__dmr1024*)res2, vv, vv, vv, vv, vv, vv, vv, vv);
   __builtin_mma_disassemble_dmr(res1, (__dmr1024*)p1);
 }
+
+// CHECK-LABEL: define dso_local void @test_dmsha2hash(
+// CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP1:%.*]], ptr noundef readonly captures(none) [[VDMRP2:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
+// CHECK-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// CHECK-NEXT:    ret void
+//
+// AIX-LABEL: define void @test_dmsha2hash(
+// AIX-SAME: ptr noundef readonly captures(none) [[VDMRP1:%.*]], ptr noundef readonly captures(none) [[VDMRP2:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// AIX-NEXT:  [[ENTRY:.*:]]
+// AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP1]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// AIX-NEXT:    [[TMP1:%.*]] = load <1024 x i1>, ptr [[VDMRP2]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// AIX-NEXT:    [[TMP2:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmsha2hash(<1024 x i1> [[TMP0]], <1024 x i1> [[TMP1]], i32 1)
+// AIX-NEXT:    store <1024 x i1> [[TMP2]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// AIX-NEXT:    ret void
+//
+void test_dmsha2hash(unsigned char *vdmrp1, unsigned char *vdmrp2, unsigned char *resp) {
+  __dmr1024 vdmr1 = *((__dmr1024 *)vdmrp1);
+  __dmr1024 vdmr2 = *((__dmr1024 *)vdmrp2);
+  __builtin_mma_dmsha2hash(&vdmr1, &vdmr2, 1);
+  *((__dmr1024 *)resp) = vdmr1;
+}
+
+// CHECK-LABEL: define dso_local void @test_dmsha3hash(
+// CHECK-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA9:![0-9]+]]
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 4)
+// CHECK-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA9]]
+// CHECK-NEXT:    ret void
+//
+// AIX-LABEL: define void @test_dmsha3hash(
+// AIX-SAME: ptr noundef readonly captures(none) [[VDMRPP:%.*]], ptr noundef writeonly captures(none) initializes((0, 256)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// AIX-NEXT:  [[ENTRY:.*:]]
+// AIX-NEXT:    [[TMP0:%.*]] = load <2048 x i1>, ptr [[VDMRPP]], align 256, !tbaa [[__DMR2048_TBAA9:![0-9]+]]
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <2048 x i1> @llvm.ppc.mma.dmsha3hash(<2048 x i1> [[TMP0]], i32 4)
+// AIX-NEXT:    store <2048 x i1> [[TMP1]], ptr [[RESP]], align 256, !tbaa [[__DMR2048_TBAA9]]
+// AIX-NEXT:    ret void
+//
+void test_dmsha3hash(unsigned char *vdmrpp,  unsigned char *resp) {
+  __dmr2048 vdmrp = *((__dmr2048 *)vdmrpp);
+  __builtin_mma_dmsha3hash(&vdmrp, 4);
+  *((__dmr2048 *)resp) = vdmrp;
+}
+
+// CHECK-LABEL: define dso_local void @test_dmxxshapad(
+// CHECK-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 1, i32 5)
+// CHECK-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// CHECK-NEXT:    ret void
+//
+// AIX-LABEL: define void @test_dmxxshapad(
+// AIX-SAME: ptr noundef readonly captures(none) [[VDMRP:%.*]], <16 x i8> noundef [[VC:%.*]], ptr noundef writeonly captures(none) initializes((0, 128)) [[RESP:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// AIX-NEXT:  [[ENTRY:.*:]]
+// AIX-NEXT:    [[TMP0:%.*]] = load <1024 x i1>, ptr [[VDMRP]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// AIX-NEXT:    [[TMP1:%.*]] = tail call <1024 x i1> @llvm.ppc.mma.dmxxshapad(<1024 x i1> [[TMP0]], <16 x i8> [[VC]], i32 2, i32 1, i32 5)
+// AIX-NEXT:    store <1024 x i1> [[TMP1]], ptr [[RESP]], align 128, !tbaa [[__DMR1024_TBAA6]]
+// AIX-NEXT:    ret void
+//
+void test_dmxxshapad(unsigned char *vdmrp, vector unsigned char vc, unsigned char *resp) {
+  __dmr1024 vdmr = *((__dmr1024 *)vdmrp);
+  __builtin_mma_dmxxshapad(&vdmr, vc, 2, 1, 5);
+  *((__dmr1024 *)resp) = vdmr;
+}
 //.
 // CHECK: [[__VECTOR_PAIR_TBAA2]] = !{[[META3:![0-9]+]], [[META3]], i64 0}
 // CHECK: [[META3]] = !{!"__vector_pair", [[META4:![0-9]+]], i64 0}
@@ -216,6 +285,8 @@ void test_dmf_basic2(char *p1, char *res1, char *res2,
 // CHECK: [[__DMR1024_TBAA6]] = !{[[META7:![0-9]+]], [[META7]], i64 0}
 // CHECK: [[META7]] = !{!"__dmr1024", [[META4]], i64 0}
 // CHECK: [[CHAR_TBAA8]] = !{[[META4]], [[META4]], i64 0}
+// CHECK: [[__DMR2048_TBAA9]] = !{[[META10:![0-9]+]], [[META10]], i64 0}
+// CHECK: [[META10]] = !{!"__dmr2048", [[META4]], i64 0}
 //.
 // AIX: [[__VECTOR_PAIR_TBAA2]] = !{[[META3:![0-9]+]], [[META3]], i64 0}
 // AIX: [[META3]] = !{!"__vector_pair", [[META4:![0-9]+]], i64 0}
@@ -224,4 +295,6 @@ void test_dmf_basic2(char *p1, char *res1, char *res2,
 // AIX: [[__DMR1024_TBAA6]] = !{[[META7:![0-9]+]], [[META7]], i64 0}
 // AIX: [[META7]] = !{!"__dmr1024", [[META4]], i64 0}
 // AIX: [[CHAR_TBAA8]] = !{[[META4]], [[META4]], i64 0}
+// AIX: [[__DMR2048_TBAA9]] = !{[[META10:![0-9]+]], [[META10]], i64 0}
+// AIX: [[META10]] = !{!"__dmr2048", [[META4]], i64 0}
 //.

--- a/clang/test/CodeGen/PowerPC/ppc-dmf-mma-builtin-err.c
+++ b/clang/test/CodeGen/PowerPC/ppc-dmf-mma-builtin-err.c
@@ -9,7 +9,9 @@
 // RUN:   FileCheck --check-prefix=ISA_FUTURE %s
 
 //__attribute__((target("no-mma")))
-void test_mma(unsigned char *vdmrp, unsigned char *vpp, vector unsigned char vc) {
+__attribute__((target("no-mma")))
+void test_mma(unsigned char *vdmrpp, unsigned char *vdmrp, unsigned char *vpp, vector unsigned char vc) {
+  __dmr2048 vdmrpair = *((__dmr2048 *)vdmrpp);
   __dmr1024 vdmr = *((__dmr1024 *)vdmrp);
   __vector_pair vp = *((__vector_pair *)vpp);
   __builtin_mma_dmxvi8gerx4(&vdmr, vp, vc);
@@ -23,6 +25,9 @@ void test_mma(unsigned char *vdmrp, unsigned char *vpp, vector unsigned char vc)
   __builtin_mma_dmxor(&vdmr, (__dmr1024*)vpp);
   __builtin_mma_build_dmr(&vdmr, vc, vc, vc, vc, vc, vc, vc, vc);
   __builtin_mma_disassemble_dmr(vdmrp, &vdmr);
+  __builtin_mma_dmsha2hash(&vdmr, &vdmr, 0);
+  __builtin_mma_dmsha3hash(&vdmrpair, 0);
+  __builtin_mma_dmxxshapad(&vdmr, vc, 0, 0, 0);
 
 // CHECK: error: '__builtin_mma_dmxvi8gerx4' needs target feature mma,paired-vector-memops
 // CHECK: error: '__builtin_mma_pmdmxvi8gerx4' needs target feature mma,paired-vector-memops
@@ -35,6 +40,9 @@ void test_mma(unsigned char *vdmrp, unsigned char *vpp, vector unsigned char vc)
 // ISA_FUTURE: error: '__builtin_mma_dmxor' needs target feature mma,isa-future-instructions
 // ISA_FUTURE: error: '__builtin_mma_build_dmr' needs target feature mma,isa-future-instructions
 // ISA_FUTURE: error: '__builtin_mma_disassemble_dmr' needs target feature mma,isa-future-instructions
+// CHECK: error: '__builtin_mma_dmsha2hash' needs target feature mma,isa-future-instructions
+// CHECK: error: '__builtin_mma_dmsha3hash' needs target feature mma,isa-future-instructions
+// CHECK: error: '__builtin_mma_dmxxshapad' needs target feature mma,isa-future-instructions
 
   // DMF VSX Vector bfloat16 GER 2x builtins.
 

--- a/clang/test/CodeGen/PowerPC/ppc-dmf-types.c
+++ b/clang/test/CodeGen/PowerPC/ppc-dmf-types.c
@@ -2,6 +2,162 @@
 // RUN: %clang_cc1 -triple powerpc64le-linux-unknown -target-cpu future \
 // RUN:   -emit-llvm -o - %s | FileCheck %s
 
+// CHECK-LABEL: @test_dmrp_copy(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[PTR1_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[PTR2_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    store ptr [[PTR1:%.*]], ptr [[PTR1_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[PTR2:%.*]], ptr [[PTR2_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR1_ADDR]], align 8
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds <2048 x i1>, ptr [[TMP0]], i64 2
+// CHECK-NEXT:    [[TMP1:%.*]] = load <2048 x i1>, ptr [[ADD_PTR]], align 256
+// CHECK-NEXT:    [[TMP2:%.*]] = load ptr, ptr [[PTR2_ADDR]], align 8
+// CHECK-NEXT:    [[ADD_PTR1:%.*]] = getelementptr inbounds <2048 x i1>, ptr [[TMP2]], i64 1
+// CHECK-NEXT:    store <2048 x i1> [[TMP1]], ptr [[ADD_PTR1]], align 256
+// CHECK-NEXT:    ret void
+//
+void test_dmrp_copy(__dmr2048 *ptr1, __dmr2048 *ptr2) {
+  *(ptr2 + 1) = *(ptr1 + 2);
+}
+
+// CHECK-LABEL: @test_dmrp_typedef(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[INP_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[OUTP_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPIN:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPOUT:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    store ptr [[INP:%.*]], ptr [[INP_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[OUTP:%.*]], ptr [[OUTP_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[INP_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP0]], ptr [[VDMRPIN]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[OUTP_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP1]], ptr [[VDMRPOUT]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = load ptr, ptr [[VDMRPIN]], align 8
+// CHECK-NEXT:    [[TMP3:%.*]] = load <2048 x i1>, ptr [[TMP2]], align 256
+// CHECK-NEXT:    [[TMP4:%.*]] = load ptr, ptr [[VDMRPOUT]], align 8
+// CHECK-NEXT:    store <2048 x i1> [[TMP3]], ptr [[TMP4]], align 256
+// CHECK-NEXT:    ret void
+//
+void test_dmrp_typedef(int *inp, int *outp) {
+  __dmr2048 *vdmrpin = (__dmr2048 *)inp;
+  __dmr2048 *vdmrpout = (__dmr2048 *)outp;
+  *vdmrpout = *vdmrpin;
+}
+
+// CHECK-LABEL: @test_dmrp_arg(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[VDMRP_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPP:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    store ptr [[VDMRP:%.*]], ptr [[VDMRP_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[PTR:%.*]], ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP0]], ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[VDMRP_ADDR]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = load <2048 x i1>, ptr [[TMP1]], align 256
+// CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    store <2048 x i1> [[TMP2]], ptr [[TMP3]], align 256
+// CHECK-NEXT:    ret void
+//
+void test_dmrp_arg(__dmr2048 *vdmrp, int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  *vdmrpp = *vdmrp;
+}
+
+// CHECK-LABEL: @test_dmrp_const_arg(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[VDMRP_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPP:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    store ptr [[VDMRP:%.*]], ptr [[VDMRP_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[PTR:%.*]], ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP0]], ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[VDMRP_ADDR]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = load <2048 x i1>, ptr [[TMP1]], align 256
+// CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    store <2048 x i1> [[TMP2]], ptr [[TMP3]], align 256
+// CHECK-NEXT:    ret void
+//
+void test_dmrp_const_arg(const __dmr2048 *const vdmrp, int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  *vdmrpp = *vdmrp;
+}
+
+// CHECK-LABEL: @test_dmrp_array_arg(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[VDMRPA_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPP:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    store ptr [[VDMRPA:%.*]], ptr [[VDMRPA_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[PTR:%.*]], ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP0]], ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[VDMRPA_ADDR]], align 8
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr inbounds <2048 x i1>, ptr [[TMP1]], i64 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load <2048 x i1>, ptr [[ARRAYIDX]], align 256
+// CHECK-NEXT:    [[TMP3:%.*]] = load ptr, ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    store <2048 x i1> [[TMP2]], ptr [[TMP3]], align 256
+// CHECK-NEXT:    ret void
+//
+void test_dmrp_array_arg(__dmr2048 vdmrpa[], int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  *vdmrpp = vdmrpa[0];
+}
+
+// CHECK-LABEL: @test_dmrp_ret_const(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPP:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    store ptr [[PTR:%.*]], ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP0]], ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds <2048 x i1>, ptr [[TMP1]], i64 2
+// CHECK-NEXT:    ret ptr [[ADD_PTR]]
+//
+const __dmr2048 *test_dmrp_ret_const(int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  return vdmrpp + 2;
+}
+
+// CHECK-LABEL: @test_dmrp_sizeof_alignof(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[PTR_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRPP:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[VDMRP:%.*]] = alloca <2048 x i1>, align 256
+// CHECK-NEXT:    [[SIZET:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[ALIGNT:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[SIZEV:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[ALIGNV:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    store ptr [[PTR:%.*]], ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[PTR_ADDR]], align 8
+// CHECK-NEXT:    store ptr [[TMP0]], ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[VDMRPP]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = load <2048 x i1>, ptr [[TMP1]], align 256
+// CHECK-NEXT:    store <2048 x i1> [[TMP2]], ptr [[VDMRP]], align 256
+// CHECK-NEXT:    store i32 256, ptr [[SIZET]], align 4
+// CHECK-NEXT:    store i32 256, ptr [[ALIGNT]], align 4
+// CHECK-NEXT:    store i32 256, ptr [[SIZEV]], align 4
+// CHECK-NEXT:    store i32 256, ptr [[ALIGNV]], align 4
+// CHECK-NEXT:    [[TMP3:%.*]] = load i32, ptr [[SIZET]], align 4
+// CHECK-NEXT:    [[TMP4:%.*]] = load i32, ptr [[ALIGNT]], align 4
+// CHECK-NEXT:    [[ADD:%.*]] = add i32 [[TMP3]], [[TMP4]]
+// CHECK-NEXT:    [[TMP5:%.*]] = load i32, ptr [[SIZEV]], align 4
+// CHECK-NEXT:    [[ADD1:%.*]] = add i32 [[ADD]], [[TMP5]]
+// CHECK-NEXT:    [[TMP6:%.*]] = load i32, ptr [[ALIGNV]], align 4
+// CHECK-NEXT:    [[ADD2:%.*]] = add i32 [[ADD1]], [[TMP6]]
+// CHECK-NEXT:    ret i32 [[ADD2]]
+//
+int test_dmrp_sizeof_alignof(int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  __dmr2048 vdmrp = *vdmrpp;
+  unsigned sizet = sizeof(__dmr2048);
+  unsigned alignt = __alignof__(__dmr2048);
+   unsigned sizev = sizeof(vdmrp);
+  unsigned alignv = __alignof__(vdmrp);
+  return sizet + alignt + sizev + alignv;
+}
 
 // CHECK-LABEL: @test_dmr_copy(
 // CHECK-NEXT:  entry:

--- a/clang/test/CodeGenCXX/ppc-mangle-mma-types.cpp
+++ b/clang/test/CodeGenCXX/ppc-mangle-mma-types.cpp
@@ -7,6 +7,9 @@
 // RUN: %clang_cc1 -triple powerpc64le-linux-unknown -target-cpu pwr8 %s \
 // RUN:   -emit-llvm -o - | FileCheck %s
 
+// CHECK: _Z1fPu9__dmr2048
+void f(__dmr2048 *vdmrp) {}
+
 // CHECK: _Z2f0Pu9__dmr1024
 void f0(__dmr1024 *vdmr) {}
 

--- a/clang/test/Sema/ppc-dmf-types.c
+++ b/clang/test/Sema/ppc-dmf-types.c
@@ -12,47 +12,86 @@
 
 // typedef
 typedef __dmr1024 dmr_t;
+typedef __dmr2048 dmrp_t;
 
 // function argument
-void testDmrArg1(__dmr1024 vdmr, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
-  __dmr1024 *vdmrp = (__dmr1024 *)ptr;
+void testDmrArg1(dmr_t vdmr, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmr_t *vdmrp = (dmr_t *)ptr;
   *vdmrp = vdmr;
 }
 
-void testDmrArg2(const __dmr1024 vdmr, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
-  __dmr1024 *vdmrp = (__dmr1024 *)ptr;
+void testDmrArg2(const dmr_t vdmr, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmr_t *vdmrp = (dmr_t *)ptr;
   *vdmrp = vdmr;
 }
 
 void testDmrArg3(const dmr_t vdmr, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
-  __dmr1024 *vdmrp = (__dmr1024 *)ptr;
+  dmr_t *vdmrp = (dmr_t *)ptr;
   *vdmrp = vdmr;
 }
 
+void testDmrPArg1(const dmrp_t vdmrp, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmrp_t *vdmrpp = (dmrp_t *)ptr;
+  *vdmrpp = vdmrp;
+}
+
+void testDmrPArg2(const dmrp_t vdmrp, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmrp_t *vdmrpp = (dmrp_t *)ptr;
+  *vdmrpp = vdmrp;
+}
+
+void testDmrPArg3(const dmrp_t vdmrp, int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmrp_t *vdmrpp = (dmrp_t *)ptr;
+  *vdmrpp = vdmrp;
+}
+
 // function return
-__dmr1024 testDmrRet1(int *ptr) { // expected-error {{invalid use of PPC MMA type}}
-  __dmr1024 *vdmrp = (__dmr1024 *)ptr;
+dmr_t testDmrRet1(int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmr_t *vdmrp = (dmr_t *)ptr;
   return *vdmrp; // expected-error {{invalid use of PPC MMA type}}
 }
 
 const dmr_t testDmrRet4(int *ptr) { // expected-error {{invalid use of PPC MMA type}}
-  __dmr1024 *vdmrp = (__dmr1024 *)ptr;
+  dmr_t *vdmrp = (dmr_t *)ptr;
   return *vdmrp; // expected-error {{invalid use of PPC MMA type}}
 }
 
+dmrp_t testDmrPRet1(int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmrp_t *vdmrpp = (dmrp_t *)ptr;
+  return *vdmrpp; // expected-error {{invalid use of PPC MMA type}}
+}
+
+const dmrp_t testDmrPRet4(int *ptr) { // expected-error {{invalid use of PPC MMA type}}
+  dmrp_t *vdmrpp = (dmrp_t *)ptr;
+  return *vdmrpp; // expected-error {{invalid use of PPC MMA type}}
+}
+
 // global
-__dmr1024 globalvdmr;        // expected-error {{invalid use of PPC MMA type}}
-const __dmr1024 globalvdmr2; // expected-error {{invalid use of PPC MMA type}}
-__dmr1024 *globalvdmrp;
-const __dmr1024 *const globalvdmrp2;
+dmr_t globalvdmr;        // expected-error {{invalid use of PPC MMA type}}
+const dmr_t globalvdmr2; // expected-error {{invalid use of PPC MMA type}}
+dmr_t *globalvdmrp;
+const dmr_t *const globalvdmrp2;
 dmr_t globalvdmr_t; // expected-error {{invalid use of PPC MMA type}}
+
+dmrp_t globalvdmrp;        // expected-error {{invalid use of PPC MMA type}}
+const dmrp_t globalvdmrp2; // expected-error {{invalid use of PPC MMA type}}
+dmrp_t *globalvdmrpp;
+const dmrp_t *const globalvdmrpp2;
+dmrp_t globalvdmrp_t; // expected-error {{invalid use of PPC MMA type}}
 
 // struct field
 struct TestDmrStruct {
   int a;
   float b;
-  __dmr1024 c; // expected-error {{invalid use of PPC MMA type}}
-  __dmr1024 *vq;
+  dmr_t c; // expected-error {{invalid use of PPC MMA type}}
+  dmr_t *vq;
+};
+
+struct TestDmrPStruct {
+  int a;
+  float b;
+  dmrp_t c; // expected-error {{invalid use of PPC MMA type}}
+  dmrp_t *vq;
 };
 
 // operators
@@ -100,4 +139,51 @@ void testDmrOperators4(int v, void *ptr) {
   __dmr1024 *vdmrp = (__dmr1024 *)ptr;
   __dmr1024 vdmr1 = (__dmr1024)v;   // expected-error {{used type '__dmr1024' where arithmetic or pointer type is required}}
   __dmr1024 vdmr2 = (__dmr1024)vdmrp; // expected-error {{used type '__dmr1024' where arithmetic or pointer type is required}}
+}
+
+int testDmrPOperators1(int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  __dmr2048 vdmrp1 = *(vdmrpp + 0);
+  __dmr2048 vdmrp2 = *(vdmrpp + 1);
+  __dmr2048 vdmrp3 = *(vdmrpp + 2);
+  if (vdmrp1) // expected-error {{statement requires expression of scalar type ('__dmr2048' invalid)}}
+    *(vdmrpp + 10) = vdmrp1;
+  if (!vdmrp2) // expected-error {{invalid argument type '__dmr2048' to unary expression}}
+    *(vdmrpp + 11) = vdmrp3;
+  int c1 = vdmrp1 && vdmrp2; // expected-error {{invalid operands to binary expression ('__dmr2048' and '__dmr2048')}}
+  int c2 = vdmrp2 == vdmrp3; // expected-error {{invalid operands to binary expression ('__dmr2048' and '__dmr2048')}}
+  int c3 = vdmrp2 < vdmrp1;  // expected-error {{invalid operands to binary expression ('__dmr2048' and '__dmr2048')}}
+  return c1 || c2 || c3;
+}
+
+void testDmrPOperators2(int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  __dmr2048 vdmrp1 = *(vdmrpp + 0);
+  __dmr2048 vdmrp2 = *(vdmrpp + 1);
+  __dmr2048 vdmrp3 = *(vdmrpp + 2);
+  vdmrp1 = -vdmrp1;        // expected-error {{invalid argument type '__dmr2048' to unary expression}}
+  vdmrp2 = vdmrp1 + vdmrp3; // expected-error {{invalid operands to binary expression ('__dmr2048' and '__dmr2048')}}
+  vdmrp2 = vdmrp2 * vdmrp3; // expected-error {{invalid operands to binary expression ('__dmr2048' and '__dmr2048')}}
+  vdmrp3 = vdmrp3 | vdmrp3; // expected-error {{invalid operands to binary expression ('__dmr2048' and '__dmr2048')}}
+  vdmrp3 = vdmrp3 << 2;    // expected-error {{invalid operands to binary expression ('__dmr2048' and 'int')}}
+  *(vdmrpp + 10) = vdmrp1;
+  *(vdmrpp + 11) = vdmrp2;
+  *(vdmrpp + 12) = vdmrp3;
+}
+
+
+vector unsigned char testDmrPOperators3(int *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  __dmr2048 vdmrp1 = *(vdmrpp + 0);
+  __dmr2048 vdmrp2 = *(vdmrpp + 1);
+  __dmr2048 vdmrp3 = *(vdmrpp + 2);
+  vdmrp1 ? *(vdmrpp + 10) = vdmrp2 : *(vdmrpp + 11) = vdmrp3; // expected-error {{used type '__dmr2048' where arithmetic or pointer type is required}}
+  vdmrp2 = vdmrp3;
+  return vdmrp2[1]; // expected-error {{subscripted value is not an array, pointer, or vector}}
+}
+
+void testDmrPOperators4(int v, void *ptr) {
+  __dmr2048 *vdmrpp = (__dmr2048 *)ptr;
+  __dmr2048 vdmrp1 = (__dmr2048)v;   // expected-error {{used type '__dmr2048' where arithmetic or pointer type is required}}
+  __dmr2048 vdmrp2 = (__dmr2048)vdmrpp; // expected-error {{used type '__dmr2048' where arithmetic or pointer type is required}}
 }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -5033,6 +5033,7 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
     case clang::BuiltinType::VectorPair:
     case clang::BuiltinType::VectorQuad:
     case clang::BuiltinType::DMR1024:
+    case clang::BuiltinType::DMR2048:
       break;
 
     // ARM -- Scalable Vector Extension


### PR DESCRIPTION
Define the __dmr2048 type to represent the DMR pair introduced by the Dense Math
Facility on PowerPC, and add three Clang builtins corresponding to DMF
cryptography:

__builtin_mma_dmsha2hash
__builtin_mma_dmsha3hash
__builtin_mma_dmxxshapad

The __dmr2048 type is required for the dmsha3hash crypto builtin, and, as with
other PPC MMA and DMR types, its use is strongly restricted.