### PR TITLE
[SCEV] Generalize (C * A /u C) -> A fold to (C1 * A /u C2) -> C1/C2 * A.

### DIFF
--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -3220,11 +3220,12 @@ const SCEV *ScalarEvolution::getMulExpr(SmallVectorImpl<const SCEV *> &Ops,
       // D is a multiple of C2, and C1 is a multiple of C1.
       const SCEV *D;
       const SCEVConstant *C2;
-      if (LHSC->getAPInt().isPowerOf2() &&
+      APInt LHSV = LHSC->getAPInt();
+      if (LHSV.isPowerOf2() &&
           match(Ops[1], m_scev_UDiv(m_SCEV(D), m_SCEVConstant(C2))) &&
           C2->getAPInt().isPowerOf2() &&
-          getMinTrailingZeros(LHSC) >= getMinTrailingZeros(C2) &&
-          getMinTrailingZeros(LHSC) <= getMinTrailingZeros(D)) {
+          LHSV.logBase2() >= C2->getAPInt().logBase2() &&
+          LHSV.logBase2() <= getMinTrailingZeros(D)) {
         return getMulExpr(getUDivExpr(LHSC, C2), D);
       }
     }

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -3216,13 +3216,16 @@ const SCEV *ScalarEvolution::getMulExpr(SmallVectorImpl<const SCEV *> &Ops,
         };
       }
 
-      // Try to fold (C * D /u C) -> D, if C is a power-of-2 and D is a multiple
-      //  of C.
+      // Try to fold (C1 * D /u C2) -> C1/C2 * D, if C1 and C2 are powers-of-2,
+      // D is a multiple of C2, and C1 is a multiple of C1.
       const SCEV *D;
-      if (match(Ops[1], m_scev_UDiv(m_SCEV(D), m_scev_Specific(LHSC))) &&
-          LHSC->getAPInt().isPowerOf2() &&
-          LHSC->getAPInt().logBase2() <= getMinTrailingZeros(D)) {
-        return D;
+      const SCEVConstant *C2;
+      if (LHSC->getAPInt().isPowerOf2() &&
+          match(Ops[1], m_scev_UDiv(m_SCEV(D), m_SCEVConstant(C2))) &&
+          C2->getAPInt().isPowerOf2() &&
+          getMinTrailingZeros(LHSC) >= getMinTrailingZeros(C2) &&
+          getMinTrailingZeros(LHSC) <= getMinTrailingZeros(D)) {
+        return getMulExpr(getUDivExpr(LHSC, C2), D);
       }
     }
   }

--- a/llvm/lib/Analysis/ScalarEvolution.cpp
+++ b/llvm/lib/Analysis/ScalarEvolution.cpp
@@ -3220,11 +3220,10 @@ const SCEV *ScalarEvolution::getMulExpr(SmallVectorImpl<const SCEV *> &Ops,
       // D is a multiple of C2, and C1 is a multiple of C1.
       const SCEV *D;
       const SCEVConstant *C2;
-      APInt LHSV = LHSC->getAPInt();
+      const APInt &LHSV = LHSC->getAPInt();
       if (LHSV.isPowerOf2() &&
           match(Ops[1], m_scev_UDiv(m_SCEV(D), m_SCEVConstant(C2))) &&
-          C2->getAPInt().isPowerOf2() &&
-          LHSV.logBase2() >= C2->getAPInt().logBase2() &&
+          C2->getAPInt().isPowerOf2() && LHSV.uge(C2->getAPInt()) &&
           LHSV.logBase2() <= getMinTrailingZeros(D)) {
         return getMulExpr(getUDivExpr(LHSC, C2), D);
       }

--- a/llvm/test/Analysis/ScalarEvolution/mul-udiv-folds.ll
+++ b/llvm/test/Analysis/ScalarEvolution/mul-udiv-folds.ll
@@ -23,7 +23,7 @@ define void @udiv4_and_udiv2(i1 %c, ptr %A) {
 ; CHECK-NEXT:    %gep.16 = getelementptr i16, ptr %A, i64 %iv
 ; CHECK-NEXT:    --> {((2 * ((zext i32 %start to i64) /u 4))<nuw><nsw> + %A),+,2}<%loop> U: full-set S: full-set Exits: ((zext i32 %start to i64) + %A) LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:    %gep.32 = getelementptr i32, ptr %A, i64 %iv
-; CHECK-NEXT:    --> {((zext i32 %start to i64) + %A),+,4}<%loop> U: full-set S: full-set Exits: ((zext i32 %start to i64) + (4 * ((zext i32 %start to i64) /u 2))<nuw><nsw> + (-4 * ((zext i32 %start to i64) /u 4))<nsw> + %A) LoopDispositions: { %loop: Computable }
+; CHECK-NEXT:    --> {((zext i32 %start to i64) + %A),+,4}<%loop> U: full-set S: full-set Exits: ((3 * (zext i32 %start to i64))<nuw><nsw> + (-4 * ((zext i32 %start to i64) /u 4))<nsw> + %A) LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:    %gep.40 = getelementptr <{ i32, i8 }>, ptr %A, i64 %iv
 ; CHECK-NEXT:    --> {((5 * ((zext i32 %start to i64) /u 4))<nuw><nsw> + %A),+,5}<%loop> U: full-set S: full-set Exits: ((5 * ((zext i32 %start to i64) /u 2))<nuw><nsw> + %A) LoopDispositions: { %loop: Computable }
 ; CHECK-NEXT:    %gep.48 = getelementptr <{ i32, i16 }>, ptr %A, i64 %iv


### PR DESCRIPTION
Generalize fold added in https://github.com/llvm/llvm-project/commit/74ec38fad0a1289f936e5388fa8bbe74653c55d9 / https://github.com/llvm/llvm-project/pull/156730 to support multiplying and
dividing by different constants, given they are both powers-of-2 and C1 is a
multiple of C2, checked via their trailing zeros.

https://alive2.llvm.org/ce/z/eqJ2xj