### PR TITLE
[bazel][mlir][python] Port #155741: stub auto-generation

### DIFF
--- a/utils/bazel/WORKSPACE
+++ b/utils/bazel/WORKSPACE
@@ -186,9 +186,9 @@ maybe(
     http_archive,
     name = "nanobind",
     build_file = "@llvm-raw//utils/bazel/third_party_build:nanobind.BUILD",
-    sha256 = "bb35deaed7efac5029ed1e33880a415638352f757d49207a8e6013fefb6c49a7",
-    strip_prefix = "nanobind-2.4.0",
-    url = "https://github.com/wjakob/nanobind/archive/refs/tags/v2.4.0.tar.gz",
+    sha256 = "8ce3667dce3e64fc06bfb9b778b6f48731482362fb89a43da156632266cd5a90",
+    strip_prefix = "nanobind-2.9.2",
+    url = "https://github.com/wjakob/nanobind/archive/refs/tags/v2.9.2.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")

--- a/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/python/BUILD.bazel
@@ -33,13 +33,6 @@ filegroup(
 )
 
 filegroup(
-    name = "ExecutionEnginePyIFiles",
-    srcs = [
-        "mlir/_mlir_libs/_mlirExecutionEngine.pyi",
-    ],
-)
-
-filegroup(
     name = "IRPyFiles",
     srcs = [
         "mlir/ir.py",
@@ -54,14 +47,6 @@ filegroup(
 )
 
 filegroup(
-    name = "IRPyIFiles",
-    srcs = [
-        "mlir/_mlir_libs/_mlir/__init__.pyi",
-        "mlir/_mlir_libs/_mlir/ir.pyi",
-    ],
-)
-
-filegroup(
     name = "MlirLibsPyFiles",
     srcs = [
         "mlir/_mlir_libs/__init__.py",
@@ -72,13 +57,6 @@ filegroup(
     name = "PassManagerPyFiles",
     srcs = [
         "mlir/passmanager.py",
-    ],
-)
-
-filegroup(
-    name = "PassManagerPyIFiles",
-    srcs = [
-        "mlir/_mlir_libs/_mlir/passmanager.pyi",
     ],
 )
 
@@ -660,13 +638,6 @@ gentbl_filegroup(
 )
 
 filegroup(
-    name = "PDLPyIFiles",
-    srcs = [
-        "mlir/_mlir_libs/_mlir/dialects/pdl.pyi",
-    ],
-)
-
-filegroup(
     name = "PDLPyFiles",
     srcs = [
         "mlir/dialects/pdl.py",
@@ -755,13 +726,6 @@ filegroup(
 ##---------------------------------------------------------------------------##
 # Quant dialect.
 ##---------------------------------------------------------------------------##
-
-filegroup(
-    name = "QuantPyIFiles",
-    srcs = [
-        "mlir/_mlir_libs/_mlir/dialects/quant.pyi",
-    ],
-)
 
 filegroup(
     name = "QuantPyFiles",


### PR DESCRIPTION
* Nanobind >= 2.9 is required now. Use 2.9.2
* Remove pyi filegroups that now refer to deleted files