### PR TITLE
[CMake] add `SKIP` to `add_lit_testsuites`

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -2192,7 +2192,12 @@ endfunction()
 
 function(add_lit_testsuites project directory)
   if (NOT LLVM_ENABLE_IDE)
-    cmake_parse_arguments(ARG "EXCLUDE_FROM_CHECK_ALL" "FOLDER;BINARY_DIR" "PARAMS;DEPENDS;ARGS" ${ARGN})
+    cmake_parse_arguments(ARG
+      "EXCLUDE_FROM_CHECK_ALL"
+      "FOLDER;BINARY_DIR"
+      "PARAMS;DEPENDS;ARGS;SKIP"
+      ${ARGN}
+      )
 
     if (NOT ARG_FOLDER)
       get_subproject_title(subproject_title)
@@ -2214,6 +2219,16 @@ function(add_lit_testsuites project directory)
 
       # Create a check- target for the directory.
       string(REPLACE "${directory}/" "" name_slash ${lit_suite})
+      set(_should_skip FALSE)
+      foreach(skip IN LISTS ARG_SKIP)
+        if(name_slash MATCHES "${skip}")
+          set(_should_skip TRUE)
+          break()
+        endif()
+      endforeach()
+      if (_should_skip)
+        continue()
+      endif()
       if (name_slash)
         set(filter ${name_slash})
         string(REPLACE "/" "-" name_slash ${name_slash})

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -247,4 +247,5 @@ add_lit_testsuite(check-mlir "Running the MLIR regression tests"
 
 add_lit_testsuites(MLIR ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${MLIR_TEST_DEPENDS}
+  SKIP "^python*"
 )

--- a/mlir/test/python/CMakeLists.txt
+++ b/mlir/test/python/CMakeLists.txt
@@ -10,3 +10,12 @@ mlir_tablegen(lib/PythonTestTypes.cpp.inc -gen-typedef-defs)
 add_public_tablegen_target(MLIRPythonTestIncGen)
 
 add_subdirectory(lib)
+
+set(MLIR_PYTHON_TEST_DEPENDS MLIRPythonModules)
+if(NOT MLIR_STANDALONE_BUILD)
+  list(APPEND MLIR_PYTHON_TEST_DEPENDS FileCheck count)
+endif()
+add_lit_testsuite(check-mlir-python "Running the MLIR Python regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${MLIR_PYTHON_TEST_DEPENDS}
+)


### PR DESCRIPTION
This PR adds `SKIP` to `add_lit_testsuites`. The purpose is to let people filter the currently exhaustive inclusion of subdirectories which might not all depend on the same `DEPENDS`. The immediate use case is MLIR where we have a collection of Python tests that currently trigger rebuilds of various tools (like `mlir-opt`) which they do not depend on. That collection of tests is updated here too.