### PR TITLE
[OpenMP] Rename z_Linux files to z_OS

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -112,20 +112,20 @@ else()
     if(${LIBOMP_ARCH} STREQUAL "i386" OR ${LIBOMP_ARCH} STREQUAL "x86_64")
       libomp_append(LIBOMP_ASMFILES z_Windows_NT-586_asm.asm) # Windows assembly file
     elseif((${LIBOMP_ARCH} STREQUAL "aarch64" OR ${LIBOMP_ARCH} STREQUAL "arm") AND (NOT MSVC OR CMAKE_C_COMPILER_ID STREQUAL "Clang"))
-      # z_Linux_asm.S works for AArch64 and ARM Windows too.
-      libomp_append(LIBOMP_GNUASMFILES z_Linux_asm.S)
+      # z_OS_asm.S works for AArch64 and ARM Windows too.
+      libomp_append(LIBOMP_GNUASMFILES z_OS_asm.S)
     else()
       # AArch64 with MSVC gets implementations of the functions from
       # ifdeffed sections in z_Windows_NT-586_util.cpp.
     endif()
   else()
     # Unix specific files
-    libomp_append(LIBOMP_CXXFILES z_Linux_util.cpp)
+    libomp_append(LIBOMP_CXXFILES z_OS_util.cpp)
     libomp_append(LIBOMP_CXXFILES kmp_gsupport.cpp)
     if("${CMAKE_SYSTEM_NAME}" MATCHES "AIX")
       libomp_append(LIBOMP_GNUASMFILES z_AIX_asm.S) # AIX assembly file
     else()
-      libomp_append(LIBOMP_GNUASMFILES z_Linux_asm.S) # Unix assembly file
+      libomp_append(LIBOMP_GNUASMFILES z_OS_asm.S) # Unix assembly file
     endif()
   endif()
   libomp_append(LIBOMP_CXXFILES thirdparty/ittnotify/ittnotify_static.cpp LIBOMP_USE_ITT_NOTIFY)

--- a/openmp/runtime/src/z_OS_asm.S
+++ b/openmp/runtime/src/z_OS_asm.S
@@ -1,5 +1,5 @@
-//  z_Linux_asm.S:  - microtasking routines specifically
-//                    written for Intel platforms running Linux* OS
+//  z_OS_asm.S:  - microtasking routines specifically
+//                 written for Intel platforms running Linux* OS
 
 //
 ////===----------------------------------------------------------------------===//
@@ -698,7 +698,7 @@ KMP_LABEL(invoke_3):
 // -- Machine type P
 // mark_description "Intel Corporation";
 	.ident "Intel Corporation"
-// --	.file "z_Linux_asm.S"
+// --	.file "z_OS_asm.S"
 	.data
 	ALIGN 4
 

--- a/openmp/runtime/src/z_OS_util.cpp
+++ b/openmp/runtime/src/z_OS_util.cpp
@@ -1,5 +1,5 @@
 /*
- * z_Linux_util.cpp -- platform specific routines.
+ * z_OS_util.cpp -- platform specific routines.
  */
 
 //===----------------------------------------------------------------------===//

--- a/openmp/runtime/src/z_Windows_NT-586_util.cpp
+++ b/openmp/runtime/src/z_Windows_NT-586_util.cpp
@@ -136,7 +136,7 @@ kmp_uint64 __kmp_test_then_and64(volatile kmp_uint64 *p, kmp_uint64 d) {
 
 #if KMP_ARCH_AARCH64 && KMP_COMPILER_MSVC
 // For !KMP_COMPILER_MSVC, this function is provided in assembly form
-// by z_Linux_asm.S.
+// by z_OS_asm.S.
 int __kmp_invoke_microtask(microtask_t pkfn, int gtid, int tid, int argc,
                            void *p_argv[]
 #if OMPT_SUPPORT


### PR DESCRIPTION
Rename the files as the contents are already supporting a range of OSes
other than Linux.