### PR TITLE
[lldb][NFC] Architecture plugins should report the vector element order

### DIFF
--- a/lldb/include/lldb/Core/Architecture.h
+++ b/lldb/include/lldb/Core/Architecture.h
@@ -129,6 +129,17 @@ public:
                                        RegisterContext &reg_context) const {
     return false;
   }
+
+  /// Get the vector element order for this architecture. This determines how
+  /// vector elements are indexed. This matters in a few places such as reading/
+  /// writing LLVM-IR values to/from target memory. Some architectures use
+  /// little-endian element ordering where element 0 is at the lowest address
+  /// even when the architecture is otherwise big-endian (e.g. MIPS MSA, ARM
+  /// NEON), but some architectures like PowerPC may use big-endian element
+  /// ordering where element 0 is at the highest address.
+  virtual lldb::ByteOrder GetVectorElementOrder() const {
+    return lldb::eByteOrderLittle;
+  }
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.cpp
+++ b/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.cpp
@@ -35,7 +35,8 @@ void ArchitecturePPC64::Terminate() {
 std::unique_ptr<Architecture> ArchitecturePPC64::Create(const ArchSpec &arch) {
   if (arch.GetTriple().isPPC64() &&
       arch.GetTriple().getObjectFormat() == llvm::Triple::ObjectFormatType::ELF)
-    return std::unique_ptr<Architecture>(new ArchitecturePPC64());
+    return std::unique_ptr<Architecture>(
+        new ArchitecturePPC64(arch.GetByteOrder()));
   return nullptr;
 }
 
@@ -59,4 +60,8 @@ void ArchitecturePPC64::AdjustBreakpointAddress(const Symbol &func,
     return;
 
   addr.SetOffset(addr.GetOffset() + loffs);
+}
+
+lldb::ByteOrder ArchitecturePPC64::GetVectorElementOrder() const {
+  return m_vector_element_order;
 }

--- a/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.h
+++ b/lldb/source/Plugins/Architecture/PPC64/ArchitecturePPC64.h
@@ -30,9 +30,14 @@ public:
   void AdjustBreakpointAddress(const Symbol &func,
                                Address &addr) const override;
 
+  lldb::ByteOrder GetVectorElementOrder() const override;
+
 private:
   static std::unique_ptr<Architecture> Create(const ArchSpec &arch);
-  ArchitecturePPC64() = default;
+  ArchitecturePPC64(lldb::ByteOrder vector_element_order)
+      : m_vector_element_order(vector_element_order) {}
+
+  lldb::ByteOrder m_vector_element_order;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
Some targets like PowerPC store their vector elements in an endian-dependent order while others use the same order regardless of endianness:
- PowerPC little endian:  little endian elements ordered 0, 1, 2, ...
- PowerPC big endian:     big endian elements ordered n-1, n-2, n-3, ...
- ARM/MIPS little endian: little endian elements ordered 0, 1, 2, ...
- ARM/MIPS big endian:    big endian elements ordered 0, 1, 2, ...

This matters when LLVM-IR values are transferred to/from target memory since LLVM-IR orders elements 0, 1, 2, ... regardless of endianness.

This will be used in #155000 by changes to the IRInterpreter to allow it to evaluate some vectors without executing on the target