### PR TITLE
[libc] Use anonymous namespace for test helper code

### DIFF
--- a/libc/test/src/setjmp/setjmp_test.cpp
+++ b/libc/test/src/setjmp/setjmp_test.cpp
@@ -10,6 +10,8 @@
 #include "src/setjmp/setjmp_impl.h"
 #include "test/UnitTest/Test.h"
 
+namespace {
+
 constexpr int MAX_LOOP = 123;
 int longjmp_called = 0;
 
@@ -45,3 +47,5 @@ TEST(LlvmLibcSetJmpTest, SetAndJumpBackValOne) {
   ASSERT_EQ(longjmp_called, 1);
   ASSERT_EQ(val, 1);
 }
+
+} // namespace

--- a/libc/test/src/stdio/printf_core/writer_test.cpp
+++ b/libc/test/src/stdio/printf_core/writer_test.cpp
@@ -6,12 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/CPP/string_view.h"
 #include "src/stdio/printf_core/writer.h"
 
+#include "src/__support/CPP/string_view.h"
 #include "src/string/memory_utils/inline_memcpy.h"
-
 #include "test/UnitTest/Test.h"
+
+namespace {
 
 using LIBC_NAMESPACE::cpp::string_view;
 using LIBC_NAMESPACE::printf_core::WriteBuffer;
@@ -314,3 +315,5 @@ TEST(LlvmLibcPrintfWriterTest, NullStringWithZeroMaxLengthWithCallback) {
   ASSERT_EQ(writer.get_chars_written(), 12);
   ASSERT_STREQ("aaaDEF111456", str);
 }
+
+} // namespace

--- a/libc/test/src/stdlib/quick_sort_test.cpp
+++ b/libc/test/src/stdlib/quick_sort_test.cpp
@@ -9,6 +9,8 @@
 #include "SortingTest.h"
 #include "src/stdlib/qsort_util.h"
 
+namespace {
+
 void quick_sort(void *array, size_t array_size, size_t elem_size,
                 int (*compare)(const void *, const void *)) {
   constexpr bool USE_QUICKSORT = true;
@@ -23,3 +25,5 @@ void quick_sort(void *array, size_t array_size, size_t elem_size,
 }
 
 LIST_SORTING_TESTS(Qsort, quick_sort);
+
+} // namespace

--- a/libc/test/src/string/memchr_test.cpp
+++ b/libc/test/src/string/memchr_test.cpp
@@ -6,10 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "hdr/signal_macros.h"
 #include "src/string/memchr.h"
-#include "test/UnitTest/Test.h"
+
 #include <stddef.h>
+
+#include "hdr/signal_macros.h"
+#include "test/UnitTest/Test.h"
+
+namespace {
 
 // A helper function that calls memchr and abstracts away the explicit cast for
 // readability purposes.
@@ -130,3 +134,5 @@ TEST(LlvmLibcMemChrTest, CrashOnNullPtr) {
 }
 
 #endif // defined(LIBC_ADD_NULL_CHECKS)
+
+} // namespace

--- a/libc/test/src/string/memrchr_test.cpp
+++ b/libc/test/src/string/memrchr_test.cpp
@@ -6,10 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "hdr/signal_macros.h"
 #include "src/string/memrchr.h"
-#include "test/UnitTest/Test.h"
+
 #include <stddef.h>
+
+#include "hdr/signal_macros.h"
+#include "test/UnitTest/Test.h"
+
+namespace {
 
 // A helper function that calls memrchr and abstracts away the explicit cast for
 // readability purposes.
@@ -122,3 +126,5 @@ TEST(LlvmLibcMemRChrTest, CrashOnNullPtr) {
 }
 
 #endif // defined(LIBC_ADD_NULL_CHECKS)
+
+} // namespace


### PR DESCRIPTION
Tests can be at top-level or inside an anonymous namespace,
doesn't matter.  But putting their helper code inside anonymous
namespaces both makes the code compatible with compiling using
-Wmissing-declarations and might let the compiler optimize the
test good a bit better.
