### PR TITLE
[gwp_asan] Use anonymous namespace for test helper code

### DIFF
--- a/compiler-rt/lib/gwp_asan/tests/compression.cpp
+++ b/compiler-rt/lib/gwp_asan/tests/compression.cpp
@@ -11,6 +11,7 @@
 
 namespace gwp_asan {
 namespace compression {
+namespace {
 
 TEST(GwpAsanCompressionTest, SingleByteVarInt) {
   uint8_t Compressed[1];
@@ -263,5 +264,7 @@ TEST(GwpAsanCompressionTest, CompressPartiallySucceedsWithTooSmallBuffer) {
   EXPECT_EQ(pack(Uncompressed, 3u, Compressed, 6u), 5u);
   EXPECT_EQ(pack(Uncompressed, 3u, Compressed, 3 * kBytesForLargestVarInt), 5u);
 }
+
+} // namespace
 } // namespace compression
 } // namespace gwp_asan

--- a/compiler-rt/lib/gwp_asan/tests/slot_reuse.cpp
+++ b/compiler-rt/lib/gwp_asan/tests/slot_reuse.cpp
@@ -6,9 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <set>
+
 #include "gwp_asan/tests/harness.h"
 
-#include <set>
+namespace {
 
 void singleByteGoodAllocDealloc(gwp_asan::GuardedPoolAllocator *GPA) {
   void *Ptr = GPA->allocate(1);
@@ -72,3 +74,5 @@ TEST_F(CustomGuardedPoolAllocator, NoReuseBeforeNecessary129) {
   InitNumSlots(kPoolSize);
   runNoReuseBeforeNecessary(&GPA, kPoolSize);
 }
+
+} // namespace

--- a/compiler-rt/lib/gwp_asan/tests/thread_contention.cpp
+++ b/compiler-rt/lib/gwp_asan/tests/thread_contention.cpp
@@ -15,6 +15,8 @@
 #include <thread>
 #include <vector>
 
+namespace {
+
 void asyncTask(gwp_asan::GuardedPoolAllocator *GPA,
                std::atomic<bool> *StartingGun, unsigned NumIterations) {
   while (!*StartingGun) {
@@ -63,3 +65,5 @@ TEST_F(CustomGuardedPoolAllocator, ThreadContention) {
   InitNumSlots(NumThreads);
   runThreadContentionTest(NumThreads, NumIterations, &GPA);
 }
+
+} // namespace


### PR DESCRIPTION
Tests can be at top-level or inside an anonymous namespace,
doesn't matter.  But putting their helper code inside anonymous
namespaces both makes the code compatible with compiling using
-Wmissing-declarations and might let the compiler optimize the
test good a bit better.
