### PR TITLE
[scudo] Use anonymous namespace for test helper code

### DIFF
--- a/compiler-rt/lib/scudo/standalone/tests/quarantine_test.cpp
+++ b/compiler-rt/lib/scudo/standalone/tests/quarantine_test.cpp
@@ -6,16 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "tests/scudo_unit_test.h"
-
 #include "quarantine.h"
 
 #include <pthread.h>
 #include <stdlib.h>
 
-static void *FakePtr = reinterpret_cast<void *>(0xFA83FA83);
-static const scudo::uptr BlockSize = 8UL;
-static const scudo::uptr LargeBlockSize = 16384UL;
+#include "tests/scudo_unit_test.h"
+
+namespace {
+
+void *FakePtr = reinterpret_cast<void *>(0xFA83FA83);
+const scudo::uptr BlockSize = 8UL;
+const scudo::uptr LargeBlockSize = 16384UL;
 
 struct QuarantineCallback {
   void recycle(void *P) { EXPECT_EQ(P, FakePtr); }
@@ -26,9 +28,9 @@ struct QuarantineCallback {
 typedef scudo::GlobalQuarantine<QuarantineCallback, void> QuarantineT;
 typedef typename QuarantineT::CacheT CacheT;
 
-static QuarantineCallback Cb;
+QuarantineCallback Cb;
 
-static void deallocateCache(CacheT *Cache) {
+void deallocateCache(CacheT *Cache) {
   while (scudo::QuarantineBatch *Batch = Cache->dequeueBatch())
     Cb.deallocate(Batch);
 }
@@ -187,8 +189,8 @@ TEST(ScudoQuarantineTest, QuarantineCacheMergeBatchesALotOfBatches) {
   deallocateCache(&ToDeallocate);
 }
 
-static const scudo::uptr MaxQuarantineSize = 1024UL << 10; // 1MB
-static const scudo::uptr MaxCacheSize = 256UL << 10;       // 256KB
+const scudo::uptr MaxQuarantineSize = 1024UL << 10; // 1MB
+const scudo::uptr MaxCacheSize = 256UL << 10;       // 256KB
 
 TEST(ScudoQuarantineTest, GlobalQuarantine) {
   QuarantineT Quarantine;
@@ -253,3 +255,5 @@ TEST(ScudoQuarantineTest, ThreadedGlobalQuarantine) {
   for (scudo::uptr I = 0; I < NumberOfThreads; I++)
     Quarantine.drainAndRecycle(&T[I].Cache, Cb);
 }
+
+} // namespace


### PR DESCRIPTION
Tests can be at top-level or inside an anonymous namespace,
doesn't matter.  But putting their helper code inside anonymous
namespaces both makes the code compatible with compiling using
-Wmissing-declarations and might let the compiler optimize the
test good a bit better.
