### PR TITLE
IRMover: Proper fix of performance regression of #146020

### DIFF
--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -70,7 +70,7 @@ public:
   using LazyCallback =
       llvm::unique_function<void(GlobalValue &GV, ValueAdder Add)>;
 
-  typedef DenseMap<const NamedMDNode *, DenseSet<const MDNode *>> NamedMDNodesT;
+  using NamedMDNodesT = DenseMap<const NamedMDNode *, DenseSet<const MDNode *>>;
 
   /// Move in the provide values in \p ValuesToLink from \p Src.
   ///

--- a/llvm/include/llvm/Linker/IRMover.h
+++ b/llvm/include/llvm/Linker/IRMover.h
@@ -10,6 +10,7 @@
 #define LLVM_LINKER_IRMOVER_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
 #include "llvm/Support/Compiler.h"
@@ -19,6 +20,8 @@ namespace llvm {
 class Error;
 class GlobalValue;
 class Metadata;
+class MDNode;
+class NamedMDNode;
 class Module;
 class StructType;
 class TrackingMDRef;
@@ -67,6 +70,8 @@ public:
   using LazyCallback =
       llvm::unique_function<void(GlobalValue &GV, ValueAdder Add)>;
 
+  typedef DenseMap<const NamedMDNode *, DenseSet<const MDNode *>> NamedMDNodesT;
+
   /// Move in the provide values in \p ValuesToLink from \p Src.
   ///
   /// - \p AddLazyFor is a call back that the IRMover will call when a global
@@ -86,6 +91,7 @@ private:
   Module &Composite;
   IdentifiedStructTypeSet IdentifiedStructTypes;
   MDMapT SharedMDs; ///< A Metadata map to use for all calls to \a move().
+  NamedMDNodesT NamedMDNodes; ///< Cache for IRMover::linkNamedMDNodes().
 };
 
 } // End llvm namespace


### PR DESCRIPTION
In #157045 I didn't realize that IRMover object is
one for entire LTO, but IRLinker is created per
module. We need one cache for combined module.

Also update StringRef key to just a pointer, which
should be enough for this task.

I timed "IRLinker::linkNamedMDNodes" code on one
of our internal binaries, not very large, but
above average.

Before #146020: 0.4859s
After #146020: 624.4686s
After #157045: 322.3493s
After this patch: 0.5574s
