### PR TITLE
[MemProf] Always add hints to allocations with memprof attributes

### DIFF
--- a/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
+++ b/llvm/lib/Transforms/Utils/SimplifyLibCalls.cpp
@@ -97,6 +97,10 @@ static cl::opt<unsigned, false, HotColdHintParser>
 static cl::opt<unsigned, false, HotColdHintParser> HotNewHintValue(
     "hot-new-hint-value", cl::Hidden, cl::init(254),
     cl::desc("Value to pass to hot/cold operator new for hot allocation"));
+static cl::opt<unsigned, false, HotColdHintParser> AmbiguousNewHintValue(
+    "ambiguous-new-hint-value", cl::Hidden, cl::init(222),
+    cl::desc(
+        "Value to pass to hot/cold operator new for ambiguous allocation"));
 
 //===----------------------------------------------------------------------===//
 // Helper Functions
@@ -1767,6 +1771,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
     HotCold = NotColdNewHintValue;
   else if (CI->getAttributes().getFnAttr("memprof").getValueAsString() == "hot")
     HotCold = HotNewHintValue;
+  else if (CI->getAttributes().getFnAttr("memprof").getValueAsString() ==
+           "ambiguous")
+    HotCold = AmbiguousNewHintValue;
   else
     return nullptr;
 
@@ -1784,9 +1791,8 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
                             LibFunc_Znwm12__hot_cold_t, HotCold);
     break;
   case LibFunc_Znwm:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNew(CI->getArgOperand(0), B, TLI,
-                            LibFunc_Znwm12__hot_cold_t, HotCold);
+    return emitHotColdNew(CI->getArgOperand(0), B, TLI,
+                          LibFunc_Znwm12__hot_cold_t, HotCold);
     break;
   case LibFunc_Znam12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1794,9 +1800,8 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
                             LibFunc_Znam12__hot_cold_t, HotCold);
     break;
   case LibFunc_Znam:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNew(CI->getArgOperand(0), B, TLI,
-                            LibFunc_Znam12__hot_cold_t, HotCold);
+    return emitHotColdNew(CI->getArgOperand(0), B, TLI,
+                          LibFunc_Znam12__hot_cold_t, HotCold);
     break;
   case LibFunc_ZnwmRKSt9nothrow_t12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1805,10 +1810,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
           LibFunc_ZnwmRKSt9nothrow_t12__hot_cold_t, HotCold);
     break;
   case LibFunc_ZnwmRKSt9nothrow_t:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNewNoThrow(
-          CI->getArgOperand(0), CI->getArgOperand(1), B, TLI,
-          LibFunc_ZnwmRKSt9nothrow_t12__hot_cold_t, HotCold);
+    return emitHotColdNewNoThrow(CI->getArgOperand(0), CI->getArgOperand(1), B,
+                                 TLI, LibFunc_ZnwmRKSt9nothrow_t12__hot_cold_t,
+                                 HotCold);
     break;
   case LibFunc_ZnamRKSt9nothrow_t12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1817,10 +1821,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
           LibFunc_ZnamRKSt9nothrow_t12__hot_cold_t, HotCold);
     break;
   case LibFunc_ZnamRKSt9nothrow_t:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNewNoThrow(
-          CI->getArgOperand(0), CI->getArgOperand(1), B, TLI,
-          LibFunc_ZnamRKSt9nothrow_t12__hot_cold_t, HotCold);
+    return emitHotColdNewNoThrow(CI->getArgOperand(0), CI->getArgOperand(1), B,
+                                 TLI, LibFunc_ZnamRKSt9nothrow_t12__hot_cold_t,
+                                 HotCold);
     break;
   case LibFunc_ZnwmSt11align_val_t12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1829,10 +1832,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
           LibFunc_ZnwmSt11align_val_t12__hot_cold_t, HotCold);
     break;
   case LibFunc_ZnwmSt11align_val_t:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNewAligned(
-          CI->getArgOperand(0), CI->getArgOperand(1), B, TLI,
-          LibFunc_ZnwmSt11align_val_t12__hot_cold_t, HotCold);
+    return emitHotColdNewAligned(CI->getArgOperand(0), CI->getArgOperand(1), B,
+                                 TLI, LibFunc_ZnwmSt11align_val_t12__hot_cold_t,
+                                 HotCold);
     break;
   case LibFunc_ZnamSt11align_val_t12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1841,10 +1843,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
           LibFunc_ZnamSt11align_val_t12__hot_cold_t, HotCold);
     break;
   case LibFunc_ZnamSt11align_val_t:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNewAligned(
-          CI->getArgOperand(0), CI->getArgOperand(1), B, TLI,
-          LibFunc_ZnamSt11align_val_t12__hot_cold_t, HotCold);
+    return emitHotColdNewAligned(CI->getArgOperand(0), CI->getArgOperand(1), B,
+                                 TLI, LibFunc_ZnamSt11align_val_t12__hot_cold_t,
+                                 HotCold);
     break;
   case LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1854,11 +1855,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
           HotCold);
     break;
   case LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNewAlignedNoThrow(
-          CI->getArgOperand(0), CI->getArgOperand(1), CI->getArgOperand(2), B,
-          TLI, LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t,
-          HotCold);
+    return emitHotColdNewAlignedNoThrow(
+        CI->getArgOperand(0), CI->getArgOperand(1), CI->getArgOperand(2), B,
+        TLI, LibFunc_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t, HotCold);
     break;
   case LibFunc_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t:
     if (OptimizeExistingHotColdNew)
@@ -1868,17 +1867,14 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
           HotCold);
     break;
   case LibFunc_ZnamSt11align_val_tRKSt9nothrow_t:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdNewAlignedNoThrow(
-          CI->getArgOperand(0), CI->getArgOperand(1), CI->getArgOperand(2), B,
-          TLI, LibFunc_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t,
-          HotCold);
+    return emitHotColdNewAlignedNoThrow(
+        CI->getArgOperand(0), CI->getArgOperand(1), CI->getArgOperand(2), B,
+        TLI, LibFunc_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t, HotCold);
     break;
   case LibFunc_size_returning_new:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdSizeReturningNew(CI->getArgOperand(0), B, TLI,
-                                         LibFunc_size_returning_new_hot_cold,
-                                         HotCold);
+    return emitHotColdSizeReturningNew(CI->getArgOperand(0), B, TLI,
+                                       LibFunc_size_returning_new_hot_cold,
+                                       HotCold);
     break;
   case LibFunc_size_returning_new_hot_cold:
     if (OptimizeExistingHotColdNew)
@@ -1887,10 +1883,9 @@ Value *LibCallSimplifier::optimizeNew(CallInst *CI, IRBuilderBase &B,
                                          HotCold);
     break;
   case LibFunc_size_returning_new_aligned:
-    if (HotCold != NotColdNewHintValue)
-      return emitHotColdSizeReturningNewAligned(
-          CI->getArgOperand(0), CI->getArgOperand(1), B, TLI,
-          LibFunc_size_returning_new_aligned_hot_cold, HotCold);
+    return emitHotColdSizeReturningNewAligned(
+        CI->getArgOperand(0), CI->getArgOperand(1), B, TLI,
+        LibFunc_size_returning_new_aligned_hot_cold, HotCold);
     break;
   case LibFunc_size_returning_new_aligned_hot_cold:
     if (OptimizeExistingHotColdNew)

--- a/llvm/test/Transforms/InstCombine/simplify-libcalls-new.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-libcalls-new.ll
@@ -5,15 +5,15 @@
 ; OFF-NOT: hot_cold_t
 ; OFF-LABEL: @new_hot_cold()
 
-;; First check with the default cold and hot hint values (255 = -2).
-; RUN: opt < %s -passes=instcombine -optimize-hot-cold-new -S | FileCheck %s --check-prefix=HOTCOLD -DCOLD=1 -DHOT=-2 -DPREVHINTCOLD=7 -DPREVHINTNOTCOLD=7 -DPREVHINTHOT=7
+;; First check with the default hint values (254 = -2, 128 = -128, 222 = -34).
+; RUN: opt < %s -passes=instcombine -optimize-hot-cold-new -S | FileCheck %s --check-prefix=HOTCOLD -DCOLD=1 -DHOT=-2 -DNOTCOLD=-128 -DAMBIG=-34 -DPREVHINTCOLD=7 -DPREVHINTNOTCOLD=7 -DPREVHINTHOT=7 -DPREVHINTAMBIG=7
 
 ;; Next check with the non-default cold and hot hint values (200 =-56).
-; RUN: opt < %s -passes=instcombine -optimize-hot-cold-new -cold-new-hint-value=5 -hot-new-hint-value=200 -S | FileCheck %s --check-prefix=HOTCOLD -DCOLD=5 -DHOT=-56 -DPREVHINTCOLD=7 -DPREVHINTNOTCOLD=7 -DPREVHINTHOT=7
+; RUN: opt < %s -passes=instcombine -optimize-hot-cold-new -cold-new-hint-value=5 -hot-new-hint-value=200 -notcold-new-hint-value=99 -ambiguous-new-hint-value=44 -S | FileCheck %s --check-prefix=HOTCOLD -DCOLD=5 -DHOT=-56 -DAMBIG=44 -DNOTCOLD=99 -DPREVHINTCOLD=7 -DPREVHINTNOTCOLD=7 -DPREVHINTHOT=7 -DPREVHINTAMBIG=7
 
 ;; Try again with the non-default cold and hot hint values (200 =-56), and this
 ;; time specify that existing hints should be updated.
-; RUN: opt < %s -passes=instcombine -optimize-hot-cold-new -cold-new-hint-value=5 -notcold-new-hint-value=100 -hot-new-hint-value=200 -optimize-existing-hot-cold-new -S | FileCheck %s --check-prefix=HOTCOLD -DCOLD=5 -DHOT=-56 -DPREVHINTCOLD=5 -DPREVHINTNOTCOLD=100 -DPREVHINTHOT=-56
+; RUN: opt < %s -passes=instcombine -optimize-hot-cold-new -cold-new-hint-value=5 -notcold-new-hint-value=100 -hot-new-hint-value=200 -ambiguous-new-hint-value=44 -optimize-existing-hot-cold-new -S | FileCheck %s --check-prefix=HOTCOLD -DCOLD=5 -DHOT=-56 -DNOTCOLD=100 -DAMBIG=44 -DPREVHINTCOLD=5 -DPREVHINTNOTCOLD=100 -DPREVHINTHOT=-56 -DPREVHINTAMBIG=44
 
 ;; Make sure that values not in 0..255 are flagged with an error
 ; RUN: not opt < %s -passes=instcombine -optimize-hot-cold-new -cold-new-hint-value=256 -S 2>&1 | FileCheck %s --check-prefix=ERROR
@@ -28,14 +28,18 @@ define void @new() {
   ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[COLD]])
   %call = call ptr @_Znwm(i64 10) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_Znwm(i64 10)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[NOTCOLD]])
   %call1 = call ptr @_Znwm(i64 10) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[HOT]])
   %call2 = call ptr @_Znwm(i64 10) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[AMBIG]])
+  %call4 = call ptr @_Znwm(i64 10) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_Znwm(i64 10)
   %call3 = call ptr @_Znwm(i64 10) #6
@@ -52,14 +56,18 @@ define void @new_align() {
   ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[COLD]])
   %call = call ptr @_ZnwmSt11align_val_t(i64 10, i64 8) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_ZnwmSt11align_val_t(i64 10, i64 8)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[NOTCOLD]])
   %call1 = call ptr @_ZnwmSt11align_val_t(i64 10, i64 8) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[HOT]])
   %call2 = call ptr @_ZnwmSt11align_val_t(i64 10, i64 8) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[AMBIG]])
+  %call4 = call ptr @_ZnwmSt11align_val_t(i64 10, i64 8) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_ZnwmSt11align_val_t(i64 10, i64 8)
   %call3 = call ptr @_ZnwmSt11align_val_t(i64 10, i64 8) #6
@@ -77,14 +85,18 @@ define void @new_nothrow() {
   ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[COLD]])
   %call = call ptr @_ZnwmRKSt9nothrow_t(i64 10, ptr %nt) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_ZnwmRKSt9nothrow_t(i64 10, ptr nonnull %nt)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[NOTCOLD]])
   %call1 = call ptr @_ZnwmRKSt9nothrow_t(i64 10, ptr %nt) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[HOT]])
   %call2 = call ptr @_ZnwmRKSt9nothrow_t(i64 10, ptr %nt) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[AMBIG]])
+  %call4 = call ptr @_ZnwmRKSt9nothrow_t(i64 10, ptr %nt) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_ZnwmRKSt9nothrow_t(i64 10, ptr nonnull %nt)
   %call3 = call ptr @_ZnwmRKSt9nothrow_t(i64 10, ptr %nt) #6
@@ -103,14 +115,18 @@ define void @new_align_nothrow() {
   ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[COLD]])
   %call = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr nonnull %nt)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[NOTCOLD]])
   %call1 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[HOT]])
   %call2 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[AMBIG]])
+  %call4 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr nonnull %nt)
   %call3 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #6
@@ -126,14 +142,18 @@ define void @array_new() {
   ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[COLD]])
   %call = call ptr @_Znam(i64 10) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_Znam(i64 10)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[NOTCOLD]])
   %call1 = call ptr @_Znam(i64 10) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[HOT]])
   %call2 = call ptr @_Znam(i64 10) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[AMBIG]])
+  %call4 = call ptr @_Znam(i64 10) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_Znam(i64 10)
   %call3 = call ptr @_Znam(i64 10) #6
@@ -150,14 +170,18 @@ define void @array_new_align() {
   ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[COLD]])
   %call = call ptr @_ZnamSt11align_val_t(i64 10, i64 8) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_ZnamSt11align_val_t(i64 10, i64 8)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[NOTCOLD]])
   %call1 = call ptr @_ZnamSt11align_val_t(i64 10, i64 8) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[HOT]])
   %call2 = call ptr @_ZnamSt11align_val_t(i64 10, i64 8) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[AMBIG]])
+  %call4 = call ptr @_ZnamSt11align_val_t(i64 10, i64 8) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_ZnamSt11align_val_t(i64 10, i64 8)
   %call3 = call ptr @_ZnamSt11align_val_t(i64 10, i64 8) #6
@@ -175,14 +199,18 @@ define void @array_new_nothrow() {
   ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[COLD]])
   %call = call ptr @_ZnamRKSt9nothrow_t(i64 10, ptr %nt) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_ZnamRKSt9nothrow_t(i64 10, ptr nonnull %nt)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[NOTCOLD]])
   %call1 = call ptr @_ZnamRKSt9nothrow_t(i64 10, ptr %nt) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[HOT]])
   %call2 = call ptr @_ZnamRKSt9nothrow_t(i64 10, ptr %nt) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[AMBIG]])
+  %call4 = call ptr @_ZnamRKSt9nothrow_t(i64 10, ptr %nt) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_ZnamRKSt9nothrow_t(i64 10, ptr nonnull %nt)
   %call3 = call ptr @_ZnamRKSt9nothrow_t(i64 10, ptr %nt) #6
@@ -201,14 +229,18 @@ define void @array_new_align_nothrow() {
   ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[COLD]])
   %call = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #0
   call void @dummy(ptr %call)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr nonnull %nt)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[NOTCOLD]])
   %call1 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #1
   call void @dummy(ptr %call1)
   ;; Attribute hot converted to __hot_cold_t hot value.
   ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[HOT]])
   %call2 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[AMBIG]])
+  %call4 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr nonnull %nt)
   %call3 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t(i64 10, i64 8, ptr %nt) #6
@@ -232,6 +264,10 @@ define void @new_hot_cold() {
   ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_Znwm12__hot_cold_t(i64 10, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_Znwm12__hot_cold_t(i64 10, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_Znwm12__hot_cold_t(i64 10, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_Znwm12__hot_cold_t(i64 10, i8 7) #6
@@ -255,6 +291,10 @@ define void @new_align_hot_cold() {
   ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_ZnwmSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 7) #6
@@ -279,6 +319,10 @@ define void @new_nothrow_hot_cold() {
   ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr %nt, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr %nt, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_ZnwmRKSt9nothrow_t12__hot_cold_t(i64 10, ptr %nt, i8 7) #6
@@ -303,6 +347,10 @@ define void @new_align_nothrow_hot_cold() {
   ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr %nt, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr %nt, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_ZnwmSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr %nt, i8 7) #6
@@ -326,6 +374,10 @@ define void @array_new_hot_cold() {
   ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_Znam12__hot_cold_t(i64 10, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_Znam12__hot_cold_t(i64 10, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_Znam12__hot_cold_t(i64 10, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_Znam12__hot_cold_t(i64 10, i8 7) #6
@@ -349,6 +401,10 @@ define void @array_new_align_hot_cold() {
   ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_ZnamSt11align_val_t12__hot_cold_t(i64 10, i64 8, i8 7) #6
@@ -373,6 +429,10 @@ define void @array_new_nothrow_hot_cold() {
   ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr %nt, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr %nt, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr nonnull %nt, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_ZnamRKSt9nothrow_t12__hot_cold_t(i64 10, ptr %nt, i8 7) #6
@@ -397,6 +457,10 @@ define void @array_new_align_nothrow_hot_cold() {
   ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[PREVHINTHOT]])
   %call2 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr %nt, i8 7) #2
   call void @dummy(ptr %call2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[PREVHINTAMBIG]])
+  %call4 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr %nt, i8 7) #7
+  call void @dummy(ptr %call4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr nonnull %nt, i8 [[PREVHINTCOLD]])
   %call3 = call ptr @_ZnamSt11align_val_tRKSt9nothrow_t12__hot_cold_t(i64 10, i64 8, ptr %nt, i8 7) #6
@@ -413,8 +477,8 @@ define void @size_returning_test() {
   %call = call {ptr, i64} @__size_returning_new(i64 10) #3
   %p  = extractvalue {ptr, i64} %call, 0
   call void @dummy(ptr %p)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @__size_returning_new(i64 10)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @__size_returning_new_hot_cold(i64 10, i8 [[NOTCOLD]])
   %call1 = call {ptr, i64} @__size_returning_new(i64 10) #4
   %p1  = extractvalue {ptr, i64} %call1, 0
   call void @dummy(ptr %p1)
@@ -423,6 +487,11 @@ define void @size_returning_test() {
   %call2 = call {ptr, i64} @__size_returning_new(i64 10) #5
   %p2  = extractvalue {ptr, i64} %call2, 0
   call void @dummy(ptr %p2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @__size_returning_new_hot_cold(i64 10, i8 [[AMBIG]])
+  %call4 = call {ptr, i64} @__size_returning_new(i64 10) #8
+  %p4  = extractvalue {ptr, i64} %call4, 0
+  call void @dummy(ptr %p4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @__size_returning_new(i64 10)
   %call3 = call {ptr, i64} @__size_returning_new(i64 10) #6
@@ -440,8 +509,8 @@ define void @size_returning_aligned_test() {
   %call = call {ptr, i64} @__size_returning_new_aligned(i64 10, i64 8) #3
   %p  = extractvalue {ptr, i64} %call, 0
   call void @dummy(ptr %p)
-  ;; Attribute notcold has no effect.
-  ; HOTCOLD: @__size_returning_new_aligned(i64 10, i64 8)
+  ;; Attribute notcold converted to __hot_cold_t notcold value.
+  ; HOTCOLD: @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 [[NOTCOLD]])
   %call1 = call {ptr, i64} @__size_returning_new_aligned(i64 10, i64 8) #4
   %p1  = extractvalue {ptr, i64} %call1, 0
   call void @dummy(ptr %p1)
@@ -450,6 +519,11 @@ define void @size_returning_aligned_test() {
   %call2 = call {ptr, i64} @__size_returning_new_aligned(i64 10, i64 8) #5
   %p2  = extractvalue {ptr, i64} %call2, 0
   call void @dummy(ptr %p2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 [[AMBIG]])
+  %call4 = call {ptr, i64} @__size_returning_new_aligned(i64 10, i64 8) #8
+  %p4  = extractvalue {ptr, i64} %call4, 0
+  call void @dummy(ptr %p4)
   ;; Attribute cold on a nobuiltin call has no effect.
   ; HOTCOLD: @__size_returning_new_aligned(i64 10, i64 8)
   %call3 = call {ptr, i64} @__size_returning_new_aligned(i64 10, i64 8) #6
@@ -477,6 +551,11 @@ define void @size_returning_update_test() {
   %call2 = call {ptr, i64} @__size_returning_new_hot_cold(i64 10, i8 7) #5
   %p2 = extractvalue {ptr, i64} %call2, 0
   call void @dummy(ptr %p2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @__size_returning_new_hot_cold(i64 10, i8 [[PREVHINTAMBIG]])
+  %call4 = call {ptr, i64} @__size_returning_new_hot_cold(i64 10, i8 7) #8
+  %p4 = extractvalue {ptr, i64} %call4, 0
+  call void @dummy(ptr %p4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @__size_returning_new_hot_cold(i64 10, i8 [[PREVHINTCOLD]])
   %call3 = call {ptr, i64} @__size_returning_new_hot_cold(i64 10, i8 7) #6
@@ -504,6 +583,11 @@ define void @size_returning_aligned_update_test() {
   %call2 = call {ptr, i64} @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 7) #5
   %p2 = extractvalue {ptr, i64} %call2, 0
   call void @dummy(ptr %p2)
+  ;; Attribute ambiguous converted to __hot_cold_t ambiguous value.
+  ; HOTCOLD: @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 [[PREVHINTAMBIG]])
+  %call4 = call {ptr, i64} @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 7) #8
+  %p4 = extractvalue {ptr, i64} %call4, 0
+  call void @dummy(ptr %p4)
   ;; Attribute cold on a nobuiltin existing hot/cold call updates the hint.
   ; HOTCOLD: @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 [[PREVHINTCOLD]])
   %call3 = call {ptr, i64} @__size_returning_new_aligned_hot_cold(i64 10, i64 8, i8 7) #6
@@ -541,11 +625,13 @@ declare {ptr, i64} @__size_returning_new_aligned_hot_cold(i64, i64, i8)
 attributes #0 = { builtin allocsize(0) "memprof"="cold" }
 attributes #1 = { builtin allocsize(0) "memprof"="notcold" }
 attributes #2 = { builtin allocsize(0) "memprof"="hot" }
+attributes #7 = { builtin allocsize(0) "memprof"="ambiguous" }
 
 ;; Use separate attributes for __size_returning_new variants since they are not
 ;; treated as builtins.
 attributes #3 = { "memprof" = "cold" }
 attributes #4 = { "memprof" = "notcold" }
 attributes #5 = { "memprof" = "hot" }
+attributes #8 = { "memprof" = "ambiguous" }
 
 attributes #6 = { nobuiltin allocsize(0) "memprof"="cold" }


### PR DESCRIPTION
Apply hints even if the attribute is the default "notcold" or
"ambiguous", to enable better tracking through the allocator.

Add an option to control the ambiguous allocation hint value.
