### PR TITLE
[lit] Move pipefail test into lit tests

### DIFF
--- a/llvm/test/Other/pipefail.txt
+++ b/llvm/test/Other/pipefail.txt
@@ -1,2 +1,0 @@
-REQUIRES: shell
-RUN: ((false | true) && echo true || echo false) | grep false

--- a/llvm/utils/lit/tests/Inputs/shtest-shell/pipefail.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-shell/pipefail.txt
@@ -1,0 +1,4 @@
+# Check that we fail if earlier operations in a pipe fail.
+#
+# RUN: false | echo test
+#

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -1,7 +1,6 @@
 # Check the internal shell handling component of the ShTest format.
 
 # RUN: not %{lit} -v %{inputs}/shtest-shell > %t.out
-# RUN: cat %t.out > /tmp/test
 # RUN: FileCheck --input-file %t.out %s
 #
 # Test again in non-UTF shell to catch potential errors with python 2 seen

--- a/llvm/utils/lit/tests/shtest-shell.py
+++ b/llvm/utils/lit/tests/shtest-shell.py
@@ -1,6 +1,7 @@
 # Check the internal shell handling component of the ShTest format.
 
 # RUN: not %{lit} -v %{inputs}/shtest-shell > %t.out
+# RUN: cat %t.out > /tmp/test
 # RUN: FileCheck --input-file %t.out %s
 #
 # Test again in non-UTF shell to catch potential errors with python 2 seen
@@ -580,6 +581,11 @@
 # CHECK: # error: command failed with exit status: 127
 # CHECK: ***
 
+# CHECK: FAIL: shtest-shell :: pipefail.txt
+# CHECK: *** TEST 'shtest-shell :: pipefail.txt' FAILED ***
+# CHECK: error: command failed with exit status: 1
+# CHECK: ***
+
 # CHECK: PASS: shtest-shell :: redirects.txt
 
 # CHECK: FAIL: shtest-shell :: rm-error-0.txt
@@ -629,4 +635,4 @@
 
 # CHECK: PASS: shtest-shell :: valid-shell.txt
 # CHECK: Unresolved Tests (1)
-# CHECK: Failed Tests (36)
+# CHECK: Failed Tests (37)


### PR DESCRIPTION
These removes another test that otherwise needs a shell. This does
remove test coverage for pipefail in the external shell, but the
external shell should be disabled by default pretty soon. This also adds
test coverage for the internal shell which did not exist before.
