### PR TITLE
[MC][COFF] Add missing sections for DWO

### DIFF
--- a/llvm/lib/MC/MCObjectFileInfo.cpp
+++ b/llvm/lib/MC/MCObjectFileInfo.cpp
@@ -776,10 +776,18 @@ void MCObjectFileInfo::initCOFFMCObjectFileInfo(const Triple &T) {
       ".debug_loc.dwo", COFF::IMAGE_SCN_MEM_DISCARDABLE |
                             COFF::IMAGE_SCN_CNT_INITIALIZED_DATA |
                             COFF::IMAGE_SCN_MEM_READ);
+  DwarfLoclistsDWOSection = Ctx->getCOFFSection(
+      ".debug_loclists.dwo", COFF::IMAGE_SCN_MEM_DISCARDABLE |
+                                 COFF::IMAGE_SCN_CNT_INITIALIZED_DATA |
+                                 COFF::IMAGE_SCN_MEM_READ);
   DwarfStrOffDWOSection = Ctx->getCOFFSection(
       ".debug_str_offsets.dwo", COFF::IMAGE_SCN_MEM_DISCARDABLE |
                                     COFF::IMAGE_SCN_CNT_INITIALIZED_DATA |
                                     COFF::IMAGE_SCN_MEM_READ);
+  DwarfRnglistsDWOSection = Ctx->getCOFFSection(
+      ".debug_rnglists.dwo", COFF::IMAGE_SCN_MEM_DISCARDABLE |
+                                 COFF::IMAGE_SCN_CNT_INITIALIZED_DATA |
+                                 COFF::IMAGE_SCN_MEM_READ);
   DwarfAddrSection = Ctx->getCOFFSection(
       ".debug_addr", COFF::IMAGE_SCN_MEM_DISCARDABLE |
                          COFF::IMAGE_SCN_CNT_INITIALIZED_DATA |

--- a/llvm/test/CodeGen/X86/debug-loclists.ll
+++ b/llvm/test/CodeGen/X86/debug-loclists.ll
@@ -2,11 +2,19 @@
 ; RUN: llvm-dwarfdump -v -debug-info -debug-loclists %t | \
 ; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF32
 
+; RUN: llc -mtriple=x86_64-pc-mingw -filetype=obj -function-sections -o %t -experimental-debug-variable-locations=true < %s
+; RUN: llvm-dwarfdump -v -debug-info -debug-loclists %t | \
+; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF32
+
 ; RUN: llc -dwarf64 -mtriple=x86_64-pc-linux -filetype=obj -function-sections -o %t -experimental-debug-variable-locations=true < %s
 ; RUN: llvm-dwarfdump -v -debug-info -debug-loclists %t | \
 ; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF64
 
 ; RUN: llc -dwarf-version=5 -split-dwarf-file=foo.dwo -mtriple=x86_64-pc-linux -filetype=obj -function-sections -o %t -experimental-debug-variable-locations=true < %s
+; RUN: llvm-dwarfdump -v -debug-info -debug-loclists %t | \
+; RUN:   FileCheck %s --check-prefixes=DWO,DWO32
+
+; RUN: llc -dwarf-version=5 -split-dwarf-file=foo.dwo -mtriple=x86_64-pc-mingw -filetype=obj -function-sections -o %t -experimental-debug-variable-locations=true < %s
 ; RUN: llvm-dwarfdump -v -debug-info -debug-loclists %t | \
 ; RUN:   FileCheck %s --check-prefixes=DWO,DWO32
 
@@ -17,20 +25,20 @@
 ; CHECK:        DW_TAG_variable
 ; DWARF32-NEXT:   DW_AT_location [DW_FORM_loclistx]   (indexed (0x0) loclist = 0x00000018:
 ; DWARF64-NEXT:   DW_AT_location [DW_FORM_loclistx]   (indexed (0x0) loclist = 0x0000002c:
-; CHECK-NEXT:       [0x0000000000000000, 0x0000000000000003) ".text._Z2f1ii": DW_OP_consts +5, DW_OP_stack_value)
+; CHECK-NEXT:       [0x0000000000000000, 0x0000000000000003) ".text{{[.$]}}_Z2f1ii": DW_OP_consts +5, DW_OP_stack_value)
 ; CHECK-NEXT:     DW_AT_name {{.*}} "x"
 
 ; CHECK:        DW_TAG_variable
 ; DWARF32-NEXT:   DW_AT_location [DW_FORM_loclistx]   (indexed (0x1) loclist = 0x00000020:
 ; DWARF64-NEXT:   DW_AT_location [DW_FORM_loclistx]   (indexed (0x1) loclist = 0x00000034:
-; CHECK-NEXT:       [0x0000000000000000, 0x0000000000000003) ".text._Z2f1ii": DW_OP_consts +3, DW_OP_stack_value
-; CHECK-NEXT:       [0x0000000000000003, 0x0000000000000004) ".text._Z2f1ii": DW_OP_consts +4, DW_OP_stack_value)
+; CHECK-NEXT:       [0x0000000000000000, 0x0000000000000003) ".text{{[.$]}}_Z2f1ii": DW_OP_consts +3, DW_OP_stack_value
+; CHECK-NEXT:       [0x0000000000000003, 0x0000000000000004) ".text{{[.$]}}_Z2f1ii": DW_OP_consts +4, DW_OP_stack_value)
 ; CHECK-NEXT:     DW_AT_name {{.*}} "y"
 
 ; CHECK:        DW_TAG_variable
 ; DWARF32-NEXT:   DW_AT_location [DW_FORM_loclistx]   (indexed (0x2) loclist = 0x00000031:
 ; DWARF64-NEXT:   DW_AT_location [DW_FORM_loclistx]	(indexed (0x2) loclist = 0x00000045:
-; CHECK-NEXT:       [0x0000000000000003, 0x0000000000000004) ".text._Z2f1ii": DW_OP_reg0 RAX)
+; CHECK-NEXT:       [0x0000000000000003, 0x0000000000000004) ".text{{[.$]}}_Z2f1ii": DW_OP_reg0 RAX)
 ; CHECK-NEXT:     DW_AT_name {{.*}} "r"
 
 ; CHECK:        .debug_loclists contents:

--- a/llvm/test/DebugInfo/X86/convert-loclist.ll
+++ b/llvm/test/DebugInfo/X86/convert-loclist.ll
@@ -1,8 +1,15 @@
-; RUN: llc -mtriple=x86_64 -filetype=obj < %s \
+; RUN: llc -mtriple=x86_64-linux -filetype=obj < %s \
 ; RUN:   | llvm-dwarfdump -debug-info -debug-loclists - | FileCheck %s
-; RUN: llc -mtriple=x86_64 -split-dwarf-file=foo.dwo -filetype=obj -dwarf-op-convert=Enable < %s \
+; RUN: llc -mtriple=x86_64-linux -split-dwarf-file=foo.dwo -filetype=obj -dwarf-op-convert=Enable < %s \
 ; RUN:   | llvm-dwarfdump -debug-info -debug-loclists - | FileCheck --check-prefix=SPLIT --check-prefix=CHECK %s
-; RUN: llc -mtriple=x86_64 -split-dwarf-file=foo.dwo -filetype=asm -dwarf-op-convert=Enable < %s \
+; RUN: llc -mtriple=x86_64-linux -split-dwarf-file=foo.dwo -filetype=asm -dwarf-op-convert=Enable < %s \
+; RUN:   | FileCheck --check-prefix=ASM %s
+
+; RUN: llc -mtriple=x86_64-mingw -filetype=obj < %s \
+; RUN:   | llvm-dwarfdump -debug-info -debug-loclists - | FileCheck %s
+; RUN: llc -mtriple=x86_64-mingw -split-dwarf-file=foo.dwo -filetype=obj -dwarf-op-convert=Enable < %s \
+; RUN:   | llvm-dwarfdump -debug-info -debug-loclists - | FileCheck --check-prefix=SPLIT --check-prefix=CHECK %s
+; RUN: llc -mtriple=x86_64-mingw -split-dwarf-file=foo.dwo -filetype=asm -dwarf-op-convert=Enable < %s \
 ; RUN:   | FileCheck --check-prefix=ASM %s
 
 ; A bit of a brittle test - this is testing the specific DWO_id. The

--- a/llvm/test/DebugInfo/X86/convert-loclist.ll
+++ b/llvm/test/DebugInfo/X86/convert-loclist.ll
@@ -1,8 +1,8 @@
-; RUN: llc -mtriple=x86_64-linux -filetype=obj < %s \
+; RUN: llc -mtriple=x86_64 -filetype=obj < %s \
 ; RUN:   | llvm-dwarfdump -debug-info -debug-loclists - | FileCheck %s
-; RUN: llc -mtriple=x86_64-linux -split-dwarf-file=foo.dwo -filetype=obj -dwarf-op-convert=Enable < %s \
+; RUN: llc -mtriple=x86_64 -split-dwarf-file=foo.dwo -filetype=obj -dwarf-op-convert=Enable < %s \
 ; RUN:   | llvm-dwarfdump -debug-info -debug-loclists - | FileCheck --check-prefix=SPLIT --check-prefix=CHECK %s
-; RUN: llc -mtriple=x86_64-linux -split-dwarf-file=foo.dwo -filetype=asm -dwarf-op-convert=Enable < %s \
+; RUN: llc -mtriple=x86_64 -split-dwarf-file=foo.dwo -filetype=asm -dwarf-op-convert=Enable < %s \
 ; RUN:   | FileCheck --check-prefix=ASM %s
 
 ; RUN: llc -mtriple=x86_64-mingw -filetype=obj < %s \

--- a/llvm/test/DebugInfo/X86/ranges_always_default.ll
+++ b/llvm/test/DebugInfo/X86/ranges_always_default.ll
@@ -3,7 +3,17 @@
 ; RUN:   | llvm-dwarfdump -debug-info -debug-addr -debug-rnglists -v - \
 ; RUN:   | FileCheck --check-prefix=RANGE %s
 
+; RUN: llc -O0 %s -mtriple=x86_64-unknown-win32-gnu -filetype=obj -o - -minimize-addr-in-v5=Default \
+; RUN:   -split-dwarf-file=test.dwo \
+; RUN:   | llvm-dwarfdump -debug-info -debug-addr -debug-rnglists -v - \
+; RUN:   | FileCheck --check-prefix=RANGE %s
+
 ; RUN: llc -O0 %s -mtriple=x86_64-unknown-linux-gnu -filetype=obj -o - -minimize-addr-in-v5=Disabled \
+; RUN:   -split-dwarf-file=test.dwo \
+; RUN:   | llvm-dwarfdump -debug-info -debug-addr -debug-rnglists -v - \
+; RUN:   | FileCheck --check-prefix=NORANGE %s
+
+; RUN: llc -O0 %s -mtriple=x86_64-unknown-win32-gnu -filetype=obj -o - -minimize-addr-in-v5=Disabled \
 ; RUN:   -split-dwarf-file=test.dwo \
 ; RUN:   | llvm-dwarfdump -debug-info -debug-addr -debug-rnglists -v - \
 ; RUN:   | FileCheck --check-prefix=NORANGE %s

--- a/llvm/test/DebugInfo/X86/split-dwarf-v5-ranges.ll
+++ b/llvm/test/DebugInfo/X86/split-dwarf-v5-ranges.ll
@@ -1,16 +1,22 @@
 ; RUN: llc -split-dwarf-file=foo.dwo -mtriple=x86_64-unknown-linux-gnu -filetype=obj %s -o %t32
 ; RUN: llvm-dwarfdump -v -debug-info -debug-rnglists %t32 | \
-; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF32
+; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF32,CHECK-ELF
+
+; RUN: llc -split-dwarf-file=foo.dwo -mtriple=x86_64-unknown-win32-gnu -filetype=obj %s -o %t32
+; RUN: llvm-dwarfdump -v -debug-info -debug-rnglists %t32 | \
+; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF32,CHECK-COFF
 
 ; RUN: llc -dwarf64 -split-dwarf-file=foo.dwo -mtriple=x86_64-unknown-linux-gnu -filetype=obj %s -o %t64
 ; RUN: llvm-dwarfdump -v -debug-info -debug-rnglists %t64 | \
-; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF64
+; RUN:   FileCheck %s --check-prefixes=CHECK,DWARF64,CHECK-ELF
 
 ; CHECK:   .debug_info contents:
 ; CHECK:   .debug_info.dwo contents:
 ; CHECK:   DW_AT_ranges [DW_FORM_rnglistx] (indexed (0x0) rangelist = 0x[[#%.8x,RNG_OFF:]]
-; CHECK:      [0x0000000000000001, 0x000000000000000c) ".text"
-; CHECK:      [0x000000000000000e, 0x0000000000000013) ".text")
+; CHECK-ELF:  [0x[[#%.16x,BEGIN1:0x01]], 0x[[#%.16x,END1:0x0c]]) ".text"
+; CHECK-ELF:  [0x[[#%.16x,BEGIN2:0x0e]], 0x[[#%.16x,END2:0x13]]) ".text")
+; CHECK-COFF: [0x[[#%.16x,BEGIN1:0x04]], 0x[[#%.16x,END1:0x0f]]) ".text"
+; CHECK-COFF: [0x[[#%.16x,BEGIN2:0x11]], 0x[[#%.16x,END2:0x17]]) ".text")
 
 ; CHECK:   .debug_rnglists.dwo contents:
 ; DWARF32: 0x00000000: range list header: length = 0x00000015, format = DWARF32, version = 0x0005, addr_size = 0x08, seg_size = 0x00, offset_entry_count = 0x00000001
@@ -21,8 +27,8 @@
 ; CHECK:   ]
 ; CHECK:   ranges:
 ; CHECK:   0x[[#RNG_OFF]]:   [DW_RLE_base_addressx]:  0x0000000000000000
-; CHECK:   0x[[#RNG_OFF+2]]: [DW_RLE_offset_pair  ]:  0x0000000000000001, 0x000000000000000c => [0x0000000000000001, 0x000000000000000c)
-; CHECK:   0x[[#RNG_OFF+5]]: [DW_RLE_offset_pair  ]:  0x000000000000000e, 0x0000000000000013 => [0x000000000000000e, 0x0000000000000013)
+; CHECK:   0x[[#RNG_OFF+2]]: [DW_RLE_offset_pair  ]:  0x[[#%.16x,BEGIN1]], 0x[[#%.16x,END1]] => [0x[[#%.16x,BEGIN1]], 0x[[#%.16x,END1]])
+; CHECK:   0x[[#RNG_OFF+5]]: [DW_RLE_offset_pair  ]:  0x[[#%.16x,BEGIN2]], 0x[[#%.16x,END2]] => [0x[[#%.16x,BEGIN2]], 0x[[#%.16x,END2]])
 ; CHECK:   0x[[#RNG_OFF+8]]: [DW_RLE_end_of_list  ]
 
 ; Function Attrs: noinline optnone uwtable


### PR DESCRIPTION
Add DWO sections `.debug_loclists.dwo` and `.debug_rnglists.dwo` to the COFF targets.
This enables building with `-DLLVM_USE_SPLIT_DWARF=ON` on the Cygwin target, which previously failed due to compiler crashes.
