### PR TITLE
[AArch64][GlobalISel] Fix passing <3 x ptr> via the stack.

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CallLowering.cpp
@@ -1256,7 +1256,7 @@ LLT CallLowering::ValueHandler::getStackValueStoreType(
     if (Flags.isPointer()) {
       LLT PtrTy = LLT::pointer(Flags.getPointerAddrSpace(),
                                ValTy.getScalarSizeInBits());
-      if (ValVT.isVector())
+      if (ValVT.isVector() && ValVT.getVectorNumElements() != 1)
         return LLT::vector(ValTy.getElementCount(), PtrTy);
       return PtrTy;
     }

--- a/llvm/test/CodeGen/AArch64/extract-vector-elt.ll
+++ b/llvm/test/CodeGen/AArch64/extract-vector-elt.ll
@@ -1093,3 +1093,38 @@ loop:
 ret:
   ret i32 %3
 }
+
+define <3 x ptr> @v3move(<3 x ptr> %a, <3 x ptr> %b, <3 x ptr> %x) {
+; CHECK-SD-LABEL: v3move:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    fmov d1, d7
+; CHECK-SD-NEXT:    fmov d0, d6
+; CHECK-SD-NEXT:    ldr d2, [sp]
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v3move:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    ldr x8, [sp]
+; CHECK-GI-NEXT:    fmov d0, d6
+; CHECK-GI-NEXT:    fmov d1, d7
+; CHECK-GI-NEXT:    fmov d2, x8
+; CHECK-GI-NEXT:    ret
+entry:
+  ret <3 x ptr> %x
+}
+
+define ptr @v3ext(<3 x ptr> %a, <3 x ptr> %b, <3 x ptr> %x) {
+; CHECK-SD-LABEL: v3ext:
+; CHECK-SD:       // %bb.0: // %entry
+; CHECK-SD-NEXT:    ldr d0, [sp]
+; CHECK-SD-NEXT:    fmov x0, d0
+; CHECK-SD-NEXT:    ret
+;
+; CHECK-GI-LABEL: v3ext:
+; CHECK-GI:       // %bb.0: // %entry
+; CHECK-GI-NEXT:    ldr x0, [sp]
+; CHECK-GI-NEXT:    ret
+entry:
+  %c = extractelement <3 x ptr> %x, i32 2
+  ret ptr %c
+}


### PR DESCRIPTION
A <3 x ptr> will become a <1 x ptr> after being split, which needs to be represented as a s64 in a LLT.