### PR TITLE
[offload] Permit redefining OPENMP_STANDALONE_BUILD

### DIFF
--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -4,7 +4,8 @@
 cmake_minimum_required(VERSION 3.20.0)
 set(LLVM_SUBPROJECT_TITLE "liboffload")
 
-if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+# Permit redefining OPENMP_STANDALONE_BUILD when doing a runtimes build.
+if (OPENMP_STANDALONE_BUILD OR "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   set(OPENMP_STANDALONE_BUILD TRUE)
   project(offload C CXX ASM)
 else()


### PR DESCRIPTION
Permit redefining `OPENMP_STANDALONE_BUILD` to make it possible to build offload correctly via runtimes build (i.e. build where the top-level project is `runtimes`).  This follows the same logic in `openmp` component.