### PR TITLE
[LLD][COFF] Display the size of all consumed inputs with `/summary`

### DIFF
--- a/lld/COFF/COFFLinkerContext.h
+++ b/lld/COFF/COFFLinkerContext.h
@@ -61,6 +61,7 @@ public:
   std::vector<ObjFile *> objFileInstances;
   std::map<std::string, PDBInputFile *> pdbInputFileInstances;
   std::vector<ImportFile *> importFileInstances;
+  std::int64_t consumedInputsSize = 0;
 
   MergeChunk *mergeChunkInstances[Log2MaxSectionAlignment + 1] = {};
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -205,6 +205,7 @@ void LinkerDriver::addFile(InputFile *file) {
     else
       cast<ObjFile>(file)->parseLazy();
   } else {
+    ctx.consumedInputsSize += file->mb.getBufferSize();
     file->parse();
     if (auto *f = dyn_cast<ObjFile>(file)) {
       ctx.objFileInstances.push_back(f);

--- a/lld/COFF/PDB.cpp
+++ b/lld/COFF/PDB.cpp
@@ -1255,11 +1255,12 @@ void PDBLinker::printStats() {
 
   print(ctx.objFileInstances.size(),
         "Input OBJ files (expanded from all cmd-line inputs)");
-  print(ctx.consumedInputsSize, "Size of all consumed OBJ files (non-lazy)");
+  print(ctx.consumedInputsSize,
+        "Size of all consumed OBJ files (non-lazy), in bytes");
   print(ctx.typeServerSourceMappings.size(), "PDB type server dependencies");
   print(ctx.precompSourceMappings.size(), "Precomp OBJ dependencies");
   print(nbTypeRecords, "Input type records");
-  print(nbTypeRecordsBytes, "Input type records bytes");
+  print(nbTypeRecordsBytes, "Size of all input type records, in bytes");
   print(builder.getTpiBuilder().getRecordCount(), "Merged TPI records");
   print(builder.getIpiBuilder().getRecordCount(), "Merged IPI records");
   print(pdbStrTab.size(), "Output PDB strings");

--- a/lld/COFF/PDB.cpp
+++ b/lld/COFF/PDB.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Object/CVDebugRecord.h"
 #include "llvm/Support/CRC.h"
 #include "llvm/Support/Endian.h"
+#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ScopedPrinter.h"
@@ -1247,11 +1248,14 @@ void PDBLinker::printStats() {
          << std::string(80, '-') << '\n';
 
   auto print = [&](uint64_t v, StringRef s) {
-    stream << format_decimal(v, 15) << " " << s << '\n';
+    stream << formatv("{0}",
+                      fmt_align(formatv("{0:N}", v), AlignStyle::Right, 20))
+           << " " << s << '\n';
   };
 
   print(ctx.objFileInstances.size(),
         "Input OBJ files (expanded from all cmd-line inputs)");
+  print(ctx.consumedInputsSize, "Size of all consumed OBJ files (non-lazy)");
   print(ctx.typeServerSourceMappings.size(), "PDB type server dependencies");
   print(ctx.precompSourceMappings.size(), "Precomp OBJ dependencies");
   print(nbTypeRecords, "Input type records");

--- a/lld/test/COFF/pdb-type-server-simple.test
+++ b/lld/test/COFF/pdb-type-server-simple.test
@@ -107,11 +107,11 @@ CHECK-LABEL:   Mod 0002 | `* Linker *`:
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
 SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    1 PDB type server dependencies
 SUMMARY-NEXT:                    0 Precomp OBJ dependencies
 SUMMARY-NEXT:                   25 Input type records
-SUMMARY-NEXT:                  868 Input type records bytes
+SUMMARY-NEXT:                  868 Size of all input type records, in bytes
 SUMMARY-NEXT:                    9 Merged TPI records
 SUMMARY-NEXT:                   16 Merged IPI records
 SUMMARY-NEXT:                    3 Output PDB strings

--- a/lld/test/COFF/pdb-type-server-simple.test
+++ b/lld/test/COFF/pdb-type-server-simple.test
@@ -106,17 +106,18 @@ CHECK-LABEL:   Mod 0002 | `* Linker *`:
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:               2 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT:               1 PDB type server dependencies
-SUMMARY-NEXT:               0 Precomp OBJ dependencies
-SUMMARY-NEXT:              25 Input type records
-SUMMARY-NEXT:             868 Input type records bytes
-SUMMARY-NEXT:               9 Merged TPI records
-SUMMARY-NEXT:              16 Merged IPI records
-SUMMARY-NEXT:               3 Output PDB strings
-SUMMARY-NEXT:               4 Global symbol records
-SUMMARY-NEXT:              14 Module symbol records
-SUMMARY-NEXT:               2 Public symbol records
+SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT:                    1 PDB type server dependencies
+SUMMARY-NEXT:                    0 Precomp OBJ dependencies
+SUMMARY-NEXT:                   25 Input type records
+SUMMARY-NEXT:                  868 Input type records bytes
+SUMMARY-NEXT:                    9 Merged TPI records
+SUMMARY-NEXT:                   16 Merged IPI records
+SUMMARY-NEXT:                    3 Output PDB strings
+SUMMARY-NEXT:                    4 Global symbol records
+SUMMARY-NEXT:                   14 Module symbol records
+SUMMARY-NEXT:                    2 Public symbol records
 
 SUMMARY:      Top 10 types responsible for the most TPI input:
 SUMMARY-NEXT:        index     total bytes   count     size

--- a/lld/test/COFF/precomp-link-samename.test
+++ b/lld/test/COFF/precomp-link-samename.test
@@ -13,7 +13,7 @@ CHECK-NOT: LF_ENDPRECOMP
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
 SUMMARY-NEXT:                    4 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    0 PDB type server dependencies
 SUMMARY-NEXT:                    2 Precomp OBJ dependencies
 

--- a/lld/test/COFF/precomp-link-samename.test
+++ b/lld/test/COFF/precomp-link-samename.test
@@ -12,9 +12,10 @@ CHECK-NOT: LF_ENDPRECOMP
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:               4 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT:               0 PDB type server dependencies
-SUMMARY-NEXT:               2 Precomp OBJ dependencies
+SUMMARY-NEXT:                    4 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT:                    0 PDB type server dependencies
+SUMMARY-NEXT:                    2 Precomp OBJ dependencies
 
 // precompa/precomp.cpp
 #include "precomp.h"

--- a/lld/test/COFF/precomp-link.test
+++ b/lld/test/COFF/precomp-link.test
@@ -60,11 +60,11 @@ CHECK-NOT: LF_ENDPRECOMP
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
 SUMMARY-NEXT:                    3 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    0 PDB type server dependencies
 SUMMARY-NEXT:                    1 Precomp OBJ dependencies
 SUMMARY-NEXT:                1,066 Input type records
-SUMMARY-NEXT:               55,968 Input type records bytes
+SUMMARY-NEXT:               55,968 Size of all input type records, in bytes
 SUMMARY-NEXT:                  874 Merged TPI records
 SUMMARY-NEXT:                  170 Merged IPI records
 SUMMARY-NEXT:                    5 Output PDB strings

--- a/lld/test/COFF/precomp-link.test
+++ b/lld/test/COFF/precomp-link.test
@@ -59,17 +59,18 @@ CHECK-NOT: LF_ENDPRECOMP
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:               3 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT:               0 PDB type server dependencies
-SUMMARY-NEXT:               1 Precomp OBJ dependencies
-SUMMARY-NEXT:            1066 Input type records
-SUMMARY-NEXT:           55968 Input type records bytes
-SUMMARY-NEXT:             874 Merged TPI records
-SUMMARY-NEXT:             170 Merged IPI records
-SUMMARY-NEXT:               5 Output PDB strings
-SUMMARY-NEXT:             167 Global symbol records
-SUMMARY-NEXT:              20 Module symbol records
-SUMMARY-NEXT:               3 Public symbol records
+SUMMARY-NEXT:                    3 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT:                    0 PDB type server dependencies
+SUMMARY-NEXT:                    1 Precomp OBJ dependencies
+SUMMARY-NEXT:                1,066 Input type records
+SUMMARY-NEXT:               55,968 Input type records bytes
+SUMMARY-NEXT:                  874 Merged TPI records
+SUMMARY-NEXT:                  170 Merged IPI records
+SUMMARY-NEXT:                    5 Output PDB strings
+SUMMARY-NEXT:                  167 Global symbol records
+SUMMARY-NEXT:                   20 Module symbol records
+SUMMARY-NEXT:                    3 Public symbol records
 
 // precomp.h
 #pragma once

--- a/lld/test/COFF/precomp-summary-fail.test
+++ b/lld/test/COFF/precomp-summary-fail.test
@@ -11,14 +11,15 @@ RUN:    /dll /out:%t.dll /debug /summary | FileCheck %s -check-prefix SUMMARY
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:               2 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT:               0 PDB type server dependencies
-SUMMARY-NEXT:               1 Precomp OBJ dependencies
-SUMMARY-NEXT:               8 Input type records
-SUMMARY-NEXT:             232 Input type records bytes
-SUMMARY-NEXT:               3 Merged TPI records
-SUMMARY-NEXT:               2 Merged IPI records
-SUMMARY-NEXT:               1 Output PDB strings
-SUMMARY-NEXT:               0 Global symbol records
-SUMMARY-NEXT:               4 Module symbol records
-SUMMARY-NEXT:               0 Public symbol records
+SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT:                    0 PDB type server dependencies
+SUMMARY-NEXT:                    1 Precomp OBJ dependencies
+SUMMARY-NEXT:                    8 Input type records
+SUMMARY-NEXT:                  232 Input type records bytes
+SUMMARY-NEXT:                    3 Merged TPI records
+SUMMARY-NEXT:                    2 Merged IPI records
+SUMMARY-NEXT:                    1 Output PDB strings
+SUMMARY-NEXT:                    0 Global symbol records
+SUMMARY-NEXT:                    4 Module symbol records
+SUMMARY-NEXT:                    0 Public symbol records

--- a/lld/test/COFF/precomp-summary-fail.test
+++ b/lld/test/COFF/precomp-summary-fail.test
@@ -12,11 +12,11 @@ RUN:    /dll /out:%t.dll /debug /summary | FileCheck %s -check-prefix SUMMARY
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
 SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy)
+SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    0 PDB type server dependencies
 SUMMARY-NEXT:                    1 Precomp OBJ dependencies
 SUMMARY-NEXT:                    8 Input type records
-SUMMARY-NEXT:                  232 Input type records bytes
+SUMMARY-NEXT:                  232 Size of all input type records, in bytes
 SUMMARY-NEXT:                    3 Merged TPI records
 SUMMARY-NEXT:                    2 Merged IPI records
 SUMMARY-NEXT:                    1 Output PDB strings


### PR DESCRIPTION
When `/summary` is used, we now also display the cumulative size of all input OBJ files, including those pulled from archives. Lazy OBJ files that were not pulled in are not accounted for.

Also added separators between digit groups, to make the output more bearable.

Example output:
```
> lld-link ... /summary
                                    Summary
--------------------------------------------------------------------------------
               4,958 Input OBJ files (expanded from all cmd-line inputs)
      46,715,790,512 Size of all consumed OBJ files (non-lazy), in bytes
                  42 PDB type server dependencies
                   0 Precomp OBJ dependencies
         293,910,064 Input type records
      16,931,361,928 Size of all input type records, in bytes
          11,201,549 Merged TPI records
           2,765,494 Merged IPI records
              38,649 Output PDB strings
          21,512,230 Global symbol records
          82,380,837 Module symbol records
             715,313 Public symbol records
```

I've skipped over the exact amounts for "Size of all consumed inputs (non-lazy)" in the unit tests, since the sizes of OBJ files can fluctuate between compilers.