### PR TITLE
Revert "[LLD][COFF] Display the size of all consumed inputs with `/summary`"

### DIFF
--- a/lld/COFF/COFFLinkerContext.h
+++ b/lld/COFF/COFFLinkerContext.h
@@ -61,7 +61,6 @@ public:
   std::vector<ObjFile *> objFileInstances;
   std::map<std::string, PDBInputFile *> pdbInputFileInstances;
   std::vector<ImportFile *> importFileInstances;
-  std::int64_t consumedInputsSize = 0;
 
   MergeChunk *mergeChunkInstances[Log2MaxSectionAlignment + 1] = {};
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -205,7 +205,6 @@ void LinkerDriver::addFile(InputFile *file) {
     else
       cast<ObjFile>(file)->parseLazy();
   } else {
-    ctx.consumedInputsSize += file->mb.getBufferSize();
     file->parse();
     if (auto *f = dyn_cast<ObjFile>(file)) {
       ctx.objFileInstances.push_back(f);

--- a/lld/COFF/PDB.cpp
+++ b/lld/COFF/PDB.cpp
@@ -44,7 +44,6 @@
 #include "llvm/Object/CVDebugRecord.h"
 #include "llvm/Support/CRC.h"
 #include "llvm/Support/Endian.h"
-#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/ScopedPrinter.h"
@@ -1248,19 +1247,15 @@ void PDBLinker::printStats() {
          << std::string(80, '-') << '\n';
 
   auto print = [&](uint64_t v, StringRef s) {
-    stream << formatv("{0}",
-                      fmt_align(formatv("{0:N}", v), AlignStyle::Right, 20))
-           << " " << s << '\n';
+    stream << format_decimal(v, 15) << " " << s << '\n';
   };
 
   print(ctx.objFileInstances.size(),
         "Input OBJ files (expanded from all cmd-line inputs)");
-  print(ctx.consumedInputsSize,
-        "Size of all consumed OBJ files (non-lazy), in bytes");
   print(ctx.typeServerSourceMappings.size(), "PDB type server dependencies");
   print(ctx.precompSourceMappings.size(), "Precomp OBJ dependencies");
   print(nbTypeRecords, "Input type records");
-  print(nbTypeRecordsBytes, "Size of all input type records, in bytes");
+  print(nbTypeRecordsBytes, "Input type records bytes");
   print(builder.getTpiBuilder().getRecordCount(), "Merged TPI records");
   print(builder.getIpiBuilder().getRecordCount(), "Merged IPI records");
   print(pdbStrTab.size(), "Output PDB strings");

--- a/lld/test/COFF/pdb-type-server-simple.test
+++ b/lld/test/COFF/pdb-type-server-simple.test
@@ -106,18 +106,17 @@ CHECK-LABEL:   Mod 0002 | `* Linker *`:
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
-SUMMARY-NEXT:                    1 PDB type server dependencies
-SUMMARY-NEXT:                    0 Precomp OBJ dependencies
-SUMMARY-NEXT:                   25 Input type records
-SUMMARY-NEXT:                  868 Size of all input type records, in bytes
-SUMMARY-NEXT:                    9 Merged TPI records
-SUMMARY-NEXT:                   16 Merged IPI records
-SUMMARY-NEXT:                    3 Output PDB strings
-SUMMARY-NEXT:                    4 Global symbol records
-SUMMARY-NEXT:                   14 Module symbol records
-SUMMARY-NEXT:                    2 Public symbol records
+SUMMARY-NEXT:               2 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT:               1 PDB type server dependencies
+SUMMARY-NEXT:               0 Precomp OBJ dependencies
+SUMMARY-NEXT:              25 Input type records
+SUMMARY-NEXT:             868 Input type records bytes
+SUMMARY-NEXT:               9 Merged TPI records
+SUMMARY-NEXT:              16 Merged IPI records
+SUMMARY-NEXT:               3 Output PDB strings
+SUMMARY-NEXT:               4 Global symbol records
+SUMMARY-NEXT:              14 Module symbol records
+SUMMARY-NEXT:               2 Public symbol records
 
 SUMMARY:      Top 10 types responsible for the most TPI input:
 SUMMARY-NEXT:        index     total bytes   count     size

--- a/lld/test/COFF/precomp-link-samename.test
+++ b/lld/test/COFF/precomp-link-samename.test
@@ -12,10 +12,9 @@ CHECK-NOT: LF_ENDPRECOMP
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:                    4 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
-SUMMARY-NEXT:                    0 PDB type server dependencies
-SUMMARY-NEXT:                    2 Precomp OBJ dependencies
+SUMMARY-NEXT:               4 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT:               0 PDB type server dependencies
+SUMMARY-NEXT:               2 Precomp OBJ dependencies
 
 // precompa/precomp.cpp
 #include "precomp.h"

--- a/lld/test/COFF/precomp-link.test
+++ b/lld/test/COFF/precomp-link.test
@@ -59,18 +59,17 @@ CHECK-NOT: LF_ENDPRECOMP
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:                    3 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
-SUMMARY-NEXT:                    0 PDB type server dependencies
-SUMMARY-NEXT:                    1 Precomp OBJ dependencies
-SUMMARY-NEXT:                1,066 Input type records
-SUMMARY-NEXT:               55,968 Size of all input type records, in bytes
-SUMMARY-NEXT:                  874 Merged TPI records
-SUMMARY-NEXT:                  170 Merged IPI records
-SUMMARY-NEXT:                    5 Output PDB strings
-SUMMARY-NEXT:                  167 Global symbol records
-SUMMARY-NEXT:                   20 Module symbol records
-SUMMARY-NEXT:                    3 Public symbol records
+SUMMARY-NEXT:               3 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT:               0 PDB type server dependencies
+SUMMARY-NEXT:               1 Precomp OBJ dependencies
+SUMMARY-NEXT:            1066 Input type records
+SUMMARY-NEXT:           55968 Input type records bytes
+SUMMARY-NEXT:             874 Merged TPI records
+SUMMARY-NEXT:             170 Merged IPI records
+SUMMARY-NEXT:               5 Output PDB strings
+SUMMARY-NEXT:             167 Global symbol records
+SUMMARY-NEXT:              20 Module symbol records
+SUMMARY-NEXT:               3 Public symbol records
 
 // precomp.h
 #pragma once

--- a/lld/test/COFF/precomp-summary-fail.test
+++ b/lld/test/COFF/precomp-summary-fail.test
@@ -11,15 +11,14 @@ RUN:    /dll /out:%t.dll /debug /summary | FileCheck %s -check-prefix SUMMARY
 
 SUMMARY:                                     Summary
 SUMMARY-NEXT: --------------------------------------------------------------------------------
-SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line inputs)
-SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
-SUMMARY-NEXT:                    0 PDB type server dependencies
-SUMMARY-NEXT:                    1 Precomp OBJ dependencies
-SUMMARY-NEXT:                    8 Input type records
-SUMMARY-NEXT:                  232 Size of all input type records, in bytes
-SUMMARY-NEXT:                    3 Merged TPI records
-SUMMARY-NEXT:                    2 Merged IPI records
-SUMMARY-NEXT:                    1 Output PDB strings
-SUMMARY-NEXT:                    0 Global symbol records
-SUMMARY-NEXT:                    4 Module symbol records
-SUMMARY-NEXT:                    0 Public symbol records
+SUMMARY-NEXT:               2 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NEXT:               0 PDB type server dependencies
+SUMMARY-NEXT:               1 Precomp OBJ dependencies
+SUMMARY-NEXT:               8 Input type records
+SUMMARY-NEXT:             232 Input type records bytes
+SUMMARY-NEXT:               3 Merged TPI records
+SUMMARY-NEXT:               2 Merged IPI records
+SUMMARY-NEXT:               1 Output PDB strings
+SUMMARY-NEXT:               0 Global symbol records
+SUMMARY-NEXT:               4 Module symbol records
+SUMMARY-NEXT:               0 Public symbol records


### PR DESCRIPTION
Reverts llvm/llvm-project#157279