### PR TITLE
[NFC][libc++] Fix typo in `libcxx/include/__memory/pointer_traits.h`

### DIFF
--- a/libcxx/include/__memory/pointer_traits.h
+++ b/libcxx/include/__memory/pointer_traits.h
@@ -255,7 +255,7 @@ concept __resettable_smart_pointer_with_args = requires(_Smart __s, _Pointer __p
 // This function ensures safe conversions between fancy pointers at compile-time, where we avoid casts from/to
 // `__void_pointer` by obtaining the underlying raw pointer from the fancy pointer using `std::to_address`,
 // then dereferencing it to retrieve the pointed-to object, and finally constructing the target fancy pointer
-// to that object using the `std::pointer_traits<>::pinter_to` function.
+// to that object using the `std::pointer_traits<>::pointer_to` function.
 template <class _PtrTo, class _PtrFrom>
 _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI _PtrTo __static_fancy_pointer_cast(const _PtrFrom& __p) {
   using __ptr_traits   = pointer_traits<_PtrTo>;


### PR DESCRIPTION
* Apply the typo fix as a separate NFC patch from here: https://github.com/llvm/llvm-project/pull/134330/files#r2313015079