### PR TITLE
[LLD] Recognize 'mipspe' as a PE target name

### DIFF
--- a/lld/Common/DriverDispatcher.cpp
+++ b/lld/Common/DriverDispatcher.cpp
@@ -45,7 +45,7 @@ static cl::TokenizerCallback getDefaultQuotingStyle() {
 
 static bool isPETargetName(StringRef s) {
   return s == "i386pe" || s == "i386pep" || s == "thumb2pe" || s == "arm64pe" ||
-         s == "arm64ecpe" || s == "arm64xpe";
+         s == "arm64ecpe" || s == "arm64xpe" || s == "mipspe";
 }
 
 static std::optional<bool> isPETarget(llvm::ArrayRef<const char *> args) {

--- a/lld/test/MinGW/driver.test
+++ b/lld/test/MinGW/driver.test
@@ -296,6 +296,7 @@ RUN: not ld.lld -m i386pep --foo 2>&1 | FileCheck -check-prefix UNKNOWN_ARG %s
 UNKNOWN_ARG: error: unknown argument: --foo
 
 RUN: not ld.lld -m i386pep 2>&1 | FileCheck -check-prefix NO_INPUT_FILES %s
+RUN: not ld.lld -m mipspe 2>&1 | FileCheck -check-prefix NO_INPUT_FILES %s
 NO_INPUT_FILES: error: no input files
 
 RUN: ld.lld -### -m i386pep foo.o 2>&1 | FileCheck -check-prefix ENABLE_AUTO_IMPORT %s


### PR DESCRIPTION
When compiling for target `mipsel-windows-gnu` triple, clang is calling linker with `mipspe` machine.
Handle this case.