### PR TITLE
[ADT] Clean up fwd_or_bidi_tag with std::conditional_t (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -535,31 +535,22 @@ public:
 
 namespace detail {
 
-template <bool is_bidirectional> struct fwd_or_bidi_tag_impl {
-  using type = std::forward_iterator_tag;
-};
-
-template <> struct fwd_or_bidi_tag_impl<true> {
-  using type = std::bidirectional_iterator_tag;
-};
-
-/// Helper which sets its type member to forward_iterator_tag if the category
-/// of \p IterT does not derive from bidirectional_iterator_tag, and to
-/// bidirectional_iterator_tag otherwise.
-template <typename IterT> struct fwd_or_bidi_tag {
-  using type = typename fwd_or_bidi_tag_impl<std::is_base_of<
-      std::bidirectional_iterator_tag,
-      typename std::iterator_traits<IterT>::iterator_category>::value>::type;
-};
+/// A type alias which is std::bidirectional_iterator_tag if the category of
+/// \p IterT derives from it, and std::forward_iterator_tag otherwise.
+template <typename IterT>
+using fwd_or_bidi_tag = std::conditional_t<
+    std::is_base_of_v<std::bidirectional_iterator_tag,
+                      typename std::iterator_traits<IterT>::iterator_category>,
+    std::bidirectional_iterator_tag, std::forward_iterator_tag>;
 
 } // namespace detail
 
 /// Defines filter_iterator to a suitable specialization of
 /// filter_iterator_impl, based on the underlying iterator's category.
 template <typename WrappedIteratorT, typename PredicateT>
-using filter_iterator = filter_iterator_impl<
-    WrappedIteratorT, PredicateT,
-    typename detail::fwd_or_bidi_tag<WrappedIteratorT>::type>;
+using filter_iterator =
+    filter_iterator_impl<WrappedIteratorT, PredicateT,
+                         detail::fwd_or_bidi_tag<WrappedIteratorT>>;
 
 /// Convenience function that takes a range of elements and a predicate,
 /// and return a new filter_iterator range.


### PR DESCRIPTION
fwd_or_bidi_tag selects one of two implementations of
fwd_or_bidi_tag_impl depending on the condition.  We can replace it
with std::conditional_t, eliminating the need for helper structs
fwd_or_bidi_tag_impl.

This patch also converts the fwd_or_bidi_tag struct into an alias
template, making "using filter_iterator" a little more readable.
