### PR TITLE
[Support] Simplify Object::operator== (NFC)

### DIFF
--- a/llvm/include/llvm/Support/JSON.h
+++ b/llvm/include/llvm/Support/JSON.h
@@ -153,6 +153,8 @@ public:
   LLVM_ABI json::Object *getObject(StringRef K);
   LLVM_ABI const json::Array *getArray(StringRef K) const;
   LLVM_ABI json::Array *getArray(StringRef K);
+
+  friend bool operator==(const Object &LHS, const Object &RHS);
 };
 LLVM_ABI bool operator==(const Object &LHS, const Object &RHS);
 inline bool operator!=(const Object &LHS, const Object &RHS) {

--- a/llvm/lib/Support/JSON.cpp
+++ b/llvm/lib/Support/JSON.cpp
@@ -84,16 +84,7 @@ json::Array *Object::getArray(StringRef K) {
     return V->getAsArray();
   return nullptr;
 }
-bool operator==(const Object &LHS, const Object &RHS) {
-  if (LHS.size() != RHS.size())
-    return false;
-  for (const auto &L : LHS) {
-    auto R = RHS.find(L.first);
-    if (R == RHS.end() || L.second != R->second)
-      return false;
-  }
-  return true;
-}
+bool operator==(const Object &LHS, const Object &RHS) { return LHS.M == RHS.M; }
 
 Array::Array(std::initializer_list<Value> Elements) {
   V.reserve(Elements.size());


### PR DESCRIPTION
This patch simplifies Object::operator== with DenseMap::operator==.
