### PR TITLE
MC: Add Triple overloads for more MC constructors

### DIFF
--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -207,7 +207,7 @@ Expected<std::unique_ptr<BinaryContext>> BinaryContext::createBinaryContext(
                              Twine("BOLT-ERROR: ", Error));
 
   std::unique_ptr<const MCRegisterInfo> MRI(
-      TheTarget->createMCRegInfo(TripleName));
+      TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     return createStringError(
         make_error_code(std::errc::not_supported),
@@ -215,7 +215,7 @@ Expected<std::unique_ptr<BinaryContext>> BinaryContext::createBinaryContext(
 
   // Set up disassembler.
   std::unique_ptr<MCAsmInfo> AsmInfo(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCTargetOptions()));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCTargetOptions()));
   if (!AsmInfo)
     return createStringError(
         make_error_code(std::errc::not_supported),
@@ -227,7 +227,7 @@ Expected<std::unique_ptr<BinaryContext>> BinaryContext::createBinaryContext(
   AsmInfo->setAllowAtInName(true);
 
   std::unique_ptr<const MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, "", FeaturesStr));
+      TheTarget->createMCSubtargetInfo(TheTriple, "", FeaturesStr));
   if (!STI)
     return createStringError(
         make_error_code(std::errc::not_supported),

--- a/clang/lib/Parse/ParseStmtAsm.cpp
+++ b/clang/lib/Parse/ParseStmtAsm.cpp
@@ -543,7 +543,8 @@ StmtResult Parser::ParseMicrosoftAsmStatement(SourceLocation AsmLoc) {
   std::string FeaturesStr =
       llvm::join(TO.Features.begin(), TO.Features.end(), ",");
 
-  std::unique_ptr<llvm::MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
+  std::unique_ptr<llvm::MCRegisterInfo> MRI(
+      TheTarget->createMCRegInfo(TheTriple));
   if (!MRI) {
     Diag(AsmLoc, diag::err_msasm_unable_to_create_target)
         << "target MC unavailable";
@@ -552,11 +553,11 @@ StmtResult Parser::ParseMicrosoftAsmStatement(SourceLocation AsmLoc) {
   // FIXME: init MCOptions from sanitizer flags here.
   llvm::MCTargetOptions MCOptions;
   std::unique_ptr<llvm::MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   // Get the instruction descriptor.
   std::unique_ptr<llvm::MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<llvm::MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TT, TO.CPU, FeaturesStr));
+      TheTarget->createMCSubtargetInfo(TheTriple, TO.CPU, FeaturesStr));
   // Target MCTargetDesc may not be linked in clang-based tools.
 
   if (!MAI || !MII || !STI) {
@@ -591,7 +592,7 @@ StmtResult Parser::ParseMicrosoftAsmStatement(SourceLocation AsmLoc) {
   }
 
   std::unique_ptr<llvm::MCInstPrinter> IP(
-      TheTarget->createMCInstPrinter(llvm::Triple(TT), 1, *MAI, *MII, *MRI));
+      TheTarget->createMCInstPrinter(TheTriple, 1, *MAI, *MII, *MRI));
 
   // Change to the Intel dialect.
   Parser->setAssemblerDialect(1);

--- a/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
+++ b/lldb/source/Plugins/Disassembler/LLVMC/DisassemblerLLVMC.cpp
@@ -1249,11 +1249,14 @@ private:
 };
 
 std::unique_ptr<DisassemblerLLVMC::MCDisasmInstance>
-DisassemblerLLVMC::MCDisasmInstance::Create(const char *triple, const char *cpu,
+DisassemblerLLVMC::MCDisasmInstance::Create(const char *triple_name,
+                                            const char *cpu,
                                             const char *features_str,
                                             unsigned flavor,
                                             DisassemblerLLVMC &owner) {
   using Instance = std::unique_ptr<DisassemblerLLVMC::MCDisasmInstance>;
+
+  llvm::Triple triple(triple_name);
 
   std::string Status;
   const llvm::Target *curr_target =

--- a/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
@@ -147,17 +147,15 @@ EmulateInstructionMIPS::EmulateInstructionMIPS(
   if (arch_flags & ArchSpec::eMIPSAse_dspr2)
     features += "+dspr2,";
 
-  m_reg_info.reset(target->createMCRegInfo(triple.getTriple()));
+  m_reg_info.reset(target->createMCRegInfo(triple));
   assert(m_reg_info.get());
 
   m_insn_info.reset(target->createMCInstrInfo());
   assert(m_insn_info.get());
 
   llvm::MCTargetOptions MCOptions;
-  m_asm_info.reset(
-      target->createMCAsmInfo(*m_reg_info, triple.getTriple(), MCOptions));
-  m_subtype_info.reset(
-      target->createMCSubtargetInfo(triple.getTriple(), cpu, features));
+  m_asm_info.reset(target->createMCAsmInfo(*m_reg_info, triple, MCOptions));
+  m_subtype_info.reset(target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_asm_info.get() && m_subtype_info.get());
 
   m_context = std::make_unique<llvm::MCContext>(
@@ -1005,11 +1003,10 @@ bool EmulateInstructionMIPS::SetInstruction(const Opcode &insn_opcode,
       uint64_t next_inst_addr = (m_addr & (~1ull)) + current_inst_size;
       Address next_addr(next_inst_addr);
 
-      const size_t bytes_read =
-          target->ReadMemory(next_addr, /* Address of next instruction */
-                             buf, sizeof(uint32_t), error, 
-                             false,  /* force_live_memory */
-                             &load_addr);
+      const size_t bytes_read = target->ReadMemory(
+          next_addr,                           /* Address of next instruction */
+          buf, sizeof(uint32_t), error, false, /* force_live_memory */
+          &load_addr);
 
       if (bytes_read == 0)
         return true;

--- a/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS/EmulateInstructionMIPS.cpp
@@ -172,7 +172,7 @@ EmulateInstructionMIPS::EmulateInstructionMIPS(
     features += "+micromips,";
 
   m_alt_subtype_info.reset(
-      target->createMCSubtargetInfo(triple.getTriple(), cpu, features));
+      target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_alt_subtype_info.get());
 
   m_alt_disasm.reset(

--- a/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
+++ b/lldb/source/Plugins/Instruction/MIPS64/EmulateInstructionMIPS64.cpp
@@ -151,17 +151,15 @@ EmulateInstructionMIPS64::EmulateInstructionMIPS64(
   if (arch_flags & ArchSpec::eMIPSAse_micromips)
     features += "+micromips,";
 
-  m_reg_info.reset(target->createMCRegInfo(triple.getTriple()));
+  m_reg_info.reset(target->createMCRegInfo(triple));
   assert(m_reg_info.get());
 
   m_insn_info.reset(target->createMCInstrInfo());
   assert(m_insn_info.get());
 
   llvm::MCTargetOptions MCOptions;
-  m_asm_info.reset(
-      target->createMCAsmInfo(*m_reg_info, triple.getTriple(), MCOptions));
-  m_subtype_info.reset(
-      target->createMCSubtargetInfo(triple.getTriple(), cpu, features));
+  m_asm_info.reset(target->createMCAsmInfo(*m_reg_info, triple, MCOptions));
+  m_subtype_info.reset(target->createMCSubtargetInfo(triple, cpu, features));
   assert(m_asm_info.get() && m_subtype_info.get());
 
   m_context = std::make_unique<llvm::MCContext>(

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -232,13 +232,13 @@ bool ABI::GetFallbackRegisterLocation(
 }
 
 std::unique_ptr<llvm::MCRegisterInfo> ABI::MakeMCRegisterInfo(const ArchSpec &arch) {
-  std::string triple = arch.GetTriple().getTriple();
+  const llvm::Triple &triple = arch.GetTriple();
   std::string lookup_error;
   const llvm::Target *target =
       llvm::TargetRegistry::lookupTarget(triple, lookup_error);
   if (!target) {
     LLDB_LOG(GetLog(LLDBLog::Process),
-             "Failed to create an llvm target for {0}: {1}", triple,
+             "Failed to create an llvm target for {0}: {1}", triple.str(),
              lookup_error);
     return nullptr;
   }

--- a/llvm/include/llvm/MC/TargetRegistry.h
+++ b/llvm/include/llvm/MC/TargetRegistry.h
@@ -389,18 +389,26 @@ public:
   /// @name Feature Constructors
   /// @{
 
-  /// createMCAsmInfo - Create a MCAsmInfo implementation for the specified
+  [[deprecated("Use overload accepting Triple instead")]]
+  MCAsmInfo *createMCAsmInfo(const MCRegisterInfo &MRI, StringRef TheTriple,
+                             const MCTargetOptions &Options) const {
+    if (!MCAsmInfoCtorFn)
+      return nullptr;
+    return MCAsmInfoCtorFn(MRI, Triple(TheTriple), Options);
+  }
+
+  /// Create a MCAsmInfo implementation for the specified
   /// target triple.
   ///
   /// \param TheTriple This argument is used to determine the target machine
   /// feature set; it should always be provided. Generally this should be
   /// either the target triple from the module, or the target triple of the
   /// host if that does not exist.
-  MCAsmInfo *createMCAsmInfo(const MCRegisterInfo &MRI, StringRef TheTriple,
+  MCAsmInfo *createMCAsmInfo(const MCRegisterInfo &MRI, const Triple &TheTriple,
                              const MCTargetOptions &Options) const {
     if (!MCAsmInfoCtorFn)
       return nullptr;
-    return MCAsmInfoCtorFn(MRI, Triple(TheTriple), Options);
+    return MCAsmInfoCtorFn(MRI, TheTriple, Options);
   }
 
   /// Create a MCObjectFileInfo implementation for the specified target
@@ -432,12 +440,26 @@ public:
     return MCInstrAnalysisCtorFn(Info);
   }
 
-  /// createMCRegInfo - Create a MCRegisterInfo implementation.
-  ///
+  [[deprecated("Use overload accepting Triple instead")]]
   MCRegisterInfo *createMCRegInfo(StringRef TT) const {
     if (!MCRegInfoCtorFn)
       return nullptr;
     return MCRegInfoCtorFn(Triple(TT));
+  }
+
+  /// Create a MCRegisterInfo implementation.
+  MCRegisterInfo *createMCRegInfo(const Triple &TT) const {
+    if (!MCRegInfoCtorFn)
+      return nullptr;
+    return MCRegInfoCtorFn(TT);
+  }
+
+  [[deprecated("Use overload accepting Triple instead")]]
+  MCSubtargetInfo *createMCSubtargetInfo(StringRef TheTriple, StringRef CPU,
+                                         StringRef Features) const {
+    if (!MCSubtargetInfoCtorFn)
+      return nullptr;
+    return MCSubtargetInfoCtorFn(Triple(TheTriple), CPU, Features);
   }
 
   /// createMCSubtargetInfo - Create a MCSubtargetInfo implementation.
@@ -449,11 +471,11 @@ public:
   /// \param CPU This specifies the name of the target CPU.
   /// \param Features This specifies the string representation of the
   /// additional target features.
-  MCSubtargetInfo *createMCSubtargetInfo(StringRef TheTriple, StringRef CPU,
+  MCSubtargetInfo *createMCSubtargetInfo(const Triple &TheTriple, StringRef CPU,
                                          StringRef Features) const {
     if (!MCSubtargetInfoCtorFn)
       return nullptr;
-    return MCSubtargetInfoCtorFn(Triple(TheTriple), CPU, Features);
+    return MCSubtargetInfoCtorFn(TheTriple, CPU, Features);
   }
 
   /// createTargetMachine - Create a target specific machine implementation
@@ -577,15 +599,31 @@ public:
     return nullptr;
   }
 
+  [[deprecated("Use overload accepting Triple instead")]]
+  MCRelocationInfo *createMCRelocationInfo(StringRef TT, MCContext &Ctx) const {
+    return createMCRelocationInfo(Triple(TT), Ctx);
+  }
+
   /// createMCRelocationInfo - Create a target specific MCRelocationInfo.
   ///
   /// \param TT The target triple.
   /// \param Ctx The target context.
-  MCRelocationInfo *createMCRelocationInfo(StringRef TT, MCContext &Ctx) const {
+  MCRelocationInfo *createMCRelocationInfo(const Triple &TT,
+                                           MCContext &Ctx) const {
     MCRelocationInfoCtorTy Fn = MCRelocationInfoCtorFn
                                     ? MCRelocationInfoCtorFn
                                     : llvm::createMCRelocationInfo;
-    return Fn(Triple(TT), Ctx);
+    return Fn(TT, Ctx);
+  }
+
+  [[deprecated("Use overload accepting Triple instead")]]
+  MCSymbolizer *
+  createMCSymbolizer(StringRef TT, LLVMOpInfoCallback GetOpInfo,
+                     LLVMSymbolLookupCallback SymbolLookUp, void *DisInfo,
+                     MCContext *Ctx,
+                     std::unique_ptr<MCRelocationInfo> &&RelInfo) const {
+    return createMCSymbolizer(Triple(TT), GetOpInfo, SymbolLookUp, DisInfo, Ctx,
+                              std::move(RelInfo));
   }
 
   /// createMCSymbolizer - Create a target specific MCSymbolizer.
@@ -601,14 +639,13 @@ public:
   /// \param RelInfo The relocation information for this target. Takes
   /// ownership.
   MCSymbolizer *
-  createMCSymbolizer(StringRef TT, LLVMOpInfoCallback GetOpInfo,
+  createMCSymbolizer(const Triple &TT, LLVMOpInfoCallback GetOpInfo,
                      LLVMSymbolLookupCallback SymbolLookUp, void *DisInfo,
                      MCContext *Ctx,
                      std::unique_ptr<MCRelocationInfo> &&RelInfo) const {
     MCSymbolizerCtorTy Fn =
         MCSymbolizerCtorFn ? MCSymbolizerCtorFn : llvm::createMCSymbolizer;
-    return Fn(Triple(TT), GetOpInfo, SymbolLookUp, DisInfo, Ctx,
-              std::move(RelInfo));
+    return Fn(TT, GetOpInfo, SymbolLookUp, DisInfo, Ctx, std::move(RelInfo));
   }
 
   /// createCustomBehaviour - Create a target specific CustomBehaviour.

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -45,7 +45,7 @@ static cl::opt<bool> EnableNoTrapAfterNoreturn(
              "after noreturn calls, even if --trap-unreachable is set."));
 
 void CodeGenTargetMachineImpl::initAsmInfo() {
-  MRI.reset(TheTarget.createMCRegInfo(getTargetTriple().str()));
+  MRI.reset(TheTarget.createMCRegInfo(getTargetTriple()));
   assert(MRI && "Unable to create reg info");
   MII.reset(TheTarget.createMCInstrInfo());
   assert(MII && "Unable to create instruction info");
@@ -53,12 +53,12 @@ void CodeGenTargetMachineImpl::initAsmInfo() {
   // to some backends having subtarget feature dependent module level
   // code generation. This is similar to the hack in the AsmPrinter for
   // module level assembly etc.
-  STI.reset(TheTarget.createMCSubtargetInfo(
-      getTargetTriple().str(), getTargetCPU(), getTargetFeatureString()));
+  STI.reset(TheTarget.createMCSubtargetInfo(getTargetTriple(), getTargetCPU(),
+                                            getTargetFeatureString()));
   assert(STI && "Unable to create subtarget info");
 
-  MCAsmInfo *TmpAsmInfo = TheTarget.createMCAsmInfo(
-      *MRI, getTargetTriple().str(), Options.MCOptions);
+  MCAsmInfo *TmpAsmInfo =
+      TheTarget.createMCAsmInfo(*MRI, getTargetTriple(), Options.MCOptions);
   // TargetSelect.h moved to a different directory between LLVM 2.9 and 3.0,
   // and if the old one gets included then MCAsmInfo will be NULL and
   // we'll crash later.

--- a/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFStreamer.cpp
@@ -55,7 +55,7 @@ Error DwarfStreamer::init(Triple TheTriple,
   TripleName = TheTriple.getTriple();
 
   // Create all the MC Objects.
-  MRI.reset(TheTarget->createMCRegInfo(TripleName));
+  MRI.reset(TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     return createStringError(std::errc::invalid_argument,
                              "no register info for target %s",
@@ -64,12 +64,12 @@ Error DwarfStreamer::init(Triple TheTriple,
   MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
   MCOptions.AsmVerbose = true;
   MCOptions.MCUseDwarfDirectory = MCTargetOptions::EnableDwarfDirectory;
-  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     return createStringError(std::errc::invalid_argument,
                              "no asm info for target %s", TripleName.c_str());
 
-  MSTI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+  MSTI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   if (!MSTI)
     return createStringError(std::errc::invalid_argument,
                              "no subtarget info for target %s",

--- a/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
+++ b/llvm/lib/DWARFLinker/Parallel/DWARFEmitterImpl.cpp
@@ -35,7 +35,7 @@ Error DwarfEmitterImpl::init(Triple TheTriple,
   TripleName = TheTriple.getTriple();
 
   // Create all the MC Objects.
-  MRI.reset(TheTarget->createMCRegInfo(TripleName));
+  MRI.reset(TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     return createStringError(std::errc::invalid_argument,
                              "no register info for target %s",
@@ -44,12 +44,12 @@ Error DwarfEmitterImpl::init(Triple TheTriple,
   MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
   MCOptions.AsmVerbose = true;
   MCOptions.MCUseDwarfDirectory = MCTargetOptions::EnableDwarfDirectory;
-  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     return createStringError(std::errc::invalid_argument,
                              "no asm info for target %s", TripleName.c_str());
 
-  MSTI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+  MSTI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   if (!MSTI)
     return createStringError(std::errc::invalid_argument,
                              "no subtarget info for target %s",

--- a/llvm/lib/DWARFLinker/Parallel/DebugLineSectionEmitter.h
+++ b/llvm/lib/DWARFLinker/Parallel/DebugLineSectionEmitter.h
@@ -73,19 +73,19 @@ private:
     TripleName = TheTriple.getTriple();
 
     // Create all the MC Objects.
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
+    MRI.reset(TheTarget->createMCRegInfo(TheTriple));
     if (!MRI)
       return createStringError(std::errc::invalid_argument,
                                "no register info for target %s",
                                TripleName.c_str());
 
     MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
     if (!MAI)
       return createStringError(std::errc::invalid_argument,
                                "no asm info for target %s", TripleName.c_str());
 
-    MSTI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+    MSTI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
     if (!MSTI)
       return createStringError(std::errc::invalid_argument,
                                "no subtarget info for target %s",

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldChecker.cpp
@@ -767,13 +767,13 @@ private:
                                      inconvertibleErrorCode());
 
     std::unique_ptr<MCSubtargetInfo> STI(
-        TheTarget->createMCSubtargetInfo(TripleName, CPU, TF.getString()));
+        TheTarget->createMCSubtargetInfo(TT, CPU, TF.getString()));
     if (!STI)
       return make_error<StringError>("Unable to create subtarget for " +
                                          TripleName,
                                      inconvertibleErrorCode());
 
-    std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+    std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
     if (!MRI)
       return make_error<StringError>("Unable to create target register info "
                                      "for " +
@@ -782,7 +782,7 @@ private:
 
     MCTargetOptions MCOptions;
     std::unique_ptr<MCAsmInfo> MAI(
-        TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+        TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
     if (!MAI)
       return make_error<StringError>("Unable to create target asm info " +
                                          TripleName,

--- a/llvm/lib/MC/MCDisassembler/Disassembler.cpp
+++ b/llvm/lib/MC/MCDisassembler/Disassembler.cpp
@@ -50,14 +50,16 @@ LLVMCreateDisasmCPUFeatures(const char *TT, const char *CPU,
   if (!TheTarget)
     return nullptr;
 
-  std::unique_ptr<const MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
+  Triple TheTriple(TT);
+  std::unique_ptr<const MCRegisterInfo> MRI(
+      TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     return nullptr;
 
   MCTargetOptions MCOptions;
   // Get the assembler info needed to setup the MCContext.
   std::unique_ptr<const MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     return nullptr;
 
@@ -66,13 +68,13 @@ LLVMCreateDisasmCPUFeatures(const char *TT, const char *CPU,
     return nullptr;
 
   std::unique_ptr<const MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TT, CPU, Features));
+      TheTarget->createMCSubtargetInfo(TheTriple, CPU, Features));
   if (!STI)
     return nullptr;
 
   // Set up the MCContext for creating symbols and MCExpr's.
   std::unique_ptr<MCContext> Ctx(
-      new MCContext(Triple(TT), MAI.get(), MRI.get(), STI.get()));
+      new MCContext(TheTriple, MAI.get(), MRI.get(), STI.get()));
   if (!Ctx)
     return nullptr;
 
@@ -83,12 +85,13 @@ LLVMCreateDisasmCPUFeatures(const char *TT, const char *CPU,
     return nullptr;
 
   std::unique_ptr<MCRelocationInfo> RelInfo(
-      TheTarget->createMCRelocationInfo(TT, *Ctx));
+      TheTarget->createMCRelocationInfo(TheTriple, *Ctx));
   if (!RelInfo)
     return nullptr;
 
-  std::unique_ptr<MCSymbolizer> Symbolizer(TheTarget->createMCSymbolizer(
-      TT, GetOpInfo, SymbolLookUp, DisInfo, Ctx.get(), std::move(RelInfo)));
+  std::unique_ptr<MCSymbolizer> Symbolizer(
+      TheTarget->createMCSymbolizer(TheTriple, GetOpInfo, SymbolLookUp, DisInfo,
+                                    Ctx.get(), std::move(RelInfo)));
   DisAsm->setSymbolizer(std::move(Symbolizer));
 
   // Set up the instruction printer.

--- a/llvm/lib/Object/ModuleSymbolTable.cpp
+++ b/llvm/lib/Object/ModuleSymbolTable.cpp
@@ -81,17 +81,16 @@ initializeRecordStreamer(const Module &M,
   const Target *T = TargetRegistry::lookupTarget(TT, Err);
   assert(T && T->hasMCAsmParser());
 
-  std::unique_ptr<MCRegisterInfo> MRI(T->createMCRegInfo(TT.str()));
+  std::unique_ptr<MCRegisterInfo> MRI(T->createMCRegInfo(TT));
   if (!MRI)
     return;
 
   MCTargetOptions MCOptions;
-  std::unique_ptr<MCAsmInfo> MAI(T->createMCAsmInfo(*MRI, TT.str(), MCOptions));
+  std::unique_ptr<MCAsmInfo> MAI(T->createMCAsmInfo(*MRI, TT, MCOptions));
   if (!MAI)
     return;
 
-  std::unique_ptr<MCSubtargetInfo> STI(
-      T->createMCSubtargetInfo(TT.str(), "", ""));
+  std::unique_ptr<MCSubtargetInfo> STI(T->createMCSubtargetInfo(TT, "", ""));
   if (!STI)
     return;
 

--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -734,7 +734,7 @@ void AArch64AsmPrinter::emitHwasanMemaccessSymbols(Module &M) {
   const Triple &TT = TM.getTargetTriple();
   assert(TT.isOSBinFormatELF());
   std::unique_ptr<MCSubtargetInfo> STI(
-      TM.getTarget().createMCSubtargetInfo(TT.str(), "", ""));
+      TM.getTarget().createMCSubtargetInfo(TT, "", ""));
   assert(STI && "Unable to create subtarget info");
   this->STI = static_cast<const AArch64Subtarget *>(&*STI);
 

--- a/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
+++ b/llvm/lib/Target/Mips/MipsAsmPrinter.cpp
@@ -967,8 +967,7 @@ void MipsAsmPrinter::EmitFPCallStub(
   // freed) and since we're at the global level we can use the default
   // constructed subtarget.
   std::unique_ptr<MCSubtargetInfo> STI(TM.getTarget().createMCSubtargetInfo(
-      TM.getTargetTriple().str(), TM.getTargetCPU(),
-      TM.getTargetFeatureString()));
+      TM.getTargetTriple(), TM.getTargetCPU(), TM.getTargetFeatureString()));
 
   //
   // .global xxxx

--- a/llvm/tools/llvm-cfi-verify/lib/FileAnalysis.cpp
+++ b/llvm/tools/llvm-cfi-verify/lib/FileAnalysis.cpp
@@ -377,6 +377,8 @@ Error FileAnalysis::initialiseDisassemblyMembers() {
   MCPU = "";
   std::string ErrorString;
 
+  Triple TheTriple(TripleName);
+
   LLVMSymbolizer::Options Opt;
   Opt.UseSymbolTable = false;
   Symbolizer.reset(new LLVMSymbolizer(Opt));
@@ -389,19 +391,19 @@ Error FileAnalysis::initialiseDisassemblyMembers() {
          "\", failed with error: " + ErrorString)
             .str());
 
-  RegisterInfo.reset(ObjectTarget->createMCRegInfo(TripleName));
+  RegisterInfo.reset(ObjectTarget->createMCRegInfo(TheTriple));
   if (!RegisterInfo)
     return make_error<UnsupportedDisassembly>(
         "Failed to initialise RegisterInfo.");
 
   MCTargetOptions MCOptions;
   AsmInfo.reset(
-      ObjectTarget->createMCAsmInfo(*RegisterInfo, TripleName, MCOptions));
+      ObjectTarget->createMCAsmInfo(*RegisterInfo, TheTriple, MCOptions));
   if (!AsmInfo)
     return make_error<UnsupportedDisassembly>("Failed to initialise AsmInfo.");
 
   SubtargetInfo.reset(ObjectTarget->createMCSubtargetInfo(
-      TripleName, MCPU, Features.getString()));
+      TheTriple, MCPU, Features.getString()));
   if (!SubtargetInfo)
     return make_error<UnsupportedDisassembly>(
         "Failed to initialise SubtargetInfo.");

--- a/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
+++ b/llvm/tools/llvm-dwarfdump/llvm-dwarfdump.cpp
@@ -678,7 +678,7 @@ createRegInfo(const object::ObjectFile &Obj) {
   const Target *TheTarget = TargetRegistry::lookupTarget(TT, TargetLookupError);
   if (!TargetLookupError.empty())
     return nullptr;
-  MCRegInfo.reset(TheTarget->createMCRegInfo(TT.str()));
+  MCRegInfo.reset(TheTarget->createMCRegInfo(TT));
   return MCRegInfo;
 }
 

--- a/llvm/tools/llvm-dwp/llvm-dwp.cpp
+++ b/llvm/tools/llvm-dwp/llvm-dwp.cpp
@@ -217,20 +217,21 @@ int llvm_dwp_main(int argc, char **argv, const llvm::ToolContext &) {
   if (!TheTarget)
     return error(ErrorStr, Context);
   std::string TripleName = ErrOrTriple->getTriple();
+  Triple TheTriple(TripleName);
 
   // Create all the MC Objects.
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     return error(Twine("no register info for target ") + TripleName, Context);
 
   MCTargetOptions MCOptions = llvm::mc::InitMCTargetOptionsFromFlags();
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     return error("no asm info for target " + TripleName, Context);
 
   std::unique_ptr<MCSubtargetInfo> MSTI(
-      TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+      TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   if (!MSTI)
     return error("no subtarget info for target " + TripleName, Context);
 

--- a/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.cpp
+++ b/llvm/tools/llvm-exegesis/lib/DisassemblerHelper.cpp
@@ -17,8 +17,8 @@ DisassemblerHelper::DisassemblerHelper(const LLVMState &State) : State_(State) {
   MCTargetOptions MCOptions;
   const auto &TM = State.getTargetMachine();
   const auto &Triple = TM.getTargetTriple();
-  AsmInfo_.reset(TM.getTarget().createMCAsmInfo(State_.getRegInfo(),
-                                                Triple.str(), MCOptions));
+  AsmInfo_.reset(
+      TM.getTarget().createMCAsmInfo(State_.getRegInfo(), Triple, MCOptions));
   InstPrinter_.reset(TM.getTarget().createMCInstPrinter(
       Triple, 0 /*default variant*/, *AsmInfo_, State_.getInstrInfo(),
       State_.getRegInfo()));

--- a/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
+++ b/llvm/tools/llvm-exegesis/lib/LlvmState.cpp
@@ -55,7 +55,7 @@ Expected<LLVMState> LLVMState::Create(std::string TripleName,
   }
 
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, CpuName, ""));
+      TheTarget->createMCSubtargetInfo(TheTriple, CpuName, ""));
   assert(STI && "Unable to create subtarget info!");
   if (!STI->isCPUStringValid(CpuName)) {
     return make_error<StringError>(Twine("invalid CPU name (")

--- a/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink.cpp
@@ -2591,13 +2591,13 @@ getTargetInfo(const Triple &TT,
                                       inconvertibleErrorCode()));
 
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, "", TF.getString()));
+      TheTarget->createMCSubtargetInfo(TT, "", TF.getString()));
   if (!STI)
     ExitOnErr(
         make_error<StringError>("Unable to create subtarget for " + TripleName,
                                 inconvertibleErrorCode()));
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
   if (!MRI)
     ExitOnErr(make_error<StringError>("Unable to create target register info "
                                       "for " +
@@ -2606,7 +2606,7 @@ getTargetInfo(const Triple &TT,
 
   MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
   if (!MAI)
     ExitOnErr(make_error<StringError>("Unable to create target asm info " +
                                           TripleName,

--- a/llvm/tools/llvm-mc/Disassembler.cpp
+++ b/llvm/tools/llvm-mc/Disassembler.cpp
@@ -165,28 +165,29 @@ static bool byteArrayFromString(ByteArrayTy &ByteArray, StringRef &Str,
   return false;
 }
 
-int Disassembler::disassemble(const Target &T, const std::string &Triple,
-                              MCSubtargetInfo &STI, MCStreamer &Streamer,
-                              MemoryBuffer &Buffer, SourceMgr &SM,
-                              MCContext &Ctx, const MCTargetOptions &MCOptions,
-                              bool HexBytes, unsigned NumBenchmarkRuns) {
-  std::unique_ptr<const MCRegisterInfo> MRI(T.createMCRegInfo(Triple));
+int Disassembler::disassemble(const Target &T, MCSubtargetInfo &STI,
+                              MCStreamer &Streamer, MemoryBuffer &Buffer,
+                              SourceMgr &SM, MCContext &Ctx,
+                              const MCTargetOptions &MCOptions, bool HexBytes,
+                              unsigned NumBenchmarkRuns) {
+  const Triple &TheTriple = STI.getTargetTriple();
+  std::unique_ptr<const MCRegisterInfo> MRI(T.createMCRegInfo(TheTriple));
   if (!MRI) {
-    errs() << "error: no register info for target " << Triple << "\n";
+    errs() << "error: no register info for target " << TheTriple.str() << '\n';
     return -1;
   }
 
   std::unique_ptr<const MCAsmInfo> MAI(
-      T.createMCAsmInfo(*MRI, Triple, MCOptions));
+      T.createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI) {
-    errs() << "error: no assembly info for target " << Triple << "\n";
+    errs() << "error: no assembly info for target " << TheTriple.str() << '\n';
     return -1;
   }
 
   std::unique_ptr<const MCDisassembler> DisAsm(
     T.createMCDisassembler(STI, Ctx));
   if (!DisAsm) {
-    errs() << "error: no disassembler for target " << Triple << "\n";
+    errs() << "error: no disassembler for target " << TheTriple.str() << '\n';
     return -1;
   }
 

--- a/llvm/tools/llvm-mc/Disassembler.h
+++ b/llvm/tools/llvm-mc/Disassembler.h
@@ -29,9 +29,9 @@ class MCTargetOptions;
 
 class Disassembler {
 public:
-  static int disassemble(const Target &T, const std::string &Triple,
-                         MCSubtargetInfo &STI, MCStreamer &Streamer,
-                         MemoryBuffer &Buffer, SourceMgr &SM, MCContext &Ctx,
+  static int disassemble(const Target &T, MCSubtargetInfo &STI,
+                         MCStreamer &Streamer, MemoryBuffer &Buffer,
+                         SourceMgr &SM, MCContext &Ctx,
                          const MCTargetOptions &MCOptions, bool HexBytes,
                          unsigned NumBenchmarkRuns);
 };

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -440,11 +440,11 @@ int main(int argc, char **argv) {
   // it later.
   SrcMgr.setIncludeDirs(IncludeDirs);
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
   assert(MRI && "Unable to create target register info!");
 
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   assert(MAI && "Unable to create target asm info!");
 
   if (CompressDebugSections != DebugCompressionType::None) {
@@ -468,7 +468,7 @@ int main(int argc, char **argv) {
   }
 
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, MCPU, FeaturesStr));
+      TheTarget->createMCSubtargetInfo(TheTriple, MCPU, FeaturesStr));
   assert(STI && "Unable to create subtarget info!");
 
   // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
@@ -652,9 +652,8 @@ int main(int argc, char **argv) {
     break;
   }
   if (disassemble)
-    Res = Disassembler::disassemble(*TheTarget, TripleName, *STI, *Str, *Buffer,
-                                    SrcMgr, Ctx, MCOptions, HexBytes,
-                                    NumBenchmarkRuns);
+    Res = Disassembler::disassemble(*TheTarget, *STI, *Str, *Buffer, SrcMgr,
+                                    Ctx, MCOptions, HexBytes, NumBenchmarkRuns);
 
   // Keep output if no errors.
   if (Res == 0) {

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -419,7 +419,7 @@ int main(int argc, char **argv) {
   }
 
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, MCPU, FeaturesStr));
+      TheTarget->createMCSubtargetInfo(TheTriple, MCPU, FeaturesStr));
   assert(STI && "Unable to create subtarget info!");
   if (!STI->isCPUStringValid(MCPU))
     return 1;
@@ -441,12 +441,12 @@ int main(int argc, char **argv) {
   bool IsOutOfOrder = STI->getSchedModel().isOutOfOrder();
   processViewOptions(IsOutOfOrder);
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
   assert(MRI && "Unable to create target register info!");
 
   MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   assert(MAI && "Unable to create target asm info!");
 
   SourceMgr SrcMgr;

--- a/llvm/tools/llvm-ml/Disassembler.cpp
+++ b/llvm/tools/llvm-ml/Disassembler.cpp
@@ -127,7 +127,8 @@ int Disassembler::disassemble(const Target &T, const std::string &TripleName,
                               MCSubtargetInfo &STI, MCStreamer &Streamer,
                               MemoryBuffer &Buffer, SourceMgr &SM,
                               raw_ostream &Out) {
-  std::unique_ptr<const MCRegisterInfo> MRI(T.createMCRegInfo(TripleName));
+  Triple TheTriple(TripleName);
+  std::unique_ptr<const MCRegisterInfo> MRI(T.createMCRegInfo(TheTriple));
   if (!MRI) {
     errs() << "error: no register info for target " << TripleName << "\n";
     return -1;
@@ -135,7 +136,7 @@ int Disassembler::disassemble(const Target &T, const std::string &TripleName,
 
   MCTargetOptions MCOptions;
   std::unique_ptr<const MCAsmInfo> MAI(
-      T.createMCAsmInfo(*MRI, TripleName, MCOptions));
+      T.createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI) {
     errs() << "error: no assembly info for target " << TripleName << "\n";
     return -1;

--- a/llvm/tools/llvm-ml/llvm-ml.cpp
+++ b/llvm/tools/llvm-ml/llvm-ml.cpp
@@ -277,8 +277,6 @@ int llvm_ml_main(int Argc, char **Argv, const llvm::ToolContext &) {
     WithColor::error(errs(), ProgName) << Error;
     return 1;
   }
-  const std::string &TripleName = TheTriple.getTriple();
-
   bool SafeSEH = InputArgs.hasArg(OPT_safeseh);
   if (SafeSEH && !(TheTriple.isArch32Bit() && TheTriple.isX86())) {
     WithColor::warning()
@@ -316,17 +314,17 @@ int llvm_ml_main(int Argc, char **Argv, const llvm::ToolContext &) {
   }
   SrcMgr.setIncludeDirs(IncludeDirs);
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
   assert(MRI && "Unable to create target register info!");
 
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   assert(MAI && "Unable to create target asm info!");
 
   MAI->setPreserveAsmComments(InputArgs.hasArg(OPT_preserve_comments));
 
-  std::unique_ptr<MCSubtargetInfo> STI(TheTarget->createMCSubtargetInfo(
-      TripleName, /*CPU=*/"", /*Features=*/""));
+  std::unique_ptr<MCSubtargetInfo> STI(
+      TheTarget->createMCSubtargetInfo(TheTriple, /*CPU=*/"", /*Features=*/""));
   assert(STI && "Unable to create subtarget info!");
 
   // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and

--- a/llvm/tools/llvm-objdump/MachODump.cpp
+++ b/llvm/tools/llvm-objdump/MachODump.cpp
@@ -127,7 +127,8 @@ void objdump::parseMachOOptions(const llvm::opt::InputArgList &InputArgs) {
 
 static const Target *GetTarget(const MachOObjectFile *MachOObj,
                                const char **McpuDefault,
-                               const Target **ThumbTarget) {
+                               const Target **ThumbTarget,
+                               Triple &ThumbTriple) {
   // Figure out the target triple.
   Triple TT(TripleName);
   if (TripleName.empty()) {
@@ -138,8 +139,8 @@ static const Target *GetTarget(const MachOObjectFile *MachOObj,
   if (TT.getArch() == Triple::arm) {
     // We've inferred a 32-bit ARM target from the object file. All MachO CPUs
     // that support ARM are also capable of Thumb mode.
-    Triple ThumbTriple = TT;
     std::string ThumbName = (Twine("thumb") + TT.getArchName().substr(3)).str();
+    ThumbTriple = TT;
     ThumbTriple.setArchName(ThumbName);
     ThumbTripleName = ThumbTriple.str();
   }
@@ -7238,7 +7239,9 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
                              StringRef DisSegName, StringRef DisSectName) {
   const char *McpuDefault = nullptr;
   const Target *ThumbTarget = nullptr;
-  const Target *TheTarget = GetTarget(MachOOF, &McpuDefault, &ThumbTarget);
+  Triple ThumbTriple;
+  const Target *TheTarget =
+      GetTarget(MachOOF, &McpuDefault, &ThumbTarget, ThumbTriple);
   if (!TheTarget) {
     // GetTarget prints out stuff.
     return;
@@ -7285,34 +7288,36 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
     FeaturesStr = Features.getString();
   }
 
+  Triple TheTriple(TripleName);
+
   MCTargetOptions MCOptions;
   // Set up disassembler.
   std::unique_ptr<const MCRegisterInfo> MRI(
-      TheTarget->createMCRegInfo(TripleName));
+      TheTarget->createMCRegInfo(TheTriple));
   CHECK_TARGET_INFO_CREATION(MRI);
   std::unique_ptr<const MCAsmInfo> AsmInfo(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   CHECK_TARGET_INFO_CREATION(AsmInfo);
   std::unique_ptr<const MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, MachOMCPU, FeaturesStr));
+      TheTarget->createMCSubtargetInfo(TheTriple, MachOMCPU, FeaturesStr));
   CHECK_TARGET_INFO_CREATION(STI);
-  MCContext Ctx(Triple(TripleName), AsmInfo.get(), MRI.get(), STI.get());
+  MCContext Ctx(TheTriple, AsmInfo.get(), MRI.get(), STI.get());
   std::unique_ptr<MCDisassembler> DisAsm(
       TheTarget->createMCDisassembler(*STI, Ctx));
   CHECK_TARGET_INFO_CREATION(DisAsm);
   std::unique_ptr<MCSymbolizer> Symbolizer;
   struct DisassembleInfo SymbolizerInfo(nullptr, nullptr, nullptr, false);
   std::unique_ptr<MCRelocationInfo> RelInfo(
-      TheTarget->createMCRelocationInfo(TripleName, Ctx));
+      TheTarget->createMCRelocationInfo(TheTriple, Ctx));
   if (RelInfo) {
     Symbolizer.reset(TheTarget->createMCSymbolizer(
-        TripleName, SymbolizerGetOpInfo, SymbolizerSymbolLookUp,
-        &SymbolizerInfo, &Ctx, std::move(RelInfo)));
+        TheTriple, SymbolizerGetOpInfo, SymbolizerSymbolLookUp, &SymbolizerInfo,
+        &Ctx, std::move(RelInfo)));
     DisAsm->setSymbolizer(std::move(Symbolizer));
   }
   int AsmPrinterVariant = AsmInfo->getAssemblerDialect();
   std::unique_ptr<MCInstPrinter> IP(TheTarget->createMCInstPrinter(
-      Triple(TripleName), AsmPrinterVariant, *AsmInfo, *InstrInfo, *MRI));
+      TheTriple, AsmPrinterVariant, *AsmInfo, *InstrInfo, *MRI));
   CHECK_TARGET_INFO_CREATION(IP);
   // Set the display preference for hex vs. decimal immediates.
   IP->setPrintImmHex(PrintImmHex);
@@ -7341,32 +7346,31 @@ static void DisassembleMachO(StringRef Filename, MachOObjectFile *MachOOF,
   struct DisassembleInfo ThumbSymbolizerInfo(nullptr, nullptr, nullptr, false);
   std::unique_ptr<MCRelocationInfo> ThumbRelInfo;
   if (ThumbTarget) {
-    ThumbMRI.reset(ThumbTarget->createMCRegInfo(ThumbTripleName));
+    ThumbMRI.reset(ThumbTarget->createMCRegInfo(ThumbTriple));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbMRI);
     ThumbAsmInfo.reset(
-        ThumbTarget->createMCAsmInfo(*ThumbMRI, ThumbTripleName, MCOptions));
+        ThumbTarget->createMCAsmInfo(*ThumbMRI, ThumbTriple, MCOptions));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbAsmInfo);
-    ThumbSTI.reset(
-        ThumbTarget->createMCSubtargetInfo(ThumbTripleName, MachOMCPU,
-                                           FeaturesStr));
+    ThumbSTI.reset(ThumbTarget->createMCSubtargetInfo(ThumbTriple, MachOMCPU,
+                                                      FeaturesStr));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbSTI);
-    ThumbCtx.reset(new MCContext(Triple(ThumbTripleName), ThumbAsmInfo.get(),
+    ThumbCtx.reset(new MCContext(ThumbTriple, ThumbAsmInfo.get(),
                                  ThumbMRI.get(), ThumbSTI.get()));
     ThumbDisAsm.reset(ThumbTarget->createMCDisassembler(*ThumbSTI, *ThumbCtx));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbDisAsm);
     MCContext *PtrThumbCtx = ThumbCtx.get();
     ThumbRelInfo.reset(
-        ThumbTarget->createMCRelocationInfo(ThumbTripleName, *PtrThumbCtx));
+        ThumbTarget->createMCRelocationInfo(ThumbTriple, *PtrThumbCtx));
     if (ThumbRelInfo) {
       ThumbSymbolizer.reset(ThumbTarget->createMCSymbolizer(
-          ThumbTripleName, SymbolizerGetOpInfo, SymbolizerSymbolLookUp,
+          ThumbTriple, SymbolizerGetOpInfo, SymbolizerSymbolLookUp,
           &ThumbSymbolizerInfo, PtrThumbCtx, std::move(ThumbRelInfo)));
       ThumbDisAsm->setSymbolizer(std::move(ThumbSymbolizer));
     }
     int ThumbAsmPrinterVariant = ThumbAsmInfo->getAssemblerDialect();
     ThumbIP.reset(ThumbTarget->createMCInstPrinter(
-        Triple(ThumbTripleName), ThumbAsmPrinterVariant, *ThumbAsmInfo,
-        *ThumbInstrInfo, *ThumbMRI));
+        ThumbTriple, ThumbAsmPrinterVariant, *ThumbAsmInfo, *ThumbInstrInfo,
+        *ThumbMRI));
     CHECK_THUMB_TARGET_INFO_CREATION(ThumbIP);
     // Set the display preference for hex vs. decimal immediates.
     ThumbIP->setPrintImmHex(PrintImmHex);

--- a/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
+++ b/llvm/tools/llvm-rtdyld/llvm-rtdyld.cpp
@@ -793,21 +793,21 @@ static int linkAndVerify() {
   TripleName = TheTriple.getTriple();
 
   std::unique_ptr<MCSubtargetInfo> STI(
-    TheTarget->createMCSubtargetInfo(TripleName, MCPU, ""));
+      TheTarget->createMCSubtargetInfo(TheTriple, MCPU, ""));
   if (!STI)
     ErrorAndExit("Unable to create subtarget info!");
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     ErrorAndExit("Unable to create target register info!");
 
   MCTargetOptions MCOptions;
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     ErrorAndExit("Unable to create target asm info!");
 
-  MCContext Ctx(Triple(TripleName), MAI.get(), MRI.get(), STI.get());
+  MCContext Ctx(TheTriple, MAI.get(), MRI.get(), STI.get());
 
   std::unique_ptr<MCDisassembler> Disassembler(
     TheTarget->createMCDisassembler(*STI, Ctx));
@@ -819,7 +819,7 @@ static int linkAndVerify() {
     ErrorAndExit("Unable to create target instruction info!");
 
   std::unique_ptr<MCInstPrinter> InstPrinter(
-      TheTarget->createMCInstPrinter(Triple(TripleName), 0, *MAI, *MII, *MRI));
+      TheTarget->createMCInstPrinter(TheTriple, 0, *MAI, *MII, *MRI));
 
   // Load any dylibs requested on the command line.
   loadDylibs();

--- a/llvm/tools/sancov/sancov.cpp
+++ b/llvm/tools/sancov/sancov.cpp
@@ -710,16 +710,16 @@ static void getObjectCoveragePoints(const object::ObjectFile &O,
   failIfNotEmpty(Error);
 
   std::unique_ptr<const MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+      TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   failIfEmpty(STI, "no subtarget info for target " + TripleName);
 
   std::unique_ptr<const MCRegisterInfo> MRI(
-      TheTarget->createMCRegInfo(TripleName));
+      TheTarget->createMCRegInfo(TheTriple));
   failIfEmpty(MRI, "no register info for target " + TripleName);
 
   MCTargetOptions MCOptions;
   std::unique_ptr<const MCAsmInfo> AsmInfo(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+      TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   failIfEmpty(AsmInfo, "no asm info for target " + TripleName);
 
   MCContext Ctx(TheTriple, AsmInfo.get(), MRI.get(), STI.get());

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCompactPrinterTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCompactPrinterTest.cpp
@@ -42,7 +42,7 @@ public:
     if (!TheTarget)
       return;
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
+    MRI.reset(TheTarget->createMCRegInfo(Triple(TripleName)));
   }
 
   void TestExprPrinter(ArrayRef<uint8_t> ExprData, StringRef Expected);

--- a/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DWARFExpressionCopyBytesTest.cpp
@@ -45,13 +45,15 @@ namespace {
 /// debug info from input to output binary.
 class DWARFExpressionCopyBytesTest : public ::testing::Test {
 public:
-  const char *TripleName = "x86_64-pc-linux";
+  static constexpr char TripleName[] = "x86_64-pc-linux";
+  Triple TheTriple;
+
   std::unique_ptr<MCRegisterInfo> MRI;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<const MCSubtargetInfo> STI;
   const Target *TheTarget;
 
-  DWARFExpressionCopyBytesTest() {
+  DWARFExpressionCopyBytesTest() : TheTriple(TripleName) {
     InitializeAllTargets();
     InitializeAllTargetMCs();
     InitializeAllAsmPrinters();
@@ -61,9 +63,9 @@ public:
     if (!TheTarget)
       return;
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCTargetOptions()));
-    STI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+    MRI.reset(TheTarget->createMCRegInfo(TheTriple));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCTargetOptions()));
+    STI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   }
 
   struct StreamerContext {

--- a/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
+++ b/llvm/unittests/DebugInfo/DWARF/DwarfGenerator.cpp
@@ -454,19 +454,19 @@ llvm::Error dwarfgen::Generator::init(Triple TheTriple, uint16_t V) {
   TripleName = TheTriple.getTriple();
 
   // Create all the MC Objects.
-  MRI.reset(TheTarget->createMCRegInfo(TripleName));
+  MRI.reset(TheTarget->createMCRegInfo(TheTriple));
   if (!MRI)
     return make_error<StringError>(Twine("no register info for target ") +
                                        TripleName,
                                    inconvertibleErrorCode());
 
   MCTargetOptions MCOptions = mc::InitMCTargetOptionsFromFlags();
-  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   if (!MAI)
     return make_error<StringError>("no asm info for target " + TripleName,
                                    inconvertibleErrorCode());
 
-  MSTI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
+  MSTI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
   if (!MSTI)
     return make_error<StringError>("no subtarget info for target " + TripleName,
                                    inconvertibleErrorCode());

--- a/llvm/unittests/MC/AMDGPU/Disassembler.cpp
+++ b/llvm/unittests/MC/AMDGPU/Disassembler.cpp
@@ -32,8 +32,8 @@ static const char *symbolLookupCallback(void *DisInfo, uint64_t ReferenceValue,
   return nullptr;
 }
 
-static const char *TripleName = "amdgcn--amdpal";
-static const char *CPUName = "gfx1030";
+static constexpr char TripleName[] = "amdgcn--amdpal";
+static constexpr char CPUName[] = "gfx1030";
 
 // Basic smoke test.
 TEST(AMDGPUDisassembler, Basic) {
@@ -77,18 +77,19 @@ TEST(AMDGPUDisassembler, MultiDisassembler) {
   if (!TheTarget)
     GTEST_SKIP();
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  Triple TT(TripleName);
+
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCTargetOptions()));
+      TheTarget->createMCAsmInfo(*MRI, TT, MCTargetOptions()));
   std::unique_ptr<const MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, CPUName, ""));
-  auto Ctx = std::make_unique<MCContext>(Triple(TripleName), MAI.get(),
-                                         MRI.get(), STI.get());
+      TheTarget->createMCSubtargetInfo(TT, CPUName, ""));
+  auto Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(), STI.get());
 
   int AsmPrinterVariant = MAI->getAssemblerDialect();
-  std::unique_ptr<MCInstPrinter> IP(TheTarget->createMCInstPrinter(
-      Triple(TripleName), AsmPrinterVariant, *MAI, *MII, *MRI));
+  std::unique_ptr<MCInstPrinter> IP(
+      TheTarget->createMCInstPrinter(TT, AsmPrinterVariant, *MAI, *MII, *MRI));
 
   SmallVector<char, 64> InsnStr, AnnoStr;
   raw_svector_ostream OS(InsnStr);
@@ -147,14 +148,15 @@ TEST(AMDGPUDisassembler, UCVersionOverride) {
   if (!TheTarget)
     GTEST_SKIP();
 
-  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TripleName));
+  Triple TT(TripleName);
+
+  std::unique_ptr<MCRegisterInfo> MRI(TheTarget->createMCRegInfo(TT));
   std::unique_ptr<MCAsmInfo> MAI(
-      TheTarget->createMCAsmInfo(*MRI, TripleName, MCTargetOptions()));
+      TheTarget->createMCAsmInfo(*MRI, TT, MCTargetOptions()));
   std::unique_ptr<const MCInstrInfo> MII(TheTarget->createMCInstrInfo());
   std::unique_ptr<MCSubtargetInfo> STI(
-      TheTarget->createMCSubtargetInfo(TripleName, CPUName, ""));
-  auto Ctx = std::make_unique<MCContext>(Triple(TripleName), MAI.get(),
-                                         MRI.get(), STI.get());
+      TheTarget->createMCSubtargetInfo(TT, CPUName, ""));
+  auto Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(), STI.get());
 
   // Define custom UC_VERSION before initializing disassembler.
   const uint8_t UC_VERSION_GFX10_DEFAULT = 0x04;
@@ -163,8 +165,8 @@ TEST(AMDGPUDisassembler, UCVersionOverride) {
   Sym->setVariableValue(MCConstantExpr::create(UC_VERSION_GFX10_NEW, *Ctx));
 
   int AsmPrinterVariant = MAI->getAssemblerDialect();
-  std::unique_ptr<MCInstPrinter> IP(TheTarget->createMCInstPrinter(
-      Triple(TripleName), AsmPrinterVariant, *MAI, *MII, *MRI));
+  std::unique_ptr<MCInstPrinter> IP(
+      TheTarget->createMCInstPrinter(TT, AsmPrinterVariant, *MAI, *MII, *MRI));
 
   testing::internal::CaptureStderr();
   std::unique_ptr<MCDisassembler> DisAsm(

--- a/llvm/unittests/MC/DwarfLineTables.cpp
+++ b/llvm/unittests/MC/DwarfLineTables.cpp
@@ -22,26 +22,27 @@ using namespace llvm;
 
 namespace {
 struct Context {
-  const char *TripleName = "x86_64-pc-linux";
+  static constexpr char TripleName[] = "x86_64-pc-linux";
+  Triple TT;
   std::unique_ptr<MCRegisterInfo> MRI;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<MCContext> Ctx;
 
-  Context() {
+  Context() : TT(TripleName) {
     llvm::InitializeAllTargetInfos();
     llvm::InitializeAllTargetMCs();
     llvm::InitializeAllDisassemblers();
 
     // If we didn't build x86, do not run the test.
     std::string Error;
-    const Target *TheTarget = TargetRegistry::lookupTarget(TripleName, Error);
+    const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
     if (!TheTarget)
       return;
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
+    MRI.reset(TheTarget->createMCRegInfo(TT));
     MCTargetOptions MCOptions;
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
-    Ctx = std::make_unique<MCContext>(Triple(TripleName), MAI.get(), MRI.get(),
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
+    Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(),
                                       /*MSTI=*/nullptr);
   }
 

--- a/llvm/unittests/MC/MCInstPrinter.cpp
+++ b/llvm/unittests/MC/MCInstPrinter.cpp
@@ -31,7 +31,8 @@ public:
     llvm::InitializeAllTargetInfos();
     llvm::InitializeAllTargetMCs();
 
-    std::string TripleName = "x86_64-pc-linux";
+    StringRef TripleName = "x86_64-pc-linux";
+    Triple TT(TripleName);
     std::string ErrorStr;
 
     const Target *TheTarget =
@@ -41,12 +42,12 @@ public:
     if (!TheTarget)
       return;
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
+    MRI.reset(TheTarget->createMCRegInfo(TT));
     MCTargetOptions MCOptions;
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCOptions));
     MII.reset(TheTarget->createMCInstrInfo());
-    Printer.reset(TheTarget->createMCInstPrinter(
-        Triple(TripleName), MAI->getAssemblerDialect(), *MAI, *MII, *MRI));
+    Printer.reset(TheTarget->createMCInstPrinter(TT, MAI->getAssemblerDialect(),
+                                                 *MAI, *MII, *MRI));
   }
 
   template <typename T> std::string formatHex(T i) {

--- a/llvm/unittests/MC/SystemZ/SystemZAsmLexerTest.cpp
+++ b/llvm/unittests/MC/SystemZ/SystemZAsmLexerTest.cpp
@@ -46,34 +46,33 @@ protected:
   std::unique_ptr<MCTargetAsmParser> TargetAsmParser;
 
   SourceMgr SrcMgr;
-  std::string TripleName;
-  llvm::Triple Triple;
+  StringRef TripleName;
+  const llvm::Triple Triple;
   const Target *TheTarget;
 
   const MCTargetOptions MCOptions;
 
   SystemZAsmLexerTest() = delete;
 
-  SystemZAsmLexerTest(std::string SystemZTriple) {
+  SystemZAsmLexerTest(StringRef SystemZTriple)
+      : TripleName(SystemZTriple), Triple(SystemZTriple) {
     // We will use the SystemZ triple, because of missing
     // Object File and Streamer support for the z/OS target.
-    TripleName = SystemZTriple;
-    Triple = llvm::Triple(TripleName);
 
     std::string Error;
     TheTarget = TargetRegistry::lookupTarget(TripleName, Error);
     EXPECT_NE(TheTarget, nullptr);
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
+    MRI.reset(TheTarget->createMCRegInfo(Triple));
     EXPECT_NE(MRI, nullptr);
 
     MII.reset(TheTarget->createMCInstrInfo());
     EXPECT_NE(MII, nullptr);
 
-    STI.reset(TheTarget->createMCSubtargetInfo(TripleName, "z10", ""));
+    STI.reset(TheTarget->createMCSubtargetInfo(Triple, "z10", ""));
     EXPECT_NE(STI, nullptr);
 
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, Triple, MCOptions));
     EXPECT_NE(MAI, nullptr);
   }
 

--- a/llvm/unittests/MC/SystemZ/SystemZMCDisassemblerTest.cpp
+++ b/llvm/unittests/MC/SystemZ/SystemZMCDisassemblerTest.cpp
@@ -23,14 +23,15 @@ using namespace llvm;
 namespace {
 
 struct Context {
-  const char *TripleName = "systemz-unknown";
+  static constexpr char TripleName[] = "systemz-unknown";
+  Triple TT;
   std::unique_ptr<MCRegisterInfo> MRI;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<MCContext> Ctx;
   std::unique_ptr<MCSubtargetInfo> STI;
   std::unique_ptr<MCDisassembler> DisAsm;
 
-  Context() {
+  Context() : TT(TripleName) {
     LLVMInitializeSystemZTargetInfo();
     LLVMInitializeSystemZTargetMC();
     LLVMInitializeSystemZDisassembler();
@@ -41,11 +42,10 @@ struct Context {
     if (!TheTarget)
       return;
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCTargetOptions()));
-    STI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
-    Ctx = std::make_unique<MCContext>(Triple(TripleName), MAI.get(), MRI.get(),
-                                      STI.get());
+    MRI.reset(TheTarget->createMCRegInfo(TT));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TT, MCTargetOptions()));
+    STI.reset(TheTarget->createMCSubtargetInfo(TT, "", ""));
+    Ctx = std::make_unique<MCContext>(TT, MAI.get(), MRI.get(), STI.get());
 
     DisAsm.reset(TheTarget->createMCDisassembler(*STI, *Ctx));
   }

--- a/llvm/unittests/MC/X86/X86MCDisassemblerTest.cpp
+++ b/llvm/unittests/MC/X86/X86MCDisassemblerTest.cpp
@@ -23,14 +23,15 @@ using namespace llvm;
 namespace {
 
 struct Context {
-  const char *TripleName = "x86_64-unknown-elf";
+  static constexpr char TripleName[] = "x86_64-unknown-elf";
+  const Triple TheTriple;
   std::unique_ptr<MCRegisterInfo> MRI;
   std::unique_ptr<MCAsmInfo> MAI;
   std::unique_ptr<MCContext> Ctx;
   std::unique_ptr<MCSubtargetInfo> STI;
   std::unique_ptr<MCDisassembler> DisAsm;
 
-  Context() {
+  Context() : TheTriple(TripleName) {
     LLVMInitializeX86TargetInfo();
     LLVMInitializeX86TargetMC();
     LLVMInitializeX86Disassembler();
@@ -41,11 +42,11 @@ struct Context {
     if (!TheTarget)
       return;
 
-    MRI.reset(TheTarget->createMCRegInfo(TripleName));
-    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCTargetOptions()));
-    STI.reset(TheTarget->createMCSubtargetInfo(TripleName, "", ""));
-    Ctx = std::make_unique<MCContext>(Triple(TripleName), MAI.get(), MRI.get(),
-                                      STI.get());
+    MRI.reset(TheTarget->createMCRegInfo(TheTriple));
+    MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCTargetOptions()));
+    STI.reset(TheTarget->createMCSubtargetInfo(TheTriple, "", ""));
+    Ctx =
+        std::make_unique<MCContext>(TheTriple, MAI.get(), MRI.get(), STI.get());
 
     DisAsm.reset(TheTarget->createMCDisassembler(*STI, *Ctx));
   }

--- a/llvm/unittests/tools/llvm-exegesis/AArch64/TargetTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/AArch64/TargetTest.cpp
@@ -32,14 +32,16 @@ constexpr const char kTriple[] = "aarch64-unknown-linux";
 
 class AArch64TargetTest : public ::testing::Test {
 protected:
+  const Triple TT;
+
   AArch64TargetTest()
-      : ExegesisTarget_(ExegesisTarget::lookup(Triple(kTriple))) {
+      : TT(kTriple), ExegesisTarget_(ExegesisTarget::lookup(TT)) {
     EXPECT_THAT(ExegesisTarget_, NotNull());
     std::string error;
     Target_ = TargetRegistry::lookupTarget(kTriple, error);
     EXPECT_THAT(Target_, NotNull());
     STI_.reset(
-        Target_->createMCSubtargetInfo(kTriple, "generic", /*no features*/ ""));
+        Target_->createMCSubtargetInfo(TT, "generic", /*no features*/ ""));
   }
 
   static void SetUpTestCase() {

--- a/llvm/unittests/tools/llvm-exegesis/PowerPC/AnalysisTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/PowerPC/AnalysisTest.cpp
@@ -26,9 +26,11 @@ using testing::UnorderedElementsAre;
 class PPCAnalysisTest : public ::testing::Test {
 protected:
   PPCAnalysisTest() {
-    const std::string TT = "powerpc64le-unknown-linux";
+    const StringRef TripleName = "powerpc64le-unknown-linux";
+    const Triple TT(TripleName);
     std::string error;
-    const Target *const TheTarget = TargetRegistry::lookupTarget(TT, error);
+    const Target *const TheTarget =
+        TargetRegistry::lookupTarget(TripleName, error);
     if (!TheTarget) {
       errs() << error << "\n";
       return;

--- a/llvm/unittests/tools/llvm-exegesis/PowerPC/TargetTest.cpp
+++ b/llvm/unittests/tools/llvm-exegesis/PowerPC/TargetTest.cpp
@@ -33,8 +33,10 @@ constexpr const char kTriple[] = "powerpc64le-unknown-linux";
 
 class PowerPCTargetTest : public PPCTestBase {
 protected:
+  const Triple TT;
+
   PowerPCTargetTest()
-      : ExegesisTarget_(ExegesisTarget::lookup(Triple(kTriple))) {
+      : TT(kTriple), ExegesisTarget_(ExegesisTarget::lookup(TT)) {
     EXPECT_THAT(ExegesisTarget_, NotNull());
     std::string error;
     Target_ = TargetRegistry::lookupTarget(kTriple, error);
@@ -47,7 +49,7 @@ protected:
 
 TEST_F(PowerPCTargetTest, SetRegToConstant) {
   const std::unique_ptr<MCSubtargetInfo> STI(
-      Target_->createMCSubtargetInfo(kTriple, "generic", ""));
+      Target_->createMCSubtargetInfo(TT, "generic", ""));
   const auto Insts = ExegesisTarget_->setRegTo(*STI, PPC::X0, APInt());
   EXPECT_THAT(Insts, Not(IsEmpty()));
 }

--- a/llvm/unittests/tools/llvm-mca/MCATestBase.cpp
+++ b/llvm/unittests/tools/llvm-mca/MCATestBase.cpp
@@ -31,17 +31,15 @@ void MCATestBase::SetUp() {
   TheTarget = getLLVMTarget();
   ASSERT_NE(TheTarget, nullptr);
 
-  StringRef TripleName = TheTriple.getTriple();
-
-  STI.reset(TheTarget->createMCSubtargetInfo(TripleName, CPUName, MAttr));
+  STI.reset(TheTarget->createMCSubtargetInfo(TheTriple, CPUName, MAttr));
   ASSERT_TRUE(STI);
   ASSERT_TRUE(STI->isCPUStringValid(CPUName));
 
-  MRI.reset(TheTarget->createMCRegInfo(TripleName));
+  MRI.reset(TheTarget->createMCRegInfo(TheTriple));
   ASSERT_TRUE(MRI);
 
   auto MCOptions = getMCTargetOptions();
-  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TripleName, MCOptions));
+  MAI.reset(TheTarget->createMCAsmInfo(*MRI, TheTriple, MCOptions));
   ASSERT_TRUE(MAI);
 
   Ctx = std::make_unique<MCContext>(TheTriple, MAI.get(), MRI.get(), STI.get());

--- a/mlir/lib/Target/LLVM/ROCDL/Target.cpp
+++ b/mlir/lib/Target/LLVM/ROCDL/Target.cpp
@@ -299,12 +299,11 @@ SerializeGPUModuleBase::assembleIsa(StringRef isa) {
   srcMgr.AddNewSourceBuffer(llvm::MemoryBuffer::getMemBuffer(isa), SMLoc());
 
   const llvm::MCTargetOptions mcOptions;
-  std::unique_ptr<llvm::MCRegisterInfo> mri(
-      target->createMCRegInfo(targetTriple));
+  std::unique_ptr<llvm::MCRegisterInfo> mri(target->createMCRegInfo(triple));
   std::unique_ptr<llvm::MCAsmInfo> mai(
-      target->createMCAsmInfo(*mri, targetTriple, mcOptions));
+      target->createMCAsmInfo(*mri, triple, mcOptions));
   std::unique_ptr<llvm::MCSubtargetInfo> sti(
-      target->createMCSubtargetInfo(targetTriple, chip, features));
+      target->createMCSubtargetInfo(triple, chip, features));
 
   llvm::MCContext ctx(triple, mai.get(), mri.get(), sti.get(), &srcMgr,
                       &mcOptions);


### PR DESCRIPTION
Avoids more Triple->string->Triple round trip. This
is a continuation of f137c3d592e96330e450a8fd63ef7e8877fc1908