### PR TITLE
[ADT] Refactor DenseSet::insert (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -192,13 +192,11 @@ public:
   void erase(const_iterator CI) { return TheMap.erase(CI.I); }
 
   std::pair<iterator, bool> insert(const ValueT &V) {
-    detail::DenseSetEmpty Empty;
-    return TheMap.try_emplace(V, Empty);
+    return TheMap.try_emplace(V);
   }
 
   std::pair<iterator, bool> insert(ValueT &&V) {
-    detail::DenseSetEmpty Empty;
-    return TheMap.try_emplace(std::move(V), Empty);
+    return TheMap.try_emplace(std::move(V));
   }
 
   /// Alternative version of insert that uses a different (and possibly less


### PR DESCRIPTION
DenseMap::try_emplace can default-construct DenseSetEmptyKey, so we
don't need to pass Empty on our own.
