### PR TITLE
[ADT] Simplify StringSet::contains (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/StringSet.h
+++ b/llvm/include/llvm/ADT/StringSet.h
@@ -57,7 +57,7 @@ public:
   }
 
   /// Check if the set contains the given \c key.
-  bool contains(StringRef key) const { return Base::FindKey(key) != -1; }
+  bool contains(StringRef key) const { return Base::contains(key); }
 };
 
 } // end namespace llvm


### PR DESCRIPTION
We can use Base::contains.
