### PR TITLE
CodeGen: Make TargetInstrInfo constructor protected

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -112,12 +112,14 @@ struct ExtAddrMode {
 /// TargetInstrInfo - Interface to description of machine instruction set
 ///
 class LLVM_ABI TargetInstrInfo : public MCInstrInfo {
-public:
+protected:
   TargetInstrInfo(unsigned CFSetupOpcode = ~0u, unsigned CFDestroyOpcode = ~0u,
                   unsigned CatchRetOpcode = ~0u, unsigned ReturnOpcode = ~0u)
       : CallFrameSetupOpcode(CFSetupOpcode),
         CallFrameDestroyOpcode(CFDestroyOpcode), CatchRetOpcode(CatchRetOpcode),
         ReturnOpcode(ReturnOpcode) {}
+
+public:
   TargetInstrInfo(const TargetInstrInfo &) = delete;
   TargetInstrInfo &operator=(const TargetInstrInfo &) = delete;
   virtual ~TargetInstrInfo();

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -75,6 +75,11 @@ public:
   }
 };
 
+class BogusTargetInstrInfo : public TargetInstrInfo {
+public:
+  BogusTargetInstrInfo() : TargetInstrInfo() {}
+};
+
 class BogusSubtarget : public TargetSubtargetInfo {
 public:
   BogusSubtarget(TargetMachine &TM)
@@ -95,7 +100,7 @@ private:
   BogusFrameLowering FL;
   BogusRegisterInfo TRI;
   BogusTargetLowering TL;
-  TargetInstrInfo TII;
+  BogusTargetInstrInfo TII;
 };
 
 static TargetOptions getTargetOptionsForBogusMachine() {


### PR DESCRIPTION
There's no use for the standalone base class TargetRegisterInfo
and TargetSubtargetInfo already do this.