### PR TITLE
[CodeGen] Make TargetRegisterInfo destructor public (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetRegisterInfo.h
@@ -273,9 +273,10 @@ protected:
                      const RegClassInfo *const RCIs,
                      const MVT::SimpleValueType *const RCVTLists,
                      unsigned Mode = 0);
-  virtual ~TargetRegisterInfo();
 
 public:
+  virtual ~TargetRegisterInfo();
+
   /// Return the number of registers for the function. (may overestimate)
   virtual unsigned getNumSupportedRegs(const MachineFunction &) const {
     return getNumRegs();


### PR DESCRIPTION
All in-tree targets store target-specific TRI in target-specific Subtarget/InstrInfo class by value, but some downstream targets may prefer to store it as `std::unique_ptr<const TargetRegisterInfo>` (to avoid inclusion of MyTargetRegisterInfo.h in MySubtarget.h).

Making the destructor public makes this possible, and also follows general C++ guidelines (the destructor should be either public virtual or protected non-virtual).

All other related classes already have their destructors public.