### PR TITLE
[mlir] Self-nominate for arith dialect maintenance

### DIFF
--- a/mlir/Maintainers.md
+++ b/mlir/Maintainers.md
@@ -46,7 +46,7 @@ dialects, build system and language bindings.
 * ‘ptr’ Dialect ([fabianmcg](https://github.com/fabianmcg))
 
 #### Basic Compute Dialects
-* ‘arith’ Dialect (core)
+* ‘arith’ Dialect (core + [kuhar](https://github.com/kuhar))
 * ‘math’ Dialect (core)
 * Rewrite System Dialects (core)
 * Transform Dialect ([martin-luecke](https://github.com/martin-luecke), [ftynse](https://github.com/ftynse), [rolfmorel](https://github.com/rolfmorel))


### PR DESCRIPTION
Following https://llvm.org/docs/DeveloperPolicy.html#maintainers, I'd like to self-nominate for arith dialect maintenance.

As per the policy:
> Maintainers are volunteering to take on the following shared responsibilities within an area of a project:
> ...

I believe I've been already performing most of the maintenance duties over the past few years, including direct code contributions, code reviews, and both starting and participating in relevant RFCs on discourse. You can look those up with:
* `git log --author=Jakub --oneline -- 'mlir/include/mlir/Dialect/Arith*' 'mlir/lib/Dialect/Arith*'`
* https://github.com/llvm/llvm-project/pulls?q=is%3Apr+label%3Amlir%3Aarith+reviewed-by%3Akuhar
* Some notable RFCs authored: https://discourse.llvm.org/t/rfc-define-precise-arith-semantics/65507, https://discourse.llvm.org/t/rfc-poison-semantics-for-mlir/66245, https://discourse.llvm.org/t/rfc-arith-add-extended-multiplication-ops/66869, https://discourse.llvm.org/t/rfc-add-integer-add-with-carry-op-to-arith/64573, https://discourse.llvm.org/t/rfc-arith-should-we-support-scalar-vector-arith-bitcast-s/65427.

In addition to the `core` category maintainers, I can bring additional perspective as I care both about conversion to llvm (as a user) and to spirv (as a maintainer).
