### PR TITLE
[clang-repl] Teach clang-repl how to load PCHs (reprise)

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1199,6 +1199,8 @@ public:
   bool isInSameModule(const Module *M1, const Module *M2) const;
 
   TranslationUnitDecl *getTranslationUnitDecl() const {
+    assert(TUDecl->getMostRecentDecl() == TUDecl &&
+           "The active TU is not current one!");
     return TUDecl->getMostRecentDecl();
   }
   void addTranslationUnitDecl() {

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1199,8 +1199,6 @@ public:
   bool isInSameModule(const Module *M1, const Module *M2) const;
 
   TranslationUnitDecl *getTranslationUnitDecl() const {
-    assert(TUDecl->getMostRecentDecl() == TUDecl &&
-           "The active TU is not current one!");
     return TUDecl->getMostRecentDecl();
   }
   void addTranslationUnitDecl() {

--- a/clang/include/clang/CodeGen/ModuleBuilder.h
+++ b/clang/include/clang/CodeGen/ModuleBuilder.h
@@ -52,6 +52,12 @@ namespace CodeGen {
 class CodeGenerator : public ASTConsumer {
   virtual void anchor();
 
+protected:
+  /// True if we've finished generating IR. This prevents us from generating
+  /// additional LLVM IR after emitting output in HandleTranslationUnit. This
+  /// can happen when Clang plugins trigger additional AST deserialization.
+  bool IRGenFinished = false;
+
 public:
   /// Return an opaque reference to the CodeGenModule object, which can
   /// be used in various secondary APIs.  It is valid as long as the

--- a/clang/lib/CodeGen/BackendConsumer.h
+++ b/clang/lib/CodeGen/BackendConsumer.h
@@ -40,11 +40,6 @@ class BackendConsumer : public ASTConsumer {
   llvm::Timer LLVMIRGeneration;
   unsigned LLVMIRGenerationRefCount = 0;
 
-  /// True if we've finished generating IR. This prevents us from generating
-  /// additional LLVM IR after emitting output in HandleTranslationUnit. This
-  /// can happen when Clang plugins trigger additional AST deserialization.
-  bool IRGenFinished = false;
-
   bool TimerIsEnabled = false;
 
   BackendAction Action;

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -238,8 +238,6 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
 
     Gen->HandleTranslationUnit(C);
 
-    IRGenFinished = true;
-
     if (TimerIsEnabled) {
       LLVMIRGenerationRefCount -= 1;
       if (LLVMIRGenerationRefCount == 0)

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -189,9 +189,7 @@ void BackendConsumer::HandleInlineFunctionDefinition(FunctionDecl *D) {
 }
 
 void BackendConsumer::HandleInterestingDecl(DeclGroupRef D) {
-  // Ignore interesting decls from the AST reader after IRGen is finished.
-  if (!IRGenFinished)
-    HandleTopLevelDecl(D);
+  HandleTopLevelDecl(D);
 }
 
 // Links each entry in LinkModules into our module. Returns true on error.
@@ -240,10 +238,13 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
 
     Gen->HandleTranslationUnit(C);
 
-    if (TimerIsEnabled && !--LLVMIRGenerationRefCount)
-      LLVMIRGeneration.yieldTo(CI.getFrontendTimer());
-
     IRGenFinished = true;
+
+    if (TimerIsEnabled) {
+      LLVMIRGenerationRefCount -= 1;
+      if (LLVMIRGenerationRefCount == 0)
+        LLVMIRGeneration.stopTimer();
+    }
   }
 
   // Silently ignore if we weren't initialized for some reason.

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -238,11 +238,8 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
 
     Gen->HandleTranslationUnit(C);
 
-    if (TimerIsEnabled) {
-      LLVMIRGenerationRefCount -= 1;
-      if (LLVMIRGenerationRefCount == 0)
-        LLVMIRGeneration.stopTimer();
-    }
+    if (TimerIsEnabled && !--LLVMIRGenerationRefCount)
+      LLVMIRGeneration.yieldTo(CI.getFrontendTimer());
   }
 
   // Silently ignore if we weren't initialized for some reason.

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -288,7 +288,6 @@ namespace {
     }
 
     void HandleTranslationUnit(ASTContext &Ctx) override {
-      IRGenFinished = true;
 
       // Release the Builder when there is no error.
       if (!Diags.hasUnrecoverableErrorOccurred() && Builder)
@@ -300,8 +299,9 @@ namespace {
         if (Builder)
           Builder->clear();
         M.reset();
-        return;
       }
+
+      IRGenFinished = true;
     }
 
     void AssignInheritanceModel(CXXRecordDecl *RD) override {

--- a/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -288,7 +288,6 @@ namespace {
     }
 
     void HandleTranslationUnit(ASTContext &Ctx) override {
-
       // Release the Builder when there is no error.
       if (!Diags.hasUnrecoverableErrorOccurred() && Builder)
         Builder->Release();

--- a/clang/lib/Interpreter/IncrementalAction.cpp
+++ b/clang/lib/Interpreter/IncrementalAction.cpp
@@ -106,7 +106,8 @@ std::unique_ptr<llvm::Module> IncrementalAction::GenModule() {
     // around we created an empty module to make CodeGen happy. We should make
     // sure it always stays empty.
     assert(((!CachedInCodeGenModule ||
-             !CI.getPreprocessorOpts().Includes.empty()) ||
+             !CI.getPreprocessorOpts().Includes.empty() ||
+             !CI.getPreprocessorOpts().ImplicitPCHInclude.empty()) ||
             (CachedInCodeGenModule->empty() &&
              CachedInCodeGenModule->global_empty() &&
              CachedInCodeGenModule->alias_empty() &&

--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -37,6 +37,10 @@ IncrementalParser::IncrementalParser(CompilerInstance &Instance,
   llvm::ErrorAsOutParameter EAO(&Err);
   Consumer = &S.getASTConsumer();
   P.reset(new Parser(S.getPreprocessor(), S, /*SkipBodies=*/false));
+
+  if (ExternalASTSource *External = S->getASTContext().getExternalSource())
+    External->StartTranslationUnit(Consumer);
+
   P->Initialize();
 }
 

--- a/clang/lib/Interpreter/IncrementalParser.cpp
+++ b/clang/lib/Interpreter/IncrementalParser.cpp
@@ -38,7 +38,7 @@ IncrementalParser::IncrementalParser(CompilerInstance &Instance,
   Consumer = &S.getASTConsumer();
   P.reset(new Parser(S.getPreprocessor(), S, /*SkipBodies=*/false));
 
-  if (ExternalASTSource *External = S->getASTContext().getExternalSource())
+  if (ExternalASTSource *External = S.getASTContext().getExternalSource())
     External->StartTranslationUnit(Consumer);
 
   P->Initialize();

--- a/clang/lib/Interpreter/Interpreter.cpp
+++ b/clang/lib/Interpreter/Interpreter.cpp
@@ -276,9 +276,10 @@ Interpreter::Interpreter(std::unique_ptr<CompilerInstance> Instance,
 
   if (Act->getCodeGen()) {
     Act->CacheCodeGenModule();
-    // The initial PTU is filled by `-include` or by CUDA includes
-    // automatically.
-    if (!CI->getPreprocessorOpts().Includes.empty()) {
+    // The initial PTU is filled by `-include`/`-include-pch` or by CUDA
+    // includes automatically.
+    if (!CI->getPreprocessorOpts().Includes.empty() ||
+        !CI->getPreprocessorOpts().ImplicitPCHInclude.empty()) {
       // We can't really directly pass the CachedInCodeGenModule to the Jit
       // because it will steal it, causing dangling references as explained in
       // Interpreter::Execute

--- a/clang/test/Interpreter/execute-pch.cpp
+++ b/clang/test/Interpreter/execute-pch.cpp
@@ -1,0 +1,14 @@
+// REQUIRES: host-supports-jit
+// UNSUPPORTED: system-aix
+
+// RUN: rm -f %t.pch
+// RUN: %clang_cc1 -fmax-type-align=16 -pic-level 2 -fdeprecated-macro -stack-protector 1 -fblocks -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -triple=%target_triple -DPCH -fincremental-extensions -emit-pch -x c++-header -o %t.pch %s
+// RUN: clang-repl -Xcc -fgnuc-version=0 -Xcc -triple=%target_triple -Xcc -include-pch -Xcc %t.pch '#include "%s"' | FileCheck %s
+
+#ifdef PCH
+int f_pch() { return 5; }
+#endif // PCH
+
+extern "C" int printf(const char *, ...);
+auto r1 = printf("f_pch = %d\n", f_pch());
+// CHECK: f_pch = 5

--- a/clang/test/Interpreter/execute-pch.cpp
+++ b/clang/test/Interpreter/execute-pch.cpp
@@ -5,10 +5,10 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 //
-// RUN: %clang -fmax-type-align=16 -Xclang -pic-level -Xclang 2 -Xclang -fdeprecated-macro -fno-stack-protector -Xclang -fwrapv -fPIC -Xclang -fblocks -Xclang -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -target %host-jit-triple -Xclang -fblocks -Xclang -fmax-type-align=8 -Xclang -fincremental-extensions -Xclang -emit-pch -x c++-header -o %t/include.pch %t/include.hpp
+// RUN: %clang -fmax-type-align=16 -Xclang -fdeprecated-macro -fno-stack-protector -Xclang -fwrapv -Xclang -fblocks -Xclang -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -target %host-jit-triple -Xclang -fblocks -Xclang -fmax-type-align=8 -Xclang -fincremental-extensions -Xclang -emit-pch -x c++-header -o %t/include.pch %t/include.hpp
 //
 // RUN: cat %t/main.cpp \
-// RUN:     | clang-repl -Xcc -fgnuc-version=0 -Xcc -fno-stack-protector -Xcc -fwrapv -Xcc -fPIC -Xcc -fblocks -Xcc -fskip-odr-check-in-gmf -Xcc -fmax-type-align=8 -Xcc -include-pch -Xcc %t/include.pch \
+// RUN:     | clang-repl -Xcc -fgnuc-version=0 -Xcc -fno-stack-protector -Xcc -fwrapv -Xcc -fblocks -Xcc -fskip-odr-check-in-gmf -Xcc -fmax-type-align=8 -Xcc -include-pch -Xcc %t/include.pch \
 // RUN:     | FileCheck %s
 
 //--- include.hpp

--- a/clang/test/Interpreter/execute-pch.cpp
+++ b/clang/test/Interpreter/execute-pch.cpp
@@ -1,14 +1,23 @@
 // REQUIRES: host-supports-jit
 // UNSUPPORTED: system-aix
+//
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+//
+// RUN: %clang -fmax-type-align=16 -Xclang -pic-level -Xclang 2 -Xclang -fdeprecated-macro -fno-stack-protector -Xclang -fwrapv -fPIC -Xclang -fblocks -Xclang -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -target %host-jit-triple -Xclang -fblocks -Xclang -fmax-type-align=8 -Xclang -fincremental-extensions -Xclang -emit-pch -x c++-header -o %t/include.pch %t/include.hpp
+//
+// RUN: cat %t/main.cpp \
+// RUN:     | clang-repl -Xcc -fgnuc-version=0 -Xcc -fno-stack-protector -Xcc -fwrapv -Xcc -fPIC -Xcc -fblocks -Xcc -fskip-odr-check-in-gmf -Xcc -fmax-type-align=8 -Xcc -include-pch -Xcc %t/include.pch \
+// RUN:     | FileCheck %s
 
-// RUN: rm -f %t.pch
-// RUN: %clang_cc1 -fmax-type-align=16 -pic-level 2 -fdeprecated-macro -stack-protector 1 -fblocks -fskip-odr-check-in-gmf -fexceptions -fcxx-exceptions -fgnuc-version=0 -triple=%target_triple -DPCH -fincremental-extensions -emit-pch -x c++-header -o %t.pch %s
-// RUN: clang-repl -Xcc -fgnuc-version=0 -Xcc -triple=%target_triple -Xcc -include-pch -Xcc %t.pch '#include "%s"' | FileCheck %s
+//--- include.hpp
 
-#ifdef PCH
 int f_pch() { return 5; }
-#endif // PCH
+
+//--- main.cpp
 
 extern "C" int printf(const char *, ...);
-auto r1 = printf("f_pch = %d\n", f_pch());
+printf("f_pch = %d\n", f_pch());
+
 // CHECK: f_pch = 5

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -140,15 +140,17 @@ def have_host_out_of_process_jit_feature_support():
 
     return False
 
-def run_clang_repl(feature_name):
+
+def run_clang_repl(args):
     clang_repl_exe = lit.util.which("clang-repl", config.clang_tools_dir)
 
     if not clang_repl_exe:
         return False
 
     try:
-        clang_repl_cmd = subprocess.Popen([clang_repl_exe, args],
-                                          stdout=subprocess.PIPE)
+        clang_repl_cmd = subprocess.Popen(
+            [clang_repl_exe, args], stdout=subprocess.PIPE
+        )
     except OSError:
         print("could not exec clang-repl")
         return False
@@ -157,6 +159,7 @@ def run_clang_repl(feature_name):
     clang_repl_cmd.wait()
 
     return clang_repl_out
+
 
 def have_host_jit_feature_support(feature_name):
     return "true" in run_clang_repl("--host-supports-" + feature_name)
@@ -194,7 +197,7 @@ if have_host_jit_feature_support('jit'):
     if have_host_clang_repl_cuda():
         config.available_features.add('host-supports-cuda')
     hosttriple = run_clang_repl("--host-jit-triple")
-    config.substitutions.append("%host-jit-triple", hosttriple.strip())
+    config.substitutions.append(("%host-jit-triple", hosttriple.strip()))
 
     if have_host_out_of_process_jit_feature_support():
         config.available_features.add("host-supports-out-of-process-jit")

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -140,16 +140,15 @@ def have_host_out_of_process_jit_feature_support():
 
     return False
 
-def have_host_jit_feature_support(feature_name):
+def run_clang_repl(feature_name):
     clang_repl_exe = lit.util.which("clang-repl", config.clang_tools_dir)
 
     if not clang_repl_exe:
         return False
 
     try:
-        clang_repl_cmd = subprocess.Popen(
-            [clang_repl_exe, "--host-supports-" + feature_name], stdout=subprocess.PIPE
-        )
+        clang_repl_cmd = subprocess.Popen([clang_repl_exe, args],
+                                          stdout=subprocess.PIPE)
     except OSError:
         print("could not exec clang-repl")
         return False
@@ -157,7 +156,10 @@ def have_host_jit_feature_support(feature_name):
     clang_repl_out = clang_repl_cmd.stdout.read().decode("ascii")
     clang_repl_cmd.wait()
 
-    return "true" in clang_repl_out
+    return clang_repl_out
+
+def have_host_jit_feature_support(feature_name):
+    return "true" in run_clang_repl("--host-supports-" + feature_name)
 
 def have_host_clang_repl_cuda():
     clang_repl_exe = lit.util.which('clang-repl', config.clang_tools_dir)
@@ -192,9 +194,7 @@ if have_host_jit_feature_support('jit'):
     if have_host_clang_repl_cuda():
         config.available_features.add('host-supports-cuda')
     hosttriple = run_clang_repl("--host-jit-triple")
-    config.substitutions.append(
-        ("%host-jit-triple",  hosttriple.strip())
-    )
+    config.substitutions.append("%host-jit-triple", hosttriple.strip())
 
     if have_host_out_of_process_jit_feature_support():
         config.available_features.add("host-supports-out-of-process-jit")

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -191,6 +191,10 @@ if have_host_jit_feature_support('jit'):
 
     if have_host_clang_repl_cuda():
         config.available_features.add('host-supports-cuda')
+    hosttriple = run_clang_repl("--host-jit-triple")
+    config.substitutions.append(
+        ("%host-jit-triple",  hosttriple.strip())
+    )
 
     if have_host_out_of_process_jit_feature_support():
         config.available_features.add("host-supports-out-of-process-jit")

--- a/clang/tools/clang-repl/ClangRepl.cpp
+++ b/clang/tools/clang-repl/ClangRepl.cpp
@@ -85,6 +85,8 @@ static llvm::cl::list<std::string>
               llvm::cl::CommaSeparated);
 static llvm::cl::opt<bool> OptHostSupportsJit("host-supports-jit",
                                               llvm::cl::Hidden);
+static llvm::cl::opt<bool> OptHostJitTriple("host-jit-triple",
+                                            llvm::cl::Hidden);
 static llvm::cl::list<std::string> OptInputs(llvm::cl::Positional,
                                              llvm::cl::desc("[code to run]"));
 
@@ -278,6 +280,11 @@ int main(int argc, const char **argv) {
       llvm::consumeError(J.takeError());
       llvm::outs() << "false\n";
     }
+    return 0;
+  } else if (OptHostJitTriple) {
+    auto J = ExitOnErr(llvm::orc::LLJITBuilder().create());
+    auto T = J->getTargetTriple();
+    llvm::outs() << T.normalize() << '\n';
     return 0;
   }
 


### PR DESCRIPTION
This is an updated version of @vgvassilev's PR from last year here: https://github.com/llvm/llvm-project/pull/94166

In short, it includes:

1. The fix for a blocking issue where `clang::Interpreter` (and thus `clang-repl`) cannot resolve symbols defined in a PCH
2. A test to prove this is working
3. A new hidden flag for `clang-repl` so that `llvm-lit` can match the host JIT triple between the PCH and `clang-repl`; previously, they may differ in some cases
4. Everything based on the latest LLVM main

Shout out to @kylc for finding a logic issue which had us stumped for a while (and securing the [bounty](https://github.com/jank-lang/jank/issues/446)).