### PR TITLE
[clang-tidy] Minor documentation wording for performance-noexcept-move-constructor

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/performance/noexcept-move-constructor.rst
@@ -9,5 +9,5 @@ marked with ``noexcept`` or marked with ``noexcept(expr)`` where ``expr``
 evaluates to ``false`` (but is not a ``false`` literal itself).
 
 Move constructors of all the types used with STL containers, for example,
-need to be declared ``noexcept``. Otherwise STL will choose copy constructors
+should be declared ``noexcept``. Otherwise STL may choose copy constructors
 instead. The same is valid for move assignment operations.


### PR DESCRIPTION

Fix #157343.
