### PR TITLE
[mlir][gpu] Refactor GpuOpsToROCDLOps pass interface (NFC)

### DIFF
--- a/mlir/include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h
+++ b/mlir/include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h
@@ -10,6 +10,8 @@
 
 #include "mlir/Conversion/GPUToROCDL/Runtimes.h"
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
+#include "llvm/ADT/DenseSet.h"
+#include <cstddef>
 #include <memory>
 
 namespace mlir {
@@ -50,7 +52,9 @@ createLowerGpuOpsToROCDLOpsPass(
     const std::string &chipset = "gfx900",
     unsigned indexBitwidth = kDeriveIndexBitwidthFromDataLayout,
     bool useBarePtrCallConv = false,
-    gpu::amd::Runtime runtime = gpu::amd::Runtime::Unknown);
+    gpu::amd::Runtime runtime = gpu::amd::Runtime::Unknown,
+    const std::optional<llvm::SmallDenseSet<llvm::StringRef>> &allowedDialects =
+        std::nullopt);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h
+++ b/mlir/include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h
@@ -10,12 +10,10 @@
 
 #include "mlir/Conversion/GPUToROCDL/Runtimes.h"
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
-#include "mlir/Pass/Pass.h"
-#include "llvm/ADT/DenseSet.h"
-#include <cstddef>
 #include <memory>
 
 namespace mlir {
+class Pass;
 class LLVMTypeConverter;
 class ConversionTarget;
 class RewritePatternSet;

--- a/mlir/include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h
+++ b/mlir/include/mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h
@@ -10,6 +10,7 @@
 
 #include "mlir/Conversion/GPUToROCDL/Runtimes.h"
 #include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
+#include "mlir/Pass/Pass.h"
 #include "llvm/ADT/DenseSet.h"
 #include <cstddef>
 #include <memory>
@@ -43,18 +44,6 @@ void populateGpuToROCDLConversionPatterns(const LLVMTypeConverter &converter,
 
 /// Configure target to convert from the GPU dialect to ROCDL.
 void configureGpuToROCDLConversionLegality(ConversionTarget &target);
-
-/// Creates a pass that lowers GPU dialect operations to ROCDL counterparts. The
-/// index bitwidth used for the lowering of the device side index computations
-/// is configurable.
-std::unique_ptr<OperationPass<gpu::GPUModuleOp>>
-createLowerGpuOpsToROCDLOpsPass(
-    const std::string &chipset = "gfx900",
-    unsigned indexBitwidth = kDeriveIndexBitwidthFromDataLayout,
-    bool useBarePtrCallConv = false,
-    gpu::amd::Runtime runtime = gpu::amd::Runtime::Unknown,
-    const std::optional<llvm::SmallDenseSet<llvm::StringRef>> &allowedDialects =
-        std::nullopt);
 
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -624,7 +624,6 @@ def ConvertGpuOpsToNVVMOps : Pass<"convert-gpu-to-nvvm", "gpu::GPUModuleOp"> {
 
 def ConvertGpuOpsToROCDLOps : Pass<"convert-gpu-to-rocdl", "gpu::GPUModuleOp"> {
   let summary = "Generate ROCDL operations for gpu operations";
-  let constructor = "mlir::createLowerGpuOpsToROCDLOpsPass()";
   let dependentDialects = [
     "ROCDL::ROCDLDialect",
     "amdgpu::AMDGPUDialect",

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -36,7 +36,6 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -288,6 +287,8 @@ struct GPUShuffleOpLowering : public ConvertOpToLLVMPattern<gpu::ShuffleOp> {
 struct LowerGpuOpsToROCDLOpsPass final
     : public impl::ConvertGpuOpsToROCDLOpsBase<LowerGpuOpsToROCDLOpsPass> {
   LowerGpuOpsToROCDLOpsPass() = default;
+  LowerGpuOpsToROCDLOpsPass(ConvertGpuOpsToROCDLOpsOptions options)
+      : ConvertGpuOpsToROCDLOpsBase(options) {}
   LowerGpuOpsToROCDLOpsPass(
       const std::string &chipset, unsigned indexBitwidth,
       bool useBarePtrCallConv, gpu::amd::Runtime runtime,
@@ -505,13 +506,4 @@ void mlir::populateGpuToROCDLConversionPatterns(
   patterns.add<GPUSubgroupSizeOpToROCDL>(converter, chipset);
 
   populateMathToROCDLConversionPatterns(converter, patterns);
-}
-
-std::unique_ptr<OperationPass<gpu::GPUModuleOp>>
-mlir::createLowerGpuOpsToROCDLOpsPass(
-    const std::string &chipset, unsigned indexBitwidth, bool useBarePtrCallConv,
-    gpu::amd::Runtime runtime,
-    const std::optional<llvm::SmallDenseSet<StringRef>> &allowedDialects) {
-  return std::make_unique<LowerGpuOpsToROCDLOpsPass>(
-      chipset, indexBitwidth, useBarePtrCallConv, runtime, allowedDialects);
 }

--- a/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
+++ b/mlir/lib/Conversion/GPUToROCDL/LowerGpuOpsToROCDLOps.cpp
@@ -286,28 +286,7 @@ struct GPUShuffleOpLowering : public ConvertOpToLLVMPattern<gpu::ShuffleOp> {
 // code.
 struct LowerGpuOpsToROCDLOpsPass final
     : public impl::ConvertGpuOpsToROCDLOpsBase<LowerGpuOpsToROCDLOpsPass> {
-  LowerGpuOpsToROCDLOpsPass() = default;
-  LowerGpuOpsToROCDLOpsPass(ConvertGpuOpsToROCDLOpsOptions options)
-      : ConvertGpuOpsToROCDLOpsBase(options) {}
-  LowerGpuOpsToROCDLOpsPass(
-      const std::string &chipset, unsigned indexBitwidth,
-      bool useBarePtrCallConv, gpu::amd::Runtime runtime,
-      std::optional<llvm::SmallDenseSet<StringRef>> allowedDialects) {
-    if (this->chipset.getNumOccurrences() == 0)
-      this->chipset = chipset;
-    if (this->indexBitwidth.getNumOccurrences() == 0)
-      this->indexBitwidth = indexBitwidth;
-    if (this->useBarePtrCallConv.getNumOccurrences() == 0)
-      this->useBarePtrCallConv = useBarePtrCallConv;
-    if (this->runtime.getNumOccurrences() == 0)
-      this->runtime = runtime;
-    if (this->allowedDialects.getNumOccurrences() == 0 &&
-        allowedDialects.has_value()) {
-      for (auto &str : allowedDialects.value()) {
-        this->allowedDialects.push_back(str.str());
-      }
-    }
-  }
+  using Base::Base;
 
   void getDependentDialects(DialectRegistry &registry) const override {
     Base::getDependentDialects(registry);


### PR DESCRIPTION
This PR deletes the `createLowerGpuOpsToROCDLOpsPass` constructor from
the .td file, making the `createConvertGpuOpsToROCDLOps` pass available to
users. This has the following effects:

1. `createLowerGpuOpsToROCDLOpsPass` is not available anymore. Instead,
`createConvertGpuOpsToROCDLOps` should be used. This makes the interface
consistent with ConvertGpuOpsToNVVMOps.

2. To call `createConvertGpuOpsToROCDLOps`, the options must be passed
via ConvertGpuOpsToROCDLOpsOptions. This has the side effect of
making the `allowed-dialects` option available, which was not
accessible via C++ before.