### PR TITLE
[Offload] Skip most liboffload tests if no devices

### DIFF
--- a/offload/unittests/OffloadAPI/common/Environment.cpp
+++ b/offload/unittests/OffloadAPI/common/Environment.cpp
@@ -129,6 +129,9 @@ const std::vector<TestEnvironment::Device> &TestEnvironment::getDevices() {
     }
   }
 
+  if (Devices.size() <= 1)
+    errs() << "Warning: No devices found for OffloadAPI tests.\n";
+
   return Devices;
 }
 

--- a/offload/unittests/OffloadAPI/common/Environment.cpp
+++ b/offload/unittests/OffloadAPI/common/Environment.cpp
@@ -129,7 +129,7 @@ const std::vector<TestEnvironment::Device> &TestEnvironment::getDevices() {
     }
   }
 
-  if (Devices.size() <= 1)
+  if (Devices.size() == 0)
     errs() << "Warning: No devices found for OffloadAPI tests.\n";
 
   return Devices;

--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -250,9 +250,13 @@ struct OffloadEventTest : OffloadQueueTest {
   ol_event_handle_t Event = nullptr;
 };
 
+// Devices might not be available for offload testing, so allow uninstantiated
+// tests (as the device list will be empty). This means that all tests requiring
+// a device will be silently skipped.
 #define OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(FIXTURE)                      \
   INSTANTIATE_TEST_SUITE_P(                                                    \
       , FIXTURE, ::testing::ValuesIn(TestEnvironment::getDevices()),           \
       [](const ::testing::TestParamInfo<TestEnvironment::Device> &info) {      \
         return SanitizeString(info.param.Name);                                \
-      })
+      });                                                                      \
+  GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(FIXTURE)


### PR DESCRIPTION
If there are no devices available for testing on liboffload, the test
will no longer throw an error when it fails to instantiate.

The tests will be silently skipped, but with a warning printed to
stderr.
