### PR TITLE
[lldb][test] Prevent TestqOffsets.py picking up host binaries

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestqOffsets.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestqOffsets.py
@@ -10,13 +10,10 @@ class TestqOffsets(GDBRemoteTestBase):
         def qOffsets(self):
             return "Text=470000;Data=470000"
 
-        def qfThreadInfo(self):
-            # Prevent LLDB defaulting to PID of 1 and looking up some other
-            # process when on an AArch64 host.
-            return "m-1"
-
     def test(self):
         self.server.responder = TestqOffsets.Responder()
+        # This ensures that we do not pick up any binaries on the host.
+        self.runCmd("platform select remote-linux")
         target = self.createTarget("qOffsets.yaml")
         text = target.modules[0].FindSection(".text")
         self.assertEqual(text.GetLoadAddress(target), lldb.LLDB_INVALID_ADDRESS)

--- a/lldb/test/API/functionalities/gdb_remote_client/TestqOffsets.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestqOffsets.py
@@ -10,6 +10,11 @@ class TestqOffsets(GDBRemoteTestBase):
         def qOffsets(self):
             return "Text=470000;Data=470000"
 
+        def qfThreadInfo(self):
+            # Prevent LLDB defaulting to PID of 1 and looking up some other
+            # process when on an AArch64 host.
+            return "m-1"
+
     def test(self):
         self.server.responder = TestqOffsets.Responder()
         target = self.createTarget("qOffsets.yaml")


### PR DESCRIPTION
Due to a fallback in GDBRemoteCommunicationClient.cpp, on Linux we will assume a PID of 1 if the remote does not respond in some way that tells us the real PID.

So if PID 1 happened to be a process that the current user could read, we would try to debug that instead. On my current machine, PID 1 was sshd run by root so we would ignore it. If I changed the fallback to some process ID run by my user, the test would fail.

To prevent this, select the remote-linux platform before creating the target. This means we won't attempt any host lookups.

Fixes #155895