### PR TITLE
[MLIR] Add option to postpone remark emission

### DIFF
--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -356,8 +356,8 @@ public:
 class RemarkEngine {
 private:
   /// Postponed remarks. They are deferred to the end of the pipeline, where the
-  /// user can intercept them for custom processing, otherwise they will be reported
-  /// on engine destruction.
+  /// user can intercept them for custom processing, otherwise they will be
+  /// reported on engine destruction.
   llvm::SmallVector<Remark, 8> postponedRemarks;
   /// Regex that filters missed optimization remarks: only matching one are
   /// reported.
@@ -412,7 +412,7 @@ private:
 
   /// Report a remark. When `forcePrintPostponedRemarks` is true, the remark
   /// will be printed even if it is postponed.
-  void report(const Remark &remark, bool forcePrintPostponedRemarks);
+  void reportImpl(const Remark &remark);
 
 public:
   /// Default constructor is deleted, use the other constructor.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -445,10 +445,10 @@ public:
   InFlightRemark emitOptimizationRemarkAnalysis(Location loc, RemarkOpts opts);
 
   /// Get the postponed remarks.
-  ArrayRef<Remark>  getPostponedRemarks() const { return postponedRemarks; }
+  ArrayRef<Remark> getPostponedRemarks() const { return postponedRemarks; }
 
   /// Clear the postponed remarks.
-  void  clearPostponedRemarks()  { postponedRemarks.clear(); }
+  void clearPostponedRemarks() { postponedRemarks.clear(); }
 };
 
 template <typename Fn, typename... Args>

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -355,7 +355,9 @@ public:
 
 class RemarkEngine {
 private:
-  /// Postponed remarks. They are shown at the end of the pipeline.
+  /// Postponed remarks. They are deferred to the end of the pipeline, where the
+  /// user can intercept them for custom processing, otherwise they will be reported
+  /// on engine destruction.
   llvm::SmallVector<Remark, 8> postponedRemarks;
   /// Regex that filters missed optimization remarks: only matching one are
   /// reported.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -13,6 +13,7 @@
 #ifndef MLIR_IR_REMARKS_H
 #define MLIR_IR_REMARKS_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/Remarks/Remark.h"
@@ -442,6 +443,12 @@ public:
   /// Report an analysis remark, this will create an InFlightRemark
   /// that can be used to build the remark using the << operator.
   InFlightRemark emitOptimizationRemarkAnalysis(Location loc, RemarkOpts opts);
+
+  /// Get the postponed remarks.
+  ArrayRef<Remark>  getPostponedRemarks() const { return postponedRemarks; }
+
+  /// Clear the postponed remarks.
+  void  clearPostponedRemarks()  { postponedRemarks.clear(); }
 };
 
 template <typename Fn, typename... Args>

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -408,6 +408,10 @@ private:
   /// Emit all postponed remarks.
   void emitPostponedRemarks();
 
+  /// Report a remark. When `forcePrintPostponedRemarks` is true, the remark
+  /// will be printed even if it is postponed.
+  void report(const Remark &remark, bool forcePrintPostponedRemarks);
+
 public:
   /// Default constructor is deleted, use the other constructor.
   RemarkEngine() = delete;
@@ -426,7 +430,7 @@ public:
                            std::string *errMsg);
 
   /// Report a remark.
-  void report(const Remark &remark, bool ignorePostpone = false);
+  void report(const Remark &remark);
 
   /// Report a successful remark, this will create an InFlightRemark
   /// that can be used to build the remark using the << operator.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -78,7 +78,7 @@ struct RemarkOpts {
   constexpr RemarkOpts function(StringRef v) const {
     return {remarkName, categoryName, subCategoryName, v, postponed};
   }
-  /// Return a copy with the function name set.
+  /// Return a copy with the postponed flag set.
   constexpr RemarkOpts postpone() const {
     return {remarkName, categoryName, subCategoryName, functionName, true};
   }
@@ -103,7 +103,6 @@ public:
           .toStringRef(fullCategoryName);
     }
   }
-  ~Remark() = default;
 
   // Remark argument that is a key-value pair that can be printed as machine
   // parsable args.

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -278,6 +278,9 @@ public:
     }
   }
   ~MLIRContextImpl() {
+    // finalize remark engine before destroying anything else.
+    remarkEngine.reset();
+
     for (auto typeMapping : registeredTypes)
       typeMapping.second->~AbstractType();
     for (auto attrMapping : registeredAttributes)

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -225,14 +225,7 @@ InFlightRemark RemarkEngine::emitOptimizationRemarkAnalysis(Location loc,
 // RemarkEngine
 //===----------------------------------------------------------------------===//
 
-void RemarkEngine::report(const Remark &remark,
-                          bool forcePrintPostponedRemarks) {
-  // Postponed remarks are shown at the end of pipeline, unless overridden.
-  if (remark.isPostponed() && !forcePrintPostponedRemarks) {
-    postponedRemarks.push_back(remark);
-    return;
-  }
-
+void RemarkEngine::reportImpl(const Remark &remark) {
   // Stream the remark
   if (remarkStreamer)
     remarkStreamer->streamOptimizationRemark(remark);

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -157,7 +157,7 @@ llvm::remarks::Remark Remark::generateRemark() const {
 
 InFlightRemark::~InFlightRemark() {
   if (remark && owner)
-    owner->report(std::move(*remark));
+    owner->report(*remark);
   owner = nullptr;
 }
 
@@ -225,9 +225,10 @@ InFlightRemark RemarkEngine::emitOptimizationRemarkAnalysis(Location loc,
 // RemarkEngine
 //===----------------------------------------------------------------------===//
 
-void RemarkEngine::report(const Remark &remark, bool ignorePostpone) {
+void RemarkEngine::report(const Remark &remark,
+                          bool forcePrintPostponedRemarks) {
   // Postponed remarks are shown at the end of pipeline, unless overridden.
-  if (remark.isPostponed() && !ignorePostpone) {
+  if (remark.isPostponed() && !forcePrintPostponedRemarks) {
     postponedRemarks.push_back(remark);
     return;
   }
@@ -241,9 +242,13 @@ void RemarkEngine::report(const Remark &remark, bool ignorePostpone) {
     emitRemark(remark.getLocation(), remark.getMsg());
 }
 
+void RemarkEngine::report(const Remark &remark) {
+  report(remark, /*forcePrintPostponedRemarks=*/false);
+}
+
 void RemarkEngine::emitPostponedRemarks() {
   for (auto &remark : postponedRemarks)
-    report(remark, /*ignorePostpone=*/true);
+    report(remark, /*forcePrintPostponedRemarks=*/true);
   postponedRemarks.clear();
 }
 

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -241,7 +241,7 @@ void RemarkEngine::report(const Remark &remark) {
 
 void RemarkEngine::emitPostponedRemarks() {
   for (auto &remark : postponedRemarks)
-    report(remark, /*forcePrintPostponedRemarks=*/true);
+    reportImpl(remark);
   postponedRemarks.clear();
 }
 

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -236,7 +236,13 @@ void RemarkEngine::reportImpl(const Remark &remark) {
 }
 
 void RemarkEngine::report(const Remark &remark) {
-  report(remark, /*forcePrintPostponedRemarks=*/false);
+  // Postponed remarks are deferred to the end of pipeline.
+  if (remark.isPostponed()) {
+    postponedRemarks.push_back(remark);
+    return;
+  }
+
+  reportImpl(remark);
 }
 
 void RemarkEngine::emitPostponedRemarks() {

--- a/mlir/unittests/IR/RemarkTest.cpp
+++ b/mlir/unittests/IR/RemarkTest.cpp
@@ -280,7 +280,7 @@ TEST(Remark, TestCustomOptimizationRemarkDiagnostic) {
     Location loc = UnknownLoc::get(&context);
 
     // Setup the remark engine
-    mlir::remark::RemarkCategories cats{/*all=*/"",
+    mlir::remark::RemarkCategories cats{/*all=*/std::nullopt,
                                         /*passed=*/categoryLoopunroll,
                                         /*missed=*/std::nullopt,
                                         /*analysis=*/std::nullopt,
@@ -332,7 +332,8 @@ TEST(Remark, TestCustomOptimizationRemarkPostponeDiagnostic) {
     Location loc = UnknownLoc::get(&context);
 
     // Setup the remark engine
-    mlir::remark::RemarkCategories cats{/*passed=*/categoryLoopunroll,
+    mlir::remark::RemarkCategories cats{/*all=*/std::nullopt,
+                                        /*passed=*/categoryLoopunroll,
                                         /*missed=*/std::nullopt,
                                         /*analysis=*/std::nullopt,
                                         /*failed=*/categoryLoopunroll};


### PR DESCRIPTION
By default, `InFlightRemark` are emitted as soon as their scope ends.

This PR adds a mode to postpone emission until the end of compilation, so remarks are processed at once.

It also provides `getPostponedRemarks` function. So if it's desired the compiler can postpone all the remarks until the end, then sort it or do something with them, and show it to the user. 

**Future work:**
This feature will allow later passes to drop, rewrite, or aggregate remarks before they are printed/streamed. This will be done in follow-up PRs.