### PR TITLE
[NFC][analyzer] Rename `ValistChecker.cpp` to `VAListChecker.cpp`

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -127,7 +127,7 @@ add_clang_library(clangStaticAnalyzerCheckers
   UnreachableCodeChecker.cpp
   VforkChecker.cpp
   VLASizeChecker.cpp
-  ValistChecker.cpp
+  VAListChecker.cpp
   VirtualCallChecker.cpp
   WebKit/ASTUtils.cpp
   WebKit/ForwardDeclChecker.cpp

--- a/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/VAListChecker.cpp
@@ -1,4 +1,4 @@
-//== ValistChecker.cpp - stdarg.h macro usage checker -----------*- C++ -*--==//
+//== VAListChecker.cpp - stdarg.h macro usage checker -----------*- C++ -*--==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/utils/gn/secondary/clang/lib/StaticAnalyzer/Checkers/BUILD.gn
+++ b/llvm/utils/gn/secondary/clang/lib/StaticAnalyzer/Checkers/BUILD.gn
@@ -135,7 +135,7 @@ static_library("Checkers") {
     "UnixAPIChecker.cpp",
     "UnreachableCodeChecker.cpp",
     "VLASizeChecker.cpp",
-    "ValistChecker.cpp",
+    "VAListChecker.cpp",
     "VforkChecker.cpp",
     "VirtualCallChecker.cpp",
     "WebKit/ASTUtils.cpp",


### PR DESCRIPTION
...to follow the capitalization style that was already applied within the file by recent commit a80c393a9c498279a1ec9fd630535b9ff139b49f.