### PR TITLE
[NFC][analyzer] Fix copypaste error in security.VAList docs

### DIFF
--- a/clang/docs/analyzer/checkers.rst
+++ b/clang/docs/analyzer/checkers.rst
@@ -1866,11 +1866,6 @@ security.VAList (C, C++)
 Reports use of uninitialized (or already released) ``va_list`` objects and
 situations where a ``va_start`` call is not followed by ``va_end``.
 
-Report out of bounds access to memory that is before the start or after the end
-of the accessed region (array, heap-allocated region, string literal etc.).
-This usually means incorrect indexing, but the checker also detects access via
-the operators ``*`` and ``->``.
-
 .. code-block:: c
 
  int test_use_after_release(int x, ...) {


### PR DESCRIPTION
My recent commit a80c393a9c498279a1ec9fd630535b9ff139b49f accidentally added a paragraph which does not belong to the new documentation of the checker `security.VAList`; this commit corrects this mistake.