### PR TITLE
[mlir][spirv] Check variable for null before dereferencing

### DIFF
--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -723,13 +723,15 @@ void mlir::spirv::ConstantOp::getAsmResultNames(
   IntegerType intTy = llvm::dyn_cast<IntegerType>(type);
 
   if (IntegerAttr intCst = llvm::dyn_cast<IntegerAttr>(getValue())) {
-    if (intTy && intTy.getWidth() == 1) {
+    assert(intTy);
+
+    if (intTy.getWidth() == 1) {
       return setNameFn(getResult(), (intCst.getInt() ? "true" : "false"));
     }
 
-    if (intTy && intTy.isSignless()) {
+    if (intTy.isSignless()) {
       specialName << intCst.getInt();
-    } else if (intTy && intTy.isUnsigned()) {
+    } else if (intTy.isUnsigned()) {
       specialName << intCst.getUInt();
     } else {
       specialName << intCst.getSInt();

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVOps.cpp
@@ -727,9 +727,9 @@ void mlir::spirv::ConstantOp::getAsmResultNames(
       return setNameFn(getResult(), (intCst.getInt() ? "true" : "false"));
     }
 
-    if (intTy.isSignless()) {
+    if (intTy && intTy.isSignless()) {
       specialName << intCst.getInt();
-    } else if (intTy.isUnsigned()) {
+    } else if (intTy && intTy.isUnsigned()) {
       specialName << intCst.getUInt();
     } else {
       specialName << intCst.getSInt();


### PR DESCRIPTION
FIxes #157453 