### PR TITLE
[llvm] Validate Parent object before dereference

### DIFF
--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -475,8 +475,7 @@ Archive::Child::Child(const Archive *Parent, const char *Start, Error *Err)
   assert(Parent && "Parent can't be nullptr if Start is not a nullptr");
 
   Header = Parent->createArchiveMemberHeader(
-      Start,
-      Parent->getData().size() - (Start - Parent->getData().data()),
+      Start, Parent->getData().size() - (Start - Parent->getData().data()),
       Err);
 
   // If we are pointed to real data, Start is not a nullptr, then there must be

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -472,8 +472,6 @@ Archive::Child::Child(const Archive *Parent, const char *Start, Error *Err)
     return;
   }
 
-  assert(Parent && "Parent can't be nullptr if Start is not a nullptr");
-
   Header = Parent->createArchiveMemberHeader(
       Start, Parent->getData().size() - (Start - Parent->getData().data()),
       Err);

--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -472,10 +472,11 @@ Archive::Child::Child(const Archive *Parent, const char *Start, Error *Err)
     return;
   }
 
+  assert(Parent && "Parent can't be nullptr if Start is not a nullptr");
+
   Header = Parent->createArchiveMemberHeader(
       Start,
-      Parent ? Parent->getData().size() - (Start - Parent->getData().data())
-             : 0,
+      Parent->getData().size() - (Start - Parent->getData().data()),
       Err);
 
   // If we are pointed to real data, Start is not a nullptr, then there must be


### PR DESCRIPTION
Fixes #157449 