### PR TITLE
[clang-tidy][NFC] Enable `modernize-use-auto` in clang-tidy config and fix warnings

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -11,7 +11,6 @@ Checks: >
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-pass-by-value,
-  -modernize-use-auto,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,

--- a/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseIntegerSignComparisonCheck.cpp
@@ -138,9 +138,9 @@ void UseIntegerSignComparisonCheck::check(
     return;
   const Expr *SubExprLHS = nullptr;
   const Expr *SubExprRHS = nullptr;
-  SourceRange R1 = SourceRange(LHS->getBeginLoc());
-  SourceRange R2 = SourceRange(BinaryOp->getOperatorLoc());
-  SourceRange R3 = SourceRange(Lexer::getLocForEndOfToken(
+  SourceRange R1(LHS->getBeginLoc());
+  SourceRange R2(BinaryOp->getOperatorLoc());
+  SourceRange R3(Lexer::getLocForEndOfToken(
       RHS->getEndLoc(), 0, *Result.SourceManager, getLangOpts()));
   if (const auto *LHSCast = llvm::dyn_cast<ExplicitCastExpr>(LHS)) {
     SubExprLHS = LHSCast->getSubExpr();

--- a/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseScopedLockCheck.cpp
@@ -98,7 +98,7 @@ static SourceRange getLockGuardRange(const TypeSourceInfo *SourceInfo) {
 
 // Find the exact source range of the 'lock_guard' name token
 static SourceRange getLockGuardNameRange(const TypeSourceInfo *SourceInfo) {
-  const TemplateSpecializationTypeLoc TemplateLoc =
+  const auto TemplateLoc =
       SourceInfo->getTypeLoc().getAs<TemplateSpecializationTypeLoc>();
   if (!TemplateLoc)
     return {};

--- a/clang-tools-extra/clang-tidy/readability/UseStdMinMaxCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/UseStdMinMaxCheck.cpp
@@ -62,7 +62,7 @@ static bool maxCondition(const BinaryOperator::Opcode Op, const Expr *CondLhs,
 static QualType getNonTemplateAlias(QualType QT) {
   while (true) {
     // cast to a TypedefType
-    if (const TypedefType *TT = dyn_cast<TypedefType>(QT)) {
+    if (const auto *TT = dyn_cast<TypedefType>(QT)) {
       // check if the typedef is a template and if it is dependent
       if (!TT->getDecl()->getDescribedTemplate() &&
           !TT->getDecl()->getDeclContext()->isDependentContext())


### PR DESCRIPTION
Closes [#156154](https://github.com/llvm/llvm-project/issues/156154)