### PR TITLE
[Verifier][AMDGPU] Restrict targets for chain calling convention.

### DIFF
--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2938,10 +2938,16 @@ void Verifier::visitFunction(const Function &F) {
           "Calling convention parameter requires byval", &F);
     break;
   }
-  case CallingConv::AMDGPU_KERNEL:
-  case CallingConv::SPIR_KERNEL:
   case CallingConv::AMDGPU_CS_Chain:
   case CallingConv::AMDGPU_CS_ChainPreserve:
+  {
+    auto TT = M.getTargetTriple().str();
+    if (TT.find("gfx1200") || TT.find("gfx942"))
+      Check(false, "Chain calling convention is invalid on this target", &F);
+  }
+    [[fallthrough]];
+  case CallingConv::AMDGPU_KERNEL:
+  case CallingConv::SPIR_KERNEL:
     Check(F.getReturnType()->isVoidTy(),
           "Calling convention requires void return type", &F);
     [[fallthrough]];

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-cs-chain-invalid-arch.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-cs-chain-invalid-arch.ll
@@ -1,0 +1,6 @@
+; RUN: not llc -mtriple=amdgcn -mcpu=gfx1200 -o - < %s 2>&1 | FileCheck %s
+
+define amdgpu_cs_chain void @test_alloca() {
+; CHECK: Chain calling convention is invalid on this target
+  ret void
+}


### PR DESCRIPTION
The chain calling convention is invalid in particular situations like being on an architecture it cannot compile to.