### PR TITLE
[lldb][test] StepUntil disable test for unsupported linkers.

### DIFF
--- a/lldb/test/API/functionalities/thread/step_until/TestStepUntil.py
+++ b/lldb/test/API/functionalities/thread/step_until/TestStepUntil.py
@@ -1,10 +1,9 @@
 """Test stepping over vrs. hitting breakpoints & subsequent stepping in various forms."""
 
-
-import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+from lldbsuite.test_event.build_exception import BuildError
 
 
 class StepUntilTestCase(TestBase):
@@ -112,10 +111,15 @@ class StepUntilTestCase(TestBase):
     @no_debug_info_test
     @skipIf(oslist=lldbplatformutil.getDarwinOSTriples() + ["windows"])
     @skipIf(archs=no_match(["x86_64", "aarch64"]))
+    @skipIf(compiler=no_match(["clang"]))
     def test_bad_line_discontinuous(self):
         """Test that we get an error if attempting to step outside the current
         function -- and the function is discontinuous"""
-        self.build(dictionary=self._build_dict_for_discontinuity())
+        try:
+            self.build(dictionary=self._build_dict_for_discontinuity())
+        except BuildError as ex:
+            self.skipTest(f"failed to build with linker script.")
+
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "At the start", lldb.SBFileSpec(self.main_source)
         )


### PR DESCRIPTION
`INSERT BEFORE` keyword is not supported in current versions gold and mold linkers. Since we cannot confirm accurately what linker and version is available on the system and when it will be supported. We test it with a sample program using the script keywords.