### PR TITLE
[LLD][COFF] Make `/summary` work when `/debug` isn't provided

### DIFF
--- a/lld/COFF/COFFLinkerContext.h
+++ b/lld/COFF/COFFLinkerContext.h
@@ -14,6 +14,7 @@
 #include "DebugTypes.h"
 #include "Driver.h"
 #include "InputFiles.h"
+#include "PDB.h"
 #include "SymbolTable.h"
 #include "Writer.h"
 #include "lld/Common/CommonLinkerContext.h"
@@ -112,6 +113,8 @@ public:
   Timer publicsLayoutTimer;
   Timer tpiStreamLayoutTimer;
   Timer diskCommitTimer;
+
+  std::optional<PDBStats> pdbStats;
 
   Configuration config;
 

--- a/lld/COFF/PDB.h
+++ b/lld/COFF/PDB.h
@@ -30,6 +30,19 @@ void createPDB(COFFLinkerContext &ctx, llvm::ArrayRef<uint8_t> sectionTable,
 std::optional<std::pair<llvm::StringRef, uint32_t>>
 getFileLineCodeView(const SectionChunk *c, uint32_t addr);
 
+// For statistics
+struct PDBStats {
+  uint64_t globalSymbols = 0;
+  uint64_t moduleSymbols = 0;
+  uint64_t publicSymbols = 0;
+  uint64_t nbTypeRecords = 0;
+  uint64_t nbTypeRecordsBytes = 0;
+  uint64_t nbTPIrecords = 0;
+  uint64_t nbIPIrecords = 0;
+  uint64_t strTabSize = 0;
+  std::string largeInputTypeRecs;
+};
+
 } // namespace coff
 } // namespace lld
 

--- a/lld/test/COFF/pdb-type-server-simple.test
+++ b/lld/test/COFF/pdb-type-server-simple.test
@@ -110,8 +110,8 @@ SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line i
 SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    1 PDB type server dependencies
 SUMMARY-NEXT:                    0 Precomp OBJ dependencies
-SUMMARY-NEXT:                   25 Input type records
-SUMMARY-NEXT:                  868 Size of all input type records, in bytes
+SUMMARY-NEXT:                   25 Input debug type records
+SUMMARY-NEXT:                  868 Size of all input debug type records, in bytes
 SUMMARY-NEXT:                    9 Merged TPI records
 SUMMARY-NEXT:                   16 Merged IPI records
 SUMMARY-NEXT:                    3 Output PDB strings

--- a/lld/test/COFF/precomp-link.test
+++ b/lld/test/COFF/precomp-link.test
@@ -3,6 +3,9 @@ RUN: llvm-pdbutil dump -types %t.pdb | FileCheck %s
 RUN: lld-link %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj %S/Inputs/precomp.obj /nodefaultlib /entry:main /debug:ghash /pdb:%t.pdb /out:%t.exe /opt:ref /opt:icf /summary | FileCheck %s -check-prefix SUMMARY
 RUN: llvm-pdbutil dump -types %t.pdb | FileCheck %s
 
+RUN: lld-link %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj %S/Inputs/precomp.obj /nodefaultlib /entry:main /out:%t.exe /opt:ref /opt:icf /summary | FileCheck %s -check-prefix SUMMARY-NODEBUG
+RUN: lld-link %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj %S/Inputs/precomp.obj /nodefaultlib /entry:main /out:%t.exe /opt:ref /opt:icf /summary | FileCheck %s -check-prefix SUMMARY-NODEBUG
+
 RUN: lld-link %S/Inputs/precomp.obj %S/Inputs/precomp-a.obj %S/Inputs/precomp-b.obj /nodefaultlib /entry:main /debug /pdb:%t.pdb /out:%t.exe /opt:ref /opt:icf
 RUN: llvm-pdbutil dump -types %t.pdb | FileCheck %s
 
@@ -63,14 +66,29 @@ SUMMARY-NEXT:                    3 Input OBJ files (expanded from all cmd-line i
 SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    0 PDB type server dependencies
 SUMMARY-NEXT:                    1 Precomp OBJ dependencies
-SUMMARY-NEXT:                1,066 Input type records
-SUMMARY-NEXT:               55,968 Size of all input type records, in bytes
+SUMMARY-NEXT:                1,066 Input debug type records
+SUMMARY-NEXT:               55,968 Size of all input debug type records, in bytes
 SUMMARY-NEXT:                  874 Merged TPI records
 SUMMARY-NEXT:                  170 Merged IPI records
 SUMMARY-NEXT:                    5 Output PDB strings
 SUMMARY-NEXT:                  167 Global symbol records
 SUMMARY-NEXT:                   20 Module symbol records
 SUMMARY-NEXT:                    3 Public symbol records
+
+SUMMARY-NODEBUG:                                     Summary
+SUMMARY-NODEBUG-NEXT: --------------------------------------------------------------------------------
+SUMMARY-NODEBUG-NEXT:                    3 Input OBJ files (expanded from all cmd-line inputs)
+SUMMARY-NODEBUG-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
+SUMMARY-NODEBUG-NEXT:                    0 PDB type server dependencies
+SUMMARY-NODEBUG-NEXT:                    0 Precomp OBJ dependencies
+SUMMARY-NODEBUG-NEXT:                    0 Input debug type records
+SUMMARY-NODEBUG-NEXT:                    0 Size of all input debug type records, in bytes
+SUMMARY-NODEBUG-NEXT:                    0 Merged TPI records
+SUMMARY-NODEBUG-NEXT:                    0 Merged IPI records
+SUMMARY-NODEBUG-NEXT:                    0 Output PDB strings
+SUMMARY-NODEBUG-NEXT:                    0 Global symbol records
+SUMMARY-NODEBUG-NEXT:                    0 Module symbol records
+SUMMARY-NODEBUG-NEXT:                    0 Public symbol records
 
 // precomp.h
 #pragma once

--- a/lld/test/COFF/precomp-summary-fail.test
+++ b/lld/test/COFF/precomp-summary-fail.test
@@ -15,8 +15,8 @@ SUMMARY-NEXT:                    2 Input OBJ files (expanded from all cmd-line i
 SUMMARY-NEXT: Size of all consumed OBJ files (non-lazy), in bytes
 SUMMARY-NEXT:                    0 PDB type server dependencies
 SUMMARY-NEXT:                    1 Precomp OBJ dependencies
-SUMMARY-NEXT:                    8 Input type records
-SUMMARY-NEXT:                  232 Size of all input type records, in bytes
+SUMMARY-NEXT:                    8 Input debug type records
+SUMMARY-NEXT:                  232 Size of all input debug type records, in bytes
 SUMMARY-NEXT:                    3 Merged TPI records
 SUMMARY-NEXT:                    2 Merged IPI records
 SUMMARY-NEXT:                    1 Output PDB strings


### PR DESCRIPTION
Previously, `/summary` was meant to print some PDB information. Now move handling of `/summary` to `Writer.cpp` so that it can have an effect when `/debug` isn't provided. This will also provide grounds for extending with more general information.
