### PR TITLE
[CIR] Fix assertion order in 'Address'

### DIFF
--- a/clang/lib/CIR/CodeGen/Address.h
+++ b/clang/lib/CIR/CodeGen/Address.h
@@ -44,12 +44,12 @@ public:
           clang::CharUnits alignment)
       : pointerAndKnownNonNull(pointer, false), elementType(elementType),
         alignment(alignment) {
-    assert(mlir::isa<cir::PointerType>(pointer.getType()) &&
-           "Expected cir.ptr type");
-
     assert(pointer && "Pointer cannot be null");
     assert(elementType && "Element type cannot be null");
     assert(!alignment.isZero() && "Alignment cannot be zero");
+
+    assert(mlir::isa<cir::PointerType>(pointer.getType()) &&
+           "Expected cir.ptr type");
 
     assert(mlir::cast<cir::PointerType>(pointer.getType()).getPointee() ==
            elementType);


### PR DESCRIPTION
We are checking the 'type' of 'pointer' before we are checking whether it is null or not!  This is clearly incorrect, so this patch reorders the asserts.