### PR TITLE
[Offload] Have olMemFree accept a platform as a param

### DIFF
--- a/offload/liboffload/API/Memory.td
+++ b/offload/liboffload/API/Memory.td
@@ -37,9 +37,12 @@ def olMemAlloc : Function {
 def olMemFree : Function {
   let desc = "Frees a memory allocation previously made by olMemAlloc.";
   let params = [
+    Param<"ol_platform_handle_t", "Platform", "handle of the platform that allocated this memory", PARAM_IN>,
     Param<"void*", "Address", "address of the allocation to free", PARAM_IN>,
   ];
-  let returns = [];
+  let returns = [
+    Return<"OL_ERRC_NOT_FOUND", ["memory was not allocated by this platform"]>
+  ];
 }
 
 def olMemcpy : Function {

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -632,7 +632,7 @@ Error olMemAlloc_impl(ol_device_handle_t Device, ol_alloc_type_t Type,
   return Error::success();
 }
 
-Error olMemFree_impl(void *Address) {
+Error olMemFree_impl(ol_platform_handle_t Platform, void *Address) {
   ol_device_handle_t Device;
   ol_alloc_type_t Type;
   {
@@ -646,6 +646,7 @@ Error olMemFree_impl(void *Address) {
     Type = AllocInfo.Type;
     OffloadContext::get().AllocInfoMap.erase(Address);
   }
+  assert(Platform == Device->Platform);
 
   if (auto Res =
           Device->Device->dataDelete(Address, convertOlToPluginAllocTy(Type)))

--- a/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
@@ -57,13 +57,13 @@ public:
   explicit DeviceContext(llvm::StringRef Platform, std::size_t DeviceId = 0);
 
   template <typename T>
-  ManagedBuffer<T> createManagedBuffer(std::size_t Size) noexcept {
+  ManagedBuffer<T> createManagedBuffer(std::size_t Size) const noexcept {
     void *UntypedAddress = nullptr;
 
     detail::allocManagedMemory(DeviceHandle, Size * sizeof(T), &UntypedAddress);
     T *TypedAddress = static_cast<T *>(UntypedAddress);
 
-    return ManagedBuffer<T>(getPlatformHandle(), TypedAddress, Size);
+    return ManagedBuffer<T>(PlatformHandle, TypedAddress, Size);
   }
 
   [[nodiscard]] llvm::Expected<std::shared_ptr<DeviceImage>>
@@ -120,9 +120,6 @@ public:
 
   [[nodiscard]] llvm::StringRef getPlatform() const noexcept;
 
-  [[nodiscard]] llvm::Expected<ol_platform_handle_t>
-  getPlatformHandle() noexcept;
-
 private:
   [[nodiscard]] llvm::Expected<ol_symbol_handle_t>
   getKernelHandle(ol_program_handle_t ProgramHandle,
@@ -134,7 +131,7 @@ private:
 
   std::size_t GlobalDeviceId;
   ol_device_handle_t DeviceHandle;
-  ol_platform_handle_t PlatformHandle = nullptr;
+  ol_platform_handle_t PlatformHandle;
 };
 } // namespace mathtest
 

--- a/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
@@ -57,13 +57,13 @@ public:
   explicit DeviceContext(llvm::StringRef Platform, std::size_t DeviceId = 0);
 
   template <typename T>
-  ManagedBuffer<T> createManagedBuffer(std::size_t Size) const noexcept {
+  ManagedBuffer<T> createManagedBuffer(std::size_t Size) noexcept {
     void *UntypedAddress = nullptr;
 
     detail::allocManagedMemory(DeviceHandle, Size * sizeof(T), &UntypedAddress);
     T *TypedAddress = static_cast<T *>(UntypedAddress);
 
-    return ManagedBuffer<T>(TypedAddress, Size);
+    return ManagedBuffer<T>(getPlatformHandle(), TypedAddress, Size);
   }
 
   [[nodiscard]] llvm::Expected<std::shared_ptr<DeviceImage>>
@@ -120,6 +120,9 @@ public:
 
   [[nodiscard]] llvm::StringRef getPlatform() const noexcept;
 
+  [[nodiscard]] llvm::Expected<ol_platform_handle_t>
+  getPlatformHandle() noexcept;
+
 private:
   [[nodiscard]] llvm::Expected<ol_symbol_handle_t>
   getKernelHandle(ol_program_handle_t ProgramHandle,
@@ -131,6 +134,7 @@ private:
 
   std::size_t GlobalDeviceId;
   ol_device_handle_t DeviceHandle;
+  ol_platform_handle_t PlatformHandle = nullptr;
 };
 } // namespace mathtest
 

--- a/offload/unittests/Conformance/include/mathtest/DeviceResources.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceResources.hpp
@@ -29,7 +29,7 @@ class DeviceContext;
 
 namespace detail {
 
-void freeDeviceMemory(void *Address) noexcept;
+void freeDeviceMemory(ol_platform_handle_t Platform, void *Address) noexcept;
 } // namespace detail
 
 //===----------------------------------------------------------------------===//
@@ -40,7 +40,7 @@ template <typename T> class [[nodiscard]] ManagedBuffer {
 public:
   ~ManagedBuffer() noexcept {
     if (Address)
-      detail::freeDeviceMemory(Address);
+      detail::freeDeviceMemory(Platform, Address);
   }
 
   ManagedBuffer(const ManagedBuffer &) = delete;
@@ -57,7 +57,7 @@ public:
       return *this;
 
     if (Address)
-      detail::freeDeviceMemory(Address);
+      detail::freeDeviceMemory(Platform, Address);
 
     Address = Other.Address;
     Size = Other.Size;
@@ -85,9 +85,11 @@ public:
 private:
   friend class DeviceContext;
 
-  explicit ManagedBuffer(T *Address, std::size_t Size) noexcept
-      : Address(Address), Size(Size) {}
+  explicit ManagedBuffer(ol_platform_handle_t Platform, T *Address,
+                         std::size_t Size) noexcept
+      : Platform(Platform), Address(Address), Size(Size) {}
 
+  ol_platform_handle_t Platform;
   T *Address = nullptr;
   std::size_t Size = 0;
 };

--- a/offload/unittests/Conformance/include/mathtest/DeviceResources.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceResources.hpp
@@ -47,7 +47,8 @@ public:
   ManagedBuffer &operator=(const ManagedBuffer &) = delete;
 
   ManagedBuffer(ManagedBuffer &&Other) noexcept
-      : Address(Other.Address), Size(Other.Size) {
+      : Platform(Other.Platform), Address(Other.Address), Size(Other.Size) {
+    Other.Platform = nullptr;
     Other.Address = nullptr;
     Other.Size = 0;
   }
@@ -59,9 +60,11 @@ public:
     if (Address)
       detail::freeDeviceMemory(Platform, Address);
 
+    Platform = Other.Platform;
     Address = Other.Address;
     Size = Other.Size;
 
+    Other.Platform = nullptr;
     Other.Address = nullptr;
     Other.Size = 0;
 
@@ -89,7 +92,7 @@ private:
                          std::size_t Size) noexcept
       : Platform(Platform), Address(Address), Size(Size) {}
 
-  ol_platform_handle_t Platform;
+  ol_platform_handle_t Platform = nullptr;
   T *Address = nullptr;
   std::size_t Size = 0;
 };

--- a/offload/unittests/Conformance/include/mathtest/GpuMathTest.hpp
+++ b/offload/unittests/Conformance/include/mathtest/GpuMathTest.hpp
@@ -75,7 +75,7 @@ public:
 
   ResultType run(GeneratorType &Generator,
                  std::size_t BufferSize = DefaultBufferSize,
-                 uint32_t GroupSize = DefaultGroupSize) noexcept {
+                 uint32_t GroupSize = DefaultGroupSize) const noexcept {
     assert(BufferSize > 0 && "Buffer size must be a positive value");
     assert(GroupSize > 0 && "Group size must be a positive value");
 
@@ -128,7 +128,7 @@ private:
     return *ExpectedKernel;
   }
 
-  [[nodiscard]] auto createBuffers(std::size_t BufferSize) {
+  [[nodiscard]] auto createBuffers(std::size_t BufferSize) const {
     auto InBuffersTuple = std::apply(
         [&](auto... InTypeIdentities) {
           return std::make_tuple(

--- a/offload/unittests/Conformance/include/mathtest/GpuMathTest.hpp
+++ b/offload/unittests/Conformance/include/mathtest/GpuMathTest.hpp
@@ -75,7 +75,7 @@ public:
 
   ResultType run(GeneratorType &Generator,
                  std::size_t BufferSize = DefaultBufferSize,
-                 uint32_t GroupSize = DefaultGroupSize) const noexcept {
+                 uint32_t GroupSize = DefaultGroupSize) noexcept {
     assert(BufferSize > 0 && "Buffer size must be a positive value");
     assert(GroupSize > 0 && "Group size must be a positive value");
 
@@ -128,7 +128,7 @@ private:
     return *ExpectedKernel;
   }
 
-  [[nodiscard]] auto createBuffers(std::size_t BufferSize) const {
+  [[nodiscard]] auto createBuffers(std::size_t BufferSize) {
     auto InBuffersTuple = std::apply(
         [&](auto... InTypeIdentities) {
           return std::make_tuple(

--- a/offload/unittests/Conformance/include/mathtest/OffloadForward.hpp
+++ b/offload/unittests/Conformance/include/mathtest/OffloadForward.hpp
@@ -32,6 +32,9 @@ typedef struct ol_program_impl_t *ol_program_handle_t;
 struct ol_symbol_impl_t;
 typedef struct ol_symbol_impl_t *ol_symbol_handle_t;
 
+struct ol_platform_impl_t;
+typedef struct ol_platform_impl_t *ol_platform_handle_t;
+
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/offload/unittests/Conformance/lib/DeviceContext.cpp
+++ b/offload/unittests/Conformance/lib/DeviceContext.cpp
@@ -286,6 +286,29 @@ DeviceContext::getKernelHandle(ol_program_handle_t ProgramHandle,
   return Handle;
 }
 
+llvm::Expected<ol_platform_handle_t>
+DeviceContext::getPlatformHandle() noexcept {
+  if (!PlatformHandle) {
+    const ol_result_t OlResult =
+        olGetDeviceInfo(DeviceHandle, OL_DEVICE_INFO_PLATFORM,
+                        sizeof(PlatformHandle), &PlatformHandle);
+
+    if (OlResult != OL_SUCCESS) {
+      PlatformHandle = nullptr;
+      llvm::StringRef Details =
+          OlResult->Details ? OlResult->Details : "No details provided";
+
+      // clang-format off
+      return llvm::createStringError(
+        llvm::Twine(Details) +
+        " (code " + llvm::Twine(OlResult->Code) + ")");
+      // clang-format on
+    }
+  }
+
+  return PlatformHandle;
+}
+
 void DeviceContext::launchKernelImpl(
     ol_symbol_handle_t KernelHandle, uint32_t NumGroups, uint32_t GroupSize,
     const void *KernelArgs, std::size_t KernelArgsSize) const noexcept {

--- a/offload/unittests/Conformance/lib/DeviceResources.cpp
+++ b/offload/unittests/Conformance/lib/DeviceResources.cpp
@@ -24,9 +24,10 @@ using namespace mathtest;
 // Helpers
 //===----------------------------------------------------------------------===//
 
-void detail::freeDeviceMemory(void *Address) noexcept {
+void detail::freeDeviceMemory(ol_platform_handle_t Platform,
+                              void *Address) noexcept {
   if (Address)
-    OL_CHECK(olMemFree(Address));
+    OL_CHECK(olMemFree(Platform, Address));
 }
 
 //===----------------------------------------------------------------------===//

--- a/offload/unittests/OffloadAPI/common/Fixtures.hpp
+++ b/offload/unittests/OffloadAPI/common/Fixtures.hpp
@@ -137,13 +137,12 @@ struct OffloadDeviceTest
     Device = DeviceParam.Handle;
     if (Device == nullptr)
       GTEST_SKIP() << "No available devices.";
+
+    ASSERT_SUCCESS(olGetDeviceInfo(Device, OL_DEVICE_INFO_PLATFORM,
+                                   sizeof(ol_platform_handle_t), &Platform));
   }
 
   ol_platform_backend_t getPlatformBackend() const {
-    ol_platform_handle_t Platform = nullptr;
-    if (olGetDeviceInfo(Device, OL_DEVICE_INFO_PLATFORM,
-                        sizeof(ol_platform_handle_t), &Platform))
-      return OL_PLATFORM_BACKEND_UNKNOWN;
     ol_platform_backend_t Backend;
     if (olGetPlatformInfo(Platform, OL_PLATFORM_INFO_BACKEND,
                           sizeof(ol_platform_backend_t), &Backend))
@@ -151,6 +150,7 @@ struct OffloadDeviceTest
     return Backend;
   }
 
+  ol_platform_handle_t Platform = nullptr;
   ol_device_handle_t Device = nullptr;
 };
 

--- a/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
+++ b/offload/unittests/OffloadAPI/kernel/olLaunchKernel.cpp
@@ -101,7 +101,7 @@ TEST_P(olLaunchKernelFooTest, Success) {
     ASSERT_EQ(Data[i], i);
   }
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelFooTest, SuccessThreaded) {
@@ -123,7 +123,7 @@ TEST_P(olLaunchKernelFooTest, SuccessThreaded) {
       ASSERT_EQ(Data[i], i);
     }
 
-    ASSERT_SUCCESS(olMemFree(Mem));
+    ASSERT_SUCCESS(olMemFree(Platform, Mem));
   });
 }
 
@@ -151,7 +151,7 @@ TEST_P(olLaunchKernelFooTest, SuccessSynchronous) {
     ASSERT_EQ(Data[i], i);
   }
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelLocalMemTest, Success) {
@@ -176,7 +176,7 @@ TEST_P(olLaunchKernelLocalMemTest, Success) {
   for (uint32_t i = 0; i < LaunchArgs.GroupSize.x * LaunchArgs.NumGroups.x; i++)
     ASSERT_EQ(Data[i], (i % 64) * 2);
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelLocalMemReductionTest, Success) {
@@ -199,7 +199,7 @@ TEST_P(olLaunchKernelLocalMemReductionTest, Success) {
   for (uint32_t i = 0; i < LaunchArgs.NumGroups.x; i++)
     ASSERT_EQ(Data[i], 2 * LaunchArgs.GroupSize.x);
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelLocalMemStaticTest, Success) {
@@ -222,7 +222,7 @@ TEST_P(olLaunchKernelLocalMemStaticTest, Success) {
   for (uint32_t i = 0; i < LaunchArgs.NumGroups.x; i++)
     ASSERT_EQ(Data[i], 2 * LaunchArgs.GroupSize.x);
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelGlobalTest, Success) {
@@ -245,7 +245,7 @@ TEST_P(olLaunchKernelGlobalTest, Success) {
     ASSERT_EQ(Data[i], i * 2);
   }
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelGlobalTest, InvalidNotAKernel) {
@@ -273,7 +273,7 @@ TEST_P(olLaunchKernelGlobalCtorTest, Success) {
     ASSERT_EQ(Data[i], i + 100);
   }
 
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchKernelGlobalDtorTest, Success) {

--- a/offload/unittests/OffloadAPI/memory/olMemAlloc.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemAlloc.cpp
@@ -17,21 +17,21 @@ TEST_P(olMemAllocTest, SuccessAllocManaged) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED, 1024, &Alloc));
   ASSERT_NE(Alloc, nullptr);
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemAllocTest, SuccessAllocHost) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_HOST, 1024, &Alloc));
   ASSERT_NE(Alloc, nullptr);
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemAllocTest, SuccessAllocDevice) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
   ASSERT_NE(Alloc, nullptr);
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemAllocTest, InvalidNullDevice) {

--- a/offload/unittests/OffloadAPI/memory/olMemFill.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFill.cpp
@@ -39,7 +39,7 @@ struct olMemFillTest : OffloadQueueTest {
       ASSERT_EQ(AllocPtr[i], Pattern);
     }
 
-    olMemFree(Alloc);
+    olMemFree(Platform, Alloc);
   }
 };
 OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olMemFillTest);
@@ -92,7 +92,7 @@ TEST_P(olMemFillTest, SuccessLarge) {
     ASSERT_EQ(AllocPtr[i].B, UINT64_MAX);
   }
 
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemFillTest, SuccessLargeEnqueue) {
@@ -120,7 +120,7 @@ TEST_P(olMemFillTest, SuccessLargeEnqueue) {
     ASSERT_EQ(AllocPtr[i].B, UINT64_MAX);
   }
 
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemFillTest, SuccessLargeByteAligned) {
@@ -146,7 +146,7 @@ TEST_P(olMemFillTest, SuccessLargeByteAligned) {
     ASSERT_EQ(AllocPtr[i].C, 255);
   }
 
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemFillTest, SuccessLargeByteAlignedEnqueue) {
@@ -176,7 +176,7 @@ TEST_P(olMemFillTest, SuccessLargeByteAlignedEnqueue) {
     ASSERT_EQ(AllocPtr[i].C, 255);
   }
 
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemFillTest, InvalidPatternSize) {
@@ -189,5 +189,5 @@ TEST_P(olMemFillTest, InvalidPatternSize) {
                olMemFill(Queue, Alloc, sizeof(Pattern), &Pattern, Size));
 
   olSyncQueue(Queue);
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }

--- a/offload/unittests/OffloadAPI/memory/olMemFree.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemFree.cpp
@@ -16,24 +16,31 @@ OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olMemFreeTest);
 TEST_P(olMemFreeTest, SuccessFreeManaged) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_MANAGED, 1024, &Alloc));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
 }
 
 TEST_P(olMemFreeTest, SuccessFreeHost) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_HOST, 1024, &Alloc));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
 }
 
 TEST_P(olMemFreeTest, SuccessFreeDevice) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
 }
 
 TEST_P(olMemFreeTest, InvalidNullPtr) {
   void *Alloc = nullptr;
   ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
-  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olMemFree(nullptr));
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER, olMemFree(Platform, nullptr));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
+}
+
+TEST_P(olMemFreeTest, InvalidPlatformPtr) {
+  void *Alloc = nullptr;
+  ASSERT_SUCCESS(olMemAlloc(Device, OL_ALLOC_TYPE_DEVICE, 1024, &Alloc));
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_HANDLE, olMemFree(nullptr, Alloc));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
 }

--- a/offload/unittests/OffloadAPI/memory/olMemcpy.cpp
+++ b/offload/unittests/OffloadAPI/memory/olMemcpy.cpp
@@ -46,7 +46,7 @@ TEST_P(olMemcpyTest, SuccessHtoD) {
   std::vector<uint8_t> Input(Size, 42);
   ASSERT_SUCCESS(olMemcpy(Queue, Alloc, Device, Input.data(), Host, Size));
   olSyncQueue(Queue);
-  olMemFree(Alloc);
+  olMemFree(Platform, Alloc);
 }
 
 TEST_P(olMemcpyTest, SuccessDtoH) {
@@ -62,7 +62,7 @@ TEST_P(olMemcpyTest, SuccessDtoH) {
   for (uint8_t Val : Output) {
     ASSERT_EQ(Val, 42);
   }
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
 }
 
 TEST_P(olMemcpyTest, SuccessDtoD) {
@@ -81,8 +81,8 @@ TEST_P(olMemcpyTest, SuccessDtoD) {
   for (uint8_t Val : Output) {
     ASSERT_EQ(Val, 42);
   }
-  ASSERT_SUCCESS(olMemFree(AllocA));
-  ASSERT_SUCCESS(olMemFree(AllocB));
+  ASSERT_SUCCESS(olMemFree(Platform, AllocA));
+  ASSERT_SUCCESS(olMemFree(Platform, AllocB));
 }
 
 TEST_P(olMemcpyTest, SuccessHtoHSync) {
@@ -110,7 +110,7 @@ TEST_P(olMemcpyTest, SuccessDtoHSync) {
   for (uint8_t Val : Output) {
     ASSERT_EQ(Val, 42);
   }
-  ASSERT_SUCCESS(olMemFree(Alloc));
+  ASSERT_SUCCESS(olMemFree(Platform, Alloc));
 }
 
 TEST_P(olMemcpyTest, SuccessSizeZero) {
@@ -146,8 +146,8 @@ TEST_P(olMemcpyGlobalTest, SuccessRoundTrip) {
   for (uint32_t I = 0; I < 64; I++)
     ASSERT_EQ(DestData[I], I);
 
-  ASSERT_SUCCESS(olMemFree(DestMem));
-  ASSERT_SUCCESS(olMemFree(SourceMem));
+  ASSERT_SUCCESS(olMemFree(Platform, DestMem));
+  ASSERT_SUCCESS(olMemFree(Platform, SourceMem));
 }
 
 TEST_P(olMemcpyGlobalTest, SuccessWrite) {
@@ -178,8 +178,8 @@ TEST_P(olMemcpyGlobalTest, SuccessWrite) {
   for (uint32_t I = 0; I < 64; I++)
     ASSERT_EQ(DestData[I], I);
 
-  ASSERT_SUCCESS(olMemFree(DestMem));
-  ASSERT_SUCCESS(olMemFree(SourceMem));
+  ASSERT_SUCCESS(olMemFree(Platform, DestMem));
+  ASSERT_SUCCESS(olMemFree(Platform, SourceMem));
 }
 
 TEST_P(olMemcpyGlobalTest, SuccessRead) {
@@ -199,5 +199,5 @@ TEST_P(olMemcpyGlobalTest, SuccessRead) {
   for (uint32_t I = 0; I < 64; I++)
     ASSERT_EQ(DestData[I], I * 2);
 
-  ASSERT_SUCCESS(olMemFree(DestMem));
+  ASSERT_SUCCESS(olMemFree(Platform, DestMem));
 }

--- a/offload/unittests/OffloadAPI/queue/olLaunchHostFunction.cpp
+++ b/offload/unittests/OffloadAPI/queue/olLaunchHostFunction.cpp
@@ -93,7 +93,7 @@ TEST_P(olLaunchHostFunctionKernelTest, SuccessBlocking) {
   }
 
   ASSERT_SUCCESS(olDestroyQueue(Queue));
-  ASSERT_SUCCESS(olMemFree(Mem));
+  ASSERT_SUCCESS(olMemFree(Platform, Mem));
 }
 
 TEST_P(olLaunchHostFunctionTest, InvalidNullCallback) {


### PR DESCRIPTION
In a future change, most of the allocation tracking will be removed from
liboffload itself and be delegated to the plugins. Therefore, we will
need to know which plugin is in charge of the allocation.
