### PR TITLE
[HashRecognize] Clarify hdr comment on GF(2^n) (NFC)

### DIFF
--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -8,8 +8,10 @@
 //
 // The HashRecognize analysis recognizes unoptimized polynomial hash functions
 // with operations over a Galois field of characteristic 2, also called binary
-// fields, or GF(2^n): this class of hash functions can be optimized using a
-// lookup-table-driven implementation, or with target-specific instructions.
+// fields, or GF(2^n). 2^n is termed the order of the Galois field. This class
+// of hash functions can be optimized using a lookup-table-driven
+// implementation, or with target-specific instructions.
+//
 // Examples:
 //
 //  1. Cyclic redundancy check (CRC), which is a polynomial division in GF(2).
@@ -24,11 +26,10 @@
 //
 //    c_m * x^m + c_(m-1) * x^(m-1) + ... + c_0 * x^0
 //
-// where each coefficient c is can take values 0 or 1, and 2^n is termed the
-// order of the Galois field. The polynomial is simply represented by m+1 bits,
-// corresponding to the coefficients. The different variants of CRC are named by
-// degree of generating polynomial used: so CRC-32 would use a polynomial of
-// degree 32.
+// where each coefficient c is can take values 0 or 1. The polynomial is simply
+// represented by m+1 bits, corresponding to the coefficients. The different
+// variants of CRC are named by degree of generating polynomial used: so CRC-32
+// would use a polynomial of degree 32.
 //
 // The reason algorithms on GF(2^n) can be optimized with a lookup-table is the
 // following: in such fields, polynomial addition and subtraction are identical

--- a/llvm/lib/Analysis/HashRecognize.cpp
+++ b/llvm/lib/Analysis/HashRecognize.cpp
@@ -24,9 +24,8 @@
 //
 //    c_m * x^m + c_(m-1) * x^(m-1) + ... + c_0 * x^0
 //
-// where each coefficient c is can take values in GF(2^n), where 2^n is termed
-// the order of the Galois field. For GF(2), each coefficient can take values
-// either 0 or 1, and the polynomial is simply represented by m+1 bits,
+// where each coefficient c is can take values 0 or 1, and 2^n is termed the
+// order of the Galois field. The polynomial is simply represented by m+1 bits,
 // corresponding to the coefficients. The different variants of CRC are named by
 // degree of generating polynomial used: so CRC-32 would use a polynomial of
 // degree 32.


### PR DESCRIPTION
Unify explanation for GF(2^n) and GF(2), which was previously convoluted.