### PR TITLE
[lldb][NFC] Fix style issues with StackID.h

### DIFF
--- a/lldb/include/lldb/Target/StackID.h
+++ b/lldb/include/lldb/Target/StackID.h
@@ -10,7 +10,6 @@
 #define LLDB_TARGET_STACKID_H
 
 #include "lldb/Core/AddressRange.h"
-#include "lldb/lldb-private.h"
 
 namespace lldb_private {
 
@@ -18,14 +17,10 @@ class Process;
 
 class StackID {
 public:
-  // Constructors and Destructors
   StackID() = default;
 
   explicit StackID(lldb::addr_t pc, lldb::addr_t cfa,
                    SymbolContextScope *symbol_scope, Process *process);
-
-  StackID(const StackID &rhs)
-      : m_pc(rhs.m_pc), m_cfa(rhs.m_cfa), m_symbol_scope(rhs.m_symbol_scope) {}
 
   ~StackID() = default;
 
@@ -51,41 +46,28 @@ public:
 
   void Dump(Stream *s);
 
-  // Operators
-  const StackID &operator=(const StackID &rhs) {
-    if (this != &rhs) {
-      m_pc = rhs.m_pc;
-      m_cfa = rhs.m_cfa;
-      m_symbol_scope = rhs.m_symbol_scope;
-    }
-    return *this;
-  }
-
 protected:
   friend class StackFrame;
 
   void SetPC(lldb::addr_t pc, Process *process);
   void SetCFA(lldb::addr_t cfa, Process *process);
 
-  lldb::addr_t m_pc =
-      LLDB_INVALID_ADDRESS; // The pc value for the function/symbol for this
-                            // frame. This will
-  // only get used if the symbol scope is nullptr (the code where we are
-  // stopped is not represented by any function or symbol in any shared
-  // library).
-  lldb::addr_t m_cfa =
-      LLDB_INVALID_ADDRESS; // The call frame address (stack pointer) value
-                            // at the beginning of the function that uniquely
-                            // identifies this frame (along with m_symbol_scope
-                            // below)
-  SymbolContextScope *m_symbol_scope =
-      nullptr; // If nullptr, there is no block or symbol for this frame.
-               // If not nullptr, this will either be the scope for the
-               // lexical block for the frame, or the scope for the
-               // symbol. Symbol context scopes are always be unique
-               // pointers since the are part of the Block and Symbol
-               // objects and can easily be used to tell if a stack ID
-               // is the same as another.
+  // The pc value for the function/symbol for this frame. This will only get
+  // used if the symbol scope is nullptr (the code where we are stopped is not
+  // represented by any function or symbol in any shared library).
+  lldb::addr_t m_pc = LLDB_INVALID_ADDRESS;
+
+  // The call frame address (stack pointer) value at the beginning of the
+  // function that uniquely identifies this frame (along with m_symbol_scope
+  // below)
+  lldb::addr_t m_cfa = LLDB_INVALID_ADDRESS;
+
+  // If nullptr, there is no block or symbol for this frame. If not nullptr,
+  // this will either be the scope for the lexical block for the frame, or the
+  // scope for the symbol. Symbol context scopes are always be unique pointers
+  // since the are part of the Block and Symbol objects and can easily be used
+  // to tell if a stack ID is the same as another.
+  SymbolContextScope *m_symbol_scope = nullptr;
 };
 
 bool operator==(const StackID &lhs, const StackID &rhs);

--- a/lldb/include/lldb/Target/StackID.h
+++ b/lldb/include/lldb/Target/StackID.h
@@ -52,21 +52,21 @@ protected:
   void SetPC(lldb::addr_t pc, Process *process);
   void SetCFA(lldb::addr_t cfa, Process *process);
 
-  // The pc value for the function/symbol for this frame. This will only get
-  // used if the symbol scope is nullptr (the code where we are stopped is not
-  // represented by any function or symbol in any shared library).
+  /// The pc value for the function/symbol for this frame. This will only get
+  /// used if the symbol scope is nullptr (the code where we are stopped is not
+  /// represented by any function or symbol in any shared library).
   lldb::addr_t m_pc = LLDB_INVALID_ADDRESS;
 
-  // The call frame address (stack pointer) value at the beginning of the
-  // function that uniquely identifies this frame (along with m_symbol_scope
-  // below)
+  /// The call frame address (stack pointer) value at the beginning of the
+  /// function that uniquely identifies this frame (along with m_symbol_scope
+  /// below)
   lldb::addr_t m_cfa = LLDB_INVALID_ADDRESS;
 
-  // If nullptr, there is no block or symbol for this frame. If not nullptr,
-  // this will either be the scope for the lexical block for the frame, or the
-  // scope for the symbol. Symbol context scopes are always be unique pointers
-  // since the are part of the Block and Symbol objects and can easily be used
-  // to tell if a stack ID is the same as another.
+  /// If nullptr, there is no block or symbol for this frame. If not nullptr,
+  /// this will either be the scope for the lexical block for the frame, or the
+  /// scope for the symbol. Symbol context scopes are always be unique pointers
+  /// since the are part of the Block and Symbol objects and can easily be used
+  /// to tell if a stack ID is the same as another.
   SymbolContextScope *m_symbol_scope = nullptr;
 };
 

--- a/lldb/source/Target/StackID.cpp
+++ b/lldb/source/Target/StackID.cpp
@@ -63,16 +63,7 @@ bool lldb_private::operator==(const StackID &lhs, const StackID &rhs) {
 }
 
 bool lldb_private::operator!=(const StackID &lhs, const StackID &rhs) {
-  if (lhs.GetCallFrameAddress() != rhs.GetCallFrameAddress())
-    return true;
-
-  SymbolContextScope *lhs_scope = lhs.GetSymbolContextScope();
-  SymbolContextScope *rhs_scope = rhs.GetSymbolContextScope();
-
-  if (lhs_scope == nullptr && rhs_scope == nullptr)
-    return lhs.GetPC() != rhs.GetPC();
-
-  return lhs_scope != rhs_scope;
+  return !(lhs == rhs);
 }
 
 bool lldb_private::operator<(const StackID &lhs, const StackID &rhs) {


### PR DESCRIPTION
Some comments were "suffixed" to member variable declarations; these are moved to before the variable.

Some constructors and operators were just defaulted and not necessary.

Some comments dividing the class into logical sections, like "// constructors and destructors", were not applied everywhere. These were removed. They are used in some parts of LLDB, but are the exception.

An include was not needed.

The operator != can be defined in terms of ==.