### PR TITLE
[clang] Rename overloaded virtual member function to prevent shadowing, NFCI

### DIFF
--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -246,15 +246,16 @@ public:
     return true;
   }
 
-  /// Overloaded member function of \c visitInputFile that should
-  /// be defined when there is a distinction between
-  /// the file name and name-as-requested. For example, when deserializing input
+  /// Similiar to member function of \c visitInputFile but should
+  /// be defined when there is a distinction between the file name
+  /// and the name-as-requested. For example, when deserializing input
   /// files from precompiled AST files.
   ///
   /// \returns true to continue receiving the next input file, false to stop.
-  virtual bool visitInputFile(StringRef FilenameAsRequested, StringRef Filename,
-                              bool isSystem, bool isOverridden,
-                              bool isExplicitModule) {
+  virtual bool visitInputFileAsRequested(StringRef FilenameAsRequested,
+                                         StringRef Filename, bool isSystem,
+                                         bool isOverridden,
+                                         bool isExplicitModule) {
     return true;
   }
 

--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -796,9 +796,10 @@ namespace {
     /// Indicates that the AST file contains particular input file.
     ///
     /// \returns true to continue receiving the next input file, false to stop.
-    bool visitInputFile(StringRef FilenameAsRequested, StringRef Filename,
-                        bool isSystem, bool isOverridden,
-                        bool isExplicitModule) override {
+    bool visitInputFileAsRequested(StringRef FilenameAsRequested,
+                                   StringRef Filename, bool isSystem,
+                                   bool isOverridden,
+                                   bool isExplicitModule) override {
 
       Out.indent(2) << "Input file: " << FilenameAsRequested;
 

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5987,7 +5987,7 @@ bool ASTReader::readASTFileControlBlock(
                 AdditionalPathBuf, UnresolvedFilename, ModuleDir);
             Filename = *FilenameBuf;
           }
-          shouldContinue = Listener.visitInputFile(
+          shouldContinue = Listener.visitInputFileAsRequested(
               *FilenameAsRequestedBuf, Filename, isSystemFile, Overridden,
               /*IsExplicitModule=*/false);
           break;

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -127,9 +127,10 @@ public:
   /// For each input file discovered, check whether it's external path is in a
   /// stable directory. Traversal is stopped if the current module is not
   /// considered stable.
-  bool visitInputFile(StringRef FilenameAsRequested, StringRef Filename,
-                      bool isSystem, bool isOverridden,
-                      bool isExplicitModule) override {
+  bool visitInputFileAsRequested(StringRef FilenameAsRequested,
+                                 StringRef Filename, bool isSystem,
+                                 bool isOverridden,
+                                 bool isExplicitModule) override {
     if (StableDirs.empty())
       return false;
     auto PrebuiltEntryIt = PrebuiltModulesASTMap.find(CurrentFile);


### PR DESCRIPTION
Resolves warnings triggered by `Woverloaded-virtual`