### PR TITLE
[llvm][docs] Add LLDB data formatters to DebuggingLLVM.rst

### DIFF
--- a/llvm/docs/DebuggingLLVM.rst
+++ b/llvm/docs/DebuggingLLVM.rst
@@ -96,6 +96,16 @@ and each instruction printed by LLVM is suffixed with the file and line
 number of the instruction according to the debug information. Note that
 this requires debug information to be enabled (e.g. pass ``-g`` to Clang).
 
+LLDB Data Formatters
+===================
+
+A handful of `LLDB data formatters
+<https://lldb.llvm.org/resources/dataformatters.html>`__ are
+provided for some of the core LLVM libraries. To use them, execute the
+following (or add it to your ``~/.lldbinit``)::
+
+  command script import /path/to/lldbDataFormatters.py
+
 GDB pretty printers
 ===================
 

--- a/llvm/docs/DebuggingLLVM.rst
+++ b/llvm/docs/DebuggingLLVM.rst
@@ -104,7 +104,7 @@ A handful of `LLDB data formatters
 provided for some of the core LLVM libraries. To use them, execute the
 following (or add it to your ``~/.lldbinit``)::
 
-  command script import llvm/utils/lldbDataFormatters.py
+  command script import /path/to/llvm/utils/lldbDataFormatters.py
 
 GDB pretty printers
 ===================
@@ -114,7 +114,7 @@ A handful of `GDB pretty printers
 provided for some of the core LLVM libraries. To use them, execute the
 following (or add it to your ``~/.gdbinit``)::
 
-  source llvm/utils/gdb-scripts/prettyprinters.py
+  source /path/to/llvm/utils/gdb-scripts/prettyprinters.py
 
 It also might be handy to enable the `print pretty
 <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Print-Settings.html>`__

--- a/llvm/docs/DebuggingLLVM.rst
+++ b/llvm/docs/DebuggingLLVM.rst
@@ -104,7 +104,7 @@ A handful of `LLDB data formatters
 provided for some of the core LLVM libraries. To use them, execute the
 following (or add it to your ``~/.lldbinit``)::
 
-  command script import /path/to/llvm/src/utils/lldbDataFormatters.py
+  command script import llvm/utils/lldbDataFormatters.py
 
 GDB pretty printers
 ===================
@@ -114,7 +114,7 @@ A handful of `GDB pretty printers
 provided for some of the core LLVM libraries. To use them, execute the
 following (or add it to your ``~/.gdbinit``)::
 
-  source /path/to/llvm/src/utils/gdb-scripts/prettyprinters.py
+  source llvm/utils/gdb-scripts/prettyprinters.py
 
 It also might be handy to enable the `print pretty
 <https://sourceware.org/gdb/current/onlinedocs/gdb.html/Print-Settings.html>`__

--- a/llvm/docs/DebuggingLLVM.rst
+++ b/llvm/docs/DebuggingLLVM.rst
@@ -97,14 +97,14 @@ number of the instruction according to the debug information. Note that
 this requires debug information to be enabled (e.g. pass ``-g`` to Clang).
 
 LLDB Data Formatters
-===================
+====================
 
 A handful of `LLDB data formatters
 <https://lldb.llvm.org/resources/dataformatters.html>`__ are
 provided for some of the core LLVM libraries. To use them, execute the
 following (or add it to your ``~/.lldbinit``)::
 
-  command script import /path/to/lldbDataFormatters.py
+  command script import /path/to/llvm/src/utils/lldbDataFormatters.py
 
 GDB pretty printers
 ===================


### PR DESCRIPTION
Add LLDB data formatters to the document about debugging LLVM.