### PR TITLE
[DebugLine] Correct debug line emittion

### DIFF
--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -181,7 +181,7 @@ void MCDwarfLineTable::emitOne(
 
   unsigned FileNum, LastLine, Column, Flags, Isa, Discriminator;
   bool IsAtStartSeq;
-  MCSymbol *LastLabel;
+  MCSymbol *PrevLabel;
   auto init = [&]() {
     FileNum = 1;
     LastLine = 1;
@@ -189,21 +189,31 @@ void MCDwarfLineTable::emitOne(
     Flags = DWARF2_LINE_DEFAULT_IS_STMT ? DWARF2_FLAG_IS_STMT : 0;
     Isa = 0;
     Discriminator = 0;
-    LastLabel = nullptr;
+    PrevLabel = nullptr;
     IsAtStartSeq = true;
   };
   init();
 
   // Loop through each MCDwarfLineEntry and encode the dwarf line number table.
   bool EndEntryEmitted = false;
-  for (const MCDwarfLineEntry &LineEntry : LineEntries) {
-    MCSymbol *Label = LineEntry.getLabel();
+  for (auto It = LineEntries.begin(); It != LineEntries.end(); ++It) {
+    auto LineEntry = *It;
+    MCSymbol *CurrLabel = LineEntry.getLabel();
     const MCAsmInfo *asmInfo = MCOS->getContext().getAsmInfo();
 
     if (LineEntry.LineStreamLabel) {
       if (!IsAtStartSeq) {
-        MCOS->emitDwarfLineEndEntry(Section, LastLabel,
-                                    /*EndLabel =*/LastLabel);
+        auto *Label = CurrLabel;
+        auto NextIt = It + 1;
+        // LineEntry with a null Label is probably a fake LineEntry we added
+        // when `-emit-func-debug-line-table-offsets` in order to terminate the
+        // sequence. Look for the next Label if possible, otherwise we will set
+        // the PC to the end of the section.
+        if (!Label && NextIt != LineEntries.end()) {
+          Label = NextIt->getLabel();
+        }
+        MCOS->emitDwarfLineEndEntry(Section, PrevLabel,
+                                    /*EndLabel =*/Label);
         init();
       }
       MCOS->emitLabel(LineEntry.LineStreamLabel, LineEntry.StreamLabelDefLoc);
@@ -211,7 +221,7 @@ void MCDwarfLineTable::emitOne(
     }
 
     if (LineEntry.IsEndEntry) {
-      MCOS->emitDwarfAdvanceLineAddr(INT64_MAX, LastLabel, Label,
+      MCOS->emitDwarfAdvanceLineAddr(INT64_MAX, PrevLabel, CurrLabel,
                                      asmInfo->getCodePointerSize());
       init();
       EndEntryEmitted = true;
@@ -258,12 +268,12 @@ void MCDwarfLineTable::emitOne(
     // At this point we want to emit/create the sequence to encode the delta in
     // line numbers and the increment of the address from the previous Label
     // and the current Label.
-    MCOS->emitDwarfAdvanceLineAddr(LineDelta, LastLabel, Label,
+    MCOS->emitDwarfAdvanceLineAddr(LineDelta, PrevLabel, CurrLabel,
                                    asmInfo->getCodePointerSize());
 
     Discriminator = 0;
     LastLine = LineEntry.getLine();
-    LastLabel = Label;
+    PrevLabel = CurrLabel;
     IsAtStartSeq = false;
   }
 
@@ -273,7 +283,7 @@ void MCDwarfLineTable::emitOne(
   // does not track ranges nor terminate the line table. In that case,
   // conservatively use the section end symbol to end the line table.
   if (!EndEntryEmitted && !IsAtStartSeq)
-    MCOS->emitDwarfLineEndEntry(Section, LastLabel);
+    MCOS->emitDwarfLineEndEntry(Section, PrevLabel);
 }
 
 void MCDwarfLineTable::endCurrentSeqAndEmitLineStreamLabel(MCStreamer *MCOS,

--- a/llvm/test/DebugInfo/ARM/stmt_seq_macho.test
+++ b/llvm/test/DebugInfo/ARM/stmt_seq_macho.test
@@ -1,0 +1,238 @@
+// RUN: split-file %s %t
+
+// RUN: clang++ --target=arm64-apple-macos11 \
+// RUN:   -x c++ %t/stmt_seq_macho.cpp \
+// RUN:   -o %t/stmt_seq_macho.o \
+// RUN:   -g -Oz -gdwarf-4 -c \
+// RUN:   -mllvm -emit-func-debug-line-table-offsets \
+// RUN:   -fdebug-compilation-dir=/private/tmp/stmt_seq \
+// RUN:   -fno-unwind-tables -fno-exceptions \
+// RUN:   -mno-outline
+
+// RUN: llvm-dwarfdump -all -v %t/stmt_seq_macho.o | FileCheck %s
+
+// CHECK: .debug_info
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[EMPTY1:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function_empty_1")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[EMPTY2:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function_empty_2")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[EMPTY3:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function_empty_3")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F1CPY1:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function1_copy1")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F3CPY1:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function3_copy1")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F2CPY1:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function2_copy1")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F3CPY2:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function3_copy2")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F2CPY2:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function2_copy2")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[FNMAIN:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "main")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[ERRLOG:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_linkage_name [DW_FORM_strp]  ({{.*}} = "_ZN12length_errorC1EPKc")
+
+// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[ERRLEN:0x[0-9a-fA-F]{8}]])
+// CHECK: DW_AT_linkage_name [DW_FORM_strp]  ({{.*}} = "_ZN12length_errorC2EPKc")
+
+// CHECK:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
+// CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
+// CHECK-NEXT: [[EMPTY1]]: 05 DW_LNS_set_column (33)
+// CHECK-NEXT: 0x00000091: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x00000092: 00 DW_LNE_set_address (0x0000000000000000)
+// CHECK-NEXT: 0x0000009d: 13 address += 0,  line += 1,  op-index += 0
+// CHECK-NEXT:             0x0000000000000000      2     33      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x0000009e: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x000000a0: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x0000000000000004      2     33      1   0             0       0  is_stmt end_sequence
+// CHECK-NEXT: [[EMPTY2]]: 05 DW_LNS_set_column (33)
+// CHECK-NEXT: 0x000000a5: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x000000a6: 00 DW_LNE_set_address (0x0000000000000004)
+// CHECK-NEXT: 0x000000b1: 14 address += 0,  line += 2,  op-index += 0
+// CHECK-NEXT:             0x0000000000000004      3     33      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x000000b2: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x000000b4: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x0000000000000008      3     33      1   0             0       0  is_stmt end_sequence
+// CHECK-NEXT: [[EMPTY3]]: 05 DW_LNS_set_column (33)
+// CHECK-NEXT: 0x000000b9: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x000000ba: 00 DW_LNE_set_address (0x0000000000000008)
+// CHECK-NEXT: 0x000000c5: 15 address += 0,  line += 3,  op-index += 0
+// CHECK-NEXT:             0x0000000000000008      4     33      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x000000c6: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x000000c8: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x000000000000000c      4     33      1   0             0       0  is_stmt end_sequence
+// CHECK-NEXT: [[F1CPY1]]: 05 DW_LNS_set_column (10)
+// CHECK-NEXT: 0x000000cd: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x000000ce: 00 DW_LNE_set_address (0x000000000000000c)
+// CHECK-NEXT: 0x000000d9: 18 address += 0,  line += 6,  op-index += 0
+// CHECK-NEXT:             0x000000000000000c      7     10      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x000000da: 05 DW_LNS_set_column (3)
+// CHECK-NEXT: 0x000000dc: 06 DW_LNS_negate_stmt
+// CHECK-NEXT: 0x000000dd: 4a address += 4,  line += 0,  op-index += 0
+// CHECK-NEXT:             0x0000000000000010      7      3      1   0             0       0
+// CHECK-NEXT: 0x000000de: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x000000e0: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x0000000000000014      7      3      1   0             0       0  end_sequence
+// CHECK-NEXT: [[F3CPY1]]: 05 DW_LNS_set_column (14)
+// CHECK-NEXT: 0x000000e5: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x000000e6: 00 DW_LNE_set_address (0x0000000000000014)
+// CHECK-NEXT: 0x000000f1: 03 DW_LNS_advance_line (12)
+// CHECK-NEXT: 0x000000f3: 01 DW_LNS_copy
+// CHECK-NEXT:             0x0000000000000014     12     14      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x000000f4: 05 DW_LNS_set_column (5)
+// CHECK-NEXT: 0x000000f6: 06 DW_LNS_negate_stmt
+// CHECK-NEXT: 0x000000f7: 4a address += 4,  line += 0,  op-index += 0
+// CHECK-NEXT:             0x0000000000000018     12      5      1   0             0       0
+// CHECK-NEXT: 0x000000f8: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x000000fa: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x000000000000001c     12      5      1   0             0       0  end_sequence
+// CHECK-NEXT: [[F2CPY1]]: 05 DW_LNS_set_column (14)
+// CHECK-NEXT: 0x000000ff: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x00000100: 00 DW_LNE_set_address (0x000000000000001c)
+// CHECK-NEXT: 0x0000010b: 03 DW_LNS_advance_line (16)
+// CHECK-NEXT: 0x0000010d: 01 DW_LNS_copy
+// CHECK-NEXT:             0x000000000000001c     16     14      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x0000010e: 05 DW_LNS_set_column (5)
+// CHECK-NEXT: 0x00000110: 06 DW_LNS_negate_stmt
+// CHECK-NEXT: 0x00000111: 4a address += 4,  line += 0,  op-index += 0
+// CHECK-NEXT:             0x0000000000000020     16      5      1   0             0       0
+// CHECK-NEXT: 0x00000112: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x00000114: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x0000000000000024     16      5      1   0             0       0  end_sequence
+// CHECK-NEXT: [[F3CPY2]]: 05 DW_LNS_set_column (14)
+// CHECK-NEXT: 0x00000119: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x0000011a: 00 DW_LNE_set_address (0x0000000000000024)
+// CHECK-NEXT: 0x00000125: 03 DW_LNS_advance_line (21)
+// CHECK-NEXT: 0x00000127: 01 DW_LNS_copy
+// CHECK-NEXT:             0x0000000000000024     21     14      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x00000128: 05 DW_LNS_set_column (5)
+// CHECK-NEXT: 0x0000012a: 06 DW_LNS_negate_stmt
+// CHECK-NEXT: 0x0000012b: 4a address += 4,  line += 0,  op-index += 0
+// CHECK-NEXT:             0x0000000000000028     21      5      1   0             0       0
+// CHECK-NEXT: 0x0000012c: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x0000012e: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x000000000000002c     21      5      1   0             0       0  end_sequence
+// CHECK-NEXT: [[F2CPY2]]: 05 DW_LNS_set_column (20)
+// CHECK-NEXT: 0x00000133: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x00000134: 00 DW_LNE_set_address (0x000000000000002c)
+// CHECK-NEXT: 0x0000013f: 03 DW_LNS_advance_line (25)
+// CHECK-NEXT: 0x00000141: 01 DW_LNS_copy
+// CHECK-NEXT:             0x000000000000002c     25     20      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x00000142: 05 DW_LNS_set_column (5)
+// CHECK-NEXT: 0x00000144: 4b address += 4,  line += 1,  op-index += 0
+// CHECK-NEXT:             0x0000000000000030     26      5      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x00000145: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x00000147: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x0000000000000034     26      5      1   0             0       0  is_stmt end_sequence
+// CHECK-NEXT: [[FNMAIN]]: 00 DW_LNE_set_address (0x0000000000000034)
+// CHECK-NEXT: 0x00000155: 03 DW_LNS_advance_line (37)
+// CHECK-NEXT: 0x00000157: 01 DW_LNS_copy
+// CHECK-NEXT:             0x0000000000000034     37      0      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x00000158: 05 DW_LNS_set_column (12)
+// CHECK-NEXT: 0x0000015a: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x0000015b: f4 address += 16,  line += 2,  op-index += 0
+// CHECK-NEXT:             0x0000000000000044     39     12      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x0000015c: bb address += 12,  line += 1,  op-index += 0
+// CHECK-NEXT:             0x0000000000000050     40     12      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x0000015d: 05 DW_LNS_set_column (9)
+// CHECK-NEXT: 0x0000015f: 82 address += 8,  line += 0,  op-index += 0
+// CHECK-NEXT:             0x0000000000000058     40      9      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x00000160: 05 DW_LNS_set_column (12)
+// CHECK-NEXT: 0x00000162: 4b address += 4,  line += 1,  op-index += 0
+// CHECK-NEXT:             0x000000000000005c     41     12      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x00000163: bb address += 12,  line += 1,  op-index += 0
+// CHECK-NEXT:             0x0000000000000068     42     12      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x00000164: 05 DW_LNS_set_column (9)
+// CHECK-NEXT: 0x00000166: 81 address += 8,  line += -1,  op-index += 0
+// CHECK-NEXT:             0x0000000000000070     41      9      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x00000167: 05 DW_LNS_set_column (18)
+// CHECK-NEXT: 0x00000169: 4f address += 4,  line += 5,  op-index += 0
+// CHECK-NEXT:             0x0000000000000074     46     18      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x0000016a: 05 DW_LNS_set_column (9)
+// CHECK-NEXT: 0x0000016c: ee address += 16,  line += -4,  op-index += 0
+// CHECK-NEXT:             0x0000000000000084     42      9      1   0             0       0  is_stmt
+// CHECK-NEXT: 0x0000016d: 05 DW_LNS_set_column (5)
+// CHECK-NEXT: 0x0000016f: 0b DW_LNS_set_epilogue_begin
+// CHECK-NEXT: 0x00000170: 4f address += 4,  line += 5,  op-index += 0
+// CHECK-NEXT:             0x0000000000000088     47      5      1   0             0       0  is_stmt epilogue_begin
+// CHECK-NEXT: 0x00000171: 02 DW_LNS_advance_pc (addr += 16, op-index += 0)
+// CHECK-NEXT: 0x00000173: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x0000000000000098     47      5      1   0             0       0  is_stmt end_sequence
+// CHECK-NEXT: [[ERRLOG]]: 05 DW_LNS_set_column (85)
+// CHECK-NEXT: 0x00000178: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x00000179: 00 DW_LNE_set_address (0x0000000000000098)
+// CHECK-NEXT: 0x00000184: 03 DW_LNS_advance_line (34)
+// CHECK-NEXT: 0x00000186: 01 DW_LNS_copy
+// CHECK-NEXT:             0x0000000000000098     34     85      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x00000187: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x00000189: 00 DW_LNE_end_sequence
+// CHECK-NEXT:             0x000000000000009c     34     85      1   0             0       0  is_stmt end_sequence
+// CHECK-NEXT: [[ERRLEN]]: 05 DW_LNS_set_column (86)
+// CHECK-NEXT: 0x0000018e: 0a DW_LNS_set_prologue_end
+// CHECK-NEXT: 0x0000018f: 00 DW_LNE_set_address (0x000000000000009c)
+// CHECK-NEXT: 0x0000019a: 03 DW_LNS_advance_line (34)
+// CHECK-NEXT: 0x0000019c: 01 DW_LNS_copy
+// CHECK-NEXT:             0x000000000000009c     34     86      1   0             0       0  is_stmt prologue_end
+// CHECK-NEXT: 0x0000019d: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
+// CHECK-NEXT: 0x0000019f: 00 DW_LNE_end_sequence
+// CHECK-NEXT: 0x00000000000000a0     34     86      1   0             0       0  is_stmt end_sequence
+
+#--- stmt_seq_macho.cpp
+#define ATTRIB extern "C" __attribute__((noinline))
+ATTRIB void function_empty_1() {}
+ATTRIB void function_empty_2() {}
+ATTRIB void function_empty_3() {}
+
+ATTRIB int function1_copy1(int a) {
+  return ++a;
+}
+
+ATTRIB int function3_copy1(int a) {
+    int b = a + 3;
+    return b + 1;
+}
+
+ATTRIB int function2_copy1(int a) {
+    return a - 22;
+}
+
+ATTRIB int function3_copy2(int a) {
+    int b = a + 3;
+    return b + 1;
+}
+
+ATTRIB int function2_copy2(int a) {
+    int result = a - 22;
+    return result;
+}
+
+struct logic_error {
+    logic_error(const char* s) {}
+};
+
+struct length_error : public logic_error {
+    __attribute__((noinline)) explicit length_error(const char* s) : logic_error(s) {}
+};
+
+int main() {
+    int sum = 0;
+    sum += function2_copy2(3);
+    sum += function3_copy2(41);
+    sum += function2_copy1(11);
+    sum += function1_copy1(42);
+    function_empty_1();
+    function_empty_2();
+    function_empty_3();
+    length_error e("test");
+    return sum;
+}

--- a/llvm/test/DebugInfo/ARM/stmt_seq_macho.test
+++ b/llvm/test/DebugInfo/ARM/stmt_seq_macho.test
@@ -1,205 +1,51 @@
 // RUN: split-file %s %t
 
 // RUN: clang++ --target=arm64-apple-macos11 \
-// RUN:   -x c++ %t/stmt_seq_macho.cpp \
-// RUN:   -o %t/stmt_seq_macho.o \
-// RUN:   -g -Oz -gdwarf-4 -c \
+// RUN:   %t/stmt_seq_macho.cpp -o %t/stmt_seq_macho.o \
+// RUN:   -g -Oz -gdwarf-4 -c -mno-outline \
 // RUN:   -mllvm -emit-func-debug-line-table-offsets \
 // RUN:   -fdebug-compilation-dir=/private/tmp/stmt_seq \
-// RUN:   -fno-unwind-tables -fno-exceptions \
-// RUN:   -mno-outline
+// RUN:   -fno-unwind-tables -fno-exceptions
 
-// RUN: llvm-dwarfdump -all -v %t/stmt_seq_macho.o | FileCheck %s
-
-// CHECK: .debug_info
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[EMPTY1:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function_empty_1")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[EMPTY2:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function_empty_2")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[EMPTY3:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function_empty_3")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F1CPY1:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function1_copy1")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F3CPY1:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function3_copy1")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F2CPY1:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function2_copy1")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F3CPY2:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function3_copy2")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[F2CPY2:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "function2_copy2")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[FNMAIN:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_name [DW_FORM_strp]  ({{.*}} = "main")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[ERRLOG:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_linkage_name [DW_FORM_strp]  ({{.*}} = "_ZN12length_errorC1EPKc")
-
-// CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[ERRLEN:0x[0-9a-fA-F]{8}]])
-// CHECK: DW_AT_linkage_name [DW_FORM_strp]  ({{.*}} = "_ZN12length_errorC2EPKc")
-
-// CHECK:      .debug_line contents:
-// CHECK-NEXT: debug_line[0x00000000]
-// CHECK-NEXT: Line table prologue:
-// CHECK-NEXT:     total_length: 0x0000019e
-// CHECK-NEXT:           format: DWARF32
-// CHECK-NEXT:          version: 4
-// CHECK-NEXT:  prologue_length: 0x00000085
-// CHECK-NEXT:  min_inst_length: 1
-// CHECK-NEXT: max_ops_per_inst: 1
-// CHECK-NEXT:  default_is_stmt: 1
-// CHECK-NEXT:        line_base: -5
-// CHECK-NEXT:       line_range: 14
-// CHECK-NEXT:      opcode_base: 13
+// RUN: llvm-dwarfdump -all %t/stmt_seq_macho.o | FileCheck %s
 
 // CHECK:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
 // CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
-// CHECK-NEXT: [[EMPTY1]]: 05 DW_LNS_set_column (33)
-// CHECK-NEXT: 0x00000091: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x00000092: 00 DW_LNE_set_address (0x0000000000000000)
-// CHECK-NEXT: 0x0000009d: 13 address += 0,  line += 1,  op-index += 0
 // CHECK-NEXT:             0x0000000000000000      2     33      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x0000009e: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x000000a0: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x0000000000000004      2     33      1   0             0       0  is_stmt end_sequence
-// CHECK-NEXT: [[EMPTY2]]: 05 DW_LNS_set_column (33)
-// CHECK-NEXT: 0x000000a5: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x000000a6: 00 DW_LNE_set_address (0x0000000000000004)
-// CHECK-NEXT: 0x000000b1: 14 address += 0,  line += 2,  op-index += 0
 // CHECK-NEXT:             0x0000000000000004      3     33      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x000000b2: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x000000b4: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x0000000000000008      3     33      1   0             0       0  is_stmt end_sequence
-// CHECK-NEXT: [[EMPTY3]]: 05 DW_LNS_set_column (33)
-// CHECK-NEXT: 0x000000b9: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x000000ba: 00 DW_LNE_set_address (0x0000000000000008)
-// CHECK-NEXT: 0x000000c5: 15 address += 0,  line += 3,  op-index += 0
 // CHECK-NEXT:             0x0000000000000008      4     33      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x000000c6: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x000000c8: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x000000000000000c      4     33      1   0             0       0  is_stmt end_sequence
-// CHECK-NEXT: [[F1CPY1]]: 05 DW_LNS_set_column (10)
-// CHECK-NEXT: 0x000000cd: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x000000ce: 00 DW_LNE_set_address (0x000000000000000c)
-// CHECK-NEXT: 0x000000d9: 18 address += 0,  line += 6,  op-index += 0
 // CHECK-NEXT:             0x000000000000000c      7     10      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x000000da: 05 DW_LNS_set_column (3)
-// CHECK-NEXT: 0x000000dc: 06 DW_LNS_negate_stmt
-// CHECK-NEXT: 0x000000dd: 4a address += 4,  line += 0,  op-index += 0
 // CHECK-NEXT:             0x0000000000000010      7      3      1   0             0       0
-// CHECK-NEXT: 0x000000de: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x000000e0: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x0000000000000014      7      3      1   0             0       0  end_sequence
-// CHECK-NEXT: [[F3CPY1]]: 05 DW_LNS_set_column (14)
-// CHECK-NEXT: 0x000000e5: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x000000e6: 00 DW_LNE_set_address (0x0000000000000014)
-// CHECK-NEXT: 0x000000f1: 03 DW_LNS_advance_line (12)
-// CHECK-NEXT: 0x000000f3: 01 DW_LNS_copy
 // CHECK-NEXT:             0x0000000000000014     12     14      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x000000f4: 05 DW_LNS_set_column (5)
-// CHECK-NEXT: 0x000000f6: 06 DW_LNS_negate_stmt
-// CHECK-NEXT: 0x000000f7: 4a address += 4,  line += 0,  op-index += 0
 // CHECK-NEXT:             0x0000000000000018     12      5      1   0             0       0
-// CHECK-NEXT: 0x000000f8: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x000000fa: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x000000000000001c     12      5      1   0             0       0  end_sequence
-// CHECK-NEXT: [[F2CPY1]]: 05 DW_LNS_set_column (14)
-// CHECK-NEXT: 0x000000ff: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x00000100: 00 DW_LNE_set_address (0x000000000000001c)
-// CHECK-NEXT: 0x0000010b: 03 DW_LNS_advance_line (16)
-// CHECK-NEXT: 0x0000010d: 01 DW_LNS_copy
 // CHECK-NEXT:             0x000000000000001c     16     14      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x0000010e: 05 DW_LNS_set_column (5)
-// CHECK-NEXT: 0x00000110: 06 DW_LNS_negate_stmt
-// CHECK-NEXT: 0x00000111: 4a address += 4,  line += 0,  op-index += 0
 // CHECK-NEXT:             0x0000000000000020     16      5      1   0             0       0
-// CHECK-NEXT: 0x00000112: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x00000114: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x0000000000000024     16      5      1   0             0       0  end_sequence
-// CHECK-NEXT: [[F3CPY2]]: 05 DW_LNS_set_column (14)
-// CHECK-NEXT: 0x00000119: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x0000011a: 00 DW_LNE_set_address (0x0000000000000024)
-// CHECK-NEXT: 0x00000125: 03 DW_LNS_advance_line (21)
-// CHECK-NEXT: 0x00000127: 01 DW_LNS_copy
 // CHECK-NEXT:             0x0000000000000024     21     14      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x00000128: 05 DW_LNS_set_column (5)
-// CHECK-NEXT: 0x0000012a: 06 DW_LNS_negate_stmt
-// CHECK-NEXT: 0x0000012b: 4a address += 4,  line += 0,  op-index += 0
 // CHECK-NEXT:             0x0000000000000028     21      5      1   0             0       0
-// CHECK-NEXT: 0x0000012c: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x0000012e: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x000000000000002c     21      5      1   0             0       0  end_sequence
-// CHECK-NEXT: [[F2CPY2]]: 05 DW_LNS_set_column (20)
-// CHECK-NEXT: 0x00000133: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x00000134: 00 DW_LNE_set_address (0x000000000000002c)
-// CHECK-NEXT: 0x0000013f: 03 DW_LNS_advance_line (25)
-// CHECK-NEXT: 0x00000141: 01 DW_LNS_copy
 // CHECK-NEXT:             0x000000000000002c     25     20      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x00000142: 05 DW_LNS_set_column (5)
-// CHECK-NEXT: 0x00000144: 4b address += 4,  line += 1,  op-index += 0
 // CHECK-NEXT:             0x0000000000000030     26      5      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x00000145: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x00000147: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x0000000000000034     26      5      1   0             0       0  is_stmt end_sequence
-// CHECK-NEXT: [[FNMAIN]]: 00 DW_LNE_set_address (0x0000000000000034)
-// CHECK-NEXT: 0x00000155: 03 DW_LNS_advance_line (37)
-// CHECK-NEXT: 0x00000157: 01 DW_LNS_copy
 // CHECK-NEXT:             0x0000000000000034     37      0      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x00000158: 05 DW_LNS_set_column (12)
-// CHECK-NEXT: 0x0000015a: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x0000015b: f4 address += 16,  line += 2,  op-index += 0
 // CHECK-NEXT:             0x0000000000000044     39     12      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x0000015c: bb address += 12,  line += 1,  op-index += 0
 // CHECK-NEXT:             0x0000000000000050     40     12      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x0000015d: 05 DW_LNS_set_column (9)
-// CHECK-NEXT: 0x0000015f: 82 address += 8,  line += 0,  op-index += 0
 // CHECK-NEXT:             0x0000000000000058     40      9      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x00000160: 05 DW_LNS_set_column (12)
-// CHECK-NEXT: 0x00000162: 4b address += 4,  line += 1,  op-index += 0
 // CHECK-NEXT:             0x000000000000005c     41     12      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x00000163: bb address += 12,  line += 1,  op-index += 0
 // CHECK-NEXT:             0x0000000000000068     42     12      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x00000164: 05 DW_LNS_set_column (9)
-// CHECK-NEXT: 0x00000166: 81 address += 8,  line += -1,  op-index += 0
 // CHECK-NEXT:             0x0000000000000070     41      9      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x00000167: 05 DW_LNS_set_column (18)
-// CHECK-NEXT: 0x00000169: 4f address += 4,  line += 5,  op-index += 0
 // CHECK-NEXT:             0x0000000000000074     46     18      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x0000016a: 05 DW_LNS_set_column (9)
-// CHECK-NEXT: 0x0000016c: ee address += 16,  line += -4,  op-index += 0
 // CHECK-NEXT:             0x0000000000000084     42      9      1   0             0       0  is_stmt
-// CHECK-NEXT: 0x0000016d: 05 DW_LNS_set_column (5)
-// CHECK-NEXT: 0x0000016f: 0b DW_LNS_set_epilogue_begin
-// CHECK-NEXT: 0x00000170: 4f address += 4,  line += 5,  op-index += 0
 // CHECK-NEXT:             0x0000000000000088     47      5      1   0             0       0  is_stmt epilogue_begin
-// CHECK-NEXT: 0x00000171: 02 DW_LNS_advance_pc (addr += 16, op-index += 0)
-// CHECK-NEXT: 0x00000173: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x0000000000000098     47      5      1   0             0       0  is_stmt end_sequence
-// CHECK-NEXT: [[ERRLOG]]: 05 DW_LNS_set_column (85)
-// CHECK-NEXT: 0x00000178: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x00000179: 00 DW_LNE_set_address (0x0000000000000098)
-// CHECK-NEXT: 0x00000184: 03 DW_LNS_advance_line (34)
-// CHECK-NEXT: 0x00000186: 01 DW_LNS_copy
 // CHECK-NEXT:             0x0000000000000098     34     85      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x00000187: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x00000189: 00 DW_LNE_end_sequence
 // CHECK-NEXT:             0x000000000000009c     34     85      1   0             0       0  is_stmt end_sequence
-// CHECK-NEXT: [[ERRLEN]]: 05 DW_LNS_set_column (86)
-// CHECK-NEXT: 0x0000018e: 0a DW_LNS_set_prologue_end
-// CHECK-NEXT: 0x0000018f: 00 DW_LNE_set_address (0x000000000000009c)
-// CHECK-NEXT: 0x0000019a: 03 DW_LNS_advance_line (34)
-// CHECK-NEXT: 0x0000019c: 01 DW_LNS_copy
 // CHECK-NEXT:             0x000000000000009c     34     86      1   0             0       0  is_stmt prologue_end
-// CHECK-NEXT: 0x0000019d: 02 DW_LNS_advance_pc (addr += 4, op-index += 0)
-// CHECK-NEXT: 0x0000019f: 00 DW_LNE_end_sequence
-// CHECK-NEXT: 0x00000000000000a0     34     86      1   0             0       0  is_stmt end_sequence
 
 #--- stmt_seq_macho.cpp
 #define ATTRIB extern "C" __attribute__((noinline))

--- a/llvm/test/DebugInfo/ARM/stmt_seq_macho.test
+++ b/llvm/test/DebugInfo/ARM/stmt_seq_macho.test
@@ -45,6 +45,20 @@
 // CHECK: DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]    ([[ERRLEN:0x[0-9a-fA-F]{8}]])
 // CHECK: DW_AT_linkage_name [DW_FORM_strp]  ({{.*}} = "_ZN12length_errorC2EPKc")
 
+// CHECK:      .debug_line contents:
+// CHECK-NEXT: debug_line[0x00000000]
+// CHECK-NEXT: Line table prologue:
+// CHECK-NEXT:     total_length: 0x0000019e
+// CHECK-NEXT:           format: DWARF32
+// CHECK-NEXT:          version: 4
+// CHECK-NEXT:  prologue_length: 0x00000085
+// CHECK-NEXT:  min_inst_length: 1
+// CHECK-NEXT: max_ops_per_inst: 1
+// CHECK-NEXT:  default_is_stmt: 1
+// CHECK-NEXT:        line_base: -5
+// CHECK-NEXT:       line_range: 14
+// CHECK-NEXT:      opcode_base: 13
+
 // CHECK:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
 // CHECK-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
 // CHECK-NEXT: [[EMPTY1]]: 05 DW_LNS_set_column (33)

--- a/llvm/test/DebugInfo/X86/DW_AT_LLVM_stmt_seq_sec_offset.ll
+++ b/llvm/test/DebugInfo/X86/DW_AT_LLVM_stmt_seq_sec_offset.ll
@@ -14,38 +14,39 @@
 ; STMT_SEQ:       DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]	(0x00000043)
 ; STMT_SEQ:   DW_AT_name {{.*}}func01
 ; STMT_SEQ:   DW_TAG_subprogram [[[ABBREV_CODE2]]]
-; STMT_SEQ:       DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]	(0x00000056)
+; STMT_SEQ:       DW_AT_LLVM_stmt_sequence [DW_FORM_sec_offset]	(0x00000058)
 ; STMT_SEQ:   DW_AT_name {{.*}}main
 
 ;; Check the entire line sequence to see that it's correct
-; STMT_SEQ:                   Address            Line   Column File   ISA Discriminator OpIndex Flags
-; STMT_SEQ-NEXT:              ------------------ ------ ------ ------ --- ------------- ------- -------------
-; STMT_SEQ-NEXT:  0x00000043: 04 DW_LNS_set_file (0)
-; STMT_SEQ-NEXT:  0x00000045: 05 DW_LNS_set_column (9)
-; STMT_SEQ-NEXT:  0x00000047: 0a DW_LNS_set_prologue_end
-; STMT_SEQ-NEXT:  0x00000048: 00 DW_LNE_set_address (0x00000000)
-; STMT_SEQ-NEXT:  0x0000004f: 16 address += 0,  line += 4,  op-index += 0
-; STMT_SEQ-NEXT:              0x0000000000000000      5      9      0   0             0       0  is_stmt prologue_end
-; STMT_SEQ-NEXT:  0x00000050: 05 DW_LNS_set_column (3)
-; STMT_SEQ-NEXT:  0x00000052: 67 address += 6,  line += 1,  op-index += 0
-; STMT_SEQ-NEXT:              0x0000000000000006      6      3      0   0             0       0  is_stmt
-; STMT_SEQ-NEXT:  0x00000053: 00 DW_LNE_end_sequence
-; STMT_SEQ-NEXT:              0x0000000000000006      6      3      0   0             0       0  is_stmt end_sequence
-; STMT_SEQ-NEXT:  0x00000056: 04 DW_LNS_set_file (0)
-; STMT_SEQ-NEXT:  0x00000058: 00 DW_LNE_set_address (0x00000008)
-; STMT_SEQ-NEXT:  0x0000005f: 03 DW_LNS_advance_line (10)
-; STMT_SEQ-NEXT:  0x00000061: 01 DW_LNS_copy
-; STMT_SEQ-NEXT:              0x0000000000000008     10      0      0   0             0       0  is_stmt
-; STMT_SEQ-NEXT:  0x00000062: 05 DW_LNS_set_column (10)
-; STMT_SEQ-NEXT:  0x00000064: 0a DW_LNS_set_prologue_end
-; STMT_SEQ-NEXT:  0x00000065: 83 address += 8,  line += 1,  op-index += 0
-; STMT_SEQ-NEXT:              0x0000000000000010     11     10      0   0             0       0  is_stmt prologue_end
-; STMT_SEQ-NEXT:  0x00000066: 05 DW_LNS_set_column (3)
-; STMT_SEQ-NEXT:  0x00000068: 9f address += 10,  line += 1,  op-index += 0
-; STMT_SEQ-NEXT:              0x000000000000001a     12      3      0   0             0       0  is_stmt
-; STMT_SEQ-NEXT:  0x00000069: 02 DW_LNS_advance_pc (addr += 5, op-index += 0)
-; STMT_SEQ-NEXT:  0x0000006b: 00 DW_LNE_end_sequence
-; STMT_SEQ-NEXT:              0x000000000000001f     12      3      0   0             0       0  is_stmt end_sequence
+; STMT_SEQ:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
+; STMT_SEQ-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
+; STMT_SEQ-NEXT: 0x00000043: 04 DW_LNS_set_file (0)
+; STMT_SEQ-NEXT: 0x00000045: 05 DW_LNS_set_column (9)
+; STMT_SEQ-NEXT: 0x00000047: 0a DW_LNS_set_prologue_end
+; STMT_SEQ-NEXT: 0x00000048: 00 DW_LNE_set_address (0x00000000)
+; STMT_SEQ-NEXT: 0x0000004f: 16 address += 0,  line += 4,  op-index += 0
+; STMT_SEQ-NEXT:             0x0000000000000000      5      9      0   0             0       0  is_stmt prologue_end
+; STMT_SEQ-NEXT: 0x00000050: 05 DW_LNS_set_column (3)
+; STMT_SEQ-NEXT: 0x00000052: 67 address += 6,  line += 1,  op-index += 0
+; STMT_SEQ-NEXT:             0x0000000000000006      6      3      0   0             0       0  is_stmt
+; STMT_SEQ-NEXT: 0x00000053: 02 DW_LNS_advance_pc (addr += 2, op-index += 0)
+; STMT_SEQ-NEXT: 0x00000055: 00 DW_LNE_end_sequence
+; STMT_SEQ-NEXT:             0x0000000000000008      6      3      0   0             0       0  is_stmt end_sequence
+; STMT_SEQ-NEXT: 0x00000058: 04 DW_LNS_set_file (0)
+; STMT_SEQ-NEXT: 0x0000005a: 00 DW_LNE_set_address (0x00000008)
+; STMT_SEQ-NEXT: 0x00000061: 03 DW_LNS_advance_line (10)
+; STMT_SEQ-NEXT: 0x00000063: 01 DW_LNS_copy
+; STMT_SEQ-NEXT:             0x0000000000000008     10      0      0   0             0       0  is_stmt
+; STMT_SEQ-NEXT: 0x00000064: 05 DW_LNS_set_column (10)
+; STMT_SEQ-NEXT: 0x00000066: 0a DW_LNS_set_prologue_end
+; STMT_SEQ-NEXT: 0x00000067: 83 address += 8,  line += 1,  op-index += 0
+; STMT_SEQ-NEXT:             0x0000000000000010     11     10      0   0             0       0  is_stmt prologue_end
+; STMT_SEQ-NEXT: 0x00000068: 05 DW_LNS_set_column (3)
+; STMT_SEQ-NEXT: 0x0000006a: 9f address += 10,  line += 1,  op-index += 0
+; STMT_SEQ-NEXT:             0x000000000000001a     12      3      0   0             0       0  is_stmt
+; STMT_SEQ-NEXT: 0x0000006b: 02 DW_LNS_advance_pc (addr += 5, op-index += 0)
+; STMT_SEQ-NEXT: 0x0000006d: 00 DW_LNE_end_sequence
+; STMT_SEQ-NEXT:             0x000000000000001f     12      3      0   0             0       0  is_stmt end_sequence
 
 ; generated from:
 ; clang -Oz -g -S -emit-llvm test.c -o test.ll

--- a/llvm/test/DebugInfo/X86/DW_AT_LLVM_stmt_seq_sec_offset.ll
+++ b/llvm/test/DebugInfo/X86/DW_AT_LLVM_stmt_seq_sec_offset.ll
@@ -18,35 +18,35 @@
 ; STMT_SEQ:   DW_AT_name {{.*}}main
 
 ;; Check the entire line sequence to see that it's correct
-; STMT_SEQ:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
-; STMT_SEQ-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
-; STMT_SEQ-NEXT: 0x00000043: 04 DW_LNS_set_file (0)
-; STMT_SEQ-NEXT: 0x00000045: 05 DW_LNS_set_column (9)
-; STMT_SEQ-NEXT: 0x00000047: 0a DW_LNS_set_prologue_end
-; STMT_SEQ-NEXT: 0x00000048: 00 DW_LNE_set_address (0x00000000)
-; STMT_SEQ-NEXT: 0x0000004f: 16 address += 0,  line += 4,  op-index += 0
-; STMT_SEQ-NEXT:             0x0000000000000000      5      9      0   0             0       0  is_stmt prologue_end
-; STMT_SEQ-NEXT: 0x00000050: 05 DW_LNS_set_column (3)
-; STMT_SEQ-NEXT: 0x00000052: 67 address += 6,  line += 1,  op-index += 0
-; STMT_SEQ-NEXT:             0x0000000000000006      6      3      0   0             0       0  is_stmt
-; STMT_SEQ-NEXT: 0x00000053: 02 DW_LNS_advance_pc (addr += 2, op-index += 0)
-; STMT_SEQ-NEXT: 0x00000055: 00 DW_LNE_end_sequence
-; STMT_SEQ-NEXT:             0x0000000000000008      6      3      0   0             0       0  is_stmt end_sequence
-; STMT_SEQ-NEXT: 0x00000058: 04 DW_LNS_set_file (0)
-; STMT_SEQ-NEXT: 0x0000005a: 00 DW_LNE_set_address (0x00000008)
-; STMT_SEQ-NEXT: 0x00000061: 03 DW_LNS_advance_line (10)
-; STMT_SEQ-NEXT: 0x00000063: 01 DW_LNS_copy
-; STMT_SEQ-NEXT:             0x0000000000000008     10      0      0   0             0       0  is_stmt
-; STMT_SEQ-NEXT: 0x00000064: 05 DW_LNS_set_column (10)
-; STMT_SEQ-NEXT: 0x00000066: 0a DW_LNS_set_prologue_end
-; STMT_SEQ-NEXT: 0x00000067: 83 address += 8,  line += 1,  op-index += 0
-; STMT_SEQ-NEXT:             0x0000000000000010     11     10      0   0             0       0  is_stmt prologue_end
-; STMT_SEQ-NEXT: 0x00000068: 05 DW_LNS_set_column (3)
-; STMT_SEQ-NEXT: 0x0000006a: 9f address += 10,  line += 1,  op-index += 0
-; STMT_SEQ-NEXT:             0x000000000000001a     12      3      0   0             0       0  is_stmt
-; STMT_SEQ-NEXT: 0x0000006b: 02 DW_LNS_advance_pc (addr += 5, op-index += 0)
-; STMT_SEQ-NEXT: 0x0000006d: 00 DW_LNE_end_sequence
-; STMT_SEQ-NEXT:             0x000000000000001f     12      3      0   0             0       0  is_stmt end_sequence
+; STMT_SEQ:                   Address            Line   Column File   ISA Discriminator OpIndex Flags
+; STMT_SEQ-NEXT:              ------------------ ------ ------ ------ --- ------------- ------- -------------
+; STMT_SEQ-NEXT:  0x00000043: 04 DW_LNS_set_file (0)
+; STMT_SEQ-NEXT:  0x00000045: 05 DW_LNS_set_column (9)
+; STMT_SEQ-NEXT:  0x00000047: 0a DW_LNS_set_prologue_end
+; STMT_SEQ-NEXT:  0x00000048: 00 DW_LNE_set_address (0x00000000)
+; STMT_SEQ-NEXT:  0x0000004f: 16 address += 0,  line += 4,  op-index += 0
+; STMT_SEQ-NEXT:              0x0000000000000000      5      9      0   0             0       0  is_stmt prologue_end
+; STMT_SEQ-NEXT:  0x00000050: 05 DW_LNS_set_column (3)
+; STMT_SEQ-NEXT:  0x00000052: 67 address += 6,  line += 1,  op-index += 0
+; STMT_SEQ-NEXT:              0x0000000000000006      6      3      0   0             0       0  is_stmt
+; STMT_SEQ-NEXT:  0x00000053: 02 DW_LNS_advance_pc (addr += 2, op-index += 0)
+; STMT_SEQ-NEXT:  0x00000055: 00 DW_LNE_end_sequence
+; STMT_SEQ-NEXT:              0x0000000000000008      6      3      0   0             0       0  is_stmt end_sequence
+; STMT_SEQ-NEXT:  0x00000058: 04 DW_LNS_set_file (0)
+; STMT_SEQ-NEXT:  0x0000005a: 00 DW_LNE_set_address (0x00000008)
+; STMT_SEQ-NEXT:  0x00000061: 03 DW_LNS_advance_line (10)
+; STMT_SEQ-NEXT:  0x00000063: 01 DW_LNS_copy
+; STMT_SEQ-NEXT:              0x0000000000000008     10      0      0   0             0       0  is_stmt
+; STMT_SEQ-NEXT:  0x00000064: 05 DW_LNS_set_column (10)
+; STMT_SEQ-NEXT:  0x00000066: 0a DW_LNS_set_prologue_end
+; STMT_SEQ-NEXT:  0x00000067: 83 address += 8,  line += 1,  op-index += 0
+; STMT_SEQ-NEXT:              0x0000000000000010     11     10      0   0             0       0  is_stmt prologue_end
+; STMT_SEQ-NEXT:  0x00000068: 05 DW_LNS_set_column (3)
+; STMT_SEQ-NEXT:  0x0000006a: 9f address += 10,  line += 1,  op-index += 0
+; STMT_SEQ-NEXT:              0x000000000000001a     12      3      0   0             0       0  is_stmt
+; STMT_SEQ-NEXT:  0x0000006b: 02 DW_LNS_advance_pc (addr += 5, op-index += 0)
+; STMT_SEQ-NEXT:  0x0000006d: 00 DW_LNE_end_sequence
+; STMT_SEQ-NEXT:              0x000000000000001f     12      3      0   0             0       0  is_stmt end_sequence
 
 ; generated from:
 ; clang -Oz -g -S -emit-llvm test.c -o test.ll

--- a/llvm/test/MC/ELF/debug-loc-label.s
+++ b/llvm/test/MC/ELF/debug-loc-label.s
@@ -17,43 +17,47 @@
 # CHECK-LINE-TABLE-NEXT: 0x0000002a: 00 DW_LNE_set_address (0x0000000000000000)
 # CHECK-LINE-TABLE-NEXT: 0x00000035: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000036: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt end_sequence
-# CHECK-LINE-TABLE-NEXT: 0x00000039: 05 DW_LNS_set_column (2)
-# CHECK-LINE-TABLE-NEXT: 0x0000003b: 00 DW_LNE_set_address (0x0000000000000008)
-# CHECK-LINE-TABLE-NEXT: 0x00000046: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x00000036: 02 DW_LNS_advance_pc (addr += 8, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x00000038: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000008      1      1      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000003b: 05 DW_LNS_set_column (2)
+# CHECK-LINE-TABLE-NEXT: 0x0000003d: 00 DW_LNE_set_address (0x0000000000000008)
+# CHECK-LINE-TABLE-NEXT: 0x00000048: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000008      1      2      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000047: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000008      1      2      1   0             0       0  is_stmt end_sequence
-# CHECK-LINE-TABLE-NEXT: 0x0000004a: 05 DW_LNS_set_column (3)
-# CHECK-LINE-TABLE-NEXT: 0x0000004c: 00 DW_LNE_set_address (0x0000000000000010)
-# CHECK-LINE-TABLE-NEXT: 0x00000057: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x00000049: 02 DW_LNS_advance_pc (addr += 8, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x0000004b: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000010      1      2      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x0000004e: 05 DW_LNS_set_column (3)
+# CHECK-LINE-TABLE-NEXT: 0x00000050: 00 DW_LNE_set_address (0x0000000000000010)
+# CHECK-LINE-TABLE-NEXT: 0x0000005b: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000010      1      3      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000058: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000010      1      3      1   0             0       0  is_stmt end_sequence
-# CHECK-LINE-TABLE-NEXT: 0x0000005b: 05 DW_LNS_set_column (4)
-# CHECK-LINE-TABLE-NEXT: 0x0000005d: 00 DW_LNE_set_address (0x0000000000000018)
-# CHECK-LINE-TABLE-NEXT: 0x00000068: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x0000005c: 02 DW_LNS_advance_pc (addr += 8, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x0000005e: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      3      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x00000061: 05 DW_LNS_set_column (4)
+# CHECK-LINE-TABLE-NEXT: 0x00000063: 00 DW_LNE_set_address (0x0000000000000018)
+# CHECK-LINE-TABLE-NEXT: 0x0000006e: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      4      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x00000069: 05 DW_LNS_set_column (5)
-# CHECK-LINE-TABLE-NEXT: 0x0000006b: 01 DW_LNS_copy
+# CHECK-LINE-TABLE-NEXT: 0x0000006f: 05 DW_LNS_set_column (5)
+# CHECK-LINE-TABLE-NEXT: 0x00000071: 01 DW_LNS_copy
 # CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      5      1   0             0       0  is_stmt
-# CHECK-LINE-TABLE-NEXT: 0x0000006c: 00 DW_LNE_end_sequence
-# CHECK-LINE-TABLE-NEXT:             0x0000000000000018      1      5      1   0             0       0  is_stmt end_sequence
+# CHECK-LINE-TABLE-NEXT: 0x00000072: 02 DW_LNS_advance_pc (addr += 8, op-index += 0)
+# CHECK-LINE-TABLE-NEXT: 0x00000074: 00 DW_LNE_end_sequence
+# CHECK-LINE-TABLE-NEXT:             0x0000000000000020      1      5      1   0             0       0  is_stmt end_sequence
 
 # CHECK-SYM:      Symbol table '.symtab' contains 9 entries:
 # CHECK-SYM-NEXT:    Num:    Value          Size Type    Bind   Vis       Ndx Name
 # CHECK-SYM-NEXT:      0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT   UND
 # CHECK-SYM-NEXT:      1: 0000000000000000     0 FILE    LOCAL  DEFAULT   ABS test.c
 # CHECK-SYM-NEXT:      2: 0000000000000000     0 SECTION LOCAL  DEFAULT     2 .text
-# CHECK-SYM-NEXT:      3: 0000000000000039     0 NOTYPE  LOCAL  DEFAULT     3 my_label_02
-# CHECK-SYM-NEXT:      4: 000000000000004a     0 NOTYPE  LOCAL  DEFAULT     3 my_label_03
-# CHECK-SYM-NEXT:      5: 000000000000005b     0 NOTYPE  LOCAL  DEFAULT     3 my_label_04
-# CHECK-SYM-NEXT:      6: 000000000000004a     0 NOTYPE  LOCAL  DEFAULT     3 my_label_03.1
-# CHECK-SYM-NEXT:      7: 000000000000006f     0 NOTYPE  LOCAL  DEFAULT     3 my_label_05
+# CHECK-SYM-NEXT:      3: 000000000000003b     0 NOTYPE  LOCAL  DEFAULT     3 my_label_02
+# CHECK-SYM-NEXT:      4: 000000000000004e     0 NOTYPE  LOCAL  DEFAULT     3 my_label_03
+# CHECK-SYM-NEXT:      5: 0000000000000061     0 NOTYPE  LOCAL  DEFAULT     3 my_label_04
+# CHECK-SYM-NEXT:      6: 000000000000004e     0 NOTYPE  LOCAL  DEFAULT     3 my_label_03.1
+# CHECK-SYM-NEXT:      7: 0000000000000077     0 NOTYPE  LOCAL  DEFAULT     3 my_label_05
 # CHECK-SYM-NEXT:      8: 0000000000000000     0 FUNC    GLOBAL DEFAULT     2 foo
 
-# CHECK-OFFSETS: 0000 39000000 4a000000 5b000000
+# CHECK-OFFSETS: 0000 3b000000 4e000000 61000000
 
 	.text
 	.file	"test.c"


### PR DESCRIPTION
### Context

#99710 introduced `.loc_label` so we can terminate a line sequence. However, it did not advance PC properly. This is problematic for 1-instruction functions as it will have zero-length sequence. The test checked in that PR shows the problem:

```
# CHECK-LINE-TABLE:                  Address            Line   Column File   ISA Discriminator OpIndex Flags
# CHECK-LINE-TABLE-NEXT:             ------------------ ------ ------ ------ --- ------------- ------- -------------
# CHECK-LINE-TABLE-NEXT: 0x00000028: 05 DW_LNS_set_column (1)
# CHECK-LINE-TABLE-NEXT: 0x0000002a: 00 DW_LNE_set_address (0x0000000000000000)
# CHECK-LINE-TABLE-NEXT: 0x00000035: 01 DW_LNS_copy
# CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt
# CHECK-LINE-TABLE-NEXT: 0x00000036: 00 DW_LNE_end_sequence
# CHECK-LINE-TABLE-NEXT:             0x0000000000000000      1      1      1   0             0       0  is_stmt end_sequence
```

Both rows having PC 0x0 is incorrect, and parsers won't be able to parse them. See more explanation why this is wrong in #154851.

### Design

This PR attempts to fix this by advancing the PC to the next available Label, and advance to the end of the section if no Label is available.

### Implementation

- `emitDwarfLineEndEntry` will advance PC to the `CurrLabel`
- If `CurrLabel` is null, its probably a fake LineEntry we introduced in #110192. In that case look for the next Label
- If still not label can be found, use `null` and `emitDwarfLineEndEntry` is smart enough to advance PC to the end of the section
- Rename `LastLabel` to `PrevLabel`, "last" can mean "previous" or "final", this is ambigous.
- Updated the tests to emit a correct label.

### Note

This fix should render #154986 and #154851 obsolete, they were temporary fixes and don't resolve the root cause.