### PR TITLE
[clang] Allow custom bug report messages

### DIFF
--- a/clang/include/clang/Config/config.h.cmake
+++ b/clang/include/clang/Config/config.h.cmake
@@ -85,4 +85,7 @@
 /* Whether CIR is built into Clang */
 #cmakedefine01 CLANG_ENABLE_CIR
 
+/* Define if there is a custom bug report message */
+#cmakedefine CLANG_CUSTOM_BUG_REPORT_MSG "${CLANG_CUSTOM_BUG_REPORT_MSG}"
+
 #endif

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -235,13 +235,13 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
 
 int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   noteBottomOfStack();
-  #ifdef CLANG_CUSTOM_BUG_REPORT_MSG
+#ifdef CLANG_CUSTOM_BUG_REPORT_MSG
   llvm::setBugReportMsg(CLANG_CUSTOM_BUG_REPORT_MSG);
-  #else
+#else
   llvm::setBugReportMsg("PLEASE submit a bug report to " BUG_REPORT_URL
                         " and include the crash backtrace, preprocessed "
                         "source, and associated run script.\n");
-  #endif
+#endif
   SmallVector<const char *, 256> Args(Argv, Argv + Argc);
 
   if (llvm::sys::Process::FixupStandardFileDescriptors())

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -235,9 +235,13 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
 
 int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   noteBottomOfStack();
+  #ifdef CLANG_CUSTOM_BUG_REPORT_MSG
+  llvm::setBugReportMsg(CLANG_CUSTOM_BUG_REPORT_MSG);
+  #else
   llvm::setBugReportMsg("PLEASE submit a bug report to " BUG_REPORT_URL
                         " and include the crash backtrace, preprocessed "
                         "source, and associated run script.\n");
+  #endif
   SmallVector<const char *, 256> Args(Argv, Argv + Argc);
 
   if (llvm::sys::Process::FixupStandardFileDescriptors())


### PR DESCRIPTION
Clang vendors may need to set a custom message for bug reports if the default is not sufficient (e.g. if they need the user to provide more information than what the default message asks for). This can be configured using the new macro `CLANG_CUSTOM_BUG_REPORT_MSG`.