### PR TITLE
[libc] Implement vector 'split' and 'concat' routines

### DIFF
--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -224,4 +224,7 @@ add_header_library(
   simd
   HDRS
     simd.h
+  DEPENDS
+    .utility
+    .tuple
 )

--- a/libc/src/__support/CPP/simd.h
+++ b/libc/src/__support/CPP/simd.h
@@ -89,19 +89,19 @@ LIBC_INLINE constexpr static auto extend(cpp::simd<T, N> x) {
 template <typename T, size_t N, size_t M, size_t... Indices>
 LIBC_INLINE constexpr static cpp::simd<T, N + M>
 concat(cpp::simd<T, N> x, cpp::simd<T, M> y, cpp::index_sequence<Indices...>) {
-  constexpr size_t Length = (N > M ? N : M);
+  constexpr size_t Size = cpp::max(N, M);
   auto remap = [](size_t idx) -> int {
     if (idx < N)
       return static_cast<int>(idx);
     if (idx < N + M)
-      return static_cast<int>((idx - N) + Length);
+      return static_cast<int>((idx - N) + Size);
     return -1;
   };
 
   // Extend the input vectors until they are the same size, then use the indices
   // to shuffle in only the indices that correspond to the original values.
-  auto x_ext = extend<T, N, Length, N>(x);
-  auto y_ext = extend<T, M, Length, M>(y);
+  auto x_ext = extend<T, N, Size, N>(x);
+  auto y_ext = extend<T, M, Size, M>(y);
   return __builtin_shufflevector(x_ext, y_ext, remap(Indices)...);
 }
 

--- a/libc/src/__support/CPP/simd.h
+++ b/libc/src/__support/CPP/simd.h
@@ -76,7 +76,7 @@ extend(cpp::simd<T, N> x, cpp::index_sequence<Indices...>) {
 template <typename T, size_t N, size_t TargetSize, size_t OriginalSize>
 LIBC_INLINE constexpr static auto extend(cpp::simd<T, N> x) {
   // Recursively resize an input vector to the target size, increasing its size
-  // by at most double the input size each step.
+  // by at most double the input size each step due to shufflevector limitation.
   if constexpr (N == TargetSize)
     return x;
   else if constexpr (TargetSize <= 2 * N)
@@ -115,12 +115,12 @@ template <typename T, size_t N, size_t Offset, size_t Head, size_t... Tail>
 LIBC_INLINE constexpr static auto split(cpp::simd<T, N> x) {
   // Recursively splits the input vector by walking the variadic template list,
   // increasing our current head each call.
-  auto first = cpp::make_tuple(
+  auto result = cpp::make_tuple(
       slice<T, N, Head, Offset>(x, cpp::make_index_sequence<Head>{}));
   if constexpr (sizeof...(Tail) > 0)
-    return cpp::tuple_cat(first, split<T, N, Offset + Head, Tail...>(x));
+    return cpp::tuple_cat(result, split<T, N, Offset + Head, Tail...>(x));
   else
-    return first;
+    return result;
 }
 
 } // namespace internal

--- a/libc/test/src/__support/CPP/simd_test.cpp
+++ b/libc/test/src/__support/CPP/simd_test.cpp
@@ -68,3 +68,29 @@ TEST(LlvmLibcSIMDTest, MaskOperations) {
   EXPECT_EQ(cpp::find_first_set(mask), 0);
   EXPECT_EQ(cpp::find_last_set(mask), 2);
 }
+
+TEST(LlvmLibcSIMDTest, SplitConcat) {
+  cpp::simd<char, 8> v(1);
+  auto [v1, v2, v3, v4] = cpp::split<2, 2, 2, 2>(v);
+  static_assert(cpp::simd_size_v<decltype(v1)> == 2 &&
+                    cpp::simd_size_v<decltype(v2)> == 2 &&
+                    cpp::simd_size_v<decltype(v3)> == 2 &&
+                    cpp::simd_size_v<decltype(v4)> == 2,
+                "invalid size");
+
+  v1 = cpp::simd<char, 2>(1);
+  v2 = cpp::simd<char, 2>(2);
+  v3 = cpp::simd<char, 2>(3);
+  v4 = cpp::simd<char, 2>(4);
+  cpp::simd<char, 8> m = cpp::concat(v1, v2, v3, v4);
+  static_assert(cpp::simd_size_v<decltype(m)> == 8, "invalid size");
+
+  cpp::simd<char, 8> c = {1, 1, 2, 2, 3, 3, 4, 4};
+  for (int i = 0; i < 8; ++i)
+    EXPECT_EQ(c[i], m[i]);
+
+  cpp::simd<char, 1> c1('\0');
+  cpp::simd<char, 8> c2('\0');
+  cpp::simd<char, 9> c3 = cpp::concat(c1, c2);
+  static_assert(cpp::simd_size_v<decltype(c3)> == 9, "invalid size");
+}

--- a/libc/test/src/__support/CPP/simd_test.cpp
+++ b/libc/test/src/__support/CPP/simd_test.cpp
@@ -70,27 +70,17 @@ TEST(LlvmLibcSIMDTest, MaskOperations) {
 }
 
 TEST(LlvmLibcSIMDTest, SplitConcat) {
-  cpp::simd<char, 8> v(1);
+  cpp::simd<char, 8> v{1, 1, 2, 2, 3, 3, 4, 4};
   auto [v1, v2, v3, v4] = cpp::split<2, 2, 2, 2>(v);
-  static_assert(cpp::simd_size_v<decltype(v1)> == 2 &&
-                    cpp::simd_size_v<decltype(v2)> == 2 &&
-                    cpp::simd_size_v<decltype(v3)> == 2 &&
-                    cpp::simd_size_v<decltype(v4)> == 2,
-                "invalid size");
+  EXPECT_TRUE(cpp::all_of(cpp::simd_cast<bool>(v1 == 1)));
+  EXPECT_TRUE(cpp::all_of(cpp::simd_cast<bool>(v2 == 2)));
+  EXPECT_TRUE(cpp::all_of(cpp::simd_cast<bool>(v3 == 3)));
+  EXPECT_TRUE(cpp::all_of(cpp::simd_cast<bool>(v4 == 4)));
 
-  v1 = cpp::simd<char, 2>(1);
-  v2 = cpp::simd<char, 2>(2);
-  v3 = cpp::simd<char, 2>(3);
-  v4 = cpp::simd<char, 2>(4);
   cpp::simd<char, 8> m = cpp::concat(v1, v2, v3, v4);
-  static_assert(cpp::simd_size_v<decltype(m)> == 8, "invalid size");
+  EXPECT_TRUE(cpp::all_of(cpp::simd_cast<bool>(m == v)));
 
-  cpp::simd<char, 8> c = {1, 1, 2, 2, 3, 3, 4, 4};
-  for (int i = 0; i < 8; ++i)
-    EXPECT_EQ(c[i], m[i]);
-
-  cpp::simd<char, 1> c1('\0');
-  cpp::simd<char, 8> c2('\0');
-  cpp::simd<char, 9> c3 = cpp::concat(c1, c2);
-  static_assert(cpp::simd_size_v<decltype(c3)> == 9, "invalid size");
+  cpp::simd<char, 1> c(~0);
+  cpp::simd<char, 8> n = cpp::concat(c, c, c, c, c, c, c, c);
+  EXPECT_TRUE(cpp::all_of(cpp::simd_cast<bool>(n == ~0)));
 }


### PR DESCRIPTION
Summary:
This provides some helpers for the split and concatenation routines for
changing the size of an existing vector. This includes a simple tuple
type to do the splitting. The tuple doesn't support structured bindings
yet.

The concat function is more limited than what would be ideal, but the
shufflevector builtin requires things of equivalent sizes and I
didn't think it was worth wrangling with that just yet.
