### PR TITLE
Fix __apple_XXX iterator that iterates over all entries.

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -43,6 +43,7 @@ public:
 
     Entry() = default;
 
+
     // Make these protected so only (final) subclasses can be copied around.
     Entry(const Entry &) = default;
     Entry(Entry &&) = default;
@@ -437,7 +438,7 @@ public:
   struct Abbrev {
     uint64_t AbbrevOffset; /// < Abbreviation offset in the .debug_names section
     uint32_t Code;         ///< Abbreviation code
-    dwarf::Tag Tag;        ///< Dwarf Tag of the described entity.
+    dwarf::Tag Tag; ///< Dwarf Tag of the described entity.
     std::vector<AttributeEncoding> Attributes; ///< List of index attributes.
 
     Abbrev(uint32_t Code, dwarf::Tag Tag, uint64_t AbbrevOffset,
@@ -726,8 +727,8 @@ public:
     bool IsLocal;
 
     std::optional<Entry> CurrentEntry;
-    uint64_t DataOffset = 0;      ///< Offset into the section.
-    std::string Key;              ///< The Key we are searching for.
+    uint64_t DataOffset = 0; ///< Offset into the section.
+    std::string Key;         ///< The Key we are searching for.
     std::optional<uint32_t> Hash; ///< Hash of Key, if it has been computed.
 
     bool getEntryAtCurrentOffset();

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -43,13 +43,13 @@ public:
 
     Entry() = default;
 
-
     // Make these protected so only (final) subclasses can be copied around.
     Entry(const Entry &) = default;
     Entry(Entry &&) = default;
     Entry &operator=(const Entry &) = default;
     Entry &operator=(Entry &&) = default;
     ~Entry() = default;
+
 
   public:
     /// Returns the Offset of the Compilation Unit associated with this

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -195,20 +195,16 @@ class LLVM_ABI AppleAcceleratorTable : public DWARFAcceleratorTable {
   /// Reads the I-th hash in the hash list.
   std::optional<uint32_t> readIthHash(uint32_t I) const {
     std::optional<uint64_t> OptOffset = getIthHashBase(I);
-    if (OptOffset) {
-      uint64_t Offset = *OptOffset;
-      return readU32FromAccel(Offset);
-    }
+    if (OptOffset)
+      return readU32FromAccel(*OptOffset);
     return std::nullopt;
   }
 
   /// Reads the I-th offset in the offset list.
   std::optional<uint32_t> readIthOffset(uint32_t I) const {
     std::optional<uint64_t> OptOffset = getIthOffsetBase(I);
-    if (OptOffset) {
-      uint64_t Offset = *OptOffset;
-      return readU32FromAccel(Offset);
-    }
+    if (OptOffset)
+      return readU32FromAccel(*OptOffset);
     return std::nullopt;
   }
 

--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFAcceleratorTable.h
@@ -309,7 +309,9 @@ public:
     /// Reads the next string pointer and the entry count for that string,
     /// populating `NumEntriesToCome`.
     /// If not possible (e.g. end of the section), becomes the end iterator.
-    /// Assumes `Offset` points to a string reference.
+    /// If `Offset` is zero, then the next valid string offset will be fetched
+    /// from the Offsets array, otherwise it will continue to parse the current
+    /// entry's strings.
     void prepareNextStringOrEnd();
 
   public:

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -335,7 +335,8 @@ void AppleAcceleratorTable::Iterator::prepareNextStringOrEnd() {
     return setToEnd();
 
   // A zero denotes the end of the collision list. Skip to the next offset
-  // in the offsets table.
+  // in the offsets table by setting the Offset to zero so we will grab the
+  // next offset from the offsets table.
   if (*StrOffset == 0) {
     Offset = 0;
     return prepareNextStringOrEnd();

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -248,8 +248,8 @@ LLVM_DUMP_METHOD void AppleAcceleratorTable::dump(raw_ostream &OS) const {
     }
 
     for (unsigned HashIdx = Index; HashIdx < Hdr.HashCount; ++HashIdx) {
-      uint64_t HashOffset = HashesBase + HashIdx * 4;
-      uint64_t OffsetsOffset = OffsetsBase + HashIdx * 4;
+      uint64_t HashOffset = HashesBase + HashIdx*4;
+      uint64_t OffsetsOffset = OffsetsBase + HashIdx*4;
       uint32_t Hash = AccelSection.getU32(&HashOffset);
 
       if (Hash % Hdr.BucketCount != Bucket)
@@ -455,7 +455,7 @@ void DWARFDebugNames::Header::dump(ScopedPrinter &W) const {
 }
 
 Error DWARFDebugNames::Header::extract(const DWARFDataExtractor &AS,
-                                       uint64_t *Offset) {
+                                             uint64_t *Offset) {
   auto HeaderError = [Offset = *Offset](Error E) {
     return createStringError(errc::illegal_byte_sequence,
                              "parsing .debug_names header at 0x%" PRIx64 ": %s",
@@ -842,9 +842,8 @@ bool DWARFDebugNames::NameIndex::dumpEntry(ScopedPrinter &W,
   uint64_t EntryId = *Offset;
   auto EntryOr = getEntry(Offset);
   if (!EntryOr) {
-    handleAllErrors(
-        EntryOr.takeError(), [](const SentinelError &) {},
-        [&W](const ErrorInfoBase &EI) { EI.log(W.startLine()); });
+    handleAllErrors(EntryOr.takeError(), [](const SentinelError &) {},
+                    [&W](const ErrorInfoBase &EI) { EI.log(W.startLine()); });
     return false;
   }
 


### PR DESCRIPTION
The previous iterator for __apple_XXX sections was assuming that all entries in the table would be contiguous and it wasn't using the offsets table to access each chain of entries for a given name. This patch fixes it so the iterator does the right thing.

This issue became apparent after a modification to strip template names from DW_AT_name entries to allow adding both the template class base name as an entry and also include the name with template names. The commit hash is 2e7ee4dc21430b0fe4c9ee306dc1d8c7986a6646. The problem is if the name starts with a "<" it will try and split the name. So if the name is `"<get-size>"` it will return an empty string as the function name, and this empty string gets added to the __apple_names table and causes large delays when using the iterators.