### PR TITLE
[CMake] Disable -Wdangling-reference warnings on GCC

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -889,6 +889,14 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
     endif()
   endif()
 
+  # Disable -Wdangling-reference, a C++-only warning from GCC 13 that seems
+  # to produce a large number of false positives.
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.1)
+      append("-Wno-dangling-reference" CMAKE_CXX_FLAGS)
+    endif()
+  endif()
+
   # Disable -Wredundant-move and -Wpessimizing-move on GCC>=9. GCC wants to
   # remove std::move in code like
   # "A foo(ConvertibleToA a) { return std::move(a); }",


### PR DESCRIPTION
This gets rid of 99 warnings which mostly seem like false positives (in a build of LLVM+Clang+LLDB, with GCC 13).

The warnings look e.g. like this:

    ../lib/ObjCopy/COFF/COFFObjcopy.cpp: In function ‘uint64_t llvm::objcopy::coff::getNextRVA(const Object&)’:
    ../lib/ObjCopy/COFF/COFFObjcopy.cpp:38:18: warning: possibly dangling reference to a temporary [-Wdangling-reference]
       38 |   const Section &Last = Obj.getSections().back();
          |                  ^~~~
    ../lib/ObjCopy/COFF/COFFObjcopy.cpp:38:47: note: the temporary was destroyed at the end of the full expression ‘(& Obj)->llvm::objcopy::coff::Object::getSections().llvm::ArrayRef<llvm::objcopy::coff::Section>::back()’
       38 |   const Section &Last = Obj.getSections().back();
          |                         ~~~~~~~~~~~~~~~~~~~~~~^~

In this example, the `Object::getSections()` method returns an `ArrayRef<Section>` from a `std::vector<Section>`. We invoke `back()` on that, and store a reference in a local variable. Even though the temporary `ArrayRef<Section>` has been destroyed, the reference points to something which still is alive in the `std::vector<Section>`.