### PR TITLE
[LLDB][SBProgress] Quick fix to the progress formatting

### DIFF
--- a/lldb/bindings/interface/SBProgressDocstrings.i
+++ b/lldb/bindings/interface/SBProgressDocstrings.i
@@ -57,8 +57,9 @@ Additionally for Python, progress is supported in a with statement. ::
     with lldb.SBProgress('Non deterministic progress', 'Detail', lldb.SBDebugger) as progress:
         for i in range(10):
             progress.Increment(1)
-    # The progress object is automatically finalized when the with statement
+            ...
 
+The progress object is automatically finalized on the exit of the with block.
 ") lldb::SBProgress;    
 
 %feature("docstring",


### PR DESCRIPTION
Earlier today I was looking at the SBProgress documentation with a colleague and found another instance where the swig block wasn't formatting correctly. I've adjusted the docs slightly to fix this. I don't actually know how to see a preview of our docstrings but I believe this will fix it.

<img width="829" height="234" alt="image" src="https://github.com/user-attachments/assets/8ef3a2df-92b9-4157-a452-f5e1ec51aa9a" />
