### PR TITLE
[lldb][nfc] Rename WritePointerToMemory argument's name

### DIFF
--- a/lldb/include/lldb/Expression/IRMemoryMap.h
+++ b/lldb/include/lldb/Expression/IRMemoryMap.h
@@ -65,7 +65,7 @@ public:
                    size_t size, Status &error);
   void WriteScalarToMemory(lldb::addr_t process_address, Scalar &scalar,
                            size_t size, Status &error);
-  void WritePointerToMemory(lldb::addr_t process_address, lldb::addr_t address,
+  void WritePointerToMemory(lldb::addr_t process_address, lldb::addr_t pointer,
                             Status &error);
   void ReadMemory(uint8_t *bytes, lldb::addr_t process_address, size_t size,
                   Status &error);

--- a/lldb/source/Expression/IRMemoryMap.cpp
+++ b/lldb/source/Expression/IRMemoryMap.cpp
@@ -637,19 +637,19 @@ void IRMemoryMap::WriteScalarToMemory(lldb::addr_t process_address,
 }
 
 void IRMemoryMap::WritePointerToMemory(lldb::addr_t process_address,
-                                       lldb::addr_t address, Status &error) {
+                                       lldb::addr_t pointer, Status &error) {
   error.Clear();
 
-  /// Only ask the Process to fix the address if this address belongs to the
+  /// Only ask the Process to fix `pointer` if the address belongs to the
   /// process. An address belongs to the process if the Allocation policy is not
   /// eAllocationPolicyHostOnly.
-  auto it = FindAllocation(address, 1);
+  auto it = FindAllocation(pointer, 1);
   if (it == m_allocations.end() ||
       it->second.m_policy != AllocationPolicy::eAllocationPolicyHostOnly)
     if (auto process_sp = GetProcessWP().lock())
-      address = process_sp->FixAnyAddress(address);
+      pointer = process_sp->FixAnyAddress(pointer);
 
-  Scalar scalar(address);
+  Scalar scalar(pointer);
 
   WriteScalarToMemory(process_address, scalar, GetAddressByteSize(), error);
 }


### PR DESCRIPTION
One of those arguments should be called `pointer` to correlate it to the name of the function and to distinguish it from the address where it will be written.