### PR TITLE
[flang][runtime] Preserve some list-directed input state in child

### DIFF
--- a/flang-rt/include/flang-rt/runtime/io-stmt.h
+++ b/flang-rt/include/flang-rt/runtime/io-stmt.h
@@ -458,6 +458,11 @@ public:
     namelistGroup_ = namelistGroup;
   }
 
+  RT_API_ATTRS bool eatComma() const { return eatComma_; }
+  RT_API_ATTRS void set_eatComma(bool yes) { eatComma_ = yes; }
+  RT_API_ATTRS bool hitSlash() const { return hitSlash_; }
+  RT_API_ATTRS void set_hitSlash(bool yes) { hitSlash_ = yes; }
+
 protected:
   const NamelistGroup *namelistGroup_{nullptr};
 

--- a/flang-rt/lib/runtime/io-stmt.cpp
+++ b/flang-rt/lib/runtime/io-stmt.cpp
@@ -1076,6 +1076,14 @@ void ChildFormattedIoStatementState<DIR, CHAR>::CompleteOperation() {
 
 template <Direction DIR, typename CHAR>
 int ChildFormattedIoStatementState<DIR, CHAR>::EndIoStatement() {
+  if constexpr (DIR == Direction::Input) {
+    if (auto *listInput{this->child()
+                .parent()
+                .template get_if<
+                    ListDirectedStatementState<Direction::Input>>()}) {
+      listInput->set_eatComma(false);
+    }
+  }
   CompleteOperation();
   return ChildIoStatementState<DIR>::EndIoStatement();
 }
@@ -1097,6 +1105,7 @@ ChildListIoStatementState<DIR>::ChildListIoStatementState(
   if constexpr (DIR == Direction::Input) {
     if (auto *listInput{child.parent()
                 .get_if<ListDirectedStatementState<Direction::Input>>()}) {
+      this->set_eatComma(listInput->eatComma());
       this->namelistGroup_ = listInput->namelistGroup();
     }
   }
@@ -1121,6 +1130,13 @@ bool ChildListIoStatementState<DIR>::AdvanceRecord(int n) {
 
 template <Direction DIR> int ChildListIoStatementState<DIR>::EndIoStatement() {
   if constexpr (DIR == Direction::Input) {
+    if (auto *listInput{this->child()
+                .parent()
+                .template get_if<
+                    ListDirectedStatementState<Direction::Input>>()}) {
+      listInput->set_eatComma(this->eatComma());
+      listInput->set_hitSlash(this->hitSlash());
+    }
     if (int status{ListDirectedStatementState<DIR>::EndIoStatement()};
         status != IostatOk) {
       return status;


### PR DESCRIPTION
Child list-directed input needs to inherit and return the state used to process trailing separators (eatComma_) and terminal '/' (hitSlash_) from any parent list-directed input statement.

Fixes https://github.com/llvm/llvm-project/issues/157509 and https://github.com/llvm/llvm-project/issues/154971.