### PR TITLE
[clang-tools-extra] Make internal shell the default for lit tests.

### DIFF
--- a/clang-tools-extra/test/clang-apply-replacements/crlf.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/crlf.cpp
@@ -1,5 +1,5 @@
 // RUN: mkdir -p %t.dir/Inputs/crlf
-// RUN: cat %S/Inputs/crlf/crlf.cpp > %t.dir/Inputs/crlf/crlf.cpp
+// RUN: cp %S/Inputs/crlf/crlf.cpp %t.dir/Inputs/crlf/crlf.cpp
 // RUN: sed "s#\$(path)#%/t.dir/Inputs/crlf#" %S/Inputs/crlf/file1.yaml > %t.dir/Inputs/crlf/file1.yaml
 // RUN: clang-apply-replacements %t.dir/Inputs/crlf
 // RUN: diff %t.dir/Inputs/crlf/crlf.cpp %S/Inputs/crlf/crlf.cpp.expected

--- a/clang-tools-extra/test/lit.cfg.py
+++ b/clang-tools-extra/test/lit.cfg.py
@@ -13,7 +13,15 @@ from lit.llvm import llvm_config
 config.name = "Clang Tools"
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# We prefer the lit internal shell which provides a better user experience on
+# failures and is faster unless the user explicitly disables it with
+# LIT_USE_INTERNAL_SHELL=0 env var.
+use_lit_shell = True
+lit_shell_env = os.environ.get("LIT_USE_INTERNAL_SHELL")
+if lit_shell_env:
+    use_lit_shell = lit.util.pythonize_bool(lit_shell_env)
+
+config.test_format = lit.formats.ShTest(not use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = [


### PR DESCRIPTION
This patch updates the clang-tools-extra lit test config to use the internal shell by default. This has some performance advantages (~10-15%) and also produces nicer failure output. It also updates one clang-tools-extra test, so that it passes using the internal shell. All the other tests appear to pass using the internal shell.