### PR TITLE
Fix GetDIE is outside of its CU error from .debug_names

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -131,8 +131,12 @@ DebugNamesDWARFIndex::GetNonSkeletonUnit(const DebugNames::Entry &entry) const {
     unit_offset = entry.getLocalTUOffset();
   if (unit_offset) {
     if (DWARFUnit *cu = m_debug_info.GetUnitAtOffset(DIERef::Section::DebugInfo,
-                                                     *unit_offset))
-      return &cu->GetNonSkeletonUnit();
+                                                     *unit_offset)) {
+      DWARFUnit &ret = cu->GetNonSkeletonUnit();
+      if (ret.IsSkeletonUnit())
+        return nullptr;
+      return &ret;
+    }
   }
   return nullptr;
 }

--- a/lldb/test/Shell/SymbolFile/DWARF/dwo-miss-getdie-ouside-cu-error.c
+++ b/lldb/test/Shell/SymbolFile/DWARF/dwo-miss-getdie-ouside-cu-error.c
@@ -1,0 +1,19 @@
+/// Check that LLDB does not emit "GetDIE for DIE {{0x[0-9a-f]+}} is outside of its CU"
+/// error message when user is searching for a matching symbol from .debug_names
+/// and fail to locate the corresponding .dwo file.
+
+/// -gsplit-dwarf is supported only on Linux.
+// REQUIRES: system-linux
+
+// RUN: %clang_host -g -gsplit-dwarf -gpubnames -gdwarf-5 %s -o main
+/// Remove the DWO file away from the expected location so that LLDB won't find the DWO next to the binary.
+// RUN: rm *.dwo
+// RUN: %lldb --no-lldbinit main \
+// RUN:   -o "b main" --batch 2>&1 | FileCheck %s
+
+// CHECK: warning: {{.*}}main unable to locate separate debug file (dwo, dwp). Debugging will be degraded.
+// CHECK-NOT: main GetDIE for DIE {{0x[0-9a-f]+}} is outside of its CU {{0x[0-9a-f]+}}
+
+int num = 5;
+
+int main(void) { return 0; }


### PR DESCRIPTION
There is a user reporting that, when .debug_names + split dwarf dwo are enabled, they keep on getting tons of `GetDIE for DIE XXXX is outside of its CU` error messages. 
The real root cause was caused by some kind of build configuration issue that failed to materialize the underlying dwo files. However, even we failed to locate dwo files, lldb should not keep on emitting this annoying errors. Investigation shows that when .debug_names failed to find the underlying dwo files, `GetNonSkeletonUnit()` API fallback to skeleton unit, then it tries to get the DIE from the skeleton unit's offset. This will fail because the .debug_names entry offset should be based on non-skeleton unit in underlying dwo files not from its skeleton unit, causing above error to be reported.

This PR fixes the issue by verifying what `GetNonSkeletonUnit()` returned is indeed non-skeleton unit, otherwise returning null to stop further probing the DIE offset. 

The newly added testcase will fail before the change while pass now.