### PR TITLE
[Utils] Ensure that empty.txt is always empty

### DIFF
--- a/llvm/utils/lit/tests/Inputs/diff-test-update/.gitignore
+++ b/llvm/utils/lit/tests/Inputs/diff-test-update/.gitignore
@@ -1,1 +1,2 @@
-*.txt
+; diff-tmp-dir.test clobbers this file
+empty.txt

--- a/llvm/utils/lit/tests/Inputs/diff-test-update/diff-tmp-dir.test
+++ b/llvm/utils/lit/tests/Inputs/diff-test-update/diff-tmp-dir.test
@@ -1,5 +1,7 @@
 # RUN: mkdir %t
-# RUN: touch %S/empty.txt
+# Tests that if file A is in the %t directory and file B is not,
+# the diff test updater copies from file A to B.
+# RUN: echo "" > %S/empty.txt
 # RUN: cp %S/1.in %t/1.txt
 
 # RUN: diff %t/1.txt %S/empty.txt

--- a/llvm/utils/lit/tests/diff-test-update.py
+++ b/llvm/utils/lit/tests/diff-test-update.py
@@ -1,10 +1,10 @@
 # RUN: not %{lit} --update-tests -v %S/Inputs/diff-test-update | FileCheck %s
 
-# CHECK: # update-diff-test: could not deduce source and target from {{.*}}/Inputs/diff-test-update/1.in and {{.*}}/Inputs/diff-test-update/2.in
-# CHECK: # update-diff-test: could not deduce source and target from {{.*}}/diff-test-update/Output/diff-bail2.test.tmp/1.txt and {{.*}}/diff-test-update/Output/diff-bail2.test.tmp/2.txt
-# CHECK: # update-diff-test: copied {{.*}}/Output/diff-expected.test.tmp/my-file.txt to {{.*}}/Output/diff-expected.test.tmp/my-file.expected
-# CHECK: # update-diff-test: copied {{.*}}/Output/diff-tmp-dir.test.tmp/1.txt to {{.*}}/Inputs/diff-test-update/empty.txt
-# CHECK: # update-diff-test: copied {{.*}}/Inputs/diff-test-update/Output/diff-tmp.test.tmp.txt to {{.*}}/Inputs/diff-test-update/diff-t-out.txt
+# CHECK: # update-diff-test: could not deduce source and target from {{.*}}1.in and {{.*}}2.in
+# CHECK: # update-diff-test: could not deduce source and target from {{.*}}1.txt and {{.*}}2.txt
+# CHECK: # update-diff-test: copied {{.*}}my-file.txt to {{.*}}my-file.expected
+# CHECK: # update-diff-test: copied {{.*}}1.txt to {{.*}}empty.txt
+# CHECK: # update-diff-test: copied {{.*}}diff-tmp.test.tmp.txt to {{.*}}diff-t-out.txt
 
 
 # CHECK: Failed: 5 (100.00%)


### PR DESCRIPTION
Previously this test case would `touch %S/empty.txt` to create and empty file. The test case then copies contents to that file, so if run a second time the `touch` command would not create an empty file.