### PR TITLE
[Support][FileSystem] Prefer `status` with `file_t` parameter. NFC.

### DIFF
--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -641,7 +641,7 @@ LLVM_ABI std::error_code status(const Twine &path, file_status &result,
                                 bool follow = true);
 
 /// A version for when a file handle is already available.
-LLVM_ABI std::error_code status(file_t FD, file_status &Result);
+LLVM_ABI std::error_code status(file_t F, file_status &Result);
 
 #ifdef _WIN32
 /// A version for when a file descriptor is already available.

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -640,12 +640,12 @@ LLVM_ABI std::error_code is_other(const Twine &path, bool &result);
 LLVM_ABI std::error_code status(const Twine &path, file_status &result,
                                 bool follow = true);
 
-/// A version for when a file descriptor is already available.
-LLVM_ABI std::error_code status(int FD, file_status &Result);
+/// A version for when a file handle is already available.
+LLVM_ABI std::error_code status(file_t FD, file_status &Result);
 
 #ifdef _WIN32
 /// A version for when a file descriptor is already available.
-LLVM_ABI std::error_code status(file_t FD, file_status &Result);
+LLVM_ABI std::error_code status(int FD, file_status &Result);
 #endif
 
 /// Get file creation mode mask of the process.

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -656,7 +656,7 @@ LLVM_ABI std::error_code status(const Twine &path, file_status &result,
                                 bool follow = true);
 
 /// A version for when a file handle is already available.
-LLVM_ABI std::error_code status(file_t FD, file_status &Result);
+LLVM_ABI std::error_code status(file_t F, file_status &Result);
 
 #ifdef _WIN32
 /// A version for when a file descriptor is already available.

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -655,12 +655,12 @@ LLVM_ABI std::error_code is_other(const Twine &path, bool &result);
 LLVM_ABI std::error_code status(const Twine &path, file_status &result,
                                 bool follow = true);
 
-/// A version for when a file descriptor is already available.
-LLVM_ABI std::error_code status(int FD, file_status &Result);
+/// A version for when a file handle is already available.
+LLVM_ABI std::error_code status(file_t FD, file_status &Result);
 
 #ifdef _WIN32
 /// A version for when a file descriptor is already available.
-LLVM_ABI std::error_code status(file_t FD, file_status &Result);
+LLVM_ABI std::error_code status(int FD, file_status &Result);
 #endif
 
 /// Get file creation mode mask of the process.


### PR DESCRIPTION
When searching the documentation for LLVM for `llvm::sys::fs::status`,
only the version with file descriptor can be found because the
documentation is built on the UNIX host and the file handle version is
defined out.

In reality, file handle version is more portable and should be displayed
instead. On UNIX, these two functions have the same underlying type,
thus it shouldn't matter which one is declared, and both versions are
still available on Windows for compatibility.
