### PR TITLE
[bazel] Remove unnecessary AllTargetsAsmParsers dep

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -9004,7 +9004,6 @@ cc_library(
         ":LLVMDialect",
         ":Pass",
         ":TargetLLVMIRTransformsIncGen",
-        "//llvm:AllTargetsAsmParsers",
         "//llvm:AllTargetsCodeGens",
         "//llvm:MC",
         "//llvm:Support",


### PR DESCRIPTION
Added in #154660 which ported #145899, but only the AllTargetsCodeGens dep actually seems necessary here.