### PR TITLE
[TableGen][CodeGen] Remove feature string from HwMode

### DIFF
--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -20,15 +20,20 @@ class Predicate; // Forward def
 // Register file description - These classes are used to fill in the target
 // description classes.
 
-class HwMode<string FS, list<Predicate> Ps> {
-  // A string representing subtarget features that turn on this HW mode.
-  // For example, "+feat1,-feat2" will indicate that the mode is active
-  // when "feat1" is enabled and "feat2" is disabled at the same time.
-  // Any other features are not checked.
-  // When multiple modes are used, they should be mutually exclusive,
-  // otherwise the results are unpredictable.
-  string Features = FS;
+// Code that will be inserted at the start of the generated
+// `*GenSubtargetInfo::getHwModeSet()` method. It is expected to define
+// variables used in Predicate::CondString. If this class is never instantiated,
+// the default
+//
+//   [[maybe_unused]] const auto *Subtarget =
+//        static_cast<const <TargetName>Subtarget *>(this);
+//
+// will be inserted, where <TargetName> is the name of the Target record.
+class HwModePredicateProlog<code c> {
+  code Code = c;
+}
 
+class HwMode<list<Predicate> Ps> {
   // A list of predicates that turn on this HW mode.
   list<Predicate> Predicates = Ps;
 }
@@ -36,7 +41,7 @@ class HwMode<string FS, list<Predicate> Ps> {
 // A special mode recognized by tablegen. This mode is considered active
 // when no other mode is active. For targets that do not use specific hw
 // modes, this is the only mode.
-def DefaultMode : HwMode<"", []>;
+def DefaultMode : HwMode<[]>;
 
 // A class used to associate objects with HW modes. It is only intended to
 // be used as a base class, where the derived class should contain a member

--- a/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64RegisterInfo.td
@@ -983,7 +983,7 @@ class ZPRRegOp <string Suffix, AsmOperandClass C, ElementSizeEnum Size,
 
 // Note: This hardware mode is enabled in AArch64Subtarget::getHwModeSet()
 // (without the use of the table-gen'd predicates).
-def SMEWithZPRPredicateSpills : HwMode<"", [Predicate<"false">]>;
+def SMEWithZPRPredicateSpills : HwMode<[Predicate<"false">]>;
 
 def PPRSpillFillRI : RegInfoByHwMode<
       [DefaultMode,              SMEWithZPRPredicateSpills],

--- a/llvm/lib/Target/Hexagon/Hexagon.td
+++ b/llvm/lib/Target/Hexagon/Hexagon.td
@@ -176,8 +176,11 @@ def UseSmallData       : Predicate<"HST->useSmallData()">;
 def UseCabac           : Predicate<"HST->useCabac()">,
                          AssemblerPredicate<(any_of FeatureCabac)>;
 
-def Hvx64:  HwMode<"+hvx-length64b", [UseHVX64B]>;
-def Hvx128: HwMode<"+hvx-length128b", [UseHVX128B]>;
+def : HwModePredicateProlog<[{
+  const auto *HST = static_cast<const HexagonSubtarget *>(this);
+}]>;
+def Hvx64:  HwMode<[UseHVX64B]>;
+def Hvx128: HwMode<[UseHVX128B]>;
 
 //===----------------------------------------------------------------------===//
 // Classes used for relation maps.

--- a/llvm/lib/Target/LoongArch/LoongArch.td
+++ b/llvm/lib/Target/LoongArch/LoongArch.td
@@ -39,7 +39,7 @@ def IsLA32
                          "LA32 Basic Integer and Privilege Instruction Set">;
 
 defvar LA32 = DefaultMode;
-def LA64 : HwMode<"+64bit", [IsLA64]>;
+def LA64 : HwMode<[IsLA64]>;
 
 // Single Precision floating point
 def FeatureBasicF

--- a/llvm/lib/Target/RISCV/RISCVFeatures.td
+++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
@@ -1682,7 +1682,7 @@ def IsRV32 : Predicate<"!Subtarget->is64Bit()">,
                                 "RV32I Base Instruction Set">;
 
 defvar RV32 = DefaultMode;
-def RV64           : HwMode<"+64bit", [IsRV64]>;
+def RV64 : HwMode<[IsRV64]>;
 
 def FeatureRelax
     : SubtargetFeature<"relax", "EnableLinkerRelax", "true",

--- a/llvm/lib/Target/SystemZ/SystemZFeatures.td
+++ b/llvm/lib/Target/SystemZ/SystemZFeatures.td
@@ -196,7 +196,7 @@ def FeatureVector : SystemZFeature<
 >;
 def FeatureNoVector : SystemZMissingFeature<"Vector">;
 
-def NoVecHwMode : HwMode<"-vector", [FeatureNoVector]>;
+def NoVecHwMode : HwMode<[FeatureNoVector]>;
 
 def Arch11NewFeatures : SystemZFeatureList<[
     FeatureLoadAndZeroRightmostByte,
@@ -426,4 +426,3 @@ def Arch9UnsupportedFeatures
   : SystemZFeatureAdd<Arch10UnsupportedFeatures.List, Arch10NewFeatures.List>;
 def Arch8UnsupportedFeatures
   : SystemZFeatureAdd<Arch9UnsupportedFeatures.List,  Arch9NewFeatures.List>;
-

--- a/llvm/test/TableGen/GlobalISelEmitter/HwModes.td
+++ b/llvm/test/TableGen/GlobalISelEmitter/HwModes.td
@@ -13,8 +13,8 @@ class MyTargetGenericInstruction : GenericInstruction {
 //def Has32 : Predicate<"Subtarget->has32()">;
 def Has64 : Predicate<"Subtarget->has64()">;
 
-//def Mode32 : HwMode<"+a", [Has32]>;
-def Mode64 : HwMode<"+b", [Has64]>;
+//def Mode32 : HwMode<[Has32]>;
+def Mode64 : HwMode<[Has64]>;
 
 def ModeVT : ValueTypeByHwMode<[DefaultMode, Mode64],
                                [i32,  i64]>;

--- a/llvm/test/TableGen/HwModeBitSet.td
+++ b/llvm/test/TableGen/HwModeBitSet.td
@@ -17,7 +17,7 @@ def Feat2 : SubtargetFeature<"feat2", "HasFeat2", "true", "enable feature 2">;
 def HasFeat1 : Predicate<"Subtarget->hasFeat1()">,
                AssemblerPredicate<(all_of Feat1)>;
 def HasFeat2 : Predicate<"Subtarget->hasFeat2()">,
-               AssemblerPredicate<(all_of Feat1)>;
+               AssemblerPredicate<(all_of Feat2)>;
 
 def TestMode : HwMode<[HasFeat1]>;
 def TestMode1 : HwMode<[HasFeat2]>;
@@ -133,8 +133,8 @@ def foo : Instruction {
 // CHECK-SUBTARGET-NEXT:    // Collect HwModes and store them as a bit set.
 // CHECK-SUBTARGET-NEXT:    unsigned Modes = 0;
 // CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1]) Modes |= (1 << 0);
-// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1]) Modes |= (1 << 1);
-// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1] && FB[TestTarget::Feat1]) Modes |= (1 << 2);
+// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat2]) Modes |= (1 << 1);
+// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1] && FB[TestTarget::Feat2]) Modes |= (1 << 2);
 // CHECK-SUBTARGET-NEXT:    return Modes;
 // CHECK-SUBTARGET-NEXT:  }
 
@@ -180,4 +180,3 @@ def foo : Instruction {
 // CHECK-SUBTARGET:         llvm_unreachable("unexpected HwModeType");
 // CHECK-SUBTARGET:         return 0; // should not get here
 // CHECK-SUBTARGET:       }
-

--- a/llvm/test/TableGen/HwModeBitSet.td
+++ b/llvm/test/TableGen/HwModeBitSet.td
@@ -11,9 +11,17 @@ def TestTarget : Target {
   let InstructionSet = TestTargetInstrInfo;
 }
 
-def TestMode : HwMode<"+feat", []>;
-def TestMode1 : HwMode<"+feat1", []>;
-def TestMode2 : HwMode<"+feat2", []>;
+def Feat1 : SubtargetFeature<"feat1", "HasFeat1", "true", "enable feature 1">;
+def Feat2 : SubtargetFeature<"feat2", "HasFeat2", "true", "enable feature 2">;
+
+def HasFeat1 : Predicate<"Subtarget->hasFeat1()">,
+               AssemblerPredicate<(all_of Feat1)>;
+def HasFeat2 : Predicate<"Subtarget->hasFeat2()">,
+               AssemblerPredicate<(all_of Feat1)>;
+
+def TestMode : HwMode<[HasFeat1]>;
+def TestMode1 : HwMode<[HasFeat2]>;
+def TestMode2 : HwMode<[HasFeat1, HasFeat2]>;
 
 class MyReg<string n>
   : Register<n> {
@@ -120,13 +128,26 @@ def foo : Instruction {
   let AsmString = "foo  $factor";
 }
 
+// CHECK-SUBTARGET-LABEL:  unsigned TestTargetGenMCSubtargetInfo::getHwModeSet() const {
+// CHECK-SUBTARGET{LITERAL}:[[maybe_unused]] const FeatureBitset &FB = getFeatureBits();
+// CHECK-SUBTARGET-NEXT:    // Collect HwModes and store them as a bit set.
+// CHECK-SUBTARGET-NEXT:    unsigned Modes = 0;
+// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1]) Modes |= (1 << 0);
+// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1]) Modes |= (1 << 1);
+// CHECK-SUBTARGET-NEXT:    if (FB[TestTarget::Feat1] && FB[TestTarget::Feat1]) Modes |= (1 << 2);
+// CHECK-SUBTARGET-NEXT:    return Modes;
+// CHECK-SUBTARGET-NEXT:  }
+
 // CHECK-SUBTARGET-LABEL: unsigned TestTargetGenSubtargetInfo::getHwModeSet() const {
-// CHECK-SUBTARGET:         unsigned Modes = 0;
-// CHECK-SUBTARGET:         if (checkFeatures("+feat")) Modes |= (1 << 0);
-// CHECK-SUBTARGET:         if (checkFeatures("+feat1")) Modes |= (1 << 1);
-// CHECK-SUBTARGET:         if (checkFeatures("+feat2")) Modes |= (1 << 2);
-// CHECK-SUBTARGET:         return Modes;
-// CHECK-SUBTARGET:       }
+// CHECK-SUBTARGET{LITERAL}:[[maybe_unused]] const auto *Subtarget =
+// CHECK-SUBTARGET-NEXT:        static_cast<const TestTargetSubtarget *>(this);
+// CHECK-SUBTARGET-NEXT:    // Collect HwModes and store them as a bit set.
+// CHECK-SUBTARGET-NEXT:    unsigned Modes = 0;
+// CHECK-SUBTARGET-NEXT:    if ((Subtarget->hasFeat1())) Modes |= (1 << 0);
+// CHECK-SUBTARGET-NEXT:    if ((Subtarget->hasFeat2())) Modes |= (1 << 1);
+// CHECK-SUBTARGET-NEXT:    if ((Subtarget->hasFeat1()) && (Subtarget->hasFeat2())) Modes |= (1 << 2);
+// CHECK-SUBTARGET-NEXT:    return Modes;
+// CHECK-SUBTARGET-NEXT:  }
 // CHECK-SUBTARGET-LABEL: unsigned TestTargetGenSubtargetInfo::getHwMode(enum HwModeType type) const {
 // CHECK-SUBTARGET:         unsigned Modes = getHwModeSet();
 // CHECK-SUBTARGET:         if (!Modes)

--- a/llvm/test/TableGen/HwModeEncodeAPInt.td
+++ b/llvm/test/TableGen/HwModeEncodeAPInt.td
@@ -17,9 +17,9 @@ def Myi32 : Operand<i32> {
 def HasA : Predicate<"Subtarget->hasA()">;
 def HasB : Predicate<"Subtarget->hasB()">;
 
-def ModeA : HwMode<"+a", [HasA]>; // Mode 1
-def ModeB : HwMode<"+b", [HasB]>; // Mode 2
-def ModeC : HwMode<"+c", []>;     // Mode 3
+def ModeA : HwMode<[HasA]>; // Mode 1
+def ModeB : HwMode<[HasB]>; // Mode 2
+def ModeC : HwMode<[]>;     // Mode 3
 
 
 def fooTypeEncDefault : InstructionEncoding {

--- a/llvm/test/TableGen/HwModeEncodeDecode.td
+++ b/llvm/test/TableGen/HwModeEncodeDecode.td
@@ -16,8 +16,8 @@ def  Myi32  : Operand<i32> {
 def HasA : Predicate<"Subtarget->hasA()">;
 def HasB : Predicate<"Subtarget->hasB()">;
 
-def ModeA : HwMode<"+a", [HasA]>;
-def ModeB : HwMode<"+b", [HasB]>;
+def ModeA : HwMode<[HasA]>;
+def ModeB : HwMode<[HasB]>;
 
 
 def fooTypeEncA : InstructionEncoding {

--- a/llvm/test/TableGen/HwModeEncodeDecode2.td
+++ b/llvm/test/TableGen/HwModeEncodeDecode2.td
@@ -20,8 +20,8 @@ def  Myi32  : Operand<i32> {
 def HasA : Predicate<"Subtarget->hasA()">;
 def HasB : Predicate<"Subtarget->hasB()">;
 
-def ModeA : HwMode<"+a", [HasA]>;
-def ModeB : HwMode<"+b", [HasB]>;
+def ModeA : HwMode<[HasA]>;
+def ModeB : HwMode<[HasB]>;
 
 
 def fooTypeEncA : InstructionEncoding {

--- a/llvm/test/TableGen/HwModeEncodeDecode3.td
+++ b/llvm/test/TableGen/HwModeEncodeDecode3.td
@@ -22,9 +22,9 @@ def Myi32 : Operand<i32> {
 def HasA : Predicate<"Subtarget->hasA()">;
 def HasB : Predicate<"Subtarget->hasB()">;
 
-def ModeA : HwMode<"+a", [HasA]>; // Mode 1
-def ModeB : HwMode<"+b", [HasB]>; // Mode 2
-def ModeC : HwMode<"+c", []>;     // Mode 3
+def ModeA : HwMode<[HasA]>; // Mode 1
+def ModeB : HwMode<[HasB]>; // Mode 2
+def ModeC : HwMode<[]>;     // Mode 3
 
 
 def fooTypeEncDefault : InstructionEncoding {

--- a/llvm/test/TableGen/HwModeSelect.td
+++ b/llvm/test/TableGen/HwModeSelect.td
@@ -21,8 +21,8 @@ def TestClass : RegisterClass<"TestTarget", [i32], 32, (add TestReg)>;
 def HasFeat1 : Predicate<"Subtarget->hasFeat1()">;
 def HasFeat2 : Predicate<"Subtarget->hasFeat2()">;
 
-def TestMode1 : HwMode<"+feat1", [HasFeat1]>;
-def TestMode2 : HwMode<"+feat2", [HasFeat2]>;
+def TestMode1 : HwMode<[HasFeat1]>;
+def TestMode2 : HwMode<[HasFeat2]>;
 
 // CHECK: error: assertion failed: The Objects and Modes lists must be the same length
 // CHECK: [[FILE]]:[[@LINE+1]]:5: error: assertion failed in this record

--- a/llvm/test/TableGen/HwModeSubRegs.td
+++ b/llvm/test/TableGen/HwModeSubRegs.td
@@ -3,7 +3,7 @@ include "llvm/Target/Target.td"
 
 def HasFeat : Predicate<"Subtarget->hasFeat()">;
 
-def TestMode : HwMode<"+feat1", [HasFeat]>;
+def TestMode : HwMode<[HasFeat]>;
 
 class MyReg<string n>
   : Register<n> {

--- a/llvm/test/TableGen/VarLenEncoderHwModes.td
+++ b/llvm/test/TableGen/VarLenEncoderHwModes.td
@@ -19,8 +19,8 @@ def GR64 : RegisterOperand<RegClass>;
 def HasA : Predicate<"Subtarget->hasA()">;
 def HasB : Predicate<"Subtarget->hasB()">;
 
-def ModeA : HwMode<"+a", [HasA]>;
-def ModeB : HwMode<"+b", [HasB]>;
+def ModeA : HwMode<[HasA]>;
+def ModeB : HwMode<[HasB]>;
 
 def fooTypeEncA : InstructionEncoding {
   dag Inst = (descend

--- a/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenDAGPatterns.cpp
@@ -14,6 +14,7 @@
 #include "CodeGenDAGPatterns.h"
 #include "CodeGenInstruction.h"
 #include "CodeGenRegisters.h"
+#include "SubtargetFeatureInfo.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
@@ -4498,13 +4499,17 @@ void CodeGenDAGPatterns::ExpandHwModeBasedTypes() {
 
       // Fill the map entry for this mode.
       const HwMode &HM = CGH.getMode(M);
-      AppendPattern(P, M, HM.Predicates);
+
+      SmallString<128> PredicateCheck;
+      raw_svector_ostream PS(PredicateCheck);
+      SubtargetFeatureInfo::emitPredicateCheck(PS, HM.Predicates);
+      AppendPattern(P, M, PredicateCheck);
 
       // Add negations of the HM's predicates to the default predicate.
       if (!DefaultCheck.empty())
         DefaultCheck += " && ";
       DefaultCheck += "!(";
-      DefaultCheck += HM.Predicates;
+      DefaultCheck.append(PredicateCheck);
       DefaultCheck += ")";
     }
 

--- a/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenHwModes.cpp
@@ -20,23 +20,17 @@ StringRef CodeGenHwModes::DefaultModeName = "DefaultMode";
 
 HwMode::HwMode(const Record *R) {
   Name = R->getName();
-  Features = R->getValueAsString("Features").str();
-
-  SmallString<128> PredicateCheck;
-  raw_svector_ostream OS(PredicateCheck);
-  ListSeparator LS(" && ");
-  for (const Record *Pred : R->getValueAsListOfDefs("Predicates")) {
-    StringRef CondString = Pred->getValueAsString("CondString");
-    if (CondString.empty())
-      continue;
-    OS << LS << '(' << CondString << ')';
-  }
-
-  Predicates = std::string(PredicateCheck);
+  Predicates = R->getValueAsListOfDefs("Predicates");
 }
 
 LLVM_DUMP_METHOD
-void HwMode::dump() const { dbgs() << Name << ": " << Features << '\n'; }
+void HwMode::dump() const {
+  dbgs() << Name << ": ";
+  ListSeparator LS;
+  for (const Record *R : Predicates)
+    dbgs() << LS << R->getName();
+  dbgs() << '\n';
+}
 
 HwModeSelect::HwModeSelect(const Record *R, CodeGenHwModes &CGH) {
   std::vector<const Record *> Modes = R->getValueAsListOfDefs("Modes");

--- a/llvm/utils/TableGen/Common/CodeGenHwModes.h
+++ b/llvm/utils/TableGen/Common/CodeGenHwModes.h
@@ -30,8 +30,7 @@ struct CodeGenHwModes;
 struct HwMode {
   HwMode(const Record *R);
   StringRef Name;
-  std::string Features;
-  std::string Predicates;
+  std::vector<const Record *> Predicates;
   void dump() const;
 };
 

--- a/llvm/utils/TableGen/Common/SubtargetFeatureInfo.h
+++ b/llvm/utils/TableGen/Common/SubtargetFeatureInfo.h
@@ -101,6 +101,12 @@ struct SubtargetFeatureInfo {
   static void emitComputeAssemblerAvailableFeatures(
       StringRef TargetName, StringRef ClassName, StringRef FuncName,
       SubtargetFeatureInfoMap &SubtargetFeatures, raw_ostream &OS);
+
+  static void emitPredicateCheck(raw_ostream &OS,
+                                 ArrayRef<const Record *> Predicates);
+
+  static void emitMCPredicateCheck(raw_ostream &OS, StringRef TargetName,
+                                   ArrayRef<const Record *> Predicates);
 };
 } // end namespace llvm
 


### PR DESCRIPTION
`Predicates` and `Features` fields serve the same purpose. They should be kept in sync, but not all predicates are based on features. This resulted in introducing dummy features for that only reason.

This patch removes `Features` field and changes TableGen emitters to use `Predicates` instead.

Historically, predicates were written with the assumption that the checking code will be used in `SelectionDAGISel` subclasses, meaning they will have access to the subclass variables, such as `Subtarget`. There are no such variables in the generated  `GenSubtargetInfo::getHwModeSet()`, so we need to provide them. This can be achieved by subclassing `HwModePredicateProlog`, see an example in `Hexagon.td`.
