### PR TITLE
[libc++] Extend __default_three_way_comparator to any types that only implements operator<=>

### DIFF
--- a/libcxx/include/__type_traits/desugars_to.h
+++ b/libcxx/include/__type_traits/desugars_to.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___TYPE_TRAITS_DESUGARS_TO_H
 
 #include <__config>
+#include <__type_traits/integral_constant.h>
 
 #if !defined(_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
 #  pragma GCC system_header
@@ -63,6 +64,9 @@ inline const bool __desugars_to_v<_CanonicalTag, _Operation&, _Args...> =
 template <class _CanonicalTag, class _Operation, class... _Args>
 inline const bool __desugars_to_v<_CanonicalTag, _Operation&&, _Args...> =
     __desugars_to_v<_CanonicalTag, _Operation, _Args...>;
+
+template <class _CanonicalTag, class _Operation, class... _Args>
+struct __desugars_to : integral_constant<bool, __desugars_to_v<_CanonicalTag, _Operation, _Args...> > {};
 
 _LIBCPP_END_NAMESPACE_STD
 

--- a/libcxx/include/__utility/lazy_synth_three_way_comparator.h
+++ b/libcxx/include/__utility/lazy_synth_three_way_comparator.h
@@ -10,6 +10,7 @@
 #define _LIBCPP___UTILITY_LAZY_SYNTH_THREE_WAY_COMPARATOR_H
 
 #include <__config>
+#include <__type_traits/conjunction.h>
 #include <__type_traits/desugars_to.h>
 #include <__type_traits/enable_if.h>
 #include <__utility/default_three_way_comparator.h>
@@ -69,11 +70,12 @@ struct __eager_compare_result {
 };
 
 template <class _Comparator, class _LHS, class _RHS>
-struct __lazy_synth_three_way_comparator<_Comparator,
-                                         _LHS,
-                                         _RHS,
-                                         __enable_if_t<__desugars_to_v<__less_tag, _Comparator, _LHS, _RHS> &&
-                                                       __has_default_three_way_comparator_v<_LHS, _RHS> > > {
+struct __lazy_synth_three_way_comparator<
+    _Comparator,
+    _LHS,
+    _RHS,
+    __enable_if_t<_And<__desugars_to<__less_tag, _Comparator, _LHS, _RHS>,
+                       __has_default_three_way_comparator<_LHS, _RHS> >::value> > {
   // This lifetimebound annotation is technically incorrect, but other specializations actually capture the lifetime of
   // the comparator.
   _LIBCPP_HIDE_FROM_ABI __lazy_synth_three_way_comparator(_LIBCPP_CTOR_LIFETIMEBOUND const _Comparator&) {}

--- a/libcxx/include/string
+++ b/libcxx/include/string
@@ -2521,6 +2521,7 @@ _LIBCPP_STRING_V1_EXTERN_TEMPLATE_LIST(_LIBCPP_DECLARE, wchar_t)
 #  endif
 #  undef _LIBCPP_DECLARE
 
+#  if _LIBCPP_STD_VER <= 17 || !__has_builtin(__builtin_lt_synthesises_from_spaceship)
 template <class _CharT, class _Traits, class _Alloc>
 struct __default_three_way_comparator<basic_string<_CharT, _Traits, _Alloc>, basic_string<_CharT, _Traits, _Alloc> > {
   using __string_t _LIBCPP_NODEBUG = basic_string<_CharT, _Traits, _Alloc>;
@@ -2533,6 +2534,7 @@ struct __default_three_way_comparator<basic_string<_CharT, _Traits, _Alloc>, bas
     return __ret;
   }
 };
+#  endif
 
 #  if _LIBCPP_STD_VER >= 17
 template <class _InputIterator,

--- a/libcxx/test/libcxx/utilities/utility/has_default_three_way.compile.pass.cpp
+++ b/libcxx/test/libcxx/utilities/utility/has_default_three_way.compile.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: c++03, c++11, c++14, c++17
+
+#include <__utility/default_three_way_comparator.h>
+#include <string>
+#include <vector>
+
+static_assert(std::__has_default_three_way_comparator<int, int>::value);
+static_assert(std::__has_default_three_way_comparator<int, long>::value);
+static_assert(std::__has_default_three_way_comparator<long, int>::value);
+static_assert(std::__has_default_three_way_comparator<long, long>::value);
+static_assert(std::__has_default_three_way_comparator<std::string, std::string>::value);
+
+#if __has_builtin(__builtin_lt_synthesises_from_spaceship)
+static_assert(std::__has_default_three_way_comparator<const std::string&, const std::string&>::value);
+static_assert(std::__has_default_three_way_comparator<const std::string&, const std::string_view&>::value);
+static_assert(std::__has_default_three_way_comparator<std::string, std::string_view>::value);
+static_assert(std::__has_default_three_way_comparator<const std::string&, const char*>::value);
+static_assert(std::__has_default_three_way_comparator<std::string, const char*>::value);
+static_assert(!std::__has_default_three_way_comparator<const std::string&, const wchar_t*>::value);
+
+static_assert(std::__has_default_three_way_comparator<const std::vector<int>&, const std::vector<int>&>::value);
+
+struct MyStruct {
+  int i;
+
+  friend auto operator<=>(MyStruct, MyStruct) = default;
+};
+
+static_assert(std::__has_default_three_way_comparator<const MyStruct&, const MyStruct&>::value);
+#endif


### PR DESCRIPTION
This uses the new `__builtin_lt_synthesises_from_spaceship` builtin from clang to use three way comparison for arbitrary user-defined types that only provide a spaceship operator.