### PR TITLE
[libclc] Don't add --override if there is no bitcode of generic implementation

### DIFF
--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -92,7 +92,8 @@ function(link_bc)
     ${ARGN}
   )
 
-  if( ARG_INTERNALIZE )
+  string( FIND "${ARG_INPUTS}" "/generic/" has_generic )
+  if( ARG_INTERNALIZE OR has_generic LESS 0 )
     set( inputs_with_flag ${ARG_INPUTS} )
   else()
     # Add the --override flag for non-generic bitcode files so that their


### PR DESCRIPTION
If there is no bitcode of generic implementation, all target bitcode files are added --override flag and our downstream has build error: `llvm-link: Not enough positional command line arguments specified!`