### PR TITLE
[MLIR][Python] Add the ability to signal pass failures in python-defined passes

### DIFF
--- a/mlir/lib/Bindings/Python/Pass.cpp
+++ b/mlir/lib/Bindings/Python/Pass.cpp
@@ -60,7 +60,7 @@ void mlir::python::populatePassManagerSubmodule(nb::module_ &m) {
   // Mapping of MlirExternalPass
   //----------------------------------------------------------------------------
   nb::class_<MlirExternalPass>(m, "ExternalPass")
-      .def("signal_failure",
+      .def("signal_pass_failure",
            [](MlirExternalPass pass) { mlirExternalPassSignalFailure(pass); });
 
   //----------------------------------------------------------------------------

--- a/mlir/lib/Bindings/Python/Pass.cpp
+++ b/mlir/lib/Bindings/Python/Pass.cpp
@@ -56,6 +56,8 @@ private:
 
 /// Create the `mlir.passmanager` here.
 void mlir::python::populatePassManagerSubmodule(nb::module_ &m) {
+  constexpr const char *mlirExternalPassAttr = "__mlir_external_pass__";
+
   //----------------------------------------------------------------------------
   // Mapping of the top-level PassManager
   //----------------------------------------------------------------------------
@@ -182,10 +184,22 @@ void mlir::python::populatePassManagerSubmodule(nb::module_ &m) {
             callbacks.clone = [](void *) -> void * {
               throw std::runtime_error("Cloning Python passes not supported");
             };
-            callbacks.run = [](MlirOperation op, MlirExternalPass,
+            callbacks.run = [](MlirOperation op, MlirExternalPass pass,
                                void *userData) {
-              nb::borrow<nb::callable>(static_cast<PyObject *>(userData))(op);
+              auto callable =
+                  nb::borrow<nb::callable>(static_cast<PyObject *>(userData));
+              nb::setattr(callable, mlirExternalPassAttr,
+                          nb::capsule(pass.ptr));
+              callable(op);
+              // delete it to avoid that it is used after
+              // the external pass is freed by the pass manager
+              nb::delattr(callable, mlirExternalPassAttr);
             };
+            nb::setattr(run, "signal_pass_failure", nb::cpp_function([run]() {
+                          nb::capsule cap = run.attr(mlirExternalPassAttr);
+                          mlirExternalPassSignalFailure(
+                              MlirExternalPass{cap.data()});
+                        }));
             auto externalPass = mlirCreateExternalPass(
                 passID, mlirStringRefCreate(name->data(), name->length()),
                 mlirStringRefCreate(argument.data(), argument.length()),

--- a/mlir/lib/Bindings/Python/Pass.cpp
+++ b/mlir/lib/Bindings/Python/Pass.cpp
@@ -196,7 +196,14 @@ void mlir::python::populatePassManagerSubmodule(nb::module_ &m) {
               nb::delattr(callable, mlirExternalPassAttr);
             };
             nb::setattr(run, "signal_pass_failure", nb::cpp_function([run]() {
-                          nb::capsule cap = run.attr(mlirExternalPassAttr);
+                          nb::capsule cap;
+                          try {
+                            cap = run.attr(mlirExternalPassAttr);
+                          } catch (nb::python_error &e) {
+                            throw std::runtime_error(
+                                "signal_pass_failure() should always be called "
+                                "from the __call__ method");
+                          }
                           mlirExternalPassSignalFailure(
                               MlirExternalPass{cap.data()});
                         }));

--- a/mlir/test/python/python_pass.py
+++ b/mlir/test/python/python_pass.py
@@ -103,3 +103,9 @@ def testCustomPass():
             pm.run(module)
         except Exception as e:
             print(f"caught exception: {e}")
+
+        # CHECK: caught exception: signal_pass_failure() should always be called from the __call__ method
+        try:
+            custom_pass_that_fails.signal_pass_failure()
+        except Exception as e:
+            print(f"caught exception: {e}")

--- a/mlir/test/python/python_pass.py
+++ b/mlir/test/python/python_pass.py
@@ -86,3 +86,20 @@ def testCustomPass():
         # CHECK: llvm.mul
         pm.add("convert-arith-to-llvm")
         pm.run(module)
+
+        # test signal_pass_failure
+        class CustomPassThatFails:
+            def __call__(self, m):
+                print("hello from pass that fails")
+                self.signal_pass_failure()
+
+        custom_pass_that_fails = CustomPassThatFails()
+
+        pm = PassManager("any")
+        pm.add(custom_pass_that_fails, "CustomPassThatFails")
+        # CHECK: hello from pass that fails
+        # CHECK: caught exception: Failure while executing pass pipeline
+        try:
+            pm.run(module)
+        except Exception as e:
+            print(f"caught exception: {e}")

--- a/mlir/test/python/python_pass.py
+++ b/mlir/test/python/python_pass.py
@@ -64,12 +64,12 @@ def testCustomPass():
         """
         )
 
-        def custom_pass_1(op):
+        def custom_pass_1(op, pass_):
             print("hello from pass 1!!!", file=sys.stderr)
 
         class CustomPass2:
-            def __call__(self, m):
-                apply_patterns_and_fold_greedily(m, frozen)
+            def __call__(self, op, pass_):
+                apply_patterns_and_fold_greedily(op, frozen)
 
         custom_pass_2 = CustomPass2()
 
@@ -89,9 +89,9 @@ def testCustomPass():
 
         # test signal_pass_failure
         class CustomPassThatFails:
-            def __call__(self, m):
+            def __call__(self, op, pass_):
                 print("hello from pass that fails")
-                self.signal_pass_failure()
+                pass_.signal_failure()
 
         custom_pass_that_fails = CustomPassThatFails()
 
@@ -101,11 +101,5 @@ def testCustomPass():
         # CHECK: caught exception: Failure while executing pass pipeline
         try:
             pm.run(module)
-        except Exception as e:
-            print(f"caught exception: {e}")
-
-        # CHECK: caught exception: signal_pass_failure() should always be called from the __call__ method
-        try:
-            custom_pass_that_fails.signal_pass_failure()
         except Exception as e:
             print(f"caught exception: {e}")

--- a/mlir/test/python/python_pass.py
+++ b/mlir/test/python/python_pass.py
@@ -88,12 +88,9 @@ def testCustomPass():
         pm.run(module)
 
         # test signal_pass_failure
-        class CustomPassThatFails:
-            def __call__(self, op, pass_):
-                print("hello from pass that fails")
-                pass_.signal_failure()
-
-        custom_pass_that_fails = CustomPassThatFails()
+        def custom_pass_that_fails(op, pass_):
+            print("hello from pass that fails")
+            pass_.signal_failure()
 
         pm = PassManager("any")
         pm.add(custom_pass_that_fails, "CustomPassThatFails")

--- a/mlir/test/python/python_pass.py
+++ b/mlir/test/python/python_pass.py
@@ -90,7 +90,7 @@ def testCustomPass():
         # test signal_pass_failure
         def custom_pass_that_fails(op, pass_):
             print("hello from pass that fails")
-            pass_.signal_failure()
+            pass_.signal_pass_failure()
 
         pm = PassManager("any")
         pm.add(custom_pass_that_fails, "CustomPassThatFails")


### PR DESCRIPTION
This is a follow-up PR for #156000.

In this PR we add the ability to signal pass failures (`signal_pass_failure()`) in python-defined passes.

To achieve this, we expose `MlirExternalPass` via `nb::class_` with a method `signal_pass_failure()`, and the callable passed to `pm.add(..)` now accepts two arguments (`op: MlirOperation, pass_: MlirExternalPass`).

For example:
```python
def custom_pass_that_fails(op, pass_):
    if some_condition:
        pass_.signal_pass_failure()
    # do something
```