### PR TITLE
[analyzer][NFC] Fix a warning in RegionStore.cpp

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
+++ b/clang/lib/StaticAnalyzer/Core/RegionStore.cpp
@@ -43,10 +43,13 @@ using namespace ento;
 namespace {
 class BindingKey {
 public:
-  enum Kind { Default = 0x0, Direct = 0x1 };
-private:
-  enum { Symbolic = 0x2 };
+  enum Kind {
+    Default = 0x0,
+    Direct = 0x1,
+    Symbolic = 0x2,
+  };
 
+private:
   llvm::PointerIntPair<const MemRegion *, 2> P;
   uint64_t Data;
 


### PR DESCRIPTION
```
clang/lib/StaticAnalyzer/Core/RegionStore.cpp: warning: bitwise operation between different enumeration types ('Kind' and '(anonymous namespace)::BindingKey::(unnamed enum at clang/lib/StaticAnalyzer/Core/RegionStore.cpp)') is deprecated [-Wdeprecated-anon-enum-enum-conversion]
   XX |     : P(r, k | Symbolic), Data(reinterpret_cast<uintptr_t>(Base)) {
      |            ~ ^ ~~~~~~~~
1 warning generated.
```