### PR TITLE
[analyzer] In LivenessValues::equals also check liveBindings

### DIFF
--- a/clang/lib/Analysis/LiveVariables.cpp
+++ b/clang/lib/Analysis/LiveVariables.cpp
@@ -128,7 +128,8 @@ LiveVariablesImpl::merge(LiveVariables::LivenessValues valsA,
 }
 
 bool LiveVariables::LivenessValues::equals(const LivenessValues &V) const {
-  return liveExprs == V.liveExprs && liveDecls == V.liveDecls;
+  return liveExprs == V.liveExprs && liveDecls == V.liveDecls &&
+         liveBindings == V.liveBindings;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This was likely accidentally omitted when `liveBindings` was introduced. I don't think in practice it matters.