### PR TITLE
[analyzer][NFC] Rename LivenessValues::equals to LivenessValues::operator==

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LiveVariables.h
+++ b/clang/include/clang/Analysis/Analyses/LiveVariables.h
@@ -34,7 +34,7 @@ public:
     llvm::ImmutableSet<const VarDecl *> liveDecls;
     llvm::ImmutableSet<const BindingDecl *> liveBindings;
 
-    bool equals(const LivenessValues &V) const;
+    bool operator==(const LivenessValues &V) const;
 
     LivenessValues()
       : liveExprs(nullptr), liveDecls(nullptr), liveBindings(nullptr) {}

--- a/clang/lib/Analysis/LiveVariables.cpp
+++ b/clang/lib/Analysis/LiveVariables.cpp
@@ -127,7 +127,7 @@ LiveVariablesImpl::merge(LiveVariables::LivenessValues valsA,
                                        BSetRefA.asImmutableSet());
 }
 
-bool LiveVariables::LivenessValues::equals(const LivenessValues &V) const {
+bool LiveVariables::LivenessValues::operator==(const LivenessValues &V) const {
   return liveExprs == V.liveExprs && liveDecls == V.liveDecls &&
          liveBindings == V.liveBindings;
 }
@@ -598,7 +598,7 @@ LiveVariables::computeLiveness(AnalysisDeclContext &AC, bool killAtAssign) {
 
     if (!everAnalyzedBlock[block->getBlockID()])
       everAnalyzedBlock[block->getBlockID()] = true;
-    else if (prevVal.equals(val))
+    else if (prevVal == val)
       continue;
 
     prevVal = val;


### PR DESCRIPTION
This is just more conventional.