### PR TITLE
[analyzer][NFC] Remove dead LiveVariables::Observer::observerKill

### DIFF
--- a/clang/include/clang/Analysis/Analyses/LiveVariables.h
+++ b/clang/include/clang/Analysis/Analyses/LiveVariables.h
@@ -58,13 +58,8 @@ public:
 
     /// A callback invoked right before invoking the
     ///  liveness transfer function on the given statement.
-    virtual void observeStmt(const Stmt *S,
-                             const CFGBlock *currentBlock,
-                             const LivenessValues& V) {}
-
-    /// Called when the live variables analysis registers
-    /// that a variable is killed.
-    virtual void observerKill(const DeclRefExpr *DR) {}
+    virtual void observeStmt(const Stmt *S, const CFGBlock *currentBlock,
+                             const LivenessValues &V) {}
   };
 
   ~LiveVariables() override;


### PR DESCRIPTION
This API was never used in the clang code base.
There might be downstream users, but I highly doubt that. I think the best is to get rid of this unused API.