### PR TITLE
[AST] Match the FoldingSetNodeID computed before and after creating TypedefType

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -5316,7 +5316,8 @@ ASTContext::getTypedefType(ElaboratedTypeKeyword Keyword,
   }
 
   llvm::FoldingSetNodeID ID;
-  TypedefType::Profile(ID, Keyword, Qualifier, Decl, UnderlyingType);
+  TypedefType::Profile(ID, Keyword, Qualifier, Decl,
+                       *TypeMatchesDeclOrNone ? QualType() : UnderlyingType);
 
   void *InsertPos = nullptr;
   if (FoldingSetPlaceholder<TypedefType> *Placeholder =


### PR DESCRIPTION


At some point the call to static `TypedefType::Profile` inside `ASTContext::getTypedefType` got out-of-sync with the non-static `TypedefType::Profile`.

This seem to cause some bad performance patterns with `FoldingSet` and are seeing 10x increases in compile times in certain scenarios. After this commit, the compile times go back to normal.

This commit does not include tests or benchmarks because we want to land this ASAP to unbreak our deployment. I will work on adding asserts, tests or benchmarks in a follow-up.