### PR TITLE
[Dexter] Make lldb-dap _post_step_hook more stable 

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -431,8 +431,15 @@ class LLDBDAP(DAP):
             if not trace_response["success"]:
                 raise DebuggerException("failed to get stack frames")
             stackframes = trace_response["body"]["stackFrames"]
-            path = stackframes[0]["source"]["path"]
             addr = stackframes[0]["instructionPointerReference"]
+            try:
+                path = stackframes[0]["source"]["path"]
+            except KeyError:
+                # We may have no path, e.g., if the module hasn't loaded or
+                # there's no debug info. If that's the case we won't have
+                # bound a source-location breakpoint here, so we can bail now.
+                return
+
             if any(
                 self._debugger_state.bp_addr_map.get(self.dex_id_to_dap_id[dex_bp_id])
                 == addr


### PR DESCRIPTION
Note the first commit in this PR includes a revert which I'll push before landing this.

---

Buildbot cross-project-tests-sie-ubuntu has been unstable recently
(https://lab.llvm.org/buildbot/#/builders/181).

Dexter uses lldb-dap in these tests. Occasionally a one will fail with a
KeyError because of a missing "stackFrames" "source" "path".

I can't reproduce the failure locally, but with https://github.com/llvm/llvm-project/pull/157130 and https://github.com/llvm/llvm-project/pull/157145 I've got DAP
logs from a pass and fail.

In a failure, "path" is missing for a step out of main (off the final brace),
and the passing test has one additional "module" event for libc.so.6.

```
<- {
  "body": {
    "module": {
      "addressRange": "0x7ffff7dd1000",
      "debugInfoSize": "4.9MB",
      "id": "5792732F-7831-58C6-6FB4-F3756458CA24-E46E827D",
      "name": "libc.so.6",
      "path": "/lib/x86_64-linux-gnu/libc.so.6",
      "symbolFilePath": "/usr/lib/debug/.build-id/57/92732f783158c66fb4f3756458ca24e46e827d.debug",
      "symbolStatus": "Symbols loaded."
    },
    "reason": "new"
  },
  "event": "module",
  "seq": 0,
  "type": "event"
}
```

That explains why we get a step that is missing a "path" component in the
failure. I don't understand why LLDB (or LLDB-DAP) is sometimes unable to load
the module (in time?). But "path" is an optional field anyway, so I think it's
worth handling in dexter even if LLDB's behaviour here is confusing.

This commit should stabilize the bot if the only time a module goes missing
is for steps outside main. (Ideally none would go missing, but those shouldn't
interfere with the tests).