### PR TITLE
[Clang][AMDGPU] Add -f[no-]atomic-backward-compatible and refine atomic codegen

### DIFF
--- a/clang/docs/LanguageExtensions.rst
+++ b/clang/docs/LanguageExtensions.rst
@@ -5901,6 +5901,22 @@ Each option has a corresponding flag:
 ``-fatomic-fine-grained-memory`` / ``-fno-atomic-fine-grained-memory``,
 and ``-fatomic-ignore-denormal-mode`` / ``-fno-atomic-ignore-denormal-mode``.
 
+To address correctness regressions on some targets, such as AMDGPU, a backward
+compatibility mode is available via the ``-f[no-]atomic-backward-compatible``
+flag. When this flag is enabled (default), the compiler keeps the older,
+more conservative behavior for floating-point atomic operations on gfx11 and
+gfx12 processors. In this mode, the compiler does not emit special metadata
+unless you explicitly request it with the ``[[clang::atomic]]`` attribute or
+specify ``-f[no-]atomic-*`` options. This preserves existing behavior and avoids
+source code changes.
+
+On AMDGPU, when backward compatibility mode is disabled, the compiler assumes
+that atomic operations are not used on fine-grained or remote memory. This
+corresponds to ``no_fine_grained_memory`` and ``no_remote_memory``. These
+assumptions allow the compiler to generate more efficient native instructions.
+However, they can cause correctness issues if atomic operations are used on
+fine-grained or remote memory.
+
 Code using the ``[[clang::atomic]]`` attribute can then selectively override
 the command-line defaults on a per-block basis. For instance:
 

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2344,23 +2344,36 @@ def fsymbol_partition_EQ : Joined<["-"], "fsymbol-partition=">, Group<f_Group>,
   Visibility<[ClangOption, CC1Option]>,
   MarshallingInfoString<CodeGenOpts<"SymbolPartition">>;
 
-defm atomic_remote_memory : BoolFOption<"atomic-remote-memory",
-  LangOpts<"AtomicRemoteMemory">, DefaultFalse,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption, FC1Option], "May have">,
-  NegFlag<SetFalse, [], [ClangOption, FlangOption], "Assume no">,
-  BothFlags<[], [ClangOption, FlangOption], " atomic operations on remote memory">>;
+defm atomic_remote_memory
+    : BoolFOption<
+          "atomic-remote-memory", LangOpts<"AtomicRemoteMemory">, DefaultFalse,
+          PosFlag<SetTrue, [], [ClangOption, CC1Option], "May have">,
+          NegFlag<SetFalse, [], [ClangOption, CC1Option], "Assume no">,
+          BothFlags<[], [ClangOption], " atomic operations on remote memory">>;
 
-defm atomic_fine_grained_memory : BoolFOption<"atomic-fine-grained-memory",
-  LangOpts<"AtomicFineGrainedMemory">, DefaultFalse,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption, FC1Option], "May have">,
-  NegFlag<SetFalse, [], [ClangOption, FlangOption], "Assume no">,
-  BothFlags<[], [ClangOption, FlangOption], " atomic operations on fine-grained memory">>;
+defm atomic_fine_grained_memory
+    : BoolFOption<"atomic-fine-grained-memory",
+                  LangOpts<"AtomicFineGrainedMemory">, DefaultFalse,
+                  PosFlag<SetTrue, [], [ClangOption, CC1Option], "May have">,
+                  NegFlag<SetFalse, [], [ClangOption, CC1Option], "Assume no">,
+                  BothFlags<[], [ClangOption],
+                            " atomic operations on fine-grained memory">>;
 
-defm atomic_ignore_denormal_mode : BoolFOption<"atomic-ignore-denormal-mode",
-  LangOpts<"AtomicIgnoreDenormalMode">, DefaultFalse,
-  PosFlag<SetTrue, [], [ClangOption, CC1Option, FlangOption, FC1Option], "Allow">,
-  NegFlag<SetFalse, [], [ClangOption, FlangOption], "Disallow">,
-  BothFlags<[], [ClangOption, FlangOption], " atomic operations to ignore denormal mode">>;
+defm atomic_ignore_denormal_mode
+    : BoolFOption<"atomic-ignore-denormal-mode",
+                  LangOpts<"AtomicIgnoreDenormalMode">, DefaultFalse,
+                  PosFlag<SetTrue, [], [ClangOption, CC1Option], "Allow">,
+                  NegFlag<SetFalse, [], [ClangOption, CC1Option], "Disallow">,
+                  BothFlags<[], [ClangOption],
+                            " atomic operations to ignore denormal mode">>;
+
+defm atomic_backward_compatible
+    : BoolFOption<"atomic-backward-compatible",
+                  LangOpts<"AtomicBackwardCompatible">, DefaultTrue,
+                  PosFlag<SetTrue, [], [ClangOption], "Enable">,
+                  NegFlag<SetFalse, [], [ClangOption, CC1Option], "Disable">,
+                  BothFlags<[], [ClangOption],
+                            " backward compatibility for atomic operations">>;
 
 defm memory_profile : OptInCC1FFlag<"memory-profile", "Enable", "Disable", " heap memory profiling">;
 def fmemory_profile_EQ : Joined<["-"], "fmemory-profile=">,

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -281,8 +281,6 @@ void AMDGPUTargetInfo::adjust(DiagnosticsEngine &Diags, LangOptions &Opts,
   // to OpenCL can be removed from the following line.
   setAddressSpaceMap((Opts.OpenCL && !Opts.OpenCLGenericAddressSpace) ||
                      !isAMDGCN(getTriple()));
-
-  AtomicOpts = AtomicOptions(Opts);
 }
 
 llvm::SmallVector<Builtin::InfosShard>

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -818,7 +818,7 @@ public:
 
   class CGAtomicOptionsRAII {
   public:
-    CGAtomicOptionsRAII(CodeGenModule &CGM_, AtomicOptions AO)
+    CGAtomicOptionsRAII(CodeGenModule &CGM_, std::optional<AtomicOptions> AO)
         : CGM(CGM_), SavedAtomicOpts(CGM.getAtomicOpts()) {
       CGM.setAtomicOpts(AO);
     }
@@ -826,7 +826,7 @@ public:
         : CGM(CGM_), SavedAtomicOpts(CGM.getAtomicOpts()) {
       if (!AA)
         return;
-      AtomicOptions AO = SavedAtomicOpts;
+      AtomicOptions AO = SavedAtomicOpts.value_or(AtomicOptions());
       for (auto Option : AA->atomicOptions()) {
         switch (Option) {
         case AtomicAttr::remote_memory:
@@ -849,7 +849,7 @@ public:
           break;
         }
       }
-      CGM.setAtomicOpts(AO);
+      CGM.setAtomicOpts(std::make_optional(AO));
     }
 
     CGAtomicOptionsRAII(const CGAtomicOptionsRAII &) = delete;
@@ -858,7 +858,7 @@ public:
 
   private:
     CodeGenModule &CGM;
-    AtomicOptions SavedAtomicOpts;
+    std::optional<AtomicOptions> SavedAtomicOpts;
   };
 
 public:

--- a/clang/lib/CodeGen/CodeGenModule.h
+++ b/clang/lib/CodeGen/CodeGenModule.h
@@ -677,7 +677,7 @@ private:
   std::optional<PointerAuthQualifier>
   computeVTPointerAuthentication(const CXXRecordDecl *ThisClass);
 
-  AtomicOptions AtomicOpts;
+  std::optional<AtomicOptions> AtomicOpts;
 
   // A set of functions which should be hot-patched; see
   // -fms-hotpatch-functions-file (and -list). This will nearly always be empty.
@@ -699,11 +699,11 @@ public:
   /// Finalize LLVM code generation.
   void Release();
 
-  /// Get the current Atomic options.
-  AtomicOptions getAtomicOpts() { return AtomicOpts; }
+  /// Get the current atomic options.
+  std::optional<AtomicOptions> getAtomicOpts() { return AtomicOpts; }
 
-  /// Set the current Atomic options.
-  void setAtomicOpts(AtomicOptions AO) { AtomicOpts = AO; }
+  /// Set the current atomic options.
+  void setAtomicOpts(std::optional<AtomicOptions> AO) { AtomicOpts = AO; }
 
   /// Return true if we should emit location information for expressions.
   bool getExpressionLocationsEnabled() const;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5865,12 +5865,15 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   RenderFloatingPointOptions(TC, D, OFastEnabled, Args, CmdArgs, JA);
 
-  Args.addOptInFlag(CmdArgs, options::OPT_fatomic_remote_memory,
-                    options::OPT_fno_atomic_remote_memory);
-  Args.addOptInFlag(CmdArgs, options::OPT_fatomic_fine_grained_memory,
-                    options::OPT_fno_atomic_fine_grained_memory);
-  Args.addOptInFlag(CmdArgs, options::OPT_fatomic_ignore_denormal_mode,
-                    options::OPT_fno_atomic_ignore_denormal_mode);
+  Args.addLastArg(CmdArgs, options::OPT_fatomic_remote_memory,
+                  options::OPT_fno_atomic_remote_memory);
+  Args.addLastArg(CmdArgs, options::OPT_fatomic_fine_grained_memory,
+                  options::OPT_fno_atomic_fine_grained_memory);
+  Args.addLastArg(CmdArgs, options::OPT_fatomic_ignore_denormal_mode,
+                  options::OPT_fno_atomic_ignore_denormal_mode);
+
+  Args.addOptOutFlag(CmdArgs, options::OPT_fatomic_backward_compatible,
+                     options::OPT_fno_atomic_backward_compatible);
 
   if (Arg *A = Args.getLastArg(options::OPT_fextend_args_EQ)) {
     const llvm::Triple::ArchType Arch = TC.getArch();

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4633,6 +4633,13 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.AtomicRemoteMemorySpecified =
+      Args.hasArg(OPT_fatomic_remote_memory, OPT_fno_atomic_remote_memory);
+  Opts.AtomicFineGrainedMemorySpecified = Args.hasArg(
+      OPT_fatomic_fine_grained_memory, OPT_fno_atomic_fine_grained_memory);
+  Opts.AtomicIgnoreDenormalModeSpecified = Args.hasArg(
+      OPT_fatomic_ignore_denormal_mode, OPT_fno_atomic_ignore_denormal_mode);
+
   return Diags.getNumErrors() == NumErrorsBefore;
 }
 

--- a/clang/test/CodeGenCUDA/amdgpu-atomic-ops.cu
+++ b/clang/test/CodeGenCUDA/amdgpu-atomic-ops.cu
@@ -7,7 +7,7 @@
 // RUN:   -fnative-half-arguments-and-returns -munsafe-fp-atomics | FileCheck -check-prefixes=FUN,CHECK,UNSAFEIR %s
 
 // RUN: %clang_cc1 -x hip %s -O3 -S -o - -triple=amdgcn-amd-amdhsa \
-// RUN:   -fcuda-is-device -target-cpu gfx1100 -fnative-half-type \
+// RUN:   -fcuda-is-device -target-cpu gfx1100 -fnative-half-type -fno-atomic-backward-compatible \
 // RUN:   -fnative-half-arguments-and-returns | FileCheck -check-prefixes=FUN,SAFE %s
 
 // RUN: %clang_cc1 -x hip %s -O3 -S -o - -triple=amdgcn-amd-amdhsa \

--- a/clang/test/CodeGenCUDA/atomic-options-backward-compat.hip
+++ b/clang/test/CodeGenCUDA/atomic-options-backward-compat.hip
@@ -1,0 +1,71 @@
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -target-cpu gfx1100 -emit-llvm -o - \
+// RUN:   -fno-atomic-backward-compatible %s | FileCheck %s --check-prefix=CHECK-NEW
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -target-cpu gfx1100 -emit-llvm -o - %s \
+// RUN:   | FileCheck %s --check-prefix=CHECK-OLD
+
+// CHECK-NEW-LABEL: @_Z16test_atomic_faddPf(
+// CHECK-NEW: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.fine.grained.memory !{{[0-9]+}}, !amdgpu.no.remote.memory !{{[0-9]+}}
+// CHECK-OLD-LABEL: @_Z16test_atomic_faddPf(
+// CHECK-OLD: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4
+void test_atomic_fadd(float* ptr) {
+  __atomic_fetch_add(ptr, 1.0f, __ATOMIC_RELAXED);
+}
+
+// CHECK-NEW-LABEL: @_Z13test_overridePf(
+// CHECK-NEW: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.fine.grained.memory !{{[0-9]+}}, !amdgpu.no.remote.memory !{{[0-9]+}}, !amdgpu.ignore.denormal.mode !{{[0-9]+}}
+// CHECK-OLD-LABEL: @_Z13test_overridePf(
+// CHECK-OLD-NOT: !amdgpu.no.fine.grained.memory
+// CHECK-OLD-NOT: !amdgpu.no.remote.memory
+// CHECK-OLD: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.ignore.denormal.mode !{{[0-9]+}}
+void test_override(float* ptr) {
+  [[clang::atomic(ignore_denormal_mode)]] {
+    __atomic_fetch_add(ptr, 1.0f, __ATOMIC_RELAXED);
+  }
+}
+
+// CHECK-NEW-LABEL: @_Z20test_nested_overridePf(
+// First atomic in the outer scope should have ignore_denormal plus the two new metadata.
+// CHECK-NEW: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.fine.grained.memory !{{[0-9]+}}, !amdgpu.no.remote.memory !{{[0-9]+}}, !amdgpu.ignore.denormal.mode !{{[0-9]+}}
+// For the inner scope with no_ignore_denormal_mode, ensure ignore.denormal is absent but the two new metadata are present.
+// CHECK-NEW: atomicrmw fsub ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.fine.grained.memory !{{[0-9]+}}, !amdgpu.no.remote.memory !{{[0-9]+}}
+// CHECK-NEW-NOT: !amdgpu.ignore.denormal.mode
+// CHECK-OLD-LABEL: @_Z20test_nested_overridePf(
+// CHECK-OLD-NOT: !amdgpu.no.fine.grained.memory
+// CHECK-OLD-NOT: !amdgpu.no.remote.memory
+// CHECK-OLD: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.ignore.denormal.mode !{{[0-9]+}}
+void test_nested_override(float* ptr) {
+  [[clang::atomic(ignore_denormal_mode)]] {
+    __atomic_fetch_add(ptr, 1.0f, __ATOMIC_RELAXED);
+
+    // CHECK-OLD-NOT: !amdgpu.no.fine.grained.memory
+    // CHECK-OLD-NOT: !amdgpu.no.remote.memory
+    // CHECK-OLD-NOT: !amdgpu.ignore.denormal.mode
+    // CHECK-OLD: atomicrmw fsub ptr %{{.*}}, float %{{.*}} monotonic, align 4
+    [[clang::atomic(no_ignore_denormal_mode)]] {
+      __atomic_fetch_sub(ptr, 1.0f, __ATOMIC_RELAXED);
+    }
+  }
+}
+
+// CHECK-NEW-LABEL: @_Z26test_fine_grained_overridePf(
+// CHECK-NEW: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.remote.memory !{{[0-9]+}}
+// CHECK-OLD-LABEL: @_Z26test_fine_grained_overridePf(
+// CHECK-OLD: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4
+// CHECK-OLD-NOT: !amdgpu.no.fine.grained.memory
+// CHECK-OLD-NOT: !amdgpu.no.remote.memory
+void test_fine_grained_override(float* ptr) {
+  [[clang::atomic(fine_grained_memory)]] {
+    __atomic_fetch_add(ptr, 1.0f, __ATOMIC_RELAXED);
+  }
+}
+
+// CHECK-NEW-LABEL: @_Z29test_no_fine_grained_overridePf(
+// CHECK-NEW: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.fine.grained.memory !{{[0-9]+}}, !amdgpu.no.remote.memory !{{[0-9]+}}
+// CHECK-OLD-LABEL: @_Z29test_no_fine_grained_overridePf(
+// CHECK-OLD: atomicrmw fadd ptr %{{.*}}, float %{{.*}} monotonic, align 4, !amdgpu.no.fine.grained.memory
+// CHECK-OLD-NOT: !amdgpu.no.remote.memory
+void test_no_fine_grained_override(float* ptr) {
+  [[clang::atomic(no_fine_grained_memory)]] {
+    __atomic_fetch_add(ptr, 1.0f, __ATOMIC_RELAXED);
+  }
+}

--- a/clang/test/Driver/atomic-options.hip
+++ b/clang/test/Driver/atomic-options.hip
@@ -2,5 +2,18 @@
 // RUN:   -fatomic-fine-grained-memory -fno-atomic-remote-memory -fatomic-ignore-denormal-mode \
 // RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-VALID
 
-// CHECK-VALID: "-cc1" {{.*}}"-triple" "amdgcn-amd-amdhsa" {{.*}}"-fatomic-fine-grained-memory" "-fatomic-ignore-denormal-mode"
-// CHECK-VALID: "-cc1" {{.*}}"-triple" {{.*}}"-fatomic-fine-grained-memory" "-fatomic-ignore-denormal-mode"
+// RUN: %clang -### -nogpulib -nogpuinc %s \
+// RUN:   2>&1 | FileCheck %s --check-prefix=NEG
+
+// RUN: %clang -### -nogpulib -nogpuinc -fno-atomic-backward-compatible %s \
+// RUN:   2>&1 | FileCheck %s --check-prefix=COMPAT
+
+// CHECK-VALID: "-cc1" {{.*}}"-triple" "amdgcn-amd-amdhsa" {{.*}} "-fno-atomic-remote-memory" "-fatomic-fine-grained-memory" "-fatomic-ignore-denormal-mode"
+// CHECK-VALID: "-cc1" {{.*}}"-triple" {{.*}}"-fno-atomic-remote-memory" "-fatomic-fine-grained-memory" "-fatomic-ignore-denormal-mode"
+
+// NEG-NOT: atomic-remote-memory
+// NEG-NOT: atomic-fine-grained-memory
+// NEG-NOT: atomic-ignore-denormal-mode
+
+// COMPAT: "-cc1" {{.*}}"-triple" "amdgcn-amd-amdhsa" {{.*}} "-fno-atomic-backward-compatible"
+// COMPAT: "-cc1" {{.*}}"-triple" {{.*}} "-fno-atomic-backward-compatible"


### PR DESCRIPTION
Clang recently introduced `-f[no]atomic-` options and `[[clang::atomic]]` attributes to give better control over atomic codegen. The default assumed no remote memory and no fine-grained memory to enable more efficient instructions. This was correct for most AMD GPUs, but it caused regressions on AMDGPU gfx11 and gfx12 for FP atomics on fine-grained memory, where earlier Clang used conservative behavior. Those changes altered metadata and instruction selection, breaking code that depended on the old defaults. For example, the following compiler-explorer link showed `__atomic_fetch_add` was emitted as CAS loop in ROCm 6.4 but as `global_atomic_add_f32` in llvm trunk for gfx1200:

https://godbolt.org/z/35Y3sdsn5

We need to restore a safe default to avoid regressions while keeping a clean path to the new model.

This patch adds `-f[no-]atomic-backward-compatible`. It is enabled by default to recover the old behavior and avoid regressions. Disabling it adopts the new and consistent atomic codegen design with explicit assumptions about memory types.

To make this robust, atomic attributes and atomic options are made tri-state (unset/true/false). This accurately conveys user intent and attribute semantics, so Clang can reconstruct prior behavior per GPU architecture and atomic data type, and still honor explicit requests. (Note: the unset state is only for initial state and cannot be specified by users explicitly.)

The tri-state change is minimal and lightweight in the driver, LangOptions, and CodeGen plumbing. The driver prefers the last `-fatomic-*` argument. CodeGen computes per-op defaults on gfx11/gfx12 FP atomics under compatibility, applies explicit options and attributes, and emits matching AMDGPU metadata.