### PR TITLE
[InstCombine] Push freeze through non-recurrence PHIs

### DIFF
--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -99,6 +99,11 @@ protected:
   SmallDenseSet<std::pair<const BasicBlock *, const BasicBlock *>, 8> BackEdges;
   bool ComputedBackEdges = false;
 
+  /// Phis for which we already attempted to fold a freeze away. If a freeze is
+  /// reintroduced on one of these phis we avoid repeating the transform to
+  /// prevent endless combine cycles.
+  SmallPtrSet<PHINode *, 16> FreezePhisVisited;
+
 public:
   InstCombiner(InstructionWorklist &Worklist, BuilderTy &Builder, Function &F,
                AAResults *AA, AssumptionCache &AC, TargetLibraryInfo &TLI,

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -99,11 +99,6 @@ protected:
   SmallDenseSet<std::pair<const BasicBlock *, const BasicBlock *>, 8> BackEdges;
   bool ComputedBackEdges = false;
 
-  /// Phis for which we already attempted to fold a freeze away. If a freeze is
-  /// reintroduced on one of these phis we avoid repeating the transform to
-  /// prevent endless combine cycles.
-  SmallPtrSet<PHINode *, 16> FreezePhisVisited;
-
 public:
   InstCombiner(InstructionWorklist &Worklist, BuilderTy &Builder, Function &F,
                AAResults *AA, AssumptionCache &AC, TargetLibraryInfo &TLI,

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -99,6 +99,11 @@ protected:
   SmallDenseSet<std::pair<const BasicBlock *, const BasicBlock *>, 8> BackEdges;
   bool ComputedBackEdges = false;
 
+  /// Phis we've already pushed a freeze through. If a freeze is reintroduced
+  /// on one of these phis we avoid repeating the transform to prevent
+  /// expensive combine cycles.
+  SmallPtrSet<PHINode *, 16> FreezePhisVisited;
+
 public:
   InstCombiner(InstructionWorklist &Worklist, BuilderTy &Builder, Function &F,
                AAResults *AA, AssumptionCache &AC, TargetLibraryInfo &TLI,

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -181,8 +181,7 @@ public:
   Instruction *visitExtractValueInst(ExtractValueInst &EV);
   Instruction *visitLandingPadInst(LandingPadInst &LI);
   Instruction *visitVAEndInst(VAEndInst &I);
-  Value *pushFreezeToPreventPoisonFromPropagating(FreezeInst &FI,
-                                                  bool PushThruPhis = false);
+  Value *pushFreezeToPreventPoisonFromPropagating(FreezeInst &FI);
   bool freezeOtherUses(FreezeInst &FI);
   Instruction *foldFreezeIntoRecurrence(FreezeInst &I, PHINode *PN);
   Instruction *visitFreeze(FreezeInst &I);

--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -181,7 +181,8 @@ public:
   Instruction *visitExtractValueInst(ExtractValueInst &EV);
   Instruction *visitLandingPadInst(LandingPadInst &LI);
   Instruction *visitVAEndInst(VAEndInst &I);
-  Value *pushFreezeToPreventPoisonFromPropagating(FreezeInst &FI);
+  Value *pushFreezeToPreventPoisonFromPropagating(FreezeInst &FI,
+                                                  bool PushThruPhis = false);
   bool freezeOtherUses(FreezeInst &FI);
   Instruction *foldFreezeIntoRecurrence(FreezeInst &I, PHINode *PN);
   Instruction *visitFreeze(FreezeInst &I);

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5077,9 +5077,6 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
       if (U == OrigUse)
         return nullptr;
 
-      if (isa<PoisonValue>(V))
-        continue;
-
       auto *UserI = cast<Instruction>(U->getUser());
       if (auto *PN = dyn_cast<PHINode>(UserI))
         Builder.SetInsertPoint(PN->getIncomingBlock(*U)->getTerminator());

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5034,11 +5034,13 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
     if (auto *PN = dyn_cast<PHINode>(V)) {
       BasicBlock *BB = PN->getParent();
       SmallPtrSet<BasicBlock *, 8> VisitedBBs;
-      for (Use &U : PN->incoming_values()) {
-        BasicBlock *InBB = PN->getIncomingBlock(U);
+      for (unsigned I = 0; I < PN->getNumIncomingValues(); ++I) {
+        Value *InV = PN->getIncomingValue(I);
+        BasicBlock *InBB = PN->getIncomingBlock(I);
+
         // We can't move freeze if the start value is the result of a
         // terminator (e.g. an invoke).
-        if (auto *OpI = dyn_cast<Instruction>(U)) {
+        if (auto *OpI = dyn_cast<Instruction>(InV)) {
           if (OpI->isTerminator())
             return false;
         }
@@ -5048,7 +5050,7 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
         // invalidating the iterator. We simply don't support this case, but it
         // could be handled if there's a use case.
         if (isBackEdge(InBB, BB) || !VisitedBBs.insert(InBB).second ||
-            match(U.get(), m_Undef()))
+            match(InV, m_Undef()))
           return false;
         VisitedBBs.insert(InBB);
       }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5043,8 +5043,12 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
             return false;
         }
 
-        if (DT.dominates(BB, InBB) || isBackEdge(InBB, BB) ||
-            VisitedBBs.contains(InBB) || match(U.get(), m_Undef()))
+        // If there's multiple incoming edges from the same predecessor we must
+        // ensure the freeze isn't pushed to a single one of the uses,
+        // invalidating the iterator. We simply don't support this case, but it
+        // could be handled if there's a use case.
+        if (isBackEdge(InBB, BB) || !VisitedBBs.insert(InBB).second ||
+            match(U.get(), m_Undef()))
           return false;
         VisitedBBs.insert(InBB);
       }

--- a/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -5077,6 +5077,9 @@ InstCombinerImpl::pushFreezeToPreventPoisonFromPropagating(FreezeInst &OrigFI) {
       if (U == OrigUse)
         return nullptr;
 
+      if (isa<PoisonValue>(V))
+        continue;
+
       auto *UserI = cast<Instruction>(U->getUser());
       if (auto *PN = dyn_cast<PHINode>(UserI))
         Builder.SetInsertPoint(PN->getIncomingBlock(*U)->getTerminator());

--- a/llvm/test/Transforms/InstCombine/freeze-landingpad.ll
+++ b/llvm/test/Transforms/InstCombine/freeze-landingpad.ll
@@ -14,14 +14,13 @@ define i32 @propagate_freeze_in_landingpad() personality ptr null {
 ; CHECK-NEXT:    [[RES1:%.*]] = invoke i32 @foo()
 ; CHECK-NEXT:            to label [[NORMAL_RETURN]] unwind label [[EXCEPTIONAL_RETURN]]
 ; CHECK:       normal_return:
-; CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[X]], 1
+; CHECK-NEXT:    [[INC]] = add i32 [[X]], 1
 ; CHECK-NEXT:    br label [[INVOKE_BB1]]
 ; CHECK:       exceptional_return:
 ; CHECK-NEXT:    [[PHI:%.*]] = phi i32 [ [[X]], [[INVOKE_BB1]] ], [ 0, [[INVOKE_BB2]] ]
 ; CHECK-NEXT:    [[LANDING_PAD:%.*]] = landingpad { ptr, i32 }
 ; CHECK-NEXT:            cleanup
-; CHECK-NEXT:    [[FR:%.*]] = freeze i32 [[PHI]]
-; CHECK-NEXT:    [[RES:%.*]] = shl i32 [[FR]], 1
+; CHECK-NEXT:    [[RES:%.*]] = shl i32 [[PHI]], 1
 ; CHECK-NEXT:    ret i32 [[RES]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/freeze-phi-visited.ll
+++ b/llvm/test/Transforms/InstCombine/freeze-phi-visited.ll
@@ -1,0 +1,37 @@
+; RUN: opt < %s -passes=instcombine -S -debug 2>&1 | FileCheck %s
+; REQUIRES: asserts
+
+; Repeatedly pushing freeze thru PHIs can be expensive so we keep track of PHIs
+; for which freeze has already been pushed thru.
+
+define i1 @a(i1 %min.iters.check2957, <4 x double> %wide.load2970, <4 x i1> %0, <4 x i1> %1) {
+.lr.ph1566:
+  br i1 %min.iters.check2957, label %vec.epilog.ph2984, label %vector.ph2959
+
+vector.ph2959:                                    ; preds = %.lr.ph1566
+  %2 = fcmp olt <4 x double> %wide.load2970, zeroinitializer
+  %bin.rdx2976 = or <4 x i1> %2, %0
+  %bin.rdx2977 = or <4 x i1> %1, %bin.rdx2976
+  %3 = call i1 @llvm.vector.reduce.or.v4i1(<4 x i1> %bin.rdx2977)
+  %rdx.select2979 = select i1 %3, i32 1, i32 0
+  br label %vec.epilog.ph2984
+
+vec.epilog.ph2984:                                ; preds = %vector.ph2959, %.lr.ph1566
+  %bc.merge.rdx2982 = phi i32 [ %rdx.select2979, %vector.ph2959 ], [ 0, %.lr.ph1566 ]
+  %4 = icmp ne i32 %bc.merge.rdx2982, 0
+  %broadcast.splatinsert2992 = insertelement <2 x i1> zeroinitializer, i1 %4, i64 0
+  %5 = call i1 @llvm.vector.reduce.or.v2i1(<2 x i1> %broadcast.splatinsert2992)
+  %6 = freeze i1 %5
+  %7 = freeze i1 %6
+  ret i1 %7
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i1 @llvm.vector.reduce.or.v4i1(<4 x i1>) #0
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i1 @llvm.vector.reduce.or.v2i1(<2 x i1>) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+; CHECK: freeze has already been pushed through PHI 'bc.merge.rdx2982', skipping.

--- a/llvm/test/Transforms/InstCombine/freeze-phi.ll
+++ b/llvm/test/Transforms/InstCombine/freeze-phi.ll
@@ -94,13 +94,14 @@ define i32 @two(i1 %cond, i32 %x, i32 %x2) {
 ; CHECK-LABEL: @two(
 ; CHECK-NEXT:    br i1 [[COND:%.*]], label [[A:%.*]], label [[B:%.*]]
 ; CHECK:       A:
+; CHECK-NEXT:    [[X_FR:%.*]] = freeze i32 [[X:%.*]]
 ; CHECK-NEXT:    br label [[C:%.*]]
 ; CHECK:       B:
+; CHECK-NEXT:    [[X2_FR:%.*]] = freeze i32 [[X2:%.*]]
 ; CHECK-NEXT:    br label [[C]]
 ; CHECK:       C:
-; CHECK-NEXT:    [[Y:%.*]] = phi i32 [ [[X:%.*]], [[A]] ], [ [[X2:%.*]], [[B]] ]
-; CHECK-NEXT:    [[Y_FR:%.*]] = freeze i32 [[Y]]
-; CHECK-NEXT:    ret i32 [[Y_FR]]
+; CHECK-NEXT:    [[Y:%.*]] = phi i32 [ [[X_FR]], [[A]] ], [ [[X2_FR]], [[B]] ]
+; CHECK-NEXT:    ret i32 [[Y]]
 ;
   br i1 %cond, label %A, label %B
 A:

--- a/llvm/test/Transforms/InstCombine/freeze.ll
+++ b/llvm/test/Transforms/InstCombine/freeze.ll
@@ -1143,9 +1143,9 @@ exit:
 
 ; We can remove this freeze as the incoming values to the PHI have the same
 ; well-defined start value and the GEP can't produce poison.
-define void @fold_phi_noundef_start_value(ptr noundef %init, i1 %cond.0, i1 %cond.1, i1 %cond.2) {
+define void @fold_phi_noundef_start_value(ptr noundef %init, i1 %cond.0, i1 %cond.1) {
 ; CHECK-LABEL: define void @fold_phi_noundef_start_value(
-; CHECK-SAME: ptr noundef [[INIT:%.*]], i1 [[COND_0:%.*]], i1 [[COND_1:%.*]], i1 [[COND_2:%.*]]) {
+; CHECK-SAME: ptr noundef [[INIT:%.*]], i1 [[COND_0:%.*]], i1 [[COND_1:%.*]]) {
 ; CHECK-NEXT:  [[ENTRY:.*]]:
 ; CHECK-NEXT:    br label %[[LOOP:.*]]
 ; CHECK:       [[LOOP]]:
@@ -1160,7 +1160,7 @@ define void @fold_phi_noundef_start_value(ptr noundef %init, i1 %cond.0, i1 %con
 ; CHECK-NEXT:    [[IV_0_INT:%.*]] = ptrtoint ptr [[IV_0]] to i64
 ; CHECK-NEXT:    [[IDX:%.*]] = sub i64 [[IV_0_INT]], [[IV_2_FR_INT]]
 ; CHECK-NEXT:    [[IV_0_NEXT]] = getelementptr i8, ptr [[IV_0]], i64 [[IDX]]
-; CHECK-NEXT:    br i1 [[COND_2]], label %[[EXIT:.*]], label %[[LOOP]]
+; CHECK-NEXT:    br i1 [[COND_1]], label %[[EXIT:.*]], label %[[LOOP]]
 ; CHECK:       [[EXIT]]:
 ; CHECK-NEXT:    ret void
 ;
@@ -1182,7 +1182,120 @@ loop.latch:
   %iv.0.int = ptrtoint ptr %iv.0 to i64
   %idx = sub i64 %iv.0.int, %iv.2.fr.int
   %iv.0.next = getelementptr i8, ptr %iv.0, i64 %idx
-  br i1 %cond.2, label %exit, label %loop
+  br i1 %cond.1, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+declare ptr @get_ptr()
+
+; When the phi isn't a simple recurrence and has multiple inputs from the same
+; predecessor, we need to be careful to avoid iterator invalidation. The phi
+; must have identical values for the predecessor and at no point should the
+; freeze be pushed to a single one of the uses, e.g.
+;
+;   %iv.2 = phi ptr [ %iv.0, %loop ], [ %iv.1.fr, %if.else ], [ %iv.1, %if.else ]
+;
+; We simply don't support this case, although it could be handled if there's a
+; use case.
+define void @fold_phi_non_simple_recurrence_multiple_forward_edges(ptr noundef %init, i1 %cond.0, i1 %cond.1) {
+; CHECK-LABEL: define void @fold_phi_non_simple_recurrence_multiple_forward_edges(
+; CHECK-SAME: ptr noundef [[INIT:%.*]], i1 [[COND_0:%.*]], i1 [[COND_1:%.*]]) {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV_0:%.*]] = phi ptr [ [[INIT]], %[[ENTRY]] ], [ [[IV_0_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
+; CHECK-NEXT:    br i1 [[COND_0]], label %[[LOOP_LATCH]], label %[[IF_ELSE:.*]]
+; CHECK:       [[IF_ELSE]]:
+; CHECK-NEXT:    [[IV_1:%.*]] = call ptr @get_ptr()
+; CHECK-NEXT:    br i1 false, label %[[LOOP_LATCH]], label %[[LOOP_LATCH]]
+; CHECK:       [[LOOP_LATCH]]:
+; CHECK-NEXT:    [[IV_2:%.*]] = phi ptr [ [[IV_0]], %[[LOOP]] ], [ [[IV_1]], %[[IF_ELSE]] ], [ [[IV_1]], %[[IF_ELSE]] ]
+; CHECK-NEXT:    [[IV_2_FR:%.*]] = freeze ptr [[IV_2]]
+; CHECK-NEXT:    [[IV_2_FR_INT:%.*]] = ptrtoint ptr [[IV_2_FR]] to i64
+; CHECK-NEXT:    [[IV_0_INT:%.*]] = ptrtoint ptr [[IV_0]] to i64
+; CHECK-NEXT:    [[IDX:%.*]] = sub i64 [[IV_0_INT]], [[IV_2_FR_INT]]
+; CHECK-NEXT:    [[IV_0_NEXT]] = getelementptr i8, ptr [[IV_0]], i64 [[IDX]]
+; CHECK-NEXT:    br i1 [[COND_1]], label %[[EXIT:.*]], label %[[LOOP]]
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv.0 = phi ptr [ %init, %entry ], [ %iv.0.next, %loop.latch ]
+  br i1 %cond.0, label %loop.latch, label %if.else
+
+if.else:
+  %iv.1 = call ptr @get_ptr()
+  br i1 %cond.0, label %loop.latch, label %loop.latch
+
+loop.latch:
+  %iv.2 = phi ptr [ %iv.0, %loop ], [ %iv.1, %if.else ], [ %iv.1, %if.else ]
+  %iv.2.fr = freeze ptr %iv.2
+  %iv.2.fr.int = ptrtoint ptr %iv.2.fr to i64
+  %iv.0.int = ptrtoint ptr %iv.0 to i64
+  %idx = sub i64 %iv.0.int, %iv.2.fr.int
+  %iv.0.next = getelementptr i8, ptr %iv.0, i64 %idx
+  br i1 %cond.1, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; When the phi input comes from an invoke, we need to be careful the freeze
+; isn't pushed after the invoke.
+define void @fold_phi_noundef_start_value_with_invoke(ptr noundef %init, i1 %cond.0, i1 %cond.1) personality ptr undef {
+; CHECK-LABEL: define void @fold_phi_noundef_start_value_with_invoke(
+; CHECK-SAME: ptr noundef [[INIT:%.*]], i1 [[COND_0:%.*]], i1 [[COND_1:%.*]]) personality ptr undef {
+; CHECK-NEXT:  [[ENTRY:.*]]:
+; CHECK-NEXT:    br label %[[LOOP:.*]]
+; CHECK:       [[LOOP]]:
+; CHECK-NEXT:    [[IV_0:%.*]] = phi ptr [ [[INIT]], %[[ENTRY]] ], [ [[IV_0_NEXT:%.*]], %[[LOOP_LATCH:.*]] ]
+; CHECK-NEXT:    br i1 [[COND_0]], label %[[LOOP_LATCH]], label %[[IF_ELSE:.*]]
+; CHECK:       [[IF_ELSE]]:
+; CHECK-NEXT:    [[IV_1:%.*]] = invoke ptr @get_ptr()
+; CHECK-NEXT:            to label %[[LOOP_LATCH]] unwind label %[[UNWIND:.*]]
+; CHECK:       [[LOOP_LATCH]]:
+; CHECK-NEXT:    [[IV_2:%.*]] = phi ptr [ [[IV_0]], %[[LOOP]] ], [ [[IV_1]], %[[IF_ELSE]] ]
+; CHECK-NEXT:    [[IV_2_FR:%.*]] = freeze ptr [[IV_2]]
+; CHECK-NEXT:    [[IV_2_FR_INT:%.*]] = ptrtoint ptr [[IV_2_FR]] to i64
+; CHECK-NEXT:    [[IV_0_INT:%.*]] = ptrtoint ptr [[IV_0]] to i64
+; CHECK-NEXT:    [[IDX:%.*]] = sub i64 [[IV_0_INT]], [[IV_2_FR_INT]]
+; CHECK-NEXT:    [[IV_0_NEXT]] = getelementptr i8, ptr [[IV_0]], i64 [[IDX]]
+; CHECK-NEXT:    br i1 [[COND_1]], label %[[EXIT:.*]], label %[[LOOP]]
+; CHECK:       [[UNWIND]]:
+; CHECK-NEXT:    [[TMP0:%.*]] = landingpad i8
+; CHECK-NEXT:            cleanup
+; CHECK-NEXT:    unreachable
+; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    ret void
+;
+entry:
+  br label %loop
+
+loop:
+  %iv.0 = phi ptr [ %init, %entry ], [ %iv.0.next, %loop.latch ]
+  br i1 %cond.0, label %loop.latch, label %if.else
+
+if.else:
+  %iv.1 = invoke ptr @get_ptr()
+  to label %loop.latch unwind label %unwind
+
+loop.latch:
+  %iv.2 = phi ptr [ %iv.0, %loop ], [ %iv.1, %if.else ]
+  %iv.2.fr = freeze ptr %iv.2
+  %iv.2.fr.int = ptrtoint ptr %iv.2.fr to i64
+  %iv.0.int = ptrtoint ptr %iv.0 to i64
+  %idx = sub i64 %iv.0.int, %iv.2.fr.int
+  %iv.0.next = getelementptr i8, ptr %iv.0, i64 %idx
+  br i1 %cond.1, label %exit, label %loop
+
+unwind:
+  landingpad i8 cleanup
+  unreachable
 
 exit:
   ret void


### PR DESCRIPTION
#157112 adds a test '@fold_phi_noundef_start_value' where we can't currently remove the freeze, even though it's possible. The two places in instcombine that deal with freezes are
'pushFreezeToPreventPoisonFromPropagating' and
'foldFreezeIntoRecurrence'.  The former doesn't support PHIs at all and the latter is restricted to recurrences. It doesn't consider this test a recurrence as the BB of the frozen PHI node '%loop.latch' does not dominate either of the BBs ('%loop', '%if.else') of the incoming values.

Therefore, I've updated 'pushFreezeToPreventPoisonFromPropagating' to support pushing the freeze to the incoming PHI values, as long as the BB of the frozen PHI *does not* dominate the BB of the incoming value(s). This fixes the test case added in #157112 and the other test changes look sensible, although perhaps I'm missing some edge cases (?).

The 'match(U.get(), m_Undef())' check for undef PHI incoming value looks necessary to catch the case covered by '@two_undef' test in freeze-phi.ll. Without this check the undef becomes zero which doesnt seem right.