### PR TITLE
[MLIR][Standalone] don't register everything

### DIFF
--- a/mlir/examples/standalone/python/CMakeLists.txt
+++ b/mlir/examples/standalone/python/CMakeLists.txt
@@ -29,6 +29,7 @@ declare_mlir_python_extension(StandalonePythonSources.Pybind11Extension
   EMBED_CAPI_LINK_LIBS
     StandaloneCAPI
     MLIRCAPITransforms
+    MLIRCAPIArith
   PYTHON_BINDINGS_LIBRARY pybind11
 )
 
@@ -40,6 +41,7 @@ declare_mlir_python_extension(StandalonePythonSources.NanobindExtension
   EMBED_CAPI_LINK_LIBS
     StandaloneCAPI
     MLIRCAPITransforms
+    MLIRCAPIArith
   PYTHON_BINDINGS_LIBRARY nanobind
   GENERATE_TYPE_STUBS
 )

--- a/mlir/examples/standalone/python/CMakeLists.txt
+++ b/mlir/examples/standalone/python/CMakeLists.txt
@@ -54,9 +54,6 @@ add_mlir_python_common_capi_library(StandalonePythonCAPI
   RELATIVE_INSTALL_ROOT "../../../.."
   DECLARED_SOURCES
     StandalonePythonSources
-    # TODO: Remove this in favor of showing fine grained registration once
-    # available.
-    MLIRPythonExtension.RegisterEverything
     MLIRPythonSources.Core
     MLIRPythonSources.Dialects.builtin
 )
@@ -70,9 +67,6 @@ add_mlir_python_modules(StandalonePythonModules
   INSTALL_PREFIX "${MLIR_BINDINGS_PYTHON_INSTALL_PREFIX}"
   DECLARED_SOURCES
     StandalonePythonSources
-    # TODO: Remove this in favor of showing fine grained registration once
-    # available.
-    MLIRPythonExtension.RegisterEverything
     MLIRPythonSources.Core
     MLIRPythonSources.Dialects.builtin
   COMMON_CAPI_LINK_LIBS

--- a/mlir/examples/standalone/python/CMakeLists.txt
+++ b/mlir/examples/standalone/python/CMakeLists.txt
@@ -28,6 +28,7 @@ declare_mlir_python_extension(StandalonePythonSources.Pybind11Extension
     StandaloneExtensionPybind11.cpp
   EMBED_CAPI_LINK_LIBS
     StandaloneCAPI
+    MLIRCAPITransforms
   PYTHON_BINDINGS_LIBRARY pybind11
 )
 
@@ -38,6 +39,7 @@ declare_mlir_python_extension(StandalonePythonSources.NanobindExtension
     StandaloneExtensionNanobind.cpp
   EMBED_CAPI_LINK_LIBS
     StandaloneCAPI
+    MLIRCAPITransforms
   PYTHON_BINDINGS_LIBRARY nanobind
   GENERATE_TYPE_STUBS
 )

--- a/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
@@ -27,7 +27,8 @@ NB_MODULE(_standaloneDialectsNanobind, m) {
       [](MlirContext context, bool load) {
         MlirDialectHandle standaloneHandle = mlirGetDialectHandle__standalone__();
         MlirDialectHandle arithHandle = mlirGetDialectHandle__arith__();
-        mlirDialectHandleRegisterDialect(handle, context);
+        mlirDialectHandleRegisterDialect(standaloneHandle, context);
+        mlirDialectHandleRegisterDialect(arithHandle, context);
         if (load) {
           mlirDialectHandleLoadDialect(handle, context);
         }

--- a/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
@@ -12,6 +12,7 @@
 #include "Standalone-c/Dialects.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
+#include "mlir-c/Dialect/Arith.h
 
 namespace nb = nanobind;
 
@@ -22,9 +23,10 @@ NB_MODULE(_standaloneDialectsNanobind, m) {
   auto standaloneM = m.def_submodule("standalone");
 
   standaloneM.def(
-      "register_dialect",
+      "register_dialects",
       [](MlirContext context, bool load) {
-        MlirDialectHandle handle = mlirGetDialectHandle__standalone__();
+        MlirDialectHandle standaloneHandle = mlirGetDialectHandle__standalone__();
+        MlirDialectHandle arithHandle = mlirGetDialectHandle__arith__();
         mlirDialectHandleRegisterDialect(handle, context);
         if (load) {
           mlirDialectHandleLoadDialect(handle, context);

--- a/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionNanobind.cpp
@@ -10,9 +10,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "Standalone-c/Dialects.h"
+#include "mlir-c/Dialect/Arith.h"
 #include "mlir/Bindings/Python/Nanobind.h"
 #include "mlir/Bindings/Python/NanobindAdaptors.h"
-#include "mlir-c/Dialect/Arith.h
 
 namespace nb = nanobind;
 
@@ -25,12 +25,14 @@ NB_MODULE(_standaloneDialectsNanobind, m) {
   standaloneM.def(
       "register_dialects",
       [](MlirContext context, bool load) {
-        MlirDialectHandle standaloneHandle = mlirGetDialectHandle__standalone__();
+        MlirDialectHandle standaloneHandle =
+            mlirGetDialectHandle__standalone__();
         MlirDialectHandle arithHandle = mlirGetDialectHandle__arith__();
         mlirDialectHandleRegisterDialect(standaloneHandle, context);
         mlirDialectHandleRegisterDialect(arithHandle, context);
         if (load) {
-          mlirDialectHandleLoadDialect(handle, context);
+          mlirDialectHandleLoadDialect(standaloneHandle, context);
+          mlirDialectHandleLoadDialect(arithHandle, context);
         }
       },
       nb::arg("context").none() = nb::none(), nb::arg("load") = true);

--- a/mlir/examples/standalone/python/StandaloneExtensionPybind11.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionPybind11.cpp
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Standalone-c/Dialects.h"
+#include "mlir-c/Dialect/Arith.h
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
 using namespace mlir::python::adaptors;
@@ -21,10 +22,12 @@ PYBIND11_MODULE(_standaloneDialectsPybind11, m) {
   auto standaloneM = m.def_submodule("standalone");
 
   standaloneM.def(
-      "register_dialect",
+      "register_dialects",
       [](MlirContext context, bool load) {
-        MlirDialectHandle handle = mlirGetDialectHandle__standalone__();
-        mlirDialectHandleRegisterDialect(handle, context);
+        MlirDialectHandle standaloneHandle = mlirGetDialectHandle__standalone__();
+        MlirDialectHandle arithHandle = mlirGetDialectHandle__arith__();
+        mlirDialectHandleRegisterDialect(standaloneHandle, context);
+        mlirDialectHandleRegisterDialect(arithHandle, context);
         if (load) {
           mlirDialectHandleLoadDialect(handle, context);
         }

--- a/mlir/examples/standalone/python/StandaloneExtensionPybind11.cpp
+++ b/mlir/examples/standalone/python/StandaloneExtensionPybind11.cpp
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Standalone-c/Dialects.h"
-#include "mlir-c/Dialect/Arith.h
+#include "mlir-c/Dialect/Arith.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
 using namespace mlir::python::adaptors;
@@ -24,12 +24,14 @@ PYBIND11_MODULE(_standaloneDialectsPybind11, m) {
   standaloneM.def(
       "register_dialects",
       [](MlirContext context, bool load) {
-        MlirDialectHandle standaloneHandle = mlirGetDialectHandle__standalone__();
+        MlirDialectHandle standaloneHandle =
+            mlirGetDialectHandle__standalone__();
         MlirDialectHandle arithHandle = mlirGetDialectHandle__arith__();
         mlirDialectHandleRegisterDialect(standaloneHandle, context);
         mlirDialectHandleRegisterDialect(arithHandle, context);
         if (load) {
-          mlirDialectHandleLoadDialect(handle, context);
+          mlirDialectHandleLoadDialect(standaloneHandle, context);
+          mlirDialectHandleLoadDialect(arithHandle, context);
         }
       },
       py::arg("context") = py::none(), py::arg("load") = true);

--- a/mlir/examples/standalone/test/python/smoketest.py
+++ b/mlir/examples/standalone/test/python/smoketest.py
@@ -14,7 +14,7 @@ else:
 
 
 with Context():
-    standalone_d.register_dialect()
+    standalone_d.register_dialects()
     module = Module.parse(
         """
     %0 = arith.constant 2 : i32


### PR DESCRIPTION
We only need to register `standalone` and `arith`.