### PR TITLE
[libc] Some compatibility update for building with MSVC.

### DIFF
--- a/libc/src/__support/CMakeLists.txt
+++ b/libc/src/__support/CMakeLists.txt
@@ -97,6 +97,7 @@ add_header_library(
     common.h
     endian_internal.h
     macros/properties/architectures.h
+    macros/properties/compiler.h
     macros/attributes.h
     macros/config.h
   DEPENDS

--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -171,6 +171,7 @@ add_header_library(
     libc.include.llvm-libc-macros.stdfix_macros
     libc.src.__support.macros.attributes
     libc.src.__support.macros.properties.types
+    libc.src.__support.macros.properties.compiler
     libc.src.__support.macros.properties.complex_types
 )
 

--- a/libc/src/__support/CPP/type_traits/is_complex.h
+++ b/libc/src/__support/CPP/type_traits/is_complex.h
@@ -13,12 +13,17 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 // LIBC_TYPES_HAS_CFLOAT16 && LIBC_TYPES_HAS_CFLOAT128
+#include "src/__support/macros/properties/compiler.h"
 #include "src/__support/macros/properties/complex_types.h"
 
 namespace LIBC_NAMESPACE_DECL {
 namespace cpp {
 
 // is_complex
+#ifdef LIBC_COMPILER_IS_MSVC
+// TODO: Add support for complex types with MSVC.
+template <typename T> struct is_complex : false_type {};
+#else
 template <typename T> struct is_complex {
 private:
   template <typename Head, typename... Args>
@@ -40,6 +45,8 @@ public:
 #endif
                               >();
 };
+#endif // LIBC_COMPILER_IS_MSVC
+
 template <typename T>
 LIBC_INLINE_VAR constexpr bool is_complex_v = is_complex<T>::value;
 template <typename T1, typename T2>

--- a/libc/src/__support/common.h
+++ b/libc/src/__support/common.h
@@ -16,6 +16,7 @@
 #include "src/__support/macros/attributes.h"
 #include "src/__support/macros/config.h"
 #include "src/__support/macros/properties/architectures.h"
+#include "src/__support/macros/properties/compiler.h"
 
 #ifndef LLVM_LIBC_FUNCTION_ATTR
 #define LLVM_LIBC_FUNCTION_ATTR
@@ -41,12 +42,12 @@
 // to cleanly export and alias the C++ symbol `LIBC_NAMESPACE::func` with the C
 // symbol `func`.  So for public packaging on MacOS, we will only export the C
 // symbol.  Moreover, a C symbol `func` in macOS is mangled as `_func`.
-#if defined(LIBC_COPT_PUBLIC_PACKAGING)
+#if defined(LIBC_COPT_PUBLIC_PACKAGING) && !defined(LIBC_COMPILER_IS_MSVC)
 #ifndef __APPLE__
 #define LLVM_LIBC_FUNCTION_IMPL(type, name, arglist)                           \
   LLVM_LIBC_ATTR(name)                                                         \
   LLVM_LIBC_FUNCTION_ATTR decltype(LIBC_NAMESPACE::name)                       \
-      __##name##_impl__ __asm__(#name);                                        \
+      __##name##_impl__ asm(#name);                                            \
   decltype(LIBC_NAMESPACE::name) name [[gnu::alias(#name)]];                   \
   type __##name##_impl__ arglist
 #else // __APPLE__

--- a/libc/src/__support/macros/optimization.h
+++ b/libc/src/__support/macros/optimization.h
@@ -34,6 +34,9 @@ LIBC_INLINE constexpr bool expects_bool_condition(T value, T expected) {
 #elif defined(LIBC_COMPILER_IS_GCC)
 #define LIBC_LOOP_NOUNROLL _Pragma("GCC unroll 0")
 #define LIBC_LOOP_UNROLL _Pragma("GCC unroll 2048")
+#elif defined(LIBC_COMPILER_IS_MSVC)
+#define LIBC_LOOP_NOUNROLL
+#define LIBC_LOOP_UNROLL
 #else
 #error "Unhandled compiler"
 #endif

--- a/libc/src/__support/macros/properties/compiler.h
+++ b/libc/src/__support/macros/properties/compiler.h
@@ -34,10 +34,10 @@
 #define LIBC_COMPILER_GCC_VER (__GNUC__ * 100 + __GNUC_MINOR__)
 #endif
 
-#if defined(_MSC_VER)
-#define LIBC_COMPILER_IS_MSC
+#if defined(_MSC_VER) && !defined(__clang__)
+#define LIBC_COMPILER_IS_MSVC
 // https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
-#define LIBC_COMPILER_MSC_VER (_MSC_VER)
+#define LIBC_COMPILER_MSVC_VER (_MSC_VER)
 #endif
 
 #endif // LLVM_LIBC_SRC___SUPPORT_MACROS_PROPERTIES_COMPILER_H


### PR DESCRIPTION
Add compiler identity macro and disable some unsupported features.