### PR TITLE
[DebugInfo] When merging locations prefer unannotated empty locs

### DIFF
--- a/llvm/lib/IR/DebugLoc.cpp
+++ b/llvm/lib/IR/DebugLoc.cpp
@@ -181,10 +181,19 @@ DebugLoc DebugLoc::getMergedLocations(ArrayRef<DebugLoc> Locs) {
   return Merged;
 }
 DebugLoc DebugLoc::getMergedLocation(DebugLoc LocA, DebugLoc LocB) {
-  if (!LocA)
-    return LocA;
-  if (!LocB)
+  if (!LocA || !LocB) {
+    // If coverage tracking is enabled, prioritize returning empty non-annotated
+    // locations to empty annotated locations.
+#if LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
+    if (!LocA && LocA.getKind() == DebugLocKind::Normal)
+      return LocA;
+    if (!LocB && LocB.getKind() == DebugLocKind::Normal)
+      return LocB;
+#endif // LLVM_ENABLE_DEBUGLOC_TRACKING_COVERAGE
+    if (!LocA)
+      return LocA;
     return LocB;
+  }
   return DILocation::getMergedLocation(LocA, LocB);
 }
 


### PR DESCRIPTION
When merging DILocations, we prefer to use DebugLoc::getMergedLocation when possible to better preserve DebugLoc coverage tracking information through transformations (as conversion to DILocations drops all coverage tracking data). Currently, DebugLoc::getMergedLocation checks to see if either DebugLoc is empty and returns it directly if so, to propagate that DebugLoc's coverage tracking data to the merged location; however, it only checks whether either location is valid, not whether they are annotated.

This is significant because an annotated location is not a bug, while an empty unannotated location may be one; therefore, we check to see if either location is unannotated, and prefer to return that location if it exists rather than an annotated one.

This change is NFC outside of DebugLoc coverage tracking builds.