### PR TITLE
[libc++] Don't mark lgamma_r as noexcept on Fuchsia

### DIFF
--- a/libcxx/include/__random/binomial_distribution.h
+++ b/libcxx/include/__random/binomial_distribution.h
@@ -104,7 +104,7 @@ public:
 #  else
 #    define _LIBCPP_LGAMMA_R_NOEXCEPT
 #  endif
-#elif defined(__LLVM_LIBC__)
+#elif defined(__LLVM_LIBC__) && !defined(__Fuchsia__)
 #  define _LIBCPP_LGAMMA_R_NOEXCEPT _NOEXCEPT
 #else
 #  define _LIBCPP_LGAMMA_R_NOEXCEPT


### PR DESCRIPTION
Building on Fuchsia is broken after #156547.
This disables the NOEXCEPT on Fuchsia to unbreak things. Hopefully we can come up with a more forward-compatible fix later.