### PR TITLE
[Support][modulemap] Fix LLVM_Support modulemap broken in #113364

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -406,7 +406,7 @@ module LLVM_Utils {
     exclude header "llvm/Support/PluginLoader.h"
     exclude header "llvm/Support/Solaris/sys/regset.h"
     textual header "llvm/Support/TargetOpcodes.def"
-
+    textual header "llvm/Support/VirtualOutputConfig.def"
   }
 
   module TargetParser {


### PR DESCRIPTION
Add VirtualOutputConfig.def to textual header.
