### PR TITLE
[DebugInfo][Mem2Reg] Assign uninitialized values with annotated locs

### DIFF
--- a/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
+++ b/llvm/lib/Transforms/Utils/PromoteMemoryToRegister.cpp
@@ -849,9 +849,12 @@ void PromoteMem2Reg::run() {
   for (unsigned i = 0, e = Allocas.size(); i != e; ++i)
     IncomingVals.init(i, UndefValue::get(Allocas[i]->getAllocatedType()));
 
-  // When handling debug info, treat all incoming values as if they have unknown
-  // locations until proven otherwise.
+  // When handling debug info, treat all incoming values as if they have
+  // compiler-generated (empty) locations, representing the uninitialized
+  // alloca, until proven otherwise.
   IncomingLocs.resize(Allocas.size());
+  for (unsigned i = 0, e = Allocas.size(); i != e; ++i)
+    IncomingLocs.init(i, DebugLoc::getCompilerGenerated());
 
   // The renamer uses the Visited set to avoid infinite loops.
   Visited.resize(F.getMaxBlockNumber(), false);


### PR DESCRIPTION
In PromoteMem2Reg, we perform a DFS over the CFG and track, for each alloca, its incoming value and its associated incoming DebugLoc, both of which are taken from stores to that alloca; these values and DebugLocs are propagated to PHI nodes when new blocks are reached. In the event that for one incoming edge no store instruction has been seen, we propagate an UndefValue and an empty DebugLoc to the PHI.

This is a perfectly valid occurrence, and assigning an empty DebugLoc to the PHI is the correct course of action; therefore, we should pass an annotated DebugLoc instead, so that in DebugLoc coverage tracking we correctly do not expect a valid DebugLoc to be present; we generally mark allocas as having CompilerGenerated locations, so I've chosen to use the same annotation to represent the uninitialized value of that alloca.

This change is NFC outside of DebugLoc coverage tracking builds.