### PR TITLE
[InstCombine] Add optimization to combine adds through zext nneg, and add testcase

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1910,6 +1910,23 @@ Instruction *InstCombinerImpl::visitAdd(BinaryOperator &I) {
   if (Instruction *Res = foldBinOpOfSelectAndCastOfSelectCondition(I))
     return Res;
 
+  // Combine adds through zext nneg:
+  // (zext nneg (X + C1)) + C2 --> zext X if C1 + C2 == 0
+  {
+    Value *X;
+    const APInt *C1, *C2;
+    if (match(&I, m_c_Add(m_NNegZExt(m_Add(m_Value(X), m_APInt(C1))),
+                          m_APInt(C2)))) {
+      // Check if the constants cancel out (C1 + C2 == 0)
+      APInt Sum = C1->sext(C2->getBitWidth()) + *C2;
+      if (Sum.isZero()) {
+        // The add inside the zext and the outer add cancel out
+        Value *NewZExt = Builder.CreateZExt(X, I.getType());
+        return replaceInstUsesWith(I, NewZExt);
+      }
+    }
+  }
+
   // Re-enqueue users of the induction variable of add recurrence if we infer
   // new nuw/nsw flags.
   if (Changed) {

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -976,3 +976,14 @@ entry:
   %res = zext nneg i2 %x to i32
   ret i32 %res
 }
+
+define i32 @zext_nneg_add_cancel(i8 %arg) {
+; CHECK-LABEL: @zext_nneg_add_cancel(
+; CHECK-NEXT:    [[ADD2:%.*]] = zext i8 [[ARG:%.*]] to i32
+; CHECK-NEXT:    ret i32 [[ADD2]]
+;
+  %add = add i8 %arg, -2
+  %zext = zext nneg i8 %add to i32
+  %add2 = add i32 %zext, 2
+  ret i32 %add2
+}

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -987,3 +987,28 @@ define i32 @zext_nneg_add_cancel(i8 %arg) {
   %add2 = add i32 %zext, 2
   ret i32 %add2
 }
+
+define i32 @zext_nneg_no_cancel(i8 %arg) {
+; CHECK-LABEL: @zext_nneg_no_cancel(
+; CHECK-NEXT:    [[TMP1:%.*]] = add i8 [[ARG:%.*]], -1
+; CHECK-NEXT:    [[ADD2:%.*]] = zext i8 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[ADD2]]
+;
+  %add = add i8 %arg, -2
+  %zext = zext nneg i8 %add to i32
+  %add2 = add i32 %zext, 1
+  ret i32 %add2
+}
+
+define i32 @zext_nneg_overflow(i8 %arg) {
+; CHECK-LABEL: @zext_nneg_overflow(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[ARG:%.*]], -2
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext nneg i8 [[ADD]] to i32
+; CHECK-NEXT:    [[ADD2:%.*]] = add nuw nsw i32 [[ZEXT]], 299
+; CHECK-NEXT:    ret i32 [[ADD2]]
+;
+  %add = add i8 %arg, -2
+  %zext = zext nneg i8 %add to i32
+  %add2 = add i32 %zext, 299
+  ret i32 %add2
+}

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -988,6 +988,21 @@ define i32 @zext_nneg_add_cancel(i8 %arg) {
   ret i32 %add2
 }
 
+define i32 @zext_nneg_add_cancel_multi_use(i8 %arg) {
+; CHECK-LABEL: @zext_nneg_add_cancel_multi_use(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[ARG:%.*]], -2
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext nneg i8 [[ADD]] to i32
+; CHECK-NEXT:    call void @use32(i32 [[ZEXT]])
+; CHECK-NEXT:    [[ADD2:%.*]] = zext i8 [[ARG]] to i32
+; CHECK-NEXT:    ret i32 [[ADD2]]
+;
+  %add = add i8 %arg, -2
+  %zext = zext nneg i8 %add to i32
+  call void @use32(i32 %zext)
+  %add2 = add i32 %zext, 2
+  ret i32 %add2
+}
+
 define i32 @zext_nneg_no_cancel(i8 %arg) {
 ; CHECK-LABEL: @zext_nneg_no_cancel(
 ; CHECK-NEXT:    [[TMP1:%.*]] = add i8 [[ARG:%.*]], -1
@@ -996,6 +1011,22 @@ define i32 @zext_nneg_no_cancel(i8 %arg) {
 ;
   %add = add i8 %arg, -2
   %zext = zext nneg i8 %add to i32
+  %add2 = add i32 %zext, 1
+  ret i32 %add2
+}
+
+define i32 @zext_nneg_no_cancel_multi_use(i8 %arg) {
+; CHECK-LABEL: @zext_nneg_no_cancel_multi_use(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[ARG:%.*]], -2
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext nneg i8 [[ADD]] to i32
+; CHECK-NEXT:    call void @use32(i32 [[ZEXT]])
+; CHECK-NEXT:    [[TMP1:%.*]] = add i8 [[ARG]], -1
+; CHECK-NEXT:    [[ADD2:%.*]] = zext i8 [[TMP1]] to i32
+; CHECK-NEXT:    ret i32 [[ADD2]]
+;
+  %add = add i8 %arg, -2
+  %zext = zext nneg i8 %add to i32
+  call void @use32(i32 %zext)
   %add2 = add i32 %zext, 1
   ret i32 %add2
 }
@@ -1009,6 +1040,21 @@ define i32 @zext_nneg_overflow(i8 %arg) {
 ;
   %add = add i8 %arg, -2
   %zext = zext nneg i8 %add to i32
+  %add2 = add i32 %zext, 299
+  ret i32 %add2
+}
+
+define i32 @zext_nneg_overflow_multi_use(i8 %arg) {
+; CHECK-LABEL: @zext_nneg_overflow_multi_use(
+; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[ARG:%.*]], -2
+; CHECK-NEXT:    [[ZEXT:%.*]] = zext nneg i8 [[ADD]] to i32
+; CHECK-NEXT:    call void @use32(i32 [[ZEXT]])
+; CHECK-NEXT:    [[ADD2:%.*]] = add nuw nsw i32 [[ZEXT]], 299
+; CHECK-NEXT:    ret i32 [[ADD2]]
+;
+  %add = add i8 %arg, -2
+  %zext = zext nneg i8 %add to i32
+  call void @use32(i32 %zext)
   %add2 = add i32 %zext, 299
   ret i32 %add2
 }

--- a/llvm/test/Transforms/InstCombine/zext.ll
+++ b/llvm/test/Transforms/InstCombine/zext.ll
@@ -1020,8 +1020,7 @@ define i32 @zext_nneg_no_cancel_multi_use(i8 %arg) {
 ; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[ARG:%.*]], -2
 ; CHECK-NEXT:    [[ZEXT:%.*]] = zext nneg i8 [[ADD]] to i32
 ; CHECK-NEXT:    call void @use32(i32 [[ZEXT]])
-; CHECK-NEXT:    [[TMP1:%.*]] = add i8 [[ARG]], -1
-; CHECK-NEXT:    [[ADD2:%.*]] = zext i8 [[TMP1]] to i32
+; CHECK-NEXT:    [[ADD2:%.*]] = add nuw nsw i32 [[ZEXT]], 1
 ; CHECK-NEXT:    ret i32 [[ADD2]]
 ;
   %add = add i8 %arg, -2
@@ -1044,17 +1043,3 @@ define i32 @zext_nneg_overflow(i8 %arg) {
   ret i32 %add2
 }
 
-define i32 @zext_nneg_overflow_multi_use(i8 %arg) {
-; CHECK-LABEL: @zext_nneg_overflow_multi_use(
-; CHECK-NEXT:    [[ADD:%.*]] = add i8 [[ARG:%.*]], -2
-; CHECK-NEXT:    [[ZEXT:%.*]] = zext nneg i8 [[ADD]] to i32
-; CHECK-NEXT:    call void @use32(i32 [[ZEXT]])
-; CHECK-NEXT:    [[ADD2:%.*]] = add nuw nsw i32 [[ZEXT]], 299
-; CHECK-NEXT:    ret i32 [[ADD2]]
-;
-  %add = add i8 %arg, -2
-  %zext = zext nneg i8 %add to i32
-  call void @use32(i32 %zext)
-  %add2 = add i32 %zext, 299
-  ret i32 %add2
-}


### PR DESCRIPTION
This adds the optimizations to combine adds through zext nneg when adds cancel. 

Updated proof: https://alive2.llvm.org/ce/z/T2BmZj
This fixes #157111 