### PR TITLE
[clang-tools-extra][test] Ensure file is writeable after copying

### DIFF
--- a/clang-tools-extra/test/clang-apply-replacements/crlf.cpp
+++ b/clang-tools-extra/test/clang-apply-replacements/crlf.cpp
@@ -1,5 +1,6 @@
 // RUN: mkdir -p %t.dir/Inputs/crlf
 // RUN: cp %S/Inputs/crlf/crlf.cpp %t.dir/Inputs/crlf/crlf.cpp
+// RUN: chmod u+w %t.dir/Inputs/crlf/crlf.cpp
 // RUN: sed "s#\$(path)#%/t.dir/Inputs/crlf#" %S/Inputs/crlf/file1.yaml > %t.dir/Inputs/crlf/file1.yaml
 // RUN: clang-apply-replacements %t.dir/Inputs/crlf
 // RUN: diff %t.dir/Inputs/crlf/crlf.cpp %S/Inputs/crlf/crlf.cpp.expected


### PR DESCRIPTION
After #157572, the invocation to clang-tidy fails w/ `Could not open <...>/crlf.cpp.tmp.dir/Inputs/crlf/crlf.cpp for writing` if run in an environment where the source tree is mounted read-only. This is because `cat` was creating a new file in a writeable dir, but running `cp` preserves the readonly file permissions from the source tree.