### PR TITLE
[clang-tidy] Rename 'cert-dcl50-cpp' to 'modernize-avoid-variadic-functions'

### DIFF
--- a/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/cert/CERTTidyModule.cpp
@@ -27,6 +27,7 @@
 #include "../misc/NonCopyableObjects.h"
 #include "../misc/StaticAssertCheck.h"
 #include "../misc/ThrowByValueCatchByReferenceCheck.h"
+#include "../modernize/AvoidVariadicFunctionsCheck.h"
 #include "../performance/MoveConstructorInitCheck.h"
 #include "../readability/EnumInitialValueCheck.h"
 #include "../readability/UppercaseLiteralSuffixCheck.h"
@@ -41,7 +42,6 @@
 #include "SetLongJmpCheck.h"
 #include "StaticObjectExceptionCheck.h"
 #include "ThrownExceptionTypeCheck.h"
-#include "VariadicFunctionDefCheck.h"
 
 namespace {
 
@@ -245,7 +245,8 @@ public:
         .registerCheck<bugprone::PointerArithmeticOnPolymorphicObjectCheck>(
             "cert-ctr56-cpp");
     // DCL
-    CheckFactories.registerCheck<VariadicFunctionDefCheck>("cert-dcl50-cpp");
+    CheckFactories.registerCheck<modernize::AvoidVariadicFunctionsCheck>(
+        "cert-dcl50-cpp");
     CheckFactories.registerCheck<bugprone::ReservedIdentifierCheck>(
         "cert-dcl51-cpp");
     CheckFactories.registerCheck<misc::NewDeleteOverloadsCheck>(

--- a/clang-tools-extra/clang-tidy/cert/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/cert/CMakeLists.txt
@@ -16,7 +16,6 @@ add_clang_library(clangTidyCERTModule STATIC
   SetLongJmpCheck.cpp
   StaticObjectExceptionCheck.cpp
   ThrownExceptionTypeCheck.cpp
-  VariadicFunctionDefCheck.cpp
 
   LINK_LIBS
   clangTidy
@@ -24,6 +23,7 @@ add_clang_library(clangTidyCERTModule STATIC
   clangTidyConcurrencyModule
   clangTidyGoogleModule
   clangTidyMiscModule
+  clangTidyModernizeModule
   clangTidyPerformanceModule
   clangTidyReadabilityModule
   clangTidyUtils

--- a/clang-tools-extra/clang-tidy/modernize/AvoidVariadicFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/AvoidVariadicFunctionsCheck.cpp
@@ -6,14 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "VariadicFunctionDefCheck.h"
+#include "AvoidVariadicFunctionsCheck.h"
 #include "clang/ASTMatchers/ASTMatchFinder.h"
 
 using namespace clang::ast_matchers;
 
-namespace clang::tidy::cert {
+namespace clang::tidy::modernize {
 
-void VariadicFunctionDefCheck::registerMatchers(MatchFinder *Finder) {
+void AvoidVariadicFunctionsCheck::registerMatchers(MatchFinder *Finder) {
   // We only care about function *definitions* that are variadic, and do not
   // have extern "C" language linkage.
   Finder->addMatcher(
@@ -22,7 +22,8 @@ void VariadicFunctionDefCheck::registerMatchers(MatchFinder *Finder) {
       this);
 }
 
-void VariadicFunctionDefCheck::check(const MatchFinder::MatchResult &Result) {
+void AvoidVariadicFunctionsCheck::check(
+    const MatchFinder::MatchResult &Result) {
   const auto *FD = Result.Nodes.getNodeAs<FunctionDecl>("func");
 
   diag(FD->getLocation(),
@@ -30,4 +31,4 @@ void VariadicFunctionDefCheck::check(const MatchFinder::MatchResult &Result) {
        "parameter pack or currying instead");
 }
 
-} // namespace clang::tidy::cert
+} // namespace clang::tidy::modernize

--- a/clang-tools-extra/clang-tidy/modernize/AvoidVariadicFunctionsCheck.h
+++ b/clang-tools-extra/clang-tidy/modernize/AvoidVariadicFunctionsCheck.h
@@ -6,20 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CERT_VARIADICFUNCTIONDEF_H
-#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CERT_VARIADICFUNCTIONDEF_H
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_AVOIDVARIADICFUNCTIONSCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_AVOIDVARIADICFUNCTIONSCHECK_H
 
 #include "../ClangTidyCheck.h"
 
-namespace clang::tidy::cert {
+namespace clang::tidy::modernize {
 
-/// Guards against any C-style variadic function definitions (not declarations).
+/// Find all function definitions of C-style variadic functions.
 ///
 /// For the user-facing documentation see:
-/// http://clang.llvm.org/extra/clang-tidy/checks/cert/dcl50-cpp.html
-class VariadicFunctionDefCheck : public ClangTidyCheck {
+/// http://clang.llvm.org/extra/clang-tidy/checks/modernize/avoid-variadic-functions.html
+class AvoidVariadicFunctionsCheck : public ClangTidyCheck {
 public:
-  VariadicFunctionDefCheck(StringRef Name, ClangTidyContext *Context)
+  AvoidVariadicFunctionsCheck(StringRef Name, ClangTidyContext *Context)
       : ClangTidyCheck(Name, Context) {}
   bool isLanguageVersionSupported(const LangOptions &LangOpts) const override {
     return LangOpts.CPlusPlus;
@@ -28,6 +28,6 @@ public:
   void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
 };
 
-} // namespace clang::tidy::cert
+} // namespace clang::tidy::modernize
 
-#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_CERT_VARIADICFUNCTIONDEF_H
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MODERNIZE_AVOIDVARIADICFUNCTIONSCHECK_H

--- a/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/modernize/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
 add_clang_library(clangTidyModernizeModule STATIC
   AvoidBindCheck.cpp
   AvoidCArraysCheck.cpp
+  AvoidVariadicFunctionsCheck.cpp
   ConcatNestedNamespacesCheck.cpp
   DeprecatedHeadersCheck.cpp
   DeprecatedIosBaseAliasesCheck.cpp

--- a/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ModernizeTidyModule.cpp
@@ -11,6 +11,7 @@
 #include "../ClangTidyModuleRegistry.h"
 #include "AvoidBindCheck.h"
 #include "AvoidCArraysCheck.h"
+#include "AvoidVariadicFunctionsCheck.h"
 #include "ConcatNestedNamespacesCheck.h"
 #include "DeprecatedHeadersCheck.h"
 #include "DeprecatedIosBaseAliasesCheck.h"
@@ -63,6 +64,8 @@ public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
     CheckFactories.registerCheck<AvoidBindCheck>("modernize-avoid-bind");
     CheckFactories.registerCheck<AvoidCArraysCheck>("modernize-avoid-c-arrays");
+    CheckFactories.registerCheck<AvoidVariadicFunctionsCheck>(
+        "modernize-avoid-variadic-functions");
     CheckFactories.registerCheck<ConcatNestedNamespacesCheck>(
         "modernize-concat-nested-namespaces");
     CheckFactories.registerCheck<DeprecatedHeadersCheck>(

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -206,6 +206,11 @@ New checks
 New check aliases
 ^^^^^^^^^^^^^^^^^
 
+- Renamed :doc:`cert-dcl50-cpp <clang-tidy/checks/cert/dcl50-cpp>` to
+  :doc:`modernize-avoid-variadic-functions
+  <clang-tidy/checks/modernize/avoid-variadic-functions>`
+  keeping initial check as an alias to the new one.
+
 - Renamed :doc:`cert-err34-c <clang-tidy/checks/cert/err34-c>` to
   :doc:`bugprone-unchecked-string-to-number-conversion
   <clang-tidy/checks/bugprone/unchecked-string-to-number-conversion>`

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
@@ -1,11 +1,10 @@
 .. title:: clang-tidy - cert-dcl50-cpp
+.. meta::
+   :http-equiv=refresh: 5;URL=../modernize/avoid-variadic-functions.html
 
 cert-dcl50-cpp
 ==============
 
-This check flags all function definitions (but not declarations) of C-style
-variadic functions.
-
-This check corresponds to the CERT C++ Coding Standard rule
-`DCL50-CPP. Do not define a C-style variadic function
-<https://www.securecoding.cert.org/confluence/display/cplusplus/DCL50-CPP.+Do+not+define+a+C-style+variadic+function>`_.
+The cert-dcl50-cpp check is an alias, please see
+`modernize-avoid-variadic-functions <../modernize/avoid-variadic-functions.html>`_
+for more information.

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
@@ -5,7 +5,7 @@
 cert-dcl50-cpp
 ==============
 
-The cert-dcl50-cpp check is an alias, please see
+The `cert-dcl50-cpp` check is an alias, please see
 `modernize-avoid-variadic-functions <../modernize/avoid-variadic-functions.html>`_
 for more information.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/cert/dcl50-cpp.rst
@@ -8,3 +8,7 @@ cert-dcl50-cpp
 The cert-dcl50-cpp check is an alias, please see
 `modernize-avoid-variadic-functions <../modernize/avoid-variadic-functions.html>`_
 for more information.
+
+This check corresponds to the CERT C++ Coding Standard rule
+`DCL50-CPP. Do not define a C-style variadic function
+<https://www.securecoding.cert.org/confluence/display/cplusplus/DCL50-CPP.+Do+not+define+a+C-style+variadic+function>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -171,7 +171,6 @@ Clang-Tidy Checks
    :doc:`bugprone-unused-return-value <bugprone/unused-return-value>`,
    :doc:`bugprone-use-after-move <bugprone/use-after-move>`,
    :doc:`bugprone-virtual-near-miss <bugprone/virtual-near-miss>`, "Yes"
-   :doc:`cert-dcl50-cpp <cert/dcl50-cpp>`,
    :doc:`cert-dcl58-cpp <cert/dcl58-cpp>`,
    :doc:`cert-env33-c <cert/env33-c>`,
    :doc:`cert-err33-c <cert/err33-c>`,
@@ -288,6 +287,7 @@ Clang-Tidy Checks
    :doc:`misc-use-internal-linkage <misc/use-internal-linkage>`, "Yes"
    :doc:`modernize-avoid-bind <modernize/avoid-bind>`, "Yes"
    :doc:`modernize-avoid-c-arrays <modernize/avoid-c-arrays>`,
+   :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,
    :doc:`modernize-concat-nested-namespaces <modernize/concat-nested-namespaces>`, "Yes"
    :doc:`modernize-deprecated-headers <modernize/deprecated-headers>`, "Yes"
    :doc:`modernize-deprecated-ios-base-aliases <modernize/deprecated-ios-base-aliases>`, "Yes"
@@ -435,6 +435,7 @@ Check aliases
    :doc:`cert-dcl03-c <cert/dcl03-c>`, :doc:`misc-static-assert <misc/static-assert>`, "Yes"
    :doc:`cert-dcl16-c <cert/dcl16-c>`, :doc:`readability-uppercase-literal-suffix <readability/uppercase-literal-suffix>`, "Yes"
    :doc:`cert-dcl37-c <cert/dcl37-c>`, :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
+   :doc:`cert-dcl50-cpp <cert/dcl50-cpp>`, :doc:`modernize-avoid-variadic-functions <modernize/avoid-variadic-functions>`,
    :doc:`cert-dcl51-cpp <cert/dcl51-cpp>`, :doc:`bugprone-reserved-identifier <bugprone/reserved-identifier>`, "Yes"
    :doc:`cert-dcl54-cpp <cert/dcl54-cpp>`, :doc:`misc-new-delete-overloads <misc/new-delete-overloads>`,
    :doc:`cert-dcl59-cpp <cert/dcl59-cpp>`, :doc:`google-build-namespaces <google/build-namespaces>`,

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.rst
@@ -1,0 +1,17 @@
+.. title:: clang-tidy - modernize-avoid-variadic-functions
+
+modernize-avoid-variadic-functions
+==================================
+
+Find all function definitions (but not declarations) of C-style variadic
+functions.
+
+Instead of C-style variadic functions, C++ function parameter pack or currying
+should be used.
+
+References
+----------
+
+This check corresponds to the CERT C++ Coding Standard rule
+`DCL50-CPP. Do not define a C-style variadic function
+<https://www.securecoding.cert.org/confluence/display/cplusplus/DCL50-CPP.+Do+not+define+a+C-style+variadic+function>`_.

--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/avoid-variadic-functions.rst
@@ -6,8 +6,9 @@ modernize-avoid-variadic-functions
 Find all function definitions (but not declarations) of C-style variadic
 functions.
 
-Instead of C-style variadic functions, C++ function parameter pack or currying
-should be used.
+Instead of C-style variadic functions, C++ function parameter pack should be
+used.
+
 
 References
 ----------

--- a/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-variadic-functions.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/modernize/avoid-variadic-functions.cpp
@@ -1,8 +1,8 @@
-// RUN: %check_clang_tidy %s cert-dcl50-cpp %t
+// RUN: %check_clang_tidy %s modernize-avoid-variadic-functions %t
 
 // Variadic function definitions are diagnosed.
 void f1(int, ...) {}
-// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: do not define a C-style variadic function; consider using a function parameter pack or currying instead [cert-dcl50-cpp]
+// CHECK-MESSAGES: :[[@LINE-1]]:6: warning: do not define a C-style variadic function; consider using a function parameter pack or currying instead [modernize-avoid-variadic-functions]
 
 // Variadic function *declarations* are not diagnosed.
 void f2(int, ...); // ok


### PR DESCRIPTION
Chose `modernize` section because we already have `modernize-avoid-bind`, `modernize-avoid-c-arrays` and this check sound modernize-ish (but next place it could go is `misc` I guess).

Closes https://github.com/llvm/llvm-project/issues/157301.