### PR TITLE
[libc] Add simple 'tuple' type to CPP helpers

### DIFF
--- a/libc/src/__support/CPP/CMakeLists.txt
+++ b/libc/src/__support/CPP/CMakeLists.txt
@@ -212,6 +212,14 @@ add_object_library(
 )
 
 add_header_library(
+  tuple
+  HDRS
+    tuple.h
+  DEPENDS
+    .utility
+)
+
+add_header_library(
   simd
   HDRS
     simd.h

--- a/libc/src/__support/CPP/tuple.h
+++ b/libc/src/__support/CPP/tuple.h
@@ -1,0 +1,144 @@
+//===-- tuple utility -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIBC_SRC___SUPPORT_CPP_UTILITY_TUPLE_H
+#define LLVM_LIBC_SRC___SUPPORT_CPP_UTILITY_TUPLE_H
+
+#include "src/__support/CPP/type_traits/decay.h"
+#include "src/__support/CPP/utility/integer_sequence.h"
+
+namespace LIBC_NAMESPACE_DECL {
+namespace cpp {
+
+template <typename... Ts> struct tuple;
+template <> struct tuple<> {};
+
+template <typename Head, typename... Tail>
+struct tuple<Head, Tail...> : tuple<Tail...> {
+  Head head;
+
+  LIBC_INLINE constexpr tuple() = default;
+
+  template <typename OHead, typename... OTail>
+  LIBC_INLINE constexpr tuple &operator=(const tuple<OHead, OTail...> &other) {
+    head = other.get_head();
+    this->get_tail() = other.get_tail();
+    return *this;
+  }
+
+  LIBC_INLINE constexpr tuple(const Head &h, const Tail &...t)
+      : tuple<Tail...>(t...), head(h) {}
+
+  LIBC_INLINE constexpr Head &get_head() { return head; }
+  LIBC_INLINE constexpr const Head &get_head() const { return head; }
+
+  LIBC_INLINE constexpr tuple<Tail...> &get_tail() { return *this; }
+  LIBC_INLINE constexpr const tuple<Tail...> &get_tail() const { return *this; }
+};
+
+template <typename... Ts> LIBC_INLINE constexpr auto make_tuple(Ts &&...args) {
+  return tuple<cpp::decay_t<Ts>...>(static_cast<Ts &&>(args)...);
+}
+template <typename... Ts> LIBC_INLINE constexpr auto tie(Ts &...args) {
+  return tuple<Ts &...>(args...);
+}
+
+template <size_t I, typename Head, typename... Tail>
+LIBC_INLINE constexpr auto &get(tuple<Head, Tail...> &t) {
+  if constexpr (I == 0)
+    return t.get_head();
+  else
+    return get<I - 1>(t.get_tail());
+}
+template <size_t I, typename Head, typename... Tail>
+LIBC_INLINE constexpr const auto &get(const tuple<Head, Tail...> &t) {
+  if constexpr (I == 0)
+    return t.get_head();
+  else
+    return get<I - 1>(t.get_tail());
+}
+template <size_t I, typename Head, typename... Tail>
+LIBC_INLINE constexpr auto &&get(tuple<Head, Tail...> &&t) {
+  if constexpr (I == 0)
+    return static_cast<Head &&>(t.get_head());
+  else
+    return get<I - 1>(static_cast<tuple<Tail...> &&>(t.get_tail()));
+}
+template <size_t I, typename Head, typename... Tail>
+LIBC_INLINE constexpr const auto &&get(const tuple<Head, Tail...> &&t) {
+  if constexpr (I == 0)
+    return static_cast<const Head &&>(t.get_head());
+  else
+    return get<I - 1>(static_cast<const tuple<Tail...> &&>(t.get_tail()));
+}
+
+template <typename T> struct tuple_size;
+template <typename... Ts> struct tuple_size<tuple<Ts...>> {
+  static constexpr size_t value = sizeof...(Ts);
+};
+
+template <size_t I, typename T> struct tuple_element;
+template <size_t I, typename Head, typename... Tail>
+struct tuple_element<I, tuple<Head, Tail...>>
+    : tuple_element<I - 1, tuple<Tail...>> {};
+template <typename Head, typename... Tail>
+struct tuple_element<0, tuple<Head, Tail...>> {
+  using type = cpp::remove_cv_t<cpp::remove_reference_t<Head>>;
+};
+
+namespace internal {
+template <typename... As, typename... Bs, size_t... I, size_t... J>
+LIBC_INLINE constexpr auto
+tuple_cat(const tuple<As...> &a, const tuple<Bs...> &b,
+          cpp::index_sequence<I...>, cpp::index_sequence<J...>) {
+  return tuple<As..., Bs...>(get<I>(a)..., get<J>(b)...);
+}
+
+template <typename First, typename Second, typename... Rest>
+LIBC_INLINE constexpr auto tuple_cat(const First &f, const Second &s,
+                                     const Rest &...rest) {
+  auto concat =
+      tuple_cat(f, s, cpp::make_index_sequence<tuple_size<First>::value>{},
+                cpp::make_index_sequence<tuple_size<Second>::value>{});
+  if constexpr (sizeof...(Rest))
+    return tuple_cat(concat, rest...);
+  else
+    return concat;
+}
+} // namespace internal
+
+template <typename... Tuples>
+LIBC_INLINE constexpr auto tuple_cat(const Tuples &...tuples) {
+  static_assert(sizeof...(Tuples) > 0, "need at least one element");
+  if constexpr (sizeof...(Tuples) == 1)
+    return (tuples, ...);
+  else
+    return internal::tuple_cat(tuples...);
+}
+
+} // namespace cpp
+} // namespace LIBC_NAMESPACE_DECL
+
+// For structured binding support.
+namespace std {
+
+template <class T> struct tuple_size;
+template <size_t I, class T> struct tuple_element;
+
+template <typename... Ts>
+struct tuple_size<LIBC_NAMESPACE::cpp::tuple<Ts...>>
+    : LIBC_NAMESPACE::cpp::tuple_size<LIBC_NAMESPACE::cpp::tuple<Ts...>> {};
+
+template <size_t I, typename... Ts>
+struct tuple_element<I, LIBC_NAMESPACE::cpp::tuple<Ts...>>
+    : LIBC_NAMESPACE::cpp::tuple_element<I, LIBC_NAMESPACE::cpp::tuple<Ts...>> {
+};
+
+} // namespace std
+
+#endif // LLVM_LIBC_SRC___SUPPORT_CPP_UTILITY_TUPLE_H

--- a/libc/src/__support/CPP/tuple.h
+++ b/libc/src/__support/CPP/tuple.h
@@ -124,7 +124,7 @@ LIBC_INLINE constexpr auto tuple_cat(const Tuples &...tuples) {
 } // namespace cpp
 } // namespace LIBC_NAMESPACE_DECL
 
-// For structured binding support.
+// Standard namespace definitions required for structured binding support.
 namespace std {
 
 template <class T> struct tuple_size;

--- a/libc/src/__support/CPP/utility/integer_sequence.h
+++ b/libc/src/__support/CPP/utility/integer_sequence.h
@@ -5,11 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #ifndef LLVM_LIBC_SRC___SUPPORT_CPP_UTILITY_INTEGER_SEQUENCE_H
 #define LLVM_LIBC_SRC___SUPPORT_CPP_UTILITY_INTEGER_SEQUENCE_H
 
 #include "src/__support/CPP/type_traits/is_integral.h"
 #include "src/__support/macros/config.h"
+
+#include <stddef.h>
 
 namespace LIBC_NAMESPACE_DECL {
 namespace cpp {
@@ -33,6 +36,13 @@ template <typename T> struct make_integer_sequence<T, -1> {
 template <typename T, int N>
 using make_integer_sequence =
     typename detail::make_integer_sequence<T, N - 1>::type;
+
+// index sequence
+template <size_t... Ints>
+using index_sequence = integer_sequence<size_t, Ints...>;
+template <int N>
+using make_index_sequence =
+    typename detail::make_integer_sequence<size_t, N - 1>::type;
 
 } // namespace cpp
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/test/src/__support/CPP/CMakeLists.txt
+++ b/libc/test/src/__support/CPP/CMakeLists.txt
@@ -131,6 +131,16 @@ add_libc_test(
 )
 
 add_libc_test(
+  tuple_test
+  SUITE
+    libc-cpp-utils-tests
+  SRCS
+    tuple_test.cpp
+  DEPENDS
+    libc.src.__support.CPP.tuple
+)
+
+add_libc_test(
   span_test
   SUITE
     libc-cpp-utils-tests

--- a/libc/test/src/__support/CPP/tuple_test.cpp
+++ b/libc/test/src/__support/CPP/tuple_test.cpp
@@ -1,0 +1,71 @@
+//===-- Unittests for cpp::tuple ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "src/__support/CPP/tuple.h"
+#include <stddef.h>
+
+#include "test/UnitTest/FPMatcher.h"
+#include "test/UnitTest/Test.h"
+
+using namespace LIBC_NAMESPACE::cpp;
+
+TEST(LlvmLibcTupleTest, Construction) {
+  tuple<int, double> t(42, 3.14);
+  EXPECT_EQ(get<0>(t), 42);
+  EXPECT_FP_EQ(get<1>(t), 3.14);
+}
+
+TEST(LlvmLibcTupleTest, MakeTuple) {
+  auto t = make_tuple(1, 2.5, 'x');
+  EXPECT_EQ(get<0>(t), 1);
+  EXPECT_FP_EQ(get<1>(t), 2.5);
+  EXPECT_EQ(get<2>(t), 'x');
+}
+
+TEST(LlvmLibcTupleTest, TieAssignment) {
+  int a = 0;
+  double b = 0;
+  char c = 0;
+  auto t = make_tuple(7, 8.5, 'y');
+  tie(a, b, c) = t;
+  EXPECT_EQ(a, 7);
+  EXPECT_FP_EQ(b, 8.5);
+  EXPECT_EQ(c, 'y');
+}
+
+TEST(LlvmLibcTupleTest, StructuredBindings) {
+  auto t = make_tuple(7, 8.5, 'y');
+  auto [x, y, z] = t;
+  EXPECT_EQ(x, 7);
+  EXPECT_FP_EQ(y, 8.5);
+  EXPECT_EQ(z, 'y');
+}
+
+TEST(LlvmLibcTupleTest, TupleCat) {
+  tuple<int, double> t(42, 3.14);
+  auto t1 = make_tuple(1, 2.5, 'x');
+  auto t2 = tuple_cat(t, t1);
+  EXPECT_EQ(get<0>(t2), 42);
+  EXPECT_FP_EQ(get<1>(t2), 3.14);
+  EXPECT_EQ(get<2>(t2), 1);
+  EXPECT_FP_EQ(get<3>(t2), 2.5);
+  EXPECT_EQ(get<4>(t2), 'x');
+}
+
+TEST(LlvmLibcTupleTest, ConstTuple) {
+  const auto t = make_tuple(100, 200.5);
+  EXPECT_EQ(get<0>(t), 100);
+  EXPECT_FP_EQ(get<1>(t), 200.5);
+}
+
+TEST(LlvmLibcTupleTest, RvalueAssignment) {
+  auto t = make_tuple(0, 0.0);
+  t = make_tuple(9, 9.5);
+  EXPECT_EQ(get<0>(t), 9);
+  EXPECT_FP_EQ(get<1>(t), 9.5);
+}

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -660,6 +660,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "__support_cpp_tuple",
+    hdrs = ["src/__support/CPP/tuple.h"],
+    deps = [
+        "__support_cpp_utility",
+    ],
+)
+
+libc_support_library(
     name = "__support_cpp_limits",
     hdrs = ["src/__support/CPP/limits.h"],
     deps = [


### PR DESCRIPTION
Summary:
This patch adds support for `cpp::tuple` with basic support for creating
and modifing tuples.
