### PR TITLE
[Clang] Fix __cpuidex conflict with other offloading targets

### DIFF
--- a/clang/lib/Headers/cpuid.h
+++ b/clang/lib/Headers/cpuid.h
@@ -348,7 +348,7 @@ static __inline int __get_cpuid_count (unsigned int __leaf,
 // In some cases, offloading will set the host as the aux triple and define the
 // builtin. Given __has_builtin does not detect builtins on aux triples, we need
 // to explicitly check for some offloading cases.
-#ifndef __NVPTX__
+#if !defined(__NVPTX__) && !defined(__AMDGPU__) && !defined(__SPIRV__)
 static __inline void __cpuidex(int __cpu_info[4], int __leaf, int __subleaf) {
   __cpuid_count(__leaf, __subleaf, __cpu_info[0], __cpu_info[1], __cpu_info[2],
                 __cpu_info[3]);

--- a/clang/test/Headers/__cpuidex_conflict.c
+++ b/clang/test/Headers/__cpuidex_conflict.c
@@ -6,6 +6,9 @@
 // Ensure that we do not run into conflicts when offloading.
 // RUN: %clang_cc1 %s -DIS_STATIC=static -ffreestanding -fopenmp -fopenmp-is-target-device -aux-triple x86_64-unknown-linux-gnu
 // RUN: %clang_cc1 -DIS_STATIC="" -triple nvptx64-nvidia-cuda -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu x86-64 -fcuda-is-device -x cuda %s -o -
+// RUN: %clang_cc1 -DIS_STATIC="" -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu x86-64 -fcuda-is-device -x cuda %s -o -
+// RUN: %clang_cc1 -DIS_STATIC="" -triple spirv64 -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu x86-64 -fcuda-is-device -x cuda %s -o -
+// RUN: %clang_cc1 -DIS_STATIC="" -triple spirv64 -aux-triple x86_64-unknown-linux-gnu -aux-target-cpu x86-64 -fsycl-is-device %s -o -
 
 typedef __SIZE_TYPE__ size_t;
 


### PR DESCRIPTION
It seems that for whatever reason we must:
1) Declare aux builtins when the compiling for an offload device
and
2) Define the aux builtin target macros when compiling for an offload device.

In `cpuid.h` we try to define `__cpuidex` if it is not defined. Given the above, the function will both be defined as a builtin in the compiler and we can't rely on the `X86` macros to be undefined in the case the aux-triple is `X86`.

 Previously a workaround was added for NVPTX in https://github.com/llvm/llvm-project/pull/152556, extend it for the other offloading targets.