### PR TITLE
Make flag-only options work in the ParsedCommand mode of adding commands

### DIFF
--- a/lldb/examples/python/cmdtemplate.py
+++ b/lldb/examples/python/cmdtemplate.py
@@ -74,6 +74,11 @@ class FrameStatCommand(ParsedCommand):
             dest = "statics",
             default = True,
         )
+        ov_parser.add_option(
+            "t",
+            "test-flag",
+            help = "test a flag value.",
+        )
 
     def get_repeat_command(self, args):
         """As an example, make the command not auto-repeat:"""
@@ -123,6 +128,11 @@ class FrameStatCommand(ParsedCommand):
                 % (variables_count, total_size, average_size),
                 file=result,
             )
+        if ov_parser.was_set("test-flag"):
+            print("Got the test flag")
+        else:
+            print("Got no test flag")
+        
         # not returning anything is akin to returning success
 
 

--- a/lldb/examples/python/cmdtemplate.py
+++ b/lldb/examples/python/cmdtemplate.py
@@ -77,7 +77,7 @@ class FrameStatCommand(ParsedCommand):
         ov_parser.add_option(
             "t",
             "test-flag",
-            help = "test a flag value.",
+            help="test a flag value.",
         )
 
     def get_repeat_command(self, args):
@@ -132,7 +132,7 @@ class FrameStatCommand(ParsedCommand):
             print("Got the test flag")
         else:
             print("Got no test flag")
-        
+
         # not returning anything is akin to returning success
 
 

--- a/lldb/examples/python/templates/parsed_cmd.py
+++ b/lldb/examples/python/templates/parsed_cmd.py
@@ -324,10 +324,19 @@ class LLDBOptionValueParser:
         value = self.__dict__[elem["dest"]]
         return value
 
-    def add_option(self, short_option, long_option, help, default = None,
-                   dest = None, required=False, groups = None,
-                   value_type=None, completion_type=None,
-                   enum_values=None):
+    def add_option(
+        self,
+        short_option,
+        long_option,
+        help,
+        default=None,
+        dest=None,
+        required=False,
+        groups=None,
+        value_type=None,
+        completion_type=None,
+        enum_values=None,
+    ):
         """
         short_option: one character, must be unique, not required
         long_option: no spaces, must be unique, required
@@ -352,11 +361,12 @@ class LLDBOptionValueParser:
 
         if not completion_type:
             completion_type = self.determine_completion(value_type)
-            
-        dict = {"short_option" : short_option,
-                "required" : required,
-                "help" : help,
-                }
+
+        dict = {
+            "short_option": short_option,
+            "required": required,
+            "help": help,
+        }
 
         if enum_values:
             if not value_type:

--- a/lldb/examples/python/templates/parsed_cmd.py
+++ b/lldb/examples/python/templates/parsed_cmd.py
@@ -241,11 +241,17 @@ class LLDBOptionValueParser:
             starts, you can override this to handle your special option.  """
         for key, elem in self.options_dict.items():
             elem['_value_set'] = False
+            # If there's no value_type, then there can't be a dest.
+            if not "value_type" in elem:
+                continue
+
             try:
                 object.__setattr__(self, elem["dest"], elem["default"])
             except AttributeError:
                 # It isn't an error not to have a "dest" variable name, you'll
                 # just have to manage this option's value on your own.
+                continue
+            except KeyError:
                 continue
 
     def set_enum_value(self, enum_values, input):
@@ -271,7 +277,13 @@ class LLDBOptionValueParser:
         elem = self.get_option_element(opt_name)
         if not elem:
             return False
-        
+
+        # If there's no value_type in element, then it has no value, so just mark
+        # it set and return:
+        if not "value_type" in elem:
+            elem["_value_set"] = True
+            return True
+
         if "enum_values" in elem:
             (value, error) = self.set_enum_value(elem["enum_values"], opt_value)
         else:
@@ -312,9 +324,9 @@ class LLDBOptionValueParser:
         value = self.__dict__[elem["dest"]]
         return value
 
-    def add_option(self, short_option, long_option, help, default,
+    def add_option(self, short_option, long_option, help, default = None,
                    dest = None, required=False, groups = None,
-                   value_type=lldb.eArgTypeNone, completion_type=None,
+                   value_type=None, completion_type=None,
                    enum_values=None):
         """
         short_option: one character, must be unique, not required
@@ -344,13 +356,22 @@ class LLDBOptionValueParser:
         dict = {"short_option" : short_option,
                 "required" : required,
                 "help" : help,
-                "value_type" : value_type,
-                "completion_type" : completion_type,
-                "dest" : dest,
-                "default" : default}
+                }
 
         if enum_values:
+            if not value_type:
+                print("I am setting value type for an enum value")
+                value_type = lldb.eArgTypeNone
+            else:
+                print(f"An enum value had a type: {value_type}")
             dict["enum_values"] = enum_values
+
+        if value_type:
+            dict["value_type"] = value_type
+            dict["completion_type"] = completion_type
+            dict["dest"] = dest
+            dict["default"] = default
+
         if groups:
             dict["groups"] = groups
 

--- a/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
+++ b/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
@@ -218,7 +218,7 @@ class ParsedCommandTestCase(TestBase):
                 "disk-file-name (set: False):",
                 "flag-value (set: False):",
                 "line-num (set: False):",
-                "enum-option (set: False):"
+                "enum-option (set: False):",
             ],
         )
         # Make sure flag values work:
@@ -230,7 +230,7 @@ class ParsedCommandTestCase(TestBase):
                 "disk-file-name (set: False):",
                 "flag-value (set: True):",
                 "line-num (set: False):",
-                "enum-option (set: False):"
+                "enum-option (set: False):",
             ],
         )
 

--- a/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
+++ b/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
@@ -34,6 +34,7 @@ class ParsedCommandTestCase(TestBase):
             else:
                 (short_opt, type, long_opt) = elem
                 substrs.append(f"-{short_opt} <{type}> ( --{long_opt} <{type}> )")
+
         self.expect("help " + cmd_name, substrs=substrs)
 
     def run_one_repeat(self, commands, expected_num_errors):
@@ -215,8 +216,21 @@ class ParsedCommandTestCase(TestBase):
                 "bool-arg (set: True): False",
                 "shlib-name (set: True): Something",
                 "disk-file-name (set: False):",
+                "flag-value (set: False):",
                 "line-num (set: False):",
-                "enum-option (set: False):",
+                "enum-option (set: False):"
+            ],
+        )
+        # Make sure flag values work:
+        self.expect(
+            "no-args -b false -s Something -f",
+            substrs=[
+                "bool-arg (set: True): False",
+                "shlib-name (set: True): Something",
+                "disk-file-name (set: False):",
+                "flag-value (set: True):",
+                "line-num (set: False):",
+                "enum-option (set: False):"
             ],
         )
 

--- a/lldb/test/API/commands/command/script/add/test_commands.py
+++ b/lldb/test/API/commands/command/script/add/test_commands.py
@@ -16,10 +16,16 @@ class ReportingCmd(ParsedCommand):
         if len(opt_def):
             result.AppendMessage("Options:\n")
             for long_option, elem in opt_def.items():
-                dest = elem["dest"]
-                result.AppendMessage(
-                    f"{long_option} (set: {elem['_value_set']}): {object.__getattribute__(self.get_parser(), dest)}\n"
-                )
+                if "value_type" in elem:
+                    print(f"Looking at {long_option} - {elem}")
+                    dest = elem["dest"]
+                    result.AppendMessage(
+                        f"{long_option} (set: {elem['_value_set']}): {object.__getattribute__(self.get_parser(), dest)}\n"
+                    )
+                else:
+                    result.AppendMessage(
+                        f"{long_option} (set: {elem['_value_set']}): flag value\n"
+                    )
         else:
             result.AppendMessage("No options\n")
 
@@ -76,6 +82,12 @@ class NoArgsCommand(ReportingCmd):
             value_type=lldb.eArgTypeFilename,
             dest="disk_file_name",
             default=None,
+        )
+
+        ov_parser.add_option(
+            "f",
+            "flag-value",
+            "This is a flag value"
         )
 
         ov_parser.add_option(

--- a/lldb/test/API/commands/command/script/add/test_commands.py
+++ b/lldb/test/API/commands/command/script/add/test_commands.py
@@ -84,11 +84,7 @@ class NoArgsCommand(ReportingCmd):
             default=None,
         )
 
-        ov_parser.add_option(
-            "f",
-            "flag-value",
-            "This is a flag value"
-        )
+        ov_parser.add_option("f", "flag-value", "This is a flag value")
 
         ov_parser.add_option(
             "l",


### PR DESCRIPTION
I neglected to add a test when I was writing tests for this, so of course it broke.  This makes it work again and adds a test.

rdar://159459160