### PR TITLE
[clang] Do not diagnose conflicting types for cfi_unchecked_callee

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -233,6 +233,9 @@ Removed Compiler Flags
 
 Attribute Changes in Clang
 --------------------------
+- The definition of a function declaration with ``[[clang::cfi_unchecked_callee]]`` inherits this
+  attribute, allowing the attribute to only be attached to the declaration. Prior, this would be
+  treated as an error where the definition and declaration would have differing types.
 
 Improvements to Clang's diagnostics
 -----------------------------------

--- a/clang/test/AST/cfi-unchecked-callee.cpp
+++ b/clang/test/AST/cfi-unchecked-callee.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -ast-dump %s | FileCheck %s
+
+
+// CHECK: FunctionDecl [[PTR:0x[a-z0-9]*]] {{.*}}func 'void () __attribute__((cfi_unchecked_callee))'
+__attribute__((cfi_unchecked_callee))
+void func(void);
+
+// CHECK-NEXT: FunctionDecl {{0x[a-z0-9]*}} prev [[PTR]] {{.*}}func 'void () __attribute__((cfi_unchecked_callee))'
+void func(void) {}

--- a/clang/test/Frontend/cfi-unchecked-callee-attribute.cpp
+++ b/clang/test/Frontend/cfi-unchecked-callee-attribute.cpp
@@ -233,3 +233,7 @@ void lambdas() {
     checked_func = checked_lambda;
   };
 }
+
+CFI_UNCHECKED_CALLEE
+void func(void);
+void func(void) {}  // No warning expected.


### PR DESCRIPTION
Clang would complain about conflicting types between a function declaration and definition if the declaraion was marked with the attribute but the definition wasn't. Do not treat this as an error. It should only be necessary to mark the declaration with the attribute.