### PR TITLE
[Offload][Conformance] Update olMemFree calls in conformance tests

### DIFF
--- a/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceContext.hpp
@@ -57,13 +57,13 @@ public:
   explicit DeviceContext(llvm::StringRef Platform, std::size_t DeviceId = 0);
 
   template <typename T>
-  ManagedBuffer<T> createManagedBuffer(std::size_t Size) noexcept {
+  ManagedBuffer<T> createManagedBuffer(std::size_t Size) const noexcept {
     void *UntypedAddress = nullptr;
 
     detail::allocManagedMemory(DeviceHandle, Size * sizeof(T), &UntypedAddress);
     T *TypedAddress = static_cast<T *>(UntypedAddress);
 
-    return ManagedBuffer<T>(getPlatformHandle(), TypedAddress, Size);
+    return ManagedBuffer<T>(PlatformHandle, TypedAddress, Size);
   }
 
   [[nodiscard]] llvm::Expected<std::shared_ptr<DeviceImage>>
@@ -120,9 +120,6 @@ public:
 
   [[nodiscard]] llvm::StringRef getPlatform() const noexcept;
 
-  [[nodiscard]] llvm::Expected<ol_platform_handle_t>
-  getPlatformHandle() noexcept;
-
 private:
   [[nodiscard]] llvm::Expected<ol_symbol_handle_t>
   getKernelHandle(ol_program_handle_t ProgramHandle,
@@ -134,7 +131,7 @@ private:
 
   std::size_t GlobalDeviceId;
   ol_device_handle_t DeviceHandle;
-  ol_platform_handle_t PlatformHandle = nullptr;
+  ol_platform_handle_t PlatformHandle;
 };
 } // namespace mathtest
 

--- a/offload/unittests/Conformance/include/mathtest/DeviceResources.hpp
+++ b/offload/unittests/Conformance/include/mathtest/DeviceResources.hpp
@@ -47,7 +47,8 @@ public:
   ManagedBuffer &operator=(const ManagedBuffer &) = delete;
 
   ManagedBuffer(ManagedBuffer &&Other) noexcept
-      : Address(Other.Address), Size(Other.Size) {
+      : Platform(Other.Platform), Address(Other.Address), Size(Other.Size) {
+    Other.Platform = nullptr;
     Other.Address = nullptr;
     Other.Size = 0;
   }
@@ -59,9 +60,11 @@ public:
     if (Address)
       detail::freeDeviceMemory(Platform, Address);
 
+    Platform = Other.Platform;
     Address = Other.Address;
     Size = Other.Size;
 
+    Other.Platform = nullptr;
     Other.Address = nullptr;
     Other.Size = 0;
 
@@ -89,7 +92,7 @@ private:
                          std::size_t Size) noexcept
       : Platform(Platform), Address(Address), Size(Size) {}
 
-  ol_platform_handle_t Platform;
+  ol_platform_handle_t Platform = nullptr;
   T *Address = nullptr;
   std::size_t Size = 0;
 };

--- a/offload/unittests/Conformance/include/mathtest/GpuMathTest.hpp
+++ b/offload/unittests/Conformance/include/mathtest/GpuMathTest.hpp
@@ -75,7 +75,7 @@ public:
 
   ResultType run(GeneratorType &Generator,
                  std::size_t BufferSize = DefaultBufferSize,
-                 uint32_t GroupSize = DefaultGroupSize) noexcept {
+                 uint32_t GroupSize = DefaultGroupSize) const noexcept {
     assert(BufferSize > 0 && "Buffer size must be a positive value");
     assert(GroupSize > 0 && "Group size must be a positive value");
 
@@ -128,7 +128,7 @@ private:
     return *ExpectedKernel;
   }
 
-  [[nodiscard]] auto createBuffers(std::size_t BufferSize) {
+  [[nodiscard]] auto createBuffers(std::size_t BufferSize) const {
     auto InBuffersTuple = std::apply(
         [&](auto... InTypeIdentities) {
           return std::make_tuple(


### PR DESCRIPTION
This PR is a follow-up to the change introduced in #157478, which added a `platform` parameter to the `olMemFree` function.