### PR TITLE
[clang][ptrauth] Warn about the use of a weak signing schema

### DIFF
--- a/clang/docs/PointerAuthentication.rst
+++ b/clang/docs/PointerAuthentication.rst
@@ -1429,10 +1429,11 @@ to be trivially copyable, which means they must be copyable with ``memcpy``.
 
 The use of a uniform constant discriminator greatly simplifies the adoption of
 arm64e, but it is a significant weakness in the mitigation because it allows any
-C function pointer to be replaced with another. Clang supports
-`-fptrauth-function-pointer-type-discrimination`, which enables a variant ABI
-that uses type discrimination for function pointers. When generating the type
-based discriminator for a function type all primitive integer types are
+C function pointer to be replaced with another. The `-Wptrauth-weak-schema`
+diagnostic warns about the use of weak pointer authentication schemas. Clang
+supports `-fptrauth-function-pointer-type-discrimination`, which enables a
+variant ABI that uses type discrimination for function pointers. When generating
+the type based discriminator for a function type all primitive integer types are
 considered equivalent due to the prevalence of mismatching integer parameter
 types in real world code. Type discrimination of function pointers is
 ABI-incompatible with the standard arm64e ABI, but it can be used in constrained

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -287,7 +287,7 @@ Improvements to Clang's diagnostics
   declarations of function pointer type and internal linkage that use a weak
   pointer authentication schema, either implicitly or by specifying a discriminator
   with no diversifiers. This warning applies only to targets supporting pointer
-  authentication.
+  authentication when the feature is enabled.
 
 Improvements to Clang's time-trace
 ----------------------------------

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -283,6 +283,12 @@ Improvements to Clang's diagnostics
   pointers under ``-Wthread-safety-beta`` (still experimental), which reduces
   both false positives but also false negatives through more precise analysis.
 
+- A new warning ``-Wptrauth-weak-schema`` has been added to detect variable
+  declarations of function pointer type and internal linkage that use a weak
+  pointer authentication schema, either implicitly or by specifying a discriminator
+  with no diversifiers. This warning applies only to targets supporting pointer
+  authentication.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -659,6 +659,11 @@ public:
     return findPointerAuthContent(T) != PointerAuthContent::None;
   }
 
+  // A simple helper function to short circuit pointer auth checks.
+  bool isPointerAuthenticationAvailable() const {
+    return LangOpts.PointerAuthCalls || LangOpts.PointerAuthIntrinsics;
+  }
+
 private:
   llvm::DenseMap<const CXXRecordDecl *, CXXRecordDeclRelocationInfo>
       RelocatableClasses;
@@ -670,10 +675,6 @@ private:
     AddressDiscriminatedData
   };
 
-  // A simple helper function to short circuit pointer auth checks.
-  bool isPointerAuthenticationAvailable() const {
-    return LangOpts.PointerAuthCalls || LangOpts.PointerAuthIntrinsics;
-  }
   PointerAuthContent findPointerAuthContent(QualType T) const;
   mutable llvm::DenseMap<const RecordDecl *, PointerAuthContent>
       RecordContainsAddressDiscriminatedPointerAuth;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1072,7 +1072,6 @@ def GNUZeroLineDirective : DiagGroup<"gnu-zero-line-directive">;
 def GNUZeroVariadicMacroArguments : DiagGroup<"gnu-zero-variadic-macro-arguments", [VariadicMacroArgumentsOmitted]>;
 def MisleadingIndentation : DiagGroup<"misleading-indentation">;
 def PtrAuthNullPointers : DiagGroup<"ptrauth-null-pointers">;
-def PtrAuthWeakSchema : DiagGroup<"ptrauth-weak-schema">;
 
 // This covers both the deprecated case (in C++98)
 // and the extension case (in C++11 onwards).

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1072,6 +1072,7 @@ def GNUZeroLineDirective : DiagGroup<"gnu-zero-line-directive">;
 def GNUZeroVariadicMacroArguments : DiagGroup<"gnu-zero-variadic-macro-arguments", [VariadicMacroArgumentsOmitted]>;
 def MisleadingIndentation : DiagGroup<"misleading-indentation">;
 def PtrAuthNullPointers : DiagGroup<"ptrauth-null-pointers">;
+def PtrAuthWeakSchema : DiagGroup<"ptrauth-weak-schema">;
 
 // This covers both the deprecated case (in C++98)
 // and the extension case (in C++11 onwards).

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1047,9 +1047,10 @@ def err_ptrauth_extra_discriminator_invalid : Error<
   "invalid extra discriminator flag '%0'; '__ptrauth' requires a value between "
   "'0' and '%1'">;
 def warn_ptrauth_weak_schema
-    : Warning<"internal variable %0 is using a weak signing schema for pointer "
-              "authentication">,
-      InGroup<PtrAuthWeakSchema>;
+    : Warning<"%0 has internal linkage with a %select{|default }1"
+              "pointer authentication schema that should be overridden by "
+              "%select{a|an explicit}1 schema with unique diversifiers">,
+      InGroup<DiagGroup<"ptrauth-weak-schema">>;
 
 /// main()
 // static main() is not an error in C, just in C++.

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -1046,6 +1046,10 @@ def err_ptrauth_address_discrimination_invalid : Error<
 def err_ptrauth_extra_discriminator_invalid : Error<
   "invalid extra discriminator flag '%0'; '__ptrauth' requires a value between "
   "'0' and '%1'">;
+def warn_ptrauth_weak_schema
+    : Warning<"internal variable %0 is using a weak signing schema for pointer "
+              "authentication">,
+      InGroup<PtrAuthWeakSchema>;
 
 /// main()
 // static main() is not an error in C, just in C++.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -3976,6 +3976,10 @@ public:
   void CheckVariableDeclarationType(VarDecl *NewVD);
   void CheckCompleteVariableDeclaration(VarDecl *VD);
 
+  // Warn about the use of a weak pointer authentication schema on a variable of
+  // function pointer type and internal linkage.
+  void DiagnoseWeakPointerAuthenticationSchema(VarDecl *VD);
+
   NamedDecl *ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
                                      TypeSourceInfo *TInfo,
                                      LookupResult &Previous,

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7628,12 +7628,12 @@ static bool isMainVar(DeclarationName Name, VarDecl *VD) {
 }
 
 void Sema::DiagnoseWeakPointerAuthenticationSchema(VarDecl *VD) {
-  if (Context.isPointerAuthenticationAvailable() &&
-      VD->isFunctionPointerType() && !VD->isExternallyVisible()) {
+  if (!Context.isPointerAuthenticationAvailable())
+    return;
+  if (VD->isFunctionPointerType() && !VD->isExternallyVisible()) {
     PointerAuthQualifier Q = VD->getType().getQualifiers().getPointerAuth();
-    if (!Q || (!Q.isAddressDiscriminated() && Q.getExtraDiscriminator() == 0)) {
+    if (!Q || (!Q.isAddressDiscriminated() && Q.getExtraDiscriminator() == 0))
       Diag(VD->getLocation(), diag::warn_ptrauth_weak_schema) << VD << !Q;
-    }
   }
 }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8359,11 +8359,13 @@ NamedDecl *Sema::ActOnVariableDeclarator(
 
   // Warn about the use of a weak pointer authentication schema on a variable
   // with internal linkage.
-  if (getLangOpts().PointerAuthCalls && NewVD->isFunctionPointerType() &&
-      !isExternallyVisible(NewVD->getLinkageInternal())) {
+  if (Context.isPointerAuthenticationAvailable() &&
+      NewVD->isFunctionPointerType() && !NewVD->isExternallyVisible()) {
     PointerAuthQualifier Q = NewVD->getType().getQualifiers().getPointerAuth();
-    if (!Q || (!Q.isAddressDiscriminated() && Q.getExtraDiscriminator() == 0))
-      Diag(NewVD->getLocation(), diag::warn_ptrauth_weak_schema) << NewVD;
+    if (!Q || (!Q.isAddressDiscriminated() && Q.getExtraDiscriminator() == 0)) {
+      Diag(NewVD->getLocation(), diag::warn_ptrauth_weak_schema)
+          << NewVD << (Q ? 0 : 1);
+    }
   }
 
   if (NewTemplate) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8363,8 +8363,7 @@ NamedDecl *Sema::ActOnVariableDeclarator(
       NewVD->isFunctionPointerType() && !NewVD->isExternallyVisible()) {
     PointerAuthQualifier Q = NewVD->getType().getQualifiers().getPointerAuth();
     if (!Q || (!Q.isAddressDiscriminated() && Q.getExtraDiscriminator() == 0)) {
-      Diag(NewVD->getLocation(), diag::warn_ptrauth_weak_schema)
-          << NewVD << (Q ? 0 : 1);
+      Diag(NewVD->getLocation(), diag::warn_ptrauth_weak_schema) << NewVD << !Q;
     }
   }
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -8357,6 +8357,15 @@ NamedDecl *Sema::ActOnVariableDeclarator(
                                    D.isFunctionDefinition());
   }
 
+  // Warn about the use of a weak pointer authentication schema on a variable
+  // with internal linkage.
+  if (getLangOpts().PointerAuthCalls && NewVD->isFunctionPointerType() &&
+      !isExternallyVisible(NewVD->getLinkageInternal())) {
+    PointerAuthQualifier Q = NewVD->getType().getQualifiers().getPointerAuth();
+    if (!Q || (!Q.isAddressDiscriminated() && Q.getExtraDiscriminator() == 0))
+      Diag(NewVD->getLocation(), diag::warn_ptrauth_weak_schema) << NewVD;
+  }
+
   if (NewTemplate) {
     if (NewVD->isInvalidDecl())
       NewTemplate->setInvalidDecl();

--- a/clang/test/Sema/ptrauth-weak-schema.c
+++ b/clang/test/Sema/ptrauth-weak-schema.c
@@ -5,6 +5,10 @@
 
 #include <ptrauth.h>
 
+#if defined(__PTRAUTH__) == defined(NO_PTRAUTH)
+#error expected pointer authentication state does not match actual
+#endif
+
 #if defined(NO_PTRAUTH)
 #define FN_PTR_AUTH(address_diversity, constant_discriminator)
 #else

--- a/clang/test/Sema/ptrauth-weak-schema.c
+++ b/clang/test/Sema/ptrauth-weak-schema.c
@@ -1,23 +1,16 @@
-// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -verify %s
-// RUN: %clang_cc1 -triple arm64e-apple-ios -DNO_PTRAUTH -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -Wno-unused-variable -verify %s
+// RUN: %clang_cc1 -triple arm64e-apple-ios -DNO_PTRAUTH -fsyntax-only -Wno-unused-variable -verify=noptrauth %s
 
-#if defined(NO_PTRAUTH)
-
-#define FN_PTR_AUTH(address_diversity, constant_discriminator)
-// expected-no-diagnostics
-
-#else // !defined(NO_PTRAUTH)
-
-#if !__has_extension(ptrauth_qualifier)
-#error __ptrauth qualifier not enabled
-#endif
+// noptrauth-no-diagnostics
 
 #include <ptrauth.h>
 
+#if defined(NO_PTRAUTH)
+#define FN_PTR_AUTH(address_diversity, constant_discriminator)
+#else
 #define FN_PTR_AUTH(address_diversity, constant_discriminator) \
   __ptrauth(ptrauth_key_function_pointer, address_diversity, constant_discriminator)
-
-#endif // defined(NO_PTRAUTH)
+#endif
 
 // Global variables with external linkage and weak pointer authentication should
 // not raise any warning.
@@ -34,9 +27,9 @@ static void(* FN_PTR_AUTH(1, 0) g3_internal_strong)(void);
 // Global variables with internal linkage and weak pointer authentication should
 // raise a warning.
 static void(* g1_internal_weak)(void);
-// expected-warning@-1 {{internal variable 'g1_internal_weak' is using a weak signing schema for pointer authentication}}
+// expected-warning@-1 {{'g1_internal_weak' has internal linkage with a default pointer authentication schema that should be overridden by an explicit schema with unique diversifiers}}
 static void(* FN_PTR_AUTH(0, 0) g2_internal_weak)(void);
-// expected-warning@-1 {{internal variable 'g2_internal_weak' is using a weak signing schema for pointer authentication}}
+// expected-warning@-1 {{'g2_internal_weak' has internal linkage with a pointer authentication schema that should be overridden by a schema with unique diversifiers}}
 
 // Assert that -Wptrauth-weak-schema silences warnings.
 #pragma clang diagnostic push
@@ -46,16 +39,13 @@ static void(* g3_internal_weak)(void);
 #endif
 
 void test_local_variables(void) {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunused-variable"
-
     #if !defined(NO_PTRAUTH)
     // Local variables (internal linkage) with weak pointer authentication
     // should raise a warning.
     static void(* l1_internal_weak)(void);
-    // expected-warning@-1 {{internal variable 'l1_internal_weak' is using a weak signing schema for pointer authentication}}
+    // expected-warning@-1 {{'l1_internal_weak' has internal linkage with a default pointer authentication schema that should be overridden by an explicit schema with unique diversifiers}}
     static void(* FN_PTR_AUTH(0, 0) l2_internal_weak)(void);
-    // expected-warning@-1 {{internal variable 'l2_internal_weak' is using a weak signing schema for pointer authentication}}
+    // expected-warning@-1 {{'l2_internal_weak' has internal linkage with a pointer authentication schema that should be overridden by a schema with unique diversifiers}}
     #endif
 
     // Local variables (internal linkage) with strong pointer authentication
@@ -63,6 +53,4 @@ void test_local_variables(void) {
     void(* FN_PTR_AUTH(1, 65535) l1_internal_strong)(void);
     void(* FN_PTR_AUTH(0, 65535) l2_internal_strong)(void);
     void(* FN_PTR_AUTH(1, 0) l3_internal_strong)(void);
-
-    #pragma clang diagnostic pop
 }

--- a/clang/test/Sema/ptrauth-weak-schema.c
+++ b/clang/test/Sema/ptrauth-weak-schema.c
@@ -50,11 +50,18 @@ void test_local_variables(void) {
     // expected-warning@-1 {{'l1_internal_weak' has internal linkage with a default pointer authentication schema that should be overridden by an explicit schema with unique diversifiers}}
     static void(* FN_PTR_AUTH(0, 0) l2_internal_weak)(void);
     // expected-warning@-1 {{'l2_internal_weak' has internal linkage with a pointer authentication schema that should be overridden by a schema with unique diversifiers}}
+    void(* l3_internal_weak)(void);
+    // expected-warning@-1 {{'l3_internal_weak' has internal linkage with a default pointer authentication schema that should be overridden by an explicit schema with unique diversifiers}}
+    void(* FN_PTR_AUTH(0, 0) l4_internal_weak)(void);
+    // expected-warning@-1 {{'l4_internal_weak' has internal linkage with a pointer authentication schema that should be overridden by a schema with unique diversifiers}}
     #endif
 
     // Local variables (internal linkage) with strong pointer authentication
     // should not raise any warning.
-    void(* FN_PTR_AUTH(1, 65535) l1_internal_strong)(void);
-    void(* FN_PTR_AUTH(0, 65535) l2_internal_strong)(void);
-    void(* FN_PTR_AUTH(1, 0) l3_internal_strong)(void);
+    static void(* FN_PTR_AUTH(1, 65535) l1_internal_strong)(void);
+    static void(* FN_PTR_AUTH(0, 65535) l2_internal_strong)(void);
+    static void(* FN_PTR_AUTH(1, 0) l3_internal_strong)(void);
+    void(* FN_PTR_AUTH(1, 65535) l4_internal_strong)(void);
+    void(* FN_PTR_AUTH(0, 65535) l5_internal_strong)(void);
+    void(* FN_PTR_AUTH(1, 0) l6_internal_strong)(void);
 }

--- a/clang/test/Sema/ptrauth-weak-schema.c
+++ b/clang/test/Sema/ptrauth-weak-schema.c
@@ -1,0 +1,68 @@
+// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls -fptrauth-intrinsics -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple arm64e-apple-ios -DNO_PTRAUTH -fsyntax-only -verify %s
+
+#if defined(NO_PTRAUTH)
+
+#define FN_PTR_AUTH(address_diversity, constant_discriminator)
+// expected-no-diagnostics
+
+#else // !defined(NO_PTRAUTH)
+
+#if !__has_extension(ptrauth_qualifier)
+#error __ptrauth qualifier not enabled
+#endif
+
+#include <ptrauth.h>
+
+#define FN_PTR_AUTH(address_diversity, constant_discriminator) \
+  __ptrauth(ptrauth_key_function_pointer, address_diversity, constant_discriminator)
+
+#endif // defined(NO_PTRAUTH)
+
+// Global variables with external linkage and weak pointer authentication should
+// not raise any warning.
+extern void(* g1_external_weak)(void);
+void(* FN_PTR_AUTH(0, 0) g2_external_weak)(void);
+
+// Global variables with internal linkage and strong pointer authentication
+// should not raise any warning.
+static void(* FN_PTR_AUTH(1, 65535) g1_internal_strong)(void);
+static void(* FN_PTR_AUTH(0, 65535) g2_internal_strong)(void);
+static void(* FN_PTR_AUTH(1, 0) g3_internal_strong)(void);
+
+#if !defined(NO_PTRAUTH)
+// Global variables with internal linkage and weak pointer authentication should
+// raise a warning.
+static void(* g1_internal_weak)(void);
+// expected-warning@-1 {{internal variable 'g1_internal_weak' is using a weak signing schema for pointer authentication}}
+static void(* FN_PTR_AUTH(0, 0) g2_internal_weak)(void);
+// expected-warning@-1 {{internal variable 'g2_internal_weak' is using a weak signing schema for pointer authentication}}
+
+// Assert that -Wptrauth-weak-schema silences warnings.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wptrauth-weak-schema"
+static void(* g3_internal_weak)(void);
+#pragma clang diagnostic pop
+#endif
+
+void test_local_variables(void) {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-variable"
+
+    #if !defined(NO_PTRAUTH)
+    // Local variables (internal linkage) with weak pointer authentication
+    // should raise a warning.
+    static void(* l1_internal_weak)(void);
+    // expected-warning@-1 {{internal variable 'l1_internal_weak' is using a weak signing schema for pointer authentication}}
+    static void(* FN_PTR_AUTH(0, 0) l2_internal_weak)(void);
+    // expected-warning@-1 {{internal variable 'l2_internal_weak' is using a weak signing schema for pointer authentication}}
+    #endif
+
+    // Local variables (internal linkage) with strong pointer authentication
+    // should not raise any warning.
+    void(* FN_PTR_AUTH(1, 65535) l1_internal_strong)(void);
+    void(* FN_PTR_AUTH(0, 65535) l2_internal_strong)(void);
+    void(* FN_PTR_AUTH(1, 0) l3_internal_strong)(void);
+
+    #pragma clang diagnostic pop
+}


### PR DESCRIPTION
In this change we added the -Wptrauth-weak-schema diagnostic (enabled by default on targets that support pointer authentication) to warn about the use of a weak signing schema for function pointers stored in global variables with internal linkage.

rdar://159299739