### PR TITLE
[orc-rt] Add const support to move_only_function.

### DIFF
--- a/orc-rt/include/orc-rt/move_only_function.h
+++ b/orc-rt/include/orc-rt/move_only_function.h
@@ -50,12 +50,38 @@ private:
   CallableT Callable;
 };
 
+template <typename RetT, typename... ArgTs> class GenericConstCallable {
+public:
+  virtual ~GenericConstCallable() = default;
+  virtual RetT call(ArgTs &&...Args) const = 0;
+};
+
+template <typename CallableT, typename RetT, typename... ArgTs>
+class GenericConstCallableImpl : public GenericConstCallable<RetT, ArgTs...> {
+public:
+  GenericConstCallableImpl(CallableT &&Callable)
+      : Callable(std::move(Callable)) {}
+  RetT call(ArgTs &&...Args) const override {
+    return Callable(std::forward<ArgTs>(Args)...);
+  }
+
+private:
+  CallableT Callable;
+};
+
 } // namespace move_only_function_detail
 
 template <typename FnT> class move_only_function;
 
 template <typename RetT, typename... ArgTs>
 class move_only_function<RetT(ArgTs...)> {
+private:
+  using GenericCallable =
+      move_only_function_detail::GenericCallable<RetT, ArgTs...>;
+  template <typename CallableT>
+  using GenericCallableImpl =
+      move_only_function_detail::GenericCallableImpl<CallableT, RetT, ArgTs...>;
+
 public:
   move_only_function() = default;
   move_only_function(std::nullptr_t) {}
@@ -66,17 +92,50 @@ public:
 
   template <typename CallableT>
   move_only_function(CallableT &&Callable)
-      : C(std::make_unique<move_only_function_detail::GenericCallableImpl<
-              std::decay_t<CallableT>, RetT, ArgTs...>>(std::move(Callable))) {}
+      : C(std::make_unique<GenericCallableImpl<std::decay_t<CallableT>>>(
+            std::move(Callable))) {}
 
-  RetT operator()(ArgTs... Params) {
+  RetT operator()(ArgTs... Params) const {
     return C->call(std::forward<ArgTs>(Params)...);
   }
 
   explicit operator bool() const { return !!C; }
 
 private:
-  std::unique_ptr<move_only_function_detail::GenericCallable<RetT, ArgTs...>> C;
+  std::unique_ptr<GenericCallable> C;
+};
+
+template <typename RetT, typename... ArgTs>
+class move_only_function<RetT(ArgTs...) const> {
+private:
+  using GenericCallable =
+      move_only_function_detail::GenericConstCallable<RetT, ArgTs...>;
+  template <typename CallableT>
+  using GenericCallableImpl =
+      move_only_function_detail::GenericConstCallableImpl<CallableT, RetT,
+                                                          ArgTs...>;
+
+public:
+  move_only_function() = default;
+  move_only_function(std::nullptr_t) {}
+  move_only_function(move_only_function &&) = default;
+  move_only_function(const move_only_function &) = delete;
+  move_only_function &operator=(move_only_function &&) = default;
+  move_only_function &operator=(const move_only_function &) = delete;
+
+  template <typename CallableT>
+  move_only_function(CallableT &&Callable)
+      : C(std::make_unique<const GenericCallableImpl<std::decay_t<CallableT>>>(
+            std::move(Callable))) {}
+
+  RetT operator()(ArgTs... Params) const {
+    return C->call(std::forward<ArgTs>(Params)...);
+  }
+
+  explicit operator bool() const { return !!C; }
+
+private:
+  std::unique_ptr<const GenericCallable> C;
 };
 
 } // namespace orc_rt


### PR DESCRIPTION
Adds support for both const move_only_functions, and const callees.