### PR TITLE
[orc-rt] Restore perfect forwarding in move_only_function initializat…

### DIFF
--- a/orc-rt/include/orc-rt/move_only_function.h
+++ b/orc-rt/include/orc-rt/move_only_function.h
@@ -41,7 +41,9 @@ public:
 template <typename CallableT, typename RetT, typename... ArgTs>
 class GenericCallableImpl : public GenericCallable<RetT, ArgTs...> {
 public:
-  GenericCallableImpl(CallableT &&Callable) : Callable(std::move(Callable)) {}
+  template <typename CallableInitT>
+  GenericCallableImpl(CallableInitT &&Callable)
+      : Callable(std::forward<CallableInitT>(Callable)) {}
   RetT call(ArgTs &&...Args) override {
     return Callable(std::forward<ArgTs>(Args)...);
   }
@@ -59,8 +61,9 @@ public:
 template <typename CallableT, typename RetT, typename... ArgTs>
 class GenericConstCallableImpl : public GenericConstCallable<RetT, ArgTs...> {
 public:
-  GenericConstCallableImpl(CallableT &&Callable)
-      : Callable(std::move(Callable)) {}
+  template <typename CallableInitT>
+  GenericConstCallableImpl(CallableInitT &&Callable)
+      : Callable(std::forward<CallableInitT>(Callable)) {}
   RetT call(ArgTs &&...Args) const override {
     return Callable(std::forward<ArgTs>(Args)...);
   }
@@ -93,7 +96,7 @@ public:
   template <typename CallableT>
   move_only_function(CallableT &&Callable)
       : C(std::make_unique<GenericCallableImpl<std::decay_t<CallableT>>>(
-            std::move(Callable))) {}
+            std::forward<CallableT>(Callable))) {}
 
   RetT operator()(ArgTs... Params) const {
     return C->call(std::forward<ArgTs>(Params)...);
@@ -126,7 +129,7 @@ public:
   template <typename CallableT>
   move_only_function(CallableT &&Callable)
       : C(std::make_unique<const GenericCallableImpl<std::decay_t<CallableT>>>(
-            std::move(Callable))) {}
+            std::forward<CallableT>(Callable))) {}
 
   RetT operator()(ArgTs... Params) const {
     return C->call(std::forward<ArgTs>(Params)...);

--- a/orc-rt/unittests/move_only_function-test.cpp
+++ b/orc-rt/unittests/move_only_function-test.cpp
@@ -228,3 +228,21 @@ TEST(MoveOnlyFunctionTest, Constness) {
     EXPECT_EQ(Const, 1U);
   }
 }
+
+TEST(MoveOnlyFunctionTest, ShouldCopyInitialize) {
+  // Check that we don't accidentally move-initialize move_only_functions.
+  class ShouldCopy {
+  public:
+    ShouldCopy(bool &Moved) : Moved(Moved) {}
+    ShouldCopy(const ShouldCopy &) = default;
+    ShouldCopy(ShouldCopy &&Other) : Moved(Other.Moved) { Moved = true; }
+    void operator()() {}
+
+  private:
+    bool &Moved;
+  };
+  bool DidMove = false;
+  ShouldCopy SC(DidMove);
+  move_only_function<void()> F(SC);
+  EXPECT_FALSE(DidMove);
+}


### PR DESCRIPTION
…ion.

After the recent change to hoist std::decay_t (cd8f47b2d4e) we were forcing move-initialization of the callable type. This commit restores perfect forwarding so that we copy-initialize where expected.