### PR TITLE
[orc-rt] Host std::decay_t out of helper for orc_rt::bind_front. NFC.

### DIFF
--- a/orc-rt/include/orc-rt/bind.h
+++ b/orc-rt/include/orc-rt/bind.h
@@ -29,8 +29,10 @@ private:
   }
 
 public:
-  BoundFn(Fn &&F, BoundArgTs &&...BoundArgs)
-      : F(std::move(F)), BoundArgs(std::forward<BoundArgTs>(BoundArgs)...) {}
+  template <typename FnInit, typename... BoundArgInitTs>
+  BoundFn(FnInit &&F, BoundArgInitTs &&...BoundArgs)
+      : F(std::forward<FnInit>(F)),
+        BoundArgs(std::forward<BoundArgInitTs>(BoundArgs)...) {}
 
   template <typename... ArgTs> auto operator()(ArgTs &&...Args) {
     return callExpandingBound(std::index_sequence_for<BoundArgTs...>(),
@@ -38,16 +40,16 @@ public:
   }
 
 private:
-  std::decay_t<Fn> F;
-  std::tuple<std::decay_t<BoundArgTs>...> BoundArgs;
+  Fn F;
+  std::tuple<BoundArgTs...> BoundArgs;
 };
 
 } // namespace detail
 
 template <typename Fn, typename... BoundArgTs>
-detail::BoundFn<Fn, BoundArgTs...> bind_front(Fn &&F,
-                                              BoundArgTs &&...BoundArgs) {
-  return detail::BoundFn<Fn, BoundArgTs...>(
+detail::BoundFn<std::decay_t<Fn>, std::decay_t<BoundArgTs>...>
+bind_front(Fn &&F, BoundArgTs &&...BoundArgs) {
+  return detail::BoundFn<std::decay_t<Fn>, std::decay_t<BoundArgTs>...>(
       std::forward<Fn>(F), std::forward<BoundArgTs>(BoundArgs)...);
 }
 


### PR DESCRIPTION
The helper implementation shouldn't differ based on how it's initialized.