### PR TITLE
[orc-rt] Use perfect forwarding for scope-exit initialization.

### DIFF
--- a/orc-rt/include/orc-rt/ScopeExit.h
+++ b/orc-rt/include/orc-rt/ScopeExit.h
@@ -21,7 +21,8 @@ namespace detail {
 
 template <typename Fn> class ScopeExitRunner {
 public:
-  ScopeExitRunner(Fn &&F) : F(F) {}
+  template <typename FnInit>
+  ScopeExitRunner(FnInit &&F) : F(std::forward<FnInit>(F)) {}
   ScopeExitRunner(const ScopeExitRunner &) = delete;
   ScopeExitRunner &operator=(const ScopeExitRunner &) = delete;
   ScopeExitRunner(ScopeExitRunner &&) = delete;

--- a/orc-rt/unittests/ScopeExitTest.cpp
+++ b/orc-rt/unittests/ScopeExitTest.cpp
@@ -37,3 +37,15 @@ TEST(ScopeExitTest, Release) {
   }
   EXPECT_FALSE(ScopeExitRun);
 }
+
+TEST(ScopeExitTest, MoveOnlyFunctionObject) {
+  struct MoveOnly {
+    MoveOnly() = default;
+    MoveOnly(MoveOnly &&) = default;
+    void operator()() {}
+  };
+
+  {
+    auto OnExit = make_scope_exit(MoveOnly());
+  }
+}


### PR DESCRIPTION
Allows the use of move-only types with make_scope_exit.