### PR TITLE
[orc-rt] Add WrapperFunction::handle support for fns, fn-ptrs.

### DIFF
--- a/orc-rt/include/orc-rt/WrapperFunction.h
+++ b/orc-rt/include/orc-rt/WrapperFunction.h
@@ -121,6 +121,14 @@ struct WFCallableTraits<RetT(ArgT, ArgTs...)> {
   typedef std::tuple<ArgTs...> TailArgTuple;
 };
 
+template <typename RetT, typename... ArgTs>
+struct WFCallableTraits<RetT (*)(ArgTs...)>
+    : public WFCallableTraits<RetT(ArgTs...)> {};
+
+template <typename RetT, typename... ArgTs>
+struct WFCallableTraits<RetT (&)(ArgTs...)>
+    : public WFCallableTraits<RetT(ArgTs...)> {};
+
 template <typename ClassT, typename RetT, typename... ArgTs>
 struct WFCallableTraits<RetT (ClassT::*)(ArgTs...)>
     : public WFCallableTraits<RetT(ArgTs...)> {};


### PR DESCRIPTION
Adds support for using functions and function pointers to the WrapperFunction::handle utility.