### PR TITLE
[Support] Use CTLog2 from PointerLikeTypeTraits.h (NFC)

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1038,7 +1038,7 @@ public:
 // PointerLikeTypeTraits is specialized so it can be used with a forward-decl of
 // Expr. Verify that we got it right.
 static_assert(llvm::PointerLikeTypeTraits<Expr *>::NumLowBitsAvailable <=
-                  llvm::detail::ConstantLog2<alignof(Expr)>::value,
+                  llvm::CTLog2<alignof(Expr)>(),
               "PointerLikeTypeTraits<Expr*> assumes too much alignment.");
 
 using ConstantExprKind = Expr::ConstantExprKind;


### PR DESCRIPTION
This patch replaces ConstantLog2 with CTLog2.  ConstantLog2 only
operates on alignment values, making the two interchangeable in this
context.  CTLog2 also has the benefit of a static_assert that ensures
its parameter is a power of two.
