### PR TITLE
[orc-rt] Simplify construction of SPSSerializableExpected from values.

### DIFF
--- a/orc-rt/include/orc-rt/SimplePackedSerialization.h
+++ b/orc-rt/include/orc-rt/SimplePackedSerialization.h
@@ -599,15 +599,11 @@ template <typename SPSTagT> class SPSExpected;
 /// See SPSSerializableError for more details.
 template <typename T> struct SPSSerializableExpected {
   SPSSerializableExpected() = default;
-  SPSSerializableExpected(Expected<T> E) {
+  explicit SPSSerializableExpected(Expected<T> E) {
     if (E)
       Val = decltype(Val)(std::in_place_index<0>, std::move(*E));
     else
       Val = decltype(Val)(std::in_place_index<1>, toString(E.takeError()));
-  }
-  SPSSerializableExpected(Error E) {
-    assert(E && "Cannot create Expected from Error::success()");
-    Val = decltype(Val)(std::in_place_index<1>, toString(std::move(E)));
   }
 
   Expected<T> toExpected() {
@@ -621,12 +617,17 @@ template <typename T> struct SPSSerializableExpected {
 
 template <typename T>
 SPSSerializableExpected<T> toSPSSerializableExpected(Expected<T> E) {
-  return std::move(E);
+  return SPSSerializableExpected<T>(std::move(E));
+}
+
+template <typename T>
+SPSSerializableExpected<T> toSPSSerializableExpected(T Val) {
+  return SPSSerializableExpected<T>(std::move(Val));
 }
 
 template <typename T>
 SPSSerializableExpected<T> toSPSSerializableExpected(Error E) {
-  return std::move(E);
+  return SPSSerializableExpected<T>(std::move(E));
 }
 
 template <typename SPSTagT, typename T>

--- a/orc-rt/unittests/SimplePackedSerializationTest.cpp
+++ b/orc-rt/unittests/SimplePackedSerializationTest.cpp
@@ -223,9 +223,29 @@ TEST(SimplePackedSerializationTest, SerializeErrorFailure) {
   EXPECT_EQ(toString(SE.toError()), std::string("test error message"));
 }
 
-TEST(SimplePackedSerializationTest, SerializeExpectedSuccess) {
+TEST(SimplePackedSerializationTest, SerializeExpectedSuccessViaExpected) {
   auto B = spsSerialize<SPSArgList<SPSExpected<uint32_t>>>(
       toSPSSerializableExpected(Expected<uint32_t>(42U)));
+  if (!B) {
+    ADD_FAILURE() << "Unexpected failure to serialize expected-success value";
+    return;
+  }
+  SPSSerializableExpected<uint32_t> SE;
+  if (!spsDeserialize<SPSArgList<SPSExpected<uint32_t>>>(*B, SE)) {
+    ADD_FAILURE() << "Unexpected failure to deserialize expected-success value";
+    return;
+  }
+
+  auto E = SE.toExpected();
+  if (E)
+    EXPECT_EQ(*E, 42U);
+  else
+    ADD_FAILURE() << "Unexpected failure value";
+}
+
+TEST(SimplePackedSerializationTest, SerializeExpectedSuccessViaValue) {
+  auto B = spsSerialize<SPSArgList<SPSExpected<uint32_t>>>(
+      toSPSSerializableExpected(uint32_t(42U)));
   if (!B) {
     ADD_FAILURE() << "Unexpected failure to serialize expected-success value";
     return;


### PR DESCRIPTION
Adds an overload of toSPSSerializableExpected that takes a plain T value and returns an SPSSerializableExpected<T>. This will reduce some boilerplate when creating SPSSerializableExpected values.