### PR TITLE
[mlir][vector] Remove hooks deprecated pre Release/21 branch

### DIFF
--- a/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
+++ b/mlir/include/mlir/Dialect/Vector/IR/VectorOps.td
@@ -972,10 +972,6 @@ def Vector_ScalableInsertOp :
     VectorType getDestVectorType() {
       return ::llvm::cast<VectorType>(getDest().getType());
     }
-    /// Wrapper for getResult, which replaced getRes.
-    [[deprecated("Use getResult instead!")]] ::mlir::Value getRes() {
-      return getResult();
-    }
   }];
 }
 
@@ -1026,10 +1022,6 @@ def Vector_ScalableExtractOp :
     }
     VectorType getResultVectorType() {
       return ::llvm::cast<VectorType>(getResult().getType());
-    }
-    /// Wrapper for getResult, which replaced getRes.
-    [[deprecated("Use getResult instead!")]] ::mlir::Value getRes() {
-      return getResult();
     }
   }];
 }
@@ -1084,10 +1076,6 @@ def Vector_InsertStridedSliceOp :
       return llvm::any_of(getStrides(), [](Attribute attr) {
         return ::llvm::cast<IntegerAttr>(attr).getInt() != 1;
       });
-    }
-    /// Wrapper for getResult, which replaced getRes.
-    [[deprecated("Use getResult instead!")]] ::mlir::Value getRes() {
-      return getResult();
     }
   }];
 

--- a/mlir/include/mlir/Interfaces/VectorInterfaces.td
+++ b/mlir/include/mlir/Interfaces/VectorInterfaces.td
@@ -187,12 +187,6 @@ def VectorTransferOpInterface : OpInterface<"VectorTransferOpInterface"> {
       return inBounds;
     }
 
-    /// Wrapper for getBase, which replaced getSource.
-    [[deprecated("Use getBase instead!")]]
-    ::mlir::Value getSource() {
-        return $_op.getBase();
-    }
-
     /// Return the number of leading shaped dimensions (of the "source" operand)
     /// that do not participate in the permutation map.
     unsigned getLeadingShapedRank() {


### PR DESCRIPTION
As mentioned on Discourse,
  * https://discourse.llvm.org/t/psa-vector-standardise-operand-naming

I am removing the deprecated Vector hooks following the creation of the
release/21 branch.

The release/21 branch was created on July 15 (about two months ago) as noted in
the LLVM 21.x release announcement
  * https://discourse.llvm.org/t/llvm-21-x-release-information-and-branching