### PR TITLE
AMDGPU: Fix using unaligned VGPR in literal test

### DIFF
--- a/llvm/test/MC/AMDGPU/vop3-literal.s
+++ b/llvm/test/MC/AMDGPU/vop3-literal.s
@@ -488,7 +488,7 @@ v_div_fmas_f64 v[6:7], 0x12345678, 0x12345678, 0x12345678
 // GFX1250: v_div_fmas_f64 v[6:7], 0x12345678, 0x12345678, 0x12345678 ; encoding: [0x06,0x00,0x38,0xd6,0xff,0xfe,0xfd,0x03,0x78,0x56,0x34,0x12]
 // GFX9-ERR: :[[@LINE-3]]:48: error: literal operands are not supported
 
-v_div_fmas_f64 v[5:6], v[1:2], 0x123457, 0x123456
+v_div_fmas_f64 v[4:5], v[2:3], 0x123457, 0x123456
 // GFX9-ERR: :[[@LINE-1]]:42: error: literal operands are not supported
 // GFX10-ERR: :[[@LINE-2]]:42: error: only one unique literal operand is allowed
 // GFX1250-ERR: :[[@LINE-3]]:42: error: only one unique literal operand is allowed
@@ -503,7 +503,7 @@ v_ldexp_f64 v[6:7], 0.12345, 0x3fbf9a6b
 // GFX1250: v_ldexp_f64 v[6:7], 0x3fbf9a6b, 0x3fbf9a6b ; encoding: [0x06,0x00,0x2b,0xd7,0xff,0xfe,0x01,0x00,0x6b,0x9a,0xbf,0x3f]
 // GFX9-ERR: :[[@LINE-3]]:30: error: literal operands are not supported
 
-v_ldexp_f64 v[5:6], 0.12345, 0x3fbf9a6c
+v_ldexp_f64 v[4:5], 0.12345, 0x3fbf9a6c
 // GFX9-ERR: :[[@LINE-1]]:30: error: literal operands are not supported
 // GFX10-ERR: :[[@LINE-2]]:30: error: only one unique literal operand is allowed
 // GFX1250-ERR: :[[@LINE-3]]:30: error: only one unique literal operand is allowed


### PR DESCRIPTION
Make sure the tested error is the literal error, not
for unaligned registers.