### PR TITLE
[NFC][GlobalISel] Pass `APInt` by const reference

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/MIPatternMatch.h
@@ -193,7 +193,7 @@ m_GFCstOrSplat(std::optional<FPValueAndVReg> &FPValReg) {
 /// Matcher for a specific constant value.
 struct SpecificConstantMatch {
   APInt RequestedVal;
-  SpecificConstantMatch(const APInt RequestedVal)
+  SpecificConstantMatch(const APInt &RequestedVal)
       : RequestedVal(RequestedVal) {}
   bool match(const MachineRegisterInfo &MRI, Register Reg) {
     APInt MatchedVal;

--- a/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/Utils.h
@@ -463,7 +463,8 @@ LLVM_ABI bool isBuildVectorConstantSplat(const Register Reg,
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
 LLVM_ABI bool isBuildVectorConstantSplat(const Register Reg,
                                          const MachineRegisterInfo &MRI,
-                                         APInt SplatValue, bool AllowUndef);
+                                         const APInt &SplatValue,
+                                         bool AllowUndef);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
@@ -475,7 +476,8 @@ LLVM_ABI bool isBuildVectorConstantSplat(const MachineInstr &MI,
 /// G_BUILD_VECTOR_TRUNC where all of the elements are \p SplatValue or undef.
 LLVM_ABI bool isBuildVectorConstantSplat(const MachineInstr &MI,
                                          const MachineRegisterInfo &MRI,
-                                         APInt SplatValue, bool AllowUndef);
+                                         const APInt &SplatValue,
+                                         bool AllowUndef);
 
 /// Return true if the specified instruction is a G_BUILD_VECTOR or
 /// G_BUILD_VECTOR_TRUNC where all of the elements are 0 or undef.

--- a/llvm/lib/CodeGen/GlobalISel/Utils.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/Utils.cpp
@@ -1409,7 +1409,8 @@ bool llvm::isBuildVectorConstantSplat(const Register Reg,
 
 bool llvm::isBuildVectorConstantSplat(const Register Reg,
                                       const MachineRegisterInfo &MRI,
-                                      APInt SplatValue, bool AllowUndef) {
+                                      const APInt &SplatValue,
+                                      bool AllowUndef) {
   if (auto SplatValAndReg = getAnyConstantSplat(Reg, MRI, AllowUndef)) {
     if (SplatValAndReg->Value.getBitWidth() < SplatValue.getBitWidth())
       return APInt::isSameValue(
@@ -1431,7 +1432,8 @@ bool llvm::isBuildVectorConstantSplat(const MachineInstr &MI,
 
 bool llvm::isBuildVectorConstantSplat(const MachineInstr &MI,
                                       const MachineRegisterInfo &MRI,
-                                      APInt SplatValue, bool AllowUndef) {
+                                      const APInt &SplatValue,
+                                      bool AllowUndef) {
   return isBuildVectorConstantSplat(MI.getOperand(0).getReg(), MRI, SplatValue,
                                     AllowUndef);
 }


### PR DESCRIPTION
Change `SpecificConstantMatch` constructor and `isBuildVectorConstantSplat` overloads to take `const APInt&` instead of by value to avoid unnecessary copies, especially for wide integers.