### PR TITLE
[Flang][Utils] Fix BUILD_SHARED_LIBS build

### DIFF
--- a/flang/lib/Utils/CMakeLists.txt
+++ b/flang/lib/Utils/CMakeLists.txt
@@ -17,6 +17,8 @@ add_flang_library(FortranUtils
   LINK_LIBS
   FIRDialect
   FIRBuilder
+  FortranEvaluate
+  FortranSupport
   HLFIRDialect
  
   MLIR_LIBS


### PR DESCRIPTION
Required for `BUILD_SHARED_LIBS=ON` builds with optimizations disabled for the new FortranUtils library.

Also see #150027 #155422