### PR TITLE
[RegAlloc] Add scaffold for -regalloc=segmenttree (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/RegAllocSegmentTree.h
+++ b/llvm/include/llvm/CodeGen/RegAllocSegmentTree.h
@@ -1,0 +1,17 @@
+//===- RegAllocSegmentTree.h - RA segtree scaffold --------------*- C++ -*-===//
+//
+// This file declares createRegAllocSegmentTree() factory (scaffold only).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CODEGEN_REGALLOCSEGMENTTREE_H
+#define LLVM_CODEGEN_REGALLOCSEGMENTTREE_H
+
+namespace llvm {
+class FunctionPass;
+
+// Factory (for -regalloc=segtre). For now it delegates to Greedy (NFC).
+FunctionPass *createRegAllocSegmentTree();
+} // end namespace llvm
+
+#endif

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -113,6 +113,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeRABasicPass(Registry);
   initializeRAGreedyLegacyPass(Registry);
   initializeRegAllocFastPass(Registry);
+  // initializeRegAllocSegmentTreePass(Registry);  // Add this line
   initializeRegUsageInfoCollectorLegacyPass(Registry);
   initializeRegUsageInfoPropagationLegacyPass(Registry);
   initializeRegisterCoalescerLegacyPass(Registry);

--- a/llvm/lib/CodeGen/RegAllocSegmentTree.cpp
+++ b/llvm/lib/CodeGen/RegAllocSegmentTree.cpp
@@ -1,0 +1,21 @@
+//===- RegAllocSegmentTree.cpp - RA segtree scaffold ----------------------===//
+//
+// Scaffold only: register -regalloc=segmenttree that delegates to Greedy (NFC).
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CodeGen/RegAllocSegmentTree.h"
+#include "llvm/CodeGen/RegAllocRegistry.h"
+
+using namespace llvm;
+
+// 工廠：目前直接委派回 Greedy（零行為變更）
+FunctionPass *llvm::createRegAllocSegmentTree() {
+  extern FunctionPass *createGreedyRegisterAllocator();
+  return createGreedyRegisterAllocator();
+}
+
+// 把選項掛進 -regalloc= 名單（名稱、描述、工廠）
+static RegisterRegAlloc
+    RAReg("segmenttree", "Segment Tree Register Allocator (scaffold)",
+          createRegAllocSegmentTree);


### PR DESCRIPTION
Adds a minimal factory + regalloc registration for . Currently delegates to Greedy allocator. No functional change.This patch introduces a scaffold for a new register allocator option
`-regalloc=segmenttree`, which currently delegates to the Greedy allocator.
No functional change is intended.

Motivation:
- Provide a separate regalloc entry point for future work on a
  segment-tree-based allocator.
- Enable early benchmarking and integration testing under a new mode.

Implementation:
- Added `RegAllocSegmentTree.cpp` / `.h` containing a factory function
  `createRegAllocSegmentTree()`.
- Registered this allocator in `RegisterRegAlloc` so that
  `llc -regalloc=segmenttree` is recognized.
- Hooked up pass initialization in `CodeGen.cpp`.

Testing:
- Verified that `llc -regalloc=segmenttree` produces identical codegen
  to `-regalloc=greedy`.

Future work:
- This is step 1 of a planned series to implement a segment-tree-based
  register allocator, targeting O(V · R · A · S · log E) allocation time
  complexity.