### PR TITLE
Revert "Mips: Force 64bit subtarget feature to be set for ABI options (#157446)"

### DIFF
--- a/llvm/lib/Target/Mips/MipsSubtarget.cpp
+++ b/llvm/lib/Target/Mips/MipsSubtarget.cpp
@@ -245,20 +245,10 @@ CodeGenOptLevel MipsSubtarget::getOptLevelToEnablePostRAScheduler() const {
 MipsSubtarget &
 MipsSubtarget::initializeSubtargetDependencies(StringRef CPU, StringRef FS,
                                                const TargetMachine &TM) {
-  const Triple &TT = TM.getTargetTriple();
-  StringRef CPUName = MIPS_MC::selectMipsCPU(TT, CPU);
-
-  std::string FullFS;
-  if (getABI().ArePtrs64bit()) {
-    FullFS = "+ptr64";
-    if (!FS.empty())
-      FullFS = (Twine(FullFS) + "," + FS).str();
-  } else {
-    FullFS = FS.str();
-  }
+  StringRef CPUName = MIPS_MC::selectMipsCPU(TM.getTargetTriple(), CPU);
 
   // Parse features string.
-  ParseSubtargetFeatures(CPUName, /*TuneCPU=*/CPUName, FullFS);
+  ParseSubtargetFeatures(CPUName, /*TuneCPU*/ CPUName, FS);
   // Initialize scheduling itinerary for the specified CPU.
   InstrItins = getInstrItineraryForCPU(CPUName);
 


### PR DESCRIPTION
This reverts commit 7768cca2c6617523e38ba9a8a3e8366752992ec5.

This is less necessary after 7f4c297e94dd604d66429dd0eb85c79e4d8c50a9