### PR TITLE
[TableGen][DecoderEmitter] Report all decoding conflicts

### DIFF
--- a/llvm/test/TableGen/FixedLenDecoderEmitter/conflict.td
+++ b/llvm/test/TableGen/FixedLenDecoderEmitter/conflict.td
@@ -9,27 +9,63 @@ def MyTarget : Target { let InstructionSet = MyTargetISA; }
 def R0 : Register<"r0"> { let Namespace = "MyTarget"; }
 def GPR32 : RegisterClass<"MyTarget", [i32], 32, (add R0)>;
 
+def X0 : Register<"x0"> { let Namespace = "MyTarget"; }
+def GPR64 : RegisterClass<"MyTarget", [i64], 64, (add X0)>;
+
 class I<dag OOps, dag IOps, list<dag> Pat>
   : Instruction {
   let Namespace = "MyTarget";
   let OutOperandList = OOps;
   let InOperandList = IOps;
   let Pattern = Pat;
+  let Size = 4;
   bits<32> Inst;
   bits<32> SoftFail;
 }
 
+// Assume there is a 2 bit encoding for the dst and src register.
 def A : I<(outs GPR32:$dst), (ins GPR32:$src1), []> {
-  let Size = 4;
-  let Inst{31...0} = 0;
+  bits<2> dst;
+  bits<2> src1;
+  let Inst{31...4} = 0;
+  let Inst{1...0} = dst;
+  let Inst{3...2} = src1;
 }
+
 def B : I<(outs GPR32:$dst), (ins GPR32:$src1), []> {
-  let Size = 4;
-  let Inst{31...0} = 0;
+  bits<2> dst;
+  bits<2> src1;
+  let Inst{31...4} = 0;
+  let Inst{1...0} = dst;
+  let Inst{3...2} = src1;
+}
+
+def C : I<(outs GPR64:$dst), (ins GPR64:$src1), []> {
+  bits<2> dst;
+  bits<2> src1;
+  let Inst{31...4} = 1;
+  let Inst{1...0} = dst;
+  let Inst{3...2} = src1;
+}
+
+def D : I<(outs GPR64:$dst), (ins GPR64:$src1), []> {
+  bits<2> dst;
+  bits<2> src1;
+  let Inst{31...4} = 1;
+  let Inst{1...0} = dst;
+  let Inst{3...2} = src1;
 }
 
 // CHECK: Decoding Conflict:
 // CHECK:     ................................
-// CHECK:     00000000000000000000000000000000
-// CHECK:     00000000000000000000000000000000  A
-// CHECK:     00000000000000000000000000000000  B
+// CHECK:     0000000000000000000000000000....
+// CHECK:     0000000000000000000000000000____  A
+// CHECK:     0000000000000000000000000000____  B
+
+// CHECK: Decoding Conflict:
+// CHECK:     ................................
+// CHECK:     0000000000000000000000000001....
+// CHECK:     0000000000000000000000000001____  C
+// CHECK:     0000000000000000000000000001____  D
+
+// CHECK: Decoding conflict encountered

--- a/llvm/test/TableGen/FixedLenDecoderEmitter/var-len-conflict-2.td
+++ b/llvm/test/TableGen/FixedLenDecoderEmitter/var-len-conflict-2.td
@@ -10,16 +10,14 @@ class I : Instruction {
 
 // Check pretty printing of decoding conflicts.
 
-// CHECK:      {{^}}Decoding Conflict:
-// CHECK-NEXT: {{^}}                    ........
-// CHECK-NEXT: {{^}}            ..............11
-// CHECK-NEXT: {{^}}            .......0......11
-// CHECK-NEXT: {{^}}            _______0______11  I16_0
-// CHECK-NEXT: {{^}}            _______0______11  I16_1
-// CHECK-NEXT: {{^}}    _______0_______0______11  I24_0
+// CHECK:      Decoding Conflict:
+// CHECK-NEXT:             ................
+// CHECK-NEXT:             ..............11
+// CHECK-NEXT:             .......0......11
+// CHECK-NEXT:             _______0______11  I16_0
+// CHECK-NEXT:             _______0______11  I16_1
+// CHECK-NEXT:     _______0_______0______11  I24_0
 
-def I8_0  : I { dag Inst = (descend (operand "$op", 6), 0b00); }
-def I8_1  : I { dag Inst = (descend (operand "$op", 6), 0b01); }
 def I16_0 : I { dag Inst = (descend (operand "$op2", 7), 0b0,
                                     (operand "$op", 6), 0b11); }
 def I16_1 : I { dag Inst = (descend (operand "$op2", 7), 0b0,

--- a/llvm/test/TableGen/FixedLenDecoderEmitter/var-len-conflict-2.td
+++ b/llvm/test/TableGen/FixedLenDecoderEmitter/var-len-conflict-2.td
@@ -10,13 +10,13 @@ class I : Instruction {
 
 // Check pretty printing of decoding conflicts.
 
-// CHECK:      Decoding Conflict:
-// CHECK-NEXT:             ................
-// CHECK-NEXT:             ..............11
-// CHECK-NEXT:             .......0......11
-// CHECK-NEXT:             _______0______11  I16_0
-// CHECK-NEXT:             _______0______11  I16_1
-// CHECK-NEXT:     _______0_______0______11  I24_0
+// CHECK:      {{^}}Decoding Conflict:
+// CHECK-NEXT: {{^}}            ................
+// CHECK-NEXT: {{^}}            ..............11
+// CHECK-NEXT: {{^}}            .......0......11
+// CHECK-NEXT: {{^}}            _______0______11  I16_0
+// CHECK-NEXT: {{^}}            _______0______11  I16_1
+// CHECK-NEXT: {{^}}    _______0_______0______11  I24_0
 
 def I16_0 : I { dag Inst = (descend (operand "$op2", 7), 0b0,
                                     (operand "$op", 6), 0b11); }

--- a/llvm/test/TableGen/FixedLenDecoderEmitter/var-len-conflict-2.td
+++ b/llvm/test/TableGen/FixedLenDecoderEmitter/var-len-conflict-2.td
@@ -11,13 +11,15 @@ class I : Instruction {
 // Check pretty printing of decoding conflicts.
 
 // CHECK:      {{^}}Decoding Conflict:
-// CHECK-NEXT: {{^}}            ................
+// CHECK-NEXT: {{^}}                    ........
 // CHECK-NEXT: {{^}}            ..............11
 // CHECK-NEXT: {{^}}            .......0......11
 // CHECK-NEXT: {{^}}            _______0______11  I16_0
 // CHECK-NEXT: {{^}}            _______0______11  I16_1
 // CHECK-NEXT: {{^}}    _______0_______0______11  I24_0
 
+def I8_0  : I { dag Inst = (descend (operand "$op", 6), 0b00); }
+def I8_1  : I { dag Inst = (descend (operand "$op", 6), 0b01); }
 def I16_0 : I { dag Inst = (descend (operand "$op2", 7), 0b0,
                                     (operand "$op", 6), 0b11); }
 def I16_1 : I { dag Inst = (descend (operand "$op2", 7), 0b0,

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -563,7 +563,7 @@ public:
   }
 
   /// Returns true if any decoding conflicts were encountered.
-  bool getHasConflict() const { return HasConflict; }
+  bool hasConflict() const { return HasConflict; }
 
 private:
   /// Applies the given filter to the set of encodings this FilterChooser
@@ -2586,7 +2586,7 @@ template <typename T> constexpr uint32_t InsnBitWidth = 0;
 
       // Emit the decoder for this (namespace, hwmode, width) combination.
       FilterChooser FC(Encodings, EncodingIDs);
-      HasConflict |= FC.getHasConflict();
+      HasConflict |= FC.hasConflict();
       // Skip emitting table entries if a conflict has been detected.
       if (HasConflict)
         continue;


### PR DESCRIPTION
Do not exit when the first decoding conflict is encountered. Instead record the conflict and continue to report any additional decoding conflicts and exit fatally after all instructions have been processed.