### PR TITLE
[LangRef] Specify that load of alloca outside lifetime is poison

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -3388,6 +3388,10 @@ the object's lifetime. A stack object's lifetime can be explicitly specified
 using :ref:`llvm.lifetime.start <int_lifestart>` and
 :ref:`llvm.lifetime.end <int_lifeend>` intrinsic function calls.
 
+As an exception to the above, loading from a stack object outside its lifetime
+is not undefined behavior and returns a poison value instead. Storing to it is
+still undefined behavior.
+
 .. _pointeraliasing:
 
 Pointer Aliasing Rules


### PR DESCRIPTION
We consider (in bounds) loads from allocas to always be speculatable, without taking lifetimes into account. This means that such loads cannot be immediate UB. Specify them as returning poison instead.

Due to stack coloring, such a load may end up loading from a different alloca, but that's compatible with poison.

Stores are still UB, but that's a much more narrow problem (I think the only transform violating that part is store scalar promotion in LICM).

Fixes https://github.com/llvm/llvm-project/issues/141892 (and probably a bunch of others...)