### PR TITLE
[offload] Fix finding libomptarget in runtimes build

### DIFF
--- a/offload/test/lit.cfg
+++ b/offload/test/lit.cfg
@@ -83,6 +83,7 @@ config.test_format = lit.formats.ShTest()
 config.test_flags = " -I " + config.test_source_root + \
     " -I " + config.omp_header_directory + \
     " -L " + config.library_dir + \
+    " -L " + config.llvm_library_intdir + \
     " -L " + config.llvm_lib_directory
 
 # compiler specific flags
@@ -165,6 +166,7 @@ else: # Unices
         config.test_flags += " -nogpulib"
     config.test_flags += " -Wl,-rpath," + config.library_dir
     config.test_flags += " -Wl,-rpath," + config.omp_host_rtl_directory
+    config.test_flags += " -Wl,-rpath," + config.llvm_library_intdir
     config.test_flags += " -Wl,-rpath," + config.llvm_lib_directory
     if config.cuda_libdir:
         config.test_flags += " -Wl,-rpath," + config.cuda_libdir


### PR DESCRIPTION
Per the logic in top-level CMakeLists, `libomptarget` is placed into `LLVM_LIBRARY_OUTPUT_INTDIR` when this variable is set.  Adjust the test logic to include this directory in `-L` and `-Wl,-rpath` arguments as well, in order to fix finding tests when building via the `runtimes` top-level directory.