### PR TITLE
[NFC][LLVM] Fix link in Maintainers.md

### DIFF
--- a/llvm/Maintainers.md
+++ b/llvm/Maintainers.md
@@ -504,7 +504,7 @@ Some subprojects maintain their own list of per-component maintainers.
 
 [LLD maintainers](https://github.com/llvm/llvm-project/blob/main/lld/Maintainers.md)
 
-[LLDB maintainers](https://github.com/llvm/llvm-project/blob/main/lldb/Maintainers.rst)
+[LLDB maintainers](https://github.com/llvm/llvm-project/blob/main/lldb/Maintainers.md)
 
 [LLVM OpenMP Library maintainers](https://github.com/llvm/llvm-project/blob/main/openmp/Maintainers.md)
 


### PR DESCRIPTION
Fixed link to LLDB maintainers list (format was changed in [48ace3f](https://github.com/llvm/llvm-project/commit/48ace3f872e4d844471cd1e821502dece3fe2bc0)). 