### PR TITLE
[libc] Update some __builtin_* usage to be compatible with MSVC.

### DIFF
--- a/libc/src/__support/CPP/bit.h
+++ b/libc/src/__support/CPP/bit.h
@@ -104,10 +104,16 @@ countr_zero(T value) {
 }
 #if __has_builtin(__builtin_ctzs)
 ADD_SPECIALIZATION(countr_zero, unsigned short, __builtin_ctzs)
-#endif
+#endif // __has_builtin(__builtin_ctzs)
+#if __has_builtin(__builtin_ctz)
 ADD_SPECIALIZATION(countr_zero, unsigned int, __builtin_ctz)
+#endif // __has_builtin(__builtin_ctz)
+#if __has_builtin(__builtin_ctzl)
 ADD_SPECIALIZATION(countr_zero, unsigned long, __builtin_ctzl)
+#endif // __has_builtin(__builtin_ctzl)
+#if __has_builtin(__builtin_ctzll)
 ADD_SPECIALIZATION(countr_zero, unsigned long long, __builtin_ctzll)
+#endif // __has_builtin(__builtin_ctzll)
 #endif // __has_builtin(__builtin_ctzg)
 
 /// Count number of 0's from the most significant bit to the least
@@ -143,10 +149,16 @@ countl_zero(T value) {
 }
 #if __has_builtin(__builtin_clzs)
 ADD_SPECIALIZATION(countl_zero, unsigned short, __builtin_clzs)
-#endif
+#endif // __has_builtin(__builtin_clzs)
+#if __has_builtin(__builtin_clz)
 ADD_SPECIALIZATION(countl_zero, unsigned int, __builtin_clz)
+#endif // __has_builtin(__builtin_clz)
+#if __has_builtin(__builtin_clzl)
 ADD_SPECIALIZATION(countl_zero, unsigned long, __builtin_clzl)
+#endif // __has_builtin(__builtin_clzl)
+#if __has_builtin(__builtin_clzll)
 ADD_SPECIALIZATION(countl_zero, unsigned long long, __builtin_clzll)
+#endif // __has_builtin(__builtin_clzll)
 #endif // __has_builtin(__builtin_clzg)
 
 #undef ADD_SPECIALIZATION
@@ -283,11 +295,17 @@ popcount(T value) {
   [[nodiscard]] LIBC_INLINE constexpr int popcount<TYPE>(TYPE value) {         \
     return BUILTIN(value);                                                     \
   }
+#if __has_builtin(__builtin_popcount)
 ADD_SPECIALIZATION(unsigned char, __builtin_popcount)
 ADD_SPECIALIZATION(unsigned short, __builtin_popcount)
 ADD_SPECIALIZATION(unsigned, __builtin_popcount)
+#endif // __builtin_popcount
+#if __has_builtin(__builtin_popcountl)
 ADD_SPECIALIZATION(unsigned long, __builtin_popcountl)
+#endif // __builtin_popcountl
+#if __has_builtin(__builtin_popcountll)
 ADD_SPECIALIZATION(unsigned long long, __builtin_popcountll)
+#endif // __builtin_popcountll
 #endif // __builtin_popcountg
 #undef ADD_SPECIALIZATION
 

--- a/libc/src/__support/macros/CMakeLists.txt
+++ b/libc/src/__support/macros/CMakeLists.txt
@@ -4,6 +4,9 @@ add_header_library(
   config
   HDRS
     config.h
+  DEPENDS
+    libc.src.__support.macros.properties.architectures
+    libc.src.__support.macros.properties.compiler
 )
 
 add_header_library(

--- a/libc/src/__support/macros/config.h
+++ b/libc/src/__support/macros/config.h
@@ -13,6 +13,13 @@
 #ifndef LLVM_LIBC_SRC___SUPPORT_MACROS_CONFIG_H
 #define LLVM_LIBC_SRC___SUPPORT_MACROS_CONFIG_H
 
+#include "src/__support/macros/properties/architectures.h"
+#include "src/__support/macros/properties/compiler.h"
+
+#ifdef LIBC_COMPILER_IS_MSVC
+#include <intrin.h>
+#endif // LIBC_COMPILER_IS_MSVC
+
 // Workaround for compilers that do not support builtin detection.
 // FIXME: This is only required for the GPU portion which should be moved.
 #ifndef __has_builtin
@@ -26,6 +33,19 @@
 #else
 #define LIBC_HAS_FEATURE(f) 0
 #endif
+
+#ifdef LIBC_COMPILER_IS_MSVC
+
+// __builtin_trap replacement
+#ifdef LIBC_TARGET_ARCH_IS_X86
+#define __builtin_trap __ud2
+#else // arm64
+#define __builtin_trap() __break(1)
+#endif
+
+#define __builtin_expect(value, expectation) (false)
+
+#endif // LIBC_COMPILER_IS_MSVC
 
 #ifdef __clang__
 // Declare a LIBC_NAMESPACE with hidden visibility. `namespace

--- a/libc/src/__support/macros/config.h
+++ b/libc/src/__support/macros/config.h
@@ -43,7 +43,7 @@
 #define __builtin_trap() __break(1)
 #endif
 
-#define __builtin_expect(value, expectation) (false)
+#define __builtin_expect(value, expectation) (value)
 
 #endif // LIBC_COMPILER_IS_MSVC
 

--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -117,6 +117,10 @@ libc_support_library(
 libc_support_library(
     name = "__support_macros_config",
     hdrs = ["src/__support/macros/config.h"],
+    deps = [
+        "__support_macros_properties_architectures",
+        "__support_macros_properties_compiler",
+    ],
 )
 
 ################################# Include Files ################################


### PR DESCRIPTION
__builtin_trap, __builtin_expect, __builtin_ctz*, __builtin_clz*, __builtin_popcount*.