### PR TITLE
[lldb][test] Re-enable `TestRerunAndExprDylib.py`

### DIFF
--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -20,9 +20,9 @@ def isUbuntu18_04():
             with open(path) as f:
                 contents = f.read()
             if "Ubuntu 18.04" in contents:
-                return True
+                return "Ubuntu 18.04 is not supported."
 
-    return False
+    return None
 
 
 class TestRerunExprDylib(TestBase):


### PR DESCRIPTION
the `skipTestIfFn` requires a function that return a string to skip or None to run the test. The `isUbuntu18_04` function returns a bool and the test is skipped on all platforms.


https://github.com/llvm/llvm-project/blob/25ebdfe0ab202a6cb30232d84bc5838439fd67d5/lldb/packages/Python/lldbsuite/test/decorators.py#L145-L157