### PR TITLE
[LLVM] Prefer octal to hex for printf

### DIFF
--- a/llvm/test/tools/llvm-cgdata/empty.test
+++ b/llvm/test/tools/llvm-cgdata/empty.test
@@ -29,9 +29,9 @@ RUN: llvm-cgdata --convert %t_emptyheader.cgdata --format text | count 0
 #   uint64_t OutlinedHashTreeOffset;
 #   uint64_t StableFunctionMapOffset;
 # }
-RUN: printf '\xffcgdata\x81' > %t_header.cgdata
-RUN: printf '\x04\x00\x00\x00' >> %t_header.cgdata
-RUN: printf '\x00\x00\x00\x00' >> %t_header.cgdata
-RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_header.cgdata
-RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_header.cgdata
+RUN: printf '\377cgdata\201' > %t_header.cgdata
+RUN: printf '\004\000\000\000' >> %t_header.cgdata
+RUN: printf '\000\000\000\000' >> %t_header.cgdata
+RUN: printf '\040\000\000\000\000\000\000\000' >> %t_header.cgdata
+RUN: printf '\040\000\000\000\000\000\000\000' >> %t_header.cgdata
 RUN: diff %t_header.cgdata %t_emptyheader.cgdata

--- a/llvm/test/tools/llvm-cgdata/error.test
+++ b/llvm/test/tools/llvm-cgdata/error.test
@@ -13,29 +13,29 @@ RUN: not llvm-cgdata --show %t_empty.cgdata 2>&1 | FileCheck %s --check-prefix=E
 EMPTY: {{.}}cgdata: empty codegen data
 
 # Not a magic.
-RUN: printf '\xff' > %t_malformed.cgdata
+RUN: printf '\377' > %t_malformed.cgdata
 RUN: not llvm-cgdata --show %t_malformed.cgdata 2>&1 | FileCheck %s --check-prefix=MALFORMED
 MALFORMED: {{.}}cgdata: malformed codegen data
 
 # The minimum header size is 24.
-RUN: printf '\xffcgdata\x81' > %t_corrupt.cgdata
+RUN: printf '\377cgdata\201' > %t_corrupt.cgdata
 RUN: not llvm-cgdata --show %t_corrupt.cgdata 2>&1 | FileCheck %s  --check-prefix=CORRUPT
 CORRUPT: {{.}}cgdata: invalid codegen data (file header is corrupt)
 
 # The current version 4 while the header says 5.
-RUN: printf '\xffcgdata\x81' > %t_version.cgdata
-RUN: printf '\x05\x00\x00\x00' >> %t_version.cgdata
-RUN: printf '\x00\x00\x00\x00' >> %t_version.cgdata
-RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_version.cgdata
-RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_version.cgdata
+RUN: printf '\377cgdata\201' > %t_version.cgdata
+RUN: printf '\005\000\000\000' >> %t_version.cgdata
+RUN: printf '\000\000\000\000' >> %t_version.cgdata
+RUN: printf '\040\000\000\000\000\000\000\000' >> %t_version.cgdata
+RUN: printf '\040\000\000\000\000\000\000\000' >> %t_version.cgdata
 RUN: not llvm-cgdata --show %t_version.cgdata 2>&1 | FileCheck %s  --check-prefix=BAD_VERSION
 BAD_VERSION: {{.}}cgdata: unsupported codegen data version
 
 # Header says an outlined hash tree, but the file ends after the header.
-RUN: printf '\xffcgdata\x81' > %t_eof.cgdata
-RUN: printf '\x02\x00\x00\x00' >> %t_eof.cgdata
-RUN: printf '\x01\x00\x00\x00' >> %t_eof.cgdata
-RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_eof.cgdata
-RUN: printf '\x20\x00\x00\x00\x00\x00\x00\x00' >> %t_eof.cgdata
+RUN: printf '\377cgdata\201' > %t_eof.cgdata
+RUN: printf '\002\000\000\000' >> %t_eof.cgdata
+RUN: printf '\001\000\000\000' >> %t_eof.cgdata
+RUN: printf '\040\000\000\000\000\000\000\000' >> %t_eof.cgdata
+RUN: printf '\040\000\000\000\000\000\000\000' >> %t_eof.cgdata
 RUN: not llvm-cgdata --show %t_eof.cgdata 2>&1 | FileCheck %s  --check-prefix=EOF
 EOF: {{.}}cgdata: end of File

--- a/llvm/test/tools/llvm-gsymutil/X86/elf-dwarf.yaml
+++ b/llvm/test/tools/llvm-gsymutil/X86/elf-dwarf.yaml
@@ -5,7 +5,7 @@
 # RUN: yaml2obj %s -o %t
 # RUN: llvm-gsymutil --convert %t -o %t.gsym 2>&1 | FileCheck %s --check-prefix=CONVERT
 # RUN: llvm-gsymutil --address=0x400391 --address=0x4004cd %t.gsym 2>&1 | FileCheck %s --check-prefix=ADDR
-# RUN: echo -e "0x400391 %/t.gsym\n0x4004cd %/t.gsym" | llvm-gsymutil --addresses-from-stdin  2>&1 | FileCheck %s --check-prefix=ADDRI --dump-input=always
+# RUN: printf "0x400391 %/t.gsym\n0x4004cd %/t.gsym" | llvm-gsymutil --addresses-from-stdin  2>&1 | FileCheck %s --check-prefix=ADDRI --dump-input=always
 # RUN: llvm-gsymutil --address=0x400391 --address=0x4004cd --verbose %t.gsym 2>&1 | FileCheck %s --check-prefix=ADDRV --dump-input=always
 # RUN: llvm-gsymutil --address=0x400391 --address=0x4004cd --verbose %t.gsym 2>&1 | FileCheck %s --check-prefix=ADDRV --dump-input=always
 # RUN: llvm-gsymutil %t.gsym 2>&1 | FileCheck %s --check-prefix=DUMP

--- a/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
+++ b/llvm/test/tools/llvm-objcopy/ELF/add-invalid-note.test
@@ -3,22 +3,22 @@
 ## Add [namesz, descsz, type, name, desc] for a build id.
 
 ## Notes should be padded to 8 bytes.
-# RUN: printf "\x04\x00\x00\x00" >  %t-miss-padding-note.bin
-# RUN: printf "\x07\x00\x00\x00" >> %t-miss-padding-note.bin
-# RUN: printf "\x03\x00\x00\x00" >> %t-miss-padding-note.bin
-# RUN: printf "GNU\x00"          >> %t-miss-padding-note.bin
-# RUN: printf "\x0c\x0d\x0e"     >> %t-miss-padding-note.bin
+# RUN: printf "\004\000\000\000" >  %t-miss-padding-note.bin
+# RUN: printf "\007\000\000\000" >> %t-miss-padding-note.bin
+# RUN: printf "\003\000\000\000" >> %t-miss-padding-note.bin
+# RUN: printf "GNU\000"          >> %t-miss-padding-note.bin
+# RUN: printf "\014\015\016"     >> %t-miss-padding-note.bin
 
 ## The namesz field bit is incorrect.
-# RUN: printf "\x08\x00\x00\x00" >  %t-invalid-size-note.bin
-# RUN: printf "\x07\x00\x00\x00" >> %t-invalid-size-note.bin
-# RUN: printf "\x03\x00\x00\x00" >> %t-invalid-size-note.bin
-# RUN: printf "GNU\x00"          >> %t-invalid-size-note.bin
-# RUN: printf "\x0c\x0d\x0e\x00" >> %t-invalid-size-note.bin
+# RUN: printf "\010\000\000\000" >  %t-invalid-size-note.bin
+# RUN: printf "\007\000\000\000" >> %t-invalid-size-note.bin
+# RUN: printf "\003\000\000\000" >> %t-invalid-size-note.bin
+# RUN: printf "GNU\000"          >> %t-invalid-size-note.bin
+# RUN: printf "\014\015\016\000" >> %t-invalid-size-note.bin
 
 ## Missing type field.
-# RUN: printf "\x08\x00\x00\x00" >  %t-short-note.bin
-# RUN: printf "\x07\x00\x00\x00" >> %t-short-note.bin
+# RUN: printf "\010\000\000\000" >  %t-short-note.bin
+# RUN: printf "\007\000\000\000" >> %t-short-note.bin
 
 # RUN: yaml2obj %s -o %t.o
 
@@ -33,11 +33,11 @@
 # CHECK-SHORT: .note.short data must be either empty or at least 12 bytes long
 
 ## Test compatibility with .note.gnu.property, which has 8-byte alignment.
-# RUN: printf "\x04\x00\x00\x00\x40\x00\x00\x00\x05\x00\x00\x00\x47\x4e\x55\x00" >  %t-note-gnu-property.bin
-# RUN: printf "\x02\x00\x00\xc0\x04\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00" >> %t-note-gnu-property.bin
-# RUN: printf "\x01\x80\x01\xc0\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00" >> %t-note-gnu-property.bin
-# RUN: printf "\x01\x00\x01\xc0\x04\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00" >> %t-note-gnu-property.bin
-# RUN: printf "\x02\x00\x01\xc0\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00" >> %t-note-gnu-property.bin
+# RUN: printf "\004\000\000\000\100\000\000\000\005\000\000\000\107\116\125\000" >  %t-note-gnu-property.bin
+# RUN: printf "\002\000\000\300\004\000\000\000\003\000\000\000\000\000\000\000" >> %t-note-gnu-property.bin
+# RUN: printf "\001\200\001\300\004\000\000\000\001\000\000\000\000\000\000\000" >> %t-note-gnu-property.bin
+# RUN: printf "\001\000\001\300\004\000\000\000\013\000\000\000\000\000\000\000" >> %t-note-gnu-property.bin
+# RUN: printf "\002\000\001\300\004\000\000\000\001\000\000\000\000\000\000\000" >> %t-note-gnu-property.bin
 # RUN: llvm-objcopy --add-section=.note.gnu.property=%t-note-gnu-property.bin %t.o %t-with-note-gnu-property.o
 
 ## Test that verification can be disabled.

--- a/llvm/test/tools/llvm-profdata/binary-ids-padding.test
+++ b/llvm/test/tools/llvm-profdata/binary-ids-padding.test
@@ -69,7 +69,7 @@ RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 
 RUN: printf '\067\265\035\031\112\165\023\344' >> %t.profraw
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t.profraw
-RUN: printf '\xc8\xff\3\0\1\0\0\0' >> %t.profraw
+RUN: printf '\310\377\3\0\1\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t.profraw

--- a/llvm/test/tools/llvm-profdata/raw-32-bits-be.test
+++ b/llvm/test/tools/llvm-profdata/raw-32-bits-be.test
@@ -31,8 +31,8 @@ RUN: printf '\0\0\0\3' >> %t
 
 RUN: printf '\344\023\165\112\031\035\265\067' >> %t
 RUN: printf '\0\0\0\0\0\0\0\2' >> %t
-RUN: printf '\0\xff\xff\xd8' >> %t
-RUN: printf '\2\xff\xff\xd3' >> %t
+RUN: printf '\0\377\377\330' >> %t
+RUN: printf '\2\377\377\323' >> %t
 RUN: printf '\0\0\0\0' >> %t
 RUN: printf '\0\0\0\0' >> %t
 RUN: printf '\0\0\0\2' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-32-bits-le.test
+++ b/llvm/test/tools/llvm-profdata/raw-32-bits-le.test
@@ -30,8 +30,8 @@ RUN: printf '\3\0\0\0' >> %t
 
 RUN: printf '\067\265\035\031\112\165\023\344' >> %t
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t
-RUN: printf '\xd8\xff\xff\0' >> %t
-RUN: printf '\xd3\xff\xff\2' >> %t
+RUN: printf '\330\377\377\0' >> %t
+RUN: printf '\323\377\377\2' >> %t
 RUN: printf '\0\0\0\0' >> %t
 RUN: printf '\0\0\0\0' >> %t
 RUN: printf '\2\0\0\0' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-64-bits-be.test
+++ b/llvm/test/tools/llvm-profdata/raw-64-bits-be.test
@@ -30,8 +30,8 @@ RUN: printf '\0\0\0\3' >> %t
 
 RUN: printf '\344\023\165\112\031\035\265\067' >> %t
 RUN: printf '\0\0\0\0\0\0\0\02' >> %t
-RUN: printf '\0\0\0\1\0\3\xff\xc8' >> %t
-RUN: printf '\0\0\0\3\0\3\xff\xc3' >> %t
+RUN: printf '\0\0\0\1\0\3\377\310' >> %t
+RUN: printf '\0\0\0\3\0\3\377\303' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t
 RUN: printf '\0\0\0\02' >> %t

--- a/llvm/test/tools/llvm-profdata/raw-64-bits-le.test
+++ b/llvm/test/tools/llvm-profdata/raw-64-bits-le.test
@@ -30,8 +30,8 @@ RUN: printf '\3\0\0\0' >> %t
 
 RUN: printf '\067\265\035\031\112\165\023\344' >> %t
 RUN: printf '\02\0\0\0\0\0\0\0' >> %t
-RUN: printf '\xc8\xff\3\0\1\0\0\0' >> %t
-RUN: printf '\xc3\xff\3\0\3\0\0\0' >> %t
+RUN: printf '\310\377\3\0\1\0\0\0' >> %t
+RUN: printf '\303\377\3\0\3\0\0\0' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t
 RUN: printf '\0\0\0\0\0\0\0\0' >> %t
 RUN: printf '\02\0\0\0' >> %t

--- a/llvm/test/tools/llvm-strings/negative-char.test
+++ b/llvm/test/tools/llvm-strings/negative-char.test
@@ -1,6 +1,6 @@
 ## Show that llvm-strings can handle a negative signed char value (i.e. > 0x7f).
 ## Such characters should form string delimiters like other unprintable ones.
 
-# RUN: echo -e "z\0\x80\0a\0" | llvm-strings --bytes 1 - | FileCheck %s
+# RUN: printf "z\0\200\0a\0" | llvm-strings --bytes 1 - | FileCheck %s
 # CHECK: z{{$}}
 # CHECK-NEXT: {{^}}a

--- a/llvm/test/tools/llvm-strings/stdin.test
+++ b/llvm/test/tools/llvm-strings/stdin.test
@@ -8,12 +8,12 @@ CASE1: abcdefg
 RUN: echo -n "abc" | llvm-strings - | FileCheck %s --implicit-check-not={{.}} --allow-empty
 
 ## Case 3: output with new line.
-RUN: echo -e "abcd\nefgh" | llvm-strings - | FileCheck %s --check-prefix=CASE3 --implicit-check-not={{.}}
+RUN: printf "abcd\nefgh" | llvm-strings - | FileCheck %s --check-prefix=CASE3 --implicit-check-not={{.}}
 CASE3:      abcd
 CASE3-NEXT: efgh
 
 ## Case 4: output containing unprintable characters.
-RUN: echo -e "abcd\x00ef\x1fghij\x7fklmn" | llvm-strings - | FileCheck %s --check-prefix=CASE4 --implicit-check-not={{.}}
+RUN: printf "abcd\000ef\037ghij\177klmn" | llvm-strings - | FileCheck %s --check-prefix=CASE4 --implicit-check-not={{.}}
 CASE4:      abcd
 CASE4-NEXT: ghij
 CASE4-NEXT: klmn

--- a/llvm/test/tools/llvm-symbolizer/basic.s
+++ b/llvm/test/tools/llvm-symbolizer/basic.s
@@ -8,8 +8,8 @@ foo:
 # RUN: llvm-mc -filetype=obj -triple=x86_64-pc-linux %s -o %t.o -g
 
 # Check input addresses specified on stdin.
-# RUN: echo -e "0xa\n0xb" | llvm-symbolizer --obj=%t.o | FileCheck %s
-# RUN: echo -e "10\n11" | llvm-symbolizer --obj=%t.o | FileCheck %s
+# RUN: printf "0xa\n0xb" | llvm-symbolizer --obj=%t.o | FileCheck %s
+# RUN: printf "10\n11" | llvm-symbolizer --obj=%t.o | FileCheck %s
 
 # Check input addresses specified on the command-line.
 # RUN: llvm-symbolizer 0xa 0xb --obj=%t.o | FileCheck %s

--- a/llvm/test/tools/llvm-symbolizer/split-dwarf-dwp.test
+++ b/llvm/test/tools/llvm-symbolizer/split-dwarf-dwp.test
@@ -3,7 +3,7 @@ RUN: mkdir -p %t
 
 RUN: cp %p/Inputs/split-dwarf-dwp.o %t/split-dwarf-dwp-different-name.o
 
-RUN: echo -e 'DATA 0\n0x54' | \
+RUN: printf 'DATA 0\n0x54' | \
 RUN:     llvm-symbolizer --dwp=%p/Inputs/split-dwarf-dwp.o.dwp \
 RUN:     --obj=%t/split-dwarf-dwp-different-name.o | FileCheck %s
 

--- a/llvm/test/tools/sanstats/elf.test
+++ b/llvm/test/tools/sanstats/elf.test
@@ -1,27 +1,27 @@
 # RUN: yaml2obj %s -o %t1.o
 # RUN: yaml2obj %s -o %t2.o
 
-# RUN: printf "\x04" > %t.stats
+# RUN: printf "\004" > %t.stats
 
 # RUN: printf "%%s" "%t1.o" >> %t.stats
-# RUN: printf "\x00" >> %t.stats
-# RUN: printf "\x01\x00\x00\x00\x01\x00\x00\x00" >> %t.stats
-# RUN: printf "\x11\x00\x00\x00\x02\x00\x00\x20" >> %t.stats
-# RUN: printf "\x21\x00\x00\x00\x03\x00\x00\x40" >> %t.stats
-# RUN: printf "\x01\x00\x00\x00\x04\x00\x00\x60" >> %t.stats
-# RUN: printf "\x11\x00\x00\x00\x05\x00\x00\x80" >> %t.stats
-# RUN: printf "\x21\x00\x00\x00\x06\x00\x00\xa0" >> %t.stats
-# RUN: printf "\x00\x00\x00\x00\x00\x00\x00\x00" >> %t.stats
+# RUN: printf "\000" >> %t.stats
+# RUN: printf "\001\000\000\000\001\000\000\000" >> %t.stats
+# RUN: printf "\021\000\000\000\002\000\000\040" >> %t.stats
+# RUN: printf "\041\000\000\000\003\000\000\100" >> %t.stats
+# RUN: printf "\001\000\000\000\004\000\000\140" >> %t.stats
+# RUN: printf "\021\000\000\000\005\000\000\200" >> %t.stats
+# RUN: printf "\041\000\000\000\006\000\000\240" >> %t.stats
+# RUN: printf "\000\000\000\000\000\000\000\000" >> %t.stats
 
 # RUN: printf "%%s" "%t2.o" >> %t.stats
-# RUN: printf "\x00" >> %t.stats
-# RUN: printf "\x21\x00\x00\x00\x07\x00\x00\x00" >> %t.stats
-# RUN: printf "\x11\x00\x00\x00\x08\x00\x00\x20" >> %t.stats
-# RUN: printf "\x01\x00\x00\x00\x09\x00\x00\x40" >> %t.stats
-# RUN: printf "\x21\x00\x00\x00\x0b\x00\x00\x60" >> %t.stats
-# RUN: printf "\x11\x00\x00\x00\x0c\x00\x00\x80" >> %t.stats
-# RUN: printf "\x01\x00\x00\x00\x0e\x00\x00\xa0" >> %t.stats
-# RUN: printf "\x00\x00\x00\x00\x00\x00\x00\x00" >> %t.stats
+# RUN: printf "\000" >> %t.stats
+# RUN: printf "\041\000\000\000\007\000\000\000" >> %t.stats
+# RUN: printf "\021\000\000\000\010\000\000\040" >> %t.stats
+# RUN: printf "\001\000\000\000\011\000\000\100" >> %t.stats
+# RUN: printf "\041\000\000\000\013\000\000\140" >> %t.stats
+# RUN: printf "\021\000\000\000\014\000\000\200" >> %t.stats
+# RUN: printf "\001\000\000\000\016\000\000\240" >> %t.stats
+# RUN: printf "\000\000\000\000\000\000\000\000" >> %t.stats
 
 # RUN: sanstats %t.stats | FileCheck %s
 


### PR DESCRIPTION
Hex escapes of the form \xff are not universally supported in the printf implementations on the platforms that LLVM runs on (although they apparently are in the shell builtins). Octal escapes are required to be supported by POSIX. This patch converts all hex escapes to octal escapes for compatibility reasons.

This came up when trying to turn on lit's internal shell by default for llvm/. We started using /usr/bin/printf instead of the shell builtin on MacOS, which does not support hex escapes.

I used the following python script to automate most of the conversion with a few manual touchups needed:
```py
import sys

def process_line(to_process: str):
    output = ""
    i = 0
    while i < len(to_process):
        if to_process[i:i+2] == '\\x':
            hex_string = to_process[i+2:i+4]
            number = int(hex_string, 16)
            output += "\\"
            octal_string = oct(number)[2:]
            if len(octal_string) == 1:
                octal_string = "00" + octal_string
            elif len(octal_string) == 2:
                octal_string = "0" + octal_string
            assert(len(octal_string) == 3)
            output += octal_string
            i += 4
        else:
            output += to_process[i]
            i += 1
    return output

with open(sys.argv[1]) as input_file:
    lines = input_file.readlines()

for i, _ in enumerate(lines):
    lines[i] = process_line(lines[i])

with open(sys.argv[1], 'w') as output_file:
    output_file.writelines(lines)
```