### PR TITLE
[clang] Fix assertion with invalid embed limit parameter value

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -308,6 +308,8 @@ Bug Fixes in This Version
 - Builtin elementwise operators now accept vector arguments that have different
   qualifiers on their elements. For example, vector of 4 ``const float`` values
   and vector of 4 ``float`` values. (#GH155405)
+- Fixed a failed assertion with a negative limit parameter value inside of
+  ``__has_embed``. (#GH157842)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -3746,6 +3746,8 @@ Preprocessor::LexEmbedParameters(Token &CurTok, bool ForHasEmbed) {
       if (Result.isNegative()) {
         Diag(CurTok, diag::err_requires_positive_value)
             << toString(Result, 10) << /*positive*/ 0;
+        if (CurTok.isNot(tok::eod))
+          DiscardUntilEndOfDirective(CurTok);
         return std::nullopt;
       }
       return Result.getLimitedValue();

--- a/clang/test/Preprocessor/embed___has_embed_parsing_errors.c
+++ b/clang/test/Preprocessor/embed___has_embed_parsing_errors.c
@@ -238,3 +238,12 @@
 #if __has_embed("media/art.txt" if_empty))
 #endif
 
+// expected-error@+2 {{invalid value '-1'; must be positive}} \
+   expected-error@+2 {{expected value in expression}}
+#if __has_embed (__FILE__ limit(-1))
+#endif
+
+// expected-error@+2 {{invalid value '-100000000000000000'; must be positive}}\
+   expected-error@+2 {{expected value in expression}}
+#if __has_embed (__FILE__ limit(-100000000000000000)) != __STDC_EMBED_NOT_FOUND__
+#endif


### PR DESCRIPTION
If a negative value was given we would fail to skip till the end of the directive and trip a failed assertion.

Fixes https://github.com/llvm/llvm-project/issues/157842