### PR TITLE
[lldb] Test global variable support of dwim-print (NFC)

### DIFF
--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         self.ci.HandleCommand(cmd, result)
         return result.GetOutput().rstrip()
 
-    VAR_IDENT = re.compile(r"(?:\$\d+|[\w.]+) = ")
+    VAR_IDENT = re.compile(r"(?:\$\d+|(?:::)?[\w.]+) = ")
 
     def _strip_result_var(self, string: str) -> str:
         """
@@ -185,3 +185,11 @@ class TestCase(TestBase):
             self, "break inside", lldb.SBFileSpec("main.cpp")
         )
         self._expect_cmd("dwim-print number", "frame variable")
+
+    def test_global_variables(self):
+        """Test dwim-print supports global variables."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+        self._expect_cmd("dwim-print gGlobal", "frame variable")

--- a/lldb/test/API/commands/dwim-print/main.cpp
+++ b/lldb/test/API/commands/dwim-print/main.cpp
@@ -1,5 +1,8 @@
 extern "C" int puts(const char *s);
 
+extern int gGlobal;
+int gGlobal = 23;
+
 struct Structure {
   int number = 30;
   void f() { puts("break inside"); }


### PR DESCRIPTION
DIL has made `frame variable` support global variables, which in turn means dwim-print
inherits support for global variables.
