### PR TITLE
[compiler-rt] Update some tests to pass with lit internal shell.

### DIFF
--- a/compiler-rt/test/hwasan/TestCases/Posix/dlerror.cpp
+++ b/compiler-rt/test/hwasan/TestCases/Posix/dlerror.cpp
@@ -4,7 +4,7 @@
 // Android HWAsan does not support LSan.
 // UNSUPPORTED: android
 
-// RUN: %clangxx_hwasan -O0 %s -o %t && HWASAN_OPTIONS=detect_leaks=1 %run %t
+// RUN: %clangxx_hwasan -O0 %s -o %t && env HWASAN_OPTIONS=detect_leaks=1 %run %t
 
 #include <assert.h>
 #include <dlfcn.h>

--- a/compiler-rt/test/rtsan/unrecognized_flags.cpp
+++ b/compiler-rt/test/rtsan/unrecognized_flags.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsanitize=realtime %s -o %t
-// RUN: RTSAN_OPTIONS="verbosity=1,asdf=1" %run %t 2>&1 | FileCheck %s
+// RUN: env RTSAN_OPTIONS="verbosity=1,asdf=1" %run %t 2>&1 | FileCheck %s
 // UNSUPPORTED: ios
 
 // Intent: Make sure we are respecting some basic common flags

--- a/compiler-rt/test/xray/TestCases/Posix/dlopen.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/dlopen.cpp
@@ -5,7 +5,7 @@
 // RUN: %clangxx_xray -g -fPIC -fxray-instrument -fxray-shared -shared -std=c++11 %t/testlib.cpp -o %t/testlib.so
 // RUN: %clangxx_xray -g -fPIC -rdynamic -fxray-instrument -fxray-shared -std=c++11 %t/main.cpp -o %t/main.o
 //
-// RUN: XRAY_OPTIONS="patch_premain=true" %run %t/main.o %t/testlib.so 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=true" %run %t/main.o %t/testlib.so 2>&1 | FileCheck %s
 
 // REQUIRES: target={{(aarch64|x86_64)-.*}}
 

--- a/compiler-rt/test/xray/TestCases/Posix/dso-dep-chains.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/dso-dep-chains.cpp
@@ -15,7 +15,7 @@
 // Executable links with a and b explicitly and loads d and e at runtime.
 // RUN: %clangxx_xray -g -fPIC -rdynamic -fxray-instrument -fxray-shared -std=c++11 %t/main.cpp %t/testliba.so %t/testlibb.so -o %t/main.o
 //
-// RUN:  XRAY_OPTIONS="patch_premain=true" %run %t/main.o %t/testlibd.so %t/testlibe.so 2>&1 | FileCheck %s
+// RUN:  env XRAY_OPTIONS="patch_premain=true" %run %t/main.o %t/testlibd.so %t/testlibe.so 2>&1 | FileCheck %s
 
 // REQUIRES: target={{(aarch64|x86_64)-.*}}
 

--- a/compiler-rt/test/xray/TestCases/Posix/patch-premain-dso.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/patch-premain-dso.cpp
@@ -4,7 +4,7 @@
 // RUN: %clangxx_xray -g -fPIC -fxray-instrument -fxray-shared -shared -std=c++11 %t/testlib.cpp -o %t/testlib.so
 // RUN: %clangxx_xray -g -fPIC -fxray-instrument -fxray-shared -std=c++11 %t/main.cpp %t/testlib.so -Wl,-rpath,%t -o %t/main.o
 
-// RUN: XRAY_OPTIONS="patch_premain=true,verbosity=1" %run %t/main.o 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=true,verbosity=1" %run %t/main.o 2>&1 | FileCheck %s
 
 // REQUIRES: target={{(aarch64|x86_64)-.*}}
 

--- a/compiler-rt/test/xray/TestCases/Posix/patching-unpatching-dso.cpp
+++ b/compiler-rt/test/xray/TestCases/Posix/patching-unpatching-dso.cpp
@@ -6,7 +6,7 @@
 // RUN: %clangxx_xray -g -fPIC -fxray-instrument -fxray-shared -shared -std=c++11 %t/testlib.cpp -o %t/testlib.so
 // RUN: %clangxx_xray -g -fPIC -fxray-instrument -fxray-shared -std=c++11 %t/main.cpp %t/testlib.so -Wl,-rpath,%t -o %t/main.o
 
-// RUN: XRAY_OPTIONS="patch_premain=false" %run %t/main.o 2>&1 | FileCheck %s
+// RUN: env XRAY_OPTIONS="patch_premain=false" %run %t/main.o 2>&1 | FileCheck %s
 
 // REQUIRES: target={{(aarch64|x86_64)-.*}}
 


### PR DESCRIPTION
The lit internal shell needs environment variable definitions to be preceded by the 'env' keyword. This PR add that to tests that were missing it.