### PR TITLE
[lldb-dap] Fix test: TestDAP_server.py

### DIFF
--- a/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
+++ b/lldb/test/API/tools/lldb-dap/server/TestDAP_server.py
@@ -127,7 +127,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         self.start_server(
             connection="listen://localhost:0",
             connection_timeout=1,
-            wait_seconds_for_termination=2,
+            wait_seconds_for_termination=5,
         )
 
     @skipIfWindows
@@ -139,7 +139,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         (_, connection) = self.start_server(
             connection="listen://localhost:0",
             connection_timeout=1,
-            wait_seconds_for_termination=2,
+            wait_seconds_for_termination=5,
         )
         # The connection timeout should not cut off the debug session
         self.run_debug_session(connection, "Alice", 1.5)
@@ -153,7 +153,7 @@ class TestDAP_server(lldbdap_testcase.DAPTestCaseBase):
         (_, connection) = self.start_server(
             connection="listen://localhost:0",
             connection_timeout=1,
-            wait_seconds_for_termination=2,
+            wait_seconds_for_termination=5,
         )
         time.sleep(0.5)
         # Should be able to connect to the server.


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/156803#issuecomment-3275911510 for full context.

Summary:
* In https://github.com/llvm/llvm-project/pull/156803, we see a builtbot failure for `TestDAP_server.py` on Debian. Note that macOS and other Linux distributions (like CentOS, or whatever Linux the [required buildbot](https://github.com/llvm/llvm-project/actions/runs/17594257911/job/49982560193#logs) uses) seem to pass the tests.
* In the 3 newly added tests, the most complex test case passed, while the other easier ones failed.
```
PASS: LLDB (/home/worker/2.0.1/lldb-x86_64-debian/build/bin/clang-x86_64) :: test_connection_timeout_multiple_sessions (TestDAP_server.TestDAP_server.test_connection_timeout_multiple_sessions)
FAIL: LLDB (/home/worker/2.0.1/lldb-x86_64-debian/build/bin/clang-x86_64) :: test_connection_timeout_long_debug_session (TestDAP_server.TestDAP_server.test_connection_timeout_long_debug_session)
FAIL: LLDB (/home/worker/2.0.1/lldb-x86_64-debian/build/bin/clang-x86_64) :: test_connection_timeout_at_server_start (TestDAP_server.TestDAP_server.test_connection_timeout_at_server_start)
```
* The error is that `process.wait(timeout)` timed out during the teardown of the tests.
* The above suggests that maybe the root cause is that the timeout is set too strictly (and that maybe the server termination on Debian is slower than the other Linux distribution for some reason).
* This patch loosens that timeout from 2s to 5s. Let's see if this works.
* FWIW, I cannot verify the root cause, because I don't have a Debian machine.