### PR TITLE
[clang] fix incorrect assumption about function type 's ExtInfo

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -350,6 +350,9 @@ Bug Fixes to C++ Support
   authentication enabled. (#GH152601)
 - Fix the check for narrowing int-to-float conversions, so that they are detected in
   cases where converting the float back to an integer is undefined behaviour (#GH157067).
+- Fix a crash when applying binary or ternary operators to two same function types with different spellings,
+  where at least one of the function parameters has an attribute which affects
+  the function type.
 - Fix an assertion failure when a ``constexpr`` variable is only referenced through
   ``__builtin_addressof``, and related issues with builtin arguments. (#GH154034)
 

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -14195,7 +14195,11 @@ static QualType getCommonNonSugarTypeNode(const ASTContext &Ctx, const Type *X,
     FunctionProtoType::ExtProtoInfo EPIX = FX->getExtProtoInfo(),
                                     EPIY = FY->getExtProtoInfo();
     assert(EPIX.ExtInfo == EPIY.ExtInfo);
-    assert(EPIX.ExtParameterInfos == EPIY.ExtParameterInfos);
+    assert(!EPIX.ExtParameterInfos == !EPIY.ExtParameterInfos);
+    assert(!EPIX.ExtParameterInfos ||
+           llvm::equal(
+               llvm::ArrayRef(EPIX.ExtParameterInfos, FX->getNumParams()),
+               llvm::ArrayRef(EPIY.ExtParameterInfos, FY->getNumParams())));
     assert(EPIX.RefQualifier == EPIY.RefQualifier);
     assert(EPIX.TypeQuals == EPIY.TypeQuals);
     assert(EPIX.Variadic == EPIY.Variadic);

--- a/clang/test/SemaCXX/sugar-common-types.cpp
+++ b/clang/test/SemaCXX/sugar-common-types.cpp
@@ -203,3 +203,27 @@ namespace member_pointers {
   N t3 = 0 ? &W1::a : &W2::b;
   // expected-error@-1 {{rvalue of type 'B1 member_pointers::W<void>::*'}}
 } // namespace member_pointers
+
+namespace FunctionTypeExtInfo {
+  namespace RecordType {
+    class A;
+    void (*x)(__attribute__((swift_async_context)) A *);
+
+    class A;
+    void (*y)(__attribute__((swift_async_context)) A *);
+
+    N t1 = 0 ? x : y;
+    // expected-error@-1 {{lvalue of type 'void (*)(__attribute__((swift_async_context)) A *)'}}
+  } // namespace RecordType
+  namespace TypedefType {
+    class A;
+    using B = A;
+    void (*x)(__attribute__((swift_async_context)) B *);
+
+    using B = A;
+    void (*y)(__attribute__((swift_async_context)) B *);
+
+    N t1 = 0 ? x : y;
+    // expected-error@-1 {{lvalue of type 'void (*)(__attribute__((swift_async_context)) B *)'}}
+  } // namespace TypedefType
+} // namespace FunctionTypeExtInfo


### PR DESCRIPTION
This fixes an assumption that the ExtInfo for two same function types would have referential equality.

This should compare these ExtInfos by value instead.

The bug is pre-existing to https://github.com/llvm/llvm-project/pull/147835, but that PR adds another way to reproduce it.