### PR TITLE
[mlir][Linalg] Allow PartialReductionOpInterface ops in tile_reduction_using_forall

### DIFF
--- a/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
+++ b/mlir/include/mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.td
@@ -2017,8 +2017,8 @@ def TileReductionUsingForallOp :
                    DefaultValuedAttr<DenseI64ArrayAttr, "{}">:$tile_sizes,
                    OptionalAttr<DeviceMappingArrayAttr>:$mapping);
   let results = (outs Variadic<TransformHandleTypeInterface>:$fill_op,
-                      TransformHandleTypeInterface:$split_linalg_op,
-                      TransformHandleTypeInterface:$combining_linalg_op,
+                      TransformHandleTypeInterface:$split_op,
+                      TransformHandleTypeInterface:$combining_op,
                       TransformHandleTypeInterface:$forall_op);
 
   let builders = [
@@ -2042,7 +2042,7 @@ def TileReductionUsingForallOp :
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::transform::TransformRewriter &rewriter,
-        ::mlir::linalg::LinalgOp target,
+        Operation *target,
         ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];


### PR DESCRIPTION
Following [PR #120118](https://github.com/llvm/llvm-project/pull/120118), this PR extends `transform.structured.tile_reduction_using_forall` so that it can be applied to any operation implementing `PartialReductionOpInterface`, rather than being restricted to LinalgOp.

Existing tests relevant to linalg ops remain valid: https://github.com/llvm/llvm-project/blob/2a2296b1aab4614bf6c95c3003000832c9d43de5/mlir/test/Dialect/Linalg/transform-tile-reduction.mlir#L114

Additional tests for non-Linalg operations (e.g., IREE custom ops that implement `PartialReductionOpInterface`) will be added on the IREE side.