### PR TITLE
[libc] Clean up errno header usage in wchar tests.

### DIFF
--- a/libc/test/src/wchar/CMakeLists.txt
+++ b/libc/test/src/wchar/CMakeLists.txt
@@ -53,7 +53,7 @@ add_libc_test(
   SRCS
     mbrtowc_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.__support.wchar.mbstate
     libc.src.string.memset
     libc.src.wchar.mbrtowc
@@ -69,7 +69,7 @@ add_libc_test(
   SRCS
     mbtowc_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.wchar.mbtowc
     libc.hdr.types.wchar_t
     libc.test.UnitTest.ErrnoCheckingTest
@@ -82,7 +82,7 @@ add_libc_test(
   SRCS
     mbstowcs_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.wchar.mbstowcs
     libc.hdr.types.wchar_t
     libc.test.UnitTest.ErrnoCheckingTest
@@ -95,7 +95,7 @@ add_libc_test(
   SRCS
     mblen_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.wchar.mblen
     libc.test.UnitTest.ErrnoCheckingTest
 )
@@ -107,7 +107,7 @@ add_libc_test(
   SRCS
     mbsrtowcs_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.__support.wchar.mbstate
     libc.src.string.memset
     libc.src.wchar.mbsrtowcs
@@ -123,7 +123,7 @@ add_libc_test(
   SRCS
     mbrlen_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.__support.wchar.mbstate
     libc.src.string.memset
     libc.src.wchar.mbsrlen
@@ -139,14 +139,14 @@ add_libc_test(
   SRCS
     mbsnrtowcs_test.cpp
   DEPENDS
-    libc.src.__support.libc_errno
+    libc.hdr.errno_macros
     libc.src.__support.wchar.mbstate
     libc.src.string.memset
     libc.src.wchar.mbsnrtowcs
     libc.hdr.types.mbstate_t
     libc.hdr.types.wchar_t
     libc.test.UnitTest.ErrnoCheckingTest
-)   
+)
 
 add_libc_test(
   mbsinit_test
@@ -179,11 +179,11 @@ add_libc_test(
   SRCS
     wcrtomb_test.cpp
   DEPENDS
+    libc.hdr.errno_macros
     libc.src.wchar.wcrtomb
     libc.src.string.memset
     libc.hdr.types.wchar_t
     libc.hdr.types.mbstate_t
-    libc.src.__support.libc_errno
     libc.src.__support.wchar.mbstate
     libc.test.UnitTest.ErrnoCheckingTest
 )
@@ -195,6 +195,7 @@ add_libc_test(
   SRCS
     wctomb_test.cpp
   DEPENDS
+    libc.hdr.errno_macros
     libc.src.wchar.wctomb
     libc.hdr.types.wchar_t
 )
@@ -478,9 +479,9 @@ add_header_library(
   HDRS
     WcstolTest.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.src.__support.CPP.limits
     libc.src.__support.CPP.type_traits
-    libc.src.errno.errno
     libc.test.UnitTest.ErrnoCheckingTest
 )
 

--- a/libc/test/src/wchar/WcstolTest.h
+++ b/libc/test/src/wchar/WcstolTest.h
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "src/__support/CPP/limits.h"
 #include "src/__support/CPP/type_traits.h"
 #include "src/__support/macros/properties/architectures.h"

--- a/libc/test/src/wchar/mblen_test.cpp
+++ b/libc/test/src/wchar/mblen_test.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
+#include "hdr/errno_macros.h"
 #include "src/wchar/mblen.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/wchar/mbrlen_test.cpp
+++ b/libc/test/src/wchar/mbrlen_test.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/wchar/mbstate.h"
 #include "src/string/memset.h"
 #include "src/wchar/mbrlen.h"

--- a/libc/test/src/wchar/mbrtowc_test.cpp
+++ b/libc/test/src/wchar/mbrtowc_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/mbstate_t.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/wchar/mbstate.h"
 #include "src/string/memset.h"
 #include "src/wchar/mbrtowc.h"

--- a/libc/test/src/wchar/mbsnrtowcs_test.cpp
+++ b/libc/test/src/wchar/mbsnrtowcs_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/mbstate_t.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/null_check.h"
 #include "src/__support/wchar/mbstate.h"
 #include "src/string/memset.h"

--- a/libc/test/src/wchar/mbsrtowcs_test.cpp
+++ b/libc/test/src/wchar/mbsrtowcs_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/mbstate_t.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/null_check.h"
 #include "src/__support/wchar/mbstate.h"
 #include "src/string/memset.h"

--- a/libc/test/src/wchar/mbstowcs_test.cpp
+++ b/libc/test/src/wchar/mbstowcs_test.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/macros/null_check.h"
 #include "src/wchar/mbstowcs.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"

--- a/libc/test/src/wchar/mbtowc_test.cpp
+++ b/libc/test/src/wchar/mbtowc_test.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/wchar/mbtowc.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"

--- a/libc/test/src/wchar/wcrtomb_test.cpp
+++ b/libc/test/src/wchar/wcrtomb_test.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/mbstate_t.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/__support/wchar/mbstate.h"
 #include "src/string/memset.h"
 #include "src/wchar/wcrtomb.h"

--- a/libc/test/src/wchar/wctomb_test.cpp
+++ b/libc/test/src/wchar/wctomb_test.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/wchar_t.h"
-#include "src/__support/libc_errno.h"
 #include "src/wchar/wctomb.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"


### PR DESCRIPTION
See PR #157898 and PR #157517 for similar changes to math tests.

Don't include libc_errno.h header, since the tests don't manipulate errno directly. Instead, where appropriate, include hdr/errno_macros.h proxy header to get errno constant values to match against.