### PR TITLE
[DecoderEmitter] Support for DecodeOrder and `resolve-conflicts-try-all`

### DIFF
--- a/llvm/include/llvm/MC/MCDecoderOps.h
+++ b/llvm/include/llvm/MC/MCDecoderOps.h
@@ -17,6 +17,7 @@ namespace llvm::MCD {
 // enabled.
 enum DecoderOps {
   OPC_Scope = 1,         // OPC_Scope(nts_t NumToSkip)
+  OPC_ScopeNoFail,       // OPC_ScopeNoFail(nts_t NumToSkip)
   OPC_ExtractField,      // OPC_ExtractField(uleb128 Start, uint8_t Len)
   OPC_FilterValueOrSkip, // OPC_FilterValueOrSkip(uleb128 Val, nts_t NumToSkip)
   OPC_FilterValue,       // OPC_FilterValue(uleb128 Val)

--- a/llvm/include/llvm/Target/Target.td
+++ b/llvm/include/llvm/Target/Target.td
@@ -551,6 +551,10 @@ class InstructionEncoding {
   // where multiple ISA namespaces exist).
   string DecoderNamespace = "";
 
+  // Within a namespace, DecodeOrder is used to order instructions when we need
+  // to attempt multiple encoding.
+  int DecodeOrder = 0;
+
   // List of predicates which will be turned into isel matching code.
   list<Predicate> Predicates = [];
 

--- a/llvm/lib/Target/AArch64/AArch64InstrFormats.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrFormats.td
@@ -1957,7 +1957,7 @@ class MRSI : RtSystemI<1, (outs GPR64:$Rt), (ins mrs_sysreg_op:$systemreg),
                        "mrs", "\t$Rt, $systemreg"> {
   bits<16> systemreg;
   let Inst{20-5} = systemreg;
-  let DecoderNamespace = "Fallback";
+  let DecodeOrder = 1;
   // The MRS is set as a NZCV setting instruction. Not all MRS instructions
   // require doing this. The alternative was to explicitly model each one, but
   // it feels like it is unnecessary because it seems there are no negative
@@ -1972,7 +1972,7 @@ class MSRI : RtSystemI<0, (outs), (ins msr_sysreg_op:$systemreg, GPR64:$Rt),
                        "msr", "\t$systemreg, $Rt"> {
   bits<16> systemreg;
   let Inst{20-5} = systemreg;
-  let DecoderNamespace = "Fallback";
+  let DecodeOrder = 1;
 }
 
 def SystemPStateFieldWithImm0_15Operand : AsmOperandClass {
@@ -2045,7 +2045,8 @@ class MSRpstateImm0_1
   // MSRpstateI aliases with MSRI. When the MSRpstateI decoder method returns
   // Fail the decoder should attempt to decode the instruction as MSRI.
   let hasCompleteDecoder = false;
-  let DecoderNamespace = "Fallback";
+  let DecodeOrder = 1;
+
 }
 
 // SYS and SYSL generic system instructions.

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.td
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.td
@@ -10712,8 +10712,8 @@ def RPRFM:
   let hasSideEffects = 1;
   // RPRFM overlaps with PRFM (reg), when the decoder method of PRFM returns
   // Fail, the decoder should attempt to decode RPRFM. This requires setting
-  // the decoder namespace to "Fallback".
-  let DecoderNamespace = "Fallback";
+  // the decode order for RPRFM to be 1 ( > decode order for PRFM).
+  let DecodeOrder = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -487,18 +487,6 @@ DecodeStatus AMDGPUDisassembler::tryDecodeInst(const uint8_t *Table, MCInst &MI,
   return MCDisassembler::Fail;
 }
 
-template <typename InsnType>
-DecodeStatus
-AMDGPUDisassembler::tryDecodeInst(const uint8_t *Table1, const uint8_t *Table2,
-                                  MCInst &MI, InsnType Inst, uint64_t Address,
-                                  raw_ostream &Comments) const {
-  for (const uint8_t *T : {Table1, Table2}) {
-    if (DecodeStatus Res = tryDecodeInst(T, MI, Inst, Address, Comments))
-      return Res;
-  }
-  return MCDisassembler::Fail;
-}
-
 template <typename T> static inline T eatBytes(ArrayRef<uint8_t>& Bytes) {
   assert(Bytes.size() >= sizeof(T));
   const auto Res =
@@ -617,18 +605,15 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
       std::bitset<96> DecW = eat12Bytes(Bytes);
 
       if (isGFX11() &&
-          tryDecodeInst(DecoderTableGFX1196, DecoderTableGFX11_FAKE1696, MI,
-                        DecW, Address, CS))
+          tryDecodeInst(DecoderTableGFX1196, MI, DecW, Address, CS))
         break;
 
       if (isGFX1250() &&
-          tryDecodeInst(DecoderTableGFX125096, DecoderTableGFX1250_FAKE1696, MI,
-                        DecW, Address, CS))
+          tryDecodeInst(DecoderTableGFX125096, MI, DecW, Address, CS))
         break;
 
       if (isGFX12() &&
-          tryDecodeInst(DecoderTableGFX1296, DecoderTableGFX12_FAKE1696, MI,
-                        DecW, Address, CS))
+          tryDecodeInst(DecoderTableGFX1296, MI, DecW, Address, CS))
         break;
 
       if (isGFX12() &&
@@ -698,18 +683,13 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
         break;
 
       if (isGFX1250() &&
-          tryDecodeInst(DecoderTableGFX125064, DecoderTableGFX1250_FAKE1664, MI,
-                        QW, Address, CS))
+          tryDecodeInst(DecoderTableGFX125064, MI, QW, Address, CS))
         break;
 
-      if (isGFX12() &&
-          tryDecodeInst(DecoderTableGFX1264, DecoderTableGFX12_FAKE1664, MI, QW,
-                        Address, CS))
+      if (isGFX12() && tryDecodeInst(DecoderTableGFX1264, MI, QW, Address, CS))
         break;
 
-      if (isGFX11() &&
-          tryDecodeInst(DecoderTableGFX1164, DecoderTableGFX11_FAKE1664, MI, QW,
-                        Address, CS))
+      if (isGFX11() && tryDecodeInst(DecoderTableGFX1164, MI, QW, Address, CS))
         break;
 
       if (isGFX11() &&
@@ -753,19 +733,14 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
       if (isGFX10() && tryDecodeInst(DecoderTableGFX1032, MI, DW, Address, CS))
         break;
 
-      if (isGFX11() &&
-          tryDecodeInst(DecoderTableGFX1132, DecoderTableGFX11_FAKE1632, MI, DW,
-                        Address, CS))
+      if (isGFX11() && tryDecodeInst(DecoderTableGFX1132, MI, DW, Address, CS))
         break;
 
       if (isGFX1250() &&
-          tryDecodeInst(DecoderTableGFX125032, DecoderTableGFX1250_FAKE1632, MI,
-                        DW, Address, CS))
+          tryDecodeInst(DecoderTableGFX125032, MI, DW, Address, CS))
         break;
 
-      if (isGFX12() &&
-          tryDecodeInst(DecoderTableGFX1232, DecoderTableGFX12_FAKE1632, MI, DW,
-                        Address, CS))
+      if (isGFX12() && tryDecodeInst(DecoderTableGFX1232, MI, DW, Address, CS))
         break;
     }
 

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -79,10 +79,6 @@ public:
   template <typename InsnType>
   DecodeStatus tryDecodeInst(const uint8_t *Table, MCInst &MI, InsnType Inst,
                              uint64_t Address, raw_ostream &Comments) const;
-  template <typename InsnType>
-  DecodeStatus tryDecodeInst(const uint8_t *Table1, const uint8_t *Table2,
-                             MCInst &MI, InsnType Inst, uint64_t Address,
-                             raw_ostream &Comments) const;
 
   Expected<bool> onSymbolStart(SymbolInfoTy &Symbol, uint64_t &Size,
                                ArrayRef<uint8_t> Bytes,

--- a/llvm/lib/Target/AMDGPU/VINTERPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VINTERPInstructions.td
@@ -239,8 +239,9 @@ defm : VInterpF16Pat<int_amdgcn_interp_p2_rtz_f16,
 
 multiclass VINTERP_Real_gfx11 <bits<7> op, string asmName> {
   defvar ps = !cast<VOP3_Pseudo>(NAME);
-  let AssemblerPredicate = isGFX11Only, DecoderNamespace = "GFX11" #
-                           !if(ps.Pfl.IsRealTrue16, "", "_FAKE16") in {
+  let AssemblerPredicate = isGFX11Only, DecoderNamespace = "GFX11",
+      // When decoding, attempt decoding IsRealTrue16 first, then the fake one.
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1) in {
     def _gfx11 :
       VINTERP_Real<ps, SIEncodingFamily.GFX11, asmName>,
       VINTERPe_gfx11<op, ps.Pfl>;
@@ -249,8 +250,9 @@ multiclass VINTERP_Real_gfx11 <bits<7> op, string asmName> {
 
 multiclass VINTERP_Real_gfx12 <bits<7> op, string asmName> {
   defvar ps = !cast<VOP3_Pseudo>(NAME);
-  let AssemblerPredicate = isGFX12Only, DecoderNamespace = "GFX12" #
-                           !if(ps.Pfl.IsRealTrue16, "", "_FAKE16") in {
+  let AssemblerPredicate = isGFX12Only, DecoderNamespace = "GFX12",
+      // When decoding, attempt decoding IsRealTrue16 first, then the fake one.
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1) in {
     def _gfx12 :
       VINTERP_Real<ps, SIEncodingFamily.GFX12, asmName>,
       VINTERPe_gfx12<op, ps.Pfl>;

--- a/llvm/lib/Target/AMDGPU/VOP1Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP1Instructions.td
@@ -940,8 +940,8 @@ multiclass VOP1_Real_e32_with_name<GFXGen Gen, bits<9> op, string opName,
                                    string asmName> {
   defvar ps = !cast<VOP1_Pseudo>(opName#"_e32");
   let AsmString = asmName # ps.AsmOperands,
-      DecoderNamespace = Gen.DecoderNamespace #
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16") in {
+      DecoderNamespace = Gen.DecoderNamespace,
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1) in {
     defm NAME : VOP1_Real_e32<Gen, op, opName>;
   }
 }
@@ -961,8 +961,8 @@ multiclass VOP1_Real_dpp_with_name<GFXGen Gen, bits<9> op, string opName,
                                    string asmName> {
   defvar ps = !cast<VOP1_Pseudo>(opName#"_e32");
   let AsmString = asmName # ps.Pfl.AsmDPP16,
-      DecoderNamespace = Gen.DecoderNamespace #
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16") in {
+      DecoderNamespace = Gen.DecoderNamespace,
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1) in {
     defm NAME : VOP1_Real_dpp<Gen, op, opName>;
   }
 }
@@ -977,8 +977,8 @@ multiclass VOP1_Real_dpp8_with_name<GFXGen Gen, bits<9> op, string opName,
                                     string asmName> {
   defvar ps = !cast<VOP1_Pseudo>(opName#"_e32");
   let AsmString = asmName # ps.Pfl.AsmDPP8,
-      DecoderNamespace = Gen.DecoderNamespace #
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16") in {
+      DecoderNamespace = Gen.DecoderNamespace,
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1) in {
     if !not(ps.Pfl.HasExt64BitDPP) then
       defm NAME : VOP1_Real_dpp8<Gen, op, opName>;
   }

--- a/llvm/lib/Target/AMDGPU/VOP2Instructions.td
+++ b/llvm/lib/Target/AMDGPU/VOP2Instructions.td
@@ -127,8 +127,8 @@ class VOP2_Real_Gen <VOP2_Pseudo ps, GFXGen Gen, string real_name = ps.Mnemonic>
   VOP2_Real <ps, Gen.Subtarget, real_name> {
   let AssemblerPredicate = Gen.AssemblerPredicate;
   let True16Predicate = !if(ps.Pfl.IsRealTrue16, UseRealTrue16Insts, NoTrue16Predicate);
-  let DecoderNamespace = Gen.DecoderNamespace#
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16");
+  let DecoderNamespace = Gen.DecoderNamespace;
+  let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
 }
 
 class VOP2_SDWA_Pseudo <string OpName, VOPProfile P, list<dag> pattern=[]> :
@@ -1517,8 +1517,8 @@ class VOP2_DPP16_Gen<bits<6> op, VOP2_DPP_Pseudo ps, GFXGen Gen,
     VOP2_DPP16<op, ps, Gen.Subtarget, opName, p> {
   let AssemblerPredicate = Gen.AssemblerPredicate;
   let True16Predicate = !if(ps.Pfl.IsRealTrue16, UseRealTrue16Insts, NoTrue16Predicate);
-  let DecoderNamespace = Gen.DecoderNamespace#
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16");
+  let DecoderNamespace = Gen.DecoderNamespace;
+  let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
 }
 
 class VOP2_DPP8<bits<6> op, VOP2_Pseudo ps,
@@ -1547,8 +1547,8 @@ class VOP2_DPP8_Gen<bits<6> op, VOP2_Pseudo ps, GFXGen Gen,
     VOP2_DPP8<op, ps, p> {
   let AssemblerPredicate = Gen.AssemblerPredicate;
   let True16Predicate = !if(ps.Pfl.IsRealTrue16, UseRealTrue16Insts, NoTrue16Predicate);
-  let DecoderNamespace = Gen.DecoderNamespace#
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16");
+  let DecoderNamespace = Gen.DecoderNamespace;
+  let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/VOPCInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPCInstructions.td
@@ -310,6 +310,7 @@ class VOPCInstAlias <VOP3_Pseudo ps, Instruction inst,
   let SubtargetPredicate = AssemblerPredicate;
 
   string DecoderNamespace; // dummy
+  int DecodeOrder; // dummy
 }
 
 multiclass VOPCInstAliases <string old_name, string Arch, string real_name = old_name, string mnemonic_from = real_name> {
@@ -1677,7 +1678,8 @@ multiclass VOPC_Real_with_name<GFXGen Gen, bits<9> op, string OpName,
                                                      pseudo_mnemonic),
                               asm_name, ps64.AsmVariantName>;
 
-    let DecoderNamespace = Gen.DecoderNamespace # !if(ps32.Pfl.IsRealTrue16, "", "_FAKE16") in {
+    let DecoderNamespace = Gen.DecoderNamespace,
+        DecodeOrder = !if(ps32.Pfl.IsRealTrue16, 0, 1) in {
       def _e32#Gen.Suffix :
         // 32 and 64 bit forms of the instruction have _e32 and _e64
         // respectively appended to their assembly mnemonic.
@@ -1753,7 +1755,7 @@ multiclass VOPC_Real_with_name<GFXGen Gen, bits<9> op, string OpName,
           def _e64_dpp8#Gen.Suffix : VOPC64_DPP8_Dst<{0, op}, ps64, asm_name>;
         }
       } // end if ps64.Pfl.HasExtVOP3DPP
-    } // End DecoderNamespace
+    } // End DecoderOrder
   } // End AssemblerPredicate
 }
 
@@ -1824,7 +1826,8 @@ multiclass VOPCX_Real_with_name<GFXGen Gen, bits<9> op, string OpName,
                                                      pseudo_mnemonic),
                               asm_name, ps64.AsmVariantName>;
 
-    let DecoderNamespace = Gen.DecoderNamespace # !if(ps32.Pfl.IsRealTrue16, "", "_FAKE16") in {
+    let DecoderNamespace = Gen.DecoderNamespace,
+        DecodeOrder = !if(ps32.Pfl.IsRealTrue16, 0, 1) in {
       def _e32#Gen.Suffix
           : VOPC_Real<ps32, Gen.Subtarget, asm_name>,
             VOPCe<op{7-0}> {
@@ -1880,7 +1883,7 @@ multiclass VOPCX_Real_with_name<GFXGen Gen, bits<9> op, string OpName,
           }
         }
       } // End if ps64.Pfl.HasExtVOP3DPP
-    } // End DecoderNamespace
+    } // End DecodeOrder
   } // End AssemblerPredicate
 }
 

--- a/llvm/lib/Target/AMDGPU/VOPInstructions.td
+++ b/llvm/lib/Target/AMDGPU/VOPInstructions.td
@@ -204,8 +204,8 @@ class VOP3_Real_Gen <VOP_Pseudo ps, GFXGen Gen, string asm_name = ps.Mnemonic> :
   VOP3_Real <ps, Gen.Subtarget, asm_name> {
   let AssemblerPredicate = Gen.AssemblerPredicate;
   let True16Predicate = !if(ps.Pfl.IsRealTrue16, UseRealTrue16Insts, NoTrue16Predicate);
-  let DecoderNamespace = Gen.DecoderNamespace#
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16");
+  let DecoderNamespace = Gen.DecoderNamespace;
+  let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
 }
 
 // XXX - Is there any reason to distinguish this from regular VOP3
@@ -1705,8 +1705,8 @@ class VOP3_DPP16_Gen_t16<bits<10> op, VOP_DPP_Pseudo ps, GFXGen Gen,
   let True16Predicate =
       !if (ps.Pfl.IsRealTrue16, UseRealTrue16Insts, NoTrue16Predicate);
   let AssemblerPredicate = Gen.AssemblerPredicate;
-  let DecoderNamespace =
-      Gen.DecoderNamespace #!if (ps.Pfl.IsRealTrue16, "", "_FAKE16");
+  let DecoderNamespace = Gen.DecoderNamespace;
+  let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
 }
 
 class Base_VOP3_DPP8<bits<10> op, VOP_Pseudo ps, string opName = ps.OpName>
@@ -1816,7 +1816,8 @@ multiclass VOP3Dot_Real_Base<GFXGen Gen, bits<10> op, string asmName, string opN
                              bit isSingle = 0> {
   defvar ps = !cast<VOP_Pseudo>(opName#"_e64");
   let AsmString = asmName # ps.AsmOperands,
-      DecoderNamespace = Gen.DecoderNamespace # !if(ps.Pfl.IsRealTrue16, "", "_FAKE16"),
+      DecoderNamespace = Gen.DecoderNamespace,
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1),
       IsSingle = !or(isSingle, ps.Pfl.IsSingle) in {
     def _e64#Gen.Suffix :
       VOP3_Real_Gen<ps, Gen>,
@@ -1886,8 +1887,8 @@ multiclass VOP3Dot_Real_dpp_Base<GFXGen Gen, bits<10> op, string asmName, string
   def _e64_dpp#Gen.Suffix :
     VOP3_DPP16_Gen_t16<op, ps, Gen> {
       let AsmString = asmName # ps.Pfl.AsmVOP3DPP16;
-      let DecoderNamespace = Gen.DecoderNamespace
-                             # !if(ps.Pfl.IsRealTrue16, "", "_FAKE16");
+      let DecoderNamespace = Gen.DecoderNamespace;
+      let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
       let Inst{11} = ?;
       let Inst{12} = ?;
     }
@@ -1915,8 +1916,8 @@ multiclass VOP3Dot_Real_dpp8_Base<GFXGen Gen, bits<10> op, string asmName, strin
     let Inst{11} = ?;
     let Inst{12} = ?;
     let AsmString = asmName # ps.Pfl.AsmVOP3DPP8;
-    let DecoderNamespace = Gen.DecoderNamespace
-                           # !if(ps.Pfl.IsRealTrue16, "", "_FAKE16");
+    let DecoderNamespace = Gen.DecoderNamespace;
+    let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
     let AssemblerPredicate = Gen.AssemblerPredicate;
   }
 }
@@ -1925,8 +1926,8 @@ multiclass VOP3_Real_dpp8_with_name<GFXGen Gen, bits<10> op, string opName,
                                     string asmName> {
   defvar ps = !cast<VOP3_Pseudo>(opName#"_e64");
   let AsmString = asmName # ps.Pfl.AsmVOP3DPP8,
-      DecoderNamespace = Gen.DecoderNamespace#
-                         !if(ps.Pfl.IsRealTrue16, "", "_FAKE16"),
+      DecoderNamespace = Gen.DecoderNamespace,
+      DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1),
       True16Predicate = !if(ps.Pfl.IsRealTrue16, UseRealTrue16Insts,
                             NoTrue16Predicate) in {
     defm NAME : VOP3_Real_dpp8_Base<Gen, op, opName>;
@@ -2006,8 +2007,8 @@ multiclass VOP3_BITOP3_Real_dpp_Base<GFXGen Gen, bits<10> op, string asmName> {
 multiclass VOP3_BITOP3_Real_dpp8_Base<GFXGen Gen, bits<10> op, string asmName> {
   defvar ps = !cast<VOP3_Pseudo>(NAME#"_e64");
   def _e64_dpp8#Gen.Suffix : VOP3_BITOP3_DPP8<op, ps, asmName> {
-    let DecoderNamespace =
-      Gen.DecoderNamespace #!if (ps.Pfl.IsRealTrue16, "", "_FAKE16");
+    let DecoderNamespace = Gen.DecoderNamespace;
+    let DecodeOrder = !if(ps.Pfl.IsRealTrue16, 0, 1);
     let AssemblerPredicate = Gen.AssemblerPredicate;
   }
 }

--- a/llvm/lib/Target/RISCV/CMakeLists.txt
+++ b/llvm/lib/Target/RISCV/CMakeLists.txt
@@ -8,7 +8,7 @@ tablegen(LLVM RISCVGenCompressInstEmitter.inc -gen-compress-inst-emitter)
 tablegen(LLVM RISCVGenMacroFusion.inc -gen-macro-fusion-pred)
 tablegen(LLVM RISCVGenDAGISel.inc -gen-dag-isel)
 tablegen(LLVM RISCVGenDisassemblerTables.inc -gen-disassembler
-              --specialize-decoders-per-bitwidth)
+              --specialize-decoders-per-bitwidth --resolve-conflicts-try-all)
 tablegen(LLVM RISCVGenInstrInfo.inc -gen-instr-info)
 tablegen(LLVM RISCVGenMCCodeEmitter.inc -gen-emitter)
 tablegen(LLVM RISCVGenMCPseudoLowering.inc -gen-pseudo-lowering)

--- a/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
+++ b/llvm/lib/Target/RISCV/Disassembler/RISCVDisassembler.cpp
@@ -689,9 +689,14 @@ static constexpr DecoderListEntry DecoderList32[]{
     {DecoderTableXMIPS32, XMIPSGroup, "Mips extensions"},
     {DecoderTableXAndes32, XAndesGroup, "Andes extensions"},
     {DecoderTableXSMT32, XSMTGroup, "SpacemiT extensions"},
-    // Standard Extensions
+
+    // Standard Extensions.
+    // The decoder order within this table is as follows:
+    // standard 32-bit instructions : 0
+    // RV32-only standard 32-bit instructions : 1
+    // Zfinx (Float in Integer) : 2 (TBD)
+    // RV32-only Zdinx (Double in Integer) : 3 (TBD)
     {DecoderTable32, {}, "standard 32-bit instructions"},
-    {DecoderTableRV32Only32, {}, "RV32-only standard 32-bit instructions"},
     {DecoderTableZfinx32, {}, "Zfinx (Float in Integer)"},
     {DecoderTableZdinxRV32Only32, {}, "RV32-only Zdinx (Double in Integer)"},
 };
@@ -739,15 +744,16 @@ static constexpr DecoderListEntry DecoderList16[]{
      {RISCV::FeatureVendorXqccmp},
      "Xqccmp (Qualcomm 16-bit Push/Pop & Double Move Instructions)"},
     {DecoderTableXwchc16, {RISCV::FeatureVendorXwchc}, "WCH QingKe XW"},
+
     // Standard Extensions
+    // Instructions in this table have the following decoding order:
+    // Zicfiss (Shadow Stack 16-bit) : -1
+    // standard 16-bit instructions : 0
+    // RV32-only 16-bit instructions : 1
+    // ZcOverlap (16-bit Instructions overlapping with Zcf/Zcd): 2
+
     // DecoderTableZicfiss16 must be checked before DecoderTable16.
-    {DecoderTableZicfiss16, {}, "Zicfiss (Shadow Stack 16-bit)"},
     {DecoderTable16, {}, "standard 16-bit instructions"},
-    {DecoderTableRV32Only16, {}, "RV32-only 16-bit instructions"},
-    // Zc* instructions incompatible with Zcf or Zcd
-    {DecoderTableZcOverlap16,
-     {},
-     "ZcOverlap (16-bit Instructions overlapping with Zcf/Zcd)"},
 };
 
 DecodeStatus RISCVDisassembler::getInstruction16(MCInst &MI, uint64_t &Size,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -2313,6 +2313,20 @@ let Predicates = [HasStdExtZihintpause] in
 def : Pat<(int_riscv_pause), (FENCE 0x1, 0x0)>;
 
 //===----------------------------------------------------------------------===//
+// Decoder orders for various instruction classes.
+//===----------------------------------------------------------------------===//
+
+// For 16 bit instructions.
+defvar DecodeOrderZicfiss16 = -1;
+defvar DecodeOrderRV32Only16 = 1;
+defvar DecodeOrderZcOverlap = 2;
+
+// For 32-bit instructions.
+defvar DecodeOrderRV32Only32 = 1;
+defvar DecodeOrderZfinx32 = 2;
+defvar DecodeOrderZdinxRV32Only32 = 2;
+
+//===----------------------------------------------------------------------===//
 // Standard extensions
 //===----------------------------------------------------------------------===//
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
@@ -2318,8 +2318,8 @@ def : Pat<(int_riscv_pause), (FENCE 0x1, 0x0)>;
 
 // For 16 bit instructions.
 defvar DecodeOrderZicfiss16 = -1;
-defvar DecodeOrderRV32Only16 = 1;
-defvar DecodeOrderZcOverlap = 2;
+defvar DecodeOrderRV32Only16 = 0;//1;
+defvar DecodeOrderZcOverlap = 0;//2;
 
 // For 32-bit instructions.
 defvar DecodeOrderRV32Only32 = 1;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoC.td
@@ -379,7 +379,7 @@ def PseudoC_ADDI_NOP : Pseudo<(outs GPRX0:$rd), (ins GPRX0:$rs1, simm6:$imm),
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0, isCall = 1,
-    DecoderNamespace = "RV32Only", Defs = [X1],
+    DecodeOrder = DecodeOrderRV32Only16, Defs = [X1],
     Predicates = [HasStdExtZca, IsRV32]  in
 def C_JAL : RVInst16CJ<0b001, 0b01, (outs), (ins bare_simm12_lsb0:$offset),
                        "c.jal", "$offset">, Sched<[WriteJal]>;
@@ -542,7 +542,7 @@ def C_UNIMP : RVInst16<(outs), (ins), "c.unimp", "", [], InstFormatOther>,
 
 } // Predicates = [HasStdExtZca]
 
-let DecoderNamespace = "RV32Only",
+let DecodeOrder = DecodeOrderRV32Only16,
     Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32] in {
   def C_FLW  : CLoad_ri<0b011, "c.flw", FPR32C, uimm7_lsb00>,
                Sched<[WriteFLD32, ReadFMemBase]> {
@@ -569,7 +569,7 @@ let DecoderNamespace = "RV32Only",
                  Sched<[WriteFST32, ReadFStoreData, ReadFMemBase]> {
     let Inst{8-7}  = imm{7-6};
   }
-} // DecoderNamespace = "RV32Only", Predicates = [HasStdExtCOrZcfOrZce, HasStdExtF, IsRV32]
+} // DecodeOrder = DecodeOrderRV32Only16
 
 let Predicates = [HasStdExtCOrZcd, HasStdExtD] in {
   def C_FLD  : CLoad_ri<0b001, "c.fld", FPR64C, uimm8_lsb000>,

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -382,9 +382,9 @@ let Predicates = [HasStdExtP] in {
   def PSLLI_H  : RVPShiftH_ri<0b000, 0b010, "pslli.h">;
   def PSSLAI_H : RVPShiftH_ri<0b101, 0b010, "psslai.h">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def SSLAI    : RVPShiftW_ri<0b101, 0b010, "sslai">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PSLLI_W  : RVPShiftW_ri<0b000, 0b010, "pslli.w">;
   def PSSLAI_W : RVPShiftW_ri<0b101, 0b010, "psslai.w">;
@@ -431,7 +431,7 @@ let Predicates = [HasStdExtP] in {
 
   def PSSHAR_HS : RVPBinaryScalar_rr<0b111, 0b00, 0b010, "psshar.hs">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def SSHA      : RVPBinaryScalar_rr<0b110, 0b01, 0b010, "ssha">;
 
   def SSHAR     : RVPBinaryScalar_rr<0b111, 0b01, 0b010, "sshar">;
@@ -461,7 +461,7 @@ let Predicates = [HasStdExtP] in {
 
   def PSATI_H    : RVPShiftH_ri<0b110, 0b100, "psati.h">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def USATI_RV32 : RVPShiftW_ri<0b010, 0b100, "usati">;
 
   def SRARI_RV32 : RVPShiftW_ri<0b101, 0b100, "srari">;
@@ -542,7 +542,7 @@ let Predicates = [HasStdExtP] in {
   def PASUBU_H : RVPBinary_rr<0b1111, 0b00, 0b000, "pasubu.h">;
   def PASUBU_B : RVPBinary_rr<0b1111, 0b10, 0b000, "pasubu.b">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def SADD     : RVPBinary_rr<0b0010, 0b01, 0b000, "sadd">;
 
   def AADD     : RVPBinary_rr<0b0011, 0b01, 0b000, "aadd">;
@@ -558,7 +558,7 @@ let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
   def SSUBU    : RVPBinary_rr<0b1110, 0b01, 0b000, "ssubu">;
 
   def ASUBU    : RVPBinary_rr<0b1111, 0b01, 0b000, "asubu">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PADD_W   : RVPBinary_rr<0b0000, 0b01, 0b000, "padd.w">;
 
@@ -596,7 +596,7 @@ let Predicates = [HasStdExtP] in {
 
   def PDIFSUMAU_B  : RVPTernary_rrr<0b0111, 0b10, 0b001, "pdifsumau.b">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def MUL_H01      : RVPBinary_rr<0b0010, 0b01, 0b001, "mul.h01">;
 
   def MACC_H01     : RVPTernary_rrr<0b0011, 0b01, 0b001, "macc.h01">;
@@ -604,7 +604,7 @@ let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
   def MULU_H01     : RVPBinary_rr<0b0110, 0b01, 0b001, "mulu.h01">;
 
   def MACCU_H01    : RVPTernary_rrr<0b0111, 0b01, 0b001, "maccu.h01">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PMUL_W_H01   : RVPBinary_rr<0b0010, 0b01, 0b001, "pmul.w.h01">;
   def MUL_W01      : RVPBinary_rr<0b0010, 0b11, 0b001, "mul.w01">;
@@ -626,9 +626,9 @@ let Predicates = [HasStdExtP] in {
 
   def PSSH1SADD_H : RVPBinary_rr<0b0110, 0b00, 0b010, "pssh1sadd.h">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def SSH1SADD    : RVPBinary_rr<0b0110, 0b01, 0b010, "ssh1sadd">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PSH1ADD_W   : RVPBinary_rr<0b0100, 0b01, 0b010, "psh1add.w">;
 
@@ -658,7 +658,7 @@ let Predicates = [HasStdExtP] in {
 
   def PMULSU_H_B11  : RVPBinary_rr<0b1110, 0b00, 0b011, "pmulsu.h.b11">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def MUL_H00       : RVPBinary_rr<0b0000, 0b01, 0b011, "mul.h00">;
 
   def MACC_H00      : RVPTernary_rrr<0b0001, 0b01, 0b011, "macc.h00">;
@@ -682,7 +682,7 @@ let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
   def MULSU_H11     : RVPBinary_rr<0b1110, 0b01, 0b011, "mulsu.h11">;
 
   def MACCSU_H11    : RVPTernary_rrr<0b1111, 0b01, 0b011, "maccsu.h11">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PMUL_W_H00    : RVPBinary_rr<0b0000, 0b01, 0b011, "pmul.w.h00">;
   def MUL_W00       : RVPBinary_rr<0b0000, 0b11, 0b011, "mul.w00">;
@@ -732,13 +732,13 @@ let Predicates = [HasStdExtP] in {
 
   def PPACKT_H    : RVPBinary_rr<0b0110, 0b00, 0b100, "ppackt.h">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def PACKBT_RV32 : RVPBinary_rr<0b0010, 0b01, 0b100, "packbt">;
 
   def PACKTB_RV32 : RVPBinary_rr<0b0100, 0b01, 0b100, "packtb">;
 
   def PACKT_RV32  : RVPBinary_rr<0b0110, 0b01, 0b100, "packt">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PPACK_W     : RVPBinary_rr<0b0000, 0b01, 0b100, "ppack.w">;
 
@@ -791,10 +791,10 @@ let Predicates = [HasStdExtP] in {
   def PM2ADDASU_H : RVPBinary_rr<0b1101, 0b00, 0b101, "pm2addasu.h">;
   def PM4ADDASU_B : RVPBinary_rr<0b1101, 0b10, 0b101, "pm4addasu.b">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def MQACC_H01  : RVPTernary_rrr<0b1111, 0b00, 0b101, "mqacc.h01">;
   def MQRACC_H01 : RVPTernary_rrr<0b1111, 0b10, 0b101, "mqracc.h01">;
-} // // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PM2ADD_W      : RVPBinary_rr<0b0000, 0b01, 0b101, "pm2add.w">;
   def PM4ADD_H      : RVPBinary_rr<0b0000, 0b11, 0b101, "pm4add.h">;
@@ -870,13 +870,13 @@ let Predicates = [HasStdExtP] in {
   def PMAXU_H  : RVPBinary_rr<0b1111, 0b00, 0b110, "pmaxu.h">;
   def PMAXU_B  : RVPBinary_rr<0b1111, 0b10, 0b110, "pmaxu.b">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def MSEQ  : RVPBinary_rr<0b1000, 0b01, 0b110, "mseq">;
 
   def MSLT  : RVPBinary_rr<0b1010, 0b01, 0b110, "mslt">;
 
   def MSLTU : RVPBinary_rr<0b1011, 0b01, 0b110, "msltu">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 let Predicates = [HasStdExtP, IsRV64] in {
   def PAS_WX   : RVPBinary_rr<0b0000, 0b01, 0b110, "pas.wx">;
   def PSA_WX   : RVPBinary_rr<0b0000, 0b11, 0b110, "psa.wx">;
@@ -936,7 +936,7 @@ let Predicates = [HasStdExtP] in {
   def PMULQ_H       : RVPBinary_rr<0b1010, 0b00, 0b111, "pmulq.h">;
   def PMULQR_H      : RVPBinary_rr<0b1010, 0b10, 0b111, "pmulqr.h">;
 } // Predicates = [HasStdExtP]
-let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
   def MULHR      : RVPBinary_rr<0b0000, 0b11, 0b111, "mulhr">;
 
   def MHACC      : RVPTernary_rrr<0b0001, 0b01, 0b111, "mhacc">;
@@ -972,7 +972,7 @@ let Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in {
 
   def MQACC_H11  : RVPTernary_rrr<0b1111, 0b00, 0b111, "mqacc.h11">;
   def MQRACC_H11 : RVPTernary_rrr<0b1111, 0b10, 0b111, "mqracc.h11">;
-} // Predicates = [HasStdExtP, IsRV32], DecoderNamespace = "RV32Only" in
+} // Predicates = [HasStdExtP, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in
 let Predicates = [HasStdExtP, IsRV64] in {
   def PMULH_W       : RVPBinary_rr<0b0000, 0b01, 0b111, "pmulh.w">;
   def PMULHR_W      : RVPBinary_rr<0b0000, 0b11, 0b111, "pmulhr.w">;

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZa.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZa.td
@@ -59,7 +59,7 @@ let Predicates = [HasStdExtZacas], IsSignExtendingOpW = 1 in {
 defm AMOCAS_W : AMO_cas_aq_rl<0b00101, 0b010, "amocas.w", GPR>;
 } // Predicates = [HasStdExtZacas]
 
-let Predicates = [HasStdExtZacas, IsRV32], DecoderNamespace = "RV32Only"  in {
+let Predicates = [HasStdExtZacas, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
 defm AMOCAS_D_RV32 : AMO_cas_aq_rl<0b00101, 0b011, "amocas.d", GPRPairRV32>;
 } // Predicates = [HasStdExtZacas, IsRV32]
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZc.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZc.td
@@ -216,7 +216,7 @@ def C_SH_INX : CStoreH_rri<0b100011, 0b0, "c.sh", GPRF16C>,
 } // Predicates = [HasStdExtZcb]
 
 // Zcmp
-let DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmp],
+let DecodeOrder = DecodeOrderZcOverlap, Predicates = [HasStdExtZcmp],
     hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 let Defs = [X10, X11] in
 def CM_MVA01S : RVInst16CA<0b101011, 0b11, 0b10, (outs),
@@ -227,9 +227,9 @@ let Uses = [X10, X11] in
 def CM_MVSA01 : RVInst16CA<0b101011, 0b01, 0b10, (outs SR07:$rs1, SR07:$rs2),
                             (ins), "cm.mvsa01", "$rs1, $rs2">,
                 Sched<[WriteIALU, WriteIALU, ReadIALU, ReadIALU]>;
-} // DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmp]...
+} // DecodeOrder = DecodeOrderZcOverlap, Predicates = [HasStdExtZcmp]...
 
-let DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmp] in {
+let DecodeOrder = DecodeOrderZcOverlap, Predicates = [HasStdExtZcmp] in {
 let hasSideEffects = 0, mayLoad = 0, mayStore = 1, Uses = [X2], Defs = [X2] in
 def CM_PUSH : RVInstZcCPPP<0b11000, "cm.push", negstackadj>,
               Sched<[WriteIALU, ReadIALU, ReadStoreData, ReadStoreData,
@@ -258,9 +258,9 @@ def CM_POP : RVInstZcCPPP<0b11010, "cm.pop">,
              Sched<[WriteIALU, WriteLDW, WriteLDW, WriteLDW, WriteLDW,
                     WriteLDW, WriteLDW, WriteLDW, WriteLDW, WriteLDW, WriteLDW,
                     WriteLDW, WriteLDW, WriteLDW, ReadIALU]>;
-} // DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmp]...
+} // DecodeOrder = DecodeOrderZcOverlap, Predicates = [HasStdExtZcmp]...
 
-let DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmt],
+let DecodeOrder = DecodeOrderZcOverlap, Predicates = [HasStdExtZcmt],
     hasSideEffects = 0, mayLoad = 0, mayStore = 0 in {
 def CM_JT : RVInst16CJ<0b101, 0b10, (outs), (ins uimm5:$index),
                        "cm.jt", "$index">{
@@ -278,7 +278,7 @@ def CM_JALT : RVInst16CJ<0b101, 0b10, (outs), (ins uimm8ge32:$index),
   let Inst{12-10} = 0b000;
   let Inst{9-2} = index;
 }
-} // DecoderNamespace = "ZcOverlap", Predicates = [HasStdExtZcmt]...
+} // DecodeOrder = DecodeOrderZcOverlap, Predicates = [HasStdExtZcmt]...
 
 
 let Predicates = [HasStdExtZcb, HasStdExtZmmul] in{

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZclsd.td
@@ -41,7 +41,8 @@ def GPRPairCRV32 : RegisterOperand<GPRPairC> {
 // Instructions
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasStdExtZclsd, IsRV32], DecoderNamespace = "ZcOverlap" in {
+let Predicates = [HasStdExtZclsd, IsRV32],
+    DecodeOrder = DecodeOrderZcOverlap in {
 def C_LDSP_RV32 : CStackLoad<0b011, "c.ldsp", GPRPairNoX0RV32, uimm9_lsb000>,
                   Sched<[WriteLDD, ReadMemBase]> {
   let Inst{4-2} = imm{8-6};
@@ -65,7 +66,7 @@ def C_SD_RV32 : CStore_rri<0b111, "c.sd", GPRPairCRV32, uimm8_lsb000>,
   let Inst{12-10} = imm{5-3};
   let Inst{6-5} = imm{7-6};
 }
-}// Predicates = [HasStdExtZclsd, IsRV32], DecoderNamespace = "ZcOverlap"
+}// Predicates = [HasStdExtZclsd, IsRV32], DecodeOrder = DecodeOrderZcOverlap
 
 //===----------------------------------------------------------------------===//
 // Assembler Pseudo Instructions

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZicfiss.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZicfiss.td
@@ -48,7 +48,7 @@ def SSPUSH : RVInstR<0b1100111, 0b100, OPC_SYSTEM, (outs), (ins GPRX1X5:$rs2),
 } // Predicates = [HasStdExtZicfiss]
 
 let Predicates = [HasStdExtZicfiss, HasStdExtZcmop],
-    DecoderNamespace = "Zicfiss" in {
+    DecodeOrder = DecodeOrderZicfiss16 in {
 let Uses = [SSP], Defs = [SSP], hasSideEffects = 0, mayLoad = 0, mayStore = 1 in
 def C_SSPUSH : RVC_SSInst<0b00001, GPRX1, "c.sspush">;
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZilsd.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZilsd.td
@@ -33,11 +33,11 @@ def riscv_st_rv32 : RVSDNode<"SD_RV32", SDT_RISCV_SD_RV32,
 // Instructions
 //===----------------------------------------------------------------------===//
 
-let Predicates = [HasStdExtZilsd, IsRV32], DecoderNamespace = "RV32Only" in {
+let Predicates = [HasStdExtZilsd, IsRV32], DecodeOrder = DecodeOrderRV32Only32 in {
 def LD_RV32 : Load_ri<0b011, "ld", GPRPairRV32>, Sched<[WriteLDD, ReadMemBase]>;
 def SD_RV32 : Store_rri<0b011, "sd", GPRPairRV32>,
               Sched<[WriteSTD, ReadStoreData, ReadMemBase]>;
-} // Predicates = [HasStdExtZilsd, IsRV32], DecoderNamespace = "RV32Only"
+} // Predicates = [HasStdExtZilsd, IsRV32], DecodeOrder = DecodeOrderRV32Only32
 
 //===----------------------------------------------------------------------===//
 // Assembler Pseudo Instructions

--- a/llvm/utils/TableGen/DecoderEmitter.cpp
+++ b/llvm/utils/TableGen/DecoderEmitter.cpp
@@ -1740,12 +1740,17 @@ void FilterChooser::dump() const {
   // Dump filter stack.
   dumpStack(errs(), Indent, PadToWidth);
 
+  bool PrintDecoderOrder = hasMultipleDecodeOrders();
+
   // Dump encodings.
   for (unsigned EncodingID : EncodingIDs) {
     const InstructionEncoding &Encoding = Encodings[EncodingID];
     errs() << Indent << indent(PadToWidth - Encoding.getBitWidth());
     printKnownBits(errs(), Encoding.getMandatoryBits(), '_');
-    errs() << "  " << Encoding.getName() << '\n';
+    errs() << "  " << Encoding.getName();
+    if (PrintDecoderOrder)
+      errs() << " (" << Encoding.getDecodeOrder() << ")";
+    errs() << '\n';
   }
 }
 


### PR DESCRIPTION
Add support for 2 features in DecoderEmitter to help resolve conflicts without resorting to decoder namespaces.

**DecodeOrder:**
Add the ability to specify a `DecodeOrder` on an instruction encoding. When the decoder emitter has to attempt decoding multiple candidate instructions, it it attempt them in their `DecodeOrder`, and if the `DecoderOrder` is same, but their Enum order (current behavior). This is useful in cases where filters created with both varying and fixed encoding currently always attempt the fixed encoding and then variable ones. If the set of candidates involved have different `DecodeOrder`, these attempts will now happen within each `DecodeOrder`. This helps eliminate, for example, AMDGPU's _FAKE16 decoder namesapces. Additionally, when we are unable to find a best filter and the set of instructions involved have multiple `DecodeOrder`, we will first bucket them according to their decode order and then try to process each bucket. This emulates the current mode of trying the decoder namespaces in a fixed order to resolve hard conflicts.

**resolve-conflicts-try-all:**
This option helps cases where currently we declare a decoding conflict and fail. Under this option, we will instead try all candidate encoding (in their DecoderOrder/Enum order).

Together, these 2 features help eliminate the use of decoder namespaces as a conflict resolution tool and allows coalescing multiple decode tables for such decoder namespace usage into a single one.

Adopt `DecodeOrder` feature for a few targets:
1. Replace AArch64 "Fallback" decoder namespace with DecodeOrder = 1.
2. Eliminate AMDGPU's usafe of `_FAKE16` variants of decoder namespaces.
3. Eliminate some RISCV 16-bit decoder namespaces.
