### PR TITLE
[compiler-rt] Removed unnecessary 'REQUIRES: shell' from lit tests.

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/duplicate_os_log_reports.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/duplicate_os_log_reports.cpp
@@ -1,5 +1,4 @@
 // UNSUPPORTED: ios
-// REQUIRES: shell
 // REQUIRES: darwin_log_cmd
 // RUN: %clangxx_asan -fsanitize-recover=address %s -o %t
 // RUN: { %env_asan_opts=halt_on_error=0,log_to_syslog=1 %run %t > %t.process_output.txt 2>&1 & } \

--- a/compiler-rt/test/asan/TestCases/Linux/read_binary_name_regtest.c
+++ b/compiler-rt/test/asan/TestCases/Linux/read_binary_name_regtest.c
@@ -6,8 +6,7 @@
 // will be unable to resolve its $ORIGIN due to readlink() restriction and will
 // thus fail to start, causing the test to die with SIGPIPE when attempting to
 // talk to it.
-// RUN: not ls /usr/include/linux/seccomp.h || ( %clang_asan %s -o %t && ( not env ASAN_OPTIONS=symbolize=0 %run %t 2>&1 ) | FileCheck %s )
-// REQUIRES: shell
+// RUN: not ls /usr/include/linux/seccomp.h || %clang_asan %s -o %t || not env ASAN_OPTIONS=symbolize=0 %run %t 2>&1 | FileCheck %s
 // UNSUPPORTED: android
 
 #include <errno.h>

--- a/compiler-rt/test/asan/TestCases/suppressions-library.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-library.cpp
@@ -4,8 +4,6 @@
 // Check that without suppressions, we catch the issue.
 // RUN: not %run %t 2>&1 | FileCheck --check-prefix=CHECK-CRASH %s
 
-// REQUIRES: shell
-
 // RUN: echo "interceptor_via_lib:"%xdynamiclib_filename > %t.supp
 // RUN: %env_asan_opts=suppressions='"%t.supp"' %run %t 2>&1 | FileCheck --check-prefix=CHECK-IGNORE %s
 

--- a/compiler-rt/test/asan/TestCases/verbose-log-path_test.cpp
+++ b/compiler-rt/test/asan/TestCases/verbose-log-path_test.cpp
@@ -1,9 +1,6 @@
 // RUN: rm -rf %t-dir && mkdir -p %t-dir
 // RUN: %clangxx_asan %s -o %t-dir/verbose-log-path_test-binary
 
-// The glob below requires bash.
-// REQUIRES: shell
-
 // Good log_path.
 // RUN: rm -f %t-dir/asan.log.*
 // RUN: %env_asan_opts=log_path=%t-dir/asan.log:log_exe_name=1 not %run %t-dir/verbose-log-path_test-binary 2> %t.out

--- a/compiler-rt/test/sanitizer_common/TestCases/external_symbolizer_path.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/external_symbolizer_path.cpp
@@ -19,8 +19,6 @@
 // RUN: %env_tool_opts=external_symbolizer_path=%d/external_symbolizer_path.cpp.tmp.bin/llvm-symbolizer \
 // RUN:   %run %t 2>&1 | FileCheck %s --check-prefix=NOT-FOUND
 
-// REQUIRES: shell
-
 // Mobile device will not have symbolizer in provided path.
 // UNSUPPORTED: ios, android
 

--- a/compiler-rt/test/sanitizer_common/TestCases/suffix-log-path_test.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/suffix-log-path_test.c
@@ -2,9 +2,6 @@
 // RUN: mkdir -p %t.dir
 // RUN: %clang %s -o %t.dir/suffix-log-path_test-binary
 
-// The glob below requires bash.
-// REQUIRES: shell
-
 // Good log_path with suffix.
 // RUN: %env_tool_opts=log_path=%t.dir/sanitizer.log:log_exe_name=1:log_suffix=.txt %run %t.dir/suffix-log-path_test-binary 2> %t.out
 // RUN: FileCheck %s < %t.dir/sanitizer.log.suffix-log-path_test-binary.*.txt

--- a/compiler-rt/test/ubsan/TestCases/Misc/coverage-levels.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/coverage-levels.cpp
@@ -1,8 +1,5 @@
 // Test various levels of coverage
 //
-// FIXME: Port the environment variable logic below for the lit shell.
-// REQUIRES: shell
-//
 // RUN: rm -rf %t-dir && mkdir %t-dir
 // RUN: %clangxx -fsanitize=shift                        -DGOOD_SHIFT=1 -O1 -fsanitize-coverage=func,trace-pc-guard  %s -o %t
 // RUN: %env_ubsan_opts=coverage=1:verbosity=1:coverage_dir='"%t-dir"' %run %t 2>&1 | FileCheck %s --check-prefix=CHECK1 --check-prefix=CHECK_NOWARN

--- a/compiler-rt/test/ubsan/TestCases/Misc/log-path_test.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/log-path_test.cpp
@@ -1,9 +1,6 @@
 // FIXME: https://code.google.com/p/address-sanitizer/issues/detail?id=316
 // XFAIL: android
 
-// The globs below do not work in the lit shell.
-// REQUIRES: shell
-
 // RUN: %clangxx -fsanitize=undefined %s -O1 -o %t
 
 // Regular run.
@@ -38,4 +35,3 @@ int main(int argc, char *argv[]) {
 }
 
 // CHECK-ERROR: runtime error: -4 is outside the range of representable values of type 'unsigned int'
-


### PR DESCRIPTION
As part of our work to migrate tests to use the lit internal shell by default, this removes 'REQUIRES: shell' from tests that don't actually require it. In one case the test was updated slightly to pass without requiring shell.