### PR TITLE
[VPlan] Remove getNumUsers(), replace with targeted helpers.

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -4174,7 +4174,7 @@ VectorizationFactor LoopVectorizationPlanner::selectVectorizationFactor() {
           // divisors.
           case Instruction::Select: {
             VPValue *VPV = VPI->getVPSingleValue();
-            if (VPV->getNumUsers() == 1) {
+            if (VPV->hasOneUser()) {
               if (auto *WR = dyn_cast<VPWidenRecipe>(*VPV->user_begin())) {
                 switch (WR->getOpcode()) {
                 case Instruction::UDiv:

--- a/llvm/lib/Transforms/Vectorize/VPlan.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlan.cpp
@@ -1066,25 +1066,25 @@ const VPRegionBlock *VPlan::getVectorLoopRegion() const {
 void VPlan::printLiveIns(raw_ostream &O) const {
   VPSlotTracker SlotTracker(this);
 
-  if (VF.getNumUsers() > 0) {
+  if (VF.hasUsers()) {
     O << "\nLive-in ";
     VF.printAsOperand(O, SlotTracker);
     O << " = VF";
   }
 
-  if (VFxUF.getNumUsers() > 0) {
+  if (VFxUF.hasUsers()) {
     O << "\nLive-in ";
     VFxUF.printAsOperand(O, SlotTracker);
     O << " = VF * UF";
   }
 
-  if (VectorTripCount.getNumUsers() > 0) {
+  if (VectorTripCount.hasUsers()) {
     O << "\nLive-in ";
     VectorTripCount.printAsOperand(O, SlotTracker);
     O << " = vector-trip-count";
   }
 
-  if (BackedgeTakenCount && BackedgeTakenCount->getNumUsers()) {
+  if (BackedgeTakenCount && BackedgeTakenCount->hasUsers()) {
     O << "\nLive-in ";
     BackedgeTakenCount->printAsOperand(O, SlotTracker);
     O << " = backedge-taken count";
@@ -1502,9 +1502,9 @@ void VPSlotTracker::assignName(const VPValue *V) {
 }
 
 void VPSlotTracker::assignNames(const VPlan &Plan) {
-  if (Plan.VF.getNumUsers() > 0)
+  if (Plan.VF.hasUsers())
     assignName(&Plan.VF);
-  if (Plan.VFxUF.getNumUsers() > 0)
+  if (Plan.VFxUF.hasUsers())
     assignName(&Plan.VFxUF);
   assignName(&Plan.VectorTripCount);
   if (Plan.BackedgeTakenCount)

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -4218,7 +4218,7 @@ public:
   /// Resets the trip count for the VPlan. The caller must make sure all uses of
   /// the original trip count have been replaced.
   void resetTripCount(VPValue *NewTripCount) {
-    assert(TripCount && NewTripCount && TripCount->getNumUsers() == 0 &&
+    assert(TripCount && NewTripCount && TripCount->hasNoUsers() &&
            "TripCount must be set when resetting");
     TripCount = NewTripCount;
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp
@@ -888,7 +888,7 @@ bool VPlanTransforms::handleMaxMinNumReductions(VPlan &Plan) {
     if (VecV == RdxResult)
       continue;
     if (auto *DerivedIV = dyn_cast<VPDerivedIVRecipe>(VecV)) {
-      if (DerivedIV->getNumUsers() == 1 &&
+      if (DerivedIV->hasOneUser() &&
           DerivedIV->getOperand(1) == &Plan.getVectorTripCount()) {
         auto *NewSel = Builder.createSelect(AnyNaN, Plan.getCanonicalIV(),
                                             &Plan.getVectorTripCount());

--- a/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanRecipes.cpp
@@ -2285,7 +2285,7 @@ InstructionCost VPWidenCastRecipe::computeCost(ElementCount VF,
   TTI::CastContextHint CCH = TTI::CastContextHint::None;
   // For Trunc/FPTrunc, get the context from the only user.
   if ((Opcode == Instruction::Trunc || Opcode == Instruction::FPTrunc) &&
-      !hasMoreThanOneUniqueUser() && getNumUsers() > 0) {
+      hasOneUser()) {
     if (auto *StoreRecipe = dyn_cast<VPRecipeBase>(*user_begin()))
       CCH = ComputeCCH(StoreRecipe);
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanSLP.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanSLP.cpp
@@ -156,8 +156,7 @@ bool VPlanSlp::areVectorizable(ArrayRef<VPValue *> Operands) const {
     return false;
   }
 
-  if (any_of(Operands,
-             [](VPValue *Op) { return Op->hasMoreThanOneUniqueUser(); })) {
+  if (any_of(Operands, [](VPValue *Op) { return !Op->hasNoOrOneUser(); })) {
     LLVM_DEBUG(dbgs() << "VPSLP: Some operands have multiple users.\n");
     return false;
   }

--- a/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanUnroll.cpp
@@ -535,7 +535,7 @@ void VPlanTransforms::replicateByVF(VPlan &Plan, ElementCount VF) {
         continue;
 
       VPBuilder Builder(RepR);
-      if (RepR->getNumUsers() == 0) {
+      if (RepR->hasNoUsers()) {
         if (isa<StoreInst>(RepR->getUnderlyingInstr()) &&
             vputils::isSingleScalar(RepR->getOperand(1))) {
           // Stores to invariant addresses need to store the last lane only.

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -56,6 +56,8 @@ class LLVM_ABI_FOR_TEST VPValue {
 
   SmallVector<VPUser *, 1> Users;
 
+  unsigned getNumUsers() const { return Users.size(); }
+
 protected:
   // Hold the underlying Value, if any, attached to this VPValue.
   Value *UnderlyingVal;
@@ -110,7 +112,6 @@ public:
   void dump() const;
 #endif
 
-  unsigned getNumUsers() const { return Users.size(); }
   void addUser(VPUser &User) { Users.push_back(&User); }
 
   /// Remove a single \p User from the list of users.
@@ -136,17 +137,12 @@ public:
     return const_user_range(user_begin(), user_end());
   }
 
-  /// Returns true if the value has more than one unique user.
-  bool hasMoreThanOneUniqueUser() const {
-    if (getNumUsers() == 0)
-      return false;
+  bool hasUsers() const { return !Users.empty(); }
+  bool hasNoUsers() const { return !hasUsers(); }
+  bool hasOneUser() const { return !hasNoUsers() && all_equal(Users); }
 
-    // Check if all users match the first user.
-    auto Current = std::next(user_begin());
-    while (Current != user_end() && *user_begin() == *Current)
-      Current++;
-    return Current != user_end();
-  }
+  /// Returns true if the value has more than one unique user.
+  bool hasNoOrOneUser() const { return hasNoUsers() || hasOneUser(); }
 
   void replaceAllUsesWith(VPValue *New);
 

--- a/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
+++ b/llvm/lib/Transforms/Vectorize/VPlanVerifier.cpp
@@ -198,8 +198,8 @@ bool VPlanVerifier::verifyEVLRecipe(const VPInstruction &EVL) const {
           }
           // EVLIVIncrement is only used by EVLIV & BranchOnCount.
           // Having more than two users is unexpected.
-          if ((I->getNumUsers() != 1) &&
-              (I->getNumUsers() != 2 || none_of(I->users(), [&I](VPUser *U) {
+          if ((size(I->users()) != 1) &&
+              (size(I->users()) != 2 || none_of(I->users(), [&I](VPUser *U) {
                  using namespace llvm::VPlanPatternMatch;
                  return match(U, m_BranchOnCount(m_Specific(I), m_VPValue()));
                }))) {

--- a/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
+++ b/llvm/unittests/Transforms/Vectorize/VPlanTest.cpp
@@ -137,38 +137,38 @@ TEST_F(VPInstructionTest, setOperand) {
   VPValue *VPV1 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 1));
   VPValue *VPV2 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 2));
   VPInstruction *I1 = new VPInstruction(0, {VPV1, VPV2});
-  EXPECT_EQ(1u, VPV1->getNumUsers());
+  EXPECT_TRUE(VPV1->hasOneUser());
   EXPECT_EQ(I1, *VPV1->user_begin());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_TRUE(VPV2->hasOneUser());
   EXPECT_EQ(I1, *VPV2->user_begin());
 
   // Replace operand 0 (VPV1) with VPV3.
   VPValue *VPV3 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 3));
   I1->setOperand(0, VPV3);
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_TRUE(VPV1->hasNoUsers());
+  EXPECT_TRUE(VPV2->hasOneUser());
   EXPECT_EQ(I1, *VPV2->user_begin());
-  EXPECT_EQ(1u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV3->hasOneUser());
   EXPECT_EQ(I1, *VPV3->user_begin());
 
   // Replace operand 1 (VPV2) with VPV3.
   I1->setOperand(1, VPV3);
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
-  EXPECT_EQ(2u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV1->hasNoUsers());
+  EXPECT_TRUE(VPV2->hasNoUsers());
+  EXPECT_EQ(2u, size(VPV3->users()));
   EXPECT_EQ(I1, *VPV3->user_begin());
   EXPECT_EQ(I1, *std::next(VPV3->user_begin()));
 
   // Replace operand 0 (VPV3) with VPV4.
   VPValue *VPV4 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 4));
   I1->setOperand(0, VPV4);
-  EXPECT_EQ(1u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV3->hasOneUser());
   EXPECT_EQ(I1, *VPV3->user_begin());
   EXPECT_EQ(I1, *VPV4->user_begin());
 
   // Replace operand 1 (VPV3) with VPV4.
   I1->setOperand(1, VPV4);
-  EXPECT_EQ(0u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV3->hasNoUsers());
   EXPECT_EQ(I1, *VPV4->user_begin());
   EXPECT_EQ(I1, *std::next(VPV4->user_begin()));
 
@@ -186,34 +186,34 @@ TEST_F(VPInstructionTest, replaceAllUsesWith) {
   VPV1->replaceAllUsesWith(VPV3);
   EXPECT_EQ(VPV3, I1->getOperand(0));
   EXPECT_EQ(VPV2, I1->getOperand(1));
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_TRUE(VPV1->hasNoUsers());
+  EXPECT_TRUE(VPV2->hasOneUser());
   EXPECT_EQ(I1, *VPV2->user_begin());
-  EXPECT_EQ(1u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV3->hasOneUser());
   EXPECT_EQ(I1, *VPV3->user_begin());
 
   // Replace all uses of VPV2 with VPV3.
   VPV2->replaceAllUsesWith(VPV3);
   EXPECT_EQ(VPV3, I1->getOperand(0));
   EXPECT_EQ(VPV3, I1->getOperand(1));
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
-  EXPECT_EQ(2u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV1->hasNoUsers());
+  EXPECT_TRUE(VPV2->hasNoUsers());
+  EXPECT_EQ(2u, size(VPV3->users()));
   EXPECT_EQ(I1, *VPV3->user_begin());
 
   // Replace all uses of VPV3 with VPV1.
   VPV3->replaceAllUsesWith(VPV1);
   EXPECT_EQ(VPV1, I1->getOperand(0));
   EXPECT_EQ(VPV1, I1->getOperand(1));
-  EXPECT_EQ(2u, VPV1->getNumUsers());
+  EXPECT_EQ(2u, size(VPV1->users()));
   EXPECT_EQ(I1, *VPV1->user_begin());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
-  EXPECT_EQ(0u, VPV3->getNumUsers());
+  EXPECT_TRUE(VPV2->hasNoUsers());
+  EXPECT_TRUE(VPV3->hasNoUsers());
 
   VPInstruction *I2 = new VPInstruction(0, {VPV1, VPV2});
-  EXPECT_EQ(3u, VPV1->getNumUsers());
+  EXPECT_EQ(3u, size(VPV1->users()));
   VPV1->replaceAllUsesWith(VPV3);
-  EXPECT_EQ(3u, VPV3->getNumUsers());
+  EXPECT_EQ(3u, size(VPV3->users()));
 
   delete I1;
   delete I2;
@@ -225,15 +225,15 @@ TEST_F(VPInstructionTest, releaseOperandsAtDeletion) {
   VPValue *VPV2 = getPlan().getOrAddLiveIn(ConstantInt::get(Int32, 1));
   VPInstruction *I1 = new VPInstruction(0, {VPV1, VPV2});
 
-  EXPECT_EQ(1u, VPV1->getNumUsers());
+  EXPECT_TRUE(VPV1->hasOneUser());
   EXPECT_EQ(I1, *VPV1->user_begin());
-  EXPECT_EQ(1u, VPV2->getNumUsers());
+  EXPECT_TRUE(VPV2->hasOneUser());
   EXPECT_EQ(I1, *VPV2->user_begin());
 
   delete I1;
 
-  EXPECT_EQ(0u, VPV1->getNumUsers());
-  EXPECT_EQ(0u, VPV2->getNumUsers());
+  EXPECT_TRUE(VPV1->hasNoUsers());
+  EXPECT_TRUE(VPV2->hasNoUsers());
 }
 
 using VPBasicBlockTest = VPlanTestBase;


### PR DESCRIPTION
Most users of getNumUsers() only care about 3 case:
 * no users
 * one (unique) user
 * or more than one (unique) user

Instead of providing getNumUsers, provide helpers that accurately check for the 3 cases above, handling duplicates.