### PR TITLE
[libc] Migrate some test/src/time tests to ErrnoCheckingTest.

### DIFF
--- a/libc/test/src/time/CMakeLists.txt
+++ b/libc/test/src/time/CMakeLists.txt
@@ -12,9 +12,11 @@ add_libc_unittest(
   CXX_STANDARD
     20
   DEPENDS
+    libc.hdr.errno_macros
     libc.src.time.asctime
     libc.hdr.types.struct_tm
     libc.src.time.time_constants
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -29,9 +31,11 @@ add_libc_unittest(
   CXX_STANDARD
     20
   DEPENDS
+    libc.hdr.errno_macros
     libc.src.time.asctime_r
     libc.hdr.types.struct_tm
     libc.src.time.time_constants
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -51,6 +55,7 @@ add_libc_unittest(
     libc.src.time.ctime
     libc.src.time.time_constants
     libc.hdr.types.struct_tm
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -70,6 +75,7 @@ add_libc_unittest(
     libc.src.time.ctime_r
     libc.src.time.time_constants
     libc.hdr.types.struct_tm
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -151,10 +157,12 @@ add_libc_unittest(
   HDRS
     TmMatcher.h
   DEPENDS
+    libc.hdr.errno_macros
     libc.src.time.gmtime
     libc.src.__support.CPP.limits
     libc.hdr.types.struct_tm
     libc.src.time.time_constants
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -169,6 +177,7 @@ add_libc_unittest(
     libc.src.time.gmtime_r
     libc.hdr.types.struct_tm
     libc.src.time.time_constants
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_test(
@@ -197,9 +206,9 @@ add_libc_test(
     nanosleep_test.cpp
   DEPENDS
     libc.include.time
-    libc.src.time.nanosleep
-    libc.src.errno.errno
     libc.hdr.types.struct_timespec
+    libc.src.time.nanosleep
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_test(

--- a/libc/test/src/time/asctime_r_test.cpp
+++ b/libc/test/src/time/asctime_r_test.cpp
@@ -6,11 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
+#include "hdr/errno_macros.h"
 #include "src/time/asctime_r.h"
 #include "src/time/time_constants.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 #include "test/src/time/TmHelper.h"
+
+using LlvmLibcAsctimeR = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 static inline char *call_asctime_r(struct tm *tm_data, int year, int month,
                                    int mday, int hour, int min, int sec,
@@ -22,7 +25,7 @@ static inline char *call_asctime_r(struct tm *tm_data, int year, int month,
 
 // asctime and asctime_r share the same code and thus didn't repeat all the
 // tests from asctime. Added couple of validation tests.
-TEST(LlvmLibcAsctimeR, Nullptr) {
+TEST_F(LlvmLibcAsctimeR, Nullptr) {
   char *result;
   result = LIBC_NAMESPACE::asctime_r(nullptr, nullptr);
   ASSERT_ERRNO_EQ(EINVAL);
@@ -39,7 +42,7 @@ TEST(LlvmLibcAsctimeR, Nullptr) {
   ASSERT_STREQ(nullptr, result);
 }
 
-TEST(LlvmLibcAsctimeR, ValidDate) {
+TEST_F(LlvmLibcAsctimeR, ValidDate) {
   char buffer[LIBC_NAMESPACE::time_constants::ASCTIME_BUFFER_SIZE];
   struct tm tm_data;
   char *result;

--- a/libc/test/src/time/asctime_test.cpp
+++ b/libc/test/src/time/asctime_test.cpp
@@ -6,10 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
+#include "hdr/errno_macros.h"
 #include "src/time/asctime.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 #include "test/src/time/TmHelper.h"
+
+using LlvmLibcAsctime = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 static inline char *call_asctime(struct tm *tm_data, int year, int month,
                                  int mday, int hour, int min, int sec, int wday,
@@ -19,7 +22,7 @@ static inline char *call_asctime(struct tm *tm_data, int year, int month,
   return LIBC_NAMESPACE::asctime(tm_data);
 }
 
-TEST(LlvmLibcAsctime, Nullptr) {
+TEST_F(LlvmLibcAsctime, Nullptr) {
   char *result;
   result = LIBC_NAMESPACE::asctime(nullptr);
   ASSERT_ERRNO_EQ(EINVAL);
@@ -27,7 +30,7 @@ TEST(LlvmLibcAsctime, Nullptr) {
 }
 
 // Weekdays are in the range 0 to 6. Test passing invalid value in wday.
-TEST(LlvmLibcAsctime, InvalidWday) {
+TEST_F(LlvmLibcAsctime, InvalidWday) {
   struct tm tm_data;
 
   // Test with wday = -1.
@@ -56,7 +59,7 @@ TEST(LlvmLibcAsctime, InvalidWday) {
 }
 
 // Months are from January to December. Test passing invalid value in month.
-TEST(LlvmLibcAsctime, InvalidMonth) {
+TEST_F(LlvmLibcAsctime, InvalidMonth) {
   struct tm tm_data;
 
   // Test with month = 0.
@@ -84,7 +87,7 @@ TEST(LlvmLibcAsctime, InvalidMonth) {
   ASSERT_ERRNO_EQ(EINVAL);
 }
 
-TEST(LlvmLibcAsctime, ValidWeekdays) {
+TEST_F(LlvmLibcAsctime, ValidWeekdays) {
   struct tm tm_data;
   char *result;
   // 1970-01-01 00:00:00.
@@ -124,7 +127,7 @@ TEST(LlvmLibcAsctime, ValidWeekdays) {
   ASSERT_STREQ("Sun Jan  4 00:00:00 1970\n", result);
 }
 
-TEST(LlvmLibcAsctime, ValidMonths) {
+TEST_F(LlvmLibcAsctime, ValidMonths) {
   struct tm tm_data;
   char *result;
   // 1970-01-01 00:00:00.
@@ -164,7 +167,7 @@ TEST(LlvmLibcAsctime, ValidMonths) {
   ASSERT_STREQ("Thu Dec 31 23:59:59 1970\n", result);
 }
 
-TEST(LlvmLibcAsctime, EndOf32BitEpochYear) {
+TEST_F(LlvmLibcAsctime, EndOf32BitEpochYear) {
   struct tm tm_data;
   char *result;
   // Test for maximum value of a signed 32-bit integer.
@@ -181,7 +184,7 @@ TEST(LlvmLibcAsctime, EndOf32BitEpochYear) {
   ASSERT_STREQ("Tue Jan 19 03:14:07 2038\n", result);
 }
 
-TEST(LlvmLibcAsctime, Max64BitYear) {
+TEST_F(LlvmLibcAsctime, Max64BitYear) {
   if (sizeof(time_t) == 4)
     return;
   // Mon Jan 1 12:50:50 2170 (200 years from 1970),

--- a/libc/test/src/time/ctime_r_test.cpp
+++ b/libc/test/src/time/ctime_r_test.cpp
@@ -8,9 +8,9 @@
 
 #include "src/time/ctime_r.h"
 #include "src/time/time_constants.h"
-#include "test/src/time/TmHelper.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
+#include "test/src/time/TmHelper.h"
 
 using LlvmLibcCtimeR = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 

--- a/libc/test/src/time/ctime_r_test.cpp
+++ b/libc/test/src/time/ctime_r_test.cpp
@@ -6,13 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/time/ctime_r.h"
 #include "src/time/time_constants.h"
-#include "test/UnitTest/Test.h"
 #include "test/src/time/TmHelper.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcCtimeR, Nullptr) {
+using LlvmLibcCtimeR = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcCtimeR, Nullptr) {
   char *result;
   result = LIBC_NAMESPACE::ctime_r(nullptr, nullptr);
   ASSERT_STREQ(nullptr, result);
@@ -26,7 +28,7 @@ TEST(LlvmLibcCtimeR, Nullptr) {
   ASSERT_STREQ(nullptr, result);
 }
 
-TEST(LlvmLibcCtimeR, ValidUnixTimestamp0) {
+TEST_F(LlvmLibcCtimeR, ValidUnixTimestamp0) {
   char buffer[LIBC_NAMESPACE::time_constants::ASCTIME_BUFFER_SIZE];
   time_t t;
   char *result;
@@ -36,7 +38,7 @@ TEST(LlvmLibcCtimeR, ValidUnixTimestamp0) {
   ASSERT_STREQ("Thu Jan  1 00:00:00 1970\n", result);
 }
 
-TEST(LlvmLibcCtime, ValidUnixTimestamp32Int) {
+TEST_F(LlvmLibcCtimeR, ValidUnixTimestamp32Int) {
   char buffer[LIBC_NAMESPACE::time_constants::ASCTIME_BUFFER_SIZE];
   time_t t;
   char *result;
@@ -46,7 +48,7 @@ TEST(LlvmLibcCtime, ValidUnixTimestamp32Int) {
   ASSERT_STREQ("Tue Jan 19 03:14:07 2038\n", result);
 }
 
-TEST(LlvmLibcCtimeR, InvalidArgument) {
+TEST_F(LlvmLibcCtimeR, InvalidArgument) {
   char buffer[LIBC_NAMESPACE::time_constants::ASCTIME_BUFFER_SIZE];
   time_t t;
   char *result;

--- a/libc/test/src/time/ctime_test.cpp
+++ b/libc/test/src/time/ctime_test.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/time/ctime.h"
-#include "test/src/time/TmHelper.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
+#include "test/src/time/TmHelper.h"
 
 using LlvmLibcCtime = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 

--- a/libc/test/src/time/ctime_test.cpp
+++ b/libc/test/src/time/ctime_test.cpp
@@ -6,18 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/time/ctime.h"
-#include "test/UnitTest/Test.h"
 #include "test/src/time/TmHelper.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
+#include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcCtime, nullptr) {
+using LlvmLibcCtime = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcCtime, nullptr) {
   char *result;
   result = LIBC_NAMESPACE::ctime(nullptr);
   ASSERT_STREQ(nullptr, result);
 }
 
-TEST(LlvmLibcCtime, ValidUnixTimestamp0) {
+TEST_F(LlvmLibcCtime, ValidUnixTimestamp0) {
   time_t t;
   char *result;
   t = 0;
@@ -25,7 +27,7 @@ TEST(LlvmLibcCtime, ValidUnixTimestamp0) {
   ASSERT_STREQ("Thu Jan  1 00:00:00 1970\n", result);
 }
 
-TEST(LlvmLibcCtime, ValidUnixTimestamp32Int) {
+TEST_F(LlvmLibcCtime, ValidUnixTimestamp32Int) {
   time_t t;
   char *result;
   t = 2147483647;
@@ -33,7 +35,7 @@ TEST(LlvmLibcCtime, ValidUnixTimestamp32Int) {
   ASSERT_STREQ("Tue Jan 19 03:14:07 2038\n", result);
 }
 
-TEST(LlvmLibcCtime, InvalidArgument) {
+TEST_F(LlvmLibcCtime, InvalidArgument) {
   time_t t;
   char *result;
   t = 2147483648;

--- a/libc/test/src/time/gmtime_r_test.cpp
+++ b/libc/test/src/time/gmtime_r_test.cpp
@@ -8,12 +8,15 @@
 
 #include "src/time/gmtime_r.h"
 #include "src/time/time_constants.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 #include "test/src/time/TmMatcher.h"
 
+using LlvmLibcGmTimeR = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
 // gmtime and gmtime_r share the same code and thus didn't repeat all the tests
 // from gmtime. Added couple of validation tests.
-TEST(LlvmLibcGmTimeR, EndOf32BitEpochYear) {
+TEST_F(LlvmLibcGmTimeR, EndOf32BitEpochYear) {
   // Test for maximum value of a signed 32-bit integer.
   // Test implementation can encode time for Tue 19 January 2038 03:14:07 UTC.
   time_t seconds = 0x7FFFFFFF;
@@ -34,7 +37,7 @@ TEST(LlvmLibcGmTimeR, EndOf32BitEpochYear) {
   EXPECT_TM_EQ(*tm_data_ptr, tm_data);
 }
 
-TEST(LlvmLibcGmTimeR, Max64BitYear) {
+TEST_F(LlvmLibcGmTimeR, Max64BitYear) {
   if (sizeof(time_t) == 4)
     return;
   // Test for Tue Jan 1 12:50:50 in 2,147,483,647th year.

--- a/libc/test/src/time/gmtime_test.cpp
+++ b/libc/test/src/time/gmtime_test.cpp
@@ -6,19 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "hdr/errno_macros.h"
 #include "hdr/types/struct_tm.h"
 #include "src/__support/CPP/limits.h" // INT_MAX, INT_MIN
-#include "src/__support/libc_errno.h"
 #include "src/time/gmtime.h"
 #include "src/time/time_constants.h"
-#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 #include "test/src/time/TmMatcher.h"
 
-using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
-using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
+using LlvmLibcGmTime = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
-TEST(LlvmLibcGmTime, OutOfRange) {
+TEST_F(LlvmLibcGmTime, OutOfRange) {
   if (sizeof(time_t) < sizeof(int64_t))
     return;
   time_t seconds =
@@ -30,7 +29,6 @@ TEST(LlvmLibcGmTime, OutOfRange) {
   EXPECT_TRUE(tm_data == nullptr);
   ASSERT_ERRNO_EQ(EOVERFLOW);
 
-  libc_errno = 0;
   seconds =
       INT_MIN *
           static_cast<int64_t>(
@@ -41,7 +39,7 @@ TEST(LlvmLibcGmTime, OutOfRange) {
   ASSERT_ERRNO_EQ(EOVERFLOW);
 }
 
-TEST(LlvmLibcGmTime, InvalidSeconds) {
+TEST_F(LlvmLibcGmTime, InvalidSeconds) {
   time_t seconds = 0;
   struct tm *tm_data = nullptr;
   // -1 second from 1970-01-01 00:00:00 returns 1969-12-31 23:59:59.
@@ -74,7 +72,7 @@ TEST(LlvmLibcGmTime, InvalidSeconds) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, InvalidMinutes) {
+TEST_F(LlvmLibcGmTime, InvalidMinutes) {
   time_t seconds = 0;
   struct tm *tm_data = nullptr;
   // -1 minute from 1970-01-01 00:00:00 returns 1969-12-31 23:59:00.
@@ -107,7 +105,7 @@ TEST(LlvmLibcGmTime, InvalidMinutes) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, InvalidHours) {
+TEST_F(LlvmLibcGmTime, InvalidHours) {
   time_t seconds = 0;
   struct tm *tm_data = nullptr;
   // -1 hour from 1970-01-01 00:00:00 returns 1969-12-31 23:00:00.
@@ -140,7 +138,7 @@ TEST(LlvmLibcGmTime, InvalidHours) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, InvalidYear) {
+TEST_F(LlvmLibcGmTime, InvalidYear) {
   // -1 year from 1970-01-01 00:00:00 returns 1969-01-01 00:00:00.
   time_t seconds = -LIBC_NAMESPACE::time_constants::DAYS_PER_NON_LEAP_YEAR *
                    LIBC_NAMESPACE::time_constants::SECONDS_PER_DAY;
@@ -158,7 +156,7 @@ TEST(LlvmLibcGmTime, InvalidYear) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, InvalidMonths) {
+TEST_F(LlvmLibcGmTime, InvalidMonths) {
   time_t seconds = 0;
   struct tm *tm_data = nullptr;
   // -1 month from 1970-01-01 00:00:00 returns 1969-12-01 00:00:00.
@@ -192,7 +190,7 @@ TEST(LlvmLibcGmTime, InvalidMonths) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, InvalidDays) {
+TEST_F(LlvmLibcGmTime, InvalidDays) {
   time_t seconds = 0;
   struct tm *tm_data = nullptr;
   // -1 day from 1970-01-01 00:00:00 returns 1969-12-31 00:00:00.
@@ -258,7 +256,7 @@ TEST(LlvmLibcGmTime, InvalidDays) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, EndOf32BitEpochYear) {
+TEST_F(LlvmLibcGmTime, EndOf32BitEpochYear) {
   // Test for maximum value of a signed 32-bit integer.
   // Test implementation can encode time for Tue 19 January 2038 03:14:07 UTC.
   time_t seconds = 0x7FFFFFFF;
@@ -276,7 +274,7 @@ TEST(LlvmLibcGmTime, EndOf32BitEpochYear) {
       *tm_data);
 }
 
-TEST(LlvmLibcGmTime, Max64BitYear) {
+TEST_F(LlvmLibcGmTime, Max64BitYear) {
   if (sizeof(time_t) == 4)
     return;
   // Mon Jan 1 12:50:50 2170 (200 years from 1970),

--- a/libc/test/src/time/nanosleep_test.cpp
+++ b/libc/test/src/time/nanosleep_test.cpp
@@ -7,21 +7,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/types/struct_timespec.h"
-#include "src/__support/libc_errno.h"
 #include "src/time/nanosleep.h"
-#include "test/UnitTest/ErrnoSetterMatcher.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
 namespace cpp = LIBC_NAMESPACE::cpp;
 
-TEST(LlvmLibcNanosleep, SmokeTest) {
-  // TODO: When we have the code to read clocks, test that time has passed.
-  using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
-  libc_errno = 0;
+using LlvmLibcNanosleep = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
+TEST_F(LlvmLibcNanosleep, SmokeTest) {
+  // TODO: When we have the code to read clocks, test that time has passed.
   struct timespec tim = {1, 500};
   struct timespec tim2 = {0, 0};
-  int ret = LIBC_NAMESPACE::nanosleep(&tim, &tim2);
-  ASSERT_ERRNO_SUCCESS();
-  ASSERT_EQ(ret, 0);
+  ASSERT_EQ(LIBC_NAMESPACE::nanosleep(&tim, &tim2), 0);
 }


### PR DESCRIPTION
Use ErrnoCheckingTest harness to clear out / validate errno value before/after the test respectively. Clean up explicit libc_errno.h inclusions which is unnecessary, since no test modifies errno directly.