### PR TITLE
[compiler-rt] Fix sig-trap.test to work with lit internal shell.

### DIFF
--- a/compiler-rt/test/fuzzer/sig-trap.test
+++ b/compiler-rt/test/fuzzer/sig-trap.test
@@ -8,4 +8,4 @@ RUN: not %run %t            2>&1 | FileCheck %s
 CHECK-DAG: BINGO
 CHECK-DAG: ERROR: libFuzzer: deadly signal
 
-RUN: trap "%run %t -handle_trap=0" TRAP
+RUN: bash -c "trap '%run %t -handle_trap=0' TRAP"


### PR DESCRIPTION
Update sig-trap.test to work with the lit internal shell, as part of our migration to make the internal shell the default for lit tests.