### PR TITLE
[compiler-rt] Mark some tests as unsupported on Windows.

### DIFF
--- a/compiler-rt/test/asan/TestCases/suppressions-library.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-library.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // RUN: %clangxx_asan -O0 -DSHARED_LIB %s %fPIC -shared -o %dynamiclib %ld_flags_rpath_so
 // RUN: %clangxx_asan -O0 %s -o %t %ld_flags_rpath_exe
 

--- a/compiler-rt/test/asan/TestCases/verbose-log-path_test.cpp
+++ b/compiler-rt/test/asan/TestCases/verbose-log-path_test.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // RUN: rm -rf %t-dir && mkdir -p %t-dir
 // RUN: %clangxx_asan %s -o %t-dir/verbose-log-path_test-binary
 

--- a/compiler-rt/test/ubsan/TestCases/Misc/coverage-levels.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/coverage-levels.cpp
@@ -1,5 +1,7 @@
 // Test various levels of coverage
 //
+// UNSUPPORTED: system-windows
+//
 // RUN: rm -rf %t-dir && mkdir %t-dir
 // RUN: %clangxx -fsanitize=shift                        -DGOOD_SHIFT=1 -O1 -fsanitize-coverage=func,trace-pc-guard  %s -o %t
 // RUN: %env_ubsan_opts=coverage=1:verbosity=1:coverage_dir='"%t-dir"' %run %t 2>&1 | FileCheck %s --check-prefix=CHECK1 --check-prefix=CHECK_NOWARN

--- a/compiler-rt/test/ubsan/TestCases/Misc/log-path_test.cpp
+++ b/compiler-rt/test/ubsan/TestCases/Misc/log-path_test.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED: system-windows
+
 // FIXME: https://code.google.com/p/address-sanitizer/issues/detail?id=316
 // XFAIL: android
 


### PR DESCRIPTION
PR157951 removed 'REQUIRES: shell' from several tests, which (among other things) caused them to start running on some Windows builders -- the 'REQUIRES: shell' prevented that.  Some of those tests fail on Windows. This PR marks those failing tests as UNSUPPORTED on Windows.