### PR TITLE
[lldb-dap] Add `debugAdapterEnv` for `attach` requests & improve regex

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -672,6 +672,29 @@
                 },
                 "markdownDescription": "The list of additional arguments used to launch the debug adapter executable. Overrides any user or workspace settings."
               },
+              "debugAdapterEnv": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `{ \"FOO\": \"1\" }`",
+                    "patternProperties": {
+                      ".*": {
+                        "type": "string"
+                      }
+                    },
+                    "default": {}
+                  },
+                  {
+                    "type": "array",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `[\"FOO=1\", \"BAR\"]`",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^((\\w+=.*)|^\\w+)$"
+                    },
+                    "default": []
+                  }
+                ]
+              },
               "program": {
                 "type": "string",
                 "description": "Path to the program to attach to."

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -422,7 +422,7 @@
                     "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `[\"FOO=1\", \"BAR\"]`",
                     "items": {
                       "type": "string",
-                      "pattern": "^((\\w+=.*)|^\\w+)$"
+                      "pattern": "^\\w+(=.*)?$"
                     },
                     "default": []
                   }
@@ -689,7 +689,7 @@
                     "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `[\"FOO=1\", \"BAR\"]`",
                     "items": {
                       "type": "string",
-                      "pattern": "^((\\w+=.*)|^\\w+)$"
+                      "pattern": "^\\w+(=.*)?$"
                     },
                     "default": []
                   }

--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -409,7 +409,7 @@
                 "anyOf": [
                   {
                     "type": "object",
-                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `{ \"FOO\": \"1\" }`",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. For example `{ \"FOO\": \"1\" }`",
                     "patternProperties": {
                       ".*": {
                         "type": "string"
@@ -419,7 +419,7 @@
                   },
                   {
                     "type": "array",
-                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `[\"FOO=1\", \"BAR\"]`",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. For example `[\"FOO=1\", \"BAR\"]`",
                     "items": {
                       "type": "string",
                       "pattern": "^\\w+(=.*)?$"
@@ -676,7 +676,7 @@
                 "anyOf": [
                   {
                     "type": "object",
-                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `{ \"FOO\": \"1\" }`",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. For example `{ \"FOO\": \"1\" }`",
                     "patternProperties": {
                       ".*": {
                         "type": "string"
@@ -686,7 +686,7 @@
                   },
                   {
                     "type": "array",
-                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. E.g. `[\"FOO=1\", \"BAR\"]`",
+                    "markdownDescription": "Additional environment variables to set when launching the debug adapter executable. For example `[\"FOO=1\", \"BAR\"]`",
                     "items": {
                       "type": "string",
                       "pattern": "^\\w+(=.*)?$"

--- a/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
+++ b/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts
@@ -92,7 +92,7 @@ function validateDAPEnv(debugConfigEnv: any): boolean {
     Array.isArray(debugConfigEnv) &&
     debugConfigEnv.findIndex(
       (entry) =>
-        typeof entry !== "string" || !/^((\\w+=.*)|^\\w+)$/.test(entry),
+        typeof entry !== "string" || !/^\w+(=.*)?$/.test(entry),
     ) !== -1
   ) {
     return false;


### PR DESCRIPTION
# Changes

#153536 added a new debug configuration field called `debugAdapterEnv` and enabled it in `launch.json` **for `launch` requests**. This patch enables the same for **`attach` requests**.

This patch also improves the regex used in this field, i.e. shortens it and fixes the double backslashes (`\\`) in `debug-adapter-factory.ts` (note: the ones in `package.json` need the double backslashes).


# Test

Manually tested the following values in `attach` requests (so that we are testing both changes at the same time):
```
// Accepted
            "debugAdapterEnv": [
                "AAA=BBB",
            ],

            "debugAdapterEnv": [
                "AAA=",
            ],

            "debugAdapterEnv": [
                "AAA",
            ],

 // Rejected
            "debugAdapterEnv": [
                "=AAA",
            ],

            "debugAdapterEnv": [
                "=",
            ],

            "debugAdapterEnv": [
                "",
            ],
```