### PR TITLE
LTO: Stop storing string triple

### DIFF
--- a/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/LTOCodeGenerator.h
@@ -239,7 +239,6 @@ private:
   std::string FeatureStr;
   std::string NativeObjectPath;
   const Target *MArch = nullptr;
-  std::string TripleStr;
   lto_diagnostic_handler_t DiagHandler = nullptr;
   void *DiagContext = nullptr;
   bool ShouldInternalize = EnableLTOInternalization;

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -375,7 +375,7 @@ bool LTOCodeGenerator::determineTarget() {
   if (TargetMach)
     return true;
 
-  if (const Triple &TT = MergedModule->getTargetTriple(); TT.empty())
+  if (MergedModule->getTargetTriple().empty())
     MergedModule->setTargetTriple(Triple(sys::getDefaultTargetTriple()));
 
   // create target machine from info for merged modules

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -375,16 +375,12 @@ bool LTOCodeGenerator::determineTarget() {
   if (TargetMach)
     return true;
 
-  TripleStr = MergedModule->getTargetTriple().str();
-  if (TripleStr.empty()) {
-    TripleStr = sys::getDefaultTargetTriple();
-    MergedModule->setTargetTriple(Triple(TripleStr));
-  }
-  llvm::Triple Triple(TripleStr);
+  if (const Triple &TT = MergedModule->getTargetTriple(); TT.empty())
+    MergedModule->setTargetTriple(Triple(sys::getDefaultTargetTriple()));
 
   // create target machine from info for merged modules
   std::string ErrMsg;
-  MArch = TargetRegistry::lookupTarget(Triple, ErrMsg);
+  MArch = TargetRegistry::lookupTarget(MergedModule->getTargetTriple(), ErrMsg);
   if (!MArch) {
     emitError(ErrMsg);
     return false;
@@ -393,10 +389,10 @@ bool LTOCodeGenerator::determineTarget() {
   // Construct LTOModule, hand over ownership of module and target. Use MAttr as
   // the default set of features.
   SubtargetFeatures Features(join(Config.MAttrs, ""));
-  Features.getDefaultSubtargetFeatures(Triple);
+  Features.getDefaultSubtargetFeatures(MergedModule->getTargetTriple());
   FeatureStr = Features.getString();
   if (Config.CPU.empty())
-    Config.CPU = lto::getThinLTODefaultCPU(Triple);
+    Config.CPU = lto::getThinLTODefaultCPU(MergedModule->getTargetTriple());
 
   // If data-sections is not explicitly set or unset, set data-sections by
   // default to match the behaviour of lld and gold plugin.
@@ -412,7 +408,7 @@ bool LTOCodeGenerator::determineTarget() {
 std::unique_ptr<TargetMachine> LTOCodeGenerator::createTargetMachine() {
   assert(MArch && "MArch is not set!");
   return std::unique_ptr<TargetMachine>(MArch->createTargetMachine(
-      Triple(TripleStr), Config.CPU, FeatureStr, Config.Options,
+      MergedModule->getTargetTriple(), Config.CPU, FeatureStr, Config.Options,
       Config.RelocModel, std::nullopt, Config.CGOptLevel));
 }
 


### PR DESCRIPTION
Simplify Triple computing code and avoid reconstruction and
string based logic