### PR TITLE
[Support] Rename CTLog2 to ConstantLog2 in MathExtras.h

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1038,7 +1038,7 @@ public:
 // PointerLikeTypeTraits is specialized so it can be used with a forward-decl of
 // Expr. Verify that we got it right.
 static_assert(llvm::PointerLikeTypeTraits<Expr *>::NumLowBitsAvailable <=
-                  llvm::CTLog2<alignof(Expr)>(),
+                  llvm::ConstantLog2<alignof(Expr)>(),
               "PointerLikeTypeTraits<Expr*> assumes too much alignment.");
 
 using ConstantExprKind = Expr::ConstantExprKind;

--- a/lld/MachO/Target.h
+++ b/lld/MachO/Target.h
@@ -49,7 +49,7 @@ public:
     pageZeroSize = LP::pageZeroSize;
     headerSize = sizeof(typename LP::mach_header);
     wordSize = LP::wordSize;
-    p2WordSize = llvm::CTLog2<LP::wordSize>();
+    p2WordSize = llvm::ConstantLog2<LP::wordSize>();
   }
 
   virtual ~TargetInfo() = default;

--- a/llvm/include/llvm/Support/Alignment.h
+++ b/llvm/include/llvm/Support/Alignment.h
@@ -94,7 +94,7 @@ public:
 
   /// Allow constructions of constexpr Align.
   template <size_t kValue> constexpr static Align Constant() {
-    return LogValue{static_cast<uint8_t>(CTLog2<kValue>())};
+    return LogValue{static_cast<uint8_t>(ConstantLog2<kValue>())};
   }
 
   /// Allow constructions of constexpr Align from types.

--- a/llvm/include/llvm/Support/MathExtras.h
+++ b/llvm/include/llvm/Support/MathExtras.h
@@ -323,12 +323,18 @@ inline bool isShiftedMask_64(uint64_t Value, unsigned &MaskIdx,
 
 /// Compile time Log2.
 /// Valid only for positive powers of two.
-template <size_t kValue> constexpr size_t CTLog2() {
+template <size_t kValue> constexpr size_t ConstantLog2() {
   static_assert(llvm::isPowerOf2_64(kValue), "Value is not a valid power of 2");
-  return 1 + CTLog2<kValue / 2>();
+  return 1 + ConstantLog2<kValue / 2>();
 }
 
-template <> constexpr size_t CTLog2<1>() { return 0; }
+template <> constexpr size_t ConstantLog2<1>() { return 0; }
+
+template <size_t kValue>
+LLVM_DEPRECATED("Use ConstantLog2 instead", "ConstantLog2")
+constexpr size_t CTLog2() {
+  return ConstantLog2<kValue>();
+}
 
 /// Return the floor log base 2 of the specified value, -1 if the value is zero.
 /// (32 bit edition.)

--- a/llvm/include/llvm/Support/PointerLikeTypeTraits.h
+++ b/llvm/include/llvm/Support/PointerLikeTypeTraits.h
@@ -51,7 +51,7 @@ template <typename T> struct PointerLikeTypeTraits<T *> {
   static inline void *getAsVoidPointer(T *P) { return P; }
   static inline T *getFromVoidPointer(void *P) { return static_cast<T *>(P); }
 
-  static constexpr int NumLowBitsAvailable = CTLog2<alignof(T)>();
+  static constexpr int NumLowBitsAvailable = ConstantLog2<alignof(T)>();
 };
 
 template <> struct PointerLikeTypeTraits<void *> {
@@ -116,7 +116,7 @@ template <> struct PointerLikeTypeTraits<uintptr_t> {
 /// potentially use alignment attributes on functions to satisfy that.
 template <int Alignment, typename FunctionPointerT>
 struct FunctionPointerLikeTypeTraits {
-  static constexpr int NumLowBitsAvailable = CTLog2<Alignment>();
+  static constexpr int NumLowBitsAvailable = ConstantLog2<Alignment>();
   static inline void *getAsVoidPointer(FunctionPointerT P) {
     assert((reinterpret_cast<uintptr_t>(P) &
             ~((uintptr_t)-1 << NumLowBitsAvailable)) == 0 &&

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -8561,7 +8561,8 @@ protected:
   /// Mapping from *single* memory location kinds, e.g., LOCAL_MEM with the
   /// value of NO_LOCAL_MEM, to the accesses encountered for this memory kind.
   using AccessSet = SmallSet<AccessInfo, 2, AccessInfo>;
-  std::array<AccessSet *, llvm::CTLog2<VALID_STATE>()> AccessKind2Accesses;
+  std::array<AccessSet *, llvm::ConstantLog2<VALID_STATE>()>
+      AccessKind2Accesses;
 
   /// Categorize the pointer arguments of CB that might access memory in
   /// AccessedLoc and update the state and access map accordingly.

--- a/llvm/unittests/Support/MathExtrasTest.cpp
+++ b/llvm/unittests/Support/MathExtrasTest.cpp
@@ -152,23 +152,23 @@ TEST(MathExtras, PowerOf2Ceil) {
   EXPECT_EQ(8U, PowerOf2Ceil(7U));
 }
 
-TEST(MathExtras, CTLog2) {
-  EXPECT_EQ(CTLog2<1ULL << 0>(), 0U);
-  EXPECT_EQ(CTLog2<1ULL << 1>(), 1U);
-  EXPECT_EQ(CTLog2<1ULL << 2>(), 2U);
-  EXPECT_EQ(CTLog2<1ULL << 3>(), 3U);
-  EXPECT_EQ(CTLog2<1ULL << 4>(), 4U);
-  EXPECT_EQ(CTLog2<1ULL << 5>(), 5U);
-  EXPECT_EQ(CTLog2<1ULL << 6>(), 6U);
-  EXPECT_EQ(CTLog2<1ULL << 7>(), 7U);
-  EXPECT_EQ(CTLog2<1ULL << 8>(), 8U);
-  EXPECT_EQ(CTLog2<1ULL << 9>(), 9U);
-  EXPECT_EQ(CTLog2<1ULL << 10>(), 10U);
-  EXPECT_EQ(CTLog2<1ULL << 11>(), 11U);
-  EXPECT_EQ(CTLog2<1ULL << 12>(), 12U);
-  EXPECT_EQ(CTLog2<1ULL << 13>(), 13U);
-  EXPECT_EQ(CTLog2<1ULL << 14>(), 14U);
-  EXPECT_EQ(CTLog2<1ULL << 15>(), 15U);
+TEST(MathExtras, ConstantLog2) {
+  EXPECT_EQ(ConstantLog2<1ULL << 0>(), 0U);
+  EXPECT_EQ(ConstantLog2<1ULL << 1>(), 1U);
+  EXPECT_EQ(ConstantLog2<1ULL << 2>(), 2U);
+  EXPECT_EQ(ConstantLog2<1ULL << 3>(), 3U);
+  EXPECT_EQ(ConstantLog2<1ULL << 4>(), 4U);
+  EXPECT_EQ(ConstantLog2<1ULL << 5>(), 5U);
+  EXPECT_EQ(ConstantLog2<1ULL << 6>(), 6U);
+  EXPECT_EQ(ConstantLog2<1ULL << 7>(), 7U);
+  EXPECT_EQ(ConstantLog2<1ULL << 8>(), 8U);
+  EXPECT_EQ(ConstantLog2<1ULL << 9>(), 9U);
+  EXPECT_EQ(ConstantLog2<1ULL << 10>(), 10U);
+  EXPECT_EQ(ConstantLog2<1ULL << 11>(), 11U);
+  EXPECT_EQ(ConstantLog2<1ULL << 12>(), 12U);
+  EXPECT_EQ(ConstantLog2<1ULL << 13>(), 13U);
+  EXPECT_EQ(ConstantLog2<1ULL << 14>(), 14U);
+  EXPECT_EQ(ConstantLog2<1ULL << 15>(), 15U);
 }
 
 TEST(MathExtras, MinAlign) {


### PR DESCRIPTION
This patch renames CTLog2 to ConstantLog2 for readability.

This patch provides a forwarder under LLVM_DEPRECATED because CTLog2
is used downstream.
