### PR TITLE
[libcxx][ci][NFC] Remove commented install line and disutils reference

### DIFF
--- a/libcxx/utils/ci/Dockerfile
+++ b/libcxx/utils/ci/Dockerfile
@@ -76,6 +76,9 @@ RUN sudo apt-get update \
     && sudo apt-get install -y \
         tzdata
 
+# Install various tools used by the build or the test suite
+# TODO add ninja-build once 1.11 is available in Ubuntu, also remove the manual
+# installation below.
 RUN sudo apt-get update \
     && sudo apt-get install -y \
         bash \
@@ -108,9 +111,6 @@ RUN sudo apt-get update \
         xz-utils \
     && sudo rm -rf /var/lib/apt/lists/*
 
-# Install various tools used by the build or the test suite
-#RUN apt-get update && apt-get install -y ninja-build python3 python3-distutils python3-psutil git gdb ccache
-# TODO add ninja-build once 1.11 is available in Ubuntu, also remove the manual installation.
 RUN <<EOF
   set -e
   wget -qO /tmp/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip


### PR DESCRIPTION
76667c768e6403e71718340a946e6f2f356bf745 added distutils because "spawn" was used, which I then removed in 268a4b0a451432833d3b398c7182d133c865dff5.

I removed it as part of removing all uses of distutils in llvm-project, tracked in #54337. Python has removed distutils in its latest versions.

Distutils was not being installed in the docker image but just mentioned in a commented out line. I think this line was leftover from when it was reformated into the multi-line command above.

So I'm removing the whole line and relocating the comments a bit.