### PR TITLE
[clang][ASTImporter] Fixed test 'ctu-import-type-decl-definition' and ASTImporter

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -1745,15 +1745,13 @@ ExpectedType ASTNodeImporter::VisitTagType(const TagType *T) {
   if (!ToDeclOrErr)
     return ToDeclOrErr.takeError();
 
-  if (DeclForType->isUsed()) {
-    // If there is a definition of the 'OriginalDecl', it should be imported to
-    // have all information for the type in the "To" AST. (In some cases no
-    // other reference may exist to the definition decl and it would not be
-    // imported otherwise.)
-    Expected<TagDecl *> ToDefDeclOrErr = import(DeclForType->getDefinition());
-    if (!ToDefDeclOrErr)
-      return ToDefDeclOrErr.takeError();
-  }
+  // If there is a definition of the 'OriginalDecl', it should be imported to
+  // have all information for the type in the "To" AST. (In some cases no
+  // other reference may exist to the definition decl and it would not be
+  // imported otherwise.)
+  Expected<TagDecl *> ToDefDeclOrErr = import(DeclForType->getDefinition());
+  if (!ToDefDeclOrErr)
+    return ToDefDeclOrErr.takeError();
 
   if (T->isCanonicalUnqualified())
     return Importer.getToContext().getCanonicalTagType(*ToDeclOrErr);

--- a/clang/test/Analysis/ctu-import-type-decl-definition.c
+++ b/clang/test/Analysis/ctu-import-type-decl-definition.c
@@ -2,26 +2,28 @@
 // RUN: mkdir -p %t
 // RUN: split-file %s %t
 
-// RUN: %clang_cc1 -emit-pch -o %t/import.c.ast %t/import.c
+// RUN: %clang_cc1 -x c -emit-pch -o %t/import.c.ast %t/import.c
 
-// RUN: %clang_extdef_map -- -x c %t/import.c >> %t/externalDefMap.tmp.txt
-// RUN: sed 's/$/.ast/' %t/externalDefMap.tmp.txt >> %t/externalDefMap.txt
+// RUN: %clang_extdef_map %t/import.c -- -c -x c > %t/externalDefMap.tmp.txt
+// RUN: sed 's/$/.ast/' %t/externalDefMap.tmp.txt > %t/externalDefMap.txt
 
 // RUN: %clang_cc1 -analyze \
 // RUN:   -analyzer-checker=core \
 // RUN:   -analyzer-config experimental-enable-naive-ctu-analysis=true \
 // RUN:   -analyzer-config display-ctu-progress=true \
 // RUN:   -analyzer-config ctu-dir=%t \
-// RUN:   -verify %t/main.c
+// RUN:   -verify %t/main.c 2>&1 | FileCheck %s
 
 //--- main.c
 
 // expected-no-diagnostics
+// CHECK: CTU loaded AST file:
 
 typedef struct X_s X_t;
-unsigned long f_import(struct X_s *xPtr);
 
-static void freeWriteFileResources(struct X_s *xPtr) {
+long f_import(struct X_s *xPtr);
+
+static void f_main(struct X_s *xPtr) {
   f_import(xPtr);
 }
 
@@ -36,7 +38,7 @@ struct X_s {
   Y_t y;
 };
 
-unsigned long f_import(struct X_s *xPtr) {
+long f_import(struct X_s *xPtr) {
   if (xPtr != 0) {
   }
   return 0;

--- a/clang/unittests/AST/ASTImporterTest.cpp
+++ b/clang/unittests/AST/ASTImporterTest.cpp
@@ -10025,7 +10025,8 @@ protected:
       EXPECT_EQ(ToD->getPreviousDecl(), ToDInherited);
     } else {
       EXPECT_EQ(FromD, FromDInherited->getPreviousDecl());
-      EXPECT_EQ(ToD, ToDInherited->getPreviousDecl());
+      // The order is reversed by the import process.
+      EXPECT_EQ(ToD->getPreviousDecl(), ToDInherited);
     }
   }
 


### PR DESCRIPTION
The test was faulty and did not reproduce the error in ASTImporter. The previous fix #156056 for the crash was not correct, this is fixed here.