### PR TITLE
[clang][bytecode] Don't update temporary in InitGlobalTemp*

### DIFF
--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -331,18 +331,17 @@ bool EvalEmitter::emitDestroy(uint32_t I, const SourceInfo &Info) {
 /// This is what we do here.
 void EvalEmitter::updateGlobalTemporaries() {
   for (const auto &[E, Temp] : S.SeenGlobalTemporaries) {
-    if (UnsignedOrNone GlobalIndex = P.getGlobal(E)) {
-      const Pointer &Ptr = P.getPtrGlobal(*GlobalIndex);
-      APValue *Cached = Temp->getOrCreateValue(true);
-
-      if (OptPrimType T = Ctx.classify(E->getType())) {
-        TYPE_SWITCH(
-            *T, { *Cached = Ptr.deref<T>().toAPValue(Ctx.getASTContext()); });
-      } else {
-        if (std::optional<APValue> APV =
-                Ptr.toRValue(Ctx, Temp->getTemporaryExpr()->getType()))
-          *Cached = *APV;
-      }
+    UnsignedOrNone GlobalIndex = P.getGlobal(E);
+    assert(GlobalIndex);
+    const Pointer &Ptr = P.getPtrGlobal(*GlobalIndex);
+    APValue *Cached = Temp->getOrCreateValue(true);
+    if (OptPrimType T = Ctx.classify(E->getType())) {
+      TYPE_SWITCH(*T,
+                  { *Cached = Ptr.deref<T>().toAPValue(Ctx.getASTContext()); });
+    } else {
+      if (std::optional<APValue> APV =
+              Ptr.toRValue(Ctx, Temp->getTemporaryExpr()->getType()))
+        *Cached = *APV;
     }
   }
   S.SeenGlobalTemporaries.clear();

--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1527,15 +1527,10 @@ bool InitGlobal(InterpState &S, CodePtr OpPC, uint32_t I) {
 template <PrimType Name, class T = typename PrimConv<Name>::T>
 bool InitGlobalTemp(InterpState &S, CodePtr OpPC, uint32_t I,
                     const LifetimeExtendedTemporaryDecl *Temp) {
+  assert(Temp);
+
   const Pointer &Ptr = S.P.getGlobal(I);
-
-  const T Value = S.Stk.peek<T>();
-  APValue APV = Value.toAPValue(S.getASTContext());
-  APValue *Cached = Temp->getOrCreateValue(true);
-  *Cached = APV;
-
   assert(Ptr.getDeclDesc()->asExpr());
-
   S.SeenGlobalTemporaries.push_back(
       std::make_pair(Ptr.getDeclDesc()->asExpr(), Temp));
 
@@ -1550,19 +1545,11 @@ bool InitGlobalTemp(InterpState &S, CodePtr OpPC, uint32_t I,
 inline bool InitGlobalTempComp(InterpState &S, CodePtr OpPC,
                                const LifetimeExtendedTemporaryDecl *Temp) {
   assert(Temp);
-  const Pointer &P = S.Stk.peek<Pointer>();
-  APValue *Cached = Temp->getOrCreateValue(true);
 
+  const Pointer &Ptr = S.Stk.peek<Pointer>();
   S.SeenGlobalTemporaries.push_back(
-      std::make_pair(P.getDeclDesc()->asExpr(), Temp));
-
-  if (std::optional<APValue> APV =
-          P.toRValue(S.getASTContext(), Temp->getTemporaryExpr()->getType())) {
-    *Cached = *APV;
-    return true;
-  }
-
-  return false;
+      std::make_pair(Ptr.getDeclDesc()->asExpr(), Temp));
+  return true;
 }
 
 template <PrimType Name, class T = typename PrimConv<Name>::T>


### PR DESCRIPTION
We can save ourselves the conversion to an APValue here since we will do that later in updateGlobalTemporaries() anyway.