### PR TITLE
[Dexter] Add `-v` to lit dexter substitutions

### DIFF
--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -116,7 +116,7 @@ def configure_dexter_substitutions():
     dexter_path = os.path.join(
         config.cross_project_tests_src_root, "debuginfo-tests", "dexter", "dexter.py"
     )
-    tools.append(ToolSubst("%dexter", f'"{sys.executable}" "{dexter_path}" test'))
+    tools.append(ToolSubst("%dexter", f'"{sys.executable}" "{dexter_path}" test -v'))
     if lldb_dap_path is not None:
         tools.append(
             ToolSubst(
@@ -167,7 +167,7 @@ def configure_dexter_substitutions():
             '"{}"'.format(sys.executable),
             '"{}"'.format(dexter_path),
             "test",
-            "--fail-lt 1.0 -w",
+            "--fail-lt 1.0 -w -v",
             "--debugger",
             dexter_regression_test_debugger,
             dexter_regression_test_additional_flags,


### PR DESCRIPTION
Buildbot cross-project-tests-sie-ubuntu has been flaky after moving to lldb-dap.

https://lab.llvm.org/buildbot/#/builders/181/builds/27670 - this test fails for a single run but unfortunately there's not enough output to diagnose it.

Add `-v` to the substitutions to get as much info as possible out of failures. Most tests already have -v added manually. If we ever find a tests needs to specifically run without it we can revert this and add `-v` manually to tests it's missing from.