### PR TITLE
[mlir] Expand error message to include unregistered dialects.

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2089,14 +2089,14 @@ OperationParser::parseCustomOperation(ArrayRef<ResultRecord> resultIDs) {
       while (regIt != regEnd && loadIt != loadEnd) {
         StringRef reg = *regIt;
         StringRef load = (*loadIt)->getNamespace();
-        if (reg < load) {
-          mergedDialects.emplace_back(*regIt++, isRegistered);
-        } else if (load < reg) {
+        if (load < reg) {
           mergedDialects.emplace_back(load, isOnlyLoaded);
-          loadIt++;
+          ++loadIt;
         } else {
-          mergedDialects.emplace_back(*regIt++, isRegistered);
-          loadIt++;
+          mergedDialects.emplace_back(reg, isRegistered);
+          ++regIt;
+          if (reg == load)
+            ++loadIt;
         }
       }
       for (; regIt != regEnd; ++regIt)

--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -2076,7 +2076,7 @@ OperationParser::parseCustomOperation(ArrayRef<ResultRecord> resultIDs) {
       if (originalOpName != opName)
         diag << " (tried '" << opName << "' as well)";
       auto &note = diag.attachNote();
-      note << "Registered dialects: ";
+      note << "Available dialects: ";
       std::vector<StringRef> registered = getContext()->getAvailableDialects();
       auto loaded = getContext()->getLoadedDialects();
 

--- a/mlir/test/IR/invalid.mlir
+++ b/mlir/test/IR/invalid.mlir
@@ -114,7 +114,7 @@ func.func @non_operation() {
 
 func.func @unknown_dialect_operation() {
   // expected-error@below {{Dialect `foo' not found for custom op 'foo.asd'}}
-  // expected-note-re@below {{Registered dialects:{{.*}} test{{.*}}}}
+  // expected-note-re@below {{Available dialects:{{.*}} test{{.*}}}}
   foo.asd
 }
 


### PR DESCRIPTION
It is possible to load unregistered dialects, this can result in a confusing error message. Mark unregistered but loaded dialects.

This is currently done as a merged list as that is most concise but requires some additional preprocessing (did merge sort given the other two lists are, could do it shorter and probably at not too much extra cost if I just used SetVectors - so alternative which uses less code and may be preferred as performance not critical here).