### PR TITLE
[clang][bytecode] Use bytecode interpreter in EvaluateAsLValue

### DIFF
--- a/clang/lib/AST/ByteCode/Interp.h
+++ b/clang/lib/AST/ByteCode/Interp.h
@@ -1527,6 +1527,8 @@ bool InitGlobal(InterpState &S, CodePtr OpPC, uint32_t I) {
 template <PrimType Name, class T = typename PrimConv<Name>::T>
 bool InitGlobalTemp(InterpState &S, CodePtr OpPC, uint32_t I,
                     const LifetimeExtendedTemporaryDecl *Temp) {
+  if (S.EvalMode == EvaluationMode::ConstantFold)
+    return false;
   assert(Temp);
 
   const Pointer &Ptr = S.P.getGlobal(I);
@@ -1544,6 +1546,8 @@ bool InitGlobalTemp(InterpState &S, CodePtr OpPC, uint32_t I,
 /// 3) Initialized global with index \I with that
 inline bool InitGlobalTempComp(InterpState &S, CodePtr OpPC,
                                const LifetimeExtendedTemporaryDecl *Temp) {
+  if (S.EvalMode == EvaluationMode::ConstantFold)
+    return false;
   assert(Temp);
 
   const Pointer &Ptr = S.Stk.peek<Pointer>();

--- a/clang/lib/AST/ByteCode/InterpState.cpp
+++ b/clang/lib/AST/ByteCode/InterpState.cpp
@@ -25,6 +25,7 @@ InterpState::InterpState(State &Parent, Program &P, InterpStack &Stk,
   CheckingPotentialConstantExpression =
       Parent.CheckingPotentialConstantExpression;
   CheckingForUndefinedBehavior = Parent.CheckingForUndefinedBehavior;
+  EvalMode = Parent.EvalMode;
 }
 
 InterpState::InterpState(State &Parent, Program &P, InterpStack &Stk,
@@ -36,6 +37,7 @@ InterpState::InterpState(State &Parent, Program &P, InterpStack &Stk,
   CheckingPotentialConstantExpression =
       Parent.CheckingPotentialConstantExpression;
   CheckingForUndefinedBehavior = Parent.CheckingForUndefinedBehavior;
+  EvalMode = Parent.EvalMode;
 }
 
 bool InterpState::inConstantContext() const {

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -17611,6 +17611,18 @@ bool Expr::EvaluateAsLValue(EvalResult &Result, const ASTContext &Ctx,
   Info.InConstantContext = InConstantContext;
   LValue LV;
   CheckedTemporaries CheckedTemps;
+
+  if (Info.EnableNewConstInterp) {
+    if (!Info.Ctx.getInterpContext().evaluate(Info, this, Result.Val,
+                                              ConstantExprKind::Normal))
+      return false;
+
+    LV.setFrom(Ctx, Result.Val);
+    return CheckLValueConstantExpression(
+        Info, getExprLoc(), Ctx.getLValueReferenceType(getType()), LV,
+        ConstantExprKind::Normal, CheckedTemps);
+  }
+
   if (!EvaluateLValue(this, LV, Info) || !Info.discardCleanups() ||
       Result.HasSideEffects ||
       !CheckLValueConstantExpression(Info, getExprLoc(),


### PR DESCRIPTION
Set the EvalMode on InterpState and abort when initalizing a global temporary, like the current interpreter does. The rest is just plumbing in EvaluateAsLValue.

Fixes #157497