### PR TITLE
[NFC][clang] replace a C-array with std::array

### DIFF
--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -5211,7 +5211,7 @@ public:
   }
 
   bool hasSpelling() const {
-    return llvm::any_of(Spellings, [](const auto &L) { return L.size() != 0; });
+    return llvm::any_of(Spellings, [](const auto &L) { return !L.empty(); });
   }
 };
 

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -5163,7 +5163,7 @@ enum class SpellingKind : size_t {
 static const size_t NumSpellingKinds = (size_t)SpellingKind::NumSpellingKinds;
 
 class SpellingList {
-  std::vector<std::string> Spellings[NumSpellingKinds];
+  std::array<std::vector<std::string>, NumSpellingKinds> Spellings;
 
 public:
   ArrayRef<std::string> operator[](SpellingKind K) const {
@@ -5211,11 +5211,7 @@ public:
   }
 
   bool hasSpelling() const {
-    for (size_t Kind = 0; Kind < NumSpellingKinds; ++Kind) {
-      if (Spellings[Kind].size() > 0)
-        return true;
-    }
-    return false;
+    return llvm::any_of(Spellings, [](const auto &L) { return L.size() != 0; });
   }
 };
 


### PR DESCRIPTION
Follow up to #157841, replacing the C-array with std::array so iterators can be used.