### PR TITLE
[lldb] Fix undefined behavior

### DIFF
--- a/lldb/source/Plugins/Instruction/ARM/EmulateInstructionARM.cpp
+++ b/lldb/source/Plugins/Instruction/ARM/EmulateInstructionARM.cpp
@@ -14135,7 +14135,13 @@ EmulateInstructionARM::AddWithCarry(uint32_t x, uint32_t y, uint8_t carry_in) {
   uint8_t overflow;
 
   uint64_t unsigned_sum = x + y + carry_in;
-  int64_t signed_sum = (int32_t)x + (int32_t)y + (int32_t)carry_in;
+  int64_t signed_sum = 0;
+  int32_t signed_sum32;
+  if (llvm::AddOverflow((int32_t)x, (int32_t)y, signed_sum32))
+    signed_sum++;
+  signed_sum += signed_sum32;
+
+  signed_sum += (int32_t)carry_in;
 
   result = UnsignedBits(unsigned_sum, 31, 0);
   //    carry_out = (result == unsigned_sum ? 0 : 1);


### PR DESCRIPTION
https://green.lab.llvm.org/job/llvm.org/view/LLDB/job/lldb-cmake-sanitized/2178/consoleText

```
[2025-09-11T13:10:53.352Z] /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-sanitized/llvm-project/lldb/source/Plugins/Instruction/ARM/EmulateInstructionARM.cpp:14138:35: runtime error: signed integer overflow: 2147483624 + 608 cannot be represented in type 'int32_t' (aka 'int')
[2025-09-11T13:10:53.352Z] SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/ec2-user/jenkins/workspace/llvm.org/lldb-cmake-sanitized/llvm-project/lldb/source/Plugins/Instruction/ARM/EmulateInstructionARM.cpp:14138:35 in 
```