### PR TITLE
[AArch64][MIR] Serialize AArch64MachineFunctionInfo::HasStackFrame to MIR

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
@@ -28,7 +28,10 @@ yaml::AArch64FunctionInfo::AArch64FunctionInfo(
     : HasRedZone(MFI.hasRedZone()),
       StackSizeSVE(MFI.hasCalculatedStackSizeSVE()
                        ? std::optional<uint64_t>(MFI.getStackSizeSVE())
-                       : std::nullopt) {}
+                       : std::nullopt),
+      HasStackFrame(MFI.hasStackFrame()
+                        ? std::optional<bool>(MFI.hasStackFrame())
+                        : std::nullopt) {}
 
 void yaml::AArch64FunctionInfo::mappingImpl(yaml::IO &YamlIO) {
   MappingTraits<AArch64FunctionInfo>::mapping(YamlIO, *this);
@@ -40,6 +43,8 @@ void AArch64FunctionInfo::initializeBaseYamlFields(
     HasRedZone = YamlMFI.HasRedZone;
   if (YamlMFI.StackSizeSVE)
     setStackSizeSVE(*YamlMFI.StackSizeSVE);
+  if (YamlMFI.HasStackFrame)
+    setHasStackFrame(*YamlMFI.HasStackFrame);
 }
 
 static std::pair<bool, bool> GetSignReturnAddress(const Function &F) {

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.h
@@ -600,6 +600,7 @@ namespace yaml {
 struct AArch64FunctionInfo final : public yaml::MachineFunctionInfo {
   std::optional<bool> HasRedZone;
   std::optional<uint64_t> StackSizeSVE;
+  std::optional<bool> HasStackFrame;
 
   AArch64FunctionInfo() = default;
   AArch64FunctionInfo(const llvm::AArch64FunctionInfo &MFI);
@@ -612,6 +613,7 @@ template <> struct MappingTraits<AArch64FunctionInfo> {
   static void mapping(IO &YamlIO, AArch64FunctionInfo &MFI) {
     YamlIO.mapOptional("hasRedZone", MFI.HasRedZone);
     YamlIO.mapOptional("stackSizeSVE", MFI.StackSizeSVE);
+    YamlIO.mapOptional("hasStackFrame", MFI.HasStackFrame);
   }
 };
 

--- a/llvm/test/CodeGen/MIR/AArch64/hasstackframe.mir
+++ b/llvm/test/CodeGen/MIR/AArch64/hasstackframe.mir
@@ -1,0 +1,41 @@
+# RUN: llc -run-pass=prologepilog -mtriple arm64-apple-ios -o - -simplify-mir \
+# RUN:    -verify-machineinstrs %s | FileCheck %s
+
+# CHECK:  hasStackFrame:   true
+
+--- |
+
+  define i32 @f(i32 %a, i32 %b) #0 {
+    %local_array = alloca [10 x i32], align 4
+    %temp = alloca i32, align 4
+    store i32 %a, ptr %temp, align 4
+    %loaded = load i32, ptr %temp, align 4
+    %gep = getelementptr inbounds [10 x i32], ptr %local_array, i64 0, i64 5
+    store i32 %loaded, ptr %gep, align 4
+    %result = add i32 %loaded, %b
+    %blah = call i32 @foo(i32 noundef %result)
+    ret i32 %blah
+  }
+
+  declare i32 @foo(i32 noundef)
+
+...
+---
+name:            f
+frameInfo:
+  adjustsStack:    true
+stack:
+  - { id: 0, name: local_array, size: 40, alignment: 4, local-offset: -40 }
+  - { id: 1, name: temp, size: 4, alignment: 4, local-offset: -44 }
+body:             |
+  bb.0:
+    liveins: $w0, $w1
+
+    STRWui renamable $w0, %stack.1.temp, 0
+    STRWui renamable $w0, %stack.0.local_array, 5
+    ADJCALLSTACKDOWN 0, 0, implicit-def dead $sp, implicit $sp
+    $w0 = ADDWrr killed renamable $w0, killed renamable $w1
+    BL @foo, csr_darwin_aarch64_aapcs, implicit-def dead $lr, implicit $sp, implicit $w0, implicit-def $sp, implicit-def $w0
+    ADJCALLSTACKUP 0, 0, implicit-def dead $sp, implicit $sp
+    RET_ReallyLR implicit $w0
+...


### PR DESCRIPTION
This patch adds serialization of AArch64MachineFunctionInfo::HasStackFrame into MIR.