### PR TITLE
[tablegen][test] Make additional-encoding.td more reliable

### DIFF
--- a/llvm/test/TableGen/FixedLenDecoderEmitter/additional-encoding.td
+++ b/llvm/test/TableGen/FixedLenDecoderEmitter/additional-encoding.td
@@ -40,7 +40,7 @@ class I<dag out_ops, dag in_ops> : Instruction {
 // CHECK-NEXT: /* 26 */ MCD::OPC_Scope, 8, 0, // Skip to: 37
 // CHECK-NEXT: /* 29 */ MCD::OPC_CheckField, 6, 6, 0,
 // CHECK-NEXT: /* 33 */ MCD::OPC_Decode, {{[0-9]+}}, 2, 0, // Opcode: {{.*}}:NOP, DecodeIdx: 0
-// CHECK-NEXT: /* 37 */ MCD::OPC_TryDecode, {{0-9]+}}, 2, 1,
+// CHECK-NEXT: /* 37 */ MCD::OPC_TryDecode, {{[0-9]+}}, 2, 1,
 // CHECK-NEXT: /* 41 */ MCD::OPC_FilterValueOrSkip, 2, 15, 0, // Skip to: 60
 // CHECK-NEXT: /* 45 */ MCD::OPC_Scope, 8, 0, // Skip to: 56
 // CHECK-NEXT: /* 48 */ MCD::OPC_CheckField, 6, 6, 0,
@@ -50,7 +50,7 @@ class I<dag out_ops, dag in_ops> : Instruction {
 // CHECK-NEXT: /* 62 */ MCD::OPC_Scope, 8, 0, // Skip to: 73
 // CHECK-NEXT: /* 65 */ MCD::OPC_CheckField, 6, 6, 0,
 // CHECK-NEXT: /* 69 */ MCD::OPC_Decode, {{[0-9]+}}, 2, 0, // Opcode: {{.*}}:NOP, DecodeIdx: 0
-// CHECK-NEXT: /* 73 */ MCD::OPC_TryDecode, {{0-9]+}}, 2, 1,
+// CHECK-NEXT: /* 73 */ MCD::OPC_TryDecode, {{[0-9]+}}, 2, 1,
 
 
 class SHIFT<bits<2> opc> : I<(outs), (ins ShAmtOp:$shamt)>, EncSHIFT<opc>;

--- a/llvm/test/TableGen/FixedLenDecoderEmitter/additional-encoding.td
+++ b/llvm/test/TableGen/FixedLenDecoderEmitter/additional-encoding.td
@@ -35,22 +35,22 @@ class I<dag out_ops, dag in_ops> : Instruction {
 // CHECK-NEXT: /* 7 */  MCD::OPC_Scope, 8, 0, // Skip to: 18
 // CHECK-NEXT: /* 10 */ MCD::OPC_CheckField, 6, 6, 0,
 // CHECK-NEXT: /* 14 */ MCD::OPC_Decode, {{[0-9]+}}, 2, 0, // Opcode: {{.*}}:NOP, DecodeIdx: 0
-// CHECK-NEXT: /* 18 */ MCD::OPC_TryDecode, 187, 2, 1,
+// CHECK-NEXT: /* 18 */ MCD::OPC_TryDecode, {{[0-9]+}}, 2, 1,
 // CHECK-NEXT: /* 22 */ MCD::OPC_FilterValueOrSkip, 1, 15, 0, // Skip to: 41
 // CHECK-NEXT: /* 26 */ MCD::OPC_Scope, 8, 0, // Skip to: 37
 // CHECK-NEXT: /* 29 */ MCD::OPC_CheckField, 6, 6, 0,
 // CHECK-NEXT: /* 33 */ MCD::OPC_Decode, {{[0-9]+}}, 2, 0, // Opcode: {{.*}}:NOP, DecodeIdx: 0
-// CHECK-NEXT: /* 37 */ MCD::OPC_TryDecode, 188, 2, 1,
+// CHECK-NEXT: /* 37 */ MCD::OPC_TryDecode, {{0-9]+}}, 2, 1,
 // CHECK-NEXT: /* 41 */ MCD::OPC_FilterValueOrSkip, 2, 15, 0, // Skip to: 60
 // CHECK-NEXT: /* 45 */ MCD::OPC_Scope, 8, 0, // Skip to: 56
 // CHECK-NEXT: /* 48 */ MCD::OPC_CheckField, 6, 6, 0,
 // CHECK-NEXT: /* 52 */ MCD::OPC_Decode, {{[0-9]+}}, 2, 0, // Opcode: {{.*}}:NOP, DecodeIdx: 0
-// CHECK-NEXT: /* 56 */ MCD::OPC_TryDecode, 189, 2, 1,
+// CHECK-NEXT: /* 56 */ MCD::OPC_TryDecode, {{[0-9]+}}, 2, 1,
 // CHECK-NEXT: /* 60 */ MCD::OPC_FilterValue, 3,
 // CHECK-NEXT: /* 62 */ MCD::OPC_Scope, 8, 0, // Skip to: 73
 // CHECK-NEXT: /* 65 */ MCD::OPC_CheckField, 6, 6, 0,
 // CHECK-NEXT: /* 69 */ MCD::OPC_Decode, {{[0-9]+}}, 2, 0, // Opcode: {{.*}}:NOP, DecodeIdx: 0
-// CHECK-NEXT: /* 73 */ MCD::OPC_TryDecode, 190, 2, 1,
+// CHECK-NEXT: /* 73 */ MCD::OPC_TryDecode, {{0-9]+}}, 2, 1,
 
 
 class SHIFT<bits<2> opc> : I<(outs), (ins ShAmtOp:$shamt)>, EncSHIFT<opc>;


### PR DESCRIPTION
Similar to `OPC_Decode`, `OPC_TryDecode` should also be relaxed in case new opcodes are added. `llvm/test/TableGen/trydecode-emission.td` is an example of a test that follows this pattern. Apply the same relaxation in `additional-encoding.td` as well. 