### PR TITLE
[libc][bazel] add tests and targets for ctype

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -1817,6 +1817,168 @@ libc_support_library(
     ],
 )
 
+################################# ctype targets ################################
+
+libc_function(
+    name = "isalnum",
+    srcs = ["src/ctype/isalnum.cpp"],
+    hdrs = ["src/ctype/isalnum.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isalpha",
+    srcs = ["src/ctype/isalpha.cpp"],
+    hdrs = ["src/ctype/isalpha.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isascii",
+    srcs = ["src/ctype/isascii.cpp"],
+    hdrs = ["src/ctype/isascii.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isblank",
+    srcs = ["src/ctype/isblank.cpp"],
+    hdrs = ["src/ctype/isblank.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "iscntrl",
+    srcs = ["src/ctype/iscntrl.cpp"],
+    hdrs = ["src/ctype/iscntrl.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isdigit",
+    srcs = ["src/ctype/isdigit.cpp"],
+    hdrs = ["src/ctype/isdigit.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isgraph",
+    srcs = ["src/ctype/isgraph.cpp"],
+    hdrs = ["src/ctype/isgraph.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "islower",
+    srcs = ["src/ctype/islower.cpp"],
+    hdrs = ["src/ctype/islower.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isprint",
+    srcs = ["src/ctype/isprint.cpp"],
+    hdrs = ["src/ctype/isprint.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "ispunct",
+    srcs = ["src/ctype/ispunct.cpp"],
+    hdrs = ["src/ctype/ispunct.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isspace",
+    srcs = ["src/ctype/isspace.cpp"],
+    hdrs = ["src/ctype/isspace.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isupper",
+    srcs = ["src/ctype/isupper.cpp"],
+    hdrs = ["src/ctype/isupper.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "isxdigit",
+    srcs = ["src/ctype/isxdigit.cpp"],
+    hdrs = ["src/ctype/isxdigit.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "toascii",
+    srcs = ["src/ctype/toascii.cpp"],
+    hdrs = ["src/ctype/toascii.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "tolower",
+    srcs = ["src/ctype/tolower.cpp"],
+    hdrs = ["src/ctype/tolower.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
+libc_function(
+    name = "toupper",
+    srcs = ["src/ctype/toupper.cpp"],
+    hdrs = ["src/ctype/toupper.h"],
+    deps = [
+        ":__support_common",
+        ":__support_ctype_utils",
+    ],
+)
+
 ################################ fenv targets ################################
 
 libc_function(

--- a/utils/bazel/llvm-project-overlay/libc/test/src/ctype/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/ctype/BUILD.bazel
@@ -1,0 +1,147 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Tests for LLVM libc ctype.h functions.
+
+load("//libc/test:libc_test_rules.bzl", "libc_test")
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+libc_test(
+    name = "isalnum_test",
+    srcs = ["isalnum_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:isalnum",
+    ],
+)
+
+libc_test(
+    name = "islpha_test",
+    srcs = ["isalpha_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:isalpha",
+    ],
+)
+
+libc_test(
+    name = "isascii_test",
+    srcs = ["isascii_test.cpp"],
+    deps = [
+        "//libc:isascii",
+    ],
+)
+
+libc_test(
+    name = "isblank_test",
+    srcs = ["isblank_test.cpp"],
+    deps = [
+        "//libc:isblank",
+    ],
+)
+
+libc_test(
+    name = "iscntrl_test",
+    srcs = ["iscntrl_test.cpp"],
+    deps = [
+        "//libc:iscntrl",
+    ],
+)
+
+libc_test(
+    name = "isdigit_test",
+    srcs = ["isdigit_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:isdigit",
+    ],
+)
+
+libc_test(
+    name = "isgraph_test",
+    srcs = ["isgraph_test.cpp"],
+    deps = [
+        "//libc:isgraph",
+    ],
+)
+
+libc_test(
+    name = "islower_test",
+    srcs = ["islower_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:islower",
+    ],
+)
+
+libc_test(
+    name = "isprint_test",
+    srcs = ["isprint_test.cpp"],
+    deps = [
+        "//libc:isprint",
+    ],
+)
+
+libc_test(
+    name = "ispunct_test",
+    srcs = ["ispunct_test.cpp"],
+    deps = [
+        "//libc:ispunct",
+    ],
+)
+
+libc_test(
+    name = "isspace_test",
+    srcs = ["isspace_test.cpp"],
+    deps = [
+        "//libc:isspace",
+    ],
+)
+
+libc_test(
+    name = "isupper_test",
+    srcs = ["isupper_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:isupper",
+    ],
+)
+
+libc_test(
+    name = "isxdigit_test",
+    srcs = ["isxdigit_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:isxdigit",
+    ],
+)
+
+libc_test(
+    name = "toascii_test",
+    srcs = ["toascii_test.cpp"],
+    deps = [
+        "//libc:toascii",
+    ],
+)
+
+libc_test(
+    name = "tolower_test",
+    srcs = ["tolower_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:tolower",
+    ],
+)
+
+libc_test(
+    name = "toupper_test",
+    srcs = ["toupper_test.cpp"],
+    deps = [
+        "//libc:__support_cpp_span",
+        "//libc:toupper",
+    ],
+)


### PR DESCRIPTION
Adds tests and targets for all the ctype functions.
