### PR TITLE
[libc][bazel] Add tests and targets for inttypes

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -4609,6 +4609,28 @@ libc_math_function(name = "ufromfpxf16")
 ############################## inttypes targets ##############################
 
 libc_function(
+    name = "strtoimax",
+    srcs = ["src/inttypes/strtoimax.cpp"],
+    hdrs = ["src/inttypes/strtoimax.h"],
+    deps = [
+        ":__support_common",
+        ":__support_str_to_integer",
+        ":errno",
+    ],
+)
+
+libc_function(
+    name = "strtoumax",
+    srcs = ["src/inttypes/strtoumax.cpp"],
+    hdrs = ["src/inttypes/strtoumax.h"],
+    deps = [
+        ":__support_common",
+        ":__support_str_to_integer",
+        ":errno",
+    ],
+)
+
+libc_function(
     name = "imaxabs",
     srcs = ["src/inttypes/imaxabs.cpp"],
     hdrs = ["src/inttypes/imaxabs.h"],

--- a/utils/bazel/llvm-project-overlay/libc/test/src/inttypes/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/inttypes/BUILD.bazel
@@ -11,6 +11,24 @@ package(default_visibility = ["//visibility:public"])
 licenses(["notice"])
 
 libc_test(
+    name = "strtoimax_test",
+    srcs = ["strtoimax_test.cpp"],
+    deps = [
+        "//libc:strtoimax",
+        "//libc/test/src/stdlib:strtol_test_helper",
+    ],
+)
+
+libc_test(
+    name = "strtoumax_test",
+    srcs = ["strtoumax_test.cpp"],
+    deps = [
+        "//libc:strtoumax",
+        "//libc/test/src/stdlib:strtol_test_helper",
+    ],
+)
+
+libc_test(
     name = "imaxabs_test",
     srcs = ["imaxabs_test.cpp"],
     deps = [


### PR DESCRIPTION
Adds tests and targets for the remaining inttypes functions.
