### PR TITLE
[llvm-debuginfod] Update tests to work with internal shell

### DIFF
--- a/llvm/test/tools/llvm-debuginfod-find/cache.test
+++ b/llvm/test/tools/llvm-debuginfod-find/cache.test
@@ -2,9 +2,10 @@ REQUIRES: curl
 UNSUPPORTED: system-windows
 
 RUN: rm -rf %t/*
-RUN: mkdir -p %t/buildid/012345678901234{5,6}
+RUN: mkdir -p %t/buildid/0123456789012345
+RUN: mkdir -p %t/buildid/0123456789012346
 RUN: echo 'f' > %t/buildid/0123456789012345/debuginfo
-RUN: cp %t/buildid/012345678901234{5,6}/debuginfo
+RUN: cp %t/buildid/0123456789012345/debuginfo %t/buildid/0123456789012346/debuginfo
 RUN: mkdir %t/cache
 RUN: env DEBUGINFOD_CACHE_PATH=%t/cache DEBUGINFOD_URLS=file://%t \
 RUN:   llvm-debuginfod-find --debuginfo 0123456789012345 > /dev/null

--- a/llvm/test/tools/llvm-debuginfod/llvm-debuginfod.test
+++ b/llvm/test/tools/llvm-debuginfod/llvm-debuginfod.test
@@ -13,20 +13,20 @@
 # RUN: rm -rf %t
 # RUN: mkdir %t
 # # Query the debuginfod server for artifacts
-# RUN: DEBUGINFOD_CACHE_PATH=%t %python %s --server-cmd 'llvm-debuginfod -v -c 3 %S/Inputs' \
+# RUN: env DEBUGINFOD_CACHE_PATH=%t %python %s --server-cmd 'llvm-debuginfod -v -c 3 %S/Inputs' \
 # RUN:   --tool-cmd 'llvm-debuginfod-find --dump --executable 2c39b7557c50162aaeb5a3148c9f76e6e46012e3' | \
 # RUN:   diff - %S/Inputs/main.exe
-# RUN: DEBUGINFOD_CACHE_PATH=%t %python %s --server-cmd 'llvm-debuginfod -v -c 3 %S/Inputs' \
+# RUN: env DEBUGINFOD_CACHE_PATH=%t %python %s --server-cmd 'llvm-debuginfod -v -c 3 %S/Inputs' \
 # RUN:   --tool-cmd 'llvm-debuginfod-find --dump --debuginfo 2c39b7557c50162aaeb5a3148c9f76e6e46012e3' | \
 # RUN:   diff - %S/Inputs/main-debug.exe
 # Debuginfod server does not yet support source files
 
 # # The artifacts should still be present in the cache without needing to query
 # # the server.
-# RUN: DEBUGINFOD_CACHE_PATH=%t llvm-debuginfod-find --dump \
+# RUN: env DEBUGINFOD_CACHE_PATH=%t llvm-debuginfod-find --dump \
 # RUN:   --executable 2c39b7557c50162aaeb5a3148c9f76e6e46012e3 | \
 # RUN:   diff - %S/Inputs/main.exe
-# RUN: DEBUGINFOD_CACHE_PATH=%t llvm-debuginfod-find --dump \
+# RUN: env DEBUGINFOD_CACHE_PATH=%t llvm-debuginfod-find --dump \
 # RUN:   --debuginfo 2c39b7557c50162aaeb5a3148c9f76e6e46012e3 | \
 # RUN:   diff - %S/Inputs/main-debug.exe
 


### PR DESCRIPTION
This patch updates the llvm-debuginfod tests to work with the lit internal shell. One test was missing env before environment variables and another was using a brace expansion.