### PR TITLE
[bazel] Fix bazel test by specifying unroll-elements.mlir as data

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/test/Dialect/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/test/Dialect/BUILD.bazel
@@ -9,6 +9,7 @@ package(default_visibility = ["//visibility:public"])
         name = "%s.test" % src,
         srcs = [src],
         data = [
+            "Vector/td/unroll-elements.mlir",
             "Vector/vector-sink-transform.mlir",
             "//llvm:llvm-symbolizer",
             "//mlir:mlir-opt",
@@ -33,6 +34,7 @@ package(default_visibility = ["//visibility:public"])
             "LLVM/*-symbol-def.mlir",
             "Transform/*-symbol-decl-and-schedule.mlir",
             "Transform/include/**/*.mlir",
+            "Vector/td/unroll-elements.mlir",
             "Vector/vector-sink-transform.mlir",
         ],
     )


### PR DESCRIPTION
`mlir/test/Dialect/Vector/td/unroll-elements.mlir` is fed as a data dependency into`mlir/test/Dialect/Vector/vector-to-elements-lowering.mlir` added in [#157142](https://github.com/llvm/llvm-project/pull/157142). The Bazel rule here automatically picks up all mlir files as tests, which leads to `vector-to-elements-lowering` failing.