### PR TITLE
RISCV unwinding enable

### DIFF
--- a/lldb/include/lldb/Core/Opcode.h
+++ b/lldb/include/lldb/Core/Opcode.h
@@ -223,7 +223,9 @@ public:
   int Dump(Stream *s, uint32_t min_byte_width) const;
 
   const void *GetOpcodeBytes() const {
-    return ((m_type == Opcode::eTypeBytes) ? m_data.inst.bytes : nullptr);
+    return ((m_type == Opcode::eTypeBytes || m_type == Opcode::eType16_32Tuples)
+                ? m_data.inst.bytes
+                : nullptr);
   }
 
   uint32_t GetByteSize() const {

--- a/lldb/source/Plugins/Instruction/RISCV/EmulateInstructionRISCV.cpp
+++ b/lldb/source/Plugins/Instruction/RISCV/EmulateInstructionRISCV.cpp
@@ -112,6 +112,14 @@ static uint32_t FPREncodingToLLDB(uint32_t reg_encode) {
   return LLDB_INVALID_REGNUM;
 }
 
+// Helper function to get register info from GPR encoding
+static std::optional<RegisterInfo>
+GPREncodingToRegisterInfo(EmulateInstructionRISCV &emulator,
+                          uint32_t reg_encode) {
+  uint32_t lldb_reg = GPREncodingToLLDB(reg_encode);
+  return emulator.GetRegisterInfo(eRegisterKindLLDB, lldb_reg);
+}
+
 bool Rd::Write(EmulateInstructionRISCV &emulator, uint64_t value) {
   uint32_t lldb_reg = GPREncodingToLLDB(rd);
   EmulateInstruction::Context ctx;
@@ -239,9 +247,8 @@ Load(EmulateInstructionRISCV &emulator, I inst, uint64_t (*extend)(E)) {
   EmulateInstructionRISCV::Context context;
 
   // Get register info for base register
-  uint32_t rs1_lldb = GPREncodingToLLDB(inst.rs1.rs);
   std::optional<RegisterInfo> reg_info_rs1 =
-      emulator.GetRegisterInfo(eRegisterKindLLDB, rs1_lldb);
+      GPREncodingToRegisterInfo(emulator, inst.rs1.rs);
 
   if (!reg_info_rs1)
     return false;
@@ -276,12 +283,10 @@ Store(EmulateInstructionRISCV &emulator, I inst) {
   EmulateInstructionRISCV::Context context;
 
   // Get register info for source and base registers
-  uint32_t rs1_lldb = GPREncodingToLLDB(inst.rs1.rs);
-  uint32_t rs2_lldb = GPREncodingToLLDB(inst.rs2.rs);
   std::optional<RegisterInfo> reg_info_rs1 =
-      emulator.GetRegisterInfo(eRegisterKindLLDB, rs1_lldb);
+      GPREncodingToRegisterInfo(emulator, inst.rs1.rs);
   std::optional<RegisterInfo> reg_info_rs2 =
-      emulator.GetRegisterInfo(eRegisterKindLLDB, rs2_lldb);
+      GPREncodingToRegisterInfo(emulator, inst.rs2.rs);
 
   if (!reg_info_rs1 || !reg_info_rs2)
     return false;

--- a/lldb/source/Plugins/Instruction/RISCV/EmulateInstructionRISCV.cpp
+++ b/lldb/source/Plugins/Instruction/RISCV/EmulateInstructionRISCV.cpp
@@ -254,7 +254,7 @@ Load(EmulateInstructionRISCV &emulator, I inst, uint64_t (*extend)(E)) {
     return false;
 
   // Set context type based on whether this is a stack-based load
-  if (inst.rs1.rs == RISCV_GPR_SP) // x2 is the stack pointer in RISC-V
+  if (inst.rs1.rs == RISCV_GPR_SP)
     context.type = EmulateInstruction::eContextPopRegisterOffStack;
   else
     context.type = EmulateInstruction::eContextRegisterLoad;
@@ -805,7 +805,7 @@ public:
                  int64_t result = rs1 + int64_t(SignExt(inst.imm));
                  // Check if this is a stack pointer adjustment
                  if (inst.rd.rd == RISCV_GPR_SP &&
-                     inst.rs1.rs == RISCV_GPR_SP) { // rd=sp, rs1=sp
+                     inst.rs1.rs == RISCV_GPR_SP) {
                    EmulateInstruction::Context context;
                    context.type =
                        EmulateInstruction::eContextAdjustStackPointer;
@@ -819,7 +819,7 @@ public:
                  // Check if this is setting up the frame pointer
                  // addi fp, sp, imm -> fp = sp + imm (frame pointer setup)
                  if (inst.rd.rd == RISCV_GPR_FP &&
-                     inst.rs1.rs == RISCV_GPR_SP) { // rd=fp, rs1=sp
+                     inst.rs1.rs == RISCV_GPR_SP) {
                    EmulateInstruction::Context context;
                    context.type = EmulateInstruction::eContextSetFramePointer;
                    auto sp_reg_info = m_emu.GetRegisterInfo(

--- a/lldb/source/Plugins/Instruction/RISCV/EmulateInstructionRISCV.h
+++ b/lldb/source/Plugins/Instruction/RISCV/EmulateInstructionRISCV.h
@@ -61,6 +61,7 @@ public:
     case eInstructionTypePCModifying:
       return true;
     case eInstructionTypePrologueEpilogue:
+      return true;
     case eInstructionTypeAll:
       return false;
     }
@@ -85,6 +86,7 @@ public:
     return SupportsThisInstructionType(inst_type);
   }
 
+  bool CreateFunctionEntryUnwind(UnwindPlan &unwind_plan) override;
   bool SetTargetTriple(const ArchSpec &arch) override;
   bool ReadInstruction() override;
   std::optional<uint32_t> GetLastInstrSize() override { return m_last_size; }
@@ -94,6 +96,8 @@ public:
   std::optional<RegisterInfo> GetRegisterInfo(lldb::RegisterKind reg_kind,
                                               uint32_t reg_num) override;
 
+  bool SetInstruction(const Opcode &opcode, const Address &inst_addr,
+                      Target *target) override;
   std::optional<DecodeResult> ReadInstructionAt(lldb::addr_t addr);
   std::optional<DecodeResult> Decode(uint32_t inst);
   bool Execute(DecodeResult inst, bool ignore_cond);

--- a/lldb/unittests/Instruction/CMakeLists.txt
+++ b/lldb/unittests/Instruction/CMakeLists.txt
@@ -2,9 +2,11 @@ add_lldb_unittest(EmulatorTests
   ARM64/TestAArch64Emulator.cpp
   LoongArch/TestLoongArchEmulator.cpp
   RISCV/TestRISCVEmulator.cpp
+  RISCV/TestRiscvInstEmulation.cpp
 
   LINK_COMPONENTS
     Support
+    ${LLVM_TARGETS_TO_BUILD}
   LINK_LIBS
     lldbCore
     lldbSymbol
@@ -12,4 +14,7 @@ add_lldb_unittest(EmulatorTests
     lldbPluginInstructionARM64
     lldbPluginInstructionLoongArch
     lldbPluginInstructionRISCV
+    lldbPluginDisassemblerLLVMC
+    lldbPluginUnwindAssemblyInstEmulation
+    lldbPluginProcessUtility
   )

--- a/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
+++ b/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
@@ -105,7 +105,6 @@ TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
   // (after saving s0/fp) row[4]:    8:  CFA=s0+0   => fp=[CFA-16] ra=[CFA-8]
   // (after setting frame pointer: s0=sp+16)
 
-
   const UnwindPlan::Row *row;
   AddressRange sample_range;
   UnwindPlan unwind_plan(eRegisterKindLLDB);

--- a/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
+++ b/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
@@ -27,9 +27,6 @@ public:
   static void SetUpTestCase();
   static void TearDownTestCase();
 
-  //  virtual void SetUp() override { }
-  //  virtual void TearDown() override { }
-
 protected:
 };
 
@@ -55,11 +52,6 @@ TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
       static_cast<UnwindAssemblyInstEmulation *>(
           UnwindAssemblyInstEmulation::CreateInstance(arch)));
   ASSERT_NE(nullptr, engine);
-
-  const UnwindPlan::Row *row;
-  AddressRange sample_range;
-  UnwindPlan unwind_plan(eRegisterKindLLDB);
-  UnwindPlan::Row::AbstractRegisterLocation regloc;
 
   // RISC-V function with compressed and uncompressed instructions
   //   0x0000: 1141          addi    sp, sp, -0x10
@@ -113,8 +105,11 @@ TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
   // (after saving s0/fp) row[4]:    8:  CFA=s0+0   => fp=[CFA-16] ra=[CFA-8]
   // (after setting frame pointer: s0=sp+16)
 
-  // Debug: Print all rows in the unwind plan
 
+  const UnwindPlan::Row *row;
+  AddressRange sample_range;
+  UnwindPlan unwind_plan(eRegisterKindLLDB);
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
   sample_range = AddressRange(0x1000, sizeof(data));
 
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(

--- a/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
+++ b/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
@@ -46,7 +46,7 @@ void TestRiscvInstEmulation::TearDownTestCase() {
 
 TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
   ArchSpec arch("riscv64-unknown-linux-gnu");
-  // Enable compressed instruction support (RVC extension)
+  // Enable compressed instruction support (RVC extension).
   arch.SetFlags(ArchSpec::eRISCV_rvc);
   std::unique_ptr<UnwindAssemblyInstEmulation> engine(
       static_cast<UnwindAssemblyInstEmulation *>(
@@ -114,7 +114,7 @@ TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
   EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
       sample_range, data, sizeof(data), unwind_plan));
 
-  // CFA=sp+0 => fp=<same> ra=<same>
+  // CFA=sp+0 => fp=<same> ra=<same>.
   row = unwind_plan.GetRowForFunctionOffset(0);
   EXPECT_EQ(0, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);
@@ -127,7 +127,7 @@ TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
   EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  // CFA=sp+16 => fp=<same> ra=<same>
+  // CFA=sp+16 => fp=<same> ra=<same>.
   row = unwind_plan.GetRowForFunctionOffset(2);
   EXPECT_EQ(2, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);
@@ -140,7 +140,7 @@ TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
   EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
   EXPECT_TRUE(regloc.IsSame());
 
-  // CFA=sp+16 => fp=<same> ra=[CFA-8]
+  // CFA=sp+16 => fp=<same> ra=[CFA-8].
   row = unwind_plan.GetRowForFunctionOffset(4);
   EXPECT_EQ(4, row->GetOffset());
   EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);

--- a/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
+++ b/lldb/unittests/Instruction/RISCV/TestRiscvInstEmulation.cpp
@@ -1,0 +1,194 @@
+//===-- TestRiscvInstEmulation.cpp ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "Plugins/UnwindAssembly/InstEmulation/UnwindAssemblyInstEmulation.h"
+
+#include "lldb/Core/AddressRange.h"
+#include "lldb/Symbol/UnwindPlan.h"
+#include "lldb/Utility/ArchSpec.h"
+
+#include "Plugins/Disassembler/LLVMC/DisassemblerLLVMC.h"
+#include "Plugins/Instruction/RISCV/EmulateInstructionRISCV.h"
+#include "Plugins/Process/Utility/lldb-riscv-register-enums.h"
+#include "llvm/Support/TargetSelect.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+class TestRiscvInstEmulation : public testing::Test {
+public:
+  static void SetUpTestCase();
+  static void TearDownTestCase();
+
+  //  virtual void SetUp() override { }
+  //  virtual void TearDown() override { }
+
+protected:
+};
+
+void TestRiscvInstEmulation::SetUpTestCase() {
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllDisassemblers();
+  DisassemblerLLVMC::Initialize();
+  EmulateInstructionRISCV::Initialize();
+}
+
+void TestRiscvInstEmulation::TearDownTestCase() {
+  DisassemblerLLVMC::Terminate();
+  EmulateInstructionRISCV::Terminate();
+}
+
+TEST_F(TestRiscvInstEmulation, TestSimpleRiscvFunction) {
+  ArchSpec arch("riscv64-unknown-linux-gnu");
+  // Enable compressed instruction support (RVC extension)
+  arch.SetFlags(ArchSpec::eRISCV_rvc);
+  std::unique_ptr<UnwindAssemblyInstEmulation> engine(
+      static_cast<UnwindAssemblyInstEmulation *>(
+          UnwindAssemblyInstEmulation::CreateInstance(arch)));
+  ASSERT_NE(nullptr, engine);
+
+  const UnwindPlan::Row *row;
+  AddressRange sample_range;
+  UnwindPlan unwind_plan(eRegisterKindLLDB);
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
+
+  // RISC-V function with compressed and uncompressed instructions
+  //   0x0000: 1141          addi    sp, sp, -0x10
+  //   0x0002: e406          sd      ra, 0x8(sp)
+  //   0x0004: e022          sd      s0, 0x0(sp)
+  //   0x0006: 0800          addi    s0, sp, 0x10
+  //   0x0008: 00000537      lui     a0, 0x0
+  //   0x000C: 00050513      mv      a0, a0
+  //   0x0010: 00000097      auipc   ra, 0x0
+  //   0x0014: 000080e7      jalr    ra <main+0x10>
+  //   0x0018: 4501          li      a0, 0x0
+  //   0x001A: ff040113      addi    sp, s0, -0x10
+  //   0x001E: 60a2          ld      ra, 0x8(sp)
+  //   0x0020: 6402          ld      s0, 0x0(sp)
+  //   0x0022: 0141          addi    sp, sp, 0x10
+  //   0x0024: 8082          ret
+  uint8_t data[] = {// 0x0000: 1141          addi sp, sp, -0x10
+                    0x41, 0x11,
+                    // 0x0002: e406          sd ra, 0x8(sp)
+                    0x06, 0xE4,
+                    // 0x0004: e022          sd s0, 0x0(sp)
+                    0x22, 0xE0,
+                    // 0x0006: 0800          addi s0, sp, 0x10
+                    0x00, 0x08,
+                    // 0x0008: 00000537      lui a0, 0x0
+                    0x37, 0x05, 0x00, 0x00,
+                    // 0x000C: 00050513      mv a0, a0
+                    0x13, 0x05, 0x05, 0x00,
+                    // 0x0010: 00000097      auipc ra, 0x0
+                    0x97, 0x00, 0x00, 0x00,
+                    // 0x0014: 000080e7      jalr ra <main+0x10>
+                    0xE7, 0x80, 0x00, 0x00,
+                    // 0x0018: 4501          li a0, 0x0
+                    0x01, 0x45,
+                    // 0x001A: ff040113      addi sp, s0, -0x10
+                    0x13, 0x01, 0x04, 0xFF,
+                    // 0x001E: 60a2          ld ra, 0x8(sp)
+                    0xA2, 0x60,
+                    // 0x0020: 6402          ld s0, 0x0(sp)
+                    0x02, 0x64,
+                    // 0x0022: 0141          addi sp, sp, 0x10
+                    0x41, 0x01,
+                    // 0x0024: 8082          ret
+                    0x82, 0x80};
+
+  // Expected UnwindPlan (prologue only - emulation stops after frame setup):
+  // row[0]:    0:  CFA=sp+0   => fp= <same>        ra= <same>
+  // row[1]:    2:  CFA=sp+16  => fp= <same>        ra= <same>      (after stack
+  // allocation) row[2]:    4:  CFA=sp+16  => fp= <same>        ra=[CFA-8]
+  // (after saving ra) row[3]:    6:  CFA=sp+16  => fp=[CFA-16]       ra=[CFA-8]
+  // (after saving s0/fp) row[4]:    8:  CFA=s0+0   => fp=[CFA-16] ra=[CFA-8]
+  // (after setting frame pointer: s0=sp+16)
+
+  // Debug: Print all rows in the unwind plan
+
+  sample_range = AddressRange(0x1000, sizeof(data));
+
+  EXPECT_TRUE(engine->GetNonCallSiteUnwindPlanFromAssembly(
+      sample_range, data, sizeof(data), unwind_plan));
+
+  // CFA=sp+0 => fp=<same> ra=<same>
+  row = unwind_plan.GetRowForFunctionOffset(0);
+  EXPECT_EQ(0, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_riscv, regloc));
+  EXPECT_TRUE(regloc.IsSame());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
+  EXPECT_TRUE(regloc.IsSame());
+
+  // CFA=sp+16 => fp=<same> ra=<same>
+  row = unwind_plan.GetRowForFunctionOffset(2);
+  EXPECT_EQ(2, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_riscv, regloc));
+  EXPECT_TRUE(regloc.IsSame());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
+  EXPECT_TRUE(regloc.IsSame());
+
+  // CFA=sp+16 => fp=<same> ra=[CFA-8]
+  row = unwind_plan.GetRowForFunctionOffset(4);
+  EXPECT_EQ(4, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_riscv, regloc));
+  EXPECT_TRUE(regloc.IsSame());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
+  EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
+  EXPECT_EQ(-8, regloc.GetOffset());
+
+  // CFA=sp+16 => fp=[CFA-16] ra=[CFA-8]
+  row = unwind_plan.GetRowForFunctionOffset(6);
+  EXPECT_EQ(6, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_sp_riscv);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(16, row->GetCFAValue().GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_riscv, regloc));
+  EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
+  EXPECT_EQ(-16, regloc.GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
+  EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
+  EXPECT_EQ(-8, regloc.GetOffset());
+
+  // CFA=s0+0 => fp=[CFA-16] ra=[CFA-8]
+  // s0 = sp + 16, so switching CFA to s0 does not change the effective
+  // locations.
+  row = unwind_plan.GetRowForFunctionOffset(8);
+  EXPECT_EQ(8, row->GetOffset());
+  EXPECT_TRUE(row->GetCFAValue().GetRegisterNumber() == gpr_fp_riscv);
+  EXPECT_TRUE(row->GetCFAValue().IsRegisterPlusOffset() == true);
+  EXPECT_EQ(0, row->GetCFAValue().GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_fp_riscv, regloc));
+  EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
+  EXPECT_EQ(-16, regloc.GetOffset());
+
+  EXPECT_TRUE(row->GetRegisterInfo(gpr_ra_riscv, regloc));
+  EXPECT_TRUE(regloc.IsAtCFAPlusOffset());
+  EXPECT_EQ(-8, regloc.GetOffset());
+}


### PR DESCRIPTION
**Added emulator unwinding support for RISCV files.**

Emulated Instructions:
ADD (addi sp, sp, imm)
STORE (sd ra, offset(sp))
LOAD (ld ra, offset(sp)).

We had to overwrite SetInstructions() since UnwindAssemblyInstEmulation calls EvaluateInstruction() directly after calling SetInstruction(), but it never calls ReadInstruction(). This means that the m_decoded member variable in the instruction emulator is never properly initialized. By overriding SetInstruction(), we decode the instruction bytes and set m_decoded directly. This ensures that subsequent emulation (including unwinding) operates on the correct instruction.

We also had to change the the OpCode GetOpcodeBytes function since recent changes made it so GetOpcodeBytes will return None for type eType16_32Tuples (an alternative and longer way, would've been to type check during the overwritten SetInstruction() and call a DataExtractor with .GetU16(&offset) to set the inst_data. 

Added a test - TestSimpleRiscvFunction (took inspiration from: [link](https://github.com/llvm/llvm-project/blob/main/lldb/unittests/UnwindAssembly/ARM64/TestArm64InstEmulation.cpp))

[----------] 1 test from TestRiscvInstEmulation
[ RUN      ] TestRiscvInstEmulation.TestSimpleRiscvFunction
[       OK ] TestRiscvInstEmulation.TestSimpleRiscvFunction (1 ms)
[----------] 1 test from TestRiscvInstEmulation (1 ms total)

[----------] Global test environment tear-down
[==========] 63 tests from 5 test suites ran. (11 ms total)
[  PASSED  ] 63 tests.