### PR TITLE
[bazel] Fix diff-test-update bazel test target by depending on split-file

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/utils/lit/tests/BUILD.bazel
@@ -31,6 +31,7 @@ expand_template(
             "//llvm:FileCheck",
             "//llvm:count",
             "//llvm:not",
+            "//llvm:split-file",
         ] + glob(["Inputs/**"]),
     )
     for src in glob(


### PR DESCRIPTION
#157765 added tests that depend on the split-file utility, which breaks the Bazel test target.