### PR TITLE
[NFCI][StaticDataLayout] Introduce an LLVM option to control the emission of `.hot` data section prefix.

### DIFF
--- a/llvm/lib/Analysis/StaticDataProfileInfo.cpp
+++ b/llvm/lib/Analysis/StaticDataProfileInfo.cpp
@@ -6,6 +6,11 @@
 #include "llvm/ProfileData/InstrProf.h"
 
 using namespace llvm;
+
+cl::opt<bool> PreserveHotDataSectionPrefix(
+    "preserve-hot-data-section-prefix", cl::Hidden, cl::init(true),
+    cl::desc("If true, hot data section prefixes are preserved"));
+
 void StaticDataProfileInfo::addConstantProfileCount(
     const Constant *C, std::optional<uint64_t> Count) {
   if (!Count) {
@@ -36,7 +41,7 @@ StringRef StaticDataProfileInfo::getConstantSectionPrefix(
   // The accummulated counter shows the constant is hot. Return 'hot' whether
   // this variable is seen by unprofiled functions or not.
   if (PSI->isHotCount(*Count))
-    return "hot";
+    return PreserveHotDataSectionPrefix ? "hot" : "";
   // The constant is not hot, and seen by unprofiled functions. We don't want to
   // assign it to unlikely sections, even if the counter says 'cold'. So return
   // an empty prefix before checking whether the counter is cold.

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -76,6 +76,8 @@
 using namespace llvm;
 using namespace dwarf;
 
+extern cl::opt<bool> PreserveHotDataSectionPrefix;
+
 static cl::opt<bool> JumpTableInFunctionSection(
     "jumptable-in-function-section", cl::Hidden, cl::init(false),
     cl::desc("Putting Jump Table in function section"));
@@ -655,26 +657,43 @@ getELFSectionNameForGlobal(const GlobalObject *GO, SectionKind Kind,
   }
 
   bool HasPrefix = false;
+  SmallString<32> SectionPrefix;
   if (const auto *F = dyn_cast<Function>(GO)) {
     // Jump table hotness takes precedence over its enclosing function's hotness
     // if it's known. The function's section prefix is used if jump table entry
     // hotness is unknown.
     if (JTE && JTE->Hotness != MachineFunctionDataHotness::Unknown) {
-      if (JTE->Hotness == MachineFunctionDataHotness::Hot) {
-        raw_svector_ostream(Name) << ".hot";
-      } else {
-        assert(JTE->Hotness == MachineFunctionDataHotness::Cold &&
-               "Hotness must be cold");
-        raw_svector_ostream(Name) << ".unlikely";
+      switch (JTE->Hotness) {
+      case MachineFunctionDataHotness::Cold:
+        raw_svector_ostream(SectionPrefix) << ".unlikely";
+        break;
+      case MachineFunctionDataHotness::Hot: {
+        if (PreserveHotDataSectionPrefix)
+          raw_svector_ostream(SectionPrefix) << ".hot";
+        break;
       }
-      HasPrefix = true;
-    } else if (std::optional<StringRef> Prefix = F->getSectionPrefix()) {
-      raw_svector_ostream(Name) << '.' << *Prefix;
-      HasPrefix = true;
-    }
+      default:
+        // Note this is unreachable code.
+        break;
+      }
+    } else if (std::optional<StringRef> Prefix = F->getSectionPrefix())
+      raw_svector_ostream(SectionPrefix) << "." << *Prefix;
   } else if (const auto *GV = dyn_cast<GlobalVariable>(GO)) {
     if (std::optional<StringRef> Prefix = GV->getSectionPrefix()) {
-      raw_svector_ostream(Name) << '.' << *Prefix;
+      raw_svector_ostream(SectionPrefix) << "." << *Prefix;
+    }
+  }
+
+  if (!SectionPrefix.empty()) {
+    bool AddSectionPrefix = true;
+    if (Kind.isReadOnly() || Kind.isReadOnlyWithRel() || Kind.isData() ||
+        Kind.isBSS()) {
+      AddSectionPrefix =
+          !SectionPrefix.starts_with(".hot") || PreserveHotDataSectionPrefix;
+    }
+
+    if (AddSectionPrefix) {
+      Name += SectionPrefix;
       HasPrefix = true;
     }
   }

--- a/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringObjectFileImpl.cpp
@@ -673,7 +673,7 @@ getELFSectionNameForGlobal(const GlobalObject *GO, SectionKind Kind,
         break;
       }
       default:
-        // Note this is unreachable code.
+        llvm_unreachable("Unknown jump table hotness");
         break;
       }
     } else if (std::optional<StringRef> Prefix = F->getSectionPrefix())


### PR DESCRIPTION
* Description:
  * This change introduces a new boolean LLVM option, `-preserve-hot-data-section-prefix`, which allows for disabling the `.hot` prefix for data sections in the intermediate object files (i.e., linker input files). The option defaults to true to maintain existing behavior.

* Context:
  * https://github.com/llvm/llvm-project/pull/148985 extends lld `-keep-data-section-prefix` to map input sections to output sections based on hotness. When the option is enabled and linker input files have three kinds of rodata sections (`.rodata`, `.rodata.hot`, `.rodata.unlikely`), the executable will also have three kinds of sections. OTOH, to have [simpler executable](https://github.com/llvm/llvm-project/pull/148920#discussion_r2208986411) and more important to avoid unstudied performance penalty from segregated hot and lukewarm data , we'd prefer to have an `.rodata.unlikely` to group the cold data, and keep the rest (hot or lukewarm) in `.rodata` section.