### PR TITLE
[mlir][NFC] Correct pattern names to match the behaviors.

### DIFF
--- a/mlir/lib/Dialect/Tensor/Transforms/ReshapePatterns.cpp
+++ b/mlir/lib/Dialect/Tensor/Transforms/ReshapePatterns.cpp
@@ -319,7 +319,7 @@ struct BubbleUpExpandThroughParallelCollapse
 /// Note - this pattern could be extended to be a swap pattern between
 /// `tensor.expand_shape` and `tensor.extract_slice`, but is currently
 /// implemented only as a bubble up pattern for `tensor.extract_slice`.
-struct BubbleUpExpandShapeThroughExtractSlice
+struct BubbleUpExtractSliceThroughExpandShape
     : public OpRewritePattern<tensor::ExtractSliceOp> {
   using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
 
@@ -427,7 +427,7 @@ struct BubbleUpExpandShapeThroughExtractSlice
 ///                                                       to tensor<15xf32>
 /// ```
 /// But this is not the intended purpose of the transformation.
-struct BubbleUpCollapseShapeThroughExtractSlice
+struct BubbleUpExtractSliceThroughCollapseShape
     : public OpRewritePattern<tensor::ExtractSliceOp> {
   using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
 
@@ -735,6 +735,6 @@ void mlir::tensor::populateBubbleUpExpandShapePatterns(
 
 void mlir::tensor::populateBubbleUpExtractSliceOpPatterns(
     RewritePatternSet &patterns) {
-  patterns.add<BubbleUpExpandShapeThroughExtractSlice,
-               BubbleUpCollapseShapeThroughExtractSlice>(patterns.getContext());
+  patterns.add<BubbleUpExtractSliceThroughExpandShape,
+               BubbleUpExtractSliceThroughCollapseShape>(patterns.getContext());
 }


### PR DESCRIPTION
It is a follow-up for https://github.com/llvm/llvm-project/pull/131982#discussion_r2286014576 and https://github.com/llvm/llvm-project/pull/126898#discussion_r2286013250.

The names do not match the behaviors, and the revision updates the names.