### PR TITLE
[TableGen] Add mapping from processor ID to resource index for packetizer

### DIFF
--- a/llvm/lib/Target/AMDGPU/R600Packetizer.cpp
+++ b/llvm/lib/Target/AMDGPU/R600Packetizer.cpp
@@ -319,6 +319,11 @@ bool R600Packetizer::runOnMachineFunction(MachineFunction &Fn) {
 
   MachineLoopInfo &MLI = getAnalysis<MachineLoopInfoWrapperPass>().getLI();
 
+  const InstrItineraryData *II = ST.getInstrItineraryData();
+  // If there is no itineraries information, abandon.
+  if (II->Itineraries == nullptr)
+    return false;
+
   // Instantiate the packetizer.
   R600PacketizerList Packetizer(Fn, ST, MLI);
 

--- a/llvm/test/TableGen/DFAPacketizer.td
+++ b/llvm/test/TableGen/DFAPacketizer.td
@@ -1,0 +1,31 @@
+// RUN: llvm-tblgen -gen-dfa-packetizer -I %p/../../include %s | FileCheck %s
+
+include "llvm/Target/Target.td"
+
+def TestTarget : Target;
+
+def TestSchedModel : SchedMachineModel {
+  let CompleteModel = 0;
+}
+
+def TestProcessor1 : ProcessorModel<"testprocessor1", TestSchedModel, []>;
+
+def FU0 : FuncUnit;
+def FU1 : FuncUnit;
+
+def OP0 : InstrItinClass;
+def OP1 : InstrItinClass;
+
+def Itin {
+  list<InstrItinData> ItinList = [
+    InstrItinData<OP0, [InstrStage<1, [FU0]>]>,
+    InstrItinData<OP1, [InstrStage<1, [FU1]>]>,
+  ];
+}
+
+// CHECK: std::map<unsigned, unsigned> TestTargetProcIdToResourceIndexStartMapping = {
+// CHECK-NEXT:   { 2,  1 }, // TestItinerariesModel
+// CHECK-NEXT: };
+
+def TestItineraries: ProcessorItineraries<[], [], Itin.ItinList>;
+def TestProcessor2 : Processor<"testprocessor2", TestItineraries, []>;

--- a/llvm/test/TableGen/DFAPacketizer.td
+++ b/llvm/test/TableGen/DFAPacketizer.td
@@ -27,9 +27,7 @@ def Itin {
 // CHECK-NEXT:   static const unsigned TestTargetProcIdToProcResourceIdxTable[][2] = {
 // CHECK-NEXT:     { 2,  1 }, // TestItinerariesModel
 // CHECK-NEXT:   };
-// CHECK-NEXT:   auto It = std::lower_bound(
-// CHECK-NEXT:       std::begin(TestTargetProcIdToProcResourceIdxTable),
-// CHECK-NEXT:       std::end(TestTargetProcIdToProcResourceIdxTable), ProcID,
+// CHECK-NEXT:   auto It = llvm::lower_bound(TestTargetProcIdToProcResourceIdxTable, ProcID,
 // CHECK-NEXT:       [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; });
 // CHECK-NEXT:   assert(*It[0] == ProcID);
 // CHECK-NEXT:   return (*It)[1];

--- a/llvm/test/TableGen/DFAPacketizer.td
+++ b/llvm/test/TableGen/DFAPacketizer.td
@@ -23,9 +23,29 @@ def Itin {
   ];
 }
 
-// CHECK: std::map<unsigned, unsigned> TestTargetProcIdToResourceIndexStartMapping = {
-// CHECK-NEXT:   { 2,  1 }, // TestItinerariesModel
-// CHECK-NEXT: };
+// CHECK:      int TestTargetGetResourceIndex(unsigned ProcID) {
+// CHECK-NEXT:   static const unsigned TestTargetProcIdToProcResourceIdxTable[][2] = {
+// CHECK-NEXT:     { 2,  1 }, // TestItinerariesModel
+// CHECK-NEXT:   };
+// CHECK-NEXT:   unsigned Mid;
+// CHECK-NEXT:   unsigned Start = 0;
+// CHECK-NEXT:   unsigned End = 1;
+// CHECK-NEXT:   while (Start < End) {
+// CHECK-NEXT:   Mid = Start + (End - Start) / 2;
+// CHECK-NEXT:   if (ProcID == TestTargetProcIdToProcResourceIdxTable[Mid][0]) {
+// CHECK-NEXT:     break;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   if (ProcID < TestTargetProcIdToProcResourceIdxTable[Mid][0])
+// CHECK-NEXT:     End = Mid;
+// CHECK-NEXT:   else
+// CHECK-NEXT:     Start = Mid + 1;
+// CHECK-NEXT:   }
+// CHECK-NEXT:   if (Start == End)
+// CHECK-NEXT:     return -1; // Didn't find
+// CHECK-NEXT:   return TestTargetProcIdToProcResourceIdxTable[Mid][1];
+// CHECK-NEXT: }
+
+// CHECK:  unsigned Index = TestTargetGetResourceIndex(IID->SchedModel.ProcID);
 
 def TestItineraries: ProcessorItineraries<[], [], Itin.ItinList>;
 def TestProcessor2 : Processor<"testprocessor2", TestItineraries, []>;

--- a/llvm/test/TableGen/DFAPacketizer.td
+++ b/llvm/test/TableGen/DFAPacketizer.td
@@ -31,6 +31,7 @@ def Itin {
 // CHECK-NEXT:       std::begin(TestTargetProcIdToProcResourceIdxTable),
 // CHECK-NEXT:       std::end(TestTargetProcIdToProcResourceIdxTable), ProcID,
 // CHECK-NEXT:       [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; });
+// CHECK-NEXT:   assert(*It[0] == ProcID);
 // CHECK-NEXT:   return (*It)[1];
 // CHECK-NEXT: }
 

--- a/llvm/test/TableGen/DFAPacketizer.td
+++ b/llvm/test/TableGen/DFAPacketizer.td
@@ -27,22 +27,11 @@ def Itin {
 // CHECK-NEXT:   static const unsigned TestTargetProcIdToProcResourceIdxTable[][2] = {
 // CHECK-NEXT:     { 2,  1 }, // TestItinerariesModel
 // CHECK-NEXT:   };
-// CHECK-NEXT:   unsigned Mid;
-// CHECK-NEXT:   unsigned Start = 0;
-// CHECK-NEXT:   unsigned End = 1;
-// CHECK-NEXT:   while (Start < End) {
-// CHECK-NEXT:   Mid = Start + (End - Start) / 2;
-// CHECK-NEXT:   if (ProcID == TestTargetProcIdToProcResourceIdxTable[Mid][0]) {
-// CHECK-NEXT:     break;
-// CHECK-NEXT:   }
-// CHECK-NEXT:   if (ProcID < TestTargetProcIdToProcResourceIdxTable[Mid][0])
-// CHECK-NEXT:     End = Mid;
-// CHECK-NEXT:   else
-// CHECK-NEXT:     Start = Mid + 1;
-// CHECK-NEXT:   }
-// CHECK-NEXT:   if (Start == End)
-// CHECK-NEXT:     return -1; // Didn't find
-// CHECK-NEXT:   return TestTargetProcIdToProcResourceIdxTable[Mid][1];
+// CHECK-NEXT:   auto It = std::lower_bound(
+// CHECK-NEXT:       std::begin(TestTargetProcIdToProcResourceIdxTable),
+// CHECK-NEXT:       std::end(TestTargetProcIdToProcResourceIdxTable), ProcID,
+// CHECK-NEXT:       [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; });
+// CHECK-NEXT:   return (*It)[1];
 // CHECK-NEXT: }
 
 // CHECK:  unsigned Index = TestTargetGetResourceIndex(IID->SchedModel.ProcID);

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -284,6 +284,7 @@ void DFAPacketizerEmitter::emitForItineraries(
      << "ProcIdToProcResourceIdxTable), ProcID,\n"
      << "      [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; "
         "});\n"
+     << "  assert(*It[0] == ProcID);\n"
      << "  return (*It)[1];\n"
      << "}\n\n";
 

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -277,25 +277,11 @@ void DFAPacketizerEmitter::emitForItineraries(
        << Model->ModelName << "\n";
   }
   OS << "  };\n"
-     << "  unsigned Mid;\n"
-     << "  unsigned Start = 0;\n"
-     << "  unsigned End = " << ProcModels.size() << ";\n"
-     << "  while (Start < End) {\n"
-     << "  Mid = Start + (End - Start) / 2;\n"
-     << "  if (ProcID == " << TargetName << DFAName
-     << "ProcIdToProcResourceIdxTable[Mid][0]) {\n"
-     << "    break;\n"
-     << "  }\n"
-     << "  if (ProcID < " << TargetName << DFAName
-     << "ProcIdToProcResourceIdxTable[Mid][0])\n"
-     << "    End = Mid;\n"
-     << "  else\n"
-     << "    Start = Mid + 1;\n"
-     << "  }\n"
-     << "  if (Start == End)\n"
-     << "    return -1; // Didn't find\n"
-     << "  return " << TargetName << DFAName
-     << "ProcIdToProcResourceIdxTable[Mid][1];\n"
+     << "  auto It = std::lower_bound(\n"
+     << "      std::begin(" << TargetName << DFAName << "ProcIdToProcResourceIdxTable),\n"
+     << "      std::end(" << TargetName << DFAName << "ProcIdToProcResourceIdxTable), ProcID,\n"
+     << "      [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; });\n"
+     << "  return (*It)[1];\n"
      << "}\n\n";
 
   // The type of a state in the nondeterministic automaton we're defining.

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -277,11 +277,8 @@ void DFAPacketizerEmitter::emitForItineraries(
        << Model->ModelName << "\n";
   }
   OS << "  };\n"
-     << "  auto It = std::lower_bound(\n"
-     << "      std::begin(" << TargetName << DFAName
-     << "ProcIdToProcResourceIdxTable),\n"
-     << "      std::end(" << TargetName << DFAName
-     << "ProcIdToProcResourceIdxTable), ProcID,\n"
+     << "  auto It = llvm::lower_bound(" << TargetName << DFAName
+     << "ProcIdToProcResourceIdxTable, ProcID,\n"
      << "      [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; "
         "});\n"
      << "  assert(*It[0] == ProcID);\n"

--- a/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
+++ b/llvm/utils/TableGen/DFAPacketizerEmitter.cpp
@@ -278,9 +278,12 @@ void DFAPacketizerEmitter::emitForItineraries(
   }
   OS << "  };\n"
      << "  auto It = std::lower_bound(\n"
-     << "      std::begin(" << TargetName << DFAName << "ProcIdToProcResourceIdxTable),\n"
-     << "      std::end(" << TargetName << DFAName << "ProcIdToProcResourceIdxTable), ProcID,\n"
-     << "      [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; });\n"
+     << "      std::begin(" << TargetName << DFAName
+     << "ProcIdToProcResourceIdxTable),\n"
+     << "      std::end(" << TargetName << DFAName
+     << "ProcIdToProcResourceIdxTable), ProcID,\n"
+     << "      [](const unsigned LHS[], unsigned Val) { return LHS[0] < Val; "
+        "});\n"
      << "  return (*It)[1];\n"
      << "}\n\n";
 


### PR DESCRIPTION
Tablegen would generate code to access TargetResourceIndices with processor ID.
The TargetProcResourceIndexStart[] array is generated for each processor which
has itineraries. The processor which doesn't has itineraries is excluded from
the array. When a target has mixed processors, the processor ID may exceed the
array size and cause the error.
This patch is to generate a table mapping processor with itineraries to resource
index, so that scheduler can get the correct resource index with processor ID.
