### PR TITLE
[mlir] Fix correct memset range in `OwningMemRef` zero-init

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
+++ b/mlir/include/mlir/ExecutionEngine/MemRefUtils.h
@@ -164,19 +164,17 @@ public:
     int64_t nElements = 1;
     for (int64_t s : shapeAlloc)
       nElements *= s;
-    auto [data, alignedData] =
+    auto [allocatedPtr, alignedData] =
         detail::allocAligned<T>(nElements, allocFun, alignment);
-    descriptor = detail::makeStridedMemRefDescriptor<Rank>(data, alignedData,
-                                                           shape, shapeAlloc);
+    descriptor = detail::makeStridedMemRefDescriptor<Rank>(
+        allocatedPtr, alignedData, shape, shapeAlloc);
     if (init) {
       for (StridedMemrefIterator<T, Rank> it = descriptor.begin(),
                                           end = descriptor.end();
            it != end; ++it)
         init(*it, it.getIndices());
     } else {
-      memset(descriptor.data, 0,
-             nElements * sizeof(T) +
-                 alignment.value_or(detail::nextPowerOf2(sizeof(T))));
+      memset(alignedData, 0, nElements * sizeof(T));
     }
   }
   /// Take ownership of an existing descriptor with a custom deleter.

--- a/mlir/unittests/ExecutionEngine/Invoke.cpp
+++ b/mlir/unittests/ExecutionEngine/Invoke.cpp
@@ -251,6 +251,24 @@ TEST(NativeMemRefJit, SKIP_WITHOUT_JIT(BasicMemref)) {
   EXPECT_EQ((a[{2, 1}]), 42.);
 }
 
+TEST(NativeMemRefJit, SKIP_WITHOUT_JIT(OwningMemrefZeroInit)) {
+  constexpr int k = 3;
+  constexpr int m = 7;
+  int64_t shape[] = {k, m};
+  // Use a large alignment to stress the case where the memref data/basePtr are
+  // disjoint.
+  int alignment = 8192;
+  OwningMemRef<float, 2> a(shape, {}, {}, alignment);
+  ASSERT_EQ(
+      (void *)(((uintptr_t)a->basePtr + alignment - 1) & ~(alignment - 1)),
+      a->data);
+  for (int i = 0; i < k; ++i) {
+    for (int j = 0; j < m; ++j) {
+      EXPECT_EQ((a[{i, j}]), 0.);
+    }
+  }
+}
+
 // A helper function that will be called from the JIT
 static void memrefMultiply(::StridedMemRefType<float, 2> *memref,
                            int32_t coefficient) {


### PR DESCRIPTION
### Problem: `OwningMemRef` zero-init can write past allocation

`OwningMemref` allocates with overprovision + manual alignment:

```cpp
auto desiredAlignment = alignment.value_or(nextPowerOf2(sizeof(T))); 
void* data = malloc(size + desiredAlignment); // size = nElements * sizeof(T)

// Compute aligned view
auto addr = reinterpret_cast<uintptr_t>(data);
auto rem  = addr % desiredAlignment;
T* alignedData = (rem == 0)
                   ? static_cast<T*>(data)
                   : reinterpret_cast<T*>(addr + (desiredAlignment - rem));
```

The descriptor stores:

* `descriptor.basePtr = data` (the raw allocation)
* `descriptor.data    = alignedData` (the aligned start)

When creating an `OwningMemRef` **without init**, we zero it. The buggy code does:

```cpp
memset(descriptor.data, 0, size + desiredAlignment); // ❌ may overrun
```

This is invalid because `descriptor.data` (the aligned pointer) **does not point to the full allocated block** (`size + desiredAlignment`). Zeroing that much from the aligned start can write past the end of the allocation.

### Correct zero-init options

Choose **one** of the following:

1. Zero the **entire allocated block** from the raw base:

```cpp
memset(descriptor.basePtr, 0,
       nElements * sizeof(T) + alignment.value_or(nextPowerOf2(sizeof(T))));
```

2. Zero **only the logical payload** (what the user sees) from the aligned start:

```cpp
memset(descriptor.data, 0, nElements * sizeof(T));
```

### Recommendation

I think one of the main root causes here is naming. At first, I assumed `descriptor.`data referred to the raw data pointer—but it doesn’t. Using more consistent naming could make the meaning clearer. For example: `descriptor.data` vs. `descriptor.alignedData`.
