### PR TITLE
[ADT] Add C++20-style llvm::identity

### DIFF
--- a/llvm/include/llvm/ADT/identity.h
+++ b/llvm/include/llvm/ADT/identity.h
@@ -15,15 +15,30 @@
 #ifndef LLVM_ADT_IDENTITY_H
 #define LLVM_ADT_IDENTITY_H
 
+#include <utility>
+
 namespace llvm {
 
-// Similar to `std::identity` from C++20.
-template <class Ty> struct identity {
+// Our legacy llvm::identity, not quite the same as std::identity.
+template <class Ty = void> struct identity {
   using is_transparent = void;
   using argument_type = Ty;
 
   Ty &operator()(Ty &self) const { return self; }
   const Ty &operator()(const Ty &self) const { return self; }
+};
+
+// Forward-ported from C++20.
+//
+// While we are migrating from the legacy version, we must refer to this
+// template as identity<>.  Once the legacy version is removed, we can
+// make this a non-template struct and remove the <>.
+template <> struct identity<void> {
+  using is_transparent = void;
+
+  template <typename T> constexpr T &&operator()(T &&self) const {
+    return std::forward<T>(self);
+  }
 };
 
 } // namespace llvm


### PR DESCRIPTION
Currently, our llvm:identity<T> is not quite like std::identity from
C++20.  Ours is a template struct while std::identity is a
non-template struct with templatized operator().  This difference
means that we cannot mechanically replace llvm::identity with
std::identity when we switch to C++20 in the future.

This patch implements llvm::identity that actually behaves like
std::identity.  The only difference is that we must refer to it as
llvm::identity<> with <> at the end.

Once this patch lands, I'm planning to migrate users of llvm::identity
to the new style.  There aren't that many:

- 4 instances of SparseSet<...>
- 3 instances of SparseMultiSet<...>
- about 50 instances of IndexedMap<...>
