### PR TITLE
[Support] Merge two implementations of addRangeElementsImpl (NFC)

### DIFF
--- a/llvm/include/llvm/Support/HashBuilder.h
+++ b/llvm/include/llvm/Support/HashBuilder.h
@@ -366,18 +366,16 @@ private:
   HashBuilder &addRangeElementsImpl(ForwardIteratorT First,
                                     ForwardIteratorT Last,
                                     std::forward_iterator_tag) {
-    for (auto It = First; It != Last; ++It)
-      add(*It);
-    return *this;
-  }
-
-  template <typename T>
-  std::enable_if_t<hashbuilder_detail::IsHashableData<T>::value &&
-                       Endianness == llvm::endianness::native,
-                   HashBuilder &>
-  addRangeElementsImpl(T *First, T *Last, std::forward_iterator_tag) {
-    this->update(ArrayRef(reinterpret_cast<const uint8_t *>(First),
-                          (Last - First) * sizeof(T)));
+    using T = typename std::iterator_traits<ForwardIteratorT>::value_type;
+    if constexpr (std::is_pointer_v<ForwardIteratorT> &&
+                  hashbuilder_detail::IsHashableData<T>::value &&
+                  Endianness == llvm::endianness::native) {
+      this->update(ArrayRef(reinterpret_cast<const uint8_t *>(First),
+                            (Last - First) * sizeof(T)));
+    } else {
+      for (auto It = First; It != Last; ++It)
+        add(*It);
+    }
     return *this;
   }
 };


### PR DESCRIPTION
This patch uses "constexpr if" to merge two implementations of
addRangeElementsImpl.  While the line count does not change much, the
"if" condition should be a lot more readable than in std::enable_if.
