### PR TITLE
[flang] Add header includes to make headers compile standalone.

### DIFF
--- a/flang-rt/lib/runtime/complex-reduction.h
+++ b/flang-rt/lib/runtime/complex-reduction.h
@@ -17,6 +17,7 @@
 #include "flang/Common/float128.h"
 #include "flang/Runtime/entry-names.h"
 #include <complex.h>
+#include <stdbool.h>
 
 struct CppDescriptor; /* dummy type name for Fortran::runtime::Descriptor */
 

--- a/flang/include/flang/Runtime/freestanding-tools.h
+++ b/flang/include/flang/Runtime/freestanding-tools.h
@@ -13,6 +13,7 @@
 #include "flang/Runtime/c-or-cpp.h"
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
 #include <cstring>
 
 // The file defines a set of utilities/classes that might be


### PR DESCRIPTION
When compiling headers standalone, we need additional header includes.