### PR TITLE
Revert "[compiler-rt][test] Use packaging.version.Version to compare glibc versions"

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -713,9 +713,9 @@ if config.target_os == "Linux":
         if config.android:
             return
 
-        from packaging.version import Version
+        from distutils.version import LooseVersion
 
-        ver = Version(ver_string)
+        ver = LooseVersion(ver_string)
         any_glibc = False
         for required in [
             "2.19",
@@ -727,7 +727,7 @@ if config.target_os == "Linux":
             "2.38",
             "2.40",
         ]:
-            if ver >= Version(required):
+            if ver >= LooseVersion(required):
                 config.available_features.add("glibc-" + required)
                 any_glibc = True
             if any_glibc:


### PR DESCRIPTION
Reverts llvm/llvm-project#142596

Got reports that some tests previously skipped are running again and failing.