### PR TITLE
Reland "[compiler-rt][test] Use packaging.version.Version to compare glibc versions" (#158230)"

### DIFF
--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -713,9 +713,9 @@ if config.target_os == "Linux":
         if config.android:
             return
 
-        from distutils.version import LooseVersion
+        from packaging.version import Version
 
-        ver = LooseVersion(ver_string)
+        ver = Version(ver_string)
         any_glibc = False
         for required in [
             "2.19",
@@ -727,7 +727,7 @@ if config.target_os == "Linux":
             "2.38",
             "2.40",
         ]:
-            if ver >= LooseVersion(required):
+            if ver >= Version(required):
                 config.available_features.add("glibc-" + required)
                 any_glibc = True
             if any_glibc:

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -713,9 +713,13 @@ if config.target_os == "Linux":
         if config.android:
             return
 
-        from packaging.version import Version
+        from packaging.version import Version, InvalidVersion
 
-        ver = Version(ver_string)
+        try:
+            ver = Version(ver_string)
+        except InvalidVersion:
+            return
+
         any_glibc = False
         for required in [
             "2.19",


### PR DESCRIPTION
This reverts commit d7b7b9cd6d12a8cbc35fba4ecfd0a557011e9cdd.

As the name suggests, packaging's Version is more strict than distutil's LooseVersion. `LooseVersion(".3")` is fine but `Version(".3")` raises an exception. I think this was happening on the Google bot, which lead us to enable tests that should not have been running.

Looking at the way we find the glibc version, it should be `<0 or more numbers>.<0 or more numbers>`. So I think the only way we're getting invalid versions is if it comes out as `X.` or `.Y`.