### PR TITLE
[Mips] Fix inst `sc` disassemble assert when configured -mattr=+ptr64

### DIFF
--- a/llvm/lib/Target/Mips/Disassembler/MipsDisassembler.cpp
+++ b/llvm/lib/Target/Mips/Disassembler/MipsDisassembler.cpp
@@ -1468,7 +1468,7 @@ static DecodeStatus DecodeMem(MCInst &Inst, unsigned Insn, uint64_t Address,
   Reg = getReg(Decoder, Mips::GPR32RegClassID, Reg);
   Base = getReg(Decoder, Mips::GPR32RegClassID, Base);
 
-  if (Inst.getOpcode() == Mips::SC ||
+  if (Inst.getOpcode() == Mips::SC || Inst.getOpcode() == Mips::SC64 ||
       Inst.getOpcode() == Mips::SCD)
     Inst.addOperand(MCOperand::createReg(Reg));
 

--- a/llvm/test/MC/Disassembler/Mips/mips64/sc-ptr64.txt
+++ b/llvm/test/MC/Disassembler/Mips/mips64/sc-ptr64.txt
@@ -1,0 +1,3 @@
+# RUN: llvm-mc -triple=mips64el-unknown-linux -disassemble -mattr=+ptr64 -mcpu=mips3 %s | FileCheck %s
+
+0xd8 0x49 0x6f 0xe2 # CHECK: sc $15, 18904($19)


### PR DESCRIPTION
When mips disassembler process `DecodeMem`, does not consider Mips::SC64, leading to `Operands.size() = 3`.
And the right `Size` value is 4, when printMemOperand would occur asserts: `assert(idx < size());`

Fix #157508.