### PR TITLE
[libc++] Fix broken unique and unique_copy benchmarks

### DIFF
--- a/libcxx/test/benchmarks/algorithms/modifying/unique.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/unique.bench.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
             }
           })
           ->Arg(32)
-          ->Arg(50) // non power-of-two
+          ->Arg(52) // non power-of-two
           ->Arg(1024)
           ->Arg(8192);
     };
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
             }
           })
           ->Arg(32)
-          ->Arg(50) // non power-of-two
+          ->Arg(52) // non power-of-two
           ->Arg(1024)
           ->Arg(8192);
     };

--- a/libcxx/test/benchmarks/algorithms/modifying/unique_copy.bench.cpp
+++ b/libcxx/test/benchmarks/algorithms/modifying/unique_copy.bench.cpp
@@ -61,6 +61,7 @@ int main(int argc, char** argv) {
             }
           })
           ->Arg(32)
+          ->Arg(52) // non power-of-two
           ->Arg(1024)
           ->Arg(8192);
     };
@@ -115,7 +116,7 @@ int main(int argc, char** argv) {
             }
           })
           ->Arg(32)
-          ->Arg(50) // non power-of-two
+          ->Arg(52) // non power-of-two
           ->Arg(1024)
           ->Arg(8192);
     };


### PR DESCRIPTION
These benchmarks have an assumption that the container size is divisible by 4 because of how we populate their content, which wasn't satisfied.