### PR TITLE
[libc++] Remove complexity calculations from <filesystem> benchmark

### DIFF
--- a/libcxx/test/benchmarks/filesystem.bench.cpp
+++ b/libcxx/test/benchmarks/filesystem.bench.cpp
@@ -30,9 +30,8 @@ void BM_PathConstructString(benchmark::State& st, GenInputs gen) {
     const path P(PP.native());
     benchmark::DoNotOptimize(P.native().data());
   }
-  st.SetComplexityN(st.range(0));
 }
-BENCHMARK_CAPTURE(BM_PathConstructString, large_string, getRandomStringInputs)->Range(8, TestNumInputs)->Complexity();
+BENCHMARK_CAPTURE(BM_PathConstructString, large_string, getRandomStringInputs)->Range(8, TestNumInputs);
 
 template <class GenInputs>
 void BM_PathConstructCStr(benchmark::State& st, GenInputs gen) {
@@ -66,7 +65,6 @@ void BM_PathConstructIter(benchmark::State& st, GenInputs gen) {
     const path P(Start, End);
     benchmark::DoNotOptimize(P.native().data());
   }
-  st.SetComplexityN(st.range(0));
 }
 template <class GenInputs>
 void BM_PathConstructInputIter(benchmark::State& st, GenInputs gen) {
@@ -77,11 +75,9 @@ void BM_PathConstructForwardIter(benchmark::State& st, GenInputs gen) {
   BM_PathConstructIter<forward_iterator>(st, gen);
 }
 BENCHMARK_CAPTURE(BM_PathConstructInputIter, large_string, getRandomStringInputs)
-    ->Range(8, TestNumInputs)
-    ->Complexity();
+    ->Range(8, TestNumInputs);
 BENCHMARK_CAPTURE(BM_PathConstructForwardIter, large_string, getRandomStringInputs)
-    ->Range(8, TestNumInputs)
-    ->Complexity();
+    ->Range(8, TestNumInputs);
 
 template <class GenInputs>
 void BM_PathIterateMultipleTimes(benchmark::State& st, GenInputs gen) {
@@ -97,11 +93,9 @@ void BM_PathIterateMultipleTimes(benchmark::State& st, GenInputs gen) {
     }
     benchmark::ClobberMemory();
   }
-  st.SetComplexityN(st.range(0));
 }
 BENCHMARK_CAPTURE(BM_PathIterateMultipleTimes, iterate_elements, getRandomStringInputs)
-    ->Range(8, TestNumInputs)
-    ->Complexity();
+    ->Range(8, TestNumInputs);
 
 template <class GenInputs>
 void BM_PathIterateOnce(benchmark::State& st, GenInputs gen) {
@@ -118,9 +112,8 @@ void BM_PathIterateOnce(benchmark::State& st, GenInputs gen) {
     }
     benchmark::ClobberMemory();
   }
-  st.SetComplexityN(st.range(0));
 }
-BENCHMARK_CAPTURE(BM_PathIterateOnce, iterate_elements, getRandomStringInputs)->Range(8, TestNumInputs)->Complexity();
+BENCHMARK_CAPTURE(BM_PathIterateOnce, iterate_elements, getRandomStringInputs)->Range(8, TestNumInputs);
 
 template <class GenInputs>
 void BM_PathIterateOnceBackwards(benchmark::State& st, GenInputs gen) {
@@ -160,16 +153,13 @@ void BM_LexicallyNormal(benchmark::State& st, GenInput gen, size_t PathLen) {
   while (st.KeepRunning()) {
     benchmark::DoNotOptimize(In.lexically_normal());
   }
-  st.SetComplexityN(st.range(0));
 }
 BENCHMARK_CAPTURE(BM_LexicallyNormal, small_path, getRandomPaths, /*PathLen*/ 5)
     ->RangeMultiplier(2)
-    ->Range(2, 256)
-    ->Complexity();
+    ->Range(2, 256);
 BENCHMARK_CAPTURE(BM_LexicallyNormal, large_path, getRandomPaths, /*PathLen*/ 32)
     ->RangeMultiplier(2)
-    ->Range(2, 256)
-    ->Complexity();
+    ->Range(2, 256);
 
 template <class GenInput>
 void BM_LexicallyRelative(benchmark::State& st, GenInput gen, size_t PathLen) {
@@ -180,15 +170,12 @@ void BM_LexicallyRelative(benchmark::State& st, GenInput gen, size_t PathLen) {
   for (auto _ : st) {
     benchmark::DoNotOptimize(TargetPath.lexically_relative(BasePath));
   }
-  st.SetComplexityN(st.range(0));
 }
 BENCHMARK_CAPTURE(BM_LexicallyRelative, small_path, getRandomPaths, /*PathLen*/ 5)
     ->RangeMultiplier(2)
-    ->Range(2, 256)
-    ->Complexity();
+    ->Range(2, 256);
 BENCHMARK_CAPTURE(BM_LexicallyRelative, large_path, getRandomPaths, /*PathLen*/ 32)
     ->RangeMultiplier(2)
-    ->Range(2, 256)
-    ->Complexity();
+    ->Range(2, 256);
 
 BENCHMARK_MAIN();

--- a/libcxx/utils/parse-google-benchmark-results
+++ b/libcxx/utils/parse-google-benchmark-results
@@ -26,6 +26,8 @@ def main(argv):
     for file in args.filename:
         js = json.load(file)
         for bm in js['benchmarks']:
+            if args.timing not in bm:
+                raise RuntimeError(f'Benchmark does not contain key for {args.timing}: {bm}')
             row = [bm['name'], bm[args.timing]]
             rows.append(row)
 


### PR DESCRIPTION
Our benchmarks are not really suited for complexity calculation, since that doesn't translate nicely to any of the performance tracking tools we have (including Lit).