### PR TITLE
[LV] Enable Histogram autovectorization by default

### DIFF
--- a/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorizationLegality.cpp
@@ -80,7 +80,7 @@ static cl::opt<LoopVectorizeHints::ScalableForceKind>
                 "cost is inconclusive.")));
 
 static cl::opt<bool> EnableHistogramVectorization(
-    "enable-histogram-loop-vectorization", cl::init(false), cl::Hidden,
+    "enable-histogram-loop-vectorization", cl::init(true), cl::Hidden,
     cl::desc("Enables autovectorization of some loops containing histograms"));
 
 /// Maximum vectorization interleave count.

--- a/llvm/test/Transforms/LoopVectorize/increment.ll
+++ b/llvm/test/Transforms/LoopVectorize/increment.ll
@@ -33,13 +33,11 @@ define void @inc(i32 %n) nounwind uwtable noinline ssp {
   ret void
 }
 
-; Can't vectorize this loop because the access to A[X] is non-linear.
-;
 ;  for (i = 0; i < n; ++i) {
 ;    A[B[i]]++;
 ;
 ;CHECK-LABEL: @histogram(
-;CHECK-NOT: <4 x i32>
+;CHECK:  call void @llvm.experimental.vector.histogram.add.v4p0.i32(<4 x ptr> %{{.*}}, i32 1, <4 x i1> splat (i1 true))
 ;CHECK: ret i32
 define i32 @histogram(ptr nocapture noalias %A, ptr nocapture noalias %B, i32 %n) nounwind uwtable ssp {
 entry:


### PR DESCRIPTION
Enabling the feature by default in order to get further testing data.

There are a few loops in popular benchmarks where this kicks in,
but none of them are particularly hot, so I don't know if this is
beneficial on current hardware. But I haven't seen any regressions yet
either.

I'll take another look at the cost functions to see if there's improvements
I can make (as separate PRs).