### PR TITLE
[libc++] Don't run multithreaded stringstream benchmarks

### DIFF
--- a/libcxx/test/benchmarks/stringstream.bench.cpp
+++ b/libcxx/test/benchmarks/stringstream.bench.cpp
@@ -80,7 +80,7 @@ static void BM_Istream_numbers(benchmark::State& state) {
   while (state.KeepRunning())
     benchmark::DoNotOptimize(i += istream_numbers(sel.imbue));
 }
-BENCHMARK(BM_Istream_numbers)->DenseRange(0, 3)->UseRealTime()->Threads(1)->ThreadPerCpu();
+BENCHMARK(BM_Istream_numbers)->DenseRange(0, 3);
 
 static void BM_Ostream_number(benchmark::State& state) {
   LocaleSelector sel(state);
@@ -92,6 +92,6 @@ static void BM_Ostream_number(benchmark::State& state) {
     benchmark::DoNotOptimize(ss.str().c_str());
   }
 }
-BENCHMARK(BM_Ostream_number)->DenseRange(0, 3)->UseRealTime()->Threads(1)->ThreadPerCpu();
+BENCHMARK(BM_Ostream_number)->DenseRange(0, 3);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
This results in invalid JSON output as reported
in google/benchmark#2039.