### PR TITLE
[flang][driver] Support -gdwarf-N option.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4674,10 +4674,11 @@ def ggdb3 : Flag<["-"], "ggdb3">, Group<ggdbN_Group>;
 def glldb : Flag<["-"], "glldb">, Group<gTune_Group>;
 def gsce : Flag<["-"], "gsce">, Group<gTune_Group>;
 def gdbx : Flag<["-"], "gdbx">, Group<gTune_Group>;
+
+let Visibility = [ClangOption, CLOption, DXCOption, FlangOption] in {
 // Equivalent to our default dwarf version. Forces usual dwarf emission when
 // CodeView is enabled.
 def gdwarf : Flag<["-"], "gdwarf">, Group<g_Group>,
-  Visibility<[ClangOption, CLOption, DXCOption]>,
   HelpText<"Generate source-level debug information with the default dwarf version">;
 def gdwarf_2 : Flag<["-"], "gdwarf-2">, Group<g_Group>,
   HelpText<"Generate source-level debug information with dwarf version 2">;
@@ -4687,6 +4688,7 @@ def gdwarf_4 : Flag<["-"], "gdwarf-4">, Group<g_Group>,
   HelpText<"Generate source-level debug information with dwarf version 4">;
 def gdwarf_5 : Flag<["-"], "gdwarf-5">, Group<g_Group>,
   HelpText<"Generate source-level debug information with dwarf version 5">;
+}
 def gdwarf64 : Flag<["-"], "gdwarf64">, Group<g_Group>,
   Visibility<[ClangOption, CC1Option, CC1AsOption]>,
   HelpText<"Enables DWARF64 format for ELF binaries, if debug information emission is enabled.">,
@@ -7626,6 +7628,8 @@ def debug_info_kind_EQ : Joined<["-"], "debug-info-kind=">;
 def record_command_line : Separate<["-"], "record-command-line">,
   HelpText<"The string to embed in the .LLVM.command.line section.">,
   MarshallingInfoString<CodeGenOpts<"RecordCommandLine">>;
+def dwarf_version_EQ : Joined<["-"], "dwarf-version=">,
+  MarshallingInfoInt<CodeGenOpts<"DwarfVersion">>;
 
 } // let Visibility = [CC1Option, CC1AsOption, FC1Option]
 
@@ -7637,8 +7641,6 @@ def debug_info_macro : Flag<["-"], "debug-info-macro">,
 def default_function_attr : Separate<["-"], "default-function-attr">,
   HelpText<"Apply given attribute to all functions">,
   MarshallingInfoStringVector<CodeGenOpts<"DefaultFunctionAttrs">>;
-def dwarf_version_EQ : Joined<["-"], "dwarf-version=">,
-  MarshallingInfoInt<CodeGenOpts<"DwarfVersion">>;
 def debugger_tuning_EQ : Joined<["-"], "debugger-tuning=">,
   Values<"gdb,lldb,sce,dbx">,
   NormalizedValuesScope<"llvm::DebuggerKind">, NormalizedValues<["GDB", "LLDB", "SCE", "DBX"]>,

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4674,12 +4674,13 @@ def ggdb3 : Flag<["-"], "ggdb3">, Group<ggdbN_Group>;
 def glldb : Flag<["-"], "glldb">, Group<gTune_Group>;
 def gsce : Flag<["-"], "gsce">, Group<gTune_Group>;
 def gdbx : Flag<["-"], "gdbx">, Group<gTune_Group>;
-
-let Visibility = [ClangOption, CLOption, DXCOption, FlangOption] in {
 // Equivalent to our default dwarf version. Forces usual dwarf emission when
 // CodeView is enabled.
 def gdwarf : Flag<["-"], "gdwarf">, Group<g_Group>,
+  Visibility<[ClangOption, CLOption, DXCOption, FlangOption]>,
   HelpText<"Generate source-level debug information with the default dwarf version">;
+
+let Visibility = [ClangOption, FlangOption] in {
 def gdwarf_2 : Flag<["-"], "gdwarf-2">, Group<g_Group>,
   HelpText<"Generate source-level debug information with dwarf version 2">;
 def gdwarf_3 : Flag<["-"], "gdwarf-3">, Group<g_Group>,

--- a/clang/lib/Driver/ToolChains/Flang.cpp
+++ b/clang/lib/Driver/ToolChains/Flang.cpp
@@ -134,12 +134,17 @@ void Flang::addOtherOptions(const ArgList &Args, ArgStringList &CmdArgs) const {
   if (Args.hasArg(options::OPT_gN_Group)) {
     Arg *gNArg = Args.getLastArg(options::OPT_gN_Group);
     DebugInfoKind = debugLevelToInfoKind(*gNArg);
-  } else if (Args.hasArg(options::OPT_g_Flag)) {
+  } else if (Args.hasArg(options::OPT_g_Group)) {
     DebugInfoKind = llvm::codegenoptions::FullDebugInfo;
   } else {
     DebugInfoKind = llvm::codegenoptions::NoDebugInfo;
   }
   addDebugInfoKind(CmdArgs, DebugInfoKind);
+  if (getDwarfNArg(Args)) {
+    const unsigned DwarfVersion = getDwarfVersion(getToolChain(), Args);
+    CmdArgs.push_back(
+        Args.MakeArgString("-dwarf-version=" + Twine(DwarfVersion)));
+  }
 }
 
 void Flang::addCodegenOptions(const ArgList &Args,

--- a/flang/include/flang/Frontend/CodeGenOptions.def
+++ b/flang/include/flang/Frontend/CodeGenOptions.def
@@ -46,6 +46,7 @@ CODEGENOPT(InterchangeLoops, 1, 0) ///< Enable loop interchange.
 CODEGENOPT(LoopVersioning, 1, 0) ///< Enable loop versioning.
 CODEGENOPT(UnrollLoops, 1, 0) ///< Enable loop unrolling
 CODEGENOPT(AliasAnalysis, 1, 0) ///< Enable alias analysis pass
+CODEGENOPT(DwarfVersion, 3, 0) ///< Dwarf version
 
 CODEGENOPT(Underscoring, 1, 1)
 ENUM_CODEGENOPT(RelocationModel, llvm::Reloc::Model, 3, llvm::Reloc::PIC_) ///< Name of the relocation model to use.

--- a/flang/lib/Frontend/CompilerInvocation.cpp
+++ b/flang/lib/Frontend/CompilerInvocation.cpp
@@ -157,6 +157,10 @@ static bool parseDebugArgs(Fortran::frontend::CodeGenOptions &opts,
           clang::DiagnosticsEngine::Warning, "Unsupported debug option: %0");
       diags.Report(debugWarning) << arg->getValue();
     }
+    // The default value of 2 here is to match clang.
+    opts.DwarfVersion =
+        getLastArgIntValue(args, clang::driver::options::OPT_dwarf_version_EQ,
+                           /*Default=*/2, diags);
   }
   return true;
 }

--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -1,0 +1,27 @@
+// RUN: %flang -### -S %s -g -gdwarf-5  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF5 %s
+// RUN: %flang -### -S %s -g1 -gdwarf-5  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s
+// RUN: %flang -### -S %s -gdwarf-5  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-WITHOUT-G-DWARF5 %s
+// RUN: %flang -### -S %s -gdwarf-4  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF4 %s
+// RUN: %flang -### -S %s -gdwarf-3  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF3 %s
+// RUN: %flang -### -S %s -gdwarf-2  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
+
+// CHECK-WITH-G-DWARF5: -debug-info-kind=standalone
+// CHECK-WITH-G-DWARF5-SAME: -dwarf-version=5
+
+// CHECK-WITH-G1-DWARF5: -debug-info-kind=line-tables-only
+// CHECK-WITH-G1-DWARF5-SAME: -dwarf-version=5
+
+// CHECK-WITHOUT-G-DWARF5: -debug-info-kind=standalone
+// CHECK-WITHOUT-G-DWARF5: -dwarf-version=5
+
+// CHECK-DWARF4: -dwarf-version=4
+
+// CHECK-DWARF3: -dwarf-version=3
+
+// CHECK-DWARF2: -dwarf-version=2

--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -18,7 +18,7 @@
 // CHECK-WITH-G1-DWARF5-SAME: -dwarf-version=5
 
 // CHECK-WITHOUT-G-DWARF5: -debug-info-kind=standalone
-// CHECK-WITHOUT-G-DWARF5: -dwarf-version=5
+// CHECK-WITHOUT-G-DWARF5-SAME: -dwarf-version=5
 
 // CHECK-DWARF4: -dwarf-version=4
 

--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -1,9 +1,9 @@
 // RUN: %flang -### -S %s -g -gdwarf-5  2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-WITH-G-DWARF5 %s
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
+// RUN: %flang -### -S %s -gdwarf-5  2>&1 \
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
 // RUN: %flang -### -S %s -g1 -gdwarf-5  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s
-// RUN: %flang -### -S %s -gdwarf-5  2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-WITHOUT-G-DWARF5 %s
 // RUN: %flang -### -S %s -gdwarf-4  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF4 %s
 // RUN: %flang -### -S %s -gdwarf-3  2>&1 \
@@ -11,14 +11,11 @@
 // RUN: %flang -### -S %s -gdwarf-2  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF2 %s
 
-// CHECK-WITH-G-DWARF5: -debug-info-kind=standalone
-// CHECK-WITH-G-DWARF5-SAME: -dwarf-version=5
+// CHECK-DWARF5: -debug-info-kind=standalone
+// CHECK-DWARF5-SAME: -dwarf-version=5
 
 // CHECK-WITH-G1-DWARF5: -debug-info-kind=line-tables-only
 // CHECK-WITH-G1-DWARF5-SAME: -dwarf-version=5
-
-// CHECK-WITHOUT-G-DWARF5: -debug-info-kind=standalone
-// CHECK-WITHOUT-G-DWARF5-SAME: -dwarf-version=5
 
 // CHECK-DWARF4: -dwarf-version=4
 


### PR DESCRIPTION
This PR adds the support for -gdwarf-N option where allows user to choose the version of the dwarf. Currently N can be 2, 3, 4, or 5. This is only the driver part of the change. Later PRs will propogate it to the IR.

Fixes https://github.com/llvm/llvm-project/issues/112910.