### PR TITLE
[lldb] Change directory creation logic in framework-header-fix

### DIFF
--- a/lldb/scripts/framework-header-fix.py
+++ b/lldb/scripts/framework-header-fix.py
@@ -115,8 +115,10 @@ def main():
         unifdef_guards = ["-U" + guard for guard in args.unifdef_guards]
 
     # Create the framework's header dir if it doesn't already exist
-    if not os.path.exists(os.path.dirname(output_file_path)):
+    try:
         os.makedirs(os.path.dirname(output_file_path))
+    except FileExistsError:
+        pass
 
     if framework_version == "lldb_main":
         modify_main_includes(input_file_path, output_file_path)


### PR DESCRIPTION
It's possible for this logic to fail if the build system runs this script in parallel. One instance could create the directory in between another instance's checking of its existence and attempt at creation.

Instead, always try to create it and ignore any FileExistsErrors.

rdar://160120161