### PR TITLE
[IntrinsicEmitter] Make AttributesMap PackedID type-adaptive

### DIFF
--- a/llvm/test/TableGen/intrinsic-attrs.td
+++ b/llvm/test/TableGen/intrinsic-attrs.td
@@ -24,7 +24,7 @@ def int_deref_ptr_ret : Intrinsic<[llvm_ptr_ty], [], [Dereferenceable<RetIndex, 
 // CHECK-NEXT: Attribute::get(C, Attribute::NoUnwind),
 // CHECK-NEXT: });
 
-// CHECK: static constexpr uint16_t IntrinsicsToAttributesMap[] = {
+// CHECK: static constexpr uint8_t IntrinsicsToAttributesMap[] = {
 // CHECK: 0 << 1 | 0, // llvm.deref.ptr.ret
 // CHECK: 1 << 1 | 1, // llvm.random.gen
 // CHECK: }; // IntrinsicsToAttributesMap


### PR DESCRIPTION
Following up #157965 which made this bit-adaptive, this patch attempts to make this map able to choose type ranging from int8 to int64 based on intrinsic inputs.