### PR TITLE
[compiler-rt] Remove enable_execute_stack support on arm64 Darwin

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -674,6 +674,11 @@ if (MINGW)
   )
 endif()
 
+# Don't build enable_execute_stack on arm64 darwin.
+if (APPLE)
+  list(REMOVE_ITEM aarch64_SOURCES enable_execute_stack.c)
+endif()
+
 set(amdgcn_SOURCES ${GENERIC_SOURCES})
 
 set(armv4t_SOURCES ${arm_min_SOURCES})


### PR DESCRIPTION
`enable_execute_stack` is not supported on arm64 Darwin because:

- It calls mprotect with `PROT_WRITE | PROT_EXEC`, which is rejected on this platform.
- It assumes a fixed 4K page size, which is not guaranteed.

This change disables building `enable_execute_stack` on arm64 Darwin and fixes the failing test:

`compiler-rt/test/builtins/Unit/enable_execute_stack_test.c`.

rdar://159705691