### PR TITLE
AMDGPU: Relax verifier for agpr/vgpr loads and stores

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -5590,7 +5590,7 @@ bool SIInstrInfo::verifyInstruction(const MachineInstr &MI,
       Data = nullptr;
 
     if (ST.hasGFX90AInsts()) {
-      if (Dst && Data &&
+      if (Dst && Data && !Dst->isTied() && !Data->isTied() &&
           (RI.isAGPR(MRI, Dst->getReg()) != RI.isAGPR(MRI, Data->getReg()))) {
         ErrInfo = "Invalid register class: "
                   "vdata and vdst should be both VGPR or AGPR";


### PR DESCRIPTION
Permit tied operands to be mismatched agpr or vgpr. The operands
are tied so they will eventually resolve to the same subclass. I'm
surprised the generic verifier doesn't enforce tied operands using
identical classes.

Fixes expensive_checks failures.