### PR TITLE
[cland-tidy][NFC] Fixed documentation for modernize-make-shared check

### DIFF
--- a/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst
@@ -37,7 +37,7 @@ Options
 .. option:: MakeSmartPtrFunctionHeader
 
    A string specifying the corresponding header of make-shared-ptr function.
-   Default is `memory`.
+   Default is `<memory>`.
 
 .. option:: IncludeStyle
 


### PR DESCRIPTION
I was surprised to see a different value for the `MakeSmartPtrFunctionHeader` option of the `modernize-make-unique` and `modernize-make-shared` clang-tidy checks. See, respectively: [modernize-make-unique](https://github.com/llvm/llvm-project/blob/86397f55d5b3ac2ebefc91bbf1a7a6a23b44a3e2/clang-tools-extra/docs/clang-tidy/checks/modernize/make-unique.rst?plain=1#L40) and [modernize-make-shared](https://github.com/llvm/llvm-project/blob/86397f55d5b3ac2ebefc91bbf1a7a6a23b44a3e2/clang-tools-extra/docs/clang-tidy/checks/modernize/make-shared.rst?plain=1#L40).

From what I've read in the codebase, I believe both checks use the same default value for the `MakeSmartPtrFunctionHeader`: `<memory>` (from [here](https://github.com/llvm/llvm-project/blob/d976be0bb4f706a7f8d446cd5639651db66bf7a9/clang-tools-extra/clang-tidy/modernize/MakeSmartPtrCheck.cpp#L45-L46)).