### PR TITLE
[RISCV][GISel] Remove unnecessary copy from X0 in G_FCONSTANT selection.

### DIFF
--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fp-constant-f16.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fp-constant-f16.mir
@@ -57,8 +57,7 @@ body:             |
     ; CHECK-LABEL: name: half_positive_zero
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x0
-    ; CHECK-NEXT: [[FMV_H_X:%[0-9]+]]:fpr16 = FMV_H_X [[COPY]]
+    ; CHECK-NEXT: [[FMV_H_X:%[0-9]+]]:fpr16 = FMV_H_X $x0
     ; CHECK-NEXT: $f10_h = COPY [[FMV_H_X]]
     ; CHECK-NEXT: PseudoRET implicit $f10_h
     %1:fprb(s16) = G_FCONSTANT half 0.000000e+00

--- a/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fp-constant.mir
+++ b/llvm/test/CodeGen/RISCV/GlobalISel/instruction-select/fp-constant.mir
@@ -56,8 +56,7 @@ body:             |
     ; CHECK-LABEL: name: float_positive_zero
     ; CHECK: liveins: $x10
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x0
-    ; CHECK-NEXT: [[FMV_W_X:%[0-9]+]]:fpr32 = FMV_W_X [[COPY]]
+    ; CHECK-NEXT: [[FMV_W_X:%[0-9]+]]:fpr32 = FMV_W_X $x0
     ; CHECK-NEXT: $f10_f = COPY [[FMV_W_X]]
     ; CHECK-NEXT: PseudoRET implicit $f10_f
     %1:fprb(s32) = G_FCONSTANT float 0.000000e+00
@@ -171,8 +170,7 @@ body:             |
     ; RV64-LABEL: name: double_positive_zero
     ; RV64: liveins: $x10
     ; RV64-NEXT: {{  $}}
-    ; RV64-NEXT: [[COPY:%[0-9]+]]:gpr = COPY $x0
-    ; RV64-NEXT: [[FMV_D_X:%[0-9]+]]:fpr64 = FMV_D_X [[COPY]]
+    ; RV64-NEXT: [[FMV_D_X:%[0-9]+]]:fpr64 = FMV_D_X $x0
     ; RV64-NEXT: $f10_d = COPY [[FMV_D_X]]
     ; RV64-NEXT: PseudoRET implicit $f10_d
     %1:fprb(s64) = G_FCONSTANT double 0.000000e+00


### PR DESCRIPTION
Instead of calling materializeImm, just assign GPRReg to X0.

While there, move conversion to APInt to only where it is necessary.