### PR TITLE
[clang-tools-extra][docs] Add "Potentially Breaking Changes" section to ReleaseNotes

### DIFF
--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -46,6 +46,21 @@ infrastructure are described first, followed by tool-specific sections.
 Major New Features
 ------------------
 
+Potentially Breaking Changes
+----------------------------
+
+- Removed :program:`clang-tidy`'s global options `IgnoreMacros` and
+  `StrictMode`, which were documented as deprecated since
+  :program:`clang-tidy-20`. Users should use the check-specific options of the
+  same name instead.
+
+- Renamed :program:`clang-tidy`'s option name of check
+  :doc:`bugprone-easily-swappable-parameters
+  <clang-tidy/checks/bugprone/easily-swappable-parameters>` from
+  ``NamePrefixSuffixSilenceDissimilarityTreshold`` to
+  ``NamePrefixSuffixSilenceDissimilarityThreshold``,
+  correcting a spelling mistake.
+
 Improvements to clangd
 ----------------------
 

--- a/clang-tools-extra/docs/ReleaseNotesTemplate.txt
+++ b/clang-tools-extra/docs/ReleaseNotesTemplate.txt
@@ -46,6 +46,9 @@ infrastructure are described first, followed by tool-specific sections.
 Major New Features
 ------------------
 
+Potentially Breaking Changes
+----------------------------
+
 Improvements to clangd
 ----------------------
 


### PR DESCRIPTION
This implements:
https://github.com/llvm/llvm-project/blob/30e9cbacab5b474de89992851f126fff300c1ab7/llvm/docs/DeveloperPolicy.rst?plain=1#L282-L286
From LLVM developer policy.