### PR TITLE
[MLIR][Python] add type hints for accessors

### DIFF
--- a/mlir/lib/Bindings/Python/IRAttributes.cpp
+++ b/mlir/lib/Bindings/Python/IRAttributes.cpp
@@ -1742,9 +1742,9 @@ nb::object integerOrBoolAttributeCaster(PyAttribute &pyAttribute) {
     return nb::cast(PyBoolAttribute(pyAttribute));
   if (PyIntegerAttribute::isaFunction(pyAttribute))
     return nb::cast(PyIntegerAttribute(pyAttribute));
-  std::string msg =
-      std::string("Can't cast unknown element type DenseArrayAttr (") +
-      nb::cast<std::string>(nb::repr(nb::cast(pyAttribute))) + ")";
+  std::string msg = std::string("Can't cast unknown attribute type Attr (") +
+                    nb::cast<std::string>(nb::repr(nb::cast(pyAttribute))) +
+                    ")";
   throw nb::type_error(msg.c_str());
 }
 

--- a/mlir/test/mlir-tblgen/op-python-bindings.td
+++ b/mlir/test/mlir-tblgen/op-python-bindings.td
@@ -36,7 +36,7 @@ def AttrSizedOperandsOp : TestOp<"attr_sized_operands",
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def variadic1(self):
+  // CHECK: def variadic1(self) -> _ods_ir.OpOperandList:
   // CHECK:   operand_range = _ods_segmented_accessor(
   // CHECK:       self.operation.operands,
   // CHECK:       self.operation.attributes["operandSegmentSizes"], 0)
@@ -44,14 +44,14 @@ def AttrSizedOperandsOp : TestOp<"attr_sized_operands",
   // CHECK-NOT: if len(operand_range)
   //
   // CHECK: @builtins.property
-  // CHECK: def non_variadic(self):
+  // CHECK: def non_variadic(self) -> _ods_ir.Value:
   // CHECK:   operand_range = _ods_segmented_accessor(
   // CHECK:       self.operation.operands,
   // CHECK:       self.operation.attributes["operandSegmentSizes"], 1)
   // CHECK:   return operand_range[0]
   //
   // CHECK: @builtins.property
-  // CHECK: def variadic2(self):
+  // CHECK: def variadic2(self) -> _Optional[_ods_ir.Value]:
   // CHECK:   operand_range = _ods_segmented_accessor(
   // CHECK:       self.operation.operands,
   // CHECK:       self.operation.attributes["operandSegmentSizes"], 2)
@@ -84,21 +84,21 @@ def AttrSizedResultsOp : TestOp<"attr_sized_results",
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def variadic1(self):
+  // CHECK: def variadic1(self) -> _Optional[_ods_ir.OpResult]:
   // CHECK:   result_range = _ods_segmented_accessor(
   // CHECK:       self.operation.results,
   // CHECK:       self.operation.attributes["resultSegmentSizes"], 0)
   // CHECK:   return result_range[0] if len(result_range) > 0 else None
   //
   // CHECK: @builtins.property
-  // CHECK: def non_variadic(self):
+  // CHECK: def non_variadic(self) -> _ods_ir.OpResult:
   // CHECK:   result_range = _ods_segmented_accessor(
   // CHECK:       self.operation.results,
   // CHECK:       self.operation.attributes["resultSegmentSizes"], 1)
   // CHECK:   return result_range[0]
   //
   // CHECK: @builtins.property
-  // CHECK: def variadic2(self):
+  // CHECK: def variadic2(self) -> _ods_ir.OpResultList:
   // CHECK:   result_range = _ods_segmented_accessor(
   // CHECK:       self.operation.results,
   // CHECK:       self.operation.attributes["resultSegmentSizes"], 2)
@@ -139,21 +139,21 @@ def AttributedOp : TestOp<"attributed_op"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def i32attr(self):
+  // CHECK: def i32attr(self) -> _ods_ir.Attribute:
   // CHECK:   return self.operation.attributes["i32attr"]
 
   // CHECK: @builtins.property
-  // CHECK: def optionalF32Attr(self):
+  // CHECK: def optionalF32Attr(self) -> _Optional[_ods_ir.Attribute]:
   // CHECK:   if "optionalF32Attr" not in self.operation.attributes:
   // CHECK:     return None
   // CHECK:   return self.operation.attributes["optionalF32Attr"]
 
   // CHECK: @builtins.property
-  // CHECK: def unitAttr(self):
+  // CHECK: def unitAttr(self) -> bool:
   // CHECK:   return "unitAttr" in self.operation.attributes
 
   // CHECK: @builtins.property
-  // CHECK: def in_(self):
+  // CHECK: def in_(self) -> _ods_ir.Attribute:
   // CHECK:   return self.operation.attributes["in"]
 
   let arguments = (ins I32Attr:$i32attr, OptionalAttr<F32Attr>:$optionalF32Attr,
@@ -186,11 +186,11 @@ def AttributedOpWithOperands : TestOp<"attributed_op_with_operands"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def in_(self):
+  // CHECK: def in_(self) -> bool:
   // CHECK:   return "in" in self.operation.attributes
 
   // CHECK: @builtins.property
-  // CHECK: def is_(self):
+  // CHECK: def is_(self) -> _Optional[_ods_ir.Attribute]:
   // CHECK:   if "is" not in self.operation.attributes:
   // CHECK:     return None
   // CHECK:   return self.operation.attributes["is"]
@@ -322,16 +322,16 @@ def MissingNamesOp : TestOp<"missing_names"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def f32(self):
+  // CHECK: def f32(self) -> _ods_ir.Value:
   // CHECK:   return self.operation.operands[1]
   let arguments = (ins I32, F32:$f32, I64);
 
   // CHECK: @builtins.property
-  // CHECK: def i32(self):
+  // CHECK: def i32(self) -> _ods_ir.OpResult:
   // CHECK:   return self.operation.results[0]
   //
   // CHECK: @builtins.property
-  // CHECK: def i64(self):
+  // CHECK: def i64(self) -> _ods_ir.OpResult:
   // CHECK:   return self.operation.results[2]
   let results = (outs I32:$i32, AnyFloat, I64:$i64);
 }
@@ -360,11 +360,11 @@ def OneOptionalOperandOp : TestOp<"one_optional_operand"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def non_optional(self):
+  // CHECK: def non_optional(self) -> _ods_ir.Value:
   // CHECK:   return self.operation.operands[0]
 
   // CHECK: @builtins.property
-  // CHECK: def optional(self):
+  // CHECK: def optional(self) -> _Optional[_ods_ir.Value]:
   // CHECK:   return None if len(self.operation.operands) < 2 else self.operation.operands[1]
 }
 
@@ -391,11 +391,11 @@ def OneVariadicOperandOp : TestOp<"one_variadic_operand"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def non_variadic(self):
+  // CHECK: def non_variadic(self) -> _ods_ir.Value:
   // CHECK:   return self.operation.operands[0]
   //
   // CHECK: @builtins.property
-  // CHECK: def variadic(self):
+  // CHECK: def variadic(self) -> _ods_ir.OpOperandList:
   // CHECK:   _ods_variadic_group_length = len(self.operation.operands) - 2 + 1
   // CHECK:   return self.operation.operands[1:1 + _ods_variadic_group_length]
   let arguments = (ins AnyType:$non_variadic, Variadic<AnyType>:$variadic);
@@ -424,12 +424,12 @@ def OneVariadicResultOp : TestOp<"one_variadic_result"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def variadic(self):
+  // CHECK: def variadic(self) -> _ods_ir.OpResultList:
   // CHECK:   _ods_variadic_group_length = len(self.operation.results) - 2 + 1
   // CHECK:   return self.operation.results[0:0 + _ods_variadic_group_length]
   //
   // CHECK: @builtins.property
-  // CHECK: def non_variadic(self):
+  // CHECK: def non_variadic(self) -> _ods_ir.OpResult:
   // CHECK:   _ods_variadic_group_length = len(self.operation.results) - 2 + 1
   // CHECK:   return self.operation.results[1 + _ods_variadic_group_length - 1]
   let results = (outs Variadic<AnyType>:$variadic, AnyType:$non_variadic);
@@ -456,7 +456,7 @@ def PythonKeywordOp : TestOp<"python_keyword"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def in_(self):
+  // CHECK: def in_(self) -> _ods_ir.Value:
   // CHECK:   return self.operation.operands[0]
   let arguments = (ins AnyType:$in);
 }
@@ -495,17 +495,17 @@ def SameResultsVariadicOp : TestOp<"same_results_variadic", [SameOperandsAndResu
 def SameVariadicOperandSizeOp : TestOp<"same_variadic_operand",
                                        [SameVariadicOperandSize]> {
   // CHECK: @builtins.property
-  // CHECK: def variadic1(self):
+  // CHECK: def variadic1(self) -> _ods_ir.OpOperandList:
   // CHECK:   start, elements_per_group = _ods_equally_sized_accessor(self.operation.operands, 1, 2, 0, 0)
   // CHECK:   return self.operation.operands[start:start + elements_per_group]
   //
   // CHECK: @builtins.property
-  // CHECK: def non_variadic(self):
+  // CHECK: def non_variadic(self) -> _ods_ir.Value:
   // CHECK:   start, elements_per_group = _ods_equally_sized_accessor(self.operation.operands, 1, 2, 0, 1)
   // CHECK:   return self.operation.operands[start]
   //
   // CHECK: @builtins.property
-  // CHECK: def variadic2(self):
+  // CHECK: def variadic2(self) -> _ods_ir.OpOperandList:
   // CHECK:   start, elements_per_group = _ods_equally_sized_accessor(self.operation.operands, 1, 2, 1, 1)
   // CHECK:   return self.operation.operands[start:start + elements_per_group]
   let arguments = (ins Variadic<AnyType>:$variadic1, AnyType:$non_variadic,
@@ -521,17 +521,17 @@ def SameVariadicOperandSizeOp : TestOp<"same_variadic_operand",
 def SameVariadicResultSizeOp : TestOp<"same_variadic_result",
                                       [SameVariadicResultSize]> {
   // CHECK: @builtins.property
-  // CHECK: def variadic1(self):
+  // CHECK: def variadic1(self) -> _ods_ir.OpResultList:
   // CHECK:   start, elements_per_group = _ods_equally_sized_accessor(self.operation.results, 1, 2, 0, 0)
   // CHECK:   return self.operation.results[start:start + elements_per_group]
   //
   // CHECK: @builtins.property
-  // CHECK: def non_variadic(self):
+  // CHECK: def non_variadic(self) -> _ods_ir.OpResult:
   // CHECK:   start, elements_per_group = _ods_equally_sized_accessor(self.operation.results, 1, 2, 0, 1)
   // CHECK:   return self.operation.results[start]
   //
   // CHECK: @builtins.property
-  // CHECK: def variadic2(self):
+  // CHECK: def variadic2(self) -> _ods_ir.OpResultList:
   // CHECK:   start, elements_per_group = _ods_equally_sized_accessor(self.operation.results, 1, 2, 1, 1)
   // CHECK:   return self.operation.results[start:start + elements_per_group]
   let results = (outs Variadic<AnyType>:$variadic1, AnyType:$non_variadic,
@@ -562,20 +562,20 @@ def SimpleOp : TestOp<"simple"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def i32(self):
+  // CHECK: def i32(self) -> _ods_ir.Value:
   // CHECK:   return self.operation.operands[0]
   //
   // CHECK: @builtins.property
-  // CHECK: def f32(self):
+  // CHECK: def f32(self) -> _ods_ir.Value:
   // CHECK:   return self.operation.operands[1]
   let arguments = (ins I32:$i32, F32:$f32);
 
   // CHECK: @builtins.property
-  // CHECK: def i64(self):
+  // CHECK: def i64(self) -> _ods_ir.OpResult:
   // CHECK:   return self.operation.results[0]
   //
   // CHECK: @builtins.property
-  // CHECK: def f64(self):
+  // CHECK: def f64(self) -> _ods_ir.OpResult:
   // CHECK:   return self.operation.results[1]
   let results = (outs I64:$i64, AnyFloat:$f64);
 }
@@ -600,11 +600,11 @@ def VariadicAndNormalRegionOp : TestOp<"variadic_and_normal_region"> {
   let regions = (region AnyRegion:$region, AnyRegion, VariadicRegion<AnyRegion>:$variadic);
 
   // CHECK:  @builtins.property
-  // CHECK:  def region(self):
+  // CHECK:  def region(self) -> _ods_ir.Region:
   // CHECK:    return self.regions[0]
 
   // CHECK:  @builtins.property
-  // CHECK:  def variadic(self):
+  // CHECK:  def variadic(self) -> _ods_ir.RegionSequence:
   // CHECK:    return self.regions[2:]
 }
 
@@ -628,7 +628,7 @@ def VariadicRegionOp : TestOp<"variadic_region"> {
   let regions = (region VariadicRegion<AnyRegion>:$Variadic);
 
   // CHECK:  @builtins.property
-  // CHECK:  def Variadic(self):
+  // CHECK:  def Variadic(self) -> _ods_ir.RegionSequence:
   // CHECK:    return self.regions[0:]
 }
 

--- a/mlir/test/mlir-tblgen/op-python-bindings.td
+++ b/mlir/test/mlir-tblgen/op-python-bindings.td
@@ -139,11 +139,11 @@ def AttributedOp : TestOp<"attributed_op"> {
   // CHECK:     successors=_ods_successors, regions=regions, loc=loc, ip=ip)
 
   // CHECK: @builtins.property
-  // CHECK: def i32attr(self) -> _ods_ir.Attribute:
+  // CHECK: def i32attr(self) -> _ods_ir.IntegerAttr:
   // CHECK:   return self.operation.attributes["i32attr"]
 
   // CHECK: @builtins.property
-  // CHECK: def optionalF32Attr(self) -> _Optional[_ods_ir.Attribute]:
+  // CHECK: def optionalF32Attr(self) -> _Optional[_ods_ir.FloatAttr]:
   // CHECK:   if "optionalF32Attr" not in self.operation.attributes:
   // CHECK:     return None
   // CHECK:   return self.operation.attributes["optionalF32Attr"]
@@ -153,7 +153,7 @@ def AttributedOp : TestOp<"attributed_op"> {
   // CHECK:   return "unitAttr" in self.operation.attributes
 
   // CHECK: @builtins.property
-  // CHECK: def in_(self) -> _ods_ir.Attribute:
+  // CHECK: def in_(self) -> _ods_ir.IntegerAttr:
   // CHECK:   return self.operation.attributes["in"]
 
   let arguments = (ins I32Attr:$i32attr, OptionalAttr<F32Attr>:$optionalF32Attr,
@@ -190,7 +190,7 @@ def AttributedOpWithOperands : TestOp<"attributed_op_with_operands"> {
   // CHECK:   return "in" in self.operation.attributes
 
   // CHECK: @builtins.property
-  // CHECK: def is_(self) -> _Optional[_ods_ir.Attribute]:
+  // CHECK: def is_(self) -> _Optional[_ods_ir.FloatAttr]:
   // CHECK:   if "is" not in self.operation.attributes:
   // CHECK:     return None
   // CHECK:   return self.operation.attributes["is"]

--- a/mlir/test/python/dialects/python_test.py
+++ b/mlir/test/python/dialects/python_test.py
@@ -629,11 +629,17 @@ def testVariadicOperandAccess():
                 [zero, one], two, [three, four]
             )
             # CHECK: Value(%{{.*}} = arith.constant 2 : i32)
-            print(variadic_operands.non_variadic)
+            non_variadic = variadic_operands.non_variadic
+            print(non_variadic)
+            assert isinstance(non_variadic, Value)
             # CHECK: ['Value(%{{.*}} = arith.constant 0 : i32)', 'Value(%{{.*}} = arith.constant 1 : i32)']
-            print(values(variadic_operands.variadic1))
+            variadic1 = variadic_operands.variadic1
+            print(values(variadic1))
+            assert isinstance(variadic1, OpOperandList)
             # CHECK: ['Value(%{{.*}} = arith.constant 3 : i32)', 'Value(%{{.*}} = arith.constant 4 : i32)']
-            print(values(variadic_operands.variadic2))
+            variadic2 = variadic_operands.variadic2
+            print(values(variadic2))
+            assert isinstance(variadic2, OpOperandList)
 
             assert (
                 inspect.signature(test.same_variadic_operand).return_annotation
@@ -692,7 +698,9 @@ def testVariadicResultAccess():
             # CHECK: i1
             print(op.non_variadic2.type)
             # CHECK: [IntegerType(i2), IntegerType(i3), IntegerType(i4)]
-            print(types(op.variadic))
+            variadic = op.variadic
+            print(types(variadic))
+            assert isinstance(variadic, OpResultList)
 
             #  Test Variadic-Variadic-Fixed
             op = test.SameVariadicResultSizeOpVVF(
@@ -754,3 +762,14 @@ def testVariadicResultAccess():
                 test.results_variadic([i[0]]),
                 OpResult,
             )
+
+
+# CHECK-LABEL: TEST: testVariadicAndNormalRegion
+@run
+def testVariadicAndNormalRegionOp():
+    with Context() as ctx, Location.unknown(ctx):
+        module = Module.create()
+        with InsertionPoint(module.body):
+            region_op = test.VariadicAndNormalRegionOp(2)
+            assert isinstance(region_op.region, Region)
+            assert isinstance(region_op.variadic, RegionSequence)

--- a/mlir/test/python/dialects/python_test.py
+++ b/mlir/test/python/dialects/python_test.py
@@ -2,6 +2,7 @@
 # RUN: %PYTHON %s nanobind | FileCheck %s
 import inspect
 import sys
+import typing
 from typing import Union
 
 from mlir.ir import *
@@ -232,6 +233,161 @@ def attrBuilder():
         )
         op.verify()
         op.print(use_local_scope=True)
+
+    # fmt: off
+    assert typing.get_type_hints(test.AttributesOp.x_affinemaparr.fset)["value"] is ArrayAttr
+    assert type(op.x_affinemaparr) is typing.get_type_hints(test.AttributesOp.x_affinemaparr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_affinemap.fset)["value"] is AffineMapAttr
+    assert type(op.x_affinemap) is typing.get_type_hints(test.AttributesOp.x_affinemap.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_arr.fset)["value"] is ArrayAttr
+    assert type(op.x_arr) is typing.get_type_hints(test.AttributesOp.x_arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_boolarr.fset)["value"] is ArrayAttr
+    assert type(op.x_boolarr) is typing.get_type_hints(test.AttributesOp.x_boolarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_bool.fset)["value"] is BoolAttr
+    assert type(op.x_bool) is typing.get_type_hints(test.AttributesOp.x_bool.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_dboolarr.fset)["value"] is DenseBoolArrayAttr
+    assert type(op.x_dboolarr) is typing.get_type_hints(test.AttributesOp.x_dboolarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_df32arr.fset)["value"] is DenseF32ArrayAttr
+    assert type(op.x_df32arr) is typing.get_type_hints(test.AttributesOp.x_df32arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_df64arr.fset)["value"] is DenseF64ArrayAttr
+    assert type(op.x_df64arr) is typing.get_type_hints(test.AttributesOp.x_df64arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_df16arr.fset)["value"] is DenseI16ArrayAttr
+    assert type(op.x_df16arr) is typing.get_type_hints(test.AttributesOp.x_df16arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_di32arr.fset)["value"] is DenseI32ArrayAttr
+    assert type(op.x_di32arr) is typing.get_type_hints(test.AttributesOp.x_di32arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_di64arr.fset)["value"] is DenseI64ArrayAttr
+    assert type(op.x_di64arr) is typing.get_type_hints(test.AttributesOp.x_di64arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_di8arr.fset)["value"] is DenseI8ArrayAttr
+    assert type(op.x_di8arr) is typing.get_type_hints(test.AttributesOp.x_di8arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_dictarr.fset)["value"] is ArrayAttr
+    assert type(op.x_dictarr) is typing.get_type_hints(test.AttributesOp.x_dictarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_dict.fset)["value"] is DictAttr
+    assert type(op.x_dict) is typing.get_type_hints(test.AttributesOp.x_dict.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_f32arr.fset)["value"] is ArrayAttr
+    assert type(op.x_f32arr) is typing.get_type_hints(test.AttributesOp.x_f32arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_f32.fset)["value"] is FloatAttr
+    assert type(op.x_f32) is typing.get_type_hints(test.AttributesOp.x_f32.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_f64arr.fset)["value"] is ArrayAttr
+    assert type(op.x_f64arr) is typing.get_type_hints(test.AttributesOp.x_f64arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_f64.fset)["value"] is FloatAttr
+    assert type(op.x_f64) is typing.get_type_hints(test.AttributesOp.x_f64.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_f64elems.fset)["value"] is DenseFPElementsAttr
+    assert type(op.x_f64elems) is typing.get_type_hints(test.AttributesOp.x_f64elems.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_flatsymrefarr.fset)["value"] is ArrayAttr
+    assert type(op.x_flatsymrefarr) is typing.get_type_hints(test.AttributesOp.x_flatsymrefarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_flatsymref.fset)["value"] is FlatSymbolRefAttr
+    assert type(op.x_flatsymref) is typing.get_type_hints(test.AttributesOp.x_flatsymref.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i16.fset)["value"] is IntegerAttr
+    assert type(op.x_i16) is typing.get_type_hints(test.AttributesOp.x_i16.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i1.fset)["value"] is BoolAttr
+    assert type(op.x_i1) is typing.get_type_hints(test.AttributesOp.x_i1.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i32arr.fset)["value"] is ArrayAttr
+    assert type(op.x_i32arr) is typing.get_type_hints(test.AttributesOp.x_i32arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i32.fset)["value"] is IntegerAttr
+    assert type(op.x_i32) is typing.get_type_hints(test.AttributesOp.x_i32.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i32elems.fset)["value"] is DenseIntElementsAttr
+    assert type(op.x_i32elems) is typing.get_type_hints(test.AttributesOp.x_i32elems.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i64arr.fset)["value"] is ArrayAttr
+    assert type(op.x_i64arr) is typing.get_type_hints(test.AttributesOp.x_i64arr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i64.fset)["value"] is IntegerAttr
+    assert type(op.x_i64) is typing.get_type_hints(test.AttributesOp.x_i64.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i64elems.fset)["value"] is DenseIntElementsAttr
+    assert type(op.x_i64elems) is typing.get_type_hints(test.AttributesOp.x_i64elems.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i64svecarr.fset)["value"] is ArrayAttr
+    assert type(op.x_i64svecarr) is typing.get_type_hints(test.AttributesOp.x_i64svecarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_i8.fset)["value"] is IntegerAttr
+    assert type(op.x_i8) is typing.get_type_hints(test.AttributesOp.x_i8.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_idx.fset)["value"] is IntegerAttr
+    assert type(op.x_idx) is typing.get_type_hints(test.AttributesOp.x_idx.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_idxelems.fset)["value"] is DenseIntElementsAttr
+    assert type(op.x_idxelems) is typing.get_type_hints(test.AttributesOp.x_idxelems.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_idxlistarr.fset)["value"] is ArrayAttr
+    assert type(op.x_idxlistarr) is typing.get_type_hints(test.AttributesOp.x_idxlistarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_si16.fset)["value"] is IntegerAttr
+    assert type(op.x_si16) is typing.get_type_hints(test.AttributesOp.x_si16.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_si1.fset)["value"] is IntegerAttr
+    assert type(op.x_si1) is typing.get_type_hints(test.AttributesOp.x_si1.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_si32.fset)["value"] is IntegerAttr
+    assert type(op.x_si32) is typing.get_type_hints(test.AttributesOp.x_si32.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_si64.fset)["value"] is IntegerAttr
+    assert type(op.x_si64) is typing.get_type_hints(test.AttributesOp.x_si64.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_si8.fset)["value"] is IntegerAttr
+    assert type(op.x_si8) is typing.get_type_hints(test.AttributesOp.x_si8.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_strarr.fset)["value"] is ArrayAttr
+    assert type(op.x_strarr) is typing.get_type_hints(test.AttributesOp.x_strarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_str.fset)["value"] is StringAttr
+    assert type(op.x_str) is typing.get_type_hints(test.AttributesOp.x_str.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_sym.fset)["value"] is StringAttr
+    assert type(op.x_sym) is typing.get_type_hints(test.AttributesOp.x_sym.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_symrefarr.fset)["value"] is ArrayAttr
+    assert type(op.x_symrefarr) is typing.get_type_hints(test.AttributesOp.x_symrefarr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_symref.fset)["value"] is SymbolRefAttr
+    assert type(op.x_symref) is typing.get_type_hints(test.AttributesOp.x_symref.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_typearr.fset)["value"] is ArrayAttr
+    assert type(op.x_typearr) is typing.get_type_hints(test.AttributesOp.x_typearr.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_type.fset)["value"] is TypeAttr
+    assert type(op.x_type) is typing.get_type_hints(test.AttributesOp.x_type.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_ui16.fset)["value"] is IntegerAttr
+    assert type(op.x_ui16) is typing.get_type_hints(test.AttributesOp.x_ui16.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_ui1.fset)["value"] is IntegerAttr
+    assert type(op.x_ui1) is typing.get_type_hints(test.AttributesOp.x_ui1.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_ui32.fset)["value"] is IntegerAttr
+    assert type(op.x_ui32) is typing.get_type_hints(test.AttributesOp.x_ui32.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_ui64.fset)["value"] is IntegerAttr
+    assert type(op.x_ui64) is typing.get_type_hints(test.AttributesOp.x_ui64.fget)["return"]
+
+    assert typing.get_type_hints(test.AttributesOp.x_ui8.fset)["value"] is IntegerAttr
+    assert type(op.x_ui8) is typing.get_type_hints(test.AttributesOp.x_ui8.fget)["return"]
+    # fmt: on
 
 
 # CHECK-LABEL: TEST: inferReturnTypes

--- a/mlir/test/python/dialects/python_test.py
+++ b/mlir/test/python/dialects/python_test.py
@@ -1,9 +1,8 @@
 # RUN: %PYTHON %s pybind11 | FileCheck %s
 # RUN: %PYTHON %s nanobind | FileCheck %s
-import inspect
 import sys
 import typing
-from typing import Union
+from typing import Union, Optional
 
 from mlir.ir import *
 import mlir.dialects.func as func
@@ -236,156 +235,207 @@ def attrBuilder():
 
     # fmt: off
     assert typing.get_type_hints(test.AttributesOp.x_affinemaparr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_affinemaparr.fget)["return"] is ArrayAttr
     assert type(op.x_affinemaparr) is typing.get_type_hints(test.AttributesOp.x_affinemaparr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_affinemap.fset)["value"] is AffineMapAttr
+    assert typing.get_type_hints(test.AttributesOp.x_affinemap.fget)["return"] is AffineMapAttr
     assert type(op.x_affinemap) is typing.get_type_hints(test.AttributesOp.x_affinemap.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_arr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_arr.fget)["return"] is ArrayAttr
     assert type(op.x_arr) is typing.get_type_hints(test.AttributesOp.x_arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_boolarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_boolarr.fget)["return"] is ArrayAttr
     assert type(op.x_boolarr) is typing.get_type_hints(test.AttributesOp.x_boolarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_bool.fset)["value"] is BoolAttr
+    assert typing.get_type_hints(test.AttributesOp.x_bool.fget)["return"] is BoolAttr
     assert type(op.x_bool) is typing.get_type_hints(test.AttributesOp.x_bool.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_dboolarr.fset)["value"] is DenseBoolArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_dboolarr.fget)["return"] is DenseBoolArrayAttr
     assert type(op.x_dboolarr) is typing.get_type_hints(test.AttributesOp.x_dboolarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_df32arr.fset)["value"] is DenseF32ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_df32arr.fget)["return"] is DenseF32ArrayAttr
     assert type(op.x_df32arr) is typing.get_type_hints(test.AttributesOp.x_df32arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_df64arr.fset)["value"] is DenseF64ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_df64arr.fget)["return"] is DenseF64ArrayAttr
     assert type(op.x_df64arr) is typing.get_type_hints(test.AttributesOp.x_df64arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_df16arr.fset)["value"] is DenseI16ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_df16arr.fget)["return"] is DenseI16ArrayAttr
     assert type(op.x_df16arr) is typing.get_type_hints(test.AttributesOp.x_df16arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_di32arr.fset)["value"] is DenseI32ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_di32arr.fget)["return"] is DenseI32ArrayAttr
     assert type(op.x_di32arr) is typing.get_type_hints(test.AttributesOp.x_di32arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_di64arr.fset)["value"] is DenseI64ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_di64arr.fget)["return"] is DenseI64ArrayAttr
     assert type(op.x_di64arr) is typing.get_type_hints(test.AttributesOp.x_di64arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_di8arr.fset)["value"] is DenseI8ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_di8arr.fget)["return"] is DenseI8ArrayAttr
     assert type(op.x_di8arr) is typing.get_type_hints(test.AttributesOp.x_di8arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_dictarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_dictarr.fget)["return"] is ArrayAttr
     assert type(op.x_dictarr) is typing.get_type_hints(test.AttributesOp.x_dictarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_dict.fset)["value"] is DictAttr
+    assert typing.get_type_hints(test.AttributesOp.x_dict.fget)["return"] is DictAttr
     assert type(op.x_dict) is typing.get_type_hints(test.AttributesOp.x_dict.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_f32arr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_f32arr.fget)["return"] is ArrayAttr
     assert type(op.x_f32arr) is typing.get_type_hints(test.AttributesOp.x_f32arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_f32.fset)["value"] is FloatAttr
+    assert typing.get_type_hints(test.AttributesOp.x_f32.fget)["return"] is FloatAttr
     assert type(op.x_f32) is typing.get_type_hints(test.AttributesOp.x_f32.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_f64arr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_f64arr.fget)["return"] is ArrayAttr
     assert type(op.x_f64arr) is typing.get_type_hints(test.AttributesOp.x_f64arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_f64.fset)["value"] is FloatAttr
+    assert typing.get_type_hints(test.AttributesOp.x_f64.fget)["return"] is FloatAttr
     assert type(op.x_f64) is typing.get_type_hints(test.AttributesOp.x_f64.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_f64elems.fset)["value"] is DenseFPElementsAttr
+    assert typing.get_type_hints(test.AttributesOp.x_f64elems.fget)["return"] is DenseFPElementsAttr
     assert type(op.x_f64elems) is typing.get_type_hints(test.AttributesOp.x_f64elems.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_flatsymrefarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_flatsymrefarr.fget)["return"] is ArrayAttr
     assert type(op.x_flatsymrefarr) is typing.get_type_hints(test.AttributesOp.x_flatsymrefarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_flatsymref.fset)["value"] is FlatSymbolRefAttr
+    assert typing.get_type_hints(test.AttributesOp.x_flatsymref.fget)["return"] is FlatSymbolRefAttr
     assert type(op.x_flatsymref) is typing.get_type_hints(test.AttributesOp.x_flatsymref.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i16.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i16.fget)["return"] is IntegerAttr
     assert type(op.x_i16) is typing.get_type_hints(test.AttributesOp.x_i16.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i1.fset)["value"] is BoolAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i1.fget)["return"] is BoolAttr
     assert type(op.x_i1) is typing.get_type_hints(test.AttributesOp.x_i1.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i32arr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i32arr.fget)["return"] is ArrayAttr
     assert type(op.x_i32arr) is typing.get_type_hints(test.AttributesOp.x_i32arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i32.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i32.fget)["return"] is IntegerAttr
     assert type(op.x_i32) is typing.get_type_hints(test.AttributesOp.x_i32.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i32elems.fset)["value"] is DenseIntElementsAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i32elems.fget)["return"] is DenseIntElementsAttr
     assert type(op.x_i32elems) is typing.get_type_hints(test.AttributesOp.x_i32elems.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i64arr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i64arr.fget)["return"] is ArrayAttr
     assert type(op.x_i64arr) is typing.get_type_hints(test.AttributesOp.x_i64arr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i64.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i64.fget)["return"] is IntegerAttr
     assert type(op.x_i64) is typing.get_type_hints(test.AttributesOp.x_i64.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i64elems.fset)["value"] is DenseIntElementsAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i64elems.fget)["return"] is DenseIntElementsAttr
     assert type(op.x_i64elems) is typing.get_type_hints(test.AttributesOp.x_i64elems.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i64svecarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i64svecarr.fget)["return"] is ArrayAttr
     assert type(op.x_i64svecarr) is typing.get_type_hints(test.AttributesOp.x_i64svecarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_i8.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_i8.fget)["return"] is IntegerAttr
     assert type(op.x_i8) is typing.get_type_hints(test.AttributesOp.x_i8.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_idx.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_idx.fget)["return"] is IntegerAttr
     assert type(op.x_idx) is typing.get_type_hints(test.AttributesOp.x_idx.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_idxelems.fset)["value"] is DenseIntElementsAttr
+    assert typing.get_type_hints(test.AttributesOp.x_idxelems.fget)["return"] is DenseIntElementsAttr
     assert type(op.x_idxelems) is typing.get_type_hints(test.AttributesOp.x_idxelems.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_idxlistarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_idxlistarr.fget)["return"] is ArrayAttr
     assert type(op.x_idxlistarr) is typing.get_type_hints(test.AttributesOp.x_idxlistarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_si16.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_si16.fget)["return"] is IntegerAttr
     assert type(op.x_si16) is typing.get_type_hints(test.AttributesOp.x_si16.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_si1.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_si1.fget)["return"] is IntegerAttr
     assert type(op.x_si1) is typing.get_type_hints(test.AttributesOp.x_si1.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_si32.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_si32.fget)["return"] is IntegerAttr
     assert type(op.x_si32) is typing.get_type_hints(test.AttributesOp.x_si32.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_si64.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_si64.fget)["return"] is IntegerAttr
     assert type(op.x_si64) is typing.get_type_hints(test.AttributesOp.x_si64.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_si8.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_si8.fget)["return"] is IntegerAttr
     assert type(op.x_si8) is typing.get_type_hints(test.AttributesOp.x_si8.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_strarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_strarr.fget)["return"] is ArrayAttr
     assert type(op.x_strarr) is typing.get_type_hints(test.AttributesOp.x_strarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_str.fset)["value"] is StringAttr
+    assert typing.get_type_hints(test.AttributesOp.x_str.fget)["return"] is StringAttr
     assert type(op.x_str) is typing.get_type_hints(test.AttributesOp.x_str.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_sym.fset)["value"] is StringAttr
+    assert typing.get_type_hints(test.AttributesOp.x_sym.fget)["return"] is StringAttr
     assert type(op.x_sym) is typing.get_type_hints(test.AttributesOp.x_sym.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_symrefarr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_symrefarr.fget)["return"] is ArrayAttr
     assert type(op.x_symrefarr) is typing.get_type_hints(test.AttributesOp.x_symrefarr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_symref.fset)["value"] is SymbolRefAttr
+    assert typing.get_type_hints(test.AttributesOp.x_symref.fget)["return"] is SymbolRefAttr
     assert type(op.x_symref) is typing.get_type_hints(test.AttributesOp.x_symref.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_typearr.fset)["value"] is ArrayAttr
+    assert typing.get_type_hints(test.AttributesOp.x_typearr.fget)["return"] is ArrayAttr
     assert type(op.x_typearr) is typing.get_type_hints(test.AttributesOp.x_typearr.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_type.fset)["value"] is TypeAttr
+    assert typing.get_type_hints(test.AttributesOp.x_type.fget)["return"] is TypeAttr
     assert type(op.x_type) is typing.get_type_hints(test.AttributesOp.x_type.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_ui16.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_ui16.fget)["return"] is IntegerAttr
     assert type(op.x_ui16) is typing.get_type_hints(test.AttributesOp.x_ui16.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_ui1.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_ui1.fget)["return"] is IntegerAttr
     assert type(op.x_ui1) is typing.get_type_hints(test.AttributesOp.x_ui1.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_ui32.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_ui32.fget)["return"] is IntegerAttr
     assert type(op.x_ui32) is typing.get_type_hints(test.AttributesOp.x_ui32.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_ui64.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_ui64.fget)["return"] is IntegerAttr
     assert type(op.x_ui64) is typing.get_type_hints(test.AttributesOp.x_ui64.fget)["return"]
 
     assert typing.get_type_hints(test.AttributesOp.x_ui8.fset)["value"] is IntegerAttr
+    assert typing.get_type_hints(test.AttributesOp.x_ui8.fget)["return"] is IntegerAttr
     assert type(op.x_ui8) is typing.get_type_hints(test.AttributesOp.x_ui8.fget)["return"]
     # fmt: on
 
@@ -449,6 +499,13 @@ def resultTypesDefinedByTraits():
             # CHECK-COUNT-2: i32
             print(same.one.type)
             print(same.two.type)
+            assert (
+                typing.get_type_hints(test.SameOperandAndResultTypeOp.one.fget)[
+                    "return"
+                ]
+                is OpResult
+            )
+            assert type(same.one) is OpResult
 
             first_type_attr = test.FirstAttrDeriveTypeAttrOp(
                 inferred.results[1], TypeAttr.get(IndexType.get())
@@ -491,6 +548,15 @@ def testOptionalOperandOp():
             op1 = test.OptionalOperandOp()
             # CHECK: op1.input is None: True
             print(f"op1.input is None: {op1.input is None}")
+            assert (
+                typing.get_type_hints(test.OptionalOperandOp.input.fget)["return"]
+                is Optional[Value]
+            )
+            assert (
+                typing.get_type_hints(test.OptionalOperandOp.result.fget)["return"]
+                is OpResult
+            )
+            assert type(op1.result) is OpResult
 
             op2 = test.OptionalOperandOp(input=op1)
             # CHECK: op2.input is None: False
@@ -754,14 +820,12 @@ def testInferTypeOpInterface():
             print(two_operands.result.type)
 
             assert (
-                inspect.signature(
-                    test.infer_results_variadic_inputs_op
-                ).return_annotation
+                typing.get_type_hints(test.infer_results_variadic_inputs_op)["return"]
                 is OpResult
             )
-            assert isinstance(
-                test.infer_results_variadic_inputs_op(single=zero, doubled=zero),
-                OpResult,
+            assert (
+                type(test.infer_results_variadic_inputs_op(single=zero, doubled=zero))
+                is OpResult
             )
 
 
@@ -785,25 +849,36 @@ def testVariadicOperandAccess():
                 [zero, one], two, [three, four]
             )
             # CHECK: Value(%{{.*}} = arith.constant 2 : i32)
-            non_variadic = variadic_operands.non_variadic
-            print(non_variadic)
-            assert isinstance(non_variadic, Value)
+            print(variadic_operands.non_variadic)
+            assert (
+                typing.get_type_hints(test.SameVariadicOperandSizeOp.non_variadic.fget)[
+                    "return"
+                ]
+                is Value
+            )
+            assert type(variadic_operands.non_variadic) is Value
+
             # CHECK: ['Value(%{{.*}} = arith.constant 0 : i32)', 'Value(%{{.*}} = arith.constant 1 : i32)']
-            variadic1 = variadic_operands.variadic1
-            print(values(variadic1))
-            assert isinstance(variadic1, OpOperandList)
+            print(values(variadic_operands.variadic1))
+            assert (
+                typing.get_type_hints(test.SameVariadicOperandSizeOp.variadic1.fget)[
+                    "return"
+                ]
+                is OpOperandList
+            )
+            assert type(variadic_operands.variadic1) is OpOperandList
+
             # CHECK: ['Value(%{{.*}} = arith.constant 3 : i32)', 'Value(%{{.*}} = arith.constant 4 : i32)']
-            variadic2 = variadic_operands.variadic2
-            print(values(variadic2))
-            assert isinstance(variadic2, OpOperandList)
+            print(values(variadic_operands.variadic2))
+            assert type(variadic_operands.variadic2) is OpOperandList
 
             assert (
-                inspect.signature(test.same_variadic_operand).return_annotation
+                typing.get_type_hints(test.same_variadic_operand)["return"]
                 is test.SameVariadicOperandSizeOp
             )
-            assert isinstance(
-                test.same_variadic_operand([zero, one], two, [three, four]),
-                test.SameVariadicOperandSizeOp,
+            assert (
+                type(test.same_variadic_operand([zero, one], two, [three, four]))
+                is test.SameVariadicOperandSizeOp
             )
 
 
@@ -828,12 +903,12 @@ def testVariadicResultAccess():
             print(types(op.variadic2))
 
             assert (
-                inspect.signature(test.same_variadic_result_vfv).return_annotation
+                typing.get_type_hints(test.same_variadic_result_vfv)["return"]
                 is Union[OpResult, OpResultList, test.SameVariadicResultSizeOpVFV]
             )
-            assert isinstance(
-                test.same_variadic_result_vfv([i[0], i[1]], i[2], [i[3], i[4]]),
-                OpResultList,
+            assert (
+                type(test.same_variadic_result_vfv([i[0], i[1]], i[2], [i[3], i[4]]))
+                is OpResultList
             )
 
             #  Test Variadic-Variadic-Variadic
@@ -854,9 +929,14 @@ def testVariadicResultAccess():
             # CHECK: i1
             print(op.non_variadic2.type)
             # CHECK: [IntegerType(i2), IntegerType(i3), IntegerType(i4)]
-            variadic = op.variadic
-            print(types(variadic))
-            assert isinstance(variadic, OpResultList)
+            print(types(op.variadic))
+            assert (
+                typing.get_type_hints(test.SameVariadicResultSizeOpFFV.variadic.fget)[
+                    "return"
+                ]
+                is OpResultList
+            )
+            assert type(op.variadic) is OpResultList
 
             #  Test Variadic-Variadic-Fixed
             op = test.SameVariadicResultSizeOpVVF(
@@ -911,13 +991,16 @@ def testVariadicResultAccess():
             print(op.non_variadic3.type)
 
             assert (
-                inspect.signature(test.results_variadic).return_annotation
+                typing.get_type_hints(test.results_variadic)["return"]
                 is Union[OpResult, OpResultList, test.ResultsVariadicOp]
             )
-            assert isinstance(
-                test.results_variadic([i[0]]),
-                OpResult,
+            assert type(test.results_variadic([i[0]])) is OpResult
+            op_res_variadic = test.ResultsVariadicOp([i[0]])
+            assert (
+                typing.get_type_hints(test.ResultsVariadicOp.res.fget)["return"]
+                is OpResultList
             )
+            assert type(op_res_variadic.res) is OpResultList
 
 
 # CHECK-LABEL: TEST: testVariadicAndNormalRegion
@@ -927,5 +1010,17 @@ def testVariadicAndNormalRegionOp():
         module = Module.create()
         with InsertionPoint(module.body):
             region_op = test.VariadicAndNormalRegionOp(2)
-            assert isinstance(region_op.region, Region)
-            assert isinstance(region_op.variadic, RegionSequence)
+            assert (
+                typing.get_type_hints(test.VariadicAndNormalRegionOp.region.fget)[
+                    "return"
+                ]
+                is Region
+            )
+            assert type(region_op.region) is Region
+            assert (
+                typing.get_type_hints(test.VariadicAndNormalRegionOp.variadic.fget)[
+                    "return"
+                ]
+                is RegionSequence
+            )
+            assert type(region_op.variadic) is RegionSequence

--- a/mlir/test/python/python_test_ops.td
+++ b/mlir/test/python/python_test_ops.td
@@ -269,4 +269,9 @@ def ResultsVariadicOp : TestOp<"results_variadic"> {
   let results = (outs Variadic<AnyType>:$res);
 }
 
+def VariadicAndNormalRegionOp : TestOp<"variadic_and_normal_region"> {
+  let regions = (region AnyRegion:$region, VariadicRegion<AnyRegion>:$variadic);
+  let assemblyFormat = "$region $variadic attr-dict";
+}
+
 #endif // PYTHON_TEST_OPS


### PR DESCRIPTION
This PR adds type hints for accessors in the generated builders.