### PR TITLE
[ADT] Reduce boilerplate in DenseSet (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -66,7 +66,8 @@ public:
   using value_type = ValueT;
   using size_type = unsigned;
 
-  explicit DenseSetImpl(unsigned InitialReserve = 0) : TheMap(InitialReserve) {}
+  DenseSetImpl() = default;
+  explicit DenseSetImpl(unsigned InitialReserve) : TheMap(InitialReserve) {}
 
   template <typename InputIt>
   DenseSetImpl(const InputIt &I, const InputIt &E)
@@ -254,40 +255,21 @@ bool operator!=(const DenseSetImpl<ValueT, MapTy, ValueInfoT> &LHS,
 
 /// Implements a dense probed hash-table based set.
 template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
-class DenseSet : public detail::DenseSetImpl<
-                     ValueT,
-                     DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
-                              detail::DenseSetPair<ValueT>>,
-                     ValueInfoT> {
-  using BaseT =
-      detail::DenseSetImpl<ValueT,
-                           DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
-                                    detail::DenseSetPair<ValueT>>,
-                           ValueInfoT>;
-
-public:
-  using BaseT::BaseT;
-};
+using DenseSet =
+    detail::DenseSetImpl<ValueT,
+                         DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
+                                  detail::DenseSetPair<ValueT>>,
+                         ValueInfoT>;
 
 /// Implements a dense probed hash-table based set with some number of buckets
 /// stored inline.
 template <typename ValueT, unsigned InlineBuckets = 4,
           typename ValueInfoT = DenseMapInfo<ValueT>>
-class SmallDenseSet
-    : public detail::DenseSetImpl<
-          ValueT,
-          SmallDenseMap<ValueT, detail::DenseSetEmpty, InlineBuckets,
-                        ValueInfoT, detail::DenseSetPair<ValueT>>,
-          ValueInfoT> {
-  using BaseT = detail::DenseSetImpl<
-      ValueT,
-      SmallDenseMap<ValueT, detail::DenseSetEmpty, InlineBuckets, ValueInfoT,
-                    detail::DenseSetPair<ValueT>>,
-      ValueInfoT>;
-
-public:
-  using BaseT::BaseT;
-};
+using SmallDenseSet = detail::DenseSetImpl<
+    ValueT,
+    SmallDenseMap<ValueT, detail::DenseSetEmpty, InlineBuckets, ValueInfoT,
+                  detail::DenseSetPair<ValueT>>,
+    ValueInfoT>;
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/ADT/DenseSet.h
+++ b/llvm/include/llvm/ADT/DenseSet.h
@@ -66,8 +66,7 @@ public:
   using value_type = ValueT;
   using size_type = unsigned;
 
-  DenseSetImpl() = default;
-  explicit DenseSetImpl(unsigned InitialReserve) : TheMap(InitialReserve) {}
+  explicit DenseSetImpl(unsigned InitialReserve = 0) : TheMap(InitialReserve) {}
 
   template <typename InputIt>
   DenseSetImpl(const InputIt &I, const InputIt &E)
@@ -251,25 +250,40 @@ bool operator!=(const DenseSetImpl<ValueT, MapTy, ValueInfoT> &LHS,
   return !(LHS == RHS);
 }
 
+template <typename ValueT, typename ValueInfoT>
+using DenseSet = DenseSetImpl<
+    ValueT, DenseMap<ValueT, DenseSetEmpty, ValueInfoT, DenseSetPair<ValueT>>,
+    ValueInfoT>;
+
+template <typename ValueT, unsigned InlineBuckets, typename ValueInfoT>
+using SmallDenseSet =
+    DenseSetImpl<ValueT,
+                 SmallDenseMap<ValueT, DenseSetEmpty, InlineBuckets, ValueInfoT,
+                               DenseSetPair<ValueT>>,
+                 ValueInfoT>;
+
 } // end namespace detail
 
 /// Implements a dense probed hash-table based set.
 template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
-using DenseSet =
-    detail::DenseSetImpl<ValueT,
-                         DenseMap<ValueT, detail::DenseSetEmpty, ValueInfoT,
-                                  detail::DenseSetPair<ValueT>>,
-                         ValueInfoT>;
+class DenseSet : public detail::DenseSet<ValueT, ValueInfoT> {
+  using BaseT = detail::DenseSet<ValueT, ValueInfoT>;
+
+public:
+  using BaseT::BaseT;
+};
 
 /// Implements a dense probed hash-table based set with some number of buckets
 /// stored inline.
 template <typename ValueT, unsigned InlineBuckets = 4,
           typename ValueInfoT = DenseMapInfo<ValueT>>
-using SmallDenseSet = detail::DenseSetImpl<
-    ValueT,
-    SmallDenseMap<ValueT, detail::DenseSetEmpty, InlineBuckets, ValueInfoT,
-                  detail::DenseSetPair<ValueT>>,
-    ValueInfoT>;
+class SmallDenseSet
+    : public detail::SmallDenseSet<ValueT, InlineBuckets, ValueInfoT> {
+  using BaseT = detail::SmallDenseSet<ValueT, InlineBuckets, ValueInfoT>;
+
+public:
+  using BaseT::BaseT;
+};
 
 } // end namespace llvm
 

--- a/mlir/include/mlir/Support/LLVM.h
+++ b/mlir/include/mlir/Support/LLVM.h
@@ -55,8 +55,13 @@ template <typename KeyT, typename ValueT, typename KeyInfoT, typename BucketT>
 class DenseMap;
 template <typename T, typename Enable>
 struct DenseMapInfo;
-template <typename ValueT, typename ValueInfoT>
-class DenseSet;
+namespace detail {
+template <typename ValueT, typename MapTy, typename ValueInfoT>
+class DenseSetImpl;
+struct DenseSetEmpty;
+template <typename KeyT>
+class DenseSetPair;
+} // namespace detail
 class MallocAllocator;
 template <typename T>
 class MutableArrayRef;
@@ -125,7 +130,11 @@ template <typename KeyT, typename ValueT,
           typename BucketT = llvm::detail::DenseMapPair<KeyT, ValueT>>
 using DenseMap = llvm::DenseMap<KeyT, ValueT, KeyInfoT, BucketT>;
 template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
-using DenseSet = llvm::DenseSet<ValueT, ValueInfoT>;
+using DenseSet = llvm::detail::DenseSetImpl<
+    ValueT,
+    llvm::DenseMap<ValueT, llvm::detail::DenseSetEmpty, ValueInfoT,
+                   llvm::detail::DenseSetPair<ValueT>>,
+    ValueInfoT>;
 template <typename T, typename Vector = llvm::SmallVector<T, 0>,
           typename Set = DenseSet<T>, unsigned N = 0>
 using SetVector = llvm::SetVector<T, Vector, Set, N>;

--- a/mlir/include/mlir/Support/LLVM.h
+++ b/mlir/include/mlir/Support/LLVM.h
@@ -55,13 +55,8 @@ template <typename KeyT, typename ValueT, typename KeyInfoT, typename BucketT>
 class DenseMap;
 template <typename T, typename Enable>
 struct DenseMapInfo;
-namespace detail {
-template <typename ValueT, typename MapTy, typename ValueInfoT>
-class DenseSetImpl;
-struct DenseSetEmpty;
-template <typename KeyT>
-class DenseSetPair;
-} // namespace detail
+template <typename ValueT, typename ValueInfoT>
+class DenseSet;
 class MallocAllocator;
 template <typename T>
 class MutableArrayRef;
@@ -130,11 +125,7 @@ template <typename KeyT, typename ValueT,
           typename BucketT = llvm::detail::DenseMapPair<KeyT, ValueT>>
 using DenseMap = llvm::DenseMap<KeyT, ValueT, KeyInfoT, BucketT>;
 template <typename ValueT, typename ValueInfoT = DenseMapInfo<ValueT>>
-using DenseSet = llvm::detail::DenseSetImpl<
-    ValueT,
-    llvm::DenseMap<ValueT, llvm::detail::DenseSetEmpty, ValueInfoT,
-                   llvm::detail::DenseSetPair<ValueT>>,
-    ValueInfoT>;
+using DenseSet = llvm::DenseSet<ValueT, ValueInfoT>;
 template <typename T, typename Vector = llvm::SmallVector<T, 0>,
           typename Set = DenseSet<T>, unsigned N = 0>
 using SetVector = llvm::SetVector<T, Vector, Set, N>;


### PR DESCRIPTION
The class definitions of DenseSet and SmallDenseSet contain a lot of
boilerplate code, repeating the lengthy base class name twice in each
definition.

This patch simplifies the two definitions by making them type aliases.
