### PR TITLE
[MachineLICM] Rematerialize instructions that may be hoisted before LICM

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
+++ b/llvm/include/llvm/CodeGen/MachineCycleAnalysis.h
@@ -48,6 +48,15 @@ public:
 //       version.
 LLVM_ABI bool isCycleInvariant(const MachineCycle *Cycle, MachineInstr &I);
 
+/// Returns true if this machine instruction loads from global offset table or
+/// constant pool.
+bool mayLoadFromGOTOrConstantPool(MachineInstr &MI);
+
+/// Returns true if this machine instruction can be a sink candidate.
+bool isSinkIntoCycleCandidate(MachineInstr &MI, MachineCycle *Cycle,
+                              MachineRegisterInfo *MRI,
+                              const TargetInstrInfo *TII);
+
 class MachineCycleAnalysis : public AnalysisInfoMixin<MachineCycleAnalysis> {
   friend AnalysisInfoMixin<MachineCycleAnalysis>;
   LLVM_ABI static AnalysisKey Key;

--- a/llvm/lib/CodeGen/MachineLICM.cpp
+++ b/llvm/lib/CodeGen/MachineLICM.cpp
@@ -102,7 +102,7 @@ static cl::opt<bool> SinkInstsIntoCycleBeforeLICM(
     "sink-insts-before-licm",
     cl::desc("Sink instructions into cycles to avoid "
              "register spills"),
-    cl::init(true), cl::Hidden);
+    cl::init(false), cl::Hidden);
 
 STATISTIC(NumHoisted,
           "Number of machine instructions hoisted out of loops");

--- a/llvm/lib/CodeGen/MachineSink.cpp
+++ b/llvm/lib/CodeGen/MachineSink.cpp
@@ -39,6 +39,7 @@
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
+#include "llvm/CodeGen/MachineLoopUtils.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/MachinePostDominators.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
@@ -257,9 +258,6 @@ private:
   MachineBasicBlock *FindSuccToSinkTo(MachineInstr &MI, MachineBasicBlock *MBB,
                                       bool &BreakPHIEdge,
                                       AllSuccsCache &AllSuccessors);
-
-  void FindCycleSinkCandidates(MachineCycle *Cycle, MachineBasicBlock *BB,
-                               SmallVectorImpl<MachineInstr *> &Candidates);
 
   bool
   aggressivelySinkIntoCycle(MachineCycle *Cycle, MachineInstr &I,
@@ -694,65 +692,6 @@ bool MachineSinking::AllUsesDominatedByBlock(Register Reg,
   return true;
 }
 
-/// Return true if this machine instruction loads from global offset table or
-/// constant pool.
-static bool mayLoadFromGOTOrConstantPool(MachineInstr &MI) {
-  assert(MI.mayLoad() && "Expected MI that loads!");
-
-  // If we lost memory operands, conservatively assume that the instruction
-  // reads from everything..
-  if (MI.memoperands_empty())
-    return true;
-
-  for (MachineMemOperand *MemOp : MI.memoperands())
-    if (const PseudoSourceValue *PSV = MemOp->getPseudoValue())
-      if (PSV->isGOT() || PSV->isConstantPool())
-        return true;
-
-  return false;
-}
-
-void MachineSinking::FindCycleSinkCandidates(
-    MachineCycle *Cycle, MachineBasicBlock *BB,
-    SmallVectorImpl<MachineInstr *> &Candidates) {
-  for (auto &MI : *BB) {
-    LLVM_DEBUG(dbgs() << "CycleSink: Analysing candidate: " << MI);
-    if (MI.isMetaInstruction()) {
-      LLVM_DEBUG(dbgs() << "CycleSink: not sinking meta instruction\n");
-      continue;
-    }
-    if (!TII->shouldSink(MI)) {
-      LLVM_DEBUG(dbgs() << "CycleSink: Instruction not a candidate for this "
-                           "target\n");
-      continue;
-    }
-    if (!isCycleInvariant(Cycle, MI)) {
-      LLVM_DEBUG(dbgs() << "CycleSink: Instruction is not cycle invariant\n");
-      continue;
-    }
-    bool DontMoveAcrossStore = true;
-    if (!MI.isSafeToMove(DontMoveAcrossStore)) {
-      LLVM_DEBUG(dbgs() << "CycleSink: Instruction not safe to move.\n");
-      continue;
-    }
-    if (MI.mayLoad() && !mayLoadFromGOTOrConstantPool(MI)) {
-      LLVM_DEBUG(dbgs() << "CycleSink: Dont sink GOT or constant pool loads\n");
-      continue;
-    }
-    if (MI.isConvergent())
-      continue;
-
-    const MachineOperand &MO = MI.getOperand(0);
-    if (!MO.isReg() || !MO.getReg() || !MO.isDef())
-      continue;
-    if (!MRI->hasOneDef(MO.getReg()))
-      continue;
-
-    LLVM_DEBUG(dbgs() << "CycleSink: Instruction added as candidate.\n");
-    Candidates.push_back(&MI);
-  }
-}
-
 PreservedAnalyses
 MachineSinkingPass::run(MachineFunction &MF,
                         MachineFunctionAnalysisManager &MFAM) {
@@ -892,7 +831,9 @@ bool MachineSinking::run(MachineFunction &MF) {
           continue;
         }
         SmallVector<MachineInstr *, 8> Candidates;
-        FindCycleSinkCandidates(Cycle, Preheader, Candidates);
+        for (auto &MI : *Preheader)
+          if (isSinkIntoCycleCandidate(MI, Cycle, MRI, TII))
+            Candidates.push_back(&MI);
 
         unsigned i = 0;
 


### PR DESCRIPTION
Fixes #115862.

https://llvm.org/docs/Passes.html#licm-loop-invariant-code-motion has said:

> Hoisting operations out of loops is a canonicalization transform. It enables and simplifies subsequent optimizations in the middle-end. Rematerialization of hoisted instructions to reduce register pressure is the responsibility of the back-end, which has more accurate information about register pressure and also handles other optimizations than LICM that increase live-ranges.

I do agree with this, but I cannot find any passes of the back-end doing this. MachineSink is what I'm looking for, but it's not enabled by default. After #117247, I don't think MachineSink is suitable for rematerializing these instructions. Hmm, and I don't really understand the code magic.

The first commit rematerializes all instructions before Machine LICM. It's easy to understand for me; we only need to improve Machine LICM if we find something. This compile time is https://llvm-compile-time-tracker.com/compare.php?from=a4993a27fb005c2c65e065e9d7703533f4d26bd2&to=8cb8bb00cce43634330626e5224cefb46696919c&stat=instructions:u.

The second commit is just my attempt to put it into MachineSink, and the compile time is https://llvm-compile-time-tracker.com/compare.php?from=a4993a27fb005c2c65e065e9d7703533f4d26bd2&to=fa91ca83e6fee687eae647d55a30190667a45954&stat=instructions%3Au.

I haven't added any test cases because I want to hear some ideas for this.

With the first commit, the new result of the reduced example that I added in https://github.com/llvm/llvm-project/issues/115862#issuecomment-3289534154 is

```
+ clang -dumpversion
21.1.0
+ gcc -dumpversion
14.3.0
+ clang -O3 main.c
+ perf stat -e instructions:u ./a.out

 Performance counter stats for './a.out':

     2,550,317,381      instructions:u

       0.186548993 seconds time elapsed

       0.185919000 seconds user
       0.000000000 seconds sys


+ clang-dev -O3 main.c
+ perf stat -e instructions:u ./a.out

 Performance counter stats for './a.out':

       528,662,772      instructions:u

       0.019543261 seconds time elapsed

       0.018484000 seconds user
       0.001030000 seconds sys


+ gcc -O3 main.c
+ perf stat -e instructions:u ./a.out

 Performance counter stats for './a.out':

       453,161,286      instructions:u

       0.014953744 seconds time elapsed

       0.013878000 seconds user
       0.001064000 seconds sys
``` 