### PR TITLE
[ADT, Support] Use std::bool_constant (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -333,20 +333,21 @@ inline uint64_t get_execution_seed() {
 // for equality. For all the platforms we care about, this holds for integers
 // and pointers, but there are platforms where it doesn't and we would like to
 // support user-defined types which happen to satisfy this property.
-template <typename T> struct is_hashable_data
-  : std::integral_constant<bool, ((is_integral_or_enum<T>::value ||
-                                   std::is_pointer<T>::value) &&
-                                  64 % sizeof(T) == 0)> {};
+template <typename T>
+struct is_hashable_data : std::bool_constant<((is_integral_or_enum<T>::value ||
+                                               std::is_pointer<T>::value) &&
+                                              64 % sizeof(T) == 0)> {};
 
 // Special case std::pair to detect when both types are viable and when there
 // is no alignment-derived padding in the pair. This is a bit of a lie because
 // std::pair isn't truly POD, but it's close enough in all reasonable
 // implementations for our use case of hashing the underlying data.
-template <typename T, typename U> struct is_hashable_data<std::pair<T, U> >
-  : std::integral_constant<bool, (is_hashable_data<T>::value &&
-                                  is_hashable_data<U>::value &&
-                                  (sizeof(T) + sizeof(U)) ==
-                                   sizeof(std::pair<T, U>))> {};
+template <typename T, typename U>
+struct is_hashable_data<std::pair<T, U>>
+    : std::bool_constant<(is_hashable_data<T>::value &&
+                          is_hashable_data<U>::value &&
+                          (sizeof(T) + sizeof(U)) == sizeof(std::pair<T, U>))> {
+};
 
 /// Helper to get the hashable data representation for a type.
 template <typename T> auto get_hashable_data(const T &value) {

--- a/llvm/include/llvm/ADT/ilist_node_options.h
+++ b/llvm/include/llvm/ADT/ilist_node_options.h
@@ -82,7 +82,7 @@ template <class... Options> struct extract_sentinel_tracking;
 template <bool EnableSentinelTracking, class... Options>
 struct extract_sentinel_tracking<
     ilist_sentinel_tracking<EnableSentinelTracking>, Options...>
-    : std::integral_constant<bool, EnableSentinelTracking>, is_explicit {};
+    : std::bool_constant<EnableSentinelTracking>, is_explicit {};
 template <class Option1, class... Options>
 struct extract_sentinel_tracking<Option1, Options...>
     : extract_sentinel_tracking<Options...> {};
@@ -119,7 +119,7 @@ template <class Tag> struct is_valid_option<ilist_tag<Tag>> : std::true_type {};
 template <class... Options> struct extract_iterator_bits;
 template <bool IteratorBits, class... Options>
 struct extract_iterator_bits<ilist_iterator_bits<IteratorBits>, Options...>
-    : std::integral_constant<bool, IteratorBits> {};
+    : std::bool_constant<IteratorBits> {};
 template <class Option1, class... Options>
 struct extract_iterator_bits<Option1, Options...>
     : extract_iterator_bits<Options...> {};
@@ -149,8 +149,8 @@ template <class... Options> struct check_options;
 template <> struct check_options<> : std::true_type {};
 template <class Option1, class... Options>
 struct check_options<Option1, Options...>
-    : std::integral_constant<bool, is_valid_option<Option1>::value &&
-                                       check_options<Options...>::value> {};
+    : std::bool_constant<is_valid_option<Option1>::value &&
+                         check_options<Options...>::value> {};
 
 /// Traits for options for \a ilist_node.
 ///

--- a/llvm/include/llvm/Support/CFGDiff.h
+++ b/llvm/include/llvm/Support/CFGDiff.h
@@ -34,18 +34,17 @@ namespace llvm {
 
 namespace detail {
 template <typename Range>
-auto reverse_if_helper(Range &&R, std::integral_constant<bool, false>) {
+auto reverse_if_helper(Range &&R, std::bool_constant<false>) {
   return std::forward<Range>(R);
 }
 
 template <typename Range>
-auto reverse_if_helper(Range &&R, std::integral_constant<bool, true>) {
+auto reverse_if_helper(Range &&R, std::bool_constant<true>) {
   return llvm::reverse(std::forward<Range>(R));
 }
 
 template <bool B, typename Range> auto reverse_if(Range &&R) {
-  return reverse_if_helper(std::forward<Range>(R),
-                           std::integral_constant<bool, B>{});
+  return reverse_if_helper(std::forward<Range>(R), std::bool_constant<B>{});
 }
 } // namespace detail
 

--- a/llvm/include/llvm/Support/FormatProviders.h
+++ b/llvm/include/llvm/Support/FormatProviders.h
@@ -29,35 +29,31 @@ namespace support {
 namespace detail {
 template <typename T>
 struct use_integral_formatter
-    : public std::integral_constant<
-          bool, is_one_of<T, uint8_t, int16_t, uint16_t, int32_t, uint32_t,
-                          int64_t, uint64_t, int, unsigned, long, unsigned long,
-                          long long, unsigned long long>::value> {};
+    : public std::bool_constant<
+          is_one_of<T, uint8_t, int16_t, uint16_t, int32_t, uint32_t, int64_t,
+                    uint64_t, int, unsigned, long, unsigned long, long long,
+                    unsigned long long>::value> {};
 
 template <typename T>
-struct use_char_formatter
-    : public std::integral_constant<bool, std::is_same_v<T, char>> {};
+struct use_char_formatter : public std::bool_constant<std::is_same_v<T, char>> {
+};
 
 template <typename T>
 struct is_cstring
-    : public std::integral_constant<bool,
-                                    is_one_of<T, char *, const char *>::value> {
-};
+    : public std::bool_constant<is_one_of<T, char *, const char *>::value> {};
 
 template <typename T>
 struct use_string_formatter
-    : public std::integral_constant<bool,
-                                    std::is_convertible_v<T, llvm::StringRef>> {
-};
+    : public std::bool_constant<std::is_convertible_v<T, llvm::StringRef>> {};
 
 template <typename T>
 struct use_pointer_formatter
-    : public std::integral_constant<bool, std::is_pointer_v<T> &&
-                                              !is_cstring<T>::value> {};
+    : public std::bool_constant<std::is_pointer_v<T> && !is_cstring<T>::value> {
+};
 
 template <typename T>
 struct use_double_formatter
-    : public std::integral_constant<bool, std::is_floating_point_v<T>> {};
+    : public std::bool_constant<std::is_floating_point_v<T>> {};
 
 class HelperFunctions {
 protected:
@@ -330,8 +326,7 @@ using IterValue = typename std::iterator_traits<IterT>::value_type;
 
 template <typename IterT>
 struct range_item_has_provider
-    : public std::integral_constant<
-          bool,
+    : public std::bool_constant<
           !support::detail::uses_missing_provider<IterValue<IterT>>::value> {};
 } // namespace detail
 } // namespace support

--- a/llvm/include/llvm/Support/FormatVariadicDetails.h
+++ b/llvm/include/llvm/Support/FormatVariadicDetails.h
@@ -96,26 +96,24 @@ public:
 // based format() invocation.
 template <typename T>
 struct uses_format_member
-    : public std::integral_constant<
-          bool, std::is_base_of_v<format_adapter, std::remove_reference_t<T>>> {
-};
+    : public std::bool_constant<
+          std::is_base_of_v<format_adapter, std::remove_reference_t<T>>> {};
 
 // Simple template that decides whether a type T should use the format_provider
 // based format() invocation.  The member function takes priority, so this test
 // will only be true if there is not ALSO a format member.
 template <typename T>
 struct uses_format_provider
-    : public std::integral_constant<
-          bool, !uses_format_member<T>::value && has_FormatProvider<T>::value> {
-};
+    : public std::bool_constant<!uses_format_member<T>::value &&
+                                has_FormatProvider<T>::value> {};
 
 // Simple template that decides whether a type T should use the operator<<
 // based format() invocation.  This takes last priority.
 template <typename T>
 struct uses_stream_operator
-    : public std::integral_constant<bool, !uses_format_member<T>::value &&
-                                              !uses_format_provider<T>::value &&
-                                              has_StreamOperator<T>::value> {};
+    : public std::bool_constant<!uses_format_member<T>::value &&
+                                !uses_format_provider<T>::value &&
+                                has_StreamOperator<T>::value> {};
 
 // Simple template that decides whether a type T has neither a member-function
 // nor format_provider based implementation that it can use.  Mostly used so
@@ -123,10 +121,9 @@ struct uses_stream_operator
 // implementation can be located.
 template <typename T>
 struct uses_missing_provider
-    : public std::integral_constant<bool, !uses_format_member<T>::value &&
-                                              !uses_format_provider<T>::value &&
-                                              !uses_stream_operator<T>::value> {
-};
+    : public std::bool_constant<!uses_format_member<T>::value &&
+                                !uses_format_provider<T>::value &&
+                                !uses_stream_operator<T>::value> {};
 
 template <typename T>
 std::enable_if_t<uses_format_member<T>::value, T>

--- a/llvm/include/llvm/Support/HashBuilder.h
+++ b/llvm/include/llvm/Support/HashBuilder.h
@@ -32,8 +32,7 @@ namespace hashbuilder_detail {
 /// Trait to indicate whether a type's bits can be hashed directly (after
 /// endianness correction).
 template <typename U>
-struct IsHashableData
-    : std::integral_constant<bool, is_integral_or_enum<U>::value> {};
+struct IsHashableData : std::bool_constant<is_integral_or_enum<U>::value> {};
 
 } // namespace hashbuilder_detail
 

--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -459,8 +459,7 @@ template <class T> struct has_FlowTraits<T, true> {
 // Test if SequenceTraits<T> is defined on type T
 template <typename T>
 struct has_SequenceTraits
-    : public std::integral_constant<bool, has_SequenceMethodTraits<T>::value> {
-};
+    : public std::bool_constant<has_SequenceMethodTraits<T>::value> {};
 
 // Test if DocumentListTraits<T> is defined on type T
 template <class T> struct has_DocumentListTraits {
@@ -683,15 +682,15 @@ struct missingTraits
 
 template <typename T, typename Context>
 struct validatedMappingTraits
-    : public std::integral_constant<
-          bool, has_MappingTraits<T, Context>::value &&
-                    has_MappingValidateTraits<T, Context>::value> {};
+    : public std::bool_constant<has_MappingTraits<T, Context>::value &&
+                                has_MappingValidateTraits<T, Context>::value> {
+};
 
 template <typename T, typename Context>
 struct unvalidatedMappingTraits
-    : public std::integral_constant<
-          bool, has_MappingTraits<T, Context>::value &&
-                    !has_MappingValidateTraits<T, Context>::value> {};
+    : public std::bool_constant<has_MappingTraits<T, Context>::value &&
+                                !has_MappingValidateTraits<T, Context>::value> {
+};
 
 // Base class for Input and Output.
 class LLVM_ABI IO {


### PR DESCRIPTION
This patch replaces, std::integral_constant<bool, ...> with
std::bool_constant for brevity.  Note that std::bool_constant was
introduced as part of C++17.

There are cases where we could strip away std::bool_constant
altogether:

  std::bool_constant<std::is_same<T, U>>

but I'm not doing that in this patch to avoid doing multiple things in
one patch.
