### PR TITLE
[Support] Use llvm::is_detected (NFC)

### DIFF
--- a/llvm/include/llvm/Support/FormatVariadicDetails.h
+++ b/llvm/include/llvm/Support/FormatVariadicDetails.h
@@ -66,13 +66,10 @@ public:
   typedef void (*Signature_format)(const Decayed &, llvm::raw_ostream &,
                                    StringRef);
 
-  template <typename U>
-  static char test(SameType<Signature_format, &U::format> *);
+  template <typename U> using check = SameType<Signature_format, &U::format>;
 
-  template <typename U> static double test(...);
-
-  static bool const value =
-      (sizeof(test<llvm::format_provider<Decayed>>(nullptr)) == 1);
+  static constexpr bool value =
+      llvm::is_detected<check, llvm::format_provider<Decayed>>::value;
 };
 
 // Test if raw_ostream& << T -> raw_ostream& is findable via ADL.


### PR DESCRIPTION
This patch uses llvm::is_detected to replace the old SFINAE-based
approach.
