### PR TITLE
[MLIR][SMTLIB][CAPI] add mlir-capi-smtlib-test to MLIR_TEST_DEPENDS

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -107,6 +107,7 @@ set(MLIR_TEST_DEPENDS
   mlir-capi-quant-test
   mlir-capi-rewrite-test
   mlir-capi-smt-test
+  mlir-capi-smtlib-test
   mlir-capi-sparse-tensor-test
   mlir-capi-transform-test
   mlir-capi-transform-interpreter-test


### PR DESCRIPTION
Add missing `mlir-capi-smtlib-test` to `MLIR_TEST_DEPENDS`.