### PR TITLE
[CodeGen] TailDuplicator should remove PHI when single predecessor block remains

### DIFF
--- a/llvm/lib/CodeGen/TailDuplicator.cpp
+++ b/llvm/lib/CodeGen/TailDuplicator.cpp
@@ -387,6 +387,16 @@ void TailDuplicator::processPHI(
     MI->eraseFromParent();
   else if (MI->getNumOperands() == 1)
     MI->setDesc(TII->get(TargetOpcode::IMPLICIT_DEF));
+  else if (TailBB->pred_size() == 2) {
+    // According to callers implementation, PredBB has not yet been removed from
+    // TailBB predecessors list. After removal TailBB will have the only one
+    // predecessor and all phi instructions should be replaced with copies.
+    assert(PredBB->isSuccessor(TailBB));
+    BuildMI(*TailBB, MI->getIterator(), MI->getDebugLoc(),
+            TII->get(TargetOpcode::COPY), MI->getOperand(0).getReg())
+        .add(MI->getOperand(1));
+    MI->eraseFromParent();
+  }
 }
 
 /// Duplicate a TailBB instruction to PredBB and update


### PR DESCRIPTION
If tail block has only single predecessor after tail duplication, `TailDuplicator` saves PHI instructions with single block input.

MIR after `TailDuplicator` looks like:

```
  bb.1:
    %1 = PHI %0, %bb.0
    ...
```

Fix proposal is to replace PHI instruction with single input by COPY instruction.

Similar to https://github.com/llvm/llvm-project/pull/158265, bug appears only in the scenario of pre-ra partial tail duplication and does not affect in-tree backends.