### PR TITLE
[lldb][LoongArch] Preserve temporary symbols starting with `.L` in lldb symbol table

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2119,8 +2119,12 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
     // generated local labels used for internal purposes (e.g. debugging,
     // optimization) and are not relevant for symbol resolution or external
     // linkage.
-    if (llvm::StringRef(symbol_name).starts_with(".L"))
-      continue;
+    // LoongArch64 always uses symbols for relocations, so temporary symbols
+    // starting with ".L" should be preserved.
+    if (arch.GetMachine() != llvm::Triple::loongarch64) {
+      if (llvm::StringRef(symbol_name).starts_with(".L"))
+        continue;
+    }
     // No need to add non-section symbols that have no names
     if (symbol.getType() != STT_SECTION &&
         (symbol_name == nullptr || symbol_name[0] == '\0'))

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2121,10 +2121,9 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
     // linkage.
     // LoongArch64 always uses symbols for relocations, so temporary symbols
     // starting with ".L" should be preserved.
-    if (arch.GetMachine() != llvm::Triple::loongarch64) {
-      if (llvm::StringRef(symbol_name).starts_with(".L"))
-        continue;
-    }
+    if (llvm::StringRef(symbol_name).starts_with(".L") &&
+       arch.GetMachine() != llvm::Triple::loongarch64)
+      continue;
     // No need to add non-section symbols that have no names
     if (symbol.getType() != STT_SECTION &&
         (symbol_name == nullptr || symbol_name[0] == '\0'))

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -2122,7 +2122,7 @@ ObjectFileELF::ParseSymbols(Symtab *symtab, user_id_t start_id,
     // LoongArch64 always uses symbols for relocations, so temporary symbols
     // starting with ".L" should be preserved.
     if (llvm::StringRef(symbol_name).starts_with(".L") &&
-       arch.GetMachine() != llvm::Triple::loongarch64)
+        arch.GetMachine() != llvm::Triple::loongarch64)
       continue;
     // No need to add non-section symbols that have no names
     if (symbol.getType() != STT_SECTION &&


### PR DESCRIPTION
LoongArch64 always uses symbols for relocations, so temporary symbols starting with ".L" should be preserved so that relocations in `.debug_info` can be fixed correctly.

After this commit, three tests passed:

```
lldb-shell :: SymbolFile/DWARF/anon_class_w_and_wo_export_symbols.ll
lldb-shell :: SymbolFile/DWARF/clang-ast-from-dwarf-unamed-and-anon-structs.cpp
lldb-shell :: SymbolFile/DWARF/clang-gmodules-type-lookup.c
```