### PR TITLE
[LLDB][PDB] Require Windows for for testing PDB plugin-selection again

### DIFF
--- a/lldb/test/Shell/SymbolFile/PDB/native-setting.cpp
+++ b/lldb/test/Shell/SymbolFile/PDB/native-setting.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: diasdk
+// REQUIRES: diasdk, target-windows
 
 // Test plugin.symbol-file.pdb.reader setting
 // RUN: %build -o %t.exe -- %s


### PR DESCRIPTION
Amends #158284 and fixes the failure on `lldb-remote-linux-win` from https://github.com/llvm/llvm-project/pull/158284#issuecomment-3290154510. That builder is configured with the DIA SDK but builds for Linux, so the debug information will be DWARF, not PDB.