### PR TITLE
Add llvm-ml64 to LLVM_TOOLCHAIN_TOOLS

### DIFF
--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1442,6 +1442,7 @@ if(NOT LLVM_TOOLCHAIN_TOOLS)
     llvm-lib
     llvm-mca
     llvm-ml
+    llvm-ml64
     llvm-nm
     llvm-objcopy
     llvm-objdump


### PR DESCRIPTION
So that it gets included in LLVM_INSTALL_TOOLCHAIN_ONLY builds, such as when building the Windows installer.

Fixes #149664