### PR TITLE
[Dexter] llvm-lit: Always log DAP messages to stderr

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/DAP.py
@@ -59,10 +59,17 @@ class DAPMessageLogger:
         if self.log_file == "-":
             self.out_handle = sys.stdout
             return
+        if self.log_file == "-e":
+            self.out_handle = sys.stderr
+            return
         self.out_handle = open(self.log_file, "w+", encoding="utf-8")
 
     def _custom_exit(self):
-        if self.out_handle is not None and self.log_file != "-":
+        if (
+            self.out_handle is not None
+            and self.log_file != "-"
+            and self.log_file != "-e"
+        ):
             self.out_handle.close()
         self.open = False
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/Debuggers.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/Debuggers.py
@@ -186,7 +186,11 @@ def handle_debugger_tool_base_options(context, defaults):  # noqa
                 '<d>could not find</> <r>"{}"</>'.format(options.lldb_executable)
             )
 
-    if options.dap_message_log is not None and options.dap_message_log != "-":
+    if (
+        options.dap_message_log is not None
+        and options.dap_message_log != "-"
+        and options.dap_message_log != "-e"
+    ):
         options.dap_message_log = os.path.abspath(options.dap_message_log)
 
 

--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/Debuggers.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/Debuggers.py
@@ -74,7 +74,7 @@ def add_debugger_tool_base_arguments(parser, defaults):
         type=str,
         metavar="<filepath>",
         default=None,
-        help="log file for messages between Dexter and the debug adapter; set to '-' to log to stdout",
+        help="log file for messages between Dexter and the debug adapter; set to '-' to log to stdout, '-e' to log to stderr",
     )
     dap_group.add_argument(
         "--colorize-dap-log",

--- a/cross-project-tests/lit.cfg.py
+++ b/cross-project-tests/lit.cfg.py
@@ -121,7 +121,7 @@ def configure_dexter_substitutions():
         tools.append(
             ToolSubst(
                 "%dexter_lldb_args",
-                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap',
+                f'--lldb-executable "{lldb_dap_path}" --debugger lldb-dap --dap-message-log=-e',
             )
         )
 
@@ -148,7 +148,9 @@ def configure_dexter_substitutions():
         dexter_regression_test_c_builder = "clang"
         dexter_regression_test_cxx_builder = "clang++"
         dexter_regression_test_debugger = "lldb-dap"
-        dexter_regression_test_additional_flags = f'--lldb-executable "{lldb_dap_path}"'
+        dexter_regression_test_additional_flags = (
+            f'--lldb-executable "{lldb_dap_path}" --dap-message-log=-e'
+        )
         dexter_regression_test_c_flags = "-O0 -glldb -std=gnu11"
         dexter_regression_test_cxx_flags = "-O0 -glldb -std=gnu++11"
 


### PR DESCRIPTION
This will help diagnose flaky buildbots. The stderr output is only shown by lit if the test fails.

---

More flakiness not addressed by recent fixes:
* https://lab.llvm.org/buildbot/#/builders/181/builds/27846
* https://lab.llvm.org/buildbot/#/builders/181/builds/27634 (https://github.com/llvm/llvm-project/issues/158306)