### PR TITLE
[libclang/python] Fix numResults field type of CCRStructure

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3150,7 +3150,7 @@ class CodeCompletionResult(Structure):
 
 
 class CCRStructure(Structure):
-    _fields_ = [("results", POINTER(CodeCompletionResult)), ("numResults", c_int)]
+    _fields_ = [("results", POINTER(CodeCompletionResult)), ("numResults", c_uint)]
 
     results: NoSliceSequence[CodeCompletionResult]
     numResults: int


### PR DESCRIPTION
Fix the type of the `numResults` field of `CCRStructure`, as pointed out here: https://github.com/llvm/llvm-project/pull/140539#discussion_r2317808734