### PR TITLE
[bazel] expose MLIR Pygments lexer to bazel overlay

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/mlir/BUILD.bazel
@@ -27,6 +27,7 @@ exports_files([
     "LICENSE.TXT",
     "run_lit.sh",
     "utils/lldb-scripts/mlirDataFormatters.py",
+    "utils/pygments/mlir_lexer.py",
     "utils/textmate/mlir.json",
 ])
 


### PR DESCRIPTION
[This existing tool](https://github.com/llvm/llvm-project/tree/main/mlir/utils/pygments) allows us to do code highlighting for MLIR, e.g., for use in docs.

However, it is not currently exposed to Bazel.  Here, I do this using `exports_files`, and rely on the user to create a `py_library`.

