### PR TITLE
[libc++] Disable atomic_wait benchmarks outside of dry-run mode

### DIFF
--- a/libcxx/test/benchmarks/atomic_wait_1_waiter_1_notifier.bench.cpp
+++ b/libcxx/test/benchmarks/atomic_wait_1_waiter_1_notifier.bench.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
+// This benchmark is very expensive and we don't want to run it on a regular basis,
+// only to ensure the code doesn't rot.
+// REQUIRES: enable-benchmarks=dry-run
+
 #include "atomic_wait_helper.h"
 
 #include <atomic>

--- a/libcxx/test/benchmarks/atomic_wait_N_waiter_N_notifier.bench.cpp
+++ b/libcxx/test/benchmarks/atomic_wait_N_waiter_N_notifier.bench.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
+// This benchmark is very expensive and we don't want to run it on a regular basis,
+// only to ensure the code doesn't rot.
+// REQUIRES: enable-benchmarks=dry-run
+
 #include "atomic_wait_helper.h"
 
 #include <atomic>

--- a/libcxx/test/benchmarks/atomic_wait_multi_waiter_1_notifier.bench.cpp
+++ b/libcxx/test/benchmarks/atomic_wait_multi_waiter_1_notifier.bench.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
+// This benchmark is very expensive and we don't want to run it on a regular basis,
+// only to ensure the code doesn't rot.
+// REQUIRES: enable-benchmarks=dry-run
+
 #include "atomic_wait_helper.h"
 
 #include <atomic>

--- a/libcxx/test/benchmarks/atomic_wait_vs_mutex_lock.bench.cpp
+++ b/libcxx/test/benchmarks/atomic_wait_vs_mutex_lock.bench.cpp
@@ -8,6 +8,10 @@
 
 // UNSUPPORTED: c++03, c++11, c++14, c++17
 
+// This benchmark is very expensive and we don't want to run it on a regular basis,
+// only to ensure the code doesn't rot.
+// REQUIRES: enable-benchmarks=dry-run
+
 #include <atomic>
 #include <cstdint>
 #include <mutex>


### PR DESCRIPTION
The atomic_wait benchmarks are great, but they tend to overload the system they're running on. For that reason, we can't run them on our CI infrastructure on a regular basis.

Instead of removing them, make them unsupported outside of dry-running, which allows keeping the benchmarks around and ensuring they don't rot, but doesn't run them along with the other benchmarks. If we need to investigate atomic_wait performance, it's trivial to mark the benchmark as supported and run it for local investigations.

This is an alternative to https://github.com/llvm/llvm-project/pull/158289.