### PR TITLE
[ASan][test-only] Allow Darwin test duplicate_os_log_reports to retry

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/duplicate_os_log_reports.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/duplicate_os_log_reports.cpp
@@ -8,8 +8,13 @@
 // RUN: FileCheck %s --check-prefixes CHECK,CHECK-PROC -input-file=%t.process_output.txt
 
 // Check syslog output. We filter recent system logs based on PID to avoid
-// getting the logs of previous test runs.
-// RUN: log show --debug --last 5m  --predicate "processID == ${TEST_PID}" --style syslog > %t.process_syslog_output.txt
+// getting the logs of previous test runs. Make some reattempts in case there
+// is a delay.
+// RUN: for I in {1..3}; do \
+// RUN:   log show --debug --last $((SECONDS + 30))s --predicate "processID == ${TEST_PID}" --style syslog > %t.process_syslog_output.txt; \
+// RUN:   if grep -q "use-after-poison" %t.process_syslog_output.txt; then break; fi; \
+// RUN:   sleep 5; \
+// RUN: done
 // RUN: FileCheck %s -input-file=%t.process_syslog_output.txt
 #include <cassert>
 #include <cstdio>


### PR DESCRIPTION
Currently this test is flaky. I believe that it may be because the logs have not flushed to disk before the `log show` command is run.

This patch allows the test to retry reading the log twice more with a 5 second sleep inbetween.