### PR TITLE
[SupportLSP] Fix typo in variable name for ResponseHandlers lock in MessageHandler::onReply

### DIFF
--- a/llvm/lib/Support/LSP/Transport.cpp
+++ b/llvm/lib/Support/LSP/Transport.cpp
@@ -120,7 +120,7 @@ bool MessageHandler::onReply(llvm::json::Value Id,
   // mapping and erase it.
   ResponseHandlerTy ResponseHandler;
   {
-    std::lock_guard<std::mutex> responseHandlersLock(ResponseHandlerTy);
+    std::lock_guard<std::mutex> ResponseHandlersLock(ResponseHandlersMutex);
     auto It = ResponseHandlers.find(debugString(Id));
     if (It != ResponseHandlers.end()) {
       ResponseHandler = std::move(It->second);


### PR DESCRIPTION
Fixes warning recognized here https://github.com/llvm/llvm-project/pull/157885/files/7d06b3db4f8f7045ad681d1dd017f920bcc115d3#r2348174808 by restoring code from e24a7bbf4515213f44d410bfc41b3dff27c49c86