### PR TITLE
[bazel] Explicitly use `output_to_bindir = 1` for genlinalg

### DIFF
--- a/utils/bazel/llvm-project-overlay/mlir/linalggen.bzl
+++ b/utils/bazel/llvm-project-overlay/mlir/linalggen.bzl
@@ -33,6 +33,7 @@ def genlinalg(name, linalggen, src, linalg_outs):
             srcs = [src],
             outs = [out],
             tools = [linalggen],
+            output_to_bindir = 1,
             cmd = (" ".join(base_args)),
         )
 


### PR DESCRIPTION
This is the default in recent versions of bazel, but old behavior is still possible w/ `--incompatible_merge_genfiles_directory=false --incompatible_skip_genfiles_symlink=false`.