### PR TITLE
[TableGen][CodeEmitter] Refactor addCodeToMergeInOperand (NFC)

### DIFF
--- a/llvm/test/TableGen/HwModeEncodeDecode3.td
+++ b/llvm/test/TableGen/HwModeEncodeDecode3.td
@@ -230,28 +230,22 @@ def unrelated: Instruction {
 // ENCODER: default: llvm_unreachable("Unhandled HwMode");
 // ENCODER: case 0: {
 // ENCODER: op = getMachineOpValue(MI, MI.getOperand(0), Fixups, STI);
-// ENCODER: op &= UINT64_C(240);
-// ENCODER: Value |= op;
+// ENCODER: Value |= (op & 0xf0);
 // ENCODER: break;
 // ENCODER: }
 // ENCODER: case 1: {
 // ENCODER: op = getMachineOpValue(MI, MI.getOperand(0), Fixups, STI);
-// ENCODER: op &= UINT64_C(240);
-// ENCODER: Value |= op;
+// ENCODER: Value |= (op & 0xf0);
 // ENCODER: break;
 // ENCODER: }
 // ENCODER: case 2: {
 // ENCODER: op = getMachineOpValue(MI, MI.getOperand(0), Fixups, STI);
-// ENCODER: op &= UINT64_C(255);
-// ENCODER: op <<= 8;
-// ENCODER: Value |= op;
+// ENCODER: Value |= (op & 0xff) << 8;
 // ENCODER: break;
 // ENCODER: }
 // ENCODER: case 3: {
 // ENCODER: op = getMachineOpValue(MI, MI.getOperand(0), Fixups, STI);
-// ENCODER: op &= UINT64_C(255);
-// ENCODER: op <<= 24;
-// ENCODER: Value |= op;
+// ENCODER: Value |= (op & 0xff) << 24;
 // ENCODER: break;
 // ENCODER: }
 // ENCODER-LABEL: case ::baz: {
@@ -265,7 +259,6 @@ def unrelated: Instruction {
 // ENCODER: default: llvm_unreachable("Unhandled HwMode");
 // ENCODER: case 2: {
 // ENCODER: op = getMachineOpValue(MI, MI.getOperand(0), Fixups, STI);
-// ENCODER: op &= UINT64_C(240);
-// ENCODER: Value |= op;
+// ENCODER: Value |= (op & 0xf0);
 // ENCODER: break;
 // ENCODER: }

--- a/llvm/test/TableGen/RegisterEncoder.td
+++ b/llvm/test/TableGen/RegisterEncoder.td
@@ -30,8 +30,7 @@ def foo1 : Instruction {
 
 // CHECK: case ::foo1: {
 // CHECK:   op = barEncoder
-// CHECK:   op &= UINT64_C(255);
-// CHECK:   Value |= op;
+// CHECK:   Value |= (op & 0xff);
 // CHECK:   break;
 // CHECK: }
 
@@ -57,10 +56,8 @@ def foo2 : Instruction {
 
 // CHECK: case ::foo2: {
 // CHECK:   op = barEncoder
-// CHECK:   op &= UINT64_C(15);
-// CHECK:   Value |= op;
+// CHECK:   Value |= (op & 0xf);
 // CHECK:   op = barEncoder
-// CHECK:   op &= UINT64_C(15);
-// CHECK:   Value |= op;
+// CHECK:   Value |= (op & 0xf) << 4;
 // CHECK:   break;
 // CHECK: }


### PR DESCRIPTION
* Use streams to avoid dealing with std::string
* Print operand masks in hex
* Make the output more succinct