### PR TITLE
[clang][Headers][lit] Fix test arm-acle-no-direct-include.c on Mac

### DIFF
--- a/clang/test/Headers/arm-acle-no-direct-include.c
+++ b/clang/test/Headers/arm-acle-no-direct-include.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cl --target=aarch64-windows-msvc -Xclang -verify /E -U__STDC_HOSTED__ -Wno-builtin-macro-redefined %s 2>&1 | FileCheck %s
+// RUN: %clang_cl --target=aarch64-windows-msvc -Xclang -verify /E -U__STDC_HOSTED__ -Wno-builtin-macro-redefined -- %s 2>&1 | FileCheck %s
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
See [here](https://github.com/llvm/llvm-project/pull/144172#issuecomment-3292907771), need to add `--` to filename parsing on Mac because the path starts with `/U` which `clang-cl` treats as the flag `/U`.