### PR TITLE
[ARM] isShifterOpProfitable should return true if we are optimizing for size

### DIFF
--- a/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
+++ b/llvm/lib/Target/ARM/ARMISelDAGToDAG.cpp
@@ -542,7 +542,7 @@ bool ARMDAGToDAGISel::isShifterOpProfitable(const SDValue &Shift,
                                             unsigned ShAmt) {
   if (!Subtarget->isLikeA9() && !Subtarget->isSwift())
     return true;
-  if (Shift.hasOneUse())
+  if (Shift.hasOneUse() || CurDAG->shouldOptForSize())
     return true;
   // R << 2 is free.
   return ShOpcVal == ARM_AM::lsl &&


### PR DESCRIPTION
Fold into a shifter-op if we are optimizing for size regardless.