### PR TITLE
[Sanitizer] Option to fallback to stderr if unable to open logfile

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_file.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_file.cpp
@@ -36,15 +36,16 @@ void RawWrite(const char *buffer) {
 
 void ReportFile::ReopenIfNecessary() {
   mu->CheckLocked();
-  if (!lastOpenFailed)
-    if (fd == kStdoutFd || fd == kStderrFd)
-      return;
-
   uptr pid = internal_getpid();
   if (lastOpenFailed && fd_pid != pid) {
+    // If lastOpenFailed is set then we fellback to stderr. If this is a new
+    // process, mark fd as invalid so we attempt to open again.
+    CHECK_EQ(fd, kStderrFd);
     fd = kInvalidFd;
     lastOpenFailed = false;
   }
+  if (fd == kStdoutFd || fd == kStderrFd)
+    return;
 
   // If in tracer, use the parent's file.
   if (pid == stoptheworld_tracer_pid)

--- a/compiler-rt/lib/sanitizer_common/sanitizer_file.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_file.h
@@ -45,7 +45,7 @@ struct ReportFile {
   uptr fd_pid;
   // Set to true if the last attempt to open the logfile failed, perhaps due to
   // permission errors
-  bool lastOpenFailed = false;
+  bool fallbackToStderrActive = false;
 
  private:
   void ReopenIfNecessary();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_file.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_file.h
@@ -43,6 +43,9 @@ struct ReportFile {
   // PID of the process that opened fd. If a fork() occurs,
   // the PID of child will be different from fd_pid.
   uptr fd_pid;
+  // Set to true if the last attempt to open the logfile failed, perhaps due to
+  // permission errors
+  bool lastOpenFailed = false;
 
  private:
   void ReopenIfNecessary();

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -65,6 +65,8 @@ COMMON_FLAG(
     bool, log_to_syslog, (bool)SANITIZER_ANDROID || (bool)SANITIZER_APPLE,
     "Write all sanitizer output to syslog in addition to other means of "
     "logging.")
+COMMON_FLAG(bool, log_fallback_to_stderr, false,
+            "When set, fallback to stderr if we are unable to open log path.")
 COMMON_FLAG(
     int, verbosity, 0,
     "Verbosity level (0 - silent, 1 - a bit of output, 2+ - more output).")

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
@@ -2,9 +2,11 @@
 
 // Case 1: Try setting a path that is an invalid/inaccessible directory.
 // RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
+// RUN: %env_tool_opts=log_fallback_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefixes=ERROR1,FALLBACK
 
 // Case 2: Try setting a path that is too large.
 // RUN: not %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
+// RUN: %env_tool_opts=log_fallback_to_stderr=1 %run %t A 2>&1 | FileCheck %s --check-prefixes=ERROR2,FALLBACK
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>
@@ -22,3 +24,4 @@ int main(int argc, char **argv) {
   }
   __sanitizer_set_report_path(buff);
 }
+// FALLBACK: Fallback to stderr

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
@@ -2,11 +2,11 @@
 
 // Case 1: Try setting a path that is an invalid/inaccessible directory.
 // RUN: not %run %t 2>&1 | FileCheck %s --check-prefix=ERROR1
-// RUN: %env_tool_opts=log_fallback_to_stderr=1 %run %t 2>&1 | FileCheck %s --check-prefixes=ERROR1,FALLBACK
+// RUN: %env_tool_opts=log_fallback_to_stderr=true %run %t 2>&1 | FileCheck %s --check-prefixes=ERROR1,FALLBACK
 
 // Case 2: Try setting a path that is too large.
 // RUN: not %run %t A 2>&1 | FileCheck %s --check-prefix=ERROR2
-// RUN: %env_tool_opts=log_fallback_to_stderr=1 %run %t A 2>&1 | FileCheck %s --check-prefixes=ERROR2,FALLBACK
+// RUN: %env_tool_opts=log_fallback_to_stderr=true %run %t A 2>&1 | FileCheck %s --check-prefixes=ERROR2,FALLBACK
 
 #include <sanitizer/common_interface_defs.h>
 #include <stdio.h>

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/sanitizer_set_report_path_fail.cpp
@@ -16,12 +16,12 @@ int main(int argc, char **argv) {
   if (argc == 1) {
     // Case 1
     sprintf(buff, "%s/report", argv[0]);
-    // ERROR1: Can't create directory: {{.*}}
+    // ERROR1: Can't create directory
   } else {
     // Case 2
     snprintf(buff, sizeof(buff), "%04095d", 42);
-    // ERROR2: Path is too long: 00000000...
+    // ERROR2: Path is too long
   }
   __sanitizer_set_report_path(buff);
 }
-// FALLBACK: Fallback to stderr
+// FALLBACK: falling back to stderr


### PR DESCRIPTION
Add the santizier option `log_fallback_to_stderr` which will set the logpath to `stderr` if there is an error with the provided logpath. We've seen this happen when process A has write permission to the logpath, but process B does not. In this case, we'd like process B to fallback to writing to `stderr`, rather than being killed.