### PR TITLE
[clang] [CUDA] Support calling `consteval` function between different target.

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -225,6 +225,8 @@ CUDA/HIP Language Changes
 CUDA Support
 ^^^^^^^^^^^^
 
+Support calling `consteval` function between different target.
+
 AIX Support
 ^^^^^^^^^^^
 

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -143,6 +143,9 @@ CUDAFunctionTarget SemaCUDA::IdentifyTarget(const FunctionDecl *D,
   if (D->hasAttr<CUDAGlobalAttr>())
     return CUDAFunctionTarget::Global;
 
+  if (D->isConsteval())
+    return CUDAFunctionTarget::HostDevice;
+
   if (hasAttr<CUDADeviceAttr>(D, IgnoreImplicitHDAttr)) {
     if (hasAttr<CUDAHostAttr>(D, IgnoreImplicitHDAttr))
       return CUDAFunctionTarget::HostDevice;

--- a/clang/test/SemaCUDA/consteval-func.cu
+++ b/clang/test/SemaCUDA/consteval-func.cu
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify %s
+
+// expected-no-diagnostics
+
+#include "Inputs/cuda.h"
+
+__device__ consteval int f() { return 0; }
+int main() { return f(); }


### PR DESCRIPTION
In CUDA, calling `consteval` functions cross excution space is allowed. So the function with `consteval` attribute need be treated as a `__host__ __device__` function.