### PR TITLE
[mlir] Allow setting of Dwarf version information.

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMDialect.td
@@ -92,6 +92,8 @@ def LLVM_Dialect : Dialect {
     static StringRef getDependentLibrariesAttrName() {
       return "llvm.dependent_libraries";
     }
+    /// Name of the dwarf version attribute.
+    static StringRef getDwarfVersionAttrName() { return "llvm.dwarf_version"; }
 
     /// Names of known llvm module flag keys.
     static StringRef getModuleFlagKeyCGProfileName() {

--- a/mlir/lib/Target/LLVMIR/DebugTranslation.h
+++ b/mlir/lib/Target/LLVMIR/DebugTranslation.h
@@ -32,7 +32,7 @@ public:
   DebugTranslation(Operation *module, llvm::Module &llvmModule);
 
   /// Adds the necessary module flags to the module, if not yet present.
-  void addModuleFlagsIfNotPresent();
+  void addModuleFlagsIfNotPresent(Operation *module);
 
   /// Translate the given location to an llvm debug location.
   llvm::DILocation *translateLoc(Location loc, llvm::DILocalScope *scope);

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -2418,7 +2418,7 @@ mlir::translateModuleToLLVMIR(Operation *module, llvm::LLVMContext &llvmContext,
 
   // Add the necessary debug info module flags, if they were not encoded in MLIR
   // beforehand.
-  translator.debugTranslation->addModuleFlagsIfNotPresent();
+  translator.debugTranslation->addModuleFlagsIfNotPresent(module);
 
   // Call the OpenMP IR Builder callbacks prior to verifying the module
   if (auto *ompBuilder = translator.getOpenMPBuilder())

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -3040,3 +3040,23 @@ llvm.mlir.global external @target_specific_attrs_only() {target_specific_attrs =
 // CHECK: @target_specific_attrs_combined = global i32 2, section "mysection", align 4 #[[ATTRS:[0-9]+]]
 // CHECK: attributes #[[ATTRS]] = { norecurse "bss-section"="my_bss.1" }
 llvm.mlir.global external @target_specific_attrs_combined(2 : i32) {alignment = 4 : i64, section = "mysection", target_specific_attrs = ["norecurse", ["bss-section", "my_bss.1"]]} : i32
+
+// -----
+
+module attributes {llvm.dwarf_version = 5 : i32} {}
+// CHECK: !{i32 7, !"Dwarf Version", i32 5}
+
+// -----
+
+module attributes {llvm.dwarf_version = 4 : i32} {}
+// CHECK: !{i32 7, !"Dwarf Version", i32 4}
+
+// -----
+
+module attributes {llvm.dwarf_version = 3 : i32} {}
+// CHECK: !{i32 7, !"Dwarf Version", i32 3}
+
+// -----
+
+module attributes {llvm.dwarf_version = 2 : i32} {}
+// CHECK: !{i32 7, !"Dwarf Version", i32 2}


### PR DESCRIPTION
The dwarf version to use can be set in the LLVM IR using the `Dwarf Version` flag. This PR allows setting this flag by using a new attribute on the module.