### PR TITLE
[CAS] Fix build failure from #114099 using gcc

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionArena.cpp
+++ b/llvm/lib/CAS/MappedFileRegionArena.cpp
@@ -272,7 +272,7 @@ Expected<MappedFileRegionArena> MappedFileRegionArena::create(
 
   // Release the shared lock so it can be closed in destoryImpl().
   SharedFileLock->release();
-  return Result;
+  return std::move(Result);
 }
 
 void MappedFileRegionArena::destroyImpl() {


### PR DESCRIPTION
Fix a buildbot failure on some bots using gcc:
```
MappedFileRegionArena.cpp:275:10: error: could not convert ‘Result’ from ‘llvm::cas::MappedFileRegionArena’ to ‘llvm::Expected<llvm::cas::MappedFileRegionArena>’
```
This is caused by RVO not activated causing the type check error.
