### PR TITLE
[libc] Migrate dirent/fcntl/sched/signal tests to ErrnoCheckingTest.

### DIFF
--- a/libc/test/src/dirent/CMakeLists.txt
+++ b/libc/test/src/dirent/CMakeLists.txt
@@ -14,5 +14,6 @@ add_libc_unittest(
     libc.src.dirent.opendir
     libc.src.dirent.readdir
     libc.src.errno.errno
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 

--- a/libc/test/src/dirent/dirent_test.cpp
+++ b/libc/test/src/dirent/dirent_test.cpp
@@ -7,19 +7,20 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/CPP/string_view.h"
-#include "src/__support/libc_errno.h"
 #include "src/dirent/closedir.h"
 #include "src/dirent/dirfd.h"
 #include "src/dirent/opendir.h"
 #include "src/dirent/readdir.h"
 
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
 #include <dirent.h>
 
+using LlvmLibcDirentTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 using string_view = LIBC_NAMESPACE::cpp::string_view;
 
-TEST(LlvmLibcDirentTest, SimpleOpenAndRead) {
+TEST_F(LlvmLibcDirentTest, SimpleOpenAndRead) {
   ::DIR *dir = LIBC_NAMESPACE::opendir("testdata");
   ASSERT_TRUE(dir != nullptr);
   // The file descriptors 0, 1 and 2 are reserved for standard streams.
@@ -54,18 +55,14 @@ TEST(LlvmLibcDirentTest, SimpleOpenAndRead) {
   ASSERT_EQ(LIBC_NAMESPACE::closedir(dir), 0);
 }
 
-TEST(LlvmLibcDirentTest, OpenNonExistentDir) {
-  libc_errno = 0;
+TEST_F(LlvmLibcDirentTest, OpenNonExistentDir) {
   ::DIR *dir = LIBC_NAMESPACE::opendir("___xyz123__.non_existent__");
   ASSERT_TRUE(dir == nullptr);
   ASSERT_ERRNO_EQ(ENOENT);
-  libc_errno = 0;
 }
 
-TEST(LlvmLibcDirentTest, OpenFile) {
-  libc_errno = 0;
+TEST_F(LlvmLibcDirentTest, OpenFile) {
   ::DIR *dir = LIBC_NAMESPACE::opendir("testdata/file1.txt");
   ASSERT_TRUE(dir == nullptr);
   ASSERT_ERRNO_EQ(ENOTDIR);
-  libc_errno = 0;
 }

--- a/libc/test/src/fcntl/CMakeLists.txt
+++ b/libc/test/src/fcntl/CMakeLists.txt
@@ -14,6 +14,7 @@ add_libc_unittest(
     libc.src.fcntl.creat
     libc.src.fcntl.open
     libc.src.unistd.close
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -32,6 +33,7 @@ add_libc_unittest(
     libc.src.unistd.getpid
     libc.hdr.types.struct_flock
     libc.hdr.fcntl_macros
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -48,5 +50,6 @@ add_libc_unittest(
     libc.src.fcntl.openat
     libc.src.unistd.close
     libc.src.unistd.read
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/fcntl/creat_test.cpp
+++ b/libc/test/src/fcntl/creat_test.cpp
@@ -6,16 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/fcntl/creat.h"
 #include "src/fcntl/open.h"
 #include "src/unistd/close.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/stat.h>
 
-TEST(LlvmLibcCreatTest, CreatAndOpen) {
+using LlvmLibcCreatTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcCreatTest, CreatAndOpen) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE = "testdata/creat.test";
   int fd = LIBC_NAMESPACE::creat(TEST_FILE, S_IRWXU);

--- a/libc/test/src/fcntl/fcntl_test.cpp
+++ b/libc/test/src/fcntl/fcntl_test.cpp
@@ -9,17 +9,19 @@
 #include "hdr/fcntl_macros.h"
 #include "hdr/stdio_macros.h"
 #include "hdr/types/struct_flock.h"
-#include "src/__support/libc_errno.h"
 #include "src/fcntl/fcntl.h"
 #include "src/fcntl/open.h"
 #include "src/unistd/close.h"
 #include "src/unistd/getpid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <sys/stat.h> // For S_IRWXU
 
-TEST(LlvmLibcFcntlTest, FcntlDupfd) {
+using LlvmLibcFcntlTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcFcntlTest, FcntlDupfd) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE_NAME = "testdata/fcntl_dup.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
@@ -41,7 +43,7 @@ TEST(LlvmLibcFcntlTest, FcntlDupfd) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd3), Succeeds(0));
 }
 
-TEST(LlvmLibcFcntlTest, FcntlGetFl) {
+TEST_F(LlvmLibcFcntlTest, FcntlGetFl) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getfl.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
@@ -57,7 +59,7 @@ TEST(LlvmLibcFcntlTest, FcntlGetFl) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 }
 
-TEST(LlvmLibcFcntlTest, FcntlSetFl) {
+TEST_F(LlvmLibcFcntlTest, FcntlSetFl) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE_NAME = "testdata/fcntl_setfl.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
@@ -92,7 +94,7 @@ TEST(LlvmLibcFcntlTest, FcntlSetFl) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 }
 
-TEST(LlvmLibcFcntlTest, FcntlGetLkRead) {
+TEST_F(LlvmLibcFcntlTest, FcntlGetLkRead) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getlkread.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
@@ -124,7 +126,7 @@ TEST(LlvmLibcFcntlTest, FcntlGetLkRead) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 }
 
-TEST(LlvmLibcFcntlTest, FcntlGetLkWrite) {
+TEST_F(LlvmLibcFcntlTest, FcntlGetLkWrite) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE_NAME = "testdata/fcntl_getlkwrite.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
@@ -155,7 +157,7 @@ TEST(LlvmLibcFcntlTest, FcntlGetLkWrite) {
   ASSERT_THAT(LIBC_NAMESPACE::close(fd), Succeeds(0));
 }
 
-TEST(LlvmLibcFcntlTest, UseAfterClose) {
+TEST_F(LlvmLibcFcntlTest, UseAfterClose) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_FILE_NAME = "testdata/fcntl_use_after_close.test";
   auto TEST_FILE = libc_make_test_file_path(TEST_FILE_NAME);
@@ -165,8 +167,7 @@ TEST(LlvmLibcFcntlTest, UseAfterClose) {
   ASSERT_ERRNO_EQ(EBADF);
 }
 
-TEST(LlvmLibcFcntlTest, SetGetOwnerTest) {
-  libc_errno = 0;
+TEST_F(LlvmLibcFcntlTest, SetGetOwnerTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   pid_t pid = LIBC_NAMESPACE::getpid();
   ASSERT_GT(pid, -1);

--- a/libc/test/src/fcntl/openat_test.cpp
+++ b/libc/test/src/fcntl/openat_test.cpp
@@ -6,17 +6,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/fcntl/open.h"
 #include "src/fcntl/openat.h"
 #include "src/unistd/close.h"
 #include "src/unistd/read.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/fcntl_macros.h"
 
-TEST(LlvmLibcUniStd, OpenAndReadTest) {
+using LlvmLibcOpenAtTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcOpenAtTest, OpenAndReadTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   constexpr const char *TEST_DIR = "testdata";
   constexpr const char *TEST_FILE = "openat.test";
@@ -36,7 +38,7 @@ TEST(LlvmLibcUniStd, OpenAndReadTest) {
   ASSERT_THAT(LIBC_NAMESPACE::close(dir_fd), Succeeds(0));
 }
 
-TEST(LlvmLibcUniStd, FailTest) {
+TEST_F(LlvmLibcOpenAtTest, FailTest) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   EXPECT_THAT(LIBC_NAMESPACE::openat(AT_FDCWD, "openat.test", O_RDONLY),
               Fails(ENOENT));

--- a/libc/test/src/sched/CMakeLists.txt
+++ b/libc/test/src/sched/CMakeLists.txt
@@ -14,6 +14,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sched.sched_getaffinity
     libc.src.sched.sched_setaffinity
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -26,6 +27,7 @@ add_libc_unittest(
   DEPENDS
     libc.src.errno.errno
     libc.src.sched.sched_yield
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -39,6 +41,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_get_priority_max
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -70,6 +73,7 @@ add_libc_unittest(
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_get_priority_max
     libc.src.unistd.getuid
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -87,6 +91,7 @@ add_libc_unittest(
     libc.src.sched.sched_get_priority_min
     libc.src.sched.sched_rr_get_interval
     libc.src.unistd.getuid
+    libc.test.UnitTest.ErrnoCheckingTest
 )
 
 add_libc_unittest(
@@ -104,5 +109,6 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.sched.sched_getaffinity
     libc.src.sched.__sched_getcpucount
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/sched/affinity_test.cpp
+++ b/libc/test/src/sched/affinity_test.cpp
@@ -7,18 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/OSUtil/syscall.h"
-#include "src/__support/libc_errno.h"
 #include "src/sched/sched_getaffinity.h"
 #include "src/sched/sched_setaffinity.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 
 #include "hdr/types/cpu_set_t.h"
 #include "hdr/types/pid_t.h"
 #include <sys/syscall.h>
 
-TEST(LlvmLibcSchedAffinityTest, SmokeTest) {
+using LlvmLibcSchedAffinityTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSchedAffinityTest, SmokeTest) {
   cpu_set_t mask;
-  libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   pid_t tid = LIBC_NAMESPACE::syscall_impl<pid_t>(SYS_gettid);
   ASSERT_GT(tid, pid_t(0));
@@ -29,19 +30,15 @@ TEST(LlvmLibcSchedAffinityTest, SmokeTest) {
               Succeeds(0));
 }
 
-TEST(LlvmLibcSchedAffinityTest, BadMask) {
+TEST_F(LlvmLibcSchedAffinityTest, BadMask) {
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
   pid_t tid = LIBC_NAMESPACE::syscall_impl<pid_t>(SYS_gettid);
 
-  libc_errno = 0;
   ASSERT_THAT(
       LIBC_NAMESPACE::sched_getaffinity(tid, sizeof(cpu_set_t), nullptr),
       Fails(EFAULT));
 
-  libc_errno = 0;
   ASSERT_THAT(
       LIBC_NAMESPACE::sched_setaffinity(tid, sizeof(cpu_set_t), nullptr),
       Fails(EFAULT));
-
-  libc_errno = 0;
 }

--- a/libc/test/src/sched/cpu_count_test.cpp
+++ b/libc/test/src/sched/cpu_count_test.cpp
@@ -7,18 +7,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/OSUtil/syscall.h"
-#include "src/__support/libc_errno.h"
 #include "src/sched/sched_getaffinity.h"
 #include "src/sched/sched_getcpucount.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 
 #include "hdr/sched_macros.h"
 #include "hdr/types/cpu_set_t.h"
 #include "hdr/types/pid_t.h"
 
-TEST(LlvmLibcSchedCpuCountTest, SmokeTest) {
+using LlvmLibcSchedCpuCountTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSchedCpuCountTest, SmokeTest) {
   cpu_set_t mask;
-  libc_errno = 0;
   using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
   pid_t tid = LIBC_NAMESPACE::syscall_impl<pid_t>(SYS_gettid);
   ASSERT_GT(tid, pid_t(0));

--- a/libc/test/src/sched/get_priority_test.cpp
+++ b/libc/test/src/sched/get_priority_test.cpp
@@ -6,14 +6,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/sched/sched_get_priority_max.h"
 #include "src/sched/sched_get_priority_min.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/sched_macros.h"
 
-TEST(LlvmLibcSchedGetPriorityTest, HandleBadPolicyTest) {
+using LlvmLibcSchedGetPriorityTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSchedGetPriorityTest, HandleBadPolicyTest) {
 
   // Test arbitrary values for which there is no policy.
   {
@@ -57,9 +59,7 @@ TEST(LlvmLibcSchedGetPriorityTest, HandleBadPolicyTest) {
   }
 }
 
-TEST(LlvmLibcSchedGetPriorityTest, SmokeTest) {
-  libc_errno = 0;
-
+TEST_F(LlvmLibcSchedGetPriorityTest, SmokeTest) {
   // We Test:
   // SCHED_OTHER, SCHED_FIFO, SCHED_RR
   // Linux specific test could also include:

--- a/libc/test/src/sched/getcpu_test.cpp
+++ b/libc/test/src/sched/getcpu_test.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/OSUtil/syscall.h"
-#include "src/__support/libc_errno.h"
 #include "src/sched/getcpu.h"
 #include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"

--- a/libc/test/src/sched/param_and_scheduler_test.cpp
+++ b/libc/test/src/sched/param_and_scheduler_test.cpp
@@ -14,6 +14,7 @@
 #include "src/sched/sched_setparam.h"
 #include "src/sched/sched_setscheduler.h"
 #include "src/unistd/getuid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/sched_macros.h"
@@ -35,11 +36,9 @@
 //       Linux specific test could also include:
 //          SCHED_ISO, SCHED_DEADLINE
 
-class SchedTest : public LIBC_NAMESPACE::testing::Test {
+class SchedTest : public LIBC_NAMESPACE::testing::ErrnoCheckingTest {
 public:
   void testSched(int policy, bool is_mandatory) {
-    libc_errno = 0;
-
     int init_policy = LIBC_NAMESPACE::sched_getscheduler(0);
     ASSERT_GE(init_policy, 0);
     ASSERT_ERRNO_SUCCESS();
@@ -56,22 +55,18 @@ public:
     // Negative pid
     ASSERT_EQ(LIBC_NAMESPACE::sched_setscheduler(-1, policy, &param), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
 
     ASSERT_EQ(LIBC_NAMESPACE::sched_getscheduler(-1), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
 
     // Invalid Policy
     ASSERT_EQ(LIBC_NAMESPACE::sched_setscheduler(0, policy | 128, &param), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
 
     // Out of bounds priority
     param.sched_priority = min_priority - 1;
     ASSERT_EQ(LIBC_NAMESPACE::sched_setscheduler(0, policy, &param), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
 
     param.sched_priority = max_priority + 1;
     ASSERT_EQ(LIBC_NAMESPACE::sched_setscheduler(0, policy, &param), -1);
@@ -99,12 +94,10 @@ public:
     param.sched_priority = -1;
     ASSERT_EQ(LIBC_NAMESPACE::sched_setparam(0, &param), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
 
     param.sched_priority = max_priority + 1;
     ASSERT_EQ(LIBC_NAMESPACE::sched_setparam(0, &param), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
 
     for (int priority = min_priority; priority <= max_priority; ++priority) {
       ASSERT_EQ(LIBC_NAMESPACE::sched_getparam(0, &param), 0);
@@ -116,11 +109,9 @@ public:
       // Negative pid
       ASSERT_EQ(LIBC_NAMESPACE::sched_setparam(-1, &param), -1);
       ASSERT_ERRNO_EQ(EINVAL);
-      libc_errno = 0;
 
       ASSERT_EQ(LIBC_NAMESPACE::sched_getparam(-1, &param), -1);
       ASSERT_ERRNO_EQ(EINVAL);
-      libc_errno = 0;
 
       // Success/unsupported policy/missing permissions
       int setparam_result = LIBC_NAMESPACE::sched_setparam(0, &param);
@@ -141,7 +132,6 @@ public:
     // Null test
     ASSERT_EQ(LIBC_NAMESPACE::sched_setscheduler(0, policy, nullptr), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
   }
 };
 
@@ -159,13 +149,9 @@ LIST_SCHED_TESTS(SCHED_BATCH, true)
 LIST_SCHED_TESTS(SCHED_IDLE, true)
 
 TEST(LlvmLibcSchedParamAndSchedulerTest, NullParamTest) {
-  libc_errno = 0;
-
   ASSERT_EQ(LIBC_NAMESPACE::sched_setparam(0, nullptr), -1);
   ASSERT_ERRNO_EQ(EINVAL);
-  libc_errno = 0;
 
   ASSERT_EQ(LIBC_NAMESPACE::sched_getparam(0, nullptr), -1);
   ASSERT_ERRNO_EQ(EINVAL);
-  libc_errno = 0;
 }

--- a/libc/test/src/sched/sched_rr_get_interval_test.cpp
+++ b/libc/test/src/sched/sched_rr_get_interval_test.cpp
@@ -6,19 +6,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/sched/sched_get_priority_min.h"
 #include "src/sched/sched_getscheduler.h"
 #include "src/sched/sched_rr_get_interval.h"
 #include "src/sched/sched_setscheduler.h"
 #include "src/unistd/getuid.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
 #include "hdr/sched_macros.h"
 #include "hdr/types/struct_timespec.h"
 
-TEST(LlvmLibcSchedRRGetIntervalTest, SmokeTest) {
-  libc_errno = 0;
+using LlvmLibcSchedRRGetIntervalTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSchedRRGetIntervalTest, SmokeTest) {
   auto SetSched = [&](int policy) {
     int min_priority = LIBC_NAMESPACE::sched_get_priority_min(policy);
     ASSERT_GE(min_priority, 0);
@@ -59,19 +60,16 @@ TEST(LlvmLibcSchedRRGetIntervalTest, SmokeTest) {
     // Null timespec
     ASSERT_EQ(LIBC_NAMESPACE::sched_rr_get_interval(0, nullptr), -1);
     ASSERT_ERRNO_EQ(EFAULT);
-    libc_errno = 0;
 
     // Negative pid
     ASSERT_EQ(LIBC_NAMESPACE::sched_rr_get_interval(-1, &ts), -1);
     ASSERT_ERRNO_EQ(EINVAL);
-    libc_errno = 0;
   }
 
   // Negative tests don't have SCHED_RR set
   SetSched(SCHED_OTHER);
   ASSERT_EQ(LIBC_NAMESPACE::sched_rr_get_interval(0, &ts), 0);
   ASSERT_ERRNO_SUCCESS();
-  libc_errno = 0;
 
   // TODO: Missing unkown pid -> ESRCH. This is read only so safe to try a few
   //       unlikely values.

--- a/libc/test/src/sched/sched_rr_get_interval_test.cpp
+++ b/libc/test/src/sched/sched_rr_get_interval_test.cpp
@@ -17,7 +17,8 @@
 #include "hdr/sched_macros.h"
 #include "hdr/types/struct_timespec.h"
 
-using LlvmLibcSchedRRGetIntervalTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+using LlvmLibcSchedRRGetIntervalTest =
+    LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 
 TEST_F(LlvmLibcSchedRRGetIntervalTest, SmokeTest) {
   auto SetSched = [&](int policy) {

--- a/libc/test/src/sched/yield_test.cpp
+++ b/libc/test/src/sched/yield_test.cpp
@@ -6,12 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/sched/sched_yield.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
-TEST(LlvmLibcSchedYieldTest, SmokeTest) {
-  libc_errno = 0;
+using LlvmLibcSchedYieldTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
+
+TEST_F(LlvmLibcSchedYieldTest, SmokeTest) {
   // sched_yield() always succeeds, just do a basic test that errno/ret are
   // properly 0.
   ASSERT_EQ(LIBC_NAMESPACE::sched_yield(), 0);

--- a/libc/test/src/signal/CMakeLists.txt
+++ b/libc/test/src/signal/CMakeLists.txt
@@ -51,6 +51,7 @@ add_libc_unittest(
     libc.src.signal.sigaddset
     libc.src.signal.sigemptyset
     libc.src.signal.sigprocmask
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -77,6 +78,7 @@ add_libc_unittest(
     libc.src.errno.errno
     libc.src.signal.raise
     libc.src.signal.signal
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )
 
@@ -124,5 +126,6 @@ add_libc_unittest(
     libc.src.signal.raise
     libc.src.signal.sigaltstack
     libc.src.signal.sigaction
+    libc.test.UnitTest.ErrnoCheckingTest
     libc.test.UnitTest.ErrnoSetterMatcher
 )

--- a/libc/test/src/signal/sigaltstack_test.cpp
+++ b/libc/test/src/signal/sigaltstack_test.cpp
@@ -9,11 +9,11 @@
 #include "hdr/signal_macros.h"
 #include "hdr/stdint_proxy.h"
 #include "src/__support/OSUtil/syscall.h" // For internal syscall function.
-#include "src/__support/libc_errno.h"
 #include "src/signal/linux/signal_utils.h"
 #include "src/signal/raise.h"
 #include "src/signal/sigaction.h"
 #include "src/signal/sigaltstack.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
@@ -23,6 +23,7 @@ constexpr int LOCAL_VAR_SIZE = 512;
 constexpr int ALT_STACK_SIZE = SIGSTKSZ + LOCAL_VAR_SIZE * 2;
 static uint8_t alt_stack[ALT_STACK_SIZE];
 
+using LlvmLibcSigaltstackTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
@@ -44,9 +45,8 @@ static void handler(int) {
   good_stack = true;
 }
 
-TEST(LlvmLibcSignalTest, SigaltstackRunOnAltStack) {
+TEST_F(LlvmLibcSigaltstackTest, SigaltstackRunOnAltStack) {
   struct sigaction action;
-  libc_errno = 0;
   ASSERT_THAT(LIBC_NAMESPACE::sigaction(SIGUSR1, nullptr, &action),
               Succeeds(0));
   action.sa_handler = handler;
@@ -68,7 +68,7 @@ TEST(LlvmLibcSignalTest, SigaltstackRunOnAltStack) {
 }
 
 // This tests for invalid input.
-TEST(LlvmLibcSignalTest, SigaltstackInvalidStack) {
+TEST_F(LlvmLibcSigaltstackTest, SigaltstackInvalidStack) {
   stack_t ss;
   ss.ss_sp = alt_stack;
   ss.ss_size = 0;

--- a/libc/test/src/signal/signal_test.cpp
+++ b/libc/test/src/signal/signal_test.cpp
@@ -6,18 +6,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/signal/raise.h"
 #include "src/signal/signal.h"
-
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
+using LlvmLibcSignalTest = LIBC_NAMESPACE::testing::ErrnoCheckingTest;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
-TEST(LlvmLibcSignal, Invalid) {
-  libc_errno = 0;
+TEST(LlvmLibcSignalTest, Invalid) {
   auto *valid = +[](int) {};
   EXPECT_THAT((void *)LIBC_NAMESPACE::signal(0, valid),
               Fails(EINVAL, (void *)SIG_ERR));
@@ -26,7 +25,7 @@ TEST(LlvmLibcSignal, Invalid) {
 }
 
 static int sum;
-TEST(LlvmLibcSignal, Basic) {
+TEST(LlvmLibcSignalTest, Basic) {
   // In case test get run multiple times.
   sum = 0;
   ASSERT_NE(LIBC_NAMESPACE::signal(

--- a/libc/test/src/signal/sigprocmask_test.cpp
+++ b/libc/test/src/signal/sigprocmask_test.cpp
@@ -6,25 +6,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "src/__support/libc_errno.h"
 #include "src/signal/raise.h"
 #include "src/signal/sigaddset.h"
 #include "src/signal/sigemptyset.h"
 #include "src/signal/sigprocmask.h"
-
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/ErrnoSetterMatcher.h"
 #include "test/UnitTest/Test.h"
 
 #include <signal.h>
 
-class LlvmLibcSignalTest : public LIBC_NAMESPACE::testing::Test {
+class LlvmLibcSigprocmaskTest
+    : public LIBC_NAMESPACE::testing::ErrnoCheckingTest {
   sigset_t oldSet;
 
 public:
-  void SetUp() override { LIBC_NAMESPACE::sigprocmask(0, nullptr, &oldSet); }
+  void SetUp() override {
+    ErrnoCheckingTest::SetUp();
+    LIBC_NAMESPACE::sigprocmask(0, nullptr, &oldSet);
+  }
 
   void TearDown() override {
     LIBC_NAMESPACE::sigprocmask(SIG_SETMASK, &oldSet, nullptr);
+    ErrnoCheckingTest::TearDown();
   }
 };
 
@@ -32,9 +36,7 @@ using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Fails;
 using LIBC_NAMESPACE::testing::ErrnoSetterMatcher::Succeeds;
 
 // This tests for invalid input.
-TEST_F(LlvmLibcSignalTest, SigprocmaskInvalid) {
-  libc_errno = 0;
-
+TEST_F(LlvmLibcSigprocmaskTest, SigprocmaskInvalid) {
   sigset_t valid;
   // 17 and -4 are out of the range for sigprocmask's how paramater.
   EXPECT_THAT(LIBC_NAMESPACE::sigprocmask(17, &valid, nullptr), Fails(EINVAL));
@@ -49,7 +51,7 @@ TEST_F(LlvmLibcSignalTest, SigprocmaskInvalid) {
 
 // This tests that when nothing is blocked, a process gets killed and alse tests
 // that when signals are blocked they are not delivered to the process.
-TEST_F(LlvmLibcSignalTest, BlockUnblock) {
+TEST_F(LlvmLibcSigprocmaskTest, BlockUnblock) {
   sigset_t sigset;
   EXPECT_EQ(LIBC_NAMESPACE::sigemptyset(&sigset), 0);
   EXPECT_EQ(LIBC_NAMESPACE::sigprocmask(SIG_SETMASK, &sigset, nullptr), 0);


### PR DESCRIPTION
Remove direct libc_errno.h inclusion and manipulation of libc_errno in various unit tests, instead relying on ErrnoCheckingTest machinery.

This is the final mechanical change of migrating libc unit tests to ErrnoCheckingTest - after it, all the unit tests relying on ASSERT_ERRNO_* macro will be using ErrnoCheckingTest.h