### PR TITLE
[libc][bazel] Fold errno_test_helpers into LibcUnitTest.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/UnitTest/BUILD.bazel
@@ -39,6 +39,7 @@ libc_test_library(
         "LibcTestMain.cpp",
     ],
     hdrs = [
+        "ErrnoCheckingTest.h",
         "ErrnoSetterMatcher.h",
         "ExecuteFunction.h",
         "LibcTest.h",
@@ -81,19 +82,6 @@ libc_test_library(
 )
 
 libc_test_library(
-    name = "errno_test_helpers",
-    hdrs = [
-        "ErrnoCheckingTest.h",
-    ],
-    deps = [
-        ":LibcUnitTest",
-        "//libc:__support_libc_errno",
-        "//libc:__support_macros_config",
-        "//libc:errno",
-    ],
-)
-
-libc_test_library(
     name = "fp_test_helpers",
     srcs = [
         "FEnvSafeTest.cpp",
@@ -108,7 +96,6 @@ libc_test_library(
     ],
     deps = [
         ":LibcUnitTest",
-        ":errno_test_helpers",
         ":string_utils",
         ":test_logger",
         "//libc:__support_cpp_array",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdio/BUILD.bazel
@@ -122,7 +122,6 @@ libc_test(
         "//libc:mkdirat",
         "//libc:open",
         "//libc:remove",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -107,7 +107,6 @@ libc_test(
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc:atof",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -208,7 +207,6 @@ libc_test_library(
         "//libc:__support_macros_properties_architectures",
         "//libc:errno",
         "//libc/test/UnitTest:LibcUnitTest",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -254,7 +252,6 @@ libc_test(
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc:strtof",
-        "//libc/test/UnitTest:errno_test_helpers",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
@@ -265,7 +262,6 @@ libc_test(
     deps = [
         "//libc:__support_fputil_fp_bits",
         "//libc:strtod",
-        "//libc/test/UnitTest:errno_test_helpers",
         "//libc/test/UnitTest:fp_test_helpers",
     ],
 )
@@ -277,6 +273,5 @@ libc_test(
         "//libc:__support_fputil_fp_bits",
         "//libc:__support_uint128",
         "//libc:strtold",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/epoll/BUILD.bazel
@@ -16,7 +16,6 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:epoll_create",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -27,7 +26,6 @@ libc_test(
         "//libc:close",
         "//libc:epoll_create1",
         "//libc:hdr_sys_epoll_macros",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -41,7 +39,6 @@ libc_test(
         "//libc:hdr_sys_epoll_macros",
         "//libc:pipe",
         "//libc:types_struct_epoll_event",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -56,7 +53,6 @@ libc_test(
         "//libc:hdr_sys_epoll_macros",
         "//libc:pipe",
         "//libc:types_struct_epoll_event",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -71,7 +67,6 @@ libc_test(
         "//libc:hdr_sys_epoll_macros",
         "//libc:pipe",
         "//libc:types_struct_epoll_event",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -87,6 +82,5 @@ libc_test(
         "//libc:pipe",
         "//libc:types_struct_epoll_event",
         "//libc:types_struct_timespec",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/sys/socket/BUILD.bazel
@@ -16,7 +16,6 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:socket",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -26,7 +25,6 @@ libc_test(
     deps = [
         "//libc:close",
         "//libc:socketpair",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -38,7 +36,6 @@ libc_test(
         "//libc:recv",
         "//libc:send",
         "//libc:socketpair",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -50,7 +47,6 @@ libc_test(
         "//libc:recvfrom",
         "//libc:sendto",
         "//libc:socketpair",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -62,6 +58,5 @@ libc_test(
         "//libc:recvmsg",
         "//libc:sendmsg",
         "//libc:socketpair",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )

--- a/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/unistd/BUILD.bazel
@@ -18,7 +18,6 @@ libc_test(
         "//libc:close",
         "//libc:open",
         "//libc:unlink",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -32,7 +31,6 @@ libc_test(
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -46,7 +44,6 @@ libc_test(
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -60,7 +57,6 @@ libc_test(
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -75,7 +71,6 @@ libc_test(
         "//libc:read",
         "//libc:unlink",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -90,7 +85,6 @@ libc_test(
         "//libc:pwrite",
         "//libc:unlink",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -104,7 +98,6 @@ libc_test(
         "//libc:read",
         "//libc:remove",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -116,7 +109,6 @@ libc_test(
         "//libc:link",
         "//libc:open",
         "//libc:unlink",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -137,7 +129,6 @@ libc_test(
         "//libc:open",
         "//libc:symlink",
         "//libc:unlink",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -152,7 +143,6 @@ libc_test(
         "//libc:truncate",
         "//libc:unlink",
         "//libc:write",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -163,7 +153,6 @@ libc_test(
         "//libc:close",
         "//libc:open",
         "//libc:unlink",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 
@@ -190,7 +179,6 @@ libc_test(
         "//libc:close",
         "//libc:isatty",
         "//libc:open",
-        "//libc/test/UnitTest:errno_test_helpers",
     ],
 )
 


### PR DESCRIPTION
LibcUnitTest helper library already contains some logic for errno validation (ErrnoSetterMatcher.h), and since errno validation is used so extensively in various unit tests, it makes sense to fold ErrnoCheckingTest.h (which would be required for errno validation soon) there as well for simplicity.