### PR TITLE
[clang-tidy][NFC] Enable 'readability-simplify-boolean-expr' check

### DIFF
--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
-  -readability-simplify-boolean-expr,
   -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument,
   -readability-use-anyofallof
@@ -37,3 +36,5 @@ Checks: >
 CheckOptions:
   - key:             performance-move-const-arg.CheckTriviallyCopyableMove
     value:           false
+  - key:             readability-simplify-boolean-expr.SimplifyDeMorganRelaxed
+    value:           true

--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
+  -readability-simplify-boolean-expr,
   -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument,
   -readability-use-anyofallof

--- a/clang-tools-extra/clang-tidy/.clang-tidy
+++ b/clang-tools-extra/clang-tidy/.clang-tidy
@@ -29,7 +29,6 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-qualified-auto,
-  -readability-simplify-boolean-expr,
   -readability-static-definition-in-anonymous-namespace,
   -readability-suspicious-call-argument,
   -readability-use-anyofallof

--- a/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
+++ b/clang-tools-extra/clang-tidy/ExpandModularHeadersPPCallbacks.cpp
@@ -23,10 +23,10 @@ public:
   /// Records that a given file entry is needed for replaying callbacks.
   void addNecessaryFile(FileEntryRef File) {
     // Don't record modulemap files because it breaks same file detection.
-    if (!(File.getName().ends_with("module.modulemap") ||
-          File.getName().ends_with("module.private.modulemap") ||
-          File.getName().ends_with("module.map") ||
-          File.getName().ends_with("module_private.map")))
+    if (!File.getName().ends_with("module.modulemap") &&
+        !File.getName().ends_with("module.private.modulemap") &&
+        !File.getName().ends_with("module.map") &&
+        !File.getName().ends_with("module_private.map"))
       FilesToRecord.insert(File);
   }
 

--- a/clang-tools-extra/clang-tidy/abseil/TimeSubtractionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/abseil/TimeSubtractionCheck.cpp
@@ -80,8 +80,8 @@ static bool parensRequired(const MatchFinder::MatchResult &Result,
                            const Expr *Node) {
   // TODO: Figure out any more contexts in which we can omit the surrounding
   // parentheses.
-  return !(isConstructorAssignment(Result, Node) || isArgument(Result, Node) ||
-           isReturn(Result, Node));
+  return !isConstructorAssignment(Result, Node) && !isArgument(Result, Node) &&
+         !isReturn(Result, Node);
 }
 
 void TimeSubtractionCheck::emitDiagnostic(const Expr *Node,

--- a/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
@@ -1880,12 +1880,9 @@ static bool prefixSuffixCoverUnderThreshold(std::size_t Threshold,
   padStringAtBegin(S1PadB, BiggerLength);
   padStringAtBegin(S2PadB, BiggerLength);
 
-  if (isCommonSuffixWithoutSomeCharacters(
-          Threshold, StringRef{S1PadB.begin(), BiggerLength},
-          StringRef{S2PadB.begin(), BiggerLength}))
-    return true;
-
-  return false;
+  return isCommonSuffixWithoutSomeCharacters(
+      Threshold, StringRef{S1PadB.begin(), BiggerLength},
+      StringRef{S2PadB.begin(), BiggerLength});
 }
 
 } // namespace filter

--- a/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/EasilySwappableParametersCheck.cpp
@@ -1880,9 +1880,12 @@ static bool prefixSuffixCoverUnderThreshold(std::size_t Threshold,
   padStringAtBegin(S1PadB, BiggerLength);
   padStringAtBegin(S2PadB, BiggerLength);
 
-  return isCommonSuffixWithoutSomeCharacters(
-      Threshold, StringRef{S1PadB.begin(), BiggerLength},
-      StringRef{S2PadB.begin(), BiggerLength});
+  if (isCommonSuffixWithoutSomeCharacters(
+          Threshold, StringRef{S1PadB.begin(), BiggerLength},
+          StringRef{S2PadB.begin(), BiggerLength}))
+    return true;
+
+  return false;
 }
 
 } // namespace filter

--- a/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
@@ -268,10 +268,8 @@ static bool isDestCapacityOverflows(const MatchFinder::MatchResult &Result) {
   // Assume that the destination array's capacity cannot overflow if the
   // expression of the memory allocation contains '+ 1'.
   StringRef DestCapacityExprStr = exprToStr(DestCapacityExpr, Result);
-  if (DestCapacityExprStr.contains("+1") || DestCapacityExprStr.contains("+ 1"))
-    return false;
-
-  return true;
+  return !(DestCapacityExprStr.contains("+1") ||
+           DestCapacityExprStr.contains("+ 1"));
 }
 
 static bool
@@ -533,10 +531,7 @@ AST_MATCHER_P(Expr, hasDefinition, ast_matchers::internal::Matcher<Expr>,
           hasLHS(declRefExpr(to(varDecl(equalsBoundNode(VarDeclName))))),
           hasRHS(ignoringImpCasts(InnerMatcher))))))));
 
-  if (DREHasDefinition.matches(*SimpleNode, Finder, Builder))
-    return true;
-
-  return false;
+  return DREHasDefinition.matches(*SimpleNode, Finder, Builder);
 }
 } // namespace
 

--- a/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/NotNullTerminatedResultCheck.cpp
@@ -268,8 +268,10 @@ static bool isDestCapacityOverflows(const MatchFinder::MatchResult &Result) {
   // Assume that the destination array's capacity cannot overflow if the
   // expression of the memory allocation contains '+ 1'.
   StringRef DestCapacityExprStr = exprToStr(DestCapacityExpr, Result);
-  return !(DestCapacityExprStr.contains("+1") ||
-           DestCapacityExprStr.contains("+ 1"));
+  if (DestCapacityExprStr.contains("+1") || DestCapacityExprStr.contains("+ 1"))
+    return false;
+
+  return true;
 }
 
 static bool
@@ -531,7 +533,10 @@ AST_MATCHER_P(Expr, hasDefinition, ast_matchers::internal::Matcher<Expr>,
           hasLHS(declRefExpr(to(varDecl(equalsBoundNode(VarDeclName))))),
           hasRHS(ignoringImpCasts(InnerMatcher))))))));
 
-  return DREHasDefinition.matches(*SimpleNode, Finder, Builder);
+  if (DREHasDefinition.matches(*SimpleNode, Finder, Builder))
+    return true;
+
+  return false;
 }
 } // namespace
 

--- a/clang-tools-extra/clang-tidy/bugprone/ReservedIdentifierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/ReservedIdentifierCheck.cpp
@@ -164,10 +164,10 @@ getFailureInfoImpl(StringRef Name, bool IsInGlobalNamespace, bool IsMacro,
 
     return Info;
   }
-  if (!(hasReservedDoubleUnderscore(Name, LangOpts) ||
-        startsWithUnderscoreCapital(Name) ||
-        startsWithUnderscoreInGlobalNamespace(Name, IsInGlobalNamespace,
-                                              IsMacro)))
+  if (!hasReservedDoubleUnderscore(Name, LangOpts) &&
+      !startsWithUnderscoreCapital(Name) &&
+      !startsWithUnderscoreInGlobalNamespace(Name, IsInGlobalNamespace,
+                                             IsMacro))
     return FailureInfo{NonReservedTag, getNonReservedFixup(std::string(Name))};
   return std::nullopt;
 }

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousEnumUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousEnumUsageCheck.cpp
@@ -100,7 +100,7 @@ static bool isPossiblyBitMask(const EnumDecl *EnumDec) {
   return NonPowOfTwoCounter >= 1 && NonPowOfTwoCounter <= 2 &&
          NonPowOfTwoCounter < EnumLen / 2 &&
          (VR.MaxVal - VR.MinVal != EnumLen - 1) &&
-         !(NonPowOfTwoCounter == 1 && isMaxValAllBitSetLiteral(EnumDec));
+         (NonPowOfTwoCounter != 1 || !isMaxValAllBitSetLiteral(EnumDec));
 }
 
 SuspiciousEnumUsageCheck::SuspiciousEnumUsageCheck(StringRef Name,

--- a/clang-tools-extra/clang-tidy/bugprone/SuspiciousEnumUsageCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SuspiciousEnumUsageCheck.cpp
@@ -100,7 +100,7 @@ static bool isPossiblyBitMask(const EnumDecl *EnumDec) {
   return NonPowOfTwoCounter >= 1 && NonPowOfTwoCounter <= 2 &&
          NonPowOfTwoCounter < EnumLen / 2 &&
          (VR.MaxVal - VR.MinVal != EnumLen - 1) &&
-         (NonPowOfTwoCounter != 1 || !isMaxValAllBitSetLiteral(EnumDec));
+         !(NonPowOfTwoCounter == 1 && isMaxValAllBitSetLiteral(EnumDec));
 }
 
 SuspiciousEnumUsageCheck::SuspiciousEnumUsageCheck(StringRef Name,

--- a/clang-tools-extra/clang-tidy/bugprone/VirtualNearMissCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/VirtualNearMissCheck.cpp
@@ -56,8 +56,8 @@ static bool checkOverridingFunctionReturnType(const ASTContext *Context,
   /// Check if the return types are covariant.
 
   // Both types must be pointers or references to classes.
-  if (!(BaseReturnTy->isPointerType() && DerivedReturnTy->isPointerType()) &&
-      !(BaseReturnTy->isReferenceType() && DerivedReturnTy->isReferenceType()))
+  if ((!BaseReturnTy->isPointerType() || !DerivedReturnTy->isPointerType()) &&
+      (!BaseReturnTy->isReferenceType() || !DerivedReturnTy->isReferenceType()))
     return false;
 
   /// BTy is the class type in return type of BaseMD. For example,

--- a/clang-tools-extra/clang-tidy/cppcoreguidelines/SpecialMemberFunctionsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/cppcoreguidelines/SpecialMemberFunctionsCheck.cpp
@@ -227,10 +227,9 @@ void SpecialMemberFunctionsCheck::checkForMissingMembers(
                    SpecialMemberFunctionKind::CopyAssignment);
   }
 
-  if (RequireFive &&
-      !(AllowMissingMoveFunctionsWhenCopyIsDeleted &&
-        (IsDeleted(SpecialMemberFunctionKind::CopyConstructor) &&
-         IsDeleted(SpecialMemberFunctionKind::CopyAssignment)))) {
+  if (RequireFive && (!AllowMissingMoveFunctionsWhenCopyIsDeleted ||
+                      !IsDeleted(SpecialMemberFunctionKind::CopyConstructor) ||
+                      !IsDeleted(SpecialMemberFunctionKind::CopyAssignment))) {
     assert(RequireThree);
     RequireMembers(SpecialMemberFunctionKind::MoveConstructor,
                    SpecialMemberFunctionKind::MoveAssignment);

--- a/clang-tools-extra/clang-tidy/google/AvoidNSObjectNewCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/AvoidNSObjectNewCheck.cpp
@@ -27,10 +27,7 @@ static bool isMessageExpressionInsideMacro(const ObjCMessageExpr *Expr) {
     return true;
 
   SourceLocation SelectorLocation = Expr->getSelectorStartLoc();
-  if (SelectorLocation.isMacroID())
-    return true;
-
-  return false;
+  return SelectorLocation.isMacroID();
 }
 
 // Walk up the class hierarchy looking for an -init method, returning true

--- a/clang-tools-extra/clang-tidy/google/AvoidNSObjectNewCheck.cpp
+++ b/clang-tools-extra/clang-tidy/google/AvoidNSObjectNewCheck.cpp
@@ -27,7 +27,10 @@ static bool isMessageExpressionInsideMacro(const ObjCMessageExpr *Expr) {
     return true;
 
   SourceLocation SelectorLocation = Expr->getSelectorStartLoc();
-  return SelectorLocation.isMacroID();
+  if (SelectorLocation.isMacroID())
+    return true;
+
+  return false;
 }
 
 // Walk up the class hierarchy looking for an -init method, returning true

--- a/clang-tools-extra/clang-tidy/llvmlibc/ImplementationInNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvmlibc/ImplementationInNamespaceCheck.cpp
@@ -39,7 +39,7 @@ void ImplementationInNamespaceCheck::check(
   }
 
   // Enforce that the namespace is the result of macro expansion
-  if (Result.SourceManager->isMacroBodyExpansion(NS->getLocation()) == false) {
+  if (!Result.SourceManager->isMacroBodyExpansion(NS->getLocation())) {
     diag(NS->getLocation(), "the outermost namespace should be the '%0' macro")
         << RequiredNamespaceDeclMacroName;
     return;
@@ -55,7 +55,7 @@ void ImplementationInNamespaceCheck::check(
   }
 
   // Lastly, make sure the namespace name actually has the __llvm_libc prefix
-  if (NS->getName().starts_with(RequiredNamespaceRefStart) == false) {
+  if (!NS->getName().starts_with(RequiredNamespaceRefStart)) {
     diag(NS->getLocation(), "the '%0' macro expansion should start with '%1'")
         << RequiredNamespaceDeclMacroName << RequiredNamespaceRefStart;
     return;

--- a/clang-tools-extra/clang-tidy/llvmlibc/ImplementationInNamespaceCheck.cpp
+++ b/clang-tools-extra/clang-tidy/llvmlibc/ImplementationInNamespaceCheck.cpp
@@ -39,7 +39,7 @@ void ImplementationInNamespaceCheck::check(
   }
 
   // Enforce that the namespace is the result of macro expansion
-  if (!Result.SourceManager->isMacroBodyExpansion(NS->getLocation())) {
+  if (Result.SourceManager->isMacroBodyExpansion(NS->getLocation()) == false) {
     diag(NS->getLocation(), "the outermost namespace should be the '%0' macro")
         << RequiredNamespaceDeclMacroName;
     return;
@@ -55,7 +55,7 @@ void ImplementationInNamespaceCheck::check(
   }
 
   // Lastly, make sure the namespace name actually has the __llvm_libc prefix
-  if (!NS->getName().starts_with(RequiredNamespaceRefStart)) {
+  if (NS->getName().starts_with(RequiredNamespaceRefStart) == false) {
     diag(NS->getLocation(), "the '%0' macro expansion should start with '%1'")
         << RequiredNamespaceDeclMacroName << RequiredNamespaceRefStart;
     return;

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -54,8 +54,7 @@ ConstCorrectnessCheck::ConstCorrectnessCheck(StringRef Name,
 
       AllowedTypes(
           utils::options::parseStringList(Options.get("AllowedTypes", ""))) {
-  if (AnalyzeValues == false && AnalyzeReferences == false &&
-      AnalyzePointers == false)
+  if (!AnalyzeValues && !AnalyzeReferences && !AnalyzePointers)
     this->configurationDiag(
         "The check 'misc-const-correctness' will not "
         "perform any analysis because 'AnalyzeValues', "

--- a/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/ConstCorrectnessCheck.cpp
@@ -54,7 +54,8 @@ ConstCorrectnessCheck::ConstCorrectnessCheck(StringRef Name,
 
       AllowedTypes(
           utils::options::parseStringList(Options.get("AllowedTypes", ""))) {
-  if (!AnalyzeValues && !AnalyzeReferences && !AnalyzePointers)
+  if (AnalyzeValues == false && AnalyzeReferences == false &&
+      AnalyzePointers == false)
     this->configurationDiag(
         "The check 'misc-const-correctness' will not "
         "perform any analysis because 'AnalyzeValues', "

--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
@@ -70,7 +70,7 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
     IgnoreHeadersRegex.emplace_back(HeaderSuffix);
   }
 
-  if (UnusedIncludes == false && MissingIncludes == false)
+  if (!UnusedIncludes && !MissingIncludes)
     this->configurationDiag("The check 'misc-include-cleaner' will not "
                             "perform any analysis because 'UnusedIncludes' and "
                             "'MissingIncludes' are both false.");

--- a/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/IncludeCleanerCheck.cpp
@@ -70,7 +70,7 @@ IncludeCleanerCheck::IncludeCleanerCheck(StringRef Name,
     IgnoreHeadersRegex.emplace_back(HeaderSuffix);
   }
 
-  if (!UnusedIncludes && !MissingIncludes)
+  if (UnusedIncludes == false && MissingIncludes == false)
     this->configurationDiag("The check 'misc-include-cleaner' will not "
                             "perform any analysis because 'UnusedIncludes' and "
                             "'MissingIncludes' are both false.");

--- a/clang-tools-extra/clang-tidy/misc/NewDeleteOverloadsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/NewDeleteOverloadsCheck.cpp
@@ -52,11 +52,8 @@ AST_MATCHER(FunctionDecl, isPlacementOverload) {
 
   const auto *FPT = Node.getType()->castAs<FunctionProtoType>();
   ASTContext &Ctx = Node.getASTContext();
-  if (Ctx.getLangOpts().SizedDeallocation &&
-      Ctx.hasSameType(FPT->getParamType(1), Ctx.getSizeType()))
-    return false;
-
-  return true;
+  return !(Ctx.getLangOpts().SizedDeallocation &&
+           Ctx.hasSameType(FPT->getParamType(1), Ctx.getSizeType()));
 }
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/misc/NewDeleteOverloadsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/NewDeleteOverloadsCheck.cpp
@@ -52,8 +52,11 @@ AST_MATCHER(FunctionDecl, isPlacementOverload) {
 
   const auto *FPT = Node.getType()->castAs<FunctionProtoType>();
   ASTContext &Ctx = Node.getASTContext();
-  return !(Ctx.getLangOpts().SizedDeallocation &&
-           Ctx.hasSameType(FPT->getParamType(1), Ctx.getSizeType()));
+  if (Ctx.getLangOpts().SizedDeallocation &&
+      Ctx.hasSameType(FPT->getParamType(1), Ctx.getSizeType()))
+    return false;
+
+  return true;
 }
 
 } // namespace

--- a/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/RedundantExpressionCheck.cpp
@@ -196,12 +196,9 @@ static bool areExclusiveRanges(BinaryOperatorKind OpcodeLHS,
 
   // Handle the case where constants are off by one: x > 5 && x < 6.
   APSInt ValueLhsPlus1;
-  if (OpcodeLHS == BO_GT && OpcodeRHS == BO_LT &&
-      incrementWithoutOverflow(ValueLHS, ValueLhsPlus1) &&
-      APSInt::compareValues(ValueLhsPlus1, ValueRHS) == 0)
-    return true;
-
-  return false;
+  return OpcodeLHS == BO_GT && OpcodeRHS == BO_LT &&
+         incrementWithoutOverflow(ValueLHS, ValueLhsPlus1) &&
+         APSInt::compareValues(ValueLhsPlus1, ValueRHS) == 0;
 }
 
 // Returns whether the ranges covered by the union of both relational
@@ -726,12 +723,10 @@ static bool areSidesBinaryConstExpressions(const BinaryOperator *&BinOp,
     return !E->isValueDependent() && E->isIntegerConstantExpr(*AstCtx);
   };
 
-  if ((IsIntegerConstantExpr(LhsBinOp->getLHS()) ||
-       IsIntegerConstantExpr(LhsBinOp->getRHS())) &&
-      (IsIntegerConstantExpr(RhsBinOp->getLHS()) ||
-       IsIntegerConstantExpr(RhsBinOp->getRHS())))
-    return true;
-  return false;
+  return (IsIntegerConstantExpr(LhsBinOp->getLHS()) ||
+          IsIntegerConstantExpr(LhsBinOp->getRHS())) &&
+         (IsIntegerConstantExpr(RhsBinOp->getLHS()) ||
+          IsIntegerConstantExpr(RhsBinOp->getRHS()));
 }
 
 static bool areSidesBinaryConstExpressionsOrDefinesOrIntegerConstant(
@@ -747,10 +742,8 @@ static bool areSidesBinaryConstExpressionsOrDefinesOrIntegerConstant(
 
   auto IsDefineExpr = [AstCtx](const Expr *E) {
     const SourceRange Lsr = E->getSourceRange();
-    if (!Lsr.getBegin().isMacroID() || E->isValueDependent() ||
-        !E->isIntegerConstantExpr(*AstCtx))
-      return false;
-    return true;
+    return !(!Lsr.getBegin().isMacroID() || E->isValueDependent() ||
+             !E->isIntegerConstantExpr(*AstCtx));
   };
 
   return IsDefineExpr(Lhs) || IsDefineExpr(Rhs);

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -188,7 +188,7 @@ static bool hasRValueOverload(const CXXConstructorDecl *Ctor,
           return false;
       } else {
         // All other parameters can be similar or paired.
-        if (!(CandidateParamType == CtorParamType || IsLValueRValuePair))
+        if (!CandidateParamType == CtorParamType && !IsLValueRValuePair)
           return false;
       }
     }

--- a/clang-tools-extra/clang-tidy/modernize/ReplaceDisallowCopyAndAssignMacroCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/ReplaceDisallowCopyAndAssignMacroCheck.cpp
@@ -61,7 +61,7 @@ private:
   bool shouldAppendSemi(SourceRange MacroLoc) {
     std::optional<Token> Next = Lexer::findNextToken(
         MacroLoc.getEnd(), PP.getSourceManager(), PP.getLangOpts());
-    return !(Next && Next->is(tok::semi));
+    return !Next || !Next->is(tok::semi);
   }
 
   ReplaceDisallowCopyAndAssignMacroCheck &Check;

--- a/clang-tools-extra/clang-tidy/modernize/UseNodiscardCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseNodiscardCheck.cpp
@@ -54,7 +54,7 @@ AST_MATCHER(CXXMethodDecl, hasTemplateReturnType) {
 }
 AST_MATCHER(CXXMethodDecl, isDefinitionOrInline) {
   // A function definition, with optional inline but not the declaration.
-  return !(Node.isThisDeclarationADefinition() && Node.isOutOfLine());
+  return !Node.isThisDeclarationADefinition() || !Node.isOutOfLine();
 }
 AST_MATCHER(QualType, isInstantiationDependentType) {
   return Node->isInstantiationDependentType();

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -459,7 +459,7 @@ UseTrailingReturnTypeCheck::UseTrailingReturnTypeCheck(
       TransformFunctions(Options.get("TransformFunctions", true)),
       TransformLambdas(Options.get("TransformLambdas", TransformLambda::All)) {
 
-  if (TransformFunctions == false && TransformLambdas == TransformLambda::None)
+  if (!TransformFunctions && TransformLambdas == TransformLambda::None)
     this->configurationDiag(
         "The check 'modernize-use-trailing-return-type' will not perform any "
         "analysis because 'TransformFunctions' and 'TransformLambdas' are "

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -459,7 +459,7 @@ UseTrailingReturnTypeCheck::UseTrailingReturnTypeCheck(
       TransformFunctions(Options.get("TransformFunctions", true)),
       TransformLambdas(Options.get("TransformLambdas", TransformLambda::All)) {
 
-  if (!TransformFunctions && TransformLambdas == TransformLambda::None)
+  if (TransformFunctions == false && TransformLambdas == TransformLambda::None)
     this->configurationDiag(
         "The check 'modernize-use-trailing-return-type' will not perform any "
         "analysis because 'TransformFunctions' and 'TransformLambdas' are "

--- a/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/UseTrailingReturnTypeCheck.cpp
@@ -410,7 +410,7 @@ static void keepSpecifiers(std::string &ReturnType, std::string &Auto,
   const auto *M = dyn_cast<CXXMethodDecl>(&F);
   if (!F.isConstexpr() && !F.isInlineSpecified() &&
       F.getStorageClass() != SC_Extern && F.getStorageClass() != SC_Static &&
-      !Fr && !(M && M->isVirtualAsWritten()))
+      !Fr && (!M || !M->isVirtualAsWritten()))
     return;
 
   // Tokenize return type. If it contains macros which contain a mix of
@@ -459,7 +459,7 @@ UseTrailingReturnTypeCheck::UseTrailingReturnTypeCheck(
       TransformFunctions(Options.get("TransformFunctions", true)),
       TransformLambdas(Options.get("TransformLambdas", TransformLambda::All)) {
 
-  if (TransformFunctions == false && TransformLambdas == TransformLambda::None)
+  if (!TransformFunctions && TransformLambdas == TransformLambda::None)
     this->configurationDiag(
         "The check 'modernize-use-trailing-return-type' will not perform any "
         "analysis because 'TransformFunctions' and 'TransformLambdas' are "

--- a/clang-tools-extra/clang-tidy/objc/NSDateFormatterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/objc/NSDateFormatterCheck.cpp
@@ -60,7 +60,7 @@ void NSDateFormatterCheck::check(const MatchFinder::MatchResult &Result) {
          "did you mean to use week-year (Y) instead?");
   }
   if (SR.contains('F')) {
-    if (!(SR.contains('e') || SR.contains('E'))) {
+    if (!SR.contains('e') && !SR.contains('E')) {
       diag(StrExpr->getExprLoc(),
            "day of week in month (F) used without day of the week (e or E); "
            "did you forget e (or E) in the format string?");

--- a/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/performance/MoveConstArgCheck.cpp
@@ -216,8 +216,8 @@ void MoveConstArgCheck::check(const MatchFinder::MatchResult &Result) {
 
     if (const CXXRecordDecl *RecordDecl = ArgType->getAsCXXRecordDecl();
         RecordDecl && RecordDecl->hasDefinition() &&
-        !(RecordDecl->hasMoveConstructor() &&
-          RecordDecl->hasMoveAssignment())) {
+        (!RecordDecl->hasMoveConstructor() ||
+         !RecordDecl->hasMoveAssignment())) {
       const bool MissingMoveAssignment = !RecordDecl->hasMoveAssignment();
       const bool MissingMoveConstructor = !RecordDecl->hasMoveConstructor();
       const bool MissingBoth = MissingMoveAssignment && MissingMoveConstructor;

--- a/clang-tools-extra/clang-tidy/portability/SIMDIntrinsicsCheck.cpp
+++ b/clang-tools-extra/clang-tidy/portability/SIMDIntrinsicsCheck.cpp
@@ -52,8 +52,8 @@ static StringRef trySuggestPpc(StringRef Name) {
 }
 
 static StringRef trySuggestX86(StringRef Name) {
-  if (!(Name.consume_front("_mm_") || Name.consume_front("_mm256_") ||
-        Name.consume_front("_mm512_")))
+  if (!Name.consume_front("_mm_") && !Name.consume_front("_mm256_") &&
+      !Name.consume_front("_mm512_"))
     return {};
 
   // [simd.alg]

--- a/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/FunctionSizeCheck.cpp
@@ -23,8 +23,8 @@ public:
   bool VisitVarDecl(VarDecl *VD) {
     // Do not count function params.
     // Do not count decomposition declarations (C++17's structured bindings).
-    if (StructNesting == 0 &&
-        !(isa<ParmVarDecl>(VD) || isa<DecompositionDecl>(VD)))
+    if (StructNesting == 0 && !isa<ParmVarDecl>(VD) &&
+        !isa<DecompositionDecl>(VD))
       ++Info.Variables;
     return true;
   }

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -209,7 +209,7 @@ getEquivalentForBoolLiteral(const CXXBoolLiteralExpr *BoolLiteral,
   // Prior to C++11, false literal could be implicitly converted to pointer.
   if (!Context.getLangOpts().CPlusPlus11 &&
       (DestType->isPointerType() || DestType->isMemberPointerType()) &&
-      !BoolLiteral->getValue()) {
+      BoolLiteral->getValue() == false) {
     return "0";
   }
 

--- a/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/ImplicitBoolConversionCheck.cpp
@@ -209,7 +209,7 @@ getEquivalentForBoolLiteral(const CXXBoolLiteralExpr *BoolLiteral,
   // Prior to C++11, false literal could be implicitly converted to pointer.
   if (!Context.getLangOpts().CPlusPlus11 &&
       (DestType->isPointerType() || DestType->isMemberPointerType()) &&
-      BoolLiteral->getValue() == false) {
+      !BoolLiteral->getValue()) {
     return "0";
   }
 

--- a/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/NonConstParameterCheck.cpp
@@ -115,8 +115,8 @@ void NonConstParameterCheck::addParm(const ParmVarDecl *Parm) {
   // Only add nonconst integer/float pointer parameters.
   const QualType T = Parm->getType();
   if (!T->isPointerType() || T->getPointeeType().isConstQualified() ||
-      !(T->getPointeeType()->isIntegerType() ||
-        T->getPointeeType()->isFloatingType()))
+      (!T->getPointeeType()->isIntegerType() &&
+       !T->getPointeeType()->isFloatingType()))
     return;
 
   auto [It, Inserted] = Parameters.try_emplace(Parm);

--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -413,14 +413,12 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
 
   // Arithmetic types are interconvertible, except scoped enums.
   if (ParamType->isArithmeticType() && ArgType->isArithmeticType()) {
-    if ((ParamType->isEnumeralType() && ParamType->castAsCanonical<EnumType>()
+    return !(
+        (ParamType->isEnumeralType() && ParamType->castAsCanonical<EnumType>()
                                             ->getOriginalDecl()
                                             ->isScoped()) ||
         (ArgType->isEnumeralType() &&
-         ArgType->castAsCanonical<EnumType>()->getOriginalDecl()->isScoped()))
-      return false;
-
-    return true;
+         ArgType->castAsCanonical<EnumType>()->getOriginalDecl()->isScoped()));
   }
 
   // Check if the argument and the param are both function types (the parameter

--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -413,12 +413,14 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
 
   // Arithmetic types are interconvertible, except scoped enums.
   if (ParamType->isArithmeticType() && ArgType->isArithmeticType()) {
-    return !(
-        (ParamType->isEnumeralType() && ParamType->castAsCanonical<EnumType>()
+    if ((ParamType->isEnumeralType() && ParamType->castAsCanonical<EnumType>()
                                             ->getOriginalDecl()
                                             ->isScoped()) ||
         (ArgType->isEnumeralType() &&
-         ArgType->castAsCanonical<EnumType>()->getOriginalDecl()->isScoped()));
+         ArgType->castAsCanonical<EnumType>()->getOriginalDecl()->isScoped()))
+      return false;
+
+    return true;
   }
 
   // Check if the argument and the param are both function types (the parameter

--- a/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
+++ b/clang-tools-extra/clang-tidy/readability/SuspiciousCallArgumentCheck.cpp
@@ -413,14 +413,12 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
 
   // Arithmetic types are interconvertible, except scoped enums.
   if (ParamType->isArithmeticType() && ArgType->isArithmeticType()) {
-    if ((ParamType->isEnumeralType() && ParamType->castAsCanonical<EnumType>()
+    return !(
+        (ParamType->isEnumeralType() && ParamType->castAsCanonical<EnumType>()
                                             ->getOriginalDecl()
                                             ->isScoped()) ||
         (ArgType->isEnumeralType() &&
-         ArgType->castAsCanonical<EnumType>()->getOriginalDecl()->isScoped()))
-      return false;
-
-    return true;
+         ArgType->castAsCanonical<EnumType>()->getOriginalDecl()->isScoped()));
   }
 
   // Check if the argument and the param are both function types (the parameter
@@ -431,7 +429,7 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
   }
 
   // Arrays or pointer arguments convert to array or pointer parameters.
-  if (!(isPointerOrArray(ArgType) && isPointerOrArray(ParamType)))
+  if (!isPointerOrArray(ArgType) || !isPointerOrArray(ParamType))
     return false;
 
   // When ParamType is an array reference, ArgType has to be of the same-sized
@@ -472,7 +470,7 @@ static bool areTypesCompatible(QualType ArgType, QualType ParamType,
 
   // Unless argument and param are both multilevel pointers, the types are not
   // convertible.
-  if (!(ParamType->isAnyPointerType() && ArgType->isAnyPointerType()))
+  if (!ParamType->isAnyPointerType() || !ArgType->isAnyPointerType())
     return false;
 
   return arePointerTypesCompatible(ArgType, ParamType, IsParamContinuouslyConst,

--- a/clang-tools-extra/clang-tidy/utils/FixItHintUtils.cpp
+++ b/clang-tools-extra/clang-tidy/utils/FixItHintUtils.cpp
@@ -29,8 +29,8 @@ FixItHint changeVarDeclToReference(const VarDecl &Var, ASTContext &Context) {
 }
 
 static bool isValueType(const Type *T) {
-  return !(isa<PointerType>(T) || isa<ReferenceType>(T) || isa<ArrayType>(T) ||
-           isa<MemberPointerType>(T) || isa<ObjCObjectPointerType>(T));
+  return !isa<PointerType>(T) && !isa<ReferenceType>(T) && !isa<ArrayType>(T) &&
+         !isa<MemberPointerType>(T) && !isa<ObjCObjectPointerType>(T);
 }
 static bool isValueType(QualType QT) { return isValueType(QT.getTypePtr()); }
 static bool isMemberOrFunctionPointer(QualType QT) {


### PR DESCRIPTION
Closes https://github.com/llvm/llvm-project/issues/156160

This is how the default configuration of this check looks like.