### PR TITLE
[IntrinsicEmitter] Make AttributesMap bound inclusive

### DIFF
--- a/llvm/test/TableGen/intrinsic-attrs.td
+++ b/llvm/test/TableGen/intrinsic-attrs.td
@@ -25,8 +25,8 @@ def int_deref_ptr_ret : Intrinsic<[llvm_ptr_ty], [], [Dereferenceable<RetIndex, 
 // CHECK-NEXT: });
 
 // CHECK: static constexpr uint16_t IntrinsicsToAttributesMap[] = {
-// CHECK: 0 << 2 | 0, // llvm.deref.ptr.ret
-// CHECK: 1 << 2 | 1, // llvm.random.gen
+// CHECK: 0 << 1 | 0, // llvm.deref.ptr.ret
+// CHECK: 1 << 1 | 1, // llvm.random.gen
 // CHECK: }; // IntrinsicsToAttributesMap
 
 // CHECK: static constexpr ArgNoAttrIDPair ArgAttrIdTable[] = {

--- a/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
+++ b/llvm/utils/TableGen/Basic/IntrinsicEmitter.cpp
@@ -629,10 +629,10 @@ static constexpr uint16_t IntrinsicsToAttributesMap[] = {)";
     UniqAttributes.try_emplace(&Int, ID);
   }
 
-  const uint8_t UniqAttributesBitSize = Log2_32_Ceil(UniqAttributes.size() + 1);
+  const uint8_t UniqAttributesBitSize = Log2_32_Ceil(UniqAttributes.size());
   // Note, ID `-1` is used to indicate no function attributes.
   const uint8_t UniqFnAttributesBitSize =
-      Log2_32_Ceil(UniqFnAttributes.size() + 2);
+      Log2_32_Ceil(UniqFnAttributes.size() + 1);
   const uint16_t NoFunctionAttrsID =
       maskTrailingOnes<uint16_t>(UniqFnAttributesBitSize);
   if (UniqAttributesBitSize + UniqFnAttributesBitSize > 16)


### PR DESCRIPTION
This is a minor fix from comment https://github.com/llvm/llvm-project/pull/157965/files#r2347317186 introduced in #157965.