### PR TITLE
[RISCV][GISel] Remove shouldBeInFConstantPool. Always convert G_FCONSTANT to G_CONSTANT without F/D.

### DIFF
--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp
@@ -871,17 +871,6 @@ bool RISCVLegalizerInfo::shouldBeInConstantPool(const APInt &APImm,
   return !(!SeqLo.empty() && (SeqLo.size() + 2) <= STI.getMaxBuildIntsCost());
 }
 
-bool RISCVLegalizerInfo::shouldBeInFConstantPool(const APFloat &APF) const {
-  [[maybe_unused]] unsigned Size = APF.getSizeInBits(APF.getSemantics());
-  assert((Size == 32 || Size == 64) && "Only support f32 and f64");
-
-  int64_t Imm = APF.bitcastToAPInt().getSExtValue();
-  RISCVMatInt::InstSeq Seq = RISCVMatInt::generateInstSeq(Imm, STI);
-  if (Seq.size() <= STI.getMaxBuildIntsCost())
-    return false;
-  return true;
-}
-
 bool RISCVLegalizerInfo::legalizeVScale(MachineInstr &MI,
                                         MachineIRBuilder &MIB) const {
   const LLT XLenTy(STI.getXLenVT());
@@ -1372,9 +1361,7 @@ bool RISCVLegalizerInfo::legalizeCustom(
   case TargetOpcode::G_ABS:
     return Helper.lowerAbsToMaxNeg(MI);
   case TargetOpcode::G_FCONSTANT: {
-    const APFloat FVal = MI.getOperand(1).getFPImm()->getValueAPF();
-    if (shouldBeInFConstantPool(FVal))
-      return Helper.lowerFConstant(MI);
+    const APFloat &FVal = MI.getOperand(1).getFPImm()->getValueAPF();
 
     // Convert G_FCONSTANT to G_CONSTANT.
     Register DstReg = MI.getOperand(0).getReg();

--- a/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
+++ b/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.h
@@ -39,7 +39,6 @@ public:
 
 private:
   bool shouldBeInConstantPool(const APInt &APImm, bool ShouldOptForSize) const;
-  bool shouldBeInFConstantPool(const APFloat &APImm) const;
   bool legalizeShlAshrLshr(MachineInstr &MI, MachineIRBuilder &MIRBuilder,
                            GISelChangeObserver &Observer) const;
 


### PR DESCRIPTION
We can unconditionally convert to G_CONSTANT. G_CONSTANT will go through its own legalization and call the integer shouldBeInConstantPool.