### PR TITLE
[flang] Allow polymorphic type mismatch for hlfir.eoshift.

### DIFF
--- a/flang/lib/Optimizer/HLFIR/IR/HLFIROps.cpp
+++ b/flang/lib/Optimizer/HLFIR/IR/HLFIROps.cpp
@@ -1618,12 +1618,15 @@ static llvm::LogicalResult verifyArrayShift(Op op) {
     if (mlir::Value boundary = op.getBoundary()) {
       mlir::Type boundaryTy =
           hlfir::getFortranElementOrSequenceType(boundary.getType());
-      if (auto match = areMatchingTypes(
-              op, eleTy, hlfir::getFortranElementType(boundaryTy),
-              /*allowCharacterLenMismatch=*/!useStrictIntrinsicVerifier);
-          match.failed())
-        return op.emitOpError(
-            "ARRAY and BOUNDARY operands must have the same element type");
+      // In case of polymorphic ARRAY type, the BOUNDARY's element type
+      // may not match the ARRAY's element type.
+      if (!hlfir::isPolymorphicType(array.getType()))
+        if (auto match = areMatchingTypes(
+                op, eleTy, hlfir::getFortranElementType(boundaryTy),
+                /*allowCharacterLenMismatch=*/!useStrictIntrinsicVerifier);
+            match.failed())
+          return op.emitOpError(
+              "ARRAY and BOUNDARY operands must have the same element type");
       if (failed(verifyOperandTypeShape(boundaryTy, "BOUNDARY")))
         return mlir::failure();
     }

--- a/flang/test/Lower/HLFIR/eoshift.f90
+++ b/flang/test/Lower/HLFIR/eoshift.f90
@@ -4,6 +4,8 @@
 module eoshift_types
   type t
   end type t
+  type, extends(t) :: t2
+  end type t2
 end module eoshift_types
 
 ! 1d shift by scalar
@@ -269,3 +271,12 @@ subroutine eoshift14(array)
 ! CHECK-DAG:           %[[VAL_3]] = arith.constant 1 : i32
 ! CHECK:           %[[VAL_5:.*]] = hlfir.eoshift{{.*}}boundary %[[VAL_4]] : (!fir.box<!fir.array<?xui32>>, i32, ui32) -> !hlfir.expr<?xui32>
 end subroutine eoshift14
+
+! CHECK-LABEL:   func.func @_QPeoshift15(
+subroutine eoshift15(array, boundary)
+  use eoshift_types
+  class(t), allocatable :: array(:,:)
+  type(t) :: boundary(:)
+  array = eoshift(array, shift=1, boundary=boundary)
+! CHECK:           hlfir.eoshift %{{.*}} %{{.*}} boundary %{{.*}}#0 : (!fir.class<!fir.heap<!fir.array<?x?x!fir.type<_QMeoshift_typesTt>>>>, i32, !fir.box<!fir.array<?x!fir.type<_QMeoshift_typesTt>>>) -> !hlfir.expr<?x?x!fir.type<_QMeoshift_typesTt>?>
+end subroutine eoshift15


### PR DESCRIPTION
When the ARRAY has polymorphic type, its element type may not match
the element type of BOUNDARY.

Fixes #158382.
