### PR TITLE
[libc] Move ASSERT_ERRNO_* macro to ErrnoCheckingTest.h

### DIFF
--- a/libc/test/UnitTest/ErrnoCheckingTest.h
+++ b/libc/test/UnitTest/ErrnoCheckingTest.h
@@ -13,6 +13,21 @@
 #include "src/__support/macros/config.h"
 #include "test/UnitTest/Test.h"
 
+// Define macro to validate the value stored in the errno and restore it
+// to zero.
+
+#define ASSERT_ERRNO_EQ(VAL)                                                   \
+  do {                                                                         \
+    ASSERT_EQ(VAL, static_cast<int>(libc_errno));                              \
+    libc_errno = 0;                                                            \
+  } while (0)
+#define ASSERT_ERRNO_SUCCESS() ASSERT_EQ(0, static_cast<int>(libc_errno))
+#define ASSERT_ERRNO_FAILURE()                                                 \
+  do {                                                                         \
+    ASSERT_NE(0, static_cast<int>(libc_errno));                                \
+    libc_errno = 0;                                                            \
+  } while (0)
+
 namespace LIBC_NAMESPACE_DECL {
 namespace testing {
 

--- a/libc/test/UnitTest/Test.h
+++ b/libc/test/UnitTest/Test.h
@@ -37,21 +37,6 @@
 #include "LibcTest.h"
 #endif
 
-// These are defined the same way for each framework, in terms of the macros
-// they all provide.
-
-#define ASSERT_ERRNO_EQ(VAL)                                                   \
-  do {                                                                         \
-    ASSERT_EQ(VAL, static_cast<int>(libc_errno));                              \
-    libc_errno = 0;                                                            \
-  } while (0)
-#define ASSERT_ERRNO_SUCCESS() ASSERT_EQ(0, static_cast<int>(libc_errno))
-#define ASSERT_ERRNO_FAILURE()                                                 \
-  do {                                                                         \
-    ASSERT_NE(0, static_cast<int>(libc_errno));                                \
-    libc_errno = 0;                                                            \
-  } while (0)
-
 // Some macro utility to append file names with LIBC_TEST macro's value to be
 // used in stdio tests.
 #undef STR

--- a/libc/test/src/errno/CMakeLists.txt
+++ b/libc/test/src/errno/CMakeLists.txt
@@ -12,4 +12,5 @@ add_libc_unittest(
     errno_test.cpp
   DEPENDS
     libc.src.errno.errno
+    libc.test.UnitTest.ErrnoCheckingTest
 )

--- a/libc/test/src/errno/errno_test.cpp
+++ b/libc/test/src/errno/errno_test.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "src/__support/libc_errno.h"
+#include "test/UnitTest/ErrnoCheckingTest.h"
 #include "test/UnitTest/Test.h"
 
 TEST(LlvmLibcErrnoTest, Basic) {


### PR DESCRIPTION
Move these macro away from Test.h, since the generic Test.h (and associated test framework library) doesn't #include or depend on any errno-handling logic. Conversely, all tests that directly ASSERT various errno values are now migrated to ErrnoCheckingTest framework, which clears it our / validates it after every use case.