### PR TITLE
[BOLT][AArch64][instr] Consider targeting ARM64 CPUs without LSE support

### DIFF
--- a/bolt/include/bolt/Core/MCPlusBuilder.h
+++ b/bolt/include/bolt/Core/MCPlusBuilder.h
@@ -51,6 +51,7 @@ class raw_ostream;
 
 namespace bolt {
 class BinaryBasicBlock;
+class BinaryContext;
 class BinaryFunction;
 
 /// Different types of indirect branches encountered during disassembly.
@@ -530,10 +531,15 @@ public:
     return 0;
   }
 
+  /// Create a helper function to increment counter for Instrumentation
+  virtual void createInstrCounterIncrFunc(BinaryContext &BC) {
+    llvm_unreachable("not implemented");
+  }
+
   /// Create increment contents of target by 1 for Instrumentation
-  virtual InstructionListType
-  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
-                       unsigned CodePointerSize) const {
+  virtual InstructionListType createInstrIncMemory(const MCSymbol *Target,
+                                                   MCContext *Ctx, bool IsLeaf,
+                                                   unsigned CodePointerSize) {
     llvm_unreachable("not implemented");
     return InstructionListType();
   }

--- a/bolt/lib/Passes/Instrumentation.cpp
+++ b/bolt/lib/Passes/Instrumentation.cpp
@@ -753,6 +753,8 @@ void Instrumentation::createAuxiliaryFunctions(BinaryContext &BC) {
       createSimpleFunction("__bolt_fini_trampoline",
                            BC.MIB->createReturnInstructionList(BC.Ctx.get()));
     }
+    if (BC.isAArch64())
+      BC.MIB->createInstrCounterIncrFunc(BC);
   }
 }
 

--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -626,9 +626,9 @@ public:
     return Insts;
   }
 
-  InstructionListType
-  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
-                       unsigned CodePointerSize) const override {
+  InstructionListType createInstrIncMemory(const MCSymbol *Target,
+                                           MCContext *Ctx, bool IsLeaf,
+                                           unsigned CodePointerSize) override {
     // We need 2 scratch registers: one for the target address (x10), and one
     // for the increment value (x11).
     // addi sp, sp, -16

--- a/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
+++ b/bolt/lib/Target/X86/X86MCPlusBuilder.cpp
@@ -3053,9 +3053,9 @@ public:
     Inst.clear();
   }
 
-  InstructionListType
-  createInstrIncMemory(const MCSymbol *Target, MCContext *Ctx, bool IsLeaf,
-                       unsigned CodePointerSize) const override {
+  InstructionListType createInstrIncMemory(const MCSymbol *Target,
+                                           MCContext *Ctx, bool IsLeaf,
+                                           unsigned CodePointerSize) override {
     InstructionListType Instrs(IsLeaf ? 13 : 11);
     unsigned int I = 0;
 

--- a/bolt/test/AArch64/instrumentation_sequence.s
+++ b/bolt/test/AArch64/instrumentation_sequence.s
@@ -1,0 +1,50 @@
+# This test is to validate instrumentation code sequence generated with
+# and without `--no-lse-atomics`.
+
+# REQUIRES: system-linux,bolt-runtime,target=aarch64{{.*}}
+
+# RUN: %clang %cflags -pie %s -o %t.so -Wl,-q -Wl,--init=_foo -Wl,--fini=_foo
+
+  .text
+  .global _foo
+  .type _foo, %function
+_foo:
+  ret
+
+  .global _start
+  .type _start, %function
+_start:
+  ret
+
+  # Dummy relocation to force relocation mode
+  .reloc 0, R_AARCH64_NONE
+
+# RUN: llvm-bolt %t.so -o %t.instr.so --instrument
+# RUN: llvm-objdump -d %t.instr.so | FileCheck %s --check-prefix=INLINE
+# INLINE: {{.*}} <_foo>:
+# INLINE-NEXT: {{.*}} stp x0, x1, [sp, #-0x10]!
+# INLINE-NEXT: {{.*}} adrp  x0, 0x{{[0-9a-f]*}} {{.*}}
+# INLINE-NEXT: {{.*}} add x0, x0, #0x{{[0-9a-f]*}}
+# INLINE-NEXT: {{.*}} mov x1, #0x1 
+# INLINE-NEXT: {{.*}} stadd x1, [x0]
+# INLINE-NEXT: {{.*}} ldp x0, x1, [sp], #0x10
+
+# RUN: llvm-bolt %t.so -o %t.instr.no_lse.so --instrument \
+# RUN:   --no-lse-atomics
+# RUN: llvm-objdump -d %t.instr.no_lse.so | FileCheck %s --check-prefix=NOLSE
+# NOLSE: {{.*}} <_foo>:
+# NOLSE-NEXT: {{.*}} stp x0, x30, [sp, #-0x10]!
+# NOLSE-NEXT: {{.*}} stp x1, x2, [sp, #-0x10]!
+# NOLSE-NEXT: {{.*}} adrp x0, 0x{{[0-9a-f]*}} {{.*}}
+# NOLSE-NEXT: {{.*}} add x0, x0, #0x{{[0-9a-f]*}}
+# NOLSE-NEXT: {{.*}} adrp x1, 0x[[PAGEBASE:[0-9a-f]*]]000 {{.*}}
+# NOLSE-NEXT: {{.*}} add x1, x1, #0x[[PAGEOFF:[0-9a-f]*]]
+# NOLSE-NEXT: {{.*}} blr x1
+# NOLSE-NEXT: {{.*}} ldp x0, x30, [sp], #0x10
+# NOLSE: {{[0]*}}[[PAGEBASE]][[PAGEOFF]] <__bolt_instr_counter_incr>:
+# NOLSE-NEXT: {{.*}} ldaxr x1, [x0]
+# NOLSE-NEXT: {{.*}} add x1, x1, #0x1
+# NOLSE-NEXT: {{.*}} stlxr w2, x1, [x0]
+# NOLSE-NEXT: {{.*}} cbnz w2, 0x{{[0-9[a-f]*}} <__bolt_instr_counter_incr>
+# NOLSE-NEXT: {{.*}} ldp x1, x2, [sp], #0x10
+# NOLSE-NEXT: {{.*}} ret


### PR DESCRIPTION
`stadd` is only available in recent arm64 CPUs that have LSE support (like Cortex-A73 and Cortex-A75) and is not available on old arm64 CPUs (like Cortex-A53 and Cortex-A55). Devices could have a mixture of these two kinds of CPUs, so we need to provide an option for BOLT to generate instrumentation sequence that emulates what `stadd` would do. The implementation puts counter increment into an injected helper function so we don't need to update CFG in the function that is being instrumented and also make instrumentation induced binary size increase smaller.