### PR TITLE
[libc] Move preinit/init/fini arrays to namespace

### DIFF
--- a/libc/startup/baremetal/fini.h
+++ b/libc/startup/baremetal/fini.h
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/stdint_proxy.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
 
 extern "C" {
 extern uintptr_t __fini_array_start[];
@@ -14,3 +17,6 @@ extern uintptr_t __fini_array_end[];
 
 void __libc_fini_array(void);
 } // extern "C"
+
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/startup/baremetal/fini.h
+++ b/libc/startup/baremetal/fini.h
@@ -18,5 +18,4 @@ extern uintptr_t __fini_array_end[];
 void __libc_fini_array(void);
 } // extern "C"
 
-
 } // namespace LIBC_NAMESPACE_DECL

--- a/libc/startup/baremetal/fini.h
+++ b/libc/startup/baremetal/fini.h
@@ -9,6 +9,7 @@
 #include "hdr/stdint_proxy.h"
 #include "src/__support/macros/config.h"
 
+// NOTE: The namespace is necessary here to set the correct symbol visibility.
 namespace LIBC_NAMESPACE_DECL {
 
 extern "C" {

--- a/libc/startup/baremetal/init.h
+++ b/libc/startup/baremetal/init.h
@@ -7,6 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "hdr/stdint_proxy.h"
+#include "src/__support/macros/config.h"
+
+namespace LIBC_NAMESPACE_DECL {
 
 extern "C" {
 extern uintptr_t __preinit_array_start[];
@@ -16,3 +19,5 @@ extern uintptr_t __init_array_end[];
 
 void __libc_init_array(void);
 } // extern "C"
+
+} // namespace LIBC_NAMESPACE_DECL

--- a/libc/startup/baremetal/init.h
+++ b/libc/startup/baremetal/init.h
@@ -9,6 +9,7 @@
 #include "hdr/stdint_proxy.h"
 #include "src/__support/macros/config.h"
 
+// NOTE: The namespace is necessary here to set the correct symbol visibility.
 namespace LIBC_NAMESPACE_DECL {
 
 extern "C" {


### PR DESCRIPTION
In change #146863 we moved definitions of preinit/init/fini arrays to header but unintentionally moved outside of the namespace. Since the namespace also controls the visibility (through LIBC_NAMESPACE_DECL), as a consequence these symbols no longer have the hidden visibility which changes the codegen from:

```
 4: 4c11          ldr     r4, [pc, #0x44]         @ 0x4c <__libc_init_array+0x4c>
 6: 4812          ldr     r0, [pc, #0x48]         @ 0x50 <__libc_init_array+0x50>
 8: 447c          add     r4, pc
 a: 4478          add     r0, pc
 c: 1b00          subs    r0, r0, r4
```

to:

```
 4: 4813          ldr     r0, [pc, #0x4c]         @ 0x54 <__libc_init_array+0x54>
 6: 4914          ldr     r1, [pc, #0x50]         @ 0x58 <__libc_init_array+0x58>
 8: 4478          add     r0, pc
 a: 4479          add     r1, pc
 c: 6804          ldr     r4, [r0]
 e: 6808          ldr     r0, [r1]
10: 1b00          subs    r0, r0, r4
```

The `ldr` will trigger a fault in case where these symbols aren't pointing to a valid memory location which is sometimes the case when the array is empty.