### PR TITLE
[flang] Fix crash in error recovery

### DIFF
--- a/flang/lib/Semantics/check-declarations.cpp
+++ b/flang/lib/Semantics/check-declarations.cpp
@@ -4164,13 +4164,17 @@ void DistinguishabilityHelper::SayNotDistinguishable(const Scope &scope,
 // comes from a different module but is not necessarily use-associated.
 void DistinguishabilityHelper::AttachDeclaration(
     parser::Message &msg, const Scope &scope, const Symbol &proc) {
-  const Scope &unit{GetTopLevelUnitContaining(proc)};
-  if (unit == scope) {
+  if (proc.owner().IsTopLevel()) {
     evaluate::AttachDeclaration(msg, proc);
   } else {
-    msg.Attach(unit.GetName().value(),
-        "'%s' is USE-associated from module '%s'"_en_US, proc.name(),
-        unit.GetName().value());
+    const Scope &unit{GetTopLevelUnitContaining(proc)};
+    if (unit == scope) {
+      evaluate::AttachDeclaration(msg, proc);
+    } else {
+      msg.Attach(unit.GetName().value(),
+          "'%s' is USE-associated from module '%s'"_en_US, proc.name(),
+          unit.GetName().value());
+    }
   }
 }
 

--- a/flang/test/Semantics/bug158405.f90
+++ b/flang/test/Semantics/bug158405.f90
@@ -1,0 +1,9 @@
+! RUN: %python %S/test_errors.py %s %flang_fc1
+subroutine s()
+  ! ERROR: Generic 'f' may not have specific procedures 's' and 'ss' as their interfaces are not distinguishable
+  interface f
+    procedure s
+    procedure ss
+  end interface
+ entry ss()
+end


### PR DESCRIPTION
Code to attach a procedure's declaration to an error message did not allow for ENTRY names, which can be in the global scope.

Fixes https://github.com/llvm/llvm-project/issues/158405.