### PR TITLE
[OpenMP] [Tests] Update test broken by #157364

### DIFF
--- a/openmp/runtime/test/affinity/format/fields_values.c
+++ b/openmp/runtime/test/affinity/format/fields_values.c
@@ -112,8 +112,13 @@ void check_native_thread_id() {
 */
 
 void check_host() {
+#ifdef _WIN32
+  typedef DWORD buffer_size_t;
+#else
+  typedef int buffer_size_t;
+#endif
   int i;
-  int buffer_size = 256;
+  buffer_size_t buffer_size = 256;
   const char* formats[2] = {"%{host}", "%H"};
   char hostname[256];
   my_gethostname(hostname, buffer_size);


### PR DESCRIPTION
Fix another test impacted by #157364.

On Windows, `GetComputerNameA()`, which is what this ends up calling, takes an `LPDWORD`, but we were handing it an `int*`; fix this by declaring it as a `DWORD` instead.