### PR TITLE
[LLDB] [Tests] Downgrade -Wincompatible-pointer-types to a warning in some tests

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/Makefile
@@ -1,6 +1,6 @@
 OBJC_SOURCES := main.m
 
-CFLAGS_EXTRAS := -w
+CFLAGS_EXTRAS := -w -Wno-error=incompatible-pointer-types
 
 
 

--- a/lldb/test/API/macosx/ignore_exceptions/Makefile
+++ b/lldb/test/API/macosx/ignore_exceptions/Makefile
@@ -1,4 +1,4 @@
 C_SOURCES := main.c
-CFLAGS_EXTRAS := -std=c99
+CFLAGS_EXTRAS := -std=c99 -Wno-error=incompatible-pointer-types
 
 include Makefile.rules


### PR DESCRIPTION
These no longer compile because the warning now defaults to an error after #157364, so downgrade the error to a warning for now; I’m not familiar enough with either LLDB or MacOS to fix these warnings properly (assuming they’re unintended).