### PR TITLE
[lldb/API] Mark SBValue with error as invalid

### DIFF
--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -97,7 +97,8 @@ public:
       // they depend on.  So I have no good way to make that check without
       // tracking that in all the ValueObject subclasses.
       TargetSP target_sp = m_valobj_sp->GetTargetSP();
-      return target_sp && target_sp->IsValid();
+      return target_sp && target_sp->IsValid() &&
+             m_valobj_sp->GetError().Success();
     }
   }
 

--- a/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
+++ b/lldb/test/API/commands/expression/call-restarts/TestCallThatRestarts.py
@@ -122,7 +122,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
         self.runCmd("process handle SIGCHLD -s 1 -p 1 -n 1")
 
         value = frame.EvaluateExpression("call_me (%d)" % (num_sigchld), options)
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         # Set signal handling back to no-stop, and continue and we should end

--- a/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
+++ b/lldb/test/API/commands/expression/call-throws/TestCallThatThrows.py
@@ -45,7 +45,7 @@ class ExprCommandWithThrowTestCase(TestBase):
         self.orig_frame_pc = frame.GetPC()
 
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         self.check_after_call()
@@ -61,7 +61,8 @@ class ExprCommandWithThrowTestCase(TestBase):
 
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
 
-        self.assertTrue(value.IsValid() and not value.GetError().Success())
+        self.assertFalse(value.IsValid())
+        self.assertFalse(value.GetError().Success())
         self.check_after_call()
 
         # Now set the ObjC language breakpoint and make sure that doesn't
@@ -76,7 +77,8 @@ class ExprCommandWithThrowTestCase(TestBase):
 
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
 
-        self.assertTrue(value.IsValid() and not value.GetError().Success())
+        self.assertFalse(value.IsValid())
+        self.assertFalse(value.GetError().Success())
         self.check_after_call()
 
         # Now turn off exception trapping, and call a function that catches the exceptions,
@@ -95,5 +97,6 @@ class ExprCommandWithThrowTestCase(TestBase):
         options.SetUnwindOnError(False)
         value = frame.EvaluateExpression("[my_class callMeIThrow]", options)
 
-        self.assertTrue(value.IsValid() and not value.GetError().Success())
+        self.assertFalse(value.IsValid())
+        self.assertFalse(value.GetError().Success())
         self.check_after_call()

--- a/lldb/test/API/commands/expression/context-object/TestContextObject.py
+++ b/lldb/test/API/commands/expression/context-object/TestContextObject.py
@@ -69,7 +69,7 @@ class ContextObjectTestCase(TestBase):
 
         # Test an expression evaluation
         value = obj_val.EvaluateExpression("1")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         #
@@ -81,7 +81,7 @@ class ContextObjectTestCase(TestBase):
 
         # Test an expression evaluation
         value = obj_val.EvaluateExpression("1")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         # Test retrieveing of an element's field
@@ -99,7 +99,7 @@ class ContextObjectTestCase(TestBase):
 
         # Test an expression evaluation
         value = obj_val.EvaluateExpression("1")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         # Test retrieveing of a dereferenced object's field
@@ -117,7 +117,7 @@ class ContextObjectTestCase(TestBase):
 
         # Test an expression evaluation
         value = obj_val.EvaluateExpression("1")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         #
@@ -129,7 +129,7 @@ class ContextObjectTestCase(TestBase):
 
         # Test an expression evaluation
         value = obj_val.EvaluateExpression("1")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         # Test retrieveing of a dereferenced object's field

--- a/lldb/test/API/commands/expression/fixits/TestFixIts.py
+++ b/lldb/test/API/commands/expression/fixits/TestFixIts.py
@@ -76,7 +76,7 @@ class ExprCommandWithFixits(TestBase):
         # Now turn off the fixits, and the expression should fail:
         options.SetAutoApplyFixIts(False)
         value = frame.EvaluateExpression(two_error_expression, options)
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertTrue(value.GetError().Fail())
         error_string = value.GetError().GetCString()
         self.assertNotEqual(

--- a/lldb/test/API/commands/expression/options/TestExprOptions.py
+++ b/lldb/test/API/commands/expression/options/TestExprOptions.py
@@ -56,7 +56,7 @@ class ExprOptionsTestCase(TestBase):
         # Make sure it fails if language is set to C:
         options.SetLanguage(lldb.eLanguageTypeC)
         val = frame.EvaluateExpression("foo != nullptr", options)
-        self.assertTrue(val.IsValid())
+        self.assertFalse(val.IsValid())
         self.assertFalse(val.GetError().Success())
 
     def test_expr_options_lang(self):
@@ -83,5 +83,5 @@ class ExprOptionsTestCase(TestBase):
         # Make sure we can't retrieve `id` variable if language is set to ObjC:
         options.SetLanguage(lldb.eLanguageTypeObjC)
         val = frame.EvaluateExpression("id == 0", options)
-        self.assertTrue(val.IsValid())
+        self.assertFalse(val.IsValid())
         self.assertFalse(val.GetError().Success())

--- a/lldb/test/API/commands/expression/scoped_enums/TestScopedEnumType.py
+++ b/lldb/test/API/commands/expression/scoped_enums/TestScopedEnumType.py
@@ -23,10 +23,10 @@ class ScopedEnumType(TestBase):
 
         ## b is not a Foo
         value = frame.EvaluateExpression("b == Foo::FooBar")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         ## integral is not implicitly convertible to a scoped enum
         value = frame.EvaluateExpression("1 == Foo::FooBar")
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())

--- a/lldb/test/API/commands/expression/timeout/TestCallWithTimeout.py
+++ b/lldb/test/API/commands/expression/timeout/TestCallWithTimeout.py
@@ -38,7 +38,7 @@ class ExprCommandWithTimeoutsTestCase(TestBase):
         frame = thread.GetFrameAtIndex(0)
 
         value = frame.EvaluateExpression(f"wait_a_while({long_time})", options)
-        self.assertTrue(value.IsValid())
+        self.assertFalse(value.IsValid())
         self.assertFalse(value.GetError().Success())
 
         # Now do the same thing with the command line command, and make sure it

--- a/lldb/test/API/python_api/sbvalue_is_valid/Makefile
+++ b/lldb/test/API/python_api/sbvalue_is_valid/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+CFLAGS_EXTRAS := -std=c++17
+
+include Makefile.rules

--- a/lldb/test/API/python_api/sbvalue_is_valid/TestSBValueIsValid.py
+++ b/lldb/test/API/python_api/sbvalue_is_valid/TestSBValueIsValid.py
@@ -1,0 +1,20 @@
+import lldb
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+
+        (target, process, thread, main_breakpoint) = lldbutil.run_to_source_breakpoint(
+            self, "return", lldb.SBFileSpec("main.cpp")
+        )
+        frame = thread.GetSelectedFrame()
+
+        v1 = self.frame().EvaluateExpression("test")
+        v2 = self.frame().EvaluateExpression("i")
+
+        self.assertFalse(v1.IsValid())
+        self.assertTrue(v1.GetError().Fail())
+        self.assertTrue(v2.IsValid())

--- a/lldb/test/API/python_api/sbvalue_is_valid/main.cpp
+++ b/lldb/test/API/python_api/sbvalue_is_valid/main.cpp
@@ -1,0 +1,4 @@
+int main() {
+  int i = 42;
+  return 0;
+}


### PR DESCRIPTION
This patch fixes the return value of `SBValue::IsValid` if `GetError` returns a failing `SBError`.

That alignes better the expectation that an `SBValue` is invalid if it has an error.