### PR TITLE
[llvm-objdump] Optimize live element tracking

### DIFF
--- a/llvm/tools/llvm-objdump/SourcePrinter.cpp
+++ b/llvm/tools/llvm-objdump/SourcePrinter.cpp
@@ -50,13 +50,6 @@ void InlinedFunction::dump(raw_ostream &OS) const {
 void InlinedFunction::printElementLine(raw_ostream &OS,
                                        object::SectionedAddress Addr,
                                        bool IsEnd) const {
-  bool LiveIn = !IsEnd && Range.LowPC == Addr.Address;
-  bool LiveOut = IsEnd && Range.HighPC == Addr.Address;
-  // This check is technically redundant as the function is only called when
-  // either a start or end address matches, but it serves as a small safeguard.
-  if (!(LiveIn || LiveOut))
-    return;
-
   uint32_t CallFile, CallLine, CallColumn, CallDiscriminator;
   InlinedFuncDie.getCallerFrame(CallFile, CallLine, CallColumn,
                                 CallDiscriminator);

--- a/llvm/tools/llvm-objdump/SourcePrinter.cpp
+++ b/llvm/tools/llvm-objdump/SourcePrinter.cpp
@@ -263,12 +263,13 @@ unsigned LiveElementPrinter::getOrCreateColumn(unsigned ElementIdx) {
 }
 
 void LiveElementPrinter::freeColumn(unsigned ColIdx) {
+  unsigned ElementIdx = ActiveCols[ColIdx].ElementIdx;
+
   // Clear the column's data.
   ActiveCols[ColIdx].clear();
 
   // Remove the element's entry from the map and add the column to the free
   // list.
-  unsigned ElementIdx = ActiveCols[ColIdx].ElementIdx;
   ElementToColumn.erase(ElementIdx);
   FreeCols.insert(ColIdx);
 }

--- a/llvm/tools/llvm-objdump/SourcePrinter.cpp
+++ b/llvm/tools/llvm-objdump/SourcePrinter.cpp
@@ -126,7 +126,6 @@ void LiveElementPrinter::addInlinedFunction(DWARFDie FuncDie,
       InlinedFuncName, U, FuncDie, InlinedFuncDie, Range));
 
   LiveElement *LE = LiveElements.back().get();
-
   // Map the element's low address (LowPC) to its pointer for fast range start
   // lookup.
   LiveElementsByAddress[FuncLowPC].push_back(LE);
@@ -153,10 +152,9 @@ void LiveElementPrinter::registerNewVariable() {
 
   if (const std::optional<DWARFAddressRange> &RangeOpt =
           CurrentVar->getLocExpr().Range) {
-    const DWARFAddressRange &Range = *RangeOpt;
     // Add the variable to address-based maps.
-    LiveElementsByAddress[Range.LowPC].push_back(CurrentVar);
-    LiveElementsByEndAddress[Range.HighPC].push_back(CurrentVar);
+    LiveElementsByAddress[RangeOpt->LowPC].push_back(CurrentVar);
+    LiveElementsByEndAddress[RangeOpt->HighPC].push_back(CurrentVar);
   }
 }
 

--- a/llvm/tools/llvm-objdump/SourcePrinter.cpp
+++ b/llvm/tools/llvm-objdump/SourcePrinter.cpp
@@ -150,11 +150,11 @@ void LiveElementPrinter::registerNewVariable() {
   // Map from a LiveElement pointer to its index in the LiveElements.
   ElementPtrToIndex[CurrentVar] = LiveElements.size() - 1;
 
-  if (const std::optional<DWARFAddressRange> &RangeOpt =
+  if (const std::optional<DWARFAddressRange> &Range =
           CurrentVar->getLocExpr().Range) {
     // Add the variable to address-based maps.
-    LiveElementsByAddress[RangeOpt->LowPC].push_back(CurrentVar);
-    LiveElementsByEndAddress[RangeOpt->HighPC].push_back(CurrentVar);
+    LiveElementsByAddress[Range->LowPC].push_back(CurrentVar);
+    LiveElementsByEndAddress[Range->HighPC].push_back(CurrentVar);
   }
 }
 

--- a/llvm/tools/llvm-objdump/SourcePrinter.h
+++ b/llvm/tools/llvm-objdump/SourcePrinter.h
@@ -10,6 +10,7 @@
 #define LLVM_TOOLS_LLVM_OBJDUMP_SOURCEPRINTER_H
 
 #include "llvm/ADT/IndexedMap.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/DebugInfo/DWARF/DWARFContext.h"
 #include "llvm/DebugInfo/Symbolize/Symbolize.h"
@@ -101,9 +102,10 @@ class LiveElementPrinter {
   // Vector that owns all LiveElement objects for memory management.
   std::vector<std::unique_ptr<LiveElement>> LiveElements;
   // Map for fast lookup of live elements by their starting address (LowPC).
-  std::unordered_multimap<uint64_t, LiveElement *> LiveElementsByAddress;
+  llvm::MapVector<uint64_t, std::vector<LiveElement *>> LiveElementsByAddress;
   // Map for fast lookup of live elements by their ending address (HighPC).
-  std::unordered_multimap<uint64_t, LiveElement *> LiveElementsByEndAddress;
+  llvm::MapVector<uint64_t, std::vector<LiveElement *>>
+      LiveElementsByEndAddress;
   // Map from a LiveElement pointer to its index in the LiveElements vector.
   std::unordered_map<LiveElement *, unsigned> ElementPtrToIndex;
   // Map from a live element index to column index for efficient lookup.

--- a/llvm/tools/llvm-objdump/SourcePrinter.h
+++ b/llvm/tools/llvm-objdump/SourcePrinter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_TOOLS_LLVM_OBJDUMP_SOURCEPRINTER_H
 #define LLVM_TOOLS_LLVM_OBJDUMP_SOURCEPRINTER_H
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IndexedMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/StringSet.h"
@@ -107,9 +108,9 @@ class LiveElementPrinter {
   llvm::MapVector<uint64_t, std::vector<LiveElement *>>
       LiveElementsByEndAddress;
   // Map from a LiveElement pointer to its index in the LiveElements vector.
-  std::unordered_map<LiveElement *, unsigned> ElementPtrToIndex;
+  llvm::DenseMap<LiveElement *, unsigned> ElementPtrToIndex;
   // Map from a live element index to column index for efficient lookup.
-  std::unordered_map<unsigned, unsigned> ElementToColumn;
+  llvm::DenseMap<unsigned, unsigned> ElementToColumn;
   // Vector of columns currently used for printing live ranges.
   std::vector<Column> ActiveCols;
   // Set of available column indices kept sorted for efficient reuse.
@@ -119,6 +120,8 @@ class LiveElementPrinter {
 
   const MCRegisterInfo &MRI;
   const MCSubtargetInfo &STI;
+
+  void registerNewVariable();
 
   void addInlinedFunction(DWARFDie FuncDie, DWARFDie InlinedFuncDie);
   void addVariable(DWARFDie FuncDie, DWARFDie VarDie);
@@ -143,7 +146,7 @@ class LiveElementPrinter {
   void freeColumn(unsigned ColIdx);
 
   // Returns the indices of all currently active elements, sorted by their DWARF
-  // discovery order (ElementIdx).
+  // discovery order.
   std::vector<unsigned> getSortedActiveElementIndices() const;
 
 public:
@@ -192,10 +195,9 @@ public:
   /// Print the live element ranges to the right of a disassembled instruction.
   void printAfterInst(formatted_raw_ostream &OS);
 
-  /// Print a line to idenfity the start of a live element.
-  void printStartLine(formatted_raw_ostream &OS, object::SectionedAddress Addr);
-  /// Print a line to idenfity the end of a live element.
-  void printEndLine(formatted_raw_ostream &OS, object::SectionedAddress Addr);
+  /// Print a line to idenfity the start/end of a live element.
+  void printBoundaryLine(formatted_raw_ostream &OS,
+                         object::SectionedAddress Addr, bool IsEnd);
 };
 
 class SourcePrinter {

--- a/llvm/tools/llvm-objdump/SourcePrinter.h
+++ b/llvm/tools/llvm-objdump/SourcePrinter.h
@@ -18,6 +18,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/FormattedStream.h"
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -98,6 +99,14 @@ class LiveElementPrinter {
 
     static constexpr unsigned NullElementIdx =
         std::numeric_limits<unsigned>::max();
+
+    // Clear the column's data.
+    void clear() {
+      ElementIdx = NullElementIdx;
+      LiveIn = false;
+      LiveOut = false;
+      MustDrawLabel = false;
+    }
   };
 
   // Vector that owns all LiveElement objects for memory management.

--- a/llvm/tools/llvm-objdump/llvm-objdump.cpp
+++ b/llvm/tools/llvm-objdump/llvm-objdump.cpp
@@ -688,7 +688,7 @@ public:
             LiveElementPrinter &LEP) {
     if (SP && (PrintSource || PrintLines))
       SP->printSourceLine(OS, Address, ObjectFilename, LEP);
-    LEP.printStartLine(OS, Address);
+    LEP.printBoundaryLine(OS, Address, false);
     LEP.printBetweenInsts(OS, false);
 
     printRawData(Bytes, Address.Address, OS, STI);
@@ -935,7 +935,7 @@ public:
                  LiveElementPrinter &LEP) override {
     if (SP && (PrintSource || PrintLines))
       SP->printSourceLine(OS, Address, ObjectFilename, LEP);
-    LEP.printStartLine(OS, Address);
+    LEP.printBoundaryLine(OS, Address, false);
     LEP.printBetweenInsts(OS, false);
 
     size_t Start = OS.tell();
@@ -990,7 +990,7 @@ public:
                  LiveElementPrinter &LEP) override {
     if (SP && (PrintSource || PrintLines))
       SP->printSourceLine(OS, Address, ObjectFilename, LEP);
-    LEP.printStartLine(OS, Address);
+    LEP.printBoundaryLine(OS, Address, false);
     LEP.printBetweenInsts(OS, false);
 
     size_t Start = OS.tell();
@@ -1029,7 +1029,7 @@ public:
                  LiveElementPrinter &LEP) override {
     if (SP && (PrintSource || PrintLines))
       SP->printSourceLine(OS, Address, ObjectFilename, LEP);
-    LEP.printStartLine(OS, Address);
+    LEP.printBoundaryLine(OS, Address, false);
     LEP.printBetweenInsts(OS, false);
 
     size_t Start = OS.tell();
@@ -2593,7 +2593,7 @@ disassembleObject(ObjectFile &Obj, const ObjectFile &DbgObj,
 
         object::SectionedAddress NextAddr = {
             SectionAddr + Index + VMAAdjustment + Size, Section.getIndex()};
-        LEP.printEndLine(FOS, NextAddr);
+        LEP.printBoundaryLine(FOS, NextAddr, true);
 
         Index += Size;
       }


### PR DESCRIPTION
This patch significantly optimizes the LiveElementPrinter
by replacing a slow linear search with efficient hash map
lookups. It refactors the code to use a map-based system
for tracking live element addresses and managing column
assignments, leading to a major performance improvement
for large binaries.