### PR TITLE
[libcxx][modules] Fix missing includes for windows

### DIFF
--- a/libcxx/include/__new/align_val_t.h
+++ b/libcxx/include/__new/align_val_t.h
@@ -16,6 +16,12 @@
 #  pragma GCC system_header
 #endif
 
+// <vcruntime_exception.h> defines its own std::align_val_t type,
+// which we use in order to be ABI-compatible with other STLs on Windows.
+#if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && defined(_LIBCPP_ABI_VCRUNTIME)
+#  include <vcruntime_new.h>
+#endif
+
 _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 #if _LIBCPP_HAS_LIBRARY_ALIGNED_ALLOCATION && !defined(_LIBCPP_ABI_VCRUNTIME)
 #  ifndef _LIBCPP_CXX03_LANG

--- a/libcxx/include/__new/exceptions.h
+++ b/libcxx/include/__new/exceptions.h
@@ -17,6 +17,12 @@
 #  pragma GCC system_header
 #endif
 
+// <vcruntime_exception.h> defines its own std::bad_alloc type,
+// which we use in order to be ABI-compatible with other STLs on Windows.
+#if defined(_LIBCPP_ABI_VCRUNTIME)
+#  include <vcruntime_exception.h>
+#endif
+
 _LIBCPP_BEGIN_UNVERSIONED_NAMESPACE_STD
 #if !defined(_LIBCPP_ABI_VCRUNTIME)
 


### PR DESCRIPTION
Previously, I was getting the following error when attempting to compile libc++ on windows with modules enabled.

```
While building module 'std':
In file included from <module-includes>:1:
In file included from gen/third_party/libc++/src/include/algorithm:1865:
In file included from gen/third_party/libc++/src/include/__algorithm/inplace_merge.h:28:
In file included from gen/third_party/libc++/src/include/__memory/unique_temporary_buffer.h:17:
In file included from gen/third_party/libc++/src/include/__memory/allocator.h:19:
gen/third_party/libc++/src/include/__new/allocate.h(40,73): error: 
      declaration of 'align_val_t' must be imported from module
      'sys_stage1.sysroot_vcruntime_new_h' before it is required
   40 |     return static_cast<_Tp*>(__builtin_operator_new(__size, static_cast<align_val...
      |                                                                         ^
../../third_party/depot_tools/win_toolchain/vs_files/e4305f407e/VC/Tools/MSVC/14.44.35207/include/vcruntime_new.h(27,33): note: 
      declaration here is not visible
   27 |     _VCRT_EXPORT_STD enum class align_val_t : size_t {};
      |                                 ^
```