### PR TITLE
[AST] Simplify TypeIsArrayType (NFC)

### DIFF
--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -9092,9 +9092,7 @@ inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &PD,
 
 // Helper class template that is used by Type::getAs to ensure that one does
 // not try to look through a qualified type to get to an array type.
-template <typename T>
-using TypeIsArrayType = std::bool_constant<std::is_same_v<T, ArrayType> ||
-                                           std::is_base_of_v<ArrayType, T>>;
+template <typename T> using TypeIsArrayType = std::is_base_of<ArrayType, T>;
 
 // Member-template getAs<specific type>'.
 template <typename T> const T *Type::getAs() const {

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -9093,9 +9093,8 @@ inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &PD,
 // Helper class template that is used by Type::getAs to ensure that one does
 // not try to look through a qualified type to get to an array type.
 template <typename T>
-using TypeIsArrayType =
-    std::integral_constant<bool, std::is_same<T, ArrayType>::value ||
-                                     std::is_base_of<ArrayType, T>::value>;
+using TypeIsArrayType = std::bool_constant<std::is_same_v<T, ArrayType> ||
+                                           std::is_base_of_v<ArrayType, T>>;
 
 // Member-template getAs<specific type>'.
 template <typename T> const T *Type::getAs() const {


### PR DESCRIPTION
This patch simplifies replaces TypeIsArrayType.  If
std::is_same<ArrayType, ArrayType> is true, then
std::is_base_of<ArrayType, ArrayType> must also be true, so
std::is_base_of<ArrayType, ArrayType> alone is sufficient.
