### PR TITLE
[Support] Remove offsetof in AMDHSAKernelDescriptor.h

### DIFF
--- a/llvm/include/llvm/Support/AMDHSAKernelDescriptor.h
+++ b/llvm/include/llvm/Support/AMDHSAKernelDescriptor.h
@@ -25,11 +25,6 @@
 #include <cstddef>
 #include <cstdint>
 
-// Gets offset of specified member in specified type.
-#ifndef offsetof
-#define offsetof(TYPE, MEMBER) ((size_t)&((TYPE*)0)->MEMBER)
-#endif // offsetof
-
 // Creates enumeration entries used for packing bits into integers. Enumeration
 // entries include bit shift amount, bit width, and bit mask.
 #ifndef AMDHSA_BITS_ENUM_ENTRY


### PR DESCRIPTION
This patch removes offsetof.  Note that we already include <cstddef>
and that <cstddef> defines offsetof.
