### PR TITLE
[flang][OpenMP] Fix failure reported on #155992

### DIFF
--- a/flang/test/Transforms/DoConcurrent/host_eval.f90
+++ b/flang/test/Transforms/DoConcurrent/host_eval.f90
@@ -1,3 +1,5 @@
+! REQUIRES: amdgpu-registered-target
+
 ! Tests `host_eval` clause code-gen and loop nest bounds on host vs. device.
 
 ! RUN: %flang_fc1 -emit-hlfir -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa   \


### PR DESCRIPTION
Adds a requirement on a test to run only when amd gpu is a registered target. We need to do this since the test uses `-triple amdgcn-amd-amdhsa` when invoking flang.