### PR TITLE
[MLIR] Move the `mlir-generate-reproducer` option to be a PassManager option instead of mlir-opt

### DIFF
--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -237,10 +237,7 @@ public:
     return hasFilters;
   }
 
-  /// Reproducer file generation (no crash required).
-  StringRef getReproducerFilename() const { return generateReproducerFileFlag; }
-
-  /// Set the reproducer output filename
+  /// Set the remarks output filename
   RemarkFormat getRemarkFormat() const { return remarkFormatFlag; }
   /// Set the remark format to use.
   std::string getRemarksAllFilter() const { return remarksAllFilterFlag; }
@@ -340,9 +337,6 @@ protected:
 
   /// Verify that the input IR round-trips perfectly.
   bool verifyRoundtripFlag = false;
-
-  /// The reproducer output filename (no crash required).
-  std::string generateReproducerFileFlag = "";
 };
 
 /// This defines the function type used to setup the pass manager. This can be

--- a/mlir/lib/Pass/Pass.cpp
+++ b/mlir/lib/Pass/Pass.cpp
@@ -1033,6 +1033,14 @@ LogicalResult PassManager::run(Operation *op) {
        << size() << " passes, verifyPasses=" << verifyPasses << " pipeline: ";
     printAsTextualPipeline(os, /*pretty=*/false);
   });
+  // Generate reproducers if requested
+  if (forceGenerateReproducer) {
+    StringRef anchorName = getAnyOpAnchorName();
+    const auto &passes = getPasses();
+    makeReproducer(anchorName, passes, op, forceGenerateReproducer,
+                   /*disableThreads=*/!getContext()->isMultithreadingEnabled(),
+                   verifyPasses);
+  }
 
   MLIRContext *context = getContext();
   std::optional<OperationName> anchorOp = getOpName(*context);

--- a/mlir/lib/Pass/PassCrashRecovery.cpp
+++ b/mlir/lib/Pass/PassCrashRecovery.cpp
@@ -427,8 +427,8 @@ LogicalResult PassManager::runWithCrashRecovery(Operation *op,
   return passManagerResult;
 }
 
-static ReproducerStreamFactory
-makeReproducerStreamFactory(StringRef outputFile) {
+ReproducerStreamFactory
+mlir::makeReproducerStreamFactory(StringRef outputFile) {
   // Capture the filename by value in case outputFile is out of scope when
   // invoked.
   std::string filename = outputFile.str();
@@ -453,13 +453,22 @@ std::string mlir::makeReproducer(
     const llvm::iterator_range<OpPassManager::pass_iterator> &passes,
     Operation *op, StringRef outputFile, bool disableThreads,
     bool verifyPasses) {
+  return makeReproducer(anchorName, passes, op,
+                        makeReproducerStreamFactory(outputFile), disableThreads,
+                        verifyPasses);
+}
 
+std::string mlir::makeReproducer(
+    StringRef anchorName,
+    const llvm::iterator_range<OpPassManager::pass_iterator> &passes,
+    Operation *op, const ReproducerStreamFactory &streamFactory,
+    bool disableThreads, bool verifyPasses) {
   std::string description;
   std::string pipelineStr;
   llvm::raw_string_ostream passOS(pipelineStr);
   ::printAsTextualPipeline(passOS, anchorName, passes);
-  appendReproducer(description, op, makeReproducerStreamFactory(outputFile),
-                   pipelineStr, disableThreads, verifyPasses);
+  appendReproducer(description, op, streamFactory, pipelineStr, disableThreads,
+                   verifyPasses);
   return description;
 }
 

--- a/mlir/lib/Pass/PassManagerOptions.cpp
+++ b/mlir/lib/Pass/PassManagerOptions.cpp
@@ -63,6 +63,11 @@ struct PassManagerOptions {
       llvm::cl::desc("When printing the IR before/after a pass, print file "
                      "tree rooted at this directory. Use in conjunction with "
                      "mlir-print-ir-* flags")};
+  llvm::cl::opt<std::string> generateReproducerFile{
+      "mlir-generate-reproducer",
+      llvm::cl::desc("Generate an mlir reproducer at the provided filename"
+                     " (no crash required)"),
+      llvm::cl::init(""), llvm::cl::value_desc("filename")};
 
   /// Add an IR printing instrumentation if enabled by any 'print-ir' flags.
   void addPrinterInstrumentation(PassManager &pm);
@@ -172,6 +177,9 @@ LogicalResult mlir::applyPassManagerCLOptions(PassManager &pm) {
 
   // Add the IR printing instrumentation.
   options->addPrinterInstrumentation(pm);
+
+  if (options->generateReproducerFile.getNumOccurrences())
+    pm.enableGeneratePassManagerReproducer(options->generateReproducerFile);
   return success();
 }
 

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -198,15 +198,6 @@ struct MlirOptMainConfigCLOptions : public MlirOptMainConfig {
     static cl::list<std::string> passPlugins(
         "load-pass-plugin", cl::desc("Load passes from plugin library"));
 
-    static cl::opt<std::string, /*ExternalStorage=*/true>
-        generateReproducerFile(
-            "mlir-generate-reproducer",
-            llvm::cl::desc(
-                "Generate an mlir reproducer at the provided filename"
-                " (no crash required)"),
-            cl::location(generateReproducerFileFlag), cl::init(""),
-            cl::value_desc("filename"));
-
     static cl::OptionCategory remarkCategory(
         "Remark Options",
         "Filter remarks by regular expression (llvm::Regex syntax).");
@@ -567,14 +558,6 @@ performActions(raw_ostream &os,
   // Run the pipeline.
   if (failed(pm.run(*op)))
     return failure();
-
-  // Generate reproducers if requested
-  if (!config.getReproducerFilename().empty()) {
-    StringRef anchorName = pm.getAnyOpAnchorName();
-    const auto &passes = pm.getPasses();
-    makeReproducer(anchorName, passes, op.get(),
-                   config.getReproducerFilename());
-  }
 
   // Print the output.
   TimingScope outputTiming = timing.nest("Output");


### PR DESCRIPTION
This makes it available to compilers in general, not limited to mlir-opt-like tools.