### PR TITLE
[CMake] Disable more noisy GCC warnings

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -911,6 +911,22 @@ if (LLVM_ENABLE_WARNINGS AND (LLVM_COMPILER_IS_GCC_COMPATIBLE OR CLANG_CL))
     endif()
   endif()
 
+  # Disable -Warray-bounds on GCC; this warning exists since a very long time,
+  # but since GCC 11, it produces a lot of very noisy, seemingly false positive
+  # warnings (potentially originating in libstdc++).
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    append("-Wno-array-bounds" CMAKE_CXX_FLAGS)
+  endif()
+
+  # Disable -Wstringop-overread on GCC; this warning produces a number of very
+  # noisy diagnostics when -Warray-bounds is disabled above; this option exists
+  # since GCC 11.
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.1)
+      append("-Wno-stringop-overread" CMAKE_CXX_FLAGS)
+    endif()
+  endif()
+
   # The LLVM libraries have no stable C++ API, so -Wnoexcept-type is not useful.
   append("-Wno-noexcept-type" CMAKE_CXX_FLAGS)
 


### PR DESCRIPTION
This disables the following very noisy warning:

    In file included from /usr/include/c++/13/string:51,
                     from /usr/include/c++/13/bits/locale_classes.h:40,
                     from /usr/include/c++/13/bits/ios_base.h:41,
                     from /usr/include/c++/13/streambuf:43,
                     from /usr/include/c++/13/bits/streambuf_iterator.h:35,
                     from /usr/include/c++/13/iterator:66,
                     from ../include/llvm/ADT/ADL.h:13,
                     from ../include/llvm/ADT/DenseMap.h:17,
                     from ../lib/Transforms/Vectorize/VPlanAnalysis.h:12,
                     from ../lib/Transforms/Vectorize/VPlan.h:27,
                     from ../lib/Transforms/Vectorize/LoopVectorizationPlanner.h:27,                 from ../lib/Transforms/Vectorize/VPlanConstruction.cpp:14:
    In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = llvm::VPBlockBase*; _Up = llvm::VPBlockBase*; bool _IsMove = true]’,
        inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
        inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
        inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
        inlined from ‘_OI std::move(_II, _II, _OI) [with _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:665:38,
        inlined from ‘llvm::SmallVectorImpl<T>& llvm::SmallVectorImpl<T>::operator=(llvm::SmallVectorImpl<T>&&) [with T = llvm::VPBlockBase*]’ at ../include/llvm/ADT/SmallVector.h:1071:25,
        inlined from ‘llvm::SmallVector<T, N>& llvm::SmallVector<T, N>::operator=(llvm::SmallVector<T, N>&&) [with T = llvm::VPBlockBase*; unsigned int N = 1]’ at ../include/llvm/ADT/SmallVector.h:1259:36,
        inlined from ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’ at ../include/llvm/Support/GenericDomTreeConstruction.h:578:14:
    /usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 24 is out of the bounds [0, 24] of object ‘<anonymous>’ with type ‘llvm::DomTreeBuilder::SemiNCAInfo<llvm::DominatorTreeBase<llvm::VPBlockBase, false> >::RootsT’ {aka ‘llvm::SmallVector<llvm::VPBlockBase*, 1>’} [-Warray-bounds=]
      437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
          |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from ../lib/Transforms/Vectorize/VPlanDominatorTree.h:23,
                     from ../lib/Transforms/Vectorize/VPlanConstruction.cpp:17:
    ../include/llvm/Support/GenericDomTreeConstruction.h: In static member function ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’:
    ../include/llvm/Support/GenericDomTreeConstruction.h:578:25: note: ‘<anonymous>’ declared here
      578 |     DT.Roots = FindRoots(DT, PostViewBUI);
          |                ~~~~~~~~~^~~~~~~~~~~~~~~~~
    In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = llvm::VPBlockBase*; _Up = llvm::VPBlockBase*; bool _IsMove = true]’,
        inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
        inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
        inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
        inlined from ‘_OI std::move(_II, _II, _OI) [with _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:665:38,
        inlined from ‘llvm::SmallVectorImpl<T>& llvm::SmallVectorImpl<T>::operator=(llvm::SmallVectorImpl<T>&&) [with T = llvm::VPBlockBase*]’ at ../include/llvm/ADT/SmallVector.h:1094:14,
        inlined from ‘llvm::SmallVector<T, N>& llvm::SmallVector<T, N>::operator=(llvm::SmallVector<T, N>&&) [with T = llvm::VPBlockBase*; unsigned int N = 1]’ at ../include/llvm/ADT/SmallVector.h:1259:36,
        inlined from ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’ at ../include/llvm/Support/GenericDomTreeConstruction.h:578:14:
    /usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 24 is out of the bounds [0, 24] of object ‘<anonymous>’ with type ‘llvm::DomTreeBuilder::SemiNCAInfo<llvm::DominatorTreeBase<llvm::VPBlockBase, false> >::RootsT’ {aka ‘llvm::SmallVector<llvm::VPBlockBase*, 1>’} [-Warray-bounds=]
      437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
          |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../include/llvm/Support/GenericDomTreeConstruction.h: In static member function ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’:
    ../include/llvm/Support/GenericDomTreeConstruction.h:578:25: note: ‘<anonymous>’ declared here
      578 |     DT.Roots = FindRoots(DT, PostViewBUI);
          |                ~~~~~~~~~^~~~~~~~~~~~~~~~~

In a regular build, there's currently 14 such warning instances, but since they are so large and noisy, they are very disruptive, and they don't seem to be an actual issue in the LLVM code base.

With the -Warray-bounds warning disabled, the build instead ends up with 9 similar warnings of the kind -Wstringop-overread:

    In file included from /usr/include/c++/13/string:51,
                     from /usr/include/c++/13/bits/locale_classes.h:40,
                     from /usr/include/c++/13/bits/ios_base.h:41,
                     from /usr/include/c++/13/streambuf:43,
                     from /usr/include/c++/13/bits/streambuf_iterator.h:35,
                     from /usr/include/c++/13/iterator:66,
                     from ../include/llvm/ADT/ADL.h:13,
                     from ../include/llvm/ADT/DenseMap.h:17,
                     from ../lib/Transforms/Vectorize/VPlanAnalysis.h:12,
                     from ../lib/Transforms/Vectorize/VPlan.h:27,
                     from ../lib/Transforms/Vectorize/LoopVectorizationPlanner.h:27,                 from ../lib/Transforms/Vectorize/VPlanConstruction.cpp:14:
    In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = llvm::VPBlockBase*; _Up = llvm::VPBlockBase*; bool _IsMove = true]’,
        inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
        inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
        inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
        inlined from ‘_OI std::move(_II, _II, _OI) [with _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:665:38,
        inlined from ‘llvm::SmallVectorImpl<T>& llvm::SmallVectorImpl<T>::operator=(llvm::SmallVectorImpl<T>&&) [with T = llvm::VPBlockBase*]’ at ../include/llvm/ADT/SmallVector.h:1071:25,
        inlined from ‘llvm::SmallVector<T, N>& llvm::SmallVector<T, N>::operator=(llvm::SmallVector<T, N>&&) [with T = llvm::VPBlockBase*; unsigned int N = 1]’ at ../include/llvm/ADT/SmallVector.h:1259:36,
        inlined from ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’ at ../include/llvm/Support/GenericDomTreeConstruction.h:578:14:
    /usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ reading between 9 and 34359738360 bytes from a region of size 8 [-Wstringop-overread]
      437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
          |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from ../lib/Transforms/Vectorize/VPlanDominatorTree.h:23,
                     from ../lib/Transforms/Vectorize/VPlanConstruction.cpp:17:
    ../include/llvm/Support/GenericDomTreeConstruction.h: In static member function ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’:
    ../include/llvm/Support/GenericDomTreeConstruction.h:578:25: note: at offset 16 into source object ‘<anonymous>’ of size 24
      578 |     DT.Roots = FindRoots(DT, PostViewBUI);
          |                ~~~~~~~~~^~~~~~~~~~~~~~~~~
    In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = llvm::VPBlockBase*; _Up = llvm::VPBlockBase*; bool _IsMove = true]’,
        inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
        inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
        inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = true; _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
        inlined from ‘_OI std::move(_II, _II, _OI) [with _II = llvm::VPBlockBase**; _OI = llvm::VPBlockBase**]’ at /usr/include/c++/13/bits/stl_algobase.h:665:38,
        inlined from ‘llvm::SmallVectorImpl<T>& llvm::SmallVectorImpl<T>::operator=(llvm::SmallVectorImpl<T>&&) [with T = llvm::VPBlockBase*]’ at ../include/llvm/ADT/SmallVector.h:1094:14,
        inlined from ‘llvm::SmallVector<T, N>& llvm::SmallVector<T, N>::operator=(llvm::SmallVector<T, N>&&) [with T = llvm::VPBlockBase*; unsigned int N = 1]’ at ../include/llvm/ADT/SmallVector.h:1259:36,
        inlined from ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’ at ../include/llvm/Support/GenericDomTreeConstruction.h:578:14:
    /usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ reading between 9 and 34359738352 bytes from a region of size 8 [-Wstringop-overread]
      437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
          |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../include/llvm/Support/GenericDomTreeConstruction.h: In static member function ‘static void llvm::DomTreeBuilder::SemiNCAInfo<DomTreeT>::CalculateFromScratch(DomTreeT&, BatchUpdatePtr) [with DomTreeT = llvm::DominatorTreeBase<llvm::VPBlockBase, false>]’:
    ../include/llvm/Support/GenericDomTreeConstruction.h:578:25: note: at offset 16 into source object ‘<anonymous>’ of size 24
      578 |     DT.Roots = FindRoots(DT, PostViewBUI);
          |                ~~~~~~~~~^~~~~~~~~~~~~~~~~

Disable both of these, as they are extremely spammy and seem to alert on things that aren't an issue in LLVM.