### PR TITLE
Make NoopStatistic constructor constexpr (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/Statistic.h
+++ b/llvm/include/llvm/ADT/Statistic.h
@@ -131,8 +131,8 @@ protected:
 
 class NoopStatistic {
 public:
-  NoopStatistic(const char * /*DebugType*/, const char * /*Name*/,
-                const char * /*Desc*/) {}
+  constexpr NoopStatistic(const char * /*DebugType*/, const char * /*Name*/,
+                          const char * /*Desc*/) {}
 
   uint64_t getValue() const { return 0; }
 


### PR DESCRIPTION
This makes it friendly to -Wglobal-constructors environments. This class is used when Statistics are disabled, the matching class, TrackingStatistic, was made constexpr a while back already in 7e5682ee6201c for other reasons.