### PR TITLE
[OpenMP] Document how to specify flags to device libraries

### DIFF
--- a/openmp/device/CMakeLists.txt
+++ b/openmp/device/CMakeLists.txt
@@ -36,6 +36,13 @@ list(APPEND compile_options -Wno-unknown-cuda-version)
 if(LLVM_DEFAULT_TARGET_TRIPLE)
   list(APPEND compile_options --target=${LLVM_DEFAULT_TARGET_TRIPLE})
 endif()
+# Ensure that CPU-related parameters won't be brought in.
+string(REGEX REPLACE "-mcpu[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-march[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-mtune[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-mbranch-protection[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REGEX REPLACE "-fcf-protection[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+list(APPEND compile_options -Wno-unused-command-line-argument)
 
 # We disable the slp vectorizer during the runtime optimization to avoid
 # vectorized accesses to the shared state. Generally, those are "good" but

--- a/openmp/device/CMakeLists.txt
+++ b/openmp/device/CMakeLists.txt
@@ -36,13 +36,6 @@ list(APPEND compile_options -Wno-unknown-cuda-version)
 if(LLVM_DEFAULT_TARGET_TRIPLE)
   list(APPEND compile_options --target=${LLVM_DEFAULT_TARGET_TRIPLE})
 endif()
-# Ensure that CPU-related parameters won't be brought in.
-string(REGEX REPLACE "-mcpu[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string(REGEX REPLACE "-march[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string(REGEX REPLACE "-mtune[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string(REGEX REPLACE "-mbranch-protection[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string(REGEX REPLACE "-fcf-protection[^ \t\r\n]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-list(APPEND compile_options -Wno-unused-command-line-argument)
 
 # We disable the slp vectorizer during the runtime optimization to avoid
 # vectorized accesses to the shared state. Generally, those are "good" but

--- a/openmp/docs/SupportAndFAQ.rst
+++ b/openmp/docs/SupportAndFAQ.rst
@@ -82,8 +82,10 @@ Support for the device library comes from a separate build of the OpenMP library
 that targets the GPU architecture. Building it requires enabling the runtime
 targets, or setting the target manually when doing a standalone build. This is
 done with the ``LLVM_RUNTIME_TARGETS`` option and then enabling the OpenMP
-runtime for the GPU target. ``RUNTIMES_<triple>_LLVM_ENABLE_RUNTIMES``. Refer to
-the cache file for the specific invocation.
+runtime for the GPU target via ``RUNTIMES_<triple>_LLVM_ENABLE_RUNTIMES``.
+It's possible to set different flags for each device library by using
+``RUNTIMES_<triple>_CMAKE_CXX_FLAGS``. Refer to the cache file for the specific
+invocation.
 
 For Nvidia offload, please see :ref:`build_nvidia_offload_capable_compiler`.
 For AMDGPU offload, please see :ref:`build_amdgpu_offload_capable_compiler`.


### PR DESCRIPTION
Add an explanation on how to use RUNTIMES_<triple>_CMAKE_CXX_FLAGS in
order to specify different compiler flags for OpenMP device libraries.