### PR TITLE
[DebugInfo] Fix memory leak in DebugSSAUpdater

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
+++ b/llvm/include/llvm/Transforms/Utils/DebugSSAUpdater.h
@@ -235,6 +235,11 @@ public:
   DebugSSAUpdater(const DebugSSAUpdater &) = delete;
   DebugSSAUpdater &operator=(const DebugSSAUpdater &) = delete;
 
+  ~DebugSSAUpdater() {
+    for (auto &Block : BlockMap)
+      delete Block.second;
+  }
+
   void reset() {
     for (auto &Block : BlockMap)
       delete Block.second;


### PR DESCRIPTION
Fixes an issue in commit 3946c50, PR #135349.

The DebugSSAUpdater class performs raw pointer allocations. It frees these properly in reset(), but does not do so in its destructor - as an immediate fix, this patch adds a destructor which frees the allocations correctly.

I'll be merging this immediately to fix the issue, but will be open to post-commit review and/or producing a better fix in a follow-up commit.