### PR TITLE
[CAS] Disable OnDiskCAS build on Solaris

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -879,10 +879,10 @@ option (LLVM_ENABLE_OCAMLDOC "Build OCaml bindings documentation." ON)
 option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 option (LLVM_ENABLE_TELEMETRY "Enable the telemetry library. If set to OFF, library cannot be enabled after build (eg., at runtime)" ON)
 
-set(LLVM_ENABLE_ONDISK_CAS_default OFF)
-if(CMAKE_SIZEOF_VOID_P GREATER_EQUAL 8)
-  # Build OnDiskCAS by default only on 64 bit machine.
-  set(LLVM_ENABLE_ONDISK_CAS_default ON)
+set(LLVM_ENABLE_ONDISK_CAS_default ON)
+if(CMAKE_SIZEOF_VOID_P LESS 8 OR "${CMAKE_SYSTEM_NAME}" MATCHES SunOS)
+  # Build OnDiskCAS by default only on 64 bit machine that is not Solaris.
+  set(LLVM_ENABLE_ONDISK_CAS_default OFF)
 endif()
 option(LLVM_ENABLE_ONDISK_CAS "Build OnDiskCAS." ${LLVM_ENABLE_ONDISK_CAS_default})
 


### PR DESCRIPTION
OnDiskCAS implementation receives error `No record locks available`
on Solaris. Disable building on Solaris for now to fix buildbot failure.
