### PR TITLE
[llvm][test][NFCI] Use absolute build path instead of a relative path

### DIFF
--- a/llvm/test/Other/codegen-plugin-loading.ll
+++ b/llvm/test/Other/codegen-plugin-loading.ll
@@ -1,4 +1,4 @@
-; RUN: llc -load %llvmshlibdir/../unittests/CodeGen/CGPluginTest/CGTestPlugin%pluginext %s -o - | FileCheck %s
+; RUN: llc -load %llvm_obj_root/unittests/CodeGen/CGPluginTest/CGTestPlugin%pluginext %s -o - | FileCheck %s
 ; REQUIRES: native, system-linux, llvm-dylib
 
 ; CHECK: CodeGen Test Pass running on main

--- a/llvm/unittests/CodeGen/CGPluginTest/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CGPluginTest/CMakeLists.txt
@@ -4,7 +4,6 @@ set(LLVM_LINK_COMPONENTS
   Core
   MC
   Target
-  TargetParser
   CodeGen
   )
 

--- a/llvm/unittests/CodeGen/CGPluginTest/Plugin/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CGPluginTest/Plugin/CMakeLists.txt
@@ -3,15 +3,12 @@ if (NOT WIN32 AND NOT CYGWIN)
   add_llvm_library(CGTestPlugin MODULE BUILDTREE_ONLY
     CodeGenTestPass.cpp
     Plugin.cpp
+
+    DEPENDS
+    intrinsics_gen
+    vt_gen
     )
 
-  # Put PLUGIN next to the unit test executable.
-  set_output_directory(CGTestPlugin
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-    LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/../
-    )
   set_target_properties(CGTestPlugin PROPERTIES FOLDER "Tests")
-
-  add_dependencies(CGTestPlugin intrinsics_gen vt_gen)
   add_dependencies(CGPluginTest CGTestPlugin)
 endif ()

--- a/llvm/unittests/CodeGen/CGPluginTest/PluginTest.cpp
+++ b/llvm/unittests/CodeGen/CGPluginTest/PluginTest.cpp
@@ -25,20 +25,6 @@
 
 using namespace llvm;
 
-namespace {
-void anchor() {}
-
-std::string libPath(const std::string &Name) {
-  const auto &Argvs = testing::internal::GetArgvs();
-  const char *Argv0 = Argvs.size() > 0 ? Argvs[0].c_str() : "CGPluginTest";
-  void *Ptr = (void *)(intptr_t)anchor;
-  std::string Path = sys::fs::getMainExecutable(Argv0, Ptr);
-  SmallString<256> Buf{sys::path::parent_path(Path)};
-  sys::path::append(Buf, (Name + LLVM_PLUGIN_EXT).c_str());
-  return std::string(Buf.str());
-}
-} // namespace
-
 namespace llvm {
 class CGPluginTests : public testing::Test {
 protected:
@@ -56,8 +42,7 @@ TEST_F(CGPluginTests, LoadPlugin) {
   GTEST_SKIP();
 #endif
 
-  auto PluginPath = libPath("CGTestPlugin");
-  ASSERT_NE("", PluginPath);
+  auto PluginPath{std::string{"CGTestPlugin"} + LLVM_PLUGIN_EXT};
 
   std::string Error;
   auto Library = sys::DynamicLibrary::getLibrary(PluginPath.c_str(), &Error);


### PR DESCRIPTION
Scoping to the root build directory instead of using the path directly is awkward and the only such occurrence in the test suite. Pass the appropriate substitution instead for this.

**Background**
In my downstream `%llvmshlibdir` is much more nested so the single `../` is insufficient.  
But we can use a much more direct substitution rather than a round-about way, which is both cleaner and avoids me needing to patch this test.