### PR TITLE
[DTLTO][TEST] XFAIL Clang driver tests for Multicall toolchains

### DIFF
--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -1,5 +1,8 @@
 // REQUIRES: lld
 
+/// https://github.com/llvm/llvm-project/issues/159125.
+// XFAIL: llvm-driver
+
 /// Check DTLTO options are forwarded to the linker.
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
@@ -10,7 +13,7 @@
 
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{[^"]+}}"
+// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"

--- a/clang/test/Driver/DTLTO/ps5-dtlto.c
+++ b/clang/test/Driver/DTLTO/ps5-dtlto.c
@@ -1,5 +1,8 @@
 // REQUIRES: lld
 
+/// https://github.com/llvm/llvm-project/issues/159125.
+// XFAIL: llvm-driver
+
 /// Check DTLTO options are forwarded to the linker.
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
@@ -10,7 +13,7 @@
 
 // FORWARD: prospero-lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{[^"]+}}"
+// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"


### PR DESCRIPTION
Previously I masked issues with Multicall + DTLTO (see #148908) due to an incomplete understanding of how the Multicall toolchain works.

This patch reverts those incorrect changes and instead marks the affected tests XFAIL when running under Multicall.

Issue #159125 tracks fixing DTLTO with Multicall.