### PR TITLE
Add IWYU export pragma to Type.h

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -19,7 +19,7 @@
 
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
-#include "clang/AST/TypeBase.h"
+#include "clang/AST/TypeBase.h" // IWYU pragma: export
 
 namespace clang {
 


### PR DESCRIPTION
According to 249167a8982afc3f55237baf1532c5c8ebd850b3, users are expected to include Type.h, which acts as a facade header for TypeBase.h.

Add an IWYU export pragma to help IWYU reason about the relationship.