### PR TITLE
[DTLTO][TEST] Get the DTLTO Clang driver tests failing on some buildbots to pass

### DIFF
--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -35,7 +35,7 @@
 
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
-// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
+// DEFAULT-SAME: "--thinlto-remote-compiler={{[^"]+}}"
 
 /// Check that nothing is forwarded when the compiler is not in LTO mode, and that
 /// appropriate unused option warnings are issued.

--- a/clang/test/Driver/DTLTO/ps5-dtlto.c
+++ b/clang/test/Driver/DTLTO/ps5-dtlto.c
@@ -35,7 +35,7 @@
 
 // DEFAULT: prospero-lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
-// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}clang{{[^\"]*}}"
+// DEFAULT-SAME: "--thinlto-remote-compiler={{[^"]+}}"
 
 /// Check that the arguments are forwarded unconditionally even when the
 /// compiler is not in LTO mode.


### PR DESCRIPTION
Make the test regexes more permissive to fix buildbot failures caused by the merge of PR https://github.com/llvm/llvm-project/pull/159129. This is the same fix as applied in: https://github.com/llvm/llvm-project/pull/148908. We retain cross-platform-test coverage to check that the path content is correct.

In a subsequent commit I will make the tests more robust, perhaps along the lines of:  PR #159151.

This is a short term fix to get the build bot green without having to revert a trail of commits.