### PR TITLE
Re-apply "[NFCI][Globals] In GlobalObjects::setSectionPrefix, do conditional update if existing prefix is not equivalent to the new one. Returns whether prefix changed."

### DIFF
--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -125,7 +125,8 @@ public:
   /// the section prefix metadata will be cleared if it exists.
   LLVM_ABI void setSectionPrefix(StringRef Prefix);
 
-  /// If \p Prefix is different from existing prefix, update section prefix.
+  /// If \p Prefix is different from existing prefix, update section prefix;
+  /// if \p Prefix is empty, an update clears the existing metadata.
   /// Returns true if an update happens and false otherwise.
   LLVM_ABI bool updateSectionPrefix(StringRef Prefix);
 

--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -121,8 +121,13 @@ public:
   /// appropriate default object file section.
   LLVM_ABI void setSection(StringRef S);
 
-  /// Set the section prefix for this global object.
+  /// Set the section prefix for this global object. If \p Prefix is empty,
+  /// the section prefix metadata will be cleared if it exists.
   LLVM_ABI void setSectionPrefix(StringRef Prefix);
+
+  /// If \p Prefix is different from existing prefix, update section prefix.
+  /// Returns true if an update happens and false otherwise.
+  LLVM_ABI bool updateSectionPrefix(StringRef Prefix);
 
   /// Get the section prefix for this global object.
   LLVM_ABI std::optional<StringRef> getSectionPrefix() const;

--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -121,9 +121,9 @@ public:
   /// appropriate default object file section.
   LLVM_ABI void setSection(StringRef S);
 
-  /// If existing prefix is different from \p Prefix is different, set it to
-  /// \p Prefix. If \p Prefix is empty, the set clears the existing metadata.
-  /// Returns true if section prefix changed and false otherwise.
+  /// If existing prefix is different from \p Prefix, set it to \p Prefix. If \p
+  /// Prefix is empty, the set clears the existing metadata. Returns true if
+  /// section prefix changed and false otherwise.
   LLVM_ABI bool setSectionPrefix(StringRef Prefix);
 
   /// Get the section prefix for this global object.

--- a/llvm/include/llvm/IR/GlobalObject.h
+++ b/llvm/include/llvm/IR/GlobalObject.h
@@ -121,14 +121,10 @@ public:
   /// appropriate default object file section.
   LLVM_ABI void setSection(StringRef S);
 
-  /// Set the section prefix for this global object. If \p Prefix is empty,
-  /// the section prefix metadata will be cleared if it exists.
-  LLVM_ABI void setSectionPrefix(StringRef Prefix);
-
-  /// If \p Prefix is different from existing prefix, update section prefix;
-  /// if \p Prefix is empty, an update clears the existing metadata.
-  /// Returns true if an update happens and false otherwise.
-  LLVM_ABI bool updateSectionPrefix(StringRef Prefix);
+  /// If existing prefix is different from \p Prefix is different, set it to
+  /// \p Prefix. If \p Prefix is empty, the set clears the existing metadata.
+  /// Returns true if section prefix changed and false otherwise.
+  LLVM_ABI bool setSectionPrefix(StringRef Prefix);
 
   /// Get the section prefix for this global object.
   LLVM_ABI std::optional<StringRef> getSectionPrefix() const;

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -583,23 +583,23 @@ bool CodeGenPrepare::_run(Function &F) {
   // if requested.
   if (BBSectionsGuidedSectionPrefix && BBSectionsProfileReader &&
       BBSectionsProfileReader->isFunctionHot(F.getName())) {
-    F.setSectionPrefix("hot");
+    EverMadeChange |= F.setSectionPrefix("hot");
   } else if (ProfileGuidedSectionPrefix) {
     // The hot attribute overwrites profile count based hotness while profile
     // counts based hotness overwrite the cold attribute.
     // This is a conservative behabvior.
     if (F.hasFnAttribute(Attribute::Hot) ||
         PSI->isFunctionHotInCallGraph(&F, *BFI))
-      F.setSectionPrefix("hot");
+      EverMadeChange |= F.setSectionPrefix("hot");
     // If PSI shows this function is not hot, we will placed the function
     // into unlikely section if (1) PSI shows this is a cold function, or
     // (2) the function has a attribute of cold.
     else if (PSI->isFunctionColdInCallGraph(&F, *BFI) ||
              F.hasFnAttribute(Attribute::Cold))
-      F.setSectionPrefix("unlikely");
+      EverMadeChange |= F.setSectionPrefix("unlikely");
     else if (ProfileUnknownInSpecialSection && PSI->hasPartialSampleProfile() &&
              PSI->isFunctionHotnessUnknown(F))
-      F.setSectionPrefix("unknown");
+      EverMadeChange |= F.setSectionPrefix("unknown");
   }
 
   /// This optimization identifies DIV instructions that can be

--- a/llvm/lib/CodeGen/CodeGenPrepare.cpp
+++ b/llvm/lib/CodeGen/CodeGenPrepare.cpp
@@ -583,23 +583,23 @@ bool CodeGenPrepare::_run(Function &F) {
   // if requested.
   if (BBSectionsGuidedSectionPrefix && BBSectionsProfileReader &&
       BBSectionsProfileReader->isFunctionHot(F.getName())) {
-    EverMadeChange |= F.setSectionPrefix("hot");
+    (void)F.setSectionPrefix("hot");
   } else if (ProfileGuidedSectionPrefix) {
     // The hot attribute overwrites profile count based hotness while profile
     // counts based hotness overwrite the cold attribute.
     // This is a conservative behabvior.
     if (F.hasFnAttribute(Attribute::Hot) ||
         PSI->isFunctionHotInCallGraph(&F, *BFI))
-      EverMadeChange |= F.setSectionPrefix("hot");
+      (void)F.setSectionPrefix("hot");
     // If PSI shows this function is not hot, we will placed the function
     // into unlikely section if (1) PSI shows this is a cold function, or
     // (2) the function has a attribute of cold.
     else if (PSI->isFunctionColdInCallGraph(&F, *BFI) ||
              F.hasFnAttribute(Attribute::Cold))
-      EverMadeChange |= F.setSectionPrefix("unlikely");
+      (void)F.setSectionPrefix("unlikely");
     else if (ProfileUnknownInSpecialSection && PSI->hasPartialSampleProfile() &&
              PSI->isFunctionHotnessUnknown(F))
-      EverMadeChange |= F.setSectionPrefix("unknown");
+      (void)F.setSectionPrefix("unknown");
   }
 
   /// This optimization identifies DIV instructions that can be

--- a/llvm/lib/CodeGen/StaticDataAnnotator.cpp
+++ b/llvm/lib/CodeGen/StaticDataAnnotator.cpp
@@ -91,8 +91,7 @@ bool StaticDataAnnotator::runOnModule(Module &M) {
     if (SectionPrefix.empty())
       continue;
 
-    GV.setSectionPrefix(SectionPrefix);
-    Changed = true;
+    Changed |= GV.setSectionPrefix(SectionPrefix);
   }
 
   return Changed;

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -289,9 +289,26 @@ void GlobalObject::setSection(StringRef S) {
 }
 
 void GlobalObject::setSectionPrefix(StringRef Prefix) {
+  if (Prefix.empty()) {
+    setMetadata(LLVMContext::MD_section_prefix, nullptr);
+    return;
+  }
   MDBuilder MDB(getContext());
   setMetadata(LLVMContext::MD_section_prefix,
               MDB.createGlobalObjectSectionPrefix(Prefix));
+}
+
+bool GlobalObject::updateSectionPrefix(StringRef Prefix) {
+  auto MD = getMetadata(LLVMContext::MD_section_prefix);
+  StringRef ExistingPrefix; // Empty by default.
+  if (MD != nullptr)
+    ExistingPrefix = cast<MDString>(MD->getOperand(1))->getString();
+
+  if (ExistingPrefix != Prefix) {
+    setSectionPrefix(Prefix);
+    return true;
+  }
+  return false;
 }
 
 std::optional<StringRef> GlobalObject::getSectionPrefix() const {

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -288,26 +288,22 @@ void GlobalObject::setSection(StringRef S) {
   setGlobalObjectFlag(HasSectionHashEntryBit, !S.empty());
 }
 
-void GlobalObject::setSectionPrefix(StringRef Prefix) {
-  if (Prefix.empty()) {
-    setMetadata(LLVMContext::MD_section_prefix, nullptr);
-    return;
-  }
-  MDBuilder MDB(getContext());
-  setMetadata(LLVMContext::MD_section_prefix,
-              MDB.createGlobalObjectSectionPrefix(Prefix));
-}
-
-bool GlobalObject::updateSectionPrefix(StringRef Prefix) {
+bool GlobalObject::setSectionPrefix(StringRef Prefix) {
   StringRef ExistingPrefix;
   if (std::optional<StringRef> MaybePrefix = getSectionPrefix())
     ExistingPrefix = *MaybePrefix;
 
-  if (ExistingPrefix != Prefix) {
-    setSectionPrefix(Prefix);
+  if (ExistingPrefix == Prefix)
+    return false;
+
+  if (Prefix.empty()) {
+    setMetadata(LLVMContext::MD_section_prefix, nullptr);
     return true;
   }
-  return false;
+  MDBuilder MDB(getContext());
+  setMetadata(LLVMContext::MD_section_prefix,
+              MDB.createGlobalObjectSectionPrefix(Prefix));
+  return true;
 }
 
 std::optional<StringRef> GlobalObject::getSectionPrefix() const {

--- a/llvm/lib/IR/Globals.cpp
+++ b/llvm/lib/IR/Globals.cpp
@@ -299,10 +299,9 @@ void GlobalObject::setSectionPrefix(StringRef Prefix) {
 }
 
 bool GlobalObject::updateSectionPrefix(StringRef Prefix) {
-  auto MD = getMetadata(LLVMContext::MD_section_prefix);
-  StringRef ExistingPrefix; // Empty by default.
-  if (MD != nullptr)
-    ExistingPrefix = cast<MDString>(MD->getOperand(1))->getString();
+  StringRef ExistingPrefix;
+  if (std::optional<StringRef> MaybePrefix = getSectionPrefix())
+    ExistingPrefix = *MaybePrefix;
 
   if (ExistingPrefix != Prefix) {
     setSectionPrefix(Prefix);

--- a/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
+++ b/llvm/lib/Transforms/Instrumentation/MemProfUse.cpp
@@ -848,13 +848,12 @@ bool MemProfUsePass::annotateGlobalVariables(
     // So we just print out the static data section prefix in LLVM_DEBUG.
     if (Record && Record->AccessCount > 0) {
       ++NumOfMemProfHotGlobalVars;
-      GVar.setSectionPrefix("hot");
-      Changed = true;
+      Changed |= GVar.setSectionPrefix("hot");
       LLVM_DEBUG(dbgs() << "Global variable " << Name
                         << " is annotated as hot\n");
     } else if (DataAccessProf->isKnownColdSymbol(Name)) {
       ++NumOfMemProfColdGlobalVars;
-      GVar.setSectionPrefix("unlikely");
+      Changed |= GVar.setSectionPrefix("unlikely");
       Changed = true;
       LLVM_DEBUG(dbgs() << "Global variable " << Name
                         << " is annotated as unlikely\n");

--- a/llvm/unittests/IR/CMakeLists.txt
+++ b/llvm/unittests/IR/CMakeLists.txt
@@ -28,6 +28,7 @@ add_llvm_unittest(IRTests
   DominatorTreeBatchUpdatesTest.cpp
   DroppedVariableStatsIRTest.cpp
   FunctionTest.cpp
+  GlobalObjectTest.cpp
   PassBuilderCallbacksTest.cpp
   IRBuilderTest.cpp
   InstructionsTest.cpp

--- a/llvm/unittests/IR/GlobalObjectTest.cpp
+++ b/llvm/unittests/IR/GlobalObjectTest.cpp
@@ -48,10 +48,10 @@ TEST_F(GlobalObjectTest, SectionPrefix) {
   ASSERT_NE(Foo, nullptr);
   ASSERT_THAT(Foo->getSectionPrefix(), Optional(StrEq("hot")));
 
-  // No actual update.
-  EXPECT_FALSE(Foo->updateSectionPrefix("hot"));
+  // Test that set method returns false since existing section prefix is hot.
+  EXPECT_FALSE(Foo->setSectionPrefix("hot"));
 
-  // Update prefix from hot to unlikely.
+  // Set prefix from hot to unlikely.
   Foo->setSectionPrefix("unlikely");
   EXPECT_THAT(Foo->getSectionPrefix(), Optional(StrEq("unlikely")));
 
@@ -66,16 +66,15 @@ TEST_F(GlobalObjectTest, SectionPrefix) {
   ASSERT_NE(Bar, nullptr);
   ASSERT_THAT(Bar->getSectionPrefix(), Eq(std::nullopt));
 
-  // Test that update method returns false since Bar doesn't have prefix
-  // metadata.
-  EXPECT_FALSE(Bar->updateSectionPrefix(""));
+  // Test that set method returns false since Bar doesn't have prefix metadata.
+  EXPECT_FALSE(Bar->setSectionPrefix(""));
 
-  // Update from empty to hot.
-  EXPECT_TRUE(Bar->updateSectionPrefix("hot"));
+  // Set from empty to hot.
+  EXPECT_TRUE(Bar->setSectionPrefix("hot"));
   EXPECT_THAT(Bar->getSectionPrefix(), Optional(StrEq("hot")));
 
-  // Teset that update method returns true and section prefix is cleared.
-  EXPECT_TRUE(Bar->updateSectionPrefix(""));
+  // Test that set method returns true and section prefix is cleared.
+  EXPECT_TRUE(Bar->setSectionPrefix(""));
   EXPECT_THAT(Bar->getSectionPrefix(), Eq(std::nullopt));
 }
 } // namespace

--- a/llvm/unittests/IR/GlobalObjectTest.cpp
+++ b/llvm/unittests/IR/GlobalObjectTest.cpp
@@ -66,7 +66,7 @@ TEST_F(GlobalObjectTest, SectionPrefix) {
   ASSERT_NE(Bar, nullptr);
   ASSERT_THAT(Bar->getSectionPrefix(), Eq(std::nullopt));
 
-  // Teset that update method returns false since Bar doesn't have prefix
+  // Test that update method returns false since Bar doesn't have prefix
   // metadata.
   EXPECT_FALSE(Bar->updateSectionPrefix(""));
 

--- a/llvm/unittests/IR/GlobalObjectTest.cpp
+++ b/llvm/unittests/IR/GlobalObjectTest.cpp
@@ -11,11 +11,10 @@
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/SourceMgr.h"
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
 using namespace llvm;
 namespace {
-
 using testing::Eq;
 using testing::Optional;
 using testing::StrEq;
@@ -33,49 +32,45 @@ static std::unique_ptr<Module> M;
 
 class GlobalObjectTest : public testing::Test {
 public:
-static void SetUpTestSuite()  {
-   
+  static void SetUpTestSuite() {
     M = parseIR(C, R"(
 @foo = global i32 3, !section_prefix !0
 @bar = global i32 0
 
 !0 = !{!"section_prefix", !"hot"}
 )");
-
   }
-
 };
 
 TEST_F(GlobalObjectTest, SectionPrefix) {
-    GlobalVariable* Foo = M->getGlobalVariable("foo");
-    
-    // Initial section prefix is hot.
-    ASSERT_NE(Foo, nullptr);
-    ASSERT_THAT(Foo->getSectionPrefix(), Optional(StrEq("hot")));
+  GlobalVariable *Foo = M->getGlobalVariable("foo");
 
-    // No actual update.
-    EXPECT_FALSE(Foo->updateSectionPrefix("hot"));
+  // Initial section prefix is hot.
+  ASSERT_NE(Foo, nullptr);
+  ASSERT_THAT(Foo->getSectionPrefix(), Optional(StrEq("hot")));
 
-    // Update prefix from hot to unlikely.
-    Foo->setSectionPrefix("unlikely");
-    EXPECT_THAT(Foo->getSectionPrefix(), Optional(StrEq("unlikely")));
-    
-    // Update prefix to empty is the same as clear.
-    Foo->setSectionPrefix("");
-    EXPECT_THAT(Foo->getSectionPrefix(), Eq(std::nullopt));
+  // No actual update.
+  EXPECT_FALSE(Foo->updateSectionPrefix("hot"));
 
-    GlobalVariable* Bar = M->getGlobalVariable("bar");
+  // Update prefix from hot to unlikely.
+  Foo->setSectionPrefix("unlikely");
+  EXPECT_THAT(Foo->getSectionPrefix(), Optional(StrEq("unlikely")));
 
-    // Initial section prefix is empty.
-    ASSERT_NE(Bar, nullptr);
-    ASSERT_THAT(Bar->getSectionPrefix(),  Eq(std::nullopt));
- 
-    // No actual update.
-    EXPECT_FALSE(Bar->updateSectionPrefix(""));
+  // Update prefix to empty is the same as clear.
+  Foo->setSectionPrefix("");
+  EXPECT_THAT(Foo->getSectionPrefix(), Eq(std::nullopt));
 
-    // Update from empty to hot.
-    EXPECT_TRUE(Bar->updateSectionPrefix("hot"));
-    EXPECT_THAT(Bar->getSectionPrefix(), Optional(StrEq("hot")));
+  GlobalVariable *Bar = M->getGlobalVariable("bar");
+
+  // Initial section prefix is empty.
+  ASSERT_NE(Bar, nullptr);
+  ASSERT_THAT(Bar->getSectionPrefix(), Eq(std::nullopt));
+
+  // No actual update.
+  EXPECT_FALSE(Bar->updateSectionPrefix(""));
+
+  // Update from empty to hot.
+  EXPECT_TRUE(Bar->updateSectionPrefix("hot"));
+  EXPECT_THAT(Bar->getSectionPrefix(), Optional(StrEq("hot")));
 }
-
 } // namespace

--- a/llvm/unittests/IR/GlobalObjectTest.cpp
+++ b/llvm/unittests/IR/GlobalObjectTest.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/GlobalObject.h"
-#include "llvm-c/Core.h"
 #include "llvm/AsmParser/Parser.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/SourceMgr.h"
@@ -56,8 +55,9 @@ TEST_F(GlobalObjectTest, SectionPrefix) {
   Foo->setSectionPrefix("unlikely");
   EXPECT_THAT(Foo->getSectionPrefix(), Optional(StrEq("unlikely")));
 
-  // Update prefix to empty is the same as clear.
+  // Set prefix to empty is the same as clear.
   Foo->setSectionPrefix("");
+  // Test that section prefix is cleared.
   EXPECT_THAT(Foo->getSectionPrefix(), Eq(std::nullopt));
 
   GlobalVariable *Bar = M->getGlobalVariable("bar");
@@ -66,11 +66,16 @@ TEST_F(GlobalObjectTest, SectionPrefix) {
   ASSERT_NE(Bar, nullptr);
   ASSERT_THAT(Bar->getSectionPrefix(), Eq(std::nullopt));
 
-  // No actual update.
+  // Teset that update method returns false since Bar doesn't have prefix
+  // metadata.
   EXPECT_FALSE(Bar->updateSectionPrefix(""));
 
   // Update from empty to hot.
   EXPECT_TRUE(Bar->updateSectionPrefix("hot"));
   EXPECT_THAT(Bar->getSectionPrefix(), Optional(StrEq("hot")));
+
+  // Teset that update method returns true and section prefix is cleared.
+  EXPECT_TRUE(Bar->updateSectionPrefix(""));
+  EXPECT_THAT(Bar->getSectionPrefix(), Eq(std::nullopt));
 }
 } // namespace

--- a/llvm/unittests/IR/GlobalObjectTest.cpp
+++ b/llvm/unittests/IR/GlobalObjectTest.cpp
@@ -1,0 +1,81 @@
+//===- GlobalObjectTest.cpp - Global object unit tests --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/GlobalObject.h"
+#include "llvm-c/Core.h"
+#include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/SourceMgr.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+using namespace llvm;
+namespace {
+
+using testing::Eq;
+using testing::Optional;
+using testing::StrEq;
+
+static std::unique_ptr<Module> parseIR(LLVMContext &C, const char *IR) {
+  SMDiagnostic Err;
+  std::unique_ptr<Module> Mod = parseAssemblyString(IR, Err, C);
+  if (!Mod)
+    Err.print("GlobalObjectTests", errs());
+  return Mod;
+}
+
+static LLVMContext C;
+static std::unique_ptr<Module> M;
+
+class GlobalObjectTest : public testing::Test {
+public:
+static void SetUpTestSuite()  {
+   
+    M = parseIR(C, R"(
+@foo = global i32 3, !section_prefix !0
+@bar = global i32 0
+
+!0 = !{!"section_prefix", !"hot"}
+)");
+
+  }
+
+};
+
+TEST_F(GlobalObjectTest, SectionPrefix) {
+    GlobalVariable* Foo = M->getGlobalVariable("foo");
+    
+    // Initial section prefix is hot.
+    ASSERT_NE(Foo, nullptr);
+    ASSERT_THAT(Foo->getSectionPrefix(), Optional(StrEq("hot")));
+
+    // No actual update.
+    EXPECT_FALSE(Foo->updateSectionPrefix("hot"));
+
+    // Update prefix from hot to unlikely.
+    Foo->setSectionPrefix("unlikely");
+    EXPECT_THAT(Foo->getSectionPrefix(), Optional(StrEq("unlikely")));
+    
+    // Update prefix to empty is the same as clear.
+    Foo->setSectionPrefix("");
+    EXPECT_THAT(Foo->getSectionPrefix(), Eq(std::nullopt));
+
+    GlobalVariable* Bar = M->getGlobalVariable("bar");
+
+    // Initial section prefix is empty.
+    ASSERT_NE(Bar, nullptr);
+    ASSERT_THAT(Bar->getSectionPrefix(),  Eq(std::nullopt));
+ 
+    // No actual update.
+    EXPECT_FALSE(Bar->updateSectionPrefix(""));
+
+    // Update from empty to hot.
+    EXPECT_TRUE(Bar->updateSectionPrefix("hot"));
+    EXPECT_THAT(Bar->getSectionPrefix(), Optional(StrEq("hot")));
+}
+
+} // namespace


### PR DESCRIPTION
This is a reland of https://github.com/llvm/llvm-project/pull/158460

Test failures are gone once I undo the changes in codegenprepare.