### PR TITLE
[clang][analyzer] Load config through the proper VFS

### DIFF
--- a/clang/lib/StaticAnalyzer/Checkers/Yaml.h
+++ b/clang/lib/StaticAnalyzer/Checkers/Yaml.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_CLANG_LIB_STATICANALYZER_CHECKER_YAML_H
 #define LLVM_CLANG_LIB_STATICANALYZER_CHECKER_YAML_H
 
+#include "clang/Basic/SourceManager.h"
 #include "clang/StaticAnalyzer/Core/CheckerManager.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/YAMLTraits.h"
@@ -31,9 +32,12 @@ std::optional<T> getConfiguration(CheckerManager &Mgr, Checker *Chk,
   if (ConfigFile.trim().empty())
     return std::nullopt;
 
-  llvm::vfs::FileSystem *FS = llvm::vfs::getRealFileSystem().get();
+  auto &VFS = Mgr.getASTContext()
+                  .getSourceManager()
+                  .getFileManager()
+                  .getVirtualFileSystem();
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buffer =
-      FS->getBufferForFile(ConfigFile.str());
+      VFS.getBufferForFile(ConfigFile.str());
 
   if (Buffer.getError()) {
     Mgr.reportInvalidCheckerOptionValue(Chk, Option,

--- a/clang/test/Analysis/Inputs/taint-generic-config-vfs.json
+++ b/clang/test/Analysis/Inputs/taint-generic-config-vfs.json
@@ -1,0 +1,17 @@
+{
+  'version': 0,
+  'use-external-names': true,
+  'roots': [
+    {
+      'name': 'DIR',
+      'type': 'directory',
+      'contents': [
+        {
+          'name': 'taint-generic-config-virtual.yaml',
+          'type': 'file',
+          'external-contents': 'DIR/taint-generic-config.yaml'
+        }
+      ]
+    }
+  ]
+}

--- a/clang/test/Analysis/taint-generic.c
+++ b/clang/test/Analysis/taint-generic.c
@@ -1,3 +1,6 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: sed -e "s|DIR|%/S/Inputs|g" %S/Inputs/taint-generic-config-vfs.json > %t/taint-generic-config-vfs.json
+
 // RUN: %clang_analyze_cc1 -Wno-format-security -Wno-pointer-to-int-cast \
 // RUN:   -Wno-incompatible-library-redeclaration -verify %s \
 // RUN:   -analyzer-checker=optin.taint.GenericTaint \
@@ -6,7 +9,8 @@
 // RUN:   -analyzer-checker=security.ArrayBound \
 // RUN:   -analyzer-checker=debug.ExprInspection \
 // RUN:   -analyzer-config \
-// RUN:     optin.taint.TaintPropagation:Config=%S/Inputs/taint-generic-config.yaml
+// RUN:     optin.taint.TaintPropagation:Config=%S/Inputs/taint-generic-config-virtual.yaml \
+// RUN:   -ivfsoverlay %t/taint-generic-config-vfs.json
 
 // RUN: %clang_analyze_cc1 -Wno-format-security -Wno-pointer-to-int-cast \
 // RUN:   -Wno-incompatible-library-redeclaration -verify %s \


### PR DESCRIPTION
This PR ensures that the Clang static analyzer loads the config file through the properly-configured VFS rather than through the bare real file system. This enables correctly going through VFS overlays, unifying the behavior with the rest of the compiler.