### PR TITLE
[flang][runtime] Fix bug with NAMELIST in child input

### DIFF
--- a/flang-rt/lib/runtime/namelist.cpp
+++ b/flang-rt/lib/runtime/namelist.cpp
@@ -596,6 +596,12 @@ bool IODEF(InputNamelist)(Cookie cookie, const NamelistGroup &group) {
   }
   if (next && *next == '/') {
     io.HandleRelativePosition(byteCount);
+    if (auto *listInput{
+            io.get_if<ListDirectedStatementState<Direction::Input>>()}) {
+      // Don't let the namelist's terminal '/' mess up a parent I/O's
+      // list-directed input.
+      listInput->set_hitSlash(false);
+    }
   } else if (*next && (*next == '&' || *next == '$')) {
     // stop at beginning of next group
   } else {


### PR DESCRIPTION
Don't let "hitSlash_" flag in child input propagate back to the parent input statement's state when the child input was NAMELIST and the NAMELIST input has properly consumed the terminal '/' character.  (It can get set if NAMELIST item input ran into it.) The current failure to reset that flag is causing list-directed parent input to stop early.

Fixes https://github.com/llvm/llvm-project/issues/159127.
Fixes #154843. 