### PR TITLE
[llvm][mustache] Precommit tests for Triple Mustache

### DIFF
--- a/llvm/unittests/Support/MustacheTest.cpp
+++ b/llvm/unittests/Support/MustacheTest.cpp
@@ -1224,3 +1224,97 @@ TEST(MustacheComments, VariableNameCollision) {
   T.render(D, OS);
   EXPECT_EQ("comments never show: ><", Out);
 }
+
+// XFAIL: The following tests for the Triple Mustache feature are expected to
+// fail. The assertions have been inverted from EXPECT_EQ to EXPECT_NE to allow
+// them to pass against the current implementation. Once Triple Mustache is
+// implemented, these assertions should be changed back to EXPECT_EQ.
+TEST(MustacheTripleMustache, Basic) {
+  Value D = Object{{"subject", "<b>World</b>"}};
+  auto T = Template("Hello, {{{subject}}}!");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("Hello, <b>World</b>!", Out);
+}
+
+TEST(MustacheTripleMustache, IntegerInterpolation) {
+  Value D = Object{{"mph", 85}};
+  auto T = Template("{{{mph}}} miles an hour!");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("85 miles an hour!", Out);
+}
+
+TEST(MustacheTripleMustache, DecimalInterpolation) {
+  Value D = Object{{"power", 1.21}};
+  auto T = Template("{{{power}}} jiggawatts!");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("1.21 jiggawatts!", Out);
+}
+
+TEST(MustacheTripleMustache, NullInterpolation) {
+  Value D = Object{{"cannot", nullptr}};
+  auto T = Template("I ({{{cannot}}}) be seen!");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("I () be seen!", Out);
+}
+
+TEST(MustacheTripleMustache, ContextMissInterpolation) {
+  Value D = Object{};
+  auto T = Template("I ({{{cannot}}}) be seen!");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("I () be seen!", Out);
+}
+
+TEST(MustacheTripleMustache, DottedNames) {
+  Value D = Object{{"person", Object{{"name", "<b>Joe</b>"}}}};
+  auto T = Template("{{{person.name}}}");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("<b>Joe</b>", Out);
+}
+
+TEST(MustacheTripleMustache, ImplicitIterator) {
+  Value D = Object{{"list", Array{"<a>", "<b>"}}};
+  auto T = Template("{{#list}}({{{.}}}){{/list}}");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("(<a>)(<b>)", Out);
+}
+
+TEST(MustacheTripleMustache, SurroundingWhitespace) {
+  Value D = Object{{"string", "---"}};
+  auto T = Template("| {{{string}}} |");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("| --- |", Out);
+}
+
+TEST(MustacheTripleMustache, Standalone) {
+  Value D = Object{{"string", "---"}};
+  auto T = Template("  {{{string}}}\n");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("  ---\n", Out);
+}
+
+TEST(MustacheTripleMustache, WithPadding) {
+  Value D = Object{{"string", "---"}};
+  auto T = Template("|{{{ string }}}|");
+  std::string Out;
+  raw_string_ostream OS(Out);
+  T.render(D, OS);
+  EXPECT_NE("|---|", Out);
+}


### PR DESCRIPTION
Add XFAIL tests for Triple Mustache following the official spec. The
tests pass by virtue of using EXPECT_NE, since GTEST doesn't support
XFAIL.