### PR TITLE
[LLVM] Fix dangling access to aliasee in stripAndAccumulateConstantOf…

### DIFF
--- a/llvm/lib/IR/Value.cpp
+++ b/llvm/lib/IR/Value.cpp
@@ -776,7 +776,7 @@ const Value *Value::stripAndAccumulateConstantOffsets(
                Operator::getOpcode(V) == Instruction::AddrSpaceCast) {
       V = cast<Operator>(V)->getOperand(0);
     } else if (auto *GA = dyn_cast<GlobalAlias>(V)) {
-      if (!GA->isInterposable())
+      if (!GA->isInterposable() && GA->getAliasee())
         V = GA->getAliasee();
     } else if (const auto *Call = dyn_cast<CallBase>(V)) {
         if (const Value *RV = Call->getReturnedArgOperand())


### PR DESCRIPTION
…fsets

Make sure LLVM bails when aliasee aren't present. Found while using `mlir-translate --mlir-to-llvm`.  Added unittest exercises the builder using a target folder, this is the original IR triggering the issue:

```
@m2 = internal alias { [1 x i64] }, ptr @k0
@k0 = private constant {{ [1 x i64] }} {
  { [1 x i64] }
    {
      [1 x i64]
        [
         i64 ptrtoint (ptr getelementptr inbounds ({ [1 x i64] },
                       ptr @m2, i32 0, i32 0, i32 1) to i64)
        ]
    }
  }, align 4
```