### PR TITLE
llvm-mca: Error on MCSubtargetInfo construction failure

### DIFF
--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -413,7 +413,11 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TheTriple, MCPU, FeaturesStr));
-  assert(STI && "Unable to create subtarget info!");
+  if (!STI) {
+    WithColor::error() << "unable to create subtarget info\n";
+    return 1;
+  }
+
   if (!STI->isCPUStringValid(MCPU))
     return 1;
 

--- a/llvm/tools/llvm-mca/llvm-mca.cpp
+++ b/llvm/tools/llvm-mca/llvm-mca.cpp
@@ -83,9 +83,9 @@ static cl::opt<std::string>
              cl::cat(ToolOptions));
 
 static cl::opt<std::string>
-    TripleName("mtriple",
-               cl::desc("Target triple. See -version for available targets"),
-               cl::cat(ToolOptions));
+    TripleNameOpt("mtriple",
+                  cl::desc("Target triple. See -version for available targets"),
+                  cl::cat(ToolOptions));
 
 static cl::opt<std::string>
     MCPU("mcpu",
@@ -292,11 +292,7 @@ static cl::opt<bool> DisableInstrumentManager(
 
 namespace {
 
-const Target *getTarget(const char *ProgName) {
-  if (TripleName.empty())
-    TripleName = Triple::normalize(sys::getDefaultTargetTriple());
-  Triple TheTriple(TripleName);
-
+const Target *getTarget(Triple &TheTriple, const char *ProgName) {
   // Get the target specific parser.
   std::string Error;
   const Target *TheTarget =
@@ -305,9 +301,6 @@ const Target *getTarget(const char *ProgName) {
     errs() << ProgName << ": " << Error;
     return nullptr;
   }
-
-  // Update TripleName with the updated triple from the target lookup.
-  TripleName = TheTriple.str();
 
   // Return the found target.
   return TheTarget;
@@ -387,17 +380,17 @@ int main(int argc, char **argv) {
   cl::ParseCommandLineOptions(argc, argv,
                               "llvm machine code performance analyzer.\n");
 
+  Triple TheTriple(TripleNameOpt.empty()
+                       ? Triple::normalize(sys::getDefaultTargetTriple())
+                       : TripleNameOpt);
+
   // Get the target from the triple. If a triple is not specified, then select
   // the default triple for the host. If the triple doesn't correspond to any
   // registered target, then exit with an error message.
   const char *ProgName = argv[0];
-  const Target *TheTarget = getTarget(ProgName);
+  const Target *TheTarget = getTarget(TheTriple, ProgName);
   if (!TheTarget)
     return 1;
-
-  // GetTarget() may replaced TripleName with a default triple.
-  // For safety, reconstruct the Triple object.
-  Triple TheTriple(TripleName);
 
   ErrorOr<std::unique_ptr<MemoryBuffer>> BufferPtr =
       MemoryBuffer::getFileOrSTDIN(InputFilename);
@@ -469,7 +462,7 @@ int main(int argc, char **argv) {
   unsigned IPtempOutputAsmVariant =
       OutputAsmVariant == -1 ? 0 : OutputAsmVariant;
   std::unique_ptr<MCInstPrinter> IPtemp(TheTarget->createMCInstPrinter(
-      Triple(TripleName), IPtempOutputAsmVariant, *MAI, *MCII, *MRI));
+      TheTriple, IPtempOutputAsmVariant, *MAI, *MCII, *MRI));
   if (!IPtemp) {
     WithColor::error()
         << "unable to create instruction printer for target triple '"
@@ -558,7 +551,7 @@ int main(int argc, char **argv) {
   if (OutputAsmVariant >= 0)
     AssemblerDialect = static_cast<unsigned>(OutputAsmVariant);
   std::unique_ptr<MCInstPrinter> IP(TheTarget->createMCInstPrinter(
-      Triple(TripleName), AssemblerDialect, *MAI, *MCII, *MRI));
+      TheTriple, AssemblerDialect, *MAI, *MCII, *MRI));
   if (!IP) {
     WithColor::error()
         << "unable to create instruction printer for target triple '"


### PR DESCRIPTION
Replace assert with a handled error. The same should probably
be done for all of the MC constructors.