### PR TITLE
clang: Emit error if assembler fails to construct subtarget

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -115,6 +115,8 @@ def err_fe_unable_to_load_plugin : Error<
     "unable to load plugin '%0': '%1'">;
 def err_fe_unable_to_create_target : Error<
     "unable to create target: '%0'">;
+def err_fe_unable_to_create_subtarget : Error<
+    "unable to create subtarget: '%0'%select{ with features '%2'|}1">;
 def err_fe_unable_to_interface_with_target : Error<
     "unable to interface with target machine">;
 def err_fe_unable_to_open_output : Error<

--- a/clang/tools/driver/cc1as_main.cpp
+++ b/clang/tools/driver/cc1as_main.cpp
@@ -480,7 +480,10 @@ static bool ExecuteAssemblerImpl(AssemblerInvocation &Opts,
 
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(Opts.Triple, Opts.CPU, FS));
-  assert(STI && "Unable to create subtarget info!");
+  if (!STI) {
+    return Diags.Report(diag::err_fe_unable_to_create_subtarget)
+           << Opts.CPU << FS.empty() << FS;
+  }
 
   MCContext Ctx(Triple(Opts.Triple), MAI.get(), MRI.get(), STI.get(), &SrcMgr,
                 &MCOptions);


### PR DESCRIPTION
We do not have consistent or good error handling of this situation.
Some tools check for errors, some just assert. The backend has no
proper way of reporting an invalid subtarget specification. MCSubtargetInfo
currently does unreasonable things like spam warnings to errs, and then
silently proceed in an invalid state. I have a patch which starts returning
null on some invalid subtargets, but all the tools need to start erroring
cleanly first. I don't think there is a reliable way to test this today. It
would have to be an incomplete backend. Ideally we would thread through
some kind of error context from the target to report the reason it's
an invalid subtarget.