### PR TITLE
llvm-mc: Error on MCSubtargetInfo construction failure

### DIFF
--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -469,7 +469,10 @@ int main(int argc, char **argv) {
 
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(TheTriple, MCPU, FeaturesStr));
-  assert(STI && "Unable to create subtarget info!");
+  if (!STI) {
+    WithColor::error(errs(), ProgName) << "unable to create subtarget info\n";
+    return 1;
+  }
 
   // FIXME: This is not pretty. MCContext has a ptr to MCObjectFileInfo and
   // MCObjectFileInfo needs a MCContext reference in order to initialize itself.


### PR DESCRIPTION
We have inconsistent handling of null returns on target MC constructors. Most tools report an error, but some assert. It's currently not possible to test this with any in-tree targets. Make this a clean error so in the future targets can fail the construction.