### PR TITLE
AMDGPU: Remove subtarget feature hacking in AsmParser

### DIFF
--- a/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
+++ b/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp
@@ -1442,20 +1442,6 @@ public:
       : MCTargetAsmParser(Options, STI, MII), Parser(_Parser) {
     MCAsmParserExtension::Initialize(Parser);
 
-    if (getFeatureBits().none()) {
-      // Set default features.
-      copySTI().ToggleFeature("southern-islands");
-    }
-
-    FeatureBitset FB = getFeatureBits();
-    if (!FB[AMDGPU::FeatureWavefrontSize64] &&
-        !FB[AMDGPU::FeatureWavefrontSize32]) {
-      // If there is no default wave size it must be a generation before gfx10,
-      // these have FeatureWavefrontSize64 in their definition already. For
-      // gfx10+ set wave32 as a default.
-      copySTI().ToggleFeature(AMDGPU::FeatureWavefrontSize32);
-    }
-
     setAvailableFeatures(ComputeAvailableFeatures(getFeatureBits()));
 
     AMDGPU::IsaVersion ISA = AMDGPU::getIsaVersion(getSTI().getCPU());

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp
@@ -83,6 +83,9 @@ createAMDGPUMCSubtargetInfo(const Triple &TT, StringRef CPU, StringRef FS) {
       createAMDGPUMCSubtargetInfoImpl(TT, CPU, /*TuneCPU*/ CPU, FS);
 
   // FIXME: We should error for the default target.
+  if (STI->getFeatureBits().none())
+    STI->ToggleFeature(AMDGPU::FeatureSouthernIslands);
+
   if (!STI->hasFeature(AMDGPU::FeatureWavefrontSize64) &&
       !STI->hasFeature(AMDGPU::FeatureWavefrontSize32)) {
     // If there is no default wave size it must be a generation before gfx10,


### PR DESCRIPTION
The wavesize hacking part was already done in
createAMDGPUMCSubtargetInfo, and we can move the default
target hack there too.