### PR TITLE
docs/ParallelMultiImageFortranRuntime: Update link to latest PRIF Specification

### DIFF
--- a/flang/docs/ParallelMultiImageFortranRuntime.md
+++ b/flang/docs/ParallelMultiImageFortranRuntime.md
@@ -14,5 +14,5 @@ interface designed for LLVM Flang to target implementations of
 Fortran's multi-image parallel features.
 
 The current revision of the PRIF specification is here:
-<https://doi.org/10.25344/S4CG6G>
+<https://doi.org/10.25344/S4M01X>
 


### PR DESCRIPTION
The PRIF Committee is pleased to announce the publication of the Parallel
Runtime Interface for Fortran (PRIF) Specification, Revision 0.6.  The latest
iteration of this specification represents the efforts of a collaborative
design process involving multiple individuals across several institutions.

The document is available here: <https://doi.org/10.25344/S4M01X>

The PRIF specification is now governed by a formal PRIF Committee.
For more details, see: <https://go.lbl.gov/prif-governance>

The Committee vote to approve the technical content in this revision
began on 2025-08-22 and concluded on 2025-09-07 with unanimous approval.

The 7-day Committee comment period for cosmetic feedback began on
2025-09-08 and concluded on 2025-09-15 with no comments.

See the Change Log in Section 1 of the document for the list of changes
relative to the prior revision.