### PR TITLE
[LLD][COFF] Add /nodbgdirmerge to control debug directory section

### DIFF
--- a/lld/COFF/Config.h
+++ b/lld/COFF/Config.h
@@ -322,6 +322,7 @@ struct Configuration {
   bool largeAddressAware = false;
   bool highEntropyVA = false;
   bool appContainer = false;
+  bool mergeDebugDirectory = true;
   bool mingw = false;
   bool warnMissingOrderSymbol = true;
   bool warnLocallyDefinedImported = true;

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2339,7 +2339,7 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       args.hasFlag(OPT_highentropyva, OPT_highentropyva_no, true);
 
   // Handle /nodbgdirmerge
-  config->mergeDebugDirectory = args.hasArg(OPT_nodbgdirmerge);
+  config->mergeDebugDirectory = !args.hasArg(OPT_nodbgdirmerge);
 
   if (!config->dynamicBase &&
       (config->machine == ARMNT || isAnyArm64(config->machine)))

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -2338,6 +2338,9 @@ void LinkerDriver::linkerMain(ArrayRef<const char *> argsArr) {
       config->is64() &&
       args.hasFlag(OPT_highentropyva, OPT_highentropyva_no, true);
 
+  // Handle /nodbgdirmerge
+  config->mergeDebugDirectory = args.hasArg(OPT_nodbgdirmerge);
+
   if (!config->dynamicBase &&
       (config->machine == ARMNT || isAnyArm64(config->machine)))
     Err(ctx) << "/dynamicbase:no is not compatible with "

--- a/lld/COFF/Options.td
+++ b/lld/COFF/Options.td
@@ -90,6 +90,8 @@ def machine : P<"machine", "Specify target platform">;
 def merge   : P<"merge", "Combine sections">;
 def mllvm   : P<"mllvm", "Options to pass to LLVM">;
 def nodefaultlib : P<"nodefaultlib", "Remove a default library">;
+def nodbgdirmerge : F<"nodbgdirmerge">,
+                      HelpText<"Emit the debug directory in a separate section">;
 def opt     : P<"opt", "Control optimizations">;
 def order   : P<"order", "Put functions in order">;
 def out     : P<"out", "Path to file to write output">;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -1232,7 +1232,7 @@ void Writer::createMiscChunks() {
   // Create Debug Information Chunks
   if (config->mingw) {
     debugInfoSec = buildidSec;
-  } else if (config->mergeDebugDirectory) {
+  } else if (!config->mergeDebugDirectory) {
     debugInfoSec = cvinfoSec;
   } else {
     debugInfoSec = rdataSec;

--- a/lld/COFF/Writer.cpp
+++ b/lld/COFF/Writer.cpp
@@ -324,6 +324,7 @@ private:
   OutputSection *bssSec;
   OutputSection *rdataSec;
   OutputSection *buildidSec;
+  OutputSection *cvinfoSec;
   OutputSection *dataSec;
   OutputSection *pdataSec;
   OutputSection *idataSec;
@@ -1092,6 +1093,7 @@ void Writer::createSections() {
   bssSec = createSection(".bss", bss | r | w);
   rdataSec = createSection(".rdata", data | r);
   buildidSec = createSection(".buildid", data | r);
+  cvinfoSec = createSection(".cvinfo", data | r);
   dataSec = createSection(".data", data | r | w);
   pdataSec = createSection(".pdata", data | r);
   idataSec = createSection(".idata", data | r);
@@ -1228,7 +1230,13 @@ void Writer::createMiscChunks() {
   });
 
   // Create Debug Information Chunks
-  debugInfoSec = config->mingw ? buildidSec : rdataSec;
+  if (config->mingw) {
+    debugInfoSec = buildidSec;
+  } else if (config->mergeDebugDirectory) {
+    debugInfoSec = cvinfoSec;
+  } else {
+    debugInfoSec = rdataSec;
+  }
   if (config->buildIDHash != BuildIDHash::None || config->debug ||
       config->repro || config->cetCompat || config->cetCompatStrict ||
       config->cetCompatIpValidationRelaxed ||

--- a/lld/test/COFF/nodbgdirmerge.test
+++ b/lld/test/COFF/nodbgdirmerge.test
@@ -10,19 +10,24 @@ RUN: llvm-readobj --sections %t.dll | FileCheck -check-prefix=CHECKNOTMERGED %s
 
 CHECKNOTMERGED:   Section {
 CHECKNOTMERGED:     Number: 3
-CHECKNOTMERGED:     Name: .cvinfo
-CHECKNOTMERGED:     Characteristics [ (0x40000040)
-CHECKNOTMERGED:       IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
-CHECKNOTMERGED:       IMAGE_SCN_MEM_READ (0x40000000)
-CHECKNOTMERGED:     ]
-CHECKNOTMERGED:   }
+CHECKNOTMERGED-NEXT:     Name: .cvinfo
+CHECKNOTMERGED-NEXT:     VirtualSize: 0x3D
+CHECKNOTMERGED-NEXT:     VirtualAddress: 0x3000
+CHECKNOTMERGED-NEXT:     RawDataSize: 512
+CHECKNOTMERGED-NEXT:     PointerToRawData: 0x800
+CHECKNOTMERGED-NEXT:     PointerToRelocations: 0
+CHECKNOTMERGED-NEXT:     PointerToLineNumbers: 0
+CHECKNOTMERGED-NEXT:     RelocationCount: 0
+CHECKNOTMERGED-NEXT:     LineNumberCount: 0
+CHECKNOTMERGED-NEXT:     Characteristics [ (0x40000040)
+CHECKNOTMERGED-NEXT:       IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+CHECKNOTMERGED-NEXT:       IMAGE_SCN_MEM_READ (0x40000000)
+CHECKNOTMERGED-NEXT:     ]
+CHECKNOTMERGED-NEXT:   }
 
 ## Check that it triggers merge on when /nodbgdirmerge is not specified
 RUN: lld-link /debug /pdb:%t.pdb /pdbaltpath:test.pdb /dll /out:%t.dll \
 RUN:   /entry:main /nodefaultlib %t1.obj %t2.obj
 RUN: llvm-readobj --sections %t.dll | FileCheck -check-prefix=CHECKMERGED %s
 
-CHECKMERGED:   Section {
-CHECKMERGED:     Number: 3
 CHECKMERGED-NOT:     Name: .cvinfo
-CHECKMERGED:   }

--- a/lld/test/COFF/nodbgdirmerge.test
+++ b/lld/test/COFF/nodbgdirmerge.test
@@ -2,7 +2,7 @@ RUN: yaml2obj %p/Inputs/pdb1.yaml -o %t1.obj
 RUN: yaml2obj %p/Inputs/pdb2.yaml -o %t2.obj
 RUN: rm -f %t.dll %t.pdb
 
-## Check that it emits the debug directory in .build section when
+## Check that it emits the debug directory in .cvinfo section when
 ## /nodbgdirmerge is specified
 RUN: lld-link /debug /pdb:%t.pdb /pdbaltpath:test.pdb /dll /out:%t.dll \
 RUN:   /entry:main /nodefaultlib /nodbgdirmerge %t1.obj %t2.obj

--- a/lld/test/COFF/nodbgdirmerge.test
+++ b/lld/test/COFF/nodbgdirmerge.test
@@ -1,0 +1,28 @@
+RUN: yaml2obj %p/Inputs/pdb1.yaml -o %t1.obj
+RUN: yaml2obj %p/Inputs/pdb2.yaml -o %t2.obj
+RUN: rm -f %t.dll %t.pdb
+
+## Check that it emits the debug directory in .build section when
+## /nodbgdirmerge is specified
+RUN: lld-link /debug /pdb:%t.pdb /pdbaltpath:test.pdb /dll /out:%t.dll \
+RUN:   /entry:main /nodefaultlib /nodbgdirmerge %t1.obj %t2.obj
+RUN: llvm-readobj --sections %t.dll | FileCheck -check-prefix=CHECKNOTMERGED %s
+
+CHECKNOTMERGED:   Section {
+CHECKNOTMERGED:     Number: 3
+CHECKNOTMERGED:     Name: .cvinfo
+CHECKNOTMERGED:     Characteristics [ (0x40000040)
+CHECKNOTMERGED:       IMAGE_SCN_CNT_INITIALIZED_DATA (0x40)
+CHECKNOTMERGED:       IMAGE_SCN_MEM_READ (0x40000000)
+CHECKNOTMERGED:     ]
+CHECKNOTMERGED:   }
+
+## Check that it triggers merge on when /nodbgdirmerge is not specified
+RUN: lld-link /debug /pdb:%t.pdb /pdbaltpath:test.pdb /dll /out:%t.dll \
+RUN:   /entry:main /nodefaultlib %t1.obj %t2.obj
+RUN: llvm-readobj --sections %t.dll | FileCheck -check-prefix=CHECKMERGED %s
+
+CHECKMERGED:   Section {
+CHECKMERGED:     Number: 3
+CHECKMERGED-NOT:     Name: .cvinfo
+CHECKMERGED:   }


### PR DESCRIPTION
Resolves #141712.

As described in the issue, this PR adds support for `/nodbgdirmerge` flag in LLD to align with MS link. When the flag is specified, the linker will emit the debug directory section in `.cvinfo` section, instead of merging it to the `.rdata`. The flag will be ignored on MinGW.