### PR TITLE
[ADT] Use std::conditional_t to simplify ilist_select_iterator_type (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/ilist_node.h
+++ b/llvm/include/llvm/ADT/ilist_node.h
@@ -52,14 +52,10 @@ template <class OptionsT> class ilist_sentinel;
 
 // Selector for which iterator type to pick given the iterator-bits node option.
 template <bool use_iterator_bits, typename Opts, bool arg1, bool arg2>
-class ilist_select_iterator_type {
-public:
-  using type = ilist_iterator<Opts, arg1, arg2>;
-};
-template <typename Opts, bool arg1, bool arg2>
-class ilist_select_iterator_type<true, Opts, arg1, arg2> {
-public:
-  using type = ilist_iterator_w_bits<Opts, arg1, arg2>;
+struct ilist_select_iterator_type {
+  using type = std::conditional_t<use_iterator_bits,
+                                  ilist_iterator_w_bits<Opts, arg1, arg2>,
+                                  ilist_iterator<Opts, arg1, arg2>>;
 };
 
 /// Implementation for an ilist node.


### PR DESCRIPTION
Without this patch, ilist_select_iterator_type uses a boolean template
parameter to select one of two types.  This patch converts that to
std::conditional_t, which is simpler than the two-class solution.
