### PR TITLE
[Support] Consolidate has_FlowTraits in YAMLTraits.h (NFC)

### DIFF
--- a/llvm/include/llvm/Support/YAMLTraits.h
+++ b/llvm/include/llvm/Support/YAMLTraits.h
@@ -442,15 +442,8 @@ template <class T> struct has_CustomMappingTraits {
       is_detected<check, CustomMappingTraits<T>>::value;
 };
 
-// has_FlowTraits<int> will cause an error with some compilers because
-// it subclasses int.  Using this wrapper only instantiates the
-// real has_FlowTraits only if the template type is a class.
-template <typename T, bool Enabled = std::is_class_v<T>> class has_FlowTraits {
-public:
-  static constexpr bool value = false;
-};
-
-template <class T> struct has_FlowTraits<T, true> {
+// Test if flow is defined on type T.
+template <typename T> struct has_FlowTraits {
   template <class U> using check = decltype(&U::flow);
 
   static constexpr bool value = is_detected<check, T>::value;


### PR DESCRIPTION
has_FlowTraits has two implementations:

- "class has_FlowTraits" says false on non-class types.
- "struct has_FlowTraits" checks for a "flow" member on class types.

This patch eliminates the former because std::is_class is redundant if
we are checking to see if &U::flow is well formed.  The comment block
being removed in this patch has been around since 2012.  I'd assume
that host compilers have improved since then.  Note that we are now
using is_detected, which wasn't the case back in 2012.
