### PR TITLE
[RISC-V] Add P-ext MC Support for Remaining Pair Operations

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -284,8 +284,8 @@ let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPPairShift_ri<bits<3> f, string opcodestr, Operand ImmType, 
                       bit direction>
     : RVPPairBase<f, 0b0, direction, (outs GPRPairRV32:$rd),
-                       (ins GPRPairRV32:$rs1, ImmType:$shamt), opcodestr,
-                       "$rd, $rs1, $shamt"> {
+                  (ins GPRPairRV32:$rs1, ImmType:$shamt), opcodestr,
+                  "$rd, $rs1, $shamt"> {
   let Inst{31}    = 0b0;
 }
 
@@ -401,7 +401,7 @@ class RVPNarrowingBinary_rr<bits<3> f, bits<2> w, string opcodestr>
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPPairBinary_rr<bits<4> f, bits<2> w, string opcodestr>
-  : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b0, 0b0, opcodestr>;
+    : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b0, 0b0, opcodestr>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPPairBinaryShift_rr<bits<3> f, bits<2> w, string opcodestr>
@@ -1298,160 +1298,160 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PNCLIPR_HS   : RVPNarrowingShift_rr<0b111, 0b01, "pnclipr.hs">;
   def NCLIPR       : RVPNarrowingShift_rr<0b111, 0b11, "nclipr">;
 
-  def PSLLI_DB      : RVPPairShiftB_ri<0b000,  "pslli.db">;
-  def PSLLI_DH      : RVPPairShiftH_ri<0b000, "pslli.dh">;
-  def PSLLI_DW      : RVPPairShiftW_ri<0b000, "pslli.dw">;
+  def PSLLI_DB     : RVPPairShiftB_ri<0b000,  "pslli.db">;
+  def PSLLI_DH     : RVPPairShiftH_ri<0b000, "pslli.dh">;
+  def PSLLI_DW     : RVPPairShiftW_ri<0b000, "pslli.dw">;
 
-  def PSSLAI_DH     : RVPPairShiftH_ri<0b101, "psslai.dh">;
-  def PSSLAI_DW     : RVPPairShiftW_ri<0b101, "psslai.dw">;
+  def PSSLAI_DH    : RVPPairShiftH_ri<0b101, "psslai.dh">;
+  def PSSLAI_DW    : RVPPairShiftW_ri<0b101, "psslai.dw">;
 
-  def PSEXT_DH_B    : RVPPairUnary_r<0b00, 0b00100, "psext.dh.b">;
-  def PSEXT_DW_B    : RVPPairUnary_r<0b01, 0b00100, "psext.dw.b">;
+  def PSEXT_DH_B   : RVPPairUnary_r<0b00, 0b00100, "psext.dh.b">;
+  def PSEXT_DW_B   : RVPPairUnary_r<0b01, 0b00100, "psext.dw.b">;
 
-  def PSEXT_DW_H    : RVPPairUnary_r<0b01, 0b00101, "psext.dw.h">;
+  def PSEXT_DW_H   : RVPPairUnary_r<0b01, 0b00101, "psext.dw.h">;
 
-  def PSABS_DH      : RVPPairUnary_r<0b00, 0b00111, "psabs.dh">;
-  def PSABS_DB      : RVPPairUnary_r<0b10, 0b00111, "psabs.db">;
+  def PSABS_DH     : RVPPairUnary_r<0b00, 0b00111, "psabs.dh">;
+  def PSABS_DB     : RVPPairUnary_r<0b10, 0b00111, "psabs.db">;
 
-  def PSLL_DHS      : RVPPairShift_rr<0b000, 0b00, "psll.dhs">;
-  def PSLL_DWS      : RVPPairShift_rr<0b000, 0b01, "psll.dws">;
-  def PSLL_DBS      : RVPPairShift_rr<0b000, 0b10, "psll.dbs">;
+  def PSLL_DHS     : RVPPairShift_rr<0b000, 0b00, "psll.dhs">;
+  def PSLL_DWS     : RVPPairShift_rr<0b000, 0b01, "psll.dws">;
+  def PSLL_DBS     : RVPPairShift_rr<0b000, 0b10, "psll.dbs">;
 
-  def PADD_DHS      : RVPPairShift_rr<0b001, 0b00, "padd.dhs">;
-  def PADD_DWS      : RVPPairShift_rr<0b001, 0b01, "padd.dws">;
-  def PADD_DBS      : RVPPairShift_rr<0b001, 0b10, "padd.dbs">;
+  def PADD_DHS     : RVPPairShift_rr<0b001, 0b00, "padd.dhs">;
+  def PADD_DWS     : RVPPairShift_rr<0b001, 0b01, "padd.dws">;
+  def PADD_DBS     : RVPPairShift_rr<0b001, 0b10, "padd.dbs">;
 
-  def PSSHA_DHS     : RVPPairShift_rr<0b110, 0b00, "pssha.dhs">;
-  def PSSHA_DWS     : RVPPairShift_rr<0b110, 0b01, "pssha.dws">;
+  def PSSHA_DHS    : RVPPairShift_rr<0b110, 0b00, "pssha.dhs">;
+  def PSSHA_DWS    : RVPPairShift_rr<0b110, 0b01, "pssha.dws">;
 
-  def PSSHAR_DHS    : RVPPairShift_rr<0b111, 0b00, "psshar.dhs">;
-  def PSSHAR_DWS    : RVPPairShift_rr<0b111, 0b01, "psshar.dws">;
+  def PSSHAR_DHS   : RVPPairShift_rr<0b111, 0b00, "psshar.dhs">;
+  def PSSHAR_DWS   : RVPPairShift_rr<0b111, 0b01, "psshar.dws">;
 
-  def PSRLI_DB      : RVPPairShiftB_ri<0b000, "psrli.db",  0b1>;
-  def PSRLI_DH      : RVPPairShiftH_ri<0b000, "psrli.dh",  0b1>;
-  def PSRLI_DW      : RVPPairShiftW_ri<0b000, "psrli.dw",  0b1>;
+  def PSRLI_DB     : RVPPairShiftB_ri<0b000, "psrli.db",  0b1>;
+  def PSRLI_DH     : RVPPairShiftH_ri<0b000, "psrli.dh",  0b1>;
+  def PSRLI_DW     : RVPPairShiftW_ri<0b000, "psrli.dw",  0b1>;
 
-  def PUSATI_DH     : RVPPairShiftH_ri<0b010, "pusati.dh", 0b1>;
-  def PUSATI_DW     : RVPPairShiftW_ri<0b010, "pusati.dw", 0b1>;
+  def PUSATI_DH    : RVPPairShiftH_ri<0b010, "pusati.dh", 0b1>;
+  def PUSATI_DW    : RVPPairShiftW_ri<0b010, "pusati.dw", 0b1>;
 
-  def PSRAI_DB      : RVPPairShiftB_ri<0b100, "psrai.db",  0b1>;
-  def PSRAI_DH      : RVPPairShiftH_ri<0b100, "psrai.dh",  0b1>;
-  def PSRAI_DW      : RVPPairShiftW_ri<0b100, "psrai.dw",  0b1>;
+  def PSRAI_DB     : RVPPairShiftB_ri<0b100, "psrai.db",  0b1>;
+  def PSRAI_DH     : RVPPairShiftH_ri<0b100, "psrai.dh",  0b1>;
+  def PSRAI_DW     : RVPPairShiftW_ri<0b100, "psrai.dw",  0b1>;
 
-  def PSRARI_DH     : RVPPairShiftH_ri<0b101, "psrari.dh", 0b1>;
-  def PSRARI_DW     : RVPPairShiftW_ri<0b101, "psrari.dw", 0b1>;
+  def PSRARI_DH    : RVPPairShiftH_ri<0b101, "psrari.dh", 0b1>;
+  def PSRARI_DW    : RVPPairShiftW_ri<0b101, "psrari.dw", 0b1>;
 
-  def PSATI_DH      : RVPPairShiftH_ri<0b110, "psati.dh",  0b1>;
-  def PSATI_DW      : RVPPairShiftW_ri<0b110, "psati.dw",  0b1>;
+  def PSATI_DH     : RVPPairShiftH_ri<0b110, "psati.dh",  0b1>;
+  def PSATI_DW     : RVPPairShiftW_ri<0b110, "psati.dw",  0b1>;
 
-  def PSRL_DHS      : RVPPairShift_rr<0b000, 0b00, "psrl.dhs", 0b1>;
-  def PSRL_DWS      : RVPPairShift_rr<0b000, 0b01, "psrl.dws", 0b1>;
-  def PSRL_DBS      : RVPPairShift_rr<0b000, 0b10, "psrl.dbs", 0b1>;
+  def PSRL_DHS     : RVPPairShift_rr<0b000, 0b00, "psrl.dhs", 0b1>;
+  def PSRL_DWS     : RVPPairShift_rr<0b000, 0b01, "psrl.dws", 0b1>;
+  def PSRL_DBS     : RVPPairShift_rr<0b000, 0b10, "psrl.dbs", 0b1>;
 
-  def PSRA_DHS      : RVPPairShift_rr<0b100, 0b00, "psra.dhs", 0b1>;
-  def PSRA_DWS      : RVPPairShift_rr<0b100, 0b01, "psra.dws", 0b1>;
-  def PSRA_DBS      : RVPPairShift_rr<0b100, 0b10, "psra.dbs", 0b1>;
+  def PSRA_DHS     : RVPPairShift_rr<0b100, 0b00, "psra.dhs", 0b1>;
+  def PSRA_DWS     : RVPPairShift_rr<0b100, 0b01, "psra.dws", 0b1>;
+  def PSRA_DBS     : RVPPairShift_rr<0b100, 0b10, "psra.dbs", 0b1>;
 
-  def PADD_DH       : RVPPairBinary_rr<0b0000, 0b00, "padd.dh">;
-  def PADD_DW       : RVPPairBinary_rr<0b0000, 0b01, "padd.dw">;
-  def PADD_DB       : RVPPairBinary_rr<0b0000, 0b10, "padd.db">;
-  def ADDD          : RVPPairBinary_rr<0b0000, 0b11, "addd">;
+  def PADD_DH      : RVPPairBinary_rr<0b0000, 0b00, "padd.dh">;
+  def PADD_DW      : RVPPairBinary_rr<0b0000, 0b01, "padd.dw">;
+  def PADD_DB      : RVPPairBinary_rr<0b0000, 0b10, "padd.db">;
+  def ADDD         : RVPPairBinary_rr<0b0000, 0b11, "addd">;
 
-  def PSADD_DH      : RVPPairBinary_rr<0b0010, 0b00, "psadd.dh">;
-  def PSADD_DW      : RVPPairBinary_rr<0b0010, 0b01, "psadd.dw">;
-  def PSADD_DB      : RVPPairBinary_rr<0b0010, 0b10, "psadd.db">;
+  def PSADD_DH     : RVPPairBinary_rr<0b0010, 0b00, "psadd.dh">;
+  def PSADD_DW     : RVPPairBinary_rr<0b0010, 0b01, "psadd.dw">;
+  def PSADD_DB     : RVPPairBinary_rr<0b0010, 0b10, "psadd.db">;
 
-  def PAADD_DH      : RVPPairBinary_rr<0b0011, 0b00, "paadd.dh">;
-  def PAADD_DW      : RVPPairBinary_rr<0b0011, 0b01, "paadd.dw">;
-  def PAADD_DB      : RVPPairBinary_rr<0b0011, 0b10, "paadd.db">;
+  def PAADD_DH     : RVPPairBinary_rr<0b0011, 0b00, "paadd.dh">;
+  def PAADD_DW     : RVPPairBinary_rr<0b0011, 0b01, "paadd.dw">;
+  def PAADD_DB     : RVPPairBinary_rr<0b0011, 0b10, "paadd.db">;
 
-  def PSADDU_DH     : RVPPairBinary_rr<0b0110, 0b00, "psaddu.dh">;
-  def PSADDU_DW     : RVPPairBinary_rr<0b0110, 0b01, "psaddu.dw">;
-  def PSADDU_DB     : RVPPairBinary_rr<0b0110, 0b10, "psaddu.db">;
+  def PSADDU_DH    : RVPPairBinary_rr<0b0110, 0b00, "psaddu.dh">;
+  def PSADDU_DW    : RVPPairBinary_rr<0b0110, 0b01, "psaddu.dw">;
+  def PSADDU_DB    : RVPPairBinary_rr<0b0110, 0b10, "psaddu.db">;
 
-  def PAADDU_DH     : RVPPairBinary_rr<0b0111, 0b00, "paaddu.dh">;
-  def PAADDU_DW     : RVPPairBinary_rr<0b0111, 0b01, "paaddu.dw">;
-  def PAADDU_DB     : RVPPairBinary_rr<0b0111, 0b10, "paaddu.db">;
+  def PAADDU_DH    : RVPPairBinary_rr<0b0111, 0b00, "paaddu.dh">;
+  def PAADDU_DW    : RVPPairBinary_rr<0b0111, 0b01, "paaddu.dw">;
+  def PAADDU_DB    : RVPPairBinary_rr<0b0111, 0b10, "paaddu.db">;
 
-  def PSUB_DH       : RVPPairBinary_rr<0b1000, 0b00, "psub.dh">;
-  def PSUB_DW       : RVPPairBinary_rr<0b1000, 0b01, "psub.dw">;
-  def PSUB_DB       : RVPPairBinary_rr<0b1000, 0b10, "psub.db">;
-  def SUBD          : RVPPairBinary_rr<0b1000, 0b11, "subd">;
+  def PSUB_DH      : RVPPairBinary_rr<0b1000, 0b00, "psub.dh">;
+  def PSUB_DW      : RVPPairBinary_rr<0b1000, 0b01, "psub.dw">;
+  def PSUB_DB      : RVPPairBinary_rr<0b1000, 0b10, "psub.db">;
+  def SUBD         : RVPPairBinary_rr<0b1000, 0b11, "subd">;
 
-  def PDIF_DH       : RVPPairBinary_rr<0b1001, 0b00, "pdif.dh">;
-  def PDIF_DB       : RVPPairBinary_rr<0b1001, 0b10, "pdif.db">;
+  def PDIF_DH      : RVPPairBinary_rr<0b1001, 0b00, "pdif.dh">;
+  def PDIF_DB      : RVPPairBinary_rr<0b1001, 0b10, "pdif.db">;
 
-  def PSSUB_DH      : RVPPairBinary_rr<0b1010, 0b00, "pssub.dh">;
-  def PSSUB_DW      : RVPPairBinary_rr<0b1010, 0b01, "pssub.dw">;
-  def PSSUB_DB      : RVPPairBinary_rr<0b1010, 0b10, "pssub.db">;
+  def PSSUB_DH     : RVPPairBinary_rr<0b1010, 0b00, "pssub.dh">;
+  def PSSUB_DW     : RVPPairBinary_rr<0b1010, 0b01, "pssub.dw">;
+  def PSSUB_DB     : RVPPairBinary_rr<0b1010, 0b10, "pssub.db">;
 
-  def PASUB_DH      : RVPPairBinary_rr<0b1011, 0b00, "pasub.dh">;
-  def PASUB_DW      : RVPPairBinary_rr<0b1011, 0b01, "pasub.dw">;
-  def PASUB_DB      : RVPPairBinary_rr<0b1011, 0b10, "pasub.db">;
+  def PASUB_DH     : RVPPairBinary_rr<0b1011, 0b00, "pasub.dh">;
+  def PASUB_DW     : RVPPairBinary_rr<0b1011, 0b01, "pasub.dw">;
+  def PASUB_DB     : RVPPairBinary_rr<0b1011, 0b10, "pasub.db">;
 
-  def PDIFU_DH      : RVPPairBinary_rr<0b1101, 0b00, "pdifu.dh">;
-  def PDIFU_DB      : RVPPairBinary_rr<0b1101, 0b10, "pdifu.db">;
+  def PDIFU_DH     : RVPPairBinary_rr<0b1101, 0b00, "pdifu.dh">;
+  def PDIFU_DB     : RVPPairBinary_rr<0b1101, 0b10, "pdifu.db">;
 
-  def PSSUBU_DH     : RVPPairBinary_rr<0b1110, 0b00, "pssubu.dh">;
-  def PSSUBU_DW     : RVPPairBinary_rr<0b1110, 0b01, "pssubu.dw">;
-  def PSSUBU_DB     : RVPPairBinary_rr<0b1110, 0b10, "pssubu.db">;
+  def PSSUBU_DH    : RVPPairBinary_rr<0b1110, 0b00, "pssubu.dh">;
+  def PSSUBU_DW    : RVPPairBinary_rr<0b1110, 0b01, "pssubu.dw">;
+  def PSSUBU_DB    : RVPPairBinary_rr<0b1110, 0b10, "pssubu.db">;
 
-  def PASUBU_DH     : RVPPairBinary_rr<0b1111, 0b00, "pasubu.dh">;
-  def PASUBU_DW     : RVPPairBinary_rr<0b1111, 0b01, "pasubu.dw">;
-  def PASUBU_DB     : RVPPairBinary_rr<0b1111, 0b10, "pasubu.db">;
+  def PASUBU_DH    : RVPPairBinary_rr<0b1111, 0b00, "pasubu.dh">;
+  def PASUBU_DW    : RVPPairBinary_rr<0b1111, 0b01, "pasubu.dw">;
+  def PASUBU_DB    : RVPPairBinary_rr<0b1111, 0b10, "pasubu.db">;
 
-  def PSH1ADD_DH    : RVPPairBinaryShift_rr<0b010, 0b00, "psh1add.dh">;
-  def PSH1ADD_DW    : RVPPairBinaryShift_rr<0b010, 0b01, "psh1add.dw">;
+  def PSH1ADD_DH   : RVPPairBinaryShift_rr<0b010, 0b00, "psh1add.dh">;
+  def PSH1ADD_DW   : RVPPairBinaryShift_rr<0b010, 0b01, "psh1add.dw">;
 
-  def PSSH1SADD_DH  : RVPPairBinaryShift_rr<0b011, 0b00, "pssh1sadd.dh">;
-  def PSSH1SADD_DW  : RVPPairBinaryShift_rr<0b011, 0b01, "pssh1sadd.dw">;
+  def PSSH1SADD_DH : RVPPairBinaryShift_rr<0b011, 0b00, "pssh1sadd.dh">;
+  def PSSH1SADD_DW : RVPPairBinaryShift_rr<0b011, 0b01, "pssh1sadd.dw">;
 
-  def PPACK_DH      : RVPPairBinaryPack_rr<0b000, 0b00, "ppack.dh">;
-  def PPACK_DW      : RVPPairBinaryPack_rr<0b000, 0b01, "ppack.dw">;
+  def PPACK_DH     : RVPPairBinaryPack_rr<0b000, 0b00, "ppack.dh">;
+  def PPACK_DW     : RVPPairBinaryPack_rr<0b000, 0b01, "ppack.dw">;
 
-  def PPACKBT_DH    : RVPPairBinaryPack_rr<0b001, 0b00, "ppackbt.dh">;
-  def PPACKBT_DW    : RVPPairBinaryPack_rr<0b001, 0b01, "ppackbt.dw">;
+  def PPACKBT_DH   : RVPPairBinaryPack_rr<0b001, 0b00, "ppackbt.dh">;
+  def PPACKBT_DW   : RVPPairBinaryPack_rr<0b001, 0b01, "ppackbt.dw">;
 
-  def PPACKTB_DH    : RVPPairBinaryPack_rr<0b010, 0b00, "ppacktb.dh">;
-  def PPACKTB_DW    : RVPPairBinaryPack_rr<0b010, 0b01, "ppacktb.dw">;
+  def PPACKTB_DH   : RVPPairBinaryPack_rr<0b010, 0b00, "ppacktb.dh">;
+  def PPACKTB_DW   : RVPPairBinaryPack_rr<0b010, 0b01, "ppacktb.dw">;
 
-  def PPACKT_DH     : RVPPairBinaryPack_rr<0b011, 0b00, "ppackt.dh">;
-  def PPACKT_DW     : RVPPairBinaryPack_rr<0b011, 0b01, "ppackt.dw">;
+  def PPACKT_DH    : RVPPairBinaryPack_rr<0b011, 0b00, "ppackt.dh">;
+  def PPACKT_DW    : RVPPairBinaryPack_rr<0b011, 0b01, "ppackt.dw">;
 
-  def PAS_DHX       : RVPPairBinaryExchanged_rr<0b0000, 0b00, "pas.dhx">;
-  def PSA_DHX       : RVPPairBinaryExchanged_rr<0b0000, 0b10, "psa.dhx">;
+  def PAS_DHX      : RVPPairBinaryExchanged_rr<0b0000, 0b00, "pas.dhx">;
+  def PSA_DHX      : RVPPairBinaryExchanged_rr<0b0000, 0b10, "psa.dhx">;
 
-  def PSAS_DHX      : RVPPairBinaryExchanged_rr<0b0010, 0b00, "psas.dhx">;
-  def PSSA_DHX      : RVPPairBinaryExchanged_rr<0b0010, 0b10, "pssa.dhx">;
+  def PSAS_DHX     : RVPPairBinaryExchanged_rr<0b0010, 0b00, "psas.dhx">;
+  def PSSA_DHX     : RVPPairBinaryExchanged_rr<0b0010, 0b10, "pssa.dhx">;
 
-  def PAAX_DHX      : RVPPairBinaryExchanged_rr<0b0011, 0b00, "paax.dhx">;
-  def PASA_DHX      : RVPPairBinaryExchanged_rr<0b0011, 0b10, "pasa.dhx">;
+  def PAAX_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b00, "paax.dhx">;
+  def PASA_DHX     : RVPPairBinaryExchanged_rr<0b0011, 0b10, "pasa.dhx">;
 
-  def PMSEQ_DH      : RVPPairBinaryExchanged_rr<0b1000, 0b00, "pmseq.dh">;
-  def PMSEQ_DW      : RVPPairBinaryExchanged_rr<0b1000, 0b01, "pmseq.dw">;
-  def PMSEQ_DB      : RVPPairBinaryExchanged_rr<0b1000, 0b10, "pmseq.db">;
+  def PMSEQ_DH     : RVPPairBinaryExchanged_rr<0b1000, 0b00, "pmseq.dh">;
+  def PMSEQ_DW     : RVPPairBinaryExchanged_rr<0b1000, 0b01, "pmseq.dw">;
+  def PMSEQ_DB     : RVPPairBinaryExchanged_rr<0b1000, 0b10, "pmseq.db">;
 
-  def PMSLT_DH      : RVPPairBinaryExchanged_rr<0b1010, 0b00, "pmslt.dh">;
-  def PMSLT_DW      : RVPPairBinaryExchanged_rr<0b1010, 0b01, "pmslt.dw">;
-  def PMSLT_DB      : RVPPairBinaryExchanged_rr<0b1010, 0b10, "pmslt.db">;
+  def PMSLT_DH     : RVPPairBinaryExchanged_rr<0b1010, 0b00, "pmslt.dh">;
+  def PMSLT_DW     : RVPPairBinaryExchanged_rr<0b1010, 0b01, "pmslt.dw">;
+  def PMSLT_DB     : RVPPairBinaryExchanged_rr<0b1010, 0b10, "pmslt.db">;
 
-  def PMSLTU_DH     : RVPPairBinaryExchanged_rr<0b1011, 0b00, "pmsltu.dh">;
-  def PMSLTU_DW     : RVPPairBinaryExchanged_rr<0b1011, 0b01, "pmsltu.dw">;
-  def PMSLTU_DB     : RVPPairBinaryExchanged_rr<0b1011, 0b10, "pmsltu.db">;
+  def PMSLTU_DH    : RVPPairBinaryExchanged_rr<0b1011, 0b00, "pmsltu.dh">;
+  def PMSLTU_DW    : RVPPairBinaryExchanged_rr<0b1011, 0b01, "pmsltu.dw">;
+  def PMSLTU_DB    : RVPPairBinaryExchanged_rr<0b1011, 0b10, "pmsltu.db">;
 
-  def PMIN_DH       : RVPPairBinaryExchanged_rr<0b1100, 0b00, "pmin.dh">;
-  def PMIN_DW       : RVPPairBinaryExchanged_rr<0b1100, 0b01, "pmin.dw">;
-  def PMIN_DB       : RVPPairBinaryExchanged_rr<0b1100, 0b10, "pmin.db">;
+  def PMIN_DH      : RVPPairBinaryExchanged_rr<0b1100, 0b00, "pmin.dh">;
+  def PMIN_DW      : RVPPairBinaryExchanged_rr<0b1100, 0b01, "pmin.dw">;
+  def PMIN_DB      : RVPPairBinaryExchanged_rr<0b1100, 0b10, "pmin.db">;
 
-  def PMINU_DH      : RVPPairBinaryExchanged_rr<0b1101, 0b00, "pminu.dh">;
-  def PMINU_DW      : RVPPairBinaryExchanged_rr<0b1101, 0b01, "pminu.dw">;
-  def PMINU_DB      : RVPPairBinaryExchanged_rr<0b1101, 0b10, "pminu.db">;
+  def PMINU_DH     : RVPPairBinaryExchanged_rr<0b1101, 0b00, "pminu.dh">;
+  def PMINU_DW     : RVPPairBinaryExchanged_rr<0b1101, 0b01, "pminu.dw">;
+  def PMINU_DB     : RVPPairBinaryExchanged_rr<0b1101, 0b10, "pminu.db">;
 
-  def PMAX_DH       : RVPPairBinaryExchanged_rr<0b1110, 0b00, "pmax.dh">;
-  def PMAX_DW       : RVPPairBinaryExchanged_rr<0b1110, 0b01, "pmax.dw">;
-  def PMAX_DB       : RVPPairBinaryExchanged_rr<0b1110, 0b10, "pmax.db">;
+  def PMAX_DH      : RVPPairBinaryExchanged_rr<0b1110, 0b00, "pmax.dh">;
+  def PMAX_DW      : RVPPairBinaryExchanged_rr<0b1110, 0b01, "pmax.dw">;
+  def PMAX_DB      : RVPPairBinaryExchanged_rr<0b1110, 0b10, "pmax.db">;
 
-  def PMAXU_DH      : RVPPairBinaryExchanged_rr<0b1111, 0b00, "pmaxu.dh">;
-  def PMAXU_DW      : RVPPairBinaryExchanged_rr<0b1111, 0b01, "pmaxu.dw">;
-  def PMAXU_DB      : RVPPairBinaryExchanged_rr<0b1111, 0b10, "pmaxu.db">;
+  def PMAXU_DH     : RVPPairBinaryExchanged_rr<0b1111, 0b00, "pmaxu.dh">;
+  def PMAXU_DW     : RVPPairBinaryExchanged_rr<0b1111, 0b01, "pmaxu.dw">;
+  def PMAXU_DB     : RVPPairBinaryExchanged_rr<0b1111, 0b10, "pmaxu.db">;
 } // Predicates = [HasStdExtP, IsRV32]

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -1298,7 +1298,7 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PNCLIPR_HS   : RVPNarrowingShift_rr<0b111, 0b01, "pnclipr.hs">;
   def NCLIPR       : RVPNarrowingShift_rr<0b111, 0b11, "nclipr">;
 
-  def PSLLI_DB     : RVPPairShiftB_ri<0b000,  "pslli.db">;
+  def PSLLI_DB     : RVPPairShiftB_ri<0b000, "pslli.db">;
   def PSLLI_DH     : RVPPairShiftH_ri<0b000, "pslli.dh">;
   def PSLLI_DW     : RVPPairShiftW_ri<0b000, "pslli.dw">;
 

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoP.td
@@ -132,6 +132,37 @@ class RVPNarrowingBase<bits<3> f, bit r, bits<4> funct4, dag outs, dag ins,
   let Inst{6-0}   = OPC_OP_IMM_32.Value;
 }
 
+// Common base for pair ops (non-widening nor narrowing)
+class RVPPairBase<bits<3> f, bit r, bit direction, dag outs, dag ins,
+                  string opcodestr, string argstr>
+  : RVInst<outs, ins, opcodestr, argstr, [], InstFormatOther> {
+  bits<5> rs1;
+  bits<5> rd;
+
+  let Inst{30-28} = f;
+  let Inst{27}    = r;
+  let Inst{19-16} = rs1{4-1};
+  let Inst{15}    = direction;
+  let Inst{14-12} = 0b110;
+  let Inst{11-8}  = rd{4-1};
+  let Inst{7}     = 0b0;
+  let Inst{6-0}   = OPC_OP_IMM_32.Value;
+}
+
+// Common base for pair binary ops
+class RVPPairBinaryBase_rr<bits<3> f, bit r, bits<2> w, bit pack, bit direction,
+                           string opcodestr>
+    : RVPPairBase<f, r, direction, (outs GPRPairRV32:$rd),
+                  (ins GPRPairRV32:$rs1, GPRPairRV32:$rs2), opcodestr,
+                  "$rd, $rs1, $rs2"> {
+  bits<5> rs2;
+
+  let Inst{31}    = 0b1;
+  let Inst{26-25} = w;
+  let Inst{24-21} = rs2{4-1};
+  let Inst{20}    = pack;
+}
+
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPShift_ri<bits<3> f, bits<3> funct3, string opcodestr, Operand ImmType>
     : RVInstIBase<funct3, OPC_OP_IMM_32, (outs GPR:$rd),
@@ -250,6 +281,39 @@ class RVPNarrowingShiftB_ri<bits<3> f, string opcodestr>
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairShift_ri<bits<3> f, string opcodestr, Operand ImmType, 
+                      bit direction>
+    : RVPPairBase<f, 0b0, direction, (outs GPRPairRV32:$rd),
+                       (ins GPRPairRV32:$rs1, ImmType:$shamt), opcodestr,
+                       "$rd, $rs1, $shamt"> {
+  let Inst{31}    = 0b0;
+}
+
+class RVPPairShiftW_ri<bits<3> f, string opcodestr, bit direction = 0b0>
+    : RVPPairShift_ri<f, opcodestr, uimm5, direction> {
+  bits<5> shamt;
+
+  let Inst{26-25} = 0b01;
+  let Inst{24-20} = shamt;
+}
+
+class RVPPairShiftH_ri<bits<3> f, string opcodestr, bit direction = 0b0>
+    : RVPPairShift_ri<f, opcodestr, uimm4, direction> {
+  bits<4> shamt;
+
+  let Inst{26-24} = 0b001;
+  let Inst{23-20} = shamt;
+}
+
+class RVPPairShiftB_ri<bits<3> f, string opcodestr, bit direction = 0b0>
+    : RVPPairShift_ri<f, opcodestr, uimm3, direction> {
+  bits<3> shamt;
+
+  let Inst{26-23} = 0b0001;
+  let Inst{22-20} = shamt;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPNarrowingShift_rr<bits<3> f, bits<2> w, string opcodestr>
     : RVPNarrowingBase<f, 0b1, 0b1100, (outs GPR:$rd),
                        (ins GPRPairRV32:$rs1, GPR:$rs2), opcodestr,
@@ -269,10 +333,31 @@ class RVPWideningShift_rr<bits<3> f, bits<2> w, string opcodestr>
 }
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairShift_rr<bits<3> f, bits<2> w, string opcodestr,
+                      bit direction = 0b0>
+    : RVPPairBase<f, 0b1, direction, (outs GPRPairRV32:$rd),
+                  (ins GPRPairRV32:$rs1, GPR:$rs2), opcodestr,
+                  "$rd, $rs1, $rs2"> {
+  bits<5> rs2;
+
+  let Inst{26-25} = w;
+  let Inst{24-20} = rs2;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPUnary_ri<bits<2> w, bits<5> uf, string opcodestr>
     : RVInstIBase<0b010, OPC_OP_IMM_32, (outs GPR:$rd), (ins GPR:$rs1),
                   opcodestr, "$rd, $rs1">  {
   let Inst{31-27} = 0b11100;
+  let Inst{26-25} = w;
+  let Inst{24-20} = uf;
+}
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairUnary_r<bits<2> w, bits<5> uf, string opcodestr>
+    : RVPPairBase<0b110, 0b0, 0b0, (outs GPRPairRV32:$rd),
+                  (ins GPRPairRV32:$rs1), opcodestr, "$rd, $rs1"> {
+  let Inst{31}    = 0b0;
   let Inst{26-25} = w;
   let Inst{24-20} = uf;
 }
@@ -313,6 +398,22 @@ class RVPNarrowingBinary_rr<bits<3> f, bits<2> w, string opcodestr>
   let Inst{26-25} = w;
   let Inst{24-20} = rs2;
 }
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairBinary_rr<bits<4> f, bits<2> w, string opcodestr>
+  : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b0, 0b0, opcodestr>;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairBinaryShift_rr<bits<3> f, bits<2> w, string opcodestr>
+    : RVPPairBinaryBase_rr<f, 0b0, w, 0b1, 0b0, opcodestr>;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairBinaryPack_rr<bits<3> f, bits<2> w, string opcodestr>
+    : RVPPairBinaryBase_rr<f, 0b0, w, 0b0, 0b1, opcodestr>;
+
+let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
+class RVPPairBinaryExchanged_rr<bits<4> f, bits<2> w, string opcodestr>
+    : RVPPairBinaryBase_rr<f{3-1}, f{0}, w, 0b1, 0b1, opcodestr>;
 
 let hasSideEffects = 0, mayLoad = 0, mayStore = 0 in
 class RVPTernary_rrr<bits<4> f, bits<2> w, bits<3> funct3, string opcodestr>
@@ -1196,4 +1297,161 @@ let Predicates = [HasStdExtP, IsRV32] in {
   def PNCLIPR_BS   : RVPNarrowingShift_rr<0b111, 0b00, "pnclipr.bs">;
   def PNCLIPR_HS   : RVPNarrowingShift_rr<0b111, 0b01, "pnclipr.hs">;
   def NCLIPR       : RVPNarrowingShift_rr<0b111, 0b11, "nclipr">;
+
+  def PSLLI_DB      : RVPPairShiftB_ri<0b000,  "pslli.db">;
+  def PSLLI_DH      : RVPPairShiftH_ri<0b000, "pslli.dh">;
+  def PSLLI_DW      : RVPPairShiftW_ri<0b000, "pslli.dw">;
+
+  def PSSLAI_DH     : RVPPairShiftH_ri<0b101, "psslai.dh">;
+  def PSSLAI_DW     : RVPPairShiftW_ri<0b101, "psslai.dw">;
+
+  def PSEXT_DH_B    : RVPPairUnary_r<0b00, 0b00100, "psext.dh.b">;
+  def PSEXT_DW_B    : RVPPairUnary_r<0b01, 0b00100, "psext.dw.b">;
+
+  def PSEXT_DW_H    : RVPPairUnary_r<0b01, 0b00101, "psext.dw.h">;
+
+  def PSABS_DH      : RVPPairUnary_r<0b00, 0b00111, "psabs.dh">;
+  def PSABS_DB      : RVPPairUnary_r<0b10, 0b00111, "psabs.db">;
+
+  def PSLL_DHS      : RVPPairShift_rr<0b000, 0b00, "psll.dhs">;
+  def PSLL_DWS      : RVPPairShift_rr<0b000, 0b01, "psll.dws">;
+  def PSLL_DBS      : RVPPairShift_rr<0b000, 0b10, "psll.dbs">;
+
+  def PADD_DHS      : RVPPairShift_rr<0b001, 0b00, "padd.dhs">;
+  def PADD_DWS      : RVPPairShift_rr<0b001, 0b01, "padd.dws">;
+  def PADD_DBS      : RVPPairShift_rr<0b001, 0b10, "padd.dbs">;
+
+  def PSSHA_DHS     : RVPPairShift_rr<0b110, 0b00, "pssha.dhs">;
+  def PSSHA_DWS     : RVPPairShift_rr<0b110, 0b01, "pssha.dws">;
+
+  def PSSHAR_DHS    : RVPPairShift_rr<0b111, 0b00, "psshar.dhs">;
+  def PSSHAR_DWS    : RVPPairShift_rr<0b111, 0b01, "psshar.dws">;
+
+  def PSRLI_DB      : RVPPairShiftB_ri<0b000, "psrli.db",  0b1>;
+  def PSRLI_DH      : RVPPairShiftH_ri<0b000, "psrli.dh",  0b1>;
+  def PSRLI_DW      : RVPPairShiftW_ri<0b000, "psrli.dw",  0b1>;
+
+  def PUSATI_DH     : RVPPairShiftH_ri<0b010, "pusati.dh", 0b1>;
+  def PUSATI_DW     : RVPPairShiftW_ri<0b010, "pusati.dw", 0b1>;
+
+  def PSRAI_DB      : RVPPairShiftB_ri<0b100, "psrai.db",  0b1>;
+  def PSRAI_DH      : RVPPairShiftH_ri<0b100, "psrai.dh",  0b1>;
+  def PSRAI_DW      : RVPPairShiftW_ri<0b100, "psrai.dw",  0b1>;
+
+  def PSRARI_DH     : RVPPairShiftH_ri<0b101, "psrari.dh", 0b1>;
+  def PSRARI_DW     : RVPPairShiftW_ri<0b101, "psrari.dw", 0b1>;
+
+  def PSATI_DH      : RVPPairShiftH_ri<0b110, "psati.dh",  0b1>;
+  def PSATI_DW      : RVPPairShiftW_ri<0b110, "psati.dw",  0b1>;
+
+  def PSRL_DHS      : RVPPairShift_rr<0b000, 0b00, "psrl.dhs", 0b1>;
+  def PSRL_DWS      : RVPPairShift_rr<0b000, 0b01, "psrl.dws", 0b1>;
+  def PSRL_DBS      : RVPPairShift_rr<0b000, 0b10, "psrl.dbs", 0b1>;
+
+  def PSRA_DHS      : RVPPairShift_rr<0b100, 0b00, "psra.dhs", 0b1>;
+  def PSRA_DWS      : RVPPairShift_rr<0b100, 0b01, "psra.dws", 0b1>;
+  def PSRA_DBS      : RVPPairShift_rr<0b100, 0b10, "psra.dbs", 0b1>;
+
+  def PADD_DH       : RVPPairBinary_rr<0b0000, 0b00, "padd.dh">;
+  def PADD_DW       : RVPPairBinary_rr<0b0000, 0b01, "padd.dw">;
+  def PADD_DB       : RVPPairBinary_rr<0b0000, 0b10, "padd.db">;
+  def ADDD          : RVPPairBinary_rr<0b0000, 0b11, "addd">;
+
+  def PSADD_DH      : RVPPairBinary_rr<0b0010, 0b00, "psadd.dh">;
+  def PSADD_DW      : RVPPairBinary_rr<0b0010, 0b01, "psadd.dw">;
+  def PSADD_DB      : RVPPairBinary_rr<0b0010, 0b10, "psadd.db">;
+
+  def PAADD_DH      : RVPPairBinary_rr<0b0011, 0b00, "paadd.dh">;
+  def PAADD_DW      : RVPPairBinary_rr<0b0011, 0b01, "paadd.dw">;
+  def PAADD_DB      : RVPPairBinary_rr<0b0011, 0b10, "paadd.db">;
+
+  def PSADDU_DH     : RVPPairBinary_rr<0b0110, 0b00, "psaddu.dh">;
+  def PSADDU_DW     : RVPPairBinary_rr<0b0110, 0b01, "psaddu.dw">;
+  def PSADDU_DB     : RVPPairBinary_rr<0b0110, 0b10, "psaddu.db">;
+
+  def PAADDU_DH     : RVPPairBinary_rr<0b0111, 0b00, "paaddu.dh">;
+  def PAADDU_DW     : RVPPairBinary_rr<0b0111, 0b01, "paaddu.dw">;
+  def PAADDU_DB     : RVPPairBinary_rr<0b0111, 0b10, "paaddu.db">;
+
+  def PSUB_DH       : RVPPairBinary_rr<0b1000, 0b00, "psub.dh">;
+  def PSUB_DW       : RVPPairBinary_rr<0b1000, 0b01, "psub.dw">;
+  def PSUB_DB       : RVPPairBinary_rr<0b1000, 0b10, "psub.db">;
+  def SUBD          : RVPPairBinary_rr<0b1000, 0b11, "subd">;
+
+  def PDIF_DH       : RVPPairBinary_rr<0b1001, 0b00, "pdif.dh">;
+  def PDIF_DB       : RVPPairBinary_rr<0b1001, 0b10, "pdif.db">;
+
+  def PSSUB_DH      : RVPPairBinary_rr<0b1010, 0b00, "pssub.dh">;
+  def PSSUB_DW      : RVPPairBinary_rr<0b1010, 0b01, "pssub.dw">;
+  def PSSUB_DB      : RVPPairBinary_rr<0b1010, 0b10, "pssub.db">;
+
+  def PASUB_DH      : RVPPairBinary_rr<0b1011, 0b00, "pasub.dh">;
+  def PASUB_DW      : RVPPairBinary_rr<0b1011, 0b01, "pasub.dw">;
+  def PASUB_DB      : RVPPairBinary_rr<0b1011, 0b10, "pasub.db">;
+
+  def PDIFU_DH      : RVPPairBinary_rr<0b1101, 0b00, "pdifu.dh">;
+  def PDIFU_DB      : RVPPairBinary_rr<0b1101, 0b10, "pdifu.db">;
+
+  def PSSUBU_DH     : RVPPairBinary_rr<0b1110, 0b00, "pssubu.dh">;
+  def PSSUBU_DW     : RVPPairBinary_rr<0b1110, 0b01, "pssubu.dw">;
+  def PSSUBU_DB     : RVPPairBinary_rr<0b1110, 0b10, "pssubu.db">;
+
+  def PASUBU_DH     : RVPPairBinary_rr<0b1111, 0b00, "pasubu.dh">;
+  def PASUBU_DW     : RVPPairBinary_rr<0b1111, 0b01, "pasubu.dw">;
+  def PASUBU_DB     : RVPPairBinary_rr<0b1111, 0b10, "pasubu.db">;
+
+  def PSH1ADD_DH    : RVPPairBinaryShift_rr<0b010, 0b00, "psh1add.dh">;
+  def PSH1ADD_DW    : RVPPairBinaryShift_rr<0b010, 0b01, "psh1add.dw">;
+
+  def PSSH1SADD_DH  : RVPPairBinaryShift_rr<0b011, 0b00, "pssh1sadd.dh">;
+  def PSSH1SADD_DW  : RVPPairBinaryShift_rr<0b011, 0b01, "pssh1sadd.dw">;
+
+  def PPACK_DH      : RVPPairBinaryPack_rr<0b000, 0b00, "ppack.dh">;
+  def PPACK_DW      : RVPPairBinaryPack_rr<0b000, 0b01, "ppack.dw">;
+
+  def PPACKBT_DH    : RVPPairBinaryPack_rr<0b001, 0b00, "ppackbt.dh">;
+  def PPACKBT_DW    : RVPPairBinaryPack_rr<0b001, 0b01, "ppackbt.dw">;
+
+  def PPACKTB_DH    : RVPPairBinaryPack_rr<0b010, 0b00, "ppacktb.dh">;
+  def PPACKTB_DW    : RVPPairBinaryPack_rr<0b010, 0b01, "ppacktb.dw">;
+
+  def PPACKT_DH     : RVPPairBinaryPack_rr<0b011, 0b00, "ppackt.dh">;
+  def PPACKT_DW     : RVPPairBinaryPack_rr<0b011, 0b01, "ppackt.dw">;
+
+  def PAS_DHX       : RVPPairBinaryExchanged_rr<0b0000, 0b00, "pas.dhx">;
+  def PSA_DHX       : RVPPairBinaryExchanged_rr<0b0000, 0b10, "psa.dhx">;
+
+  def PSAS_DHX      : RVPPairBinaryExchanged_rr<0b0010, 0b00, "psas.dhx">;
+  def PSSA_DHX      : RVPPairBinaryExchanged_rr<0b0010, 0b10, "pssa.dhx">;
+
+  def PAAX_DHX      : RVPPairBinaryExchanged_rr<0b0011, 0b00, "paax.dhx">;
+  def PASA_DHX      : RVPPairBinaryExchanged_rr<0b0011, 0b10, "pasa.dhx">;
+
+  def PMSEQ_DH      : RVPPairBinaryExchanged_rr<0b1000, 0b00, "pmseq.dh">;
+  def PMSEQ_DW      : RVPPairBinaryExchanged_rr<0b1000, 0b01, "pmseq.dw">;
+  def PMSEQ_DB      : RVPPairBinaryExchanged_rr<0b1000, 0b10, "pmseq.db">;
+
+  def PMSLT_DH      : RVPPairBinaryExchanged_rr<0b1010, 0b00, "pmslt.dh">;
+  def PMSLT_DW      : RVPPairBinaryExchanged_rr<0b1010, 0b01, "pmslt.dw">;
+  def PMSLT_DB      : RVPPairBinaryExchanged_rr<0b1010, 0b10, "pmslt.db">;
+
+  def PMSLTU_DH     : RVPPairBinaryExchanged_rr<0b1011, 0b00, "pmsltu.dh">;
+  def PMSLTU_DW     : RVPPairBinaryExchanged_rr<0b1011, 0b01, "pmsltu.dw">;
+  def PMSLTU_DB     : RVPPairBinaryExchanged_rr<0b1011, 0b10, "pmsltu.db">;
+
+  def PMIN_DH       : RVPPairBinaryExchanged_rr<0b1100, 0b00, "pmin.dh">;
+  def PMIN_DW       : RVPPairBinaryExchanged_rr<0b1100, 0b01, "pmin.dw">;
+  def PMIN_DB       : RVPPairBinaryExchanged_rr<0b1100, 0b10, "pmin.db">;
+
+  def PMINU_DH      : RVPPairBinaryExchanged_rr<0b1101, 0b00, "pminu.dh">;
+  def PMINU_DW      : RVPPairBinaryExchanged_rr<0b1101, 0b01, "pminu.dw">;
+  def PMINU_DB      : RVPPairBinaryExchanged_rr<0b1101, 0b10, "pminu.db">;
+
+  def PMAX_DH       : RVPPairBinaryExchanged_rr<0b1110, 0b00, "pmax.dh">;
+  def PMAX_DW       : RVPPairBinaryExchanged_rr<0b1110, 0b01, "pmax.dw">;
+  def PMAX_DB       : RVPPairBinaryExchanged_rr<0b1110, 0b10, "pmax.db">;
+
+  def PMAXU_DH      : RVPPairBinaryExchanged_rr<0b1111, 0b00, "pmaxu.dh">;
+  def PMAXU_DW      : RVPPairBinaryExchanged_rr<0b1111, 0b01, "pmaxu.dw">;
+  def PMAXU_DB      : RVPPairBinaryExchanged_rr<0b1111, 0b10, "pmaxu.db">;
 } // Predicates = [HasStdExtP, IsRV32]

--- a/llvm/test/MC/RISCV/invalid-instruction-spellcheck.s
+++ b/llvm/test/MC/RISCV/invalid-instruction-spellcheck.s
@@ -22,10 +22,10 @@ fl ft0, 0(sp)
 # CHECK-RV64IF: did you mean: flw, la, lb, ld, lh, li, lw
 # CHECK-NEXT: fl ft0, 0(sp)
 
-addd x1, x1, x1
+addc x1, x1, x1
 # CHECK-RV32: did you mean: add, addi
 # CHECK-RV64: did you mean: add, addi, addw
-# CHECK-NEXT: addd x1, x1, x1
+# CHECK-NEXT: addc x1, x1, x1
 
 vm x0, x0
 # CHECK: did you mean: mv

--- a/llvm/test/MC/RISCV/rv32p-valid.s
+++ b/llvm/test/MC/RISCV/rv32p-valid.s
@@ -1017,3 +1017,342 @@ pnclipr.hs a4, s2, t3
 # CHECK-ASM-AND-OBJ: nclipr t1, t5, a2
 # CHECK-ASM: encoding: [0x1b,0xc3,0xcf,0x7e]
 nclipr t1, t5, a2
+# CHECK-ASM-AND-OBJ: pslli.db a0, s2, 0
+# CHECK-ASM: encoding: [0x1b,0x65,0x89,0x00]
+pslli.db a0, s2, 0
+# CHECK-ASM-AND-OBJ: pslli.dh t3, t1, 2
+# CHECK-ASM: encoding: [0x1b,0x6e,0x23,0x01]
+pslli.dh t3, t1, 2
+# CHECK-ASM-AND-OBJ: pslli.dw a4, t3, 1
+# CHECK-ASM: encoding: [0x1b,0x67,0x1e,0x02]
+pslli.dw a4, t3, 1
+# CHECK-ASM-AND-OBJ: psslai.dh t1, a4, 3
+# CHECK-ASM: encoding: [0x1b,0x63,0x37,0x51]
+psslai.dh t1, a4, 3
+# CHECK-ASM-AND-OBJ: psslai.dw a0, t3, 5
+# CHECK-ASM: encoding: [0x1b,0x65,0x5e,0x52]
+psslai.dw a0, t3, 5
+# CHECK-ASM-AND-OBJ: psext.dh.b t1, t5
+# CHECK-ASM: encoding: [0x1b,0x63,0x4f,0x60]
+psext.dh.b t1, t5
+# CHECK-ASM-AND-OBJ: psext.dw.b t5, t5
+# CHECK-ASM: encoding: [0x1b,0x6f,0x4f,0x62]
+psext.dw.b t5, t5
+# CHECK-ASM-AND-OBJ: psext.dw.h s0, t1
+# CHECK-ASM: encoding: [0x1b,0x64,0x53,0x62]
+psext.dw.h s0, t1
+# CHECK-ASM-AND-OBJ: psabs.dh s0, s2
+# CHECK-ASM: encoding: [0x1b,0x64,0x79,0x60]
+psabs.dh s0, s2
+# CHECK-ASM-AND-OBJ: psabs.db s2, a2
+# CHECK-ASM: encoding: [0x1b,0x69,0x76,0x64]
+psabs.db s2, a2
+# CHECK-ASM-AND-OBJ: psll.dhs s2, t3, a4
+# CHECK-ASM: encoding: [0x1b,0x69,0xee,0x08]
+psll.dhs s2, t3, a4
+# CHECK-ASM-AND-OBJ: psll.dws a2, t1, t3
+# CHECK-ASM: encoding: [0x1b,0x66,0xc3,0x0b]
+psll.dws a2, t1, t3
+# CHECK-ASM-AND-OBJ: psll.dbs a0, a4, a2
+# CHECK-ASM: encoding: [0x1b,0x65,0xc7,0x0c]
+psll.dbs a0, a4, a2
+# CHECK-ASM-AND-OBJ: padd.dhs t1, a4, s2
+# CHECK-ASM: encoding: [0x1b,0x63,0x27,0x19]
+padd.dhs t1, a4, s2
+# CHECK-ASM-AND-OBJ: padd.dws a4, a4, t3
+# CHECK-ASM: encoding: [0x1b,0x67,0xc7,0x1b]
+padd.dws a4, a4, t3
+# CHECK-ASM-AND-OBJ: padd.dbs a2, a4, t3
+# CHECK-ASM: encoding: [0x1b,0x66,0xc7,0x1d]
+padd.dbs a2, a4, t3
+# CHECK-ASM-AND-OBJ: pssha.dhs a0, s0, s2
+# CHECK-ASM: encoding: [0x1b,0x65,0x24,0x69]
+pssha.dhs a0, s0, s2
+# CHECK-ASM-AND-OBJ: pssha.dws a0, t1, s2
+# CHECK-ASM: encoding: [0x1b,0x65,0x23,0x6b]
+pssha.dws a0, t1, s2
+# CHECK-ASM-AND-OBJ: psshar.dhs a2, a4, t3
+# CHECK-ASM: encoding: [0x1b,0x66,0xc7,0x79]
+psshar.dhs a2, a4, t3
+# CHECK-ASM-AND-OBJ: psshar.dws s0, t3, s0
+# CHECK-ASM: encoding: [0x1b,0x64,0x8e,0x7a]
+psshar.dws s0, t3, s0
+# CHECK-ASM-AND-OBJ: psrli.db t5, a2, 0
+# CHECK-ASM: encoding: [0x1b,0xef,0x86,0x00]
+psrli.db t5, a2, 0
+# CHECK-ASM-AND-OBJ: psrli.dh a2, t3, 1
+# CHECK-ASM: encoding: [0x1b,0xe6,0x1e,0x01]
+psrli.dh a2, t3, 1
+# CHECK-ASM-AND-OBJ: psrli.dw s2, t1, 3
+# CHECK-ASM: encoding: [0x1b,0xe9,0x33,0x02]
+psrli.dw s2, t1, 3
+# CHECK-ASM-AND-OBJ: pusati.dh a0, a4, 5
+# CHECK-ASM: encoding: [0x1b,0xe5,0x57,0x21]
+pusati.dh a0, a4, 5
+# CHECK-ASM-AND-OBJ: pusati.dw a0, s2, 7
+# CHECK-ASM: encoding: [0x1b,0xe5,0x79,0x22]
+pusati.dw a0, s2, 7
+# CHECK-ASM-AND-OBJ: psrai.db t5, t5, 1
+# CHECK-ASM: encoding: [0x1b,0xef,0x9f,0x40]
+psrai.db t5, t5, 1
+# CHECK-ASM-AND-OBJ: psrai.dh s0, a2, 5
+# CHECK-ASM: encoding: [0x1b,0xe4,0x56,0x41]
+psrai.dh s0, a2, 5
+# CHECK-ASM-AND-OBJ: psrai.dw t5, a0, 9
+# CHECK-ASM: encoding: [0x1b,0xef,0x95,0x42]
+psrai.dw t5, a0, 9
+# CHECK-ASM-AND-OBJ: psrari.dh a2, a2, 6
+# CHECK-ASM: encoding: [0x1b,0xe6,0x66,0x51]
+psrari.dh a2, a2, 6
+# CHECK-ASM-AND-OBJ: psrari.dw a4, a0, 5
+# CHECK-ASM: encoding: [0x1b,0xe7,0x55,0x52]
+psrari.dw a4, a0, 5
+# CHECK-ASM-AND-OBJ: psati.dh s2, s2, 9
+# CHECK-ASM: encoding: [0x1b,0xe9,0x99,0x61]
+psati.dh s2, s2, 9
+# CHECK-ASM-AND-OBJ: psati.dw t5, t3, 14
+# CHECK-ASM: encoding: [0x1b,0xef,0xee,0x62]
+psati.dw t5, t3, 14
+# CHECK-ASM-AND-OBJ: psrl.dhs a0, t1, t5
+# CHECK-ASM: encoding: [0x1b,0xe5,0xe3,0x09]
+psrl.dhs a0, t1, t5
+# CHECK-ASM-AND-OBJ: psrl.dws s0, s2, t1
+# CHECK-ASM: encoding: [0x1b,0xe4,0x69,0x0a]
+psrl.dws s0, s2, t1
+# CHECK-ASM-AND-OBJ: psrl.dbs a0, s0, t5
+# CHECK-ASM: encoding: [0x1b,0xe5,0xe4,0x0d]
+psrl.dbs a0, s0, t5
+# CHECK-ASM-AND-OBJ: psra.dhs a4, t3, t1
+# CHECK-ASM: encoding: [0x1b,0xe7,0x6e,0x48]
+psra.dhs a4, t3, t1
+# CHECK-ASM-AND-OBJ: psra.dws a2, s2, t1
+# CHECK-ASM: encoding: [0x1b,0xe6,0x69,0x4a]
+psra.dws a2, s2, t1
+# CHECK-ASM-AND-OBJ: psra.dbs s0, t1, t5
+# CHECK-ASM: encoding: [0x1b,0xe4,0xe3,0x4d]
+psra.dbs s0, t1, t5
+# CHECK-ASM-AND-OBJ: padd.dh s2, a4, a2
+# CHECK-ASM: encoding: [0x1b,0x69,0xc7,0x80]
+padd.dh s2, a4, a2
+# CHECK-ASM-AND-OBJ: padd.dw a2, s2, a2
+# CHECK-ASM: encoding: [0x1b,0x66,0xc9,0x82]
+padd.dw a2, s2, a2
+# CHECK-ASM-AND-OBJ: padd.db a4, a2, a2
+# CHECK-ASM: encoding: [0x1b,0x67,0xc6,0x84]
+padd.db a4, a2, a2
+# CHECK-ASM-AND-OBJ: addd t1, s2, s0
+# CHECK-ASM: encoding: [0x1b,0x63,0x89,0x86]
+addd t1, s2, s0
+# CHECK-ASM-AND-OBJ: psadd.dh t3, s2, t3
+# CHECK-ASM: encoding: [0x1b,0x6e,0xc9,0x91]
+psadd.dh t3, s2, t3
+# CHECK-ASM-AND-OBJ: psadd.dw a4, t3, t3
+# CHECK-ASM: encoding: [0x1b,0x67,0xce,0x93]
+psadd.dw a4, t3, t3
+# CHECK-ASM-AND-OBJ: psadd.db t5, s0, a2
+# CHECK-ASM: encoding: [0x1b,0x6f,0xc4,0x94]
+psadd.db t5, s0, a2
+# CHECK-ASM-AND-OBJ: paadd.dh t1, s2, a0
+# CHECK-ASM: encoding: [0x1b,0x63,0xa9,0x98]
+paadd.dh t1, s2, a0
+# CHECK-ASM-AND-OBJ: paadd.dw a4, a2, s0
+# CHECK-ASM: encoding: [0x1b,0x67,0x86,0x9a]
+paadd.dw a4, a2, s0
+# CHECK-ASM-AND-OBJ: paadd.db t5, t3, s0
+# CHECK-ASM: encoding: [0x1b,0x6f,0x8e,0x9c]
+paadd.db t5, t3, s0
+# CHECK-ASM-AND-OBJ: psaddu.dh a4, a2, t5
+# CHECK-ASM: encoding: [0x1b,0x67,0xe6,0xb1]
+psaddu.dh a4, a2, t5
+# CHECK-ASM-AND-OBJ: psaddu.dw a4, t5, s2
+# CHECK-ASM: encoding: [0x1b,0x67,0x2f,0xb3]
+psaddu.dw a4, t5, s2
+# CHECK-ASM-AND-OBJ: psaddu.db a4, a0, t1
+# CHECK-ASM: encoding: [0x1b,0x67,0x65,0xb4]
+psaddu.db a4, a0, t1
+# CHECK-ASM-AND-OBJ: paaddu.dh a4, a4, s2
+# CHECK-ASM: encoding: [0x1b,0x67,0x27,0xb9]
+paaddu.dh a4, a4, s2
+# CHECK-ASM-AND-OBJ: paaddu.dw t3, s0, t5
+# CHECK-ASM: encoding: [0x1b,0x6e,0xe4,0xbb]
+paaddu.dw t3, s0, t5
+# CHECK-ASM-AND-OBJ: paaddu.db a0, s0, s0
+# CHECK-ASM: encoding: [0x1b,0x65,0x84,0xbc]
+paaddu.db a0, s0, s0
+# CHECK-ASM-AND-OBJ: psub.dh t5, a4, a4
+# CHECK-ASM: encoding: [0x1b,0x6f,0xe7,0xc0]
+psub.dh t5, a4, a4
+# CHECK-ASM-AND-OBJ: psub.dw t1, s0, t5
+# CHECK-ASM: encoding: [0x1b,0x63,0xe4,0xc3]
+psub.dw t1, s0, t5
+# CHECK-ASM-AND-OBJ: psub.db a4, a0, t5
+# CHECK-ASM: encoding: [0x1b,0x67,0xe5,0xc5]
+psub.db a4, a0, t5
+# CHECK-ASM-AND-OBJ: subd a2, a4, t1
+# CHECK-ASM: encoding: [0x1b,0x66,0x67,0xc6]
+subd a2, a4, t1
+# CHECK-ASM-AND-OBJ: pdif.dh t5, t1, t3
+# CHECK-ASM: encoding: [0x1b,0x6f,0xc3,0xc9]
+pdif.dh t5, t1, t3
+# CHECK-ASM-AND-OBJ: pdif.db t1, t5, a0
+# CHECK-ASM: encoding: [0x1b,0x63,0xaf,0xcc]
+pdif.db t1, t5, a0
+# CHECK-ASM-AND-OBJ: pssub.dh s0, s2, s2
+# CHECK-ASM: encoding: [0x1b,0x64,0x29,0xd1]
+pssub.dh s0, s2, s2
+# CHECK-ASM-AND-OBJ: pssub.dw t3, a2, t3
+# CHECK-ASM: encoding: [0x1b,0x6e,0xc6,0xd3]
+pssub.dw t3, a2, t3
+# CHECK-ASM-AND-OBJ: pssub.db a0, s0, s2
+# CHECK-ASM: encoding: [0x1b,0x65,0x24,0xd5]
+pssub.db a0, s0, s2
+# CHECK-ASM-AND-OBJ: pasub.dh t1, a4, s0
+# CHECK-ASM: encoding: [0x1b,0x63,0x87,0xd8]
+pasub.dh t1, a4, s0
+# CHECK-ASM-AND-OBJ: pasub.dw t1, s2, s2
+# CHECK-ASM: encoding: [0x1b,0x63,0x29,0xdb]
+pasub.dw t1, s2, s2
+# CHECK-ASM-AND-OBJ: pasub.db a0, a0, a0
+# CHECK-ASM: encoding: [0x1b,0x65,0xa5,0xdc]
+pasub.db a0, a0, a0
+# CHECK-ASM-AND-OBJ: pdifu.dh t5, a4, a4
+# CHECK-ASM: encoding: [0x1b,0x6f,0xe7,0xe8]
+pdifu.dh t5, a4, a4
+# CHECK-ASM-AND-OBJ: pdifu.db t1, t1, a4
+# CHECK-ASM: encoding: [0x1b,0x63,0xe3,0xec]
+pdifu.db t1, t1, a4
+# CHECK-ASM-AND-OBJ: pssubu.dh t5, t1, t5
+# CHECK-ASM: encoding: [0x1b,0x6f,0xe3,0xf1]
+pssubu.dh t5, t1, t5
+# CHECK-ASM-AND-OBJ: pssubu.dw a4, a4, t1
+# CHECK-ASM: encoding: [0x1b,0x67,0x67,0xf2]
+pssubu.dw a4, a4, t1
+# CHECK-ASM-AND-OBJ: pssubu.db s0, t5, a2
+# CHECK-ASM: encoding: [0x1b,0x64,0xcf,0xf4]
+pssubu.db s0, t5, a2
+# CHECK-ASM-AND-OBJ: pasubu.dh t5, a2, a2
+# CHECK-ASM: encoding: [0x1b,0x6f,0xc6,0xf8]
+pasubu.dh t5, a2, a2
+# CHECK-ASM-AND-OBJ: pasubu.dw a0, a2, a4
+# CHECK-ASM: encoding: [0x1b,0x65,0xe6,0xfa]
+pasubu.dw a0, a2, a4
+# CHECK-ASM-AND-OBJ: pasubu.db a0, s0, s0
+# CHECK-ASM: encoding: [0x1b,0x65,0x84,0xfc]
+pasubu.db a0, s0, s0
+# CHECK-ASM-AND-OBJ: psh1add.dh t5, a4, t5
+# CHECK-ASM: encoding: [0x1b,0x6f,0xf7,0xa1]
+psh1add.dh t5, a4, t5
+# CHECK-ASM-AND-OBJ: psh1add.dw a4, t5, s0
+# CHECK-ASM: encoding: [0x1b,0x67,0x9f,0xa2]
+psh1add.dw a4, t5, s0
+# CHECK-ASM-AND-OBJ: pssh1sadd.dh t3, a4, a0
+# CHECK-ASM: encoding: [0x1b,0x6e,0xb7,0xb0]
+pssh1sadd.dh t3, a4, a0
+# CHECK-ASM-AND-OBJ: pssh1sadd.dw t1, t1, a2
+# CHECK-ASM: encoding: [0x1b,0x63,0xd3,0xb2]
+pssh1sadd.dw t1, t1, a2
+# CHECK-ASM-AND-OBJ: ppack.dh a2, t1, s2
+# CHECK-ASM: encoding: [0x1b,0xe6,0x23,0x81]
+ppack.dh a2, t1, s2
+# CHECK-ASM-AND-OBJ: ppack.dw t5, t3, a4
+# CHECK-ASM: encoding: [0x1b,0xef,0xee,0x82]
+ppack.dw t5, t3, a4
+# CHECK-ASM-AND-OBJ: ppackbt.dh t1, t3, t1
+# CHECK-ASM: encoding: [0x1b,0xe3,0x6e,0x90]
+ppackbt.dh t1, t3, t1
+# CHECK-ASM-AND-OBJ: ppackbt.dw a4, t5, a2
+# CHECK-ASM: encoding: [0x1b,0xe7,0xcf,0x92]
+ppackbt.dw a4, t5, a2
+# CHECK-ASM-AND-OBJ: ppacktb.dh a4, t1, a2
+# CHECK-ASM: encoding: [0x1b,0xe7,0xc3,0xa0]
+ppacktb.dh a4, t1, a2
+# CHECK-ASM-AND-OBJ: ppacktb.dw a2, t5, s0
+# CHECK-ASM: encoding: [0x1b,0xe6,0x8f,0xa2]
+ppacktb.dw a2, t5, s0
+# CHECK-ASM-AND-OBJ: ppackt.dh a0, a0, s0
+# CHECK-ASM: encoding: [0x1b,0xe5,0x85,0xb0]
+ppackt.dh a0, a0, s0
+# CHECK-ASM-AND-OBJ: ppackt.dw a4, a4, a2
+# CHECK-ASM: encoding: [0x1b,0xe7,0xc7,0xb2]
+ppackt.dw a4, a4, a2
+# CHECK-ASM-AND-OBJ: pas.dhx t3, t3, s2
+# CHECK-ASM: encoding: [0x1b,0xee,0x3e,0x81]
+pas.dhx t3, t3, s2
+# CHECK-ASM-AND-OBJ: psa.dhx a0, s2, a2
+# CHECK-ASM: encoding: [0x1b,0xe5,0xd9,0x84]
+psa.dhx a0, s2, a2
+# CHECK-ASM-AND-OBJ: psas.dhx a2, a2, s0
+# CHECK-ASM: encoding: [0x1b,0xe6,0x96,0x90]
+psas.dhx a2, a2, s0
+# CHECK-ASM-AND-OBJ: pssa.dhx t3, t3, t3
+# CHECK-ASM: encoding: [0x1b,0xee,0xde,0x95]
+pssa.dhx t3, t3, t3
+# CHECK-ASM-AND-OBJ: paax.dhx t3, t3, a4
+# CHECK-ASM: encoding: [0x1b,0xee,0xfe,0x98]
+paax.dhx t3, t3, a4
+# CHECK-ASM-AND-OBJ: pasa.dhx a0, t1, t1
+# CHECK-ASM: encoding: [0x1b,0xe5,0x73,0x9c]
+pasa.dhx a0, t1, t1
+# CHECK-ASM-AND-OBJ: pmseq.dh a4, t1, t3
+# CHECK-ASM: encoding: [0x1b,0xe7,0xd3,0xc1]
+pmseq.dh a4, t1, t3
+# CHECK-ASM-AND-OBJ: pmseq.dw t1, s0, a2
+# CHECK-ASM: encoding: [0x1b,0xe3,0xd4,0xc2]
+pmseq.dw t1, s0, a2
+# CHECK-ASM-AND-OBJ: pmseq.db a2, a2, t5
+# CHECK-ASM: encoding: [0x1b,0xe6,0xf6,0xc5]
+pmseq.db a2, a2, t5
+# CHECK-ASM-AND-OBJ: pmslt.dh s2, t5, s2
+# CHECK-ASM: encoding: [0x1b,0xe9,0x3f,0xd1]
+pmslt.dh s2, t5, s2
+# CHECK-ASM-AND-OBJ: pmslt.dw t1, t1, a2
+# CHECK-ASM: encoding: [0x1b,0xe3,0xd3,0xd2]
+pmslt.dw t1, t1, a2
+# CHECK-ASM-AND-OBJ: pmslt.db t5, s0, s2
+# CHECK-ASM: encoding: [0x1b,0xef,0x34,0xd5]
+pmslt.db t5, s0, s2
+# CHECK-ASM-AND-OBJ: pmsltu.dh s2, a0, s2
+# CHECK-ASM: encoding: [0x1b,0xe9,0x35,0xd9]
+pmsltu.dh s2, a0, s2
+# CHECK-ASM-AND-OBJ: pmsltu.dw s0, t3, a0
+# CHECK-ASM: encoding: [0x1b,0xe4,0xbe,0xda]
+pmsltu.dw s0, t3, a0
+# CHECK-ASM-AND-OBJ: pmsltu.db s0, t3, t3
+# CHECK-ASM: encoding: [0x1b,0xe4,0xde,0xdd]
+pmsltu.db s0, t3, t3
+# CHECK-ASM-AND-OBJ: pmin.dh a2, s0, t3
+# CHECK-ASM: encoding: [0x1b,0xe6,0xd4,0xe1]
+pmin.dh a2, s0, t3
+# CHECK-ASM-AND-OBJ: pmin.dw a2, s0, t3
+# CHECK-ASM: encoding: [0x1b,0xe6,0xd4,0xe3]
+pmin.dw a2, s0, t3
+# CHECK-ASM-AND-OBJ: pmin.db t3, s2, t3
+# CHECK-ASM: encoding: [0x1b,0xee,0xd9,0xe5]
+pmin.db t3, s2, t3
+# CHECK-ASM-AND-OBJ: pminu.dh t1, t3, t5
+# CHECK-ASM: encoding: [0x1b,0xe3,0xfe,0xe9]
+pminu.dh t1, t3, t5
+# CHECK-ASM-AND-OBJ: pminu.dw t1, t3, t5
+# CHECK-ASM: encoding: [0x1b,0xe3,0xfe,0xeb]
+pminu.dw t1, t3, t5
+# CHECK-ASM-AND-OBJ: pminu.db t1, s0, a2
+# CHECK-ASM: encoding: [0x1b,0xe3,0xd4,0xec]
+pminu.db t1, s0, a2
+# CHECK-ASM-AND-OBJ: pmax.dh a0, a0, a0
+# CHECK-ASM: encoding: [0x1b,0xe5,0xb5,0xf0]
+pmax.dh a0, a0, a0
+# CHECK-ASM-AND-OBJ: pmax.dw a0, a0, a0
+# CHECK-ASM: encoding: [0x1b,0xe5,0xb5,0xf2]
+pmax.dw a0, a0, a0
+# CHECK-ASM-AND-OBJ: pmax.db a2, a2, s2
+# CHECK-ASM: encoding: [0x1b,0xe6,0x36,0xf5]
+pmax.db a2, a2, s2
+# CHECK-ASM-AND-OBJ: pmaxu.dh a4, t3, s0
+# CHECK-ASM: encoding: [0x1b,0xe7,0x9e,0xf8]
+pmaxu.dh a4, t3, s0
+# CHECK-ASM-AND-OBJ: pmaxu.dw a4, t3, s0
+# CHECK-ASM: encoding: [0x1b,0xe7,0x9e,0xfa]
+pmaxu.dw a4, t3, s0
+# CHECK-ASM-AND-OBJ: pmaxu.db a4, t5, a0
+# CHECK-ASM: encoding: [0x1b,0xe7,0xbf,0xfc]
+pmaxu.db a4, t5, a0


### PR DESCRIPTION
This patch implements pages 21-24 from jhauser.us/RISCV/ext-P/RVP-instrEncodings-015.pdf

Documentation:
[jhauser.us/RISCV/ext-P/RVP-baseInstrs-014.pdf](https://jhauser.us/RISCV/ext-P/RVP-baseInstrs-014.pdf)
[jhauser.us/RISCV/ext-P/RVP-instrEncodings-015.pdf](https://jhauser.us/RISCV/ext-P/RVP-instrEncodings-015.pdf)