### PR TITLE
[BasicAA] Handle scalable vectors in new errno aliasing checks.

### DIFF
--- a/llvm/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/llvm/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1866,7 +1866,8 @@ AliasResult BasicAAResult::aliasErrno(const MemoryLocation &Loc,
   // There cannot be any alias with errno if the given memory location is an
   // identified function-local object, or the size of the memory access is
   // larger than the integer size.
-  if (Loc.Size.hasValue() && Loc.Size.getValue() * 8 > TLI.getIntSize())
+  if (Loc.Size.hasValue() &&
+      Loc.Size.getValue().getKnownMinValue() * 8 > TLI.getIntSize())
     return AliasResult::NoAlias;
 
   if (isIdentifiedFunctionLocal(getUnderlyingObject(Loc.Ptr)))


### PR DESCRIPTION
This is a minor fixup for scalable vectors after f9f62ef4ae555a. It handles them in the same way as other memory locations that are larger than errno, preventing the failure on implicit conversion from a scalable location.