### PR TITLE
[libc++] XFAIL regex tests that are currently failing on macOS

### DIFF
--- a/libcxx/test/std/re/re.alg/re.alg.match/awk.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/awk.locale.pass.cpp
@@ -20,6 +20,7 @@
 // TODO(netbsd): incomplete support for locales
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, netbsd, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 // REQUIRES: locale.cs_CZ.ISO8859-2
 
 #include <regex>

--- a/libcxx/test/std/re/re.alg/re.alg.match/basic.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/basic.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.match/ecma.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/ecma.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.match/extended.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.match/extended.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/awk.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/awk.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/basic.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/basic.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/ecma.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/ecma.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.alg/re.alg.search/extended.locale.pass.cpp
+++ b/libcxx/test/std/re/re.alg/re.alg.search/extended.locale.pass.cpp
@@ -24,6 +24,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}, freebsd
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <cassert>

--- a/libcxx/test/std/re/re.traits/lookup_collatename.pass.cpp
+++ b/libcxx/test/std/re/re.traits/lookup_collatename.pass.cpp
@@ -25,6 +25,7 @@
 // TODO: investigation needed
 // XFAIL: target={{.*}}-linux-gnu{{.*}}
 // XFAIL: target={{.*}}-amazon-linux{{.*}}
+// XFAIL: target={{.*}}-apple-{{.*}}
 
 #include <regex>
 #include <iterator>


### PR DESCRIPTION
It seems that an OS update changed the localization on macOS. This XFAILs the tests to make sure the CI is green again until the tests can be updated.
