### PR TITLE
[clang-format] Fix for BreakTemplateDeclarations and RequiresClausePosition

### DIFF
--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -5854,6 +5854,12 @@ bool TokenAnnotator::mustBreakBefore(const AnnotatedLine &Line,
     // concept ...
     if (Right.is(tok::kw_concept))
       return Style.BreakBeforeConceptDeclarations == FormatStyle::BBCDS_Always;
+    if (Style.BreakTemplateDeclarations == FormatStyle::BTDS_Yes &&
+        Right.is(TT_RequiresClause) &&
+        (Style.RequiresClausePosition == FormatStyle::RCPS_WithPreceding ||
+         Style.RequiresClausePosition == FormatStyle::RCPS_SingleLine)) {
+      return false;
+    }
     return Style.BreakTemplateDeclarations == FormatStyle::BTDS_Yes ||
            (Style.BreakTemplateDeclarations == FormatStyle::BTDS_Leave &&
             Right.NewlinesBefore > 0);

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -10848,6 +10848,14 @@ TEST_F(FormatTest, WrapsTemplateDeclarations) {
                "public:\n"
                "  E *f();\n"
                "};");
+  AlwaysBreak.RequiresClausePosition = FormatStyle::RCPS_SingleLine;
+  verifyFormat("template <typename T> requires std::floating_point<T>\n"
+               "using LerpValue = ClampedValue<T, T{0}, T{1}>;",
+               AlwaysBreak);
+  AlwaysBreak.RequiresClausePosition = FormatStyle::RCPS_WithPreceding;
+  verifyFormat("template <typename T> requires std::floating_point<T>\n"
+               "using LerpValue = ClampedValue<T, T{0}, T{1}>;",
+               AlwaysBreak);
 
   FormatStyle NeverBreak = getLLVMStyle();
   NeverBreak.BreakTemplateDeclarations = FormatStyle::BTDS_No;


### PR DESCRIPTION

   when BreakTemplateDeclarations is set to yes and
    RequiresClausePosition is SingleLine or WithPreceding
    requires clause should be on the same line

Fixes #150845