### PR TITLE
[LLDB][NativePDB] Add modifiers to modified type name

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -549,10 +549,18 @@ lldb::TypeSP SymbolFileNativePDB::CreateModifierType(PdbTypeSymId type_id,
   TpiStream &stream = m_index->tpi();
 
   std::string name;
+
+  if ((mr.Modifiers & ModifierOptions::Const) != ModifierOptions::None)
+    name += "const ";
+  if ((mr.Modifiers & ModifierOptions::Volatile) != ModifierOptions::None)
+    name += "volatile ";
+  if ((mr.Modifiers & ModifierOptions::Unaligned) != ModifierOptions::None)
+    name += "__unaligned ";
+
   if (mr.ModifiedType.isSimple())
-    name = std::string(GetSimpleTypeName(mr.ModifiedType.getSimpleKind()));
+    name += GetSimpleTypeName(mr.ModifiedType.getSimpleKind());
   else
-    name = computeTypeName(stream.typeCollection(), mr.ModifiedType);
+    name += computeTypeName(stream.typeCollection(), mr.ModifiedType);
   Declaration decl;
   lldb::TypeSP modified_type = GetOrCreateType(mr.ModifiedType);
 

--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites.test
@@ -74,10 +74,10 @@
 # CHECK:       LineEntry: [0x0000000140001004-0x000000014000100c): /tmp/a.h:5
 # CHECK-NEXT:  Symbol: id = {{.*}}, range = [0x0000000140001000-0x0000000140001046), name="main"
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = <empty>, decl =
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argc", type = "int", valid ranges = <block>, location = [0x0000000140001000, 0x000000014000102d) -> DW_OP_reg26 XMM9
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argv", type = "char **", valid ranges = <block>, location = [0x0000000140001000, 0x0000000140001045) -> DW_OP_reg3 RBX
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
 
 # CHECK-LABEL: (lldb) image lookup -a 0x140001010 -v
 # CHECK:       Summary: {{.*}}`main + 16 [inlined] Namespace1::foo + 12 at a.h:7
@@ -88,10 +88,10 @@
 # CHECK:       LineEntry: [0x0000000140001010-0x0000000140001018): /tmp/a.h:7
 # CHECK-NEXT:  Symbol: id = {{.*}}, range = [0x0000000140001000-0x0000000140001046), name="main"
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = <empty>, decl =
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argc", type = "int", valid ranges = <block>, location = [0x0000000140001000, 0x000000014000102d) -> DW_OP_reg26 XMM9
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argv", type = "char **", valid ranges = <block>, location = [0x0000000140001000, 0x0000000140001045) -> DW_OP_reg3 RBX
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
 
 # CHECK-LABEL: (lldb) image lookup -a 0x14000101c -v
 # CHECK:       Summary: {{.*}}`main + 28 [inlined] Class1::bar at b.h:5
@@ -104,12 +104,12 @@
 # CHECK:       LineEntry: [0x000000014000101c-0x0000000140001022): /tmp/b.h:5
 # CHECK-NEXT:  Symbol: id = {{.*}}, range = [0x0000000140001000-0x0000000140001046), name="main"
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = [0x000000014000101c, 0x000000014000101e) -> DW_OP_reg24 XMM7
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "bar_local", type = "int", valid ranges = <block>, location = [0x000000014000101c, 0x0000000140001039) -> DW_OP_breg7 RSP+52
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "bar_local", type = "volatile int", valid ranges = <block>, location = [0x000000014000101c, 0x0000000140001039) -> DW_OP_breg7 RSP+52
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = <empty>, decl =
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argc", type = "int", valid ranges = <block>, location = [0x0000000140001000, 0x000000014000102d) -> DW_OP_reg26 XMM9
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argv", type = "char **", valid ranges = <block>, location = [0x0000000140001000, 0x0000000140001045) -> DW_OP_reg3 RBX
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
 
 # CHECK-LABEL: (lldb) image lookup -a 0x14000102a -v
 # CHECK:       Summary: {{.*}}`main + 42 [inlined] Namespace2::Class2::func at c.h:5
@@ -124,13 +124,13 @@
 # CHECK:       LineEntry: [0x000000014000102a-0x0000000140001031): /tmp/c.h:5
 # CHECK-NEXT:  Symbol: id = {{.*}}, range = [0x0000000140001000-0x0000000140001046), name="main"
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = [0x000000014000102a, 0x0000000140001039) -> DW_OP_reg24 XMM7
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "func_local", type = "int", valid ranges = <block>, location = [0x000000014000102a, 0x0000000140001039) -> DW_OP_breg7 RSP+48
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "bar_local", type = "int", valid ranges = <block>, location = [0x000000014000101c, 0x0000000140001039) -> DW_OP_breg7 RSP+52
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "func_local", type = "volatile int", valid ranges = <block>, location = [0x000000014000102a, 0x0000000140001039) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "bar_local", type = "volatile int", valid ranges = <block>, location = [0x000000014000101c, 0x0000000140001039) -> DW_OP_breg7 RSP+52
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = <empty>, decl =
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001039) -> DW_OP_breg7 RSP+44
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argc", type = "int", valid ranges = <block>, location = [0x0000000140001000, 0x000000014000102d) -> DW_OP_reg26 XMM9
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argv", type = "char **", valid ranges = <block>, location = [0x0000000140001000, 0x0000000140001045) -> DW_OP_reg3 RBX
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
 
 # CHECK-LABEL: (lldb) image lookup -a 0x140001039 -v
 # CHECK:       Summary: {{.*}}`main + 57 at a.cpp:3
@@ -139,7 +139,7 @@
 # CHECK:       LineEntry: [0x0000000140001039-0x000000014000103d): /tmp/a.cpp:3
 # CHECK-NEXT:  Symbol: id = {{.*}}, range = [0x0000000140001000-0x0000000140001046), name="main"
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argv", type = "char **", valid ranges = <block>, location = [0x0000000140001000, 0x0000000140001045) -> DW_OP_reg3 RBX
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
 
 # CHECK-LABEL: (lldb) image lookup -a 0x140001044 -v
 # CHECK:       Summary: {{.*}}`main + 68 [inlined] Namespace1::foo + 5 at a.h:8
@@ -150,10 +150,10 @@
 # CHECK:       LineEntry: [0x0000000140001044-0x0000000140001046): /tmp/a.h:8
 # CHECK-NEXT:  Symbol: id = {{.*}}, range = [0x0000000140001000-0x0000000140001046), name="main"
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "x", type = "int", valid ranges = <block>, location = <empty>, decl =
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "int", valid ranges = <block>, location = [0x0000000140001044, 0x0000000140001046) -> DW_OP_breg7 RSP+44
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "foo_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001044, 0x0000000140001046) -> DW_OP_breg7 RSP+44
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argc", type = "int", valid ranges = <block>, location = [0x0000000140001044, 0x0000000140001045) -> DW_OP_reg26 XMM9
 # CHECK-NEXT:  Variable: id = {{.*}}, name = "argv", type = "char **", valid ranges = <block>, location = [0x0000000140001000, 0x0000000140001045) -> DW_OP_reg3 RBX
-# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
+# CHECK-NEXT:  Variable: id = {{.*}}, name = "main_local", type = "volatile int", valid ranges = <block>, location = [0x0000000140001004, 0x0000000140001046) -> DW_OP_breg7 RSP+48
 
 # CHECK-LABEL: (lldb) target modules dump ast
 # CHECK-NEXT:  Dumping clang ast for 1 modules.

--- a/lldb/test/Shell/SymbolFile/PDB/type-quals.test
+++ b/lldb/test/Shell/SymbolFile/PDB/type-quals.test
@@ -2,35 +2,37 @@ REQUIRES: target-windows, msvc
 RUN: mkdir -p %t.dir
 RUN: %build --compiler=clang-cl --mode=compile --arch=32 --nodefaultlib --output=%t.dir/TypeQualsTest.cpp.obj %S/Inputs/TypeQualsTest.cpp
 RUN: %build --compiler=msvc --mode=link --arch=32 --nodefaultlib --output=%t.dir/TypeQualsTest.cpp.exe %t.dir/TypeQualsTest.cpp.obj
-RUN: lldb-test symbols %t.dir/TypeQualsTest.cpp.exe | FileCheck %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=0 lldb-test symbols %t.dir/TypeQualsTest.cpp.exe | FileCheck %s
+RUN: env LLDB_USE_NATIVE_PDB_READER=1 lldb-test symbols %t.dir/TypeQualsTest.cpp.exe | FileCheck %s
 
 CHECK: Module [[MOD:.*]]
-CHECK-DAG: SymbolFile pdb ([[MOD]])
+CHECK-DAG: SymbolFile {{(native-)?}}pdb ([[MOD]])
 CHECK-DAG:      Type{{.*}} , name = "const int", size = 4, compiler_type = {{.*}} const int
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} const int *
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} const int **const
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} const int *const
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} const int *const *
-CHECK-DAG:      Type{{.*}} , name = "Func1", {{.*}}, compiler_type = {{.*}} void (const int *, const int *, const int **const, const int *const *)
+CHECK-DAG:      Type{{.*}} , {{.*}}, compiler_type = {{.*}} void (const int *, const int *, const int **const, const int *const *)
 
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} volatile int *
-CHECK-DAG:      Type{{.*}} , name = "Func2", {{.*}}, compiler_type = {{.*}} void (volatile int *, volatile int *)
+CHECK-DAG:      Type{{.*}} , {{.*}}, compiler_type = {{.*}} void (volatile int *, volatile int *)
 
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} int *
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} int *&
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} int &&
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} int &
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} const int &
-CHECK-DAG:      Type{{.*}} , name = "Func3", {{.*}}, compiler_type = {{.*}} void (int *&, int &, const int &, int &&)
+CHECK-DAG:      Type{{.*}} , {{.*}}, compiler_type = {{.*}} void (int *&, int &, const int &, int &&)
 
 // FIXME: __unaligned is not supported.
-CHECK-DAG:      Type{{.*}} , name = "Func4", {{.*}}, compiler_type = {{.*}} void (int *, int *)
+CHECK-DAG:      Type{{.*}} , {{.*}}, compiler_type = {{.*}} void (int *, int *)
 
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} int *__restrict
 CHECK-DAG:      Type{{.*}} , size = 4, compiler_type = {{.*}} int &__restrict
-CHECK-DAG:      Type{{.*}} , name = "Func5", {{.*}}, compiler_type = {{.*}} void (int, int *__restrict, int &__restrict)
+CHECK-DAG:      Type{{.*}} , {{.*}}, compiler_type = {{.*}} void (int, int *__restrict, int &__restrict)
 
-CHECK-DAG:      Type{{.*}} , name = "Func6", {{.*}}, compiler_type = {{.*}} void (const volatile int *__restrict)
+CHECK-DAG:      Type{{.*}} , name = "{{volatile const|const volatile}} int", size = 4, compiler_type = {{.*}} {{volatile const|const volatile}} int
+CHECK-DAG:      Type{{.*}} , {{.*}}, compiler_type = {{.*}} void (const volatile int *__restrict)
 
 CHECK-DAG:      Type{{.*}} , size = 400, compiler_type = {{.*}} volatile int *[100]
 CHECK-DAG:      Type{{.*}} , size = 4000, compiler_type = {{.*}} volatile int *[10][100]


### PR DESCRIPTION
When creating LLDB types from `LF_MODIFIER` records, the type name of the modified type was used. This didn't include the modifiers (`const`/`volatile`/`__unaligned`). With this PR, they're included.

The DIA plugin had a test for this. That test also assumed that function types had a name. I removed that check here, because function/procedure types themselves in PDB don't have a name:

```
  0x1015 | LF_ARGLIST [size = 20, hash = 0xBCB6]
           0x0074 (int): `int`
           0x1013: `int* __restrict`
           0x1014: `int& __restrict`
  0x1016 | LF_PROCEDURE [size = 16, hash = 0x3F611]
           return type = 0x0003 (void), # args = 3, param list = 0x1015
           calling conv = cdecl, options = None
```

I assume DIA gets the name from the function symbol itself. In the native plugin, that name isn't included and multiple functions with the same signature will reuse one type, whereas DIA would create a new type for each function. The [Shell/SymbolFile/PDB/func-symbols.test](https://github.com/llvm/llvm-project/blob/b29c7ded31d81ca47aed0157c543c8b6a0f5866c/lldb/test/Shell/SymbolFile/PDB/func-symbols.test) also relies on this.