### PR TITLE
[llvm][CAS] Enable CAS on 32-bit systems again

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -880,8 +880,8 @@ option (LLVM_ENABLE_BINDINGS "Build bindings." ON)
 option (LLVM_ENABLE_TELEMETRY "Enable the telemetry library. If set to OFF, library cannot be enabled after build (eg., at runtime)" ON)
 
 set(LLVM_ENABLE_ONDISK_CAS_default ON)
-if(CMAKE_SIZEOF_VOID_P LESS 8 OR "${CMAKE_SYSTEM_NAME}" MATCHES SunOS)
-  # Build OnDiskCAS by default only on 64 bit machine that is not Solaris.
+if("${CMAKE_SYSTEM_NAME}" MATCHES SunOS)
+  # Build OnDiskCAS by default only on non-Solaris machines.
   set(LLVM_ENABLE_ONDISK_CAS_default OFF)
 endif()
 option(LLVM_ENABLE_ONDISK_CAS "Build OnDiskCAS." ${LLVM_ENABLE_ONDISK_CAS_default})


### PR DESCRIPTION
dd56becdbc31cce16973172f0a447207ddf67861 has fixed the alignment problem we were seeing on Arm 32-bit.