### PR TITLE
[DebugInfo] Remove class and function names from Doxygen comments in LexicalScopes.h (NFC)

### DIFF
--- a/llvm/include/llvm/CodeGen/LexicalScopes.h
+++ b/llvm/include/llvm/CodeGen/LexicalScopes.h
@@ -34,13 +34,12 @@ class MachineInstr;
 class MDNode;
 
 //===----------------------------------------------------------------------===//
-/// InsnRange - This is used to track range of instructions with identical
-/// lexical scope.
+/// This is used to track range of instructions with identical lexical scope.
 ///
 using InsnRange = std::pair<const MachineInstr *, const MachineInstr *>;
 
 //===----------------------------------------------------------------------===//
-/// LexicalScope - This class is used to track scope information.
+/// This class is used to track scope information.
 ///
 class LexicalScope {
 public:
@@ -66,10 +65,10 @@ public:
   SmallVectorImpl<LexicalScope *> &getChildren() { return Children; }
   SmallVectorImpl<InsnRange> &getRanges() { return Ranges; }
 
-  /// addChild - Add a child scope.
+  /// Add a child scope.
   void addChild(LexicalScope *S) { Children.push_back(S); }
 
-  /// openInsnRange - This scope covers instruction range starting from MI.
+  /// This scope covers instruction range starting from MI.
   void openInsnRange(const MachineInstr *MI) {
     if (!FirstInsn)
       FirstInsn = MI;
@@ -78,8 +77,7 @@ public:
       Parent->openInsnRange(MI);
   }
 
-  /// extendInsnRange - Extend the current instruction range covered by
-  /// this scope.
+  /// Extend the current instruction range covered by this scope.
   void extendInsnRange(const MachineInstr *MI) {
     assert(FirstInsn && "MI Range is not open!");
     LastInsn = MI;
@@ -87,9 +85,9 @@ public:
       Parent->extendInsnRange(MI);
   }
 
-  /// closeInsnRange - Create a range based on FirstInsn and LastInsn collected
-  /// until now. This is used when a new scope is encountered while walking
-  /// machine instructions.
+  /// Create a range based on FirstInsn and LastInsn collected until now.
+  /// This is used when a new scope is encountered while walking machine
+  /// instructions.
   void closeInsnRange(LexicalScope *NewScope = nullptr) {
     assert(LastInsn && "Last insn missing!");
     Ranges.push_back(InsnRange(FirstInsn, LastInsn));
@@ -101,7 +99,7 @@ public:
       Parent->closeInsnRange(NewScope);
   }
 
-  /// dominates - Return true if current scope dominates given lexical scope.
+  /// Return true if current scope dominates given lexical scope.
   bool dominates(const LexicalScope *S) const {
     if (S == this)
       return true;
@@ -116,7 +114,7 @@ public:
   unsigned getDFSIn() const { return DFSIn; }
   void setDFSIn(unsigned I) { DFSIn = I; }
 
-  /// dump - print lexical scope.
+  /// Print lexical scope.
   LLVM_ABI void dump(unsigned Indent = 0) const;
 
 private:
@@ -136,31 +134,30 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
-/// LexicalScopes -  This class provides interface to collect and use lexical
-/// scoping information from machine instruction.
+/// This class provides interface to collect and use lexical scoping information
+/// from machine instruction.
 ///
 class LexicalScopes {
 public:
   LexicalScopes() = default;
 
-  /// initialize - Scan machine function and constuct lexical scope nest, resets
+  /// Scan machine function and constuct lexical scope nest, resets
   /// the instance if necessary.
   LLVM_ABI void initialize(const MachineFunction &);
 
-  /// releaseMemory - release memory.
+  /// Release memory.
   LLVM_ABI void reset();
 
-  /// empty - Return true if there is any lexical scope information available.
+  /// Return true if there is any lexical scope information available.
   bool empty() { return CurrentFnLexicalScope == nullptr; }
 
-  /// getCurrentFunctionScope - Return lexical scope for the current function.
+  /// Return lexical scope for the current function.
   LexicalScope *getCurrentFunctionScope() const {
     return CurrentFnLexicalScope;
   }
 
-  /// getMachineBasicBlocks - Populate given set using machine basic blocks
-  /// which have machine instructions that belong to lexical scope identified by
-  /// DebugLoc.
+  /// Populate given set using machine basic blocks which have machine
+  /// instructions that belong to lexical scope identified by DebugLoc.
   LLVM_ABI void
   getMachineBasicBlocks(const DILocation *DL,
                         SmallPtrSetImpl<const MachineBasicBlock *> &MBBs);
@@ -169,39 +166,39 @@ public:
   /// instruction's lexical scope in a given machine basic block.
   LLVM_ABI bool dominates(const DILocation *DL, MachineBasicBlock *MBB);
 
-  /// findLexicalScope - Find lexical scope, either regular or inlined, for the
-  /// given DebugLoc. Return NULL if not found.
+  /// Find lexical scope, either regular or inlined, for the given DebugLoc.
+  /// Return NULL if not found.
   LLVM_ABI LexicalScope *findLexicalScope(const DILocation *DL);
 
-  /// getAbstractScopesList - Return a reference to list of abstract scopes.
+  /// Return a reference to list of abstract scopes.
   ArrayRef<LexicalScope *> getAbstractScopesList() const {
     return AbstractScopesList;
   }
 
-  /// findAbstractScope - Find an abstract scope or return null.
+  /// Find an abstract scope or return null.
   LexicalScope *findAbstractScope(const DILocalScope *N) {
     auto I = AbstractScopeMap.find(N);
     return I != AbstractScopeMap.end() ? &I->second : nullptr;
   }
 
-  /// findInlinedScope - Find an inlined scope for the given scope/inlined-at.
+  /// Find an inlined scope for the given scope/inlined-at.
   LexicalScope *findInlinedScope(const DILocalScope *N, const DILocation *IA) {
     auto I = InlinedLexicalScopeMap.find(std::make_pair(N, IA));
     return I != InlinedLexicalScopeMap.end() ? &I->second : nullptr;
   }
 
-  /// findLexicalScope - Find regular lexical scope or return null.
+  /// Find regular lexical scope or return null.
   LexicalScope *findLexicalScope(const DILocalScope *N) {
     auto I = LexicalScopeMap.find(N);
     return I != LexicalScopeMap.end() ? &I->second : nullptr;
   }
 
-  /// getOrCreateAbstractScope - Find or create an abstract lexical scope.
+  /// Find or create an abstract lexical scope.
   LLVM_ABI LexicalScope *getOrCreateAbstractScope(const DILocalScope *Scope);
 
 private:
-  /// getOrCreateLexicalScope - Find lexical scope for the given Scope/IA. If
-  /// not available then create new lexical scope.
+  /// Find lexical scope for the given Scope/IA. If not available
+  /// then create new lexical scope.
   LLVM_ABI LexicalScope *
   getOrCreateLexicalScope(const DILocalScope *Scope,
                           const DILocation *IA = nullptr);
@@ -210,14 +207,14 @@ private:
               : nullptr;
   }
 
-  /// getOrCreateRegularScope - Find or create a regular lexical scope.
+  /// Find or create a regular lexical scope.
   LexicalScope *getOrCreateRegularScope(const DILocalScope *Scope);
 
-  /// getOrCreateInlinedScope - Find or create an inlined lexical scope.
+  /// Find or create an inlined lexical scope.
   LexicalScope *getOrCreateInlinedScope(const DILocalScope *Scope,
                                         const DILocation *InlinedAt);
 
-  /// extractLexicalScopes - Extract instruction ranges for each lexical scopes
+  /// Extract instruction ranges for each lexical scopes
   /// for the given machine function.
   void extractLexicalScopes(SmallVectorImpl<InsnRange> &MIRanges,
                             DenseMap<const MachineInstr *, LexicalScope *> &M);
@@ -228,27 +225,24 @@ private:
 
   const MachineFunction *MF = nullptr;
 
-  /// LexicalScopeMap - Tracks the scopes in the current function.
+  /// Tracks the scopes in the current function.
   // Use an unordered_map to ensure value pointer validity over insertion.
   std::unordered_map<const DILocalScope *, LexicalScope> LexicalScopeMap;
 
-  /// InlinedLexicalScopeMap - Tracks inlined function scopes in current
-  /// function.
+  /// Tracks inlined function scopes in current function.
   std::unordered_map<std::pair<const DILocalScope *, const DILocation *>,
                      LexicalScope,
                      pair_hash<const DILocalScope *, const DILocation *>>
       InlinedLexicalScopeMap;
 
-  /// AbstractScopeMap - These scopes are  not included LexicalScopeMap.
+  /// These scopes are  not included LexicalScopeMap.
   // Use an unordered_map to ensure value pointer validity over insertion.
   std::unordered_map<const DILocalScope *, LexicalScope> AbstractScopeMap;
 
-  /// AbstractScopesList - Tracks abstract scopes constructed while processing
-  /// a function.
+  /// Tracks abstract scopes constructed while processing a function.
   SmallVector<LexicalScope *, 4> AbstractScopesList;
 
-  /// CurrentFnLexicalScope - Top level scope for the current function.
-  ///
+  /// Top level scope for the current function.
   LexicalScope *CurrentFnLexicalScope = nullptr;
 
   /// Map a location to the set of basic blocks it dominates. This is a cache


### PR DESCRIPTION
Duplication of function and class name in the comment is discouraged in https://llvm.org/docs/CodingStandards.html#doxygen-use-in-documentation-comments.

I'll be merging this immediately, as this change was requested in https://github.com/llvm/llvm-project/pull/159104#discussion_r2353613772, but I'm open to post-commit review.