### PR TITLE
[clang][Sema] Avoid warnings when mixing diagnostic categories (NFC)

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6836,9 +6836,10 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   if (AL.getKind() == ParsedAttr::UnknownAttribute ||
       !AL.existsInTarget(S.Context.getTargetInfo())) {
     if (AL.isRegularKeywordAttribute() || AL.isDeclspecAttribute()) {
-      S.Diag(AL.getLoc(), AL.isRegularKeywordAttribute()
-                              ? diag::err_keyword_not_supported_on_target
-                              : diag::warn_unhandled_ms_attribute_ignored)
+      S.Diag(AL.getLoc(),
+             AL.isRegularKeywordAttribute()
+                 ? (unsigned)diag::err_keyword_not_supported_on_target
+                 : (unsigned)diag::warn_unhandled_ms_attribute_ignored)
           << AL.getAttrName() << AL.getRange();
     } else {
       S.DiagnoseUnknownAttribute(AL);

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -673,9 +673,10 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
         (S.Context.getLangOpts().SYCLIsDevice && Aux &&
          A.existsInTarget(*Aux)))) {
     if (A.isRegularKeywordAttribute() || A.isDeclspecAttribute()) {
-      S.Diag(A.getLoc(), A.isRegularKeywordAttribute()
-                             ? diag::err_keyword_not_supported_on_target
-                             : diag::warn_unhandled_ms_attribute_ignored)
+      S.Diag(A.getLoc(),
+             A.isRegularKeywordAttribute()
+                 ? (unsigned)diag::err_keyword_not_supported_on_target
+                 : (unsigned)diag::warn_unhandled_ms_attribute_ignored)
           << A << A.getRange();
     } else {
       S.DiagnoseUnknownAttribute(A);


### PR DESCRIPTION
These statements conditionally select between diagnostics of different categories (common vs. sema). Although the diagnostic IDs do not overlap between categories, they are organized in different enums, and this raises warnings in specific compilers. The clang warning suggest this behavior is deprecated in C++20 (the warning is ignored by default in C++17 mode). By converting the diagnostic IDs to unsigned, we avoid the issue.