### PR TITLE
[clang] Add unreachable after fully covered switches, avoid GCC warnings. NFC.

### DIFF
--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -14101,6 +14101,7 @@ bool IntExprEvaluator::VisitBuiltinCallExpr(const CallExpr *E,
       return Success(Result, E);
     }
     }
+    llvm_unreachable("Fully covered switch above");
   }
   case Builtin::BIstrlen:
   case Builtin::BIwcslen:

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3520,6 +3520,7 @@ std::string tools::complexRangeKindToStr(LangOptions::ComplexRangeKind Range) {
     return "none";
     break;
   }
+  llvm_unreachable("Fully covered switch above");
 }
 
 std::string


### PR DESCRIPTION
This avoids the following warnings:

    ../../clang/lib/AST/ExprConstant.cpp: In member function ‘bool {anonymous}::IntExprEvaluator::VisitBuiltinCallExpr(const clang::CallExpr*, unsigned int)’:
    ../../clang/lib/AST/ExprConstant.cpp:14104:3: warning: this statement may fall through [-Wimplicit-fallthrough=]
    14104 |   }
          |   ^
    ../../clang/lib/AST/ExprConstant.cpp:14105:3: note: here
    14105 |   case Builtin::BIstrlen:
          |   ^~~~
    ../../clang/lib/Driver/ToolChains/CommonArgs.cpp: In function ‘std::string clang::driver::tools::complexRangeKindToStr(clang::LangOptionsBase::ComplexRangeKind ’:
    ../../clang/lib/Driver/ToolChains/CommonArgs.cpp:3523:1: warning: control reaches end of non-void function [-Wreturn-type]
     3523 | }
          | ^