### PR TITLE
[LLVM][CodeGen] Update PPCFastISel::SelectRet for ConstantInt based vectors.

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCFastISel.cpp
+++ b/llvm/lib/Target/PowerPC/PPCFastISel.cpp
@@ -1707,7 +1707,8 @@ bool PPCFastISel::SelectRet(const Instruction *I) {
 
     // Special case for returning a constant integer of any size - materialize
     // the constant as an i64 and copy it to the return register.
-    if (const ConstantInt *CI = dyn_cast<ConstantInt>(RV)) {
+    if (isa<ConstantInt>(RV) && RV->getType()->isIntegerTy()) {
+      const ConstantInt *CI = cast<ConstantInt>(RV);
       CCValAssign &VA = ValLocs[0];
 
       Register RetReg = VA.getLocReg();

--- a/llvm/test/CodeGen/PowerPC/vec_constants.ll
+++ b/llvm/test/CodeGen/PowerPC/vec_constants.ll
@@ -3,6 +3,10 @@
 ; RUN: llc -verify-machineinstrs -O0 -mcpu=pwr7 -mtriple=powerpc64-ibm-aix-xcoff -vec-extabi < %s | FileCheck %s --check-prefixes=CHECK,BE
 ; RUN: llc -verify-machineinstrs -O0 -mcpu=pwr7 -mtriple=powerpc64le-unknown-linux-gnu < %s | FileCheck %s --check-prefixes=CHECK,LE
 
+; RUN: llc -verify-machineinstrs -O0 -mcpu=pwr7 -mtriple=powerpc64-unknown-linux-gnu -use-constant-int-for-fixed-length-splat -use-constant-fp-for-fixed-length-splat < %s | FileCheck %s --check-prefixes=CHECK,BE
+; RUN: llc -verify-machineinstrs -O0 -mcpu=pwr7 -mtriple=powerpc64-ibm-aix-xcoff -vec-extabi -use-constant-int-for-fixed-length-splat -use-constant-fp-for-fixed-length-splat < %s | FileCheck %s --check-prefixes=CHECK,BE
+; RUN: llc -verify-machineinstrs -O0 -mcpu=pwr7 -mtriple=powerpc64le-unknown-linux-gnu -use-constant-int-for-fixed-length-splat -use-constant-fp-for-fixed-length-splat < %s | FileCheck %s --check-prefixes=CHECK,LE
+
 define void @test1(ptr %P1, ptr %P2, ptr %P3) nounwind {
 ; BE-LABEL: test1:
 ; BE:       # %bb.0:


### PR DESCRIPTION
The current implementation assumes ConstantInt return values are scalar, which is not true when use-constant-int-for-fixed-length-splat is enabled.