### PR TITLE
[clang] Avoid warnings about enum mismatch in ternary expressions. NFC.

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6837,8 +6837,10 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
       !AL.existsInTarget(S.Context.getTargetInfo())) {
     if (AL.isRegularKeywordAttribute() || AL.isDeclspecAttribute()) {
       S.Diag(AL.getLoc(), AL.isRegularKeywordAttribute()
-                              ? diag::err_keyword_not_supported_on_target
-                              : diag::warn_unhandled_ms_attribute_ignored)
+                              ? static_cast<unsigned>(
+                                    diag::err_keyword_not_supported_on_target)
+                              : static_cast<unsigned>(
+                                    diag::warn_unhandled_ms_attribute_ignored))
           << AL.getAttrName() << AL.getRange();
     } else {
       S.DiagnoseUnknownAttribute(AL);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6835,12 +6835,11 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
   // though they were unknown attributes.
   if (AL.getKind() == ParsedAttr::UnknownAttribute ||
       !AL.existsInTarget(S.Context.getTargetInfo())) {
-    if (AL.isRegularKeywordAttribute() || AL.isDeclspecAttribute()) {
-      S.Diag(AL.getLoc(), AL.isRegularKeywordAttribute()
-                              ? static_cast<unsigned>(
-                                    diag::err_keyword_not_supported_on_target)
-                              : static_cast<unsigned>(
-                                    diag::warn_unhandled_ms_attribute_ignored))
+    if (AL.isRegularKeywordAttribute()) {
+      S.Diag(AL.getLoc(), diag::err_keyword_not_supported_on_target)
+          << AL.getAttrName() << AL.getRange();
+    } else if (AL.isDeclspecAttribute()) {
+      S.Diag(AL.getLoc(), diag::warn_unhandled_ms_attribute_ignored)
           << AL.getAttrName() << AL.getRange();
     } else {
       S.DiagnoseUnknownAttribute(AL);

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -672,12 +672,11 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
       !(A.existsInTarget(S.Context.getTargetInfo()) ||
         (S.Context.getLangOpts().SYCLIsDevice && Aux &&
          A.existsInTarget(*Aux)))) {
-    if (A.isRegularKeywordAttribute() || A.isDeclspecAttribute()) {
-      S.Diag(A.getLoc(), A.isRegularKeywordAttribute()
-                             ? static_cast<unsigned>(
-                                   diag::err_keyword_not_supported_on_target)
-                             : static_cast<unsigned>(
-                                   diag::warn_unhandled_ms_attribute_ignored))
+    if (A.isRegularKeywordAttribute()) {
+      S.Diag(A.getLoc(), diag::err_keyword_not_supported_on_target)
+          << A << A.getRange();
+    } else if (A.isDeclspecAttribute()) {
+      S.Diag(A.getLoc(), diag::warn_unhandled_ms_attribute_ignored)
           << A << A.getRange();
     } else {
       S.DiagnoseUnknownAttribute(A);

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -674,8 +674,10 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
          A.existsInTarget(*Aux)))) {
     if (A.isRegularKeywordAttribute() || A.isDeclspecAttribute()) {
       S.Diag(A.getLoc(), A.isRegularKeywordAttribute()
-                             ? diag::err_keyword_not_supported_on_target
-                             : diag::warn_unhandled_ms_attribute_ignored)
+                             ? static_cast<unsigned>(
+                                   diag::err_keyword_not_supported_on_target)
+                             : static_cast<unsigned>(
+                                   diag::warn_unhandled_ms_attribute_ignored))
           << A << A.getRange();
     } else {
       S.DiagnoseUnknownAttribute(A);


### PR DESCRIPTION
This avoids the following kind of warning when built with GCC:

    ../../clang/lib/Sema/SemaStmtAttr.cpp: In function ‘clang::Attr* ProcessStmtAttribute(clang::Sema&, clang::Stmt*, const clang::ParsedAttr&, clang::SourceRange)’:
    ../../clang/lib/Sema/SemaStmtAttr.cpp:677:30: warning: enumerated mismatch in conditional expression: ‘clang::diag::<unnamed enum>’ vs ‘clang::diag::<unnamed enum>’ [-Wenum-compare]
      676 |       S.Diag(A.getLoc(), A.isRegularKeywordAttribute()
          |                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      677 |                              ? diag::err_keyword_not_supported_on_targe
          |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      678 |                              : diag::warn_unhandled_ms_attribute_ignore )
          |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

These enums are non-overlapping, but due they are defined in different enum scopes due to how they are generated with tablegen.