### PR TITLE
[AArch64] Mark a variable as maybe unused. NFC.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -19076,7 +19076,7 @@ static SDValue performUADDVCombine(SDNode *N, SelectionDAG &DAG) {
   }
 
   // uaddv(A) --> A if all lanes of A are known to be zeros except the 0th lane.
-  MVT VT = N->getSimpleValueType(0);
+  [[maybe_unused]] MVT VT = N->getSimpleValueType(0);
   MVT OpVT = A.getSimpleValueType();
   assert(VT == OpVT &&
          "The operand type should be consistent with the result type of UADDV");


### PR DESCRIPTION
This avoids the following warning if building with asserts disabled:

    ../lib/Target/AArch64/AArch64ISelLowering.cpp:19079:7: warning: unused variable 'VT' [-Wunused-variable]
     19079 |   MVT VT = N->getSimpleValueType(0);
           |       ^~