### PR TITLE
[lldb] Avoid build warnings when building for Windows. NFC.

### DIFF
--- a/lldb/source/Host/common/File.cpp
+++ b/lldb/source/Host/common/File.cpp
@@ -659,7 +659,7 @@ Status NativeFile::Write(const void *buf, size_t &num_bytes) {
 #ifdef _WIN32
     if (is_windows_console) {
       llvm::raw_fd_ostream(_fileno(m_stream), false)
-          .write((char *)buf, num_bytes);
+          .write((const char *)buf, num_bytes);
       return error;
     }
 #endif

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -321,7 +321,6 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
     stream << "[Error] ";
     break;
   case lldb::eSeverityInfo:
-  default:
     stream << "[Info] ";
     break;
   }


### PR DESCRIPTION
This avoids the following warnings from Clang:

    ../../lldb/source/Host/windows/Host.cpp:324:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
      324 |   default:
          |   ^
    ../../lldb/source/Host/common/File.cpp:662:26: warning: cast from 'const void *' to 'char *' drops const qualifier [-Wcast-qual]
      662 |           .write((char *)buf, num_bytes);
          |                          ^