### PR TITLE
[analyzer] Enhance array bound checking for `ConstantArrayType`

### DIFF
--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -915,9 +915,18 @@ def decodeValueOfObjCType : Checker<"decodeValueOfObjCType">,
 
 let ParentPackage = Security in {
 
-  def ArrayBoundChecker : Checker<"ArrayBound">,
-                          HelpText<"Warn about out of bounds access to memory">,
-                          Documentation<HasDocumentation>;
+  def ArrayBoundChecker
+      : Checker<"ArrayBound">,
+        HelpText<"Warn about out of bounds access to memory">,
+        CheckerOptions<[
+          CmdLineOption<Boolean,
+                        "EnableFakeFlexibleArrayWarn",
+                        "Do not silence out-of-bound accesses to arrays of size 1 or 0 that are "
+                        "the last member of a record, or member of an union",
+                        "false",
+                          Released>,
+        ]>,
+        Documentation<HasDocumentation>;
 
   def FloatLoopCounter
       : Checker<"FloatLoopCounter">,

--- a/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/ArrayBoundChecker.cpp
@@ -636,7 +636,10 @@ static Messages getNegativeIndexMessage(StringRef Name,
                   Name, ArraySizeVal, IndexStr)};
 }
 
-static std::string truncateWithEllipsis(StringRef Str, size_t MaxLength) {
+template <size_t MaxLength = 20>
+static std::string truncateWithEllipsis(StringRef Str) {
+  static_assert(MaxLength > 4, "MaxLength must be long enough to hold a single "
+                               "character plus the ellipsis");
   if (Str.size() <= MaxLength)
     return Str.str();
 
@@ -661,8 +664,7 @@ static Messages getOOBIndexMessage(StringRef Name, NonLoc Index,
     Out << "an overflowing index";
   }
 
-  std::string const ElemTypeStr =
-      truncateWithEllipsis(ElemType.getAsString(), 20);
+  std::string const ElemTypeStr = truncateWithEllipsis(ElemType.getAsString());
 
   Out << ", while it holds only ";
   if (ExtentN != 1)

--- a/clang/test/Analysis/ArrayBound/brief-tests.c
+++ b/clang/test/Analysis/ArrayBound/brief-tests.c
@@ -1,4 +1,8 @@
 // RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection -verify %s
+// RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection \
+// RUN:                    -DWARN_FLEXIBLE_ARRAY -analyzer-config security.ArrayBound:EnableFakeFlexibleArrayWarn=true -verify %s
+
+#include "../Inputs/system-header-simulator-for-malloc.h"
 
 // Miscellaneous tests for `security.ArrayBound` where we only test the
 // presence or absence of a bug report. If a test doesn't fit in a more
@@ -6,6 +10,9 @@
 // then it should be placed here.
 
 void clang_analyzer_value(int);
+void clang_analyzer_eval(int);
+void clang_analyzer_warnIfReached();
+
 
 // Tests doing an out-of-bounds access after the end of an array using:
 // - constant integer index
@@ -88,7 +95,7 @@ void test1_ptr_arith_ok2(int x) {
 // - constant integer size for buffer
 void test2(int x) {
   int buf[100];
-  buf[-1] = 1; // expected-warning{{Out of bound access to memory}}
+  buf[-1] = 1; // expected-warning{{Out of bound access to 'buf' at a negative index}}
 }
 
 // Tests doing an out-of-bounds access before the start of an array using:
@@ -118,7 +125,7 @@ void test2_ptr_arith(int x) {
 // - constant integer sizes for the array
 void test2_multi(int x) {
   int buf[100][100];
-  buf[0][-1] = 1; // expected-warning{{Out of bound access to memory}}
+  buf[0][-1] = 1; // expected-warning{{Out of bound access to the subarray 'buf[0]' at a negative index}}
 }
 
 // Tests doing an out-of-bounds access before the start of a multi-dimensional
@@ -127,7 +134,17 @@ void test2_multi(int x) {
 // - constant integer sizes for the array
 void test2_multi_b(int x) {
   int buf[100][100];
-  buf[-1][0] = 1; // expected-warning{{Out of bound access to memory}}
+  buf[-1][0] = 1; // expected-warning{{Out of bound access to 'buf' at a negative index}}
+}
+
+void test2_multi_c() {
+  int buf[100][100];
+  buf[0][103] = 1; // expected-warning{{Out of bound access to memory after the end of the subarray 'buf[0]'}}
+}
+
+void test2_multi_d() {
+  int buf[80][90][100];
+  buf[0][91][0] = 1; // expected-warning {{Out of bound access to memory after the end of the subarray 'buf[0]'}}
 }
 
 void test2_multi_ok(int x) {
@@ -138,7 +155,7 @@ void test2_multi_ok(int x) {
 void test3(int x) {
   int buf[100];
   if (x < 0)
-    buf[x] = 1; // expected-warning{{Out of bound access to memory}}
+    buf[x] = 1; // expected-warning{{Out of bound access to 'buf' at a negative index}}
 }
 
 void test4(int x) {
@@ -164,7 +181,7 @@ typedef struct {
 user_t *get_symbolic_user(void);
 char test_underflow_symbolic_2() {
   user_t *user = get_symbolic_user();
-  return user->name[-1]; // expected-warning{{Out of bound access to memory}}
+  return user->name[-1]; // expected-warning{{Out of bound access to the field 'name' at a negative index}}
 }
 
 void test_incomplete_struct(void) {
@@ -271,4 +288,168 @@ void sizeof_vla_3(int a) {
     y[4] = 4; // no-warning
     y[5] = 5; // should be {{Out of bounds access}}
   }
+}
+
+void md_array_assumptions(int x, int y, int z) {
+  int array[80][90][100];
+  int value = array[x][y][z];
+
+  clang_analyzer_eval(x < 80); // expected-warning {{TRUE}}
+  clang_analyzer_eval(y < 90); // expected-warning {{TRUE}}
+  clang_analyzer_eval(z < 100); // expected-warning {{TRUE}}
+
+  clang_analyzer_eval(x >= 0); // expected-warning {{TRUE}}
+  clang_analyzer_eval(y >= 0); // expected-warning {{TRUE}}
+  clang_analyzer_eval(z >= 0); // expected-warning {{TRUE}}
+}
+
+int unsigned_index_quirk_inner(unsigned char index) {
+  static const unsigned char array[] = {8, 8, 4, 4, 2, 2, 1};
+
+  if (index < 6) {
+    return 0;
+  }
+
+  // Unsurprising
+  clang_analyzer_eval(index >= 6); // expected-warning {{TRUE}}
+
+  index++;
+
+  // Could overflow since 255 is a possible value, kind of surprising
+  clang_analyzer_eval(index > 6); // expected-warning {{TRUE}} expected-warning {{FALSE}}
+
+  if (index >= 7) {
+    return 0;
+  }
+
+  // Because of the if above, 7 is not possible. But because of the overflow, 0
+  // is.
+  clang_analyzer_eval(index == 0); // expected-warning {{TRUE}}
+
+  // Regression test: if we don't call `simplifySVal` so 255+1 is folded into 0,
+  // we get a false positive "out of bounds".
+  return array[index]; // no warning
+}
+
+struct WithTrailingArray {
+  int nargs;
+  int args[1];
+};
+
+int use_trailing(struct WithTrailingArray *p) {
+#ifdef WARN_FLEXIBLE_ARRAY
+  // expected-warning@+2 {{Potential out of bound access to the field 'args', which may be a 'flexible array member'}}
+#endif
+  int x = p->args[3];
+  // No sink
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+  return x;
+}
+
+struct NotReallyTrailing {
+  int array[1];
+  int more_data;
+};
+
+int use_non_trailing(struct NotReallyTrailing *p) {
+  int x = p->array[3]; // expected-warning {{Out of bound access to memory after the end of the field 'array'}}
+  clang_analyzer_warnIfReached(); // sink, no warning
+  return x;
+}
+
+struct TrailingNoException {
+  int n;
+  int some[2];
+};
+
+int use_trailing_no_exception(struct TrailingNoException *p) {
+  int x = p->some[10]; // expected-warning {{Out of bound access to memory after the end of the field 'some'}}
+  clang_analyzer_warnIfReached(); // sink, no warning
+  return x;
+}
+
+int regular_one_array() {
+  int array[1];
+  int x = array[2]; // expected-warning {{Out of bound access to memory after the end of 'array'}}
+  clang_analyzer_warnIfReached(); // sink, no warning
+  return x;
+}
+
+struct WithTrailing0 {
+  int nargs;
+  int args[0];
+};
+
+int use_trailing0(struct WithTrailing0 *p) {
+#ifdef WARN_FLEXIBLE_ARRAY
+  // expected-warning@+2 {{Potential out of bound access to the field 'args', which may be a 'flexible array member'}}
+#endif
+  int x = p->args[10]; // no warning
+  // No sink
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+  return x;
+}
+
+struct RealFlexibleArray {
+  int nargs;
+  int args[];
+};
+
+// Trailing array, allocation unknown
+int use_real_trailing(struct RealFlexibleArray *p) {
+  int x = p->args[3]; // no warning
+  // No sink
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+  return x;
+}
+
+int use_allocated_fam() {
+  struct RealFlexibleArray *p = malloc(sizeof(struct RealFlexibleArray) + 10 * sizeof(int));
+  // This is a false negative.
+  // `ArrayBoundCheckers` queries for the extent of the memory region
+  // `Element{SymRegion{conj_$2{void *, LC1, S1173, #1}},0 S64b,struct RealFlexibleArray}.args`,
+  // which is unknown. Either `ArrayBoundCheckers`, or `DynamicExtent.cpp` should
+  // learn how to handle this pattern.
+  int x = p->args[30];
+  free(p);
+  return x;
+}
+
+// Pattern used in GCC
+union FlexibleArrayUnion {
+  int args[1];
+  struct {int x, y, z;};
+};
+
+int use_union(union FlexibleArrayUnion *p) {
+#ifdef WARN_FLEXIBLE_ARRAY
+  // expected-warning@+2 {{Potential out of bound access to the field 'args', which may be a 'flexible array member'}}
+#endif
+  int x = p->args[2];
+  // No sink
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+  return x;
+}
+
+void custom_unreachable();
+
+int get_index(char b) {
+  switch (b) {
+  case 'a':
+    return 0;
+  default:
+    custom_unreachable();
+  }
+  // expected-warning@+1 {{non-void function does not return a value in all control paths}}
+}
+
+int access_by_undefined(char b) {
+  char array[10] = {0};
+  int i = get_index(b);
+  // CPP-7012, even though there is a path that does return a value, CSA keeps going
+  clang_analyzer_value(i); // expected-warning {{[-2147483648, 2147483647]}} expected-warning {{32s:0}}
+  int x = array[i];
+  // `i` could be [0, 9], but `get_index` should have pruned [1, 9] out of the possible scenarios
+  clang_analyzer_value(i); // expected-warning {{[0, 9]}} expected-warning {{32s:0}}
+  return x;
 }

--- a/clang/test/Analysis/ArrayBound/flexible-array-members.c
+++ b/clang/test/Analysis/ArrayBound/flexible-array-members.c
@@ -1,0 +1,101 @@
+// RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection \
+// RUN:                    -fstrict-flex-arrays=0 -DSTRICT_FLEX=0 \
+// RUN:                    -verify %s
+//
+// RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection \
+// RUN:                    -fstrict-flex-arrays=1 -DSTRICT_FLEX=1 \
+// RUN:                    -verify %s
+//
+// RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection \
+// RUN:                    -fstrict-flex-arrays=2 -DSTRICT_FLEX=2 \
+// RUN:                    -verify %s
+//
+// RUN: %clang_analyze_cc1 -Wno-array-bounds -analyzer-checker=core,security.ArrayBound,debug.ExprInspection \
+// RUN:                    -fstrict-flex-arrays=3 -DSTRICT_FLEX=3 \
+// RUN:                    -verify %s
+
+#include "../Inputs/system-header-simulator-for-malloc.h"
+
+void clang_analyzer_warnIfReached();
+
+struct RealFAM {
+  int size;
+  int args[];
+};
+
+int use_fam(struct RealFAM *ptr) {
+  int x = ptr->args[1];
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+  return x;
+}
+
+struct FAM0 {
+  int size;
+  int args[0];
+};
+
+int use_fam0(struct FAM0 *ptr) {
+  int x = ptr->args[1];
+#if STRICT_FLEX > 2
+  // expected-warning@-2 {{Out of bound access to memory after the end of the field 'args'}}
+#else
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+#endif
+  return x;
+}
+
+struct FAM1 {
+  int size;
+  int args[1];
+};
+
+int use_fam1(struct FAM1 *ptr) {
+  int x = ptr->args[2];
+#if STRICT_FLEX > 1
+  // expected-warning@-2 {{Out of bound access to memory after the end of the field 'args'}}
+#else
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+#endif
+  return x;
+}
+
+struct FAMN {
+  int size;
+  int args[64];
+};
+
+int use_famn(struct FAMN *ptr) {
+  int x = ptr->args[128];
+#if STRICT_FLEX > 0
+  // expected-warning@-2 {{Out of bound access to memory after the end of the field 'args'}}
+#else
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+#endif
+  return x;
+}
+
+struct NotFAM {
+  int keys[1];
+  int values[1];
+};
+
+int use_not_fam(struct NotFAM *ptr) {
+  return ptr->keys[3]; // expected-warning {{Out of bound access to memory after the end of the field 'keys'}}
+}
+
+// Pattern used in GCC
+union FlexibleArrayUnion {
+  int args[1];
+  struct {int x, y, z;};
+};
+
+
+int use_union(union FlexibleArrayUnion *p) {
+  int x = p->args[2];
+#if STRICT_FLEX > 1
+  // expected-warning@-2 {{Out of bound access to memory after the end of the field 'args'}}
+#else
+  clang_analyzer_warnIfReached(); // expected-warning {{REACHABLE}}
+#endif
+  return x;
+}

--- a/clang/test/Analysis/ArrayBound/verbose-tests.c
+++ b/clang/test/Analysis/ArrayBound/verbose-tests.c
@@ -240,14 +240,18 @@ struct vec {
 
 double arrayInStruct(void) {
   return v.elems[64];
-  // expected-warning@-1 {{Out of bound access to memory after the end of the field 'elems'}}
-  // expected-note@-2 {{Access of the field 'elems' at index 64, while it holds only 64 'double' elements}}
+#if STRICT_FLEX >= 1
+  // expected-warning@-2 {{Out of bound access to memory after the end of the field 'elems'}}
+  // expected-note@-3 {{Access of the field 'elems' at index 64, while it holds only 64 'double' elements}}
+#endif
 }
 
 double arrayInStructPtr(struct vec *pv) {
   return pv->elems[64];
-  // expected-warning@-1 {{Out of bound access to memory after the end of the field 'elems'}}
-  // expected-note@-2 {{Access of the field 'elems' at index 64, while it holds only 64 'double' elements}}
+#if STRICT_FLEX >= 1
+  // expected-warning@-2 {{Out of bound access to memory after the end of the field 'elems'}}
+  // expected-note@-3 {{Access of the field 'elems' at index 64, while it holds only 64 'double' elements}}
+#endif
 }
 
 struct item {
@@ -465,16 +469,4 @@ int test_case_long_elem_name() {
   return table[55].x;
   // expected-warning@-1 {{Out of bound access to memory after the end of 'table'}}
   // expected-note@-2 {{Access of 'table' at index 55, while it holds only 10 'struct VERYLONGPR...' elements}}
-}
-
-struct What {
-  int x[0];
-  int y;
-};
-
-int who() {
-  struct What who;
-  return who.x[1];
-  // expected-warning@-1 {{Out of bound access to memory after the end of the field 'x'}}
-  // expected-note@-2 {{Access of the field 'x' at index 1, while it holds only 0 'int' elements}}
 }

--- a/clang/test/Analysis/analyzer-config.c
+++ b/clang/test/Analysis/analyzer-config.c
@@ -120,6 +120,7 @@
 // CHECK-NEXT: region-store-small-array-limit = 5
 // CHECK-NEXT: region-store-small-struct-limit = 2
 // CHECK-NEXT: report-in-main-source-file = false
+// CHECK-NEXT: security.ArrayBound:EnableFakeFlexibleArrayWarn = false
 // CHECK-NEXT: security.cert.env.InvalidPtr:InvalidatingGetEnv = false
 // CHECK-NEXT: serialize-stats = false
 // CHECK-NEXT: silence-checkers = ""


### PR DESCRIPTION
- `ArrayBoundChecker` now directly models index accesses on `ConstantArrayType`, enabling more detection of out-of-bounds (OOB) accesses for arrays with known constant sizes.
- Improved support for multi-dimensional arrays.

By default, positive OOB accesses of "fake" Flexible Array Members (FAM) are silenced, and do not introduce any assumption on the index beyond it not being negative.
The option`security.ArrayBound:EnableFakeFlexibleArrayWarn` allows to opt-in for warnings in these cases (without sinking).

With this patch we can now warn on OOB access even if we know nothing about the allocation, since the type suffices.

Additionally, this also allows to report OOB accesses on subarrays. For instance:

```cpp
int array[10][10];

array[0][10];
```

Before this change, `ArrayBoundChecker` would not report an OOB, since only the byte offset is taken into account:
0 * 10 + 10 = 10, which is less than the allocated 100 bytes. This is, nonetheless, UB per the standard.

CPP-6852, CPP-6956