### PR TITLE
[CI] Test lit when it is changed

### DIFF
--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -150,6 +150,7 @@ PROJECT_CHECK_TARGETS = {
     "mlir": "check-mlir",
     "openmp": "check-openmp",
     "polly": "check-polly",
+    "lit": "check-lit",
 }
 
 RUNTIMES = {"libcxx", "libcxxabi", "libunwind", "compiler-rt", "libc", "flang-rt"}
@@ -166,7 +167,11 @@ META_PROJECTS = {
     ("llvm", "utils", "gn"): "gn",
     (".github", "workflows", "premerge.yaml"): ".ci",
     ("third-party",): ".ci",
+    ("llvm", "utils", "lit"): "lit"
 }
+
+# Projects that should run tests but cannot be explicitly built.
+SKIP_BUILD_PROJECTS = ["CIR", "lit"]
 
 # Projects that should not run any tests. These need to be metaprojects.
 SKIP_PROJECTS = ["docs", "gn"]
@@ -315,7 +320,9 @@ def get_env_variables(modified_files: list[str], platform: str) -> Set[str]:
     # clang build, but it requires an explicit option to enable. We set that
     # option here, and remove it from the projects_to_build list.
     enable_cir = "ON" if "CIR" in projects_to_build else "OFF"
-    projects_to_build.discard("CIR")
+    # Remove any metaprojects from the list of projects to build.
+    for project in SKIP_BUILD_PROJECTS:
+        projects_to_build.discard(project)
 
     # We use a semicolon to separate the projects/runtimes as they get passed
     # to the CMake invocation and thus we need to use the CMake list separator

--- a/.ci/compute_projects.py
+++ b/.ci/compute_projects.py
@@ -167,7 +167,7 @@ META_PROJECTS = {
     ("llvm", "utils", "gn"): "gn",
     (".github", "workflows", "premerge.yaml"): ".ci",
     ("third-party",): ".ci",
-    ("llvm", "utils", "lit"): "lit"
+    ("llvm", "utils", "lit"): "lit",
 }
 
 # Projects that should run tests but cannot be explicitly built.

--- a/.ci/compute_projects_test.py
+++ b/.ci/compute_projects_test.py
@@ -413,6 +413,30 @@ class TestComputeProjects(unittest.TestCase):
             "check-cxx check-cxxabi check-unwind",
         )
 
+    def test_lit(self):
+        env_variables = compute_projects.get_env_variables(
+            ["llvm/utils/lit/CMakeLists.txt"], "Linux"
+        )
+        self.assertEqual(
+            env_variables["projects_to_build"],
+            "bolt;clang;clang-tools-extra;flang;lld;lldb;llvm;mlir;polly",
+        )
+        self.assertEqual(
+            env_variables["project_check_targets"],
+            "check-bolt check-clang check-clang-tools check-flang check-lit check-lld check-lldb check-llvm check-mlir check-polly",
+        )
+        self.assertEqual(
+            env_variables["runtimes_to_build"], "libcxx;libcxxabi;libunwind"
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets"],
+            "",
+        )
+        self.assertEqual(
+            env_variables["runtimes_check_targets_needs_reconfig"],
+            "check-cxx check-cxxabi check-unwind",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This patch makes it so that we run the lit tests when lit is changed. This can make it much easier to catch portability issues with the tests (like tests not working properly on Windows). It's also helpful as we spend time working on enabling the internal shell by default.