### PR TITLE
[SLPVectorizer] Move size checks (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6828,12 +6828,11 @@ bool BoUpSLP::isStridedLoad(ArrayRef<Value *> VL, ArrayRef<Value *> PointerOps,
     return false;
 
   // Try to generate strided load node.
-  auto IsAnyPointerUsedOutGraph =
-      any_of(PointerOps, [&](Value *V) {
-        return isa<Instruction>(V) && any_of(V->users(), [&](User *U) {
-                 return !isVectorized(U) && !MustGather.contains(U);
-               });
-      });
+  auto IsAnyPointerUsedOutGraph = any_of(PointerOps, [&](Value *V) {
+    return isa<Instruction>(V) && any_of(V->users(), [&](User *U) {
+             return !isVectorized(U) && !MustGather.contains(U);
+           });
+  });
 
   const uint64_t AbsoluteDiff = std::abs(Diff);
   Type *ScalarTy = VL.front()->getType();

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6824,14 +6824,12 @@ bool BoUpSLP::isStridedLoad(ArrayRef<Value *> VL, ArrayRef<Value *> PointerOps,
                             const int64_t Diff,
                             StridedPtrInfo &SPtrInfo) const {
   const size_t Sz = VL.size();
-  // Simple check if not a strided access - clear order.
-  bool IsPossibleStrided = Diff % (Sz - 1) == 0;
-  if (!IsPossibleStrided)
+  if (Diff % (Sz - 1) != 0)
     return false;
 
   // Try to generate strided load node.
   auto IsAnyPointerUsedOutGraph =
-      IsPossibleStrided && any_of(PointerOps, [&](Value *V) {
+      Iany_of(PointerOps, [&](Value *V) {
         return isa<Instruction>(V) && any_of(V->users(), [&](User *U) {
                  return !isVectorized(U) && !MustGather.contains(U);
                });

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -6829,7 +6829,7 @@ bool BoUpSLP::isStridedLoad(ArrayRef<Value *> VL, ArrayRef<Value *> PointerOps,
 
   // Try to generate strided load node.
   auto IsAnyPointerUsedOutGraph =
-      Iany_of(PointerOps, [&](Value *V) {
+      any_of(PointerOps, [&](Value *V) {
         return isa<Instruction>(V) && any_of(V->users(), [&](User *U) {
                  return !isVectorized(U) && !MustGather.contains(U);
                });

--- a/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
+++ b/llvm/lib/Transforms/Vectorize/SLPVectorizer.cpp
@@ -2237,8 +2237,7 @@ public:
   bool isStridedLoad(ArrayRef<Value *> VL, ArrayRef<Value *> PointerOps,
                      ArrayRef<unsigned> Order, const TargetTransformInfo &TTI,
                      const DataLayout &DL, ScalarEvolution &SE,
-                     const bool IsAnyPointerUsedOutGraph, const int64_t Diff,
-                     StridedPtrInfo &SPtrInfo) const;
+                     const int64_t Diff, StridedPtrInfo &SPtrInfo) const;
 
   /// Checks if the given array of loads can be represented as a vectorized,
   /// scatter or just simple gather.
@@ -6822,10 +6821,22 @@ bool BoUpSLP::isStridedLoad(ArrayRef<Value *> VL, ArrayRef<Value *> PointerOps,
                             ArrayRef<unsigned> Order,
                             const TargetTransformInfo &TTI,
                             const DataLayout &DL, ScalarEvolution &SE,
-                            const bool IsAnyPointerUsedOutGraph,
                             const int64_t Diff,
                             StridedPtrInfo &SPtrInfo) const {
   const size_t Sz = VL.size();
+  // Simple check if not a strided access - clear order.
+  bool IsPossibleStrided = Diff % (Sz - 1) == 0;
+  if (!IsPossibleStrided)
+    return false;
+
+  // Try to generate strided load node.
+  auto IsAnyPointerUsedOutGraph =
+      IsPossibleStrided && any_of(PointerOps, [&](Value *V) {
+        return isa<Instruction>(V) && any_of(V->users(), [&](User *U) {
+                 return !isVectorized(U) && !MustGather.contains(U);
+               });
+      });
+
   const uint64_t AbsoluteDiff = std::abs(Diff);
   Type *ScalarTy = VL.front()->getType();
   auto *VecTy = getWidenedType(ScalarTy, Sz);
@@ -6956,18 +6967,7 @@ BoUpSLP::LoadsState BoUpSLP::canVectorizeLoads(
                                    cast<Instruction>(V), UserIgnoreList);
                              }))
       return LoadsState::CompressVectorize;
-    // Simple check if not a strided access - clear order.
-    bool IsPossibleStrided = *Diff % (Sz - 1) == 0;
-    // Try to generate strided load node.
-    auto IsAnyPointerUsedOutGraph =
-        IsPossibleStrided && any_of(PointerOps, [&](Value *V) {
-          return isa<Instruction>(V) && any_of(V->users(), [&](User *U) {
-                   return !isVectorized(U) && !MustGather.contains(U);
-                 });
-        });
-    if (IsPossibleStrided &&
-        isStridedLoad(VL, PointerOps, Order, *TTI, *DL, *SE,
-                      IsAnyPointerUsedOutGraph, *Diff, SPtrInfo))
+    if (isStridedLoad(VL, PointerOps, Order, *TTI, *DL, *SE, *Diff, SPtrInfo))
       return LoadsState::StridedVectorize;
   }
   if (!TTI->isLegalMaskedGather(VecTy, CommonAlignment) ||


### PR DESCRIPTION
Move size checks inside `isStridedLoad`. In the future we plan to possibly change the size and type of strided load there.