### PR TITLE
[Clang][Sema] Emit warnings for non-dependent expressions in dependent context regardless of reachability

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -498,6 +498,8 @@ Improvements to Clang's diagnostics
 - Clang now generates a fix-it for C++20 designated initializers when the 
   initializers do not match the declaration order in the structure. 
 
+- Now more analysis-based warnings are emitted before template instantiation.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -16846,7 +16846,7 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body, bool IsInstantiation,
           getDiagnostics().getSuppressAllDiagnostics()) {
         DiscardCleanupsInEvaluationContext();
       }
-      if (!hasUncompilableErrorOccurred() && !isa<FunctionTemplateDecl>(dcl)) {
+      if (!hasUncompilableErrorOccurred()) {
         // Since the body is valid, issue any analysis-based warnings that are
         // enabled.
         ActivePolicy = &WP;
@@ -16903,7 +16903,11 @@ Decl *Sema::ActOnFinishFunctionBody(Decl *dcl, Stmt *Body, bool IsInstantiation,
     PopDeclContext();
 
   if (!RetainFunctionScopeInfo)
-    PopFunctionScopeInfo(ActivePolicy, dcl);
+    // If `dcl` is `FunctionTemplateDecl`, pass its corresponding
+    // `FunctionDecl`, otherwise (e.g., `ObjCMethodDecl`), pass `dcl`,
+    // so that we can emit some diagnostics in
+    // `AnalysisBasedWarnings::IssueWarnings()`
+    PopFunctionScopeInfo(ActivePolicy, FD ? FD : dcl);
   // If any errors have occurred, clear out any temporaries that may have
   // been leftover. This ensures that these temporaries won't be picked up for
   // deletion in some later function.

--- a/clang/test/SemaCXX/warn-unsequenced.cpp
+++ b/clang/test/SemaCXX/warn-unsequenced.cpp
@@ -782,8 +782,8 @@ int Foo<X>::Run() {
   // cxx11-warning@-1 {{unsequenced modification and access to 'num'}}
 
   foo(num++, num++);
-  // cxx11-warning@-1 {{multiple unsequenced modifications to 'num'}}
-  // cxx17-warning@-2 {{multiple unsequenced modifications to 'num'}}
+  // cxx11-warning@-1 2{{multiple unsequenced modifications to 'num'}}
+  // cxx17-warning@-2 2{{multiple unsequenced modifications to 'num'}}
   return 1;
 }
 

--- a/clang/test/SemaCXX/warn-unused-value.cpp
+++ b/clang/test/SemaCXX/warn-unused-value.cpp
@@ -178,3 +178,52 @@ auto b() {
 }
 } // namespace test6
 #endif
+
+#if __cplusplus >= 201402L
+namespace test7 {
+auto L1 = [] {
+  0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  return;
+  0, 0;
+};
+auto L2 = [](auto) {
+  0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  return;
+  0, 0; // expected-warning {{left operand of comma operator has no effect}}
+};
+
+void f1() {
+  auto L1 = [] {
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+    return;
+    0, 0;
+  };
+  auto L2 = [](auto) {
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+    return;
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  };
+
+  0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  return;
+  0, 0;
+}
+
+template <typename> void f2() {
+  auto L1 = [] {
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+    return;
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  };
+  auto L2 = [](auto) {
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+    return;
+    0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  };
+
+  0, 0; // expected-warning {{left operand of comma operator has no effect}}
+  return;
+  0, 0; // expected-warning {{left operand of comma operator has no effect}}
+}
+}
+#endif


### PR DESCRIPTION
Before this patch, all diagnostics in `FunctionScopes.back()->PossiblyUnreachableDiags` are discarded if they are in dependent context, but we don't perform CFG analysis after template instantiation, so some diagnostics are never emitted.

In this patch, diagnostics from non-dependent expressions are emitted, as they are never "instantiated" during template instantiation, and most semantic checks are not performed again. Some false positive will be introduced but I think more false negative will be fixed.

Diagnostics from dependent expressions are still not emitted until being instantiated to provide more precise diagnostics.