### PR TITLE
Reapply "[llvm-exegesis] Exclude loads/stores from aliasing instruction set" (#156735)

### DIFF
--- a/llvm/test/tools/llvm-exegesis/AArch64/no-aliasing-ld-str.s
+++ b/llvm/test/tools/llvm-exegesis/AArch64/no-aliasing-ld-str.s
@@ -1,0 +1,8 @@
+REQUIRES: aarch64-registered-target
+
+RUN: llvm-exegesis -mtriple=aarch64 -mcpu=neoverse-v2 -mode=latency --dump-object-to-disk=%d --opcode-name=FMOVWSr --benchmark-phase=assemble-measured-code 2>&1
+RUN: llvm-objdump -d %d > %t.s
+RUN: FileCheck %s < %t.s
+
+CHECK-NOT: ld{{[1-4]}}
+CHECK-NOT: st{{[1-4]}}

--- a/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
+++ b/llvm/tools/llvm-exegesis/lib/SerialSnippetGenerator.cpp
@@ -57,6 +57,12 @@ computeAliasingInstructions(const LLVMState &State, const Instruction *Instr,
       continue;
     if (OtherInstr.hasMemoryOperands())
       continue;
+    // Filtering out loads/stores might belong in hasMemoryOperands(), but that
+    // complicates things as there are instructions with may load/store that
+    // don't have operands (e.g. X86's CLUI instruction). So, it's easier to
+    // filter them out here.
+    if (OtherInstr.Description.mayLoad() || OtherInstr.Description.mayStore())
+      continue;
     if (!ET.allowAsBackToBack(OtherInstr))
       continue;
     if (Instr->hasAliasingRegistersThrough(OtherInstr, ForbiddenRegisters))


### PR DESCRIPTION
Move the mayLoad/mayStore checks out of hasMemoryOperands; there are instructions with these properties that don't have operands.