### PR TITLE
Fix possible underflow in ParseAndSetPath

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_file.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_file.cpp
@@ -108,6 +108,9 @@ static void ParseAndSetPath(const char *pattern, char *dest,
   CHECK(dest);
   CHECK_GE(dest_size, 1);
   dest[0] = '\0';
+  // Return empty string if empty string was passed
+  if (internal_strlen(pattern) == 0)
+    return;
   uptr next_substr_start_idx = 0;
   for (uptr i = 0; i < internal_strlen(pattern) - 1; i++) {
     if (pattern[i] != '%')


### PR DESCRIPTION
If an empty path is passed, the internal_strlen -1 below will loop round to become uptr max. Adding this check ensures that this would be caught