### PR TITLE
[lldb][test] Disable parallel module loading for TestNetBSDCore.py

### DIFF
--- a/lldb/test/API/functionalities/postmortem/netbsd-core/TestNetBSDCore.py
+++ b/lldb/test/API/functionalities/postmortem/netbsd-core/TestNetBSDCore.py
@@ -117,6 +117,8 @@ class NetBSDCoreCommonTestCase(TestBase):
                 )
 
     def do_test(self, filename, pid, region_count):
+        # Temporary workaround for https://github.com/llvm/llvm-project/issues/159377
+        self.runCmd("settings set target.parallel-module-load false")
         target = self.dbg.CreateTarget(filename)
         process = target.LoadCore(filename + ".core")
 


### PR DESCRIPTION
Since #157170 this test has been flakey on several LLDB buildbots. I suspect it's to do with mutli-threading, there are more details in #159377.

Disable parallel loading for now so we are not spamming people making unrelated changes.