### PR TITLE
[PowerPC] Fix vector extend result types in BUILD_VECTOR lowering

### DIFF
--- a/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
+++ b/llvm/lib/Target/PowerPC/PPCISelLowering.cpp
@@ -9904,20 +9904,24 @@ SDValue PPCTargetLowering::LowerBUILD_VECTOR(SDValue Op,
     SmallVector<SDValue, 16> Ops(16, C);
     SDValue BV = DAG.getBuildVector(MVT::v16i8, dl, Ops);
     unsigned IID;
+    EVT VT;
     switch (SplatSize) {
     default:
       llvm_unreachable("Unexpected type for vector constant.");
     case 2:
       IID = Intrinsic::ppc_altivec_vupklsb;
+      VT = MVT::v8i16;
       break;
     case 4:
       IID = Intrinsic::ppc_altivec_vextsb2w;
+      VT = MVT::v4i32;
       break;
     case 8:
       IID = Intrinsic::ppc_altivec_vextsb2d;
+      VT = MVT::v2i64;
       break;
     }
-    SDValue Extend = BuildIntrinsicOp(IID, BV, DAG, dl);
+    SDValue Extend = BuildIntrinsicOp(IID, BV, DAG, dl, VT);
     return DAG.getBitcast(Op->getValueType(0), Extend);
   }
   assert(!IsSplat64 && "Unhandled 64-bit splat pattern");

--- a/llvm/test/CodeGen/PowerPC/splat-extend.ll
+++ b/llvm/test/CodeGen/PowerPC/splat-extend.ll
@@ -48,3 +48,21 @@ define dso_local noundef <2 x i64> @v11l() local_unnamed_addr {
 entry:
   ret <2 x i64> splat (i64 -11)
 }
+
+declare <4 x i32> @llvm.ppc.altivec.vextsb2w(<16 x i8>)
+
+define i32 @crash(ptr %p) {
+; CHECK-LABEL: crash:
+; CHECK:       # %bb.0: # %entry
+; CHECK-NEXT:    xxspltib v2, 127
+; CHECK-NEXT:    vextsb2w v2, v2
+; CHECK-NEXT:    stxv v2, 0(r3)
+; CHECK-NEXT:    li r3, 0
+; CHECK-NEXT:    stxv v2, 0(0)
+; CHECK-NEXT:    blr
+entry:
+  store <4 x i32> <i32 127, i32 127, i32 127, i32 127>, ptr %p, align 16
+  %0 = call <4 x i32> @llvm.ppc.altivec.vextsb2w(<16 x i8> <i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127, i8 127>)
+  store <4 x i32> %0, ptr null, align 16
+  ret i32 0
+}


### PR DESCRIPTION
The result type of the vector extend intrinsics generated by the BUILD_VECTOR lowering code should match how they are actually defined. Currently the result type is defaulting to the operand type there. This can conflict with calls to the same intrinsic from other paths.