### PR TITLE
Use internal linkage for __NoopCoro_ResumeDestroy

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -132,7 +132,7 @@ void Lowerer::lowerCoroNoop(IntrinsicInst *II) {
 
     // Create a Noop function that does nothing.
     Function *NoopFn = Function::createWithDefaultAttr(
-        FnTy, GlobalValue::LinkageTypes::PrivateLinkage,
+        FnTy, GlobalValue::LinkageTypes::InternalLinkage,
         M.getDataLayout().getProgramAddressSpace(), "__NoopCoro_ResumeDestroy",
         &M);
     NoopFn->setCallingConv(CallingConv::Fast);

--- a/llvm/test/Transforms/Coroutines/coro-noop-pacbti.ll
+++ b/llvm/test/Transforms/Coroutines/coro-noop-pacbti.ll
@@ -1,7 +1,7 @@
 
 ; RUN: opt < %s -S -passes=coro-early | FileCheck %s
 
-; CHECK:      define private fastcc void @__NoopCoro_ResumeDestroy(ptr %0) #1 {
+; CHECK:      define internal fastcc void @__NoopCoro_ResumeDestroy(ptr %0) #1 {
 ; CHECK-NEXT: entry:
 ; CHECK-NEXT:   ret void
 ; CHECK-NEXT: }

--- a/llvm/test/Transforms/Coroutines/coro-noop.ll
+++ b/llvm/test/Transforms/Coroutines/coro-noop.ll
@@ -26,7 +26,7 @@ declare ptr @llvm.coro.noop()
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 
 
-; CHECK: define private fastcc void @__NoopCoro_ResumeDestroy(ptr %0) !dbg ![[RESUME:[0-9]+]] {
+; CHECK: define internal fastcc void @__NoopCoro_ResumeDestroy(ptr %0) !dbg ![[RESUME:[0-9]+]] {
 ; CHECK-NEXT: entry
 ; CHECK-NEXT:    ret void
 


### PR DESCRIPTION
`__NoopCoro_ResumeDestroy` currently has private linkage, which causes [issues for Arm64EC](https://github.com/llvm/llvm-project/issues/158341). The Arm64EC lowering is trying to mangle and add thunks for `__NoopCoro_ResumeDestroy`, since it sees that it's address is taken (and, therefore, might be called from x64 code via a function pointer). MSVC's linker requires that the function be placed in COMDAT (`LNK1361: non COMDAT symbol '.L#__NoopCoro_ResumeDestroy' in hybrid binary`) which trips an assert in the verifier (`comdat global value has private linkage`) and the subsequent linking step fails since the private symbol isn't in the symbol table.

Since there is no reason to use private linkage for `__NoopCoro_ResumeDestroy` and other coro related functions have also been [switched to internal linkage to improve debugging](https://github.com/llvm/llvm-project/pull/151224), this change switches to using internal linkage.

Fixes #158341