### PR TITLE
Fix build failure in CommonArgs.cpp on MSVC 2022: warning C4715: 'clang::driver::tools::complexRangeKindToStr': not all control paths return a value

### DIFF
--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3506,20 +3506,16 @@ std::string tools::complexRangeKindToStr(LangOptions::ComplexRangeKind Range) {
   switch (Range) {
   case LangOptions::ComplexRangeKind::CX_Full:
     return "full";
-    break;
   case LangOptions::ComplexRangeKind::CX_Basic:
     return "basic";
-    break;
   case LangOptions::ComplexRangeKind::CX_Improved:
     return "improved";
-    break;
   case LangOptions::ComplexRangeKind::CX_Promoted:
     return "promoted";
-    break;
   case LangOptions::ComplexRangeKind::CX_None:
     return "none";
-    break;
   }
+  llvm_unreachable("Unknown ComplexRangeKind!");
 }
 
 std::string


### PR DESCRIPTION
Fixes this error:
```
llvm\clang\lib\Driver\ToolChains\CommonArgs.cpp(3523) : warning C4715: 'clang::driver::tools::complexRangeKindToStr': not all control paths return a value
```

This was not seen in the builders as they use MSVC 2019.

Opted to add an `llvm_unreachable` after the switch instead of a `default` so that Clang's warnings about uncovered enum values will still trigger. This matches #112767 and #139309.

Also removed the dead `break` statements after the returns.