### PR TITLE
[DTLTO] Remove XFAIL for llvm-driver

### DIFF
--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -1,8 +1,5 @@
 // REQUIRES: lld
 
-/// https://github.com/llvm/llvm-project/issues/159125.
-// XFAIL: llvm-driver
-
 /// Check DTLTO options are forwarded to the linker.
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.


### PR DESCRIPTION
DTLTO is still incompatible with llvm-driver, but the test started passing after https://github.com/llvm/llvm-project/pull/159151.