### PR TITLE
[DTLTO][TEST] Make Clang driver tests even more robust

### DIFF
--- a/clang/test/Driver/DTLTO/dtlto.c
+++ b/clang/test/Driver/DTLTO/dtlto.c
@@ -1,8 +1,5 @@
 // REQUIRES: lld
 
-/// https://github.com/llvm/llvm-project/issues/159125.
-// XFAIL: llvm-driver
-
 /// Check DTLTO options are forwarded to the linker.
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
@@ -15,7 +12,7 @@
 // FORWARD: filename.py:[[CLANG:.*]]
 // FORWARD: ld.lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}[[CLANG]]"
+// FORWARD-SAME: "--thinlto-remote-compiler={{[^"]*}}[[CLANG]]"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"
@@ -39,9 +36,10 @@
 // RUN: FileCheck %s --input-file=%t_default.log --check-prefix=DEFAULT \
 // RUN:   --implicit-check-not=distributor --implicit-check-not=remote-compiler
 
+// DEFAULT: filename.py:[[CLANG:.*]]
 // DEFAULT: ld.lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
-// DEFAULT-SAME: "--thinlto-remote-compiler={{[^"]+}}"
+// DEFAULT-SAME: "--thinlto-remote-compiler={{[^"]*}}[[CLANG]]"
 
 /// Check that nothing is forwarded when the compiler is not in LTO mode, and that
 /// appropriate unused option warnings are issued.

--- a/clang/test/Driver/DTLTO/ps5-dtlto.c
+++ b/clang/test/Driver/DTLTO/ps5-dtlto.c
@@ -1,8 +1,5 @@
 // REQUIRES: lld
 
-/// https://github.com/llvm/llvm-project/issues/159125.
-// XFAIL: llvm-driver
-
 /// Check DTLTO options are forwarded to the linker.
 
 /// Check that options are forwarded as expected with --thinlto-distributor=.
@@ -15,7 +12,7 @@
 // FORWARD: filename.py:[[CLANG:.*]]
 // FORWARD: prospero-lld
 // FORWARD-SAME: "--thinlto-distributor=d.exe"
-// FORWARD-SAME: "--thinlto-remote-compiler={{.*}}[[CLANG]]"
+// FORWARD-SAME: "--thinlto-remote-compiler={{[^"]*}}[[CLANG]]"
 // FORWARD-SAME: "--thinlto-distributor-arg=a1"
 // FORWARD-SAME: "--thinlto-distributor-arg=a2"
 // FORWARD-SAME: "--thinlto-distributor-arg=a3"
@@ -42,7 +39,7 @@
 // DEFAULT: filename.py:[[CLANG:.*]]
 // DEFAULT: prospero-lld
 // DEFAULT-SAME: "--thinlto-distributor=d.exe"
-// DEFAULT-SAME: "--thinlto-remote-compiler={{.*}}[[CLANG]]"
+// DEFAULT-SAME: "--thinlto-remote-compiler={{[^"]*}}[[CLANG]]"
 
 /// Check that the arguments are forwarded unconditionally even when the
 /// compiler is not in LTO mode.


### PR DESCRIPTION
Remove XFAILs for llvm-driver. DTLTO is still incompatible with llvm-driver, but these tests now pass after #159151.

Modify a missed regex to use filename.py (missed in #159151).

Tighten overly greedy regexes to prevent spurious failures.