### PR TITLE
[flang] Implement FNUM()

### DIFF
--- a/flang-rt/include/flang-rt/runtime/file.h
+++ b/flang-rt/include/flang-rt/runtime/file.h
@@ -27,6 +27,7 @@ class OpenFile {
 public:
   using FileOffset = std::int64_t;
 
+  int fd() const { return fd_; }
   const char *path() const { return path_.get(); }
   std::size_t pathLength() const { return pathLength_; }
   void set_path(OwningPtr<char> &&, std::size_t bytes);

--- a/flang-rt/lib/runtime/extensions.cpp
+++ b/flang-rt/lib/runtime/extensions.cpp
@@ -424,6 +424,15 @@ std::int64_t RTNAME(Ftell)(int unitNumber) {
     return -1;
   }
 }
+
+std::int32_t FORTRAN_PROCEDURE_NAME(fnum)(const int &unitNumber) {
+  if (ExternalFileUnit * unit{ExternalFileUnit::LookUp(unitNumber)}) {
+    return unit->fd();
+  } else {
+    return -1;
+  }
+}
+
 } // namespace io
 
 } // extern "C"

--- a/flang-rt/lib/runtime/unit.h
+++ b/flang-rt/lib/runtime/unit.h
@@ -59,6 +59,7 @@ class PseudoOpenFile {
 public:
   using FileOffset = std::int64_t;
 
+  RT_API_ATTRS int fd() const { return 1 /*stdout*/; }
   RT_API_ATTRS const char *path() const { return nullptr; }
   RT_API_ATTRS std::size_t pathLength() const { return 0; }
   RT_API_ATTRS void set_path(OwningPtr<char> &&, std::size_t bytes) {}

--- a/flang/docs/Intrinsics.md
+++ b/flang/docs/Intrinsics.md
@@ -716,6 +716,7 @@ CALL BACKTRACE()
 CALL FDATE(TIME)
 CALL GETLOG(USRNAME)
 CALL GETENV(NAME [, VALUE, LENGTH, STATUS, TRIM_NAME, ERRMSG ])
+unixFD = FNUM(FORTRAN_UNIT)
 ```
 
 ## Intrinsic Procedure Name Resolution
@@ -778,6 +779,7 @@ This phase currently supports all the intrinsic procedures listed above but the 
 | Atomic intrinsic subroutines | ATOMIC_ADD |
 | Collective intrinsic subroutines | CO_REDUCE |
 | Library subroutines | BACKTRACE, FDATE, GETLOG, GETENV |
+| Library functions | FNUM |
 
 
 ### Intrinsic Function Folding

--- a/flang/include/flang/Runtime/extensions.h
+++ b/flang/include/flang/Runtime/extensions.h
@@ -45,6 +45,9 @@ std::int32_t RTNAME(Fseek)(int unit, std::int64_t zeroBasedPos, int whence,
     const char *sourceFileName, int lineNumber);
 std::int64_t RTNAME(Ftell)(int unit);
 
+// FNUM maps a Fortran unit number to its UNIX file descriptor
+std::int32_t FORTRAN_PROCEDURE_NAME(fnum)(const int &unitNumber);
+
 // GNU Fortran 77 compatibility function IARGC.
 std::int32_t FORTRAN_PROCEDURE_NAME(iargc)();
 


### PR DESCRIPTION
The GNU Fortran library function FNUM(u) returns the UNIX file descriptor that corresponds to an open Fortran unit number, if any; otherwise -1.

This implementation is a library extension only, not an intrinsic.