### PR TITLE
[lldb] Add a static_assert that g_core_definitions matches the Core enum

### DIFF
--- a/lldb/source/Utility/ArchSpec.cpp
+++ b/lldb/source/Utility/ArchSpec.cpp
@@ -41,7 +41,7 @@ struct CoreDefinition {
 } // namespace lldb_private
 
 // This core information can be looked using the ArchSpec::Core as the index
-static const CoreDefinition g_core_definitions[] = {
+static constexpr const CoreDefinition g_core_definitions[] = {
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::arm, ArchSpec::eCore_arm_generic,
      "arm"},
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::arm, ArchSpec::eCore_arm_armv4,
@@ -90,12 +90,12 @@ static const CoreDefinition g_core_definitions[] = {
      "thumbv6m"},
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7,
      "thumbv7"},
-    {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7f,
-     "thumbv7f"},
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7s,
      "thumbv7s"},
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7k,
      "thumbv7k"},
+    {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7f,
+     "thumbv7f"},
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7m,
      "thumbv7m"},
     {eByteOrderLittle, 4, 2, 4, llvm::Triple::thumb, ArchSpec::eCore_thumbv7em,
@@ -256,6 +256,15 @@ static const CoreDefinition g_core_definitions[] = {
 static_assert(sizeof(g_core_definitions) / sizeof(CoreDefinition) ==
                   ArchSpec::kNumCores,
               "make sure we have one core definition for each core");
+
+template <int I> struct ArchSpecValidator : ArchSpecValidator<I + 1> {
+  static_assert(g_core_definitions[I].core == I,
+                "g_core_definitions order doesn't match Core enumeration");
+};
+
+template <> struct ArchSpecValidator<ArchSpec::kNumCores> {};
+
+ArchSpecValidator<ArchSpec::eCore_arm_generic> validator;
 
 struct ArchDefinitionEntry {
   ArchSpec::Core core;


### PR DESCRIPTION
This PR uses the same trick as 7ced9fff95473 to ensure the `g_core_definitions` table is correctly indexed by the Core enum. It's easy to make a mistake. Case in point: this caught two entries that appeared in the wrong order.