### PR TITLE
[LLDB] Add support for the structured data plugins in lldb-server

### DIFF
--- a/lldb/include/lldb/Host/common/NativeProcessProtocol.h
+++ b/lldb/include/lldb/Host/common/NativeProcessProtocol.h
@@ -409,6 +409,14 @@ public:
                                    "Not implemented");
   }
 
+  /// Get the list of structured data plugins supported by this process. They
+  /// must match the `type` field used by the corresponding
+  /// StructuredDataPlugins in the client.
+  ///
+  /// \return
+  ///     A vector of structured data plugin names.
+  virtual std::vector<std::string> GetStructuredDataPlugins() { return {}; };
+
 protected:
   struct SoftwareBreakpoint {
     uint32_t ref_count;

--- a/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
+++ b/lldb/include/lldb/Utility/StringExtractorGDBRemote.h
@@ -119,6 +119,7 @@ public:
     eServerPacketType_qRegisterInfo,
     eServerPacketType_qShlibInfoAddr,
     eServerPacketType_qStepPacketSupported,
+    eServerPacketType_qStructuredDataPlugins,
     eServerPacketType_qSupported,
     eServerPacketType_qSyncThreadStateSupported,
     eServerPacketType_qThreadExtraInfo,

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.h
@@ -86,6 +86,9 @@ public:
 
   Status InitializeConnection(std::unique_ptr<Connection> connection);
 
+  GDBRemoteCommunication::PacketResult
+  SendStructuredDataPacket(const llvm::json::Value &value);
+
   struct DebuggedProcess {
     enum class Flag {
       vkilled = (1u << 0),
@@ -184,6 +187,8 @@ protected:
   PacketResult Handle_qfThreadInfo(StringExtractorGDBRemote &packet);
 
   PacketResult Handle_qsThreadInfo(StringExtractorGDBRemote &packet);
+
+  PacketResult Handle_qStructuredDataPlugins(StringExtractorGDBRemote &packet);
 
   PacketResult Handle_p(StringExtractorGDBRemote &packet);
 

--- a/lldb/source/Utility/StringExtractorGDBRemote.cpp
+++ b/lldb/source/Utility/StringExtractorGDBRemote.cpp
@@ -280,6 +280,8 @@ StringExtractorGDBRemote::GetServerPacketType() const {
         return eServerPacketType_qSupported;
       if (PACKET_MATCHES("qSyncThreadStateSupported"))
         return eServerPacketType_qSyncThreadStateSupported;
+      if (PACKET_MATCHES("qStructuredDataPlugins"))
+        return eServerPacketType_qStructuredDataPlugins;
       break;
 
     case 'T':

--- a/lldb/unittests/tools/lldb-server/tests/LLGSTest.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/LLGSTest.cpp
@@ -9,6 +9,7 @@
 #include "TestBase.h"
 #include "lldb/Host/Host.h"
 #include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
 
 using namespace llgs_tests;
 using namespace lldb_private;
@@ -73,4 +74,17 @@ TEST_F(TestBase, LLGS_TEST(vAttachRichError)) {
           &ErrorInfoBase::message,
           testing::StartsWith(
               "cannot attach to process 1 when another process with pid"))));
+}
+
+TEST_F(TestBase, LLGS_TEST(qStructuredDataPlugins)) {
+  auto ClientOr = TestClient::launchCustom(
+      getLogFileName(),
+      /* disable_stdio */ true, {}, {getInferiorPath("environment_check")});
+  ASSERT_THAT_EXPECTED(ClientOr, Succeeded());
+  auto &Client = **ClientOr;
+  std::string response_string;
+  ASSERT_THAT_ERROR(
+      Client.SendMessage("qStructuredDataPlugins", response_string),
+      Succeeded());
+  EXPECT_STREQ("[]", response_string.c_str());
 }


### PR DESCRIPTION
The LLDB client has support for structured data plugins, but lldb-server doesn't have corresponding support for it. This patch adds the missing functionality in LLGS for servers to register their supported plugins and send corresponding async messages.