### PR TITLE
[BOLT][AArch64] Treat `br x30` as a return

### DIFF
--- a/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
+++ b/bolt/lib/Target/AArch64/AArch64MCPlusBuilder.cpp
@@ -152,6 +152,27 @@ public:
     return isLoadFromStack(Inst);
   };
 
+  bool isReturn(const MCInst &Inst) const override {
+    // BR X30 is equivalent to RET
+    if (Inst.getOpcode() == AArch64::BR &&
+        Inst.getOperand(0).getReg() == AArch64::LR)
+      return true;
+
+    return Analysis->isReturn(Inst);
+  }
+
+  bool isBranch(const MCInst &Inst) const override {
+    if (isReturn(Inst))
+      return false;
+    return Analysis->isBranch(Inst);
+  }
+
+  bool isIndirectBranch(const MCInst &Inst) const override {
+    if (isReturn(Inst))
+      return false;
+    return Analysis->isIndirectBranch(Inst);
+  }
+
   void createCall(MCInst &Inst, const MCSymbol *Target,
                   MCContext *Ctx) override {
     createDirectCall(Inst, Target, Ctx, false);

--- a/bolt/test/AArch64/br-x30.s
+++ b/bolt/test/AArch64/br-x30.s
@@ -1,0 +1,16 @@
+## Test that "br x30" is treated as a return instruction and not as an indirect
+## branch.
+
+# RUN: %clang %cflags %s -o %t.exe -Wl,-q -Wl,--entry=foo
+# RUN: llvm-bolt %t.exe -o %t.bolt --print-cfg 2>&1 | FileCheck %s
+
+# CHECK: BB Count : 2
+# CHECK-NOT: UNKNOWN CONTROL FLOW
+
+  .text
+  .global foo
+  .type foo, %function
+foo:
+  br x30
+  nop
+  .size foo, .-foo


### PR DESCRIPTION
On AArch64, `br x30` instruction is equivalent to `ret`. Treat it as such while analysing the control flow.

Without the special case, `br x30` is considered an indirect branch with an unknown control flow making a control flow analysis more complicated than necessary.

We can also replace `br x30` with `ret`. I'd rather do it in a separate pass to allow tools built on top of BOLT to have access to the original assembly.