### PR TITLE
[RISCV] Add MVendorID, MArchID, and MImpID for sifive-p550.

### DIFF
--- a/clang/test/CodeGen/RISCV/builtin-cpu-is.c
+++ b/clang/test/CodeGen/RISCV/builtin-cpu-is.c
@@ -37,3 +37,21 @@ int test_cpu_is_veyron_v1() {
 int test_cpu_is_spacemit_x60() {
   return __builtin_cpu_is("spacemit-x60");
 }
+
+// CHECK-RV64-LABEL: define dso_local signext i32 @test_cpu_is_sifive_p550(
+// CHECK-RV64-SAME: ) #[[ATTR0]] {
+// CHECK-RV64-NEXT:  [[ENTRY:.*:]]
+// CHECK-RV64-NEXT:    [[TMP0:%.*]] = load i32, ptr @__riscv_cpu_model, align 4
+// CHECK-RV64-NEXT:    [[TMP1:%.*]] = icmp eq i32 [[TMP0]], 1161
+// CHECK-RV64-NEXT:    [[TMP2:%.*]] = load i64, ptr getelementptr inbounds nuw ({ i32, i64, i64 }, ptr @__riscv_cpu_model, i32 0, i32 1), align 8
+// CHECK-RV64-NEXT:    [[TMP3:%.*]] = icmp eq i64 [[TMP2]], -9223372036854775800
+// CHECK-RV64-NEXT:    [[TMP4:%.*]] = and i1 [[TMP1]], [[TMP3]]
+// CHECK-RV64-NEXT:    [[TMP5:%.*]] = load i64, ptr getelementptr inbounds nuw ({ i32, i64, i64 }, ptr @__riscv_cpu_model, i32 0, i32 2), align 8
+// CHECK-RV64-NEXT:    [[TMP6:%.*]] = icmp eq i64 [[TMP5]], 102892581
+// CHECK-RV64-NEXT:    [[TMP7:%.*]] = and i1 [[TMP4]], [[TMP6]]
+// CHECK-RV64-NEXT:    [[CONV:%.*]] = zext i1 [[TMP7]] to i32
+// CHECK-RV64-NEXT:    ret i32 [[CONV]]
+//
+int test_cpu_is_sifive_p550() {
+  return __builtin_cpu_is("sifive-p550");
+}

--- a/llvm/lib/Target/RISCV/RISCVProcessors.td
+++ b/llvm/lib/Target/RISCV/RISCVProcessors.td
@@ -390,7 +390,11 @@ def SIFIVE_P550 : RISCVProcessorModel<"sifive-p550", SiFiveP500Model,
                                        FeatureStdExtC,
                                        FeatureStdExtZba,
                                        FeatureStdExtZbb],
-                                      SiFiveP500TuneFeatures>;
+                                      SiFiveP500TuneFeatures> {
+  let MVendorID = 0x489;
+  let MArchID = 0x8000000000000008;
+  let MImpID = 0x6220425;
+}
 
 def SIFIVE_P670 : RISCVProcessorModel<"sifive-p670", SiFiveP600Model,
                                       !listconcat(RVA22U64Features,


### PR DESCRIPTION
cat /proc/cpuinfo from HiFive Premier board

processor	: 0
hart		: 0
isa		: rv64imafdch_zicsr_zifencei_zba_zbb_sscofpmf
mmu		: sv48
mvendorid	: 0x489
marchid		: 0x8000000000000008
mimpid		: 0x6220425