### PR TITLE
[RISCV] Update the vector integer division cycle in SiFive7 scheduling model

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
+++ b/llvm/lib/Target/RISCV/RISCVSchedSiFive7.td
@@ -694,8 +694,11 @@ multiclass SiFive7WriteResBase<int VLEN,
 
   foreach mx = SchedMxList in {
     foreach sew = SchedSEWSet<mx>.val in {
-      defvar Cycles = !mul(SiFive7GetDivOrSqrtFactor<sew>.c,
-                           !div(SiFive7GetCyclesOnePerElement<mx, sew, VLEN>.c, 4));
+      // One bit at a time, but up to four elements can be processed at a time.
+      // Add 3 to number of elements to ensure the group formed by remainder
+      // elements are accounted for.
+      defvar Cycles =
+          !mul(sew, !div(!add(3, SiFive7GetCyclesOnePerElement<mx, sew, VLEN>.c), 4));
       defvar IsWorstCase = SiFive7IsWorstCaseMXSEW<mx, sew, SchedMxList>.c;
       let Latency = Cycles, AcquireAtCycles = [0, 1], ReleaseAtCycles = [1, !add(1, Cycles)] in {
         defm : LMULSEWWriteResMXSEW<"WriteVIDivV", [VCQ, VA1], mx, sew, IsWorstCase>;

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/different-sew-instruments.s
@@ -11,13 +11,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      359
+# CHECK-NEXT: Total Cycles:      261
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.01
-# CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 356.0
+# CHECK-NEXT: uOps Per Cycle:    0.02
+# CHECK-NEXT: IPC:               0.02
+# CHECK-NEXT: Block RThroughput: 258.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -29,9 +29,9 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -45,14 +45,14 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     356.00 2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     258.00 2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/fractional-lmul-data.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/fractional-lmul-data.s
@@ -11,13 +11,13 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      91
+# CHECK-NEXT: Total Cycles:      85
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.04
-# CHECK-NEXT: IPC:               0.04
-# CHECK-NEXT: Block RThroughput: 88.0
+# CHECK-NEXT: uOps Per Cycle:    0.05
+# CHECK-NEXT: IPC:               0.05
+# CHECK-NEXT: Block RThroughput: 82.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -29,9 +29,9 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      64    64.00                       vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      30    30.00                       vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      16    16.00                       vdiv.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -45,11 +45,11 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     88.00  2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     82.00  2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     65.00  1.00    -      -     vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vdiv.vv	v12, v12, v12

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/multiple-same-sew-instruments.s
@@ -16,13 +16,13 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      8
-# CHECK-NEXT: Total Cycles:      574
+# CHECK-NEXT: Total Cycles:      648
 # CHECK-NEXT: Total uOps:        8
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 571.0
+# CHECK-NEXT: Block RThroughput: 645.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -34,13 +34,13 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      114   114.00                      vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdivu.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e32, m1, tu, mu
-# CHECK-NEXT:  1      112   112.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      112   112.00                      vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdivu.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -54,18 +54,18 @@ vdivu.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     3.00    -     571.00 5.00    -      -
+# CHECK-NEXT:  -      -     3.00    -     645.00 5.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdivu.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vdivu.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdivu.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/needs-sew-but-only-lmul.s
@@ -10,13 +10,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      485
+# CHECK-NEXT: Total Cycles:      261
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.01
 # CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 482.0
+# CHECK-NEXT: Block RThroughput: 258.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -28,8 +28,8 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -43,13 +43,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     482.00 2.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     258.00 2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-at-start.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      2
-# CHECK-NEXT: Total Cycles:      244
+# CHECK-NEXT: Total Cycles:      132
 # CHECK-NEXT: Total uOps:        2
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.01
-# CHECK-NEXT: IPC:               0.01
-# CHECK-NEXT: Block RThroughput: 241.0
+# CHECK-NEXT: uOps Per Cycle:    0.02
+# CHECK-NEXT: IPC:               0.02
+# CHECK-NEXT: Block RThroughput: 129.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,7 +26,7 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -40,12 +40,12 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     241.00 1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     129.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-middle.s
@@ -13,13 +13,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      3
-# CHECK-NEXT: Total Cycles:      2834
+# CHECK-NEXT: Total Cycles:      2050
 # CHECK-NEXT: Total uOps:        3
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 2834.0
+# CHECK-NEXT: Block RThroughput: 2050.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -30,9 +30,9 @@ vdiv.vv v8, v8, v12
 # CHECK-NEXT: [6]: HasSideEffects (U)
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
-# CHECK-NEXT:  1      1920  1920.00                     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  1      912   912.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                     vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -46,13 +46,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     2834.00 2.00   -      -
+# CHECK-NEXT:  -      -     1.00    -     2050.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
-# CHECK-NEXT:  -      -      -      -     1921.00 1.00   -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     913.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-in-region.s
@@ -12,13 +12,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      2
-# CHECK-NEXT: Total Cycles:      118
+# CHECK-NEXT: Total Cycles:      132
 # CHECK-NEXT: Total uOps:        2
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 115.0
+# CHECK-NEXT: Block RThroughput: 129.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -30,7 +30,7 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -44,12 +44,12 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     115.00 1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     129.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/sew-instrument-straddles-region.s
@@ -13,13 +13,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      2
-# CHECK-NEXT: Total Cycles:      118
+# CHECK-NEXT: Total Cycles:      132
 # CHECK-NEXT: Total uOps:        2
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.02
 # CHECK-NEXT: IPC:               0.02
-# CHECK-NEXT: Block RThroughput: 115.0
+# CHECK-NEXT: Block RThroughput: 129.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -31,7 +31,7 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -45,12 +45,12 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     1.00    -     115.00 1.00    -      -
+# CHECK-NEXT:  -      -     1.00    -     129.00 1.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vector-integer-arithmetic.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vector-integer-arithmetic.s
@@ -775,13 +775,13 @@ vmv.v.v v4, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      727
-# CHECK-NEXT: Total Cycles:      12174
+# CHECK-NEXT: Total Cycles:      10980
 # CHECK-NEXT: Total uOps:        727
 
 # CHECK:      Dispatch Width:    2
-# CHECK-NEXT: uOps Per Cycle:    0.06
-# CHECK-NEXT: IPC:               0.06
-# CHECK-NEXT: Block RThroughput: 11583.0
+# CHECK-NEXT: uOps Per Cycle:    0.07
+# CHECK-NEXT: IPC:               0.07
+# CHECK-NEXT: Block RThroughput: 10389.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -1272,49 +1272,49 @@ vmv.v.v v4, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      8     16.00                       vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      30    30.00                       vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      16    16.00                       vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      60    60.00                       vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      32    32.00                       vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      120   120.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      64    64.00                       vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      128   128.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      480   480.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      256   256.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      960   960.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      512   512.00                      vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      1920  1920.00                     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      30    30.00                       vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      32    32.00                       vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      60    60.00                       vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      64    64.00                       vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      120   120.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      128   128.00                      vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      256   256.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      480   480.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      512   512.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      960   960.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      56    56.00                       vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      64    64.00                       vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      112   112.00                      vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      224   224.00                      vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      256   256.00                      vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      448   448.00                      vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      512   512.00                      vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   896.00                      vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      1024  1024.00                     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      114   114.00                      vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      228   228.00                      vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      256   256.00                      vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      456   456.00                      vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      512   512.00                      vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      912   912.00                      vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      1024  1024.00                     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      8     1.00                        vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, zero, e8, mf4, tu, mu
@@ -1532,7 +1532,7 @@ vmv.v.v v4, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     342.00  -     11583.00 385.00  -    -
+# CHECK-NEXT:  -      -     342.00  -     10389.00 385.00  -    -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
@@ -2016,49 +2016,49 @@ vmv.v.v v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     17.00  1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     121.00 1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     65.00  1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     481.00 1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     257.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     961.00 1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     513.00 1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1921.00 1.00   -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     31.00  1.00    -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     33.00  1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00  1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     65.00  1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     121.00 1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     257.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     481.00 1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     513.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     961.00 1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     57.00  1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     65.00  1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     113.00 1.00    -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     225.00 1.00    -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     257.00 1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     449.00 1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     513.00 1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     115.00 1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     229.00 1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     257.00 1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     457.00 1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     513.00 1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     913.00 1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -     2.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetivli-lmul-sew-instrument.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      1141
+# CHECK-NEXT: Total Cycles:      1157
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 1138.0
+# CHECK-NEXT: Block RThroughput: 1154.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,9 +26,9 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetivli	zero, 8, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                     vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -42,14 +42,14 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     1138.00 2.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     1154.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetivli	zero, 8, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX280/vsetvli-lmul-sew-instrument.s
@@ -8,13 +8,13 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Iterations:        1
 # CHECK-NEXT: Instructions:      4
-# CHECK-NEXT: Total Cycles:      1141
+# CHECK-NEXT: Total Cycles:      1157
 # CHECK-NEXT: Total uOps:        4
 
 # CHECK:      Dispatch Width:    2
 # CHECK-NEXT: uOps Per Cycle:    0.00
 # CHECK-NEXT: IPC:               0.00
-# CHECK-NEXT: Block RThroughput: 1138.0
+# CHECK-NEXT: Block RThroughput: 1154.0
 
 # CHECK:      Instruction Info:
 # CHECK-NEXT: [1]: #uOps
@@ -26,9 +26,9 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    Instructions:
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      128   128.00                      vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U     vsetvli	zero, a0, e32, m8, tu, mu
-# CHECK-NEXT:  1      896   896.00                      vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                     vdiv.vv	v8, v8, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN512SiFive7FDiv
@@ -42,14 +42,14 @@ vdiv.vv v8, v8, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]
-# CHECK-NEXT:  -      -     2.00    -     1138.00 2.00   -      -
+# CHECK-NEXT:  -      -     2.00    -     1154.00 2.00   -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00 1.00    -      -     vdiv.vv	v8, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -     vsetvli	zero, a0, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00 1.00    -      -     vdiv.vv	v8, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00 1.00   -      -     vdiv.vv	v8, v8, v12
 
 # CHECK:      Timeline view:
 # CHECK-NEXT: Index     0123

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX390/fractional-lmul-data.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX390/fractional-lmul-data.s
@@ -35,9 +35,9 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]                                        [9]                        Instructions:
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      112   112.00                       112   VLEN1024X300SiFive7VA1[1,113],VLEN1024X300SiFive7VA1OrVA2[1,113],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      128   128.00                       128   VLEN1024X300SiFive7VA1[1,129],VLEN1024X300SiFive7VA1OrVA2[1,129],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      60    60.00                        60    VLEN1024X300SiFive7VA1[1,61],VLEN1024X300SiFive7VA1OrVA2[1,61],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  1      32    32.00                        32    VLEN1024X300SiFive7VA1[1,33],VLEN1024X300SiFive7VA1OrVA2[1,33],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v12, v12, v12
 
 # CHECK:      Resources:
 # CHECK-NEXT: [0]   - VLEN1024X300SiFive7FDiv
@@ -52,11 +52,11 @@ vdiv.vv v12, v12, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]
-# CHECK-NEXT:  -      -     2.00    -     174.00  -     2.00    -      -
+# CHECK-NEXT:  -      -     2.00    -     162.00  -     2.00    -      -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    Instructions:
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     113.00  -     1.00    -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     129.00  -     1.00    -      -     vdiv.vv	v12, v12, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00   -     1.00    -      -     vdiv.vv	v12, v12, v12
+# CHECK-NEXT:  -      -      -      -     33.00   -     1.00    -      -     vdiv.vv	v12, v12, v12

--- a/llvm/test/tools/llvm-mca/RISCV/SiFiveX390/vector-integer-arithmetic.s
+++ b/llvm/test/tools/llvm-mca/RISCV/SiFiveX390/vector-integer-arithmetic.s
@@ -1278,49 +1278,49 @@ vmv.v.v v4, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e64, m8, tu, mu
 # CHECK-NEXT:  1      8     8.00                         8     VLEN1024X300SiFive7VA1OrVA2[1,17],VLEN1024X300SiFive7VCQ VMULHU_VX    vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  1      60    60.00                        60    VLEN1024X300SiFive7VA1[1,61],VLEN1024X300SiFive7VA1OrVA2[1,61],VLEN1024X300SiFive7VCQ VDIVU_VV vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      32    32.00                        32    VLEN1024X300SiFive7VA1[1,33],VLEN1024X300SiFive7VA1OrVA2[1,33],VLEN1024X300SiFive7VCQ VDIVU_VV vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  1      120   120.00                       120   VLEN1024X300SiFive7VA1[1,121],VLEN1024X300SiFive7VA1OrVA2[1,121],VLEN1024X300SiFive7VCQ VDIVU_VX vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      64    64.00                        64    VLEN1024X300SiFive7VA1[1,65],VLEN1024X300SiFive7VA1OrVA2[1,65],VLEN1024X300SiFive7VCQ VDIVU_VX vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  1      240   240.00                       240   VLEN1024X300SiFive7VA1[1,241],VLEN1024X300SiFive7VA1OrVA2[1,241],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      128   128.00                       128   VLEN1024X300SiFive7VA1[1,129],VLEN1024X300SiFive7VA1OrVA2[1,129],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  1      480   480.00                       480   VLEN1024X300SiFive7VA1[1,481],VLEN1024X300SiFive7VA1OrVA2[1,481],VLEN1024X300SiFive7VCQ VDIV_VX vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      256   256.00                       256   VLEN1024X300SiFive7VA1[1,257],VLEN1024X300SiFive7VA1OrVA2[1,257],VLEN1024X300SiFive7VCQ VDIV_VX vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  1      960   960.00                       960   VLEN1024X300SiFive7VA1[1,961],VLEN1024X300SiFive7VA1OrVA2[1,961],VLEN1024X300SiFive7VCQ VREMU_VV vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      512   512.00                       512   VLEN1024X300SiFive7VA1[1,513],VLEN1024X300SiFive7VA1OrVA2[1,513],VLEN1024X300SiFive7VCQ VREMU_VV vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  1      1920  1920.00                      1920  VLEN1024X300SiFive7VA1[1,1921],VLEN1024X300SiFive7VA1OrVA2[1,1921],VLEN1024X300SiFive7VCQ VREMU_VX vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      1024  1024.00                      1024  VLEN1024X300SiFive7VA1[1,1025],VLEN1024X300SiFive7VA1OrVA2[1,1025],VLEN1024X300SiFive7VCQ VREMU_VX vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  1      3840  3840.00                      3840  VLEN1024X300SiFive7VA1[1,3841],VLEN1024X300SiFive7VA1OrVA2[1,3841],VLEN1024X300SiFive7VCQ VREM_VV vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      2048  2048.00                      2048  VLEN1024X300SiFive7VA1[1,2049],VLEN1024X300SiFive7VA1OrVA2[1,2049],VLEN1024X300SiFive7VCQ VREM_VV vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  1      60    60.00                        60    VLEN1024X300SiFive7VA1[1,61],VLEN1024X300SiFive7VA1OrVA2[1,61],VLEN1024X300SiFive7VCQ VREM_VX vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      64    64.00                        64    VLEN1024X300SiFive7VA1[1,65],VLEN1024X300SiFive7VA1OrVA2[1,65],VLEN1024X300SiFive7VCQ VREM_VX vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  1      120   120.00                       120   VLEN1024X300SiFive7VA1[1,121],VLEN1024X300SiFive7VA1OrVA2[1,121],VLEN1024X300SiFive7VCQ VDIVU_VV vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      128   128.00                       128   VLEN1024X300SiFive7VA1[1,129],VLEN1024X300SiFive7VA1OrVA2[1,129],VLEN1024X300SiFive7VCQ VDIVU_VV vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  1      240   240.00                       240   VLEN1024X300SiFive7VA1[1,241],VLEN1024X300SiFive7VA1OrVA2[1,241],VLEN1024X300SiFive7VCQ VDIVU_VX vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      256   256.00                       256   VLEN1024X300SiFive7VA1[1,257],VLEN1024X300SiFive7VA1OrVA2[1,257],VLEN1024X300SiFive7VCQ VDIVU_VX vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  1      480   480.00                       480   VLEN1024X300SiFive7VA1[1,481],VLEN1024X300SiFive7VA1OrVA2[1,481],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      512   512.00                       512   VLEN1024X300SiFive7VA1[1,513],VLEN1024X300SiFive7VA1OrVA2[1,513],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  1      960   960.00                       960   VLEN1024X300SiFive7VA1[1,961],VLEN1024X300SiFive7VA1OrVA2[1,961],VLEN1024X300SiFive7VCQ VDIV_VX vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      1024  1024.00                      1024  VLEN1024X300SiFive7VA1[1,1025],VLEN1024X300SiFive7VA1OrVA2[1,1025],VLEN1024X300SiFive7VCQ VDIV_VX vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  1      1920  1920.00                      1920  VLEN1024X300SiFive7VA1[1,1921],VLEN1024X300SiFive7VA1OrVA2[1,1921],VLEN1024X300SiFive7VCQ VREMU_VV vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      2048  2048.00                      2048  VLEN1024X300SiFive7VA1[1,2049],VLEN1024X300SiFive7VA1OrVA2[1,2049],VLEN1024X300SiFive7VCQ VREMU_VV vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  1      112   112.00                       112   VLEN1024X300SiFive7VA1[1,113],VLEN1024X300SiFive7VA1OrVA2[1,113],VLEN1024X300SiFive7VCQ VREMU_VX vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      128   128.00                       128   VLEN1024X300SiFive7VA1[1,129],VLEN1024X300SiFive7VA1OrVA2[1,129],VLEN1024X300SiFive7VCQ VREMU_VX vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  1      224   224.00                       224   VLEN1024X300SiFive7VA1[1,225],VLEN1024X300SiFive7VA1OrVA2[1,225],VLEN1024X300SiFive7VCQ VREM_VV vrem.vv	v4, v8, v12
+# CHECK-NEXT:  1      256   256.00                       256   VLEN1024X300SiFive7VA1[1,257],VLEN1024X300SiFive7VA1OrVA2[1,257],VLEN1024X300SiFive7VCQ VREM_VV vrem.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  1      448   448.00                       448   VLEN1024X300SiFive7VA1[1,449],VLEN1024X300SiFive7VA1OrVA2[1,449],VLEN1024X300SiFive7VCQ VREM_VX vrem.vx	v4, v8, a0
+# CHECK-NEXT:  1      512   512.00                       512   VLEN1024X300SiFive7VA1[1,513],VLEN1024X300SiFive7VA1OrVA2[1,513],VLEN1024X300SiFive7VCQ VREM_VX vrem.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  1      896   896.00                       896   VLEN1024X300SiFive7VA1[1,897],VLEN1024X300SiFive7VA1OrVA2[1,897],VLEN1024X300SiFive7VCQ VDIVU_VV vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                      1024  VLEN1024X300SiFive7VA1[1,1025],VLEN1024X300SiFive7VA1OrVA2[1,1025],VLEN1024X300SiFive7VCQ VDIVU_VV vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  1      1792  1792.00                      1792  VLEN1024X300SiFive7VA1[1,1793],VLEN1024X300SiFive7VA1OrVA2[1,1793],VLEN1024X300SiFive7VCQ VDIVU_VX vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  1      2048  2048.00                      2048  VLEN1024X300SiFive7VA1[1,2049],VLEN1024X300SiFive7VA1OrVA2[1,2049],VLEN1024X300SiFive7VCQ VDIVU_VX vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  1      228   228.00                       228   VLEN1024X300SiFive7VA1[1,229],VLEN1024X300SiFive7VA1OrVA2[1,229],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  1      256   256.00                       256   VLEN1024X300SiFive7VA1[1,257],VLEN1024X300SiFive7VA1OrVA2[1,257],VLEN1024X300SiFive7VCQ VDIV_VV vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  1      456   456.00                       456   VLEN1024X300SiFive7VA1[1,457],VLEN1024X300SiFive7VA1OrVA2[1,457],VLEN1024X300SiFive7VCQ VDIV_VX vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  1      512   512.00                       512   VLEN1024X300SiFive7VA1[1,513],VLEN1024X300SiFive7VA1OrVA2[1,513],VLEN1024X300SiFive7VCQ VDIV_VX vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  1      912   912.00                       912   VLEN1024X300SiFive7VA1[1,913],VLEN1024X300SiFive7VA1OrVA2[1,913],VLEN1024X300SiFive7VCQ VREMU_VV vremu.vv	v4, v8, v12
+# CHECK-NEXT:  1      1024  1024.00                      1024  VLEN1024X300SiFive7VA1[1,1025],VLEN1024X300SiFive7VA1OrVA2[1,1025],VLEN1024X300SiFive7VCQ VREMU_VV vremu.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  1      1824  1824.00                      1824  VLEN1024X300SiFive7VA1[1,1825],VLEN1024X300SiFive7VA1OrVA2[1,1825],VLEN1024X300SiFive7VCQ VREMU_VX vremu.vx	v4, v8, a0
+# CHECK-NEXT:  1      2048  2048.00                      2048  VLEN1024X300SiFive7VA1[1,2049],VLEN1024X300SiFive7VA1OrVA2[1,2049],VLEN1024X300SiFive7VCQ VREMU_VX vremu.vx	v4, v8, a0
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  1      8     1.00                         8     VLEN1024X300SiFive7VA1OrVA2[1,2],VLEN1024X300SiFive7VCQ VWMUL_VV      vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  1      3     1.00                  U      1     VLEN1024X300SiFive7PipeA,VLEN1024X300SiFive7PipeAB VSETVLI            vsetvli	zero, zero, e8, mf4, tu, mu
@@ -1539,7 +1539,7 @@ vmv.v.v v4, v12
 
 # CHECK:      Resource pressure per iteration:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]
-# CHECK-NEXT:  -      -     342.00  -     20046.50 682.50 385.00  -    -
+# CHECK-NEXT:  -      -     342.00  -     17658.50 682.50 385.00  -    -
 
 # CHECK:      Resource pressure by instruction:
 # CHECK-NEXT: [0]    [1]    [2]    [3]    [4]    [5]    [6]    [7]    [8]    Instructions:
@@ -2023,49 +2023,49 @@ vmv.v.v v4, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
 # CHECK-NEXT:  -      -      -      -     8.50   8.50   1.00    -      -     vmulhu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00   -     1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     33.00   -     1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     121.00  -     1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     65.00   -     1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00  -     1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00  -     1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     481.00  -     1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     257.00  -     1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     961.00  -     1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     513.00  -     1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     1921.00  -    1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1025.00  -    1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     3841.00  -    1.00    -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2049.00  -    1.00    -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf4, tu, mu
-# CHECK-NEXT:  -      -      -      -     61.00   -     1.00    -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     65.00   -     1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     121.00  -     1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     129.00  -     1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     241.00  -     1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     257.00  -     1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     481.00  -     1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     513.00  -     1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     961.00  -     1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     1025.00  -    1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e16, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1921.00  -    1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     2049.00  -    1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, mf2, tu, mu
-# CHECK-NEXT:  -      -      -      -     113.00  -     1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     129.00  -     1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     225.00  -     1.00    -      -     vrem.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     257.00  -     1.00    -      -     vrem.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     449.00  -     1.00    -      -     vrem.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     513.00  -     1.00    -      -     vrem.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     897.00  -     1.00    -      -     vdivu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00  -    1.00    -      -     vdivu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e32, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1793.00  -    1.00    -      -     vdivu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2049.00  -    1.00    -      -     vdivu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m1, tu, mu
-# CHECK-NEXT:  -      -      -      -     229.00  -     1.00    -      -     vdiv.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     257.00  -     1.00    -      -     vdiv.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m2, tu, mu
-# CHECK-NEXT:  -      -      -      -     457.00  -     1.00    -      -     vdiv.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     513.00  -     1.00    -      -     vdiv.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m4, tu, mu
-# CHECK-NEXT:  -      -      -      -     913.00  -     1.00    -      -     vremu.vv	v4, v8, v12
+# CHECK-NEXT:  -      -      -      -     1025.00  -    1.00    -      -     vremu.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e64, m8, tu, mu
-# CHECK-NEXT:  -      -      -      -     1825.00  -    1.00    -      -     vremu.vx	v4, v8, a0
+# CHECK-NEXT:  -      -      -      -     2049.00  -    1.00    -      -     vremu.vx	v4, v8, a0
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf8, tu, mu
 # CHECK-NEXT:  -      -      -      -     1.00   1.00   1.00    -      -     vwmul.vv	v4, v8, v12
 # CHECK-NEXT:  -      -     1.00    -      -      -      -      -      -     vsetvli	zero, zero, e8, mf4, tu, mu


### PR DESCRIPTION
Vector integer division in SiFive7 processes a single bit at a time up to 4 elements. This patch updates to reflect this behavior. 