### PR TITLE
[flang] Handle DATA-style default component /inits/ in time

### DIFF
--- a/flang/lib/Semantics/data-to-inits.cpp
+++ b/flang/lib/Semantics/data-to-inits.cpp
@@ -943,10 +943,19 @@ void ConstructInitializer(const Symbol &symbol,
 
 void ConvertToInitializers(
     DataInitializations &inits, evaluate::ExpressionAnalyzer &exprAnalyzer) {
+  // Process DATA-style component /initializers/ now, so that they appear as
+  // default values in time for EQUIVALENCE processing in ProcessScopes.
+  for (auto &[symbolPtr, initialization] : inits) {
+    if (symbolPtr->owner().IsDerivedType()) {
+      ConstructInitializer(*symbolPtr, initialization, exprAnalyzer);
+    }
+  }
   if (ProcessScopes(
           exprAnalyzer.context().globalScope(), exprAnalyzer, inits)) {
     for (auto &[symbolPtr, initialization] : inits) {
-      ConstructInitializer(*symbolPtr, initialization, exprAnalyzer);
+      if (!symbolPtr->owner().IsDerivedType()) {
+        ConstructInitializer(*symbolPtr, initialization, exprAnalyzer);
+      }
     }
   }
 }

--- a/flang/test/Semantics/data24.f90
+++ b/flang/test/Semantics/data24.f90
@@ -1,0 +1,16 @@
+! RUN: %flang_fc1 -fdebug-dump-symbols %s 2>&1 | FileCheck %s
+! Ensure that DATA-style default component /initializers/ are processed
+! before they are needed to handle EQUIVALENCE'd storage.
+type t
+  sequence
+  integer :: j(10) /1,2,3,4,5,6,7,8,9,10/
+end type
+type(t) :: A
+integer arr(10)
+equivalence (A, arr)
+end
+
+!CHECK: .F18.0, SAVE (CompilerCreated) size=40 offset=0: ObjectEntity type: INTEGER(4) shape: 1_8:10_8 init:[INTEGER(4)::1_4,2_4,3_4,4_4,5_4,6_4,7_4,8_4,9_4,10_4]
+!CHECK: a size=40 offset=0: ObjectEntity type: TYPE(t)
+!CHECK: arr size=40 offset=0: ObjectEntity type: INTEGER(4) shape: 1_8:10_8
+!CHECK: Equivalence Sets: (a,arr(1)) (.F18.0,a)


### PR DESCRIPTION
DEC-style default component initializers that use DATA statement syntax aren't processed until DATA statement values are converted into init() expressions in the symbol table.  Part of that conversion process involves combining storage-associated (EQUIVALENCE) symbols with compiler-generated symbols with initialization when the associated symbols have initialization, and part of that process involves the application of default component initializers; so we need to make sure that they've already been processed.

(Fixes Fujitsu Fortran test 0633_0004.f.)