### PR TITLE
[LiveDebugVariables] Use bundle-aware iterators consistently

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugVariables.cpp
+++ b/llvm/lib/CodeGen/LiveDebugVariables.cpp
@@ -1973,8 +1973,8 @@ void LiveDebugVariables::LDVImpl::emitDebugValues(VirtRegMap *VRM) {
 
     if (MachineInstr *Pos = Slots->getInstructionFromIndex(Idx)) {
       // Insert at the end of any debug instructions.
-      auto PostDebug = std::next(Pos->getIterator());
-      PostDebug = skipDebugInstructionsForward(PostDebug, MBB->instr_end());
+      auto PostDebug = std::next(MachineBasicBlock::iterator(Pos));
+      PostDebug = skipDebugInstructionsForward(PostDebug, MBB->end());
       EmitInstsHere(PostDebug);
     } else {
       // Insert position disappeared; walk forwards through slots until we

--- a/llvm/test/DebugInfo/X86/live-debug-vars-bundle.mir
+++ b/llvm/test/DebugInfo/X86/live-debug-vars-bundle.mir
@@ -1,0 +1,48 @@
+# RUN: llc -run-pass=livedebugvars -run-pass=virtregrewriter -o - %s | FileCheck %s
+
+# Regression test for a bug where LiveDebugVariables used the wrong instruction
+# iterator type when debugInstrRef=true, and triggered an assertion.
+
+--- |
+  target triple = "x86_64-unknown-linux-gnu"
+
+  define i32 @foo(i32 %a, i32 %b) !dbg !4 {
+  entry:
+    ret i32 0, !dbg !10
+  }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!3}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+  !1 = !DIFile(filename: "-", directory: "./")
+  !2 = !{}
+  !3 = !{i32 2, !"Debug Info Version", i32 3}
+  !4 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !5, isLocal: false, isDefinition: true, scopeLine: 2, isOptimized: true, unit: !0, retainedNodes: !2)
+  !5 = !DISubroutineType(types: !6)
+  !6 = !{!7, !7, !7}
+  !7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+  !8 = !DILocalVariable(name: "local_var", scope: !4, file: !1, line: 7, type: !7)
+  !9 = !DILocation(line: 7, column: 1, scope: !4)
+  !10 = !DILocation(line: 8, column: 3, scope: !4)
+
+...
+---
+name:            foo
+tracksRegLiveness: true
+debugInstrRef: true
+body:             |
+  bb.0:
+    $esi = MOV32ri 2, debug-instr-number 1
+    BUNDLE {
+      NOOP
+    }
+    DBG_INSTR_REF !8, !DIExpression(), dbg-instr-ref(1, 0), debug-location !9
+    RET 0, undef $eax, debug-location !10
+...
+
+# CHECK-LABEL: name:            foo
+# CHECK: bb.0:
+# CHECK: BUNDLE {
+# CHECK: }
+# CHECK: DBG_INSTR_REF


### PR DESCRIPTION
Most of the pass works in terms of MachineBasicBlock::iterator (MachineInstrBundleIterator), but here one is constructed from an arbitrary instruction which may be within a bundle, causing an assertion.

I broke out the regression test in this review as the initial commit, but I plan to squash before landing.