### PR TITLE
[TableGen] Increase IndexWidth DAGISelMatcherEmitter.

### DIFF
--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -29,7 +29,7 @@
 using namespace llvm;
 
 enum {
-  IndexWidth = 6,
+  IndexWidth = 7,
   FullIndexWidth = IndexWidth + 4,
   HistOpcWidth = 40,
 };


### PR DESCRIPTION
RISC-V has over a million bytes in the table.