### PR TITLE
Reland "[lldb] Fix OP_deref evaluation for large integer resu…

### DIFF
--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -909,8 +909,6 @@ static llvm::Error Evaluate_DW_OP_deref(DWARFExpression::Stack &stack,
               " for DW_OP_deref",
               pointer_addr),
           error.takeError());
-    if (ABISP abi_sp = process->GetABI())
-      pointer_value = abi_sp->FixCodeAddress(pointer_value);
     stack.back().GetScalar() = pointer_value;
     stack.back().ClearContext();
   } break;

--- a/lldb/unittests/Expression/CMakeLists.txt
+++ b/lldb/unittests/Expression/CMakeLists.txt
@@ -1,3 +1,8 @@
+if ("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+  set(LINK_COMPONENTS_AARCH AArch64)
+  set(LINK_LIBS_AARCH lldbPluginABIAArch64)
+endif()
+
 add_lldb_unittest(ExpressionTests
   ClangParserTest.cpp
   ClangExpressionDeclMapTest.cpp
@@ -6,6 +11,9 @@ add_lldb_unittest(ExpressionTests
   CppModuleConfigurationTest.cpp
   ExpressionTest.cpp
 
+  LINK_COMPONENTS
+    Support
+    ${LINK_COMPONENTS_AARCH}
   LINK_LIBS
     lldbCore
     lldbPluginObjectFileELF
@@ -18,4 +26,9 @@ add_lldb_unittest(ExpressionTests
     lldbUtilityHelpers
     lldbSymbolHelpers
     LLVMTestingSupport
+    ${LINK_LIBS_AARCH}
   )
+
+if ("AArch64" IN_LIST LLVM_TARGETS_TO_BUILD)
+  target_compile_definitions(ExpressionTests PRIVATE ARCH_AARCH64)
+endif()


### PR DESCRIPTION
…lts (#159460)""

The original had an issue on "AArch-less" bots.
Fixed it with some ifdefs around the presence of the AArch ABI plugin.

This reverts commit 1a4685df13282ae5c1d7dce055a71a7130bfab3c.