### PR TITLE
[libc][bazel] Add BUILD rules for fma and fmaf functions.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -3834,7 +3834,19 @@ libc_math_function(name = "floorf128")
 
 libc_math_function(name = "floorf16")
 
-# TODO: Add fma, fmaf, fmal, fmaf128 functions.
+libc_math_function(
+    name = "fma",
+    additional_deps = [
+        ":__support_fputil_fma",
+    ],
+)
+
+libc_math_function(
+    name = "fmaf",
+    additional_deps = [
+        ":__support_fputil_fma",
+    ],
+)
 
 libc_math_function(
     name = "fmaf16",

--- a/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/math/smoke/BUILD.bazel
@@ -475,7 +475,15 @@ math_test(
     hdrs = ["FloorTest.h"],
 )
 
-# TODO: Add fma, fmaf, fmal, fmaf128 tests.
+math_test(
+    name = "fma",
+    hdrs = ["FmaTest.h"],
+)
+
+math_test(
+    name = "fmaf",
+    hdrs = ["FmaTest.h"],
+)
 
 # TODO: Reenable this test once it passes at Google.
 # math_test(


### PR DESCRIPTION
This change adds the capability to build fma/fmaf with Bazel (fmal, fmaf128 variants are not implemented yet), and run smoke tests.

BUILD rules for regular MPFR-based tests will be added later, since they require support for building rand/srand as well, which is missing in Bazel for now.