### PR TITLE
[IR] Simplify HasCachedHash with is_detected (NFC)

### DIFF
--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -986,15 +986,10 @@ static T *uniquifyImpl(T *N, DenseSet<T *, InfoT> &Store) {
 }
 
 template <class NodeTy> struct MDNode::HasCachedHash {
-  using Yes = char[1];
-  using No = char[2];
-  template <class U, U Val> struct SFINAE {};
-
   template <class U>
-  static Yes &check(SFINAE<void (U::*)(unsigned), &U::setHash> *);
-  template <class U> static No &check(...);
+  using check = decltype(static_cast<void (U::*)(unsigned)>(&U::setHash));
 
-  static const bool value = sizeof(check<NodeTy>(nullptr)) == sizeof(Yes);
+  static constexpr bool value = is_detected<check, NodeTy>::value;
 };
 
 MDNode *MDNode::uniquify() {


### PR DESCRIPTION
With is_detected, we don't need to implement a SFINAE trick on our own.
