### PR TITLE
benchmarks: Skip runtime libcalls benchmark for llvm-driver build

### DIFF
--- a/llvm/benchmarks/CMakeLists.txt
+++ b/llvm/benchmarks/CMakeLists.txt
@@ -13,24 +13,30 @@ add_benchmark(SandboxIRBench SandboxIRBench.cpp PARTIAL_SOURCES_INTENDED)
 
 add_benchmark(RuntimeLibcallsBench RuntimeLibcalls.cpp PARTIAL_SOURCES_INTENDED)
 
+if(NOT LLVM_TOOL_LLVM_DRIVER_BUILD)
+  # TODO: Check if the tools aer in LLVM_DISTRIBUTION_COMPONENTS with
+  # the driver build. Also support the driver build by invoking the
+  # tools through llvm-driver
+  get_host_tool_path(llvm-nm LLVM_NM llvm_nm_exe llvm_nm_target)
+  get_host_tool_path(llc LLC llc_exe llc_target)
 
-# Extract the list of symbols in a random utility as sample data.
-set(SYMBOL_TEST_DATA_FILE "sample_symbol_list.txt")
+  if(TARGET ${llc_target} AND TARGET ${llvm_nm_target})
+    # Extract the list of symbols in a random utility as sample data.
+    set(SYMBOL_TEST_DATA_FILE "sample_symbol_list.txt")
+    set(SYMBOL_TEST_DATA_SOURCE_BINARY ${llc_exe})
 
-get_host_tool_path(llvm-nm LLVM_NM llvm_nm_exe llvm_nm_target)
-get_host_tool_path(llc LLC llc_exe llc_target)
+    add_custom_command(OUTPUT ${SYMBOL_TEST_DATA_FILE}
+      COMMAND ${llvm_nm_exe} --no-demangle --no-sort
+      --format=just-symbols
+      ${SYMBOL_TEST_DATA_SOURCE_BINARY} > ${SYMBOL_TEST_DATA_FILE}
+     DEPENDS ${llvm_nm_target} ${llc_target})
 
-if(TARGET ${llc_target} AND TARGET ${llvm_nm_target})
-  add_custom_command(OUTPUT ${SYMBOL_TEST_DATA_FILE}
-    COMMAND ${llvm_nm_exe} --no-demangle --no-sort
-    --format=just-symbols
-    ${SYMBOL_TEST_DATA_SOURCE_BINARY} > ${SYMBOL_TEST_DATA_FILE}
-   DEPENDS ${llvm_nm_target} ${llc_target})
+    add_custom_target(generate-runtime-libcalls-sample-symbol-list
+                      DEPENDS ${SYMBOL_TEST_DATA_FILE})
 
-  add_custom_target(generate-runtime-libcalls-sample-symbol-list
-                    DEPENDS ${SYMBOL_TEST_DATA_FILE})
-
-  add_dependencies(RuntimeLibcallsBench generate-runtime-libcalls-sample-symbol-list)
-  target_compile_definitions(RuntimeLibcallsBench PRIVATE
-    -DSYMBOL_TEST_DATA_FILE="${CMAKE_CURRENT_BINARY_DIR}/${SYMBOL_TEST_DATA_FILE}")
+    add_dependencies(RuntimeLibcallsBench
+                     generate-runtime-libcalls-sample-symbol-list)
+    target_compile_definitions(RuntimeLibcallsBench PRIVATE
+      -DSYMBOL_TEST_DATA_FILE="${CMAKE_CURRENT_BINARY_DIR}/${SYMBOL_TEST_DATA_FILE}")
+  endif()
 endif()


### PR DESCRIPTION
Apparently if you enable LLVM_TOOL_LLVM_DRIVER_BUILD, many individual
tool binaries are not built and instead create object targets which
are linked into an llvm-driver tool which you need to use instead.
In principle we could reconstruct this command with llvm-driver, but
I can't get a build to complete when I turn this on as a standalone
option.