### PR TITLE
[MLIR][Remark] Add support for dropping remarks

### DIFF
--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -356,8 +356,8 @@ public:
 class RemarkEngine {
 private:
   /// Postponed remarks. They are deferred to the end of the pipeline, where the
-  /// user can intercept them for custom processing, otherwise they will be reported
-  /// on engine destruction.
+  /// user can intercept them for custom processing, otherwise they will be
+  /// reported on engine destruction.
   llvm::SmallVector<Remark, 8> postponedRemarks;
   /// Regex that filters missed optimization remarks: only matching one are
   /// reported.
@@ -412,7 +412,7 @@ private:
 
   /// Report a remark. When `forcePrintPostponedRemarks` is true, the remark
   /// will be printed even if it is postponed.
-  void report(const Remark &remark, bool forcePrintPostponedRemarks);
+  void reportImpl(const Remark &remark);
 
 public:
   /// Default constructor is deleted, use the other constructor.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -445,10 +445,10 @@ public:
   InFlightRemark emitOptimizationRemarkAnalysis(Location loc, RemarkOpts opts);
 
   /// Get the postponed remarks.
-  ArrayRef<Remark>  getPostponedRemarks() const { return postponedRemarks; }
+  ArrayRef<Remark> getPostponedRemarks() const { return postponedRemarks; }
 
   /// Clear the postponed remarks.
-  void  clearPostponedRemarks()  { postponedRemarks.clear(); }
+  void clearPostponedRemarks() { postponedRemarks.clear(); }
 };
 
 template <typename Fn, typename... Args>

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -355,7 +355,9 @@ public:
 
 class RemarkEngine {
 private:
-  /// Postponed remarks. They are shown at the end of the pipeline.
+  /// Postponed remarks. They are deferred to the end of the pipeline, where the
+  /// user can intercept them for custom processing, otherwise they will be reported
+  /// on engine destruction.
   llvm::SmallVector<Remark, 8> postponedRemarks;
   /// Regex that filters missed optimization remarks: only matching one are
   /// reported.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -13,6 +13,7 @@
 #ifndef MLIR_IR_REMARKS_H
 #define MLIR_IR_REMARKS_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/Remarks/Remark.h"
@@ -442,6 +443,12 @@ public:
   /// Report an analysis remark, this will create an InFlightRemark
   /// that can be used to build the remark using the << operator.
   InFlightRemark emitOptimizationRemarkAnalysis(Location loc, RemarkOpts opts);
+
+  /// Get the postponed remarks.
+  ArrayRef<Remark>  getPostponedRemarks() const { return postponedRemarks; }
+
+  /// Clear the postponed remarks.
+  void  clearPostponedRemarks()  { postponedRemarks.clear(); }
 };
 
 template <typename Fn, typename... Args>

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -408,6 +408,10 @@ private:
   /// Emit all postponed remarks.
   void emitPostponedRemarks();
 
+  /// Report a remark. When `forcePrintPostponedRemarks` is true, the remark
+  /// will be printed even if it is postponed.
+  void report(const Remark &remark, bool forcePrintPostponedRemarks);
+
 public:
   /// Default constructor is deleted, use the other constructor.
   RemarkEngine() = delete;
@@ -426,7 +430,7 @@ public:
                            std::string *errMsg);
 
   /// Report a remark.
-  void report(const Remark &remark, bool ignorePostpone = false);
+  void report(const Remark &remark);
 
   /// Report a successful remark, this will create an InFlightRemark
   /// that can be used to build the remark using the << operator.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -576,21 +576,25 @@ struct DenseMapInfo<mlir::remark::detail::Remark> {
   static constexpr StringRef kEmptyKey = "<EMPTY_KEY>";
   static constexpr StringRef kTombstoneKey = "<TOMBSTONE_KEY>";
 
+  /// Helper to provide a static dummy context for sentinel keys.
+  static mlir::MLIRContext *getStaticDummyContext() {
+    static mlir::MLIRContext dummyContext;
+    return &dummyContext;
+  }
+
   /// Create an empty remark
   static inline mlir::remark::detail::Remark getEmptyKey() {
-    mlir::MLIRContext dummyContext;
     return mlir::remark::detail::Remark(
         mlir::remark::RemarkKind::RemarkUnknown, mlir::DiagnosticSeverity::Note,
-        mlir::UnknownLoc::get(&dummyContext),
+        mlir::UnknownLoc::get(getStaticDummyContext()),
         mlir::remark::RemarkOpts::name(kEmptyKey));
   }
 
   /// Create a dead remark
   static inline mlir::remark::detail::Remark getTombstoneKey() {
-    mlir::MLIRContext dummyContext;
     return mlir::remark::detail::Remark(
         mlir::remark::RemarkKind::RemarkUnknown, mlir::DiagnosticSeverity::Note,
-        mlir::UnknownLoc::get(&dummyContext),
+        mlir::UnknownLoc::get(getStaticDummyContext()),
         mlir::remark::RemarkOpts::name(kTombstoneKey));
   }
 

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -78,7 +78,7 @@ struct RemarkOpts {
   constexpr RemarkOpts function(StringRef v) const {
     return {remarkName, categoryName, subCategoryName, v, postponed};
   }
-  /// Return a copy with the function name set.
+  /// Return a copy with the postponed flag set.
   constexpr RemarkOpts postpone() const {
     return {remarkName, categoryName, subCategoryName, functionName, true};
   }
@@ -103,7 +103,6 @@ public:
           .toStringRef(fullCategoryName);
     }
   }
-  ~Remark() = default;
 
   // Remark argument that is a key-value pair that can be printed as machine
   // parsable args.

--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -453,7 +453,7 @@ public:
   InFlightRemark emitOptimizationRemarkAnalysis(Location loc, RemarkOpts opts);
 
   /// Get the postponed remarks.
-  DenseSet<Remark> getPostponedRemarks() const { return postponedRemarks; }
+  const DenseSet<Remark> &getPostponedRemarks() const { return postponedRemarks; }
 
   /// Clear the postponed remarks.
   void clearPostponedRemarks() { postponedRemarks.clear(); }

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -278,6 +278,9 @@ public:
     }
   }
   ~MLIRContextImpl() {
+    // finalize remark engine before destroying anything else.
+    remarkEngine.reset();
+
     for (auto typeMapping : registeredTypes)
       typeMapping.second->~AbstractType();
     for (auto attrMapping : registeredAttributes)

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -225,14 +225,7 @@ InFlightRemark RemarkEngine::emitOptimizationRemarkAnalysis(Location loc,
 // RemarkEngine
 //===----------------------------------------------------------------------===//
 
-void RemarkEngine::report(const Remark &remark,
-                          bool forcePrintPostponedRemarks) {
-  // Postponed remarks are shown at the end of pipeline, unless overridden.
-  if (remark.isPostponed() && !forcePrintPostponedRemarks) {
-    postponedRemarks.push_back(remark);
-    return;
-  }
-
+void RemarkEngine::reportImpl(const Remark &remark) {
   // Stream the remark
   if (remarkStreamer)
     remarkStreamer->streamOptimizationRemark(remark);

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -157,7 +157,7 @@ llvm::remarks::Remark Remark::generateRemark() const {
 
 InFlightRemark::~InFlightRemark() {
   if (remark && owner)
-    owner->report(std::move(*remark));
+    owner->report(*remark);
   owner = nullptr;
 }
 
@@ -225,9 +225,10 @@ InFlightRemark RemarkEngine::emitOptimizationRemarkAnalysis(Location loc,
 // RemarkEngine
 //===----------------------------------------------------------------------===//
 
-void RemarkEngine::report(const Remark &remark, bool ignorePostpone) {
+void RemarkEngine::report(const Remark &remark,
+                          bool forcePrintPostponedRemarks) {
   // Postponed remarks are shown at the end of pipeline, unless overridden.
-  if (remark.isPostponed() && !ignorePostpone) {
+  if (remark.isPostponed() && !forcePrintPostponedRemarks) {
     postponedRemarks.push_back(remark);
     return;
   }
@@ -241,9 +242,13 @@ void RemarkEngine::report(const Remark &remark, bool ignorePostpone) {
     emitRemark(remark.getLocation(), remark.getMsg());
 }
 
+void RemarkEngine::report(const Remark &remark) {
+  report(remark, /*forcePrintPostponedRemarks=*/false);
+}
+
 void RemarkEngine::emitPostponedRemarks() {
   for (auto &remark : postponedRemarks)
-    report(remark, /*ignorePostpone=*/true);
+    report(remark, /*forcePrintPostponedRemarks=*/true);
   postponedRemarks.clear();
 }
 

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -70,7 +70,7 @@ static void printArgs(llvm::raw_ostream &os, llvm::ArrayRef<Remark::Arg> args) {
 void Remark::print(llvm::raw_ostream &os, bool printLocation) const {
   // Header: [Type] pass:remarkName
   StringRef type = getRemarkTypeString();
-  StringRef categoryName = getFullCategoryName();
+  StringRef categoryName = getCombinedCategoryName();
   StringRef name = remarkName;
 
   os << '[' << type << "] ";
@@ -140,7 +140,7 @@ llvm::remarks::Remark Remark::generateRemark() const {
   r.RemarkType = getRemarkType();
   r.RemarkName = getRemarkName();
   // MLIR does not use passes; instead, it has categories and sub-categories.
-  r.PassName = getFullCategoryName();
+  r.PassName = getCombinedCategoryName();
   r.FunctionName = getFunction();
   r.Loc = locLambda();
   for (const Remark::Arg &arg : getArgs()) {
@@ -238,7 +238,7 @@ void RemarkEngine::reportImpl(const Remark &remark) {
 void RemarkEngine::report(const Remark &remark) {
   // Postponed remarks are deferred to the end of pipeline.
   if (remark.isPostponed()) {
-    postponedRemarks.push_back(remark);
+    postponedRemarks.insert(remark);
     return;
   }
 

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -241,7 +241,7 @@ void RemarkEngine::report(const Remark &remark) {
 
 void RemarkEngine::emitPostponedRemarks() {
   for (auto &remark : postponedRemarks)
-    report(remark, /*forcePrintPostponedRemarks=*/true);
+    reportImpl(remark);
   postponedRemarks.clear();
 }
 

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -236,7 +236,13 @@ void RemarkEngine::reportImpl(const Remark &remark) {
 }
 
 void RemarkEngine::report(const Remark &remark) {
-  report(remark, /*forcePrintPostponedRemarks=*/false);
+  // Postponed remarks are deferred to the end of pipeline.
+  if (remark.isPostponed()) {
+    postponedRemarks.push_back(remark);
+    return;
+  }
+
+  reportImpl(remark);
 }
 
 void RemarkEngine::emitPostponedRemarks() {

--- a/mlir/unittests/IR/RemarkTest.cpp
+++ b/mlir/unittests/IR/RemarkTest.cpp
@@ -10,9 +10,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Remarks.h"
 #include "mlir/Remark/RemarkStreamer.h"
-#include "mlir/Support/TypeID.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/IR/LLVMRemarkStreamer.h"
 #include "llvm/Remarks/RemarkFormat.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/LogicalResult.h"
@@ -405,4 +403,112 @@ TEST(Remark, TestCustomOptimizationRemarkPostponeDiagnostic) {
   EXPECT_NE(errOut.find(pass2Msg), std::string::npos); // printed
 }
 
+TEST(Remark, TestRemarkDrop) {
+  testing::internal::CaptureStderr();
+  const auto *pass1Msg = "I am failed";
+  const auto *pass2Msg = "I succeeded";
+  std::string categoryLoopunroll("LoopUnroll");
+  {
+    MLIRContext context;
+    Location loc = FileLineColLoc::get(&context, "test.cpp", 1, 5);
+    Location locOther = FileLineColLoc::get(&context, "test.cpp", 55, 5);
+
+    // Setup the remark engine
+    mlir::remark::RemarkCategories cats{/*all=*/categoryLoopunroll,
+                                        /*passed=*/categoryLoopunroll,
+                                        /*missed=*/categoryLoopunroll,
+                                        /*analysis=*/categoryLoopunroll,
+                                        /*failed=*/categoryLoopunroll};
+
+    LogicalResult isEnabled = remark::enableOptimizationRemarks(
+        context, std::make_unique<MyCustomStreamer>(), cats, true);
+    ASSERT_TRUE(succeeded(isEnabled)) << "Failed to enable remark engine";
+
+    // [Pass-early]: Failed remark is emitted as postponed but not shown
+    {
+      remark::failed(loc, remark::RemarkOpts::name("unroller")
+                              .category(categoryLoopunroll)
+                              .postpone())
+          << pass1Msg;
+
+      // Ensure no remark has been printed yet.
+      llvm::errs().flush();
+      std::string errOut1 = testing::internal::GetCapturedStderr();
+      EXPECT_TRUE(errOut1.empty())
+          << "Expected no stderr output before postponed remarks are flushed";
+    }
+    testing::internal::CaptureStderr();
+    // [Pass-late]: Drop the failed remark, and emit a passed remark
+    {
+      // Step 1. Drop the remark from early-pass
+      bool dropped = remark::dropPostponedRemark(
+          loc, remark::RemarkKind::RemarkFailure,
+          remark::RemarkOpts::name("unroller").category(categoryLoopunroll));
+
+      EXPECT_TRUE(dropped) << "Expected the remark to be dropped";
+
+      // Step 2. Print the pass remark
+      remark::passed(
+          loc,
+          remark::RemarkOpts::name("unroller").category(categoryLoopunroll))
+          << pass2Msg;
+    }
+  }
+  // done with the compilation
+  llvm::errs().flush();
+  std::string errOut2 = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(errOut2.find(pass1Msg), std::string::npos);
+  EXPECT_NE(errOut2.find(pass2Msg), std::string::npos);
+}
+
+TEST(Remark, TestRemarkCannotDrop) {
+  testing::internal::CaptureStderr();
+  const auto *pass1Msg = "I am failed";
+  const auto *pass2Msg = "I succeeded";
+  std::string categoryLoopunroll("LoopUnroll");
+  {
+    MLIRContext context;
+    Location loc = FileLineColLoc::get(&context, "test.cpp", 1, 5);
+    Location locOther = FileLineColLoc::get(&context, "test.cpp", 55, 5);
+    // Setup the remark engine
+    mlir::remark::RemarkCategories cats{/*all=*/categoryLoopunroll,
+                                        /*passed=*/categoryLoopunroll,
+                                        /*missed=*/categoryLoopunroll,
+                                        /*analysis=*/categoryLoopunroll,
+                                        /*failed=*/categoryLoopunroll};
+
+    LogicalResult isEnabled = remark::enableOptimizationRemarks(
+        context, std::make_unique<MyCustomStreamer>(), cats, true);
+    ASSERT_TRUE(succeeded(isEnabled)) << "Failed to enable remark engine";
+    // [Pass-early]: Failed remark is emitted as postponed but not shown
+    {
+      remark::failed(locOther, remark::RemarkOpts::name("unroller")
+                                   .category(categoryLoopunroll)
+                                   .postpone())
+          << pass1Msg;
+    }
+    // [Pass-late]: Drop the failed remark, and emit a passed remark
+    {
+      // Step 1. Drop the remark from early-pass
+      bool dropped = remark::dropPostponedRemark(
+          loc, remark::RemarkKind::RemarkFailure,
+          remark::RemarkOpts::name("unroller").category(categoryLoopunroll));
+
+      EXPECT_FALSE(dropped) << "Expected the remark should not be dropped it "
+                               "has different location";
+
+      // Step 2. Print the pass remark
+      remark::passed(
+          loc,
+          remark::RemarkOpts::name("unroller").category(categoryLoopunroll))
+          << pass2Msg;
+    }
+  }
+  // done with the compilation
+  llvm::errs().flush();
+  std::string errOut3 = testing::internal::GetCapturedStderr();
+  EXPECT_NE(errOut3.find(pass1Msg), std::string::npos); // printed
+  EXPECT_NE(errOut3.find(pass2Msg), std::string::npos); // printed
+}
 } // namespace

--- a/mlir/unittests/IR/RemarkTest.cpp
+++ b/mlir/unittests/IR/RemarkTest.cpp
@@ -280,7 +280,7 @@ TEST(Remark, TestCustomOptimizationRemarkDiagnostic) {
     Location loc = UnknownLoc::get(&context);
 
     // Setup the remark engine
-    mlir::remark::RemarkCategories cats{/*all=*/"",
+    mlir::remark::RemarkCategories cats{/*all=*/std::nullopt,
                                         /*passed=*/categoryLoopunroll,
                                         /*missed=*/std::nullopt,
                                         /*analysis=*/std::nullopt,
@@ -332,7 +332,8 @@ TEST(Remark, TestCustomOptimizationRemarkPostponeDiagnostic) {
     Location loc = UnknownLoc::get(&context);
 
     // Setup the remark engine
-    mlir::remark::RemarkCategories cats{/*passed=*/categoryLoopunroll,
+    mlir::remark::RemarkCategories cats{/*all=*/std::nullopt,
+                                        /*passed=*/categoryLoopunroll,
                                         /*missed=*/std::nullopt,
                                         /*analysis=*/std::nullopt,
                                         /*failed=*/categoryLoopunroll};


### PR DESCRIPTION
This PR adds support for dropping remarks emitted by earlier passes. It is a common use case in optimizing compilers where many passes are involved.
    
For example, consider the following pipeline. In that case, `pass-late` can drop the `failed unrolling` remark because it is irrelevant, and emit new remark. 
    
```
    pass-early : failed unrolling
    ... other passes ...
    pass-late  : succeeded unrolling
```

To be droppable, a remark must be emitted as a `postponed` remark. Non-postponed remarks are emitted immediately and cannot be dropped later.

Requires https://github.com/llvm/llvm-project/pull/157434