### PR TITLE
[lldb] Correct 32-bit build failure in StopInfoMachException.cpp

### DIFF
--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -78,7 +78,7 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
 }
 
 static constexpr uint8_t g_mte_tag_shift = 64 - 8;
-static constexpr uintptr_t g_mte_tag_mask = (uintptr_t)0x0f << g_mte_tag_shift;
+static constexpr addr_t g_mte_tag_mask = (addr_t)0x0f << g_mte_tag_shift;
 
 bool StopInfoMachException::DetermineTagMismatch(ExecutionContext &exe_ctx) {
   const bool IsBadAccess = m_value == 1;            // EXC_BAD_ACCESS
@@ -97,7 +97,7 @@ bool StopInfoMachException::DetermineTagMismatch(ExecutionContext &exe_ctx) {
               m_exc_code, bad_address);
 
   const uint8_t tag = (bad_address & g_mte_tag_mask) >> g_mte_tag_shift;
-  const uint64_t canonical_addr = bad_address & ~g_mte_tag_mask;
+  const addr_t canonical_addr = bad_address & ~g_mte_tag_mask;
   strm.Printf(
       "Note: MTE tag mismatch detected: pointer tag=%d, address=0x%" PRIx64,
       tag, canonical_addr);


### PR DESCRIPTION
uintptr_t is usually a good idea when handling pointers, but lldb has to handle 64-bit addresses that might be from a remote system, on a 32-bit system.

So I've changed a few instances here to use addr_t which is 64-bit everywhere.

Before we got:
https://lab.llvm.org/buildbot/#/builders/18/builds/21247

```
../llvm-project/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp:81:28: error: constexpr variable 'g_mte_tag_mask' must be initialized by a constant expression
   81 | static constexpr uintptr_t g_mte_tag_mask = (uintptr_t)0x0f << g_mte_tag_shift;
      |                            ^                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../llvm-project/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp:81:61: note: shift count 56 >= width of type 'uintptr_t' (aka 'unsigned int') (32 bits)
   81 | static constexpr uintptr_t g_mte_tag_mask = (uintptr_t)0x0f << g_mte_tag_shift;
      |                                                             ^
1 error generated.
```

Original code added by #159117.