### PR TITLE
[libc++] Make the benchmarking data pseudo-random

### DIFF
--- a/libcxx/test/benchmarks/GenerateInput.h
+++ b/libcxx/test/benchmarks/GenerateInput.h
@@ -25,7 +25,7 @@ static const char Letters[] = {
 static const std::size_t LettersSize = sizeof(Letters);
 
 inline std::default_random_engine& getRandomEngine() {
-  static std::default_random_engine RandEngine(std::random_device{}());
+  static std::default_random_engine RandEngine(123456);
   return RandEngine;
 }
 


### PR DESCRIPTION
Having truly random data makes it quite difficult to compare benchmark results, since a significant amount of difference can simply be due to different input data. Making the data determinisic helps a lot when trying to figure out whether specific changes indeed improve the performance.
