### PR TITLE
[clang][ExprConst] Try to minimize emitting unneeded diagnostics

### DIFF
--- a/clang/include/clang/AST/Decl.h
+++ b/clang/include/clang/AST/Decl.h
@@ -61,6 +61,7 @@ class CompoundStmt;
 class DependentFunctionTemplateSpecializationInfo;
 class EnumDecl;
 class Expr;
+struct EvalStatus;
 class FunctionTemplateDecl;
 class FunctionTemplateSpecializationInfo;
 class FunctionTypeLoc;
@@ -1412,7 +1413,7 @@ public:
   APValue *evaluateValue() const;
 
 private:
-  APValue *evaluateValueImpl(SmallVectorImpl<PartialDiagnosticAt> &Notes,
+  APValue *evaluateValueImpl(EvalStatus &EStatus,
                              bool IsConstantInitialization) const;
 
 public:
@@ -1446,7 +1447,7 @@ public:
   /// constant initializer. Should only be called once, after completing the
   /// definition of the variable.
   bool checkForConstantInitialization(
-      SmallVectorImpl<PartialDiagnosticAt> &Notes) const;
+      SmallVectorImpl<PartialDiagnosticAt> *Notes) const;
 
   void setInitStyle(InitializationStyle Style) {
     VarDeclBits.InitStyle = Style;

--- a/clang/lib/AST/ByteCode/Compiler.cpp
+++ b/clang/lib/AST/ByteCode/Compiler.cpp
@@ -6985,8 +6985,8 @@ bool Compiler<Emitter>::visitDeclRef(const ValueDecl *D, const Expr *E) {
       // here -- we will create a global variable in any case, and that
       // will have the state of initializer evaluation attached.
       APValue V;
-      SmallVector<PartialDiagnosticAt> Notes;
-      (void)Init->EvaluateAsInitializer(V, Ctx.getASTContext(), VD, Notes,
+      EvalStatus EStatus;
+      (void)Init->EvaluateAsInitializer(V, Ctx.getASTContext(), VD, EStatus,
                                         true);
       return this->visitDeclRef(D, E);
     }

--- a/clang/lib/AST/ByteCode/InterpState.h
+++ b/clang/lib/AST/ByteCode/InterpState.h
@@ -64,9 +64,7 @@ public:
   const Frame *getBottomFrame() const override { return &BottomFrame; }
 
   // Access objects from the walker context.
-  Expr::EvalStatus &getEvalStatus() const override {
-    return Parent.getEvalStatus();
-  }
+  EvalStatus &getEvalStatus() const override { return Parent.getEvalStatus(); }
   ASTContext &getASTContext() const override { return Ctx.getASTContext(); }
   const LangOptions &getLangOpts() const {
     return Ctx.getASTContext().getLangOpts();

--- a/clang/lib/AST/ByteCode/State.cpp
+++ b/clang/lib/AST/ByteCode/State.cpp
@@ -84,7 +84,12 @@ PartialDiagnostic &State::addDiag(SourceLocation Loc, diag::kind DiagId) {
 
 OptionalDiagnostic State::diag(SourceLocation Loc, diag::kind DiagId,
                                unsigned ExtraNotes, bool IsCCEDiag) {
-  Expr::EvalStatus &EvalStatus = getEvalStatus();
+  EvalStatus &EvalStatus = getEvalStatus();
+  if (IsCCEDiag)
+    EvalStatus.HasCCEDiagnostic = true;
+  else
+    EvalStatus.HasFFDiagnostic = true;
+
   if (EvalStatus.Diag) {
     if (hasPriorDiagnostic()) {
       return OptionalDiagnostic();

--- a/clang/lib/AST/ByteCode/State.h
+++ b/clang/lib/AST/ByteCode/State.h
@@ -88,7 +88,7 @@ public:
   virtual bool hasActiveDiagnostic() = 0;
   virtual void setActiveDiagnostic(bool Flag) = 0;
   virtual void setFoldFailureDiagnostic(bool Flag) = 0;
-  virtual Expr::EvalStatus &getEvalStatus() const = 0;
+  virtual EvalStatus &getEvalStatus() const = 0;
   virtual ASTContext &getASTContext() const = 0;
   virtual bool hasPriorDiagnostic() = 0;
   virtual unsigned getCallStackDepth() = 0;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -14855,8 +14855,7 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
                 << Init->getSourceRange();
           }
         }
-        (void)var->checkForConstantInitialization(Notes);
-        Notes.clear();
+        (void)var->checkForConstantInitialization(nullptr);
       } else if (CacheCulprit) {
         Notes.emplace_back(CacheCulprit->getExprLoc(),
                            PDiag(diag::note_invalid_subexpr_in_const_expr));
@@ -14864,7 +14863,7 @@ void Sema::CheckCompleteVariableDeclaration(VarDecl *var) {
       }
     } else {
       // Evaluate the initializer to see if it's a constant initializer.
-      HasConstInit = var->checkForConstantInitialization(Notes);
+      HasConstInit = var->checkForConstantInitialization(&Notes);
     }
 
     if (HasConstInit) {


### PR DESCRIPTION
There are a few places in clang where we pass a list of diagnostic notes to the `evaluate*` functions, which so some extra work when that list is passed (e.g. attaching call stacks to the diagnostics). We then sometimes later don't use the notes list at all, or we only use it to check if any notes have been emitted.

This patch adds two new flags to `EvalStatus` to check if any diagnostics have been emitted (right now one of the would suffice though, I guess), which replaces the `Notes.empty()` use case.

It also changes the signature of `EvaluateAsInitializer` to pass an `EvalStatus` object instead, so we don't _have_ to pass a notes list but can still examine the resulting flags.