### PR TITLE
[clang][bytecode] Pass `SourceInfo` objects by value

### DIFF
--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.cpp
@@ -207,8 +207,7 @@ void emit(Program &P, llvm::SmallVectorImpl<std::byte> &Code,
 }
 
 template <typename... Tys>
-bool ByteCodeEmitter::emitOp(Opcode Op, const Tys &...Args,
-                             const SourceInfo &SI) {
+bool ByteCodeEmitter::emitOp(Opcode Op, const Tys &...Args, SourceInfo SI) {
   bool Success = true;
 
   // The opcode is followed by arguments. The source info is

--- a/clang/lib/AST/ByteCode/ByteCodeEmitter.h
+++ b/clang/lib/AST/ByteCode/ByteCodeEmitter.h
@@ -99,7 +99,7 @@ private:
 
   /// Emits an opcode.
   template <typename... Tys>
-  bool emitOp(Opcode Op, const Tys &...Args, const SourceInfo &L);
+  bool emitOp(Opcode Op, const Tys &...Args, SourceInfo L);
 
 protected:
 #define GET_LINK_PROTO

--- a/clang/lib/AST/ByteCode/EvalEmitter.cpp
+++ b/clang/lib/AST/ByteCode/EvalEmitter.cpp
@@ -177,7 +177,7 @@ bool EvalEmitter::speculate(const CallExpr *E, const LabelTy &EndLabel) {
   return this->emitBool(true, E);
 }
 
-template <PrimType OpType> bool EvalEmitter::emitRet(const SourceInfo &Info) {
+template <PrimType OpType> bool EvalEmitter::emitRet(SourceInfo Info) {
   if (!isActive())
     return true;
 
@@ -186,7 +186,7 @@ template <PrimType OpType> bool EvalEmitter::emitRet(const SourceInfo &Info) {
   return true;
 }
 
-template <> bool EvalEmitter::emitRet<PT_Ptr>(const SourceInfo &Info) {
+template <> bool EvalEmitter::emitRet<PT_Ptr>(SourceInfo Info) {
   if (!isActive())
     return true;
 
@@ -247,12 +247,12 @@ template <> bool EvalEmitter::emitRet<PT_Ptr>(const SourceInfo &Info) {
   return true;
 }
 
-bool EvalEmitter::emitRetVoid(const SourceInfo &Info) {
+bool EvalEmitter::emitRetVoid(SourceInfo Info) {
   EvalResult.setValid();
   return true;
 }
 
-bool EvalEmitter::emitRetValue(const SourceInfo &Info) {
+bool EvalEmitter::emitRetValue(SourceInfo Info) {
   const auto &Ptr = S.Stk.pop<Pointer>();
 
   if (!EvalResult.checkReturnValue(S, Ctx, Ptr, Info))
@@ -270,7 +270,7 @@ bool EvalEmitter::emitRetValue(const SourceInfo &Info) {
   return false;
 }
 
-bool EvalEmitter::emitGetPtrLocal(uint32_t I, const SourceInfo &Info) {
+bool EvalEmitter::emitGetPtrLocal(uint32_t I, SourceInfo Info) {
   if (!isActive())
     return true;
 
@@ -280,7 +280,7 @@ bool EvalEmitter::emitGetPtrLocal(uint32_t I, const SourceInfo &Info) {
 }
 
 template <PrimType OpType>
-bool EvalEmitter::emitGetLocal(uint32_t I, const SourceInfo &Info) {
+bool EvalEmitter::emitGetLocal(uint32_t I, SourceInfo Info) {
   if (!isActive())
     return true;
 
@@ -296,7 +296,7 @@ bool EvalEmitter::emitGetLocal(uint32_t I, const SourceInfo &Info) {
 }
 
 template <PrimType OpType>
-bool EvalEmitter::emitSetLocal(uint32_t I, const SourceInfo &Info) {
+bool EvalEmitter::emitSetLocal(uint32_t I, SourceInfo Info) {
   if (!isActive())
     return true;
 
@@ -310,7 +310,7 @@ bool EvalEmitter::emitSetLocal(uint32_t I, const SourceInfo &Info) {
   return true;
 }
 
-bool EvalEmitter::emitDestroy(uint32_t I, const SourceInfo &Info) {
+bool EvalEmitter::emitDestroy(uint32_t I, SourceInfo Info) {
   if (!isActive())
     return true;
 

--- a/clang/lib/AST/ByteCode/Source.h
+++ b/clang/lib/AST/ByteCode/Source.h
@@ -92,6 +92,7 @@ public:
 private:
   llvm::PointerUnion<const Decl *, const Stmt *> Source;
 };
+static_assert(sizeof(SourceInfo) == sizeof(void *));
 
 using SourceMap = std::vector<std::pair<unsigned, SourceInfo>>;
 

--- a/clang/utils/TableGen/ClangOpcodesEmitter.cpp
+++ b/clang/utils/TableGen/ClangOpcodesEmitter.cpp
@@ -200,7 +200,7 @@ void ClangOpcodesEmitter::EmitEmitter(raw_ostream &OS, StringRef N,
       OS << (AsRef ? "const " : " ") << Name << " " << (AsRef ? "&" : "") << "A"
          << I << ", ";
     }
-    OS << "const SourceInfo &L) {\n";
+    OS << "SourceInfo L) {\n";
 
     // Emit a call to write the opcodes.
     OS << "  return emitOp<";
@@ -231,7 +231,7 @@ void ClangOpcodesEmitter::EmitProto(raw_ostream &OS, StringRef N,
       OS << (AsRef ? "const " : " ") << Name << " " << (AsRef ? "&" : "")
          << ", ";
     }
-    OS << "const SourceInfo &);\n";
+    OS << "SourceInfo);\n";
   });
 
   // Emit a template method for custom emitters to have less to implement.
@@ -248,7 +248,7 @@ void ClangOpcodesEmitter::EmitProto(raw_ostream &OS, StringRef N,
     OS << "bool emit" << N << "(";
     for (const auto *Arg : Args)
       OS << Arg->getValueAsString("Name") << ", ";
-    OS << "const SourceInfo &);\n";
+    OS << "SourceInfo);\n";
     OS << "#endif\n";
   }
 
@@ -272,7 +272,7 @@ void ClangOpcodesEmitter::EmitGroup(raw_ostream &OS, StringRef N,
     OS << "PrimType, ";
   for (auto *Arg : Args)
     OS << Arg->getValueAsString("Name") << ", ";
-  OS << "const SourceInfo &I);\n";
+  OS << "SourceInfo I);\n";
   OS << "#endif\n";
 
   // Emit the dispatch implementation in the source.
@@ -294,7 +294,7 @@ void ClangOpcodesEmitter::EmitGroup(raw_ostream &OS, StringRef N,
     OS << (AsRef ? "const " : " ") << Name << " " << (AsRef ? "&" : "") << "A"
        << I << ", ";
   }
-  OS << "const SourceInfo &I) {\n";
+  OS << "SourceInfo I) {\n";
 
   std::function<void(size_t, const Twine &)> Rec;
   SmallVector<const Record *, 2> TS;
@@ -368,7 +368,7 @@ void ClangOpcodesEmitter::EmitEval(raw_ostream &OS, StringRef N,
                 OS << (AsRef ? "const " : " ") << Name << " "
                    << (AsRef ? "&" : "") << "A" << I << ", ";
               }
-              OS << "const SourceInfo &L) {\n";
+              OS << "SourceInfo L) {\n";
               OS << "  if (!isActive()) return true;\n";
               OS << "  CurrentSource = L;\n";
 


### PR DESCRIPTION
They are only pointer-sized and copying them is cheaper than taking the const ref.