### PR TITLE
[flang] Disable -gdwarf-5 tests on AIX.

### DIFF
--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -1,3 +1,4 @@
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 // RUN: %flang -### -S %s -g -gdwarf-5  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
 // RUN: %flang -### -S %s -gdwarf-5  2>&1 \

--- a/flang/test/Driver/flang-dwarf-version.f90
+++ b/flang/test/Driver/flang-dwarf-version.f90
@@ -1,10 +1,18 @@
-// UNSUPPORTED: target={{.*}}-aix{{.*}}
+// RUN: %if !target={{.*aix.*}} %{ \
 // RUN: %flang -### -S %s -g -gdwarf-5  2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s \
+// RUN: %}
+
+// RUN: %if !target={{.*aix.*}} %{ \
 // RUN: %flang -### -S %s -gdwarf-5  2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s
+// RUN:             | FileCheck --check-prefix=CHECK-DWARF5 %s \
+// RUN: %}
+
+// RUN: %if !target={{.*aix.*}} %{ \
 // RUN: %flang -### -S %s -g1 -gdwarf-5  2>&1 \
-// RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s
+// RUN:             | FileCheck --check-prefix=CHECK-WITH-G1-DWARF5 %s \
+// RUN: %}
+
 // RUN: %flang -### -S %s -gdwarf-4  2>&1 \
 // RUN:             | FileCheck --check-prefix=CHECK-DWARF4 %s
 // RUN: %flang -### -S %s -gdwarf-3  2>&1 \

--- a/flang/test/Integration/debug-dwarf-flags.f90
+++ b/flang/test/Integration/debug-dwarf-flags.f90
@@ -1,4 +1,4 @@
-// UNSUPPORTED: target={{.*}}-aix{{.*}}
+! UNSUPPORTED: target={{.*}}-aix{{.*}}
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone -dwarf-version=5 %s  \
 ! RUN:         -o - | FileCheck --check-prefix=CHECK-DWARF5 %s
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=line-tables-only -dwarf-version=5 \

--- a/flang/test/Integration/debug-dwarf-flags.f90
+++ b/flang/test/Integration/debug-dwarf-flags.f90
@@ -1,8 +1,13 @@
-! UNSUPPORTED: target={{.*}}-aix{{.*}}
+! RUN: %if !target={{.*aix.*}} %{ \
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone -dwarf-version=5 %s  \
-! RUN:         -o - | FileCheck --check-prefix=CHECK-DWARF5 %s
+! RUN:         -o - | FileCheck --check-prefix=CHECK-DWARF5 %s \
+! RUN: %}
+
+! RUN: %if !target={{.*aix.*}} %{ \
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=line-tables-only -dwarf-version=5 \
-! RUN:         %s -o - | FileCheck --check-prefix=CHECK-DWARF5 %s
+! RUN:         %s -o - | FileCheck --check-prefix=CHECK-DWARF5 %s \
+! RUN: %}
+
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone -dwarf-version=4 %s  \
 ! RUN:         -o - | FileCheck --check-prefix=CHECK-DWARF4 %s
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone -dwarf-version=3 %s  \

--- a/flang/test/Integration/debug-dwarf-flags.f90
+++ b/flang/test/Integration/debug-dwarf-flags.f90
@@ -1,3 +1,4 @@
+// UNSUPPORTED: target={{.*}}-aix{{.*}}
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=standalone -dwarf-version=5 %s  \
 ! RUN:         -o - | FileCheck --check-prefix=CHECK-DWARF5 %s
 ! RUN: %flang_fc1 -emit-llvm -debug-info-kind=line-tables-only -dwarf-version=5 \


### PR DESCRIPTION
After recent addition of -gdwarf-N options in flang, I saw that newly added tests failing on AIX bot. The gdwarf-5 option is not supported on that platform. Disabling the test on AIX for now.