### PR TITLE
Fix NDEBUG Wundef warning; NFC

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
+++ b/llvm/lib/Transforms/Instrumentation/PGOCtxProfLowering.cpp
@@ -98,7 +98,7 @@ std::pair<uint32_t, uint32_t> getNumCountersAndCallsites(const Function &F) {
                "same total nr of callsites parameter");
         NumCallsites = V;
       }
-#if NDEBUG
+#ifdef NDEBUG
       if (NumCounters && NumCallsites)
         return std::make_pair(NumCounters, NumCallsites);
 #endif


### PR DESCRIPTION
The `NDEBUG` macro is tested for defined-ness everywhere else.  The instance here triggers a warning when compiling with `-Wundef`.