### PR TITLE
[LLVM][Support] Allow `char[N]` parameters in `llvm::format`

### DIFF
--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -44,6 +44,7 @@ add_llvm_unittest(SupportTests
   ExtensibleRTTITest.cpp
   FileCollectorTest.cpp
   FileOutputBufferTest.cpp
+  Format.cpp
   FormatVariadicTest.cpp
   FSUniqueIDTest.cpp
   GenericDomTreeTest.cpp

--- a/llvm/unittests/Support/Format.cpp
+++ b/llvm/unittests/Support/Format.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Format.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+namespace {
+
+template <typename FormatTy>
+std::string printToString(unsigned MaxN, FormatTy &&Fmt) {
+  std::vector<char> Dst(MaxN + 2);
+  int N = Fmt.snprint(Dst.data(), Dst.size());
+  Dst.back() = 0;
+  return N < 0 ? "" : Dst.data();
+}
+
+template <typename Expected, typename Arg>
+constexpr bool checkDecayTypeEq(const Arg &arg) {
+  return std::is_same_v<detail::decay_if_c_char_array_t<Arg>, Expected>;
+}
+
+TEST(Format, DecayIfCCharArray) {
+  char Array[] = "Array";
+  const char ConstArray[] = "ConstArray";
+  char PtrBuf[] = "Ptr";
+  char *Ptr = PtrBuf;
+  const char *PtrToConst = "PtrToConst";
+
+  EXPECT_EQ("        Literal", printToString(20, format("%15s", "Literal")));
+  EXPECT_EQ("          Array", printToString(20, format("%15s", Array)));
+  EXPECT_EQ("     ConstArray", printToString(20, format("%15s", ConstArray)));
+  EXPECT_EQ("            Ptr", printToString(20, format("%15s", Ptr)));
+  EXPECT_EQ("     PtrToConst", printToString(20, format("%15s", PtrToConst)));
+
+  EXPECT_TRUE(checkDecayTypeEq<const char *>("Literal"));
+  EXPECT_TRUE(checkDecayTypeEq<const char *>(Array));
+  EXPECT_TRUE(checkDecayTypeEq<const char *>(ConstArray));
+  EXPECT_TRUE(checkDecayTypeEq<char *>(Ptr));
+  EXPECT_TRUE(checkDecayTypeEq<const char *>(PtrToConst));
+  EXPECT_TRUE(checkDecayTypeEq<char>(PtrToConst[0]));
+  EXPECT_TRUE(
+      checkDecayTypeEq<const char *>(static_cast<const char *>("Literal")));
+
+  wchar_t WCharArray[] = L"WCharArray";
+  EXPECT_TRUE(checkDecayTypeEq<wchar_t[11]>(WCharArray));
+  EXPECT_TRUE(checkDecayTypeEq<wchar_t>(WCharArray[0]));
+}
+
+} // namespace


### PR DESCRIPTION
Cygwin builds are currently broken after #157312, which effectively reverted #138117. The root cause is that Cygwin defines `DL_info::dli_fname` as `char[N]`, which is not a valid parameter type for `llvm::format`.

This patch allows `llvm::format` to accept `char[N]` by decaying it to `const char *`. As a result, string literals are also accepted without an explicit cast.

Other array types remain rejected:
- Wide/unicode character arrays (e.g., `wchar_t[N]`) are not supported, as LLVM does not use them and they are less compatible with platform's `printf` implementations.
- Non-character arrays (e.g., `int[N]`) are also rejected, since passing such arrays to `printf` is meaningless.