### PR TITLE
[lldb][lldb-dap] Disable all lldb-dap tests on Windows on Arm

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/lldbdap_testcase.py
@@ -5,12 +5,16 @@ import uuid
 
 import dap_server
 from dap_server import Source
+from lldbsuite.test.decorators import skipIf
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbplatformutil
 import lldbgdbserverutils
 import base64
 
 
+# DAP tests as a whole have been flakey on the Windows on Arm bot. See:
+# https://github.com/llvm/llvm-project/issues/137660
+@skipIf(oslist=["windows"], archs=["aarch64"])
 class DAPTestCaseBase(TestBase):
     # set timeout based on whether ASAN was enabled or not. Increase
     # timeout by a factor of 10 if ASAN is enabled.

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -40,7 +40,6 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
             self.continue_to_exit()
 
     @skipIfNetBSD  # Hangs on NetBSD as well
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/137660
     def test_by_pid(self):
         """
         Tests attaching to a process by process ID.
@@ -56,7 +55,6 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.set_and_hit_breakpoint(continueToExit=True)
 
     @skipIfNetBSD  # Hangs on NetBSD as well
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/137660
     def test_by_name(self):
         """
         Tests attaching to a process by process name.
@@ -95,7 +93,6 @@ class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
         self.set_and_hit_breakpoint(continueToExit=True)
 
     @skipIfNetBSD  # Hangs on NetBSD as well
-    @skipIfWindows
     def test_commands(self):
         """
         Tests the "initCommands", "preRunCommands", "stopCommands",

--- a/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
+++ b/lldb/test/API/tools/lldb-dap/cancel/TestDAP_cancel.py
@@ -37,7 +37,6 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
     def async_cancel(self, requestId: int) -> int:
         return self.send_async_req(command="cancel", arguments={"requestId": requestId})
 
-    @skipIfWindows
     def test_pending_request(self):
         """
         Tests cancelling a pending request.
@@ -70,7 +69,6 @@ class TestDAP_cancel(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(cancel_resp["success"], True)
         self.continue_to_exit()
 
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/137660
     def test_inflight_request(self):
         """
         Tests cancelling an inflight request.

--- a/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
+++ b/lldb/test/API/tools/lldb-dap/console/TestDAP_console.py
@@ -38,7 +38,6 @@ class TestDAP_console(lldbdap_testcase.DAPTestCaseBase):
             ),
         )
 
-    @skipIfWindows
     def test_scopes_variables_setVariable_evaluate(self):
         """
         Tests that the "scopes" request causes the currently selected

--- a/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
+++ b/lldb/test/API/tools/lldb-dap/io/TestDAP_io.py
@@ -76,7 +76,6 @@ class TestDAP_io(lldbdap_testcase.DAPTestCaseBase):
         process.stdin.close()
         self.assertEqual(process.wait(timeout=5.0), EXIT_FAILURE)
 
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/137660
     def test_partial_content_length(self):
         """
         lldb-dap returns a failure exit code when the input stream is closed

--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -96,8 +96,6 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
         # Check the return code
         self.assertEqual(self.dap_server.process.poll(), 0)
 
-    # Flakey on Windows, https://github.com/llvm/llvm-project/issues/137660.
-    @skipIfWindows
     def test_stopOnEntry(self):
         """
         Tests the default launch of a simple program that stops at the
@@ -144,7 +142,6 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
                 )
         self.assertTrue(found, "verified program working directory")
 
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/137660
     def test_debuggerRoot(self):
         """
         Tests the "debuggerRoot" will change the working directory of

--- a/lldb/test/API/tools/lldb-dap/startDebugging/TestDAP_startDebugging.py
+++ b/lldb/test/API/tools/lldb-dap/startDebugging/TestDAP_startDebugging.py
@@ -8,7 +8,6 @@ import lldbdap_testcase
 
 
 class TestDAP_startDebugging(lldbdap_testcase.DAPTestCaseBase):
-    @skipIfWindows # https://github.com/llvm/llvm-project/issues/137660
     def test_startDebugging(self):
         """
         Tests the "startDebugging" reverse request. It makes sure that the IDE can

--- a/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
+++ b/lldb/test/API/tools/lldb-dap/step/TestDAP_step.py
@@ -84,7 +84,6 @@ class TestDAP_step(lldbdap_testcase.DAPTestCaseBase):
                     # only step one thread that is at the breakpoint and stop
                     break
 
-    @skipIfWindows
     def test_step_over_inlined_function(self):
         """
         Test stepping over when the program counter is in another file.

--- a/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
+++ b/lldb/test/API/tools/lldb-dap/stepInTargets/TestDAP_stepInTargets.py
@@ -102,7 +102,6 @@ class TestDAP_stepInTargets(lldbdap_testcase.DAPTestCaseBase):
         self.continue_to_exit()
 
     @skipIf(archs=["x86", "x86_64"])
-    @skipIfWindows
     def test_supported_capability_other_archs(self):
         program = self.getBuildArtifact("a.out")
         self.build_and_launch(program)


### PR DESCRIPTION
This reverts the following commits:
a0a82ee19d6f2ff1013407ba4c973bfe5428423f
757bb36a58c7d7151a28c6a5fc7caa2e1f44de87
83b48b13f3a70bf56053e92593270c519859cfd7
b45f1fb377636a34c01e34b89341c97d19975554
d2e153981e62fb2ea781ef456ff744f9893e0733
e2d1bbebbb099c7010a31fad62a9128166ef14a0
71cae12442e7476e6397fd73db05e127bfe2d035
7dd879bdc01297a551196a60bb5a5a90ca4dd1ed
f3b542e3148cfc244f63cb7c987ccf8ebc71942b

Where I had disabled specific tests due to them being flakey on our Windows on Arm bot.

Clearly this strategy isn't working because
every day I see a new random test failing.

Until something can be done about this, disable
every lldb-dap test on Windows on Arm. The coverage we get is just not worth spamming contributors
who have nothing to do with lldb-dap.

See #137660