### PR TITLE
[lldb][test] Disable a procfile test when threading is not enabled

### DIFF
--- a/lldb/unittests/Host/posix/SupportTest.cpp
+++ b/lldb/unittests/Host/posix/SupportTest.cpp
@@ -38,4 +38,5 @@ TEST(Support, getProcFile_Tid) {
   ASSERT_TRUE(BufferOrError);
   ASSERT_TRUE(*BufferOrError);
 }
-#endif // #if (defined(_AIX) || defined(__linux__)) && defined(LLVM_ENABLE_THREADING)
+#endif // #if (defined(_AIX) || defined(__linux__)) &&
+       // defined(LLVM_ENABLE_THREADING)

--- a/lldb/unittests/Host/posix/SupportTest.cpp
+++ b/lldb/unittests/Host/posix/SupportTest.cpp
@@ -26,7 +26,7 @@ TEST(Support, getProcFile_Pid) {
 }
 #endif // #ifndef __APPLE__
 
-#if defined(_AIX) || defined(__linux__)
+#if (defined(_AIX) || defined(__linux__)) && defined(LLVM_ENABLE_THREADING)
 TEST(Support, getProcFile_Tid) {
   auto BufferOrError = getProcFile(getpid(), llvm::get_threadid(),
 #ifdef _AIX
@@ -38,4 +38,4 @@ TEST(Support, getProcFile_Tid) {
   ASSERT_TRUE(BufferOrError);
   ASSERT_TRUE(*BufferOrError);
 }
-#endif // #if defined(_AIX) || defined(__linux__)
+#endif // #if (defined(_AIX) || defined(__linux__)) && defined(LLVM_ENABLE_THREADING)


### PR DESCRIPTION
As is done for other procfile tests.