### PR TITLE
[mlir] Fix unqualified APInt in LoopLikeOpInterface tablegen

### DIFF
--- a/mlir/include/mlir/Interfaces/LoopLikeInterface.td
+++ b/mlir/include/mlir/Interfaces/LoopLikeInterface.td
@@ -236,7 +236,7 @@ def LoopLikeOpInterface : OpInterface<"LoopLikeOpInterface"> {
     InterfaceMethod<[{
         Compute the static trip count if possible.
       }],
-      /*retTy=*/"::std::optional<APInt>",
+      /*retTy=*/"::std::optional<::llvm::APInt>",
       /*methodName=*/"getStaticTripCount",
       /*args=*/(ins),
       /*methodBody=*/"",


### PR DESCRIPTION
In the recent change adding `getStaticTripCount` there is an omitted namespace on `APInt` which means the build fails for projects using this interface outside of `llvm` namespace (or `using llvm::APInt`).