### PR TITLE
[Clangd] [NFC] Fix dereference of null value

### DIFF
--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -145,8 +145,11 @@ std::string getQualification(ASTContext &Context,
   for (const auto *CurD : llvm::reverse(Parents)) {
     if (auto *TD = llvm::dyn_cast<TagDecl>(CurD)) {
       QualType T;
-      if (const auto *RD = dyn_cast<CXXRecordDecl>(TD);
-          ClassTemplateDecl *CTD = RD->getDescribedClassTemplate()) {
+      const auto *RD = dyn_cast<CXXRecordDecl>(TD);
+      ClassTemplateDecl *CTD = nullptr;
+      if (RD)
+        CTD = RD->getDescribedClassTemplate();
+      if (RD && CTD) {
         ArrayRef<TemplateArgument> Args;
         if (const auto *SD = dyn_cast<ClassTemplateSpecializationDecl>(RD))
           Args = SD->getTemplateArgs().asArray();

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -145,11 +145,8 @@ std::string getQualification(ASTContext &Context,
   for (const auto *CurD : llvm::reverse(Parents)) {
     if (auto *TD = llvm::dyn_cast<TagDecl>(CurD)) {
       QualType T;
-      const auto *RD = dyn_cast<CXXRecordDecl>(TD);
-      ClassTemplateDecl *CTD = nullptr;
-      if (RD)
-        CTD = RD->getDescribedClassTemplate();
-      if (RD && CTD) {
+      if (const auto *RD = cast<CXXRecordDecl>(TD);
+          ClassTemplateDecl *CTD = RD->getDescribedClassTemplate()) {
         ArrayRef<TemplateArgument> Args;
         if (const auto *SD = dyn_cast<ClassTemplateSpecializationDecl>(RD))
           Args = SD->getTemplateArgs().asArray();

--- a/clang-tools-extra/clangd/AST.cpp
+++ b/clang-tools-extra/clangd/AST.cpp
@@ -145,8 +145,9 @@ std::string getQualification(ASTContext &Context,
   for (const auto *CurD : llvm::reverse(Parents)) {
     if (auto *TD = llvm::dyn_cast<TagDecl>(CurD)) {
       QualType T;
-      if (const auto *RD = cast<CXXRecordDecl>(TD);
-          ClassTemplateDecl *CTD = RD->getDescribedClassTemplate()) {
+      if (const auto *RD = dyn_cast<CXXRecordDecl>(TD);
+          ClassTemplateDecl *CTD =
+              RD ? RD->getDescribedClassTemplate() : nullptr) {
         ArrayRef<TemplateArgument> Args;
         if (const auto *SD = dyn_cast<ClassTemplateSpecializationDecl>(RD))
           Args = SD->getTemplateArgs().asArray();


### PR DESCRIPTION
This is a find from static analysis tool complaining about potential dereference of `nullptr` for `RD`.