### PR TITLE
[CodeGen][NewPM] Port `ReachingDefAnalysis` to new pass manager.

### DIFF
--- a/llvm/include/llvm/CodeGen/ExecutionDomainFix.h
+++ b/llvm/include/llvm/CodeGen/ExecutionDomainFix.h
@@ -133,7 +133,7 @@ class ExecutionDomainFix : public MachineFunctionPass {
   using OutRegsInfoMap = SmallVector<LiveRegsDVInfo, 4>;
   OutRegsInfoMap MBBOutRegsInfos;
 
-  ReachingDefAnalysis *RDA = nullptr;
+  ReachingDefInfo *RDI = nullptr;
 
 public:
   ExecutionDomainFix(char &PassID, const TargetRegisterClass &RC)
@@ -141,7 +141,7 @@ public:
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();
-    AU.addRequired<ReachingDefAnalysis>();
+    AU.addRequired<ReachingDefInfoWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
 

--- a/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
+++ b/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
@@ -344,13 +344,11 @@ public:
   ReachingDefInfoWrapperPass();
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
-
+  MachineFunctionProperties getRequiredProperties() const override;
   bool runOnMachineFunction(MachineFunction &F) override;
-
   void releaseMemory() override { RDI.releaseMemory(); }
 
   ReachingDefInfo &getRDI() { return RDI; }
-
   const ReachingDefInfo &getRDI() const { return RDI; }
 };
 

--- a/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
+++ b/llvm/include/llvm/CodeGen/ReachingDefAnalysis.h
@@ -26,6 +26,7 @@
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/CodeGen/LoopTraversal.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
+#include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/InitializePasses.h"
 
 namespace llvm {
@@ -110,7 +111,7 @@ private:
 };
 
 /// This class provides the reaching def analysis.
-class ReachingDefAnalysis : public MachineFunctionPass {
+class ReachingDefInfo {
 private:
   MachineFunction *MF = nullptr;
   const TargetRegisterInfo *TRI = nullptr;
@@ -156,24 +157,16 @@ private:
   using BlockSet = SmallPtrSetImpl<MachineBasicBlock*>;
 
 public:
-  static char ID; // Pass identification, replacement for typeid
+  ReachingDefInfo();
+  ReachingDefInfo(ReachingDefInfo &&);
+  ~ReachingDefInfo();
+  /// Handle invalidation explicitly.
+  bool invalidate(MachineFunction &F, const PreservedAnalyses &PA,
+                  MachineFunctionAnalysisManager::Invalidator &);
 
-  ReachingDefAnalysis() : MachineFunctionPass(ID) {
-    initializeReachingDefAnalysisPass(*PassRegistry::getPassRegistry());
-  }
-  void releaseMemory() override;
-
-  void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.setPreservesAll();
-    MachineFunctionPass::getAnalysisUsage(AU);
-  }
-
-  void printAllReachingDefs(MachineFunction &MF);
-  bool runOnMachineFunction(MachineFunction &MF) override;
-
-  MachineFunctionProperties getRequiredProperties() const override {
-    return MachineFunctionProperties().setNoVRegs().setTracksLiveness();
-  }
+  void run(MachineFunction &mf);
+  void print(raw_ostream &OS);
+  void releaseMemory();
 
   /// Re-run the analysis.
   void reset();
@@ -317,6 +310,48 @@ private:
   /// Reg that reaches MI, relative to the begining of MI's basic block.
   /// Note that Reg may represent a stack slot.
   MachineInstr *getReachingLocalMIDef(MachineInstr *MI, Register Reg) const;
+};
+
+class ReachingDefAnalysis : public AnalysisInfoMixin<ReachingDefAnalysis> {
+  friend AnalysisInfoMixin<ReachingDefAnalysis>;
+  static AnalysisKey Key;
+
+public:
+  using Result = ReachingDefInfo;
+
+  Result run(MachineFunction &MF, MachineFunctionAnalysisManager &MFAM);
+};
+
+/// Printer pass for the \c ReachingDefInfo results.
+class ReachingDefPrinterPass : public PassInfoMixin<ReachingDefPrinterPass> {
+  raw_ostream &OS;
+
+public:
+  explicit ReachingDefPrinterPass(raw_ostream &OS) : OS(OS) {}
+
+  PreservedAnalyses run(MachineFunction &MF,
+                        MachineFunctionAnalysisManager &MFAM);
+
+  static bool isRequired() { return true; }
+};
+
+class ReachingDefInfoWrapperPass : public MachineFunctionPass {
+  ReachingDefInfo RDI;
+
+public:
+  static char ID;
+
+  ReachingDefInfoWrapperPass();
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+  bool runOnMachineFunction(MachineFunction &F) override;
+
+  void releaseMemory() override { RDI.releaseMemory(); }
+
+  ReachingDefInfo &getRDI() { return RDI; }
+
+  const ReachingDefInfo &getRDI() const { return RDI; }
 };
 
 } // namespace llvm

--- a/llvm/include/llvm/InitializePasses.h
+++ b/llvm/include/llvm/InitializePasses.h
@@ -264,7 +264,7 @@ LLVM_ABI void initializePromoteLegacyPassPass(PassRegistry &);
 LLVM_ABI void initializeRABasicPass(PassRegistry &);
 LLVM_ABI void initializePseudoProbeInserterPass(PassRegistry &);
 LLVM_ABI void initializeRAGreedyLegacyPass(PassRegistry &);
-LLVM_ABI void initializeReachingDefAnalysisPass(PassRegistry &);
+LLVM_ABI void initializeReachingDefInfoWrapperPassPass(PassRegistry &);
 LLVM_ABI void initializeReassociateLegacyPassPass(PassRegistry &);
 LLVM_ABI void
 initializeRegAllocEvictionAdvisorAnalysisLegacyPass(PassRegistry &);

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -82,10 +82,9 @@ MACHINE_FUNCTION_ANALYSIS("machine-post-dom-tree",
 MACHINE_FUNCTION_ANALYSIS("machine-trace-metrics", MachineTraceMetricsAnalysis())
 MACHINE_FUNCTION_ANALYSIS("machine-uniformity", MachineUniformityAnalysis())
 MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
+MACHINE_FUNCTION_ANALYSIS("reaching-def", ReachingDefAnalysis())
 MACHINE_FUNCTION_ANALYSIS("regalloc-evict", RegAllocEvictionAdvisorAnalysis())
 MACHINE_FUNCTION_ANALYSIS("regalloc-priority", RegAllocPriorityAdvisorAnalysis())
-MACHINE_FUNCTION_ANALYSIS("reaching-def",
-ReachingDefAnalysis())
 MACHINE_FUNCTION_ANALYSIS("slot-indexes", SlotIndexesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("spill-code-placement", SpillPlacementAnalysis())
 MACHINE_FUNCTION_ANALYSIS("virtregmap", VirtRegMapAnalysis())
@@ -152,9 +151,9 @@ MACHINE_FUNCTION_PASS("print<machine-post-dom-tree>",
                       MachinePostDominatorTreePrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<machine-uniformity>",
                       MachineUniformityPrinterPass(errs()))
+MACHINE_FUNCTION_PASS("print<reaching-def>", ReachingDefPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<slot-indexes>", SlotIndexesPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<virtregmap>", VirtRegMapPrinterPass(errs()))
-MACHINE_FUNCTION_PASS("print<reaching-def>", ReachingDefPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("process-imp-defs", ProcessImplicitDefsPass())
 MACHINE_FUNCTION_PASS("prolog-epilog", PrologEpilogInserterPass())
 MACHINE_FUNCTION_PASS("reg-usage-collector", RegUsageInfoCollectorPass())

--- a/llvm/include/llvm/Passes/MachinePassRegistry.def
+++ b/llvm/include/llvm/Passes/MachinePassRegistry.def
@@ -84,6 +84,8 @@ MACHINE_FUNCTION_ANALYSIS("machine-uniformity", MachineUniformityAnalysis())
 MACHINE_FUNCTION_ANALYSIS("pass-instrumentation", PassInstrumentationAnalysis(PIC))
 MACHINE_FUNCTION_ANALYSIS("regalloc-evict", RegAllocEvictionAdvisorAnalysis())
 MACHINE_FUNCTION_ANALYSIS("regalloc-priority", RegAllocPriorityAdvisorAnalysis())
+MACHINE_FUNCTION_ANALYSIS("reaching-def",
+ReachingDefAnalysis())
 MACHINE_FUNCTION_ANALYSIS("slot-indexes", SlotIndexesAnalysis())
 MACHINE_FUNCTION_ANALYSIS("spill-code-placement", SpillPlacementAnalysis())
 MACHINE_FUNCTION_ANALYSIS("virtregmap", VirtRegMapAnalysis())
@@ -96,8 +98,7 @@ MACHINE_FUNCTION_ANALYSIS("virtregmap", VirtRegMapAnalysis())
 // MachinePostDominatorTreeAnalysis())
 // MACHINE_FUNCTION_ANALYSIS("machine-region-info",
 // MachineRegionInfoPassAnalysis())
-// MACHINE_FUNCTION_ANALYSIS("reaching-def",
-// ReachingDefAnalysisAnalysis()) MACHINE_FUNCTION_ANALYSIS("gc-analysis",
+// MACHINE_FUNCTION_ANALYSIS("gc-analysis",
 // GCMachineCodeAnalysisPass())
 #undef MACHINE_FUNCTION_ANALYSIS
 
@@ -153,6 +154,7 @@ MACHINE_FUNCTION_PASS("print<machine-uniformity>",
                       MachineUniformityPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<slot-indexes>", SlotIndexesPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("print<virtregmap>", VirtRegMapPrinterPass(errs()))
+MACHINE_FUNCTION_PASS("print<reaching-def>", ReachingDefPrinterPass(errs()))
 MACHINE_FUNCTION_PASS("process-imp-defs", ProcessImplicitDefsPass())
 MACHINE_FUNCTION_PASS("prolog-epilog", PrologEpilogInserterPass())
 MACHINE_FUNCTION_PASS("reg-usage-collector", RegUsageInfoCollectorPass())

--- a/llvm/lib/CodeGen/BreakFalseDeps.cpp
+++ b/llvm/lib/CodeGen/BreakFalseDeps.cpp
@@ -46,7 +46,7 @@ private:
   /// Storage for register unit liveness.
   LivePhysRegs LiveRegSet;
 
-  ReachingDefAnalysis *RDA = nullptr;
+  ReachingDefInfo *RDI = nullptr;
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -57,7 +57,7 @@ public:
 
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesAll();
-    AU.addRequired<ReachingDefAnalysis>();
+    AU.addRequired<ReachingDefInfoWrapperPass>();
     MachineFunctionPass::getAnalysisUsage(AU);
   }
 
@@ -101,7 +101,7 @@ private:
 
 char BreakFalseDeps::ID = 0;
 INITIALIZE_PASS_BEGIN(BreakFalseDeps, DEBUG_TYPE, "BreakFalseDeps", false, false)
-INITIALIZE_PASS_DEPENDENCY(ReachingDefAnalysis)
+INITIALIZE_PASS_DEPENDENCY(ReachingDefInfoWrapperPass)
 INITIALIZE_PASS_END(BreakFalseDeps, DEBUG_TYPE, "BreakFalseDeps", false, false)
 
 FunctionPass *llvm::createBreakFalseDeps() { return new BreakFalseDeps(); }
@@ -153,7 +153,7 @@ bool BreakFalseDeps::pickBestRegisterForUndef(MachineInstr *MI, unsigned OpIdx,
   unsigned MaxClearanceReg = OriginalReg;
   ArrayRef<MCPhysReg> Order = RegClassInfo.getOrder(OpRC);
   for (MCPhysReg Reg : Order) {
-    unsigned Clearance = RDA->getClearance(MI, Reg);
+    unsigned Clearance = RDI->getClearance(MI, Reg);
     if (Clearance <= MaxClearance)
       continue;
     MaxClearance = Clearance;
@@ -173,7 +173,7 @@ bool BreakFalseDeps::pickBestRegisterForUndef(MachineInstr *MI, unsigned OpIdx,
 bool BreakFalseDeps::shouldBreakDependence(MachineInstr *MI, unsigned OpIdx,
                                            unsigned Pref) {
   MCRegister Reg = MI->getOperand(OpIdx).getReg().asMCReg();
-  unsigned Clearance = RDA->getClearance(MI, Reg);
+  unsigned Clearance = RDI->getClearance(MI, Reg);
   LLVM_DEBUG(dbgs() << "Clearance: " << Clearance << ", want " << Pref);
 
   if (Pref > Clearance) {
@@ -282,7 +282,7 @@ bool BreakFalseDeps::runOnMachineFunction(MachineFunction &mf) {
   MF = &mf;
   TII = MF->getSubtarget().getInstrInfo();
   TRI = MF->getSubtarget().getRegisterInfo();
-  RDA = &getAnalysis<ReachingDefAnalysis>();
+  RDI = &getAnalysis<ReachingDefInfoWrapperPass>().getRDI();
 
   RegClassInfo.runOnMachineFunction(mf, /*Rev=*/true);
 

--- a/llvm/lib/CodeGen/CodeGen.cpp
+++ b/llvm/lib/CodeGen/CodeGen.cpp
@@ -112,6 +112,7 @@ void llvm::initializeCodeGen(PassRegistry &Registry) {
   initializeProcessImplicitDefsLegacyPass(Registry);
   initializeRABasicPass(Registry);
   initializeRAGreedyLegacyPass(Registry);
+  initializeReachingDefInfoWrapperPassPass(Registry);
   initializeRegAllocFastPass(Registry);
   initializeRegUsageInfoCollectorLegacyPass(Registry);
   initializeRegUsageInfoPropagationLegacyPass(Registry);

--- a/llvm/lib/CodeGen/ExecutionDomainFix.cpp
+++ b/llvm/lib/CodeGen/ExecutionDomainFix.cpp
@@ -337,9 +337,9 @@ void ExecutionDomainFix::visitSoftInstr(MachineInstr *mi, unsigned mask) {
     }
     // Sorted insertion.
     // Enables giving priority to the latest domains during merging.
-    const int Def = RDA->getReachingDef(mi, RC->getRegister(rx));
+    const int Def = RDI->getReachingDef(mi, RC->getRegister(rx));
     auto I = partition_point(Regs, [&](int I) {
-      return RDA->getReachingDef(mi, RC->getRegister(I)) <= Def;
+      return RDI->getReachingDef(mi, RC->getRegister(I)) <= Def;
     });
     Regs.insert(I, rx);
   }
@@ -435,7 +435,7 @@ bool ExecutionDomainFix::runOnMachineFunction(MachineFunction &mf) {
   if (!anyregs)
     return false;
 
-  RDA = &getAnalysis<ReachingDefAnalysis>();
+  RDI = &getAnalysis<ReachingDefInfoWrapperPass>().getRDI();
 
   // Initialize the AliasMap on the first use.
   if (AliasMap.empty()) {

--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -33,6 +33,8 @@ ReachingDefAnalysis::run(MachineFunction &MF,
 PreservedAnalyses
 ReachingDefPrinterPass::run(MachineFunction &MF,
                             MachineFunctionAnalysisManager &MFAM) {
+  MFPropsModifier _(*this, MF);
+
   auto &RDI = MFAM.getResult<ReachingDefAnalysis>(MF);
   OS << "Reaching definitions for for machine function: " << MF.getName()
      << '\n';
@@ -68,6 +70,11 @@ bool ReachingDefInfo::invalidate(
 void ReachingDefInfoWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
   MachineFunctionPass::getAnalysisUsage(AU);
+}
+
+MachineFunctionProperties
+ReachingDefInfoWrapperPass::getRequiredProperties() const {
+  return MachineFunctionProperties().setNoVRegs();
 }
 
 static bool isValidReg(const MachineOperand &MO) {

--- a/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
+++ b/llvm/lib/CodeGen/ReachingDefAnalysis.cpp
@@ -20,13 +20,55 @@ using namespace llvm;
 
 #define DEBUG_TYPE "reaching-defs-analysis"
 
-static cl::opt<bool> PrintAllReachingDefs("print-all-reaching-defs", cl::Hidden,
-                                          cl::desc("Used for test purpuses"),
-                                          cl::Hidden);
+AnalysisKey ReachingDefAnalysis::Key;
 
-char ReachingDefAnalysis::ID = 0;
-INITIALIZE_PASS(ReachingDefAnalysis, DEBUG_TYPE, "ReachingDefAnalysis", false,
-                true)
+ReachingDefAnalysis::Result
+ReachingDefAnalysis::run(MachineFunction &MF,
+                         MachineFunctionAnalysisManager &MFAM) {
+  ReachingDefInfo RDI;
+  RDI.run(MF);
+  return RDI;
+}
+
+PreservedAnalyses
+ReachingDefPrinterPass::run(MachineFunction &MF,
+                            MachineFunctionAnalysisManager &MFAM) {
+  auto &RDI = MFAM.getResult<ReachingDefAnalysis>(MF);
+  OS << "Reaching definitions for for machine function: " << MF.getName()
+     << '\n';
+  RDI.print(OS);
+  return PreservedAnalyses::all();
+}
+
+INITIALIZE_PASS(ReachingDefInfoWrapperPass, DEBUG_TYPE,
+                "Reaching Definitions Analysis", false, true)
+
+char ReachingDefInfoWrapperPass::ID = 0;
+
+ReachingDefInfoWrapperPass::ReachingDefInfoWrapperPass()
+    : MachineFunctionPass(ID) {
+  initializeReachingDefInfoWrapperPassPass(*PassRegistry::getPassRegistry());
+}
+
+ReachingDefInfo::ReachingDefInfo() = default;
+ReachingDefInfo::ReachingDefInfo(ReachingDefInfo &&) = default;
+ReachingDefInfo::~ReachingDefInfo() = default;
+
+bool ReachingDefInfo::invalidate(
+    MachineFunction &MF, const PreservedAnalyses &PA,
+    MachineFunctionAnalysisManager::Invalidator &) {
+  // Check whether the analysis, all analyses on machine functions, or the
+  // machine function's CFG have been preserved.
+  auto PAC = PA.getChecker<ReachingDefAnalysis>();
+  return !PAC.preserved() &&
+         !PAC.preservedSet<AllAnalysesOn<MachineFunction>>() &&
+         !PAC.preservedSet<CFGAnalyses>();
+}
+
+void ReachingDefInfoWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.setPreservesAll();
+  MachineFunctionPass::getAnalysisUsage(AU);
+}
 
 static bool isValidReg(const MachineOperand &MO) {
   return MO.isReg() && MO.getReg();
@@ -64,7 +106,7 @@ static bool isFIDef(const MachineInstr &MI, int FrameIndex,
   return false;
 }
 
-void ReachingDefAnalysis::enterBasicBlock(MachineBasicBlock *MBB) {
+void ReachingDefInfo::enterBasicBlock(MachineBasicBlock *MBB) {
   unsigned MBBNumber = MBB->getNumber();
   assert(MBBNumber < MBBReachingDefs.numBlockIDs() &&
          "Unexpected basic block number.");
@@ -116,7 +158,7 @@ void ReachingDefAnalysis::enterBasicBlock(MachineBasicBlock *MBB) {
       MBBReachingDefs.append(MBBNumber, Unit, LiveRegs[Unit]);
 }
 
-void ReachingDefAnalysis::leaveBasicBlock(MachineBasicBlock *MBB) {
+void ReachingDefInfo::leaveBasicBlock(MachineBasicBlock *MBB) {
   assert(!LiveRegs.empty() && "Must enter basic block first.");
   unsigned MBBNumber = MBB->getNumber();
   assert(MBBNumber < MBBOutRegsInfos.size() &&
@@ -134,7 +176,7 @@ void ReachingDefAnalysis::leaveBasicBlock(MachineBasicBlock *MBB) {
   LiveRegs.clear();
 }
 
-void ReachingDefAnalysis::processDefs(MachineInstr *MI) {
+void ReachingDefInfo::processDefs(MachineInstr *MI) {
   assert(!MI->isDebugInstr() && "Won't process debug instructions");
 
   unsigned MBBNumber = MI->getParent()->getNumber();
@@ -167,7 +209,7 @@ void ReachingDefAnalysis::processDefs(MachineInstr *MI) {
   ++CurInstr;
 }
 
-void ReachingDefAnalysis::reprocessBasicBlock(MachineBasicBlock *MBB) {
+void ReachingDefInfo::reprocessBasicBlock(MachineBasicBlock *MBB) {
   unsigned MBBNumber = MBB->getNumber();
   assert(MBBNumber < MBBReachingDefs.numBlockIDs() &&
          "Unexpected basic block number.");
@@ -212,7 +254,7 @@ void ReachingDefAnalysis::reprocessBasicBlock(MachineBasicBlock *MBB) {
   }
 }
 
-void ReachingDefAnalysis::processBasicBlock(
+void ReachingDefInfo::processBasicBlock(
     const LoopTraversal::TraversedMBBInfo &TraversedMBB) {
   MachineBasicBlock *MBB = TraversedMBB.MBB;
   LLVM_DEBUG(dbgs() << printMBBReference(*MBB)
@@ -232,12 +274,22 @@ void ReachingDefAnalysis::processBasicBlock(
   leaveBasicBlock(MBB);
 }
 
-void ReachingDefAnalysis::printAllReachingDefs(MachineFunction &MF) {
-  dbgs() << "RDA results for " << MF.getName() << "\n";
+void ReachingDefInfo::run(MachineFunction &mf) {
+  MF = &mf;
+  const TargetSubtargetInfo &STI = MF->getSubtarget();
+  TRI = STI.getRegisterInfo();
+  TII = STI.getInstrInfo();
+  LLVM_DEBUG(dbgs() << "********** REACHING DEFINITION ANALYSIS **********\n");
+  init();
+  traverse();
+}
+
+void ReachingDefInfo::print(raw_ostream &OS) {
+  OS << "RDA results for " << MF->getName() << "\n";
   int Num = 0;
   DenseMap<MachineInstr *, int> InstToNumMap;
   SmallPtrSet<MachineInstr *, 2> Defs;
-  for (MachineBasicBlock &MBB : MF) {
+  for (MachineBasicBlock &MBB : *MF) {
     for (MachineInstr &MI : MBB) {
       for (MachineOperand &MO : MI.operands()) {
         Register Reg;
@@ -256,37 +308,29 @@ void ReachingDefAnalysis::printAllReachingDefs(MachineFunction &MF) {
           continue;
         Defs.clear();
         getGlobalReachingDefs(&MI, Reg, Defs);
-        MO.print(dbgs(), TRI);
+        MO.print(OS, TRI);
         SmallVector<int, 0> Nums;
         for (MachineInstr *Def : Defs)
           Nums.push_back(InstToNumMap[Def]);
         llvm::sort(Nums);
-        dbgs() << ":{ ";
+        OS << ":{ ";
         for (int Num : Nums)
-          dbgs() << Num << " ";
-        dbgs() << "}\n";
+          OS << Num << " ";
+        OS << "}\n";
       }
-      dbgs() << Num << ": " << MI << "\n";
+      OS << Num << ": " << MI << "\n";
       InstToNumMap[&MI] = Num;
       ++Num;
     }
   }
 }
 
-bool ReachingDefAnalysis::runOnMachineFunction(MachineFunction &mf) {
-  MF = &mf;
-  const TargetSubtargetInfo &STI = MF->getSubtarget();
-  TRI = STI.getRegisterInfo();
-  TII = STI.getInstrInfo();
-  LLVM_DEBUG(dbgs() << "********** REACHING DEFINITION ANALYSIS **********\n");
-  init();
-  traverse();
-  if (PrintAllReachingDefs)
-    printAllReachingDefs(*MF);
+bool ReachingDefInfoWrapperPass::runOnMachineFunction(MachineFunction &mf) {
+  RDI.run(mf);
   return false;
 }
 
-void ReachingDefAnalysis::releaseMemory() {
+void ReachingDefInfo::releaseMemory() {
   // Clear the internal vectors.
   MBBOutRegsInfos.clear();
   MBBReachingDefs.clear();
@@ -295,13 +339,13 @@ void ReachingDefAnalysis::releaseMemory() {
   LiveRegs.clear();
 }
 
-void ReachingDefAnalysis::reset() {
+void ReachingDefInfo::reset() {
   releaseMemory();
   init();
   traverse();
 }
 
-void ReachingDefAnalysis::init() {
+void ReachingDefInfo::init() {
   NumRegUnits = TRI->getNumRegUnits();
   NumStackObjects = MF->getFrameInfo().getNumObjects();
   ObjectIndexBegin = MF->getFrameInfo().getObjectIndexBegin();
@@ -312,7 +356,7 @@ void ReachingDefAnalysis::init() {
   TraversedMBBOrder = Traversal.traverse(*MF);
 }
 
-void ReachingDefAnalysis::traverse() {
+void ReachingDefInfo::traverse() {
   // Traverse the basic blocks.
   for (LoopTraversal::TraversedMBBInfo TraversedMBB : TraversedMBBOrder)
     processBasicBlock(TraversedMBB);
@@ -331,7 +375,7 @@ void ReachingDefAnalysis::traverse() {
 #endif
 }
 
-int ReachingDefAnalysis::getReachingDef(MachineInstr *MI, Register Reg) const {
+int ReachingDefInfo::getReachingDef(MachineInstr *MI, Register Reg) const {
   assert(InstIds.count(MI) && "Unexpected machine instuction.");
   int InstId = InstIds.lookup(MI);
   int DefRes = ReachingDefDefaultVal;
@@ -367,15 +411,15 @@ int ReachingDefAnalysis::getReachingDef(MachineInstr *MI, Register Reg) const {
   return LatestDef;
 }
 
-MachineInstr *ReachingDefAnalysis::getReachingLocalMIDef(MachineInstr *MI,
-                                                         Register Reg) const {
+MachineInstr *ReachingDefInfo::getReachingLocalMIDef(MachineInstr *MI,
+                                                     Register Reg) const {
   return hasLocalDefBefore(MI, Reg)
              ? getInstFromId(MI->getParent(), getReachingDef(MI, Reg))
              : nullptr;
 }
 
-bool ReachingDefAnalysis::hasSameReachingDef(MachineInstr *A, MachineInstr *B,
-                                             Register Reg) const {
+bool ReachingDefInfo::hasSameReachingDef(MachineInstr *A, MachineInstr *B,
+                                         Register Reg) const {
   MachineBasicBlock *ParentA = A->getParent();
   MachineBasicBlock *ParentB = B->getParent();
   if (ParentA != ParentB)
@@ -384,8 +428,8 @@ bool ReachingDefAnalysis::hasSameReachingDef(MachineInstr *A, MachineInstr *B,
   return getReachingDef(A, Reg) == getReachingDef(B, Reg);
 }
 
-MachineInstr *ReachingDefAnalysis::getInstFromId(MachineBasicBlock *MBB,
-                                                 int InstId) const {
+MachineInstr *ReachingDefInfo::getInstFromId(MachineBasicBlock *MBB,
+                                             int InstId) const {
   assert(static_cast<size_t>(MBB->getNumber()) <
              MBBReachingDefs.numBlockIDs() &&
          "Unexpected basic block number.");
@@ -404,18 +448,17 @@ MachineInstr *ReachingDefAnalysis::getInstFromId(MachineBasicBlock *MBB,
   return nullptr;
 }
 
-int ReachingDefAnalysis::getClearance(MachineInstr *MI, Register Reg) const {
+int ReachingDefInfo::getClearance(MachineInstr *MI, Register Reg) const {
   assert(InstIds.count(MI) && "Unexpected machine instuction.");
   return InstIds.lookup(MI) - getReachingDef(MI, Reg);
 }
 
-bool ReachingDefAnalysis::hasLocalDefBefore(MachineInstr *MI,
-                                            Register Reg) const {
+bool ReachingDefInfo::hasLocalDefBefore(MachineInstr *MI, Register Reg) const {
   return getReachingDef(MI, Reg) >= 0;
 }
 
-void ReachingDefAnalysis::getReachingLocalUses(MachineInstr *Def, Register Reg,
-                                               InstSet &Uses) const {
+void ReachingDefInfo::getReachingLocalUses(MachineInstr *Def, Register Reg,
+                                           InstSet &Uses) const {
   MachineBasicBlock *MBB = Def->getParent();
   MachineBasicBlock::iterator MI = MachineBasicBlock::iterator(Def);
   while (++MI != MBB->end()) {
@@ -438,8 +481,8 @@ void ReachingDefAnalysis::getReachingLocalUses(MachineInstr *Def, Register Reg,
   }
 }
 
-bool ReachingDefAnalysis::getLiveInUses(MachineBasicBlock *MBB, Register Reg,
-                                        InstSet &Uses) const {
+bool ReachingDefInfo::getLiveInUses(MachineBasicBlock *MBB, Register Reg,
+                                    InstSet &Uses) const {
   for (MachineInstr &MI :
        instructionsWithoutDebug(MBB->instr_begin(), MBB->instr_end())) {
     for (auto &MO : MI.operands()) {
@@ -456,8 +499,8 @@ bool ReachingDefAnalysis::getLiveInUses(MachineBasicBlock *MBB, Register Reg,
   return isReachingDefLiveOut(&*Last, Reg);
 }
 
-void ReachingDefAnalysis::getGlobalUses(MachineInstr *MI, Register Reg,
-                                        InstSet &Uses) const {
+void ReachingDefInfo::getGlobalUses(MachineInstr *MI, Register Reg,
+                                    InstSet &Uses) const {
   MachineBasicBlock *MBB = MI->getParent();
 
   // Collect the uses that each def touches within the block.
@@ -481,8 +524,8 @@ void ReachingDefAnalysis::getGlobalUses(MachineInstr *MI, Register Reg,
   }
 }
 
-void ReachingDefAnalysis::getGlobalReachingDefs(MachineInstr *MI, Register Reg,
-                                                InstSet &Defs) const {
+void ReachingDefInfo::getGlobalReachingDefs(MachineInstr *MI, Register Reg,
+                                            InstSet &Defs) const {
   if (auto *Def = getUniqueReachingMIDef(MI, Reg)) {
     Defs.insert(Def);
     return;
@@ -492,15 +535,14 @@ void ReachingDefAnalysis::getGlobalReachingDefs(MachineInstr *MI, Register Reg,
     getLiveOuts(MBB, Reg, Defs);
 }
 
-void ReachingDefAnalysis::getLiveOuts(MachineBasicBlock *MBB, Register Reg,
-                                      InstSet &Defs) const {
+void ReachingDefInfo::getLiveOuts(MachineBasicBlock *MBB, Register Reg,
+                                  InstSet &Defs) const {
   SmallPtrSet<MachineBasicBlock*, 2> VisitedBBs;
   getLiveOuts(MBB, Reg, Defs, VisitedBBs);
 }
 
-void ReachingDefAnalysis::getLiveOuts(MachineBasicBlock *MBB, Register Reg,
-                                      InstSet &Defs,
-                                      BlockSet &VisitedBBs) const {
+void ReachingDefInfo::getLiveOuts(MachineBasicBlock *MBB, Register Reg,
+                                  InstSet &Defs, BlockSet &VisitedBBs) const {
   if (VisitedBBs.count(MBB))
     return;
 
@@ -517,8 +559,8 @@ void ReachingDefAnalysis::getLiveOuts(MachineBasicBlock *MBB, Register Reg,
       getLiveOuts(Pred, Reg, Defs, VisitedBBs);
 }
 
-MachineInstr *ReachingDefAnalysis::getUniqueReachingMIDef(MachineInstr *MI,
-                                                          Register Reg) const {
+MachineInstr *ReachingDefInfo::getUniqueReachingMIDef(MachineInstr *MI,
+                                                      Register Reg) const {
   // If there's a local def before MI, return it.
   MachineInstr *LocalDef = getReachingLocalMIDef(MI, Reg);
   if (LocalDef && InstIds.lookup(LocalDef) < InstIds.lookup(MI))
@@ -537,19 +579,19 @@ MachineInstr *ReachingDefAnalysis::getUniqueReachingMIDef(MachineInstr *MI,
   return nullptr;
 }
 
-MachineInstr *ReachingDefAnalysis::getMIOperand(MachineInstr *MI,
-                                                unsigned Idx) const {
+MachineInstr *ReachingDefInfo::getMIOperand(MachineInstr *MI,
+                                            unsigned Idx) const {
   assert(MI->getOperand(Idx).isReg() && "Expected register operand");
   return getUniqueReachingMIDef(MI, MI->getOperand(Idx).getReg());
 }
 
-MachineInstr *ReachingDefAnalysis::getMIOperand(MachineInstr *MI,
-                                                MachineOperand &MO) const {
+MachineInstr *ReachingDefInfo::getMIOperand(MachineInstr *MI,
+                                            MachineOperand &MO) const {
   assert(MO.isReg() && "Expected register operand");
   return getUniqueReachingMIDef(MI, MO.getReg());
 }
 
-bool ReachingDefAnalysis::isRegUsedAfter(MachineInstr *MI, Register Reg) const {
+bool ReachingDefInfo::isRegUsedAfter(MachineInstr *MI, Register Reg) const {
   MachineBasicBlock *MBB = MI->getParent();
   LiveRegUnits LiveRegs(*TRI);
   LiveRegs.addLiveOuts(*MBB);
@@ -569,8 +611,7 @@ bool ReachingDefAnalysis::isRegUsedAfter(MachineInstr *MI, Register Reg) const {
   return false;
 }
 
-bool ReachingDefAnalysis::isRegDefinedAfter(MachineInstr *MI,
-                                            Register Reg) const {
+bool ReachingDefInfo::isRegDefinedAfter(MachineInstr *MI, Register Reg) const {
   MachineBasicBlock *MBB = MI->getParent();
   auto Last = MBB->getLastNonDebugInstr();
   if (Last != MBB->end() &&
@@ -583,8 +624,8 @@ bool ReachingDefAnalysis::isRegDefinedAfter(MachineInstr *MI,
   return false;
 }
 
-bool ReachingDefAnalysis::isReachingDefLiveOut(MachineInstr *MI,
-                                               Register Reg) const {
+bool ReachingDefInfo::isReachingDefLiveOut(MachineInstr *MI,
+                                           Register Reg) const {
   MachineBasicBlock *MBB = MI->getParent();
   LiveRegUnits LiveRegs(*TRI);
   LiveRegs.addLiveOuts(*MBB);
@@ -604,8 +645,8 @@ bool ReachingDefAnalysis::isReachingDefLiveOut(MachineInstr *MI,
   return true;
 }
 
-MachineInstr *ReachingDefAnalysis::getLocalLiveOutMIDef(MachineBasicBlock *MBB,
-                                                        Register Reg) const {
+MachineInstr *ReachingDefInfo::getLocalLiveOutMIDef(MachineBasicBlock *MBB,
+                                                    Register Reg) const {
   LiveRegUnits LiveRegs(*TRI);
   LiveRegs.addLiveOuts(*MBB);
   if (Reg.isPhysical() && LiveRegs.available(Reg))
@@ -639,9 +680,8 @@ static bool mayHaveSideEffects(MachineInstr &MI) {
 // Can we safely move 'From' to just before 'To'? To satisfy this, 'From' must
 // not define a register that is used by any instructions, after and including,
 // 'To'. These instructions also must not redefine any of Froms operands.
-template<typename Iterator>
-bool ReachingDefAnalysis::isSafeToMove(MachineInstr *From,
-                                       MachineInstr *To) const {
+template <typename Iterator>
+bool ReachingDefInfo::isSafeToMove(MachineInstr *From, MachineInstr *To) const {
   if (From->getParent() != To->getParent() || From == To)
     return false;
 
@@ -669,8 +709,8 @@ bool ReachingDefAnalysis::isSafeToMove(MachineInstr *From,
   return true;
 }
 
-bool ReachingDefAnalysis::isSafeToMoveForwards(MachineInstr *From,
-                                               MachineInstr *To) const {
+bool ReachingDefInfo::isSafeToMoveForwards(MachineInstr *From,
+                                           MachineInstr *To) const {
   using Iterator = MachineBasicBlock::iterator;
   // Walk forwards until we find the instruction.
   for (auto I = Iterator(From), E = From->getParent()->end(); I != E; ++I)
@@ -679,8 +719,8 @@ bool ReachingDefAnalysis::isSafeToMoveForwards(MachineInstr *From,
   return false;
 }
 
-bool ReachingDefAnalysis::isSafeToMoveBackwards(MachineInstr *From,
-                                                MachineInstr *To) const {
+bool ReachingDefInfo::isSafeToMoveBackwards(MachineInstr *From,
+                                            MachineInstr *To) const {
   using Iterator = MachineBasicBlock::reverse_iterator;
   // Walk backwards until we find the instruction.
   for (auto I = Iterator(From), E = From->getParent()->rend(); I != E; ++I)
@@ -689,23 +729,21 @@ bool ReachingDefAnalysis::isSafeToMoveBackwards(MachineInstr *From,
   return false;
 }
 
-bool ReachingDefAnalysis::isSafeToRemove(MachineInstr *MI,
-                                         InstSet &ToRemove) const {
+bool ReachingDefInfo::isSafeToRemove(MachineInstr *MI,
+                                     InstSet &ToRemove) const {
   SmallPtrSet<MachineInstr*, 1> Ignore;
   SmallPtrSet<MachineInstr*, 2> Visited;
   return isSafeToRemove(MI, Visited, ToRemove, Ignore);
 }
 
-bool
-ReachingDefAnalysis::isSafeToRemove(MachineInstr *MI, InstSet &ToRemove,
-                                    InstSet &Ignore) const {
+bool ReachingDefInfo::isSafeToRemove(MachineInstr *MI, InstSet &ToRemove,
+                                     InstSet &Ignore) const {
   SmallPtrSet<MachineInstr*, 2> Visited;
   return isSafeToRemove(MI, Visited, ToRemove, Ignore);
 }
 
-bool
-ReachingDefAnalysis::isSafeToRemove(MachineInstr *MI, InstSet &Visited,
-                                    InstSet &ToRemove, InstSet &Ignore) const {
+bool ReachingDefInfo::isSafeToRemove(MachineInstr *MI, InstSet &Visited,
+                                     InstSet &ToRemove, InstSet &Ignore) const {
   if (Visited.count(MI) || Ignore.count(MI))
     return true;
   else if (mayHaveSideEffects(*MI)) {
@@ -733,8 +771,8 @@ ReachingDefAnalysis::isSafeToRemove(MachineInstr *MI, InstSet &Visited,
   return true;
 }
 
-void ReachingDefAnalysis::collectKilledOperands(MachineInstr *MI,
-                                                InstSet &Dead) const {
+void ReachingDefInfo::collectKilledOperands(MachineInstr *MI,
+                                            InstSet &Dead) const {
   Dead.insert(MI);
   auto IsDead = [this, &Dead](MachineInstr *Def, Register Reg) {
     if (mayHaveSideEffects(*Def))
@@ -765,14 +803,13 @@ void ReachingDefAnalysis::collectKilledOperands(MachineInstr *MI,
   }
 }
 
-bool ReachingDefAnalysis::isSafeToDefRegAt(MachineInstr *MI,
-                                           Register Reg) const {
+bool ReachingDefInfo::isSafeToDefRegAt(MachineInstr *MI, Register Reg) const {
   SmallPtrSet<MachineInstr*, 1> Ignore;
   return isSafeToDefRegAt(MI, Reg, Ignore);
 }
 
-bool ReachingDefAnalysis::isSafeToDefRegAt(MachineInstr *MI, Register Reg,
-                                           InstSet &Ignore) const {
+bool ReachingDefInfo::isSafeToDefRegAt(MachineInstr *MI, Register Reg,
+                                       InstSet &Ignore) const {
   // Check for any uses of the register after MI.
   if (isRegUsedAfter(MI, Reg)) {
     if (auto *Def = getReachingLocalMIDef(MI, Reg)) {

--- a/llvm/lib/Passes/PassBuilder.cpp
+++ b/llvm/lib/Passes/PassBuilder.cpp
@@ -145,6 +145,7 @@
 #include "llvm/CodeGen/PostRASchedulerList.h"
 #include "llvm/CodeGen/PreISelIntrinsicLowering.h"
 #include "llvm/CodeGen/ProcessImplicitDefs.h"
+#include "llvm/CodeGen/ReachingDefAnalysis.h"
 #include "llvm/CodeGen/RegAllocEvictionAdvisor.h"
 #include "llvm/CodeGen/RegAllocFast.h"
 #include "llvm/CodeGen/RegAllocGreedyPass.h"

--- a/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
+++ b/llvm/lib/Target/ARM/ARMLowOverheadLoops.cpp
@@ -269,7 +269,7 @@ namespace {
     // If this block begins with a VPT, we can check whether it's using
     // at least one predicated input(s), as well as possible loop invariant
     // which would result in it being implicitly predicated.
-    bool hasImplicitlyValidVPT(VPTBlock &Block, ReachingDefAnalysis &RDA) {
+    bool hasImplicitlyValidVPT(VPTBlock &Block, ReachingDefInfo &RDI) {
       SmallVectorImpl<MachineInstr *> &Insts = Block.getInsts();
       MachineInstr *VPT = Insts.front();
       assert(isVPTOpcode(VPT->getOpcode()) &&
@@ -289,7 +289,7 @@ namespace {
         return true;
 
       auto IsOperandPredicated = [&](MachineInstr *MI, unsigned Idx) {
-        MachineInstr *Op = RDA.getMIOperand(MI, MI->getOperand(Idx));
+        MachineInstr *Op = RDI.getMIOperand(MI, MI->getOperand(Idx));
         return Op && PredicatedInsts.count(Op) && isPredicatedOnVCTP(Op);
       };
 
@@ -299,7 +299,7 @@ namespace {
           return true;
 
         SmallPtrSet<MachineInstr *, 2> Defs;
-        RDA.getGlobalReachingDefs(MI, MO.getReg(), Defs);
+        RDI.getGlobalReachingDefs(MI, MO.getReg(), Defs);
         if (Defs.empty())
           return true;
 
@@ -316,7 +316,7 @@ namespace {
              (IsOperandPredicated(VPT, 2) || IsOperandInvariant(VPT, 2));
     }
 
-    bool isValid(ReachingDefAnalysis &RDA) {
+    bool isValid(ReachingDefInfo &RDI) {
       // All predication within the loop should be based on vctp. If the block
       // isn't predicated on entry, check whether the vctp is within the block
       // and that all other instructions are then predicated on it.
@@ -326,7 +326,7 @@ namespace {
               return getVPTInstrPredicate(*MI) == ARMVCC::Else;
             }))
           continue;
-        if (hasImplicitlyValidVPT(Block, RDA))
+        if (hasImplicitlyValidVPT(Block, RDI))
           continue;
 
         SmallVectorImpl<MachineInstr *> &Insts = Block.getInsts();
@@ -363,7 +363,7 @@ namespace {
     MachineLoop &ML;
     MachineBasicBlock *Preheader = nullptr;
     MachineLoopInfo &MLI;
-    ReachingDefAnalysis &RDA;
+    ReachingDefInfo &RDI;
     const TargetRegisterInfo &TRI;
     const ARMBaseInstrInfo &TII;
     MachineFunction *MF = nullptr;
@@ -382,10 +382,9 @@ namespace {
     bool CannotTailPredicate = false;
     VPTState VPTstate;
 
-    LowOverheadLoop(MachineLoop &ML, MachineLoopInfo &MLI,
-                    ReachingDefAnalysis &RDA, const TargetRegisterInfo &TRI,
-                    const ARMBaseInstrInfo &TII)
-        : ML(ML), MLI(MLI), RDA(RDA), TRI(TRI), TII(TII),
+    LowOverheadLoop(MachineLoop &ML, MachineLoopInfo &MLI, ReachingDefInfo &RDI,
+                    const TargetRegisterInfo &TRI, const ARMBaseInstrInfo &TII)
+        : ML(ML), MLI(MLI), RDI(RDI), TRI(TRI), TII(TII),
           TPNumElements(MachineOperand::CreateImm(0)) {
       MF = ML.getHeader()->getParent();
       if (auto *MBB = ML.getLoopPreheader())
@@ -468,7 +467,7 @@ namespace {
   class ARMLowOverheadLoops : public MachineFunctionPass {
     MachineFunction           *MF = nullptr;
     MachineLoopInfo           *MLI = nullptr;
-    ReachingDefAnalysis       *RDA = nullptr;
+    ReachingDefInfo *RDI = nullptr;
     const ARMBaseInstrInfo    *TII = nullptr;
     MachineRegisterInfo       *MRI = nullptr;
     const TargetRegisterInfo  *TRI = nullptr;
@@ -482,7 +481,7 @@ namespace {
     void getAnalysisUsage(AnalysisUsage &AU) const override {
       AU.setPreservesCFG();
       AU.addRequired<MachineLoopInfoWrapperPass>();
-      AU.addRequired<ReachingDefAnalysis>();
+      AU.addRequired<ReachingDefInfoWrapperPass>();
       MachineFunctionPass::getAnalysisUsage(AU);
     }
 
@@ -525,12 +524,12 @@ char ARMLowOverheadLoops::ID = 0;
 INITIALIZE_PASS(ARMLowOverheadLoops, DEBUG_TYPE, ARM_LOW_OVERHEAD_LOOPS_NAME,
                 false, false)
 
-static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
-                      InstSet &ToRemove, InstSet &Ignore) {
+static bool TryRemove(MachineInstr *MI, ReachingDefInfo &RDI, InstSet &ToRemove,
+                      InstSet &Ignore) {
 
   // Check that we can remove all of Killed without having to modify any IT
   // blocks.
-  auto WontCorruptITs = [](InstSet &Killed, ReachingDefAnalysis &RDA) {
+  auto WontCorruptITs = [](InstSet &Killed, ReachingDefInfo &RDI) {
     // Collect the dead code and the MBBs in which they reside.
     SmallPtrSet<MachineBasicBlock*, 2> BasicBlocks;
     for (auto *Dead : Killed)
@@ -542,7 +541,7 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
       for (auto &IT : *MBB) {
         if (IT.getOpcode() != ARM::t2IT)
           continue;
-        RDA.getReachingLocalUses(&IT, MCRegister::from(ARM::ITSTATE),
+        RDI.getReachingLocalUses(&IT, MCRegister::from(ARM::ITSTATE),
                                  ITBlocks[&IT]);
       }
     }
@@ -554,7 +553,7 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
     for (auto *Dead : Killed) {
       if (MachineOperand *MO =
               Dead->findRegisterUseOperand(ARM::ITSTATE, /*TRI=*/nullptr)) {
-        MachineInstr *IT = RDA.getMIOperand(Dead, *MO);
+        MachineInstr *IT = RDI.getMIOperand(Dead, *MO);
         RemoveITs.insert(IT);
         auto &CurrentBlock = ITBlocks[IT];
         CurrentBlock.erase(Dead);
@@ -571,10 +570,10 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
   };
 
   SmallPtrSet<MachineInstr *, 2> Uses;
-  if (!RDA.isSafeToRemove(MI, Uses, Ignore))
+  if (!RDI.isSafeToRemove(MI, Uses, Ignore))
     return false;
 
-  if (WontCorruptITs(Uses, RDA)) {
+  if (WontCorruptITs(Uses, RDI)) {
     ToRemove.insert_range(Uses);
     LLVM_DEBUG(dbgs() << "ARM Loops: Able to remove: " << *MI
                << " - can also remove:\n";
@@ -582,8 +581,8 @@ static bool TryRemove(MachineInstr *MI, ReachingDefAnalysis &RDA,
                  dbgs() << "   - " << *Use);
 
     SmallPtrSet<MachineInstr*, 4> Killed;
-    RDA.collectKilledOperands(MI, Killed);
-    if (WontCorruptITs(Killed, RDA)) {
+    RDI.collectKilledOperands(MI, Killed);
+    if (WontCorruptITs(Killed, RDI)) {
       ToRemove.insert_range(Killed);
       LLVM_DEBUG(for (auto *Dead : Killed)
                    dbgs() << "   - " << *Dead);
@@ -610,7 +609,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
     return false;
   }
 
-  if (!VPTstate.isValid(RDA)) {
+  if (!VPTstate.isValid(RDI)) {
     LLVM_DEBUG(dbgs() << "ARM Loops: Invalid VPT state.\n");
     return false;
   }
@@ -637,7 +636,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
     // If the register is defined within loop, then we can't perform TP.
     // TODO: Check whether this is just a mov of a register that would be
     // available.
-    if (RDA.hasLocalDefBefore(VCTP, NumElements)) {
+    if (RDI.hasLocalDefBefore(VCTP, NumElements)) {
       LLVM_DEBUG(dbgs() << "ARM Loops: VCTP operand is defined in the loop.\n");
       return false;
     }
@@ -647,15 +646,15 @@ bool LowOverheadLoop::ValidateTailPredicate() {
     // use the value.
 
     if (StartInsertPt != StartInsertBB->end() &&
-        !RDA.isReachingDefLiveOut(&*StartInsertPt, NumElements)) {
+        !RDI.isReachingDefLiveOut(&*StartInsertPt, NumElements)) {
       if (auto *ElemDef =
-              RDA.getLocalLiveOutMIDef(StartInsertBB, NumElements)) {
-        if (RDA.isSafeToMoveForwards(ElemDef, &*StartInsertPt)) {
+              RDI.getLocalLiveOutMIDef(StartInsertBB, NumElements)) {
+        if (RDI.isSafeToMoveForwards(ElemDef, &*StartInsertPt)) {
           ElemDef->removeFromParent();
           StartInsertBB->insert(StartInsertPt, ElemDef);
           LLVM_DEBUG(dbgs()
                      << "ARM Loops: Moved element count def: " << *ElemDef);
-        } else if (RDA.isSafeToMoveBackwards(&*StartInsertPt, ElemDef)) {
+        } else if (RDI.isSafeToMoveBackwards(&*StartInsertPt, ElemDef)) {
           StartInsertPt->removeFromParent();
           StartInsertBB->insertAfter(MachineBasicBlock::iterator(ElemDef),
                                      &*StartInsertPt);
@@ -666,8 +665,8 @@ bool LowOverheadLoop::ValidateTailPredicate() {
           // insertion point
           MachineOperand Operand = ElemDef->getOperand(1);
           if (isMovRegOpcode(ElemDef->getOpcode()) &&
-              RDA.getUniqueReachingMIDef(ElemDef, Operand.getReg().asMCReg()) ==
-                  RDA.getUniqueReachingMIDef(&*StartInsertPt,
+              RDI.getUniqueReachingMIDef(ElemDef, Operand.getReg().asMCReg()) ==
+                  RDI.getUniqueReachingMIDef(&*StartInsertPt,
                                              Operand.getReg().asMCReg())) {
             TPNumElements = Operand;
             NumElements = TPNumElements.getReg();
@@ -689,7 +688,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
       if (MBB->empty())
         return false;
       // NumElements is redefined in this block.
-      if (RDA.hasLocalDefBefore(&MBB->back(), NumElements))
+      if (RDI.hasLocalDefBefore(&MBB->back(), NumElements))
         return true;
 
       // Don't continue searching up through multiple predecessors.
@@ -751,7 +750,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
   // tail predicated loop. Explicitly refer to the vctp operand no matter which
   // register NumElements has been assigned to, since that is what the
   // modifications will be using
-  if (auto *Def = RDA.getUniqueReachingMIDef(
+  if (auto *Def = RDI.getUniqueReachingMIDef(
           &MBB->back(), VCTP->getOperand(1).getReg().asMCReg())) {
     SmallPtrSet<MachineInstr*, 2> ElementChain;
     SmallPtrSet<MachineInstr*, 2> Ignore;
@@ -759,7 +758,7 @@ bool LowOverheadLoop::ValidateTailPredicate() {
 
     Ignore.insert_range(VCTPs);
 
-    if (TryRemove(Def, RDA, ElementChain, Ignore)) {
+    if (TryRemove(Def, RDI, ElementChain, Ignore)) {
       bool FoundSub = false;
 
       for (auto *MI : ElementChain) {
@@ -789,11 +788,11 @@ bool LowOverheadLoop::ValidateTailPredicate() {
   if ((Start->getOpcode() == ARM::t2DoLoopStartTP ||
        Start->getOpcode() == ARM::t2WhileLoopStartTP) &&
       Preheader && !Preheader->empty() &&
-      !RDA.hasLocalDefBefore(VCTP, VCTP->getOperand(1).getReg())) {
-    if (auto *Def = RDA.getUniqueReachingMIDef(
+      !RDI.hasLocalDefBefore(VCTP, VCTP->getOperand(1).getReg())) {
+    if (auto *Def = RDI.getUniqueReachingMIDef(
             &Preheader->back(), VCTP->getOperand(1).getReg().asMCReg())) {
       SmallPtrSet<MachineInstr *, 2> Ignore(llvm::from_range, VCTPs);
-      TryRemove(Def, RDA, ToRemove, Ignore);
+      TryRemove(Def, RDI, ToRemove, Ignore);
     }
   }
 
@@ -858,7 +857,7 @@ static bool canGenerateNonZeros(const MachineInstr &MI) {
 // still be zeros.
 static bool producesFalseLanesZero(MachineInstr &MI,
                                    const TargetRegisterClass *QPRs,
-                                   const ReachingDefAnalysis &RDA,
+                                   const ReachingDefInfo &RDI,
                                    InstSet &FalseLanesZero) {
   if (canGenerateNonZeros(MI))
     return false;
@@ -891,7 +890,7 @@ static bool producesFalseLanesZero(MachineInstr &MI,
     // - If it's predicated, it only matters that it's def register already has
     //   false lane zeros, so we can ignore the uses.
     SmallPtrSet<MachineInstr *, 2> Defs;
-    RDA.getGlobalReachingDefs(&MI, MO.getReg(), Defs);
+    RDI.getGlobalReachingDefs(&MI, MO.getReg(), Defs);
     if (Defs.empty())
       return false;
     for (auto *Def : Defs) {
@@ -949,7 +948,7 @@ bool LowOverheadLoop::ValidateLiveOuts() {
 
     if (isPredicated)
       Predicated.insert(&MI);
-    if (producesFalseLanesZero(MI, QPRs, RDA, FalseLanesZero))
+    if (producesFalseLanesZero(MI, QPRs, RDI, FalseLanesZero))
       FalseLanesZero.insert(&MI);
     else if (MI.getNumDefs() == 0)
       continue;
@@ -975,7 +974,7 @@ bool LowOverheadLoop::ValidateLiveOuts() {
   auto HasPredicatedUsers = [this](MachineInstr *MI, const MachineOperand &MO,
                               SmallPtrSetImpl<MachineInstr *> &Predicated) {
     SmallPtrSet<MachineInstr *, 2> Uses;
-    RDA.getGlobalUses(MI, MO.getReg().asMCReg(), Uses);
+    RDI.getGlobalUses(MI, MO.getReg().asMCReg(), Uses);
     for (auto *Use : Uses) {
       if (Use != MI && !Predicated.count(Use))
         return false;
@@ -1022,7 +1021,7 @@ bool LowOverheadLoop::ValidateLiveOuts() {
     // Check Q-regs that are live in the exit blocks. We don't collect scalars
     // because they won't be affected by lane predication.
     if (QPRs->contains(RegMask.PhysReg))
-      if (auto *MI = RDA.getLocalLiveOutMIDef(Header, RegMask.PhysReg))
+      if (auto *MI = RDI.getLocalLiveOutMIDef(Header, RegMask.PhysReg))
         LiveOutMIs.insert(MI);
   }
 
@@ -1039,7 +1038,7 @@ bool LowOverheadLoop::ValidateLiveOuts() {
     if (MI->getOpcode() == ARM::MQPRCopy) {
       VMOVCopies.insert(MI);
       MachineInstr *CopySrc =
-          RDA.getUniqueReachingMIDef(MI, MI->getOperand(1).getReg());
+          RDI.getUniqueReachingMIDef(MI, MI->getOperand(1).getReg());
       if (CopySrc)
         Worklist.push_back(CopySrc);
     } else if (NonPredicated.count(MI) && FalseLanesUnknown.contains(MI)) {
@@ -1109,7 +1108,7 @@ bool LowOverheadLoop::AddVCTP(MachineInstr *MI) {
   // If it does, store it in the VCTPs set, else refuse it.
   MachineInstr *Prev = VCTPs.back();
   if (!Prev->getOperand(1).isIdenticalTo(MI->getOperand(1)) ||
-      !RDA.hasSameReachingDef(Prev, MI, MI->getOperand(1).getReg().asMCReg())) {
+      !RDI.hasSameReachingDef(Prev, MI, MI->getOperand(1).getReg().asMCReg())) {
     LLVM_DEBUG(dbgs() << "ARM Loops: Found VCTP with a different reaching "
                          "definition from the main VCTP");
     return false;
@@ -1290,7 +1289,7 @@ bool ARMLowOverheadLoops::runOnMachineFunction(MachineFunction &mf) {
   LLVM_DEBUG(dbgs() << "ARM Loops on " << MF->getName() << " ------------- \n");
 
   MLI = &getAnalysis<MachineLoopInfoWrapperPass>().getLI();
-  RDA = &getAnalysis<ReachingDefAnalysis>();
+  RDI = &getAnalysis<ReachingDefInfoWrapperPass>().getRDI();
   MF->getProperties().setTracksLiveness();
   MRI = &MF->getRegInfo();
   TII = ST.getInstrInfo();
@@ -1338,7 +1337,7 @@ bool ARMLowOverheadLoops::ProcessLoop(MachineLoop *ML) {
     return nullptr;
   };
 
-  LowOverheadLoop LoLoop(*ML, *MLI, *RDA, *TRI, *TII);
+  LowOverheadLoop LoLoop(*ML, *MLI, *RDI, *TRI, *TII);
   // Search the preheader for the start intrinsic.
   // FIXME: I don't see why we shouldn't be supporting multiple predecessors
   // with potentially multiple set.loop.iterations, so we need to enable this.
@@ -1390,7 +1389,7 @@ bool ARMLowOverheadLoops::ProcessLoop(MachineLoop *ML) {
   // TODO: Check for copy chains that really have no effect.
   if (LoLoop.Dec != LoLoop.End) {
     SmallPtrSet<MachineInstr *, 2> Uses;
-    RDA->getReachingLocalUses(LoLoop.Dec, MCRegister::from(ARM::LR), Uses);
+    RDI->getReachingLocalUses(LoLoop.Dec, MCRegister::from(ARM::LR), Uses);
     if (Uses.size() > 1 || !Uses.count(LoLoop.End)) {
       LLVM_DEBUG(dbgs() << "ARM Loops: Unable to remove LoopDec.\n");
       LoLoop.Revert = true;
@@ -1432,7 +1431,7 @@ bool ARMLowOverheadLoops::RevertLoopDec(MachineInstr *MI) const {
 
   // If nothing defines CPSR between LoopDec and LoopEnd, use a t2SUBS.
   bool SetFlags =
-      RDA->isSafeToDefRegAt(MI, MCRegister::from(ARM::CPSR), Ignore);
+      RDI->isSafeToDefRegAt(MI, MCRegister::from(ARM::CPSR), Ignore);
 
   llvm::RevertLoopDec(MI, TII, SetFlags);
   return SetFlags;
@@ -1508,7 +1507,7 @@ void ARMLowOverheadLoops::IterationCountDCE(LowOverheadLoop &LoLoop) {
 
   LLVM_DEBUG(dbgs() << "ARM Loops: Trying DCE on loop iteration count.\n");
 
-  MachineInstr *Def = RDA->getMIOperand(LoLoop.Start, 1);
+  MachineInstr *Def = RDI->getMIOperand(LoLoop.Start, 1);
   if (!Def) {
     LLVM_DEBUG(dbgs() << "ARM Loops: Couldn't find iteration count.\n");
     return;
@@ -1517,7 +1516,7 @@ void ARMLowOverheadLoops::IterationCountDCE(LowOverheadLoop &LoLoop) {
   // Collect and remove the users of iteration count.
   SmallPtrSet<MachineInstr*, 4> Killed  = { LoLoop.Start, LoLoop.Dec,
                                             LoLoop.End };
-  if (!TryRemove(Def, *RDA, LoLoop.ToRemove, Killed))
+  if (!TryRemove(Def, *RDI, LoLoop.ToRemove, Killed))
     LLVM_DEBUG(dbgs() << "ARM Loops: Unsafe to remove loop iteration count.\n");
 }
 
@@ -1642,7 +1641,7 @@ void ARMLowOverheadLoops::ConvertVPTBlocks(LowOverheadLoop &LoLoop) {
             LLVM_DEBUG(dbgs() << "ARM Loops: Created VPST: " << *MIB);
             LoLoop.BlockMasksToRecompute.insert(MIB.getInstr());
           } else {
-            // No RDA checks are necessary here since the VPST would have been
+            // No RDI checks are necessary here since the VPST would have been
             // directly after the VCMP
             ReplaceVCMPWithVPT(VCMP, VCMP);
           }
@@ -1669,7 +1668,7 @@ void ARMLowOverheadLoops::ConvertVPTBlocks(LowOverheadLoop &LoLoop) {
       assert(getVPTInstrPredicate(*Next) != ARMVCC::None &&
              "The instruction after a VPST must be predicated");
       (void)Next;
-      MachineInstr *VprDef = RDA->getUniqueReachingMIDef(VPST, ARM::VPR);
+      MachineInstr *VprDef = RDI->getUniqueReachingMIDef(VPST, ARM::VPR);
       if (VprDef && VCMPOpcodeToVPT(VprDef->getOpcode()) &&
           !LoLoop.ToRemove.contains(VprDef)) {
         MachineInstr *VCMP = VprDef;
@@ -1680,8 +1679,8 @@ void ARMLowOverheadLoops::ConvertVPTBlocks(LowOverheadLoop &LoLoop) {
         // VPST already.
         if (std::none_of(++MachineBasicBlock::iterator(VCMP),
                          MachineBasicBlock::iterator(VPST), hasVPRUse) &&
-            RDA->hasSameReachingDef(VCMP, VPST, VCMP->getOperand(1).getReg()) &&
-            RDA->hasSameReachingDef(VCMP, VPST, VCMP->getOperand(2).getReg())) {
+            RDI->hasSameReachingDef(VCMP, VPST, VCMP->getOperand(1).getReg()) &&
+            RDI->hasSameReachingDef(VCMP, VPST, VCMP->getOperand(2).getReg())) {
           ReplaceVCMPWithVPT(VCMP, VPST);
           LLVM_DEBUG(dbgs() << "ARM Loops: Removing VPST: " << *VPST);
           LoLoop.ToRemove.insert(VPST);
@@ -1792,8 +1791,8 @@ void ARMLowOverheadLoops::Expand(LowOverheadLoop &LoLoop) {
   for (auto *MBB : reverse(PostOrder))
     recomputeLivenessFlags(*MBB);
 
-  // We've moved, removed and inserted new instructions, so update RDA.
-  RDA->reset();
+  // We've moved, removed and inserted new instructions, so update RDI.
+  RDI->reset();
 }
 
 bool ARMLowOverheadLoops::RevertNonLoops() {

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -331,7 +331,7 @@ char ARMExecutionDomainFix::ID;
 
 INITIALIZE_PASS_BEGIN(ARMExecutionDomainFix, "arm-execution-domain-fix",
   "ARM Execution Domain Fix", false, false)
-INITIALIZE_PASS_DEPENDENCY(ReachingDefAnalysis)
+INITIALIZE_PASS_DEPENDENCY(ReachingDefInfoWrapperPass)
 INITIALIZE_PASS_END(ARMExecutionDomainFix, "arm-execution-domain-fix",
   "ARM Execution Domain Fix", false, false)
 

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -402,7 +402,7 @@ char X86ExecutionDomainFix::ID;
 
 INITIALIZE_PASS_BEGIN(X86ExecutionDomainFix, "x86-execution-domain-fix",
   "X86 Execution Domain Fix", false, false)
-INITIALIZE_PASS_DEPENDENCY(ReachingDefAnalysis)
+INITIALIZE_PASS_DEPENDENCY(ReachingDefInfoWrapperPass)
 INITIALIZE_PASS_END(X86ExecutionDomainFix, "x86-execution-domain-fix",
   "X86 Execution Domain Fix", false, false)
 

--- a/llvm/test/CodeGen/ARM/O3-pipeline.ll
+++ b/llvm/test/CodeGen/ARM/O3-pipeline.ll
@@ -162,7 +162,7 @@
 ; CHECK-NEXT:      Machine Copy Propagation Pass
 ; CHECK-NEXT:      Post-RA pseudo instruction expansion pass
 ; CHECK-NEXT:      ARM load / store optimization pass
-; CHECK-NEXT:      ReachingDefAnalysis
+; CHECK-NEXT:      Reaching Definitions Analysis
 ; CHECK-NEXT:      ARM Execution Domain Fix
 ; CHECK-NEXT:      BreakFalseDeps
 ; CHECK-NEXT:      ARM pseudo instruction expansion pass
@@ -204,14 +204,14 @@
 ; CHECK-NEXT:      Lazy Machine Block Frequency Analysis
 ; CHECK-NEXT:      Machine Optimization Remark Emitter
 ; CHECK-NEXT:      Stack Frame Layout Analysis
-; CHECK-NEXT:      ReachingDefAnalysis
+; CHECK-NEXT:      Reaching Definitions Analysis
 ; CHECK-NEXT:      ARM fix for Cortex-A57 AES Erratum 1742098
 ; CHECK-NEXT:      ARM Branch Targets
 ; CHECK-NEXT:      MachineDominator Tree Construction
 ; CHECK-NEXT:      ARM constant island placement and branch shortening pass
 ; CHECK-NEXT:      MachineDominator Tree Construction
 ; CHECK-NEXT:      Machine Natural Loop Construction
-; CHECK-NEXT:      ReachingDefAnalysis
+; CHECK-NEXT:      Reaching Definitions Analysis
 ; CHECK-NEXT:      ARM Low Overhead Loops pass
 ; CHECK-NEXT:      Lazy Machine Block Frequency Analysis
 ; CHECK-NEXT:      Machine Optimization Remark Emitter

--- a/llvm/test/CodeGen/RISCV/rda-stack.mir
+++ b/llvm/test/CodeGen/RISCV/rda-stack.mir
@@ -1,4 +1,4 @@
-# RUN: llc %s -mtriple=riscv64 -run-pass=reaching-defs-analysis -print-all-reaching-defs -o - 2>&1 | FileCheck %s
+# RUN: llc %s -mtriple=riscv64 --passes='print<reaching-def>'  -o - 2>&1 | FileCheck %s
 
 ---
 name:            test0

--- a/llvm/test/CodeGen/SystemZ/rda-stack-copy.mir
+++ b/llvm/test/CodeGen/SystemZ/rda-stack-copy.mir
@@ -1,4 +1,4 @@
-# RUN: llc %s -mtriple=s390x-linux-gnu -run-pass=reaching-defs-analysis -print-all-reaching-defs -o - 2>&1 | FileCheck %s
+# RUN: llc %s -mtriple=s390x-linux-gnu --passes='print<reaching-def>'  -o - 2>&1 | FileCheck %s
 
 ---
 name:            test0

--- a/llvm/test/CodeGen/X86/opt-pipeline.ll
+++ b/llvm/test/CodeGen/X86/opt-pipeline.ll
@@ -195,7 +195,7 @@
 ; CHECK-NEXT:       Insert fentry calls
 ; CHECK-NEXT:       Insert XRay ops
 ; CHECK-NEXT:       Implement the 'patchable-function' attribute
-; CHECK-NEXT:       ReachingDefAnalysis
+; CHECK-NEXT:       Reaching Definitions Analysis
 ; CHECK-NEXT:       X86 Execution Dependency Fix
 ; CHECK-NEXT:       BreakFalseDeps
 ; CHECK-NEXT:       X86 Indirect Branch Tracking

--- a/llvm/test/CodeGen/X86/print-reaching-defs.mir
+++ b/llvm/test/CodeGen/X86/print-reaching-defs.mir
@@ -1,4 +1,6 @@
- # RUN: llc --passes='print<reaching-def>' -filetype=null 2>&1 %s | FileCheck %s
+# RUN: llc -mtriple=x86_64-unknown-unknown \
+# RUN: --passes='print<reaching-def>' \
+# RUN: -filetype=null 2>&1 %s | FileCheck %s
 
 ---
 name:            is_odd

--- a/llvm/test/CodeGen/X86/print-reaching-defs.mir
+++ b/llvm/test/CodeGen/X86/print-reaching-defs.mir
@@ -1,0 +1,14 @@
+ # RUN: llc --passes='print<reaching-def>' -filetype=null 2>&1 %s | FileCheck %s
+
+---
+name:            is_odd
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $edi
+    $eax = MOV32rr $edi
+    $eax = AND32ri killed $eax, 1, implicit-def dead $eflags
+    RET64 $eax
+...
+# CHECK: Reaching definitions for for machine function: is_odd
+# CHECK-NEXT: RDA results for is_odd


### PR DESCRIPTION
In this commit:
  (1) Added new pass manager support for `ReachingDefAnalysis`.
  (2) Added printer pass.
  (3) Make old pass manager use `ReachingDefInfoWrapperPass`