### PR TITLE
[clang][Sema] Reject negative tuple sizes

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -1219,7 +1219,7 @@ static IsTupleLike isTupleLike(Sema &S, SourceLocation Loc, QualType T,
     return IsTupleLike::Error;
 
   E = S.VerifyIntegerConstantExpression(E.get(), &Size, Diagnoser);
-  if (E.isInvalid())
+  if (E.isInvalid() || Size.isNegative())
     return IsTupleLike::Error;
 
   return IsTupleLike::TupleLike;

--- a/clang/test/SemaCXX/builtin-structured-binding-size.cpp
+++ b/clang/test/SemaCXX/builtin-structured-binding-size.cpp
@@ -229,3 +229,12 @@ static_assert(__is_same_as(tag_of_t<S1>, int));
 static_assert(__is_same_as(tag_of_t<int>, int)); // error
 // expected-error@-1 {{constraints not satisfied for alias template 'tag_of_t' [with T = int]}}
 // expected-note@#tag-of-constr {{because substituted constraint expression is ill-formed: type 'int' cannot be decomposed}}
+
+struct Neg {
+  int a;
+};
+template <> struct std::tuple_size<Neg> {
+  static constexpr int value = -1;
+};
+
+int e = __builtin_structured_binding_size(Neg); // expected-error {{type 'Neg' cannot be decomposed}}


### PR DESCRIPTION
Negative sizes don't make sense and trip up the code using `UnsignedOrNone`.

Fixes #159563