### PR TITLE
[LLDB]Fix buffer-over-flow bug introduced in 157170

### DIFF
--- a/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
+++ b/lldb/source/Plugins/Process/elf-core/ProcessElfCore.cpp
@@ -952,7 +952,7 @@ llvm::Error ProcessElfCore::parseLinuxNotes(llvm::ArrayRef<CoreNote> notes) {
         return status.ToError();
       thread_data.name.assign (prpsinfo.pr_fname, strnlen (prpsinfo.pr_fname, sizeof (prpsinfo.pr_fname)));
       SetID(prpsinfo.pr_pid);
-      m_executable_name = prpsinfo.pr_fname;
+      m_executable_name = thread_data.name;
       break;
     }
     case ELF::NT_SIGINFO: {


### PR DESCRIPTION
If `pr_name` is longer than 16, it would be a non-null terminated string. Assigning it to `std::string m_executable_name` would cause an overflow read. Instead, just copy the name from thread_data.name.

To repro, run the `elf-core/TestLinuxCore.py` with asan
(Question: why is the new variable needed in the first place? can't the thread_data.name be used?)