### PR TITLE
[VPlan] Strip dead code in cst live-in match (NFC)

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -108,6 +108,7 @@ template <typename Pred, unsigned BitWidth = 0> struct int_pred_ty {
     Value *V = VPV->getLiveInIRValue();
     if (!V)
       return false;
+    assert(!V->getType()->isVectorTy() && "Unexpected vector live-in");
     const auto *CI = dyn_cast<ConstantInt>(V);
     if (!CI)
       return false;

--- a/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanPatternMatch.h
@@ -109,10 +109,6 @@ template <typename Pred, unsigned BitWidth = 0> struct int_pred_ty {
     if (!V)
       return false;
     const auto *CI = dyn_cast<ConstantInt>(V);
-    if (!CI && V->getType()->isVectorTy())
-      if (const auto *C = dyn_cast<Constant>(V))
-        CI = dyn_cast_or_null<ConstantInt>(
-            C->getSplatValue(/*AllowPoison=*/false));
     if (!CI)
       return false;
 


### PR DESCRIPTION
A live-in constant can never be of vector type.