### PR TITLE
Do not print locations in anonymous tag names.

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -397,6 +397,11 @@ PrintingPolicy CGDebugInfo::getPrintingPolicy() const {
 
   // Apply -fdebug-prefix-map.
   PP.Callbacks = &PrintCB;
+  // If we have lambdas as template parameters, two debug entries from different
+  // CUs will get merged in LTO, but their human-readable DW_AT_name will be
+  // different. Disable printing of location of an anonymous tag name to prevent
+  // that from happening.
+  PP.AnonymousTagLocations = false;
   return PP;
 }
 

--- a/clang/test/DebugInfo/CXX/anonymous-locs.cpp
+++ b/clang/test/DebugInfo/CXX/anonymous-locs.cpp
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -std=c++20 -emit-obj -debug-info-kind=standalone -dwarf-version=5 -triple x86_64-apple-darwin -o %t %s 
+// RUN: llvm-dwarfdump %t | FileCheck %s
+
+// CHECK: DW_TAG_structure_type
+// CHECK-NEXT: DW_AT_calling_convention	(DW_CC_pass_by_value)
+// CHECK-NEXT: DW_AT_name	("Foo<(lambda){}>")
+
+template<auto T>
+struct Foo {
+};
+
+Foo<[] {}> f;
+
+auto func() { return f; }

--- a/clang/test/DebugInfo/CXX/prefix-map-lambda.cpp
+++ b/clang/test/DebugInfo/CXX/prefix-map-lambda.cpp
@@ -3,8 +3,6 @@
 
 template <typename T> void b(T) {}
 void c() {
-  // CHECK: !DISubprogram(name: "b<(lambda at
-  // CHECK-SAME:          SOURCE_ROOT
-  // CHECK-SAME:          [[@LINE+1]]:{{[0-9]+}})>"
+  // CHECK: !DISubprogram(name: "b<(lambda)>"
   b([]{});
 }

--- a/clang/test/DebugInfo/CXX/simple-template-names.cpp
+++ b/clang/test/DebugInfo/CXX/simple-template-names.cpp
@@ -70,18 +70,18 @@ void f() {
   // anything other than another unnamed class/struct.
   auto Lambda = [] {};
   f1<decltype(Lambda)>();
-  // CHECK: !DISubprogram(name: "f1<(lambda at {{.*}}simple-template-names.cpp:[[# @LINE - 2]]:17)>",
+  // CHECK: !DISubprogram(name: "f1<(lambda)>",
   f1<t1<t1<decltype(Lambda)>>>();
-  // CHECK: !DISubprogram(name: "f1<t1<t1<(lambda at {{.*}}> > >",
+  // CHECK: !DISubprogram(name: "f1<t1<t1<(lambda)> > >",
   struct {
   } unnamed_struct;
   f1<decltype(unnamed_struct)>();
-  // CHECK: !DISubprogram(name: "f1<(unnamed struct at {{.*}}simple-template-names.cpp:[[# @LINE - 3]]:3)>",
+  // CHECK: !DISubprogram(name: "f1<(unnamed)>",
   f1<void (decltype(unnamed_struct))>();
-  // CHECK: !DISubprogram(name: "f1<void ((unnamed struct at {{.*}}simple-template-names.cpp:[[# @LINE - 5]]:3))>",
+  // CHECK: !DISubprogram(name: "f1<void ((unnamed))>",
   enum {} unnamed_enum;
   f1<decltype(unnamed_enum)>();
-  // CHECK: !DISubprogram(name: "f1<(unnamed enum at {{.*}}simple-template-names.cpp:[[# @LINE - 2]]:3)>",
+  // CHECK: !DISubprogram(name: "f1<(unnamed)>",
 
   // Declarations can't readily be reversed as the value in the DWARF only
   // contains the address of the value - we'd have to do symbol lookup to find
@@ -128,5 +128,5 @@ void f() {
   // CHECK: !DISubprogram(name: "f1<int () __attribute__((noreturn))>",
   
   f4<UnnamedEnum1>();
-  // CHECK: !DISubprogram(name: "f4<((unnamed enum at {{.*}}))0>"
+  // CHECK: !DISubprogram(name: "f4<((unnamed))0>"
 }

--- a/clang/test/DebugInfo/Generic/debug-prefix-map.cpp
+++ b/clang/test/DebugInfo/Generic/debug-prefix-map.cpp
@@ -8,4 +8,4 @@ struct alignas(64) an {
 
 struct an *pan = new an;
 
-// CHECK: !DISubprogram(name: "(unnamed struct at ./UNLIKELY_PATH/empty{{/|\\\\}}{{.*}}",
+// CHECK: !DISubprogram(name: "(unnamed)",

--- a/clang/test/DebugInfo/Generic/slash.test
+++ b/clang/test/DebugInfo/Generic/slash.test
@@ -6,5 +6,5 @@ RUN: cd %t-dir
 RUN: %clang -target x86_64-pc-win32 -emit-llvm -S -g  %t-dir/debug-info-slash.cpp -Iheader -o - | FileCheck --check-prefix=WIN %s
 RUN: %clang -target x86_64-linux-gnu -emit-llvm -S -g  %t-dir/debug-info-slash.cpp -Iheader -o - | FileCheck --check-prefix=LINUX %s
 
-WIN:   lambda at header\\Inputs\\debug-info-slash.h
-LINUX: lambda at header/Inputs/debug-info-slash.h
+WIN:   lambda
+LINUX: lambda


### PR DESCRIPTION
If we use LTO as a driver, we can see that even if we have lambdas in
template parameters, two debug entries from different CUs will get
merged in LTO, but their human-readable DW_AT_name will be different if
we emit the locations in anonymous tag names.

Therefore we would never have two dies with the same linkage name but
different human readable names. Which probably should not happen.

This change prevents that from happening.

In our example:

We can see with `AnonymousTagLocations` set to true, the dwarfdump output will be

`DW_AT_name	("Foo<(lambda at a.cpp:12:5){}>")`

But with `AnonymousTagLocations` set to false, the dwarfdump output will be

`DW_AT_name	("Foo<(lambda){}>")`
