### PR TITLE
[test][CAS] Fix unused variable warning in unittest

### DIFF
--- a/llvm/unittests/CAS/ProgramTest.cpp
+++ b/llvm/unittests/CAS/ProgramTest.cpp
@@ -26,6 +26,8 @@ extern char **environ;
 using namespace llvm;
 using namespace llvm::cas;
 
+#if LLVM_ENABLE_ONDISK_CAS
+
 extern const char *TestMainArgv0;
 static char ProgramID = 0;
 
@@ -80,8 +82,6 @@ protected:
 
   ArrayRef<StringRef> getEnviron() const { return EnvTable; }
 };
-
-#if LLVM_ENABLE_ONDISK_CAS
 
 static Error emptyConstructor(MappedFileRegionArena &) {
   return Error::success();


### PR DESCRIPTION
Fix unused variable warning blocking AIX bot.
