### PR TITLE
Fixing CI failure by removing a test

### DIFF
--- a/flang/test/Driver/lto-fatlto.f90
+++ b/flang/test/Driver/lto-fatlto.f90
@@ -2,11 +2,9 @@
 ! checks fatlto objects: that valid bitcode is included in the object file generated. 
 
 ! RUN: %flang -fc1 -triple x86_64-unknown-linux-gnu -flto -ffat-lto-objects -emit-obj %s -o %t.o
-! RUN: llvm-readelf -S %t.o | FileCheck %s --check-prefixes=ELF
 ! RUN: llvm-objcopy --dump-section=.llvm.lto=%t.bc %t.o
 ! RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefixes=DIS
 
-! ELF: .llvm.lto
 ! DIS: define void @_QQmain()
 ! DIS-NEXT:  ret void
 ! DIS-NEXT: }


### PR DESCRIPTION
CI failure happened as it could not find `llvm-readelf`. Removing the test now, as the other tests inturn verify that there is an llvm.lto section by copying it to a bc and checking its contents.