### PR TITLE
[clang] Only set non-empty bypass to scan VFS

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -445,13 +445,14 @@ public:
 
     // Use the dependency scanning optimized file system if requested to do so.
     if (DepFS) {
-      SmallString<256> ModulesCachePath;
-      normalizeModuleCachePath(
-          *FileMgr, ScanInstance.getHeaderSearchOpts().ModuleCachePath,
-          ModulesCachePath);
       DepFS->resetBypassedPathPrefix();
-      if (!ModulesCachePath.empty())
+      if (!ScanInstance.getHeaderSearchOpts().ModuleCachePath.empty()) {
+        SmallString<256> ModulesCachePath;
+        normalizeModuleCachePath(
+            *FileMgr, ScanInstance.getHeaderSearchOpts().ModuleCachePath,
+            ModulesCachePath);
         DepFS->setBypassedPathPrefix(ModulesCachePath);
+      }
 
       ScanInstance.setDependencyDirectivesGetter(
           std::make_unique<ScanningDependencyDirectivesGetter>(*FileMgr));


### PR DESCRIPTION
Normalizing an empty modules cache path results in an incorrect non-empty path (the working directory). This PR conditionalizes more code to avoid this. Tested downstream by swift/llvm-project and the `DependencyScanningCAPITests.DependencyScanningFSCacheOutOfDate` unit test.