### PR TITLE
[lldb] Don't call FixDataAddress when reading fp in ReadGPRValue

### DIFF
--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -2228,9 +2228,6 @@ bool RegisterContextUnwind::ReadGPRValue(lldb::RegisterKind register_kind,
         if (generic_regnum == LLDB_REGNUM_GENERIC_PC ||
             generic_regnum == LLDB_REGNUM_GENERIC_RA)
           value = abi_sp->FixCodeAddress(value);
-        if (generic_regnum == LLDB_REGNUM_GENERIC_SP ||
-            generic_regnum == LLDB_REGNUM_GENERIC_FP)
-          value = abi_sp->FixDataAddress(value);
       }
       return true;
     }


### PR DESCRIPTION
Based on testing on processors that use pointer metadata, and with all the work done to delay calls to FixDataAddress, this is no longer necessary.

Note that, with debugserver in particular, this is an NFC change: the code path here is for frame zero, and debugserver will strip metadata when reading fp from frame zero anyway.