### PR TITLE
[flang]enable llvm-readelf

### DIFF
--- a/flang/test/CMakeLists.txt
+++ b/flang/test/CMakeLists.txt
@@ -73,8 +73,10 @@ if (NOT FLANG_STANDALONE_BUILD)
     count
     not
     llvm-dis
+    llvm-objcopy
     llvm-objdump
     llvm-profdata
+    llvm-readelf
     llvm-readobj
     split-file
   )


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/158125 resulted in CI failure as `llvm-readelf` and `llvm-objcopy` were not listed in flang test deps. This PR fixes it.