### PR TITLE
[RISCV] Ignore debug instructions in RISCVVLOptimizer

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
+++ b/llvm/lib/Target/RISCV/RISCVVLOptimizer.cpp
@@ -1665,7 +1665,8 @@ bool RISCVVLOptimizer::runOnMachineFunction(MachineFunction &MF) {
   for (MachineBasicBlock *MBB : post_order(&MF)) {
     assert(MDT->isReachableFromEntry(MBB));
     for (MachineInstr &MI : reverse(*MBB))
-      Worklist.insert(&MI);
+      if (!MI.isDebugInstr())
+        Worklist.insert(&MI);
   }
 
   while (!Worklist.empty()) {

--- a/llvm/test/CodeGen/RISCV/rvv/vl-opt.mir
+++ b/llvm/test/CodeGen/RISCV/rvv/vl-opt.mir
@@ -770,3 +770,11 @@ body: |
   bb.2:
     PseudoVSE8_V_M1 %inc, $noreg, %avl2, 3 /* e8 */
 ...
+---
+name: dbg_value
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: dbg_value
+    ; CHECK: DBG_VALUE %0:vr
+    DBG_VALUE %0:vr
+...


### PR DESCRIPTION
Don't put them onto the worklist, since they'll crash when we try to check their opcode.

Fixes #159422
