### PR TITLE
[libc][bazel] Add Bazel rules for rand/srand functions.

### DIFF
--- a/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/BUILD.bazel
@@ -279,6 +279,14 @@ libc_support_library(
 )
 
 libc_support_library(
+    name = "hdr_stdlib_macros",
+    hdrs = ["hdr/stdlib_macros.h"],
+    deps = [
+        ":hdr_stdlib_overlay",
+    ],
+)
+
+libc_support_library(
     name = "hdr_stdlib_overlay",
     hdrs = ["hdr/stdlib_overlay.h"],
 )
@@ -5063,6 +5071,41 @@ libc_function(
         ":__support_common",
         ":qsort_util",
         ":types_size_t",
+    ],
+)
+
+libc_support_library(
+    name = "rand_util",
+    srcs = ["src/stdlib/rand_util.cpp"],
+    hdrs = ["src/stdlib/rand_util.h"],
+    deps = [
+        ":__support_cpp_atomic",
+        ":__support_macros_attributes",
+        ":__support_macros_config",
+    ],
+)
+
+libc_function(
+    name = "rand",
+    srcs = ["src/stdlib/rand.cpp"],
+    hdrs = ["src/stdlib/rand.h"],
+    deps = [
+        ":__support_common",
+        ":__support_macros_config",
+        ":__support_threads_sleep",
+        ":hdr_stdlib_macros",
+        ":rand_util",
+    ],
+)
+
+libc_function(
+    name = "srand",
+    srcs = ["src/stdlib/srand.cpp"],
+    hdrs = ["src/stdlib/srand.h"],
+    deps = [
+        ":__support_common",
+        ":__support_macros_config",
+        ":rand_util",
     ],
 )
 

--- a/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/libc/test/src/stdlib/BUILD.bazel
@@ -159,6 +159,15 @@ libc_test(
     ],
 )
 
+libc_test(
+    name = "rand_test",
+    srcs = ["rand_test.cpp"],
+    deps = [
+        "//libc:rand",
+        "//libc:srand",
+    ],
+)
+
 libc_test_library(
     name = "strfrom_test_helper",
     hdrs = ["StrfromTest.h"],


### PR DESCRIPTION
These functions are unlikely to be used in the overlay mode (since they are stateful), but internal llvm-libc implementation is used in tests for FMA family of functions, so we need Bazel support for them to ensure proper test coverage.