### PR TITLE
[clang][Dependency Scanning] Canonicalize Defines of a Compiler Invocation As Early As Possible

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -392,7 +392,8 @@ public:
                      std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                      DiagnosticConsumer *DiagConsumer) {
     // Making sure that we canonicalize the defines before we create the deep
-    // copy.
+    // copy to avoid unnecessary variants in the scanner and in the resulting
+    // explicit command lines.
     if (any(Service.getOptimizeArgs() & ScanningOptimizations::Macros))
       canonicalizeDefines(Invocation->getPreprocessorOpts());
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -391,10 +391,13 @@ public:
                      IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
                      std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                      DiagnosticConsumer *DiagConsumer) {
+    // Making sure that we canonicalize the defines before we create the deep
+    // copy.
+    if (any(Service.getOptimizeArgs() & ScanningOptimizations::Macros))
+      canonicalizeDefines(Invocation->getPreprocessorOpts());
+
     // Make a deep copy of the original Clang invocation.
     CompilerInvocation OriginalInvocation(*Invocation);
-    if (any(Service.getOptimizeArgs() & ScanningOptimizations::Macros))
-      canonicalizeDefines(OriginalInvocation.getPreprocessorOpts());
 
     if (Scanned) {
       // Scanning runs once for the first -cc1 invocation in a chain of driver

--- a/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
+++ b/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
@@ -8,6 +8,9 @@
 // RUN:   -j 1 -format experimental-full -optimize-args=canonicalize-macros > %t/deps.db
 // RUN: cat %t/deps.db | FileCheck %s -DPREFIX=%/t
 
+// This tests that we have two scanning module variants.
+// RUN: find %t/module-cache -name "*.pcm" | wc -l | grep 2
+
 // Verify that there are only two variants and that the expected merges have
 // happened.
 


### PR DESCRIPTION
Before this patch, we only perform `-D` canonicalization on the deep copy of the `CompilerInvocation` instance, since the canonicalization should have no impact on scanning. 

However, in the presence of CAS, the content of the `builtin` macros are included in the context hash. This patch makes sure that we canonicalize the scanning `CompilerInvocation`'s `-D`s.

Part of work for rdar://136303612. 