### PR TITLE
Revert "[IR] Simplify HasCachedHash with is_detected (NFC) (#159510)"

### DIFF
--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -986,10 +986,15 @@ static T *uniquifyImpl(T *N, DenseSet<T *, InfoT> &Store) {
 }
 
 template <class NodeTy> struct MDNode::HasCachedHash {
-  template <class U>
-  using check = decltype(static_cast<void (U::*)(unsigned)>(&U::setHash));
+  using Yes = char[1];
+  using No = char[2];
+  template <class U, U Val> struct SFINAE {};
 
-  static constexpr bool value = is_detected<check, NodeTy>::value;
+  template <class U>
+  static Yes &check(SFINAE<void (U::*)(unsigned), &U::setHash> *);
+  template <class U> static No &check(...);
+
+  static const bool value = sizeof(check<NodeTy>(nullptr)) == sizeof(Yes);
 };
 
 MDNode *MDNode::uniquify() {


### PR DESCRIPTION
This reverts commit d6b7ac830ab4c1b26a1b2eecd15306eccf9cea90. Build breakages reported on the PR hint at not working with certain versions of the host compiler.