### PR TITLE
[Offload] Change ELF machine type for SPIR-V OpenMP image

### DIFF
--- a/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
+++ b/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
@@ -11,7 +11,7 @@
 // RUN: llvm-readelf -t %t.elf | FileCheck -check-prefix=CHECK-SECTION %s
 // RUN: llvm-readelf -n %t.elf | FileCheck -check-prefix=CHECK-NOTES %s
 
-// CHECK-MACHINE: Machine: 8086
+// CHECK-MACHINE: Machine: Intel Graphics Technology
 
 // CHECK-SECTION: .note.inteloneompoffload
 // CHECK-SECTION: __openmp_offload_spirv_0

--- a/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
+++ b/clang/test/Tooling/clang-linker-wrapper-spirv-elf.cpp
@@ -7,8 +7,11 @@
 // RUN: %clangxx -fopenmp -fopenmp-targets=spirv64-intel -nogpulib -c -o %t_clang-linker-wrapper-spirv-elf.o %s
 // RUN: not clang-linker-wrapper -o a.out %t_clang-linker-wrapper-spirv-elf.o --save-temps --linker-path=ld
 // RUN: clang-offload-packager --image=triple=spirv64-intel,kind=openmp,file=%t.elf  %t_tmp/a.out.openmp.image.wrapper.o
+// RUN: llvm-readelf -h %t.elf | FileCheck -check-prefix=CHECK-MACHINE %s
 // RUN: llvm-readelf -t %t.elf | FileCheck -check-prefix=CHECK-SECTION %s
 // RUN: llvm-readelf -n %t.elf | FileCheck -check-prefix=CHECK-NOTES %s
+
+// CHECK-MACHINE: Machine: 8086
 
 // CHECK-SECTION: .note.inteloneompoffload
 // CHECK-SECTION: __openmp_offload_spirv_0

--- a/llvm/lib/Frontend/Offloading/Utility.cpp
+++ b/llvm/lib/Frontend/Offloading/Utility.cpp
@@ -423,10 +423,7 @@ Error offloading::intel::containerizeOpenMPSPIRVImage(
   Header.Class = ELF::ELFCLASS64;
   Header.Data = ELF::ELFDATA2LSB;
   Header.Type = ELF::ET_DYN;
-  // Use a fake machine type as there is not one specifically for
-  // Intel GPUs, the associated runtime plugin is looking for
-  // this value.
-  Header.Machine = 0x8086;
+  Header.Machine = ELF::EM_INTELGT;
 
   // Create a section with notes.
   ELFYAML::NoteSection Section{};

--- a/llvm/lib/Frontend/Offloading/Utility.cpp
+++ b/llvm/lib/Frontend/Offloading/Utility.cpp
@@ -423,9 +423,10 @@ Error offloading::intel::containerizeOpenMPSPIRVImage(
   Header.Class = ELF::ELFCLASS64;
   Header.Data = ELF::ELFDATA2LSB;
   Header.Type = ELF::ET_DYN;
-  // Use an existing Intel machine type as there is not one specifically for
-  // Intel GPUs.
-  Header.Machine = ELF::EM_IA_64;
+  // Use a fake machine type as there is not one specifically for
+  // Intel GPUs, the associated runtime plugin is looking for
+  // this value.
+  Header.Machine = 0x8086;
 
   // Create a section with notes.
   ELFYAML::NoteSection Section{};


### PR DESCRIPTION
This needs to match the runtime plugin (currently in PR [here](https://github.com/llvm/llvm-project/pull/158900)), and use the recently-added `INTELGT` machine type which is correct for Intel GPU images.