### PR TITLE
[Flang] Fix handling of unlimited polymorphic arrays

### DIFF
--- a/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
@@ -126,9 +126,9 @@ public:
                // assignment is the copy of the contents, because the dynamic
                // types of the LHS and the RHS must match already. We use the
                // runtime in this case so that the polymorphic (including
-               // unlimited) content is copied properly.
-               (lhs.isPolymorphic() && assignOp.isTemporaryLHS()) ||
-               lhs.isPolymorphic() || rhs.isPolymorphic()) {
+               // unlimited) content is copied properly. This is also needed
+               // for unlimited polymorphic arrays in WHERE statements.
+               (lhs.isPolymorphic())) {
       // Use the runtime for simplicity. An optimization pass will be added to
       // inline array assignment when profitable.
       mlir::Value from = emboxRHS(rhsExv);

--- a/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
+++ b/flang/lib/Optimizer/HLFIR/Transforms/ConvertToFIR.cpp
@@ -127,7 +127,8 @@ public:
                // types of the LHS and the RHS must match already. We use the
                // runtime in this case so that the polymorphic (including
                // unlimited) content is copied properly.
-               (lhs.isPolymorphic() && assignOp.isTemporaryLHS())) {
+               (lhs.isPolymorphic() && assignOp.isTemporaryLHS()) ||
+               lhs.isPolymorphic() || rhs.isPolymorphic()) {
       // Use the runtime for simplicity. An optimization pass will be added to
       // inline array assignment when profitable.
       mlir::Value from = emboxRHS(rhsExv);

--- a/flang/test/HLFIR/unlimited-polymorphic-where-construct.f90
+++ b/flang/test/HLFIR/unlimited-polymorphic-where-construct.f90
@@ -1,0 +1,25 @@
+! RUN: flang -fc1 -emit-hlfir %s -o - | FileCheck %s
+
+module m1
+  type x
+  end type x
+  logical,parameter::t=.true.,f=.false.
+  logical::mask(3)=[t,f,t]
+end module m1
+
+subroutine s1
+  use m1
+  class(*),allocatable::v(:),u(:)
+  allocate(x::v(3))
+  allocate(x::u(3))
+  where(mask)
+     u=v
+  end where
+! CHECK: hlfir.region_assign
+! CHECK: !fir.ref<!fir.class<!fir.heap<!fir.array<?xnone>>>>
+end subroutine s1
+
+program main
+  call s1
+  print *,'pass'
+end program main


### PR DESCRIPTION
Make sure that unlimited polymorphic arrays in WHERE constructs are processed through the runtime assignment path.

Fixes #133669