### PR TITLE
[SFrames] reland Emit and relax FREs #158154

### DIFF
--- a/llvm/include/llvm/BinaryFormat/SFrame.h
+++ b/llvm/include/llvm/BinaryFormat/SFrame.h
@@ -117,6 +117,7 @@ template <endianness E> struct FDEInfo {
     Info = ((PAuthKey & 1) << 5) | ((static_cast<uint8_t>(FDE) & 1) << 4) |
            (static_cast<uint8_t>(FRE) & 0xf);
   }
+  uint8_t getFuncInfo() const { return Info; }
 };
 
 template <endianness E> struct FuncDescEntry {
@@ -155,6 +156,7 @@ template <endianness E> struct FREInfo {
     Info = ((RA & 1) << 7) | ((static_cast<uint8_t>(Sz) & 3) << 5) |
            ((N & 0xf) << 1) | (static_cast<uint8_t>(Reg) & 1);
   }
+  uint8_t getFREInfo() const { return Info; }
 };
 
 template <typename T, endianness E> struct FrameRowEntry {

--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -168,6 +168,7 @@ public:
   virtual bool relaxAlign(MCFragment &F, unsigned &Size) { return false; }
   virtual bool relaxDwarfLineAddr(MCFragment &) const { return false; }
   virtual bool relaxDwarfCFA(MCFragment &) const { return false; }
+  virtual bool relaxSFrameCFA(MCFragment &) const { return false; }
 
   // Defined by linker relaxation targets to possibly emit LEB128 relocations
   // and set Value at the relocated location.

--- a/llvm/include/llvm/MC/MCAssembler.h
+++ b/llvm/include/llvm/MC/MCAssembler.h
@@ -117,6 +117,7 @@ private:
   void relaxBoundaryAlign(MCBoundaryAlignFragment &BF);
   void relaxDwarfLineAddr(MCFragment &F);
   void relaxDwarfCallFrameFragment(MCFragment &F);
+  void relaxSFrameFragment(MCFragment &DF);
 
 public:
   /// Construct a new assembler instance.

--- a/llvm/include/llvm/MC/MCObjectStreamer.h
+++ b/llvm/include/llvm/MC/MCObjectStreamer.h
@@ -150,6 +150,9 @@ public:
                              MCSymbol *EndLabel = nullptr) override;
   void emitDwarfAdvanceFrameAddr(const MCSymbol *LastLabel,
                                  const MCSymbol *Label, SMLoc Loc);
+  void emitSFrameCalculateFuncOffset(const MCSymbol *FunCabsel,
+                                     const MCSymbol *FREBegin,
+                                     MCFragment *FDEFrag, SMLoc Loc);
   void emitCVLocDirective(unsigned FunctionId, unsigned FileNo, unsigned Line,
                           unsigned Column, bool PrologueEnd, bool IsStmt,
                           StringRef FileName, SMLoc Loc) override;

--- a/llvm/include/llvm/MC/MCSFrame.h
+++ b/llvm/include/llvm/MC/MCSFrame.h
@@ -16,9 +16,14 @@
 #ifndef LLVM_MC_MCSFRAME_H
 #define LLVM_MC_MCSFRAME_H
 
+#include "llvm/ADT/SmallVector.h"
+#include <cstdint>
+
 namespace llvm {
 
+class MCContext;
 class MCObjectStreamer;
+class MCFragment;
 
 class MCSFrameEmitter {
 public:
@@ -26,6 +31,15 @@ public:
   //
   // \param Streamer - Emit into this stream.
   static void emit(MCObjectStreamer &Streamer);
+
+  // Encode the FRE's function offset.
+  //
+  // \param C - Context.
+  // \param Offset - Offset to encode.
+  // \param Out - Destination of the encoding.
+  // \param FDEFrag - Frag that specifies the encoding format.
+  static void encodeFuncOffset(MCContext &C, uint64_t Offset,
+                               SmallVectorImpl<char> &Out, MCFragment *FDEFrag);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/MC/MCSection.h
+++ b/llvm/include/llvm/MC/MCSection.h
@@ -59,6 +59,7 @@ public:
     FT_Org,
     FT_Dwarf,
     FT_DwarfFrame,
+    FT_SFrame,
     FT_BoundaryAlign,
     FT_SymbolId,
     FT_CVInlineLines,
@@ -143,6 +144,12 @@ private:
       // .loc dwarf directives.
       int64_t LineDelta;
     } dwarf;
+    struct {
+      // This FRE describes unwind info at AddrDelta from function start.
+      const MCExpr *AddrDelta;
+      // Fragment that records how many bytes of AddrDelta to emit.
+      MCFragment *FDEFragment;
+    } sframe;
   } u{};
 
 public:
@@ -295,6 +302,24 @@ public:
   void setDwarfLineDelta(int64_t LineDelta) {
     assert(Kind == FT_Dwarf);
     u.dwarf.LineDelta = LineDelta;
+  }
+
+  //== FT_SFrame functions
+  const MCExpr &getSFrameAddrDelta() const {
+    assert(Kind == FT_SFrame);
+    return *u.sframe.AddrDelta;
+  }
+  void setSFrameAddrDelta(const MCExpr *E) {
+    assert(Kind == FT_SFrame);
+    u.sframe.AddrDelta = E;
+  }
+  MCFragment *getSFrameFDE() const {
+    assert(Kind == FT_SFrame);
+    return u.sframe.FDEFragment;
+  }
+  void setSFrameFDE(MCFragment *F) {
+    assert(Kind == FT_SFrame);
+    u.sframe.FDEFragment = F;
   }
 };
 

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -22,6 +22,7 @@
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCInst.h"
 #include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCSFrame.h"
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/MC/MCValue.h"
@@ -199,6 +200,7 @@ uint64_t MCAssembler::computeFragmentSize(const MCFragment &F) const {
   case MCFragment::FT_LEB:
   case MCFragment::FT_Dwarf:
   case MCFragment::FT_DwarfFrame:
+  case MCFragment::FT_SFrame:
   case MCFragment::FT_CVInlineLines:
   case MCFragment::FT_CVDefRange:
     return F.getSize();
@@ -399,6 +401,7 @@ static void writeFragment(raw_ostream &OS, const MCAssembler &Asm,
   case MCFragment::FT_LEB:
   case MCFragment::FT_Dwarf:
   case MCFragment::FT_DwarfFrame:
+  case MCFragment::FT_SFrame:
   case MCFragment::FT_CVInlineLines:
   case MCFragment::FT_CVDefRange: {
     if (F.getKind() == MCFragment::FT_Data)
@@ -914,6 +917,24 @@ void MCAssembler::relaxDwarfCallFrameFragment(MCFragment &F) {
   F.clearVarFixups();
 }
 
+void MCAssembler::relaxSFrameFragment(MCFragment &F) {
+  assert(F.getKind() == MCFragment::FT_SFrame);
+  MCContext &C = getContext();
+  int64_t Value;
+  bool Abs = F.getSFrameAddrDelta().evaluateAsAbsolute(Value, *this);
+  if (!Abs) {
+    C.reportError(F.getSFrameAddrDelta().getLoc(),
+                  "invalid CFI advance_loc expression in sframe");
+    F.setSFrameAddrDelta(MCConstantExpr::create(0, C));
+    return;
+  }
+
+  SmallVector<char, 4> Data;
+  MCSFrameEmitter::encodeFuncOffset(Context, Value, Data, F.getSFrameFDE());
+  F.setVarContents(Data);
+  F.clearVarFixups();
+}
+
 bool MCAssembler::relaxFragment(MCFragment &F) {
   auto Size = computeFragmentSize(F);
   switch (F.getKind()) {
@@ -931,6 +952,9 @@ bool MCAssembler::relaxFragment(MCFragment &F) {
     break;
   case MCFragment::FT_DwarfFrame:
     relaxDwarfCallFrameFragment(F);
+    break;
+  case MCFragment::FT_SFrame:
+    relaxSFrameFragment(F);
     break;
   case MCFragment::FT_BoundaryAlign:
     relaxBoundaryAlign(static_cast<MCBoundaryAlignFragment &>(F));

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -53,6 +53,7 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
   case MCFragment::FT_Org:           OS << "Org"; break;
   case MCFragment::FT_Dwarf:         OS << "Dwarf"; break;
   case MCFragment::FT_DwarfFrame:    OS << "DwarfCallFrame"; break;
+  case MCFragment::FT_SFrame:        OS << "SFrame"; break;
   case MCFragment::FT_LEB:           OS << "LEB"; break;
   case MCFragment::FT_BoundaryAlign: OS<<"BoundaryAlign"; break;
   case MCFragment::FT_SymbolId:      OS << "SymbolId"; break;
@@ -79,7 +80,8 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
   case MCFragment::FT_Align:
   case MCFragment::FT_LEB:
   case MCFragment::FT_Dwarf:
-  case MCFragment::FT_DwarfFrame: {
+  case MCFragment::FT_DwarfFrame:
+  case MCFragment::FT_SFrame: {
     if (isLinkerRelaxable())
       OS << " LinkerRelaxable";
     auto Fixed = getContents();
@@ -129,6 +131,7 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
       OS << " LineDelta:" << getDwarfLineDelta();
       break;
     case MCFragment::FT_DwarfFrame:
+    case MCFragment::FT_SFrame:
       OS << " AddrDelta:";
       getDwarfAddrDelta().print(OS, nullptr);
       break;

--- a/llvm/lib/MC/MCObjectStreamer.cpp
+++ b/llvm/lib/MC/MCObjectStreamer.cpp
@@ -583,6 +583,19 @@ void MCObjectStreamer::emitDwarfAdvanceFrameAddr(const MCSymbol *LastLabel,
   newFragment();
 }
 
+void MCObjectStreamer::emitSFrameCalculateFuncOffset(const MCSymbol *FuncBase,
+                                                     const MCSymbol *FREBegin,
+                                                     MCFragment *FDEFrag,
+                                                     SMLoc Loc) {
+  assert(FuncBase && "No function base address");
+  assert(FREBegin && "FRE doesn't describe a location");
+  auto *F = getCurrentFragment();
+  F->Kind = MCFragment::FT_SFrame;
+  F->setSFrameAddrDelta(buildSymbolDiff(*this, FREBegin, FuncBase, Loc));
+  F->setSFrameFDE(FDEFrag);
+  newFragment();
+}
+
 void MCObjectStreamer::emitCVLocDirective(unsigned FunctionId, unsigned FileNo,
                                           unsigned Line, unsigned Column,
                                           bool PrologueEnd, bool IsStmt,

--- a/llvm/test/MC/ELF/cfi-sframe-encoding.s
+++ b/llvm/test/MC/ELF/cfi-sframe-encoding.s
@@ -1,0 +1,85 @@
+# RUN: llvm-mc --filetype=obj --gsframe -triple x86_64 %s -o %t.o
+# RUN: llvm-readelf --sframe %t.o | FileCheck %s
+
+# Tests selection for the proper FDE AddrX encoding at the boundaries
+# between uint8_t, uint16_t, and uint32_t. The first FRE always fits
+# anywhere, because its address-offset is zero. The last FRE
+# determines the smallest AddrX it is possible to use.  Align
+# functions to 1024 to make it easier to interpet offsets.
+
+	.cfi_sections .sframe
+
+        .align 1024
+fde0_uses_addr1:
+# CHECK:        FuncDescEntry [0] {
+# CHECK:          Start FRE Offset: 0x0
+# CHECK-NEXT:          Num FREs: 2
+# CHECK:            FRE Type: Addr1 (0x0)
+	.cfi_startproc
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x0
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 8
+# CHECK-NEXT:          RA Offset: -8
+# CHECK-NEXT:        }
+        .fill 0xFF
+	.cfi_def_cfa_offset 16
+# CHECK-NEXT:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0xFF
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 16
+# CHECK-NEXT:          RA Offset: -8
+  	nop
+        .cfi_endproc
+
+        .align 1024	
+fde1_uses_addr2:
+# CHECK:        FuncDescEntry [1] {
+# CHECK:          Start FRE Offset: 0x6
+# CHECK-NEXT:          Num FREs: 2
+# CHECK:            FRE Type: Addr2 (0x1)
+	.cfi_startproc
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x400
+        .fill 0xFF + 1
+	.cfi_def_cfa_offset 16
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x500
+        .cfi_endproc
+
+.align 1024	
+fde2_uses_addr2:
+# CHECK:        FuncDescEntry [2] {
+# CHECK:          Start FRE Offset: 0xE
+# CHECK-NEXT:          Num FREs: 2
+# CHECK:            FRE Type: Addr2 (0x1)
+	.cfi_startproc
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x800
+        .fill 0xFFFF
+	.cfi_def_cfa_offset 16
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x107FF
+	nop
+        .cfi_endproc
+
+        .align 1024
+fde3_uses_addr4:
+# CHECK:        FuncDescEntry [3] {
+# CHECK:          Start FRE Offset: 0x16
+# CHECK-NEXT:          Num FREs: 2
+# CHECK:            FRE Type: Addr4 (0x2)
+	.cfi_startproc
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x10800
+        .fill 0xFFFF + 1
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x20800
+	.cfi_def_cfa_offset 16
+	nop
+        .cfi_endproc
+

--- a/llvm/test/MC/ELF/cfi-sframe-fre-cases.s
+++ b/llvm/test/MC/ELF/cfi-sframe-fre-cases.s
@@ -1,0 +1,113 @@
+# RUN: llvm-mc --filetype=obj --gsframe -triple x86_64 %s -o %t.o
+# RUN: llvm-readelf --sframe %t.o | FileCheck %s
+
+# Tests selection for the proper FRE::BX encoding at the boundaries
+# between int8_t, int16_t, and int32_t.  Ensures the largest offset
+# between CFA, RA, and FP governs. Align functions to 1024 to make it
+# easier to interpet offsets. Some directives require alignment, so
+# it isn't always possible to test exact boundaries.
+
+# Also, check that irrelevant cfi directives don't create new fres,
+# or affect the current ones. Checking the Start Address ensures that
+# the proper FRE gets the proper checks. Using .long makes addresses
+# architecture independent.
+
+        .align 1024
+fde4_fre_offset_sizes:
+# CHECK:        FuncDescEntry [0] {
+# CHECK:          Start FRE Offset: 0
+# CHECK:            FRE Type: Addr1 (0x0)
+	.cfi_startproc
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x0
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 8
+# CHECK-NEXT:          RA Offset: -8
+        .long 0
+# Uninteresting register no new fre, no effect on cfa
+	.cfi_offset 0, 8
+        .long 0
+	.cfi_def_cfa_offset 0x78
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x8
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 120
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+# Uninteresting register no new fre, no effect on cfa
+        .cfi_rel_offset 1, 8
+        .long 0 
+	.cfi_def_cfa_offset 0x80 
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x10
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B2 (0x1)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 128
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+# Uninteresting register no new fre, no effect on cfa
+        .cfi_val_offset 1, 8
+        .long 0
+	.cfi_def_cfa_offset 0x7FFF
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x18
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B2 (0x1)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 32767
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+	.cfi_def_cfa_offset 0x8000
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x1C
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B4 (0x2)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 32768
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+	.cfi_def_cfa_offset 0x8
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x20
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 8
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+	.cfi_adjust_cfa_offset 0x8
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x24
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: SP (0x1)
+# CHECK-NEXT:          CFA Offset: 16
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+	.cfi_def_cfa_register  6  # switch to fp
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x28
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B1 (0x0)
+# CHECK-NEXT:          Base Register: FP (0x0)
+# CHECK-NEXT:          CFA Offset: 16
+# CHECK-NEXT:          RA Offset: -8
+	.long 0
+	.cfi_offset 7, 32
+	# sp not the cfa but with large offset still changes encoding.
+	.cfi_offset 6, 0x7FF8
+# CHECK:        Frame Row Entry {
+# CHECK-NEXT:          Start Address: 0x2C
+# CHECK-NEXT:          Return Address Signed: No
+# CHECK-NEXT:          Offset Size: B2 (0x1)
+# CHECK-NEXT:          Base Register: FP (0x0)
+# CHECK-NEXT:          CFA Offset: 16
+# CHECK-NEXT:          RA Offset: -8
+# CHECK-NEXT:          FP Offset: 32760
+	.long 0
+        .cfi_endproc

--- a/llvm/test/MC/ELF/cfi-sframe.s
+++ b/llvm/test/MC/ELF/cfi-sframe.s
@@ -1,82 +1,85 @@
-// TODO: Add other architectures as they gain sframe support
-// REQUIRES: x86-registered-target
-// RUN: llvm-mc --assemble --filetype=obj --gsframe -triple x86_64 %s -o %t.o
-// RUN: llvm-readelf --sframe %t.o | FileCheck %s
+# RUN: llvm-mc --filetype=obj --gsframe -triple x86_64 %s -o %t.o
+# RUN: llvm-readelf --sframe %t.o | FileCheck %s
 
 	.cfi_sections .sframe
-f1:
-	.cfi_startproc  // FRE 0
+f0:
+	.cfi_startproc  # FRE 0
 	nop
-	.cfi_def_cfa_offset 16  // FRE 1
-	.cfi_def_cfa_offset 8   // location didn't change. No new FRE, but new offset.
+	.cfi_def_cfa_offset 16  # FRE 1 
+	.cfi_def_cfa_offset 8   # location didn't change. No new FRE, but new offset.
 	nop
-	.cfi_def_cfa_offset 8   // offset didn't change. No new FRE.
+	.cfi_def_cfa_offset 8   # offset didn't change. No new FRE.
 	nop
-	.cfi_def_cfa_offset 16  // FRE 2. new location, new offset.
+	.cfi_def_cfa_offset 16  # FRE 2. new location, new offset.
 	nop
-	.cfi_register 0, 1      // Uninteresting register. No new FRE.
+	.cfi_register 0, 1      # Uninteresting register. No new FRE.
 	nop
 
         .cfi_endproc
 
-f2:
+f1:
 	.cfi_startproc
 	nop
 	nop
         .cfi_endproc
 
-// CHECK: SFrame section '.sframe' {
-// CHECK-NEXT:  Header {
-// CHECK-NEXT:    Magic: 0xDEE2
-// CHECK-NEXT:    Version: V2 (0x2)
-// CHECK-NEXT:    Flags [ (0x4)
-// CHECK:    ABI: AMD64EndianLittle (0x3)
-// CHECK-NEXT:    CFA fixed FP offset (unused): 0
-// CHECK-NEXT:    CFA fixed RA offset: 0
-// CHECK-NEXT:    Auxiliary header length: 0
-// CHECK-NEXT:    Num FDEs: 2
-// CHECK-NEXT:    Num FREs: 0
-// CHECK-NEXT:    FRE subsection length: 0
-// CHECK-NEXT:    FDE subsection offset: 0
-// CHECK-NEXT:    FRE subsection offset: 40
-// CHECK:    Function Index [
-// CHECK-NEXT:        FuncDescEntry [0] {
-// CHECK-NEXT:          PC {
-// CHECK-NEXT:            Relocation: {{.*}}PC32{{.*}}
-// CHECK-NEXT:            Symbol Name: .text
-// CHECK-NEXT:            Start Address: {{.*}}
-// CHECK-NEXT:          }
-// CHECK-NEXT:          Size: 0x5
-// CHECK-NEXT:          Start FRE Offset: 0x0
-// CHECK-NEXT:          Num FREs: 0
-// CHECK-NEXT:          Info {
-// CHECK-NEXT:            FRE Type: Addr1 (0x0)
-// CHECK-NEXT:            FDE Type: PCInc (0x0)
-// CHECK-NEXT:            Raw: 0x0
-// CHECK-NEXT:          }
-// CHECK-NEXT:          Repetitive block size (unused): 0x0
-// CHECK-NEXT:          Padding2: 0x0
-// CHECK-NEXT:          FREs [
-// CHECK-NEXT:          ]
-// CHECK-NEXT:        }
-// CHECK-NEXT:        FuncDescEntry [1] {
-// CHECK-NEXT:          PC {
-// CHECK-NEXT:            Relocation: {{.*}}PC32{{.*}}
-// CHECK-NEXT:            Symbol Name: .text
-// CHECK-NEXT:            Start Address: {{.*}}
-// CHECK-NEXT:          }
-// CHECK-NEXT:          Size: 0x2
-// CHECK-NEXT:          Start FRE Offset: 0x0
-// CHECK-NEXT:          Num FREs: 0
-// CHECK-NEXT:          Info {
-// CHECK-NEXT:            FRE Type: Addr1 (0x0)
-// CHECK-NEXT:            FDE Type: PCInc (0x0)
-// CHECK-NEXT:            Raw: 0x0
-// CHECK-NEXT:          }
-// CHECK-NEXT:          Repetitive block size (unused): 0x0
-// CHECK-NEXT:          Padding2: 0x0
-// CHECK-NEXT:          FREs [
-// CHECK-NEXT:          ]
-// CHECK-NEXT:        }
-// CHECK-NEXT:      ]
-// CHECK-NEXT:    }
+f2:
+	.cfi_startproc
+        .cfi_endproc
+
+f3:
+	.cfi_startproc simple
+        .cfi_endproc
+
+# CHECK: SFrame section '.sframe' {
+# CHECK-NEXT:  Header {
+# CHECK-NEXT:    Magic: 0xDEE2
+# CHECK-NEXT:    Version: V2 (0x2)
+# CHECK-NEXT:    Flags [ (0x4)
+# CHECK:    ABI: AMD64EndianLittle (0x3)
+# CHECK-NEXT:    CFA fixed FP offset (unused): 0
+# CHECK-NEXT:    CFA fixed RA offset: -8
+# CHECK-NEXT:    Auxiliary header length: 0
+# CHECK-NEXT:    Num FDEs: 2
+# CHECK-NEXT:    Num FREs: 4
+# CHECK-NEXT:    FRE subsection length: 12
+# CHECK-NEXT:    FDE subsection offset: 0
+# CHECK-NEXT:    FRE subsection offset: 40
+# CHECK:    Function Index [
+# CHECK-NEXT:        FuncDescEntry [0] {
+# CHECK-NEXT:          PC {
+# CHECK-NEXT:            Relocation: {{.*}}PC32{{.*}}
+# CHECK-NEXT:            Symbol Name: .text
+# CHECK-NEXT:            Start Address: {{.*}}
+# CHECK-NEXT:          }
+# CHECK-NEXT:          Size: 0x5
+# CHECK-NEXT:          Start FRE Offset: 0x0
+# CHECK-NEXT:          Num FREs: 3
+# CHECK-NEXT:          Info {
+# CHECK-NEXT:            FRE Type: Addr1 (0x0)
+# CHECK-NEXT:            FDE Type: PCInc (0x0)
+# CHECK-NEXT:            Raw: 0x0
+# CHECK-NEXT:          }
+# CHECK-NEXT:          Repetitive block size (unused): 0x0
+# CHECK-NEXT:          Padding2: 0x0
+
+# Contents of FREs are tested elsewhere
+	
+# CHECK:             FuncDescEntry [1] {
+# CHECK-NEXT:          PC {
+# CHECK-NEXT:            Relocation: {{.*}}PC32{{.*}}
+# CHECK-NEXT:            Symbol Name: .text
+# CHECK-NEXT:            Start Address: {{.*}}
+# CHECK-NEXT:          }
+# CHECK-NEXT:          Size: 0x2
+# CHECK-NEXT:          Start FRE Offset: 0x9
+# CHECK-NEXT:          Num FREs: 1
+# CHECK-NEXT:          Info {
+# CHECK-NEXT:            FRE Type: Addr1 (0x0)
+# CHECK-NEXT:            FDE Type: PCInc (0x0)
+# CHECK-NEXT:            Raw: 0x0
+# CHECK-NEXT:          }
+# CHECK-NEXT:          Repetitive block size (unused): 0x0
+# CHECK-NEXT:          Padding2: 0x0
+
+


### PR DESCRIPTION
[Previously reverted due to msan failures on two uninitialized padding bits.]

This PR emits and relaxes the FREs generated in the previous PR.

After this change llvm emits usable sframe sections that can be linked with the gnu linker. There are a few remaining cfi directives to handle before they are generally usable, however.

The output isn't identical with gnu-gas in every case (this code produces fewer identical FREs in a row than gas), but I'm reasonably sure that they are correct regardless. There are even more size optimizations that can be done later.

Also, while working on the tests, I found a few bugs in older portions and cleaned those up.

This is a fairly big commit, but I'm not sure how to make it smaller.