### PR TITLE
TableGen multi-result support in source patterns

### DIFF
--- a/mlir/include/mlir/TableGen/Pattern.h
+++ b/mlir/include/mlir/TableGen/Pattern.h
@@ -433,8 +433,9 @@ public:
                         DagAndConstant(node.getAsOpaquePointer(), operandIndex,
                                        variadicSubIndex));
     }
-    static SymbolInfo getResult(const Operator *op) {
-      return SymbolInfo(op, Kind::Result, std::nullopt);
+    static SymbolInfo getResult(const Operator *op, int index) {
+      return SymbolInfo(op, Kind::Result,
+                        DagAndConstant(nullptr, index, std::nullopt));
     }
     static SymbolInfo getValue() {
       return SymbolInfo(nullptr, Kind::Value, std::nullopt);

--- a/mlir/lib/TableGen/Pattern.cpp
+++ b/mlir/lib/TableGen/Pattern.cpp
@@ -528,7 +528,8 @@ bool SymbolInfoMap::bindOpArgument(DagNode node, StringRef symbol,
 bool SymbolInfoMap::bindOpResult(StringRef symbol, const Operator &op) {
   int index = -1;
   StringRef name = getValuePackName(symbol, &index);
-  auto inserted = symbolInfoMap.emplace(name.str(), SymbolInfo::getResult(&op, index));
+  auto inserted =
+      symbolInfoMap.emplace(name.str(), SymbolInfo::getResult(&op, index));
 
   return symbolInfoMap.count(inserted->first) == 1;
 }

--- a/mlir/test/lib/Dialect/Test/TestOps.td
+++ b/mlir/test/lib/Dialect/Test/TestOps.td
@@ -1660,6 +1660,16 @@ def OneResultOp3 : TEST_Op<"one_result3"> {
   let results = (outs I32:$result1);
 }
 
+def OneResultOp4 : TEST_Op<"one_result4"> {
+  let arguments = (ins F32);
+  let results = (outs F32);
+}
+
+def TwoResultOp2 : TEST_Op<"two_result2"> {
+  let arguments = (ins);
+  let results = (outs F32, F32);
+}
+
 // Test using multi-result op as a whole
 def : Pat<(ThreeResultOp MultiResultOpKind1:$kind),
           (AnotherThreeResultOp $kind)>;
@@ -1695,6 +1705,12 @@ def : Pattern<
         (OneResultOp3 $interm__1),
         (AnotherTwoResultOp $kind)
     ]>;
+
+// Test referencing a one-param op whose
+// param comes from the first result of a two-result op.
+def : Pat<
+  (OneResultOp4 (TwoResultOp2:$a__1)),
+  (replaceWithValue $a__0)>;
 
 //===----------------------------------------------------------------------===//
 // Test Patterns (Variadic Ops)

--- a/mlir/test/mlir-tblgen/pattern.mlir
+++ b/mlir/test/mlir-tblgen/pattern.mlir
@@ -594,6 +594,25 @@ func.func @testMatchMixedVaradicOptional(%arg0: i32, %arg1: i32, %arg2: i32, %ar
   return
 }
 
+// CHECK-LABEL: @replaceOneResultWithNSuffixArgMatch
+func.func @replaceOneResultWithNSuffixArgMatch() -> (f32) {
+  // CHECK: %0:2 = "test.two_result2"() : () -> (f32, f32)
+  %0:2 = "test.two_result2"() : () -> (f32, f32)
+  %1 = "test.one_result4"(%0#1) : (f32) -> (f32)
+  // CHECK: return %0#0 : f32
+  return %1 : f32
+}
+
+// CHECK-LABEL: @replaceOneResultWithNSuffixArgNoMatch
+func.func @replaceOneResultWithNSuffixArgNoMatch() -> (f32) {
+  // CHECK: %0:2 = "test.two_result2"() : () -> (f32, f32)
+  %0:2 = "test.two_result2"() : () -> (f32, f32)
+  // CHECK: %1 = "test.one_result4"(%0#0) : (f32) -> f32
+  %1 = "test.one_result4"(%0#0) : (f32) -> (f32)
+  // CHECK: return %1 : f32
+  return %1 : f32
+}
+
 //===----------------------------------------------------------------------===//
 // Test patterns that operate on properties
 //===----------------------------------------------------------------------===//

--- a/mlir/tools/mlir-tblgen/RewriterGen.cpp
+++ b/mlir/tools/mlir-tblgen/RewriterGen.cpp
@@ -621,9 +621,9 @@ void PatternEmitter::emitOpMatch(DagNode tree, StringRef opName, int depth) {
     os << formatv("{0} = {1};\n", name, castedName);
 
   if (index != -1) {
-    emitMatchCheck(opName,
-      formatv("(resultNumber{0} == 1)", depth),
-      formatv("\"{0} does not come from result number {1} type\"", castedName, index));
+   emitMatchCheck(opName, formatv("(resultNumber{0} == 1)", depth),
+                  formatv("\"{0} does not come from result number {1} type\"",
+                          castedName, index));
   }
 
   for (int i = 0, opArgIdx = 0, e = tree.getNumArgs(), nextOperand = 0; i != e;
@@ -669,9 +669,10 @@ void PatternEmitter::emitOpMatch(DagNode tree, StringRef opName, int depth) {
           "auto *{0} = "
           "(*{1}.getODSOperands({2}).begin()).getDefiningOp();\n",
           argName, castedName, nextOperand);
-        os.indent() << formatv(
+      os.indent() << formatv(
           "[[maybe_unused]] auto resultNumber{0} = "
-          "::llvm::dyn_cast<::mlir::OpResult>((*{1}.getODSOperands({2}).begin())).getResultNumber();\n",
+          "::llvm::dyn_cast<::mlir::OpResult>((*{1}.getODSOperands({2}).begin()"
+          ")).getResultNumber();\n",
           depth + 1, castedName, nextOperand);
       // Null check of operand's definingOp
       emitMatchCheck(


### PR DESCRIPTION
The changes proposed in this pull request enhance the matching capabilities of the TableGen language. It extends the "__N suffix" approach, only previously available in replacement patterns.

The new logic is exercised in the following TableGen pattern. Notice `OneResultOp4` references a two-result operation, and multi-result operations previously never matched. With these changes, the `"__1"` suffix means this pattern will now match when the parameter received is `#1` from `TwoResultOp2`, as seen in the MLIR example below.

```td
def : Pat<
  (OneResultOp4 (TwoResultOp2:$a__1)),
  (replaceWithValue $a__0)>;
```

```mlir
%0:2 = "test.two_result2"() : () -> (f32, f32)
%1 = "test.one_result4"(%0#1) : (f32) -> (f32)
return %1 : f32
```

CC @jpienaar following up after our Discord [conversation](https://discord.com/channels/636084430946959380/1375177152684883968). Hope you find this is a good addition! Thanks in advance for reviewing my code.

Thank you!