### PR TITLE
[Offload]  Implement 'olIsValidBinary' in offload and clean up

### DIFF
--- a/offload/liboffload/API/Program.td
+++ b/offload/liboffload/API/Program.td
@@ -24,6 +24,18 @@ def olCreateProgram : Function {
     let returns = [];
 }
 
+def olIsValidBinary : Function {
+    let desc = "Validate if the binary image pointed to by `ProgData` is compatible with the device.";
+    let details = ["The provided `ProgData` will not be loaded onto the device"];
+    let params = [
+        Param<"ol_device_handle_t", "Device", "handle of the device", PARAM_IN>,
+        Param<"const void*", "ProgData", "pointer to the program binary data", PARAM_IN>,
+        Param<"size_t", "ProgDataSize", "size of the program binary in bytes", PARAM_IN>,
+        Param<"bool*", "Valid", "output is true if the image is compatible", PARAM_OUT>
+    ];
+    let returns = [];
+}
+
 def olDestroyProgram : Function {
     let desc = "Destroy the program and free all underlying resources.";
     let details = [];

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -887,7 +887,6 @@ Error olMemFill_impl(ol_queue_handle_t Queue, void *Ptr, size_t PatternSize,
 
 Error olCreateProgram_impl(ol_device_handle_t Device, const void *ProgData,
                            size_t ProgDataSize, ol_program_handle_t *Program) {
-  // Make a copy of the program binary in case it is released by the caller.
   StringRef Buffer(reinterpret_cast<const char *>(ProgData), ProgDataSize);
   Expected<plugin::DeviceImageTy *> Res =
       Device->Device->loadBinary(Device->Device->Plugin, Buffer);
@@ -901,7 +900,6 @@ Error olCreateProgram_impl(ol_device_handle_t Device, const void *ProgData,
 
 Error olIsValidBinary_impl(ol_device_handle_t Device, const void *ProgData,
                            size_t ProgDataSize, bool *IsValid) {
-  // Make a copy of the program binary in case it is released by the caller.
   StringRef Buffer(reinterpret_cast<const char *>(ProgData), ProgDataSize);
   *IsValid = Device->Device->Plugin.isDeviceCompatible(
       Device->Device->getDeviceId(), Buffer);

--- a/offload/liboffload/src/OffloadImpl.cpp
+++ b/offload/liboffload/src/OffloadImpl.cpp
@@ -899,6 +899,15 @@ Error olCreateProgram_impl(ol_device_handle_t Device, const void *ProgData,
   return Error::success();
 }
 
+Error olIsValidBinary_impl(ol_device_handle_t Device, const void *ProgData,
+                           size_t ProgDataSize, bool *IsValid) {
+  // Make a copy of the program binary in case it is released by the caller.
+  StringRef Buffer(reinterpret_cast<const char *>(ProgData), ProgDataSize);
+  *IsValid = Device->Device->Plugin.isDeviceCompatible(
+      Device->Device->getDeviceId(), Buffer);
+  return Error::success();
+}
+
 Error olDestroyProgram_impl(ol_program_handle_t Program) {
   auto &Device = Program->Image->getDevice();
   if (auto Err = Device.unloadBinary(Program->Image))

--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -219,7 +219,10 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
     // Scan the RTLs that have associated images until we find one that supports
     // the current image.
     for (auto &R : plugins()) {
-      if (!R.is_plugin_compatible(Img))
+      StringRef Buffer(reinterpret_cast<const char *>(Img->ImageStart),
+                       utils::getPtrDiff(Img->ImageEnd, Img->ImageStart));
+
+      if (!R.isPluginCompatible(Buffer))
         continue;
 
       if (!initializePlugin(R))
@@ -242,7 +245,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
           continue;
         }
 
-        if (!R.is_device_compatible(DeviceId, Img))
+        if (!R.isDeviceCompatible(DeviceId, Buffer))
           continue;
 
         DP("Image " DPxMOD " is compatible with RTL %s device %d!\n",

--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -1378,10 +1378,10 @@ public:
 
   /// Returns non-zero if the \p Image is compatible with the plugin. This
   /// function does not require the plugin to be initialized before use.
-  int32_t is_plugin_compatible(__tgt_device_image *Image);
+  int32_t isPluginCompatible(StringRef Image);
 
   /// Returns non-zero if the \p Image is compatible with the device.
-  int32_t is_device_compatible(int32_t DeviceId, __tgt_device_image *Image);
+  int32_t isDeviceCompatible(int32_t DeviceId, StringRef Image);
 
   /// Returns non-zero if the plugin device has been initialized.
   int32_t is_device_initialized(int32_t DeviceId) const;

--- a/offload/unittests/OffloadAPI/CMakeLists.txt
+++ b/offload/unittests/OffloadAPI/CMakeLists.txt
@@ -35,6 +35,7 @@ add_offload_unittest("platform"
 
 add_offload_unittest("program"
     program/olCreateProgram.cpp
+    program/olIsValidBinary.cpp
     program/olDestroyProgram.cpp)
 
 add_offload_unittest("queue"

--- a/offload/unittests/OffloadAPI/program/olIsValidBinary.cpp
+++ b/offload/unittests/OffloadAPI/program/olIsValidBinary.cpp
@@ -27,9 +27,23 @@ TEST_P(olIsValidBinaryTest, Success) {
   ASSERT_SUCCESS(
       olIsValidBinary(Device, DeviceBin->getBufferStart(), 0, &IsValid));
   ASSERT_FALSE(IsValid);
+}
 
-  ASSERT_ERROR(
-      OL_ERRC_INVALID_NULL_POINTER,
-      olIsValidBinary(Device, nullptr, DeviceBin->getBufferSize(), &IsValid));
+TEST_P(olIsValidBinaryTest, Invalid) {
+
+  std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
+  ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
+  ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+
+  bool IsValid = false;
+  ASSERT_SUCCESS(
+      olIsValidBinary(Device, DeviceBin->getBufferStart(), 0, &IsValid));
+  ASSERT_FALSE(IsValid);
+}
+
+TEST_P(olIsValidBinaryTest, NullPointer) {
+  bool IsValid = false;
+  ASSERT_ERROR(OL_ERRC_INVALID_NULL_POINTER,
+               olIsValidBinary(Device, nullptr, 42, &IsValid));
   ASSERT_FALSE(IsValid);
 }

--- a/offload/unittests/OffloadAPI/program/olIsValidBinary.cpp
+++ b/offload/unittests/OffloadAPI/program/olIsValidBinary.cpp
@@ -23,4 +23,13 @@ TEST_P(olIsValidBinaryTest, Success) {
   ASSERT_SUCCESS(olIsValidBinary(Device, DeviceBin->getBufferStart(),
                                  DeviceBin->getBufferSize(), &IsValid));
   ASSERT_TRUE(IsValid);
+
+  ASSERT_SUCCESS(
+      olIsValidBinary(Device, DeviceBin->getBufferStart(), 0, &IsValid));
+  ASSERT_FALSE(IsValid);
+
+  ASSERT_ERROR(
+      OL_ERRC_INVALID_NULL_POINTER,
+      olIsValidBinary(Device, nullptr, DeviceBin->getBufferSize(), &IsValid));
+  ASSERT_FALSE(IsValid);
 }

--- a/offload/unittests/OffloadAPI/program/olIsValidBinary.cpp
+++ b/offload/unittests/OffloadAPI/program/olIsValidBinary.cpp
@@ -1,0 +1,26 @@
+//===------- Offload API tests - olIsValidBinary --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "../common/Fixtures.hpp"
+#include <OffloadAPI.h>
+#include <gtest/gtest.h>
+
+using olIsValidBinaryTest = OffloadDeviceTest;
+OFFLOAD_TESTS_INSTANTIATE_DEVICE_FIXTURE(olIsValidBinaryTest);
+
+TEST_P(olIsValidBinaryTest, Success) {
+
+  std::unique_ptr<llvm::MemoryBuffer> DeviceBin;
+  ASSERT_TRUE(TestEnvironment::loadDeviceBinary("foo", Device, DeviceBin));
+  ASSERT_GE(DeviceBin->getBufferSize(), 0lu);
+
+  bool IsValid = false;
+  ASSERT_SUCCESS(olIsValidBinary(Device, DeviceBin->getBufferStart(),
+                                 DeviceBin->getBufferSize(), &IsValid));
+  ASSERT_TRUE(IsValid);
+}


### PR DESCRIPTION
Summary:
This exposes the 'isDeviceCompatible' routine for checking if a binary
*can* be loaded. This is useful if people don't want to consume errors
everywhere when figuring out which image to put to what device.

I don't know if this is a good name, I was thining like `olIsCompatible`
or whatever. Let me know what you think.

Long term I'd like to be able to do something similar to what OpenMP
does where we can conditionally only initialize devices if we need them.
That's going to be support needed if we want this to be more
generic.
