### PR TITLE
Fix libFuzzer array alignment with empty modules

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp
@@ -69,6 +69,9 @@ void TracePC::HandleInline8bitCountersInit(uint8_t *Start, uint8_t *Stop) {
 }
 
 void TracePC::HandlePCsInit(const uintptr_t *Start, const uintptr_t *Stop) {
+  if (Start == Stop) {
+    return;
+  }
   const PCTableEntry *B = reinterpret_cast<const PCTableEntry *>(Start);
   const PCTableEntry *E = reinterpret_cast<const PCTableEntry *>(Stop);
   if (NumPCTables && ModulePCTable[NumPCTables - 1].Start == B) return;

--- a/compiler-rt/test/fuzzer/SimulateEmptyModuleTest.cpp
+++ b/compiler-rt/test/fuzzer/SimulateEmptyModuleTest.cpp
@@ -1,0 +1,60 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Like SimpleTest, but simulates an "empty" module (i.e. one without any functions to instrument).
+// This reproduces a previous bug (when libFuzzer is compiled with assertions enabled).
+
+#include <assert.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <ostream>
+
+extern "C" {
+void __sanitizer_cov_8bit_counters_init(uint8_t *Start, uint8_t *Stop);
+void __sanitizer_cov_pcs_init(const uintptr_t *pcs_beg,
+                              const uintptr_t *pcs_end);
+}
+
+void dummy_func() {}
+
+uint8_t empty_8bit_counters[0];
+uintptr_t empty_pcs[0];
+
+uint8_t fake_8bit_counters[1] = {0};
+uintptr_t fake_pcs[2] = {reinterpret_cast<uintptr_t>(&dummy_func),
+                         reinterpret_cast<uintptr_t>(&dummy_func)};
+
+// Register two modules at program launch (same time they'd normally be registered).
+// Triggering the bug requires loading an empty module, then a non-empty module after it.
+bool dummy = []() {
+  // First, simulate loading an empty module.
+  __sanitizer_cov_8bit_counters_init(empty_8bit_counters, empty_8bit_counters);
+  __sanitizer_cov_pcs_init(empty_pcs, empty_pcs);
+
+  // Next, simulate loading a non-empty module.
+  __sanitizer_cov_8bit_counters_init(fake_8bit_counters,
+                                     fake_8bit_counters + 1);
+  __sanitizer_cov_pcs_init(fake_pcs, fake_pcs + 2);
+
+  return true;
+}();
+
+static volatile int Sink;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  assert(Data);
+  if (Size > 0 && Data[0] == 'H') {
+    Sink = 1;
+    if (Size > 1 && Data[1] == 'i') {
+      Sink = 2;
+      if (Size > 2 && Data[2] == '!') {
+        std::cout << "BINGO; Found the target, exiting\n" << std::flush;
+        exit(0);
+      }
+    }
+  }
+  return 0;
+}

--- a/compiler-rt/test/fuzzer/empty-module.test
+++ b/compiler-rt/test/fuzzer/empty-module.test
@@ -1,0 +1,7 @@
+CHECK: BINGO
+RUN: %cpp_compiler %S/SimulateEmptyModuleTest.cpp -o %t-SimulateEmptyModuleTest
+
+RUN: not %run %t-SimulateEmptyModuleTest         2>&1 | FileCheck %s
+
+# only_ascii mode. Will perform some minimal self-validation.
+RUN: not %run %t-SimulateEmptyModuleTest -only_ascii=1 2>&1


### PR DESCRIPTION
The following assertion was being triggered:
```
assert.h assertion failed at llvm-project/compiler-rt/lib/fuzzer/FuzzerTracePC.cpp:237 in void fuzzer::TracePC::UpdateObservedPCs(): M.Size() == (size_t)(ModulePCTable[i].Stop - ModulePCTable[i].Start)
```

# The bug

When built with `-fsanitize=fuzzer`, each “module” (.so file, or the binary itself) will be instrumented, and when loaded into the process will make a call to these two functions:
 - `__sanitizer_cov_8bit_counters_init`
 - `__sanitizer_cov_pcs_init`

Each of these is called with start and end pointers defining an array.

In libFuzzer, these functions are implemented with `HandleInline8bitCountersInit` and `HandlePCsInit`. Each of them pushes back the provided pointers into a separate array, `Modules` and `ModulePCTable` respectively. These arrays are meant to be kept in-sync; index i into Modules should refer to the same `.so` as index i into ModulePCTable. The assertion was triggering because these lists got out-of-sync.

The problem is that the 8bit handler contains this line:
```
if (Start == Stop) return;
```
but the PC handler contains no such corresponding line. This meant that if a module was ever instrumented but “empty” (its 8bit counter and PC arrays were both of length 0), then its PC array would still be added but its 8bit counter array would not.

# Why this issue was never seen before

The circumstances to trigger this issue are unusual:
 - You need a compilation unit that doesn't contain any code (though it may contain global variable declarations and similar). That doesn't happen very often.
 - That compilation unit must be dynamically linked, not statically linked. If statically linked, it’ll be merged into a single “module” with the main binary, and the arrays will be merged as well; you won’t end up with length-0 arrays.
 - To notice the issue, assertions must be enabled. If disabled, libFuzzer will be buggy (it may have worse coverage), but it won't crash, and "worse coverage" is extremely unlikely to be noticed.

# This change

This change solves the issue by adding the same `if (Start == Stop) return;` check to `HandlePCsInit`. This prevents the arrays from getting out-of-sync. This change also adds a test that identifies the previous issue when compiled with assertions enabled, but now passes with the fix.