### PR TITLE
[lldb] Fix build when LLDB_ENABLE_PYTHON is OFF

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -187,6 +187,10 @@ if (LLDB_ENABLE_PYTHON)
   endif()
   option(LLDB_ENABLE_PYTHON_LIMITED_API "Force LLDB to only use the Python Limited API (requires SWIG 4.2 or later)"
     ${default_enable_python_limited_api})
+else()
+  # Even if Python scripting is disabled, we still need a Python interpreter to
+  # build, for example to generate SBLanguages.h.
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
 endif()
 
 if (LLVM_EXTERNAL_CLANG_SOURCE_DIR)


### PR DESCRIPTION
Even if Python scripting is disabled, we still need a Python interpreter to build, for example to generate SBLanguages.h or fix up the framework headers.