### PR TITLE
[llvm][clang] Propagate VFS through LTO to `PGOOptions`

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1389,11 +1389,11 @@ runThinLTOBackend(CompilerInstance &CI, ModuleSummaryIndex *CombinedIndex,
   // FIXME: Both ExecuteAction and thinBackend set up optimization remarks for
   // the same context.
   finalizeLLVMOptimizationRemarks(M->getContext());
-  if (Error E =
-          thinBackend(Conf, -1, AddStream, *M, *CombinedIndex, ImportList,
-                      ModuleToDefinedGVSummaries[M->getModuleIdentifier()],
-                      /*ModuleMap=*/nullptr, Conf.CodeGenOnly,
-                      /*IRAddStream=*/nullptr, CGOpts.CmdArgs)) {
+  if (Error E = thinBackend(
+          Conf, &CI.getVirtualFileSystem(), -1, AddStream, *M, *CombinedIndex,
+          ImportList, ModuleToDefinedGVSummaries[M->getModuleIdentifier()],
+          /*ModuleMap=*/nullptr, Conf.CodeGenOnly,
+          /*IRAddStream=*/nullptr, CGOpts.CmdArgs)) {
     handleAllErrors(std::move(E), [&](ErrorInfoBase &EIB) {
       errs() << "Error running ThinLTO backend: " << EIB.message() << '\n';
     });

--- a/llvm/include/llvm/LTO/LTO.h
+++ b/llvm/include/llvm/LTO/LTO.h
@@ -29,6 +29,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/thread.h"
 #include "llvm/Transforms/IPO/FunctionAttrs.h"
 #include "llvm/Transforms/IPO/FunctionImport.h"
@@ -210,6 +211,7 @@ using ImportsFilesContainer = llvm::SmallVector<std::string>;
 class ThinBackendProc {
 protected:
   const Config &Conf;
+  IntrusiveRefCntPtr<vfs::FileSystem> FS;
   ModuleSummaryIndex &CombinedIndex;
   const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries;
   IndexWriteCallback OnWrite;
@@ -220,11 +222,12 @@ protected:
 
 public:
   ThinBackendProc(
-      const Config &Conf, ModuleSummaryIndex &CombinedIndex,
+      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS,
+      ModuleSummaryIndex &CombinedIndex,
       const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
       lto::IndexWriteCallback OnWrite, bool ShouldEmitImportsFiles,
       ThreadPoolStrategy ThinLTOParallelism)
-      : Conf(Conf), CombinedIndex(CombinedIndex),
+      : Conf(Conf), FS(std::move(FS)), CombinedIndex(CombinedIndex),
         ModuleToDefinedGVSummaries(ModuleToDefinedGVSummaries),
         OnWrite(OnWrite), ShouldEmitImportsFiles(ShouldEmitImportsFiles),
         BackendThreadPool(ThinLTOParallelism) {}

--- a/llvm/include/llvm/LTO/LTOBackend.h
+++ b/llvm/include/llvm/LTO/LTOBackend.h
@@ -56,14 +56,14 @@ LLVM_ABI Error backend(const Config &C, AddStreamFn AddStream,
 /// the backend will skip optimization and only perform code generation. If
 /// \p IRAddStream is not nullptr, it will be called just before code generation
 /// to serialize the optimized IR.
-LLVM_ABI Error
-thinBackend(const Config &C, unsigned Task, AddStreamFn AddStream, Module &M,
-            const ModuleSummaryIndex &CombinedIndex,
-            const FunctionImporter::ImportMapTy &ImportList,
-            const GVSummaryMapTy &DefinedGlobals,
-            MapVector<StringRef, BitcodeModule> *ModuleMap, bool CodeGenOnly,
-            AddStreamFn IRAddStream = nullptr,
-            const std::vector<uint8_t> &CmdArgs = std::vector<uint8_t>());
+LLVM_ABI Error thinBackend(
+    const Config &C, IntrusiveRefCntPtr<vfs::FileSystem> FS, unsigned Task,
+    AddStreamFn AddStream, Module &M, const ModuleSummaryIndex &CombinedIndex,
+    const FunctionImporter::ImportMapTy &ImportList,
+    const GVSummaryMapTy &DefinedGlobals,
+    MapVector<StringRef, BitcodeModule> *ModuleMap, bool CodeGenOnly,
+    AddStreamFn IRAddStream = nullptr,
+    const std::vector<uint8_t> &CmdArgs = std::vector<uint8_t>());
 
 LLVM_ABI Error finalizeOptimizationRemarks(LLVMRemarkFileHandle DiagOutputFile);
 

--- a/llvm/include/llvm/LTO/LTOBackend.h
+++ b/llvm/include/llvm/LTO/LTOBackend.h
@@ -35,8 +35,8 @@ class Target;
 namespace lto {
 
 /// Runs middle-end LTO optimizations on \p Mod.
-LLVM_ABI bool opt(const Config &Conf, TargetMachine *TM, unsigned Task,
-                  Module &Mod, bool IsThinLTO,
+LLVM_ABI bool opt(const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS,
+                  TargetMachine *TM, unsigned Task, Module &Mod, bool IsThinLTO,
                   ModuleSummaryIndex *ExportSummary,
                   const ModuleSummaryIndex *ImportSummary,
                   const std::vector<uint8_t> &CmdArgs);

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Support/TimeProfiler.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/VCSRevision.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/IPO.h"
@@ -1545,7 +1546,8 @@ public:
       if (!MOrErr)
         return MOrErr.takeError();
 
-      return thinBackend(Conf, Task, AddStream, **MOrErr, CombinedIndex,
+      auto FS = vfs::getRealFileSystem();
+      return thinBackend(Conf, FS, Task, AddStream, **MOrErr, CombinedIndex,
                          ImportList, DefinedGlobals, &ModuleMap,
                          Conf.CodeGenOnly);
     };
@@ -1659,7 +1661,8 @@ public:
       if (!MOrErr)
         return MOrErr.takeError();
 
-      return thinBackend(Conf, Task, CGAddStream, **MOrErr, CombinedIndex,
+      auto FS = vfs::getRealFileSystem();
+      return thinBackend(Conf, FS, Task, CGAddStream, **MOrErr, CombinedIndex,
                          ImportList, DefinedGlobals, &ModuleMap,
                          Conf.CodeGenOnly, IRAddStream);
     };
@@ -1754,7 +1757,8 @@ public:
       std::unique_ptr<Module> LoadedModule =
           cgdata::loadModuleForTwoRounds(BM, Task, BackendContext, *IRFiles);
 
-      return thinBackend(Conf, Task, AddStream, *LoadedModule, CombinedIndex,
+      auto FS = vfs::getRealFileSystem();
+      return thinBackend(Conf, FS, Task, AddStream, *LoadedModule, CombinedIndex,
                          ImportList, DefinedGlobals, &ModuleMap,
                          /*CodeGenOnly=*/true);
     };

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1633,14 +1633,15 @@ class FirstRoundThinBackend : public InProcessThinBackend {
 
 public:
   FirstRoundThinBackend(
-      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS, ModuleSummaryIndex &CombinedIndex,
-      ThreadPoolStrategy ThinLTOParallelism,
+      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS,
+      ModuleSummaryIndex &CombinedIndex, ThreadPoolStrategy ThinLTOParallelism,
       const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
       AddStreamFn CGAddStream, FileCache CGCache, AddStreamFn IRAddStream,
       FileCache IRCache)
-      : InProcessThinBackend(Conf, std::move(FS), CombinedIndex, ThinLTOParallelism,
-                             ModuleToDefinedGVSummaries, std::move(CGAddStream),
-                             std::move(CGCache), /*OnWrite=*/nullptr,
+      : InProcessThinBackend(Conf, std::move(FS), CombinedIndex,
+                             ThinLTOParallelism, ModuleToDefinedGVSummaries,
+                             std::move(CGAddStream), std::move(CGCache),
+                             /*OnWrite=*/nullptr,
                              /*ShouldEmitIndexFiles=*/false,
                              /*ShouldEmitImportsFiles=*/false),
         IRAddStream(std::move(IRAddStream)), IRCache(std::move(IRCache)) {}
@@ -1728,15 +1729,15 @@ class SecondRoundThinBackend : public InProcessThinBackend {
 
 public:
   SecondRoundThinBackend(
-      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS, ModuleSummaryIndex &CombinedIndex,
-      ThreadPoolStrategy ThinLTOParallelism,
+      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS,
+      ModuleSummaryIndex &CombinedIndex, ThreadPoolStrategy ThinLTOParallelism,
       const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
       AddStreamFn AddStream, FileCache Cache,
       std::unique_ptr<SmallVector<StringRef>> IRFiles,
       stable_hash CombinedCGDataHash)
-      : InProcessThinBackend(Conf, std::move(FS), CombinedIndex, ThinLTOParallelism,
-                             ModuleToDefinedGVSummaries, std::move(AddStream),
-                             std::move(Cache),
+      : InProcessThinBackend(Conf, std::move(FS), CombinedIndex,
+                             ThinLTOParallelism, ModuleToDefinedGVSummaries,
+                             std::move(AddStream), std::move(Cache),
                              /*OnWrite=*/nullptr,
                              /*ShouldEmitIndexFiles=*/false,
                              /*ShouldEmitImportsFiles=*/false),
@@ -1758,8 +1759,8 @@ public:
       std::unique_ptr<Module> LoadedModule =
           cgdata::loadModuleForTwoRounds(BM, Task, BackendContext, *IRFiles);
 
-      return thinBackend(Conf, FS, Task, AddStream, *LoadedModule, CombinedIndex,
-                         ImportList, DefinedGlobals, &ModuleMap,
+      return thinBackend(Conf, FS, Task, AddStream, *LoadedModule,
+                         CombinedIndex, ImportList, DefinedGlobals, &ModuleMap,
                          /*CodeGenOnly=*/true);
     };
     if (!Cache.isValid() || !CombinedIndex.modulePaths().count(ModuleID) ||
@@ -1850,14 +1851,15 @@ class WriteIndexesThinBackend : public ThinBackendProc {
 
 public:
   WriteIndexesThinBackend(
-      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS, ModuleSummaryIndex &CombinedIndex,
-      ThreadPoolStrategy ThinLTOParallelism,
+      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS,
+      ModuleSummaryIndex &CombinedIndex, ThreadPoolStrategy ThinLTOParallelism,
       const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
       std::string OldPrefix, std::string NewPrefix,
       std::string NativeObjectPrefix, bool ShouldEmitImportsFiles,
       raw_fd_ostream *LinkedObjectsFile, lto::IndexWriteCallback OnWrite)
-      : ThinBackendProc(Conf, std::move(FS), CombinedIndex, ModuleToDefinedGVSummaries,
-                        OnWrite, ShouldEmitImportsFiles, ThinLTOParallelism),
+      : ThinBackendProc(Conf, std::move(FS), CombinedIndex,
+                        ModuleToDefinedGVSummaries, OnWrite,
+                        ShouldEmitImportsFiles, ThinLTOParallelism),
         OldPrefix(OldPrefix), NewPrefix(NewPrefix),
         NativeObjectPrefix(NativeObjectPrefix),
         LinkedObjectsFile(LinkedObjectsFile) {}
@@ -2288,17 +2290,18 @@ class OutOfProcessThinBackend : public CGThinBackend {
 
 public:
   OutOfProcessThinBackend(
-      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS, ModuleSummaryIndex &CombinedIndex,
-      ThreadPoolStrategy ThinLTOParallelism,
+      const Config &Conf, IntrusiveRefCntPtr<vfs::FileSystem> FS,
+      ModuleSummaryIndex &CombinedIndex, ThreadPoolStrategy ThinLTOParallelism,
       const DenseMap<StringRef, GVSummaryMapTy> &ModuleToDefinedGVSummaries,
       AddStreamFn AddStream, lto::IndexWriteCallback OnWrite,
       bool ShouldEmitIndexFiles, bool ShouldEmitImportsFiles,
       StringRef LinkerOutputFile, StringRef Distributor,
       ArrayRef<StringRef> DistributorArgs, StringRef RemoteCompiler,
       ArrayRef<StringRef> RemoteCompilerArgs, bool SaveTemps)
-      : CGThinBackend(Conf, std::move(FS), CombinedIndex, ModuleToDefinedGVSummaries,
-                      AddStream, OnWrite, ShouldEmitIndexFiles,
-                      ShouldEmitImportsFiles, ThinLTOParallelism),
+      : CGThinBackend(Conf, std::move(FS), CombinedIndex,
+                      ModuleToDefinedGVSummaries, AddStream, OnWrite,
+                      ShouldEmitIndexFiles, ShouldEmitImportsFiles,
+                      ThinLTOParallelism),
         LinkerOutputFile(LinkerOutputFile), DistributorPath(Distributor),
         DistributorArgs(DistributorArgs), RemoteCompiler(RemoteCompiler),
         RemoteCompilerArgs(RemoteCompilerArgs), SaveTemps(SaveTemps) {}

--- a/llvm/lib/LTO/LTO.cpp
+++ b/llvm/lib/LTO/LTO.cpp
@@ -1663,7 +1663,6 @@ public:
       if (!MOrErr)
         return MOrErr.takeError();
 
-      auto FS = vfs::getRealFileSystem();
       return thinBackend(Conf, FS, Task, CGAddStream, **MOrErr, CombinedIndex,
                          ImportList, DefinedGlobals, &ModuleMap,
                          Conf.CodeGenOnly, IRAddStream);
@@ -1759,7 +1758,6 @@ public:
       std::unique_ptr<Module> LoadedModule =
           cgdata::loadModuleForTwoRounds(BM, Task, BackendContext, *IRFiles);
 
-      auto FS = vfs::getRealFileSystem();
       return thinBackend(Conf, FS, Task, AddStream, *LoadedModule, CombinedIndex,
                          ImportList, DefinedGlobals, &ModuleMap,
                          /*CodeGenOnly=*/true);

--- a/llvm/lib/LTO/LTOBackend.cpp
+++ b/llvm/lib/LTO/LTOBackend.cpp
@@ -602,8 +602,10 @@ static void dropDeadSymbols(Module &Mod, const GVSummaryMapTy &DefinedGlobals,
   }
 }
 
-Error lto::thinBackend(const Config &Conf, unsigned Task, AddStreamFn AddStream,
-                       Module &Mod, const ModuleSummaryIndex &CombinedIndex,
+Error lto::thinBackend(const Config &Conf,
+                       IntrusiveRefCntPtr<vfs::FileSystem> FS, unsigned Task,
+                       AddStreamFn AddStream, Module &Mod,
+                       const ModuleSummaryIndex &CombinedIndex,
                        const FunctionImporter::ImportMapTy &ImportList,
                        const GVSummaryMapTy &DefinedGlobals,
                        MapVector<StringRef, BitcodeModule> *ModuleMap,
@@ -643,7 +645,6 @@ Error lto::thinBackend(const Config &Conf, unsigned Task, AddStreamFn AddStream,
   auto OptimizeAndCodegen =
       [&](Module &Mod, TargetMachine *TM,
           LLVMRemarkFileHandle DiagnosticOutputFile) {
-        auto FS = vfs::getRealFileSystem();
         // Perform optimization and code generation for ThinLTO.
         if (!opt(Conf, FS, TM, Task, Mod, /*IsThinLTO=*/true,
                  /*ExportSummary=*/nullptr, /*ImportSummary=*/&CombinedIndex,

--- a/llvm/lib/LTO/LTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/LTOCodeGenerator.cpp
@@ -46,6 +46,7 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Host.h"
@@ -612,7 +613,8 @@ bool LTOCodeGenerator::optimize() {
 
   ModuleSummaryIndex CombinedIndex(false);
   TargetMach = createTargetMachine();
-  if (!opt(Config, TargetMach.get(), 0, *MergedModule, /*IsThinLTO=*/false,
+  auto FS = vfs::getRealFileSystem();
+  if (!opt(Config, FS, TargetMach.get(), 0, *MergedModule, /*IsThinLTO=*/false,
            /*ExportSummary=*/&CombinedIndex, /*ImportSummary=*/nullptr,
            /*CmdArgs*/ std::vector<uint8_t>())) {
     emitError("LTO middle-end optimizations failed");


### PR DESCRIPTION
This PR propagates the correctly-configured VFS from Clang through the LTO infrastructure into the `PGOOptions` constructor in `LTOBackend.cpp`. This works towards unifying the way the compiler interacts with the FS.