### PR TITLE
[vscode-lldb] Improve logging in Server Mode

### DIFF
--- a/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
+++ b/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts
@@ -167,9 +167,12 @@ Restarting the server will interrupt any existing debug sessions and start a new
     return [
       path,
       ...args,
-      ...Object.entries(env ?? {}).map(
-        (entry) => String(entry[0]) + "=" + String(entry[1]),
-      ),
+      ...Object.entries(env ?? {})
+        // Filter and sort to avoid restarting the server just because the
+        // order of env changed or the log path changed.
+        .filter((entry) => String(entry[0]) !== "LLDBDAP_LOG")
+        .sort()
+        .map((entry) => String(entry[0]) + "=" + String(entry[1])),
     ];
   }
 }

--- a/lldb/tools/lldb-dap/src-ts/logging.ts
+++ b/lldb/tools/lldb-dap/src-ts/logging.ts
@@ -44,7 +44,7 @@ export class LogFilePathProvider {
     const logFolder = this.logFolder || this.context.logUri.fsPath;
     switch(type) {
     case LogType.DEBUG_SESSION:
-        return path.join(logFolder, `lldb-dap-session-${formatDate(new Date())}-vscode-${vscode.env.sessionId}.log`);
+        return path.join(logFolder, `lldb-dap-${formatDate(new Date())}-${vscode.env.sessionId.split("-")[0]}.log`);
         break;
     }
   }

--- a/lldb/tools/lldb-dap/src-ts/logging.ts
+++ b/lldb/tools/lldb-dap/src-ts/logging.ts
@@ -1,4 +1,3 @@
-import * as os from 'os';
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -45,7 +44,7 @@ export class LogFilePathProvider {
     const logFolder = this.logFolder || this.context.logUri.fsPath;
     switch(type) {
     case LogType.DEBUG_SESSION:
-        return path.join(logFolder, `lldb-dap-session-${os.userInfo().username}-${formatDate(new Date())}.log`);
+        return path.join(logFolder, `lldb-dap-session-${formatDate(new Date())}-vscode-${vscode.env.sessionId}.log`);
         break;
     }
   }

--- a/lldb/tools/lldb-dap/src-ts/logging.ts
+++ b/lldb/tools/lldb-dap/src-ts/logging.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -44,7 +45,7 @@ export class LogFilePathProvider {
     const logFolder = this.logFolder || this.context.logUri.fsPath;
     switch(type) {
     case LogType.DEBUG_SESSION:
-        return path.join(logFolder, `lldb-dap-session-${formatDate(new Date())}.log`);
+        return path.join(logFolder, `lldb-dap-session-${os.userInfo().username}-${formatDate(new Date())}.log`);
         break;
     }
   }


### PR DESCRIPTION
A few improvements to logging when lldb-dap is started in **Server Mode** AND when the **`lldb-dap.logFolder`** setting is used (not `lldb-dap.log-path`).

### Improvement #1
**Avoid the prompt of restarting the server when starting each debug session.**

That prompt is caused by the combination of the following facts:
1. The log filename changes every time a new debug session is starting (see [here](https://github.com/llvm/llvm-project/blob/9d6062c490548a5e6fea103e010ab3c9bc73a86d/lldb/tools/lldb-dap/src-ts/logging.ts#L47))
2. The log filename is passed to the server via an environment variable called "LLDBDAP_LOG" (see [here](https://github.com/llvm/llvm-project/blob/9d6062c490548a5e6fea103e010ab3c9bc73a86d/lldb/tools/lldb-dap/src-ts/debug-adapter-factory.ts#L263-L269))
3. All environment variables are put into the "spawn info" variable (see [here](https://github.com/llvm/llvm-project/blob/9d6062c490548a5e6fea103e010ab3c9bc73a86d/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts#L170-L172)).
4. The old and new "spawn info" are compared to decide if a prompt should show (see [here](https://github.com/llvm/llvm-project/blob/9d6062c490548a5e6fea103e010ab3c9bc73a86d/lldb/tools/lldb-dap/src-ts/lldb-dap-server.ts#L107-L110)).

The fix is to remove the "LLDBDAP_LOG" from the "spawn info" variable, so that the same server can be reused if the log path is the only thing that has changed.

### Improvement #2
**Avoid log file conflict when multiple users share a machine and start server in the same second.**

The problem: If two users start lldb-dap server in the same second, they will share the same log path. The first user will create the log file. The second user will find that they cannot access the same file, so their server will fail to start.

The fix is to add a part of the VS Code session ID to the log filename.

### Improvement #3
**Avoid restarting the server when the order of environment variables changed.**

This is done by sorting the environment variables before putting them into the "spawn info".
