### PR TITLE
[RISCV] Use bseti 31 for (or X, -2147483648) when upper 32 bits aren't used.

### DIFF
--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -575,7 +575,7 @@ def : Pat<(XLenVT (and GPR:$r, BCLRIANDIMask:$i)),
 } // Predicates = [HasStdExtZbs]
 
 let Predicates = [HasStdExtZbs, IsRV64] in {
-// If the original code was setting, clearing, or inverting bit 31 or an i32,
+// If the original code was setting, clearing, or inverting bit 31 of an i32,
 // type legalization might have sign extended the constant so it doesn't have a
 // single 0 or 1 bit. If the upper 32 bits aren't used by later instructions we
 // can still use bseti/bclri.

--- a/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td
@@ -574,6 +574,19 @@ def : Pat<(XLenVT (and GPR:$r, BCLRIANDIMask:$i)),
                  (BCLRITwoBitsMaskHigh BCLRIANDIMask:$i))>;
 } // Predicates = [HasStdExtZbs]
 
+let Predicates = [HasStdExtZbs, IsRV64] in {
+// If the original code was setting, clearing, or inverting bit 31 or an i32,
+// type legalization might have sign extended the constant so it doesn't have a
+// single 0 or 1 bit. If the upper 32 bits aren't used by later instructions we
+// can still use bseti/bclri.
+def : Pat<(binop_allwusers<and> GPR:$rs1, (XLenVT 2147483647)),
+          (BCLRI GPR:$rs1, 31)>;
+def : Pat<(binop_allwusers<or> GPR:$rs1, (XLenVT -2147483648)),
+          (BSETI GPR:$rs1, 31)>;
+def : Pat<(binop_allwusers<xor> GPR:$rs1, (XLenVT -2147483648)),
+          (BINVI GPR:$rs1, 31)>;
+}
+
 let Predicates = [HasStdExtZbb] in
 def : PatGpr<riscv_orc_b, ORC_B>;
 

--- a/llvm/test/CodeGen/RISCV/rv64zbs.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbs.ll
@@ -547,8 +547,20 @@ define signext i32 @bclri_i32_31(i32 signext %a) nounwind {
 ; CHECK-NEXT:    slli a0, a0, 33
 ; CHECK-NEXT:    srli a0, a0, 33
 ; CHECK-NEXT:    ret
-  %and = and i32 %a, -2147483649
+  %and = and i32 %a, 2147483647
   ret i32 %and
+}
+
+define signext i32 @bclri_i32_31_allWUsers(i32 signext %a) nounwind {
+; CHECK-LABEL: bclri_i32_31_allWUsers:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    slli a0, a0, 33
+; CHECK-NEXT:    srli a0, a0, 33
+; CHECK-NEXT:    addiw a0, a0, 1
+; CHECK-NEXT:    ret
+  %and = and i32 %a, 2147483647
+  %add = add i32 %and, 1
+  ret i32 %add
 }
 
 define i64 @bclri_i64_10(i64 %a) nounwind {
@@ -724,6 +736,18 @@ define signext i32 @bseti_i32_31(i32 signext %a) nounwind {
   ret i32 %or
 }
 
+define signext i32 @bseti_i32_31_allWUsers(i32 signext %a) nounwind {
+; CHECK-LABEL: bseti_i32_31_allWUsers:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a1, 524288
+; CHECK-NEXT:    or a0, a0, a1
+; CHECK-NEXT:    addiw a0, a0, 1
+; CHECK-NEXT:    ret
+  %or = or i32 %a, 2147483648
+  %add = add i32 %or, 1
+  ret i32 %add
+}
+
 define i64 @bseti_i64_10(i64 %a) nounwind {
 ; CHECK-LABEL: bseti_i64_10:
 ; CHECK:       # %bb.0:
@@ -860,6 +884,18 @@ define signext i32 @binvi_i32_31(i32 signext %a) nounwind {
 ; CHECK-NEXT:    ret
   %xor = xor i32 %a, 2147483648
   ret i32 %xor
+}
+
+define void @binvi_i32_31_allWUsers(i32 signext %a, ptr %p) nounwind {
+; CHECK-LABEL: binvi_i32_31_allWUsers:
+; CHECK:       # %bb.0:
+; CHECK-NEXT:    lui a2, 524288
+; CHECK-NEXT:    xor a0, a0, a2
+; CHECK-NEXT:    sw a0, 0(a1)
+; CHECK-NEXT:    ret
+  %xor = xor i32 %a, 2147483648
+  store i32 %xor, ptr %p
+  ret void
 }
 
 define i64 @binvi_i64_10(i64 %a) nounwind {

--- a/llvm/test/CodeGen/RISCV/rv64zbs.ll
+++ b/llvm/test/CodeGen/RISCV/rv64zbs.ll
@@ -552,12 +552,18 @@ define signext i32 @bclri_i32_31(i32 signext %a) nounwind {
 }
 
 define signext i32 @bclri_i32_31_allWUsers(i32 signext %a) nounwind {
-; CHECK-LABEL: bclri_i32_31_allWUsers:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    slli a0, a0, 33
-; CHECK-NEXT:    srli a0, a0, 33
-; CHECK-NEXT:    addiw a0, a0, 1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: bclri_i32_31_allWUsers:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    slli a0, a0, 33
+; RV64I-NEXT:    srli a0, a0, 33
+; RV64I-NEXT:    addiw a0, a0, 1
+; RV64I-NEXT:    ret
+;
+; RV64ZBS-LABEL: bclri_i32_31_allWUsers:
+; RV64ZBS:       # %bb.0:
+; RV64ZBS-NEXT:    bclri a0, a0, 31
+; RV64ZBS-NEXT:    addiw a0, a0, 1
+; RV64ZBS-NEXT:    ret
   %and = and i32 %a, 2147483647
   %add = add i32 %and, 1
   ret i32 %add
@@ -737,12 +743,18 @@ define signext i32 @bseti_i32_31(i32 signext %a) nounwind {
 }
 
 define signext i32 @bseti_i32_31_allWUsers(i32 signext %a) nounwind {
-; CHECK-LABEL: bseti_i32_31_allWUsers:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a1, 524288
-; CHECK-NEXT:    or a0, a0, a1
-; CHECK-NEXT:    addiw a0, a0, 1
-; CHECK-NEXT:    ret
+; RV64I-LABEL: bseti_i32_31_allWUsers:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    lui a1, 524288
+; RV64I-NEXT:    or a0, a0, a1
+; RV64I-NEXT:    addiw a0, a0, 1
+; RV64I-NEXT:    ret
+;
+; RV64ZBS-LABEL: bseti_i32_31_allWUsers:
+; RV64ZBS:       # %bb.0:
+; RV64ZBS-NEXT:    bseti a0, a0, 31
+; RV64ZBS-NEXT:    addiw a0, a0, 1
+; RV64ZBS-NEXT:    ret
   %or = or i32 %a, 2147483648
   %add = add i32 %or, 1
   ret i32 %add
@@ -887,12 +899,18 @@ define signext i32 @binvi_i32_31(i32 signext %a) nounwind {
 }
 
 define void @binvi_i32_31_allWUsers(i32 signext %a, ptr %p) nounwind {
-; CHECK-LABEL: binvi_i32_31_allWUsers:
-; CHECK:       # %bb.0:
-; CHECK-NEXT:    lui a2, 524288
-; CHECK-NEXT:    xor a0, a0, a2
-; CHECK-NEXT:    sw a0, 0(a1)
-; CHECK-NEXT:    ret
+; RV64I-LABEL: binvi_i32_31_allWUsers:
+; RV64I:       # %bb.0:
+; RV64I-NEXT:    lui a2, 524288
+; RV64I-NEXT:    xor a0, a0, a2
+; RV64I-NEXT:    sw a0, 0(a1)
+; RV64I-NEXT:    ret
+;
+; RV64ZBS-LABEL: binvi_i32_31_allWUsers:
+; RV64ZBS:       # %bb.0:
+; RV64ZBS-NEXT:    binvi a0, a0, 31
+; RV64ZBS-NEXT:    sw a0, 0(a1)
+; RV64ZBS-NEXT:    ret
   %xor = xor i32 %a, 2147483648
   store i32 %xor, ptr %p
   ret void


### PR DESCRIPTION
If the original type was i32, type legalization will sign extend
the constant. This prevents it from having a single bit set or clear
so other patterns can't match. If the upper bits aren't used, we
can ignore the sign extension.
    
Similar for bclri and binvi.