### PR TITLE
[mlir][arith] Simplify inheriting constructors declarations. NFC.

### DIFF
--- a/mlir/lib/Conversion/ArithToAMDGPU/ArithToAMDGPU.cpp
+++ b/mlir/lib/Conversion/ArithToAMDGPU/ArithToAMDGPU.cpp
@@ -46,7 +46,7 @@ struct ArithToAMDGPUConversionPass final
 };
 
 struct ExtFOnFloat8RewritePattern final : OpRewritePattern<arith::ExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   Chipset chipset;
   ExtFOnFloat8RewritePattern(MLIRContext *ctx, Chipset chipset,
@@ -72,7 +72,7 @@ struct TruncFToFloat8RewritePattern final : OpRewritePattern<arith::TruncFOp> {
 struct TruncfToFloat16RewritePattern final
     : public OpRewritePattern<arith::TruncFOp> {
 
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const override;
@@ -80,7 +80,7 @@ struct TruncfToFloat16RewritePattern final
 
 struct ScalingExtFRewritePattern final
     : OpRewritePattern<arith::ScalingExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::ScalingExtFOp op,
                                 PatternRewriter &rewriter) const override;
@@ -88,7 +88,7 @@ struct ScalingExtFRewritePattern final
 
 struct ScalingTruncFRewritePattern final
     : OpRewritePattern<arith::ScalingTruncFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::ScalingTruncFOp op,
                                 PatternRewriter &rewriter) const override;

--- a/mlir/lib/Conversion/ArithToArmSME/ArithToArmSME.cpp
+++ b/mlir/lib/Conversion/ArithToArmSME/ArithToArmSME.cpp
@@ -44,7 +44,7 @@ namespace {
 
 /// Conversion pattern for dense arith.constant.
 struct ConstantOpToArmSMELowering : public OpRewritePattern<arith::ConstantOp> {
-  using OpRewritePattern<arith::ConstantOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::ConstantOp constantOp,
                                 PatternRewriter &rewriter) const final {

--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -52,7 +52,7 @@ namespace {
 class ArithConstantOpConversionPattern
     : public OpConversionPattern<arith::ConstantOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ConstantOp arithConst,
@@ -94,7 +94,7 @@ Value adaptValueType(Value val, ConversionPatternRewriter &rewriter, Type ty) {
 
 class CmpFOpConversion : public OpConversionPattern<arith::CmpFOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::CmpFOp op, OpAdaptor adaptor,
@@ -248,7 +248,7 @@ private:
 
 class CmpIOpConversion : public OpConversionPattern<arith::CmpIOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   bool needsUnsignedCmp(arith::CmpIPredicate pred) const {
     switch (pred) {
@@ -314,7 +314,7 @@ public:
 
 class NegFOpConversion : public OpConversionPattern<arith::NegFOp> {
 public:
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::NegFOp op, OpAdaptor adaptor,
@@ -647,7 +647,7 @@ class UnsignedShiftOpConversion final
 
 class SelectOpConversion : public OpConversionPattern<arith::SelectOp> {
 public:
-  using OpConversionPattern<arith::SelectOp>::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::SelectOp selectOp, OpAdaptor adaptor,

--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -57,7 +57,7 @@ struct ConstrainedVectorConvertToLLVMPattern
 /// are the same.
 struct IdentityBitcastLowering final
     : public OpConversionPattern<arith::BitcastOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::BitcastOp op, OpAdaptor adaptor,

--- a/mlir/lib/Conversion/TosaToArith/TosaToArith.cpp
+++ b/mlir/lib/Conversion/TosaToArith/TosaToArith.cpp
@@ -23,7 +23,7 @@ namespace {
 
 class ConstOpConverter : public OpRewritePattern<tosa::ConstOp> {
 public:
-  using OpRewritePattern<tosa::ConstOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tosa::ConstOp op,
                                 PatternRewriter &rewriter) const final {
@@ -60,7 +60,7 @@ Value getConstantValue(Location loc, Type type, int64_t value,
 class ApplyScaleGenericOpConverter
     : public OpRewritePattern<tosa::ApplyScaleOp> {
 public:
-  using OpRewritePattern<tosa::ApplyScaleOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tosa::ApplyScaleOp op,
                                 PatternRewriter &rewriter) const final {
@@ -126,7 +126,7 @@ public:
 
 class ApplyScale32BitOpConverter : public OpRewritePattern<tosa::ApplyScaleOp> {
 public:
-  using OpRewritePattern<tosa::ApplyScaleOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(tosa::ApplyScaleOp op,
                                 PatternRewriter &rewriter) const final {

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -2137,7 +2137,7 @@ OpFoldResult arith::CmpFOp::fold(FoldAdaptor adaptor) {
 
 class CmpFIntToFPConst final : public OpRewritePattern<CmpFOp> {
 public:
-  using OpRewritePattern<CmpFOp>::OpRewritePattern;
+  using Base::Base;
 
   static CmpIPredicate convertToIntegerPredicate(CmpFPredicate pred,
                                                  bool isUnsigned) {
@@ -2431,7 +2431,7 @@ void arith::CmpFOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
 
 //  select %arg, %c1, %c0 => extui %arg
 struct SelectToExtUI : public OpRewritePattern<arith::SelectOp> {
-  using OpRewritePattern<arith::SelectOp>::OpRewritePattern;
+  using Base::Base;
 
   LogicalResult matchAndRewrite(arith::SelectOp op,
                                 PatternRewriter &rewriter) const override {

--- a/mlir/lib/Dialect/Arith/Transforms/EmulateWideInt.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/EmulateWideInt.cpp
@@ -173,7 +173,7 @@ namespace {
 //===----------------------------------------------------------------------===//
 
 struct ConvertConstant final : OpConversionPattern<arith::ConstantOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ConstantOp op, OpAdaptor,
@@ -235,7 +235,7 @@ struct ConvertConstant final : OpConversionPattern<arith::ConstantOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertAddI final : OpConversionPattern<arith::AddIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::AddIOp op, OpAdaptor adaptor,
@@ -325,7 +325,7 @@ static arith::CmpIPredicate toUnsignedPredicate(arith::CmpIPredicate pred) {
 }
 
 struct ConvertCmpI final : OpConversionPattern<arith::CmpIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::CmpIOp op, OpAdaptor adaptor,
@@ -381,7 +381,7 @@ struct ConvertCmpI final : OpConversionPattern<arith::CmpIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertMulI final : OpConversionPattern<arith::MulIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::MulIOp op, OpAdaptor adaptor,
@@ -422,7 +422,7 @@ struct ConvertMulI final : OpConversionPattern<arith::MulIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertExtSI final : OpConversionPattern<arith::ExtSIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ExtSIOp op, OpAdaptor adaptor,
@@ -460,7 +460,7 @@ struct ConvertExtSI final : OpConversionPattern<arith::ExtSIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertExtUI final : OpConversionPattern<arith::ExtUIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ExtUIOp op, OpAdaptor adaptor,
@@ -598,7 +598,7 @@ struct ConvertIndexCastIndexToInt final : OpConversionPattern<CastOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertSelect final : OpConversionPattern<arith::SelectOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::SelectOp op, OpAdaptor adaptor,
@@ -631,7 +631,7 @@ struct ConvertSelect final : OpConversionPattern<arith::SelectOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertShLI final : OpConversionPattern<arith::ShLIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ShLIOp op, OpAdaptor adaptor,
@@ -720,7 +720,7 @@ struct ConvertShLI final : OpConversionPattern<arith::ShLIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertShRUI final : OpConversionPattern<arith::ShRUIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ShRUIOp op, OpAdaptor adaptor,
@@ -809,7 +809,7 @@ struct ConvertShRUI final : OpConversionPattern<arith::ShRUIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertShRSI final : OpConversionPattern<arith::ShRSIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::ShRSIOp op, OpAdaptor adaptor,
@@ -872,7 +872,7 @@ struct ConvertShRSI final : OpConversionPattern<arith::ShRSIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertSubI final : OpConversionPattern<arith::SubIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::SubIOp op, OpAdaptor adaptor,
@@ -912,7 +912,7 @@ struct ConvertSubI final : OpConversionPattern<arith::SubIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertSIToFP final : OpConversionPattern<arith::SIToFPOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::SIToFPOp op, OpAdaptor adaptor,
@@ -951,7 +951,7 @@ struct ConvertSIToFP final : OpConversionPattern<arith::SIToFPOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertUIToFP final : OpConversionPattern<arith::UIToFPOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::UIToFPOp op, OpAdaptor adaptor,
@@ -1015,7 +1015,7 @@ struct ConvertUIToFP final : OpConversionPattern<arith::UIToFPOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertFPToSI final : OpConversionPattern<arith::FPToSIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::FPToSIOp op, OpAdaptor adaptor,
@@ -1065,7 +1065,7 @@ struct ConvertFPToSI final : OpConversionPattern<arith::FPToSIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertFPToUI final : OpConversionPattern<arith::FPToUIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::FPToUIOp op, OpAdaptor adaptor,
@@ -1137,7 +1137,7 @@ struct ConvertFPToUI final : OpConversionPattern<arith::FPToUIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertTruncI final : OpConversionPattern<arith::TruncIOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(arith::TruncIOp op, OpAdaptor adaptor,
@@ -1166,7 +1166,7 @@ struct ConvertTruncI final : OpConversionPattern<arith::TruncIOp> {
 //===----------------------------------------------------------------------===//
 
 struct ConvertVectorPrint final : OpConversionPattern<vector::PrintOp> {
-  using OpConversionPattern::OpConversionPattern;
+  using Base::Base;
 
   LogicalResult
   matchAndRewrite(vector::PrintOp op, OpAdaptor adaptor,

--- a/mlir/lib/Dialect/Arith/Transforms/ExpandOps.cpp
+++ b/mlir/lib/Dialect/Arith/Transforms/ExpandOps.cpp
@@ -59,7 +59,7 @@ namespace {
 /// Expands CeilDivUIOp (n, m) into
 ///  n == 0 ? 0 : ((n-1) / m) + 1
 struct CeilDivUIOpConverter : public OpRewritePattern<arith::CeilDivUIOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::CeilDivUIOp op,
                                 PatternRewriter &rewriter) const final {
     Location loc = op.getLoc();
@@ -85,7 +85,7 @@ struct CeilDivUIOpConverter : public OpRewritePattern<arith::CeilDivUIOp> {
 ///   return z;
 /// }
 struct CeilDivSIOpConverter : public OpRewritePattern<arith::CeilDivSIOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::CeilDivSIOp op,
                                 PatternRewriter &rewriter) const final {
     Location loc = op.getLoc();
@@ -127,7 +127,7 @@ struct CeilDivSIOpConverter : public OpRewritePattern<arith::CeilDivSIOp> {
 ///   return z;
 /// }
 struct FloorDivSIOpConverter : public OpRewritePattern<arith::FloorDivSIOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::FloorDivSIOp op,
                                 PatternRewriter &rewriter) const final {
     Location loc = op.getLoc();
@@ -230,7 +230,7 @@ public:
 };
 
 struct BFloat16ExtFOpConverter : public OpRewritePattern<arith::ExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::ExtFOp op,
                                 PatternRewriter &rewriter) const final {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -260,7 +260,7 @@ struct BFloat16ExtFOpConverter : public OpRewritePattern<arith::ExtFOp> {
 };
 
 struct BFloat16TruncFOpConverter : public OpRewritePattern<arith::TruncFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const final {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -364,7 +364,7 @@ struct BFloat16TruncFOpConverter : public OpRewritePattern<arith::TruncFOp> {
 ///
 /// 4) F32 bits[1:22] = 0
 struct F4E2M1ExtFOpConverter : public OpRewritePattern<arith::ExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::ExtFOp op,
                                 PatternRewriter &rewriter) const final {
     Location loc = op.getLoc();
@@ -430,7 +430,7 @@ struct F4E2M1ExtFOpConverter : public OpRewritePattern<arith::ExtFOp> {
 };
 
 struct F8E8M0ExtFOpConverter : public OpRewritePattern<arith::ExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::ExtFOp op,
                                 PatternRewriter &rewriter) const final {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -502,7 +502,7 @@ struct F8E8M0ExtFOpConverter : public OpRewritePattern<arith::ExtFOp> {
 ///   Step 5: Round up if necessary, if mantissa[1:] greater than 1000000 or
 ///   subnormal.
 struct F4E2M1TruncFOpConverter : public OpRewritePattern<arith::TruncFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const final {
     Location loc = op.getLoc();
@@ -603,7 +603,7 @@ Since All kinds of Infs and NaNs are mapped to same exponent bits in F32 type,
 they all map to NaN in F8E8M0 Type.
 */
 struct F8E8M0TruncFOpConverter : public OpRewritePattern<arith::TruncFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::TruncFOp op,
                                 PatternRewriter &rewriter) const final {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -642,7 +642,7 @@ struct F8E8M0TruncFOpConverter : public OpRewritePattern<arith::TruncFOp> {
 };
 
 struct ScalingExtFOpConverter : public OpRewritePattern<arith::ScalingExtFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::ScalingExtFOp op,
                                 PatternRewriter &rewriter) const final {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);
@@ -684,7 +684,7 @@ Expands arith.ScalingTruncFOp(in, scale) into
  */
 struct ScalingTruncFOpConverter
     : public OpRewritePattern<arith::ScalingTruncFOp> {
-  using OpRewritePattern::OpRewritePattern;
+  using Base::Base;
   LogicalResult matchAndRewrite(arith::ScalingTruncFOp op,
                                 PatternRewriter &rewriter) const final {
     ImplicitLocOpBuilder b(op.getLoc(), rewriter);


### PR DESCRIPTION
Use the `Base` type alias from https://github.com/llvm/llvm-project/pull/158433.