### PR TITLE
[NFC] [IndVarSimplify] Add non-overflowing usub test

### DIFF
--- a/llvm/test/Transforms/IndVarSimplify/X86/overflow-intrinsics.ll
+++ b/llvm/test/Transforms/IndVarSimplify/X86/overflow-intrinsics.ll
@@ -140,6 +140,9 @@ for.body:                                         ; preds = %entry, %cont
   %0 = tail call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %i.04, i32 1)
   %1 = extractvalue { i32, i1 } %0, 1
 
+; It is theoretically possible to prove this, but SCEV cannot
+; represent non-unsigned-wrapping subtraction operations.
+
 ; CHECK: for.body:
 ; CHECK:  [[COND:%[^ ]+]] = extractvalue { i32, i1 } %1, 1
 ; CHECK-NEXT:  br i1 [[COND]], label %trap, label %cont, !nosanitize !0

--- a/llvm/test/Transforms/IndVarSimplify/X86/overflow-intrinsics.ll
+++ b/llvm/test/Transforms/IndVarSimplify/X86/overflow-intrinsics.ll
@@ -109,12 +109,9 @@ for.body:                                         ; preds = %entry, %cont
   %0 = tail call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %i.04, i32 1)
   %1 = extractvalue { i32, i1 } %0, 1
 
-; It is theoretically possible to prove this, but SCEV cannot
-; represent non-unsigned-wrapping subtraction operations.
-
 ; CHECK: for.body:
-; CHECK:  [[COND:%[^ ]+]] = extractvalue { i32, i1 } %1, 1
-; CHECK-NEXT:  br i1 [[COND]], label %trap, label %cont, !nosanitize !0
+; CHECK-NOT: @llvm.usub.with.overflow.i32
+; CHECK: br i1 false, label %trap, label %cont, !nosanitize !0
   br i1 %1, label %trap, label %cont, !nosanitize !{}
 
 trap:                                             ; preds = %for.body
@@ -123,7 +120,7 @@ trap:                                             ; preds = %for.body
 
 cont:                                             ; preds = %for.body
   %2 = extractvalue { i32, i1 } %0, 0
-  %cmp = icmp sgt i32 %2, -1
+  %cmp = icmp sgt i32 %2, 0
   br i1 %cmp, label %for.body, label %for.cond.cleanup
 }
 


### PR DESCRIPTION
We would reenter the loop with %i.04 being 0, so the usub would
overflow to -1. This was the only test in this file that had
an overflow in the loop, the other ones did not.
