### PR TITLE
[Clang][CIR] fix enumeration value 'OMPGroupPrivate' not handled in switch

### DIFF
--- a/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
@@ -665,8 +665,9 @@ void CIRGenFunction::emitDecl(const Decl &d, bool evaluateConditionDecl) {
   case Decl::ImplicitConceptSpecialization:
   case Decl::TopLevelStmt:
   case Decl::UsingPack:
-  case Decl::OMPDeclareReduction:
   case Decl::OMPDeclareMapper:
+  case Decl::OMPDeclareReduction:
+  case Decl::OMPGroupPrivate:
     cgm.errorNYI(d.getSourceRange(),
                  std::string("emitDecl: unhandled decl type: ") +
                      d.getDeclKindName());


### PR DESCRIPTION
```
FAILED: tools/clang/lib/CIR/CodeGen/CMakeFiles/obj.clangCIR.dir/CIRGenDecl.cpp.o 
/opt/llvm/bin/clang++ ... tools/clang/lib/CIR/CodeGen/CMakeFiles/obj.clangCIR.dir/CIRGenDecl.cpp.o -MF tools/clang/lib/CIR/CodeGen/CMakeFiles/obj.clangCIR.dir/CIRGenDecl.cpp.o.d -o tools/clang/lib/CIR/CodeGen/CMakeFiles/obj.clangCIR.dir/CIRGenDecl.cpp.o -c /home/gha/actions-runner/_work/llvm-project/llvm-project/clang/lib/CIR/CodeGen/CIRGenDecl.cpp
2025-09-19T02:23:43.9318111Z /home/gha/actions-runner/_work/llvm-project/llvm-project/clang/lib/CIR/CodeGen/CIRGenDecl.cpp:554:11: error: enumeration value 'OMPGroupPrivate' not handled in switch [-Werror,-Wswitch]
2025-09-19T02:23:43.9319096Z   554 |   switch (d.getKind()) {
2025-09-19T02:23:43.9319657Z       |           ^~~~~~~~~~~
2025-09-19T02:23:43.9319928Z 1 error generated.
```

https://github.com/llvm/llvm-project/actions/runs/17846550129/job/50746815259?pr=157930#step:3:9257