### PR TITLE
[clang-tidy] Fix `bugprone-sizeof-expression` crash on arrays of dependent type

### DIFF
--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -378,7 +378,7 @@ void SizeofExpressionCheck::check(const MatchFinder::MatchResult &Result) {
     if (const auto *Type = dyn_cast<ArrayType>(SizeofArgTy)) {
       // check if the array element size is larger than one. If true,
       // the size of the array is higher than the number of elements
-      if (!getSizeOfType(Ctx, Type).isOne()) {
+      if (!getSizeOfType(Ctx, Type->getElementType().getTypePtr()).isOne()) {
         diag(SzOfExpr->getBeginLoc(),
              "suspicious usage of 'sizeof' in the loop")
             << SzOfExpr->getSourceRange();

--- a/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
+++ b/clang-tools-extra/clang-tidy/bugprone/SizeofExpressionCheck.cpp
@@ -378,8 +378,7 @@ void SizeofExpressionCheck::check(const MatchFinder::MatchResult &Result) {
     if (const auto *Type = dyn_cast<ArrayType>(SizeofArgTy)) {
       // check if the array element size is larger than one. If true,
       // the size of the array is higher than the number of elements
-      CharUnits SSize = Ctx.getTypeSizeInChars(Type->getElementType());
-      if (!SSize.isOne()) {
+      if (!getSizeOfType(Ctx, Type).isOne()) {
         diag(SzOfExpr->getBeginLoc(),
              "suspicious usage of 'sizeof' in the loop")
             << SzOfExpr->getSourceRange();

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -233,7 +233,7 @@ Changes in existing checks
 
 - Improved :doc:`bugprone-sizeof-expression
   <clang-tidy/checks/bugprone/sizeof-expression>` check by fixing
-  a crash on ``sizeof`` of an array of template type.
+  a crash on ``sizeof`` of an array of dependent type.
 
 - Improved :doc:`bugprone-tagged-union-member-count
   <clang-tidy/checks/bugprone/tagged-union-member-count>` by fixing a false

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -231,6 +231,10 @@ Changes in existing checks
   <clang-tidy/checks/bugprone/signed-char-misuse>` check by fixing
   false positives on C23 enums with the fixed underlying type of signed char.
 
+- Improved :doc:`bugprone-sizeof-expression
+  <clang-tidy/checks/bugprone/sizeof-expression>` check by fixing
+  a crash on ``sizeof`` of an array of template type.
+
 - Improved :doc:`bugprone-tagged-union-member-count
   <clang-tidy/checks/bugprone/tagged-union-member-count>` by fixing a false
   positive when enums or unions from system header files or the ``std``

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -1,4 +1,6 @@
-// RUN: %check_clang_tidy %s bugprone-sizeof-expression %t -- -config="{CheckOptions: {bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: true}}" --
+// RUN: %check_clang_tidy %s bugprone-sizeof-expression %t \
+// RUN:   -- -config="{CheckOptions: {bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: true}}" \
+// RUN:   -- -fno-delayed-template-parsing
 
 class C {
   int size() { return sizeof(this); }

--- a/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/bugprone/sizeof-expression.cpp
@@ -227,6 +227,13 @@ void loop_access_elements(int num, struct B b) {
   for(int i = 0, j = 0; i < sizeof(arr) && j < sizeof(buf); i++, j++) {}
 }
 
+template <typename T>
+void templated_array() {
+  T arr[10];
+  // CHECK-MESSAGES: :[[@LINE+1]]:23: warning: suspicious usage of 'sizeof' in the loop [bugprone-sizeof-expression]
+  for (int i = 0; i < sizeof(arr); ++i) {}
+}
+
 template <int T>
 int Foo() { int A[T]; return sizeof(T); }
 // CHECK-MESSAGES: :[[@LINE-1]]:30: warning: suspicious usage of 'sizeof(K)'


### PR DESCRIPTION
Fixes #158422.