### PR TITLE
[ELF] Add --print-gc-sections=<file>

### DIFF
--- a/lld/ELF/Config.h
+++ b/lld/ELF/Config.h
@@ -358,7 +358,7 @@ struct Config {
   bool optRemarksWithHotness;
   bool picThunk;
   bool pie;
-  bool printGcSections;
+  llvm::StringRef printGcSections;
   bool printIcfSections;
   bool printMemoryUsage;
   std::optional<uint64_t> randomizeSectionPadding;

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -1510,8 +1510,14 @@ static void readConfigs(Ctx &ctx, opt::InputArgList &args) {
   ctx.arg.pie = args.hasFlag(OPT_pie, OPT_no_pie, false);
   ctx.arg.printIcfSections =
       args.hasFlag(OPT_print_icf_sections, OPT_no_print_icf_sections, false);
-  ctx.arg.printGcSections =
-      args.hasFlag(OPT_print_gc_sections, OPT_no_print_gc_sections, false);
+  if (auto *arg =
+          args.getLastArg(OPT_print_gc_sections, OPT_no_print_gc_sections,
+                          OPT_print_gc_sections_eq)) {
+    if (arg->getOption().matches(OPT_print_gc_sections))
+      ctx.arg.printGcSections = "-";
+    else if (arg->getOption().matches(OPT_print_gc_sections_eq))
+      ctx.arg.printGcSections = arg->getValue();
+  }
   ctx.arg.printMemoryUsage = args.hasArg(OPT_print_memory_usage);
   ctx.arg.printArchiveStats = args.getLastArgValue(OPT_print_archive_stats);
   ctx.arg.printSymbolOrder = args.getLastArgValue(OPT_print_symbol_order);

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -533,8 +533,8 @@ template <class ELFT> void elf::markLive(Ctx &ctx) {
   std::error_code ec;
   raw_fd_ostream os = ctx.openAuxiliaryFile(ctx.arg.printGcSections, ec);
   if (ec) {
-    ErrAlways(ctx) << "--print-gc-sections=: cannot open "
-                   << ctx.arg.printGcSections << ": " << ec.message();
+    Err(ctx) << "cannot open --print-gc-sections= file "
+             << ctx.arg.printGcSections << ": " << ec.message();
     return;
   }
   for (InputSectionBase *sec : ctx.inputSections)

--- a/lld/ELF/MarkLive.cpp
+++ b/lld/ELF/MarkLive.cpp
@@ -528,10 +528,18 @@ template <class ELFT> void elf::markLive(Ctx &ctx) {
     MarkLive<ELFT, false>(ctx, 1).moveToMain();
 
   // Report garbage-collected sections.
-  if (ctx.arg.printGcSections)
-    for (InputSectionBase *sec : ctx.inputSections)
-      if (!sec->isLive())
-        Msg(ctx) << "removing unused section " << sec;
+  if (ctx.arg.printGcSections.empty())
+    return;
+  std::error_code ec;
+  raw_fd_ostream os = ctx.openAuxiliaryFile(ctx.arg.printGcSections, ec);
+  if (ec) {
+    ErrAlways(ctx) << "--print-gc-sections=: cannot open "
+                   << ctx.arg.printGcSections << ": " << ec.message();
+    return;
+  }
+  for (InputSectionBase *sec : ctx.inputSections)
+    if (!sec->isLive())
+      os << "removing unused section " << toStr(ctx, sec) << '\n';
 }
 
 template void elf::markLive<ELF32LE>(Ctx &);

--- a/lld/ELF/Options.td
+++ b/lld/ELF/Options.td
@@ -388,6 +388,9 @@ defm pie: B<"pie",
 defm print_gc_sections: B<"print-gc-sections",
     "List removed unused sections",
     "Do not list removed unused sections (default)">;
+def print_gc_sections_eq: JJ<"print-gc-sections=">,
+  HelpText<"List removed unused sections to <file>">,
+  MetaVarName<"<file>">;
 
 defm print_icf_sections: B<"print-icf-sections",
     "List identical folded sections",

--- a/lld/docs/ReleaseNotes.rst
+++ b/lld/docs/ReleaseNotes.rst
@@ -29,6 +29,9 @@ Non-comprehensive list of changes in this release
 ELF Improvements
 ----------------
 
+* ``--print-gc-sections=<file>`` prints garbage collection section listing to a file.
+  (`#159706 <https://github.com/llvm/llvm-project/pull/159706>`_)
+
 Breaking changes
 ----------------
 

--- a/lld/docs/ld.lld.1
+++ b/lld/docs/ld.lld.1
@@ -522,6 +522,8 @@ Don't use.
 
 .It Fl -print-gc-sections
 List removed unused sections.
+.It Fl -print-gc-sections Ns = Ns Ar file
+List removed unused sections to the specified file.
 .It Fl -print-icf-sections
 List identical folded sections.
 .It Fl -print-map

--- a/lld/test/ELF/gc-sections-print.s
+++ b/lld/test/ELF/gc-sections-print.s
@@ -16,6 +16,10 @@
 
 # NOPRINT-NOT: removing
 
+# RUN: not ld.lld %t --gc-sections --print-gc-sections=/ -o %t2 2>&1 | FileCheck --check-prefix=ERR %s
+
+# ERR: error: cannot open --print-gc-sections= file /: {{.*}}
+
 .globl _start
 .protected a, x, y
 _start:

--- a/lld/test/ELF/gc-sections-print.s
+++ b/lld/test/ELF/gc-sections-print.s
@@ -1,11 +1,16 @@
 # REQUIRES: x86
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
 # RUN: ld.lld %t --gc-sections --print-gc-sections -o %t2 2>&1 | FileCheck -check-prefix=PRINT %s
+# RUN: ld.lld %t --gc-sections --print-gc-sections=- -o %t2 2>&1 | FileCheck -check-prefix=PRINT %s
+# RUN: ld.lld %t --gc-sections --print-gc-sections=%t.txt
+# RUN: FileCheck --check-prefix=PRINT %s --input-file=%t.txt
 
 # PRINT:      removing unused section {{.*}}:(.text.x)
 # PRINT-NEXT: removing unused section {{.*}}:(.text.y)
 
-# RUN: ld.lld %t --gc-sections --print-gc-sections --no-print-gc-sections -o %t2 >& %t.log
+# RUN: rm %t.txt
+# RUN: ld.lld %t --gc-sections --print-gc-sections --print-gc-sections=%t.txt --no-print-gc-sections -o %t2 >& %t.log
+# RUN: not ls %t.txt
 # RUN: echo >> %t.log
 # RUN: FileCheck -check-prefix=NOPRINT %s < %t.log
 


### PR DESCRIPTION
Add `--print-gc-sections=<file>` to redirect garbage collection section
listing to a file, avoiding contamination of stdout with other linker
output. mold has recently added the option.
GNU ld feature request: https://sourceware.org/bugzilla/show_bug.cgi?id=33331
