### PR TITLE
Greedy: Simplify collectHintInfo using MachineOperands. NFCI.

### DIFF
--- a/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -2395,7 +2395,7 @@ void RAGreedy::collectHintInfo(Register Reg, HintsInfo &Out) {
       continue;
 
     // Look for the other end of the copy.
-    const MachineOperand &OtherOpnd = Instr.getOperand(1 - Opnd.getOperandNo());
+    const MachineOperand &OtherOpnd = Instr.getOperand(Opnd.isDef());
     Register OtherReg = OtherOpnd.getReg();
     if (OtherReg == Reg)
       continue;

--- a/llvm/lib/CodeGen/RegAllocGreedy.cpp
+++ b/llvm/lib/CodeGen/RegAllocGreedy.cpp
@@ -2389,22 +2389,18 @@ void RAGreedy::initializeCSRCost() {
 void RAGreedy::collectHintInfo(Register Reg, HintsInfo &Out) {
   const TargetRegisterClass *RC = MRI->getRegClass(Reg);
 
-  for (const MachineInstr &Instr : MRI->reg_nodbg_instructions(Reg)) {
-    if (!Instr.isCopy())
+  for (const MachineOperand &Opnd : MRI->reg_nodbg_operands(Reg)) {
+    const MachineInstr &Instr = *Opnd.getParent();
+    if (!Instr.isCopy() || Opnd.isImplicit())
       continue;
 
     // Look for the other end of the copy.
-    Register OtherReg = Instr.getOperand(0).getReg();
-    unsigned OtherSubReg = Instr.getOperand(0).getSubReg();
-    unsigned SubReg = Instr.getOperand(1).getSubReg();
-
-    if (OtherReg == Reg) {
-      OtherReg = Instr.getOperand(1).getReg();
-      OtherSubReg = Instr.getOperand(1).getSubReg();
-      SubReg = Instr.getOperand(0).getSubReg();
-      if (OtherReg == Reg)
-        continue;
-    }
+    const MachineOperand &OtherOpnd = Instr.getOperand(1 - Opnd.getOperandNo());
+    Register OtherReg = OtherOpnd.getReg();
+    if (OtherReg == Reg)
+      continue;
+    unsigned OtherSubReg = OtherOpnd.getSubReg();
+    unsigned SubReg = Opnd.getSubReg();
 
     // Get the current assignment.
     MCRegister OtherPhysReg =


### PR DESCRIPTION
If a COPY uses Reg but only in an implicit operand then the new
implementation ignores it but the old implementation would have treated
it as a copy of Reg. Probably this case never occurs in practice. Other
than that, this patch is NFC.
