### PR TITLE
Fix perf-helper.py

### DIFF
--- a/clang/utils/perf-training/perf-helper.py
+++ b/clang/utils/perf-training/perf-helper.py
@@ -238,6 +238,7 @@ def get_cc1_command_for_args(cmd, env):
             or ln.startswith("LLVM Profile Note")
             or ln.startswith(" (in-process)")
             or ln.startswith("Configuration file:")
+            or ln.startswith("Build config:")
             or " version " in ln
         ):
             continue


### PR DESCRIPTION
When build with assertions, there will be an output like the following that needs to be filtered out, similar to the other ones.

`'Build config: +assertions'`