### PR TITLE
[cross-project-tests] Add a couple of missing testing dependencies

### DIFF
--- a/cross-project-tests/CMakeLists.txt
+++ b/cross-project-tests/CMakeLists.txt
@@ -21,9 +21,11 @@ set(CROSS_PROJECT_TEST_DEPS
   count
   llvm-ar
   llvm-config
+  llvm-dis
   llvm-dwarfdump
   llvm-objdump
   not
+  obj2yaml
   split-file
   )
 


### PR DESCRIPTION
Added testing dependencies for `llvm-dis` and `obj2yaml`.