### PR TITLE
[clang][bytecode] Typecheck called function pointers more thorougly

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -446,8 +446,6 @@ Context::getOverridingFunction(const CXXRecordDecl *DynamicDecl,
 
 const Function *Context::getOrCreateFunction(const FunctionDecl *FuncDecl) {
   assert(FuncDecl);
-  FuncDecl = FuncDecl->getMostRecentDecl();
-
   if (const Function *Func = P->getFunction(FuncDecl))
     return Func;
 

--- a/clang/lib/AST/ByteCode/Interp.cpp
+++ b/clang/lib/AST/ByteCode/Interp.cpp
@@ -1750,9 +1750,8 @@ bool CallPtr(InterpState &S, CodePtr OpPC, uint32_t ArgSize,
   const Pointer &Ptr = S.Stk.pop<Pointer>();
 
   if (Ptr.isZero()) {
-    const auto *E = cast<CallExpr>(S.Current->getExpr(OpPC));
-    S.FFDiag(E, diag::note_constexpr_null_callee)
-        << const_cast<Expr *>(E->getCallee()) << E->getSourceRange();
+    S.FFDiag(S.Current->getSource(OpPC), diag::note_constexpr_null_callee)
+        << const_cast<Expr *>(CE->getCallee()) << CE->getSourceRange();
     return false;
   }
 
@@ -1776,6 +1775,14 @@ bool CallPtr(InterpState &S, CodePtr OpPC, uint32_t ArgSize,
   if (F->hasNonNullAttr()) {
     if (!CheckNonNullArgs(S, OpPC, F, CE, ArgSize))
       return false;
+  }
+
+  // Can happen when casting function pointers around.
+  QualType CalleeType = CE->getCallee()->getType();
+  if (CalleeType->isPointerType() &&
+      !S.getASTContext().hasSameFunctionTypeIgnoringExceptionSpec(
+          F->getDecl()->getType(), CalleeType->getPointeeType())) {
+    return false;
   }
 
   assert(ArgSize >= F->getWrittenArgSize());

--- a/clang/test/AST/ByteCode/functions.cpp
+++ b/clang/test/AST/ByteCode/functions.cpp
@@ -1,9 +1,9 @@
-// RUN: %clang_cc1 -fexperimental-new-constant-interpreter -pedantic -verify=expected,both %s
-// RUN: %clang_cc1 -std=c++14 -fexperimental-new-constant-interpreter -pedantic -verify=expected,both %s
-// RUN: %clang_cc1 -std=c++20 -fexperimental-new-constant-interpreter -pedantic -verify=expected,both %s
-// RUN: %clang_cc1 -pedantic -verify=ref,both %s
-// RUN: %clang_cc1 -pedantic -std=c++14 -verify=ref,both %s
-// RUN: %clang_cc1 -pedantic -std=c++20 -verify=ref,both %s
+// RUN: %clang_cc1            -pedantic -verify=expected,both %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++14 -pedantic -verify=expected,both %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1 -std=c++20 -pedantic -verify=expected,both %s -fexperimental-new-constant-interpreter
+// RUN: %clang_cc1            -pedantic -verify=ref,both      %s
+// RUN: %clang_cc1 -std=c++14 -pedantic -verify=ref,both      %s
+// RUN: %clang_cc1 -std=c++20 -pedantic -verify=ref,both      %s
 
 #define fold(x) (__builtin_constant_p(0) ? (x) : (x))
 
@@ -672,10 +672,8 @@ namespace FunctionCast {
   constexpr int test4 = fold(IntFn(DoubleFn(f)))();
   constexpr int test5 = IntFn(fold(DoubleFn(f)))(); // both-error {{constant expression}} \
                                                     // both-note {{cast that performs the conversions of a reinterpret_cast is not allowed in a constant expression}}
-  // FIXME: Interpreter is less strict here.
-  constexpr int test6 = fold(IntPtrFn(f2))() == nullptr; // ref-error {{constant expression}}
-  // FIXME: The following crashes interpreter
-  // constexpr int test6 = fold(IntFn(f3)());
+  constexpr int test6 = fold(IntPtrFn(f2))() == nullptr; // both-error {{constant expression}}
+  constexpr int test7 = fold(IntFn(f3)()); // both-error {{must be initialized by a constant expression}}
 }
 
 #if __cplusplus >= 202002L


### PR DESCRIPTION
Fix two older FIXME items from the `functions.cpp` test.