### PR TITLE
[llvm][test][CGPluginTest] Add back missing TargetParser dependency

### DIFF
--- a/llvm/unittests/CodeGen/CGPluginTest/CMakeLists.txt
+++ b/llvm/unittests/CodeGen/CGPluginTest/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   Core
   MC
   Target
+  TargetParser
   CodeGen
   )
 


### PR DESCRIPTION
Din't seem to be used, but is.

    [737/738] Linking CXX executable unittests/CodeGen/CGPluginTest/CGPluginTest
    FAILED: unittests/CodeGen/CGPluginTest/CGPluginTest
    : && /usr/bin/c++ -fPIC -fno-semantic-interposition -fvisibility-inlines-hidden -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-uninitialized -Wno-nonnull -Wno-class-memaccess -Wno-redundant-move -Wno-pessimizing-move -Wno-array-bounds -Wno-stringop-overread -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wsuggest-override -Wno-comment -Wno-misleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -Wl,--export-dynamic   -Wl,--gc-sections unittests/CodeGen/CGPluginTest/CMakeFiles/CGPluginTest.dir/PluginTest.cpp.o unittests/CodeGen/CGPluginTest/CMakeFiles/CGPluginTest.dir/Plugin/CodeGenTestPass.cpp.o -o unittests/CodeGen/CGPluginTest/CGPluginTest  -Wl,-rpath,/home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib  lib/libLLVMX86CodeGen.so.22.0git  lib/libLLVMX86AsmParser.so.22.0git  lib/libLLVMX86De
     sc.so.22.0git  lib/libLLVMX86Disassembler.so.22.0git  lib/libLLVMX86Info.so.22.0git  lib/libLLVMAMDGPUCodeGen.so.22.0git  lib/libLLVMAMDGPUAsmParser.so.22.0git  lib/libLLVMAMDGPUDisassembler.so.22.0git  lib/libllvm_gtest_main.so.22.0git  lib/libLLVMTestingSupport.so.22.0git  lib/libLLVMCodeGen.so.22.0git  lib/libLLVMTarget.so.22.0git  lib/libLLVMAMDGPUDesc.so.22.0git  lib/libLLVMAMDGPUInfo.so.22.0git  lib/libLLVMAMDGPUUtils.so.22.0git  lib/libLLVMCore.so.22.0git  lib/libLLVMMC.so.22.0git  lib/libllvm_gtest.so.22.0git  lib/libLLVMSupport.so.22.0git  -Wl,-rpath-link,/home/botworker/builds/openmp-offload-amdgpu-runtime-2/llvm.build/lib && :
    /usr/bin/ld: unittests/CodeGen/CGPluginTest/CMakeFiles/CGPluginTest.dir/PluginTest.cpp.o: undefined reference to symbol '_ZN4llvm6TripleC1ERKNS_5TwineES3_S3_'

Fixes: 4e1c996674cc340f290b0a528e2038e76494d8d4