### PR TITLE
[LLDB][PDB] Run UDT layout test with native PDB too

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/udt-layout.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/udt-layout.test
@@ -1,0 +1,129 @@
+# REQUIRES: target-windows
+
+# Test UDT layout reconstruction
+# RUN: split-file %s %t
+# RUN: %build --compiler=clang-cl -o %t.exe -- %t/main.cpp
+# RUN: %lldb -f %t.exe -s %t/commands.input 2>&1 | FileCheck %s
+
+#--- main.cpp
+
+// this is from the DIA plugin (UdtLayoutTest.cpp)
+struct A {
+  explicit A(int u) { _u._u3 = u; }
+  A(const A &) = default;
+  virtual ~A() = default;
+
+private:
+  union U {
+    char _u1;
+    short _u2;
+    int _u3;
+  };
+
+  A::U _u;
+};
+
+#pragma pack(push, 1)
+template <int I> struct B : public virtual A {
+  B(char a, unsigned short b, int c) : A(a + b + c), _a(a), _b(b), _c(c) {}
+
+private:
+  char _a;
+  unsigned short : 3;
+  unsigned short _b : 6;
+  unsigned short : 4;
+  int _c;
+};
+#pragma pack(pop)
+
+#pragma pack(push, 16)
+class C : private virtual B<0>, public virtual B<1>, private B<2>, public B<3> {
+public:
+  C(char x, char y, char z)
+      : A(x - y + z), B<0>(x, y, z), B<1>(x * 2, y * 2, z * 2),
+        B<2>(x * 3, y * 3, z * 3), B<3>(x * 4, y * 4, z * 4), _x(x * 5),
+        _y(y * 5), _z(z * 5) {}
+
+  static int abc;
+
+private:
+  int _x;
+  short _y;
+  char _z;
+};
+int C::abc = 123;
+#pragma pack(pop)
+
+class List {
+public:
+  List() = default;
+  List(List *p, List *n, C v) : Prev(p), Next(n), Value(v) {}
+
+private:
+  List *Prev = nullptr;
+  List *Next = nullptr;
+  C Value{1, 2, 3};
+};
+
+int main() {
+  List ls[16];
+  return 0; // break here
+}
+
+#--- commands.input
+
+settings set target.max-children-depth 10
+br set -p "break here"
+run
+target variable
+frame variable
+quit
+
+# CHECK: (int) ::C::abc = 123
+
+# CHECK:      (List[16]) ls = {
+# CHECK:        [15] = {
+# CHECK-NEXT:     Prev = nullptr
+# CHECK-NEXT:     Next = nullptr
+# CHECK-NEXT:     Value = {
+# CHECK-NEXT:       B<2> = {
+# CHECK-NEXT:         A = {
+# CHECK-NEXT:           _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)
+# CHECK-NEXT:         }
+# CHECK-NEXT:         _a = '\x03'
+# CHECK-NEXT:         _b = 6
+# CHECK-NEXT:         _c = 9
+# CHECK-NEXT:       }
+# CHECK-NEXT:       B<3> = {
+# CHECK-NEXT:         A = {
+# CHECK-NEXT:           _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)
+# CHECK-NEXT:         }
+# CHECK-NEXT:         _a = '\x04'
+# CHECK-NEXT:         _b = 8
+# CHECK-NEXT:         _c = 12
+# CHECK-NEXT:       }
+# CHECK-NEXT:       A = {
+# CHECK-NEXT:         _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)
+# CHECK-NEXT:       }
+# CHECK-NEXT:       B<0> = {
+# CHECK-NEXT:         A = {
+# CHECK-NEXT:           _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)
+# CHECK-NEXT:         }
+# CHECK-NEXT:         _a = '\x01'
+# CHECK-NEXT:         _b = 2
+# CHECK-NEXT:         _c = 3
+# CHECK-NEXT:       }
+# CHECK-NEXT:       B<1> = {
+# CHECK-NEXT:         A = {
+# CHECK-NEXT:           _u = (_u1 = '\x02', _u2 = 2, _u3 = 2)
+# CHECK-NEXT:         }
+# CHECK-NEXT:         _a = '\x02'
+# CHECK-NEXT:         _b = 4
+# CHECK-NEXT:         _c = 6
+# CHECK-NEXT:       }
+# CHECK-NEXT:       _x = 5
+# CHECK-NEXT:       _y = 10
+# CHECK-NEXT:       _z = '\x0f'
+# CHECK-NEXT:     }
+# CHECK-NEXT:   }
+# CHECK-NEXT: }

--- a/lldb/test/Shell/SymbolFile/PDB/udt-layout.test
+++ b/lldb/test/Shell/SymbolFile/PDB/udt-layout.test
@@ -1,4 +1,4 @@
-REQUIRES: target-windows, lld
+REQUIRES: target-windows, lld, diasdk
 RUN: %build --compiler=clang-cl --output=%t.exe %S/Inputs/UdtLayoutTest.cpp
 RUN: %lldb -b -s %S/Inputs/UdtLayoutTest.script -- %t.exe | FileCheck %s
 


### PR DESCRIPTION
This test was failing with the native plugin due to two reasons:

1. The static `C::abc` was printed as `(int) ::C::abc = 123`
2. The order of the base classes of [`C` (`List::Value`)](https://github.com/llvm/llvm-project/blob/b7e4edca3d56ec87f719c202f5397b245595f7cc/lldb/test/Shell/SymbolFile/PDB/Inputs/UdtLayoutTest.cpp#L30) is different between DIA and the native plugin. I don't know how the order in the DIA plugin is determined - it prints `B<0>`, `B<1>`, `B<2>`, `B<3>`, `A`. The native plugin follows the order of the bases in memory and prints `B<2>`, `B<3>`, `A`, `B<0>`, `B<1>` (last three are the virtual bases).
    <details><summary>Class layout of C</summary>
    
    ```
    class C size(88):
            +---
    0       | +--- (base class B<2>)
    0       | | {vbptr}
    8       | | _a
    9.      | | _b (bitstart=3,nbits=6)
    11      | | _c
            | +---
    15      | +--- (base class B<3>)
    15      | | {vbptr}
    23      | | _a
    24.     | | _b (bitstart=3,nbits=6)
    26      | | _c
            | +---
            | <alignment member> (size=2)
    32      | _x
    36      | _y
    38      | _z
            | <alignment member> (size=1)
            | <alignment member> (size=2)
            +---
            +--- (virtual base A)
    40      | {vfptr}
    48      | U _u
            | <alignment member> (size=4)
            +---
            +--- (virtual base B<0>)
    56      | {vbptr}
    64      | _a
    65.     | _b (bitstart=3,nbits=6)
    67      | _c
            +---
            +--- (virtual base B<1>)
    71      | {vbptr}
    79      | _a
    80.     | _b (bitstart=3,nbits=6)
    82      | _c
            +---
    ```
    </details>

I split the tests for the plugins for better readability. 