### PR TITLE
[modules] Fix assert on Clang module import from the global module fragment.

### DIFF
--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -772,7 +772,12 @@ void Sema::BuildModuleInclude(SourceLocation DirectiveLoc, Module *Mod) {
     Module *ThisModule = PP.getHeaderSearchInfo().lookupModule(
         getLangOpts().CurrentModule, DirectiveLoc, false, false);
     (void)ThisModule;
-    assert(ThisModule && "was expecting a module if building one");
+    // For named modules, the current module name is not known while parsing the
+    // global module fragment and lookupModule may return null.
+    assert((getLangOpts().getCompilingModule() ==
+                LangOptionsBase::CMK_ModuleInterface ||
+            ThisModule) &&
+           "was expecting a  module if building a Clang module");
   }
 }
 

--- a/clang/lib/Sema/SemaModule.cpp
+++ b/clang/lib/Sema/SemaModule.cpp
@@ -777,7 +777,7 @@ void Sema::BuildModuleInclude(SourceLocation DirectiveLoc, Module *Mod) {
     assert((getLangOpts().getCompilingModule() ==
                 LangOptionsBase::CMK_ModuleInterface ||
             ThisModule) &&
-           "was expecting a  module if building a Clang module");
+           "was expecting a module if building a Clang module");
   }
 }
 

--- a/clang/test/Modules/named-module-with-fmodules.cppm
+++ b/clang/test/Modules/named-module-with-fmodules.cppm
@@ -1,0 +1,24 @@
+// Checks that Clang modules can be imported from within the global module 
+// fragment of a named module interface unit.
+// Fixes #159768.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t
+// RUN: split-file %s %t
+
+// RUN: %clang -std=c++23 -fmodules -fmodule-map-file=%t/module.modulemap \
+// RUN:   --precompile %t/A.cppm -o %t/A.pcm
+
+//--- module.modulemap
+module foo { header "foo.h" }
+
+//--- foo.h
+// empty
+
+//--- A.cppm
+module;
+#include "foo.h"
+export module A;
+
+export auto A() -> int { return 42; }
+


### PR DESCRIPTION
Fixes #159768.

When building a named module interface with `-fmodules` enabled, importing a Clang module from inside the global module fragment causes Clang to crash only on assertion builds.
This fixes the assert and adds a test.