### PR TITLE
[Offload] Allow building liboffload without libomptarget

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -209,7 +209,7 @@ foreach(entry ${runtimes})
   string(REPLACE "-" "_" canon_name ${name})
   string(TOUPPER ${canon_name} canon_name)
   list(APPEND prefixes ${canon_name})
-  if (${canon_name} STREQUAL "OPENMP")
+  if (${canon_name} STREQUAL "OPENMP" OR ${canon_name} STREQUAL "OFFLOAD")
     list(APPEND prefixes "LIBOMP" "LIBOMPTARGET")
   endif()
   # Many compiler-rt options start with SANITIZER_ and DARWIN_ rather than

--- a/offload/CMakeLists.txt
+++ b/offload/CMakeLists.txt
@@ -24,6 +24,15 @@ elseif(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
   return()
 endif()
 
+set(OPENMP_ENABLED OFF)
+if("openmp" IN_LIST LLVM_ENABLE_RUNTIMES)
+  set(OPENMP_ENABLED ON)
+endif()
+set(LIBOFFLOAD_ENABLED OFF)
+if("offload" IN_LIST LLVM_ENABLE_RUNTIMES)
+  set(OFFLOAD_ENABLED ON)
+endif()
+
 set(OFFLOAD_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(OPENMP_STANDALONE_BUILD)
@@ -376,7 +385,9 @@ add_subdirectory(tools)
 add_subdirectory(docs)
 
 # Build target agnostic offloading library.
+if(OPENMP_ENABLED)
 add_subdirectory(libomptarget)
+endif()
 
 add_subdirectory(liboffload)
 

--- a/offload/test/CMakeLists.txt
+++ b/offload/test/CMakeLists.txt
@@ -33,6 +33,7 @@ if(TARGET omp)
   set(OMP_DEPEND omp)
 endif()
 
+if(OPENMP_ENABLED)
 string(REGEX MATCHALL "([^\ ]+\ |[^\ ]+$)" SYSTEM_TARGETS "${LIBOMPTARGET_SYSTEM_TARGETS}")
 foreach(CURRENT_TARGET IN LISTS SYSTEM_TARGETS)
   string(STRIP "${CURRENT_TARGET}" CURRENT_TARGET)
@@ -63,6 +64,7 @@ add_offload_testsuite(check-offload
   EXCLUDE_FROM_CHECK_ALL
   DEPENDS llvm-offload-device-info omptarget ${OMP_DEPEND} ${LIBOMPTARGET_TESTED_PLUGINS}
   ARGS ${LIBOMPTARGET_LIT_ARG_LIST})
+endif()
 
 # Add liboffload unit tests - the test binary will run on all available devices
 configure_lit_site_cfg(

--- a/offload/tools/CMakeLists.txt
+++ b/offload/tools/CMakeLists.txt
@@ -13,4 +13,7 @@ macro(add_openmp_tool_symlink name)
 endmacro()
 
 add_subdirectory(deviceinfo)
+
+if(OPENMP_ENABLED)
 add_subdirectory(kernelreplay)
+endif()


### PR DESCRIPTION
This patch makes `LLVM_ENABLE_RUNTIMES="offload"` build. The
target `libomptarget` will not be available, but `LLVMOffload` will
still be built.

The check target `check-offload` is not available (it has a mix of
both liboffload and libomptarget), but `check-offload-unit` is and
passes.
