### PR TITLE
Allow setting breakpoints in objc++ files

### DIFF
--- a/lldb/tools/lldb-dap/package.json
+++ b/lldb/tools/lldb-dap/package.json
@@ -348,6 +348,9 @@
         "language": "objective-c"
       },
       {
+        "language": "objective-cpp"
+      },
+      {
         "language": "objectpascal"
       },
       {
@@ -375,6 +378,7 @@
           "fortran-modern",
           "nim",
           "objective-c",
+          "objective-cpp",
           "objectpascal",
           "pascal",
           "rust",


### PR DESCRIPTION
Moving this here from https://github.com/llvm/vscode-lldb/pull/3
> With the released verson of the lldb-dap extension, I have to set breakpoints in objcpp (*.mm) files via the debug console (b Myfile.mm:123) or change the detected file type in VSCode to objc or cpp. VSCode should allow setting breakpoints in objcpp files with vscode-lldb with this change to the package.json