### PR TITLE
[LLVM] Exclude specialized lit test suites from check-all

### DIFF
--- a/llvm/test/FileCheck/CMakeLists.txt
+++ b/llvm/test/FileCheck/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lit_testsuite(check-llvm-filecheck "Running lit suite for FileCheck"
   ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
   DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
   )

--- a/llvm/test/TableGen/CMakeLists.txt
+++ b/llvm/test/TableGen/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lit_testsuite(check-llvm-tablegen "Running lit suite for TableGen"
   ${CMAKE_CURRENT_BINARY_DIR}
+  EXCLUDE_FROM_CHECK_ALL
   DEPENDS ${LLVM_TEST_DEPENDS_COMMON}
   DEPENDS llvm-tblgen
   )


### PR DESCRIPTION
Exclude specialized test suites from `check-all`. Without that, FileCheck and TableGen tests are run twice, and then those that use `%t` seem to fail

```
FAIL: LLVM :: TableGen/RuntimeLibcallEmitter-conflict-warning.td (70661 of 87819)
******************** TEST 'LLVM :: TableGen/RuntimeLibcallEmitter-conflict-warning.td' FAILED ********************
Exit Code: 2
********************
PASS: LLVM :: TableGen/RuntimeLibcallEmitter-conflict-warning.td (70665 of 87819
```

Note: Same test with 2 different numbers, so its run twice and when that happens concurrently, the %t file is shared among the 2 instances causing bad interaction and test failure.
