### PR TITLE
[test] llvm-ar: Adjust 2 tests to pass again after inadvertent unXFAIL for some target triples

### DIFF
--- a/llvm/test/tools/llvm-ar/extract.test
+++ b/llvm/test/tools/llvm-ar/extract.test
@@ -1,5 +1,4 @@
 ## Test extract operation.
-# XFAIL: target={{.*}}-darwin{{.*}}
 
 # RUN: rm -rf %t && mkdir -p %t/extracted/
 
@@ -9,7 +8,7 @@
 
 # RUN: echo filea > %t/a.txt
 # RUN: echo fileb > %t/b.txt
-# RUN: llvm-ar rc %t/archive.a %t/a.txt %t/b.txt
+# RUN: llvm-ar rc --format=gnu %t/archive.a %t/a.txt %t/b.txt
 
 ## Single member:
 # RUN: cd %t/extracted && llvm-ar xv %t/archive.a a.txt | FileCheck %s --check-prefix=A

--- a/llvm/test/tools/llvm-ar/print.test
+++ b/llvm/test/tools/llvm-ar/print.test
@@ -1,12 +1,11 @@
 ## Test Print output
-# XFAIL: target={{.*}}-darwin{{.*}}
 
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: echo file1 > %t/1.txt
 # RUN: echo file2 > %t/2.txt
 # RUN: echo file3 > %t/3.txt
 
-# RUN: llvm-ar -rc %t/archive.a %t/1.txt %t/2.txt %t/3.txt
+# RUN: llvm-ar -rc --format=gnu %t/archive.a %t/1.txt %t/2.txt %t/3.txt
 
 ## Print empty archive:
 # RUN: llvm-ar --format=gnu  cr %t/empty.a


### PR DESCRIPTION
The problem with the current `target={{.*}}-darwin{{.*}}` XFAIL condition (changed in https://github.com/llvm/llvm-project/pull/130144) is that the Swift build script uses Apple platform names like 'macosx', not 'darwin', for the LLVM target triple, e.g. `arm64-apple-macosx13.0`.

These tests appear to have been originally XFAILed because the default format on macOS (darwin) adds newlines as padding to align members. See: https://github.com/llvm/llvm-project/blob/ee8394d9469a2946ffe2e7d192c593ecf3f93098/llvm/lib/Object/ArchiveWriter.cpp#L897-L904

Use `--format=gnu` to cope with the differences in the output and reenable the tests.

rdar://157213658