### PR TITLE
[lldb] install lldb-tblgen by default to ease cross-compilation (one-liner)

### DIFF
--- a/lldb/utils/TableGen/CMakeLists.txt
+++ b/lldb/utils/TableGen/CMakeLists.txt
@@ -8,6 +8,7 @@ if (NOT DEFINED LLDB_TABLEGEN_EXE)
     set(LLVM_LINK_COMPONENTS Support)
 
     add_tablegen(lldb-tblgen LLDB
+      DESTINATION "${CMAKE_INSTALL_BINDIR}"
       LLDBOptionDefEmitter.cpp
       LLDBPropertyDefEmitter.cpp
       LLDBTableGen.cpp


### PR DESCRIPTION
Right now, cross-building `lldb` means either installing a native `lldb-tblgen` by hand (non-trivial, as CMake is painful) or first building all of native clang because of how the CMake rules work, which is not fun.

In keeping with the pattern established by llvm-tblgen and clang-tblgen, install lldb-tblgen to ease cross-compilation.