### PR TITLE
[lldb] Fix Linux build when LLDB_ENABLE_PYTHON is OFF

### DIFF
--- a/lldb/cmake/modules/LLDBConfig.cmake
+++ b/lldb/cmake/modules/LLDBConfig.cmake
@@ -191,6 +191,15 @@ else()
   # Even if Python scripting is disabled, we still need a Python interpreter to
   # build, for example to generate SBLanguages.h.
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+  # Remove lldb-python-scripts from distribution components.
+  # LLVM_DISTRIBUTION_COMPONENTS is set in a cache where LLDB_ENABLE_PYTHON does
+  # not yet have a value. We have to touch up LLVM_DISTRIBUTION_COMPONENTS after
+  # the fact.
+  if(LLVM_DISTRIBUTION_COMPONENTS)
+    list(REMOVE_ITEM LLVM_DISTRIBUTION_COMPONENTS lldb-python-scripts)
+    set(LLVM_DISTRIBUTION_COMPONENTS ${LLVM_DISTRIBUTION_COMPONENTS} CACHE STRING "" FORCE)
+  endif()
 endif()
 
 if (LLVM_EXTERNAL_CLANG_SOURCE_DIR)


### PR DESCRIPTION
Remove 'lldb-python-scripts' from LLVM_DISTRIBUTION_COMPONENTS when Python scripting is disabled. Otherwise we get

```
Specified distribution component 'lldb-python-scripts' doesn't have an install target
```