### PR TITLE
[lld-link] Do not assert when reporting error about non-thin archive

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -405,8 +405,12 @@ void LinkerDriver::enqueueArchiveMember(const Archive::Child &c,
                                         StringRef parentName) {
 
   auto reportBufferError = [=](Error &&e) {
+    StringRef childName =
+      CHECK(c.getName(),
+            "could not get child name for archive " + parentName +
+            " while loading symbol " + toCOFFString(ctx, sym));
     Fatal(ctx) << "could not get the buffer for the member defining symbol "
-               << &sym << ": " << parentName << "(" << check(c.getName())
+               << &sym << ": " << parentName << "(" << childName
                << "): " << std::move(e);
   };
 

--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -404,9 +404,9 @@ void LinkerDriver::enqueueArchiveMember(const Archive::Child &c,
                                         const Archive::Symbol &sym,
                                         StringRef parentName) {
 
-  auto reportBufferError = [=](Error &&e, StringRef childName) {
+  auto reportBufferError = [=](Error &&e) {
     Fatal(ctx) << "could not get the buffer for the member defining symbol "
-               << &sym << ": " << parentName << "(" << childName
+               << &sym << ": " << parentName << "(" << check(c.getName())
                << "): " << std::move(e);
   };
 
@@ -414,7 +414,7 @@ void LinkerDriver::enqueueArchiveMember(const Archive::Child &c,
     uint64_t offsetInArchive = c.getChildOffset();
     Expected<MemoryBufferRef> mbOrErr = c.getMemoryBufferRef();
     if (!mbOrErr)
-      reportBufferError(mbOrErr.takeError(), check(c.getFullName()));
+      reportBufferError(mbOrErr.takeError());
     MemoryBufferRef mb = mbOrErr.get();
     enqueueTask([=]() {
       llvm::TimeTraceScope timeScope("Archive: ", mb.getBufferIdentifier());
@@ -433,7 +433,7 @@ void LinkerDriver::enqueueArchiveMember(const Archive::Child &c,
   enqueueTask([=]() {
     auto mbOrErr = future->get();
     if (mbOrErr.second)
-      reportBufferError(errorCodeToError(mbOrErr.second), childName);
+      reportBufferError(errorCodeToError(mbOrErr.second));
     llvm::TimeTraceScope timeScope("Archive: ",
                                    mbOrErr.first->getBufferIdentifier());
     ctx.driver.addThinArchiveBuffer(takeBuffer(std::move(mbOrErr.first)),


### PR DESCRIPTION
Follow-up to https://reviews.llvm.org/D57974, which added calls to Archive::Child::getFullName() to produce strings in errors.

But getFullName() is only valid on thin archives, and should only be used to open the file the archive points to. For diagnostics, getName() is better: It works for both thin and non-thin files, and it doesn't make a very long string for thin files. And we already prepend the name of the parent archive file anyways.