### PR TITLE
[OpenMP][NFC] Clean up a bunch of warnings and clang-tidy messages

### DIFF
--- a/offload/plugins-nextgen/cuda/src/rtl.cpp
+++ b/offload/plugins-nextgen/cuda/src/rtl.cpp
@@ -160,15 +160,15 @@ struct CUDAKernelTy : public GenericKernelTy {
   /// Return maximum block size for maximum occupancy
   Expected<uint64_t> maxGroupSize(GenericDeviceTy &,
                                   uint64_t DynamicMemSize) const override {
-    int minGridSize;
-    int maxBlockSize;
+    int MinGridSize;
+    int MaxBlockSize;
     auto Res = cuOccupancyMaxPotentialBlockSize(
-        &minGridSize, &maxBlockSize, Func, NULL, DynamicMemSize, INT_MAX);
+        &MinGridSize, &MaxBlockSize, Func, NULL, DynamicMemSize, INT_MAX);
     if (auto Err = Plugin::check(
             Res, "error in cuOccupancyMaxPotentialBlockSize: %s")) {
       return Err;
     }
-    return maxBlockSize;
+    return MaxBlockSize;
   }
 
 private:

--- a/openmp/device/include/State.h
+++ b/openmp/device/include/State.h
@@ -327,6 +327,8 @@ private:
   Ty Val;
   bool Active;
 };
+template <typename VTy, typename Ty>
+ValueRAII(VTy &, Ty, Ty, bool, IdentTy *, bool) -> ValueRAII<VTy, Ty>;
 
 /// TODO
 inline state::Value<uint32_t, state::VK_RunSchedChunk> RunSchedChunk;

--- a/openmp/device/src/Misc.cpp
+++ b/openmp/device/src/Misc.cpp
@@ -23,7 +23,7 @@ namespace impl {
 /// Lookup a device-side function using a host pointer /p HstPtr using the table
 /// provided by the device plugin. The table is an ordered pair of host and
 /// device pointers sorted on the value of the host pointer.
-void *indirectCallLookup(void *HstPtr) {
+static void *indirectCallLookup(void *HstPtr) {
   if (!HstPtr)
     return nullptr;
 
@@ -114,6 +114,7 @@ void omp_free(void *ptr, omp_allocator_handle_t allocator) {
   case omp_high_bw_mem_alloc:
   case omp_low_lat_mem_alloc:
     free(ptr);
+    return;
   case omp_null_allocator:
   default:
     return;

--- a/openmp/device/src/Synchronization.cpp
+++ b/openmp/device/src/Synchronization.cpp
@@ -57,8 +57,6 @@ uint32_t atomicInc(uint32_t *A, uint32_t V, atomic::OrderingTy Ordering,
     ScopeSwitch(ORDER)
 
   switch (Ordering) {
-  default:
-    __builtin_unreachable();
     Case(atomic::relaxed);
     Case(atomic::acquire);
     Case(atomic::release);

--- a/openmp/tools/omptest/src/OmptAssertEvent.cpp
+++ b/openmp/tools/omptest/src/OmptAssertEvent.cpp
@@ -24,9 +24,6 @@ const char *omptest::to_string(ObserveState State) {
     return "Always";
   case ObserveState::Never:
     return "Never";
-  default:
-    assert(false && "Requested string representation for unknown ObserveState");
-    return "UNKNOWN";
   }
 }
 


### PR DESCRIPTION
Summary:
I made the GPU flags accept more of the default LLVM warnings, which
triggered some new cases. Clean those up and fix some other ones while
I'm at it.
