### PR TITLE
[bazel][AArch64] Port #156364: fix tablegen args

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -2224,7 +2224,6 @@ llvm_target_lib_list = [lib for lib in [
             "lib/Target/AArch64/AArch64GenSubtargetInfo.inc": ["-gen-subtarget"],
             "lib/Target/AArch64/AArch64GenDisassemblerTables.inc": [
                 "-gen-disassembler",
-                "-ignore-non-decodable-operands",
             ],
             "lib/Target/AArch64/AArch64GenSystemOperands.inc": ["-gen-searchable-tables"],
             "lib/Target/AArch64/AArch64GenExegesis.inc": ["-gen-exegesis"],
@@ -2249,6 +2248,7 @@ llvm_target_lib_list = [lib for lib in [
             "lib/Target/ARM/ARMGenSubtargetInfo.inc": ["-gen-subtarget"],
             "lib/Target/ARM/ARMGenDisassemblerTables.inc": [
                 "-gen-disassembler",
+                "-ignore-non-decodable-operands",
             ],
         },
     },


### PR DESCRIPTION
This was updated in #156364 but `-ignore-non-decodable-operands` was removed from the wrong tablegen arg list (arm vs aarch64)