### PR TITLE
[flang] Catch attempts to use assumed-rank as elemental argument

### DIFF
--- a/flang/lib/Semantics/check-call.cpp
+++ b/flang/lib/Semantics/check-call.cpp
@@ -1483,6 +1483,10 @@ static bool CheckElementalConformance(parser::ContextualMessages &messages,
             evaluate::SayWithDeclaration(messages, *wholeSymbol,
                 "Whole assumed-size array '%s' may not be used as an argument to an elemental procedure"_err_en_US,
                 wholeSymbol->name());
+          } else if (IsAssumedRank(*wholeSymbol)) {
+            evaluate::SayWithDeclaration(messages, *wholeSymbol,
+                "Assumed-rank array '%s' may not be used as an argument to an elemental procedure"_err_en_US,
+                wholeSymbol->name());
           }
         }
         if (auto argShape{evaluate::GetShape(context, *expr)}) {

--- a/flang/test/Semantics/elemental03.f90
+++ b/flang/test/Semantics/elemental03.f90
@@ -1,0 +1,13 @@
+!RUN: %python %S/test_errors.py %s %flang_fc1
+module m
+ contains
+  elemental real function f(x)
+    real, intent(in) :: x
+    f = x
+  end
+  subroutine s(a)
+    real a(..)
+    !ERROR: Assumed-rank array 'a' may not be used as an argument to an elemental procedure
+    print *, f(a)
+  end
+end


### PR DESCRIPTION
An assumed-rank array may not be used as an argument to an elemental procedure.

Fixes https://github.com/llvm/llvm-project/issues/159555.