### PR TITLE
[LLVM] Remove explicit dependency on builtins build

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -568,7 +568,7 @@ if(build_runtimes)
 
   if(NOT LLVM_RUNTIME_TARGETS)
     runtime_default_target(
-      DEPENDS ${builtins_dep} ${extra_deps}
+      DEPENDS ${extra_deps}
       CMAKE_ARGS ${extra_cmake_args}
       PREFIXES ${prefixes}
       EXTRA_ARGS ${extra_args})
@@ -576,7 +576,7 @@ if(build_runtimes)
   else()
     if("default" IN_LIST LLVM_RUNTIME_TARGETS)
       runtime_default_target(
-        DEPENDS ${builtins_dep} ${extra_deps}
+        DEPENDS ${extra_deps}
         CMAKE_ARGS ${extra_cmake_args}
         PREFIXES ${prefixes}
         EXTRA_ARGS ${extra_args})
@@ -613,18 +613,10 @@ if(build_runtimes)
     endif()
 
     foreach(name ${LLVM_RUNTIME_TARGETS})
-      if(builtins_dep)
-        if (LLVM_BUILTIN_TARGETS)
-          set(builtins_dep_name "${builtins_dep}-${name}")
-        else()
-          set(builtins_dep_name ${builtins_dep})
-        endif()
-      endif()
-
       check_apple_target(${name} runtime)
 
       runtime_register_target(${name}
-        DEPENDS ${builtins_dep_name} ${extra_deps}
+        DEPENDS ${extra_deps}
         CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name} ${extra_cmake_args}
         EXTRA_ARGS TARGET_TRIPLE ${name} ${extra_args})
     endforeach()


### PR DESCRIPTION
Summary:
The LLVM runtimes build internally uses `ExternalProject_Add`. This then
uses `BUILD_ALWAYS` to force the targets to be up-to-date when needed.
One problem with this is that we have the builtins step and the runtimes
step, which depends on the former. This means that when we build, we
always touch the builtins, which then makes the runtimes stale.

This patch tries to weaken that relationship by just getting rid of the
explicit dependency. Because these targets are already `BUILD_ALWAYS`
the compiler-rt target will always be built before the runtimes. This
means it will always be available in-order when doing a normal build.

What this patch changes is that now if someone makes a significant
change to the `compiler-rt` runtime implementation it now may not
trigger a rebuild of every single source file. I'm not sure if this
behavior was here previously in the first place either, since it was
just using a stale dependency and never did any extra work. I'm pretty
sure most of the uses of the library are implicit through `clang` so it
probably wouldn't track that dependency right anyway.

I cold be wrong, but I'm hoping this resolves an issue I've had for a
long time which makes it prohibitively difficult to use the runtimes
interface with compiler-rt enabled as a runtime.

Fixes: https://github.com/llvm/llvm-project/issues/98897
