### PR TITLE
[clang][PAC] Don't try to diagnose use of pointer auth on dependent types #159505

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1707,6 +1707,9 @@ ASTContext::findPointerAuthContent(QualType T) const {
   assert(isPointerAuthenticationAvailable());
 
   T = T.getCanonicalType();
+  if (T->isDependentType())
+    return PointerAuthContent::None;
+
   if (T.hasAddressDiscriminatedPointerAuth())
     return PointerAuthContent::AddressDiscriminatedData;
   const RecordDecl *RD = T->getAsRecordDecl();


### PR DESCRIPTION
We can't give a correct answer for dependent types, so for now just report no ptrauth involves if the type being queried is dependent. In future we may want to distinguigh the `None` vs `Dependent` cases but that does not seem warranted for now.

Fixes #159505