### PR TITLE
CodeGen: Make all targets override pseudos with pointers

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64.td
+++ b/llvm/lib/Target/AArch64/AArch64.td
@@ -40,6 +40,8 @@ include "AArch64SchedPredExynos.td"
 include "AArch64SchedPredNeoverse.td"
 include "AArch64Combine.td"
 
+defm : RemapAllTargetPseudoPointerOperands<GPR64sp>;
+
 def AArch64InstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/R600.td
+++ b/llvm/lib/Target/AMDGPU/R600.td
@@ -8,15 +8,6 @@
 
 include "llvm/Target/Target.td"
 
-def R600InstrInfo : InstrInfo {
-  let guessInstructionProperties = 1;
-}
-
-def R600 : Target {
-  let InstructionSet = R600InstrInfo;
-  let AllowRegisterRenaming = 1;
-}
-
 let Namespace = "R600" in {
 
 foreach Index = 0-15 in {
@@ -26,6 +17,18 @@ foreach Index = 0-15 in {
 include "R600RegisterInfo.td"
 
 }
+
+defm : RemapAllTargetPseudoPointerOperands<R600_Addr>;
+
+def R600InstrInfo : InstrInfo {
+  let guessInstructionProperties = 1;
+}
+
+def R600 : Target {
+  let InstructionSet = R600InstrInfo;
+  let AllowRegisterRenaming = 1;
+}
+
 
 def NullALU : InstrItinClass;
 def ALU_NULL : FuncUnit;

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -4751,3 +4751,14 @@ def V_ILLEGAL : Enc32, InstSI<(outs), (ins), "v_illegal"> {
   let hasSideEffects = 1;
   let SubtargetPredicate = isGFX10Plus;
 }
+
+defvar VGPR32_Ptr_Opcodes = [LOAD_STACK_GUARD];
+defvar VGPR64_Ptr_Opcodes = !listremove(PseudosWithPtrOps, VGPR32_Ptr_Opcodes);
+
+foreach inst = VGPR32_Ptr_Opcodes in {
+  def : RemapPointerOperands<inst, VGPR_32>;
+}
+
+foreach inst = VGPR64_Ptr_Opcodes in {
+  def : RemapPointerOperands<inst, VReg_64_AlignTarget>;
+}

--- a/llvm/lib/Target/ARM/ARM.td
+++ b/llvm/lib/Target/ARM/ARM.td
@@ -38,6 +38,14 @@ include "ARMSchedule.td"
 //===----------------------------------------------------------------------===//
 
 include "ARMInstrInfo.td"
+
+def Thumb1OnlyMode : HwMode<[IsThumb1Only]>;
+def arm_ptr_rc : RegClassByHwMode<
+  [DefaultMode, Thumb1OnlyMode],
+  [GPR, tGPR]>;
+
+defm : RemapAllTargetPseudoPointerOperands<arm_ptr_rc>;
+
 def ARMInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AVR/AVR.td
+++ b/llvm/lib/Target/AVR/AVR.td
@@ -32,6 +32,8 @@ include "AVRRegisterInfo.td"
 
 include "AVRInstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<PTRDISPREGS>;
+
 def AVRInstrInfo : InstrInfo;
 
 //===---------------------------------------------------------------------===//

--- a/llvm/lib/Target/BPF/BPF.td
+++ b/llvm/lib/Target/BPF/BPF.td
@@ -13,6 +13,9 @@ include "BPFCallingConv.td"
 include "BPFInstrInfo.td"
 include "GISel/BPFRegisterBanks.td"
 
+
+defm : RemapAllTargetPseudoPointerOperands<GPR>;
+
 def BPFInstrInfo : InstrInfo;
 
 class Proc<string Name, list<SubtargetFeature> Features>

--- a/llvm/lib/Target/CSKY/CSKY.td
+++ b/llvm/lib/Target/CSKY/CSKY.td
@@ -671,6 +671,8 @@ def : CK860V<"ck860fv", NoSchedModel,
 // Define the CSKY target.
 //===----------------------------------------------------------------------===//
 
+defm : RemapAllTargetPseudoPointerOperands<GPR>;
+
 def CSKYInstrInfo : InstrInfo;
 
 

--- a/llvm/lib/Target/DirectX/DirectX.td
+++ b/llvm/lib/Target/DirectX/DirectX.td
@@ -22,6 +22,8 @@ include "DXILStubs.td"
 // DirectX Subtarget features.
 //===----------------------------------------------------------------------===//
 
+defm : RemapAllTargetPseudoPointerOperands<DXILClass>;
+
 def DirectXInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Hexagon/Hexagon.td
+++ b/llvm/lib/Target/Hexagon/Hexagon.td
@@ -413,6 +413,8 @@ include "HexagonPatternsV65.td"
 include "HexagonDepMappings.td"
 include "HexagonIntrinsics.td"
 
+defm : RemapAllTargetPseudoPointerOperands<IntRegs>;
+
 def HexagonInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Lanai/Lanai.td
+++ b/llvm/lib/Target/Lanai/Lanai.td
@@ -21,6 +21,8 @@ include "LanaiRegisterInfo.td"
 include "LanaiCallingConv.td"
 include "LanaiInstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<GPR>;
+
 def LanaiInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/LoongArch/LoongArch.td
+++ b/llvm/lib/Target/LoongArch/LoongArch.td
@@ -202,6 +202,8 @@ def : ProcessorModel<"la664", NoSchedModel, [Feature64Bit,
 // Define the LoongArch target.
 //===----------------------------------------------------------------------===//
 
+defm : RemapAllTargetPseudoPointerOperands<GPR>;
+
 def LoongArchInstrInfo : InstrInfo {
   let guessInstructionProperties = 0;
 }

--- a/llvm/lib/Target/M68k/M68k.td
+++ b/llvm/lib/Target/M68k/M68k.td
@@ -95,6 +95,8 @@ include "GISel/M68kRegisterBanks.td"
 
 include "M68kInstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<AR16>;
+
 def M68kInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/MSP430/MSP430.td
+++ b/llvm/lib/Target/MSP430/MSP430.td
@@ -61,6 +61,8 @@ include "MSP430CallingConv.td"
 
 include "MSP430InstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<GR16>;
+
 def MSP430InstrInfo : InstrInfo;
 
 //===---------------------------------------------------------------------===//

--- a/llvm/lib/Target/Mips/Mips.td
+++ b/llvm/lib/Target/Mips/Mips.td
@@ -244,6 +244,8 @@ include "MipsScheduleI6400.td"
 include "MipsScheduleP5600.td"
 include "MipsScheduleGeneric.td"
 
+defm : RemapAllTargetPseudoPointerOperands<mips_ptr_rc>;
+
 def MipsInstrInfo : InstrInfo {
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTX.td
+++ b/llvm/lib/Target/NVPTX/NVPTX.td
@@ -150,6 +150,16 @@ def : Proc<"sm_121",  [SM121, PTX88]>;
 def : Proc<"sm_121a", [SM121a, PTX88]>;
 def : Proc<"sm_121f", [SM121f, PTX88]>;
 
+
+def Is64Bit : Predicate<"Subtarget->getTargetTriple().getArch() == Triple::nvptx64">;
+def NVPTX64 : HwMode<[Is64Bit]>;
+
+def nvptx_ptr_rc : RegClassByHwMode<
+  [DefaultMode, NVPTX64],
+  [B32, B64]>;
+
+defm : RemapAllTargetPseudoPointerOperands<nvptx_ptr_rc>;
+
 def NVPTXInstrInfo : InstrInfo {
 }
 

--- a/llvm/lib/Target/PowerPC/PPC.td
+++ b/llvm/lib/Target/PowerPC/PPC.td
@@ -820,6 +820,8 @@ def PPCAsmParserVariant : AsmParserVariant {
   string BreakCharacters = ".";
 }
 
+defm : RemapAllTargetPseudoPointerOperands<ppc_ptr_rc>;
+
 def PPC : Target {
   // Information about the instructions.
   let InstructionSet = PPCInstrInfo;

--- a/llvm/lib/Target/PowerPC/PPCRegisterInfo.td
+++ b/llvm/lib/Target/PowerPC/PPCRegisterInfo.td
@@ -904,6 +904,10 @@ def PPCRegGxRCNoR0Operand : AsmOperandClass {
   let Name = "RegGxRCNoR0"; let PredicateMethod = "isRegNumber";
 }
 
+def ppc_ptr_rc : RegClassByHwMode<
+  [PPC32, PPC64],
+  [GPRC, G8RC]>;
+
 def ptr_rc_nor0_by_hwmode : RegClassByHwMode<
   [PPC32, PPC64],
   [GPRC_NOR0, G8RC_NOX0]>;

--- a/llvm/lib/Target/RISCV/RISCV.td
+++ b/llvm/lib/Target/RISCV/RISCV.td
@@ -96,6 +96,8 @@ def RISCVAsmWriter : AsmWriter {
   int PassSubtarget = 1;
 }
 
+defm : RemapAllTargetPseudoPointerOperands<GPR>;
+
 def RISCV : Target {
   let InstructionSet = RISCVInstrInfo;
   let AssemblyParsers = [RISCVAsmParser];

--- a/llvm/lib/Target/SPIRV/SPIRV.td
+++ b/llvm/lib/Target/SPIRV/SPIRV.td
@@ -14,6 +14,8 @@ include "SPIRVInstrInfo.td"
 include "SPIRVCombine.td"
 include "SPIRVBuiltins.td"
 
+defm : RemapAllTargetPseudoPointerOperands<pID>;
+
 def SPIRVInstrInfo : InstrInfo;
 
 class Proc<string Name, list<SubtargetFeature> Features>

--- a/llvm/lib/Target/Sparc/Sparc.td
+++ b/llvm/lib/Target/Sparc/Sparc.td
@@ -126,6 +126,8 @@ include "SparcCallingConv.td"
 include "SparcSchedule.td"
 include "SparcInstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<sparc_ptr_rc>;
+
 def SparcInstrInfo : InstrInfo;
 
 def SparcAsmParser : AsmParser {

--- a/llvm/lib/Target/SystemZ/SystemZ.td
+++ b/llvm/lib/Target/SystemZ/SystemZ.td
@@ -57,6 +57,9 @@ include "SystemZInstrHFP.td"
 include "SystemZInstrDFP.td"
 include "SystemZInstrSystem.td"
 
+
+defm : RemapAllTargetPseudoPointerOperands<ADDR64Bit>;
+
 def SystemZInstrInfo : InstrInfo { let guessInstructionProperties = 0; }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/VE/VE.td
+++ b/llvm/lib/Target/VE/VE.td
@@ -30,6 +30,7 @@ include "VERegisterInfo.td"
 include "VECallingConv.td"
 include "VEInstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<ve_ptr_rc>;
 def VEInstrInfo : InstrInfo {}
 
 def VEAsmParser : AsmParser {

--- a/llvm/lib/Target/WebAssembly/WebAssembly.td
+++ b/llvm/lib/Target/WebAssembly/WebAssembly.td
@@ -108,6 +108,14 @@ include "WebAssemblyRegisterInfo.td"
 
 include "WebAssemblyInstrInfo.td"
 
+def WASM64 : HwMode<[HasAddr64]>;
+
+def wasm_ptr_rc : RegClassByHwMode<
+  [DefaultMode, WASM64],
+  [I32, I64]>;
+
+defm : RemapAllTargetPseudoPointerOperands<wasm_ptr_rc>;
+
 def WebAssemblyInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -795,6 +795,8 @@ include "X86Schedule.td"
 include "X86InstrInfo.td"
 include "X86SchedPredicates.td"
 
+defm : RemapAllTargetPseudoPointerOperands<x86_ptr_rc>;
+
 def X86InstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/XCore/XCore.td
+++ b/llvm/lib/Target/XCore/XCore.td
@@ -24,6 +24,8 @@ include "XCoreRegisterInfo.td"
 include "XCoreInstrInfo.td"
 include "XCoreCallingConv.td"
 
+defm : RemapAllTargetPseudoPointerOperands<GRRegs>;
+
 def XCoreInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/Xtensa/Xtensa.td
+++ b/llvm/lib/Target/Xtensa/Xtensa.td
@@ -44,6 +44,8 @@ include "XtensaCallingConv.td"
 
 include "XtensaInstrInfo.td"
 
+defm : RemapAllTargetPseudoPointerOperands<AR>;
+
 def XtensaInstrInfo : InstrInfo;
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This eliminates the need to have PointerLikeRegClass handling in
codegen.