### PR TITLE
[LLD][ELF] Support OVERLAY symbol assignments

### DIFF
--- a/lld/ELF/ScriptParser.cpp
+++ b/lld/ELF/ScriptParser.cpp
@@ -996,8 +996,13 @@ OutputDesc *ScriptParser::readOverlaySectionDescription() {
       ctx.script->createOutputSection(readName(), getCurrentLocation());
   osd->osec.inOverlay = true;
   expect("{");
-  while (auto tok = till("}"))
-    osd->osec.commands.push_back(readInputSectionDescription(tok));
+  while (auto tok = till("}")) {
+    if (SymbolAssignment *assign = readAssignment(tok)) {
+      osd->osec.commands.push_back(assign);
+    } else {
+      osd->osec.commands.push_back(readInputSectionDescription(tok));
+    }
+  }
   osd->osec.phdrs = readOutputSectionPhdrs();
   return osd;
 }

--- a/lld/test/ELF/linkerscript/overlay-symbol-assign.test
+++ b/lld/test/ELF/linkerscript/overlay-symbol-assign.test
@@ -1,0 +1,32 @@
+# REQUIRES: x86
+# RUN: echo 'nop; .section .small, "a"; .long 0; .section .big1, "a"; .quad 1; .section .big2, "a"; .quad 2;' \
+# RUN:   | llvm-mc -filetype=obj -triple=x86_64 - -o %t.o
+# RUN: ld.lld %t.o --script %s -o %t
+
+SECTIONS {
+  OVERLAY 0x1000 : AT ( 0x4000 ) {
+    .out.big { 
+      *(.big1)
+      . = ALIGN(0x100);
+      *(.big2)
+    }
+    .out.small { *(.small) }
+  }
+}
+
+## A variant of overlay.test with explicit program header assingment.
+## Check that we generate two program headers consistent with the overlay
+
+# RUN: llvm-readelf -S -l %t | FileCheck %s
+
+# CHECK: Section Headers:
+# CHECK:      Name       Type     Address          Off    Size
+# CHECK:      .out.big   PROGBITS 0000000000001000 001000 000108
+# CHECK-NEXT: .out.small PROGBITS 0000000000001000 002000 000004
+
+
+# CHECK:      Program Headers:
+# CHECK:      Type Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
+# CHECK-NEXT: LOAD 0x001000 0x0000000000001000 0x0000000000004000 0x000108 0x000108 R   0x1000
+# CHECK-NEXT: LOAD 0x002000 0x0000000000001000 0x0000000000004108 0x000004 0x000004 R   0x1000
+


### PR DESCRIPTION
This enables symbol assignment within OVERLAY linker script descriptions. This is a valuable addition to the OVERLAY syntax, as it allows defining symbols that can be used for alignment within overlay sections.

https://github.com/llvm/llvm-project/issues/158569