### PR TITLE
[IR] Modernize HasCachedHash  (NFC)

### DIFF
--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -986,15 +986,11 @@ static T *uniquifyImpl(T *N, DenseSet<T *, InfoT> &Store) {
 }
 
 template <class NodeTy> struct MDNode::HasCachedHash {
-  using Yes = char[1];
-  using No = char[2];
-  template <class U, U Val> struct SFINAE {};
-
   template <class U>
-  static Yes &check(SFINAE<void (U::*)(unsigned), &U::setHash> *);
-  template <class U> static No &check(...);
+  static std::true_type check(SameType<void (U::*)(unsigned), &U::setHash> *);
+  template <class U> static std::false_type check(...);
 
-  static const bool value = sizeof(check<NodeTy>(nullptr)) == sizeof(Yes);
+  static constexpr bool value = decltype(check<NodeTy>(nullptr))::value;
 };
 
 MDNode *MDNode::uniquify() {


### PR DESCRIPTION
This patch modernizes HasCachedHash.

- "struct SFINAE" is replaced with identically defined SameType.

- The return types Yes and No are replaced with std::true_type and
  std::false_type.

My previous attempt (#159510) to clean up HasCachedHash failed on
clang++-18, but this version works with clang++-18.
