### PR TITLE
[IR] Simplify dispatchRecalculateHash and dispatchResetHash (NFC)

### DIFF
--- a/llvm/include/llvm/IR/Metadata.h
+++ b/llvm/include/llvm/IR/Metadata.h
@@ -1410,18 +1410,14 @@ private:
   void eraseFromStore();
 
   template <class NodeTy> struct HasCachedHash;
-  template <class NodeTy>
-  static void dispatchRecalculateHash(NodeTy *N, std::true_type) {
-    N->recalculateHash();
+  template <class NodeTy> static void dispatchRecalculateHash(NodeTy *N) {
+    if constexpr (HasCachedHash<NodeTy>::value)
+      N->recalculateHash();
   }
-  template <class NodeTy>
-  static void dispatchRecalculateHash(NodeTy *, std::false_type) {}
-  template <class NodeTy>
-  static void dispatchResetHash(NodeTy *N, std::true_type) {
-    N->setHash(0);
+  template <class NodeTy> static void dispatchResetHash(NodeTy *N) {
+    if constexpr (HasCachedHash<NodeTy>::value)
+      N->setHash(0);
   }
-  template <class NodeTy>
-  static void dispatchResetHash(NodeTy *, std::false_type) {}
 
   /// Merge branch weights from two direct callsites.
   static MDNode *mergeDirectCallProfMetadata(MDNode *A, MDNode *B,

--- a/llvm/lib/IR/Metadata.cpp
+++ b/llvm/lib/IR/Metadata.cpp
@@ -1007,8 +1007,7 @@ MDNode *MDNode::uniquify() {
 #define HANDLE_MDNODE_LEAF_UNIQUABLE(CLASS)                                    \
   case CLASS##Kind: {                                                          \
     CLASS *SubclassThis = cast<CLASS>(this);                                   \
-    std::bool_constant<HasCachedHash<CLASS>::value> ShouldRecalculateHash;     \
-    dispatchRecalculateHash(SubclassThis, ShouldRecalculateHash);              \
+    dispatchRecalculateHash(SubclassThis);                                     \
     return uniquifyImpl(SubclassThis, getContext().pImpl->CLASS##s);           \
   }
 #include "llvm/IR/Metadata.def"
@@ -1064,8 +1063,7 @@ void MDNode::storeDistinctInContext() {
     llvm_unreachable("Invalid subclass of MDNode");
 #define HANDLE_MDNODE_LEAF(CLASS)                                              \
   case CLASS##Kind: {                                                          \
-    std::bool_constant<HasCachedHash<CLASS>::value> ShouldResetHash;           \
-    dispatchResetHash(cast<CLASS>(this), ShouldResetHash);                     \
+    dispatchResetHash(cast<CLASS>(this));                                      \
     break;                                                                     \
   }
 #include "llvm/IR/Metadata.def"


### PR DESCRIPTION
This patch simplifies dispatchRecalculateHash and dispatchResetHash
with "constexpr if".

This patch does not inline dispatchRecalculateHash and
dispatchResetHash into their respective call sites.  Using "constexpr
if" in a non-template context like MDNode::uniquify would still
require the discarded branch to be syntactically valid, causing a
compilation error for node types that do not have
recalculateHash/setHash.  Using template functions ensures that the
"constexpr if" is evaluated in a proper template context, allowing the
compiler to fully discard the inactive branch.
