### PR TITLE
[llvm][test][CGPluginTest] Fix plugin path

### DIFF
--- a/llvm/test/Other/codegen-plugin-loading.ll
+++ b/llvm/test/Other/codegen-plugin-loading.ll
@@ -1,4 +1,4 @@
-; RUN: llc -load %llvm_obj_root/unittests/CodeGen/CGPluginTest/CGTestPlugin%pluginext %s -o - | FileCheck %s
+; RUN: llc -load %llvmshlibdir/unittests/CodeGen/CGPluginTest/CGTestPlugin%pluginext %s -o - | FileCheck %s
 ; REQUIRES: native, system-linux, llvm-dylib
 
 ; CHECK: CodeGen Test Pass running on main


### PR DESCRIPTION
During development I introduced the `%llvm_obj_root` substitution but later removed it as a better solution became apparent. Revert this to the original substitution while keeping the new path.

Fixes: 4e1c996674cc340f290b0a528e2038e76494d8d4