### PR TITLE
[DAG] Skip `mstore` combine for `<1 x ty>` vectors

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -22606,7 +22606,7 @@ static SDValue foldToMaskedStore(StoreSDNode *Store, SelectionDAG &DAG,
 
   // Skip this combine for non-vector types and for <1 x ty> vectors, as they
   // will be scalarized later.
-  if (!VT.isVector() || VT.getVectorNumElements() == 1)
+  if (!VT.isVector() || VT.isScalableVector() || VT.getVectorNumElements() == 1)
     return SDValue();
 
   unsigned AddrSpace = Store->getAddressSpace();

--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
@@ -22603,6 +22603,12 @@ static SDValue foldToMaskedStore(StoreSDNode *Store, SelectionDAG &DAG,
   SDValue StorePtr = Store->getBasePtr();
   SDValue StoreOffset = Store->getOffset();
   EVT VT = Store->getMemoryVT();
+
+  // Skip this combine for non-vector types and for <1 x ty> vectors, as they
+  // will be scalarized later.
+  if (!VT.isVector() || VT.getVectorNumElements() == 1)
+    return SDValue();
+
   unsigned AddrSpace = Store->getAddressSpace();
   Align Alignment = Store->getAlign();
   const TargetLowering &TLI = DAG.getTargetLoweringInfo();

--- a/llvm/test/CodeGen/AArch64/combine-storetomstore.ll
+++ b/llvm/test/CodeGen/AArch64/combine-storetomstore.ll
@@ -1191,3 +1191,23 @@ define void @test_masked_store_unaligned_v8i64(<8 x i64> %data, ptr %ptr, <8 x i
   store <8 x i64> %sel, ptr %ptr_vec, align 1
   ret void
 }
+
+@global = external global i64
+
+define void @PR159912(<1 x i1> %arg) #0 {
+; SVE-LABEL: PR159912:
+; SVE:       // %bb.0:
+; SVE-NEXT:    adrp x8, :got:global
+; SVE-NEXT:    tst w0, #0x1
+; SVE-NEXT:    ldr x8, [x8, :got_lo12:global]
+; SVE-NEXT:    csetm x9, ne
+; SVE-NEXT:    fmov d1, x9
+; SVE-NEXT:    ldr d0, [x8]
+; SVE-NEXT:    bic v0.8b, v0.8b, v1.8b
+; SVE-NEXT:    str d0, [x8]
+; SVE-NEXT:    ret
+  %load = load <1 x i64>, ptr @global, align 8
+  %select = select <1 x i1> %arg, <1 x i64> zeroinitializer, <1 x i64> %load
+  store <1 x i64> %select, ptr @global, align 8
+  ret void
+}

--- a/llvm/test/CodeGen/AArch64/combine-storetomstore.ll
+++ b/llvm/test/CodeGen/AArch64/combine-storetomstore.ll
@@ -1192,22 +1192,18 @@ define void @test_masked_store_unaligned_v8i64(<8 x i64> %data, ptr %ptr, <8 x i
   ret void
 }
 
-@global = external global i64
-
-define void @PR159912(<1 x i1> %arg) #0 {
+define void @PR159912(<1 x i1> %arg, ptr %ptr) #0 {
 ; SVE-LABEL: PR159912:
 ; SVE:       // %bb.0:
-; SVE-NEXT:    adrp x8, :got:global
 ; SVE-NEXT:    tst w0, #0x1
-; SVE-NEXT:    ldr x8, [x8, :got_lo12:global]
-; SVE-NEXT:    csetm x9, ne
-; SVE-NEXT:    fmov d1, x9
-; SVE-NEXT:    ldr d0, [x8]
+; SVE-NEXT:    ldr d0, [x1]
+; SVE-NEXT:    csetm x8, ne
+; SVE-NEXT:    fmov d1, x8
 ; SVE-NEXT:    bic v0.8b, v0.8b, v1.8b
-; SVE-NEXT:    str d0, [x8]
+; SVE-NEXT:    str d0, [x1]
 ; SVE-NEXT:    ret
-  %load = load <1 x i64>, ptr @global, align 8
+  %load = load <1 x i64>, ptr %ptr, align 8
   %select = select <1 x i1> %arg, <1 x i64> zeroinitializer, <1 x i64> %load
-  store <1 x i64> %select, ptr @global, align 8
+  store <1 x i64> %select, ptr %ptr, align 8
   ret void
 }


### PR DESCRIPTION
Fixes #159912