### PR TITLE
[LLVM] Remove `prepare-check-lit` from lit testsuite dependencies

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -65,7 +65,6 @@ set(LLVM_TEST_DEPENDS_COMMON
   count
   llvm-config
   not
-  prepare-check-lit
   )
 
 set(LLVM_TEST_DEPENDS


### PR DESCRIPTION
Remove `prepare-check-lit` as it's not intended to prepare the `llvm-lit` binary (which was the original intent of adding this target to the dependencies). `llvm-lit` is pre-populated when you run cmake, so there is no need to have an extra dependency for that. That also means that if you do `rm -rf build/bin` and then run `ninja -C build check-llvm-filecheck` llvm-lit will not get copied over and you need to run cmake again to get it back.