### PR TITLE
[llvm][test][CGPluginTest] Fix plugin path again

### DIFF
--- a/llvm/test/Other/codegen-plugin-loading.ll
+++ b/llvm/test/Other/codegen-plugin-loading.ll
@@ -1,4 +1,4 @@
-; RUN: llc -load %llvmshlibdir/unittests/CodeGen/CGPluginTest/CGTestPlugin%pluginext %s -o - | FileCheck %s
+; RUN: llc -load %llvmshlibdir/CGTestPlugin%pluginext %s -o - | FileCheck %s
 ; REQUIRES: native, system-linux, llvm-dylib
 
 ; CHECK: CodeGen Test Pass running on main


### PR DESCRIPTION
I forgot to remove a bunch of the intermediary path. That's what I get for not waiting my local build to finish.

Fixes: 47c1b650626043f0a8f8e32851617201751f9439