### PR TITLE
[ADT] Simplify enable_if_struct_deref_supported (NFC)

### DIFF
--- a/llvm/include/llvm/ADT/fallible_iterator.h
+++ b/llvm/include/llvm/ADT/fallible_iterator.h
@@ -67,10 +67,9 @@ namespace llvm {
 /// without requiring redundant error checks.
 template <typename Underlying> class fallible_iterator {
 private:
-  template <typename T>
-  using enable_if_struct_deref_supported = std::enable_if_t<
-      !std::is_void<decltype(std::declval<T>().operator->())>::value,
-      decltype(std::declval<T>().operator->())>;
+  template <typename T, typename U = decltype(std::declval<T>().operator->())>
+  using enable_if_struct_deref_supported =
+      std::enable_if_t<!std::is_void_v<U>, U>;
 
 public:
   /// Construct a fallible iterator that *cannot* be used as an end-of-range


### PR DESCRIPTION
This patch simplifies enable_if_struct_deref_supported by using a
default template parameter as a temporary type alias.  This way, we do
not have to repeat decltype(...).
