### PR TITLE
[MLIR][ExecutionEngine] Restore internal _mlir_{*} builtins

### DIFF
--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -147,9 +147,11 @@ extern "C" double rtclock() {
 #endif // _WIN32
 }
 
-extern "C" void *mlirAlloc(uint64_t size) { return malloc(size); }
+// NOLINTBEGIN(*-identifier-naming)
 
-extern "C" void *mlirAlignedAlloc(uint64_t alignment, uint64_t size) {
+extern "C" void *_mlir_alloc(uint64_t size) { return malloc(size); }
+extern "C" void *_mlir_malloc(uint64_t size) { return malloc(size); }
+extern "C" void *_mlir_aligned_alloc(uint64_t alignment, uint64_t size) {
 #ifdef _WIN32
   return _aligned_malloc(size, alignment);
 #elif defined(__APPLE__)
@@ -163,9 +165,9 @@ extern "C" void *mlirAlignedAlloc(uint64_t alignment, uint64_t size) {
 #endif
 }
 
-extern "C" void mlirFree(void *ptr) { free(ptr); }
+extern "C" void _mlir_free(void *ptr) { free(ptr); }
 
-extern "C" void mlirAlignedFree(void *ptr) {
+extern "C" void _mlir_aligned_free(void *ptr) {
 #ifdef _WIN32
   _aligned_free(ptr);
 #else
@@ -212,5 +214,7 @@ IMPL_STDSORT(I64, int64_t)
 IMPL_STDSORT(F64, double)
 IMPL_STDSORT(F32, float)
 #undef IMPL_STDSORT
+
+// NOLINTEND(*-identifier-naming)
 
 #endif // MLIR_CRUNNERUTILS_DEFINE_FUNCTIONS


### PR DESCRIPTION
During clang-tidy fixes, ```_mlir_{alloc,aligned_alloc,free,aligned_free}``` were lost, see the commit: https://github.com/llvm/llvm-project/commit/c599650a0d2a1ae512490ca303e46ef81931c520

* Current ```mlir{Alloc,AlignedAlloc,Free,AlignedFree}``` are [dangling declarations](https://github.com/llvm/llvm-project/blob/efd96afedf2c0f6f2cc34cf5a9a7e3e78f592255/mlir/lib/ExecutionEngine/CRunnerUtils.cpp#L150-L174).
* This PR restores the previous behaviour and utility but also keep clang-tidy happy.

------

#### Issue details

* Prior to this, using [mlir-runner-testcase.py.gz](https://github.com/user-attachments/files/22444224/mlir-runner-testcase.py.gz) reveals the following missing symbols:
```
-> pm.add("finalize-memref-to-llvm{use-generic-functions=false}")
$ ./mlir-runner-testcase.py
Could not compile malloc:
  Symbols not found: [ _mlir_malloc ]
Generated object file 'obj.o' for inspection.
```

```
-> pm.add("finalize-memref-to-llvm{use-generic-functions=false use-aligned-alloc=1}")
$ ./mlir-runner-testcase.py
Could not compile aligned_alloc:
  Symbols not found: [ _mlir_aligned_alloc ]
Generated object file 'obj.o' for inspection.
```

* Using this PR, symbols resolves and are picked up properly:

```
$ ./mlir-runner-testcase.py 
Generated object file 'obj.o' for inspection.

$ readelf -Ws obj.o 
Symbol table '.symtab' contains 7 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 0000000000000000     0 FILE    LOCAL  DEFAULT  ABS LLVMDialectModule
     2: 0000000000000000    98 FUNC    GLOBAL DEFAULT    3 main
     3: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND aligned_alloc
     4: 0000000000000070   101 FUNC    GLOBAL DEFAULT    3 _mlir_ciface_main
     5: 00000000000000e0   108 FUNC    GLOBAL DEFAULT    3 _mlir_main
     6: 0000000000000150   111 FUNC    GLOBAL DEFAULT    3 _mlir__mlir_ciface_main
``` 

**Note:** Of course one can still use ```use-generic-functions=true``` with his own custom shared library, but the scope of this PR is to restore the functionality back to simply what ```libmlir_c_runner_utils.so``` already ships as builtins.
