### PR TITLE
[clang] ast-dump: use template pattern for `instantiated_from`

### DIFF
--- a/clang/lib/AST/JSONNodeDumper.cpp
+++ b/clang/lib/AST/JSONNodeDumper.cpp
@@ -944,6 +944,9 @@ void JSONNodeDumper::VisitVarDecl(const VarDecl *VD) {
     }
   }
   attributeOnlyIfTrue("isParameterPack", VD->isParameterPack());
+  if (const auto *Instance = VD->getTemplateInstantiationPattern())
+    JOS.attribute("TemplateInstantiationPattern",
+                  createPointerRepresentation(Instance));
 }
 
 void JSONNodeDumper::VisitFieldDecl(const FieldDecl *FD) {
@@ -975,6 +978,10 @@ void JSONNodeDumper::VisitFunctionDecl(const FunctionDecl *FD) {
 
   if (StringLiteral *Msg = FD->getDeletedMessage())
     JOS.attribute("deletedMessage", Msg->getString());
+
+  if (const auto *Instance = FD->getTemplateInstantiationPattern())
+    JOS.attribute("TemplateInstantiationPattern",
+                  createPointerRepresentation(Instance));
 }
 
 void JSONNodeDumper::VisitEnumDecl(const EnumDecl *ED) {
@@ -984,6 +991,9 @@ void JSONNodeDumper::VisitEnumDecl(const EnumDecl *ED) {
   if (ED->isScoped())
     JOS.attribute("scopedEnumTag",
                   ED->isScopedUsingClassTag() ? "class" : "struct");
+  if (const auto *Instance = ED->getTemplateInstantiationPattern())
+    JOS.attribute("TemplateInstantiationPattern",
+                  createPointerRepresentation(Instance));
 }
 void JSONNodeDumper::VisitEnumConstantDecl(const EnumConstantDecl *ECD) {
   VisitNamedDecl(ECD);
@@ -1002,6 +1012,10 @@ void JSONNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *RD) {
     if (CTSD->hasStrictPackMatch())
       JOS.attribute("strict-pack-match", true);
   }
+
+  if (const auto *Instance = RD->getTemplateInstantiationPattern())
+    JOS.attribute("TemplateInstantiationPattern",
+                  createPointerRepresentation(Instance));
 
   // All other information requires a complete definition.
   if (!RD->isCompleteDefinition())

--- a/clang/lib/AST/TextNodeDumper.cpp
+++ b/clang/lib/AST/TextNodeDumper.cpp
@@ -2273,7 +2273,7 @@ void TextNodeDumper::VisitEnumDecl(const EnumDecl *D) {
   if (D->isFixed())
     dumpType(D->getIntegerType());
 
-  if (const auto *Instance = D->getInstantiatedFromMemberEnum()) {
+  if (const auto *Instance = D->getTemplateInstantiationPattern()) {
     OS << " instantiated_from";
     dumpPointer(Instance);
   }
@@ -2379,7 +2379,7 @@ void TextNodeDumper::VisitFunctionDecl(const FunctionDecl *D) {
   if (!D->param_empty() && !D->param_begin())
     OS << " <<<NULL params x " << D->getNumParams() << ">>>";
 
-  if (const auto *Instance = D->getInstantiatedFromMemberFunction()) {
+  if (const auto *Instance = D->getTemplateInstantiationPattern()) {
     OS << " instantiated_from";
     dumpPointer(Instance);
   }
@@ -2467,6 +2467,11 @@ void TextNodeDumper::VisitVarDecl(const VarDecl *D) {
     OS << " destroyed";
   if (D->isParameterPack())
     OS << " pack";
+
+  if (const auto *Instance = D->getTemplateInstantiationPattern()) {
+    OS << " instantiated_from";
+    dumpPointer(Instance);
+  }
 
   if (D->hasInit()) {
     const Expr *E = D->getInit();
@@ -2615,7 +2620,7 @@ void TextNodeDumper::VisitTypeAliasTemplateDecl(
 
 void TextNodeDumper::VisitCXXRecordDecl(const CXXRecordDecl *D) {
   VisitRecordDecl(D);
-  if (const auto *Instance = D->getInstantiatedFromMemberClass()) {
+  if (const auto *Instance = D->getTemplateInstantiationPattern()) {
     OS << " instantiated_from";
     dumpPointer(Instance);
   }

--- a/clang/test/AST/ast-dump-decl.cpp
+++ b/clang/test/AST/ast-dump-decl.cpp
@@ -334,7 +334,7 @@ namespace testClassTemplateDecl {
 // CHECK-NEXT:  | |-CXXDestructorDecl 0x[[#%x,TEMPLATE_DESTRUCTOR_DECL:]] <line:[[@LINE-50]]:5, col:24> col:5 ~TestClassTemplate<T> 'void ()' not_selected{{$}}
 // CHECK-NEXT:  | |-CXXMethodDecl 0x[[#%x,TEMPLATE_METHOD_DECL:]] <line:[[@LINE-50]]:5, col:11> col:9 j 'int ()'{{$}}
 // CHECK-NEXT:  | `-FieldDecl 0x{{.+}} <line:[[@LINE-50]]:5, col:9> col:9 i 'int'{{$}}
-// CHECK-NEXT:  |-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-56]]:3, line:[[@LINE-50]]:3> line:[[@LINE-56]]:30 class TestClassTemplate definition implicit_instantiation{{$}}
+// CHECK-NEXT:  |-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-56]]:3, line:[[@LINE-50]]:3> line:[[@LINE-56]]:30 class TestClassTemplate definition instantiated_from 0x{{.+}} implicit_instantiation{{$}}
 // CHECK-NEXT:  | |-DefinitionData standard_layout has_user_declared_ctor can_const_default_init{{$}}
 // CHECK-NEXT:  | | |-DefaultConstructor exists non_trivial user_provided{{$}}
 // CHECK-NEXT:  | | |-CopyConstructor simple trivial has_const_param implicit_has_const_param{{$}}
@@ -371,7 +371,7 @@ namespace testClassTemplateDecl {
 // CHECK-NEXT:  |-CXXRecordDecl 0x{{.+}} <col:14, col:20> col:20 implicit class TestClassTemplate{{$}}
 // CHECK-NEXT:  `-FieldDecl 0x{{.+}} <line:[[@LINE-78]]:5, col:9> col:9 j 'int'{{$}}
 
-// CHECK:       ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:{{.*}}:3, col:44> col:25 class TestClassTemplate definition explicit_instantiation_declaration{{$}}
+// CHECK:       ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:{{.*}}:3, col:44> col:25 class TestClassTemplate definition instantiated_from 0x{{.+}} explicit_instantiation_declaration{{$}}
 // CHECK-NEXT:  |-DefinitionData standard_layout has_user_declared_ctor can_const_default_init{{$}}
 // CHECK-NEXT:  | |-DefaultConstructor exists non_trivial user_provided{{$}}
 // CHECK-NEXT:  | |-CopyConstructor simple trivial has_const_param needs_implicit implicit_has_const_param{{$}}
@@ -389,7 +389,7 @@ namespace testClassTemplateDecl {
 // CHECK-NEXT:  |-CXXMethodDecl 0x{{.+}} <line:[[@LINE-104]]:5, col:11> col:9 j 'int ()' explicit_instantiation_declaration instantiated_from {{0x[^ ]+}}{{$}}
 // CHECK-NEXT:  `-FieldDecl 0x{{.+}} <line:[[@LINE-104]]:5, col:9> col:9 i 'int'{{$}}
 
-// CHECK:       ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-91]]:3, col:37> col:18 class TestClassTemplate definition explicit_instantiation_definition{{$}}
+// CHECK:       ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-91]]:3, col:37> col:18 class TestClassTemplate definition instantiated_from 0x{{.+}} explicit_instantiation_definition{{$}}
 // CHECK-NEXT:  |-DefinitionData standard_layout has_user_declared_ctor can_const_default_init{{$}}
 // CHECK-NEXT:  | |-DefaultConstructor exists non_trivial user_provided{{$}}
 // CHECK-NEXT:  | |-CopyConstructor simple trivial has_const_param needs_implicit implicit_has_const_param{{$}}
@@ -518,7 +518,7 @@ namespace testClassTemplateDecl {
 // CHECK-NEXT: | |-EnumDecl 0x[[#%x,SCOPED_MEMBER_ENUM_E3:]] <line:[[@LINE-22]]:5, col:21> col:16 class E3 'T'
 // CHECK-NEXT: | `-EnumDecl 0x[[#%x,SCOPED_MEMBER_ENUM_E4:]] <line:[[@LINE-22]]:5, col:21> col:16 class E4 'int'
 // CHECK-NEXT: |-ClassTemplateSpecialization 0x{{.+}} 'TestClassTemplateWithScopedMemberEnum'
-// CHECK-NEXT: `-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-28]]:3, line:[[@LINE-23]]:3> line:[[@LINE-28]]:31 struct TestClassTemplateWithScopedMemberEnum definition implicit_instantiation
+// CHECK-NEXT: `-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-28]]:3, line:[[@LINE-23]]:3> line:[[@LINE-28]]:31 struct TestClassTemplateWithScopedMemberEnum definition instantiated_from 0x{{.+}} implicit_instantiation
 // CHECK:        |-TemplateArgument type 'int'
 // CHECK-NEXT:   | `-BuiltinType 0x{{.+}} 'int'
 // CHECK:        |-EnumDecl 0x{{.+}} <line:[[@LINE-30]]:5, col:21> col:16 class E1 'int' instantiated_from 0x[[#SCOPED_MEMBER_ENUM_E1]]{{$}}
@@ -526,7 +526,7 @@ namespace testClassTemplateDecl {
 // CHECK-NEXT:   |-EnumDecl 0x{{.+}} <line:[[@LINE-30]]:5, col:21> col:16 class E3 'int' instantiated_from 0x[[#SCOPED_MEMBER_ENUM_E3]]{{$}}
 // CHECK-NEXT:   |-EnumDecl 0x{{.+}} <line:[[@LINE-30]]:5, col:21> col:16 class E4 'int' instantiated_from 0x[[#SCOPED_MEMBER_ENUM_E4]]{{$}}
 
-// CHECK:      ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-29]]:3, col:65> col:19 struct TestClassTemplateWithScopedMemberEnum definition explicit_instantiation_definition
+// CHECK:      ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-29]]:3, col:65> col:19 struct TestClassTemplateWithScopedMemberEnum definition instantiated_from 0x{{.+}} explicit_instantiation_definition
 // CHECK:      |-TemplateArgument type 'unsigned int'
 // CHECK-NEXT: | `-BuiltinType 0x{{.+}} 'unsigned int'
 // CHECK:      |-EnumDecl 0x{{.+}} <line:[[@LINE-38]]:5, col:21> col:16 class E1 'unsigned int' instantiated_from 0x[[#SCOPED_MEMBER_ENUM_E1]]{{$}}
@@ -575,7 +575,7 @@ namespace testClassTemplateDecl {
 // CHECK-NEXT: | `-EnumDecl 0x[[#%x,UNSCOPED_MEMBER_ENUM_E4:]] <line:[[@LINE-22]]:5, col:15> col:10 E4 'int'
 // CHECK-NEXT: `-ClassTemplateSpecialization {{.+}} 'TestClassTemplateWithUnscopedMemberEnum'
 
-// CHECK:      ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-22]]:3, col:67> col:19 struct TestClassTemplateWithUnscopedMemberEnum definition explicit_instantiation_definition
+// CHECK:      ClassTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-22]]:3, col:67> col:19 struct TestClassTemplateWithUnscopedMemberEnum definition instantiated_from 0x{{.+}} explicit_instantiation_definition
 // CHECK:      |-TemplateArgument type 'unsigned int'
 // CHECK-NEXT: | `-BuiltinType 0x{{.+}} 'unsigned int'
 // CHECK:      |-EnumDecl 0x{{.+}} <line:[[@LINE-31]]:5, col:15> col:10 E1 'unsigned int' instantiated_from 0x[[#UNSCOPED_MEMBER_ENUM_E1]]{{$}}
@@ -603,7 +603,7 @@ namespace testCanonicalTemplate {
   // CHECK-NEXT:   |-TemplateTypeParmDecl 0x{{.+}} <col:12, col:21> col:21 referenced typename depth 0 index 0 T{{$}}
   // CHECK-NEXT:   |-FunctionDecl 0x{{.*}} <col:24, col:51> col:29 TestFunctionTemplate 'void (T)'{{$}}
   // CHECK-NEXT:   | `-ParmVarDecl 0x{{.*}} <col:50> col:51 'T'{{$}}
-  // CHECK-NEXT:   `-FunctionDecl 0x{{.*}} <line:[[@LINE-6]]:24, col:51> col:29 used TestFunctionTemplate 'void (testCanonicalTemplate::A)' implicit_instantiation{{$}}
+  // CHECK-NEXT:   `-FunctionDecl 0x{{.*}} <line:[[@LINE-6]]:24, col:51> col:29 used TestFunctionTemplate 'void (testCanonicalTemplate::A)' implicit_instantiation instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:     |-TemplateArgument type 'testCanonicalTemplate::A'{{$}}
   // CHECK-NEXT:     | `-RecordType 0x{{.+}} 'testCanonicalTemplate::A' canonical{{$}}
   // CHECK-NEXT:     |   `-CXXRecord 0x{{.+}} 'A'{{$}}
@@ -635,7 +635,7 @@ namespace testCanonicalTemplate {
   // CHECK-NEXT: |   `-ClassTemplateDecl 0x{{.+}} parent 0x{{.+}} <col:5, col:40> col:40 friend_undeclared TestClassTemplate{{$}}
   // CHECK-NEXT: |     |-TemplateTypeParmDecl 0x{{.+}} <col:14, col:23> col:23 typename depth 1 index 0 T2{{$}}
   // CHECK-NEXT: |     `-CXXRecordDecl 0x{{.+}} parent 0x{{.+}} <col:34, col:40> col:40 class TestClassTemplate{{$}}
-  // CHECK-NEXT: `-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-19]]:3, line:[[@LINE-17]]:3> line:[[@LINE-19]]:31 class TestClassTemplate definition implicit_instantiation{{$}}
+  // CHECK-NEXT: `-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-19]]:3, line:[[@LINE-17]]:3> line:[[@LINE-19]]:31 class TestClassTemplate definition instantiated_from 0x{{.+}} implicit_instantiation{{$}}
   // CHECK-NEXT:   |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init{{$}}
   // CHECK-NEXT:   | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr{{$}}
   // CHECK-NEXT:   | |-CopyConstructor simple trivial has_const_param implicit_has_const_param{{$}}
@@ -668,7 +668,7 @@ namespace testCanonicalTemplate {
   // CHECK:      ClassTemplateDecl 0x{{.+}} <{{.+}}:[[@LINE-5]]:3, col:31> col:31 TestClassTemplate2{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <col:12, col:21> col:21 typename depth 0 index 0 T1{{$}}
   // CHECK-NEXT: |-CXXRecordDecl 0x{{.+}} <col:25, col:31> col:31 class TestClassTemplate2{{$}}
-  // CHECK-NEXT: `-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-6]]:3, line:[[@LINE-5]]:3> line:[[@LINE-6]]:31 class TestClassTemplate2 definition implicit_instantiation{{$}}
+  // CHECK-NEXT: `-ClassTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-6]]:3, line:[[@LINE-5]]:3> line:[[@LINE-6]]:31 class TestClassTemplate2 definition instantiated_from 0x{{.+}} implicit_instantiation{{$}}
   // CHECK-NEXT:   |-DefinitionData pass_in_registers empty aggregate standard_layout trivially_copyable pod trivial literal has_constexpr_non_copy_move_ctor can_const_default_init{{$}}
   // CHECK-NEXT:   | |-DefaultConstructor exists trivial constexpr defaulted_is_constexpr{{$}}
   // CHECK-NEXT:   | |-CopyConstructor simple trivial has_const_param implicit_has_const_param{{$}}
@@ -719,28 +719,28 @@ namespace testCanonicalTemplate {
 
   // CHECK:      VarTemplateDecl 0x{{.+}} <{{.+}}:[[@LINE-11]]:7, col:43> col:43 TestVarTemplate{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <col:16, col:25> col:25 referenced typename depth 0 index 0 T{{$}}
-  // CHECK-NEXT: |-VarDecl 0x{{.+}} <col:28, col:43> col:43 TestVarTemplate 'const T' static{{$}}
-  // CHECK-NEXT: |-VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-12]]:3, line:[[@LINE-11]]:34> col:14 referenced TestVarTemplate 'const int' implicit_instantiation cinit{{$}}
+  // CHECK-NEXT: |-VarDecl 0x{{.+}} <col:28, col:43> col:43 TestVarTemplate 'const T' static instantiated_from 0x{{.+}}{{$}}
+  // CHECK-NEXT: |-VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-12]]:3, line:[[@LINE-11]]:34> col:14 referenced TestVarTemplate 'const int' implicit_instantiation cinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT: | |-NestedNameSpecifier TypeSpec 'S'{{$}}
   // CHECK-NEXT: | |-TemplateArgument type 'int'{{$}}
   // CHECK-NEXT: | | `-BuiltinType 0x{{.+}} 'int'{{$}}
   // CHECK-NEXT: | `-InitListExpr 0x{{.+}} <col:32, col:34> 'int'{{$}}
-  // CHECK-NEXT: `-VarTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-19]]:7, col:43> col:43 referenced TestVarTemplate 'const int' implicit_instantiation static{{$}}
+  // CHECK-NEXT: `-VarTemplateSpecializationDecl 0x{{.+}} <line:[[@LINE-19]]:7, col:43> col:43 referenced TestVarTemplate 'const int' implicit_instantiation static instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:   `-TemplateArgument type 'int'{{$}}
 
-  // CHECK:     VarTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-22]]:7, col:43> col:43 referenced TestVarTemplate 'const int' implicit_instantiation static{{$}}
+  // CHECK:     VarTemplateSpecializationDecl 0x{{.+}} <{{.+}}:[[@LINE-22]]:7, col:43> col:43 referenced TestVarTemplate 'const int' implicit_instantiation static instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:`-TemplateArgument type 'int'{{$}}
   // CHECK-NEXT:  `-BuiltinType 0x{{.+}} 'int'{{$}}
 
   // CHECK:      VarTemplateDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-24]]:3, line:[[@LINE-23]]:34> col:14 TestVarTemplate{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <line:[[@LINE-25]]:12, col:21> col:21 referenced typename depth 0 index 0 T{{$}}
-  // CHECK-NEXT: |-VarDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-25]]:3, col:34> col:14 TestVarTemplate 'const T' cinit{{$}}
+  // CHECK-NEXT: |-VarDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <line:[[@LINE-25]]:3, col:34> col:14 TestVarTemplate 'const T' cinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT: | |-NestedNameSpecifier TypeSpec 'S'{{$}}
   // CHECK-NEXT: | `-InitListExpr 0x{{.+}} <col:32, col:34> 'void'{{$}}
   // CHECK-NEXT: |-VarTemplateSpecialization 0x{{.+}} 'TestVarTemplate' 'const int'{{$}}
   // CHECK-NEXT: `-VarTemplateSpecialization 0x{{.+}} 'TestVarTemplate' 'const int'{{$}}
 
-  // CHECK:      VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-32]]:3, line:[[@LINE-31]]:34> col:14 referenced TestVarTemplate 'const int' implicit_instantiation cinit{{$}}
+  // CHECK:      VarTemplateSpecializationDecl 0x{{.+}} parent 0x{{.+}} prev 0x{{.+}} <{{.+}}:[[@LINE-32]]:3, line:[[@LINE-31]]:34> col:14 referenced TestVarTemplate 'const int' implicit_instantiation cinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT: |-NestedNameSpecifier TypeSpec 'S'{{$}}
   // CHECK-NEXT: |-TemplateArgument type 'int'{{$}}
   // CHECK-NEXT: | `-BuiltinType 0x{{.+}} 'int'{{$}}
@@ -945,13 +945,13 @@ namespace TestConstexprVariableTemplateWithInitializer {
   template<typename T> constexpr T foo{};
   // CHECK:      VarTemplateDecl 0x{{.+}} <{{.+}}:[[@LINE-1]]:3, col:40> col:36 foo{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <col:12, col:21> col:21 referenced typename depth 0 index 0 T{{$}}
-  // CHECK-NEXT: `-VarDecl 0x{{.+}} <col:24, col:40> col:36 foo 'const T' constexpr listinit{{$}}
+  // CHECK-NEXT: `-VarDecl 0x{{.+}} <col:24, col:40> col:36 foo 'const T' constexpr listinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:  `-InitListExpr 0x{{.+}} <col:39, col:40> 'void'{{$}}
 
   template<typename T> constexpr int val{42};
   // CHECK:      VarTemplateDecl 0x{{.+}} <{{.+}}:[[@LINE-1]]:3, col:44> col:38 val{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <col:12, col:21> col:21 typename depth 0 index 0 T{{$}}
-  // CHECK-NEXT: `-VarDecl 0x{{.+}} <col:24, col:44> col:38 val 'const int' constexpr listinit{{$}}
+  // CHECK-NEXT: `-VarDecl 0x{{.+}} <col:24, col:44> col:38 val 'const int' constexpr listinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:  |-value: Int 42{{$}}
   // CHECK-NEXT:  `-InitListExpr 0x{{.+}} <col:41, col:44> 'int'{{$}}
 
@@ -964,13 +964,13 @@ namespace TestConstexprVariableTemplateWithInitializer {
   inline constexpr in_place_type_t<_Tp> in_place_type{};
   // CHECK:     -VarTemplateDecl 0x{{.+}} <line:[[@LINE-2]]:3, line:[[@LINE-1]]:55> col:41 in_place_type{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <line:[[@LINE-3]]:13, col:22> col:22 referenced typename depth 0 index 0 _Tp{{$}}
-  // CHECK-NEXT: `-VarDecl 0x{{.+}} <line:[[@LINE-3]]:3, col:55> col:41 in_place_type 'const in_place_type_t<_Tp>' inline constexpr listinit{{$}}
+  // CHECK-NEXT: `-VarDecl 0x{{.+}} <line:[[@LINE-3]]:3, col:55> col:41 in_place_type 'const in_place_type_t<_Tp>' inline constexpr listinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:  `-InitListExpr 0x{{.+}} <col:54, col:55> 'void'{{$}}
 
   template <typename T> constexpr T call_init(0);
   // CHECK:     -VarTemplateDecl 0x{{.+}} <line:[[@LINE-1]]:3, col:48> col:37 call_init{{$}}
   // CHECK-NEXT: |-TemplateTypeParmDecl 0x{{.+}} <col:13, col:22> col:22 referenced typename depth 0 index 0 T{{$}}
-  // CHECK-NEXT: `-VarDecl 0x{{.+}} <col:25, col:48> col:37 call_init 'const T' constexpr callinit{{$}}
+  // CHECK-NEXT: `-VarDecl 0x{{.+}} <col:25, col:48> col:37 call_init 'const T' constexpr callinit instantiated_from 0x{{.+}}{{$}}
   // CHECK-NEXT:  `-ParenListExpr 0x{{.+}} <col:46, col:48> 'NULL TYPE'{{$}}
   // CHECK-NEXT:   `-IntegerLiteral 0x{{.+}} <col:47> 'int' 0{{$}}
 }

--- a/clang/test/AST/ast-dump-template-json-win32-mangler-crash.cpp
+++ b/clang/test/AST/ast-dump-template-json-win32-mangler-crash.cpp
@@ -1024,6 +1024,7 @@ int main()
 // CHECK-NEXT:      "inline": true,
 // CHECK-NEXT:      "constexpr": true,
 // CHECK-NEXT:      "init": "c",
+// CHECK-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // CHECK-NEXT:      "inner": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "id": "0x{{.*}}",
@@ -1251,6 +1252,7 @@ int main()
 // CHECK-NEXT:      "inline": true,
 // CHECK-NEXT:      "constexpr": true,
 // CHECK-NEXT:      "init": "c",
+// CHECK-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // CHECK-NEXT:      "inner": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "id": "0x{{.*}}",
@@ -1761,6 +1763,7 @@ int main()
 // CHECK-NEXT:      "inline": true,
 // CHECK-NEXT:      "constexpr": true,
 // CHECK-NEXT:      "init": "c",
+// CHECK-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // CHECK-NEXT:      "inner": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "id": "0x{{.*}}",
@@ -2781,6 +2784,7 @@ int main()
 // CHECK-NEXT:      "inline": true,
 // CHECK-NEXT:      "constexpr": true,
 // CHECK-NEXT:      "init": "c",
+// CHECK-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // CHECK-NEXT:      "inner": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "id": "0x{{.*}}",
@@ -3077,6 +3081,7 @@ int main()
 // CHECK-NEXT:      "inline": true,
 // CHECK-NEXT:      "constexpr": true,
 // CHECK-NEXT:      "init": "c",
+// CHECK-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // CHECK-NEXT:      "inner": [
 // CHECK-NEXT:       {
 // CHECK-NEXT:        "id": "0x{{.*}}",

--- a/clang/test/AST/ast-dump-templates-pattern.cpp
+++ b/clang/test/AST/ast-dump-templates-pattern.cpp
@@ -1,0 +1,74 @@
+// RUN: %clang_cc1 -triple x86_64 -std=c++26 -ast-dump -ast-dump-filter=Test %s \
+// RUN: | FileCheck --match-full-lines %s
+
+// Test with serialization:
+// RUN: %clang_cc1 -triple x86_64 -std=c++26 -emit-pch -o %t %s
+// RUN: %clang_cc1 -triple x86_64 -x c++ -std=c++26 -include-pch %t -ast-dump-all -ast-dump-filter=Test /dev/null \
+// RUN: | sed -e "s/ <undeserialized declarations>//" -e "s/ imported//" \
+// RUN: | FileCheck --match-full-lines %s
+
+namespace TestClassRedecl {
+  template <class T> struct A {};
+  template <class T> struct A;
+  template struct A<int>;
+// CHECK-LABEL: Dumping TestClassRedecl:
+// CHECK: |-ClassTemplateDecl {{.+}} <line:[[@LINE-4]]:{{.+}} A
+// CHECK: | |-CXXRecordDecl 0x[[TestClassRedecl_D1:[^ ]+]] {{.+}} struct A definition
+// CHECK: | `-ClassTemplateSpecialization 0x[[TestClassRedecl_S:[^ ]+]] 'A'
+// CHECK: |-ClassTemplateDecl {{.+}} <line:[[@LINE-6]]:{{.+}} A
+// CHECK: | |-CXXRecordDecl 0x[[TestClassRedecl_D2:[^ ]+]] prev 0x[[TestClassRedecl_D1]] {{.+}} struct A
+// CHECK: | `-ClassTemplateSpecialization 0x[[TestClassRedecl_S]] 'A'
+// CHECK: `-ClassTemplateSpecializationDecl 0x[[TestClassRedecl_S]] <line:[[@LINE-8]]:{{.+}} struct A definition instantiated_from 0x[[TestClassRedecl_D1]] explicit_instantiation_definition
+}
+
+namespace TestFunctionRedecl {
+  template <class T> void f() {}
+  template <class T> void f();
+  template void f<int>();
+// CHECK-LABEL: Dumping TestFunctionRedecl:
+// CHECK: |-FunctionTemplateDecl 0x[[TestFunctionRedecl_T1:[^ ]+]] <line:[[@LINE-4]]:{{.+}} f
+// CHECK: | |-FunctionDecl 0x[[TestFunctionRedecl_D1:[^ ]+]] {{.+}} f 'void ()'
+// CHECK: | `-FunctionDecl 0x[[TestFunctionRedecl_S1:[^ ]+]] {{.+}} f 'void ()' explicit_instantiation_definition instantiated_from 0x[[TestFunctionRedecl_D1]]
+// CHECK: `-FunctionTemplateDecl 0x[[TestFunctionRedecl_T2:[^ ]+]] prev 0x[[TestFunctionRedecl_T1]] <line:[[@LINE-6]]:{{.+}} f
+// CHECK:   |-FunctionDecl 0x[[TestFunctionRedecl_D2:[^ ]+]] prev 0x[[TestFunctionRedecl_D1]] {{.+}} f 'void ()'
+// CHECK:   `-Function 0x[[TestFunctionRedecl_S1]] 'f' 'void ()'
+}
+
+// FIXME: Bogus instantiated_from self-reference.
+namespace TestVariableRedecl {
+  template <class T> T a = 0;
+  template <class T> extern T a;
+  template int a<int>;
+// CHECK-LABEL: Dumping TestVariableRedecl:
+// CHECK: |-VarTemplateDecl 0x[[TestVariableRedecl_T1:[^ ]+]] <line:[[@LINE-4]]:{{.+}} a
+// CHECK: | |-VarDecl 0x[[TestVariableRedecl_D1:[^ ]+]] {{.+}} a 'T' cinit instantiated_from 0x[[TestVariableRedecl_D1]]
+// CHECK: | `-VarTemplateSpecialization 0x[[TestVariableRedecl_S1:[^ ]+]] 'a' 'int'
+// CHECK: |-VarTemplateDecl 0x[[TestVariableRedecl_T2:[^ ]+]] prev 0x[[TestVariableRedecl_T1]] <line:[[@LINE-6]]:{{.+}} a
+// CHECK: | |-VarDecl 0x[[TestVariableRedecl_D2:[^ ]+]] prev 0x[[TestVariableRedecl_D1]] {{.+}} a 'T' extern instantiated_from 0x[[TestVariableRedecl_D1]]
+// CHECK: | `-VarTemplateSpecialization 0x[[TestVariableRedecl_S1]] 'a' 'int'
+// CHECK: `-VarTemplateSpecializationDecl 0x[[TestVariableRedecl_S1]] {{.+}} a 'int' explicit_instantiation_definition cinit instantiated_from 0x[[TestVariableRedecl_D1]]
+}
+
+namespace TestNestedClassRedecl {
+  template <class T> struct A {
+    template <class U> struct B;
+  };
+  template <class T> struct A;
+  template <class T> template <class U> struct A<T>::B {};
+  template struct A<int>::B<char>;
+// CHECK-LABEL: Dumping TestNestedClassRedecl:
+// CHECK: |-ClassTemplateDecl 0x[[TestNestedClassRedecl_A_T1:[^ ]+]] <line:[[@LINE-7]]:{{.+}} A
+// CHECK: | |-CXXRecordDecl 0x[[TestNestedClassRedecl_A_D1:[^ ]+]] <{{.+}}line:[[@LINE-6]]:{{.+}}> line:[[@LINE-8]]:{{.+}} struct A definition
+// CHECK: | | `-ClassTemplateDecl 0x[[TestNestedClassRedecl_B_T1:[^ ]+]] <line:[[@LINE-8]]:{{.+}} B
+// CHECK: | |   `-CXXRecordDecl 0x[[TestNestedClassRedecl_B_D1:[^ ]+]] {{.+}} struct B
+// CHECK: | `-ClassTemplateSpecializationDecl 0x[[TestNestedClassRedecl_A_S1:[^ ]+]] <line:[[@LINE-8]]:{{.+}} line:[[@LINE-11]]:{{.+}} struct A definition instantiated_from 0x[[TestNestedClassRedecl_A_D1]] implicit_instantiation
+// CHECK: |   `-ClassTemplateDecl 0x{{.+}} <line:[[@LINE-11]]:{{.+}} B
+// CHECK: |     |-CXXRecordDecl 0x{{.+}} struct B
+// CHECK: |     `-ClassTemplateSpecialization  0x[[TestNestedClassRedecl_B_S1:[^ ]+]] 'B'
+// CHECK: |-ClassTemplateDecl 0x{{.+}} prev 0x[[TestNestedClassRedecl_A_T1]] <line:[[@LINE-12]]:{{.+}} A
+// CHECK: | |-CXXRecordDecl 0x[[TestNestedClassRedecl_A_D2:[^ ]+]] prev 0x[[TestNestedClassRedecl_A_D1]] {{.+}} struct A
+// CHECK: | `-ClassTemplateSpecialization 0x[[TestNestedClassRedecl_A_S1]] 'A'
+// CHECK: |-ClassTemplateDecl 0x{{.+}} parent 0x[[TestNestedClassRedecl_A_D1]] prev 0x[[TestNestedClassRedecl_B_T1]] <line:[[@LINE-14]]:{{.+}} B
+// CHECK: | `-CXXRecordDecl 0x[[TestNestedClassRedecl_B_D2:[^ ]+]] parent 0x[[TestNestedClassRedecl_A_D1]] prev 0x[[TestNestedClassRedecl_B_D1]] {{.+}} struct B definition
+// CHECK: `-ClassTemplateSpecializationDecl 0x[[TestNestedClassRedecl_B_S1]] parent 0x[[TestNestedClassRedecl_A_S1]] <line:[[@LINE-15]]:{{.+}} struct B definition instantiated_from 0x[[TestNestedClassRedecl_B_D2]] explicit_instantiation_definition
+}

--- a/clang/test/AST/ast-dump-templates.cpp
+++ b/clang/test/AST/ast-dump-templates.cpp
@@ -132,7 +132,11 @@ namespace test7 {
   template <class...> class B {};
   template struct A<B>;
 // DUMP-LABEL: NamespaceDecl {{.*}} test7{{$}}
-// DUMP:       ClassTemplateSpecializationDecl {{.*}} struct A definition explicit_instantiation_definition strict-pack-match{{$}}
+// DUMP:       ClassTemplateDecl 0x{{.+}} A{{$}}
+// DUMP-NEXT:  |-TemplateTemplateParmDecl
+// DUMP-NEXT:  | `-TemplateTypeParmDecl
+// DUMP-NEXT:  |-CXXRecordDecl 0x[[TEST7_PAT:[^ ]+]] {{.+}} struct A definition
+// DUMP:       ClassTemplateSpecializationDecl {{.*}} struct A definition instantiated_from 0x[[TEST7_PAT]] explicit_instantiation_definition strict-pack-match{{$}}
 } // namespce test7
 
 namespace test8 {
@@ -929,6 +933,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "name": "foo",
 // JSON-NEXT:      "tagUsed": "struct",
 // JSON-NEXT:      "completeDefinition": true,
+// JSON-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:      "definitionData": {
 // JSON-NEXT:       "canConstDefaultInit": true,
 // JSON-NEXT:       "canPassInRegisters": true,
@@ -1073,6 +1078,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "void ()"
 // JSON-NEXT:        },
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "id": "0x{{.*}}",
@@ -1119,6 +1125,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "int ()"
 // JSON-NEXT:        },
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "id": "0x{{.*}}",
@@ -1566,6 +1573,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "name": "foo",
 // JSON-NEXT:      "tagUsed": "struct",
 // JSON-NEXT:      "completeDefinition": true,
+// JSON-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:      "definitionData": {
 // JSON-NEXT:       "canConstDefaultInit": true,
 // JSON-NEXT:       "canPassInRegisters": true,
@@ -1710,6 +1718,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "void ()"
 // JSON-NEXT:        },
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "id": "0x{{.*}}",
@@ -1756,6 +1765,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "double ()"
 // JSON-NEXT:        },
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "id": "0x{{.*}}",
@@ -2430,6 +2440,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "type": {
 // JSON-NEXT:       "qualType": "int ()"
 // JSON-NEXT:      },
+// JSON-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:      "inner": [
 // JSON-NEXT:       {
 // JSON-NEXT:        "kind": "TemplateArgument",
@@ -4621,6 +4632,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "name": "foo",
 // JSON-NEXT:        "tagUsed": "struct",
 // JSON-NEXT:        "completeDefinition": true,
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "definitionData": {
 // JSON-NEXT:         "canConstDefaultInit": true,
 // JSON-NEXT:         "canPassInRegisters": true,
@@ -4733,7 +4745,8 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "type": {
 // JSON-NEXT:           "qualType": "void ()"
 // JSON-NEXT:          },
-// JSON-NEXT:          "storageClass": "static"
+// JSON-NEXT:          "storageClass": "static",
+// JSON-NEXT:          "TemplateInstantiationPattern": "0x{{.*}}"
 // JSON-NEXT:         }
 // JSON-NEXT:        ]
 // JSON-NEXT:       },
@@ -4892,6 +4905,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "name": "foo",
 // JSON-NEXT:      "tagUsed": "struct",
 // JSON-NEXT:      "completeDefinition": true,
+// JSON-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:      "definitionData": {
 // JSON-NEXT:       "canConstDefaultInit": true,
 // JSON-NEXT:       "canPassInRegisters": true,
@@ -5003,7 +5017,8 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "void ()"
 // JSON-NEXT:        },
-// JSON-NEXT:        "storageClass": "static"
+// JSON-NEXT:        "storageClass": "static",
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}"
 // JSON-NEXT:       }
 // JSON-NEXT:      ]
 // JSON-NEXT:     }
@@ -5151,6 +5166,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "void ()"
 // JSON-NEXT:        },
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "kind": "TemplateArgument",
@@ -5425,6 +5441,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "type": {
 // JSON-NEXT:         "qualType": "void ()"
 // JSON-NEXT:        },
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "kind": "TemplateArgument",
@@ -5640,6 +5657,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        },
 // JSON-NEXT:        "constexpr": true,
 // JSON-NEXT:        "init": "c",
+// JSON-NEXT:        "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:        "inner": [
 // JSON-NEXT:         {
 // JSON-NEXT:          "id": "0x{{.*}}",
@@ -5843,8 +5861,8 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 4308,
-// JSON-NEXT:      "line": 136,
+// JSON-NEXT:      "offset": 4553,
+// JSON-NEXT:      "line": 140,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -6206,6 +6224,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "tagUsed": "struct",
 // JSON-NEXT:      "completeDefinition": true,
 // JSON-NEXT:      "strict-pack-match": true,
+// JSON-NEXT:      "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:      "definitionData": {
 // JSON-NEXT:       "canConstDefaultInit": true,
 // JSON-NEXT:       "canPassInRegisters": true,
@@ -6294,20 +6313,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:    "id": "0x{{.*}}",
 // JSON-NEXT:    "kind": "NamespaceDecl",
 // JSON-NEXT:    "loc": {
-// JSON-NEXT:     "offset": 4339,
-// JSON-NEXT:     "line": 138,
+// JSON-NEXT:     "offset": 4584,
+// JSON-NEXT:     "line": 142,
 // JSON-NEXT:     "col": 11,
 // JSON-NEXT:     "tokLen": 5
 // JSON-NEXT:    },
 // JSON-NEXT:    "range": {
 // JSON-NEXT:     "begin": {
-// JSON-NEXT:      "offset": 4329,
+// JSON-NEXT:      "offset": 4574,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 4648,
-// JSON-NEXT:      "line": 147,
+// JSON-NEXT:      "offset": 4893,
+// JSON-NEXT:      "line": 151,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -6318,21 +6337,21 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 4379,
-// JSON-NEXT:       "line": 140,
+// JSON-NEXT:       "offset": 4624,
+// JSON-NEXT:       "line": 144,
 // JSON-NEXT:       "col": 8,
 // JSON-NEXT:       "tokLen": 8
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 4347,
-// JSON-NEXT:        "line": 139,
+// JSON-NEXT:        "offset": 4592,
+// JSON-NEXT:        "line": 143,
 // JSON-NEXT:        "col": 1,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 4379,
-// JSON-NEXT:        "line": 140,
+// JSON-NEXT:        "offset": 4624,
+// JSON-NEXT:        "line": 144,
 // JSON-NEXT:        "col": 8,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       }
@@ -6343,19 +6362,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 4369,
-// JSON-NEXT:         "line": 139,
+// JSON-NEXT:         "offset": 4614,
+// JSON-NEXT:         "line": 143,
 // JSON-NEXT:         "col": 23,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 4356,
+// JSON-NEXT:          "offset": 4601,
 // JSON-NEXT:          "col": 10,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 4369,
+// JSON-NEXT:          "offset": 4614,
 // JSON-NEXT:          "col": 23,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -6371,19 +6390,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 4379,
-// JSON-NEXT:         "line": 140,
+// JSON-NEXT:         "offset": 4624,
+// JSON-NEXT:         "line": 144,
 // JSON-NEXT:         "col": 8,
 // JSON-NEXT:         "tokLen": 8
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 4372,
+// JSON-NEXT:          "offset": 4617,
 // JSON-NEXT:          "col": 1,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 4379,
+// JSON-NEXT:          "offset": 4624,
 // JSON-NEXT:          "col": 8,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         }
@@ -6402,21 +6421,21 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplateSpecializationDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 4407,
-// JSON-NEXT:       "line": 142,
+// JSON-NEXT:       "offset": 4652,
+// JSON-NEXT:       "line": 146,
 // JSON-NEXT:       "col": 8,
 // JSON-NEXT:       "tokLen": 8
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 4389,
-// JSON-NEXT:        "line": 141,
+// JSON-NEXT:        "offset": 4634,
+// JSON-NEXT:        "line": 145,
 // JSON-NEXT:        "col": 1,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 4422,
-// JSON-NEXT:        "line": 142,
+// JSON-NEXT:        "offset": 4667,
+// JSON-NEXT:        "line": 146,
 // JSON-NEXT:        "col": 23,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -6436,20 +6455,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:    "id": "0x{{.*}}",
 // JSON-NEXT:    "kind": "NamespaceDecl",
 // JSON-NEXT:    "loc": {
-// JSON-NEXT:     "offset": 4680,
-// JSON-NEXT:     "line": 149,
+// JSON-NEXT:     "offset": 4925,
+// JSON-NEXT:     "line": 153,
 // JSON-NEXT:     "col": 11,
 // JSON-NEXT:     "tokLen": 28
 // JSON-NEXT:    },
 // JSON-NEXT:    "range": {
 // JSON-NEXT:     "begin": {
-// JSON-NEXT:      "offset": 4670,
+// JSON-NEXT:      "offset": 4915,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 5303,
-// JSON-NEXT:      "line": 158,
+// JSON-NEXT:      "offset": 5548,
+// JSON-NEXT:      "line": 162,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -6460,19 +6479,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 4737,
-// JSON-NEXT:       "line": 150,
+// JSON-NEXT:       "offset": 4982,
+// JSON-NEXT:       "line": 154,
 // JSON-NEXT:       "col": 27,
 // JSON-NEXT:       "tokLen": 1
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 4713,
+// JSON-NEXT:        "offset": 4958,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 4737,
+// JSON-NEXT:        "offset": 4982,
 // JSON-NEXT:        "col": 27,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -6483,18 +6502,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 4728,
+// JSON-NEXT:         "offset": 4973,
 // JSON-NEXT:         "col": 18,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 4723,
+// JSON-NEXT:          "offset": 4968,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 4723,
+// JSON-NEXT:          "offset": 4968,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         }
@@ -6507,18 +6526,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 4737,
+// JSON-NEXT:         "offset": 4982,
 // JSON-NEXT:         "col": 27,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 4730,
+// JSON-NEXT:          "offset": 4975,
 // JSON-NEXT:          "col": 20,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 4737,
+// JSON-NEXT:          "offset": 4982,
 // JSON-NEXT:          "col": 27,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -6532,19 +6551,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplatePartialSpecializationDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 4779,
-// JSON-NEXT:       "line": 151,
+// JSON-NEXT:       "offset": 5024,
+// JSON-NEXT:       "line": 155,
 // JSON-NEXT:       "col": 40,
 // JSON-NEXT:       "tokLen": 1
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 4742,
+// JSON-NEXT:        "offset": 4987,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 4789,
+// JSON-NEXT:        "offset": 5034,
 // JSON-NEXT:        "col": 50,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -6604,18 +6623,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 4758,
+// JSON-NEXT:         "offset": 5003,
 // JSON-NEXT:         "col": 19,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 4752,
+// JSON-NEXT:          "offset": 4997,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 4758,
+// JSON-NEXT:          "offset": 5003,
 // JSON-NEXT:          "col": 19,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -6630,18 +6649,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 4768,
+// JSON-NEXT:         "offset": 5013,
 // JSON-NEXT:         "col": 29,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 4762,
+// JSON-NEXT:          "offset": 5007,
 // JSON-NEXT:          "col": 23,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 4768,
+// JSON-NEXT:          "offset": 5013,
 // JSON-NEXT:          "col": 29,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -6659,20 +6678,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:    "id": "0x{{.*}}",
 // JSON-NEXT:    "kind": "NamespaceDecl",
 // JSON-NEXT:    "loc": {
-// JSON-NEXT:     "offset": 5358,
-// JSON-NEXT:     "line": 160,
+// JSON-NEXT:     "offset": 5603,
+// JSON-NEXT:     "line": 164,
 // JSON-NEXT:     "col": 11,
 // JSON-NEXT:     "tokLen": 26
 // JSON-NEXT:    },
 // JSON-NEXT:    "range": {
 // JSON-NEXT:     "begin": {
-// JSON-NEXT:      "offset": 5348,
+// JSON-NEXT:      "offset": 5593,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 6613,
-// JSON-NEXT:      "line": 183,
+// JSON-NEXT:      "offset": 6858,
+// JSON-NEXT:      "line": 187,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -6683,20 +6702,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 5415,
-// JSON-NEXT:       "line": 161,
+// JSON-NEXT:       "offset": 5660,
+// JSON-NEXT:       "line": 165,
 // JSON-NEXT:       "col": 29,
 // JSON-NEXT:       "tokLen": 1
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 5389,
+// JSON-NEXT:        "offset": 5634,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 5516,
-// JSON-NEXT:        "line": 165,
+// JSON-NEXT:        "offset": 5761,
+// JSON-NEXT:        "line": 169,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -6707,19 +6726,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 5405,
-// JSON-NEXT:         "line": 161,
+// JSON-NEXT:         "offset": 5650,
+// JSON-NEXT:         "line": 165,
 // JSON-NEXT:         "col": 19,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 5399,
+// JSON-NEXT:          "offset": 5644,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 5405,
+// JSON-NEXT:          "offset": 5650,
 // JSON-NEXT:          "col": 19,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -6733,19 +6752,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 5415,
+// JSON-NEXT:         "offset": 5660,
 // JSON-NEXT:         "col": 29,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 5408,
+// JSON-NEXT:          "offset": 5653,
 // JSON-NEXT:          "col": 22,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 5516,
-// JSON-NEXT:          "line": 165,
+// JSON-NEXT:          "offset": 5761,
+// JSON-NEXT:          "line": 169,
 // JSON-NEXT:          "col": 3,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -6808,19 +6827,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXRecordDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 5415,
-// JSON-NEXT:           "line": 161,
+// JSON-NEXT:           "offset": 5660,
+// JSON-NEXT:           "line": 165,
 // JSON-NEXT:           "col": 29,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 5408,
+// JSON-NEXT:            "offset": 5653,
 // JSON-NEXT:            "col": 22,
 // JSON-NEXT:            "tokLen": 6
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 5415,
+// JSON-NEXT:            "offset": 5660,
 // JSON-NEXT:            "col": 29,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -6833,19 +6852,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TypeAliasDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 5429,
-// JSON-NEXT:           "line": 162,
+// JSON-NEXT:           "offset": 5674,
+// JSON-NEXT:           "line": 166,
 // JSON-NEXT:           "col": 11,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 5423,
+// JSON-NEXT:            "offset": 5668,
 // JSON-NEXT:            "col": 5,
 // JSON-NEXT:            "tokLen": 5
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 5440,
+// JSON-NEXT:            "offset": 5685,
 // JSON-NEXT:            "col": 22,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -6896,19 +6915,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TypeAliasDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 5453,
-// JSON-NEXT:           "line": 163,
+// JSON-NEXT:           "offset": 5698,
+// JSON-NEXT:           "line": 167,
 // JSON-NEXT:           "col": 11,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 5447,
+// JSON-NEXT:            "offset": 5692,
 // JSON-NEXT:            "col": 5,
 // JSON-NEXT:            "tokLen": 5
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 5470,
+// JSON-NEXT:            "offset": 5715,
 // JSON-NEXT:            "col": 28,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -6952,19 +6971,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TypeAliasDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 5483,
-// JSON-NEXT:           "line": 164,
+// JSON-NEXT:           "offset": 5728,
+// JSON-NEXT:           "line": 168,
 // JSON-NEXT:           "col": 11,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 5477,
+// JSON-NEXT:            "offset": 5722,
 // JSON-NEXT:            "col": 5,
 // JSON-NEXT:            "tokLen": 5
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 5511,
+// JSON-NEXT:            "offset": 5756,
 // JSON-NEXT:            "col": 39,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -7032,20 +7051,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:    "id": "0x{{.*}}",
 // JSON-NEXT:    "kind": "NamespaceDecl",
 // JSON-NEXT:    "loc": {
-// JSON-NEXT:     "offset": 6666,
-// JSON-NEXT:     "line": 185,
+// JSON-NEXT:     "offset": 6911,
+// JSON-NEXT:     "line": 189,
 // JSON-NEXT:     "col": 11,
 // JSON-NEXT:     "tokLen": 19
 // JSON-NEXT:    },
 // JSON-NEXT:    "range": {
 // JSON-NEXT:     "begin": {
-// JSON-NEXT:      "offset": 6656,
+// JSON-NEXT:      "offset": 6901,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 9524,
-// JSON-NEXT:      "line": 225,
+// JSON-NEXT:      "offset": 9769,
+// JSON-NEXT:      "line": 229,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -7056,19 +7075,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 6789,
-// JSON-NEXT:       "line": 187,
+// JSON-NEXT:       "offset": 7034,
+// JSON-NEXT:       "line": 191,
 // JSON-NEXT:       "col": 41,
 // JSON-NEXT:       "tokLen": 9
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 6751,
+// JSON-NEXT:        "offset": 6996,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 6800,
+// JSON-NEXT:        "offset": 7045,
 // JSON-NEXT:        "col": 52,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -7079,18 +7098,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6767,
+// JSON-NEXT:         "offset": 7012,
 // JSON-NEXT:         "col": 19,
 // JSON-NEXT:         "tokLen": 3
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6761,
+// JSON-NEXT:          "offset": 7006,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6767,
+// JSON-NEXT:          "offset": 7012,
 // JSON-NEXT:          "col": 19,
 // JSON-NEXT:          "tokLen": 3
 // JSON-NEXT:         }
@@ -7104,18 +7123,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6777,
+// JSON-NEXT:         "offset": 7022,
 // JSON-NEXT:         "col": 29,
 // JSON-NEXT:         "tokLen": 3
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6772,
+// JSON-NEXT:          "offset": 7017,
 // JSON-NEXT:          "col": 24,
 // JSON-NEXT:          "tokLen": 4
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6777,
+// JSON-NEXT:          "offset": 7022,
 // JSON-NEXT:          "col": 29,
 // JSON-NEXT:          "tokLen": 3
 // JSON-NEXT:         }
@@ -7131,18 +7150,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6789,
+// JSON-NEXT:         "offset": 7034,
 // JSON-NEXT:         "col": 41,
 // JSON-NEXT:         "tokLen": 9
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6782,
+// JSON-NEXT:          "offset": 7027,
 // JSON-NEXT:          "col": 34,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6800,
+// JSON-NEXT:          "offset": 7045,
 // JSON-NEXT:          "col": 52,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -7205,18 +7224,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXRecordDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 6789,
+// JSON-NEXT:           "offset": 7034,
 // JSON-NEXT:           "col": 41,
 // JSON-NEXT:           "tokLen": 9
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 6782,
+// JSON-NEXT:            "offset": 7027,
 // JSON-NEXT:            "col": 34,
 // JSON-NEXT:            "tokLen": 6
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 6789,
+// JSON-NEXT:            "offset": 7034,
 // JSON-NEXT:            "col": 41,
 // JSON-NEXT:            "tokLen": 9
 // JSON-NEXT:           }
@@ -7233,19 +7252,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 6843,
-// JSON-NEXT:       "line": 188,
+// JSON-NEXT:       "offset": 7088,
+// JSON-NEXT:       "line": 192,
 // JSON-NEXT:       "col": 41,
 // JSON-NEXT:       "tokLen": 9
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 6805,
+// JSON-NEXT:        "offset": 7050,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 6854,
+// JSON-NEXT:        "offset": 7099,
 // JSON-NEXT:        "col": 52,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -7256,18 +7275,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6821,
+// JSON-NEXT:         "offset": 7066,
 // JSON-NEXT:         "col": 19,
 // JSON-NEXT:         "tokLen": 3
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6815,
+// JSON-NEXT:          "offset": 7060,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6821,
+// JSON-NEXT:          "offset": 7066,
 // JSON-NEXT:          "col": 19,
 // JSON-NEXT:          "tokLen": 3
 // JSON-NEXT:         }
@@ -7281,18 +7300,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6831,
+// JSON-NEXT:         "offset": 7076,
 // JSON-NEXT:         "col": 29,
 // JSON-NEXT:         "tokLen": 3
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6826,
+// JSON-NEXT:          "offset": 7071,
 // JSON-NEXT:          "col": 24,
 // JSON-NEXT:          "tokLen": 4
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6831,
+// JSON-NEXT:          "offset": 7076,
 // JSON-NEXT:          "col": 29,
 // JSON-NEXT:          "tokLen": 3
 // JSON-NEXT:         }
@@ -7308,18 +7327,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6843,
+// JSON-NEXT:         "offset": 7088,
 // JSON-NEXT:         "col": 41,
 // JSON-NEXT:         "tokLen": 9
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6836,
+// JSON-NEXT:          "offset": 7081,
 // JSON-NEXT:          "col": 34,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6854,
+// JSON-NEXT:          "offset": 7099,
 // JSON-NEXT:          "col": 52,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -7382,18 +7401,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXRecordDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 6843,
+// JSON-NEXT:           "offset": 7088,
 // JSON-NEXT:           "col": 41,
 // JSON-NEXT:           "tokLen": 9
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 6836,
+// JSON-NEXT:            "offset": 7081,
 // JSON-NEXT:            "col": 34,
 // JSON-NEXT:            "tokLen": 6
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 6843,
+// JSON-NEXT:            "offset": 7088,
 // JSON-NEXT:            "col": 41,
 // JSON-NEXT:            "tokLen": 9
 // JSON-NEXT:           }
@@ -7410,21 +7429,21 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplatePartialSpecializationDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 6907,
-// JSON-NEXT:       "line": 191,
+// JSON-NEXT:       "offset": 7152,
+// JSON-NEXT:       "line": 195,
 // JSON-NEXT:       "col": 10,
 // JSON-NEXT:       "tokLen": 9
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 6860,
-// JSON-NEXT:        "line": 190,
+// JSON-NEXT:        "offset": 7105,
+// JSON-NEXT:        "line": 194,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 6941,
-// JSON-NEXT:        "line": 191,
+// JSON-NEXT:        "offset": 7186,
+// JSON-NEXT:        "line": 195,
 // JSON-NEXT:        "col": 44,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -7531,12 +7550,12 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:              "kind": "DeclRefExpr",
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 6931,
+// JSON-NEXT:                "offset": 7176,
 // JSON-NEXT:                "col": 34,
 // JSON-NEXT:                "tokLen": 2
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 6931,
+// JSON-NEXT:                "offset": 7176,
 // JSON-NEXT:                "col": 34,
 // JSON-NEXT:                "tokLen": 2
 // JSON-NEXT:               }
@@ -7570,12 +7589,12 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "kind": "DeclRefExpr",
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 6936,
+// JSON-NEXT:            "offset": 7181,
 // JSON-NEXT:            "col": 39,
 // JSON-NEXT:            "tokLen": 2
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 6936,
+// JSON-NEXT:            "offset": 7181,
 // JSON-NEXT:            "col": 39,
 // JSON-NEXT:            "tokLen": 2
 // JSON-NEXT:           }
@@ -7599,19 +7618,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6876,
-// JSON-NEXT:         "line": 190,
+// JSON-NEXT:         "offset": 7121,
+// JSON-NEXT:         "line": 194,
 // JSON-NEXT:         "col": 19,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6870,
+// JSON-NEXT:          "offset": 7115,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6876,
+// JSON-NEXT:          "offset": 7121,
 // JSON-NEXT:          "col": 19,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -7626,18 +7645,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6885,
+// JSON-NEXT:         "offset": 7130,
 // JSON-NEXT:         "col": 28,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6880,
+// JSON-NEXT:          "offset": 7125,
 // JSON-NEXT:          "col": 23,
 // JSON-NEXT:          "tokLen": 4
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6885,
+// JSON-NEXT:          "offset": 7130,
 // JSON-NEXT:          "col": 28,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -7654,18 +7673,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6894,
+// JSON-NEXT:         "offset": 7139,
 // JSON-NEXT:         "col": 37,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6889,
+// JSON-NEXT:          "offset": 7134,
 // JSON-NEXT:          "col": 32,
 // JSON-NEXT:          "tokLen": 4
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6894,
+// JSON-NEXT:          "offset": 7139,
 // JSON-NEXT:          "col": 37,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -7682,19 +7701,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 6907,
-// JSON-NEXT:         "line": 191,
+// JSON-NEXT:         "offset": 7152,
+// JSON-NEXT:         "line": 195,
 // JSON-NEXT:         "col": 10,
 // JSON-NEXT:         "tokLen": 9
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 6900,
+// JSON-NEXT:          "offset": 7145,
 // JSON-NEXT:          "col": 3,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 6907,
+// JSON-NEXT:          "offset": 7152,
 // JSON-NEXT:          "col": 10,
 // JSON-NEXT:          "tokLen": 9
 // JSON-NEXT:         }
@@ -7709,21 +7728,21 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "ClassTemplatePartialSpecializationDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 8223,
-// JSON-NEXT:       "line": 209,
+// JSON-NEXT:       "offset": 8468,
+// JSON-NEXT:       "line": 213,
 // JSON-NEXT:       "col": 10,
 // JSON-NEXT:       "tokLen": 9
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 8173,
-// JSON-NEXT:        "line": 208,
+// JSON-NEXT:        "offset": 8418,
+// JSON-NEXT:        "line": 212,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 8257,
-// JSON-NEXT:        "line": 209,
+// JSON-NEXT:        "offset": 8502,
+// JSON-NEXT:        "line": 213,
 // JSON-NEXT:        "col": 44,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -7830,12 +7849,12 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:              "kind": "DeclRefExpr",
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 8247,
+// JSON-NEXT:                "offset": 8492,
 // JSON-NEXT:                "col": 34,
 // JSON-NEXT:                "tokLen": 2
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 8247,
+// JSON-NEXT:                "offset": 8492,
 // JSON-NEXT:                "col": 34,
 // JSON-NEXT:                "tokLen": 2
 // JSON-NEXT:               }
@@ -7869,12 +7888,12 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "kind": "DeclRefExpr",
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 8252,
+// JSON-NEXT:            "offset": 8497,
 // JSON-NEXT:            "col": 39,
 // JSON-NEXT:            "tokLen": 2
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 8252,
+// JSON-NEXT:            "offset": 8497,
 // JSON-NEXT:            "col": 39,
 // JSON-NEXT:            "tokLen": 2
 // JSON-NEXT:           }
@@ -7898,19 +7917,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 8192,
-// JSON-NEXT:         "line": 208,
+// JSON-NEXT:         "offset": 8437,
+// JSON-NEXT:         "line": 212,
 // JSON-NEXT:         "col": 22,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 8183,
+// JSON-NEXT:          "offset": 8428,
 // JSON-NEXT:          "col": 13,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 8192,
+// JSON-NEXT:          "offset": 8437,
 // JSON-NEXT:          "col": 22,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -7925,18 +7944,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 8201,
+// JSON-NEXT:         "offset": 8446,
 // JSON-NEXT:         "col": 31,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 8196,
+// JSON-NEXT:          "offset": 8441,
 // JSON-NEXT:          "col": 26,
 // JSON-NEXT:          "tokLen": 4
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 8201,
+// JSON-NEXT:          "offset": 8446,
 // JSON-NEXT:          "col": 31,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -7953,18 +7972,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "NonTypeTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 8210,
+// JSON-NEXT:         "offset": 8455,
 // JSON-NEXT:         "col": 40,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 8205,
+// JSON-NEXT:          "offset": 8450,
 // JSON-NEXT:          "col": 35,
 // JSON-NEXT:          "tokLen": 4
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 8210,
+// JSON-NEXT:          "offset": 8455,
 // JSON-NEXT:          "col": 40,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -7981,19 +8000,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "CXXRecordDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 8223,
-// JSON-NEXT:         "line": 209,
+// JSON-NEXT:         "offset": 8468,
+// JSON-NEXT:         "line": 213,
 // JSON-NEXT:         "col": 10,
 // JSON-NEXT:         "tokLen": 9
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 8216,
+// JSON-NEXT:          "offset": 8461,
 // JSON-NEXT:          "col": 3,
 // JSON-NEXT:          "tokLen": 6
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 8223,
+// JSON-NEXT:          "offset": 8468,
 // JSON-NEXT:          "col": 10,
 // JSON-NEXT:          "tokLen": 9
 // JSON-NEXT:         }
@@ -8010,20 +8029,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:    "id": "0x{{.*}}",
 // JSON-NEXT:    "kind": "NamespaceDecl",
 // JSON-NEXT:    "loc": {
-// JSON-NEXT:     "offset": 9570,
-// JSON-NEXT:     "line": 227,
+// JSON-NEXT:     "offset": 9815,
+// JSON-NEXT:     "line": 231,
 // JSON-NEXT:     "col": 11,
 // JSON-NEXT:     "tokLen": 8
 // JSON-NEXT:    },
 // JSON-NEXT:    "range": {
 // JSON-NEXT:     "begin": {
-// JSON-NEXT:      "offset": 9560,
+// JSON-NEXT:      "offset": 9805,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 9979,
-// JSON-NEXT:      "line": 241,
+// JSON-NEXT:      "offset": 10224,
+// JSON-NEXT:      "line": 245,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -8034,20 +8053,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "NamespaceDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 9644,
-// JSON-NEXT:       "line": 230,
+// JSON-NEXT:       "offset": 9889,
+// JSON-NEXT:       "line": 234,
 // JSON-NEXT:       "col": 13,
 // JSON-NEXT:       "tokLen": 1
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 9634,
+// JSON-NEXT:        "offset": 9879,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 9
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 9695,
-// JSON-NEXT:        "line": 232,
+// JSON-NEXT:        "offset": 9940,
+// JSON-NEXT:        "line": 236,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -8058,19 +8077,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "ClassTemplateDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 9680,
-// JSON-NEXT:         "line": 231,
+// JSON-NEXT:         "offset": 9925,
+// JSON-NEXT:         "line": 235,
 // JSON-NEXT:         "col": 33,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 9652,
+// JSON-NEXT:          "offset": 9897,
 // JSON-NEXT:          "col": 5,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 9690,
+// JSON-NEXT:          "offset": 9935,
 // JSON-NEXT:          "col": 43,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -8081,18 +8100,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9670,
+// JSON-NEXT:           "offset": 9915,
 // JSON-NEXT:           "col": 23,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9661,
+// JSON-NEXT:            "offset": 9906,
 // JSON-NEXT:            "col": 14,
 // JSON-NEXT:            "tokLen": 8
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9670,
+// JSON-NEXT:            "offset": 9915,
 // JSON-NEXT:            "col": 23,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8107,18 +8126,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXRecordDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9680,
+// JSON-NEXT:           "offset": 9925,
 // JSON-NEXT:           "col": 33,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9673,
+// JSON-NEXT:            "offset": 9918,
 // JSON-NEXT:            "col": 26,
 // JSON-NEXT:            "tokLen": 6
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9690,
+// JSON-NEXT:            "offset": 9935,
 // JSON-NEXT:            "col": 43,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8173,18 +8192,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXRecordDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9680,
+// JSON-NEXT:             "offset": 9925,
 // JSON-NEXT:             "col": 33,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9673,
+// JSON-NEXT:              "offset": 9918,
 // JSON-NEXT:              "col": 26,
 // JSON-NEXT:              "tokLen": 6
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8197,18 +8216,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXConstructorDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9684,
+// JSON-NEXT:             "offset": 9929,
 // JSON-NEXT:             "col": 37,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9684,
+// JSON-NEXT:              "offset": 9929,
 // JSON-NEXT:              "col": 37,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9687,
+// JSON-NEXT:              "offset": 9932,
 // JSON-NEXT:              "col": 40,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8222,18 +8241,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:              "id": "0x{{.*}}",
 // JSON-NEXT:              "kind": "ParmVarDecl",
 // JSON-NEXT:              "loc": {
-// JSON-NEXT:               "offset": 9687,
+// JSON-NEXT:               "offset": 9932,
 // JSON-NEXT:               "col": 40,
 // JSON-NEXT:               "tokLen": 1
 // JSON-NEXT:              },
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 9686,
+// JSON-NEXT:                "offset": 9931,
 // JSON-NEXT:                "col": 39,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 9686,
+// JSON-NEXT:                "offset": 9931,
 // JSON-NEXT:                "col": 39,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               }
@@ -8250,18 +8269,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "ClassTemplateSpecializationDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9680,
+// JSON-NEXT:           "offset": 9925,
 // JSON-NEXT:           "col": 33,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9652,
+// JSON-NEXT:            "offset": 9897,
 // JSON-NEXT:            "col": 5,
 // JSON-NEXT:            "tokLen": 8
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9690,
+// JSON-NEXT:            "offset": 9935,
 // JSON-NEXT:            "col": 43,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8269,6 +8288,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "name": "S",
 // JSON-NEXT:          "tagUsed": "struct",
 // JSON-NEXT:          "completeDefinition": true,
+// JSON-NEXT:          "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:          "definitionData": {
 // JSON-NEXT:           "canConstDefaultInit": true,
 // JSON-NEXT:           "canPassInRegisters": true,
@@ -8329,18 +8349,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXRecordDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9680,
+// JSON-NEXT:             "offset": 9925,
 // JSON-NEXT:             "col": 33,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9673,
+// JSON-NEXT:              "offset": 9918,
 // JSON-NEXT:              "col": 26,
 // JSON-NEXT:              "tokLen": 6
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8353,18 +8373,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXConstructorDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9684,
+// JSON-NEXT:             "offset": 9929,
 // JSON-NEXT:             "col": 37,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9684,
+// JSON-NEXT:              "offset": 9929,
 // JSON-NEXT:              "col": 37,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9687,
+// JSON-NEXT:              "offset": 9932,
 // JSON-NEXT:              "col": 40,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8375,23 +8395,24 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "type": {
 // JSON-NEXT:             "qualType": "void (int)"
 // JSON-NEXT:            },
+// JSON-NEXT:            "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:            "inner": [
 // JSON-NEXT:             {
 // JSON-NEXT:              "id": "0x{{.*}}",
 // JSON-NEXT:              "kind": "ParmVarDecl",
 // JSON-NEXT:              "loc": {
-// JSON-NEXT:               "offset": 9687,
+// JSON-NEXT:               "offset": 9932,
 // JSON-NEXT:               "col": 40,
 // JSON-NEXT:               "tokLen": 1
 // JSON-NEXT:              },
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 9686,
+// JSON-NEXT:                "offset": 9931,
 // JSON-NEXT:                "col": 39,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 9686,
+// JSON-NEXT:                "offset": 9931,
 // JSON-NEXT:                "col": 39,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               }
@@ -8406,18 +8427,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXConstructorDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9680,
+// JSON-NEXT:             "offset": 9925,
 // JSON-NEXT:             "col": 33,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8436,18 +8457,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:              "id": "0x{{.*}}",
 // JSON-NEXT:              "kind": "ParmVarDecl",
 // JSON-NEXT:              "loc": {
-// JSON-NEXT:               "offset": 9680,
+// JSON-NEXT:               "offset": 9925,
 // JSON-NEXT:               "col": 33,
 // JSON-NEXT:               "tokLen": 1
 // JSON-NEXT:              },
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 9680,
+// JSON-NEXT:                "offset": 9925,
 // JSON-NEXT:                "col": 33,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 9680,
+// JSON-NEXT:                "offset": 9925,
 // JSON-NEXT:                "col": 33,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               }
@@ -8462,18 +8483,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXConstructorDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9680,
+// JSON-NEXT:             "offset": 9925,
 // JSON-NEXT:             "col": 33,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8492,18 +8513,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:              "id": "0x{{.*}}",
 // JSON-NEXT:              "kind": "ParmVarDecl",
 // JSON-NEXT:              "loc": {
-// JSON-NEXT:               "offset": 9680,
+// JSON-NEXT:               "offset": 9925,
 // JSON-NEXT:               "col": 33,
 // JSON-NEXT:               "tokLen": 1
 // JSON-NEXT:              },
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 9680,
+// JSON-NEXT:                "offset": 9925,
 // JSON-NEXT:                "col": 33,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 9680,
+// JSON-NEXT:                "offset": 9925,
 // JSON-NEXT:                "col": 33,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               }
@@ -8518,18 +8539,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "CXXDestructorDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9680,
+// JSON-NEXT:             "offset": 9925,
 // JSON-NEXT:             "col": 33,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8553,18 +8574,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "FunctionTemplateDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 9684,
+// JSON-NEXT:         "offset": 9929,
 // JSON-NEXT:         "col": 37,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 9652,
+// JSON-NEXT:          "offset": 9897,
 // JSON-NEXT:          "col": 5,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 9687,
+// JSON-NEXT:          "offset": 9932,
 // JSON-NEXT:          "col": 40,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -8576,18 +8597,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9670,
+// JSON-NEXT:           "offset": 9915,
 // JSON-NEXT:           "col": 23,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9661,
+// JSON-NEXT:            "offset": 9906,
 // JSON-NEXT:            "col": 14,
 // JSON-NEXT:            "tokLen": 8
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9670,
+// JSON-NEXT:            "offset": 9915,
 // JSON-NEXT:            "col": 23,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8602,18 +8623,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXDeductionGuideDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9684,
+// JSON-NEXT:           "offset": 9929,
 // JSON-NEXT:           "col": 37,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9684,
+// JSON-NEXT:            "offset": 9929,
 // JSON-NEXT:            "col": 37,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9687,
+// JSON-NEXT:            "offset": 9932,
 // JSON-NEXT:            "col": 40,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8628,18 +8649,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "ParmVarDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9687,
+// JSON-NEXT:             "offset": 9932,
 // JSON-NEXT:             "col": 40,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9686,
+// JSON-NEXT:              "offset": 9931,
 // JSON-NEXT:              "col": 39,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9686,
+// JSON-NEXT:              "offset": 9931,
 // JSON-NEXT:              "col": 39,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8654,18 +8675,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXDeductionGuideDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9684,
+// JSON-NEXT:           "offset": 9929,
 // JSON-NEXT:           "col": 37,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9684,
+// JSON-NEXT:            "offset": 9929,
 // JSON-NEXT:            "col": 37,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9687,
+// JSON-NEXT:            "offset": 9932,
 // JSON-NEXT:            "col": 40,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8676,6 +8697,7 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "type": {
 // JSON-NEXT:           "qualType": "auto (int) -> GH153540::N::S<int>"
 // JSON-NEXT:          },
+// JSON-NEXT:          "TemplateInstantiationPattern": "0x{{.*}}",
 // JSON-NEXT:          "inner": [
 // JSON-NEXT:           {
 // JSON-NEXT:            "kind": "TemplateArgument",
@@ -8696,18 +8718,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "ParmVarDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9687,
+// JSON-NEXT:             "offset": 9932,
 // JSON-NEXT:             "col": 40,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9686,
+// JSON-NEXT:              "offset": 9931,
 // JSON-NEXT:              "col": 39,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9686,
+// JSON-NEXT:              "offset": 9931,
 // JSON-NEXT:              "col": 39,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8724,18 +8746,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "FunctionTemplateDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 9680,
+// JSON-NEXT:         "offset": 9925,
 // JSON-NEXT:         "col": 33,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 9652,
+// JSON-NEXT:          "offset": 9897,
 // JSON-NEXT:          "col": 5,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 9680,
+// JSON-NEXT:          "offset": 9925,
 // JSON-NEXT:          "col": 33,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -8747,18 +8769,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9670,
+// JSON-NEXT:           "offset": 9915,
 // JSON-NEXT:           "col": 23,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9661,
+// JSON-NEXT:            "offset": 9906,
 // JSON-NEXT:            "col": 14,
 // JSON-NEXT:            "tokLen": 8
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9670,
+// JSON-NEXT:            "offset": 9915,
 // JSON-NEXT:            "col": 23,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8773,18 +8795,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "CXXDeductionGuideDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 9680,
+// JSON-NEXT:           "offset": 9925,
 // JSON-NEXT:           "col": 33,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9680,
+// JSON-NEXT:            "offset": 9925,
 // JSON-NEXT:            "col": 33,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9680,
+// JSON-NEXT:            "offset": 9925,
 // JSON-NEXT:            "col": 33,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8799,18 +8821,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "id": "0x{{.*}}",
 // JSON-NEXT:            "kind": "ParmVarDecl",
 // JSON-NEXT:            "loc": {
-// JSON-NEXT:             "offset": 9680,
+// JSON-NEXT:             "offset": 9925,
 // JSON-NEXT:             "col": 33,
 // JSON-NEXT:             "tokLen": 1
 // JSON-NEXT:            },
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9680,
+// JSON-NEXT:              "offset": 9925,
 // JSON-NEXT:              "col": 33,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8829,20 +8851,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "FunctionDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 9704,
-// JSON-NEXT:       "line": 233,
+// JSON-NEXT:       "offset": 9949,
+// JSON-NEXT:       "line": 237,
 // JSON-NEXT:       "col": 8,
 // JSON-NEXT:       "tokLen": 1
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 9699,
+// JSON-NEXT:        "offset": 9944,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 4
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 9725,
-// JSON-NEXT:        "line": 235,
+// JSON-NEXT:        "offset": 9970,
+// JSON-NEXT:        "line": 239,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -8858,14 +8880,14 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "kind": "CompoundStmt",
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 9708,
-// JSON-NEXT:          "line": 233,
+// JSON-NEXT:          "offset": 9953,
+// JSON-NEXT:          "line": 237,
 // JSON-NEXT:          "col": 12,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 9725,
-// JSON-NEXT:          "line": 235,
+// JSON-NEXT:          "offset": 9970,
+// JSON-NEXT:          "line": 239,
 // JSON-NEXT:          "col": 3,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -8876,13 +8898,13 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "kind": "CXXFunctionalCastExpr",
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 9714,
-// JSON-NEXT:            "line": 234,
+// JSON-NEXT:            "offset": 9959,
+// JSON-NEXT:            "line": 238,
 // JSON-NEXT:            "col": 5,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 9720,
+// JSON-NEXT:            "offset": 9965,
 // JSON-NEXT:            "col": 11,
 // JSON-NEXT:            "tokLen": 1
 // JSON-NEXT:           }
@@ -8907,12 +8929,12 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:            "kind": "CXXConstructExpr",
 // JSON-NEXT:            "range": {
 // JSON-NEXT:             "begin": {
-// JSON-NEXT:              "offset": 9714,
+// JSON-NEXT:              "offset": 9959,
 // JSON-NEXT:              "col": 5,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             },
 // JSON-NEXT:             "end": {
-// JSON-NEXT:              "offset": 9720,
+// JSON-NEXT:              "offset": 9965,
 // JSON-NEXT:              "col": 11,
 // JSON-NEXT:              "tokLen": 1
 // JSON-NEXT:             }
@@ -8933,12 +8955,12 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:              "kind": "IntegerLiteral",
 // JSON-NEXT:              "range": {
 // JSON-NEXT:               "begin": {
-// JSON-NEXT:                "offset": 9719,
+// JSON-NEXT:                "offset": 9964,
 // JSON-NEXT:                "col": 10,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               },
 // JSON-NEXT:               "end": {
-// JSON-NEXT:                "offset": 9719,
+// JSON-NEXT:                "offset": 9964,
 // JSON-NEXT:                "col": 10,
 // JSON-NEXT:                "tokLen": 1
 // JSON-NEXT:               }
@@ -8963,20 +8985,20 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:    "id": "0x{{.*}}",
 // JSON-NEXT:    "kind": "NamespaceDecl",
 // JSON-NEXT:    "loc": {
-// JSON-NEXT:     "offset": 10014,
-// JSON-NEXT:     "line": 243,
+// JSON-NEXT:     "offset": 10259,
+// JSON-NEXT:     "line": 247,
 // JSON-NEXT:     "col": 11,
 // JSON-NEXT:     "tokLen": 40
 // JSON-NEXT:    },
 // JSON-NEXT:    "range": {
 // JSON-NEXT:     "begin": {
-// JSON-NEXT:      "offset": 10004,
+// JSON-NEXT:      "offset": 10249,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 9
 // JSON-NEXT:     },
 // JSON-NEXT:     "end": {
-// JSON-NEXT:      "offset": 11286,
-// JSON-NEXT:      "line": 263,
+// JSON-NEXT:      "offset": 11531,
+// JSON-NEXT:      "line": 267,
 // JSON-NEXT:      "col": 1,
 // JSON-NEXT:      "tokLen": 1
 // JSON-NEXT:     }
@@ -8987,19 +9009,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "TypeAliasTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 10179,
-// JSON-NEXT:       "line": 246,
+// JSON-NEXT:       "offset": 10424,
+// JSON-NEXT:       "line": 250,
 // JSON-NEXT:       "col": 38,
 // JSON-NEXT:       "tokLen": 5
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 10144,
+// JSON-NEXT:        "offset": 10389,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 10196,
+// JSON-NEXT:        "offset": 10441,
 // JSON-NEXT:        "col": 55,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -9010,18 +9032,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTemplateParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 10175,
+// JSON-NEXT:         "offset": 10420,
 // JSON-NEXT:         "col": 34,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 10153,
+// JSON-NEXT:          "offset": 10398,
 // JSON-NEXT:          "col": 12,
 // JSON-NEXT:          "tokLen": 8
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 10175,
+// JSON-NEXT:          "offset": 10420,
 // JSON-NEXT:          "col": 34,
 // JSON-NEXT:          "tokLen": 2
 // JSON-NEXT:         }
@@ -9034,18 +9056,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:          "id": "0x{{.*}}",
 // JSON-NEXT:          "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:          "loc": {
-// JSON-NEXT:           "offset": 10167,
+// JSON-NEXT:           "offset": 10412,
 // JSON-NEXT:           "col": 26,
 // JSON-NEXT:           "tokLen": 1
 // JSON-NEXT:          },
 // JSON-NEXT:          "range": {
 // JSON-NEXT:           "begin": {
-// JSON-NEXT:            "offset": 10162,
+// JSON-NEXT:            "offset": 10407,
 // JSON-NEXT:            "col": 21,
 // JSON-NEXT:            "tokLen": 5
 // JSON-NEXT:           },
 // JSON-NEXT:           "end": {
-// JSON-NEXT:            "offset": 10162,
+// JSON-NEXT:            "offset": 10407,
 // JSON-NEXT:            "col": 21,
 // JSON-NEXT:            "tokLen": 5
 // JSON-NEXT:           }
@@ -9060,18 +9082,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TypeAliasDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 10185,
+// JSON-NEXT:         "offset": 10430,
 // JSON-NEXT:         "col": 44,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 10179,
+// JSON-NEXT:          "offset": 10424,
 // JSON-NEXT:          "col": 38,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 10196,
+// JSON-NEXT:          "offset": 10441,
 // JSON-NEXT:          "col": 55,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -9116,19 +9138,19 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:      "id": "0x{{.*}}",
 // JSON-NEXT:      "kind": "TypeAliasTemplateDecl",
 // JSON-NEXT:      "loc": {
-// JSON-NEXT:       "offset": 10219,
-// JSON-NEXT:       "line": 247,
+// JSON-NEXT:       "offset": 10464,
+// JSON-NEXT:       "line": 251,
 // JSON-NEXT:       "col": 21,
 // JSON-NEXT:       "tokLen": 5
 // JSON-NEXT:      },
 // JSON-NEXT:      "range": {
 // JSON-NEXT:       "begin": {
-// JSON-NEXT:        "offset": 10201,
+// JSON-NEXT:        "offset": 10446,
 // JSON-NEXT:        "col": 3,
 // JSON-NEXT:        "tokLen": 8
 // JSON-NEXT:       },
 // JSON-NEXT:       "end": {
-// JSON-NEXT:        "offset": 10246,
+// JSON-NEXT:        "offset": 10491,
 // JSON-NEXT:        "col": 48,
 // JSON-NEXT:        "tokLen": 1
 // JSON-NEXT:       }
@@ -9139,18 +9161,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TemplateTypeParmDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 10216,
+// JSON-NEXT:         "offset": 10461,
 // JSON-NEXT:         "col": 18,
 // JSON-NEXT:         "tokLen": 1
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 10210,
+// JSON-NEXT:          "offset": 10455,
 // JSON-NEXT:          "col": 12,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 10216,
+// JSON-NEXT:          "offset": 10461,
 // JSON-NEXT:          "col": 18,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }
@@ -9164,18 +9186,18 @@ namespace AliasDependentTemplateSpecializationType {
 // JSON-NEXT:        "id": "0x{{.*}}",
 // JSON-NEXT:        "kind": "TypeAliasDecl",
 // JSON-NEXT:        "loc": {
-// JSON-NEXT:         "offset": 10225,
+// JSON-NEXT:         "offset": 10470,
 // JSON-NEXT:         "col": 27,
 // JSON-NEXT:         "tokLen": 2
 // JSON-NEXT:        },
 // JSON-NEXT:        "range": {
 // JSON-NEXT:         "begin": {
-// JSON-NEXT:          "offset": 10219,
+// JSON-NEXT:          "offset": 10464,
 // JSON-NEXT:          "col": 21,
 // JSON-NEXT:          "tokLen": 5
 // JSON-NEXT:         },
 // JSON-NEXT:         "end": {
-// JSON-NEXT:          "offset": 10246,
+// JSON-NEXT:          "offset": 10491,
 // JSON-NEXT:          "col": 48,
 // JSON-NEXT:          "tokLen": 1
 // JSON-NEXT:         }

--- a/clang/test/AST/attr-lifetime-capture-by.cpp
+++ b/clang/test/AST/attr-lifetime-capture-by.cpp
@@ -42,7 +42,7 @@ struct map {
 
 struct [[gsl::Pointer()]] View {};
 std::vector<View> views;
-// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct vector definition implicit_instantiation
+// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct vector definition instantiated_from 0x{{.+}} implicit_instantiation
 
 // CHECK:       CXXMethodDecl {{.*}} push_back 'void (const View &)'
 // CHECK-NEXT:           ParmVarDecl {{.*}} 'const View &'
@@ -59,7 +59,7 @@ std::vector<View> views;
 
 template <class T> struct [[gsl::Pointer()]] ViewTemplate {};
 std::vector<ViewTemplate<int>> templated_views;
-// CHECK:       ClassTemplateSpecializationDecl {{.*}} struct vector definition implicit_instantiation
+// CHECK:       ClassTemplateSpecializationDecl {{.*}} struct vector definition instantiated_from 0x{{.+}} implicit_instantiation
 
 // CHECK:       CXXMethodDecl {{.*}} push_back 'void (const ViewTemplate<int> &)'
 // CHECK-NEXT:           ParmVarDecl {{.*}} 'const ViewTemplate<int> &'
@@ -76,7 +76,7 @@ std::vector<ViewTemplate<int>> templated_views;
 // CHECK-NEXT:               LifetimeCaptureByAttr {{.*}} Implicit
 
 std::vector<int*> pointers;
-// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct vector definition implicit_instantiation
+// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct vector definition instantiated_from 0x{{.+}} implicit_instantiation
 
 // CHECK:       CXXMethodDecl {{.*}} push_back 'void (int *const &)'
 // CHECK-NEXT:           ParmVarDecl {{.*}} 'int *const &'
@@ -92,7 +92,7 @@ std::vector<int*> pointers;
 // CHECK-NOT:               LifetimeCaptureByAttr
 
 std::vector<int> ints;
-// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct vector definition implicit_instantiation
+// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct vector definition instantiated_from 0x{{.+}} implicit_instantiation
 // CHECK:       TemplateArgument type 'int'
 
 // CHECK:       CXXMethodDecl {{.*}} push_back 'void (const int &)'
@@ -107,7 +107,7 @@ std::vector<int> ints;
 // CHECK-NOT:   LifetimeCaptureByAttr
 
 std::map<View, int> map;
-// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct map definition implicit_instantiation
+// CHECK:   ClassTemplateSpecializationDecl {{.*}} struct map definition instantiated_from 0x{{.+}} implicit_instantiation
 
 // CHECK:       CXXMethodDecl {{.*}} operator[] 'int &(View &&)' implicit_instantiation
 // CHECK-NEXT:           ParmVarDecl {{.*}} p 'View &&'

--- a/clang/test/ASTSYCL/ast-dump-sycl-kernel-call-stmt.cpp
+++ b/clang/test/ASTSYCL/ast-dump-sycl-kernel-call-stmt.cpp
@@ -62,7 +62,7 @@ void skep2<KN<2>>(K<2>);
 // CHECK-NEXT: | | |   `-DeclRefExpr {{.*}} 'KT' lvalue ParmVar {{.*}} 'k' 'KT'
 // CHECK-NEXT: | | `-SYCLKernelEntryPointAttr {{.*}} KNT
 
-// CHECK-NEXT: | `-FunctionDecl {{.*}} skep2 'void (K<2>)' explicit_instantiation_definition
+// CHECK-NEXT: | `-FunctionDecl {{.*}} skep2 'void (K<2>)' explicit_instantiation_definition instantiated_from 0x{{.+}}
 // CHECK-NEXT: |   |-TemplateArgument type 'KN<2>'
 // CHECK-NEXT: |   | `-RecordType {{.*}} 'KN<2>' canonical
 // CHECK-NEXT: |   |   `-ClassTemplateSpecialization {{.*}} 'KN'

--- a/clang/test/ASTSYCL/ast-dump-sycl-kernel-entry-point.cpp
+++ b/clang/test/ASTSYCL/ast-dump-sycl-kernel-entry-point.cpp
@@ -62,7 +62,7 @@ void skep4(F f) {
 void test_skep4() {
   skep4<KNT<4>>([]{});
 }
-// CHECK:      | `-FunctionDecl {{.*}} used skep4 'void ((lambda at {{.*}}))' implicit_instantiation
+// CHECK:      | `-FunctionDecl {{.*}} used skep4 'void ((lambda at {{.*}}))' implicit_instantiation instantiated_from 0x{{.+}}
 // CHECK-NEXT: |   |-TemplateArgument type 'KN<4>'
 // CHECK:      |   |-TemplateArgument type '(lambda at {{.*}})'
 // CHECK:      |   `-SYCLKernelEntryPointAttr {{.*}} struct KN<4>
@@ -79,7 +79,7 @@ void skep5(T) {
 // CHECK:      | | `-SYCLKernelEntryPointAttr {{.*}} KNT
 
 // Checks for the explicit template instantiation declaration below.
-// CHECK:      | `-FunctionDecl {{.*}} skep5 'void (int)' explicit_instantiation_definition
+// CHECK:      | `-FunctionDecl {{.*}} skep5 'void (int)' explicit_instantiation_definition instantiated_from 0x{{.+}}
 // CHECK-NEXT: |   |-TemplateArgument type 'KN<5, 4>'
 // CHECK:      |   |-TemplateArgument type 'int'
 // CHECK:      |   `-SYCLKernelEntryPointAttr {{.*}} KN<5, 4>

--- a/clang/test/ParserHLSL/hlsl_resource_class_attr.hlsl
+++ b/clang/test/ParserHLSL/hlsl_resource_class_attr.hlsl
@@ -28,7 +28,7 @@ template<typename T> struct MyBuffer2 {
   __hlsl_resource_t [[hlsl::resource_class(UAV)]] h;
 };
 
-// CHECK: ClassTemplateSpecializationDecl 0x{{[0-9a-f]+}} <line:[[# @LINE - 4]]:1, line:[[# @LINE - 2]]:1> line:[[# @LINE - 4]]:29 struct MyBuffer2 definition implicit_instantiation
+// CHECK: ClassTemplateSpecializationDecl 0x{{[0-9a-f]+}} <line:[[# @LINE - 4]]:1, line:[[# @LINE - 2]]:1> line:[[# @LINE - 4]]:29 struct MyBuffer2 definition instantiated_from 0x{{.+}} implicit_instantiation
 // CHECK: TemplateArgument type 'float'
 // CHECK: BuiltinType 0x{{[0-9a-f]+}} 'float'
 // CHECK: CXXRecordDecl 0x{{[0-9a-f]+}} <col:22, col:29> col:29 implicit struct MyBuffer2

--- a/clang/test/ParserHLSL/hlsl_resource_handle_attrs.hlsl
+++ b/clang/test/ParserHLSL/hlsl_resource_handle_attrs.hlsl
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -x hlsl -ast-dump -o - %s | FileCheck %s
 
-// CHECK: ClassTemplateSpecializationDecl {{.*}} class RWBuffer definition implicit_instantiation
+// CHECK: ClassTemplateSpecializationDecl {{.*}} class RWBuffer definition instantiated_from 0x{{.+}} implicit_instantiation
 // CHECK: TemplateArgument type 'float'
 // CHECK: BuiltinType {{.*}} 'float'
 // CHECK: FieldDecl {{.*}} implicit{{.*}} __handle '__hlsl_resource_t
@@ -8,7 +8,7 @@
 // CHECK-SAME{LITERAL}: [[hlsl::contained_type(float)]]
 RWBuffer<float> Buffer1;
 
-// CHECK: ClassTemplateSpecializationDecl {{.*}} class RasterizerOrderedBuffer definition implicit_instantiation
+// CHECK: ClassTemplateSpecializationDecl {{.*}} class RasterizerOrderedBuffer definition instantiated_from 0x{{.+}} implicit_instantiation
 // CHECK: TemplateArgument type 'vector<float, 4>'
 // CHECK: ExtVectorType {{.*}} 'vector<float, 4>' 4
 // CHECK: BuiltinType {{.*}} 'float'

--- a/clang/test/SemaTemplate/deduction-guide.cpp
+++ b/clang/test/SemaTemplate/deduction-guide.cpp
@@ -249,7 +249,7 @@ G g = {1};
 // CHECK-LABEL: Dumping <deduction guide for G>:
 // CHECK: FunctionTemplateDecl
 // CHECK: |-CXXDeductionGuideDecl {{.*}} implicit <deduction guide for G> 'auto (T) -> G<T>' aggregate
-// CHECK: `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for G> 'auto (int) -> G<int>' implicit_instantiation aggregate
+// CHECK: `-CXXDeductionGuideDecl {{.*}} implicit used <deduction guide for G> 'auto (int) -> G<int>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 
 template<typename X>
 using AG = G<X>;
@@ -350,7 +350,7 @@ X x = {{1, 2}};
 // CHECK-NEXT: |-TemplateTypeParmDecl {{.+}} <col:11, col:17> col:17 referenced class depth 0 index 0 T
 // CHECK:      |-CXXDeductionGuideDecl {{.+}} <col:27> col:27 implicit <deduction guide for X> 'auto (T (&&)[2]) -> GH64625::X<T>' aggregate
 // CHECK-NEXT: | `-ParmVarDecl {{.+}} <col:27> col:27 'T (&&)[2]'
-// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:27> col:27 implicit used <deduction guide for X> 'auto (int (&&)[2]) -> GH64625::X<int>' implicit_instantiation aggregate
+// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:27> col:27 implicit used <deduction guide for X> 'auto (int (&&)[2]) -> GH64625::X<int>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 // CHECK-NEXT:  |-TemplateArgument type 'int'
 // CHECK-NEXT:  | `-BuiltinType {{.+}} 'int'
 // CHECK-NEXT:  `-ParmVarDecl {{.+}} <col:27> col:27 'int (&&)[2]'
@@ -375,7 +375,7 @@ TwoArrays ta = {{1, 2}, {3, 4, 5}};
 // CHECK:      |-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit <deduction guide for TwoArrays> 'auto (T (&&)[2], U (&&)[3]) -> GH64625::TwoArrays<T, U>' aggregate
 // CHECK-NEXT: | |-ParmVarDecl {{.+}} <col:36> col:36 'T (&&)[2]'
 // CHECK-NEXT: | `-ParmVarDecl {{.+}} <col:36> col:36 'U (&&)[3]'
-// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit used <deduction guide for TwoArrays> 'auto (int (&&)[2], int (&&)[3]) -> GH64625::TwoArrays<int, int>' implicit_instantiation aggregate
+// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit used <deduction guide for TwoArrays> 'auto (int (&&)[2], int (&&)[3]) -> GH64625::TwoArrays<int, int>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 // CHECK-NEXT:   |-TemplateArgument type 'int'
 // CHECK-NEXT:   | `-BuiltinType {{.+}} 'int'
 // CHECK-NEXT:   |-TemplateArgument type 'int'
@@ -399,7 +399,7 @@ TwoArrays tb = {1, 2, {3, 4, 5}};
 // CHECK-NEXT: | |-ParmVarDecl {{.+}} <col:36> col:36 'T'
 // CHECK-NEXT: | |-ParmVarDecl {{.+}} <col:36> col:36 'T'
 // CHECK-NEXT: | `-ParmVarDecl {{.+}} <col:36> col:36 'U (&&)[3]'
-// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit used <deduction guide for TwoArrays> 'auto (int, int, int (&&)[3]) -> GH64625::TwoArrays<int, int>' implicit_instantiation aggregate
+// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit used <deduction guide for TwoArrays> 'auto (int, int, int (&&)[3]) -> GH64625::TwoArrays<int, int>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 // CHECK-NEXT:   |-TemplateArgument type 'int'
 // CHECK-NEXT:   | `-BuiltinType {{.+}} 'int'
 // CHECK-NEXT:   |-TemplateArgument type 'int'
@@ -425,7 +425,7 @@ TwoArrays tc = {{1, 2}, 3, 4, 5};
 // CHECK-NEXT: | |-ParmVarDecl {{.+}} <col:36> col:36 'U'
 // CHECK-NEXT: | |-ParmVarDecl {{.+}} <col:36> col:36 'U'
 // CHECK-NEXT: | `-ParmVarDecl {{.+}} <col:36> col:36 'U'
-// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit used <deduction guide for TwoArrays> 'auto (int (&&)[2], int, int, int) -> GH64625::TwoArrays<int, int>' implicit_instantiation aggregate
+// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:36> col:36 implicit used <deduction guide for TwoArrays> 'auto (int (&&)[2], int, int, int) -> GH64625::TwoArrays<int, int>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 // CHECK-NEXT:   |-TemplateArgument type 'int'
 // CHECK-NEXT:   | `-BuiltinType {{.+}} 'int'
 // CHECK-NEXT:   |-TemplateArgument type 'int'
@@ -463,7 +463,7 @@ A a{.f1 = {1}};
 // CHECK-NEXT: |-NonTypeTemplateParmDecl {{.+}} <col:11, col:15> col:15 referenced 'int' depth 0 index 0 N
 // CHECK:      |-CXXDeductionGuideDecl {{.+}} <col:25> col:25 implicit <deduction guide for A> 'auto (int (&&)[N]) -> GH83368::A<N>' aggregate
 // CHECK-NEXT: | `-ParmVarDecl {{.+}} <col:25> col:25 'int (&&)[N]'
-// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:25> col:25 implicit used <deduction guide for A> 'auto (int (&&)[1]) -> GH83368::A<1>' implicit_instantiation aggregate
+// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} <col:25> col:25 implicit used <deduction guide for A> 'auto (int (&&)[1]) -> GH83368::A<1>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 // CHECK-NEXT:   |-TemplateArgument integral '1'
 // CHECK-NEXT:   `-ParmVarDecl {{.+}} <col:25> col:25 'int (&&)[1]'
 // CHECK-NEXT: FunctionProtoType {{.+}} 'auto (int (&&)[N]) -> GH83368::A<N>' dependent trailing_return
@@ -902,7 +902,7 @@ void f() {
 // CHECK:      |-CXXDeductionGuideDecl {{.+}} implicit <deduction guide for Vec2d> 'auto (T, T) -> GH67173::Vec2d<T>' aggregate
 // CHECK-NEXT: | |-ParmVarDecl {{.+}} col:27 'T'
 // CHECK-NEXT: | `-ParmVarDecl {{.+}} col:27 'T'
-// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} implicit used <deduction guide for Vec2d> 'auto (int, int) -> GH67173::Vec2d<int>' implicit_instantiation aggregate
+// CHECK-NEXT: `-CXXDeductionGuideDecl {{.+}} implicit used <deduction guide for Vec2d> 'auto (int, int) -> GH67173::Vec2d<int>' implicit_instantiation instantiated_from 0x{{.+}} aggregate
 // CHECK-NEXT:   |-TemplateArgument type 'int'
 // CHECK-NEXT:   | `-BuiltinType {{.+}} 'int'
 // CHECK-NEXT:   |-ParmVarDecl {{.+}} 'int'


### PR DESCRIPTION
This changes the instiantiated_from field to use
`getTemplateInstantiationPattern`, which makes this field work for all template specialization kinds, not just member templates.

Also adds this field to variables, and adds equivalents for the JSON dumper as well.