### PR TITLE
[BPF] Avoid generating .comment section

### DIFF
--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
@@ -31,6 +31,7 @@ public:
     UsesELFSectionDirectiveForBSS = true;
     HasSingleParameterDotFile = true;
     HasDotTypeDotSizeDirective = true;
+    HasIdentDirective = false;
 
     SupportsDebugInformation = true;
     ExceptionsType = ExceptionHandling::DwarfCFI;


### PR DESCRIPTION
The kernel libbpf does not need .comment section. If not filtering out in llvm, the section will be filtered out in libbpf. So let us filter it out as early as possible which is in llvm.

The following is an example.
```
  $ cat t.c
  int test() { return 5; }
```
Without this change:
```
  $ llvm-readelf -S t.o
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .strtab           STRTAB          0000000000000000 000110 000047 00      0   0  1
  [ 2] .text             PROGBITS        0000000000000000 000040 000010 00  AX  0   0  8
  [ 3] .comment          PROGBITS        0000000000000000 000050 000072 01  MS  0   0  1
  [ 4] .note.GNU-stack   PROGBITS        0000000000000000 0000c2 000000 00      0   0  1
  [ 5] .llvm_addrsig     LLVM_ADDRSIG    0000000000000000 000110 000000 00   E  6   0  1
  [ 6] .symtab           SYMTAB          0000000000000000 0000c8 000048 18      1   2  8
```
With this change:
```
  $ llvm-readelf -S t.o
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .strtab           STRTAB          0000000000000000 000098 00003e 00      0   0  1
  [ 2] .text             PROGBITS        0000000000000000 000040 000010 00  AX  0   0  8
  [ 3] .note.GNU-stack   PROGBITS        0000000000000000 000050 000000 00      0   0  1
  [ 4] .llvm_addrsig     LLVM_ADDRSIG    0000000000000000 000098 000000 00   E  5   0  1
  [ 5] .symtab           SYMTAB          0000000000000000 000050 000048 18      1   2  8
```