### PR TITLE
[MC][BPF] Avoid generating .note.GNU-stack section

### DIFF
--- a/llvm/include/llvm/MC/MCAsmInfoELF.h
+++ b/llvm/include/llvm/MC/MCAsmInfoELF.h
@@ -15,7 +15,7 @@ namespace llvm {
 
 class MCAsmInfoELF : public MCAsmInfo {
   virtual void anchor();
-  MCSection *getNonexecutableStackSection(MCContext &Ctx) const final;
+  MCSection *getNonexecutableStackSection(MCContext &Ctx) const override;
   void printSwitchToSection(const MCSection &, uint32_t, const Triple &,
                             raw_ostream &) const final;
   bool useCodeAlign(const MCSection &Sec) const final;

--- a/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
+++ b/llvm/lib/Target/BPF/MCTargetDesc/BPFMCAsmInfo.h
@@ -47,6 +47,10 @@ public:
   void setDwarfUsesRelocationsAcrossSections(bool enable) {
     DwarfUsesRelocationsAcrossSections = enable;
   }
+
+  MCSection *getNonexecutableStackSection(MCContext &Ctx) const override {
+    return nullptr;
+  }
 };
 }
 


### PR DESCRIPTION
The kernel libbpf does not need .note.GNU-stack section. If not filtering out in llvm, the section will be filtered out in libbpf. So let us filter it out as early as possible which is in llvm.

Change function getNonexecutableStackSection() in MCAsmInfoELF.h from 'final' to 'override' so target (e.g. BPF) can decide whether '.note.GNU-stack' section should be emitted or not.

The following is an example.
```
  $ cat t.c
  int test() { return 5; }
```
Without this change:
```
  $ llvm-readelf -S t.o
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .strtab           STRTAB          0000000000000000 000110 000047 00      0   0  1
  [ 2] .text             PROGBITS        0000000000000000 000040 000010 00  AX  0   0  8
  [ 3] .comment          PROGBITS        0000000000000000 000050 000072 01  MS  0   0  1
  [ 4] .note.GNU-stack   PROGBITS        0000000000000000 0000c2 000000 00      0   0  1
  [ 5] .llvm_addrsig     LLVM_ADDRSIG    0000000000000000 000110 000000 00   E  6   0  1
  [ 6] .symtab           SYMTAB          0000000000000000 0000c8 000048 18      1   2  8
```
With this change:
```
  $ llvm-readelf -S t.o
  [Nr] Name              Type            Address          Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            0000000000000000 000000 000000 00      0   0  0
  [ 1] .strtab           STRTAB          0000000000000000 000110 000037 00      0   0  1
  [ 2] .text             PROGBITS        0000000000000000 000040 000010 00  AX  0   0  8
  [ 3] .comment          PROGBITS        0000000000000000 000050 000072 01  MS  0   0  1
  [ 4] .llvm_addrsig     LLVM_ADDRSIG    0000000000000000 000110 000000 00   E  5   0  1
  [ 5] .symtab           SYMTAB          0000000000000000 0000c8 000048 18      1   2  8
  ```