### PR TITLE
[Github] Test pr-code-lint workflow on changes to workflow

### DIFF
--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -10,6 +10,7 @@ on:
       - 'users/**'
     paths:
       - 'clang-tools-extra/clang-tidy/**'
+      - '.github/workflows/pr-code-lint.yml'
 
 jobs:
   code_linter:


### PR DESCRIPTION
This patch ensures that the pr-code-lint workflow is run for testing whenever the workflow file is changed. This will not catch actual functionality issues on most changes but does ensure that the workflow is not completely broken.