### PR TITLE
[ProfCheck] Add three new tests to XFail List

### DIFF
--- a/llvm/utils/profcheck-xfail.txt
+++ b/llvm/utils/profcheck-xfail.txt
@@ -1214,6 +1214,7 @@ Transforms/LoopVectorize/AArch64/predication_costs.ll
 Transforms/LoopVectorize/AArch64/reduction-recurrence-costs-sve.ll
 Transforms/LoopVectorize/AArch64/reduction-small-size.ll
 Transforms/LoopVectorize/AArch64/reg-usage.ll
+Transforms/LoopVectorize/AArch64/replicating-load-store-costs.ll
 Transforms/LoopVectorize/AArch64/runtime-check-trip-count-decisions.ll
 Transforms/LoopVectorize/AArch64/scalable-call.ll
 Transforms/LoopVectorize/AArch64/scalable-predicate-instruction.ll
@@ -1745,6 +1746,7 @@ Transforms/PGOProfile/profcheck-select.ll
 Transforms/PGOProfile/prof-verify.ll
 Transforms/PGOProfile/prof-verify-no-entrycount.ll
 Transforms/PGOProfile/X86/macho.ll
+Transforms/PhaseOrdering/AArch64/constraint-elimination-placement.ll
 Transforms/PhaseOrdering/AArch64/globals-aa-required-for-vectorization.ll
 Transforms/PhaseOrdering/AArch64/hoisting-sinking-required-for-vectorization.ll
 Transforms/PhaseOrdering/AArch64/loopflatten.ll
@@ -1970,6 +1972,7 @@ Transforms/SROA/slice-width.ll
 Transforms/SROA/std-clamp.ll
 Transforms/SROA/vector-conversion.ll
 Transforms/SROA/vector-promotion.ll
+Transforms/SROA/vector-promotion-cannot-tree-structure-merge.ll
 Transforms/StackProtector/cross-dso-cfi-stack-chk-fail.ll
 Transforms/StructurizeCFG/AMDGPU/uniform-regions.ll
 Transforms/StructurizeCFG/hoist-zerocost.ll


### PR DESCRIPTION
We have not gotten to LoopVectorize or SROA yet. The phase ordering pass issue is probably the result of another pass that we have not gotten to yet.