### PR TITLE
[Clang] Fix an error-recovery crash after d1a80dea

### DIFF
--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -354,6 +354,8 @@ ParsedType Sema::getDestructorName(const IdentifierInfo &II,
         CheckTypenameType(ElaboratedTypeKeyword::None, SourceLocation(),
                           SS.getWithLocInContext(Context), II, NameLoc, &TSI,
                           /*DeducedTSTContext=*/true);
+    if (T.isNull())
+      return ParsedType();
     return CreateParsedType(T, TSI);
   }
 

--- a/clang/test/SemaTemplate/destructor-template.cpp
+++ b/clang/test/SemaTemplate/destructor-template.cpp
@@ -104,3 +104,18 @@ struct T : S {
   ~T() = default;
 };
 } // namespace PR38671
+
+namespace GH159630 {
+
+struct X {
+  template<typename T>
+  struct typo { // expected-note {{'typo' declared here}}
+    ~typo();
+  };
+};
+
+template<typename T>
+X::typo<T>::typ0::~typ0() {} // expected-error {{no member named 'typ0'}} \
+                             // expected-error {{no type named 'typ0'}}
+
+}


### PR DESCRIPTION
d1a80dea tried to ensure a TypeSourceInfo for a destructor name. However, we don't actually have one during error recovery, so we should bail in that case.

No release note, since it's a regression and a backport could improve the stability of clangd.

Fixes https://github.com/llvm/llvm-project/issues/159630