### PR TITLE
[Support] Fix memory leak in `Timer.cpp` on shutdown

### DIFF
--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -312,8 +312,10 @@ TimerGroup::~TimerGroup() {
       Next->Prev = Prev;
   };
 
-  // If the managed instance is already dead, it means we're in the CRT
-  // destruction, so no need to lock.
+  // TimerGlobals is always created implicity, through a call to timerLock(),
+  // when a TimeGroup is created. On CRT shutdown, the TimerGlobals instance
+  // might have been destroyed already. Avoid re-creating it if calling
+  // timerLock().
   if (!isTimerGlobalsConstructed()) {
     unlink();
     return;

--- a/llvm/lib/Support/Timer.cpp
+++ b/llvm/lib/Support/Timer.cpp
@@ -57,6 +57,7 @@ static SignpostEmitter &signposts();
 static sys::SmartMutex<true> &timerLock();
 static TimerGroup &defaultTimerGroup();
 static Name2PairMap &namedGroupedTimers();
+static bool isTimerGlobalsConstructed();
 
 //===----------------------------------------------------------------------===//
 //
@@ -305,13 +306,23 @@ TimerGroup::~TimerGroup() {
     PrintQueuedTimers(*OutStream);
   }
 
+  auto unlink = [&]() {
+    *Prev = Next;
+    if (Next)
+      Next->Prev = Prev;
+  };
+
+  // If the managed instance is already dead, it means we're in the CRT
+  // destruction, so no need to lock.
+  if (!isTimerGlobalsConstructed()) {
+    unlink();
+    return;
+  }
+
   // Remove the group from the TimerGroupList.
   sys::SmartScopedLock<true> L(timerLock());
-  *Prev = Next;
-  if (Next)
-    Next->Prev = Prev;
+  unlink();
 }
-
 
 void TimerGroup::removeTimer(Timer &T) {
   sys::SmartScopedLock<true> L(timerLock());
@@ -557,3 +568,7 @@ void TimerGroup::constructForStatistics() {
 }
 
 void *TimerGroup::acquireTimerGlobals() { return ManagedTimerGlobals.claim(); }
+
+static bool isTimerGlobalsConstructed() {
+  return ManagedTimerGlobals.isConstructed();
+}


### PR DESCRIPTION
This used to happen in the global destruction, after `main()` has exited. Previously, we were re-creating the `llvm::TimerGlobals` object at this point.

<img width="855" height="270" alt="image" src="https://github.com/user-attachments/assets/757e9416-a74a-406a-841e-d3e4cc6a69a1" />
