### PR TITLE
[clang] Fix -Wdouble-promotion in C++ list-initialization

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -417,6 +417,7 @@ Bug Fixes to C++ Support
   ``__builtin_addressof``, and related issues with builtin arguments. (#GH154034)
 - Fix an assertion failure when taking the address on a non-type template parameter argument of
   object type. (#GH151531)
+- Suppress ``-Wdouble-promotion`` when explicitly asked for with C++ list initialization (#GH33409).
 
 Bug Fixes to AST Handling
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -12382,6 +12382,11 @@ void Sema::CheckImplicitConversion(Expr *E, QualType T, SourceLocation CC,
       }
       // ... or possibly if we're increasing rank, too
       else if (Order < 0) {
+        // Don't warn if we are in a C++ list initialization expression, as
+        // that means the promotion was asked for explicitly.
+        if (IsListInit)
+          return;
+
         if (SourceMgr.isInSystemMacro(CC))
           return;
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -12797,7 +12797,7 @@ static void CheckCommaOperand(
     S.CheckImplicitConversion(E, T, CC);
 }
 
-static Expr* IgnoreExplicitCastForImplicitConversionCheck(ExplicitCastExpr *E) {
+static Expr *IgnoreExplicitCastForImplicitConversionCheck(ExplicitCastExpr *E) {
   // In the special case of C++ function-style cast with braces,
   // CXXFunctionalCastExpr has InitListExpr as direct child with a single
   // initializer. It basically belongs to the cast itself, so for the purposes

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -12910,8 +12910,8 @@ static void AnalyzeImplicitConversions(
   // Skip past explicit casts.
   if (auto *CE = dyn_cast<ExplicitCastExpr>(E)) {
     E = CE->getSubExpr();
-    // In the special case of C++ function-style cast with braces,
-    // CXXFunctionalCastExpr has InitListExpr as direct child with a single
+    // In the special case of a C++ function-style cast with braces,
+    // CXXFunctionalCastExpr has an InitListExpr as direct child with a single
     // initializer. This InitListExpr basically belongs to the cast itself, so
     // we skip it too. Specifically this is needed to silence -Wdouble-promotion
     if (isa<CXXFunctionalCastExpr>(CE)) {

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -12797,22 +12797,6 @@ static void CheckCommaOperand(
     S.CheckImplicitConversion(E, T, CC);
 }
 
-static Expr *IgnoreExplicitCastForImplicitConversionCheck(ExplicitCastExpr *E) {
-  // In the special case of C++ function-style cast with braces,
-  // CXXFunctionalCastExpr has InitListExpr as direct child with a single
-  // initializer. It basically belongs to the cast itself, so for the purposes
-  // of checking for implicit conversions to warn about it should be skipped
-  // too.
-  if (auto *FCE = dyn_cast<CXXFunctionalCastExpr>(E)) {
-    if (auto *IFCE = dyn_cast<InitListExpr>(FCE->getSubExpr())) {
-      if (IFCE->getNumInits() == 1) {
-        return IFCE->getInit(0);
-      }
-    }
-  }
-  return E->getSubExpr();
-}
-
 /// Data recursive variant of AnalyzeImplicitConversions. Subexpressions
 /// that should be visited are added to WorkList.
 static void AnalyzeImplicitConversions(
@@ -12925,7 +12909,19 @@ static void AnalyzeImplicitConversions(
 
   // Skip past explicit casts.
   if (auto *CE = dyn_cast<ExplicitCastExpr>(E)) {
-    E = IgnoreExplicitCastForImplicitConversionCheck(CE)->IgnoreParenImpCasts();
+    E = CE->getSubExpr();
+    // In the special case of C++ function-style cast with braces,
+    // CXXFunctionalCastExpr has InitListExpr as direct child with a single
+    // initializer. This InitListExpr basically belongs to the cast itself, so
+    // we skip it too. Specifically this is needed to silence -Wdouble-promotion
+    if (isa<CXXFunctionalCastExpr>(CE)) {
+      if (auto *InitListE = dyn_cast<InitListExpr>(E)) {
+        if (InitListE->getNumInits() == 1) {
+          E = InitListE->getInit(0);
+        }
+      }
+    }
+    E = E->IgnoreParenImpCasts();
     if (!CE->getType()->isVoidType() && E->getType()->isAtomicType())
       S.Diag(E->getBeginLoc(), diag::warn_atomic_implicit_seq_cst);
     WorkList.push_back({E, CC, IsListInit});

--- a/clang/test/Sema/warn-double-promotion.c
+++ b/clang/test/Sema/warn-double-promotion.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -verify -fsyntax-only %s -Wdouble-promotion
+// RUN: %clang_cc1 -triple x86_64-apple-darwin -verify -fsyntax-only -x c++ %s -Wdouble-promotion
 
 float ReturnFloatFromDouble(double d) {
   return d;

--- a/clang/test/Sema/warn-double-promotion.c
+++ b/clang/test/Sema/warn-double-promotion.c
@@ -49,6 +49,15 @@ void Assignment(float f, double d, long double ld) {
   d = ld;
 }
 
+void AssignmentWithExtraParens(float f, double d, long double ld) {
+  d = (f);  //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
+  ld = (f); //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+  ld = (d); //expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+  d = (double)(f);
+  ld = (long double)(f);
+  ld = (long double)(d);
+}
+
 extern void DoubleParameter(double);
 extern void LongDoubleParameter(long double);
 

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -1,30 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -verify -fsyntax-only %s -Wdouble-promotion
+// expected-no-diagnostics
 
 using LongDouble = long double;
-
-float ReturnFloatFromDouble(double d) {
-  return d;
-}
-
-float ReturnFloatFromLongDouble(long double ld) {
-  return ld;
-}
-
-double ReturnDoubleFromLongDouble(long double ld) {
-  return ld;
-}
-
-double ReturnDoubleFromFloat(float f) {
-  return f;  //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
-}
-
-long double ReturnLongDoubleFromFloat(float f) {
-  return f;  //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
-}
-
-long double ReturnLongDoubleFromDouble(double d) {
-  return d;  //expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
-}
 
 double ReturnDoubleFromFloatWithExplicitCast(float f) {
   return static_cast<double>(f);
@@ -51,27 +28,18 @@ long double ReturnLongDoubleFromDoubleWithExplicitListInitialization(double d) {
 }
 
 void Assignment(float f, double d, long double ld) {
-  d = f;  //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
-  ld = f; //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
-  ld = d; //expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
   d = static_cast<double>(f);
   ld = static_cast<long double>(f);
   ld = static_cast<long double>(d);
   d = double{f};
   ld = LongDouble{f};
   ld = LongDouble{d};
-  f = d;
-  f = ld;
-  d = ld;
 }
 
 extern void DoubleParameter(double);
 extern void LongDoubleParameter(long double);
 
 void ArgumentPassing(float f, double d) {
-  DoubleParameter(f); // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
-  LongDoubleParameter(f); // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
-  LongDoubleParameter(d); // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
   DoubleParameter(static_cast<double>(f));
   LongDoubleParameter(static_cast<long double>(f));
   LongDoubleParameter(static_cast<long double>(d));
@@ -81,12 +49,6 @@ void ArgumentPassing(float f, double d) {
 }
 
 void BinaryOperator(float f, double d, long double ld) {
-  f = f * d; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
-  f = d * f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
-  f = f * ld; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
-  f = ld * f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
-  d = d * ld; // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
-  d = ld * d; // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
   f = static_cast<double>(f) * d;
   f = d * static_cast<double>(f);
   f = static_cast<long double>(f) * ld;
@@ -102,29 +64,10 @@ void BinaryOperator(float f, double d, long double ld) {
 }
 
 void MultiplicationAssignment(float f, double d, long double ld) {
-  d *= f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
-  ld *= f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
-  ld *= d; // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
   d *= static_cast<double>(f);
   ld *= static_cast<long double>(f);
   ld *= static_cast<long double>(d);
   d *= double{f};
   ld *= LongDouble{f};
   ld *= LongDouble{d};
-
-  // FIXME: These cases should produce warnings as above.
-  f *= d;
-  f *= ld;
-  d *= ld;
-}
-
-// FIXME: As with a binary operator, the operands to the conditional operator are
-// converted to a common type and should produce a warning.
-void ConditionalOperator(float f, double d, long double ld, int i) {
-  f = i ? f : d;
-  f = i ? d : f;
-  f = i ? f : ld;
-  f = i ? ld : f;
-  d = i ? d : ld;
-  d = i ? ld : d;
 }

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -verify -fsyntax-only %s -Wdouble-promotion
-// expected-no-diagnostics
 
 using LongDouble = long double;
 
@@ -37,6 +36,52 @@ long double ReturnLongDoubleFromFloatWithFunctionStyleCast(float f) {
 
 long double ReturnLongDoubleFromDoubleWithFunctionStyleCast(double d) {
   return LongDouble(d);
+}
+
+void InitializationWithParens(float f, double d) {
+  {
+    double d(f);  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
+    long double ld0(f);  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+    long double ld1(d);  // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+  }
+  {
+    double d(static_cast<double>(f));
+    long double ld0(static_cast<long double>(f));
+    long double ld1(static_cast<long double>(d));
+  }
+  {
+    double d(double{f});
+    long double ld0(LongDouble{f});
+    long double ld1(LongDouble{d});
+  }
+  {
+    double d((double(f)));
+    long double ld0((LongDouble(f)));
+    long double ld1((LongDouble(d)));
+  }
+}
+
+void InitializationWithBraces(float f, double d) {
+  {
+    double d{f};  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
+    long double ld0{f};  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+    long double ld1{d};  // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+  }
+  {
+    double d{static_cast<double>(f)};
+    long double ld0{static_cast<long double>(f)};
+    long double ld1{static_cast<long double>(d)};
+  }
+  {
+    double d{double{f}};
+    long double ld0{LongDouble{f}};
+    long double ld1{LongDouble{d}};
+  }
+  {
+    double d{double(f)};
+    long double ld0{LongDouble(f)};
+    long double ld1{LongDouble(d)};
+  }
 }
 
 void Assignment(float f, double d, long double ld) {

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -25,24 +25,39 @@ long double ReturnLongDoubleFromDouble(double d) {
 }
 
 double ReturnDoubleFromFloatWithExplicitCast(float f) {
-  return (double)f;
+  return static_cast<double>(f);
 }
 
 long double ReturnLongDoubleFromFloatWithExplicitCast(float f) {
-  return (long double)f;
+  return static_cast<long double>(f);
 }
 
 long double ReturnLongDoubleFromDoubleWithExplicitCast(double d) {
-  return (long double)d;
+  return static_cast<long double>(d);
+}
+
+double ReturnDoubleFromFloatWithExplicitListInitialization(float f) {
+  return double{f};
+}
+
+long double ReturnLongDoubleFromFloatWithExplicitListInitialization(float f) {
+  return (long double){f};
+}
+
+long double ReturnLongDoubleFromDoubleWithExplicitListInitialization(double d) {
+  return (long double){d};
 }
 
 void Assignment(float f, double d, long double ld) {
   d = f;  //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
   ld = f; //expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
   ld = d; //expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
-  d = (double)f;
-  ld = (long double)f;
-  ld = (long double)d;
+  d = static_cast<double>(f);
+  ld = static_cast<long double>(f);
+  ld = static_cast<long double>(d);
+  d = double{f};
+  ld = (long double){f};
+  ld = (long double){d};
   f = d;
   f = ld;
   d = ld;
@@ -55,9 +70,12 @@ void ArgumentPassing(float f, double d) {
   DoubleParameter(f); // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
   LongDoubleParameter(f); // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
   LongDoubleParameter(d); // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
-  DoubleParameter((double)f);
-  LongDoubleParameter((long double)f);
-  LongDoubleParameter((long double)d);
+  DoubleParameter(static_cast<double>(f));
+  LongDoubleParameter(static_cast<long double>(f));
+  LongDoubleParameter(static_cast<long double>(d));
+  DoubleParameter(double{f});
+  LongDoubleParameter((long double){f});
+  LongDoubleParameter((long double){d});
 }
 
 void BinaryOperator(float f, double d, long double ld) {
@@ -67,21 +85,30 @@ void BinaryOperator(float f, double d, long double ld) {
   f = ld * f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
   d = d * ld; // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
   d = ld * d; // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
-  f = (double)f * d;
-  f = d * (double)f;
-  f = (long double)f * ld;
-  f = ld * (long double)f;
-  d = (long double)d * ld;
-  d = ld * (long double)d;
+  f = static_cast<double>(f) * d;
+  f = d * static_cast<double>(f);
+  f = static_cast<long double>(f) * ld;
+  f = ld * static_cast<long double>(f);
+  d = static_cast<long double>(d) * ld;
+  d = ld * static_cast<long double>(d);
+  f = double{f} * d;
+  f = d * double{f};
+  f = (long double){f} * ld;
+  f = ld * (long double){f};
+  d = (long double){d} * ld;
+  d = ld * (long double){d};
 }
 
 void MultiplicationAssignment(float f, double d, long double ld) {
   d *= f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
   ld *= f; // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
   ld *= d; // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
-  d *= (double)f;
-  ld *= (long double)f;
-  ld *= (long double)d;
+  d *= static_cast<double>(f);
+  ld *= static_cast<long double>(f);
+  ld *= static_cast<long double>(d);
+  d *= double{f};
+  ld *= (long double){f};
+  ld *= (long double){d};
 
   // FIXME: These cases should produce warnings as above.
   f *= d;

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-darwin -verify -fsyntax-only %s -Wdouble-promotion
 
+using LongDouble = long double;
+
 float ReturnFloatFromDouble(double d) {
   return d;
 }
@@ -41,11 +43,11 @@ double ReturnDoubleFromFloatWithExplicitListInitialization(float f) {
 }
 
 long double ReturnLongDoubleFromFloatWithExplicitListInitialization(float f) {
-  return (long double){f};
+  return LongDouble{f};
 }
 
 long double ReturnLongDoubleFromDoubleWithExplicitListInitialization(double d) {
-  return (long double){d};
+  return LongDouble{d};
 }
 
 void Assignment(float f, double d, long double ld) {
@@ -56,8 +58,8 @@ void Assignment(float f, double d, long double ld) {
   ld = static_cast<long double>(f);
   ld = static_cast<long double>(d);
   d = double{f};
-  ld = (long double){f};
-  ld = (long double){d};
+  ld = LongDouble{f};
+  ld = LongDouble{d};
   f = d;
   f = ld;
   d = ld;
@@ -74,8 +76,8 @@ void ArgumentPassing(float f, double d) {
   LongDoubleParameter(static_cast<long double>(f));
   LongDoubleParameter(static_cast<long double>(d));
   DoubleParameter(double{f});
-  LongDoubleParameter((long double){f});
-  LongDoubleParameter((long double){d});
+  LongDoubleParameter(LongDouble{f});
+  LongDoubleParameter(LongDouble{d});
 }
 
 void BinaryOperator(float f, double d, long double ld) {
@@ -93,10 +95,10 @@ void BinaryOperator(float f, double d, long double ld) {
   d = ld * static_cast<long double>(d);
   f = double{f} * d;
   f = d * double{f};
-  f = (long double){f} * ld;
-  f = ld * (long double){f};
-  d = (long double){d} * ld;
-  d = ld * (long double){d};
+  f = LongDouble{f} * ld;
+  f = ld * LongDouble{f};
+  d = LongDouble{d} * ld;
+  d = ld * LongDouble{d};
 }
 
 void MultiplicationAssignment(float f, double d, long double ld) {
@@ -107,8 +109,8 @@ void MultiplicationAssignment(float f, double d, long double ld) {
   ld *= static_cast<long double>(f);
   ld *= static_cast<long double>(d);
   d *= double{f};
-  ld *= (long double){f};
-  ld *= (long double){d};
+  ld *= LongDouble{f};
+  ld *= LongDouble{d};
 
   // FIXME: These cases should produce warnings as above.
   f *= d;

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -27,6 +27,18 @@ long double ReturnLongDoubleFromDoubleWithExplicitListInitialization(double d) {
   return LongDouble{d};
 }
 
+double ReturnDoubleFromFloatWithFunctionStyleCast(float f) {
+  return double(f);
+}
+
+long double ReturnLongDoubleFromFloatWithFunctionStyleCast(float f) {
+  return LongDouble(f);
+}
+
+long double ReturnLongDoubleFromDoubleWithFunctionStyleCast(double d) {
+  return LongDouble(d);
+}
+
 void Assignment(float f, double d, long double ld) {
   d = static_cast<double>(f);
   ld = static_cast<long double>(f);
@@ -34,6 +46,9 @@ void Assignment(float f, double d, long double ld) {
   d = double{f};
   ld = LongDouble{f};
   ld = LongDouble{d};
+  d = double(f);
+  ld = LongDouble(f);
+  ld = LongDouble(d);
 }
 
 extern void DoubleParameter(double);
@@ -46,6 +61,9 @@ void ArgumentPassing(float f, double d) {
   DoubleParameter(double{f});
   LongDoubleParameter(LongDouble{f});
   LongDoubleParameter(LongDouble{d});
+  DoubleParameter(double(f));
+  LongDoubleParameter(LongDouble(f));
+  LongDoubleParameter(LongDouble(d));
 }
 
 void BinaryOperator(float f, double d, long double ld) {
@@ -61,6 +79,12 @@ void BinaryOperator(float f, double d, long double ld) {
   f = ld * LongDouble{f};
   d = LongDouble{d} * ld;
   d = ld * LongDouble{d};
+  f = double(f) * d;
+  f = d * double(f);
+  f = LongDouble(f) * ld;
+  f = ld * LongDouble(f);
+  d = LongDouble(d) * ld;
+  d = ld * LongDouble(d);
 }
 
 void MultiplicationAssignment(float f, double d, long double ld) {
@@ -70,4 +94,7 @@ void MultiplicationAssignment(float f, double d, long double ld) {
   d *= double{f};
   ld *= LongDouble{f};
   ld *= LongDouble{d};
+  d *= double(f);
+  ld *= LongDouble(f);
+  ld *= LongDouble(d);
 }

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -108,6 +108,12 @@ void AssignmentWithExtraParens(float f, double d, long double ld) {
   ld = LongDouble((d));
 }
 
+void AssignmentWithExtraBraces(float f, double d, long double ld) {
+  d = double{{f}};  // expected-warning{{too many braces around scalar initializer}}
+  ld = LongDouble{{f}};  // expected-warning{{too many braces around scalar initializer}}
+  ld = LongDouble{{d}};  // expected-warning{{too many braces around scalar initializer}}
+}
+
 extern void DoubleParameter(double);
 extern void LongDoubleParameter(long double);
 

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -155,3 +155,96 @@ void MultiplicationAssignment(float f, double d, long double ld) {
   ld *= LongDouble(f);
   ld *= LongDouble(d);
 }
+
+struct ConstructWithDouble {
+  ConstructWithDouble(double);
+};
+
+struct ConstructWithLongDouble {
+  ConstructWithLongDouble(long double);
+};
+
+void Construct(float f, double d) {
+  ConstructWithDouble{f};  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
+  ConstructWithLongDouble{f};  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+  ConstructWithLongDouble{d};  // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+  ConstructWithDouble{static_cast<double>(f)};
+  ConstructWithLongDouble{static_cast<long double>(f)};
+  ConstructWithLongDouble{static_cast<long double>(d)};
+  ConstructWithDouble{double{f}};
+  ConstructWithLongDouble{LongDouble{f}};
+  ConstructWithLongDouble{LongDouble{d}};
+  ConstructWithDouble{double(f)};
+  ConstructWithLongDouble{LongDouble(f)};
+  ConstructWithLongDouble{LongDouble(d)};
+}
+
+template <class T> T ReturnTFromFloat(float f) {
+  return f;  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}} \
+             // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+}
+
+template <class T> T ReturnTFromDouble(double d) {
+  return d;  // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+}
+
+template <class T> T ReturnTFromFloatWithStaticCast(float f) {
+  return static_cast<T>(f);
+}
+
+template <class T> T ReturnTFromDoubleWithStaticCast(double d) {
+  return static_cast<T>(d);
+}
+
+template <class T> T ReturnTFromFloatWithExplicitListInitialization(float f) {
+  return T{f};
+}
+
+template <class T> T ReturnTFromDoubleWithExplicitListInitialization(double d) {
+  return T{d};
+}
+
+template <class T> T ReturnTFromFloatWithFunctionStyleCast(float f) {
+  return T(f);
+}
+
+template <class T> T ReturnTFromDoubleWithFunctionStyleCast(double d) {
+  return T(d);
+}
+
+void TestTemplate(float f, double d) {
+  ReturnTFromFloat<double>(f);  // expected-note{{in instantiation of function template specialization 'ReturnTFromFloat<double>' requested here}}
+  ReturnTFromFloat<long double>(f);  // expected-note{{in instantiation of function template specialization 'ReturnTFromFloat<long double>' requested here}}
+  ReturnTFromDouble<long double>(d);  // expected-note{{in instantiation of function template specialization 'ReturnTFromDouble<long double>' requested here}}
+  ReturnTFromFloatWithStaticCast<double>(f);
+  ReturnTFromFloatWithStaticCast<long double>(f);
+  ReturnTFromDoubleWithStaticCast<long double>(d);
+  ReturnTFromFloatWithExplicitListInitialization<double>(f);
+  ReturnTFromFloatWithExplicitListInitialization<long double>(f);
+  ReturnTFromDoubleWithExplicitListInitialization<long double>(d);
+  ReturnTFromFloatWithFunctionStyleCast<double>(f);
+  ReturnTFromFloatWithFunctionStyleCast<long double>(f);
+  ReturnTFromDoubleWithFunctionStyleCast<long double>(d);
+}
+
+struct MemberInitializerListParens {
+  double m_d;
+  long double m_ld0;
+  long double m_ld1;
+  MemberInitializerListParens(float f, double d):
+    m_d(f),  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
+    m_ld0(f),  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+    m_ld1(d)  // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+  {}
+};
+
+struct MemberInitializerListBraces {
+  double m_d;
+  long double m_ld0;
+  long double m_ld1;
+  MemberInitializerListBraces(float f, double d):
+    m_d{f},  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'double'}}
+    m_ld0{f},  // expected-warning{{implicit conversion increases floating-point precision: 'float' to 'long double'}}
+    m_ld1{d}  // expected-warning{{implicit conversion increases floating-point precision: 'double' to 'long double'}}
+  {}
+};

--- a/clang/test/Sema/warn-double-promotion.cpp
+++ b/clang/test/Sema/warn-double-promotion.cpp
@@ -96,6 +96,18 @@ void Assignment(float f, double d, long double ld) {
   ld = LongDouble(d);
 }
 
+void AssignmentWithExtraParens(float f, double d, long double ld) {
+  d = static_cast<double>((f));
+  ld = static_cast<long double>((f));
+  ld = static_cast<long double>((d));
+  d = double{(f)};
+  ld = LongDouble{(f)};
+  ld = LongDouble{(d)};
+  d = double((f));
+  ld = LongDouble((f));
+  ld = LongDouble((d));
+}
+
 extern void DoubleParameter(double);
 extern void LongDoubleParameter(long double);
 


### PR DESCRIPTION
Resolves https://github.com/llvm/llvm-project/issues/33409.

The information `IsListInit` is already passed to function `CheckImplicitConversion` for another use-case which makes adding a condition for the double-promotion case simple.

Also adds tests, both for the changed list-initialization case as well as for normal explicit casts which already would have passed before this PR. These negative tests are added directly next to the positive tests in `warn-double-promotion.c` or for the C++-specific cases in a new .cpp version of that file.