### PR TITLE
[clang] fix using enum redecl in template regression

### DIFF
--- a/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -220,10 +220,11 @@ bool Sema::RequireCompleteDeclContext(CXXScopeSpec &SS,
 ///
 bool Sema::RequireCompleteEnumDecl(EnumDecl *EnumD, SourceLocation L,
                                    CXXScopeSpec *SS) {
-  if (EnumD->isCompleteDefinition()) {
+  if (EnumDecl *Def = EnumD->getDefinition();
+      Def && Def->isCompleteDefinition()) {
     // If we know about the definition but it is not visible, complain.
     NamedDecl *SuggestedDef = nullptr;
-    if (!hasReachableDefinition(EnumD, &SuggestedDef,
+    if (!hasReachableDefinition(Def, &SuggestedDef,
                                 /*OnlyNeedComplete*/ false)) {
       // If the user is going to see an error here, recover by making the
       // definition visible.

--- a/clang/test/SemaCXX/cxx20-using-enum.cpp
+++ b/clang/test/SemaCXX/cxx20-using-enum.cpp
@@ -288,4 +288,14 @@ struct S {
   };
 };
 }
+
+namespace Redecl {
+  enum class A : int { X };
+  enum class A : int;
+  template <class> struct B {
+    using enum A;
+    using Z = decltype(X);
+  };
+  template struct B<int>;
+} // namespace Redecl
 #endif


### PR DESCRIPTION
This fixes a regression reported here: https://github.com/llvm/llvm-project/pull/155313#issuecomment-3315883183

Since this regression was never released, there are no release notes.