### PR TITLE
[clang-tools-extra] Fix python syntax - pull in Queue from module queue

### DIFF
--- a/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
+++ b/clang-tools-extra/clang-include-fixer/find-all-symbols/tool/run-find-all-symbols.py
@@ -26,7 +26,7 @@ import argparse
 import json
 import multiprocessing
 import os
-import Queue
+from queue import Queue
 import shutil
 import subprocess
 import sys
@@ -105,7 +105,7 @@ def main():
 
     try:
         # Spin up a bunch of tidy-launching threads.
-        queue = Queue.Queue(max_task)
+        queue = Queue(max_task)
         for _ in range(max_task):
             t = threading.Thread(
                 target=run_find_all_symbols, args=(args, tmpdir, build_path, queue)


### PR DESCRIPTION
No such module as Queue - the Queue class is part of the queue module.