### PR TITLE
[AMDGPU] Simplify template metaprogramming in IsMCExpr##member (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -56,18 +56,15 @@ using namespace llvm::AMDGPU;
                        std::true_type>;                                        \
   };                                                                           \
   class IsMCExpr##member {                                                     \
-    template <typename U,                                                      \
-              typename std::enable_if_t<                                       \
-                  HasMember##member::RESULT &&                                 \
-                      std::is_same_v<decltype(U::member), const MCExpr *>,     \
-                  U> * = nullptr>                                              \
-    static constexpr std::true_type HasMCExprType(decltype(U::member) *);      \
+    template <typename U>                                                      \
+    static constexpr auto HasMCExprType(int) -> std::bool_constant<            \
+        HasMember##member::RESULT &&                                           \
+        std::is_same_v<decltype(U::member), const MCExpr *>>;                  \
     template <typename U> static constexpr std::false_type HasMCExprType(...); \
                                                                                \
   public:                                                                      \
     static constexpr bool RESULT =                                             \
-        std::is_same_v<decltype(HasMCExprType<AMDGPUMCKernelCodeT>(nullptr)),  \
-                       std::true_type>;                                        \
+        decltype(HasMCExprType<AMDGPUMCKernelCodeT>(0))::value;                \
   };                                                                           \
   class GetMember##member {                                                    \
   public:                                                                      \


### PR DESCRIPTION
Without this patch, we compute a type trait in a roundabout manner:

- Compute a boolean value in the primary template.
- Pass the value to std::enable_if_t.
- Return std::true_type (or std::false_type on the fallback path).
- Compare the return type to std::true_type.

That is, when the expression for the first boolean value above is well
formed, we already have the answer we are looking for.

This patch bypasses the entire sequence by having the primary template
return std::bool_constant and adjusting RESULT to extract the ::value
of the boolean type.
