### PR TITLE
[Support] Fix some warnings in LSP Transport

### DIFF
--- a/llvm/lib/Support/LSP/Transport.cpp
+++ b/llvm/lib/Support/LSP/Transport.cpp
@@ -120,7 +120,7 @@ bool MessageHandler::onReply(llvm::json::Value Id,
   // mapping and erase it.
   ResponseHandlerTy ResponseHandler;
   {
-    std::lock_guard<std::mutex> responseHandlersLock(ResponseHandlerTy);
+    std::lock_guard<std::mutex> responseHandlersLock(ResponseHandlersMutex);
     auto It = ResponseHandlers.find(debugString(Id));
     if (It != ResponseHandlers.end()) {
       ResponseHandler = std::move(It->second);

--- a/llvm/unittests/Support/LSP/Transport.cpp
+++ b/llvm/unittests/Support/LSP/Transport.cpp
@@ -174,7 +174,7 @@ TEST_F(TransportInputTest, OutgoingRequest) {
 
 TEST_F(TransportInputTest, OutgoingRequestJSONParseFailure) {
   // Make an outgoing request that expects a failure response.
-  bool responseCallbackInvoked = false;
+  unsigned responseCallbackInvoked = 0;
   auto callFn = getMessageHandler().outgoingRequest<CompletionList, Position>(
       "outgoing-request-json-parse-failure",
       [&responseCallbackInvoked](const llvm::json::Value &id,

--- a/llvm/unittests/Support/LSP/Transport.cpp
+++ b/llvm/unittests/Support/LSP/Transport.cpp
@@ -200,6 +200,6 @@ TEST_F(TransportInputTest, OutgoingRequestJSONParseFailure) {
              "{\"jsonrpc\":\"2.0\",\"id\":109,\"result\":{\"line\":3,"
              "\"character\":2}}\n");
   runTransport();
-  EXPECT_EQ(responseCallbackInvoked, 1);
+  EXPECT_EQ(responseCallbackInvoked, 1u);
 }
 } // namespace

--- a/llvm/unittests/Support/LSP/Transport.cpp
+++ b/llvm/unittests/Support/LSP/Transport.cpp
@@ -190,7 +190,7 @@ TEST_F(TransportInputTest, OutgoingRequestJSONParseFailure) {
         responseCallbackInvoked += 1;
       });
   callFn({}, 109);
-  EXPECT_EQ(responseCallbackInvoked, 0);
+  EXPECT_EQ(responseCallbackInvoked, 0u);
 
   // The request receives multiple responses, but only the first one triggers
   // the response callback. The first response has erroneous JSON that causes a


### PR DESCRIPTION
When building with latest MSVC on Windows, this fixes some compile-time warnings from last week's integration in https://github.com/llvm/llvm-project/pull/157885:
```
[321/5941] Building CXX object lib\Support\LSP\CMakeFiles\LLVMSupportLSP.dir\Transport.cpp.obj
C:\git\llvm-project\llvm\lib\Support\LSP\Transport.cpp(123): warning C4930: 'std::lock_guard<std::mutex> responseHandlersLock(llvm::lsp::MessageHandler::ResponseHandlerTy)': prototyped function not called (was a variable definition intended?)
[384/5941] Building CXX object unittests\Support\LSP\CMakeFiles\LLVMSupportLSPTests.dir\Transport.cpp.obj
C:\git\llvm-project\llvm\unittests\Support\LSP\Transport.cpp(190): warning C4804: '+=': unsafe use of type 'bool' in operation
```