### PR TITLE
[Github][CI] fix invalid path in clang-tidy helper

### DIFF
--- a/llvm/utils/git/code-lint-helper.py
+++ b/llvm/utils/git/code-lint-helper.py
@@ -193,7 +193,7 @@ def run_clang_tidy(changed_files: List[str], args: LintArgs) -> Optional[str]:
         return None
 
     tidy_diff_cmd = [
-        "code-lint-tools/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py",
+        "clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py",
         "-path",
         args.build_path,
         "-p1",


### PR DESCRIPTION
This path was left untouched after refactoring made in https://github.com/llvm/llvm-project/pull/159967 which broke clang-tidy runner.

Verified in https://github.com/llvm/llvm-project/actions/runs/17899070269/job/50889629273.