### PR TITLE
[clang-tidy][NFC] let multi-line string first line does not wrap

### DIFF
--- a/clang-tools-extra/clang-tidy/add_new_check.py
+++ b/clang-tools-extra/clang-tidy/add_new_check.py
@@ -90,7 +90,7 @@ def write_header(
             + "_H"
         )
         f.write(
-            """
+            """\
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -142,7 +142,7 @@ def write_implementation(
     print("Creating %s..." % filename)
     with io.open(filename, "w", encoding="utf8", newline="\n") as f:
         f.write(
-            """
+            """\
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -347,7 +347,8 @@ def write_test(
     print("Creating %s..." % filename)
     with io.open(filename, "w", encoding="utf8", newline="\n") as f:
         f.write(
-            """// RUN: %%check_clang_tidy %(standard)s%%s %(check_name_dashes)s %%t
+            """\
+// RUN: %%check_clang_tidy %(standard)s%%s %(check_name_dashes)s %%t
 
 // FIXME: Add something that triggers the check here.
 void f();


### PR DESCRIPTION
add `\` to avoid a blank first line
