### PR TITLE
[mlir][spirv] Rework type extension queries

### DIFF
--- a/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTypes.h
+++ b/mlir/include/mlir/Dialect/SPIRV/IR/SPIRVTypes.h
@@ -89,8 +89,6 @@ public:
   /// Returns true if the given float type is valid for the SPIR-V dialect.
   static bool isValid(IntegerType);
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 
@@ -118,8 +116,6 @@ public:
   /// implementation dependent.
   bool hasCompileTimeKnownNumElements() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 
@@ -148,8 +144,6 @@ public:
   /// type.
   unsigned getArrayStride() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 
@@ -193,8 +187,6 @@ public:
   ImageFormat getImageFormat() const;
   // TODO: Add support for Access qualifier
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 };
@@ -213,8 +205,6 @@ public:
 
   StorageClass getStorageClass() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 };
@@ -239,8 +229,6 @@ public:
   /// type.
   unsigned getArrayStride() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 };
@@ -265,8 +253,6 @@ public:
 
   Type getImageType() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<spirv::StorageClass> storage = std::nullopt);
   void
   getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                   std::optional<spirv::StorageClass> storage = std::nullopt);
@@ -420,8 +406,6 @@ public:
              ArrayRef<MemberDecorationInfo> memberDecorations = {},
              ArrayRef<StructDecorationInfo> structDecorations = {});
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 };
@@ -456,8 +440,6 @@ public:
   /// Returns the use parameter of the cooperative matrix.
   CooperativeMatrixUseKHR getUse() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 
@@ -512,8 +494,6 @@ public:
   /// Returns the elements' type (i.e, single element type).
   Type getElementType() const;
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 };
@@ -552,8 +532,6 @@ public:
   bool hasRank() const { return !getShape().empty(); }
   operator ShapedType() const { return llvm::cast<ShapedType>(*this); }
 
-  void getExtensions(SPIRVType::ExtensionArrayRefVector &extensions,
-                     std::optional<StorageClass> storage = std::nullopt);
   void getCapabilities(SPIRVType::CapabilityArrayRefVector &capabilities,
                        std::optional<StorageClass> storage = std::nullopt);
 };

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
@@ -72,7 +72,7 @@ private:
 
   SPIRVType::ExtensionArrayRefVector &extensions;
   std::optional<StorageClass> storage;
-  DenseSet<Type> seen;
+  llvm::SmallDenseSet<Type> seen;
 };
 
 } // namespace

--- a/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
+++ b/mlir/lib/Dialect/SPIRV/IR/SPIRVTypes.cpp
@@ -41,7 +41,7 @@ public:
   // Main visitor entry point. Adds all extensions to the vector. Saves `type`
   // as seen and dispatches to the right concrete `.add` function.
   void add(SPIRVType type) {
-    if (auto [_it, inserted] = seen.insert(type); !inserted)
+    if (auto [_it, inserted] = seen.insert({type, storage}); !inserted)
       return;
 
     TypeSwitch<SPIRVType>(type)
@@ -70,7 +70,7 @@ private:
 
   SPIRVType::ExtensionArrayRefVector &extensions;
   std::optional<StorageClass> storage;
-  llvm::SmallDenseSet<Type> seen;
+  llvm::SmallDenseSet<std::pair<Type, std::optional<StorageClass>>> seen;
 };
 
 } // namespace

--- a/mlir/test/Conversion/SCFToSPIRV/unsupported.mlir
+++ b/mlir/test/Conversion/SCFToSPIRV/unsupported.mlir
@@ -1,4 +1,4 @@
-// RUN: mlir-opt -convert-scf-to-spirv %s -o - | FileCheck %s
+// RUN: mlir-opt --convert-scf-to-spirv %s --verify-diagnostics --split-input-file | FileCheck %s
 
 // `scf.parallel` conversion is not supported yet.
 // Make sure that we do not accidentally invalidate this function by removing
@@ -18,4 +18,15 @@ func.func @func(%arg0: i64) {
     scf.reduce
   }
   return
+}
+
+// -----
+
+// Make sure we don't crash on recursive structs.
+// TODO(https://github.com/llvm/llvm-project/issues/159963): Promote this to a `vce-deduction.mlir` testcase.
+
+// expected-error@below {{failed to legalize operation 'spirv.module' that was explicitly marked illegal}}
+spirv.module Physical64 GLSL450 {
+  spirv.GlobalVariable @recursive:
+    !spirv.ptr<!spirv.struct<rec, (!spirv.ptr<!spirv.struct<rec>, StorageBuffer>)>, StorageBuffer>
 }


### PR DESCRIPTION
* Fix infinite recursion with nested structs.
* Drop `::getExtensions` function from derived types, so that there's only one entry point that queries type extensions.
* Move all extension logic to a new helper class -- this way the `::getExtensions` functions can't diverge across concrete types and 'convenience types' like `CompositeType`.

We should also fix `::getCapabilities` in a similar way and move the testcase to `vce-deduction.mlir`.

Issue: https://github.com/llvm/llvm-project/issues/159963