### PR TITLE
[QualGroup][docs] Reorganize QualGroup docs under Reference section

### DIFF
--- a/llvm/docs/GettingInvolved.rst
+++ b/llvm/docs/GettingInvolved.rst
@@ -208,7 +208,7 @@ what to add to your calendar invite.
      - 3rd Tuesday of the month
      - `ics <https://drive.google.com/file/d/1ten-u-4yjOcCoONUtR4_AxsFxRDTUp1b/view?usp=sharing>`__
      - `Meeting details/agenda: <https://docs.google.com/document/d/1Glzy2JiWuysbD-HBWGUOkZqT09GJ4_Ljodr0lXD5XfQ/edit>`__
-   * - LLVM Qualification Working Group
+   * - `LLVM Qualification Working Group <https://llvm.org/docs/QualGroup.html>`__
      - 1st Tuesday/Wednesday of the month
      - `ics <https://calendar.google.com/calendar/ical/c_fe5774fa2769c5085d6b87e8fac272e8940e7d0089bc0e0a58dc3ead7978504b%40group.calendar.google.com/public/basic.ics>`__
        `gcal <https://calendar.google.com/calendar/embed?src=c_fe5774fa2769c5085d6b87e8fac272e8940e7d0089bc0e0a58dc3ead7978504b%40group.calendar.google.com&ctz=Asia%2FTokyo>`__

--- a/llvm/docs/Reference.rst
+++ b/llvm/docs/Reference.rst
@@ -46,6 +46,7 @@ LLVM and API reference documentation.
    ScudoHardenedAllocator
    MemoryModelRelaxationAnnotations
    MemTagSanitizer
+   QualGroup
    Security
    SecurityTransparencyReports
    SegmentedStacks

--- a/llvm/docs/index.rst
+++ b/llvm/docs/index.rst
@@ -86,7 +86,6 @@ LLVM welcomes contributions of all kinds. To learn more, see the following artic
    :hidden:
 
    GettingInvolved
-   QualGroup
 
 * :doc:`GettingInvolved`
 * :ref:`development-process`
@@ -97,8 +96,6 @@ LLVM welcomes contributions of all kinds. To learn more, see the following artic
   Reporting a security issue
 
 * :ref:`report-security-issue`
-
-* :doc:`QualGroup`
 
 Indices and tables
 ==================


### PR DESCRIPTION
This patch makes the following updates to the `QualGroup` documentation:

✅ 1. Move to Reference section
Relocated the Qualification Working Group (QualGroup) docs from the main index into the Reference section for better organization and consistency.

✅ 2. Add link in GettingInvolved
Inserted a proper link to the QualGroup documentation in the GettingInvolved sync-ups table, improving discoverability for newcomers.

✅ 3. Align structure with Security Group
Revised the documentation layout to follow the same structure pattern as the Security Group docs, ensuring consistency across LLVM working group references.