### PR TITLE
[libcxx] Add local %T substitution

### DIFF
--- a/libcxx/utils/libcxx/test/format.py
+++ b/libcxx/utils/libcxx/test/format.py
@@ -92,6 +92,7 @@ def parseScript(test, preamble):
     #       errors, which doesn't make sense for clang-verify tests because we may want to check
     #       for specific warning diagnostics.
     _checkBaseSubstitutions(substitutions)
+    substitutions.append(("%T", tmpDir))
     substitutions.append(
         ("%{build}", "%{cxx} %s %{flags} %{compile_flags} %{link_flags} -o %t.exe")
     )


### PR DESCRIPTION
This patch adds a %T substitution directly into the libc++ test format.
This ensures that the libc++ test format will continue to work when we
remove support for %T in llvm lit.
