### PR TITLE
[libclc] Fix ctest failures after 7f3661128b1e: adjust external check and make shuffle helpers static

### DIFF
--- a/libclc/check_external_funcs.sh
+++ b/libclc/check_external_funcs.sh
@@ -17,7 +17,7 @@ fi
 TMP_FILE=$(mktemp)
 
 # Check for external functions. Calls to llvm intrinsics are OK
-$DIS < $FILE | grep '^\s*declare ' | grep -v '@llvm' > "$TMP_FILE"
+$DIS < $FILE | grep '^[[:space:]]*declare ' | grep -v '@llvm' > "$TMP_FILE"
 COUNT=$(wc -l < "$TMP_FILE")
 
 if [ "$COUNT" -ne "0" ]; then

--- a/libclc/check_external_funcs.sh
+++ b/libclc/check_external_funcs.sh
@@ -16,12 +16,12 @@ fi
 
 TMP_FILE=$(mktemp)
 
-# Check for calls. Calls to llvm intrinsics are OK
-$DIS < $FILE | grep ' call ' | grep -v '@llvm' > "$TMP_FILE"
+# Check for external functions. Calls to llvm intrinsics are OK
+$DIS < $FILE | grep '^\s*declare ' | grep -v '@llvm' > "$TMP_FILE"
 COUNT=$(wc -l < "$TMP_FILE")
 
 if [ "$COUNT" -ne "0" ]; then
-  echo "ERROR: $COUNT unresolved calls detected in $FILE"
+  echo "ERROR: $COUNT unresolved external functions detected in $FILE"
   cat $TMP_FILE
   ret=1
 else

--- a/libclc/clc/lib/generic/misc/clc_shuffle.cl
+++ b/libclc/clc/lib/generic/misc/clc_shuffle.cl
@@ -52,7 +52,7 @@
     return VAR.sF;
 
 #define _CLC_GET_ELEMENT_DEFINE(ARGTYPE, ARGSIZE, IDXTYPE)                     \
-  _CLC_INLINE ARGTYPE __clc_get_el_##ARGTYPE##ARGSIZE##_##IDXTYPE(             \
+  static ARGTYPE __clc_get_el_##ARGTYPE##ARGSIZE##_##IDXTYPE(                  \
       ARGTYPE##ARGSIZE x, IDXTYPE idx) {                                       \
     switch (idx) { _CLC_ELEMENT_CASES##ARGSIZE(x) default : return 0; }        \
   }

--- a/libclc/clc/lib/generic/misc/clc_shuffle2.cl
+++ b/libclc/clc/lib/generic/misc/clc_shuffle2.cl
@@ -52,7 +52,7 @@
     return VAR.sF;
 
 #define _CLC_GET_ELEMENT_DEFINE(ARGTYPE, ARGSIZE, IDXTYPE)                     \
-  _CLC_INLINE ARGTYPE __clc_get_el_##ARGTYPE##ARGSIZE##_##IDXTYPE(             \
+  static ARGTYPE __clc_get_el_##ARGTYPE##ARGSIZE##_##IDXTYPE(                  \
       ARGTYPE##ARGSIZE x, ARGTYPE##ARGSIZE y, IDXTYPE idx) {                   \
     if (idx < ARGSIZE)                                                         \
       switch (idx) { _CLC_ELEMENT_CASES##ARGSIZE(x) default : return 0; }      \

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -502,14 +502,14 @@ function(add_libclc_builtin_set)
     return()
   endif()
 
-  # Add a test for whether or not the libraries contain unresolved calls which
-  # would usually indicate a build problem. Note that we don't perform this
-  # test for all libclc targets:
+  # Add a test for whether or not the libraries contain unresolved functions
+  # which would usually indicate a build problem. Note that we don't perform
+  # this test for all libclc targets:
   # * nvptx-- targets don't include workitem builtins
   # * clspv targets don't include all OpenCL builtins
   if( NOT ARG_ARCH MATCHES "^(nvptx|clspv)(64)?$" )
-    add_test( NAME external-calls-${obj_suffix}
-      COMMAND ./check_external_calls.sh ${libclc_builtins_lib} ${LLVM_TOOLS_BINARY_DIR}
+    add_test( NAME external-funcs-${obj_suffix}
+      COMMAND ./check_external_funcs.sh ${libclc_builtins_lib} ${LLVM_TOOLS_BINARY_DIR}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} )
   endif()
 


### PR DESCRIPTION
* Replace call-site check with external declaration scan (grep declare) to avoid false positives for not-inlined __clc_* functions.
* _clc_get_el* helpers are defined as inline in clc_shuffle2.cl, so they have available_externally attribute. When they fail to inline they are deleted by EliminateAvailableExternallyPass and become unresolved in cedar-r600--.bc. Mark them static to resolve the issue.