### PR TITLE
[AMDGPU] Simplify "class HasMember##member" with llvm::is_detected (NFC)

### DIFF
--- a/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/Utils/AMDKernelCodeTUtils.cpp
@@ -40,20 +40,12 @@ using namespace llvm::AMDGPU;
 //     returns.
 #define GEN_HAS_MEMBER(member)                                                 \
   class HasMember##member {                                                    \
-  private:                                                                     \
-    struct KnownWithMember {                                                   \
-      int member;                                                              \
-    };                                                                         \
-    class AmbiguousDerived : public AMDGPUMCKernelCodeT,                       \
-                             public KnownWithMember {};                        \
     template <typename U>                                                      \
-    static constexpr std::false_type Test(decltype(U::member) *);              \
-    template <typename U> static constexpr std::true_type Test(...);           \
+    using check_member = decltype(std::declval<U>().member);                   \
                                                                                \
   public:                                                                      \
     static constexpr bool RESULT =                                             \
-        std::is_same_v<decltype(Test<AmbiguousDerived>(nullptr)),              \
-                       std::true_type>;                                        \
+        llvm::is_detected<check_member, AMDGPUMCKernelCodeT>::value;           \
   };                                                                           \
   class IsMCExpr##member {                                                     \
     template <typename U>                                                      \


### PR DESCRIPTION
"class HasMember##member" detects a specific member with a complex
SFINAE logic involving multiple inheritance.  This patch simplifies
that by switching to llvm::is_detected.
