### PR TITLE
[bolt][riscv] Fix conditional tail call

### DIFF
--- a/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
+++ b/bolt/lib/Target/RISCV/RISCVMCPlusBuilder.cpp
@@ -213,9 +213,26 @@ public:
     case RISCV::C_J:
     case RISCV::C_JR:
       break;
+    case RISCV::BEQ:
+    case RISCV::BNE:
+    case RISCV::BGE:
+    case RISCV::BGEU:
+    case RISCV::BLT:
+    case RISCV::BLTU:
+    case RISCV::C_BEQZ:
+    case RISCV::C_BNEZ:
+      break;
     }
 
     setTailCall(Inst);
+    return true;
+  }
+
+  bool convertTailCallToJmp(MCInst &Inst) override {
+    removeAnnotation(Inst, MCPlus::MCAnnotation::kTailCall);
+    clearOffset(Inst);
+    if (getConditionalTailCall(Inst))
+      unsetConditionalTailCall(Inst);
     return true;
   }
 
@@ -320,6 +337,7 @@ public:
     default:
       return false;
     case RISCV::C_J:
+    case RISCV::PseudoTAIL:
       OpNum = 0;
       return true;
     case RISCV::AUIPC:


### PR DESCRIPTION
When using bolt to optimize the conditional tail call, such an error message `unsupported tail call opcode` is encountered. To resolve this issue, we need to enhance convertJmpToTailCall with support for conditional branches, and extend getSymbolRefOperandNum to handle PseudoTAIL.

For example, it will change the following code
```
beq a0, a6, func1
beq a0, a5, func2

ret
```
to
```
beq a0, a6, .L1
beq a0, a6, .L2

.L1
tail func1

.L2
tail func2
```