### PR TITLE
[libc++][NFC] Remove guard around noop_coroutine_handle.h

### DIFF
--- a/libcxx/include/__coroutine/noop_coroutine_handle.h
+++ b/libcxx/include/__coroutine/noop_coroutine_handle.h
@@ -20,8 +20,6 @@
 
 _LIBCPP_BEGIN_NAMESPACE_STD
 
-#  if __has_builtin(__builtin_coro_noop) || defined(_LIBCPP_COMPILER_GCC)
-
 // [coroutine.noop]
 // [coroutine.promise.noop]
 struct noop_coroutine_promise {};
@@ -56,12 +54,12 @@ public:
 private:
   _LIBCPP_HIDE_FROM_ABI friend coroutine_handle<noop_coroutine_promise> noop_coroutine() noexcept;
 
-#    if __has_builtin(__builtin_coro_noop)
+#  if __has_builtin(__builtin_coro_noop)
   _LIBCPP_HIDE_FROM_ABI coroutine_handle() noexcept { this->__handle_ = __builtin_coro_noop(); }
 
   void* __handle_ = nullptr;
 
-#    elif defined(_LIBCPP_COMPILER_GCC)
+#  elif defined(_LIBCPP_COMPILER_GCC)
   // GCC doesn't implement __builtin_coro_noop().
   // Construct the coroutine frame manually instead.
   struct __noop_coroutine_frame_ty_ {
@@ -78,19 +76,17 @@ private:
 
   _LIBCPP_HIDE_FROM_ABI coroutine_handle() noexcept = default;
 
-#    endif // __has_builtin(__builtin_coro_noop)
+#  endif // __has_builtin(__builtin_coro_noop)
 };
 
 using noop_coroutine_handle = coroutine_handle<noop_coroutine_promise>;
 
-#    if defined(_LIBCPP_COMPILER_GCC)
+#  if defined(_LIBCPP_COMPILER_GCC)
 inline noop_coroutine_handle::__noop_coroutine_frame_ty_ noop_coroutine_handle::__noop_coroutine_frame_{};
-#    endif
+#  endif
 
 // [coroutine.noop.coroutine]
 inline _LIBCPP_HIDE_FROM_ABI noop_coroutine_handle noop_coroutine() noexcept { return noop_coroutine_handle(); }
-
-#  endif // __has_builtin(__builtin_coro_noop) || defined(_LIBCPP_COMPILER_GCC)
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
This check is always true, since all supported version of Clang have `__builtin_coro_noop` and the only other supported compiler is GCC.
