### PR TITLE
[clang] Fix crash with -lstdc++ in -ccc-print-phases

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -2668,7 +2668,15 @@ static unsigned PrintActions1(const Compilation &C, Action *A,
   int SibKind = HeadSibAction;
   os << Action::getClassName(A->getKind()) << ", ";
   if (InputAction *IA = dyn_cast<InputAction>(A)) {
-    os << "\"" << IA->getInputArg().getValue() << "\"";
+    llvm::StringRef InputValue{};
+    const auto &Opt = IA->getInputArg().getOption();
+    if (Opt.matches(options::OPT_Z_reserved_lib_stdcxx))
+      InputValue = "stdc++";
+    else if(Opt.matches(options::OPT_Z_reserved_lib_cckext))
+      InputValue = "cc_kext";
+    else
+      InputValue = IA->getInputArg().getValue();
+    os << "\"" << InputValue << "\"";
   } else if (BindArchAction *BIA = dyn_cast<BindArchAction>(A)) {
     os << '"' << BIA->getArchName() << '"' << ", {"
        << PrintActions1(C, *BIA->input_begin(), Ids, SibIndent, SibKind) << "}";


### PR DESCRIPTION
Fixes #160046

The clang crash occurred because the -lstdc++ flag was rewritten by the driver as -Z-reserved-lib-stdcxx, which doesn’t have a value. As a result, Option::getValue accessed out of bounds. The same issue also happens with the -lcc_kext flag.