### PR TITLE
[libc++] Simplify __memory/shared_count.h a bit

### DIFF
--- a/libcxx/include/__mutex/once_flag.h
+++ b/libcxx/include/__mutex/once_flag.h
@@ -10,10 +10,9 @@
 #define _LIBCPP___MUTEX_ONCE_FLAG_H
 
 #include <__config>
-#include <__functional/invoke.h>
 #include <__memory/addressof.h>
-#include <__memory/shared_count.h> // __libcpp_acquire_load
 #include <__tuple/tuple_size.h>
+#include <__type_traits/invoke.h>
 #include <__utility/forward.h>
 #include <__utility/integer_sequence.h>
 #include <__utility/move.h>
@@ -117,6 +116,15 @@ void _LIBCPP_HIDE_FROM_ABI __call_once_proxy(void* __vp) {
 }
 
 _LIBCPP_EXPORTED_FROM_ABI void __call_once(volatile once_flag::_State_type&, void*, void (*)(void*));
+
+template <class _ValueType>
+inline _LIBCPP_HIDE_FROM_ABI _ValueType __libcpp_acquire_load(_ValueType const* __value) {
+#if _LIBCPP_HAS_THREADS
+  return __atomic_load_n(__value, __ATOMIC_ACQUIRE);
+#else
+  return *__value;
+#endif
+}
 
 #ifndef _LIBCPP_CXX03_LANG
 

--- a/libcxx/include/mutex
+++ b/libcxx/include/mutex
@@ -500,6 +500,10 @@ _LIBCPP_END_NAMESPACE_STD
 
 _LIBCPP_POP_MACROS
 
+#  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 23
+#    include <typeinfo>
+#  endif
+
 #  if !defined(_LIBCPP_REMOVE_TRANSITIVE_INCLUDES) && _LIBCPP_STD_VER <= 20
 #    include <atomic>
 #    include <concepts>
@@ -513,7 +517,6 @@ _LIBCPP_POP_MACROS
 #    include <stdexcept>
 #    include <system_error>
 #    include <type_traits>
-#    include <typeinfo>
 #  endif
 #endif // __cplusplus < 201103L && defined(_LIBCPP_USE_FROZEN_CXX03_HEADERS)
 

--- a/libcxx/test/libcxx/transitive_includes/cxx26.csv
+++ b/libcxx/test/libcxx/transitive_includes/cxx26.csv
@@ -669,7 +669,6 @@ mutex ctime
 mutex limits
 mutex ratio
 mutex tuple
-mutex typeinfo
 mutex version
 new version
 numbers version


### PR DESCRIPTION
This removes a few checks that aren't required anymore and moves some code around to the places where it's actually used.
