### PR TITLE
[MLIR] Introduce RemarkPolicy for enhanced remark handling

### DIFF
--- a/mlir/include/mlir/IR/Remarks.h
+++ b/mlir/include/mlir/IR/Remarks.h
@@ -34,13 +34,13 @@ struct RemarkCategories {
 
 /// Define the policy to use for the remark engine.
 enum RemarkPolicy {
+  // Show all remarks
   RemarkPolicyAll = 0,
+  // Show only the last remark per location, remark name and category
   RemarkPolicyFinal = 1,
 };
 
-/// Define the operations to perform on the remark engine.
-/// By default none are, the provided regex matches against the category names
-/// for each kind of remark.
+/// Options to create a RemarkEngine.
 struct RemarkEngineOpts {
   RemarkCategories categories;
   RemarkPolicy policy;

--- a/mlir/include/mlir/Remark/RemarkStreamer.h
+++ b/mlir/include/mlir/Remark/RemarkStreamer.h
@@ -45,6 +45,6 @@ namespace mlir::remark {
 /// mlir::emitRemarks.
 LogicalResult enableOptimizationRemarksWithLLVMStreamer(
     MLIRContext &ctx, StringRef filePath, llvm::remarks::Format fmt,
-    const RemarkCategories &cat, bool printAsEmitRemarks = false);
+    const RemarkEngineOpts &opts, bool printAsEmitRemarks = false);
 
 } // namespace mlir::remark

--- a/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
+++ b/mlir/include/mlir/Tools/mlir-opt/MlirOptMain.h
@@ -44,6 +44,11 @@ enum class RemarkFormat {
   REMARK_FORMAT_BITSTREAM,
 };
 
+enum class RemarkPolicy {
+  REMARK_POLICY_ALL,
+  REMARK_POLICY_FINAL,
+};
+
 /// Configuration options for the mlir-opt tool.
 /// This is intended to help building tools like mlir-opt by collecting the
 /// supported options.
@@ -242,6 +247,8 @@ public:
 
   /// Set the reproducer output filename
   RemarkFormat getRemarkFormat() const { return remarkFormatFlag; }
+  /// Set the remark policy to use.
+  RemarkPolicy getRemarkPolicy() const { return remarkPolicyFlag; }
   /// Set the remark format to use.
   std::string getRemarksAllFilter() const { return remarksAllFilterFlag; }
   /// Set the remark output file.
@@ -265,6 +272,8 @@ protected:
 
   /// Remark format
   RemarkFormat remarkFormatFlag = RemarkFormat::REMARK_FORMAT_STDOUT;
+  /// Remark policy
+  RemarkPolicy remarkPolicyFlag = RemarkPolicy::REMARK_POLICY_ALL;
   /// Remark file to output to
   std::string remarksOutputFileFlag = "";
   /// Remark filters

--- a/mlir/lib/IR/MLIRContext.cpp
+++ b/mlir/lib/IR/MLIRContext.cpp
@@ -278,6 +278,8 @@ public:
     }
   }
   ~MLIRContextImpl() {
+    // finalize remark engine before destroying anything else.
+    remarkEngine.reset();
     for (auto typeMapping : registeredTypes)
       typeMapping.second->~AbstractType();
     for (auto attrMapping : registeredAttributes)

--- a/mlir/lib/IR/Remarks.cpp
+++ b/mlir/lib/IR/Remarks.cpp
@@ -238,7 +238,7 @@ void RemarkEngine::reportImpl(const Remark &remark) {
 void RemarkEngine::report(const Remark &&remark) {
   // Postponed remarks are deferred to the end of pipeline.
   if (remarkPolicy == RemarkPolicy::RemarkPolicyFinal) {
-    bool erased = postponedRemarks.erase(remark);
+    postponedRemarks.erase(remark);
     postponedRemarks.insert(remark);
     return;
   }

--- a/mlir/lib/Remark/RemarkStreamer.cpp
+++ b/mlir/lib/Remark/RemarkStreamer.cpp
@@ -60,14 +60,14 @@ void LLVMRemarkStreamer::finalize() {
 namespace mlir::remark {
 LogicalResult enableOptimizationRemarksWithLLVMStreamer(
     MLIRContext &ctx, StringRef path, llvm::remarks::Format fmt,
-    const RemarkCategories &cat, bool printAsEmitRemarks) {
+    const RemarkEngineOpts &opts, bool printAsEmitRemarks) {
 
   FailureOr<std::unique_ptr<detail::MLIRRemarkStreamerBase>> sOr =
       detail::LLVMRemarkStreamer::createToFile(path, fmt);
   if (failed(sOr))
     return failure();
 
-  return remark::enableOptimizationRemarks(ctx, std::move(*sOr), cat,
+  return remark::enableOptimizationRemarks(ctx, std::move(*sOr), opts,
                                            printAsEmitRemarks);
 }
 

--- a/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
+++ b/mlir/lib/Tools/mlir-opt/MlirOptMain.cpp
@@ -537,7 +537,7 @@ performActions(raw_ostream &os,
       config.getRemarksFailedFilter()};
   remark::RemarkPolicy policy =
       config.getRemarkPolicy() == RemarkPolicy::REMARK_POLICY_FINAL
-          ? policy = remark::RemarkPolicy::RemarkPolicyFinal
+          ? remark::RemarkPolicy::RemarkPolicyFinal
           : remark::RemarkPolicy::RemarkPolicyAll;
   remark::RemarkEngineOpts opts{cats, policy};
 

--- a/mlir/test/Pass/remark-final.mlir
+++ b/mlir/test/Pass/remark-final.mlir
@@ -7,26 +7,10 @@ module @foo {
 
 // CHECK-NOT: This is a test passed remark (should be dropped)
 
-// CHECK: --- !Failure
-// CHECK: Name:            test-remark
-// CHECK: Function:        '<unknown function>'
-// CHECK: Args:
-// CHECK:   - Remark:          This is a test failed remark
-// CHECK:   - Reason:          because we are testing the remark pipeline
-// CHECK:   - Suggestion:      try using the remark pipeline feature
+// CHECK: !Failure
+// CHECK: Remark:          This is a test failed remark
+// CHECK: !Analysis
+// CHECK: Remark:          This is a test analysis remark
+// CHECK: !Passed
+// CHECK: Remark:          This is a test passed remark
 
-// CHECK: --- !Passed
-// CHECK: Pass:            category-1-passed
-// CHECK: Name:            test-remark
-// CHECK: Function:        '<unknown function>'
-// CHECK: Args:
-// CHECK:   - Remark:          This is a test passed remark
-// CHECK:   - Reason:          because we are testing the remark pipeline
-// CHECK:   - Suggestion:      try using the remark pipeline feature
-
-// CHECK: --- !Analysis
-// CHECK: Pass:            category-2-analysis
-// CHECK: Name:            test-remark
-// CHECK: Function:        '<unknown function>'
-// CHECK: Args:
-// CHECK:   - Remark:          This is a test analysis remark

--- a/mlir/test/Pass/remark-final.mlir
+++ b/mlir/test/Pass/remark-final.mlir
@@ -1,5 +1,5 @@
 // RUN: mlir-opt %s --test-remark --remarks-filter="category.*" --remark-policy=final --remark-format=yaml --remarks-output-file=%t.yaml
-// RUN: FileCheck %t.yaml < %s 
+// RUN: FileCheck %s < %t.yaml
 module @foo {
   "test.op"() : () -> ()
   

--- a/mlir/test/Pass/remark-final.mlir
+++ b/mlir/test/Pass/remark-final.mlir
@@ -1,0 +1,38 @@
+// RUN: mlir-opt %s --test-remark --remarks-filter="category.*" --remark-policy=final --remark-format=yaml --remarks-output-file=%t.yaml
+// RUN: FileCheck %t.yaml < %s 
+module @foo {
+  "test.op"() : () -> ()
+  
+}
+
+// CHECK-NOT: This is a test passed remark (should be dropped)
+
+// CHECK: --- !Failure
+// CHECK: Name:            test-remark
+// CHECK: DebugLoc:        { File: '../mlir/test/Pass/remark-final.mlir', Line: 4, 
+// CHECK:                    Column: 3 }
+// CHECK: Function:        '<unknown function>'
+// CHECK: Args:
+// CHECK:   - Remark:          This is a test failed remark
+// CHECK:   - Reason:          because we are testing the remark pipeline
+// CHECK:   - Suggestion:      try using the remark pipeline feature
+
+// CHECK: --- !Passed
+// CHECK: Pass:            category-1-passed
+// CHECK: Name:            test-remark
+// CHECK: DebugLoc:        { File: '../mlir/test/Pass/remark-final.mlir', Line: 4, 
+// CHECK-NEXT:                    Column: 3 }
+// CHECK: Function:        '<unknown function>'
+// CHECK: Args:
+// CHECK:   - Remark:          This is a test passed remark
+// CHECK:   - Reason:          because we are testing the remark pipeline
+// CHECK:   - Suggestion:      try using the remark pipeline feature
+
+// CHECK: --- !Analysis
+// CHECK: Pass:            category-2-analysis
+// CHECK: Name:            test-remark
+// CHECK: DebugLoc:        { File: '../mlir/test/Pass/remark-final.mlir', Line: 4, 
+// CHECK-NEXT:                    Column: 3 }
+// CHECK: Function:        '<unknown function>'
+// CHECK: Args:
+// CHECK:   - Remark:          This is a test analysis remark

--- a/mlir/test/Pass/remark-final.mlir
+++ b/mlir/test/Pass/remark-final.mlir
@@ -9,8 +9,6 @@ module @foo {
 
 // CHECK: --- !Failure
 // CHECK: Name:            test-remark
-// CHECK: DebugLoc:        { File: '../mlir/test/Pass/remark-final.mlir', Line: 4, 
-// CHECK:                    Column: 3 }
 // CHECK: Function:        '<unknown function>'
 // CHECK: Args:
 // CHECK:   - Remark:          This is a test failed remark
@@ -20,8 +18,6 @@ module @foo {
 // CHECK: --- !Passed
 // CHECK: Pass:            category-1-passed
 // CHECK: Name:            test-remark
-// CHECK: DebugLoc:        { File: '../mlir/test/Pass/remark-final.mlir', Line: 4, 
-// CHECK-NEXT:                    Column: 3 }
 // CHECK: Function:        '<unknown function>'
 // CHECK: Args:
 // CHECK:   - Remark:          This is a test passed remark
@@ -31,8 +27,6 @@ module @foo {
 // CHECK: --- !Analysis
 // CHECK: Pass:            category-2-analysis
 // CHECK: Name:            test-remark
-// CHECK: DebugLoc:        { File: '../mlir/test/Pass/remark-final.mlir', Line: 4, 
-// CHECK-NEXT:                    Column: 3 }
 // CHECK: Function:        '<unknown function>'
 // CHECK: Args:
 // CHECK:   - Remark:          This is a test analysis remark

--- a/mlir/test/lib/Pass/TestRemarksPass.cpp
+++ b/mlir/test/lib/Pass/TestRemarksPass.cpp
@@ -43,7 +43,12 @@ public:
           << remark::add("This is a test missed remark")
           << remark::reason("because we are testing the remark pipeline")
           << remark::suggest("try using the remark pipeline feature");
-
+      mlir::remark::passed(
+          loc,
+          remark::RemarkOpts::name("test-remark").category("category-1-passed"))
+          << remark::add("This is a test passed remark (should be dropped)")
+          << remark::reason("because we are testing the remark pipeline")
+          << remark::suggest("try using the remark pipeline feature");
       mlir::remark::passed(
           loc,
           remark::RemarkOpts::name("test-remark").category("category-1-passed"))


### PR DESCRIPTION
PR introduces RemarkPolicy to show remarks and drop.

A very typical compiler diagnostic scenario is shown below. In this example, `Remark-1` is incorrect, because `pass-late` actually unrolled the loop.
```
    [pass-early] : emit Remark-1: failed unrolling, postponed
    ... other passes ...
    [pass-late]  : emit Remark-2: succeeded unrolling // same location/op
```

PR introduces `RemarkPolicy` to the RemarkEngine and adds an option `--remark-policy=all|final`
- `all` : shows Remark-1 and Remark-2.
- `final` : RemarkEngine postpones all remarks by default, and automatically drops earlier ones, keeping only the last remark per location + remark name + category.