### PR TITLE
[clang][nfc] Define ConstRecursiveASTVisitor twin of RecursiveASTVisitor

### DIFF
--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.h
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.h
@@ -72,7 +72,8 @@ public:
   /// Accessor for DeclParents.
   const DeclParentMap &getDeclToParentStmtMap() { return DeclParents; }
 
-  friend class clang::RecursiveASTVisitorBase<StmtAncestorASTVisitor, /*Const=*/false>;
+  friend class clang::RecursiveASTVisitorBase<StmtAncestorASTVisitor,
+                                              /*Const=*/false>;
 
 private:
   StmtParentMap StmtAncestors;
@@ -98,7 +99,8 @@ public:
   /// Accessor for Components.
   const ComponentVector &getComponents() { return Components; }
 
-  friend class clang::RecursiveASTVisitorBase<ComponentFinderASTVisitor, /*Const=*/false>;
+  friend class clang::RecursiveASTVisitorBase<ComponentFinderASTVisitor,
+                                              /*Const=*/false>;
 
 private:
   ComponentVector Components;
@@ -155,7 +157,8 @@ public:
     return DependsOnInsideVariable;
   }
 
-  friend class clang::RecursiveASTVisitorBase<DependencyFinderASTVisitor, /*Const=*/false>;
+  friend class clang::RecursiveASTVisitorBase<DependencyFinderASTVisitor,
+                                              /*Const=*/false>;
 
 private:
   const StmtParentMap *StmtParents;
@@ -188,7 +191,8 @@ public:
     return Found;
   }
 
-  friend class clang::RecursiveASTVisitorBase<DeclFinderASTVisitor, /*Const=*/false>;
+  friend class clang::RecursiveASTVisitorBase<DeclFinderASTVisitor,
+                                              /*Const=*/false>;
 
 private:
   std::string Name;

--- a/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.h
+++ b/clang-tools-extra/clang-tidy/modernize/LoopConvertUtils.h
@@ -72,7 +72,7 @@ public:
   /// Accessor for DeclParents.
   const DeclParentMap &getDeclToParentStmtMap() { return DeclParents; }
 
-  friend class clang::RecursiveASTVisitor<StmtAncestorASTVisitor>;
+  friend class clang::RecursiveASTVisitorBase<StmtAncestorASTVisitor, /*Const=*/false>;
 
 private:
   StmtParentMap StmtAncestors;
@@ -98,7 +98,7 @@ public:
   /// Accessor for Components.
   const ComponentVector &getComponents() { return Components; }
 
-  friend class clang::RecursiveASTVisitor<ComponentFinderASTVisitor>;
+  friend class clang::RecursiveASTVisitorBase<ComponentFinderASTVisitor, /*Const=*/false>;
 
 private:
   ComponentVector Components;
@@ -155,7 +155,7 @@ public:
     return DependsOnInsideVariable;
   }
 
-  friend class clang::RecursiveASTVisitor<DependencyFinderASTVisitor>;
+  friend class clang::RecursiveASTVisitorBase<DependencyFinderASTVisitor, /*Const=*/false>;
 
 private:
   const StmtParentMap *StmtParents;
@@ -188,7 +188,7 @@ public:
     return Found;
   }
 
-  friend class clang::RecursiveASTVisitor<DeclFinderASTVisitor>;
+  friend class clang::RecursiveASTVisitorBase<DeclFinderASTVisitor, /*Const=*/false>;
 
 private:
   std::string Name;
@@ -340,7 +340,7 @@ public:
 private:
   /// Typedef used in CRTP functions.
   using VisitorBase = RecursiveASTVisitor<ForLoopIndexUseVisitor>;
-  friend class RecursiveASTVisitor<ForLoopIndexUseVisitor>;
+  friend class RecursiveASTVisitorBase<ForLoopIndexUseVisitor, /*Const=*/false>;
 
   /// Overriden methods for RecursiveASTVisitor's traversal.
   bool TraverseArraySubscriptExpr(ArraySubscriptExpr *E);

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -95,7 +95,7 @@ static bool paramReferredExactlyOnce(const CXXConstructorDecl *Ctor,
   /// \see ExactlyOneUsageVisitor::hasExactlyOneUsageIn()
   class ExactlyOneUsageVisitor
       : public RecursiveASTVisitor<ExactlyOneUsageVisitor> {
-    friend class RecursiveASTVisitor<ExactlyOneUsageVisitor>;
+    friend class RecursiveASTVisitorBase<ExactlyOneUsageVisitor, /*Const=*/false>;
 
   public:
     ExactlyOneUsageVisitor(const ParmVarDecl *ParamDecl)

--- a/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
+++ b/clang-tools-extra/clang-tidy/modernize/PassByValueCheck.cpp
@@ -95,7 +95,8 @@ static bool paramReferredExactlyOnce(const CXXConstructorDecl *Ctor,
   /// \see ExactlyOneUsageVisitor::hasExactlyOneUsageIn()
   class ExactlyOneUsageVisitor
       : public RecursiveASTVisitor<ExactlyOneUsageVisitor> {
-    friend class RecursiveASTVisitorBase<ExactlyOneUsageVisitor, /*Const=*/false>;
+    friend class RecursiveASTVisitorBase<ExactlyOneUsageVisitor,
+                                         /*Const=*/false>;
 
   public:
     ExactlyOneUsageVisitor(const ParmVarDecl *ParamDecl)

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -168,7 +168,8 @@ QualType declaredType(const TypeDecl *D);
 /// Retrieves the deduced type at a given location (auto, decltype).
 /// It will return the underlying type.
 /// If the type is an undeduced auto, returns the type itself.
-std::optional<QualType> getDeducedType(const ASTContext &, const HeuristicResolver *,
+std::optional<QualType> getDeducedType(const ASTContext &,
+                                       const HeuristicResolver *,
                                        SourceLocation Loc);
 
 // Find the abbreviated-function-template `auto` within a type, or returns null.

--- a/clang-tools-extra/clangd/AST.h
+++ b/clang-tools-extra/clangd/AST.h
@@ -168,7 +168,7 @@ QualType declaredType(const TypeDecl *D);
 /// Retrieves the deduced type at a given location (auto, decltype).
 /// It will return the underlying type.
 /// If the type is an undeduced auto, returns the type itself.
-std::optional<QualType> getDeducedType(ASTContext &, const HeuristicResolver *,
+std::optional<QualType> getDeducedType(const ASTContext &, const HeuristicResolver *,
                                        SourceLocation Loc);
 
 // Find the abbreviated-function-template `auto` within a type, or returns null.
@@ -180,7 +180,7 @@ TemplateTypeParmTypeLoc getContainedAutoParamType(TypeLoc TL);
 
 // If TemplatedDecl is the generic body of a template, and the template has
 // exactly one visible instantiation, return the instantiated body.
-NamedDecl *getOnlyInstantiation(NamedDecl *TemplatedDecl);
+NamedDecl *getOnlyInstantiation(const NamedDecl *TemplatedDecl);
 
 /// Return attributes attached directly to a node.
 std::vector<const Attr *> getAttributes(const DynTypedNode &);

--- a/clang/include/clang/AST/StmtOpenACC.h
+++ b/clang/include/clang/AST/StmtOpenACC.h
@@ -81,7 +81,6 @@ public:
 class OpenACCAssociatedStmtConstruct : public OpenACCConstructStmt {
   friend class ASTStmtWriter;
   friend class ASTStmtReader;
-  template <typename Derived> friend class RecursiveASTVisitor;
   Stmt *AssociatedStmt = nullptr;
 
 protected:

--- a/clang/lib/AST/ParentMapContext.cpp
+++ b/clang/lib/AST/ParentMapContext.cpp
@@ -363,7 +363,7 @@ public:
   ASTVisitor(ParentMap &Map) : Map(Map) {}
 
 private:
-  friend class RecursiveASTVisitor<ASTVisitor>;
+  friend class RecursiveASTVisitorBase<ASTVisitor, false>;
 
   using VisitorBase = RecursiveASTVisitor<ASTVisitor>;
 

--- a/clang/lib/Index/IndexBody.cpp
+++ b/clang/lib/Index/IndexBody.cpp
@@ -508,7 +508,7 @@ public:
   bool TraverseTypeConstraint(const TypeConstraint *C) {
     IndexCtx.handleReference(C->getNamedConcept(), C->getConceptNameLoc(),
                              Parent, ParentDC);
-    return RecursiveASTVisitor::TraverseTypeConstraint(C);
+    return base::TraverseTypeConstraint(C);
   }
 };
 

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3983,10 +3983,10 @@ void EmitClangAttrASTVisitor(const RecordKeeper &Records, raw_ostream &OS) {
     const Record &R = *Attr;
     if (!R.getValueAsBit("ASTNode"))
       continue;
-    OS << "  bool Traverse" << R.getName()
-       << "Attr(MaybeConst<" << R.getName() << "Attr> *A);\n";
-    OS << "  bool Visit" << R.getName()
-       << "Attr(MaybeConst<" << R.getName() << "Attr> *A) {\n"
+    OS << "  bool Traverse" << R.getName() << "Attr(MaybeConst<" << R.getName()
+       << "Attr> *A);\n";
+    OS << "  bool Visit" << R.getName() << "Attr(MaybeConst<" << R.getName()
+       << "Attr> *A) {\n"
        << "    return true; \n"
        << "  }\n";
   }

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -3983,10 +3983,10 @@ void EmitClangAttrASTVisitor(const RecordKeeper &Records, raw_ostream &OS) {
     const Record &R = *Attr;
     if (!R.getValueAsBit("ASTNode"))
       continue;
-    OS << "  bool Traverse"
-       << R.getName() << "Attr(" << R.getName() << "Attr *A);\n";
-    OS << "  bool Visit"
-       << R.getName() << "Attr(" << R.getName() << "Attr *A) {\n"
+    OS << "  bool Traverse" << R.getName()
+       << "Attr(MaybeConst<" << R.getName() << "Attr> *A);\n";
+    OS << "  bool Visit" << R.getName()
+       << "Attr(MaybeConst<" << R.getName() << "Attr> *A) {\n"
        << "    return true; \n"
        << "  }\n";
   }
@@ -3998,9 +3998,9 @@ void EmitClangAttrASTVisitor(const RecordKeeper &Records, raw_ostream &OS) {
     if (!R.getValueAsBit("ASTNode"))
       continue;
 
-    OS << "template <typename Derived>\n"
-       << "bool VISITORCLASS<Derived>::Traverse"
-       << R.getName() << "Attr(" << R.getName() << "Attr *A) {\n"
+    OS << "template <typename Derived, bool IsConst>\n"
+       << "bool VISITORCLASS<Derived, IsConst>::Traverse" << R.getName()
+       << "Attr(MaybeConst<" << R.getName() << "Attr> *A) {\n"
        << "  if (!getDerived().VisitAttr(A))\n"
        << "    return false;\n"
        << "  if (!getDerived().Visit" << R.getName() << "Attr(A))\n"
@@ -4018,8 +4018,9 @@ void EmitClangAttrASTVisitor(const RecordKeeper &Records, raw_ostream &OS) {
   }
 
   // Write generic Traverse routine
-  OS << "template <typename Derived>\n"
-     << "bool VISITORCLASS<Derived>::TraverseAttr(Attr *A) {\n"
+  OS << "template <typename Derived, bool IsConst>\n"
+     << "bool VISITORCLASS<Derived, IsConst>::TraverseAttr("
+     << "MaybeConst<Attr> *A) {\n"
      << "  if (!A)\n"
      << "    return true;\n"
      << "\n"
@@ -4032,7 +4033,8 @@ void EmitClangAttrASTVisitor(const RecordKeeper &Records, raw_ostream &OS) {
 
     OS << "    case attr::" << R.getName() << ":\n"
        << "      return getDerived().Traverse" << R.getName() << "Attr("
-       << "cast<" << R.getName() << "Attr>(A));\n";
+       << "const_cast<MaybeConst<" << R.getName()
+       << "Attr> *>(static_cast<const " << R.getName() << "Attr *>(A)));\n";
   }
   OS << "  }\n";  // end switch
   OS << "  llvm_unreachable(\"bad attribute kind\");\n";


### PR DESCRIPTION
Downstream whenever we reach out for a RecursiveASTVisitor we always
have to add a few const_casts to shoe it in. This NFC patch introduces a
const version of the same CRTP class.

To reduce code duplication, I factored out all the common logic (which is
all of it) into `RecursiveASTVisitorBase` and made `RecursiveASTVisitor`
and `ConstRecursiveASTVisitor` essentially the two instances of it, that
you should use depending on whether you want to modify AST in your
visitor.

This is very similar to the DynamicRecursiveASTVisitor structure. One
point of difference is that instead of type aliases I use inheritance to
reduce the diff of this change because templated alias is not accepted
in the implementation forwarding of the overridden member functions:
`return RecursiveASTVisitor::TraverseStmt(S);` works only if
`RecursiveASTVisitor` is defined as a derived class of
`RecursiveASTVisitorBase` and not as a parametric alias. This was not an
issue for DynamicRecursiveASTVisitor because it is not parameterized
by the `Derived` type.

Unfortunately, I did not manager to maintain a full backwards
compatibility when it comes to the `friend` declarations, you have to
befriend the `RecursiveASTVisitorBase` and not `RecursiveASTVisitor`.
Moreover, the error message is not obvious, as it speaks of the member
function being private and does not point to the `friend` declaration.