### PR TITLE
[LLDB][PDB] Warn if DIA plugin is requested but not available

### DIFF
--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -164,7 +164,6 @@ private:
     case ePDBReaderDIA:
       return false;
     default:
-    case ePDBReaderDefault:
       return ShouldUseNativeReaderByDefault();
     }
   }

--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -106,7 +106,7 @@ enum {
 #include "SymbolFilePDBPropertiesEnum.inc"
 };
 
-static bool g_should_use_native_reader_by_default = [] {
+static const bool g_should_use_native_reader_by_default = [] {
   llvm::StringRef env_value = ::getenv("LLDB_USE_NATIVE_PDB_READER");
 
 #if !LLVM_ENABLE_DIA_SDK || !defined(_WIN32)

--- a/lldb/test/Shell/SymbolFile/NativePDB/native-setting.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/native-setting.cpp
@@ -4,8 +4,14 @@
 // RUN: %build -o %t.exe -- %s
 // RUN: env -u LLDB_USE_NATIVE_PDB_READER %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=NO-ENV %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER= %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=NO-ENV %s
+
 // RUN: env LLDB_USE_NATIVE_PDB_READER=0 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV1 %s
+
+// RUN: env LLDB_USE_NATIVE_PDB_READER=foo %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
+// RUN: env LLDB_USE_NATIVE_PDB_READER=42 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
+// RUN: env LLDB_USE_NATIVE_PDB_READER=-1 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
+
 // RUN: env LLDB_USE_NATIVE_PDB_READER=0 %lldb \
 // RUN:     -o 'settings set plugin.symbol-file.pdb.reader dia' \
 // RUN:     -o 'target create %t.exe' \

--- a/lldb/test/Shell/SymbolFile/NativePDB/native-setting.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/native-setting.cpp
@@ -1,6 +1,6 @@
-// REQUIRES: diasdk, target-windows
+// REQUIRES: !diasdk, target-windows
 
-// Test plugin.symbol-file.pdb.reader setting
+// Test plugin.symbol-file.pdb.reader setting without the DIA SDK
 // RUN: %build -o %t.exe -- %s
 // RUN: env -u LLDB_USE_NATIVE_PDB_READER %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=NO-ENV %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER= %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=NO-ENV %s
@@ -30,29 +30,29 @@
 // NO-ENV-NOT: warning:
 // NO-ENV: (lldb) target modules dump symfile
 // NO-ENV: Dumping debug symbols for 1 modules.
-// NO-ENV: SymbolFile pdb
+// NO-ENV: SymbolFile native-pdb
 
-// ENV0-NOT: warning:
+// ENV0: warning: The DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead.
 // ENV0: (lldb) target modules dump symfile
 // ENV0: Dumping debug symbols for 1 modules.
-// ENV0: SymbolFile pdb
+// ENV0: SymbolFile native-pdb
 
 // ENV1-NOT: warning:
 // ENV1: (lldb) target modules dump symfile
 // ENV1: Dumping debug symbols for 1 modules.
 // ENV1: SymbolFile native-pdb
 
-// ENV0-SET-DIA-NOT: warning:
+// ENV0-SET-DIA: warning: The DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead.
 // ENV0-SET-DIA: (lldb) target modules dump symfile
 // ENV0-SET-DIA: Dumping debug symbols for 1 modules.
-// ENV0-SET-DIA: SymbolFile pdb
+// ENV0-SET-DIA: SymbolFile native-pdb
 
-// ENV1-SET-DIA-NOT: warning:
+// ENV1-SET-DIA: warning: The DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead.
 // ENV1-SET-DIA: (lldb) target modules dump symfile
 // ENV1-SET-DIA: Dumping debug symbols for 1 modules.
-// ENV1-SET-DIA: SymbolFile pdb
+// ENV1-SET-DIA: SymbolFile native-pdb
 
-// ENV0-SET-NATIVE-NOT: warning:
+// ENV1-SET-NATIVE-NOT: warning:
 // ENV0-SET-NATIVE: (lldb) target modules dump symfile
 // ENV0-SET-NATIVE: Dumping debug symbols for 1 modules.
 // ENV0-SET-NATIVE: SymbolFile native-pdb

--- a/lldb/test/Shell/SymbolFile/PDB/native-setting.cpp
+++ b/lldb/test/Shell/SymbolFile/PDB/native-setting.cpp
@@ -4,8 +4,14 @@
 // RUN: %build -o %t.exe -- %s
 // RUN: env -u LLDB_USE_NATIVE_PDB_READER %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=NO-ENV %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER= %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=NO-ENV %s
+
 // RUN: env LLDB_USE_NATIVE_PDB_READER=0 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
 // RUN: env LLDB_USE_NATIVE_PDB_READER=1 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV1 %s
+
+// RUN: env LLDB_USE_NATIVE_PDB_READER=foo %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
+// RUN: env LLDB_USE_NATIVE_PDB_READER=42 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
+// RUN: env LLDB_USE_NATIVE_PDB_READER=-1 %lldb %t.exe -o 'target modules dump symfile' 2>&1 | FileCheck --check-prefix=ENV0 %s
+
 // RUN: env LLDB_USE_NATIVE_PDB_READER=0 %lldb \
 // RUN:     -o 'settings set plugin.symbol-file.pdb.reader dia' \
 // RUN:     -o 'target create %t.exe' \


### PR DESCRIPTION
If LLDB was built without the DIA SDK and the DIA reader is explicitly requested (through `LLDB_USE_NATIVE_PDB_READER=0` or `settings set plugin.symbol-file.pdb.reader dia`), LLDB should print a warning, because it will use the native reader in any case (https://github.com/llvm/llvm-project/pull/159769#discussion_r2367316980).

This PR adds the warning and a test when LLDB is not built with the SDK on Windows. I don't think any builder runs this configuration, as there are still five failing tests. I tested this locally with and without the SDK.