### PR TITLE
[clang][bytecode] Only block pointers can be partially initialized

### DIFF
--- a/clang/lib/AST/ByteCode/EvaluationResult.cpp
+++ b/clang/lib/AST/ByteCode/EvaluationResult.cpp
@@ -133,6 +133,8 @@ bool EvaluationResult::checkFullyInitialized(InterpState &S,
 
   if (Ptr.isZero())
     return true;
+  if (!Ptr.isBlockPointer())
+    return true;
 
   // We can't inspect dead pointers at all. Return true here so we can
   // diagnose them later.

--- a/clang/test/AST/ByteCode/typeid.cpp
+++ b/clang/test/AST/ByteCode/typeid.cpp
@@ -32,10 +32,10 @@ static_assert(&typeid(int) < &typeid(long)); // both-error {{not an integral con
 static_assert(&typeid(int) > &typeid(long)); // both-error {{not an integral constant expression}} \
                                              // both-note {{comparison between pointers to unrelated objects '&typeid(int)' and '&typeid(long)' has unspecified value}}
 
- struct Base {
-   virtual void func() ;
- };
- struct Derived : Base {};
+struct Base {
+ virtual void func() ;
+};
+struct Derived : Base {};
 
 constexpr bool test() {
   Derived derived;
@@ -51,4 +51,11 @@ int dontcrash() {
       typeid(int)
   );
   return pti.__flags == 0 ? 1 : 0;
+}
+
+namespace TypeidPtrInEvaluationResult {
+  struct C {};
+  C c = C();
+  consteval const std::type_info *ftype_info() { return &typeid(c); }
+  const std::type_info *T1 = ftype_info();
 }


### PR DESCRIPTION
So ignore the rest in `checkFullyInitialized()`.

Fixes #160071