### PR TITLE
[NFC][clang] Quote literal builtin attribute markers in Builtins.def docs

### DIFF
--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -67,38 +67,38 @@
 // The third value provided to the macro specifies information about attributes
 // of the function.  These must be kept in sync with the predicates in the
 // Builtin::Context class.  Currently we have:
-//  n -> nothrow
-//  r -> noreturn
-//  U -> pure
-//  c -> const
-//  t -> signature is meaningless, use custom typechecking
-//  T -> type is not important to semantic analysis and codegen; recognize as
-//       builtin even if type doesn't match signature, and don't warn if we
-//       can't be sure the type is right
-//  F -> this is a libc/libm function with a '__builtin_' prefix added.
-//  f -> this is a libc/libm function without a '__builtin_' prefix, or with
-//       'z', a C++ standard library function in namespace std::. This builtin
-//       is disableable by '-fno-builtin-foo' / '-fno-builtin-std-foo'.
-//  h -> this function requires a specific header or an explicit declaration.
-//  i -> this is a runtime library implemented function without the
-//       '__builtin_' prefix. It will be implemented in compiler-rt or libgcc.
-//  p:N: -> this is a printf-like function whose Nth argument is the format
-//          string.
-//  P:N: -> similar to the p:N: attribute, but the function is like vprintf
-//          in that it accepts its arguments as a va_list rather than
-//          through an ellipsis
-//  s:N: -> this is a scanf-like function whose Nth argument is the format
-//          string.
-//  S:N: -> similar to the s:N: attribute, but the function is like vscanf
-//          in that it accepts its arguments as a va_list rather than
-//          through an ellipsis
-//  e -> const, but only when -fno-math-errno and FP exceptions are ignored
-//  g -> const when FP exceptions are ignored
-//  j -> returns_twice (like setjmp)
-//  u -> arguments are not evaluated for their side-effects
-//  V:N: -> requires vectors of at least N bits to be legal
-//  C<N,M_0,...,M_k> -> callback behavior: argument N is called with argument
-//                      M_0, ..., M_k as payload
-//  z -> this is a function in (possibly-versioned) namespace std
-//  E -> this function can be constant evaluated by Clang frontend
-//  G -> this is a C++20 consteval function
+//  'n' -> nothrow
+//  'r' -> noreturn
+//  'U' -> pure
+//  'c' -> const
+//  't' -> signature is meaningless, use custom typechecking
+//  'T' -> type is not important to semantic analysis and codegen; recognize as
+//         builtin even if type doesn't match signature, and don't warn if we
+//         can't be sure the type is right
+//  'F' -> this is a libc/libm function with a '__builtin_' prefix added.
+//  'f' -> this is a libc/libm function without a '__builtin_' prefix, or with
+//         'z', a C++ standard library function in namespace std::. This builtin
+//         is disableable by '-fno-builtin-foo' / '-fno-builtin-std-foo'.
+//  'h' -> this function requires a specific header or an explicit declaration.
+//  'i' -> this is a runtime library implemented function without the
+//         '__builtin_' prefix. It will be implemented in compiler-rt or libgcc.
+//  'p':N: -> this is a printf-like function whose Nth argument is the format
+//            string.
+//  'P':N: -> similar to the p:N: attribute, but the function is like vprintf
+//            in that it accepts its arguments as a va_list rather than
+//            through an ellipsis
+//  's':N: -> this is a scanf-like function whose Nth argument is the format
+//            string.
+//  'S':N: -> similar to the s:N: attribute, but the function is like vscanf
+//            in that it accepts its arguments as a va_list rather than
+//            through an ellipsis
+//  'e' -> const, but only when -fno-math-errno and FP exceptions are ignored
+//  'g' -> const when FP exceptions are ignored
+//  'j' -> returns_twice (like setjmp)
+//  'u' -> arguments are not evaluated for their side-effects
+//  'V':N: -> requires vectors of at least N bits to be legal
+//  'C'<N,M_0,...,M_k> -> callback behavior: argument N is called with argument
+//                        M_0, ..., M_k as payload
+//  'z' -> this is a function in (possibly-versioned) namespace std
+//  'E' -> this function can be constant evaluated by Clang frontend
+//  'G' -> this is a C++20 consteval function

--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -66,7 +66,8 @@
 
 // The third value provided to the macro specifies information about attributes
 // of the function.  These must be kept in sync with the predicates in the
-// Builtin::Context class.  Currently we have:
+// Builtin::Context class.  Note: In the descriptions below, {num} is a
+// placeholder for an integer.  Currently we have:
 //
 // (In the descriptions below, {num} is a placeholder for an integer)
 //
@@ -85,23 +86,23 @@
 //  h -> this function requires a specific header or an explicit declaration.
 //  i -> this is a runtime library implemented function without the
 //       '__builtin_' prefix. It will be implemented in compiler-rt or libgcc.
-//  p:{num}: -> this is a printf-like function whose {num}th argument is the format
-//              string.
-//  P:{num}: -> similar to the p:{num}: attribute, but the function is like vprintf
-//              in that it accepts its arguments as a va_list rather than
+//  p:{num}: -> this is a printf-like function whose {num}th argument is the
+//              format string.
+//  P:{num}: -> similar to the p:{num}: attribute, but the function is like
+//              vprintf in that it accepts its arguments as a va_list rather than
 //              through an ellipsis
-//  s:{num}: -> this is a scanf-like function whose {num}th argument is the format
-//              string.
-//  S:{num}: -> similar to the s:{num}: attribute, but the function is like vscanf
-//              in that it accepts its arguments as a va_list rather than
+//  s:{num}: -> this is a scanf-like function whose {num}th argument is the
+//              format string.
+//  S:{num}: -> similar to the s:{num}: attribute, but the function is like
+//              vscanf in that it accepts its arguments as a va_list rather than
 //              through an ellipsis
 //  e -> const, but only when -fno-math-errno and FP exceptions are ignored
 //  g -> const when FP exceptions are ignored
 //  j -> returns_twice (like setjmp)
 //  u -> arguments are not evaluated for their side-effects
 //  V:{num}: -> requires vectors of at least {num} bits to be legal
-//  C<{num},M_0,...,M_k> -> callback behavior: argument {num} is called with argument
-//                          M_0, ..., M_k as payload
+//  C<{num},M_0,...,M_k> -> callback behavior: argument {num} is called with
+//                          argument M_0, ..., M_k as payload
 //  z -> this is a function in (possibly-versioned) namespace std
 //  E -> this function can be constant evaluated by Clang frontend
 //  G -> this is a C++20 consteval function

--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -67,38 +67,41 @@
 // The third value provided to the macro specifies information about attributes
 // of the function.  These must be kept in sync with the predicates in the
 // Builtin::Context class.  Currently we have:
-//  'n' -> nothrow
-//  'r' -> noreturn
-//  'U' -> pure
-//  'c' -> const
-//  't' -> signature is meaningless, use custom typechecking
-//  'T' -> type is not important to semantic analysis and codegen; recognize as
-//         builtin even if type doesn't match signature, and don't warn if we
-//         can't be sure the type is right
-//  'F' -> this is a libc/libm function with a '__builtin_' prefix added.
-//  'f' -> this is a libc/libm function without a '__builtin_' prefix, or with
-//         'z', a C++ standard library function in namespace std::. This builtin
-//         is disableable by '-fno-builtin-foo' / '-fno-builtin-std-foo'.
-//  'h' -> this function requires a specific header or an explicit declaration.
-//  'i' -> this is a runtime library implemented function without the
-//         '__builtin_' prefix. It will be implemented in compiler-rt or libgcc.
-//  'p':N: -> this is a printf-like function whose Nth argument is the format
-//            string.
-//  'P':N: -> similar to the p:N: attribute, but the function is like vprintf
-//            in that it accepts its arguments as a va_list rather than
-//            through an ellipsis
-//  's':N: -> this is a scanf-like function whose Nth argument is the format
-//            string.
-//  'S':N: -> similar to the s:N: attribute, but the function is like vscanf
-//            in that it accepts its arguments as a va_list rather than
-//            through an ellipsis
-//  'e' -> const, but only when -fno-math-errno and FP exceptions are ignored
-//  'g' -> const when FP exceptions are ignored
-//  'j' -> returns_twice (like setjmp)
-//  'u' -> arguments are not evaluated for their side-effects
-//  'V':N: -> requires vectors of at least N bits to be legal
-//  'C'<N,M_0,...,M_k> -> callback behavior: argument N is called with argument
-//                        M_0, ..., M_k as payload
-//  'z' -> this is a function in (possibly-versioned) namespace std
-//  'E' -> this function can be constant evaluated by Clang frontend
-//  'G' -> this is a C++20 consteval function
+//
+// (In the descriptions below, {num} is a placeholder for an integer)
+//
+//  n -> nothrow
+//  r -> noreturn
+//  U -> pure
+//  c -> const
+//  t -> signature is meaningless, use custom typechecking
+//  T -> type is not important to semantic analysis and codegen; recognize as
+//       builtin even if type doesn't match signature, and don't warn if we
+//       can't be sure the type is right
+//  F -> this is a libc/libm function with a '__builtin_' prefix added.
+//  f -> this is a libc/libm function without a '__builtin_' prefix, or with
+//       'z', a C++ standard library function in namespace std::. This builtin
+//       is disableable by '-fno-builtin-foo' / '-fno-builtin-std-foo'.
+//  h -> this function requires a specific header or an explicit declaration.
+//  i -> this is a runtime library implemented function without the
+//       '__builtin_' prefix. It will be implemented in compiler-rt or libgcc.
+//  p:{num}: -> this is a printf-like function whose {num}th argument is the format
+//              string.
+//  P:{num}: -> similar to the p:{num}: attribute, but the function is like vprintf
+//              in that it accepts its arguments as a va_list rather than
+//              through an ellipsis
+//  s:{num}: -> this is a scanf-like function whose {num}th argument is the format
+//              string.
+//  S:{num}: -> similar to the s:{num}: attribute, but the function is like vscanf
+//              in that it accepts its arguments as a va_list rather than
+//              through an ellipsis
+//  e -> const, but only when -fno-math-errno and FP exceptions are ignored
+//  g -> const when FP exceptions are ignored
+//  j -> returns_twice (like setjmp)
+//  u -> arguments are not evaluated for their side-effects
+//  V:{num}: -> requires vectors of at least {num} bits to be legal
+//  C<{num},M_0,...,M_k> -> callback behavior: argument {num} is called with argument
+//                          M_0, ..., M_k as payload
+//  z -> this is a function in (possibly-versioned) namespace std
+//  E -> this function can be constant evaluated by Clang frontend
+//  G -> this is a C++20 consteval function

--- a/clang/include/clang/Basic/Builtins.def
+++ b/clang/include/clang/Basic/Builtins.def
@@ -68,9 +68,6 @@
 // of the function.  These must be kept in sync with the predicates in the
 // Builtin::Context class.  Note: In the descriptions below, {num} is a
 // placeholder for an integer.  Currently we have:
-//
-// (In the descriptions below, {num} is a placeholder for an integer)
-//
 //  n -> nothrow
 //  r -> noreturn
 //  U -> pure


### PR DESCRIPTION
Clarify the documentation in Builtins.def by quoting literal attribute markers (e.g. 'n', 'r', 'U', 'N') to distinguish them from placeholders such as N in C<N,...>. This avoids confusion and makes the attribute docs clearer.