### PR TITLE
[flang-rt] Set _POSIX_C_SOURCE on Darwin

### DIFF
--- a/flang-rt/cmake/modules/AddFlangRT.cmake
+++ b/flang-rt/cmake/modules/AddFlangRT.cmake
@@ -251,8 +251,15 @@ function (add_flangrt_library name)
           $<$<COMPILE_LANGUAGE:CXX>:-nogpulib -flto -fvisibility=hidden -Wno-unknown-cuda-version --cuda-feature=+ptx63>
         )
     elseif (APPLE)
+      # Clang on Darwin enables non-POSIX extensions by default.
+      # This causes some macros to leak, such as HUGE from <math.h>, which
+      # causes some conflicts with Flang symbols (but not with Flang-RT, for
+      # now).
+      # It also causes some Flang-RT extensions to be disabled, such as fdate,
+      # that checks for _POSIX_C_SOURCE.
+      # Setting _POSIX_C_SOURCE avoids these issues.
       target_compile_options(${tgtname} PRIVATE
-          $<$<COMPILE_LANGUAGE:CXX>:${DARWIN_osx_BUILTIN_MIN_VER_FLAG}>
+          $<$<COMPILE_LANGUAGE:CXX>:${DARWIN_osx_BUILTIN_MIN_VER_FLAG} -D_POSIX_C_SOURCE=200809>
         )
     endif ()
 

--- a/flang-rt/unittests/CMakeLists.txt
+++ b/flang-rt/unittests/CMakeLists.txt
@@ -78,6 +78,15 @@ function(add_flangrt_dependent_libs target)
         instead falls back to builtins from Compiler-RT. Linking with ${tgtname}
         may result in a linker error.")
     endif ()
+  elseif (APPLE)
+    # Clang on Darwin enables non-POSIX extensions by default.
+    # This causes some macros to leak, such as HUGE from <math.h>, which
+    # causes some conflicts with Flang symbols (but not with Flang-RT, for
+    # now).
+    # It also causes some Flang-RT extensions to be disabled, such as fdate,
+    # that checks for _POSIX_C_SOURCE.
+    # Setting _POSIX_C_SOURCE avoids these issues.
+    target_compile_options(${target} PRIVATE "-D_POSIX_C_SOURCE=200809")
   endif ()
 endfunction()
 


### PR DESCRIPTION
Clang on Darwin enables non-POSIX extensions by default.
This causes some macros to leak, such as HUGE from <math.h>, which
causes some conflicts with Flang symbols (but not with Flang-RT, for
now).

It also causes some Flang-RT extensions to be disabled, such as FDATE,
that checks for _POSIX_C_SOURCE. Setting _POSIX_C_SOURCE avoids these
issues. This is already being done in Flang, but it was not ported to
Flang-RT.

This also fixes check-flang-rt on Darwin, as NoArgv.FdateNotSupported
is broken since the flang runtime was moved to flang-rt.

Fixes #82036
