### PR TITLE
[BOLT] Check if symbol is in data area of function

### DIFF
--- a/bolt/include/bolt/Core/BinaryFunction.h
+++ b/bolt/include/bolt/Core/BinaryFunction.h
@@ -683,7 +683,8 @@ private:
   ///
   /// Prefer to use BinaryContext::getFunctionForSymbol(EntrySymbol, &ID)
   /// instead of calling this function directly.
-  uint64_t getEntryIDForSymbol(const MCSymbol *EntrySymbol) const;
+  std::optional<uint64_t>
+  getEntryIDForSymbol(const MCSymbol *EntrySymbol) const;
 
   /// If the function represents a secondary split function fragment, set its
   /// parent fragment to \p BF.

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2519,10 +2519,6 @@ BinaryFunction *BinaryContext::getFunctionForSymbol(const MCSymbol *Symbol,
   BinaryFunction *BF = BFI->second;
   if (EntryDesc) {
     std::optional<uint64_t> EntryID = BF->getEntryIDForSymbol(Symbol);
-    if (BF->isMultiEntry() && EntryID.has_value() && *EntryID != 0 &&
-        !BF->validateInternalBranches()) {
-      EntryID = 0;
-    }
     *EntryDesc = EntryID.value_or(0);
   }
 

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2517,8 +2517,16 @@ BinaryFunction *BinaryContext::getFunctionForSymbol(const MCSymbol *Symbol,
     return nullptr;
 
   BinaryFunction *BF = BFI->second;
-  if (EntryDesc)
+  if (EntryDesc) {
+    const uint64_t Address = BF->getAddress() + Symbol->getOffset();
+    if (BF->isInConstantIsland(Address)) {
+      this->outs() << "BOLT-WARNING: symbol " << Symbol->getName()
+                   << " is in data region of function 0x"
+                   << Twine::utohexstr(Address) << ".\n";
+      return nullptr;
+    }
     *EntryDesc = BF->getEntryIDForSymbol(Symbol);
+  }
 
   return BF;
 }

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2522,7 +2522,7 @@ BinaryFunction *BinaryContext::getFunctionForSymbol(const MCSymbol *Symbol,
     if (BF->isInConstantIsland(Address)) {
       this->outs() << "BOLT-WARNING: symbol " << Symbol->getName()
                    << " is in data region of function 0x"
-                   << Twine::utohexstr(Address) << ".\n";
+                   << Twine::utohexstr(BF->getAddress()) << ".\n";
       return nullptr;
     }
     *EntryDesc = BF->getEntryIDForSymbol(Symbol);

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2518,13 +2518,12 @@ BinaryFunction *BinaryContext::getFunctionForSymbol(const MCSymbol *Symbol,
 
   BinaryFunction *BF = BFI->second;
   if (EntryDesc) {
-    const uint64_t Address = BF->getAddress() + Symbol->getOffset();
-    if (BF->isInConstantIsland(Address)) {
-      this->outs() << "BOLT-WARNING: symbol " << Symbol->getName()
-                   << " is in data region of function " << BF->getOneName()
-                   << "(0x" << Twine::utohexstr(BF->getAddress()) << ").\n";
+    std::optional<uint64_t> EntryID = BF->getEntryIDForSymbol(Symbol);
+    if (BF->isMultiEntry() && EntryID.has_value() && *EntryID != 0 &&
+        !BF->validateInternalBranches()) {
+      EntryID = 0;
     }
-    *EntryDesc = BF->getEntryIDForSymbol(Symbol).value_or(0);
+    *EntryDesc = EntryID.value_or(0);
   }
 
   return BF;

--- a/bolt/lib/Core/BinaryContext.cpp
+++ b/bolt/lib/Core/BinaryContext.cpp
@@ -2521,11 +2521,10 @@ BinaryFunction *BinaryContext::getFunctionForSymbol(const MCSymbol *Symbol,
     const uint64_t Address = BF->getAddress() + Symbol->getOffset();
     if (BF->isInConstantIsland(Address)) {
       this->outs() << "BOLT-WARNING: symbol " << Symbol->getName()
-                   << " is in data region of function 0x"
-                   << Twine::utohexstr(BF->getAddress()) << ".\n";
-      return nullptr;
+                   << " is in data region of function " << BF->getOneName()
+                   << "(0x" << Twine::utohexstr(BF->getAddress()) << ").\n";
     }
-    *EntryDesc = BF->getEntryIDForSymbol(Symbol);
+    *EntryDesc = BF->getEntryIDForSymbol(Symbol).value_or(0);
   }
 
   return BF;

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -3887,7 +3887,7 @@ MCSymbol *BinaryFunction::getSymbolForEntryID(uint64_t EntryID) {
 
 std::optional<uint64_t>
 BinaryFunction::getEntryIDForSymbol(const MCSymbol *Symbol) const {
-  if (!isMultiEntry())
+  if (!isMultiEntry() || !Symbol)
     return 0;
 
   for (const MCSymbol *FunctionSymbol : getSymbols())

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -3885,7 +3885,8 @@ MCSymbol *BinaryFunction::getSymbolForEntryID(uint64_t EntryID) {
   return nullptr;
 }
 
-uint64_t BinaryFunction::getEntryIDForSymbol(const MCSymbol *Symbol) const {
+std::optional<uint64_t>
+BinaryFunction::getEntryIDForSymbol(const MCSymbol *Symbol) const {
   if (!isMultiEntry())
     return 0;
 
@@ -3912,8 +3913,7 @@ uint64_t BinaryFunction::getEntryIDForSymbol(const MCSymbol *Symbol) const {
       return NumEntries;
     ++NumEntries;
   }
-
-  llvm_unreachable("symbol not found");
+  return std::nullopt;
 }
 
 bool BinaryFunction::forEachEntryPoint(EntryPointCallbackTy Callback) const {

--- a/bolt/lib/Core/BinaryFunction.cpp
+++ b/bolt/lib/Core/BinaryFunction.cpp
@@ -1908,7 +1908,7 @@ bool BinaryFunction::scanExternalRefs() {
 }
 
 bool BinaryFunction::validateInternalBranches() {
-  if (!isSimple() || TrapsOnEntry)
+  if (!hasInstructions() || !isSimple() || TrapsOnEntry)
     return true;
 
   for (const auto &KV : Labels) {

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -11,10 +11,16 @@
 # CHECK-NOT: UNREACHABLE
 
 // Now BOLT throws a warning and does not crash.
-# CHECK: BOLT-WARNING: ignoring entry point at address 0x{{[0-9a-f]+}} in constant island of function first_block
+# CHECK: BOLT-WARNING: corrupted control flow detected in function main{{.*}}:
+# CHECK-SAME: an external branch/call targets an invalid instruction in
+# CHECK-SAME: function first_block at address {{.*}}; ignoring both functions
+
+# CHECK: BOLT-WARNING: ignoring entry point at address 0x{{[0-9a-f]+}}
+# CHECK-SAME: in constant island of function first_block
 
 .text
 .global main
+.type main, %function
 main:
         add     x0, x1, x1
         bl      first_block
@@ -26,11 +32,8 @@ first_block:
         add     x0, x1, x1
         bl      second_block
         ret
-second_block:
-        add     x0, x1, x1
-        bl      third_block
-        ret
+
 $x:
-third_block:
+second_block:
         add     x0, x1, x1
         ret

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -26,6 +26,10 @@ main:
         bl      first_block
         ret
 
+.type foo, %function
+foo:
+   nop
+
 .global first_block
 $d:
 first_block:

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -13,10 +13,9 @@
 // Now BOLT throws a warning and does not crash.
 # CHECK: BOLT-WARNING: corrupted control flow detected in function main{{.*}}:
 # CHECK-SAME: an external branch/call targets an invalid instruction in
-# CHECK-SAME: function first_block at address {{.*}}; ignoring both functions
+# CHECK-SAME: function foo{{.*}} at address {{.*}}; ignoring both functions
 
-# CHECK: BOLT-WARNING: ignoring entry point at address 0x{{[0-9a-f]+}}
-# CHECK-SAME: in constant island of function first_block
+# CHECK: BOLT-WARNING: ignoring entry point at address 0x{{[0-9a-f]+}} in constant island of function foo{{.*}}
 
 .text
 .global main
@@ -29,8 +28,6 @@ main:
 .type foo, %function
 foo:
    nop
-
-.global first_block
 $d:
 first_block:
         add     x0, x1, x1

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -11,7 +11,7 @@
 # CHECK-NOT: UNREACHABLE
 
 // Now BOLT throws a warning and does not crash.
-# CHECK: BOLT-WARNING: symbol third_block/1  is in data region of function first_block(0x{{[0-9a-f]+}}).
+# CHECK: BOLT-WARNING: ignoring entry point at address 0x{{[0-9a-f]+}} in constant island of function first_block
 
 .text
 .global main

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -1,6 +1,5 @@
-// This test checks that when looking for a function
-// corresponding to a symbol, BOLT is not looking 
-// through a data area (constant island).
+// This test checks that when looking for a function corresponding to a
+// symbol, BOLT is not looking through a data area (constant island).
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
 # RUN: %clang %cflags %t.o -o %t.exe -Wl,-q

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -1,0 +1,49 @@
+// This test checks that when looking for a function
+// correspnding to a symbol, BOLT is not looking 
+// through a data area (constant island).
+
+# RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o
+# RUN: %clang %cflags %t.o -o %t.exe -Wl,-q
+# RUN: llvm-bolt %t.exe -o %t.bolt 2>&1 | FileCheck %s
+
+// Before adding a check for constant islands, BOLT would exit with an error
+// of the form: "symbol not found" and throw an LLVM UNREACHABLE error.
+# CHECK-NOT: symbol not found
+# CHECK-NOT: UNREACHABLE
+
+// Now BOLT throws a warning and does not crash.
+# CHECK: BOLT-WARNING: symbol [[SYM:.*]]  is in data region of function 0x{{.*}}.
+
+.text
+.global main
+main:
+        stp     x14, x15, [sp, -8]!
+        mov     x14, sp
+        adrp    x1, .test
+        add     x0, x1, :lo12:.test
+        bl      first_block
+        ret
+
+.global first_block
+$d:
+first_block:
+        stp     x14, x15, [sp, -8]!
+        mov     x14, sp
+        bl      second_block
+        ret
+second_block:
+        stp     x14, x15, [sp, -8]!
+        mov     x14, sp
+        bl      third_block
+        ret
+$x:
+third_block:
+        stp     x14, x15, [sp, -8]!
+        mov     x14, sp
+        adrp    x1, .data
+        add     x0, x1, :lo12:.test
+        ret
+
+.data
+.test:
+        .string "test"

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -12,38 +12,26 @@
 # CHECK-NOT: UNREACHABLE
 
 // Now BOLT throws a warning and does not crash.
-# CHECK: BOLT-WARNING: symbol [[SYM:.*]]  is in data region of function 0x{{.*}}.
+# CHECK: BOLT-WARNING: symbol third_block/1  is in data region of function first_block(0x{{[0-9a-f]+}}).
 
 .text
 .global main
 main:
-        stp     x14, x15, [sp, -8]!
-        mov     x14, sp
-        adrp    x1, .test
-        add     x0, x1, :lo12:.test
+        add     x0, x1, x1
         bl      first_block
         ret
 
 .global first_block
 $d:
 first_block:
-        stp     x14, x15, [sp, -8]!
-        mov     x14, sp
+        add     x0, x1, x1
         bl      second_block
         ret
 second_block:
-        stp     x14, x15, [sp, -8]!
-        mov     x14, sp
+        add     x0, x1, x1
         bl      third_block
         ret
 $x:
 third_block:
-        stp     x14, x15, [sp, -8]!
-        mov     x14, sp
-        adrp    x1, .data
-        add     x0, x1, :lo12:.test
+        add     x0, x1, x1
         ret
-
-.data
-.test:
-        .string "test"

--- a/bolt/test/AArch64/check-symbol-area.s
+++ b/bolt/test/AArch64/check-symbol-area.s
@@ -1,5 +1,5 @@
 // This test checks that when looking for a function
-// correspnding to a symbol, BOLT is not looking 
+// corresponding to a symbol, BOLT is not looking 
 // through a data area (constant island).
 
 # RUN: llvm-mc -filetype=obj -triple aarch64-unknown-unknown %s -o %t.o


### PR DESCRIPTION
There are cases in which `getEntryIDForSymbol` is called, where the given Symbol is in a constant island, and so BOLT can not find its function. This causes BOLT to reach `llvm_unreachable("symbol not found")` and crash. This patch adds a check that avoids this crash and gives a warning to the user.