### PR TITLE
[lld] Fix requires in cstring test

### DIFF
--- a/lld/test/MachO/cstring.ll
+++ b/lld/test/MachO/cstring.ll
@@ -1,4 +1,4 @@
-; REQUIRES: aarch64
+; REQUIRES: x86
 ; RUN: llvm-as %s -o %t.o
 
 ; RUN: %lld -dylib --separate-cstring-literal-sections %t.o -o - | llvm-objdump --macho --section-headers - | FileCheck %s


### PR DESCRIPTION
Fix a test added in https://github.com/llvm/llvm-project/pull/158720. I had accidentally required arm64 when the test was using x86_64.