### PR TITLE
[flang] Silence bogus error

### DIFF
--- a/flang/lib/Semantics/resolve-names.cpp
+++ b/flang/lib/Semantics/resolve-names.cpp
@@ -3376,7 +3376,8 @@ bool ScopeHandler::CheckPossibleBadForwardRef(const Symbol &symbol) {
       context().SetError(symbol);
       return true;
     }
-    if ((IsDummy(symbol) || FindCommonBlockContaining(symbol)) &&
+    if ((IsDummy(symbol) ||
+            (!symbol.has<UseDetails>() && FindCommonBlockContaining(symbol))) &&
         isImplicitNoneType() && symbol.test(Symbol::Flag::Implicit) &&
         !context().HasError(symbol)) {
       // Dummy or COMMON was implicitly typed despite IMPLICIT NONE(TYPE) in

--- a/flang/test/Semantics/bug159977.f90
+++ b/flang/test/Semantics/bug159977.f90
@@ -1,0 +1,11 @@
+! RUN: %flang_fc1 -fsyntax-only -pedantic %s  2>&1 | FileCheck %s --allow-empty
+! Ensure no bogus "no explicit type for ..." error on USE-associated
+! implicitly-typed COMMON block object in scope with IMPLICIT NONE.
+! CHECK-NOT: error:
+module m
+  common /block/ var
+end
+subroutine test
+  use m
+  implicit none
+end


### PR DESCRIPTION
One of the checks for implicitly-typed names under IMPLICIT NONE has a false positive case for USE-associated items in COMMON blocks.

Fixes https://github.com/llvm/llvm-project/issues/159977.