### PR TITLE
[CIR][NFC] Fix memory corruption in type converter

### DIFF
--- a/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
+++ b/clang/lib/CIR/Lowering/DirectToLLVM/LowerToLLVM.cpp
@@ -2381,9 +2381,6 @@ static void prepareTypeConverter(mlir::LLVMTypeConverter &converter,
       }
       break;
     }
-    converter.addConversion([&](cir::VoidType type) -> mlir::Type {
-      return mlir::LLVM::LLVMVoidType::get(type.getContext());
-    });
 
     // Record has a name: lower as an identified record.
     mlir::LLVM::LLVMStructType llvmStruct;


### PR DESCRIPTION
This fixes a problem where a rogue call to converter.addConversion inside of a type conversion lambda was causing memory corruption that (luckily!) triggered a test failure on some build platforms.

Near as I can tell, the unwanted addConversion call was the result of a bad rebase (by me). The code shouldn't have ever been there. Because the failure depends on the build environment, I can't find a reliable way to test this change.