### PR TITLE
[clang][fatlto] Only run sanitzer passes in prelink pipelines

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -700,7 +700,12 @@ static void addSanitizers(const Triple &TargetTriple,
                           const CodeGenOptions &CodeGenOpts,
                           const LangOptions &LangOpts, PassBuilder &PB) {
   auto SanitizersCallback = [&](ModulePassManager &MPM, OptimizationLevel Level,
-                                ThinOrFullLTOPhase) {
+                                ThinOrFullLTOPhase phase) {
+    // FatLTO pipelines already added these to the prelink pipeline.
+    if (CodeGenOpts.FatLTO &&
+        (CodeGenOpts.PrepareForThinLTO || CodeGenOpts.PrepareForLTO) &&
+        ThinOrFullLTOPhase::None != phase)
+      return;
     if (CodeGenOpts.hasSanitizeCoverage()) {
       auto SancovOpts = getSancovOptsFromCGOpts(CodeGenOpts);
       MPM.addPass(SanitizerCoveragePass(


### PR DESCRIPTION
FatLTO will run the sanitizer callbaks on both the pre and post link
pipelines, meaning they will run twice. These passes usually have
a check to prevent doing the wrong thing, but that shouldn't be
relied upon, since we know these will always run as part of the
prelink pipelines under FatLTO.

Fixes #159629