### PR TITLE
[mlir][arith] Fold min/max with absorption and redundancy

### DIFF
--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -1156,6 +1156,30 @@ OpFoldResult MaxSIOp::fold(FoldAdaptor adaptor) {
       return getLhs();
   }
 
+  // max(max(a, b), b) -> max(a, b)
+  // max(max(a, b), a) -> max(a, b)
+  if (auto max = getLhs().getDefiningOp<MaxSIOp>())
+    if (getRhs() == max.getRhs() || getRhs() == max.getLhs())
+      return getLhs();
+
+  // max(a, max(a, b)) -> max(a, b)
+  // max(b, max(a, b)) -> max(a, b)
+  if (auto max = getRhs().getDefiningOp<MaxSIOp>())
+    if (getLhs() == max.getRhs() || getLhs() == max.getLhs())
+      return getRhs();
+
+  // max(min(a, b), a) -> a
+  // max(min(b, a), a) -> a
+  if (auto min = getLhs().getDefiningOp<MinSIOp>())
+    if (getRhs() == min.getRhs() || getRhs() == min.getLhs())
+      return getRhs();
+
+  // max(a, min(a, b)) -> a
+  // max(a, min(b, a)) -> a
+  if (auto min = getRhs().getDefiningOp<MinSIOp>())
+    if (getLhs() == min.getRhs() || getLhs() == min.getLhs())
+      return getLhs();
+
   return constFoldBinaryOp<IntegerAttr>(adaptor.getOperands(),
                                         [](const APInt &a, const APInt &b) {
                                           return llvm::APIntOps::smax(a, b);
@@ -1180,6 +1204,30 @@ OpFoldResult MaxUIOp::fold(FoldAdaptor adaptor) {
     if (intValue.isMinValue())
       return getLhs();
   }
+
+  // max(max(a, b), b) -> max(a, b)
+  // max(max(a, b), a) -> max(a, b)
+  if (auto max = getLhs().getDefiningOp<MaxUIOp>())
+    if (getRhs() == max.getRhs() || getRhs() == max.getLhs())
+      return getLhs();
+
+  // max(a, max(a, b)) -> max(a, b)
+  // max(b, max(a, b)) -> max(a, b)
+  if (auto max = getRhs().getDefiningOp<MaxUIOp>())
+    if (getLhs() == max.getRhs() || getLhs() == max.getLhs())
+      return getRhs();
+
+  // max(min(a, b), a) -> a
+  // max(min(b, a), a) -> a
+  if (auto min = getLhs().getDefiningOp<MinUIOp>())
+    if (getRhs() == min.getRhs() || getRhs() == min.getLhs())
+      return getRhs();
+
+  // max(a, min(a, b)) -> a
+  // max(a, min(b, a)) -> a
+  if (auto min = getRhs().getDefiningOp<MinUIOp>())
+    if (getLhs() == min.getRhs() || getLhs() == min.getLhs())
+      return getLhs();
 
   return constFoldBinaryOp<IntegerAttr>(adaptor.getOperands(),
                                         [](const APInt &a, const APInt &b) {
@@ -1242,6 +1290,30 @@ OpFoldResult MinSIOp::fold(FoldAdaptor adaptor) {
       return getLhs();
   }
 
+  // min(min(a, b), b) -> min(a, b)
+  // min(min(a, b), a) -> min(a, b)
+  if (auto min = getLhs().getDefiningOp<MinSIOp>())
+    if (getRhs() == min.getRhs() || getRhs() == min.getLhs())
+      return getLhs();
+
+  // min(a, min(a, b)) -> min(a, b)
+  // min(b, min(a, b)) -> min(a, b)
+  if (auto min = getRhs().getDefiningOp<MinSIOp>())
+    if (getLhs() == min.getRhs() || getLhs() == min.getLhs())
+      return getRhs();
+
+  // min(max(a, b), a) -> a
+  // min(max(b, a), a) -> a
+  if (auto max = getLhs().getDefiningOp<MaxSIOp>())
+    if (getRhs() == max.getRhs() || getRhs() == max.getLhs())
+      return getRhs();
+
+  // min(a, max(a, b)) -> a
+  // min(a, max(b, a)) -> a
+  if (auto max = getRhs().getDefiningOp<MaxSIOp>())
+    if (getLhs() == max.getRhs() || getLhs() == max.getLhs())
+      return getLhs();
+
   return constFoldBinaryOp<IntegerAttr>(adaptor.getOperands(),
                                         [](const APInt &a, const APInt &b) {
                                           return llvm::APIntOps::smin(a, b);
@@ -1266,6 +1338,30 @@ OpFoldResult MinUIOp::fold(FoldAdaptor adaptor) {
     if (intValue.isMaxValue())
       return getLhs();
   }
+
+  // min(min(a, b), b) -> min(a, b)
+  // min(min(a, b), a) -> min(a, b)
+  if (auto min = getLhs().getDefiningOp<MinUIOp>())
+    if (getRhs() == min.getRhs() || getRhs() == min.getLhs())
+      return getLhs();
+
+  // min(a, min(a, b)) -> min(a, b)
+  // min(b, min(a, b)) -> min(a, b)
+  if (auto min = getRhs().getDefiningOp<MinUIOp>())
+    if (getLhs() == min.getRhs() || getLhs() == min.getLhs())
+      return getRhs();
+
+  // min(max(a, b), a) -> a
+  // min(max(b, a), a) -> a
+  if (auto max = getLhs().getDefiningOp<MaxUIOp>())
+    if (getRhs() == max.getRhs() || getRhs() == max.getLhs())
+      return getRhs();
+
+  // min(a, max(a, b)) -> a
+  // min(a, max(b, a)) -> a
+  if (auto max = getRhs().getDefiningOp<MaxUIOp>())
+    if (getLhs() == max.getRhs() || getLhs() == max.getLhs())
+      return getLhs();
 
   return constFoldBinaryOp<IntegerAttr>(adaptor.getOperands(),
                                         [](const APInt &a, const APInt &b) {

--- a/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
+++ b/mlir/lib/Dialect/Arith/IR/ArithOps.cpp
@@ -1116,6 +1116,18 @@ OpFoldResult arith::MaximumFOp::fold(FoldAdaptor adaptor) {
   if (matchPattern(adaptor.getRhs(), m_NegInfFloat()))
     return getLhs();
 
+  // max(max(a, b), b) -> max(a, b)
+  // max(max(a, b), a) -> max(a, b)
+  if (auto max = getLhs().getDefiningOp<MaximumFOp>())
+    if (getRhs() == max.getRhs() || getRhs() == max.getLhs())
+      return getLhs();
+
+  // max(a, max(a, b)) -> max(a, b)
+  // max(b, max(a, b)) -> max(a, b)
+  if (auto max = getRhs().getDefiningOp<MaximumFOp>())
+    if (getLhs() == max.getRhs() || getLhs() == max.getLhs())
+      return getRhs();
+
   return constFoldBinaryOp<FloatAttr>(
       adaptor.getOperands(),
       [](const APFloat &a, const APFloat &b) { return llvm::maximum(a, b); });
@@ -1133,6 +1145,18 @@ OpFoldResult arith::MaxNumFOp::fold(FoldAdaptor adaptor) {
   // maxnumf(x, NaN) -> x
   if (matchPattern(adaptor.getRhs(), m_NaNFloat()))
     return getLhs();
+
+  // max(max(a, b), b) -> max(a, b)
+  // max(max(a, b), a) -> max(a, b)
+  if (auto max = getLhs().getDefiningOp<MaxNumFOp>())
+    if (getRhs() == max.getRhs() || getRhs() == max.getLhs())
+      return getLhs();
+
+  // max(a, max(a, b)) -> max(a, b)
+  // max(b, max(a, b)) -> max(a, b)
+  if (auto max = getRhs().getDefiningOp<MaxNumFOp>())
+    if (getLhs() == max.getRhs() || getLhs() == max.getLhs())
+      return getRhs();
 
   return constFoldBinaryOp<FloatAttr>(adaptor.getOperands(), llvm::maxnum);
 }
@@ -1248,6 +1272,18 @@ OpFoldResult arith::MinimumFOp::fold(FoldAdaptor adaptor) {
   if (matchPattern(adaptor.getRhs(), m_PosInfFloat()))
     return getLhs();
 
+  // min(min(a, b), b) -> min(a, b)
+  // min(min(a, b), a) -> min(a, b)
+  if (auto min = getLhs().getDefiningOp<MinimumFOp>())
+    if (getRhs() == min.getRhs() || getRhs() == min.getLhs())
+      return getLhs();
+
+  // min(a, min(a, b)) -> min(a, b)
+  // min(b, min(a, b)) -> min(a, b)
+  if (auto min = getRhs().getDefiningOp<MinimumFOp>())
+    if (getLhs() == min.getRhs() || getLhs() == min.getLhs())
+      return getRhs();
+
   return constFoldBinaryOp<FloatAttr>(
       adaptor.getOperands(),
       [](const APFloat &a, const APFloat &b) { return llvm::minimum(a, b); });
@@ -1265,6 +1301,18 @@ OpFoldResult arith::MinNumFOp::fold(FoldAdaptor adaptor) {
   // minnumf(x, NaN) -> x
   if (matchPattern(adaptor.getRhs(), m_NaNFloat()))
     return getLhs();
+
+  // min(min(a, b), b) -> min(a, b)
+  // min(min(a, b), a) -> min(a, b)
+  if (auto min = getLhs().getDefiningOp<MinNumFOp>())
+    if (getRhs() == min.getRhs() || getRhs() == min.getLhs())
+      return getLhs();
+
+  // min(a, min(a, b)) -> min(a, b)
+  // min(b, min(a, b)) -> min(a, b)
+  if (auto min = getRhs().getDefiningOp<MinNumFOp>())
+    if (getLhs() == min.getRhs() || getLhs() == min.getLhs())
+      return getRhs();
 
   return constFoldBinaryOp<FloatAttr>(
       adaptor.getOperands(),

--- a/mlir/test/Dialect/Arith/canonicalize.mlir
+++ b/mlir/test/Dialect/Arith/canonicalize.mlir
@@ -1984,6 +1984,40 @@ func.func @test_maxsi2(%arg0 : i8) -> (i8, i8, i8, i8) {
   return %0, %1, %2, %3: i8, i8, i8, i8
 }
 
+// CHECK-LABEL:   foldMaxsiMaxsi1
+// CHECK:           %[[MAXSI:.*]] = arith.maxsi %arg1, %arg0 : i32
+// CHECK:           return %[[MAXSI]] : i32
+func.func public @foldMaxsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
+  %max1 = arith.maxsi %arg1, %arg0 : i32
+  %max2 = arith.maxsi %max1, %arg1 : i32
+  func.return %max2 : i32
+}
+
+// CHECK-LABEL:   foldMaxsiMaxsi2
+// CHECK:           %[[MAXSI:.*]] = arith.maxsi %arg1, %arg0 : i32
+// CHECK:           return %[[MAXSI]] : i32
+func.func public @foldMaxsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
+  %max1 = arith.maxsi %arg1, %arg0 : i32
+  %max2 = arith.maxsi %arg1, %max1 : i32
+  func.return %max2 : i32
+}
+
+// CHECK-LABEL:   foldMaxsiMinsi1
+// CHECK:           return %arg0 : i32
+func.func public @foldMaxsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minsi %arg1, %arg0 : i32
+  %max2 = arith.maxsi %min1, %arg0 : i32
+  func.return %max2 : i32
+}
+
+// CHECK-LABEL:   foldMaxsiMinsi2
+// CHECK:           return %arg0 : i32
+func.func public @foldMaxsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minsi %arg1, %arg0 : i32
+  %max2 = arith.maxsi %arg0, %min1 : i32
+  func.return %max2 : i32
+}
+
 // -----
 
 // CHECK-LABEL: test_maxui
@@ -2016,6 +2050,40 @@ func.func @test_maxui2(%arg0 : i8) -> (i8, i8, i8, i8) {
   %2 = arith.maxui %minIntCst, %arg0 : i8
   %3 = arith.maxui %c0, %arg0 : i8
   return %0, %1, %2, %3: i8, i8, i8, i8
+}
+
+// CHECK-LABEL:   foldMaxuiMaxui1
+// CHECK:           %[[MAXUI:.*]] = arith.maxui %arg1, %arg0 : i32
+// CHECK:           return %[[MAXUI]] : i32
+func.func public @foldMaxuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
+  %max1 = arith.maxui %arg1, %arg0 : i32
+  %max2 = arith.maxui %max1, %arg1 : i32
+  func.return %max2 : i32
+}
+
+// CHECK-LABEL:   foldMaxuiMaxui2
+// CHECK:           %[[MAXUI:.*]] = arith.maxui %arg1, %arg0 : i32
+// CHECK:           return %[[MAXUI]] : i32
+func.func public @foldMaxuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
+  %max1 = arith.maxui %arg1, %arg0 : i32
+  %max2 = arith.maxui %arg1, %max1 : i32
+  func.return %max2 : i32
+}
+
+// CHECK-LABEL:   foldMaxuiMinui1
+// CHECK:           return %arg0 : i32
+func.func public @foldMaxuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minui %arg1, %arg0 : i32
+  %max2 = arith.maxui %min1, %arg0 : i32
+  func.return %max2 : i32
+}
+
+// CHECK-LABEL:   foldMaxuiMinui2
+// CHECK:           return %arg0 : i32
+func.func public @foldMaxuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minui %arg1, %arg0 : i32
+  %max2 = arith.maxui %arg0, %min1 : i32
+  func.return %max2 : i32
 }
 
 // -----
@@ -2052,6 +2120,40 @@ func.func @test_minsi2(%arg0 : i8) -> (i8, i8, i8, i8) {
   return %0, %1, %2, %3: i8, i8, i8, i8
 }
 
+// CHECK-LABEL:   foldMinsiMinsi1
+// CHECK:           %[[MINSI:.*]] = arith.minsi %arg1, %arg0 : i32
+// CHECK:           return %[[MINSI]] : i32
+func.func public @foldMinsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minsi %arg1, %arg0 : i32
+  %min2 = arith.minsi %min1, %arg1 : i32
+  func.return %min2 : i32
+}
+
+// CHECK-LABEL:   foldMinsiMinsi2
+// CHECK:           %[[MINSI:.*]] = arith.minsi %arg1, %arg0 : i32
+// CHECK:           return %[[MINSI]] : i32
+func.func public @foldMinsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minsi %arg1, %arg0 : i32
+  %min2 = arith.minsi %arg1, %min1 : i32
+  func.return %min2 : i32
+}
+
+// CHECK-LABEL:   foldMinsiMaxsi1
+// CHECK:           return %arg0 : i32
+func.func public @foldMinsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.maxsi %arg1, %arg0 : i32
+  %min2 = arith.minsi %min1, %arg0 : i32
+  func.return %min2 : i32
+}
+
+// CHECK-LABEL:   foldMinsiMaxsi2
+// CHECK:           return %arg0 : i32
+func.func public @foldMinsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.maxsi %arg1, %arg0 : i32
+  %min2 = arith.minsi %arg0, %min1 : i32
+  func.return %min2 : i32
+}
+
 // -----
 
 // CHECK-LABEL: test_minui
@@ -2084,6 +2186,40 @@ func.func @test_minui2(%arg0 : i8) -> (i8, i8, i8, i8) {
   %2 = arith.minui %minIntCst, %arg0 : i8
   %3 = arith.minui %c0, %arg0 : i8
   return %0, %1, %2, %3: i8, i8, i8, i8
+}
+
+// CHECK-LABEL:   foldMinuiMinui1
+// CHECK:           %[[MINUI:.*]] = arith.minui %arg1, %arg0 : i32
+// CHECK:           return %[[MINUI]] : i32
+func.func public @foldMinuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minui %arg1, %arg0 : i32
+  %min2 = arith.minui %min1, %arg1 : i32
+  func.return %min2 : i32
+}
+
+// CHECK-LABEL:   foldMinuiMinui2
+// CHECK:           %[[MINUI:.*]] = arith.minui %arg1, %arg0 : i32
+// CHECK:           return %[[MINUI]] : i32
+func.func public @foldMinuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
+  %min1 = arith.minui %arg1, %arg0 : i32
+  %min2 = arith.minui %arg1, %min1 : i32
+  func.return %min2 : i32
+}
+
+// CHECK-LABEL:   foldMinuiMaxui1
+// CHECK:           return %arg0 : i32
+func.func public @foldMinuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
+  %max1 = arith.maxui %arg1, %arg0 : i32
+  %min2 = arith.minui %max1, %arg0 : i32
+  func.return %min2 : i32
+}
+
+// CHECK-LABEL:   foldMinuiMaxui2
+// CHECK:           return %arg0 : i32
+func.func public @foldMinuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
+  %max1 = arith.maxui %arg1, %arg0 : i32
+  %min2 = arith.minui %arg0, %max1 : i32
+  func.return %min2 : i32
 }
 
 // -----
@@ -3377,4 +3513,3 @@ func.func @unreachable() {
   %add = arith.addi %add, %c1_i64 : i64
   cf.br ^unreachable
 }
-

--- a/mlir/test/Dialect/Arith/canonicalize.mlir
+++ b/mlir/test/Dialect/Arith/canonicalize.mlir
@@ -2237,6 +2237,24 @@ func.func @test_minimumf(%arg0 : f32) -> (f32, f32, f32) {
   return %0, %1, %2 : f32, f32, f32
 }
 
+// CHECK-LABEL:   foldMinimumfMinimumf1
+// CHECK:           %[[MINF:.*]] = arith.minimumf %arg1, %arg0 : f32
+// CHECK:           return %[[MINF]] : f32
+func.func public @foldMinimumfMinimumf1(%arg0: f32, %arg1: f32) -> f32 {
+  %min1 = arith.minimumf %arg1, %arg0 : f32
+  %min2 = arith.minimumf %min1, %arg1 : f32
+  func.return %min2 : f32
+}
+
+// CHECK-LABEL:   foldMinimumfMinimumf2
+// CHECK:           %[[MINF:.*]] = arith.minimumf %arg1, %arg0 : f32
+// CHECK:           return %[[MINF]] : f32
+func.func public @foldMinimumfMinimumf2(%arg0: f32, %arg1: f32) -> f32 {
+  %min1 = arith.minimumf %arg1, %arg0 : f32
+  %min2 = arith.minimumf %arg1, %min1 : f32
+  func.return %min2 : f32
+}
+
 // -----
 
 // CHECK-LABEL: @test_maximumf(
@@ -2250,6 +2268,24 @@ func.func @test_maximumf(%arg0 : f32) -> (f32, f32, f32) {
   %1 = arith.maximumf %arg0, %arg0 : f32
   %2 = arith.maximumf %-inf, %arg0 : f32
   return %0, %1, %2 : f32, f32, f32
+}
+
+// CHECK-LABEL:   foldMaximumfMaximumf1
+// CHECK:           %[[MAXF:.*]] = arith.maximumf %arg1, %arg0 : f32
+// CHECK:           return %[[MAXF]] : f32
+func.func public @foldMaximumfMaximumf1(%arg0: f32, %arg1: f32) -> f32 {
+  %max1 = arith.maximumf %arg1, %arg0 : f32
+  %max2 = arith.maximumf %max1, %arg1 : f32
+  func.return %max2 : f32
+}
+
+// CHECK-LABEL:   foldMaximumfMaximumf2
+// CHECK:           %[[MAXF:.*]] = arith.maximumf %arg1, %arg0 : f32
+// CHECK:           return %[[MAXF]] : f32
+func.func public @foldMaximumfMaximumf2(%arg0: f32, %arg1: f32) -> f32 {
+  %max1 = arith.maximumf %arg1, %arg0 : f32
+  %max2 = arith.maximumf %arg1, %max1 : f32
+  func.return %max2 : f32
 }
 
 // -----
@@ -2271,6 +2307,25 @@ func.func @test_minnumf(%arg0 : f32) -> (f32, f32, f32, f32) {
   return %0, %1, %2, %3 : f32, f32, f32, f32
 }
 
+// CHECK-LABEL:   foldMinnumfMinnumf1
+// CHECK:           %[[MINF:.*]] = arith.minnumf %arg1, %arg0 : f32
+// CHECK:           return %[[MINF]] : f32
+func.func public @foldMinnumfMinnumf1(%arg0: f32, %arg1: f32) -> f32 {
+  %min1 = arith.minnumf %arg1, %arg0 : f32
+  %min2 = arith.minnumf %min1, %arg1 : f32
+  func.return %min2 : f32
+}
+
+// CHECK-LABEL:   foldMinnumfMinnumf2
+// CHECK:           %[[MINF:.*]] = arith.minnumf %arg1, %arg0 : f32
+// CHECK:           return %[[MINF]] : f32
+func.func public @foldMinnumfMinnumf2(%arg0: f32, %arg1: f32) -> f32 {
+  %min1 = arith.minnumf %arg1, %arg0 : f32
+  %min2 = arith.minnumf %arg1, %min1 : f32
+  func.return %min2 : f32
+}
+
+
 // -----
 
 // CHECK-LABEL: @test_maxnumf(
@@ -2288,6 +2343,24 @@ func.func @test_maxnumf(%arg0 : f32) -> (f32, f32, f32, f32) {
   %2 = arith.maxnumf %-inf, %arg0 : f32
   %3 = arith.maxnumf %nan, %arg0 : f32
   return %0, %1, %2, %3 : f32, f32, f32, f32
+}
+
+// CHECK-LABEL:   foldMaxnumfMaxnumf1
+// CHECK:           %[[MAXF:.*]] = arith.maxnumf %arg1, %arg0 : f32
+// CHECK:           return %[[MAXF]] : f32
+func.func public @foldMaxnumfMaxnumf1(%arg0: f32, %arg1: f32) -> f32 {
+  %max1 = arith.maxnumf %arg1, %arg0 : f32
+  %max2 = arith.maxnumf %max1, %arg1 : f32
+  func.return %max2 : f32
+}
+
+// CHECK-LABEL:   foldMaxnumfMaxnumf2
+// CHECK:           %[[MAXF:.*]] = arith.maxnumf %arg1, %arg0 : f32
+// CHECK:           return %[[MAXF]] : f32
+func.func public @foldMaxnumfMaxnumf2(%arg0: f32, %arg1: f32) -> f32 {
+  %max1 = arith.maxnumf %arg1, %arg0 : f32
+  %max2 = arith.maxnumf %arg1, %max1 : f32
+  func.return %max2 : f32
 }
 
 // -----

--- a/mlir/test/Dialect/Arith/canonicalize.mlir
+++ b/mlir/test/Dialect/Arith/canonicalize.mlir
@@ -2240,7 +2240,7 @@ func.func @test_minimumf(%arg0 : f32) -> (f32, f32, f32) {
 // CHECK-LABEL:   foldMinimumfMinimumf1
 // CHECK:           %[[MINF:.*]] = arith.minimumf %arg1, %arg0 : f32
 // CHECK:           return %[[MINF]] : f32
-func.func public @foldMinimumfMinimumf1(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMinimumfMinimumf1(%arg0: f32, %arg1: f32) -> f32 {
   %min1 = arith.minimumf %arg1, %arg0 : f32
   %min2 = arith.minimumf %min1, %arg1 : f32
   func.return %min2 : f32
@@ -2249,7 +2249,7 @@ func.func public @foldMinimumfMinimumf1(%arg0: f32, %arg1: f32) -> f32 {
 // CHECK-LABEL:   foldMinimumfMinimumf2
 // CHECK:           %[[MINF:.*]] = arith.minimumf %arg1, %arg0 : f32
 // CHECK:           return %[[MINF]] : f32
-func.func public @foldMinimumfMinimumf2(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMinimumfMinimumf2(%arg0: f32, %arg1: f32) -> f32 {
   %min1 = arith.minimumf %arg1, %arg0 : f32
   %min2 = arith.minimumf %arg1, %min1 : f32
   func.return %min2 : f32
@@ -2273,7 +2273,7 @@ func.func @test_maximumf(%arg0 : f32) -> (f32, f32, f32) {
 // CHECK-LABEL:   foldMaximumfMaximumf1
 // CHECK:           %[[MAXF:.*]] = arith.maximumf %arg1, %arg0 : f32
 // CHECK:           return %[[MAXF]] : f32
-func.func public @foldMaximumfMaximumf1(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMaximumfMaximumf1(%arg0: f32, %arg1: f32) -> f32 {
   %max1 = arith.maximumf %arg1, %arg0 : f32
   %max2 = arith.maximumf %max1, %arg1 : f32
   func.return %max2 : f32
@@ -2282,7 +2282,7 @@ func.func public @foldMaximumfMaximumf1(%arg0: f32, %arg1: f32) -> f32 {
 // CHECK-LABEL:   foldMaximumfMaximumf2
 // CHECK:           %[[MAXF:.*]] = arith.maximumf %arg1, %arg0 : f32
 // CHECK:           return %[[MAXF]] : f32
-func.func public @foldMaximumfMaximumf2(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMaximumfMaximumf2(%arg0: f32, %arg1: f32) -> f32 {
   %max1 = arith.maximumf %arg1, %arg0 : f32
   %max2 = arith.maximumf %arg1, %max1 : f32
   func.return %max2 : f32
@@ -2310,7 +2310,7 @@ func.func @test_minnumf(%arg0 : f32) -> (f32, f32, f32, f32) {
 // CHECK-LABEL:   foldMinnumfMinnumf1
 // CHECK:           %[[MINF:.*]] = arith.minnumf %arg1, %arg0 : f32
 // CHECK:           return %[[MINF]] : f32
-func.func public @foldMinnumfMinnumf1(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMinnumfMinnumf1(%arg0: f32, %arg1: f32) -> f32 {
   %min1 = arith.minnumf %arg1, %arg0 : f32
   %min2 = arith.minnumf %min1, %arg1 : f32
   func.return %min2 : f32
@@ -2319,7 +2319,7 @@ func.func public @foldMinnumfMinnumf1(%arg0: f32, %arg1: f32) -> f32 {
 // CHECK-LABEL:   foldMinnumfMinnumf2
 // CHECK:           %[[MINF:.*]] = arith.minnumf %arg1, %arg0 : f32
 // CHECK:           return %[[MINF]] : f32
-func.func public @foldMinnumfMinnumf2(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMinnumfMinnumf2(%arg0: f32, %arg1: f32) -> f32 {
   %min1 = arith.minnumf %arg1, %arg0 : f32
   %min2 = arith.minnumf %arg1, %min1 : f32
   func.return %min2 : f32
@@ -2348,7 +2348,7 @@ func.func @test_maxnumf(%arg0 : f32) -> (f32, f32, f32, f32) {
 // CHECK-LABEL:   foldMaxnumfMaxnumf1
 // CHECK:           %[[MAXF:.*]] = arith.maxnumf %arg1, %arg0 : f32
 // CHECK:           return %[[MAXF]] : f32
-func.func public @foldMaxnumfMaxnumf1(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMaxnumfMaxnumf1(%arg0: f32, %arg1: f32) -> f32 {
   %max1 = arith.maxnumf %arg1, %arg0 : f32
   %max2 = arith.maxnumf %max1, %arg1 : f32
   func.return %max2 : f32
@@ -2357,7 +2357,7 @@ func.func public @foldMaxnumfMaxnumf1(%arg0: f32, %arg1: f32) -> f32 {
 // CHECK-LABEL:   foldMaxnumfMaxnumf2
 // CHECK:           %[[MAXF:.*]] = arith.maxnumf %arg1, %arg0 : f32
 // CHECK:           return %[[MAXF]] : f32
-func.func public @foldMaxnumfMaxnumf2(%arg0: f32, %arg1: f32) -> f32 {
+func.func @foldMaxnumfMaxnumf2(%arg0: f32, %arg1: f32) -> f32 {
   %max1 = arith.maxnumf %arg1, %arg0 : f32
   %max2 = arith.maxnumf %arg1, %max1 : f32
   func.return %max2 : f32

--- a/mlir/test/Dialect/Arith/canonicalize.mlir
+++ b/mlir/test/Dialect/Arith/canonicalize.mlir
@@ -1987,7 +1987,7 @@ func.func @test_maxsi2(%arg0 : i8) -> (i8, i8, i8, i8) {
 // CHECK-LABEL:   foldMaxsiMaxsi1
 // CHECK:           %[[MAXSI:.*]] = arith.maxsi %arg1, %arg0 : i32
 // CHECK:           return %[[MAXSI]] : i32
-func.func public @foldMaxsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
   %max1 = arith.maxsi %arg1, %arg0 : i32
   %max2 = arith.maxsi %max1, %arg1 : i32
   func.return %max2 : i32
@@ -1996,7 +1996,7 @@ func.func public @foldMaxsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK-LABEL:   foldMaxsiMaxsi2
 // CHECK:           %[[MAXSI:.*]] = arith.maxsi %arg1, %arg0 : i32
 // CHECK:           return %[[MAXSI]] : i32
-func.func public @foldMaxsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
   %max1 = arith.maxsi %arg1, %arg0 : i32
   %max2 = arith.maxsi %arg1, %max1 : i32
   func.return %max2 : i32
@@ -2004,7 +2004,7 @@ func.func public @foldMaxsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMaxsiMinsi1
 // CHECK:           return %arg0 : i32
-func.func public @foldMaxsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minsi %arg1, %arg0 : i32
   %max2 = arith.maxsi %min1, %arg0 : i32
   func.return %max2 : i32
@@ -2012,7 +2012,7 @@ func.func public @foldMaxsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMaxsiMinsi2
 // CHECK:           return %arg0 : i32
-func.func public @foldMaxsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minsi %arg1, %arg0 : i32
   %max2 = arith.maxsi %arg0, %min1 : i32
   func.return %max2 : i32
@@ -2055,7 +2055,7 @@ func.func @test_maxui2(%arg0 : i8) -> (i8, i8, i8, i8) {
 // CHECK-LABEL:   foldMaxuiMaxui1
 // CHECK:           %[[MAXUI:.*]] = arith.maxui %arg1, %arg0 : i32
 // CHECK:           return %[[MAXUI]] : i32
-func.func public @foldMaxuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
   %max1 = arith.maxui %arg1, %arg0 : i32
   %max2 = arith.maxui %max1, %arg1 : i32
   func.return %max2 : i32
@@ -2064,7 +2064,7 @@ func.func public @foldMaxuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK-LABEL:   foldMaxuiMaxui2
 // CHECK:           %[[MAXUI:.*]] = arith.maxui %arg1, %arg0 : i32
 // CHECK:           return %[[MAXUI]] : i32
-func.func public @foldMaxuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
   %max1 = arith.maxui %arg1, %arg0 : i32
   %max2 = arith.maxui %arg1, %max1 : i32
   func.return %max2 : i32
@@ -2072,7 +2072,7 @@ func.func public @foldMaxuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMaxuiMinui1
 // CHECK:           return %arg0 : i32
-func.func public @foldMaxuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minui %arg1, %arg0 : i32
   %max2 = arith.maxui %min1, %arg0 : i32
   func.return %max2 : i32
@@ -2080,7 +2080,7 @@ func.func public @foldMaxuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMaxuiMinui2
 // CHECK:           return %arg0 : i32
-func.func public @foldMaxuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMaxuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minui %arg1, %arg0 : i32
   %max2 = arith.maxui %arg0, %min1 : i32
   func.return %max2 : i32
@@ -2123,7 +2123,7 @@ func.func @test_minsi2(%arg0 : i8) -> (i8, i8, i8, i8) {
 // CHECK-LABEL:   foldMinsiMinsi1
 // CHECK:           %[[MINSI:.*]] = arith.minsi %arg1, %arg0 : i32
 // CHECK:           return %[[MINSI]] : i32
-func.func public @foldMinsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minsi %arg1, %arg0 : i32
   %min2 = arith.minsi %min1, %arg1 : i32
   func.return %min2 : i32
@@ -2132,7 +2132,7 @@ func.func public @foldMinsiMinsi1(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK-LABEL:   foldMinsiMinsi2
 // CHECK:           %[[MINSI:.*]] = arith.minsi %arg1, %arg0 : i32
 // CHECK:           return %[[MINSI]] : i32
-func.func public @foldMinsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minsi %arg1, %arg0 : i32
   %min2 = arith.minsi %arg1, %min1 : i32
   func.return %min2 : i32
@@ -2140,7 +2140,7 @@ func.func public @foldMinsiMinsi2(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMinsiMaxsi1
 // CHECK:           return %arg0 : i32
-func.func public @foldMinsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.maxsi %arg1, %arg0 : i32
   %min2 = arith.minsi %min1, %arg0 : i32
   func.return %min2 : i32
@@ -2148,7 +2148,7 @@ func.func public @foldMinsiMaxsi1(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMinsiMaxsi2
 // CHECK:           return %arg0 : i32
-func.func public @foldMinsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinsiMaxsi2(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.maxsi %arg1, %arg0 : i32
   %min2 = arith.minsi %arg0, %min1 : i32
   func.return %min2 : i32
@@ -2191,7 +2191,7 @@ func.func @test_minui2(%arg0 : i8) -> (i8, i8, i8, i8) {
 // CHECK-LABEL:   foldMinuiMinui1
 // CHECK:           %[[MINUI:.*]] = arith.minui %arg1, %arg0 : i32
 // CHECK:           return %[[MINUI]] : i32
-func.func public @foldMinuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minui %arg1, %arg0 : i32
   %min2 = arith.minui %min1, %arg1 : i32
   func.return %min2 : i32
@@ -2200,7 +2200,7 @@ func.func public @foldMinuiMinui1(%arg0: i32, %arg1: i32) -> i32 {
 // CHECK-LABEL:   foldMinuiMinui2
 // CHECK:           %[[MINUI:.*]] = arith.minui %arg1, %arg0 : i32
 // CHECK:           return %[[MINUI]] : i32
-func.func public @foldMinuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
   %min1 = arith.minui %arg1, %arg0 : i32
   %min2 = arith.minui %arg1, %min1 : i32
   func.return %min2 : i32
@@ -2208,7 +2208,7 @@ func.func public @foldMinuiMinui2(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMinuiMaxui1
 // CHECK:           return %arg0 : i32
-func.func public @foldMinuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
   %max1 = arith.maxui %arg1, %arg0 : i32
   %min2 = arith.minui %max1, %arg0 : i32
   func.return %min2 : i32
@@ -2216,7 +2216,7 @@ func.func public @foldMinuiMaxui1(%arg0: i32, %arg1: i32) -> i32 {
 
 // CHECK-LABEL:   foldMinuiMaxui2
 // CHECK:           return %arg0 : i32
-func.func public @foldMinuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
+func.func @foldMinuiMaxui2(%arg0: i32, %arg1: i32) -> i32 {
   %max1 = arith.maxui %arg1, %arg0 : i32
   %min2 = arith.minui %arg0, %max1 : i32
   func.return %min2 : i32


### PR DESCRIPTION
Supported folding for arith.maxsi, arith.maxui, arith.minsi, arith.minui, arith.maxnumf, arith.minnumf, arith.maximumf, arith,minimumf.

1. Fold redundant consecutive min/max operations: 
max(max(a, b), b) -> max(a, b) 
max(max(a, b), a) -> max(a, b) 
max(a, max(a, b)) -> max(a, b) 
max(b, max(a, b)) -> max(a, b) 
(similar cases for min)

2. Fold using the absorption law: 
max(min(a, b), a) -> a 
max(min(b, a), a) -> a 
max(a, min(a, b)) -> a 
max(a, min(b, a)) -> a 
(similar cases for min; not applicable to floating-point)