### PR TITLE
[Tooling] Simplify a use of std::is_same (NFC)

### DIFF
--- a/clang/include/clang/Tooling/Refactoring/RefactoringOptionVisitor.h
+++ b/clang/include/clang/Tooling/Refactoring/RefactoringOptionVisitor.h
@@ -37,11 +37,11 @@ namespace internal {
 template <typename T> struct HasHandle {
 private:
   template <typename ClassT>
-  static auto check(ClassT *) -> typename std::is_same<
-      decltype(std::declval<RefactoringOptionVisitor>().visit(
-          std::declval<RefactoringOption>(),
-          *std::declval<std::optional<T> *>())),
-      void>::type;
+  static auto check(ClassT *)
+      -> std::is_same<decltype(std::declval<RefactoringOptionVisitor>().visit(
+                          std::declval<RefactoringOption>(),
+                          *std::declval<std::optional<T> *>())),
+                      void>;
 
   template <typename> static std::false_type check(...);
 


### PR DESCRIPTION
std::is_same<...>::type is functionally the same as std::is_same<...>.
This patch removes the redundant ::type at the end.
