### PR TITLE
[ADT] Use list-initialization for returning pairs

### DIFF
--- a/llvm/include/llvm/ADT/DenseMapInfo.h
+++ b/llvm/include/llvm/ADT/DenseMapInfo.h
@@ -139,13 +139,11 @@ struct DenseMapInfo<std::pair<T, U>> {
   using SecondInfo = DenseMapInfo<U>;
 
   static constexpr Pair getEmptyKey() {
-    return std::make_pair(FirstInfo::getEmptyKey(),
-                          SecondInfo::getEmptyKey());
+    return {FirstInfo::getEmptyKey(), SecondInfo::getEmptyKey()};
   }
 
   static constexpr Pair getTombstoneKey() {
-    return std::make_pair(FirstInfo::getTombstoneKey(),
-                          SecondInfo::getTombstoneKey());
+    return {FirstInfo::getTombstoneKey(), SecondInfo::getTombstoneKey()};
   }
 
   static unsigned getHashValue(const Pair& PairVal) {

--- a/llvm/include/llvm/ADT/STLExtras.h
+++ b/llvm/include/llvm/ADT/STLExtras.h
@@ -1371,7 +1371,7 @@ public:
   offset_base(const std::pair<BaseT, ptrdiff_t> &base, ptrdiff_t index) {
     // We encode the internal base as a pair of the derived base and a start
     // index into the derived base.
-    return std::make_pair(base.first, base.second + index);
+    return {base.first, base.second + index};
   }
   /// See `detail::indexed_accessor_range_base` for details.
   static ReferenceT

--- a/llvm/include/llvm/ADT/SparseMultiSet.h
+++ b/llvm/include/llvm/ADT/SparseMultiSet.h
@@ -400,7 +400,7 @@ public:
   RangePair equal_range(const KeyT &K) {
     iterator B = find(K);
     iterator E = iterator(this, SMSNode::INVALID, B.SparseIdx);
-    return std::make_pair(B, E);
+    return {B, E};
   }
 
   /// Insert a new element at the tail of the subset list. Returns an iterator

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -717,8 +717,8 @@ namespace llvm {
     split(StringRef Separator) const {
       size_t Idx = find(Separator);
       if (Idx == npos)
-        return std::make_pair(*this, StringRef());
-      return std::make_pair(slice(0, Idx), substr(Idx + Separator.size()));
+        return {*this, StringRef()};
+      return {slice(0, Idx), substr(Idx + Separator.size())};
     }
 
     /// Split into two substrings around the last occurrence of a separator
@@ -735,8 +735,8 @@ namespace llvm {
     rsplit(StringRef Separator) const {
       size_t Idx = rfind(Separator);
       if (Idx == npos)
-        return std::make_pair(*this, StringRef());
-      return std::make_pair(slice(0, Idx), substr(Idx + Separator.size()));
+        return {*this, StringRef()};
+      return {slice(0, Idx), substr(Idx + Separator.size())};
     }
 
     /// Split into substrings around the occurrences of a separator string.


### PR DESCRIPTION
In C++17 and later, "return {A, B};" guarantees copy elision for a
std::pair return type, ensuring the object is constructed directly in
the return slot.  This patch updates those instances under ADT/.
