### PR TITLE
[clang] Format "array is too large" diagnostics with separators

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -6794,7 +6794,9 @@ bool Sema::tryToFixVariablyModifiedVarType(TypeSourceInfo *&TInfo,
   if (SizeIsNegative)
     Diag(Loc, diag::err_typecheck_negative_array_size);
   else if (Oversized.getBoolValue())
-    Diag(Loc, diag::err_array_too_large) << toString(Oversized, 10);
+    Diag(Loc, diag::err_array_too_large) << toString(
+        Oversized, 10, Oversized.isSigned(), /*formatAsCLiteral=*/false,
+        /*UpperCase=*/false, /*InsertSeparators=*/true);
   else if (FailedFoldDiagID)
     Diag(Loc, FailedFoldDiagID);
   return false;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2395,7 +2395,10 @@ ExprResult Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
         if (ActiveSizeBits > ConstantArrayType::getMaxSizeBits(Context))
           return ExprError(
               Diag((*ArraySize)->getBeginLoc(), diag::err_array_too_large)
-              << toString(*Value, 10) << (*ArraySize)->getSourceRange());
+              << toString(*Value, 10, Value->isSigned(),
+                          /*formatAsCLiteral=*/false, /*UpperCase=*/false,
+                          /*InsertSeparators=*/true)
+              << (*ArraySize)->getSourceRange());
       }
 
       KnownArraySize = Value->getZExtValue();

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2270,7 +2270,10 @@ QualType Sema::BuildArrayType(QualType T, ArraySizeModifier ASM,
               : ConstVal.getActiveBits();
       if (ActiveSizeBits > ConstantArrayType::getMaxSizeBits(Context)) {
         Diag(ArraySize->getBeginLoc(), diag::err_array_too_large)
-            << toString(ConstVal, 10) << ArraySize->getSourceRange();
+            << toString(ConstVal, 10, ConstVal.isSigned(),
+                        /*formatAsCLiteral=*/false, /*UpperCase=*/false,
+                        /*InsertSeparators=*/true)
+            << ArraySize->getSourceRange();
         return QualType();
       }
 

--- a/clang/test/C/C23/n2838.c
+++ b/clang/test/C/C23/n2838.c
@@ -4,9 +4,9 @@
  * Types and sizes
  */
 
-char buffer4[0xFFFF'FFFF'FFFF'FFFF'1wb]; /* expected-error {{array is too large (295147905179352825841 elements)}} */
-char buffer3[0xFFFF'FFFF'FFFF'FFFFwb];   /* expected-error {{array is too large (18446744073709551615 elements)}} */
-char buffer2[0x7FFF'FFFF'FFFF'FFFFwb];   /* expected-error {{array is too large (9223372036854775807 elements)}} */
+char buffer4[0xFFFF'FFFF'FFFF'FFFF'1wb]; /* expected-error {{array is too large (295'147'905'179'352'825'841 elements)}} */
+char buffer3[0xFFFF'FFFF'FFFF'FFFFwb];   /* expected-error {{array is too large (18'446'744'073'709'551'615 elements)}} */
+char buffer2[0x7FFF'FFFF'FFFF'FFFFwb];   /* expected-error {{array is too large (9'223'372'036'854'775'807 elements)}} */
 char buffer1[0x1FFF'FFFF'FFFF'FFFFwb];   /* array is juuuuuust right */
 
 /* The largest object we can create is still smaller than SIZE_MAX. */

--- a/clang/test/C/drs/dr2xx.c
+++ b/clang/test/C/drs/dr2xx.c
@@ -370,7 +370,7 @@ void dr266(void) {
    */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wlong-long"
-  (void)sizeof(int[__SIZE_MAX__ / 2][__SIZE_MAX__ / 2]); /* expected-error-re 2 {{array is too large ({{[0-9]+}} elements)}} */
+  (void)sizeof(int[__SIZE_MAX__ / 2][__SIZE_MAX__ / 2]); /* expected-error-re 2 {{array is too large ({{[0-9']+}} elements)}} */
 #pragma clang diagnostic pop
 }
 


### PR DESCRIPTION
We only display this diagnostic with large numbers, so add the separators. 

Not sure if `295'147'905'179'352'825'841` is much better than `295147905179352825841` but I think it would be nice to have separators in more diagnostics.