### PR TITLE
[clang-reorder-fields] Check for flexible array member

### DIFF
--- a/clang-tools-extra/test/clang-reorder-fields/FlexibleArrayMember.c
+++ b/clang-tools-extra/test/clang-reorder-fields/FlexibleArrayMember.c
@@ -1,0 +1,10 @@
+// RUN: clang-reorder-fields -record-name Foo -fields-order z,y,x %s -- 2>&1 | FileCheck --check-prefix=CHECK-BAD %s
+// RUN: clang-reorder-fields -record-name Foo -fields-order y,x,z %s -- | FileCheck --check-prefix=CHECK-GOOD %s
+
+// CHECK-BAD: {{^Flexible array member must remain the last field in the struct}}
+
+struct Foo {
+  int x;   // CHECK-GOOD:      {{^  int y;}}
+  int y;   // CHECK-GOOD-NEXT: {{^  int x;}}
+  int z[]; // CHECK-GOOD-NEXT: {{^  int z\[\];}}
+};


### PR DESCRIPTION
A flexible array member must remain the last field in the struct.