### PR TITLE
[BOLT] Improve unmarked-data.test

### DIFF
--- a/bolt/test/AArch64/unmarked-data.test
+++ b/bolt/test/AArch64/unmarked-data.test
@@ -2,7 +2,7 @@
 
 // RUN: yaml2obj %S/Inputs/unmarked-data.yaml -o %t.exe
 // RUN: llvm-bolt %t.exe -o %t.bolt --lite=0 --use-old-text=0 2>&1 | FileCheck %s
-// CHECK-NOT: BOLT-WARNING
+// CHECK-NOT: BOLT-WARNING: unable to disassemble instruction at offset
 // RUN: llvm-objdump -j .text -d --disassemble-symbols=first,second %t.bolt | FileCheck %s -check-prefix=CHECK-SYMBOL
 // CHECK-SYMBOL: <first>:
 // CHECK-SYMBOL: <second>:


### PR DESCRIPTION
The test checked for no BOLT-WARNINGs without specifying the expected warning. This caused the test to fail on warnings unrelated to the test.

Added the BOLT-WARNING that was present before 8579db96e8c31.