### PR TITLE
[clang-format] Support fine-grained alignment of variable declarations

### DIFF
--- a/clang/docs/ClangFormatStyleOptions.rst
+++ b/clang/docs/ClangFormatStyleOptions.rst
@@ -396,6 +396,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -427,6 +442,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to
@@ -554,6 +584,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -585,6 +630,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to
@@ -712,6 +772,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -743,6 +818,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to
@@ -871,6 +961,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -902,6 +1007,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to
@@ -1149,6 +1269,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -1180,6 +1315,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to
@@ -1305,6 +1455,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -1336,6 +1501,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to
@@ -1461,6 +1641,21 @@ the configuration (without a prefix: ``Auto``).
       a &= 2;
       bbb = 2;
 
+  * ``bool AlignFreeVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int v1;
+      float        v2;
+      size_t       v3;
+
+      false:
+      unsigned int v1;
+      float v2;
+      size_t v3;
+
   * ``bool AlignFunctionDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     are aligned.
 
@@ -1492,6 +1687,21 @@ the configuration (without a prefix: ``Auto``).
       int     &r;
       int     *p;
       int (*f)();
+
+  * ``bool AlignMemberVariableDeclarations`` Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    variable declarations are aligned.
+
+    .. code-block:: c++
+
+      true:
+      unsigned int member1;
+      float        member2;
+      size_t       member3;
+
+      false:
+      unsigned int member1;
+      float member2;
+      size_t member3;
 
   * ``bool PadOperators`` Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     operators are left-padded to the same length as long ones in order to

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -532,6 +532,8 @@ clang-format
   literals.
 - Add ``Leave`` suboption to ``IndentPPDirectives``.
 - Add ``AllowBreakBeforeQtProperty`` option.
+- Add ``AlignFreeVariableDeclarations`` and ``AlignMemberVariableDeclarations``
+  to ``AlignConsecutiveDeclarations``.
 
 libclang
 --------

--- a/clang/include/clang/Format/Format.h
+++ b/clang/include/clang/Format/Format.h
@@ -226,6 +226,20 @@ struct FormatStyle {
     ///   bbb = 2;
     /// \endcode
     bool AlignCompound;
+    /// Only for ``AlignConsecutiveDeclarations``. Whether non-member variable
+    /// declarations are aligned.
+    /// \code
+    ///   true:
+    ///   unsigned int v1;
+    ///   float        v2;
+    ///   size_t       v3;
+    ///
+    ///   false:
+    ///   unsigned int v1;
+    ///   float v2;
+    ///   size_t v3;
+    /// \endcode
+    bool AlignFreeVariableDeclarations;
     /// Only for ``AlignConsecutiveDeclarations``. Whether function declarations
     /// are aligned.
     /// \code
@@ -256,6 +270,20 @@ struct FormatStyle {
     ///   int (*f)();
     /// \endcode
     bool AlignFunctionPointers;
+    /// Only for ``AlignConsecutiveDeclarations``. Whether class/struct member
+    /// variable declarations are aligned.
+    /// \code
+    ///   true:
+    ///   unsigned int member1;
+    ///   float        member2;
+    ///   size_t       member3;
+    ///
+    ///   false:
+    ///   unsigned int member1;
+    ///   float member2;
+    ///   size_t member3;
+    /// \endcode
+    bool AlignMemberVariableDeclarations;
     /// Only for ``AlignConsecutiveAssignments``.  Whether short assignment
     /// operators are left-padded to the same length as long ones in order to
     /// put all assignment operators to the right of the left hand side.
@@ -279,8 +307,11 @@ struct FormatStyle {
       return Enabled == R.Enabled && AcrossEmptyLines == R.AcrossEmptyLines &&
              AcrossComments == R.AcrossComments &&
              AlignCompound == R.AlignCompound &&
+             AlignFreeVariableDeclarations == R.AlignFreeVariableDeclarations &&
              AlignFunctionDeclarations == R.AlignFunctionDeclarations &&
              AlignFunctionPointers == R.AlignFunctionPointers &&
+             AlignMemberVariableDeclarations ==
+                 R.AlignMemberVariableDeclarations &&
              PadOperators == R.PadOperators;
     }
     bool operator!=(const AlignConsecutiveStyle &R) const {

--- a/clang/lib/Format/Format.cpp
+++ b/clang/lib/Format/Format.cpp
@@ -47,38 +47,53 @@ struct ScalarEnumerationTraits<FormatStyle::BreakBeforeNoexceptSpecifierStyle> {
 template <> struct MappingTraits<FormatStyle::AlignConsecutiveStyle> {
   static void enumInput(IO &IO, FormatStyle::AlignConsecutiveStyle &Value) {
     IO.enumCase(Value, "None", FormatStyle::AlignConsecutiveStyle({}));
-    IO.enumCase(Value, "Consecutive",
-                FormatStyle::AlignConsecutiveStyle(
-                    {/*Enabled=*/true, /*AcrossEmptyLines=*/false,
-                     /*AcrossComments=*/false, /*AlignCompound=*/false,
-                     /*AlignFunctionDeclarations=*/true,
-                     /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));
-    IO.enumCase(Value, "AcrossEmptyLines",
-                FormatStyle::AlignConsecutiveStyle(
-                    {/*Enabled=*/true, /*AcrossEmptyLines=*/true,
-                     /*AcrossComments=*/false, /*AlignCompound=*/false,
-                     /*AlignFunctionDeclarations=*/true,
-                     /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));
-    IO.enumCase(Value, "AcrossComments",
-                FormatStyle::AlignConsecutiveStyle(
-                    {/*Enabled=*/true, /*AcrossEmptyLines=*/false,
-                     /*AcrossComments=*/true, /*AlignCompound=*/false,
-                     /*AlignFunctionDeclarations=*/true,
-                     /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));
-    IO.enumCase(Value, "AcrossEmptyLinesAndComments",
-                FormatStyle::AlignConsecutiveStyle(
-                    {/*Enabled=*/true, /*AcrossEmptyLines=*/true,
-                     /*AcrossComments=*/true, /*AlignCompound=*/false,
-                     /*AlignFunctionDeclarations=*/true,
-                     /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));
+    IO.enumCase(
+        Value, "Consecutive",
+        FormatStyle::AlignConsecutiveStyle(
+            {/*Enabled=*/true, /*AcrossEmptyLines=*/false,
+             /*AcrossComments=*/false, /*AlignCompound=*/false,
+             /*AlignFreeVariableDeclarations=*/true,
+             /*AlignFunctionDeclarations=*/true,
+             /*AlignFunctionPointers=*/false,
+             /*AlignMemberVariableDeclarations=*/true, /*PadOperators=*/true}));
+    IO.enumCase(
+        Value, "AcrossEmptyLines",
+        FormatStyle::AlignConsecutiveStyle(
+            {/*Enabled=*/true, /*AcrossEmptyLines=*/true,
+             /*AcrossComments=*/false, /*AlignCompound=*/false,
+             /*AlignFreeVariableDeclarations=*/true,
+             /*AlignFunctionDeclarations=*/true,
+             /*AlignFunctionPointers=*/false,
+             /*AlignMemberVariableDeclarations=*/true, /*PadOperators=*/true}));
+    IO.enumCase(
+        Value, "AcrossComments",
+        FormatStyle::AlignConsecutiveStyle(
+            {/*Enabled=*/true, /*AcrossEmptyLines=*/false,
+             /*AcrossComments=*/true, /*AlignCompound=*/false,
+             /*AlignFreeVariableDeclarations=*/true,
+             /*AlignFunctionDeclarations=*/true,
+             /*AlignFunctionPointers=*/false,
+             /*AlignMemberVariableDeclarations=*/true, /*PadOperators=*/true}));
+    IO.enumCase(
+        Value, "AcrossEmptyLinesAndComments",
+        FormatStyle::AlignConsecutiveStyle(
+            {/*Enabled=*/true, /*AcrossEmptyLines=*/true,
+             /*AcrossComments=*/true, /*AlignCompound=*/false,
+             /*AlignFreeVariableDeclarations=*/true,
+             /*AlignFunctionDeclarations=*/true,
+             /*AlignFunctionPointers=*/false,
+             /*AlignMemberVariableDeclarations=*/true, /*PadOperators=*/true}));
 
     // For backward compatibility.
-    IO.enumCase(Value, "true",
-                FormatStyle::AlignConsecutiveStyle(
-                    {/*Enabled=*/true, /*AcrossEmptyLines=*/false,
-                     /*AcrossComments=*/false, /*AlignCompound=*/false,
-                     /*AlignFunctionDeclarations=*/true,
-                     /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));
+    IO.enumCase(
+        Value, "true",
+        FormatStyle::AlignConsecutiveStyle(
+            {/*Enabled=*/true, /*AcrossEmptyLines=*/false,
+             /*AcrossComments=*/false, /*AlignCompound=*/false,
+             /*AlignFreeVariableDeclarations=*/true,
+             /*AlignFunctionDeclarations=*/true,
+             /*AlignFunctionPointers=*/false,
+             /*AlignMemberVariableDeclarations=*/true, /*PadOperators=*/true}));
     IO.enumCase(Value, "false", FormatStyle::AlignConsecutiveStyle({}));
   }
 
@@ -87,9 +102,13 @@ template <> struct MappingTraits<FormatStyle::AlignConsecutiveStyle> {
     IO.mapOptional("AcrossEmptyLines", Value.AcrossEmptyLines);
     IO.mapOptional("AcrossComments", Value.AcrossComments);
     IO.mapOptional("AlignCompound", Value.AlignCompound);
+    IO.mapOptional("AlignFreeVariableDeclarations",
+                   Value.AlignFreeVariableDeclarations);
     IO.mapOptional("AlignFunctionDeclarations",
                    Value.AlignFunctionDeclarations);
     IO.mapOptional("AlignFunctionPointers", Value.AlignFunctionPointers);
+    IO.mapOptional("AlignMemberVariableDeclarations",
+                   Value.AlignMemberVariableDeclarations);
     IO.mapOptional("PadOperators", Value.PadOperators);
   }
 };
@@ -1555,7 +1574,9 @@ FormatStyle getLLVMStyle(FormatStyle::LanguageKind Language) {
   LLVMStyle.AlignConsecutiveAssignments.PadOperators = true;
   LLVMStyle.AlignConsecutiveBitFields = {};
   LLVMStyle.AlignConsecutiveDeclarations = {};
+  LLVMStyle.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations = true;
   LLVMStyle.AlignConsecutiveDeclarations.AlignFunctionDeclarations = true;
+  LLVMStyle.AlignConsecutiveDeclarations.AlignMemberVariableDeclarations = true;
   LLVMStyle.AlignConsecutiveMacros = {};
   LLVMStyle.AlignConsecutiveShortCaseStatements = {};
   LLVMStyle.AlignConsecutiveTableGenBreakingDAGArgColons = {};

--- a/clang/lib/Format/FormatToken.h
+++ b/clang/lib/Format/FormatToken.h
@@ -313,7 +313,7 @@ struct FormatToken {
         EndsBinaryExpression(false), PartOfMultiVariableDeclStmt(false),
         ContinuesLineCommentSection(false), Finalized(false),
         ClosesRequiresClause(false), EndsCppAttributeGroup(false),
-        BlockKind(BK_Unknown), Decision(FD_Unformatted),
+        IsInClassScope(false), BlockKind(BK_Unknown), Decision(FD_Unformatted),
         PackingKind(PPK_Inconclusive), TypeIsFinalized(false),
         Type(TT_Unknown) {}
 
@@ -390,6 +390,10 @@ struct FormatToken {
 
   /// \c true if this token ends a group of C++ attributes.
   unsigned EndsCppAttributeGroup : 1;
+
+  /// \c true if this token is within a class-like scope and not within a
+  /// function inside that scope.
+  unsigned IsInClassScope : 1;
 
 private:
   /// Contains the kind of block if this token is a brace.

--- a/clang/lib/Format/TokenAnnotator.cpp
+++ b/clang/lib/Format/TokenAnnotator.cpp
@@ -1313,6 +1313,8 @@ private:
     }
     FormatToken *Tok = CurrentToken;
     next();
+    if (!Scopes.empty() && Scopes.back() == ST_Class)
+      Tok->IsInClassScope = true;
     // In Verilog primitives' state tables, `:`, `?`, and `-` aren't normal
     // operators.
     if (Tok->is(TT_VerilogTableItem))

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -1017,11 +1017,13 @@ void WhitespaceManager::alignConsecutiveDeclarations() {
         if (C.Tok->is(TT_FunctionDeclarationName))
           return Style.AlignConsecutiveDeclarations.AlignFunctionDeclarations;
         if (C.Tok->IsInClassScope && !Style.AlignConsecutiveDeclarations
-                                          .AlignMemberVariableDeclarations)
+                                          .AlignMemberVariableDeclarations) {
           return false;
+        }
         if (!C.Tok->IsInClassScope &&
-            !Style.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations)
+            !Style.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations) {
           return false;
+        }
         if (C.Tok->isNot(TT_StartOfName))
           return false;
         if (C.Tok->Previous &&

--- a/clang/lib/Format/WhitespaceManager.cpp
+++ b/clang/lib/Format/WhitespaceManager.cpp
@@ -1016,6 +1016,12 @@ void WhitespaceManager::alignConsecutiveDeclarations() {
           return Style.AlignConsecutiveDeclarations.AlignFunctionPointers;
         if (C.Tok->is(TT_FunctionDeclarationName))
           return Style.AlignConsecutiveDeclarations.AlignFunctionDeclarations;
+        if (C.Tok->IsInClassScope && !Style.AlignConsecutiveDeclarations
+                                          .AlignMemberVariableDeclarations)
+          return false;
+        if (!C.Tok->IsInClassScope &&
+            !Style.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations)
+          return false;
         if (C.Tok->isNot(TT_StartOfName))
           return false;
         if (C.Tok->Previous &&

--- a/clang/unittests/Format/ConfigParseTest.cpp
+++ b/clang/unittests/Format/ConfigParseTest.cpp
@@ -327,51 +327,63 @@ TEST(ConfigParseTest, ParsesConfiguration) {
     Style.FIELD.Enabled = true;                                                \
     CHECK_PARSE(#FIELD ": None", FIELD,                                        \
                 FormatStyle::AlignConsecutiveStyle({}));                       \
-    CHECK_PARSE(                                                               \
-        #FIELD ": Consecutive", FIELD,                                         \
-        FormatStyle::AlignConsecutiveStyle(                                    \
-            {/*Enabled=*/true, /*AcrossEmptyLines=*/false,                     \
-             /*AcrossComments=*/false, /*AlignCompound=*/false,                \
-             /*AlignFunctionDeclarations=*/true,                               \
-             /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));        \
-    CHECK_PARSE(                                                               \
-        #FIELD ": AcrossEmptyLines", FIELD,                                    \
-        FormatStyle::AlignConsecutiveStyle(                                    \
-            {/*Enabled=*/true, /*AcrossEmptyLines=*/true,                      \
-             /*AcrossComments=*/false, /*AlignCompound=*/false,                \
-             /*AlignFunctionDeclarations=*/true,                               \
-             /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));        \
-    CHECK_PARSE(                                                               \
-        #FIELD ": AcrossComments", FIELD,                                      \
-        FormatStyle::AlignConsecutiveStyle(                                    \
-            {/*Enabled=*/true, /*AcrossEmptyLines=*/false,                     \
-             /*AcrossComments=*/true, /*AlignCompound=*/false,                 \
-             /*AlignFunctionDeclarations=*/true,                               \
-             /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));        \
-    CHECK_PARSE(                                                               \
-        #FIELD ": AcrossEmptyLinesAndComments", FIELD,                         \
-        FormatStyle::AlignConsecutiveStyle(                                    \
-            {/*Enabled=*/true, /*AcrossEmptyLines=*/true,                      \
-             /*AcrossComments=*/true, /*AlignCompound=*/false,                 \
-             /*AlignFunctionDeclarations=*/true,                               \
-             /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));        \
+    CHECK_PARSE(#FIELD ": Consecutive", FIELD,                                 \
+                FormatStyle::AlignConsecutiveStyle(                            \
+                    {/*Enabled=*/true, /*AcrossEmptyLines=*/false,             \
+                     /*AcrossComments=*/false, /*AlignCompound=*/false,        \
+                     /*AlignFreeVariableDeclarations=*/true,                   \
+                     /*AlignFunctionDeclarations=*/true,                       \
+                     /*AlignFunctionPointers=*/false,                          \
+                     /*AlgnMemberVariableDeclarations=*/true,                  \
+                     /*PadOperators=*/true}));                                 \
+    CHECK_PARSE(#FIELD ": AcrossEmptyLines", FIELD,                            \
+                FormatStyle::AlignConsecutiveStyle(                            \
+                    {/*Enabled=*/true, /*AcrossEmptyLines=*/true,              \
+                     /*AcrossComments=*/false, /*AlignCompound=*/false,        \
+                     /*AlignFreeVariableDeclarations=*/true,                   \
+                     /*AlignFunctionDeclarations=*/true,                       \
+                     /*AlignFunctionPointers=*/false,                          \
+                     /*AlgnMemberVariableDeclarations=*/true,                  \
+                     /*PadOperators=*/true}));                                 \
+    CHECK_PARSE(#FIELD ": AcrossComments", FIELD,                              \
+                FormatStyle::AlignConsecutiveStyle(                            \
+                    {/*Enabled=*/true, /*AcrossEmptyLines=*/false,             \
+                     /*AcrossComments=*/true, /*AlignCompound=*/false,         \
+                     /*AlignFreeVariableDeclarations=*/true,                   \
+                     /*AlignFunctionDeclarations=*/true,                       \
+                     /*AlignFunctionPointers=*/false,                          \
+                     /*AlgnMemberVariableDeclarations=*/true,                  \
+                     /*PadOperators=*/true}));                                 \
+    CHECK_PARSE(#FIELD ": AcrossEmptyLinesAndComments", FIELD,                 \
+                FormatStyle::AlignConsecutiveStyle(                            \
+                    {/*Enabled=*/true, /*AcrossEmptyLines=*/true,              \
+                     /*AcrossComments=*/true, /*AlignCompound=*/false,         \
+                     /*AlignFreeVariableDeclarations=*/true,                   \
+                     /*AlignFunctionDeclarations=*/true,                       \
+                     /*AlignFunctionPointers=*/false,                          \
+                     /*AlgnMemberVariableDeclarations=*/true,                  \
+                     /*PadOperators=*/true}));                                 \
     /* For backwards compability, false / true should still parse */           \
     CHECK_PARSE(#FIELD ": false", FIELD,                                       \
                 FormatStyle::AlignConsecutiveStyle({}));                       \
-    CHECK_PARSE(                                                               \
-        #FIELD ": true", FIELD,                                                \
-        FormatStyle::AlignConsecutiveStyle(                                    \
-            {/*Enabled=*/true, /*AcrossEmptyLines=*/false,                     \
-             /*AcrossComments=*/false, /*AlignCompound=*/false,                \
-             /*AlignFunctionDeclarations=*/true,                               \
-             /*AlignFunctionPointers=*/false, /*PadOperators=*/true}));        \
+    CHECK_PARSE(#FIELD ": true", FIELD,                                        \
+                FormatStyle::AlignConsecutiveStyle(                            \
+                    {/*Enabled=*/true, /*AcrossEmptyLines=*/false,             \
+                     /*AcrossComments=*/false, /*AlignCompound=*/false,        \
+                     /*AlignFreeVariableDeclarations=*/true,                   \
+                     /*AlignFunctionDeclarations=*/true,                       \
+                     /*AlignFunctionPointers=*/false,                          \
+                     /*AlgnMemberVariableDeclarations=*/true,                  \
+                     /*PadOperators=*/true}));                                 \
                                                                                \
     CHECK_PARSE_NESTED_BOOL(FIELD, Enabled);                                   \
     CHECK_PARSE_NESTED_BOOL(FIELD, AcrossEmptyLines);                          \
     CHECK_PARSE_NESTED_BOOL(FIELD, AcrossComments);                            \
     CHECK_PARSE_NESTED_BOOL(FIELD, AlignCompound);                             \
+    CHECK_PARSE_NESTED_BOOL(FIELD, AlignFreeVariableDeclarations);             \
     CHECK_PARSE_NESTED_BOOL(FIELD, AlignFunctionDeclarations);                 \
     CHECK_PARSE_NESTED_BOOL(FIELD, AlignFunctionPointers);                     \
+    CHECK_PARSE_NESTED_BOOL(FIELD, AlignMemberVariableDeclarations);           \
     CHECK_PARSE_NESTED_BOOL(FIELD, PadOperators);                              \
   } while (false)
 

--- a/clang/unittests/Format/FormatTest.cpp
+++ b/clang/unittests/Format/FormatTest.cpp
@@ -20323,6 +20323,61 @@ TEST_F(FormatTest, AlignConsecutiveDeclarations) {
                "void f2(void);\n"
                "size_t f3(void);",
                Alignment);
+
+  Alignment.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations = false;
+  verifyFormat("int func() { //\n"
+               "  int local1;\n"
+               "  unsigned local2;\n"
+               "}\n"
+               "class Z {\n"
+               "  int      member1;\n"
+               "  unsigned member2;\n"
+               "  int funcInClass() {\n"
+               "    int localInClass1;\n"
+               "    unsigned localInClass2;\n"
+               "  }\n"
+               "};\n"
+               "int global1;\n"
+               "unsigned global2;",
+               Alignment);
+
+  Alignment.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations = true;
+  Alignment.AlignConsecutiveDeclarations.AlignMemberVariableDeclarations =
+      false;
+  verifyFormat("int func() { //\n"
+               "  int      local1;\n"
+               "  unsigned local2;\n"
+               "}\n"
+               "class Z {\n"
+               "  int member1;\n"
+               "  unsigned member2;\n"
+               "  int funcInClass() {\n"
+               "    int      localInClass1;\n"
+               "    unsigned localInClass2;\n"
+               "  }\n"
+               "};\n"
+               "int      global1;\n"
+               "unsigned global2;",
+               Alignment);
+
+  Alignment.AlignConsecutiveDeclarations.AlignFreeVariableDeclarations = false;
+  Alignment.AlignConsecutiveDeclarations.AlignMemberVariableDeclarations =
+      false;
+  verifyFormat("int func() { //\n"
+               "  int local1;\n"
+               "  unsigned local2;\n"
+               "}\n"
+               "class Z {\n"
+               "  int member1;\n"
+               "  unsigned member2;\n"
+               "  int funcInClass() {\n"
+               "    int localInClass1;\n"
+               "    unsigned localInClass2;\n"
+               "  }\n"
+               "};\n"
+               "int global1;\n"
+               "unsigned global2;",
+               Alignment);
 }
 
 TEST_F(FormatTest, AlignConsecutiveShortCaseStatements) {
@@ -20566,15 +20621,19 @@ TEST_F(FormatTest, AlignWithLineBreaks) {
             FormatStyle::AlignConsecutiveStyle(
                 {/*Enabled=*/false, /*AcrossEmptyLines=*/false,
                  /*AcrossComments=*/false, /*AlignCompound=*/false,
+                 /*AlignFreeVariableDeclarations=*/false,
                  /*AlignFunctionDeclarations=*/false,
                  /*AlignFunctionPointers=*/false,
+                 /*AlignMemberVariableDeclarations=*/false,
                  /*PadOperators=*/true}));
   EXPECT_EQ(Style.AlignConsecutiveDeclarations,
             FormatStyle::AlignConsecutiveStyle(
                 {/*Enabled=*/false, /*AcrossEmptyLines=*/false,
                  /*AcrossComments=*/false, /*AlignCompound=*/false,
+                 /*AlignFreeVariableDeclarations=*/true,
                  /*AlignFunctionDeclarations=*/true,
                  /*AlignFunctionPointers=*/false,
+                 /*AlignMemberVariableDeclarations=*/true,
                  /*PadOperators=*/false}));
   verifyFormat("void foo() {\n"
                "  int myVar = 5;\n"


### PR DESCRIPTION
This allows disabling variable alignment declarations while still having function alignment. It also distinguishes between class member variables and other variables (e.g. function local variables).

Fixes #143947.