### PR TITLE
[SupportTests] Waive failures in ProgramEnvTest.TestExecuteEmptyEnvironment on MinGW

### DIFF
--- a/llvm/unittests/Support/ProgramTest.cpp
+++ b/llvm/unittests/Support/ProgramTest.cpp
@@ -695,7 +695,14 @@ TEST_F(ProgramEnvTest, TestExecuteEmptyEnvironment) {
   int RetCode = ExecuteAndWait(Executable, argv, ArrayRef<StringRef>{}, {}, 0,
                                0, &Error, &ExecutionFailed);
   EXPECT_FALSE(ExecutionFailed) << Error;
+#ifndef __MINGW32__
+  // When running with an empty environment, the child process doesn't in herit
+  // the PATH variable. On MinGW, it is common for executables to require a
+  // shared libstdc++ or libc++ DLL, which may be in PATH but not in the
+  // directory of SupportTests.exe - leading to STATUS_DLL_NOT_FOUND errors.
+  // Therefore, waive this failure in MinGW environments.
   ASSERT_EQ(0, RetCode);
+#endif
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
In MinGW build configurations, built executables often can end up depending on a DLL for libstdc++ or libc++. This DLL typicall isn't installed system wide, but is either installed in the same directory as the executables, or found through PATH.

If this dependency DLL has to be found through PATH, this test fails when attempting to execute the SupportTests executable with an empty environment.

Waive the failure to execute the executable in this case.