### PR TITLE
Use existing AvailabilityKind enum for code completion availability

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3051,13 +3051,13 @@ SPELLING_CACHE = {
 }
 
 
-def _convert_screaming_caps_to_pascal_case(kind: BaseEnumeration):
+def _convert_screaming_caps_to_pascal_case(kind: str):
     """
     Converting the new enum names (full upper-case, underscore separated)
     to the old ones (separated by capitalization), e.g. RESULT_TYPE -> ResultType
     """
     # Remove underscores
-    components = kind.name.split("_")
+    components = kind.split("_")
     # Upper-camel case each split component
     components = [component.lower().capitalize() for component in components]
     return "".join(components)
@@ -3193,7 +3193,7 @@ class CompletionString(ClangObject):
             + " || Priority: "
             + str(self.priority)
             + " || Availability: "
-            + _kind_to_old_name(self.availability)
+            + _convert_screaming_caps_to_pascal_case(self.availability.name)
             + " || Brief comment: "
             + str(self.briefComment)
         )

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3144,6 +3144,51 @@ completionChunkKindMap = {
 
 
 class CompletionString(ClangObject):
+    # AvailabilityKindCompat is an exact copy of AvailabilityKind, except for __str__.
+    # This is a temporary measure to keep the string representation the same
+    # until we change CompletionString.availability to return AvailabilityKind,
+    # like Cursor.availability does.
+    # Note that deriving from AvailabilityKind directly is not possible.
+    class AvailabilityKindCompat(BaseEnumeration):
+        """
+        Describes the availability of an entity.
+        It is deprecated in favor of AvailabilityKind.
+        """
+
+        # Ensure AvailabilityKindCompat is comparable with AvailabilityKind
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, (AvailabilityKind, CompletionString.AvailabilityKindCompat)):
+                return self.value == other.value
+            else:
+                return NotImplemented
+
+        def __str__(self) -> str:
+            """
+            Converts enum value to string in the old camelCase format.
+            This is a temporary measure that will be changed in the future release
+            to return string in ALL_CAPS format, like for other enums.
+            """
+
+            warnings.warn(
+                "String representation of 'CompletionString.availability' will be "
+                "changed in a future release from 'camelCase' to 'ALL_CAPS' to "
+                "match other enums. 'CompletionString.availability' can be "
+                "compared to 'AvailabilityKind' directly, "
+                "without conversion to string.",
+                DeprecationWarning,
+            )
+            # Remove underscores
+            components = self.name.split("_")
+            # Upper-camel case each split component
+            components = [component.lower().capitalize() for component in components]
+            return "".join(components)
+
+        AVAILABLE = 0
+        DEPRECATED = 1
+        NOT_AVAILABLE = 2
+        NOT_ACCESSIBLE = 3
+
+
     def __len__(self) -> int:
         return self.num_chunks
 
@@ -3170,7 +3215,7 @@ class CompletionString(ClangObject):
     @property
     def availability(self) -> AvailabilityKindCompat:
         res = conf.lib.clang_getCompletionAvailability(self.obj)
-        return AvailabilityKindCompat.from_id(res)
+        return CompletionString.AvailabilityKindCompat.from_id(res)
 
     @property
     def briefComment(self) -> str:
@@ -3186,50 +3231,6 @@ class CompletionString(ClangObject):
             + " || Brief comment: "
             + str(self.briefComment)
         )
-
-# AvailabilityKindCompat is an exact copy of AvailabilityKind, except for __str__.
-# This is a temporary measure to keep the string representation the same
-# until we change CompletionString.availability to return AvailabilityKind,
-# like Cursor.availability does.
-# Note that deriving from AvailabilityKind directly is not possible.
-class AvailabilityKindCompat(BaseEnumeration):
-    """
-    Describes the availability of an entity.
-    It is deprecated in favor of AvailabilityKind.
-    """
-
-    # Ensure AvailabilityKindCompat is comparable with AvailabilityKind
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, (AvailabilityKind, AvailabilityKindCompat)):
-            return self.value == other.value
-        else:
-            return NotImplemented
-
-    def __str__(self) -> str:
-        """
-        Converts enum value to string in the old camelCase format.
-        This is a temporary measure that will be changed in the future release
-        to return string in ALL_CAPS format, like for other enums.
-        """
-
-        warnings.warn(
-            "String representation of 'CompletionString.availability' will be "
-            "changed in a future release from 'camelCase' to 'ALL_CAPS' to "
-            "match other enums. 'CompletionString.availability' can be "
-            "compared to 'AvailabilityKind' directly, "
-            "without conversion to string.",
-            DeprecationWarning,
-        )
-        # Remove underscores
-        components = self.name.split("_")
-        # Upper-camel case each split component
-        components = [component.lower().capitalize() for component in components]
-        return "".join(components)
-
-    AVAILABLE = 0
-    DEPRECATED = 1
-    NOT_AVAILABLE = 2
-    NOT_ACCESSIBLE = 3
 
 
 class CodeCompletionResult(Structure):

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3157,7 +3157,9 @@ class CompletionString(ClangObject):
 
         # Ensure AvailabilityKindCompat is comparable with AvailabilityKind
         def __eq__(self, other: object) -> bool:
-            if isinstance(other, (AvailabilityKind, CompletionString.AvailabilityKindCompat)):
+            if isinstance(
+                other, (AvailabilityKind, CompletionString.AvailabilityKindCompat)
+            ):
                 return self.value == other.value
             else:
                 return NotImplemented
@@ -3187,7 +3189,6 @@ class CompletionString(ClangObject):
         DEPRECATED = 1
         NOT_AVAILABLE = 2
         NOT_ACCESSIBLE = 3
-
 
     def __len__(self) -> int:
         return self.num_chunks

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3051,7 +3051,7 @@ SPELLING_CACHE = {
 }
 
 
-def _kind_to_old_name(kind: BaseEnumeration):
+def _convert_screaming_caps_to_pascal_case(kind: BaseEnumeration):
     """
     Converting the new enum names (full upper-case, underscore separated)
     to the old ones (separated by capitalization), e.g. RESULT_TYPE -> ResultType

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3155,16 +3155,6 @@ completionChunkKindMap = {
 
 
 class CompletionString(ClangObject):
-    class Availability:
-        def __init__(self, name):
-            self.name = name
-
-        def __str__(self):
-            return self.name
-
-        def __repr__(self):
-            return "<Availability: %s>" % self
-
     def __len__(self) -> int:
         return self.num_chunks
 

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -84,6 +84,7 @@ from ctypes import (
 import os
 import sys
 from enum import Enum
+import warnings
 
 from typing import (
     Any,
@@ -3186,6 +3187,7 @@ class CompletionString(ClangObject):
             + str(self.briefComment)
         )
 
+
 # AvailabilityKindCompat is an exact copy of AvailabilityKind, except for __str__
 # This is a temporary measure to keep the string representation the same
 # until we unify the return of CompletionString.availability to be AvailabilityKind
@@ -3209,6 +3211,14 @@ class AvailabilityKindCompat(BaseEnumeration):
         This is a temporary measure and will be changed in a future release
         to return the same format (full upper-case, underscore separated) like other Kinds
         """
+
+        warnings.warn(
+            "The CompletionString.availability's return value will be changed in "
+            "a future release to be unified with other kinds. As a result, its string "
+            "representations will change to full upper-case, prefixed with the class name "
+            "(e.g. NotAvailable -> AvailabilityKind.NOT_AVAILABLE).",
+            DeprecationWarning,
+        )
         # Remove underscores
         components = self.name.split("_")
         # Upper-camel case each split component

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3200,7 +3200,7 @@ class AvailabilityKindCompat(BaseEnumeration):
 
     # Ensure AvailabilityKindCompat is comparable with AvailabilityKind
     def __eq__(self, other: object) -> bool:
-        if isinstance(other, AvailabilityKind):
+        if isinstance(other, (AvailabilityKind, AvailabilityKindCompat)):
             return self.value == other.value
         else:
             return NotImplemented

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3051,6 +3051,16 @@ SPELLING_CACHE = {
 }
 
 
+# Converting the new enum names (full upper-case, underscore separated)
+# to the old ones (separated by capitalization), e.g. RESULT_TYPE -> ResultType
+def _kind_to_old_name(kind: BaseEnumeration):
+    # Remove underscores
+    components = kind.name.split("_")
+    # Upper-camel case each split component
+    components = [component.lower().capitalize() for component in components]
+    return "".join(components)
+
+
 class CompletionChunk:
     class Kind:
         def __init__(self, name: str):
@@ -3177,9 +3187,9 @@ class CompletionString(ClangObject):
         return conf.lib.clang_getCompletionPriority(self.obj)  # type: ignore [no-any-return]
 
     @property
-    def availability(self) -> CompletionChunk.Kind:
+    def availability(self) -> AvailabilityKind:
         res = conf.lib.clang_getCompletionAvailability(self.obj)
-        return availabilityKinds[res]
+        return AvailabilityKind.from_id(res)
 
     @property
     def briefComment(self) -> str:
@@ -3191,18 +3201,10 @@ class CompletionString(ClangObject):
             + " || Priority: "
             + str(self.priority)
             + " || Availability: "
-            + str(self.availability)
+            + _kind_to_old_name(self.availability)
             + " || Brief comment: "
             + str(self.briefComment)
         )
-
-
-availabilityKinds = {
-    0: CompletionChunk.Kind("Available"),
-    1: CompletionChunk.Kind("Deprecated"),
-    2: CompletionChunk.Kind("NotAvailable"),
-    3: CompletionChunk.Kind("NotAccessible"),
-}
 
 
 class CodeCompletionResult(Structure):

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3187,14 +3187,15 @@ class CompletionString(ClangObject):
             + str(self.briefComment)
         )
 
-
-# AvailabilityKindCompat is an exact copy of AvailabilityKind, except for __str__
+# AvailabilityKindCompat is an exact copy of AvailabilityKind, except for __str__.
 # This is a temporary measure to keep the string representation the same
-# until we unify the return of CompletionString.availability to be AvailabilityKind
-# Note that deriving from AvailabilityKind directly is not possible
+# until we change CompletionString.availability to return AvailabilityKind,
+# like Cursor.availability does.
+# Note that deriving from AvailabilityKind directly is not possible.
 class AvailabilityKindCompat(BaseEnumeration):
     """
     Describes the availability of an entity.
+    It is deprecated in favor of AvailabilityKind.
     """
 
     # Ensure AvailabilityKindCompat is comparable with AvailabilityKind
@@ -3206,17 +3207,17 @@ class AvailabilityKindCompat(BaseEnumeration):
 
     def __str__(self) -> str:
         """
-        Returns the common enum names (full upper-case, underscore separated)
-        to the old format (separated by capitalization), e.g. NOT_ACCESSIBLE -> NotAccessible
-        This is a temporary measure and will be changed in a future release
-        to return the same format (full upper-case, underscore separated) like other Kinds
+        Converts enum value to string in the old camelCase format.
+        This is a temporary measure that will be changed in the future release
+        to return string in ALL_CAPS format, like for other enums.
         """
 
         warnings.warn(
-            "The CompletionString.availability's return value will be changed in "
-            "a future release to be unified with other kinds. As a result, its string "
-            "representations will change to full upper-case, prefixed with the class name "
-            "(e.g. NotAvailable -> AvailabilityKind.NOT_AVAILABLE).",
+            "String representation of 'CompletionString.availability' will be "
+            "changed in a future release from 'camelCase' to 'ALL_CAPS' to "
+            "match other enums. 'CompletionString.availability' can be "
+            "compared to 'AvailabilityKind' directly, "
+            "without conversion to string.",
             DeprecationWarning,
         )
         # Remove underscores

--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -3051,9 +3051,11 @@ SPELLING_CACHE = {
 }
 
 
-# Converting the new enum names (full upper-case, underscore separated)
-# to the old ones (separated by capitalization), e.g. RESULT_TYPE -> ResultType
 def _kind_to_old_name(kind: BaseEnumeration):
+    """
+    Converting the new enum names (full upper-case, underscore separated)
+    to the old ones (separated by capitalization), e.g. RESULT_TYPE -> ResultType
+    """
     # Remove underscores
     components = kind.name.split("_")
     # Upper-camel case each split component

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -143,8 +143,8 @@ void f(P x, Q y) {
         # Compare with regular kind
         for compatKind in AvailabilityKindCompat:
             commonKind = AvailabilityKind.from_id(compatKind.value)
-            nextKindId = (compatKind.value+1) % numKinds
-            commonKindUnequal= AvailabilityKind.from_id(nextKindId)
+            nextKindId = (compatKind.value + 1) % numKinds
+            commonKindUnequal = AvailabilityKind.from_id(nextKindId)
             self.assertEqual(commonKind, compatKind)
             self.assertEqual(compatKind, commonKind)
             self.assertNotEqual(commonKindUnequal, compatKind)
@@ -153,7 +153,7 @@ void f(P x, Q y) {
         # Compare two compat kinds
         for compatKind in AvailabilityKindCompat:
             compatKind2 = AvailabilityKindCompat.from_id(compatKind.value)
-            nextKindId = (compatKind.value+1) % numKinds
+            nextKindId = (compatKind.value + 1) % numKinds
             compatKind2Unequal = AvailabilityKind.from_id(nextKindId)
             self.assertEqual(compatKind, compatKind2)
             self.assertEqual(compatKind2, compatKind)

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -152,9 +152,13 @@ void f(P x, Q y) {
 
         # Compare two compat kinds
         for compatKind in CompletionString.AvailabilityKindCompat:
-            compatKind2 = CompletionString.AvailabilityKindCompat.from_id(compatKind.value)
+            compatKind2 = CompletionString.AvailabilityKindCompat.from_id(
+                compatKind.value
+            )
             nextKindId = (compatKind.value + 1) % numKinds
-            compatKind2Unequal = CompletionString.AvailabilityKindCompat.from_id(nextKindId)
+            compatKind2Unequal = CompletionString.AvailabilityKindCompat.from_id(
+                nextKindId
+            )
             self.assertEqual(compatKind, compatKind2)
             self.assertEqual(compatKind2, compatKind)
             self.assertNotEqual(compatKind2Unequal, compatKind)

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -1,4 +1,4 @@
-from clang.cindex import AvailabilityKind, AvailabilityKindCompat, TranslationUnit
+from clang.cindex import AvailabilityKind, CompletionString, TranslationUnit
 
 import unittest
 from pathlib import Path
@@ -138,10 +138,10 @@ void f(P x, Q y) {
         self.check_completion_results(cr, expected)
 
     def test_availability_kind_compat_(self):
-        numKinds = len(AvailabilityKindCompat)
+        numKinds = len(CompletionString.AvailabilityKindCompat)
 
         # Compare with regular kind
-        for compatKind in AvailabilityKindCompat:
+        for compatKind in CompletionString.AvailabilityKindCompat:
             commonKind = AvailabilityKind.from_id(compatKind.value)
             nextKindId = (compatKind.value + 1) % numKinds
             commonKindUnequal = AvailabilityKind.from_id(nextKindId)
@@ -151,10 +151,10 @@ void f(P x, Q y) {
             self.assertNotEqual(compatKind, commonKindUnequal)
 
         # Compare two compat kinds
-        for compatKind in AvailabilityKindCompat:
-            compatKind2 = AvailabilityKindCompat.from_id(compatKind.value)
+        for compatKind in CompletionString.AvailabilityKindCompat:
+            compatKind2 = CompletionString.AvailabilityKindCompat.from_id(compatKind.value)
             nextKindId = (compatKind.value + 1) % numKinds
-            compatKind2Unequal = AvailabilityKindCompat.from_id(nextKindId)
+            compatKind2Unequal = CompletionString.AvailabilityKindCompat.from_id(nextKindId)
             self.assertEqual(compatKind, compatKind2)
             self.assertEqual(compatKind2, compatKind)
             self.assertNotEqual(compatKind2Unequal, compatKind)
@@ -168,5 +168,5 @@ void f(P x, Q y) {
             3: "NotAccessible",
         }
         for id, string in kindStringMap.items():
-            kind = AvailabilityKindCompat.from_id(id)
+            kind = CompletionString.AvailabilityKindCompat.from_id(id)
             self.assertEqual(str(kind), string)

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -1,4 +1,4 @@
-from clang.cindex import TranslationUnit, AvailabilityKind, AvailabilityKindCompat
+from clang.cindex import AvailabilityKind, AvailabilityKindCompat, TranslationUnit
 
 import unittest
 from pathlib import Path

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -1,5 +1,4 @@
-from clang.cindex import TranslationUnit
-
+from clang.cindex import TranslationUnit, AvailabilityKind, AvailabilityKindCompat
 
 import unittest
 from pathlib import Path
@@ -137,3 +136,37 @@ void f(P x, Q y) {
             "{'void', ResultType} | {'~P', TypedText} | {'(', LeftParen} | {')', RightParen} || Priority: 79 || Availability: Available || Brief comment: ",
         ]
         self.check_completion_results(cr, expected)
+
+    def test_availability_kind_compat_(self):
+        numKinds = len(AvailabilityKindCompat)
+
+        # Compare with regular kind
+        for compatKind in AvailabilityKindCompat:
+            commonKind = AvailabilityKind.from_id(compatKind.value)
+            nextKindId = (compatKind.value+1) % numKinds
+            commonKindUnequal= AvailabilityKind.from_id(nextKindId)
+            self.assertEqual(commonKind, compatKind)
+            self.assertEqual(compatKind, commonKind)
+            self.assertNotEqual(commonKindUnequal, compatKind)
+            self.assertNotEqual(compatKind, commonKindUnequal)
+
+        # Compare two compat kinds
+        for compatKind in AvailabilityKindCompat:
+            compatKind2 = AvailabilityKindCompat.from_id(compatKind.value)
+            nextKindId = (compatKind.value+1) % numKinds
+            compatKind2Unequal = AvailabilityKind.from_id(nextKindId)
+            self.assertEqual(compatKind, compatKind2)
+            self.assertEqual(compatKind2, compatKind)
+            self.assertNotEqual(compatKind2Unequal, compatKind)
+            self.assertNotEqual(compatKind, compatKind2Unequal)
+
+    def test_compat_str(self):
+        kindStringMap = {
+            0: "Available",
+            1: "Deprecated",
+            2: "NotAvailable",
+            3: "NotAccessible",
+        }
+        for id, string in kindStringMap.items():
+            kind = AvailabilityKindCompat.from_id(id)
+            self.assertEqual(str(kind), string)

--- a/clang/bindings/python/tests/cindex/test_code_completion.py
+++ b/clang/bindings/python/tests/cindex/test_code_completion.py
@@ -154,7 +154,7 @@ void f(P x, Q y) {
         for compatKind in AvailabilityKindCompat:
             compatKind2 = AvailabilityKindCompat.from_id(compatKind.value)
             nextKindId = (compatKind.value + 1) % numKinds
-            compatKind2Unequal = AvailabilityKind.from_id(nextKindId)
+            compatKind2Unequal = AvailabilityKindCompat.from_id(nextKindId)
             self.assertEqual(compatKind, compatKind2)
             self.assertEqual(compatKind2, compatKind)
             self.assertNotEqual(compatKind2Unequal, compatKind)

--- a/clang/bindings/python/tests/cindex/test_enums.py
+++ b/clang/bindings/python/tests/cindex/test_enums.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from clang.cindex import (
     AccessSpecifier,
     AvailabilityKind,
+    AvailabilityKindCompat,
     BinaryOperator,
     CursorKind,
     ExceptionSpecificationKind,
@@ -22,7 +23,10 @@ from clang.cindex import (
 
 
 class TestEnums(unittest.TestCase):
+    # Test all enum classes, except for AvailabilityKindCompat since it is
+    # just a copy of AvailabilityKind and has no corresponding C-class
     enums = BaseEnumeration.__subclasses__()
+    enums.remove(AvailabilityKindCompat)
 
     def test_from_id(self):
         """Check that kinds can be constructed from valid IDs"""

--- a/clang/bindings/python/tests/cindex/test_enums.py
+++ b/clang/bindings/python/tests/cindex/test_enums.py
@@ -4,8 +4,8 @@ from pathlib import Path
 from clang.cindex import (
     AccessSpecifier,
     AvailabilityKind,
-    AvailabilityKindCompat,
     BinaryOperator,
+    CompletionString,
     CursorKind,
     ExceptionSpecificationKind,
     LanguageKind,
@@ -26,7 +26,7 @@ class TestEnums(unittest.TestCase):
     # Test all enum classes, except for AvailabilityKindCompat since it is
     # just a copy of AvailabilityKind and has no corresponding C-class
     enums = BaseEnumeration.__subclasses__()
-    enums.remove(AvailabilityKindCompat)
+    enums.remove(CompletionString.AvailabilityKindCompat)
 
     def test_from_id(self):
         """Check that kinds can be constructed from valid IDs"""

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -55,18 +55,16 @@ Clang Frontend Potentially Breaking Changes
 Clang Python Bindings Potentially Breaking Changes
 --------------------------------------------------
 - Remove ``CompletionString.Availability``. No libclang interfaces returned instances of it.
-- Remove ``CompletionString.Kind`` and its container, ``availabilityKinds``.
-  ``CompletionString.availability`` now returns instances of ``CompletionString.AvailabilityKindCompat``.
+- ``CompletionString.availability`` now returns instances of ``CompletionString.AvailabilityKindCompat``.
 
   Instances of ``AvailabilityKindCompat`` have the same ``__str__`` representation
-  as the previous ``CompletionString.Kind``s and are equality-compatible with
+  as the previous ``CompletionString.Kind``s and are equality-comparable with
   the existing ``AvailabilityKind`` enum. It will be replaced by ``AvailabilityKind``
   in a future release. When this happens, the return type of ``CompletionString.availability``
   will change to ``AvailabilityKind``, so it is recommended to use ``AvailabilityKind``
   to compare with the return values of ``CompletionString.availability``.
-
-  In this release, uses of ``availabilityKinds`` need to be replaced by
-  ``CompletionString.AvailabilityKindCompat``.
+- Remove ``availabilityKinds``. In this release, uses of ``availabilityKinds``
+  need to be replaced by ``CompletionString.AvailabilityKindCompat``.
 
 What's New in Clang |release|?
 ==============================

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -54,6 +54,19 @@ Clang Frontend Potentially Breaking Changes
 
 Clang Python Bindings Potentially Breaking Changes
 --------------------------------------------------
+- Remove ``CompletionString.Availability``. No libclang interfaces returned instances of it.
+- Remove ``CompletionString.Kind`` and its container, ``availabilityKinds``.
+  ``CompletionString.availability`` now returns instances of ``CompletionString.AvailabilityKindCompat``.
+
+  Instances of ``AvailabilityKindCompat`` have the same ``__str__`` representation
+  as the previous ``CompletionString.Kind``s and are equality-compatible with
+  the existing ``AvailabilityKind`` enum. It will be replaced by ``AvailabilityKind``
+  in a future release. When this happens, the return type of ``CompletionString.availability``
+  will change to ``AvailabilityKind``, so it is recommended to use ``AvailabilityKind``
+  to compare with the return values of ``CompletionString.availability``.
+
+  In this release, uses of ``availabilityKinds`` need to be replaced by
+  ``CompletionString.AvailabilityKindCompat``.
 
 What's New in Clang |release|?
 ==============================

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -58,7 +58,7 @@ Clang Python Bindings Potentially Breaking Changes
 - ``CompletionString.availability`` now returns instances of ``CompletionString.AvailabilityKindCompat``.
 
   Instances of ``AvailabilityKindCompat`` have the same ``__str__`` representation
-  as the previous ``CompletionString.Kind``s and are equality-comparable with
+  as the previous ``CompletionChunk.Kind``s and are equality-comparable with
   the existing ``AvailabilityKind`` enum. It will be replaced by ``AvailabilityKind``
   in a future release. When this happens, the return type of ``CompletionString.availability``
   will change to ``AvailabilityKind``, so it is recommended to use ``AvailabilityKind``

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -64,7 +64,7 @@ Clang Python Bindings Potentially Breaking Changes
   will change to ``AvailabilityKind``, so it is recommended to use ``AvailabilityKind``
   to compare with the return values of ``CompletionString.availability``.
 - Remove ``availabilityKinds``. In this release, uses of ``availabilityKinds``
-  need to be replaced by ``CompletionString.AvailabilityKindCompat``.
+  need to be replaced by ``CompletionString.AvailabilityKind``.
 
 What's New in Clang |release|?
 ==============================


### PR DESCRIPTION
This adresses point 4 from #156680. This is a necessary step before `CompletionChunk.Kind` can be removed.

The `ChunkCompletion.Kind` implements `__str__` and `__repr__` differently from our other enum classes. I have adapted the `__repr__` of `CompletionString` to stringify the availability of the chunk differently so that it still looks the same as before.

Also introduce a temporary `AvailabilityKindCompat` to ensure that `__str__` returns the same format, while also leaving a deprecation warning that this will be removed in a future release.