### PR TITLE
Update callers of isTriviallyReMaterializable to check trivialness

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -2213,7 +2213,11 @@ findPrologueEndLoc(const MachineFunction *MF) {
       -> std::optional<std::pair<const MachineInstr *, bool>> {
     // Is this instruction trivial data shuffling or frame-setup?
     bool isCopy = (TII.isCopyInstr(MI) ? true : false);
-    bool isTrivRemat = TII.isTriviallyReMaterializable(MI);
+    bool isTrivRemat =
+        TII.isTriviallyReMaterializable(MI) &&
+        llvm::all_of(MI.all_uses(), [](const MachineOperand &MO) {
+          return MO.getReg().isVirtual();
+        });
     bool isFrameSetup = MI.getFlag(MachineInstr::FrameSetup);
 
     if (!isFrameSetup && MI.getDebugLoc()) {

--- a/llvm/lib/CodeGen/RegAllocScore.cpp
+++ b/llvm/lib/CodeGen/RegAllocScore.cpp
@@ -79,8 +79,11 @@ llvm::calculateRegAllocScore(const MachineFunction &MF,
         return MBFI.getBlockFreqRelativeToEntryBlock(&MBB);
       },
       [&](const MachineInstr &MI) {
-        return MF.getSubtarget().getInstrInfo()->isTriviallyReMaterializable(
-            MI);
+        auto *TTI = MF.getSubtarget().getInstrInfo();
+        return TTI->isTriviallyReMaterializable(MI) &&
+               llvm::all_of(MI.all_uses(), [](const MachineOperand &MO) {
+                 return MO.getReg().isVirtual();
+               });
       });
 }
 

--- a/llvm/lib/Target/WebAssembly/WebAssemblyRegStackify.cpp
+++ b/llvm/lib/Target/WebAssembly/WebAssemblyRegStackify.cpp
@@ -260,7 +260,10 @@ static void query(const MachineInstr &MI, bool &Read, bool &Write,
 // Test whether Def is safe and profitable to rematerialize.
 static bool shouldRematerialize(const MachineInstr &Def,
                                 const WebAssemblyInstrInfo *TII) {
-  return Def.isAsCheapAsAMove() && TII->isTriviallyReMaterializable(Def);
+  return Def.isAsCheapAsAMove() && TII->isTriviallyReMaterializable(Def) &&
+         llvm::all_of(Def.all_uses(), [](const MachineOperand &MO) {
+           return MO.getReg().isVirtual();
+         });
 }
 
 // Identify the definition for this register at this point. This is a


### PR DESCRIPTION
This is a preparatory change for an upcoming reorganization of our rematerialization APIs.  Despite the interface being documented as "trivial" (meaning no virtual register uses on the instruction being considered for remat), our actual implementation inconsistently supports non-trivial remat, and certain backends (AMDGPU and RISC-V mostly) lie about instructions being trivial to abuse that.  We want to allow non-triial remat more broadly, but first we need to do some cleanup to make it understandable what's going on.

These three call sites are ones which appear to actually want the trivial definition, and appear fairly low risk to change.

p.s. I'm deliberately *not* updating any APIs in this change, I'm going to do that as a followup once it's clear which category each callsite fits in.

Edit: Warning to anyone looking at this later, the landed version contained a nasty bug where I'd accidentally reversed the condition being checked for.  This was (accidentally) undone in https://github.com/llvm/llvm-project/pull/160377 but results in this change description being super misleading.  Sorry!