### PR TITLE
[LV] Compute SCEV for memcheck before unlinking

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -641,6 +641,8 @@ LLVM_ABI Loop *cloneLoop(Loop *L, Loop *PL, ValueToValueMapTy &VM, LoopInfo *LI,
 
 /// Add code that checks at runtime if the accessed arrays in \p PointerChecks
 /// overlap. Returns the final comparator value or NULL if no check is needed.
+/// If \p HoistRuntimeChecks and \p TheLoop has a parent, sets \p
+/// AllChecksHoisted when all checks are outer-loop invariant (hoistable).
 LLVM_ABI Value *
 addRuntimeChecks(Instruction *Loc, Loop *TheLoop,
                  const SmallVectorImpl<RuntimePointerCheck> &PointerChecks,

--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -644,7 +644,8 @@ LLVM_ABI Loop *cloneLoop(Loop *L, Loop *PL, ValueToValueMapTy &VM, LoopInfo *LI,
 LLVM_ABI Value *
 addRuntimeChecks(Instruction *Loc, Loop *TheLoop,
                  const SmallVectorImpl<RuntimePointerCheck> &PointerChecks,
-                 SCEVExpander &Expander, bool HoistRuntimeChecks = false);
+                 SCEVExpander &Expander, bool HoistRuntimeChecks,
+                 bool &AllChecksHoisted);
 
 LLVM_ABI Value *addDiffRuntimeChecks(
     Instruction *Loc, ArrayRef<PointerDiffInfo> Checks, SCEVExpander &Expander,

--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -640,14 +640,15 @@ LLVM_ABI Loop *cloneLoop(Loop *L, Loop *PL, ValueToValueMapTy &VM, LoopInfo *LI,
                          LPPassManager *LPM);
 
 /// Add code that checks at runtime if the accessed arrays in \p PointerChecks
-/// overlap. Returns the final comparator value or NULL if no check is needed.
-/// If \p HoistRuntimeChecks and \p TheLoop has a parent, sets \p
-/// AllChecksHoisted when all checks are outer-loop invariant (hoistable).
-LLVM_ABI Value *
+/// overlap. Returns a pair of the final comparator value (or NULL if no check
+/// is needed) and a boolean indicating whether all checks are outer-loop
+/// invariant (hoistable). If \p HoistRuntimeChecks is true and \p TheLoop has
+/// a parent, the boolean is set to true when all checks are outer-loop
+/// invariant, i.e. hoistable, or false otherwise.
+LLVM_ABI std::pair<Value *, bool>
 addRuntimeChecks(Instruction *Loc, Loop *TheLoop,
                  const SmallVectorImpl<RuntimePointerCheck> &PointerChecks,
-                 SCEVExpander &Expander, bool HoistRuntimeChecks,
-                 bool &AllChecksHoisted);
+                 SCEVExpander &Expander, bool HoistRuntimeChecks = false);
 
 LLVM_ABI Value *addDiffRuntimeChecks(
     Instruction *Loc, ArrayRef<PointerDiffInfo> Checks, SCEVExpander &Expander,

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -2087,6 +2087,7 @@ struct PointerBounds {
   TrackingVH<Value> Start;
   TrackingVH<Value> End;
   Value *StrideToCheck;
+  bool IsInvariant = false;
 };
 
 /// Expand code for the lower and upper bound of the pointer group \p CG
@@ -2145,6 +2146,18 @@ static PointerBounds expandBounds(const RuntimeCheckingPtrGroup *CG,
     }
   }
 
+  bool IsInvariant = false;
+  if (HoistRuntimeChecks && TheLoop->getParentLoop()) {
+    const Loop *OuterLoop = TheLoop->getParentLoop();
+    ScalarEvolution &SE = *Exp.getSE();
+    // Stride, if set, is the step recurrence of an AddRec for OuterLoop,
+    // so it is always invariant in OuterLoop.
+    assert((!Stride || SE.isLoopInvariant(Stride, OuterLoop)) &&
+           "Stride must be outer-loop invariant");
+    IsInvariant = SE.isLoopInvariant(Low, OuterLoop) &&
+                  SE.isLoopInvariant(High, OuterLoop);
+  }
+
   Start = Exp.expandCodeFor(Low, PtrArithTy, Loc);
   End = Exp.expandCodeFor(High, PtrArithTy, Loc);
   if (CG->NeedsFreeze) {
@@ -2155,7 +2168,7 @@ static PointerBounds expandBounds(const RuntimeCheckingPtrGroup *CG,
   Value *StrideVal =
       Stride ? Exp.expandCodeFor(Stride, Stride->getType(), Loc) : nullptr;
   LLVM_DEBUG(dbgs() << "Start: " << *Low << " End: " << *High << "\n");
-  return {Start, End, StrideVal};
+  return {Start, End, StrideVal, IsInvariant};
 }
 
 /// Turns a collection of checks into a collection of expanded upper and
@@ -2179,19 +2192,18 @@ expandBounds(const SmallVectorImpl<RuntimePointerCheck> &PointerChecks, Loop *L,
   return ChecksWithBounds;
 }
 
-Value *llvm::addRuntimeChecks(
+std::pair<Value *, bool> llvm::addRuntimeChecks(
     Instruction *Loc, Loop *TheLoop,
     const SmallVectorImpl<RuntimePointerCheck> &PointerChecks,
-    SCEVExpander &Exp, bool HoistRuntimeChecks, bool &AllChecksHoisted) {
+    SCEVExpander &Exp, bool HoistRuntimeChecks) {
   // TODO: Move noalias annotation code from LoopVersioning here and share with LV if possible.
   // TODO: Pass  RtPtrChecking instead of PointerChecks and SE separately, if possible
   auto ExpandedChecks =
       expandBounds(PointerChecks, TheLoop, Loc, Exp, HoistRuntimeChecks);
 
   LLVMContext &Ctx = Loc->getContext();
-  auto *SE = Exp.getSE();
-  auto *OuterLoop = TheLoop->getParentLoop();
-  AllChecksHoisted = HoistRuntimeChecks && OuterLoop != nullptr;
+  bool AllChecksHoisted =
+      HoistRuntimeChecks && TheLoop->getParentLoop() != nullptr;
   IRBuilder ChkBuilder(Ctx, InstSimplifyFolder(Loc->getDataLayout()));
   ChkBuilder.SetInsertPoint(Loc);
   // Our instructions might fold to a constant.
@@ -2231,18 +2243,8 @@ Value *llvm::addRuntimeChecks(
       IsConflict = ChkBuilder.CreateOr(IsConflict, IsNegativeStride);
     }
 
-    if (AllChecksHoisted) {
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.Start), OuterLoop);
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.Start), OuterLoop);
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.End), OuterLoop);
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.End), OuterLoop);
-      if (A.StrideToCheck)
-        AllChecksHoisted &=
-            SE->isLoopInvariant(SE->getSCEV(A.StrideToCheck), OuterLoop);
-      if (B.StrideToCheck)
-        AllChecksHoisted &=
-            SE->isLoopInvariant(SE->getSCEV(B.StrideToCheck), OuterLoop);
-    }
+    if (AllChecksHoisted)
+      AllChecksHoisted &= A.IsInvariant && B.IsInvariant;
 
     if (MemoryRuntimeCheck) {
       IsConflict =
@@ -2252,7 +2254,7 @@ Value *llvm::addRuntimeChecks(
   }
 
   Exp.eraseDeadInstructions(MemoryRuntimeCheck);
-  return MemoryRuntimeCheck;
+  return {MemoryRuntimeCheck, AllChecksHoisted};
 }
 
 namespace {

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -2182,17 +2182,22 @@ expandBounds(const SmallVectorImpl<RuntimePointerCheck> &PointerChecks, Loop *L,
 Value *llvm::addRuntimeChecks(
     Instruction *Loc, Loop *TheLoop,
     const SmallVectorImpl<RuntimePointerCheck> &PointerChecks,
-    SCEVExpander &Exp, bool HoistRuntimeChecks) {
+    SCEVExpander &Exp, bool HoistRuntimeChecks, bool &AllChecksHoisted) {
   // TODO: Move noalias annotation code from LoopVersioning here and share with LV if possible.
   // TODO: Pass  RtPtrChecking instead of PointerChecks and SE separately, if possible
   auto ExpandedChecks =
       expandBounds(PointerChecks, TheLoop, Loc, Exp, HoistRuntimeChecks);
 
   LLVMContext &Ctx = Loc->getContext();
+  auto *SE = Exp.getSE();
+  auto *OuterLoop = TheLoop->getParentLoop();
+  AllChecksHoisted = HoistRuntimeChecks && OuterLoop;
   IRBuilder ChkBuilder(Ctx, InstSimplifyFolder(Loc->getDataLayout()));
   ChkBuilder.SetInsertPoint(Loc);
   // Our instructions might fold to a constant.
   Value *MemoryRuntimeCheck = nullptr;
+
+  AllChecksHoisted = HoistRuntimeChecks && OuterLoop;
 
   for (const auto &[A, B] : ExpandedChecks) {
     // Check if two pointers (A and B) conflict where conflict is computed as:
@@ -2214,6 +2219,14 @@ Value *llvm::addRuntimeChecks(
     //  IsConflict = bound0 & bound1
     Value *Cmp0 = ChkBuilder.CreateICmpULT(A.Start, B.End, "bound0");
     Value *Cmp1 = ChkBuilder.CreateICmpULT(B.Start, A.End, "bound1");
+
+    if (AllChecksHoisted) {
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.Start), OuterLoop);
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.Start), OuterLoop);
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.End), OuterLoop);
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.End), OuterLoop);
+    }
+
     Value *IsConflict = ChkBuilder.CreateAnd(Cmp0, Cmp1, "found.conflict");
     if (A.StrideToCheck) {
       Value *IsNegativeStride = ChkBuilder.CreateICmpSLT(

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -2191,13 +2191,11 @@ Value *llvm::addRuntimeChecks(
   LLVMContext &Ctx = Loc->getContext();
   auto *SE = Exp.getSE();
   auto *OuterLoop = TheLoop->getParentLoop();
-  AllChecksHoisted = HoistRuntimeChecks && OuterLoop;
+  AllChecksHoisted = HoistRuntimeChecks && OuterLoop != nullptr;
   IRBuilder ChkBuilder(Ctx, InstSimplifyFolder(Loc->getDataLayout()));
   ChkBuilder.SetInsertPoint(Loc);
   // Our instructions might fold to a constant.
   Value *MemoryRuntimeCheck = nullptr;
-
-  AllChecksHoisted = HoistRuntimeChecks && OuterLoop;
 
   for (const auto &[A, B] : ExpandedChecks) {
     // Check if two pointers (A and B) conflict where conflict is computed as:
@@ -2220,13 +2218,6 @@ Value *llvm::addRuntimeChecks(
     Value *Cmp0 = ChkBuilder.CreateICmpULT(A.Start, B.End, "bound0");
     Value *Cmp1 = ChkBuilder.CreateICmpULT(B.Start, A.End, "bound1");
 
-    if (AllChecksHoisted) {
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.Start), OuterLoop);
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.Start), OuterLoop);
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.End), OuterLoop);
-      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.End), OuterLoop);
-    }
-
     Value *IsConflict = ChkBuilder.CreateAnd(Cmp0, Cmp1, "found.conflict");
     if (A.StrideToCheck) {
       Value *IsNegativeStride = ChkBuilder.CreateICmpSLT(
@@ -2240,6 +2231,20 @@ Value *llvm::addRuntimeChecks(
           "stride.check");
       IsConflict = ChkBuilder.CreateOr(IsConflict, IsNegativeStride);
     }
+
+    if (AllChecksHoisted) {
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.Start), OuterLoop);
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.Start), OuterLoop);
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(A.End), OuterLoop);
+      AllChecksHoisted &= SE->isLoopInvariant(SE->getSCEV(B.End), OuterLoop);
+      if (A.StrideToCheck)
+        AllChecksHoisted &=
+            SE->isLoopInvariant(SE->getSCEV(A.StrideToCheck), OuterLoop);
+      if (B.StrideToCheck)
+        AllChecksHoisted &=
+            SE->isLoopInvariant(SE->getSCEV(B.StrideToCheck), OuterLoop);
+    }
+
     if (MemoryRuntimeCheck) {
       IsConflict =
           ChkBuilder.CreateOr(MemoryRuntimeCheck, IsConflict, "conflict.rdx");

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -2217,7 +2217,6 @@ Value *llvm::addRuntimeChecks(
     //  IsConflict = bound0 & bound1
     Value *Cmp0 = ChkBuilder.CreateICmpULT(A.Start, B.End, "bound0");
     Value *Cmp1 = ChkBuilder.CreateICmpULT(B.Start, A.End, "bound1");
-
     Value *IsConflict = ChkBuilder.CreateAnd(Cmp0, Cmp1, "found.conflict");
     if (A.StrideToCheck) {
       Value *IsNegativeStride = ChkBuilder.CreateICmpSLT(

--- a/llvm/lib/Transforms/Utils/LoopVersioning.cpp
+++ b/llvm/lib/Transforms/Utils/LoopVersioning.cpp
@@ -62,9 +62,9 @@ void LoopVersioning::versionLoop(
   const auto &RtPtrChecking = *LAI.getRuntimePointerChecking();
 
   SCEVExpander Exp2(*RtPtrChecking.getSE(), "induction");
-  MemRuntimeCheck = addRuntimeChecks(RuntimeCheckBB->getTerminator(),
-                                     VersionedLoop, AliasChecks, Exp2)
-                        .first;
+  std::pair<Value *, bool> CheckRes = addRuntimeChecks(
+      RuntimeCheckBB->getTerminator(), VersionedLoop, AliasChecks, Exp2);
+  MemRuntimeCheck = CheckRes.first;
 
   SCEVExpander Exp(*SE, "scev.check");
   SCEVRuntimeCheck =

--- a/llvm/lib/Transforms/Utils/LoopVersioning.cpp
+++ b/llvm/lib/Transforms/Utils/LoopVersioning.cpp
@@ -62,10 +62,9 @@ void LoopVersioning::versionLoop(
   const auto &RtPtrChecking = *LAI.getRuntimePointerChecking();
 
   SCEVExpander Exp2(*RtPtrChecking.getSE(), "induction");
-  bool AllChecksHoisted = false;
-  MemRuntimeCheck =
-      addRuntimeChecks(RuntimeCheckBB->getTerminator(), VersionedLoop,
-                       AliasChecks, Exp2, false, AllChecksHoisted);
+  MemRuntimeCheck = addRuntimeChecks(RuntimeCheckBB->getTerminator(),
+                                     VersionedLoop, AliasChecks, Exp2)
+                        .first;
 
   SCEVExpander Exp(*SE, "scev.check");
   SCEVRuntimeCheck =

--- a/llvm/lib/Transforms/Utils/LoopVersioning.cpp
+++ b/llvm/lib/Transforms/Utils/LoopVersioning.cpp
@@ -62,10 +62,10 @@ void LoopVersioning::versionLoop(
   const auto &RtPtrChecking = *LAI.getRuntimePointerChecking();
 
   SCEVExpander Exp2(*RtPtrChecking.getSE(), "induction");
-  bool AllCheckHoisted = false;
+  bool AllChecksHoisted = false;
   MemRuntimeCheck =
       addRuntimeChecks(RuntimeCheckBB->getTerminator(), VersionedLoop,
-                       AliasChecks, Exp2, false, AllCheckHoisted);
+                       AliasChecks, Exp2, false, AllChecksHoisted);
 
   SCEVExpander Exp(*SE, "scev.check");
   SCEVRuntimeCheck =

--- a/llvm/lib/Transforms/Utils/LoopVersioning.cpp
+++ b/llvm/lib/Transforms/Utils/LoopVersioning.cpp
@@ -62,8 +62,10 @@ void LoopVersioning::versionLoop(
   const auto &RtPtrChecking = *LAI.getRuntimePointerChecking();
 
   SCEVExpander Exp2(*RtPtrChecking.getSE(), "induction");
-  MemRuntimeCheck = addRuntimeChecks(RuntimeCheckBB->getTerminator(),
-                                     VersionedLoop, AliasChecks, Exp2);
+  bool AllCheckHoisted = false;
+  MemRuntimeCheck =
+      addRuntimeChecks(RuntimeCheckBB->getTerminator(), VersionedLoop,
+                       AliasChecks, Exp2, false, AllCheckHoisted);
 
   SCEVExpander Exp(*SE, "scev.check");
   SCEVRuntimeCheck =

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1539,6 +1539,8 @@ class GeneratedRTChecks {
   /// If it is nullptr no memory runtime checks have been generated.
   Value *MemRuntimeCheckCond = nullptr;
 
+  bool AllCheckHoisted = false;
+
   DominatorTree *DT;
   LoopInfo *LI;
   TargetTransformInfo *TTI;
@@ -1638,16 +1640,11 @@ public:
       } else {
         MemRuntimeCheckCond = addRuntimeChecks(
             MemCheckBlock->getTerminator(), L, RtPtrChecking.getChecks(),
-            MemCheckExp, VectorizerParams::HoistRuntimeChecks);
+            MemCheckExp, VectorizerParams::HoistRuntimeChecks, AllCheckHoisted);
       }
       assert(MemRuntimeCheckCond &&
              "no RT checks generated although RtPtrChecking "
              "claimed checks are required");
-      // Compute SCEV while the block is reachable.
-      // After unlinking, SCEV returns unknown/poison (constant -> invariant),
-      // which makes getCost() wrongly discount hoisted checks.
-      if (OuterLoop)
-        PSE.getSE()->getSCEV(MemRuntimeCheckCond);
     }
 
     SCEVExp.eraseDeadInstructions(SCEVCheckCond);
@@ -1724,13 +1721,11 @@ public:
       // the checks will likely be hoisted out and so the effective cost will
       // reduce according to the outer loop trip count.
       if (OuterLoop) {
-        ScalarEvolution *SE = MemCheckExp.getSE();
         // TODO: If profitable, we could refine this further by analysing every
         // individual memory check, since there could be a mixture of loop
         // variant and invariant checks that mean the final condition is
         // variant.
-        const SCEV *Cond = SE->getSCEV(MemRuntimeCheckCond);
-        if (SE->isLoopInvariant(Cond, OuterLoop)) {
+        if (AllCheckHoisted) {
           // It seems reasonable to assume that we can reduce the effective
           // cost of the checks even when we know nothing about the trip
           // count. Assume that the outer loop executes at least twice.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1596,6 +1596,10 @@ public:
     BasicBlock *LoopHeader = L->getHeader();
     BasicBlock *Preheader = L->getLoopPreheader();
 
+    // Outer loop is used as part of later cost calculations (e.g. to
+    // determine if runtime checks are loop-invariant and can be hoisted).
+    OuterLoop = L->getParentLoop();
+
     // Use SplitBlock to create blocks for SCEV & memory runtime checks to
     // ensure the blocks are properly added to LoopInfo & DominatorTree. Those
     // may be used by SCEVExpander. The blocks will be un-linked from their
@@ -1639,6 +1643,11 @@ public:
       assert(MemRuntimeCheckCond &&
              "no RT checks generated although RtPtrChecking "
              "claimed checks are required");
+      // Compute SCEV while the block is reachable.
+      // After unlinking, SCEV returns unknown/poison (constant -> invariant),
+      // which makes getCost() wrongly discount hoisted checks.
+      if (OuterLoop)
+        PSE.getSE()->getSCEV(MemRuntimeCheckCond);
     }
 
     SCEVExp.eraseDeadInstructions(SCEVCheckCond);
@@ -1678,8 +1687,6 @@ public:
       LI->removeBlock(SCEVCheckBlock);
     }
 
-    // Outer loop is used as part of the later cost calculations.
-    OuterLoop = L->getParentLoop();
   }
 
   InstructionCost getCost() {

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1540,7 +1540,7 @@ class GeneratedRTChecks {
   Value *MemRuntimeCheckCond = nullptr;
 
   /// True if memory checks are outer-loop invariant (hoistable).
-  /// Used to discount check cost for inner loops.
+  /// Used to discount the cost of performing runtime checks for inner loops.
   bool AllChecksHoisted = false;
 
   DominatorTree *DT;
@@ -1636,10 +1636,9 @@ public:
             },
             IC);
       } else {
-        MemRuntimeCheckCond = addRuntimeChecks(
+        std::tie(MemRuntimeCheckCond, AllChecksHoisted) = addRuntimeChecks(
             MemCheckBlock->getTerminator(), L, RtPtrChecking.getChecks(),
-            MemCheckExp, VectorizerParams::HoistRuntimeChecks,
-            AllChecksHoisted);
+            MemCheckExp, VectorizerParams::HoistRuntimeChecks);
       }
       assert(MemRuntimeCheckCond &&
              "no RT checks generated although RtPtrChecking "

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1539,7 +1539,7 @@ class GeneratedRTChecks {
   /// If it is nullptr no memory runtime checks have been generated.
   Value *MemRuntimeCheckCond = nullptr;
 
-  bool AllCheckHoisted = false;
+  bool AllChecksHoisted = false;
 
   DominatorTree *DT;
   LoopInfo *LI;
@@ -1640,7 +1640,8 @@ public:
       } else {
         MemRuntimeCheckCond = addRuntimeChecks(
             MemCheckBlock->getTerminator(), L, RtPtrChecking.getChecks(),
-            MemCheckExp, VectorizerParams::HoistRuntimeChecks, AllCheckHoisted);
+            MemCheckExp, VectorizerParams::HoistRuntimeChecks,
+            AllChecksHoisted);
       }
       assert(MemRuntimeCheckCond &&
              "no RT checks generated although RtPtrChecking "
@@ -1683,7 +1684,6 @@ public:
       DT->eraseNode(SCEVCheckBlock);
       LI->removeBlock(SCEVCheckBlock);
     }
-
   }
 
   InstructionCost getCost() {
@@ -1725,7 +1725,7 @@ public:
         // individual memory check, since there could be a mixture of loop
         // variant and invariant checks that mean the final condition is
         // variant.
-        if (AllCheckHoisted) {
+        if (AllChecksHoisted) {
           // It seems reasonable to assume that we can reduce the effective
           // cost of the checks even when we know nothing about the trip
           // count. Assume that the outer loop executes at least twice.

--- a/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
+++ b/llvm/lib/Transforms/Vectorize/LoopVectorize.cpp
@@ -1539,6 +1539,8 @@ class GeneratedRTChecks {
   /// If it is nullptr no memory runtime checks have been generated.
   Value *MemRuntimeCheckCond = nullptr;
 
+  /// True if memory checks are outer-loop invariant (hoistable).
+  /// Used to discount check cost for inner loops.
   bool AllChecksHoisted = false;
 
   DominatorTree *DT;
@@ -1597,10 +1599,6 @@ public:
 
     BasicBlock *LoopHeader = L->getHeader();
     BasicBlock *Preheader = L->getLoopPreheader();
-
-    // Outer loop is used as part of later cost calculations (e.g. to
-    // determine if runtime checks are loop-invariant and can be hoisted).
-    OuterLoop = L->getParentLoop();
 
     // Use SplitBlock to create blocks for SCEV & memory runtime checks to
     // ensure the blocks are properly added to LoopInfo & DominatorTree. Those
@@ -1684,6 +1682,9 @@ public:
       DT->eraseNode(SCEVCheckBlock);
       LI->removeBlock(SCEVCheckBlock);
     }
+
+    // Outer loop is used as part of the later cost calculations.
+    OuterLoop = L->getParentLoop();
   }
 
   InstructionCost getCost() {

--- a/llvm/test/Transforms/LoopVectorize/AArch64/low_trip_memcheck_cost.ll
+++ b/llvm/test/Transforms/LoopVectorize/AArch64/low_trip_memcheck_cost.ll
@@ -255,7 +255,7 @@ define void @outer_cannot_hoist(ptr nocapture noundef %dst, ptr nocapture nounde
 ; CHECK:      Calculating cost of runtime checks:
 ; CHECK-NOT:  We expect runtime memory checks to be hoisted out of the outer loop.
 ; CHECK:      Total cost of runtime checks: 7
-; CHECK-NEXT: LV: Minimum required TC for runtime checks to be profitable:8
+; CHECK: LV: Minimum required TC for runtime checks to be profitable:8
 entry:
   br label %outer.loop
 

--- a/llvm/test/Transforms/LoopVectorize/vplan-native-path-inner-loop-with-runtime-checks.ll
+++ b/llvm/test/Transforms/LoopVectorize/vplan-native-path-inner-loop-with-runtime-checks.ll
@@ -20,8 +20,7 @@ define void @expand(ptr %src, ptr %dst, i64 %0) {
 ; CHECK-NEXT:    [[SMAX6:%.*]] = call i64 @llvm.smax.i64(i64 [[TMP6]], i64 1000)
 ; CHECK-NEXT:    [[TMP7:%.*]] = shl i64 [[SMAX6]], 4
 ; CHECK-NEXT:    [[SCEVGEP7:%.*]] = getelementptr i8, ptr [[DST]], i64 [[TMP7]]
-; CHECK-NEXT:    [[SMAX8:%.*]] = call i64 @llvm.smax.i64(i64 [[TMP6]], i64 1000)
-; CHECK-NEXT:    [[TMP8:%.*]] = sub i64 [[SMAX8]], [[TMP0]]
+; CHECK-NEXT:    [[TMP8:%.*]] = sub i64 [[SMAX6]], [[TMP0]]
 ; CHECK-NEXT:    br label %[[OUTER_HEADER:.*]]
 ; CHECK:       [[OUTER_HEADER]]:
 ; CHECK-NEXT:    [[OUTER_IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[OUTER_IV_NEXT:%.*]], %[[OUTER_LATCH:.*]] ]

--- a/llvm/test/Transforms/LoopVectorize/vplan-native-path-inner-loop-with-runtime-checks.ll
+++ b/llvm/test/Transforms/LoopVectorize/vplan-native-path-inner-loop-with-runtime-checks.ll
@@ -20,7 +20,8 @@ define void @expand(ptr %src, ptr %dst, i64 %0) {
 ; CHECK-NEXT:    [[SMAX6:%.*]] = call i64 @llvm.smax.i64(i64 [[TMP6]], i64 1000)
 ; CHECK-NEXT:    [[TMP7:%.*]] = shl i64 [[SMAX6]], 4
 ; CHECK-NEXT:    [[SCEVGEP7:%.*]] = getelementptr i8, ptr [[DST]], i64 [[TMP7]]
-; CHECK-NEXT:    [[TMP8:%.*]] = sub i64 [[SMAX6]], [[TMP0]]
+; CHECK-NEXT:    [[SMAX8:%.*]] = call i64 @llvm.smax.i64(i64 [[TMP6]], i64 1000)
+; CHECK-NEXT:    [[TMP8:%.*]] = sub i64 [[SMAX8]], [[TMP0]]
 ; CHECK-NEXT:    br label %[[OUTER_HEADER:.*]]
 ; CHECK:       [[OUTER_HEADER]]:
 ; CHECK-NEXT:    [[OUTER_IV:%.*]] = phi i64 [ 0, %[[ENTRY]] ], [ [[OUTER_IV_NEXT:%.*]], %[[OUTER_LATCH:.*]] ]


### PR DESCRIPTION
When generating runtime memory checks for outer loops, we split blocks and later unlink them, making the memcheck block unreachable. For instructions in unreachable blocks, ScalarEvolution returns an unknown/poison SCEV, which is treated as a constant and thus loop-invariant. The cost model then assumes the check can be hoisted and underestimates its cost. See this code in `GeneratedRTChecks::getCost`:

```
        const SCEV *Cond = SE->getSCEV(MemRuntimeCheckCond);
        if (SE->isLoopInvariant(Cond, OuterLoop)) {
```

Set OuterLoop early in GeneratedRTChecks::create and compute the SCEV for MemRuntimeCheckCond before unlinking, so getCost() sees the cached expression rather than a poison constant.