### PR TITLE
[MLIR] Reuse AsmState to enable fast generate-runtime-verification pass; add location-only pass option

### DIFF
--- a/mlir/include/mlir/Interfaces/RuntimeVerifiableOpInterface.td
+++ b/mlir/include/mlir/Interfaces/RuntimeVerifiableOpInterface.td
@@ -32,15 +32,11 @@ def RuntimeVerifiableOpInterface : OpInterface<"RuntimeVerifiableOpInterface"> {
       /*retTy=*/"void",
       /*methodName=*/"generateRuntimeVerification",
       /*args=*/(ins "::mlir::OpBuilder &":$builder,
-                    "::mlir::Location":$loc)
+                    "::mlir::Location":$loc,
+                    "function_ref<std::string(Operation *, StringRef)>":$generateErrorMessage)
     >,
   ];
 
-  let extraClassDeclaration = [{
-    /// Generate the error message that will be printed to the user when 
-    /// verification fails.
-    static std::string generateErrorMessage(Operation *op, const std::string &msg);
-  }];
 }
 
 #endif // MLIR_INTERFACES_RUNTIMEVERIFIABLEOPINTERFACE

--- a/mlir/include/mlir/Transforms/Passes.h
+++ b/mlir/include/mlir/Transforms/Passes.h
@@ -47,6 +47,7 @@ class GreedyRewriteConfig;
 #define GEN_PASS_DECL_TOPOLOGICALSORT
 #define GEN_PASS_DECL_COMPOSITEFIXEDPOINTPASS
 #define GEN_PASS_DECL_BUBBLEDOWNMEMORYSPACECASTS
+#define GEN_PASS_DECL_GENERATERUNTIMEVERIFICATION
 #include "mlir/Transforms/Passes.h.inc"
 
 /// Creates an instance of the Canonicalizer pass, configured with default

--- a/mlir/include/mlir/Transforms/Passes.td
+++ b/mlir/include/mlir/Transforms/Passes.td
@@ -270,7 +270,14 @@ def GenerateRuntimeVerification : Pass<"generate-runtime-verification"> {
     passes that are suspected to introduce faulty IR.
   }];
   let constructor = "mlir::createGenerateRuntimeVerificationPass()";
+  let options = [
+    Option<"verboseLevel", "verbose-level", "unsigned", /*default=*/"1",
+           "Verbosity level for runtime verification messages: "
+           "0 = Minimum (only source location), "
+           "1 = Detailed (include full operation details, names, types, shapes, etc.)">
+  ];
 }
+
 
 def Inliner : Pass<"inline"> {
   let summary = "Inline function calls";

--- a/mlir/lib/Interfaces/RuntimeVerifiableOpInterface.cpp
+++ b/mlir/lib/Interfaces/RuntimeVerifiableOpInterface.cpp
@@ -8,31 +8,5 @@
 
 #include "mlir/Interfaces/RuntimeVerifiableOpInterface.h"
 
-namespace mlir {
-class Location;
-class OpBuilder;
-
-/// Generate an error message string for the given op and the specified error.
-std::string
-RuntimeVerifiableOpInterface::generateErrorMessage(Operation *op,
-                                                   const std::string &msg) {
-  std::string buffer;
-  llvm::raw_string_ostream stream(buffer);
-  OpPrintingFlags flags;
-  // We may generate a lot of error messages and so we need to ensure the
-  // printing is fast.
-  flags.elideLargeElementsAttrs();
-  flags.printGenericOpForm();
-  flags.skipRegions();
-  flags.useLocalScope();
-  stream << "ERROR: Runtime op verification failed\n";
-  op->print(stream, flags);
-  stream << "\n^ " << msg;
-  stream << "\nLocation: ";
-  op->getLoc().print(stream);
-  return buffer;
-}
-} // namespace mlir
-
 /// Include the definitions of the interface.
 #include "mlir/Interfaces/RuntimeVerifiableOpInterface.cpp.inc"

--- a/mlir/lib/Transforms/GenerateRuntimeVerification.cpp
+++ b/mlir/lib/Transforms/GenerateRuntimeVerification.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/IR/AsmState.h"
 #include "mlir/Transforms/Passes.h"
 
 #include "mlir/IR/Builders.h"
@@ -25,9 +26,51 @@ struct GenerateRuntimeVerificationPass
           GenerateRuntimeVerificationPass> {
   void runOnOperation() override;
 };
+
+/// Default error message generator for runtime verification failures.
+///
+/// This class generates error messages with different levels of verbosity:
+/// - Level 0: Shows only the error message and operation location
+/// - Level 1: Shows the full operation string, error message, and location
+///
+/// Clients can call getVerboseLevel() to retrieve the current verbose level
+/// and use it to customize their own error message generators with similar
+/// behavior patterns.
+class DefaultErrMsgGenerator {
+private:
+  unsigned vLevel;
+  AsmState &state;
+
+public:
+  DefaultErrMsgGenerator(unsigned verboseLevel, AsmState &asmState)
+      : vLevel(verboseLevel), state(asmState) {}
+
+  std::string operator()(Operation *op, StringRef msg) {
+    std::string buffer;
+    llvm::raw_string_ostream stream(buffer);
+    stream << "ERROR: Runtime op verification failed\n";
+    if (vLevel == 1) {
+      op->print(stream, state);
+      stream << "\n";
+    }
+    stream << "^\nLocation: ";
+    op->getLoc().print(stream);
+    return buffer;
+  }
+
+  unsigned getVerboseLevel() const { return vLevel; }
+};
 } // namespace
 
 void GenerateRuntimeVerificationPass::runOnOperation() {
+  // Check verboseLevel is in range [0, 1].
+  if (verboseLevel > 1) {
+    getOperation()->emitError(
+        "generate-runtime-verification pass: set verboseLevel to 0 or 1");
+    signalPassFailure();
+    return;
+  }
+
   // The implementation of the RuntimeVerifiableOpInterface may create ops that
   // can be verified. We don't want to generate verification for IR that
   // performs verification, so gather all runtime-verifiable ops first.
@@ -36,10 +79,22 @@ void GenerateRuntimeVerificationPass::runOnOperation() {
     ops.push_back(verifiableOp);
   });
 
+  // We may generate a lot of error messages and so we need to ensure the
+  // printing is fast.
+  OpPrintingFlags flags;
+  flags.elideLargeElementsAttrs();
+  flags.skipRegions();
+  flags.useLocalScope();
+  AsmState state(getOperation(), flags);
+
+  // Client can call getVerboseLevel() to fetch verbose level.
+  DefaultErrMsgGenerator defaultErrMsgGenerator(verboseLevel.getValue(), state);
+
   OpBuilder builder(getOperation()->getContext());
   for (RuntimeVerifiableOpInterface verifiableOp : ops) {
     builder.setInsertionPoint(verifiableOp);
-    verifiableOp.generateRuntimeVerification(builder, verifiableOp.getLoc());
+    verifiableOp.generateRuntimeVerification(builder, verifiableOp.getLoc(),
+                                             defaultErrMsgGenerator);
   };
 }
 

--- a/mlir/test/Dialect/Linalg/runtime-verification.mlir
+++ b/mlir/test/Dialect/Linalg/runtime-verification.mlir
@@ -1,13 +1,18 @@
 // RUN: mlir-opt %s -generate-runtime-verification | FileCheck %s
+// RUN: mlir-opt %s --generate-runtime-verification="verbose-level=0" | FileCheck %s --check-prefix=VERBOSE0
 
 // Most of the tests for linalg runtime-verification are implemented as integration tests.
 
 #identity = affine_map<(d0) -> (d0)>
 
 // CHECK-LABEL: @static_dims
+// VERBOSE0-LABEL: @static_dims
 func.func @static_dims(%arg0: tensor<5xf32>, %arg1: tensor<5xf32>) -> (tensor<5xf32>) {
     // CHECK: %[[TRUE:.*]] = index.bool.constant true
     // CHECK: cf.assert %[[TRUE]]
+    // VERBOSE0: %[[TRUE:.*]] = index.bool.constant true
+    // VERBOSE0: cf.assert %[[TRUE]]
+    // VERBOSE0-SAME: ERROR: Runtime op verification failed\0A^\0ALocation: loc(
     %result = tensor.empty() : tensor<5xf32> 
     %0 = linalg.generic {
       indexing_maps = [#identity, #identity, #identity],
@@ -26,9 +31,11 @@ func.func @static_dims(%arg0: tensor<5xf32>, %arg1: tensor<5xf32>) -> (tensor<5x
 #map = affine_map<() -> ()>
 
 // CHECK-LABEL: @scalars
+// VERBOSE1-LABEL: @scalars
 func.func @scalars(%arg0: tensor<f32>, %arg1: tensor<f32>) -> (tensor<f32>) {
     // No runtime checks are required if the operands are all scalars
     // CHECK-NOT: cf.assert
+    // VERBOSE1-NOT: cf.assert
     %result = tensor.empty() : tensor<f32> 
     %0 = linalg.generic {
       indexing_maps = [#map, #map, #map],


### PR DESCRIPTION
The pass generate-runtime-verification generates additional runtime op verification checks.

Currently, the pass is extremely expensive. For example, with a mobilenet v2 ssd network(converted to mlir), running this pass alone in debug mode will take 30 minutes. The same observation has been made to other networks as small as 5 Mb.

The culprit is this line "op->print(stream, flags);" in function "RuntimeVerifiableOpInterface::generateErrorMessage" in File mlir/lib/Interfaces/RuntimeVerifiableOpInterface.cpp.

As we are printing the op with all the names of the operands in the middle end, we are constructing a new SSANameState for each op->print(...) call. Thus, we are doing a new SSA analysis for each error message printed.

Perf profiling shows that 98% percent of the time is spent in the constructor of SSANameState.

This change refactored the message generator. We use a toplevel AsmState, and reuse it with all the op-print(stream, asmState). With a release build, this change reduces the pass exeuction time from ~160 seconds to 0.3 seconds on my machine. 

This change also adds verbose options to  generate-runtime-verification pass. 
verbose 0: print only source location with error message.
verbose 1: print the full op, including the name of the operands.
