### PR TITLE
[lldb][test] check if CoreDumping info is supported

### DIFF
--- a/lldb/unittests/Host/posix/HostTest.cpp
+++ b/lldb/unittests/Host/posix/HostTest.cpp
@@ -120,7 +120,7 @@ TEST_F(HostTest, GetProcessInfoSetsPriority) {
   ASSERT_TRUE(Info.IsZombie().has_value());
   ASSERT_FALSE(Info.IsZombie().value());
 
-  // CoreDumping was added in kernel version 4.15 
+  // CoreDumping was added in kernel version 4.15.
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
   ASSERT_TRUE(Info.IsCoreDumping().has_value());
   ASSERT_FALSE(Info.IsCoreDumping().value());

--- a/lldb/unittests/Host/posix/HostTest.cpp
+++ b/lldb/unittests/Host/posix/HostTest.cpp
@@ -15,6 +15,10 @@
 #include <cerrno>
 #include <sys/resource.h>
 
+#ifdef __linux__
+#include <linux/version.h>
+#endif // __linux__
+
 using namespace lldb_private;
 
 namespace {
@@ -116,7 +120,12 @@ TEST_F(HostTest, GetProcessInfoSetsPriority) {
   ASSERT_TRUE(Info.IsZombie().has_value());
   ASSERT_FALSE(Info.IsZombie().value());
 
+  // CoreDumping was added in kernel version 4.15 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
   ASSERT_TRUE(Info.IsCoreDumping().has_value());
   ASSERT_FALSE(Info.IsCoreDumping().value());
+#else
+  ASSERT_FALSE(Info.IsCoreDumping().has_value());
+#endif
 }
 #endif


### PR DESCRIPTION
CoreDumping in /proc/pid/stat was added in kernel 4.15, this causes the test to fail in older kernel versions. see https://man7.org/linux/man-pages/man5/proc_pid_status.5.html