### PR TITLE
[compiler-rt] Remove temporary directories from lit tests

### DIFF
--- a/compiler-rt/test/asan/TestCases/Linux/odr-violation.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/odr-violation.cpp
@@ -10,39 +10,38 @@
 // -fno-sanitize-address-use-odr-indicator turns off both.
 //
 // Different size: detect a bug if detect_odr_violation>=1
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -g -DBUILD_SO=1 -fPIC -shared -fno-sanitize-address-use-odr-indicator %s -o %dynamiclib
-// RUN: %clangxx_asan -g -fno-sanitize-address-use-odr-indicator %s %ld_flags_rpath_exe -o %t.dir/ODR-EXE
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=1 not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2 not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=0     %run %t.dir/ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0                        not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -g -fno-sanitize-address-use-odr-indicator %s %ld_flags_rpath_exe -o %t-ODR-EXE
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=1 not %run %t-ODR-EXE 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2 not %run %t-ODR-EXE 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=0     %run %t-ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0                        not %run %t-ODR-EXE 2>&1 | FileCheck %s
 //
 // Same size: report a bug only if detect_odr_violation>=2.
 // RUN: %clangxx_asan -g -DBUILD_SO=1 -fPIC -shared -fno-sanitize-address-use-odr-indicator %s -o %dynamiclib -DSZ=100
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=1     %run %t.dir/ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2 not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0                        not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
-// RUN: echo "odr_violation:foo::ZZZ" > %t.dir/supp
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2:suppressions=%t.dir/supp  not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
-// RUN: echo "odr_violation:foo::G" > %t.dir/supp
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2:suppressions=%t.dir/supp      %run %t.dir/ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
-// RUN: rm -f %t.dir/supp
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=1     %run %t-ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2 not %run %t-ODR-EXE 2>&1 | FileCheck %s
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0                        not %run %t-ODR-EXE 2>&1 | FileCheck %s
+// RUN: echo "odr_violation:foo::ZZZ" > %t.supp
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2:suppressions=%t.supp  not %run %t-ODR-EXE 2>&1 | FileCheck %s
+// RUN: echo "odr_violation:foo::G" > %t.supp
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0:detect_odr_violation=2:suppressions=%t.supp      %run %t-ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
+// RUN: rm -f %t.supp
 //
 // Use private aliases for global variables without indicator symbol.
 // RUN: %clangxx_asan -g -DBUILD_SO=1 -fPIC -shared -mllvm -asan-use-odr-indicator=0 %s -o %dynamiclib -DSZ=100
-// RUN: %clangxx_asan -g -mllvm -asan-use-odr-indicator=0 %s %ld_flags_rpath_exe -o %t.dir/ODR-EXE
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0 %run %t.dir/ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
+// RUN: %clangxx_asan -g -mllvm -asan-use-odr-indicator=0 %s %ld_flags_rpath_exe -o %t-ODR-EXE
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0 %run %t-ODR-EXE 2>&1 | FileCheck %s --check-prefix=DISABLED
 
 // Use private aliases for global variables: use indicator symbol to detect ODR violation.
 // RUN: %clangxx_asan -g -DBUILD_SO=1 -fPIC -shared %s -o %dynamiclib -DSZ=100
-// RUN: %clangxx_asan -g %s %ld_flags_rpath_exe -o %t.dir/ODR-EXE
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0 not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -g %s %ld_flags_rpath_exe -o %t-ODR-EXE
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0 not %run %t-ODR-EXE 2>&1 | FileCheck %s
 
 // Same as above but with clang switches.
 // RUN: %clangxx_asan -g -DBUILD_SO=1 -fPIC -shared -fsanitize-address-use-odr-indicator %s -o %dynamiclib -DSZ=100
-// RUN: %clangxx_asan -g -fsanitize-address-use-odr-indicator %s %ld_flags_rpath_exe -o %t.dir/ODR-EXE
-// RUN: %env_asan_opts=fast_unwind_on_malloc=0 not %run %t.dir/ODR-EXE 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -g -fsanitize-address-use-odr-indicator %s %ld_flags_rpath_exe -o %t-ODR-EXE
+// RUN: %env_asan_opts=fast_unwind_on_malloc=0 not %run %t-ODR-EXE 2>&1 | FileCheck %s
 
 // GNU driver doesn't handle .so files properly.
 // REQUIRES: Clang
@@ -59,7 +58,7 @@ namespace foo { char G[SZ]; }
 #include <stdio.h>
 namespace foo { char G[100]; }
 // CHECK: ERROR: AddressSanitizer: odr-violation
-// CHECK: size=100 'foo::G' {{.*}}odr-violation.cpp:[[@LINE-2]] in {{.*}}/ODR-EXE
+// CHECK: size=100 'foo::G' {{.*}}odr-violation.cpp:[[@LINE-2]] in {{.*}}ODR-EXE
 // CHECK: size={{4|100}} 'foo::G'
 int main(int argc, char **argv) {
   printf("PASS: %p\n", &foo::G);
@@ -67,7 +66,7 @@ int main(int argc, char **argv) {
 #endif
 
 // CHECK: These globals were registered at these points:
-// CHECK: {{odr-violation.cpp|ODR-EXE}}
+// CHECK: {{odr-violation.cpp|.*ODR-EXE}}
 // CHECK: odr-violation.cpp{{$}}
 // CHECK: SUMMARY: AddressSanitizer: odr-violation: global 'foo::G' at {{.*}}odr-violation.cpp
 // DISABLED: PASS

--- a/compiler-rt/test/asan/TestCases/Linux/preinit_test.cpp
+++ b/compiler-rt/test/asan/TestCases/Linux/preinit_test.cpp
@@ -1,7 +1,6 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -DFUNC=zzzz %s -shared -o %dynamiclib -fPIC
-// RUN: %clangxx_asan -DFUNC=main %s -o %t.dir/EXE %ld_flags_rpath_exe
-// RUN: %run %t.dir/EXE
+// RUN: %clangxx_asan -DFUNC=main %s -o %t-EXE %ld_flags_rpath_exe
+// RUN: %run %t-EXE
 
 // GNU driver doesn't handle .so files properly.
 // REQUIRES: Clang

--- a/compiler-rt/test/asan/TestCases/Posix/coverage-reset.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage-reset.cpp
@@ -1,7 +1,6 @@
-// RUN: rm -rf %t.dir && mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard -DSHARED %s -shared -o %dynamiclib -fPIC %ld_flags_rpath_so
-// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %ld_flags_rpath_exe -o %t.dir/EXE
-// RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t.dir/EXE 2>&1 | tee /tmp/test
+// RUN: %clangxx_asan -fsanitize-coverage=func,trace-pc-guard %s %ld_flags_rpath_exe -o %t-EXE
+// RUN: %env_asan_opts=coverage=1:verbosity=1 %run %t-EXE 2>&1 | tee /tmp/test
 //
 // UNSUPPORTED: ios
 

--- a/compiler-rt/test/asan/TestCases/Posix/interception-in-shared-lib-test.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/interception-in-shared-lib-test.cpp
@@ -1,9 +1,8 @@
 // Check that memset() call from a shared library gets intercepted.
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_asan -O0 %s -DSHARED_LIB \
 // RUN:     -shared -o %dynamiclib -fPIC %ld_flags_rpath_so
-// RUN: %clangxx_asan -O0 %s -o %t.dir/EXE %ld_flags_rpath_exe && \
-// RUN:     not %run %t.dir/EXE 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -O0 %s -o %t-EXE %ld_flags_rpath_exe && \
+// RUN:     not %run %t-EXE 2>&1 | FileCheck %s
 
 #include <stdio.h>
 #include <string.h>

--- a/compiler-rt/test/cfi/cross-dso-diagnostic.cpp
+++ b/compiler-rt/test/cfi/cross-dso-diagnostic.cpp
@@ -1,9 +1,8 @@
 // Check that cross-DSO diagnostics print the names of both modules
 
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_diag -g -DSHARED_LIB -fPIC -shared -o %dynamiclib %s %ld_flags_rpath_so
-// RUN: %clangxx_cfi_diag -g -o %t.dir/file_exe_suffix %s %ld_flags_rpath_exe
-// RUN: %t.dir/file_exe_suffix 2>&1 | FileCheck -DDSONAME=%xdynamiclib_namespec %s
+// RUN: %clangxx_cfi_diag -g -o %t-file_exe_suffix %s %ld_flags_rpath_exe
+// RUN: %t-file_exe_suffix 2>&1 | FileCheck -DDSONAME=%xdynamiclib_namespec %s
 
 // UNSUPPORTED: target={{.*windows-msvc.*}}
 // REQUIRES: cxxabi

--- a/compiler-rt/test/cfi/cross-dso/icall/icall-from-dso.cpp
+++ b/compiler-rt/test/cfi/cross-dso/icall/icall-from-dso.cpp
@@ -1,9 +1,8 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso %s -o %t.dir/exe %ld_flags_rpath_exe && %expect_crash %t.dir/exe 2>&1 | FileCheck %s
+// RUN: %clangxx_cfi_dso %s -o %t-exe %ld_flags_rpath_exe && %expect_crash %t-exe 2>&1 | FileCheck %s
 
 // RUN: %clangxx_cfi_dso_diag -g -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso_diag -g %s -o %t.dir/exe %ld_flags_rpath_exe && %t.dir/exe 2>&1 | FileCheck %s --check-prefix=CFI-DIAG
+// RUN: %clangxx_cfi_dso_diag -g %s -o %t-exe %ld_flags_rpath_exe && %t-exe 2>&1 | FileCheck %s --check-prefix=CFI-DIAG
 
 #include <stdio.h>
 

--- a/compiler-rt/test/cfi/cross-dso/icall/icall.cpp
+++ b/compiler-rt/test/cfi/cross-dso/icall/icall.cpp
@@ -1,9 +1,8 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso %s -o %t.dir/exe %ld_flags_rpath_exe && %expect_crash %t.dir/exe 2>&1 | FileCheck %s
+// RUN: %clangxx_cfi_dso %s -o %t-exe %ld_flags_rpath_exe && %expect_crash %t-exe 2>&1 | FileCheck %s
 
 // RUN: %clangxx_cfi_dso_diag -g -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso_diag -g %s -o %t.dir/exe %ld_flags_rpath_exe && %t.dir/exe 2>&1 | FileCheck %s --check-prefix=CFI-DIAG
+// RUN: %clangxx_cfi_dso_diag -g %s -o %t-exe %ld_flags_rpath_exe && %t-exe 2>&1 | FileCheck %s --check-prefix=CFI-DIAG
 
 #include <stdio.h>
 

--- a/compiler-rt/test/cfi/cross-dso/simple-fail.cpp
+++ b/compiler-rt/test/cfi/cross-dso/simple-fail.cpp
@@ -1,38 +1,37 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %expect_crash %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
-// RUN: %expect_crash %t.dir/exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
+// RUN: %clangxx_cfi_dso %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %expect_crash %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %expect_crash %t-exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
 
 // RUN: %clangxx_cfi_dso -DB32 -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DB32 %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %expect_crash %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
-// RUN: %expect_crash %t.dir/exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
+// RUN: %clangxx_cfi_dso -DB32 %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %expect_crash %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %expect_crash %t-exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
 
 // RUN: %clangxx_cfi_dso -DB64 -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DB64 %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %expect_crash %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
-// RUN: %expect_crash %t.dir/exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
+// RUN: %clangxx_cfi_dso -DB64 %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %expect_crash %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %expect_crash %t-exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
 
 // RUN: %clangxx_cfi_dso -DBM -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DBM %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %expect_crash %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
-// RUN: %expect_crash %t.dir/exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
+// RUN: %clangxx_cfi_dso -DBM %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %expect_crash %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %expect_crash %t-exe x 2>&1 | FileCheck --check-prefix=CFI-CAST %s
 
 // RUN: %clangxx -DBM -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx -DBM %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=NCFI %s
-// RUN: %t.dir/exe x 2>&1 | FileCheck --check-prefix=NCFI %s
+// RUN: %clangxx -DBM %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=NCFI %s
+// RUN: %t-exe x 2>&1 | FileCheck --check-prefix=NCFI %s
 
 // RUN: %clangxx -DBM -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DBM %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=NCFI %s
-// RUN: %t.dir/exe x 2>&1 | FileCheck --check-prefix=NCFI %s
+// RUN: %clangxx_cfi_dso -DBM %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=NCFI %s
+// RUN: %t-exe x 2>&1 | FileCheck --check-prefix=NCFI %s
 
 // RUN: %clangxx_cfi_dso_diag -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso_diag %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI-DIAG-CALL %s
-// RUN: %t.dir/exe x 2>&1 | FileCheck --check-prefix=CFI-DIAG-CALL --check-prefix=CFI-DIAG-CAST %s
+// RUN: %clangxx_cfi_dso_diag %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=CFI-DIAG-CALL %s
+// RUN: %t-exe x 2>&1 | FileCheck --check-prefix=CFI-DIAG-CALL --check-prefix=CFI-DIAG-CAST %s
 
 // Tests that the CFI mechanism crashes the program when making a virtual call
 // to an object of the wrong class but with a compatible vtable, by casting a

--- a/compiler-rt/test/cfi/cross-dso/simple-pass.cpp
+++ b/compiler-rt/test/cfi/cross-dso/simple-pass.cpp
@@ -1,24 +1,23 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx_cfi_dso -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -g %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %clangxx_cfi_dso -g %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
 
 // RUN: %clangxx_cfi_dso -DB32 -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DB32 %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %clangxx_cfi_dso -DB32 %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
 
 // RUN: %clangxx_cfi_dso -DB64 -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DB64 %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %clangxx_cfi_dso -DB64 %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
 
 // RUN: %clangxx_cfi_dso -DBM -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_dso -DBM %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=CFI %s
+// RUN: %clangxx_cfi_dso -DBM %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=CFI %s
 
 // RUN: %clangxx -DBM -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx -DBM %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %t.dir/exe 2>&1 | FileCheck --check-prefix=NCFI %s
-// RUN: %t.dir/exe x 2>&1 | FileCheck --check-prefix=NCFI %s
+// RUN: %clangxx -DBM %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %t-exe 2>&1 | FileCheck --check-prefix=NCFI %s
+// RUN: %t-exe x 2>&1 | FileCheck --check-prefix=NCFI %s
 
 // Tests that the CFI mechanism crashes the program when making a virtual call
 // to an object of the wrong class but with a compatible vtable, by casting a

--- a/compiler-rt/test/cfi/target_uninstrumented.cpp
+++ b/compiler-rt/test/cfi/target_uninstrumented.cpp
@@ -1,7 +1,6 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -g -DSHARED_LIB %s -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx_cfi_diag -g %s -o %t.dir/EXE %ld_flags_rpath_exe
-// RUN: %run %t.dir/EXE 2>&1 | FileCheck %s
+// RUN: %clangxx_cfi_diag -g %s -o %t-EXE %ld_flags_rpath_exe
+// RUN: %run %t-EXE 2>&1 | FileCheck %s
 
 // REQUIRES: cxxabi
 // UNSUPPORTED: target={{.*windows-msvc.*}}

--- a/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
+++ b/compiler-rt/test/tsan/on_initialize_finalize_hooks.cpp
@@ -1,7 +1,6 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clang_tsan -O1 %s -DBUILD_LIB=1 -fno-sanitize=thread -shared -fPIC -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clang_tsan -O1 %s -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %run %t.dir/exe | FileCheck %s
+// RUN: %clang_tsan -O1 %s -o %t-exe %ld_flags_rpath_exe
+// RUN: %run %t-exe | FileCheck %s
 
 // Test that initialization/finalization hooks are called, even when they are
 // not defined in the main executable, but by another another library that

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/function.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/function.cpp
@@ -1,9 +1,8 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -std=c++17 -fsanitize=function %s -O3 -g -DSHARED_LIB -fPIC -shared -o %dynamiclib %ld_flags_rpath_so
-// RUN: %clangxx -std=c++17 -fsanitize=function %s -O3 -g -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %run %t.dir/exe 2>&1 | FileCheck %s --check-prefix=CHECK
+// RUN: %clangxx -std=c++17 -fsanitize=function %s -O3 -g -o %t-exe %ld_flags_rpath_exe
+// RUN: %run %t-exe 2>&1 | FileCheck %s --check-prefix=CHECK
 // Verify that we can disable symbolization if needed:
-// RUN: %env_ubsan_opts=symbolize=0 %run %t.dir/exe 2>&1 | FileCheck %s --check-prefix=NOSYM
+// RUN: %env_ubsan_opts=symbolize=0 %run %t-exe 2>&1 | FileCheck %s --check-prefix=NOSYM
 
 struct Shared {};
 using FnShared = void (*)(Shared *);

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/vptr-non-unique-typeinfo.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/vptr-non-unique-typeinfo.cpp
@@ -1,7 +1,6 @@
-// RUN: mkdir -p %t.dir && cd %t.dir
 // RUN: %clangxx -frtti -fsanitize=vptr -fno-sanitize-recover=vptr -I%p/Helpers -g %s -fPIC -shared -o %dynamiclib -DBUILD_SO %ld_flags_rpath_so
-// RUN: %clangxx -frtti -fsanitize=vptr -fno-sanitize-recover=vptr -I%p/Helpers -g %s -O3 -o %t.dir/exe %ld_flags_rpath_exe
-// RUN: %run %t.dir/exe
+// RUN: %clangxx -frtti -fsanitize=vptr -fno-sanitize-recover=vptr -I%p/Helpers -g %s -O3 -o %t-exe %ld_flags_rpath_exe
+// RUN: %run %t-exe
 //
 // REQUIRES: cxxabi
 // FIXME: Should pass on Android, but started failing around 2023-11-05 for unknown reasons.


### PR DESCRIPTION
This patch removes  substitutions that create temporary directories to house executables in.

This is a continuation of the changes in #155302