### PR TITLE
[z.OS] fix strnlen() usage in Context.cpp available on z/OS

### DIFF
--- a/clang/lib/AST/ByteCode/Context.cpp
+++ b/clang/lib/AST/ByteCode/Context.cpp
@@ -18,6 +18,7 @@
 #include "clang/AST/ASTLambda.h"
 #include "clang/AST/Expr.h"
 #include "clang/Basic/TargetInfo.h"
+#include "llvm/Support/SystemZ/zOSSupport.h"
 
 using namespace clang;
 using namespace clang::interp;


### PR DESCRIPTION
On z/OS `strnlen()` is not available by default so we use the wrapper header `zOSSupport.h` to make it visible. This will fix the following error:

```
clang/lib/AST/ByteCode/Context.cpp:250:16: error: use of undeclared identifier 'strnlen'
  250 |       Result = strnlen(reinterpret_cast<const char *>(Ptr.getRawAddress()), N);
      |                ^~~~~~~
1 error generated.
```