### PR TITLE
[Clang][Driver][LLVM] Add -fno-inline-functions-called-once; expose p…

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6959,8 +6959,12 @@ defm merge_constants : BooleanFFlag<"merge-constants">, Group<clang_ignored_gcc_
 defm modulo_sched : BooleanFFlag<"modulo-sched">, Group<clang_ignored_gcc_optimization_f_Group>;
 defm modulo_sched_allow_regmoves : BooleanFFlag<"modulo-sched-allow-regmoves">,
     Group<clang_ignored_gcc_optimization_f_Group>;
-defm inline_functions_called_once : BooleanFFlag<"inline-functions-called-once">,
-    Group<clang_ignored_gcc_optimization_f_Group>;
+defm inline_functions_called_once
+  : BooleanFFlag<"inline-functions-called-once">,
+    Group<f_clang_Group>,
+    Visibility<[ClangOption, CC1Option]>,
+    HelpText<"Control inlining of TU-local functions called exactly once "
+             "(use -fno-inline-functions-called-once to inhibit it)">;
 def finline_limit_EQ : Joined<["-"], "finline-limit=">, Group<clang_ignored_gcc_optimization_f_Group>;
 defm finline_limit : BooleanFFlag<"inline-limit">, Group<clang_ignored_gcc_optimization_f_Group>;
 defm inline_small_functions : BooleanFFlag<"inline-small-functions">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7266,6 +7266,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_finline_max_stacksize_EQ);
 
+  // Forward -fno-inline-functions-called-once to LLVM so the pass is enabled.
+  if (Args.hasArg(options::OPT_fno_inline_functions_called_once)) {
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back("-no-inline-functions-called-once");
+  }
+
   // FIXME: Find a better way to determine whether we are in C++20.
   bool HaveCxx20 =
       Std &&

--- a/clang/test/CodeGen/no-inline-func-called-once.c
+++ b/clang/test/CodeGen/no-inline-func-called-once.c
@@ -1,0 +1,32 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang -O1 -S -emit-llvm %s -fno-inline-functions-called-once -o - | FileCheck %s --check-prefix=NOINLINE
+
+// We verify three things:
+//   1) There is a surviving call to bad_function (so it wasn’t inlined).
+//   2) bad_function’s definition exists and carries an attribute group id.
+//   3) That attribute group includes 'noinline'.
+
+// The call is earlier in the IR than the callee/attributes, so use -DAG for the
+// first two checks to avoid order constraints, then pin the attributes match.
+
+// NOINLINE-DAG: call{{.*}} @bad_function{{.*}}
+// NOINLINE-DAG: define internal{{.*}} @bad_function{{.*}} #[[ATTR:[0-9]+]]
+// NOINLINE: attributes #[[ATTR]] = { {{.*}}noinline{{.*}} }
+
+volatile int G;
+
+static void bad_function(void) {
+  // Volatile side effect ensures the call can’t be DCE’d.
+  G++;
+}
+
+static void test(void) {
+  // Exactly one TU-local caller of bad_function.
+  bad_function();
+}
+
+int main(void) {
+  // Make the caller reachable so it survives global DCE.
+  test();
+  return 0;
+}

--- a/clang/test/Driver/clang_f_opts.c
+++ b/clang/test/Driver/clang_f_opts.c
@@ -277,7 +277,6 @@
 // RUN:     -fgcse-las                                                        \
 // RUN:     -fgcse-sm                                                         \
 // RUN:     -fipa-cp                                                          \
-// RUN:     -finline-functions-called-once                                    \
 // RUN:     -fmodulo-sched                                                    \
 // RUN:     -fmodulo-sched-allow-regmoves                                     \
 // RUN:     -fpeel-loops                                                      \
@@ -349,7 +348,6 @@
 // RUN: -fgcse-las                                                            \
 // RUN: -fgcse-sm                                                             \
 // RUN: -fipa-cp                                                              \
-// RUN: -finline-functions-called-once                                        \
 // RUN: -fmodulo-sched                                                        \
 // RUN: -fmodulo-sched-allow-regmoves                                         \
 // RUN: -fpeel-loops                                                          \
@@ -409,7 +407,6 @@
 // CHECK-WARNING-DAG: optimization flag '-fgcse-las' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fgcse-sm' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fipa-cp' is not supported
-// CHECK-WARNING-DAG: optimization flag '-finline-functions-called-once' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fmodulo-sched' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fmodulo-sched-allow-regmoves' is not supported
 // CHECK-WARNING-DAG: optimization flag '-fpeel-loops' is not supported

--- a/clang/test/Driver/fno-inline-functions-called-once.c
+++ b/clang/test/Driver/fno-inline-functions-called-once.c
@@ -1,0 +1,20 @@
+// REQUIRES: x86-registered-target
+
+// Check that -fno-inline-functions-called-once is forwarded to LLVM.
+// RUN: %clang -### -S %s -fno-inline-functions-called-once 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=FWD
+// FWD: "-mllvm" "-no-inline-functions-called-once"
+
+// Check that the positive form does NOT forward anything to -mllvm.
+// RUN: %clang -### -S %s -finline-functions-called-once 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=POS
+// POS-NOT: -mllvm
+// POS-NOT: -no-inline-functions-called-once
+
+// Help text should show both flags (order-independent).
+// RUN: %clang --help 2>&1 | FileCheck %s --check-prefix=HELP
+// HELP-DAG: -finline-functions-called-once
+// HELP-DAG: -fno-inline-functions-called-once
+
+int x;
+

--- a/llvm/include/llvm/Transforms/IPO/NoInlineFuncCalledOnce.h
+++ b/llvm/include/llvm/Transforms/IPO/NoInlineFuncCalledOnce.h
@@ -1,0 +1,18 @@
+#ifndef LLVM_TRANSFORMS_IPO_NOINLINEFUNCCALLEDONCE_H
+#define LLVM_TRANSFORMS_IPO_NOINLINEFUNCCALLEDONCE_H
+
+#include "llvm/IR/PassManager.h"
+#include "llvm/Support/CommandLine.h"
+
+namespace llvm {
+
+struct NoInlineFuncCalledOncePass
+    : public PassInfoMixin<NoInlineFuncCalledOncePass> {
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+};
+
+// single definition of the control flag lives in the .cpp (declared here)
+extern cl::opt<bool> EnableNoInlineFuncCalledOnce;
+
+} // namespace llvm
+#endif

--- a/llvm/lib/Transforms/IPO/CMakeLists.txt
+++ b/llvm/lib/Transforms/IPO/CMakeLists.txt
@@ -33,6 +33,7 @@ add_llvm_component_library(LLVMipo
   MemProfContextDisambiguation.cpp
   MergeFunctions.cpp
   ModuleInliner.cpp
+  NoInlineFuncCalledOnce.cpp
   OpenMPOpt.cpp
   PartialInlining.cpp
   SampleContextTracker.cpp

--- a/llvm/lib/Transforms/IPO/NoInlineFuncCalledOnce.cpp
+++ b/llvm/lib/Transforms/IPO/NoInlineFuncCalledOnce.cpp
@@ -1,0 +1,62 @@
+#include "llvm/Transforms/IPO/NoInlineFuncCalledOnce.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace llvm;
+
+PreservedAnalyses NoInlineFuncCalledOncePass::run(Module &M,
+                                                  ModuleAnalysisManager &) {
+  DenseMap<Function *, unsigned> DirectCalls;
+  DenseSet<Function *> Recursive;
+
+  for (Function &F : M)
+    if (!F.isDeclaration() && (F.hasInternalLinkage() || F.hasPrivateLinkage()))
+      DirectCalls[&F] = 0;
+
+  for (Function &Caller : M) {
+    if (Caller.isDeclaration())
+      continue;
+    for (Instruction &I : instructions(Caller)) {
+      auto *CB = dyn_cast<CallBase>(&I);
+      if (!CB)
+        continue;
+      const Value *Op = CB->getCalledOperand()->stripPointerCasts();
+      if (auto *Callee = const_cast<Function *>(dyn_cast<Function>(Op))) {
+        if (!DirectCalls.count(Callee))
+          continue;
+        DirectCalls[Callee] += 1;
+        if (&Caller == Callee)
+          Recursive.insert(Callee);
+      }
+    }
+  }
+
+  bool Changed = false;
+  for (auto &KV : DirectCalls) {
+    Function *F = KV.first;
+    unsigned N = KV.second;
+
+    if (N != 1)
+      continue; // only called-once
+    if (Recursive.count(F))
+      continue; // skip recursion
+    if (F->hasAddressTaken())
+      continue; // skip address-taken
+    if (F->hasFnAttribute(Attribute::AlwaysInline))
+      continue;
+    if (F->hasFnAttribute(Attribute::NoInline))
+      continue;
+
+    F->addFnAttr(Attribute::NoInline);
+    Changed = true;
+  }
+
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}


### PR DESCRIPTION
…ositive form in --help

This wires the Clang driver boolean flag and forwards the negative form to LLVM as '-mllvm -no-inline-functions-called-once'. The positive form is exposed in --help (no backend flag forwarded). Default behavior is unchanged unless the flag is passed.

LLVM side: add the NoInlineFuncCalledOnce pass and thread the flag through PassBuilder pipelines.

Tests:
  - clang/test/Driver/fno_inline_functions_called_once.c
  - clang/test/CodeGen/no_inline_called_once.c

Also drops obsolete 'unsupported flag' expectations in clang/test/Driver/clang_f_opts.c.  

**Motivation**

**-fno-inline-functions-called-once** lets users keep TU-local, single-caller helpers as real calls even under -O2/-O3, preserving useful function boundaries without disabling other optimizations.

**Why this helps**

    - **Clearer debugging & reports:** Tiny helper frames often vanish when inlined, making ASan/UBSan/crash stacks point at the caller. Keeping the call preserves a distinct frame and symbol.
    - **Works with probes & profilers:** Tools that hook function entry (uprobes/DTrace/eBPF, perf) need a stable entry address; inlining removes it.
    - **Function-level coverage/profiling:** Some workflows aggregate by callee; inlining collapses data into the caller and adds noise across builds.
    - **Large / third-party code:** Sprinkling __attribute__((noinline)) is invasive and brittle as call counts change. A build switch applies the policy uniformly.
    - **Reproducibility in low-level code:** Inlining can shift register/stack layout and timing; keeping tiny helpers uninlined can stabilize repros while the rest remains optimized.

**Scope & risk**

    - Opt-in only (off by default).
    - Narrow effect: Only TU-local functions called exactly once are affected; other inlining heuristics are unchanged.

**Ecosystem parity**

    - GCC provides the same toggle (-f[no-]inline-functions-called-once), so this aligns Clang/LLVM with existing expectations.