### PR TITLE
[clang-doc] fix CSS, JS paths for HTML Mustache generation

### DIFF
--- a/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
+++ b/clang-tools-extra/clang-doc/HTMLMustacheGenerator.cpp
@@ -274,11 +274,12 @@ Error MustacheHTMLGenerator::generateDocForInfo(Info *I, raw_ostream &OS,
 }
 
 Error MustacheHTMLGenerator::createResources(ClangDocContext &CDCtx) {
+  std::string ResourcePath(CDCtx.OutDirectory + "/html");
   for (const auto &FilePath : CDCtx.UserStylesheets)
-    if (Error Err = copyFile(FilePath, CDCtx.OutDirectory))
+    if (Error Err = copyFile(FilePath, ResourcePath))
       return Err;
   for (const auto &FilePath : CDCtx.JsScripts)
-    if (Error Err = copyFile(FilePath, CDCtx.OutDirectory))
+    if (Error Err = copyFile(FilePath, ResourcePath))
       return Err;
   return Error::success();
 }


### PR DESCRIPTION
Resource creation not using the correct path after the patch that placed
HTML files into their own directory.