### PR TITLE
[bazel] Add llvm-remarkutil cc_binary

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -4970,6 +4970,22 @@ cc_binary(
 )
 
 cc_binary(
+    name = "llvm-remarkutil",
+    srcs = glob([
+        "tools/llvm-remarkutil/**/*.cpp",
+        "tools/llvm-remarkutil/**/*.h",
+    ]),
+    copts = llvm_copts,
+    includes = ["tools/llvm-remarkutil"],
+    stamp = 0,
+    deps = [
+        ":Demangle",
+        ":Remarks",
+        ":Support",
+    ],
+)
+
+cc_binary(
     name = "llvm-rtdyld",
     srcs = glob([
         "tools/llvm-rtdyld/*.cpp",


### PR DESCRIPTION
This is being used in some tests now such as [dfbd76bda01e804a66c3750193f5e766e4e4cf62](https://github.com/llvm/llvm-project/commit/dfbd76bda01e804a66c3750193f5e766e4e4cf62#diff-44281ca7d921d675879d00ac18d544d23029a65f813b1e401459789b4b4ca6f8)