### PR TITLE
[LLDB][PDB] Fix plugin warning message style

### DIFF
--- a/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/PDB/SymbolFilePDB.cpp
@@ -139,8 +139,8 @@ public:
     if (!IsNativeReaderRequested()) {
       static std::once_flag g_warning_shown;
       Debugger::ReportWarning(
-          "The DIA PDB reader was explicitly requested, but LLDB was built "
-          "without the DIA SDK. The native reader will be used instead.",
+          "the DIA PDB reader was explicitly requested, but LLDB was built "
+          "without the DIA SDK. The native reader will be used instead",
           {}, &g_warning_shown);
     }
     return true;

--- a/lldb/test/Shell/SymbolFile/NativePDB/native-setting.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/native-setting.cpp
@@ -38,7 +38,7 @@
 // NO-ENV: Dumping debug symbols for 1 modules.
 // NO-ENV: SymbolFile native-pdb
 
-// ENV0: warning: The DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead.
+// ENV0: warning: the DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead
 // ENV0: (lldb) target modules dump symfile
 // ENV0: Dumping debug symbols for 1 modules.
 // ENV0: SymbolFile native-pdb
@@ -48,12 +48,12 @@
 // ENV1: Dumping debug symbols for 1 modules.
 // ENV1: SymbolFile native-pdb
 
-// ENV0-SET-DIA: warning: The DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead.
+// ENV0-SET-DIA: warning: the DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead
 // ENV0-SET-DIA: (lldb) target modules dump symfile
 // ENV0-SET-DIA: Dumping debug symbols for 1 modules.
 // ENV0-SET-DIA: SymbolFile native-pdb
 
-// ENV1-SET-DIA: warning: The DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead.
+// ENV1-SET-DIA: warning: the DIA PDB reader was explicitly requested, but LLDB was built without the DIA SDK. The native reader will be used instead
 // ENV1-SET-DIA: (lldb) target modules dump symfile
 // ENV1-SET-DIA: Dumping debug symbols for 1 modules.
 // ENV1-SET-DIA: SymbolFile native-pdb


### PR DESCRIPTION
Makes the warning message conform to the [LLVM error and warning style](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) as mentioned in https://github.com/llvm/llvm-project/pull/160067#discussion_r2373391186.