### PR TITLE
[flang][acc] Support fir.convert in type categorization

### DIFF
--- a/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
+++ b/flang/lib/Optimizer/OpenACC/Support/FIROpenACCTypeInterfaces.cpp
@@ -365,6 +365,14 @@ getBaseRef(mlir::TypedValue<mlir::acc::PointerLikeType> varPtr) {
             // object, get the base object.
             return op.getRef();
           })
+          .Case<fir::ConvertOp>([&](auto op) -> mlir::Value {
+            // Strip the conversion and recursively check the operand
+            if (auto ptrLikeOperand = mlir::dyn_cast_if_present<
+                    mlir::TypedValue<mlir::acc::PointerLikeType>>(
+                    op.getValue()))
+              return getBaseRef(ptrLikeOperand);
+            return varPtr;
+          })
           .Default([&](mlir::Operation *) { return varPtr; });
 
   return baseRef;

--- a/flang/test/Fir/OpenACC/openacc-type-categories.mlir
+++ b/flang/test/Fir/OpenACC/openacc-type-categories.mlir
@@ -1,0 +1,36 @@
+// Use --mlir-disable-threading so that the diagnostic printing is serialized.
+// RUN: fir-opt %s -pass-pipeline='builtin.module(test-fir-openacc-interfaces)' -split-input-file --mlir-disable-threading 2>&1 | FileCheck %s
+
+module {
+  fir.global linkonce @test_string constant : !fir.char<1,26> {
+    %0 = fir.string_lit "hello_world_test_string\00"(26) : !fir.char<1,26>
+    fir.has_value %0 : !fir.char<1,26>
+  }
+
+  // Test global constant string with pointer conversion
+  func.func @_QPtest_global_string_ptr() {
+    %0 = fir.address_of(@test_string) : !fir.ref<!fir.char<1,26>>
+    %1 = fir.convert %0 : (!fir.ref<!fir.char<1,26>>) -> !fir.ref<i8>
+    %2 = acc.copyin varPtr(%1 : !fir.ref<i8>) -> !fir.ref<i8> {name = "test_string", structured = false}
+    acc.enter_data dataOperands(%2 : !fir.ref<i8>)
+    return
+  }
+
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<i8>) -> !fir.ref<i8> {name = "test_string", structured = false}
+  // CHECK: Pointer-like and Mappable: !fir.ref<i8>
+  // CHECK: Type category: nonscalar
+
+  // Test array with pointer conversion
+  func.func @_QPtest_alloca_array_ptr() {
+    %c10 = arith.constant 10 : index
+    %0 = fir.alloca !fir.array<10xf32> {bindc_name = "local_array", uniq_name = "_QFtest_alloca_array_ptrElocal_array"}
+    %1 = fir.convert %0 : (!fir.ref<!fir.array<10xf32>>) -> !fir.ref<i8>
+    %2 = acc.copyin varPtr(%1 : !fir.ref<i8>) -> !fir.ref<i8> {name = "local_array", structured = false}
+    acc.enter_data dataOperands(%2 : !fir.ref<i8>)
+    return
+  }
+
+  // CHECK: Visiting: %{{.*}} = acc.copyin varPtr(%{{.*}} : !fir.ref<i8>) -> !fir.ref<i8> {name = "local_array", structured = false}
+  // CHECK: Pointer-like and Mappable: !fir.ref<i8>
+  // CHECK: Type category: array
+}


### PR DESCRIPTION
Ensure that casting operations do not prevent mis-categorization. This pattern is seen when variables are casted to be passed by raw pointers. I encountered this problem because Fortran runtime calls take file name by pointer.