### PR TITLE
[lld][WebAssembly] Allow --import-memory to take single name

### DIFF
--- a/lld/test/wasm/memory-naming.test
+++ b/lld/test/wasm/memory-naming.test
@@ -65,6 +65,21 @@
 # CHECK-IMPORT-NEXT:        Index:           0
 # CHECK-IMPORT-NEXT:  - Type:
 
+# RUN:wasm-ld --import-memory=foo -o %t.import.wasm %t.start.o
+# RUN: obj2yaml %t.import.wasm | FileCheck -check-prefix=CHECK-IMPORT-DEFAULT %s
+
+# Verify that memory import module defaults to `env`, which is the default
+# module for all imports.
+
+# CHECK-IMPORT-DEFAULT:       - Type:            IMPORT
+# CHECK-IMPORT-DEFAULT-NEXT:    Imports:
+# CHECK-IMPORT-DEFAULT-NEXT:      - Module:          env
+# CHECK-IMPORT-DEFAULT-NEXT:        Field:           foo
+# CHECK-IMPORT-DEFAULT-NEXT:        Kind:            MEMORY
+# CHECK-IMPORT-DEFAULT-NEXT:        Memory:
+# CHECK-IMPORT-DEFAULT-NEXT:          Minimum:         0x2
+# CHECK-IMPORT-DEFAULT-NEXT:  - Type:
+
 # RUN:wasm-ld --import-memory=foo,bar --export-memory=qux -o %t.both.wasm %t.start.o
 # RUN: obj2yaml %t.both.wasm | FileCheck -check-prefix=CHECK-BOTH %s
 

--- a/lld/wasm/Driver.cpp
+++ b/lld/wasm/Driver.cpp
@@ -542,14 +542,13 @@ static void readConfigs(opt::InputArgList &args) {
   ctx.arg.noinhibitExec = args.hasArg(OPT_noinhibit_exec);
 
   if (args.hasArg(OPT_import_memory_with_name)) {
-    ctx.arg.memoryImport =
-        args.getLastArgValue(OPT_import_memory_with_name).split(",");
+    auto argValue = args.getLastArgValue(OPT_import_memory_with_name);
+    if (argValue.contains(','))
+      ctx.arg.memoryImport = argValue.split(",");
+    else
+      ctx.arg.memoryImport = {defaultModule, argValue};
   } else if (args.hasArg(OPT_import_memory)) {
-    ctx.arg.memoryImport =
-        std::pair<llvm::StringRef, llvm::StringRef>(defaultModule, memoryName);
-  } else {
-    ctx.arg.memoryImport =
-        std::optional<std::pair<llvm::StringRef, llvm::StringRef>>();
+    ctx.arg.memoryImport = {defaultModule, memoryName};
   }
 
   if (args.hasArg(OPT_export_memory_with_name)) {
@@ -746,8 +745,7 @@ static void setConfigs() {
       error("--export-memory is incompatible with --shared");
     }
     if (!ctx.arg.memoryImport.has_value()) {
-      ctx.arg.memoryImport = std::pair<llvm::StringRef, llvm::StringRef>(
-          defaultModule, memoryName);
+      ctx.arg.memoryImport = {defaultModule, memoryName};
     }
   }
 


### PR DESCRIPTION
Previously we only tested it as taking a pair of `module` and `name`, e.g `--import-memory=mymodule,mymemory`.

However, rather confusingly, if you just specified `--import-memory=foo` it would set the module to `foo` and the name to empty string.

This changes the interpretation of `--import-memory=foo` to mean import `foo` from the default module (which is currently `env`, but one day we make it configurable).